### PR TITLE
[dmd-cxx] Use Target as entrypoint for toArgTypes, remove forward declarations

### DIFF
--- a/src/dstruct.c
+++ b/src/dstruct.c
@@ -22,9 +22,9 @@
 #include "statement.h"
 #include "template.h"
 #include "tokens.h"
+#include "target.h"
 
 Type *getTypeInfoType(Loc loc, Type *t, Scope *sc);
-TypeTuple *toArgTypes(Type *t);
 void unSpeculative(Scope *sc, RootObject *o);
 bool MODimplicitConv(MOD modfrom, MOD modto);
 Expression *resolve(Loc loc, Scope *sc, Dsymbol *s, bool hasOverloads);
@@ -1303,7 +1303,7 @@ void StructDeclaration::finalizeSize()
         }
     }
 
-    TypeTuple *tt = toArgTypes(type);
+    TypeTuple *tt = Target::toArgTypes(type);
     size_t dim = tt->arguments->dim;
     if (dim >= 1)
     {

--- a/src/expressionsem.c
+++ b/src/expressionsem.c
@@ -37,7 +37,6 @@
 bool typeMerge(Scope *sc, TOK op, Type **pt, Expression **pe1, Expression **pe2);
 bool isArrayOpValid(Expression *e);
 Expression *expandVar(int result, VarDeclaration *v);
-TypeTuple *toArgTypes(Type *t);
 bool checkAssignEscape(Scope *sc, Expression *e, bool gag);
 bool checkParamArgumentEscape(Scope *sc, FuncDeclaration *fdc, Identifier *par, Expression *arg, bool gag);
 bool checkAccess(AggregateDeclaration *ad, Loc loc, Scope *sc, Dsymbol *smember);
@@ -2074,7 +2073,7 @@ public:
                      * The results of this are highly platform dependent, and intended
                      * primarly for use in implementing va_arg().
                      */
-                    tded = toArgTypes(e->targ);
+                    tded = Target::toArgTypes(e->targ);
                     if (!tded)
                         goto Lno;           // not valid for a parameter
                     break;

--- a/src/target.c
+++ b/src/target.c
@@ -28,6 +28,7 @@ const char *toCppMangleItanium(Dsymbol *);
 const char *cppTypeInfoMangleItanium(Dsymbol *);
 const char *toCppMangleMSVC(Dsymbol *);
 const char *cppTypeInfoMangleMSVC(Dsymbol *);
+TypeTuple *toArgTypes(Type *t);
 
 int Target::ptrsize;
 int Target::realsize;
@@ -530,4 +531,13 @@ bool Target::cppFundamentalType(const Type *t, bool& isFundamental)
 LINK Target::systemLinkage()
 {
     return global.params.isWindows ? LINKwindows : LINKc;
+}
+
+/**
+ * Return a tuple describing how argument type is put to a function.
+ * Value is an empty tuple if type is always passed on the stack.
+ */
+TypeTuple *Target::toArgTypes(Type *t)
+{
+  return ::toArgTypes(t);
 }

--- a/src/target.h
+++ b/src/target.h
@@ -21,6 +21,7 @@ class Dsymbol;
 class Expression;
 class Parameter;
 class Type;
+class TypeTuple;
 struct OutBuffer;
 
 struct Target
@@ -73,4 +74,5 @@ struct Target
     static Type *cppParameterType(Parameter *p);
     static bool cppFundamentalType(const Type *t, bool& isFundamental);
     static LINK systemLinkage();
+    static TypeTuple *toArgTypes(Type *t);
 };


### PR DESCRIPTION
This is a backport of #7622, which allows the compiler to provide its own implementation and optionally support more platforms.