### PR TITLE
Lexer. Skip 4 whitespaces at a time

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -370,14 +370,22 @@ class Lexer
             case '\f':
                 p++;
                 continue; // skip white space
-            case '\r':
+           case '\r':
                 p++;
                 if (*p != '\n') // if CR stands by itself
+                {
                     endOfLine();
+                    goto skipFourSpaces;
+                }
                 continue; // skip white space
             case '\n':
                 p++;
                 endOfLine();
+                skipFourSpaces:
+                while (*(cast(uint*)p) == 0x20202020) //' ' == 0x20
+                {
+                    p+=4;
+                }
                 continue; // skip white space
             case '0':
                 if (!isZeroSecond(p[1]))        // if numeric literal does not continue

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -370,7 +370,7 @@ class Lexer
             case '\f':
                 p++;
                 continue; // skip white space
-           case '\r':
+            case '\r':
                 p++;
                 if (*p != '\n') // if CR stands by itself
                 {

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -452,8 +452,8 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     {
         if (params.addMain && m.srcfile.toString() == "__main.d")
         {
-            auto data = arraydup("int main(){return 0;}\0\0"); // need 2 trailing nulls for sentinel
-            m.srcBuffer = new FileBuffer(cast(ubyte[]) data[0 .. $-2]);
+            auto data = arraydup("int main(){return 0;}\0\0\0\0"); // need 2 trailing nulls for sentinel and 2 for lexer
+            m.srcBuffer = new FileBuffer(cast(ubyte[]) data[0 .. $-4]);
         }
         else if (m.srcfile.toString() == "__stdin.d")
         {
@@ -778,7 +778,7 @@ private FileBuffer readFromStdin()
     ubyte* buffer = null;
     for (;;)
     {
-        buffer = cast(ubyte*)mem.xrealloc(buffer, sz + 2); // +2 for sentinel
+        buffer = cast(ubyte*)mem.xrealloc(buffer, sz + 4); // +2 for sentinel and +2 for lexer
 
         // Fill up buffer
         do
@@ -798,6 +798,8 @@ private FileBuffer readFromStdin()
                 assert(pos < sz + 2);
                 buffer[pos] = '\0';
                 buffer[pos + 1] = '\0';
+                buffer[pos + 2] = '\0';
+                buffer[pos + 3] = '\0';
                 return FileBuffer(buffer[0 .. pos]);
             }
         } while (pos < sz);

--- a/src/dmd/root/file.d
+++ b/src/dmd/root/file.d
@@ -104,7 +104,7 @@ nothrow:
                 return result;
             }
             size = cast(size_t)buf.st_size;
-            ubyte* buffer = cast(ubyte*)mem.xmalloc_noscan(size + 2);
+            ubyte* buffer = cast(ubyte*)mem.xmalloc_noscan(size + 4);
             numread = .read(fd, buffer, size);
             if (numread != size)
             {
@@ -119,6 +119,9 @@ nothrow:
             // Always store a wchar ^Z past end of buffer so scanner has a sentinel
             buffer[size] = 0; // ^Z is obsolete, use 0
             buffer[size + 1] = 0;
+            buffer[size + 2] = 0; //add two more so lexer doesnt read pass the buffer
+            buffer[size + 3] = 0;
+
             result.success = true;
             result.buffer.data = buffer[0 .. size];
             return result;
@@ -146,7 +149,7 @@ nothrow:
             if (h == INVALID_HANDLE_VALUE)
                 return result;
             size = GetFileSize(h, null);
-            ubyte* buffer = cast(ubyte*)mem.xmalloc_noscan(size + 2);
+            ubyte* buffer = cast(ubyte*)mem.xmalloc_noscan(size + 4);
             if (ReadFile(h, buffer, size, &numread, null) != TRUE)
                 goto err2;
             if (numread != size)
@@ -156,6 +159,8 @@ nothrow:
             // Always store a wchar ^Z past end of buffer so scanner has a sentinel
             buffer[size] = 0; // ^Z is obsolete, use 0
             buffer[size + 1] = 0;
+            buffer[size + 2] = 0; //add two more so lexer doesnt read pass the buffer
+            buffer[size + 3] = 0;
             result.success = true;
             result.buffer.data = buffer[0 .. size];
             return result;


### PR DESCRIPTION
Made lexer skip 4 spaces at a time after newline. Here are some benchmarks lexing DMD source code.
Current lexer:
dmd                213149 usecs
dmd -O -inline 137161 usecs
ldc --O3           108218 usecs

New improved:
dmd                194221 usecs    9%  faster
dmd -O -inline 123456 usecs  10% faster
ldc --O3            90630 usecs   16% faster

Overall compilation speed might speed up by 1% for simple code.