### PR TITLE
semaphoreCI: Enable PIC on all platforms

### DIFF
--- a/semaphoreci.sh
+++ b/semaphoreci.sh
@@ -29,6 +29,8 @@ else
     BRANCH="${BRANCH_NAME}"
 fi
 export BRANCH
+# Ubuntu 18 and above require PIC, but build.d doesn't set it by default on x86
+export PIC=1
 
 source ci.sh
 


### PR DESCRIPTION
As we want to switch to the new SemaphoreCI platform, Ubuntu 18.04,
we need to enable PIC on x86 as well.