### PR TITLE
fix Issue 19550 - [REG 2.078] Massive compiler backend slowdown

### DIFF
--- a/src/dmd/backend/gflow.d
+++ b/src/dmd/backend/gflow.d
@@ -621,7 +621,7 @@ private void aecpgenkill(ref GlobalOptimizer go)
                 vec_free(b.Bkill2);
                 elem* e;
                 for (e = b.Belem; e.Eoper == OPcomma; e = e.EV.E2)
-                    accumaecp(b.Bgen,b.Bkill,e);
+                    accumaecp(b.Bgen,b.Bkill,e.EV.E1);
                 if (e.Eoper == OPandand || e.Eoper == OPoror)
                 {
                     accumaecp(b.Bgen,b.Bkill,e.EV.E1);


### PR DESCRIPTION
Fixes typo which caused a redundant O(N^2) slowdown.

I set the branch to master, I'll leave it to @MartinNowak to decide whether this should be in stable.