### PR TITLE
dtoh: Add explicit conversions for not implictly convertible expressions

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -779,7 +779,7 @@ struct Loc
     const char* filename;
     uint32_t linnum;
     uint32_t charnum;
-    const char* toChars(bool showColumns = global.params.showColumns, uint8_t messageStyle = global.params.messageStyle) const;
+    const char* toChars(bool showColumns = global.params.showColumns, uint8_t messageStyle = static_cast<uint8_t>(global.params.messageStyle)) const;
     bool equals(const Loc& loc) const;
     Loc() :
         filename(),
@@ -2661,7 +2661,7 @@ public:
     bool doNotInferScope;
     bool doNotInferReturn;
     uint8_t isdataseg;
-    static VarDeclaration* create(const Loc& loc, Type* type, Identifier* ident, Initializer* _init, StorageClass storage_class = STC::undefined_);
+    static VarDeclaration* create(const Loc& loc, Type* type, Identifier* ident, Initializer* _init, StorageClass storage_class = static_cast<StorageClass>(STC::undefined_));
     Dsymbol* syntaxCopy(Dsymbol* s);
     void setFieldOffset(AggregateDeclaration* ad, uint32_t* poffset, bool isunion);
     const char* kind() const;
@@ -7284,19 +7284,19 @@ struct Global
     ~Global();
     Global() :
         inifilename(),
-        mars_ext("d"),
+        mars_ext(1, "d"),
         obj_ext(),
         lib_ext(),
         dll_ext(),
-        doc_ext("html"),
-        ddoc_ext("ddoc"),
-        hdr_ext("di"),
-        cxxhdr_ext("h"),
-        json_ext("json"),
-        map_ext("map"),
+        doc_ext(4, "html"),
+        ddoc_ext(4, "ddoc"),
+        hdr_ext(2, "di"),
+        cxxhdr_ext(1, "h"),
+        json_ext(4, "json"),
+        map_ext(3, "map"),
         run_noext(),
-        copyright("Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved"),
-        written("written by Walter Bright"),
+        copyright(73, "Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved"),
+        written(24, "written by Walter Bright"),
         path(),
         filePath(),
         vendor(),

--- a/test/compilable/dtoh_cpp98_compat.d
+++ b/test/compilable/dtoh_cpp98_compat.d
@@ -39,6 +39,8 @@ struct _d_dynamicArray
 };
 #endif
 
+struct MyString;
+
 struct Null
 {
     void* field;
@@ -48,7 +50,7 @@ private:
 public:
     Null() :
         field(NULL),
-        null_(_d_dynamicArray< const char >())
+        null_()
     {
     }
 };
@@ -56,6 +58,26 @@ public:
 extern void* typeof_null;
 
 extern void* inferred_null;
+
+struct MyString
+{
+    _d_dynamicArray< const char > str;
+    MyString() :
+        str()
+    {
+    }
+};
+
+struct Wrapper
+{
+    MyString s1;
+    MyString s2;
+    Wrapper() :
+        s1(MyString(_d_dynamicArray< const char >( 5, "Hello" ))),
+        s2(MyString(_d_dynamicArray< const char >()))
+    {
+    }
+};
 ---
 */
 
@@ -69,3 +91,14 @@ extern (C++) struct Null
 
 extern (C++) __gshared typeof(null) typeof_null = null;
 extern (C++) __gshared inferred_null = null;
+
+extern (C++) struct MyString
+{
+    string str;
+}
+
+extern (C++) struct Wrapper
+{
+    MyString s1 = MyString("Hello");
+    MyString s2 = MyString(null);
+}

--- a/test/compilable/dtoh_extern_type.d
+++ b/test/compilable/dtoh_extern_type.d
@@ -43,6 +43,8 @@ struct _d_dynamicArray
 # define _d_real long double
 #endif
 
+struct Null;
+
 class ClassFromStruct
 {
 public:
@@ -94,7 +96,18 @@ struct Null
 {
     _d_dynamicArray< const char > null_;
     Null() :
-        null_({})
+        null_()
+    {
+    }
+};
+
+struct Wrapper
+{
+    Null n1;
+    Null n2;
+    Wrapper() :
+        n1(Null({ 5, "Hello" })),
+        n2(Null({}))
     {
     }
 };
@@ -137,6 +150,12 @@ extern(C++) struct Floats
 extern (C++) struct Null
 {
     string null_ = null;
+}
+
+extern (C++) struct Wrapper
+{
+    Null n1 = Null("Hello");
+    Null n2 = Null(null);
 }
 
 extern(C++) __gshared immutable string helloWorld = `"Hello\World!"`;

--- a/test/compilable/dtoh_functions.d
+++ b/test/compilable/dtoh_functions.d
@@ -1,4 +1,4 @@
-/*
+/+
 REQUIRED_ARGS: -HC -c -o-
 PERMUTE_ARGS:
 TEST_OUTPUT:
@@ -40,6 +40,8 @@ struct _d_dynamicArray
 #endif
 
 struct S;
+struct W1;
+struct W2;
 struct S2;
 
 extern "C" int32_t bar(int32_t x);
@@ -63,7 +65,37 @@ enum class E : int64_t
     m = 1LL,
 };
 
-extern void enums(uint64_t e = $?:32=1LLU|64=E::m$);
+enum class MS : uint8_t
+{
+    dm = 0u,
+};
+
+namespace MSN
+{
+    static S const s = S(42);
+};
+
+struct W1
+{
+    MS ms;
+    /* MSN */ S msn;
+    W1()
+    {
+    }
+};
+
+struct W2
+{
+    W1 w1;
+    W2() :
+        w1()
+    {
+    }
+};
+
+extern W2 w2;
+
+extern void enums(uint64_t e = $?:32=1LLU|64=static_cast<uint64_t>(E::m)$, uint8_t e2 = static_cast<uint8_t>(w2.w1.ms), S s = static_cast<S>(w2.w1.msn));
 
 struct S
 {
@@ -110,7 +142,7 @@ extern void special(int32_t a = ptr->i, int32_t b = ptr->get(1, 2), int32_t j = 
 
 extern void variadic(int32_t _param_0, ...);
 ---
-*/
++/
 
 int foo(int x)
 {
@@ -177,7 +209,13 @@ enum E : long
     m = 1
 }
 
-void enums(ulong e = E.m) {}
+enum MS : ubyte { dm }
+enum MSN : S { s = S(42) }
+struct W1 { MS ms; MSN msn; }
+struct W2 { W1 w1; }
+W2 w2;
+
+void enums(ulong e = E.m, ubyte e2 = w2.w1.ms, S s = w2.w1.msn) {}
 
 struct S
 {


### PR DESCRIPTION
Adds special cases for several implicit conversions that do not translate directly to C++ (slices initialized to null, strings, ...)