### PR TITLE
Fix Issue 20791 - extern(C++ <strings>) should allow a trailing comma

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -2252,6 +2252,9 @@ final class Parser(AST) : Lexer
                                 if (token.value != TOK.comma)
                                     break;
                                 nextToken();
+                                // Allow trailing commas as done for argument lists, arrays, ...
+                                if (token.value == TOK.rightParentheses)
+                                    break;
                             }
                         }
                     }

--- a/test/compilable/testparse.d
+++ b/test/compilable/testparse.d
@@ -174,3 +174,8 @@ void testIfConditionWithSTCandType()
     auto call(){return 0;}
     if (const size_t i = call()) {}
 }
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=20791
+extern(C++, "foo", )
+struct S {}


### PR DESCRIPTION
This inconsistency was also mentioned in the [spec PR](dlang/dlang.org#2716)