### PR TITLE
fix Issues 20596, 20967 - [REG2.086] Error on missed stack allocation for clo…

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1408,7 +1408,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         {
                             // or a delegate that doesn't escape a reference to the function
                             FuncDeclaration f = (cast(FuncExp)ex).fd;
-                            f.tookAddressOf--;
+                            if (f.tookAddressOf)
+                                f.tookAddressOf--;
                         }
                     }
                 }

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -839,7 +839,7 @@ ByRef:
          * then uncount that address of. This is so it won't cause a
          * closure to be allocated.
          */
-        if (va && va.isScope() && fd.tookAddressOf && global.params.vsafe)
+        if (va && va.isScope() && fd.tookAddressOf)
             --fd.tookAddressOf;
 
         foreach (v; vars)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2048,7 +2048,8 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                         FuncDeclaration f = ve.var.isFuncDeclaration();
                         if (f)
                         {
-                            f.tookAddressOf--;
+                            if (f.tookAddressOf)
+                                --f.tookAddressOf;
                             //printf("--tookAddressOf = %d\n", f.tookAddressOf);
                         }
                     }
@@ -8532,7 +8533,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         dvx.e1 = e1x;
                         auto cx = cast(CallExp)ce.copy();
                         cx.e1 = dvx;
-                        if (global.params.vsafe && checkConstructorEscape(sc, cx, false))
+                        if (checkConstructorEscape(sc, cx, false))
                             return setError();
 
                         Expression e0;

--- a/test/compilable/test20596.d
+++ b/test/compilable/test20596.d
@@ -1,0 +1,31 @@
+// PERMUTE_ARGS: -preview=dip1000
+
+// https://issues.dlang.org/show_bug.cgi?id=20596
+
+struct S(T)
+{
+    void delegate() dg;
+
+    this(scope void delegate() dg)
+    {
+        this.dg = dg;
+    }
+}
+
+@nogc void fooTemplate()
+{
+    int num;
+
+    void foo() { int dummy = num; }
+
+    scope s = S!int(&foo);
+}
+
+void test3032() @nogc
+{
+    int n = 1;
+    scope fp = (){ n = 10; };       // no closure
+    fp();
+}
+
+


### PR DESCRIPTION
…sure for template

Although a regression fix, it is an old issue and is potentially disruptive so it shouldn't go into stable.
I'll add test cases if it passes.