### PR TITLE
Fix Issues 20714, 20965 - Postblit has priority over copy constructor

### DIFF
--- a/test/fail_compilation/fail20965.d
+++ b/test/fail_compilation/fail20965.d
@@ -1,0 +1,26 @@
+// https://issues.dlang.org/show_bug.cgi?id=20965
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20965.d(24): Error: copy constructor `fail20965.S.this` cannot be used because it is annotated with `@disable`
+---
+*/
+
+struct C
+{
+    this(this) {}
+}
+
+struct S
+{
+    C c;
+    @disable this(ref typeof(this));
+}
+
+void main()
+{
+    S s1;
+    auto s2 = s1; // problem
+}
+

--- a/test/runnable/test20714.d
+++ b/test/runnable/test20714.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=20714
+
+struct Blitter
+{
+    int payload;
+    this(this){}
+}
+
+struct Adder
+{
+    Blitter blitter;
+    this(int payload) {this.blitter.payload = payload;}
+    this(ref Adder rhs) {this.blitter.payload = rhs.blitter.payload + 1;}
+}
+
+void main()
+{
+    Adder piece1 = 1;
+    auto piece2 = piece1;
+
+    assert(piece2.blitter.payload == 2);
+}


### PR DESCRIPTION
Currently, whenever a postblit is defined, the copy constructor will get ignored (except if the postblit is disabled). This patch makes it so that whenever a copy constructor is defined it will take precedence over generated postblits. However if we have a user defined postblit, which is not disabled, it will take precedence over the copy constructor (user-defined or generated).

Technically this is a silent change of code behavior, however, I suspect that there are not any cases where you have copy constructors which are hanging around in code without being called. Anyway let's see if anything breaks.

This will need a spec update in case it will be accepted.