### PR TITLE
Issue 21247 - Static assert accepts tuple of (bool, string)

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -922,7 +922,7 @@ extern (C++) final class StaticIfCondition : Condition
             if (!exp)
                 return errorReturn();
 
-            bool result = evalStaticCondition(sc, exp, exp, errors);
+            bool result = evalStaticCondition(sc, exp, errors);
 
             // Prevent repeated condition evaluation.
             // See: fail_compilation/fail7815.d

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -883,7 +883,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         ti.inst = ti; // temporary instantiation to enable genIdent()
         scx.flags |= SCOPE.constraint;
         bool errors;
-        const bool result = evalStaticCondition(scx, constraint, lastConstraint, errors, &lastConstraintNegs);
+        const bool result = evalStaticCondition(scx, lastConstraint, errors, &lastConstraintNegs);
         if (result || errors)
         {
             lastConstraint = null;

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -99,7 +99,10 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
         import dmd.staticcond;
         bool errors;
-        bool result = evalStaticCondition(sc, sa.exp, sa.exp, errors);
+        Expression msg;
+        bool result = evalStaticCondition(sc, sa.exp, sa.exp, errors,null, &msg);
+        if (msg)
+            sa.msg = msg;
         sc = sc.pop();
         if (errors)
         {

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -100,7 +100,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
         import dmd.staticcond;
         bool errors;
         Expression msg;
-        bool result = evalStaticCondition(sc, sa.exp, sa.exp, errors,null, &msg);
+        bool result = evalStaticCondition(sc, sa.exp, errors, null, &msg);
         if (msg)
             sa.msg = msg;
         sc = sc.pop();

--- a/src/dmd/staticcond.d
+++ b/src/dmd/staticcond.d
@@ -34,7 +34,6 @@ import dmd.tokens;
  * necessary.
  * Params:
  *      sc  = instantiating scope
- *      original = original expression, for error messages
  *      e =  resulting expression
  *      errors = set to `true` if errors occurred
  *      negatives = array to store negative clauses
@@ -42,7 +41,7 @@ import dmd.tokens;
  * Returns:
  *      true if evaluates to true
  */
-bool evalStaticCondition(Scope* sc, Expression original, Expression e, out bool errors, Expressions* negatives = null, Expression* msg = null)
+bool evalStaticCondition(Scope* sc, Expression e, out bool errors, Expressions* negatives = null, Expression* msg = null)
 {
     if (negatives)
         negatives.setDim(0);

--- a/test/fail_compilation/issue21247.d
+++ b/test/fail_compilation/issue21247.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/issue21247.d(14): Error: static assert:  "foo"
+fail_compilation/issue21247.d(12): Error: static assert:  "foo"
 ---
 */
 

--- a/test/fail_compilation/issue21247.d
+++ b/test/fail_compilation/issue21247.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/issue21247.d(14): Error: static assert:  "foo"
+---
+*/
+
+alias AliasSeq(T...) = T;
+
+alias check(T) = AliasSeq!(false, "foo");
+
+static assert(check!int);


### PR DESCRIPTION
This doesn't fix the whole issue yet (only static assert, not yet regular assert)and probably needs a spec update too. There is probably room to argue that static assert should behave like `pragma(msg, ...)` in accepting type and unlimited arguments but for now this just allows tuples of `(bool)` and `(bool, string)`.