### PR TITLE
Fix issue 16971 - Misleading error messages...

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3455,7 +3455,7 @@ else
         {
             if (sc.os && sc.os.tok != TOK.onScopeFailure)
             {
-                bs.error("`break` is not inside `%s` bodies", Token.toChars(sc.os.tok));
+                bs.error("`break` is not allowed inside `%s` bodies", Token.toChars(sc.os.tok));
             }
             else if (sc.fes)
             {
@@ -3542,7 +3542,7 @@ else
         {
             if (sc.os && sc.os.tok != TOK.onScopeFailure)
             {
-                cs.error("`continue` is not inside `%s` bodies", Token.toChars(sc.os.tok));
+                cs.error("`continue` is not allowed inside `%s` bodies", Token.toChars(sc.os.tok));
             }
             else if (sc.fes)
             {

--- a/test/fail_compilation/fail6889.d
+++ b/test/fail_compilation/fail6889.d
@@ -4,10 +4,10 @@ TEST_OUTPUT:
 fail_compilation/fail6889.d(16): Error: cannot `goto` out of `scope(success)` block
 fail_compilation/fail6889.d(17): Error: cannot `goto` in to `scope(success)` block
 fail_compilation/fail6889.d(19): Error: `return` statements cannot be in `scope(success)` bodies
-fail_compilation/fail6889.d(23): Error: `continue` is not inside `scope(success)` bodies
-fail_compilation/fail6889.d(24): Error: `break` is not inside `scope(success)` bodies
-fail_compilation/fail6889.d(29): Error: `continue` is not inside `scope(success)` bodies
-fail_compilation/fail6889.d(30): Error: `break` is not inside `scope(success)` bodies
+fail_compilation/fail6889.d(23): Error: `continue` is not allowed inside `scope(success)` bodies
+fail_compilation/fail6889.d(24): Error: `break` is not allowed inside `scope(success)` bodies
+fail_compilation/fail6889.d(29): Error: `continue` is not allowed inside `scope(success)` bodies
+fail_compilation/fail6889.d(30): Error: `break` is not allowed inside `scope(success)` bodies
 ---
 */
 void test_success()
@@ -88,10 +88,10 @@ TEST_OUTPUT:
 fail_compilation/fail6889.d(100): Error: cannot `goto` out of `scope(exit)` block
 fail_compilation/fail6889.d(101): Error: cannot `goto` in to `scope(exit)` block
 fail_compilation/fail6889.d(103): Error: `return` statements cannot be in `scope(exit)` bodies
-fail_compilation/fail6889.d(107): Error: `continue` is not inside `scope(exit)` bodies
-fail_compilation/fail6889.d(108): Error: `break` is not inside `scope(exit)` bodies
-fail_compilation/fail6889.d(113): Error: `continue` is not inside `scope(exit)` bodies
-fail_compilation/fail6889.d(114): Error: `break` is not inside `scope(exit)` bodies
+fail_compilation/fail6889.d(107): Error: `continue` is not allowed inside `scope(exit)` bodies
+fail_compilation/fail6889.d(108): Error: `break` is not allowed inside `scope(exit)` bodies
+fail_compilation/fail6889.d(113): Error: `continue` is not allowed inside `scope(exit)` bodies
+fail_compilation/fail6889.d(114): Error: `break` is not allowed inside `scope(exit)` bodies
 ---
 */
 void test_exit()


### PR DESCRIPTION
..."break is not inside scope(exit) bodies" "continue is not inside scope(exit) bodies"