### PR TITLE
add __totype(string) expressions

### DIFF
--- a/changelog/totype.md
+++ b/changelog/totype.md
@@ -1,0 +1,22 @@
+# Basic Type __totype
+
+The following construct is added as a BasicType:
+
+---
+TotypeType:
+    __totype ( AssignExpression )
+---
+
+AssignExpression is evaluated at compile time, and the result must be
+a string. The string must be a sequence of characters representing the
+mangling of an existing type. The TotypeType is then that type.
+
+For example:
+
+---
+pragma(msg, 1.mangleof); // prints `i`
+__totype("i") x;         // declares `x` as having type `int`
+__totype("Pi") p;        // declares `p` as having type `int*`
+__totype(3) y;           // error: `3` is not a string
+__totype("#Hello") z;    // error: `#Hello` is not a recognized mangling of a type
+---

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -194,6 +194,7 @@ struct ASTBase
         Terror,
         Tinstance,
         Ttypeof,
+        Ttotype,
         Ttuple,
         Tslice,
         Treturn,
@@ -244,6 +245,7 @@ struct ASTBase
     alias Terror = ENUMTY.Terror;
     alias Tinstance = ENUMTY.Tinstance;
     alias Ttypeof = ENUMTY.Ttypeof;
+    alias Ttotype = ENUMTY.Ttotype;
     alias Ttuple = ENUMTY.Ttuple;
     alias Tslice = ENUMTY.Tslice;
     alias Treturn = ENUMTY.Treturn;
@@ -2804,6 +2806,7 @@ struct ASTBase
                 sizeTy[Tident] = __traits(classInstanceSize, TypeIdentifier);
                 sizeTy[Tinstance] = __traits(classInstanceSize, TypeInstance);
                 sizeTy[Ttypeof] = __traits(classInstanceSize, TypeTypeof);
+                sizeTy[Ttotype] = __traits(classInstanceSize, TypeTotype);
                 sizeTy[Tenum] = __traits(classInstanceSize, TypeEnum);
                 sizeTy[Tstruct] = __traits(classInstanceSize, TypeStruct);
                 sizeTy[Tclass] = __traits(classInstanceSize, TypeClass);
@@ -3076,6 +3079,8 @@ struct ASTBase
             if (ty == Terror)
                 return this;
             if (ty == Ttypeof)
+                return this;
+            if (ty == Ttotype)
                 return this;
             if (ty == Tident)
                 return this;
@@ -3565,6 +3570,7 @@ struct ASTBase
             inout(TypeIdentifier) isTypeIdentifier() { return ty == Tident     ? cast(typeof(return))this : null; }
             inout(TypeInstance)   isTypeInstance()   { return ty == Tinstance  ? cast(typeof(return))this : null; }
             inout(TypeTypeof)     isTypeTypeof()     { return ty == Ttypeof    ? cast(typeof(return))this : null; }
+            inout(TypeTotype)     isTypeTotype()     { return ty == Ttotype    ? cast(typeof(return))this : null; }
             inout(TypeReturn)     isTypeReturn()     { return ty == Treturn    ? cast(typeof(return))this : null; }
             inout(TypeStruct)     isTypeStruct()     { return ty == Tstruct    ? cast(typeof(return))this : null; }
             inout(TypeEnum)       isTypeEnum()       { return ty == Tenum      ? cast(typeof(return))this : null; }
@@ -4593,6 +4599,30 @@ struct ASTBase
         override TypeTypeof syntaxCopy()
         {
             auto t = new TypeTypeof(loc, exp.syntaxCopy());
+            t.syntaxCopyHelper(this);
+            t.mod = mod;
+            return t;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) final class TypeTotype : TypeQualified
+    {
+        Expression exp;
+
+        extern (D) this(const ref Loc loc, Expression exp)
+        {
+            super(Ttotype, loc);
+            this.exp = exp;
+        }
+
+        override Type syntaxCopy()
+        {
+            auto t = new TypeTotype(loc, exp.syntaxCopy());
             t.syntaxCopyHelper(this);
             t.mod = mod;
             return t;

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -136,12 +136,37 @@ import dmd.identifier;
 import dmd.mtype;
 import dmd.root.ctfloat;
 import dmd.root.outbuffer;
+import dmd.root.stringtable;
 import dmd.root.aav;
 import dmd.root.string;
 import dmd.target;
 import dmd.tokens;
 import dmd.utf;
 import dmd.visitor;
+
+
+/**********************************************
+ * Convert a string representing a type (the deco) and
+ * return its equivalent Type.
+ * Params:
+ *      deco = string containing the deco
+ * Returns:
+ *      null for failed to convert
+ *      Type for succeeded
+ */
+
+public Type decoToType(const(char)[] deco)
+{
+    auto sv = Type.stringtable.lookup(deco);
+    if (sv && sv.value)
+    {
+        Type t = sv.value;
+        assert(t.deco);
+        return t;
+    }
+    return null;
+}
+
 
 private immutable char[TMAX] mangleChar =
 [
@@ -205,6 +230,7 @@ private immutable char[TMAX] mangleChar =
     Tinstance    : '@',
     Terror       : '@',
     Ttypeof      : '@',
+    Ttotype      : '@',
     Tslice       : '@',
     Treturn      : '@',
     Tvector      : '@',

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -478,7 +478,8 @@ enum class TOK : uint8_t
     showCtfeContext = 232u,
     objcClassReference = 233u,
     vectorArray = 234u,
-    max_ = 235u,
+    totype = 235u,
+    max_ = 236u,
 };
 
 class StringExp;
@@ -647,6 +648,7 @@ class TypeDelegate;
 class TypeIdentifier;
 class TypeInstance;
 class TypeTypeof;
+class TypeTotype;
 class TypeReturn;
 class TypeStruct;
 class TypeEnum;
@@ -1277,7 +1279,7 @@ public:
     static ClassDeclaration* typeinfoshared;
     static ClassDeclaration* typeinfowild;
     static TemplateDeclaration* rtinfo;
-    static Type* basic[46LLU];
+    static Type* basic[47LLU];
     virtual const char* kind() const;
     Type* copy() const;
     virtual Type* syntaxCopy();
@@ -1386,6 +1388,7 @@ public:
     TypeIdentifier* isTypeIdentifier();
     TypeInstance* isTypeInstance();
     TypeTypeof* isTypeTypeof();
+    TypeTotype* isTypeTotype();
     TypeReturn* isTypeReturn();
     TypeStruct* isTypeStruct();
     TypeEnum* isTypeEnum();
@@ -4907,16 +4910,17 @@ enum class ENUMTY
     Terror = 34,
     Tinstance = 35,
     Ttypeof = 36,
-    Ttuple = 37,
-    Tslice = 38,
-    Treturn = 39,
-    Tnull = 40,
-    Tvector = 41,
-    Tint128 = 42,
-    Tuns128 = 43,
-    Ttraits = 44,
-    Tmixin = 45,
-    TMAX = 46,
+    Ttotype = 37,
+    Ttuple = 38,
+    Tslice = 39,
+    Treturn = 40,
+    Tnull = 41,
+    Tvector = 42,
+    Tint128 = 43,
+    Tuns128 = 44,
+    Ttraits = 45,
+    Tmixin = 46,
+    TMAX = 47,
 };
 
 typedef uint8_t TY;
@@ -5277,6 +5281,16 @@ public:
     d_uns64 size(const Loc& loc);
     void accept(Visitor* v);
     ~TypeTypeof();
+};
+
+class TypeTotype final : public TypeQualified
+{
+public:
+    Expression* exp;
+    const char* kind() const;
+    TypeTotype* syntaxCopy();
+    void accept(Visitor* v);
+    ~TypeTotype();
 };
 
 class TypeReturn final : public TypeQualified

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3738,6 +3738,14 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
         visitTypeQualifiedHelper(t);
     }
 
+    void visitTotype(TypeTotype t)
+    {
+        buf.writestring("__totype(");
+        t.exp.expressionToBuffer(buf, hgs);
+        buf.writeByte(')');
+        visitTypeQualifiedHelper(t);
+    }
+
     void visitReturn(TypeReturn t)
     {
         buf.writestring("typeof(return)");
@@ -3819,6 +3827,7 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
         case Tident:     return visitIdentifier(cast(TypeIdentifier)t);
         case Tinstance:  return visitInstance(cast(TypeInstance)t);
         case Ttypeof:    return visitTypeof(cast(TypeTypeof)t);
+        case Ttotype:    return visitTotype(cast(TypeTotype)t);
         case Treturn:    return visitReturn(cast(TypeReturn)t);
         case Tenum:      return visitEnum(cast(TypeEnum)t);
         case Tstruct:    return visitStruct(cast(TypeStruct)t);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -275,6 +275,7 @@ enum ENUMTY : int
     Terror,
     Tinstance,
     Ttypeof,
+    Ttotype,
     Ttuple,
     Tslice,
     Treturn,
@@ -325,6 +326,7 @@ alias Tdchar = ENUMTY.Tdchar;
 alias Terror = ENUMTY.Terror;
 alias Tinstance = ENUMTY.Tinstance;
 alias Ttypeof = ENUMTY.Ttypeof;
+alias Ttotype = ENUMTY.Ttotype;
 alias Ttuple = ENUMTY.Ttuple;
 alias Tslice = ENUMTY.Tslice;
 alias Treturn = ENUMTY.Treturn;
@@ -490,6 +492,7 @@ extern (C++) abstract class Type : ASTNode
             sizeTy[Tident] = __traits(classInstanceSize, TypeIdentifier);
             sizeTy[Tinstance] = __traits(classInstanceSize, TypeInstance);
             sizeTy[Ttypeof] = __traits(classInstanceSize, TypeTypeof);
+            sizeTy[Ttotype] = __traits(classInstanceSize, TypeTotype);
             sizeTy[Tenum] = __traits(classInstanceSize, TypeEnum);
             sizeTy[Tstruct] = __traits(classInstanceSize, TypeStruct);
             sizeTy[Tclass] = __traits(classInstanceSize, TypeClass);
@@ -2690,6 +2693,7 @@ extern (C++) abstract class Type : ASTNode
         inout(TypeIdentifier) isTypeIdentifier() { return ty == Tident     ? cast(typeof(return))this : null; }
         inout(TypeInstance)   isTypeInstance()   { return ty == Tinstance  ? cast(typeof(return))this : null; }
         inout(TypeTypeof)     isTypeTypeof()     { return ty == Ttypeof    ? cast(typeof(return))this : null; }
+        inout(TypeTotype)     isTypeTotype()     { return ty == Ttotype    ? cast(typeof(return))this : null; }
         inout(TypeReturn)     isTypeReturn()     { return ty == Treturn    ? cast(typeof(return))this : null; }
         inout(TypeStruct)     isTypeStruct()     { return ty == Tstruct    ? cast(typeof(return))this : null; }
         inout(TypeEnum)       isTypeEnum()       { return ty == Tenum      ? cast(typeof(return))this : null; }
@@ -5686,6 +5690,38 @@ extern (C++) final class TypeTypeof : TypeQualified
             return exp.type.size(loc);
         else
             return TypeQualified.size(loc);
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+/***********************************************************
+ */
+extern (C++) final class TypeTotype : TypeQualified
+{
+    Expression exp;
+
+    extern (D) this(const ref Loc loc, Expression exp)
+    {
+        super(Ttotype, loc);
+        this.exp = exp;
+    }
+
+    override const(char)* kind() const
+    {
+        return "totype";
+    }
+
+    override TypeTotype syntaxCopy()
+    {
+        //printf("TypeTypeof::syntaxCopy() %s\n", toChars());
+        auto t = new TypeTotype(loc, exp.syntaxCopy());
+        t.syntaxCopyHelper(this);
+        t.mod = mod;
+        return t;
     }
 
     override void accept(Visitor v)

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -286,6 +286,7 @@ enum TOK : ubyte
 
     objcClassReference,
     vectorArray,
+    totype,
 
     max_,
 }
@@ -419,6 +420,7 @@ private immutable TOK[] keywords =
     TOK.prettyFunction,
     TOK.shared_,
     TOK.immutable_,
+    TOK.totype,
 ];
 
 // Initialize the identifier pool
@@ -565,6 +567,7 @@ extern (C++) struct Token
         TOK.nothrow_: "nothrow",
         TOK.gshared: "__gshared",
         TOK.traits: "__traits",
+        TOK.totype: "__totype",
         TOK.vector: "__vector",
         TOK.overloadSet: "__overloadset",
         TOK.file: "__FILE__",

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1747,6 +1747,21 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         return t;
     }
 
+    Type visitTotype(TypeTotype mtype)
+    {
+        //printf("TypeTotype::semantic() %s\n", mtype.toChars());
+        StringExp se = semanticString(sc, mtype.exp, "__totype");
+        if (!se)
+            return Type.terror;
+        Type t = decoToType(se.toUTF8(sc).peekString());
+        if (!t)
+        {
+            .error(loc, "cannot determine `%s`", mtype.toChars());
+            return error();
+        }
+        return t;
+    }
+
     Type visitTraits(TypeTraits mtype)
     {
         if (mtype.ty == Terror)
@@ -1999,6 +2014,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         case Tident:     return visitIdentifier(cast(TypeIdentifier)type);
         case Tinstance:  return visitInstance(cast(TypeInstance)type);
         case Ttypeof:    return visitTypeof(cast(TypeTypeof)type);
+        case Ttotype:    return visitTotype(cast(TypeTotype)type);
         case Ttraits:    return visitTraits(cast(TypeTraits)type);
         case Treturn:    return visitReturn(cast(TypeReturn)type);
         case Tstruct:    return visitStruct(cast(TypeStruct)type);

--- a/test/compilable/totype.d
+++ b/test/compilable/totype.d
@@ -1,0 +1,17 @@
+/* TEST_OUTPUT:
+---
+i int
+d double
+Pi int*
+---
+*/
+
+pragma(msg, 1.mangleof, " ", __totype(1.mangleof));
+pragma(msg, (1.0).mangleof, " ", __totype((1.0).mangleof));
+pragma(msg, (int*).mangleof, " ", __totype((int*).mangleof));
+
+static assert(is(__totype(1.mangleof) == int));
+static assert(is(__totype((1.0).mangleof) == double));
+static assert(is(__totype((int*).mangleof) == int*));
+
+


### PR DESCRIPTION
This adds a new `Type` construct:
```
__totype("i") x;
```
where `__totype` takes as its argument a string that is a mangled type, and produces the corresponding type (in this case `int`), which can be used where-ever a `Type` is used.

This, in effect, closes the circle where `.mangleof` produces a string literal representing the type, and `__typeof` correspondingly converts the string back into a type. It's an obvious (in retrospect) building block in D's metaprogramming.

What's it good for? Quite simply, it enables a type to be treated as an expression, along with everything an expression can do. Being a compile-time construct, the expression handed to it is fully evaluated by CTFE. It has the potential to completely obsolete `typeid` and all the compiler magic that comes with it, i.e. a major simplification and a big boost in metaprogramming power.

This is a prototype for experimenting and for proof of concept. It's kinda shocking how little code is required for it.