### PR TITLE
Fix Issue 5409 - Disallow (!x & y)

### DIFF
--- a/changelog/dep-logical-not-bitwise-binary.dd
+++ b/changelog/dep-logical-not-bitwise-binary.dd
@@ -1,0 +1,17 @@
+Deprecate logical NOT in bitwise binary expressions
+
+If a logical NOT operator is used for the left operand of a bitwise binary
+expression, parentheses should be added to explicitly indicate the intended
+order of operations:
+
+---
+int a, b;
+...
+auto w = !a & b;     // Deprecated
+auto x = (!a) & b;   // OK
+auto y = !(a & b);   // OK
+auto z = !a && b;    // OK
+---
+
+This makes it clear which part of the expression is intended to be affected by
+the NOT operator.

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -766,6 +766,17 @@ extern (C++) abstract class Expression : ASTNode
         }
     }
 
+    final void deprecationSupplemental(const(char)* format, ...) const
+    {
+        if (type != Type.terror)
+        {
+            va_list ap;
+            va_start(ap, format);
+            .vdeprecationSupplemental(loc, format, ap);
+            va_end(ap);
+        }
+    }
+
     /**********************************
      * Combine e1 and e2 by CommaExp if both are not NULL.
      */

--- a/test/compilable/test5409a.d
+++ b/test/compilable/test5409a.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS:
+// PERMUTE_ARGS:
+
+void main()
+{
+    auto a = 12345;
+    auto b = 54321;
+
+    auto c = (!a) & b;
+    auto d = !(a & b);
+    auto e = (!a) | b;
+    auto f = !(a | b);
+}

--- a/test/compilable/test5409b.d
+++ b/test/compilable/test5409b.d
@@ -1,0 +1,23 @@
+// REQUIRED_ARGS:
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+compilable/test5409b.d(20): Deprecation: `!a & b`: Boolean operator `!` has higher precedence than bitwise operator `&`.
+compilable/test5409b.d(20):        Use one of the following instead: `!a && b` or `!(a & b)` or `(!a) & b`
+compilable/test5409b.d(21): Deprecation: `!a | b`: Boolean operator `!` has higher precedence than bitwise operator `|`.
+compilable/test5409b.d(21):        Use one of the following instead: `!a || b` or `!(a | b)` or `(!a) | b`
+compilable/test5409b.d(22): Deprecation: `!a ^ b`: Boolean operator `!` has higher precedence than bitwise operator `^`.
+compilable/test5409b.d(22):        Use one of the following instead: `!(a ^ b)` or `(!a) ^ b`
+---
+*/
+
+void main()
+{
+    auto a = 12345;
+    auto b = 54321;
+
+    auto c = !a & b;
+    auto d = !a | b;
+    auto e = !a ^ b;
+}


### PR DESCRIPTION
Using the `!` operator and operators `&` or `|` in the same expression without parentheses is a mistake in most cases.