### PR TITLE
Fix Issue 20909 - .offsetof fails on forward reference of field

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3124,6 +3124,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         {
             if (ident == Id.offsetof)
             {
+                v.dsymbolSemantic(null);
                 if (v.isField())
                 {
                     auto ad = v.toParent().isAggregateDeclaration();

--- a/test/compilable/test20909.d
+++ b/test/compilable/test20909.d
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=20909
+
+struct S
+{
+    long a;
+    static assert(x.sizeof == 4);
+    enum offset = x.offsetof;
+    static assert(offset == 8);   // OK now
+    int x;
+}


### PR DESCRIPTION
Run semantic on the variable first to make sure it's an instance field.