### PR TITLE
dtoh: Remove isBuildingCompiler and related code

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3918,8 +3918,6 @@ public:
     ~TemplateMixin();
 };
 
-enum : bool { isBuildingCompiler = false };
-
 extern void genCppHdrFiles(Array<Module*>& ms);
 
 class ToCppBuffer : public Visitor


### PR DESCRIPTION
As frontend.h is being built without it, I assume then that the goal is to make dtoh usable without the need for "insider knowledge" specific to the dmd internals.