### PR TITLE
[dmd-cxx] Move check for NRVO from ReturnStatement semantic into FuncDeclaration

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -669,6 +669,7 @@ public:
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc=0);
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc=0);
     void checkDmain();
+    bool checkNrvo();
 
     FuncDeclaration *isFuncDeclaration() { return this; }
 

--- a/src/func.c
+++ b/src/func.c
@@ -1761,7 +1761,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 if (storage_class & STCauto)
                     storage_class &= ~STCauto;
             }
-            if (retStyle(f) != RETstack)
+            if (retStyle(f) != RETstack || checkNrvo())
                 nrvo_can = 0;
 
             if (fbody->isErrorStatement())
@@ -4291,6 +4291,53 @@ void FuncDeclaration::checkDmain()
         error("must return int or void, not %s", tf->nextOf()->toChars());
     else if (tf->parameterList.varargs || nparams >= 2 || argerr)
         error("parameters must be main() or main(string[] args)");
+}
+
+/***********************************************
+ * Check all return statements for a function to verify that returning
+ * using NRVO is possible.
+ *
+ * Returns:
+ *      true if the result cannot be returned by hidden reference.
+ */
+bool FuncDeclaration::checkNrvo()
+{
+    if (!nrvo_can)
+        return true;
+
+    if (returns == NULL)
+        return true;
+
+    TypeFunction *tf = type->toTypeFunction();
+    if (tf->isref)
+        return true;
+
+    for (size_t i = 0; i < returns->length; i++)
+    {
+        ReturnStatement *rs = (*returns)[i];
+
+        if (VarExp *ve = rs->exp->isVarExp())
+        {
+            VarDeclaration *v = ve->var->isVarDeclaration();
+            if (!v || v->isOut() || v->isRef())
+                return true;
+            else if (nrvo_var == NULL)
+            {
+                if (!v->isDataseg() && !v->isParameter() && v->toParent2() == this)
+                {
+                    //printf("Setting nrvo to %s\n", v->toChars());
+                    nrvo_var = v;
+                }
+                else
+                    return true;
+            }
+            else if (nrvo_var != v)
+                return true;
+        }
+        else //if (!exp->isLvalue())    // keep NRVO-ability
+            return true;
+    }
+    return false;
 }
 
 const char *FuncDeclaration::kind() const

--- a/src/statementsem.c
+++ b/src/statementsem.c
@@ -2861,42 +2861,9 @@ public:
                  *    return x; return 3;  // ok, x can be a value
                  */
             }
-
-            // handle NRVO
-            if (fd->nrvo_can && rs->exp->op == TOKvar)
-            {
-                VarExp *ve = (VarExp *)rs->exp;
-                VarDeclaration *v = ve->var->isVarDeclaration();
-
-                if (tf->isref)
-                {
-                    // Function returns a reference
-                    if (!inferRef)
-                        fd->nrvo_can = 0;
-                }
-                else if (!v || v->isOut() || v->isRef())
-                    fd->nrvo_can = 0;
-                else if (fd->nrvo_var == NULL)
-                {
-                    if (!v->isDataseg() && !v->isParameter() && v->toParent2() == fd)
-                    {
-                        //printf("Setting nrvo to %s\n", v->toChars());
-                        fd->nrvo_var = v;
-                    }
-                    else
-                        fd->nrvo_can = 0;
-                }
-                else if (fd->nrvo_var != v)
-                    fd->nrvo_can = 0;
-            }
-            else //if (!exp->isLvalue())    // keep NRVO-ability
-                fd->nrvo_can = 0;
         }
         else
         {
-            // handle NRVO
-            fd->nrvo_can = 0;
-
             // infer return type
             if (fd->inferRetType)
             {


### PR DESCRIPTION
Backport of #8467. This is a companion patch for NRVO related fixes in [pr d/96156](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96156) and [d/96157](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96157).