### PR TITLE
dtoh: Support tuple members/parameters/variables

### DIFF
--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -628,6 +628,11 @@ public:
 
         visited[cast(void*)vd] = true;
 
+        // Tuple field are expanded into multiple VarDeclarations
+        // (we'll visit them later)
+        if (vd.type && vd.type.isTypeTuple())
+            return;
+
         if (vd.type == AST.Type.tsize_t)
             origType = &vd.originalType;
         scope(exit) origType = null;

--- a/test/dshell/extra-files/cpp_header_gen/app.cpp
+++ b/test/dshell/extra-files/cpp_header_gen/app.cpp
@@ -38,5 +38,16 @@ int main()
     S2 s2;
     s2.s = c->s;
 
+    WithTuple wt = createTuple();
+    // printf("\n(%d, %f)\n\n", wt.__memberTuple_field_0, wt.__memberTuple_field_1);
+    assert(wt.__memberTuple_field_0 == 1);
+    assert(wt.__memberTuple_field_1 == 2.0);
+
+    // printf("\n(%d, %f)\n\n", __globalTuple_field_0, __globalTuple_field_1);
+    assert(__globalTuple_field_0 == 3);
+    assert(__globalTuple_field_1 == 4.0);
+
+    tupleFunction(5, 6.0);
+
     return 0;
 }

--- a/test/dshell/extra-files/cpp_header_gen/library.d
+++ b/test/dshell/extra-files/cpp_header_gen/library.d
@@ -89,3 +89,23 @@ static if (true)
         S s;
     }
 }
+
+alias AliasSeq(T...) = T;
+
+__gshared AliasSeq!(int, double) globalTuple = AliasSeq!(3, 4.0);
+
+void tupleFunction(AliasSeq!(int, double) argTuple)
+{
+    assert(argTuple[0] == 5);
+    assert(argTuple[1] == 6.0);
+}
+
+struct WithTuple
+{
+    AliasSeq!(int, double) memberTuple;
+}
+
+WithTuple createTuple()
+{
+    return WithTuple(1, 2.0);
+}


### PR DESCRIPTION
Emit all tuple members into the header file instead of causing an assertion failure.

Not really fond of exposing internal names like `__globalTuple_field_0` but generating nicer names seems to  be pretty akward even for struct members (would need to manage more "global" state in the visitor) with little benefit.