### PR TITLE
do not cache instances of recursive templates

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -2491,6 +2491,8 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
     extern (D) void removeInstance(TemplateInstance ti)
     {
         //printf("removeInstance() %s\n", ti.toChars());
+        if (!ti)
+            return;
         auto tibox = TemplateInstanceBox(ti);
         debug (FindExistingInstance) ++nRemoved;
         instances.remove(tibox);


### PR DESCRIPTION
The idea is that if a template recursively calls itself, the only instance that needs to be cached in `TemplateDeclaration.instances` is the first one.