### PR TITLE
dwarfdbginf.d: reset_symbuf to Barray

### DIFF
--- a/src/dmd/backend/barray.d
+++ b/src/dmd/backend/barray.d
@@ -17,7 +17,7 @@ import core.stdc.string;
 
 nothrow:
 
-extern (C++): void err_nomem();
+extern (C++): private void err_nomem();
 
 /*************************************
  * A reusable array that ratchets up in capacity.

--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -51,6 +51,7 @@ else
     import core.sys.posix.unistd : getcwd;
 }
 
+import dmd.backend.barray;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.code;
@@ -115,7 +116,7 @@ static if (MACHOBJ)
 
 Symbol* getRtlsymPersonality();
 
-private Outbuffer  *reset_symbuf;        // Keep pointers to reset symbols
+private Barray!(Symbol*) resetSyms;        // Keep pointers to reset symbols
 }
 
 /***********************************
@@ -1028,20 +1029,9 @@ else static if (ELFOBJ)
 
     /* ======================================== */
 
-    if (reset_symbuf)
-    {
-        Symbol **p = cast(Symbol **)reset_symbuf.buf;
-        const size_t n = reset_symbuf.length() / (Symbol *).sizeof;
-        for (size_t i = 0; i < n; ++i)
-            symbol_reset(p[i]);
-        reset_symbuf.reset();
-    }
-    else
-    {
-        reset_symbuf = cast(Outbuffer*) calloc(1, Outbuffer.sizeof);
-        assert(reset_symbuf);
-        reset_symbuf.reserve(50 * (Symbol *).sizeof);
-    }
+    foreach (s; resetSyms)
+        symbol_reset(s);
+    resetSyms.reset();
 
     /* ======================================== */
 
@@ -2717,7 +2707,7 @@ uint dwarf_typidx(type *t)
                 debug_info.buf.writeByte(0);          // no more children
             }
             s.Stypidx = idx;
-            reset_symbuf.write(&s, (s).sizeof);
+            resetSyms.push(s);
             return idx;                 // no need to cache it
         }
 
@@ -2806,7 +2796,7 @@ uint dwarf_typidx(type *t)
             debug_info.buf.writeByte(0);              // no more children
 
             s.Stypidx = idx;
-            reset_symbuf.write(&s, s.sizeof);
+            resetSyms.push(s);
             return idx;                 // no need to cache it
         }
 


### PR DESCRIPTION
Simpler, fewer lines, removes awful casts.