### PR TITLE
[dmd-cxx] expression.c: Fix wrong sizeof VectorArrayExp

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -5775,7 +5775,7 @@ Expression *VectorExp::syntaxCopy()
 /************************************************************/
 
 VectorArrayExp::VectorArrayExp(Loc loc, Expression *e1)
-        : UnaExp(loc, TOKvectorarray, sizeof(VectorExp), e1)
+        : UnaExp(loc, TOKvectorarray, sizeof(VectorArrayExp), e1)
 {
 }
 


### PR DESCRIPTION
This Expression node is smaller than VectorExp, causing valgrind to complain.

==162456== Invalid read of size 8
==162456==    at 0x6C38E9: Expression::copy() (expression.c:2046)
==162456==    by 0x664547: visit (dcast.c:68)
==162456==    by 0x664547: implicitCastTo(Expression*, Scope*, Type*)::ImplicitC
astTo::visit(Expression*) (dcast.c:54)
==162456==    by 0x66BE8A: implicitCastTo(Expression*, Scope*, Type*) (dcast.c:1
60)