### PR TITLE
Remove unecessary permutations for frontend flags from runnable tests

### DIFF
--- a/test/runnable/bug7068.d
+++ b/test/runnable/bug7068.d
@@ -1,4 +1,5 @@
-// PERMUTE_ARGS: -inline -g -O -d
+// REQUIRED_ARGS:  -d
+// PERMUTE_ARGS: -inline -g -O
 void main()
 {
     auto darray1 = new int*[](10);

--- a/test/runnable/sctor.d
+++ b/test/runnable/sctor.d
@@ -1,6 +1,6 @@
 /*
-REQUIRED_ARGS:
-PERMUTE_ARGS: -w -d -de -dw
+REQUIRED_ARGS: -w -de
+PERMUTE_ARGS:
 RUN_OUTPUT:
 ---
 Success

--- a/test/runnable/sctor2.d
+++ b/test/runnable/sctor2.d
@@ -1,4 +1,5 @@
-// PERMUTE_ARGS: -w -d -dw
+// REQUIRED_ARGS: -w -de
+// PERMUTE_ARGS:
 
 /***************************************************/
 // 15665

--- a/test/runnable/test11447c.d
+++ b/test/runnable/test11447c.d
@@ -1,6 +1,7 @@
 // COMPILE_SEPARATELY
 // EXTRA_SOURCES: imports/c11447.d
-// PERMUTE_ARGS: -allinst -w -debug -g
+// REQUIRED_ARGS: -w
+// PERMUTE_ARGS: -allinst -debug -g
 
 import imports.c11447;
 

--- a/test/runnable/test9259.d
+++ b/test/runnable/test9259.d
@@ -1,4 +1,5 @@
-// PERMUTE_ARGS: -inline -release -g -O -d -dw -de
+// REQUIRED_ARGS: -de
+// PERMUTE_ARGS: -inline -release -g -O
 
 void test(int*[] arr...)
 {


### PR DESCRIPTION
They are independent of codegen related flags and cause a big slowdown
for some tests (e.g. `runnable/test9259.d` drops from 42 to 5.6 seconds)