### PR TITLE
Add explicit @system attribute to extern functions

### DIFF
--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -273,7 +273,7 @@ struct seg_data
         int isCode() { return seg_data_isCode(this); }
 }
 
-extern int seg_data_isCode(const ref seg_data sd);
+extern int seg_data_isCode(const ref seg_data sd) @system;
 
 struct linnum_data
 {
@@ -316,8 +316,8 @@ struct FuncParamRegs
     const(ubyte)* floatregs;    // map to fp register
 }
 
-extern FuncParamRegs FuncParamRegs_create(tym_t tyf);
-extern int FuncParamRegs_alloc(ref FuncParamRegs fpr, type *t, tym_t ty, reg_t *preg1, reg_t *preg2);
+extern FuncParamRegs FuncParamRegs_create(tym_t tyf) @system;
+extern int FuncParamRegs_alloc(ref FuncParamRegs fpr, type *t, tym_t ty, reg_t *preg1, reg_t *preg2) @system;
 
 extern __gshared
 {

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -53,7 +53,7 @@ static if (ELFOBJ)
 import dmd.backend.dwarf;
 import dmd.backend.melf;
 
-extern bool symbol_iscomdat2(Symbol* s);
+extern bool symbol_iscomdat2(Symbol* s) @system;
 
 static if (TARGET_LINUX)
     enum ELFOSABI = ELFOSABI_LINUX;


### PR DESCRIPTION
Needed for compatibility with @safe-by-default.

---

Found using the deprecation message in https://github.com/dlang/dmd/pull/11176.