### PR TITLE
[dmd-cxx] Allow NULL returns from Target::toArgTypes

### DIFF
--- a/src/dstruct.c
+++ b/src/dstruct.c
@@ -1304,7 +1304,7 @@ void StructDeclaration::finalizeSize()
     }
 
     TypeTuple *tt = Target::toArgTypes(type);
-    size_t dim = tt->arguments->dim;
+    size_t dim = tt ? tt->arguments->dim : 0;
     if (dim >= 1)
     {
         assert(dim <= 2);

--- a/src/target.c
+++ b/src/target.c
@@ -536,6 +536,7 @@ LINK Target::systemLinkage()
 /**
  * Return a tuple describing how argument type is put to a function.
  * Value is an empty tuple if type is always passed on the stack.
+ * NULL if the type is a `void` or argtypes aren't supported by the target.
  */
 TypeTuple *Target::toArgTypes(Type *t)
 {


### PR DESCRIPTION
And document what it means if NULL is returned.

Another backport which allows unsupported targets to return NULL without the compiler crashing.