### PR TITLE
Fix issue 20825: paths in error messages from build.d should be click…

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -63,7 +63,9 @@ int main(string[] args)
     }
     catch (BuildException e)
     {
-        writeln(e.msg);
+        // Ensure paths are relative to the root directory
+        // s.t. error messages are clickable in most IDE's
+        writeln(e.msg.replace(buildPath("dmd", ""), buildPath("src", "dmd", "")));
         return 1;
     }
 }


### PR DESCRIPTION
…able.

Just to improve the current development process.

Before:
```
[...]
-----------------------------------------------------------
ERROR: dmd/expression.d(763): Error: undefined identifier `xxx`
```
After:
```
[...]
-----------------------------------------------------------
ERROR: src/dmd/expression.d(763): Error: undefined identifier `xxx`
```