### PR TITLE
fix Issue 21037 - AVX code sometimes fails to set VEX prefix

### DIFF
--- a/src/dmd/backend/cgxmm.d
+++ b/src/dmd/backend/cgxmm.d
@@ -274,8 +274,7 @@ void xmmeq(ref CodeBuilder cdb, elem *e, opcode_t op, elem *e1, elem *e2,regm_t 
     if (!(regvar && reg == XMM0 + ((cs.Irm & 7) | (cs.Irex & REX_B ? 8 : 0))))
     {
         cdb.gen(&cs);         // MOV EA+offset,reg
-        if (op == OPeq)
-            checkSetVex(cdb.last(), tyml);
+        checkSetVex(cdb.last(), tyml);
     }
 
     if (e1.Ecount ||                     // if lvalue is a CSE or


### PR DESCRIPTION
I don't know why that `if` was there, looking back to the commit that introduced it offers no clue. I don't know why testxmm.d wasn't failing before, perhaps the tests suddenly started running with avx enabled?

Anyhow, the test is in `testxmm.d`.