### PR TITLE
Fix Issue 21299: Undefined reference to dmd.root.stringtable.StringValue!(Type).lstring()

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -5928,6 +5928,17 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     {
         tempinst.minst = null;
     }
+    // https://issues.dlang.org/show_bug.cgi?id=21299
+    // If not speculative, this instance should have the same instantiating
+    // root module as its enclosing template symbol. This can differ when
+    // the enclosing template gets changed from non-root to a root instance
+    // in the instantiation graph. When that occurs, this instance also
+    // needs to be appended to the root module, otherwise there will be
+    // undefined references at link-time.
+    if (tempinst.minst && tempinst.tinst)
+    {
+        tempinst.minst = tempinst.tinst.minst;
+    }
 
     tempinst.gagged = (global.gag > 0);
 

--- a/test/compilable/imports/test21299/func.d
+++ b/test/compilable/imports/test21299/func.d
@@ -1,0 +1,8 @@
+module imports.test21299.func;
+import imports.test21299.mtype;
+import imports.test21299.rootstringtable;
+class FuncDeclaration {
+    StringTable!Type stringtable;
+    StringTable2!Type stringtable2;
+    StringTable3!Type stringtable3;
+}

--- a/test/compilable/imports/test21299/mtype.d
+++ b/test/compilable/imports/test21299/mtype.d
@@ -1,0 +1,8 @@
+module imports.test21299.mtype;
+import imports.test21299.func;
+import imports.test21299.rootstringtable;
+class Type {
+    StringTable!Type stringtable;
+    StringTable2!Type stringtable2;
+    StringTable3!Type stringtable3;
+}

--- a/test/compilable/imports/test21299/rootstringtable.d
+++ b/test/compilable/imports/test21299/rootstringtable.d
@@ -1,0 +1,96 @@
+module imports.test21299.rootstringtable;
+struct StringValue(T)
+{
+    char* lstring()
+    {
+        return cast(char*)&this;
+    }
+}
+
+struct StringTable(T)
+{
+    StringValue!T* insert()
+    {
+        allocValue;
+        return getValue;
+    }
+
+    uint allocValue()
+    {
+        StringValue!(T) sv;
+        sv.lstring[0] = 0;
+        return 0;
+    }
+
+    StringValue!T* getValue()
+    {
+        return cast(StringValue!T*)&this;
+    }
+}
+
+// Other tests are the same as the original issue, but use other kinds of
+// nesting Dsymbols that need to be handled by templateInstanceSemantic().
+struct StringValue2(T)
+{
+    char* lstring()
+    {
+        return cast(char*)&this;
+    }
+}
+
+struct StringTable2(T)
+{
+  @nogc // AttribDeclaration (also covers pragma, extern(), static foreach, ...)
+  {
+    StringValue2!T* insert()
+    {
+        allocValue;
+        return getValue;
+    }
+
+    uint allocValue()
+    {
+        StringValue2!(T) sv;
+        sv.lstring[0] = 0;
+        return 0;
+    }
+
+    StringValue2!T* getValue()
+    {
+        return cast(StringValue2!T*)&this;
+    }
+  }
+}
+
+//
+struct StringValue3(T)
+{
+    char* lstring()
+    {
+        return cast(char*)&this;
+    }
+}
+
+struct StringTable3(T)
+{
+  static if (true) // ConditionalDeclaration (static if)
+  {
+    StringValue3!T* insert()
+    {
+        allocValue;
+        return getValue;
+    }
+
+    uint allocValue()
+    {
+        StringValue3!(T) sv;
+        sv.lstring[0] = 0;
+        return 0;
+    }
+
+    StringValue3!T* getValue()
+    {
+        return cast(StringValue3!T*)&this;
+    }
+  }
+}

--- a/test/compilable/test21299a.d
+++ b/test/compilable/test21299a.d
@@ -1,0 +1,4 @@
+// EXTRA_SOURCES: imports/test21299/mtype.d imports/test21299/rootstringtable.d
+// REQUIRED_ARGS: -main
+// LINK
+module test21299a;

--- a/test/compilable/test21299b.d
+++ b/test/compilable/test21299b.d
@@ -1,0 +1,4 @@
+// EXTRA_SOURCES: imports/test21299/func.d imports/test21299/rootstringtable.d
+// REQUIRED_ARGS: -main
+// LINK:
+module test21299b;

--- a/test/compilable/test21299c.d
+++ b/test/compilable/test21299c.d
@@ -1,0 +1,5 @@
+// EXTRA_SOURCES: imports/test21299/mtype.d imports/test21299/func.d imports/test21299/rootstringtable.d
+// COMPILE_SEPARATELY:
+// LINK:
+module test21299c;
+void main() {}

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -1409,7 +1409,7 @@ int tryMain(string[] args)
             {
                 foreach (filename; testArgs.sources ~ (autoCompileImports ? null : testArgs.compiledImports))
                 {
-                    string newo= result_path ~ replace(replace(filename, ".d", envData.obj), envData.sep~"imports"~envData.sep, envData.sep);
+                    string newo = output_dir ~ envData.sep ~ replace(filename.baseName(), ".d", envData.obj);
                     toCleanup ~= newo;
 
                     command = format("%s -conf= -m%s -I%s %s %s -od%s -c %s %s", envData.dmd, envData.model, input_dir,


### PR DESCRIPTION
In `templateInstanceSemantic`, there exists special handling of matching template instances for the same template declaration to ensure that only at most one instance gets codegen'd.

If the primary instance `inst` originated from a non-root module, the `minst` field will be updated so it is now coming from a root module, however all Dsymbol `inst.members` of the instance still have their `_scope.minst` pointing at the original non-root module. We must now propagate `minst` to all members so that forward referenced dependencies that get instantiated will also be appended to the root module, otherwise there will be undefined references at link-time.

This doesn't affect compilations where all modules are compiled  together, as every module is a root module in that situation.  What this primarily affects are cases where there is a mix of root and non-root  modules, and a template was first instantiated in a non-root context, then later instantiated again in a root context.

Visually, this is how the tree looks before and after this change:
```
Before:
TemplateInstance
  tinst: this
  minst: root
  members:
  - StringTable:
      _scope: null
      members:
      - insert:
          _scope:
            minst: nonroot
      - allocValue:
          _scope:
            minst: nonroot
      - getValue:
          _scope:
            minst: nonroot

After:
TemplateInstance
  tinst: this
  minst: root
  members:
  - StringTable:
      _scope: null
      members:
      - insert:
          _scope:
            minst: root
      - allocValue:
          _scope:
            minst: root
      - getValue:
          _scope:
            minst: root
```