### PR TITLE
do not Copy-Propagate static variables

### DIFF
--- a/src/dmd/backend/gflow.d
+++ b/src/dmd/backend/gflow.d
@@ -580,6 +580,7 @@ private void aecpgenkill(ref GlobalOptimizer go, int flowxx)
                     n.EV.E1.Eoper == OPvar &&
                     n.EV.E2.Eoper == OPvar &&
                     !((n.EV.E1.Ety | n.EV.E2.Ety) & (mTYvolatile | mTYshared)) &&
+                    !((n.EV.E1.EV.Vsym.Sflags | n.EV.E2.EV.Vsym.Sflags) & SFLlivexit) &&
                     n.EV.E1.EV.Vsym != n.EV.E2.EV.Vsym)
                 {
                     n.Nflags |= NFLaecp;

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1959,6 +1959,25 @@ void test20050()
 
 ////////////////////////////////////////////////////////////////////////
 
+// http://github.com/dlang/dmd/pull/11238
+
+int testCpStatic1(int y)
+{
+    __gshared int yyy = 7;
+    auto x = yyy; // no copy-propagation
+    if (y)
+        return x;
+    return x + 3;
+}
+
+void testCpStatic()
+{
+    assert(testCpStatic1(1) == 7);
+    assert(testCpStatic1(0) == 10);
+}
+
+////////////////////////////////////////////////////////////////////////
+
 int main()
 {
     testgoto();
@@ -2029,6 +2048,7 @@ int main()
     testfastpar();
     testNegConst();
     test20050();
+    testCpStatic();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
because it prevents caching a static in a local variable that might get enregistered.