### PR TITLE
Fix Issue 21293 - dtoh: segfault when encountering opaque enum

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -10,6 +10,7 @@ experimental C++ header generator:
   using the compiler internal names instaed of causing an assertion failure.
 - Interfaces are now emitted as base classes.
 - No auto-generated default constructor for unions
+- Opaque enums no longer cause segfaults & are properly exported for C++ 11
 
 Note: The header generator is still considerer experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/test/compilable/dtoh_enum.d
+++ b/test/compilable/dtoh_enum.d
@@ -106,6 +106,8 @@ namespace MyEnumCpp
 
 static MyEnum const testCpp = Foo(42);
 
+enum class opaque;
+enum class typedOpaque : int64_t;
 ---
 */
 
@@ -193,3 +195,7 @@ enum d = &foo;
 
 immutable bool e_b;
 enum e = &e_b;
+
+enum opaque;
+enum typedOpaque : long;
+enum arrayOpaque : int[4]; // Cannot be exported to C++

--- a/test/compilable/dtoh_enum_cpp98.d
+++ b/test/compilable/dtoh_enum_cpp98.d
@@ -193,3 +193,8 @@ enum d = &foo;
 
 immutable bool e_b;
 enum e = &e_b;
+
+// Opaque enums require C++ 11
+enum opaque;
+enum typedOpaque : long;
+enum arrayOpaque : int[4];

--- a/test/compilable/dtoh_verbose.d
+++ b/test/compilable/dtoh_verbose.d
@@ -18,6 +18,7 @@ TEST_OUTPUT:
 // ignoring function dtoh_verbose.bar because it's extern
 // ignoring variable dtoh_verbose.i1 because of linkage
 // ignored function dtoh_verbose.templ!int.templ
+// ignoring enum dtoh_verbose.arrayOpaque because of it's base type
 ---
 */
 
@@ -40,3 +41,5 @@ int i1;
 void templ(T)(T t) {}
 
 alias inst = templ!int;
+
+enum arrayOpaque : int[4];


### PR DESCRIPTION
Don't access non-existant members and require C++11.

CC @jacob-carlborg 