### PR TITLE
Fix Issue 20923 - Redefinition of 'size_t' is affecting TypeStruct fu…

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -809,7 +809,7 @@ FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
      * hash value will also contain the result of parent class's toHash().
      */
     const(char)[] code =
-        "size_t h = 0;" ~
+        ".object.size_t h = 0;" ~
         "foreach (i, T; typeof(p.tupleof))" ~
         // workaround https://issues.dlang.org/show_bug.cgi?id=17968
         "    static if(is(T* : const(.object.Object)*)) " ~

--- a/test/compilable/test20923.d
+++ b/test/compilable/test20923.d
@@ -1,0 +1,13 @@
+version (D_LP64)
+{
+    alias size_t = uint;
+}
+else
+{
+    alias size_t = ulong;
+}
+
+struct S
+{
+    real not_reproduceable_without_this_variable;
+}


### PR DESCRIPTION
…nctions

Quoting bugzilla message: 

The redefinition of size_t is affecting builtin TypeStruct functions (these don't have location info), this is clearly a bug.
The code should work and you can change size_t but if you are intended to do it for this kind of methods you should be modifying object.d.