### PR TITLE
Make tests pass on single-digit days of month

### DIFF
--- a/test/fail_compilation/fail7524a.d
+++ b/test/fail_compilation/fail7524a.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -o-
 TEST_OUTPUT:
 ----
 fail_compilation/fail7524a.d(10): Error: #line integer ["filespec"]\n expected
-fail_compilation/fail7524a.d(10): Error: declaration expected, not `"$r:\w+ \d+ \d+$"`
+fail_compilation/fail7524a.d(10): Error: declaration expected, not `"$r:\w+ +\d+ \d+$"`
 ----
 */
 


### PR DESCRIPTION
Previously, a regex used to match the result of __DATE__ would fail on
the 1st through 9th of a month, because it expected one space between
the month and day instead of two.