### PR TITLE
remove typesafe variadic functions

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -2979,9 +2979,11 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         {
                             /* This is:
                              *      at ai ...
+                             * https://dlang.org/spec/function.html#typesafe_variadic_functions
                              */
                             if (storageClass & (STC.out_ | STC.ref_))
                                 error("variadic argument cannot be `out` or `ref`");
+                            error("typesafe variadic functions have been removed");
                             varargs = VarArg.typesafe;
                             parameters.push(param);
                             nextToken();


### PR DESCRIPTION
Don't be too alarmed yet, I'm planning on removing this feature as it is now redundant with other features. This PR is to find out if anyone at all is using it.

https://dlang.org/spec/function.html#typesafe_variadic_functions