### PR TITLE
Allow implicit conversion of static array of class X to static array of some baseclass of X

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -3686,12 +3686,25 @@ extern (C++) final class TypeSArray : TypeArray
 
             if (dim.equals(tsa.dim))
             {
+                MATCH m = next.implicitConvTo(tsa.next);
+
+                /* Allow conversion to non-interface base class.
+                 */
+                if (m == MATCH.convert &&
+                    next.ty == Tclass)
+                {
+                    if (auto toc = tsa.next.isTypeClass)
+                    {
+                        if (!toc.sym.isInterfaceDeclaration)
+                            return MATCH.convert;
+                    }
+                }
+
                 /* Since static arrays are value types, allow
                  * conversions from const elements to non-const
                  * ones, just like we allow conversion from const int
                  * to int.
                  */
-                MATCH m = next.implicitConvTo(tsa.next);
                 if (m >= MATCH.constant)
                 {
                     if (mod != to.mod)

--- a/test/compilable/commontype.d
+++ b/test/compilable/commontype.d
@@ -240,7 +240,7 @@ static assert(is( X!( void function() pure @trusted, void function() nothrow @sa
 static assert(is( X!( void function() @trusted, void function() ) == void function()));
 static assert(is( X!( void function() @trusted, void function() @trusted ) == void function() @trusted ));
 static assert(is( X!( void function() @safe, void function() @trusted ) == void function() @trusted ));
-static assert(is( X!( void function() @trusted, void function() @safe ) == void function() @safe )); // not commutative 
+static assert(is( X!( void function() @trusted, void function() @safe ) == void function() @safe )); // not commutative
 
 static assert(is( X!( const(int function())*, int function()* ) == const(int function())* ));
 static assert(is( X!( immutable(int function())*, int function()* ) == const(int function())* ));
@@ -299,10 +299,10 @@ static assert(is( X!( shared(const(C))[4], shared(C)[4] ) == shared(const(C))[4]
 static assert(is( X!( shared(C)[4], shared(const(C))[4] ) == shared(const(C))[4] ));
 
 // base class conversion
-static assert(Error!( C[4], B[4] ));
+static assert(is( X!(C[4], B[4]) ));
 static assert(Error!( C[4], I[4] ));
 static assert(Error!( C[4], D[4] ));
-static assert(is( X!( C[4], const(B)[4] ) == const(B)[] )); // !?
+static assert(is( X!( C[4], const(B)[4] ) == const(B)[4] ));
 static assert(Error!( C[4], const(I)[4] ));
 static assert(Error!( C[4], const(D)[4] ));
 static assert(Error!( C*[4], B*[4] ));

--- a/test/compilable/iconv_class_array.d
+++ b/test/compilable/iconv_class_array.d
@@ -1,0 +1,34 @@
+@safe pure:
+
+class X
+{
+    this(int x) @safe pure { this.x = x; }
+    int x;
+}
+
+class Y : X
+{
+    this(int x) @safe pure { super(x); }
+    int x;
+}
+
+static void fm(X[] xs) {}
+static void fc(const(X)[] xs) {}
+static void fi(immutable(X)[] xs) {}
+
+static void f2m(X[2] xs) {}
+static void f2mr(ref X[2] xs) {}
+
+void test()
+{
+    Y[] y = [new Y(42), new Y(43)];
+    immutable(Y)[] yi = [new Y(42), new Y(43)];
+    static assert(!__traits(compiles, { fm(y); }));
+    fc(y);
+    fc(yi);
+    fi(yi);
+
+    Y[2] y2 = [new Y(42), new Y(43)];
+    f2m(y2);
+    static assert(!__traits(compiles, { f2mr(y2); }));
+}

--- a/test/fail_compilation/iconv_interface_array.d
+++ b/test/fail_compilation/iconv_interface_array.d
@@ -1,0 +1,48 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/iconv_interface_array.d(45): Error: function `iconv_interface_array.testA(I1[4] arr)` is not callable using argument types `(C[4])`
+fail_compilation/iconv_interface_array.d(45):        cannot pass argument `arr` of type `C[4]` to parameter `I1[4] arr`
+fail_compilation/iconv_interface_array.d(46): Error: function `iconv_interface_array.testB(I2[4] arr)` is not callable using argument types `(C[4])`
+fail_compilation/iconv_interface_array.d(46):        cannot pass argument `arr` of type `C[4]` to parameter `I2[4] arr`
+fail_compilation/iconv_interface_array.d(47): Error: function `iconv_interface_array.testC(I3[4] arr)` is not callable using argument types `(C[4])`
+fail_compilation/iconv_interface_array.d(47):        cannot pass argument `arr` of type `C[4]` to parameter `I3[4] arr`
+---
+*/
+
+interface I1 { int a(int); }
+interface I2 { int b(int); }
+interface I3 { int c(int); }
+
+class C : I1, I2, I3
+{
+    int a(int i) { return 1 * i; }
+    int b(int i) { return 2 * i; }
+    int c(int i) { return 3 * i; }
+}
+
+void testA(I1[4] arr)
+{
+    foreach (uint idx, obj; arr)
+        assert(obj.a(idx) == 1 * idx);
+}
+
+void testB(I2[4] arr)
+{
+    foreach (idx, obj; arr)
+        assert(obj.b(cast(int) idx) == 2 * idx);
+}
+
+void testC(I3[4] arr)
+{
+    foreach (idx, obj; arr)
+        assert(obj.c(cast(int) idx) == 3 * idx);
+}
+
+void main()
+{
+    C[4] arr = [ new C, new C, new C, new C ];
+    testA(arr);
+    testB(arr);
+    testC(arr);
+}


### PR DESCRIPTION
~Since this conversion already works for dynamic arrays I see no reason why it shouldn't work for static arrays?~
Conversion is currently not allowed on dynamic arrays either.