### PR TITLE
Turn output of -vtemplates into compiler-messages and show template instances

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -682,8 +682,13 @@ dmd -cov -unittest myprog.d
         Option("vtls",
             "list all variables going into thread local storage"
         ),
-        Option("vtemplates",
-            "list statistics on template instantiations"
+        Option("vtemplates=[list-instances]",
+            "list statistics on template instantiations",
+            `An optional argument determines extra diagnostics,
+            where:
+            $(DL
+            $(DT list-instances)$(DD Also shows all instantiation contexts for each template.)
+            )`,
         ),
         Option("w",
             "warnings as errors (compilation will halt)",

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -471,5 +471,3 @@ bool isSpecialEnumIdent(const Identifier ident) @nogc nothrow
             ident == Id.__c_long_double ||
             ident == Id.__c_wchar_t;
 }
-
-

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -5954,7 +5954,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     TemplateDeclaration tempdecl = tempinst.tempdecl.isTemplateDeclaration();
     assert(tempdecl);
 
-    TemplateStats.incInstance(tempdecl);
+    TemplateStats.incInstance(tempdecl, tempinst);
 
     tempdecl.checkDeprecated(tempinst.loc, sc);
 
@@ -6094,7 +6094,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     tempinst.parent = tempinst.enclosing ? tempinst.enclosing : tempdecl.parent;
     //printf("parent = '%s'\n", parent.kind());
 
-    TemplateStats.incUnique(tempdecl.isTemplateDeclaration());
+    TemplateStats.incUnique(tempdecl, tempinst);
 
     TemplateInstance tempdecl_instance_idx = tempdecl.addInstance(tempinst);
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -126,6 +126,7 @@ extern (C++) struct Param
     bool showColumns;       // print character (column) numbers in diagnostics
     bool vtls;              // identify thread local variables
     bool vtemplates;        // collect and list statistics on template instantiations
+    bool vtemplatesListInstances; // collect and list statistics on template instantiations origins. TODO: make this an enum when we want to list other kinds of instances
     bool vgc;               // identify gc usage
     bool vfield;            // identify non-mutable field variables
     bool vcomplex;          // identify complex/imaginary type usage

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -105,6 +105,7 @@ struct Param
     bool showColumns;   // print character (column) numbers in diagnostics
     bool vtls;          // identify thread local variables
     bool vtemplates;    // collect and list statistics on template instantiations
+    bool vtemplatesListInstances; // collect and list statistics on template instantiations origins
     bool vgc;           // identify gc usage
     bool vfield;        // identify non-mutable field variables
     bool vcomplex;      // identify complex/imaginary type usage

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1831,8 +1831,22 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             params.vcg_ast = true;
         else if (arg == "-vtls") // https://dlang.org/dmd.html#switch-vtls
             params.vtls = true;
-        else if (arg == "-vtemplates") // https://dlang.org/dmd.html#switch-vtemplates
+        else if (startsWith(p + 1, "vtemplates")) // https://dlang.org/dmd.html#switch-vtemplates
+        {
             params.vtemplates = true;
+            if (p[1 + "vtemplates".length] == '=')
+            {
+                const(char)[] style = arg[1 + "vtemplates=".length .. $];
+                switch (style)
+                {
+                case "list-instances":
+                    params.vtemplatesListInstances = true;
+                    break;
+                default:
+                    error("unknown vtemplates style '%.*s', must be 'list-instances'", cast(int) style.length, style.ptr);
+                }
+            }
+        }
         else if (arg == "-vcolumns") // https://dlang.org/dmd.html#switch-vcolumns
             params.showColumns = true;
         else if (arg == "-vgc") // https://dlang.org/dmd.html#switch-vgc

--- a/test/compilable/vtemplates.d
+++ b/test/compilable/vtemplates.d
@@ -1,12 +1,15 @@
 /* REQUIRED_ARGS: -vtemplates
 TEST_OUTPUT:
 ---
-  Number   Unique   Name
-       4        3   foo(int I)()
+compilable/vtemplates.d(10): vtemplate: 4 (3 unique) instantiation(s) of template `foo(int I)()` found
+compilable/vtemplates.d(11): vtemplate: 5 (2 unique) instantiation(s) of template `goo1(int I)()` found
+compilable/vtemplates.d(12): vtemplate: 3 (2 unique) instantiation(s) of template `goo2(int I)()` found
 ---
 */
 
 void foo(int I)() { }
+void goo1(int I)() { }
+void goo2(int I)() { goo1!(I); }
 
 void test()
 {
@@ -14,4 +17,12 @@ void test()
     foo!(1)();
     foo!(2)();
     foo!(3)();
+
+    goo1!(1)();
+    goo1!(1)();
+    goo1!(2)();
+
+    goo2!(1)();
+    goo2!(2)();
+    goo2!(2)();
 }

--- a/test/compilable/vtemplates_list.d
+++ b/test/compilable/vtemplates_list.d
@@ -1,0 +1,35 @@
+/* REQUIRED_ARGS: -vtemplates=list-instances
+TEST_OUTPUT:
+---
+compilable/vtemplates_list.d(19): vtemplate: 4 (3 unique) instantiation(s) of template `foo(int I)()` found, they are:
+compilable/vtemplates_list.d(25): vtemplate: explicit instance `foo!1`
+compilable/vtemplates_list.d(26): vtemplate: explicit instance `foo!1`
+compilable/vtemplates_list.d(27): vtemplate: explicit instance `foo!2`
+compilable/vtemplates_list.d(28): vtemplate: explicit instance `foo!3`
+compilable/vtemplates_list.d(20): vtemplate: 3 (1 unique) instantiation(s) of template `goo1(int I)()` found, they are:
+compilable/vtemplates_list.d(30): vtemplate: explicit instance `goo1!1`
+compilable/vtemplates_list.d(31): vtemplate: explicit instance `goo1!1`
+compilable/vtemplates_list.d(21): vtemplate: implicit instance `goo1!1`
+compilable/vtemplates_list.d(21): vtemplate: 2 (1 unique) instantiation(s) of template `goo2(int I)()` found, they are:
+compilable/vtemplates_list.d(33): vtemplate: explicit instance `goo2!1`
+compilable/vtemplates_list.d(34): vtemplate: explicit instance `goo2!1`
+---
+*/
+
+void foo(int I)() { }
+void goo1(int I)() { }
+void goo2(int I)() { goo1!(I); }
+
+void test()
+{
+    foo!(1)();
+    foo!(1)();
+    foo!(2)();
+    foo!(3)();
+
+    goo1!(1)();
+    goo1!(1)();
+
+    goo2!(1)();
+    goo2!(1)();
+}


### PR DESCRIPTION
Currently sorts on descending number of unique instances.

Updates default behaviour fo `-vtemplates`.

Sample output:

```
phobos/std/meta.d(1811): vtemplate: found 193 total (187 unique) instantiation(s) of template `isSame(ab...) if (ab.length == 2)`, instances are:
phobos/std/meta.d(287): vtemplate: instance `isSame!(BigInt, byte)`
phobos/std/meta.d(287): vtemplate: instance `isSame!(BigInt, ubyte)`
...
druntime/import/object.d(2952): vtemplate: found 147 total (147 unique) instantiation(s) of template `RTInfo(T)`, instances are:
phobos/std/traits.d(189): vtemplate: instance `RTInfo!(Demangle!uint)`
phobos/std/conv.d(4501): vtemplate: instance `RTInfo!(S)`
...
```