### PR TITLE
[stable] Add dmd.argtypes_aarch64 for the AAPCS64 ABI

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1158,7 +1158,7 @@ auto sourceFiles()
             tocvdebug.d s2ir.d toobj.d e2ir.d eh.d iasm.d iasmdmd.d iasmgcc.d objc_glue.d
         "),
         frontend: fileArray(env["D"], "
-            access.d aggregate.d aliasthis.d apply.d argtypes.d argtypes_sysv_x64.d arrayop.d
+            access.d aggregate.d aliasthis.d apply.d argtypes.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d
             arraytypes.d ast_node.d astcodegen.d asttypename.d attrib.d blockexit.d builtin.d canthrow.d chkformat.d
             cli.d clone.d compiler.d complex.d cond.d constfold.d cppmangle.d cppmanglewin.d ctfeexpr.d
             ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d dimport.d dinifile.d

--- a/src/dmd/README.md
+++ b/src/dmd/README.md
@@ -205,6 +205,7 @@ Note that these groups have no strict meaning, the category assignments are a bi
 | [tocsym.d](https://github.com/dlang/dmd/blob/master/src/dmd/tocsym.d)                       | Convert a D symbol to a symbol the linker understands (with mangled name)           |
 | [argtypes.d](https://github.com/dlang/dmd/blob/master/src/dmd/argtypes.d)                   | Convert a D type into simple (register) types for calling conventions               |
 | [argtypes_sysv_x64.d](https://github.com/dlang/dmd/blob/master/src/dmd/argtypes_sysv_x64.d) | 'argtypes' for the x86_64 System V ABI                                              |
+| [argtypes_aarch64.d](https://github.com/dlang/dmd/blob/master/src/dmd/argtypes_aarch64.d)   | 'argtypes' for the AArch64 ABI                                                      |
 | [glue.d](https://github.com/dlang/dmd/blob/master/src/dmd/glue.d)                           | Generate the object file for function declarations                                  |
 | [gluelayer.d](https://github.com/dlang/dmd/blob/master/src/dmd/gluelayer.d)                 | Declarations for back-end functions that the front-end invokes                      |
 | [todt.d](https://github.com/dlang/dmd/blob/master/src/dmd/todt.d)                           | Convert initializers into structures that the back-end will add to the data segment |

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -177,9 +177,8 @@ public:
     structalign_t alignment;    // alignment applied outside of the struct
     StructPOD ispod;            // if struct is POD
 
-    // For 64 bit Efl function call/return ABI
-    Type *arg1type;
-    Type *arg2type;
+    // ABI-specific type(s) if the struct can be passed in registers
+    TypeTuple *argTypes;
 
     // Even if struct is defined as non-root symbol, some built-in operations
     // (e.g. TypeidExp, NewExp, ArrayLiteralExp, etc) request its TypeInfo.
@@ -197,6 +196,9 @@ public:
 
     StructDeclaration *isStructDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
+
+    unsigned numArgTypes() const;
+    Type *argType(unsigned index);
 };
 
 class UnionDeclaration : public StructDeclaration

--- a/src/dmd/argtypes.d
+++ b/src/dmd/argtypes.d
@@ -55,7 +55,7 @@ extern (C++) TypeTuple toArgTypes(Type t)
         void memory()
         {
             //printf("\ttoArgTypes() %s => [ ]\n", t.toChars());
-            result = new TypeTuple(); // pass on the stack
+            result = TypeTuple.empty; // pass on the stack
         }
 
         ///

--- a/src/dmd/argtypes_aarch64.d
+++ b/src/dmd/argtypes_aarch64.d
@@ -1,0 +1,193 @@
+/**
+ * Break down a D type into basic (register) types for the AArch64 ABI.
+ *
+ * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
+ * Authors:     Martin Kinkelin
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/argtypes_aarch64.d, _argtypes_aarch64.d)
+ * Documentation:  https://dlang.org/phobos/dmd_argtypes_aarch64.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/argtypes_aarch64.d
+ */
+
+module dmd.argtypes_aarch64;
+
+import dmd.mtype;
+
+/****************************************************
+ * This breaks a type down into 'simpler' types that can be passed to a function
+ * in registers, and returned in registers.
+ * This is the implementation for the AAPCS64 ABI, based on
+ * https://github.com/ARM-software/abi-aa/blob/master/aapcs64/aapcs64.rst.
+ * Params:
+ *      t = type to break down
+ * Returns:
+ *      tuple of 1 type if `t` can be passed in registers; e.g., a static array
+ *      for Homogeneous Floating-point/Vector Aggregates (HFVA).
+ *      A tuple of zero length means the type cannot be passed/returned in registers.
+ *      null indicates a `void`.
+ */
+extern (C++) TypeTuple toArgTypes_aarch64(Type t)
+{
+    if (t == Type.terror)
+        return new TypeTuple(t);
+
+    const size = cast(size_t) t.size();
+    if (size == 0)
+        return null;
+
+    Type tb = t.toBasetype();
+    const isAggregate = tb.ty == Tstruct || tb.ty == Tsarray || tb.ty == Tarray || tb.ty == Tdelegate || tb.iscomplex();
+    if (!isAggregate)
+        return new TypeTuple(t);
+
+    Type hfvaType;
+    enum maxNumHFVAElements = 4;
+    const isHFVA = size > maxNumHFVAElements * 16 ? false : isHFVA(tb, maxNumHFVAElements, &hfvaType);
+
+    // non-PODs and larger non-HFVA PODs are passed indirectly by value (pointer to caller-allocated copy)
+    if ((size > 16 && !isHFVA) || !isPOD(tb))
+        return TypeTuple.empty;
+
+    if (isHFVA)
+    {
+        // pass in SIMD registers
+        return new TypeTuple(hfvaType);
+    }
+
+    // pass remaining aggregates in 1 or 2 GP registers
+    static Type getGPType(size_t size)
+    {
+        switch (size)
+        {
+        case 1:  return Type.tint8;
+        case 2:  return Type.tint16;
+        case 4:  return Type.tint32;
+        case 8:  return Type.tint64;
+        default: return Type.tint64.sarrayOf((size + 7) / 8);
+        }
+    }
+    return new TypeTuple(getGPType(size));
+}
+
+/**
+ * A Homogeneous Floating-point/Vector Aggregate (HFA/HVA) is an ARM/AArch64
+ * concept that consists of up to 4 elements of the same floating point/vector
+ * type. It is the aggregate final data layout that matters so structs, unions,
+ * static arrays and complex numbers can result in an HFVA.
+ *
+ * simple HFAs: struct F1 {float f;}  struct D4 {double a,b,c,d;}
+ * interesting HFA: struct {F1[2] vals; float weight;}
+ *
+ * If the type is an HFVA and `rewriteType` is specified, it is set to a
+ * corresponding static array type.
+ */
+extern (C++) bool isHFVA(Type t, int maxNumElements = 4, Type* rewriteType = null)
+{
+    t = t.toBasetype();
+    if ((t.ty != Tstruct && t.ty != Tsarray && !t.iscomplex()) || !isPOD(t))
+        return false;
+
+    Type fundamentalType;
+    const N = getNestedHFVA(t, fundamentalType);
+    if (N < 1 || N > maxNumElements)
+        return false;
+
+    if (rewriteType)
+        *rewriteType = fundamentalType.sarrayOf(N);
+
+    return true;
+}
+
+private:
+
+bool isPOD(Type t)
+{
+    auto baseType = t.baseElemOf();
+    if (auto ts = baseType.isTypeStruct())
+        return ts.sym.isPOD();
+    return true;
+}
+
+/**
+ * Recursive helper.
+ * Returns size_t.max if the type isn't suited as HFVA (element) or incompatible
+ * to the specified fundamental type, otherwise the number of consumed elements
+ * of that fundamental type.
+ * If `fundamentalType` is null, it is set on the first occasion and then left
+ * untouched.
+ */
+size_t getNestedHFVA(Type t, ref Type fundamentalType)
+{
+    t = t.toBasetype();
+
+    if (auto tarray = t.isTypeSArray())
+    {
+        const N = getNestedHFVA(tarray.nextOf(), fundamentalType);
+        return N == size_t.max ? N : N * cast(size_t) tarray.dim.toUInteger(); // => T[0] may return 0
+    }
+
+    if (auto tstruct = t.isTypeStruct())
+    {
+        // check each field recursively and set fundamentalType
+        bool isEmpty = true;
+        foreach (field; tstruct.sym.fields)
+        {
+            const field_N = getNestedHFVA(field.type, fundamentalType);
+            if (field_N == size_t.max)
+                return field_N;
+            if (field_N > 0) // might be 0 for empty static array
+                isEmpty = false;
+        }
+
+        // an empty struct (no fields or only empty static arrays) is an undefined
+        // byte, i.e., no HFVA
+        if (isEmpty)
+            return size_t.max;
+
+        // due to possibly overlapping fields (for unions and nested anonymous
+        // unions), use the overall struct size to determine N
+        const structSize = t.size();
+        const fundamentalSize = fundamentalType.size();
+        assert(structSize % fundamentalSize == 0);
+        return cast(size_t) (structSize / fundamentalSize);
+    }
+
+    Type thisFundamentalType;
+    size_t N;
+
+    if (t.isTypeVector())
+    {
+        thisFundamentalType = t;
+        N = 1;
+    }
+    else if (t.isfloating()) // incl. imaginary and complex
+    {
+        auto ftSize = t.size();
+        N = 1;
+
+        if (t.iscomplex())
+        {
+            ftSize /= 2;
+            N = 2;
+        }
+
+        switch (ftSize)
+        {
+            case  4: thisFundamentalType = Type.tfloat32; break;
+            case  8: thisFundamentalType = Type.tfloat64; break;
+            case 16: thisFundamentalType = Type.tfloat80; break; // IEEE quadruple
+            default: assert(0, "unexpected floating-point type size");
+        }
+    }
+    else
+    {
+        return size_t.max; // reject all other types
+    }
+
+    if (!fundamentalType)
+        fundamentalType = thisFundamentalType; // initialize
+    else if (fundamentalType != thisFundamentalType)
+        return size_t.max; // incompatible fundamental types, reject
+
+    return N;
+}

--- a/src/dmd/argtypes_sysv_x64.d
+++ b/src/dmd/argtypes_sysv_x64.d
@@ -37,7 +37,7 @@ extern (C++) TypeTuple toArgTypes_sysv_x64(Type t)
     if (size == 0)
         return null;
     if (size > 32)
-        return new TypeTuple();
+        return TypeTuple.empty;
 
     const classification = classify(t, size);
     const classes = classification.slice();
@@ -47,7 +47,7 @@ extern (C++) TypeTuple toArgTypes_sysv_x64(Type t)
     switch (c0)
     {
     case Class.memory:
-         return new TypeTuple();
+         return TypeTuple.empty;
     case Class.x87:
         return new TypeTuple(Type.tfloat80);
     case Class.complexX87:

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -220,9 +220,8 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     structalign_t alignment;    // alignment applied outside of the struct
     StructPOD ispod;            // if struct is POD
 
-    // For 64 bit Efl function call/return ABI
-    Type arg1type;
-    Type arg2type;
+    // ABI-specific type(s) if the struct can be passed in registers
+    TypeTuple argTypes;
 
     // Even if struct is defined as non-root symbol, some built-in operations
     // (e.g. TypeidExp, NewExp, ArrayLiteralExp, etc) request its TypeInfo.
@@ -421,15 +420,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             }
         }
 
-        auto tt = target.toArgTypes(type);
-        size_t dim = tt ? tt.arguments.dim : 0;
-        if (dim >= 1)
-        {
-            assert(dim <= 2);
-            arg1type = (*tt.arguments)[0].type;
-            if (dim == 2)
-                arg2type = (*tt.arguments)[1].type;
-        }
+        argTypes = target.toArgTypes(type);
     }
 
     /***************************************
@@ -602,6 +593,16 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     override void accept(Visitor v)
     {
         v.visit(this);
+    }
+
+    final uint numArgTypes() const
+    {
+        return argTypes && argTypes.arguments ? cast(uint) argTypes.arguments.dim : 0;
+    }
+
+    final Type argType(uint index)
+    {
+        return index < numArgTypes() ? (*argTypes.arguments)[index].type : null;
     }
 }
 

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1007,9 +1007,9 @@ Lagain:
 
             TypeStruct tc = cast(TypeStruct)tb;
             StructDeclaration sd = tc.sym;
-            if (sd.arg1type && !sd.arg2type)
+            if (sd.numArgTypes() == 1)
             {
-                tb = sd.arg1type;
+                tb = sd.argType(0);
                 goto Lagain;
             }
             goto default;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6140,6 +6140,9 @@ extern (C++) final class TypeClass : Type
  */
 extern (C++) final class TypeTuple : Type
 {
+    // 'logically immutable' cached global - don't modify!
+    __gshared TypeTuple empty = new TypeTuple();
+
     Parameters* arguments;  // types making up the tuple
 
     extern (D) this(Parameters* arguments)

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -815,6 +815,9 @@ public:
 class TypeTuple : public Type
 {
 public:
+    // 'logically immutable' cached global - don't modify (neither pointer nor pointee)!
+    static TypeTuple *empty;
+
     Parameters *arguments;      // types making up the tuple
 
     static TypeTuple *create(Parameters *arguments);

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -522,14 +522,14 @@ extern (C++) struct Target
                 // win32 returns otherwise POD structs with ctors via memory
                 return true;
             }
-            if (sd.arg1type && !sd.arg2type)
+            if (sd.numArgTypes() == 1)
             {
-                tns = sd.arg1type;
+                tns = sd.argType(0);
                 if (tns.ty != Tstruct)
                     goto L2;
                 goto Lagain;
             }
-            else if (global.params.is64bit && !sd.arg1type && !sd.arg2type)
+            else if (global.params.is64bit && sd.numArgTypes() == 0)
                 return true;
             else if (sd.isPOD())
             {

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -161,7 +161,9 @@ public:
         {
             // Create a new backend type
             StructDeclaration sym = t.sym;
-            t.ctype = type_struct_class(sym.toPrettyChars(true), sym.alignsize, sym.structsize, sym.arg1type ? Type_toCtype(sym.arg1type) : null, sym.arg2type ? Type_toCtype(sym.arg2type) : null, sym.isUnionDeclaration() !is null, false, sym.isPOD() != 0, sym.hasNoFields);
+            auto arg1type = sym.argType(0);
+            auto arg2type = sym.argType(1);
+            t.ctype = type_struct_class(sym.toPrettyChars(true), sym.alignsize, sym.structsize, arg1type ? Type_toCtype(arg1type) : null, arg2type ? Type_toCtype(arg2type) : null, sym.isUnionDeclaration() !is null, false, sym.isPOD() != 0, sym.hasNoFields);
             /* Add in fields of the struct
              * (after setting ctype to avoid infinite recursion)
              */

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -1328,19 +1328,16 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         if (global.params.is64bit)
         {
-            Type t = sd.arg1type;
             foreach (i; 0 .. 2)
             {
                 // m_argi
-                if (t)
+                if (auto t = sd.argType(i))
                 {
                     genTypeInfo(d.loc, t, null);
                     dtb.xoff(toSymbol(t.vtinfo), 0);
                 }
                 else
                     dtb.size(0);
-
-                t = sd.arg2type;
             }
         }
 


### PR DESCRIPTION
From https://github.com/ldc-developers/ldc/pull/3393; only useful for LDC for now.