### PR TITLE
[dmd-cxx] fix Issue 21295: Add test for symbol lookup/resolve in compilation broken

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -340,6 +340,13 @@ void AliasDeclaration::semantic(Scope *sc)
 void AliasDeclaration::aliasSemantic(Scope *sc)
 {
     //printf("AliasDeclaration::semantic() %s\n", toChars());
+
+    // as AliasDeclaration::semantic, in case we're called first.
+    // see https://issues.dlang.org/show_bug.cgi?id=21001
+    storage_class |= sc->stc & STCdeprecated;
+    protection = sc->protection;
+    userAttribDecl = sc->userAttribDecl;
+
     // TypeTraits needs to know if it's located in an AliasDeclaration
     sc->flags |= SCOPEalias;
 

--- a/test/fail_compilation/fail21001.d
+++ b/test/fail_compilation/fail21001.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21001.d(12): Error: undefined identifier `Alias`
+---
+*/
+
+module fail21001;
+
+import imports.fail21001b;
+
+void main() { Alias var; }

--- a/test/fail_compilation/imports/fail21001b.d
+++ b/test/fail_compilation/imports/fail21001b.d
@@ -1,0 +1,5 @@
+module imports.fail21001b;
+
+private struct S { Alias member; }
+
+private alias Alias = int;

--- a/test/fail_compilation/imports/issue21295ast_node.d
+++ b/test/fail_compilation/imports/issue21295ast_node.d
@@ -1,0 +1,5 @@
+module imports.issue21295ast_node;
+import imports.issue21295visitor : Visitor;
+class ASTNode {
+    void accept(Visitor);
+}

--- a/test/fail_compilation/imports/issue21295astcodegen.d
+++ b/test/fail_compilation/imports/issue21295astcodegen.d
@@ -1,0 +1,4 @@
+module imports.issue21295astcodegen;
+struct ASTCodegen {
+    import imports.issue21295dtemplate;
+}

--- a/test/fail_compilation/imports/issue21295dtemplate.d
+++ b/test/fail_compilation/imports/issue21295dtemplate.d
@@ -1,0 +1,3 @@
+module imports.issue21295dtemplate;
+import imports.issue21295ast_node;
+class TemplateParameter : ASTNode { }

--- a/test/fail_compilation/imports/issue21295visitor.d
+++ b/test/fail_compilation/imports/issue21295visitor.d
@@ -1,0 +1,3 @@
+module imports.issue21295visitor;
+import imports.issue21295astcodegen;
+class Visitor { }

--- a/test/fail_compilation/issue21295.d
+++ b/test/fail_compilation/issue21295.d
@@ -1,0 +1,9 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/issue21295.d(9): Deprecation: imports.issue21295ast_node.Visitor is not visible from module issue21295
+---
+*/
+import imports.issue21295ast_node;
+Visitor should_fail;


### PR DESCRIPTION
Strictly, this is related to good old issue 10378

In dmd mainline, this went from compilable -> fail_compilation due to an indirect bug fix.

In dmd-cxx, we're still in the deprecation transition phase for bug 10378, so we use `-de` is used in the test instead.