### PR TITLE
Fix Issue 21159 - DWARF: DW_AT_pure should be emitted for pure functions

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -1646,6 +1646,15 @@ static if (ELFOBJ || MACHOBJ)
         {
             abuf.writeByte(DW_AT_external);       abuf.writeByte(DW_FORM_flag);
         }
+        if (sfunc.Sfunc.Fflags3 & Fpure)
+        {
+            abuf.writeByte(DW_AT_pure);
+            static if (DWARF_VERSION >= 4)
+                abuf.writeByte(DW_FORM_flag_present);
+            else
+                abuf.writeByte(DW_FORM_flag);
+        }
+
         abuf.writeByte(DW_AT_low_pc);     abuf.writeByte(DW_FORM_addr);
         abuf.writeByte(DW_AT_high_pc);    abuf.writeByte(DW_FORM_addr);
         abuf.writeByte(DW_AT_frame_base); abuf.writeByte(DW_FORM_data4);
@@ -1675,6 +1684,12 @@ static if (ELFOBJ || MACHOBJ)
 
         if (sfunc.Sclass == SCglobal)
             debug_info.buf.writeByte(1);              // DW_AT_external
+
+        static if (DWARF_VERSION < 4)
+        {
+            if (sfunc.Sfunc.Fflags3 & Fpure)
+                debug_info.buf.writeByte(true);         // DW_AT_pure
+        }
 
         // DW_AT_low_pc and DW_AT_high_pc
         dwarf_appreladdr(debug_info.seg, debug_info.buf, seg, funcoffset);

--- a/test/dshell/dwarf.d
+++ b/test/dshell/dwarf.d
@@ -4,6 +4,8 @@ import std.algorithm;
 import std.file;
 import std.process;
 
+import std.conv;
+
 int main()
 {
     version(DigitalMars) { }
@@ -24,11 +26,21 @@ int main()
     else
         immutable slash = "/";
 
-
     // If the Unix system doesn't have objdump, disable the tests
-    auto sysHasObjdump = executeShell("objdump --help");
-    if (sysHasObjdump.status)
+    auto sysObjdump = executeShell("objdump --version");
+    if (sysObjdump.status)
         return DISABLED;
+    // DWARF 3 (and 4) support has been implemented in version 2.20 (2.20.51.0.1)
+    try
+    {
+        if(sysObjdump.output.split("\n")[0][$ - 4 .. $].to!double < 2.20)
+            return DISABLED;
+    }
+    catch (ConvException ce)
+    {
+        // The conversion failed, then it's definitively an old version (or a too new)
+        return DISABLED;
+    }
 
     immutable extra_dwarf_dir = EXTRA_FILES ~ slash ~ "dwarf" ~ slash;
     bool failed;

--- a/test/dshell/extra-files/dwarf/excepted_results/fix21159.txt
+++ b/test/dshell/extra-files/dwarf/excepted_results/fix21159.txt
@@ -1,0 +1,1 @@
+DW_AT_pure

--- a/test/dshell/extra-files/dwarf/fix21159.d
+++ b/test/dshell/extra-files/dwarf/fix21159.d
@@ -1,0 +1,9 @@
+void main()
+{
+
+}
+
+void foo() pure
+{
+
+}


### PR DESCRIPTION
> A subprogram entry may have a DW_AT_pure attribute, which is a flag. The
attribute indicates whether the subroutine was declared with the “pure”
keyword or property.