### PR TITLE
dtoh: Handle typeof(...) in template declarations

### DIFF
--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1437,6 +1437,35 @@ public:
 
     }
 
+    override void visit(AST.TypeTypeof t)
+    {
+        debug (Debug_DtoH)
+        {
+            printf("[AST.TypeInstance enter] %s\n", t.toChars());
+            scope(exit) printf("[AST.TypeInstance exit] %s\n", t.toChars());
+        }
+        assert(t.exp);
+
+        if (t.exp.type)
+        {
+            t.exp.type.accept(this);
+        }
+        else if (t.exp.isThisExp())
+        {
+            // Short circuit typeof(this) => <Aggregate name>
+            assert(adparent);
+            buf.writestring(adparent.ident.toChars());
+        }
+        else
+        {
+            // Relying on C++'s typeof might produce wrong results
+            // but it's the best we've got here.
+            buf.writestring("typeof(");
+            t.exp.accept(this);
+            buf.writeByte(')');
+        }
+    }
+
     override void visit(AST.TypeBasic t)
     {
         debug (Debug_DtoH)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3975,6 +3975,7 @@ public:
     void visit(Type* t);
     void visit(TypeIdentifier* t);
     void visit(TypeNull* t);
+    void visit(TypeTypeof* t);
     void visit(TypeBasic* t);
     void visit(TypePointer* t);
     void visit(TypeSArray* t);

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -41,6 +41,14 @@ struct Bar
     // Ignoring var v alignment 0
     Foo<T> v;
 };
+
+template <typename T>
+struct Array
+{
+    typedef Array This;
+    typedef typeof(1 + 2) Int;
+    typedef typeof(T::a) IC;
+};
 ---
 */
 
@@ -69,4 +77,11 @@ extern(C++)
     {
         Foo!T v;
     }
+}
+
+extern (C++) struct Array(T)
+{
+    alias This = typeof(this);
+    alias Int = typeof(1 + 2);
+    alias IC = typeof(T.a);
 }


### PR DESCRIPTION
`typeof(...)` is usually replaced during semantic but not inside of a template declarations. This triggered an assertion failure because there was no appropriate `visit` implementation for `TypeTypeof`.