### PR TITLE
[RFC] Don't consider onemember in TemplateDeclaration.kind

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -704,7 +704,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
     override const(char)* kind() const
     {
-        return (onemember && onemember.isAggregateDeclaration()) ? onemember.kind() : "template";
+        return "template";
     }
 
     override const(char)* toChars() const

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1143,8 +1143,8 @@ public:
         }
         if ((hgs.hdrgen || hgs.fullDump) && visitEponymousMember(d))
             return;
-        if (hgs.ddoc)
-            buf.writestring(d.kind());
+        if (hgs.ddoc && d.onemember && d.onemember.isAggregateDeclaration)
+            buf.writestring(d.onemember.kind());
         else
             buf.writestring("template");
         buf.writeByte(' ');

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1604,7 +1604,7 @@ extern(C++) Type typeSemantic(Type t, const ref Loc loc, Scope* sc)
             {
                 auto td = s.isTemplateDeclaration;
                 if (td && td.onemember && td.onemember.isAggregateDeclaration)
-                    .error(loc, "template %s `%s` is used as a type without instantiation"
+                    .error(loc, "%s `%s` is used as a type without instantiation"
                         ~ "; to instantiate it use `%s!(arguments)`",
                         s.kind, s.toPrettyChars, s.ident.toChars);
                 else

--- a/test/fail_compilation/diag14235.d
+++ b/test/fail_compilation/diag14235.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag14235.d(11): Error: template identifier `Undefined` is not a member of module `imports.a14235`
-fail_compilation/diag14235.d(12): Error: template identifier `Something` is not a member of module `imports.a14235`, did you mean struct `SomeThing(T...)`?
+fail_compilation/diag14235.d(12): Error: template identifier `Something` is not a member of module `imports.a14235`, did you mean template `SomeThing(T...)`?
 fail_compilation/diag14235.d(13): Error: `imports.a14235.SomeClass` is not a template, it is a class
 ---
 */

--- a/test/fail_compilation/ice11518.d
+++ b/test/fail_compilation/ice11518.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11518.d(17): Error: class `ice11518.B` matches more than one template declaration:
+fail_compilation/ice11518.d(17): Error: template `ice11518.B` matches more than one template declaration:
 fail_compilation/ice11518.d(12):     `B(T : A!T)`
 and
 fail_compilation/ice11518.d(13):     `B(T : A!T)`

--- a/test/fail_compilation/ice14907.d
+++ b/test/fail_compilation/ice14907.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14907.d(14): Error: struct `ice14907.S(int v = S)` recursive template expansion
+fail_compilation/ice14907.d(14): Error: template `ice14907.S(int v = S)` recursive template expansion
 fail_compilation/ice14907.d(19):        while looking for match for `S!()`
 fail_compilation/ice14907.d(15): Error: template `ice14907.f(int v = f)()` recursive template expansion
 fail_compilation/ice14907.d(20):        while looking for match for `f!()`

--- a/test/fail_compilation/ice20057.d
+++ b/test/fail_compilation/ice20057.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice20057.d(9): Error: alias `ice20057.BlackHole` conflicts with struct `ice20057.BlackHole(alias T)` at fail_compilation/ice20057.d(8)
+fail_compilation/ice20057.d(9): Error: alias `ice20057.BlackHole` conflicts with template `ice20057.BlackHole(alias T)` at fail_compilation/ice20057.d(8)
 ---
 */
 

--- a/test/fail_compilation/notype.d
+++ b/test/fail_compilation/notype.d
@@ -22,10 +22,10 @@ t tv;
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/notype.d(4): Error: template struct `notype.S(int var = 3)` is used as a type without instantiation; to instantiate it use `S!(arguments)`
+fail_compilation/notype.d(4): Error: template `notype.S(int var = 3)` is used as a type without instantiation; to instantiate it use `S!(arguments)`
 fail_compilation/notype.d(7): Error: template `notype.A()` is used as a type
 fail_compilation/notype.d(10): Error: template `notype.e()` is used as a type
-fail_compilation/notype.d(15): Error: template interface `notype.I()` is used as a type without instantiation; to instantiate it use `I!(arguments)`
+fail_compilation/notype.d(15): Error: template `notype.I()` is used as a type without instantiation; to instantiate it use `I!(arguments)`
 fail_compilation/notype.d(20): Error: template `notype.t()` is used as a type
 ---
 */

--- a/test/fail_compilation/traits.d
+++ b/test/fail_compilation/traits.d
@@ -18,11 +18,11 @@ fail_compilation/traits.d(202): Error: expected 1 arguments for `isPackage` but 
 fail_compilation/traits.d(203): Error: expected 1 arguments for `isModule` but had 0
 fail_compilation/traits.d(300): Error: In expression `__traits(allMembers, float)` `float` can't have members
 fail_compilation/traits.d(300):        `float` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation
-fail_compilation/traits.d(306): Error: In expression `__traits(allMembers, TemplatedStruct)` struct `TemplatedStruct(T)` has no members
+fail_compilation/traits.d(306): Error: In expression `__traits(allMembers, TemplatedStruct)` template `TemplatedStruct(T)` has no members
 fail_compilation/traits.d(306):        `TemplatedStruct(T)` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation
 fail_compilation/traits.d(309): Error: In expression `__traits(derivedMembers, float)` `float` can't have members
 fail_compilation/traits.d(309):        `float` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation
-fail_compilation/traits.d(316): Error: In expression `__traits(derivedMembers, TemplatedStruct)` struct `TemplatedStruct(T)` has no members
+fail_compilation/traits.d(316): Error: In expression `__traits(derivedMembers, TemplatedStruct)` template `TemplatedStruct(T)` has no members
 fail_compilation/traits.d(316):        `TemplatedStruct(T)` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation
 ---
 */


### PR DESCRIPTION
This usually yields better error messages and makes it more explicit when other code cares about `onemember`.
This also avoids special cases when implementing proper derpecations for templates (WIP).

Let me know what you think,