### PR TITLE
fix Issue 6166 - Named return value optimization not dealt with in in…

### DIFF
--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -2326,9 +2326,17 @@ void asm_merge_symbol(ref OPND o1, Dsymbol s)
         return;
     }
 
-    auto v = s.isVarDeclaration();
-    if (v)
+    if (auto v = s.isVarDeclaration())
     {
+        if (auto fd = asmstate.sc.func)
+        {
+             /* https://issues.dlang.org/show_bug.cgi?id=6166
+              * We could leave it on unless fd.nrvo_var==v,
+              * but fd.nrvo_var isn't set yet
+              */
+             fd.nrvo_can = false;
+        }
+
         if (v.isParameter())
             asmstate.statement.refparam = true;
 

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -6903,6 +6903,28 @@ void test63()
 }
 
 /****************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=6166
+
+struct NRV { int[8] a; }
+
+NRV rvo()
+{
+    NRV v;
+    v.a[1] = 3;
+    asm @nogc pure
+    {
+        mov int ptr v+4,7;
+    }
+    return v;
+}
+
+void test6166()
+{
+    auto n = rvo();
+    assert(n.a[1] == 7);
+}
+
+/****************************************************/
 
 int main()
 {
@@ -6981,6 +7003,7 @@ int main()
     test18553();
     test20126();
     test63();
+    test6166();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
…line assembler

The fix simply disables NRVO if there is inline assembler that accesses variables.