### PR TITLE
dtoh: Emit _d_dynamicArray template which represents slices

### DIFF
--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -126,7 +126,7 @@ extern(C++) void genCppHdrFiles(ref Modules ms)
     buf.writenl();
     buf.writestringln("#pragma once");
     buf.writenl();
-//    buf.writestring("#include <assert.h>\n");
+    hashInclude(buf, "<assert.h>");
     hashInclude(buf, "<stddef.h>");
     hashInclude(buf, "<stdint.h>");
 //    buf.writestring(buf, "#include <stdio.h>\n");
@@ -149,6 +149,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 `);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5,6 +5,22 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 #if !defined(_d_real)
 # define _d_real long double
 #endif
@@ -1128,7 +1144,7 @@ struct ObjcClassDeclaration
 struct FileName
 {
 private:
-    DArray< const char > str;
+    _d_dynamicArray< const char > str;
 public:
     static bool equals(const char* name1, const char* name2);
     static bool absolute(const char* name);
@@ -2346,7 +2362,7 @@ struct BaseClass
     ClassDeclaration* sym;
     uint32_t offset;
     Array<FuncDeclaration* > vtbl;
-    DArray< BaseClass > baseInterfaces;
+    _d_dynamicArray< BaseClass > baseInterfaces;
     bool fillVtbl(ClassDeclaration* cd, Array<FuncDeclaration* >* vtbl, int32_t newinstance);
     ~BaseClass();
     BaseClass() :
@@ -2387,7 +2403,7 @@ public:
     Array<Dsymbol* > vtbl;
     Array<Dsymbol* > vtblFinal;
     Array<BaseClass* >* baseclasses;
-    DArray< BaseClass* > interfaces;
+    _d_dynamicArray< BaseClass* > interfaces;
     Array<BaseClass* >* vtblInterfaces;
     TypeInfoClassDeclaration* vclassinfo;
     bool com;
@@ -2527,7 +2543,7 @@ public:
     Prot protection;
     LINK linkage;
     int32_t inuse;
-    DArray< char > mangleOverride;
+    _d_dynamicArray< char > mangleOverride;
     const char* kind() const;
     d_uns64 size(const Loc& loc);
     Dsymbol* search(const Loc& loc, Identifier* ident, int32_t flags = 8);
@@ -2954,7 +2970,7 @@ public:
     static void _init();
     static void deinitialize();
     static AggregateDeclaration* moduleinfo;
-    DArray< char > arg;
+    _d_dynamicArray< char > arg;
     ModuleDeclaration* md;
     FileName srcfile;
     FileName objfile;
@@ -5072,13 +5088,13 @@ extern "C" void printInternalFailure(_IO_FILE* stream);
 
 extern void generateJson(Array<Module* >* modules);
 
-typedef int32_t(*MainFunc)(DArray< DArray< char > > args);
+typedef int32_t(*MainFunc)(_d_dynamicArray< _d_dynamicArray< char > > args);
 
-extern "C" DArray< DArray< char > > rt_options;
+extern "C" _d_dynamicArray< _d_dynamicArray< char > > rt_options;
 
 extern "C" int32_t main(int32_t argc, char** argv);
 
-extern "C" int32_t _Dmain(DArray< DArray< char > > _param_0);
+extern "C" int32_t _Dmain(_d_dynamicArray< _d_dynamicArray< char > > _param_0);
 
 extern "C" void printGlobalConfigs(_IO_FILE* stream);
 
@@ -6464,7 +6480,7 @@ struct Target
     TargetC c;
     TargetCPP cpp;
     TargetObjC objc;
-    DArray< const char > architectureName;
+    _d_dynamicArray< const char > architectureName;
     template <typename T>
     struct FPTypeProperties
     {
@@ -6841,26 +6857,26 @@ struct Param
     CHECKENABLE boundscheck;
     CHECKACTION checkAction;
     uint32_t errorLimit;
-    DArray< const char > argv0;
+    _d_dynamicArray< const char > argv0;
     Array<const char* > modFileAliasStrings;
     Array<const char* >* imppath;
     Array<const char* >* fileImppath;
-    DArray< const char > objdir;
-    DArray< const char > objname;
-    DArray< const char > libname;
+    _d_dynamicArray< const char > objdir;
+    _d_dynamicArray< const char > objname;
+    _d_dynamicArray< const char > libname;
     bool doDocComments;
-    DArray< const char > docdir;
-    DArray< const char > docname;
+    _d_dynamicArray< const char > docdir;
+    _d_dynamicArray< const char > docname;
     Array<const char* > ddocfiles;
     bool doHdrGeneration;
-    DArray< const char > hdrdir;
-    DArray< const char > hdrname;
+    _d_dynamicArray< const char > hdrdir;
+    _d_dynamicArray< const char > hdrname;
     bool hdrStripPlainFunctions;
     CxxHeaderMode doCxxHdrGeneration;
-    DArray< const char > cxxhdrdir;
-    DArray< const char > cxxhdrname;
+    _d_dynamicArray< const char > cxxhdrdir;
+    _d_dynamicArray< const char > cxxhdrname;
     bool doJsonGeneration;
-    DArray< const char > jsonfilename;
+    _d_dynamicArray< const char > jsonfilename;
     JsonFieldFlags jsonFieldFlags;
     OutBuffer* mixinOut;
     const char* mixinFile;
@@ -6869,10 +6885,10 @@ struct Param
     Array<const char* >* debugids;
     uint32_t versionlevel;
     Array<const char* >* versionids;
-    DArray< const char > defaultlibname;
-    DArray< const char > debuglibname;
-    DArray< const char > mscrtlib;
-    DArray< const char > moduleDepsFile;
+    _d_dynamicArray< const char > defaultlibname;
+    _d_dynamicArray< const char > debuglibname;
+    _d_dynamicArray< const char > mscrtlib;
+    _d_dynamicArray< const char > moduleDepsFile;
     OutBuffer* moduleDeps;
     MessageStyle messageStyle;
     bool debugb;
@@ -6888,10 +6904,10 @@ struct Param
     Array<bool > linkswitchIsForCC;
     Array<const char* > libfiles;
     Array<const char* > dllfiles;
-    DArray< const char > deffile;
-    DArray< const char > resfile;
-    DArray< const char > exefile;
-    DArray< const char > mapfile;
+    _d_dynamicArray< const char > deffile;
+    _d_dynamicArray< const char > resfile;
+    _d_dynamicArray< const char > exefile;
+    _d_dynamicArray< const char > mapfile;
     ~Param();
     Param() :
         obj(true),
@@ -7045,23 +7061,23 @@ enum : uint32_t { STRUCTALIGN_DEFAULT = 4294967295u };
 
 struct Global
 {
-    DArray< const char > inifilename;
-    DArray< char > mars_ext;
-    DArray< const char > obj_ext;
-    DArray< const char > lib_ext;
-    DArray< const char > dll_ext;
-    DArray< char > doc_ext;
-    DArray< char > ddoc_ext;
-    DArray< char > hdr_ext;
-    DArray< char > cxxhdr_ext;
-    DArray< char > json_ext;
-    DArray< char > map_ext;
+    _d_dynamicArray< const char > inifilename;
+    _d_dynamicArray< char > mars_ext;
+    _d_dynamicArray< const char > obj_ext;
+    _d_dynamicArray< const char > lib_ext;
+    _d_dynamicArray< const char > dll_ext;
+    _d_dynamicArray< char > doc_ext;
+    _d_dynamicArray< char > ddoc_ext;
+    _d_dynamicArray< char > hdr_ext;
+    _d_dynamicArray< char > cxxhdr_ext;
+    _d_dynamicArray< char > json_ext;
+    _d_dynamicArray< char > map_ext;
     bool run_noext;
-    DArray< char > copyright;
-    DArray< char > written;
+    _d_dynamicArray< char > copyright;
+    _d_dynamicArray< char > written;
     Array<const char* >* path;
     Array<const char* >* filePath;
-    DArray< const char > vendor;
+    _d_dynamicArray< const char > vendor;
     Param params;
     uint32_t errors;
     uint32_t warnings;
@@ -7542,7 +7558,7 @@ class Identifier final : public RootObject
 {
     int32_t value;
     bool isAnonymous_;
-    DArray< char > name;
+    _d_dynamicArray< char > name;
 public:
     static Identifier* create(const char* name);
     const char* toChars() const;
@@ -7561,8 +7577,8 @@ struct Token
     Loc loc;
     const char* ptr;
     TOK value;
-    DArray< const char > blockComment;
-    DArray< const char > lineComment;
+    _d_dynamicArray< const char > blockComment;
+    _d_dynamicArray< const char > lineComment;
     union
     {
         int64_t intvalue;
@@ -7598,7 +7614,7 @@ struct Array
     // Ignoring var length alignment 0
     size_t length;
     // Ignoring var data alignment 0
-    DArray< T > data;
+    _d_dynamicArray< T > data;
     // Ignoring var SMALLARRAYCAP alignment 0
     // Ignoring var smallarray alignment 0
     void* smallarray;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -19,6 +20,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 #if !defined(_d_real)

--- a/test/compilable/dtoh_21217.d
+++ b/test/compilable/dtoh_21217.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_21217.d
+++ b/test/compilable/dtoh_21217.d
@@ -10,13 +10,29 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 struct Foo
 {
     int32_t a;
     enum : int32_t { b = 2 };
 
-    // Ignored enum `test21217.Foo.c` because it is `private`.
+    // Ignored enum `dtoh_21217.Foo.c` because it is `private`.
 protected:
     enum : int32_t { d = 4 };
 
@@ -34,7 +50,7 @@ private:
         b = 2,
     };
 
-    // Ignored enum `test21217.Foo.h` because it is `private`.
+    // Ignored enum `dtoh_21217.Foo.h` because it is `private`.
 public:
     Foo() :
         a(1)

--- a/test/compilable/dtoh_AliasDeclaration.d
+++ b/test/compilable/dtoh_AliasDeclaration.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_AliasDeclaration.d
+++ b/test/compilable/dtoh_AliasDeclaration.d
@@ -10,6 +10,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 struct S;
 struct S2;

--- a/test/compilable/dtoh_AliasDeclaration_98.d
+++ b/test/compilable/dtoh_AliasDeclaration_98.d
@@ -9,6 +9,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 template <typename T, typename U>
 struct TS

--- a/test/compilable/dtoh_AliasDeclaration_98.d
+++ b/test/compilable/dtoh_AliasDeclaration_98.d
@@ -6,6 +6,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -23,6 +24,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_AnonDeclaration.d
+++ b/test/compilable/dtoh_AnonDeclaration.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_AnonDeclaration.d
+++ b/test/compilable/dtoh_AnonDeclaration.d
@@ -10,6 +10,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 struct S
 {

--- a/test/compilable/dtoh_CPPNamespaceDeclaration.d
+++ b/test/compilable/dtoh_CPPNamespaceDeclaration.d
@@ -10,6 +10,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 namespace nameSpace
 {

--- a/test/compilable/dtoh_CPPNamespaceDeclaration.d
+++ b/test/compilable/dtoh_CPPNamespaceDeclaration.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_ClassDeclaration.d
+++ b/test/compilable/dtoh_ClassDeclaration.d
@@ -10,6 +10,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 class C;
 class A;

--- a/test/compilable/dtoh_ClassDeclaration.d
+++ b/test/compilable/dtoh_ClassDeclaration.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_StructDeclaration.d
+++ b/test/compilable/dtoh_StructDeclaration.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_StructDeclaration.d
+++ b/test/compilable/dtoh_StructDeclaration.d
@@ -10,6 +10,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 struct S;
 struct Inner;
@@ -19,10 +35,12 @@ struct S
     int8_t a;
     int32_t b;
     int64_t c;
+    _d_dynamicArray< int32_t > arr;
     S() :
         a(),
         b(),
-        c()
+        c(),
+        arr()
     {
     }
 };
@@ -151,6 +169,7 @@ extern (C++) struct S
     byte a;
     int b;
     long c;
+    int[] arr;
 }
 
 extern (C++) struct S2

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -10,6 +10,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 template <typename T>
 struct A

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_VarDeclaration.d
+++ b/test/compilable/dtoh_VarDeclaration.d
@@ -10,6 +10,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 #if !defined(_d_real)
 # define _d_real long double
 #endif
@@ -40,7 +56,7 @@ extern _d_real r;
 
 extern int32_t si[4$?:32=u|64=LLU$];
 
-extern const DArray< const int32_t > di;
+extern const _d_dynamicArray< const int32_t > di;
 
 extern void* ii;
 

--- a/test/compilable/dtoh_VarDeclaration.d
+++ b/test/compilable/dtoh_VarDeclaration.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 #if !defined(_d_real)

--- a/test/compilable/dtoh_cpp98_compat.d
+++ b/test/compilable/dtoh_cpp98_compat.d
@@ -10,6 +10,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 struct Null
 {

--- a/test/compilable/dtoh_cpp98_compat.d
+++ b/test/compilable/dtoh_cpp98_compat.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_enum.d
+++ b/test/compilable/dtoh_enum.d
@@ -10,6 +10,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 struct Foo;
 struct FooCpp;

--- a/test/compilable/dtoh_enum.d
+++ b/test/compilable/dtoh_enum.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_enum_cpp98.d
+++ b/test/compilable/dtoh_enum_cpp98.d
@@ -10,6 +10,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 struct Foo;
 struct FooCpp;

--- a/test/compilable/dtoh_enum_cpp98.d
+++ b/test/compilable/dtoh_enum_cpp98.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_extern_type.d
+++ b/test/compilable/dtoh_extern_type.d
@@ -11,6 +11,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 class ClassFromStruct
 {

--- a/test/compilable/dtoh_extern_type.d
+++ b/test/compilable/dtoh_extern_type.d
@@ -8,6 +8,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -25,6 +26,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_functions.d
+++ b/test/compilable/dtoh_functions.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_functions.d
+++ b/test/compilable/dtoh_functions.d
@@ -10,6 +10,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 struct S;
 struct S2;
@@ -80,7 +96,7 @@ extern int32_t(*f)(int32_t );
 
 extern void special(int32_t a = ptr->i, int32_t b = ptr->get(1, 2), int32_t j = (*f)(1));
 
-extern void strings(DArray< char > s = "\"Hello\\World!\"");
+extern void strings(_d_dynamicArray< char > s = "\"Hello\\World!\"");
 
 extern void variadic(int32_t _param_0, ...);
 ---

--- a/test/compilable/dtoh_protection.d
+++ b/test/compilable/dtoh_protection.d
@@ -8,6 +8,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -25,6 +26,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_protection.d
+++ b/test/compilable/dtoh_protection.d
@@ -11,6 +11,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 struct S1
 {

--- a/test/compilable/dtoh_unittest_block.d
+++ b/test/compilable/dtoh_unittest_block.d
@@ -10,6 +10,23 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
+
 
 ---
 */

--- a/test/compilable/dtoh_unittest_block.d
+++ b/test/compilable/dtoh_unittest_block.d
@@ -7,6 +7,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -24,6 +25,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/compilable/dtoh_verbose.d
+++ b/test/compilable/dtoh_verbose.d
@@ -9,6 +9,22 @@ TEST_OUTPUT:
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef CUSTOM_D_ARRAY_TYPE
+#define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
+#else
+/// Represents a D [] array
+template<typename T>
+struct _d_dynamicArray
+{
+    size_t length;
+    T *ptr;
+
+    _d_dynamicArray() : length(0), ptr(NULL) { }
+
+    _d_dynamicArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
+};
+#endif
 
 // Ignored function dtoh_verbose.foo because of linkage
 // Ignored variable dtoh_verbose.i because of linkage

--- a/test/compilable/dtoh_verbose.d
+++ b/test/compilable/dtoh_verbose.d
@@ -6,6 +6,7 @@ TEST_OUTPUT:
 
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -23,6 +24,16 @@ struct _d_dynamicArray
 
     _d_dynamicArray(size_t length_in, T *ptr_in)
         : length(length_in), ptr(ptr_in) { }
+
+    T& operator[](const size_t idx) {
+        assert(idx < length);
+        return ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        assert(idx < length);
+        return ptr[idx];
+    }
 };
 #endif
 

--- a/test/dshell/extra-files/cpp_header_gen/app.cpp
+++ b/test/dshell/extra-files/cpp_header_gen/app.cpp
@@ -1,6 +1,3 @@
-// This should be solved by the header generator
-
-#include "dcompat.h"
 #include "library.h"
 
 #include <assert.h>

--- a/test/dshell/extra-files/cpp_header_gen/app.cpp
+++ b/test/dshell/extra-files/cpp_header_gen/app.cpp
@@ -13,6 +13,8 @@ int main()
     assert(!c->s.b);
     assert(c->name.ptr == name);
     assert(c->name.length == length);
+    assert(c->name[1] == 'e');
+    assert(const_cast<const C*>(c)->name[2] == 'a');
     c->verify();
 
     assert(foo(c->s) == bar(c));


### PR DESCRIPTION
Since slices are a central building block of D, they should also be easily accessible from C++.

CC @ibuclaw 

----
Questions:

- Should `_d_dynamicArray` define addtional functions, e.g. `operator[]`?
- Should `_d_dynamicArray` be hidden behind an `#if !defined(...)` to allow custom definitions?