### PR TITLE
[refactor] constfold: Use >>> for evaluating Ushr expressions

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -672,22 +672,22 @@ UnionExp Ushr(const ref Loc loc, Type type, Expression e1, Expression e2)
     case Tuns8:
     case Tchar:
         // Possible only with >>>=. >>> always gets promoted to int.
-        value = (value & 0xFF) >> count;
+        value = (value & 0xFF) >>> count;
         break;
     case Tint16:
     case Tuns16:
     case Twchar:
         // Possible only with >>>=. >>> always gets promoted to int.
-        value = (value & 0xFFFF) >> count;
+        value = (value & 0xFFFF) >>> count;
         break;
     case Tint32:
     case Tuns32:
     case Tdchar:
-        value = (value & 0xFFFFFFFF) >> count;
+        value = (value & 0xFFFFFFFF) >>> count;
         break;
     case Tint64:
     case Tuns64:
-        value = cast(d_uns64)value >> count;
+        value = value >>> count;
         break;
     case Terror:
         emplaceExp!(ErrorExp)(&ue);


### PR DESCRIPTION
Essentially dogfooding the `>>>` operator, so the compiler uses it to evaluate `>>>` at compile-time.

The test runnable/constfold.d already touches this code path a number of times with several static asserts.