### PR TITLE
Fix Issue 12223 - __traits(getMember,...) needed for aliases

### DIFF
--- a/changelog/add_traits_child.dd
+++ b/changelog/add_traits_child.dd
@@ -1,0 +1,27 @@
+Add `__traits(child, parent, member)`
+
+Takes two arguments. The first must be a symbol or expression and the second
+must be a symbol, such as an alias to a member of `parent`. The result is
+`member` interpreted with its `this` context set to `parent`. This is the
+inverse of `__traits(parent, member)`.
+
+---
+struct A
+{
+    int i;
+    int foo(int j) {
+        return i * j;
+    }
+}
+
+alias Ai = A.i;
+
+void main()
+{
+    A a;
+
+    __traits(child, a, Ai) = 3;
+    assert(a.i == 3);
+    assert(__traits(child, a, A.foo)(2) == 6);
+}
+---

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -442,6 +442,7 @@ immutable Msgtable[] msgtable =
     { "identifier" },
     { "getProtection" },
     { "parent" },
+    { "child" },
     { "getMember" },
     { "getOverloads" },
     { "getVirtualFunctions" },

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -926,7 +926,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         else
         {
             e.error("symbol or expression expected as first argument of __traits `child` instead of `%s`", op.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         ex = ex.expressionSemantic(sc);
@@ -935,7 +935,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!symc)
         {
             e.error("symbol expected as second argument of __traits `child` instead of `%s`", oc.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         if (auto d = symc.isDeclaration())

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -921,15 +921,12 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto op = (*e.args)[0];
         if (auto symp = getDsymbol(op))
             ex = new DsymbolExp(e.loc, symp);
+        else if (auto exp = op.isExpression())
+            ex = exp;
         else
         {
-            ex = op.isExpression();
-            if (!ex)
-            {
-                e.error("symbol or expression expected as first argument of __traits `%s` instead of `%s`",
-                        e.ident.toChars(), op.toChars());
-                return new ErrorExp();
-            }
+            e.error("symbol or expression expected as first argument of __traits `%s` instead of `%s`", e.ident.toChars(), op.toChars());
+            return new ErrorExp();
         }
 
         ex = ex.expressionSemantic(sc);

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -945,10 +945,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         else if (auto ti = symc.isScopeDsymbol())
             ex = new DotExp(e.loc, ex, new ScopeExp(e.loc, ti));
         else
-        {
-            e.error("invalid second argument of __traits `child`");
-            return new ErrorExp();
-        }
+            assert(0);
 
         ex = ex.expressionSemantic(sc);
         return ex;

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -925,7 +925,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             ex = exp;
         else
         {
-            e.error("symbol or expression expected as first argument of __traits `%s` instead of `%s`", e.ident.toChars(), op.toChars());
+            e.error("symbol or expression expected as first argument of __traits `child` instead of `%s`", op.toChars());
             return new ErrorExp();
         }
 
@@ -934,8 +934,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto symc = getDsymbol(oc);
         if (!symc)
         {
-            e.error("symbol expected as second argument of __traits `%s` instead of `%s`",
-                    e.ident.toChars(), oc.toChars());
+            e.error("symbol expected as second argument of __traits `child` instead of `%s`", oc.toChars());
             return new ErrorExp();
         }
 
@@ -947,7 +946,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             ex = new DotExp(e.loc, ex, new ScopeExp(e.loc, ti));
         else
         {
-            e.error("invalid second argument of __traits `%s`", e.ident.toChars());
+            e.error("invalid second argument of __traits `child`");
             return new ErrorExp();
         }
 

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -123,6 +123,7 @@ shared static this()
         "identifier",
         "getProtection",
         "parent",
+        "child",
         "getLinkage",
         "getMember",
         "getOverloads",
@@ -910,6 +911,51 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             }
         }
         return symbolToExp(s, e.loc, sc, false);
+    }
+    if (e.ident == Id.child)
+    {
+        if (dim != 2)
+            return dimError(2);
+
+        Expression ex;
+        auto op = (*e.args)[0];
+        if (auto symp = getDsymbol(op))
+            ex = new DsymbolExp(e.loc, symp);
+        else
+        {
+            ex = op.isExpression();
+            if (!ex)
+            {
+                e.error("symbol or expression expected as first argument of __traits `%s` instead of `%s`",
+                        e.ident.toChars(), op.toChars());
+                return new ErrorExp();
+            }
+        }
+
+        ex = ex.expressionSemantic(sc);
+        auto oc = (*e.args)[1];
+        auto symc = getDsymbol(oc);
+        if (!symc)
+        {
+            e.error("symbol expected as second argument of __traits `%s` instead of `%s`",
+                    e.ident.toChars(), oc.toChars());
+            return new ErrorExp();
+        }
+
+        if (auto d = symc.isDeclaration())
+            ex = new DotVarExp(e.loc, ex, d);
+        else if (auto td = symc.isTemplateDeclaration())
+            ex = new DotExp(e.loc, ex, new TemplateExp(e.loc, td));
+        else if (auto ti = symc.isScopeDsymbol())
+            ex = new DotExp(e.loc, ex, new ScopeExp(e.loc, ti));
+        else
+        {
+            e.error("invalid second argument of __traits `%s`", e.ident.toChars());
+            return new ErrorExp();
+        }
+
+        ex = ex.expressionSemantic(sc);
+        return ex;
     }
     if (e.ident == Id.hasMember ||
         e.ident == Id.getMember ||

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1699,6 +1699,7 @@ extern(C++) Type typeSemantic(Type t, const ref Loc loc, Scope* sc)
             mtype.exp.ident != Id.derivedMembers &&
             mtype.exp.ident != Id.getMember &&
             mtype.exp.ident != Id.parent &&
+            mtype.exp.ident != Id.child &&
             mtype.exp.ident != Id.getOverloads &&
             mtype.exp.ident != Id.getVirtualFunctions &&
             mtype.exp.ident != Id.getVirtualMethods &&

--- a/test/fail_compilation/traits_child.d
+++ b/test/fail_compilation/traits_child.d
@@ -1,0 +1,15 @@
+/************************************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/traits_child.d(100): Error: expected 2 arguments for `child` but had 1
+fail_compilation/traits_child.d(101): Error: symbol or expression expected as first argument of __traits `child` instead of `long`
+fail_compilation/traits_child.d(102): Error: symbol expected as second argument of __traits `child` instead of `3`
+---
+*/
+
+#line 100
+enum a = __traits(child, long);
+enum b = __traits(child, long, 3);
+enum c = __traits(child, "hi", 3);

--- a/test/runnable/traits_child.d
+++ b/test/runnable/traits_child.d
@@ -63,8 +63,21 @@ alias ctset = C.t.set;
 alias cm = C.m;
 alias cmset = C.m.set;
 
+
+// adapted from http://thecybershadow.net/d/dconf2017/#/21
+struct S { string a, b, c; }
+
+static string printField(alias field)()
+{
+    S s = { a: "aa", b: "bb", c: "cc" };
+    return __traits(child, s, field);
+}
+
 void main()
 {
+    auto f = printField!(S.b)();
+    assert(f == "bb");
+
     A a;
     __traits(child, a, ai) = 3;
     assert(a.i == 3);

--- a/test/runnable/traits_child.d
+++ b/test/runnable/traits_child.d
@@ -1,0 +1,109 @@
+struct A
+{
+    ulong i;
+    void foo(ulong a)
+    {
+        i = a;
+    }
+
+    void foo(string s)
+    {
+        i = s.length;
+    }
+
+    void bar(T)(T a)
+    {
+        i = a;
+    }
+
+    void bar(T : string)(T s)
+    {
+        i = s.length;
+    }
+}
+
+alias ai = A.i;
+alias afoo = A.foo;
+alias abar = A.bar;
+alias abar_ulong = A.bar!ulong;
+alias abar_string = A.bar!string;
+
+struct B
+{
+    A a;
+}
+
+alias ba = B.a;
+
+template T(alias x)
+{
+    void set(int n)
+    {
+        x = n;
+    }
+}
+
+mixin template M(alias x)
+{
+    void set(int n)
+    {
+        x = n;
+    }
+}
+
+struct C
+{
+    int i;
+    alias t = T!i;
+    mixin M!i m;
+}
+
+alias ct = C.t;
+alias ctset = C.t.set;
+alias cm = C.m;
+alias cmset = C.m.set;
+
+void main()
+{
+    A a;
+    __traits(child, a, ai) = 3;
+    assert(a.i == 3);
+    assert(__traits(child, a, ai) == 3);
+    __traits(child, a, afoo)(2);
+    assert(a.i == 2);
+    __traits(child, a, afoo)("hello");
+    assert(a.i == 5);
+    __traits(child, a, abar)(6);
+    assert(a.i == 6);
+    __traits(child, a, abar_ulong)(7);
+    assert(a.i == 7);
+    __traits(child, a, abar_string)("hi");
+    assert(a.i == 2);
+
+    __traits(child, a, A.i) = 7;
+    assert(a.i == 7);
+    __traits(child, a, A.bar)(3);
+    assert(a.i == 3);
+    __traits(child, a, A.bar!ulong)(4);
+    assert(a.i == 4);
+    __traits(child, a, __traits(getMember, A, "i")) = 5;
+    assert(a.i == 5);
+    __traits(child, a, __traits(getOverloads, A, "bar", true)[1])("hi!");
+    assert(a.i == 3);
+
+    B b;
+    __traits(child, b.a, ai) = 2;
+    assert(b.a.i == 2);
+    __traits(child, __traits(child, b, ba), ai) = 3;
+    assert(b.a.i == 3);
+
+    C c;
+    __traits(child, c, ct).set(3);
+    assert(c.i == 3);
+    __traits(child, c, ctset)(4);
+    assert(c.i == 4);
+    __traits(child, c, cm).set(5);
+    assert(c.i == 5);
+    __traits(child, c, cmset)(6);
+    assert(c.i == 6);
+}


### PR DESCRIPTION
Add `__traits(child, p, c)` to interpret `c` with the `this` context set to `p`.
This is the opposite of `__traits(parent, c)`. `c` should be a symbol missing it's
`this` context, such an an alias to a member of `p`.

This is a reboot of #3329. @CyberShadow closed that because he saw limited uses without the ability to bind contexts to templates. However, there are still lots of uses. An interesting use case is situations where it is impossible to get a symbol with the `this` context using introspection, such as a template instance obtained from a declaration from `__traits(getOverloads)`.