### PR TITLE
Extend checkaction=context for boolean convertible expressions

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5988,7 +5988,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 (*tiargs)[1] = (*es)[0].type;
                 (*tiargs)[2] = (*es)[1].type;
             }
-            else // Format exp.e1 before any additional boolean conversion
+
+            // Format exp.e1 before any additional boolean conversion
+            // Ignore &&/|| because "assert(...) failed" is more informative than "false != true"
+            else if (tok != TOK.andAnd && tok != TOK.orOr)
             {
                 es = new Expressions(1);
                 tiargs = new Objects(2);
@@ -6026,6 +6029,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.msg = new StringExp(loc, "assert(__ctfe) failed!");
                     goto LSkip;
                 }
+            }
+            else
+            {
+                OutBuffer buf;
+                buf.printf("%s failed", exp.toChars());
+                exp.msg = new StringExp(Loc.initial, buf.extractSlice());
+                goto LSkip;
             }
 
             Expression __assertFail = new IdentifierExp(exp.loc, Id.empty);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5870,6 +5870,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (generateMsg)
         // no message - use assert expression as msg
         {
+            if (!verifyHookExist(exp.loc, *sc, Id._d_assert_fail, "generating assert messages"))
+                return setError();
+
             /*
             {
               auto a = e1, b = e2;
@@ -5915,6 +5918,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.e1 = e1;
             }
 
+            Expressions* es;
+            Objects* tiargs;
+            Loc loc = exp.e1.loc;
+
             const tok = exp.e1.op;
             bool isEqualsCallExpression;
             if (tok == TOK.call)
@@ -5938,12 +5945,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 tok == TOK.in_ ||
                 isEqualsCallExpression)
             {
-                if (!verifyHookExist(exp.loc, *sc, Id._d_assert_fail, "generating assert messages"))
-                    return setError();
-
-                auto es = new Expressions(2);
-                auto tiargs = new Objects(3);
-                Loc loc = exp.e1.loc;
+                es = new Expressions(2);
+                tiargs = new Objects(3);
 
                 if (isEqualsCallExpression)
                 {
@@ -5984,22 +5987,56 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 (*tiargs)[0] = comp;
                 (*tiargs)[1] = (*es)[0].type;
                 (*tiargs)[2] = (*es)[1].type;
-
-                Expression __assertFail = new IdentifierExp(exp.loc, Id.empty);
-                auto assertFail = new DotIdExp(loc, __assertFail, Id.object);
-
-                auto dt = new DotTemplateInstanceExp(loc, assertFail, Id._d_assert_fail, tiargs);
-                auto ec = CallExp.create(Loc.initial, dt, es);
-                exp.msg = ec;
             }
-            else
+            else // Format exp.e1 before any additional boolean conversion
             {
-                OutBuffer buf;
-                buf.printf("%s failed", exp.toChars());
-                exp.msg = new StringExp(Loc.initial, buf.extractSlice());
+                es = new Expressions(1);
+                tiargs = new Objects(2);
+
+                if (auto ne = exp.e1.isNotExp())
+                {
+                    // Fetch the (potential non-bool) expression and fold
+                    // (n) negations into (n % 2) negations, e.g. !!a => a
+                    for (bool neg = true; ; neg = !neg)
+                    {
+                        if (auto ne2 = ne.e1.isNotExp())
+                            ne = ne2;
+                        else
+                        {
+                            (*es)[0] = maybePromoteToTmp(ne.e1);
+                            (*tiargs)[0] = new StringExp(loc, neg ? "!" : "");
+                            break;
+                        }
+                    }
+                }
+                else
+                {   // Simply format exp.e1
+                    (*es)[0] = maybePromoteToTmp(exp.e1);
+                    // No special treatment for other operators to avoid redundant template instantions
+                    (*tiargs)[0] = new StringExp(loc, "");
+                }
+
+                (*tiargs)[1] = (*es)[0].type;
+
+                // Passing __ctfe to auto ref infers ref and aborts compilation:
+                // "cannot modify compiler-generated variable __ctfe"
+                auto ve = (*es)[0].isVarExp();
+                if (ve && ve.var.ident == Id.ctfe)
+                {
+                    exp.msg = new StringExp(loc, "assert(__ctfe) failed!");
+                    goto LSkip;
+                }
             }
+
+            Expression __assertFail = new IdentifierExp(exp.loc, Id.empty);
+            auto assertFail = new DotIdExp(loc, __assertFail, Id.object);
+
+            auto dt = new DotTemplateInstanceExp(loc, assertFail, Id._d_assert_fail, tiargs);
+            auto ec = CallExp.create(Loc.initial, dt, es);
+            exp.msg = ec;
         }
 
+        LSkip:
         if (Expression ex = unaSemantic(exp, sc))
         {
             result = ex;

--- a/test/fail_compilation/fail145.d
+++ b/test/fail_compilation/fail145.d
@@ -1,8 +1,8 @@
 /*
-REQUIRED_ARGS: -checkaction=context
+
 TEST_OUTPUT:
 ---
-fail_compilation/fail145.d(14): Error: `"assert(i && (i < 0)) failed"`
+fail_compilation/fail145.d(14): Error: `assert(i && (i < 0))` failed
 fail_compilation/fail145.d(27):        called from here: `bar(7)`
 ---
 */

--- a/test/fail_compilation/fail145.d
+++ b/test/fail_compilation/fail145.d
@@ -1,8 +1,8 @@
 /*
-
+REQUIRED_ARGS: -checkaction=context
 TEST_OUTPUT:
 ---
-fail_compilation/fail145.d(14): Error: `assert(i && (i < 0))` failed
+fail_compilation/fail145.d(14): Error: `"assert(i && (i < 0)) failed"`
 fail_compilation/fail145.d(27):        called from here: `bar(7)`
 ---
 */

--- a/test/runnable/testassert.d
+++ b/test/runnable/testassert.d
@@ -1,5 +1,6 @@
 /*
 REQUIRED_ARGS: -checkaction=context -dip25 -dip1000
+PERMUTE_ARGS: -O -g -inline
 */
 
 void test8765()
@@ -15,7 +16,7 @@ void test8765()
         // no-message -> assert expression
         msg = e.msg;
     }
-    assert(msg && msg == "assert(a) failed");
+    assert(msg == "0 != true");
 }
 
  void test9255()
@@ -193,6 +194,33 @@ void testMixinExpression() @safe
     assert(msg == "S() == S()");
 }
 
+void testUnaryFormat()
+{
+    int zero = 0, one = 1;
+    assert(getMessage(assert(zero)) == "0 != true");
+    assert(getMessage(assert(!one)) == "1 == true");
+
+    assert(getMessage(assert(!cast(int) 1.5)) == "1 == true");
+
+    assert(getMessage(assert(!!__ctfe)) == "assert(__ctfe) failed!");
+
+    static struct S
+    {
+        int i;
+        bool opCast() const
+        {
+            return i < 2;
+        }
+    }
+
+    assert(getMessage(assert(S(4))) == "S(4) != true");
+
+    S s = S(4);
+    assert(getMessage(assert(*&s)) == "S(4) != true");
+
+    assert(getMessage(assert(--(++zero))) == "0 != true");
+}
+
 void main()
 {
     test8765();
@@ -200,4 +228,5 @@ void main()
     test20114();
     test20375();
     testMixinExpression();
+    testUnaryFormat();
 }


### PR DESCRIPTION
Simply format the argument passed to `assert`.

~~Depends on dlang/druntime#3047~~

CC @kinke