### PR TITLE
[dmd-cxx] Fix Issue 9937: CTFE floats don't overflow correctly

### DIFF
--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -7742,3 +7742,19 @@ struct RBNode(T)
 
 static assert(!__traits(compiles, { alias bug18057 = RBNode!int; }));
 
+/************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=9937
+
+int test9937()
+{
+    import core.math;
+
+    float x = float.max;
+    x *= 2;
+    x = toPrec!float(x);
+    x /= 2;
+    assert(x == float.infinity);
+    return 1;
+}
+
+static assert(test9937());


### PR DESCRIPTION
Adjusts original test to include new toPrec intrinsic

(Missed the inclusion of this test).