### PR TITLE
d_do_test: Use flock instead of File.lock on SemaphoreCI

### DIFF
--- a/semaphoreci.sh
+++ b/semaphoreci.sh
@@ -17,6 +17,10 @@ export DMD=${DMD:-dmd}         # can be {dmd,ldc,gdc}
 export N=4
 export OS_NAME=linux
 export FULL_BUILD="${PULL_REQUEST_NUMBER+false}"
+
+# File.lock() doesn't work reliable, use flock() instead
+export USE_FLOCK=1
+
 # SemaphoreCI doesn't provide a convenient way to the base branch (e.g. master or stable)
 if [ -n "${PULL_REQUEST_NUMBER:-}" ]; then
     BRANCH=$((curl -fsSL https://api.github.com/repos/dlang/dmd/pulls/$PULL_REQUEST_NUMBER || echo) | jq -r '.base.ref')

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -152,6 +152,7 @@ immutable(EnvData) processEnvironment()
     envData.printRuntime   = environment.get("PRINT_RUNTIME", "") == "1";
     envData.tryDisabled    = environment.get("TRY_DISABLED") == "1";
     envData.useFlock       = environment.get("USE_FLOCK") == "1";
+    writeln("useFlock = ", envData.useFlock);
 
     if (envData.ccompiler.empty)
     {


### PR DESCRIPTION
`File.lock` (which uses `fcntl`) doesn't work properly on recent Ubuntu,
so use `flock()` as a fallback.