### PR TITLE
Fix Issue 21246 - Compiler must show mismatching types when functions do not properly override

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3953,6 +3953,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     {
                         OutBuffer buf1;
 
+                        if (fd.toChars() == funcdecl.toChars())
+                            hgs.fullQual = true;
                         functionToBufferFull(cast(TypeFunction)(fd.type), &buf1,
                             new Identifier(fd.toPrettyChars()), &hgs, null);
 

--- a/test/fail_compilation/imports/test21246.d
+++ b/test/fail_compilation/imports/test21246.d
@@ -1,0 +1,8 @@
+module imports.test21246;
+
+class Clock {}
+
+class B
+{
+    void set (Clock clock) { }
+}

--- a/test/fail_compilation/test21246.d
+++ b/test/fail_compilation/test21246.d
@@ -1,0 +1,19 @@
+// https://issues.dlang.org/show_bug.cgi?id=21246
+// EXTRA_FILES: imports.test21246
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test21246.d(16): Error: function `void test21246.C.set(Clock clock)` does not override any function, did you mean to override `void imports.test21246.B.set(imports.test21246.Clock clock)`?
+---
+*/
+module test21246;
+
+import imports.test21246;
+
+class Clock { }
+class C : B
+{
+    override void set (Clock clock) { }
+}
+
+void main () { }


### PR DESCRIPTION
When the overriding function has the same name as a potential overriden function, then print the fully qualified names of the parameters of the overriden function.