### PR TITLE
[dmd-cxx] fix issue 9490 - 'this' is not found when expression is in parentheses

### DIFF
--- a/src/expressionsem.c
+++ b/src/expressionsem.c
@@ -812,6 +812,16 @@ public:
         exp->type->resolve(exp->loc, sc, &e, &t, &s, true);
         if (e)
         {
+            // `(Type)` is actually `(var)` so if `(var)` is a member requiring `this`
+            // then rewrite as `(this.var)` in case it would be followed by a DotVar
+            // to fix https://issues.dlang.org/show_bug.cgi?id=9490
+            VarExp *ve = e->isVarExp();
+            if (ve && ve->var && exp->parens && !ve->var->isStatic() && !(sc->stc & STCstatic) &&
+                sc->func && sc->func->needThis() && ve->var->toParent2()->isAggregateDeclaration())
+            {
+                // printf("apply fix for issue 9490: add `this.` to `%s`...\n", e->toChars());
+                e = new DotVarExp(exp->loc, new ThisExp(exp->loc), ve->var, false);
+            }
             //printf("e = %s %s\n", Token::toChars(e->op), e->toChars());
             e = semantic(e, sc);
         }

--- a/src/parse.c
+++ b/src/parse.c
@@ -7531,6 +7531,7 @@ Expression *Parser::parseUnaryExp()
                                 return NULL;
                             }
                             e = new TypeExp(loc, t);
+                            e->parens = 1;
                             e = parsePostExp(e);
                         }
                         else

--- a/test/compilable/b9490.d
+++ b/test/compilable/b9490.d
@@ -1,0 +1,39 @@
+// https://issues.dlang.org/show_bug.cgi?id=9490
+class A
+{
+    int[1] arr;
+
+    this()
+    {
+        assert(arr.length);
+        assert((arr).length);
+    }
+}
+
+class C
+{
+    struct Foo { int a; void funcToo(){} }
+    Foo foo;
+
+    auto get(){return foo;}
+
+    void test()
+    {
+        // Error: need 'this' to access member a
+        (foo).a = 1;
+        (foo).funcToo();
+        (get()).a = 2;
+    }
+}
+
+struct S { int i; }
+struct S1 { S s; }
+void f(int) { }
+
+void main()
+{
+    S1 s1;
+    f(s1.s.tupleof); // OK
+    f((s1.s).tupleof); // Error: need 'this' to access member s
+}
+


### PR DESCRIPTION
Backport of #10592