### PR TITLE
fix issue 20788 - Difference between colored and non colored output

### DIFF
--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -662,7 +662,6 @@ private void colorSyntaxHighlight(ref OutBuffer buf)
                     immutable pre = "";
                     i = buf.insert(iCodeStart, pre);
                     i = buf.insert(i, codebuf[]);
-                    i--; // point to the ending ) so when the for loop does i++, it will see the next character
                     break;
                 }
                 inBacktick = true;

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -654,11 +654,11 @@ private void colorSyntaxHighlight(ref OutBuffer buf)
                 {
                     inBacktick = false;
                     OutBuffer codebuf;
-                    codebuf.write(buf[iCodeStart + 1 .. i]);
+                    codebuf.write(buf[iCodeStart .. i]);
                     codebuf.writeByte(0);
                     // escape the contents, but do not perform highlighting except for DDOC_PSYMBOL
                     colorHighlightCode(codebuf);
-                    buf.remove(iCodeStart, i - iCodeStart + 1); // also trimming off the current `
+                    buf.remove(iCodeStart, i - iCodeStart);
                     immutable pre = "";
                     i = buf.insert(iCodeStart, pre);
                     i = buf.insert(i, codebuf[]);
@@ -666,7 +666,7 @@ private void colorSyntaxHighlight(ref OutBuffer buf)
                     break;
                 }
                 inBacktick = true;
-                iCodeStart = i;
+                iCodeStart = i + 1;
                 break;
 
             default:

--- a/test/compilable/testcolor.sh
+++ b/test/compilable/testcolor.sh
@@ -35,6 +35,12 @@ check -color=auto "test" "$expectedWithoutColor"
 check -color=on "test" "$expectedWithColor"
 check -color=off "test" "$expectedWithoutColor"
 
+gooCode="void foo() {} void main() { goo(); }"
+gooExpectedWithoutColor='__stdin.d(1): Error: undefined identifier `goo`, did you mean function `foo`?'
+gooExpectedWithColor=$'\033[1m__stdin.d(1): \033[1;31mError: \033[mundefined identifier `\033[0;36m\033[m\033[1mgoo\033[0;36m\033[m`, did you mean function `\033[0;36m\033[m\033[1mfoo\033[0;36m\033[m`?'
+check -color=on "$gooCode" "$gooExpectedWithColor"
+check -color=off "$gooCode" "$gooExpectedWithoutColor"
+
 if [[ "$(script --version)" == script\ from\ util-linux\ * ]]
 then
     actual="$(SHELL="$(command -v bash)" TERM="faketerm" script -q -c "echo test | ( $DMD -c -o- -)" /dev/null | normalize)" || true

--- a/test/compilable/testcolor.sh
+++ b/test/compilable/testcolor.sh
@@ -28,7 +28,7 @@ check()
 }
 
 expectedWithoutColor=__stdin.d\(2\):\ Error:\ no\ identifier\ for\ declarator\ \`test\`
-expectedWithColor=$'\033'\[1m__stdin.d\(2\):\ $'\033'\[1\;31mError:\ $'\033'\[mno\ identifier\ for\ declarator\ $'\033'\[0\;36m$'\033'\[m$'\033'\[1mtest$'\033'\[0\;36m$'\033'\[m
+expectedWithColor=$'\033'\[1m__stdin.d\(2\):\ $'\033'\[1\;31mError:\ $'\033'\[mno\ identifier\ for\ declarator\ \`$'\033'\[0\;36m$'\033'\[m$'\033'\[1mtest$'\033'\[0\;36m$'\033'\[m\`
 
 check -c "test" "$expectedWithoutColor"
 check -color=auto "test" "$expectedWithoutColor"


### PR DESCRIPTION
So that an error copied from the (colored) terminal can be pasted into a dustmite command line (or any other context where the backticks are expected).