### PR TITLE
dmd.mars: Predefine FreeBSD_11 when targeting FreeBSD

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1241,6 +1241,9 @@ void addDefaultVersionIdentifiers(const ref Param params)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("FreeBSD");
+        // FIXME: Need a way to statically and/or dynamically set the major FreeBSD version,
+        // to support FreeBSD 12.x and later releases both as a native and cross compiler.
+        VersionCondition.addPredefinedGlobalIdent("FreeBSD_11");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         VersionCondition.addPredefinedGlobalIdent("CppRuntime_Clang");
     }


### PR DESCRIPTION
This is a first step for supporting the new versioned bindings in druntime.  The next step would be to allow overriding this version to allow compilation on FreeBSD 12.x (or other versions).

The current stalled attempt at doing just that is in #8567.  But rather than rehashing that PR, this just lays down what is necessary to build dlang/druntime#3271.

[Paragraph 24.2.1.4](https://dlang.org/spec/version.html#predefined-versions) in the D spec already covers this version condition, that is it not reserved is due to [issue 17544](https://issues.dlang.org/show_bug.cgi?id=17544) not being resolved.