### PR TITLE
Convert enum BUILTIN to enum class, add gcc and llvm members.

### DIFF
--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -438,3 +438,14 @@ Expression eval_toPrecReal(Loc loc, FuncDeclaration fd, Expressions* arguments)
     Expression arg0 = (*arguments)[0];
     return new RealExp(loc, arg0.toReal(), Type.tfloat80);
 }
+
+// These built-ins are reserved for GDC and LDC.
+Expression eval_gcc(Loc, FuncDeclaration, Expressions*)
+{
+    assert(0);
+}
+
+Expression eval_llvm(Loc, FuncDeclaration, Expressions*)
+{
+    assert(0);
+}

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -439,43 +439,43 @@ enum ILS
 
 /**************************************************************/
 
-enum BUILTIN
+enum class BUILTIN : char
 {
-    BUILTINunknown = -1,    /// not known if this is a builtin
-    BUILTINunimp,           /// this is not a builtin
-    BUILTINsin,
-    BUILTINcos,
-    BUILTINtan,
-    BUILTINsqrt,
-    BUILTINfabs,
-    BUILTINldexp,
-    BUILTINlog,
-    BUILTINlog2,
-    BUILTINlog10,
-    BUILTINexp,
-    BUILTINexpm1,
-    BUILTINexp2,
-    BUILTINround,
-    BUILTINfloor,
-    BUILTINceil,
-    BUILTINtrunc,
-    BUILTINcopysign,
-    BUILTINpow,
-    BUILTINfmin,
-    BUILTINfmax,
-    BUILTINfma,
-    BUILTINisnan,
-    BUILTINisinfinity,
-    BUILTINisfinite,
-    BUILTINbsf,
-    BUILTINbsr,
-    BUILTINbswap,
-    BUILTINpopcnt,
-    BUILTINyl2x,
-    BUILTINyl2xp1,
-    BUILTINtoPrecFloat,
-    BUILTINtoPrecDouble,
-    BUILTINtoPrecReal
+    unknown = -1,    /// not known if this is a builtin
+    unimp,           /// this is not a builtin
+    sin,
+    cos,
+    tan,
+    sqrt,
+    fabs,
+    ldexp,
+    log,
+    log2,
+    log10,
+    exp,
+    expm1,
+    exp2,
+    round,
+    floor,
+    ceil,
+    trunc,
+    copysign,
+    pow,
+    fmin,
+    fmax,
+    fma,
+    isnan,
+    isinfinity,
+    isfinite,
+    bsf,
+    bsr,
+    bswap,
+    popcnt,
+    yl2x,
+    yl2xp1,
+    toPrecFloat,
+    toPrecDouble,
+    toPrecReal
 };
 
 Expression *eval_builtin(Loc loc, FuncDeclaration *fd, Expressions *arguments);

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -443,6 +443,8 @@ enum class BUILTIN : char
 {
     unknown = -1,    /// not known if this is a builtin
     unimp,           /// this is not a builtin
+    gcc,             /// this is a GCC builtin
+    llvm,            /// this is an LLVM builtin
     sin,
     cos,
     tan,

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -64,7 +64,7 @@ enum ILS : int
     yes,                 /// can inline
 }
 
-enum BUILTIN : int
+enum BUILTIN : byte
 {
     unknown = -1,    /// not known if this is a builtin
     unimp,           /// this is not a builtin

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -68,6 +68,8 @@ enum BUILTIN : byte
 {
     unknown = -1,    /// not known if this is a builtin
     unimp,           /// this is not a builtin
+    gcc,             /// this is a GCC builtin
+    llvm,            /// this is an LLVM builtin
     sin,
     cos,
     tan,


### PR DESCRIPTION
GDC doesn't discriminate _what_ built-in it is dealing with.  All it cares about is whether or not it's a built-in gcc backend recognizes in the first place.

For example, many functions in `core.stdc.*` (i.e: `printf`) are marked as built-ins.