### PR TITLE
[stable] dmd.dsymbolsem: Fix va_list check for pragma([printf,scanf])

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3498,8 +3498,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             static bool isVa_list(Parameter p)
             {
-                // What it's actually pointing to depends on the target
-                return p.type.isTypePointer() !is null;
+                return p.type.equals(Type.tvalist);
             }
 
             const nparams = f.parameterList.length;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3496,8 +3496,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 return false;
             }
 
-            static bool isVa_list(Parameter p)
+            bool isVa_list(Parameter p)
             {
+                Type.tvalist = Type.tvalist.typeSemantic(funcdecl.loc, sc);
                 return p.type.equals(Type.tvalist);
             }
 


### PR DESCRIPTION
E.g., `va_list` is a struct for non-Apple ARM targets.