### PR TITLE
test: Move imports/test18868_fls.d from COMPILE_SEPARATELY to EXTRA_SOURCES

### DIFF
--- a/test/runnable/test18868.d
+++ b/test/runnable/test18868.d
@@ -1,6 +1,6 @@
 /*
-COMPILE_SEPARATELY: runnable/imports/test18868_fls.d
-EXTRA_SOURCES: imports/test18868_a.d
+COMPILE_SEPARATELY
+EXTRA_SOURCES: imports/test18868_a.d imports/test18868_fls.d
 PERMUTE_ARGS:
 */
 


### PR DESCRIPTION
For the same reason that sources should not go into `REQUIRED_ARGS`, `COMPILE_SEPARATELY` should not be abused in the same manner either.

The following:
```
dmd -c test18868.d
dmd -c imports/test18868_a.d
dmd imports/test18868_fls.d imports/test18868_a.o test18868.o
```
Is really equivalent to:
```
dmd -c test18868.d
dmd -c imports/test18868_a.d
dmd -c imports/test18868_fls.d
dmd imports/test18868_fls.o imports/test18868_a.o test18868.o
```
Except that it elides the need for an extra compile invocation.

To be sure, I tested on 2.080.1, and both methods of compiling share the same bug.  After 2.081.0, the bug being fixed is gone.