### PR TITLE
recognize isAlias template pattern(s), process directly

### DIFF
--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -67,6 +67,7 @@ public:
     bool ismixin;               // template declaration is only to be used as a mixin
     bool isstatic;              // this is static template declaration
     bool isAliasSeq;            // matches `template AliasSeq(T...) { alias AliasSeq = T; }
+    bool isAlias;               // matches `template Alias(T) { alias Alias = T; }
     Prot protection;
     int inuse;                  // for recursive expansion detection
 


### PR DESCRIPTION
Recognizes the patterns:
```
template Alias(T) { alias Alias = T; }
template InoutOf(T) { alias InoutOf       =        inout(T) ; }
template ConstOf(T) { alias ConstOf       =        const(T) ; }
template SharedOf(T) { alias SharedOf      =       shared(T) ; }
template SharedInoutOf(T) { alias SharedInoutOf = shared(inout(T)); }
template SharedConstOf(T) { alias SharedConstOf = shared(const(T)); }
template ImmutableOf(T) { alias ImmutableOf   =    immutable(T) ; }
```
and handles them directly rather than going through the template instantiation process.