### PR TITLE
Trivial: Correct some version-out logging statements

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -522,7 +522,7 @@ MATCH implicitConvTo(Expression e, Type t)
         {
             version (none)
             {
-                printf("NullExp::implicitConvTo(this=%s, type=%s, t=%s, committed = %d)\n", e.toChars(), e.type.toChars(), t.toChars(), e.committed);
+                printf("NullExp::implicitConvTo(this=%s, type=%s, t=%s)\n", e.toChars(), e.type.toChars(), t.toChars());
             }
             if (e.type.equals(t))
             {

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -761,7 +761,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             printf("VarDeclaration::semantic('%s', parent = '%s') sem = %d\n",
                    dsym.toChars(), sc.parent ? sc.parent.toChars() : null, dsym.semanticRun);
             printf(" type = %s\n", dsym.type ? dsym.type.toChars() : "null");
-            printf(" stc = x%x\n", dsym.storage_class.stc);
+            printf(" stc = x%llx\n", dsym.storage_class);
             printf(" storage_class = x%llx\n", dsym.storage_class);
             printf("linkage = %d\n", dsym.linkage);
             //if (strcmp(toChars(), "mul") == 0) assert(0);
@@ -6348,7 +6348,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
                     }
                 }
             }
-            //printf("[%s] %s doSemantic3 = %d\n", loc.toChars(), toChars(), doSemantic3);
+            //printf("[%s] %s doSemantic3 = %d\n", tempinst.tinst.loc.toChars(), tempinst.tinst.toChars(), doSemantic3);
         }
         if (doSemantic3)
             tempinst.trySemantic3(sc2);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4666,7 +4666,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     printf("ue.e1 = %s\n", ue.e1.toChars());
                     printf("f = %s\n", exp.f.toChars());
-                    printf("t = %s\n", t.toChars());
+                    printf("t1 = %s\n", t1.toChars());
                     printf("e1 = %s\n", exp.e1.toChars());
                     printf("e1.type = %s\n", exp.e1.type.toChars());
                 }

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2847,8 +2847,7 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
             {
                 Expression arg = (*fargs)[i];
                 assert(arg.type);
-                printf("\t%s: ", arg.toChars());
-                arg.type.print();
+                printf("\t%s: %s\n", arg.toChars(), arg.type.toChars());
             }
         }
     }

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -11,6 +11,7 @@
 
 module dmd.toctype;
 
+import core.stdc.stdio;
 import core.stdc.stdlib;
 
 import dmd.backend.cc : Classsym, Symbol;

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -932,11 +932,11 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                 printf("index is %p %s\n", mtype.index, mtype.index.toChars());
                 mtype.index.check();
                 printf("index.mod = x%x\n", mtype.index.mod);
-                printf("index.ito = x%x\n", mtype.index.ito);
-                if (mtype.index.ito)
+                printf("index.ito = x%p\n", mtype.index.getMcache().ito);
+                if (mtype.index.getMcache().ito)
                 {
-                    printf("index.ito.mod = x%x\n", mtype.index.ito.mod);
-                    printf("index.ito.ito = x%x\n", mtype.index.ito.ito);
+                    printf("index.ito.mod = x%x\n", mtype.index.getMcache().ito.mod);
+                    printf("index.ito.ito = x%p\n", mtype.index.getMcache().ito.getMcache().ito);
                 }
             }
         }
@@ -1554,7 +1554,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
     Type visitDelegate(TypeDelegate mtype)
     {
-        //printf("TypeDelegate::semantic() %s\n", toChars());
+        //printf("TypeDelegate::semantic() %s\n", mtype.toChars());
         if (mtype.deco) // if semantic() already run
         {
             //printf("already done\n");


### PR DESCRIPTION
The extra import follow the custom of having dead imports to `std.stdio` to allow for easier debugging.