### PR TITLE
TEST ONLY: Change derived-incondition logic to require it to be a superset of parent incondition.

### DIFF
--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -34,7 +34,7 @@ class B : A
     {
         float f;
         printf("B.foo.in %d\n", i);
-        assert(i == 4);
+        assert(i == 2 || i == 4);
         assert(x == 7);
         f = f + i;
     }
@@ -88,7 +88,7 @@ class B2 : A2
     {
         float f;
         printf("B2.foo.in %d\n", i);
-        assert(i == 4);
+        assert(i == 2 || i == 4);
         assert(x == 7);
         f = f + i;
     }
@@ -110,7 +110,7 @@ class C : B2
     {
         float f;
         printf("C.foo.in %d\n", i);
-        assert(i == 6);
+        assert(i == 2 || i == 4 || i == 6);
         assert(x == 7);
         f = f + i;
     }
@@ -437,7 +437,7 @@ class C6549
 class CD6549 : C6549
 {
     override int foo(int)
-    in { assert(false); }
+    in { /*assert(false);*/ }
     do { return 10; }
 }
 
@@ -454,7 +454,7 @@ abstract class D6549
 class DD6549 : D6549
 {
     override int foo(int)
-    in { assert(false); }
+    in { /*assert(false);*/ }
     do { return 10; }
 }
 
@@ -462,12 +462,12 @@ void test6549()
 {
     auto c = new CD6549;
     c.foo(10);
-    assert(C6549.icount == 1);
+    // assert(C6549.icount == 1);
     assert(C6549.ocount == 1);
 
     auto d = new DD6549;
     d.foo(10);
-    assert(D6549.icount == 1);
+    // assert(D6549.icount == 1);
     assert(D6549.ocount == 1);
 }
 
@@ -509,7 +509,7 @@ class A7335
 class B7335 : A7335
 {
     override void setValue(int newValue)
-    in { assert(false); }
+    in { /*assert(false);*/ }
     out { assert(mValue == 3); }
     do
     {
@@ -585,7 +585,10 @@ void test7517()
         static C self;
 
         void setEnable()
-        in {}       // supply in-contract to invoke I.setEnable.in
+        in {
+            result ~= "C.setEnable.in/";
+            assert(!enabled);
+        }
         do
         {
             assert(self is this);
@@ -615,7 +618,7 @@ void test7517()
 
     result = null;
     i.setEnable();
-    assert(result == "I.setEnable.in/C.enabled/C.setEnable/I.setEnable.out/C.enabled/");
+    assert(result == "C.setEnable.in/C.enabled/C.setEnable/I.setEnable.out/C.enabled/", result);
 
     result = null;
     i.setDisable();
@@ -835,6 +838,7 @@ void test8093()
 /*******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=9383
 
+/+
 class A9383
 {
     static void delegate() dg;
@@ -1004,6 +1008,7 @@ void test15524()
     a.bar2("2"); assert(A15524.val == "2");     // closure [local]
     a.bar3("3"); assert(A15524.val == "3");     // closure [parameter]
 }
++/
 
 void test15524a()
 {
@@ -1179,7 +1184,7 @@ class C15984 : I15984
     do  { check15984("C.f3  ", this, i); }
 
     void f4(out int i, lazy int j)
-    in  { assert(0); }
+    in  { /*assert(0);*/ }
     do  { i = 10; }
 }
 
@@ -1296,8 +1301,8 @@ int main()
     test7517();
     test8073();
     test8093();
-    test9383();
-    test15524();
+    // test9383();
+    // test15524();
     test15524a();
     test14779();
     test15984();


### PR DESCRIPTION
See https://forum.dlang.org/thread/mjcppoaykiwqegkfrerb@forum.dlang.org

Instead of requiring *either* of the current or the super incondition to be true, with this change DMD requires that the child incondition actually widens the scope of the parent incondition, but fully includes it.

The behavior of the "accidentally turn off inconditions feature", aka "leaving out in() entirely", is unaffected.

That is:

```
parent()
in (i == 3);
...
override parent()
// was: in (i == 4);
in (i == 3 || i == 4);
```

The point of this PR is to discover which, if any, projects break with this change.