### PR TITLE
dmd.root.rmem: Remove non-GC version code.

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -902,23 +902,20 @@ else
      */
     extern (C) int main(int argc, char** argv)
     {
-        static if (isGCAvailable)
+        bool lowmem = false;
+        foreach (i; 1 .. argc)
         {
-            bool lowmem = false;
-            foreach (i; 1 .. argc)
+            if (strcmp(argv[i], "-lowmem") == 0)
             {
-                if (strcmp(argv[i], "-lowmem") == 0)
-                {
-                    lowmem = true;
-                    break;
-                }
+                lowmem = true;
+                break;
             }
-            if (!lowmem)
-            {
-                __gshared string[] disable_options = [ "gcopt=disable:1" ];
-                rt_options = disable_options;
-                mem.disableGC();
-            }
+        }
+        if (!lowmem)
+        {
+            __gshared string[] disable_options = [ "gcopt=disable:1" ];
+            rt_options = disable_options;
+            mem.disableGC();
         }
 
         // initialize druntime and call _Dmain() below
@@ -940,9 +937,6 @@ else
         }
 
         import core.runtime;
-        import core.memory;
-        static if (!isGCAvailable)
-            GC.disable();
 
         version(D_Coverage)
         {
@@ -1789,15 +1783,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             params.stackstomp = true;
         else if (arg == "-lowmem") // https://dlang.org/dmd.html#switch-lowmem
         {
-            static if (isGCAvailable)
-            {
-                // ignore, already handled in C main
-            }
-            else
-            {
-                error("switch '%s' requires DMD to be built with '-version=GC'", arg.ptr);
-                continue;
-            }
+            // ignore, already handled in C main
         }
         else if (arg.length > 6 && arg[0..6] == "--DRT-")
         {

--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -16,78 +16,62 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
 
-version = GC;
-
-version (GC)
-{
-    import core.memory : GC;
-
-    enum isGCAvailable = true;
-}
-else
-    enum isGCAvailable = false;
+import core.memory : GC;
 
 extern (C++) struct Mem
 {
     static char* xstrdup(const(char)* s) nothrow
     {
-        version (GC)
-            if (isGCEnabled)
-                return s ? s[0 .. strlen(s) + 1].dup.ptr : null;
+        if (isGCEnabled)
+            return s ? s[0 .. strlen(s) + 1].dup.ptr : null;
 
         return s ? cast(char*)check(.strdup(s)) : null;
     }
 
     static void xfree(void* p) pure nothrow
     {
-        version (GC)
-            if (isGCEnabled)
-                return GC.free(p);
+        if (isGCEnabled)
+            return GC.free(p);
 
         pureFree(p);
     }
 
     static void* xmalloc(size_t size) pure nothrow
     {
-        version (GC)
-            if (isGCEnabled)
-                return size ? GC.malloc(size) : null;
+        if (isGCEnabled)
+            return size ? GC.malloc(size) : null;
 
         return size ? check(pureMalloc(size)) : null;
     }
 
     static void* xmalloc_noscan(size_t size) pure nothrow
     {
-        version (GC)
-            if (isGCEnabled)
-                return size ? GC.malloc(size, GC.BlkAttr.NO_SCAN) : null;
+        if (isGCEnabled)
+            return size ? GC.malloc(size, GC.BlkAttr.NO_SCAN) : null;
 
         return size ? check(pureMalloc(size)) : null;
     }
 
     static void* xcalloc(size_t size, size_t n) pure nothrow
     {
-        version (GC)
-            if (isGCEnabled)
-                return size * n ? GC.calloc(size * n) : null;
+        if (isGCEnabled)
+            return size * n ? GC.calloc(size * n) : null;
 
         return (size && n) ? check(pureCalloc(size, n)) : null;
     }
 
     static void* xcalloc_noscan(size_t size, size_t n) pure nothrow
     {
-        version (GC)
-            if (isGCEnabled)
-                return size * n ? GC.calloc(size * n, GC.BlkAttr.NO_SCAN) : null;
+        if (isGCEnabled)
+            return size * n ? GC.calloc(size * n, GC.BlkAttr.NO_SCAN) : null;
 
         return (size && n) ? check(pureCalloc(size, n)) : null;
     }
 
     static void* xrealloc(void* p, size_t size) pure nothrow
     {
-        version (GC)
-            if (isGCEnabled)
-                return GC.realloc(p, size);
+        if (isGCEnabled)
+            return GC.realloc(p, size);
 
         if (!size)
         {
@@ -100,9 +84,8 @@ extern (C++) struct Mem
 
     static void* xrealloc_noscan(void* p, size_t size) pure nothrow
     {
-        version (GC)
-            if (isGCEnabled)
-                return GC.realloc(p, size, GC.BlkAttr.NO_SCAN);
+        if (isGCEnabled)
+            return GC.realloc(p, size, GC.BlkAttr.NO_SCAN);
 
         if (!size)
         {
@@ -132,34 +115,31 @@ extern (C++) struct Mem
         return p ? p : error();
     }
 
-    version (GC)
+    __gshared bool _isGCEnabled = true;
+
+    // fake purity by making global variable immutable (_isGCEnabled only modified before startup)
+    enum _pIsGCEnabled = cast(immutable bool*) &_isGCEnabled;
+
+    static bool isGCEnabled() pure nothrow @nogc @safe
     {
-        __gshared bool _isGCEnabled = true;
+        return *_pIsGCEnabled;
+    }
 
-        // fake purity by making global variable immutable (_isGCEnabled only modified before startup)
-        enum _pIsGCEnabled = cast(immutable bool*) &_isGCEnabled;
+    static void disableGC() nothrow @nogc
+    {
+        _isGCEnabled = false;
+    }
 
-        static bool isGCEnabled() pure nothrow @nogc @safe
-        {
-            return *_pIsGCEnabled;
-        }
+    static void addRange(const(void)* p, size_t size) nothrow @nogc
+    {
+        if (isGCEnabled)
+            GC.addRange(p, size);
+    }
 
-        static void disableGC() nothrow @nogc
-        {
-            _isGCEnabled = false;
-        }
-
-        static void addRange(const(void)* p, size_t size) nothrow @nogc
-        {
-            if (isGCEnabled)
-                GC.addRange(p, size);
-        }
-
-        static void removeRange(const(void)* p) nothrow @nogc
-        {
-            if (isGCEnabled)
-                GC.removeRange(p);
-        }
+    static void removeRange(const(void)* p) nothrow @nogc
+    {
+        if (isGCEnabled)
+            GC.removeRange(p);
     }
 }
 
@@ -197,9 +177,8 @@ extern (D) void* allocmemoryNoFree(size_t m_size) nothrow @nogc
 
 extern (D) void* allocmemory(size_t m_size) nothrow
 {
-    version (GC)
-        if (mem.isGCEnabled)
-            return GC.malloc(m_size);
+    if (mem.isGCEnabled)
+        return GC.malloc(m_size);
 
     return allocmemoryNoFree(m_size);
 }
@@ -238,35 +217,28 @@ static if (OVERRIDE_MEMALLOC)
         return allocmemory(m_size);
     }
 
-    version (GC)
+    private void* allocClass(const ClassInfo ci) nothrow pure
     {
-        private void* allocClass(const ClassInfo ci) nothrow pure
-        {
-            alias BlkAttr = GC.BlkAttr;
+        alias BlkAttr = GC.BlkAttr;
 
-            assert(!(ci.m_flags & TypeInfo_Class.ClassFlags.isCOMclass));
+        assert(!(ci.m_flags & TypeInfo_Class.ClassFlags.isCOMclass));
 
-            BlkAttr attr = BlkAttr.NONE;
-            if (ci.m_flags & TypeInfo_Class.ClassFlags.hasDtor
-                && !(ci.m_flags & TypeInfo_Class.ClassFlags.isCPPclass))
-                attr |= BlkAttr.FINALIZE;
-            if (ci.m_flags & TypeInfo_Class.ClassFlags.noPointers)
-                attr |= BlkAttr.NO_SCAN;
-            return GC.malloc(ci.initializer.length, attr, ci);
-        }
-
-        extern (C) void* _d_newitemU(const TypeInfo ti) nothrow;
+        BlkAttr attr = BlkAttr.NONE;
+        if (ci.m_flags & TypeInfo_Class.ClassFlags.hasDtor
+            && !(ci.m_flags & TypeInfo_Class.ClassFlags.isCPPclass))
+            attr |= BlkAttr.FINALIZE;
+        if (ci.m_flags & TypeInfo_Class.ClassFlags.noPointers)
+            attr |= BlkAttr.NO_SCAN;
+        return GC.malloc(ci.initializer.length, attr, ci);
     }
+
+    extern (C) void* _d_newitemU(const TypeInfo ti) nothrow;
 
     extern (C) Object _d_newclass(const ClassInfo ci) nothrow
     {
         const initializer = ci.initializer;
 
-        version (GC)
-            auto p = mem.isGCEnabled ? allocClass(ci) : allocmemoryNoFree(initializer.length);
-        else
-            auto p = allocmemoryNoFree(initializer.length);
-
+        auto p = mem.isGCEnabled ? allocClass(ci) : allocmemoryNoFree(initializer.length);
         memcpy(p, initializer.ptr, initializer.length);
         return cast(Object) p;
     }
@@ -275,9 +247,8 @@ static if (OVERRIDE_MEMALLOC)
     {
         extern (C) Object _d_allocclass(const ClassInfo ci) nothrow
         {
-            version (GC)
-                if (mem.isGCEnabled)
-                    return cast(Object) allocClass(ci);
+            if (mem.isGCEnabled)
+                return cast(Object) allocClass(ci);
 
             return cast(Object) allocmemoryNoFree(ci.initializer.length);
         }
@@ -285,22 +256,14 @@ static if (OVERRIDE_MEMALLOC)
 
     extern (C) void* _d_newitemT(TypeInfo ti) nothrow
     {
-        version (GC)
-            auto p = mem.isGCEnabled ? _d_newitemU(ti) : allocmemoryNoFree(ti.tsize);
-        else
-            auto p = allocmemoryNoFree(ti.tsize);
-
+        auto p = mem.isGCEnabled ? _d_newitemU(ti) : allocmemoryNoFree(ti.tsize);
         memset(p, 0, ti.tsize);
         return p;
     }
 
     extern (C) void* _d_newitemiT(TypeInfo ti) nothrow
     {
-        version (GC)
-            auto p = mem.isGCEnabled ? _d_newitemU(ti) : allocmemoryNoFree(ti.tsize);
-        else
-            auto p = allocmemoryNoFree(ti.tsize);
-
+        auto p = mem.isGCEnabled ? _d_newitemU(ti) : allocmemoryNoFree(ti.tsize);
         const initializer = ti.initializer;
         memcpy(p, initializer.ptr, initializer.length);
         return p;

--- a/src/dmd/root/rmem.h
+++ b/src/dmd/root/rmem.h
@@ -22,14 +22,12 @@ struct Mem
     static void *xrealloc(void *p, d_size_t size);
     static void error();
 
-#if 1 // version (GC)
     static bool _isGCEnabled;
 
     static bool isGCEnabled();
     static void disableGC();
     static void addRange(const void *p, d_size_t size);
     static void removeRange(const void *p);
-#endif
 };
 
 extern Mem mem;


### PR DESCRIPTION
Both the -lowmem and non-lowmem paths have been pretty well tested at this point.