### PR TITLE
rename CompileExp to MixinExp

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -5559,13 +5559,13 @@ struct ASTBase
         }
     }
 
-    extern (C++) final class CompileExp : Expression
+    extern (C++) final class MixinExp : Expression
     {
         Expressions* exps;
 
         extern (D) this(const ref Loc loc, Expressions* exps)
         {
-            super(loc, TOK.mixin_, __traits(classInstanceSize, CompileExp));
+            super(loc, TOK.mixin_, __traits(classInstanceSize, MixinExp));
             this.exps = exps;
         }
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1691,7 +1691,7 @@ extern (C++) abstract class Expression : ASTNode
         inout(TraitsExp)    isTraitsExp() { return op == TOK.traits ? cast(typeof(return))this : null; }
         inout(HaltExp)      isHaltExp() { return op == TOK.halt ? cast(typeof(return))this : null; }
         inout(IsExp)        isExp() { return op == TOK.is_ ? cast(typeof(return))this : null; }
-        inout(CompileExp)   isCompileExp() { return op == TOK.mixin_ ? cast(typeof(return))this : null; }
+        inout(MixinExp)     isMixinExp() { return op == TOK.mixin_ ? cast(typeof(return))this : null; }
         inout(ImportExp)    isImportExp() { return op == TOK.import_ ? cast(typeof(return))this : null; }
         inout(AssertExp)    isAssertExp() { return op == TOK.assert_ ? cast(typeof(return))this : null; }
         inout(DotIdExp)     isDotIdExp() { return op == TOK.dotIdentifier ? cast(typeof(return))this : null; }
@@ -4613,19 +4613,19 @@ extern (C++) class BinAssignExp : BinExp
 /***********************************************************
  * https://dlang.org/spec/expression.html#mixin_expressions
  */
-extern (C++) final class CompileExp : Expression
+extern (C++) final class MixinExp : Expression
 {
     Expressions* exps;
 
     extern (D) this(const ref Loc loc, Expressions* exps)
     {
-        super(loc, TOK.mixin_, __traits(classInstanceSize, CompileExp));
+        super(loc, TOK.mixin_, __traits(classInstanceSize, MixinExp));
         this.exps = exps;
     }
 
     override Expression syntaxCopy()
     {
-        return new CompileExp(loc, arraySyntaxCopy(exps));
+        return new MixinExp(loc, arraySyntaxCopy(exps));
     }
 
     override bool equals(const RootObject o) const
@@ -4635,7 +4635,7 @@ extern (C++) final class CompileExp : Expression
         auto e = o.isExpression();
         if (!e)
             return false;
-        if (auto ce = e.isCompileExp())
+        if (auto ce = e.isMixinExp())
         {
             if (exps.dim != ce.exps.dim)
                 return false;

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -145,7 +145,7 @@ public:
     TraitsExp* isTraitsExp();
     HaltExp* isHaltExp();
     IsExp* isExp();
-    CompileExp* isCompileExp();
+    MixinExp* isMixinExp();
     ImportExp* isImportExp();
     AssertExp* isAssertExp();
     DotIdExp* isDotIdExp();
@@ -706,7 +706,7 @@ public:
 
 /****************************************************************/
 
-class CompileExp : public UnaExp
+class MixinExp : public UnaExp
 {
 public:
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5826,7 +5826,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         result = (cast(BinExp)e).reorderSettingAAElem(sc);
     }
 
-    private Expression compileIt(CompileExp exp)
+    private Expression compileIt(MixinExp exp)
     {
         OutBuffer buf;
         if (expressionsToString(buf, sc, exp.exps))
@@ -5851,14 +5851,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         return e;
     }
 
-    override void visit(CompileExp exp)
+    override void visit(MixinExp exp)
     {
         /* https://dlang.org/spec/expression.html#mixin_expressions
          */
 
         static if (LOGSEMANTIC)
         {
-            printf("CompileExp::semantic('%s')\n", exp.toChars());
+            printf("MixinExp::semantic('%s')\n", exp.toChars());
         }
 
         auto e = compileIt(exp);
@@ -6014,7 +6014,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
 
             // if the assert condition is a mixin expression, try to compile it
-            if (auto ce = exp.e1.isCompileExp())
+            if (auto ce = exp.e1.isMixinExp())
             {
                 if (auto e1 = compileIt(ce))
                     exp.e1 = e1;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -483,7 +483,7 @@ class TypeidExp;
 class TraitsExp;
 class HaltExp;
 class IsExp;
-class CompileExp;
+class MixinExp;
 class ImportExp;
 class AssertExp;
 class DotIdExp;
@@ -1021,7 +1021,7 @@ public:
     TraitsExp* isTraitsExp();
     HaltExp* isHaltExp();
     IsExp* isExp();
-    CompileExp* isCompileExp();
+    MixinExp* isMixinExp();
     ImportExp* isImportExp();
     AssertExp* isAssertExp();
     DotIdExp* isDotIdExp();
@@ -1493,7 +1493,7 @@ public:
     virtual void visit(NewExp* e);
     virtual void visit(AssocArrayLiteralExp* e);
     virtual void visit(ArrayLiteralExp* e);
-    virtual void visit(CompileExp* e);
+    virtual void visit(MixinExp* e);
     virtual void visit(FuncExp* e);
     virtual void visit(IntervalExp* e);
     virtual void visit(TypeExp* e);
@@ -4026,7 +4026,7 @@ public:
     void accept(Visitor* v);
 };
 
-class CompileExp : public Expression
+class MixinExp : public Expression
 {
 public:
     Array<Expression*>* exps;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2307,7 +2307,7 @@ public:
         expToBuffer(commaExtract, precedence[exp.op], buf, hgs);
     }
 
-    override void visit(CompileExp e)
+    override void visit(MixinExp e)
     {
         buf.writestring("mixin(");
         argsToBuffer(e.exps, buf, hgs, null);

--- a/src/dmd/lambdacomp.d
+++ b/src/dmd/lambdacomp.d
@@ -466,7 +466,7 @@ public:
 
     override void visit(ArrayLiteralExp) { buf.setsize(0); }
     override void visit(AssocArrayLiteralExp) { buf.setsize(0); }
-    override void visit(CompileExp) { buf.setsize(0); }
+    override void visit(MixinExp) { buf.setsize(0); }
     override void visit(ComplexExp) { buf.setsize(0); }
     override void visit(DeclarationExp) { buf.setsize(0); }
     override void visit(DefaultInitExp) { buf.setsize(0); }

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -5749,7 +5749,7 @@ final class Parser(AST) : Lexer
                     check(TOK.semicolon);
                     if (e.op == TOK.mixin_)
                     {
-                        AST.CompileExp cpe = cast(AST.CompileExp)e;
+                        AST.MixinExp cpe = cast(AST.MixinExp)e;
                         s = new AST.CompileStatement(loc, cpe.exps);
                     }
                     else
@@ -8197,7 +8197,7 @@ final class Parser(AST) : Lexer
                 if (token.value != TOK.leftParentheses)
                     error("found `%s` when expecting `%s` following %s", token.toChars(), Token.toChars(TOK.leftParentheses), "`mixin`".ptr);
                 auto exps = parseArguments();
-                e = new AST.CompileExp(loc, exps);
+                e = new AST.MixinExp(loc, exps);
                 break;
             }
         case TOK.import_:

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -182,7 +182,7 @@ public:
     void visit(AST.NewExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.AssocArrayLiteralExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.ArrayLiteralExp e) { visit(cast(AST.Expression)e); }
-    void visit(AST.CompileExp e) { visit(cast(AST.Expression)e); }
+    void visit(AST.MixinExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.FuncExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.IntervalExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.TypeExp e) { visit(cast(AST.Expression)e); }

--- a/src/dmd/strictvisitor.d
+++ b/src/dmd/strictvisitor.d
@@ -167,7 +167,7 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.CallExp) { assert(0); }
     override void visit(AST.DotIdExp) { assert(0); }
     override void visit(AST.AssertExp) { assert(0); }
-    override void visit(AST.CompileExp) { assert(0); }
+    override void visit(AST.MixinExp) { assert(0); }
     override void visit(AST.ImportExp) { assert(0); }
     override void visit(AST.DotTemplateInstanceExp) { assert(0); }
     override void visit(AST.ArrayExp) { assert(0); }

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -1002,9 +1002,9 @@ package mixin template ParseVisitMethods(AST)
         e.e2.accept(this);
     }
 
-    override void visit(AST.CompileExp e)
+    override void visit(AST.MixinExp e)
     {
-        //printf("Visiting CompileExp\n");
+        //printf("Visiting MixinExp\n");
         visitArgs(e.exps);
     }
 

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -211,7 +211,7 @@ class IsExp;
 class UnaExp;
 class BinExp;
 class BinAssignExp;
-class CompileExp;
+class MixinExp;
 class ImportExp;
 class AssertExp;
 class DotIdExp;
@@ -466,7 +466,7 @@ public:
     virtual void visit(NewExp *e) { visit((Expression *)e); }
     virtual void visit(AssocArrayLiteralExp *e) { visit((Expression *)e); }
     virtual void visit(ArrayLiteralExp *e) { visit((Expression *)e); }
-    virtual void visit(CompileExp *e) { visit((Expression *)e); }
+    virtual void visit(MixinExp *e) { visit((Expression *)e); }
     virtual void visit(FuncExp *e) { visit((Expression *)e); }
     virtual void visit(IntervalExp *e) { visit((Expression *)e); }
     virtual void visit(TypeExp *e) { visit((Expression *)e); }


### PR DESCRIPTION
I'm tired of the misleading name. Corresponds to `TypeMixin`.