### PR TITLE
dmd.mtype: Remove dead set in Type._init

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2861,7 +2861,6 @@ struct ASTBase
 
             tshiftcnt = tint32;
             terror = basic[Terror];
-            tnull = basic[Tnull];
             tnull = new TypeNull();
             tnull.deco = tnull.merge().deco;
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -892,7 +892,6 @@ extern (C++) abstract class Type : ASTNode
 
         tshiftcnt = tint32;
         terror = basic[Terror];
-        tnull = basic[Tnull];
         tnull = new TypeNull();
         tnull.deco = tnull.merge().deco;
 


### PR DESCRIPTION
- Tnull is not in the basetab, so it just sets tnull to null.
- tnull gets overwritten immediately afterwards.