### PR TITLE
Fix 19970 - Cast from 0 to ptr is not null at CTFE

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -746,6 +746,15 @@ Expression getAggregateFromPointer(Expression e, dinteger_t* ofs)
             return se.e1;
         }
     }
+
+    // It can be a `null` disguised as a cast, e.g. `cast(void*)0`.
+    if (auto ie = e.isIntegerExp())
+        if (ie.type.ty == Tpointer && ie.getInteger() == 0)
+            return new NullExp(ie.loc, e.type.nextOf());
+    // Those casts are invalid, but let the rest of the code handle it,
+    // as it could be something like `x !is null`, which doesn't need
+    // to dereference the pointer, even if the pointer is `cast(void*)420`.
+
     return e;
 }
 

--- a/test/compilable/test19970.d
+++ b/test/compilable/test19970.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=19970
+
+enum void* p = cast(void*)0;
+static assert(p is null);
+static assert(ctfeLocal(p));
+static assert(ctfeGlobal());
+
+bool ctfeGlobal ()
+{
+    return p is null;
+}
+
+bool ctfeLocal (const void* ptr) pure
+{
+    return ptr is null;
+}


### PR DESCRIPTION
That fix seems a bit too specific, but it solves the bug. New test cases welcome @EyalIO .