### PR TITLE
dmd.argtypes: Remove dead code for 64-bit ABI and rename to dmd.argtypes_x86

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1192,7 +1192,7 @@ auto sourceFiles()
             s2ir.d tocsym.d toctype.d tocvdebug.d todt.d toir.d toobj.d
         "),
         frontend: fileArray(env["D"], "
-            access.d aggregate.d aliasthis.d apply.d argtypes.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d
+            access.d aggregate.d aliasthis.d apply.d argtypes_x86.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d
             arraytypes.d ast_node.d astcodegen.d asttypename.d attrib.d blockexit.d builtin.d canthrow.d chkformat.d
             cli.d clone.d compiler.d complex.d cond.d constfold.d cppmangle.d cppmanglewin.d ctfeexpr.d
             ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d dimport.d dinifile.d

--- a/src/dmd/README.md
+++ b/src/dmd/README.md
@@ -203,7 +203,7 @@ Note that these groups have no strict meaning, the category assignments are a bi
 | [stmtstate.d](https://github.com/dlang/dmd/blob/master/src/dmd/stmtstate.d)                 | Used to help transform statement AST into flow graph                                |
 | [toctype.d](https://github.com/dlang/dmd/blob/master/src/dmd/toctype.d)                     | Convert a D type to a type the back-end understands                                 |
 | [tocsym.d](https://github.com/dlang/dmd/blob/master/src/dmd/tocsym.d)                       | Convert a D symbol to a symbol the linker understands (with mangled name)           |
-| [argtypes.d](https://github.com/dlang/dmd/blob/master/src/dmd/argtypes.d)                   | Convert a D type into simple (register) types for calling conventions               |
+| [argtypes_x86.d](https://github.com/dlang/dmd/blob/master/src/dmd/argtypes_x86.d)           | Convert a D type into simple (register) types for the 32-bit x86 ABI                |
 | [argtypes_sysv_x64.d](https://github.com/dlang/dmd/blob/master/src/dmd/argtypes_sysv_x64.d) | 'argtypes' for the x86_64 System V ABI                                              |
 | [argtypes_aarch64.d](https://github.com/dlang/dmd/blob/master/src/dmd/argtypes_aarch64.d)   | 'argtypes' for the AArch64 ABI                                                      |
 | [glue.d](https://github.com/dlang/dmd/blob/master/src/dmd/glue.d)                           | Generate the object file for function declarations                                  |

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -25,7 +25,7 @@
 
 module dmd.target;
 
-import dmd.argtypes;
+import dmd.argtypes_x86;
 import dmd.argtypes_sysv_x64;
 import core.stdc.string : strlen;
 import dmd.cppmangle;
@@ -556,11 +556,12 @@ extern (C++) struct Target
      */
     extern (C++) TypeTuple toArgTypes(Type t)
     {
-        if (global.params.is64bit && isPOSIX)
-            return .toArgTypes_sysv_x64(t);
-        if (global.params.is64bit && global.params.isWindows)
-            return null;
-        return .toArgTypes(t);
+        if (global.params.is64bit)
+        {
+            // no argTypes for Win64 yet
+            return isPOSIX ? toArgTypes_sysv_x64(t) : null;
+        }
+        return toArgTypes_x86(t);
     }
 
     /**


### PR DESCRIPTION
As proposed in #8837 and now feasible as #10200 has finally been merged.