### PR TITLE
change reset_symbols to Barray

### DIFF
--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -820,8 +820,12 @@ struct func_t
 
     char *Fredirect;            // redirect function name to this name in object
 
-    // Array of catch types for EH_DWARF Types Table generation
-    Barray!(Symbol*) typesTable;
+version (SPP) { } else
+{
+    version (MARS)
+        // Array of catch types for EH_DWARF Types Table generation
+        Barray!(Symbol*) typesTable;
+}
 
     union
     {

--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -960,7 +960,8 @@ version (SCPP_HTOD)
                 list_free(&f.Fthunks,cast(list_free_fp)&symbol_free);
               }
                 list_free(&f.Fsymtree,cast(list_free_fp)&symbol_free);
-                f.typesTable.dtor();
+                version (MARS)
+                    f.typesTable.dtor();
                 func_free(f);
             }
             switch (s.Sclass)


### PR DESCRIPTION
as `resetSymbols` instead of bashing `Outbuffer` into the task.

The changes to typesTable are because since cc.d is not compiled to an object file, parts of the Barray!(Symbol*) never get linked in.