### PR TITLE
[dmd-cxx] Use module source name if searchPath returns null

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1212,8 +1212,9 @@ Ldone:
         if (type && mod)
         {
             printedMain = true;
-            const char *name = FileName::searchPath(global.path, mod->srcfile->toChars(), true);
-            message("entry     %-10s\t%s", type, name);
+            const char *name = mod->srcfile->toChars();
+            const char *path = FileName::searchPath(global.path, name, true);
+            message("entry     %-10s\t%s", type, path ? path : name);
         }
     }
 


### PR DESCRIPTION
This can happen if the module was read from stdin.

Backports #11617.