### PR TITLE
[dmd-cxx] Use run-time allocated mutexes for plain `synchronized` statements

### DIFF
--- a/src/idgen.c
+++ b/src/idgen.c
@@ -262,7 +262,7 @@ Msgtable msgtable[] =
     { "aaRehash", "_aaRehash" },
     { "monitorenter", "_d_monitorenter" },
     { "monitorexit", "_d_monitorexit" },
-    { "criticalenter", "_d_criticalenter" },
+    { "criticalenter", "_d_criticalenter2" },
     { "criticalexit", "_d_criticalexit" },
     { "__ArrayEq", NULL },
     { "__ArrayPostblit", NULL },

--- a/src/target.c
+++ b/src/target.c
@@ -116,45 +116,6 @@ static void initFloatConstants(Target::FPTypeProperties<T> &f)
 #endif
 }
 
-static unsigned getCriticalSectionSize(const Param &params)
-{
-    if (params.isWindows)
-    {
-        // sizeof(CRITICAL_SECTION) for Windows.
-        return params.isLP64 ? 40 : 24;
-    }
-    else if (params.isLinux)
-    {
-        // sizeof(pthread_mutex_t) for Linux.
-        if (params.is64bit)
-            return params.isLP64 ? 40 : 32;
-        else
-            return params.isLP64 ? 40 : 24;
-    }
-    else if (params.isFreeBSD)
-    {
-        // sizeof(pthread_mutex_t) for FreeBSD.
-        return params.isLP64 ? 8 : 4;
-    }
-    else if (params.isOpenBSD)
-    {
-        // sizeof(pthread_mutex_t) for OpenBSD.
-        return params.isLP64 ? 8 : 4;
-    }
-    else if (params.isOSX)
-    {
-        // sizeof(pthread_mutex_t) for OSX.
-        return params.isLP64 ? 64 : 44;
-    }
-    else if (params.isSolaris)
-    {
-        // sizeof(pthread_mutex_t) for Solaris.
-        return 24;
-    }
-    assert(0);
-    return 0;
-}
-
 void Target::_init(const Param &params)
 {
     initFloatConstants<float>(target.FloatProperties);
@@ -240,8 +201,6 @@ void Target::_init(const Param &params)
     else
         c.long_doublesize = realsize;
 
-    c.criticalSectionSize = getCriticalSectionSize(params);
-
     if (params.isLinux || params.isFreeBSD
         || params.isOpenBSD || params.isSolaris)
         cpp.twoDtorInVtable = true;
@@ -301,17 +260,6 @@ unsigned Target::alignsize(Type* type)
 unsigned Target::fieldalign(Type* type)
 {
     return type->alignsize();
-}
-
-/***********************************
- * Return size of OS critical section.
- * NOTE: can't use the sizeof() calls directly since cross compiling is
- * supported and would end up using the host sizes rather than the target
- * sizes.
- */
-unsigned Target::critsecsize()
-{
-    return c.criticalSectionSize;
 }
 
 /***********************************

--- a/src/target.h
+++ b/src/target.h
@@ -28,7 +28,6 @@ struct TargetC
 {
     unsigned longsize;            // size of a C 'long' or 'unsigned long' type
     unsigned long_doublesize;     // size of a C 'long double'
-    unsigned criticalSectionSize; // size of os critical section
 };
 
 struct TargetCPP
@@ -98,7 +97,6 @@ public:
     // Type sizes and support.
     unsigned alignsize(Type *type);
     unsigned fieldalign(Type *type);
-    unsigned critsecsize();
     Type *va_listType(const Loc &loc, Scope *sc);  // get type of va_list
     int isVectorTypeSupported(int sz, Type *type);
     bool isVectorOpSupported(Type *type, TOK op, Type *t2 = NULL);


### PR DESCRIPTION
Backport of #11824, depends on dlang/druntime#3248