### PR TITLE
Refactor attributes parsing (Parser.parseAttribute)

### DIFF
--- a/test/fail_compilation/b20780.d
+++ b/test/fail_compilation/b20780.d
@@ -1,11 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/b20780.d(12): Error: `@identifier` or `@(ArgumentList)` expected, not `@)`
-fail_compilation/b20780.d(12): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`
-fail_compilation/b20780.d(13): Error: `@identifier` or `@(ArgumentList)` expected, not `@,`
-fail_compilation/b20780.d(13): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`
-fail_compilation/b20780.d(13): Error: basic type expected, not `,`
+fail_compilation/b20780.d(10): Error: `@identifier` or `@(ArgumentList)` expected, not `@)`
+fail_compilation/b20780.d(11): Error: `@identifier` or `@(ArgumentList)` expected, not `@,`
+fail_compilation/b20780.d(11): Error: basic type expected, not `,`
 ---
 */
 

--- a/test/fail_compilation/ice11967.d
+++ b/test/fail_compilation/ice11967.d
@@ -1,13 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11967.d(13): Error: use `@(attributes)` instead of `[attributes]`
-fail_compilation/ice11967.d(13): Error: expression expected, not `%`
-fail_compilation/ice11967.d(13): Error: found `g` when expecting `)`
-fail_compilation/ice11967.d(13): Error: found `{` when expecting `]`
-fail_compilation/ice11967.d(14): Error: `@identifier` or `@(ArgumentList)` expected, not `@End of File`
-fail_compilation/ice11967.d(14): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`
-fail_compilation/ice11967.d(14): Error: declaration expected following attribute, not end of file
+fail_compilation/ice11967.d(12): Error: use `@(attributes)` instead of `[attributes]`
+fail_compilation/ice11967.d(12): Error: expression expected, not `%`
+fail_compilation/ice11967.d(12): Error: found `g` when expecting `)`
+fail_compilation/ice11967.d(12): Error: found `{` when expecting `]`
+fail_compilation/ice11967.d(13): Error: `@identifier` or `@(ArgumentList)` expected, not `@End of File`
+fail_compilation/ice11967.d(13): Error: declaration expected following attribute, not end of file
 ---
 */
 [F(%g{@


### PR DESCRIPTION
```
Use a ref for the parameter instead of a pointer to a pointer,
as passing 'null' would lead to a SEGV.
Change the code flow to return early, avoiding spaghetti control
flow (e.g. 'if (stc) {} else if (...) {} else {}').
Finally, improve documentation to be DDOC-abidding.
```