### PR TITLE
expression.d: Convert AssignExp.memset from int mask to enum (and use enum class)

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -3219,7 +3219,7 @@ public:
         // ---------------------------------------
         // If it is a construction of a ref variable, it is a ref assignment
         if ((e.op == TOK.construct || e.op == TOK.blit) &&
-            ((cast(AssignExp)e).memset & MemorySet.referenceInit))
+            ((cast(AssignExp)e).memset == MemorySet.referenceInit))
         {
             assert(!fp);
 

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2742,7 +2742,7 @@ elem *toElem(Expression e, IRState *irs)
                 Type ta = are.e1.type.toBasetype();
 
                 // which we do if the 'next' types match
-                if (ae.memset & MemorySet.blockAssign)
+                if (ae.memset == MemorySet.blockAssign)
                 {
                     // Do a memset for array[]=v
                     //printf("Lpair %s\n", ae.toChars());
@@ -2978,7 +2978,7 @@ elem *toElem(Expression e, IRState *irs)
 
             /* Look for initialization of an `out` or `ref` variable
              */
-            if (ae.memset & MemorySet.referenceInit)
+            if (ae.memset == MemorySet.referenceInit)
             {
                 assert(ae.op == TOK.construct || ae.op == TOK.blit);
                 auto ve = ae.e1.isVarExp();

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5742,6 +5742,7 @@ extern (C++) final class PreExp : UnaExp
 
 enum MemorySet
 {
+    none            = 0,    // simple assignment
     blockAssign     = 1,    // setting the contents of an array
     referenceInit   = 2,    // setting the reference of STC.ref_ variable
 }
@@ -5750,7 +5751,7 @@ enum MemorySet
  */
 extern (C++) class AssignExp : BinExp
 {
-    int memset;         // combination of MemorySet flags
+    MemorySet memset;
 
     /************************************************************/
     /* op can be TOK.assign, TOK.construct, or TOK.blit */
@@ -5824,7 +5825,7 @@ extern (C++) final class ConstructExp : AssignExp
         super(loc, TOK.construct, ve, e2);
 
         if (v.storage_class & (STC.ref_ | STC.out_))
-            memset |= MemorySet.referenceInit;
+            memset = MemorySet.referenceInit;
     }
 
     override void accept(Visitor v)
@@ -5852,7 +5853,7 @@ extern (C++) final class BlitExp : AssignExp
         super(loc, TOK.blit, ve, e2);
 
         if (v.storage_class & (STC.ref_ | STC.out_))
-            memset |= MemorySet.referenceInit;
+            memset = MemorySet.referenceInit;
     }
 
     override void accept(Visitor v)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -1020,6 +1020,7 @@ public:
 
 enum class MemorySet
 {
+    none            = 0,    // simple assignment
     blockAssign     = 1,    // setting the contents of an array
     referenceInit   = 2     // setting the reference of STCref variable
 };
@@ -1027,7 +1028,7 @@ enum class MemorySet
 class AssignExp : public BinExp
 {
 public:
-    int memset;         // combination of MemorySet flags
+    MemorySet memset;
 
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *ex);

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -1018,7 +1018,7 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
-enum MemorySet
+enum class MemorySet
 {
     blockAssign     = 1,    // setting the contents of an array
     referenceInit   = 2     // setting the reference of STCref variable

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8553,13 +8553,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         else if (exp.op == TOK.construct && exp.e1.op == TOK.variable &&
                  (cast(VarExp)exp.e1).var.storage_class & (STC.out_ | STC.ref_))
         {
-            exp.memset |= MemorySet.referenceInit;
+            exp.memset = MemorySet.referenceInit;
         }
 
         /* If it is an assignment from a 'foreign' type,
          * check for operator overloading.
          */
-        if (exp.memset & MemorySet.referenceInit)
+        if (exp.memset == MemorySet.referenceInit)
         {
             // If this is an initialization of a reference,
             // do nothing
@@ -9160,7 +9160,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             // Check for block assignment. If it is of type void[], void[][], etc,
             // '= null' is the only allowable block assignment (Bug 7493)
-            exp.memset |= MemorySet.blockAssign;    // make it easy for back end to tell what this is
+            exp.memset = MemorySet.blockAssign;    // make it easy for back end to tell what this is
             e2x = e2x.implicitCastTo(sc, t1.nextOf());
             if (exp.op != TOK.blit && e2x.isLvalue() && exp.e1.checkPostblit(sc, t1.nextOf()))
                 return setError();
@@ -9320,7 +9320,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if ((t2.ty == Tarray || t2.ty == Tsarray) && isArrayOpValid(exp.e2))
         {
             // Look for valid array operations
-            if (!(exp.memset & MemorySet.blockAssign) &&
+            if (exp.memset != MemorySet.blockAssign &&
                 exp.e1.op == TOK.slice &&
                 (isUnaArrayOp(exp.e2.op) || isBinArrayOp(exp.e2.op)))
             {
@@ -9334,7 +9334,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             // Drop invalid array operations in e2
             //  d = a[] + b[], d = (a[] + b[])[0..2], etc
-            if (checkNonAssignmentArrayOp(exp.e2, !(exp.memset & MemorySet.blockAssign) && exp.op == TOK.assign))
+            if (checkNonAssignmentArrayOp(exp.e2, exp.memset != MemorySet.blockAssign && exp.op == TOK.assign))
                 return setError();
 
             // Remains valid array assignments


### PR DESCRIPTION
As I'm currently looking at code generation of AssignExp's, I noticed that these don't have a prefix.

```
if (e->memset & referenceInit)
{
}
// ...
if (e->memset & blockAssign)
{
}
```
Updating the headers to fix that.

@kinke FYI