### PR TITLE
Improve error message for implicit string concatenation

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -7852,8 +7852,10 @@ final class Parser(AST) : Lexer
                             postfix = token.postfix;
                         }
 
-                        error("Implicit string concatenation is deprecated, use %s ~ %s instead",
-                                    prev.toChars(), token.toChars());
+                        error("Implicit string concatenation is error-prone and disallowed in D");
+                        errorSupplemental(token.loc, "Use the explicit syntax instead " ~
+                             "(concatenating literals is `@nogc`): %s ~ %s",
+                             prev.toChars(), token.toChars());
 
                         const len1 = len;
                         const len2 = token.len;

--- a/test/fail_compilation/diag10805.d
+++ b/test/fail_compilation/diag10805.d
@@ -1,10 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10805.d(11): Error: delimited string must end in FOO"
-fail_compilation/diag10805.d(13): Error: unterminated string constant starting at fail_compilation/diag10805.d(13)
-fail_compilation/diag10805.d(13): Error: Implicit string concatenation is deprecated, use "" ~ "" instead
-fail_compilation/diag10805.d(14): Error: semicolon expected following auto declaration, not `End of File`
+fail_compilation/diag10805.d(12): Error: delimited string must end in FOO"
+fail_compilation/diag10805.d(14): Error: unterminated string constant starting at fail_compilation/diag10805.d(14)
+fail_compilation/diag10805.d(14): Error: Implicit string concatenation is error-prone and disallowed in D
+fail_compilation/diag10805.d(14):        Use the explicit syntax instead (concatenating literals is `@nogc`): "" ~ ""
+fail_compilation/diag10805.d(15): Error: semicolon expected following auto declaration, not `End of File`
 ---
 */
 

--- a/test/fail_compilation/fail196.d
+++ b/test/fail_compilation/fail196.d
@@ -1,22 +1,23 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail196.d(25): Error: delimited string must end in )"
-fail_compilation/fail196.d(25): Error: Implicit string concatenation is deprecated, use "foo(xxx)" ~ ";\x0a    assert(s == " instead
-fail_compilation/fail196.d(26): Error: semicolon expected, not `foo`
-fail_compilation/fail196.d(26): Error: found `");\x0a\x0a    s = q"` when expecting `;` following statement
-fail_compilation/fail196.d(28): Error: found `";\x0a    assert(s == "` when expecting `;` following statement
-fail_compilation/fail196.d(29): Error: found `");\x0a\x0a    s = q"` when expecting `;` following statement
-fail_compilation/fail196.d(31): Error: found `{` when expecting `;` following statement
-fail_compilation/fail196.d(31): Error: found `}` when expecting `;` following statement
-fail_compilation/fail196.d(32): Error: found `foo` when expecting `;` following statement
+fail_compilation/fail196.d(26): Error: delimited string must end in )"
+fail_compilation/fail196.d(26): Error: Implicit string concatenation is error-prone and disallowed in D
+fail_compilation/fail196.d(26):        Use the explicit syntax instead (concatenating literals is `@nogc`): "foo(xxx)" ~ ";\x0a    assert(s == "
+fail_compilation/fail196.d(27): Error: semicolon expected, not `foo`
+fail_compilation/fail196.d(27): Error: found `");\x0a\x0a    s = q"` when expecting `;` following statement
+fail_compilation/fail196.d(29): Error: found `";\x0a    assert(s == "` when expecting `;` following statement
+fail_compilation/fail196.d(30): Error: found `");\x0a\x0a    s = q"` when expecting `;` following statement
+fail_compilation/fail196.d(32): Error: found `{` when expecting `;` following statement
 fail_compilation/fail196.d(32): Error: found `}` when expecting `;` following statement
-fail_compilation/fail196.d(34): Error: found `<` when expecting `;` following statement
-fail_compilation/fail196.d(35): Error: found `foo` when expecting `;` following statement
-fail_compilation/fail196.d(35): Error: found `<` instead of statement
-fail_compilation/fail196.d(41): Error: unterminated string constant starting at fail_compilation/fail196.d(41)
-fail_compilation/fail196.d(43): Error: found `End of File` when expecting `}` following compound statement
-fail_compilation/fail196.d(43): Error: found `End of File` when expecting `}` following compound statement
+fail_compilation/fail196.d(33): Error: found `foo` when expecting `;` following statement
+fail_compilation/fail196.d(33): Error: found `}` when expecting `;` following statement
+fail_compilation/fail196.d(35): Error: found `<` when expecting `;` following statement
+fail_compilation/fail196.d(36): Error: found `foo` when expecting `;` following statement
+fail_compilation/fail196.d(36): Error: found `<` instead of statement
+fail_compilation/fail196.d(42): Error: unterminated string constant starting at fail_compilation/fail196.d(42)
+fail_compilation/fail196.d(44): Error: found `End of File` when expecting `}` following compound statement
+fail_compilation/fail196.d(44): Error: found `End of File` when expecting `}` following compound statement
 ---
 */
 

--- a/test/fail_compilation/issue3827.d
+++ b/test/fail_compilation/issue3827.d
@@ -2,8 +2,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/issue3827.d(12): Error: Implicit string concatenation is deprecated, use "Hello" ~ "World" instead
-fail_compilation/issue3827.d(13): Error: Implicit string concatenation is deprecated, use "A" ~ "B" instead
+fail_compilation/issue3827.d(14): Error: Implicit string concatenation is error-prone and disallowed in D
+fail_compilation/issue3827.d(14):        Use the explicit syntax instead (concatenating literals is `@nogc`): "Hello" ~ "World"
+fail_compilation/issue3827.d(15): Error: Implicit string concatenation is error-prone and disallowed in D
+fail_compilation/issue3827.d(15):        Use the explicit syntax instead (concatenating literals is `@nogc`): "A" ~ "B"
 ---
 */
 


### PR DESCRIPTION
Listing it as deprecated can be misleading to the user.
Add a friendlier error message, as well as the mention that it is @nogc,
which might not be obvious for new users.