### PR TITLE
Run dshell tests after runnable tests ...

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -18,7 +18,7 @@ import std.algorithm, std.conv, std.datetime, std.exception, std.file, std.forma
 import tools.paths;
 
 const scriptDir = __FILE_FULL_PATH__.dirName.buildNormalizedPath;
-immutable testDirs = ["runnable", "runnable_cxx", "compilable", "fail_compilation", "dshell"];
+immutable testDirs = ["runnable", "runnable_cxx", "dshell", "compilable", "fail_compilation"];
 shared bool verbose; // output verbose logging
 shared bool force; // always run all tests (ignores timestamp checking)
 shared string hostDMD; // path to host DMD binary (used for building the tools)


### PR DESCRIPTION
because they usually require more runtime than `compilable` and
`fail_compilation` tests. This ensures proper parallelization for
high job counts.