### PR TITLE
[dmd-cxx] Fix case codes to match isVectorTypeSupported

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3824,11 +3824,11 @@ Type *TypeVector::semantic(Loc loc, Scope *sc)
     case 1: // no support at all
         error(loc, "SIMD vector types not supported on this platform");
         return terror;
-    case 2: // invalid size
-        error(loc, "%d byte vector type %s is not supported on this platform", sz, toChars());
-        return terror;
-    case 3: // invalid base type
+    case 2: // invalid base type
         error(loc, "vector type %s is not supported on this platform", toChars());
+        return terror;
+    case 3: // invalid size
+        error(loc, "%d byte vector type %s is not supported on this platform", sz, toChars());
         return terror;
     default:
         assert(0);


### PR DESCRIPTION
Invalid base and invalid size errors were the wrong way round.