### PR TITLE
Fix linker errors when buillding unittests on Windows

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -339,8 +339,10 @@ alias backend = makeRuleWithArgs!((MethodInitializer!BuildRule builder, BuildRul
         env["HOST_DMD_RUN"],
         "-c",
         "-of" ~ rule.target,
-        "-betterC"]
-        .chain(flags["DFLAGS"], extraFlags, rule.sources).array)
+        ]
+        .chain(
+            extraFlags.canFind("-unittest") ? [] : ["-betterC"],
+            flags["DFLAGS"], extraFlags, rule.sources).array)
 );
 
 /// Returns: the rules that generate required string files: VERSION and SYSCONFDIR.imp

--- a/src/dmd/root/longdouble.d
+++ b/src/dmd/root/longdouble.d
@@ -804,8 +804,8 @@ size_t ld_sprint(char* str, int fmt, longdouble_soft x) @system
     ld_sprint(buffer.ptr, 'a', ld_pi);
     assert(strcmp(buffer.ptr, "0x1.921fb54442d1846ap+1") == 0);
 
-    ld_sprint(buffer.ptr, 'g', longdouble_soft(2.0));
-    assert(strcmp(buffer.ptr, "2.00000") == 0);
+    auto len = ld_sprint(buffer.ptr, 'g', longdouble_soft(2.0));
+    assert(buffer[0 .. len] == "2.00000" || buffer[0 .. len] == "2"); // Win10 - 64bit
 
     ld_sprint(buffer.ptr, 'g', longdouble_soft(1234567.89));
     assert(strcmp(buffer.ptr, "1.23457e+06") == 0);


### PR DESCRIPTION
Unittest builds fail with a linker error about a missing `ModuleInfo`:
```
dmd.obj : error LNK2001: unresolved external symbol _D3dmd7backend8bcomplex12__ModuleInfoZ
```

The `ModuleInfo` is omitted because the backend is compiled with `-betterC`
(don't know why this isn't an issue for linux - checked on Arch - and older
windows versions, e.g. the auto-tester)

Compiling the unittest builds without `-betterC` is the easy solution but
this workaround [1] could also be considered if we want to keep that flag.

[1] https://dlang.org/spec/betterc.html#unittests