### PR TITLE
fix Issue 21364 - Improperly aligned struct when one member is a GPR …

### DIFF
--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -1247,7 +1247,7 @@ extern (C) int
  */
 void stackoffsets(int flags)
 {
-    //printf("stackoffsets() %s\n", funcsym_p.Sident);
+    //printf("stackoffsets() %s\n", funcsym_p.Sident.ptr);
 
     Para.init();        // parameter offset
     Fast.init();        // SCfastpar offset
@@ -1310,7 +1310,7 @@ void stackoffsets(int flags)
         if (alignsize > STACKALIGN)
             alignsize = STACKALIGN;         // no point if the stack is less aligned
 
-        //printf("symbol '%s', size = x%lx, alignsize = %d, read = %x\n",s.Sident,(long)sz, (int)alignsize, s.Sflags & SFLread);
+        //printf("symbol '%s', size = %d, alignsize = %d, read = %x\n",s.Sident.ptr, cast(int)sz, cast(int)alignsize, s.Sflags & SFLread);
         assert(cast(int)sz >= 0);
 
         switch (s.Sclass)

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -2750,7 +2750,8 @@ uint el_alignsize(elem *e)
 {
     const tym = tybasic(e.Ety);
     uint alignsize = tyalignsize(tym);
-    if (alignsize == cast(uint)-1)
+    if (alignsize == cast(uint)-1 ||
+        (e.Ety & (mTYxmmgpr | mTYgprxmm)))
     {
         assert(e.ET);
         alignsize = type_alignsize(e.ET);

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -2129,6 +2129,30 @@ void16 simd_stox(XMM opcode)(void16 op1, void16 op2)
 }
 
 /*****************************************/
+// https://issues.dlang.org/show_bug.cgi?id=21364
+
+struct X21364
+{
+    float x0;
+    long  x1;
+}
+
+version (X86_64)
+    static assert(X21364.alignof == 8);
+
+void foo21364(int bar, X21364 x, int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9)
+{
+    assert(i1 == 2);
+    assert(bar == 1);
+}
+
+void test21364()
+{
+    X21364 x = X21364();
+    foo21364(1, x, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+}
+
+/*****************************************/
 
 int main()
 {
@@ -2174,6 +2198,7 @@ int main()
     test6();
     test7();
     test20981();
+    test21364();
 
     return 0;
 }


### PR DESCRIPTION
…and the other is an XMM