### PR TITLE
Disable codegen for a function if assert(__ctfe) is at the toplevel

### DIFF
--- a/changelog/assert_ctfe.dd
+++ b/changelog/assert_ctfe.dd
@@ -1,0 +1,20 @@
+ctfe-only function elision
+
+As of now assert(__ctfe) inside the outmoster scope of a function body or inside an in contract will cause the function to not be emitted into the object file.
+Should a another function attempt to use a ctfe-only function a compile error will be emitted.
+
+-------
+string generateMixin(string name)
+{
+    assert(__ctfe);
+    return `string `" ~ name ~ `= "This is not a good mixin";`;
+}
+
+pragma(msg, generateMixin("Flood")); // will work
+
+void main(string[] args)
+{
+    import std.stdio;
+    writeln(generateMixin(args[0])); // will fail with an compile time error
+}
+-------

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -175,6 +175,11 @@ private elem *callfunc(const ref Loc loc,
     elem *eside = null;
     elem *eresult = ehidden;
 
+    if (fd.flags & FUNCFLAG.compileTimeOnly)
+    {
+        fd.error("may only be used for CTFE");
+    }
+
     version (none)
     {
         printf("callfunc(directcall = %d, tret = '%s', ec = %p, fd = %p)\n",

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -175,7 +175,7 @@ private elem *callfunc(const ref Loc loc,
     elem *eside = null;
     elem *eresult = ehidden;
 
-    if (fd.flags & FUNCFLAG.compileTimeOnly)
+    if (fd && (fd.flags & FUNCFLAG.compileTimeOnly))
     {
         fd.error("may only be used for CTFE");
     }

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -738,6 +738,10 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     if (!fd.fbody)
         return;
 
+    // Don't generate code for compile time only functions
+    if (fd.flags & FUNCFLAG.compileTimeOnly)
+        return;
+
     UnitTestDeclaration ud = fd.isUnitTestDeclaration();
     if (ud && !global.params.useUnitTests)
         return;

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1000,6 +1000,27 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 if (global.params.useOut == CHECKENABLE.off)
                     fens = null;
             }
+
+            // if the function body or the in contracts contain "assert(__ctfe)" set the compile time only flag
+            {
+                if (funcdecl.fbody)
+                {
+                    if (auto cs = funcdecl.fbody.isCompoundStatement())
+                        if (auto s = cs.statements)
+                            if (s.length && isAssertCtfe((*s)[0]))
+                                funcdecl.flags |= FUNCFLAG.compileTimeOnly;
+                }
+
+                if (funcdecl.frequire)
+                {
+                    auto cs = funcdecl.frequire.isCompoundStatement();
+                    if (cs && containsAssertCtfe(cs))
+                    {
+                        funcdecl.flags |= FUNCFLAG.compileTimeOnly;
+                    }
+                }
+            }
+
             if (funcdecl.fbody && funcdecl.fbody.isErrorStatement())
             {
             }

--- a/test/compilable/extra-files/ctfeonly-postscript.sh
+++ b/test/compilable/extra-files/ctfeonly-postscript.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+obj_file=${OUTPUT_BASE}_0.o
+
+if nm "${obj_file}" | grep -q "ctfeOnly";
+then
+    exit 1
+fi

--- a/test/compilable/test_ctfeonly.d
+++ b/test/compilable/test_ctfeonly.d
@@ -1,0 +1,20 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS:
+// POST_SCRIPT: compilable/extra-files/ctfeonly-postscript.sh
+// I guess the platforms below don't have nm
+// DISABLED: win32 win64 osx
+
+
+string ctfeOnly(string x, string y)
+{
+    assert(__ctfe);
+    return (x ~ " " ~ y);
+}
+string ctfeOnlyIn(string x, string y)
+in {
+    assert(__ctfe);
+}
+do
+{
+    return (x ~ " " ~ y);
+}

--- a/test/fail_compilation/fail_ctfeonly.d
+++ b/test/fail_compilation/fail_ctfeonly.d
@@ -1,0 +1,31 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fail_ctfeonly.d(10): Error: function `fail_ctfeonly.ctfeOnly` may only be used for CTFE
+fail_compilation/fail_ctfeonly.d(19): Error: function `fail_ctfeonly.ctfeOnly2` may only be used for CTFE
+---
+*/
+
+
+
+string ctfeOnly(string x, string y)
+in {
+    assert(__ctfe);
+}
+do
+{
+    return (x ~ " " ~ y);
+}
+
+string ctfeOnly2(string x, string y)
+{
+    assert(__ctfe);
+    return (x ~ " " ~ y);
+}
+
+
+void main(string[] args)
+{
+    import core.stdc.stdio;
+    printf("%s", ctfeOnly(args[0], args[1]).ptr);
+    printf("%s", ctfeOnly2(args[0], args[1]).ptr);
+}


### PR DESCRIPTION
This does what's in the title.

Let's see if it breaks anything.
