### PR TITLE
Correct name of param baseType in TypeVector.this(Type) to elide self…

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -3707,7 +3707,7 @@ struct ASTBase
     {
         Type basetype;
 
-        extern (D) this(Type baseType)
+        extern (D) this(Type basetype)
         {
             super(Tvector);
             this.basetype = basetype;


### PR DESCRIPTION
…-assignment.

Found by self-assignment diagnostics here: https://github.com/dlang/dmd/pull/11553,