### PR TITLE
Make `-preview=in` means `[ref] const scope` and accept rvalues

### DIFF
--- a/changelog/preview-in.dd
+++ b/changelog/preview-in.dd
@@ -1,0 +1,36 @@
+Added support for input parameters (`in` parameter, `-preview=in`)
+
+D has supported the `in`, `ref`, and `out` storage classes on parameters
+since its inception. `out` and `ref` are commonly used,
+however `in` was usually left behind, as, while it was originally intended
+as an alias to `const scope`, it was made an alias to `const` when
+support for `scope` was introduced (DIP1000).
+
+DMD v2.092.0 rectified this by adding `-preview=in` to mean `const scope`,
+as it was originally intended, instead of `const` without the switch.
+
+However, this didn't really capture the intended meaning of `in`:
+the be applied on input parameters.
+Input parameters are parameters that a function intend to only examine,
+without modifying it, nor keeping a reference to them around.
+This is covered by `const scope`. However, some input parameters can
+be pretty large, or copying them can have side effects (postblit, copy constructor),
+hence those should be passed by reference to avoid runtime overhead.
+Which prompts a new issue: D doesn't support passing rvalues by references.
+Hence, when designing an API accepting an input parameter, a common
+practice was to have both an `in`-accepting overload, and an `in ref`-accepting one.
+While this works well for a single parameter, it also suffers from combinatorial explosion.
+
+This release reworks the meaning of `in` to properly support all those use cases.
+`in` parameters will now be passed by reference when optimal, and will accept rvalue.
+When using the switch, `in ref` parameters will also trigger an error.
+
+Note that the rules for passing by reference are as follow:
+- If the type has an elaborate copy or destruction (postblit, copy constructor, destructor),
+the type is always passed by reference.
+- If the type is not copy-able, it will always be passed by reference.
+- Reference types (dynamic arrays, function pointers, delegates, associative arrays, classes)
+  do not get passed by `ref`. This allows for covariance on delegates.
+- Otherwise, if the type's size requires it, it will be passed by reference.
+  Currently, types which are over twice the machine word size will be passed by reference,
+  however this is controlled by the backend and can be changed based on the platform's ABI.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -757,7 +757,7 @@ dmd -cov -unittest myprog.d
         Feature("nosharedaccess", "noSharedAccess",
             "disable access to shared memory objects"),
         Feature("in", "previewIn",
-            "in means scope const"),
+            "`in` on parameters means `scope const [ref]` and accepts rvalues"),
     ];
 }
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1974,7 +1974,23 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                     arg = arg.optimize(WANTvalue, p.isReference());
                 }
             }
-            if (p.storageClass & STC.ref_)
+
+            // Support passing rvalue to `in` parameters
+            if ((p.storageClass & (STC.in_ | STC.ref_)) == (STC.in_ | STC.ref_))
+            {
+                if (!arg.isLvalue())
+                {
+                    auto v = copyToTemp(STC.exptemp, "__rvalue", arg);
+                    Expression ev = new DeclarationExp(arg.loc, v);
+                    ev = new CommaExp(arg.loc, ev, new VarExp(arg.loc, v));
+                    arg = ev.expressionSemantic(sc);
+                }
+                arg = arg.toLvalue(sc, arg);
+
+                // Look for mutable misaligned pointer, etc., in @safe mode
+                err |= checkUnsafeAccess(sc, arg, false, true);
+            }
+            else if (p.storageClass & STC.ref_)
             {
                 if (global.params.rvalueRefParam &&
                     !arg.isLvalue() &&

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -166,7 +166,7 @@ extern (C++) struct Param
     bool useTypeInfo = true;     // generate runtime type information
     bool useExceptions = true;   // support exception handling
     bool noSharedAccess;         // read/write access to shared memory objects
-    bool previewIn;         // `in` means `scope const`
+    bool previewIn;         // `in` means `[ref] scope const`, accepts rvalues
     bool betterC;           // be a "better C" compiler; no dependency on D runtime
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -144,7 +144,7 @@ struct Param
     bool useTypeInfo;   // generate runtime type information
     bool useExceptions; // support exception handling
     bool noSharedAccess; // read/write access to shared memory objects
-    bool previewIn;     // `in` means `scope const`
+    bool previewIn;     // `in` means `scope const`, perhaps `ref`, accepts rvalues
     bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3059,6 +3059,8 @@ private void parameterToBuffer(Parameter p, OutBuffer* buf, HdrGenState* hgs)
 
     if (p.storageClass & STC.in_)
         buf.writestring("in ");
+    else if (global.params.previewIn && p.storageClass & STC.ref_)
+        buf.writestring("ref ");
     else if (p.storageClass & STC.out_)
         buf.writestring("out ");
     else if (p.storageClass & STC.lazy_)
@@ -3066,7 +3068,7 @@ private void parameterToBuffer(Parameter p, OutBuffer* buf, HdrGenState* hgs)
     else if (p.storageClass & STC.alias_)
         buf.writestring("alias ");
 
-    if (p.storageClass & STC.ref_)
+    if (!global.params.previewIn && p.storageClass & STC.ref_)
         buf.writestring("ref ");
 
     StorageClass stc = p.storageClass;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4856,6 +4856,19 @@ extern (C++) final class TypeFunction : TypeNext
                                 ta = tn.sarrayOf(dim);
                             }
                         }
+                        else if ((p.storageClass & STC.in_) && global.params.previewIn)
+                        {
+                            // Allow converting a literal to an `in` which is `ref`
+                            if (arg.op == TOK.arrayLiteral && tp.ty == Tsarray)
+                            {
+                                Type tn = tp.nextOf();
+                                dinteger_t dim = (cast(TypeSArray)tp).dim.toUInteger();
+                                ta = tn.sarrayOf(dim);
+                            }
+
+                            // Need to make this a rvalue through a temporary
+                            m = MATCH.convert;
+                        }
                         else if (!global.params.rvalueRefParam ||
                                  p.storageClass & STC.out_ ||
                                  !arg.type.isCopyable())  // can't copy to temp for ref parameter

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -741,6 +741,63 @@ extern (C++) struct Target
         return global.params.is64bit ? (sz + 7) & ~7 : (sz + 3) & ~3;
     }
 
+    /**
+     * Determine which `in` parameters needs to be passed by `ref`
+     *
+     * Called from `TypeFunction` semantic with the full function type.
+     * This routine must iterate over parameters, and may set `STC.ref_`
+     * for any parameter which already have `STC.in_`.
+     * This hook must never set `STC.ref_` if the parameter is not `STC.in_`,
+     * nor should it ever change anything else.
+     *
+     * This hook will not be called when `-preview=in` wasn't passed to the
+     * frontend, hence it needs not care about `global.params.previewIn`.
+     *
+     * Params:
+     *   tf    = Type of the function to inspect. The type will have its
+     *           parameter types semantically resolved, however other attributes
+     *           (return type, `@safe` / `nothrow`, etc...) must not be used.
+     */
+    extern(C++) void applyInRefParams (TypeFunction tf)
+    {
+        foreach (_idx, p; tf.parameterList)
+        {
+            // Ignore non-`in` or already-`ref` parameters
+            if ((p.storageClass & (STC.in_ | STC.ref_)) != STC.in_)
+                continue;
+
+            assert(p.type !is null);
+            // If it has a copy constructor / destructor / postblit,
+            // it is always by ref
+            if (p.type.needsDestruction() || p.type.needsCopyOrPostblit())
+                p.storageClass |= STC.ref_;
+            // If the type can't be copied, always by `ref`
+            else if (!p.type.isCopyable())
+                p.storageClass |= STC.ref_;
+            // The Win64 ABI requires x87 real to be passed by ref
+            else if (global.params.isWindows && global.params.is64bit &&
+                     p.type.ty == Tfloat80)
+                p.storageClass |= STC.ref_;
+
+            // If it's a dynamic array, use the value type as it
+            // allows covariance between `in char[]` and `scope const(char)[]`
+            // The same reasoning applies to pointers and classes,
+            // but that is handled by the `(sz > 8)` below.
+            else if (p.type.ty == Tarray)
+                continue;
+            // Pass delegates by value to allow covariance
+            // Function pointers are a single pointers and handled below.
+            else if (p.type.ty == Tdelegate)
+                continue;
+            else
+            {
+                const sz = p.type.size();
+                if (global.params.is64bit ? (sz > 16) : (sz > 8))
+                    p.storageClass |= STC.ref_;
+            }
+        }
+    }
+
     // this guarantees `getTargetInfo` and `allTargetInfos` remain in sync
     private enum TargetInfoKeys
     {

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -106,6 +106,7 @@ public:
     TypeTuple *toArgTypes(Type *t);
     bool isReturnOnStack(TypeFunction *tf, bool needsThis);
     d_uns64 parameterSize(const Loc& loc, Type *t);
+    void applyInRefParams(TypeFunction *tf);
     Expression *getTargetInfo(const char* name, const Loc& loc);
 };
 

--- a/test/compilable/previewhelp.d
+++ b/test/compilable/previewhelp.d
@@ -16,6 +16,6 @@ Upcoming language changes listed by -preview=name:
   =dtorfields       destruct fields of partially constructed objects
   =rvaluerefparam   enable rvalue arguments to ref parameters
   =nosharedaccess   disable access to shared memory objects
-  =in               in means scope const
+  =in               `in` on parameters means `scope const [ref]` and accepts rvalues
 ----
 */

--- a/test/compilable/previewin.d
+++ b/test/compilable/previewin.d
@@ -1,7 +1,66 @@
 /* REQUIRED_ARGS: -preview=dip1000 -preview=in
  */
 
-@safe:
-void fun(in int* inParam);
+import core.stdc.time;
+
+void fun(in int* inParam) @safe;
 static assert([__traits(getParameterStorageClasses, fun, 0)] == ["in"]);
 static assert (is(typeof(fun) P == __parameters) && is(P[0] == const int*));
+
+
+void test()
+{
+    withDefaultValue(42);
+    withDefaultValue();
+    withDefaultRef(TimeRef.init);
+    withDefaultRef();
+
+    withInitDefaultValue();
+    withInitDefaultRef();
+}
+
+struct FooBar
+{
+    string toString() const
+    {
+        string result;
+        // Type inference works
+        this.toString((buf) { result ~= buf; });
+        // Specifying the STC too
+        this.toString((in buf) { result ~= buf; });
+        // Some covariance
+        this.toString((const scope buf) { result ~= buf; });
+        this.toString((scope const(char)[] buf) { result ~= buf; });
+        this.toString((scope const(char[]) buf) { result ~= buf; });
+        return result;
+    }
+
+    void toString(scope void delegate(in char[]) sink) const
+    {
+        sink("Hello world");
+    }
+}
+
+// Ensure that default parameter works even if non CTFEable
+void withDefaultValue(in time_t currTime = time(null)) {}
+struct TimeRef { time_t now; ulong[4] bloat; }
+void withDefaultRef(in TimeRef currTime = TimeRef(time(null))) {}
+
+// Ensure that default parameters work with `.init`
+void withInitDefaultValue(in size_t defVal = size_t.init) {}
+void withInitDefaultRef(in TimeRef defVal = TimeRef.init) {}
+
+// Ensure that temporary aren't needlessly created
+// (if they are, it'll trigger the "goto skips declaration" error)
+void checkNotIdentity(in void* p1, in void* p2) { assert(p1 !is p2); }
+void checkTemporary()
+{
+    int* p = new int;
+    if (p is null)
+        goto LError;
+    // Should not generate temporary, pass the pointers by value
+    checkNotIdentity(/*lvalue*/ p, /*rvalue*/ null);
+    checkNotIdentity(new int, null);
+LError:
+    assert(0);
+}

--- a/test/fail_compilation/diagin.d
+++ b/test/fail_compilation/diagin.d
@@ -2,33 +2,24 @@
 PERMUTE_ARGS: -preview=in
 TEST_OUTPUT:
 ---
-fail_compilation/diagin.d(18): Error: function `diagin.foo(in string)` is not callable using argument types `()`
-fail_compilation/diagin.d(18):        missing argument for parameter #1: `in string`
-fail_compilation/diagin.d(19): Error: function `diagin.foo1(in ref string)` is not callable using argument types `()`
-fail_compilation/diagin.d(19):        missing argument for parameter #1: `in ref string`
-fail_compilation/diagin.d(20): Error: template `diagin.foo2` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/diagin.d(27):        `foo2(T)(in T v, string)`
-fail_compilation/diagin.d(22): Error: template `diagin.foo3` cannot deduce function from argument types `!()(bool[])`, candidates are:
-fail_compilation/diagin.d(28):        `foo3(T)(in ref T v, string)`
+fail_compilation/diagin.d(14): Error: function `diagin.foo(in string)` is not callable using argument types `()`
+fail_compilation/diagin.d(14):        missing argument for parameter #1: `in string`
+fail_compilation/diagin.d(16): Error: template `diagin.foo1` cannot deduce function from argument types `!()(bool[])`, candidates are:
+fail_compilation/diagin.d(20):        `foo1(T)(in T v, string)`
 ---
  */
 
 void main ()
 {
     foo();
-    foo1();
-    foo2(42);
     bool[] lvalue;
-    foo3(lvalue);
+    foo1(lvalue);
 }
 
 void foo(in string) {}
-void foo1(in ref string) {}
-void foo2(T)(in T v, string) {}
-void foo3(T)(ref in T v, string) {}
+void foo1(T)(in T v, string) {}
 
 // Ensure that `in` has a unique mangling
 static assert(foo.mangleof       == `_D6diagin3fooFIAyaZv`);
-static assert(foo1.mangleof      == `_D6diagin4foo1FIKAyaZv`);
-static assert(foo2!int.mangleof  == `_D6diagin__T4foo2TiZQiFNaNbNiNfIiAyaZv`);
-static assert(foo3!char.mangleof == `_D6diagin__T4foo3TaZQiFNaNbNiNfIKaAyaZv`);
+static assert(foo1!int.mangleof  == `_D6diagin__T4foo1TiZQiFNaNbNiNfIiAyaZv`);
+static assert(foo1!char.mangleof == `_D6diagin__T4foo1TaZQiFNaNbNiNfIaAyaZv`);

--- a/test/fail_compilation/diaginref.d
+++ b/test/fail_compilation/diaginref.d
@@ -1,0 +1,13 @@
+/*
+REQUIRED_ARGS: -preview=in
+TEST_OUTPUT:
+---
+fail_compilation/diaginref.d(11): Error: attribute `ref` is redundant with previously-applied `in`
+fail_compilation/diaginref.d(13): Error: attribute `in` cannot be added after `ref`: remove `ref`
+---
+ */
+
+void foo(in string) {}
+void foo1(in ref string) {}
+void foo2(T)(in T v, string) {}
+void foo3(T)(ref in T v, string) {}

--- a/test/fail_compilation/previewin.d
+++ b/test/fail_compilation/previewin.d
@@ -1,0 +1,68 @@
+/*
+REQUIRED_ARGS: -preview=in -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/previewin.d(3): Error: function `previewin.func1(void function(ulong[8]) dg)` is not callable using argument types `(void function(in ulong[8]))`
+fail_compilation/previewin.d(3):        cannot pass argument `& func_byRef` of type `void function(in ulong[8])` to parameter `void function(ulong[8]) dg`
+fail_compilation/previewin.d(4): Error: function `previewin.func2(void function(ref ulong[8]) dg)` is not callable using argument types `(void function(in ulong[8]))`
+fail_compilation/previewin.d(4):        cannot pass argument `& func_byRef` of type `void function(in ulong[8])` to parameter `void function(ref ulong[8]) dg`
+fail_compilation/previewin.d(7): Error: function `previewin.func4(void function(ref uint) dg)` is not callable using argument types `(void function(in uint))`
+fail_compilation/previewin.d(7):        cannot pass argument `& func_byValue` of type `void function(in uint)` to parameter `void function(ref uint) dg`
+fail_compilation/previewin.d(41): Error: scope variable `arg` assigned to non-scope `myGlobal`
+fail_compilation/previewin.d(42): Error: scope variable `arg` assigned to non-scope `myGlobal`
+fail_compilation/previewin.d(43): Error: scope variable `arg` may not be returned
+fail_compilation/previewin.d(44): Error: scope variable `arg` assigned to `escape` with longer lifetime
+fail_compilation/previewin.d(48): Error: returning `arg` escapes a reference to parameter `arg`
+fail_compilation/previewin.d(48):        perhaps annotate the parameter with `return`
+---
+ */
+
+#line 1
+void main ()
+{
+    func1(&func_byRef); // No
+    func2(&func_byRef); // No
+    func3(&func_byRef); // Could be Yes, but currently No
+
+    func4(&func_byValue); // No
+    func5(&func_byValue); // Yes
+
+    func6(&func_byValue2); // Yes
+    func7(&func_byValue3); // Yes
+
+    tryEscape("Hello World"); // Yes by `tryEscape` is NG
+}
+
+// Takes by `scope ref const`
+void func_byRef(in ulong[8]) {}
+// Takes by `scope const`
+void func_byValue(in uint) {}
+
+// Error: `ulong[8]` is passed by `ref`
+void func1(void function(scope ulong[8]) dg) {}
+// Error: Missing `scope` on a `ref`
+void func2(void function(ref ulong[8]) dg) {}
+// Works: `scope ref`
+void func3(void function(scope const ref ulong[8]) dg) {}
+
+// Error: `uint` is passed by value
+void func4(void function(ref uint) dg) {}
+// Works: By value `scope const`
+void func5(void function(scope const uint) dg) {}
+
+// This works for arrays:
+void func_byValue2(in char[]) {}
+void func6(void function(char[]) dg) {}
+void func_byValue3(scope const(char)[]) {}
+void func7(void function(in char[]) dg) {}
+
+// Make sure things cannot be escaped (`scope` is applied)
+const(char)[] myGlobal;
+void tryEscape(in char[] arg) @safe { myGlobal = arg; }
+void tryEscape2(scope const char[] arg) @safe { myGlobal = arg; }
+const(char)[] tryEscape3(in char[] arg) @safe { return arg; }
+void tryEscape4(in char[] arg, ref const(char)[] escape) @safe { escape = arg; }
+// Okay: value type
+ulong[8] tryEscape5(in ulong[8] arg) @safe { return arg; }
+// NG: Ref
+ref const(ulong[8]) tryEscape6(in ulong[8] arg) @safe { return arg; }

--- a/test/runnable/previewin.d
+++ b/test/runnable/previewin.d
@@ -1,0 +1,188 @@
+// REQUIRED_ARGS: -preview=dip1000 -preview=in
+
+void main ()
+{
+    testWithAllAttributes();
+    testForeach();
+}
+
+void testWithAllAttributes() @safe pure nothrow @nogc
+{
+    // Used to test dtors
+    bool isTestOver = false;
+
+    // rvalues
+    testin1(42);
+    testin2([42, ulong.max, ulong.min, 42UL]);
+    testin3(ValueT(42));
+    testin3(RefT(42));
+    testin4([ValueT(0), ValueT(1), ValueT(2), ValueT(3),
+             ValueT(4), ValueT(5), ValueT(6), ValueT(7)]);
+    testin4([RefT(42), RefT(84), RefT(126), RefT(4)]);
+    testin5(NonCopyable(true));
+    testin6(WithPostblit(true));
+    testin7(WithCopyCtor(true));
+    isTestOver = false;
+    testin8(WithDtor(&isTestOver), &isTestOver);
+    isTestOver = false;
+
+    // lvalues
+    uint      a1;
+    ulong[4]  a2;
+    ValueT    a3;
+    ValueT[8] a4;
+    RefT      a5;
+    RefT[4]   a6;
+    NonCopyable  a7 = NonCopyable(true);
+    WithPostblit  a8;
+    WithCopyCtor a9;
+    WithDtor     a10 = WithDtor(&isTestOver);
+
+    testin1(a1);
+    testin2(a2);
+    testin3(a3);
+    testin3(a5);
+    testin4(a4);
+    testin4(a6);
+    testin5(a7);
+    testin6(a8);
+    testin7(a9);
+    isTestOver = false;
+    testin8(a10, null);
+
+    // Arguments are all values, no `ref` needed
+    testin9(int.init);
+    testin9(char.init, ubyte.init, short.init, int.init, size_t.init);
+    // Arguments are all refs
+    testin9(a2, a4, a5, a6, a7, a8, a9, a10);
+    testin9(NonCopyable(true), WithPostblit(true), WithCopyCtor(true));
+    // Mixed values and ref
+    testin9(char.init, ubyte.init, a2, a4, a5, a6, a7, a8, a9, a10, size_t.init);
+
+    // With dtor
+    isTestOver = false;
+    testin10(&isTestOver, NonCopyable(true), WithPostblit(true),
+             WithCopyCtor(true), WithDtor(&isTestOver));
+    isTestOver = true;
+}
+
+void testForeach() @safe pure
+{
+    int testCallNC (in NonCopyable k, in NonCopyable v)
+    {
+        assert(k == v);
+        return k.value - v.value;
+    }
+
+    NonCopyable[NonCopyable] nc;
+    nc[NonCopyable(0)] = NonCopyable(0);
+    nc[NonCopyable(42)] = NonCopyable(42);
+    nc[NonCopyable(int.min)] = NonCopyable(int.min);
+    nc[NonCopyable(int.max)] = NonCopyable(int.max);
+    foreach (ref k, const ref v; nc)
+    {
+        assert(k.value == v.value);
+        assert(testCallNC(k, v) == 0);
+    }
+    assert(nc == nc);
+    assert(nc.length == 4);
+
+    RefT[RefT] rt;
+    rt[RefT(42)] = RefT(42);
+    rt[RefT(4)] = RefT(4);
+    rt[RefT(242)] = RefT(242);
+    rt[RefT(24)] = RefT(24);
+    foreach (k, v; rt)
+        assert(k.value == v.value);
+    assert(rt == rt);
+
+    static struct Msg
+    {
+        ubyte[3] value;
+        const(char)[] msg;
+    }
+
+    static void testMsg (in Msg k_func, in Msg v_func)
+    {
+        assert(k_func.value == v_func.value);
+        assert(k_func.msg == v_func.msg);
+        assert(k_func == v_func);
+    }
+
+    Msg[Msg] msg;
+    msg[Msg([1, 2, 3], "123")] = Msg([1, 2, 3], "123");
+    msg[Msg([42, 4, 2], "4242")] = Msg([42, 4, 2], "4242");
+    msg[Msg([242, 4, 0], "2424")] = Msg([242, 4, 0], "2424");
+    foreach (ref k_loop, ref v_loop; msg)
+        testMsg(k_loop, v_loop);
+}
+
+struct ValueT { int value; }
+struct RefT   { ubyte[64] value; }
+
+struct NonCopyable
+{
+    @safe pure nothrow @nogc:
+
+    int value;
+    this(int b) { this.value = b; }
+
+    @disable this(this);
+    @disable this(ref NonCopyable);
+}
+
+struct WithPostblit
+{
+    int value;
+    this(this) @safe pure nothrow @nogc { assert(0); }
+}
+
+struct WithCopyCtor
+{
+    @safe pure nothrow @nogc:
+
+    int value;
+    this(int b) { this.value = b; }
+    this(ref WithCopyCtor) { assert(0); }
+}
+
+struct WithDtor
+{
+    bool* value;
+    ~this() scope @safe pure nothrow @nogc {  assert(*value); }
+}
+
+@safe pure nothrow @nogc:
+
+// By value
+void testin1(in uint p) {}
+// By ref because of size
+void testin2(in ulong[4] p) {}
+// By value or ref depending on size
+void testin3(in ValueT p) {}
+void testin3(in RefT p) {}
+// By ref because of size
+void testin4(in ValueT[8] p) {}
+void testin4(in RefT[4] p) {}
+
+// By ref because of non-copyability
+void testin5(in NonCopyable noncopy) {}
+//  By ref because of postblit
+void testin6(in WithPostblit withposblit) {}
+//  By ref because of copy ctor
+void testin7(in WithCopyCtor withcopy) {}
+//  By ref because of dtor
+void testin8(in WithDtor withdtor, scope bool* isTestOver)
+{
+    if (isTestOver)
+        *isTestOver = true;
+}
+
+// Allow to test various tuples (e.g. `(int, int)` and `(int, WithDtor)`)
+// `ref` is only applied to the members which need it
+void testin9(T...)(in T args) {}
+void testin10(T...)(scope bool* isTestOver, in T args)
+{
+    if (isTestOver)
+        *isTestOver = true;
+}


### PR DESCRIPTION
```
As explained in the changelog entry, this puts `in` more in line with its meaning:
that of an input parameter.
This change was prompted by the introduction of `-preview=in` to make `in` means
`const scope` (its original meaning). If we introduce a `preview` switch,
we might as well go all the way.
```

Needs test, I know, and won't pass the CI because druntime has scope `const scope` inheriting `in`.
But before I dig into making this work, I'd like to start the discussion on the concept itself.

The goal is to make `in` the "go to" type for input parameter. I had this in mind for a long time, and discussed it with @JinShil on some occasions.
Now that `-preview=in` has been merged ( #10769 ), I figured it would be the right time to introduce it, hoping to get his approved before the next release.

CC @atilaneves @WalterBright  