### PR TITLE
refactor Type.resolve()

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -6623,7 +6623,7 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
             sc2.stc |= ds.storage_class & (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.shared_ | STC.disable);
         }
         ds.type = ds.type.addSTC(ds.storage_class);
-        ds.type.resolve(ds.loc, sc2, &e, &t, &s);
+        ds.type.resolve(ds.loc, sc2, e, t, s);
         if (sc2 != sc)
             sc2.pop();
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1983,11 +1983,11 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                                  * instantiation scope 'sc' and the one
                                  * belonging to the template itself. */
                                 sco = sc;
-                                taa.index.resolve(instLoc, sco, &e, &t, &s);
+                                taa.index.resolve(instLoc, sco, e, t, s);
                                 if (!e)
                                 {
                                     sco = paramscope;
-                                    taa.index.resolve(instLoc, sco, &e, &t, &s);
+                                    taa.index.resolve(instLoc, sco, e, t, s);
                                 }
                                 global.endGagging(errors);
 
@@ -3847,7 +3847,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         Expression e;
                         Type tx;
                         Dsymbol s;
-                        taa.index.resolve(Loc.initial, sc, &e, &tx, &s);
+                        taa.index.resolve(Loc.initial, sc, e, tx, s);
                         edim = s ? getValue(s) : getValue(e);
                     }
                 }
@@ -4058,7 +4058,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         Type tx;
                         Expression e;
                         Dsymbol s;
-                        tid.resolve(tp.loc, sc, &e, &tx, &s);
+                        tid.resolve(tp.loc, sc, e, tx, s);
                         Pool!TypeIdentifier.dispose(tid);
                         if (tx)
                         {
@@ -4242,7 +4242,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     L1:
                         if (j == IDX_NOTFOUND)
                         {
-                            t2.resolve((cast(TypeIdentifier)t2).loc, sc, &e2, &t2, &s2);
+                            t2.resolve((cast(TypeIdentifier)t2).loc, sc, e2, t2, s2);
                             if (e2)
                                 goto Le;
                             goto Lnomatch;
@@ -4261,7 +4261,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         j = templateParameterLookup(t2, parameters);
                         if (j == IDX_NOTFOUND)
                         {
-                            t2.resolve((cast(TypeIdentifier)t2).loc, sc, &e2, &t2, &s2);
+                            t2.resolve((cast(TypeIdentifier)t2).loc, sc, e2, t2, s2);
                             if (s2)
                                 goto Ls;
                             goto Lnomatch;
@@ -6581,7 +6581,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 //printf("type %s\n", ta.toChars());
 
                 // It might really be an Expression or an Alias
-                ta.resolve(loc, sc, &ea, &ta, &sa, (flags & 1) != 0);
+                ta.resolve(loc, sc, ea, ta, sa, (flags & 1) != 0);
                 if (ea)
                     goto Lexpr;
                 if (sa)
@@ -7642,7 +7642,7 @@ extern (C++) final class TemplateMixin : TemplateInstance
             Expression e;
             Type t;
             Dsymbol s;
-            tqual.resolve(loc, sc, &e, &t, &s);
+            tqual.resolve(loc, sc, e, t, s);
             if (!s)
             {
                 error("is not defined");

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3215,7 +3215,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type t;
         Dsymbol s;
 
-        dmd.typesem.resolve(exp.type, exp.loc, sc, &e, &t, &s, true);
+        dmd.typesem.resolve(exp.type, exp.loc, sc, e, t, s, true);
         if (e)
         {
             // `(Type)` is actually `(var)` so if `(var)` is a member requiring `this`
@@ -5275,7 +5275,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (ta)
         {
-            dmd.typesem.resolve(ta, exp.loc, sc, &ea, &ta, &sa, true);
+            dmd.typesem.resolve(ta, exp.loc, sc, ea, ta, sa, true);
         }
 
         if (ea)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5390,7 +5390,7 @@ extern (C++) final class TypeTraits : Type
         Type t;
         Expression e;
         Dsymbol s;
-        resolve(this, loc, sc, &e, &t, &s);
+        resolve(this, loc, sc, e, t, s);
         if (t && t.ty != Terror)
             s = t.toDsymbol(sc);
         else if (e)
@@ -5442,7 +5442,7 @@ extern (C++) final class TypeMixin : Type
         Type t;
         Expression e;
         Dsymbol s;
-        resolve(this, loc, sc, &e, &t, &s);
+        resolve(this, loc, sc, e, t, s);
         if (t)
             s = t.toDsymbol(sc);
         else if (e)
@@ -5578,7 +5578,7 @@ extern (C++) final class TypeIdentifier : TypeQualified
         Type t;
         Expression e;
         Dsymbol s;
-        resolve(this, loc, sc, &e, &t, &s);
+        resolve(this, loc, sc, e, t, s);
         if (t && t.ty != Tident)
             s = t.toDsymbol(sc);
         if (e)
@@ -5626,7 +5626,7 @@ extern (C++) final class TypeInstance : TypeQualified
         Expression e;
         Dsymbol s;
         //printf("TypeInstance::semantic(%s)\n", toChars());
-        resolve(this, loc, sc, &e, &t, &s);
+        resolve(this, loc, sc, e, t, s);
         if (t && t.ty != Tinstance)
             s = t.toDsymbol(sc);
         return s;
@@ -5671,7 +5671,7 @@ extern (C++) final class TypeTypeof : TypeQualified
         Expression e;
         Type t;
         Dsymbol s;
-        resolve(this, loc, sc, &e, &t, &s);
+        resolve(this, loc, sc, e, t, s);
         return s;
     }
 
@@ -5716,7 +5716,7 @@ extern (C++) final class TypeReturn : TypeQualified
         Expression e;
         Type t;
         Dsymbol s;
-        resolve(this, loc, sc, &e, &t, &s);
+        resolve(this, loc, sc, e, t, s);
         return s;
     }
 

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1729,7 +1729,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 if (!ex && t)
                 {
                     Dsymbol s;
-                    t.resolve(e.loc, sc2, &ex, &t, &s);
+                    t.resolve(e.loc, sc2, ex, t, s);
                     if (t)
                     {
                         t.typeSemantic(e.loc, sc2);


### PR DESCRIPTION
Replace raw pointer parameters to `Type.resolve()` with `out` parameters.