### PR TITLE
semantic: avoid runtime _d_arraysetlength call when .length = 0

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -150,6 +150,7 @@ check_clean_git()
     rm -f install.sh
     # auto-removal of these files doesn't work on CirleCi
     rm -f test/compilable/vcg-ast.d.cg
+    rm -f test/compilable/vcg-ast-arraylength.d.cg
     # Ensure that there are no untracked changes
     make -f posix.mak check-clean-git
 }

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -9137,6 +9137,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (!verifyHookExist(exp.loc, *sc, Id._d_arraysetlengthTImpl, "resizing arrays"))
                 return setError();
 
+            // use slice expression when arr.length = 0 to avoid runtime call
+            if(exp.e2.isConst() && exp.e2.toUInteger() == 0)
+            {
+                IntervalExp ie = new IntervalExp(ale.loc, exp.e2, exp.e2);
+                Expression se = new SliceExp(ale.loc, ale.e1, ie);
+                Expression as = new AssignExp(ale.loc, ale.e1, se);
+                auto res = as.expressionSemantic(sc);
+                return setResult(res);
+            }
+
             // Lower to object._d_arraysetlengthTImpl!(typeof(e1))._d_arraysetlengthT{,Trace}(e1, e2)
             Expression id = new IdentifierExp(ale.loc, Id.empty);
             id = new DotIdExp(ale.loc, id, Id.object);

--- a/test/compilable/extra-files/vcg-ast-arraylength-postscript.sh
+++ b/test/compilable/extra-files/vcg-ast-arraylength-postscript.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source tools/common_funcs.sh
+
+# Test if there's call to the runtime for .length = 100
+grep "_d_arraysetlengthT(arr, 100.*)" "${TEST_DIR}/${TEST_NAME}.d.cg"
+# Make sure there's no call to the runtime for .length = 0
+! grep "_d_arraysetlengthT(arr, 0.*)" "${TEST_DIR}/${TEST_NAME}.d.cg"
+# Test if a slice expr is applied for the above case
+grep "arr = arr\[0..0\]" "${TEST_DIR}/${TEST_NAME}.d.cg"
+
+rm_retry "${TEST_DIR}/${TEST_NAME}.d.cg"

--- a/test/compilable/vcg-ast-arraylength.d
+++ b/test/compilable/vcg-ast-arraylength.d
@@ -1,0 +1,15 @@
+module vcg_ast_arraylength;
+// REQUIRED_ARGS: -vcg-ast -o-
+// PERMUTE_ARGS:
+// POST_SCRIPT: compilable/extra-files/vcg-ast-arraylength-postscript.sh
+
+void main()
+{
+	int[] arr = [1, 2, 3];
+
+	// may use runtime call
+	arr.length = 100;
+
+	// should convert to arr = arr[0 .. 0];
+	arr.length = 0;
+}


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

This simple code
```d
void main()
{
    int[] a;
    a.length = 0;
}
```

Produces this code with a runtime call on semantic analysis:
```d
void main()
{
	int[] a = null;
	_d_arraysetlengthT(a, 0LU);
	return 0;
}
```

The runtime call `_d_arraysetlengthT` does internally slicing if `new_length <= current_length`
```d
if (newlength <= (*p).length)
{
    *p = (*p)[0 .. newlength];
    void* newdata = (*p).ptr;
    return newdata[0 .. newlength];
}
```
For `0` as new length, this expression will always be true, no matter what, so this should be `a = a[0 .. 0]` instead of `_d_arraysetlengthT(a, 0LU)`

I'm not quite sure if this optimization should be made on the semantic analysis but I assumed it because the `ArrayLengthExpr` assignment is converted to `_d_arraysetlengthT` there.