### PR TITLE
dtoh: Generate fieldwise constructors for aggregates

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -1,0 +1,9 @@
+Improvements for the C++ header generation
+
+The following features/bugfixes/improvements were implemented for the
+experimental C++ header generator:
+
+- Generate fieldwise constructors for aggregates
+
+Note: The header generator is still considerer experimental, so please submit
+      any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1209,6 +1209,16 @@ public:
             swcto()
         {
         }
+        Mcache(Type* cto, Type* ito = nullptr, Type* sto = nullptr, Type* scto = nullptr, Type* wto = nullptr, Type* wcto = nullptr, Type* swto = nullptr, Type* swcto = nullptr) :
+            cto(cto),
+            ito(ito),
+            sto(sto),
+            scto(scto),
+            wto(wto),
+            wcto(wcto),
+            swto(swto),
+            swcto(swcto)
+            {}
     };
 
 private:
@@ -1734,6 +1744,11 @@ struct ObjcFuncDeclaration
         isOptional()
     {
     }
+    ObjcFuncDeclaration(ObjcSelector* selector, VarDeclaration* selectorParameter = nullptr, bool isOptional = false) :
+        selector(selector),
+        selectorParameter(selectorParameter),
+        isOptional(isOptional)
+        {}
 };
 
 struct ParameterList
@@ -1767,6 +1782,10 @@ struct TargetC
         long_doublesize()
     {
     }
+    TargetC(uint32_t longsize, uint32_t long_doublesize = 0u) :
+        longsize(longsize),
+        long_doublesize(long_doublesize)
+        {}
 };
 
 struct TargetCPP
@@ -1786,6 +1805,11 @@ struct TargetCPP
         twoDtorInVtable()
     {
     }
+    TargetCPP(bool reverseOverloads, bool exceptions = false, bool twoDtorInVtable = false) :
+        reverseOverloads(reverseOverloads),
+        exceptions(exceptions),
+        twoDtorInVtable(twoDtorInVtable)
+        {}
 };
 
 struct TargetObjC
@@ -1795,6 +1819,9 @@ struct TargetObjC
         supported()
     {
     }
+    TargetObjC(bool supported) :
+        supported(supported)
+        {}
 };
 
 enum class Sizeok : uint8_t
@@ -4685,6 +4712,10 @@ struct Ensure
         ensure()
     {
     }
+    Ensure(Identifier* id, Statement* ensure = nullptr) :
+        id(id),
+        ensure(ensure)
+        {}
 };
 
 class FuncDeclaration : public Declaration
@@ -6754,6 +6785,21 @@ public:
         RealProperties()
     {
     }
+    Target(uint32_t ptrsize, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u), TargetCPP cpp = TargetCPP(false, false, false), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, FPTypeProperties<float > FloatProperties = FPTypeProperties(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
+        ptrsize(ptrsize),
+        realsize(realsize),
+        realpad(realpad),
+        realalignsize(realalignsize),
+        classinfosize(classinfosize),
+        maxStaticDataSize(maxStaticDataSize),
+        c(c),
+        cpp(cpp),
+        objc(objc),
+        architectureName(architectureName),
+        FloatProperties(FloatProperties),
+        DoubleProperties(DoubleProperties),
+        RealProperties(RealProperties)
+        {}
 };
 
 extern Target target;
@@ -7261,6 +7307,148 @@ struct Param
         mapfile()
     {
     }
+    Param(bool obj, bool link = true, bool dll = false, bool lib = false, bool multiobj = false, bool oneobj = false, bool trace = false, bool tracegc = false, bool verbose = false, bool vcg_ast = false, bool showColumns = false, bool vtls = false, bool vtemplates = false, bool vtemplatesListInstances = false, bool vgc = false, bool vfield = false, bool vcomplex = false, uint8_t symdebug = 0u, bool symdebugref = false, bool alwaysframe = false, bool optimize = false, bool map = false, bool is64bit = true, bool isLP64 = false, TargetOS targetOS = (TargetOS)1u, bool hasObjectiveC = false, bool mscoff = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool stackstomp = false, bool useUnitTests = false, bool useInline = false, bool useDIP25 = false, bool noDIP25 = false, bool useDIP1021 = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, PIC pic = (PIC)0u, bool color = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool nofloat = false, bool ignoreUnsupportedPragmas = false, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool noSharedAccess = false, bool previewIn = false, bool shortenedMethods = false, bool betterC = false, bool addMain = false, bool allInst = false, bool fix16997 = false, bool fixAliasThis = false, bool inclusiveInContracts = false, bool vsafe = false, bool ehnogc = false, bool dtorFields = false, bool fieldwise = false, bool rvalueRefParam = false, CppStdRevision cplusplus = (CppStdRevision)201103u, bool markdown = true, bool vmarkdown = false, bool showGaggedErrors = false, bool printErrorContext = false, bool manual = false, bool usage = false, bool mcpuUsage = false, bool transitionUsage = false, bool checkUsage = false, bool checkActionUsage = false, bool revertUsage = false, bool previewUsage = false, bool externStdUsage = false, bool hcUsage = false, bool logo = false, CPU cpu = (CPU)11, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, uint32_t errorLimit = 20u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array(0LLU, {}, arrayliteral), Array<const char* >* imppath = nullptr, Array<const char* >* fileImppath = nullptr, _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, bool doDocComments = false, _d_dynamicArray< const char > docdir = {}, _d_dynamicArray< const char > docname = {}, Array<const char* > ddocfiles = Array(0LLU, {}, arrayliteral), bool doHdrGeneration = false, _d_dynamicArray< const char > hdrdir = {}, _d_dynamicArray< const char > hdrname = {}, bool hdrStripPlainFunctions = true, CxxHeaderMode doCxxHdrGeneration = (CxxHeaderMode)0u, _d_dynamicArray< const char > cxxhdrdir = {}, _d_dynamicArray< const char > cxxhdrname = {}, bool doJsonGeneration = false, _d_dynamicArray< const char > jsonfilename = {}, JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, OutBuffer* mixinOut = nullptr, const char* mixinFile = nullptr, int32_t mixinLines = 0, uint32_t debuglevel = 0u, Array<const char* >* debugids = nullptr, uint32_t versionlevel = 0u, Array<const char* >* versionids = nullptr, _d_dynamicArray< const char > defaultlibname = {}, _d_dynamicArray< const char > debuglibname = {}, _d_dynamicArray< const char > mscrtlib = {}, _d_dynamicArray< const char > moduleDepsFile = {}, OutBuffer* moduleDeps = nullptr, _d_dynamicArray< const char > makeDepsFile = {}, OutBuffer* makeDeps = nullptr, MessageStyle messageStyle = (MessageStyle)0u, bool debugb = false, bool debugc = false, bool debugf = false, bool debugr = false, bool debugx = false, bool debugy = false, bool run = false, Array<const char* > runargs = Array(0LLU, {}, arrayliteral), Array<const char* > objfiles = Array(0LLU, {}, arrayliteral), Array<const char* > linkswitches = Array(0LLU, {}, arrayliteral), Array<bool > linkswitchIsForCC = Array(0LLU, {}, arrayliteral), Array<const char* > libfiles = Array(0LLU, {}, arrayliteral), Array<const char* > dllfiles = Array(0LLU, {}, arrayliteral), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
+        obj(obj),
+        link(link),
+        dll(dll),
+        lib(lib),
+        multiobj(multiobj),
+        oneobj(oneobj),
+        trace(trace),
+        tracegc(tracegc),
+        verbose(verbose),
+        vcg_ast(vcg_ast),
+        showColumns(showColumns),
+        vtls(vtls),
+        vtemplates(vtemplates),
+        vtemplatesListInstances(vtemplatesListInstances),
+        vgc(vgc),
+        vfield(vfield),
+        vcomplex(vcomplex),
+        symdebug(symdebug),
+        symdebugref(symdebugref),
+        alwaysframe(alwaysframe),
+        optimize(optimize),
+        map(map),
+        is64bit(is64bit),
+        isLP64(isLP64),
+        targetOS(targetOS),
+        hasObjectiveC(hasObjectiveC),
+        mscoff(mscoff),
+        useDeprecated(useDeprecated),
+        stackstomp(stackstomp),
+        useUnitTests(useUnitTests),
+        useInline(useInline),
+        useDIP25(useDIP25),
+        noDIP25(noDIP25),
+        useDIP1021(useDIP1021),
+        release(release),
+        preservePaths(preservePaths),
+        warnings(warnings),
+        pic(pic),
+        color(color),
+        cov(cov),
+        covPercent(covPercent),
+        ctfe_cov(ctfe_cov),
+        nofloat(nofloat),
+        ignoreUnsupportedPragmas(ignoreUnsupportedPragmas),
+        useModuleInfo(useModuleInfo),
+        useTypeInfo(useTypeInfo),
+        useExceptions(useExceptions),
+        noSharedAccess(noSharedAccess),
+        previewIn(previewIn),
+        shortenedMethods(shortenedMethods),
+        betterC(betterC),
+        addMain(addMain),
+        allInst(allInst),
+        fix16997(fix16997),
+        fixAliasThis(fixAliasThis),
+        inclusiveInContracts(inclusiveInContracts),
+        vsafe(vsafe),
+        ehnogc(ehnogc),
+        dtorFields(dtorFields),
+        fieldwise(fieldwise),
+        rvalueRefParam(rvalueRefParam),
+        cplusplus(cplusplus),
+        markdown(markdown),
+        vmarkdown(vmarkdown),
+        showGaggedErrors(showGaggedErrors),
+        printErrorContext(printErrorContext),
+        manual(manual),
+        usage(usage),
+        mcpuUsage(mcpuUsage),
+        transitionUsage(transitionUsage),
+        checkUsage(checkUsage),
+        checkActionUsage(checkActionUsage),
+        revertUsage(revertUsage),
+        previewUsage(previewUsage),
+        externStdUsage(externStdUsage),
+        hcUsage(hcUsage),
+        logo(logo),
+        cpu(cpu),
+        useInvariants(useInvariants),
+        useIn(useIn),
+        useOut(useOut),
+        useArrayBounds(useArrayBounds),
+        useAssert(useAssert),
+        useSwitchError(useSwitchError),
+        boundscheck(boundscheck),
+        checkAction(checkAction),
+        errorLimit(errorLimit),
+        argv0(argv0),
+        modFileAliasStrings(modFileAliasStrings),
+        imppath(imppath),
+        fileImppath(fileImppath),
+        objdir(objdir),
+        objname(objname),
+        libname(libname),
+        doDocComments(doDocComments),
+        docdir(docdir),
+        docname(docname),
+        ddocfiles(ddocfiles),
+        doHdrGeneration(doHdrGeneration),
+        hdrdir(hdrdir),
+        hdrname(hdrname),
+        hdrStripPlainFunctions(hdrStripPlainFunctions),
+        doCxxHdrGeneration(doCxxHdrGeneration),
+        cxxhdrdir(cxxhdrdir),
+        cxxhdrname(cxxhdrname),
+        doJsonGeneration(doJsonGeneration),
+        jsonfilename(jsonfilename),
+        jsonFieldFlags(jsonFieldFlags),
+        mixinOut(mixinOut),
+        mixinFile(mixinFile),
+        mixinLines(mixinLines),
+        debuglevel(debuglevel),
+        debugids(debugids),
+        versionlevel(versionlevel),
+        versionids(versionids),
+        defaultlibname(defaultlibname),
+        debuglibname(debuglibname),
+        mscrtlib(mscrtlib),
+        moduleDepsFile(moduleDepsFile),
+        moduleDeps(moduleDeps),
+        makeDepsFile(makeDepsFile),
+        makeDeps(makeDeps),
+        messageStyle(messageStyle),
+        debugb(debugb),
+        debugc(debugc),
+        debugf(debugf),
+        debugr(debugr),
+        debugx(debugx),
+        debugy(debugy),
+        run(run),
+        runargs(runargs),
+        objfiles(objfiles),
+        linkswitches(linkswitches),
+        linkswitchIsForCC(linkswitchIsForCC),
+        libfiles(libfiles),
+        dllfiles(dllfiles),
+        deffile(deffile),
+        resfile(resfile),
+        exefile(exefile),
+        mapfile(mapfile)
+        {}
 };
 
 typedef uint32_t structalign_t;
@@ -7331,6 +7519,34 @@ struct Global
         debugids()
     {
     }
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > mars_ext = { 1, "d" }, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, _d_dynamicArray< const char > doc_ext = { 4, "html" }, _d_dynamicArray< const char > ddoc_ext = { 4, "ddoc" }, _d_dynamicArray< const char > hdr_ext = { 2, "di" }, _d_dynamicArray< const char > cxxhdr_ext = { 1, "h" }, _d_dynamicArray< const char > json_ext = { 4, "json" }, _d_dynamicArray< const char > map_ext = { 3, "map" }, bool run_noext = false, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, 0u, false, false, false, false, true, false, (TargetOS)1u, false, false, (DiagnosticReporting)1u, false, false, false, false, false, false, false, false, (DiagnosticReporting)2u, (PIC)0u, false, false, 0u, false, false, false, true, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, (CppStdRevision)201103u, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, (CPU)11, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKACTION)0u, 20u, {}, Array(0LLU, {}, arrayliteral), nullptr, nullptr, {}, {}, {}, false, {}, {}, Array(0LLU, {}, arrayliteral), false, {}, {}, true, (CxxHeaderMode)0u, {}, {}, false, {}, (JsonFieldFlags)0u, nullptr, nullptr, 0, 0u, nullptr, 0u, nullptr, {}, {}, {}, {}, nullptr, {}, nullptr, (MessageStyle)0u, false, false, false, false, false, false, false, Array(0LLU, {}, arrayliteral), Array(0LLU, {}, arrayliteral), Array(0LLU, {}, arrayliteral), Array(0LLU, {}, arrayliteral), Array(0LLU, {}, arrayliteral), Array(0LLU, {}, arrayliteral), {}, {}, {}, {}), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr) :
+        inifilename(inifilename),
+        mars_ext(mars_ext),
+        obj_ext(obj_ext),
+        lib_ext(lib_ext),
+        dll_ext(dll_ext),
+        doc_ext(doc_ext),
+        ddoc_ext(ddoc_ext),
+        hdr_ext(hdr_ext),
+        cxxhdr_ext(cxxhdr_ext),
+        json_ext(json_ext),
+        map_ext(map_ext),
+        run_noext(run_noext),
+        copyright(copyright),
+        written(written),
+        path(path),
+        filePath(filePath),
+        vendor(vendor),
+        params(params),
+        errors(errors),
+        warnings(warnings),
+        gag(gag),
+        gaggedErrors(gaggedErrors),
+        gaggedWarnings(gaggedWarnings),
+        console(console),
+        versionids(versionids),
+        debugids(debugids)
+        {}
 };
 
 typedef uint64_t dinteger_t;
@@ -7813,6 +8029,14 @@ struct Token
         lineComment()
     {
     }
+    Token(Token* next, Loc loc = Loc(nullptr, 0u, 0u), const char* ptr = nullptr, TOK value = (TOK)0u, _d_dynamicArray< const char > blockComment = {}, _d_dynamicArray< const char > lineComment = {}) :
+        next(next),
+        loc(loc),
+        ptr(ptr),
+        value(value),
+        blockComment(blockComment),
+        lineComment(lineComment)
+        {}
 };
 
 template <typename T>

--- a/test/compilable/dtoh_21217.d
+++ b/test/compilable/dtoh_21217.d
@@ -68,6 +68,9 @@ public:
         a(1)
     {
     }
+    Foo(int32_t a) :
+        a(a)
+        {}
 };
 
 ---

--- a/test/compilable/dtoh_ClassDeclaration.d
+++ b/test/compilable/dtoh_ClassDeclaration.d
@@ -97,6 +97,9 @@ public:
             x()
         {
         }
+        Inner(int32_t x) :
+            x(x)
+            {}
     };
 
     class InnerC

--- a/test/compilable/dtoh_StructDeclaration.d
+++ b/test/compilable/dtoh_StructDeclaration.d
@@ -55,6 +55,12 @@ struct S
         arr()
     {
     }
+    S(int8_t a, int32_t b = 0, int64_t c = 0LL, _d_dynamicArray< int32_t > arr = {}) :
+        a(a),
+        b(b),
+        c(c),
+        arr(arr)
+        {}
 };
 
 struct S2
@@ -100,6 +106,12 @@ struct S4
         d()
     {
     }
+    S4(int32_t a, int64_t b = 0LL, int32_t c = 0, int8_t d = 0) :
+        a(a),
+        b(b),
+        c(c),
+        d(d)
+        {}
 };
 
 #pragma pack(push, 1)
@@ -125,6 +137,9 @@ struct Null
         field(nullptr)
     {
     }
+    Null(void* field) :
+        field(field)
+        {}
 };
 
 struct A
@@ -150,6 +165,9 @@ struct A
             x()
         {
         }
+        Inner(int32_t x) :
+            x(x)
+            {}
     };
 
     typedef Inner I;
@@ -160,6 +178,10 @@ struct A
         s()
     {
     }
+    A(int32_t a, S s = S(0, 0, 0LL, {})) :
+        a(a),
+        s(s)
+        {}
 };
 
 union U

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -57,6 +57,9 @@ struct B
         x()
     {
     }
+    B(A<int32_t > x) :
+        x(x)
+        {}
 };
 
 template <typename T>

--- a/test/compilable/dtoh_cpp98_compat.d
+++ b/test/compilable/dtoh_cpp98_compat.d
@@ -53,6 +53,10 @@ public:
         null_()
     {
     }
+    Null(void* field, _d_dynamicArray< const char > null_ = _d_dynamicArray< const char >()) :
+        field(field),
+        null_(null_)
+        {}
 };
 
 extern void* typeof_null;
@@ -66,6 +70,9 @@ struct MyString
         str()
     {
     }
+    MyString(_d_dynamicArray< const char > str) :
+        str(str)
+        {}
 };
 
 struct Wrapper
@@ -77,6 +84,10 @@ struct Wrapper
         s2(MyString(_d_dynamicArray< const char >()))
     {
     }
+    Wrapper(MyString s1, MyString s2 = MyString(_d_dynamicArray< const char >())) :
+        s1(s1),
+        s2(s2)
+        {}
 };
 ---
 */

--- a/test/compilable/dtoh_enum.d
+++ b/test/compilable/dtoh_enum.d
@@ -136,6 +136,9 @@ struct FooCpp
         i()
     {
     }
+    FooCpp(int32_t i) :
+        i(i)
+        {}
 };
 
 namespace MyEnumCpp

--- a/test/compilable/dtoh_enum_cpp98.d
+++ b/test/compilable/dtoh_enum_cpp98.d
@@ -124,6 +124,9 @@ struct FooCpp
         i()
     {
     }
+    FooCpp(int32_t i) :
+        i(i)
+        {}
 };
 
 namespace MyEnumCpp

--- a/test/compilable/dtoh_extern_type.d
+++ b/test/compilable/dtoh_extern_type.d
@@ -90,6 +90,14 @@ struct Floats
         nInf(-INFINITY)
     {
     }
+    Floats(float f, double d = 4.56, _d_real r = 7.89L, double nan = NAN, double inf = INFINITY, double nInf = -INFINITY) :
+        f(f),
+        d(d),
+        r(r),
+        nan(nan),
+        inf(inf),
+        nInf(nInf)
+        {}
 };
 
 struct Null
@@ -99,6 +107,9 @@ struct Null
         null_()
     {
     }
+    Null(_d_dynamicArray< const char > null_) :
+        null_(null_)
+        {}
 };
 
 struct Wrapper
@@ -110,6 +121,10 @@ struct Wrapper
         n2(Null({}))
     {
     }
+    Wrapper(Null n1, Null n2 = Null({})) :
+        n1(n1),
+        n2(n2)
+        {}
 };
 
 extern const _d_dynamicArray< const char > helloWorld;

--- a/test/compilable/dtoh_functions.d
+++ b/test/compilable/dtoh_functions.d
@@ -82,6 +82,10 @@ struct W1
     W1()
     {
     }
+    W1(MS ms, /* MSN */ S msn = S(42)) :
+        ms(ms),
+        msn(msn)
+        {}
 };
 
 struct W2
@@ -91,6 +95,9 @@ struct W2
         w1()
     {
     }
+    W2(W1 w1) :
+        w1(w1)
+        {}
 };
 
 extern W2 w2;
@@ -107,6 +114,9 @@ struct S
         i()
     {
     }
+    S(int32_t i) :
+        i(i)
+        {}
 };
 
 extern S s;
@@ -128,6 +138,9 @@ struct S2
         s()
     {
     }
+    S2(S s) :
+        s(s)
+        {}
 };
 
 extern S2 s2;

--- a/test/compilable/dtoh_protection.d
+++ b/test/compilable/dtoh_protection.d
@@ -105,6 +105,9 @@ public:
             publicInner()
         {
         }
+        PublicInnerStruct(int32_t publicInner) :
+            publicInner(publicInner)
+            {}
     };
 
 private:
@@ -118,6 +121,9 @@ private:
             publicInner()
         {
         }
+        PrivateInnerClass(int32_t publicInner) :
+            publicInner(publicInner)
+            {}
     };
 
 public:


### PR DESCRIPTION
This replicates the D behaviour on the C++ side and is required for generated ctors / default arguments which invoke a single argument ctor.

---

~~Depends on #11937~~