### PR TITLE
Add kind() to TypeError and TypeTraits

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2707,6 +2707,11 @@ extern (C++) final class TypeError : Type
         super(Terror);
     }
 
+    override const(char)* kind() const
+    {
+        return "error";
+    }
+
     override Type syntaxCopy()
     {
         // No semantic analysis done, no need to copy
@@ -5136,6 +5141,11 @@ extern (C++) final class TypeTraits : Type
         super(Ttraits);
         this.loc = loc;
         this.exp = exp;
+    }
+
+    override const(char)* kind() const
+    {
+        return "traits";
     }
 
     override Type syntaxCopy()

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -348,6 +348,7 @@ public:
 class TypeError : public Type
 {
 public:
+    const char *kind();
     Type *syntaxCopy();
 
     d_uns64 size(const Loc &loc);
@@ -648,6 +649,7 @@ class TypeTraits : public Type
     /// The symbol when exp doesn't represent a type.
     Dsymbol *sym;
 
+    const char *kind();
     Type *syntaxCopy();
     d_uns64 size(const Loc &loc);
     Dsymbol *toDsymbol(Scope *sc);


### PR DESCRIPTION
Super annoying getting a crash when printing info about types.