### PR TITLE
fix Issue 17617 - No RIP relative addressing available in x64 inline …

### DIFF
--- a/test/fail_compilation/iasm1.d
+++ b/test/fail_compilation/iasm1.d
@@ -53,9 +53,13 @@ void test2()
 ---
 fail_compilation/iasm1.d(306): Error: operand cannot have both R8 and [R9]
 fail_compilation/iasm1.d(307): Error: operand cannot have both RDX and 0x3
+fail_compilation/iasm1.d(308): Error: cannot have two symbols in addressing mode
+fail_compilation/iasm1.d(309): Error: cannot have two symbols in addressing mode
+fail_compilation/iasm1.d(310): Error: cannot have two symbols in addressing mode
 ---
 */
 
+// https://issues.dlang.org/show_bug.cgi?id=17616
 // https://issues.dlang.org/show_bug.cgi?id=18373
 
 #line 300
@@ -67,6 +71,9 @@ void test3()
         naked;
         mov RAX,[R9][R10]R8;
         mov RAX,[3]RDX;
+	mov RAX,[RIP][RIP];
+	mov RAX,[RIP][RCX];
+	mov RAX,[RIP]RCX;
     }
 }
 

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -186,6 +186,9 @@ void test6()
         0x49, 0x8B, 0x45, 0x00,         // mov RAX,0[R13]
         0x4A, 0x8B, 0x04, 0x1D, 0x00, 0x00, 0x00, 0x00, // mov RAX,[00h][R11]
         0x49, 0x8B, 0x03,               // mov RAX,[R11]
+
+        0x8B, 0x05, 0x00, 0x00, 0x00, 0x00,  // mov EAX,[RIP]
+        0x8B, 0x05, 0x05, 0x00, 0x00, 0x00,  // mov EAX,5[RIP]
     ];
     int i;
 
@@ -218,6 +221,9 @@ void test6()
         mov     RAX,[R13]               ;
         mov     RAX,[0+1*R11]           ;
         mov     RAX,[R11]               ;
+
+        mov     EAX,[RIP]               ;
+        mov     EAX,5[RIP]              ;
 
 L1:
         pop     RBX                     ;


### PR DESCRIPTION
…assembly (iasm)

RIP is a real register on the PDP-11, in that it is accessible like any other register. On the x64, however, it's just a wacky special case  addressing mode, meaning supporting it requires wacky special case code in the assembler.