### PR TITLE
Fix issue 20444 - Support `SOURCE_DATE_EPOCH` for reproducible builds

### DIFF
--- a/changelog/reproducible-builds.dd
+++ b/changelog/reproducible-builds.dd
@@ -1,0 +1,8 @@
+Environment variable `SOURCE_DATE_EPOCH` is now supported
+
+The environment variable `SOURCE_DATE_EPOCH` is used for
+$(LINK2 https://reproducible-builds.org/, reproducible builds).
+It is an UNIX timestamp (seconds since 1970-01-01 00:00:00),
+as described $(LINK2 https://reproducible-builds.org/docs/source-date-epoch/, here).
+DMD now correctly recognize it and will set the `__DATE__`,
+`__TIME__`, and `__TIMESTAMP__` tokens accordingly.

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -65,13 +65,13 @@ extern (C++) struct Target
     uint classinfosize;       /// size of `ClassInfo`
     ulong maxStaticDataSize;  /// maximum size of static data
 
-    // C ABI
+    /// C ABI
     TargetC c;
 
-    // C++ ABI
+    /// C++ ABI
     TargetCPP cpp;
 
-    // Objective-C ABI
+    /// Objective-C ABI
     TargetObjC objc;
 
     /**

--- a/test/dshell/extra-files/source_date_epoch.d
+++ b/test/dshell/extra-files/source_date_epoch.d
@@ -1,0 +1,9 @@
+module source_date_epoch;
+
+static immutable Date = __DATE__;
+static immutable Time = __TIME__;
+static immutable TimeStamp = __TIMESTAMP__;
+
+pragma(msg, Date);
+pragma(msg, Time);
+pragma(msg, TimeStamp);

--- a/test/dshell/issue20444_SOURCE_DATE_EPOCH.d
+++ b/test/dshell/issue20444_SOURCE_DATE_EPOCH.d
@@ -1,0 +1,21 @@
+import dshell;
+
+immutable string expected =
+`Apr 24 1992
+14:14:00
+Fri Apr 24 14:14:00 1992
+`;
+
+void main ()
+{
+    string[string] env = [
+        "SOURCE_DATE_EPOCH": "704124840",
+        "TZ": "UTC",
+        "LC_ALL": "C",
+    ];
+
+    const output = shellExpand("$OUTPUT_BASE/source_date_epoch.txt");
+    run("$DMD -m$MODEL -o- -c $EXTRA_FILES/source_date_epoch.d", stdout, File(output, "wb"), env);
+    const result = readText(output).filterCompilerOutput;
+    assert(result == expected, result);
+}


### PR DESCRIPTION
```
Adds support for the de-facto standard `SOURCE_DATE_EPOCH` variable,
for lexer tokens `__DATE__`, `__TIME__`, `__TIMESTAMP__`.
```

~Since this PR touches a bunch of unrelated things, I'll split it into multiple PRs, this PR is solely to show the end goal.~
 
CC @jelly : Can you check the last commit ?
~CC @ibuclaw , you might be interested in this.~