### PR TITLE
CirrusCi: move steps into a common script

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,52 +1,8 @@
-common_steps_template: &COMMON_STEPS_TEMPLATE
-  install_prerequisites_script: |
-    set -uexo pipefail
-    if [ "$OS_NAME" == "linux" ]; then
-      packages="git-core make g++ gdb curl libcurl3 tzdata zip unzip xz-utils"
-      if [ "$MODEL" == "32" ]; then
-        dpkg --add-architecture i386
-        packages="$packages g++-multilib libcurl3-gnutls:i386"
-      fi
-      if [ "${DMD:0:4}" == "gdmd" ]; then
-        packages="$packages sudo software-properties-common wget"
-      fi
-      apt-get -q update
-      apt-get install -yq $packages
-    elif [ "$OS_NAME" == "darwin" ]; then
-      # required for install.sh
-      brew install gnupg
-    elif [ "$OS_NAME" == "freebsd" ]; then
-      packages="git gmake bash"
-      if [ "${D_VERSION:-x}" == "2.079.0" ] ; then
-        packages="$packages lang/gcc9"
-      fi
-      pkg install -y $packages
-      rm /usr/bin/make
-      ln -s /usr/local/bin/gmake /usr/bin/make
-    fi
-    # create a `dmd` symlink to the repo dir, necessary for druntime/Phobos
-    ln -s $CIRRUS_WORKING_DIR ../dmd
-  install_host_compiler_script: |
-    source ci.sh
-    # kludge
-    if [ "${DMD:0:4}" == "gdmd" ]; then export DMD="gdmd"; fi
-    if [ -z "${D_VERSION+x}" ]; then install_d "$DMD"; else install_d "$DMD-$D_VERSION"; fi
-  setup_repos_script: |
-    export BRANCH=${CIRRUS_BASE_BRANCH:-$CIRRUS_BRANCH}
-    source ci.sh
-    setup_repos
-  build_script: |
-    source ci.sh
-    build
-  test_dmd_script: |
-    source ci.sh
-    test_dmd
-  test_druntime_script: |
-    set -uexo pipefail
-    make -j$N -C ../druntime -f posix.mak MODEL=$MODEL unittest
-  test_phobos_script: |
-    set -uexo pipefail
-    make -j$N -C ../phobos -f posix.mak MODEL=$MODEL unittest
+# keep this config in sync between dmd, druntime and phobos
+with common_steps_template: &COMMON_STEPS_TEMPLATE
+  run_script: |
+    if [ "$OS_NAME" == "freebsd" ]; then pkg install -y bash; fi
+    bash cirrusci.sh
 
 environment:
   CIRRUS_CLONE_DEPTH: 50

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+################################################################################
+# Cirrus build script shared across DMD, DRuntime and Phobos
+################################################################################
+set -uexo pipefail
+
+echo ">> Installing prerequisites"
+if [ "$OS_NAME" == "linux" ]; then
+  packages="git-core make g++ gdb curl libcurl3 tzdata zip unzip xz-utils"
+  if [ "$MODEL" == "32" ]; then
+    dpkg --add-architecture i386
+    packages="$packages g++-multilib libcurl3-gnutls:i386"
+  fi
+  if [ "${DMD:0:4}" == "gdmd" ]; then
+    packages="$packages sudo software-properties-common wget"
+  fi
+  apt-get -q update
+  apt-get install -yq $packages
+elif [ "$OS_NAME" == "darwin" ]; then
+  # required for install.sh
+  brew install gnupg
+elif [ "$OS_NAME" == "freebsd" ]; then
+  packages="git gmake bash"
+  if [ "${D_VERSION:-x}" == "2.079.0" ] ; then
+    packages="$packages lang/gcc9"
+  fi
+  pkg install -y $packages
+  rm /usr/bin/make
+  ln -s /usr/local/bin/gmake /usr/bin/make
+fi
+# create a `dmd` symlink to the repo dir, necessary for druntime/Phobos
+ln -s "$CIRRUS_WORKING_DIR" ../dmd
+
+################################################################################
+
+echo ">> Install host compiler"
+source ci.sh
+# kludge
+if [ "${DMD:0:4}" == "gdmd" ]; then export DMD="gdmd"; fi
+if [ -z "${D_VERSION+x}" ]; then install_d "$DMD"; else install_d "$DMD-$D_VERSION"; fi
+
+################################################################################
+
+echo ">> Setup repositories"
+
+export BRANCH=${CIRRUS_BASE_BRANCH:-$CIRRUS_BRANCH}
+source ci.sh
+setup_repos
+
+################################################################################
+
+echo ">> Build repositories"
+build
+
+################################################################################
+
+echo ">> Test DMD"
+test_dmd
+
+################################################################################
+
+echo ">> Test DRuntime"
+make -j$N -C ../druntime -f posix.mak MODEL=$MODEL unittest
+
+################################################################################
+
+echo ">> Test Phobos"
+make -j$N -C ../phobos -f posix.mak MODEL=$MODEL unittest


### PR DESCRIPTION
This just moves all build steps into `cirrusci.sh`.

Motivation: reduce the duplication between the `.cirrus.yml` at dmd, druntime and Phobos. This allows to have one only one file that needs to be updated.
Downside: this will only be represented as a single job in the UI, so it might be a bit harder to track down what went wrong, but we're doing the same concept with the Azure Pipeline (see e.g. https://github.com/dlang/druntime/blob/master/azure-pipelines.yml)

There are still more changes that need to happen to this script first before it can be used at druntime / Phobos, but I wanted to separate this and do it in a different PR.