### PR TITLE
delete debug hack which turns all non-root instances to speculative

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -7139,7 +7139,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     {
         Module mi = minst; // instantiated . inserted module
 
-        if (global.params.useUnitTests || global.params.debuglevel)
+        if (global.params.useUnitTests)
         {
             // Turn all non-root instances to speculative
             if (mi && !mi.isRoot())


### PR DESCRIPTION
This leads to an unnecessary semantic analysis since the -debug special case for code generation was already deleted.

https://github.com/dlang/dmd/commit/bd8149d7cc23142d38e2f226e24cdf455ca5f10f 