### PR TITLE
Optimize backend 'OmfObj_bytes' function

### DIFF
--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -3308,6 +3308,19 @@ uint OmfObj_bytes(int seg, targ_size_t offset, uint nbytes, void* p)
             lr = cast(Ledatarec*)SegData[seg].ledata;
             if (lr.i + nbytes <= LEDATAMAX)
                 goto L1;
+            if (lr.i == LEDATAMAX)
+            {
+                while (nbytes > LEDATAMAX)  // start writing full ledatas
+                {
+                    lr = ledata_new(seg, offset);
+                    memcpy(lr.data.ptr, p, LEDATAMAX);
+                    p = (cast(char *)p) + LEDATAMAX;
+                    nbytes -= LEDATAMAX;
+                    offset += LEDATAMAX;
+                    lr.i = LEDATAMAX;
+                }
+                goto L1;
+            }
         }
     }
     else


### PR DESCRIPTION
Write `LEDATAMAX` bytes when possible to avoid quadratic behavior of using `OmfObj_byte` to copy every byte.

Test case (Windows): `dmd -c -m32 -J. test.d`
```
void main()
{
   auto i = import("100mb_file");
}
```
Compilation time is like 3 minutes (tested on QEMU vm).