### PR TITLE
Fix Issue 21272 - Overzealous and inconsistent foreach shadowing deprecations for nested functions

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5190,8 +5190,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 else
                 {
+                    /* https://issues.dlang.org/show_bug.cgi?id=21272
+                     * If we are in a foreach body we need to extract the
+                     * function containing the foreach
+                     */
+                    FuncDeclaration fes_enclosing_func;
+                    if (sc.func && sc.func.fes)
+                        fes_enclosing_func = sc.enclosing.enclosing.func;
+
                     // Disallow shadowing
-                    for (Scope* scx = sc.enclosing; scx && (scx.func == sc.func || (scx.func && sc.func.fes)); scx = scx.enclosing)
+                    for (Scope* scx = sc.enclosing; scx && (scx.func == sc.func || (fes_enclosing_func && scx.func == fes_enclosing_func)); scx = scx.enclosing)
                     {
                         Dsymbol s2;
                         if (scx.scopesym && scx.scopesym.symtab && (s2 = scx.scopesym.symtab.lookup(s.ident)) !is null && s != s2)

--- a/test/fail_compilation/fail2195.d
+++ b/test/fail_compilation/fail2195.d
@@ -16,3 +16,19 @@ void main()
         int variable;  // shadowing is disallowed but not detected
     }
 }
+
+void fun()
+{
+    int var1, var2, var3;
+
+    void gun()
+    {
+        int var1; // OK?
+
+        int[] arr;
+        foreach (i, var2; arr) {} // OK?
+
+        int[int] aa;
+        foreach (k, var3; aa) {} // Not OK??
+    }
+}


### PR DESCRIPTION
If we have declarations inside the scope of a foreach statement, we need to extract the function that contains the foreach and check for shadowing only the scope of that function.