### PR TITLE
include all the dmd files

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1361,8 +1361,8 @@ auto sourceFiles()
             dtype.d debugprint.d fp.d symbol.d symtab.d elem.d dcode.d cgsched.d cg87.d cgxmm.d cgcod.d cod1.d cod2.d
             cod3.d cv8.d dcgcv.d pdata.d util2.d var.d md5.d backconfig.d ph2.d drtlsym.d dwarfeh.d ptrntab.d
             dvarstats.d dwarfdbginf.d cgen.d os.d goh.d barray.d cgcse.d elpicpie.d
-            machobj.d elfobj.d mscoffobj.d
-            " ~ ((env["OS"] == "windows") ? "cgobj.d filespec.d newman.d" : "aarray.d")
+            machobj.d elfobj.d mscoffobj.d filespec.d newman.d cgobj.d aarray.d
+            "
         ),
     };
 

--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -101,12 +101,6 @@ else
 
 int obj_namestring(char *p,const(char)* name);
 
-version (MARS)
-{
-// C++ name mangling is handled by front end
-const(char)* cpp_mangle(Symbol* s) { return &s.Sident[0]; }
-}
-
 static if (TARGET_WINDOS)
 {
 
@@ -2406,9 +2400,9 @@ size_t OmfObj_mangle(Symbol *s,char *dest)
 
     //printf("OmfObj_mangle('%s'), mangle = x%x\n",s.Sident.ptr,type_mangle(s.Stype));
 version (SCPP)
-    name = CPP ? cpp_mangle(s) : s.Sident.ptr;
+    name = CPP ? cpp_mangle(s) : &s.Sident[0];
 else version (MARS)
-    name = cast(char*)cpp_mangle(s);
+    name = &s.Sident[0];
 else
     static assert(0);
 

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -83,7 +83,6 @@ version (MARS)
 {
     // C++ name mangling is handled by front end
     const(char)* cpp_mangle2(Symbol* s) { return &s.Sident[0]; }
-    const(char)* cpp_mangle(Symbol* s) { return &s.Sident[0]; }
 }
 else
     const(char)* cpp_mangle2(Symbol* s) { return cpp_mangle(s); }

--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -103,12 +103,7 @@ else
 Symbol *asm_define_label(const(char)* id);
 
 // cpp.c
-version (SCPP)
-    const(char)* cpp_mangle(Symbol* s);
-else version (MARS)
-    const(char)* cpp_mangle(Symbol* s);
-else
-    const(char)* cpp_mangle(Symbol* s) { return &s.Sident[0]; }
+const(char)* cpp_mangle(Symbol* s);
 
 // ee.c
 void eecontext_convs(SYMIDX marksi);

--- a/src/dmd/backend/machobj.d
+++ b/src/dmd/backend/machobj.d
@@ -53,12 +53,6 @@ static if (MACHOBJ)
 import dmd.backend.dwarf;
 import dmd.backend.mach;
 
-version (MARS)
-{
-    // C++ name mangling is handled by front end
-    const(char)* cpp_mangle(Symbol* s) { return &s.Sident[0]; }
-}
-
 alias nlist = dmd.backend.mach.nlist;   // avoid conflict with dmd.backend.dlist.nlist
 
 /****************************************
@@ -2104,23 +2098,23 @@ char *unsstr (uint value)
 char *obj_mangle2(Symbol *s,char *dest)
 {
     size_t len;
-    char *name;
+    const(char)* name;
 
     //printf("Obj_mangle(s = %p, '%s'), mangle = x%x\n",s,s.Sident.ptr,type_mangle(s.Stype));
     symbol_debug(s);
     assert(dest);
 version (SCPP)
 {
-    name = CPP ? cpp_mangle(s) : s.Sident.ptr;
+    name = CPP ? cpp_mangle(s) : &s.Sident[0];
 }
 else version (MARS)
 {
     // C++ name mangling is handled by front end
-    name = s.Sident.ptr;
+    name = &s.Sident[0];
 }
 else
 {
-    name = s.Sident.ptr;
+    name = &s.Sident[0];
 }
     len = strlen(name);                 // # of bytes in name
     //dbg_printf("len %d\n",len);

--- a/src/dmd/backend/mscoffobj.d
+++ b/src/dmd/backend/mscoffobj.d
@@ -1691,12 +1691,12 @@ char *obj_mangle2(Symbol *s,char *dest)
     assert(dest);
 
 version (SCPP)
-    name = CPP ? cpp_mangle(s) : s.Sident.ptr;
+    name = CPP ? cpp_mangle(s) : &s.Sident[0];
 else version (MARS)
     // C++ name mangling is handled by front end
-    name = s.Sident.ptr;
+    name = &s.Sident[0];
 else
-    name = s.Sident.ptr;
+    name = &s.Sident[0];
 
     len = strlen(name);                 // # of bytes in name
     //dbg_printf("len %d\n",len);

--- a/src/dmd/backend/out.d
+++ b/src/dmd/backend/out.d
@@ -1413,16 +1413,9 @@ version (SCPP)
         else if (config.flags & CFGsegs) // if user set switch for this
         {
             version (SCPP)
-            {
-                objmod.codeseg(cast(char*)cpp_mangle(funcsym_p),1);
-            }
+                objmod.codeseg(cpp_mangle(funcsym_p),1);
             else
-            {
-                if (config.exe & EX_windos)
-                    objmod.codeseg(cast(char*)cpp_mangle(funcsym_p),1);
-                else
-                    objmod.codeseg(cast(char*)funcsym_p.Sident.ptr, 1);
-            }
+                objmod.codeseg(&funcsym_p.Sident[0], 1);
                                         // generate new code segment
         }
         cod3_align(cseg);               // align start of function


### PR DESCRIPTION
because to build a cross-compiler, it all has to be there.