### PR TITLE
Fix Issue 21352 - enum members should not be given UDAs of its parent…

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2534,7 +2534,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         // Eval UDA in this same scope. Issues 19344, 20835, 21122
         if (em.userAttribDecl)
+        {
+            // Set scope but avoid extra sc.uda attachment inside setScope()
+            auto inneruda = em.userAttribDecl.userAttribDecl;
             em.userAttribDecl.setScope(sc);
+            em.userAttribDecl.userAttribDecl = inneruda;
+        }
 
         // The first enum member is special
         bool first = (em == (*em.ed.members)[0]);

--- a/test/compilable/test20835.d
+++ b/test/compilable/test20835.d
@@ -42,3 +42,18 @@ void test21122()
 }
 
 alias getAllUDAs(A...) = __traits(getAttributes, A);
+
+// https://issues.dlang.org/show_bug.cgi?id=21352
+
+@("aaa") enum Hoge {
+        @("bbb") foo, // tuple("aaa", "bbb") -> should be only tuple("bbb")
+        bar,  // tuple()
+}
+@("aaa") struct Fuga {
+        @("bbb") int foo; // tuple("bbb")
+        int bar; // tuple()
+}
+static assert([__traits(getAttributes, Hoge.foo)] == ["bbb"]); //NG -> fixed
+static assert([__traits(getAttributes, Hoge.bar)] == []);
+static assert([__traits(getAttributes, Fuga.foo)] == ["bbb"]);
+static assert([__traits(getAttributes, Fuga.bar)] == []);


### PR DESCRIPTION
… enum declaration

It seems using `setScope(sc)` here has the side effect of copying `sc.userAttribDecl` to `em.userAttribDecl.userAttribDecl` if the latter is null.
Setting `_scope = sc` directly is all we need.