### PR TITLE
dtoh: Properly handle default values of function arguments

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -6,6 +6,7 @@ experimental C++ header generator:
 - Enums are no longer emitted in macros and `enum class` is used when the
   C++ standard set from `-extern-std=` is c++11 or later.
 - Forward referenced declarations are now properly indented.
+- Default functions parameters are properly emitted
 - Tuple members/parameters/variables are emitted as individual variables
   using the compiler internal names instead of causing an assertion failure.
 - Interfaces are now emitted as base classes.

--- a/test/compilable/dtoh_functions.d
+++ b/test/compilable/dtoh_functions.d
@@ -11,6 +11,36 @@ TEST_OUTPUT:
 #include <stdint.h>
 
 
+struct S;
+struct S2;
+
+extern S* ptr;
+
+extern int32_t(*f)(int32_t );
+
+extern void special(int32_t a = ptr->i, int32_t b = ptr->get(1, 2), int32_t j = (*f)(1));
+
+struct S2
+{
+    S s;
+    struct S3
+    {
+        static int32_t i;
+        S3()
+        {
+        }
+    };
+
+    S2() :
+        s()
+    {
+    }
+};
+
+extern S2 s2;
+
+extern void chains(int32_t a = s2.s.i, int32_t b = S2::S3::i);
+
 extern "C" int32_t bar(int32_t x);
 
 extern "C" int32_t bar2(int32_t x);
@@ -24,6 +54,29 @@ extern int32_t baz2(int32_t x);
 extern int32_t baz4(int32_t x = 42);
 
 extern size_t baz5(size_t x = 42);
+
+enum class E : int64_t
+{
+    m = 1LL,
+};
+
+extern void enums(uint64_t e = $?:32=1LLU|64=E::m$);
+
+struct S
+{
+    int32_t i;
+    int32_t get(int32_t , int32_t );
+    static int32_t get();
+    static const int32_t staticVar;
+    S() :
+        i()
+    {
+    }
+};
+
+extern S s;
+
+extern void aggregates(int32_t a = s.i, int32_t b = s.get(1, 2), int32_t c = S::get(), int32_t d = S::staticVar);
 ---
 */
 
@@ -79,3 +132,43 @@ extern (C++) size_t baz5(size_t x = 42)
 {
     return x * 42;
 }
+
+extern (C++):
+
+enum E : long
+{
+    m = 1
+}
+
+void enums(ulong e = E.m) {}
+
+struct S
+{
+    int i;
+    int get(int, int);
+    static int get();
+    static const int staticVar;
+}
+
+S s;
+
+void aggregates(int a = s.i, int b = s.get(1, 2), int c = S.get(), int d = S.staticVar) {}
+
+struct S2
+{
+
+    S s;
+    static struct S3
+    {
+        static int i = 3;
+    }
+}
+
+S2 s2;
+
+void chains(int a = s2.s.i, int b = S2.S3.i) {}
+
+S* ptr;
+int function(int) f;
+
+void special(int a = ptr.i, int b = ptr.get(1, 2), int j = f(1)) {}


### PR DESCRIPTION
Removes the special casing in favour of visiting the actual expression and implements handlers for expressions which require different syntax in C++ (e.g. static member access, implicit dereferencing of pointers, ...).

CC @Geod24 