### PR TITLE
Disable Windows builds on the auto-tester - replace with Azure pipelines

### DIFF
--- a/.azure-pipelines/windows-artifact.yml
+++ b/.azure-pipelines/windows-artifact.yml
@@ -1,0 +1,6 @@
+steps:
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: windows-$(ARCH)
+      targetPath: artifacts
+    displayName: Publish artifacts

--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -126,7 +126,12 @@ if [ "$MODEL" == "32" ] ; then
 fi
 
 "$HOST_DC" -m$MODEL -g -i run.d
-./run --environment --jobs=$N all ARGS="-O -inline -g" MODEL="$MODEL"
+targets=("all")
+if [ "$HOST_DMD_VERSION" = "2.079.0" ] ; then
+    # do not run runnable_cxx or unit_tests with older bootstrap compilers
+    targets=("compilable" "fail_compilation" "runnable"  "dshell")
+fi
+./run --environment --jobs=$N "${targets[@]}" ARGS="-O -inline -g" MODEL="$MODEL"
 
 ################################################################################
 # Prepare artifacts

--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -127,11 +127,13 @@ fi
 
 "$HOST_DC" -m$MODEL -g -i run.d
 targets=("all")
+args=('ARGS=-O -inline -g') # no -release for faster builds
 if [ "$HOST_DMD_VERSION" = "2.079.0" ] ; then
     # do not run runnable_cxx or unit_tests with older bootstrap compilers
     targets=("compilable" "fail_compilation" "runnable"  "dshell")
+    args=() # use default set of args
 fi
-./run --environment --jobs=$N "${targets[@]}" ARGS="-O -inline -g" MODEL="$MODEL"
+./run --environment --jobs=$N "${targets[@]}" "${args[@]}" MODEL="$MODEL"
 
 ################################################################################
 # Prepare artifacts

--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -14,8 +14,3 @@ steps:
       bash --version
       sh --login .azure-pipelines/windows.sh
     displayName: Build DMD
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: windows-$(ARCH)
-      targetPath: artifacts
-    displayName: Publish artifacts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,18 +1,53 @@
 # Learn more: https://aka.ms/yaml
 jobs:
-  - job: Windows
+  - job: Windows_Bootstrap
     timeoutInMinutes: 120
     pool:
       vmImage: 'vs2017-win2016'
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
-      HOST_DMD_VERSION: 2.092.1
+      HOST_DMD_VERSION: 2.079.0
     strategy:
       matrix:
         x64:
           OS: Win_64
           MODEL: 64
           ARCH: x64
+          D_COMPILER: dmd
+    steps:
+      - template: .azure-pipelines/windows.yml
+
+  - job: Windows
+    timeoutInMinutes: 120
+    pool:
+      vmImage: 'vs2017-win2016'
+    variables:
+      VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
+      HOST_DMD_VERSION: LATEST
+    strategy:
+      matrix:
+        x64:
+          OS: Win_64
+          MODEL: 64
+          ARCH: x64
+          D_COMPILER: dmd
+    steps:
+      - template: .azure-pipelines/windows.yml
+      - template: .azure-pipelines/windows-artifact.yml
+
+  - job: Windows_OMF_Bootstrap
+    timeoutInMinutes: 120
+    pool:
+      vmImage: 'vs2017-win2016'
+    variables:
+      VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
+      HOST_DMD_VERSION: 2.079.0
+    strategy:
+      matrix:
+        win32:
+          OS: Win_32
+          MODEL: 32
+          ARCH: x86
           D_COMPILER: dmd
     steps:
       - template: .azure-pipelines/windows.yml
@@ -33,6 +68,7 @@ jobs:
           D_COMPILER: dmd
     steps:
       - template: .azure-pipelines/windows.yml
+      - template: .azure-pipelines/windows-artifact.yml
 
   - job: Windows_VisualD
     timeoutInMinutes: 120

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -79,8 +79,9 @@ defaulttarget: $G debdmd
 
 # FIXME: Windows test suite uses src/dmd.exe instead of $(GENERATED)/dmd.exe
 auto-tester-build: $(GEN)\build.exe
-	$(RUN_BUILD) "ENABLE_RELEASE=1" "ENABLE_ASSERTS=1" $@
-	copy $(TARGETEXE) .
+	echo "Windows builds have been disabled"
+	#$(RUN_BUILD) "ENABLE_RELEASE=1" "ENABLE_ASSERTS=1" $@
+	#copy $(TARGETEXE) .
 
 dmd: $G reldmd
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -209,8 +209,13 @@ start_all_tests: $(RUNNER)
 	$(EXECUTE_RUNNER) all
 
 # The auto-tester cannot run runnable_cxx as its compiler is too old
+ifeq (windows,$(OS))
+auto-tester-test:
+	echo "Windows builds have been disabled"
+else
 auto-tester-test: $(RUNNER)
 	$(EXECUTE_RUNNER) runnable compilable fail_compilation dshell
+endif
 
 $(RESULTS_DIR)/d_do_test$(EXE): tools/d_do_test.d tools/sanitize_json.d $(RESULTS_DIR)/.created
 	@echo "Building d_do_test tool"

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -1606,7 +1606,7 @@ int runBashTest(string input_dir, string test_name, const ref EnvData envData)
         const cmd = "bash " ~ script ~ ' ' ~ input_dir ~ ' ' ~  test_name;
         const env = [
             // Make sure the path is bash-friendly
-            "DMD": envData.dmd.relativePath(dmdTestDir).replace('\\', '/')
+            "DMD": envData.dmd.relativePath(dmdTestDir).replace("\\", "/")
         ];
 
         auto process = spawnShell(cmd, env, Config.none, dmdTestDir);


### PR DESCRIPTION
We wanted to switch away from the auto-tester for a long time now. However, finding good alternatives has always been tricky and it often was blocked on e.g. a replacement for the FreeBSD testing. Now that the Windows machines are randomly failing again and no one knows why and it's super hard to debug, I think it's more than overdue to start the migration. Over the last months (years?) we have made good experiences with Azure pipelines and they offer 10 concurrent builds for open source projects. It's a stable infrastructure and upgrading to e.g. a newer visual studio build is as easy as changing the VM Image. LDC has been using Azure Pipelines for their Windows testing successfully for a long time as well.

This PR starts to disable the Windows builds on the auto-tester (auto-tester will still fail as the Makefiles need to be disabled on druntime + Phobos too) and adds two Windows builds to Azure with our bootstrapping compiler version (2.079.0).

The other bootstrap builds (Linux, FreeBSD, OSX) can be moved to other CIs later, but for now we want to unblock the broken CI checks.

CC @MoonlightSentinel @andralex @PetarKirov 