### PR TITLE
CircleCi: use build.d and run.d directly

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -464,7 +464,7 @@ Params:
     key = key to check for existence and write into the new env
     default_ = fallback value if the key doesn't exist in the global environment
 */
-auto getDefault(string[string] env, string key, string default_)
+auto setDefault(string[string] env, string key, string default_)
 {
     if (key in environment)
         env[key] = environment[key];
@@ -486,13 +486,13 @@ string[string] getEnvironment()
     env["BUILD"] = build;
     env["EXE"] = exeExtension;
     env["DMD"] = dmdPath;
-    env.getDefault("DMD_TEST_COVERAGE", "0");
+    env.setDefault("DMD_TEST_COVERAGE", "0");
 
     const generatedSuffix = "generated/%s/%s/%s".format(os, build, model);
 
     version(Windows)
     {
-        env.getDefault("ARGS", "-inline -release -g -O");
+        env.setDefault("ARGS", "-inline -release -g -O");
         env["OBJ"] = ".obj";
         env["DSEP"] = `\\`;
         env["SEP"] = `\`;
@@ -503,7 +503,7 @@ string[string] getEnvironment()
     }
     else
     {
-        env.getDefault("ARGS", "-inline -release -g -O -fPIC");
+        env.setDefault("ARGS", "-inline -release -g -O -fPIC");
         env["OBJ"] = ".o";
         env["DSEP"] = "/";
         env["SEP"] = "/";


### PR DESCRIPTION
Currently CodeCov reports a lot of random coverage changes, e.g.

![image](https://user-images.githubusercontent.com/4370550/92070286-e37c8300-edab-11ea-9231-4ac66a3cd824.png)

I believe this is due to the testsuite being run in parallel and non-atomic updates of the `.lst` coverage files.

I used the opportunity to avoid calling the deprecated makefiles:
- `ENABLE_WARNINGS` was only used for the C++ build (-> removed)
- `PIC=1` is the default (-> removed)

This is not the ideal solution. I'm just checking whether this is the root of the problem.

edit: the runtime is already using locking - https://github.com/dlang/druntime/blob/c4d3720552aeac75cb7b466023fb86ca4f3a3e79/src/rt/cover.d#L204