### PR TITLE
dmd.root.rmem: Rename allocmemory to allocmemoryNoFree

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -704,7 +704,7 @@ extern (C++) abstract class Expression : ASTNode
         }
 
         // memory never freed, so can use the faster bump-pointer-allocation
-        e = cast(Expression)_d_allocmemory(size);
+        e = cast(Expression)allocmemory(size);
         //printf("Expression::copy(op = %d) e = %p\n", op, e);
         return cast(Expression)memcpy(cast(void*)e, cast(void*)this, size);
     }


### PR DESCRIPTION
Define a new allocmemory function that implements same as the _d_allocmemory override, and call it instead in Expression::copy.

I can see no valid reason to have these functions `extern(C)`, so they've been switched to `extern(D)`.

Fixes build regression caused by #10994.