### PR TITLE
fix Issue 16317 - Wrong binop evaluation/load order when optimizing

### DIFF
--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -3700,8 +3700,15 @@ static if (0)  // Doesn't work too well, removed
         {
             tym_t ty;
 
+            version (MARS)
+                enum side = false; // don't allow side effects in e2.EV.E2 because of
+                                   // D order-of-evaluation rules
+            else
+                enum side = true;  // ok in C and C++
+
             // Replace (e1 = e1 op e) with (e1 op= e)
-            if (el_match(e1,e2.EV.E1))
+            if (el_match(e1,e2.EV.E1) &&
+                (side || !el_sideeffect(e2.EV.E2)))
             {
                 ty = e2.EV.E2.Ety;
                 e.EV.E2 = el_selecte2(e2);

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1910,6 +1910,28 @@ void testNegConst()
 
 ////////////////////////////////////////////////////////////////////////
 
+// https://issues.dlang.org/show_bug.cgi?id=16317
+
+int add8ret3(ref int s)
+{
+    s += 8;
+    return 3;
+}
+
+int binAdd(int val)
+{
+    val = val + add8ret3(val);
+    return val;
+}
+
+void test16317()
+{
+    assert(binAdd(1) == (1 + 3));
+    static assert(binAdd(1) == (1 + 3));
+}
+
+////////////////////////////////////////////////////////////////////////
+
 // https://issues.dlang.org/show_bug.cgi?id=20050
 
 int test20050_g = 0;
@@ -2048,12 +2070,12 @@ void testsbbrex()
     // special code is generated for these two cases
     static long foolt(dchar c)
     {
-	return c < 0x10000 ? 1 : 2;
+        return c < 0x10000 ? 1 : 2;
     }
 
     static long fooge(uint c)
     {
-	return c >= 0x10000 ? 1L : 2L;
+        return c >= 0x10000 ? 1L : 2L;
     }
 
     assert(foolt(0) == 1);
@@ -2218,12 +2240,12 @@ void test16268()
 {
     static void f(byte x)
     {
-	for (byte i = 0; i <= x && i >= 0; ++i)
-	{
-	    assert(i >= 0);
-	    assert(i != -1);
-	    //printf("%d\n", i);
-	}
+        for (byte i = 0; i <= x && i >= 0; ++i)
+        {
+            assert(i >= 0);
+            assert(i != -1);
+            //printf("%d\n", i);
+        }
     }
 
     f(byte.max);
@@ -2307,6 +2329,7 @@ int main()
     testfastpar();
     test20363();
     testNegConst();
+    test16317();
     test20050();
     testCpStatic();
     test7();


### PR DESCRIPTION
This also wound up converting tabs to spaces in mars1.d