### PR TITLE
[dmd-cxx] speller.c: Initialize ncost variable.

### DIFF
--- a/src/root/speller.c
+++ b/src/root/speller.c
@@ -58,7 +58,7 @@ void *spellerY(const char *seed, size_t seedlen, fp_speller_t fp, void *fparg,
     memcpy(buf, seed, index);
     *cost = INT_MAX;
     void* p = NULL;
-    int ncost;
+    int ncost = 0;
 
     /* Delete at seed[index] */
     if (index < seedlen)
@@ -122,7 +122,7 @@ void *spellerX(const char *seed, size_t seedlen, fp_speller_t fp, void *fparg,
         if (!buf)
             return NULL;                      // no matches
     }
-    int cost = INT_MAX, ncost;
+    int cost = INT_MAX, ncost = 0;
     void *p = NULL, *np;
 
     /* Deletions */


### PR DESCRIPTION
Use of uninitialized varaible caught by valgrind.

==163577== Conditional jump or move depends on uninitialised value(s)
==163577==    at 0x7546CB: combineSpellerResult (speller.c:30)
==163577==    by 0x7546CB: spellerX(char const*, unsigned long, void* (*)(void*,
 char const*, int*), void*, char const*, int) (speller.c:154)
==163577==    by 0x754881: speller(char const*, void* (*)(void*, char const*, in
t*), void*, char const*) (speller.c:224)
==163577==    by 0x6F877A: semantic (func.c:1112)