### PR TITLE
Remove extern(Pascal), deprecated in v2.084.0

### DIFF
--- a/changelog/extern-pascal.dd
+++ b/changelog/extern-pascal.dd
@@ -1,0 +1,3 @@
+`extern(Pascal)` has been removed
+
+This unused linkage was deprecated in $(LINK2 v2.084.0, https://dlang.org/changelog/2.084.0.html#deprecated_extern_pascal) and has now been removed.

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6734,8 +6734,6 @@ struct ASTBase
             return "C++";
         case LINK.windows:
             return "Windows";
-        case LINK.pascal:
-            return "Pascal";
         case LINK.objc:
             return "Objective-C";
         }

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1169,9 +1169,6 @@ extern(D):
             case LINK.windows:
                 tmp.buf.writeByte('G'); // stdcall
                 break;
-            case LINK.pascal:
-                tmp.buf.writeByte('C');
-                break;
             case LINK.d:
             case LINK.default_:
             case LINK.system:

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -92,7 +92,6 @@ private immutable char[TMAX] mangleChar =
     Tstruct      : 'S',
     //              T   // Ttypedef
     //              U   // C function
-    //              V   // Pascal function
     //              W   // Windows function
     //              X   // variadic T t...)
     //              Y   // variadic T t,...)
@@ -369,9 +368,6 @@ public:
         case LINK.windows:
             mc = 'W';
             break;
-        case LINK.pascal:
-            mc = 'V';
-            break;
         case LINK.cpp:
             mc = 'R';
             break;
@@ -580,7 +576,6 @@ public:
                     break;
                 case LINK.c:
                 case LINK.windows:
-                case LINK.pascal:
                 case LINK.objc:
                     return d.ident.toString();
                 case LINK.cpp:

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -171,9 +171,8 @@ enum class LINK : uint8_t
     c = 2u,
     cpp = 3u,
     windows = 4u,
-    pascal = 5u,
-    objc = 6u,
-    system = 7u,
+    objc = 5u,
+    system = 6u,
 };
 
 class LinkDeclaration;
@@ -7453,7 +7452,6 @@ struct Id
     static Identifier* C;
     static Identifier* D;
     static Identifier* Windows;
-    static Identifier* Pascal;
     static Identifier* System;
     static Identifier* Objective;
     static Identifier* exit;

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -673,7 +673,6 @@ enum LINK : ubyte
     c,
     cpp,
     windows,
-    pascal,
     objc,
     system,
 }

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -663,7 +663,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             // functions without D or C++ name mangling mixed in at global scope
             // shouldn't have multiple definitions
             if (p.isTemplateMixin() && (fd.linkage == LINK.c || fd.linkage == LINK.windows ||
-                fd.linkage == LINK.pascal || fd.linkage == LINK.objc))
+                fd.linkage == LINK.objc))
             {
                 const q = p.toParent();
                 if (q && q.isModule())
@@ -1328,10 +1328,6 @@ tym_t totym(Type tx)
                     if (global.params.is64bit)
                         goto case LINK.c;
                     t = (tf.parameterList.varargs == VarArg.variadic) ? TYnfunc : TYnsfunc;
-                    break;
-
-                case LINK.pascal:
-                    t = (tf.parameterList.varargs == VarArg.variadic) ? TYnfunc : TYnpfunc;
                     break;
 
                 case LINK.c:

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2858,8 +2858,6 @@ string linkageToString(LINK linkage) pure nothrow
         return "C++";
     case LINK.windows:
         return "Windows";
-    case LINK.pascal:
-        return "Pascal";
     case LINK.objc:
         return "Objective-C";
     case LINK.system:

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -186,7 +186,6 @@ immutable Msgtable[] msgtable =
     { "C" },
     { "D" },
     { "Windows" },
-    { "Pascal" },
     { "System" },
     { "Objective" },
 

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -325,7 +325,6 @@ public:
         case LINK.c:        return property(name, "c");
         case LINK.cpp:      return property(name, "cpp");
         case LINK.windows:  return property(name, "windows");
-        case LINK.pascal:   return property(name, "pascal");
         case LINK.objc:     return property(name, "objc");
         }
     }

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -2243,7 +2243,7 @@ final class Parser(AST) : Lexer
         }
         LINK invalidLinkage()
         {
-            error("valid linkage identifiers are `D`, `C`, `C++`, `Objective-C`, `Pascal`, `Windows`, `System`");
+            error("valid linkage identifiers are `D`, `C`, `C++`, `Objective-C`, `Windows`, `System`");
             return returnLinkage(LINK.d);
         }
 
@@ -2254,11 +2254,6 @@ final class Parser(AST) : Lexer
         nextToken();
         if (id == Id.Windows)
             return returnLinkage(LINK.windows);
-        else if (id == Id.Pascal)
-        {
-            deprecation("`extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.");
-            return returnLinkage(LINK.pascal);
-        }
         else if (id == Id.D)
             return returnLinkage(LINK.d);
         else if (id == Id.System)

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -728,7 +728,7 @@ extern (C++) struct Target
         }
         else if (params.isWindows &&
                  !params.is64bit &&
-                 (tf.linkage == LINK.cpp || tf.linkage == LINK.pascal) &&
+                 tf.linkage == LINK.cpp &&
                  tf.isfloating())
         {
             /* See DMC++ function exp2_retmethod()

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -289,10 +289,6 @@ Symbol *toSymbol(Dsymbol s)
                     m = global.params.is64bit ? mTYman_c : mTYman_std;
                     break;
 
-                case LINK.pascal:
-                    m = mTYman_pas;
-                    break;
-
                 case LINK.objc:
                 case LINK.c:
                     m = mTYman_c;
@@ -381,11 +377,6 @@ Symbol *toSymbol(Dsymbol s)
                 {
                     case LINK.windows:
                         t.Tmangle = global.params.is64bit ? mTYman_c : mTYman_std;
-                        break;
-
-                    case LINK.pascal:
-                        t.Tty = TYnpfunc;
-                        t.Tmangle = mTYman_pas;
                         break;
 
                     case LINK.c:

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1002,9 +1002,6 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 case LINK.windows:
                     return global.params.is64bit ? mTYman_c : mTYman_std;
 
-                case LINK.pascal:
-                    return mTYman_pas;
-
                 case LINK.objc:
                 case LINK.c:
                     return mTYman_c;

--- a/test/compilable/callconv.d
+++ b/test/compilable/callconv.d
@@ -2,8 +2,6 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/callconv.d(21): Deprecation: `extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.
-compilable/callconv.d(30): Deprecation: `extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.
 ---
 */
 
@@ -17,24 +15,6 @@ struct ABC
 ABC abc;
 
 int x,y,z;
-
-extern (Pascal):
-ABC test1(int xx, int yy, int zz)
-{
-    x = xx;
-    y = yy;
-    z = zz;
-    return abc;
-}
-
-extern (Pascal):
-ABC test1v(int xx, int yy, int zz, ...)
-{
-    x = xx;
-    y = yy;
-    z = zz;
-    return abc;
-}
 
 extern (C):
 ABC test2v(int xx, int yy, int zz, ...)
@@ -78,5 +58,3 @@ ABC test4v(int xx, int yy, int zz, ...)
     z = zz;
     return abc;
 }
-
-

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -855,18 +855,10 @@
                 "name": "vlinkageWindows"
             },
             {
-                "char": 20,
-                "deco": "VALUE_REMOVED_FOR_TEST",
-                "kind": "variable",
-                "line": 190,
-                "linkage": "pascal",
-                "name": "vlinkagePascal"
-            },
-            {
                 "char": 25,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "variable",
-                "line": 191,
+                "line": 190,
                 "linkage": "objc",
                 "name": "vlinkageObjc"
             },
@@ -874,7 +866,7 @@
                 "char": 12,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 193,
+                "line": 192,
                 "name": "flinkageDefault",
                 "storageClass": [
                     "extern"
@@ -884,14 +876,14 @@
                 "char": 15,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 194,
+                "line": 193,
                 "name": "flinkageD"
             },
             {
                 "char": 15,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 195,
+                "line": 194,
                 "linkage": "c",
                 "name": "linakgeC"
             },
@@ -899,7 +891,7 @@
                 "char": 17,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 196,
+                "line": 195,
                 "linkage": "cpp",
                 "name": "flinkageCpp"
             },
@@ -907,30 +899,22 @@
                 "char": 21,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 197,
+                "line": 196,
                 "linkage": "windows",
                 "name": "flinkageWindows"
-            },
-            {
-                "char": 20,
-                "deco": "VALUE_REMOVED_FOR_TEST",
-                "kind": "function",
-                "line": 198,
-                "linkage": "pascal",
-                "name": "flinkagePascal"
             },
             {
                 "char": 25,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 199,
+                "line": 197,
                 "linkage": "objc",
                 "name": "flinkageObjc"
             },
             {
                 "char": 7,
                 "kind": "template",
-                "line": 201,
+                "line": 199,
                 "members": [],
                 "name": "test18211",
                 "parameters": [
@@ -945,7 +929,7 @@
                 "char": 1,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "alias",
-                "line": 210,
+                "line": 208,
                 "name": "F",
                 "originalType": "size_t function(size_t a)"
             }

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -187,7 +187,6 @@ extern(D) int vlinkageD;
 extern(C) int vlinakgeC;
 extern(C++) __gshared int vlinkageCpp;
 extern(Windows) int vlinkageWindows;
-extern(Pascal) int vlinkagePascal;
 extern(Objective-C) int vlinkageObjc;
 
 extern int flinkageDefault();
@@ -195,7 +194,6 @@ extern(D) int flinkageD();
 extern(C) int linakgeC();
 extern(C++) int flinkageCpp();
 extern(Windows) int flinkageWindows();
-extern(Pascal) int flinkagePascal();
 extern(Objective-C) int flinkageObjc();
 
 mixin template test18211(int n)

--- a/test/compilable/test17419.d
+++ b/test/compilable/test17419.d
@@ -15,14 +15,12 @@ static assert(__traits(getLinkage, aliasc) == "C");
 extern (D) int food();
 extern (C++) int foocpp();
 extern (Windows) int foow();
-extern (Pascal) int foop();
 extern (Objective-C) int fooobjc();
 extern (System) int foos();
 
 static assert(__traits(getLinkage, food) == "D");
 static assert(__traits(getLinkage, foocpp) == "C++");
 static assert(__traits(getLinkage, foow) == "Windows");
-static assert(__traits(getLinkage, foop) == "Pascal");
 static assert(__traits(getLinkage, fooobjc) == "Objective-C");
 version (Windows)
     static assert(__traits(getLinkage, foos) == "Windows");

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2,7 +2,6 @@
 /*
 TEST_OUTPUT:
 ---
-runnable/nested.d(800): Deprecation: `extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.
 null
 ---
 */
@@ -797,18 +796,9 @@ void test33()
         return 3;
     }
 
-    extern (Pascal) int Foo4(int a, int b, int c)
-    {
-        assert(a == 1);
-        assert(b == 2);
-        assert(c == 3);
-        return 4;
-    }
-
     assert(Foo1(1, 2, 3) == 1);
     assert(Foo2(1, 2, 3) == 2);
     assert(Foo3(1, 2, 3) == 3);
-    assert(Foo4(1, 2, 3) == 4);
 
     printf("test33 success\n");
 }

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -3,9 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-runnable/test4.d(616): Deprecation: `extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.
-runnable/test4.d(629): Deprecation: `extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.
-runnable/test4.d(767): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/test4.d(754): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 ---
 */
 
@@ -613,11 +611,6 @@ extern (C) int cfc(int x, int y)
     return x * 10 + y;
 }
 
-extern (Pascal) int cfp(int x, int y)
-{
-    return x * 10 + y;
-}
-
 int cfd(int x, int y)
 {
     return x * 10 + y;
@@ -626,7 +619,6 @@ int cfd(int x, int y)
 
 extern (Windows) int function (int, int) fpw;
 extern (C) int function (int, int) fpc;
-extern (Pascal) int function (int, int) fpp;
 int function (int, int) fpd;
 
 void test20()
@@ -636,7 +628,6 @@ void test20()
 
     fpw = &cfw;
     fpc = &cfc;
-    fpp = &cfp;
     fpd = &cfd;
 
 //printf("test w\n");
@@ -646,10 +637,6 @@ void test20()
 //printf("test c\n");
     i = (*fpc)(3, 4);
     assert(i == 34);
-
-//printf("test p\n");
-    i = (*fpp)(5, 6);
-    assert(i == 56);
 
 //printf("test d\n");
     i = (*fpd)(7, 8);
@@ -1532,4 +1519,3 @@ int main()
     printf("Success\n");
     return 0;
 }
-

--- a/test/unit/parser/diagnostic_reporter.d
+++ b/test/unit/parser/diagnostic_reporter.d
@@ -101,26 +101,3 @@ unittest
 
     assert(reporter.warningCount == 1);
 }
-
-@("deprecations: extern(Pascal)")
-unittest
-{
-    static class DeprecationsCountingDiagnosticReporter : NoopDiagnosticReporter
-    {
-        int deprecationCount;
-
-        override bool deprecation(const ref Loc, const(char)*, va_list, const(char)*, const(char)*)
-        {
-            deprecationCount++;
-            return true;
-        }
-    }
-
-    scope reporter = new DeprecationsCountingDiagnosticReporter;
-
-    parseModule("test.d", q{
-        extern (Pascal) void foo();
-    });
-
-    assert(reporter.deprecationCount == 1);
-}


### PR DESCRIPTION
It's been 10 releases, time to go! I could make it an explicit error but I don't think that makes much sense.
Will raise dlang.org PR.