### PR TITLE
Fix issue 20779: compiler segfaults when struct contains itself

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -3769,6 +3769,7 @@ struct ASTBase
     {
         StructDeclaration sym;
         AliasThisRec att = AliasThisRec.fwdref;
+        bool inuse = false;
 
         extern (D) this(StructDeclaration sym)
         {

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5484,6 +5484,7 @@ extern (C++) final class TypeStruct : Type
 {
     StructDeclaration sym;
     AliasThisRec att = AliasThisRec.fwdref;
+    bool inuse = false; // struct currently subject of recursive method call
 
     extern (D) this(StructDeclaration sym)
     {
@@ -5641,6 +5642,11 @@ extern (C++) final class TypeStruct : Type
 
     override bool needsNested()
     {
+        if (inuse) return false; // circular type, error instead of crashing
+
+        inuse = true;
+        scope(exit) inuse = false;
+
         if (sym.isNested())
             return true;
 

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -729,6 +729,7 @@ class TypeStruct : public Type
 public:
     StructDeclaration *sym;
     AliasThisRec att;
+    bool inuse;
 
     static TypeStruct *create(StructDeclaration *sym);
     const char *kind();

--- a/test/fail_compilation/fail20779.d
+++ b/test/fail_compilation/fail20779.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=20779
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20779.d(12): Error: struct `fail20779.X` cannot have field `x` with same struct type
+---
+*/
+
+module fail20779;
+
+struct X
+{
+    X x;
+
+    enum e = __traits(compiles, X.init);
+}


### PR DESCRIPTION
When working with metaprogramming, the error message saying that the struct should not contain itself can get swallowed by gagging.

In this case, only the segfault remains, leading to an unsatisfactory user experience. Fix the segfault by breaking the infinite recursion.
