### PR TITLE
[dmd-cxx] semantic3: Remove nrvo_can test done before body semantic

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1704,9 +1704,6 @@ void FuncDeclaration::semantic3(Scope *sc)
                 }
             }
 
-            if (!inferRetType && retStyle(f) != RETstack)
-                nrvo_can = 0;
-
             bool inferRef = (f->isref && (storage_class & STCauto));
 
             fbody = ::semantic(fbody, sc2);


### PR DESCRIPTION
Backport of #11626.