### PR TITLE
add support for Object.RTTypeid template

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2578,6 +2578,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (tempdecl.ident == Id.RTInfo)
                 Type.rtinfo = tempdecl;
+
+            if (tempdecl.ident == Id.RTTypeid)
+                Type.rttypeid = tempdecl;
         }
 
         /* Remember Scope for later instantiations, but make

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -107,6 +107,7 @@ immutable Msgtable[] msgtable =
     { "outer" },
     { "Exception" },
     { "RTInfo" },
+    { "RTTypeid" },
     { "Throwable" },
     { "Error" },
     { "withSym", "__withSym" },

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -423,6 +423,7 @@ extern (C++) abstract class Type : ASTNode
     extern (C++) __gshared ClassDeclaration typeinfowild;
 
     extern (C++) __gshared TemplateDeclaration rtinfo;
+    extern (C++) __gshared TemplateDeclaration rttypeid;
 
     extern (C++) __gshared Type[TMAX] basic;
 


### PR DESCRIPTION
Currently, instances of TypeInfo are generated by a complex and tedious process inside the compiler. This change experiments with using a template in druntime, Object.RTTypeid instead, to generate it. The compiler will know nothing about the contents of TypeInfo, leaving people free to innovate with the definition of RTTypeid. (All that code in the compiler will be removed once RTTypeid is successful.)

This is analogous to the successful use of Object.RTinfo to generate info for the garbage collector. The implementation of RTTypeid is very similar for that for RTinfo, which can be found in Semantic3Visitor in semantic3.d

This PR makes it so that if Object.RTTypeid is not there, it falls back to the original compiler implementation of TypeInfo.