### PR TITLE
Use run-time allocated mutexes for plain `synchronized` statements

### DIFF
--- a/changelog/runtime-synchronized.dd
+++ b/changelog/runtime-synchronized.dd
@@ -1,0 +1,28 @@
+Plain `synchronized` statements now use run-time allocated mutexes.
+
+Synchronized statements have two forms, `synchronized` and `synchronized(exp)`.
+When there is no expression argument, a global mutex is created using a static
+buffer big enough to store the platform dependant critical section type and a
+pointer field.
+
+Example:
+```
+void main()
+{
+    synchronized {
+        // __gshared byte[40 + 8] __critsec;
+        // _d_criticalenter(&__critsec[0]);
+        // scope(exit) _d_criticalexit(&__critsec[0]);
+        (cast() counter) += 1;
+    }
+}
+```
+
+This implementation suffers from a couple deficiencies. Neither the size nor
+alignment of the `critsec` buffer are obtained from the OS critical section
+type defined in druntime. As a result, if the size allocated by the compiler is
+too small, or the platform has strict alignment requirements, then the program
+run-time will crash on entering the synchronized statement.
+
+This code will now call a new implementation that allocates the critical
+section lazily at run-time, moving all logic out of the compiler to druntime.

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1764,11 +1764,9 @@ struct TargetC
 {
     uint32_t longsize;
     uint32_t long_doublesize;
-    uint32_t criticalSectionSize;
     TargetC() :
         longsize(),
-        long_doublesize(),
-        criticalSectionSize()
+        long_doublesize()
     {
     }
 };
@@ -6722,7 +6720,6 @@ public:
     void deinitialize();
     uint32_t alignsize(Type* type);
     uint32_t fieldalign(Type* type);
-    uint32_t critsecsize();
     Type* va_listType(const Loc& loc, Scope* sc);
     int32_t isVectorTypeSupported(int32_t sz, Type* type);
     bool isVectorOpSupported(Type* type, uint8_t op, Type* t2 = nullptr);

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -303,7 +303,7 @@ immutable Msgtable[] msgtable =
     { "aaRehash", "_aaRehash" },
     { "monitorenter", "_d_monitorenter" },
     { "monitorexit", "_d_monitorexit" },
-    { "criticalenter", "_d_criticalenter" },
+    { "criticalenter", "_d_criticalenter2" },
     { "criticalexit", "_d_criticalexit" },
     { "__ArrayPostblit" },
     { "__ArrayDtor" },

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -254,16 +254,6 @@ extern (C++) struct Target
     }
 
     /**
-     * Size of the target OS critical section.
-     * Returns:
-     *      size in bytes
-     */
-    extern (C++) uint critsecsize()
-    {
-        return c.criticalSectionSize;
-    }
-
-    /**
      * Type for the `va_list` type for the target; e.g., required for `_argptr`
      * declarations.
      * NOTE: For Posix/x86_64 this returns the type which will really
@@ -931,7 +921,6 @@ struct TargetC
 {
     uint longsize;            /// size of a C `long` or `unsigned long` type
     uint long_doublesize;     /// size of a C `long double`
-    uint criticalSectionSize; /// size of os critical section
 
     extern (D) void initialize(ref const Param params, ref const Target target)
     {
@@ -954,51 +943,6 @@ struct TargetC
             long_doublesize = 8;
         else
             long_doublesize = target.realsize;
-
-        criticalSectionSize = getCriticalSectionSize(params);
-    }
-
-    private static uint getCriticalSectionSize(ref const Param params) pure
-    {
-        if (params.targetOS == TargetOS.Windows)
-        {
-            // sizeof(CRITICAL_SECTION) for Windows.
-            return params.isLP64 ? 40 : 24;
-        }
-        else if (params.targetOS == TargetOS.linux)
-        {
-            // sizeof(pthread_mutex_t) for Linux.
-            if (params.is64bit)
-                return params.isLP64 ? 40 : 32;
-            else
-                return params.isLP64 ? 40 : 24;
-        }
-        else if (params.targetOS == TargetOS.FreeBSD)
-        {
-            // sizeof(pthread_mutex_t) for FreeBSD.
-            return params.isLP64 ? 8 : 4;
-        }
-        else if (params.targetOS == TargetOS.OpenBSD)
-        {
-            // sizeof(pthread_mutex_t) for OpenBSD.
-            return params.isLP64 ? 8 : 4;
-        }
-        else if (params.targetOS == TargetOS.DragonFlyBSD)
-        {
-            // sizeof(pthread_mutex_t) for DragonFlyBSD.
-            return params.isLP64 ? 8 : 4;
-        }
-        else if (params.targetOS == TargetOS.OSX)
-        {
-            // sizeof(pthread_mutex_t) for OSX.
-            return params.isLP64 ? 64 : 44;
-        }
-        else if (params.targetOS == TargetOS.Solaris)
-        {
-            // sizeof(pthread_mutex_t) for Solaris.
-            return 24;
-        }
-        assert(0);
     }
 }
 

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -29,7 +29,6 @@ struct TargetC
 {
     unsigned longsize;            // size of a C 'long' or 'unsigned long' type
     unsigned long_doublesize;     // size of a C 'long double'
-    unsigned criticalSectionSize; // size of os critical section
 };
 
 struct TargetCPP
@@ -102,7 +101,6 @@ public:
     // Type sizes and support.
     unsigned alignsize(Type *type);
     unsigned fieldalign(Type *type);
-    unsigned critsecsize();
     Type *va_listType(const Loc &loc, Scope *sc);  // get type of va_list
     int isVectorTypeSupported(int sz, Type *type);
     bool isVectorOpSupported(Type *type, TOK op, Type *t2 = NULL);


### PR DESCRIPTION
Synchronized statements have two forms, `synchronized` and `synchronized(exp)`.
When there is no expression argument, a global mutex is created using a static
buffer big enough to store the platform dependant critical section type and a
pointer field.

Example:
```
void main()
{
    synchronized {
        // __gshared byte[40 + 8] __critsec;
        // _d_criticalenter(&__critsec[0]);
        // scope(exit) _d_criticalexit(&__critsec[0]);
        (cast() counter) += 1;
    }
}
```

This implementation suffers from a couple deficiencies. Neither the size nor
alignment of the `critsec` buffer are obtained from the OS critical section
type defined in druntime. As a result, if the size allocated by the compiler is
too small, or the platform has strict alignment requirements, then the program
run-time will crash on entering the synchronized statement.

This code will now call a new implementation that allocates the critical
section lazily at run-time, moving all logic out of the compiler to druntime.