### PR TITLE
Remove qualifiers from toPrec return type

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -486,7 +486,7 @@ if (!irs.params.is64bit) assert(tysize(TYnptr) == 4);
         {
             static int X(int fty, int tty) { return fty * TMAX + tty; }
 
-            final switch (X(tybasic(ep.Ety), tyret))
+            final switch (X(tybasic(ep.Ety), tybasic(tyret)))
             {
             case X(TYfloat, TYfloat):     // float -> float
             case X(TYdouble, TYdouble):   // double -> double

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -3523,6 +3523,16 @@ void testToPrec()
     static assert(toPrec!double(ctpif) == ctpif);
     static assert(toPrec!real(ctpif) == ctpif);
 
+    assert(toPrec!float(ctpir) == ctpif);
+    assert(toPrec!double(ctpir) == ctpid);
+    assert(toPrec!real(ctpir) == ctpir);
+    assert(toPrec!float(ctpid) == ctpif);
+    assert(toPrec!double(ctpid) == ctpid);
+    assert(toPrec!real(ctpid) == ctpid);
+    assert(toPrec!float(ctpif) == ctpif);
+    assert(toPrec!double(ctpif) == ctpif);
+    assert(toPrec!real(ctpif) == ctpif);
+
     static real rtpir = 0xc.90fdaa22168c235p-2;
     static double rtpid = 0x1.921fb54442d18p+1;
     static float rtpif = 0x1.921fb6p+1;


### PR DESCRIPTION
The const flag being set on the return type triggered switch errors