### PR TITLE
Fix Issue 20894 - ICE: passing a member template mixin identifier as …

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -6612,6 +6612,14 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     sa = (cast(DotTemplateExp)ea).td;
                     goto Ldsym;
                 }
+                if (ea.op == TOK.dot)
+                {
+                    if (auto se = (cast(DotExp)ea).e2.isScopeExp())
+                    {
+                        sa = se.sds;
+                        goto Ldsym;
+                    }
+                }
             }
             else if (sa)
             {
@@ -7394,7 +7402,8 @@ bool definitelyValueParameter(Expression e)
         e.op == TOK.type || e.op == TOK.dotType ||
         e.op == TOK.template_ || e.op == TOK.dotTemplateDeclaration ||
         e.op == TOK.function_ || e.op == TOK.error ||
-        e.op == TOK.this_ || e.op == TOK.super_)
+        e.op == TOK.this_ || e.op == TOK.super_ ||
+        e.op == TOK.dot)
         return false;
 
     if (e.op != TOK.dotVariable)

--- a/test/compilable/test20894.d
+++ b/test/compilable/test20894.d
@@ -1,0 +1,46 @@
+// https://issues.dlang.org/show_bug.cgi?id=20894
+
+mixin template MT()
+{
+    int   a;
+    alias b = char;
+    void  c() {}
+}
+
+struct S
+{
+    mixin MT mt;
+}
+
+void main()
+{
+    auto r = S();
+    enum c = S();
+
+    foo!(S.mt);
+    foo!(r.mt);
+    foo!(c.mt);          // OK <- ICE
+
+    foo!(mixin("S.mt"));
+    foo!(mixin("r.mt")); // OK <- ICE
+    foo!(mixin("c.mt")); // OK <- ICE
+
+    // some checks
+    foo!(r.mt, c.mt);
+    foo!(mixin("r.mt"), c.mt);
+    foo!(r.mt, mixin("c.mt"));
+    foo!(S.mt, mixin("c.mt"));
+}
+
+alias Tup(T...) = T;
+
+void foo(A...)()
+{
+    static if (A.length == 2)
+    {
+        static assert(__traits(isSame, A[0], A[1]));
+        enum members = __traits(allMembers, A[0]);
+        static assert(members == __traits(allMembers, A[1]));
+        static assert(members == Tup!("a", "b", "c"));
+    }
+}


### PR DESCRIPTION
…alias argument

Don't run `ctfeInterpret` on a `DotExp` and extract the symbol from the `e2` (`ScopeExp`).