### PR TITLE
Improve static function frame access error message and coverage

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1597,7 +1597,7 @@ extern (C++) class VarDeclaration : Declaration
         //printf("\tfdthis = %s\n", fdthis.toChars());
         if (loc.isValid())
         {
-            if (fdthis.getLevelAndCheck(loc, sc, fdv) == fdthis.LevelError)
+            if (fdthis.getLevelAndCheck(loc, sc, fdv, this) == fdthis.LevelError)
                 return true;
         }
 

--- a/test/fail_compilation/diag10984.d
+++ b/test/fail_compilation/diag10984.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10984.d(11): Error: static function diag10984.f.n cannot access frame of function diag10984.f
+fail_compilation/diag10984.d(12): Error: `static` function `diag10984.f.n` cannot access variable `x` in frame of function `diag10984.f`
+fail_compilation/diag10984.d(11):        `x` declared here
 ---
 */
 

--- a/test/fail_compilation/diag15411.d
+++ b/test/fail_compilation/diag15411.d
@@ -2,8 +2,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag15411.d(13): Error: function diag15411.test15411.__funcliteral1 cannot access frame of function diag15411.test15411
-fail_compilation/diag15411.d(14): Error: function diag15411.test15411.__funcliteral2 cannot access frame of function diag15411.test15411
+fail_compilation/diag15411.d(17): Error: function `diag15411.test15411.__funcliteral1` cannot access variable `i` in frame of function `diag15411.test15411`
+fail_compilation/diag15411.d(16):        `i` declared here
+fail_compilation/diag15411.d(18): Error: function `diag15411.test15411.__funcliteral2` cannot access variable `i` in frame of function `diag15411.test15411`
+fail_compilation/diag15411.d(16):        `i` declared here
+fail_compilation/diag15411.d(26): Error: `static` function `diag15411.testNestedFunction.myFunc2` cannot access function `myFunc1` in frame of function `diag15411.testNestedFunction`
+fail_compilation/diag15411.d(25):        `myFunc1` declared here
 ---
 */
 
@@ -12,4 +16,12 @@ void test15411()
     auto i = 0;
     auto j = (function() { return i; })();
     auto f =  function() { return i; };
+}
+
+void testNestedFunction ()
+{
+    int i = 42;
+
+    void myFunc1() { assert(i == 42); }
+    static void myFunc2 () { myFunc1(); }
 }

--- a/test/fail_compilation/diag9148.d
+++ b/test/fail_compilation/diag9148.d
@@ -41,7 +41,8 @@ void test9148a() pure
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9148.d(53): Error: static function diag9148.test9148b.foo cannot access frame of function diag9148.test9148b
+fail_compilation/diag9148.d(54): Error: `static` function `diag9148.test9148b.foo` cannot access variable `x` in frame of function `diag9148.test9148b`
+fail_compilation/diag9148.d(51):        `x` declared here
 ---
 */
 

--- a/test/fail_compilation/diag9831.d
+++ b/test/fail_compilation/diag9831.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9831.d(12): Error: function diag9831.main.__lambda1 cannot access frame of function D main
+fail_compilation/diag9831.d(13): Error: function `diag9831.main.__lambda1` cannot access variable `c` in frame of function `D main`
+fail_compilation/diag9831.d(11):        `c` declared here
 ---
 */
 

--- a/test/fail_compilation/fail39.d
+++ b/test/fail_compilation/fail39.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail39.d(11): Error: function fail39.main.__funcliteral2 cannot access frame of function D main
+fail_compilation/fail39.d(12): Error: function `fail39.main.__funcliteral2` cannot access function `foo` in frame of function `D main`
+fail_compilation/fail39.d(11):        `foo` declared here
 ---
 */
 


### PR DESCRIPTION
```
- Add syntax highlight using backtips;
- Actually tell the user what symbol is being accessed, not just what functions are involved;
- Add a test for static function calling nested function,
  which wasn't fully covered before (comes in addition to test39);
```