### PR TITLE
add support for Object.TypeInfoStructGeneric template

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2578,6 +2578,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (tempdecl.ident == Id.RTInfo)
                 Type.rtinfo = tempdecl;
+
+            if (tempdecl.ident == Id.TypeInfoStructGeneric)
+                Type.typeinfostructgeneric = tempdecl;
         }
 
         /* Remember Scope for later instantiations, but make

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1461,6 +1461,7 @@ public:
     static ClassDeclaration* typeinfoshared;
     static ClassDeclaration* typeinfowild;
     static TemplateDeclaration* rtinfo;
+    static TemplateDeclaration* typeinfostructgeneric;
     static Type* basic[48LLU];
     virtual const char* kind() const;
     Type* copy() const;
@@ -8412,6 +8413,7 @@ struct Id final
     static Identifier* outer;
     static Identifier* Exception;
     static Identifier* RTInfo;
+    static Identifier* TypeInfoStructGeneric;
     static Identifier* Throwable;
     static Identifier* Error;
     static Identifier* withSym;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -107,6 +107,7 @@ immutable Msgtable[] msgtable =
     { "outer" },
     { "Exception" },
     { "RTInfo" },
+    { "TypeInfoStructGeneric" },
     { "Throwable" },
     { "Error" },
     { "withSym", "__withSym" },

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -423,6 +423,7 @@ extern (C++) abstract class Type : ASTNode
     extern (C++) __gshared ClassDeclaration typeinfowild;
 
     extern (C++) __gshared TemplateDeclaration rtinfo;
+    extern (C++) __gshared TemplateDeclaration typeinfostructgeneric;
 
     extern (C++) __gshared Type[TMAX] basic;
 

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -215,6 +215,7 @@ public:
     static ClassDeclaration *typeinfowild;
 
     static TemplateDeclaration *rtinfo;
+    static TemplateDeclaration *typeinfostructgeneric;
 
     static Type *basic[(int)TY::TMAX];
 

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -11,18 +11,24 @@
 
 module dmd.typinf;
 
+import dmd.arraytypes;
 import dmd.astenums;
 import dmd.declaration;
 import dmd.dmodule;
 import dmd.dscope;
 import dmd.dclass;
 import dmd.dstruct;
+import dmd.dsymbolsem;
+import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
+import dmd.expressionsem;
 import dmd.globals;
 import dmd.gluelayer;
 import dmd.location;
 import dmd.mtype;
+import dmd.semantic2;
+import dmd.semantic3;
 import dmd.visitor;
 import core.stdc.stdio;
 
@@ -64,16 +70,47 @@ extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope
     Type t = torig.merge2(); // do this since not all Type's are merge'd
     if (!t.vtinfo)
     {
-        if (t.isShared()) // does both 'shared' and 'shared const'
-            t.vtinfo = TypeInfoSharedDeclaration.create(t);
-        else if (t.isConst())
-            t.vtinfo = TypeInfoConstDeclaration.create(t);
-        else if (t.isImmutable())
-            t.vtinfo = TypeInfoInvariantDeclaration.create(t);
-        else if (t.isWild())
-            t.vtinfo = TypeInfoWildDeclaration.create(t);
-        else
-            t.vtinfo = getTypeInfoDeclaration(t);
+        if (Type.typeinfostructgeneric && t.isTypeStruct())
+        {
+            // Evaluate: TypeInfoStructGeneric!t
+            auto tiargs = new Objects();
+            tiargs.push(t);
+            auto ti = new TemplateInstance(loc, Type.typeinfostructgeneric, tiargs);
+
+            Scope* sc3 = ti.tempdecl._scope.startCTFE();
+            sc3.tinst = sc.tinst;
+            sc3.minst = sc.minst;
+            ti.dsymbolSemantic(sc3);
+            ti.semantic2(sc3);
+            ti.semantic3(sc3);
+            auto ex = symbolToExp(ti.toAlias(), Loc.initial, sc3, false);
+
+            sc3.endCTFE();
+
+            ex = ex.ctfeInterpret();
+            t.vtinfo = cast(TypeInfoDeclaration) ex.isVarExp();
+            /* Save this for when TypeInfoStructGeneric is fully operational
+            if (!t.vtinfo)
+            {
+                .error(loc, "`object.TypeInfoStructGeneric!T` did not return a TypeInfo variable");
+                fatal();
+            }
+            */
+        }
+
+        if (!t.vtinfo)
+        {
+            if (t.isShared()) // does both 'shared' and 'shared const'
+                t.vtinfo = TypeInfoSharedDeclaration.create(t);
+            else if (t.isConst())
+                t.vtinfo = TypeInfoConstDeclaration.create(t);
+            else if (t.isImmutable())
+                t.vtinfo = TypeInfoInvariantDeclaration.create(t);
+            else if (t.isWild())
+                t.vtinfo = TypeInfoWildDeclaration.create(t);
+            else
+                t.vtinfo = getTypeInfoDeclaration(t);
+        }
         assert(t.vtinfo);
 
         // ClassInfos are generated as part of ClassDeclaration codegen


### PR DESCRIPTION
Currently, instances of TypeInfo_Struct are generated by a complex and tedious process inside the compiler. This change experiments with using a template in druntime, Object.TypeInfoStructGeneric instead, to generate it. The compiler will know nothing about the contents of TypeInfo_Struct, leaving people free to innovate with the definition of TypeInfoStructGeneric. (All that code in the compiler will be removed once TypeInfoStructGeneric is successful.)

This is analogous to the successful use of Object.RTinfo to generate info for the garbage collector. The implementation of TypeInfoStructGeneric is very similar for that for RTinfo, which can be found in Semantic3Visitor in semantic3.d

This PR makes it so that if Object.TypeInfoStructGeneric is not there, it falls back to the original compiler implementation of TypeInfoStruct.

This is analogous to https://github.com/dlang/dmd/pull/11459