### PR TITLE
Give the proper Loc information when calling assert hook

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6194,7 +6194,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             auto assertFail = new DotIdExp(loc, __assertFail, Id.object);
 
             auto dt = new DotTemplateInstanceExp(loc, assertFail, Id._d_assert_fail, tiargs);
-            auto ec = CallExp.create(Loc.initial, dt, es);
+            auto ec = CallExp.create(loc, dt, es);
             exp.msg = ec;
         }
 


### PR DESCRIPTION
```
Before this change, if calling the internal _d_assert_fail hook failed,
no file/line informations were provided, making it hard to track down
the origin of the error.
Obviously, calling _d_assert_fail is done by the compiler and should never
result in an error in the first place, but if it does, we can now see why.
```