### PR TITLE
[critical bugfix] Increase size for temporary HID identifier

### DIFF
--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -912,15 +912,15 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         // If function returns a struct, put a pointer to that
         // as the first argument
         .type *thidden = Type_toCtype(tf.next.pointerTo());
-        char[5+4+1] hiddenparam = void;
-        __gshared int hiddenparami;    // how many we've generated so far
+        char[5 + 10 + 1] hiddenparam = void;
+        __gshared uint hiddenparami;    // how many we've generated so far
 
         const(char)* name;
         if (fd.nrvo_can && fd.nrvo_var)
             name = fd.nrvo_var.ident.toChars();
         else
         {
-            sprintf(hiddenparam.ptr, "__HID%d", ++hiddenparami);
+            sprintf(hiddenparam.ptr, "__HID%u", ++hiddenparami);
             name = hiddenparam.ptr;
         }
         shidden = symbol_name(name, SCparameter, thidden);


### PR DESCRIPTION
For hidden parameters, a unique identifier is generated within the backend
of the form __HID%d.
For that string "__HID".length + 4 + "\0".length bytes were allocated,
Making 9999 hidden parameters the highest number which could be used.
This change removes the assumption that there can be only 9999 hidden parameters.
And extends the buffer to the maximal number of 10 digits which is the maxmal number that can be represented with a 32bit unsinged integer.

@WalterBright @thewilsonator 