### PR TITLE
Fix 20916 - Print trace for deprecations triggered inside templates

### DIFF
--- a/changelog/deprecation-context.dd
+++ b/changelog/deprecation-context.dd
@@ -1,0 +1,11 @@
+Deprecation triggered inside of templates now show instantiation trace
+
+A common issue when dealing with deprecations is to have it trigger in library code,
+for example having a `deprecated` `alias this`, or a hook (`opApply`, range primitives...)
+being called by a function deeply nested inside Phobos.
+
+In such cases, finding out where the instantiation comes from can be quite tedious.
+From this release, if a deprecation is triggered inside a template, the compiler
+will show the template instantiation trace, just like it already does on error.
+The same limit apply (6 frames, recursive templates are compressed), and `-v`
+can be used to lift it.

--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -154,7 +154,7 @@ Expression resolveAliasThis(Scope* sc, Expression e, bool gag = false)
  */
 bool checkDeprecatedAliasThis(AliasThis at, const ref Loc loc, Scope* sc)
 {
-    import dmd.errors : deprecation;
+    import dmd.errors : deprecation, Classification;
     import dmd.dsymbolsem : getMessage;
 
     if (global.params.useDeprecated != DiagnosticReporting.off
@@ -173,6 +173,10 @@ bool checkDeprecatedAliasThis(AliasThis at, const ref Loc loc, Scope* sc)
         else
             deprecation(loc, "`alias %s this` is deprecated",
                         at.sym.toChars());
+
+        if (auto ti = sc.parent ? sc.parent.isInstantiated() : null)
+            ti.printInstantiationTrace(Classification.deprecation);
+
         return true;
     }
     return false;

--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -160,19 +160,19 @@ bool checkDeprecatedAliasThis(AliasThis at, const ref Loc loc, Scope* sc)
     if (global.params.useDeprecated != DiagnosticReporting.off
         && at.isDeprecated() && !sc.isDeprecated())
     {
-            const(char)* message = null;
-            for (Dsymbol p = at; p; p = p.parent)
-            {
-                message = p.depdecl ? p.depdecl.getMessage() : null;
-                if (message)
-                    break;
-            }
+        const(char)* message = null;
+        for (Dsymbol p = at; p; p = p.parent)
+        {
+            message = p.depdecl ? p.depdecl.getMessage() : null;
             if (message)
-                deprecation(loc, "`alias %s this` is deprecated - %s",
-                            at.sym.toChars(), message);
-            else
-                deprecation(loc, "`alias %s this` is deprecated",
-                            at.sym.toChars());
+                break;
+        }
+        if (message)
+            deprecation(loc, "`alias %s this` is deprecated - %s",
+                        at.sym.toChars(), message);
+        else
+            deprecation(loc, "`alias %s this` is deprecated",
+                        at.sym.toChars());
         return true;
     }
     return false;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -417,6 +417,9 @@ extern (C++) class Dsymbol : ASTNode
         else
             deprecation(loc, "is deprecated");
 
+        if (auto ti = sc.parent ? sc.parent.isInstantiated() : null)
+            ti.printInstantiationTrace(Classification.deprecation);
+
         return true;
     }
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5974,7 +5974,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         if (global.gag)
             return;
 
-        const(uint) max_shown = 6;
+        // Print full trace for verbose mode, otherwise only short traces
+        const(uint) max_shown = !global.params.verbose ? 6 : uint.max;
         const(char)* format = "instantiated from here: `%s`";
 
         // determine instantiation depth and number of recursive instantiations
@@ -5992,8 +5993,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 ++n_totalrecursions;
         }
 
-        // show full trace only if it's short or verbose is on
-        if (n_instantiations <= max_shown || global.params.verbose)
+        if (n_instantiations <= max_shown)
         {
             for (TemplateInstance cur = this; cur; cur = cur.tinst)
             {

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5984,6 +5984,10 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         for (TemplateInstance cur = this; cur; cur = cur.tinst)
         {
             ++n_instantiations;
+            // Set error here as we don't want it to depend on the number of
+            // entries that are being printed.
+            cur.errors = true;
+
             // If two instantiations use the same declaration, they are recursive.
             // (this works even if they are instantiated from different places in the
             // same template).
@@ -5996,10 +6000,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         if (n_instantiations <= max_shown)
         {
             for (TemplateInstance cur = this; cur; cur = cur.tinst)
-            {
-                cur.errors = true;
                 errorSupplemental(cur.loc, format, cur.toChars());
-            }
         }
         else if (n_instantiations - n_totalrecursions <= max_shown)
         {
@@ -6008,7 +6009,6 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             int recursionDepth = 0;
             for (TemplateInstance cur = this; cur; cur = cur.tinst)
             {
-                cur.errors = true;
                 if (cur.tinst && cur.tempdecl && cur.tinst.tempdecl && cur.tempdecl.loc.equals(cur.tinst.tempdecl.loc))
                 {
                     ++recursionDepth;
@@ -6030,8 +6030,6 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             uint i = 0;
             for (TemplateInstance cur = this; cur; cur = cur.tinst)
             {
-                cur.errors = true;
-
                 if (i == max_shown / 2)
                     errorSupplemental(cur.loc, "... (%d instantiations, -v to show) ...", n_instantiations - max_shown);
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3864,7 +3864,6 @@ public:
     bool oneMember(Dsymbol** ps, Identifier* ident);
     const char* toChars() const;
     const char* toPrettyCharsHelper();
-    void printInstantiationTrace();
     Identifier* getIdent();
     bool equalsx(TemplateInstance* ti);
     size_t toHash();

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -281,7 +281,6 @@ public:
     bool oneMember(Dsymbol **ps, Identifier *ident);
     const char *toChars() const;
     const char* toPrettyCharsHelper();
-    void printInstantiationTrace();
     Identifier *getIdent();
     hash_t toHash();
 

--- a/test/compilable/diag20916.d
+++ b/test/compilable/diag20916.d
@@ -1,0 +1,48 @@
+/*
+TEST_OUTPUT:
+---
+compilable/diag20916.d(36): Deprecation: `alias fb this` is deprecated
+compilable/diag20916.d(41):        instantiated from here: `jump2!(Foo)`
+compilable/diag20916.d(46):        instantiated from here: `jump1!(Foo)`
+compilable/diag20916.d(36): Deprecation: function `diag20916.FooBar.toString` is deprecated
+compilable/diag20916.d(41):        instantiated from here: `jump2!(Foo)`
+compilable/diag20916.d(46):        instantiated from here: `jump1!(Foo)`
+compilable/diag20916.d(36): Deprecation: function `diag20916.Bar.toString!().toString` is deprecated
+compilable/diag20916.d(41):        instantiated from here: `jump2!(Bar)`
+compilable/diag20916.d(47):        instantiated from here: `jump1!(Bar)`
+---
+ */
+
+struct FooBar
+{
+    deprecated string toString() const { return "42"; }
+    int value = 42;
+}
+
+struct Foo
+{
+    FooBar fb;
+    deprecated alias fb this;
+}
+
+struct Bar
+{
+    deprecated string toString()() const { return "42"; }
+    int value = 42;
+}
+
+void jump2(T) (T value)
+{
+    assert(value.toString() == "42");
+}
+
+void jump1(T) (T value)
+{
+    jump2(value);
+}
+
+void main ()
+{
+    jump1(Foo.init);
+    jump1(Bar.init);
+}

--- a/test/fail_compilation/deprecations.d
+++ b/test/fail_compilation/deprecations.d
@@ -2,11 +2,12 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/deprecations.d(42): Deprecation: struct `deprecations.S` is deprecated
-fail_compilation/deprecations.d(63): Error: template instance `deprecations.otherPar!()` error instantiating
-fail_compilation/deprecations.d(54): Deprecation: struct `deprecations.S` is deprecated
-fail_compilation/deprecations.d(54): Deprecation: struct `deprecations.S` is deprecated
-fail_compilation/deprecations.d(64): Error: template instance `deprecations.otherVar!()` error instantiating
+fail_compilation/deprecations.d(43): Deprecation: struct `deprecations.S` is deprecated
+fail_compilation/deprecations.d(64): Error: template instance `deprecations.otherPar!()` error instantiating
+fail_compilation/deprecations.d(55): Deprecation: struct `deprecations.S` is deprecated
+fail_compilation/deprecations.d(65):        instantiated from here: `otherVar!()`
+fail_compilation/deprecations.d(55): Deprecation: struct `deprecations.S` is deprecated
+fail_compilation/deprecations.d(65):        instantiated from here: `otherVar!()`
 ---
 
 https://issues.dlang.org/show_bug.cgi?id=20474

--- a/test/fail_compilation/ice11822.d
+++ b/test/fail_compilation/ice11822.d
@@ -4,9 +4,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11822.d(32): Deprecation: function `ice11822.d` is deprecated
-fail_compilation/ice11822.d(21):        instantiated from here: `S!(__lambda1)`
-fail_compilation/ice11822.d(32):        instantiated from here: `g!((n) => d(i))`
+fail_compilation/ice11822.d(33): Deprecation: function `ice11822.d` is deprecated
+fail_compilation/ice11822.d(16):        instantiated from here: `__lambda1!int`
+fail_compilation/ice11822.d(22):        instantiated from here: `S!(__lambda1)`
+fail_compilation/ice11822.d(33):        instantiated from here: `g!((n) => d(i))`
 ---
 */
 


### PR DESCRIPTION
This turned out to be way easier than I expected.
@John-Colvin : Want to give this a shot ?

I also think it segv dtoh (and I have an idea where the bug is), but let's see what the auto-tester says...