### PR TITLE
Changed entry points to be function literals and made semantic visitors inheritable

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -29,6 +29,9 @@ import dmd.semantic2;
 import dmd.semantic3;
 import dmd.tokens;
 import dmd.statement;
+import dmd.dsymbol;
+import dmd.dtemplate;
+import dmd.init;
 
 extern (C++) __gshared
 {
@@ -172,6 +175,20 @@ extern (C++) struct Compiler
          */
         __gshared OnStatementSemanticDone onStatementSemanticDone
                     = function void(Statement s, Scope *sc) {};
+
+        alias AlternativeDsymbolSemantic = void function(Dsymbol, Scope*);
+        alias AlternativeStatementSemantic = Statement function(Statement, Scope*);
+        alias AlternativeExpressionSemantic = Expression function(Expression, Scope*);
+        alias AlternativeTemplateParamSemantic = bool function(TemplateParameter, Scope*, TemplateParameters*);
+        alias AlternativeTypeSemantic = Type function(Type, const ref Loc, Scope*);
+        alias AlternativeInitializerSemantic = Initializer function(Initializer, Scope*, Type, NeedInterpret);
+
+        __gshared AlternativeDsymbolSemantic alternativeDsymbolSemantic;
+        __gshared AlternativeStatementSemantic alternativeStatementSemantic;
+        __gshared AlternativeExpressionSemantic alternativeExpressionSemantic;
+        __gshared AlternativeTemplateParamSemantic alternativeTemplateParamSemantic;
+        __gshared AlternativeTypeSemantic alternativeTypeSemantic;
+        __gshared AlternativeInitializerSemantic alternativeInitializerSemantic;
     }
 }
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -558,11 +558,12 @@ private uint setMangleOverride(Dsymbol s, const(char)[] sym)
 /*************************************
  * Does semantic analysis on the public face of declarations.
  */
-extern(C++) void dsymbolSemantic(Dsymbol dsym, Scope* sc)
-{
-    scope v = new DsymbolSemanticVisitor(sc);
-    dsym.accept(v);
-}
+__gshared extern(C++) void function(Dsymbol dsym, Scope* sc) dsymbolSemantic
+    = function void(Dsymbol dsym, Scope* sc)
+        {
+            scope v = new DsymbolSemanticVisitor(sc);
+            dsym.accept(v);
+        };
 
 structalign_t getAlignment(AlignDeclaration ad, Scope* sc)
 {
@@ -636,7 +637,7 @@ package bool allowsContractWithoutBody(FuncDeclaration funcdecl)
     return true;
 }
 
-private extern(C++) final class DsymbolSemanticVisitor : Visitor
+extern(C++) class DsymbolSemanticVisitor : Visitor
 {
     alias visit = Visitor.visit;
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -70,6 +70,7 @@ import dmd.target;
 import dmd.templateparamsem;
 import dmd.typesem;
 import dmd.visitor;
+import dmd.compiler;
 
 enum LOG = false;
 
@@ -560,6 +561,15 @@ private uint setMangleOverride(Dsymbol s, const(char)[] sym)
  */
 extern(C++) void dsymbolSemantic(Dsymbol dsym, Scope* sc)
 {
+    version (CallbackAPI)
+    {
+        if (Compiler.alternativeDsymbolSemantic)
+        {
+            Compiler.alternativeDsymbolSemantic(dsym, sc);
+            return;
+        }
+    }
+
     scope v = new DsymbolSemanticVisitor(sc);
     dsym.accept(v);
 }

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -558,12 +558,11 @@ private uint setMangleOverride(Dsymbol s, const(char)[] sym)
 /*************************************
  * Does semantic analysis on the public face of declarations.
  */
-__gshared extern(C++) void function(Dsymbol dsym, Scope* sc) dsymbolSemantic
-    = function void(Dsymbol dsym, Scope* sc)
-        {
-            scope v = new DsymbolSemanticVisitor(sc);
-            dsym.accept(v);
-        };
+extern(C++) void dsymbolSemantic(Dsymbol dsym, Scope* sc)
+{
+    scope v = new DsymbolSemanticVisitor(sc);
+    dsym.accept(v);
+}
 
 structalign_t getAlignment(AlignDeclaration ad, Scope* sc)
 {
@@ -637,7 +636,15 @@ package bool allowsContractWithoutBody(FuncDeclaration funcdecl)
     return true;
 }
 
-extern(C++) class DsymbolSemanticVisitor : Visitor
+private extern (C++) final class DsymbolSemanticVisitor : DsymbolSemanticVisitorImpl
+{
+    this(Scope* sc)
+    {
+        super(sc);
+    }
+}
+
+extern (C++) abstract class DsymbolSemanticVisitorImpl : Visitor
 {
     alias visit = Visitor.visit;
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2463,7 +2463,15 @@ private Module loadStdMath()
     return impStdMath.mod;
 }
 
-extern (C++) class ExpressionSemanticVisitor : Visitor
+private extern (C++) final class ExpressionSemanticVisitor : ExpressionSemanticVisitorImpl
+{
+    this(Scope* sc)
+    {
+        super(sc);
+    }
+}
+
+extern (C++) abstract class ExpressionSemanticVisitorImpl : Visitor
 {
     alias visit = Visitor.visit;
 
@@ -11471,16 +11479,13 @@ Expression binSemanticProp(BinExp e, Scope* sc)
     return null;
 }
 
-/**
- * Entrypoint for semantic ExpressionSemanticVisitor
- */
-__gshared extern (C++) Expression function(Expression e, Scope* sc) expressionSemantic
-    = function Expression(Expression e, Scope* sc)
-        {
-            scope v = new ExpressionSemanticVisitor(sc);
-            e.accept(v);
-            return v.result;
-        };
+// entrypoint for semantic ExpressionSemanticVisitor
+extern (C++) Expression expressionSemantic(Expression e, Scope* sc)
+{
+    scope v = new ExpressionSemanticVisitor(sc);
+    e.accept(v);
+    return v.result;
+}
 
 Expression semanticX(DotIdExp exp, Scope* sc)
 {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2463,7 +2463,7 @@ private Module loadStdMath()
     return impStdMath.mod;
 }
 
-private extern (C++) final class ExpressionSemanticVisitor : Visitor
+extern (C++) class ExpressionSemanticVisitor : Visitor
 {
     alias visit = Visitor.visit;
 
@@ -11471,13 +11471,16 @@ Expression binSemanticProp(BinExp e, Scope* sc)
     return null;
 }
 
-// entrypoint for semantic ExpressionSemanticVisitor
-extern (C++) Expression expressionSemantic(Expression e, Scope* sc)
-{
-    scope v = new ExpressionSemanticVisitor(sc);
-    e.accept(v);
-    return v.result;
-}
+/**
+ * Entrypoint for semantic ExpressionSemanticVisitor
+ */
+__gshared extern (C++) Expression function(Expression e, Scope* sc) expressionSemantic
+    = function Expression(Expression e, Scope* sc)
+        {
+            scope v = new ExpressionSemanticVisitor(sc);
+            e.accept(v);
+            return v.result;
+        };
 
 Expression semanticX(DotIdExp exp, Scope* sc)
 {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -75,6 +75,7 @@ import dmd.typinf;
 import dmd.utf;
 import dmd.utils;
 import dmd.visitor;
+import dmd.compiler;
 
 enum LOGSEMANTIC = false;
 
@@ -11482,6 +11483,11 @@ Expression binSemanticProp(BinExp e, Scope* sc)
 // entrypoint for semantic ExpressionSemanticVisitor
 extern (C++) Expression expressionSemantic(Expression e, Scope* sc)
 {
+    version (CallbackAPI)
+        if (Compiler.alternativeExpressionSemantic)
+            return Compiler.alternativeExpressionSemantic(e, sc);
+
+
     scope v = new ExpressionSemanticVisitor(sc);
     e.accept(v);
     return v.result;

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -37,6 +37,7 @@ import dmd.statement;
 import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
+import dmd.compiler;
 
 /********************************
  * If possible, convert array initializer to associative array initializer.
@@ -91,6 +92,12 @@ Lno:
  */
 extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t, NeedInterpret needInterpret)
 {
+    version (CallbackAPI)
+    {
+        if (Compiler.alternativeInitializerSemantic)
+            return Compiler.alternativeInitializerSemantic(init, sc, t, needInterpret);
+    }
+
     Initializer visitVoid(VoidInitializer i)
     {
         i.type = t;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -125,7 +125,12 @@ private Expression checkAssignmentAsCondition(Expression e)
 extern(C++) Statement statementSemantic(Statement s, Scope* sc)
 {
     version (CallbackAPI)
+    {
         Compiler.onStatementSemanticStart(s, sc);
+
+        if (Compiler.alternativeStatementSemantic)
+            return Compiler.alternativeStatementSemantic(s, sc);
+    }
 
     scope v = new StatementSemanticVisitor(sc);
     s.accept(v);

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -121,22 +121,25 @@ private Expression checkAssignmentAsCondition(Expression e)
     return e;
 }
 
-// Performs semantic analysis in Statement AST nodes
-extern(C++) Statement statementSemantic(Statement s, Scope* sc)
-{
-    version (CallbackAPI)
-        Compiler.onStatementSemanticStart(s, sc);
+/**
+ * Performs semantic analysis in Statement AST nodes
+ */
+__gshared extern (C++) Statement function(Statement, Scope*) statementSemantic
+    = function Statement(Statement s, Scope* sc)
+        {
+            version (CallbackAPI)
+                Compiler.onStatementSemanticStart(s, sc);
 
-    scope v = new StatementSemanticVisitor(sc);
-    s.accept(v);
+            scope v = new StatementSemanticVisitor(sc);
+            s.accept(v);
 
-    version (CallbackAPI)
-        Compiler.onStatementSemanticDone(s, sc);
+            version (CallbackAPI)
+                Compiler.onStatementSemanticDone(s, sc);
 
-    return v.result;
-}
+            return v.result;
+        };
 
-private extern (C++) final class StatementSemanticVisitor : Visitor
+extern (C++) class StatementSemanticVisitor : Visitor
 {
     alias visit = Visitor.visit;
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -121,25 +121,30 @@ private Expression checkAssignmentAsCondition(Expression e)
     return e;
 }
 
-/**
- * Performs semantic analysis in Statement AST nodes
- */
-__gshared extern (C++) Statement function(Statement, Scope*) statementSemantic
-    = function Statement(Statement s, Scope* sc)
-        {
-            version (CallbackAPI)
-                Compiler.onStatementSemanticStart(s, sc);
+// Performs semantic analysis in Statement AST nodes
+extern(C++) Statement statementSemantic(Statement s, Scope* sc)
+{
+    version (CallbackAPI)
+        Compiler.onStatementSemanticStart(s, sc);
 
-            scope v = new StatementSemanticVisitor(sc);
-            s.accept(v);
+    scope v = new StatementSemanticVisitor(sc);
+    s.accept(v);
 
-            version (CallbackAPI)
-                Compiler.onStatementSemanticDone(s, sc);
+    version (CallbackAPI)
+        Compiler.onStatementSemanticDone(s, sc);
 
-            return v.result;
-        };
+    return v.result;
+}
 
-extern (C++) class StatementSemanticVisitor : Visitor
+private extern (C++) final class StatementSemanticVisitor : StatementSemanticVisitorImpl
+{
+    this(Scope* sc)
+    {
+        super(sc);
+    }
+}
+
+extern (C++) abstract class StatementSemanticVisitorImpl : Visitor
 {
     alias visit = Visitor.visit;
 

--- a/src/dmd/templateparamsem.d
+++ b/src/dmd/templateparamsem.d
@@ -22,6 +22,7 @@ import dmd.root.rootobject;
 import dmd.mtype;
 import dmd.typesem;
 import dmd.visitor;
+import dmd.compiler;
 
 /************************************************
  * Performs semantic on TemplateParameter AST nodes.
@@ -35,6 +36,10 @@ import dmd.visitor;
  */
 extern(C++) bool tpsemantic(TemplateParameter tp, Scope* sc, TemplateParameters* parameters)
 {
+    version (CallbackAPI)
+        if (Compiler.alternativeTemplateParamSemantic)
+            return Compiler.alternativeTemplateParamSemantic(tp, sc, parameters);
+
     scope v = new TemplateParameterSemanticVisitor(sc, parameters);
     tp.accept(v);
     return v.result;

--- a/src/dmd/templateparamsem.d
+++ b/src/dmd/templateparamsem.d
@@ -33,15 +33,17 @@ import dmd.visitor;
  * Returns:
  *      `true` if no errors
  */
-extern(C++) bool tpsemantic(TemplateParameter tp, Scope* sc, TemplateParameters* parameters)
-{
-    scope v = new TemplateParameterSemanticVisitor(sc, parameters);
-    tp.accept(v);
-    return v.result;
-}
+__gshared extern(C++) bool function(TemplateParameter tp, Scope* sc,
+                                    TemplateParameters* parameters) tpsemantic
+    = function bool(TemplateParameter tp, Scope* sc, TemplateParameters* parameters)
+        {
+            scope v = new TemplateParameterSemanticVisitor(sc, parameters);
+            tp.accept(v);
+            return v.result;
+        };
 
 
-private extern (C++) final class TemplateParameterSemanticVisitor : Visitor
+extern (C++) class TemplateParameterSemanticVisitor : Visitor
 {
     alias visit = Visitor.visit;
 

--- a/src/dmd/templateparamsem.d
+++ b/src/dmd/templateparamsem.d
@@ -33,17 +33,22 @@ import dmd.visitor;
  * Returns:
  *      `true` if no errors
  */
-__gshared extern(C++) bool function(TemplateParameter tp, Scope* sc,
-                                    TemplateParameters* parameters) tpsemantic
-    = function bool(TemplateParameter tp, Scope* sc, TemplateParameters* parameters)
-        {
-            scope v = new TemplateParameterSemanticVisitor(sc, parameters);
-            tp.accept(v);
-            return v.result;
-        };
+extern(C++) bool tpsemantic(TemplateParameter tp, Scope* sc, TemplateParameters* parameters)
+{
+    scope v = new TemplateParameterSemanticVisitor(sc, parameters);
+    tp.accept(v);
+    return v.result;
+}
 
+private extern (C++) final class TemplateParameterSemanticVisitor : TemplateParameterSemanticVisitorImpl
+{
+    this(Scope* sc, TemplateParameters* parameters)
+    {
+        super(sc, parameters);
+    }
+}
 
-extern (C++) class TemplateParameterSemanticVisitor : Visitor
+extern (C++) abstract class TemplateParameterSemanticVisitorImpl : Visitor
 {
     alias visit = Visitor.visit;
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -61,6 +61,7 @@ import dmd.sideeffect;
 import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
+import dmd.compiler;
 
 /**************************
  * This evaluates exp while setting length to be the number
@@ -641,6 +642,10 @@ Expression typeToExpressionHelper(TypeQualified t, Expression e, size_t i = 0)
  */
 extern(C++) Type typeSemantic(Type t, const ref Loc loc, Scope* sc)
 {
+    version (CallbackAPI)
+        if (Compiler.alternativeTypeSemantic)
+            Compiler.alternativeTypeSemantic(t, loc, sc);
+
     static Type error()
     {
         return Type.terror;


### PR DESCRIPTION
I have changed the entry points to be function literals so that the user of the DMD library could alter semantic analysis (e.g. by using a different visitor). This is also the reason why I removed the `private` and `final` specifiers from the visitors, as being able to extend them is crucial for more flexibility. For instance, while handling autocompletion in DCD, I've come across the need to be able to extract information from an incomplete function call:

`int foo(int bar) {...}`

`foo()`

I want to be able to give the signature of the function as a pop-up suggestion in order for the user to see what kind of arguments they need to supply. However, since semantic analysis will fail on this, the AST node (`CallExp`) corresponding to the call above will be replaced with an `ErrorExp` that has no information whatsoever. Extending the original `ExpressionSemanticVisitor` in order to override the `visit` method for `CallExp` would solve this issue. I could simply call the method in the parent class and if `ErrorExp` was returned, I will add the original node back into the AST.

I would have done the same changes with the entry points in `initsem.d` (`initializerSemantic`) and `typesem.d` (`typeSemantic`), but they do not use any visitors. I could still change them in the same way or, besides doing so, create a visitor instead of defining nested functions in the entry point to handle types and initialisers. What do you think about this?

The only other option to give the user more flexibility that was considered was to templatise the entry points by adding a parameter representing the visitor to be instantiated, but this would have implied major changes. All wrappers over semantic analysis (`semantic`, `semantic2`, `semantic3`) would have had to be templatised, as well as all other occurrences of the entry points. This would've also affected the compilation time of DMD.