### PR TITLE
dtoh: Emit floating point literals according to their base type ...

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -19,6 +19,8 @@ experimental C++ header generator:
 - Opaque enums no longer cause segfaults & are properly exported for C++ 11
 - C++11 constructs are avoided when compiling with `-extern-std=c++98`.
 - Using `typeof(null)` type no longer causes an assertion failure.
+- The base type of floating point literals is propagated into the header
+- `NaN`, `Infinity` are emitted using `NAN`/`INFINITY` from `math.h`.
 - Final classes are marked as `final`
 - Identifier chains in templates are printed completely
 - Proper vtable layout is ensured by emitting hidden placeholders for

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_21217.d
+++ b/test/compilable/dtoh_21217.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_AliasDeclaration.d
+++ b/test/compilable/dtoh_AliasDeclaration.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_AliasDeclaration_98.d
+++ b/test/compilable/dtoh_AliasDeclaration_98.d
@@ -9,6 +9,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_AnonDeclaration.d
+++ b/test/compilable/dtoh_AnonDeclaration.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_CPPNamespaceDeclaration.d
+++ b/test/compilable/dtoh_CPPNamespaceDeclaration.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_ClassDeclaration.d
+++ b/test/compilable/dtoh_ClassDeclaration.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_StructDeclaration.d
+++ b/test/compilable/dtoh_StructDeclaration.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_VarDeclaration.d
+++ b/test/compilable/dtoh_VarDeclaration.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_cpp98_compat.d
+++ b/test/compilable/dtoh_cpp98_compat.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_enum.d
+++ b/test/compilable/dtoh_enum.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_enum_cpp98.d
+++ b/test/compilable/dtoh_enum_cpp98.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_extern_type.d
+++ b/test/compilable/dtoh_extern_type.d
@@ -11,6 +11,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE
@@ -37,6 +38,9 @@ struct _d_dynamicArray
         return ptr[idx];
     }
 };
+#endif
+#if !defined(_d_real)
+# define _d_real long double
 #endif
 
 class ClassFromStruct
@@ -66,6 +70,25 @@ struct StructFromClass
 {
     virtual void foo();
 };
+
+struct Floats
+{
+    float f;
+    double d;
+    _d_real r;
+    double nan;
+    double inf;
+    double nInf;
+    Floats() :
+        f(1.23F),
+        d(4.56),
+        r(7.89L),
+        nan(NAN),
+        inf(INFINITY),
+        nInf(-INFINITY)
+    {
+    }
+};
 ---
 */
 
@@ -87,4 +110,15 @@ extern (C++, struct) struct StructFromStruct
 extern (C++, struct) class StructFromClass
 {
     void foo() {}
+}
+
+extern(C++) struct Floats
+{
+    float f = 1.23f;
+    double d = 4.56;
+    real r = 7.89L;
+
+    double nan = double.nan;
+    double inf = double.infinity;
+    double nInf = -double.infinity;
 }

--- a/test/compilable/dtoh_functions.d
+++ b/test/compilable/dtoh_functions.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_protection.d
+++ b/test/compilable/dtoh_protection.d
@@ -11,6 +11,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_unittest_block.d
+++ b/test/compilable/dtoh_unittest_block.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE

--- a/test/compilable/dtoh_verbose.d
+++ b/test/compilable/dtoh_verbose.d
@@ -9,6 +9,7 @@ TEST_OUTPUT:
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <math.h>
 
 #ifdef CUSTOM_D_ARRAY_TYPE
 #define _d_dynamicArray CUSTOM_D_ARRAY_TYPE


### PR DESCRIPTION
... and respect `NaN` / `Infinity`. The latter is implemented using the `NAN` and `INFINITY` macros from `math.h` to ensure compatibility with < C++ 11.