### PR TITLE
Move the implementation of `-preview=in` from parser to semantic

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -2889,14 +2889,7 @@ final class Parser(AST) : Lexer
                         // Don't call nextToken again.
                     }
                 case TOK.in_:
-                    if (global.params.inMeansScopeConst)
-                    {
-                        // `in` now means `const scope` as originally intented
-                        stc = STC.const_ | STC.scope_;
-                    }
-                    else
-                        stc = STC.in_;
-
+                    stc = STC.in_;
                     goto L2;
 
                 case TOK.out_:

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1261,6 +1261,9 @@ extern(C++) Type typeSemantic(Type t, const ref Loc loc, Scope* sc)
             for (size_t i = 0; i < dim; i++)
             {
                 Parameter fparam = tf.parameterList[i];
+                // If `-preview=in` is on, set `scope` as well
+                if ((fparam.storageClass & STC.in_) && global.params.inMeansScopeConst)
+                    fparam.storageClass |= STC.scope_;
                 fparam.storageClass |= STC.parameter;
                 mtype.inuse++;
                 fparam.type = fparam.type.typeSemantic(loc, argsc);


### PR DESCRIPTION
```
As noted in the original PR, implementing `-preview=in` in the parser
breaks the header generation.
This moves the change to semantic, fixing the header generation.
However, a persistent problem is that the user will still see
`foo(scope const(T))` instead of `foo(in T)` in error messages,
due to the way the type is altered.
This require a deeper refactoring to fix and will be done in a later PR.
```

On the long run, I restarted my efforts to make `in` a first class citizen ( see #11000 ) and there's a lot of fixes required to make this work sanely.