### PR TITLE
freebsd: Make version 12 the default to target

### DIFF
--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -929,7 +929,7 @@ extern (C++) struct Target
         else version (FreeBSD_11)       return "11";
         else version (FreeBSD_10)       return "10";
         // FIXME: Need a way to dynamically set the major FreeBSD version?
-        else /* default supported */    return "11";
+        else /* default supported */    return "12";
     }
 }
 


### PR DESCRIPTION
FreeBSD 12.0 was initially released in 2018, and version 13.0 is expected to arrive around March next year.  It's about time that it was made the default, even though support has only been recent.

Not changing any of the DFLAGS passed to the freebsd pipeline environments.