### PR TITLE
add backend/symtab.d to put symtab_t declarations in

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1301,7 +1301,7 @@ auto sourceFiles()
             backend.d bcomplex.d evalu8.d divcoeff.d dvec.d go.d gsroa.d glocal.d gdag.d gother.d gflow.d
             out.d
             gloop.d compress.d cgelem.d cgcs.d ee.d cod4.d cod5.d nteh.d blockopt.d mem.d cg.d cgreg.d
-            dtype.d debugprint.d fp.d symbol.d elem.d dcode.d cgsched.d cg87.d cgxmm.d cgcod.d cod1.d cod2.d
+            dtype.d debugprint.d fp.d symbol.d symtab.d elem.d dcode.d cgsched.d cg87.d cgxmm.d cgcod.d cod1.d cod2.d
             cod3.d cv8.d dcgcv.d pdata.d util2.d var.d md5.d backconfig.d ph2.d drtlsym.d dwarfeh.d ptrntab.d
             dvarstats.d dwarfdbginf.d cgen.d os.d goh.d barray.d cgcse.d elpicpie.d
             machobj.d elfobj.d

--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -19,6 +19,7 @@ import dmd.backend.code_x86;
 import dmd.backend.dlist;
 import dmd.backend.dt;
 import dmd.backend.el;
+import dmd.backend.symtab;
 import dmd.backend.type;
 
 extern (C++):
@@ -701,13 +702,6 @@ struct BlockRange
 /**********************************
  * Functions
  */
-
-struct symtab_t
-{
-    SYMIDX top;                 // 1 past end
-    SYMIDX symmax;              // max # of entries in tab[] possible
-    Symbol **tab;               // local Symbol table
-}
 
 alias func_flags_t = uint;
 enum

--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -361,7 +361,6 @@ enum
 enum REGMAX = 29;      // registers are numbered 0..10
 
 alias tym_t = uint;    // data type big enough for type masks
-alias SYMIDX = int;    // symbol table index
 
 
 version (MARS)

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -44,6 +44,7 @@ import dmd.backend.obj;
 import dmd.backend.oper;
 import dmd.backend.outbuf;
 import dmd.backend.rtlsym;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 import dmd.backend.xmm;

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -37,6 +37,7 @@ import dmd.backend.goh;
 import dmd.backend.el;
 import dmd.backend.outbuf;
 import dmd.backend.rtlsym;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -43,6 +43,7 @@ import dmd.backend.obj;
 import dmd.backend.oper;
 import dmd.backend.outbuf;
 import dmd.backend.rtlsym;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 import dmd.backend.xmm;

--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -40,6 +40,7 @@ import dmd.backend.global;
 import dmd.backend.mem;
 import dmd.backend.obj;
 import dmd.backend.outbuf;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/backend/dvarstats.d
+++ b/src/dmd/backend/dvarstats.d
@@ -21,6 +21,7 @@ import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.global;
 import dmd.backend.code;
+import dmd.backend.symtab;
 
 extern (C++):
 

--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -69,6 +69,7 @@ static if (ELFOBJ || MACHOBJ)
     import dmd.backend.obj;
     import dmd.backend.oper;
     import dmd.backend.outbuf;
+    import dmd.backend.symtab;
     import dmd.backend.ty;
     import dmd.backend.type;
 

--- a/src/dmd/backend/ee.d
+++ b/src/dmd/backend/ee.d
@@ -23,6 +23,7 @@ import core.stdc.time;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.global;
+import dmd.backend.symtab;
 import dmd.backend.type;
 import dmd.backend.oper;
 import dmd.backend.el;

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -41,6 +41,7 @@ import dmd.backend.global;
 import dmd.backend.obj;
 import dmd.backend.oper;
 import dmd.backend.outbuf;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/backend/gflow.d
+++ b/src/dmd/backend/gflow.d
@@ -1365,7 +1365,7 @@ private void accumlv(vec_t GEN,vec_t KILL,elem *n)
             case OPvar:
                 if (symbol_isintab(n.EV.Vsym))
                 {
-                    SYMIDX si = n.EV.Vsym.Ssymnum;
+                    const si = n.EV.Vsym.Ssymnum;
 
                     assert(cast(uint)si < globsym.top);
                     if (!vec_testbit(si,KILL))  // if not in KILL

--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -28,6 +28,7 @@ import dmd.backend.dlist;
 import dmd.backend.el;
 import dmd.backend.el : elem;
 import dmd.backend.mem;
+import dmd.backend.symtab;
 import dmd.backend.type;
 //import dmd.backend.obj;
 
@@ -320,10 +321,6 @@ extern __gshared
 }
 
 /* Symbol.c */
-extern (C) Symbol **symtab_realloc(Symbol **tab, size_t symmax);
-Symbol **symtab_malloc(size_t symmax);
-Symbol **symtab_calloc(size_t symmax);
-void symtab_free(Symbol **tab);
 //#if TERMCODE
 //void symbol_keep(Symbol *s);
 //#else

--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -34,6 +34,7 @@ import dmd.backend.global;
 import dmd.backend.goh;
 import dmd.backend.el;
 import dmd.backend.outbuf;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/backend/go.d
+++ b/src/dmd/backend/go.d
@@ -29,6 +29,7 @@ import dmd.backend.oper;
 import dmd.backend.global;
 import dmd.backend.goh;
 import dmd.backend.el;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/backend/goh.d
+++ b/src/dmd/backend/goh.d
@@ -22,6 +22,7 @@ import dmd.backend.cdef;
 import dmd.backend.oper;
 import dmd.backend.global;
 import dmd.backend.el;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/backend/gother.d
+++ b/src/dmd/backend/gother.d
@@ -33,6 +33,7 @@ import dmd.backend.global;
 import dmd.backend.goh;
 import dmd.backend.el;
 import dmd.backend.outbuf;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/backend/gsroa.d
+++ b/src/dmd/backend/gsroa.d
@@ -29,6 +29,7 @@ import dmd.backend.code_x86;
 import dmd.backend.oper;
 import dmd.backend.global;
 import dmd.backend.el;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/backend/nteh.d
+++ b/src/dmd/backend/nteh.d
@@ -33,6 +33,7 @@ import dmd.backend.el;
 import dmd.backend.global;
 import dmd.backend.oper;
 import dmd.backend.rtlsym;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/backend/out.d
+++ b/src/dmd/backend/out.d
@@ -35,6 +35,7 @@ import dmd.backend.obj;
 import dmd.backend.oper;
 import dmd.backend.outbuf;
 import dmd.backend.rtlsym;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -44,6 +44,7 @@ import dmd.backend.el;
 import dmd.backend.global;
 import dmd.backend.mem;
 import dmd.backend.oper;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 
@@ -85,66 +86,6 @@ void struct_free(struct_t *st) { }
 
 func_t* func_calloc() { return cast(func_t *) calloc(1, func_t.sizeof); }
 void func_free(func_t* f) { free(f); }
-
-/*********************************
- * Allocate/free symbol table.
- */
-
-extern (C) Symbol **symtab_realloc(Symbol **tab, size_t symmax)
-{   Symbol **newtab;
-
-    if (config.flags2 & (CFG2phgen | CFG2phuse | CFG2phauto | CFG2phautoy))
-    {
-        newtab = cast(Symbol **) MEM_PH_REALLOC(tab, symmax * (Symbol *).sizeof);
-    }
-    else
-    {
-        newtab = cast(Symbol **) realloc(tab, symmax * (Symbol *).sizeof);
-        if (!newtab)
-            err_nomem();
-    }
-    return newtab;
-}
-
-Symbol **symtab_malloc(size_t symmax)
-{   Symbol **newtab;
-
-    if (config.flags2 & (CFG2phgen | CFG2phuse | CFG2phauto | CFG2phautoy))
-    {
-        newtab = cast(Symbol **) MEM_PH_MALLOC(symmax * (Symbol *).sizeof);
-    }
-    else
-    {
-        newtab = cast(Symbol **) malloc(symmax * (Symbol *).sizeof);
-        if (!newtab)
-            err_nomem();
-    }
-    return newtab;
-}
-
-Symbol **symtab_calloc(size_t symmax)
-{   Symbol **newtab;
-
-    if (config.flags2 & (CFG2phgen | CFG2phuse | CFG2phauto | CFG2phautoy))
-    {
-        newtab = cast(Symbol **) MEM_PH_CALLOC(symmax * (Symbol *).sizeof);
-    }
-    else
-    {
-        newtab = cast(Symbol **) calloc(symmax, (Symbol *).sizeof);
-        if (!newtab)
-            err_nomem();
-    }
-    return newtab;
-}
-
-void symtab_free(Symbol **tab)
-{
-    if (config.flags2 & (CFG2phgen | CFG2phuse | CFG2phauto | CFG2phautoy))
-        MEM_PH_FREE(tab);
-    else if (tab)
-        free(tab);
-}
 
 /*******************************
  * Type out symbol information.

--- a/src/dmd/backend/symtab.d
+++ b/src/dmd/backend/symtab.d
@@ -1,0 +1,105 @@
+/**
+ * Symbol table array.
+ *
+ * Copyright:   Copyright (C) 1985-1998 by Symantec
+ *              Copyright (C) 2000-2020 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/symtab.d, backend/_symtab.d)
+ * Documentation:  https://dlang.org/phobos/dmd_backend_symtab.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/symtab.d
+ */
+
+module dmd.backend.symtab;
+
+import core.stdc.stdio;
+import core.stdc.stdlib;
+
+import dmd.backend.cdef;
+import dmd.backend.cc;
+import dmd.backend.mem;
+
+
+extern (C++):
+
+nothrow:
+
+alias SYMIDX = int;    // symbol table index
+
+alias MEM_PH_MALLOC = mem_malloc;
+alias MEM_PH_CALLOC = mem_calloc;
+alias MEM_PH_FREE = mem_free;
+alias MEM_PH_FREEFP = mem_freefp;
+alias MEM_PH_STRDUP = mem_strdup;
+alias MEM_PH_REALLOC = mem_realloc;
+
+private void err_nomem();
+
+struct symtab_t
+{
+    SYMIDX top;                 // 1 past end
+    SYMIDX symmax;              // max # of entries in tab[] possible
+    Symbol **tab;               // local Symbol table
+}
+
+/*********************************
+ * Allocate/free symbol table.
+ */
+
+extern (C) Symbol **symtab_realloc(Symbol **tab, size_t symmax)
+{   Symbol **newtab;
+
+    if (config.flags2 & (CFG2phgen | CFG2phuse | CFG2phauto | CFG2phautoy))
+    {
+        newtab = cast(Symbol **) MEM_PH_REALLOC(tab, symmax * (Symbol *).sizeof);
+    }
+    else
+    {
+        newtab = cast(Symbol **) realloc(tab, symmax * (Symbol *).sizeof);
+        if (!newtab)
+            err_nomem();
+    }
+    return newtab;
+}
+
+Symbol **symtab_malloc(size_t symmax)
+{   Symbol **newtab;
+
+    if (config.flags2 & (CFG2phgen | CFG2phuse | CFG2phauto | CFG2phautoy))
+    {
+        newtab = cast(Symbol **) MEM_PH_MALLOC(symmax * (Symbol *).sizeof);
+    }
+    else
+    {
+        newtab = cast(Symbol **) malloc(symmax * (Symbol *).sizeof);
+        if (!newtab)
+            err_nomem();
+    }
+    return newtab;
+}
+
+Symbol **symtab_calloc(size_t symmax)
+{   Symbol **newtab;
+
+    if (config.flags2 & (CFG2phgen | CFG2phuse | CFG2phauto | CFG2phautoy))
+    {
+        newtab = cast(Symbol **) MEM_PH_CALLOC(symmax * (Symbol *).sizeof);
+    }
+    else
+    {
+        newtab = cast(Symbol **) calloc(symmax, (Symbol *).sizeof);
+        if (!newtab)
+            err_nomem();
+    }
+    return newtab;
+}
+
+void symtab_free(Symbol **tab)
+{
+    if (config.flags2 & (CFG2phgen | CFG2phuse | CFG2phauto | CFG2phautoy))
+        MEM_PH_FREE(tab);
+    else if (tab)
+        free(tab);
+}
+
+

--- a/src/dmd/backend/var.d
+++ b/src/dmd/backend/var.d
@@ -22,6 +22,7 @@ import dmd.backend.dlist;
 import dmd.backend.goh;
 import dmd.backend.obj;
 import dmd.backend.oper;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -32,6 +32,7 @@ import dmd.backend.obj;
 import dmd.backend.oper;
 import dmd.backend.outbuf;
 import dmd.backend.rtlsym;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 


### PR DESCRIPTION
The logic for `symtab_t` is a mess, when it should be simple as it is a simple array. The first step to gain control over it is to move it to its own file, `symtab.d`