### PR TITLE
[dmd-cxx] Fix Issue 20092 and Issue 20356 - recursive expansion/optimization fixes

### DIFF
--- a/src/dmacro.c
+++ b/src/dmacro.c
@@ -226,11 +226,10 @@ void Macro::expand(OutBuffer *buf, size_t start, size_t *pend,
 {
     // limit recursive expansion
     static int nest;
-    static const int nestLimit = 1000;
-    if (nest > nestLimit)
+    if (nest > global.recursionLimit)
     {
-        error(Loc(), "DDoc macro expansion limit exceeded; more than %d "
-            "expansions.", nestLimit);
+        error(Loc(), "DDoc macro expansion limit exceeded; more than %d expansions.",
+              global.recursionLimit);
         return;
     }
     nest++;

--- a/src/expressionsem.c
+++ b/src/expressionsem.c
@@ -2896,7 +2896,7 @@ public:
             else
             {
                 static int nest;
-                if (++nest > 500)
+                if (++nest > global.recursionLimit)
                 {
                     exp->error("recursive evaluation of %s", exp->toChars());
                     --nest;

--- a/src/globals.h
+++ b/src/globals.h
@@ -244,6 +244,8 @@ struct Global
     Array<class Identifier*>* versionids; // command line versions and predefined versions
     Array<class Identifier*>* debugids;   // command line debug versions and predefined versions
 
+    enum { recursionLimit = 500 }; // number of recursive template expansions before abort
+
     /* Start gagging. Return the current number of gagged errors
      */
     unsigned startGagging();

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2189,7 +2189,7 @@ Expression *Type::noMember(Scope *sc, Expression *e, Identifier *ident, int flag
 
     static int nest;      // https://issues.dlang.org/show_bug.cgi?id=17380
 
-    if (++nest > 500)
+    if (++nest > global.recursionLimit)
     {
       ::error(e->loc, "cannot resolve identifier `%s`", ident->toChars());
       --nest;
@@ -5536,7 +5536,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
 
     bool errors = false;
 
-    if (inuse > 500)
+    if (inuse > global.recursionLimit)
     {
         inuse = 0;
         ::error(loc, "recursive type");

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -19,6 +19,7 @@
 #include "init.h"
 #include "enum.h"
 #include "ctfe.h"
+#include "errors.h"
 
 Expression *semantic(Expression *e, Scope *sc);
 
@@ -1214,10 +1215,18 @@ Expression *Expression_optimize(Expression *e, int result, bool keepLvalue)
     v.ret = e;
 
     // Optimize the expression until it can no longer be simplified.
-    while (ex != v.ret)
+    size_t b = 0;
+    while (1)
     {
+        if (b++ == global.recursionLimit)
+        {
+            e->error("infinite loop while optimizing expression");
+            fatal();
+        }
         ex = v.ret;
         ex->accept(&v);
+        if (ex == v.ret)
+            break;
     }
     return ex;
 }

--- a/test/compilable/ice20092.d
+++ b/test/compilable/ice20092.d
@@ -1,0 +1,10 @@
+void foo()
+{
+    (void[1]).init.front;
+}
+
+void front(T)(T[] a)
+{
+    static assert(is(T == void));
+}
+


### PR DESCRIPTION
Adds enum global.recursionLimit and uses it in all places where such errors can occur (#10685).