### PR TITLE
Fixup PR11989: Remove pascal from LINK in global.h

### DIFF
--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -403,7 +403,6 @@ enum class LINK : uint8_t
     c,
     cpp,
     windows,
-    pascal,
     objc,
     system
 };


### PR DESCRIPTION
This was overlooked in #11989