### PR TITLE
Fix issue 15235: inline asm: silent ICE (segfault) in asm_add_exp()

### DIFF
--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -2294,9 +2294,10 @@ private void asm_merge_opnds(ref OPND o1, ref OPND o2)
     {
         debug psz = "o1.s && os.s";
 ILLEGAL_ADDRESS_ERROR:
-        debug printf("Invalid addr because /%s/\n", psz);
+        debug (debuga) printf("Invalid addr because /%s/\n", psz);
 
         error(asmstate.loc, "cannot have two symbols in addressing mode");
+        return;
     }
     else if (o2.s)
     {

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -1274,7 +1274,7 @@ opflag_t asm_determine_operand_flags(OPND *popnd)
     if (popnd.base && !popnd.s && !popnd.disp && !popnd.vreal)
             return popnd.base.ty;
     debug (debuga)
-        printf("popnd.base = %s\n, popnd.pregDisp1 = %p\n", popnd.base ? popnd.base.regstr : "NONE", popnd.pregDisp1);
+        printf("popnd.base = %s\n, popnd.pregDisp1 = %p\n", (popnd.base ? popnd.base.regstr : "NONE").ptr, popnd.pregDisp1);
 
     ps = popnd.s;
     Declaration ds = ps ? ps.isDeclaration() : null;
@@ -2269,9 +2269,9 @@ private void asm_merge_opnds(ref OPND o1, ref OPND o2)
     debug (EXTRA_DEBUG) debug (debuga)
     {
         printf("asm_merge_opnds(o1 = ");
-        asm_output_popnd(o1);
+        asm_output_popnd(&o1);
         printf(", o2 = ");
-        asm_output_popnd(o2);
+        asm_output_popnd(&o2);
         printf(")\n");
     }
     debug (EXTRA_DEBUG)
@@ -2411,7 +2411,7 @@ ILLEGAL_ADDRESS_ERROR:
     debug (debuga)
     {
         printf("Merged result = /");
-        asm_output_popnd(o1);
+        asm_output_popnd(&o1);
         printf("/\n");
     }
 }

--- a/test/fail_compilation/diag15235.d
+++ b/test/fail_compilation/diag15235.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag15235.d(11): Error: cannot have two symbols in addressing mode
+---
+*/
+
+void main()
+{
+    asm {
+        mov [EBX+EBX+EBX], EAX; // prints the same error message 20 times
+    }
+}


### PR DESCRIPTION
return once the first memory error is found rather than falling through and goto-ing back to it a bunch of times

Also, this file looks like it could use some refactoring.  I may look into that next