### PR TITLE
put scope array literals on stack

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2897,6 +2897,21 @@ extern (C++) final class ArrayLiteralExp : Expression
         return result ? (dim != 0) : (dim == 0);
     }
 
+    override Expression addDtorHook(Scope* sc)
+    {
+        if (basis)
+            basis = basis.addDtorHook(sc);
+        if (elements)
+        {
+            foreach (ref e; (*elements)[])
+            {
+                if (e)
+                    e = e.addDtorHook(sc);
+            }
+        }
+        return this;
+    }
+
     override StringExp toStringExp()
     {
         TY telem = type.nextOf().toBasetype().ty;

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -6200,6 +6200,16 @@ void test11472()
 
 /***************************************************/
 
+@nogc int bar253(scope int[] a) { return a[2]; }
+
+@nogc void test253()
+{
+    int i = bar253([1, 2, 3, 4]);
+    assert(i == 3);
+}
+
+/***************************************************/
+
 int main()
 {
     checkAlign();
@@ -6503,6 +6513,7 @@ int main()
     test5332();
     test11472();
     test13285();
+    test253();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
The following:
```
int foo(int[] a ...);
void test() {
    foo(1,2,3,4);
}
```
will put the 1,2,3,4 array on the stack. This PR makes the following:
```
int bar(scope int[] a);
void test() {
    bar([1,2,3,4]);
}
```
also put 1,2,3,4 on the stack instead of on the GC heap.

The idea is to remove the advantages of Typesafe Variadic Functions https://dlang.org/spec/function.html#variadic so they become redundant and can be deprecated. The fewer special cases like TVFs, the better.