### PR TITLE
Fix Issue 20919 - DMD crash when '__traits' prints error involving a …

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3333,6 +3333,10 @@ private void objectToBuffer(RootObject oarg, OutBuffer* buf, HdrGenState* hgs)
             objectToBuffer(arg, buf, hgs);
         }
     }
+    else if (auto p = isParameter(oarg))
+    {
+        parameterToBuffer(p, buf, hgs);
+    }
     else if (!oarg)
     {
         buf.writestring("NULL");

--- a/test/fail_compilation/test20919.d
+++ b/test/fail_compilation/test20919.d
@@ -1,0 +1,13 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test20919.d(12): Error: `__traits(getAttributes, int a)` does not give a valid type
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=20919
+
+void foo(int a) {}
+
+static if (is(typeof(foo) params == __parameters))
+{
+    __traits(getAttributes, params) a;
+}


### PR DESCRIPTION
…Parameter