### PR TITLE
Move newScope from the AST nodes to dsymbolsem.d

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -135,24 +135,6 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         protection = Prot(Prot.Kind.public_);
     }
 
-    /***************************************
-     * Create a new scope from sc.
-     * semantic, semantic2 and semantic3 will use this for aggregate members.
-     */
-    Scope* newScope(Scope* sc)
-    {
-        auto sc2 = sc.push(this);
-        sc2.stc &= STCFlowThruAggregate;
-        sc2.parent = this;
-        sc2.inunion = isUnionDeclaration();
-        sc2.protection = Prot(Prot.Kind.public_);
-        sc2.explicitProtection = 0;
-        sc2.aligndecl = null;
-        sc2.userAttribDecl = null;
-        sc2.namespace = null;
-        return sc2;
-    }
-
     override final void setScope(Scope* sc)
     {
         // Might need a scope to resolve forward references. The check for

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -119,7 +119,6 @@ public:
     bool noDefaultCtor;         // no default construction
     Sizeok sizeok;              // set when structsize contains valid data
 
-    virtual Scope *newScope(Scope *sc);
     void setScope(Scope *sc);
     bool determineFields();
     size_t nonHiddenFields();
@@ -281,7 +280,6 @@ public:
 
     static ClassDeclaration *create(Loc loc, Identifier *id, BaseClasses *baseclasses, Dsymbols *members, bool inObject);
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
     bool isBaseOf2(ClassDeclaration *cd);
 
     #define OFFSET_RUNTIME 0x76543210
@@ -318,7 +316,6 @@ class InterfaceDeclaration : public ClassDeclaration
 {
 public:
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
     bool isBaseOf(ClassDeclaration *cd, int *poffset);
     bool isBaseOf(BaseClass *bc, int *poffset);
     const char *kind() const;

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -25,7 +25,6 @@ public:
     Dsymbols *decl;     // array of Dsymbol's
 
     virtual Dsymbols *include(Scope *sc);
-    virtual Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);
     void importAll(Scope *sc);
@@ -48,7 +47,6 @@ public:
     StorageClass stc;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     StorageClassDeclaration *isStorageClassDeclaration() { return this; }
@@ -63,7 +61,6 @@ public:
     const char *msgstr;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
     void setScope(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -75,7 +72,6 @@ public:
 
     static LinkDeclaration *create(LINK p, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
     const char *toChars() const;
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -86,7 +82,6 @@ public:
     CPPMANGLE cppmangle;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
     void setScope(Scope *sc);
     const char *toChars() const;
     void accept(Visitor *v) { v->visit(this); }
@@ -98,7 +93,6 @@ public:
     Expression *exp;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
     const char *toChars() const;
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -110,7 +104,6 @@ public:
     Identifiers* pkg_identifiers;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     const char *kind() const;
     const char *toPrettyChars(bool unused);
@@ -126,7 +119,6 @@ public:
 
     AlignDeclaration(const Loc &loc, Expression *ealign, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -153,7 +145,6 @@ public:
     Expressions *args;          // array of Expression's
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
     const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -213,7 +204,6 @@ class ForwardingAttribDeclaration : public AttribDeclaration
 public:
     ForwardingScopeDsymbol *sym;
 
-    Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     ForwardingAttribDeclaration *isForwardingAttribDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -246,7 +236,6 @@ public:
     Expressions *atts;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
     void setScope(Scope *sc);
     Expressions *getAttributes();
     const char *kind() const;

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -400,19 +400,6 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         return ScopeDsymbol.syntaxCopy(cd);
     }
 
-    override Scope* newScope(Scope* sc)
-    {
-        auto sc2 = super.newScope(sc);
-        if (isCOMclass())
-        {
-            /* This enables us to use COM objects under Linux and
-             * work with things like XPCOM
-             */
-            sc2.linkage = target.systemLinkage();
-        }
-        return sc2;
-    }
-
     /*********************************************
      * Determine if 'this' is a base class of cd.
      * This is used to detect circular inheritance only.
@@ -1003,19 +990,6 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
             s ? cast(InterfaceDeclaration)s
               : new InterfaceDeclaration(loc, ident, null);
         return ClassDeclaration.syntaxCopy(id);
-    }
-
-
-    override Scope* newScope(Scope* sc)
-    {
-        auto sc2 = super.newScope(sc);
-        if (com)
-            sc2.linkage = LINK.windows;
-        else if (classKind == ClassKind.cpp)
-            sc2.linkage = LINK.cpp;
-        else if (classKind == ClassKind.objc)
-            sc2.linkage = LINK.objc;
-        return sc2;
     }
 
     /*******************************************

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -6672,3 +6672,244 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
             ScopeDsymbol.multiplyDefined(Loc.initial, sx, ds);
     }
 }
+
+// Create a new scope from sc.
+Scope* newScope(Dsymbol dsym, Scope* sc)
+{
+    scope v = new ScopeVisitor(sc);
+    dsym.accept(v);
+    return v.result;
+}
+
+private extern(C++) final class ScopeVisitor : Visitor
+{
+    alias visit = Visitor.visit;
+
+    private Scope* sc;
+    Scope* result;
+
+    this(Scope* sc,)
+    {
+        this.sc = sc;
+    }
+
+    /****************************************
+    * Create a new scope if one or more given attributes
+    * are different from the sc's.
+    * If the returned scope != sc, the caller should pop
+    * the scope after it used.
+    */
+    private static Scope* createNewScope(Scope* sc, StorageClass stc, LINK linkage,
+        CPPMANGLE cppmangle, Prot protection, int explicitProtection,
+        AlignDeclaration aligndecl, PINLINE inlining)
+    {
+        Scope* sc2 = sc;
+        if (stc != sc.stc ||
+            linkage != sc.linkage ||
+            cppmangle != sc.cppmangle ||
+            !protection.isSubsetOf(sc.protection) ||
+            explicitProtection != sc.explicitProtection ||
+            aligndecl !is sc.aligndecl ||
+            inlining != sc.inlining)
+        {
+            // create new one for changes
+            sc2 = sc.copy();
+            sc2.stc = stc;
+            sc2.linkage = linkage;
+            sc2.cppmangle = cppmangle;
+            sc2.protection = protection;
+            sc2.explicitProtection = explicitProtection;
+            sc2.aligndecl = aligndecl;
+            sc2.inlining = inlining;
+        }
+        return sc2;
+    }
+
+    override void visit(AggregateDeclaration ad)
+    {
+        auto sc2 = sc.push(ad);
+        sc2.stc &= STCFlowThruAggregate;
+        sc2.parent = ad;
+        sc2.inunion = ad.isUnionDeclaration();
+        sc2.protection = Prot(Prot.Kind.public_);
+        sc2.explicitProtection = 0;
+        sc2.aligndecl = null;
+        sc2.userAttribDecl = null;
+        sc2.namespace = null;
+        result = sc2;
+    }
+
+    override void visit(ClassDeclaration cd)
+    {
+        visit(cast(AggregateDeclaration) cd);
+        auto sc2 = result;
+        if (cd.isCOMclass())
+        {
+            /* This enables us to use COM objects under Linux and
+             * work with things like XPCOM
+             */
+            sc2.linkage = target.systemLinkage();
+        }
+        result = sc2;
+    }
+
+    override void visit(InterfaceDeclaration id)
+    {
+        visit(cast(ClassDeclaration) id);
+        auto sc2 = result;
+        if (id.com)
+            sc2.linkage = LINK.windows;
+        else if (id.classKind == ClassKind.cpp)
+            sc2.linkage = LINK.cpp;
+        else if (id.classKind == ClassKind.objc)
+            sc2.linkage = LINK.objc;
+        result = sc2;
+    }
+
+    override void visit(AttribDeclaration ad)
+    {
+        result = sc;
+    }
+
+    override void visit(StorageClassDeclaration scd)
+    {
+        StorageClass scstc = sc.stc;
+        /* These sets of storage classes are mutually exclusive,
+         * so choose the innermost or most recent one.
+         */
+        if (scd.stc & (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.manifest))
+            scstc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.manifest);
+        if (scd.stc & (STC.auto_ | STC.scope_ | STC.static_ | STC.tls | STC.manifest | STC.gshared))
+            scstc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.tls | STC.manifest | STC.gshared);
+        if (scd.stc & (STC.const_ | STC.immutable_ | STC.manifest))
+            scstc &= ~(STC.const_ | STC.immutable_ | STC.manifest);
+        if (scd.stc & (STC.gshared | STC.shared_ | STC.tls))
+            scstc &= ~(STC.gshared | STC.shared_ | STC.tls);
+        if (scd.stc & (STC.safe | STC.trusted | STC.system))
+            scstc &= ~(STC.safe | STC.trusted | STC.system);
+        scstc |= scd.stc;
+        //printf("scstc = x%llx\n", scstc);
+        result = createNewScope(sc, scstc, sc.linkage, sc.cppmangle,
+            sc.protection, sc.explicitProtection, sc.aligndecl, sc.inlining);
+    }
+
+    /**
+     * Provides a new scope with `STC.deprecated_` and `Scope.depdecl` set
+     *
+     * Calls `StorageClassDeclaration.newScope` (as it must be called or copied
+     * in any function overriding `newScope`), then set the `Scope`'s depdecl.
+     *
+     */
+    override void visit(DeprecatedDeclaration dd)
+    {
+        this.visit(cast(StorageClassDeclaration) dd);
+        // The enclosing scope is deprecated as well
+        if (result == sc)
+            result = sc.push();
+        result.depdecl = dd;
+    }
+
+    override void visit(LinkDeclaration ld)
+    {
+        result = createNewScope(sc, sc.stc, ld.linkage, sc.cppmangle, sc.protection, sc.explicitProtection,
+            sc.aligndecl, sc.inlining);
+    }
+
+    override void visit(CPPMangleDeclaration cppmd)
+    {
+        result = createNewScope(sc, sc.stc, LINK.cpp, cppmd.cppmangle, sc.protection, sc.explicitProtection,
+            sc.aligndecl, sc.inlining);
+    }
+
+    /**
+     * Returns:
+     *   A copy of the parent scope, with `cppnd` as `namespace` and C++ linkage
+     */
+    override void visit(CPPNamespaceDeclaration cppnd)
+    {
+        auto scx = sc.copy();
+        scx.linkage = LINK.cpp;
+        scx.namespace = cppnd;
+        result = scx;
+    }
+
+    override void visit(ProtDeclaration pd)
+    {
+        if (pd.pkg_identifiers)
+            dsymbolSemantic(pd, sc);
+        result = createNewScope(sc, sc.stc, sc.linkage, sc.cppmangle, pd.protection, 1, sc.aligndecl, sc.inlining);
+    }
+
+    override void visit(AlignDeclaration ad)
+    {
+        result = createNewScope(sc, sc.stc, sc.linkage, sc.cppmangle, sc.protection, sc.explicitProtection, ad, sc.inlining);
+    }
+
+    override void visit(PragmaDeclaration pd)
+    {
+        if (pd.ident == Id.Pinline)
+        {
+            PINLINE inlining = PINLINE.default_;
+            if (!(pd.args) || pd.args.dim == 0)
+                inlining = PINLINE.default_;
+            else if (pd.args.dim != 1)
+            {
+                pd.error("one boolean expression expected for `pragma(inline)`, not %llu", cast(ulong) pd.args.dim);
+                pd.args.setDim(1);
+                (*(pd.args))[0] = ErrorExp.get();
+            }
+            else
+            {
+                Expression e = (*(pd.args))[0];
+                if (e.op != TOK.int64 || !e.type.equals(Type.tbool))
+                {
+                    if (e.op != TOK.error)
+                    {
+                        pd.error("pragma(`inline`, `true` or `false`) expected, not `%s`", e.toChars());
+                        (*(pd.args))[0] = ErrorExp.get();
+                    }
+                }
+                else if (e.isBool(true))
+                    inlining = PINLINE.always;
+                else if (e.isBool(false))
+                    inlining = PINLINE.never;
+            }
+            result = createNewScope(sc, sc.stc, sc.linkage, sc.cppmangle, sc.protection, sc.explicitProtection, sc.aligndecl, inlining);
+            return;
+        }
+        if (pd.ident == Id.printf || pd.ident == Id.scanf)
+        {
+            auto sc2 = sc.push();
+
+            if (pd.ident == Id.printf)
+                // Override previous setting, never let both be set
+                sc2.flags = (sc2.flags & ~SCOPE.scanf) | SCOPE.printf;
+            else
+                sc2.flags = (sc2.flags & ~SCOPE.printf) | SCOPE.scanf;
+
+            result = sc2;
+            return;
+        }
+        result = sc;
+    }
+
+    /**************************************
+     * Use the ForwardingScopeDsymbol as the parent symbol for members.
+     */
+    override void visit(ForwardingAttribDeclaration fad)
+    {
+        result = sc.push(fad.sym);
+    }
+
+    override void visit(UserAttributeDeclaration uad)
+    {
+        Scope* sc2 = sc;
+        if (uad.atts && uad.atts.dim)
+        {
+            // create new one for changes
+            sc2 = sc.copy();
+            sc2.userAttribDecl = uad;
+        }
+        result = sc2;
+    }
+}

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1812,7 +1812,6 @@ public:
     Prot protection;
     bool noDefaultCtor;
     Sizeok sizeok;
-    virtual Scope* newScope(Scope* sc);
     void setScope(Scope* sc);
     bool determineFields();
     size_t nonHiddenFields();
@@ -1915,7 +1914,6 @@ class AttribDeclaration : public Dsymbol
 public:
     Array<Dsymbol*>* decl;
     virtual Array<Dsymbol*>* include(Scope* sc);
-    virtual Scope* newScope(Scope* sc);
     void addMember(Scope* sc, ScopeDsymbol* sds);
     void setScope(Scope* sc);
     void importAll(Scope* sc);
@@ -1937,7 +1935,6 @@ class StorageClassDeclaration : public AttribDeclaration
 public:
     StorageClass stc;
     Dsymbol* syntaxCopy(Dsymbol* s);
-    Scope* newScope(Scope* sc);
     bool oneMember(Dsymbol** ps, Identifier* ident);
     void addMember(Scope* sc, ScopeDsymbol* sds);
     StorageClassDeclaration* isStorageClassDeclaration();
@@ -1950,7 +1947,6 @@ public:
     Expression* msg;
     char* msgstr;
     Dsymbol* syntaxCopy(Dsymbol* s);
-    Scope* newScope(Scope* sc);
     void setScope(Scope* sc);
     void accept(Visitor* v);
 };
@@ -1961,7 +1957,6 @@ public:
     LINK linkage;
     static LinkDeclaration* create(LINK p, Array<Dsymbol*>* decl);
     Dsymbol* syntaxCopy(Dsymbol* s);
-    Scope* newScope(Scope* sc);
     const char* toChars() const;
     void accept(Visitor* v);
 };
@@ -1971,7 +1966,6 @@ class CPPMangleDeclaration : public AttribDeclaration
 public:
     CPPMANGLE cppmangle;
     Dsymbol* syntaxCopy(Dsymbol* s);
-    Scope* newScope(Scope* sc);
     void setScope(Scope* sc);
     const char* toChars() const;
     void accept(Visitor* v);
@@ -1982,7 +1976,6 @@ class CPPNamespaceDeclaration : public AttribDeclaration
 public:
     Expression* exp;
     Dsymbol* syntaxCopy(Dsymbol* s);
-    Scope* newScope(Scope* sc);
     const char* toChars() const;
     void accept(Visitor* v);
     CPPNamespaceDeclaration* isCPPNamespaceDeclaration();
@@ -1994,7 +1987,6 @@ public:
     Prot protection;
     Array<Identifier*>* pkg_identifiers;
     Dsymbol* syntaxCopy(Dsymbol* s);
-    Scope* newScope(Scope* sc);
     void addMember(Scope* sc, ScopeDsymbol* sds);
     const char* kind() const;
     const char* toPrettyChars(bool _param_0);
@@ -2010,7 +2002,6 @@ public:
 
     uint32_t salign;
     Dsymbol* syntaxCopy(Dsymbol* s);
-    Scope* newScope(Scope* sc);
     void accept(Visitor* v);
 };
 
@@ -2035,7 +2026,6 @@ class PragmaDeclaration : public AttribDeclaration
 public:
     Array<Expression*>* args;
     Dsymbol* syntaxCopy(Dsymbol* s);
-    Scope* newScope(Scope* sc);
     const char* kind() const;
     void accept(Visitor* v);
 };
@@ -2092,7 +2082,6 @@ class ForwardingAttribDeclaration : public AttribDeclaration
 public:
     ForwardingScopeDsymbol* sym;
     ForwardingAttribDeclaration(Array<Dsymbol*>* decl);
-    Scope* newScope(Scope* sc);
     void addMember(Scope* sc, ScopeDsymbol* sds);
     ForwardingAttribDeclaration* isForwardingAttribDeclaration();
     void accept(Visitor* v);
@@ -2117,7 +2106,6 @@ class UserAttributeDeclaration : public AttribDeclaration
 public:
     Array<Expression*>* atts;
     Dsymbol* syntaxCopy(Dsymbol* s);
-    Scope* newScope(Scope* sc);
     void setScope(Scope* sc);
     Array<Expression*>* getAttributes();
     const char* kind() const;
@@ -2389,7 +2377,6 @@ public:
     Symbol* cpp_type_info_ptr_sym;
     static ClassDeclaration* create(Loc loc, Identifier* id, Array<BaseClass*>* baseclasses, Array<Dsymbol*>* members, bool inObject);
     Dsymbol* syntaxCopy(Dsymbol* s);
-    Scope* newScope(Scope* sc);
     bool isBaseOf2(ClassDeclaration* cd);
     enum : int32_t { OFFSET_RUNTIME = 1985229328 };
 
@@ -2423,7 +2410,6 @@ class InterfaceDeclaration : public ClassDeclaration
 {
 public:
     Dsymbol* syntaxCopy(Dsymbol* s);
-    Scope* newScope(Scope* sc);
     bool isBaseOf(ClassDeclaration* cd, int32_t* poffset);
     bool isBaseOf(BaseClass* bc, int32_t* poffset);
     const char* kind() const;


### PR DESCRIPTION
Moving semantic operations out of AST nodes (attrib.d, aggregate.d, dclass.d)