### PR TITLE
Deprecate alias this for classes

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -12488,6 +12488,11 @@ Expression resolveAliasThis(Scope* sc, Expression e, bool gag = false)
     {
         if (ad.aliasthis)
         {
+            if (ad.isClassDeclaration)
+            {
+                error(ad.aliasthis.loc, "alias this is deprecated for classes");
+            }
+
             uint olderrors = gag ? global.startGagging() : 0;
             Loc loc = e.loc;
             Type tthis = (e.op == TOK.type ? e.type : null);


### PR DESCRIPTION
This is just a test to see how widespread _alias this_ is used in classes, and perhaps bring to light code which should be improved.  This PR should not be merged.

See thread starting at https://forum.dlang.org/post/vggskphkqxtriqnavmnf@forum.dlang.org for context.

> Potential solution for implementing multiple alias this:
>-------------------------------------------------------
> Deprecate _alias this_ for classes, and implement _multiple alias this_ for structs.  That will give users the composition feature they need, and in addition, because structs cannot inherit, it removes the complexity @WalterBright spoke of.