### PR TITLE
finish encapsulating bit masking of OpndSize

### DIFF
--- a/src/dmd/backend/iasm.d
+++ b/src/dmd/backend/iasm.d
@@ -187,6 +187,8 @@ enum
     _m64    = CONSTRUCT_FLAGS(OpndSize._64, _m, _normal, 0 ),
     _m128   = CONSTRUCT_FLAGS(OpndSize._anysize, _m, _normal, 0 ),
     _m256   = CONSTRUCT_FLAGS(OpndSize._anysize, _m, _normal, 0 ),
+    _m48_32_16_8    = CONSTRUCT_FLAGS(OpndSize._48_32_16_8, _m, _normal, 0 ),
+    _m64_48_32_16_8 = CONSTRUCT_FLAGS(OpndSize._64_48_32_16_8, _m, _normal, 0 ),
     _rm8    = CONSTRUCT_FLAGS(OpndSize._8, _rm, _normal, 0 ),
     _rm16   = CONSTRUCT_FLAGS(OpndSize._16, _rm, _normal, 0 ),
     _rm32   = CONSTRUCT_FLAGS(OpndSize._32, _rm, _normal, 0),
@@ -269,34 +271,31 @@ enum OpndSize : ubyte
 {
     none = 0,
 
-    _8  = 0x1,
-    _16 = 0x2,
-    _32 = 0x4,
-    _48 = 0x8,
-    _64 = 0x10,
+    _8,  // 0x1,
+    _16, // 0x2,
+    _32, // 0x4,
+    _48, // 0x8,
+    _64, // 0x10,
 
-    _16_8       = _16 | _8,
-    _32_8       = _32 | _8,
-    _32_16      = _32 | _16,
-    _32_16_8    = _32 | _16 | _8,
-    _64_32      = _64 | _32,
-    _64_32_8    = _64 | _32 | _8,
-    _64_32_16   = _64 | _32 | _16,
-    _64_32_16_8 = _64 | _32 | _16 | _8,
+    _16_8,       // _16 | _8,
+    _32_8,       // _32 | _8,
+    _32_16,      // _32 | _16,
+    _32_16_8,    // _32 | _16 | _8,
+    _48_32,      // _48 | _32,
+    _48_32_16_8, // _48 | _32 | _16 | _8,
+    _64_32,      // _64 | _32,
+    _64_32_8,    // _64 | _32 | _8,
+    _64_32_16,   // _64 | _32 | _16,
+    _64_32_16_8, // _64 | _32 | _16 | _8,
+    _64_48_32_16_8, // _64 | _48 | _32 | _16 | _8,
 
-    _anysize    = _64 | _48 | _32 | _16 | _8,
+    _anysize = _64_48_32_16_8,    // _64 | _48 | _32 | _16 | _8,
 }
 
 /*************************************
  * Extract OpndSize from opflag_t.
  */
 OpndSize getOpndSize(opflag_t us) { return cast(OpndSize) (us & 0x1F); }
-
-/*************************************
- * Returns: true if sz1 is one of sz2
- */
-bool isOneOf(OpndSize sz1, OpndSize sz2) { return (sz1 & sz2) != 0; }
-bool isOneOf(int sz) { return sz != 0; }
 
 // For aopty (3 bits)
 alias ASM_OPERAND_TYPE = uint;

--- a/src/dmd/backend/ptrntab.d
+++ b/src/dmd/backend/ptrntab.d
@@ -191,7 +191,7 @@ PTRNTAB1[3] aptb1INT= /* INT */ [
         { ASM_END }
 ];
 PTRNTAB1[2] aptb1INVLPG = /* INVLPG */ [         // 486 only instruction
-        { 0x0f01,       _I386|_7, _m8 | _m16 | _m32 | _m48 },
+        { 0x0f01,       _I386|_7, _m48_32_16_8 },
         { ASM_END }
 ];
 
@@ -588,9 +588,9 @@ PTRNTAB2[3]  aptb2LDS = /* LDS */ [
 ];
 
 PTRNTAB2[7]  aptb2LEA = /* LEA */ [
-        { 0x8d, _r|_16_bit,             _r16,   _m8 | _m16 | _m32 | _m48 },
-        { 0x8d, _r|_32_bit,             _r32,   _m8 | _m16 | _m32 | _m48 },
-        { 0x8d, _r|_64_bit,             _r64,   _m8 | _m16 | _m32 | _m48 | _m64 },
+        { 0x8d, _r|_16_bit,             _r16,   _m48_32_16_8 },
+        { 0x8d, _r|_32_bit,             _r32,   _m48_32_16_8 },
+        { 0x8d, _r|_64_bit,             _r64,   _m64_48_32_16_8 },
         { 0x8d, _r|_16_bit,             _r16,   _rel16 },
         { 0x8d, _r|_32_bit,             _r32,   _rel32 },
         { 0x8d, _r|_64_bit,             _r64,   _rel32 },


### PR DESCRIPTION
by moving those operations into `isOneOf()`

Then we can change OpndSize into a sequence of values rather than an enumeration.

I put this in a separate PR because the swapping of operands is a bit tricky to get right.