### PR TITLE
Small type mismatch in loop variable

### DIFF
--- a/src/dmd/backend/out.d
+++ b/src/dmd/backend/out.d
@@ -663,9 +663,9 @@ Symbol *out_string_literal(const(char)* str, uint len, uint sz)
             break;
 
         case 2:
-            for (int i = 0; i < len; ++i)
+            foreach (i; 0 .. len)
             {
-                const(ushort)* p = cast(const(ushort)*)str;
+                auto p = cast(const(ushort)*)str;
                 if (p[i] == 0)
                 {
                     s.Sseg = CDATA;
@@ -675,9 +675,9 @@ Symbol *out_string_literal(const(char)* str, uint len, uint sz)
             break;
 
         case 4:
-            for (int i = 0; i < len; ++i)
+            foreach (i; 0 .. len)
             {
-                const(uint)* p = cast(const(uint)*)str;
+                auto p = cast(const(uint)*)str;
                 if (p[i] == 0)
                 {
                     s.Sseg = CDATA;


### PR DESCRIPTION
len is uint so should be the i loop variable. While 2 billion char long symbols are unlikely and the bug will probably never trigger (indexing the p with a negative value) it is still a bug.
Submitted also as a training wheel submission to learn the contribution procedure.