### PR TITLE
fix Issue 18373 - The inline assembler parser allows strange constructs

### DIFF
--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -2283,6 +2283,19 @@ private void asm_merge_opnds(ref OPND o1, ref OPND o2)
         else
             o1.pregDisp2 = o2.pregDisp2;
     }
+
+    if (o1.base && o1.pregDisp1)
+    {
+        asmerr("operand cannot have both %s and [%s]", o1.base.regstr.ptr, o1.pregDisp1.regstr.ptr);
+        return;
+    }
+
+    if (o1.base && o1.disp)
+    {
+        asmerr("operand cannot have both %s and 0x%llx", o1.base.regstr.ptr, o1.disp);
+        return;
+    }
+
     if (o2.uchMultiplier)
     {
         if (o1.uchMultiplier)

--- a/test/fail_compilation/iasm1.d
+++ b/test/fail_compilation/iasm1.d
@@ -49,6 +49,29 @@ void test2()
 
 /*********************************************/
 
+/* TEST_OUTPUT:
+---
+fail_compilation/iasm1.d(306): Error: operand cannot have both R8 and [R9]
+fail_compilation/iasm1.d(307): Error: operand cannot have both RDX and 0x3
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=18373
+
+#line 300
+
+void test3()
+{
+    asm
+    {
+        naked;
+        mov RAX,[R9][R10]R8;
+        mov RAX,[3]RDX;
+    }
+}
+
+/*********************************************/
+
 /*
 TEST_OUTPUT:
 ---


### PR DESCRIPTION
Not much to this.