### PR TITLE
constant fold typeid(T).tsize()

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8737,6 +8737,7 @@ struct Id final
     static Identifier* isCopyable;
     static Identifier* toType;
     static Identifier* parameters;
+    static Identifier* tsize;
     static Identifier* allocator;
     static Identifier* basic_string;
     static Identifier* basic_istream;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -493,6 +493,9 @@ immutable Msgtable[] msgtable =
     { "toType" },
     { "parameters" },
 
+    // For TypeInfo members
+    { "tsize" },
+
     // For C++ mangling
     { "allocator" },
     { "basic_string" },

--- a/compiler/test/runnable/testtypeid.d
+++ b/compiler/test/runnable/testtypeid.d
@@ -561,6 +561,15 @@ void test15680()
 
 /******************************************************/
 
+void test41()
+{
+    //enum i = typeid(3).tsize;
+    //assert(i == 4);
+    static assert(typeid(4.0).tsize == 8);
+}
+
+/******************************************************/
+
 int main()
 {
     test2();
@@ -601,6 +610,7 @@ int main()
     test13045a();
     test13045b();
     test15680();
+    test41();
 
     return 0;
 }


### PR DESCRIPTION
The idea here is that since the compiler knows what .tsize() is, it can be constant folded. Works with both runtime and compile time computations. If this is successful, will generalize it to more typeid members.