### PR TITLE
runnable_cxx: Use relative path in wrapper scripts

### DIFF
--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -176,7 +176,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ github.workspace }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}/
-        key: ${{ matrix.cxx-version }}-${{ matrix.arch }}
+        key: ${{ matrix.cxx-version }}-${{ matrix.arch }}-1
 
     - name: '[Posix] Setting up clang ${{ matrix.cxx-version }}'
       if: matrix.compiler == 'clang' && runner.os != 'Windows' && steps.cache-clang.outputs.cache-hit != 'true'
@@ -189,15 +189,18 @@ jobs:
         # and config files where only introduced from 6.0.0, use a wrapper script.
         if [ "${{ matrix.os }}" == "macOS-10.15" ]; then
           # Note: heredoc shouldn't be indented
-          cat <<EOF > ${TMP_CC}-wrapper
+          cat << 'EOF' > ${TMP_CC}-wrapper
         #!/bin/bash
-        ${TMP_CC} -isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ \$@
+        # Note: We need to use this because github.workspace is not stable
+        SCRIPT_FULL_PATH=$(dirname "$0")
+        ${SCRIPT_FULL_PATH}/clang -isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ $@
         EOF
           # Invoking clang with `clang++` will link the C++ standard library
           # Make sure we got two separate wrapper for this
-          cat <<EOF > ${TMP_CC}++-wrapper
+          cat << 'EOF' > ${TMP_CC}++-wrapper
         #!/bin/bash
-        ${TMP_CC}++ -isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ \$@
+        SCRIPT_FULL_PATH=$(dirname "$0")
+        ${SCRIPT_FULL_PATH}/clang++ -isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ $@
         EOF
           chmod +x ${TMP_CC}-wrapper ${TMP_CC}++-wrapper
         fi


### PR DESCRIPTION
Currently the runnable scripts error out with:
```
Expected version X.Y.Z, from '/Users/runner/runners/2.168.0/work/dmd/dmd/clang+llvm-9.0.0-x86_64-darwin-apple/bin/clang++-wrapper', got:
/Users/runner/runners/2.168.0/work/dmd/dmd/clang+llvm-9.0.0-x86_64-darwin-apple/bin/clang++-wrapper: line 2: /Users/runner/runners/2.165.2/work/dmd/dmd/clang+llvm-9.0.0-x86_64-darwin-apple/bin/clang++: No such file or directory
```

As can be seen, the ` ${{ github.workspace }}` property points to `/Users/runner/runners/2.168.0/work/dmd/`,
but the script was actually generated and cached on `/Users/runner/runners/2.165.2/work/dmd/`,
an older version of the runner.
Using a path relative to the script ensure that this does not happen anymore.
Additionally, the cache key was changed to force invalidation.