### PR TITLE
Follow up on #11869 cleanup cppmanglewin.d refactor

### DIFF
--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1255,8 +1255,8 @@ extern(D):
         }
         tmp.buf.writeByte('Z');
         const(char)* ret = tmp.buf.extractChars();
-        memcpy(&saved_idents, &tmp.saved_idents, (const(char)*).sizeof * VC_SAVED_IDENT_CNT);
-        memcpy(&saved_types, &tmp.saved_types, Type.sizeof * VC_SAVED_TYPE_CNT);
+        saved_idents[] = tmp.saved_idents[];
+        saved_types[] = tmp.saved_types[];
         return ret;
     }
 }


### PR DESCRIPTION
I missed one last memcpy in https://github.com/dlang/dmd/pull/11869

Fortunately the sizes haven't changed.

cc @WalterBright  