### PR TITLE
Azure CI: Bump LDC host compiler version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
     variables:
       D_COMPILER: ldc
       VISUALD_VER: v0.49.0
-      LDC_VERSION: 1.20.0
+      LDC_VERSION: 1.23.0
     strategy:
       matrix:
         x64_Debug:


### PR DESCRIPTION
As I suspect `libcurl.dll` bundled with LDC v1.20 to be the cause for the crashing Phobos unittests. That DLL was upgraded with LDC v1.21 from v7.65.3 to v7.69.1.