### PR TITLE
Fix Issue 21424 - Variable is incremented twice

### DIFF
--- a/test/runnable/test21424.d
+++ b/test/runnable/test21424.d
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=21424
+
+void main()
+{
+    ubyte[10] buf;
+    size_t pos = 0;
+    size_t num = 5;
+    buf[pos++] += num;
+    assert(pos == 1);
+    assert(buf[0] == 5);
+    assert(buf[1] == 0);
+}


### PR DESCRIPTION
Test case:
```
    ubyte[10] buf;
    size_t pos = 0;
    size_t num = 5;
    buf[pos++] += num;
```
Here DMD internally generates something like:
`cast(ulong)cast(int) (tmp = pos++ + &buf, *tmp) += num`

That expression had to be converted to:
`(tmp = pos++ + &buf,  cast(ulong)cast(int) *tmp) += num`
but the implementation worked only for one cast (fixed now). And because of that the compiler ended up creating an assign operation duplicating the comma exp in both sides:
`(tmp = pos++ + &buf, *tmp) = cast(...)(tmp = pos++ + &buf, *tmp) + num`