### PR TITLE
Revert "convert LINK and other enums to ubyte"

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -113,11 +113,11 @@ enum class Kind
 };
 
 struct BitArray;
-enum class CPPMANGLE : uint8_t
+enum class CPPMANGLE
 {
-    def = 0u,
-    asStruct = 1u,
-    asClass = 2u,
+    def = 0,
+    asStruct = 1,
+    asClass = 2,
 };
 
 class AliasThis;
@@ -135,16 +135,16 @@ class GotoCaseStatement;
 class ReturnStatement;
 class GotoStatement;
 struct Ensure;
-enum class LINK : uint8_t
+enum class LINK
 {
-    default_ = 0u,
-    d = 1u,
-    c = 2u,
-    cpp = 3u,
-    windows = 4u,
-    pascal = 5u,
-    objc = 6u,
-    system = 7u,
+    default_ = 0,
+    d = 1,
+    c = 2,
+    cpp = 3,
+    windows = 4,
+    pascal = 5,
+    objc = 6,
+    system = 7,
 };
 
 class LinkDeclaration;
@@ -440,12 +440,12 @@ enum class TOK : uint8_t
 
 class StringExp;
 class TupleExp;
-enum class MATCH : uint8_t
+enum class MATCH
 {
-    nomatch = 0u,
-    convert = 1u,
-    constant = 2u,
-    exact = 3u,
+    nomatch = 0,
+    convert = 1,
+    constant = 2,
+    exact = 3,
 };
 
 enum class Modifiable
@@ -677,11 +677,11 @@ class ObjcClassReferenceExp;
 class ThrownExceptionExp;
 struct ASTCodegen;
 union __AnonStruct__u;
-enum class PINLINE : uint8_t
+enum class PINLINE
 {
-    default_ = 0u,
-    never = 1u,
-    always = 2u,
+    default_ = 0,
+    never = 1,
+    always = 2,
 };
 
 struct ObjcFuncDeclaration;

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -659,7 +659,7 @@ nothrow:
     }
 }
 
-enum LINK : ubyte
+enum LINK : int
 {
     default_,
     d,
@@ -671,14 +671,14 @@ enum LINK : ubyte
     system,
 }
 
-enum CPPMANGLE : ubyte
+enum CPPMANGLE : int
 {
     def,
     asStruct,
     asClass,
 }
 
-enum MATCH : ubyte
+enum MATCH : int
 {
     nomatch,   // no match
     convert,   // match with conversions
@@ -686,7 +686,7 @@ enum MATCH : ubyte
     exact,     // exact match
 }
 
-enum PINLINE : ubyte
+enum PINLINE : int
 {
     default_,     // as specified on the command line
     never,   // never inline

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -396,38 +396,38 @@ struct Loc
     bool equals(const Loc& loc) const;
 };
 
-enum class LINK : uint8_t
+enum LINK
 {
-    default_,
-    d,
-    c,
-    cpp,
-    windows,
-    pascal,
-    objc,
-    system
+    LINKdefault,
+    LINKd,
+    LINKc,
+    LINKcpp,
+    LINKwindows,
+    LINKpascal,
+    LINKobjc,
+    LINKsystem
 };
 
-enum class CPPMANGLE : uint8_t
+enum CPPMANGLE
 {
-    def,
-    asStruct,
-    asClass
+    CPPMANGLEdefault,
+    CPPMANGLEstruct,
+    CPPMANGLEclass
 };
 
-enum class MATCH : uint8_t
+enum MATCH
 {
-    nomatch,       // no match
-    convert,       // match with conversions
-    constant,      // match with conversion to const
-    exact          // exact match
+    MATCHnomatch,       // no match
+    MATCHconvert,       // match with conversions
+    MATCHconst,         // match with conversion to const
+    MATCHexact          // exact match
 };
 
-enum class PINLINE : uint8_t
+enum PINLINE
 {
-    default_,     // as specified on the command line
-    never,        // never inline
-    always        // always inline
+    PINLINEdefault,      // as specified on the command line
+    PINLINEnever,        // never inline
+    PINLINEalways        // always inline
 };
 
 typedef uinteger_t StorageClass;

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -220,9 +220,9 @@ void test_visitors()
     tp->accept(&tv);
     assert(tv.type == true);
 
-    LinkDeclaration *ld = LinkDeclaration::create(LINK::d, NULL);
+    LinkDeclaration *ld = LinkDeclaration::create(LINKd, NULL);
     assert(ld->isAttribDeclaration() == static_cast<AttribDeclaration *>(ld));
-    assert(ld->linkage == LINK::d);
+    assert(ld->linkage == LINKd);
     ld->accept(&tv);
     assert(tv.attrib == true);
 
@@ -247,7 +247,7 @@ void test_visitors()
     assert(tv.typeinfo == true);
 
     Parameters *args = new Parameters;
-    TypeFunction *tf = TypeFunction::create(args, Type::tvoid, VARARGnone, LINK::c);
+    TypeFunction *tf = TypeFunction::create(args, Type::tvoid, VARARGnone, LINKc);
     FuncDeclaration *fd = FuncDeclaration::create(Loc (), Loc (), Identifier::idPool("test"),
                                                   STCextern, tf);
     assert(fd->isFuncDeclaration() == fd);
@@ -346,7 +346,7 @@ void test_parameters()
     args->push(Parameter::create(STCundefined, Type::tint32, NULL, NULL, NULL));
     args->push(Parameter::create(STCundefined, Type::tint64, NULL, NULL, NULL));
 
-    TypeFunction *tf = TypeFunction::create(args, Type::tvoid, VARARGnone, LINK::c);
+    TypeFunction *tf = TypeFunction::create(args, Type::tvoid, VARARGnone, LINKc);
 
     assert(tf->parameterList.length() == 2);
     assert(tf->parameterList[0]->type == Type::tint32);
@@ -360,7 +360,7 @@ void test_types()
 {
     Parameters *args = new Parameters;
     StorageClass stc = STCnothrow|STCproperty|STCreturn|STCreturninferred|STCtrusted;
-    TypeFunction *tfunction = TypeFunction::create(args, Type::tvoid, VARARGnone, LINK::d, stc);
+    TypeFunction *tfunction = TypeFunction::create(args, Type::tvoid, VARARGnone, LINKd, stc);
 
     assert(tfunction->isnothrow());
     assert(!tfunction->isnogc());
@@ -372,7 +372,7 @@ void test_types()
     assert(!tfunction->isScopeQual());
     assert(tfunction->isreturninferred());
     assert(!tfunction->isscopeinferred());
-    assert(tfunction->linkage == LINK::d);
+    assert(tfunction->linkage == LINKd);
     assert(tfunction->trust == TRUST::trusted);
     assert(tfunction->purity == PURE::impure);
 }


### PR DESCRIPTION
Reverts dlang/dmd#11851
It broke master, as can be seen in the comment of the PR.