### PR TITLE
[dmd-cxx] Fix Issue 21299: Undefined reference to dmd.root.stringtable.StringValue!(Type).lstring()

### DIFF
--- a/test/compilable/imports/test21299/func.d
+++ b/test/compilable/imports/test21299/func.d
@@ -1,0 +1,8 @@
+module imports.test21299.func;
+import imports.test21299.mtype;
+import imports.test21299.rootstringtable;
+class FuncDeclaration {
+    StringTable!Type stringtable;
+    StringTable2!Type stringtable2;
+    StringTable3!Type stringtable3;
+}

--- a/test/compilable/imports/test21299/mtype.d
+++ b/test/compilable/imports/test21299/mtype.d
@@ -1,0 +1,8 @@
+module imports.test21299.mtype;
+import imports.test21299.func;
+import imports.test21299.rootstringtable;
+class Type {
+    StringTable!Type stringtable;
+    StringTable2!Type stringtable2;
+    StringTable3!Type stringtable3;
+}

--- a/test/compilable/imports/test21299/rootstringtable.d
+++ b/test/compilable/imports/test21299/rootstringtable.d
@@ -1,0 +1,96 @@
+module imports.test21299.rootstringtable;
+struct StringValue(T)
+{
+    char* lstring()
+    {
+        return cast(char*)&this;
+    }
+}
+
+struct StringTable(T)
+{
+    StringValue!T* insert()
+    {
+        allocValue;
+        return getValue;
+    }
+
+    uint allocValue()
+    {
+        StringValue!(T) sv;
+        sv.lstring[0] = 0;
+        return 0;
+    }
+
+    StringValue!T* getValue()
+    {
+        return cast(StringValue!T*)&this;
+    }
+}
+
+// Other tests are the same as the original issue, but use other kinds of
+// nesting Dsymbols that need to be handled by templateInstanceSemantic().
+struct StringValue2(T)
+{
+    char* lstring()
+    {
+        return cast(char*)&this;
+    }
+}
+
+struct StringTable2(T)
+{
+  @nogc // AttribDeclaration (also covers pragma, extern(), static foreach, ...)
+  {
+    StringValue2!T* insert()
+    {
+        allocValue;
+        return getValue;
+    }
+
+    uint allocValue()
+    {
+        StringValue2!(T) sv;
+        sv.lstring[0] = 0;
+        return 0;
+    }
+
+    StringValue2!T* getValue()
+    {
+        return cast(StringValue2!T*)&this;
+    }
+  }
+}
+
+//
+struct StringValue3(T)
+{
+    char* lstring()
+    {
+        return cast(char*)&this;
+    }
+}
+
+struct StringTable3(T)
+{
+  static if (true) // ConditionalDeclaration (static if)
+  {
+    StringValue3!T* insert()
+    {
+        allocValue;
+        return getValue;
+    }
+
+    uint allocValue()
+    {
+        StringValue3!(T) sv;
+        sv.lstring[0] = 0;
+        return 0;
+    }
+
+    StringValue3!T* getValue()
+    {
+        return cast(StringValue3!T*)&this;
+    }
+  }
+}

--- a/test/compilable/test21299a.d
+++ b/test/compilable/test21299a.d
@@ -1,0 +1,4 @@
+// EXTRA_SOURCES: imports/test21299/mtype.d imports/test21299/rootstringtable.d
+// REQUIRED_ARGS: -main
+// LINK
+module test21299a;

--- a/test/compilable/test21299b.d
+++ b/test/compilable/test21299b.d
@@ -1,0 +1,4 @@
+// EXTRA_SOURCES: imports/test21299/func.d imports/test21299/rootstringtable.d
+// REQUIRED_ARGS: -main
+// LINK:
+module test21299b;

--- a/test/compilable/test21299c.d
+++ b/test/compilable/test21299c.d
@@ -1,0 +1,5 @@
+// EXTRA_SOURCES: imports/test21299/mtype.d imports/test21299/func.d imports/test21299/rootstringtable.d
+// COMPILE_SEPARATELY:
+// LINK:
+module test21299c;
+void main() {}


### PR DESCRIPTION
Backport of #11837, which'll be backported to gcc-9 and gcc-10 to squash any bootstrap issues that may come about from refactoring dmd.