### PR TITLE
Infer dtor attributes etc. before checks for (deprecated) DeleteExp

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7117,6 +7117,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             if (ad.dtor)
             {
+                err |= !ad.dtor.functionSemantic();
                 err |= exp.checkPurity(sc, ad.dtor);
                 err |= exp.checkSafety(sc, ad.dtor);
                 err |= exp.checkNogc(sc, ad.dtor);

--- a/test/runnable/imports/std15017variant.d
+++ b/test/runnable/imports/std15017variant.d
@@ -1,6 +1,6 @@
 module imports.std15017variant;
 
-struct VariantN(size_t maxDataSize)
+struct VariantN(uint maxDataSize)
 {
     VariantN opAssign() { return this; }
 

--- a/test/runnable/link15017.d
+++ b/test/runnable/link15017.d
@@ -46,6 +46,7 @@ void test()
     // OK <- in DeleteExp::semantic
     Variant10* p10;
     delete p10;
+    static assert(Variant10.__dtor.mangleof == "_D7imports15std15017variant__T8VariantNVki10ZQp6__dtorMFNaNbNiNfZv");
 }
 
 void main() {}


### PR DESCRIPTION
When a function hasn't had its attributes inferred yet, but is checked for being pure/safe/..., it is for some reason set as impure/non-safe, and a later semantic analysis doesn't infer them anymore...

E.g.: https://github.com/dlang/dmd/blob/b6526dfc9994049b386ab1da0e38d7655adedf73/src/dmd/func.d#L1337-L1338 https://github.com/dlang/dmd/blob/b6526dfc9994049b386ab1da0e38d7655adedf73/src/dmd/func.d#L1376-L1381