### PR TITLE
dtoh: Implement visit method for TypeNull types

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -7,11 +7,12 @@ experimental C++ header generator:
   C++ standard set from `-extern-std=` is c++11 or later.
 - Forward referenced declarations are now properly indented.
 - Tuple members/parameters/variables are emitted as individual variables
-  using the compiler internal names instaed of causing an assertion failure.
+  using the compiler internal names instead of causing an assertion failure.
 - Interfaces are now emitted as base classes.
 - No auto-generated default constructor for unions
 - Opaque enums no longer cause segfaults & are properly exported for C++ 11
 - C++11 constructs are avoided when compiling with `-extern-std=c++98`.
+- Using `typeof(null)` type no longer causes an assertion failure.
 
 Note: The header generator is still considerer experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1342,6 +1342,20 @@ public:
         buf.writestring(t.ident.toChars());
     }
 
+    override void visit(AST.TypeNull t)
+    {
+        debug (Debug_DtoH)
+        {
+            printf("[AST.TypeNull enter] %s\n", t.toChars());
+            scope(exit) printf("[AST.TypeNull exit] %s\n", t.toChars());
+        }
+        if (global.params.cplusplus >= CppStdRevision.cpp11)
+            buf.writestring("nullptr_t");
+        else
+            buf.writestring("void*");
+
+    }
+
     override void visit(AST.TypeBasic t)
     {
         debug (Debug_DtoH)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3497,6 +3497,7 @@ public:
     void typeToBuffer(Type* t, Identifier* ident);
     void visit(Type* t);
     void visit(TypeIdentifier* t);
+    void visit(TypeNull* t);
     void visit(TypeBasic* t);
     void visit(TypePointer* t);
     void visit(TypeSArray* t);

--- a/test/compilable/dtoh_VarDeclaration.d
+++ b/test/compilable/dtoh_VarDeclaration.d
@@ -26,6 +26,10 @@ union U;
 union U2;
 
 extern "C" size_t v;
+
+extern nullptr_t typeof_null;
+
+extern nullptr_t inferred_null;
 ---
 */
 
@@ -50,3 +54,6 @@ extern (C) union U;
 extern (C++) union U2;
 
 extern (C) size_t v;
+
+extern (C++) __gshared typeof(null) typeof_null = null;
+extern (C++) __gshared inferred_null = null;

--- a/test/compilable/dtoh_cpp98_compat.d
+++ b/test/compilable/dtoh_cpp98_compat.d
@@ -20,6 +20,10 @@ struct Null
     }
 };
 
+extern void* typeof_null;
+
+extern void* inferred_null;
+
 ---
 */
 
@@ -27,3 +31,6 @@ extern (C++) struct Null
 {
     void* field = null;
 }
+
+extern (C++) __gshared typeof(null) typeof_null = null;
+extern (C++) __gshared inferred_null = null;


### PR DESCRIPTION
In `cpmangle.d`, `typeof(null)` is mangled as a `nullptr_t`, so that's what we go for here in the dtoh translation.