### PR TITLE
C++: Use enum class for CPU type definition

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -445,7 +445,7 @@ alias runCxxUnittest = makeRule!((runCxxBuilder, runCxxRule) {
         .sources(srcDir.buildPath("tests", "cxxfrontend.c") ~ .sources.frontendHeaders ~ .sources.dmd.all ~ .sources.root)
         .target(env["G"].buildPath("cxxfrontend").objName)
         // No explicit if since CXX_KIND will always be either g++ or clang++
-        .command([ env["CXX"], env["CXX_KIND"] == "g++" ? "-std=c++11" : "-xc++",
+        .command([ env["CXX"], "-xc++", "-std=c++11",
                    "-c", frontendRule.sources[0], "-o" ~ frontendRule.target, "-I" ~ env["D"] ] ~ flags["CXXFLAGS"])
     );
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -53,7 +53,7 @@ enum
     CHECKACTION_context   // call D assert with the error context on failure
 };
 
-enum CPU
+enum class CPU
 {
     x87,
     mmx,

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -70,6 +70,7 @@ static void frontend_init()
     global.params.isLinux = true;
     global.vendor = "Front-End Tester";
     global.params.objname = NULL;
+    global.params.cpu = CPU::native;
 
     Type::_init();
     Id::initialize();


### PR DESCRIPTION
enum CPU was added to C++ headers incorrectly (it's members should have been CPUx87, CPUmmx, ...).  However as C++11 is now the baseline, will just switch it over to using `enum class`.

FYI @kinke 