### PR TITLE
[dmd-cxx] Fix win32 builds using dmc compiler

### DIFF
--- a/src/root/dsystem.h
+++ b/src/root/dsystem.h
@@ -64,10 +64,15 @@
 #include <malloc.h>
 #endif
 
-// If not present, dmc will error 'number is not representable'.
 #ifdef __DMC__
+// If not present, dmc will error 'number is not representable'.
 #undef UINT64_MAX
 #define UINT64_MAX      18446744073709551615ULL
 #undef UINT32_MAX
 #define UINT32_MAX      4294967295U
+
+// If not present, dmc will error 'undefined identifier'.
+#ifndef INVALID_FILE_ATTRIBUTES
+#define INVALID_FILE_ATTRIBUTES -1L
+#endif
 #endif


### PR DESCRIPTION
To my surprise, Windows builds are still being done, despite failures in CI.

https://auto-tester.puremagic.com/show-run.ghtml?projectid=17&runid=181160&dataid=1258654

#9457 caused the build proper to fail, so adding in the missing macro.