### PR TITLE
target: Rename va_list field to tvalist

### DIFF
--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -107,7 +107,7 @@ extern (C++) struct Target
     FPTypeProperties!double DoubleProperties;   ///
     FPTypeProperties!real_t RealProperties;     ///
 
-    private Type va_list; // cached lazy result of va_listType()
+    private Type tvalist; // cached lazy result of va_listType()
 
     /**
      * Initialize the Target
@@ -262,24 +262,24 @@ extern (C++) struct Target
      */
     extern (C++) Type va_listType(const ref Loc loc, Scope* sc)
     {
-        if (va_list)
-            return va_list;
+        if (tvalist)
+            return tvalist;
 
         if (global.params.isWindows)
         {
-            va_list = Type.tchar.pointerTo();
+            tvalist = Type.tchar.pointerTo();
         }
         else if (global.params.isLinux        || global.params.isFreeBSD || global.params.isOpenBSD ||
                  global.params.isDragonFlyBSD || global.params.isSolaris || global.params.isOSX)
         {
             if (global.params.is64bit)
             {
-                va_list = new TypeIdentifier(Loc.initial, Identifier.idPool("__va_list_tag")).pointerTo();
-                va_list = typeSemantic(va_list, loc, sc);
+                tvalist = new TypeIdentifier(Loc.initial, Identifier.idPool("__va_list_tag")).pointerTo();
+                tvalist = typeSemantic(tvalist, loc, sc);
             }
             else
             {
-                va_list = Type.tchar.pointerTo();
+                tvalist = Type.tchar.pointerTo();
             }
         }
         else
@@ -287,7 +287,7 @@ extern (C++) struct Target
             assert(0);
         }
 
-        return va_list;
+        return tvalist;
     }
 
     /**

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -90,7 +90,7 @@ struct Target
     FPTypeProperties<real_t> RealProperties;
 
 private:
-    Type *va_list;
+    Type *tvalist;
 
 public:
     void _init(const Param& params);


### PR DESCRIPTION
The former name just makes my eyes burn (also, there's a limitation that you can no longer use `va_list` as a type inside a Target member function).