### PR TITLE
Fix issue 20796: package protected symbol declared in the same packag…

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -618,7 +618,6 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
         if (protection.kind == Prot.Kind.package_ && protection.pkg && sc._module)
         {
             Module m = sc._module;
-            Package pkg = m.parent ? m.parent.isPackage() : null;
 
             // While isAncestorPackageOf does an equality check, the fix for issue 17441 adds a check to see if
             // each package's .isModule() properites are equal.
@@ -627,11 +626,12 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
             // This breaks package declarations of the package in question if they are declared in
             // the same package.d file, which _do_ have a module associated with them, and hence a non-null
             // isModule()
-            if (m.isPackage() && protection.pkg.ident.equals(m.isPackage().ident))
-            {}
-
-            else if (!pkg || !protection.pkg.isAncestorPackageOf(pkg))
-                error("does not bind to one of ancestor packages of module `%s`", m.toPrettyChars(true));
+            if (!m.isPackage() || !protection.pkg.ident.equals(m.isPackage().ident))
+            {
+                Package pkg = m.parent ? m.parent.isPackage() : null;
+                if (!pkg || !protection.pkg.isAncestorPackageOf(pkg))
+                    error("does not bind to one of ancestor packages of module `%s`", m.toPrettyChars(true));
+            }
         }
         return AttribDeclaration.addMember(sc, sds);
     }

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -619,7 +619,18 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
         {
             Module m = sc._module;
             Package pkg = m.parent ? m.parent.isPackage() : null;
-            if (!pkg || !protection.pkg.isAncestorPackageOf(pkg))
+
+            // While isAncestorPackageOf does an equality check, the fix for issue 17441 adds a check to see if
+            // each package's .isModule() properites are equal.
+            //
+            // Properties generated from `package(foo)` i.e. protection.pkg have .isModule() == null.
+            // This breaks package declarations of the package in question if they are declared in
+            // the same package.d file, which _do_ have a module associated with them, and hence a non-null
+            // isModule()
+            if (m.isPackage() && protection.pkg.ident.equals(m.isPackage().ident))
+            {}
+
+            else if (!pkg || !protection.pkg.isAncestorPackageOf(pkg))
                 error("does not bind to one of ancestor packages of module `%s`", m.toPrettyChars(true));
         }
         return AttribDeclaration.addMember(sc, sds);

--- a/test/compilable/bug20796.d
+++ b/test/compilable/bug20796.d
@@ -1,0 +1,2 @@
+// EXTRA_SOURCES: protection/issue20796/package.d
+// https://issues.dlang.org/show_bug.cgi?id=20796

--- a/test/compilable/protection/issue20796/package.d
+++ b/test/compilable/protection/issue20796/package.d
@@ -1,0 +1,5 @@
+module issue20796;
+
+package(issue20796) void foo()
+{
+}


### PR DESCRIPTION
…e.d don't work

N.B I'm unsure if I need to do anything special to ensure that the test runs, given it is in a subfolder. cc @MoonlightSentinel hopefully you know.