### PR TITLE
dtoh: Don't generate default constructors for unions

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -9,6 +9,7 @@ experimental C++ header generator:
 - Tuple members/parameters/variables are emitted as individual variables
   using the compiler internal names instaed of causing an assertion failure.
 - Interfaces are now emitted as base classes.
+- No auto-generated default constructor for unions
 
 Note: The header generator is still considerer experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -960,7 +960,7 @@ public:
         buf.level--;
         adparent = save;
         // Generate default ctor
-        if (!sd.noDefaultCtor)
+        if (!sd.noDefaultCtor && !sd.isUnionDeclaration())
         {
             buf.level++;
             buf.printf("%s()", sd.ident.toChars());

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3572,9 +3572,6 @@ struct UnionExp
         char indexexp[82LLU];
         char sliceexp[83LLU];
         char vectorexp[69LLU];
-        __AnonStruct__u()
-        {
-        }
     };
     #pragma pack(pop)
 

--- a/test/compilable/dtoh_StructDeclaration.d
+++ b/test/compilable/dtoh_StructDeclaration.d
@@ -121,6 +121,12 @@ struct A
     {
     }
 };
+
+union U
+{
+    int32_t i;
+    char c;
+};
 ---
 */
 
@@ -205,4 +211,10 @@ extern (C++) struct A
 
     extern(C++) class C;
 
+}
+
+extern(C++) union U
+{
+    int i;
+    char c;
 }

--- a/test/dshell/extra-files/cpp_header_gen/library.d
+++ b/test/dshell/extra-files/cpp_header_gen/library.d
@@ -59,8 +59,7 @@ struct S
 
 union U
 {
-    // int a;   // FIXME: Generates struct constructor
-                // U() : a(), b() {}
+    int a;
     bool b;
 }
 


### PR DESCRIPTION
Default ctors were accidentally emitted because unions are handled as `StructDeclaration`s.