### PR TITLE
Revert "Fix Issue 21299: Undefined reference to dmd.root.stringtable.StringValue!(Type).lstring()"

### DIFF
--- a/test/compilable/test21299d.d
+++ b/test/compilable/test21299d.d
@@ -1,0 +1,27 @@
+// REQUIRED_ARGS: -main
+// LINK:
+module test21299d;
+
+struct DefaultPredicates
+{
+    struct IsEqual(T)
+    {
+        static opCall(in T, in T)
+        {
+            return 0;
+        }
+    }
+}
+
+void moveToEnd(T, Pred = DefaultPredicates.IsEqual!T)(T[] array, T element, Pred pred = Pred.init)
+{
+    pred(array[0], element);
+}
+
+class Task
+{
+    void removeTerminationHook(void delegate() hook)
+    {
+        moveToEnd([], hook);
+    }
+}


### PR DESCRIPTION
Reverts dlang/dmd#11874

I was right the first time round, even if it is the most uncomfortable approach so far.

@Geod24 merge please. :-)
@MartinNowak release 2.094.2 please. :-)