### PR TITLE
Fix Issue 20842 - Structs with disabled default/copy ctors can't be i…

### DIFF
--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -607,6 +607,41 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     {
         return index < numArgTypes() ? (*argTypes.arguments)[index].type : null;
     }
+
+    final bool hasNonDisabledCtor()
+    {
+        static extern (C++) class HasNonDisabledCtorVisitor : Visitor
+        {
+            bool result;
+
+            this() {}
+
+            alias visit = Visitor.visit;
+
+            override void visit(CtorDeclaration cd)
+            {
+                if (!(cd.storage_class & STC.disable))
+                    result = true;
+            }
+
+            override void visit(TemplateDeclaration td)
+            {
+                result = true;
+            }
+
+            override void visit(OverloadSet os)
+            {
+                for (size_t i = 0; i < os.a.dim; i++)
+                    os.a[i].accept(this);
+            }
+        }
+
+        if (!ctor)
+            return false;
+        scope v = new HasNonDisabledCtorVisitor();
+        ctor.accept(v);
+        return v.result;
+    }
 }
 
 /**********************************

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -111,7 +111,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
         if (t.ty == Tstruct)
         {
             StructDeclaration sd = (cast(TypeStruct)t).sym;
-            if (sd.ctor)
+            if (sd.hasNonDisabledCtor())
             {
                 error(i.loc, "%s `%s` has constructors, cannot use `{ initializers }`, use `%s( initializers )` instead", sd.kind(), sd.toChars(), sd.toChars());
                 return new ErrorInitializer();

--- a/test/compilable/test20842.d
+++ b/test/compilable/test20842.d
@@ -1,0 +1,33 @@
+// https://issues.dlang.org/show_bug.cgi?id=20842
+
+struct A
+{
+    int i;
+    @disable this(ref A);
+}
+
+A a = { i: 123 };
+
+struct B
+{
+    int i;
+    @disable this();
+}
+
+B b = { i: 123 };
+
+union C
+{
+    int i;
+    @disable this(ref C);
+}
+
+C c = { i: 123 };
+
+union D
+{
+    int i;
+    @disable this();
+}
+
+D d = { i: 123 };


### PR DESCRIPTION
…nitialized

A struct must now have at least one non-`@disable`d constructor to be
ineligible for brace initialization.