### PR TITLE
fix Issue 20162 - Sign Extension for ?: optimization done wrong

### DIFF
--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -2293,8 +2293,6 @@ void cdcond(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     regm_t psw = *pretregs & mPSW;               /* save PSW bit                 */
     const op1 = e1.Eoper;
     uint sz1 = tysize(e1.Ety);
-    uint rex = (I64 && sz1 == 8) ? REX_W : 0;
-    uint grex = rex << 16;
     uint jop = jmpopcode(e1);
 
     uint jop1 = jmpopcode(e21);
@@ -2341,6 +2339,10 @@ void cdcond(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         e22.Eoper == OPconst
        )
     {
+        uint sz = tysize(e.Ety);
+        uint rex = (I64 && sz == 8) ? REX_W : 0;
+        uint grex = rex << 16;
+
         regm_t retregs;
         targ_size_t v1,v2;
 
@@ -2357,7 +2359,7 @@ void cdcond(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                 retregs = BYTEREGS;
         }
 
-        cdcmp_flag = 1;
+        cdcmp_flag = 1 | rex;
         v1 = cast(targ_size_t)e21.EV.Vllong;
         v2 = cast(targ_size_t)e22.EV.Vllong;
         if (jop == JNC)

--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -3140,8 +3140,8 @@ L3:
             {
                 getregs(cdb,retregs);
                 genregs(cdb,0x19,reg,reg);     // SBB reg,reg
-                if (rex)
-                    code_orrex(cdb.last(), rex);
+                if (rex || flag & REX_W)
+                    code_orrex(cdb.last(), REX_W);
                 if (flag)
                 { }                                         // cdcond() will handle it
                 else if (jop == JNC)

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -638,14 +638,14 @@ void testfastdiv()
 
     static foreach (T; tuple!(int, long, uint, ulong))
     {{
-	T u = 10000;
-	T r;
-	static foreach (C; tuple!(10, 14, 14007, -10, -14, -14007))
-	{
-	    r = divC!C(u);     assert(r == u / (z + C));
-	    r = modC!C(u);     assert(r == u % (z + C));
-	    r = remquoC!C(u);  assert(r == ((u / (z + C) | (u % (z + C)))));
-	}
+        T u = 10000;
+        T r;
+        static foreach (C; tuple!(10, 14, 14007, -10, -14, -14007))
+        {
+            r = divC!C(u);     assert(r == u / (z + C));
+            r = modC!C(u);     assert(r == u % (z + C));
+            r = remquoC!C(u);  assert(r == ((u / (z + C) | (u % (z + C)))));
+        }
     }}
 }
 
@@ -2021,6 +2021,51 @@ void testrolror()
 
 ////////////////////////////////////////////////////////////////////////
 
+// https://issues.dlang.org/show_bug.cgi?id=20162
+
+void test20162()
+{
+    static long f(long a)
+    {
+         assert(a == -1L);
+         return a;
+    }
+
+    foreach (i; 1 .. 2)
+    {
+        foreach (j; 0 .. 2)
+        {
+            printf("%d %d %llx\n", i,
+              ((i != 0) ? -1 : +1),
+              f((i != 0) ? -1 : +1));
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void testsbbrex()
+{
+    // special code is generated for these two cases
+    static long foolt(dchar c)
+    {
+	return c < 0x10000 ? 1 : 2;
+    }
+
+    static long fooge(uint c)
+    {
+	return c >= 0x10000 ? 1L : 2L;
+    }
+
+    assert(foolt(0) == 1);
+    assert(foolt(0x10000) == 2);
+    assert(fooge(0) == 2);
+    assert(fooge(0x10000) == 1);
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
 // Some tests for OPmemcpy
 
 enum N = 128;
@@ -2205,6 +2250,8 @@ int main()
     test7();
     testbyteswap();
     testrolror();
+    test20162();
+    testsbbrex();
     testmemcpy();
     testMulLea();
     testMulAssPair();


### PR DESCRIPTION
The problem was the REX_W bit was set incorrectly for sign extension. It should be set based on e.Ety rather than e1.Ety.

Some of the diffs in mars1.d are due to converting tabs to spaces.