### PR TITLE
Fix Issue 20626 - ICE when using typeof of unittest symbol without -u…

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2896,7 +2896,10 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, Expression* pe, Type* pt, Ds
         if (auto f = mt.exp.op == TOK.variable    ? (cast(   VarExp)mt.exp).var.isFuncDeclaration()
                    : mt.exp.op == TOK.dotVariable ? (cast(DotVarExp)mt.exp).var.isFuncDeclaration() : null)
         {
-            if (f.checkForwardRef(loc))
+            // f might be a unittest declaration which is incomplete when compiled
+            // without -unittest. That causes a segfault in checkForwardRef, see
+            // https://issues.dlang.org/show_bug.cgi?id=20626
+            if ((!f.isUnitTestDeclaration() || global.params.useUnitTests) && f.checkForwardRef(loc))
                 goto Lerr;
         }
         if (auto f = isFuncAddress(mt.exp))

--- a/test/fail_compilation/test20626.d
+++ b/test/fail_compilation/test20626.d
@@ -1,0 +1,22 @@
+/*
+REQUIRED_ARGS: -check=invariant=off
+TEST_OUTPUT:
+----
+fail_compilation/test20626.d(2): Error: expression `__unittest_L1_C1` has no type
+_error_
+const void()
+----
+
+https://issues.dlang.org/show_bug.cgi?id=20626
+*/
+
+#line 1
+unittest {}
+pragma(msg, typeof(__unittest_L1_C1));
+
+struct S
+{
+    invariant {}
+}
+
+pragma(msg, typeof(S.init.__invariant1));


### PR DESCRIPTION
…nittest flag.

Not sure if this is the behaviour but the special unittest functions should not be used in user code anyway.