### PR TITLE
Fix 21313 - Use curl's retry-all-errors option

### DIFF
--- a/.azure-pipelines/lib.sh
+++ b/.azure-pipelines/lib.sh
@@ -25,7 +25,7 @@ clone() {
 download() {
     local url="$1"
     local path="$2"
-    curl -fsSL -A "$CURL_USER_AGENT" --retry 5 --retry-max-time 120  --connect-timeout 5 --speed-time 30 --speed-limit 1024 "$url" -o "$path"
+    curl -fsSL -A "$CURL_USER_AGENT" --retry 5 --retry-all-errors --retry-max-time 300  --connect-timeout 15 --speed-time 30 --speed-limit 1024 "$url" -o "$path"
 }
 
 ################################################################################
@@ -94,4 +94,3 @@ clone_repos() {
         fi
     done
 }
-

--- a/src/bootstrap.sh
+++ b/src/bootstrap.sh
@@ -13,7 +13,7 @@ HOST_DMD_VER="${HOST_DMD_VER:-2.088.0}"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 GENERATED="$( cd "$DIR/.." >/dev/null 2>&1 && pwd )/generated"
-CURL_FLAGS=(-fsSL --retry 5 --retry-max-time 120 --connect-timeout 5 --speed-time 30 --speed-limit 1024)
+CURL_FLAGS=(-fsSL --retry 5 --retry-all-errors --retry-max-time 300 --connect-timeout 15 --speed-time 30 --speed-limit 1024)
 
 # detect model
 uname_m="$(uname -m)"
@@ -57,7 +57,8 @@ if [ ! -e "${HOST_RDMD}" ] ; then
     # prefer xz if available
     if command -v xz &> /dev/null ; then
         echo "[boostrap] Downloading compiler ${HOST_DMD_URL}.tar.xz"
-        curl "${CURL_FLAGS[@]}" "${HOST_DMD_URL}.tar.xz" | tar -C "${HOST_DMD_ROOT}" -Jxf - || rm -rf "${HOST_DMD_ROOT}"
+        curl "${CURL_FLAGS[@]}" "${HOST_DMD_URL}.tar.xz -o ${HOST_DMD_ROOT}/dmd_bootstrap.tar.xz"
+        tar ${HOST_DMD_ROOT}/dmd_bootstrap.tar.xz -C "${HOST_DMD_ROOT}" -Jxf - || rm -rf "${HOST_DMD_ROOT}"
     else
         echo "[bootstrap] Downloading compiler ${HOST_DMD_URL}.zip"
         TMPFILE="$(mktemp deleteme.XXXXXXXX.zip)"

--- a/src/build.d
+++ b/src/build.d
@@ -1065,9 +1065,12 @@ void parseEnvironment()
         if (!env["HOST_DMD"].exists)
         {
             writefln("Downloading DMD %s", hostDMDVer);
-            auto curlFlags = "-fsSL --retry 5 --retry-max-time 120 --connect-timeout 5 --speed-time 30 --speed-limit 1024";
+            const curlFlags = "-fsSL --retry 5 --retry-max-time 300 --connect-timeout 15 --speed-time 30 --speed-limit 1024";
             hostDMDRoot.mkdirRecurse;
-            ("curl " ~ curlFlags ~ " " ~ hostDMDURL~".tar.xz | tar -C "~hostDMDRoot~" -Jxf - || rm -rf "~hostDMDRoot).spawnShell.wait;
+            executeShell("curl " ~ curlFlags ~ "-o " ~
+                         hostDMDRoot ~ "/dmd_bootstrap.tar.xz" ~ hostDMDURL~".tar.xz");
+            executeShell("tar "~ hostDMDRoot ~ "/dmd_bootstrap.tar.xz -C " ~
+                         hostDMDRoot~" -Jxf - || rm -rf "~hostDMDRoot);
         }
     }
     else


### PR DESCRIPTION
```
Curl would only retry 400s, 500s, and timeout, not connection closed by peer
or other kind of transition connections.
Using '--retry-all-errors' fixes this, however care must be put into avoiding
the usage of pipes (see manual).
Additionally, the total timeout was increased to 5 minutes as requested by Walter,
and the connection timeout was also extended to reflect to be more tolerant.
```