### PR TITLE
Enable -checkaction=context by default

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -10,6 +10,7 @@ CIRCLE_STAGE=${CIRCLE_STAGE:-pic}
 CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-dmd}
 BUILD="debug"
 DMD=dmd
+OS=linux
 
 case $CIRCLE_NODE_INDEX in
     0) MODEL=64 ;;
@@ -111,7 +112,7 @@ coverage()
     # load environment for bootstrap compiler
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
 
-    local build_path=generated/linux/$BUILD/$MODEL
+    local build_path=generated/$OS/$BUILD/$MODEL
     local builder=generated/build
 
     dmd -g -od=generated -of=$builder compiler/src/build
@@ -163,7 +164,7 @@ check_clean_git()
 # sanitycheck for the run_individual_tests script
 check_run_individual()
 {
-    local build_path=generated/linux/$BUILD/$MODEL
+    local build_path=generated/$OS/$BUILD/$MODEL
     "${build_path}/dmd" -Icompiler/test -i -run ./compiler/test/run.d "BUILD=$BUILD" "MODEL=$MODEL" compiler/test/runnable/template2962.d ./compiler/test/compilable/test14275.d
 }
 
@@ -177,7 +178,7 @@ check_d_builder()
     rm -rf generated # just to be sure
     # TODO: add support for 32-bit builds
     ./compiler/src/build.d MODEL=64
-    ./generated/linux/release/64/dmd --version | grep -v "dirty"
+    ./generated/$OS/release/64/dmd --version | grep -v "dirty"
     ./compiler/src/build.d clean
     deactivate
 }

--- a/changelog/checkaction-context-default.dd
+++ b/changelog/checkaction-context-default.dd
@@ -1,0 +1,15 @@
+Enhanced `assert` informations are now printed by default
+
+Starting from this release, DMD will now print rich informations on assert failures.
+For example, the following code:
+---
+void main ()
+{
+    int a = 0, b = 42;
+    assert(a == b);
+}
+---
+
+Will now print: `core.exception.AssertError@filename.d(4): 0 != 42`.
+This behavior was previously accessible via the CLI switch `-checkaction=context`.
+To revert to the old behavior, use `-checkaction=D`.

--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -465,10 +465,10 @@ enum CHECKENABLE : ubyte
 /// What should happend when an assertion fails
 enum CHECKACTION : ubyte
 {
+    context,      /// call D assert with the error context on failure
     D,            /// call D assert on failure
     C,            /// call C assert on failure
     halt,         /// cause program halt on failure
-    context,      /// call D assert with the error context on failure
 }
 
 extern (C++) struct structalign_t

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6226,10 +6226,10 @@ enum class CHECKENABLE : uint8_t
 
 enum class CHECKACTION : uint8_t
 {
-    D = 0u,
-    C = 1u,
-    halt = 2u,
-    context = 3u,
+    context = 0u,
+    D = 1u,
+    C = 2u,
+    halt = 3u,
 };
 
 enum class CLIIdentifierTable : uint8_t

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -220,7 +220,8 @@ extern (C++) struct Param
     CHECKENABLE useSwitchError = CHECKENABLE._default;  // check for switches without a default
     CHECKENABLE boundscheck    = CHECKENABLE._default;  // state of -boundscheck switch
 
-    CHECKACTION checkAction = CHECKACTION.D; // action to take when bounds, asserts or switch defaults are violated
+    /// Action to take when bounds, asserts or switch defaults are violated
+    CHECKACTION checkAction = CHECKACTION.context;
 
     CLIIdentifierTable dIdentifierTable = CLIIdentifierTable.default_;
     CLIIdentifierTable cIdentifierTable = CLIIdentifierTable.default_;

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -52,10 +52,10 @@ enum
 typedef unsigned char CHECKACTION;
 enum
 {
+    CHECKACTION_context,  // call D assert with the error context on failure
     CHECKACTION_D,        // call D assert on failure
     CHECKACTION_C,        // call C assert on failure
-    CHECKACTION_halt,     // cause program halt on failure
-    CHECKACTION_context   // call D assert with the error context on failure
+    CHECKACTION_halt      // cause program halt on failure
 };
 
 enum JsonFieldFlags

--- a/compiler/test/dshell/dll_cxx.d
+++ b/compiler/test/dshell/dll_cxx.d
@@ -44,7 +44,7 @@ int main()
     // The arguments have to be passed as an array, because run would replace '/' with '\\' otherwise.
     run(dllCmd);
 
-    run(`$DMD -m$MODEL -g -od=$OUTPUT_BASE -of=$EXE_NAME $SRC/testdll.d ` ~ mainExtra);
+    run(`$DMD -m$MODEL -checkaction=D -g -od=$OUTPUT_BASE -of=$EXE_NAME $SRC/testdll.d ` ~ mainExtra);
 
     run(`$EXE_NAME`, stdout, stderr, [`LD_LIBRARY_PATH`: Vars.OUTPUT_BASE]);
 

--- a/compiler/test/run.d
+++ b/compiler/test/run.d
@@ -309,6 +309,8 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
         {
             buildCommand = [
                 hostDMD,
+                // Do not depend on linking Phobos, especially for `dshell_prebuilt`
+                "-checkaction=D",
                 "-m"~env["MODEL"],
                 "-of"~targetBin,
                 sourceFile

--- a/compiler/test/runnable/complex.d
+++ b/compiler/test/runnable/complex.d
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS: -d
+REQUIRED_ARGS: -d -checkaction=D
 TEST_OUTPUT:
 ---
 ---

--- a/compiler/test/runnable/iasm.d
+++ b/compiler/test/runnable/iasm.d
@@ -1,4 +1,5 @@
 // PERMUTE_ARGS:
+// REQUIRED_ARGS: -checkaction=D
 
 // Copyright (c) 1999-2016 by The D Language Foundation
 // All Rights Reserved

--- a/compiler/test/runnable/iasm64.d
+++ b/compiler/test/runnable/iasm64.d
@@ -1,4 +1,5 @@
 // PERMUTE_ARGS:
+// REQUIRED_ARGS: -checkaction=D
 
 // Copyright (c) 1999-2016 by The D Language Foundation
 // All Rights Reserved


### PR DESCRIPTION
Putting this up there to see how people feel about it / what breaks.
Currently this switch is not usable as it creates a linker error in Phobos.
Having it the default would bring a lot of benefit - at the expense of breaking some code, e.g. non-copyable structs or structs with side effect.

Side note: That was the whole point of having `-preview=in` - make this kind of generic code easier to write.