### PR TITLE
[WIP] Attempt stabilizing order of semantic analysis in forward referenced structs

### DIFF
--- a/test/compilable/test20753a.d
+++ b/test/compilable/test20753a.d
@@ -1,0 +1,19 @@
+struct IniFragment
+{
+    HashCollection children;
+}
+struct HashCollection
+{
+    struct Item
+    {
+        IniFragment value;
+    }
+    Item[] items;
+    
+    ref lookupToReturnValue()
+    {
+        return items[0].value;
+    }
+
+    enum canDup = is(typeof(items.dup));
+}

--- a/test/compilable/test20753b.d
+++ b/test/compilable/test20753b.d
@@ -1,0 +1,19 @@
+struct HashCollection
+{
+    struct Item
+    {
+        IniFragment value;
+    }
+    Item[] items;
+
+    ref lookupToReturnValue()
+    {
+        return items[0].value;
+    }
+
+    enum canDup = is(typeof(items.dup));
+}
+struct IniFragment
+{
+    HashCollection children;
+}


### PR DESCRIPTION
Not a fix proper yet, but may hold a clue as to the regressions caused by #5500 

Added test comes from https://issues.dlang.org/show_bug.cgi?id=20753

DMD is able to successfully compile both with this patch, but it can't compile much each, hence WIP for now.