### PR TITLE
[stable] Prevent redundant type semantic for va_list

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2686,7 +2686,6 @@ struct ASTBase
         extern (C++) __gshared Type tstring;     // immutable(char)[]
         extern (C++) __gshared Type twstring;    // immutable(wchar)[]
         extern (C++) __gshared Type tdstring;    // immutable(dchar)[]
-        extern (C++) __gshared Type tvalist;     // va_list alias
         extern (C++) __gshared Type terror;      // for error recovery
         extern (C++) __gshared Type tnull;       // for null type
 
@@ -2847,7 +2846,6 @@ struct ASTBase
             tstring = tchar.immutableOf().arrayOf();
             twstring = twchar.immutableOf().arrayOf();
             tdstring = tdchar.immutableOf().arrayOf();
-            tvalist = Target.va_listType();
 
             const isLP64 = global.params.isLP64;
 

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6516,7 +6516,7 @@ struct ASTBase
     {
         extern (C++) __gshared int ptrsize;
 
-        extern (C++) static Type va_listType()
+        extern (C++) static Type va_listType(const ref Loc loc, Scope* sc)
         {
             if (global.params.isWindows)
             {

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3498,7 +3498,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             bool isVa_list(Parameter p)
             {
-                return p.type.equals(Type.getVaList(funcdecl.loc, sc));
+                return p.type.equals(target.va_listType(funcdecl.loc, sc));
             }
 
             const nparams = f.parameterList.length;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3498,8 +3498,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             bool isVa_list(Parameter p)
             {
-                Type.tvalist = Type.tvalist.typeSemantic(funcdecl.loc, sc);
-                return p.type.equals(Type.tvalist);
+                return p.type.equals(Type.getVaList(funcdecl.loc, sc));
             }
 
             const nparams = f.parameterList.length;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -469,18 +469,6 @@ extern (C++) abstract class Type : ASTNode
 
     extern (C++) __gshared Type[TMAX] basic;
 
-    /// Returns the resolved special va_list type.
-    extern (C++) static Type getVaList(const ref Loc loc, Scope* sc)
-    {
-        // Target.va_listType() may return a type based on some TypeIdentifier,
-        // possibly referring to a symbol in core.stdc.stdarg etc.
-        // So defer its semantic by resolving va_list lazily.
-        __gshared Type tvalist = null;
-        if (!tvalist)
-            tvalist = typeSemantic(target.va_listType(), loc, sc);
-        return tvalist;
-    }
-
     extern (D) __gshared StringTable!Type stringtable;
     extern (D) private __gshared ubyte[TMAX] sizeTy = ()
         {

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -440,7 +440,6 @@ extern (C++) abstract class Type : ASTNode
     extern (C++) __gshared Type tstring;     // immutable(char)[]
     extern (C++) __gshared Type twstring;    // immutable(wchar)[]
     extern (C++) __gshared Type tdstring;    // immutable(dchar)[]
-    extern (C++) __gshared Type tvalist;     // va_list alias
     extern (C++) __gshared Type terror;      // for error recovery
     extern (C++) __gshared Type tnull;       // for null type
 
@@ -469,6 +468,18 @@ extern (C++) abstract class Type : ASTNode
     extern (C++) __gshared TemplateDeclaration rtinfo;
 
     extern (C++) __gshared Type[TMAX] basic;
+
+    /// Returns the resolved special va_list type.
+    extern (C++) static Type getVaList(const ref Loc loc, Scope* sc)
+    {
+        // Target.va_listType() may return a type based on some TypeIdentifier,
+        // possibly referring to a symbol in core.stdc.stdarg etc.
+        // So defer its semantic by resolving va_list lazily.
+        __gshared Type tvalist = null;
+        if (!tvalist)
+            tvalist = typeSemantic(target.va_listType(), loc, sc);
+        return tvalist;
+    }
 
     extern (D) __gshared StringTable!Type stringtable;
     extern (D) private __gshared ubyte[TMAX] sizeTy = ()
@@ -891,7 +902,6 @@ extern (C++) abstract class Type : ASTNode
         tstring = tchar.immutableOf().arrayOf();
         twstring = twchar.immutableOf().arrayOf();
         tdstring = tdchar.immutableOf().arrayOf();
-        tvalist = target.va_listType();
 
         const isLP64 = global.params.isLP64;
 

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -189,7 +189,6 @@ public:
     static Type *tstring;               // immutable(char)[]
     static Type *twstring;              // immutable(wchar)[]
     static Type *tdstring;              // immutable(dchar)[]
-    static Type *tvalist;               // va_list alias
     static Type *terror;                // for error recovery
     static Type *tnull;                 // for null type
 
@@ -218,6 +217,8 @@ public:
     static TemplateDeclaration *rtinfo;
 
     static Type *basic[TMAX];
+
+    static Type *getVaList(const Loc &loc, Scope *sc);
 
     virtual const char *kind();
     Type *copy() const;

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -218,8 +218,6 @@ public:
 
     static Type *basic[TMAX];
 
-    static Type *getVaList(const Loc &loc, Scope *sc);
-
     virtual const char *kind();
     Type *copy() const;
     virtual Type *syntaxCopy();

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -401,7 +401,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 if (f.linkage == LINK.d || f.parameterList.length)
                 {
                     // Declare _argptr
-                    Type t = Type.tvalist;
+                    Type t = Type.getVaList(funcdecl.loc, sc);
                     // Init is handled in FuncDeclaration_toObjFile
                     funcdecl.v_argptr = new VarDeclaration(funcdecl.loc, t, Id._argptr, new VoidInitializer(funcdecl.loc));
                     funcdecl.v_argptr.storage_class |= STC.temp;

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -401,7 +401,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 if (f.linkage == LINK.d || f.parameterList.length)
                 {
                     // Declare _argptr
-                    Type t = Type.getVaList(funcdecl.loc, sc);
+                    Type t = target.va_listType(funcdecl.loc, sc);
                     // Init is handled in FuncDeclaration_toObjFile
                     funcdecl.v_argptr = new VarDeclaration(funcdecl.loc, t, Id._argptr, new VoidInitializer(funcdecl.loc));
                     funcdecl.v_argptr.storage_class |= STC.temp;

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -89,12 +89,16 @@ struct Target
     FPTypeProperties<double> DoubleProperties;
     FPTypeProperties<real_t> RealProperties;
 
+private:
+    Type *va_list;
+
+public:
     void _init(const Param& params);
     // Type sizes and support.
     unsigned alignsize(Type *type);
     unsigned fieldalign(Type *type);
     unsigned critsecsize();
-    Type *va_listType();  // get type of va_list
+    Type *va_listType(const Loc &loc, Scope *sc);  // get type of va_list
     int isVectorTypeSupported(int sz, Type *type);
     bool isVectorOpSupported(Type *type, TOK op, Type *t2 = NULL);
     // ABI and backend.


### PR DESCRIPTION
When checking for `pragma(printf/scanf)`. Also use a resolved type when declaring `_argptr` (required for LDC: #9896).

Targeting `stable` because I've unknowingly introduced the potential multiple semantic passes in #11068 (I thought it'd be a noop after the first sema).