### PR TITLE
Fix 21225 - preview=dtorfields inserts unnecessary dtor calls...

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1356,7 +1356,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
          * https://issues.dlang.org/show_bug.cgi?id=14246
          */
         AggregateDeclaration ad = ctor.isMemberDecl();
-        if (ctor.fbody && ad && ad.fieldDtor && global.params.dtorFields)
+        if (ctor.fbody && ad && ad.fieldDtor && global.params.dtorFields && !ctor.type.toTypeFunction.isnothrow)
         {
             /* Generate:
              *   this.fieldDtor()

--- a/test/compilable/dtorfields.d
+++ b/test/compilable/dtorfields.d
@@ -32,3 +32,18 @@ class Child : Parent
 {
     HasDtor member;
 }
+
+/******************************************
+ * https://issues.dlang.org/show_bug.cgi?id=21225
+ */
+
+struct NothrowConstructed
+{
+    ~this() {}
+}
+
+struct NothrowConstructor
+{
+    NothrowConstructed member;
+    this(int) pure nothrow {}
+}


### PR DESCRIPTION
... in nothrow ctors

Fixed by not inserting the destructor call if the constructor is
`nothrow` - which makes the generated `catch`-block unreachable
(unless the ctor violates it's `nothrow` guarantee - which is UB).

This also saves time & memory spent on generating unused AST elements.

----

Note; This should also reduce the amount of breakage introduced by -preview=dtorfields`