### PR TITLE
remove unused Scope* sc from TypeAArray, avoiding stale pointers

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2299,7 +2299,6 @@ extern (C++) abstract class Type : ASTNode
                 else if (ty == Taarray)
                 {
                     t = new TypeAArray(t, (cast(TypeAArray)this).index.syntaxCopy());
-                    (cast(TypeAArray)t).sc = (cast(TypeAArray)this).sc; // duplicate scope
                 }
                 else if (ty == Tdelegate)
                 {
@@ -2372,7 +2371,6 @@ extern (C++) abstract class Type : ASTNode
                 else if (ty == Taarray)
                 {
                     t = new TypeAArray(utn, (cast(TypeAArray)this).index);
-                    (cast(TypeAArray)t).sc = (cast(TypeAArray)this).sc; // duplicate scope
                 }
                 else
                     assert(0);
@@ -3838,7 +3836,6 @@ extern (C++) final class TypeAArray : TypeArray
 {
     Type index;     // key type
     Loc loc;
-    Scope* sc;
 
     extern (D) this(Type t, Type index)
     {

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -481,7 +481,6 @@ class TypeAArray : public TypeArray
 public:
     Type *index;                // key type
     Loc loc;
-    Scope *sc;
 
     static TypeAArray *create(Type *t, Type *index);
     const char *kind();

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -884,7 +884,6 @@ extern(C++) Type typeSemantic(Type t, const ref Loc loc, Scope* sc)
         }
 
         mtype.loc = loc;
-        mtype.sc = sc;
         if (sc)
             sc.setNoFree();
 


### PR DESCRIPTION
while everyone's trying to reduce memory footprint: `sc` is an unused pointer of `TypeAArray` that is also a stale pointer prohibiting collecting some garbage when using the GC.