### PR TITLE
gloop.d: recycle instead of free arrays

### DIFF
--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -83,9 +83,9 @@ nothrow:
         foreach (ref iv; Lopeqlist)
             iv.reset();
 
-        Llis.dtor();
-        Livlist.dtor();
-        Lopeqlist.dtor();
+        Llis.reset();
+        Livlist.reset();
+        Lopeqlist.reset();
     }
 
     /***********************


### PR DESCRIPTION
Found a spot I'd missed in https://github.com/dlang/dmd/pull/11180