### PR TITLE
Add D_Preview<name> to identify enabled preview switches

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -764,6 +764,19 @@ dmd -cov -unittest myprog.d
         Feature("in", "previewIn",
             "`in` on parameters means `scope const [ref]` and accepts rvalues"),
     ];
+
+    /// Helper to generate one `D_Preview_<name>` version per flag enabled
+    static string generatePreviewVersions(string argname)
+    {
+        string ret;
+        foreach (flag; previews)
+        {
+            ret ~= `if (` ~ argname ~ `.` ~ flag.paramName ~
+                `) VersionCondition.addPredefinedGlobalIdent("D_Preview_` ~ flag.name
+                ~ `");` ~ '\n';
+        }
+        return ret;
+    }
 }
 
 /**

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1291,6 +1291,10 @@ void addDefaultVersionIdentifiers(const ref Param params)
     }
 
     VersionCondition.addPredefinedGlobalIdent("D_HardFloat");
+
+    // Version identifiers for `-preview` switches
+    import dmd.cli : Usage;
+    mixin(Usage.generatePreviewVersions("params"));
 }
 
 private void printPredefinedVersions(FILE* stream)

--- a/test/compilable/previewversions.d
+++ b/test/compilable/previewversions.d
@@ -1,0 +1,14 @@
+/**
+REQUIRED_ARGS: -preview=in -preview=dip1000
+*/
+
+version (D_Preview_dip1000) {}
+else static assert(0, "Missing `D_Preview_dip1000`");
+
+version (D_Preview_in) {}
+else static assert(0, "Missing `D_Preview_in`");
+
+version (D_Preview_dip1008)
+{
+    static assert(0, "Found unexpected version `D_Preview_dip1008`");
+}


### PR DESCRIPTION
```
This will allow to adapt library code, e.g. Phobos, without having to observe the effect.
The downside is that those versions probably need to go through deprecation after the
flag is disabled, something which wouldn't be needed if the user was only observing the effect.
```