### PR TITLE
d_do_test: Use lock for both gdb .d and .sh tests

### DIFF
--- a/test/runnable/gdb15729.sh
+++ b/test/runnable/gdb15729.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
-
+GDB_SCRIPT="
+b lib15729.d:16
+r
+echo RESULT=
+p s.val
+"
 
 $DMD -g -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${LIBEXT} -lib ${EXTRA_FILES}${SEP}lib15729.d
 $DMD -g -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}gdb15729.d ${OUTPUT_BASE}${LIBEXT}
 
 if [ $OS == "linux" ]; then
-    cat > ${OUTPUT_BASE}.gdb <<-EOF
-       b lib15729.d:16
-       r
-       echo RESULT=
-       p s.val
-EOF
+    echo "${GDB_SCRIPT}" > ${OUTPUT_BASE}.gdb
     gdb ${OUTPUT_BASE}${EXE} --batch -x ${OUTPUT_BASE}.gdb | grep 'RESULT=.*1234'
 fi
 


### PR DESCRIPTION
If @MoonlightSentinel is right about it being a lock file problem.  _Maybe_ using the same locking mechanism for both GDB D and Shell scripts might do the trick?

(I'll rebuild semaphoreci pipelines a few times to try to trigger a failure).