### PR TITLE
[build.d] Print stdout for dmd

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -400,6 +400,7 @@ alias dmdExe = makeRuleWithArgs!((MethodInitializer!BuildRule builder, BuildRule
     auto lexer = lexer(targetSuffix, depFlags);
     auto backend = backend(targetSuffix, depFlags);
     builder
+        .name("dmd")
         // include lexer.o and backend.o
         .sources(dmdSources.chain(lexer.targets, backend.targets).array)
         .target(env["DMD_PATH"] ~ targetSuffix)
@@ -1580,7 +1581,13 @@ class BuildRule
             }
             else if (command.length)
             {
-                command.run;
+                import std.ascii : newline;
+                const output = command.run.strip;
+                if (output.length > 0) {
+                    auto ruleName = name.length ? name : "log";
+                    // add [<name>] prefix to all log messages
+                    output.splitter(newline).map!(e => "[" ~ ruleName ~ "] " ~ e).joiner(newline).writeln;
+                }
             }
         }
 


### PR DESCRIPTION
CC @andralex 

Downside is that it prints the TLS warning twice now. Maybe only in verbose mode?

```
>  ./build.d
(TX) DMD_CONF
(DC) BACKEND
(DC) LEXER
[lexer] /usr/include/dlang/dmd/core/exception.d(631): `_store` is thread local
(DC) DMD
[dmd] /usr/include/dlang/dmd/core/exception.d(631): `_store` is thread local
Success
```