### PR TITLE
Issue transition warnings for {posix,win32,win64}.mak files

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -39,6 +39,10 @@
 # install               Installs dmd into $(INSTALL_DIR)
 ################################################################################
 
+$(warning ===== DEPRECATION NOTICE ===== )
+$(warning ===== DEPRECATION: posix.mak is deprecated. Please use src/build.d instead.)
+$(warning ============================== )
+
 # Forward D compiler bootstrapping to bootstrap.sh
 ifneq (,$(AUTO_BOOTSTRAP))
 default:

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -1,3 +1,4 @@
+# DEPRECATED - use src\build.d
 #_ win32.mak
 #
 # Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved
@@ -85,6 +86,9 @@ auto-tester-build: $(GEN)\build.exe
 dmd: $G reldmd
 
 $(GEN)\build.exe: build.d $(HOST_DMD_PATH)
+	echo "===== DEPRECATION NOTICE ====="
+	echo "===== DEPRECATION: win32.mak is deprecated. Please use src\build.d instead."
+	echo "=============================="
 	$(HOST_DC) -m$(MODEL) -of$@ -g build.d
 
 release:

--- a/src/win64.mak
+++ b/src/win64.mak
@@ -1,3 +1,4 @@
+# DEPRECATED - use src\build.d
 #_ win64.mak
 #
 # Supports same targets as win32.mak.

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,3 +1,5 @@
+$(warning ===== DEPRECATION: test/Makefile is deprecated. Please use test/run.d instead.)
+
 ifeq (Windows_NT,$(OS))
     ifeq ($(findstring WOW64, $(shell uname)),WOW64)
         OS:=windows


### PR DESCRIPTION
I'm aware that there are still a few CIs and packers out there using the Makefiles, but I think it's time we start to raise awareness to everyone. The Makefiles are already only wrappers for the respective D files. They won't be removed in the immediate future (too many of the CIs here use them still directly).

CC @MoonlightSentinel 