### PR TITLE
Fix issue 20809 - return statement might access memory from destructed temporary

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5978,6 +5978,7 @@ private elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi, bo
  * Params:
  *      e = Expression to convert
  *      irs = context
+ *      refFunc = does function return a reference
  * Returns:
  *      generated elem tree
  */

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5946,7 +5946,9 @@ private elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi, bo
             {
                 *pe = el_combine(edtors, erx);
             }
-            else if (refFunc && elemIsLvalue(erx))
+            else if (refFunc && elemIsLvalue(erx) ||
+                     (tybasic(erx.Ety) == TYstruct || tybasic(erx.Ety) == TYarray) &&
+                     !(erx.ET && type_size(erx.ET) <= 16) )
             {
                 /* Lvalue, take a pointer to it
                  */

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5947,8 +5947,8 @@ private elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi, bo
                 *pe = el_combine(edtors, erx);
             }
             else if (refFunc && elemIsLvalue(erx) ||
-                     (tybasic(erx.Ety) == TYstruct || tybasic(erx.Ety) == TYarray) &&
-                     !(erx.ET && type_size(erx.ET) <= 16) )
+                     (!refFunc && (tybasic(erx.Ety) == TYstruct || tybasic(erx.Ety) == TYarray) &&
+                     !(erx.ET && type_size(erx.ET) <= 16)) )
             {
                 /* Lvalue, take a pointer to it
                  */

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -6044,43 +6044,44 @@ elem *toElemDtor2(Expression e, IRState *irs)
 
             /* Append edtors to er, while preserving the value of er
             */
-            // if (tybasic(er.Ety) == TYvoid)
-            // {
-            //     /* No value to preserve, so simply append
-            //     */
-            //     er = el_combine(er, edtors);
-            // }
-            // else
-            // {
+            if (tybasic(er.Ety) == TYvoid)
+            {
+                /* No value to preserve, so simply append
+                */
+                er = el_combine(er, edtors);
+            }
+            else
+            {
                 elem **pe;
                 for (pe = &er; (*pe).Eoper == OPcomma; pe = &(*pe).EV.E2)
                 {
                 }
                 elem *erx = *pe;
 
-                // if (erx.Eoper == OPconst || erx.Eoper == OPrelconst)
-                // {
-                //     *pe = el_combine(edtors, erx);
-                // }
-                // else if (elemIsLvalue(erx))
-                // {
-                //     /* Lvalue, take a pointer to it
-                //     */
-                //     elem *ep = el_una(OPaddr, TYnptr, erx);
-                //     elem *e = el_same(&ep);
-                //     ep = el_combine(ep, edtors);
-                //     ep = el_combine(ep, e);
-                //     e = el_una(OPind, erx.Ety, ep);
-                //     e.ET = erx.ET;
-                //     *pe = e;
-                // }
-                // else
-                // {
+                if (erx.Eoper == OPconst || erx.Eoper == OPrelconst)
+                {
+                    *pe = el_combine(edtors, erx);
+                }
+                else if ((tybasic(erx.Ety) == TYstruct || tybasic(erx.Ety) == TYarray) &&
+                     !(erx.ET && type_size(erx.ET) <= 16))
+                {
+                    /* Lvalue, take a pointer to it
+                    */
+                    elem *ep = el_una(OPaddr, TYnptr, erx);
+                    elem *e = el_same(&ep);
+                    ep = el_combine(ep, edtors);
+                    ep = el_combine(ep, e);
+                    e = el_una(OPind, erx.Ety, ep);
+                    e.ET = erx.ET;
+                    *pe = e;
+                }
+                else
+                {
                     elem *e = el_same(&erx);
                     erx = el_combine(erx, edtors);
                     *pe = el_combine(erx, e);
-                // }
-            // }
+                }
+            }
         }
         return er;
     }

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -691,7 +691,7 @@ private extern (C++) class S2irVisitor : Visitor
             }
             else
             {
-                e = toElemDtor(s.exp, irs);
+                e = toElemDtor2(s.exp, irs);
                 assert(e);
             }
         L1:

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -167,7 +167,7 @@ private extern (C++) class S2irVisitor : Visitor
         block *bexit = mystate.breakBlock ? mystate.breakBlock : dmd.backend.global.block_calloc();
 
         incUsage(irs, s.loc);
-        e = toElemDtor(s.condition, irs);
+        e = toElemDtor(s.condition, irs, false);
         block_appendexp(blx.curblock, e);
         block *bcond = blx.curblock;
         block_next(blx, BCiftrue, null);
@@ -241,7 +241,7 @@ private extern (C++) class S2irVisitor : Visitor
 
         block_next(blx, BCgoto, mystate.contBlock);
         incUsage(irs, s.condition.loc);
-        block_appendexp(mystate.contBlock, toElemDtor(s.condition, irs));
+        block_appendexp(mystate.contBlock, toElemDtor(s.condition, irs, false));
         block_next(blx, BCiftrue, mystate.breakBlock);
 
     }
@@ -268,7 +268,7 @@ private extern (C++) class S2irVisitor : Visitor
         if (s.condition)
         {
             incUsage(irs, s.condition.loc);
-            block_appendexp(bcond, toElemDtor(s.condition, irs));
+            block_appendexp(bcond, toElemDtor(s.condition, irs, false));
             block_next(blx,BCiftrue,null);
             bcond.appendSucc(blx.curblock);
             bcond.appendSucc(mystate.breakBlock);
@@ -291,7 +291,7 @@ private extern (C++) class S2irVisitor : Visitor
         if (s.increment)
         {
             incUsage(irs, s.increment.loc);
-            block_appendexp(mystate.contBlock, toElemDtor(s.increment, irs));
+            block_appendexp(mystate.contBlock, toElemDtor(s.increment, irs, false));
         }
 
         /* The 'break' block follows the for statement.
@@ -447,7 +447,7 @@ private extern (C++) class S2irVisitor : Visitor
             }
 
         incUsage(irs, s.loc);
-        elem *econd = toElemDtor(s.condition, irs);
+        elem *econd = toElemDtor(s.condition, irs, false);
         if (s.hasVars)
         {   /* Generate a sequence of if-then-else blocks for the cases.
              */
@@ -461,7 +461,7 @@ private extern (C++) class S2irVisitor : Visitor
             if (numcases)
                 foreach (cs; *s.cases)
                 {
-                    elem *ecase = toElemDtor(cs.exp, irs);
+                    elem *ecase = toElemDtor(cs.exp, irs, false);
                     elem *e = el_bin(OPeqeq, TYbool, el_copytree(econd), ecase);
                     block *b = blx.curblock;
                     block_appendexp(b, e);
@@ -586,7 +586,7 @@ private extern (C++) class S2irVisitor : Visitor
 
         //printf("SwitchErrorStatement.toIR(), exp = %s\n", s.exp ? s.exp.toChars() : "");
         incUsage(irs, s.loc);
-        block_appendexp(blx.curblock, toElemDtor(s.exp, irs));
+        block_appendexp(blx.curblock, toElemDtor(s.exp, irs, false));
     }
 
     /**************************************
@@ -635,7 +635,7 @@ private extern (C++) class S2irVisitor : Visitor
                         if (t.ty == Tfunction && retStyle(cast(TypeFunction)t, ce.f && ce.f.needThis()) == RET.stack)
                         {
                             irs.ehidden = el_var(irs.shidden);
-                            e = toElemDtor(s.exp, irs);
+                            e = toElemDtor(s.exp, irs, false);
                             e = el_una(OPaddr, TYnptr, e);
                             goto L1;
                         }
@@ -657,13 +657,13 @@ private extern (C++) class S2irVisitor : Visitor
                         if (t.ty == Tfunction && retStyle(cast(TypeFunction)t, fd && fd.needThis()) == RET.stack)
                         {
                             irs.ehidden = el_var(irs.shidden);
-                            e = toElemDtor(s.exp, irs);
+                            e = toElemDtor(s.exp, irs, false);
                             e = el_una(OPaddr, TYnptr, e);
                             goto L1;
                         }
                     }
                 }
-                e = toElemDtor(s.exp, irs);
+                e = toElemDtor(s.exp, irs, false);
                 assert(e);
 
                 if (writetohp ||
@@ -686,12 +686,12 @@ private extern (C++) class S2irVisitor : Visitor
             else if (tf.isref)
             {
                 // Reference return, so convert to a pointer
-                e = toElemDtor(s.exp, irs);
+                e = toElemDtor(s.exp, irs, true);
                 e = addressElem(e, s.exp.type.pointerTo());
             }
             else
             {
-                e = toElemDtor2(s.exp, irs);
+                e = toElemDtor(s.exp, irs, false);
                 assert(e);
             }
         L1:
@@ -729,7 +729,7 @@ private extern (C++) class S2irVisitor : Visitor
             if (s.exp.hasCode)
                 incUsage(irs, s.loc);
 
-            block_appendexp(blx.curblock, toElemDtor(s.exp, irs));
+            block_appendexp(blx.curblock, toElemDtor(s.exp, irs, false));
         }
     }
 
@@ -825,7 +825,7 @@ private extern (C++) class S2irVisitor : Visitor
             // Perform initialization of with handle
             auto ie = s.wthis._init.isExpInitializer();
             assert(ie);
-            auto ei = toElemDtor(ie.exp, irs);
+            auto ei = toElemDtor(ie.exp, irs, false);
             auto e = el_var(sp);
             e = el_bin(OPeq,e.Ety, e, ei);
             elem_setLoc(e, s.loc);
@@ -848,7 +848,7 @@ private extern (C++) class S2irVisitor : Visitor
         Blockx *blx = irs.blx;
 
         incUsage(irs, s.loc);
-        elem *e = toElemDtor(s.exp, irs);
+        elem *e = toElemDtor(s.exp, irs, false);
         const int rtlthrow = config.ehmethod == EHmethod.EH_DWARF ? RTLSYM_THROWDWARF : RTLSYM_THROWC;
         e = el_bin(OPcall, TYvoid, el_var(getRtlsym(rtlthrow)),e);
         block_appendexp(blx.curblock, e);

--- a/test/runnable/return_statement.d
+++ b/test/runnable/return_statement.d
@@ -1,3 +1,4 @@
+//PERMUTE_ARGS: -release -g -O
 struct S
 {
     __gshared int numDtor;

--- a/test/runnable/return_statement.d
+++ b/test/runnable/return_statement.d
@@ -19,14 +19,6 @@ struct St
 }
 int foo() { return St(2).a; }
 ref int passthrough(return ref int i) { return St(2).a ? i : i; }
-//-------------
-struct Str{
-    int[8] a;
-    ~this(){ a[] = 0; }
-    ref val(){ return a; }
-}
-Str barz(){ return Str([2,2,2,2,2,2,2,2]); }
-int[8] fooz(){ return barz.val; }
 
 void main()
 {
@@ -37,5 +29,4 @@ void main()
     assert(&passthrough(i) == &i);
     assert(foo() == 2);
 
-    assert(fooz() == [2,2,2,2,2,2,2,2]);
 }

--- a/test/runnable/return_statement.d
+++ b/test/runnable/return_statement.d
@@ -19,6 +19,14 @@ struct St
 }
 int foo() { return St(2).a; }
 ref int passthrough(return ref int i) { return St(2).a ? i : i; }
+//-------------
+struct Str{
+    int[8] a;
+    ~this(){ a[] = 0; }
+    ref val(){ return a; }
+}
+Str barz(){ return Str([2,2,2,2,2,2,2,2]); }
+int[8] fooz(){ return barz.val; }
 
 void main()
 {
@@ -26,6 +34,8 @@ void main()
     assert(literal() == 123);
     assert(S.numDtor == 2);
     int i;
-    assert(&passthrough(i) == &i); //issue 20401
-    assert(foo() == 2); //issue 20809
+    assert(&passthrough(i) == &i);
+    assert(foo() == 2);
+
+    assert(fooz() == [2,2,2,2,2,2,2,2]);
 }

--- a/test/runnable/return_statement.d
+++ b/test/runnable/return_statement.d
@@ -1,0 +1,30 @@
+struct S
+{
+    __gshared int numDtor;
+    int a;
+    ~this() { ++numDtor; a = 0; }
+    ref int val() return { return a; }
+}
+
+S make() { return S(2); }
+
+int call() { return make().val; }
+int literal() { return S(123).val; }
+//------------
+struct St
+{
+    int a;
+    ~this() { a = 0; }
+}
+int foo() { return St(2).a; }
+ref int passthrough(return ref int i) { return St(2).a ? i : i; }
+
+void main()
+{
+    assert(call() == 2);
+    assert(literal() == 123);
+    assert(S.numDtor == 2);
+    int i;
+    assert(&passthrough(i) == &i); //issue 20401
+    assert(foo() == 2); //issue 20809
+}


### PR DESCRIPTION
This is an attempt at fixing this issue. I realized that I bit more than I can chew on this one.
What this patch provides:

1.An idea where the bug is and what kind of change is needed to fix it. (I copy pasted function and commented out code so that the peace of code that I want to run gets to run. To my surprise it worked and it passes all the tests. ¯_(ツ)_/¯)
2.A test case that is combination of issue 20401, issue 20809 and ldc-developers/ldc#3426

The problems:

1. Copy paste is not good engineering but I dont know exactly how to proceed forward. There is not enough information arriving at appendDtors() to make proper decision. One solution is to create new function specific to this case. Or pass additional information trough function parameters(kinda hard when its in else statement). And of course dont break more code.
2. -_Attached test is run with -inline and it triggers Issue 20803 - [REG2.071.0] Objects are destroyed too early with -inline_ - No longer true

Solutions:
A. Some one uses this to kickstart a new pull request.
B. Some one helps with guidance because im not confident that I can make required changes and think of all possible cases to make sure it doesnt break something else.