### PR TITLE
Fix 8044 - Print name of enum passed a tmpl param

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1777,19 +1777,17 @@ public:
             case Tenum:
                 {
                     TypeEnum te = cast(TypeEnum)t;
-                    if (hgs.fullDump)
+                    auto sym = te.sym;
+                    if (sym && sym.members && (!hgs.inEnumDecl || hgs.inEnumDecl != sym))
                     {
-                        auto sym = te.sym;
-                        if (hgs.inEnumDecl && sym && hgs.inEnumDecl != sym)  foreach(i;0 .. sym.members.dim)
+                        foreach (em; *sym.members)
                         {
-                            EnumMember em = cast(EnumMember) (*sym.members)[i];
-                            if (em.value.toInteger == v)
+                            if ((cast(EnumMember)em).value.toInteger == v)
                             {
                                 buf.printf("%s.%s", sym.toChars(), em.ident.toChars());
                                 return ;
                             }
                         }
-                        //assert(0, "We could not find the EmumMember");// for some reason it won't append char* ~ e.toChars() ~ " in " ~ sym.toChars() );
                     }
 
                     buf.printf("cast(%s)", te.sym.toChars());

--- a/test/fail_compilation/b6227.d
+++ b/test/fail_compilation/b6227.d
@@ -1,9 +1,9 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/b6227.d(16): Error: Comparison between different enumeration types `X` and `Y`; If this behavior is intended consider using `std.conv.asOriginalType`
-fail_compilation/b6227.d(16):        while evaluating: `static assert(!(cast(X)0 != cast(Y)0))`
+fail_compilation/b6227.d(16):        while evaluating: `static assert(!(X.O != Y.U))`
 fail_compilation/b6227.d(17): Error: Comparison between different enumeration types `X` and `Y`; If this behavior is intended consider using `std.conv.asOriginalType`
-fail_compilation/b6227.d(17):        while evaluating: `static assert(cast(X)0 == cast(Y)0)`
+fail_compilation/b6227.d(17):        while evaluating: `static assert(X.O == Y.U)`
 ---
 */
 enum X {

--- a/test/fail_compilation/diag12380.d
+++ b/test/fail_compilation/diag12380.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag12380.d(12): Error: cannot implicitly convert expression `cast(E)0` of type `E` to `void*`
+fail_compilation/diag12380.d(12): Error: cannot implicitly convert expression `E.a` of type `E` to `void*`
 ---
 */
 

--- a/test/fail_compilation/diag8044.d
+++ b/test/fail_compilation/diag8044.d
@@ -1,0 +1,19 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag8044.d(18): Error: template instance `diag8044.test!(Enum.Bar)` does not match template declaration `test(Enum en)()`
+  with `en = Bar`
+  must satisfy the following constraint:
+`       0`
+---
+ */
+enum Enum { Foo, Bar }
+void test(Enum en)()
+    if(0)
+{
+}
+
+void main()
+{
+    test!(Enum.Bar)();
+}

--- a/test/fail_compilation/fail17602.d
+++ b/test/fail_compilation/fail17602.d
@@ -2,7 +2,7 @@
 EXTRA_FILES: imports/imp17602.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail17602.d(17): Error: cannot implicitly convert expression `cast(Status)0` of type `imports.imp17602.Status` to `fail17602.Status`
+fail_compilation/fail17602.d(17): Error: cannot implicitly convert expression `Status.on` of type `imports.imp17602.Status` to `fail17602.Status`
 ---
 */
 

--- a/test/fail_compilation/fail5435.d
+++ b/test/fail_compilation/fail5435.d
@@ -2,18 +2,18 @@
 /*
 TEST_OUTPUT:
 ---
-cast(Enum5435)0
-cast(Enum5435)1
-cast(Enum5435)2
+Enum5435.A
+Enum5435.B
+Enum5435.C
 fail_compilation/fail5435.d(38): Error: cannot implicitly convert expression `"foo"` of type `string` to `Enum5435`
 fail_compilation/fail5435.d(38):        while evaluating `pragma(msg, foo)`
 fail_compilation/fail5435.d(38): Error: cannot implicitly convert expression `3.0` of type `double` to `Enum5435`
 fail_compilation/fail5435.d(38):        while evaluating `pragma(msg, foo)`
-fail_compilation/fail5435.d(39): Error: cannot implicitly convert expression `cast(Enum5435)0` of type `Enum5435` to `string`
+fail_compilation/fail5435.d(39): Error: cannot implicitly convert expression `Enum5435.A` of type `Enum5435` to `string`
 fail_compilation/fail5435.d(39):        while evaluating `pragma(msg, foo)`
-fail_compilation/fail5435.d(39): Error: cannot implicitly convert expression `cast(Enum5435)1` of type `Enum5435` to `string`
+fail_compilation/fail5435.d(39): Error: cannot implicitly convert expression `Enum5435.B` of type `Enum5435` to `string`
 fail_compilation/fail5435.d(39):        while evaluating `pragma(msg, foo)`
-fail_compilation/fail5435.d(39): Error: cannot implicitly convert expression `cast(Enum5435)2` of type `Enum5435` to `string`
+fail_compilation/fail5435.d(39): Error: cannot implicitly convert expression `Enum5435.C` of type `Enum5435` to `string`
 fail_compilation/fail5435.d(39):        while evaluating `pragma(msg, foo)`
 foo
 fail_compilation/fail5435.d(39): Error: cannot implicitly convert expression `3.0` of type `double` to `string`


### PR DESCRIPTION
The fix was actually quite trivial. Looking at the code flow, I doubt this actually change any other diagnostic, but let's see what the CI says.