### PR TITLE
Add a simple object pool based on a freelist, apply to `TemplateInstance`

### DIFF
--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -22,6 +22,7 @@ import dmd.expression;
 import dmd.globals;
 import dmd.identifier;
 import dmd.mtype;
+import dmd.root.rmem;
 import dmd.visitor;
 
 /***********************************************************
@@ -265,7 +266,7 @@ extern (C++) final class Import : Dsymbol
             Identifier _alias = aliases[i];
             if (!_alias)
                 _alias = name;
-            auto tname = new TypeIdentifier(loc, name);
+            auto tname = Pool!TypeIdentifier.make(loc, name);
             auto ad = new AliasDeclaration(loc, _alias, tname);
             ad._import = this;
             ad.addMember(sc, sd);

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4092,7 +4092,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (cmainTemplateExists())
             {
                 // add `mixin _d_cmain!();` to the declaring module
-                auto tqual = new TypeIdentifier(funcdecl.loc, Id.CMain);
+                auto tqual = Pool!TypeIdentifier.make(funcdecl.loc, Id.CMain);
                 auto tm = new TemplateMixin(funcdecl.loc, null, tqual, null);
                 sc._module.members.push(tm);
             }

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1525,10 +1525,8 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                 if (auto ttp = param.isTemplateThisParameter())
                 {
                     hasttp = true;
-
-                    auto t = Pool!TypeIdentifier.make(Loc.initial, ttp.ident);
+                    scope t = new TypeIdentifier(Loc.initial, ttp.ident);
                     MATCH m = deduceType(tthis, paramscope, t, parameters, dedtypes);
-                    Pool!TypeIdentifier.dispose(t);
                     if (m <= MATCH.nomatch)
                         goto Lnomatch;
                     if (m < match)
@@ -2950,6 +2948,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
             return 0;
 
         Ltd_best2:
+            Pool!TemplateInstance.dispose(ti);
             return 0;
 
         Ltd2:

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -67,6 +67,7 @@ import dmd.mtype;
 import dmd.opover;
 import dmd.root.array;
 import dmd.root.outbuffer;
+import dmd.root.rmem;
 import dmd.root.rootobject;
 import dmd.semantic2;
 import dmd.semantic3;
@@ -8319,28 +8320,5 @@ void printTemplateStats()
     foreach (td, ref ts; TemplateStats.stats)
     {
         printf("%8u %8u   %s\n", ts.numInstantiations, ts.uniqueInstantiations, (cast(const TemplateDeclaration) td).toChars());
-    }
-}
-
-struct Pool(T)
-if (is(T == class))
-{
-    private static T root;
-
-    static T make(A...)(auto ref A args)
-    {
-        if (!root)
-            return new T(args);
-        auto result = root;
-        root = *(cast(T*) root);
-        memcpy(cast(void*) result, T.classinfo.initializer.ptr, T.classinfo.initializer.length);
-        result.__ctor(args);
-        return result;
-    }
-
-    static void dispose(T goner)
-    {
-        *(cast(T*) goner) = root;
-        root = goner;
     }
 }

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1526,8 +1526,9 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                 {
                     hasttp = true;
 
-                    Type t = new TypeIdentifier(Loc.initial, ttp.ident);
+                    auto t = Pool!TypeIdentifier.make(Loc.initial, ttp.ident);
                     MATCH m = deduceType(tthis, paramscope, t, parameters, dedtypes);
+                    Pool!TypeIdentifier.dispose(t);
                     if (m <= MATCH.nomatch)
                         goto Lnomatch;
                     if (m < match)
@@ -4074,11 +4075,12 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                          * it up and seeing if is an alias.
                          * https://issues.dlang.org/show_bug.cgi?id=1454
                          */
-                        auto tid = new TypeIdentifier(tp.loc, tp.tempinst.name);
+                        auto tid = Pool!TypeIdentifier.make(tp.loc, tp.tempinst.name);
                         Type tx;
                         Expression e;
                         Dsymbol s;
                         tid.resolve(tp.loc, sc, &e, &tx, &s);
+                        Pool!TypeIdentifier.dispose(tid);
                         if (tx)
                         {
                             s = tx.toDsymbol(sc);
@@ -5418,9 +5420,12 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
     override final bool declareParameter(Scope* sc)
     {
         //printf("TemplateTypeParameter.declareParameter('%s')\n", ident.toChars());
-        auto ti = new TypeIdentifier(loc, ident);
+        auto ti = Pool!TypeIdentifier.make(loc, ident);
         Declaration ad = new AliasDeclaration(loc, ident, ti);
-        return sc.insert(ad) !is null;
+        if (sc.insert(ad) !is null)
+            return true;
+        Pool!TypeIdentifier.dispose(ti);
+        return false;
     }
 
     override final void print(RootObject oarg, RootObject oded)
@@ -5467,7 +5472,7 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
         {
             // Use this for alias-parameter's too (?)
             if (!tdummy)
-                tdummy = new TypeIdentifier(loc, ident);
+                tdummy = Pool!TypeIdentifier.make(loc, ident);
             t = tdummy;
         }
         return t;
@@ -5644,9 +5649,12 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
 
     override bool declareParameter(Scope* sc)
     {
-        auto ti = new TypeIdentifier(loc, ident);
+        auto ti = Pool!TypeIdentifier.make(loc, ident);
         Declaration ad = new AliasDeclaration(loc, ident, ti);
-        return sc.insert(ad) !is null;
+        if (sc.insert(ad) !is null)
+            return true;
+        Pool!TypeIdentifier.dispose(ti);
+        return false;
     }
 
     override void print(RootObject oarg, RootObject oded)
@@ -5726,9 +5734,12 @@ extern (C++) final class TemplateTupleParameter : TemplateParameter
 
     override bool declareParameter(Scope* sc)
     {
-        auto ti = new TypeIdentifier(loc, ident);
+        auto ti = Pool!TypeIdentifier.make(loc, ident);
         Declaration ad = new AliasDeclaration(loc, ident, ti);
-        return sc.insert(ad) !is null;
+        if (sc.insert(ad) !is null)
+            return true;
+        Pool!TypeIdentifier.dispose(ti);
+        return false;
     }
 
     override void print(RootObject oarg, RootObject oded)

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -3119,7 +3119,6 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
             m.count = 1;
             assert(m.lastf);
             m.last = MATCH.nomatch;
-            Pool!TemplateInstance.dispose(ti);
             return;
         }
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3803,7 +3803,7 @@ extern (C++) final class FuncExp : Expression
             if (!tf.next && tof.next)
                 fd.treq = to;
 
-            auto ti = new TemplateInstance(loc, td, tiargs);
+            auto ti = Pool!TemplateInstance.make(loc, td, tiargs);
             Expression ex = (new ScopeExp(loc, ti)).expressionSemantic(td._scope);
 
             // Reset inference target for the later re-semantic
@@ -4730,7 +4730,7 @@ extern (C++) final class DotTemplateInstanceExp : UnaExp
     {
         super(loc, TOK.dotTemplateInstance, __traits(classInstanceSize, DotTemplateInstanceExp), e);
         //printf("DotTemplateInstanceExp()\n");
-        this.ti = new TemplateInstance(loc, name, tiargs);
+        this.ti = Pool!TemplateInstance.make(loc, name, tiargs);
     }
 
     extern (D) this(const ref Loc loc, Expression e, TemplateInstance ti)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -61,6 +61,7 @@ import dmd.root.ctfloat;
 import dmd.root.file;
 import dmd.root.filename;
 import dmd.root.outbuffer;
+import dmd.root.rmem;
 import dmd.root.rootobject;
 import dmd.root.string;
 import dmd.semantic2;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -463,7 +463,7 @@ private Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
     if (ue.op == TOK.dotTemplateInstance)
     {
         DotTemplateInstanceExp dti = cast(DotTemplateInstanceExp)ue;
-        auto ti = new TemplateInstance(loc, s.ident, dti.ti.tiargs);
+        auto ti = Pool!TemplateInstance.make(loc, s.ident, dti.ti.tiargs);
         if (!ti.updateTempDecl(sc, s))
             return new ErrorExp();
         return new ScopeExp(loc, ti);
@@ -4152,7 +4152,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
 
-            auto ti = new TemplateInstance(exp.loc, exp.td, tiargs);
+            auto ti = Pool!TemplateInstance.make(exp.loc, exp.td, tiargs);
             return (new ScopeExp(exp.loc, ti)).expressionSemantic(sc);
         }
         return exp.expressionSemantic(sc);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5341,7 +5341,7 @@ extern (C++) final class TypeIdentifier : TypeQualified
 
     override Type syntaxCopy()
     {
-        auto t = new TypeIdentifier(loc, ident);
+        auto t = Pool!TypeIdentifier.make(loc, ident);
         t.syntaxCopyHelper(this);
         t.mod = mod;
         return t;

--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -411,8 +411,8 @@ pure nothrow unittest
     assert(sEmpty.arraydup is null);
 }
 
-debug = Pool;
-debug = PoolSummary;
+//debug = Pool;
+//debug = PoolSummary;
 
 /**
 Defines a pool for class objects. Objects can be fetched from the pool with make() and returned to the pool with

--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -411,8 +411,10 @@ pure nothrow unittest
     assert(sEmpty.arraydup is null);
 }
 
+// Define this to have Pool emit traces of objects allocated and disposed
 //debug = Pool;
-//debug = PoolSummary;
+// Define this in addition to Pool to emit per-call traces (otherwise summaries are printed at the end).
+//debug = PoolVerbose;
 
 /**
 Defines a pool for class objects. Objects can be fetched from the pool with make() and returned to the pool with
@@ -435,7 +437,13 @@ if (is(T == class))
     {
         debug(Pool)
         {
-            debug(PoolSummary)
+            debug(PoolVerbose)
+            {
+                fprintf(stderr, "%.*s(%u): bytes: %lu Pool!(%.*s)."~fun~"()\n",
+                    cast(int) f.length, f.ptr, l, T.classinfo.initializer.length,
+                    cast(int) T.stringof.length, T.stringof.ptr);
+            }
+            else
             {
                 static ulong calls;
                 if (calls == 0)
@@ -450,12 +458,6 @@ if (is(T == class))
                     atexit(&summarize);
                 }
                 ++calls;
-            }
-            else
-            {
-                fprintf(stderr, "%.*s(%u): bytes: %lu Pool!(%.*s)."~fun~"()\n",
-                    cast(int) f.length, f.ptr, l, T.classinfo.initializer.length,
-                    cast(int) T.stringof.length, T.stringof.ptr);
             }
         }
     }

--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -428,7 +428,7 @@ if (is(T == class))
     /// The freelist's root
     private static T root;
 
-    private static void trackCalls(string fun, string f, uint l)()
+    private static void trace(string fun, string f, uint l)()
     {
         debug(Pool)
         {
@@ -464,10 +464,10 @@ if (is(T == class))
     {
         if (!root)
         {
-            trackCalls!("makeNew", f, l)();
+            trace!("makeNew", f, l)();
             return new T(args);
         }
-        trackCalls!("makeReuse", f, l)();
+        trace!("makeReuse", f, l)();
         auto result = root;
         root = *(cast(T*) root);
         memcpy(cast(void*) result, T.classinfo.initializer.ptr, T.classinfo.initializer.length);
@@ -480,7 +480,7 @@ if (is(T == class))
     */
     static void dispose(string f = __FILE__, uint l = __LINE__, A...)(T goner)
     {
-        trackCalls!("dispose", f, l)();
+        trace!("dispose", f, l)();
         *(cast(T*) goner) = root;
         root = goner;
     }

--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -440,9 +440,9 @@ if (is(T == class))
                     // Plant summary printer
                     static extern(C) void summarize()
                     {
-                        fprintf(stderr, "%.*s(%u): Pool!(%.*s)."~fun~"() calls=%lu bytes=%lu\n",
-                            cast(int) f.length, f.ptr, l, cast(int) T.stringof.length, T.stringof.ptr,
-                            calls, T.classinfo.initializer.length * calls);
+                        fprintf(stderr, "%.*s(%u): bytes: %lu calls: %lu Pool!(%.*s)."~fun~"()\n",
+                            cast(int) f.length, f.ptr, l, ((T.classinfo.initializer.length + 15) & ~15) * calls,
+                            calls, cast(int) T.stringof.length, T.stringof.ptr);
                     }
                     atexit(&summarize);
                 }
@@ -450,9 +450,9 @@ if (is(T == class))
             }
             else
             {
-                fprintf(stderr, "%.*s(%u): Pool!(%.*s)."~fun~"() bytes=%zu\n",
-                    cast(int) f.length, f.ptr, l, cast(int) T.stringof.length, T.stringof.ptr,
-                    T.classinfo.initializer.length);
+                fprintf(stderr, "%.*s(%u): bytes: %lu Pool!(%.*s)."~fun~"()\n",
+                    cast(int) f.length, f.ptr, l, T.classinfo.initializer.length,
+                    cast(int) T.stringof.length, T.stringof.ptr);
             }
         }
     }

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1473,7 +1473,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             // Evaluate: RTinfo!type
             auto tiargs = new Objects();
             tiargs.push(ad.type);
-            auto ti = new TemplateInstance(ad.loc, Type.rtinfo, tiargs);
+            auto ti = Pool!TemplateInstance.make(ad.loc, Type.rtinfo, tiargs);
 
             Scope* sc3 = ti.tempdecl._scope.startCTFE();
             sc3.tinst = sc.tinst;

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -44,6 +44,7 @@ import dmd.dinterpret;
 import dmd.mtype;
 import dmd.parse;
 import dmd.root.outbuffer;
+import dmd.root.rmem;
 import dmd.root.rootobject;
 import dmd.sapply;
 import dmd.sideeffect;
@@ -57,7 +58,7 @@ import dmd.visitor;
  */
 TypeIdentifier getThrowable()
 {
-    auto tid = new TypeIdentifier(Loc.initial, Id.empty);
+    auto tid = Pool!TypeIdentifier.make(Loc.initial, Id.empty);
     tid.addIdent(Id.object);
     tid.addIdent(Id.Throwable);
     return tid;
@@ -69,7 +70,7 @@ TypeIdentifier getThrowable()
  */
 TypeIdentifier getException()
 {
-    auto tid = new TypeIdentifier(Loc.initial, Id.empty);
+    auto tid = Pool!TypeIdentifier.make(Loc.initial, Id.empty);
     tid.addIdent(Id.object);
     tid.addIdent(Id.Exception);
     return tid;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -49,6 +49,7 @@ import dmd.mtype;
 import dmd.nogc;
 import dmd.opover;
 import dmd.root.outbuffer;
+import dmd.root.rmem;
 import dmd.root.string;
 import dmd.semantic2;
 import dmd.sideeffect;
@@ -4183,7 +4184,7 @@ else
                 if (!_alias)
                     _alias = name;
 
-                auto tname = new TypeIdentifier(s.loc, name);
+                auto tname = Pool!TypeIdentifier.make(s.loc, name);
                 auto ad = new AliasDeclaration(s.loc, _alias, tname);
                 ad._import = s;
                 s.aliasdecls.push(ad);

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -40,6 +40,7 @@ import dmd.globals;
 import dmd.id;
 import dmd.identifier;
 import dmd.mtype;
+import dmd.root.rmem;
 import dmd.typesem;
 import dmd.tokens : TOK;
 import dmd.root.ctfloat;
@@ -274,7 +275,7 @@ extern (C++) struct Target
         {
             if (global.params.is64bit)
             {
-                tvalist = new TypeIdentifier(Loc.initial, Identifier.idPool("__va_list_tag")).pointerTo();
+                tvalist = Pool!TypeIdentifier.make(Loc.initial, Identifier.idPool("__va_list_tag")).pointerTo();
                 tvalist = typeSemantic(tvalist, loc, sc);
             }
             else


### PR DESCRIPTION
The `Pool` template allows recycling of memory allocated for specific types. It implements a simple freelist that dispenses objects with `make`. Objects can be returned to the pool with `dispose`. Objects that have been `dispose`d should not be used any longer.

This improves memory usage in a large app in my measurements, albeit only a little (1%). The trick here is to insert calls to `dispose` wherever appropriate. I only chose a handful of obvious cases, but I'm sure there are more.
