### PR TITLE
Fix 21063 - getLinkage fails with forward references

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1433,19 +1433,34 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 e.error("argument to `__traits(getLinkage, %s)` is not a declaration", o.toChars());
                 return new ErrorExp();
             }
+
             if (d !is null)
                 link = d.linkage;
-            else final switch (agg.classKind)
+            else
             {
-                case ClassKind.d:
-                    link = LINK.d;
-                    break;
-                case ClassKind.cpp:
-                    link = LINK.cpp;
-                    break;
-                case ClassKind.objc:
-                    link = LINK.objc;
-                    break;
+                // Resolves forward references
+                if (agg.sizeok != Sizeok.done)
+                {
+                    agg.size(e.loc);
+                    if (agg.sizeok != Sizeok.done)
+                    {
+                        e.error("%s `%s` is forward referenced", agg.kind(), agg.toChars());
+                        return new ErrorExp();
+                    }
+                }
+
+                final switch (agg.classKind)
+                {
+                    case ClassKind.d:
+                        link = LINK.d;
+                        break;
+                    case ClassKind.cpp:
+                        link = LINK.cpp;
+                        break;
+                    case ClassKind.objc:
+                        link = LINK.objc;
+                        break;
+                }
             }
         }
         auto linkage = linkageToChars(link);

--- a/test/compilable/fwdref21063.d
+++ b/test/compilable/fwdref21063.d
@@ -1,0 +1,14 @@
+template Info(T, int line) {
+    static assert(__traits(getLinkage, T) == "C++");
+    alias Info = void;
+}
+
+// Forward reference
+static assert(__traits(getLinkage, Klass) == "C++");
+alias info1 = Info!(Klass, __LINE__);
+
+extern (C++) class Klass { void derp() {} }
+
+// Backward reference
+static assert(__traits(getLinkage, Klass) == "C++");
+alias info2 = Info!(Klass, __LINE__);


### PR DESCRIPTION
Use the same code as other traits, e.g. getClassInstanceSize, use.