### PR TITLE
[stable] dmd.root.filename: Restore C++ absolute() / ext() versions

### DIFF
--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -94,6 +94,12 @@ nothrow:
      * Returns:
      *  true if absolute path name.
      */
+    extern (C++) static bool absolute(const(char)* name) pure @nogc
+    {
+        return absolute(name.toDString);
+    }
+
+    /// Ditto
     extern (D) static bool absolute(const(char)[] name) pure @nogc
     {
         if (!name.length)
@@ -145,6 +151,12 @@ nothrow:
      *  Points past '.' of extension.
      *  If there isn't one, return null.
      */
+    extern (C++) static const(char)* ext(const(char)* str) pure @nogc
+    {
+        return ext(str.toDString).ptr;
+    }
+
+    /// Ditto
     extern (D) static const(char)[] ext(const(char)[] str) nothrow pure @safe @nogc
     {
         foreach_reverse (idx, char e; str)


### PR DESCRIPTION
As LDC uses them. They hadn't been removed from the C++ header yet.