### PR TITLE
Issue 21398 - Name clash between import and method triggers a segfault

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -163,7 +163,7 @@ private bool hasProtectedAccess(Scope *sc, Dsymbol s)
  * Check access to d for expression e.d
  * Returns true if the declaration is not accessible.
  */
-bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
+bool checkAccess(Loc loc, Scope* sc, Expression e, Dsymbol d)
 {
     if (sc.flags & SCOPE.noaccesscheck)
         return false;

--- a/test/compilable/test21398.d
+++ b/test/compilable/test21398.d
@@ -1,0 +1,31 @@
+// https://issues.dlang.org/show_bug.cgi?id=21398
+
+module test21398;
+
+void free(void* ptr);
+
+class MAlloc(T)
+{
+    import test21398: free;
+
+    void free(T)(T* value)
+    {
+        free(value);
+    }
+}
+
+struct Box(T)
+{
+    private T* __ptr;
+    alias A = MAlloc!T;
+
+    ~this()
+    {
+        A.free(__ptr);
+    }
+}
+
+void main()
+{
+    auto b = Box!(char)();
+}


### PR DESCRIPTION
Problem was here:
`d = cast(Declaration)mostVisibleOverload(fd, sc._module);`

The function `mostVisibleOverload()` can return many kinds of objects, most are derived from `Declaration` except for `TemplateDeclaration` so we need to handle that case as well.