### PR TITLE
Update D-Scanner: v0.9.0 -> v0.11.0

### DIFF
--- a/src/.dscanner.ini
+++ b/src/.dscanner.ini
@@ -101,6 +101,8 @@ if_constraints_indent="enabled"
 trust_too_much="enabled"
 ; Check for redundant storage classes on variable declarations")
 redundant_storage_classes="enabled"
+; Check for unused function return values
+unused_result="disabled"
 
 ; Configure which modules are checked with a specific checker
 ; Please help to extend these checks onto more Phobos modules

--- a/src/build.d
+++ b/src/build.d
@@ -593,8 +593,8 @@ alias style = makeRule!((builder, rule)
             // FIXME: Omitted --shallow-submodules because it requires a more recent
             //        git version which is not available on buildkite
             env["GIT"], "clone", "--depth=1", "--recurse-submodules",
-            "--branch=v0.9.0",
-            "https://github.com/dlang-community/Dscanner", dscannerDir
+            "--branch=v0.11.0",
+            "https://github.com/dlang-community/D-Scanner", dscannerDir
         ])
     );
 


### PR DESCRIPTION
The URL was changed because the project was apparently renamed a while ago.
Luckily Github keeps URL around for a while, but might as well fix it.