### PR TITLE
Fix Issue 20831 - __traits(getAttributes) failes to compile when used…

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1045,7 +1045,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     ti = dsym._init ? dsym._init.syntaxCopy() : null;
 
                 StorageClass storage_class = STC.temp | dsym.storage_class;
-                if (arg.storageClass & STC.parameter)
+                if ((dsym.storage_class & STC.parameter) && (arg.storageClass & STC.parameter))
                     storage_class |= arg.storageClass;
                 auto v = new VarDeclaration(dsym.loc, arg.type, id, ti, storage_class);
                 //printf("declaring field %s of type %s\n", v.toChars(), v.type.toChars());

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -876,6 +876,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     continue;
                 // don't add it, if it has no name
                 auto v = new VarDeclaration(loc, fparam.type, fparam.ident, null);
+                fparam.storageClass |= STC.parameter;
                 v.storage_class = fparam.storageClass;
                 v.dsymbolSemantic(scx);
                 if (!ti.symtab)
@@ -6591,7 +6592,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                         tiargs.reserve(dim);
                         foreach (i, arg; *tt.arguments)
                         {
-                            if (flags & 2 && (arg.ident || arg.userAttribDecl))
+                            if (flags & 2 && (arg.storageClass & STC.parameter))
                                 tiargs.insert(j + i, arg);
                             else
                                 tiargs.insert(j + i, arg.type);

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1813,7 +1813,6 @@ public:
         }
         ident = p.ident;
         p.type.accept(this);
-        assert(!(p.storageClass & ~(AST.STC.ref_)));
         if (p.storageClass & AST.STC.ref_)
             buf.writeByte('&');
         buf.writeByte(' ');

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -3011,7 +3011,7 @@ final class Parser(AST) : Lexer
                             if (hasdefault)
                                 error("default argument expected for `%s`", ai ? ai.toChars() : at.toChars());
                         }
-                        auto param = new AST.Parameter(storageClass, at, ai, ae, null);
+                        auto param = new AST.Parameter(storageClass | STC.parameter, at, ai, ae, null);
                         if (udas)
                         {
                             auto a = new AST.Dsymbols();
@@ -4962,7 +4962,7 @@ final class Parser(AST) : Lexer
                 parameterList.parameters = new AST.Parameters();
                 Identifier id = Identifier.generateId("__T");
                 AST.Type t = new AST.TypeIdentifier(loc, id);
-                parameterList.parameters.push(new AST.Parameter(0, t, token.ident, null, null));
+                parameterList.parameters.push(new AST.Parameter(STC.parameter, t, token.ident, null, null));
 
                 tpl = new AST.TemplateParameters();
                 AST.TemplateParameter tp = new AST.TemplateTypeParameter(loc, id, null, null);

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1262,9 +1262,11 @@ extern(C++) Type typeSemantic(Type t, const ref Loc loc, Scope* sc)
             for (size_t i = 0; i < dim; i++)
             {
                 Parameter fparam = tf.parameterList[i];
+                fparam.storageClass |= STC.parameter;
                 mtype.inuse++;
                 fparam.type = fparam.type.typeSemantic(loc, argsc);
                 mtype.inuse--;
+
                 if (fparam.type.ty == Terror)
                 {
                     errors = true;
@@ -1473,7 +1475,7 @@ extern(C++) Type typeSemantic(Type t, const ref Loc loc, Scope* sc)
                         }
                         fparam.type = new TypeTuple(newparams);
                     }
-                    fparam.storageClass = 0;
+                    fparam.storageClass = STC.parameter;
 
                     /* Reset number of parameters, and back up one to do this fparam again,
                      * now that it is a tuple

--- a/test/runnable/uda.d
+++ b/test/runnable/uda.d
@@ -687,6 +687,14 @@ void test20()
 }
 
 /************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=20831
+
+void foo20831(int f, float, @("test") string s = "test") {}
+
+static if(is(typeof(foo20831) Params20831 == __parameters))
+    static assert([__traits(getAttributes, Params20831[1..2])] == []);
+
+/************************************************/
 
 int main()
 {


### PR DESCRIPTION
… on a parameter with no name

I'm marking each `Parameter` that is actually a function parameter with `STC.parameter`, thus we can test if a `Parameter` instance is a function argument in a more robust way.
I've a couple of patchs for other issues using this approach.

An alternative fix is to generate identifiers for unnamed parameters in semantic 1, they are generated in semantic 3 which causes a few bugs now. I'll report them sometime.