### PR TITLE
End the deprecation period for implicit base class override

### DIFF
--- a/changelog/implicit-override-deprecation-end-17349.dd
+++ b/changelog/implicit-override-deprecation-end-17349.dd
@@ -1,0 +1,22 @@
+The deprecation period for implicit override has ended
+
+Implicit overrides of base classes methods were deprecated in 2.075.0
+(released 2017-07-19) when [issue 17349](https://issues.dlang.org/show_bug.cgi?id=17349)
+was fixed by [PR 6731](https://github.com/dlang/dmd/pull/6731).
+
+The deprecation period has now ended and the following code will always error from now:
+---
+class Base
+{
+    void myFunction();
+    void myOtherFunction(void* ptr);
+}
+
+class Child : Base
+{
+    // Error: Implicitly overriding `Base.myFunction`
+    void myFunction() const;
+    // Error: Implicitly overriding `Base.myOtherFunction(void*)`
+    void myOtherFunction(const void* ptr);
+}
+---

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -592,7 +592,7 @@ public:
     bool equals(const RootObject *o) const;
 
     int overrides(FuncDeclaration *fd);
-    int findVtblIndex(Dsymbols *vtbl, int dim, bool fix17349 = true);
+    int findVtblIndex(Dsymbols *vtbl, int dim);
     BaseClass *overrideInterface();
     bool overloadInsert(Dsymbol *s);
     bool inUnittest();

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3760,12 +3760,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         }
                         else
                         {
-                            int vi2 = funcdecl.findVtblIndex(&cd.baseClass.vtbl, cast(int)cd.baseClass.vtbl.dim, false);
-                            if (vi2 < 0)
-                                // https://issues.dlang.org/show_bug.cgi?id=17349
-                                deprecation(funcdecl.loc, "cannot implicitly override base class method `%s` with `%s`; add `override` attribute", fdv.toPrettyChars(), funcdecl.toPrettyChars());
-                            else
-                                error(funcdecl.loc, "cannot implicitly override base class method `%s` with `%s`; add `override` attribute", fdv.toPrettyChars(), funcdecl.toPrettyChars());
+                            // https://issues.dlang.org/show_bug.cgi?id=17349
+                            error(funcdecl.loc, "cannot implicitly override base class method `%s` with `%s`; add `override` attribute",
+                                  fdv.toPrettyChars(), funcdecl.toPrettyChars());
                         }
                     }
                     doesoverride = true;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -628,12 +628,11 @@ extern (C++) class FuncDeclaration : Declaration
      * Params:
      *      vtbl     = vtable to use
      *      dim      = maximal vtable dimension
-     *      fix17349 = enable fix https://issues.dlang.org/show_bug.cgi?id=17349
      * Returns:
      *      -1      didn't find one
      *      -2      can't determine because of forward references
      */
-    final int findVtblIndex(Dsymbols* vtbl, int dim, bool fix17349 = true)
+    final int findVtblIndex(Dsymbols* vtbl, int dim)
     {
         //printf("findVtblIndex() %s\n", toChars());
         FuncDeclaration mismatch = null;
@@ -669,7 +668,7 @@ extern (C++) class FuncDeclaration : Declaration
                 }
 
                 StorageClass stc = 0;
-                int cov = type.covariant(fdv.type, &stc, fix17349);
+                int cov = type.covariant(fdv.type, &stc);
                 //printf("\tbaseclass cov = %d\n", cov);
                 switch (cov)
                 {

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -567,7 +567,6 @@ extern (C++) abstract class Type : ASTNode
      * Params:
      *      t = type 'this' is covariant with
      *      pstc = if not null, store STCxxxx which would make it covariant
-     *      fix17349 = enable fix https://issues.dlang.org/show_bug.cgi?id=17349
      * Returns:
      *      0       types are distinct
      *      1       this is covariant with t
@@ -576,7 +575,7 @@ extern (C++) abstract class Type : ASTNode
      *      3       cannot determine covariance because of forward references
      *      *pstc   STCxxxx which would make it covariant
      */
-    final int covariant(Type t, StorageClass* pstc = null, bool fix17349 = true)
+    final int covariant(Type t, StorageClass* pstc = null)
     {
         version (none)
         {
@@ -614,8 +613,6 @@ extern (C++) abstract class Type : ASTNode
 
                 if (!fparam1.type.equals(fparam2.type))
                 {
-                    if (!fix17349)
-                        goto Ldistinct;
                     Type tp1 = fparam1.type;
                     Type tp2 = fparam2.type;
                     if (tp1.ty == tp2.ty)

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -214,7 +214,7 @@ public:
     bool equivalent(Type *t);
     // kludge for template.isType()
     DYNCAST dyncast() const { return DYNCAST_TYPE; }
-    int covariant(Type *t, StorageClass *pstc = NULL, bool fix17349 = true);
+    int covariant(Type *t, StorageClass *pstc = NULL);
     const char *toChars() const;
     char *toPrettyChars(bool QualifyTypes = false);
     static void _init();

--- a/test/fail_compilation/fail17354.d
+++ b/test/fail_compilation/fail17354.d
@@ -1,8 +1,7 @@
-/* REQUIRED_ARGS: -de
- * TEST_OUTPUT:
+/* TEST_OUTPUT:
 ---
-fail_compilation/fail17354.d(13): Deprecation: cannot implicitly override base class method `object.Object.opEquals` with `fail17354.Foo.opEquals`; add `override` attribute
-fail_compilation/fail17354.d(18): Deprecation: cannot implicitly override base class method `object.Object.opEquals` with `fail17354.Bar.opEquals`; add `override` attribute
+fail_compilation/fail17354.d(12): Error: cannot implicitly override base class method `object.Object.opEquals` with `fail17354.Foo.opEquals`; add `override` attribute
+fail_compilation/fail17354.d(17): Error: cannot implicitly override base class method `object.Object.opEquals` with `fail17354.Bar.opEquals`; add `override` attribute
 ---
  */
 

--- a/test/fail_compilation/fix17349.d
+++ b/test/fail_compilation/fix17349.d
@@ -1,8 +1,6 @@
-/* REQUIRED_ARGS: -dw
- * PERMUTE_ARGS:
- * TEST_OUTPUT:
+/* TEST_OUTPUT:
 ---
-compilable/fix17349.d(37): Deprecation: cannot implicitly override base class method `fix17349.E.foo` with `fix17349.F.foo`; add `override` attribute
+fail_compilation/fix17349.d(35): Error: cannot implicitly override base class method `fix17349.E.foo` with `fix17349.F.foo`; add `override` attribute
 ---
  */
 
@@ -36,5 +34,3 @@ class E {
 class F : E {
     void foo(const void*);
 }
-
-


### PR DESCRIPTION
As mentioned in the release notes, this was deprecated 3 years ago,
as part of v2.075.0.