### PR TITLE
A version of -allinst that works

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -6187,16 +6187,6 @@ extern (C++) class TemplateInstance : ScopeDsymbol
      */
     final bool needsCodegen()
     {
-        if (global.params.allInst)
-        {
-            return true;
-        }
-
-        if (isDiscardable())
-        {
-            return false;
-        }
-
         if (!minst)
         {
             // If this is a speculative instantiation,
@@ -6213,6 +6203,10 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             if (tinst && tinst.needsCodegen())
             {
                 minst = tinst.minst; // cache result
+                if (global.params.allInst && minst)
+                {
+                    return true;
+                }
                 assert(minst);
                 assert(minst.isRoot() || minst.rootImports());
                 return true;
@@ -6220,11 +6214,25 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             if (tnext && (tnext.needsCodegen() || tnext.minst))
             {
                 minst = tnext.minst; // cache result
+                if (global.params.allInst && minst)
+                {
+                    return true;
+                }
                 assert(minst);
                 return minst.isRoot() || minst.rootImports();
             }
 
             // Elide codegen because this is really speculative.
+            return false;
+        }
+
+        if (global.params.allInst)
+        {
+            return true;
+        }
+
+        if (isDiscardable())
+        {
             return false;
         }
 


### PR DESCRIPTION
This doesn't have tests because I don't know of a way to reproduce the issue it's fixing easily other than to run the [autowrap](https://github.com/symmetryinvestments/autowrap) tests. I've tried [adding them to CI](https://github.com/dlang/ci/pull/432) but things are broken now so I can't (and that PR needs some adjustment anyway).

This PR mimics the debug (since deleted) and unittest hacks that emitted nearly all templated code that has hidden issues for a while given that dub defaults to using `-debug` and the way we figure out if changes break anything is nearly always `dub test` (which of course uses `-unittest`). I suspect many a dub package would break today if their tests were run without `-debug` or `-unittest` (say, by an alternate test runner).

The main change is checking for speculative templates early, fixing the ones that look that way and aren't, and returning true if the module instance isn't null *and* `-allinst` is passed.