### PR TITLE
Fix Issue 20795 - [dip1000] segfault on templated opEquals

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -209,7 +209,7 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, Exp
 
     foreach (Expression ee; er.byexp)
     {
-        if (sc.func.setUnsafe())
+        if (sc.func && sc.func.setUnsafe())
         {
             if (!gag)
                 error(ee.loc, "reference to stack allocated value returned by `%s` assigned to non-scope parameter `%s`",

--- a/test/compilable/test20795.d
+++ b/test/compilable/test20795.d
@@ -1,0 +1,35 @@
+// https://issues.dlang.org/show_bug.cgi?id=20795
+
+// REQUIRED_ARGS: -dip1000
+
+struct Foo
+{
+    void opEquals(T)(T rhs) if (T.init.opCast!string) {}
+}
+
+struct Bar
+{
+    void opEquals()(Bar)
+    {
+        Gun() == Foo();
+    }
+}
+
+class Baz
+{
+    void opCast(T)() {}
+}
+
+struct Gun
+{
+    void[24] buff;
+
+    auto underlying()
+    {
+        return cast(Baz) buff.ptr;
+    }
+
+    alias underlying this;
+
+    void opEquals(R)(R) if (Bar.init == R.init) {}
+}


### PR DESCRIPTION
`sc.func` is null when trying to call `setUnsafe`.

What puzzles me is that `sc.func` is used throughout the whole function without any checks. This makes me wonder if the check should be added at the start of the function.