### PR TITLE
dmd.dstruct: Return false immediately after setting StructPOD.no

### DIFF
--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -566,7 +566,10 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         ispod = StructPOD.yes;
 
         if (enclosing || postblit || dtor || hasCopyCtor)
+        {
             ispod = StructPOD.no;
+            return false;
+        }
 
         // Recursively check all fields are POD.
         for (size_t i = 0; i < fields.dim; i++)
@@ -575,7 +578,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             if (v.storage_class & STC.ref_)
             {
                 ispod = StructPOD.no;
-                break;
+                return false;
             }
 
             Type tv = v.type.baseElemOf();
@@ -586,7 +589,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
                 if (!sd.isPOD())
                 {
                     ispod = StructPOD.no;
-                    break;
+                    return false;
                 }
             }
         }


### PR DESCRIPTION
For the case of nested or non-trivial structs, there's no point checking all fields (recursively), the answer is still no.