### PR TITLE
Fix 20604 - [ICE] dtoh ICE with nested template structs

### DIFF
--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1634,6 +1634,16 @@ public:
         buf.writestring(" >");
     }
 
+    override void visit(AST.TypeInstance t)
+    {
+        debug (Debug_DtoH)
+        {
+            printf("[AST.TypeInstance enter] %s\n", t.toChars());
+            scope(exit) printf("[AST.TypeInstance exit] %s\n", t.toChars());
+        }
+        visitTi(t.tempinst);
+    }
+
     private void visitTi(AST.TemplateInstance ti)
     {
         debug (Debug_DtoH)
@@ -1670,7 +1680,7 @@ public:
                 if (!AST.isType(o))
                     return;
             }
-            buf.writestring(ti.tempdecl.ident.toChars());
+            buf.writestring(ti.name.toChars());
         }
         buf.writeByte('<');
         foreach (i, o; *ti.tiargs)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3983,6 +3983,7 @@ public:
     void visit(TypeEnum* t);
     void visit(TypeStruct* t);
     void visit(TypeDArray* t);
+    void visit(TypeInstance* t);
     void visit(TemplateDeclaration* td);
     void visit(TypeClass* t);
     void visit(Parameter* p);

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -27,6 +27,20 @@ struct B
     {
     }
 };
+
+template <typename T>
+struct Foo
+{
+    // Ignoring var val alignment 0
+    T val;
+};
+
+template <typename T>
+struct Bar
+{
+    // Ignoring var v alignment 0
+    Foo<T> v;
+};
 ---
 */
 
@@ -41,4 +55,18 @@ extern (C++) struct A(T)
 extern (C++) struct B
 {
     A!int x;
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=20604
+extern(C++)
+{
+    struct Foo (T)
+    {
+        T val;
+    }
+
+    struct Bar (T)
+    {
+        Foo!T v;
+    }
 }


### PR DESCRIPTION
Define a handler for TypeInstance and handle potentially missing template identifiers.

(Extracted from #11848)

---

Currently not targeting `stable` because the issue was marked as major because of the CI role and all recent improvements were merged to `master`.