### PR TITLE
dmd.mars: Add method to predefine FreeBSD_12 at compile-time.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,6 +71,7 @@ task:
   timeout_in: 60m
   environment:
     OS_NAME: freebsd
+    CI_DFLAGS: -version=TARGET_FREEBSD12
   install_bash_script: pkg install -y bash
   << : *COMMON_STEPS_TEMPLATE
 
@@ -84,5 +85,6 @@ task:
   environment:
     OS_NAME: freebsd
     HOST_DC: dmd-2.079.0
+    CI_DFLAGS: -version=TARGET_FREEBSD11
   install_bash_script: pkg install -y bash
   << : *COMMON_STEPS_TEMPLATE

--- a/ci.sh
+++ b/ci.sh
@@ -15,6 +15,8 @@ if [ -z ${FULL_BUILD+x} ] ; then echo "Variable 'FULL_BUILD' needs to be set."; 
 if [ -z ${MODEL+x} ] ; then echo "Variable 'MODEL' needs to be set."; exit 1; fi
 # HOST_DC: dmd[-<version>]|ldc[-<version>]|gdmd-<version>
 if [ -z ${HOST_DC+x} ] ; then echo "Variable 'HOST_DC' needs to be set."; exit 1; fi
+# CI_DFLAGS: Optional flags to pass to the build
+if [ -z ${CI_DFLAGS+x} ] ; then CI_DFLAGS=""; fi
 
 CURL_USER_AGENT="DMD-CI $(curl --version | head -n 1)"
 build_path=generated/$OS_NAME/release/$MODEL
@@ -50,7 +52,7 @@ clone() {
 # build dmd, druntime, phobos
 build() {
     source ~/dlang/*/activate # activate host compiler, incl. setting `DMD`
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD ENABLE_RELEASE=1 ENABLE_WARNINGS=1 all
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=1 ENABLE_WARNINGS=1 all
     make -j$N -C ../druntime -f posix.mak MODEL=$MODEL
     make -j$N -C ../phobos -f posix.mak MODEL=$MODEL
     deactivate # deactivate host compiler

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -365,9 +365,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
 
     setTarget(params);
 
-    // Predefined version identifiers
-    addDefaultVersionIdentifiers(params);
-
     setDefaultLibrary();
 
     // Initialization
@@ -387,6 +384,9 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     }
     import dmd.root.ctfloat : CTFloat;
     CTFloat.initialize();
+
+    // Predefined version identifiers
+    addDefaultVersionIdentifiers(params);
 
     if (params.verbose)
     {
@@ -1241,9 +1241,7 @@ void addDefaultVersionIdentifiers(const ref Param params)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("FreeBSD");
-        // FIXME: Need a way to statically and/or dynamically set the major FreeBSD version,
-        // to support FreeBSD 12.x and later releases both as a native and cross compiler.
-        VersionCondition.addPredefinedGlobalIdent("FreeBSD_11");
+        VersionCondition.addPredefinedGlobalIdent("FreeBSD_" ~ target.FreeBSDMajor);
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         VersionCondition.addPredefinedGlobalIdent("CppRuntime_Clang");
     }

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -912,6 +912,25 @@ extern (C++) struct Target
             || params.isDragonFlyBSD
             || params.isSolaris;
     }
+
+    /**
+     * Returns:
+     *  FreeBSD major version string being targeted.
+     */
+    extern (D) @property string FreeBSDMajor() scope const nothrow @nogc
+    in { assert(params.isFreeBSD); }
+    do
+    {
+        // FIXME: Need better a way to statically set the major FreeBSD version?
+             version (TARGET_FREEBSD12) return "12";
+        else version (TARGET_FREEBSD11) return "11";
+        else version (TARGET_FREEBSD10) return "10";
+        else version (FreeBSD_12)       return "12";
+        else version (FreeBSD_11)       return "11";
+        else version (FreeBSD_10)       return "10";
+        // FIXME: Need a way to dynamically set the major FreeBSD version?
+        else /* default supported */    return "11";
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This allows to statically set which version of FreeBSD to compile for using DFLAGS, choices are FreeBSD 10, 11 or 12. If unset, the default is to use the same version as the host, or fallback to version 11 if compiling on a different host, or using an old D compiler to build DMD.

To be decided is whether there should be a dynamic way of detecting the FreeBSD OS version as well, such as by using getosreldate().

Small reboot of the stalled PR #8567