### PR TITLE
Get rid of obsolete __ArrayEq lowering

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -3525,29 +3525,6 @@ void fix16997(Scope* sc, UnaExp ue)
 
 /***********************************
  * See if both types are arrays that can be compared
- * for equality. Return true if so.
- * If they are arrays, but incompatible, issue error.
- * This is to enable comparing things like an immutable
- * array with a mutable one.
- */
-extern (C++) bool arrayTypeCompatible(Loc loc, Type t1, Type t2)
-{
-    t1 = t1.toBasetype().merge2();
-    t2 = t2.toBasetype().merge2();
-
-    if ((t1.ty == Tarray || t1.ty == Tsarray || t1.ty == Tpointer) && (t2.ty == Tarray || t2.ty == Tsarray || t2.ty == Tpointer))
-    {
-        if (t1.nextOf().implicitConvTo(t2.nextOf()) < MATCH.constant && t2.nextOf().implicitConvTo(t1.nextOf()) < MATCH.constant && (t1.nextOf().ty != Tvoid && t2.nextOf().ty != Tvoid))
-        {
-            error(loc, "array equality comparison type mismatch, `%s` vs `%s`", t1.toChars(), t2.toChars());
-        }
-        return true;
-    }
-    return false;
-}
-
-/***********************************
- * See if both types are arrays that can be compared
  * for equality without any casting. Return true if so.
  * This is to enable comparing things like an immutable
  * array with a mutable one.

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -306,7 +306,6 @@ immutable Msgtable[] msgtable =
     { "monitorexit", "_d_monitorexit" },
     { "criticalenter", "_d_criticalenter" },
     { "criticalexit", "_d_criticalexit" },
-    { "__ArrayEq" },
     { "__ArrayPostblit" },
     { "__ArrayDtor" },
     { "_d_delThrowable" },

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -874,7 +874,6 @@ public:
 
 /**************************************************************/
 
-bool arrayTypeCompatible(Loc loc, Type *t1, Type *t2);
 bool arrayTypeCompatibleWithoutCasting(Type *t1, Type *t2);
 
 // If the type is a class or struct, returns the symbol for it, else null.


### PR DESCRIPTION
Checking arrays of different element types for equality is handled by the (more recent) `__equals()` lowering, rendering `__ArrayEq` obsolete and enabling to get rid of duplicated functionality in druntime, see: https://github.com/dlang/druntime/blob/9ce4a36f1f4edb73683775e5824272da9e27dccc/src/core/internal/array/equality.d#L56-L65