### PR TITLE
Fix Issue 20833 - Template members prevent __traits(getOverloads) from working properly

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1040,6 +1040,15 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                     f = td.funcroot;
                 ex = null;
             }
+            else if (ex.op == TOK.dotTemplateDeclaration)
+            {
+                DotTemplateExp dte = cast(DotTemplateExp)ex;
+                auto td = dte.td;
+                f = td;
+                if (td && td.funcroot)
+                    f = td.funcroot;
+                ex = null;
+            }
 
             bool[string] funcTypeHash;
 

--- a/test/compilable/b20833.d
+++ b/test/compilable/b20833.d
@@ -1,0 +1,20 @@
+struct A
+{
+    void foo(T)(T t) {}
+    void foo(long l) {}
+
+    void bar(long l) {}
+    void bar(T)(T t) {}
+}
+
+static assert(__traits(getOverloads, A, "foo").length == 1);
+static assert(__traits(getOverloads, A.init, "foo").length == 1);
+
+static assert(__traits(getOverloads, A, "foo", true).length == 2);
+static assert(__traits(getOverloads, A.init, "foo", true).length == 2);
+
+static assert(__traits(getOverloads, A, "bar").length == 1);
+static assert(__traits(getOverloads, A.init, "bar").length == 1);
+
+static assert(__traits(getOverloads, A, "bar", true).length == 2);
+static assert(__traits(getOverloads, A.init, "bar", true).length == 2);


### PR DESCRIPTION
There was no handling for `DotTemplateExpression`s so declaring a template overload before a regular overload prevented it from finding any overloads.

Fixes a regression introduced by #8195.