### PR TITLE
fix Issue 2617 - asm silently accepts ambiguous-sized operations

### DIFF
--- a/test/fail_compilation/failasm.d
+++ b/test/fail_compilation/failasm.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -m32
 TEST_OUTPUT:
 ---
-fail_compilation/failasm.d(112): Error: use -m64 to compile 64 bit instructions
+fail_compilation/failasm.d(111): Error: use -m64 to compile 64 bit instructions
 ---
 */
 
@@ -15,7 +15,6 @@ uint func()
     asm
     {
         naked;
-        inc [EAX];
         inc byte ptr [EAX];
         inc short ptr [EAX];
         inc int ptr [EAX];

--- a/test/fail_compilation/failasm2.d
+++ b/test/fail_compilation/failasm2.d
@@ -1,0 +1,35 @@
+/*
+REQUIRED_ARGS: -m32
+TEST_OUTPUT:
+---
+fail_compilation/failasm2.d(108): Error: operand size for opcode `inc` is ambiguous, add `ptr byte/short/int/long` prefix
+fail_compilation/failasm2.d(110): Error: operand size for opcode `dec` is ambiguous, add `ptr byte/short/int/long` prefix
+fail_compilation/failasm2.d(111): Error: operand size for opcode `imul` is ambiguous, add `ptr byte/short/int/long` prefix
+fail_compilation/failasm2.d(112): Error: operand size for opcode `idiv` is ambiguous, add `ptr byte/short/int/long` prefix
+fail_compilation/failasm2.d(113): Error: operand size for opcode `mul` is ambiguous, add `ptr byte/short/int/long` prefix
+fail_compilation/failasm2.d(114): Error: operand size for opcode `div` is ambiguous, add `ptr byte/short/int/long` prefix
+fail_compilation/failasm2.d(115): Error: operand size for opcode `neg` is ambiguous, add `ptr byte/short/int/long` prefix
+fail_compilation/failasm2.d(116): Error: operand size for opcode `not` is ambiguous, add `ptr byte/short/int/long` prefix
+---
+*/
+
+#line 100
+
+// https://issues.dlang.org/show_bug.cgi?id=2617
+
+uint test2617()
+{
+    asm
+    {
+        naked;
+        inc     [EAX];
+        inc     byte ptr [EAX];
+        dec     [EAX];
+        imul    [EAX];
+        idiv    [EAX];
+        mul     [EAX];
+        div     [EAX];
+        neg     [EAX];
+        not     [EAX];
+    }
+}

--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -3888,7 +3888,7 @@ void test52()
 //      neg     i       ;
 //      neg     l       ;
         neg     x       ;
-        neg     [EBX]   ;
+        neg     byte ptr [EBX]   ;
 
 L1:     pop     EAX     ;
         mov     p[EBP],EAX ;

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -3902,8 +3902,8 @@ void test52()
 //      neg     i       ;
 //      neg     l       ;
         neg     x       ;
-        neg     [EBX]   ;
-        neg     [RBX]   ;
+        neg     byte ptr [EBX]   ;
+        neg     byte ptr [RBX]   ;
         neg     R8      ;
 
 L1:     pop     RAX     ;


### PR DESCRIPTION
Checks to see if `ptr byte/short/int/long` is needed to disambiguate.