### PR TITLE
build.d: Add `test` target to run the test suite

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -442,7 +442,7 @@ alias dmdDefault = makeRule!((builder, rule) => builder
     .deps([dmdExe(null, null, null), dmdConf])
 );
 
-/// Run's the test suite using `run.d`
+/// Run's the test suite (unittests & `run.d`)
 alias runTests = makeRule!((testBuilder, testRule)
 {
     // Precompiles the test runner
@@ -456,7 +456,7 @@ alias runTests = makeRule!((testBuilder, testRule)
         .name("test")
         .description("Run the test suite using test/run.d")
         .msg("(RUN) TEST")
-        .deps([dmdDefault, runner])
+        .deps([dmdDefault, runDmdUnittest, runner])
         .commandFunction({
             // Use spawnProcess to avoid output redirection for `command`s
             const scope cmd = [ runner.targets[0], "-j" ~ jobs.to!string ];

--- a/src/build.d
+++ b/src/build.d
@@ -22,9 +22,12 @@ import std.parallelism : TaskPool, totalCPUs;
 const thisBuildScript = __FILE_FULL_PATH__.buildNormalizedPath;
 const srcDir = thisBuildScript.dirName;
 const dmdRepo = srcDir.dirName;
+const testDir = dmdRepo.buildPath("test");
+
 shared bool verbose; // output verbose logging
 shared bool force; // always build everything (ignores timestamp checking)
 shared bool dryRun; /// dont execute targets, just print command to be executed
+__gshared int jobs; // Number of jobs to run in parallel
 
 __gshared string[string] env;
 __gshared string[][string] flags;
@@ -38,6 +41,7 @@ immutable rootRules = [
     &runDmdUnittest,
     &clean,
     &checkwhitespace,
+    &runTests,
     &buildFrontendHeaders,
     &runCxxHeadersTest,
     &runCxxUnittest,
@@ -72,7 +76,7 @@ int main(string[] args)
 
 void runMain(string[] args)
 {
-    int jobs = totalCPUs;
+    jobs = totalCPUs;
     bool calledFromMake = false;
     auto res = getopt(args,
         "j|jobs", "Specifies the number of jobs (commands) to run simultaneously (default: %d)".format(totalCPUs), &jobs,
@@ -437,6 +441,30 @@ alias dmdDefault = makeRule!((builder, rule) => builder
     .description("Build dmd")
     .deps([dmdExe(null, null, null), dmdConf])
 );
+
+/// Run's the test suite using `run.d`
+alias runTests = makeRule!((testBuilder, testRule)
+{
+    // Precompiles the test runner
+    alias runner = methodInit!(BuildRule, (rundBuilder, rundRule) => rundBuilder
+        .msg("(DMD) RUN.D")
+        .sources([ testDir.buildPath( "run.d") ])
+        .target(env["GENERATED"].buildPath("run".exeName))
+        .command([ env["HOST_DMD"], "-of=" ~ rundRule.target, "-i", "-I" ~ testDir] ~ rundRule.sources));
+
+    testBuilder
+        .name("test")
+        .description("Run the test suite using test/run.d")
+        .msg("(RUN) TEST")
+        .deps([dmdDefault, runner])
+        .commandFunction({
+            // Use spawnProcess to avoid output redirection for `command`s
+            const scope cmd = [ runner.targets[0], "-j" ~ jobs.to!string ];
+            log("%-(%s %)", cmd);
+            if (spawnProcess(cmd, null, Config.init, testDir).wait())
+                abortBuild("Tests failed!");
+        });
+});
 
 /// BuildRule to run the DMD unittest executable.
 alias runDmdUnittest = makeRule!((builder, rule) {


### PR DESCRIPTION
Calling `./build.d test` will now build dmd and run the test suite as done for the makefile.