### PR TITLE
 Fix Issue 21213 - preview=dtorfields with strict attributes... 

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -5433,13 +5433,14 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 //printf("Creating default this(){} for class %s\n", toChars());
                 auto btf = fd.type.toTypeFunction();
                 auto tf = new TypeFunction(ParameterList(), null, LINK.d, fd.storage_class);
-                tf.mod       = btf.mod;
-                tf.purity    = btf.purity;
-                tf.isnothrow = btf.isnothrow;
-                tf.isnogc    = btf.isnogc;
-                tf.trust     = btf.trust;
+                tf.mod = btf.mod;
+                // Don't copy @safe, ... from the base class constructor and let it be inferred instead
+                // This is required if other lowerings add code to the generated constructor which
+                // is less strict (e.g. `preview=dtorfields` might introduce a call to a less qualified dtor)
 
                 auto ctor = new CtorDeclaration(cldec.loc, Loc.initial, 0, tf);
+                ctor.storage_class |= STC.inference;
+                ctor.generated = true;
                 ctor.fbody = new CompoundStatement(Loc.initial, new Statements());
 
                 cldec.members.push(ctor);

--- a/test/compilable/dtorfields.d
+++ b/test/compilable/dtorfields.d
@@ -19,3 +19,16 @@ extern(C++) class Extern
     HasDtor member;
     this();
 }
+
+/******************************************
+ * https://issues.dlang.org/show_bug.cgi?id=21213
+ */
+class Parent
+{
+    this() nothrow pure @nogc @safe {}
+}
+
+class Child : Parent
+{
+    HasDtor member;
+}


### PR DESCRIPTION
... in base class constructor - by infer attributes for generated
subclass constructors.

Simply copying the attributes from the base class ctor doesn't work if
other lowerings extend the generated function body.

This is e.g. problematic for `-preview=dtorfields` which adds a call
to the destructor which is often less qualified than the constructor.