### PR TITLE
Mangle C++ function parameter pack (POSIX)

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1483,6 +1483,9 @@ private final class CppMangleVisitor : Visitor
         // expressions are mangled in <X..E>
         if (param.isTemplateValueParameter())
             buf.writeByte('X');
+        else if (param.isTemplateTupleParameter() &&
+                 global.params.cplusplus >= CppStdRevision.cpp11)
+            buf.writestring("Dp");
         buf.writeByte('T');
         writeSequenceFromIndex(idx);
         buf.writeByte('_');

--- a/test/runnable_cxx/externmangle.d
+++ b/test/runnable_cxx/externmangle.d
@@ -1,4 +1,5 @@
 // EXTRA_CPP_SOURCES: externmangle.cpp
+// REQUIRED_ARGS: -extern-std=c++11
 
 import core.stdc.config;
 import core.stdc.stdint;
@@ -238,6 +239,23 @@ void test39()
 
 extern(C++, "foo", "bar", "baz") int doStuff(int);
 
+version(CppRuntime_DigitalMars) // DMC doesn't support c++11
+{
+    void test40() {}
+}
+else
+{
+    void test40();
+
+    void foovargs(T...)(T args)
+    {
+        float ret = args[0] + args[1];
+        assert(ret == 3.0f);
+    }
+
+    alias FooVargs = foovargs!(int, float);
+}
+
 void main()
 {
     test1(Foo!int());
@@ -329,4 +347,6 @@ void main()
     test39();
 
     assert(doStuff(2) == 4);
+
+    test40();
 }

--- a/test/runnable_cxx/extra-files/externmangle.cpp
+++ b/test/runnable_cxx/extra-files/externmangle.cpp
@@ -425,3 +425,12 @@ namespace foo
         }
     }
 }
+
+#ifndef __DMC__ // DMC doesn't support c++11
+template<typename ...T> void foovargs(T... args);
+
+void test40()
+{
+    foovargs<int, float>(1, 2.0f);
+}
+#endif


### PR DESCRIPTION
From https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle.function-type

When a function parameter is a C++11 function parameter pack, its type is mangled with `Dp <type>`, i.e., its type is a pack expansion: 
```
 <type>  ::= Dp <type>          # pack expansion (C++11)
```