### PR TITLE
[dmd-cxx] Support __traits(getLinkage) in classes and structs

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -71,6 +71,19 @@ FuncDeclaration *buildDtor(AggregateDeclaration *ad, Scope *sc);
 FuncDeclaration *buildInv(AggregateDeclaration *ad, Scope *sc);
 FuncDeclaration *search_toString(StructDeclaration *sd);
 
+struct ClassKind
+{
+    enum Type
+    {
+        /// the class is a d(efault) class
+        d,
+        /// the class is a C++ interface
+        cpp,
+        /// the class is an Objective-C class/interface
+        objc,
+    };
+};
+
 class AggregateDeclaration : public ScopeDsymbol
 {
 public:
@@ -83,6 +96,8 @@ public:
     Sizeok sizeok;              // set when structsize contains valid data
     Dsymbol *deferred;          // any deferred semantic2() or semantic3() symbol
     bool isdeprecated;          // true if deprecated
+
+    ClassKind::Type classKind;  // specifies the linkage type
 
     /* !=NULL if is nested
      * pointing to the dsymbol that directly enclosing it.
@@ -274,8 +289,6 @@ public:
 
     TypeInfoClassDeclaration *vclassinfo;       // the ClassInfo object for this ClassDeclaration
     bool com;                           // true if this is a COM class (meaning it derives from IUnknown)
-    bool cpp;                           // true if this is a C++ interface
-    bool isobjc;                        // true if this is an Objective-C class/interface
     bool isscope;                       // true if this is a scope class
     Abstract isabstract;                // 0: fwdref, 1: is abstract class, 2: not abstract
     int inuse;                          // to prevent recursive attempts

--- a/src/dclass.c
+++ b/src/dclass.c
@@ -553,7 +553,7 @@ void ClassDeclaration::semantic(Scope *sc)
         baseok = BASEOKdone;
 
         // If no base class, and this is not an Object, use Object as base class
-        if (!baseClass && ident != Id::Object && classKind != ClassKind::cpp)
+        if (!baseClass && ident != Id::Object && !isCPPclass())
         {
             if (!object || object->errors)
                 badObjectDotD(this);
@@ -598,7 +598,7 @@ void ClassDeclaration::semantic(Scope *sc)
             // then this is a COM interface too.
             if (b->sym->isCOMinterface())
                 com = true;
-            if (classKind == ClassKind::cpp && !b->sym->isCPPinterface())
+            if (isCPPclass() && !b->sym->isCPPinterface())
             {
                 ::error(loc, "C++ class '%s' cannot implement D interface '%s'",
                     toPrettyChars(), b->sym->toPrettyChars());
@@ -673,7 +673,7 @@ Lancestorsdone:
         // initialize vtbl
         if (baseClass)
         {
-            if (classKind == ClassKind::cpp && baseClass->vtbl.dim == 0)
+            if (isCPPclass() && baseClass->vtbl.dim == 0)
             {
                 error("C++ base class %s needs at least one virtual function", baseClass->toChars());
             }
@@ -1085,7 +1085,7 @@ void ClassDeclaration::finalizeSize()
 
         alignsize = baseClass->alignsize;
         structsize = baseClass->structsize;
-        if (classKind == ClassKind::cpp && global.params.isWindows)
+        if (isCPPclass() && global.params.isWindows)
             structsize = (structsize + alignsize - 1) & ~(alignsize - 1);
     }
     else if (isInterfaceDeclaration())
@@ -1100,7 +1100,7 @@ void ClassDeclaration::finalizeSize()
     {
         alignsize = Target::ptrsize;
         structsize = Target::ptrsize;      // allow room for __vptr
-        if (classKind != ClassKind::cpp)
+        if (!isCPPclass())
             structsize += Target::ptrsize; // allow room for __monitor
     }
 

--- a/src/dclass.c
+++ b/src/dclass.c
@@ -240,12 +240,10 @@ ClassDeclaration::ClassDeclaration(Loc loc, Identifier *id, BaseClasses *basecla
     }
 
     com = false;
-    cpp = false;
     isscope = false;
     isabstract = ABSfwdref;
     inuse = 0;
     baseok = BASEOKnone;
-    isobjc = false;
     cpp_type_info_ptr_sym = NULL;
 }
 
@@ -389,7 +387,7 @@ void ClassDeclaration::semantic(Scope *sc)
         userAttribDecl = sc->userAttribDecl;
 
         if (sc->linkage == LINKcpp)
-            cpp = true;
+            classKind = ClassKind::cpp;
         if (sc->linkage == LINKobjc)
             objc()->setObjc(this);
     }
@@ -555,7 +553,7 @@ void ClassDeclaration::semantic(Scope *sc)
         baseok = BASEOKdone;
 
         // If no base class, and this is not an Object, use Object as base class
-        if (!baseClass && ident != Id::Object && !cpp)
+        if (!baseClass && ident != Id::Object && classKind != ClassKind::cpp)
         {
             if (!object || object->errors)
                 badObjectDotD(this);
@@ -583,7 +581,7 @@ void ClassDeclaration::semantic(Scope *sc)
             if (baseClass->isCOMclass())
                 com = true;
             if (baseClass->isCPPclass())
-                cpp = true;
+                classKind = ClassKind::cpp;
             if (baseClass->isscope)
                 isscope = true;
             enclosing = baseClass->enclosing;
@@ -600,7 +598,7 @@ void ClassDeclaration::semantic(Scope *sc)
             // then this is a COM interface too.
             if (b->sym->isCOMinterface())
                 com = true;
-            if (cpp && !b->sym->isCPPinterface())
+            if (classKind == ClassKind::cpp && !b->sym->isCPPinterface())
             {
                 ::error(loc, "C++ class '%s' cannot implement D interface '%s'",
                     toPrettyChars(), b->sym->toPrettyChars());
@@ -675,7 +673,7 @@ Lancestorsdone:
         // initialize vtbl
         if (baseClass)
         {
-            if (cpp && baseClass->vtbl.dim == 0)
+            if (classKind == ClassKind::cpp && baseClass->vtbl.dim == 0)
             {
                 error("C++ base class %s needs at least one virtual function", baseClass->toChars());
             }
@@ -1087,7 +1085,7 @@ void ClassDeclaration::finalizeSize()
 
         alignsize = baseClass->alignsize;
         structsize = baseClass->structsize;
-        if (cpp && global.params.isWindows)
+        if (classKind == ClassKind::cpp && global.params.isWindows)
             structsize = (structsize + alignsize - 1) & ~(alignsize - 1);
     }
     else if (isInterfaceDeclaration())
@@ -1102,7 +1100,7 @@ void ClassDeclaration::finalizeSize()
     {
         alignsize = Target::ptrsize;
         structsize = Target::ptrsize;      // allow room for __vptr
-        if (!cpp)
+        if (classKind != ClassKind::cpp)
             structsize += Target::ptrsize; // allow room for __monitor
     }
 
@@ -1299,7 +1297,7 @@ bool ClassDeclaration::isCOMinterface() const
 
 bool ClassDeclaration::isCPPclass() const
 {
-    return cpp;
+    return classKind == ClassKind::cpp;
 }
 
 bool ClassDeclaration::isCPPinterface() const
@@ -1378,7 +1376,7 @@ bool ClassDeclaration::isAbstract()
 
 int ClassDeclaration::vtblOffset() const
 {
-    return cpp ? 0 : 1;
+    return classKind == ClassKind::cpp ? 0 : 1;
 }
 
 /****************************************
@@ -1405,7 +1403,7 @@ InterfaceDeclaration::InterfaceDeclaration(Loc loc, Identifier *id, BaseClasses 
     if (id == Id::IUnknown)     // IUnknown is the root of all COM interfaces
     {
         com = true;
-        cpp = true;             // IUnknown is also a C++ interface
+        classKind = ClassKind::cpp; // IUnknown is also a C++ interface
     }
 }
 
@@ -1422,9 +1420,9 @@ Scope *InterfaceDeclaration::newScope(Scope *sc)
     Scope *sc2 = ClassDeclaration::newScope(sc);
     if (com)
         sc2->linkage = LINKwindows;
-    else if (cpp)
+    else if (classKind == ClassKind::cpp)
         sc2->linkage = LINKcpp;
-    else if (isobjc)
+    else if (classKind == ClassKind::objc)
         sc2->linkage = LINKobjc;
     return sc2;
 }
@@ -1523,7 +1521,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
         }
 
         if (!baseclasses->dim && sc->linkage == LINKcpp)
-            cpp = true;
+            classKind = ClassKind::cpp;
         if (sc->linkage == LINKobjc)
             objc()->setObjc(this);
 
@@ -1605,7 +1603,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
             if (b->sym->isCOMinterface())
                 com = true;
             if (b->sym->isCPPinterface())
-                cpp = true;
+                classKind = ClassKind::cpp;
         }
 
         interfaceSemantic(sc);
@@ -1817,7 +1815,7 @@ bool InterfaceDeclaration::isCOMinterface() const
 
 bool InterfaceDeclaration::isCPPinterface() const
 {
-    return cpp;
+    return classKind == ClassKind::cpp;
 }
 
 /*******************************************

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -2174,7 +2174,7 @@ Expression *VarDeclaration::callScopeDtor(Scope *)
 
             // Destroying C++ scope classes crashes currently. Since C++ class dtors are not currently supported, simply do not run dtors for them.
             // See https://issues.dlang.org/show_bug.cgi?id=13182
-            if (cd->classKind == ClassKind::cpp)
+            if (cd->isCPPclass())
             {
                 break;
             }

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -2174,7 +2174,7 @@ Expression *VarDeclaration::callScopeDtor(Scope *)
 
             // Destroying C++ scope classes crashes currently. Since C++ class dtors are not currently supported, simply do not run dtors for them.
             // See https://issues.dlang.org/show_bug.cgi?id=13182
-            if (cd->cpp)
+            if (cd->classKind == ClassKind::cpp)
             {
                 break;
             }

--- a/src/dstruct.c
+++ b/src/dstruct.c
@@ -194,6 +194,7 @@ AggregateDeclaration::AggregateDeclaration(Loc loc, Identifier *id)
     sizeok = SIZEOKnone;        // size not determined yet
     deferred = NULL;
     isdeprecated = false;
+    classKind = ClassKind::d;
     inv = NULL;
     aggNew = NULL;
     aggDelete = NULL;
@@ -1071,6 +1072,9 @@ void StructDeclaration::semantic(Scope *sc)
         if (storage_class & STCabstract)
             error("structs, unions cannot be abstract");
         userAttribDecl = sc->userAttribDecl;
+
+        if (sc->linkage == LINKcpp)
+            classKind = ClassKind::cpp;
     }
     else if (symtab && !scx)
     {

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4106,9 +4106,9 @@ elem *toElem(Expression *e, IRState *irs)
                         // Casting from derived class to base class is a no-op
                     }
                 }
-                else if (cdfrom->classKind == ClassKind::cpp)
+                else if (cdfrom->isCPPclass())
                 {
-                    if (cdto->classKind == ClassKind::cpp)
+                    if (cdto->isCPPclass())
                     {
                         /* Casting from a C++ interface to a C++ interface
                          * is always a 'paint' operation

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -455,8 +455,8 @@ if (I32) assert(tysize[TYnptr] == 4);
                 e = el_una(OPld_d, tyret, ep);
                 break;
 
-	    default:
-		assert(0);
+            default:
+                assert(0);
             }
 #undef X
         }

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4106,9 +4106,9 @@ elem *toElem(Expression *e, IRState *irs)
                         // Casting from derived class to base class is a no-op
                     }
                 }
-                else if (cdfrom->cpp)
+                else if (cdfrom->classKind == ClassKind::cpp)
                 {
-                    if (cdto->cpp)
+                    if (cdto->classKind == ClassKind::cpp)
                     {
                         /* Casting from a C++ interface to a C++ interface
                          * is always a 'paint' operation

--- a/src/func.c
+++ b/src/func.c
@@ -876,7 +876,7 @@ void FuncDeclaration::semantic(Scope *sc)
 
                 /* These quirky conditions mimic what VC++ appears to do
                  */
-                if (global.params.mscoff && cd->cpp &&
+                if (global.params.mscoff && cd->classKind == ClassKind::cpp &&
                     cd->baseClass && cd->baseClass->vtbl.dim)
                 {
                     /* if overriding an interface function, then this is not
@@ -902,7 +902,7 @@ void FuncDeclaration::semantic(Scope *sc)
                 {
                     //printf("\tintroducing function %s\n", toChars());
                     introducing = 1;
-                    if (cd->cpp && Target::reverseCppOverloads)
+                    if (cd->classKind == ClassKind::cpp && Target::reverseCppOverloads)
                     {
                         // with dmc, overloaded functions are grouped and in reverse order
                         vtblIndex = (int)cd->vtbl.dim;

--- a/src/func.c
+++ b/src/func.c
@@ -876,7 +876,7 @@ void FuncDeclaration::semantic(Scope *sc)
 
                 /* These quirky conditions mimic what VC++ appears to do
                  */
-                if (global.params.mscoff && cd->classKind == ClassKind::cpp &&
+                if (global.params.mscoff && cd->isCPPclass() &&
                     cd->baseClass && cd->baseClass->vtbl.dim)
                 {
                     /* if overriding an interface function, then this is not
@@ -902,7 +902,7 @@ void FuncDeclaration::semantic(Scope *sc)
                 {
                     //printf("\tintroducing function %s\n", toChars());
                     introducing = 1;
-                    if (cd->classKind == ClassKind::cpp && Target::reverseCppOverloads)
+                    if (cd->isCPPclass() && Target::reverseCppOverloads)
                     {
                         // with dmc, overloaded functions are grouped and in reverse order
                         vtblIndex = (int)cd->vtbl.dim;

--- a/src/opover.c
+++ b/src/opover.c
@@ -962,7 +962,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                 ClassDeclaration *cd1 = t1->isClassHandle();
                 ClassDeclaration *cd2 = t2->isClassHandle();
 
-                if (!(cd1->classKind == ClassKind::cpp || cd2->classKind == ClassKind::cpp))
+                if (!(cd1->isCPPclass() || cd2->isCPPclass()))
                 {
                     /* Rewrite as:
                      *      .object.opEquals(e1, e2)

--- a/src/opover.c
+++ b/src/opover.c
@@ -962,7 +962,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                 ClassDeclaration *cd1 = t1->isClassHandle();
                 ClassDeclaration *cd2 = t2->isClassHandle();
 
-                if (!(cd1->cpp || cd2->cpp))
+                if (!(cd1->classKind == ClassKind::cpp || cd2->classKind == ClassKind::cpp))
                 {
                     /* Rewrite as:
                      *      .object.opEquals(e1, e2)

--- a/src/todt.c
+++ b/src/todt.c
@@ -693,7 +693,7 @@ static void membersToDt(AggregateDeclaration *ad, DtBuilder& dtb,
         {
             dtb.xoff(toVtblSymbol(concreteType), 0);  // __vptr
             offset = Target::ptrsize;
-            if (!cd->cpp)
+            if (cd->classKind != ClassKind::cpp)
             {
                 dtb.size(0);              // __monitor
                 offset += Target::ptrsize;

--- a/src/todt.c
+++ b/src/todt.c
@@ -693,7 +693,7 @@ static void membersToDt(AggregateDeclaration *ad, DtBuilder& dtb,
         {
             dtb.xoff(toVtblSymbol(concreteType), 0);  // __vptr
             offset = Target::ptrsize;
-            if (cd->classKind != ClassKind::cpp)
+            if (!cd->isCPPclass())
             {
                 dtb.size(0);              // __monitor
                 offset += Target::ptrsize;

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -362,7 +362,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                 dtb.size(0);                    // monitor
 
                 // initializer[]
-                assert(cd->structsize >= 8 || (cd->classKind == ClassKind::cpp && cd->structsize >= 4));
+                assert(cd->structsize >= 8 || (cd->isCPPclass() && cd->structsize >= 4));
                 dtb.size(cd->structsize);           // size
                 dtb.xoff(sinit, 0, TYnptr);      // initializer
 

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -362,7 +362,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                 dtb.size(0);                    // monitor
 
                 // initializer[]
-                assert(cd->structsize >= 8 || (cd->cpp && cd->structsize >= 4));
+                assert(cd->structsize >= 8 || (cd->classKind == ClassKind::cpp && cd->structsize >= 4));
                 dtb.size(cd->structsize);           // size
                 dtb.xoff(sinit, 0, TYnptr);      // initializer
 

--- a/test/compilable/test17419.d
+++ b/test/compilable/test17419.d
@@ -35,3 +35,21 @@ void bar()
     void nested() { }
     static assert(__traits(getLinkage, typeof(&nested)) == "D");
 }
+
+class FooD {}
+interface FooDInterface {}
+extern (C++) class FooCpp {}
+extern (C++) struct FooCppStruct {}
+extern (C++) interface FooCppInterface {}
+
+static assert(__traits(getLinkage, FooD) == "D");
+static assert(__traits(getLinkage, FooDInterface) == "D");
+static assert(__traits(getLinkage, FooCpp) == "C++");
+static assert(__traits(getLinkage, FooCppStruct) == "C++");
+static assert(__traits(getLinkage, FooCppInterface) == "C++");
+
+version (D_ObjectiveC)
+{
+    extern (Objective-C) interface FooObjC {}
+    static assert(__traits(getLinkage, FooObjC) == "Objective-C");
+}


### PR DESCRIPTION
This selectively backports several PRs so that only the introduction of classKind is done, along with the adding of getLinkage, as it is cheap and trivial once the rest is in place.

The classKind AST information is absolutely vital in order to get proper debug symbol resolving support for extern(C++) types.

