### PR TITLE
Properly fix TypeFunction.funcFlags alignment issue

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -281,7 +281,7 @@ struct ASTBase
         fwd,   // POD not yet computed
     }
 
-    enum TRUST : int
+    enum TRUST : ubyte
     {
         default_   = 0,
         system     = 1,    // @system (same as TRUST.default)
@@ -290,7 +290,7 @@ struct ASTBase
         live       = 4,    // @live
     }
 
-    enum PURE : int
+    enum PURE : ubyte
     {
         impure      = 0,    // not pure at all
         fwdref      = 1,    // it's pure, but not known which level yet
@@ -3965,8 +3965,9 @@ struct ASTBase
 
         ParameterList parameterList;   // function parameters
 
-        private enum FunctionFlag
+        private enum FunctionFlag : uint
         {
+            none            = 0,
             isnothrow       = 0x0001, // nothrow
             isnogc          = 0x0002, // is @nogc
             isproperty      = 0x0004, // can be called without parentheses
@@ -3980,14 +3981,13 @@ struct ASTBase
             inoutParam      = 0x0400, // inout on the parameters
             inoutQual       = 0x0800, // inout on the qualifier
         }
-        static assert (FunctionFlag.max <= ushort.max, "flags are stored in a ushort");
 
         LINK linkage;               // calling convention
+        FunctionFlag funcFlags;
         TRUST trust;                // level of trust
-        Expressions* fargs;         // function arguments
         PURE purity = PURE.impure;
-        ushort funcFlags;
         byte inuse;
+        Expressions* fargs;         // function arguments
 
         extern (D) this(ParameterList pl, Type treturn, LINK linkage, StorageClass stc = 0)
         {

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4148,7 +4148,7 @@ enum RET : int
     stack        = 2,    // returned on stack
 }
 
-enum TRUST : int
+enum TRUST : ubyte
 {
     default_   = 0,
     system     = 1,    // @system (same as TRUST.default)
@@ -4165,7 +4165,7 @@ enum TRUSTformat : int
 alias TRUSTformatDefault = TRUSTformat.TRUSTformatDefault;
 alias TRUSTformatSystem = TRUSTformat.TRUSTformatSystem;
 
-enum PURE : int
+enum PURE : ubyte
 {
     impure      = 0,    // not pure at all
     fwdref      = 1,    // it's pure, but not known which level yet
@@ -4182,8 +4182,9 @@ extern (C++) final class TypeFunction : TypeNext
 
     ParameterList parameterList;   // function parameters
 
-    private enum FunctionFlag
+    private enum FunctionFlag : uint
     {
+        none            = 0,
         isnothrow       = 0x0001, // nothrow
         isnogc          = 0x0002, // is @nogc
         isproperty      = 0x0004, // can be called without parentheses
@@ -4197,14 +4198,13 @@ extern (C++) final class TypeFunction : TypeNext
         inoutParam      = 0x0400, // inout on the parameters
         inoutQual       = 0x0800, // inout on the qualifier
     }
-    static assert (FunctionFlag.max <= ushort.max, "flags are stored in a ushort");
 
     LINK linkage;               // calling convention
+    FunctionFlag funcFlags;
     TRUST trust;                // level of trust
-    Expressions* fargs;         // function arguments
     PURE purity = PURE.impure;
-    ushort funcFlags;
     byte inuse;
+    Expressions* fargs;         // function arguments
 
     extern (D) this(ParameterList pl, Type treturn, LINK linkage, StorageClass stc = 0)
     {

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -515,12 +515,12 @@ enum RET
     RETstack    = 2     // returned on stack
 };
 
-enum TRUST
+enum class TRUST : unsigned char
 {
-    TRUSTdefault = 0,
-    TRUSTsystem = 1,    // @system (same as TRUSTdefault)
-    TRUSTtrusted = 2,   // @trusted
-    TRUSTsafe = 3       // @safe
+    default_ = 0,
+    system = 1,    // @system (same as TRUSTdefault)
+    trusted = 2,   // @trusted
+    safe = 3       // @safe
 };
 
 enum TRUSTformat
@@ -529,13 +529,13 @@ enum TRUSTformat
     TRUSTformatSystem    // emit @system when trust == TRUSTdefault
 };
 
-enum PURE
+enum class PURE : unsigned char
 {
-    PUREimpure = 0,     // not pure at all
-    PUREfwdref = 1,     // it's pure, but not known which level yet
-    PUREweak = 2,       // no mutable globals are read or written
-    PUREconst = 3,      // parameters are values or const
-    PUREstrong = 4      // parameters are values or immutable
+    impure = 0,     // not pure at all
+    fwdref = 1,     // it's pure, but not known which level yet
+    weak = 2,       // no mutable globals are read or written
+    const_ = 3,     // parameters are values or const
+    strong = 4      // parameters are values or immutable
 };
 
 class Parameter : public ASTNode
@@ -578,11 +578,11 @@ public:
 
     ParameterList parameterList; // function parameters
     LINK linkage;                // calling convention
+    unsigned funcFlags;
     TRUST trust;                 // level of trust
-    Expressions *fargs;          // function arguments
     PURE purity;                 // PURExxxx
-    unsigned short funcFlags;
     char inuse;
+    Expressions *fargs;          // function arguments
 
     static TypeFunction *create(Parameters *parameters, Type *treturn, VarArg varargs, LINK linkage, StorageClass stc = 0);
     const char *kind();

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -362,8 +362,8 @@ void test_types()
     assert(tfunction->isreturninferred());
     assert(!tfunction->isscopeinferred());
     assert(tfunction->linkage == LINKd);
-    assert(tfunction->trust == TRUSTtrusted);
-    assert(tfunction->purity == PUREimpure);
+    assert(tfunction->trust == TRUST::trusted);
+    assert(tfunction->purity == PURE::impure);
 }
 
 /**********************************/


### PR DESCRIPTION
PR #11594 worked around it by aligning the field at a 4-bytes boundary for now, but doesn't guarantee that it remains this way.

This commit gets rid of the manual ushort optimization and stores the flags as their 4-bytes enum type, but shrinks the sizes of the `TRUST` and `PURE` enums from 4 to 1 byte and rearranges the `TypeFunction` fields, so that the TypeFunction class instance size remains more or less the same (64-bit hosts: 112 bytes now vs. 111 bytes before; 32-bit: 72 vs. 75 bytes).