### PR TITLE
fix Issue 15745 - Inline Assembly stomped on by Profiling

### DIFF
--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -924,7 +924,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
      * 2. impact on function inlining
      * 3. what to do when writing out .di files, or other pretty printing
      */
-    if (global.params.trace && !fd.isCMain() && !fd.naked)
+    if (global.params.trace && !fd.isCMain() && !fd.naked && !(fd.hasReturnExp & 8))
     {
         /* The profiler requires TLS, and TLS may not be set up yet when C main()
          * gets control (i.e. OSX), leading to a crash.

--- a/test/runnable/testprofile.d
+++ b/test/runnable/testprofile.d
@@ -67,9 +67,34 @@ void test13331() {asm {naked; ret;}}
 
 // ------------------
 
-void main()
+// https://issues.dlang.org/show_bug.cgi?id=15745
+
+ubyte LS1B(uint board)
+{
+    asm
+    {
+        bsf EAX, board;
+    }
+}
+
+void test15754()
+{
+
+    for (int i = 0; i < 31; ++i)
+    {
+        auto slide = (1U << i);
+        auto ls1b = slide.LS1B;
+        assert(ls1b == i);
+    }
+}
+
+// ------------------
+
+int main()
 {
     test1();
     test5689();
     test13331();
+    test15754();
+    return 0;
 }


### PR DESCRIPTION
The fix is to not insert profiling instrumentation into functions with inline assembler.