### PR TITLE
[dmd-cxx] Backport struct ParameterList from upstream master

### DIFF
--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -66,7 +66,7 @@ FuncDeclaration *buildArrayOp(Identifier *ident, BinExp *exp, Scope *sc)
 
     /* Construct the function
      */
-    TypeFunction *ftype = new TypeFunction(fparams, exp->e1->type, 0, LINKc, stc);
+    TypeFunction *ftype = new TypeFunction(ParameterList(fparams), exp->e1->type, LINKc, stc);
     //printf("fd: %s %s\n", ident->toChars(), ftype->toChars());
     FuncDeclaration *fd = new FuncDeclaration(Loc(), Loc(), ident, STCundefined, ftype);
     fd->fbody = fbody;

--- a/src/clone.c
+++ b/src/clone.c
@@ -117,11 +117,10 @@ FuncDeclaration *hasIdentityOpAssign(AggregateDeclaration *ad, Scope *sc)
         {
             if (f->errors)
                 return NULL;
-            int varargs;
-            Parameters *fparams = f->getParameters(&varargs);
-            if (fparams->length >= 1)
+            ParameterList fparams = f->getParameterList();
+            if (fparams.length())
             {
-                Parameter *fparam0 = Parameter::getNth(fparams, 0);
+                Parameter *fparam0 = fparams[0];
                 if (fparam0->type->toDsymbol(NULL) != ad)
                     f = NULL;
             }
@@ -246,7 +245,7 @@ FuncDeclaration *buildOpAssign(StructDeclaration *sd, Scope *sc)
 
     Parameters *fparams = new Parameters;
     fparams->push(new Parameter(STCnodtor, sd->type, Id::p, NULL));
-    TypeFunction *tf = new TypeFunction(fparams, sd->handleType(), 0, LINKd, stc | STCref);
+    TypeFunction *tf = new TypeFunction(ParameterList(fparams), sd->handleType(), LINKd, stc | STCref);
 
     FuncDeclaration *fop = new FuncDeclaration(declLoc, Loc(), Id::assign, stc, tf);
     fop->storage_class |= STCinference;
@@ -505,7 +504,7 @@ FuncDeclaration *buildXopEquals(StructDeclaration *sd, Scope *sc)
                  */
                 Parameters *parameters = new Parameters;
                 parameters->push(new Parameter(STCref | STCconst, sd->type, NULL, NULL));
-                tfeqptr = new TypeFunction(parameters, Type::tbool, 0, LINKd);
+                tfeqptr = new TypeFunction(ParameterList(parameters), Type::tbool, LINKd);
                 tfeqptr->mod = MODconst;
                 tfeqptr = (TypeFunction *)tfeqptr->semantic(Loc(), &scx);
             }
@@ -534,7 +533,7 @@ FuncDeclaration *buildXopEquals(StructDeclaration *sd, Scope *sc)
     Parameters *parameters = new Parameters;
     parameters->push(new Parameter(STCref | STCconst, sd->type, Id::p, NULL));
     parameters->push(new Parameter(STCref | STCconst, sd->type, Id::q, NULL));
-    TypeFunction *tf = new TypeFunction(parameters, Type::tbool, 0, LINKd);
+    TypeFunction *tf = new TypeFunction(ParameterList(parameters), Type::tbool, LINKd);
 
     Identifier *id = Id::xopEquals;
     FuncDeclaration *fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);
@@ -585,7 +584,7 @@ FuncDeclaration *buildXopCmp(StructDeclaration *sd, Scope *sc)
                  */
                 Parameters *parameters = new Parameters;
                 parameters->push(new Parameter(STCref | STCconst, sd->type, NULL, NULL));
-                tfcmpptr = new TypeFunction(parameters, Type::tint32, 0, LINKd);
+                tfcmpptr = new TypeFunction(ParameterList(parameters), Type::tint32, LINKd);
                 tfcmpptr->mod = MODconst;
                 tfcmpptr = (TypeFunction *)tfcmpptr->semantic(Loc(), &scx);
             }
@@ -619,7 +618,7 @@ FuncDeclaration *buildXopCmp(StructDeclaration *sd, Scope *sc)
     Parameters *parameters = new Parameters;
     parameters->push(new Parameter(STCref | STCconst, sd->type, Id::p, NULL));
     parameters->push(new Parameter(STCref | STCconst, sd->type, Id::q, NULL));
-    TypeFunction *tf = new TypeFunction(parameters, Type::tint32, 0, LINKd);
+    TypeFunction *tf = new TypeFunction(ParameterList(parameters), Type::tint32, LINKd);
 
     Identifier *id = Id::xopCmp;
     FuncDeclaration *fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);
@@ -718,7 +717,7 @@ FuncDeclaration *buildXtoHash(StructDeclaration *sd, Scope *sc)
         static TypeFunction *tftohash;
         if (!tftohash)
         {
-            tftohash = new TypeFunction(NULL, Type::thash_t, 0, LINKd);
+            tftohash = new TypeFunction(ParameterList(), Type::thash_t, LINKd);
             tftohash->mod = MODconst;
             tftohash = (TypeFunction *)tftohash->merge();
         }
@@ -740,7 +739,8 @@ FuncDeclaration *buildXtoHash(StructDeclaration *sd, Scope *sc)
 
     Parameters *parameters = new Parameters();
     parameters->push(new Parameter(STCref | STCconst, sd->type, Id::p, NULL));
-    TypeFunction *tf = new TypeFunction(parameters, Type::thash_t, 0, LINKd, STCnothrow | STCtrusted);
+    TypeFunction *tf = new TypeFunction(ParameterList(parameters), Type::thash_t,
+                                        LINKd, STCnothrow | STCtrusted);
 
     Identifier *id = Id::xtoHash;
     FuncDeclaration *fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);

--- a/src/cond.c
+++ b/src/cond.c
@@ -122,7 +122,7 @@ static void lowerArrayAggregate(StaticForeach *sfe, Scope *sc)
 
 static Expression *wrapAndCall(Loc loc, Statement *s)
 {
-    TypeFunction *tf = new TypeFunction(new Parameters(), NULL, 0, LINKdefault, 0);
+    TypeFunction *tf = new TypeFunction(ParameterList(), NULL, LINKdefault, 0);
     FuncLiteralDeclaration *fd = new FuncLiteralDeclaration(loc, loc, tf, TOKreserved, NULL);
     fd->fbody = s;
     FuncExp *fe = new FuncExp(loc, fd);

--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -657,7 +657,8 @@ class CppMangleVisitor : public Visitor
         if (tf->linkage == LINKcpp) //Template args accept extern "C" symbols with special mangling
         {
             assert(tf->ty == Tfunction);
-            mangleFunctionParameters(tf->parameters, tf->varargs);
+            mangleFunctionParameters(tf->parameterList.parameters,
+                                     tf->parameterList.varargs);
         }
     }
 
@@ -982,7 +983,8 @@ public:
         if (t->isref)
             tn  = tn->referenceTo();
         tn->accept(this);
-        mangleFunctionParameters(t->parameters, t->varargs);
+        mangleFunctionParameters(t->parameterList.parameters,
+                                 t->parameterList.varargs);
         buf->writeByte('E');
         append(t);
     }

--- a/src/cppmanglewin.c
+++ b/src/cppmanglewin.c
@@ -924,7 +924,7 @@ private:
         else if (p->storageClass & STClazy)
         {
             // Mangle as delegate
-            Type *td = new TypeFunction(NULL, t, 0, LINKd);
+            Type *td = new TypeFunction(ParameterList(), t, LINKd);
             td = new TypeDelegate(td);
             t = t->merge();
         }
@@ -957,7 +957,7 @@ private:
                     tmp.buf.writeByte('A');
                     break;
                 case LINKcpp:
-                    if (needthis && type->varargs != 1)
+                    if (needthis && type->parameterList.varargs != VARARGvariadic)
                         tmp.buf.writeByte('E'); // thiscall
                     else
                         tmp.buf.writeByte('A'); // cdecl
@@ -1005,17 +1005,17 @@ private:
             rettype->accept(&tmp);
             tmp.flags &= ~MANGLE_RETURN_TYPE;
         }
-        if (!type->parameters || !type->parameters->length)
+        if (!type->parameterList.parameters || !type->parameterList.parameters->length)
         {
-            if (type->varargs == 1)
+            if (type->parameterList.varargs == VARARGvariadic)
                 tmp.buf.writeByte('Z');
             else
                 tmp.buf.writeByte('X');
         }
         else
         {
-            Parameter_foreach(type->parameters, &mangleParameterDg, (void*)&tmp);
-            if (type->varargs == 1)
+            Parameter_foreach(type->parameterList.parameters, &mangleParameterDg, (void*)&tmp);
+            if (type->parameterList.varargs == VARARGvariadic)
             {
                 tmp.buf.writeByte('Z');
             }

--- a/src/dcast.c
+++ b/src/dcast.c
@@ -838,8 +838,8 @@ MATCH implicitConvTo(Expression *e, Type *t)
              * and see if we can convert the function argument to the modded type
              */
 
-            size_t nparams = Parameter::dim(tf->parameters);
-            size_t j = (tf->linkage == LINKd && tf->varargs == 1); // if TypeInfoArray was prepended
+            size_t nparams = tf->parameterList.length();
+            size_t j = tf->isDstyleVariadic(); // if TypeInfoArray was prepended
             if (e->e1->op == TOKdotvar)
             {
                 /* Treat 'this' as just another function argument
@@ -855,7 +855,7 @@ MATCH implicitConvTo(Expression *e, Type *t)
                 Type *targ = earg->type->toBasetype();
                 if (i - j < nparams)
                 {
-                    Parameter *fparam = Parameter::getNth(tf->parameters, i - j);
+                    Parameter *fparam = tf->parameterList[i - j];
                     if (fparam->storageClass & STClazy)
                         return;                 // not sure what to do with this
                     Type *tparam = fparam->type;
@@ -1124,15 +1124,15 @@ MATCH implicitConvTo(Expression *e, Type *t)
 
                 Expressions *args = (fd == e->allocator) ? e->newargs : e->arguments;
 
-                size_t nparams = Parameter::dim(tf->parameters);
-                size_t j = (tf->linkage == LINKd && tf->varargs == 1); // if TypeInfoArray was prepended
+                size_t nparams = tf->parameterList.length();
+                size_t j = tf->isDstyleVariadic(); // if TypeInfoArray was prepended
                 for (size_t i = j; i < e->arguments->length; ++i)
                 {
                     Expression *earg = (*args)[i];
                     Type *targ = earg->type->toBasetype();
                     if (i - j < nparams)
                     {
-                        Parameter *fparam = Parameter::getNth(tf->parameters, i - j);
+                        Parameter *fparam = tf->parameterList[i - j];
                         if (fparam->storageClass & STClazy)
                             return;                 // not sure what to do with this
                         Type *tparam = fparam->type;

--- a/src/dclass.c
+++ b/src/dclass.c
@@ -803,7 +803,7 @@ Lancestorsdone:
         {
             //printf("Creating default this(){} for class %s\n", toChars());
             TypeFunction *btf = fd->type->toTypeFunction();
-            TypeFunction *tf = new TypeFunction(NULL, NULL, 0, LINKd, fd->storage_class);
+            TypeFunction *tf = new TypeFunction(ParameterList(), NULL, LINKd, fd->storage_class);
             tf->mod = btf->mod;
             tf->purity = btf->purity;
             tf->isnothrow = btf->isnothrow;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -664,7 +664,7 @@ public:
     void buildResultVar(Scope *sc, Type *tret);
     Statement *mergeFrequire(Statement *);
     Statement *mergeFensure(Statement *, Identifier *oid);
-    Parameters *getParameters(int *pvarargs);
+    ParameterList getParameterList();
 
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc=0);
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc=0);
@@ -866,9 +866,9 @@ class NewDeclaration : public FuncDeclaration
 {
 public:
     Parameters *parameters;
-    int varargs;
+    VarArg varargs;
 
-    NewDeclaration(Loc loc, Loc endloc, StorageClass stc, Parameters *arguments, int varargs);
+    NewDeclaration(Loc loc, Loc endloc, StorageClass stc, Parameters *arguments, VarArg varargs);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     const char *kind() const;

--- a/src/delegatize.c
+++ b/src/delegatize.c
@@ -39,7 +39,7 @@ Expression *toDelegate(Expression *e, Type* t, Scope *sc)
     //printf("Expression::toDelegate(t = %s) %s\n", t->toChars(), e->toChars());
     Loc loc = e->loc;
 
-    TypeFunction *tf = new TypeFunction(NULL, t, 0, LINKd);
+    TypeFunction *tf = new TypeFunction(ParameterList(), t, LINKd);
     if (t->hasWild())
         tf->mod = MODwild;
     FuncLiteralDeclaration *fld =

--- a/src/dinterpret.c
+++ b/src/dinterpret.c
@@ -760,7 +760,7 @@ static Expression *interpretFunction(UnionExp *pue, FuncDeclaration *fd, InterSt
     Type *tb = fd->type->toBasetype();
     assert(tb->ty == Tfunction);
     TypeFunction *tf = (TypeFunction *)tb;
-    if (tf->varargs && arguments &&
+    if (tf->parameterList.varargs != VARARGnone && arguments &&
         ((fd->parameters && arguments->length != fd->parameters->length) || (!fd->parameters && arguments->length)))
     {
         fd->error("C-style variadic functions are not yet implemented in CTFE");
@@ -795,7 +795,7 @@ static Expression *interpretFunction(UnionExp *pue, FuncDeclaration *fd, InterSt
     for (size_t i = 0; i < dim; i++)
     {
         Expression *earg = (*arguments)[i];
-        Parameter *fparam = Parameter::getNth(tf->parameters, i);
+        Parameter *fparam = tf->parameterList[i];
 
         if (fparam->storageClass & (STCout | STCref))
         {
@@ -859,7 +859,7 @@ static Expression *interpretFunction(UnionExp *pue, FuncDeclaration *fd, InterSt
     for (size_t i = 0; i < dim; i++)
     {
         Expression *earg = eargs[i];
-        Parameter *fparam = Parameter::getNth(tf->parameters, i);
+        Parameter *fparam = tf->parameterList[i];
         VarDeclaration *v = (*fd->parameters)[i];
         ctfeStack.push(v);
 
@@ -6554,7 +6554,7 @@ Expression *interpret_aaApply(UnionExp *pue, InterState *istate, Expression *aa,
     size_t numParams = fd->parameters->length;
     assert(numParams == 1 || numParams == 2);
 
-    Parameter *fparam = Parameter::getNth(((TypeFunction *)fd->type)->parameters, numParams - 1);
+    Parameter *fparam = ((TypeFunction *)fd->type)->parameterList[numParams - 1];
     bool wantRefValue = 0 != (fparam->storageClass & (STCout | STCref));
 
     Expressions args;

--- a/src/dmangle.c
+++ b/src/dmangle.c
@@ -261,9 +261,9 @@ public:
         }
 
         // Write argument types
-        paramsToDecoBuffer(t->parameters);
+        paramsToDecoBuffer(t->parameterList.parameters);
         //if (buf->data[buf->offset - 1] == '@') halt();
-        buf->writeByte('Z' - t->varargs);   // mark end of arg list
+        buf->writeByte('Z' - t->parameterList.varargs);   // mark end of arg list
         if (tret != NULL)
             visitWithMask(tret, 0);
 

--- a/src/doc.c
+++ b/src/doc.c
@@ -127,7 +127,7 @@ bool isCVariadicParameter(Dsymbols *a, const utf8_t *p, size_t len)
     for (size_t i = 0; i < a->length; i++)
     {
         TypeFunction *tf = isTypeFunction((*a)[i]);
-        if (tf && tf->varargs == 1 && cmp("...", p, len) == 0)
+        if (tf && tf->parameterList.varargs == VARARGvariadic && cmp("...", p, len) == 0)
             return true;
     }
     return false;
@@ -138,11 +138,11 @@ bool isCVariadicParameter(Dsymbols *a, const utf8_t *p, size_t len)
 static Parameter *isFunctionParameter(Dsymbol *s, const utf8_t *p, size_t len)
 {
     TypeFunction *tf = isTypeFunction(s);
-    if (tf && tf->parameters)
+    if (tf && tf->parameterList.parameters)
     {
-        for (size_t k = 0; k < tf->parameters->length; k++)
+        for (size_t k = 0; k < tf->parameterList.parameters->length; k++)
         {
-            Parameter *fparam = (*tf->parameters)[k];
+            Parameter *fparam = (*tf->parameterList.parameters)[k];
             if (fparam->ident && cmp(fparam->ident->toChars(), p, len) == 0)
             {
                 return fparam;
@@ -1733,7 +1733,8 @@ void ParamSection::write(Loc loc, DocComment *, Scope *sc, Dsymbols *a, OutBuffe
     TypeFunction *tf = a->length == 1 ? isTypeFunction(s) : NULL;
     if (tf)
     {
-        size_t pcount = (tf->parameters ? tf->parameters->length : 0) + (int)(tf->varargs == 1);
+        size_t pcount = (tf->parameterList.parameters ? tf->parameterList.parameters->length : 0) +
+                        (int)(tf->parameterList.varargs == VARARGvariadic);
         if (pcount != paramcount)
         {
             warning(s->loc, "Ddoc: parameter count mismatch");

--- a/src/dstruct.c
+++ b/src/dstruct.c
@@ -45,7 +45,7 @@ FuncDeclaration *search_toString(StructDeclaration *sd)
         static TypeFunction *tftostring;
         if (!tftostring)
         {
-            tftostring = new TypeFunction(NULL, Type::tstring, 0, LINKd);
+            tftostring = new TypeFunction(ParameterList(), Type::tstring, LINKd);
             tftostring = tftostring->merge()->toTypeFunction();
         }
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -195,7 +195,7 @@ elem *callfunc(Loc loc,
         }
 
         // j=1 if _arguments[] is first argument
-        int j = (tf->linkage == LINKd && tf->varargs == 1);
+        int j = tf->isDstyleVariadic();
 
         for (size_t i = 0; i < arguments->length ; i++)
         {
@@ -204,10 +204,10 @@ elem *callfunc(Loc loc,
 
             //printf("\targ[%d]: %s\n", i, arg->toChars());
 
-            size_t nparams = Parameter::dim(tf->parameters);
+            size_t nparams = tf->parameterList.length();
             if (i - j < nparams && i >= j)
             {
-                Parameter *p = Parameter::getNth(tf->parameters, i - j);
+                Parameter *p = tf->parameterList[i - j];
 
                 if (p->storageClass & (STCout | STCref))
                 {
@@ -482,7 +482,7 @@ if (I32) assert(tysize[TYnptr] == 4);
         else
             e = el_una(ns ? OPucallns : OPucall, tyret, ec);
 
-        if (tf->varargs)
+        if (tf->parameterList.varargs)
             e->Eflags |= EFLAGS_variadic;
     }
 

--- a/src/escape.c
+++ b/src/escape.c
@@ -707,12 +707,12 @@ static void inferReturn(FuncDeclaration *fd, VarDeclaration *v)
     else
     {
         // Perform 'return' inference on parameter
-        if (tf->ty == Tfunction && tf->parameters)
+        if (tf->ty == Tfunction)
         {
-            const size_t dim = Parameter::dim(tf->parameters);
+            const size_t dim = tf->parameterList.length();
             for (size_t i = 0; i < dim; i++)
             {
-                Parameter *p = Parameter::getNth(tf->parameters, i);
+                Parameter *p = tf->parameterList[i];
                 if (p->ident == v->ident)
                 {
                     p->storageClass |= STCreturn;
@@ -950,14 +950,14 @@ static void escapeByValue(Expression *e, EscapeByResults *er)
                 /* j=1 if _arguments[] is first argument,
                  * skip it because it is not passed by ref
                  */
-                size_t j = (tf->linkage == LINKd && tf->varargs == 1);
+                size_t j = tf->isDstyleVariadic();
                 for (size_t i = j; i < e->arguments->length; ++i)
                 {
                     Expression *arg = (*e->arguments)[i];
-                    size_t nparams = Parameter::dim(tf->parameters);
+                    size_t nparams = tf->parameterList.length();
                     if (i - j < nparams && i >= j)
                     {
-                        Parameter *p = Parameter::getNth(tf->parameters, i - j);
+                        Parameter *p = tf->parameterList[i - j];
                         const StorageClass stc = tf->parameterStorageClass(p);
                         if ((stc & (STCscope)) && (stc & STCreturn))
                             arg->accept(this);
@@ -1146,15 +1146,15 @@ static void escapeByRef(Expression *e, EscapeByResults *er)
                     /* j=1 if _arguments[] is first argument,
                      * skip it because it is not passed by ref
                      */
-                    size_t j = (tf->linkage == LINKd && tf->varargs == 1);
+                    size_t j = tf->isDstyleVariadic();
 
                     for (size_t i = j; i < e->arguments->length; ++i)
                     {
                         Expression *arg = (*e->arguments)[i];
-                        size_t nparams = Parameter::dim(tf->parameters);
+                        size_t nparams = tf->parameterList.length();
                         if (i - j < nparams && i >= j)
                         {
-                            Parameter *p = Parameter::getNth(tf->parameters, i - j);
+                            Parameter *p = tf->parameterList[i - j];
                             const StorageClass stc = tf->parameterStorageClass(p);
                             if ((stc & (STCout | STCref)) && (stc & STCreturn))
                                 arg->accept(this);

--- a/src/glue.c
+++ b/src/glue.c
@@ -1416,11 +1416,11 @@ unsigned totym(Type *tx)
                 case LINKwindows:
                     if (global.params.is64bit)
                         goto Lc;
-                    t = (tf->varargs == 1) ? TYnfunc : TYnsfunc;
+                    t = (tf->parameterList.varargs == VARARGvariadic) ? TYnfunc : TYnsfunc;
                     break;
 
                 case LINKpascal:
-                    t = (tf->varargs == 1) ? TYnfunc : TYnpfunc;
+                    t = (tf->parameterList.varargs == VARARGvariadic) ? TYnfunc : TYnpfunc;
                     break;
 
                 case LINKc:
@@ -1435,7 +1435,7 @@ unsigned totym(Type *tx)
                     break;
 
                 case LINKd:
-                    t = (tf->varargs == 1) ? TYnfunc : TYjfunc;
+                    t = (tf->parameterList.varargs == VARARGvariadic) ? TYnfunc : TYjfunc;
                     break;
 
                 default:

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -918,7 +918,7 @@ public:
         if (ident)
             buf->writestring(ident);
 
-        parametersToBuffer(t->parameters, t->varargs);
+        parametersToBuffer(t->parameterList.parameters, t->parameterList.varargs);
 
         /* Use postfix style for attributes
          */
@@ -988,7 +988,7 @@ public:
             }
             buf->writeByte(')');
         }
-        parametersToBuffer(t->parameters, t->varargs);
+        parametersToBuffer(t->parameterList.parameters, t->parameterList.varargs);
 
         t->inuse--;
     }
@@ -2012,7 +2012,7 @@ public:
         // Don't print tf->mod, tf->trust, and tf->linkage
         if (!f->inferRetType && tf->next)
             typeToBuffer(tf->next, NULL);
-        parametersToBuffer(tf->parameters, tf->varargs);
+        parametersToBuffer(tf->parameterList.parameters, tf->parameterList.varargs);
 
         CompoundStatement *cs = f->fbody->isCompoundStatement();
         Statement *s1;
@@ -3469,11 +3469,11 @@ void arrayObjectsToBuffer(OutBuffer *buf, Objects *objects)
     }
 }
 
-const char *parametersTypeToChars(Parameters *parameters, int varargs)
+const char *parametersTypeToChars(ParameterList pl)
 {
     OutBuffer buf;
     HdrGenState hgs;
     PrettyPrintVisitor v(&buf, &hgs);
-    v.parametersToBuffer(parameters, varargs);
+    v.parametersToBuffer(pl.parameters, pl.varargs);
     return buf.extractString();
 }

--- a/src/hdrgen.h
+++ b/src/hdrgen.h
@@ -46,7 +46,7 @@ void arrayObjectsToBuffer(OutBuffer *buf, Objects *objects);
 
 void moduleToBuffer(OutBuffer *buf, Module *m);
 
-const char *parametersTypeToChars(Parameters *parameters, int varargs);
+const char *parametersTypeToChars(ParameterList pl);
 
 bool stcToBuffer(OutBuffer *buf, StorageClass stc);
 const char *stcToChars(StorageClass& stc);

--- a/src/initsem.c
+++ b/src/initsem.c
@@ -182,8 +182,7 @@ public:
             TOK tok = (t->ty == Tdelegate) ? TOKdelegate : TOKfunction;
             /* Rewrite as empty delegate literal { }
             */
-            Parameters *parameters = new Parameters;
-            Type *tf = new TypeFunction(parameters, NULL, 0, LINKd);
+            Type *tf = new TypeFunction(ParameterList(), NULL, LINKd);
             FuncLiteralDeclaration *fd = new FuncLiteralDeclaration(i->loc, Loc(), tf, tok, NULL);
             fd->fbody = new CompoundStatement(i->loc, new Statements());
             fd->endloc = i->loc;

--- a/src/inline.c
+++ b/src/inline.c
@@ -1459,7 +1459,7 @@ bool canInline(FuncDeclaration *fd, int hasthis, int hdrscan, bool statementsToo
     {
         assert(fd->type->ty == Tfunction);
         TypeFunction *tf = (TypeFunction *)fd->type;
-        if (tf->varargs == 1)   // no variadic parameter lists
+        if (tf->parameterList.varargs == VARARGvariadic)   // no variadic parameter lists
             goto Lno;
 
         /* Don't inline a function that returns non-void, but has

--- a/src/json.c
+++ b/src/json.c
@@ -679,7 +679,7 @@ public:
 
         TypeFunction *tf = (TypeFunction *)d->type;
         if (tf && tf->ty == Tfunction)
-            property("parameters", tf->parameters);
+            property("parameters", tf->parameterList.parameters);
 
         property("endline", "endchar", &d->endloc);
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1567,11 +1567,11 @@ Type *stripDefaultArgs(Type *t)
     {
         TypeFunction *tf = (TypeFunction *)t;
         Type *tret = stripDefaultArgs(tf->next);
-        Parameters *params = N::stripParams(tf->parameters);
-        if (tret == tf->next && params == tf->parameters)
+        Parameters *params = N::stripParams(tf->parameterList.parameters);
+        if (tret == tf->next && params == tf->parameterList.parameters)
             goto Lnot;
         tf = (TypeFunction *)tf->copy();
-        tf->parameters = params;
+        tf->parameterList.parameters = params;
         tf->next = tret;
         //printf("strip %s\n   <- %s\n", tf->toChars(), t->toChars());
         t = tf;
@@ -1985,24 +1985,25 @@ Type *TypeFunction::substWildTo(unsigned)
 
     assert(next);
     Type *tret = next->substWildTo(m);
-    Parameters *params = parameters;
+    Parameters *params = parameterList.parameters;
     if (mod & MODwild)
-        params = parameters->copy();
+        params = parameterList.parameters->copy();
     for (size_t i = 0; i < params->length; i++)
     {
         Parameter *p = (*params)[i];
         Type *t = p->type->substWildTo(m);
         if (t == p->type)
             continue;
-        if (params == parameters)
-            params = parameters->copy();
+        if (params == parameterList.parameters)
+            params = parameterList.parameters->copy();
         (*params)[i] = new Parameter(p->storageClass, t, NULL, NULL);
     }
-    if (next == tret && params == parameters)
+    if (next == tret && params == parameterList.parameters)
         return this;
 
     // Similar to TypeFunction::syntaxCopy;
-    TypeFunction *t = new TypeFunction(params, tret, varargs, linkage);
+    TypeFunction *t = new TypeFunction(ParameterList(params, parameterList.varargs),
+                                       tret, linkage);
     t->mod = ((mod & MODwild) ? (mod & ~MODwild) | MODconst : mod);
     t->isnothrow = isnothrow;
     t->isnogc = isnogc;
@@ -5119,14 +5120,13 @@ bool TypeReference::isZeroInit(Loc)
 
 /***************************** TypeFunction *****************************/
 
-TypeFunction::TypeFunction(Parameters *parameters, Type *treturn, int varargs, LINK linkage, StorageClass stc)
+TypeFunction::TypeFunction(const ParameterList &pl, Type *treturn, LINK linkage, StorageClass stc)
     : TypeNext(Tfunction, treturn)
 {
 //if (!treturn) *(char*)0=0;
 //    assert(treturn);
-    assert(0 <= varargs && varargs <= 2);
-    this->parameters = parameters;
-    this->varargs = varargs;
+    assert(VARARGnone <= pl.varargs && pl.varargs <= VARARGtypesafe);
+    this->parameterList = pl;
     this->linkage = linkage;
     this->inuse = 0;
     this->isnothrow = false;
@@ -5167,9 +5167,9 @@ TypeFunction::TypeFunction(Parameters *parameters, Type *treturn, int varargs, L
         this->trust = TRUSTtrusted;
 }
 
-TypeFunction *TypeFunction::create(Parameters *parameters, Type *treturn, int varargs, LINK linkage, StorageClass stc)
+TypeFunction *TypeFunction::create(Parameters *parameters, Type *treturn, VarArg varargs, LINK linkage, StorageClass stc)
 {
-    return new TypeFunction(parameters, treturn, varargs, linkage, stc);
+    return new TypeFunction(ParameterList(parameters, varargs), treturn, linkage, stc);
 }
 
 const char *TypeFunction::kind()
@@ -5180,8 +5180,9 @@ const char *TypeFunction::kind()
 Type *TypeFunction::syntaxCopy()
 {
     Type *treturn = next ? next->syntaxCopy() : NULL;
-    Parameters *params = Parameter::arraySyntaxCopy(parameters);
-    TypeFunction *t = new TypeFunction(params, treturn, varargs, linkage);
+    Parameters *parameters = Parameter::arraySyntaxCopy(parameterList.parameters);
+    TypeFunction *t = new TypeFunction(ParameterList(parameters, parameterList.varargs),
+                                       treturn, linkage);
     t->mod = mod;
     t->isnothrow = isnothrow;
     t->isnogc = isnogc;
@@ -5233,19 +5234,19 @@ int Type::covariant(Type *t, StorageClass *pstc, bool fix17349)
     t1 = (TypeFunction *)this;
     t2 = (TypeFunction *)t;
 
-    if (t1->varargs != t2->varargs)
+    if (t1->parameterList.varargs != t2->parameterList.varargs)
         goto Ldistinct;
 
-    if (t1->parameters && t2->parameters)
+    if (t1->parameterList.parameters && t2->parameterList.parameters)
     {
-        size_t dim = Parameter::dim(t1->parameters);
-        if (dim != Parameter::dim(t2->parameters))
+        size_t dim = t1->parameterList.length();
+        if (dim != t2->parameterList.length())
             goto Ldistinct;
 
         for (size_t i = 0; i < dim; i++)
         {
-            Parameter *fparam1 = Parameter::getNth(t1->parameters, i);
-            Parameter *fparam2 = Parameter::getNth(t2->parameters, i);
+            Parameter *fparam1 = t1->parameterList[i];
+            Parameter *fparam2 = t2->parameterList[i];
 
             if (!fparam1->type->equals(fparam2->type))
             {
@@ -5287,10 +5288,10 @@ int Type::covariant(Type *t, StorageClass *pstc, bool fix17349)
             notcovariant |= !fparam1->isCovariant(t1->isref, fparam2);
         }
     }
-    else if (t1->parameters != t2->parameters)
+    else if (t1->parameterList.parameters != t2->parameterList.parameters)
     {
-        size_t dim1 = !t1->parameters ? 0 : t1->parameters->length;
-        size_t dim2 = !t2->parameters ? 0 : t2->parameters->length;
+        size_t dim1 = t1->parameterList.length();
+        size_t dim2 = t2->parameterList.length();
         if (dim1 || dim2)
             goto Ldistinct;
     }
@@ -5447,14 +5448,15 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
      * as semantic() will get called again on this.
      */
     TypeFunction *tf = copy()->toTypeFunction();
-    if (parameters)
+    if (parameterList.parameters)
     {
-        tf->parameters = parameters->copy();
-        for (size_t i = 0; i < parameters->length; i++)
+        tf->parameterList.parameters = parameterList.parameters->copy();
+        for (size_t i = 0; i < parameterList.parameters->length; i++)
         {
             void *pp = mem.xmalloc(sizeof(Parameter));
-            Parameter *p = (Parameter *)memcpy(pp, (void *)(*parameters)[i], sizeof(Parameter));
-            (*tf->parameters)[i] = p;
+            Parameter *p = (Parameter *)memcpy(pp, (void *)(*parameterList.parameters)[i],
+                                               sizeof(Parameter));
+            (*tf->parameterList.parameters)[i] = p;
         }
     }
 
@@ -5513,7 +5515,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
     }
 
     unsigned char wildparams = 0;
-    if (tf->parameters)
+    if (tf->parameterList.parameters)
     {
         /* Create a scope for evaluating the default arguments for the parameters
          */
@@ -5522,10 +5524,10 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
         argsc->protection = Prot(PROTpublic);
         argsc->func = NULL;
 
-        size_t dim = Parameter::dim(tf->parameters);
+        size_t dim = tf->parameterList.length();
         for (size_t i = 0; i < dim; i++)
         {
-            Parameter *fparam = Parameter::getNth(tf->parameters, i);
+            Parameter *fparam = tf->parameterList[i];
             inuse++;
             fparam->type = fparam->type->semantic(loc, argsc);
             inuse--;
@@ -5728,7 +5730,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                 /* Reset number of parameters, and back up one to do this fparam again,
                  * now that it is a tuple
                  */
-                dim = Parameter::dim(tf->parameters);
+                dim = tf->parameterList.length();
                 i--;
                 continue;
             }
@@ -5770,13 +5772,13 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
     }
     tf->iswild = wildparams;
 
-    if (tf->isproperty && (tf->varargs || Parameter::dim(tf->parameters) > 2))
+    if (tf->isproperty && (tf->parameterList.varargs != VARARGnone || tf->parameterList.length() > 2))
     {
         error(loc, "properties can only have zero, one, or two parameter");
         errors = true;
     }
 
-    if (tf->varargs == 1 && tf->linkage != LINKd && Parameter::dim(tf->parameters) == 0)
+    if (tf->parameterList.varargs == VARARGvariadic && tf->linkage != LINKd && tf->parameterList.length() == 0)
     {
         error(loc, "variadic functions with non-D linkage must have at least one parameter");
         errors = true;
@@ -5880,10 +5882,10 @@ void TypeFunction::purityLevel()
 
     /* Evaluate what kind of purity based on the modifiers for the parameters
      */
-    const size_t dim = Parameter::dim(tf->parameters);
+    const size_t dim = tf->parameterList.length();
     for (size_t i = 0; i < dim; i++)
     {
-        Parameter *fparam = Parameter::getNth(tf->parameters, i);
+        Parameter *fparam = tf->parameterList[i];
         Type *t = fparam->type;
         if (!t)
             continue;
@@ -5968,13 +5970,13 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
         }
     }
 
-    size_t nparams = Parameter::dim(parameters);
+    size_t nparams = parameterList.length();
     size_t nargs = args ? args->length : 0;
     if (nparams == nargs)
         ;
     else if (nargs > nparams)
     {
-        if (varargs == 0)
+        if (parameterList.varargs == VARARGnone)
             goto Nomatch;               // too many args; no match
         match = MATCHconvert;           // match ... with a "conversion" match level
     }
@@ -5983,7 +5985,7 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
     {
         if (u >= nparams)
             break;
-        Parameter *p = Parameter::getNth(parameters, u);
+        Parameter *p = parameterList[u];
         Expression *arg = (*args)[u];
         assert(arg);
         Type *tprm = p->type;
@@ -6016,7 +6018,7 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
     {
         MATCH m;
 
-        Parameter *p = Parameter::getNth(parameters, u);
+        Parameter *p = parameterList[u];
         assert(p);
         if (u >= nargs)
         {
@@ -6107,14 +6109,14 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
         /* prefer matching the element type rather than the array
          * type when more arguments are present with T[]...
          */
-        if (varargs == 2 && u + 1 == nparams && nargs > nparams)
+        if (parameterList.varargs == VARARGtypesafe && u + 1 == nparams && nargs > nparams)
             goto L1;
 
         //printf("\tm = %d\n", m);
         if (m == MATCHnomatch)                  // if no match
         {
           L1:
-            if (varargs == 2 && u + 1 == nparams)       // if last varargs param
+            if (parameterList.varargs == VARARGtypesafe && u + 1 == nparams)       // if last varargs param
             {
                 Type *tb = p->type->toBasetype();
                 TypeSArray *tsa;
@@ -6192,14 +6194,25 @@ Nomatch:
  */
 bool TypeFunction::hasLazyParameters()
 {
-    size_t dim = Parameter::dim(parameters);
+    size_t dim = parameterList.length();
     for (size_t i = 0; i < dim; i++)
     {
-        Parameter *fparam = Parameter::getNth(parameters, i);
+        Parameter *fparam = parameterList[i];
         if (fparam->storageClass & STClazy)
             return true;
     }
     return false;
+}
+
+/*******************************
+ * Check for `extern (D) U func(T t, ...)` variadic function type,
+ * which has `_arguments[]` added as the first argument.
+ * Returns:
+ *  true if D-style variadic
+ */
+bool TypeFunction::isDstyleVariadic() const
+{
+    return linkage == LINKd && parameterList.varargs == VARARGvariadic;
 }
 
 /***************************
@@ -6254,10 +6267,10 @@ StorageClass TypeFunction::parameterStorageClass(Parameter *p)
     // See if p can escape via any of the other parameters
     if (purity == PUREweak)
     {
-        const size_t dim = Parameter::dim(parameters);
+        const size_t dim = parameterList.length();
         for (size_t i = 0; i < dim; i++)
         {
-            Parameter *fparam = Parameter::getNth(parameters, i);
+            Parameter *fparam = parameterList[i];
             Type *t = fparam->type;
             if (!t)
                 continue;
@@ -6305,7 +6318,7 @@ Type *TypeFunction::addStorageClass(StorageClass stc)
         (stc & STCsafe && t->trust < TRUSTtrusted))
     {
         // Klunky to change these
-        TypeFunction *tf = new TypeFunction(t->parameters, t->next, t->varargs, t->linkage, 0);
+        TypeFunction *tf = new TypeFunction(t->parameterList, t->next, t->linkage, 0);
         tf->mod = t->mod;
         tf->fargs = fargs;
         tf->purity = t->purity;
@@ -9298,6 +9311,22 @@ Expression *TypeNull::defaultInit(Loc)
     return new NullExp(Loc(), Type::tnull);
 }
 
+/***********************************************************
+ * Encapsulate Parameters* so .length and [i] can be used on it.
+ * https://dlang.org/spec/function.html#ParameterList
+ */
+
+ParameterList::ParameterList(Parameters *parameters, VarArg varargs)
+{
+    this->parameters = parameters;
+    this->varargs = varargs;
+}
+
+size_t ParameterList::length()
+{
+    return Parameter::dim(parameters);
+}
+
 /***************************** Parameter *****************************/
 
 Parameter::Parameter(StorageClass storageClass, Type *type, Identifier *ident, Expression *defaultArg)
@@ -9355,7 +9384,7 @@ Type *Parameter::isLazyArray()
             TypeDelegate *td = (TypeDelegate *)tel;
             TypeFunction *tf = td->next->toTypeFunction();
 
-            if (!tf->varargs && Parameter::dim(tf->parameters) == 0)
+            if (!tf->parameterList.varargs == VARARGnone && tf->parameterList.length() == 0)
             {
                 return tf->next;    // return type of delegate
             }

--- a/src/opover.c
+++ b/src/opover.c
@@ -1923,9 +1923,9 @@ static int inferApplyArgTypesY(TypeFunction *tf, Parameters *parameters, int fla
 {   size_t nparams;
     Parameter *p;
 
-    if (Parameter::dim(tf->parameters) != 1)
+    if (tf->parameterList.length() != 1)
         goto Lnomatch;
-    p = Parameter::getNth(tf->parameters, 0);
+    p = tf->parameterList[0];
     if (p->type->ty != Tdelegate)
         goto Lnomatch;
     tf = (TypeFunction *)p->type->nextOf();
@@ -1934,8 +1934,8 @@ static int inferApplyArgTypesY(TypeFunction *tf, Parameters *parameters, int fla
     /* We now have tf, the type of the delegate. Match it against
      * the parameters, filling in missing parameter types.
      */
-    nparams = Parameter::dim(tf->parameters);
-    if (nparams == 0 || tf->varargs)
+    nparams = tf->parameterList.length();
+    if (nparams == 0 || tf->parameterList.varargs != VARARGnone)
         goto Lnomatch;          // not enough parameters
     if (parameters->length != nparams)
         goto Lnomatch;          // not enough parameters
@@ -1943,7 +1943,7 @@ static int inferApplyArgTypesY(TypeFunction *tf, Parameters *parameters, int fla
     for (size_t u = 0; u < nparams; u++)
     {
         p = (*parameters)[u];
-        Parameter *param = Parameter::getNth(tf->parameters, u);
+        Parameter *param = tf->parameterList[u];
         if (p->type)
         {
             if (!p->type->equals(param->type))

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -531,7 +531,7 @@ Expression *Expression_optimize(Expression *e, int result, bool keepLvalue)
                 TypeFunction *tf = (TypeFunction *)t1;
                 for (size_t i = 0; i < e->arguments->length; i++)
                 {
-                    Parameter *p = Parameter::getNth(tf->parameters, i);
+                    Parameter *p = tf->parameterList[i];
                     bool keep = p && (p->storageClass & (STCref | STCout)) != 0;
                     expOptimize((*e->arguments)[i], WANTvalue, keep);
                 }

--- a/src/parse.h
+++ b/src/parse.h
@@ -103,7 +103,7 @@ public:
     Dsymbol *parseUnitTest(PrefixAttributes *pAttrs);
     Dsymbol *parseNew(PrefixAttributes *pAttrs);
     Dsymbol *parseDelete(PrefixAttributes *pAttrs);
-    Parameters *parseParameters(int *pvarargs, TemplateParameters **tpl = NULL);
+    Parameters *parseParameters(VarArg *pvarargs, TemplateParameters **tpl = NULL);
     EnumDeclaration *parseEnum();
     Dsymbol *parseAggregate();
     BaseClasses *parseBaseClasses();

--- a/src/statementsem.c
+++ b/src/statementsem.c
@@ -897,18 +897,17 @@ public:
             {
                 if (FuncDeclaration *fd = sapplyOld->isFuncDeclaration())
                 {
-                    int fvarargs;  // ignored (opApply shouldn't take variadics)
-                    Parameters *fparameters = fd->getParameters(&fvarargs);
+                    ParameterList fparameters = fd->getParameterList();
 
-                    if (Parameter::dim(fparameters) == 1)
+                    if (fparameters.length() == 1)
                     {
                         // first param should be the callback function
-                        Parameter *fparam = Parameter::getNth(fparameters, 0);
+                        Parameter *fparam = fparameters[0];
                         if ((fparam->type->ty == Tpointer || fparam->type->ty == Tdelegate) &&
                             fparam->type->nextOf()->ty == Tfunction)
                         {
                             TypeFunction *tf = (TypeFunction *)fparam->type->nextOf();
-                            foreachParamCount = Parameter::dim(tf->parameters);
+                            foreachParamCount = tf->parameterList.length();
                             foundMismatch = true;
                         }
                     }
@@ -1433,9 +1432,9 @@ public:
                             tfld = (TypeFunction *)tab->nextOf();
                         Lget:
                             //printf("tfld = %s\n", tfld->toChars());
-                            if (tfld->parameters->length == 1)
+                            if (tfld->parameterList.parameters->length == 1)
                             {
-                                Parameter *p = Parameter::getNth(tfld->parameters, 0);
+                                Parameter *p = tfld->parameterList[0];
                                 if (p->type && p->type->ty == Tdelegate)
                                 {
                                     Type *t = p->type->semantic(loc, sc2);
@@ -1460,7 +1459,7 @@ public:
                         p->type = p->type->addStorageClass(p->storageClass);
                         if (tfld)
                         {
-                            Parameter *prm = Parameter::getNth(tfld->parameters, i);
+                            Parameter *prm = tfld->parameterList[i];
                             //printf("\tprm = %s%s\n", (prm->storageClass&STCref?"ref ":""), prm->ident->toChars());
                             stc = prm->storageClass & STCref;
                             id = p->ident;    // argument copy is not need.
@@ -1497,7 +1496,7 @@ public:
                     }
                     // Bugzilla 13840: Throwable nested function inside nothrow function is acceptable.
                     StorageClass stc = mergeFuncAttrs(STCsafe | STCpure | STCnogc, fs->func);
-                    tfld = new TypeFunction(params, Type::tint32, 0, LINKd, stc);
+                    tfld = new TypeFunction(ParameterList(params), Type::tint32, LINKd, stc);
                     fs->cases = new Statements();
                     fs->gotos = new ScopeStatements();
                     FuncLiteralDeclaration *fld = new FuncLiteralDeclaration(loc, Loc(), tfld, TOKdelegate, fs);
@@ -1575,7 +1574,8 @@ public:
                             dgparams->push(new Parameter(0, Type::tvoidptr, NULL, NULL));
                             if (dim == 2)
                                 dgparams->push(new Parameter(0, Type::tvoidptr, NULL, NULL));
-                            fldeTy[i] = new TypeDelegate(new TypeFunction(dgparams, Type::tint32, 0, LINKd));
+                            fldeTy[i] = new TypeDelegate(new TypeFunction(ParameterList(dgparams),
+                                                                          Type::tint32, LINKd));
                             params->push(new Parameter(0, fldeTy[i], NULL, NULL));
                             fdapply[i] = FuncDeclaration::genCfunc(params, Type::tint32, name[i]);
                         }
@@ -1640,7 +1640,8 @@ public:
                         dgparams->push(new Parameter(0, Type::tvoidptr, NULL, NULL));
                         if (dim == 2)
                             dgparams->push(new Parameter(0, Type::tvoidptr, NULL, NULL));
-                        dgty = new TypeDelegate(new TypeFunction(dgparams, Type::tint32, 0, LINKd));
+                        dgty = new TypeDelegate(new TypeFunction(ParameterList(dgparams),
+                                                                 Type::tint32, LINKd));
                         params->push(new Parameter(0, dgty, NULL, NULL));
                         fdapply = FuncDeclaration::genCfunc(params, Type::tint32, fdname);
 

--- a/src/target.c
+++ b/src/target.c
@@ -534,7 +534,7 @@ Type *TargetCPP::parameterType(Parameter *p)
     else if (p->storageClass & STClazy)
     {
         // Mangle as delegate
-        Type *td = new TypeFunction(NULL, t, 0, LINKd);
+        Type *td = new TypeFunction(ParameterList(), t, LINKd);
         td = new TypeDelegate(td);
         t = t->merge();
     }

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -347,7 +347,7 @@ Symbol *toSymbol(Dsymbol *s)
                         s->Sflags |= SFLpublic;
                         if (fd->isThis() && !global.params.is64bit && global.params.isWindows)
                         {
-                            if (((TypeFunction *)fd->type)->varargs == 1)
+                            if (((TypeFunction *)fd->type)->parameterList.varargs == VARARGvariadic)
                             {
                                 t->Tty = TYnfunc;
                             }

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -72,7 +72,7 @@ public:
 
     void visit(TypeFunction *t)
     {
-        size_t nparams = Parameter::dim(t->parameters);
+        size_t nparams = t->parameterList.length();
 
         type *tmp[10];
         type **ptypes = tmp;
@@ -81,7 +81,7 @@ public:
 
         for (size_t i = 0; i < nparams; i++)
         {
-            Parameter *p = Parameter::getNth(t->parameters, i);
+            Parameter *p = t->parameterList[i];
             type *tp = Type_toCtype(p->type);
             if (p->storageClass & (STCout | STCref))
                 tp = type_allocn(TYnref, tp);
@@ -94,7 +94,7 @@ public:
             ptypes[i] = tp;
         }
 
-        t->ctype = type_function(totym(t), ptypes, nparams, t->varargs == 1, Type_toCtype(t->next));
+        t->ctype = type_function(totym(t), ptypes, nparams, t->parameterList.varargs == 1, Type_toCtype(t->next));
 
         if (nparams > 10)
             free(ptypes);

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -653,7 +653,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                                 if (tf->ty == Tfunction)
                                     cd->error("use of %s%s is hidden by %s; use 'alias %s = %s.%s;' to introduce base class overload set",
                                         fd->toPrettyChars(),
-                                        parametersTypeToChars(tf->parameters, tf->varargs),
+                                        parametersTypeToChars(tf->parameterList),
                                         cd->toChars(),
 
                                         fd->toChars(),

--- a/src/traits.c
+++ b/src/traits.c
@@ -969,7 +969,7 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
             return dimError(e, 1, dim);
 
         LINK link;
-        int varargs;
+        VarArg varargs;
         RootObject *o = (*e->args)[0];
         Type *t = isType(o);
         TypeFunction *tf = NULL;
@@ -985,7 +985,7 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
         if (tf)
         {
             link = tf->linkage;
-            varargs = tf->varargs;
+            varargs = tf->parameterList.varargs;
         }
         else
         {
@@ -997,7 +997,7 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
                 return new ErrorExp();
             }
             link = fd->linkage;
-            fd->getParameters(&varargs);
+            varargs = fd->getParameterList().varargs;
         }
         const char *style;
         switch (varargs)
@@ -1034,10 +1034,10 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
             else if (t->ty == Tpointer && t->nextOf()->ty == Tfunction)
                 tf = (TypeFunction *)t->nextOf();
         }
-        Parameters* fparams;
+        ParameterList fparams;
         if (tf)
         {
-            fparams = tf->parameters;
+            fparams = tf->parameterList;
         }
         else
         {
@@ -1049,7 +1049,7 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
                     o->toChars(), o1->toChars());
                 return new ErrorExp();
             }
-            fparams = fd->getParameters(NULL);
+            fparams = fd->getParameterList();
         }
 
         StorageClass stc;
@@ -1064,14 +1064,14 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
         }
         ex = ex->ctfeInterpret();
         uinteger_t ii = ex->toUInteger();
-        if (ii >= Parameter::dim(fparams))
+        if (ii >= fparams.length())
         {
-            e->error("parameter index must be in range 0..%u not %s", (unsigned)Parameter::dim(fparams), ex->toChars());
+            e->error("parameter index must be in range 0..%u not %s", (unsigned)fparams.length(), ex->toChars());
             return new ErrorExp();
         }
 
         unsigned n = (unsigned)ii;
-        Parameter *p = Parameter::getNth(fparams, n);
+        Parameter *p = fparams[n];
         stc = p->storageClass;
 
         // This mirrors hdrgen.visit(Parameter p)


### PR DESCRIPTION
Pulls in 'enum VarArg', 'isDstyleVariadic', and 'getParameterList' as dependencies in the refactoring.

A ParameterList constructor has been added for the convenience of the C++ port, this is not present in upstream DMD.