### PR TITLE
[PoC] Add @nodiscard attribute

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -136,6 +136,7 @@ struct ASTBase
         local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
         returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
         live                = (1L << 53),   // function @live attribute
+        nodiscard           = (1L << 54),   // @nodiscard
 
         safeGroup = STC.safe | STC.trusted | STC.system,
         IOR  = STC.in_ | STC.ref_ | STC.out_,
@@ -149,7 +150,7 @@ struct ASTBase
          STC.abstract_ | STC.synchronized_ | STC.deprecated_ | STC.override_ | STC.lazy_ |
          STC.alias_ | STC.out_ | STC.in_ | STC.manifest | STC.immutable_ | STC.shared_ |
          STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls |
-         STC.gshared | STC.property | STC.live |
+         STC.gshared | STC.property | STC.live | STC.nodiscard |
          STC.safeGroup | STC.disable);
 
     enum ENUMTY : int
@@ -6685,6 +6686,7 @@ struct ASTBase
             SCstring(STC.live, TOK.at, "@live"),
             SCstring(STC.disable, TOK.at, "@disable"),
             SCstring(STC.future, TOK.at, "@__future"),
+            SCstring(STC.nodiscard, TOK.at, "@nodiscard"),
             SCstring(0, TOK.reserved)
         ];
         for (int i = 0; table[i].stc; i++)

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -771,6 +771,8 @@ dmd -cov -unittest myprog.d
             "disable access to shared memory objects"),
         Feature("in", "previewIn",
             "`in` on parameters means `scope const [ref]` and accepts rvalues"),
+        Feature("nodiscard", "nodiscardAttribute",
+            "enable `@nodiscard` attribute"),
         // DEPRECATED previews
         // trigger deprecation message once D repositories don't use this flag anymore
         Feature("markdown", "markdown", "enable Markdown replacements in Ddoc", false, false),

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -253,6 +253,7 @@ enum STC : ulong
     local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
     returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
     live                = (1L << 53),   // function @live attribute
+    nodiscard           = (1L << 54),   // @nodiscard
 
     // Group members are mutually exclusive (there can be only one)
     safeGroup = STC.safe | STC.trusted | STC.system,
@@ -269,7 +270,7 @@ enum STCStorageClass =
     (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ |
      STC.deprecated_ | STC.future | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest |
      STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared |
-     STC.property | STC.safeGroup | STC.disable | STC.local | STC.live);
+     STC.property | STC.safeGroup | STC.disable | STC.local | STC.live | STC.nodiscard);
 
 /* These storage classes "flow through" to the inner scope of a Dsymbol
  */

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2493,13 +2493,14 @@ enum class STC : uint64_t
     local = 2251799813685248LLU,
     returninferred = 4503599627370496LLU,
     live = 9007199254740992LLU,
+    nodiscard = 18014398509481984LLU,
     safeGroup = 60129542144LLU,
     IOR = 2103296LLU,
     TYPECTOR = 2685403140LLU,
     FUNCATTR = 9011661828521984LLU,
 };
 
-static STC const STCStorageClass = (STC)12407095344775071LLU;
+static STC const STCStorageClass = (STC)30421493854257055LLU;
 
 static STC const STCFlowThruAggregate = (STC)60129542144LLU;
 
@@ -7250,6 +7251,7 @@ struct Id
     static Identifier* property;
     static Identifier* nogc;
     static Identifier* live;
+    static Identifier* nodiscard;
     static Identifier* safe;
     static Identifier* trusted;
     static Identifier* system;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6781,6 +6781,7 @@ struct Param
     bool useExceptions;
     bool noSharedAccess;
     bool previewIn;
+    bool nodiscardAttribute;
     bool betterC;
     bool addMain;
     bool allInst;
@@ -6925,6 +6926,7 @@ struct Param
         useExceptions(true),
         noSharedAccess(),
         previewIn(),
+        nodiscardAttribute(),
         betterC(),
         addMain(),
         allInst(),

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -176,6 +176,7 @@ extern (C++) struct Param
     bool useExceptions = true;   // support exception handling
     bool noSharedAccess;         // read/write access to shared memory objects
     bool previewIn;         // `in` means `[ref] scope const`, accepts rvalues
+    bool nodiscardAttribute; // @nodiscard is a built-in attribute
     bool betterC;           // be a "better C" compiler; no dependency on D runtime
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -154,6 +154,7 @@ struct Param
     bool useExceptions; // support exception handling
     bool noSharedAccess; // read/write access to shared memory objects
     bool previewIn;     // `in` means `scope const`, perhaps `ref`, accepts rvalues
+    bool nodiscardAttribute; // @nodiscard is a built-in attribute
     bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2771,6 +2771,7 @@ string stcToString(ref StorageClass stc)
         SCstring(STC.disable, TOK.at, "@disable"),
         SCstring(STC.future, TOK.at, "@__future"),
         SCstring(STC.local, TOK.at, "__local"),
+        SCstring(STC.nodiscard, TOK.at, "@nodiscard"),
         SCstring(0, TOK.reserved)
     ];
     for (int i = 0; table[i].stc; i++)

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -202,6 +202,7 @@ immutable Msgtable[] msgtable =
     { "property" },
     { "nogc" },
     { "live" },
+    { "nodiscard" },
     { "safe" },
     { "trusted" },
     { "system" },

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1444,6 +1444,8 @@ final class Parser(AST) : Lexer
             stc = isBuiltinAtAttribute(token.ident);
             if (!stc)
             {
+                if (token.ident == Id.nodiscard)
+                    deprecation("use of `@nodiscard` as a user-defined attribute is deprecated.");
                 // Allow identifier, template instantiation, or function call
                 AST.Expression exp = parsePrimaryExp();
                 if (token.value == TOK.leftParentheses)
@@ -9191,23 +9193,28 @@ final class Parser(AST) : Lexer
                (ident == Id.trusted)   ? AST.STC.trusted   :
                (ident == Id.system)    ? AST.STC.system    :
                (ident == Id.live)      ? AST.STC.live      :
+               (global.params.nodiscardAttribute) &&
                (ident == Id.nodiscard) ? AST.STC.nodiscard :
                (ident == Id.future)    ? AST.STC.future    :
                (ident == Id.disable)   ? AST.STC.disable   :
                0;
     }
 
-    enum StorageClass atAttrGroup =
-                AST.STC.property  |
-                AST.STC.nogc      |
-                AST.STC.safe      |
-                AST.STC.trusted   |
-                AST.STC.system    |
-                AST.STC.live      |
-                AST.STC.nodiscard |
-                /*AST.STC.future   |*/ // probably should be included
-                AST.STC.disable;
+    static StorageClass atAttrGroup()
+    {
+        enum StorageClass atAttrGroup =
+                    AST.STC.property  |
+                    AST.STC.nogc      |
+                    AST.STC.safe      |
+                    AST.STC.trusted   |
+                    AST.STC.system    |
+                    AST.STC.live      |
+                    /*AST.STC.future   |*/ // probably should be included
+                    AST.STC.disable;
+        return atAttrGroup |
+            (global.params.nodiscardAttribute ? AST.STC.nodiscard : 0);
     }
+}
 
 enum PREC : int
 {

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1477,7 +1477,7 @@ final class Parser(AST) : Lexer
             *pudas = AST.UserAttributeDeclaration.concat(*pudas, udas);
         }
         else
-            error("valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`");
+            error("valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`, `@nodiscard`");
         return stc;
     }
 
@@ -9185,24 +9185,26 @@ final class Parser(AST) : Lexer
      */
     static StorageClass isBuiltinAtAttribute(Identifier ident)
     {
-        return (ident == Id.property) ? AST.STC.property :
-               (ident == Id.nogc)     ? AST.STC.nogc     :
-               (ident == Id.safe)     ? AST.STC.safe     :
-               (ident == Id.trusted)  ? AST.STC.trusted  :
-               (ident == Id.system)   ? AST.STC.system   :
-               (ident == Id.live)     ? AST.STC.live     :
-               (ident == Id.future)   ? AST.STC.future   :
-               (ident == Id.disable)  ? AST.STC.disable  :
+        return (ident == Id.property)  ? AST.STC.property  :
+               (ident == Id.nogc)      ? AST.STC.nogc      :
+               (ident == Id.safe)      ? AST.STC.safe      :
+               (ident == Id.trusted)   ? AST.STC.trusted   :
+               (ident == Id.system)    ? AST.STC.system    :
+               (ident == Id.live)      ? AST.STC.live      :
+               (ident == Id.nodiscard) ? AST.STC.nodiscard :
+               (ident == Id.future)    ? AST.STC.future    :
+               (ident == Id.disable)   ? AST.STC.disable   :
                0;
     }
 
     enum StorageClass atAttrGroup =
-                AST.STC.property |
-                AST.STC.nogc     |
-                AST.STC.safe     |
-                AST.STC.trusted  |
-                AST.STC.system   |
-                AST.STC.live     |
+                AST.STC.property  |
+                AST.STC.nogc      |
+                AST.STC.safe      |
+                AST.STC.trusted   |
+                AST.STC.system    |
+                AST.STC.live      |
+                AST.STC.nodiscard |
                 /*AST.STC.future   |*/ // probably should be included
                 AST.STC.disable;
     }

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -240,6 +240,8 @@ private bool isAssignment(Expression e)
  */
 private bool isNodiscard(Expression e)
 {
+    if (!global.params.nodiscardAttribute)
+        return false;
     if (auto ce = e.isCallExp())
     {
         if (ce.f && (ce.f.storage_class & STC.nodiscard)) {

--- a/test/compilable/nodiscard_assign.d
+++ b/test/compilable/nodiscard_assign.d
@@ -1,3 +1,6 @@
+/*
+REQUIRED_ARGS: -preview=nodiscard
+*/
 @nodiscard struct S {}
 
 void assign()

--- a/test/compilable/nodiscard_assign.d
+++ b/test/compilable/nodiscard_assign.d
@@ -1,0 +1,7 @@
+@nodiscard struct S {}
+
+void assign()
+{
+    S a, b;
+    a = b;
+}

--- a/test/compilable/nodiscard_deprecation.d
+++ b/test/compilable/nodiscard_deprecation.d
@@ -1,0 +1,8 @@
+/*
+TEST_OUTPUT
+---
+compilable/nodiscard_deprecation.d(8): Deprecation: use of `@nodiscard` as a user-defined attribute is deprecated.
+---
+*/
+struct nodiscard {}
+@nodiscard extern int func();

--- a/test/compilable/nodiscard_funcptr.d
+++ b/test/compilable/nodiscard_funcptr.d
@@ -1,0 +1,7 @@
+@nodiscard extern int func();
+auto fp = &func;
+
+void ignore()
+{
+    fp();
+}

--- a/test/compilable/nodiscard_funcptr.d
+++ b/test/compilable/nodiscard_funcptr.d
@@ -1,3 +1,6 @@
+/*
+REQUIRED_ARGS: -preview=nodiscard
+*/
 @nodiscard extern int func();
 auto fp = &func;
 

--- a/test/compilable/nodiscard_nestedfunc.d
+++ b/test/compilable/nodiscard_nestedfunc.d
@@ -1,3 +1,6 @@
+/*
+REQUIRED_ARGS: -preview=nodiscard
+*/
 @nodiscard int outer()
 {
     int inner() { return 0; }

--- a/test/compilable/nodiscard_nestedfunc.d
+++ b/test/compilable/nodiscard_nestedfunc.d
@@ -1,0 +1,6 @@
+@nodiscard int outer()
+{
+    int inner() { return 0; }
+    inner();
+    return 0;
+}

--- a/test/compilable/nodiscard_suppress.d
+++ b/test/compilable/nodiscard_suppress.d
@@ -1,0 +1,6 @@
+@nodiscard extern int func();
+
+void ignore()
+{
+    cast(void) func();
+}

--- a/test/compilable/nodiscard_suppress.d
+++ b/test/compilable/nodiscard_suppress.d
@@ -1,3 +1,6 @@
+/*
+REQUIRED_ARGS: -preview=nodiscard
+*/
 @nodiscard extern int func();
 
 void ignore()

--- a/test/compilable/previewhelp.d
+++ b/test/compilable/previewhelp.d
@@ -16,5 +16,6 @@ Upcoming language changes listed by -preview=name:
   =rvaluerefparam   enable rvalue arguments to ref parameters
   =nosharedaccess   disable access to shared memory objects
   =in               `in` on parameters means `scope const [ref]` and accepts rvalues
+  =nodiscard        enable `@nodiscard` attribute
 ----
 */

--- a/test/fail_compilation/b20780.d
+++ b/test/fail_compilation/b20780.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/b20780.d(12): Error: @identifier or @(ArgumentList) expected, not `@)`
-fail_compilation/b20780.d(12): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`
+fail_compilation/b20780.d(12): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`, `@nodiscard`
 fail_compilation/b20780.d(13): Error: @identifier or @(ArgumentList) expected, not `@,`
-fail_compilation/b20780.d(13): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`
+fail_compilation/b20780.d(13): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`, `@nodiscard`
 fail_compilation/b20780.d(13): Error: basic type expected, not `,`
 ---
 */

--- a/test/fail_compilation/ice11967.d
+++ b/test/fail_compilation/ice11967.d
@@ -6,7 +6,7 @@ fail_compilation/ice11967.d(13): Error: expression expected, not `%`
 fail_compilation/ice11967.d(13): Error: found `g` when expecting `)`
 fail_compilation/ice11967.d(13): Error: found `{` when expecting `]`
 fail_compilation/ice11967.d(14): Error: @identifier or @(ArgumentList) expected, not `@End of File`
-fail_compilation/ice11967.d(14): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`
+fail_compilation/ice11967.d(14): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`, `@nodiscard`
 fail_compilation/ice11967.d(14): Error: declaration expected following attribute, not end of file
 ---
 */

--- a/test/fail_compilation/nodiscard_function.d
+++ b/test/fail_compilation/nodiscard_function.d
@@ -1,7 +1,8 @@
 /*
+REQUIRED_ARGS: -preview=nodiscard
 TEST_OUTPUT
 ---
-fail_compilation/nodiscard_function.d(11): Error: ignored return value of `@nodiscard` function `nodiscard_function.func`; prepend a `cast(void)` if intentional
+fail_compilation/nodiscard_function.d(12): Error: ignored return value of `@nodiscard` function `nodiscard_function.func`; prepend a `cast(void)` if intentional
 ---
 */
 @nodiscard extern int func();

--- a/test/fail_compilation/nodiscard_function.d
+++ b/test/fail_compilation/nodiscard_function.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT
+---
+fail_compilation/nodiscard_function.d(11): Error: ignored return value of `@nodiscard` function `nodiscard_function.func`; prepend a `cast(void)` if intentional
+---
+*/
+@nodiscard extern int func();
+
+void ignore()
+{
+    func();
+}

--- a/test/fail_compilation/nodiscard_type.d
+++ b/test/fail_compilation/nodiscard_type.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT
+---
+fail_compilation/nodiscard_type.d(12): Error: ignored value of `@nodiscard` type `S`; prepend a `cast(void)` if intentional
+---
+*/
+@nodiscard struct S {};
+extern S func();
+
+void ignore()
+{
+    func();
+}

--- a/test/fail_compilation/nodiscard_type.d
+++ b/test/fail_compilation/nodiscard_type.d
@@ -1,7 +1,8 @@
 /*
+REQUIRED_ARGS: -preview=nodiscard
 TEST_OUTPUT
 ---
-fail_compilation/nodiscard_type.d(12): Error: ignored value of `@nodiscard` type `S`; prepend a `cast(void)` if intentional
+fail_compilation/nodiscard_type.d(13): Error: ignored value of `@nodiscard` type `S`; prepend a `cast(void)` if intentional
 ---
 */
 @nodiscard struct S {};


### PR DESCRIPTION
**Edit:** This PR was based on an early draft version of DIP 1038. It has been superseded by #13589. The original PR description follows below.

---

Fixes issue 5464 - Attribute to not ignore function result

---

Still need to write up a DIP for this, but I figured I'd post it early to get feedback. The design is the same as Rust's `#[must_use]`: on a function, it applies to the return value; on a type, it applies to all expressions of that type.