### PR TITLE
[stable] dmd.expressionsem: Fix potential segfault

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2033,7 +2033,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                     (ale = a.isArrayLiteralExp()) !is null)
                 {
                     // allocate the array literal as temporary static array on the stack
-                    ale.type = ale.type.nextOf().sarrayOf(ale.elements.length);
+                    ale.type = ale.type.nextOf().sarrayOf(ale.elements ? ale.elements.length : 0);
                     auto tmp = copyToTemp(0, "__arrayliteral_on_stack", ale);
                     auto declareTmp = new DeclarationExp(ale.loc, tmp);
                     auto castToSlice = new CastExp(ale.loc, new VarExp(ale.loc, tmp), p.type);


### PR DESCRIPTION
Addressing https://github.com/dlang/dmd/pull/11039/files#r422478333. I haven't quickly found a way to test it; modifying the original testcase to `takeScopeSlice([])` has already worked fine.