### PR TITLE
test: Use asserts instead of printf in test8 va_arg checks

### DIFF
--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -752,19 +752,19 @@ int foo42(const(char) *x, ...)
     va_list ap;
 
     va_start!(typeof(x))(ap, x);
-    printf("&x = %p, ap = %p\n", &x, ap);
+    assert(ap != va_list.init);
 
     int i;
     i = va_arg!(typeof(i))(ap);
-    printf("i = %d\n", i);
+    assert(i == 3);
 
     long l;
     l = va_arg!(typeof(l))(ap);
-    printf("l = %lld\n", l);
+    assert(l == 23);
 
     uint k;
     k = va_arg!(typeof(k))(ap);
-    printf("k = %u\n", k);
+    assert(k == 4);
 
     va_end(ap);
 


### PR DESCRIPTION
```
printf("&x = %p, ap = %p\n", &x, ap);
```
This printf does not work on targets where va_list either a struct or static array.