### PR TITLE
Fix Issue 20016 - JSON (-X) compilerInfo.platforms generation depends on params.isXXX for platform detection

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1262,7 +1262,7 @@ auto sourceFiles()
             libmach.d libmscoff.d libomf.d link.d mars.d mtype.d nogc.d nspace.d ob.d objc.d opover.d optimize.d
             parse.d parsetimevisitor.d permissivevisitor.d printast.d safe.d sapply.d scanelf.d scanmach.d
             scanmscoff.d scanomf.d semantic2.d semantic3.d sideeffect.d statement.d statement_rewrite_walker.d
-            statementsem.d staticassert.d staticcond.d stmtstate.d target.d templateparamsem.d traits.d
+            statementsem.d staticassert.d staticcond.d stmtstate.d target.d target_platform.d templateparamsem.d traits.d
             transitivevisitor.d typesem.d typinf.d utils.d visitor.d vsoptions.d foreachvar.d
         "),
         backendHeaders: fileArray(env["C"], "

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -731,6 +731,16 @@ struct ObNode;
 class StoppableVisitor;
 struct Token;
 struct code;
+BEGIN_ENUM(Platform, PLATFORM, platform)
+ENUM_KEY(int32_t, Linux, 0, Platform, PLATFORM, platform, P)
+ENUM_KEY(int32_t, OSX, 1, Platform, PLATFORM, platform, P)
+ENUM_KEY(int32_t, FreeBSD, 2, Platform, PLATFORM, platform, P)
+ENUM_KEY(int32_t, OpenBSD, 3, Platform, PLATFORM, platform, P)
+ENUM_KEY(int32_t, Solaris, 4, Platform, PLATFORM, platform, P)
+ENUM_KEY(int32_t, Windows, 5, Platform, PLATFORM, platform, P)
+ENUM_KEY(int32_t, DragonFlyBSD, 6, Platform, PLATFORM, platform, P)
+END_ENUM(Platform, PLATFORM, platform)
+
 struct TargetC;
 struct TargetCPP;
 struct TargetObjC;
@@ -6425,10 +6435,12 @@ struct Target
     uint32_t realalignsize;
     uint32_t classinfosize;
     uint64_t maxStaticDataSize;
+    Platform platform;
     TargetC c;
     TargetCPP cpp;
     TargetObjC objc;
     DArray< const char > architectureName;
+    DArray< DArray< char > > platformNames;
     template <typename T>
     struct FPTypeProperties
     {
@@ -6493,6 +6505,7 @@ struct Target
         cpp(),
         objc(),
         architectureName(),
+        platformNames(),
         FloatProperties(),
         DoubleProperties(),
         RealProperties()
@@ -6620,16 +6633,6 @@ BEGIN_ENUM_NUMERIC(uint8_t, HIGHLIGHT, HIGHLIGHT, highlight)
     ENUM_KEY_NUMERIC(uint8_t, Comment, 8u, HIGHLIGHT, HIGHLIGHT, highlight, HIGHLIGHT)
     ENUM_KEY_NUMERIC(uint8_t, Other, 6u, HIGHLIGHT, HIGHLIGHT, highlight, HIGHLIGHT)
 END_ENUM_NUMERIC(uint8_t, HIGHLIGHT, HIGHLIGHT, highlight)
-
-BEGIN_ENUM_NUMERIC(bool, TARGET, TARGET, target)
-    ENUM_KEY_NUMERIC(bool, Linux, true, TARGET, TARGET, target, TARGET)
-    ENUM_KEY_NUMERIC(bool, OSX, false, TARGET, TARGET, target, TARGET)
-    ENUM_KEY_NUMERIC(bool, FreeBSD, false, TARGET, TARGET, target, TARGET)
-    ENUM_KEY_NUMERIC(bool, OpenBSD, false, TARGET, TARGET, target, TARGET)
-    ENUM_KEY_NUMERIC(bool, Solaris, false, TARGET, TARGET, target, TARGET)
-    ENUM_KEY_NUMERIC(bool, Windows, false, TARGET, TARGET, target, TARGET)
-    ENUM_KEY_NUMERIC(bool, DragonFlyBSD, false, TARGET, TARGET, target, TARGET)
-END_ENUM_NUMERIC(bool, TARGET, TARGET, target)
 
 BEGIN_ENUM_NUMERIC(uint8_t, DiagnosticReporting, DIAGNOSTICREPORTING, diagnosticreporting)
     ENUM_KEY_NUMERIC(uint8_t, error, 0u, DiagnosticReporting, DIAGNOSTICREPORTING, diagnosticreporting, DR)

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -836,33 +836,8 @@ public:
         property("size_t", size_t.sizeof);
         propertyStart("platforms");
         arrayStart();
-        if (global.params.isWindows)
-        {
-            item("windows");
-        }
-        else
-        {
-            item("posix");
-            if (global.params.isLinux)
-                item("linux");
-            else if (global.params.isOSX)
-                item("osx");
-            else if (global.params.isFreeBSD)
-            {
-                item("freebsd");
-                item("bsd");
-            }
-            else if (global.params.isOpenBSD)
-            {
-                item("openbsd");
-                item("bsd");
-            }
-            else if (global.params.isSolaris)
-            {
-                item("solaris");
-                item("bsd");
-            }
-        }
+        foreach (const p; target.platformNames)
+            item(p);
         arrayEnd();
 
         propertyStart("architectures");

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -69,6 +69,7 @@ struct Target
     TargetObjC objc;
 
     DString architectureName;    // name of the platform architecture (e.g. X86_64)
+    DArray<DString> platformNames;
 
     template <typename T>
     struct FPTypeProperties

--- a/src/dmd/target_platform.d
+++ b/src/dmd/target_platform.d
@@ -1,0 +1,43 @@
+/**
+ * Determines the platform to use for the compiler backend.
+ * At the moment this the platform is defined statically by the host compiler.
+ *
+ * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/target_platform.d, _target_platform.d)
+ * Documentation:  https://dlang.org/phobos/dmd_target_platform.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/target_platform.d
+ */
+
+module dmd.target_platform;
+
+// Supported platforms by the backend
+enum Platform
+{
+    Linux,
+    OSX,
+    FreeBSD,
+    OpenBSD,
+    Solaris,
+    Windows,
+    DragonFlyBSD,
+}
+
+extern(D):
+
+// provide a global platform until globals does not use platform anymore
+version (Windows)
+    enum platform = Platform.Windows;
+else version (linux)
+    enum platform = Platform.Linux;
+else version (OSX)
+    enum platform = Platform.OSX;
+else version (FreeBSD)
+    enum platform = Platform.FreeBSD;
+else version (OpenBSD)
+    enum platform = Platform.Solaris;
+else version (DragonFlyBSD)
+    enum platform = Platform.DragonFlyBSD;
+else
+    static assert(0, "Unknown platform");


### PR DESCRIPTION
As there's no replacement for the `is{Windows,Linux, ...}` parameters in `globals.params` I started a replacement in `target`.

The `final switch (platform)` are evaluated at runtime as it's a first step from moving away from a hard-coded host compiler platform target. However, I had to cheat at two places as some parts of dmd can't currently be imported on all platforms.

CC @ibuclaw 
