### PR TITLE
fix Issue 20958 - incomplete semantic analysis when generating code f…

### DIFF
--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -72,8 +72,6 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
 {
     if (sc)
     {
-        if (!sc.func)
-            return;
         if (sc.intypeof)
             return;
         if (sc.flags & (SCOPE.ctfe | SCOPE.compile))

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2869,7 +2869,14 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, Expression* pe, Type* pt, Ds
          * }
          */
         Scope* sc2 = sc.push();
-        sc2.intypeof = 1;
+
+        if (!mt.exp.isTypeidExp())
+            /* Treat typeof(typeid(exp)) as needing
+             * the full semantic analysis of the typeid.
+             * https://issues.dlang.org/show_bug.cgi?id=20958
+             */
+            sc2.intypeof = 1;
+
         auto exp2 = mt.exp.expressionSemantic(sc2);
         exp2 = resolvePropertiesOnly(sc2, exp2);
         sc2.pop();

--- a/test/compilable/imports/u20958.d
+++ b/test/compilable/imports/u20958.d
@@ -1,0 +1,6 @@
+struct W()
+{
+    int[] J;
+}
+
+typeof(typeid(W!())) OB;

--- a/test/compilable/test20958.d
+++ b/test/compilable/test20958.d
@@ -1,0 +1,1 @@
+import imports.u20958;


### PR DESCRIPTION
…or function

This is a fix for a regression caused by a 5 year old PR https://github.com/dlang/dmd/pull/5166

The fix is a bit risky, so it shouldn't go into stable. For example, I can find no reason for lines 75,76 to be there, but they are part of the cause for the regression.