### PR TITLE
Don't compile runnable/testptrref_gc.d with -lowmem

### DIFF
--- a/test/runnable/testptrref_gc.d
+++ b/test/runnable/testptrref_gc.d
@@ -1,3 +1,3 @@
-// REQUIRED_ARGS: -lowmem -Jrunnable
+// REQUIRED_ARGS: -Jrunnable
 // EXTRA_FILES: testptrref.d
 mixin(import("testptrref.d"));


### PR DESCRIPTION
Maybe this will resolve the missing import.
The file is present as it sometimes fail on a subsequent run