### PR TITLE
Fix issue 21198 - Inout copy constructor on union field does not prev…

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -528,7 +528,7 @@ LcheckFields:
     ccd.semantic3(sc2);
     //printf("ccd semantic: %s\n", ccd.type.toChars());
     sc2.pop();
-    if (global.endGagging(errors))
+    if (global.endGagging(errors) || sd.isUnionDeclaration())
     {
         ccd.storage_class |= STC.disable;
         ccd.fbody = null;

--- a/test/fail_compilation/test21198.d
+++ b/test/fail_compilation/test21198.d
@@ -1,0 +1,24 @@
+// https://issues.dlang.org/show_bug.cgi?id=21198
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test21198.d(23): Error: copy constructor `test21198.U.this` cannot be used because it is annotated with `@disable`
+---
+*/
+
+struct S
+{
+    this(ref inout(S) other) inout {}
+}
+
+union U
+{
+    S s;
+}
+
+void fun()
+{
+    U original;
+    U copy = original;
+}


### PR DESCRIPTION
…ent copy-initialization of union

Previously, generated copy constructors of unions were disabled only if
they failed to type-check. They are now disabled in all cases, as
required by the language spec.