### PR TITLE
Fix issue 20861: Interface implementations are not checked when code gen is skipped

### DIFF
--- a/changelog/check_interface_implementations.dd
+++ b/changelog/check_interface_implementations.dd
@@ -1,0 +1,25 @@
+Properly check interface implementations
+
+In previous releases the check to verify that a class implements all methods of
+the interfaces it implements was performed late in the compilation phase. This
+caused the check to not be performed when code generation was skipped
+(compiling with the `-o-` flag).
+
+In this release the check has been moved to an earlier phase of the compilation,
+causing errors to be reported even when the `-o-` flag is used. This can cause
+some breakage if a piece of code has only been compiled with the `-o-` flag.
+
+The compiler will now properly report an error for the following code when the
+`-o-` flag is used:
+
+```
+interface Foo
+{
+    void foo();
+}
+
+class Bar : Foo
+{
+
+}
+```

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -85,40 +85,20 @@ extern (C++) struct BaseClass
         for (size_t j = sym.vtblOffset(); j < sym.vtbl.dim; j++)
         {
             FuncDeclaration ifd = sym.vtbl[j].isFuncDeclaration();
-            FuncDeclaration fd;
-            TypeFunction tf;
 
             //printf("        vtbl[%d] is '%s'\n", j, ifd ? ifd.toChars() : "null");
             assert(ifd);
 
             // Find corresponding function in this class
-            tf = ifd.type.toTypeFunction();
-            fd = cd.findFunc(ifd.ident, tf);
+            auto tf = ifd.type.toTypeFunction();
+            auto fd = cd.findFunc(ifd.ident, tf);
             if (fd && !fd.isAbstract())
             {
-                //printf("            found\n");
-                // Check that calling conventions match
-                if (fd.linkage != ifd.linkage)
-                    fd.error("linkage doesn't match interface function");
-
-                // Check that it is current
-                //printf("newinstance = %d fd.toParent() = %s ifd.toParent() = %s\n",
-                    //newinstance, fd.toParent().toChars(), ifd.toParent().toChars());
-                if (newinstance && fd.toParent() != cd && ifd.toParent() == sym)
-                    cd.error("interface function `%s` is not implemented", ifd.toFullSignature());
-
                 if (fd.toParent() == cd)
                     result = true;
             }
             else
-            {
-                //printf("            not found %p\n", fd);
-                // BUG: should mark this class as abstract?
-                if (!cd.isAbstract())
-                    cd.error("interface function `%s` is not implemented", ifd.toFullSignature());
-
                 fd = null;
-            }
             if (vtbl)
                 (*vtbl)[j] = fd;
         }

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4859,6 +4859,47 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(ClassDeclaration cldec)
     {
+        /// Checks that the given class implements all methods of its interfaces.
+        static void checkInterfaceImplementations(ClassDeclaration cd)
+        {
+            foreach (base; cd.interfaces)
+            {
+                // first entry is ClassInfo reference
+                auto methods = base.sym.vtbl[base.sym.vtblOffset .. $];
+
+                foreach (m; methods)
+                {
+                    auto ifd = m.isFuncDeclaration;
+                    assert(ifd);
+
+                    auto type = ifd.type.toTypeFunction();
+                    auto fd = cd.findFunc(ifd.ident, type);
+
+                    if (fd && !fd.isAbstract)
+                    {
+                        //printf("            found\n");
+                        // Check that calling conventions match
+                        if (fd.linkage != ifd.linkage)
+                            fd.error("linkage doesn't match interface function");
+
+                        // Check that it is current
+                        //printf("newinstance = %d fd.toParent() = %s ifd.toParent() = %s\n",
+                            //newinstance, fd.toParent().toChars(), ifd.toParent().toChars());
+                        if (fd.toParent() != cd && ifd.toParent() == base.sym)
+                            cd.error("interface function `%s` is not implemented", ifd.toFullSignature());
+                    }
+
+                    else
+                    {
+                        //printf("            not found %p\n", fd);
+                        // BUG: should mark this class as abstract?
+                        if (!cd.isAbstract())
+                            cd.error("interface function `%s` is not implemented", ifd.toFullSignature());
+                    }
+                }
+            }
+        }
+
         //printf("ClassDeclaration.dsymbolSemantic(%s), type = %p, sizeok = %d, this = %p\n", cldec.toChars(), cldec.type, cldec.sizeok, this);
         //printf("\tparent = %p, '%s'\n", sc.parent, sc.parent ? sc.parent.toChars() : "");
         //printf("sc.stc = %x\n", sc.stc);
@@ -5501,6 +5542,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (0 &&          // deprecation disabled for now to accommodate existing extensive use
             cldec.storage_class & STC.scope_)
             deprecation(cldec.loc, "`scope` as a type constraint is deprecated.  Use `scope` at the usage site.");
+
+        checkInterfaceImplementations(cldec);
     }
 
     override void visit(InterfaceDeclaration idec)

--- a/src/dmd/root/string.d
+++ b/src/dmd/root/string.d
@@ -107,7 +107,7 @@ unittest
  * | Line separator      |                   | `U+2028`           |
  * | Paragraph separator |                   | `U+2029`           |
  *
- * This function will also strip `\n\r`.
+ * This function will also strip `\r\n`.
  */
 string stripLeadingLineTerminator(string str) pure nothrow @nogc @safe
 {
@@ -115,18 +115,20 @@ string stripLeadingLineTerminator(string str) pure nothrow @nogc @safe
     enum lineSeparator = "\xE2\x80\xA8";
     enum paragraphSeparator = "\xE2\x80\xA9";
 
+    static assert(lineSeparator.length == paragraphSeparator.length);
+
     if (str.length == 0)
         return str;
 
     switch (str[0])
     {
-        case '\n':
+        case '\r':
         {
-            if (str.length >= 2 && str[1] == '\r')
+            if (str.length >= 2 && str[1] == '\n')
                 return str[2 .. $];
             goto case;
         }
-        case '\v', '\f', '\r': return str[1 .. $];
+        case '\v', '\f', '\n': return str[1 .. $];
 
         case nextLine[0]:
         {
@@ -138,12 +140,12 @@ string stripLeadingLineTerminator(string str) pure nothrow @nogc @safe
 
         case lineSeparator[0]:
         {
-            if (str.length >= 3)
+            if (str.length >= lineSeparator.length)
             {
-                const prefix = str[0 .. 3];
+                const prefix = str[0 .. lineSeparator.length];
 
                 if (prefix == lineSeparator || prefix == paragraphSeparator)
-                    return str[3 .. $];
+                    return str[lineSeparator.length .. $];
             }
 
             return str;
@@ -166,7 +168,8 @@ unittest
     assert("\u0085foo".stripLeadingLineTerminator == "foo");
     assert("\u2028foo".stripLeadingLineTerminator == "foo");
     assert("\u2029foo".stripLeadingLineTerminator == "foo");
-    assert("\n\rfoo".stripLeadingLineTerminator == "foo");
+    assert("\n\rfoo".stripLeadingLineTerminator == "\rfoo");
+    assert("\r\nfoo".stripLeadingLineTerminator == "foo");
 }
 
 /**

--- a/test/fail_compilation/diag8318.d
+++ b/test/fail_compilation/diag8318.d
@@ -16,7 +16,8 @@ class Bar8318 : Foo8318
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8318.d(24): Error: function `diag8318.C10021.makeI` return type inference is not supported if may override base class function
+fail_compilation/diag8318.d(25): Error: function `diag8318.C10021.makeI` return type inference is not supported if may override base class function
+fail_compilation/diag8318.d(25): Error: class `diag8318.C10021` interface function `I10021 makeI()` is not implemented
 ---
 */
 interface I10021 { I10021 makeI(); }
@@ -26,7 +27,8 @@ class C10021 : I10021 { auto   makeI() { return this; } }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8318.d(38): Error: function `diag8318.Bar10195.baz` return type inference is not supported if may override base class function
+fail_compilation/diag8318.d(40): Error: function `diag8318.Bar10195.baz` return type inference is not supported if may override base class function
+fail_compilation/diag8318.d(38): Error: class `diag8318.Bar10195` interface function `int baz()` is not implemented
 ---
 */
 interface Foo10195
@@ -41,7 +43,7 @@ class Bar10195 : Foo10195
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8318.d(50): Error: function `diag8318.B14173.foo` does not override any function
+fail_compilation/diag8318.d(52): Error: function `diag8318.B14173.foo` does not override any function
 ---
 */
 class A14173 {}

--- a/test/fail_compilation/diag9191.d
+++ b/test/fail_compilation/diag9191.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag9191.d(16): Error: function `void diag9191.C1.aaa()` does not override any function, did you mean to override `void diag9191.B1.aa()`?
-fail_compilation/diag9191.d(21): Error: function `diag9191.C2.aaa` does not override any function
-fail_compilation/diag9191.d(31): Error: function `void diag9191.C3.foo()` does not override any function, did you mean to override `void diag9191.B2._foo()`?
-fail_compilation/diag9191.d(36): Error: function `void diag9191.C4.toStringa()` does not override any function, did you mean to override `string object.Object.toString()`?
+fail_compilation/diag9191.d(22): Error: function `diag9191.C2.aaa` does not override any function
+fail_compilation/diag9191.d(33): Error: function `void diag9191.C3.foo()` does not override any function, did you mean to override `void diag9191.B2._foo()`?
+fail_compilation/diag9191.d(38): Error: function `void diag9191.C4.toStringa()` does not override any function, did you mean to override `string object.Object.toString()`?
 ---
 */
 
@@ -14,11 +14,13 @@ class B1 { void aa(); }
 class C1 : B1, I1
 {
     override void aaa();
+    void a() {}
 }
 
 class C2 : I1
 {
     override void aaa();
+    void a() {}
 }
 
 class B2

--- a/test/fail_compilation/test17451.d
+++ b/test/fail_compilation/test17451.d
@@ -40,6 +40,6 @@ struct ThreadSlot {
         ArraySet!Task tasks;
 }
 
-class Libevent2ManualEvent {
+class Libevent2ManualEvent : ManualEvent {
         HashMap!ThreadSlot m_waiters;
 }

--- a/test/tools/unit_test_runner.d
+++ b/test/tools/unit_test_runner.d
@@ -61,11 +61,12 @@ void writeRunnerFile(Range)(Range moduleNames, string path, string filter)
 
         UnitTestResult unitTestRunner()
         {
-            import std.algorithm : canFind, each, map;
+            import std.algorithm : any, canFind, each, map;
+            import std.array : array;
             import std.conv : text;
             import std.format : format;
             import std.meta : Alias;
-            import std.range : empty, front, enumerate;
+            import std.range : chain, empty, enumerate, only, repeat;
             import std.stdio : writeln, writefln, stderr, stdout;
             import std.string : join;
             import std.traits : hasUDA, isCallable;
@@ -77,11 +78,27 @@ void writeRunnerFile(Range)(Range moduleNames, string path, string filter)
             struct Test
             {
                 Throwable throwable;
-                string name;
+                string[] descriptions;
 
-                string toString()
+                string toString(size_t i)
                 {
-                    return format!"%%s\n%%s"(name, throwable);
+                    const descs = descriptions;
+                    const index = text(i + 1) ~ ") ";
+
+                    enum fmt = "%%s%%s\n%%s";
+
+                    if (descs.length < 2)
+                        return format!fmt(index, descriptions.join(""), throwable);
+
+                    auto trailing = descs[1 .. $]
+                        .map!(e => ' '.repeat(index.length).array ~ e);
+
+                    const description = descriptions[0]
+                        .only
+                        .chain(trailing)
+                        .join("\n");
+
+                    return format!fmt(index, description, throwable);
                 }
 
                 string fileInfo()
@@ -98,8 +115,7 @@ void writeRunnerFile(Range)(Range moduleNames, string path, string filter)
             {
                 if (!failedTests.empty)
                 {
-                    alias formatTest = t =>
-                        format!"%%s) %%s"(t.index + 1, t.value.toString);
+                    alias formatTest = t => t.value.toString(t.index);
 
                     const failedTestsMessage = failedTests
                         .enumerate
@@ -160,9 +176,9 @@ void writeRunnerFile(Range)(Range moduleNames, string path, string filter)
                     {
                         static if (!attributes.empty)
                         {
-                            test.name = attributes.front;
+                            test.descriptions = attributes;
 
-                            if (attributes.front.canFind(filter))
+                            if (attributes.any!(a => a.canFind(filter)))
                             {
                                 testCount++;
                                 executeCallbacks(beforeEachCallbacks);

--- a/test/unit/compilable/crlf.d
+++ b/test/unit/compilable/crlf.d
@@ -70,7 +70,8 @@ unittest
 
     enum code = crLFCode ~ "\r\n" ~ codeLines.join('\n') ~ '\n';
 
-    assert(compiles(code));
+    const result = compiles(code);
+    assert(result, "\n" ~ result.toString);
 }
 
 private:

--- a/test/unit/interfaces/check_implementations_20861.d
+++ b/test/unit/interfaces/check_implementations_20861.d
@@ -1,0 +1,196 @@
+/**
+ * Test cases for issue [20861][1].
+ *
+ * It's intended to verify that a class implements all the methods of all
+ * interfaces it implements, even though code generation is not performed.
+ *
+ * Also https://github.com/ldc-developers/ldc/issues/3302.
+ *
+ * [1]: https://issues.dlang.org/show_bug.cgi?id=20861
+ */
+module interfaces.check_implementations_20861;
+
+import dmd.globals : Loc;
+
+import support : afterEach, beforeEach, compiles, stripDelimited, Diagnostic;
+
+@beforeEach initializeFrontend()
+{
+    import dmd.frontend : initDMD;
+    initDMD();
+}
+
+@afterEach deinitializeFrontend()
+{
+    import dmd.frontend : deinitializeDMD;
+    deinitializeDMD();
+}
+
+@("when an interface method is not implemented")
+{
+    @("it should report an error")
+    unittest
+    {
+        enum filename = "test.d";
+
+        enum code = q{
+            interface Foo
+            {
+                void foo();
+            }
+
+            class Bar : Foo { }
+        }.stripDelimited;
+
+        enum message = "Error: class test.Bar interface function void foo() is not implemented";
+        enum expected = Diagnostic(Loc(filename, 6, 1), message);
+
+        const diagnostics = compiles(code, filename);
+        assert(diagnostics == [expected], "\n" ~ diagnostics.toString);
+    }
+
+    @("when an interface method is included as a string mixin")
+    @("it should report an error")
+    unittest
+    {
+        enum filename = "test.d";
+
+        enum code = q{
+            interface Foo
+            {
+                mixin("void foo();");
+            }
+
+            class Bar : Foo { }
+        }.stripDelimited;
+
+        enum message = "Error: class test.Bar interface function void foo() is not implemented";
+        enum expected = Diagnostic(Loc(filename, 6, 1), message);
+
+        const diagnostics = compiles(code, filename);
+        assert(diagnostics == [expected], "\n" ~ diagnostics.toString);
+    }
+
+    @("when an interface method is included as a template mixin")
+    @("it should report an error")
+    unittest
+    {
+        enum filename = "test.d";
+
+        enum code = q{
+            template Baz()
+            {
+                void foo();
+            }
+
+            interface Foo
+            {
+                mixin Baz;
+            }
+
+            class Bar : Foo { }
+        }.stripDelimited;
+
+        enum message = "Error: class test.Bar interface function void foo() is not implemented";
+        enum expected = Diagnostic(Loc(filename, 11, 1), message);
+
+        const diagnostics = compiles(code, filename);
+        assert(diagnostics == [expected], "\n" ~ diagnostics.toString);
+    }
+
+    @("when an interface is not reimplemented")
+    @("it should report an error")
+    unittest
+    {
+        enum filename = "test.d";
+
+        enum code = q{
+            interface D
+            {
+                void foo();
+            }
+
+            class A : D
+            {
+                void foo() {}
+            }
+
+            class B : A, D
+            {
+            }
+        }.stripDelimited;
+
+        enum message = "Error: class test.B interface function void foo() is not implemented";
+        enum expected = Diagnostic(Loc(filename, 11, 1), message);
+
+        const diagnostics = compiles(code, filename);
+        assert(diagnostics == [expected], "\n" ~ diagnostics.toString);
+    }
+}
+
+@("when all interface methods are implemented")
+{
+    @("it should compile")
+    unittest
+    {
+        enum code = q{
+            interface Foo
+            {
+                void foo();
+            }
+
+            class Bar : Foo
+            {
+                void foo() {}
+            }
+        }.stripDelimited;
+
+        const result = compiles(code);
+        assert(result, "\n" ~ result.toString);
+    }
+
+    @("when a method is implemented using a string mixin")
+    @("it should compile")
+    unittest
+    {
+        enum code = q{
+            interface Foo
+            {
+                void foo();
+            }
+
+            class Bar : Foo
+            {
+                mixin("void foo() {}");
+            }
+        }.stripDelimited;
+
+        const result = compiles(code);
+        assert(result, "\n" ~ result.toString);
+    }
+
+    @("when a method is implemented using a template mixin")
+    @("it should compile")
+    unittest
+    {
+        enum code = q{
+            interface Foo
+            {
+                void foo();
+            }
+
+            template Baz()
+            {
+                void foo() {}
+            }
+
+            class Bar : Foo
+            {
+                mixin Baz;
+            }
+        }.stripDelimited;
+
+        const result = compiles(code);
+        assert(result, "\n" ~ result.toString);
+    }
+}


### PR DESCRIPTION
The problem being that check was performed when the vtable was generated, during code generation. If the compiler was invoked with `-o-`, which skips code generation, the check was not performed. The fix is to move the check to the semantic phase of the compilation.

This is also required for Objective-C classes, which don't have a vtable at all, even during code generation.