### PR TITLE
Fix 19210: Poor error message for `return` function parameter that is not `ref`

### DIFF
--- a/test/fail_compilation/dip25.d
+++ b/test/fail_compilation/dip25.d
@@ -2,7 +2,11 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/dip25.d(13): Deprecation: returning `this.buffer[]` escapes a reference to parameter `this`, perhaps annotate with `return`
+fail_compilation/dip25.d(17): Deprecation: returning `this.buffer[]` escapes a reference to parameter `this`
+fail_compilation/dip25.d(17):        perhaps annotate the parameter with `return`
+fail_compilation/dip25.d(22): Error: returning `identity(x)` escapes a reference to local variable `x`
+fail_compilation/dip25.d(23): Deprecation: returning `identity(x)` escapes a reference to parameter `x`
+fail_compilation/dip25.d(23):        perhaps annotate the parameter with `return`
 ---
 */
 struct Data
@@ -13,6 +17,10 @@ struct Data
         return buffer[];
     }
 }
+
+ref int identity(return ref int x) { return x; }
+ref int fun(return int x) { return identity(x); }
+ref int fun2(ref int x) { return identity(x); }
 
 void main()
 {

--- a/test/fail_compilation/fail13902.d
+++ b/test/fail_compilation/fail13902.d
@@ -54,14 +54,14 @@ int* testEscape1()
 TEST_OUTPUT:
 ---
 fail_compilation/fail13902.d(88): Error: Using the result of a comma expression is not allowed
-fail_compilation/fail13902.d(75): Error: returning `& x` escapes a reference to parameter `x`, perhaps annotate with `return`
-fail_compilation/fail13902.d(76): Error: returning `&s1.v` escapes a reference to parameter `s1`, perhaps annotate with `return`
-fail_compilation/fail13902.d(81): Error: returning `& sa1` escapes a reference to parameter `sa1`, perhaps annotate with `return`
-fail_compilation/fail13902.d(82): Error: returning `&sa2[0][0]` escapes a reference to parameter `sa2`, perhaps annotate with `return`
-fail_compilation/fail13902.d(83): Error: returning `& x` escapes a reference to parameter `x`, perhaps annotate with `return`
-fail_compilation/fail13902.d(84): Error: returning `(& x+4)` escapes a reference to parameter `x`, perhaps annotate with `return`
-fail_compilation/fail13902.d(85): Error: returning `& x + cast(long)x * 4L` escapes a reference to parameter `x`, perhaps annotate with `return`
-fail_compilation/fail13902.d(88): Error: returning `& y` escapes a reference to parameter `y`, perhaps annotate with `return`
+fail_compilation/fail13902.d(75): Error: returning `& x` escapes a reference to local variable `x`
+fail_compilation/fail13902.d(76): Error: returning `&s1.v` escapes a reference to local variable `s1`
+fail_compilation/fail13902.d(81): Error: returning `& sa1` escapes a reference to local variable `sa1`
+fail_compilation/fail13902.d(82): Error: returning `&sa2[0][0]` escapes a reference to local variable `sa2`
+fail_compilation/fail13902.d(83): Error: returning `& x` escapes a reference to local variable `x`
+fail_compilation/fail13902.d(84): Error: returning `(& x+4)` escapes a reference to local variable `x`
+fail_compilation/fail13902.d(85): Error: returning `& x + cast(long)x * 4L` escapes a reference to local variable `x`
+fail_compilation/fail13902.d(88): Error: returning `& y` escapes a reference to local variable `y`
 ---
 */
 int* testEscape2(
@@ -134,9 +134,9 @@ int* testEscape3(
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(150): Error: returning `cast(int[])sa1` escapes a reference to parameter `sa1`, perhaps annotate with `return`
-fail_compilation/fail13902.d(151): Error: returning `cast(int[])sa1` escapes a reference to parameter `sa1`, perhaps annotate with `return`
-fail_compilation/fail13902.d(152): Error: returning `sa1[]` escapes a reference to parameter `sa1`, perhaps annotate with `return`
+fail_compilation/fail13902.d(150): Error: returning `cast(int[])sa1` escapes a reference to local variable `sa1`
+fail_compilation/fail13902.d(151): Error: returning `cast(int[])sa1` escapes a reference to local variable `sa1`
+fail_compilation/fail13902.d(152): Error: returning `sa1[]` escapes a reference to local variable `sa1`
 fail_compilation/fail13902.d(155): Error: returning `cast(int[])sa2` escapes a reference to local variable `sa2`
 fail_compilation/fail13902.d(156): Error: returning `cast(int[])sa2` escapes a reference to local variable `sa2`
 fail_compilation/fail13902.d(157): Error: returning `sa2[]` escapes a reference to local variable `sa2`
@@ -223,14 +223,14 @@ ref int testEscapeRef1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(240): Error: returning `x` escapes a reference to parameter `x`, perhaps annotate with `return`
-fail_compilation/fail13902.d(241): Error: returning `s1.v` escapes a reference to parameter `s1`, perhaps annotate with `return`
-fail_compilation/fail13902.d(245): Error: returning `sa1[0]` escapes a reference to parameter `sa1`, perhaps annotate with `return`
-fail_compilation/fail13902.d(246): Error: returning `sa2[0][0]` escapes a reference to parameter `sa2`, perhaps annotate with `return`
-fail_compilation/fail13902.d(247): Error: returning `x = 1` escapes a reference to parameter `x`, perhaps annotate with `return`
-fail_compilation/fail13902.d(248): Error: returning `x += 1` escapes a reference to parameter `x`, perhaps annotate with `return`
-fail_compilation/fail13902.d(249): Error: returning `s1.v = 1` escapes a reference to parameter `s1`, perhaps annotate with `return`
-fail_compilation/fail13902.d(250): Error: returning `s1.v += 1` escapes a reference to parameter `s1`, perhaps annotate with `return`
+fail_compilation/fail13902.d(240): Error: returning `x` escapes a reference to local variable `x`
+fail_compilation/fail13902.d(241): Error: returning `s1.v` escapes a reference to local variable `s1`
+fail_compilation/fail13902.d(245): Error: returning `sa1[0]` escapes a reference to local variable `sa1`
+fail_compilation/fail13902.d(246): Error: returning `sa2[0][0]` escapes a reference to local variable `sa2`
+fail_compilation/fail13902.d(247): Error: returning `x = 1` escapes a reference to local variable `x`
+fail_compilation/fail13902.d(248): Error: returning `x += 1` escapes a reference to local variable `x`
+fail_compilation/fail13902.d(249): Error: returning `s1.v = 1` escapes a reference to local variable `s1`
+fail_compilation/fail13902.d(250): Error: returning `s1.v += 1` escapes a reference to local variable `s1`
 ---
 */
 ref int testEscapeRef2(
@@ -323,7 +323,8 @@ int[] testSlice2() { int[3] sa; int n; return sa[n..2][1..2]; }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(323): Error: returning `vda[0]` escapes a reference to parameter `vda`, perhaps annotate with `return`
+fail_compilation/fail13902.d(324): Error: returning `vda[0]` escapes a reference to parameter `vda`
+fail_compilation/fail13902.d(324):        perhaps annotate the parameter with `return`
 ---
 */
 ref int testDynamicArrayVariadic1(int[] vda...) { return vda[0]; }
@@ -333,8 +334,8 @@ int[3]  testDynamicArrayVariadic3(int[] vda...) { return vda[0..3]; }   // no er
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(334): Error: returning `vsa[0]` escapes a reference to parameter `vsa`, perhaps annotate with `return`
-fail_compilation/fail13902.d(335): Error: returning `vsa[]` escapes a reference to variadic parameter `vsa`
+fail_compilation/fail13902.d(335): Error: returning `vsa[0]` escapes a reference to local variable `vsa`
+fail_compilation/fail13902.d(336): Error: returning `vsa[]` escapes a reference to variadic parameter `vsa`
 ---
 */
 ref int testStaticArrayVariadic1(int[3] vsa...) { return vsa[0]; }

--- a/test/fail_compilation/fail20084.d
+++ b/test/fail_compilation/fail20084.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail20084.d(109): Error: returning `v.front()` escapes a reference to parameter `v`, perhaps annotate with `return`
+fail_compilation/fail20084.d(109): Error: returning `v.front()` escapes a reference to local variable `v`
 ---
 */
 

--- a/test/fail_compilation/fail20448.d
+++ b/test/fail_compilation/fail20448.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20448.d(16): Error: returning `p.x` escapes a reference to parameter `p`, perhaps annotate with `return`
+fail_compilation/fail20448.d(16): Error: returning `p.x` escapes a reference to local variable `p`
 fail_compilation/fail20448.d(22): Error: template instance `fail20448.member!"x"` error instantiating
 ---
 */

--- a/test/fail_compilation/fix18575.d
+++ b/test/fail_compilation/fix18575.d
@@ -1,10 +1,10 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fix18575.d(27): Error: returning `s.foo()` escapes a reference to parameter `s`, perhaps annotate with `return`
-fail_compilation/fix18575.d(31): Error: returning `s.foo()` escapes a reference to parameter `s`, perhaps annotate with `return`
-fail_compilation/fix18575.d(35): Error: returning `s.abc()` escapes a reference to parameter `s`, perhaps annotate with `return`
-fail_compilation/fix18575.d(39): Error: returning `s.ghi(t)` escapes a reference to parameter `t`, perhaps annotate with `return`
+fail_compilation/fix18575.d(27): Error: returning `s.foo()` escapes a reference to local variable `s`
+fail_compilation/fix18575.d(31): Error: returning `s.foo()` escapes a reference to local variable `s`
+fail_compilation/fix18575.d(35): Error: returning `s.abc()` escapes a reference to local variable `s`
+fail_compilation/fix18575.d(39): Error: returning `s.ghi(t)` escapes a reference to local variable `t`
 ---
 */
 

--- a/test/fail_compilation/test16589.d
+++ b/test/fail_compilation/test16589.d
@@ -2,18 +2,18 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test16589.d(26): Error: returning `&this.data` escapes a reference to parameter `this`, perhaps annotate with `return`
-fail_compilation/test16589.d(31): Error: returning `&this` escapes a reference to parameter `this`, perhaps annotate with `return`
-fail_compilation/test16589.d(37): Error: returning `&s.data` escapes a reference to parameter `s`, perhaps annotate with `return`
-fail_compilation/test16589.d(42): Error: returning `&s` escapes a reference to parameter `s`, perhaps annotate with `return`
-fail_compilation/test16589.d(47): Error: returning `&s.data` escapes a reference to parameter `s`, perhaps annotate with `return`
-fail_compilation/test16589.d(52): Error: returning `& s` escapes a reference to parameter `s`, perhaps annotate with `return`
+fail_compilation/test16589.d(26): Error: returning `&this.data` escapes a reference to parameter `this`
+fail_compilation/test16589.d(26):        perhaps annotate the parameter with `return`
+fail_compilation/test16589.d(31): Error: returning `&this` escapes a reference to parameter `this`
+fail_compilation/test16589.d(31):        perhaps annotate the parameter with `return`
+fail_compilation/test16589.d(37): Error: returning `&s.data` escapes a reference to parameter `s`
+fail_compilation/test16589.d(37):        perhaps annotate the parameter with `return`
+fail_compilation/test16589.d(42): Error: returning `&s` escapes a reference to parameter `s`
+fail_compilation/test16589.d(42):        perhaps annotate the parameter with `return`
+fail_compilation/test16589.d(47): Error: returning `&s.data` escapes a reference to local variable `s`
+fail_compilation/test16589.d(52): Error: returning `& s` escapes a reference to local variable `s`
 ---
 */
-
-
-
-
 
 // https://issues.dlang.org/show_bug.cgi?id=16589
 
@@ -61,5 +61,3 @@ class C
         return &data;
     }
 }
-
-

--- a/test/fail_compilation/test17450.d
+++ b/test/fail_compilation/test17450.d
@@ -2,8 +2,10 @@
 REQUIRED_ARGS: -preview=dip1000 -preview=dip25
 TEST_OUTPUT:
 ---
-fail_compilation/test17450.d(15): Error: returning `&s.bar` escapes a reference to parameter `s`, perhaps annotate with `return`
-fail_compilation/test17450.d(18): Error: returning `&this.bar` escapes a reference to parameter `this`, perhaps annotate with `return`
+fail_compilation/test17450.d(17): Error: returning `&s.bar` escapes a reference to parameter `s`
+fail_compilation/test17450.d(17):        perhaps annotate the parameter with `return`
+fail_compilation/test17450.d(20): Error: returning `&this.bar` escapes a reference to parameter `this`
+fail_compilation/test17450.d(20):        perhaps annotate the parameter with `return`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=17450


### PR DESCRIPTION
```
If the type does not have references, adding `return` won't help.
This we only suggest adding `return` when it actually has an effect.
In addition, value types parameter are now qualified of "local variable",
because that's what they are.
Last, when the error is on `this`, the message advise to annotate the function.
```