### PR TITLE
Issue 21295: Add test for symbol lookup/resolve in compilation broken

### DIFF
--- a/test/fail_compilation/imports/issue21295ast_node.d
+++ b/test/fail_compilation/imports/issue21295ast_node.d
@@ -1,0 +1,5 @@
+module imports.issue21295ast_node;
+import imports.issue21295visitor : Visitor;
+class ASTNode {
+    void accept(Visitor);
+}

--- a/test/fail_compilation/imports/issue21295astcodegen.d
+++ b/test/fail_compilation/imports/issue21295astcodegen.d
@@ -1,0 +1,4 @@
+module imports.issue21295astcodegen;
+struct ASTCodegen {
+    import imports.issue21295dtemplate;
+}

--- a/test/fail_compilation/imports/issue21295dtemplate.d
+++ b/test/fail_compilation/imports/issue21295dtemplate.d
@@ -1,0 +1,3 @@
+module imports.issue21295dtemplate;
+import imports.issue21295ast_node;
+class TemplateParameter : ASTNode { }

--- a/test/fail_compilation/imports/issue21295visitor.d
+++ b/test/fail_compilation/imports/issue21295visitor.d
@@ -1,0 +1,3 @@
+module imports.issue21295visitor;
+import imports.issue21295astcodegen;
+class Visitor { }

--- a/test/fail_compilation/issue21295.d
+++ b/test/fail_compilation/issue21295.d
@@ -1,0 +1,8 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/issue21295.d(8): Error: undefined identifier `Visitor`
+---
+*/
+import imports.issue21295ast_node;
+Visitor should_fail;


### PR DESCRIPTION
This bug affects older versions of dmd, and was discovered to be present in the compiler codebase.  dmd-cxx backport coming shortly...