### PR TITLE
Pass quiet/verbose information from makefile to build.d

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -2,6 +2,9 @@ INSTALL_DIR=$(PWD)/../install
 ECTAGS_LANGS = Make,C,C++,D,Sh
 ECTAGS_FILES = src/dmd/*.[chd] src/dmd/backend/*.[chd] src/dmd/root/*.[chd]
 
+# Default is quiet mode, override with QUIET= in the command line
+QUIET=@
+
 .PHONY: all clean test install auto-tester-build auto-tester-test toolchain-info
 
 all:

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -46,6 +46,10 @@ ifeq (,$(BUILD))
 BUILD=release
 endif
 
+ifeq (,$(QUIET))
+VERBOSE=--verbose
+endif
+
 ifneq ($(BUILD),release)
     ifneq ($(BUILD),debug)
         $(error Unrecognized BUILD=$(BUILD), must be 'debug' or 'release')
@@ -107,7 +111,7 @@ all: dmd
 .PHONY: all
 
 dmd: $(GENERATED)/build
-	$(RUN_BUILD) $@
+	$(RUN_BUILD) $@ $(VERBOSE)
 .PHONY: dmd
 
 $(GENERATED)/build: build.d $(HOST_DMD_PATH)


### PR DESCRIPTION
I needed to take a look at what build.d is running, and there may be an occasional need for that. There was a `QUIET` flag in use (introduced I think by @MartinNowak), so I'm working off of that.

With this PR the quiet mode would be the default, override with `QUIET=` in the command line. (This is a minor change from the previous state of affairs.) The variable is passed down to src/posix.mak and then verboseness of build.d is decided depending on that.