### PR TITLE
[RFC] Improve errors for fields overriding destructor attributes

### DIFF
--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -60,6 +60,8 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
                 {
                     e.error("%s `%s` is not `nothrow`",
                         f.kind(), f.toPrettyChars());
+
+                    e.checkOverridenDtor(null, f, dd => dd.type.toTypeFunction().isnothrow, "not nothrow");
                 }
                 stop = true;  // if any function throws, then the whole expression throws
             }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1184,6 +1184,12 @@ extern (C++) abstract class Expression : ASTNode
             if (fieldSd.dtor && !check(fieldSd.dtor))
             {
                 field.loc.errorSupplemental(" - %s %s", field.type.toChars(), field.toChars());
+
+                if (fieldSd.dtor.generated)
+                    checkOverridenDtor(sc, fieldSd.dtor, check, checkName);
+                else
+                    fieldSd.dtor.loc.errorSupplemental("   %.*s `%s.~this` is declared here",
+                                            cast(int) checkName.length, checkName.ptr, fieldSd.toChars());
             }
         }
     }

--- a/test/fail_compilation/dtor_attributes.d
+++ b/test/fail_compilation/dtor_attributes.d
@@ -6,16 +6,20 @@ TEST_OUTPUT:
 fail_compilation/dtor_attributes.d(118): Error: `pure` function `dtor_attributes.test1` cannot call impure destructor `dtor_attributes.Strict.~this`
 fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is impure because of the following field's destructors:
 fail_compilation/dtor_attributes.d(111):         - HasDtor member
+fail_compilation/dtor_attributes.d(103):           impure `HasDtor.~this` is declared here
 fail_compilation/dtor_attributes.d(118): Error: `@safe` function `dtor_attributes.test1` cannot call `@system` destructor `dtor_attributes.Strict.~this`
 fail_compilation/dtor_attributes.d(113):        `dtor_attributes.Strict.~this` is declared here
 fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is @system because of the following field's destructors:
 fail_compilation/dtor_attributes.d(111):         - HasDtor member
+fail_compilation/dtor_attributes.d(103):           @system `HasDtor.~this` is declared here
 fail_compilation/dtor_attributes.d(118): Error: `@nogc` function `dtor_attributes.test1` cannot call non-@nogc destructor `dtor_attributes.Strict.~this`
 fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is non-@nogc because of the following field's destructors:
 fail_compilation/dtor_attributes.d(111):         - HasDtor member
+fail_compilation/dtor_attributes.d(103):           non-@nogc `HasDtor.~this` is declared here
 fail_compilation/dtor_attributes.d(118): Error: destructor `dtor_attributes.Strict.~this` is not `nothrow`
 fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is not nothrow because of the following field's destructors:
 fail_compilation/dtor_attributes.d(111):         - HasDtor member
+fail_compilation/dtor_attributes.d(103):           not nothrow `HasDtor.~this` is declared here
 fail_compilation/dtor_attributes.d(116): Error: `nothrow` function `dtor_attributes.test1` may throw
 ---
 */
@@ -49,6 +53,7 @@ TEST_OUTPUT:
 fail_compilation/dtor_attributes.d(209): Error: `pure` function `dtor_attributes.test2` cannot call impure destructor `dtor_attributes.StrictClass.~this`
 fail_compilation/dtor_attributes.d(204):        generated `StrictClass.~this` is impure because of the following field's destructors:
 fail_compilation/dtor_attributes.d(203):         - HasDtor member
+fail_compilation/dtor_attributes.d(103):           impure `HasDtor.~this` is declared here
 ---
 */
 #line 200
@@ -72,6 +77,7 @@ TEST_OUTPUT:
 fail_compilation/dtor_attributes.d(321): Error: `pure` function `dtor_attributes.test3` cannot call impure destructor `dtor_attributes.StrictStructRef.~this`
 fail_compilation/dtor_attributes.d(316):        generated `StrictStructRef.~this` is impure because of the following field's destructors:
 fail_compilation/dtor_attributes.d(310):         - HasDtor structMember
+fail_compilation/dtor_attributes.d(103):           impure `HasDtor.~this` is declared here
 ---
 */
 #line 300
@@ -107,6 +113,7 @@ TEST_OUTPUT:
 fail_compilation/dtor_attributes.d(411): Error: `pure` function `dtor_attributes.test4` cannot call impure destructor `dtor_attributes.StrictNested.~this`
 fail_compilation/dtor_attributes.d(406):        generated `StrictNested.~this` is impure because of the following field's destructors:
 fail_compilation/dtor_attributes.d(403):         - HasDtor[4] arrayMember
+fail_compilation/dtor_attributes.d(103):           impure `HasDtor.~this` is declared here
 ---
 */
 #line 400
@@ -153,6 +160,11 @@ TEST_OUTPUT:
 fail_compilation/dtor_attributes.d(618): Error: `pure` function `dtor_attributes.test6` cannot call impure destructor `dtor_attributes.HasNestedDtor3.~this`
 fail_compilation/dtor_attributes.d(611):        generated `HasNestedDtor3.~this` is impure because of the following field's destructors:
 fail_compilation/dtor_attributes.d(613):         - HasNestedDtor2 member3
+fail_compilation/dtor_attributes.d(606):        generated `HasNestedDtor2.~this` is impure because of the following field's destructors:
+fail_compilation/dtor_attributes.d(608):         - HasNestedDtor1 member2
+fail_compilation/dtor_attributes.d(601):        generated `HasNestedDtor1.~this` is impure because of the following field's destructors:
+fail_compilation/dtor_attributes.d(603):         - HasDtor member1
+fail_compilation/dtor_attributes.d(103):           impure `HasDtor.~this` is declared here
 ---
 */
 #line 600

--- a/test/fail_compilation/dtor_attributes.d
+++ b/test/fail_compilation/dtor_attributes.d
@@ -1,0 +1,178 @@
+/*
+Informative error messages if the compiler generated destructor overrides a user-defined one.
+
+TEST_OUTPUT:
+---
+fail_compilation/dtor_attributes.d(118): Error: `pure` function `dtor_attributes.test1` cannot call impure destructor `dtor_attributes.Strict.~this`
+fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is impure because of the following field's destructors:
+fail_compilation/dtor_attributes.d(111):         - HasDtor member
+fail_compilation/dtor_attributes.d(118): Error: `@safe` function `dtor_attributes.test1` cannot call `@system` destructor `dtor_attributes.Strict.~this`
+fail_compilation/dtor_attributes.d(113):        `dtor_attributes.Strict.~this` is declared here
+fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is @system because of the following field's destructors:
+fail_compilation/dtor_attributes.d(111):         - HasDtor member
+fail_compilation/dtor_attributes.d(118): Error: `@nogc` function `dtor_attributes.test1` cannot call non-@nogc destructor `dtor_attributes.Strict.~this`
+fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is non-@nogc because of the following field's destructors:
+fail_compilation/dtor_attributes.d(111):         - HasDtor member
+fail_compilation/dtor_attributes.d(118): Error: destructor `dtor_attributes.Strict.~this` is not `nothrow`
+fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is not nothrow because of the following field's destructors:
+fail_compilation/dtor_attributes.d(111):         - HasDtor member
+fail_compilation/dtor_attributes.d(116): Error: `nothrow` function `dtor_attributes.test1` may throw
+---
+*/
+#line 100
+
+struct HasDtor
+{
+    ~this() {}
+}
+
+// The user-defined dtor is overriden by a generated dtor calling both
+// - HasDtor.~this
+// - Strict.~this
+struct Strict
+{
+    HasDtor member;
+
+    ~this() pure nothrow @nogc @safe {}
+}
+
+void test1() pure nothrow @nogc @safe
+{
+    Strict s;
+}
+
+/*
+Works for clases as well.
+
+TEST_OUTPUT:
+---
+fail_compilation/dtor_attributes.d(209): Error: `pure` function `dtor_attributes.test2` cannot call impure destructor `dtor_attributes.StrictClass.~this`
+fail_compilation/dtor_attributes.d(204):        generated `StrictClass.~this` is impure because of the following field's destructors:
+fail_compilation/dtor_attributes.d(203):         - HasDtor member
+---
+*/
+#line 200
+
+class StrictClass
+{
+    HasDtor member;
+    ~this() pure {}
+}
+
+void test2() pure
+{
+    scope instance = new StrictClass();
+}
+
+/*
+Ignores members whose destructors are not called.
+
+TEST_OUTPUT:
+---
+fail_compilation/dtor_attributes.d(321): Error: `pure` function `dtor_attributes.test3` cannot call impure destructor `dtor_attributes.StrictStructRef.~this`
+fail_compilation/dtor_attributes.d(316):        generated `StrictStructRef.~this` is impure because of the following field's destructors:
+fail_compilation/dtor_attributes.d(310):         - HasDtor structMember
+---
+*/
+#line 300
+
+class HasDtorClass
+{
+    ~this() {}
+}
+
+struct Empty {}
+
+struct StrictStructRef
+{
+    HasDtor structMember;
+    HasDtorClass classMember;
+    int intMember;
+    int[2] arrayMember;
+    Empty e;
+
+    ~this() pure {}
+}
+
+void test3() pure
+{
+    StrictStructRef structInstance;
+}
+
+/*
+Types from nested types work as well.
+
+TEST_OUTPUT:
+---
+fail_compilation/dtor_attributes.d(411): Error: `pure` function `dtor_attributes.test4` cannot call impure destructor `dtor_attributes.StrictNested.~this`
+fail_compilation/dtor_attributes.d(406):        generated `StrictNested.~this` is impure because of the following field's destructors:
+fail_compilation/dtor_attributes.d(403):         - HasDtor[4] arrayMember
+---
+*/
+#line 400
+
+struct StrictNested
+{
+    HasDtor[4] arrayMember;
+    HasDtorClass[4] classMember;
+
+    ~this() pure {}
+}
+
+void test4() pure
+{
+    StrictNested structInstance;
+}
+
+/*
+Ignores member destructors when the user-defined one is permissive enough (e.g. both impure)
+
+TEST_OUTPUT:
+---
+fail_compilation/dtor_attributes.d(509): Error: `pure` function `dtor_attributes.test5` cannot call impure destructor `dtor_attributes.Permissive.~this`
+---
+*/
+#line 500
+
+struct Permissive
+{
+    HasDtor[4] arrayMember;
+    ~this() {}
+}
+
+void test5() pure
+{
+    Permissive structInstance;
+}
+
+/*
+Works with destructors generated through multiple layers
+
+TEST_OUTPUT:
+---
+fail_compilation/dtor_attributes.d(618): Error: `pure` function `dtor_attributes.test6` cannot call impure destructor `dtor_attributes.HasNestedDtor3.~this`
+fail_compilation/dtor_attributes.d(611):        generated `HasNestedDtor3.~this` is impure because of the following field's destructors:
+fail_compilation/dtor_attributes.d(613):         - HasNestedDtor2 member3
+---
+*/
+#line 600
+
+struct HasNestedDtor1
+{
+    HasDtor member1;
+}
+
+struct HasNestedDtor2
+{
+    HasNestedDtor1 member2;
+}
+
+struct HasNestedDtor3
+{
+    HasNestedDtor2 member3;
+}
+
+void test6() pure
+{
+    HasNestedDtor3 instance;
+}

--- a/test/fail_compilation/dtorfields_attributes.d
+++ b/test/fail_compilation/dtorfields_attributes.d
@@ -7,13 +7,16 @@ TEST_OUTPUT:
 fail_compilation/dtorfields_attributes.d(117): Error: `pure` constructor `dtorfields_attributes.Strict.this` cannot call impure destructor `dtorfields_attributes.Strict.~this`
 fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` is impure because of the following field's destructors:
 fail_compilation/dtorfields_attributes.d(115):         - HasDtor member
+fail_compilation/dtorfields_attributes.d(103):           impure `HasDtor.~this` is declared here
 fail_compilation/dtorfields_attributes.d(117): Error: `@safe` constructor `dtorfields_attributes.Strict.this` cannot call `@system` destructor `dtorfields_attributes.Strict.~this`
 fail_compilation/dtorfields_attributes.d(119):        `dtorfields_attributes.Strict.~this` is declared here
 fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` is @system because of the following field's destructors:
 fail_compilation/dtorfields_attributes.d(115):         - HasDtor member
+fail_compilation/dtorfields_attributes.d(103):           @system `HasDtor.~this` is declared here
 fail_compilation/dtorfields_attributes.d(117): Error: `@nogc` constructor `dtorfields_attributes.Strict.this` cannot call non-@nogc destructor `dtorfields_attributes.Strict.~this`
 fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` is non-@nogc because of the following field's destructors:
 fail_compilation/dtorfields_attributes.d(115):         - HasDtor member
+fail_compilation/dtorfields_attributes.d(103):           non-@nogc `HasDtor.~this` is declared here
 ---
 */
 #line 100

--- a/test/fail_compilation/dtorfields_attributes.d
+++ b/test/fail_compilation/dtorfields_attributes.d
@@ -1,0 +1,40 @@
+/*
+Informative error messages if the compiler inserted an optional destructor call into the constructor.
+
+REQUIRED_ARGS: -preview=dtorfields
+TEST_OUTPUT:
+---
+fail_compilation/dtorfields_attributes.d(117): Error: `pure` constructor `dtorfields_attributes.Strict.this` cannot call impure destructor `dtorfields_attributes.Strict.~this`
+fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` is impure because of the following field's destructors:
+fail_compilation/dtorfields_attributes.d(115):         - HasDtor member
+fail_compilation/dtorfields_attributes.d(117): Error: `@safe` constructor `dtorfields_attributes.Strict.this` cannot call `@system` destructor `dtorfields_attributes.Strict.~this`
+fail_compilation/dtorfields_attributes.d(119):        `dtorfields_attributes.Strict.~this` is declared here
+fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` is @system because of the following field's destructors:
+fail_compilation/dtorfields_attributes.d(115):         - HasDtor member
+fail_compilation/dtorfields_attributes.d(117): Error: `@nogc` constructor `dtorfields_attributes.Strict.this` cannot call non-@nogc destructor `dtorfields_attributes.Strict.~this`
+fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` is non-@nogc because of the following field's destructors:
+fail_compilation/dtorfields_attributes.d(115):         - HasDtor member
+---
+*/
+#line 100
+
+struct HasDtor
+{
+    ~this()
+    {
+        // Enforce @system, ... just to be sure
+        __gshared int i;
+        if (++i)
+            throw new Exception(new immutable(char)[](10));
+    }
+}
+
+// The user-defined dtor matches the ctor attributes
+struct Strict
+{
+    HasDtor member;
+
+    this(int) pure @nogc @safe {} // nothrow doesn't generate dtor call
+
+    ~this() pure @nogc @safe {}
+}


### PR DESCRIPTION
Compiler generated destructors calling both field and user-defined
destructors can have less-restrictive attributes than the user-defined
one. This caused confusing error messages stating that the destructor
is not `pure`albeit the user marked their implementation as `pure`.

This commit adds an additional error message explaining the situation
and also lists the fields causing the attribute missmatch s.t. the user
may fix their respective destructors.

---

TL;DR: The compiler tells you why your code doesn't compile even though your non-rewritten code should - especially important for `-preview=fielddtors`. 