### PR TITLE
dtoh: Don't use enum namespaces as types

### DIFF
--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1237,7 +1237,7 @@ public:
                 buf.writestring("static ");
                 writeEnumTypeName(memberType);
                 buf.printf(" const %s = ", m.ident.toChars());
-                m.value.accept(this);
+                m.origValue.accept(this);
                 buf.writestring(";");
             }
             buf.writenl();

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1499,7 +1499,17 @@ public:
             return;
         }
 
-        buf.writestring(ed.toChars());
+        const kind = getEnumKind(ed.memtype);
+
+        // Check if the enum was emitted as a real enum
+        if (kind == EnumKind.Int || kind == EnumKind.Numeric)
+            buf.writestring(ed.toChars());
+        else
+        {
+            // Use the base type if the enum was emitted as a namespace
+            buf.printf("/* %s */ ", ed.ident.toChars());
+            ed.memtype.accept(this);
+        }
     }
 
     override void visit(AST.TypeEnum t)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7077,11 +7077,11 @@ enum class Color
 
 namespace Classification
 {
-    static Color const error = (Classification)(Color)9;
-    static Color const gagged = (Classification)(Color)12;
-    static Color const warning = (Classification)(Color)11;
-    static Color const deprecation = (Classification)(Color)14;
-    static Color const tip = (Classification)(Color)10;
+    static Color const error = (/* Classification */ Color)(Color)9;
+    static Color const gagged = (/* Classification */ Color)(Color)12;
+    static Color const warning = (/* Classification */ Color)(Color)11;
+    static Color const deprecation = (/* Classification */ Color)(Color)14;
+    static Color const tip = (/* Classification */ Color)(Color)10;
 };
 
 extern void error(const Loc& loc, const char* format, ...);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7077,11 +7077,11 @@ enum class Color
 
 namespace Classification
 {
-    static Color const error = (/* Classification */ Color)(Color)9;
-    static Color const gagged = (/* Classification */ Color)(Color)12;
-    static Color const warning = (/* Classification */ Color)(Color)11;
-    static Color const deprecation = (/* Classification */ Color)(Color)14;
-    static Color const tip = (/* Classification */ Color)(Color)10;
+    static Color const error = (Color)9;
+    static Color const gagged = (Color)12;
+    static Color const warning = (Color)11;
+    static Color const deprecation = (Color)14;
+    static Color const tip = (Color)10;
 };
 
 extern void error(const Loc& loc, const char* format, ...);

--- a/test/compilable/dtoh_enum.d
+++ b/test/compilable/dtoh_enum.d
@@ -1,4 +1,4 @@
-/*
+/+
 REQUIRED_ARGS: -HC -c -o-
 PERMUTE_ARGS:
 TEST_OUTPUT:
@@ -97,7 +97,7 @@ namespace MyEnum
     static Foo const B = Foo(84);
 };
 
-static MyEnum const test = Foo(42);
+static /* MyEnum */ Foo const test = Foo(42);
 
 struct FooCpp
 {
@@ -114,12 +114,12 @@ namespace MyEnumCpp
     static FooCpp const B = FooCpp(84);
 };
 
-static MyEnum const testCpp = Foo(42);
+static /* MyEnum */ Foo const testCpp = Foo(42);
 
 enum class opaque;
 enum class typedOpaque : int64_t;
 ---
-*/
++/
 
 enum Anon = 10;
 enum Anon2 = true;

--- a/test/compilable/dtoh_enum_cpp98.d
+++ b/test/compilable/dtoh_enum_cpp98.d
@@ -1,4 +1,4 @@
-/*
+/+
 REQUIRED_ARGS: -extern-std=c++98 -HC -c -o-
 PERMUTE_ARGS:
 TEST_OUTPUT:
@@ -87,7 +87,7 @@ namespace MyEnum
     static Foo const B = Foo(84);
 };
 
-static MyEnum const test = Foo(42);
+static /* MyEnum */ Foo const test = Foo(42);
 
 struct FooCpp
 {
@@ -104,10 +104,10 @@ namespace MyEnumCpp
     static FooCpp const B = FooCpp(84);
 };
 
-static MyEnum const testCpp = Foo(42);
+static /* MyEnum */ Foo const testCpp = Foo(42);
 
 ---
-*/
++/
 
 enum Anon = 10;
 enum Anon2 = true;


### PR DESCRIPTION
Use the base type for variables/parameters/... when the enum was emitted as a namespace.