### PR TITLE
Add Windows-specific unit tests for absolute()

### DIFF
--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -124,6 +124,13 @@ nothrow:
     {
         assert(absolute("/"[]) == true);
         assert(absolute(""[]) == false);
+
+        version (Windows)
+        {
+            assert(absolute(r"\"[]) == true);
+            assert(absolute(r"\\"[]) == true);
+            assert(absolute(r"c:"[]) == true);
+        }
     }
 
     /**


### PR DESCRIPTION
Add unit tests for paths starting with:
- Backslash (`\`)
- Disk drive name (`c:`)