### PR TITLE
Fix Issue 20742 - dmd -X (JSON output) includes uncompiled symbols

### DIFF
--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -577,6 +577,7 @@ public:
         if (d.condition.inc != Include.notComputed)
         {
             visit(cast(AttribDeclaration)d);
+            return; // Don't visit the if/else bodies again below
         }
         Dsymbols* ds = d.decl ? d.decl : d.elsedecl;
         for (size_t i = 0; i < ds.dim; i++)

--- a/test/compilable/json20742.d
+++ b/test/compilable/json20742.d
@@ -1,0 +1,69 @@
+/*
+REQUIRED_ARGS: -Xf- -o- -version=Showme
+PERMUTE_ARGS:
+TEST_OUTPUT:
+----
+[
+ {
+  "kind" : "module",
+  "file" : "compilable$?:windows=\\|/$json20742.d",
+  "members" : [
+   {
+    "name" : "X1",
+    "kind" : "struct",
+    "protection" : "private",
+    "line" : 52,
+    "char" : 13,
+    "members" : []
+   },
+   {
+    "name" : "Y2",
+    "kind" : "struct",
+    "protection" : "private",
+    "line" : 59,
+    "char" : 13,
+    "members" : []
+   },
+   {
+    "name" : "A1",
+    "kind" : "struct",
+    "protection" : "private",
+    "line" : 62,
+    "char" : 13,
+    "members" : []
+   },
+   {
+    "name" : "B2",
+    "kind" : "struct",
+    "protection" : "private",
+    "line" : 69,
+    "char" : 13,
+    "members" : []
+   }
+  ]
+ }
+]
+----
+
+https://issues.dlang.org/show_bug.cgi?id=20742
+*/
+
+version(Showme)
+    private struct X1 {}
+else
+    private struct X2 {}
+
+version(Hideme)
+    private struct Y1 {}
+else
+    private struct Y2 {}
+
+static if (true)
+    private struct A1 {}
+else
+    private struct A2 {}
+
+static if (false)
+    private struct B1 {}
+else
+    private struct B2 {}


### PR DESCRIPTION
PR #6621 took the code for pending `ConditionalDeclaration`s from
doc.d but missed the early return.

CC @schveiguy 

Reference:

https://github.com/dlang/dmd/blob/83a929e6bfc7459b84432825b0e4f3f8913c2e4c/src/dmd/doc.d#L1202-L1219