### PR TITLE
Fix issue 21203: Accept pragma(mangle) on aggregate types

### DIFF
--- a/changelog/pragma-mangle-aggregate.dd
+++ b/changelog/pragma-mangle-aggregate.dd
@@ -1,0 +1,43 @@
+`pragma(mangle)` can now be applied to aggregates
+
+The syntax is `pragma(mangle, str_or_decl [, str] ) declaration;` where `str_or_decl` is either:
+a string expression to substitute the name of `declaration`;
+or a `class`, `struct`, or `union` declaration or template instance to use instead of `declaration`s for mangling.
+If the optional second argument is present, use that as a name instead but keep the namespaces and template parameters of
+`str_or_decl` (if any).
+
+This enables binding with functions that take classes by value or reference and to classes that are D keywords.
+
+To bind C++'s `std::function` by value:
+---
+extern(C++, "std")
+{
+    template std_function(F)
+    {
+        pragma(mangle, "function")
+        class std_function
+        {
+            // member variables and functions
+        }
+    }
+}
+
+template ScopeClass(C , string name)
+{
+    enum ns = __traits(getCppNamespaces,C);
+    extern(C++, class) extern(C++,(ns))
+    {
+        pragma(mangle, C, name)
+        struct ScopeClass
+        {
+            char[__traits(classInstanceSize, C)] buffer;
+            // member variables and functions
+        }
+    }
+}
+
+alias FuncType = void function(int);
+alias RawFuncType = typeof(*FuncType.init);
+// Mangles as `void funk(std::function<void(int)> a)`
+extern(C++) void funk( ScopeClass!(std_function!(RawFuncType)),"function") a );
+---

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -70,6 +70,16 @@ enum ClassKind : ubyte
     objc,
 }
 
+/**
+ * If an aggregate has a pargma(mangle, ...) this holds the information
+ * to mangle.
+ */
+struct MangleOverride
+{
+    Dsymbol agg;   // The symbol to copy template parameters from (if any)
+    Identifier id; // the name to override the aggregate's with, defaults to agg.ident
+}
+
 /***********************************************************
  * Abstract aggregate as a common ancestor for Class- and StructDeclaration.
  */
@@ -88,6 +98,9 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     /// This information is used by the MSVC mangler
     /// Only valid for class and struct. TODO: Merge with ClassKind ?
     CPPMANGLE cppmangle;
+
+    /// overridden symbol with pragma(mangle, "...") if not null
+    MangleOverride* mangleOverride;
 
     /**
      * !=null if is nested

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -68,6 +68,12 @@ enum class ClassKind : uint8_t
   objc
 };
 
+struct MangleOverride
+{
+    Dsymbol *agg;
+    Identifier *id;
+};
+
 class AggregateDeclaration : public ScopeDsymbol
 {
 public:
@@ -81,6 +87,8 @@ public:
     ClassKind classKind;        // specifies the linkage type
     CPPMANGLE cppmangle;
 
+    // overridden symbol with pragma(mangle, "...")
+    MangleOverride *mangleOverride;
     /* !=NULL if is nested
      * pointing to the dsymbol that directly enclosing it.
      * 1. The function that enclosing it (nested struct and class)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -150,6 +150,7 @@ enum class CPPMANGLE : uint8_t
     asClass = 2u,
 };
 
+struct MangleOverride;
 class AliasThis;
 class Expression;
 class TypeTuple;
@@ -1634,6 +1635,7 @@ public:
     Dsymbol* deferred;
     ClassKind classKind;
     CPPMANGLE cppmangle;
+    MangleOverride* mangleOverride;
     Dsymbol* enclosing;
     VarDeclaration* vthis;
     VarDeclaration* vthis2;

--- a/test/compilable/issue21203.d
+++ b/test/compilable/issue21203.d
@@ -1,0 +1,207 @@
+
+template ScopeClass(C , string name = C.stringof)
+//if (is(C == class) && __traits(getLinkage, C) == "C++")
+{
+    //enum name = C.stringof;
+    enum ns = __traits(getCppNamespaces,C);
+    extern(C++, class)
+    {
+        extern(C++,(ns))
+        {
+            pragma(mangle, C, name)
+            struct ScopeClass
+            {
+                char[__traits(classInstanceSize, C)] buffer;
+                //... all the things ...
+            }
+        }
+    }
+}
+
+// Basic tests
+extern(C++)
+{
+    class MyClassA {}
+    void funa(ScopeClass!MyClassA);           // mangles MyClass
+    void funb(const ScopeClass!MyClassA);     // mangles const MyClass
+    void func(ref ScopeClass!MyClassA);       // mangles MyClass&
+    void fund(ref const ScopeClass!MyClassA); // mangles const MyClass&
+    void fune(const(ScopeClass!MyClassA)*);
+}
+
+version (Posix)
+{
+    static assert(funa.mangleof == "_Z4funa8MyClassA");
+    static assert(funb.mangleof == "_Z4funb8MyClassA");
+    static assert(func.mangleof == "_Z4funcR8MyClassA");
+    static assert(fund.mangleof == "_Z4fundRK8MyClassA");
+    static assert(fune.mangleof == "_Z4funePK8MyClassA");
+}
+else version (CppRuntime_Microsoft)
+{
+    static assert(funa.mangleof == "?funa@@YAXVMyClassA@@@Z");
+    static assert(funb.mangleof == "?funb@@YAXVMyClassA@@@Z");
+    static if (size_t.sizeof == ulong.sizeof)
+    {
+        static assert(func.mangleof == "?func@@YAXAEAVMyClassA@@@Z");
+        static assert(fund.mangleof == "?fund@@YAXAEBVMyClassA@@@Z");
+        static assert(fune.mangleof == "?fune@@YAXPEBVMyClassA@@@Z");
+    }
+    else
+    {
+        static assert(func.mangleof == "?func@@YAXAAVMyClassA@@@Z");
+        static assert(fund.mangleof == "?fund@@YAXABVMyClassA@@@Z");
+        static assert(fune.mangleof == "?fune@@YAXPBVMyClassA@@@Z");
+    }
+}
+
+//Basic tests with a namespace
+extern(C++, "ns")
+{
+    class MyClassB {}
+    void funf(ScopeClass!MyClassB);           // mangles MyClass
+    void fung(const ScopeClass!MyClassB);     // mangles const MyClass
+    void funh(ref ScopeClass!MyClassB);       // mangles MyClass&
+    void funi(ref const ScopeClass!MyClassB); // mangles const MyClass&
+    void funj(const(ScopeClass!MyClassB)*);
+}
+
+version (Posix)
+{
+    static assert(funf.mangleof == "_ZN2ns4funfENS_8MyClassBE");
+    static assert(fung.mangleof == "_ZN2ns4fungENS_8MyClassBE");
+    static assert(funh.mangleof == "_ZN2ns4funhERNS_8MyClassBE");
+    static assert(funi.mangleof == "_ZN2ns4funiERKNS_8MyClassBE");
+    static assert(funj.mangleof == "_ZN2ns4funjEPKNS_8MyClassBE");
+}
+else version (CppRuntime_Microsoft)
+{
+    static assert(funf.mangleof == "?funf@ns@@YAXVMyClassB@1@@Z");
+    static assert(fung.mangleof == "?fung@ns@@YAXVMyClassB@1@@Z");
+    static if (size_t.sizeof == ulong.sizeof)
+    {
+        static assert(funh.mangleof == "?funh@ns@@YAXAEAVMyClassB@1@@Z");
+        static assert(funi.mangleof == "?funi@ns@@YAXAEBVMyClassB@1@@Z");
+        static assert(funj.mangleof == "?funj@ns@@YAXPEBVMyClassB@1@@Z");
+    }
+    else
+    {
+        static assert(funh.mangleof == "?funh@ns@@YAXAAVMyClassB@1@@Z");
+        static assert(funi.mangleof == "?funi@ns@@YAXABVMyClassB@1@@Z");
+        static assert(funj.mangleof == "?funj@ns@@YAXPBVMyClassB@1@@Z");
+    }
+}
+
+//Templates
+extern(C++)
+{
+    void funTempl(T)();
+    class MyClassC {}
+    alias funTemplA = funTempl!(ScopeClass!MyClassC);
+    alias funTemplB = funTempl!(const ScopeClass!MyClassC);
+    alias funTemplC = funTempl!(const(ScopeClass!MyClassC)*);
+    // N.B funTempl!([const] ref ScopeClass!MyClassC) is not permissable in D
+}
+version (Posix)
+{
+    static assert(funTemplA.mangleof == "_Z8funTemplI8MyClassCEvv");
+    static assert(funTemplB.mangleof == "_Z8funTemplIK8MyClassCEvv");
+    static assert(funTemplC.mangleof == "_Z8funTemplIPK8MyClassCEvv");
+}
+else version (CppRuntime_Microsoft)
+{
+    static assert(funTemplA.mangleof == "??$funTempl@VMyClassC@@@@YAXXZ");
+    static assert(funTemplB.mangleof == "??$funTempl@$$CBVMyClassC@@@@YAXXZ");
+    static if (size_t.sizeof == ulong.sizeof)
+        static assert(funTemplC.mangleof == "??$funTempl@PEBVMyClassC@@@@YAXXZ");
+    else
+        static assert(funTemplC.mangleof == "??$funTempl@PBVMyClassC@@@@YAXXZ");
+}
+
+template _function(F)
+{
+extern(C++, "std")
+{
+    extern(C++, struct)
+    pragma(mangle, "function")
+    class _function
+    {
+    }
+}
+}
+template FunctionOf(F)
+{
+    F f;
+    alias FunctionOf = typeof(*f);
+}
+extern(C++) void funk(ScopeClass!(_function!(FunctionOf!(void function(int))),"function") a ){ }
+
+version (Posix)
+{
+    static assert(funk.mangleof == "_Z4funkSt8functionIFviEE");
+}
+else version (CppRuntime_Microsoft)
+{
+    static assert(funk.mangleof == "?funk@@YAXV?$function@$$A6AXH@Z@std@@@Z");
+}
+
+extern(C++, "ns")
+{
+    pragma(mangle, "function")
+    class _function2
+    {
+        public final void test();
+    }
+}
+
+version (Posix)
+{
+    static assert(_function2.test.mangleof == "_ZN2ns8function4testEv");
+}
+else version (CppRuntime_Microsoft)
+{
+    static if (size_t.sizeof == ulong.sizeof)
+        static assert(_function2.test.mangleof == "?test@function@ns@@QEAAXXZ");
+    else
+        static assert(_function2.test.mangleof == "?test@function@ns@@QAEXXZ");
+}
+
+extern(C++, "ns")
+{
+    template _function3(T)
+    {
+        pragma(mangle, _function3, "function")
+        class _function3
+        {
+            public final void test();
+        }
+    }
+}
+
+version (Posix)
+{
+    static assert(_function3!(int).test.mangleof == "_ZN2ns8functionIiE4testEv");
+}
+else version (CppRuntime_Microsoft)
+{
+    static if (size_t.sizeof == ulong.sizeof)
+        static assert(_function3!(int).test.mangleof == "?test@?$function@H@ns@@QEAAXXZ");
+    else
+        static assert(_function3!(int).test.mangleof == "?test@?$function@H@ns@@QAEXXZ");
+}
+
+extern(C++)
+{
+    struct Foo {}
+    pragma(mangle, Foo)  struct Foo_Doppelganger {}
+
+    void funl(Foo_Doppelganger f);
+}
+version (Posix)
+{
+    static assert(funl.mangleof == "_Z4funl3Foo");
+}
+else version (CppRuntime_Microsoft)
+{
+    static assert(funl.mangleof == "?funl@@YAXUFoo@@@Z");
+}

--- a/test/fail_compilation/issue21203.d
+++ b/test/fail_compilation/issue21203.d
@@ -1,0 +1,17 @@
+// Ideally this should work, at least give a nice error messae
+/**
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/issue21203.d(12): Error: pragma `mangle` cannot apply to a template declaration
+fail_compilation/issue21203.d(12):        use `template Class(Args...){ pragma(mangle, "other_name") class Class {}`
+---
+*/
+
+extern(C++)
+pragma(mangle,"gdkfjgh")
+class F(T)
+{
+
+}
+void use(F!int a) {}


### PR DESCRIPTION
The basic idea is to have a way to substitute the name of the class as a value type and then modify it (e.g. with `ref`) to get the correct mangling for symbols that are otherwise impossible to represent.

Todo

- [X] namespaces
- [x] ABI tags
- [X] reserved names (e.g. `std::function`)

spec PR https://github.com/dlang/dlang.org/pull/2875

cc @TurkeyMan @AndrejMitrovic 