### PR TITLE
ignore pragma(printf) and pragma(scanf)

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2006,6 +2006,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 pd.error("takes no argument");
             goto Ldecl;
         }
+        else if (pd.ident == Id.printf || pd.ident == Id.scanf)
+        {
+            goto Ldecl;
+        }
         else if (global.params.ignoreUnsupportedPragmas)
         {
             if (global.params.verbose)


### PR DESCRIPTION
Currently, the `printf` and `scanf` format checking only works for names hardwired into the compiler. The compiler needs to recognize printf-like and scanf-like functions written by the user. This will be done with:
```
pragma(printf) extern (C) int printf(const(char)* format, ...);
```
and similarly for `scanf`. To avoid a chicken-and-egg scenario in implementing it, first just ignore the new pragmas. Then the rest can be done in one PR.

This is a pragma rather than an attribute because it does not become part of the function type. Not being part of the function type means things like:
```
(*fp)("%d", i);
```
won't get the format checked. But a workaround exists using a wrapper function along the lines of:
```
int fp_printf(fp_t* fp, const(char)* format, ...) { return (*fp)(format, valist); }
```
where the `fp` is a pointer to a `vprintf` style function. So I don't think it is worth adding to the type system and dealing with issues like mangling, covariance and implicit casting.