### PR TITLE
std.math.fabs(float) and fabs(double) are now intrinsics

### DIFF
--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -523,6 +523,11 @@ int intrinsic_op(FuncDeclaration fd)
     Lstdmath:
         if (argtype1 is Type.tfloat80 || id3 == Id._sqrt)
             goto Lmath;
+        if (id3 == Id.fabs &&
+            (argtype1 is Type.tfloat32 || argtype1 is Type.tfloat64))
+        {
+            op = OPabs;
+        }
     }
     else if (id1 == Id.core)
     {


### PR DESCRIPTION
Enabled by https://github.com/dlang/dmd/pull/11449

Blocking https://github.com/dlang/phobos/pull/7565