### PR TITLE
Add `-gdwarf=<version>` compiler switch

### DIFF
--- a/changelog/dwarf-switch.dd
+++ b/changelog/dwarf-switch.dd
@@ -1,0 +1,8 @@
+Add `-gdwarf=<version>` switch for the DMD compiler.
+
+Emit DWARF symbolic debug info (non-Windows machines only).
+Supported versions are 3, 4, and 5.
+
+Once added, the `-g` switch is implicitly activated.
+
+Note: DWARF Version 5 is experimental.

--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -54,6 +54,7 @@ extern (C) void out_config_init(
         bool useModuleInfo,     // implement ModuleInfo
         bool useTypeInfo,       // implement TypeInfo
         bool useExceptions,     // implement exception handling
+        ubyte dwarf,            // DWARF version used
         string _version         // Compiler version
         )
 {
@@ -74,6 +75,23 @@ version (MARS)
     tytab[TYchar] |= TYFLuns;
     bool mscoff = model & 1;
     model &= 32 | 64;
+
+    if (dwarf < 3 || dwarf > 5)
+    {
+        if (dwarf)
+        {
+            import dmd.backend.errors;
+            error(null, 0, 0, "DWARF version %u is not supported", dwarf);
+        }
+
+        // Default DWARF version
+        config.dwarf = 3;
+    }
+    else
+    {
+        config.dwarf = dwarf;
+    }
+
 static if (TARGET_WINDOS)
 {
     if (model == 64)

--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -762,6 +762,7 @@ struct Config
     bool useModuleInfo;         // implement ModuleInfo
     bool useTypeInfo;           // implement TypeInfo
     bool useExceptions;         // implement exception handling
+    ubyte dwarf;                // DWARF version
 }
 
 enum THRESHMAX = 0xFFFF;

--- a/src/dmd/backend/dwarf.d
+++ b/src/dmd/backend/dwarf.d
@@ -16,8 +16,6 @@ extern (C++):
 
 nothrow:
 
-enum DWARF_VERSION = 3;
-
 void dwarf_initfile(const(char) *filename);
 void dwarf_termfile();
 void dwarf_initmodule(const(char) *filename, const(char) *modulename);

--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -1605,7 +1605,7 @@ static if (1)
         }
         abuf.writeByte(DW_AT_name);      abuf.writeByte(DW_FORM_string);
 
-        static if (DWARF_VERSION >= 4)
+        if (config.dwarf >= 4)
             abuf.writeuLEB128(DW_AT_linkage_name);
         else
             abuf.writeuLEB128(DW_AT_MIPS_linkage_name);
@@ -1624,7 +1624,7 @@ static if (1)
         if (sfunc.Sfunc.Fflags3 & Fpure)
         {
             abuf.writeByte(DW_AT_pure);
-            static if (DWARF_VERSION >= 4)
+            if (config.dwarf >= 4)
                 abuf.writeByte(DW_FORM_flag_present);
             else
                 abuf.writeByte(DW_FORM_flag);
@@ -1660,11 +1660,8 @@ static if (1)
         if (sfunc.Sclass == SCglobal)
             debug_info.buf.writeByte(1);              // DW_AT_external
 
-        static if (DWARF_VERSION < 4)
-        {
-            if (sfunc.Sfunc.Fflags3 & Fpure)
-                debug_info.buf.writeByte(true);         // DW_AT_pure
-        }
+        if (config.dwarf < 4 && sfunc.Sfunc.Fflags3 & Fpure)
+            debug_info.buf.writeByte(true);           // DW_AT_pure
 
         // DW_AT_low_pc and DW_AT_high_pc
         dwarf_appreladdr(debug_info.seg, debug_info.buf, seg, funcoffset);

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -352,10 +352,15 @@ dmd -cov -unittest myprog.d
                 $(LINK2 http://dlang.org/windbg.html, Debugging on Windows).
             )
             $(UNIX
-                Add symbolic debug info in Dwarf format
+                Add symbolic debug info in DWARF format
                 for debuggers such as
                 $(D gdb)
             )`,
+        ),
+        Option("gdwarf=<version>",
+            "add DWARF symbolic debug info",
+            "The value of version may be 3, 4 or 5, defaulting to 3.",
+            cast(TargetOS) (TargetOS.all & ~cast(uint)TargetOS.Windows)
         ),
         Option("gf",
             "emit debug info for all referenced types",
@@ -925,4 +930,13 @@ struct CLIUsage
   =silent               Silently ignore non-exern(C[++]) declarations
   =verbose              Add a comment for ignored non-exern(C[++]) declarations
 ";
+
+    /// Options supported by -gdwarf
+    enum gdwarfUsage = "Available DWARF versions:
+  =[h|help|?]           List information on choices
+  =3                    Emit DWARF version 3 debug information
+  =4                    Emit DWARF version 4 debug information
+  =5                    Emit DWARF version 5 debug information
+";
+
 }

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -51,6 +51,7 @@ extern (C) void out_config_init(
         bool useModuleInfo,     // implement ModuleInfo
         bool useTypeInfo,       // implement TypeInfo
         bool useExceptions,     // implement exception handling
+        ubyte dwarf,            // DWARF version used
         string _version         // Compiler version
         );
 
@@ -101,6 +102,7 @@ void backend_init()
         params.useModuleInfo && Module.moduleinfo,
         params.useTypeInfo && Type.dtypeinfo,
         params.useExceptions && ClassDeclaration.throwable,
+        dmdParams.dwarf,
         global.versionString()
     );
 


### PR DESCRIPTION
This would allow us to emit DWARF v5 code as experimental https://github.com/dlang/dmd/pull/11426.

Ping @ibuclaw 