### PR TITLE
test: Make sdtor/S17457 a non-POD type, @disable copying.

### DIFF
--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -2831,6 +2831,7 @@ struct S17457 {
     this(int seconds) {
         dg17457 = &mfunc;
     }
+    @disable this(this);
     void mfunc() {}
 }
 


### PR DESCRIPTION
While at run-time, it is pretty much guaranteed to be true due to call slot optimizations (or in dmd lingo, hidden parameter) using the first argument position to hold a pointer to the return address.  At compile-time, it is UB to assert that the address of a local variable and non-local parameter are the same for so long as we are not explicitly generating code to make it provable otherwise.  NRVO itself remains only an optimization, and there is no guarantee if it is not part of the spec.

Disabling copying on the struct enforces that there's no copying done, and so the assert for the address comparison should pass as this is precisely defined in the spec.