### PR TITLE
dtoh: Emit templated function declarations

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3947,6 +3947,7 @@ public:
     bool forwardedAA;
     Type** origType;
     Kind currentProt;
+    int32_t ignoredCounter;
     bool hasReal;
     bool printIgnored;
     ToCppBuffer(OutBuffer* checkbuf, OutBuffer* fwdbuf, OutBuffer* donebuf, OutBuffer* buf);
@@ -7620,6 +7621,24 @@ public:
     // Ignoring var SMALLARRAYCAP alignment 0
     // Ignoring var smallarray alignment 0
     void* smallarray;
+    Array(size_t dim);
+    ~Array();
+    const char* toChars() const;
+    Array& push(T ptr);
+    Array& append(Array* a);
+    void reserve(size_t nentries);
+    void remove(size_t i);
+    void insert(size_t index, Array* a);
+    void insert(size_t index, T ptr);
+    void setDim(size_t newdim);
+    size_t find(T ptr) const;
+    bool contains(T ptr) const;
+    T& opIndex(size_t i);
+    T* tdata();
+    Array<T>* copy() const;
+    void shift(T ptr);
+    void zero();
+    T pop();
     typedef length opDollar;
     typedef length dim;
 };

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -17,6 +17,7 @@ struct A
     // Ignoring var x alignment 0
 public:
     T x;
+    void foo();
 };
 
 struct B
@@ -48,7 +49,15 @@ struct Array
     typedef Array This;
     typedef typeof(1 + 2) Int;
     typedef typeof(T::a) IC;
+    Array(size_t dim);
+    ~Array();
+    void get() const;
+    template <typename T>
+    bool opCast() const;
 };
+
+template <typename T, typename U>
+extern T foo(U u);
 ---
 */
 
@@ -84,4 +93,17 @@ extern (C++) struct Array(T)
     alias This = typeof(this);
     alias Int = typeof(1 + 2);
     alias IC = typeof(T.a);
+
+    this(size_t dim) pure nothrow {}
+    @disable this(this);
+    ~this() {}
+    void get() const {}
+
+    bool opCast(T)() const pure nothrow @nogc @safe
+    if (is(T == bool))
+    {
+        return str.ptr !is null;
+    }
 }
+
+extern(C++) T foo(T, U)(U u) { return T.init; }

--- a/test/compilable/dtoh_verbose.d
+++ b/test/compilable/dtoh_verbose.d
@@ -17,6 +17,7 @@ TEST_OUTPUT:
 // Ignored non-cpp class C
 // Ignored function dtoh_verbose.bar because it's extern
 // Ignored variable dtoh_verbose.i1 because of linkage
+// Ignored template dtoh_verbose.templ(T)(T t) because of linkage
 // Ignored function dtoh_verbose.templ!int.templ
 // Ignored enum dtoh_verbose.arrayOpaque because of it's base type
 struct Hidden


### PR DESCRIPTION
Previously only templated struct declarations were emitted because templated declarations require special handling (missing attributes, incomplete information, ...).

This commit enables templated functions but other declarations are still pending.

---

Extracted from #11848 