### PR TITLE
Use .NOTPARALLEL in posix.mak instead of lockfiles in build.d

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -76,3 +76,8 @@ style:
 	$(QUIET)$(MAKE) -C src -f posix.mak style
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)
+
+# Dont run targets in parallel because this makefile is just a thin wrapper
+# for build.d and multiple invocations might stomp on each other.
+# (build.d employs it's own parallelization)
+.NOTPARALLEL:

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -92,8 +92,7 @@ ifeq (,$(HOST_DMD_PATH))
 endif
 HOST_DMD_RUN:=$(HOST_DMD)
 
-RUN_BUILD = $(GENERATED)/build HOST_DMD="$(HOST_DMD)" CXX="$(HOST_CXX)" OS=$(OS) BUILD=$(BUILD) MODEL=$(MODEL) AUTO_BOOTSTRAP="$(AUTO_BOOTSTRAP)" DOCDIR="$(DOCDIR)" STDDOC="$(STDDOC)" DOC_OUTPUT_DIR="$(DOC_OUTPUT_DIR)" MAKE="$(MAKE)" --called-from-make
-
+RUN_BUILD = $(GENERATED)/build HOST_DMD="$(HOST_DMD)" CXX="$(HOST_CXX)" OS=$(OS) BUILD=$(BUILD) MODEL=$(MODEL) AUTO_BOOTSTRAP="$(AUTO_BOOTSTRAP)" DOCDIR="$(DOCDIR)" STDDOC="$(STDDOC)" DOC_OUTPUT_DIR="$(DOC_OUTPUT_DIR)" MAKE="$(MAKE)"
 ######## Begin build targets
 
 all: dmd
@@ -199,5 +198,10 @@ endif
 ######################################################
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)
+
+# Dont run targets in parallel because this makefile is just a thin wrapper
+# for build.d and multiple invocations might stomp on each other.
+# (build.d employs it's own parallelization)
+.NOTPARALLEL:
 
 endif


### PR DESCRIPTION
They achieve the same behaviour as `posix.mak` simply forwards to `build.d`.

This is a workaround for https://issues.dlang.org/show_bug.cgi?id=20999
which seems to be caused by some local library based on these observations:

- the failure is restricted to the macair host, no failures
  on D-Autotester.local
- the failure happens upon the second invocation of `build.d`
- removing `--called-from-make` makes the errror disappear.
  This switch enables a lockfile (`generated/build.lock`) which ensures
  that mutliple instances of build.d are run mutually exclusive (this
  was required during the `make` -> `build.d` transition but is obsolete now)