### PR TITLE
[stable] Fix little C++ header regression

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -12,6 +12,7 @@
 
 #include "dsymbol.h"
 #include "mtype.h"
+#include "objc.h"
 #include "tokens.h"
 
 class Expression;
@@ -26,7 +27,6 @@ struct Ensure
 };
 class FuncDeclaration;
 class StructDeclaration;
-struct ObjcSelector;
 struct IntRange;
 
 #define STCundefined    0ULL


### PR DESCRIPTION
As `FuncDeclaration` now contains a `ObjcFuncDeclaration objc` field.