### PR TITLE
Fix Issue 21117 - When compiler segfaults running autotester, cannot …

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -185,17 +185,19 @@ Options:
             writefln("================================================================================");
         }
 
-        int ret;
+        bool failed;
         ensureToolsExists(env, EnumMembers!TestTools);
         foreach (target; parallel(targets, 1))
         {
             log("run: %-(%s %)", target.args);
             int status = spawnProcess(target.args, env, Config.none, scriptDir).wait;
-            if (status)
+            if (status != 0)
+            {
                 writefln(">>> TARGET FAILED: ", target.filename);
-            ret |= status;
+                failed = true;
+            }
         }
-        if (ret)
+        if (failed)
             return 1;
     }
 

--- a/test/run.d
+++ b/test/run.d
@@ -190,7 +190,10 @@ Options:
         foreach (target; parallel(targets, 1))
         {
             log("run: %-(%s %)", target.args);
-            ret |= spawnProcess(target.args, env, Config.none, scriptDir).wait;
+            int status = spawnProcess(target.args, env, Config.none, scriptDir).wait;
+            if (status)
+                writefln(">>> TARGET FAILED: ", target.filename);
+            ret |= status;
         }
         if (ret)
             return 1;


### PR DESCRIPTION
…tell which file it was testing

Be loud and obvious about which targets fail, regardless of configured
verbosity.