### PR TITLE
fix Issue 18412 - [REG2.077.0] immutable array in library becomes nul…

### DIFF
--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -5307,7 +5307,7 @@ void assignaddrc(code *c)
         switch (c.IFL1)
         {
             case FLdata:
-                if (config.objfmt == OBJ_OMF && s.Sclass != SCcomdat)
+                if (config.objfmt == OBJ_OMF && s.Sclass != SCcomdat && s.Sclass != SCextern)
                 {
                     version (MARS)
                     {

--- a/test/runnable/extra-files/m1.d
+++ b/test/runnable/extra-files/m1.d
@@ -1,0 +1,4 @@
+// https://issues.dlang.org/show_bug.cgi?id=18412
+
+import m2: f;
+void main() { f(); }

--- a/test/runnable/extra-files/m2.d
+++ b/test/runnable/extra-files/m2.d
@@ -1,0 +1,11 @@
+static this()
+{
+    auto k = keywords;
+}
+
+immutable int[] keywords = [42];
+
+void f()
+{
+    assert(keywords.ptr !is null); /* fails; should pass */
+}

--- a/test/runnable/test18412.sh
+++ b/test/runnable/test18412.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+
+
+$DMD -m${MODEL} -I${TEST_DIR} -od${RESULTS_TEST_DIR} -lib ${EXTRA_FILES}/m2.d
+$DMD -m${MODEL} -I${TEST_DIR} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}/m1.d ${RESULTS_TEST_DIR}/m2${LIBEXT}
+
+
+${OUTPUT_BASE}${EXE}
+
+rm_retry ${OUTPUT_BASE}{${OBJ},${EXE}}
+


### PR DESCRIPTION
…l when referenced in static constructor

This isn't really a regression, it's just happenstance it didn't show up before. It is not the fault of https://github.com/dlang/dmd/pull/7150 even though that PR exposed the problem.