### PR TITLE
Remove unused STC.tls

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6598,7 +6598,6 @@ struct ASTBase
             SCstring(STC.pure_, Token.toString(TOK.pure_)),
             SCstring(STC.ref_, Token.toString(TOK.ref_)),
             SCstring(STC.return_, Token.toString(TOK.return_)),
-            SCstring(STC.tls, "__thread"),
             SCstring(STC.gshared, Token.toString(TOK.gshared)),
             SCstring(STC.nogc, "@nogc"),
             SCstring(STC.live, "@live"),

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -247,12 +247,12 @@ extern (C++) class StorageClassDeclaration : AttribDeclaration
          */
         if (stc & (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.manifest))
             scstc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.manifest);
-        if (stc & (STC.auto_ | STC.scope_ | STC.static_ | STC.tls | STC.manifest | STC.gshared))
-            scstc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.tls | STC.manifest | STC.gshared);
+        if (stc & (STC.auto_ | STC.scope_ | STC.static_ | STC.manifest | STC.gshared))
+            scstc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.manifest | STC.gshared);
         if (stc & (STC.const_ | STC.immutable_ | STC.manifest))
             scstc &= ~(STC.const_ | STC.immutable_ | STC.manifest);
-        if (stc & (STC.gshared | STC.shared_ | STC.tls))
-            scstc &= ~(STC.gshared | STC.shared_ | STC.tls);
+        if (stc & (STC.gshared | STC.shared_))
+            scstc &= ~(STC.gshared | STC.shared_);
         if (stc & (STC.safe | STC.trusted | STC.system))
             scstc &= ~(STC.safe | STC.trusted | STC.system);
         scstc |= stc;

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -246,7 +246,7 @@ private CT Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNotThrow)
         if (vd.storage_class & STC.manifest)
         {
         }
-        else if (vd.isStatic() || vd.storage_class & (STC.extern_ | STC.tls | STC.gshared))
+        else if (vd.isStatic() || vd.storage_class & (STC.extern_ | STC.gshared))
         {
         }
         else

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1141,7 +1141,7 @@ extern (C++) class VarDeclaration : Declaration
 
         if (!isField())
             return;
-        assert(!(storage_class & (STC.static_ | STC.extern_ | STC.parameter | STC.tls)));
+        assert(!(storage_class & (STC.static_ | STC.extern_ | STC.parameter)));
 
         //printf("+VarDeclaration::setFieldOffset(ad = %s) %s\n", ad.toChars(), toChars());
 
@@ -1217,7 +1217,7 @@ extern (C++) class VarDeclaration : Declaration
 
     override final inout(AggregateDeclaration) isThis() inout
     {
-        if (!(storage_class & (STC.static_ | STC.extern_ | STC.manifest | STC.templateparameter | STC.tls | STC.gshared | STC.ctfe)))
+        if (!(storage_class & (STC.static_ | STC.extern_ | STC.manifest | STC.templateparameter | STC.gshared | STC.ctfe)))
         {
             /* The casting is necessary because `s = s.parent` is otherwise rejected
              */
@@ -1285,7 +1285,7 @@ extern (C++) class VarDeclaration : Declaration
                 error("forward referenced");
                 type = Type.terror;
             }
-            else if (storage_class & (STC.static_ | STC.extern_ | STC.tls | STC.gshared) ||
+            else if (storage_class & (STC.static_ | STC.extern_ | STC.gshared) ||
                 parent.isModule() || parent.isTemplateInstance() || parent.isNspace())
             {
                 assert(!isParameter() && !isResult());

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -71,7 +71,6 @@ struct IntRange;
     #define STCnodtor             0x10000000ULL    /// do not run destructor
     #define STCnothrow            0x20000000ULL    /// `nothrow` meaning never throws exceptions
     #define STCpure               0x40000000ULL    /// `pure` function
-    #define STCtls                0x80000000ULL    /// thread local
 
     #define STCalias              0x100000000ULL    /// `alias` parameter
     #define STCshared             0x200000000ULL    /// accessible from multiple threads

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -716,7 +716,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (dsym.storage_class & STC.scope_)
         {
-            StorageClass stc = dsym.storage_class & (STC.static_ | STC.extern_ | STC.manifest | STC.tls | STC.gshared);
+            StorageClass stc = dsym.storage_class & (STC.static_ | STC.extern_ | STC.manifest | STC.gshared);
             if (stc)
             {
                 OutBuffer buf;
@@ -733,7 +733,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        if (dsym.storage_class & (STC.static_ | STC.extern_ | STC.manifest | STC.templateparameter | STC.tls | STC.gshared | STC.ctfe))
+        if (dsym.storage_class & (STC.static_ | STC.extern_ | STC.manifest | STC.templateparameter | STC.gshared | STC.ctfe))
         {
         }
         else
@@ -794,7 +794,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (dsym.type.hasWild())
         {
-            if (dsym.storage_class & (STC.static_ | STC.extern_ | STC.tls | STC.gshared | STC.manifest | STC.field) || dsym.isDataseg())
+            if (dsym.storage_class & (STC.static_ | STC.extern_ | STC.gshared | STC.manifest | STC.field) || dsym.isDataseg())
             {
                 dsym.error("only parameters or stack based variables can be `inout`");
             }
@@ -841,7 +841,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         FuncDeclaration fd = parent.isFuncDeclaration();
         if (dsym.type.isscope() && !(dsym.storage_class & STC.nodtor))
         {
-            if (dsym.storage_class & (STC.field | STC.out_ | STC.ref_ | STC.static_ | STC.manifest | STC.tls | STC.gshared) || !fd)
+            if (dsym.storage_class & (STC.field | STC.out_ | STC.ref_ | STC.static_ | STC.manifest | STC.gshared) || !fd)
             {
                 dsym.error("globals, statics, fields, manifest constants, ref and out parameters cannot be `scope`");
             }
@@ -871,7 +871,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 }
             }
             else if (!dsym._init &&
-                     !(dsym.storage_class & (STC.static_ | STC.extern_ | STC.tls | STC.gshared | STC.manifest | STC.field | STC.parameter)) &&
+                     !(dsym.storage_class & (STC.static_ | STC.extern_ | STC.gshared | STC.manifest | STC.field | STC.parameter)) &&
                      dsym.type.hasVoidInitPointers())
             {
                 if (sc.func.setUnsafe())
@@ -977,7 +977,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 // If local variable, use AssignExp to handle all the various
                 // possibilities.
-                if (fd && !(dsym.storage_class & (STC.manifest | STC.static_ | STC.tls | STC.gshared | STC.extern_)) && !dsym._init.isVoidInitializer())
+                if (fd && !(dsym.storage_class & (STC.manifest | STC.static_ | STC.gshared | STC.extern_)) && !dsym._init.isVoidInitializer())
                 {
                     //printf("fd = '%s', var = '%s'\n", fd.toChars(), toChars());
                     if (!ei)
@@ -1476,7 +1476,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (scd.decl)
         {
             sc = sc.push();
-            sc.stc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.tls | STC.gshared);
+            sc.stc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.gshared);
             sc.inunion = scd.isunion ? scd : null;
             sc.flags = 0;
             for (size_t i = 0; i < scd.decl.dim; i++)

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -940,17 +940,12 @@ public:
             return;
         }
 
-        if (vd.storage_class & (AST.STC.static_ | AST.STC.extern_ | AST.STC.tls | AST.STC.gshared) ||
+        if (vd.storage_class & (AST.STC.static_ | AST.STC.extern_ | AST.STC.gshared) ||
         vd.parent && vd.parent.isModule())
         {
             if (vd.linkage != LINK.c && vd.linkage != LINK.cpp && !(tdparent && (this.linkage == LINK.c || this.linkage == LINK.cpp)))
             {
                 ignored("variable %s because of linkage", vd.toPrettyChars());
-                return;
-            }
-            if (vd.storage_class & AST.STC.tls)
-            {
-                ignored("variable %s because of thread-local storage", vd.toPrettyChars());
                 return;
             }
             if (!isSupportedType(type))

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5937,9 +5937,6 @@ elem *sarray_toDarray(const ref Loc loc, Type tfrom, Type tto, elem *e)
     return e;
 }
 
-/************************************
- */
-
 elem *getTypeInfo(Loc loc, Type t, IRState *irs)
 {
     assert(t.ty != Terror);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8246,6 +8246,8 @@ struct Id final
     static Identifier* core;
     static Identifier* etc;
     static Identifier* attribute;
+    static Identifier* atomic;
+    static Identifier* atomicOp;
     static Identifier* math;
     static Identifier* sin;
     static Identifier* cos;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2843,7 +2843,6 @@ string stcToString(ref StorageClass stc)
         SCstring(STC.pure_, Token.toString(TOK.pure_)),
         SCstring(STC.ref_, Token.toString(TOK.ref_)),
         SCstring(STC.return_, Token.toString(TOK.return_)),
-        SCstring(STC.tls, "__thread"),
         SCstring(STC.gshared, Token.toString(TOK.gshared)),
         SCstring(STC.nogc, "@nogc"),
         SCstring(STC.live, "@live"),

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -360,6 +360,8 @@ immutable Msgtable[] msgtable =
     { "core" },
     { "etc" },
     { "attribute" },
+    { "atomic" },
+    { "atomicOp" },
     { "math" },
     { "sin" },
     { "cos" },

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -2317,7 +2317,7 @@ private bool expNeedsDtor(Expression exp)
                 s = s.toAlias();
                 if (s != vd)
                     return Dsymbol_needsDtor(s);
-                else if (vd.isStatic() || vd.storage_class & (STC.extern_ | STC.tls | STC.gshared | STC.manifest))
+                else if (vd.isStatic() || vd.storage_class & (STC.extern_ | STC.gshared | STC.manifest))
                     return;
                 if (vd.needsScopeDtor())
                 {

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1263,7 +1263,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         }
 
         checkConflictSTCGroup(STC.const_ | STC.immutable_ | STC.manifest);
-        checkConflictSTCGroup(STC.gshared | STC.shared_ | STC.tls);
+        checkConflictSTCGroup(STC.gshared | STC.shared_);
         checkConflictSTCGroup!true(STC.safeGroup);
 
         return orig;
@@ -9599,5 +9599,3 @@ private bool writeMixin(const(char)[] s, ref Loc loc)
 
     return true;
 }
-
-


### PR DESCRIPTION
```
STC.tls was originally set on __thread variables.
However, __thread was removed from the language in 2013
(20ef96fe1d5c1631f5aead01873f17ca85cc944b),
as TLS was made the default for global variables.
The STC was however left in place, but was only ever set
in one place: for the gate in [shared] static {c,d}tors.
However, this was likely to be an accident, and it also looks wrong:
the gate for shared static {c,d}tor was static (which is TLS),
while the gate for non-shared module {c,d}tors was STC.tls,
which had no effect (so it was effectively a local variable).

However, that bug was not visible, thanks to the glue layer,
which has special handling of gate variables, essentially
ignoring the STC.
```