### PR TITLE
TypeFunction: Process default parameter only after all parameter semantic has been done

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -415,7 +415,8 @@ public:
         }
 
         // Write argument types
-        paramsToDecoBuffer(t.parameterList.parameters);
+        foreach (idx, param; t.parameterList)
+            param.accept(this);
         //if (buf.data[buf.length - 1] == '@') assert(0);
         buf.writeByte('Z' - t.parameterList.varargs); // mark end of arg list
         if (tret !is null)
@@ -455,7 +456,10 @@ public:
     {
         //printf("TypeTuple.toDecoBuffer() t = %p, %s\n", t, t.toChars());
         visit(cast(Type)t);
-        paramsToDecoBuffer(t.arguments);
+        Parameter._foreach(t.arguments, (idx, param) {
+                param.accept(this);
+                return 0;
+        });
         buf.writeByte('Z');
     }
 
@@ -1088,18 +1092,6 @@ public:
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    void paramsToDecoBuffer(Parameters* parameters)
-    {
-        //printf("Parameter.paramsToDecoBuffer()\n");
-
-        int paramsToDecoBufferDg(size_t n, Parameter p)
-        {
-            p.accept(this);
-            return 0;
-        }
-
-        Parameter._foreach(parameters, &paramsToDecoBufferDg);
-    }
 
     override void visit(Parameter p)
     {
@@ -1231,6 +1223,7 @@ void mangleToFuncSignature(ref OutBuffer buf, FuncDeclaration fd)
     scope Mangler v = new Mangler(&buf);
 
     MODtoDecoBuffer(&buf, tf.mod);
-    v.paramsToDecoBuffer(tf.parameterList.parameters);
+    foreach (idx, param; tf.parameterList)
+        param.accept(v);
     buf.writeByte('Z' - tf.parameterList.varargs);
 }


### PR DESCRIPTION
This PR comes in support of #11000 .

The main feedback that came from the forum thread and the PR is that the backend needed to instruct the frontend on what to do. Which makes complete sense, so I started implementing it.

However, in order to make a bearable API available to the backend, I went with the following API:
```diff
+    /**
+     * Determine which `in` parameters needs to be passed by `ref`
+     *
+     * Called from `TypeFunction` semantic with the full function type.
+     * This routine must iterate over parameters, and may set `STC.inRef`
+     * for any parameter which already have `STC.in_`.
+     * This hook must never set `STC.inRef` if the parameter is not `STC.in_`,
+     * nor should it ever change anything else.
+     *
+     * This hook will not be called when `-preview=in` wasn't passed to the
+     * frontend, hence it needs not care about `global.params.previewIn`.
+     *
+     * Params:
+     *   tf    = Type of the function to inspect. The type will have its
+     *           parameter types semantically resolved, however other attributes
+     *           (return type, `@safe` / `nothrow`, etc...) must not be used.
+     */
+    extern(C++) void applyInRefParams (TypeFunction tf)
```

The main goal was to avoid having to pass parameters piecemeal, as it would force the backend to keep some state around or would complicate implementation.
`STC.inRef` is a new storage class added to `enum STC`, as adding `ref` would make it show up in error messages and header generation (and `in ref` is still valid).

However, a few problems presented themselves: First, a bunch of reference-related things were processed before tuples were expanded and the loop restarted (hence tuples were moved as early as they could in the loop), but then tuple expansion depended on default parameter semantic (semantic was needed so we would get a fully expanded `TupleExp`), and default parameter semantic depended on known if the type was `ref`  or not. On top of that,  `auto ref` also depends on the default argument having gone through semantic.

Having the default parameter semantic depend on the type of the parameter makes sense, but not quite the other way around. The solution was to have an iterator that would keep a reference to the original parameter, so that we could postpone default parameter semantic until the parameter semantic was fully done, save for `auto ref`. Luckily, `auto ref` and `in` are conflicting features and will not be usable together.

Finally, and since it was related, I threw in the additional commit to use `foreach` directly when possible in `dmangle.d`