### PR TITLE
fix Issue 11435 - Pushing indirect ref to byte or short can read beyo…

### DIFF
--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -4654,13 +4654,15 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
         case OPind:
             if (!e.Ecount)                         /* if *e1       */
             {
-                if (sz <= REGSIZE)
-                {   // Watch out for single byte quantities being up
-                    // against the end of a segment or in memory-mapped I/O
-                    if (!(config.exe & EX_flat) && szb == 1)
-                        break;
-                    goto L1;            // can handle it with loadea()
+                if (sz < REGSIZE)
+                {
+                    /* Don't push REGSIZE quantity because it may
+                     * straddle past the end of valid memory
+                     */
+                    break;
                 }
+                if (sz == REGSIZE)
+                    goto case OPvar;    // handle it with loadea()
 
                 // Avoid PUSH MEM on the Pentium when optimizing for speed
                 if (config.flags4 & CFG4speed &&

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -2287,6 +2287,67 @@ void test16268()
 }
 
 ////////////////////////////////////////////////////////////////////////
+// https://issues.dlang.org/show_bug.cgi?id=11435
+
+void test11435a()
+{
+    alias T = byte;
+
+    static void fun(T c, T b, int v)
+    {
+    }
+
+    static void abc(T[] b)
+    {
+        fun(b[0], b[1], 0);
+    }
+
+    version(Windows)
+    {
+        import core.sys.windows.windows;
+        auto p = VirtualAlloc(null, 4096, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+    }
+    else
+    {
+        import core.sys.posix.sys.mman;
+        auto p = mmap(null, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0L);
+    }
+    assert(p);
+    auto px = (cast(T*)(p + 4096 - 2 * T.sizeof));
+    abc(px[0..2]);
+}
+
+void test11435b()
+{
+    import core.sys.windows.windows;
+    alias T = short;
+
+    static void fun(T c, T b, int v)
+    {
+    }
+
+    static void abc(T[] b)
+    {
+        fun(b[0], b[1], 0);
+    }
+
+    version(Windows)
+    {
+        import core.sys.windows.windows;
+        auto p = VirtualAlloc(null, 4096, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+    }
+    else
+    {
+        import core.sys.posix.sys.mman;
+        auto p = mmap(null, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0L);
+    }
+    assert(p);
+    auto px = (cast(T*)(p + 4096 - 2 * T.sizeof));
+    abc(px[0..2]);
+}
+
+
+////////////////////////////////////////////////////////////////////////
 
 int main()
 {
@@ -2379,6 +2440,8 @@ int main()
     test21038();
     test19846();
     test16268();
+    test11435a();
+    test11435b();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
…nd edge of valid memory

Hard to write a reliable test case for this.