### PR TITLE
gother.d: Elemdata's from linked list to Rarray

### DIFF
--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -1146,7 +1146,7 @@ private void markinvar(elem *n,vec_t rd)
                 {
                     tmp = vec_calloc(go.defnod.length);
                     //filterrd(tmp,rd,v);
-                    listrds(rd,n1,tmp);
+                    listrds(rd,n1,tmp,null);
                     for (i = 0; (i = cast(uint) vec_index(i, tmp)) < go.defnod.length; ++i)
                         if (go.defnod[i].DNelem != n &&
                             vec_testbit(go.defnod[i].DNblock.Bdfoidx,lv))
@@ -1253,7 +1253,7 @@ private void markinvar(elem *n,vec_t rd)
             {
                 tmp = vec_calloc(go.defnod.length);
                 //filterrd(tmp,rd,v);       // only the RDs pertaining to v
-                listrds(rd,n,tmp);  // only the RDs pertaining to v
+                listrds(rd,n,tmp,null);  // only the RDs pertaining to v
 
                 // if (no RDs within loop)
                 //  then it's loop invariant
@@ -1629,7 +1629,7 @@ Lnextlis:
                     //        return;
 
                     //filterrd(tmp,dfo[i].Binrd,v);
-                    listrds(dfo[i].Binrd,n.EV.E1,tmp);
+                    listrds(dfo[i].Binrd,n.EV.E1,tmp,null);
                     uint j;
                     for (j = 0; (j = cast(uint) vec_index(j, tmp)) < go.defnod.length; ++j)  // for each RD of v in Binrd
                     {
@@ -1651,7 +1651,7 @@ Lnextlis:
                 //         <can't move this assignment>
 
                 //filterrd(tmp,b.Binrd,v);
-                listrds(b.Binrd,n.EV.E1,tmp);
+                listrds(b.Binrd,n.EV.E1,tmp,null);
                 uint j;
                 for (j = 0; (j = cast(uint) vec_index(j, tmp)) < go.defnod.length; ++j)  // for each RD of v in Binrd
                 {

--- a/src/dmd/backend/go.d
+++ b/src/dmd/backend/go.d
@@ -85,7 +85,7 @@ void rmdeadass();
 void elimass(elem *);
 void deadvar();
 void verybusyexp();
-Barray!(elem*) listrds(vec_t, elem *, vec_t);
+void listrds(vec_t, elem *, vec_t, Barray!(elem*)*);
 
 /* gslice.c */
 void sliceStructs(symtab_t*, block*);

--- a/src/dmd/backend/goh.d
+++ b/src/dmd/backend/goh.d
@@ -128,7 +128,7 @@ void rmdeadass();
 void elimass(elem *);
 void deadvar();
 void verybusyexp();
-Barray!(elem*) listrds(vec_t, elem *, vec_t);
+void listrds(vec_t, elem *, vec_t, Barray!(elem*)*);
 
 /* gslice.c */
 void sliceStructs(symtab_t* symtab, block* startblock);


### PR DESCRIPTION
Change Elemdata from a threaded linked list to an Rarray, and recycle its allocations instead of malloc/free.