### PR TITLE
test: Add explicit module declaration to imports for issue16995.d

### DIFF
--- a/test/runnable/imports/another_module_with_tests.d
+++ b/test/runnable/imports/another_module_with_tests.d
@@ -1,3 +1,4 @@
+module imports.another_module_with_tests;
 unittest {}
 unittest {}
 unittest { assert(false); }

--- a/test/runnable/imports/module_with_tests.d
+++ b/test/runnable/imports/module_with_tests.d
@@ -1,1 +1,2 @@
+module imports.module_with_tests;
 unittest {} unittest { assert(false); }


### PR DESCRIPTION
Small workaround for gdc testsuite (it currently ignores COMPILE_SEPARATELY).  But on the other hand, this makes these consistent with other import sources.