### PR TITLE
[dmd-cxx] ctfeexpr: Backport fix for ICE in setValue at dinterpret.c:7046

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -1913,7 +1913,7 @@ bool isCtfeValueValid(Expression *newval)
         // e1 should be a CTFE reference
         Expression *e1 = ((AddrExp *)newval)->e1;
         return tb->ty == Tpointer &&
-               ((e1->op == TOKstructliteral && isCtfeValueValid(e1)) ||
+               (((e1->op == TOKstructliteral || e1->op == TOKarrayliteral) && isCtfeValueValid(e1)) ||
                 (e1->op == TOKvar) ||
                 (e1->op == TOKdotvar && isCtfeReferenceValid(e1)) ||
                 (e1->op == TOKindex && isCtfeReferenceValid(e1)) ||

--- a/src/dinterpret.c
+++ b/src/dinterpret.c
@@ -1947,15 +1947,6 @@ public:
             Type *elemtype = ((TypeArray *)(val->type))->next;
             d_uns64 elemsize = elemtype->size();
 
-            // It's OK to cast from fixed length to dynamic array, eg &int[3] to int[]*
-            if (val->type->ty == Tsarray && pointee->ty == Tarray &&
-                elemsize == pointee->nextOf()->size())
-            {
-                new(pue) AddrExp(e->loc, val, e->type);
-                result = pue->exp();
-                return;
-            }
-
             // It's OK to cast from fixed length to fixed length array, eg &int[n] to int[d]*.
             if (val->type->ty == Tsarray && pointee->ty == Tsarray &&
                 elemsize == pointee->nextOf()->size())

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3235,6 +3235,44 @@ int ctfeSort6250()
 
 static assert(ctfeSort6250() == 57);
 
+/**************************************************/
+
+long[]* simple6250b(long[]* x) { return x; }
+
+void swap6250b(long[]* lhs, long[]* rhs)
+{
+    long[] kk = *lhs;
+    assert(simple6250b(lhs) == lhs);
+    lhs = simple6250b(lhs);
+    assert(kk[0] == 18);
+    assert((*lhs)[0] == 18);
+    assert((*rhs)[0] == 19);
+    *lhs = *rhs;
+    assert((*lhs)[0] == 19);
+    *rhs = kk;
+    assert(*rhs == kk);
+    assert(kk[0] == 18);
+    assert((*rhs)[0] == 18);
+}
+
+long ctfeSort6250b()
+{
+     long[][2] x;
+     long[3] a = [17, 18, 19];
+     x[0] = a[1 .. 2];
+     x[1] = a[2 .. $];
+     assert(x[0][0] == 18);
+     assert(x[0][1] == 19);
+     swap6250b(&x[0], &x[1]);
+     assert(x[0][0] == 19);
+     assert(x[1][0] == 18);
+     a[1] = 57;
+     assert(x[0][0] == 19);
+     return x[1][0];
+}
+
+static assert(ctfeSort6250b() == 57);
+
 /**************************************************
     6672 circular references in array
 **************************************************/

--- a/test/fail_compilation/reg6769.d
+++ b/test/fail_compilation/reg6769.d
@@ -1,0 +1,29 @@
+/*
+TEST_OUTPUT
+---
+fail_compilation/reg6769.d(14): Error: reinterpreting cast from `int[]` to `int[7]*` is not supported in CTFE
+fail_compilation/reg6769.d(27):        called from here: `reg6769a([0, 1, 2, 3, 4, 5, 6])`
+fail_compilation/reg6769.d(27):        while evaluating: `static assert(reg6769a([0, 1, 2, 3, 4, 5, 6]) == 1)`
+fail_compilation/reg6769.d(20): Error: reinterpreting cast from `int[7]` to `int[]*` is not supported in CTFE
+fail_compilation/reg6769.d(28):        called from here: `reg6769b([0, 1, 2, 3, 4, 5, 6])`
+fail_compilation/reg6769.d(28):        while evaluating: `static assert(reg6769b([0, 1, 2, 3, 4, 5, 6]) == 1)`
+---
+*/
+int reg6769a(int[] a)
+{
+    int[7]* b = cast(int[7]*)&a;
+    return (*b)[1];
+}
+
+int reg6769b(int[7] a)
+{
+    int[]* b = cast(int[]*)&a;
+    return (*b)[1];
+}
+
+void main()
+{
+    // Both should never succeed, run-time would raise a SEGV.
+    static assert(reg6769a([0,1,2,3,4,5,6]) == 1);
+    static assert(reg6769b([0,1,2,3,4,5,6]) == 1);
+}


### PR DESCRIPTION
This was fixed in #9282 (d6139e3e6).

See #11546 for adding the test to master.