### PR TITLE
Fix Issue 21164 - segfault on incomplete static if

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -918,6 +918,10 @@ extern (C++) final class StaticIfCondition : Condition
 
             import dmd.staticcond;
             bool errors;
+
+            if (!exp)
+                return errorReturn();
+
             bool result = evalStaticCondition(sc, exp, exp, errors);
 
             // Prevent repeated condition evaluation.

--- a/test/fail_compilation/imports/test21164a.d
+++ b/test/fail_compilation/imports/test21164a.d
@@ -1,0 +1,9 @@
+struct D(E)
+{
+    void G()    {
+        import imports.test21164d;
+        I;
+    }
+
+}
+

--- a/test/fail_compilation/imports/test21164b.d
+++ b/test/fail_compilation/imports/test21164b.d
@@ -1,0 +1,4 @@
+import imports.test21164c;
+enum N = O();
+alias Q = R!(N, S);
+

--- a/test/fail_compilation/imports/test21164c.d
+++ b/test/fail_compilation/imports/test21164c.d
@@ -1,0 +1,10 @@
+enum S = 1;
+
+struct O
+{
+}
+
+struct R(O U, int W)
+{
+}
+

--- a/test/fail_compilation/imports/test21164d.d
+++ b/test/fail_compilation/imports/test21164d.d
@@ -1,0 +1,9 @@
+auto AB()
+{
+static if}
+
+auto I()
+{
+AB;
+}
+

--- a/test/fail_compilation/test21164.d
+++ b/test/fail_compilation/test21164.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/imports/test21164d.d(3): Error: (expression) expected following `static if`
+fail_compilation/imports/test21164d.d(3): Error: found `}` instead of statement
+fail_compilation/test21164.d(11): Error: template instance `test21164a.D!(R!(O(), 1))` error instantiating
+---
+*/
+import imports.test21164a;
+import imports.test21164b;
+auto GB(D!Q)
+{
+}


### PR DESCRIPTION
With this change, when evaluating a static if, we now check for the existence of an static if
condition and will only proceed if there is one.