### PR TITLE
build.d: Move gluelayer from glue to frontend.

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1153,7 +1153,7 @@ auto sourceFiles()
     }
     DmdSources dmd = {
         glue: fileArray(env["D"], "
-            stmtstate.d toctype.d glue.d gluelayer.d todt.d tocsym.d toir.d dmsc.d
+            stmtstate.d toctype.d glue.d todt.d tocsym.d toir.d dmsc.d
             tocvdebug.d s2ir.d toobj.d e2ir.d eh.d iasm.d iasmdmd.d iasmgcc.d objc_glue.d
         "),
         frontend: fileArray(env["D"], "
@@ -1162,7 +1162,7 @@ auto sourceFiles()
             cli.d clone.d compiler.d complex.d cond.d constfold.d cppmangle.d cppmanglewin.d ctfeexpr.d
             ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d dimport.d dinifile.d
             dinterpret.d dmacro.d dmangle.d dmodule.d doc.d dscope.d dstruct.d dsymbol.d dsymbolsem.d
-            dtemplate.d dtoh.d dversion.d env.d escape.d expression.d expressionsem.d func.d hdrgen.d impcnvtab.d
+            dtemplate.d dtoh.d dversion.d env.d escape.d expression.d expressionsem.d func.d gluelayer.d hdrgen.d impcnvtab.d
             imphint.d init.d initsem.d inline.d inlinecost.d intrange.d json.d lambdacomp.d lib.d libelf.d
             libmach.d libmscoff.d libomf.d link.d mars.d mtype.d nogc.d nspace.d ob.d objc.d opover.d optimize.d
             parse.d parsetimevisitor.d permissivevisitor.d printast.d safe.d sapply.d scanelf.d scanmach.d


### PR DESCRIPTION
It's really a front-end module that acts as the bridge for other front-end modules to import glue-specific symbols.

Part of sorting out build rule for cxx-unittest (blocking #11331).