### PR TITLE
dmd.ctorflow: Remove self reference assignments in mergeFieldInit

### DIFF
--- a/src/dmd/ctorflow.d
+++ b/src/dmd/ctorflow.d
@@ -190,27 +190,33 @@ bool mergeFieldInit(ref CSX a, const CSX b) pure nothrow
         return true;
     }
 
+    // The logic here is to prefer the branch that neither halts nor returns.
     bool ok;
     if (!bHalt && bRet)
     {
+        // Branch b returns, no merging required.
         ok = (b & CSX.this_ctor);
     }
     else if (!aHalt && aRet)
     {
+        // Branch a returns, but b doesn't, b takes precedence.
         ok = (a & CSX.this_ctor);
         a = b;
     }
     else if (bHalt)
     {
+        // Branch b halts, no merging required.
         ok = (a & CSX.this_ctor);
     }
     else if (aHalt)
     {
+        // Branch a halts, but b doesn't, b takes precedence.
         ok = (b & CSX.this_ctor);
         a = b;
     }
     else
     {
+        // Neither branch returns nor halts, merge flags.
         ok = !((a ^ b) & CSX.this_ctor);
         a |= b;
     }

--- a/src/dmd/ctorflow.d
+++ b/src/dmd/ctorflow.d
@@ -194,7 +194,6 @@ bool mergeFieldInit(ref CSX a, const CSX b) pure nothrow
     if (!bHalt && bRet)
     {
         ok = (b & CSX.this_ctor);
-        a = a;
     }
     else if (!aHalt && aRet)
     {
@@ -204,7 +203,6 @@ bool mergeFieldInit(ref CSX a, const CSX b) pure nothrow
     else if (bHalt)
     {
         ok = (a & CSX.this_ctor);
-        a = a;
     }
     else if (aHalt)
     {


### PR DESCRIPTION
@WalterBright - I'm not sure whether or not this was really a typo and it should have been `a = b`.