### PR TITLE
GH Action: Check out the correct branch after merge

### DIFF
--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -140,6 +140,23 @@ jobs:
           # Other CIs will test bootstrapping.
           compiler: dmd-2.091.0
 
+    ##############################################
+    # Find out which branch we need to check out #
+    ##############################################
+    - name: Determine base branch
+      id: base_branch
+      shell: bash
+      run: |
+        # For pull requests, base_ref will not be empty
+        if [ ! -z ${{ github.base_ref }} ]; then
+            echo "::set-output name=branch::${{ github.base_ref }}"
+        # Otherwise, use whatever ref we have:
+        # For branches this in the format 'refs/heads/<branch_name>',
+        # and for tags it is refs/tags/<tag_name>.
+        else
+            echo "::set-output name=branch::${{ github.ref }}"
+        fi
+
     #########################################
     # Checking out up DMD, druntime, Phobos #
     #########################################
@@ -153,14 +170,14 @@ jobs:
       with:
         path: druntime
         repository: dlang/druntime
-        ref: ${{ github.base_ref }}
+        ref: ${{ steps.base_branch.outputs.branch }}
         persist-credentials: false
     - name: Checkout Phobos
       uses: actions/checkout@v2
       with:
         path: phobos
         repository: dlang/phobos
-        ref: ${{ github.base_ref }}
+        ref: ${{ steps.base_branch.outputs.branch }}
         persist-credentials: false
 
 


### PR DESCRIPTION
```
Unfortunately, the documentation states that `github.base_ref` and `github.head_ref`
are only available in pull requests, so instead we're using `github.ref` when
`github.base_ref` is empty.
```

See also: https://github.com/dlang/druntime/pull/3277