### PR TITLE
Refactor `TemplateInstance` to reduce its size

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5790,11 +5790,6 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     Dsymbol aliasdecl;          // !=null if instance is an alias for its sole member
     TemplateInstance inst;      // refer to existing instance
     ScopeDsymbol argsym;        // argument symbol table
-    int inuse;                  // for recursive expansion detection
-    int nest;                   // for recursive pretty printing detection
-    bool semantictiargsdone;    // has semanticTiargs() been done?
-    bool havetempdecl;          // if used second constructor
-    bool gagged;                // if the instantiation is done with error gagging
     size_t hash;                // cached result of toHash()
     Expressions* fargs;         // for function template, these are the function arguments
 
@@ -5807,6 +5802,36 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     TemplateInstance tinst;     // enclosing template instance
     TemplateInstance tnext;     // non-first instantiated instances
     Module minst;               // the top module that instantiated this instance
+
+    uint inuse;                  // for recursive expansion detection
+    ushort nest;                 // for recursive pretty printing detection
+
+    private ubyte flags;
+    private enum Flag : uint { semantictiargsdone = 1, havetempdecl = 2, gagged = 4 }
+    @property pure nothrow @nogc
+    {
+        // has semanticTiargs() been done?
+        bool semantictiargsdone() const { return (flags & Flag.semantictiargsdone) != 0; }
+        void semantictiargsdone(bool x)
+        {
+            if (x) flags |= Flag.semantictiargsdone;
+            else flags &= ~Flag.semantictiargsdone;
+        }
+        // if used second constructor
+        bool havetempdecl() const { return (flags & Flag.havetempdecl) != 0; }
+        void havetempdecl(bool x)
+        {
+            if (x) flags |= Flag.havetempdecl;
+            else flags &= ~Flag.havetempdecl;
+        }
+        // if the instantiation is done with error gagging
+        bool gagged() const { return (flags & Flag.gagged) != 0; }
+        void gagged(bool x)
+        {
+            if (x) flags |= Flag.gagged;
+            else flags &= ~Flag.gagged;
+        }
+    }
 
     extern (D) this(const ref Loc loc, Identifier ident, Objects* tiargs)
     {

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5808,23 +5808,23 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
     private ubyte flags;
     private enum Flag : uint { semantictiargsdone = 1, havetempdecl = 2, gagged = 4 }
-    @property pure nothrow @nogc
+    final @safe @property pure nothrow @nogc
     {
-        // has semanticTiargs() been done?
+        /// has semanticTiargs() been done?
         bool semantictiargsdone() const { return (flags & Flag.semantictiargsdone) != 0; }
         void semantictiargsdone(bool x)
         {
             if (x) flags |= Flag.semantictiargsdone;
             else flags &= ~Flag.semantictiargsdone;
         }
-        // if used second constructor
+        /// if used second constructor
         bool havetempdecl() const { return (flags & Flag.havetempdecl) != 0; }
         void havetempdecl(bool x)
         {
             if (x) flags |= Flag.havetempdecl;
             else flags &= ~Flag.havetempdecl;
         }
-        // if the instantiation is done with error gagging
+        /// if the instantiation is done with error gagging
         bool gagged() const { return (flags & Flag.gagged) != 0; }
         void gagged(bool x)
         {

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5803,33 +5803,32 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     TemplateInstance tnext;     // non-first instantiated instances
     Module minst;               // the top module that instantiated this instance
 
-    uint inuse;                  // for recursive expansion detection
-    ushort nest;                 // for recursive pretty printing detection
+    uint inuse;                 // for recursive expansion detection
+    uint nest;                  // for recursive pretty printing detection, 3 MSBs reserved for flags (below)
+    private enum Flag : uint { semantictiargsdone = 1u << 31, havetempdecl = 1u << 30, gagged = 1u << 29 }
 
-    private ubyte flags;
-    private enum Flag : uint { semantictiargsdone = 1, havetempdecl = 2, gagged = 4 }
     final @safe @property pure nothrow @nogc
     {
         /// has semanticTiargs() been done?
-        bool semantictiargsdone() const { return (flags & Flag.semantictiargsdone) != 0; }
+        bool semantictiargsdone() const { return (nest & Flag.semantictiargsdone) != 0; }
         void semantictiargsdone(bool x)
         {
-            if (x) flags |= Flag.semantictiargsdone;
-            else flags &= ~Flag.semantictiargsdone;
+            if (x) nest |= Flag.semantictiargsdone;
+            else nest &= ~Flag.semantictiargsdone;
         }
         /// if used second constructor
-        bool havetempdecl() const { return (flags & Flag.havetempdecl) != 0; }
+        bool havetempdecl() const { return (nest & Flag.havetempdecl) != 0; }
         void havetempdecl(bool x)
         {
-            if (x) flags |= Flag.havetempdecl;
-            else flags &= ~Flag.havetempdecl;
+            if (x) nest |= Flag.havetempdecl;
+            else nest &= ~Flag.havetempdecl;
         }
         /// if the instantiation is done with error gagging
-        bool gagged() const { return (flags & Flag.gagged) != 0; }
+        bool gagged() const { return (nest & Flag.gagged) != 0; }
         void gagged(bool x)
         {
-            if (x) flags |= Flag.gagged;
-            else flags &= ~Flag.gagged;
+            if (x) nest |= Flag.gagged;
+            else nest &= ~Flag.gagged;
         }
     }
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5803,8 +5803,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     TemplateInstance tnext;     // non-first instantiated instances
     Module minst;               // the top module that instantiated this instance
 
-    uint inuse;                 // for recursive expansion detection
-    uint nest;                  // for recursive pretty printing detection, 3 MSBs reserved for flags (below)
+    ushort nest;                // for recursive pretty printing detection, 3 MSBs reserved for flags (below)
+    ubyte inuse;                // for recursive expansion detection
     private enum Flag : uint { semantictiargsdone = 1u << 31, havetempdecl = 1u << 30, gagged = 1u << 29 }
 
     final @safe @property pure nothrow @nogc

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5805,7 +5805,13 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
     ushort nest;                // for recursive pretty printing detection, 3 MSBs reserved for flags (below)
     ubyte inuse;                // for recursive expansion detection
-    private enum Flag : uint { semantictiargsdone = 1u << 31, havetempdecl = 1u << 30, gagged = 1u << 29 }
+
+    private enum Flag : uint
+    {
+        semantictiargsdone = 1u << (nest.sizeof * 8 - 1),
+        havetempdecl = semantictiargsdone >> 1,
+        gagged = semantictiargsdone >> 2
+    }
 
     final @safe @property pure nothrow @nogc
     {

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5814,10 +5814,10 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         available = gagged - 1 // always last flag minus one, 1s for all available bits
     }
 
-    final @safe @property pure nothrow @nogc
+    extern(D) final @safe @property pure nothrow @nogc
     {
         ushort nest() const { return _nest & Flag.available; }
-        void nestUp() { assert(_nest < Flag.available); ++_nest; }
+        void nestUp() { assert(nest() < Flag.available); ++_nest; }
         void nestDown() { assert(nest() > 0); --_nest; }
         /// has semanticTiargs() been done?
         bool semantictiargsdone() const { return (_nest & Flag.semantictiargsdone) != 0; }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3328,14 +3328,14 @@ private void tiargsToBuffer(TemplateInstance ti, OutBuffer* buf, HdrGenState* hg
         }
     }
     buf.writeByte('(');
-    ti.nest++;
+    ti.nestUp();
     foreach (i, arg; *ti.tiargs)
     {
         if (i)
             buf.writestring(", ");
         objectToBuffer(arg, buf, hgs);
     }
-    ti.nest--;
+    ti.nestDown();
     buf.writeByte(')');
 }
 

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -255,8 +255,6 @@ public:
     Dsymbol *aliasdecl;                 // !=NULL if instance is an alias for its sole member
     TemplateInstance *inst;             // refer to existing instance
     ScopeDsymbol *argsym;               // argument symbol table
-    int inuse;                          // for recursive expansion detection
-    int nest;                           // for recursive pretty printing detection
     bool semantictiargsdone;            // has semanticTiargs() been done?
     bool havetempdecl;                  // if used second constructor
     bool gagged;                        // if the instantiation is done with error gagging
@@ -272,6 +270,46 @@ public:
     TemplateInstance *tinst;            // enclosing template instance
     TemplateInstance *tnext;            // non-first instantiated instances
     Module *minst;                      // the top module that instantiated this instance
+
+private:
+    unsigned short _nest;                // for recursive pretty printing detection, 3 MSBs reserved for flags (below)
+public:
+    unsigned char inuse;                 // for recursive expansion detection
+
+private:
+    enum Flag
+    {
+        flag_semantictiargsdone = 1u << (sizeof(_nest) * 8 - 1), // MSB of _nest
+        flag_havetempdecl = semantictiargsdone >> 1,
+        flag_gagged = semantictiargsdone >> 2,
+        flag_available = gagged - 1 // always last flag minus one, 1s for all available bits
+    }
+
+public:
+    unsigned short nest() const { return _nest & flag_available; }
+    void nestUp() { assert(_nest < flag_available); ++_nest; }
+    void nestDown() { assert(nest() > 0); --_nest; }
+    /// has semanticTiargs() been done?
+    bool semantictiargsdone() const { return (_nest & flag_semantictiargsdone) != 0; }
+    void semantictiargsdone(bool x)
+    {
+        if (x) _nest |= flag_semantictiargsdone;
+        else _nest &= ~flag_semantictiargsdone;
+    }
+    /// if used second constructor
+    bool havetempdecl() const { return (_nest & flag_havetempdecl) != 0; }
+    void havetempdecl(bool x)
+    {
+        if (x) _nest |= flag_havetempdecl;
+        else _nest &= ~flag_havetempdecl;
+    }
+    /// if the instantiation is done with error gagging
+    bool gagged() const { return (_nest & flag_gagged) != 0; }
+    void gagged(bool x)
+    {
+        if (x) _nest |= flag_gagged;
+        else _nest &= ~flag_gagged;
+    }
 
     Dsymbol *syntaxCopy(Dsymbol *);
     Dsymbol *toAlias();                 // resolve real symbol

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -255,9 +255,6 @@ public:
     Dsymbol *aliasdecl;                 // !=NULL if instance is an alias for its sole member
     TemplateInstance *inst;             // refer to existing instance
     ScopeDsymbol *argsym;               // argument symbol table
-    bool semantictiargsdone;            // has semanticTiargs() been done?
-    bool havetempdecl;                  // if used second constructor
-    bool gagged;                        // if the instantiation is done with error gagging
     hash_t hash;                        // cached result of toHash()
     Expressions *fargs;                 // for function template, these are the function arguments
 
@@ -287,7 +284,7 @@ private:
 
 public:
     unsigned short nest() const { return _nest & flag_available; }
-    void nestUp() { assert(_nest < flag_available); ++_nest; }
+    void nestUp() { assert(nest() < flag_available); ++_nest; }
     void nestDown() { assert(nest() > 0); --_nest; }
     /// has semanticTiargs() been done?
     bool semantictiargsdone() const { return (_nest & flag_semantictiargsdone) != 0; }

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -269,44 +269,9 @@ public:
     Module *minst;                      // the top module that instantiated this instance
 
 private:
-    unsigned short _nest;                // for recursive pretty printing detection, 3 MSBs reserved for flags (below)
+    unsigned short _nest;                // for recursive pretty printing detection, 3 MSBs reserved for flags
 public:
     unsigned char inuse;                 // for recursive expansion detection
-
-private:
-    enum Flag
-    {
-        flag_semantictiargsdone = 1u << (sizeof(_nest) * 8 - 1), // MSB of _nest
-        flag_havetempdecl = semantictiargsdone >> 1,
-        flag_gagged = semantictiargsdone >> 2,
-        flag_available = gagged - 1 // always last flag minus one, 1s for all available bits
-    }
-
-public:
-    unsigned short nest() const { return _nest & flag_available; }
-    void nestUp() { assert(nest() < flag_available); ++_nest; }
-    void nestDown() { assert(nest() > 0); --_nest; }
-    /// has semanticTiargs() been done?
-    bool semantictiargsdone() const { return (_nest & flag_semantictiargsdone) != 0; }
-    void semantictiargsdone(bool x)
-    {
-        if (x) _nest |= flag_semantictiargsdone;
-        else _nest &= ~flag_semantictiargsdone;
-    }
-    /// if used second constructor
-    bool havetempdecl() const { return (_nest & flag_havetempdecl) != 0; }
-    void havetempdecl(bool x)
-    {
-        if (x) _nest |= flag_havetempdecl;
-        else _nest &= ~flag_havetempdecl;
-    }
-    /// if the instantiation is done with error gagging
-    bool gagged() const { return (_nest & flag_gagged) != 0; }
-    void gagged(bool x)
-    {
-        if (x) _nest |= flag_gagged;
-        else _nest &= ~flag_gagged;
-    }
 
     Dsymbol *syntaxCopy(Dsymbol *);
     Dsymbol *toAlias();                 // resolve real symbol


### PR DESCRIPTION
This reduces the size of `TemplateInstance` from 384 bytes to 375 bytes. It does not affect compilation times or memory consumed in my tests on a large project. The impact will come if combined with other size improvements.