### PR TITLE
d_do_test: Don't link with OPT:NOICF by default on windows

### DIFF
--- a/test/runnable/test17338.d
+++ b/test/runnable/test17338.d
@@ -1,5 +1,8 @@
 // PERMUTE_ARGS:
 
+// COMDAT folding increases runtime by > 80x
+// REQUIRED_ARGS(windows): -L/OPT:NOICF
+
 // Apparently omf or optlink does not support more than 32767 symbols.
 // DISABLED: win32
 

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -452,11 +452,6 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     if (testArgs.mode == TestMode.FAIL_COMPILE)
         testArgs.requiredArgs = "-verrors=0 " ~ testArgs.requiredArgs;
 
-    // https://issues.dlang.org/show_bug.cgi?id=10664: exceptions don't work reliably with COMDAT folding
-    // it also slows down some tests drastically, e.g. runnable/test17338.d
-    if (envData.usingMicrosoftCompiler)
-        testArgs.requiredArgs ~= " -L/OPT:NOICF";
-
     {
         string argSetsStr;
         findTestParameter(envData, file, "ARG_SETS", argSetsStr, ";");


### PR DESCRIPTION
The issue related to COMDAT folding was fixed in #11736.