### PR TITLE
Fix Issue 20744 - Using __parameters result in function definition ca…

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -1428,9 +1428,15 @@ extern (C++) final class UserAttributeDeclaration : AttribDeclaration
             if (isGNUABITag(exp))
             {
                 if (sym.isCPPNamespaceDeclaration() || sym.isNspace())
+                {
                     exp.error("`@%s` cannot be applied to namespaces", Id.udaGNUAbiTag.toChars());
+                    sym.errors = true;
+                }
                 else if (linkage != LINK.cpp)
+                {
                     exp.error("`@%s` can only apply to C++ symbols", Id.udaGNUAbiTag.toChars());
+                    sym.errors = true;
+                }
                 // Only one `@gnuAbiTag` is allowed by semantic2
                 return;
             }

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2199,6 +2199,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         //printf("UserAttributeDeclaration::semantic() %p\n", this);
         if (uad.decl && !uad._scope)
             uad.Dsymbol.setScope(sc); // for function local symbols
+        arrayExpressionSemantic(uad.atts, sc, true);
         return attribSemantic(uad);
     }
 

--- a/test/compilable/test20744.d
+++ b/test/compilable/test20744.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=20744
+
+struct A {
+    struct S {}
+    void f(@S int = 3);
+    alias fun = Issue20744!f;
+}
+
+template Issue20744(func...) {
+    static if (is(typeof(func[0]) PT == __parameters)) {
+        alias Issue20744 = (PT args) {};
+    }
+}

--- a/test/fail_compilation/cpp_abi_tag.d
+++ b/test/fail_compilation/cpp_abi_tag.d
@@ -2,14 +2,14 @@
 REQUIRED_ARGS: -extern-std=c++11
 TEST_OUTPUT:
 ---
+fail_compilation/cpp_abi_tag.d(111): Error: `@gnuAbiTag` can only apply to C++ symbols
+fail_compilation/cpp_abi_tag.d(131): Error: `@gnuAbiTag` cannot be applied to namespaces
 fail_compilation/cpp_abi_tag.d(102): Error: `@gnuAbiTag` at least one argument expected
 fail_compilation/cpp_abi_tag.d(105): Error: `@gnuAbiTag` at least one argument expected
 fail_compilation/cpp_abi_tag.d(108): Error: `@gnuAbiTag` char `0x99` not allowed in mangling
-fail_compilation/cpp_abi_tag.d(111): Error: `@gnuAbiTag` can only apply to C++ symbols
 fail_compilation/cpp_abi_tag.d(114): Error: argument `2` to `@gnuAbiTag` cannot be `null`
 fail_compilation/cpp_abi_tag.d(114): Error: argument `3` to `@gnuAbiTag` cannot be empty
 fail_compilation/cpp_abi_tag.d(117): Error: `@gnuAbiTag` at least one argument expected
-fail_compilation/cpp_abi_tag.d(131): Error: `@gnuAbiTag` cannot be applied to namespaces
 fail_compilation/cpp_abi_tag.d(137): Error: only one `@gnuAbiTag` allowed per symbol
 fail_compilation/cpp_abi_tag.d(137):        instead of `@gnuAbiTag(["x"]) @gnuAbiTag(["a"])`, use `@gnuAbiTag("x", "a")`
 ---


### PR DESCRIPTION
…uses wrong lookup

Run semantic on expressions inside the UDA to be sure things gets added to theirs corresponding scope.