### PR TITLE
Disable Windows tests on auto-tester

### DIFF
--- a/samples/win32.mak
+++ b/samples/win32.mak
@@ -5,6 +5,9 @@ DFLAGS=-m$(MODEL)
 EXAMPLES = hello d2html dhry pi sieve wc wc2 \
 	winsamp dserver$(MODEL) mydll$(MODEL) htmlget listener
 
+auto-tester-test:
+	echo "Windows builds have been disabled"
+
 all: $(EXAMPLES)
 	echo done
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -144,7 +144,12 @@ ifneq ($(N),)
     EXECUTE_RUNNER:=$(EXECUTE_RUNNER) --jobs=$N
 endif
 
+ifeq (windows,$(OS))
+all:
+	echo "Windows builds have been disabled"
+else
 all: run_tests
+endif
 
 quick: $(RUNNER)
 	$(EXECUTE_RUNNER) $@


### PR DESCRIPTION
It turns out that the `auto-tester-test` target is unused, but `all` is called :/

See: https://github.com/dlang/dmd/pull/11653