### PR TITLE
dcompat.h: Don't segfault when initializing DStrings with a NULL pointer and fix DMC compatibility

### DIFF
--- a/src/dmd/root/dcompat.h
+++ b/src/dmd/root/dcompat.h
@@ -29,7 +29,7 @@ struct DString : public DArray<const char>
     DString() : DArray() { }
 
     DString(const char *ptr)
-        : DArray(strlen(ptr), ptr) { }
+        : DArray(ptr ? strlen(ptr) : 0, ptr) { }
 
     DString(size_t length, const char *ptr)
         : DArray(length, ptr) { }

--- a/src/dmd/root/dcompat.h
+++ b/src/dmd/root/dcompat.h
@@ -26,13 +26,13 @@ struct DArray
 
 struct DString : public DArray<const char>
 {
-    DString() : DArray() { }
+    DString() : DArray<const char>() { }
 
     DString(const char *ptr)
-        : DArray(ptr ? strlen(ptr) : 0, ptr) { }
+        : DArray<const char>(ptr ? strlen(ptr) : 0, ptr) { }
 
     DString(size_t length, const char *ptr)
-        : DArray(length, ptr) { }
+        : DArray<const char>(length, ptr) { }
 };
 
 /// Corresponding C++ type that maps to D size_t

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -69,6 +69,7 @@ static void frontend_init()
     global._init();
     global.params.isLinux = true;
     global.vendor = "Front-End Tester";
+    global.params.objname = NULL;
 
     Type::_init();
     Id::initialize();


### PR DESCRIPTION
These were things noted when trying out DStrings in the dmd-cxx branch.