### PR TITLE
Backend: Remove unused 'mask/maskl' global from var

### DIFF
--- a/src/dmd/backend/var.d
+++ b/src/dmd/backend/var.d
@@ -184,27 +184,6 @@ int level = 0;                  /* declaration level                    */
 param_t *paramlst = null;       /* function parameter list              */
 tym_t pointertype = TYnptr;     /* default data pointer type            */
 
-/************************
- * Bit masks
- */
-
-const uint[32] mask =
-        [1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192,16384,0x8000,
-         0x10000,0x20000,0x40000,0x80000,0x100000,0x200000,0x400000,0x800000,
-         0x1000000,0x2000000,0x4000000,0x8000000,
-         0x10000000,0x20000000,0x40000000,0x80000000];
-
-static if (0)
-{
-const uint[32] maskl =
-        [1,2,4,8,0x10,0x20,0x40,0x80,
-         0x100,0x200,0x400,0x800,0x1000,0x2000,0x4000,0x8000,
-         0x10000,0x20000,0x40000,0x80000,0x100000,0x200000,0x400000,0x800000,
-         0x1000000,0x2000000,0x4000000,0x8000000,
-         0x10000000,0x20000000,0x40000000,0x80000000];
-}
-
-
 /* From util.c */
 
 /*****************************
@@ -1041,4 +1020,3 @@ enum TXsimd       = [
                      TYlong16,TYulong16,TYllong8,TYullong8,
                      TYfloat16,TYdouble8,
                     ];
-


### PR DESCRIPTION
```
Those globals were not used anywhere in DMD,
nor do they seem to be used by DMC.
```

@WalterBright : A quick grep on DMC did not reveal anything, but I'd like your ACK on this.
This was originally prompted by the `mask` / `maskl` arrays which seemed rather superfluous, but then I realized more could be removed.