### PR TITLE
partially revert #10891, split Outbuffer.reserve() into hot and cold paths for better performance

### DIFF
--- a/src/dmd/backend/outbuf.d
+++ b/src/dmd/backend/outbuf.d
@@ -72,9 +72,23 @@ struct Outbuffer
         return ret;
     }
 
-    // Make sure we have at least `nbyte` available for writting
+    /********************
+     * Make sure we have at least `nbytes` available for writing,
+     * allocate more if necessary.
+     * This is the inlinable fast path. Prefer `enlarge` if allocation
+     * will always happen.
+     */
     void reserve(size_t nbytes)
     {
+        // Keep small so it is inlined
+        if (pend - p < nbytes)
+            enlarge(nbytes);
+    }
+
+    // Reserve nbytes in buffer
+    void enlarge(size_t nbytes)
+    {
+        pragma(inline, false);  // do not inline slow path
         const size_t oldlen = pend - buf;
         const size_t used = p - buf;
 


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/10891

The purpose of splitting reserve() into reserve() and enlarge() is so that reserve() can be inlined, while the slow path enlarge() should not be inlined.

This is important because outbuf is speed critical.