### PR TITLE
Use statically allocated ErrorExp instance

### DIFF
--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -121,7 +121,7 @@ Expression arrayOp(BinExp e, Scope* sc)
     if (tbn.ty == Tvoid)
     {
         e.error("cannot perform array operations on `void[]` arrays");
-        return new ErrorExp();
+        return ErrorExp.get();
     }
     if (!isArrayOpValid(e))
         return arrayOpInvalidError(e);
@@ -149,7 +149,7 @@ Expression arrayOp(BinExp e, Scope* sc)
 
     auto fd = resolveFuncCall(e.loc, sc, arrayOp, tiargs, null, args, FuncResolveFlag.standard);
     if (!fd || fd.errors)
-        return new ErrorExp();
+        return ErrorExp.get();
     return new CallExp(e.loc, new VarExp(e.loc, fd, false), args).expressionSemantic(sc);
 }
 
@@ -167,7 +167,7 @@ Expression arrayOp(BinAssignExp e, Scope* sc)
         e.error("slice `%s` is not mutable", e.e1.toChars());
         if (e.op == TOK.addAssign)
             checkPossibleAddCatError!(AddAssignExp, CatAssignExp)(e.isAddAssignExp);
-        return new ErrorExp();
+        return ErrorExp.get();
     }
     if (e.e1.op == TOK.arrayLiteral)
     {
@@ -374,7 +374,7 @@ ErrorExp arrayOpInvalidError(Expression e)
         checkPossibleAddCatError!(AddExp, CatExp)(e.isAddExp());
     else if (e.op == TOK.addAssign)
         checkPossibleAddCatError!(AddAssignExp, CatAssignExp)(e.isAddAssignExp());
-    return new ErrorExp();
+    return ErrorExp.get();
 }
 
 private void checkPossibleAddCatError(AddT, CatT)(AddT ae)

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -883,7 +883,7 @@ extern (C++) final class PragmaDeclaration : AttribDeclaration
             {
                 error("one boolean expression expected for `pragma(inline)`, not %llu", cast(ulong) args.dim);
                 args.setDim(1);
-                (*args)[0] = new ErrorExp();
+                (*args)[0] = ErrorExp.get();
             }
             else
             {
@@ -893,7 +893,7 @@ extern (C++) final class PragmaDeclaration : AttribDeclaration
                     if (e.op != TOK.error)
                     {
                         error("pragma(`inline`, `true` or `false`) expected, not `%s`", e.toChars());
-                        (*args)[0] = new ErrorExp();
+                        (*args)[0] = ErrorExp.get();
                     }
                 }
                 else if (e.isBool(true))

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -176,7 +176,7 @@ extern (C++) final class StaticForeach : RootObject
         }
         else
         {
-            aggrfe.aggr = new ErrorExp();
+            aggrfe.aggr = ErrorExp.get();
         }
     }
 

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -144,7 +144,7 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
                         e.toChars(), ts[0], ts[1]);
                 }
             }
-            result = new ErrorExp();
+            result = ErrorExp.get();
         }
 
         override void visit(StringExp e)
@@ -1619,7 +1619,7 @@ Expression castTo(Expression e, Scope* sc, Type t)
                 auto ts = toAutoQualChars(e.type, t);
                 e.error("cannot cast expression `%s` of type `%s` to `%s` because of different sizes",
                     e.toChars(), ts[0], ts[1]);
-                result = new ErrorExp();
+                result = ErrorExp.get();
                 return;
             }
 
@@ -1643,7 +1643,7 @@ Expression castTo(Expression e, Scope* sc, Type t)
                     {
                         // copied from sarray_toDarray() in e2ir.c
                         e.error("cannot cast expression `%s` of type `%s` to `%s` since sizes don't line up", e.toChars(), e.type.toChars(), t.toChars());
-                        result = new ErrorExp();
+                        result = ErrorExp.get();
                         return;
                     }
                     goto Lok;
@@ -1703,7 +1703,7 @@ Expression castTo(Expression e, Scope* sc, Type t)
                         return;
                 }
                 e.error("cannot cast expression `%s` of type `%s` to `%s`", e.toChars(), e.type.toChars(), t.toChars());
-                result = new ErrorExp();
+                result = ErrorExp.get();
                 return;
             }
 
@@ -1770,7 +1770,7 @@ Expression castTo(Expression e, Scope* sc, Type t)
             if (!e.committed && t.ty == Tpointer && t.nextOf().ty == Tvoid)
             {
                 e.error("cannot convert string literal to `void*`");
-                result = new ErrorExp();
+                result = ErrorExp.get();
                 return;
             }
 
@@ -2100,7 +2100,7 @@ Expression castTo(Expression e, Scope* sc, Type t)
             {
                 if (f.checkForwardRef(e.loc))
                 {
-                    result = new ErrorExp();
+                    result = ErrorExp.get();
                     return;
                 }
             }
@@ -2153,7 +2153,7 @@ Expression castTo(Expression e, Scope* sc, Type t)
             {
                 if (checkArrayLiteralEscape(sc, ae, false))
                 {
-                    result = new ErrorExp();
+                    result = ErrorExp.get();
                     return;
                 }
             }
@@ -2327,7 +2327,7 @@ Expression castTo(Expression e, Scope* sc, Type t)
                         else if (f.needThis())
                         {
                             e.error("no `this` to create delegate for `%s`", f.toChars());
-                            result = new ErrorExp();
+                            result = ErrorExp.get();
                             return;
                         }
                         else if (f.isNested())
@@ -2338,7 +2338,7 @@ Expression castTo(Expression e, Scope* sc, Type t)
                         else
                         {
                             e.error("cannot cast from function pointer to delegate");
-                            result = new ErrorExp();
+                            result = ErrorExp.get();
                             return;
                         }
                     }
@@ -2356,7 +2356,7 @@ Expression castTo(Expression e, Scope* sc, Type t)
             {
                 if (f.checkForwardRef(e.loc))
                 {
-                    result = new ErrorExp();
+                    result = ErrorExp.get();
                     return;
                 }
             }
@@ -2412,7 +2412,7 @@ Expression castTo(Expression e, Scope* sc, Type t)
             {
                 if (f.checkForwardRef(e.loc))
                 {
-                    result = new ErrorExp();
+                    result = ErrorExp.get();
                     return;
                 }
             }
@@ -2533,7 +2533,7 @@ Expression castTo(Expression e, Scope* sc, Type t)
             auto ts = toAutoQualChars(tsa ? tsa : e.type, t);
             e.error("cannot cast expression `%s` of type `%s` to `%s`",
                 e.toChars(), ts[0], ts[1]);
-            result = new ErrorExp();
+            result = ErrorExp.get();
         }
     }
 
@@ -2680,7 +2680,7 @@ Expression scaleFactor(BinExp be, Scope* sc)
         else if (sc.func.setUnsafe())
         {
             be.error("pointer arithmetic not allowed in @safe functions");
-            return new ErrorExp();
+            return ErrorExp.get();
         }
     }
 
@@ -3414,7 +3414,7 @@ Expression typeCombine(BinExp be, Scope* sc)
         Expression ex = be.incompatibleTypes();
         if (ex.op == TOK.error)
             return ex;
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     Type t1 = be.e1.type.toBasetype();
@@ -3453,7 +3453,7 @@ Expression integralPromotions(Expression e, Scope* sc)
     {
     case Tvoid:
         e.error("void has no value");
-        return new ErrorExp();
+        return ErrorExp.get();
 
     case Tint8:
     case Tuns8:

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1540,7 +1540,7 @@ extern (C++) class VarDeclaration : Declaration
         if (!e)
         {
             .error(loc, "cannot make expression out of initializer for `%s`", toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         e = e.copy();

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -57,7 +57,7 @@ Expression toDelegate(Expression e, Type t, Scope* sc)
     bool r = lambdaCheckForNestedRef(e, sc);
     sc = sc.pop();
     if (r)
-        return new ErrorExp();
+        return ErrorExp.get();
 
     Statement s;
     if (t.ty == Tvoid)

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -193,7 +193,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
 
         Expression errorReturn()
         {
-            *pval = new ErrorExp();
+            *pval = ErrorExp.get();
             return *pval;
         }
 
@@ -287,7 +287,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
     Expression getDefaultValue(const ref Loc loc)
     {
         Expression handleErrors(){
-            defaultval = new ErrorExp();
+            defaultval = ErrorExp.get();
             return defaultval;
         }
         //printf("EnumDeclaration::getDefaultValue() %p %s\n", this, toChars());
@@ -428,7 +428,7 @@ extern (C++) final class EnumMember : VarDeclaration
     {
         dsymbolSemantic(this, sc);
         if (errors)
-            return new ErrorExp();
+            return ErrorExp.get();
         checkDisabled(loc, sc);
 
         if (depdecl && !depdecl._scope)
@@ -436,7 +436,7 @@ extern (C++) final class EnumMember : VarDeclaration
         checkDeprecated(loc, sc);
 
         if (errors)
-            return new ErrorExp();
+            return ErrorExp.get();
         Expression e = new VarExp(loc, this);
         return e.expressionSemantic(sc);
     }

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -71,7 +71,7 @@ public Expression ctfeInterpret(Expression e)
         case TOK.type:
         case TOK.typeid_:
              if (e.type.ty == Terror)
-                return new ErrorExp();
+                return ErrorExp.get();
             goto case TOK.error;
 
         case TOK.error:
@@ -84,7 +84,7 @@ public Expression ctfeInterpret(Expression e)
     assert(e.type); // https://issues.dlang.org/show_bug.cgi?id=14642
     //assert(e.type.ty != Terror);    // FIXME
     if (e.type.ty == Terror)
-        return new ErrorExp();
+        return ErrorExp.get();
 
     auto rgnpos = ctfeGlobals.region.savePos();
 
@@ -95,7 +95,7 @@ public Expression ctfeInterpret(Expression e)
     if (!CTFEExp.isCantExp(result))
         result = scrubReturnValue(e.loc, result);
     if (CTFEExp.isCantExp(result))
-        result = new ErrorExp();
+        result = ErrorExp.get();
 
     ctfeGlobals.region.release(rgnpos);
 
@@ -6474,7 +6474,7 @@ private Expression scrubReturnValue(const ref Loc loc, Expression e)
     else if (auto vie = e.isVoidInitExp())
     {
         error(loc, "uninitialized variable `%s` cannot be returned from CTFE", vie.var.toChars());
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     e = resolveSlice(e);

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1015,7 +1015,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 {
                     error(dsym.loc, "tuple of %d elements cannot be assigned to tuple of %d elements", cast(int)tedim, cast(int)nelems);
                     for (size_t u = tedim; u < nelems; u++) // fill dummy expression
-                        te.exps.push(new ErrorExp());
+                        te.exps.push(ErrorExp.get());
                 }
             }
 
@@ -1365,7 +1365,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                             if (!e)
                             {
                                 dsym.error("is not a static and cannot have static initializer");
-                                e = new ErrorExp();
+                                e = ErrorExp.get();
                             }
                         }
                         ei = new ExpInitializer(dsym._init.loc, e);
@@ -1949,7 +1949,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 pd.error("string expected for mangled name");
                 pd.args.setDim(1);
-                (*pd.args)[0] = new ErrorExp(); // error recovery
+                (*pd.args)[0] = ErrorExp.get(); // error recovery
                 goto Ldecl;
             }
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5580,7 +5580,7 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
             e = e.resolveLoc(instLoc, sc); // use the instantiated loc
             e = e.optimize(WANTvalue);
             if (global.errors != olderrs)
-                e = new ErrorExp();
+                e = ErrorExp.get();
         }
         return e;
     }
@@ -6713,11 +6713,11 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     else if (definitelyValueParameter(ea))
                     {
                         if (ea.checkValue()) // check void expression
-                            ea = new ErrorExp();
+                            ea = ErrorExp.get();
                         uint olderrs = global.errors;
                         ea = ea.ctfeInterpret();
                         if (global.errors != olderrs)
-                            ea = new ErrorExp();
+                            ea = ErrorExp.get();
                     }
                 }
                 //printf("-[%d] ea = %s %s\n", j, Token.toChars(ea.op), ea.toChars());

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -219,7 +219,7 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
             if (ae.arguments.dim == 1)
                 return null;
             ae.error("multi-dimensional slicing requires template `opSlice`");
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         //printf("[%d] e = %s\n", i, e.toChars());
 
@@ -271,7 +271,7 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
         if (!e.type)
         {
             ae.error("`%s` has no value", e.toChars());
-            e = new ErrorExp();
+            e = ErrorExp.get();
         }
         if (e.op == TOK.error)
             return e;
@@ -326,7 +326,7 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, IntervalExp ie, Expression* p
 
     sc = sc.pop();
 
-    return errors ? new ErrorExp() : ae;
+    return errors ? ErrorExp.get() : ae;
 }
 
 /******************************
@@ -466,7 +466,7 @@ private Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
         DotTemplateInstanceExp dti = cast(DotTemplateInstanceExp)ue;
         auto ti = Pool!TemplateInstance.make(loc, s.ident, dti.ti.tiargs);
         if (!ti.updateTempDecl(sc, s))
-            return new ErrorExp();
+            return ErrorExp.get();
         return new ScopeExp(loc, ti);
     }
     else
@@ -515,12 +515,12 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
                 if (!ce.arguments || ce.arguments.dim != 1)
                 {
                     ce.error("expected key as argument to `aa.remove()`");
-                    return new ErrorExp();
+                    return ErrorExp.get();
                 }
                 if (!eleft.type.isMutable())
                 {
                     ce.error("cannot remove key from `%s` associative array `%s`", MODtoChars(t.mod), eleft.toChars());
-                    return new ErrorExp();
+                    return ErrorExp.get();
                 }
                 Expression key = (*ce.arguments)[0];
                 key = key.expressionSemantic(sc);
@@ -530,7 +530,7 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
                 key = key.implicitCastTo(sc, taa.index);
 
                 if (key.checkValue() || key.checkSharedAccess(sc))
-                    return new ErrorExp();
+                    return ErrorExp.get();
 
                 semanticTypeInfo(sc, taa.index);
 
@@ -557,7 +557,7 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
                     Expressions* originalArguments = Expression.arraySyntaxCopy(ce.arguments);
 
                     if (arrayExpressionSemantic(originalArguments, sc))
-                        return new ErrorExp();
+                        return ErrorExp.get();
 
                     /* fall down to UFCS */
                 }
@@ -877,17 +877,17 @@ Lagain:
                 error(loc, "circular reference to %s `%s`", v.kind(), v.toPrettyChars());
             else            // variable type cannot be determined
                 error(loc, "forward reference to %s `%s`", v.kind(), v.toPrettyChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         if (v.type.ty == Terror)
-            return new ErrorExp();
+            return ErrorExp.get();
 
         if ((v.storage_class & STC.manifest) && v._init)
         {
             if (v.inuse)
             {
                 error(loc, "circular initialization of %s `%s`", v.kind(), v.toPrettyChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             e = v.expandInitializer(loc);
             v.inuse++;
@@ -898,7 +898,7 @@ Lagain:
 
         // Change the ancestor lambdas to delegate before hasThis(sc) call.
         if (v.checkNestedReference(sc, loc))
-            return new ErrorExp();
+            return ErrorExp.get();
 
         if (v.needThis() && hasThis(sc))
             e = new DotVarExp(loc, new ThisExp(loc), v);
@@ -917,10 +917,10 @@ Lagain:
     {
         f = f.toAliasFunc();
         if (!f.functionSemantic())
-            return new ErrorExp();
+            return ErrorExp.get();
 
         if (!hasOverloads && f.checkForwardRef(loc))
-            return new ErrorExp();
+            return ErrorExp.get();
 
         auto fd = s.isFuncDeclaration();
         fd.type = f.type;
@@ -943,7 +943,7 @@ Lagain:
         if (!imp.pkg)
         {
             .error(loc, "forward reference of import `%s`", imp.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         auto ie = new ScopeExp(loc, imp.pkg);
         return ie.expressionSemantic(sc);
@@ -983,7 +983,7 @@ Lagain:
     {
         ti.dsymbolSemantic(sc);
         if (!ti.inst || ti.errors)
-            return new ErrorExp();
+            return ErrorExp.get();
         s = ti.toAlias();
         if (!s.isTemplateInstance())
             goto Lagain;
@@ -1007,7 +1007,7 @@ Lagain:
     }
 
     .error(loc, "%s `%s` is not a variable", s.kind(), s.toChars());
-    return new ErrorExp();
+    return ErrorExp.get();
 }
 
 /*************************************************************
@@ -1106,7 +1106,7 @@ L1:
             if (flag)
                 return null;
             e1.error("`this` for `%s` needs to be type `%s` not type `%s`", var.toChars(), ad.toChars(), t.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
     }
     return e1;
@@ -1147,7 +1147,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         {
             e2 = e2.expressionSemantic(sc);
             if (e2.op == TOK.error)
-                return new ErrorExp();
+                return ErrorExp.get();
             e2 = resolveProperties(sc, e2);
 
             Expressions a;
@@ -1158,7 +1158,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                 if (FuncDeclaration f = resolveFuncCall(loc, sc, os.a[i], tiargs, tthis, &a, FuncResolveFlag.quiet))
                 {
                     if (f.errors)
-                        return new ErrorExp();
+                        return ErrorExp.get();
                     fd = f;
                     assert(fd.type.ty == Tfunction);
                 }
@@ -1175,14 +1175,14 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                 if (FuncDeclaration f = resolveFuncCall(loc, sc, os.a[i], tiargs, tthis, null, FuncResolveFlag.quiet))
                 {
                     if (f.errors)
-                        return new ErrorExp();
+                        return ErrorExp.get();
                     fd = f;
                     assert(fd.type.ty == Tfunction);
                     TypeFunction tf = cast(TypeFunction)fd.type;
                     if (!tf.isref && e2)
                     {
                         error(loc, "%s is not an lvalue", e1.toChars());
-                        return new ErrorExp();
+                        return ErrorExp.get();
                     }
                 }
             }
@@ -1262,7 +1262,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         {
             e2 = e2.expressionSemantic(sc);
             if (e2.op == TOK.error)
-                return new ErrorExp();
+                return ErrorExp.get();
             e2 = resolveProperties(sc, e2);
 
             Expressions a;
@@ -1272,7 +1272,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
             if (fd && fd.type)
             {
                 if (fd.errors)
-                    return new ErrorExp();
+                    return ErrorExp.get();
                 assert(fd.type.ty == Tfunction);
                 Expression e = new CallExp(loc, e1, e2);
                 return e.expressionSemantic(sc);
@@ -1283,7 +1283,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
             if (fd && fd.type)
             {
                 if (fd.errors)
-                    return new ErrorExp();
+                    return ErrorExp.get();
                 assert(fd.type.ty == Tfunction);
                 TypeFunction tf = cast(TypeFunction)fd.type;
                 if (!e2 || tf.isref)
@@ -1310,7 +1310,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         VarExp ve = cast(VarExp)e1;
         VarDeclaration v = ve.var.isVarDeclaration();
         if (v && ve.checkPurity(sc, v))
-            return new ErrorExp();
+            return ErrorExp.get();
     }
     if (e2)
         return null;
@@ -1330,32 +1330,32 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         {
             // Check for reading overlapped pointer field in @safe code.
             if (checkUnsafeAccess(sc, e1, true, true))
-                return new ErrorExp();
+                return ErrorExp.get();
         }
         else if (e1.op == TOK.dot)
         {
             e1.error("expression has no value");
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         else if (e1.op == TOK.call)
         {
             CallExp ce = cast(CallExp)e1;
             // Check for reading overlapped pointer field in @safe code.
             if (checkUnsafeAccess(sc, ce.e1, true, true))
-                return new ErrorExp();
+                return ErrorExp.get();
         }
     }
 
     if (!e1.type)
     {
         error(loc, "cannot resolve type for %s", e1.toChars());
-        e1 = new ErrorExp();
+        e1 = ErrorExp.get();
     }
     return e1;
 
 Leprop:
     error(loc, "not a property %s", e1.toChars());
-    return new ErrorExp();
+    return ErrorExp.get();
 }
 
 extern (C++) Expression resolveProperties(Scope* sc, Expression e)
@@ -1363,7 +1363,7 @@ extern (C++) Expression resolveProperties(Scope* sc, Expression e)
     //printf("resolveProperties(%s)\n", e.toChars());
     e = resolvePropertiesX(sc, e);
     if (e.checkRightThis(sc))
-        return new ErrorExp();
+        return ErrorExp.get();
     return e;
 }
 
@@ -1605,7 +1605,7 @@ private bool preFunctionParameters(Scope* sc, Expressions* exps, const bool repo
                     if (reportErrors)
                     {
                         arg.error("cannot pass type `%s` as a function argument", arg.toChars());
-                        arg = new ErrorExp();
+                        arg = ErrorExp.get();
                     }
                     err = true;
                 }
@@ -1615,13 +1615,13 @@ private bool preFunctionParameters(Scope* sc, Expressions* exps, const bool repo
                 if (reportErrors)
                 {
                     arg.error("cannot pass function `%s` as a function argument", arg.toChars());
-                    arg = new ErrorExp();
+                    arg = ErrorExp.get();
                 }
                 err = true;
             }
             else if (checkNonAssignmentArrayOp(arg))
             {
-                arg = new ErrorExp();
+                arg = ErrorExp.get();
                 err = true;
             }
             (*exps)[i] = arg;
@@ -2491,7 +2491,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     private void setError()
     {
-        result = new ErrorExp();
+        result = ErrorExp.get();
     }
 
     /**************************
@@ -2745,7 +2745,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         else
             exp.error("undefined identifier `%s`", exp.ident.toChars());
 
-        result = new ErrorExp();
+        result = ErrorExp.get();
     }
 
     override void visit(DsymbolExp e)
@@ -2817,7 +2817,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     Lerr:
         e.error("`this` is only defined in non-static member functions, not `%s`", sc.parent.toChars());
-        result = new ErrorExp();
+        result = ErrorExp.get();
     }
 
     override void visit(SuperExp e)
@@ -2897,7 +2897,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     Lerr:
         e.error("`super` is only allowed in non-static class member functions");
-        result = new ErrorExp();
+        result = ErrorExp.get();
     }
 
     override void visit(NullExp e)
@@ -4026,7 +4026,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (exp.matchType(exp.fd.treq, sc, &fe) > MATCH.nomatch)
                     e = fe;
                 else
-                    e = new ErrorExp();
+                    e = ErrorExp.get();
             }
             goto Ldone;
         }
@@ -4043,7 +4043,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             if (exp.fd.type && exp.fd.type.ty == Tfunction && !exp.fd.type.nextOf())
                 (cast(TypeFunction)exp.fd.type).next = Type.terror;
-            e = new ErrorExp();
+            e = ErrorExp.get();
             goto Ldone;
         }
 
@@ -4129,7 +4129,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.errorSupplemental("too %s arguments, expected `%d`, got `%d`",
                                       arguments.dim < dim ? "few".ptr : "many".ptr,
                                       cast(int)dim, cast(int)arguments.dim);
-                return new ErrorExp();
+                return ErrorExp.get();
             }
 
             auto tiargs = new Objects();
@@ -5267,12 +5267,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (tb.toDsymbol(sc).isClassDeclaration().classKind == ClassKind.cpp)
             {
                 error(exp.loc, "Runtime type information is not supported for `extern(C++)` classes");
-                e = new ErrorExp();
+                e = ErrorExp.get();
             }
             else if (!Type.typeinfoclass)
             {
                 error(exp.loc, "`object.TypeInfo_Class` could not be found, but is implicitly used");
-                e = new ErrorExp();
+                e = ErrorExp.get();
             }
             else
             {
@@ -5285,7 +5285,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else if (ta.ty == Terror)
         {
-            e = new ErrorExp();
+            e = ErrorExp.get();
         }
         else
         {
@@ -7346,7 +7346,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         else if (exp.e1.type.ty == Tvoid)
             checkElem(exp.e1);
 
-        result = res ? new ErrorExp() : exp;
+        result = res ? ErrorExp.get() : exp;
     }
 
     override void visit(VectorArrayExp e)
@@ -7709,7 +7709,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         else
             exp.error("cannot use `[]` operator on expression of type `%s`", exp.e1.type.toChars());
 
-        result = new ErrorExp();
+        result = ErrorExp.get();
     }
 
     override void visit(DotExp exp)
@@ -8209,9 +8209,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             auto sle = new StructLiteralExp(loc, sd, null, t);
             if (!sd.fill(loc, sle.elements, true))
-                return new ErrorExp();
+                return ErrorExp.get();
             if (checkFrameAccess(loc, sc, sd, sle.elements.dim))
-                return new ErrorExp();
+                return ErrorExp.get();
 
             sle.type = t;
             return sle;
@@ -9125,7 +9125,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 exp.error("slice `%s` is not mutable, struct `%s` has immutable members",
                     exp.e1.toChars(), tn.baseElemOf().toChars());
-                result = new ErrorExp();
+                result = ErrorExp.get();
                 return;
             }
 
@@ -9148,7 +9148,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     exp.error("array `%s` is not mutable, struct `%s` has immutable members",
                         exp.e1.toChars(), tn.baseElemOf().toChars());
-                    result = new ErrorExp();
+                    result = ErrorExp.get();
                     return;
                 }
             }
@@ -9838,7 +9838,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             else
             {
                 exp.error("can't subtract `%s` from pointer", t2.toChars());
-                e = new ErrorExp();
+                e = ErrorExp.get();
             }
             result = e;
             return;
@@ -11170,7 +11170,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 exp.error("incompatible types for array comparison: `%s` and `%s`",
                           exp.e1.type.toChars(), exp.e2.type.toChars());
-                __equals = new ErrorExp();
+                __equals = ErrorExp.get();
             }
 
             result = __equals;
@@ -11557,13 +11557,13 @@ Expression semanticX(DotIdExp exp, Scope* sc)
                 {
                     if (f.checkForwardRef(exp.loc))
                     {
-                        return new ErrorExp();
+                        return ErrorExp.get();
                     }
                     if (f.flags & (FUNCFLAG.purityInprocess | FUNCFLAG.safetyInprocess |
                                    FUNCFLAG.nothrowInprocess | FUNCFLAG.nogcInprocess))
                     {
                         f.error(exp.loc, "cannot retrieve its `.mangleof` while inferring attributes");
-                        return new ErrorExp();
+                        return ErrorExp.get();
                     }
                 }
                 OutBuffer buf;
@@ -11621,12 +11621,12 @@ Expression semanticX(DotIdExp exp, Scope* sc)
     if ((exp.e1.op == TOK.dotTemplateDeclaration || exp.e1.op == TOK.template_) && exp.ident != Id.stringof)
     {
         exp.error("template `%s` does not have property `%s`", exp.e1.toChars(), exp.ident.toChars());
-        return new ErrorExp();
+        return ErrorExp.get();
     }
     if (!exp.e1.type)
     {
         exp.error("expression `%s` does not have property `%s`", exp.e1.toChars(), exp.ident.toChars());
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     return exp;
@@ -11734,10 +11734,10 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
                         exp.error("circular reference to %s `%s`", v.kind(), v.toPrettyChars());
                     else
                         exp.error("forward reference to %s `%s`", v.kind(), v.toPrettyChars());
-                    return new ErrorExp();
+                    return ErrorExp.get();
                 }
                 if (v.type.ty == Terror)
-                    return new ErrorExp();
+                    return ErrorExp.get();
 
                 if ((v.storage_class & STC.manifest) && v._init && !exp.wantsym)
                 {
@@ -11748,7 +11748,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
                     if (v.inuse)
                     {
                         error(exp.loc, "circular initialization of %s `%s`", v.kind(), v.toPrettyChars());
-                        return new ErrorExp();
+                        return ErrorExp.get();
                     }
                     e = v.expandInitializer(exp.loc);
                     v.inuse++;
@@ -11782,7 +11782,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
             {
                 //printf("it's a function\n");
                 if (!f.functionSemantic())
-                    return new ErrorExp();
+                    return ErrorExp.get();
                 if (f.needThis())
                 {
                     if (!eleft)
@@ -11892,7 +11892,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
         }
         else
             exp.error("undefined identifier `%s` in %s `%s`", exp.ident.toChars(), ie.sds.kind(), ie.sds.toPrettyChars());
-        return new ErrorExp();
+        return ErrorExp.get();
     }
     else if (t1b.ty == Tpointer && exp.e1.type.ty != Tenum && exp.ident != Id._init && exp.ident != Id.__sizeof && exp.ident != Id.__xalignof && exp.ident != Id.offsetof && exp.ident != Id._mangleof && exp.ident != Id.stringof)
     {
@@ -11937,7 +11937,7 @@ Expression semanticY(DotTemplateInstanceExp exp, Scope* sc, int flag)
 
     static Expression errorExp()
     {
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     auto die = new DotIdExp(exp.loc, exp.e1, exp.ti.name);
@@ -12278,7 +12278,7 @@ Expression getThisSkipNestedFuncs(const ref Loc loc, Scope* sc, Dsymbol s, Aggre
             if (flag)
                 return null;
             e1.error("need `this` of type `%s` to access member `%s` from static function `%s`", ad.toChars(), var.toChars(), f.toChars());
-            e1 = new ErrorExp();
+            e1 = ErrorExp.get();
             return e1;
         }
         s = s.toParent2();

--- a/src/dmd/iasmgcc.d
+++ b/src/dmd/iasmgcc.d
@@ -343,7 +343,7 @@ public Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
             if (i < s.outputargs)
                 e = e.modifiableLvalue(sc, null);
             else if (e.checkValue())
-                e = new ErrorExp();
+                e = ErrorExp.get();
             (*s.args)[i] = e;
 
             e = (*s.constraints)[i];

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -74,7 +74,7 @@ Expression toAssocArrayLiteral(ArrayInitializer ai)
     return e;
 Lno:
     error(ai.loc, "not an associative array initializer");
-    return new ErrorExp();
+    return ErrorExp.get();
 }
 
 /******************************************
@@ -517,7 +517,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
                 if (dim1 != dim2)
                 {
                     i.exp.error("mismatched array lengths, %d and %d", cast(int)dim1, cast(int)dim2);
-                    i.exp = new ErrorExp();
+                    i.exp = ErrorExp.get();
                 }
             }
             i.exp = i.exp.implicitCastTo(sc, t);
@@ -720,7 +720,7 @@ extern (C++) Expression initializerToExpression(Initializer init, Type itype = n
 
     Expression visitError(ErrorInitializer)
     {
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     /***************************************
@@ -750,7 +750,7 @@ extern (C++) Expression initializerToExpression(Initializer init, Type itype = n
         {
             if (init.type == Type.terror)
             {
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             t = init.type.toBasetype();
             switch (t.ty)

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -99,7 +99,7 @@ public Expression inlineCopy(Expression e, Scope* sc)
     if (cost >= COST_MAX)
     {
         e.error("cannot inline default argument `%s`", e.toChars());
-        return new ErrorExp();
+        return ErrorExp.get();
     }
     scope ids = new InlineDoState(sc.parent, null);
     return doInlineAs!Expression(e, ids);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2742,7 +2742,7 @@ extern (C++) final class TypeError : Type
 
     override Expression defaultInitLiteral(const ref Loc loc)
     {
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     override void accept(Visitor v)
@@ -5588,7 +5588,7 @@ extern (C++) final class TypeStruct : Type
         }
         sym.size(loc);
         if (sym.sizeok != Sizeok.done)
-            return new ErrorExp();
+            return ErrorExp.get();
 
         auto structelems = new Expressions(sym.nonHiddenFields());
         uint offset = 0;
@@ -5599,7 +5599,7 @@ extern (C++) final class TypeStruct : Type
             if (vd.inuse)
             {
                 error(loc, "circular reference to `%s`", vd.toPrettyChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             if (vd.offset < offset || vd.type.size() == 0)
                 e = null;

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -239,7 +239,7 @@ Expression checkGC(Scope* sc, Expression e)
         scope NOGCVisitor gcv = new NOGCVisitor(f);
         walkPostorder(e, gcv);
         if (gcv.err)
-            return new ErrorExp();
+            return ErrorExp.get();
     }
     return e;
 }

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -652,7 +652,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                     if (s && !s.isTemplateDeclaration())
                     {
                         e.e1.error("`%s.opBinary` isn't a template", e.e1.toChars());
-                        result = new ErrorExp();
+                        result = ErrorExp.get();
                         return;
                     }
                 }
@@ -662,7 +662,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                     if (s_r && !s_r.isTemplateDeclaration())
                     {
                         e.e2.error("`%s.opBinaryRight` isn't a template", e.e2.toChars());
-                        result = new ErrorExp();
+                        result = ErrorExp.get();
                         return;
                     }
                     if (s_r && s_r == s) // https://issues.dlang.org/show_bug.cgi?id=12778
@@ -730,7 +730,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                     functionResolve(m, s, e.loc, sc, tiargs, e.e1.type, &args2);
                     if (m.lastf && (m.lastf.errors || m.lastf.semantic3Errors))
                     {
-                        result = new ErrorExp();
+                        result = ErrorExp.get();
                         return;
                     }
                 }
@@ -740,7 +740,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                     functionResolve(m, s_r, e.loc, sc, tiargs, e.e2.type, &args1);
                     if (m.lastf && (m.lastf.errors || m.lastf.semantic3Errors))
                     {
-                        result = new ErrorExp();
+                        result = ErrorExp.get();
                         return;
                     }
                 }
@@ -815,7 +815,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                             functionResolve(m, s_r, e.loc, sc, tiargs, e.e1.type, &args2);
                             if (m.lastf && (m.lastf.errors || m.lastf.semantic3Errors))
                             {
-                                result = new ErrorExp();
+                                result = ErrorExp.get();
                                 return;
                             }
                         }
@@ -825,7 +825,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                             functionResolve(m, s, e.loc, sc, tiargs, e.e2.type, &args1);
                             if (m.lastf && (m.lastf.errors || m.lastf.semantic3Errors))
                             {
-                                result = new ErrorExp();
+                                result = ErrorExp.get();
                                 return;
                             }
                         }
@@ -935,7 +935,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 e.error("use `%s` instead of `%s` when comparing with `null`",
                     Token.toChars(e.op == TOK.equal ? TOK.identity : TOK.notIdentity),
                     Token.toChars(e.op));
-                result = new ErrorExp();
+                result = ErrorExp.get();
                 return;
             }
             if (t1.ty == Tclass && t2.ty == Tnull ||
@@ -1060,7 +1060,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 {
                     e.error("cannot compare `%s` because its auto generated member-wise equality has recursive definition",
                         t1.toChars());
-                    result = new ErrorExp();
+                    result = ErrorExp.get();
                 }
                 return;
             }
@@ -1076,7 +1076,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 {
                     e.error("mismatched tuple lengths, `%d` and `%d`",
                         cast(int)dim, cast(int)tup2.exps.dim);
-                    result = new ErrorExp();
+                    result = ErrorExp.get();
                     return;
                 }
 
@@ -1231,7 +1231,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
             // Don't attempt 'alias this' if an error occurred
             if (e.e1.type.ty == Terror || e.e2.type.ty == Terror)
             {
-                result = new ErrorExp();
+                result = ErrorExp.get();
                 return;
             }
             Identifier id = opId(e);
@@ -1247,7 +1247,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 if (s && !s.isTemplateDeclaration())
                 {
                     e.error("`%s.opOpAssign` isn't a template", e.e1.toChars());
-                    result = new ErrorExp();
+                    result = ErrorExp.get();
                     return;
                 }
             }
@@ -1287,7 +1287,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                     functionResolve(m, s, e.loc, sc, tiargs, e.e1.type, &args2);
                     if (m.lastf && (m.lastf.errors || m.lastf.semantic3Errors))
                     {
-                        result = new ErrorExp();
+                        result = ErrorExp.get();
                         return;
                     }
                 }
@@ -1366,7 +1366,7 @@ private Expression compare_overload(BinExp e, Scope* sc, Identifier id, TOK* pop
         {
             functionResolve(m, s, e.loc, sc, tiargs, e.e1.type, &args2);
             if (m.lastf && (m.lastf.errors || m.lastf.semantic3Errors))
-                return new ErrorExp();
+                return ErrorExp.get();
         }
         FuncDeclaration lastf = m.lastf;
         int count = m.count;
@@ -1374,7 +1374,7 @@ private Expression compare_overload(BinExp e, Scope* sc, Identifier id, TOK* pop
         {
             functionResolve(m, s_r, e.loc, sc, tiargs, e.e2.type, &args1);
             if (m.lastf && (m.lastf.errors || m.lastf.semantic3Errors))
-                return new ErrorExp();
+                return ErrorExp.get();
         }
         if (m.count > 1)
         {

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -66,7 +66,7 @@ Expression expandVar(int result, VarDeclaration v)
 
     static Expression errorReturn()
     {
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     if (!v)
@@ -281,7 +281,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
 
         void error()
         {
-            ret = new ErrorExp();
+            ret = ErrorExp.get();
         }
 
         bool expOptimize(ref Expression e, int flags, bool keepLvalue = false)

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -117,7 +117,7 @@ private Expression checkAssignmentAsCondition(Expression e)
     if (ec.op == TOK.assign)
     {
         ec.error("assignment cannot be used as a condition, perhaps `==` was meant?");
-        return new ErrorExp();
+        return ErrorExp.get();
     }
     return e;
 }
@@ -188,14 +188,14 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             s.exp = resolveProperties(sc, s.exp);
             s.exp = s.exp.addDtorHook(sc);
             if (checkNonAssignmentArrayOp(s.exp))
-                s.exp = new ErrorExp();
+                s.exp = ErrorExp.get();
             if (auto f = isFuncAddress(s.exp))
             {
                 if (f.checkForwardRef(s.exp.loc))
-                    s.exp = new ErrorExp();
+                    s.exp = ErrorExp.get();
             }
             if (discardValue(s.exp))
-                s.exp = new ErrorExp();
+                s.exp = ErrorExp.get();
 
             s.exp = s.exp.optimize(WANTvalue);
             s.exp = checkGC(sc, s.exp);
@@ -517,7 +517,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         ds.condition = ds.condition.expressionSemantic(sc);
         ds.condition = resolveProperties(sc, ds.condition);
         if (checkNonAssignmentArrayOp(ds.condition))
-            ds.condition = new ErrorExp();
+            ds.condition = ErrorExp.get();
         ds.condition = ds.condition.optimize(WANTvalue);
         ds.condition = checkGC(sc, ds.condition);
 
@@ -590,7 +590,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             fs.condition = fs.condition.expressionSemantic(sc);
             fs.condition = resolveProperties(sc, fs.condition);
             if (checkNonAssignmentArrayOp(fs.condition))
-                fs.condition = new ErrorExp();
+                fs.condition = ErrorExp.get();
             fs.condition = fs.condition.optimize(WANTvalue);
             fs.condition = checkGC(sc, fs.condition);
 
@@ -602,7 +602,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             fs.increment = fs.increment.expressionSemantic(sc);
             fs.increment = resolveProperties(sc, fs.increment);
             if (checkNonAssignmentArrayOp(fs.increment))
-                fs.increment = new ErrorExp();
+                fs.increment = ErrorExp.get();
             fs.increment = fs.increment.optimize(WANTvalue);
             fs.increment = checkGC(sc, fs.increment);
         }
@@ -2247,7 +2247,7 @@ else
             ifs.condition = ifs.condition.addDtorHook(scd);
         }
         if (checkNonAssignmentArrayOp(ifs.condition))
-            ifs.condition = new ErrorExp();
+            ifs.condition = ErrorExp.get();
         ifs.condition = checkGC(scd, ifs.condition);
 
         // Convert to boolean after declaring prm so this works:
@@ -2536,7 +2536,7 @@ else
             }
         }
         if (checkNonAssignmentArrayOp(ss.condition))
-            ss.condition = new ErrorExp();
+            ss.condition = ErrorExp.get();
         ss.condition = ss.condition.optimize(WANTvalue);
         ss.condition = checkGC(sc, ss.condition);
         if (ss.condition.op == TOK.error)
@@ -3171,14 +3171,14 @@ else
 
             rs.exp = resolveProperties(sc, rs.exp);
             if (rs.exp.checkType())
-                rs.exp = new ErrorExp();
+                rs.exp = ErrorExp.get();
             if (auto f = isFuncAddress(rs.exp))
             {
                 if (fd.inferRetType && f.checkForwardRef(rs.exp.loc))
-                    rs.exp = new ErrorExp();
+                    rs.exp = ErrorExp.get();
             }
             if (checkNonAssignmentArrayOp(rs.exp))
-                rs.exp = new ErrorExp();
+                rs.exp = ErrorExp.get();
 
             // Extract side-effect part
             rs.exp = Expression.extractLast(rs.exp, e0);

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -393,20 +393,20 @@ private Expression pointerBitmap(TraitsExp e)
     if (!e.args || e.args.dim != 1)
     {
         error(e.loc, "a single type expected for trait pointerBitmap");
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     Type t = getType((*e.args)[0]);
     if (!t)
     {
         error(e.loc, "`%s` is not a type", (*e.args)[0].toChars());
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     Array!(d_uns64) data;
     d_uns64 sz = getTypePointerBitmap(e.loc, t, &data);
     if (sz == d_uns64.max)
-        return new ErrorExp();
+        return ErrorExp.get();
 
     auto exps = new Expressions(data.dim + 1);
     (*exps)[0] = new IntegerExp(e.loc, sz, Type.tsize_t);
@@ -438,7 +438,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!TemplateInstance.semanticTiargs(e.loc, sc, e.args, 1))
         {
             sc.stc = save;
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         sc.stc = save;
     }
@@ -447,7 +447,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     Expression dimError(int expected)
     {
         e.error("expected %d arguments for `%s` but had %d", expected, e.ident.toChars(), cast(int)dim);
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     static IntegerExp True()
@@ -621,7 +621,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             e.error("type expected as second argument of __traits `%s` instead of `%s`",
                 e.ident.toChars(), o.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         Type tb = t.baseElemOf();
@@ -642,7 +642,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             e.error("type expected as second argument of __traits `%s` instead of `%s`",
                 e.ident.toChars(), o.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         Type tb = t.baseElemOf();
@@ -664,7 +664,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             e.error("type expected as second argument of __traits `%s` instead of `%s`",
                     e.ident.toChars(), o.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         t = t.toBasetype();     // get the base in case `t` is an `enum`
@@ -697,7 +697,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         }
 
         e.error("aggregate or function expected instead of `%s`", o.toChars());
-        return new ErrorExp();
+        return ErrorExp.get();
     }
     if (e.ident == Id.isDisabled)
     {
@@ -791,7 +791,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
          * Bit 1 means don't convert Parameter to Type if Parameter has an identifier
          */
         if (!TemplateInstance.semanticTiargs(e.loc, sc, e.args, 2))
-            return new ErrorExp();
+            return ErrorExp.get();
         if (dim != 1)
             return dimError(1);
 
@@ -802,7 +802,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             if (!po.ident)
             {
                 e.error("argument `%s` has no identifier", po.type.toChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             id = po.ident;
         }
@@ -812,7 +812,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             if (!s || !s.ident)
             {
                 e.error("argument `%s` has no identifier", o.toChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             id = s.ident;
         }
@@ -830,7 +830,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         bool ok = TemplateInstance.semanticTiargs(e.loc, sc2, e.args, 1);
         sc2.pop();
         if (!ok)
-            return new ErrorExp();
+            return ErrorExp.get();
 
         auto o = (*e.args)[0];
         auto s = getDsymbolWithoutExpCtx(o);
@@ -838,7 +838,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             if (!isError(o))
                 e.error("argument `%s` has no protection", o.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         if (s.semanticRun == PASS.init)
             s.dsymbolSemantic(null);
@@ -889,7 +889,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!s || s.isImport())
         {
             e.error("argument `%s` has no parent", o.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         if (auto f = s.isFuncDeclaration())
@@ -925,7 +925,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!ex)
         {
             e.error("expression expected as second argument of __traits `%s`", e.ident.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         ex = ex.ctfeInterpret();
 
@@ -937,7 +937,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             if (!b.type.equals(Type.tbool))
             {
                 e.error("`bool` expected as third argument of `__traits(getOverloads)`, not `%s` of type `%s`", b.toChars(), b.type.toChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             includeTemplates = b.isBool(true);
         }
@@ -946,14 +946,14 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!se || se.len == 0)
         {
             e.error("string expected as second argument of __traits `%s` instead of `%s`", e.ident.toChars(), ex.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         se = se.toUTF8(sc);
 
         if (se.sz != 1)
         {
             e.error("string must be chars");
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         auto id = Identifier.idPool(se.peekString());
 
@@ -979,7 +979,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         else
         {
             e.error("invalid first argument");
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         // ignore symbol visibility and disable access checks for these traits
@@ -1138,7 +1138,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!cd)
         {
             e.error("first argument is not a class");
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         if (cd.sizeok != Sizeok.done)
         {
@@ -1147,7 +1147,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (cd.sizeok != Sizeok.done)
         {
             e.error("%s `%s` is forward referenced", cd.kind(), cd.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         return new IntegerExp(e.loc, cd.structsize, Type.tsize_t);
@@ -1175,7 +1175,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
          * Bit 1 means don't convert Parameter to Type if Parameter has an identifier
          */
         if (!TemplateInstance.semanticTiargs(e.loc, sc, e.args, 3))
-            return new ErrorExp();
+            return ErrorExp.get();
 
         if (dim != 1)
             return dimError(1);
@@ -1216,7 +1216,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                     printf("t = %d %s\n", t.ty, t.toChars());
             }
             e.error("first argument is not a symbol");
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         auto exps = udad ? udad.getAttributes() : new Expressions();
@@ -1237,7 +1237,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!tf)
         {
             e.error("first argument is not a function");
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         auto mods = new Expressions();
@@ -1267,7 +1267,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!tf)
         {
             e.error("argument to `__traits(isReturnOnStack, %s)` is not a function", o.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         bool value = target.isReturnOnStack(tf, fd && fd.needThis());
@@ -1302,7 +1302,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             if (!fd)
             {
                 e.error("argument to `__traits(getFunctionVariadicStyle, %s)` is not a function", o.toChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             link = fd.linkage;
             varargs = fd.getParameterList().varargs;
@@ -1343,7 +1343,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             e.error("first argument to `__traits(getParameterStorageClasses, %s, %s)` is not a function",
                 o.toChars(), o1.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         StorageClass stc;
@@ -1354,14 +1354,14 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             e.error("expression expected as second argument of `__traits(getParameterStorageClasses, %s, %s)`",
                 o.toChars(), o1.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         ex = ex.ctfeInterpret();
         auto ii = ex.toUInteger();
         if (ii >= fparams.length)
         {
             e.error("parameter index must be in range 0..%u not %s", cast(uint)fparams.length, ex.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         uint n = cast(uint)ii;
@@ -1431,7 +1431,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             if (!s || ((d = s.isDeclaration()) is null && (agg = s.isAggregateDeclaration()) is null))
             {
                 e.error("argument to `__traits(getLinkage, %s)` is not a declaration", o.toChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             if (d !is null)
                 link = d.linkage;
@@ -1465,7 +1465,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             e.error("In expression `%s` `%s` can't have members", e.toChars(), o.toChars());
             e.errorSupplemental("`%s` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation", o.toChars());
 
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         if (auto imp = s.isImport())
         {
@@ -1478,7 +1478,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             e.error("In expression `%s` %s `%s` has no members", e.toChars(), s.kind(), s.toChars());
             e.errorSupplemental("`%s` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation", s.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         auto idents = new Identifiers();
@@ -1706,9 +1706,9 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         Objects ob2;
         ob2.push((*e.args)[1]);
         if (!TemplateInstance.semanticTiargs(e.loc, sc, &ob1, 0))
-            return new ErrorExp();
+            return ErrorExp.get();
         if (!TemplateInstance.semanticTiargs(e.loc, sc, &ob2, 0))
-            return new ErrorExp();
+            return ErrorExp.get();
         if (ob1.dim != ob2.dim)
             return False();
         foreach (immutable i; 0 .. ob1.dim)
@@ -1727,7 +1727,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             e.error("argument `%s` to __traits(getUnitTests) must be a module or aggregate",
                 o.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         if (auto imp = s.isImport()) // https://issues.dlang.org/show_bug.cgi?id=10990
             s = imp.mod;
@@ -1737,7 +1737,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             e.error("argument `%s` to __traits(getUnitTests) must be a module or aggregate, not a %s",
                 s.toChars(), s.kind());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         auto exps = new Expressions();
@@ -1783,7 +1783,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!fd)
         {
             e.error("first argument to __traits(getVirtualIndex) must be a function");
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         fd = fd.toAliasFunc(); // Necessary to support multiple overloads.
@@ -1804,7 +1804,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             e.error("type expected as second argument of __traits `%s` instead of `%s`",
                 e.ident.toChars(), o.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         Type tb = t.baseElemOf();
@@ -1820,7 +1820,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!ex || !se || se.len == 0)
         {
             e.error("string expected as argument of __traits `%s` instead of `%s`", e.ident.toChars(), ex.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         se = se.toUTF8(sc);
 
@@ -1830,7 +1830,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             e.error("`getTargetInfo` key `\"%.*s\"` not supported by this implementation",
                 cast(int)slice.length, slice.ptr);
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         return r.expressionSemantic(sc);
     }
@@ -1843,7 +1843,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!s || !s.loc.isValid())
         {
             e.error("can only get the location of a symbol, not `%s`", arg0.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         const fd = s.isFuncDeclaration();
@@ -1855,7 +1855,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                     "use `__traits(getOverloads, ..., \"%s\"%s)[N]` " ~
                     "to get the Nth overload",
                     arg0.toChars(), /*td ? ", true".ptr :*/ "".ptr);
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         auto exps = new Expressions(3);
@@ -1880,7 +1880,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         e.error("unrecognized trait `%s`, did you mean `%.*s`?", e.ident.toChars(), cast(int) sub.length, sub.ptr);
     else
         e.error("unrecognized trait `%s`", e.ident.toChars());
-    return new ErrorExp();
+    return ErrorExp.get();
 }
 
 /// compare arguments of __traits(isSame)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -344,7 +344,7 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
                     else
                         error(loc, "identifier `%s` of `%s` is not defined", id.toChars(), mt.toChars());
                 }
-                *pe = new ErrorExp();
+                *pe = ErrorExp.get();
                 return;
             }
         }
@@ -2100,7 +2100,7 @@ Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier iden
         {
             d_uns64 sz = mt.size(loc);
             if (sz == SIZE_INVALID)
-                return new ErrorExp();
+                return ErrorExp.get();
             e = new IntegerExp(loc, sz, Type.tsize_t);
         }
         else if (ident == Id.__xalignof)
@@ -2124,7 +2124,7 @@ Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier iden
             if (!mt.deco)
             {
                 error(loc, "forward reference of type `%s.mangleof`", mt.toChars());
-                e = new ErrorExp();
+                e = ErrorExp.get();
             }
             else
             {
@@ -2170,14 +2170,14 @@ Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier iden
                     }
                 }
             }
-            e = new ErrorExp();
+            e = ErrorExp.get();
         }
         return e;
     }
 
     Expression visitError(TypeError)
     {
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     Expression visitBasic(TypeBasic mt)
@@ -2468,7 +2468,7 @@ Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier iden
         else
         {
             error(loc, "no property `%s` for tuple `%s`", ident.toChars(), mt.toChars());
-            e = new ErrorExp();
+            e = ErrorExp.get();
         }
         return e;
     }
@@ -3142,7 +3142,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                     objc.checkOffsetof(e, ad);
                     ad.size(e.loc);
                     if (ad.sizeok != Sizeok.done)
-                        return new ErrorExp();
+                        return ErrorExp.get();
                     return new IntegerExp(e.loc, v.offset, Type.tsize_t);
                 }
             }
@@ -3176,7 +3176,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
 
     Expression visitError(TypeError)
     {
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     Expression visitBasic(TypeBasic mt)
@@ -3355,12 +3355,12 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             if (e.op == TOK.type)
             {
                 e.error("`%s` is not an expression", e.toChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             else if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
             {
                 e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             e = e.castTo(sc, e.type.nextOf().pointerTo());
         }
@@ -3382,7 +3382,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         if (e.op == TOK.type && (ident == Id.length || ident == Id.ptr))
         {
             e.error("`%s` is not an expression", e.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
         if (ident == Id.length)
         {
@@ -3397,7 +3397,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             }
             if (checkNonAssignmentArrayOp(e))
             {
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             e = new ArrayLengthExp(e.loc, e);
             e.type = Type.tsize_t;
@@ -3408,7 +3408,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
             {
                 e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             return e.castTo(sc, mt.next.pointerTo());
         }
@@ -3474,7 +3474,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
             {
                 e.error("`%s.funcptr` cannot be used in `@safe` code", e.toChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             e = new DelegateFuncptrExp(e.loc, e);
             e = e.expressionSemantic(sc);
@@ -3509,7 +3509,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         if (++nest > global.recursionLimit)
         {
             .error(e.loc, "cannot resolve identifier `%s`", ident.toChars());
-            return returnExp(gagError ? null : new ErrorExp());
+            return returnExp(gagError ? null : ErrorExp.get());
         }
 
 
@@ -3557,7 +3557,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 if (!td)
                 {
                     fd.error("must be a template `opDispatch(string s)`, not a %s", fd.kind());
-                    return returnExp(new ErrorExp());
+                    return returnExp(ErrorExp.get());
                 }
                 auto se = new StringExp(e.loc, ident.toString());
                 auto tiargs = new Objects();
@@ -3695,11 +3695,11 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                     e.error("circular reference to %s `%s`", v.kind(), v.toPrettyChars());
                 else
                     e.error("forward reference to %s `%s`", v.kind(), v.toPrettyChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             if (v.type.ty == Terror)
             {
-                return new ErrorExp();
+                return ErrorExp.get();
             }
 
             if ((v.storage_class & STC.manifest) && v._init)
@@ -3707,7 +3707,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 if (v.inuse)
                 {
                     e.error("circular initialization of %s `%s`", v.kind(), v.toPrettyChars());
-                    return new ErrorExp();
+                    return ErrorExp.get();
                 }
                 checkAccess(e.loc, sc, null, v);
                 Expression ve = new VarExp(e.loc, v);
@@ -3750,7 +3750,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 ti.dsymbolSemantic(sc);
                 if (!ti.inst || ti.errors) // if template failed to expand
                 {
-                    return new ErrorExp();
+                    return ErrorExp.get();
                 }
             }
             s = ti.inst.toAlias();
@@ -3783,7 +3783,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         if (!d)
         {
             e.error("`%s.%s` is not a declaration", e.toChars(), ident.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         if (e.op == TOK.type)
@@ -3855,7 +3855,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             else if (!(flag & 1))
             {
                 mt.sym.error("is forward referenced when looking for `%s`", ident.toChars());
-                e = new ErrorExp();
+                e = ErrorExp.get();
             }
             else
                 e = null;
@@ -3880,7 +3880,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                     e.error("no property `%s` for type `%s`", ident.toChars(),
                         mt.toChars());
 
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             return res;
         }
@@ -3983,7 +3983,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 if (!Type.typeinfoclass)
                 {
                     error(e.loc, "`object.TypeInfo_Class` could not be found, but is implicitly used");
-                    return new ErrorExp();
+                    return ErrorExp.get();
                 }
 
                 Type t = Type.typeinfoclass.type;
@@ -4125,11 +4125,11 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                     e.error("circular reference to %s `%s`", v.kind(), v.toPrettyChars());
                 else
                     e.error("forward reference to %s `%s`", v.kind(), v.toPrettyChars());
-                return new ErrorExp();
+                return ErrorExp.get();
             }
             if (v.type.ty == Terror)
             {
-                return new ErrorExp();
+                return ErrorExp.get();
             }
 
             if ((v.storage_class & STC.manifest) && v._init)
@@ -4137,7 +4137,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 if (v.inuse)
                 {
                     e.error("circular initialization of %s `%s`", v.kind(), v.toPrettyChars());
-                    return new ErrorExp();
+                    return ErrorExp.get();
                 }
                 checkAccess(e.loc, sc, null, v);
                 Expression ve = new VarExp(e.loc, v);
@@ -4178,7 +4178,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 ti.dsymbolSemantic(sc);
                 if (!ti.inst || ti.errors) // if template failed to expand
                 {
-                    return new ErrorExp();
+                    return ErrorExp.get();
                 }
             }
             s = ti.inst.toAlias();
@@ -4212,7 +4212,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         if (!d)
         {
             e.error("`%s.%s` is not a declaration", e.toChars(), ident.toChars());
-            return new ErrorExp();
+            return ErrorExp.get();
         }
 
         if (e.op == TOK.type)
@@ -4408,7 +4408,7 @@ Expression defaultInit(Type mt, const ref Loc loc)
 
         case Tvoid:
             error(loc, "`void` does not have a default initializer");
-            return new ErrorExp();
+            return ErrorExp.get();
 
         default:
             break;
@@ -4442,7 +4442,7 @@ Expression defaultInit(Type mt, const ref Loc loc)
     Expression visitFunction(TypeFunction mt)
     {
         error(loc, "`function` does not have a default initializer");
-        return new ErrorExp();
+        return ErrorExp.get();
     }
 
     Expression visitStruct(TypeStruct mt)
@@ -4504,7 +4504,7 @@ Expression defaultInit(Type mt, const ref Loc loc)
 
         case Tnull:     return new NullExp(Loc.initial, Type.tnull);
 
-        case Terror:    return new ErrorExp();
+        case Terror:    return ErrorExp.get();
 
         case Tarray:
         case Taarray:


### PR DESCRIPTION
```
There's no need to instantiate ErrorExp over and over.
In a typical library, ErrorExp is usually instantiated thousands of times
(because of typeof, __traits(compiles), constraints).
This can quickly go in the tens of thousands if the application is
metaprogramming-heavy. While ErrorExp is only 40 bytes,
it's a very low hangingg fruit in term of memory usagge,
and not reaching the GC is a new win.
```

Note, I measured the number of `ErrorExp` instantiations on a few projects before doing this.
My project (bpfkorea/agora) had 18725 ErrorExp instantiations.
Other projects, thanks to the `dub build`:
```
taggedalgebraic 0.11.8: building configuration "library"...
Instantiated 4 ErrorExp
eventcore 0.8.48: building configuration "kqueue"...
Instantiated 4280 ErrorExp
stdx-allocator 2.77.5: building configuration "library"...
Instantiated 317 ErrorExp
vibe-core 1.8.1: building configuration "kqueue"...
Instantiated 6031 ErrorExp
vibe-d:utils 0.9.0: building configuration "library"...
Instantiated 1482 ErrorExp
vibe-d:data 0.9.0: building configuration "library"...
Instantiated 3373 ErrorExp
mir-linux-kernel 1.0.1: building configuration "library"...
Instantiated 8 ErrorExp
vibe-d:crypto 0.9.0: building configuration "library"...
Instantiated 389 ErrorExp
diet-ng 1.6.1: building configuration "library"...
Instantiated 2380 ErrorExp
vibe-d:stream 0.9.0: building configuration "library"...
Instantiated 1425 ErrorExp
vibe-d:textfilter 0.9.0: building configuration "library"...
Instantiated 2040 ErrorExp
vibe-d:inet 0.9.0: building configuration "library"...
Instantiated 3202 ErrorExp
vibe-d:tls 0.9.0: building configuration "openssl"...
Instantiated 3512 ErrorExp
vibe-d:http 0.9.0: building configuration "library"...
Instantiated 9816 ErrorExp
vibe-d:mail 0.9.0: building configuration "library"...
Instantiated 1894 ErrorExp
vibe-d:mongodb 0.9.0: building configuration "library"...
Instantiated 5014 ErrorExp
vibe-d:redis 0.9.0: building configuration "library"...
Instantiated 3434 ErrorExp
vibe-d:web 0.9.0: building configuration "library"...
Instantiated 2967 ErrorExp
vibe-d 0.9.0: building configuration "vibe-d-test-vibe-core"...
Instantiated 10713 ErrorExp

d2sqlite3 ~master: building configuration "with-lib"...
Instantiated 2129 ErrorExp
tinyendian ~master: building configuration "library"...
Instantiated 52 ErrorExp
dyaml ~master: building configuration "library"...
Instantiated 6313 ErrorExp
localrest ~master: building configuration "library"...
Instantiated 1163 ErrorExp
```

I lost the exact numbers for druntime / Phobos but it was about 1.8k / 9k IIRC.
I checked the RSS / peak and other stats. It's not life changing but it's visible.