### PR TITLE
fix Issue 18748 - bt instruction with immediate offset uses 64-bit va…

### DIFF
--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -1471,7 +1471,8 @@ private elem * elbitwise(elem *e, goal_t goal)
                 e.Eoper == OPand &&
                 ul == 1 &&
                 (e.EV.E1.Eoper == OPshr || e.EV.E1.Eoper == OPashr) &&
-                sz <= REGSIZE
+                sz <= REGSIZE &&
+                tysize(e1.Ety) >= 2     // BT doesn't work on byte operands
                )
             {
                 e.EV.E1.Eoper = OPbtst;

--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -3612,11 +3612,11 @@ void cdbtst(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         cs.Irm |= modregrm(0,mode,0);
         cs.Iflags |= CFpsw | word;
         cs.IFL2 = FLconst;
-        if (_tysize[ty1] == SHORTSIZE)
+        if (sz <= SHORTSIZE)
         {
             cs.IEV2.Vint = e2.EV.Vint & 15;
         }
-        else if (_tysize[ty1] == 4)
+        else if (sz == 4)
         {
             cs.IEV2.Vint = e2.EV.Vint & 31;
         }


### PR DESCRIPTION
…riant for 32-bit data