### PR TITLE
 Add __traits(isDynamicArray, T), second try

### DIFF
--- a/changelog/trait_isdynamicarray.dd
+++ b/changelog/trait_isdynamicarray.dd
@@ -1,0 +1,9 @@
+Added new builtin trait `__traits(isDynamicArray, T)`.
+
+A new trait
+
+---
+__traits(isDynamicArray, T)
+---
+
+has been added that checks whether a type `T` is a dynamic array (slice) or not.

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -425,6 +425,7 @@ immutable Msgtable[] msgtable =
     { "isFloating" },
     { "isIntegral" },
     { "isScalar" },
+    { "isDynamicArray" },
     { "isStaticArray" },
     { "isUnsigned" },
     { "isVirtualFunction" },

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -105,6 +105,7 @@ shared static this()
         "isFloating",
         "isIntegral",
         "isScalar",
+        "isDynamicArray",
         "isStaticArray",
         "isUnsigned",
         "isVirtualFunction",
@@ -583,6 +584,10 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     if (e.ident == Id.isFuture)
     {
        return isDeclX(t => t.isFuture());
+    }
+    if (e.ident == Id.isDynamicArray)
+    {
+        return isTypeX(t => (t.toBasetype().ty == Tarray));
     }
     if (e.ident == Id.isStaticArray)
     {

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -548,6 +548,10 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         });
     }
 
+    if (e.ident == Id.isDynamicArray)
+    {
+        return isTypeX(t => (t.toBasetype().ty == Tarray));
+    }
     if (e.ident == Id.isArithmetic)
     {
         return isTypeX(t => t.isintegral() || t.isfloating());
@@ -584,10 +588,6 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     if (e.ident == Id.isFuture)
     {
        return isDeclX(t => t.isFuture());
-    }
-    if (e.ident == Id.isDynamicArray)
-    {
-        return isTypeX(t => (t.toBasetype().ty == Tarray));
     }
     if (e.ident == Id.isStaticArray)
     {

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -548,10 +548,6 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         });
     }
 
-    if (e.ident == Id.isDynamicArray)
-    {
-        return isTypeX(t => (t.toBasetype().ty == Tarray));
-    }
     if (e.ident == Id.isArithmetic)
     {
         return isTypeX(t => t.isintegral() || t.isfloating());
@@ -588,6 +584,10 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     if (e.ident == Id.isFuture)
     {
        return isDeclX(t => t.isFuture());
+    }
+    if (e.ident == Id.isDynamicArray)
+    {
+        return isTypeX(t => (t.toBasetype().ty == Tarray));
     }
     if (e.ident == Id.isStaticArray)
     {

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -980,4 +980,4 @@ enum enumOfTypeString : string
     a = "a",
     b = "b",
 }
-static assert(__traits(isDynamicArray, enumOfTypeString) == true);
+static assert(__traits(isDynamicArray, enumOfTypeString));

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -974,3 +974,10 @@ static assert(!__traits(compiles,
 {
     static class C11624 : I11624 { }
 }));
+
+enum enumOfTypeString : string
+{
+    a = "a",
+    b = "b",
+}
+static assert(__traits(isDynamicArray, enumOfTypeString) == true);

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -305,6 +305,12 @@ void test7a()
     assert(__traits(isDynamicArray, char) == false);
     assert(__traits(isDynamicArray, wchar) == false);
     assert(__traits(isDynamicArray, dchar) == false);
+    enum E : string
+    {
+        a = "a",
+        b = "b",
+    }
+    assert(__traits(isDynamicArray, E) == true);
 }
 
 /********************************************************/

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -271,7 +271,45 @@ void test6()
 
 /********************************************************/
 
-void test7()
+void test7a()
+{
+    assert(__traits(isDynamicArray) == false);
+    assert(__traits(isDynamicArray, S) == false);
+    assert(__traits(isDynamicArray, C) == false);
+    assert(__traits(isDynamicArray, E) == false);
+    assert(__traits(isDynamicArray, void*) == false);
+    assert(__traits(isDynamicArray, void[]) == true);
+    assert(__traits(isDynamicArray, void[3]) == false);
+    assert(__traits(isDynamicArray, int[char]) == false);
+    assert(__traits(isDynamicArray, float, float) == false);
+    assert(__traits(isDynamicArray, float, S) == false);
+
+    assert(__traits(isDynamicArray, void) == false);
+    assert(__traits(isDynamicArray, byte) == false);
+    assert(__traits(isDynamicArray, ubyte) == false);
+    assert(__traits(isDynamicArray, short) == false);
+    assert(__traits(isDynamicArray, ushort) == false);
+    assert(__traits(isDynamicArray, int) == false);
+    assert(__traits(isDynamicArray, uint) == false);
+    assert(__traits(isDynamicArray, long) == false);
+    assert(__traits(isDynamicArray, ulong) == false);
+    assert(__traits(isDynamicArray, float) == false);
+    assert(__traits(isDynamicArray, double) == false);
+    assert(__traits(isDynamicArray, real) == false);
+    assert(__traits(isDynamicArray, ifloat) == false);
+    assert(__traits(isDynamicArray, idouble) == false);
+    assert(__traits(isDynamicArray, ireal) == false);
+    assert(__traits(isDynamicArray, cfloat) == false);
+    assert(__traits(isDynamicArray, cdouble) == false);
+    assert(__traits(isDynamicArray, creal) == false);
+    assert(__traits(isDynamicArray, char) == false);
+    assert(__traits(isDynamicArray, wchar) == false);
+    assert(__traits(isDynamicArray, dchar) == false);
+}
+
+/********************************************************/
+
+void test7b()
 {
     assert(__traits(isStaticArray) == false);
     assert(__traits(isStaticArray, S) == false);
@@ -1501,7 +1539,8 @@ int main()
     test4();
     test5();
     test6();
-    test7();
+    test7a();
+    test7b();
     test8();
     test9();
     test10();


### PR DESCRIPTION
Discussion at https://forum.dlang.org/post/nhnofvzmijywsgqyyibw@forum.dlang.org.

Reopening of https://github.com/dlang/dmd/pull/9014.

This benchmark clearly shows the overhead of the templated approach for the case when trait argument is not an enum. In the enum case the overheads is gonna be greater because `isDynamicArray` is gonna instantiate twice for each enum parameter.

```D
// version = useBuiltin;           ///< Use new builtin trait __traits(isDynamicArray, ...)

private static alias ScalarTypes = AliasSeq!(bool,
                                             char, wchar, dchar,
                                             byte, ubyte,
                                             short, ushort,
                                             int, uint,
                                             long, ulong,
                                             float, double, real,
                                             cfloat, cdouble, creal,
                                             ifloat, idouble, ireal,
                                             string, wstring, dstring);

private static enum qualifiers = AliasSeq!("", "const", "inout", "immutable", "shared", "shared const");

static private template isDynamicArray(T)
{
    static if (is(T == U[], U))
        enum bool isDynamicArray = true;
    else static if (is(T U == enum))
        enum bool isDynamicArray = isDynamicArray!U;
    else
        enum bool isDynamicArray = false;
}

static foreach (T; ScalarTypes)
{
    static foreach (U; ScalarTypes)
    {
        static foreach (V; ScalarTypes)
        {
            mixin("struct ",
                  T, "_" ,U, "_" ,V,
                  " {",
                  T, " t; ",
                  U, " u; ",
                  V, " v; ",
                  "}");
            static foreach (qualifier; qualifiers)
            {
                version(useBuiltin)
                    static assert(__traits(isDynamicArray, mixin(qualifier, "(", T, "_", U, "_", V, ")")[])); // min over 10 runs: 2.62s.
                else
                    // static assert(is(mixin(qualifier, "(", T, "_", U, "_", V, ")")[] == X[], X)); // min over 10 runs: 2.75s
                    static assert(isDynamicArray!(mixin(qualifier, "(", T, "_", U, "_", V, ")")[])); // min over 10 runs: 3.19s
            }
        }
    }
}
```

There's also the issue of API consistency. If `isStaticArray` is present as a builtin trait a developer is gonna ask why isn't `isDynamicArray` present aswell?