### PR TITLE
var.d: remove TARGET dependency

### DIFF
--- a/src/dmd/backend/var.d
+++ b/src/dmd/backend/var.d
@@ -832,16 +832,8 @@ __gshared byte[256] _tysize =
     TYvtshape  : -1,
 ];
 
-// Alignment of long doubles varies by target
-static if (TARGET_OSX)
-    enum LDOUBLE_ALIGN = 16;
-else static if (TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_DRAGONFLYBSD || TARGET_SOLARIS)
-    enum LDOUBLE_ALIGN = 4;
-else static if (TARGET_WINDOS)
-    enum LDOUBLE_ALIGN = 2;
-else
-    static assert(0, "fix this");
-
+// set alignment after we know the target
+enum SET_ALIGN = -1;
 
 /// Size of a type to use for alignment
 __gshared byte[256] _tyalignsize =
@@ -870,15 +862,15 @@ __gshared byte[256] _tyalignsize =
     TYfloat   : FLOATSIZE,
     TYdouble  : DOUBLESIZE,
     TYdouble_alias : 8,
-    TYldouble : LDOUBLE_ALIGN,
+    TYldouble : SET_ALIGN,
 
     TYifloat   : FLOATSIZE,
     TYidouble  : DOUBLESIZE,
-    TYildouble : LDOUBLE_ALIGN,
+    TYildouble : SET_ALIGN,
 
     TYcfloat   : 2*FLOATSIZE,
     TYcdouble  : 2*DOUBLESIZE,
-    TYcldouble : LDOUBLE_ALIGN,
+    TYcldouble : SET_ALIGN,
 
     TYfloat4  : 16,
     TYdouble2 : 16,


### PR DESCRIPTION
It's set later at config time anyway.