### PR TITLE
Fix issue 14188 - implement emitting Makefile-compatible dependencies file

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -310,6 +310,9 @@ dmd -cov -unittest myprog.d
             With $(I filename), write module dependencies as text to $(I filename)
             (only imports).`,
         ),
+        Option("makefiledeps=<filename>",
+               "Write module dependencies in makefile format to filename (only imports)",
+        ),
         Option("extern-std=<standard>",
             "set C++ name mangling compatibility with <standard>",
             "Standards supported are:

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -262,6 +262,8 @@ extern (C++) struct Param
 
     const(char)[] moduleDepsFile;        // filename for deps output
     OutBuffer* moduleDeps;              // contents to be written to deps file
+    const(char)[] makefileDepsFile;     // filename for makefile deps output
+    OutBuffer* makefileDeps;            // contents to be written to the makefile deps file
     MessageStyle messageStyle = MessageStyle.digitalmars; // style of file/line annotations on messages
 
     // Hidden debug switches

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -643,6 +643,22 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
             printf("%.*s", cast(int)data.length, data.ptr);
     }
 
+    if (OutBuffer* ob = params.makefileDeps)
+    {
+        foreach (i; 1 .. modules[0].aimports.dim)
+            semantic3OnDependencies(modules[0].aimports[i]);
+        Module.runDeferredSemantic3();
+
+        ob.writestring("\n\n");
+        const data = (*ob)[];
+        assert(params.makefileDepsFile);
+
+        if (params.makefileDepsFile)
+            writeFile(Loc.initial, params.makefileDepsFile, data);
+        else
+            printf("%.*s", cast(int)data.length, data.ptr);
+    }
+
     printCtfePerformanceStats();
     printTemplateStats();
 

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -2420,6 +2420,23 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             }
             params.moduleDeps = new OutBuffer();
         }
+        else if (startsWith(p + 1, "makefiledeps="))
+        {
+            if (params.makefileDeps)
+            {
+                error("-makefiledeps[=file] can only be provided once!");
+                break;
+            }
+            if (p[13] != '=' || p[14] == '\0')
+            {
+                goto Lerror;
+            }
+            params.makefileDepsFile = (p + 1 + 13).toDString;
+            if (!params.makefileDepsFile[0])
+                goto Lnoarg;
+
+            params.makefileDeps = new OutBuffer();
+        }
         else if (arg == "-main")             // https://dlang.org/dmd.html#switch-main
         {
             params.addMain = true;

--- a/test/compilable/issue14188.sh
+++ b/test/compilable/issue14188.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+$DMD --version
+
+echo 'import bar;' > foo.d
+touch bar.d
+echo 'foo.o: bar.d' > expected.deps
+$DMD -o- -makefiledeps=actual.deps foo.d
+diff_output=$(diff actual.deps expected.deps)
+diff_result=$?
+echo "diff_result: $diff_result"
+
+# rm foo.d bar.d actual.deps expected.deps
+
+
+exit $diff_result


### PR DESCRIPTION
This allows dmd to be used with ninja (and make [with some effort](https://github.com/atilaneves/reggae/blob/03d4c8f8ac8ee7cffecc95e6e7adfc1a6b3fdb38/payload/reggae/backend/make.d#L126)) while correctly tracking which modules depend on which so as to only rebuild what's necessary.

I racked my head trying to come up with a good test but failed. It doesn't help that the test suite has crude tools to deal with this. Diffing the output is a terrible idea since the formatting doesn't matter as long as make an ninja parse it fine. Then there's the fact that this lists modules from druntime, and those could change. I considered appending to the output and running make but doing that from a bash script is exhausting.

In the end, this is simple and unlikely to change in the future. Also, I'm expecting review comments anyway without the tests.