### PR TITLE
Revert reinterpret cast introduced in #432, add ICE test case for 32-bit targets

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -1862,14 +1862,6 @@ public:
             Type elemtype = (cast(TypeArray)val.type).next;
             d_uns64 elemsize = elemtype.size();
 
-            // It's OK to cast from fixed length to dynamic array, eg &int[3] to int[]*
-            if (val.type.ty == Tsarray && pointee.ty == Tarray && elemsize == pointee.nextOf().size())
-            {
-                emplaceExp!(AddrExp)(pue, e.loc, val, e.type);
-                result = pue.exp();
-                return;
-            }
-
             // It's OK to cast from fixed length to fixed length array, eg &int[n] to int[d]*.
             if (val.type.ty == Tsarray && pointee.ty == Tsarray && elemsize == pointee.nextOf().size())
             {

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3,7 +3,7 @@
 TEST_OUTPUT:
 ---
 compilable/interpret3.d(2914): Deprecation: `case` variables have to be `const` or `immutable`
-compilable/interpret3.d(6313): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
+compilable/interpret3.d(6351): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
 ---
 */
 
@@ -3224,6 +3224,44 @@ int ctfeSort6250()
 }
 
 static assert(ctfeSort6250() == 57);
+
+/**************************************************/
+
+long[]* simple6250b(long[]* x) { return x; }
+
+void swap6250b(long[]* lhs, long[]* rhs)
+{
+    long[] kk = *lhs;
+    assert(simple6250b(lhs) == lhs);
+    lhs = simple6250b(lhs);
+    assert(kk[0] == 18);
+    assert((*lhs)[0] == 18);
+    assert((*rhs)[0] == 19);
+    *lhs = *rhs;
+    assert((*lhs)[0] == 19);
+    *rhs = kk;
+    assert(*rhs == kk);
+    assert(kk[0] == 18);
+    assert((*rhs)[0] == 18);
+}
+
+long ctfeSort6250b()
+{
+     long[][2] x;
+     long[3] a = [17, 18, 19];
+     x[0] = a[1 .. 2];
+     x[1] = a[2 .. $];
+     assert(x[0][0] == 18);
+     assert(x[0][1] == 19);
+     swap6250b(&x[0], &x[1]);
+     assert(x[0][0] == 19);
+     assert(x[1][0] == 18);
+     a[1] = 57;
+     assert(x[0][0] == 19);
+     return x[1][0];
+}
+
+static assert(ctfeSort6250b() == 57);
 
 /**************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=6672

--- a/test/fail_compilation/reg6769.d
+++ b/test/fail_compilation/reg6769.d
@@ -1,0 +1,29 @@
+/*
+TEST_OUTPUT
+---
+fail_compilation/reg6769.d(14): Error: reinterpreting cast from `int[]` to `int[7]*` is not supported in CTFE
+fail_compilation/reg6769.d(27):        called from here: `reg6769a([0, 1, 2, 3, 4, 5, 6])`
+fail_compilation/reg6769.d(27):        while evaluating: `static assert(reg6769a([0, 1, 2, 3, 4, 5, 6]) == 1)`
+fail_compilation/reg6769.d(20): Error: reinterpreting cast from `int[7]` to `int[]*` is not supported in CTFE
+fail_compilation/reg6769.d(28):        called from here: `reg6769b([0, 1, 2, 3, 4, 5, 6])`
+fail_compilation/reg6769.d(28):        while evaluating: `static assert(reg6769b([0, 1, 2, 3, 4, 5, 6]) == 1)`
+---
+*/
+int reg6769a(int[] a)
+{
+    int[7]* b = cast(int[7]*)&a;
+    return (*b)[1];
+}
+
+int reg6769b(int[7] a)
+{
+    int[]* b = cast(int[]*)&a;
+    return (*b)[1];
+}
+
+void main()
+{
+    // Both should never succeed, run-time would raise a SEGV.
+    static assert(reg6769a([0,1,2,3,4,5,6]) == 1);
+    static assert(reg6769b([0,1,2,3,4,5,6]) == 1);
+}


### PR DESCRIPTION
An ICE was seen when running the testsuite for a 16-bit target.  This ICE was indirectly fixed in #9282 (d6139e3e6), however you could the same ICE on 32-bit if `int[]` was swapped with `long[]`.

The reason why an ICE would happen is because the condition:
```
if (val.type.ty == Tsarray && pointee.ty == Tarray && elemsize == pointee.nextOf().size())
```
Would also inadvertently match `int[]` and `int[][2]` on 16-bit, `long[]` and `long[][2]` on 32-bit (and if there was support, `cent[]` and `cent[][2]` on 64-bit), and generate the wrong code for interpreting the assignment expression.

However looking further into it, the code that introduced the ICE in #432 made it possible for reinterpret casts that would have invalid results at run-time to yield a sensible result at CTFE.  So that change has been reverted too.  The original reason for why it was necessary is no longer relevant any more.