### PR TITLE
start adding support for storage classes for ...

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6407,7 +6407,15 @@ extern (C++) final class TypeNull : Type
 extern (C++) struct ParameterList
 {
     Parameters* parameters;
+    StorageClass stc;                   // storage class of ...
     VarArg varargs = VarArg.none;
+
+    this(Parameters* parameters, VarArg varargs = VarArg.none, StorageClass stc = 0)
+    {
+        this.parameters = parameters;
+        this.varargs = varargs;
+        this.stc = stc;
+    }
 
     size_t length()
     {

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -571,6 +571,7 @@ public:
 struct ParameterList
 {
     Parameters* parameters;
+    StorageClass stc;
     VarArg varargs;
 
     size_t length();

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -18,6 +18,7 @@ import core.stdc.string;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
+import dmd.hdrgen;
 import dmd.lexer;
 import dmd.errors;
 import dmd.root.filename;
@@ -2809,6 +2810,10 @@ final class Parser(AST) : Lexer
         auto parameters = new AST.Parameters();
         AST.VarArg varargs = AST.VarArg.none;
         int hasdefault = 0;
+        StorageClass varargsStc;
+
+        // Attributes allowed for ...
+        enum VarArgsStc = STC.const_ | STC.immutable_ | STC.shared_ | STC.scope_ | STC.return_;
 
         check(TOK.leftParentheses);
         while (1)
@@ -2831,6 +2836,14 @@ final class Parser(AST) : Lexer
 
                 case TOK.dotDotDot:
                     varargs = AST.VarArg.variadic;
+                    varargsStc = storageClass;
+                    if (varargsStc & ~VarArgsStc)
+                    {
+                        OutBuffer buf;
+                        stcToBuffer(&buf, varargsStc & ~VarArgsStc);
+                        error("variadic parameter cannot have attributes `%s`", buf.peekChars());
+                        varargsStc &= VarArgsStc;
+                    }
                     nextToken();
                     break;
 
@@ -3049,7 +3062,7 @@ final class Parser(AST) : Lexer
         L1:
         }
         check(TOK.rightParentheses);
-        return AST.ParameterList(parameters, varargs);
+        return AST.ParameterList(parameters, varargs, varargsStc);
     }
 
     /*************************************

--- a/test/fail_compilation/varargsstc.d
+++ b/test/fail_compilation/varargsstc.d
@@ -1,0 +1,11 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/varargsstc.d(102): Error: variadic parameter cannot have attributes `out ref`
+---
+ */
+
+#line 100
+
+int printf(const(char)*, const scope shared return ...);
+int printf(const(char)*, ref out scope immutable shared return ...);
+


### PR DESCRIPTION
Currently, attributes are accepted for ... function parameters, but they are ignored. They are needed to support calling things like `printf` from @live functions. This is a start on that, by rejecting invalid attributes.