### PR TITLE
Add location to linkage symbols

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1312,10 +1312,10 @@ struct ASTBase
     {
         LINK linkage;
 
-        extern (D) this(LINK p, Dsymbols* decl)
+        extern (D) this(const ref Loc loc, LINK p, Dsymbols* decl)
         {
-            super(decl);
-            linkage = p;
+            super(loc, null, decl);
+            this.linkage = p;
         }
 
         override void accept(Visitor v)
@@ -1362,9 +1362,9 @@ struct ASTBase
     {
         CPPMANGLE cppmangle;
 
-        extern (D) this(CPPMANGLE p, Dsymbols* decl)
+        extern (D) this(const ref Loc loc, CPPMANGLE p, Dsymbols* decl)
         {
-            super(decl);
+            super(loc, null, decl);
             cppmangle = p;
         }
 
@@ -1378,15 +1378,14 @@ struct ASTBase
     {
         Expression exp;
 
-        extern (D) this(Identifier ident, Dsymbols* decl)
+        extern (D) this(const ref Loc loc, Identifier ident, Dsymbols* decl)
         {
-            super(decl);
-            this.ident = ident;
+            super(loc, ident, decl);
         }
 
-        extern (D) this(Expression exp, Dsymbols* decl)
+        extern (D) this(const ref Loc loc, Expression exp, Dsymbols* decl)
         {
-            super(decl);
+            super(loc, null, decl);
             this.exp = exp;
         }
 

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -393,22 +393,22 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
 {
     LINK linkage; /// either explicitly set or `default_`
 
-    extern (D) this(LINK linkage, Dsymbols* decl)
+    extern (D) this(const ref Loc loc, LINK linkage, Dsymbols* decl)
     {
-        super(decl);
+        super(loc, null, decl);
         //printf("LinkDeclaration(linkage = %d, decl = %p)\n", linkage, decl);
         this.linkage = (linkage == LINK.system) ? target.systemLinkage() : linkage;
     }
 
-    static LinkDeclaration create(LINK p, Dsymbols* decl)
+    static LinkDeclaration create(const ref Loc loc, LINK p, Dsymbols* decl)
     {
-        return new LinkDeclaration(p, decl);
+        return new LinkDeclaration(loc, p, decl);
     }
 
     override LinkDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        return new LinkDeclaration(linkage, Dsymbol.arraySyntaxCopy(decl));
+        return new LinkDeclaration(loc, linkage, Dsymbol.arraySyntaxCopy(decl));
     }
 
     override Scope* newScope(Scope* sc)
@@ -445,9 +445,9 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
 {
     CPPMANGLE cppmangle;
 
-    extern (D) this(CPPMANGLE cppmangle, Dsymbols* decl)
+    extern (D) this(const ref Loc loc, CPPMANGLE cppmangle, Dsymbols* decl)
     {
-        super(decl);
+        super(loc, null, decl);
         //printf("CPPMangleDeclaration(cppmangle = %d, decl = %p)\n", cppmangle, decl);
         this.cppmangle = cppmangle;
     }
@@ -455,7 +455,7 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
     override CPPMangleDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        return new CPPMangleDeclaration(cppmangle, Dsymbol.arraySyntaxCopy(decl));
+        return new CPPMangleDeclaration(loc, cppmangle, Dsymbol.arraySyntaxCopy(decl));
     }
 
     override Scope* newScope(Scope* sc)
@@ -515,23 +515,21 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
     /// CTFE-able expression, resolving to `TupleExp` or `StringExp`
     Expression exp;
 
-    extern (D) this(Identifier ident, Dsymbols* decl)
+    extern (D) this(const ref Loc loc, Identifier ident, Dsymbols* decl)
     {
-        super(decl);
-        this.ident = ident;
+        super(loc, ident, decl);
     }
 
-    extern (D) this(Expression exp, Dsymbols* decl)
+    extern (D) this(const ref Loc loc, Expression exp, Dsymbols* decl)
     {
-        super(decl);
+        super(loc, null, decl);
         this.exp = exp;
     }
 
-    extern (D) this(Identifier ident, Expression exp, Dsymbols* decl,
+    extern (D) this(const ref Loc loc, Identifier ident, Expression exp, Dsymbols* decl,
                     CPPNamespaceDeclaration parent)
     {
-        super(decl);
-        this.ident = ident;
+        super(loc, ident, decl);
         this.exp = exp;
         this.cppnamespace = parent;
     }
@@ -540,7 +538,7 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
     {
         assert(!s);
         return new CPPNamespaceDeclaration(
-            this.ident, this.exp, Dsymbol.arraySyntaxCopy(this.decl), this.cppnamespace);
+            this.loc, this.ident, this.exp, Dsymbol.arraySyntaxCopy(this.decl), this.cppnamespace);
     }
 
     /**

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -73,7 +73,7 @@ class LinkDeclaration : public AttribDeclaration
 public:
     LINK linkage;
 
-    static LinkDeclaration *create(LINK p, Dsymbols *decl);
+    static LinkDeclaration *create(const Loc &loc, LINK p, Dsymbols *decl);
     LinkDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     const char *toChars() const;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2187,7 +2187,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     auto exp = (*te.exps)[d];
                     auto prev = d ? current : ns.cppnamespace;
                     current = (d + 1) != te.exps.dim
-                        ? new CPPNamespaceDeclaration(exp, null)
+                        ? new CPPNamespaceDeclaration(ns.loc, exp, null)
                         : ns;
                     current.exp = exp;
                     current.cppnamespace = prev;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2024,7 +2024,7 @@ class LinkDeclaration final : public AttribDeclaration
 {
 public:
     LINK linkage;
-    static LinkDeclaration* create(LINK p, Array<Dsymbol* >* decl);
+    static LinkDeclaration* create(const Loc& loc, LINK p, Array<Dsymbol* >* decl);
     LinkDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     const char* toChars() const;

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -220,7 +220,7 @@ void test_visitors()
     tp->accept(&tv);
     assert(tv.type == true);
 
-    LinkDeclaration *ld = LinkDeclaration::create(LINK::d, NULL);
+    LinkDeclaration *ld = LinkDeclaration::create(loc, LINK::d, NULL);
     assert(ld->isAttribDeclaration() == static_cast<AttribDeclaration *>(ld));
     assert(ld->linkage == LINK::d);
     ld->accept(&tv);

--- a/test/unit/parser/linkage_location.d
+++ b/test/unit/parser/linkage_location.d
@@ -1,0 +1,296 @@
+module parser.linkage_location;
+
+import dmd.frontend : parseModule;
+import support : afterEach, beforeEach;
+import dmd.attrib : CPPMangleDeclaration, CPPNamespaceDeclaration, LinkDeclaration;
+import dmd.globals : Loc;
+import dmd.visitor : SemanticTimeTransitiveVisitor;
+
+@beforeEach initializeFrontend()
+{
+    import dmd.frontend : initDMD;
+
+    initDMD();
+}
+
+@afterEach deinitializeFrontend()
+{
+    import dmd.frontend : deinitializeDMD;
+    deinitializeDMD();
+}
+
+extern (C++) static class Visitor : SemanticTimeTransitiveVisitor
+{
+    alias visit = typeof(super).visit;
+    Loc l;
+
+    override void visit(CPPMangleDeclaration md)
+    {
+        l = md.loc;
+    }
+
+    override void visit(CPPNamespaceDeclaration nd)
+    {
+        l = nd.loc;
+    }
+}
+
+// Testing cpp mangling
+
+@("extern (C++, struct) class")
+unittest
+{
+    auto t = parseModule("test.d", "extern (C++, struct) class C {}");
+
+    scope visitor = new Visitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 1);
+}
+
+@("extern (C++, struct) struct")
+unittest
+{
+    auto t = parseModule("test.d", "extern (C++, struct) struct S {}");
+
+    scope visitor = new Visitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 1);
+}
+
+@("extern (C++, class) class")
+unittest
+{
+    auto t = parseModule("test.d", "extern (C++, class) class C {}");
+
+    scope visitor = new Visitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 1);
+}
+
+@("extern (C++, class) struct")
+unittest
+{
+    auto t = parseModule("test.d", "extern (C++, class) struct C {}");
+
+    scope visitor = new Visitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 1);
+}
+
+@("extern (C++, struct) {}")
+unittest
+{
+    auto t = parseModule("test.d", "extern (C++, struct) {}");
+
+    scope visitor = new Visitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 1);
+}
+
+@("extern (C++, class) {}")
+unittest
+{
+    auto t = parseModule("test.d", "extern (C++, class) {}");
+
+    scope visitor = new Visitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 1);
+}
+
+// Testing namespaces
+
+@(`"namespace"`)
+unittest
+{
+    auto t = parseModule("test.d", `extern (C++, "namespace") {}`);
+
+    scope visitor = new Visitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 1);
+}
+
+@(`"name"~"space"`)
+unittest
+{
+    auto t = parseModule("test.d", `extern (C++, "name"~"space") {}`);
+
+    scope visitor = new Visitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 1);
+}
+
+extern (C++) static class NamespaceVisitor : SemanticTimeTransitiveVisitor
+{
+    alias visit = typeof(super).visit;
+    Loc[] l;
+
+    override void visit(CPPNamespaceDeclaration nd)
+    {
+        l ~= nd.loc;
+        if (nd.decl.length) {
+            CPPNamespaceDeclaration next = cast(CPPNamespaceDeclaration)nd.decl.pop();
+            next.accept(this);
+        }
+    }
+}
+
+@("multiple namespaces - comma separated")
+unittest
+{
+    auto t = parseModule("test.d", `extern (C++, "ns1", "ns2", "ns3") {}`);
+
+    scope visitor = new NamespaceVisitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.length == 3);
+    foreach (Loc l; visitor.l) {
+        assert(l.linnum == 1);
+        assert(l.charnum == 1);
+    }
+}
+
+@("multiple namespaces - same line")
+unittest
+{
+    auto t = parseModule("test.d", `extern (C++, "ns1") extern(C++, "ns2") {}`);
+
+    scope visitor = new NamespaceVisitor;
+    t.module_.accept(visitor);
+    int charnum = 1;
+
+    assert(visitor.l.length == 2);
+    foreach (Loc l; visitor.l) {
+        assert(l.linnum == 1);
+        assert(l.charnum == charnum);
+        charnum += 20;
+    }
+}
+
+@("multiple namespaces - different lines")
+unittest
+{
+    auto t = parseModule("test.d", "extern (C++, 'ns1')\nextern(C++, 'ns2') {}");
+
+    scope visitor = new NamespaceVisitor;
+    t.module_.accept(visitor);
+    int linnum = 1;
+
+    assert(visitor.l.length == 2);
+    foreach (Loc l; visitor.l) {
+        assert(l.linnum == linnum);
+        assert(l.charnum == 1);
+        linnum++;
+    }
+}
+
+// Testing linkage
+
+extern (C++) static class LinkVisitor : SemanticTimeTransitiveVisitor
+{
+    alias visit = typeof(super).visit;
+    Loc l;
+
+    override void visit(LinkDeclaration ld)
+    {
+        l = ld.loc;
+    }
+}
+
+enum Links = [
+    "C",
+    "C++",
+    "D",
+    "Objective-C",
+    "Windows",
+    "System"];
+
+static foreach (link; Links)
+{
+    @("extern("~link~")")
+    unittest
+    {
+        auto t = parseModule("test.d", "first_token extern("~link~")");
+
+        scope visitor = new LinkVisitor;
+        t.module_.accept(visitor);
+
+        assert(visitor.l.linnum == 1);
+        assert(visitor.l.charnum == 13);
+    }
+}
+
+@("extern(C++) variable")
+unittest
+{
+    auto t = parseModule("test.d", "first_token extern(C++) int a;");
+
+    scope visitor = new LinkVisitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 13);
+}
+
+@("extern(C++) function")
+unittest
+{
+    auto t = parseModule("test.d", "first_token extern(C++) void f();");
+
+    scope visitor = new LinkVisitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 13);
+}
+
+@("extern(C++) struct")
+unittest
+{
+    auto t = parseModule("test.d", "first_token extern(C++) struct C {}");
+
+    scope visitor = new LinkVisitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 13);
+}
+
+@("extern(C++) class")
+unittest
+{
+    auto t = parseModule("test.d", "first_token extern(C++) class C {}");
+
+    scope visitor = new LinkVisitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 13);
+}
+
+@("alias t = extern(C++) void f();")
+unittest
+{
+    auto t = parseModule("test.d", "alias t = extern(C++) void f();");
+
+    scope visitor = new LinkVisitor;
+    t.module_.accept(visitor);
+
+    assert(visitor.l.linnum == 1);
+    assert(visitor.l.charnum == 11);
+}


### PR DESCRIPTION
Currently:
CPPMangleDeclaration - location of `struct` or `class` - changed to location of  `extern`
CPPNamespaceDeclaration - location of `extern` (same as `Nspace`)
LinkDeclaration - location of `extern`