### PR TITLE
toobj.d: Remove dead error message in overload shadowing detection

### DIFF
--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1078,21 +1078,14 @@ private bool finishVtbl(ClassDeclaration cd)
             if (!fd.leastAsSpecialized(fd2) && !fd2.leastAsSpecialized(fd))
                 continue;
             // Hiding detected: same name, overlapping specializations
-            TypeFunction tf = cast(TypeFunction)fd.type;
-            if (tf.ty == Tfunction)
-            {
-                cd.error("use of `%s%s` is hidden by `%s`; use `alias %s = %s.%s;` to introduce base class overload set",
-                    fd.toPrettyChars(),
-                    parametersTypeToChars(tf.parameterList),
-                    cd.toChars(),
-                    fd.toChars(),
-                    fd.parent.toChars(),
-                    fd.toChars());
-            }
-            else
-            {
-                cd.error("use of `%s` is hidden by `%s`", fd.toPrettyChars(), cd.toChars());
-            }
+            TypeFunction tf = fd.type.toTypeFunction();
+            cd.error("use of `%s%s` is hidden by `%s`; use `alias %s = %s.%s;` to introduce base class overload set",
+                fd.toPrettyChars(),
+                parametersTypeToChars(tf.parameterList),
+                cd.toChars(),
+                fd.toChars(),
+                fd.parent.toChars(),
+                fd.toChars());
             hasError = true;
             break;
         }


### PR DESCRIPTION
The else branch was added back in 2.015 (when V1/V2 was still being maintained in the same codebase).  Can't see any associated bug report for it other than the feature:

> Relaxed hidden hijacking detection when hidden function is disjoint from overloading with any other virtual function in the hierarchy.

Regardless:
1. I'm not aware of any case where the type of a FuncDeclaration is anything other than a TypeFunction.
2. The ty of a TypeFunction should only ever be a Tfunction.

