### PR TITLE
Support partial regex matching in TEST_OUTPUT

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -379,6 +379,9 @@ depend on the current platform and target:
                     - OS: posix, windows, ...
                     - Model: 64, 32mscoff and 32 (also matches 32mscoff)
 
+    $r:<regex>$     any text matching <regex> (using $ inside of <regex> is not
+                    supported, use multiple regexes instead)
+
 Both stderr and stdout of the DMD are captured for output comparison.
 
 ## Test Coding Practices

--- a/test/fail_compilation/needspkgmod.d
+++ b/test/fail_compilation/needspkgmod.d
@@ -7,15 +7,10 @@
 // PERMUTE_ARGS:
 // LINK:
 /*
-Can't really check for the missing function bar here because the error message
-varies A LOT between different linkers. Assume that there is no other cause
-of linking failure because then other tests would fail as well. Hence search
-for the linker failure message issued by DMD:
-
-TRANSFORM_OUTPUT: remove_lines("^(?!Error:).+$")
 TEST_OUTPUT:
 ----
-Error: linker exited with status $n$
+$r:.+_D7imports9pkgmod3133mod3barFZv.*$
+Error: $r:.+$ exited with status $n$
 ----
 */
 import imports.pkgmod313.mod;


### PR DESCRIPTION
`$r:<regex>$` matches the output against the given regex

CC @kinke 