### PR TITLE
Fix Issue 21120 - Inconsistent mangling of __init symbol

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -176,8 +176,8 @@ private extern (C++) final class Mangler : Visitor
     alias visit = Visitor.visit;
 public:
     static assert(Key.sizeof == size_t.sizeof);
-    AssocArray!(Type, size_t) types;
-    AssocArray!(Identifier, size_t) idents;
+    AssocArray!(Type, size_t) types;        // Type => (offset+1) in buf
+    AssocArray!(Identifier, size_t) idents; // Identifier => (offset+1) in buf
     OutBuffer* buf;
 
     extern (D) this(OutBuffer* buf)
@@ -229,15 +229,7 @@ public:
     bool backrefType(Type t)
     {
         if (!t.isTypeBasic())
-        {
-            auto p = types.getLvalue(t);
-            if (*p)
-            {
-                writeBackRef(buf.length - *p);
-                return true;
-            }
-            *p = buf.length;
-        }
+            return backrefImpl(types, t);
         return false;
     }
 
@@ -256,13 +248,19 @@ public:
     */
     bool backrefIdentifier(Identifier id)
     {
-        auto p = idents.getLvalue(id);
+        return backrefImpl(idents, id);
+    }
+
+    private extern(D) bool backrefImpl(T)(ref AssocArray!(T, size_t) aa, T key)
+    {
+        auto p = aa.getLvalue(key);
         if (*p)
         {
-            writeBackRef(buf.length - *p);
+            const offset = *p - 1;
+            writeBackRef(buf.length - offset);
             return true;
         }
-        *p = buf.length;
+        *p = buf.length + 1;
         return false;
     }
 

--- a/test/runnable/test21120.d
+++ b/test/runnable/test21120.d
@@ -1,0 +1,27 @@
+// https://issues.dlang.org/show_bug.cgi?id=21120
+
+module one.two.three;
+
+struct S {}
+
+struct StructTemplate(T)
+{
+    int a = 123; // non-zero initialized
+
+    ref const(StructTemplate) getInitSymbol()
+    {
+        return initSymbol!StructTemplate;
+    }
+}
+
+template initSymbol(T)
+{
+    pragma(mangle, "_D" ~ T.mangleof[1..$] ~ "6__initZ")
+    extern immutable T initSymbol;
+}
+
+void main()
+{
+    StructTemplate!S inst;
+    assert(inst.getInitSymbol() == inst);
+}


### PR DESCRIPTION
The mangling code previously assumed no identifier would ever start at buffer offset 0. Get rid of that assumption by storing offset+1.