### PR TITLE
Make -{preview|revert|transition}=all work again

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -582,8 +582,8 @@ dmd -cov -unittest myprog.d
             off when generating an object, interface, or Ddoc file
             name. $(SWLINK -op) will leave it on.`,
         ),
-        Option("preview=<id>",
-            "enable an upcoming language change identified by 'id'",
+        Option("preview=<name>",
+            "enable an upcoming language change identified by 'name'",
             `Preview an upcoming language change identified by $(I id)`,
         ),
         Option("preview=[h|help|?]",
@@ -608,8 +608,8 @@ dmd -cov -unittest myprog.d
             done for system and trusted functions, and assertion failures
             are undefined behaviour.`
         ),
-        Option("revert=<id>",
-            "revert language change identified by 'id'",
+        Option("revert=<name>",
+            "revert language change identified by 'name'",
             `Revert language change identified by $(I id)`,
         ),
         Option("revert=[h|help|?]",
@@ -627,8 +627,8 @@ dmd -cov -unittest myprog.d
             `$(UNIX Generate shared library)
              $(WINDOWS Generate DLL library)`,
         ),
-        Option("transition=<id>",
-            "help with language change identified by 'id'",
+        Option("transition=<name>",
+            "help with language change identified by 'name'",
             `Show additional info about language change identified by $(I id)`,
         ),
         Option("transition=[h|help|?]",
@@ -818,7 +818,7 @@ struct CLIUsage
         auto buf = description.capitalize ~ " listed by -"~flagName~"=name:
 ";
         auto allTransitions = [Usage.Feature("all", null,
-            "list information on all " ~ description)] ~ features;
+            "Enables all available " ~ description)] ~ features;
         foreach (t; allTransitions)
         {
             if (t.deprecated_)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1530,7 +1530,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
 
                     buf ~= `params.`~t.paramName~` = true;`;
                 }
-                buf ~= "break;\n";
+                buf ~= "return true;\n";
 
                 foreach (t; features)
                 {

--- a/test/compilable/previewall.d
+++ b/test/compilable/previewall.d
@@ -1,0 +1,10 @@
+// ARG_SETS: -preview=all
+// ARG_SETS: -transition=all
+// ARG_SETS: -revert=all
+import core.stdc.stdio;
+
+void main (string[] args)
+{
+    if (args.length == 42)
+        printf("Hello World\n");
+}

--- a/test/compilable/previewhelp.d
+++ b/test/compilable/previewhelp.d
@@ -4,7 +4,7 @@ ARG_SETS: -preview=h
 TEST_OUTPUT:
 ----
 Upcoming language changes listed by -preview=name:
-  =all              list information on all upcoming language changes
+  =all              Enables all available upcoming language changes
   =dip25            implement https://github.com/dlang/DIPs/blob/master/DIPs/archive/DIP25.md (Sealed references)
   =dip1000          implement https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1000.md (Scoped Pointers)
   =dip1008          implement https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1008.md (@nogc Throwable)

--- a/test/compilable/reverthelp.d
+++ b/test/compilable/reverthelp.d
@@ -4,7 +4,7 @@ ARG_SETS: -revert=h
 TEST_OUTPUT:
 ----
 Revertable language changes listed by -revert=name:
-  =all              list information on all revertable language changes
+  =all              Enables all available revertable language changes
   =dip25            revert DIP25 changes https://github.com/dlang/DIPs/blob/master/DIPs/archive/DIP25.md
 ----
 */

--- a/test/compilable/transitionhelp.d
+++ b/test/compilable/transitionhelp.d
@@ -4,7 +4,7 @@ ARG_SETS: -transition=h
 TEST_OUTPUT:
 ----
 Language transitions listed by -transition=name:
-  =all              list information on all language transitions
+  =all              Enables all available language transitions
   =field            list all non-mutable fields which occupy an object instance
   =complex          give deprecation messages about all usages of complex or imaginary types
   =tls              list all variables going into thread local storage


### PR DESCRIPTION
```
The code was probably changed at some point from a break to a return,
but the 'all' special case was not updated.
For clarity, some text was also edited: 'id' has been renamed to 'name',
as 'id' has been used in the past to mean number,
and it's also used this way for -version and -debug.
Finally, the description for 'all' was fixed.
```

https://forum.dlang.org/thread/pmfzmivcddflekgweuuo@forum.dlang.org