### PR TITLE
Fix STC of parameters to some druntime hooks

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1744,7 +1744,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     {
                         auto params = new Parameters();
                         params.push(new Parameter(0, Type.tvoid.pointerTo(), null, null, null));
-                        params.push(new Parameter(STC.in_, Type.tsize_t, null, null, null));
+                        params.push(new Parameter(STC.const_, Type.tsize_t, null, null, null));
                         auto dgparams = new Parameters();
                         dgparams.push(new Parameter(0, Type.tvoidptr, null, null, null));
                         if (dim == 2)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3426,7 +3426,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             if (fd_aaLen is null)
             {
                 auto fparams = new Parameters();
-                fparams.push(new Parameter(STC.in_, mt, null, null, null));
+                fparams.push(new Parameter(STC.const_ | STC.scope_, mt, null, null, null));
                 fd_aaLen = FuncDeclaration.genCfunc(fparams, Type.tsize_t, Id.aaLen);
                 TypeFunction tf = fd_aaLen.type.toTypeFunction();
                 tf.purity = PURE.const_;


### PR DESCRIPTION
```
They have been out of sync since PRs were made to replace `in`
with `const scope` in druntime, such as dlang/druntime#2781 (2.089).
```

https://github.com/dlang/druntime/blob/0dfc0ce5aef1fde00713b56e9be99dcdfb04d171/src/rt/aaA.d#L707
https://github.com/dlang/druntime/blob/0dfc0ce5aef1fde00713b56e9be99dcdfb04d171/src/rt/aaA.d#L724
https://github.com/dlang/druntime/blob/0dfc0ce5aef1fde00713b56e9be99dcdfb04d171/src/rt/aaA.d#L497