### PR TITLE
Add location to StaticForeachDeclaration

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1463,7 +1463,7 @@ struct ASTBase
 
         extern (D) this(StaticForeach sfe, Dsymbols* decl)
         {
-            super(decl);
+            super(sfe.loc, null, decl);
             this.sfe = sfe;
         }
 

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -1129,7 +1129,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
 
     extern (D) this(StaticForeach sfe, Dsymbols* decl)
     {
-        super(decl);
+        super(sfe.loc, null, decl);
         this.sfe = sfe;
     }
 
@@ -1357,7 +1357,6 @@ extern (C++) final class UserAttributeDeclaration : AttribDeclaration
     extern (D) this(Expressions* atts, Dsymbols* decl)
     {
         super(decl);
-        //printf("UserAttributeDeclaration()\n");
         this.atts = atts;
     }
 

--- a/test/unit/parser/conditionalcompilation_location.d
+++ b/test/unit/parser/conditionalcompilation_location.d
@@ -2,7 +2,7 @@ module parser.conditionalcompilation_location;
 
 import dmd.frontend : parseModule;
 import support : afterEach, beforeEach;
-import dmd.attrib : ConditionalDeclaration, StaticIfDeclaration;
+import dmd.attrib : ConditionalDeclaration, StaticIfDeclaration, StaticForeachDeclaration;
 import dmd.globals : Loc;
 import dmd.visitor : SemanticTimeTransitiveVisitor;
 
@@ -34,6 +34,11 @@ extern (C++) class Visitor : SemanticTimeTransitiveVisitor
     override void visit(StaticIfDeclaration sif)
     {
         l = sif.loc;
+    }
+
+    override void visit(StaticForeachDeclaration sfd)
+    {
+        l = sfd.loc;
     }
 }
 
@@ -76,6 +81,16 @@ enum tests = [
     Test("`static if` and condition different lines", "static if\n(a)"),
     Test("`static if`, condition and parantheses on different lines", "static if\n(\na\n)"),
     Test("`static` and `if` on different lines", "static\nif\n(a)"),
+
+    Test("`static foreach` and condition on the same line", "static foreach(a; b)"),
+    Test("`static foreach` and condition different lines", "static foreach\n(a; b)"),
+    Test("`static foreach`, condition and parantheses on different lines", "static foreach\n(\na; b\n)"),
+    Test("`static` and `foreach` on different lines", "static\nforeach\n(a; b)"),
+
+    Test("`static foreach_reverse` and condition on the same line", "static foreach_reverse(a; b)"),
+    Test("`static foreach_reverse` and condition different lines", "static foreach_reverse\n(a; b)"),
+    Test("`static foreach_reverse`, condition and parantheses on different lines", "static foreach_reverse\n(\na; b\n)"),
+    Test("`static` and `foreach_reverse` on different lines", "static\nforeach_reverse\n(a; b)"),
 ];
 
 static foreach (test; tests)


### PR DESCRIPTION
Location starts from `static`, just like the `StaticForeach` object it contains