### PR TITLE
Fix issue 8059 - Deprecate `.classinfo` in favor of `typeid`

### DIFF
--- a/changelog/deprecate-classinfo.dd
+++ b/changelog/deprecate-classinfo.dd
@@ -1,0 +1,57 @@
+Class property `.classinfo` has been deprecated
+
+This property returns the `TypeInfo_class` of the class on which it is called.
+It can be called with either an instance, or a type.
+As it was redundant with `typeid`, and `typeid` better relates to `typeof`,
+as well as not suffering from shadowing issues, `.classinfo` is now deprecated.
+
+The following code:
+---
+import std.stdio;
+void main ()
+{
+    scope o = new Object;
+    writeln(o.classinfo.name);
+    writeln(Object.classinfo.name);
+}
+---
+
+Can be turned into:
+---
+import std.stdio;
+void main ()
+{
+    scope o = new Object;
+    writeln(typeid(o).name);
+    writeln(typeid(Object).name);
+}
+---
+
+Note that in the event `typeid` is called with an `interface` as an argument,
+it will return the `TypeInfo_Interface` of the argument.
+Once can obtain the equivalent of `.classinfo` by using `typeid(myInterface).info`.
+
+Finally, `.classinfo` wrongfully accepted `this` and `super` as types in `static functions.
+Hence, the following code:
+---
+class Classe
+{
+    static void foo ()
+    {
+        writeln("Class info: ", this.classinfo);
+        writeln("Object class info: ", super.classinfo);
+    }
+}
+---
+
+Need to be turned into:
+---
+class Classe
+{
+    static void foo ()
+    {
+        writeln("Class info: ", typeid(typeof(this)));
+        writeln("Object class info: ", typeid(typeof(super)));
+    }
+}
+---

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1150,7 +1150,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             if (funcdecl.isStatic())
                             {
                                 // The monitor is in the ClassInfo
-                                vsync = new DotIdExp(funcdecl.loc, symbolToExp(cd, funcdecl.loc, sc2, false), Id.classinfo);
+                                vsync = new TypeidExp(funcdecl.loc, cd.type);
                             }
                             else
                             {

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3996,6 +3996,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 }
 
                 Type t = Type.typeinfoclass.type;
+                const eOrig = e;
                 if (e.op == TOK.type || e.op == TOK.dotType)
                 {
                     /* For type.classinfo, we know the classinfo
@@ -4006,6 +4007,15 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                     e = new VarExp(e.loc, mt.sym.vclassinfo);
                     e = e.addressOf();
                     e.type = t; // do this so we don't get redundant dereference
+
+                    // @@@DEPRECATED_2.092.0@@@
+                    if (mt.sym.isInterfaceDeclaration())
+                        e.deprecation("`.classinfo` property is deprecated - use `typeid(%s).info` instead",
+                                      eOrig.toChars());
+                    else
+                        e.deprecation("`.classinfo` property is deprecated - use `typeid(%s)` instead",
+                                      eOrig.toChars());
+
                 }
                 else
                 {
@@ -4025,6 +4035,11 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                              */
                             error(e.loc, "no `.classinfo` for C++ interface objects");
                         }
+                        // @@@DEPRECATED_2.092.0@@@
+                        else
+                            e.deprecation("`.classinfo` property is deprecated - use `typeid(%s).info` instead",
+                                          eOrig.toChars());
+
                         /* For an interface, the first entry in the vtbl[]
                          * is actually a pointer to an instance of struct Interface.
                          * The first member of Interface is the .classinfo,
@@ -4034,6 +4049,10 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                         e = new PtrExp(e.loc, e);
                         e.type = t.pointerTo();
                     }
+                    // @@@DEPRECATED_2.092.0@@@
+                    else
+                        e.deprecation("`.classinfo` property is deprecated - use `typeid(%s)` instead",
+                                      eOrig.toChars());
                     e = new PtrExp(e.loc, e, t);
                 }
                 return e;

--- a/test/fail_compilation/fail160.d
+++ b/test/fail_compilation/fail160.d
@@ -14,7 +14,7 @@ template Wrapper(B, alias Func, int func)
     alias typeof(&Func) FuncPtr;
 
     private static FuncPtr get_funcptr() { return func; }
-} 
+}
 
 
 int main(char[][] args)
@@ -23,4 +23,3 @@ int main(char[][] args)
 
     return 0;
 }
-

--- a/test/fail_compilation/fail160.d
+++ b/test/fail_compilation/fail160.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail160.d(22): Error: `typeid(fail160.Foo).vtbl` is not yet implemented at compile time
+fail_compilation/fail160.d(22): Error: `typeid(Foo).info` is not yet implemented at compile time
 ---
 */
 
@@ -19,7 +19,7 @@ template Wrapper(B, alias Func, int func)
 
 int main(char[][] args)
 {
-    auto x = new Wrapper!(Foo, Foo.work, cast(int)(Foo.classinfo.vtbl[0]))();
+    auto x = new Wrapper!(Foo, Foo.work, cast(int)(typeid(Foo).info.vtbl[0]))();
 
     return 0;
 }

--- a/test/fail_compilation/fail19923.d
+++ b/test/fail_compilation/fail19923.d
@@ -14,5 +14,5 @@ class Object {}
 void test()
 {
     Object o;
-    auto ti = o.classinfo;
+    auto ti = typeid(o);
 }

--- a/test/fail_compilation/fail19923.d
+++ b/test/fail_compilation/fail19923.d
@@ -1,4 +1,4 @@
-/* 
+/*
 DFLAGS:
 REQUIRED_ARGS:
 TEST_OUTPUT:
@@ -16,4 +16,3 @@ void test()
     Object o;
     auto ti = o.classinfo;
 }
-

--- a/test/fail_compilation/fail8059.d
+++ b/test/fail_compilation/fail8059.d
@@ -1,0 +1,26 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/fail8059.d(19): Deprecation: `.classinfo` property is deprecated - use `typeid(Object)` instead
+fail_compilation/fail8059.d(20): Deprecation: `.classinfo` property is deprecated - use `typeid(Object)` instead
+fail_compilation/fail8059.d(21): Deprecation: `.classinfo` property is deprecated - use `typeid(o)` instead
+fail_compilation/fail8059.d(24): Deprecation: `.classinfo` property is deprecated - use `typeid(Interface).info` instead
+fail_compilation/fail8059.d(25): Deprecation: `.classinfo` property is deprecated - use `typeid(i).info` instead
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=8059
+
+interface Interface {}
+
+void main ()
+{
+    scope o = new Object;
+    assert(Object.classinfo !is null);
+    assert(Object.classinfo  is typeid(Object));
+    assert(o.classinfo       is typeid(o));
+
+    Interface i;
+    assert(Interface.classinfo !is null);
+    assert(i.classinfo !is null);
+}

--- a/test/runnable/interface2.d
+++ b/test/runnable/interface2.d
@@ -34,8 +34,8 @@ void test1()
     printf("f = %p\n", f);
     assert(cast(void*)b !is cast(void*)f);
 
-    printf("f.class = '%.*s'\n", cast(int)f.classinfo.name.length, f.classinfo.name.ptr);
-    assert(f.classinfo.name == "interface2.Foo");
+    printf("f.class = '%.*s'\n", cast(int)typeid(f).name.length, typeid(f).name.ptr);
+    assert(typeid(f).name == "interface2.Foo");
 
     f.bar();
     assert(p1 is cast(void*)b);
@@ -668,7 +668,7 @@ void test19()
     assert(cast(void*)c + (2*(void*).sizeof) == cast(void*)icov);
     assert(cast(void*)c + (3*(void*).sizeof) == cast(void*)ifoo);
 
-    string s = ifoo.classinfo.name;
+    string s = typeid(ifoo).name;
     printf("%.*s\n", cast(int)s.length, s.ptr);
     assert(s == "interface2.IFoo19");
 
@@ -1122,10 +1122,8 @@ void testTypeid()
 
     assert(typeid(typeof(o)) is typeid(Object));
     assert(typeid(o) is typeid(D));
-    assert(o.classinfo is typeid(D));
     assert(typeid(typeof(i)) is typeid(I));
     assert(typeid(i) !is typeid(J));
-    assert(i.classinfo !is typeid(J));
 }
 
 /*******************************************************/

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -3025,7 +3025,7 @@ void test105()
     assert(t105ia.test105a() == "test105a");
     assert(t105ib.test105b() == "test105b");
 
-    assert(t105a.classinfo is Test105b.classinfo);
+    assert(typeid(t105a) is typeid(Test105b));
     //t105b.d = -1;
     //assert(t105b.d == -1);
     //assert(t105a.d == 42);
@@ -3143,12 +3143,12 @@ enum const(Test108) t108 = new Test108(38);
 void test108()
 {
     const Test108 obj = t108;
-    assert(obj.classinfo is Test108.classinfo);
+    assert(typeid(obj) is typeid(Test108));
     assert(obj.f == 38);
 
     const Getter iobj = t108;
     assert(iobj.getNum() == 38);
-    assert((cast(Object)iobj).classinfo is Test108.classinfo);
+    assert(typeid(cast(Object)iobj) is typeid(Test108));
     assert(t108 is t108);
 }
 */

--- a/test/runnable/template4.d
+++ b/test/runnable/template4.d
@@ -726,7 +726,7 @@ string name26;
 template aliastest(alias A) {
     pragma(msg,"Alias Test instantiated");
     void aliastest() {
-        name26 = (new A!().al).classinfo.name;
+        name26 = typeid(new A!().al).name;
         //writefln("Alias Test: ", name26);
     }
 }

--- a/test/runnable/test11.d
+++ b/test/runnable/test11.d
@@ -1388,5 +1388,3 @@ int main(string[] argv)
     printf("Success\n");
     return 0;
 }
-
-

--- a/test/runnable/test11.d
+++ b/test/runnable/test11.d
@@ -968,7 +968,7 @@ void test51()
 
     B51.b = a;
     assert(B51.b.bar == 3);
-    assert(B51.b.classinfo == A51.classinfo);
+    assert(typeid(B51.b) == typeid(A51));
 
     C51 c;
     c.x = &c;

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -1249,4 +1249,3 @@ int main(string[] argv)
     printf("Success\n");
     return 0;
 }
-

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -777,7 +777,7 @@ void test36()
 {
     A36 a = new A36;
 
-    printf("A36.sizeof = %zd\n", a.classinfo.initializer.length);
+    printf("A36.sizeof = %zd\n", typeid(a).initializer.length);
     printf("%d\n", a.s);
     printf("%d\n", a.a);
     printf("%d\n", a.b);
@@ -785,9 +785,9 @@ void test36()
     printf("%d\n", a.d);
 
     version(D_LP64)
-        assert(a.classinfo.initializer.length == 36);
+        assert(typeid(a).initializer.length == 36);
     else
-        assert(a.classinfo.initializer.length == 28);
+        assert(typeid(a).initializer.length == 28);
     assert(a.s == 1);
     assert(a.a == 2);
     assert(a.b == 3);
@@ -818,10 +818,10 @@ class Foo38
 {
     static void display_name()
     {
-        printf("%.*s\n", cast(int)Object.classinfo.name.length, Object.classinfo.name.ptr);
-        assert(Object.classinfo.name == "object.Object");
-        assert(super.classinfo.name == "object.Object");
-        assert(this.classinfo.name == "test12.Foo38");
+        printf("%.*s\n", cast(int)typeid(Object).name.length, typeid(Object).name.ptr);
+        assert(typeid(Object).name == "object.Object");
+        assert(typeid(typeof(super)).name == "object.Object");
+        assert(typeid(typeof(this)).name == "test12.Foo38");
     }
 }
 

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -392,8 +392,8 @@ class B27 : A27
 {
     static this()
     {
-        foo27(B27.classinfo);
-        foo27(A27.classinfo);
+        foo27(typeid(B27));
+        foo27(typeid(A27));
     }
 }
 
@@ -423,18 +423,18 @@ void foo28(ClassInfo ci)
 class A28
 {
     static this() {
-    foo28(A28.classinfo );
+        foo28(typeid(A28));
     }
 }
 
 class B28 : A28
 {
     static this() {
-        foo28(B28.classinfo );
+        foo28(typeid(B28));
         (new B28()).bodge_it();
     }
     void bodge_it() {
-        foo28(A28.classinfo );
+        foo28(typeid(A28));
     }
 }
 

--- a/test/runnable/test23.d
+++ b/test/runnable/test23.d
@@ -1318,8 +1318,8 @@ class C68
 void test68()
 {
     auto v1 = test.C68.value;
-    auto v2 = C68.classinfo;
-    auto v3 = test.C68.classinfo;
+    auto v2 = typeid(C68);
+    auto v3 = typeid(test.C68);
     assert(v2 == v3);
 }
 

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -940,9 +940,9 @@ void test47()
 void test48()
 {
     Object o = new Object();
-    printf("%.*s\n", cast(int)typeof(o).classinfo.name.length, typeof(o).classinfo.name.ptr);
-    printf("%.*s\n", cast(int)(typeof(o)).classinfo.name.length, (typeof(o)).classinfo.name.ptr);
-    printf("%.*s\n", cast(int)(Object).classinfo.name.length, (Object).classinfo.name.ptr);
+    printf("%.*s\n", cast(int)typeid(typeof(o)).name.length, typeid(typeof(o)).name.ptr);
+    printf("%.*s\n", cast(int)(typeid(typeof(o))).name.length, (typeid(typeof(o))).name.ptr);
+    printf("%.*s\n", cast(int)(typeid(Object)).name.length, (typeid(Object)).name.ptr);
 }
 
 /*******************************************/
@@ -1222,7 +1222,7 @@ void test64()
 {
     auto x = new Container64;
 
-    assert(!(x.classinfo.flags & 2));
+    assert(!(typeid(x).flags & 2));
 }
 
 /*******************************************/

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -1361,4 +1361,3 @@ void main()
 
     printf("Success\n");
 }
-

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -799,7 +799,7 @@ void test30()
     printf("test30()\n");
     GC30 gc;
 
-    GC30.gcLock = Object.classinfo;
+    GC30.gcLock = typeid(Object);
     assert(gc.malloc() == null);
 }
 

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -1491,4 +1491,3 @@ int main()
     printf("Success\n");
     return 0;
 }
-

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -1308,8 +1308,8 @@ void test79()
     C79 c = new C79();
 //    writeln(c.__vptr);
 //    writeln(c.__vptr[0]);
-//    writeln(cast(void*)c.classinfo);
-    assert(c.__vptr[0] == cast(void*)c.classinfo);
+//    writeln(cast(const void*)typeid(c));
+    assert(c.__vptr[0] == cast(const void*)typeid(c));
 //    writeln(c.__monitor);
     assert(c.__monitor == null);
     synchronized (c)
@@ -3579,7 +3579,7 @@ void test219()
   pragma(msg, T219!(int).C.mangleof);
   pragma(msg, C.mangleof); // incorrectly outputs the same as above
 
-  assert(T219!(int).C.classinfo !is C.classinfo); // fails
+  assert(typeid(T219!(int).C) !is typeid(C)); // fails
   assert(T219!(int).C.mangleof != C.mangleof); // fails
 }
 
@@ -3598,9 +3598,9 @@ void test220()
   mixin T220!(int);
 
   // all print 8
-//  writeln(T220!(int).C.classinfo.initializer.length);
-//  writeln(C.classinfo.initializer.length);
-//  writeln(D220.classinfo.initializer.length);
+//  writeln(typeid(T220!(int).C).initializer.length);
+//  writeln(typeid(C).initializer.length);
+//  writeln(typeid(D220).initializer.length);
 
   auto c = new C; // segfault in _d_newclass
 }

--- a/test/runnable/test5.d
+++ b/test/runnable/test5.d
@@ -57,9 +57,9 @@ int main()
 {
     bar b = new bar();
 
-    printf("b.size = x%zx\n", b.classinfo.initializer.length);
-    printf("bar.size = x%zx\n", bar.classinfo.initializer.length);
-    assert(b.classinfo.initializer.length == bar.classinfo.initializer.length);
+    printf("b.size = x%zx\n", typeid(b).initializer.length);
+    printf("bar.size = x%zx\n", typeid(bar).initializer.length);
+    assert(typeid(b).initializer.length == typeid(bar).initializer.length);
     abc(b);
     return 0;
 }

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -626,8 +626,8 @@ class C42
 
 void test42()
 {
-    printf("%zd\n", C42.classinfo.initializer.length);
-    assert(C42.classinfo.initializer.length == 12 + (void*).sizeof +
+    printf("%zd\n", typeid(C42).initializer.length);
+    assert(typeid(C42).initializer.length == 12 + (void*).sizeof +
         (void*).sizeof);
     C42 c = new C42;
     assert(c.a == 1);

--- a/test/runnable/testinvariant.d
+++ b/test/runnable/testinvariant.d
@@ -18,8 +18,8 @@ int testinvariant()
     Foo f = new Foo();
     printf("f = %p\n", f);
     printf("f.sizeof = x%zx\n", Foo.sizeof);
-    printf("f.classinfo = %p\n", f.classinfo);
-    printf("f.classinfo._invariant = %p\n", f.classinfo.base);
+    printf("typeid(f) = %p\n", typeid(f));
+    printf("typeid(f)._invariant = %p\n", typeid(f).base);
     f.test();
     printf("world\n");
     return 0;

--- a/test/runnable/testptrref.d
+++ b/test/runnable/testptrref.d
@@ -21,7 +21,7 @@ version(CRuntime_Microsoft)
                                               void[] function(string name) nothrow @nogc);
         dataSection = findImageSection(".data");
     }
-    
+
     void[] tlsRange;
     static this()
     {
@@ -30,7 +30,7 @@ version(CRuntime_Microsoft)
                                               void[] function() nothrow @nogc);
         tlsRange = initTLSRanges();
     }
-    
+
     version = ptrref_supported;
 }
 else version(Win32)
@@ -126,7 +126,7 @@ bool findDataPtr(const(void)* ptr)
             void* addr = dataSection.ptr + *p;
         else
             void* addr = *p;
-        
+
         if (addr == ptr)
             return true;
     }
@@ -158,7 +158,7 @@ void testRefPtr()
 
     assert(!findTlsPtr(cast(size_t*)&tlsStr)); // length
     assert(findTlsPtr(cast(size_t*)&tlsStr + 1)); // ptr
-    
+
     // monitor is manually managed
     assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
     assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
@@ -167,7 +167,7 @@ void testRefPtr()
     assert(!findTlsPtr(&arr));
     assert(!findDataPtr(cast(size_t*)&arr + 1));
     assert(!findTlsPtr(cast(size_t*)&arr + 1));
-    
+
     assert(findDataPtr(cast(size_t*)&strArr[0] + 1)); // ptr in _DATA!
     assert(findDataPtr(cast(size_t*)&strArr[1] + 1)); // ptr in _DATA!
     strArr[1] = "c";

--- a/test/runnable/testptrref.d
+++ b/test/runnable/testptrref.d
@@ -160,8 +160,8 @@ void testRefPtr()
     assert(findTlsPtr(cast(size_t*)&tlsStr + 1)); // ptr
 
     // monitor is manually managed
-    assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
-    assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
+    assert(!findDataPtr(cast(size_t*)cast(void*)typeid(Class) + 1));
+    assert(!findDataPtr(cast(size_t*)cast(void*)typeid(Class) + 1));
 
     assert(!findDataPtr(&arr));
     assert(!findTlsPtr(&arr));

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -401,7 +401,7 @@ void test13()
     assert(__traits(hasMember, S, "aaa") == false);
 
     auto k = __traits(classInstanceSize, C);
-    assert(k == C.classinfo.initializer.length);
+    assert(k == typeid(C).initializer.length);
 }
 
 /********************************************************/

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4169,7 +4169,7 @@ void test5437()
 void test1962()
 {
     class C { abstract void x(); }
-    assert(C.classinfo.create() is null);
+    assert(typeid(C).create() is null);
 }
 
 /***************************************************/


### PR DESCRIPTION
Previous attempt was a while ago: https://github.com/dlang/dmd/pull/2792
Since @andralex seemed fine with the idea I figured I'd pick up the issue.