### PR TITLE
Fix issue 20789: -de should disable is(T : U) if T alias-this to U is deprecated unless in deprecated scope

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2015,6 +2015,12 @@ extern (C++) abstract class Type : ASTNode
         return t;
     }
 
+    final bool hasDeprecatedAliasThis()
+    {
+        auto ad = isAggregate(this);
+        return ad && ad.aliasthis && (ad.aliasthis.isDeprecated || ad.aliasthis.sym.isDeprecated);
+    }
+
     final Type aliasthisOf()
     {
         auto ad = isAggregate(this);

--- a/test/compilable/test20789.d
+++ b/test/compilable/test20789.d
@@ -1,0 +1,34 @@
+// REQUIRED_ARGS: -de
+module compilable.test20789;
+
+struct S(bool deprecateFunction, bool deprecateAlias)
+{
+    static if (deprecateFunction)
+        deprecated string get() { return "foo"; }
+    else
+        string get() { return "foo"; }
+
+    static if (deprecateAlias)
+        deprecated alias get this;
+    else
+        alias get this;
+}
+
+void main()
+{
+    void normalFun()
+    {
+        static assert( is(S!(false, false) : string));
+        static assert(!is(S!(false, true ) : string));
+        static assert(!is(S!(true , false) : string));
+        static assert(!is(S!(true , true ) : string));
+    }
+    deprecated void deprecatedFun()
+    {
+        // deprecations are allowed in a deprecated scope.
+        static assert(is(S!(false, false) : string));
+        static assert(is(S!(false, true ) : string));
+        static assert(is(S!(true , false) : string));
+        static assert(is(S!(true , true ) : string));
+    }
+}


### PR DESCRIPTION
Don't indicate deprecated `alias this` or `alias this` of deprecated symbol as implicit conversion in `is` when `-de` (deprecations as errors) is on.

Example:
```
struct S {
    string foo() { return "foo"; }
    // conversion to string is deprecated, and -de is on
    // so string s = S.init would error
    deprecated alias foo this;
}

// but S is still indicated as convertible to string.
static assert(!is(S : string)); // Assert failed.
```
