### PR TITLE
Add more highlighting to some parser error messages

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1466,7 +1466,7 @@ final class Parser(AST) : Lexer
         }
         else
         {
-            error("@identifier or @(ArgumentList) expected, not `@%s`", token.toChars());
+            error("`@identifier` or `@(ArgumentList)` expected, not `@%s`", token.toChars());
         }
 
         if (stc)

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1694,7 +1694,7 @@ final class Parser(AST) : Lexer
                     {
                         if (token.value != TOK.identifier)
                         {
-                            error("identifier expected for template alias parameter");
+                            error("identifier expected for template `alias` parameter");
                             goto Lerr;
                         }
                         tp_ident = token.ident;
@@ -1761,7 +1761,7 @@ final class Parser(AST) : Lexer
                     nextToken();
                     if (token.value != TOK.identifier)
                     {
-                        error("identifier expected for template this parameter");
+                        error("identifier expected for template `this` parameter");
                         goto Lerr;
                     }
                     loc = token.loc;
@@ -1902,7 +1902,7 @@ final class Parser(AST) : Lexer
 
         tm = new AST.TemplateMixin(locMixin, id, tqual, tiargs);
         if (token.value != TOK.semicolon)
-            error("`;` expected after mixin");
+            error("`;` expected after `mixin`");
         nextToken();
 
         return tm;
@@ -2385,7 +2385,7 @@ final class Parser(AST) : Lexer
             else if (token.value == TOK.int32Literal || token.value == TOK.int64Literal)
                 level = cast(uint)token.unsvalue;
             else
-                error("identifier or integer expected inside debug(...), not `%s`", token.toChars());
+                error("identifier or integer expected inside `debug(...)`, not `%s`", token.toChars());
             nextToken();
             check(TOK.rightParentheses);
         }
@@ -2417,7 +2417,7 @@ final class Parser(AST) : Lexer
             else if (token.value == TOK.assert_)
                 id = Identifier.idPool(Token.toString(TOK.assert_));
             else
-                error("identifier or integer expected inside version(...), not `%s`", token.toChars());
+                error("identifier or integer expected inside `version(...)`, not `%s`", token.toChars());
             nextToken();
             check(TOK.rightParentheses);
         }

--- a/test/fail_compilation/b20780.d
+++ b/test/fail_compilation/b20780.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/b20780.d(12): Error: @identifier or @(ArgumentList) expected, not `@)`
+fail_compilation/b20780.d(12): Error: `@identifier` or `@(ArgumentList)` expected, not `@)`
 fail_compilation/b20780.d(12): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`
-fail_compilation/b20780.d(13): Error: @identifier or @(ArgumentList) expected, not `@,`
+fail_compilation/b20780.d(13): Error: `@identifier` or `@(ArgumentList)` expected, not `@,`
 fail_compilation/b20780.d(13): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`
 fail_compilation/b20780.d(13): Error: basic type expected, not `,`
 ---

--- a/test/fail_compilation/diag_debug_conditional.d
+++ b/test/fail_compilation/diag_debug_conditional.d
@@ -1,0 +1,11 @@
+/**
+TEST_OUTPUT:
+---
+fail_compilation/diag_debug_conditional.d(1): Error: identifier or integer expected inside `debug(...)`, not `alias`
+fail_compilation/diag_debug_conditional.d(2): Error: identifier or integer expected inside `version(...)`, not `alias`
+fail_compilation/diag_debug_conditional.d(3): Error: declaration expected following attribute, not end of file
+---
+ */
+#line 1
+debug(alias)
+version(alias)

--- a/test/fail_compilation/diag_template_alias.d
+++ b/test/fail_compilation/diag_template_alias.d
@@ -1,0 +1,11 @@
+/**
+TEST_OUTPUT:
+---
+fail_compilation/diag_template_alias.d(1): Error: identifier expected for template `alias` parameter
+fail_compilation/diag_template_alias.d(1): Error: found `alias` when expecting `(`
+fail_compilation/diag_template_alias.d(1): Error: semicolon expected following function declaration
+fail_compilation/diag_template_alias.d(1): Error: declaration expected, not `(`
+---
+ */
+#line 1
+void func1(alias alias)() {}

--- a/test/fail_compilation/diag_template_this.d
+++ b/test/fail_compilation/diag_template_this.d
@@ -1,0 +1,11 @@
+/**
+TEST_OUTPUT:
+---
+fail_compilation/diag_template_this.d(1): Error: identifier expected for template `this` parameter
+fail_compilation/diag_template_this.d(1): Error: found `this` when expecting `(`
+fail_compilation/diag_template_this.d(1): Error: semicolon expected following function declaration
+fail_compilation/diag_template_this.d(1): Error: declaration expected, not `(`
+---
+ */
+#line 1
+void func1(this this)() {}

--- a/test/fail_compilation/fail246.d
+++ b/test/fail_compilation/fail246.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail246.d-mixin-11(11): Error: identifier expected, not `End of File`
-fail_compilation/fail246.d-mixin-11(11): Error: `;` expected after mixin
+fail_compilation/fail246.d-mixin-11(11): Error: `;` expected after `mixin`
 ---
 */
 

--- a/test/fail_compilation/fail247.d
+++ b/test/fail_compilation/fail247.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail247.d-mixin-9(9): Error: identifier expected, not `End of File`
-fail_compilation/fail247.d-mixin-9(9): Error: `;` expected after mixin
+fail_compilation/fail247.d-mixin-9(9): Error: `;` expected after `mixin`
 ---
 */
 

--- a/test/fail_compilation/ice11967.d
+++ b/test/fail_compilation/ice11967.d
@@ -5,7 +5,7 @@ fail_compilation/ice11967.d(13): Error: use `@(attributes)` instead of `[attribu
 fail_compilation/ice11967.d(13): Error: expression expected, not `%`
 fail_compilation/ice11967.d(13): Error: found `g` when expecting `)`
 fail_compilation/ice11967.d(13): Error: found `{` when expecting `]`
-fail_compilation/ice11967.d(14): Error: @identifier or @(ArgumentList) expected, not `@End of File`
+fail_compilation/ice11967.d(14): Error: `@identifier` or `@(ArgumentList)` expected, not `@End of File`
 fail_compilation/ice11967.d(14): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`
 fail_compilation/ice11967.d(14): Error: declaration expected following attribute, not end of file
 ---


### PR DESCRIPTION
Pretty trivial diff, I was annoyed that some keywords / user code didn't have highlighting so  here's a fix.
While doing so, I also realized that we're pretty inconsistent in some error message, e.g. we have `';' expected following '%'` and `semicolon expected [...]`.