### PR TITLE
fix Issue 16274 - short argument passed in 16 bit register

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2101,6 +2101,13 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
             if (!p.isReference())
                 err |= arg.checkSharedAccess(sc);
 
+            // Promote bytes, words, etc., to ints
+            if (!p.isReference() && !(p.storageClass & STC.lazy_) &&
+                target.c.promoteIntArguments(tf))
+            {
+                arg = integralPromotions(arg, sc);
+            }
+
             arg = arg.optimize(WANTvalue, p.isReference());
 
             /* Determine if this parameter is the "first reference" parameter through which

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1738,6 +1738,7 @@ struct TargetC
     uint32_t longsize;
     uint32_t long_doublesize;
     uint32_t criticalSectionSize;
+    bool promoteIntArguments(TypeFunction* tf);
     TargetC() :
         longsize(),
         long_doublesize(),

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -949,6 +949,19 @@ struct TargetC
         criticalSectionSize = getCriticalSectionSize(params);
     }
 
+    /**
+     * Returns true if named 8-bit and 16-bit integer arguments should be
+     * passed as an `int`. This avoids errors in certain cases of mismatch.
+     * Params:
+     *      tf = function type being called
+     * Returns:
+     *      true if integral promotions should be applied
+     */
+    extern (C++) bool promoteIntArguments(TypeFunction tf)
+    {
+        return (tf.linkage != LINK.d);
+    }
+
     private static uint getCriticalSectionSize(ref const Param params) pure
     {
         if (params.isWindows)

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -29,6 +29,8 @@ struct TargetC
     unsigned longsize;            // size of a C 'long' or 'unsigned long' type
     unsigned long_doublesize;     // size of a C 'long double'
     unsigned criticalSectionSize; // size of os critical section
+
+    bool promoteIntArguments(TypeFunction *tf);
 };
 
 struct TargetCPP

--- a/test/runnable/test16274.d
+++ b/test/runnable/test16274.d
@@ -1,0 +1,207 @@
+/******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=16274
+
+// These tests inspect the value of EDI parameter register.
+// Integer promotions should have been done on:
+//  - extern(C):   Yes (X86 and X86_64, shorts and bytes passed in EDI).
+//  - extern(C++): Yes (X86 and X86_64, shorts and bytes passed in EDI).
+//  - extern(D):   No  (shorts passed in DI, bytes in DIL, however EDI is used with -O).
+//
+// N.B: extern(D) tests are really UB, as the caller is free to pass
+// parameters as any size if it so pleases.
+//
+// On x86, parameters are pushed as 32-bit integers on the stack,
+// but we don't test for that.
+version (D_InlineAsm_X86_64)
+{
+    version (Posix)
+        version = SysV_X64_ABI;
+}
+extern(C) void test16274_cshort(short a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0xFFFFFFFF);
+    }
+    assert(a == -1);
+}
+
+extern(C) void test16274_cushort(ushort a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0x00000002);
+    }
+    assert(a == 2);
+}
+
+extern(C) void test16274_cbyte(byte a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0xFFFFFFFD);
+    }
+    assert(a == -3);
+}
+
+extern(C) void test16274_cubyte(ubyte a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0x00000004);
+    }
+    assert(a == 4);
+}
+
+extern(C++) void test16274_cppshort(short a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0xFFFFFFFF);
+    }
+    assert(a == -1);
+}
+
+extern(C++) void test16274_cppushort(ushort a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0x00000002);
+    }
+    assert(a == 2);
+}
+
+extern(C++) void test16274_cppbyte(byte a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0xFFFFFFFD);
+    }
+    assert(a == -3);
+}
+
+extern(C++) void test16274_cppubyte(ubyte a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0x00000004);
+    }
+    assert(a == 4);
+}
+
+extern(D) void test16274_dshort(short a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0xDEADFFFF || z == 0xFFFFFFFF);
+    }
+    assert(a == -1);
+}
+
+extern(D) void test16274_dushort(ushort a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0xDEAD0002 || z == 0x00000002);
+    }
+    assert(a == 2);
+}
+
+extern(D) void test16274_dbyte(byte a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0xDEADBEFD || z == 0x000000FD);
+    }
+    assert(a == -3);
+}
+
+extern(D) void test16274_dubyte(ubyte a)
+{
+    version (SysV_X64_ABI)
+    {
+        uint z = void;
+        asm { mov z, EDI; }
+        assert(z == 0xDEADBE04 || z == 0x00000004);
+    }
+    assert(a == 4);
+}
+
+// Fill the registers used to pass parameters
+void test16274_fill()
+{
+    version (SysV_X64_ABI)
+    {
+        asm { mov EDI, 0xDEADBEEF; }
+    }
+}
+
+void test_short()
+{
+    short a = -1;
+    static foreach(lang; ["c", "cpp", "d"])
+    {
+        test16274_fill();
+        mixin("test16274_"~lang~"short(a);");
+    }
+}
+
+void test_ushort()
+{
+    ushort a = 2;
+    static foreach(lang; ["c", "cpp", "d"])
+    {
+        test16274_fill();
+        mixin("test16274_"~lang~"ushort(a);");
+    }
+}
+
+void test_byte()
+{
+    byte a = -3;
+    static foreach(lang; ["c", "cpp", "d"])
+    {
+        test16274_fill();
+        mixin("test16274_"~lang~"byte(a);");
+    }
+}
+
+void test_ubyte()
+{
+    ubyte a = 4;
+    static foreach(lang; ["c", "cpp", "d"])
+    {
+        test16274_fill();
+        mixin("test16274_"~lang~"ubyte(a);");
+    }
+}
+
+void main()
+{
+    test_short();
+    test_ushort();
+    test_byte();
+    test_ubyte();
+}

--- a/test/runnable_cxx/cabi1.d
+++ b/test/runnable_cxx/cabi1.d
@@ -238,6 +238,31 @@ void test16()
 }
 
 /******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=16274
+
+extern(C) void test16274_c(short a, ushort b, byte c, ubyte d);
+
+void test16274_d(short a, ushort b, byte c, ubyte d)
+{
+    //printf("%d %d %d %d\n", a, b, c, d);
+    assert(a == -1);
+    assert(b == 2);
+    assert(c == -3);
+    assert(d == 4);
+    test16274_c(a, b, c, d);
+}
+
+void test16274()
+{
+    short a = -1;
+    ushort b = 2;
+    byte c = -3;
+    ubyte d = 4;
+    test16274_c(a, b, c, d);
+    test16274_d(a, b, c, d);
+}
+
+/******************************************/
 
 int main()
 {
@@ -257,6 +282,7 @@ else
     test14();
     test15();
     test16();
+    test16274();
 
     return 0;
 }

--- a/test/runnable_cxx/cppa.d
+++ b/test/runnable_cxx/cppa.d
@@ -1253,6 +1253,31 @@ void test15802()
         assert(Foo15802!(int).boo(1) == 1);
 }
 
+/******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=16274
+
+extern(C++) void test16274_cpp(short a, ushort b, byte c, ubyte d);
+
+void test16274_d(short a, ushort b, byte c, ubyte d)
+{
+    //printf("%d %d %d %d\n", a, b, c, d);
+    assert(a == -1);
+    assert(b == 2);
+    assert(c == -3);
+    assert(d == 4);
+    test16274_cpp(a, b, c, d);
+}
+
+void test16274()
+{
+    short a = -1;
+    ushort b = 2;
+    byte c = -3;
+    ubyte d = 4;
+    test16274_cpp(a, b, c, d);
+    test16274_d(a, b, c, d);
+}
+
 /****************************************/
 // https://issues.dlang.org/show_bug.cgi?id=16536
 // mangling mismatch on OSX
@@ -1644,6 +1669,7 @@ void main()
     test15455();
     test15372();
     test15802();
+    test16274();
     test16536();
     test15589();
     test15589b();

--- a/test/runnable_cxx/extra-files/cabi2.cpp
+++ b/test/runnable_cxx/extra-files/cabi2.cpp
@@ -247,7 +247,17 @@ S16 ctest16(char x, S16 s, char y) {
   return s;
 }
 
+/**********************************************/
+// https://issues.dlang.org/show_bug.cgi?id=16274
 
+void test16274_c(signed short a, unsigned short b, signed char c, unsigned char d)
+{
+    //printf("%d %d %d %d\n", a, b, c, d);
+    assert(a == -1);
+    assert(b == 2);
+    assert(c == -3);
+    assert(d == 4);
+}
 
 #if __cplusplus
 }

--- a/test/runnable_cxx/extra-files/cppb.cpp
+++ b/test/runnable_cxx/extra-files/cppb.cpp
@@ -798,6 +798,17 @@ void test15802b()
     int t = Foo15802<int>::boo(1);
 }
 
+/****************************************/
+// https://issues.dlang.org/show_bug.cgi?id=16274
+
+void test16274_cpp(signed short a, unsigned short b, signed char c, unsigned char d)
+{
+    //printf("%d %d %d %d\n", a, b, c, d);
+    assert(a == -1);
+    assert(b == 2);
+    assert(c == -3);
+    assert(d == 4);
+}
 
 /****************************************/
 // https://issues.dlang.org/show_bug.cgi?id=16536


### PR DESCRIPTION
This moved the fix being done in #11651 from the glue to the front-end, as the code already exists to handle C promotions.

A target hook is preferred here, as some ABIs require promotion (x86, x86_64), but many others do not (ARM, SPARC, POWERPC), and each implementing compiler back-end should be able to answer yes/no.

For DMD - being tied to x86-only - promotions are only done if the function is not `extern(D)`.  No promotions are done for D language functions.  This is to be consistent with variadic arguments.