### PR TITLE
fix Issue 20730 - [REG 2.091] __traits(compiles) fails if any ungagged errors occurred in compilation

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1572,6 +1572,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                         err = true;
                         break;
                     }
+                    const olderrors = global.errors;
                     const len = buf.length;
                     buf.writeByte(0);
                     const str = buf.extractSlice()[0 .. len];
@@ -1580,7 +1581,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                     //printf("p.loc.linnum = %d\n", p.loc.linnum);
 
                     o = p.parseTypeOrAssignExp(TOK.endOfFile);
-                    if (errors != global.errors || p.token.value != TOK.endOfFile)
+                    if (olderrors != global.errors || p.token.value != TOK.endOfFile)
                     {
                         err = true;
                         break;

--- a/test/fail_compilation/fail20730a.d
+++ b/test/fail_compilation/fail20730a.d
@@ -1,0 +1,40 @@
+/*
+REQUIRED_ARGS: -o-
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/fail20730a.d(12): Error: undefined identifier `undef20730`
+---
+*/
+void test20730()
+{
+    auto f = File().byLine;
+    undef20730();
+}
+
+struct File
+{
+    shared uint refs;
+
+    this(this)
+    {
+        atomicOp!"+="(refs, 1);
+    }
+
+    struct ByLineImpl(Char)
+    {
+        File file;
+        char[] line;
+    }
+
+    auto byLine()
+    {
+        return ByLineImpl!char();
+    }
+}
+
+T atomicOp(string op, T, V1)(ref shared T val, V1 mod)
+    if (__traits(compiles, mixin("*cast(T*)&val" ~ op ~ "mod")))
+{
+    return val;
+}

--- a/test/fail_compilation/fail20730b.d
+++ b/test/fail_compilation/fail20730b.d
@@ -1,0 +1,47 @@
+/*
+REQUIRED_ARGS: -verrors=spec -o-
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+(spec:1) fail_compilation/fail20730b.d-mixin-44(44): Error: C style cast illegal, use `cast(int)mod`
+fail_compilation/fail20730b.d(27): Error: template `fail20730b.atomicOp` cannot deduce function from argument types `!("+=")(shared(uint), int)`, candidates are:
+fail_compilation/fail20730b.d(42):        `atomicOp(string op, T, V1)(ref shared T val, V1 mod)`
+  with `op = "+=",
+       T = uint,
+       V1 = int`
+  must satisfy the following constraint:
+`       __traits(compiles, mixin("(int)mod"))`
+---
+*/
+void test20730()
+{
+    auto f = File().byLine;
+}
+
+struct File
+{
+    shared uint refs;
+
+    this(this)
+    {
+        atomicOp!"+="(refs, 1);
+    }
+
+    struct ByLineImpl(Char)
+    {
+        File file;
+        char[] line;
+    }
+
+    auto byLine()
+    {
+        return ByLineImpl!char();
+    }
+}
+
+T atomicOp(string op, T, V1)(ref shared T val, V1 mod)
+    // C-style cast causes raises a parser error whilst gagged.
+    if (__traits(compiles, mixin("(int)mod")))
+{
+    return val;
+}


### PR DESCRIPTION
When running semantic on __traits(compiles), errors are gagged, so the saved errors count is global.gaggedErrors, and not global.errors.

So the condition always evaluated as true if any real errors occured during compilation, and every subsequent __traits(compiles) errors too, whether it is valid syntax or not.
