### PR TITLE
Fix 20410 - ReplaceTypeUnless replaces enums with their basetype

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -4349,6 +4349,8 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             if (tb.ty == tparam.ty || tb.ty == Tsarray && tparam.ty == Taarray)
             {
                 result = deduceType(tb, sc, tparam, parameters, dedtypes, wm);
+                if (result == MATCH.exact)
+                    result = MATCH.convert;
                 return;
             }
             visit(cast(Type)t);

--- a/test/compilable/test20410.d
+++ b/test/compilable/test20410.d
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=20410
+
+enum E : string { foo = "foo" }
+
+static assert( is(E  : string));
+static assert( is(E  : T[], T));
+static assert(!is(E == string));
+static assert(!is(E == T[], T));


### PR DESCRIPTION
When matching an enum against a type specialization, a match obtained
using the enum's base type is now correctly considered a match by
implicit conversion rather than an exact match.