### PR TITLE
fix Issue 20771, 20772, 20775 disallow passing non-trivially copyable types as variadic arguments

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2125,10 +2125,15 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                 }
             }
 
-            // Do not allow types that need destructors
+            // Do not allow types that need destructors or copy constructors.
             if (arg.type.needsDestruction())
             {
                 arg.error("cannot pass types that need destruction as variadic arguments");
+                err = true;
+            }
+            if (arg.type.needsCopyOrPostblit())
+            {
+                arg.error("cannot pass types with postblits or copy constructors as variadic arguments");
                 err = true;
             }
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2571,6 +2571,15 @@ extern (C++) abstract class Type : ASTNode
         return false;
     }
 
+    /********************************
+     * true if when type is copied, it needs a copy constructor or postblit
+     * applied. Only applies to value types, not ref types.
+     */
+    bool needsCopyOrPostblit()
+    {
+        return false;
+    }
+
     /*********************************
      *
      */
@@ -3693,6 +3702,11 @@ extern (C++) final class TypeSArray : TypeArray
     override bool needsDestruction()
     {
         return next.needsDestruction();
+    }
+
+    override bool needsCopyOrPostblit()
+    {
+        return next.needsCopyOrPostblit();
     }
 
     /*********************************
@@ -5639,6 +5653,11 @@ extern (C++) final class TypeStruct : Type
         return sym.dtor !is null;
     }
 
+    override bool needsCopyOrPostblit()
+    {
+        return sym.hasCopyCtor || sym.postblit;
+    }
+
     override bool needsNested()
     {
         if (sym.isNested())
@@ -5904,6 +5923,11 @@ extern (C++) final class TypeEnum : Type
     override bool needsDestruction()
     {
         return memType().needsDestruction();
+    }
+
+    override bool needsCopyOrPostblit()
+    {
+        return memType().needsCopyOrPostblit();
     }
 
     override bool needsNested()

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -314,6 +314,7 @@ public:
     Type *baseElemOf();
     uinteger_t sizemask();
     virtual bool needsDestruction();
+    virtual bool needsCopyOrPostblit();
     virtual bool needsNested();
 
     // For eliminating dynamic_cast
@@ -446,6 +447,7 @@ public:
     Expression *defaultInitLiteral(const Loc &loc);
     bool hasPointers();
     bool needsDestruction();
+    bool needsCopyOrPostblit();
     bool needsNested();
 
     void accept(Visitor *v) { v->visit(this); }
@@ -742,6 +744,7 @@ public:
     bool isAssignable();
     bool isBoolean() /*const*/;
     bool needsDestruction() /*const*/;
+    bool needsCopyOrPostblit();
     bool needsNested();
     bool hasPointers();
     bool hasVoidInitPointers();
@@ -775,6 +778,7 @@ public:
     bool isString();
     bool isAssignable();
     bool needsDestruction();
+    bool needsCopyOrPostblit();
     bool needsNested();
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);

--- a/test/fail_compilation/fail20771.d
+++ b/test/fail_compilation/fail20771.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20771.d(19): Error: cannot pass types with postblits or copy constructors as variadic arguments
+fail_compilation/fail20771.d(20): Error: cannot pass types with postblits or copy constructors as variadic arguments
+---
+*/
+extern void variadic(...);
+
+struct S20771
+{
+    int field;
+    this(this) { }
+}
+
+void test()
+{
+    auto v = S20771(0);
+    variadic(v,
+             S20771(1));
+}

--- a/test/fail_compilation/fail20772.d
+++ b/test/fail_compilation/fail20772.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20772.d(20): Error: cannot pass types with postblits or copy constructors as variadic arguments
+fail_compilation/fail20772.d(21): Error: cannot pass types with postblits or copy constructors as variadic arguments
+---
+*/
+extern void variadic(...);
+
+struct S20772
+{
+    int field;
+    this(int) { }
+    this(ref S20772 o) { }
+}
+
+void test()
+{
+    auto v = S20772(0);
+    variadic(v,
+             S20772(1));
+}

--- a/test/fail_compilation/fail20775.d
+++ b/test/fail_compilation/fail20775.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20775.d(19): Error: cannot pass types that need destruction as variadic arguments
+fail_compilation/fail20775.d(20): Error: cannot pass types that need destruction as variadic arguments
+---
+*/
+extern void variadic(...);
+
+struct S20775
+{
+    int field;
+    ~this() { }
+}
+
+void test()
+{
+    auto v = S20775(0);
+    variadic(v,
+             S20775(1));
+}


### PR DESCRIPTION
DMD doesn't support this, so make it an error, same as destructors.

At some point, will need to readdress this so that these are passed by invisible reference (same as GDC), which will fix issue 20770 too.