### PR TITLE
Fix Issue 20017 - JSON (-X) compilerInfo.architectures generation depends on params.isXXX for CPU detection

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6478,6 +6478,7 @@ struct Target
     TargetC c;
     TargetCPP cpp;
     TargetObjC objc;
+    DArray< const char > architectureName;
     template <typename T>
     struct FPTypeProperties
     {
@@ -6530,7 +6531,7 @@ struct Target
     END_ENUM(TargetInfoKeys, TARGETINFOKEYS, targetinfokeys)
 
     Expression* getTargetInfo(const char* name, const Loc& loc);
-    Target() : ptrsize(), realsize(), realpad(), realalignsize(), classinfosize(), maxStaticDataSize(), c(), cpp(), objc(), FloatProperties(), DoubleProperties(), RealProperties() {}
+    Target() : ptrsize(), realsize(), realpad(), realalignsize(), classinfosize(), maxStaticDataSize(), c(), cpp(), objc(), architectureName(), FloatProperties(), DoubleProperties(), RealProperties() {}
 };
 
 extern Target target;

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -827,6 +827,7 @@ public:
     */
     private void generateCompilerInfo()
     {
+        import dmd.target : target;
         objectStart();
         requiredProperty("vendor", global.vendor);
         requiredProperty("version", global.versionString());
@@ -866,10 +867,7 @@ public:
 
         propertyStart("architectures");
         arrayStart();
-        if (global.params.is64bit)
-            item("x86_64");
-        else
-            version(X86) item("x86");
+        item(target.architectureName);
         arrayEnd();
 
         propertyStart("predefinedVersions");

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -77,6 +77,9 @@ extern (C++) struct Target
     /// Objective-C ABI
     TargetObjC objc;
 
+    /// Architecture name
+    const(char)[] architectureName;
+
     /**
      * Values representing all properties for floating point types
      */
@@ -178,6 +181,11 @@ extern (C++) struct Target
         c.initialize(params, this);
         cpp.initialize(params, this);
         objc.initialize(params, this);
+
+        if (global.params.is64bit)
+            architectureName = "X86_64";
+        else
+            architectureName = "X86";
     }
 
     /**

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -68,6 +68,8 @@ struct Target
     // Objective-C ABI
     TargetObjC objc;
 
+    DString architectureName;    // name of the platform architecture (e.g. X86_64)
+
     template <typename T>
     struct FPTypeProperties
     {

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -111,6 +111,9 @@ void test_compiler_globals()
     assert(strncmp(global.versionChars(), "v2.", 3) == 0);
     unsigned versionNumber = global.versionNumber();
     assert(versionNumber >= 2060 && versionNumber <= 3000);
+
+    assert(strcmp(target.architectureName.ptr, "X86_64") == 0 ||
+           strcmp(target.architectureName.ptr, "X86") == 0);
 }
 
 /**********************************/


### PR DESCRIPTION
Just moves the hard-coded bit to `target.d`. Not sure what could be done about this as there's a wealth of information available.

CC @ibuclaw 