### PR TITLE
fix Issue 21320 - @live mistakes borrowed pointer for owner in parameter

### DIFF
--- a/src/dmd/ob.d
+++ b/src/dmd/ob.d
@@ -1844,6 +1844,8 @@ void doDataFlowAnalysis(ref ObState obstate)
         {
             if (v.isOut())
                 state = PtrState.Undefined;
+            else if (v.isBorrowedPtr())
+                state = PtrState.Borrowed;
             else
                 state = PtrState.Owner;
         }

--- a/test/fail_compilation/fob2.d
+++ b/test/fail_compilation/fob2.d
@@ -161,3 +161,18 @@ fail_compilation/fob2.d(603): Error: variable `fob2.test6.p` is left dangling at
     return p;
 }
 
+/* TEST_OUTPUT:
+---
+fail_compilation/fob2.d(705): Error: variable `fob2.test7.p` is not Owner, cannot consume its value
+---
+*/
+
+#line 700
+
+void free7(int*);
+
+@live void test7(scope int* p)
+{
+    free7(p);
+}
+


### PR DESCRIPTION
Shouldn't be able to free a borrowed pointer.