### PR TITLE
Fix issue 21234: Import expression can read files outside of -J path in case of symlink/hardlink

### DIFF
--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -844,42 +844,7 @@ nothrow:
         }
         else version (Posix)
         {
-            if (path)
-            {
-                /* Each path is converted to a cannonical name and then a check is done to see
-                 * that the searched name is really a child one of the the paths searched.
-                 */
-                for (size_t i = 0; i < path.dim; i++)
-                {
-                    const(char)* cname = null;
-                    const(char)* cpath = canonicalName((*path)[i]);
-                    //printf("FileName::safeSearchPath(): name=%s; path=%s; cpath=%s\n",
-                    //      name, (char *)path.data[i], cpath);
-                    if (cpath is null)
-                        goto cont;
-                    cname = canonicalName(combine(cpath, name));
-                    //printf("FileName::safeSearchPath(): cname=%s\n", cname);
-                    if (cname is null)
-                        goto cont;
-                    //printf("FileName::safeSearchPath(): exists=%i "
-                    //      "strncmp(cpath, cname, %i)=%i\n", exists(cname),
-                    //      strlen(cpath), strncmp(cpath, cname, strlen(cpath)));
-                    // exists and name is *really* a "child" of path
-                    if (exists(cname) && strncmp(cpath, cname, strlen(cpath)) == 0)
-                    {
-                        mem.xfree(cast(void*)cpath);
-                        const(char)* p = mem.xstrdup(cname);
-                        mem.xfree(cast(void*)cname);
-                        return p;
-                    }
-                cont:
-                    if (cpath)
-                        mem.xfree(cast(void*)cpath);
-                    if (cname)
-                        mem.xfree(cast(void*)cname);
-                }
-            }
-            return null;
+            return FileName.searchPath(path, name, false);
         }
         else
         {

--- a/test/runnable/test21234.sh
+++ b/test/runnable/test21234.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+rm_retry -r ${OUTPUT_BASE}
+mkdir -p ${OUTPUT_BASE}/import
+
+cat > ${OUTPUT_BASE}/src.d << EOF
+void main()
+{
+    pragma(msg, import("file"));
+}
+EOF
+
+cat > ${OUTPUT_BASE}/file << EOF
+Hello!
+EOF
+
+ln -s ../file ${OUTPUT_BASE}/import/file
+
+$DMD -o- -od=${OUTPUT_BASE} -J=${OUTPUT_BASE}/import ${OUTPUT_BASE}/src.d
+
+rm_retry -r ${OUTPUT_BASE}


### PR DESCRIPTION
This change make import expression (`import("...")`) to work on Posix the same way as it works on Windows.

The original code tries to resolve symlinks on Posix and rejects a file if its real path is outside of -J options (although hardlinks pointing outside of -J are allowed).

This approach has the following issues:
- It doesn't allow the use case where -J directory has symlinks to cherry-picked files from other places (hardlinks and/or copying of files are not always possible).
- Different behavior on Posix vs. Windows.

From the other side, providing -J option to compiler means explicit consent to use the content of -J directory regardless of the type of this content (regular file/symlink/pipe etc).

See https://issues.dlang.org/show_bug.cgi?id=21234 for more details.