### PR TITLE
test: Add or fix EXTRA_FILES directive to fail compilation tests

### DIFF
--- a/test/fail_compilation/b17918.d
+++ b/test/fail_compilation/b17918.d
@@ -1,4 +1,6 @@
-/* TEST_OUTPUT:
+/*
+EXTRA_FILES: imports/b17918a.d
+TEST_OUTPUT:
 ---
 fail_compilation/imports/b17918a.d(7): Error: undefined identifier `_listMap`
 ---

--- a/test/fail_compilation/checkimports2.d
+++ b/test/fail_compilation/checkimports2.d
@@ -1,10 +1,11 @@
+// EXTRA_FILES: imports/imp1.d imports/imp2.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/checkimports2.d(24): Error: no property `X` for type `checkimports2.B`, did you mean `imports.imp2.X`?
-fail_compilation/checkimports2.d(24):        while evaluating: `static assert((B).X == 0)`
-fail_compilation/checkimports2.d(25): Error: no property `Y` for type `checkimports2.B`, did you mean `imports.imp2.Y`?
-fail_compilation/checkimports2.d(25):        while evaluating: `static assert((B).Y == 2)`
+fail_compilation/checkimports2.d(25): Error: no property `X` for type `checkimports2.B`, did you mean `imports.imp2.X`?
+fail_compilation/checkimports2.d(25):        while evaluating: `static assert((B).X == 0)`
+fail_compilation/checkimports2.d(26): Error: no property `Y` for type `checkimports2.B`, did you mean `imports.imp2.Y`?
+fail_compilation/checkimports2.d(26):        while evaluating: `static assert((B).Y == 2)`
 ---
 */
 

--- a/test/fail_compilation/constraints_aggr.d
+++ b/test/fail_compilation/constraints_aggr.d
@@ -1,21 +1,22 @@
 /*
+EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_aggr.d(31): Error: template `imports.constraints.C.f` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_aggr.d(32): Error: template `imports.constraints.C.f` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(60):        `f(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_aggr.d(32): Error: template `imports.constraints.C.g` cannot deduce function from argument types `!()()`, candidates are:
+fail_compilation/constraints_aggr.d(33): Error: template `imports.constraints.C.g` cannot deduce function from argument types `!()()`, candidates are:
 fail_compilation/imports/constraints.d(63):        `g(this T)()`
   with `T = imports.constraints.C`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_aggr.d(34): Error: template instance `imports.constraints.S!int` does not match template declaration `S(T)`
+fail_compilation/constraints_aggr.d(35): Error: template instance `imports.constraints.S!int` does not match template declaration `S(T)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_aggr.d(43): Error: template instance `imports.constraints.BitFlags!(Enum)` does not match template declaration `BitFlags(E, bool unsafe = false)`
+fail_compilation/constraints_aggr.d(44): Error: template instance `imports.constraints.BitFlags!(Enum)` does not match template declaration `BitFlags(E, bool unsafe = false)`
   with `E = Enum`
   must satisfy one of the following constraints:
 `       unsafe

--- a/test/fail_compilation/constraints_defs.d
+++ b/test/fail_compilation/constraints_defs.d
@@ -1,38 +1,39 @@
 /*
+EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_defs.d(48): Error: template instance `constraints_defs.main.def!(int, 0, (a) => a)` does not match template declaration `def(T, int i = 5, alias R)()`
+fail_compilation/constraints_defs.d(49): Error: template instance `constraints_defs.main.def!(int, 0, (a) => a)` does not match template declaration `def(T, int i = 5, alias R)()`
   with `T = int,
        i = 0,
        R = __lambda1`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_defs.d(49): Error: template instance `imports.constraints.defa!int` does not match template declaration `defa(T, U = int)()`
+fail_compilation/constraints_defs.d(50): Error: template instance `imports.constraints.defa!int` does not match template declaration `defa(T, U = int)()`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_defs.d(50): Error: template instance `imports.constraints.defv!()` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
+fail_compilation/constraints_defs.d(51): Error: template instance `imports.constraints.defv!()` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
   with `Ts = ()`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_defs.d(51): Error: template instance `imports.constraints.defv!int` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
+fail_compilation/constraints_defs.d(52): Error: template instance `imports.constraints.defv!int` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
   with `T = int,
        Ts = ()`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_defs.d(52): Error: template instance `imports.constraints.defv!(int, 0)` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
+fail_compilation/constraints_defs.d(53): Error: template instance `imports.constraints.defv!(int, 0)` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
   with `T = int,
        i = 0,
        Ts = ()`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_defs.d(53): Error: template instance `imports.constraints.defv!(int, 0, bool)` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
+fail_compilation/constraints_defs.d(54): Error: template instance `imports.constraints.defv!(int, 0, bool)` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
   with `T = int,
        i = 0,
        Ts = (bool)`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_defs.d(54): Error: template instance `imports.constraints.defv!(int, 0, bool, float)` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
+fail_compilation/constraints_defs.d(55): Error: template instance `imports.constraints.defv!(int, 0, bool, float)` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
   with `T = int,
        i = 0,
        Ts = (bool, float)`

--- a/test/fail_compilation/constraints_func1.d
+++ b/test/fail_compilation/constraints_func1.d
@@ -1,72 +1,73 @@
 /*
+EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func1.d(78): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(79): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(9):        `test1(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(79): Error: template `imports.constraints.test2` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(80): Error: template `imports.constraints.test2` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(10):        `test2(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(80): Error: template `imports.constraints.test3` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(81): Error: template `imports.constraints.test3` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(11):        `test3(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(81): Error: template `imports.constraints.test4` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(82): Error: template `imports.constraints.test4` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(12):        `test4(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(82): Error: template `imports.constraints.test5` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(83): Error: template `imports.constraints.test5` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(13):        `test5(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func1.d(83): Error: template `imports.constraints.test6` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(84): Error: template `imports.constraints.test6` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(14):        `test6(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T
        !P!T`
-fail_compilation/constraints_func1.d(84): Error: template `imports.constraints.test7` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(85): Error: template `imports.constraints.test7` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(15):        `test7(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func1.d(85): Error: template `imports.constraints.test8` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(86): Error: template `imports.constraints.test8` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(16):        `test8(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(86): Error: template `imports.constraints.test9` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(87): Error: template `imports.constraints.test9` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(17):        `test9(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(87): Error: template `imports.constraints.test10` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(88): Error: template `imports.constraints.test10` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(18):        `test10(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(88): Error: template `imports.constraints.test11` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(89): Error: template `imports.constraints.test11` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(19):        `test11(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T`
-fail_compilation/constraints_func1.d(89): Error: template `imports.constraints.test12` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func1.d(90): Error: template `imports.constraints.test12` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(20):        `test12(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(91): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int, int)`, candidates are:
+fail_compilation/constraints_func1.d(92): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int, int)`, candidates are:
 fail_compilation/imports/constraints.d(9):        `test1(T)(T v)`
 ---
 */

--- a/test/fail_compilation/constraints_func2.d
+++ b/test/fail_compilation/constraints_func2.d
@@ -1,83 +1,84 @@
 /*
+EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func2.d(93): Error: template `imports.constraints.test13` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(94): Error: template `imports.constraints.test13` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(23):        `test13(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T`
-fail_compilation/constraints_func2.d(94): Error: template `imports.constraints.test14` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(95): Error: template `imports.constraints.test14` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(24):        `test14(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        N!T`
-fail_compilation/constraints_func2.d(95): Error: template `imports.constraints.test15` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(96): Error: template `imports.constraints.test15` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(25):        `test15(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        !P!T`
-fail_compilation/constraints_func2.d(96): Error: template `imports.constraints.test16` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(97): Error: template `imports.constraints.test16` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(26):        `test16(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(97): Error: template `imports.constraints.test17` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(98): Error: template `imports.constraints.test17` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(27):        `test17(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(98): Error: template `imports.constraints.test18` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(99): Error: template `imports.constraints.test18` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(28):        `test18(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(99): Error: template `imports.constraints.test19` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(100): Error: template `imports.constraints.test19` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(29):        `test19(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T
        N!T`
-fail_compilation/constraints_func2.d(100): Error: template `imports.constraints.test20` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(101): Error: template `imports.constraints.test20` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(30):        `test20(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(101): Error: template `imports.constraints.test21` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(102): Error: template `imports.constraints.test21` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(31):        `test21(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(102): Error: template `imports.constraints.test22` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(103): Error: template `imports.constraints.test22` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(32):        `test22(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        !P!T`
-fail_compilation/constraints_func2.d(103): Error: template `imports.constraints.test23` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(104): Error: template `imports.constraints.test23` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(33):        `test23(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        N!T
        !P!T`
-fail_compilation/constraints_func2.d(104): Error: template `imports.constraints.test24` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(105): Error: template `imports.constraints.test24` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(34):        `test24(R)(R r)`
   with `R = int`
   must satisfy the following constraint:
 `       __traits(hasMember, R, "stuff")`
-fail_compilation/constraints_func2.d(105): Error: template `imports.constraints.test25` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func2.d(106): Error: template `imports.constraints.test25` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(35):        `test25(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(106): Error: template `imports.constraints.test26` cannot deduce function from argument types `!(float)(int)`, candidates are:
+fail_compilation/constraints_func2.d(107): Error: template `imports.constraints.test26` cannot deduce function from argument types `!(float)(int)`, candidates are:
 fail_compilation/imports/constraints.d(36):        `test26(T, U)(U u)`
   with `T = float,
        U = int`

--- a/test/fail_compilation/constraints_func3.d
+++ b/test/fail_compilation/constraints_func3.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func3.d(52): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func3.d(53): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(39):        `overload(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
@@ -12,7 +13,7 @@ fail_compilation/imports/constraints.d(40):        `overload(T)(T v)`
 `       !P!T`
 fail_compilation/imports/constraints.d(41):        `overload(T)(T v1, T v2)`
 fail_compilation/imports/constraints.d(42):        `overload(T, V)(T v1, V v2)`
-fail_compilation/constraints_func3.d(53): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int, string)`, candidates are:
+fail_compilation/constraints_func3.d(54): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int, string)`, candidates are:
 fail_compilation/imports/constraints.d(39):        `overload(T)(T v)`
 fail_compilation/imports/constraints.d(40):        `overload(T)(T v)`
 fail_compilation/imports/constraints.d(41):        `overload(T)(T v1, T v2)`
@@ -22,21 +23,21 @@ fail_compilation/imports/constraints.d(42):        `overload(T, V)(T v1, V v2)`
   must satisfy one of the following constraints:
 `       N!T
        N!V`
-fail_compilation/constraints_func3.d(55): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()()`, candidates are:
+fail_compilation/constraints_func3.d(56): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()()`, candidates are:
 fail_compilation/imports/constraints.d(43):        `variadic(A, T...)(A a, T v)`
-fail_compilation/constraints_func3.d(56): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/constraints_func3.d(57): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int)`, candidates are:
 fail_compilation/imports/constraints.d(43):        `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = ()`
   must satisfy the following constraint:
 `       N!int`
-fail_compilation/constraints_func3.d(57): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int)`, candidates are:
+fail_compilation/constraints_func3.d(58): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int)`, candidates are:
 fail_compilation/imports/constraints.d(43):        `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = (int)`
   must satisfy the following constraint:
 `       N!int`
-fail_compilation/constraints_func3.d(58): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int, int)`, candidates are:
+fail_compilation/constraints_func3.d(59): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int, int)`, candidates are:
 fail_compilation/imports/constraints.d(43):        `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = (int, int)`

--- a/test/fail_compilation/constraints_tmpl.d
+++ b/test/fail_compilation/constraints_tmpl.d
@@ -1,26 +1,27 @@
 /*
+EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_tmpl.d(34): Error: template instance `imports.constraints.dummy!()` does not match template declaration `dummy()()`
+fail_compilation/constraints_tmpl.d(35): Error: template instance `imports.constraints.dummy!()` does not match template declaration `dummy()()`
   must satisfy the following constraint:
 `       false`
-fail_compilation/constraints_tmpl.d(36): Error: template instance `imports.constraints.message_nice!(int, int)` does not match template declaration `message_nice(T, U)()`
+fail_compilation/constraints_tmpl.d(37): Error: template instance `imports.constraints.message_nice!(int, int)` does not match template declaration `message_nice(T, U)()`
   with `T = int,
        U = int`
   must satisfy the following constraint:
 `       N!U`
-fail_compilation/constraints_tmpl.d(37): Error: template instance `imports.constraints.message_ugly!int` does not match template declaration `message_ugly(T)(T v)`
+fail_compilation/constraints_tmpl.d(38): Error: template instance `imports.constraints.message_ugly!int` does not match template declaration `message_ugly(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_tmpl.d(39): Error: template instance `args!int` does not match template declaration `args(T, U)()`
-fail_compilation/constraints_tmpl.d(40): Error: template instance `imports.constraints.args!(int, float)` does not match template declaration `args(T, U)()`
+fail_compilation/constraints_tmpl.d(40): Error: template instance `args!int` does not match template declaration `args(T, U)()`
+fail_compilation/constraints_tmpl.d(41): Error: template instance `imports.constraints.args!(int, float)` does not match template declaration `args(T, U)()`
   with `T = int,
        U = float`
   must satisfy one of the following constraints:
 `       N!T
        N!U`
-fail_compilation/constraints_tmpl.d(42): Error: template instance `constraints_tmpl.main.lambda!((a) => a)` does not match template declaration `lambda(alias pred)()`
+fail_compilation/constraints_tmpl.d(43): Error: template instance `constraints_tmpl.main.lambda!((a) => a)` does not match template declaration `lambda(alias pred)()`
   with `pred = __lambda1`
   must satisfy the following constraint:
 `       N!int`

--- a/test/fail_compilation/diag10089.d
+++ b/test/fail_compilation/diag10089.d
@@ -1,8 +1,9 @@
 /*
+EXTRA_FILES: imports/diag10089a.d imports/diag10089b.d
 TEST_OUTPUT:
 ---
-fail_compilation/diag10089.d(15): Error: undefined identifier `chunks` in package `imports`
-fail_compilation/diag10089.d(17): Error: template `Foo()` does not have property `chunks`
+fail_compilation/diag10089.d(16): Error: undefined identifier `chunks` in package `imports`
+fail_compilation/diag10089.d(18): Error: template `Foo()` does not have property `chunks`
 ---
 */
 

--- a/test/fail_compilation/diag10141.d
+++ b/test/fail_compilation/diag10141.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/diag10141a.d imports/diag10141b.d
 TEST_OUTPUT:
 ---
-fail_compilation/diag10141.d(9): Error: module `imports.diag10141a` import `unexisting_symbol` not found
+fail_compilation/diag10141.d(10): Error: module `imports.diag10141a` import `unexisting_symbol` not found
 ---
 */
 

--- a/test/fail_compilation/diag10169.d
+++ b/test/fail_compilation/diag10169.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/a10169.d
 TEST_OUTPUT:
 ---
-fail_compilation/diag10169.d(11): Error: no property `x` for type `imports.a10169.B`
+fail_compilation/diag10169.d(12): Error: no property `x` for type `imports.a10169.B`
 ---
 */
 import imports.a10169;

--- a/test/fail_compilation/diag14235.d
+++ b/test/fail_compilation/diag14235.d
@@ -1,9 +1,10 @@
 /*
+EXTRA_FILES: imports/a14235.d
 TEST_OUTPUT:
 ---
-fail_compilation/diag14235.d(11): Error: template identifier `Undefined` is not a member of module `imports.a14235`
-fail_compilation/diag14235.d(12): Error: template identifier `Something` is not a member of module `imports.a14235`, did you mean struct `SomeThing(T...)`?
-fail_compilation/diag14235.d(13): Error: `imports.a14235.SomeClass` is not a template, it is a class
+fail_compilation/diag14235.d(12): Error: template identifier `Undefined` is not a member of module `imports.a14235`
+fail_compilation/diag14235.d(13): Error: template identifier `Something` is not a member of module `imports.a14235`, did you mean struct `SomeThing(T...)`?
+fail_compilation/diag14235.d(14): Error: `imports.a14235.SomeClass` is not a template, it is a class
 ---
 */
 

--- a/test/fail_compilation/diag5385.d
+++ b/test/fail_compilation/diag5385.d
@@ -1,14 +1,15 @@
 /*
+EXTRA_FILES: imports/fail5385.d
 TEST_OUTPUT:
 ---
-fail_compilation/diag5385.d(19): Error: no property `privX` for type `imports.fail5385.C`
-fail_compilation/diag5385.d(20): Error: no property `packX` for type `imports.fail5385.C`
-fail_compilation/diag5385.d(21): Error: no property `privX2` for type `imports.fail5385.C`
-fail_compilation/diag5385.d(22): Error: no property `packX2` for type `imports.fail5385.C`
-fail_compilation/diag5385.d(23): Error: no property `privX` for type `imports.fail5385.S`
-fail_compilation/diag5385.d(24): Error: no property `packX` for type `imports.fail5385.S`
-fail_compilation/diag5385.d(25): Error: no property `privX2` for type `imports.fail5385.S`
-fail_compilation/diag5385.d(26): Error: no property `packX2` for type `imports.fail5385.S`
+fail_compilation/diag5385.d(20): Error: no property `privX` for type `imports.fail5385.C`
+fail_compilation/diag5385.d(21): Error: no property `packX` for type `imports.fail5385.C`
+fail_compilation/diag5385.d(22): Error: no property `privX2` for type `imports.fail5385.C`
+fail_compilation/diag5385.d(23): Error: no property `packX2` for type `imports.fail5385.C`
+fail_compilation/diag5385.d(24): Error: no property `privX` for type `imports.fail5385.S`
+fail_compilation/diag5385.d(25): Error: no property `packX` for type `imports.fail5385.S`
+fail_compilation/diag5385.d(26): Error: no property `privX2` for type `imports.fail5385.S`
+fail_compilation/diag5385.d(27): Error: no property `packX2` for type `imports.fail5385.S`
 ---
 */
 

--- a/test/fail_compilation/diag9210a.d
+++ b/test/fail_compilation/diag9210a.d
@@ -1,6 +1,6 @@
 // REQUIRED_ARGS: -o-
 // PERMUTE_ARGS:
-
+// EXTRA_FILES: imports/diag9210b.d imports/diag9210c.d imports/diag9210stdcomplex.d imports/diag9210stdtraits.d
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/dip22a.d
+++ b/test/fail_compilation/dip22a.d
@@ -1,11 +1,12 @@
 /*
+EXTRA_FILES: imports/dip22a.d
 TEST_OUTPUT:
 ---
-fail_compilation/dip22a.d(15): Error: no property `bar` for type `imports.dip22a.Klass`
-fail_compilation/dip22a.d(16): Error: no property `bar` for type `imports.dip22a.Struct`
-fail_compilation/dip22a.d(17): Error: undefined identifier `bar` in module `imports.dip22a`
-fail_compilation/dip22a.d(18): Error: no property `bar` for type `void`
-fail_compilation/dip22a.d(19): Error: no property `bar` for type `int`
+fail_compilation/dip22a.d(16): Error: no property `bar` for type `imports.dip22a.Klass`
+fail_compilation/dip22a.d(17): Error: no property `bar` for type `imports.dip22a.Struct`
+fail_compilation/dip22a.d(18): Error: undefined identifier `bar` in module `imports.dip22a`
+fail_compilation/dip22a.d(19): Error: no property `bar` for type `void`
+fail_compilation/dip22a.d(20): Error: no property `bar` for type `int`
 ---
 */
 import imports.dip22a;

--- a/test/fail_compilation/dip22b.d
+++ b/test/fail_compilation/dip22b.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/dip22b.d imports/dip22c.d
 TEST_OUTPUT:
 ---
-fail_compilation/dip22b.d(11): Error: undefined identifier `Foo`, did you mean variable `foo`?
+fail_compilation/dip22b.d(12): Error: undefined identifier `Foo`, did you mean variable `foo`?
 ---
 */
 module pkg.dip22;

--- a/test/fail_compilation/dip22e.d
+++ b/test/fail_compilation/dip22e.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/dip22d.d imports/dip22e.d
 TEST_OUTPUT:
 ---
-fail_compilation/dip22e.d(13): Error: undefined identifier `foo`, did you mean struct `Foo`?
+fail_compilation/dip22e.d(14): Error: undefined identifier `foo`, did you mean struct `Foo`?
 ---
 */
 

--- a/test/fail_compilation/fail10277.d
+++ b/test/fail_compilation/fail10277.d
@@ -1,5 +1,5 @@
+// EXTRA_FILES: imports/fail10277.d
 module fail10227;
-
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/fail10528.d
+++ b/test/fail_compilation/fail10528.d
@@ -1,14 +1,15 @@
 /*
+EXTRA_FILES: imports/a10528.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail10528.d(19): Error: undefined identifier `a`
-fail_compilation/fail10528.d(20): Error: undefined identifier `a` in module `a10528`
-fail_compilation/fail10528.d(22): Error: undefined identifier `b`
-fail_compilation/fail10528.d(23): Error: undefined identifier `b` in module `a10528`
-fail_compilation/fail10528.d(25): Error: no property `c` for type `a10528.S`
+fail_compilation/fail10528.d(20): Error: undefined identifier `a`
+fail_compilation/fail10528.d(21): Error: undefined identifier `a` in module `a10528`
+fail_compilation/fail10528.d(23): Error: undefined identifier `b`
+fail_compilation/fail10528.d(24): Error: undefined identifier `b` in module `a10528`
 fail_compilation/fail10528.d(26): Error: no property `c` for type `a10528.S`
-fail_compilation/fail10528.d(28): Error: no property `d` for type `a10528.C`
+fail_compilation/fail10528.d(27): Error: no property `c` for type `a10528.S`
 fail_compilation/fail10528.d(29): Error: no property `d` for type `a10528.C`
+fail_compilation/fail10528.d(30): Error: no property `d` for type `a10528.C`
 ---
 */
 

--- a/test/fail_compilation/fail15667.d
+++ b/test/fail_compilation/fail15667.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -o-
+// EXTRA_FILES: imports/a15667.d
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/fail15896.d
+++ b/test/fail_compilation/fail15896.d
@@ -1,10 +1,11 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -de
+// EXTRA_FILES: imports/imp15896.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail15896.d(11): Error: module `imports.imp15896` member `thebar` is not visible from module `fail15896`
-fail_compilation/fail15896.d(11): Error: module `imports.imp15896` member `packagebar` is not visible from module `fail15896`
+fail_compilation/fail15896.d(12): Error: module `imports.imp15896` member `thebar` is not visible from module `fail15896`
+fail_compilation/fail15896.d(12): Error: module `imports.imp15896` member `packagebar` is not visible from module `fail15896`
 ---
 */
 

--- a/test/fail_compilation/fail17602.d
+++ b/test/fail_compilation/fail17602.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/imp17602.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail17602.d(16): Error: cannot implicitly convert expression `cast(Status)0` of type `imports.imp17602.Status` to `fail17602.Status`
+fail_compilation/fail17602.d(17): Error: cannot implicitly convert expression `cast(Status)0` of type `imports.imp17602.Status` to `fail17602.Status`
 ---
 */
 

--- a/test/fail_compilation/fail17625.d
+++ b/test/fail_compilation/fail17625.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/a17625.d imports/b17625.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail17625.d(15): Error: undefined identifier `boo`
+fail_compilation/fail17625.d(16): Error: undefined identifier `boo`
 ---
 */
 

--- a/test/fail_compilation/fail17630.d
+++ b/test/fail_compilation/fail17630.d
@@ -1,9 +1,10 @@
 // REQUIRED_ARGS: -de
+// EXTRA_FILES: imports/a17630.d
 // EXTRA_SOURCES: imports/b17630.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail17630.d(12): Error: module `a17630` import `Erase` not found, did you mean variable `b17630.Erase`?
+fail_compilation/fail17630.d(13): Error: module `a17630` import `Erase` not found, did you mean variable `b17630.Erase`?
 ---
 */
 

--- a/test/fail_compilation/fail17646.d
+++ b/test/fail_compilation/fail17646.d
@@ -1,12 +1,13 @@
 /*
 REQUIRED_ARGS: -o-
 PERMUTE_ARGS:
+EXTRA_FILES: imports/fail17646.d
 TEST_OUTPUT:
 ---
 fail_compilation/imports/fail17646.d(10): Error: found `}` instead of statement
 fail_compilation/imports/fail17646.d(7): Error: function `imports.fail17646.allTestData!"".allTestData` has no `return` statement, but is expected to return a value of type `const(TestData)[]`
-fail_compilation/fail17646.d(16): Error: template instance `imports.fail17646.allTestData!""` error instantiating
-fail_compilation/fail17646.d(19):        instantiated from here: `runTests!""`
+fail_compilation/fail17646.d(17): Error: template instance `imports.fail17646.allTestData!""` error instantiating
+fail_compilation/fail17646.d(20):        instantiated from here: `runTests!""`
 ---
 */
 int runTests(Modules...)()

--- a/test/fail_compilation/fail18219.d
+++ b/test/fail_compilation/fail18219.d
@@ -1,11 +1,12 @@
 // EXTRA_SOURCES: imports/b18219.d
+// EXTRA_FILES: imports/a18219.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18219.d(15): Error: no property `Foobar` for type `AST`, did you mean `b18219.Foobar`?
-fail_compilation/fail18219.d(16): Error: no property `Bar` for type `a18219.AST`
-fail_compilation/fail18219.d(17): Error: no property `fun` for type `AST`, did you mean `b18219.fun`?
-fail_compilation/fail18219.d(18): Error: no property `Foobar` for type `AST`, did you mean `b18219.Foobar`?
+fail_compilation/fail18219.d(16): Error: no property `Foobar` for type `AST`, did you mean `b18219.Foobar`?
+fail_compilation/fail18219.d(17): Error: no property `Bar` for type `a18219.AST`
+fail_compilation/fail18219.d(18): Error: no property `fun` for type `AST`, did you mean `b18219.fun`?
+fail_compilation/fail18219.d(19): Error: no property `Foobar` for type `AST`, did you mean `b18219.Foobar`?
 ---
 */
 import imports.a18219;

--- a/test/fail_compilation/fail18243.d
+++ b/test/fail_compilation/fail18243.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/a18243.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail18243.d(14): Error: none of the overloads of `isNaN` are callable using argument types `!()(float)`
+fail_compilation/fail18243.d(15): Error: none of the overloads of `isNaN` are callable using argument types `!()(float)`
 ---
 */
 

--- a/test/fail_compilation/fail18938.d
+++ b/test/fail_compilation/fail18938.d
@@ -1,5 +1,6 @@
 // REQUIRED_ARGS: -c -Ifail_compilation/imports/
 // EXTRA_SOURCES: imports/test18938a/cache.d imports/test18938a/file.d
+// EXTRA_FILES: imports/test18938b/file.d
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/fail18979.d
+++ b/test/fail_compilation/fail18979.d
@@ -1,7 +1,8 @@
+// EXTRA_FILES: imports/imp18979.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18979.d(12): Error: no property `__ctor` for type `imports.imp18979.Foo`
+fail_compilation/fail18979.d(13): Error: no property `__ctor` for type `imports.imp18979.Foo`
 ----
 */
 

--- a/test/fail_compilation/fail1900.d
+++ b/test/fail_compilation/fail1900.d
@@ -1,10 +1,11 @@
 /*
+EXTRA_FILES: imports/fail1900a.d imports/fail1900b.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail1900.d(26): Error: template `fail1900.Mix1a!().Foo` matches more than one template declaration:
-fail_compilation/fail1900.d(13):     `Foo(ubyte x)`
+fail_compilation/fail1900.d(27): Error: template `fail1900.Mix1a!().Foo` matches more than one template declaration:
+fail_compilation/fail1900.d(14):     `Foo(ubyte x)`
 and
-fail_compilation/fail1900.d(14):     `Foo(byte x)`
+fail_compilation/fail1900.d(15):     `Foo(byte x)`
 ---
 */
 
@@ -29,7 +30,7 @@ void test1900a()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail1900.d(41): Error: template `imports.fail1900b.Bar(short n)` at fail_compilation/imports/fail1900b.d(2) conflicts with template `imports.fail1900a.Bar(int n)` at fail_compilation/imports/fail1900a.d(2)
+fail_compilation/fail1900.d(42): Error: template `imports.fail1900b.Bar(short n)` at fail_compilation/imports/fail1900b.d(2) conflicts with template `imports.fail1900a.Bar(int n)` at fail_compilation/imports/fail1900a.d(2)
 ---
 */
 
@@ -44,7 +45,7 @@ void test1900b()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail1900.d(65): Error: template `fail1900.Mix2b!().Baz(int x)` at fail_compilation/fail1900.d(57) conflicts with template `fail1900.Mix2a!().Baz(byte x)` at fail_compilation/fail1900.d(53)
+fail_compilation/fail1900.d(66): Error: template `fail1900.Mix2b!().Baz(int x)` at fail_compilation/fail1900.d(58) conflicts with template `fail1900.Mix2a!().Baz(byte x)` at fail_compilation/fail1900.d(54)
 ---
 */
 

--- a/test/fail_compilation/fail19609.d
+++ b/test/fail_compilation/fail19609.d
@@ -1,15 +1,16 @@
 // https://issues.dlang.org/show_bug.cgi?id=19609
 /*
+EXTRA_FILES: imports/fail19609a.d imports/fail19609b.d imports/fail19609c.d imports/fail19609d.d
 TEST_OUTPUT
 ---
 fail_compilation/imports/fail19609a.d(1): Error: `string` expected for deprecation message, not `([""])` of type `string[]`
-fail_compilation/fail19609.d(15): Deprecation: module `imports.fail19609a` is deprecated
+fail_compilation/fail19609.d(16): Deprecation: module `imports.fail19609a` is deprecated
 fail_compilation/imports/fail19609b.d(1): Error: `string` expected for deprecation message, not `([1])` of type `int[]`
-fail_compilation/fail19609.d(16): Deprecation: module `imports.fail19609b` is deprecated
+fail_compilation/fail19609.d(17): Deprecation: module `imports.fail19609b` is deprecated
 fail_compilation/imports/fail19609c.d(1): Error: `string` expected for deprecation message, not `(123.4F)` of type `float`
-fail_compilation/fail19609.d(17): Deprecation: module `imports.fail19609c` is deprecated
+fail_compilation/fail19609.d(18): Deprecation: module `imports.fail19609c` is deprecated
 fail_compilation/imports/fail19609d.d(1): Error: undefined identifier `msg`
-fail_compilation/fail19609.d(19): Deprecation: module `imports.fail19609d` is deprecated
+fail_compilation/fail19609.d(20): Deprecation: module `imports.fail19609d` is deprecated
 ---
 */
 import imports.fail19609a;

--- a/test/fail_compilation/fail20637.d
+++ b/test/fail_compilation/fail20637.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/fail20637b.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail20637.d(11): Error: no property `foo` for type `imports.fail20637b.A`
+fail_compilation/fail20637.d(12): Error: no property `foo` for type `imports.fail20637b.A`
 ---
 */
 module fail20637;

--- a/test/fail_compilation/fail20638.d
+++ b/test/fail_compilation/fail20638.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/fail20638b.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail20638.d(12): Error: undefined identifier `foo` in module `imports.fail20638b`
+fail_compilation/fail20638.d(13): Error: undefined identifier `foo` in module `imports.fail20638b`
 ---
 */
 module fail20638;

--- a/test/fail_compilation/fail313.d
+++ b/test/fail_compilation/fail313.d
@@ -1,9 +1,10 @@
 /*
+EXTRA_FILES: imports/a313.d imports/b313.d imports/pkg313/package.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail313.d(15): Error: undefined identifier `b313` in package `imports`, perhaps add `static import imports.b313;`
-fail_compilation/fail313.d(22): Error: undefined identifier `core`
-fail_compilation/fail313.d(27): Error: undefined identifier `pkg313` in package `imports`, perhaps add `static import imports.pkg313;`
+fail_compilation/fail313.d(16): Error: undefined identifier `b313` in package `imports`, perhaps add `static import imports.b313;`
+fail_compilation/fail313.d(23): Error: undefined identifier `core`
+fail_compilation/fail313.d(28): Error: undefined identifier `pkg313` in package `imports`, perhaps add `static import imports.pkg313;`
 ---
 */
 module test313;

--- a/test/fail_compilation/fail320.d
+++ b/test/fail_compilation/fail320.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/fail320a.d imports/fail320b.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail320.d(10): Error: no overload matches for `foo`
+fail_compilation/fail320.d(11): Error: no overload matches for `foo`
 ---
 */
 

--- a/test/fail_compilation/fail347.d
+++ b/test/fail_compilation/fail347.d
@@ -1,9 +1,10 @@
 /*
+EXTRA_FILES: imports/fail347a.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail347.d(21): Error: undefined identifier `bbr`, did you mean variable `bar`?
-fail_compilation/fail347.d(22): Error: no property `ofo` for type `S`, did you mean `fail347.S.foo`?
-fail_compilation/fail347.d(23): Error: undefined identifier `strlenx`, did you mean function `strlen`?
+fail_compilation/fail347.d(22): Error: undefined identifier `bbr`, did you mean variable `bar`?
+fail_compilation/fail347.d(23): Error: no property `ofo` for type `S`, did you mean `fail347.S.foo`?
+fail_compilation/fail347.d(24): Error: undefined identifier `strlenx`, did you mean function `strlen`?
 ---
 */
 

--- a/test/fail_compilation/fail355.d
+++ b/test/fail_compilation/fail355.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/fail355.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail355.d(8): Error: module `imports.fail355` import `nonexistent` not found
+fail_compilation/fail355.d(9): Error: module `imports.fail355` import `nonexistent` not found
 ---
 */
 

--- a/test/fail_compilation/fail356a.d
+++ b/test/fail_compilation/fail356a.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/fail356.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail356a.d(8): Error: variable `fail356a.imports` conflicts with import `fail356a.imports` at fail_compilation/fail356a.d(7)
+fail_compilation/fail356a.d(9): Error: variable `fail356a.imports` conflicts with import `fail356a.imports` at fail_compilation/fail356a.d(8)
 ---
 */
 import imports.fail356;

--- a/test/fail_compilation/fail356b.d
+++ b/test/fail_compilation/fail356b.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/fail356.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail356b.d(8): Error: variable `fail356b.bar` conflicts with alias `fail356b.bar` at fail_compilation/fail356b.d(7)
+fail_compilation/fail356b.d(9): Error: variable `fail356b.bar` conflicts with alias `fail356b.bar` at fail_compilation/fail356b.d(8)
 ---
 */
 import imports.fail356 : bar;

--- a/test/fail_compilation/fail356c.d
+++ b/test/fail_compilation/fail356c.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/fail356.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail356c.d(8): Error: variable `fail356c.foo` conflicts with import `fail356c.foo` at fail_compilation/fail356c.d(7)
+fail_compilation/fail356c.d(9): Error: variable `fail356c.foo` conflicts with import `fail356c.foo` at fail_compilation/fail356c.d(8)
 ---
 */
 import foo = imports.fail356;

--- a/test/fail_compilation/ice10600.d
+++ b/test/fail_compilation/ice10600.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/ice10600a.d imports/ice10600b.d
 TEST_OUTPUT:
 ---
-fail_compilation/ice10600.d(30): Error: template instance `to!(int, double)` does not match template declaration `to(T)`
+fail_compilation/ice10600.d(31): Error: template instance `to!(int, double)` does not match template declaration `to(T)`
 ---
 */
 

--- a/test/fail_compilation/ice10727a.d
+++ b/test/fail_compilation/ice10727a.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -c
+// EXTRA_FILES: imports/foo10727a.d imports/stdtraits10727.d
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/ice10727b.d
+++ b/test/fail_compilation/ice10727b.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -c
+// EXTRA_FILES: imports/foo10727b.d imports/stdtraits10727.d
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/ice11513a.d
+++ b/test/fail_compilation/ice11513a.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_FILES: imports/ice11513x.d
 TEST_OUTPUT:
 ---
 fail_compilation/imports/ice11513x.d(1): Error: package name 'ice11513a' conflicts with usage as a module name in file fail_compilation/ice11513a.d

--- a/test/fail_compilation/ice11513b.d
+++ b/test/fail_compilation/ice11513b.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_FILES: imports/ice11513y.d
 TEST_OUTPUT:
 ---
 fail_compilation/imports/ice11513y.d(1): Error: package name 'ice11513b' conflicts with usage as a module name in file fail_compilation/ice11513b.d

--- a/test/fail_compilation/ice11850.d
+++ b/test/fail_compilation/ice11850.d
@@ -1,9 +1,10 @@
 /*
+EXTRA_FILES: imports/a11850.d
 TEST_OUTPUT:
 ---
-fail_compilation/ice11850.d(14): Error: incompatible types for `(a) < ([0])`: `uint[]` and `int[]`
+fail_compilation/ice11850.d(15): Error: incompatible types for `(a) < ([0])`: `uint[]` and `int[]`
 fail_compilation/imports/a11850.d(9):        instantiated from here: `FilterResult!(__lambda1, uint[][])`
-fail_compilation/ice11850.d(14):        instantiated from here: `filter!(uint[][])`
+fail_compilation/ice11850.d(15):        instantiated from here: `filter!(uint[][])`
 ---
 */
 

--- a/test/fail_compilation/ice11919.d
+++ b/test/fail_compilation/ice11919.d
@@ -1,10 +1,11 @@
 /*
+EXTRA_FILES: imports/a11919.d
 TEST_OUTPUT:
 ---
-fail_compilation/ice11919.d(17): Error: initializer must be an expression, not `foo`
+fail_compilation/ice11919.d(18): Error: initializer must be an expression, not `foo`
 fail_compilation/imports/a11919.d(4): Error: template instance `a11919.doBar!(Foo).doBar.zoo!(t)` error instantiating
 fail_compilation/imports/a11919.d(11):        instantiated from here: `doBar!(Foo)`
-fail_compilation/ice11919.d(25):        instantiated from here: `doBar!(Bar)`
+fail_compilation/ice11919.d(26):        instantiated from here: `doBar!(Bar)`
 ---
 */
 

--- a/test/fail_compilation/ice13131.d
+++ b/test/fail_compilation/ice13131.d
@@ -1,4 +1,5 @@
 // EXTRA_SOURCES: imports/a13131parameters.d imports/a13131elec.d
+// EXTRA_FILES: imports/a13131checkpoint.d
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/ice13311.d
+++ b/test/fail_compilation/ice13311.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_FILES: imports/a13311.d
 TEST_OUTPUT:
 ---
 fail_compilation/imports/a13311.d(8): Error: undefined identifier `PieceTree`

--- a/test/fail_compilation/ice14424.d
+++ b/test/fail_compilation/ice14424.d
@@ -1,8 +1,9 @@
 // REQUIRED_ARGS: -o- -unittest
+// EXTRA_FILES: imports/a14424.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14424.d(12): Error: `tuple(__unittest_L3_C1)` has no effect
+fail_compilation/ice14424.d(13): Error: `tuple(__unittest_L3_C1)` has no effect
 ---
 */
 

--- a/test/fail_compilation/ice15788.d
+++ b/test/fail_compilation/ice15788.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/range15788.d
 TEST_OUTPUT:
 ---
-fail_compilation/ice15788.d(17): Error: none of the overloads of `iota` are callable using argument types `!()(S, S)`
+fail_compilation/ice15788.d(18): Error: none of the overloads of `iota` are callable using argument types `!()(S, S)`
 ---
 */
 

--- a/test/fail_compilation/ice15816.d
+++ b/test/fail_compilation/ice15816.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_FILES: imports/a15816.d
 TEST_OUTPUT:
 ---
 fail_compilation/imports/a15816.d(3): Error: anonymous classes not allowed

--- a/test/fail_compilation/ice18803a.d
+++ b/test/fail_compilation/ice18803a.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_FILES: ice18803b.d
 TEST_OUTPUT:
 ---
 fail_compilation/ice18803b.d(9): Error: (expression) expected following `static if`

--- a/test/fail_compilation/ice19762.d
+++ b/test/fail_compilation/ice19762.d
@@ -1,4 +1,4 @@
-// EXTRA_SOURCES:
+// EXTRA_FILES: imports/b19762.d imports/c19762.d
 // PERMUTE_ARGS: -g
 
 /*

--- a/test/fail_compilation/ice20057.d
+++ b/test/fail_compilation/ice20057.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/i20057.d
 TEST_OUTPUT:
 ---
-fail_compilation/ice20057.d(9): Error: alias `ice20057.BlackHole` conflicts with struct `ice20057.BlackHole(alias T)` at fail_compilation/ice20057.d(8)
+fail_compilation/ice20057.d(10): Error: alias `ice20057.BlackHole` conflicts with struct `ice20057.BlackHole(alias T)` at fail_compilation/ice20057.d(9)
 ---
 */
 

--- a/test/fail_compilation/ice20709.d
+++ b/test/fail_compilation/ice20709.d
@@ -1,5 +1,5 @@
 /*
-EXTRA_FILES: imports/imp20915.d
+EXTRA_FILES: imports/imp20709.d
 TEST_OUTPUT:
 ---
 fail_compilation/ice20709.d(10): Error: module `imp20709` import `Point` not found

--- a/test/fail_compilation/ice7782.d
+++ b/test/fail_compilation/ice7782.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/ice7782algorithm.d imports/ice7782range.d
 TEST_OUTPUT:
 ----
-fail_compilation/ice7782.d(12): Error: module `ice7782math` is in file 'imports/ice7782range/imports/ice7782math.d' which cannot be read
+fail_compilation/ice7782.d(13): Error: module `ice7782math` is in file 'imports/ice7782range/imports/ice7782math.d' which cannot be read
 import path[0] = fail_compilation
 import path[1] = $p:druntime/import$
 import path[2] = $p:phobos$

--- a/test/fail_compilation/ice9865.d
+++ b/test/fail_compilation/ice9865.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/ice9865b.d
 TEST_OUTPUT:
 ---
-fail_compilation/ice9865.d(8): Error: alias `ice9865.Baz` recursive alias declaration
+fail_compilation/ice9865.d(9): Error: alias `ice9865.Baz` recursive alias declaration
 ---
 */
 

--- a/test/fail_compilation/lookup.d
+++ b/test/fail_compilation/lookup.d
@@ -1,10 +1,11 @@
 /*
+EXTRA_FILES: imports/imp1.d imports/imp2.d
 TEST_OUTPUT:
 ---
-fail_compilation/lookup.d(23): Error: no property `X` for type `lookup.B`, did you mean `imports.imp2.X`?
-fail_compilation/lookup.d(23):        while evaluating: `static assert((B).X == 0)`
-fail_compilation/lookup.d(24): Error: no property `Y` for type `lookup.B`, did you mean `imports.imp2.Y`?
-fail_compilation/lookup.d(24):        while evaluating: `static assert((B).Y == 2)`
+fail_compilation/lookup.d(24): Error: no property `X` for type `lookup.B`, did you mean `imports.imp2.X`?
+fail_compilation/lookup.d(24):        while evaluating: `static assert((B).X == 0)`
+fail_compilation/lookup.d(25): Error: no property `Y` for type `lookup.B`, did you mean `imports.imp2.Y`?
+fail_compilation/lookup.d(25):        while evaluating: `static assert((B).Y == 2)`
 ---
 */
 

--- a/test/fail_compilation/protattr1.d
+++ b/test/fail_compilation/protattr1.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_FILES: protection/subpkg/test1.d
 TEST_OUTPUT:
 ---
 fail_compilation/protection/subpkg/test1.d(3): Error: protection attribute `package(undefined)` does not bind to one of ancestor packages of module `protection.subpkg.test1`

--- a/test/fail_compilation/protattr2.d
+++ b/test/fail_compilation/protattr2.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_FILES: protection/subpkg/test2.d
 TEST_OUTPUT:
 ---
 fail_compilation/protection/subpkg/test2.d(3): Error: protection attribute `package(protection.subpkg2)` does not bind to one of ancestor packages of module `protection.subpkg.test2`

--- a/test/fail_compilation/protattr3.d
+++ b/test/fail_compilation/protattr3.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_FILES: protection/subpkg/test3.d
 TEST_OUTPUT:
 ---
 fail_compilation/protection/subpkg/test3.d(3): Error: `protection package` expected as dot-separated identifiers, got `123`

--- a/test/fail_compilation/spell9644.d
+++ b/test/fail_compilation/spell9644.d
@@ -1,6 +1,6 @@
 // REQUIRED_ARGS: -o-
 // PERMUTE_ARGS:
-
+// EXTRA_FILES: imports/spell9644a.d imports/spell9644b.d
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/test13152.d
+++ b/test/fail_compilation/test13152.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/test13152a.d imports/test13152b.d imports/test13152c.d imports/test13152d.d imports/test13152e.d imports/test13152f.d imports/test13152g.d imports/test13152h.d imports/test13152i.d imports/test13152j.d imports/test13152k.d imports/test13152l.d imports/test13152m.d imports/test13152n.d imports/test13152o.d imports/test13152p.d imports/test13152q.d imports/test13152r.d imports/test13152s.d imports/test13152t.d imports/test13152u.d imports/test13152v.d imports/test13152w.d imports/test13152x.d imports/test13152y.d imports/test13152z.d
 TEST_OUTPUT:
 ---
-fail_compilation/test13152.d(11): Error: undefined identifier `x`
+fail_compilation/test13152.d(12): Error: undefined identifier `x`
 ---
 */
 import imports.test13152a;

--- a/test/fail_compilation/test143.d
+++ b/test/fail_compilation/test143.d
@@ -1,9 +1,10 @@
 // REQUIRED_ARGS: -de
 // https://issues.dlang.org/show_bug.cgi?id=143
+// EXTRA_FILES: imports/test143.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test143.d(19): Error: undefined identifier `x`
+fail_compilation/test143.d(20): Error: undefined identifier `x`
 ---
 */
 module test143;

--- a/test/fail_compilation/test15785.d
+++ b/test/fail_compilation/test15785.d
@@ -1,9 +1,10 @@
 // PERMUTE_ARGS:
+// EXTRA_FILES: imports/test15785.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test15785.d(16): Error: no property `foo` for type `imports.test15785.Base`
-fail_compilation/test15785.d(17): Error: undefined identifier `bar`
+fail_compilation/test15785.d(17): Error: no property `foo` for type `imports.test15785.Base`
+fail_compilation/test15785.d(18): Error: undefined identifier `bar`
 ---
 */
 

--- a/test/fail_compilation/test15785b.d
+++ b/test/fail_compilation/test15785b.d
@@ -1,10 +1,11 @@
 // PERMUTE_ARGS:
+// EXTRA_FILES: imports/test15785.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test15785b.d(14): Error: `imports.test15785.Base.T` is not visible from module `test15785b`
 fail_compilation/test15785b.d(15): Error: `imports.test15785.Base.T` is not visible from module `test15785b`
-fail_compilation/test15785b.d(16): Error: `imports.test15785.IBase2.T` is not visible from module `test15785b`
+fail_compilation/test15785b.d(16): Error: `imports.test15785.Base.T` is not visible from module `test15785b`
+fail_compilation/test15785b.d(17): Error: `imports.test15785.IBase2.T` is not visible from module `test15785b`
 ---
 */
 import imports.test15785;

--- a/test/fail_compilation/test15897.d
+++ b/test/fail_compilation/test15897.d
@@ -1,8 +1,9 @@
 // REQUIRED_ARGS: -de
+// EXTRA_FILES: imports/test15897.d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test15897.d(18): Error: no property `create` for type `imports.test15897.Cat`
+fail_compilation/test15897.d(19): Error: no property `create` for type `imports.test15897.Cat`
 ---
 */
 module test15897;

--- a/test/fail_compilation/test15925.d
+++ b/test/fail_compilation/test15925.d
@@ -1,9 +1,10 @@
 /*
 PERMUTE_ARGS:
+EXTRA_FILES: imports/imp15925.d
 TEST_OUTPUT:
 ---
-fail_compilation/test15925.d(18): Error: undefined identifier `X`
-fail_compilation/test15925.d(18):        while evaluating: `static assert(X == 1)`
+fail_compilation/test15925.d(19): Error: undefined identifier `X`
+fail_compilation/test15925.d(19):        while evaluating: `static assert(X == 1)`
 ---
 */
 

--- a/test/fail_compilation/test18554.d
+++ b/test/fail_compilation/test18554.d
@@ -1,7 +1,8 @@
 /* REQUIRED_ARGS: -preview=dip1000
+EXTRA_FILES: imports/imp18554.d
 TEST_OUTPUT:
 ---
-fail_compilation/test18554.d(15): Error: struct `imp18554.S` member `i` is not accessible from `@safe` code
+fail_compilation/test18554.d(16): Error: struct `imp18554.S` member `i` is not accessible from `@safe` code
 ---
 */
 

--- a/test/fail_compilation/test19107.d
+++ b/test/fail_compilation/test19107.d
@@ -1,8 +1,9 @@
 /*
+EXTRA_FILES: imports/imp19661.d imports/test19107a.d imports/test19107b.d
 TEST_OUTPUT:
 ---
-fail_compilation/test19107.d(23): Error: template `test19107.all` cannot deduce function from argument types `!((c) => c)(string[])`, candidates are:
-fail_compilation/test19107.d(17):        `all(alias pred, T)(T t)`
+fail_compilation/test19107.d(24): Error: template `test19107.all` cannot deduce function from argument types `!((c) => c)(string[])`, candidates are:
+fail_compilation/test19107.d(18):        `all(alias pred, T)(T t)`
   with `pred = __lambda2,
        T = string[]`
   must satisfy the following constraint:

--- a/test/fail_compilation/test19661.d
+++ b/test/fail_compilation/test19661.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/imp19661.d
 TEST_OUTPUT:
 ---
-fail_compilation/test19661.d(10): Error: variables cannot be initialized with an expression of type `void`. Use `void` initialization instead.
+fail_compilation/test19661.d(11): Error: variables cannot be initialized with an expression of type `void`. Use `void` initialization instead.
 ---
 */
 

--- a/test/fail_compilation/test314.d
+++ b/test/fail_compilation/test314.d
@@ -1,10 +1,11 @@
 /*
+EXTRA_FILES: imports/a314.d imports/b314.d imports/c314.d
 TEST_OUTPUT:
 ---
-fail_compilation/test314.d(18): Error: undefined identifier `renamed`
-fail_compilation/test314.d(19): Error: undefined identifier `bug`
-fail_compilation/test314.d(21): Error: undefined identifier `renamedpkg`
-fail_compilation/test314.d(22): Error: undefined identifier `bugpkg`
+fail_compilation/test314.d(19): Error: undefined identifier `renamed`
+fail_compilation/test314.d(20): Error: undefined identifier `bug`
+fail_compilation/test314.d(22): Error: undefined identifier `renamedpkg`
+fail_compilation/test314.d(23): Error: undefined identifier `bugpkg`
 ---
 */
 

--- a/test/fail_compilation/test5412a.d
+++ b/test/fail_compilation/test5412a.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/test5412a.d imports/test5412b.d
 TEST_OUTPUT:
 ---
-fail_compilation/test5412a.d(10): Error: import `test5412a.A` conflicts with import `test5412a.A` at fail_compilation/test5412a.d(9)
+fail_compilation/test5412a.d(11): Error: import `test5412a.A` conflicts with import `test5412a.A` at fail_compilation/test5412a.d(10)
 ---
 */
 module test5412a;

--- a/test/fail_compilation/test5412b.d
+++ b/test/fail_compilation/test5412b.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: imports/test5412a.d imports/test5412b.d
 TEST_OUTPUT:
 ---
-fail_compilation/test5412b.d(10): Error: static import `test5412b.A` conflicts with import `test5412b.A` at fail_compilation/test5412b.d(9)
+fail_compilation/test5412b.d(11): Error: static import `test5412b.A` conflicts with import `test5412b.A` at fail_compilation/test5412b.d(10)
 ---
 */
 module test5412b;

--- a/test/fail_compilation/test5412c.d
+++ b/test/fail_compilation/test5412c.d
@@ -1,7 +1,8 @@
 /*
+EXTRA_FILES: test5412c2.di imports/test5412a.d
 TEST_OUTPUT:
 ---
-fail_compilation/test5412c.d(10): Error: import `test5412c.test5412c2` conflicts with import `test5412c.test5412c2` at fail_compilation/test5412c.d(9)
+fail_compilation/test5412c.d(11): Error: import `test5412c.test5412c2` conflicts with import `test5412c.test5412c2` at fail_compilation/test5412c.d(10)
 ---
 */
 module test5412c;

--- a/test/fail_compilation/test64.d
+++ b/test/fail_compilation/test64.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_FILES: imports/test64a.d
 TEST_OUTPUT:
 ---
 fail_compilation/imports/test64a.d(1): Error: module `imports` from file fail_compilation/imports/test64a.d conflicts with package name imports


### PR DESCRIPTION
It's been a while since I last looked through whether the reasons for failure was `module 'mod' is in file 'file' which cannot be read`. So this has gotten somewhat out of sync.

Unfortunately, there's no TEST_OUTPUT support in gdc's dejagnu testsuite, and even if there were, error format is in GNU message style, so not straightforward to implement, so this has to be hand checked every so often.