### PR TITLE
add EX_windos

### DIFF
--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -504,14 +504,10 @@ enum
     EX_RATIONAL     = 4,       // RATIONAL 286 program
     EX_PHARLAP      = 8,       // PHARLAP 386 program
     EX_COM          = 0x10,    // MSDOS .COM program
-//  EX_WIN16        = 0x20,    // Windows 3.x 16 bit program (no longer supported)
     EX_OS2          = 0x40,    // OS/2 2.0 32 bit program
     EX_OS1          = 0x80,    // OS/2 1.x 16 bit program
     EX_WIN32        = 0x100,
     EX_MZ           = 0x200,   // MSDOS real mode program
-    EX_XENIX        = 0x400,
-    EX_SCOUNIX      = 0x800,
-    EX_UNIXSVR4     = 0x1000,
     EX_LINUX        = 0x2000,
     EX_WIN64        = 0x4000,  // AMD64 and Windows (64 bit mode)
     EX_LINUX64      = 0x8000,  // AMD64 and Linux (64 bit mode)
@@ -532,7 +528,10 @@ enum exefmt_t EX_flat = EX_OS2 | EX_WIN32 | EX_WIN64 | EX_posix;
 
 // All DOS executable types
 enum exefmt_t EX_dos =  EX_DOSX | EX_ZPM | EX_RATIONAL | EX_PHARLAP |
-                         EX_COM | EX_MZ /*| EX_WIN16*/;
+                         EX_COM | EX_MZ;
+
+// Windows and DOS executable types
+enum exefmt_t EX_windos = EX_dos | EX_OS1 | EX_OS2 | EX_WIN32 | EX_WIN64;
 
 // All POSIX systems
 enum exefmt_t EX_posix = EX_LINUX   | EX_LINUX64   |

--- a/src/dmd/backend/obj.d
+++ b/src/dmd/backend/obj.d
@@ -753,6 +753,11 @@ version (OMFandMSCOFF)
                 :    OmfObj_tlv_bootstrap();
         }
 
+        Symbol *getGOTsym()
+        {
+            assert(0);
+        }
+
         void gotref(Symbol *s)
         {
         }


### PR DESCRIPTION
The end goal is to convert compile-time branching to runtime branching, so that DMD can become a cross-compiler. This PR is progress in eliminating reliance on compile-time `TARGET_` enums.