### PR TITLE
Github CI: Replace set-env with environment file

### DIFF
--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -207,11 +207,11 @@ jobs:
       run: |
         TMP_CC='${{ github.workspace }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}/bin/clang'
         if [ "${{ matrix.os }}" == "macOS-10.15" ]; then
-          echo ::set-env name=CC::${TMP_CC}-wrapper
-          echo ::set-env name=CXX::${TMP_CC}++-wrapper
+          echo "CC=${TMP_CC}-wrapper" >> $GITHUB_ENV
+          echo "CXX=${TMP_CC}++-wrapper" >> $GITHUB_ENV
         else
-          echo ::set-env name=CC::${TMP_CC}
-          echo ::set-env name=CXX::${TMP_CC}++
+          echo "CC=${TMP_CC}" >> $GITHUB_ENV
+          echo "CXX=${TMP_CC}++" >> $GITHUB_ENV
         fi
 
     # On OSX and Linux, clang is installed by default and in the path,
@@ -241,8 +241,8 @@ jobs:
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
         sudo apt-get update
         sudo apt-get install ${{ matrix.target }} ${{ matrix.target }}-multilib
-        echo ::set-env name=CC::${{ matrix.target }}
-        echo ::set-env name=CXX::${{ matrix.target }}
+        echo "CC=${{ matrix.target }}" >> $GITHUB_ENV
+        echo "CXX=${{ matrix.target }}" >> $GITHUB_ENV
 
     # Make sure ${CC} works and we don't use the $PATH one
     - name: '[Linux] Verifying installed g++ version'


### PR DESCRIPTION
Due to a security vulnerability, Github is removing set-env and add-path.
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/