### PR TITLE
Fix issue 21153  - DWARF: DMD emits the mangled name for DW_AT_name

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -895,11 +895,11 @@ static if (ELFOBJ || MACHOBJ)
              */
             Symbol *fdesym;
             {
-                const size_t len = strlen(sfunc.Sident.ptr);
+                const size_t len = strlen(getSymName(sfunc));
                 char *name = cast(char *)malloc(len + 3 + 1);
                 if (!name)
                     err_nomem();
-                memcpy(name, sfunc.Sident.ptr, len);
+                memcpy(name, getSymName(sfunc), len);
                 memcpy(name + len, ".eh".ptr, 3 + 1);
                 fdesym = symbol_name(name, SCglobal, tspvoid);
                 Obj.pubdef(dfseg, fdesym, startsize);
@@ -1664,12 +1664,7 @@ static if (ELFOBJ || MACHOBJ)
             debug_info.buf.write32(idxsibling);       // DW_AT_sibling
         }
 
-        const(char)* name;
-
-        version (MARS)
-            name = sfunc.prettyIdent ? sfunc.prettyIdent : sfunc.Sident.ptr;
-        else
-            name = sfunc.Sident.ptr;
+        const(char)* name = getSymName(sfunc);
 
         debug_info.buf.writeString(name);             // DW_AT_name
         debug_info.buf.writeString(sfunc.Sident.ptr);    // DW_AT_MIPS_linkage_name
@@ -1722,7 +1717,7 @@ static if (ELFOBJ || MACHOBJ)
                         uint tidx = dwarf_typidx(sa.Stype);
 
                         debug_info.buf.writeuLEB128(vcode);           // abbreviation code
-                        debug_info.buf.writeString(sa.Sident.ptr);       // DW_AT_name
+                        debug_info.buf.writeString(getSymName(sa));   // DW_AT_name
                         debug_info.buf.write32(tidx);                 // DW_AT_type
                         debug_info.buf.writeByte(sa.Sflags & SFLartifical ? 1 : 0); // DW_FORM_tag
                         soffset = cast(uint)debug_info.buf.length();
@@ -1791,8 +1786,7 @@ static if (ELFOBJ || MACHOBJ)
         /* ============= debug_pubnames =========================== */
 
         debug_pubnames.buf.write32(infobuf_offset);
-        // Should be the fully qualified name, not the simple DW_AT_name
-        debug_pubnames.buf.writeString(sfunc.Sident.ptr);
+        debug_pubnames.buf.writeString(name);
 
         /* ============= debug_aranges =========================== */
 
@@ -1894,7 +1888,7 @@ static if (ELFOBJ || MACHOBJ)
                 code = dwarf_abbrev_code(abuf.buf, abuf.length());
 
                 debug_info.buf.writeuLEB128(code);        // abbreviation code
-                debug_info.buf.writeString(s.Sident.ptr);    // DW_AT_name
+                debug_info.buf.writeString(getSymName(s));// DW_AT_name
                 debug_info.buf.write32(typidx);           // DW_AT_type
                 debug_info.buf.writeByte(1);              // DW_AT_external
 
@@ -2602,7 +2596,7 @@ static if (ELFOBJ || MACHOBJ)
                     code = dwarf_abbrev_code(abbrevTypeStruct1.ptr, (abbrevTypeStruct1).sizeof);
                     idx = cast(uint)debug_info.buf.length();
                     debug_info.buf.writeuLEB128(code);
-                    debug_info.buf.writeString(s.Sident.ptr);        // DW_AT_name
+                    debug_info.buf.writeString(getSymName(s));    // DW_AT_name
                     debug_info.buf.writeByte(1);                  // DW_AT_declaration
                     break;                  // don't set Stypidx
                 }
@@ -2635,7 +2629,7 @@ static if (ELFOBJ || MACHOBJ)
                     code = dwarf_abbrev_code(abbrevTypeStruct0.ptr, (abbrevTypeStruct0).sizeof);
                     idx = cast(uint)debug_info.buf.length();
                     debug_info.buf.writeuLEB128(code);
-                    debug_info.buf.writeString(s.Sident.ptr);        // DW_AT_name
+                    debug_info.buf.writeString(getSymName(s));    // DW_AT_name
                     debug_info.buf.writeByte(0);                  // DW_AT_byte_size
                 }
                 else
@@ -2673,7 +2667,7 @@ static if (ELFOBJ || MACHOBJ)
 
                     idx = cast(uint)debug_info.buf.length();
                     debug_info.buf.writeuLEB128(code);
-                    debug_info.buf.writeString(s.Sident.ptr);        // DW_AT_name
+                    debug_info.buf.writeString(getSymName(s));      // DW_AT_name
                     if (sz <= 0xFF)
                         debug_info.buf.writeByte(cast(uint)sz);     // DW_AT_byte_size
                     else if (sz <= 0xFFFF)
@@ -2692,7 +2686,7 @@ static if (ELFOBJ || MACHOBJ)
                         {
                             case SCmember:
                                 debug_info.buf.writeuLEB128(membercode);
-                                debug_info.buf.writeString(sf.Sident.ptr);
+                                debug_info.buf.writeString(getSymName(sf));      // DW_AT_name
                                 //debug_info.buf.write32(dwarf_typidx(sf.Stype));
                                 uint fi = (cast(uint *)fieldidx.buf)[n];
                                 debug_info.buf.write32(fi);
@@ -2757,7 +2751,7 @@ static if (ELFOBJ || MACHOBJ)
                     code = dwarf_abbrev_code(abbrevTypeEnumForward.ptr, abbrevTypeEnumForward.sizeof);
                     idx = cast(uint)debug_info.buf.length();
                     debug_info.buf.writeuLEB128(code);
-                    debug_info.buf.writeString(s.Sident.ptr);        // DW_AT_name
+                    debug_info.buf.writeString(getSymName(s));    // DW_AT_name
                     debug_info.buf.writeByte(1);                  // DW_AT_declaration
                     break;                  // don't set Stypidx
                 }
@@ -2783,7 +2777,7 @@ static if (ELFOBJ || MACHOBJ)
 
                 idx = cast(uint)debug_info.buf.length();
                 debug_info.buf.writeuLEB128(code);
-                debug_info.buf.writeString(s.Sident.ptr);    // DW_AT_name
+                debug_info.buf.writeString(getSymName(s));// DW_AT_name
                 debug_info.buf.writeByte(sz);             // DW_AT_byte_size
 
                 foreach (sl2; ListRange(s.Senum.SEenumlist))
@@ -2792,7 +2786,7 @@ static if (ELFOBJ || MACHOBJ)
                     const value = cast(uint)el_tolongt(sf.Svalue);
 
                     debug_info.buf.writeuLEB128(membercode);
-                    debug_info.buf.writeString(sf.Sident.ptr);
+                    debug_info.buf.writeString(getSymName(sf)); // DW_AT_name
                     if (tyuns(tbase2.Tty))
                         debug_info.buf.writeuLEB128(value);
                     else
@@ -2830,6 +2824,22 @@ static if (ELFOBJ || MACHOBJ)
             idx = *pidx;
         }
         return idx;
+    }
+
+    /**
+     *  Returns a pretty identifier name from `sym`.
+     *
+     *  Params:
+     *      sym = the symbol which the name comes from
+     *  Returns:
+     *      The identifier name
+     */
+    const(char)* getSymName(Symbol* sym)
+    {
+        version (MARS)
+            return sym.prettyIdent ? sym.prettyIdent : sym.Sident.ptr;
+        else
+            return sym.Sident.ptr;
     }
 
     /* ======================= Abbreviation Codes ====================== */

--- a/test/dshell/dwarf.d
+++ b/test/dshell/dwarf.d
@@ -1,0 +1,90 @@
+import dshell;
+
+import std.algorithm;
+import std.file;
+import std.process;
+
+int main()
+{
+    version(DigitalMars) { }
+    else
+    {
+        writeln("Skipping dwarf.d for non-DMD compilers.");
+        return DISABLED;
+    }
+
+    version(Windows)
+    {
+        writeln("Skipping dwarf.d for Windows.");
+        return DISABLED;
+    }
+
+    version(Windows)
+        immutable slash = "\\";
+    else
+        immutable slash = "/";
+
+
+    // If the Unix system doesn't have objdump, disable the tests
+    auto sysHasObjdump = executeShell("objdump --help");
+    if (sysHasObjdump.status)
+        return DISABLED;
+
+    immutable extra_dwarf_dir = EXTRA_FILES ~ slash ~ "dwarf" ~ slash;
+    bool failed;
+
+    // test them all
+    foreach (string path; dirEntries(extra_dwarf_dir, SpanMode.shallow))
+    {
+        if (!isFile(path) || extension(path) != ".d")
+            continue;
+
+        // retrieve the filename without the extension
+        auto filename = baseName(stripExtension(path));
+
+
+        string exe = OUTPUT_BASE ~ slash ~ filename;
+        run("$DMD -m$MODEL -of" ~ exe ~ "$EXE -conf= -fPIE -g"
+            ~ " -I" ~ extra_dwarf_dir ~ " " ~ path);
+
+        // Write objdump result to a file
+        auto objdump = exe ~ ".objdump";
+
+        auto objdump_file = File(objdump, "w");
+        run("objdump -W " ~ exe, objdump_file);
+        objdump_file.close();
+
+        // Objdump excepted results
+        string excepted_results_file = extra_dwarf_dir ~ "excepted_results"
+            ~ slash ~ filename ~ ".txt";
+
+        if (!exists(excepted_results_file))
+            assert(0, "DWARF tests must have a .txt file in the `excepted_results`"
+                ~ " folder which contains the DWARF dump info");
+
+        // Read file result as a string
+        auto result = cast(string)readText(objdump);
+
+        string failmsg;
+
+        foreach (line; File(excepted_results_file).byLine)
+        {
+            if (!canFind(result, line))
+            {
+                failmsg ~= filename ~ ": Couln't find `" ~ line
+                    ~ "` in the DWARF dump info.\n";
+                failed = true;
+            }
+        }
+
+        if (failmsg)
+        {
+            // Writes the result into stdout for the CI machines.
+            writeln(result);
+            write(failmsg);
+        }
+    }
+
+    return failed;
+}
+

--- a/test/dshell/extra-files/dwarf/excepted_results/fix21153.txt
+++ b/test/dshell/extra-files/dwarf/excepted_results/fix21153.txt
@@ -1,0 +1,4 @@
+DW_AT_name        : fix21153.i
+D main
+fix21153._d_cmain!().main
+

--- a/test/dshell/extra-files/dwarf/fix21153.d
+++ b/test/dshell/extra-files/dwarf/fix21153.d
@@ -1,0 +1,6 @@
+int i;
+
+void main()
+{
+
+}


### PR DESCRIPTION
As `gdb` is intelligent, `DW_AT_name` is automatically demangled, if necessary.
So, this commit seems useless, however, for data consistency between `DW_AT_name` and `DW_AT_linkage_name`, this is necessary.

There's still some DWARF issues with DMD (like the module name before the variable name, see below), but that's for another PR (coming soon).