### PR TITLE
dtoh: Emit immutable as const instead of mutable

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -22,6 +22,7 @@ experimental C++ header generator:
 - The base type of floating point literals is propagated into the header
 - `NaN`, `Infinity` are emitted using `NAN`/`INFINITY` from `math.h`.
 - Final classes are marked as `final`
+- `immutable` is emitted as `const` instead of mutable
 - Identifier chains in templates are printed completely
 - Proper vtable layout is ensured by emitting hidden placeholders for
   virtual functions that are not `extern(C|C++)`.

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -428,8 +428,8 @@ public:
     {
         debug (Debug_DtoH)
         {
-            printf("[AST.StorageClassDeclaration enter] %s\n", pd.toChars());
-            scope(exit) printf("[AST.StorageClassDeclaration exit] %s\n", pd.toChars());
+            printf("[AST.StorageClassDeclaration enter] %s\n", scd.toChars());
+            scope(exit) printf("[AST.StorageClassDeclaration exit] %s\n", scd.toChars());
         }
         const stcStash = this.storageClass;
         this.storageClass |= scd.stc;
@@ -555,13 +555,13 @@ public:
             writeProtection(AST.Prot.Kind.private_);
         funcToBuffer(tf, fd);
         // FIXME: How to determine if fd is const without tf?
-        if (adparent && tf && tf.isConst())
+        if (adparent && tf && (tf.isConst() || tf.isImmutable()))
         {
             bool fdOverridesAreConst = true;
             foreach (fdv; fd.foverrides)
             {
                 auto tfv = cast(AST.TypeFunction)fdv.type;
-                if (!tfv.isConst())
+                if (!tfv.isConst() && !tfv.isImmutable())
                 {
                     fdOverridesAreConst = false;
                     break;
@@ -1438,7 +1438,7 @@ public:
             printf("[AST.TypeBasic enter] %s\n", t.toChars());
             scope(exit) printf("[AST.TypeBasic exit] %s\n", t.toChars());
         }
-        if (t.isConst())
+        if (t.isConst() || t.isImmutable())
             buf.writestring("const ");
         string typeName;
         switch (t.ty)
@@ -1485,7 +1485,7 @@ public:
         t.next.accept(this);
         if (t.next.ty != AST.Tfunction)
             buf.writeByte('*');
-        if (t.isConst())
+        if (t.isConst() || t.isImmutable())
             buf.writestring(" const");
     }
 
@@ -1594,7 +1594,7 @@ public:
             //printf("Visiting enum %s from module %s %s\n", t.sym.toPrettyChars(), t.toChars(), t.sym.loc.toChars());
             visitAsRoot(t.sym, fwdbuf);
         }
-        if (t.isConst())
+        if (t.isConst() || t.isImmutable())
             buf.writestring("const ");
         enumToBuffer(t.sym);
     }
@@ -1614,7 +1614,7 @@ public:
             fwdbuf.writestringln(";");
         }
 
-        if (t.isConst())
+        if (t.isConst() || t.isImmutable())
             buf.writestring("const ");
         if (auto ti = t.sym.parent.isTemplateInstance())
         {
@@ -1631,7 +1631,7 @@ public:
             printf("[AST.TypeDArray enter] %s\n", t.toChars());
             scope(exit) printf("[AST.TypeDArray exit] %s\n", t.toChars());
         }
-        if (t.isConst())
+        if (t.isConst() || t.isImmutable())
             buf.writestring("const ");
         buf.writestring("_d_dynamicArray< ");
         t.next.accept(this);
@@ -1761,11 +1761,11 @@ public:
             fwdbuf.writestringln(";");
         }
 
-        if (t.isConst())
+        if (t.isConst() || t.isImmutable())
             buf.writestring("const ");
         buf.writestring(t.sym.toChars());
         buf.writeByte('*');
-        if (t.isConst())
+        if (t.isConst() || t.isImmutable())
             buf.writestring(" const");
     }
 
@@ -2006,6 +2006,7 @@ public:
             printf("[AST.StringExp enter] %s\n", e.toChars());
             scope(exit) printf("[AST.StringExp exit] %s\n", e.toChars());
         }
+
         if (e.sz == 2)
             buf.writeByte('u');
         else if (e.sz == 4)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5061,7 +5061,7 @@ extern void generateJson(Array<Module* >* modules);
 
 typedef int32_t(*MainFunc)(_d_dynamicArray< _d_dynamicArray< char > > args);
 
-extern "C" _d_dynamicArray< _d_dynamicArray< char > > rt_options;
+extern "C" _d_dynamicArray< _d_dynamicArray< const char > > rt_options;
 
 extern "C" int32_t main(int32_t argc, char** argv);
 
@@ -7263,19 +7263,19 @@ typedef uint32_t structalign_t;
 struct Global
 {
     _d_dynamicArray< const char > inifilename;
-    _d_dynamicArray< char > mars_ext;
+    _d_dynamicArray< const char > mars_ext;
     _d_dynamicArray< const char > obj_ext;
     _d_dynamicArray< const char > lib_ext;
     _d_dynamicArray< const char > dll_ext;
-    _d_dynamicArray< char > doc_ext;
-    _d_dynamicArray< char > ddoc_ext;
-    _d_dynamicArray< char > hdr_ext;
-    _d_dynamicArray< char > cxxhdr_ext;
-    _d_dynamicArray< char > json_ext;
-    _d_dynamicArray< char > map_ext;
+    _d_dynamicArray< const char > doc_ext;
+    _d_dynamicArray< const char > ddoc_ext;
+    _d_dynamicArray< const char > hdr_ext;
+    _d_dynamicArray< const char > cxxhdr_ext;
+    _d_dynamicArray< const char > json_ext;
+    _d_dynamicArray< const char > map_ext;
     bool run_noext;
-    _d_dynamicArray< char > copyright;
-    _d_dynamicArray< char > written;
+    _d_dynamicArray< const char > copyright;
+    _d_dynamicArray< const char > written;
     Array<const char* >* path;
     Array<const char* >* filePath;
     _d_dynamicArray< const char > vendor;

--- a/test/compilable/dtoh_cpp98_compat.d
+++ b/test/compilable/dtoh_cpp98_compat.d
@@ -42,13 +42,13 @@ struct _d_dynamicArray
 struct Null
 {
     void* field;
-    _d_dynamicArray< char > null_;
+    _d_dynamicArray< const char > null_;
 private:
     Null(int32_t );
 public:
     Null() :
         field(NULL),
-        null_(_d_dynamicArray< char >())
+        null_(_d_dynamicArray< const char >())
     {
     }
 };

--- a/test/compilable/dtoh_enum.d
+++ b/test/compilable/dtoh_enum.d
@@ -54,6 +54,8 @@ enum class Enum
     Two = 1,
 };
 
+extern const Enum constEnum;
+
 enum class EnumDefaultType
 {
     One = 1,
@@ -158,6 +160,8 @@ enum Enum
     One,
     Two
 }
+
+extern(C++) __gshared const(Enum) constEnum;
 
 enum EnumDefaultType : int
 {

--- a/test/compilable/dtoh_extern_type.d
+++ b/test/compilable/dtoh_extern_type.d
@@ -92,12 +92,14 @@ struct Floats
 
 struct Null
 {
-    _d_dynamicArray< char > null_;
+    _d_dynamicArray< const char > null_;
     Null() :
         null_({})
     {
     }
 };
+
+extern const _d_dynamicArray< const char > helloWorld;
 ---
 */
 
@@ -136,3 +138,5 @@ extern (C++) struct Null
 {
     string null_ = null;
 }
+
+extern(C++) __gshared immutable string helloWorld = `"Hello\World!"`;

--- a/test/compilable/dtoh_functions.d
+++ b/test/compilable/dtoh_functions.d
@@ -108,8 +108,6 @@ extern int32_t(*f)(int32_t );
 
 extern void special(int32_t a = ptr->i, int32_t b = ptr->get(1, 2), int32_t j = (*f)(1));
 
-extern void strings(_d_dynamicArray< char > s = "\"Hello\\World!\"");
-
 extern void variadic(int32_t _param_0, ...);
 ---
 */
@@ -211,8 +209,6 @@ S* ptr;
 int function(int) f;
 
 void special(int a = ptr.i, int b = ptr.get(1, 2), int j = f(1)) {}
-
-void strings(string s = `"Hello\World!"`) {}
 
 import core.stdc.stdarg;
 void variadic(int, ...) {}

--- a/test/dshell/extra-files/cpp_header_gen/app.cpp
+++ b/test/dshell/extra-files/cpp_header_gen/app.cpp
@@ -57,5 +57,8 @@ int main()
     assert(templated(Templated<int>(4)).t == 4);
 #endif
 
+    int i;
+    assert(&i == inoutFunc(&i));
+
     return 0;
 }

--- a/test/dshell/extra-files/cpp_header_gen/library.d
+++ b/test/dshell/extra-files/cpp_header_gen/library.d
@@ -133,3 +133,8 @@ extern(C++) Templated!int templated(Templated!(Templated!int) i)
 {
     return typeof(return)(i.t.t);
 }
+
+inout(int)* inoutFunc(inout int* ptr)
+{
+    return ptr;
+}


### PR DESCRIPTION
`Type.isConst` is false for immutable symbols, so we need to check for `isImmutable` as well.

Note that `inout` is currently mangled as mutable, so we can't rely on `!Type.isMutable`.