### PR TITLE
fix Issue 21181 - Inline Assembler compiles long ptr as a byte operati…

### DIFF
--- a/test/fail_compilation/failasm.d
+++ b/test/fail_compilation/failasm.d
@@ -1,0 +1,24 @@
+/*
+REQUIRED_ARGS: -m32
+TEST_OUTPUT:
+---
+fail_compilation/failasm.d(112): Error: use -m64 to compile 64 bit instructions
+---
+*/
+
+#line 100
+
+// https://issues.dlang.org/show_bug.cgi?id=21181
+
+uint func()
+{
+    asm
+    {
+        naked;
+        inc [EAX];
+        inc byte ptr [EAX];
+        inc short ptr [EAX];
+        inc int ptr [EAX];
+        inc long ptr [EAX];
+    }
+}


### PR DESCRIPTION
…on for 32 bit compiles

The `ptr` should override the matching logic.