### PR TITLE
add TYrestrictPtr to backend

### DIFF
--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -458,9 +458,11 @@ else
 
     _tysize[TYimmutPtr] = _tysize[TYnptr];
     _tysize[TYsharePtr] = _tysize[TYnptr];
+    _tysize[TYrestrictPtr] = _tysize[TYnptr];
     _tysize[TYfgPtr] = _tysize[TYnptr];
     _tyalignsize[TYimmutPtr] = _tyalignsize[TYnptr];
     _tyalignsize[TYsharePtr] = _tyalignsize[TYnptr];
+    _tyalignsize[TYrestrictPtr] = _tyalignsize[TYnptr];
     _tyalignsize[TYfgPtr] = _tyalignsize[TYnptr];
 }
 
@@ -548,9 +550,11 @@ else
 
     _tysize[TYimmutPtr] = _tysize[TYnptr];
     _tysize[TYsharePtr] = _tysize[TYnptr];
+    _tysize[TYrestrictPtr] = _tysize[TYnptr];
     _tysize[TYfgPtr] = _tysize[TYnptr];
     _tyalignsize[TYimmutPtr] = _tyalignsize[TYnptr];
     _tyalignsize[TYsharePtr] = _tyalignsize[TYnptr];
+    _tyalignsize[TYrestrictPtr] = _tyalignsize[TYnptr];
     _tyalignsize[TYfgPtr] = _tyalignsize[TYnptr];
 }
 

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -3087,6 +3087,7 @@ void codelem(ref CodeBuilder cdb,elem *e,regm_t *pretregs,uint constflag)
                     case TYfgPtr:
                     case TYimmutPtr:
                     case TYsharePtr:
+                    case TYrestrictPtr:
                         *pretregs |= I16 ? IDXREGS : ALLREGS;
                         break;
 

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -178,6 +178,7 @@ int elemisone(elem *e)
             case TYnptr:
             case TYimmutPtr:
             case TYsharePtr:
+            case TYrestrictPtr:
             case TYfgPtr:
             case TYbool:
             case TYwchar_t:
@@ -242,6 +243,7 @@ int elemisnegone(elem *e)
             case TYvptr:
             case TYimmutPtr:
             case TYsharePtr:
+            case TYrestrictPtr:
             case TYfgPtr:
             case TYbool:
             case TYwchar_t:
@@ -1177,6 +1179,7 @@ private elem * elmin(elem *e, goal_t goal)
              tybasic(tym) == TYsptr ||
              tybasic(tym) == TYfgPtr ||
              tybasic(tym) == TYimmutPtr ||
+             tybasic(tym) == TYrestrictPtr ||
              tybasic(tym) == TYsharePtr)
            )
         {

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -636,6 +636,7 @@ regm_t regmask(tym_t tym, tym_t tyf)
         case TYcptr:
         case TYimmutPtr:
         case TYsharePtr:
+        case TYrestrictPtr:
         case TYfgPtr:
             return mAX;
 

--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -476,6 +476,7 @@ void cv_init()
             dttab4[TYsptr] = 0x600;
             dttab4[TYimmutPtr] = 0x600;
             dttab4[TYsharePtr] = 0x600;
+            dttab4[TYrestrictPtr] = 0x600;
             dttab4[TYfgPtr] = 0x600;
         }
         else
@@ -485,6 +486,7 @@ void cv_init()
             dttab4[TYnptr] = 0x400;
             dttab4[TYimmutPtr] = 0x400;
             dttab4[TYsharePtr] = 0x400;
+            dttab4[TYrestrictPtr] = 0x400;
             dttab4[TYfgPtr] = 0x400;
         }
         dttab4[TYcptr] = 0x400;
@@ -1966,6 +1968,7 @@ L1:
         case TYnptr:
         case TYimmutPtr:
         case TYsharePtr:
+        case TYrestrictPtr:
 version (MARS)
 {
             if (t.Tkey)

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -2205,6 +2205,7 @@ L1:
                     case TYcptr:
                     case TYimmutPtr:
                     case TYsharePtr:
+                    case TYrestrictPtr:
                     case TYfgPtr:
                         if (_tysize[TYnptr] == SHORTSIZE)
                             goto case_short;
@@ -2508,6 +2509,7 @@ version (SCPP_HTOD)
         case TYnref:
         case TYimmutPtr:
         case TYsharePtr:
+        case TYrestrictPtr:
         case TYfgPtr:
             if (_tysize[TYnptr] == SHORTSIZE)
                 goto Ushort;
@@ -2906,6 +2908,7 @@ case_tym:
         case TYnref:
         case TYimmutPtr:
         case TYsharePtr:
+        case TYrestrictPtr:
         case TYfgPtr:
             if (_tysize[TYnptr] == LONGSIZE)
                 goto L1;

--- a/src/dmd/backend/evalu8.d
+++ b/src/dmd/backend/evalu8.d
@@ -109,6 +109,7 @@ version (SCPP)
                 case TYnptr:
                 case TYimmutPtr:
                 case TYsharePtr:
+                case TYrestrictPtr:
                 case TYfgPtr:
                     b = el_tolong(e) != 0;
                     break;

--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -2064,6 +2064,7 @@ private famlist * newfamlist(tym_t ty)
         case TYnullptr:
         case TYimmutPtr:
         case TYsharePtr:
+        case TYrestrictPtr:
         case TYfgPtr:
             ty = TYint;
             if (I64)
@@ -3381,6 +3382,7 @@ private famlist * flcmp(famlist *f1,famlist *f2)
             case TYnptr:        // BUG: 64 bit pointers?
             case TYimmutPtr:
             case TYsharePtr:
+            case TYrestrictPtr:
             case TYfgPtr:
             case TYnullptr:
             case TYint:

--- a/src/dmd/backend/newman.d
+++ b/src/dmd/backend/newman.d
@@ -1032,6 +1032,7 @@ private void cpp_basic_data_type(type *t)
         case TYnptr:
         case TYimmutPtr:
         case TYsharePtr:
+        case TYrestrictPtr:
         case TYfgPtr:
             c = cast(char)('P' + cpp_cvidx(t.Tty));
             CHAR(c);

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -141,8 +141,9 @@ enum
     TYsharePtr          = 0x5C, // pointer to shared data
     TYimmutPtr          = 0x5D, // pointer to immutable data
     TYfgPtr             = 0x5E, // GS: pointer (I32) FS: pointer (I64)
+    TYrestrictPtr       = 0x5F, // restrict pointer
 
-    TYMAX               = 0x5F,
+    TYMAX               = 0x60,
 }
 
 alias TYerror = TYint;

--- a/src/dmd/backend/var.d
+++ b/src/dmd/backend/var.d
@@ -409,6 +409,7 @@ extern (C) __gshared const(char)*[TYMAX] tystring =
     TYvptr     : "__handle *",
     TYimmutPtr : "__immutable *",
     TYsharePtr : "__shared *",
+    TYrestrictPtr : "__restrict *",
     TYfgPtr    : "__fg *",
     TYffunc    : "far C func",
     TYfpfunc   : "far Pascal func",
@@ -617,6 +618,7 @@ __gshared ubyte[TYMAX] dttab =
     TYvptr     : 0x40,
     TYimmutPtr : 0x20,
     TYsharePtr : 0x20,
+    TYrestrictPtr : 0x20,
     TYfgPtr    : 0x20,
     TYffunc    : 0x64,
     TYfpfunc   : 0x73,
@@ -726,6 +728,7 @@ __gshared ushort[TYMAX] dttab4 =
     TYvptr     : 0x200,
     TYimmutPtr : 0x100,
     TYsharePtr : 0x100,
+    TYrestrictPtr : 0x100,
     TYfgPtr    : 0x100,
     TYffunc    : 0x00,
     TYfpfunc   : 0x00,
@@ -835,6 +838,7 @@ __gshared byte[256] _tysize =
     TYvptr     : 4,
     TYimmutPtr : 2,
     TYsharePtr : 2,
+    TYrestrictPtr : 2,
     TYfgPtr    : 2,
     TYffunc    : -1,
     TYfpfunc   : -1,
@@ -955,6 +959,7 @@ __gshared byte[256] _tyalignsize =
     TYvptr     : 4,
     TYimmutPtr : 2,
     TYsharePtr : 2,
+    TYrestrictPtr : 2,
     TYfgPtr    : 2,
     TYffunc    : -1,
     TYfpfunc   : -1,
@@ -975,7 +980,7 @@ __gshared byte[256] _tyalignsize =
 private:
 
 enum TXptr       = [ TYnptr ];
-enum TXptr_nflat = [ TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,TYvptr,TYimmutPtr,TYsharePtr,TYfgPtr ];
+enum TXptr_nflat = [ TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,TYvptr,TYimmutPtr,TYsharePtr,TYrestrictPtr,TYfgPtr ];
 enum TXreal      = [ TYfloat,TYdouble,TYdouble_alias,TYldouble,
                      TYfloat4,TYdouble2,
                      TYfloat8,TYdouble4,


### PR DESCRIPTION
Create a new type, `TYrestrictPtr`, to be used to implement optimizations where the pointer is the only reference to a mutable memory object. Will be used for `@live` functions. Same concept as C99 `restrict` pointers, but the compiler will figure out where to put it for you.

Doesn't do anything at the moment. Semantics to come later.