### PR TITLE
remove use of redundant global config.exe

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -107,7 +107,7 @@ bool ISX64REF(Declaration var)
 
     if (var.isParameter())
     {
-        if (config.exe == EX_WIN64)
+        if (global.params.isWindows && global.params.is64bit)
         {
             return var.type.size(Loc.initial) > REGSIZE
                 || (var.storage_class & STC.lazy_)
@@ -126,7 +126,7 @@ bool ISX64REF(Declaration var)
  */
 bool ISX64REF(IRState* irs, Expression exp)
 {
-    if (config.exe == EX_WIN64)
+    if (irs.params.isWindows && irs.params.is64bit)
     {
         return exp.type.size(Loc.initial) > REGSIZE
             || (exp.type.isTypeStruct() && !exp.type.isTypeStruct().sym.isPOD());
@@ -263,7 +263,7 @@ private elem *callfunc(const ref Loc loc,
                 continue;
             }
 
-            if (config.exe == EX_WIN64 && tybasic(ea.Ety) == TYcfloat)
+            if (irs.params.isWindows && irs.params.is64bit && tybasic(ea.Ety) == TYcfloat)
             {
                 /* Treat a cfloat like it was a struct { float re,im; }
                  */
@@ -1065,10 +1065,10 @@ Lagain:
                     type *t2 = evalue.ET.Ttag.Sstruct.Sarg2type;
                     if (!t1 && !t2)
                     {
-                        if (config.exe != EX_WIN64 || sz > 8)
+                        if (!irs.params.isWindows || sz > 8)
                             r = RTLSYM_MEMSETN;
                     }
-                    else if (config.exe != EX_WIN64 &&
+                    else if (!irs.params.isWindows &&
                              r == RTLSYM_MEMSET128ii &&
                              tyfloating(t1.Tty) &&
                              tyfloating(t2.Tty))
@@ -1094,7 +1094,7 @@ Lagain:
         edim = el_bin(OPmul, TYsize_t, edim, el_long(TYsize_t, sz));
     }
 
-    if (config.exe == EX_WIN64 && sz > REGSIZE)
+    if (irs.params.isWindows && irs.params.is64bit && sz > REGSIZE)
     {
         evalue = addressElem(evalue, tb);
     }
@@ -1931,7 +1931,7 @@ elem *toElem(Expression e, IRState *irs)
                     elem *earray = ExpressionsToStaticArray(ne.loc, ne.arguments, &sdata);
 
                     e = el_pair(TYdarray, el_long(TYsize_t, ne.arguments.dim), el_ptr(sdata));
-                    if (config.exe == EX_WIN64)
+                    if (irs.params.isWindows && irs.params.is64bit)
                         e = addressElem(e, Type.tsize_t.arrayOf());
                     e = el_param(e, getTypeInfo(ne.loc, ne.type, irs));
                     int rtl = t.isZeroInit(Loc.initial) ? RTLSYM_NEWARRAYMTX : RTLSYM_NEWARRAYMITX;
@@ -2154,7 +2154,7 @@ elem *toElem(Expression e, IRState *irs)
                     size_t len = strlen(id);
                     Symbol *si = toStringSymbol(id, len, 1);
                     elem *efilename = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-                    if (config.exe == EX_WIN64)
+                    if (irs.params.isWindows && irs.params.is64bit)
                         efilename = addressElem(efilename, Type.tstring, true);
 
                     if (ae.msg)
@@ -2166,7 +2166,7 @@ elem *toElem(Expression e, IRState *irs)
                          */
                         elem *emsg = toElemDtor(ae.msg, irs);
                         emsg = array_toDarray(ae.msg.type, emsg);
-                        if (config.exe == EX_WIN64)
+                        if (irs.params.isWindows && irs.params.is64bit)
                             emsg = addressElem(emsg, Type.tvoid.arrayOf(), false);
 
                         ea = el_var(getRtlsym(ud ? RTLSYM_DUNITTEST_MSG : RTLSYM_DASSERT_MSG));
@@ -2325,7 +2325,7 @@ elem *toElem(Expression e, IRState *irs)
         {
             elem *ex = toElem(e, irs);
             ex = array_toDarray(e.type, ex);
-            if (config.exe == EX_WIN64)
+            if (irs.params.isWindows && irs.params.is64bit)
             {
                 ex = addressElem(ex, Type.tvoid.arrayOf(), false);
             }
@@ -2375,7 +2375,7 @@ elem *toElem(Expression e, IRState *irs)
                 elem *earr = ElemsToStaticArray(ce.loc, ce.type, &elems, &sdata);
 
                 elem *ep = el_pair(TYdarray, el_long(TYsize_t, elems.dim), el_ptr(sdata));
-                if (config.exe == EX_WIN64)
+                if (irs.params.isWindows && irs.params.is64bit)
                     ep = addressElem(ep, Type.tvoid.arrayOf());
                 ep = el_param(ep, getTypeInfo(ce.loc, ta, irs));
                 e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYCATNTX)), ep);
@@ -2951,7 +2951,7 @@ elem *toElem(Expression e, IRState *irs)
                          */
                         el_free(esize);
                         elem *eti = getTypeInfo(ae.e1.loc, t1.nextOf().toBasetype(), irs);
-                        if (config.exe == EX_WIN64)
+                        if (irs.params.isWindows && irs.params.is64bit)
                         {
                             eto   = addressElem(eto,   Type.tvoid.arrayOf());
                             efrom = addressElem(efrom, Type.tvoid.arrayOf());
@@ -2966,7 +2966,7 @@ elem *toElem(Expression e, IRState *irs)
                         // Generate:
                         //      _d_arraycopy(eto, efrom, esize)
 
-                        if (config.exe == EX_WIN64)
+                        if (irs.params.isWindows && irs.params.is64bit)
                         {
                             eto   = addressElem(eto,   Type.tvoid.arrayOf());
                             efrom = addressElem(efrom, Type.tvoid.arrayOf());
@@ -3259,7 +3259,7 @@ elem *toElem(Expression e, IRState *irs)
                      *      _d_arrayctor(ti, e2, e1)
                      */
                     elem *eti = getTypeInfo(ae.e1.loc, t1b.nextOf().toBasetype(), irs);
-                    if (config.exe == EX_WIN64)
+                    if (irs.params.isWindows && irs.params.is64bit)
                     {
                         e1 = addressElem(e1, Type.tvoid.arrayOf());
                         e2 = addressElem(e2, Type.tvoid.arrayOf());
@@ -3282,7 +3282,7 @@ elem *toElem(Expression e, IRState *irs)
                      *      _d_arrayassign_r(ti, e2, e1, etmp)
                      */
                     elem *eti = getTypeInfo(ae.e1.loc, t1b.nextOf().toBasetype(), irs);
-                    if (config.exe == EX_WIN64)
+                    if (irs.params.isWindows && irs.params.is64bit)
                     {
                         e1 = addressElem(e1, Type.tvoid.arrayOf());
                         e2 = addressElem(e2, Type.tvoid.arrayOf());
@@ -3362,7 +3362,7 @@ elem *toElem(Expression e, IRState *irs)
                     assert(tb1n.equals(tb2.nextOf().toBasetype()));
 
                     e1 = el_una(OPaddr, TYnptr, e1);
-                    if (config.exe == EX_WIN64)
+                    if (irs.params.isWindows && irs.params.is64bit)
                         e2 = addressElem(e2, tb2, true);
                     else
                         e2 = useOPstrpar(e2);
@@ -5594,7 +5594,7 @@ elem *toElem(Expression e, IRState *irs)
 
                 elem *ev = el_pair(TYdarray, el_long(TYsize_t, dim), el_ptr(svalues));
                 elem *ek = el_pair(TYdarray, el_long(TYsize_t, dim), el_ptr(skeys  ));
-                if (config.exe == EX_WIN64)
+                if (irs.params.isWindows && irs.params.is64bit)
                 {
                     ev = addressElem(ev, Type.tvoid.arrayOf());
                     ek = addressElem(ek, Type.tvoid.arrayOf());
@@ -6167,7 +6167,7 @@ private elem *filelinefunction(IRState *irs, const ref Loc loc)
     size_t len = strlen(id);
     Symbol *si = toStringSymbol(id, len, 1);
     elem *efilename = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-    if (config.exe == EX_WIN64)
+    if (irs.params.isWindows && irs.params.is64bit)
         efilename = addressElem(efilename, Type.tstring, true);
 
     elem *elinnum = el_long(TYint, loc.linnum);
@@ -6182,7 +6182,7 @@ private elem *filelinefunction(IRState *irs, const ref Loc loc)
     len = strlen(s);
     si = toStringSymbol(s, len, 1);
     elem *efunction = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-    if (config.exe == EX_WIN64)
+    if (irs.params.isWindows && irs.params.is64bit)
         efunction = addressElem(efunction, Type.tstring, true);
 
     return el_params(efunction, elinnum, efilename, null);

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -459,14 +459,14 @@ void genObjFile(Module m, bool multiobj)
         elem *ecov  = el_pair(TYdarray, el_long(TYsize_t, m.numlines), el_ptr(m.cov));
         elem *ebcov = el_pair(TYdarray, el_long(TYsize_t, m.numlines), el_ptr(bcov));
 
-        if (config.exe == EX_WIN64)
+        if (global.params.isWindows && global.params.is64bit)
         {
             ecov  = addressElem(ecov,  Type.tvoid.arrayOf(), false);
             ebcov = addressElem(ebcov, Type.tvoid.arrayOf(), false);
         }
 
         elem *efilename = toEfilename(m);
-        if (config.exe == EX_WIN64)
+        if (global.params.isWindows && global.params.is64bit)
             efilename = addressElem(efilename, Type.tstring, true);
 
         elem *e = el_params(
@@ -875,7 +875,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         {
             if (fpr.alloc(sp.Stype, sp.Stype.Tty, &sp.Spreg, &sp.Spreg2))
             {
-                sp.Sclass = (config.exe == EX_WIN64) ? SCshadowreg : SCfastpar;
+                sp.Sclass = (global.params.isWindows && global.params.is64bit) ? SCshadowreg : SCfastpar;
                 sp.Sfl = (sp.Sclass == SCshadowreg) ? FLpara : FLfast;
             }
         }
@@ -1129,7 +1129,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
         {
             objmod.external_def("main");
         }
-        else if (config.exe == EX_WIN32)
+        else if (global.params.isWindows && !global.params.is64bit)
         {
             objmod.external_def("_main");
             objmod.external_def("__acrtused_con");
@@ -1153,7 +1153,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
                 obj_includelib(global.params.mscrtlib);
             objmod.includelib("OLDNAMES");
         }
-        else if (config.exe == EX_WIN32)
+        else if (global.params.isWindows && !global.params.is64bit)
         {
             objmod.external_def("__acrtused_con");        // bring in C startup code
             objmod.includelib("snn.lib");          // bring in C runtime library
@@ -1209,7 +1209,7 @@ private bool onlyOneMain(Loc loc)
         if (global.params.addMain)
             msg = ", -main switch added another `main()`";
         const(char)* otherMainNames = "";
-        if (config.exe == EX_WIN32 || config.exe == EX_WIN64)
+        if (global.params.isWindows)
             otherMainNames = ", `WinMain`, or `DllMain`";
         error(loc, "only one `main`%s allowed%s. Previously found `main` at %s",
             otherMainNames, msg, lastLoc.toChars());

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -175,7 +175,7 @@ Symbol *toSymbol(Dsymbol s)
             }
             else if (vd.storage_class & STC.lazy_)
             {
-                if (config.exe == EX_WIN64 && vd.isParameter())
+                if (global.params.isWindows && global.params.is64bit && vd.isParameter())
                     t = type_fake(TYnptr);
                 else
                     t = type_fake(TYdelegate);          // Tdelegate as C type
@@ -492,21 +492,21 @@ Symbol *toImport(Symbol *sym)
     import core.stdc.stdlib : alloca;
     char *id = cast(char *) alloca(6 + strlen(n) + 1 + type_paramsize(sym.Stype).sizeof*3 + 1);
     int idlen;
-    if (config.exe != EX_WIN32 && config.exe != EX_WIN64)
+    if (!global.params.isWindows)
     {
         id = n;
         idlen = cast(int)strlen(n);
     }
     else if (sym.Stype.Tmangle == mTYman_std && tyfunc(sym.Stype.Tty))
     {
-        if (config.exe == EX_WIN64)
+        if (global.params.isWindows && global.params.is64bit)
             idlen = sprintf(id,"__imp_%s",n);
         else
             idlen = sprintf(id,"_imp__%s@%u",n,cast(uint)type_paramsize(sym.Stype));
     }
     else
     {
-        idlen = sprintf(id,(config.exe == EX_WIN64) ? "__imp_%s" : "_imp__%s",n);
+        idlen = sprintf(id,(global.params.isWindows && global.params.is64bit) ? "__imp_%s" : "_imp__%s",n);
     }
     auto t = type_alloc(TYnptr | mTYconst);
     t.Tnext = sym.Stype;


### PR DESCRIPTION
config.exe should be used only by the code generator. This will make the dmd front end code more consistent.