### PR TITLE
Fix duplicate function declarations in dmd/tests

### DIFF
--- a/src/dmd/backend/go.d
+++ b/src/dmd/backend/go.d
@@ -61,7 +61,6 @@ void flowlv();
 void flowae();
 void flowvbe();
 void flowcp();
-void flowae();
 void genkillae();
 void flowarraybounds();
 int ae_field_affect(elem *lvalue,elem *e);

--- a/test/runnable/extra-files/cdvecfill.d
+++ b/test/runnable/extra-files/cdvecfill.d
@@ -27,30 +27,30 @@ version (D_AVX)
     __vector(double[2]) test(double val) { return val; }
     __vector(double[2]) test(double* pval) { return *pval; }
 
-    __vector(ubyte[32]) test(ubyte val) { return val; }
-    __vector(ubyte[32]) test(ubyte* pval) { return *pval; }
-    __vector(byte[32]) test(byte val) { return val; }
-    __vector(byte[32]) test(byte* pval) { return *pval; }
+    __vector(ubyte[32]) test2(ubyte val) { return val; }
+    __vector(ubyte[32]) test2(ubyte* pval) { return *pval; }
+    __vector(byte[32]) test2(byte val) { return val; }
+    __vector(byte[32]) test2(byte* pval) { return *pval; }
 
-    __vector(ushort[16]) test(ushort val) { return val; }
-    __vector(ushort[16]) test(ushort* pval) { return *pval; }
-    __vector(short[16]) test(short val) { return val; }
-    __vector(short[16]) test(short* pval) { return *pval; }
+    __vector(ushort[16]) test2(ushort val) { return val; }
+    __vector(ushort[16]) test2(ushort* pval) { return *pval; }
+    __vector(short[16]) test2(short val) { return val; }
+    __vector(short[16]) test2(short* pval) { return *pval; }
 
-    __vector(uint[8]) test(uint val) { return val; }
-    __vector(uint[8]) test(uint* pval) { return *pval; }
-    __vector(int[8]) test(int val) { return val; }
-    __vector(int[8]) test(int* pval) { return *pval; }
+    __vector(uint[8]) test2(uint val) { return val; }
+    __vector(uint[8]) test2(uint* pval) { return *pval; }
+    __vector(int[8]) test2(int val) { return val; }
+    __vector(int[8]) test2(int* pval) { return *pval; }
 
-    __vector(ulong[4]) test(ulong val) { return val; }
-    __vector(ulong[4]) test(ulong* pval) { return *pval; }
-    __vector(long[4]) test(long val) { return val; }
-    __vector(long[4]) test(long* pval) { return *pval; }
+    __vector(ulong[4]) test2(ulong val) { return val; }
+    __vector(ulong[4]) test2(ulong* pval) { return *pval; }
+    __vector(long[4]) test2(long val) { return val; }
+    __vector(long[4]) test2(long* pval) { return *pval; }
 
-    __vector(float[8]) test(float val) { return val; }
-    __vector(float[8]) test(float* pval) { return *pval; }
-    __vector(double[4]) test(double val) { return val; }
-    __vector(double[4]) test(double* pval) { return *pval; }
+    __vector(float[8]) test2(float val) { return val; }
+    __vector(float[8]) test2(float* pval) { return *pval; }
+    __vector(double[4]) test2(double val) { return val; }
+    __vector(double[4]) test2(double* pval) { return *pval; }
 }
 else version (D_AVX)
 {
@@ -79,30 +79,30 @@ else version (D_AVX)
     __vector(double[2]) test(double val) { return val; }
     __vector(double[2]) test(double* pval) { return *pval; }
 
-    __vector(ubyte[32]) test(ubyte val) { return val; }
-    __vector(ubyte[32]) test(ubyte* pval) { return *pval; }
-    __vector(byte[32]) test(byte val) { return val; }
-    __vector(byte[32]) test(byte* pval) { return *pval; }
+    __vector(ubyte[32]) test2(ubyte val) { return val; }
+    __vector(ubyte[32]) test2(ubyte* pval) { return *pval; }
+    __vector(byte[32]) test2(byte val) { return val; }
+    __vector(byte[32]) test2(byte* pval) { return *pval; }
 
-    __vector(ushort[16]) test(ushort val) { return val; }
-    __vector(ushort[16]) test(ushort* pval) { return *pval; }
-    __vector(short[16]) test(short val) { return val; }
-    __vector(short[16]) test(short* pval) { return *pval; }
+    __vector(ushort[16]) test2(ushort val) { return val; }
+    __vector(ushort[16]) test2(ushort* pval) { return *pval; }
+    __vector(short[16]) test2(short val) { return val; }
+    __vector(short[16]) test2(short* pval) { return *pval; }
 
-    __vector(uint[8]) test(uint val) { return val; }
-    __vector(uint[8]) test(uint* pval) { return *pval; }
-    __vector(int[8]) test(int val) { return val; }
-    __vector(int[8]) test(int* pval) { return *pval; }
+    __vector(uint[8]) test2(uint val) { return val; }
+    __vector(uint[8]) test2(uint* pval) { return *pval; }
+    __vector(int[8]) test2(int val) { return val; }
+    __vector(int[8]) test2(int* pval) { return *pval; }
 
-    __vector(ulong[4]) test(ulong val) { return val; }
-    __vector(ulong[4]) test(ulong* pval) { return *pval; }
-    __vector(long[4]) test(long val) { return val; }
-    __vector(long[4]) test(long* pval) { return *pval; }
+    __vector(ulong[4]) test2(ulong val) { return val; }
+    __vector(ulong[4]) test2(ulong* pval) { return *pval; }
+    __vector(long[4]) test2(long val) { return val; }
+    __vector(long[4]) test2(long* pval) { return *pval; }
 
-    __vector(float[8]) test(float val) { return val; }
-    __vector(float[8]) test(float* pval) { return *pval; }
-    __vector(double[4]) test(double val) { return val; }
-    __vector(double[4]) test(double* pval) { return *pval; }
+    __vector(float[8]) test2(float val) { return val; }
+    __vector(float[8]) test2(float* pval) { return *pval; }
+    __vector(double[4]) test2(double val) { return val; }
+    __vector(double[4]) test2(double* pval) { return *pval; }
 }
 else
 {

--- a/test/runnable/extra-files/cdvecfillavx.out
+++ b/test/runnable/extra-files/cdvecfillavx.out
@@ -181,18 +181,18 @@ Disassembly of section .text._D9cdvecfill4testFPdZNhG2d:
    9:	00 00                	add    BYTE PTR [rax],al
 	...
 
-Disassembly of section .text._D9cdvecfill4testFhZNhG32h:
+Disassembly of section .text._D9cdvecfill5test2FhZNhG32h:
 
-0000000000000000 <_D9cdvecfill4testFhZNhG32h>:
+0000000000000000 <_D9cdvecfill5test2FhZNhG32h>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
    8:	c4 e2 79 00 c1       	vpshufb xmm0,xmm0,xmm1
    d:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
   13:	c3                   	ret    
 
-Disassembly of section .text._D9cdvecfill4testFPhZNhG32h:
+Disassembly of section .text._D9cdvecfill5test2FPhZNhG32h:
 
-0000000000000000 <_D9cdvecfill4testFPhZNhG32h>:
+0000000000000000 <_D9cdvecfill5test2FPhZNhG32h>:
    0:	0f b6 07             	movzx  eax,BYTE PTR [rdi]
    3:	c5 f9 6e c0          	vmovd  xmm0,eax
    7:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
@@ -201,18 +201,18 @@ Disassembly of section .text._D9cdvecfill4testFPhZNhG32h:
   16:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFgZNhG32g:
+Disassembly of section .text._D9cdvecfill5test2FgZNhG32g:
 
-0000000000000000 <_D9cdvecfill4testFgZNhG32g>:
+0000000000000000 <_D9cdvecfill5test2FgZNhG32g>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
    8:	c4 e2 79 00 c1       	vpshufb xmm0,xmm0,xmm1
    d:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
   13:	c3                   	ret    
 
-Disassembly of section .text._D9cdvecfill4testFPgZNhG32g:
+Disassembly of section .text._D9cdvecfill5test2FPgZNhG32g:
 
-0000000000000000 <_D9cdvecfill4testFPgZNhG32g>:
+0000000000000000 <_D9cdvecfill5test2FPgZNhG32g>:
    0:	0f be 07             	movsx  eax,BYTE PTR [rdi]
    3:	c5 f9 6e c0          	vmovd  xmm0,eax
    7:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
@@ -221,18 +221,18 @@ Disassembly of section .text._D9cdvecfill4testFPgZNhG32g:
   16:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFtZNhG16t:
+Disassembly of section .text._D9cdvecfill5test2FtZNhG16t:
 
-0000000000000000 <_D9cdvecfill4testFtZNhG16t>:
+0000000000000000 <_D9cdvecfill5test2FtZNhG16t>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
    8:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
    d:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
   13:	c3                   	ret    
 
-Disassembly of section .text._D9cdvecfill4testFPtZNhG16t:
+Disassembly of section .text._D9cdvecfill5test2FPtZNhG16t:
 
-0000000000000000 <_D9cdvecfill4testFPtZNhG16t>:
+0000000000000000 <_D9cdvecfill5test2FPtZNhG16t>:
    0:	0f b7 07             	movzx  eax,WORD PTR [rdi]
    3:	c5 f9 6e c0          	vmovd  xmm0,eax
    7:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
@@ -241,18 +241,18 @@ Disassembly of section .text._D9cdvecfill4testFPtZNhG16t:
   16:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFsZNhG16s:
+Disassembly of section .text._D9cdvecfill5test2FsZNhG16s:
 
-0000000000000000 <_D9cdvecfill4testFsZNhG16s>:
+0000000000000000 <_D9cdvecfill5test2FsZNhG16s>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
    8:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
    d:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
   13:	c3                   	ret    
 
-Disassembly of section .text._D9cdvecfill4testFPsZNhG16s:
+Disassembly of section .text._D9cdvecfill5test2FPsZNhG16s:
 
-0000000000000000 <_D9cdvecfill4testFPsZNhG16s>:
+0000000000000000 <_D9cdvecfill5test2FPsZNhG16s>:
    0:	0f bf 07             	movsx  eax,WORD PTR [rdi]
    3:	c5 f9 6e c0          	vmovd  xmm0,eax
    7:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
@@ -261,69 +261,69 @@ Disassembly of section .text._D9cdvecfill4testFPsZNhG16s:
   16:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFkZNhG8k:
+Disassembly of section .text._D9cdvecfill5test2FkZNhG8k:
 
-0000000000000000 <_D9cdvecfill4testFkZNhG8k>:
+0000000000000000 <_D9cdvecfill5test2FkZNhG8k>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
    9:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
    f:	c3                   	ret    
 
-Disassembly of section .text._D9cdvecfill4testFPkZNhG8k:
+Disassembly of section .text._D9cdvecfill5test2FPkZNhG8k:
 
-0000000000000000 <_D9cdvecfill4testFPkZNhG8k>:
+0000000000000000 <_D9cdvecfill5test2FPkZNhG8k>:
    0:	c4 e2 7d 18 07       	vbroadcastss ymm0,DWORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFiZNhG8i:
+Disassembly of section .text._D9cdvecfill5test2FiZNhG8i:
 
-0000000000000000 <_D9cdvecfill4testFiZNhG8i>:
+0000000000000000 <_D9cdvecfill5test2FiZNhG8i>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
    9:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
    f:	c3                   	ret    
 
-Disassembly of section .text._D9cdvecfill4testFPiZNhG8i:
+Disassembly of section .text._D9cdvecfill5test2FPiZNhG8i:
 
-0000000000000000 <_D9cdvecfill4testFPiZNhG8i>:
+0000000000000000 <_D9cdvecfill5test2FPiZNhG8i>:
    0:	c4 e2 7d 18 07       	vbroadcastss ymm0,DWORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFmZNhG4m:
+Disassembly of section .text._D9cdvecfill5test2FmZNhG4m:
 
-0000000000000000 <_D9cdvecfill4testFmZNhG4m>:
+0000000000000000 <_D9cdvecfill5test2FmZNhG4m>:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c5 f9 6c c0          	vpunpcklqdq xmm0,xmm0,xmm0
    9:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
    f:	c3                   	ret    
 
-Disassembly of section .text._D9cdvecfill4testFPmZNhG4m:
+Disassembly of section .text._D9cdvecfill5test2FPmZNhG4m:
 
-0000000000000000 <_D9cdvecfill4testFPmZNhG4m>:
+0000000000000000 <_D9cdvecfill5test2FPmZNhG4m>:
    0:	c4 e2 7d 19 07       	vbroadcastsd ymm0,QWORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFlZNhG4l:
+Disassembly of section .text._D9cdvecfill5test2FlZNhG4l:
 
-0000000000000000 <_D9cdvecfill4testFlZNhG4l>:
+0000000000000000 <_D9cdvecfill5test2FlZNhG4l>:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c5 f9 6c c0          	vpunpcklqdq xmm0,xmm0,xmm0
    9:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
    f:	c3                   	ret    
 
-Disassembly of section .text._D9cdvecfill4testFPlZNhG4l:
+Disassembly of section .text._D9cdvecfill5test2FPlZNhG4l:
 
-0000000000000000 <_D9cdvecfill4testFPlZNhG4l>:
+0000000000000000 <_D9cdvecfill5test2FPlZNhG4l>:
    0:	c4 e2 7d 19 07       	vbroadcastsd ymm0,QWORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFfZNhG8f:
+Disassembly of section .text._D9cdvecfill5test2FfZNhG8f:
 
-0000000000000000 <_D9cdvecfill4testFfZNhG8f>:
+0000000000000000 <_D9cdvecfill5test2FfZNhG8f>:
    0:	50                   	push   rax
    1:	c5 fa 11 04 24       	vmovss DWORD PTR [rsp],xmm0
    6:	c5 fa 10 04 24       	vmovss xmm0,DWORD PTR [rsp]
@@ -332,16 +332,16 @@ Disassembly of section .text._D9cdvecfill4testFfZNhG8f:
   16:	59                   	pop    rcx
   17:	c3                   	ret    
 
-Disassembly of section .text._D9cdvecfill4testFPfZNhG8f:
+Disassembly of section .text._D9cdvecfill5test2FPfZNhG8f:
 
-0000000000000000 <_D9cdvecfill4testFPfZNhG8f>:
+0000000000000000 <_D9cdvecfill5test2FPfZNhG8f>:
    0:	c4 e2 7d 18 07       	vbroadcastss ymm0,DWORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFdZNhG4d:
+Disassembly of section .text._D9cdvecfill5test2FdZNhG4d:
 
-0000000000000000 <_D9cdvecfill4testFdZNhG4d>:
+0000000000000000 <_D9cdvecfill5test2FdZNhG4d>:
    0:	50                   	push   rax
    1:	c5 fb 11 04 24       	vmovsd QWORD PTR [rsp],xmm0
    6:	c5 fb 10 04 24       	vmovsd xmm0,QWORD PTR [rsp]
@@ -351,9 +351,9 @@ Disassembly of section .text._D9cdvecfill4testFdZNhG4d:
   16:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFPdZNhG4d:
+Disassembly of section .text._D9cdvecfill5test2FPdZNhG4d:
 
-0000000000000000 <_D9cdvecfill4testFPdZNhG4d>:
+0000000000000000 <_D9cdvecfill5test2FPdZNhG4d>:
    0:	c4 e2 7d 19 07       	vbroadcastsd ymm0,QWORD PTR [rdi]
    5:	c3                   	ret    
 	...

--- a/test/runnable/extra-files/cdvecfillavx2.out
+++ b/test/runnable/extra-files/cdvecfillavx2.out
@@ -159,129 +159,129 @@ Disassembly of section .text._D9cdvecfill4testFPdZNhG2d:
    9:	00 00                	add    BYTE PTR [rax],al
 	...
 
-Disassembly of section .text._D9cdvecfill4testFhZNhG32h:
+Disassembly of section .text._D9cdvecfill5test2FhZNhG32h:
 
-0000000000000000 <_D9cdvecfill4testFhZNhG32h>:
+0000000000000000 <_D9cdvecfill5test2FhZNhG32h>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 78 c0       	vpbroadcastb ymm0,xmm0
    9:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFPhZNhG32h:
+Disassembly of section .text._D9cdvecfill5test2FPhZNhG32h:
 
-0000000000000000 <_D9cdvecfill4testFPhZNhG32h>:
+0000000000000000 <_D9cdvecfill5test2FPhZNhG32h>:
    0:	c4 e2 7d 78 07       	vpbroadcastb ymm0,BYTE PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFgZNhG32g:
+Disassembly of section .text._D9cdvecfill5test2FgZNhG32g:
 
-0000000000000000 <_D9cdvecfill4testFgZNhG32g>:
+0000000000000000 <_D9cdvecfill5test2FgZNhG32g>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 78 c0       	vpbroadcastb ymm0,xmm0
    9:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFPgZNhG32g:
+Disassembly of section .text._D9cdvecfill5test2FPgZNhG32g:
 
-0000000000000000 <_D9cdvecfill4testFPgZNhG32g>:
+0000000000000000 <_D9cdvecfill5test2FPgZNhG32g>:
    0:	c4 e2 7d 78 07       	vpbroadcastb ymm0,BYTE PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFtZNhG16t:
+Disassembly of section .text._D9cdvecfill5test2FtZNhG16t:
 
-0000000000000000 <_D9cdvecfill4testFtZNhG16t>:
+0000000000000000 <_D9cdvecfill5test2FtZNhG16t>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 79 c0       	vpbroadcastw ymm0,xmm0
    9:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFPtZNhG16t:
+Disassembly of section .text._D9cdvecfill5test2FPtZNhG16t:
 
-0000000000000000 <_D9cdvecfill4testFPtZNhG16t>:
+0000000000000000 <_D9cdvecfill5test2FPtZNhG16t>:
    0:	c4 e2 7d 79 07       	vpbroadcastw ymm0,WORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFsZNhG16s:
+Disassembly of section .text._D9cdvecfill5test2FsZNhG16s:
 
-0000000000000000 <_D9cdvecfill4testFsZNhG16s>:
+0000000000000000 <_D9cdvecfill5test2FsZNhG16s>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 79 c0       	vpbroadcastw ymm0,xmm0
    9:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFPsZNhG16s:
+Disassembly of section .text._D9cdvecfill5test2FPsZNhG16s:
 
-0000000000000000 <_D9cdvecfill4testFPsZNhG16s>:
+0000000000000000 <_D9cdvecfill5test2FPsZNhG16s>:
    0:	c4 e2 7d 79 07       	vpbroadcastw ymm0,WORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFkZNhG8k:
+Disassembly of section .text._D9cdvecfill5test2FkZNhG8k:
 
-0000000000000000 <_D9cdvecfill4testFkZNhG8k>:
+0000000000000000 <_D9cdvecfill5test2FkZNhG8k>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 58 c0       	vpbroadcastd ymm0,xmm0
    9:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFPkZNhG8k:
+Disassembly of section .text._D9cdvecfill5test2FPkZNhG8k:
 
-0000000000000000 <_D9cdvecfill4testFPkZNhG8k>:
+0000000000000000 <_D9cdvecfill5test2FPkZNhG8k>:
    0:	c4 e2 7d 58 07       	vpbroadcastd ymm0,DWORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFiZNhG8i:
+Disassembly of section .text._D9cdvecfill5test2FiZNhG8i:
 
-0000000000000000 <_D9cdvecfill4testFiZNhG8i>:
+0000000000000000 <_D9cdvecfill5test2FiZNhG8i>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 58 c0       	vpbroadcastd ymm0,xmm0
    9:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFPiZNhG8i:
+Disassembly of section .text._D9cdvecfill5test2FPiZNhG8i:
 
-0000000000000000 <_D9cdvecfill4testFPiZNhG8i>:
+0000000000000000 <_D9cdvecfill5test2FPiZNhG8i>:
    0:	c4 e2 7d 58 07       	vpbroadcastd ymm0,DWORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFmZNhG4m:
+Disassembly of section .text._D9cdvecfill5test2FmZNhG4m:
 
-0000000000000000 <_D9cdvecfill4testFmZNhG4m>:
+0000000000000000 <_D9cdvecfill5test2FmZNhG4m>:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c4 e2 7d 59 c0       	vpbroadcastq ymm0,xmm0
    a:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFPmZNhG4m:
+Disassembly of section .text._D9cdvecfill5test2FPmZNhG4m:
 
-0000000000000000 <_D9cdvecfill4testFPmZNhG4m>:
+0000000000000000 <_D9cdvecfill5test2FPmZNhG4m>:
    0:	c4 e2 7d 59 07       	vpbroadcastq ymm0,QWORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFlZNhG4l:
+Disassembly of section .text._D9cdvecfill5test2FlZNhG4l:
 
-0000000000000000 <_D9cdvecfill4testFlZNhG4l>:
+0000000000000000 <_D9cdvecfill5test2FlZNhG4l>:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c4 e2 7d 59 c0       	vpbroadcastq ymm0,xmm0
    a:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFPlZNhG4l:
+Disassembly of section .text._D9cdvecfill5test2FPlZNhG4l:
 
-0000000000000000 <_D9cdvecfill4testFPlZNhG4l>:
+0000000000000000 <_D9cdvecfill5test2FPlZNhG4l>:
    0:	c4 e2 7d 59 07       	vpbroadcastq ymm0,QWORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFfZNhG8f:
+Disassembly of section .text._D9cdvecfill5test2FfZNhG8f:
 
-0000000000000000 <_D9cdvecfill4testFfZNhG8f>:
+0000000000000000 <_D9cdvecfill5test2FfZNhG8f>:
    0:	50                   	push   rax
    1:	c5 fa 11 04 24       	vmovss DWORD PTR [rsp],xmm0
    6:	c5 fa 10 04 24       	vmovss xmm0,DWORD PTR [rsp]
@@ -290,16 +290,16 @@ Disassembly of section .text._D9cdvecfill4testFfZNhG8f:
   11:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFPfZNhG8f:
+Disassembly of section .text._D9cdvecfill5test2FPfZNhG8f:
 
-0000000000000000 <_D9cdvecfill4testFPfZNhG8f>:
+0000000000000000 <_D9cdvecfill5test2FPfZNhG8f>:
    0:	c4 e2 7d 18 07       	vbroadcastss ymm0,DWORD PTR [rdi]
    5:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFdZNhG4d:
+Disassembly of section .text._D9cdvecfill5test2FdZNhG4d:
 
-0000000000000000 <_D9cdvecfill4testFdZNhG4d>:
+0000000000000000 <_D9cdvecfill5test2FdZNhG4d>:
    0:	50                   	push   rax
    1:	c5 fb 11 04 24       	vmovsd QWORD PTR [rsp],xmm0
    6:	c5 fb 10 04 24       	vmovsd xmm0,QWORD PTR [rsp]
@@ -308,9 +308,9 @@ Disassembly of section .text._D9cdvecfill4testFdZNhG4d:
   11:	c3                   	ret    
 	...
 
-Disassembly of section .text._D9cdvecfill4testFPdZNhG4d:
+Disassembly of section .text._D9cdvecfill5test2FPdZNhG4d:
 
-0000000000000000 <_D9cdvecfill4testFPdZNhG4d>:
+0000000000000000 <_D9cdvecfill5test2FPdZNhG4d>:
    0:	c4 e2 7d 19 07       	vbroadcastsd ymm0,QWORD PTR [rdi]
    5:	c3                   	ret    
 	...


### PR DESCRIPTION
Extracted from #8429 to reduce the diff.

The change to `go.d` isn't required but it's redundant anyway.