### PR TITLE
build.d: Move stmtstate from glue to frontend.

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1154,7 +1154,7 @@ auto sourceFiles()
     }
     DmdSources dmd = {
         glue: fileArray(env["D"], "
-            stmtstate.d toctype.d glue.d todt.d tocsym.d toir.d dmsc.d
+            toctype.d glue.d todt.d tocsym.d toir.d dmsc.d
             tocvdebug.d s2ir.d toobj.d e2ir.d eh.d iasm.d iasmdmd.d iasmgcc.d objc_glue.d
         "),
         frontend: fileArray(env["D"], "
@@ -1168,7 +1168,7 @@ auto sourceFiles()
             libmach.d libmscoff.d libomf.d link.d mars.d mtype.d nogc.d nspace.d ob.d objc.d opover.d optimize.d
             parse.d parsetimevisitor.d permissivevisitor.d printast.d safe.d sapply.d scanelf.d scanmach.d
             scanmscoff.d scanomf.d semantic2.d semantic3.d sideeffect.d statement.d statement_rewrite_walker.d
-            statementsem.d staticassert.d staticcond.d target.d templateparamsem.d traits.d
+            statementsem.d staticassert.d staticcond.d stmtstate.d target.d templateparamsem.d traits.d
             transitivevisitor.d typesem.d typinf.d utils.d visitor.d vsoptions.d foreachvar.d
         "),
         backendHeaders: fileArray(env["C"], "

--- a/src/build.d
+++ b/src/build.d
@@ -1154,8 +1154,8 @@ auto sourceFiles()
     }
     DmdSources dmd = {
         glue: fileArray(env["D"], "
-            toctype.d glue.d todt.d tocsym.d toir.d dmsc.d
-            tocvdebug.d s2ir.d toobj.d e2ir.d eh.d iasm.d iasmdmd.d iasmgcc.d objc_glue.d
+            dmsc.d e2ir.d eh.d iasm.d iasmdmd.d iasmgcc.d glue.d objc_glue.d
+            s2ir.d tocsym.d toctype.d tocvdebug.d todt.d toir.d toobj.d
         "),
         frontend: fileArray(env["D"], "
             access.d aggregate.d aliasthis.d apply.d argtypes.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d


### PR DESCRIPTION
This used to be a glue module, but now it's used by both front and glue ends.

Part of sorting out build rule for cxx-unittest (blocking #11331).