### PR TITLE
dtoh: Fully print identifier chains

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -20,6 +20,7 @@ experimental C++ header generator:
 - C++11 constructs are avoided when compiling with `-extern-std=c++98`.
 - Using `typeof(null)` type no longer causes an assertion failure.
 - Final classes are marked as `final`
+- Identifier chains in templates are printed completely
 - Proper vtable layout is ensured by emitting hidden placeholders for
   virtual functions that are not `extern(C|C++)`.
 

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1278,7 +1278,24 @@ public:
             printf("[AST.TypeIdentifier enter] %s\n", t.toChars());
             scope(exit) printf("[AST.TypeIdentifier exit] %s\n", t.toChars());
         }
+        if (t.idents.length)
+            buf.writestring("typename ");
+
         buf.writestring(t.ident.toChars());
+
+        foreach (arg; t.idents)
+        {
+            buf.writestring("::");
+
+            import dmd.root.rootobject;
+            // Is this even possible?
+            if (arg.dyncast != DYNCAST.identifier)
+            {
+                printf("arg.dyncast() = %d\n", arg.dyncast());
+                assert(false);
+            }
+            buf.writestring((cast(Identifier) arg).toChars());
+        }
     }
 
     override void visit(AST.TypeNull t)

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -62,6 +62,11 @@ struct Array
     void get() const;
     template <typename T>
     bool opCast() const;
+    // Ignoring var i alignment 0
+    typename T::Member i;
+    // Ignoring var j alignment 0
+    typename Outer::Member::Nested j;
+    void visit(typename T::Member::Nested i);
     Array()
     {
     }
@@ -115,6 +120,22 @@ extern (C++) struct Array(T)
     {
         return str.ptr !is null;
     }
+
+    T.Member i;
+    Outer.Member.Nested j;
+    void visit(T.Member.Nested i) {}
 }
+
+// Not emitted yet even though it is used above
+struct Outer
+{
+    int a;
+    static struct Member
+    {
+        alias Nested = int;
+    }
+}
+
+// alias AO = Array!Outer;
 
 extern(C++) T foo(T, U)(U u) { return T.init; }


### PR DESCRIPTION
Formerly only the first identifier was emitted instead of all parts.