### PR TITLE
Fix Issue 20884 - Using getMember with a type as first argument can l…

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -933,10 +933,14 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         auto id = Identifier.idPool(se.peekString());
 
-        /* Prefer dsymbol, because it might need some runtime contexts.
+        /* Prefer a Type, because getDsymbol(Type) can lose type modifiers.
+           Then a Dsymbol, because it might need some runtime contexts.
          */
+
         Dsymbol sym = getDsymbol(o);
-        if (sym)
+        if (auto t = isType(o))
+            ex = typeDotIdExp(e.loc, t, id);
+        else if (sym)
         {
             if (e.ident == Id.hasMember)
             {
@@ -946,8 +950,6 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             ex = new DsymbolExp(e.loc, sym);
             ex = new DotIdExp(e.loc, ex, id);
         }
-        else if (auto t = isType(o))
-            ex = typeDotIdExp(e.loc, t, id);
         else if (auto ex2 = isExpression(o))
             ex = new DotIdExp(e.loc, ex2, id);
         else

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -153,3 +153,18 @@ static assert(!__traits(compiles, __traits(hasCopyConstructor)));
 static assert(!__traits(compiles, __traits(hasCopyConstructor, S())));
 static assert(!__traits(compiles, __traits(hasPostblit)));
 static assert(!__traits(compiles, __traits(hasPostblit, S())));
+
+/******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=20884
+
+struct S20884
+{
+  int x;
+}
+
+alias T20884 = immutable(S20884);
+enum m20884 = "x";
+
+static assert(is(typeof(__traits(getMember, T20884, m20884)) == immutable(int))); // OK now
+static assert(is(          typeof(mixin("T20884." ~ m20884)) == immutable(int)));
+static assert(is(                           typeof(T20884.x) == immutable(int)));


### PR DESCRIPTION
…ose type qualifiers.

This bug was extracted from issue [13343](https://issues.dlang.org/show_bug.cgi?id=13343)