### PR TITLE
semantic3: Remove nrvo_can test done before body semantic

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -567,9 +567,6 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     }
                 }
 
-                if (!funcdecl.inferRetType && !target.isReturnOnStack(f, funcdecl.needThis()))
-                    funcdecl.nrvo_can = 0;
-
                 bool inferRef = (f.isref && (funcdecl.storage_class & STC.auto_));
 
                 funcdecl.fbody = funcdecl.fbody.statementSemantic(sc2);


### PR DESCRIPTION
This is redundant as the same check is done again after the function body has finished semantic, when the return type has been inferred, and its size finalized.

At no point does semantic analysis depend on the nrvo_can value, all uses are either after semantic body (NrvoWalker), or in post-semantic passes (inline, codegen).