### PR TITLE
Test runner: Do not set workUnitSize when calling parallel

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -180,7 +180,7 @@ Options:
 
         int ret;
         ensureToolsExists(env, EnumMembers!TestTools);
-        foreach (target; parallel(targets, 1))
+        foreach (target; parallel(targets))
         {
             log("run: %-(%s %)", target.args);
             ret |= spawnProcess(target.args, env, Config.none, scriptDir).wait;


### PR DESCRIPTION
```
This completely destroys performance on OSX for some reason.
It also doesn't make as much sense for fast-running test (e.g. tests that skip codegen).
```

CC @MoonlightSentinel : This fixed the issue I was seeing on Mac OSX Catalina. @jacob-carlborg did you experience similar problem (`make -f posix.mak -j8` being dead slow) ?