### PR TITLE
Fix AA iteration order dependency in testaa2.d

### DIFF
--- a/test/runnable/testaa2.d
+++ b/test/runnable/testaa2.d
@@ -6,8 +6,6 @@ foo()
 foo() 2
 foo() 3
 foo() 4
-c["foo"] = 3
-c["bar"] = 4
 Success
 ---
 */
@@ -62,10 +60,9 @@ void foo2()
     value = c.values;
     assert(value.length == 2);
 
-    for (i = 0; i < key.length; i++)
-    {
-        printf("c[\"%.*s\"] = %d\n", cast(int)key[i].length, key[i].ptr, value[i]);
-    }
+    const fooIndex = key[1] == "foo";
+    assert(key[fooIndex] == "foo" && value[fooIndex] == 3);
+    assert(key[1 - fooIndex] == "bar" && value[1 - fooIndex] == 4);
 
     assert("foo" in c);
     c.remove("foo");


### PR DESCRIPTION
Blocking https://github.com/dlang/druntime/pull/3148#issuecomment-652723332

>A DMD test is failing because it depends on a specific AA traversal order. I am inclined to consider that erroneous based on https://dlang.org/spec/hash-map.html: "The built-in associative arrays do not preserve the order of the keys inserted into the array. **In particular, in a foreach loop the order in which the elements are iterated is typically unspecified.**"

```console
Test runnable/testaa2.d failed: 
expected:
----
foo()
foo() 2
foo() 3
foo() 4
c["foo"] = 3
c["bar"] = 4
Success
----
actual:
----
foo()
foo() 2
foo() 3
foo() 4
c["bar"] = 4
c["foo"] = 3
Success
```