### PR TITLE
Bump host compiler for Azure Win64

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
       vmImage: 'vs2017-win2016'
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
-      HOST_DMD_VERSION: 2.084.1
+      HOST_DMD_VERSION: 2.092.1
     strategy:
       matrix:
         x64:


### PR DESCRIPTION
Current master seems to trigger an already fixed bug in the host compiler.
(Obviously not an ideal solution, just trying to unblock the CI for now.
We can always revert this later)