### PR TITLE
__traits(getCppNamespace,...) returns duplicate names for templates

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1963,6 +1963,10 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         for (auto p = s; !p.isModule(); p = p.toParent())
         {
             p.dsymbolSemantic(sc);
+
+            if (p.isTemplateInstance())
+                continue;
+
             if (p.isNspace())
                 exps.insert(0, new StringExp(p.loc, p.ident.toString()));
 

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -279,4 +279,12 @@ static assert (__traits(getCppNamespaces,NS.GetNamespaceTest10) == Seq!("NS", "n
 static assert (__traits(getCppNamespaces,NS.GetNamespaceTest11) == Seq!("NS", "nested", "nested2"));
 static assert (__traits(getCppNamespaces,NS.GetNamespaceTest12) == Seq!("NS", "nested4", "nested3"));
 
+extern(C++, `ns`) struct GetNamespaceTestTemplated(T) {}
+extern(C++, `ns`)
+template GetNamespaceTestTemplated2(T)
+{
+    struct GetNamespaceTestTemplated2 {}
+}
 
+static assert (__traits(getCppNamespaces,GetNamespaceTestTemplated).length  == 1);
+static assert (__traits(getCppNamespaces,GetNamespaceTestTemplated2).length == 1);


### PR DESCRIPTION
Fixes an oversight in https://github.com/dlang/dmd/pull/11863

without this change the added tests return `tuple("ns", "ns")`.