### PR TITLE
Put CallbackAPI under version DMDLIB

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -30,6 +30,11 @@ import dmd.semantic3;
 import dmd.tokens;
 import dmd.statement;
 
+version (DMDLIB)
+{
+    version = CallbackAPI;
+}
+
 extern (C++) __gshared
 {
     /// Module in which the D main is

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -60,6 +60,11 @@ import dmd.typesem;
 import dmd.visitor;
 import dmd.compiler;
 
+version (DMDLIB)
+{
+    version = CallbackAPI;
+}
+
 /*****************************************
  * CTFE requires FuncDeclaration::labtab for the interpretation.
  * So fixing the label name inside in/out contracts is necessary


### PR DESCRIPTION
Moving all dmd as a library versions under the same version to easily enable them when needed. So far only 
`CallbackAPI` and `LocOffset` fit this description but more may be added in the future.