### PR TITLE
Enhance the implementation of anonymous identifiers

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -273,8 +273,6 @@ public:
     bool stack;                         // true if this is a scope class
     int cppDtorVtblIndex;               // slot reserved for the virtual destructor [extern(C++)]
     bool inuse;                         // to prevent recursive attempts
-    bool isActuallyAnonymous;           // true if this class has an identifier, but was originally declared anonymous
-                                        // used in support of https://issues.dlang.org/show_bug.cgi?id=17371
 
     Abstract isabstract;                // 0: fwdref, 1: is abstract class, 2: not abstract
     Baseok baseok;                      // set the progress of base classes resolving
@@ -289,7 +287,6 @@ public:
     #define OFFSET_RUNTIME 0x76543210
     #define OFFSET_FWDREF 0x76543211
     virtual bool isBaseOf(ClassDeclaration *cd, int *poffset);
-    bool isAnonymous();
 
     bool isBaseInfoComplete();
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -188,10 +188,6 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     /// to prevent recursive attempts
     private bool inuse;
 
-    /// true if this class has an identifier, but was originally declared anonymous
-    /// used in support of https://issues.dlang.org/show_bug.cgi?id=17371
-    private bool isActuallyAnonymous;
-
     Abstract isabstract;
 
     /// set the progress of base classes resolving
@@ -210,11 +206,9 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         objc = ObjcClassDeclaration(this);
 
         if (!id)
-        {
-            isActuallyAnonymous = true;
-        }
+            id = Identifier.generateAnonymousId("class");
 
-        super(loc, id ? id : Identifier.generateId("__anonclass"));
+        super(loc, id);
 
         __gshared const(char)* msg = "only object.d can define this reserved class name";
 
@@ -673,11 +667,6 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     final bool hasMonitor()
     {
         return classKind == ClassKind.d;
-    }
-
-    override bool isAnonymous()
-    {
-        return isActuallyAnonymous;
     }
 
     final bool isFuncHidden(FuncDeclaration fd)

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1127,17 +1127,14 @@ extern (C++) class VarDeclaration : Declaration
 
     VarDeclarations* maybes;        // STC.maybescope variables that are assigned to this STC.maybescope variable
 
-    private bool _isAnonymous;
-
     final extern (D) this(const ref Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.undefined_)
+    in
     {
-        if (ident is Identifier.anonymous)
-        {
-            ident = Identifier.generateId("__anonvar");
-            _isAnonymous = true;
-        }
-        //printf("VarDeclaration('%s')\n", ident.toChars());
         assert(ident);
+    }
+    do
+    {
+        //printf("VarDeclaration('%s')\n", ident.toChars());
         super(loc, ident);
         debug
         {
@@ -1284,11 +1281,6 @@ extern (C++) class VarDeclaration : Declaration
     {
         //printf("VarDeclaration::needThis(%s, x%x)\n", toChars(), storage_class);
         return isField();
-    }
-
-    override final bool isAnonymous()
-    {
-        return _isAnonymous;
     }
 
     override final bool isExport() const

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -237,9 +237,6 @@ public:
 
     VarDeclarations *maybes;    // STCmaybescope variables that are assigned to this STCmaybescope variable
 
-private:
-    bool _isAnonymous;
-
 public:
     static VarDeclaration *create(const Loc &loc, Type *t, Identifier *id, Initializer *init, StorageClass storage_class = STCundefined);
     Dsymbol *syntaxCopy(Dsymbol *);
@@ -247,7 +244,6 @@ public:
     const char *kind() const;
     AggregateDeclaration *isThis();
     bool needThis();
-    bool isAnonymous();
     bool isExport() const;
     bool isImportedSymbol() const;
     bool isDataseg();

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -307,9 +307,9 @@ extern (C++) class Dsymbol : ASTNode
         return false;
     }
 
-    bool isAnonymous()
+    final bool isAnonymous() const
     {
-        return ident is null;
+        return ident is null || ident.isAnonymous;
     }
 
     extern(D) private const(char)[] prettyFormatHelper()

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -165,7 +165,7 @@ public:
     Loc getLoc();
     const char *locToChars();
     bool equals(const RootObject *o) const;
-    virtual bool isAnonymous();
+    bool isAnonymous() const;
     void error(const Loc &loc, const char *format, ...);
     void error(const char *format, ...);
     void deprecation(const Loc &loc, const char *format, ...);

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -17,17 +17,19 @@ class Identifier : public RootObject
 {
 private:
     int value;
+    bool isAnonymous_;
     DString string;
 
 public:
-    static Identifier* anonymous();
     static Identifier* create(const char *string);
     bool equals(const RootObject *o) const;
     const char *toChars() const;
     int getValue() const;
+    bool isAnonymous() const;
     const char *toHChars2() const;
     DYNCAST dyncast() const;
 
+    static Identifier *generateId(const char *prefix, size_t length, size_t suffix);
     static Identifier *idPool(const char *s, unsigned len);
 
     static inline Identifier *idPool(const char *s)

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -634,7 +634,8 @@ extern(C++) private final class Supported : Objc
         if (!fd.selector)
             return null;
 
-        auto var = new VarDeclaration(fd.loc, Type.tvoidptr, Identifier.anonymous, null);
+        auto ident = Identifier.generateAnonymousId("_cmd");
+        auto var = new VarDeclaration(fd.loc, Type.tvoidptr, ident, null);
         var.storage_class |= STC.parameter;
         var.dsymbolSemantic(sc);
         if (!sc.insert(var))
@@ -646,9 +647,10 @@ extern(C++) private final class Supported : Objc
 
     override void setMetaclass(InterfaceDeclaration interfaceDeclaration, Scope* sc) const
     {
-        static auto newMetaclass(Loc loc, BaseClasses* metaBases)
+        auto newMetaclass(Loc loc, BaseClasses* metaBases)
         {
-            return new InterfaceDeclaration(loc, null, metaBases);
+            auto ident = createMetaclassIdentifier(interfaceDeclaration);
+            return new InterfaceDeclaration(loc, ident, metaBases);
         }
 
         .setMetaclass!newMetaclass(interfaceDeclaration, sc);
@@ -658,7 +660,8 @@ extern(C++) private final class Supported : Objc
     {
         auto newMetaclass(Loc loc, BaseClasses* metaBases)
         {
-            return new ClassDeclaration(loc, null, metaBases, new Dsymbols(), 0);
+            auto ident = createMetaclassIdentifier(classDeclaration);
+            return new ClassDeclaration(loc, ident, metaBases, new Dsymbols(), 0);
         }
 
         .setMetaclass!newMetaclass(classDeclaration, sc);
@@ -797,4 +800,10 @@ if (is(T == ClassDeclaration) || is(T == InterfaceDeclaration))
 
         objc.metaclass.dsymbolSemantic(sc);
     }
+}
+
+private Identifier createMetaclassIdentifier(ClassDeclaration classDeclaration)
+{
+    const name = "class_" ~ classDeclaration.ident.toString ~ "_Meta";
+    return Identifier.generateAnonymousId(name);
 }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -4290,7 +4290,7 @@ void catchSemantic(Catch c, Scope* sc)
         // DIP1008 requires destruction of the Throwable, even if the user didn't specify an identifier
         auto ident = c.ident;
         if (!ident && global.params.ehnogc)
-            ident = Identifier.anonymous();
+            ident = Identifier.generateAnonymousId("var");
 
         if (ident)
         {


### PR DESCRIPTION
The main motivation is to allow using recognizable names for anonymous identifiers, for debugging purpose.

This also simplifies the implementation by only having one implementation.
