### PR TITLE
[dmd-cxx] Remove extern(Pascal), deprecated in v2.084.0

### DIFF
--- a/src/cppmanglewin.c
+++ b/src/cppmanglewin.c
@@ -965,9 +965,6 @@ private:
                 case LINKwindows:
                     tmp.buf.writeByte('G'); // stdcall
                     break;
-                case LINKpascal:
-                    tmp.buf.writeByte('C');
-                    break;
                 default:
                     tmp.visit((Type*)type);
                     break;

--- a/src/dmangle.c
+++ b/src/dmangle.c
@@ -223,7 +223,6 @@ public:
             case LINKd:             mc = 'F';       break;
             case LINKc:             mc = 'U';       break;
             case LINKwindows:       mc = 'W';       break;
-            case LINKpascal:        mc = 'V';       break;
             case LINKcpp:           mc = 'R';       break;
             case LINKobjc:          mc = 'Y';       break;
             default:
@@ -415,7 +414,6 @@ public:
 
                 case LINKc:
                 case LINKwindows:
-                case LINKpascal:
                 case LINKobjc:
                     buf->writestring(d->ident->toChars());
                     return;

--- a/src/globals.h
+++ b/src/globals.h
@@ -310,7 +310,6 @@ enum LINK
     LINKc,
     LINKcpp,
     LINKwindows,
-    LINKpascal,
     LINKobjc,
     LINKsystem
 };

--- a/src/glue.c
+++ b/src/glue.c
@@ -1417,10 +1417,6 @@ unsigned totym(Type *tx)
                     t = (tf->parameterList.varargs == VARARGvariadic) ? TYnfunc : TYnsfunc;
                     break;
 
-                case LINKpascal:
-                    t = (tf->parameterList.varargs == VARARGvariadic) ? TYnfunc : TYnpfunc;
-                    break;
-
                 case LINKc:
                 case LINKcpp:
                 case LINKobjc:

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -1271,7 +1271,6 @@ public:
             case LINKc:             p = "C";                break;
             case LINKcpp:           p = "C++";              break;
             case LINKwindows:       p = "Windows";          break;
-            case LINKpascal:        p = "Pascal";           break;
             case LINKobjc:          p = "Objective-C";      break;
             default:
                 assert(0);
@@ -3367,7 +3366,6 @@ const char *linkageToChars(LINK linkage)
         case LINKc:         return "C";
         case LINKcpp:       return "C++";
         case LINKwindows:   return "Windows";
-        case LINKpascal:    return "Pascal";
         case LINKobjc:      return "Objective-C";
         case LINKsystem:    return "System";
         default:            assert(0);

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -145,7 +145,6 @@ Msgtable msgtable[] =
     { "C", NULL },
     { "D", NULL },
     { "Windows", NULL },
-    { "Pascal", NULL },
     { "System", NULL },
     { "Objective", NULL },
 

--- a/src/json.c
+++ b/src/json.c
@@ -323,9 +323,6 @@ public:
             case LINKwindows:
                 property(name, "windows");
                 break;
-            case LINKpascal:
-                property(name, "pascal");
-                break;
             default:
                 assert(false);
         }

--- a/src/parse.c
+++ b/src/parse.c
@@ -1294,8 +1294,6 @@ LINK Parser::parseLinkage(Identifiers **pidents, CPPMANGLE *pcppmangle, bool *pc
         nextToken();
         if (id == Id::Windows)
             link = LINKwindows;
-        else if (id == Id::Pascal)
-            link = LINKpascal;
         else if (id == Id::D)
             link = LINKd;
         else if (id == Id::C)
@@ -1399,7 +1397,7 @@ LINK Parser::parseLinkage(Identifiers **pidents, CPPMANGLE *pcppmangle, bool *pc
         else
         {
         LinvalidLinkage:
-            error("valid linkage identifiers are D, C, C++, Objective-C, Pascal, Windows, System");
+            error("valid linkage identifiers are D, C, C++, Objective-C, Windows, System");
             link = LINKd;
         }
     }

--- a/src/test.c
+++ b/src/test.c
@@ -1,0 +1,5 @@
+int main()
+{
+  int and = 2;
+  return and;
+}

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -234,10 +234,6 @@ Symbol *toSymbol(Dsymbol *s)
                     m = global.params.is64bit ? mTYman_c : mTYman_std;
                     break;
 
-                case LINKpascal:
-                    m = mTYman_pas;
-                    break;
-
                 case LINKobjc:
                 case LINKc:
                     m = mTYman_c;
@@ -328,11 +324,6 @@ Symbol *toSymbol(Dsymbol *s)
                 {
                     case LINKwindows:
                         t->Tmangle = global.params.is64bit ? mTYman_c : mTYman_std;
-                        break;
-
-                    case LINKpascal:
-                        t->Tty = TYnpfunc;
-                        t->Tmangle = mTYman_pas;
                         break;
 
                     case LINKc:

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1363,9 +1363,6 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                 case LINKwindows:
                     return global.params.is64bit ? mTYman_c : mTYman_std;
 
-                case LINKpascal:
-                    return mTYman_pas;
-
                 case LINKobjc:
                 case LINKc:
                     return mTYman_c;

--- a/test/compilable/callconv.d
+++ b/test/compilable/callconv.d
@@ -11,24 +11,6 @@ ABC abc;
 
 int x,y,z;
 
-extern (Pascal):
-ABC test1(int xx, int yy, int zz)
-{
-    x = xx;
-    y = yy;
-    z = zz;
-    return abc;
-}
-
-extern (Pascal):
-ABC test1v(int xx, int yy, int zz, ...)
-{
-    x = xx;
-    y = yy;
-    z = zz;
-    return abc;
-}
-
 extern (C):
 ABC test2v(int xx, int yy, int zz, ...)
 {
@@ -71,5 +53,3 @@ ABC test4v(int xx, int yy, int zz, ...)
     z = zz;
     return abc;
 }
-
-

--- a/test/compilable/test17419.d
+++ b/test/compilable/test17419.d
@@ -10,14 +10,12 @@ static assert(__traits(getLinkage, aliasc) == "C");
 extern (D) int food();
 extern (C++) int foocpp();
 extern (Windows) int foow();
-extern (Pascal) int foop();
 extern (Objective-C) int fooobjc();
 extern (System) int foos();
 
 static assert(__traits(getLinkage, food) == "D");
 static assert(__traits(getLinkage, foocpp) == "C++");
 static assert(__traits(getLinkage, foow) == "Windows");
-static assert(__traits(getLinkage, foop) == "Pascal");
 static assert(__traits(getLinkage, fooobjc) == "Objective-C");
 version (Windows)
     static assert(__traits(getLinkage, foos) == "Windows");

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -790,18 +790,9 @@ void test33()
         return 3;
     }
 
-    extern (Pascal) int Foo4(int a, int b, int c)
-    {
-        assert(a == 1);
-        assert(b == 2);
-        assert(c == 3);
-        return 4;
-    }
-
     assert(Foo1(1, 2, 3) == 1);
     assert(Foo2(1, 2, 3) == 2);
     assert(Foo3(1, 2, 3) == 3);
-    assert(Foo4(1, 2, 3) == 4);
 
     printf("test33 success\n");
 }

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -605,11 +605,6 @@ extern (C) int cfc(int x, int y)
     return x * 10 + y;
 }
 
-extern (Pascal) int cfp(int x, int y)
-{
-    return x * 10 + y;
-}
-
 int cfd(int x, int y)
 {
     return x * 10 + y;
@@ -618,7 +613,6 @@ int cfd(int x, int y)
 
 extern (Windows) int function (int, int) fpw;
 extern (C) int function (int, int) fpc;
-extern (Pascal) int function (int, int) fpp;
 int function (int, int) fpd;
 
 void test20()
@@ -628,7 +622,6 @@ void test20()
 
     fpw = &cfw;
     fpc = &cfc;
-    fpp = &cfp;
     fpd = &cfd;
 
 //printf("test w\n");
@@ -638,10 +631,6 @@ void test20()
 //printf("test c\n");
     i = (*fpc)(3, 4);
     assert(i == 34);
-
-//printf("test p\n");
-    i = (*fpp)(5, 6);
-    assert(i == 56);
 
 //printf("test d\n");
     i = (*fpd)(7, 8);
@@ -1480,4 +1469,3 @@ int main()
     printf("Success\n");
     return 0;
 }
-


### PR DESCRIPTION
Backported from #11989 - @Geod24 