### PR TITLE
Fix Issue 20989 - Checking array.ptr causes safety error ...

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5926,6 +5926,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             */
             Expression maybePromoteToTmp(ref Expression op)
             {
+                // https://issues.dlang.org/show_bug.cgi?id=20989
+                // Flag that _d_assert_fail will never dereference `array.ptr` to avoid safety
+                // errors for `assert(!array.ptr)` => `_d_assert_fail!"!"(array.ptr)`
+                {
+                    auto die = op.isDotIdExp();
+                    if (die && die.ident == Id.ptr)
+                        die.noderef = true;
+                }
+
                 op = op.expressionSemantic(sc);
                 op = resolveProperties(sc, op);
                 if (op.hasSideEffect)

--- a/test/compilable/test20100.d
+++ b/test/compilable/test20100.d
@@ -36,3 +36,12 @@ void main() {
     testClass();
     testAnonymousFunction();
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=20989
+ void test20989() @safe
+{
+    uint[] arr = [1, 2, 3];
+    assert(arr.ptr);
+    assert(!arr.ptr);
+    assert(arr.ptr is arr.ptr);
+}


### PR DESCRIPTION
... with `-checkaction=context`.

Explicity flag `DotIdExpressions` as `noderef` because `_d_assert_fail` will not dereference the pointer and thus make the call `@safe`.