### PR TITLE
Fix Issue 20840 - No deprecation for template from deprecated selecti…

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -6299,6 +6299,14 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 }
             }
 
+            // The template might originate from a selective import which implies that
+            // s is a lowered AliasDeclaration of the actual TemplateDeclaration.
+            // This is the last place where we see the deprecated alias because it is
+            // stripped below, so check if the selective import was deprecated.
+            // See https://issues.dlang.org/show_bug.cgi?id=20840.
+            if (s.isAliasDeclaration())
+                s.checkDeprecated(this.loc, sc);
+
             if (!updateTempDecl(sc, s))
             {
                 return false;

--- a/test/fail_compilation/deprecatedImports.d
+++ b/test/fail_compilation/deprecatedImports.d
@@ -1,0 +1,31 @@
+/*
+REQUIRED_ARGS: -de
+EXTRA_FILES: imports/deprecatedImporta.d imports/deprecatedImportb.d
+
+TEST_OUTPUT:
+----
+fail_compilation/deprecatedImports.d(19): Deprecation: alias `deprecatedImporta.foo` is deprecated - Please import deprecatedImportb directly!
+fail_compilation/deprecatedImports.d(21): Deprecation: alias `deprecatedImporta.bar` is deprecated - Please import deprecatedImportb directly!
+fail_compilation/deprecatedImports.d(23): Deprecation: alias `deprecatedImporta.AliasSeq` is deprecated - Please import deprecatedImportb directly!
+fail_compilation/deprecatedImports.d(27): Deprecation: alias `deprecatedImporta.S` is deprecated - Please import deprecatedImportb directly!
+fail_compilation/deprecatedImports.d(29): Deprecation: alias `deprecatedImporta.C` is deprecated - Please import deprecatedImportb directly!
+fail_compilation/deprecatedImports.d(31): Deprecation: alias `deprecatedImporta.I` is deprecated - Please import deprecatedImportb directly!
+fail_compilation/deprecatedImports.d(25): Deprecation: alias `deprecatedImporta.E` is deprecated - Please import deprecatedImportb directly!
+----
+*/
+
+import imports.deprecatedImporta;
+
+alias f = foo;
+
+alias b = bar!(int);
+
+alias Types = AliasSeq!(int);
+
+int x = E;
+
+S s;
+
+C c;
+
+I i;

--- a/test/fail_compilation/imports/deprecatedImporta.d
+++ b/test/fail_compilation/imports/deprecatedImporta.d
@@ -1,0 +1,2 @@
+deprecated("Please import deprecatedImportb directly!")
+public import imports.deprecatedImportb : AliasSeq, foo, bar, E, S, C, I;

--- a/test/fail_compilation/imports/deprecatedImportb.d
+++ b/test/fail_compilation/imports/deprecatedImportb.d
@@ -1,0 +1,13 @@
+alias AliasSeq(T...) = T;
+
+void foo() {}
+
+void bar(T)(T t) {}
+
+enum E = 2;
+
+struct S {}
+
+class C {}
+
+interface I {}


### PR DESCRIPTION
…ve import

Selective imports are lowered to an AliasDeclarations which were discarded when
resolving the actual TemplateDeclaration. So make sure to check the AD as well.