### PR TITLE
Add pragma(printf) to most error/warning/deprecation functions...

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1059,6 +1059,17 @@ void processEnvironment()
         dflags ~= ["-fsanitize="~env["ENABLE_SANITIZERS"]];
     }
 
+    // Check if pragma(printf) is supported
+    {
+        auto pipes = pipeProcess([env["HOST_DMD_RUN"], "-c", "-o-", "-"]);
+        pipes.stdin.writeln(q{
+            pragma(printf)
+            extern(C) void printf(char*, ...);
+        });
+        pipes.stdin.close();
+        if (pipes.pid.wait())
+            dflags ~= "-ignore";
+    }
     // Retain user-defined flags
     flags["DFLAGS"] = dflags ~= flags.get("DFLAGS", []);
 }

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -414,6 +414,7 @@ struct ASTBase
             return "symbol";
         }
 
+        pragma(printf)
         final void error(const(char)* format, ...)
         {
             va_list ap;
@@ -4389,6 +4390,7 @@ struct ASTBase
             return copy();
         }
 
+        pragma(printf)
         final void error(const(char)* format, ...) const
         {
             if (type != Type.terror)

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -842,7 +842,7 @@ extern (C++) final class PragmaDeclaration : AttribDeclaration
                 inlining = PINLINE.default_;
             else if (args.dim != 1)
             {
-                error("one boolean expression expected for `pragma(inline)`, not %d", args.dim);
+                error("one boolean expression expected for `pragma(inline)`, not %zd", args.dim);
                 args.setDim(1);
                 (*args)[0] = new ErrorExp();
             }

--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -92,6 +92,7 @@ struct Loc
     }
 }
 
+pragma(printf)
 void error(Loc loc, const(char)* format, ...);
 }
 
@@ -439,7 +440,7 @@ void objrecord(uint rectyp, const(char)* record, uint reclen)
  * Returns:
  *      # of bytes stored
  */
-
+// pragma(printf) // TODO: Requires pragma(printf, <format index>)
 void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);
 void fatal();
 

--- a/src/dmd/backend/errors.di
+++ b/src/dmd/backend/errors.di
@@ -16,4 +16,5 @@ module dmd.backend.errors;
  */
 nothrow:
 
+// pragma(printf) // TODO: Requires pragma(printf, <format index>)
 extern (C++) void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1273,7 +1273,7 @@ UnionExp Index(Type type, Expression e1, Expression e2)
             ArrayLiteralExp ale = cast(ArrayLiteralExp)e1;
             if (i >= ale.elements.dim)
             {
-                e1.error("array index %llu is out of bounds `%s[0 .. %u]`", i, e1.toChars(), ale.elements.dim);
+                e1.error("array index %zu is out of bounds `%s[0 .. %zu]`", i, e1.toChars(), ale.elements.dim);
                 emplaceExp!(ErrorExp)(&ue);
             }
             else

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -764,7 +764,7 @@ extern (C++) final class Module : Package
 
             if (buf.length & 3)
             {
-                error("odd length of UTF-32 char source %u", buf.length);
+                error("odd length of UTF-32 char source %zu", buf.length);
                 fatal();
             }
 
@@ -810,7 +810,7 @@ extern (C++) final class Module : Package
 
             if (buf.length & 1)
             {
-                error("odd length of UTF-16 char source %u", buf.length);
+                error("odd length of UTF-16 char source %zu", buf.length);
                 fatal();
             }
 

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -306,7 +306,7 @@ private final class ParamSection : Section
                             cast(int)(tf.parameterList.varargs == VarArg.variadic);
             if (pcount != paramcount)
             {
-                warning(s.loc, "Ddoc: parameter count mismatch, expected %d, got %d", pcount, paramcount);
+                warning(s.loc, "Ddoc: parameter count mismatch, expected %zd, got %zd", pcount, paramcount);
                 if (paramcount == 0)
                 {
                     // Chances are someone messed up the format

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -456,7 +456,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
                     // CTFE sometimes creates null as hidden pointer; we'll allow this.
                     continue;
                 }
-                .error(loc, "more initializers than fields (%d) of `%s`", nfields, toChars());
+                .error(loc, "more initializers than fields (%zd) of `%s`", nfields, toChars());
                 return false;
             }
             VarDeclaration v = fields[i];

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -317,6 +317,7 @@ extern (C++) class Dsymbol : ASTNode
         return '`' ~ cstr.toDString() ~ "`\0";
     }
 
+    pragma(printf)
     final void error(const ref Loc loc, const(char)* format, ...)
     {
         va_list ap;
@@ -325,6 +326,7 @@ extern (C++) class Dsymbol : ASTNode
         va_end(ap);
     }
 
+    pragma(printf)
     final void error(const(char)* format, ...)
     {
         va_list ap;
@@ -334,6 +336,7 @@ extern (C++) class Dsymbol : ASTNode
         va_end(ap);
     }
 
+    pragma(printf)
     final void deprecation(const ref Loc loc, const(char)* format, ...)
     {
         va_list ap;
@@ -342,6 +345,7 @@ extern (C++) class Dsymbol : ASTNode
         va_end(ap);
     }
 
+    pragma(printf)
     final void deprecation(const(char)* format, ...)
     {
         va_list ap;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2188,7 +2188,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                             return; // An error happened in `identFromSE`
                     }
                     else
-                        ns.exp.error("`%s`: index %d is not a string constant, it is a `%s`",
+                        ns.exp.error("`%s`: index %zd is not a string constant, it is a `%s`",
                                      ns.exp.toChars(), d, ns.exp.type.toChars());
                 }
             }

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -42,6 +42,7 @@ enum Classification
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
+pragma(printf)
 extern (C++) void error(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -57,7 +58,9 @@ extern (C++) void error(const ref Loc loc, const(char)* format, ...)
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
-extern (D) void error(Loc loc, const(char)* format, ...)
+pragma(printf)
+extern(C++) // Hack to allow verification
+void error(Loc loc, const(char)* format, ...)
 {
     va_list ap;
     va_start(ap, format);
@@ -74,6 +77,7 @@ extern (D) void error(Loc loc, const(char)* format, ...)
  *      format   = printf-style format specification
  *      ...      = printf-style variadic arguments
  */
+// pragma(printf) // Needs pragma(printf, <format index>)
 extern (C++) void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...)
 {
     const loc = Loc(filename, linnum, charnum);
@@ -91,6 +95,7 @@ extern (C++) void error(const(char)* filename, uint linnum, uint charnum, const(
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
+pragma(printf)
 extern (C++) void errorSupplemental(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -106,6 +111,7 @@ extern (C++) void errorSupplemental(const ref Loc loc, const(char)* format, ...)
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
+pragma(printf)
 extern (C++) void warning(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -122,6 +128,7 @@ extern (C++) void warning(const ref Loc loc, const(char)* format, ...)
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
+pragma(printf)
 extern (C++) void warningSupplemental(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -138,6 +145,7 @@ extern (C++) void warningSupplemental(const ref Loc loc, const(char)* format, ..
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
+pragma(printf)
 extern (C++) void deprecation(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -154,6 +162,7 @@ extern (C++) void deprecation(const ref Loc loc, const(char)* format, ...)
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
+pragma(printf)
 extern (C++) void deprecationSupplemental(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -170,6 +179,7 @@ extern (C++) void deprecationSupplemental(const ref Loc loc, const(char)* format
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
+pragma(printf)
 extern (C++) void message(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -184,6 +194,7 @@ extern (C++) void message(const ref Loc loc, const(char)* format, ...)
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
+pragma(printf)
 extern (C++) void message(const(char)* format, ...)
 {
     va_list ap;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -722,6 +722,7 @@ extern (C++) abstract class Expression : ASTNode
         return buf.extractChars();
     }
 
+    pragma(printf)
     final void error(const(char)* format, ...) const
     {
         if (type != Type.terror)
@@ -733,6 +734,7 @@ extern (C++) abstract class Expression : ASTNode
         }
     }
 
+    pragma(printf)
     final void errorSupplemental(const(char)* format, ...)
     {
         if (type == Type.terror)
@@ -744,6 +746,7 @@ extern (C++) abstract class Expression : ASTNode
         va_end(ap);
     }
 
+    pragma(printf)
     final void warning(const(char)* format, ...) const
     {
         if (type != Type.terror)
@@ -755,6 +758,7 @@ extern (C++) abstract class Expression : ASTNode
         }
     }
 
+    pragma(printf)
     final void deprecation(const(char)* format, ...) const
     {
         if (type != Type.terror)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3090,7 +3090,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         expandTuples(e.values);
         if (e.keys.dim != e.values.dim)
         {
-            e.error("number of keys is %u, must match number of values %u", e.keys.dim, e.values.dim);
+            e.error("number of keys is %zu, must match number of values %zu", e.keys.dim, e.values.dim);
             return setError();
         }
 

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -2308,7 +2308,7 @@ ILLEGAL_ADDRESS_ERROR:
         size_t index = cast(int)o2.disp;
         if (index >= tup.objects.dim)
         {
-            error(asmstate.loc, "tuple index %u exceeds length %u", index, tup.objects.dim);
+            error(asmstate.loc, "tuple index %zu exceeds length %zu", index, tup.objects.dim);
         }
         else
         {

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -2287,6 +2287,8 @@ class Lexer
         return scanloc;
     }
 
+    pragma(printf)
+    extern(C++) // Hack to allow verification
     final void error(const(char)* format, ...)
     {
         va_list args;
@@ -2295,6 +2297,8 @@ class Lexer
         va_end(args);
     }
 
+    pragma(printf)
+    extern(C++) // Hack to allow verification
     final void error(const ref Loc loc, const(char)* format, ...)
     {
         va_list args;
@@ -2303,6 +2307,8 @@ class Lexer
         va_end(args);
     }
 
+    pragma(printf)
+    extern(C++) // Hack to allow verification
     final void deprecation(const(char)* format, ...)
     {
         va_list args;

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -107,6 +107,8 @@ class Library
         writeFile(Loc.initial, loc.filename.toDString, libbuf[]);
     }
 
+    pragma(printf)
+    extern(C++) // Hack to allow verification
     final void error(const(char)* format, ...)
     {
         va_list ap;

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -831,7 +831,7 @@ version (Windows)
                 if (status == 0)
                     args = "@_CMDLINE";
                 else
-                    error(Loc.initial, "command line length of %d is too long", len);
+                    error(Loc.initial, "command line length of %zd is too long", len);
             }
         }
         // Normalize executable path separators

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -678,7 +678,7 @@ static:
             // create symbol
             __gshared size_t selectorCount = 0;
             char[42] nameString;
-            sprintf(nameString.ptr, "L_OBJC_SELECTOR_REFERENCES_%lu", selectorCount);
+            sprintf(nameString.ptr, "L_OBJC_SELECTOR_REFERENCES_%zu", selectorCount);
             refSymbol = symbol_name(nameString.ptr, SCstatic, type_fake(TYnptr));
 
             refSymbol.Sdt = dtb.finish();

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -176,6 +176,7 @@ extern (C++) abstract class Statement : ASTNode
         return buf.extractSlice().ptr;
     }
 
+    pragma(printf)
     final void error(const(char)* format, ...)
     {
         va_list ap;
@@ -184,6 +185,7 @@ extern (C++) abstract class Statement : ASTNode
         va_end(ap);
     }
 
+    pragma(printf)
     final void warning(const(char)* format, ...)
     {
         va_list ap;
@@ -192,6 +194,7 @@ extern (C++) abstract class Statement : ASTNode
         va_end(ap);
     }
 
+    pragma(printf)
     final void deprecation(const(char)* format, ...)
     {
         va_list ap;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1138,7 +1138,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             if (foundMismatch && dim != foreachParamCount)
             {
                 const(char)* plural = foreachParamCount > 1 ? "s" : "";
-                fs.error("cannot infer argument types, expected %d argument%s, not %d",
+                fs.error("cannot infer argument types, expected %zd argument%s, not %zd",
                     foreachParamCount, plural, dim);
             }
             else
@@ -1582,7 +1582,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     if (exps.dim != dim)
                     {
                         const(char)* plural = exps.dim > 1 ? "s" : "";
-                        fs.error("cannot infer argument types, expected %d argument%s, not %d",
+                        fs.error("cannot infer argument types, expected %zd argument%s, not %zd",
                             exps.dim, plural, dim);
                         goto case Terror;
                     }

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -165,7 +165,7 @@ extern (C++) void Initializer_toDt(Initializer init, ref DtBuilder dtb)
                 }
                 else if (ai.dim > tadim)
                 {
-                    error(ai.loc, "too many initializers, %d, for array[%d]", ai.dim, tadim);
+                    error(ai.loc, "too many initializers, %d, for array[%zd]", ai.dim, tadim);
                 }
                 dtb.cat(dtbarray);
                 break;

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1937,7 +1937,7 @@ Lnext:
     }
 
     if (auto sub = speller!trait_search_fp(e.ident.toString()))
-        e.error("unrecognized trait `%s`, did you mean `%.*s`?", e.ident.toChars(), sub.length, sub.ptr);
+        e.error("unrecognized trait `%s`, did you mean `%.*s`?", e.ident.toChars(), cast(int) sub.length, sub.ptr);
     else
         e.error("unrecognized trait `%s`", e.ident.toChars());
     return new ErrorExp();

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -151,7 +151,7 @@ private void resolveTupleIndex(const ref Loc loc, Scope* sc, Dsymbol s, Expressi
     const(uinteger_t) d = eindex.toUInteger();
     if (d >= tup.objects.dim)
     {
-        .error(loc, "tuple index `%llu` exceeds length %u", d, tup.objects.dim);
+        .error(loc, "tuple index `%llu` exceeds length %zu", d, tup.objects.dim);
         *pt = Type.terror;
         return;
     }
@@ -2622,7 +2622,7 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, Expression* pe, Type* pt, Ds
                 const d = mt.dim.toUInteger();
                 if (d >= tup.objects.dim)
                 {
-                    error(loc, "tuple index `%llu` exceeds length %u", d, tup.objects.dim);
+                    error(loc, "tuple index `%llu` exceeds length %zu", d, tup.objects.dim);
                     return returnError();
                 }
 
@@ -3008,7 +3008,7 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, Expression* pe, Type* pt, Ds
                 const i2 = mt.upr.toUInteger();
                 if (!(i1 <= i2 && i2 <= td.objects.dim))
                 {
-                    error(loc, "slice `[%llu..%llu]` is out of range of [0..%u]", i1, i2, td.objects.dim);
+                    error(loc, "slice `[%llu..%llu]` is out of range of [0..%zu]", i1, i2, td.objects.dim);
                     return returnError();
                 }
 

--- a/src/dmd/utils.d
+++ b/src/dmd/utils.d
@@ -83,7 +83,7 @@ extern (D) void writeFile(Loc loc, const(char)[] filename, const void[] data)
     ensurePathToNameExists(Loc.initial, filename);
     if (!File.write(filename, data))
     {
-        error(loc, "Error writing file '%*.s'", filename.length, filename.ptr);
+        error(loc, "Error writing file '%*.s'", cast(int) filename.length, filename.ptr);
         fatal();
     }
 }
@@ -104,7 +104,7 @@ void ensurePathToNameExists(Loc loc, const(char)[] name)
     {
         if (!FileName.ensurePathExists(pt))
         {
-            error(loc, "cannot create directory %*.s", pt.length, pt.ptr);
+            error(loc, "cannot create directory %*.s", cast(int) pt.length, pt.ptr);
             fatal();
         }
     }


### PR DESCRIPTION
..because those functions forward to printf and friends. The remaining functions require `pragma(printf, <format index>)` because the format string is preceded by another `char*` argument.

Also add `-ignore` when building dmd if the host compiler is older than 2.092.0.

CC @WalterBright
This is blocked because  `pragma(printf)` requires `extern(C|C++)` linkage and hence forced me to make some functions `extern(C++)` for now - which is not a viable solution.
I think we should remove this restriction because `pragma(printf)` can validate the **arguments** passed to `printf` wrappers regardless of their linkage.

EDIT:
Also blocked because `ignore` does not work for `pragma(printf)`...