### PR TITLE
Fix Issue 13292 - DMD accepts both -m32 and -m64

### DIFF
--- a/test/compilable/test13292.sh
+++ b/test/compilable/test13292.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$DMD -c -o- -main -m${MODEL} ${EXTRA_FILES}/minimal/object.d

--- a/test/fail_compilation/fail13292.sh
+++ b/test/fail_compilation/fail13292.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+errmsg="$(! $DMD -c -o- -main -m32 -m64 ${EXTRA_FILES}/minimal/object.d 2>&1 > /dev/null)"
+expected="Error: Conflicting target architectures specified: -m32 and -m64."
+
+if [ "$errmsg" != "$expected" ]; then exit 1; fi
+
+exit 0


### PR DESCRIPTION
Now raises an error when conflicting `-mXXX` arguments are given.
However, multiple `-mXXX` are still valid, iff all `XXX` are the same.