### PR TITLE
Separate objc data from the rest of `FuncDeclaration`

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -506,8 +506,6 @@ public:
     VarDeclaration *vthis;              // 'this' parameter (member and nested)
     bool isThis2;                       // has a dual-context 'this' parameter
     VarDeclaration *v_arguments;        // '_arguments' parameter
-    ObjcSelector *selector;             // Objective-C method selector (member function only)
-    VarDeclaration *selectorParameter;  // Objective-C implicit selector parameter
 
     VarDeclaration *v_argptr;           // '_argptr' variable
     VarDeclarations *parameters;        // Array of VarDeclaration's for parameters
@@ -580,6 +578,10 @@ public:
     FuncDeclarations *inlinedNestedCallees;
 
     unsigned flags;                     // FUNCFLAGxxxxx
+
+    // Data for a function declaration that is needed for the Objective-C
+    // integration.
+    ObjcFuncDeclaration objc;
 
     static FuncDeclaration *create(const Loc &loc, const Loc &endloc, Identifier *id, StorageClass storage_class, Type *type);
     Dsymbol *syntaxCopy(Dsymbol *);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1038,7 +1038,7 @@ L1:
     }
     else if (ad && ad.isClassDeclaration && ad.isClassDeclaration.classKind == ClassKind.objc &&
              var.isFuncDeclaration && var.isFuncDeclaration.isStatic &&
-             var.isFuncDeclaration.selector)
+             var.isFuncDeclaration.objc.selector)
     {
         return new ObjcClassReferenceExp(e1.loc, cast(ClassDeclaration) ad);
     }

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -784,7 +784,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     size_t pi = (fd.v_arguments !is null);
     if (fd.parameters)
         pi += fd.parameters.dim;
-    if (fd.selector)
+    if (fd.objc.selector)
         pi++; // Extra argument for Objective-C selector
     // Create a temporary buffer, params[], to hold function parameters
     Symbol*[10] paramsbuf = void;

--- a/src/dmd/objc.h
+++ b/src/dmd/objc.h
@@ -48,6 +48,12 @@ struct ObjcClassDeclaration
     bool isRootClass() const;
 };
 
+struct ObjcFuncDeclaration
+{
+    ObjcSelector* selector;
+    VarDeclaration* selectorParameter;
+};
+
 class Objc
 {
 public:

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -194,9 +194,9 @@ extern(C++) final class Supported : ObjcGlue
 
     override void setupMethodSelector(FuncDeclaration fd, elem** esel)
     {
-        if (fd && fd.selector && !*esel)
+        if (fd && fd.objc.selector && !*esel)
         {
-            *esel = el_var(Symbols.getMethVarRef(fd.selector.toString()));
+            *esel = el_var(Symbols.getMethVarRef(fd.objc.selector.toString()));
         }
     }
 
@@ -289,11 +289,11 @@ extern(C++) final class Supported : ObjcGlue
     }
     do
     {
-        if (!fd.selector)
+        if (!fd.objc.selector)
             return count;
 
-        assert(fd.selectorParameter);
-        auto selectorSymbol = fd.selectorParameter.toSymbol();
+        assert(fd.objc.selectorParameter);
+        auto selectorSymbol = fd.objc.selectorParameter.toSymbol();
         memmove(params + 1, params, count * params[0].sizeof);
         params[0] = selectorSymbol;
 
@@ -1125,8 +1125,8 @@ private:
 
             if (func && func.fbody)
             {
-                assert(func.selector);
-                dtb.xoff(func.selector.toNameSymbol(), 0); // method name
+                assert(func.objc.selector);
+                dtb.xoff(func.objc.selector.toNameSymbol(), 0); // method name
                 dtb.xoff(Symbols.getMethVarType(func), 0); // method type string
                 dtb.xoff(func.toSymbol(), 0); // function implementation
             }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -4260,7 +4260,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             if (mt.sym.classKind == ClassKind.objc
                 && d.isFuncDeclaration()
                 && d.isFuncDeclaration().isStatic
-                && d.isFuncDeclaration().selector)
+                && d.isFuncDeclaration().objc.selector)
             {
                 auto classRef = new ObjcClassReferenceExp(e.loc, mt.sym);
                 return new DotVarExp(e.loc, classRef, d).expressionSemantic(sc);


### PR DESCRIPTION
This allows to move some more things to the `objc` module and makes it consistent with class declarations.