### PR TITLE
test: Synchronize simd tests with gdc testsuite

### DIFF
--- a/test/compilable/b16697.d
+++ b/test/compilable/b16697.d
@@ -1,13 +1,18 @@
-version(D_SIMD)
+static assert(!is(         float     == __vector));
+static assert(!is(         float[1]  == __vector));
+static assert(!is(         float[4]  == __vector));
+static assert(!is(__vector(float[3]) == __vector));
+static assert(!is(__vector(float[5]) == __vector));
+
+static if (__traits(compiles, __vector(float[4])))
 {
-    static assert(!is(         float       == __vector)); 
-    static assert(!is(         float[1]    == __vector)); 
-    static assert(!is(         float[4]    == __vector)); 
-    static assert( is(__vector(float[4])   == __vector)); 
-    static assert(!is(__vector(float[3])   == __vector)); 
-    static assert(!is(__vector(float[5])   == __vector)); 
-    static assert( is(__vector(float[4]) X == __vector) &&
-                   is(X == float[4])); 
-    static assert( is(__vector(byte[16]) X == __vector) &&
-                   is(X == byte[16])); 
+    static assert(is(__vector(float[4])   == __vector));
+    static assert(is(__vector(float[4]) X == __vector) &&
+                  is(X == float[4]));
+}
+
+static if (__traits(compiles, __vector(byte[16])))
+{
+    static assert(is(__vector(byte[16]) X == __vector) &&
+                  is(X == byte[16]));
 }

--- a/test/compilable/commontype.d
+++ b/test/compilable/commontype.d
@@ -455,32 +455,27 @@ static assert(is( X!( Si, Sl ) == long ));
  * Vectors
  */
 
-version(D_SIMD)
+static if (__traits(compiles, int4))
 {
+    static assert(is( X!( int4, int4 ) == int4));
+    static assert(is( X!( int4, const(int4) ) == const(int4)));
+    static assert(is( X!( int4, immutable(int4) ) == const(int4)));
+    static assert(is( X!( __vector(const(int)[4]), int4 ) == int4));
+    static assert(is( X!( int4, __vector(const(int)[4]) ) == int4));
 
-static assert(is( X!( int4, int4 ) == int4));
-static assert(is( X!( int4, const(int4) ) == const(int4)));
-static assert(is( X!( int4, immutable(int4) ) == const(int4)));
-static assert(is( X!( __vector(const(int)[4]), int4 ) == int4));
-static assert(is( X!( int4, __vector(const(int)[4]) ) == int4));
-
-static assert(Error!( byte16, void16 ));
-static assert(Error!( int4, void16 ));
-static assert(Error!( float4, void16 ));
-static assert(Error!( byte16, ubyte16 ));
-static assert(Error!( short8, ushort8 ));
-static assert(Error!( int4, uint4 ));
-static assert(Error!( int4, float4 ));
-version (D_AVX)
-{
-static assert(Error!( long4, ulong4 ));
-static assert(Error!( double4, float8 ));
+    static assert(Error!( int[4], int4 ));
+    static assert(Error!( int4, int[4] ));
 }
 
-static assert(Error!( int[4], int4 ));
-static assert(Error!( int4, int[4] ));
-
-}
+static if (__traits(compiles, { byte16 a; void16 b; }))  static assert(Error!( byte16, void16 ));
+static if (__traits(compiles, { int4 a; void16 b; }))    static assert(Error!( int4, void16 ));
+static if (__traits(compiles, { float4 a; void16 b; }))  static assert(Error!( float4, void16 ));
+static if (__traits(compiles, { byte16 a; ubyte16 b; })) static assert(Error!( byte16, ubyte16 ));
+static if (__traits(compiles, { short8 a; ushort8 b; })) static assert(Error!( short8, ushort8 ));
+static if (__traits(compiles, { int4 a; uint4 b; }))     static assert(Error!( int4, uint4 ));
+static if (__traits(compiles, { int4 a; float4 b; }))    static assert(Error!( int4, float4 ));
+static if (__traits(compiles, { long4 a; ulong4 b; }))   static assert(Error!( long4, ulong4 ));
+static if (__traits(compiles, { double4 a; float8 b; })) static assert(Error!( double4, float8 ));
 
 /******************************
  * Null

--- a/test/compilable/isZeroInit.d
+++ b/test/compilable/isZeroInit.d
@@ -72,7 +72,9 @@ struct S5
 }
 static assert(__traits(isZeroInit, S5));
 
-version(D_SIMD):
-import core.simd : int4;
-static assert(__traits(isZeroInit, Holder!(int4, 0)));
-static assert(!__traits(isZeroInit, Holder!(int4, 1)));
+template Vector(T) { alias __vector(T) Vector; }
+static if (is(Vector!(int[4])))
+{
+    static assert(__traits(isZeroInit, Holder!(Vector!(int[4]), 0)));
+    static assert(!__traits(isZeroInit, Holder!(Vector!(int[4]), 1)));
+}

--- a/test/compilable/test10312.d
+++ b/test/compilable/test10312.d
@@ -1,5 +1,5 @@
 
-version(D_SIMD)
+static if (__traits(compiles, __vector(float[4])))
 {
     const __vector(float[4]) si = [1f, 1f, 1f, 1f];
 

--- a/test/compilable/test11371.d
+++ b/test/compilable/test11371.d
@@ -1,5 +1,5 @@
 
-version(D_SIMD)
+static if (__traits(compiles, __vector(long[2])))
 {
     __vector(long[2]) f()
     {

--- a/test/compilable/test11656.d
+++ b/test/compilable/test11656.d
@@ -1,5 +1,5 @@
 
-version(D_SIMD)
+static if (__traits(compiles, __vector(float[4])))
 {
 	struct Foo
 	{

--- a/test/compilable/test17793.d
+++ b/test/compilable/test17793.d
@@ -1,7 +1,7 @@
 // REQUIRED_ARGS: -mcpu=avx2
 import core.simd;
 
-version (D_AVX)
+static if (__traits(compiles, double4))
 {
     double4 foo();
     void test(double[4]);

--- a/test/compilable/test19224.d
+++ b/test/compilable/test19224.d
@@ -1,5 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=19224
-version (D_SIMD)
+static if (__traits(compiles, __vector(float[4])))
 {
     float sum(const float[4] val)
     {
@@ -8,7 +8,7 @@ version (D_SIMD)
         return sum;
     }
 
-    import core.simd : float4;
+    alias float4 = __vector(float[4]);
 
     enum x = sum(float4.init.array);
     static assert(x is float.nan);

--- a/test/compilable/test8543.d
+++ b/test/compilable/test8543.d
@@ -1,5 +1,5 @@
 
-version (D_SIMD)
+static if (__traits(compiles, __vector(float[4])))
 {
     struct vfloat
     {

--- a/test/fail_compilation/vector_types.d
+++ b/test/fail_compilation/vector_types.d
@@ -11,7 +11,7 @@ fail_compilation/vector_types.d(19): Error: 32 byte vector type `__vector(ushort
 fail_compilation/vector_types.d(20): Error: 32 byte vector type `__vector(ubyte[32])` is not supported on this platform
 ---
 */
-version (D_SIMD):
+
 alias a = __vector(double[4]);
 alias b = __vector(float[8]);
 alias c = __vector(ulong[4]);

--- a/test/runnable/b18034.d
+++ b/test/runnable/b18034.d
@@ -1,8 +1,8 @@
 // REQUIRED_ARGS: -O
-version (D_SIMD)
-{
-    import core.simd;
+import core.simd;
 
+static if (__traits(compiles, { void16 a; ushort8 b; }))
+{
     void check(void16 a) 
     {
         foreach (x; (cast(ushort8)a).array) 

--- a/test/runnable/bug11155.d
+++ b/test/runnable/bug11155.d
@@ -1,6 +1,6 @@
 // PERMUTE_ARGS:
 
-version(D_SIMD)
+static if (__traits(compiles, __vector(float[4])))
 {
     alias float4 = __vector(float[4]);
 

--- a/test/runnable/test17337.d
+++ b/test/runnable/test17337.d
@@ -1,6 +1,6 @@
 // REQUIRED_ARGS: -mcpu=native
 
-version (D_SIMD)
+static if (__traits(compiles, __vector(ubyte[16])))
 {
     alias ubyte16 = __vector(ubyte[16]);
 

--- a/test/runnable/test19223.d
+++ b/test/runnable/test19223.d
@@ -1,6 +1,7 @@
-version (D_SIMD)
+
+static if (__traits(compiles, __vector(int[4])))
 {
-    import core.simd;
+    alias int4 = __vector(int[4]);
 
     int fn(const int[4] x)
     {

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4355,12 +4355,6 @@ void test240() {
     double a = void;
     double b = void;
     double x = void;
-    version (D_SIMD)
-    {
-//	assert((cast(size_t)&a & 7) == 0);
-//	assert((cast(size_t)&b & 7) == 0);
-//	assert((cast(size_t)&x & 7) == 0);
-    }
     a = foo240();
     b = foo240();
     x = a*a + a*a + a*a + a*a + a*a + a*a + a*a +

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -129,7 +129,7 @@ void test1()
 
 void test2()
 {
-    byte16 v1,v2,v3;
+    byte16 v1, v2 = 1, v3 = 1;
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
@@ -189,7 +189,7 @@ void test2()
 
 void test2b()
 {
-    ubyte16 v1,v2,v3;
+    ubyte16 v1, v2 = 1, v3 = 1;
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
@@ -249,7 +249,7 @@ void test2b()
 
 void test2c()
 {
-    short8 v1,v2,v3;
+    short8 v1, v2 = 1, v3 = 1;
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
@@ -310,7 +310,7 @@ void test2c()
 
 void test2d()
 {
-    ushort8 v1,v2,v3;
+    ushort8 v1, v2 = 1, v3 = 1;
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
@@ -370,7 +370,7 @@ void test2d()
 
 void test2e()
 {
-    int4 v1,v2,v3;
+    int4 v1, v2 = 1, v3 = 1;
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
@@ -436,7 +436,7 @@ void test2e()
 
 void test2f()
 {
-    uint4 v1,v2,v3;
+    uint4 v1, v2 = 1, v3 = 1;
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
@@ -502,7 +502,7 @@ void test2f()
 
 void test2g()
 {
-    long2 v1,v2,v3;
+    long2 v1, v2 = 1, v3 = 1;
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
@@ -562,7 +562,7 @@ void test2g()
 
 void test2h()
 {
-    ulong2 v1,v2,v3;
+    ulong2 v1, v2 = 1, v3 = 1;
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
@@ -622,7 +622,7 @@ void test2h()
 
 void test2i()
 {
-    float4 v1,v2,v3;
+    float4 v1, v2 = 1, v3 = 1;
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
@@ -682,7 +682,7 @@ void test2i()
 
 void test2j()
 {
-    double2 v1,v2,v3;
+    double2 v1, v2 = 1, v3 = 1;
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
@@ -1347,7 +1347,6 @@ float4 foo9304(float4 a)
 void test9304()
 {
     auto a = foo9304([0, 1, 2, 3]);
-    //writeln(a.array);
     assert(a.array == [0,-1,-2,-3]);
 }
 

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -12,56 +12,101 @@ alias TypeTuple(T...) = T;
 /*****************************************/
 // https://issues.dlang.org/show_bug.cgi?id=16087
 
-static assert(void16.alignof == 16);
-static assert(double2.alignof == 16);
-static assert(float4.alignof == 16);
-static assert(byte16.alignof == 16);
-static assert(ubyte16.alignof == 16);
-static assert(short8.alignof == 16);
-static assert(ushort8.alignof == 16);
-static assert(int4.alignof == 16);
-static assert(uint4.alignof == 16);
-static assert(long2.alignof == 16);
-static assert(ulong2.alignof == 16);
+static if (__traits(compiles, void8))   static assert(void8.alignof == 8);
+static if (__traits(compiles, double1)) static assert(double1.alignof == 8);
+static if (__traits(compiles, float2))  static assert(float2.alignof == 8);
+static if (__traits(compiles, byte8))   static assert(byte8.alignof == 8);
+static if (__traits(compiles, ubyte8))  static assert(ubyte8.alignof == 8);
+static if (__traits(compiles, short4))  static assert(short4.alignof == 8);
+static if (__traits(compiles, ushort4)) static assert(ushort4.alignof == 8);
+static if (__traits(compiles, int2))    static assert(int2.alignof == 8);
+static if (__traits(compiles, uint2))   static assert(uint2.alignof == 8);
+static if (__traits(compiles, long1))   static assert(long1.alignof == 8);
+static if (__traits(compiles, ulong1))  static assert(ulong1.alignof == 8);
 
-static assert(void16.sizeof == 16);
-static assert(double2.sizeof == 16);
-static assert(float4.sizeof == 16);
-static assert(byte16.sizeof == 16);
-static assert(ubyte16.sizeof == 16);
-static assert(short8.sizeof == 16);
-static assert(ushort8.sizeof == 16);
-static assert(int4.sizeof == 16);
-static assert(uint4.sizeof == 16);
-static assert(long2.sizeof == 16);
-static assert(ulong2.sizeof == 16);
+static if (__traits(compiles, void8))   static assert(void8.sizeof == 8);
+static if (__traits(compiles, double1)) static assert(double1.sizeof == 8);
+static if (__traits(compiles, float2))  static assert(float2.sizeof == 8);
+static if (__traits(compiles, byte8))   static assert(byte8.sizeof == 8);
+static if (__traits(compiles, ubyte8))  static assert(ubyte8.sizeof == 8);
+static if (__traits(compiles, short4))  static assert(short4.sizeof == 8);
+static if (__traits(compiles, ushort4)) static assert(ushort4.sizeof == 8);
+static if (__traits(compiles, int2))    static assert(int2.sizeof == 8);
+static if (__traits(compiles, uint2))   static assert(uint2.sizeof == 8);
+static if (__traits(compiles, long1))   static assert(long1.sizeof == 8);
+static if (__traits(compiles, ulong1))  static assert(ulong1.sizeof == 8);
 
-version (D_AVX)
-{
-    static assert(void32.alignof == 32);
-    static assert(double4.alignof == 32);
-    static assert(float8.alignof == 32);
-    static assert(byte32.alignof == 32);
-    static assert(ubyte32.alignof == 32);
-    static assert(short16.alignof == 32);
-    static assert(ushort16.alignof == 32);
-    static assert(int8.alignof == 32);
-    static assert(uint8.alignof == 32);
-    static assert(long4.alignof == 32);
-    static assert(ulong4.alignof == 32);
+static if (__traits(compiles, void16))  static assert(void16.alignof == 16);
+static if (__traits(compiles, double2)) static assert(double2.alignof == 16);
+static if (__traits(compiles, float4))  static assert(float4.alignof == 16);
+static if (__traits(compiles, byte16))  static assert(byte16.alignof == 16);
+static if (__traits(compiles, ubyte16)) static assert(ubyte16.alignof == 16);
+static if (__traits(compiles, short8))  static assert(short8.alignof == 16);
+static if (__traits(compiles, ushort8)) static assert(ushort8.alignof == 16);
+static if (__traits(compiles, int4))    static assert(int4.alignof == 16);
+static if (__traits(compiles, uint4))   static assert(uint4.alignof == 16);
+static if (__traits(compiles, long2))   static assert(long2.alignof == 16);
+static if (__traits(compiles, ulong2))  static assert(ulong2.alignof == 16);
 
-    static assert(void32.sizeof == 32);
-    static assert(double4.sizeof == 32);
-    static assert(float8.sizeof == 32);
-    static assert(byte32.sizeof == 32);
-    static assert(ubyte32.sizeof == 32);
-    static assert(short16.sizeof == 32);
-    static assert(ushort16.sizeof == 32);
-    static assert(int8.sizeof == 32);
-    static assert(uint8.sizeof == 32);
-    static assert(long4.sizeof == 32);
-    static assert(ulong4.sizeof == 32);
-}
+static if (__traits(compiles, void16))  static assert(void16.sizeof == 16);
+static if (__traits(compiles, double2)) static assert(double2.sizeof == 16);
+static if (__traits(compiles, float4))  static assert(float4.sizeof == 16);
+static if (__traits(compiles, byte16))  static assert(byte16.sizeof == 16);
+static if (__traits(compiles, ubyte16)) static assert(ubyte16.sizeof == 16);
+static if (__traits(compiles, short8))  static assert(short8.sizeof == 16);
+static if (__traits(compiles, ushort8)) static assert(ushort8.sizeof == 16);
+static if (__traits(compiles, int4))    static assert(int4.sizeof == 16);
+static if (__traits(compiles, uint4))   static assert(uint4.sizeof == 16);
+static if (__traits(compiles, long2))   static assert(long2.sizeof == 16);
+static if (__traits(compiles, ulong2))  static assert(ulong2.sizeof == 16);
+
+static if (__traits(compiles, void32))   static assert(void32.alignof == 32);
+static if (__traits(compiles, double4))  static assert(double4.alignof == 32);
+static if (__traits(compiles, float8))   static assert(float8.alignof == 32);
+static if (__traits(compiles, byte32))   static assert(byte32.alignof == 32);
+static if (__traits(compiles, ubyte32))  static assert(ubyte32.alignof == 32);
+static if (__traits(compiles, short16))  static assert(short16.alignof == 32);
+static if (__traits(compiles, ushort16)) static assert(ushort16.alignof == 32);
+static if (__traits(compiles, int8))     static assert(int8.alignof == 32);
+static if (__traits(compiles, uint8))    static assert(uint8.alignof == 32);
+static if (__traits(compiles, long4))    static assert(long4.alignof == 32);
+static if (__traits(compiles, ulong4))   static assert(ulong4.alignof == 32);
+
+static if (__traits(compiles, void32))   static assert(void32.sizeof == 32);
+static if (__traits(compiles, double4))  static assert(double4.sizeof == 32);
+static if (__traits(compiles, float8))   static assert(float8.sizeof == 32);
+static if (__traits(compiles, byte32))   static assert(byte32.sizeof == 32);
+static if (__traits(compiles, ubyte32))  static assert(ubyte32.sizeof == 32);
+static if (__traits(compiles, short16))  static assert(short16.sizeof == 32);
+static if (__traits(compiles, ushort16)) static assert(ushort16.sizeof == 32);
+static if (__traits(compiles, int8))     static assert(int8.sizeof == 32);
+static if (__traits(compiles, uint8))    static assert(uint8.sizeof == 32);
+static if (__traits(compiles, long4))    static assert(long4.sizeof == 32);
+static if (__traits(compiles, ulong4))   static assert(ulong4.sizeof == 32);
+
+static if (__traits(compiles, void64))   static assert(void64.alignof == 64);
+static if (__traits(compiles, double8))  static assert(double8.alignof == 64);
+static if (__traits(compiles, float16))  static assert(float16.alignof == 64);
+static if (__traits(compiles, byte64))   static assert(byte64.alignof == 64);
+static if (__traits(compiles, ubyte64))  static assert(ubyte64.alignof == 64);
+static if (__traits(compiles, short32))  static assert(short32.alignof == 64);
+static if (__traits(compiles, ushort32)) static assert(ushort32.alignof == 64);
+static if (__traits(compiles, int16))    static assert(int16.alignof == 64);
+static if (__traits(compiles, uint16))   static assert(uint16.alignof == 64);
+static if (__traits(compiles, long8))    static assert(long8.alignof == 64);
+static if (__traits(compiles, ulong8))   static assert(ulong8.alignof == 64);
+
+static if (__traits(compiles, void64))   static assert(void64.sizeof == 64);
+static if (__traits(compiles, double8))  static assert(double8.sizeof == 64);
+static if (__traits(compiles, float16))  static assert(float16.sizeof == 64);
+static if (__traits(compiles, byte64))   static assert(byte64.sizeof == 64);
+static if (__traits(compiles, ubyte64))  static assert(ubyte64.sizeof == 64);
+static if (__traits(compiles, short32))  static assert(short32.sizeof == 64);
+static if (__traits(compiles, ushort32)) static assert(ushort32.sizeof == 64);
+static if (__traits(compiles, int16))    static assert(int16.sizeof == 64);
+static if (__traits(compiles, uint16))   static assert(uint16.sizeof == 64);
+static if (__traits(compiles, long8))    static assert(long8.sizeof == 64);
+static if (__traits(compiles, ulong8))   static assert(ulong8.sizeof == 64);
 
 /*****************************************/
 
@@ -374,7 +419,7 @@ void test2e()
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
-    version (D_AVX) // SSE4.1
+    static if (__traits(compiles, { v1 = v2 * v3; })) // SSE4.1
         v1 = v2 * v3;
     else
         static assert(!__traits(compiles, v1 * v2));
@@ -405,7 +450,7 @@ void test2e()
 
     v1 += v2;
     v1 -= v2;
-    version (D_AVX) // SSE4.1
+    static if (__traits(compiles, { v1 *= v2; })) // SSE4.1
         v1 *= v2;
     else
         static assert(!__traits(compiles, v1 *= v2));
@@ -440,7 +485,7 @@ void test2f()
     v1 = v2;
     v1 = v2 + v3;
     v1 = v2 - v3;
-    version (D_AVX) // SSE4.1
+    static if (__traits(compiles, { v1 = v2 * v3; })) // SSE4.1
         v1 = v2 * v3;
     else
         static assert(!__traits(compiles, v1 * v2));
@@ -471,7 +516,7 @@ void test2f()
 
     v1 += v2;
     v1 -= v2;
-    version (D_AVX) // SSE4.1
+    static if (__traits(compiles, { v1 *= v2; })) // SSE4.1
         v1 *= v2;
     else
         static assert(!__traits(compiles, v1 *= v2));
@@ -1672,7 +1717,7 @@ void test16448()
 
 /*****************************************/
 
-version (D_AVX)
+static if (__traits(compiles, byte32))
 {
     void foo_byte32(byte t, byte s)
     {
@@ -1860,7 +1905,7 @@ void test10447()
 /*****************************************/
 // https://issues.dlang.org/show_bug.cgi?id=17237
 
-version (D_AVX)
+static if (__traits(compiles, int8))
 {
     struct S17237
     {
@@ -1937,7 +1982,7 @@ void refIntrinsics()
 
 void test6a()
 {
-    version (D_AVX2)
+    static if (__traits(compiles, { long4 x; x += 1; }))
     {
         // stack occasionally misaligned
         float f = 0;
@@ -1949,7 +1994,7 @@ void test6a()
 
 void test6b()
 {
-    version (D_AVX2)
+    static if (__traits(compiles, long4))
     {
         struct S {long4 v;}
         S s;
@@ -1965,7 +2010,7 @@ void test6()
 
 /*****************************************/
 
-version (D_AVX)
+static if (__traits(compiles, double4))
 {
     double4 test7r(double4 v)
     {
@@ -1975,7 +2020,7 @@ version (D_AVX)
 
 void test7()
 {
-    version (D_AVX)
+    static if (__traits(compiles, double4))
     {
         // 32 bytes sliced down to 16 bytes
         double4 v = 1;
@@ -1990,7 +2035,7 @@ void test7()
 
 auto test20052()
 {
-    version (D_AVX2)
+    static if (__traits(compiles, long4))
     {
         struct S { long4 v; }
         S s;


### PR DESCRIPTION
Removes the use of D_SIMD and D_AVX as a static gate, so that gdc and ldc can also test them.