### PR TITLE
fix issue 20719 by passing previously seen structs to isTypeIsolated …

### DIFF
--- a/test/fail_compilation/test20719.d
+++ b/test/fail_compilation/test20719.d
@@ -1,0 +1,32 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test20719.d(13): Error: struct `test20719.SumType` no size because of forward reference
+fail_compilation/test20719.d(32): Error: variable `test20719.isCopyable!(SumType).__lambda2.foo` size of type `SumType` is invalid
+fail_compilation/test20719.d(18): Error: template instance `test20719.isCopyable!(SumType)` error instantiating
+---
+*/
+struct SumType
+{
+    alias Types = AliasSeq!(typeof(this));
+    union Storage
+    {
+        Types[0] t;
+    }
+
+    Storage storage;
+
+    static if (isCopyable!(Types[0])) {}
+    static if (isAssignable!(Types[0])) {}
+}
+
+alias AliasSeq(TList...) = TList;
+
+enum isAssignable(Rhs) = __traits(compiles, lvalueOf = rvalueOf!Rhs);
+
+struct __InoutWorkaroundStruct {}
+
+T rvalueOf(T)();
+
+T lvalueOf()(__InoutWorkaroundStruct);
+
+enum isCopyable(S) = { S foo; };


### PR DESCRIPTION
…recursive calls

I'm really unsure about this fix and would appreciate suggestions for alternative fixes.  Without it, the test bounces between recursive calls on SumType and Storage.  If the struct has no pointers, then I think this probably should return true, so my call to return false might not be the right approach.