### PR TITLE
De-virtualize toBasetype() so it is inlineable

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2191,9 +2191,13 @@ extern (C++) abstract class Type : ASTNode
      * If this is a shell around another type,
      * get that other type.
      */
-    Type toBasetype()
+    final Type toBasetype()
     {
-        return this;
+        /* This function is used heavily.
+         * De-virtualize it so it can be easily inlined.
+         */
+        TypeEnum te;
+        return ((te = isTypeEnum()) !is null) ? te.toBasetype2() : this;
     }
 
     bool isBaseOf(Type t, int* poffset)
@@ -5966,7 +5970,7 @@ extern (C++) final class TypeEnum : Type
         return MATCH.nomatch;
     }
 
-    override Type toBasetype()
+    extern (D) Type toBasetype2()
     {
         if (!sym.members && !sym.memtype)
             return this;

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -292,7 +292,7 @@ public:
     virtual Type *makeSharedWildConst();
     virtual Type *makeMutable();
     virtual Dsymbol *toDsymbol(Scope *sc);
-    virtual Type *toBasetype();
+    Type *toBasetype();
     virtual bool isBaseOf(Type *t, int *poffset);
     virtual MATCH implicitConvTo(Type *to);
     virtual MATCH constConv(Type *to);
@@ -784,7 +784,6 @@ public:
     bool needsNested();
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
-    Type *toBasetype();
     bool isZeroInit(const Loc &loc);
     bool hasPointers();
     bool hasVoidInitPointers();


### PR DESCRIPTION
@andralex profiled it as being in the dirty dozen timewasters in dmd. Address that by de-virtualizing it and making it inlineable.