### PR TITLE
elfobj: look up both name index and seg index with hash

### DIFF
--- a/src/dmd/backend/aarray.d
+++ b/src/dmd/backend/aarray.d
@@ -465,7 +465,7 @@ nothrow:
 
 // Key is the slice specified by (*TinfoPair.pbase)[Pair.start .. Pair.end]
 
-struct Pair { uint start, end; }
+public struct Pair { uint start, end; }
 
 public struct TinfoPair
 {
@@ -525,6 +525,39 @@ nothrow:
     }
 
     uint* get(uint start, uint end)
+    {
+        auto p = Pair(start, end);
+        return aa.get(&p);
+    }
+
+    uint length()
+    {
+        return cast(uint)aa.length();
+    }
+}
+
+// Interface for C++ code
+public extern (C++) struct AApair2
+{
+nothrow:
+    alias AA = AArray!(TinfoPair, Pair);
+    AA aa;
+
+    static AApair2* create(ubyte** pbase)
+    {
+        auto a = cast(AApair2*)calloc(1, AApair2.sizeof);
+        assert(a);
+        a.aa.tkey.pbase = pbase;
+        return a;
+    }
+
+    static void destroy(AApair2* aap)
+    {
+        aap.aa.destroy();
+        free(aap);
+    }
+
+    Pair* get(uint start, uint end)
     {
         auto p = Pair(start, end);
         return aa.get(&p);


### PR DESCRIPTION
The problem is `elf_getsegment()` consumes up to 10% of the runtime in its loop, so we avoid calling that function entirely by looking up the seg index in the hashtable that is already looked up. The name index lookup is replaced with a pair where the first field is the name index and the second is the seg index.