### PR TITLE
Preview: in-contract expressions are required to be a superset of the parent incondition, instead of being implicitly either-or.

### DIFF
--- a/changelog/inclusive-incontracts.dd
+++ b/changelog/inclusive-incontracts.dd
@@ -1,0 +1,25 @@
+Add `-preview=inclusiveincontracts`: `in` contracts must be an explicit superset of the parent `in` contracts.
+
+As per Liskov, `in` contracts can only loosen the conditions placed on the method they appear on.
+Currently this is enforced by automatically "oring" together the `in` contract with the `in` contract
+on the parent method, creating a combined contract that is necessarily looser than the parent.
+
+However, this leads to odd behavior like this code passing:
+
+```
+class A
+{
+    void foo(int i) in (i > 0) { }
+}
+class B : A
+{
+    void foo(int i) in (i < 0) { }
+}
+unittest { (new B).foo(5); }
+```
+
+That is because the `in` contract of `B.foo` is $(I implicitly) `super.in() || i < 0`, ie. `i > 0 || i < 0`
+
+With `-preview=inclusiveincontracts`, this code will now fail with an `AssertError`.
+To reach the previous behavior, you would have to write out `in (i > 0 || i < 0)`;
+that is, you explicitly include the parent's `in` contract in the child's.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -771,6 +771,8 @@ dmd -cov -unittest myprog.d
             "disable access to shared memory objects"),
         Feature("in", "previewIn",
             "`in` on parameters means `scope const [ref]` and accepts rvalues"),
+        Feature("inclusiveincontracts", "inclusiveInContracts",
+            "'in' contracts of overridden methods must be a superset of parent contract"),
         // DEPRECATED previews
         // trigger deprecation message once D repositories don't use this flag anymore
         Feature("markdown", "markdown", "enable Markdown replacements in Ddoc", false, false),
@@ -844,7 +846,8 @@ struct CLIUsage
                 continue;
             buf ~= "  =";
             buf ~= t.name;
-            auto lineLength = 3 + t.name.length;
+            buf ~= " "; // at least one separating space
+            auto lineLength = "  =".length + t.name.length + " ".length;
             foreach (i; lineLength .. maxFlagLength)
                 buf ~= " ";
             buf ~= t.helpText;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6787,6 +6787,7 @@ struct Param
     bool allInst;
     bool fix16997;
     bool fixAliasThis;
+    bool inclusiveInContracts;
     bool vsafe;
     bool ehnogc;
     bool dtorFields;
@@ -6931,6 +6932,7 @@ struct Param
         allInst(),
         fix16997(),
         fixAliasThis(),
+        inclusiveInContracts(),
         vsafe(),
         ehnogc(),
         dtorFields(),

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -182,6 +182,7 @@ extern (C++) struct Param
     bool fix16997;          // fix integral promotions for unary + - ~ operators
                             // https://issues.dlang.org/show_bug.cgi?id=16997
     bool fixAliasThis;      // if the current scope has an alias this, check it before searching upper scopes
+    bool inclusiveInContracts;   // 'in' contracts of overridden methods must be a superset of parent contract
     /** The --transition=safe switch should only be used to show code with
      * silent semantics changes related to @safe improvements.  It should not be
      * used to hide a feature that will have to go through deprecate-then-error

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -161,6 +161,7 @@ struct Param
     bool fix16997;      // fix integral promotions for unary + - ~ operators
                         // https://issues.dlang.org/show_bug.cgi?id=16997
     bool fixAliasThis;  // if the current scope has an alias this, check it before searching upper scopes
+    bool inclusiveInContracts;   // 'in' contracts of overridden methods must be a superset of parent contract
     bool vsafe;         // use enhanced @safe checking
     bool ehnogc;        // use @nogc exception handling
     bool dtorFields;        // destruct fields of partially constructed objects

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -935,7 +935,15 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 sc2 = sc2.pop();
             }
 
-            funcdecl.frequire = funcdecl.mergeFrequire(funcdecl.frequire, funcdecl.fdrequireParams);
+            if (global.params.inclusiveInContracts)
+            {
+                funcdecl.frequire = funcdecl.mergeFrequireInclusivePreview(
+                    funcdecl.frequire, funcdecl.fdrequireParams);
+            }
+            else
+            {
+                funcdecl.frequire = funcdecl.mergeFrequire(funcdecl.frequire, funcdecl.fdrequireParams);
+            }
             funcdecl.fensure = funcdecl.mergeFensure(funcdecl.fensure, Id.result, funcdecl.fdensureParams);
 
             Statement freq = funcdecl.frequire;

--- a/test/compilable/previewhelp.d
+++ b/test/compilable/previewhelp.d
@@ -16,5 +16,6 @@ Upcoming language changes listed by -preview=name:
   =rvaluerefparam   enable rvalue arguments to ref parameters
   =nosharedaccess   disable access to shared memory objects
   =in               `in` on parameters means `scope const [ref]` and accepts rvalues
+  =inclusiveincontracts 'in' contracts of overridden methods must be a superset of parent contract
 ----
 */

--- a/test/runnable/inclusive_incontracts.d
+++ b/test/runnable/inclusive_incontracts.d
@@ -1,0 +1,80 @@
+// REQUIRED_ARGS: -preview=inclusiveincontracts
+// PERMUTE_ARGS: -O -inline
+
+import core.exception : AssertError;
+
+void main()
+{
+    basic_test;
+    multiple_incontracts_test;
+}
+
+void basic_test()
+{
+    class A
+    {
+        void foo() @nogc
+        in (true, "foo")
+        {
+        }
+    }
+
+    class B : A
+    {
+        override void foo() @nogc
+        in (false, "nope not foo")
+        {
+        }
+    }
+
+    auto b = new B;
+
+    try
+    {
+        b.foo;
+        throw new Exception("Assert expected.");
+    }
+    catch (AssertError assertError)
+    {
+        assert(assertError.line == 25); // line of invalid in-contract
+        assert(assertError.msg == "Logic error: in-contract was tighter than parent in-contract");
+    }
+}
+
+void multiple_incontracts_test()
+{
+    class A
+    {
+        void foo(int a, int b)
+        in (a > 0, "A::a")
+        in (b > 0, "B::b")
+        {
+        }
+    }
+
+    class B : A
+    {
+        override void foo(int a, int b)
+        in (a >= 0, "B::a")
+        in (b > 0, "B::b")
+        {
+        }
+    }
+
+    auto b = new B;
+
+    b.foo(0, 2);
+    try
+    {
+        b.foo(0, 0);
+        throw new Exception("Assert expected.");
+    }
+    catch (AssertError assertError) {
+        /**
+         * Having found that the looser contract in B is not fulfilled, we try
+         * the stricter contract in A. As that one is also violated, we error.
+         */
+        assert(assertError.line == 49);
+        assert(assertError.msg == "A::a");
+    }
+}


### PR DESCRIPTION
As per https://github.com/dlang/dmd/pull/11440 . Hidden behind `-preview=inclusivein`. I have a DIP ready to go as well at https://github.com/FeepingCreature/DIPs/blob/DIP-inclusive-in-contracts/DIPs/1NNN-MB.md . Should I do a forum post next or do this review first?

- [x] Add a changelog entry