### PR TITLE
iasm: make OpndSize its own type

### DIFF
--- a/src/dmd/backend/iasm.d
+++ b/src/dmd/backend/iasm.d
@@ -1,12 +1,13 @@
 /**
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * Declarations for ptrntab.d, the instruction tables for the inline assembler.
  *
  * Copyright:   Copyright (C) 1982-1998 by Symantec
  *              Copyright (C) 2000-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     Mike Cote, John Micco, $(LINK2 http://www.digitalmars.com, Walter Bright),
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/iasm.d, backend/iasm.d)
+ * Documentation:  https://dlang.org/phobos/dmd_backend_iasm.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/iasm.d
  */
 
 module dmd.backend.iasm;
@@ -175,35 +176,35 @@ alias opflag_t = uint;
 // Operand flags for normal opcodes
 enum
 {
-    _r8     = CONSTRUCT_FLAGS( _8, _reg, _normal, 0 ),
-    _r16    = CONSTRUCT_FLAGS(_16, _reg, _normal, 0 ),
-    _r32    = CONSTRUCT_FLAGS(_32, _reg, _normal, 0 ),
-    _r64    = CONSTRUCT_FLAGS(_64, _reg, _normal, 0 ),
-    _m8     = CONSTRUCT_FLAGS(_8, _m, _normal, 0 ),
-    _m16    = CONSTRUCT_FLAGS(_16, _m, _normal, 0 ),
-    _m32    = CONSTRUCT_FLAGS(_32, _m, _normal, 0 ),
-    _m48    = CONSTRUCT_FLAGS( _48, _m, _normal, 0 ),
-    _m64    = CONSTRUCT_FLAGS( _64, _m, _normal, 0 ),
-    _m128   = CONSTRUCT_FLAGS( _anysize, _m, _normal, 0 ),
-    _m256   = CONSTRUCT_FLAGS( _anysize, _m, _normal, 0 ),
-    _rm8    = CONSTRUCT_FLAGS(_8, _rm, _normal, 0 ),
-    _rm16   = CONSTRUCT_FLAGS(_16, _rm, _normal, 0 ),
-    _rm32   = CONSTRUCT_FLAGS(_32, _rm, _normal, 0),
-    _rm64   = CONSTRUCT_FLAGS(_64, _rm, _normal, 0),
-    _r32m8  = CONSTRUCT_FLAGS(_32|_8, _rm, _normal, 0),
-    _r32m16 = CONSTRUCT_FLAGS(_32|_16, _rm, _normal, 0),
-    _regm8  = CONSTRUCT_FLAGS(_64|_32|_8, _rm, _normal, 0),
-    _imm8   = CONSTRUCT_FLAGS(_8, _imm, _normal, 0 ),
-    _imm16  = CONSTRUCT_FLAGS(_16, _imm, _normal, 0),
-    _imm32  = CONSTRUCT_FLAGS(_32, _imm, _normal, 0),
-    _imm64  = CONSTRUCT_FLAGS(_64, _imm, _normal, 0),
-    _rel8   = CONSTRUCT_FLAGS(_8, _rel, _normal, 0),
-    _rel16  = CONSTRUCT_FLAGS(_16, _rel, _normal, 0),
-    _rel32  = CONSTRUCT_FLAGS(_32, _rel, _normal, 0),
-    _p1616  = CONSTRUCT_FLAGS(_32, _p, _normal, 0),
-    _m1616  = CONSTRUCT_FLAGS(_32, _mnoi, _normal, 0),
-    _p1632  = CONSTRUCT_FLAGS(_48, _p, _normal, 0 ),
-    _m1632  = CONSTRUCT_FLAGS(_48, _mnoi, _normal, 0),
+    _r8     = CONSTRUCT_FLAGS(OpndSize._8, _reg, _normal, 0 ),
+    _r16    = CONSTRUCT_FLAGS(OpndSize._16, _reg, _normal, 0 ),
+    _r32    = CONSTRUCT_FLAGS(OpndSize._32, _reg, _normal, 0 ),
+    _r64    = CONSTRUCT_FLAGS(OpndSize._64, _reg, _normal, 0 ),
+    _m8     = CONSTRUCT_FLAGS(OpndSize._8, _m, _normal, 0 ),
+    _m16    = CONSTRUCT_FLAGS(OpndSize._16, _m, _normal, 0 ),
+    _m32    = CONSTRUCT_FLAGS(OpndSize._32, _m, _normal, 0 ),
+    _m48    = CONSTRUCT_FLAGS(OpndSize._48, _m, _normal, 0 ),
+    _m64    = CONSTRUCT_FLAGS(OpndSize._64, _m, _normal, 0 ),
+    _m128   = CONSTRUCT_FLAGS(OpndSize._anysize, _m, _normal, 0 ),
+    _m256   = CONSTRUCT_FLAGS(OpndSize._anysize, _m, _normal, 0 ),
+    _rm8    = CONSTRUCT_FLAGS(OpndSize._8, _rm, _normal, 0 ),
+    _rm16   = CONSTRUCT_FLAGS(OpndSize._16, _rm, _normal, 0 ),
+    _rm32   = CONSTRUCT_FLAGS(OpndSize._32, _rm, _normal, 0),
+    _rm64   = CONSTRUCT_FLAGS(OpndSize._64, _rm, _normal, 0),
+    _r32m8  = CONSTRUCT_FLAGS(OpndSize._32_8, _rm, _normal, 0),
+    _r32m16 = CONSTRUCT_FLAGS(OpndSize._32_16, _rm, _normal, 0),
+    _regm8  = CONSTRUCT_FLAGS(OpndSize._64_32_8, _rm, _normal, 0),
+    _imm8   = CONSTRUCT_FLAGS(OpndSize._8, _imm, _normal, 0 ),
+    _imm16  = CONSTRUCT_FLAGS(OpndSize._16, _imm, _normal, 0),
+    _imm32  = CONSTRUCT_FLAGS(OpndSize._32, _imm, _normal, 0),
+    _imm64  = CONSTRUCT_FLAGS(OpndSize._64, _imm, _normal, 0),
+    _rel8   = CONSTRUCT_FLAGS(OpndSize._8, _rel, _normal, 0),
+    _rel16  = CONSTRUCT_FLAGS(OpndSize._16, _rel, _normal, 0),
+    _rel32  = CONSTRUCT_FLAGS(OpndSize._32, _rel, _normal, 0),
+    _p1616  = CONSTRUCT_FLAGS(OpndSize._32, _p, _normal, 0),
+    _m1616  = CONSTRUCT_FLAGS(OpndSize._32, _mnoi, _normal, 0),
+    _p1632  = CONSTRUCT_FLAGS(OpndSize._48, _p, _normal, 0 ),
+    _m1632  = CONSTRUCT_FLAGS(OpndSize._48, _mnoi, _normal, 0),
     _special  = CONSTRUCT_FLAGS( 0, 0, _rspecial, 0 ),
     _seg    = CONSTRUCT_FLAGS( 0, 0, _rseg, 0 ),
     _a16    = CONSTRUCT_FLAGS( 0, 0, _addr16, 0 ),
@@ -215,15 +216,15 @@ enum
     _lbl    = CONSTRUCT_FLAGS( 0, 0, _flbl, 0 ),
                                                 // Label (in current function)
 
-    _mmm32  = CONSTRUCT_FLAGS( 0, _m, 0, _32),
-    _mmm64  = CONSTRUCT_FLAGS( _64, _m, 0, _f64),
+    _mmm32  = CONSTRUCT_FLAGS( 0, _m, 0, OpndSize._32),
+    _mmm64  = CONSTRUCT_FLAGS( OpndSize._64, _m, 0, _f64),
     _mmm128 = CONSTRUCT_FLAGS( 0, _m, 0, _f128),
 
-    _xmm_m16  = CONSTRUCT_FLAGS( _16,      _m, _rspecial, ASM_GET_uRegmask(_xmm)),
-    _xmm_m32  = CONSTRUCT_FLAGS( _32,      _m, _rspecial, ASM_GET_uRegmask(_xmm)),
-    _xmm_m64  = CONSTRUCT_FLAGS( _anysize, _m, _rspecial, ASM_GET_uRegmask(_xmm)),
-    _xmm_m128 = CONSTRUCT_FLAGS( _anysize, _m, _rspecial, ASM_GET_uRegmask(_xmm)),
-    _ymm_m256 = CONSTRUCT_FLAGS( _anysize, _m, _rspecial, ASM_GET_uRegmask(_ymm)),
+    _xmm_m16  = CONSTRUCT_FLAGS( OpndSize._16,      _m, _rspecial, ASM_GET_uRegmask(_xmm)),
+    _xmm_m32  = CONSTRUCT_FLAGS( OpndSize._32,      _m, _rspecial, ASM_GET_uRegmask(_xmm)),
+    _xmm_m64  = CONSTRUCT_FLAGS( OpndSize._anysize, _m, _rspecial, ASM_GET_uRegmask(_xmm)),
+    _xmm_m128 = CONSTRUCT_FLAGS( OpndSize._anysize, _m, _rspecial, ASM_GET_uRegmask(_xmm)),
+    _ymm_m256 = CONSTRUCT_FLAGS( OpndSize._anysize, _m, _rspecial, ASM_GET_uRegmask(_ymm)),
 
     _moffs8  = _rel8,
     _moffs16 = _rel16,
@@ -242,7 +243,7 @@ enum
     _fm128  = CONSTRUCT_FLAGS( 0, _m, 0, _f128 ),
     _fanysize = (_f64 | _f80 | _f112 ),
 
-    _float_m = CONSTRUCT_FLAGS( _anysize, _float, 0, _fanysize),
+    _float_m = CONSTRUCT_FLAGS( OpndSize._anysize, _float, 0, _fanysize),
 
     _st     = CONSTRUCT_FLAGS( 0, _float, 0, _rst ),   // stack register 0
     _m112   = CONSTRUCT_FLAGS( 0, _m, 0, _f112 ),
@@ -254,26 +255,48 @@ enum
 ////////////////// FLAGS /////////////////////////////////////
 
 // bit size                      5            3          3              7
-uint CONSTRUCT_FLAGS(uint uSizemask, uint aopty, uint amod, uint uRegmask)
+opflag_t CONSTRUCT_FLAGS(uint uSizemask, uint aopty, uint amod, uint uRegmask)
 {
     return uSizemask | (aopty << 5) | (amod << 8) | (uRegmask << 11);
 }
 
-uint ASM_GET_uSizemask(uint us) { return us & 0x1F; }
 uint ASM_GET_aopty(uint us)     { return cast(ASM_OPERAND_TYPE)((us >> 5) & 7); }
 uint ASM_GET_amod(uint us)      { return cast(ASM_MODIFIERS)((us >> 8) & 7); }
 uint ASM_GET_uRegmask(uint us)  { return (us >> 11) & 0x7F; }
 
 // For uSizemask (5 bits)
-enum
+enum OpndSize : ubyte
 {
+    none = 0,
+
     _8  = 0x1,
     _16 = 0x2,
     _32 = 0x4,
     _48 = 0x8,
     _64 = 0x10,
-    _anysize = (_8 | _16 | _32 | _48 | _64 ),
+
+    _16_8       = _16 | _8,
+    _32_8       = _32 | _8,
+    _32_16      = _32 | _16,
+    _32_16_8    = _32 | _16 | _8,
+    _64_32      = _64 | _32,
+    _64_32_8    = _64 | _32 | _8,
+    _64_32_16   = _64 | _32 | _16,
+    _64_32_16_8 = _64 | _32 | _16 | _8,
+
+    _anysize    = _64 | _48 | _32 | _16 | _8,
 }
+
+/*************************************
+ * Extract OpndSize from opflag_t.
+ */
+OpndSize getOpndSize(opflag_t us) { return cast(OpndSize) (us & 0x1F); }
+
+/*************************************
+ * Returns: true if sz1 is one of sz2
+ */
+bool isOneOf(OpndSize sz1, OpndSize sz2) { return (sz1 & sz2) != 0; }
+bool isOneOf(int sz) { return sz != 0; }
 
 // For aopty (3 bits)
 alias ASM_OPERAND_TYPE = uint;


### PR DESCRIPTION
As https://issues.dlang.org/show_bug.cgi?id=12832 shows, the 5 bit field for a mask of operands has simply run out of bits. Hence, it needs to become an enumerated sequential type with room for more values. This requires refactoring to abstract away the leaky design that it is bit flags.

Making it its own type helps a lot with code clarity.

Changing it to a ubyte instead of a uint helps the compiler diagnose errors (assigning it an out-of-range value).

This just refactors for encapsulation. Changing it to a sequential list of values is for later.