### PR TITLE
Revert "Fix Issue 11292 - Cannot re-initialize a const field in postblit"

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -89,18 +89,15 @@ bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
         if (s)
             fd = s.isFuncDeclaration();
         if (fd &&
-            ((var.isField() && (fd.isCtorDeclaration() || fd.isPostBlitDeclaration())) ||
-             (!var.isField() && fd.isStaticCtorDeclaration())) &&
+            ((fd.isCtorDeclaration() && var.isField()) ||
+             (fd.isStaticCtorDeclaration() && !var.isField())) &&
             fd.toParentDecl() == var.toParent2() &&
             (!e1 || e1.op == TOK.this_))
         {
             bool result = true;
 
-            if (!fd.isPostBlitDeclaration())
-            {
-                var.ctorinit = true;
-                //printf("setting ctorinit\n");
-            }
+            var.ctorinit = true;
+            //printf("setting ctorinit\n");
 
             if (var.isField() && sc.ctorflow.fieldinit.length && !sc.intypeof)
             {

--- a/test/compilable/test11292.d
+++ b/test/compilable/test11292.d
@@ -1,5 +1,0 @@
-struct S
-{
-    immutable int x;
-    this(this) { x = 1; }
-}

--- a/test/runnable/test21357.d
+++ b/test/runnable/test21357.d
@@ -1,0 +1,35 @@
+// https://issues.dlang.org/show_bug.cgi?id=21357
+// PERMUTE_ARGS:
+struct BatchState
+{
+    int[10] arr;
+
+    BatchState copy()
+    {
+        auto ret = BatchState(arr);
+        arr[0] += 1;
+        return ret;
+    }
+}
+
+struct GrayArea
+{
+    BatchState low;
+
+    this(this)
+    {
+        low = low.copy;
+    }
+}
+
+void main()
+{
+    GrayArea a;
+    a.low.arr[0] = 1;
+    GrayArea b;
+    b.low.arr[0] = 4;
+    b = a; // calls the postblit
+
+    assert(a.low.arr[0] == 1);
+    assert(b.low.arr[0] == 1);
+}


### PR DESCRIPTION
Reverts dlang/dmd#11190

Rationale for revert, a postblit does not construct new memory, as can be shown in the failing test in https://issues.dlang.org/show_bug.cgi?id=21357