### PR TITLE
Emit standard DWARF3 opcode for TLS address

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -1939,7 +1939,7 @@ static if (ELFOBJ)
                     Obj.addrel(debug_info.seg, debug_info.buf.length(), R_386_TLS_LDO_32, s.Sxtrnnum, 0);
                     debug_info.buf.write32(0);
                 }
-                debug_info.buf.writeByte(DW_OP_GNU_push_tls_address);
+                debug_info.buf.writeByte(DW_OP_form_tls_address);
             }
             else
             {


### PR DESCRIPTION
DW_OP_GNU_push_tls_address is a GNU extension prior to DWARF2.
DWARF3 introduced DW_OP_form_tls_address with the exact same semantic, as can be seen here:
- https://sourceware.org/legacy-ml/gdb-patches/2016-08/msg00222.html
- https://reviews.llvm.org/rL274366

Caveat: GDB support was "only" added in 7.12, [which was released on 2016-10-07](https://lists.gnu.org/archive/html/info-gnu/2016-10/msg00007.html).

Since I don't use DMD (debug infos are utterly broken on MacOSX), I didn't observe any downside of this, but I was going over the DWARF code and found this oddity and figured it was time to replace it.

CC @ibuclaw 