### PR TITLE
toobj.d: Use isTypeClass in visitClassReference

### DIFF
--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -533,7 +533,7 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
 
     void visitClassReference(ClassReferenceExp e)
     {
-        InterfaceDeclaration to = (cast(TypeClass)e.type).sym.isInterfaceDeclaration();
+        auto to = e.type.toBasetype().isTypeClass().sym.isInterfaceDeclaration();
 
         if (to) //Static typeof this literal is an interface. We must add offset to symbol
         {


### PR DESCRIPTION
~This should segfault because~ `e.type` is not a TypeClass, but a TypeEnum (it accidentally works because the `sym` field is in the same position for class and enum nodes, and both EnumDeclaration and ClassDeclaration have `isInterfaceDeclaration` in their vtable). 

Real change coming later...

EDIT: Updated to use `toBasetype`.