### PR TITLE
WIP fix issue 14835: silence unreachable code warnings caused by conditional compilation

### DIFF
--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1435,17 +1435,15 @@ extern (C++) final class ConditionalStatement : Statement
         //printf("ConditionalStatement::flatten()\n");
         if (condition.include(sc))
         {
+            s = new DebugStatement(loc, ifbody);
             DebugCondition dc = condition.isDebugCondition();
             if (dc)
             {
-                s = new DebugStatement(loc, ifbody);
                 debugThrowWalker(ifbody);
             }
-            else
-                s = ifbody;
         }
         else
-            s = elsebody;
+            s = new DebugStatement(loc, elsebody);
 
         auto a = new Statements();
         a.push(s);
@@ -1842,6 +1840,7 @@ extern (C++) final class ReturnStatement : Statement
 {
     Expression exp;
     size_t caseDim;
+    bool inStaticIf = false;
 
     extern (D) this(const ref Loc loc, Expression exp)
     {

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -524,7 +524,7 @@ class ReturnStatement : public Statement
 public:
     Expression *exp;
     size_t caseDim;
-
+    bool inStaticIf;
     Statement *syntaxCopy();
 
     ReturnStatement *endsWithReturnStatement() { return this; }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3133,6 +3133,9 @@ else
             errors = true;
         }
 
+        if (sc.flags & SCOPE.debug_)
+            rs.inStaticIf = true;
+
         if (fd.isCtorDeclaration())
         {
             if (rs.exp)

--- a/test/compilable/test14835.d
+++ b/test/compilable/test14835.d
@@ -1,0 +1,18 @@
+//REQUIRED_ARGS: -w
+template naiveAllInts(T...)
+{
+    auto fun()
+    {
+        static foreach(U; T)
+        {
+            static if (is(U : int))
+                return false;
+        }
+        return true;
+    }
+    alias naiveAllInts = fun;
+}
+
+alias string = immutable(char)[];
+enum b = naiveAllInts!(float, string);
+enum a = naiveAllInts!(int,string);


### PR DESCRIPTION
My strategy was to attach extra info to ReturnStatements indicating whether or not they were conditionally compiled.  

Then, I take this into account in blockExit.visit(ReturnStatement) and blockExit.visit(CompoundStatement).  

My test case compiles without warning, but Druntime won't build, with errors in core/demangle.d .  My suspicion is that somehow I broke attribute inference, but I have no idea how.  Any suggestions on what I should try to fix this?