### PR TITLE
fix Issue 19179 - extern(C++) small-struct by-val uses wrong ABI

### DIFF
--- a/test/runnable_cxx/extra-files/cpp19179.cpp
+++ b/test/runnable_cxx/extra-files/cpp19179.cpp
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=19179
+
+struct SmallStruct { int x, y; };
+
+SmallStruct test_small(SmallStruct);
+void test_small_noret(SmallStruct);
+
+void cppmain()
+{
+	SmallStruct s;
+	s.x = 10;
+	s.y = 20;
+	test_small(s);
+	test_small_noret(s);
+}

--- a/test/runnable_cxx/test19179.d
+++ b/test/runnable_cxx/test19179.d
@@ -1,0 +1,32 @@
+// EXTRA_CPP_SOURCES: cpp19179.cpp
+
+// https://issues.dlang.org/show_bug.cgi?id=19179
+
+import core.stdc.stdio;
+
+extern(C++) struct SmallStruct { int x = 10, y = 20; }
+
+extern (C++)
+SmallStruct test_small(SmallStruct s)
+{
+    printf("%d %d\n", s.x, s.y); // prints: invalid memory
+    assert(s.x == 10);
+    assert(s.y == 20);
+    return s;
+}
+
+extern (C++)
+void test_small_noret(SmallStruct s)
+{
+    printf("%d %d\n", s.x, s.y); // prints: 10 20
+    assert(s.x == 10);
+    assert(s.y == 20);
+}
+
+extern (C++) void cppmain();
+
+int main()
+{
+    cppmain();
+    return 0;
+}


### PR DESCRIPTION
The bug worksforme on my machine, adding test case to ensure it works generally.