### PR TITLE
Use errorSupplemental for long read-modify-write error message

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1383,9 +1383,10 @@ extern (C++) abstract class Expression : ASTNode
             break;
         }
 
-        error("read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!\"%s\"(%s, %s)` instead.", Token.toChars(rmwOp), toChars(), ex ? ex.toChars() : "1");
-
-         return true;
+        error("read-modify-write operations are not allowed for `shared` variables");
+        errorSupplemental("Use `core.atomic.atomicOp!\"%s\"(%s, %s)` instead",
+                          Token.toChars(rmwOp), toChars(), ex ? ex.toChars() : "1");
+        return true;
     }
 
     /***************************************

--- a/test/fail_compilation/diag3672.d
+++ b/test/fail_compilation/diag3672.d
@@ -2,29 +2,52 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag3672.d(35): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 1)` instead.
-fail_compilation/diag3672.d(36): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 1)` instead.
-fail_compilation/diag3672.d(37): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(x, 1)` instead.
-fail_compilation/diag3672.d(38): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(x, 1)` instead.
-fail_compilation/diag3672.d(39): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 1)` instead.
-fail_compilation/diag3672.d(40): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 2)` instead.
-fail_compilation/diag3672.d(41): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(x, 3)` instead.
-fail_compilation/diag3672.d(42): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"|="(x, y)` instead.
-fail_compilation/diag3672.d(43): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"*="(x, y)` instead.
-fail_compilation/diag3672.d(44): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"/="(x, y)` instead.
-fail_compilation/diag3672.d(45): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"%="(x, y)` instead.
-fail_compilation/diag3672.d(46): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"&="(x, y)` instead.
-fail_compilation/diag3672.d(47): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"^="(x, y)` instead.
-fail_compilation/diag3672.d(48): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"<<="(x, y)` instead.
-fail_compilation/diag3672.d(49): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!">>="(x, y)` instead.
-fail_compilation/diag3672.d(50): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!">>>="(x, y)` instead.
-fail_compilation/diag3672.d(51): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"^^="(x, y)` instead.
-fail_compilation/diag3672.d(52): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(ptr, 1)` instead.
-fail_compilation/diag3672.d(53): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(ptr, 1)` instead.
-fail_compilation/diag3672.d(54): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(ptr, 1)` instead.
-fail_compilation/diag3672.d(55): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(ptr, 1)` instead.
+fail_compilation/diag3672.d(8): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(8):        Use `core.atomic.atomicOp!"+="(x, 1)` instead
+fail_compilation/diag3672.d(9): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(9):        Use `core.atomic.atomicOp!"+="(x, 1)` instead
+fail_compilation/diag3672.d(10): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(10):        Use `core.atomic.atomicOp!"-="(x, 1)` instead
+fail_compilation/diag3672.d(11): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(11):        Use `core.atomic.atomicOp!"-="(x, 1)` instead
+fail_compilation/diag3672.d(12): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(12):        Use `core.atomic.atomicOp!"+="(x, 1)` instead
+fail_compilation/diag3672.d(13): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(13):        Use `core.atomic.atomicOp!"+="(x, 2)` instead
+fail_compilation/diag3672.d(14): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(14):        Use `core.atomic.atomicOp!"-="(x, 3)` instead
+fail_compilation/diag3672.d(15): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(15):        Use `core.atomic.atomicOp!"|="(x, y)` instead
+fail_compilation/diag3672.d(16): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(16):        Use `core.atomic.atomicOp!"*="(x, y)` instead
+fail_compilation/diag3672.d(17): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(17):        Use `core.atomic.atomicOp!"/="(x, y)` instead
+fail_compilation/diag3672.d(18): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(18):        Use `core.atomic.atomicOp!"%="(x, y)` instead
+fail_compilation/diag3672.d(19): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(19):        Use `core.atomic.atomicOp!"&="(x, y)` instead
+fail_compilation/diag3672.d(20): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(20):        Use `core.atomic.atomicOp!"^="(x, y)` instead
+fail_compilation/diag3672.d(21): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(21):        Use `core.atomic.atomicOp!"<<="(x, y)` instead
+fail_compilation/diag3672.d(22): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(22):        Use `core.atomic.atomicOp!">>="(x, y)` instead
+fail_compilation/diag3672.d(23): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(23):        Use `core.atomic.atomicOp!">>>="(x, y)` instead
+fail_compilation/diag3672.d(24): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(24):        Use `core.atomic.atomicOp!"^^="(x, y)` instead
+fail_compilation/diag3672.d(25): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(25):        Use `core.atomic.atomicOp!"+="(ptr, 1)` instead
+fail_compilation/diag3672.d(26): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(26):        Use `core.atomic.atomicOp!"+="(ptr, 1)` instead
+fail_compilation/diag3672.d(27): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(27):        Use `core.atomic.atomicOp!"-="(ptr, 1)` instead
+fail_compilation/diag3672.d(28): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672.d(28):        Use `core.atomic.atomicOp!"-="(ptr, 1)` instead
 ---
 */
+
+#line 1
 shared int x;
 shared int y;
 shared int* ptr;

--- a/test/fail_compilation/diag3672a.d
+++ b/test/fail_compilation/diag3672a.d
@@ -2,8 +2,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag3672a.d(15): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(ns.x, 1)` instead.
-fail_compilation/diag3672a.d(17): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(s.sx, 1)` instead.
+fail_compilation/diag3672a.d(17): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672a.d(17):        Use `core.atomic.atomicOp!"+="(ns.x, 1)` instead
+fail_compilation/diag3672a.d(19): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672a.d(19):        Use `core.atomic.atomicOp!"+="(s.sx, 1)` instead
 ---
 */
 class NS { shared int x; }
@@ -20,8 +22,10 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag3672a.d(31): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(s.var, 1)` instead.
-fail_compilation/diag3672a.d(32): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(s.var, 2)` instead.
+fail_compilation/diag3672a.d(35): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672a.d(35):        Use `core.atomic.atomicOp!"+="(s.var, 1)` instead
+fail_compilation/diag3672a.d(36): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/diag3672a.d(36):        Use `core.atomic.atomicOp!"-="(s.var, 2)` instead
 ---
 */
 void test13003()

--- a/test/fail_compilation/fail3672.d
+++ b/test/fail_compilation/fail3672.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3672.d(27): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(*p, 1)` instead.
-fail_compilation/fail3672.d(31): Error: none of the `opOpAssign` overloads of `SF` are callable for `*sfp` of type `shared(SF)`
+fail_compilation/fail3672.d(28): Error: read-modify-write operations are not allowed for `shared` variables
+fail_compilation/fail3672.d(28):        Use `core.atomic.atomicOp!"+="(*p, 1)` instead
+fail_compilation/fail3672.d(32): Error: none of the `opOpAssign` overloads of `SF` are callable for `*sfp` of type `shared(SF)`
 ---
 */
 


### PR DESCRIPTION
More user friendly and in line with other error messages.