### PR TITLE
[dmd-cxx] posix.mak: Update C++ baseline support to C++11

### DIFF
--- a/src/backend/cg87.c
+++ b/src/backend/cg87.c
@@ -711,7 +711,7 @@ __body
 #define M_LN2_L         0x1.62e42fefa39ef358p-1L        // 0.693147 fldln2
     {0.0,1.0,M_PI_L,M_LOG2T_L,M_LOG2E_L,M_LOG2_L,M_LN2_L};
 #endif
-    static char opcode[7 + 1] =
+    static unsigned char opcode[7 + 1] =
         /* FLDZ,FLD1,FLDPI,FLDL2T,FLDL2E,FLDLG2,FLDLN2,0 */
         {0xEE,0xE8,0xEB,0xE9,0xEA,0xEC,0xED,0};
     int i;

--- a/src/backend/cgen.c
+++ b/src/backend/cgen.c
@@ -365,7 +365,7 @@ void CodeBuilder::gen2sib(unsigned op, unsigned rm, unsigned sib)
  * Generate an ASM sequence.
  */
 
-code *genasm(code *c,char *s,unsigned slen)
+code *genasm(code *c,unsigned char *s,unsigned slen)
 {   code *ce;
 
     ce = code_calloc();

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -2496,7 +2496,7 @@ code *callclib(elem *e,unsigned clib,regm_t *pretregs,regm_t keepmask)
         pop87();
 
   if (config.target_cpu >= TARGET_80386 && clib == CLIBlmul && !I32)
-  {     static char lmul[] = {
+  {     static unsigned char lmul[] = {
             0x66,0xc1,0xe1,0x10,        // shl  ECX,16
             0x8b,0xcb,                  // mov  CX,BX           ;ECX = CX,BX
             0x66,0xc1,0xe0,0x10,        // shl  EAX,16

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -423,12 +423,12 @@ void cod3_align_bytes(size_t nbytes)
         }
         else
         {
-            static const char nops[] = {
+            static const unsigned char nops[] = {
                 0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90
             }; // XCHG AX,AX
             if (n > sizeof(nops))
                 n = sizeof(nops);
-            p = nops;
+            p = (char *)nops;
         }
         objmod->write_bytes(SegData[cseg],n,const_cast<char*>(p));
         nbytes -= n;
@@ -2672,7 +2672,7 @@ L1:
                         goto L4;
                     c = genclrreg(c,reg);
                     goto inc;
-                case -1:
+                case ~(targ_size_t)0:
                     if (I64)
                         goto L4;
                     c = genclrreg(c,reg);

--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -3274,7 +3274,7 @@ code *cdasm(elem *e,regm_t *pretregs)
     /* Assume all regs are destroyed    */
     c = getregs(ALLREGS | mES);
 #endif
-    c = genasm(c,e->EV.ss.Vstring,e->EV.ss.Vstrlen);
+    c = genasm(c,(unsigned char *)e->EV.ss.Vstring,e->EV.ss.Vstrlen);
     return cat(c,fixresult(e,(I16 ? mDX | mAX : mAX),pretregs));
 }
 

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -544,7 +544,7 @@ code *gen (code *c , code *cs );
 code *gen1 (code *c , unsigned op );
 code *gen2 (code *c , unsigned op , unsigned rm );
 code *gen2sib(code *c,unsigned op,unsigned rm,unsigned sib);
-code *genasm (code *c , char *s , unsigned slen );
+code *genasm (code *c , unsigned char *s , unsigned slen );
 code *gencsi (code *c , unsigned op , unsigned rm , unsigned FL2 , SYMIDX si );
 code *gencs (code *c , unsigned op , unsigned rm , unsigned FL2 , symbol *s );
 code *genc2 (code *c , unsigned op , unsigned rm , targ_size_t EV2 );

--- a/src/backend/go.c
+++ b/src/backend/go.c
@@ -65,7 +65,7 @@ void dbg_optprint(char *);
 
 int go_flag(char *cp)
 {   unsigned i;
-    unsigned flag;
+    int flag;
 
     enum GL     // indices of various flags in flagtab[]
     {

--- a/src/backend/go.h
+++ b/src/backend/go.h
@@ -36,7 +36,7 @@ typedef unsigned mftype;        /* a type big enough for all the flags  */
 #define MFloop  0x800           // loop till no more changes
 #define MFtree  0x1000          // optelem (tree optimization)
 #define MFlocal 0x2000          // localize expressions
-#define MFall   (~0)            // do everything
+#define MFall   0xFFFF          // do everything
 
 /**********************************
  * Definition elem vector, used for reaching definitions.

--- a/src/backend/iasm.h
+++ b/src/backend/iasm.h
@@ -378,7 +378,7 @@ int asm_state(int iFlags);
 void asm_process_fixup( block **ppblockLabels );
 
 typedef struct _PTRNTAB4 {
-        unsigned usOpcode;
+        int opcode;
         unsigned usFlags;
         opflag_t usOp1;
         opflag_t usOp2;
@@ -387,7 +387,7 @@ typedef struct _PTRNTAB4 {
 } PTRNTAB4, * PPTRNTAB4, ** PPPTRNTAB4;
 
 typedef struct _PTRNTAB3 {
-        unsigned usOpcode;
+        int opcode;
         unsigned usFlags;
         opflag_t usOp1;
         opflag_t usOp2;
@@ -395,20 +395,20 @@ typedef struct _PTRNTAB3 {
 } PTRNTAB3, * PPTRNTAB3, ** PPPTRNTAB3;
 
 typedef struct _PTRNTAB2 {
-        unsigned usOpcode;
+        int opcode;
         unsigned usFlags;
         opflag_t usOp1;
         opflag_t usOp2;
 } PTRNTAB2, * PPTRNTAB2, ** PPPTRNTAB2;
 
 typedef struct _PTRNTAB1 {
-        unsigned usOpcode;
+        int opcode;
         unsigned usFlags;
         opflag_t usOp1;
 } PTRNTAB1, * PPTRNTAB1, ** PPPTRNTAB1;
 
 typedef struct _PTRNTAB0 {
-        unsigned usOpcode;
+        int opcode;
         #define ASM_END 0xffff          // special opcode meaning end of table
         unsigned usFlags;
 } PTRNTAB0, * PPTRNTAB0, ** PPPTRNTAB0;

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -2648,7 +2648,7 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                 }
 
                 val = pseg->SDbuf->size();
-                static char halts[5] = { 0xF4,0xF4,0xF4,0xF4,0xF4 };
+                static unsigned char halts[5] = { 0xF4,0xF4,0xF4,0xF4,0xF4 };
                 pseg->SDbuf->write(halts, 5);
 
                 // Add symbol s to indirectsymbuf1

--- a/src/backend/ptrntab.c
+++ b/src/backend/ptrntab.c
@@ -4120,11 +4120,11 @@ popcnt
  */
 
 PTRNTAB2 aptb2CRC32[] = /* CRC32 */ {
-        { 0xF20F38F0, _r        , _r32, _rm8  },
-        { 0xF20F38F0, _r|_64_bit, _r64, _rm8  },
-        { 0xF20F38F1, _r|_16_bit, _r32, _rm16 },
-        { 0xF20F38F1, _r|_32_bit, _r32, _rm32 },
-        { 0xF20F38F1, _r|_64_bit, _r64, _rm64 },
+        { (int)0xF20F38F0, _r        , _r32, _rm8  },
+        { (int)0xF20F38F0, _r|_64_bit, _r64, _rm8  },
+        { (int)0xF20F38F1, _r|_16_bit, _r32, _rm16 },
+        { (int)0xF20F38F1, _r|_32_bit, _r32, _rm32 },
+        { (int)0xF20F38F1, _r|_64_bit, _r64, _rm64 },
         { ASM_END }
 };
 

--- a/src/iasmdmd.c
+++ b/src/iasmdmd.c
@@ -575,7 +575,7 @@ RETRY:
         {
             //printf("opflags1 = "); asm_output_flags(opflags1); printf("\n");
             PTRNTAB1 *table1;
-            for (table1 = pop->ptb.pptb1; table1->usOpcode != ASM_END;
+            for (table1 = pop->ptb.pptb1; table1->opcode != ASM_END;
                     table1++)
             {
                 //printf("table    = "); asm_output_flags(table1->usOp1); printf("\n");
@@ -583,7 +583,7 @@ RETRY:
                 //printf("bMatch1 = x%x\n", bMatch1);
                 if (bMatch1)
                 {
-                    if (table1->usOpcode == 0x68 &&
+                    if (table1->opcode == 0x68 &&
                         table1->usOp1 == _imm16
                       )
                         // Don't match PUSH imm16 in 32 bit code
@@ -621,7 +621,7 @@ RETRY:
                 }
             }
         Lfound1:
-            if (table1->usOpcode == ASM_END)
+            if (table1->opcode == ASM_END)
             {
 #ifdef DEBUG
                 if (debuga)
@@ -697,7 +697,7 @@ TYPE_SIZE_ERROR:
             //printf("opflags2 = "); asm_output_flags(opflags2); printf("\n");
             PTRNTAB2 *table2;
             for (table2 = pop->ptb.pptb2;
-                 table2->usOpcode != ASM_END;
+                 table2->opcode != ASM_END;
                  table2++)
             {
                 //printf("table1   = "); asm_output_flags(table2->usOp1); printf(" ");
@@ -762,7 +762,7 @@ TYPE_SIZE_ERROR:
 #endif
             }
         Lfound2:
-            if (table2->usOpcode == ASM_END)
+            if (table2->opcode == ASM_END)
             {
 #ifdef DEBUG
                 if (debuga)
@@ -804,7 +804,7 @@ TYPE_SIZE_ERROR:
         {
             PTRNTAB3 *table3;
             for (table3 = pop->ptb.pptb3;
-                 table3->usOpcode != ASM_END;
+                 table3->opcode != ASM_END;
                  table3++)
             {
                 bMatch1 = asm_match_flags(opflags1, table3->usOp1);
@@ -836,7 +836,7 @@ TYPE_SIZE_ERROR:
                 }
             }
         Lfound3:
-            if (table3->usOpcode == ASM_END)
+            if (table3->opcode == ASM_END)
             {
 #ifdef DEBUG
                 if (debuga)
@@ -880,7 +880,7 @@ TYPE_SIZE_ERROR:
         {
             PTRNTAB4 *table4;
             for (table4 = pop->ptb.pptb4;
-                 table4->usOpcode != ASM_END;
+                 table4->opcode != ASM_END;
                  table4++)
             {
                 bMatch1 = asm_match_flags(opflags1, table4->usOp1);
@@ -917,7 +917,7 @@ TYPE_SIZE_ERROR:
                 }
             }
         Lfound4:
-            if (table4->usOpcode == ASM_END)
+            if (table4->opcode == ASM_END)
             {
 #ifdef DEBUG
                 if (debuga)
@@ -1390,9 +1390,9 @@ static code *asm_emit(Loc loc,
             }
             break;
     }
-    unsigned usOpcode = ptb.pptb0->usOpcode;
+    unsigned opcode = ptb.pptb0->opcode;
 
-    pc->Iop = usOpcode;
+    pc->Iop = opcode;
     if (pc->Ivex.pfx == 0xC4)
     {
 #ifdef DEBUG
@@ -1534,7 +1534,7 @@ static code *asm_emit(Loc loc,
             goto L1;
         goto L2;
     }
-    else if ((usOpcode & 0xFFFD00) == 0x0F3800)    // SSSE3, SSE4
+    else if ((opcode & 0xFFFD00) == 0x0F3800)    // SSSE3, SSE4
     {
         emit(0xFF);
         emit(0xFD);
@@ -1542,13 +1542,13 @@ static code *asm_emit(Loc loc,
         goto L3;
     }
 
-    switch (usOpcode & 0xFF0000)
+    switch (opcode & 0xFF0000)
     {
         case 0:
             break;
 
         case 0x660000:
-            usOpcode &= 0xFFFF;
+            opcode &= 0xFFFF;
             goto L3;
 
         case 0xF20000:                      // REPNE
@@ -1556,11 +1556,11 @@ static code *asm_emit(Loc loc,
             // BUG: What if there's an address size prefix or segment
             // override prefix? Must the REP be adjacent to the rest
             // of the opcode?
-            usOpcode &= 0xFFFF;
+            opcode &= 0xFFFF;
             goto L3;
 
         case 0x0F0000:                      // an AMD instruction
-            puc = ((unsigned char *) &usOpcode);
+            puc = ((unsigned char *) &opcode);
             if (puc[1] != 0x0F)             // if not AMD instruction 0x0F0F
                 goto L4;
             emit(puc[2]);
@@ -1572,7 +1572,7 @@ static code *asm_emit(Loc loc,
             goto L3;
 
         default:
-            puc = ((unsigned char *) &usOpcode);
+            puc = ((unsigned char *) &opcode);
         L4:
             emit(puc[2]);
             emit(puc[1]);
@@ -1581,9 +1581,9 @@ static code *asm_emit(Loc loc,
             pc->Irm = puc[0];
             goto L3;
     }
-    if (usOpcode & 0xff00)
+    if (opcode & 0xff00)
     {
-        puc = ((unsigned char *) &(usOpcode));
+        puc = ((unsigned char *) &(opcode));
         emit(puc[1]);
         emit(puc[0]);
         pc->Iop = puc[1];
@@ -1593,7 +1593,7 @@ static code *asm_emit(Loc loc,
         }
         else
         {
-            if (usOpcode == 0xDFE0) // FSTSW AX
+            if (opcode == 0xDFE0) // FSTSW AX
             {
                 pc->Irm = puc[0];
                 goto L2;
@@ -1611,7 +1611,7 @@ static code *asm_emit(Loc loc,
     }
     else
     {
-        emit(usOpcode);
+        emit(opcode);
     }
 L3: ;
 
@@ -1760,10 +1760,10 @@ L1:
                 (amodTable1 == _rspecial && !(uRegmaskTable1 & (0x08 | 0x10))),
                 (aoptyTable2 == _rm)
                 );
-            printf("usOpcode = %x\n", usOpcode);
+            printf("opcode = %x\n", opcode);
 #endif
-            if (ptb.pptb0->usOpcode == 0x0F7E ||    // MOVD _rm32,_mm
-                ptb.pptb0->usOpcode == 0x660F7E     // MOVD _rm32,_xmm
+            if (ptb.pptb0->opcode == 0x0F7E ||    // MOVD _rm32,_mm
+                ptb.pptb0->opcode == 0x660F7E     // MOVD _rm32,_xmm
                )
             {
                 asm_make_modrm_byte(
@@ -1838,14 +1838,14 @@ L1:
                 auchOpcode[usIdx-1] += reg;
 #endif
             }
-            else if (ptb.pptb0->usOpcode == 0xF30FD6 ||
-                     ptb.pptb0->usOpcode == 0x0F12 ||
-                     ptb.pptb0->usOpcode == 0x0F16 ||
-                     ptb.pptb0->usOpcode == 0x660F50 ||
-                     ptb.pptb0->usOpcode == 0x0F50 ||
-                     ptb.pptb0->usOpcode == 0x660FD7 ||
-                     ptb.pptb0->usOpcode == MOVDQ2Q ||
-                     ptb.pptb0->usOpcode == 0x0FD7)
+            else if (ptb.pptb0->opcode == 0xF30FD6 ||
+                     ptb.pptb0->opcode == 0x0F12 ||
+                     ptb.pptb0->opcode == 0x0F16 ||
+                     ptb.pptb0->opcode == 0x660F50 ||
+                     ptb.pptb0->opcode == 0x0F50 ||
+                     ptb.pptb0->opcode == 0x660FD7 ||
+                     ptb.pptb0->opcode == MOVDQ2Q ||
+                     ptb.pptb0->opcode == 0x0FD7)
             {
                 asm_make_modrm_byte(
 #ifdef DEBUG
@@ -1883,10 +1883,10 @@ L1:
 
     case 3:
         if (aoptyTable2 == _m || aoptyTable2 == _rm ||
-            usOpcode == 0x0FC5     ||    // pextrw  _r32,  _mm,    _imm8
-            usOpcode == 0x660FC5   ||    // pextrw  _r32, _xmm,    _imm8
-            usOpcode == 0x660F3A20 ||    // pinsrb  _xmm, _r32/m8, _imm8
-            usOpcode == 0x660F3A22       // pinsrd  _xmm, _rm32,   _imm8
+            opcode == 0x0FC5     ||    // pextrw  _r32,  _mm,    _imm8
+            opcode == 0x660FC5   ||    // pextrw  _r32, _xmm,    _imm8
+            opcode == 0x660F3A20 ||    // pinsrb  _xmm, _r32/m8, _imm8
+            opcode == 0x660F3A22       // pinsrd  _xmm, _rm32,   _imm8
            )
         {
             asm_make_modrm_byte(

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -74,7 +74,6 @@ endif
 # Compiler Warnings
 ifdef ENABLE_WARNINGS
 WARNINGS := -Wall -Wextra \
-	-Wno-narrowing \
 	-Wwrite-strings \
 	-Wno-long-long \
 	-Wno-variadic-macros \
@@ -110,7 +109,6 @@ endif
 # Clang Specific
 ifeq ($(CXX_KIND), clang++)
 WARNINGS += \
-	-Wno-c++11-narrowing \
 	-Wno-undefined-var-template \
 	-Wno-absolute-value \
 	-Wno-missing-braces \
@@ -134,7 +132,6 @@ BACK_WARNINGS := $(GLUE_WARNINGS) \
 # Clang Specific
 ifeq ($(CXX_KIND), clang++)
 WARNINGS += \
-	-Wno-c++11-narrowing \
 	-Wno-undefined-var-template \
 	-Wno-absolute-value
 GLUE_WARNINGS += \

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -159,7 +159,7 @@ CXXFLAGS := $(WARNINGS) \
 # GCC Specific
 ifeq ($(CXX_KIND), g++)
 CXXFLAGS += \
-	-std=gnu++98
+	-std=c++11
 endif
 # Clang Specific
 ifeq ($(CXX_KIND), clang++)
@@ -226,6 +226,12 @@ DMD_FLAGS  := -I$(ROOT) $(DMD_WARNINGS)
 GLUE_FLAGS := -I$(ROOT) -I$(TK) -I$(C) $(GLUE_WARNINGS)
 BACK_FLAGS := -I$(ROOT) -I$(TK) -I$(C) -I. -DDMDV2=1 $(BACK_WARNINGS)
 ROOT_FLAGS := -I$(ROOT) $(ROOT_WARNINGS)
+
+# GCC Specific
+ifeq ($(CXX_KIND), g++)
+BACK_FLAGS += \
+	-std=gnu++11
+endif
 
 ifeq ($(OS), osx)
 ifeq ($(MODEL), 64)


### PR DESCRIPTION
Only parts that needed backporting were narrowing-related fixes in #6215 and #8080.

While `-std=c++11` is used for the front-end, the back-end uses hexadecimal floats, which are part of C99, C11, C++17 standards, but not C++11.  So the back-end is built with `-std=gnu++11` instead.