### PR TITLE
always compile in libmach and scanmach

### DIFF
--- a/src/dmd/scanmach.d
+++ b/src/dmd/scanmach.d
@@ -11,13 +11,13 @@
 
 module dmd.scanmach;
 
-version(OSX):
-
 import core.stdc.string;
 import core.stdc.stdint;
-import core.sys.darwin.mach.loader;
 import dmd.globals;
 import dmd.errors;
+
+//import core.sys.darwin.mach.loader;
+import dmd.backend.mach;
 
 private enum LOG = false;
 


### PR DESCRIPTION
This is a start to cross-compiling library generation. The trouble here is that core.sys.darwin.mach.loader is conditionally compiled for Darwin, which of course makes it unusable for cross-compilation. This restriction seems unnecessary, I'll see about removing it.