### PR TITLE
Fix Issue 20911 - Documentation for test/unit is non-existant

### DIFF
--- a/test/unit/compilable/crlf.d
+++ b/test/unit/compilable/crlf.d
@@ -1,3 +1,5 @@
+// See ../../README.md for information about DMD unit tests.
+
 module compilable.crlf;
 
 import support : afterEach, beforeEach, defaultImportPaths;

--- a/test/unit/deinitialization.d
+++ b/test/unit/deinitialization.d
@@ -1,3 +1,5 @@
+// See ../README.md for information about DMD unit tests.
+
 module deinitialization;
 
 @("global.deinitialize")

--- a/test/unit/frontend.d
+++ b/test/unit/frontend.d
@@ -1,3 +1,5 @@
+// See ../README.md for information about DMD unit tests.
+
 module frontend;
 
 import support : afterEach, defaultImportPaths;

--- a/test/unit/interfaces/check_implementations_20861.d
+++ b/test/unit/interfaces/check_implementations_20861.d
@@ -1,3 +1,5 @@
+// See ../../README.md for information about DMD unit tests.
+
 /**
  * Test cases for issue [20861][1].
  *

--- a/test/unit/lexer/diagnostic_reporter.d
+++ b/test/unit/lexer/diagnostic_reporter.d
@@ -1,3 +1,5 @@
+// See ../../README.md for information about DMD unit tests.
+
 module lexer.diagnostic_reporter;
 
 import core.stdc.stdarg;

--- a/test/unit/parser/diagnostic_reporter.d
+++ b/test/unit/parser/diagnostic_reporter.d
@@ -1,3 +1,5 @@
+// See ../../README.md for information about DMD unit tests.
+
 module parser.diagnostic_reporter;
 
 import core.stdc.stdarg;

--- a/test/unit/self_test.d
+++ b/test/unit/self_test.d
@@ -1,3 +1,5 @@
+// See ../README.md for information about DMD unit tests.
+
 module self_test;
 
 import support : afterEach, beforeEach, defaultImportPaths;

--- a/test/unit/support.d
+++ b/test/unit/support.d
@@ -1,3 +1,5 @@
+// See ../README.md for information about DMD unit tests.
+
 module support;
 
 import core.stdc.stdarg : va_list;


### PR DESCRIPTION
Add a short comment at the top of each file describing where to find the documentation on how to author and run DMD unit tests.