### PR TITLE
add -vtemplates switch to print template instantiation statistics

### DIFF
--- a/changelog/vtemplates.dd
+++ b/changelog/vtemplates.dd
@@ -1,0 +1,10 @@
+Add -vtemplates switch to collect and list template statistics
+
+Template instantiations can consume lots of time and memory.
+By passing the -vtemplates switch to the compiler,
+the compiler will collect and print statistics about template usage
+in the code being compiled.
+
+For each template that was instantiated, a list of how many
+times it is instantiated, and how many of those instantiations
+are unique, is printed.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -681,6 +681,9 @@ dmd -cov -unittest myprog.d
         Option("vtls",
             "list all variables going into thread local storage"
         ),
+        Option("vtemplates",
+            "list statistics on template instantiations"
+        ),
         Option("w",
             "warnings as errors (compilation will halt)",
             `Enable $(LINK2 $(ROOT_DIR)articles/warnings.html, warnings)`

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -5944,6 +5944,8 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     TemplateDeclaration tempdecl = tempinst.tempdecl.isTemplateDeclaration();
     assert(tempdecl);
 
+    TemplateStats.incInstance(tempdecl);
+
     // If tempdecl is a mixin, disallow it
     if (tempdecl.ismixin)
     {
@@ -6079,6 +6081,8 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     tempinst.inst = tempinst;
     tempinst.parent = tempinst.enclosing ? tempinst.enclosing : tempdecl.parent;
     //printf("parent = '%s'\n", parent.kind());
+
+    TemplateStats.incUnique(tempdecl.isTemplateDeclaration());
 
     TemplateInstance tempdecl_instance_idx = tempdecl.addInstance(tempinst);
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -8173,3 +8173,58 @@ MATCH matchArg(TemplateParameter tp, Scope* sc, RootObject oarg, size_t i, Templ
     else
         assert(0);
 }
+
+
+/***********************************************
+ * Collect and print statistics on template instantiations.
+ */
+struct TemplateStats
+{
+    __gshared TemplateStats[const void*] stats;
+
+    uint numInstantiations;     // number of instantiations of the template
+    uint uniqueInstantiations;  // number of unique instantiations of the template
+
+    /*******************************
+     * Add this instance
+     */
+    static void incInstance(const TemplateDeclaration td)
+    {
+        if (!global.params.vtemplates)
+            return;
+        if (!td)
+            return;
+        if (auto ts = cast(const void*) td in stats)
+            ++ts.numInstantiations;
+        else
+            stats[cast(const void*) td] = TemplateStats(1, 0);
+    }
+
+    /*******************************
+     * Add this unique instance
+     */
+    static void incUnique(const TemplateDeclaration td)
+    {
+        if (!global.params.vtemplates)
+            return;
+        if (!td)
+            return;
+        if (auto ts = cast(const void*) td in stats)
+            ++ts.uniqueInstantiations;
+        else
+            stats[cast(const void*) td] = TemplateStats(0, 1);
+    }
+}
+
+
+void printTemplateStats()
+{
+    if (!global.params.vtemplates)
+        return;
+
+    printf("  Number   Unique   Name\n");
+    foreach (td, ref ts; TemplateStats.stats)
+    {
+        printf("%8u %8u   %s\n", ts.numInstantiations, ts.uniqueInstantiations, (cast(const TemplateDeclaration) td).toChars());
+    }
+}

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -125,6 +125,7 @@ extern (C++) struct Param
     bool vcg_ast;           // write-out codegen-ast
     bool showColumns;       // print character (column) numbers in diagnostics
     bool vtls;              // identify thread local variables
+    bool vtemplates;        // collect and list statistics on template instantiations
     bool vgc;               // identify gc usage
     bool vfield;            // identify non-mutable field variables
     bool vcomplex;          // identify complex/imaginary type usage

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -104,6 +104,7 @@ struct Param
     bool vcg_ast;       // write-out codegen-ast
     bool showColumns;   // print character (column) numbers in diagnostics
     bool vtls;          // identify thread local variables
+    bool vtemplates;    // collect and list statistics on template instantiations
     bool vgc;           // identify gc usage
     bool vfield;        // identify non-mutable field variables
     bool vcomplex;      // identify complex/imaginary type usage

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -34,6 +34,7 @@ import dmd.dmodule;
 import dmd.doc;
 import dmd.dsymbol;
 import dmd.dsymbolsem;
+import dmd.dtemplate;
 import dmd.dtoh;
 import dmd.errors;
 import dmd.expression;
@@ -643,6 +644,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     }
 
     printCtfePerformanceStats();
+    printTemplateStats();
 
     Library library = null;
     if (params.lib)
@@ -1841,6 +1843,8 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             params.vcg_ast = true;
         else if (arg == "-vtls") // https://dlang.org/dmd.html#switch-vtls
             params.vtls = true;
+        else if (arg == "-vtemplates") // https://dlang.org/dmd.html#switch-vtemplates
+            params.vtemplates = true;
         else if (arg == "-vcolumns") // https://dlang.org/dmd.html#switch-vcolumns
             params.showColumns = true;
         else if (arg == "-vgc") // https://dlang.org/dmd.html#switch-vgc

--- a/test/compilable/vtemplates.d
+++ b/test/compilable/vtemplates.d
@@ -1,0 +1,17 @@
+/* REQUIRED_ARGS: -vtemplates
+TEST_OUTPUT:
+---
+  Number   Unique   Name
+       4        3   foo(int I)()
+---
+*/
+
+void foo(int I)() { }
+
+void test()
+{
+    foo!(1)();
+    foo!(1)();
+    foo!(2)();
+    foo!(3)();
+}


### PR DESCRIPTION
No more guessing which template is instantiated the most.

Possible enhancements would be things like how much time is spent instantiating each template, and how long its mangled name is.