### PR TITLE
Fix Issue 21074 - const lost in mixin (extra case)

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3051,6 +3051,8 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, Expression* pe, Type* pt, Ds
         if (auto t = o.isType())
         {
             resolve(t, loc, sc, pe, pt, ps, intypeid);
+            if (*pt)
+                (*pt) = (*pt).addMod(mt.mod);
         }
         else if (auto e = o.isExpression())
         {

--- a/test/compilable/mixintype2.d
+++ b/test/compilable/mixintype2.d
@@ -48,6 +48,7 @@ alias T4 = mixin(q{const(mixin("__traits(getMember, S, \"T\")"))})*;
 alias T5 = const(mixin(q{Byte}))*;
 alias T6 = const(mixin(q{immutable(Byte)}))*;
 alias T7 = const(mixin(q{shared(Byte)}))*;
+alias T8 = const(mixin(q{Byte*}));
 
 // the following tests now work
 static assert(is(T0 == const(ubyte)*));
@@ -58,6 +59,7 @@ static assert(is(T4 == const(float*)*));
 static assert(is(T5 == const(ubyte)*));
 static assert(is(T6 == immutable(ubyte)*));
 static assert(is(T7 == const(shared(ubyte))*));
+static assert(is(T8 == const(ubyte*)));
 
 // this doesn't work but I'll file a new issue
 /*


### PR DESCRIPTION
I didn't notice this case yesterday (#11458).