### PR TITLE
C++: Remove duplication of 'All Rights Reserved'

### DIFF
--- a/src/dmd/root/array.h
+++ b/src/dmd/root/array.h
@@ -1,5 +1,5 @@
 /* Copyright (C) 2011-2020 by The D Language Foundation, All Rights Reserved
- * All Rights Reserved, written by Walter Bright
+ * written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt

--- a/src/dmd/root/bitarray.h
+++ b/src/dmd/root/bitarray.h
@@ -1,5 +1,5 @@
 /* Copyright (C) 2011-2020 by The D Language Foundation, All Rights Reserved
- * All Rights Reserved, written by Walter Bright
+ * written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt

--- a/src/dmd/root/ctfloat.h
+++ b/src/dmd/root/ctfloat.h
@@ -1,6 +1,6 @@
 
 /* Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
- * All Rights Reserved, written by Walter Bright
+ * written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt

--- a/src/dmd/root/file.h
+++ b/src/dmd/root/file.h
@@ -1,6 +1,6 @@
 
 /* Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
- * All Rights Reserved, written by Walter Bright
+ * written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt

--- a/src/dmd/root/filename.h
+++ b/src/dmd/root/filename.h
@@ -1,6 +1,6 @@
 
 /* Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
- * All Rights Reserved, written by Walter Bright
+ * written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt

--- a/src/dmd/root/longdouble.h
+++ b/src/dmd/root/longdouble.h
@@ -1,6 +1,6 @@
 
 /* Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
- * All Rights Reserved, written by Rainer Schuetze
+ * written by Rainer Schuetze
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt

--- a/src/dmd/root/object.h
+++ b/src/dmd/root/object.h
@@ -1,6 +1,6 @@
 
 /* Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
- * All Rights Reserved, written by Walter Bright
+ * written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt

--- a/src/dmd/root/outbuffer.h
+++ b/src/dmd/root/outbuffer.h
@@ -1,6 +1,6 @@
 
 /* Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
- * All Rights Reserved, written by Walter Bright
+ * written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt

--- a/src/dmd/root/port.h
+++ b/src/dmd/root/port.h
@@ -1,6 +1,6 @@
 
 /* Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
- * All Rights Reserved, written by Walter Bright
+ * written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt

--- a/src/dmd/root/rmem.h
+++ b/src/dmd/root/rmem.h
@@ -1,6 +1,6 @@
 
 /* Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
- * All Rights Reserved, written by Walter Bright
+ * written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt

--- a/src/dmd/root/root.h
+++ b/src/dmd/root/root.h
@@ -1,6 +1,6 @@
 
 /* Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
- * All Rights Reserved, written by Walter Bright
+ * written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt


### PR DESCRIPTION
I guess this should have been handled by the script that updates the copyright years, but I'll do by hand as it's quicker than the time it'll take to debug it (and it's a one-off change anyway).