### PR TITLE
[dmd-cxx] Fix regression caused from backporting semantic visitor conversion

### DIFF
--- a/src/expressionsem.c
+++ b/src/expressionsem.c
@@ -6883,6 +6883,7 @@ public:
         if (Expression *ex = binSemanticProp(exp, sc))
         {
             result = ex;
+            return;
         }
         Expression *e = exp->op_overload(sc);
         if (e)


### PR DESCRIPTION
The early return got left out.

Reduced test that triggered segfault will be put in gdc tree.