### PR TITLE
recognize byteswap and generate XCHG

### DIFF
--- a/src/dmd/backend/evalu8.d
+++ b/src/dmd/backend/evalu8.d
@@ -1736,7 +1736,13 @@ else
         e.EV.Vlong = i1 & 1;
         break;
     case OPbswap:
-        e.EV.Vint = core.bitop.bswap(cast(uint) i1);
+        if (tysize(tym) == 2)
+        {
+            e.EV.Vint = ((i1 >> 8) & 0x00FF) |
+                        ((i1 << 8) & 0xFF00);
+        }
+        else
+            e.EV.Vint = core.bitop.bswap(cast(uint) i1);
         break;
 
     case OPpopcnt:

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -2012,6 +2012,23 @@ void test7()
 
 ////////////////////////////////////////////////////////////////////////
 
+// http://github.com/dlang/dmd/pull/11388
+
+ushort byteswap(ushort x) pure
+{
+    // Should be detected and XCHG instruction generated
+    return cast(ushort) (((x >> 8) & 0xFF) | ((x << 8) & 0xFF00u));
+}
+
+void testbyteswap()
+{
+    assert(byteswap(0xF234) == 0x34F2);
+    static ushort xx = 0xF234;
+    assert(byteswap(xx) == 0x34F2);
+}
+
+////////////////////////////////////////////////////////////////////////
+
 int main()
 {
     testgoto();
@@ -2085,6 +2102,7 @@ int main()
     test20050();
     testCpStatic();
     test7();
+    testbyteswap();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Much faster than the old shift, mask, and or code.

Related to https://github.com/dlang/druntime/pull/3150