### PR TITLE
Fix 13567 - Infer attributes for private functions

### DIFF
--- a/changelog/inference-for-private-function.dd
+++ b/changelog/inference-for-private-function.dd
@@ -1,0 +1,14 @@
+`private` functions now have their attributes inferred
+
+In order to reduce the amount of attributes users have to apply to their code,
+`private` functions will now have their attributes inferred as templates
+or `auto` functions currently do.
+
+E.g. the following is now possible:
+---
+private void bar() {}
+
+void foo() @safe nothrow @nogc pure {
+  bar();
+}
+---

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1288,6 +1288,10 @@ extern (C++) class FuncDeclaration : Declaration
             (!isMember() || sc.func.isSafeBypassingInference() && !isInstantiated()))
             return true;
 
+        // Private functions get their attributes inferred
+        if (this.prot.kind == Prot.Kind.private_)
+            return true;
+
         if (isFuncLiteralDeclaration() ||               // externs are not possible with literals
             (storage_class & STC.inference) ||           // do attribute inference
             (inferRetType && !isCtorDeclaration()))

--- a/test/compilable/inference.d
+++ b/test/compilable/inference.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=13567
+
+private void dfunc1 () { }
+private void dfunc2 () { throw new Exception("Hello World"); }
+private extern(C) void dfunc3 () { }
+private extern(C++) void dfunc4 () { }
+
+void caller1() @safe pure nothrow @nogc {
+    dfunc1();
+    dfunc3();
+    dfunc4();
+}
+void caller2() @safe pure {
+    dfunc2();
+}


### PR DESCRIPTION
💥 

Needs https://github.com/dlang/druntime/pull/3214 and maybe others (DMD tests pass on my machine).
Pre-approved by @WalterBright in 2015 and I doubt he changed his mind on having more inference since.

Opening as draft just to give some time for feedback. I think it's one of those things that everyone wants, but if anyone can come up with ways to break it, it's welcome. I'm thinking about `public` aliases & the like.