### PR TITLE
Fix issue 20734 - Allocate array literals as arguments to scope slice parameters on the stack

### DIFF
--- a/test/runnable/test20734.d
+++ b/test/runnable/test20734.d
@@ -2,12 +2,12 @@
 REQUIRED_ARGS: -betterC -preview=dip1000
 */
 
-int numDtor;
+__gshared int numDtor;
 
 struct S
 {
     int a;
-    ~this() nothrow @nogc @safe { ++numDtor; }
+    ~this() nothrow @nogc @trusted { ++numDtor; }
 }
 
 void takeScopeSlice(const scope S[] slice) nothrow @nogc @safe {}
@@ -15,6 +15,6 @@ void takeScopeSlice(const scope S[] slice) nothrow @nogc @safe {}
 extern(C) int main() nothrow @nogc @safe
 {
     takeScopeSlice([ S(1), S(2) ]); // @nogc => no GC allocation
-    assert(numDtor == 2); // stack-allocated array literal properly destructed
+    (() @trusted { assert(numDtor == 2); })(); // stack-allocated array literal properly destructed
     return 0;
 }

--- a/test/runnable/test20734.d
+++ b/test/runnable/test20734.d
@@ -1,0 +1,20 @@
+/*
+REQUIRED_ARGS: -betterC -preview=dip1000
+*/
+
+int numDtor;
+
+struct S
+{
+    int a;
+    ~this() nothrow @nogc @safe { ++numDtor; }
+}
+
+void takeScopeSlice(const scope S[] slice) nothrow @nogc @safe {}
+
+extern(C) int main() nothrow @nogc @safe
+{
+    takeScopeSlice([ S(1), S(2) ]); // @nogc => no GC allocation
+    assert(numDtor == 2); // stack-allocated array literal properly destructed
+    return 0;
+}


### PR DESCRIPTION
Requires https://github.com/dlang/druntime/pull/3032 (specifically, adding `scope` to `__ArrayDtor()`). I've given this a quick test ride with LDC on Win64; druntime and Phobos unittests still pass; most `-checkaction=context` compile errors for the Phobos unittests are gone too.