### PR TITLE
target: Add TargetCPP.thunkMangle, implement for itanium ABI

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1776,6 +1776,7 @@ struct TargetCPP
     bool twoDtorInVtable;
     const char* toMangle(Dsymbol* s);
     const char* typeInfoMangle(ClassDeclaration* cd);
+    const char* thunkMangle(FuncDeclaration* fd, int32_t offset);
     const char* typeMangle(Type* t);
     Type* parameterType(Parameter* p);
     bool fundamentalType(const Type* const t, bool& isFundamental);
@@ -2316,6 +2317,8 @@ enum class CppOperator
 extern const char* toCppMangleItanium(Dsymbol* s);
 
 extern const char* cppTypeInfoMangleItanium(Dsymbol* s);
+
+extern const char* cppThunkMangleItanium(FuncDeclaration* fd, int32_t offset);
 
 extern const char* toCppMangleMSVC(Dsymbol* s);
 

--- a/src/dmd/mangle.h
+++ b/src/dmd/mangle.h
@@ -20,6 +20,7 @@ struct OutBuffer;
 // In cppmangle.d
 const char *toCppMangleItanium(Dsymbol *s);
 const char *cppTypeInfoMangleItanium(Dsymbol *s);
+const char *cppThunkMangleItanium(FuncDeclaration *fd, int offset);
 
 // In cppmanglewin.d
 const char *toCppMangleMSVC(Dsymbol *s);

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1053,6 +1053,20 @@ struct TargetCPP
     }
 
     /**
+     * Get mangle name of a this-adjusting thunk to the given function
+     * declaration for C++ ABI.
+     * Params:
+     *      fd = function with C++ linkage
+     *      offset = call offset to the vptr
+     * Returns:
+     *      string mangling of C++ thunk, or null if unhandled
+     */
+    extern (C++) const(char)* thunkMangle(FuncDeclaration fd, int offset)
+    {
+        return null;
+    }
+
+    /**
      * Gets vendor-specific type mangling for C++ ABI.
      * Params:
      *      t = type to inspect

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -39,6 +39,7 @@ struct TargetCPP
 
     const char *toMangle(Dsymbol *s);
     const char *typeInfoMangle(ClassDeclaration *cd);
+    const char *thunkMangle(FuncDeclaration *fd, int offset);
     const char *typeMangle(Type *t);
     Type *parameterType(Parameter *p);
     bool fundamentalType(const Type *t, bool& isFundamental);


### PR DESCRIPTION
In C++ (gcc's implementation in particular) thunks are part of the definition of the function.  When a function has no body, the thunk is just left as an undefined external symbol.

Though not supported in dmd, where thunks are connected to the class definition and not extern, this allows gdc to both reference and define thunks generated by g++, rather than generate a local thunk.

This means that this code doesn't result in a linker error (but it does for dmd because of differences in implementation that have already explained).
```d
// d
extern (C++):
class Base { void based() { } }
interface Interface { int MethodCPP(); int MethodD(); }
class Derived : Base, Interface {
    int MethodCPP();
    int MethodD() { return 3; }
}
```
```c++
// c++
class Base { public: virtual void base(); };
class Interface { public: virtual int MethodCPP() = 0; virtual int MethodD() = 0; };
class Derived : public Base, public Interface {
public:
    int MethodCPP() { return 30; }
    int MethodD();
};
```
