### PR TITLE
build.d: Change  working directory to the project root

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -194,8 +194,7 @@ codecov()
     # CodeCov gets confused by lst files which it can't matched
     rm -rf test/runnable/extra-files
     download "https://codecov.io/bash" "https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov" "codecov.sh"
-    cd src # need to run from compilation folder for gcov to find sources
-    bash ../codecov.sh -p .. -x gcov-4.9 # must match g++ version (on CircleCI `g++` is 4.9 and `gcov` 4.6 :/)
+    bash ./codecov.sh -p . -x gcov-4.9 # must match g++ version (on CircleCI `g++` is 4.9 and `gcov` 4.6 :/)
 }
 
 case $1 in

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -194,7 +194,7 @@ codecov()
     # CodeCov gets confused by lst files which it can't matched
     rm -rf test/runnable/extra-files
     download "https://codecov.io/bash" "https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov" "codecov.sh"
-    bash ./codecov.sh -p . -x gcov-4.9 # must match g++ version (on CircleCI `g++` is 4.9 and `gcov` 4.6 :/)
+    bash ./codecov.sh -p . -Z
 }
 
 case $1 in

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -920,9 +920,9 @@ version (NoMain) {} else
                 return path;
             }
             version (Windows)
-                enum sourcePath = dirName(dirName(__FILE_FULL_PATH__, '\\'), '\\');
+                enum sourcePath = dirName(dirName(dirName(__FILE_FULL_PATH__, '\\'), '\\'), '\\');
             else
-                enum sourcePath = dirName(dirName(__FILE_FULL_PATH__, '/'), '/');
+                enum sourcePath = dirName(dirName(dirName(__FILE_FULL_PATH__, '/'), '/'), '/');
 
             dmd_coverSourcePath(sourcePath);
             dmd_coverDestPath(sourcePath);


### PR DESCRIPTION
.. instead of `src`. This ensures that error messages, coverage data, ... will be reported relative to the root directory as expected by many IDE's.