### PR TITLE
Don't spawn excess threads in run.d.

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -116,7 +116,7 @@ Options:
         return 0;
     }
 
-    defaultPoolThreads = jobs;
+    defaultPoolThreads = jobs - 1; // main thread executes tasks as well
 
     // parse arguments
     args.popFront;


### PR DESCRIPTION
Creating a taskPool with `jobs` workers results in `jobs + 1` active threads
because the main thread is executing task as well when calling `parallel`.