### PR TITLE
WIP: Extend cases where expressions are passed by move [skip ci]

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -185,6 +185,9 @@ public:
     // ABI-specific type(s) if the struct can be passed in registers
     TypeTuple *argTypes;
 
+    VarExp* wasMovedBy;         // `VarExp` this was moved by
+    uint vrefCount;             // total number of references in `VarExp`s
+
     static StructDeclaration *create(Loc loc, Identifier *id, bool inObject);
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semanticTypeInfoMembers();

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -439,6 +439,11 @@ extern (C++) abstract class Declaration : Dsymbol
         return s;
     }
 
+    final bool mayNeedMove() const pure nothrow @nogc @safe
+    {
+        return (storage_class & (STC.ref_ | STC.manifest | STC.out_)) == 0;
+    }
+
     final bool isStatic() const pure nothrow @nogc @safe
     {
         return (storage_class & STC.static_) != 0;

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -225,6 +225,9 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     // ABI-specific type(s) if the struct can be passed in registers
     TypeTuple argTypes;
 
+    VarExp wasMovedBy;          // `VarExp` this was moved by
+    uint vrefCount;             // total number of references in `VarExp`s
+
     extern (D) this(const ref Loc loc, Identifier id, bool inObject)
     {
         super(loc, id);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3599,11 +3599,16 @@ extern (C++) final class SymOffExp : SymbolExp
  */
 extern (C++) final class VarExp : SymbolExp
 {
+    uint vrefOrder;
     bool delegateWasExtracted;
     extern (D) this(const ref Loc loc, Declaration var, bool hasOverloads = true)
     {
-        if (var.isVarDeclaration())
+        if (auto sd = var.isStructDeclaration())
+        {
+            vrefOrder = sd.vrefCount++;
+            //loc.message("VarExp(): ve:%p var:%p ro:%d rc:%d", this, var, vrefOrder, vd.vrefCount); // TODO: reuse `inuse`?
             hasOverloads = false;
+        }
 
         super(loc, TOK.variable, __traits(classInstanceSize, VarExp), var, hasOverloads);
         //printf("VarExp(this = %p, '%s', loc = %s)\n", this, var.toChars(), loc.toChars());

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -563,6 +563,7 @@ public:
 class VarExp : public SymbolExp
 {
 public:
+    unsigned vrefOrder;
     bool delegateWasExtracted;
     static VarExp *create(Loc loc, Declaration *var, bool hasOverloads = true);
     bool equals(const RootObject *o) const;

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -573,6 +573,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 if (!funcdecl.fbody)
                     funcdecl.fbody = new CompoundStatement(Loc.initial, new Statements());
 
+                inferStatementRvalues(sc, funcdecl.fbody);
+
                 if (funcdecl.naked)
                 {
                     fpreinv = null;         // can't accommodate with no stack frame

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -59,6 +59,7 @@ import dmd.tokens;
 import dmd.typesem;
 import dmd.visitor;
 import dmd.compiler;
+import dmd.dstruct;
 
 /*****************************************
  * CTFE requires FuncDeclaration::labtab for the interpretation.
@@ -3082,7 +3083,7 @@ else
         if (fd.fes)
             fd = fd.fes.func; // fd is now function enclosing foreach
 
-            TypeFunction tf = cast(TypeFunction)fd.type;
+        TypeFunction tf = cast(TypeFunction)fd.type;
         assert(tf.ty == Tfunction);
 
         if (rs.exp && rs.exp.op == TOK.variable && (cast(VarExp)rs.exp).var == fd.vresult)
@@ -4408,5 +4409,90 @@ TupleForeachRet!(isStatic, isDecl) makeTupleForeach(bool isStatic, bool isDecl)(
     else
     {
         return v.makeTupleForeach!(isStatic, isDecl)(fs, args);
+    }
+}
+
+/*************************************
+ * Infer `STC.rvalue` of variables and non-`ref`-parameters
+ * (`VarDeclaration`s) in function `fd`.
+ *
+ * TODO: can we activate pass-by-move lazily for different `VarExp`'s of the
+ * same `VarDeclaration`?
+ *
+ * TODO: can we |= nodtor and then insert call to destructor for if branches
+ * that doesn't need moving?
+ */
+void inferStatementRvalues(Scope* sc,
+                           Statement ts) // top statemennt
+{
+    assert(ts);
+    if (CompoundStatement s = ts.isCompoundStatement)
+    {
+        if (!s.statements)
+            return;
+        foreach (Statement ss; *s.statements) // sub-statement
+            if (ss)
+                inferStatementRvalues(sc, ss);
+    }
+    else if (ReturnStatement s = ts.isReturnStatement)
+    {
+        if (s.exp)
+            if (VarExp ve = s.exp.isVarExp)
+                tryMove(sc, ve);
+    }
+    else if (ExpStatement s = ts.isExpStatement)
+    {
+        if (s.exp)
+            if (AssignExp ae = s.exp.isAssignExp)
+                if (VarExp ve = ae.e2.isVarExp)
+                    tryMove(sc, ve);
+    }
+    else if (IfStatement s = ts.isIfStatement)
+    {
+        if (s.ifbody)
+            inferStatementRvalues(sc, s.ifbody);
+        if (s.elsebody)
+            inferStatementRvalues(sc, s.elsebody);
+        if (s.condition)
+            inferExpressionRvalues(sc, s.condition);
+        // TODO: `vd.cannotBeRvalue` = true for each `vd` referenced under s
+    }
+    else
+    {
+        // ts.loc.warning("TODO: ts:%p", ts);
+    }
+}
+
+void inferExpressionRvalues(Scope* sc, Expression e)
+{
+    assert(e);
+}
+
+void tryMove(Scope* sc, VarExp e)
+{
+    assert(e);
+    if (!e.var.mayNeedMove)
+        return;
+    // e.warning("e.var:%p %p", e.var, e.var.isStructDeclaration);
+    // e.var.loc.warning("var:%p %s", e.var, e.var.toChars());
+    if (StructDeclaration sd = e.var.isStructDeclaration)
+    {
+        const isLastRef = (e.vrefOrder + 1 == sd.vrefCount);
+        if (!isLastRef) // if all value-passing of `e` can be passed as an r-value
+            return;
+        if (sd.wasMovedBy)
+        {
+            e.loc.warning("variable `%s` already moved", e.toChars());
+            sd.wasMovedBy.loc.warningSupplemental("already moved by `%s`", sd.wasMovedBy.toChars());
+        }
+        else
+        {
+            /* trigger move `VarExp.isLvalue` to assignment
+             * `false` and, in turn, move in `doCopyOrMove`: */
+            sd.storage_class |= STC.rvalue;
+            sd.wasMovedBy = e;
+            // e.loc.message("variable `%s` was moved", e.toChars());
+            // sd.loc.message("from inferred rvalue declaration `%s`", sd.toChars());
+        }
     }
 }

--- a/test/fail_compilation/more_moves.d
+++ b/test/fail_compilation/more_moves.d
@@ -1,0 +1,144 @@
+// REQUIRED_ARGS: -w -vcolumns -unittest
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/more_moves.d(27,12): Error: struct `more_moves.S` is not copyable because it is annotated with `@disable`
+fail_compilation/more_moves.d(33,9): Error: struct `more_moves.S` is not copyable because it is annotated with `@disable`
+---
+*/
+
+@safe:
+
+// uint postblit;                  // number of calls made to `S.this(this)`
+
+struct S
+{
+@safe:
+    @disable this(this);
+    //this(this) { postblit += 1; }
+    // TODO include copy constructor
+    int x;
+    alias x this;
+}
+
+S moveSingleReturn(S e, int x)
+{
+    return e;                   // move is now enabled
+}
+
+S moveAssignment(S e, int x)
+{
+    S f;
+    f = e;                      // TODO: enable move here
+}
+
+// S moveSingleReturnAlreadyMovedInAssignment(S e, int x)
+// {
+//     S f;
+//     f = e;                   // TODO: enable move here
+//     return e;                // TODO: error, already moved, give location of move
+// }
+
+// S moveSingleReturnAlreadyMovedInInit(S e, int x)
+// {
+//     S f = e;                 // TODO: enable move here
+//     return e;                // TODO: error, already moved, give location of move
+// }
+
+// @safe unittest
+// {
+//     testAA(S.init);
+//     assert(postblit == 0);
+
+//     testC(S.init);
+//     assert(postblit == 0);
+// }
+
+// S testAA(S e)
+// {
+//     return moveSingleReturn(e, 1);         // TODO: moved
+// }
+
+// S testC(S e)
+// {
+//     auto f = e;                 // single ref of `e` can be moved to `f`
+//     return f;                   // single ref of `f` can be moved
+// }
+
+// S testMM(S e, int x)
+// {
+//     if (x == 1)
+//         return e;               // moved
+//     else
+//         return e;               // moved
+// }
+
+// S testME(S e, int x)
+// {
+//     if (x == 1)
+//         return e;               // moved
+//     return e;                   // moved
+// }
+
+// S testV(S e)
+// {
+//     S f;
+//     f = e;                      // single ref of `e` can be moved to `f`
+//     return f;                   // single ref of `f` can be moved
+// }
+
+// S testAAA(S e)
+// {
+//     return (e.x == 0 ?
+//             moveSingleReturn(e, 1) :       // TODO: moved
+//             moveSingleReturn(e, 1));       // TODO: moved
+// }
+
+// // TODO: Detect cases:
+// // each VarExp of `e` must be either
+// // - reads of members (`DotVarExp` where e1 is `e`)
+// // - pass by move in return statement
+// // - final assignment
+// S testB(S e)
+// {
+//     if (e.x == 0)               // member read ok
+//         return moveSingleReturn(e, 1);     // parameter can be passed by move
+//     return moveSingleReturn(e, 1);         // parameter can be passed by move
+// }
+
+// struct A
+// {
+//     this(S e)
+//     {
+//         this.e = e; // last ref so `e` can be moved
+//     }
+//     S e;
+// }
+
+// S testD(S e)
+// {
+//     auto f = e;                 // can't move `e`
+//     auto g = e;                 // can't move `e`
+//     return f;                   // can move `f`
+// }
+
+// // Can move e because all refs to `e` are direct returns.
+// S testE(S e)
+// {
+//     if (true)
+//         return e;               // first ref of `e` is moved
+//     else
+//         return e;               // second ref of `e` is moved
+// }
+
+// S testF(S e)
+// {
+//     auto f = e;                 // can't move `e`
+//     if (e.x == 0)
+//         return e;               // can't move `e`
+//     else if (e.x == 1)
+//         return e;               // can't move `e`
+//     else
+//         return f;               // can move `f`
+// }


### PR DESCRIPTION
This enables more situations where variables and parameters are automatically passed by move. It works by detecting when all the references to a `VarDeclaration` can be passed by move. For those cases move is triggered by setting `STC.rvalue` of the `VarDeclaration`.

The first goal here is to enable a lazy range to be constructed with a non-copyable container type as its source ranges, typically, as

```D
this(R)(R source)
{
    this.source = source; // `source` can be passed by move here
}
```

. This case can be activated by a simple special-casing in `inferStatementRvalues` without the current added book-keepings

- `VarExp.vrefOrder`
- `VarDeclaration.vrefCount`
- `VarDeclaraiton.wasMovedBy`

which are currently there for experimenting purposes.

There book-keepings are here because they enable more pass-by-move cases. The question is if we should try enabling these as well.

There's now also a possibility to enable better error messages by giving the location of the `VarExp` that already moved a `VarDeclaration` if more than one move occurs for the same `VarDeclaration`.