### PR TITLE
Github Actions: Drop testing for LLVM < v6.0.0

### DIFF
--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -58,10 +58,9 @@ jobs:
         os: [ macOS-10.15, ubuntu-16.04, windows-2019 ]
 
         target: [
-          # We test clang all the way back to v3.9.0 (2016-09-02),
-          # as it's the first version to support ABI tags
-          clang-9.0.0, clang-8.0.0, clang-7.0.0,
-          clang-6.0.0,  clang-5.0.2, clang-4.0.0, clang-3.9.0,
+          # We test clang all the way back to v6.0.0 (2018-03-08),
+          # matching what LDC does.
+          clang-9.0.0, clang-8.0.0, clang-7.0.0, clang-6.0.0,
           # For g++, we test all major's latest minor releases since the
           # introduction of ABI the dual ABI (v5.1, 2015-04-15)
           g++-9, g++-8, g++-7, g++-6, g++-5,
@@ -108,11 +107,6 @@ jobs:
           - { target: clang-8.0.0, compiler: clang, cxx-version: 8.0.0 }
           - { target: clang-7.0.0, compiler: clang, cxx-version: 7.0.0 }
           - { target: clang-6.0.0, compiler: clang, cxx-version: 6.0.0 }
-          - { target: clang-5.0.2, compiler: clang, cxx-version: 5.0.2 }
-          # Note: 4.0.1 has no 16.04 package and the OSX archive extracts
-          #  to a different arch, so we don't use it
-          - { target: clang-4.0.0, compiler: clang, cxx-version: 4.0.0 }
-          - { target: clang-3.9.0, compiler: clang, cxx-version: 3.9.0 }
           # g++ boilerplace
           - { target: g++-9, compiler: g++, cxx-version: 9.3.0 }
           - { target: g++-8, compiler: g++, cxx-version: 8.4.0 }


### PR DESCRIPTION
```
Matches what LDC did recently.
Hopefully this will also reduce the cache load,
potentially resulting in less cache eviction,
and so less downloads.
```

CC @wilzbach @kinke 