### PR TITLE
use SYMIDX.max instead of -1

### DIFF
--- a/src/dmd/backend/cgreg.d
+++ b/src/dmd/backend/cgreg.d
@@ -31,6 +31,7 @@ import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;
 import dmd.backend.oper;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 
@@ -239,7 +240,7 @@ private void el_weights(int bi,elem *e,uint weight)
             {
                 case OPvar:
                     Symbol *s = e.EV.Vsym;
-                    if (s.Ssymnum != -1 && s.Sflags & GTregcand)
+                    if (s.Ssymnum != SYMIDX.max && s.Sflags & GTregcand)
                     {
                         s.Sweight += weight;
                         //printf("adding %d weight to '%s' (block %d, Ssymnum %d), giving Sweight %d\n",weight,s.Sident.ptr,bi,s.Ssymnum,s.Sweight);
@@ -274,7 +275,7 @@ private int cgreg_benefit(Symbol *s, reg_t reg, Symbol *retsym)
     //printf("cgreg_benefit(s = '%s', reg = %d)\n", s.Sident.ptr, reg);
 
     vec_sub(s.Slvreg,s.Srange,regrange[reg]);
-    int si = s.Ssymnum;
+    int si = cast(int)s.Ssymnum;
 
     reg_t dst_integer_reg;
     reg_t dst_float_reg;

--- a/src/dmd/backend/debugprint.d
+++ b/src/dmd/backend/debugprint.d
@@ -34,6 +34,7 @@ import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.goh;
 import dmd.backend.oper;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 
@@ -252,7 +253,7 @@ void WReqn(elem *e)
 
             case OPvar:
                 printf("%s",e.EV.Vsym.Sident.ptr);
-                if (e.EV.Vsym.Ssymnum != -1)
+                if (e.EV.Vsym.Ssymnum != SYMIDX.max)
                     printf("(%d)",e.EV.Vsym.Ssymnum);
                 if (e.EV.Voffset != 0)
                 {

--- a/src/dmd/backend/drtlsym.d
+++ b/src/dmd/backend/drtlsym.d
@@ -31,6 +31,7 @@ import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.global;
 import dmd.backend.rtlsym;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 
@@ -254,7 +255,7 @@ private void symbolz(Symbol** ps, int fl, regm_t regsaved, const(char)* name, SY
 {
     Symbol *s = symbol_calloc(name);
     s.Stype = t;
-    s.Ssymnum = -1;
+    s.Ssymnum = SYMIDX.max;
     s.Sclass = SCextern;
     s.Sfl = cast(char)fl;
     s.Sregsaved = regsaved;

--- a/src/dmd/backend/gsroa.d
+++ b/src/dmd/backend/gsroa.d
@@ -74,7 +74,7 @@ extern (D) private void sliceStructs_Gather(const symtab_t* symtab, SymInfo[] si
             case OPvar:
             {
                 const si = e.EV.Vsym.Ssymnum;
-                if (si >= 0 && sia[si].canSlice)
+                if (si != SYMIDX.max && sia[si].canSlice)
                 {
                     assert(si < symtab.top);
                     const n = nthSlice(e);
@@ -128,7 +128,7 @@ extern (D) private void sliceStructs_Gather(const symtab_t* symtab, SymInfo[] si
                     {
                         const e1 = e.EV.E1;
                         const si = e1.EV.Vsym.Ssymnum;
-                        if (si >= 0 && sia[si].canSlice)
+                        if (si != SYMIDX.max && sia[si].canSlice)
                         {
                             assert(si < symtab.top);
                             if (nthSlice(e1) == NOTSLICE)
@@ -183,7 +183,7 @@ extern (D) private void sliceStructs_Replace(symtab_t* symtab, const SymInfo[] s
                 const si = s.Ssymnum;
                 //printf("e: %d %d\n", si, sia[si].canSlice);
                 //elem_print(e);
-                if (si >= 0 && sia[si].canSlice)
+                if (si != SYMIDX.max && sia[si].canSlice)
                 {
                     const n = nthSlice(e);
                     if (getSize(e) == 2 * SLICESIZE)

--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -100,7 +100,7 @@ version (COMPILE)
     if (!s) return;
     printf("symbol %p '%s'\n ",s,s.Sident.ptr);
     printf(" Sclass = "); WRclass(cast(SC) s.Sclass);
-    printf(" Ssymnum = %d",s.Ssymnum);
+    printf(" Ssymnum = %d",cast(int)s.Ssymnum);
     printf(" Sfl = "); WRFL(cast(FL) s.Sfl);
     printf(" Sseg = %d\n",s.Sseg);
 //  printf(" Ssize   = x%02x\n",s.Ssize);
@@ -329,7 +329,7 @@ debug
     s.id = Symbol.IDsymbol;
 }
     memcpy(s.Sident.ptr,id,len + 1);
-    s.Ssymnum = -1;
+    s.Ssymnum = SYMIDX.max;
     return s;
 }
 
@@ -409,13 +409,13 @@ version (SCPP_HTOD)
     //printf("symbol_genauto(t) '%s'\n", s.Sident.ptr);
     if (pstate.STdefertemps)
     {   symbol_keep(s);
-        s.Ssymnum = -1;
+        s.Ssymnum = SYMIDX.max;
     }
     else
     {   s.Sflags |= SFLfree;
         if (init_staticctor)
         {   // variable goes into _STI_xxxx
-            s.Ssymnum = -1;            // deferred allocation
+            s.Ssymnum = SYMIDX.max;            // deferred allocation
 //printf("test2\n");
 //if (s.Sident[4] == '2') *(char*)0=0;
         }
@@ -1059,7 +1059,7 @@ static if (0)
 private void symbol_undef(Symbol *s)
 {
   s.Sclass = SCunde;
-  s.Ssymnum = -1;
+  s.Ssymnum = SYMIDX.max;
   type_free(s.Stype);                  /* free type data               */
   s.Stype = null;
 }
@@ -1109,7 +1109,7 @@ else
     debug if (debugy)
         printf("symbol_add(%p '%s') = %d\n",s,s.Sident.ptr,symtab.top);
 
-    assert(s.Ssymnum == -1);
+    assert(s.Ssymnum == SYMIDX.max);
     return s.Ssymnum = symtab.top++;
 }
 
@@ -1160,7 +1160,7 @@ debug
             symbol_debug(s);
 }
             s.Sl = s.Sr = null;
-            s.Ssymnum = -1;
+            s.Ssymnum = SYMIDX.max;
             symbol_free(s);
         }
     }
@@ -1179,7 +1179,7 @@ Symbol * symbol_copy(Symbol *s)
     scopy = symbol_calloc(s.Sident.ptr);
     memcpy(scopy,s,Symbol.sizeof - s.Sident.sizeof);
     scopy.Sl = scopy.Sr = scopy.Snext = null;
-    scopy.Ssymnum = -1;
+    scopy.Ssymnum = SYMIDX.max;
     if (scopy.Sdt)
     {
         auto dtb = DtBuilder(0);

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -68,6 +68,7 @@ import dmd.backend.global;
 import dmd.backend.obj;
 import dmd.backend.oper;
 import dmd.backend.rtlsym;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 
@@ -1326,7 +1327,7 @@ elem *toElem(Expression e, IRState *irs)
                 goto L1;
             }
 
-            if (s.Sclass == SCauto && s.Ssymnum == -1)
+            if (s.Sclass == SCauto && s.Ssymnum == SYMIDX.max)
             {
                 //printf("\tadding symbol %s\n", s.Sident);
                 symbol_add(s);

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -60,6 +60,7 @@ import dmd.backend.global;
 import dmd.backend.obj;
 import dmd.backend.oper;
 import dmd.backend.rtlsym;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 
@@ -1445,7 +1446,7 @@ private extern (C++) class S2irVisitor : Visitor
                 case FLdsymbol:
                 case FLfunc:
                     sym = toSymbol(cast(Dsymbol)c.IEV1.Vdsym);
-                    if (sym.Sclass == SCauto && sym.Ssymnum == -1)
+                    if (sym.Sclass == SCauto && sym.Ssymnum == SYMIDX.max)
                         symbol_add(sym);
                     c.IEV1.Vsym = sym;
                     c.IFL1 = sym.Sfl ? sym.Sfl : FLauto;
@@ -1473,7 +1474,7 @@ private extern (C++) class S2irVisitor : Visitor
                 {
                     Declaration d = cast(Declaration)c.IEV2.Vdsym;
                     sym = toSymbol(cast(Dsymbol)d);
-                    if (sym.Sclass == SCauto && sym.Ssymnum == -1)
+                    if (sym.Sclass == SCauto && sym.Ssymnum == SYMIDX.max)
                         symbol_add(sym);
                     c.IEV2.Vsym = sym;
                     c.IFL2 = sym.Sfl ? sym.Sfl : FLauto;

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -53,6 +53,7 @@ import dmd.backend.type;
 import dmd.backend.global;
 import dmd.backend.oper;
 import dmd.backend.cgcv;
+import dmd.backend.symtab;
 import dmd.backend.ty;
 
 extern (C++):
@@ -688,7 +689,7 @@ Symbol *aaGetSymbol(TypeAArray taa, const(char)* func, int flags)
 
     auto s = symbol_calloc(id, idlen);
     s.Sclass = SCextern;
-    s.Ssymnum = -1;
+    s.Ssymnum = SYMIDX.max;
     symbol_func(s);
 
     auto t = type_function(TYnfunc, null, false, Type_toCtype(taa.next));


### PR DESCRIPTION
SYMIDX is currently an `int`. Should be a `size_t`. This means the use of the -1 as a magic number has to change. The preferred "not in the range" value is `T.max`, so this changes `-1` to `SYMIDX.max`.

This is in its own PR because if I miss one of the `-1`'s, a bug will be introduced.