### PR TITLE
dtoh: Remove special handling for templated struct declarations

### DIFF
--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -796,18 +796,21 @@ public:
             printf("[AST.StructDeclaration enter] %s\n", sd.toChars());
             scope(exit) printf("[AST.StructDeclaration exit] %s\n", sd.toChars());
         }
-        if (sd.isInstantiated())
+        auto td = sd.isInstantiated();
+        if (td && td !is tdparent)
             return;
         if (cast(void*)sd in visited)
             return;
-        if (!sd.type || !sd.type.deco)
-            return;
+
         visited[cast(void*)sd] = true;
         if (linkage != LINK.c && linkage != LINK.cpp)
         {
             ignored("non-cpp struct %s because of linkage", sd.toChars());
             return;
         }
+
+        const ignoredStash = this.ignoredCounter;
+        scope (exit) this.ignoredCounter = ignoredStash;
 
         pushAlignToBuffer(sd.alignment);
 
@@ -934,12 +937,18 @@ public:
         popAlignToBuffer(sd.alignment);
         buf.writenl();
 
-        checkbuf.level++;
-        const sn = sd.ident.toChars();
-        const sz = sd.size(Loc.initial);
-        checkbuf.printf("assert(sizeof(%s) == %llu);", sn, sz);
-        checkbuf.writenl();
-        checkbuf.level--;
+        // Workaround because size triggers a forward-reference error
+        // for struct templates (the size is undetermined even if the
+        // size doesn't depend on the parameters)
+        if (!tdparent)
+        {
+            checkbuf.level++;
+            const sn = sd.ident.toChars();
+            const sz = sd.size(Loc.initial);
+            checkbuf.printf("assert(sizeof(%s) == %llu);", sn, sz);
+            checkbuf.writenl();
+            checkbuf.level--;
+        }
     }
 
     private void pushAlignToBuffer(uint alignment)
@@ -949,7 +958,8 @@ public:
         //       "Invalid alignment size");
 
         // When no alignment is specified, `uint.max` is the default
-        if (alignment == STRUCTALIGN_DEFAULT)
+        // FIXME: alignment is 0 for structs templated members
+        if (alignment == STRUCTALIGN_DEFAULT || (tdparent && alignment == 0))
         {
             return;
         }
@@ -960,7 +970,7 @@ public:
 
     private void popAlignToBuffer(uint alignment)
     {
-        if (alignment == STRUCTALIGN_DEFAULT)
+        if (alignment == STRUCTALIGN_DEFAULT || (tdparent && alignment == 0))
             return;
 
         buf.writestringln("#pragma pack(pop)");
@@ -1595,42 +1605,13 @@ public:
         }
         buf.writestringln(">");
 
-        // TODO replace this block with a sd.accept
-        if (auto sd = td.onemember.isStructDeclaration())
-        {
-            buf.writestring(sd.isUnionDeclaration() ? "union " : "struct ");
-            buf.writestring(sd.ident.toChars());
-            if (sd.members)
-            {
-                buf.writenl();
-                buf.writestringln("{");
-                auto savex = adparent;
-                adparent = sd;
-                buf.level++;
-                foreach (m; *sd.members)
-                {
-                    m.accept(this);
-                }
-                buf.level--;
-                adparent = savex;
-                buf.writestringln("};");
-                buf.writenl();
-            }
-            else
-            {
-                buf.writestringln(";");
-                buf.writenl();
-            }
-        }
-        else
-        {
-            const oldIgnored = this.ignoredCounter;
-            td.onemember.accept(this);
+        const oldIgnored = this.ignoredCounter;
+        td.onemember.accept(this);
 
-            // Remove "template<...>" if the symbol could not be emitted
-            if (oldIgnored != this.ignoredCounter)
-                buf.setsize(bookmark);
-        }
+        // Remove "template<...>" if the symbol could not be emitted
+        if (oldIgnored != this.ignoredCounter)
+            buf.setsize(bookmark);
+
         tdparent = save;
     }
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6953,6 +6953,9 @@ struct Target
         d_int64 max_10_exp;
         // Ignoring var min_10_exp alignment 0
         d_int64 min_10_exp;
+        FPTypeProperties()
+        {
+        }
     };
 
     FPTypeProperties<float> FloatProperties;
@@ -7614,7 +7617,6 @@ template <typename T>
 struct Array
 {
     // Ignoring var length alignment 0
-public:
     size_t length;
     // Ignoring var data alignment 0
     DArray< T > data;
@@ -7641,6 +7643,9 @@ public:
     T pop();
     typedef length opDollar;
     typedef length dim;
+    Array()
+    {
+    }
 };
 
 struct CTFloat

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -15,9 +15,11 @@ template <typename T>
 struct A
 {
     // Ignoring var x alignment 0
-public:
     T x;
     void foo();
+    A()
+    {
+    }
 };
 
 struct B
@@ -34,6 +36,9 @@ struct Foo
 {
     // Ignoring var val alignment 0
     T val;
+    Foo()
+    {
+    }
 };
 
 template <typename T>
@@ -41,6 +46,9 @@ struct Bar
 {
     // Ignoring var v alignment 0
     Foo<T> v;
+    Bar()
+    {
+    }
 };
 
 template <typename T>
@@ -54,6 +62,9 @@ struct Array
     void get() const;
     template <typename T>
     bool opCast() const;
+    Array()
+    {
+    }
 };
 
 template <typename T, typename U>


### PR DESCRIPTION
Replace the custom logic with a simple `visit` call and adapt
`visit(AST.StructDeclaration)` to deal with the oddities of a templated
`StructDeclaration`.

@ibuclaw This also fixes the redundant `public:` for templated structs.

---

(Another fix extracted from #11848) 