### PR TITLE
build.d: Don't needlessly rebuilt cxx-headers

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1698,6 +1698,11 @@ class BuildRule
             {
                 command.run;
             }
+            else
+                // Do not automatically return true if the target has neither
+                // command nor command function (e.g. dmdDefault) to avoid
+                // unecessary rebuilds
+                return depUpdated;
         }
 
         return true;


### PR DESCRIPTION
Targets aggregrating other targets as dependencies were previously considered as rebuilt even though they didn't do any work.

This change propagate the status from the dependencies if a target has neither `command` nor `commandFunction`.