### PR TITLE
fix Issue 16268 - Wrong loop optimization in code with integer overflow

### DIFF
--- a/src/dmd/backend/gother.d
+++ b/src/dmd/backend/gother.d
@@ -750,6 +750,14 @@ private void intranges()
     targ_llong initial,increment,final_;
 
     if (debugc) printf("intranges()\n");
+    static if (0)
+    {
+        foreach (int i, ref rel; rellist)
+        {
+            printf("[%d] rel.pelem: ", i); WReqn(rel.pelem); printf("\n");
+        }
+    }
+
     foreach (ref rel; rellist)
     {
         rb = rel.pblock;
@@ -841,7 +849,13 @@ private void intranges()
         /* Determine if we can make the relational an unsigned  */
         if (initial >= 0)
         {
-            if (final_ >= initial)
+            if (final_ == 0 && relatop == OPge)
+            {
+                /* if the relation is (i >= 0) there is likely some dependency
+                 * on switching sign, so do not make it unsigned
+                 */
+            }
+            else if (final_ >= initial)
             {
                 if (increment > 0 && ((final_ - initial) % increment) == 0)
                     goto makeuns;

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -2212,6 +2212,24 @@ void test19846()
 }
 
 ////////////////////////////////////////////////////////////////////////
+// https://issues.dlang.org/show_bug.cgi?id=16268
+
+void test16268()
+{
+    static void f(byte x)
+    {
+	for (byte i = 0; i <= x && i >= 0; ++i)
+	{
+	    assert(i >= 0);
+	    assert(i != -1);
+	    //printf("%d\n", i);
+	}
+    }
+
+    f(byte.max);
+}
+
+////////////////////////////////////////////////////////////////////////
 
 int main()
 {
@@ -2301,6 +2319,7 @@ int main()
     testMulAssPair();
     test21038();
     test19846();
+    test16268();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
The code was converting the loop variable to unsigned, although it depended on overflowing from positive to negative.