### PR TITLE
Missing/Incorrect deprecation for templates

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2727,6 +2727,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         tempdecl.protection = sc.protection;
         tempdecl.cppnamespace = sc.namespace;
         tempdecl.isstatic = tempdecl.toParent().isModule() || (tempdecl._scope.stc & STC.static_);
+        tempdecl.deprecated_ = !!(sc.stc & STC.deprecated_);
+
         UserAttributeDeclaration.checkGNUABITag(tempdecl, sc.linkage);
 
         if (!tempdecl.isstatic)
@@ -5948,6 +5950,8 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
 
     TemplateStats.incInstance(tempdecl);
 
+    tempdecl.checkDeprecated(tempinst.loc, sc);
+
     // If tempdecl is a mixin, disallow it
     if (tempdecl.ismixin)
     {
@@ -6202,6 +6206,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     sc2.parent = tempinst;
     sc2.tinst = tempinst;
     sc2.minst = tempinst.minst;
+    sc2.stc &= ~STC.deprecated_;
     tempinst.tryExpandMembers(sc2);
 
     tempinst.semanticRun = PASS.semanticdone;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -560,6 +560,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
     bool isstatic;          // this is static template declaration
     bool isTrivialAliasSeq; /// matches pattern `template AliasSeq(T...) { alias AliasSeq = T; }`
     bool isTrivialAlias;    /// matches pattern `template Alias(T) { alias Alias = qualifiers(T); }`
+    bool deprecated_;       /// this template declaration is deprecated
     Prot protection;
     int inuse;              /// for recursive expansion detection
 
@@ -2521,6 +2522,11 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         if (dim == 0)
             return null;
         return (*parameters)[dim - 1].isTemplateTupleParameter();
+    }
+
+    extern(C++) override bool isDeprecated() const
+    {
+        return this.deprecated_;
     }
 
     /***********************************

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -68,6 +68,7 @@ public:
     bool isstatic;              // this is static template declaration
     bool isTrivialAliasSeq;     // matches `template AliasSeq(T...) { alias AliasSeq = T; }
     bool isTrivialAlias;        // matches pattern `template Alias(T) { alias Alias = qualifiers(T); }`
+    bool deprecated_;           // this template declaration is deprecated
     Prot protection;
     int inuse;                  // for recursive expansion detection
 
@@ -87,6 +88,7 @@ public:
     TemplateDeclaration *isTemplateDeclaration() { return this; }
 
     TemplateTupleParameter *isVariadic();
+    bool isDeprecated() const;
     bool isOverloadable() const;
 
     void accept(Visitor *v) { v->visit(this); }

--- a/test/compilable/depmsg.d
+++ b/test/compilable/depmsg.d
@@ -14,7 +14,7 @@ compilable/depmsg.d(43): Deprecation: enum `depmsg.main.Inner.E` is deprecated -
 compilable/depmsg.d(43): Deprecation: enum `depmsg.main.Inner.E` is deprecated - With message!
 compilable/depmsg.d(45): Deprecation: alias `depmsg.main.Inner.G` is deprecated - With message!
 compilable/depmsg.d(46): Deprecation: variable `depmsg.main.Inner.H` is deprecated - With message!
-compilable/depmsg.d(47): Deprecation: class `depmsg.main.Inner.I!().I` is deprecated - With message!
+compilable/depmsg.d(47): Deprecation: class `depmsg.main.Inner.I()` is deprecated - With message!
 ---
 */
 void main()

--- a/test/fail_compilation/depmsg.d
+++ b/test/fail_compilation/depmsg.d
@@ -14,7 +14,7 @@ fail_compilation/depmsg.d(44): Deprecation: enum `depmsg.main.Inner.E` is deprec
 fail_compilation/depmsg.d(44): Deprecation: enum `depmsg.main.Inner.E` is deprecated - With message!
 fail_compilation/depmsg.d(46): Deprecation: alias `depmsg.main.Inner.G` is deprecated - With message!
 fail_compilation/depmsg.d(47): Deprecation: variable `depmsg.main.Inner.H` is deprecated - With message!
-fail_compilation/depmsg.d(48): Deprecation: class `depmsg.main.Inner.I!().I` is deprecated - With message!
+fail_compilation/depmsg.d(48): Deprecation: class `depmsg.main.Inner.I()` is deprecated - With message!
 ---
 */
 

--- a/test/fail_compilation/depmsg15815.d
+++ b/test/fail_compilation/depmsg15815.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/depmsg15815.d(23): Deprecation: alias `depmsg15815.Alias!(const(Foo)).Alias` is deprecated - message
+fail_compilation/depmsg15815.d(23): Deprecation: template `depmsg15815.Alias(T)` is deprecated - message
 Foo
 ---
 */

--- a/test/fail_compilation/deprecatedTemplates.d
+++ b/test/fail_compilation/deprecatedTemplates.d
@@ -1,0 +1,63 @@
+/*
+REQUIRED_ARGS: -de
+
+TEST_OUTPUT:
+----
+fail_compilation/deprecatedTemplates.d(103): Deprecation: template `deprecatedTemplates.AliasSeq(V...)` is deprecated
+fail_compilation/deprecatedTemplates.d(107): Deprecation: struct `deprecatedTemplates.S1(V...)` is deprecated
+fail_compilation/deprecatedTemplates.d(115): Deprecation: template `deprecatedTemplates.C(V...)` is deprecated
+----
+*/
+#line 100
+
+deprecated alias AliasSeq(V...) = V;
+
+alias x = AliasSeq!(1, 2, 3);
+
+deprecated struct S1(V...) {}
+
+alias T1 = S1!();
+
+deprecated template C(V...)
+{
+    int i;
+    int j;
+}
+
+alias D = C!();
+
+/*
+TEST_OUTPUT:
+----
+fail_compilation/deprecatedTemplates.d(202): Deprecation: template `deprecatedTemplates.AliasSeqMsg(V...)` is deprecated - Reason
+----
+*/
+#line 200
+deprecated("Reason") alias AliasSeqMsg(V...) = V;
+
+alias xMsg = AliasSeqMsg!(1, 2, 3);
+
+deprecated struct DS()
+{
+    S1!() s;
+}
+
+deprecated struct DS2()
+{
+    static struct DS3()
+    {
+        S1!() s;
+    }
+
+    static struct DS4
+    {
+        S1!() s;
+    }
+}
+
+deprecated void foo()
+{
+    DS!() d1;
+    DS2!().DS3!() d2;
+    DS2!().DS4 d3;
+}

--- a/test/fail_compilation/diag14875.d
+++ b/test/fail_compilation/diag14875.d
@@ -40,7 +40,7 @@ fail_compilation/diag14875.d(47): Deprecation: class `diag14875.Dep` is deprecat
 fail_compilation/diag14875.d(51): Deprecation: variable `diag14875.depVar` is deprecated
 4: Dep
 fail_compilation/diag14875.d(58): Deprecation: variable `diag14875.depVar` is deprecated
-fail_compilation/diag14875.d(59): Deprecation: variable `diag14875.Vaz!(Dep).Vaz` is deprecated
+fail_compilation/diag14875.d(59): Deprecation: template `diag14875.Vaz(T)` is deprecated
 ---
 */
 


### PR DESCRIPTION
Deprecating templates mostly worked by accident before because the
members were flagged as deprecated. This doesn't work for all cases
and produces invalid error message claiming that the member (instead)
of the template declaration) is deprecated.

Example:
```
struct X {}

deprecated template T()
{
    void foo() {}
    struct S {}
    class C {}
    interface I {}
    enum E { F }
    int i;
    enum j = 2;
    alias Y = X;
}

void main()
{
    T!().foo();
    T!().S s;
    T!().Y y;
    T!().C c;
    T!().I i;
    T!().E e;
    T!().i = 2;
    int j = T!().j;
}
```

Output before:
```
de.d(17): Deprecation: function onlineapp.T!().foo is deprecated
de.d(17): Deprecation: function onlineapp.T!().foo is deprecated
de.d(18): Deprecation: struct onlineapp.T!().S is deprecated
de.d(20): Deprecation: class onlineapp.T!().C is deprecated
de.d(21): Deprecation: interface onlineapp.T!().I is deprecated
de.d(22): Deprecation: enum onlineapp.T!().E is deprecated
de.d(23): Deprecation: variable onlineapp.T!().i is deprecated
de.d(24): Deprecation: variable onlineapp.T!().j is deprecated
```

Output after:
```
de.d(17): Deprecation: template onlineapp.T is deprecated
de.d(17): Deprecation: template onlineapp.T is deprecated
de.d(18): Deprecation: template onlineapp.T is deprecated
de.d(20): Deprecation: template onlineapp.T is deprecated
de.d(21): Deprecation: template onlineapp.T is deprecated
de.d(22): Deprecation: template onlineapp.T is deprecated
de.d(23): Deprecation: template onlineapp.T is deprecated
de.d(24): Deprecation: template onlineapp.T is deprecated
```