### PR TITLE
implement `__traits(getCppNamespaces, symbol)`

### DIFF
--- a/changelog/traits-getcppnamespaces.dd
+++ b/changelog/traits-getcppnamespaces.dd
@@ -1,0 +1,15 @@
+Add `__traits(getCppNamespaces, symbol)` to retrieve the C++ namespaces a symbol resides in.
+
+This new trait returns a tuple of strings representing the namespace(s) the symbol resides in.
+This enables determining what namespaces a given symbol resides in for use in reflection, and can be used directly with an `extern(C++)` declaration as demonstrated below.
+
+```
+extern(C++, "ns")
+struct Foo {}
+static assert(__traits(getCppNamespaces, Foo)[0] == "ns");
+struct Bar {}
+static assert(!__traits(getCppNamespaces, Foo).length);
+extern(C++, __traits(getCppNamespaces, Foo)) struct Baz {}
+static assert(__traits(getCppNamespaces, Foo) ==  __traits(getCppNamespaces, Baz));
+```
+

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7538,6 +7538,7 @@ struct Id
     static Identifier* getUnitTests;
     static Identifier* getVirtualIndex;
     static Identifier* getPointerBitmap;
+    static Identifier* getCppNamespaces;
     static Identifier* isReturnOnStack;
     static Identifier* isZeroInit;
     static Identifier* getTargetInfo;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -462,6 +462,7 @@ immutable Msgtable[] msgtable =
     { "getUnitTests" },
     { "getVirtualIndex" },
     { "getPointerBitmap" },
+    { "getCppNamespaces" },
     { "isReturnOnStack" },
     { "isZeroInit" },
     { "getTargetInfo" },

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -236,3 +236,47 @@ static assert(!__traits(isSame,
     Seq!(int, Seq!(a => a + a)),
     Seq!(int, Seq!(a => a * a))
 ));
+
+// Do these out of order to ensure there are no forward refencing bugs
+
+extern(C++, __traits(getCppNamespaces,GetNamespaceTest1)) struct GetNamespaceTest4 {}
+static assert (__traits(getCppNamespaces,GetNamespaceTest1) ==
+               __traits(getCppNamespaces,GetNamespaceTest4));
+
+extern(C++, "ns") struct GetNamespaceTest1 {}
+extern(C++, "multiple", "namespaces") struct GetNamespaceTest2 {}
+extern(C++, mixin("Seq!(`ns`, `nt`)")) struct GetNamespaceTest3 {}
+static assert(__traits(getCppNamespaces,GetNamespaceTest1)[0] == "ns");
+static assert(__traits(getCppNamespaces,GetNamespaceTest2) == Seq!("multiple","namespaces"));
+static assert(__traits(getCppNamespaces,GetNamespaceTest3) == Seq!("ns", "nt"));
+
+extern(C++, __traits(getCppNamespaces,GetNamespaceTest5)) struct GetNamespaceTest8 {}
+static assert (__traits(getCppNamespaces,GetNamespaceTest5) ==
+               __traits(getCppNamespaces,GetNamespaceTest8));
+
+extern(C++, ns) struct GetNamespaceTest5 {}
+extern(C++, multiple) extern(C++, namespaces) struct GetNamespaceTest6 {}
+static assert(__traits(getCppNamespaces,GetNamespaceTest5)[0] == "ns");
+static assert(__traits(getCppNamespaces,GetNamespaceTest6) == Seq!("multiple","namespaces"));
+
+extern(C++, NS)
+{
+    struct GetNamespaceTest9 {}
+    extern(C++, nested)
+    {
+        struct GetNamespaceTest10 {}
+        extern(C++,"nested2")
+            struct GetNamespaceTest11 {}
+    }
+    extern (C++, "nested3")
+    {
+        extern(C++, nested4)
+            struct GetNamespaceTest12 {}
+    }
+}
+static assert (__traits(getCppNamespaces,NS.GetNamespaceTest9)[0] == "NS");
+static assert (__traits(getCppNamespaces,NS.GetNamespaceTest10) == Seq!("NS", "nested"));
+static assert (__traits(getCppNamespaces,NS.GetNamespaceTest11) == Seq!("NS", "nested", "nested2"));
+static assert (__traits(getCppNamespaces,NS.GetNamespaceTest12) == Seq!("NS", "nested4", "nested3"));
+
+

--- a/test/fail_compilation/traits.d
+++ b/test/fail_compilation/traits.d
@@ -19,6 +19,8 @@ fail_compilation/traits.d(309): Error: In expression `__traits(derivedMembers, f
 fail_compilation/traits.d(309):        `float` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation
 fail_compilation/traits.d(316): Error: In expression `__traits(derivedMembers, TemplatedStruct)` struct `TemplatedStruct(T)` has no members
 fail_compilation/traits.d(316):        `TemplatedStruct(T)` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation
+fail_compilation/traits.d(404): Error: function `traits.func1` circular reference in `__traits(GetCppNamespaces,...)`
+fail_compilation/traits.d(413): Error: function `traits.foo1.func1` circular reference in `__traits(GetCppNamespaces,...)`
 ---
 */
 
@@ -59,3 +61,23 @@ enum DM5 = __traits(derivedMembers, Interface);             // no error
 enum DM6 = __traits(derivedMembers, TemplatedStruct!float); // no error
 enum DM7 = __traits(derivedMembers, TemplatedStruct);       // compile error
 enum DM8 = __traits(derivedMembers, mixin(__MODULE__));     // no error
+
+#line 400
+extern(C++, "bar")
+extern(C++, __traits(getCppNamespaces, func1)) void func () {}
+
+extern(C++, "foo")
+extern(C++, __traits(getCppNamespaces, func2)) void func1 () {}
+
+extern(C++, "foobar")
+extern(C++, __traits(getCppNamespaces, func)) void func2 () {}
+
+extern(C++, bar1)
+extern(C++, __traits(getCppNamespaces, foo1.func1)) void func () {}
+
+extern(C++, foo1)
+extern(C++, __traits(getCppNamespaces, foobar1.func2)) void func1 () {}
+
+extern(C++, foobar1)
+extern(C++, __traits(getCppNamespaces, bar1.func)) void func2 () {}
+


### PR DESCRIPTION
Spec PR dlang/dlang.org#2867

Adds `__traits(getCppNamespaces, symbol)` which retrieves, as a tuple
of strings, the C++ namespaces a symbol resides in.

This enables reflection and compile time code generation capabilities
to C++ namespaces.
