### PR TITLE
fix Issue 16092 - AVX registers YMM0-YMM7 are inaccessible to 32-bit asm

### DIFF
--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -417,7 +417,7 @@ enum // the x86 CPU numbers for these registers
     _FS           = 4,
 }
 
-immutable REG[63] regtab =
+immutable REG[71] regtab =
 [
     {"AL",   _AL,    _r8 | _al},
     {"AH",   _AH,    _r8},
@@ -482,6 +482,14 @@ immutable REG[63] regtab =
     {"XMM5", 5,      _xmm},
     {"XMM6", 6,      _xmm},
     {"XMM7", 7,      _xmm},
+    {"YMM0",   0,    _ymm},
+    {"YMM1",   1,    _ymm},
+    {"YMM2",   2,    _ymm},
+    {"YMM3",   3,    _ymm},
+    {"YMM4",   4,    _ymm},
+    {"YMM5",   5,    _ymm},
+    {"YMM6",   6,    _ymm},
+    {"YMM7",   7,    _ymm},
 ];
 
 
@@ -536,7 +544,7 @@ enum // 64 bit only registers
     _R15B = 15,
 }
 
-immutable REG[73] regtab64 =
+immutable REG[65] regtab64 =
 [
     {"RAX",  _RAX,   _r64 | _rax},
     {"RBX",  _RBX,   _r64},
@@ -595,14 +603,6 @@ immutable REG[73] regtab64 =
     {"XMM14", 14,    _xmm},
     {"XMM15", 15,    _xmm},
 
-    {"YMM0",   0,    _ymm},
-    {"YMM1",   1,    _ymm},
-    {"YMM2",   2,    _ymm},
-    {"YMM3",   3,    _ymm},
-    {"YMM4",   4,    _ymm},
-    {"YMM5",   5,    _ymm},
-    {"YMM6",   6,    _ymm},
-    {"YMM7",   7,    _ymm},
     {"YMM8",   8,    _ymm},
     {"YMM9",   9,    _ymm},
     {"YMM10", 10,    _ymm},

--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -2290,6 +2290,8 @@ void test23()
         0xF3, 0x0F, 0x16, 0x4D, 0xE8,   // movshdup     XMM1,-010h[EBP]
         0xF3, 0x0F, 0x12, 0xCA,         // movsldup     XMM1,XMM2
         0xF3, 0x0F, 0x12, 0x4D, 0xE8,   // movsldup     XMM1,-010h[EBP]
+
+        0xC4, 0xE3, 0x7D, 0x04, 0xC7, 0xAA, // vpermilps YMM0,YMM7,0AAh ;
     ];
     int i;
 
@@ -2339,6 +2341,8 @@ void test23()
 
         movsldup        XMM1,XMM2       ;
         movsldup        XMM1,m128[EBP]  ;
+
+        vpermilps       YMM0,YMM7,0xAA  ;
 
 L1:                                     ;
         pop     EBX                     ;


### PR DESCRIPTION
Just add them to the table of registers available in 32 bit mode.