### PR TITLE
target.h: Add forward declaration for FuncDeclaration

### DIFF
--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -19,6 +19,7 @@
 class ClassDeclaration;
 class Dsymbol;
 class Expression;
+class FuncDeclaration;
 class Parameter;
 class Type;
 class TypeTuple;


### PR DESCRIPTION
In the event that the target header is included before declaration.h