### PR TITLE
add out parameters to prolog_frame()

### DIFF
--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -1051,7 +1051,7 @@ else
     }
     else if (needframe)                 // if variables or parameters
     {
-        prolog_frame(cdbx, farfunc, xlocalsize, &enter, &cfa_offset);
+        prolog_frame(cdbx, farfunc, xlocalsize, enter, cfa_offset);
         hasframe = 1;
     }
 

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -3187,10 +3187,10 @@ void prolog_16bit_windows_farfunc(ref CodeBuilder cdb, tym_t* tyf, bool* pushds)
  * Returns:
  *      generated code
  */
-void prolog_frame(ref CodeBuilder cdb, bool farfunc, ref uint xlocalsize, bool* enter, int* cfa_offset)
+void prolog_frame(ref CodeBuilder cdb, bool farfunc, ref uint xlocalsize, out bool enter, out int cfa_offset)
 {
     //printf("prolog_frame\n");
-    *cfa_offset = 0;
+    cfa_offset = 0;
 
     if (0 && config.exe == EX_WIN64)
     {
@@ -3198,7 +3198,7 @@ void prolog_frame(ref CodeBuilder cdb, bool farfunc, ref uint xlocalsize, bool* 
         // LEA RBP,0[RSP]
         cdb. gen1(0x50 + BP);
         cdb.genc1(LEA,(REX_W<<16) | (modregrm(0,4,SP)<<8) | modregrm(2,BP,4),FLconst,0);
-        *enter = false;
+        enter = false;
         return;
     }
 
@@ -3246,12 +3246,12 @@ static if (NTEXCEPTIONS == 2)
              * which is why the offset of BP is set to 8
              */
             dwarf_CFA_set_reg_offset(BP, off);        // CFA is now 0[EBP]
-            *cfa_offset = off;  // remember the difference between the CFA and the frame pointer
+            cfa_offset = off;  // remember the difference between the CFA and the frame pointer
         }
-        *enter = false;              /* do not use ENTER instruction */
+        enter = false;              /* do not use ENTER instruction */
     }
     else
-        *enter = true;
+        enter = true;
 }
 
 /**********************************************

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -578,7 +578,7 @@ extern __gshared
 void prolog_ifunc(ref CodeBuilder cdb, tym_t* tyf);
 void prolog_ifunc2(ref CodeBuilder cdb, tym_t tyf, tym_t tym, bool pushds);
 void prolog_16bit_windows_farfunc(ref CodeBuilder cdb, tym_t* tyf, bool* pushds);
-void prolog_frame(ref CodeBuilder cdb, bool farfunc, ref uint xlocalsize, bool* enter, int* cfa_offset);
+void prolog_frame(ref CodeBuilder cdb, bool farfunc, ref uint xlocalsize, out bool enter, out int cfa_offset);
 void prolog_frameadj(ref CodeBuilder cdb, tym_t tyf, uint xlocalsize, bool enter, bool* pushalloc);
 void prolog_frameadj2(ref CodeBuilder cdb, tym_t tyf, uint xlocalsize, bool* pushalloc);
 void prolog_setupalloca(ref CodeBuilder cdb);


### PR DESCRIPTION
`out` parameters improve clarity and come with extra safety checks.