### PR TITLE
use TargetOS instead of params.isXXXXX

### DIFF
--- a/src/dmd/argtypes_x86.d
+++ b/src/dmd/argtypes_x86.d
@@ -349,7 +349,7 @@ extern (C++) TypeTuple toArgTypes_x86(Type t)
             default:
                 return memory();
             }
-            if (global.params.isFreeBSD && nfields == 1 &&
+            if (global.params.targetOS == TargetOS.FreeBSD && nfields == 1 &&
                 (sz == 4 || sz == 8))
             {
                 /* FreeBSD changed their 32 bit ABI at some point before 10.3 for the following:

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6745,12 +6745,11 @@ struct ASTBase
 
         extern (C++) static Type va_listType(const ref Loc loc, Scope* sc)
         {
-            if (global.params.isWindows)
+            if (global.params.targetOS == TargetOS.Windows)
             {
                 return Type.tchar.pointerTo();
             }
-            else if (global.params.isLinux || global.params.isFreeBSD || global.params.isOpenBSD  || global.params.isDragonFlyBSD ||
-                global.params.isSolaris || global.params.isOSX)
+            else if (global.params.targetOS & TargetOS.Posix)
             {
                 if (global.params.is64bit)
                 {

--- a/src/dmd/chkformat.d
+++ b/src/dmd/chkformat.d
@@ -251,7 +251,7 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
                 break;
 
             case Format.ls:     // pointer to wchar_t string
-                const twchar_t = global.params.isWindows ? Twchar : Tdchar;
+                const twchar_t = global.params.targetOS == TargetOS.Windows ? Twchar : Tdchar;
                 if (!(t.ty == Tpointer && tnext.ty == twchar_t))
                     errorMsg(null, slice, e, "wchar_t*", t);
                 break;
@@ -456,7 +456,7 @@ bool checkScanfFormat(ref const Loc loc, scope const char[] format, scope Expres
 
             case Format.lc:
             case Format.ls:     // pointer to wchar_t string
-                const twchar_t = global.params.isWindows ? Twchar : Tdchar;
+                const twchar_t = global.params.targetOS == TargetOS.Windows ? Twchar : Tdchar;
                 if (!(t.ty == Tpointer && tnext.ty == twchar_t))
                     errorMsg(null, slice, e, "wchar_t*", t);
                 break;

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -14,16 +14,27 @@
  */
 module dmd.cli;
 
+/* The enum TargetOS is an exact copy of the one in dmd.globals.
+ * Duplicated here because this file is stand-alone.
+ */
+
 /// Bit decoding of the TargetOS
-enum TargetOS
+enum TargetOS : ubyte
 {
-    all = int.max,
-    linux = 1,
-    windows = 2,
-    macOS = 4,
-    freeBSD = 8,
-    solaris = 16,
-    dragonFlyBSD = 32,
+    /* These are mutually exclusive; one and only one is set.
+     * Match spelling and casing of corresponding version identifiers
+     */
+    linux        = 1,
+    Windows      = 2,
+    OSX          = 4,
+    OpenBSD      = 8,
+    FreeBSD      = 0x10,
+    Solaris      = 0x20,
+    DragonFlyBSD = 0x40,
+
+    // Combination masks
+    all = linux | Windows | OSX | FreeBSD | Solaris | DragonFlyBSD,
+    Posix = linux | OSX | FreeBSD | Solaris | DragonFlyBSD,
 }
 
 // Detect the current TargetOS
@@ -33,23 +44,23 @@ version (linux)
 }
 else version(Windows)
 {
-    private enum targetOS = TargetOS.windows;
+    private enum targetOS = TargetOS.Windows;
 }
 else version(OSX)
 {
-    private enum targetOS = TargetOS.macOS;
+    private enum targetOS = TargetOS.OSX;
 }
 else version(FreeBSD)
 {
-    private enum targetOS = TargetOS.freeBSD;
+    private enum targetOS = TargetOS.FreeBSD;
 }
 else version(DragonFlyBSD)
 {
-    private enum targetOS = TargetOS.dragonFlyBSD;
+    private enum targetOS = TargetOS.DragonFlyBSD;
 }
 else version(Solaris)
 {
-    private enum targetOS = TargetOS.solaris;
+    private enum targetOS = TargetOS.Solaris;
 }
 else
 {
@@ -330,7 +341,7 @@ dmd -cov -unittest myprog.d
         ),
         Option("fPIC",
             "generate position independent code",
-            TargetOS.all & ~(TargetOS.windows | TargetOS.macOS)
+            cast(TargetOS) (TargetOS.all & ~(TargetOS.Windows | TargetOS.OSX))
         ),
         Option("g",
             "add symbolic debug info",
@@ -466,11 +477,11 @@ dmd -cov -unittest myprog.d
             $(WINDOWS Compile a 32 bit executable. This is the default.
             The generated object code is in OMF and is meant to be used with the
             $(LINK2 http://www.digitalmars.com/download/freecompiler.html, Digital Mars C/C++ compiler)).`,
-            (TargetOS.all & ~TargetOS.dragonFlyBSD)  // available on all OS'es except DragonFly, which does not support 32-bit binaries
+            cast(TargetOS) (TargetOS.all & ~cast(uint)TargetOS.DragonFlyBSD)  // available on all OS'es except DragonFly, which does not support 32-bit binaries
         ),
         Option("m32mscoff",
             "generate 32 bit code and write MS-COFF object files",
-            TargetOS.windows
+            TargetOS.Windows
         ),
         Option("m64",
             "generate 64 bit code",
@@ -545,7 +556,7 @@ dmd -cov -unittest myprog.d
             The detection can be skipped explicitly if $(TT msvcrt120) is specified as
             $(I libname).
             If $(I libname) is empty, no C runtime library is automatically linked in.",
-            TargetOS.windows,
+            TargetOS.Windows,
         ),
         Option("mv=<package.module>=<filespec>",
             "use <filespec> as source file for <package.module>",
@@ -716,7 +727,7 @@ dmd -cov -unittest myprog.d
         Option("Xcc=<driverflag>",
             "pass driverflag to linker driver (cc)",
             "Pass $(I driverflag) to the linker driver (`$CC` or `cc`)",
-            TargetOS.all & ~TargetOS.windows
+            cast(TargetOS) (TargetOS.all & ~cast(uint)TargetOS.Windows)
         ),
     ];
 

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -566,7 +566,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
             alignsize = baseClass.alignsize;
             structsize = baseClass.structsize;
-            if (classKind == ClassKind.cpp && global.params.isWindows)
+            if (classKind == ClassKind.cpp && global.params.targetOS == TargetOS.Windows)
                 structsize = (structsize + alignsize - 1) & ~(alignsize - 1);
         }
         else if (isInterfaceDeclaration())

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -579,7 +579,7 @@ struct Scope
         else if (ident == Id.unsigned)
             tok = TOK.uns32;
         else if (ident == Id.wchar_t)
-            tok = global.params.isWindows ? TOK.wchar_ : TOK.dchar_;
+            tok = global.params.targetOS == TargetOS.Windows ? TOK.wchar_ : TOK.dchar_;
         else
             return null;
         return Token.toChars(tok);

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -107,13 +107,13 @@ bool ISX64REF(Declaration var)
 
     if (var.isParameter())
     {
-        if (global.params.isWindows && global.params.is64bit)
+        if (global.params.targetOS == TargetOS.Windows && global.params.is64bit)
         {
             return var.type.size(Loc.initial) > REGSIZE
                 || (var.storage_class & STC.lazy_)
                 || (var.type.isTypeStruct() && !var.type.isTypeStruct().sym.isPOD());
         }
-        else if (!global.params.isWindows)
+        else if (global.params.targetOS & TargetOS.Posix)
         {
             return !(var.storage_class & STC.lazy_) && var.type.isTypeStruct() && !var.type.isTypeStruct().sym.isPOD();
         }
@@ -126,12 +126,12 @@ bool ISX64REF(Declaration var)
  */
 bool ISX64REF(IRState* irs, Expression exp)
 {
-    if (irs.params.isWindows && irs.params.is64bit)
+    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
     {
         return exp.type.size(Loc.initial) > REGSIZE
             || (exp.type.isTypeStruct() && !exp.type.isTypeStruct().sym.isPOD());
     }
-    else if (!irs.params.isWindows)
+    else if (irs.params.targetOS & TargetOS.Posix)
     {
         return exp.type.isTypeStruct() && !exp.type.isTypeStruct().sym.isPOD();
     }
@@ -263,7 +263,7 @@ private elem *callfunc(const ref Loc loc,
                 continue;
             }
 
-            if (irs.params.isWindows && irs.params.is64bit && tybasic(ea.Ety) == TYcfloat)
+            if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit && tybasic(ea.Ety) == TYcfloat)
             {
                 /* Treat a cfloat like it was a struct { float re,im; }
                  */
@@ -553,7 +553,7 @@ if (!irs.params.is64bit) assert(tysize(TYnptr) == 4);
     }
     else if (retmethod == RET.stack)
     {
-        if (irs.params.isOSX && eresult)
+        if (irs.params.targetOS == TargetOS.OSX && eresult)
         {
             /* ABI quirk: hidden pointer is not returned in registers
              */
@@ -1065,10 +1065,10 @@ Lagain:
                     type *t2 = evalue.ET.Ttag.Sstruct.Sarg2type;
                     if (!t1 && !t2)
                     {
-                        if (!irs.params.isWindows || sz > 8)
+                        if (irs.params.targetOS & TargetOS.Posix || sz > 8)
                             r = RTLSYM_MEMSETN;
                     }
-                    else if (!irs.params.isWindows &&
+                    else if (irs.params.targetOS & TargetOS.Posix &&
                              r == RTLSYM_MEMSET128ii &&
                              tyfloating(t1.Tty) &&
                              tyfloating(t2.Tty))
@@ -1094,7 +1094,7 @@ Lagain:
         edim = el_bin(OPmul, TYsize_t, edim, el_long(TYsize_t, sz));
     }
 
-    if (irs.params.isWindows && irs.params.is64bit && sz > REGSIZE)
+    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit && sz > REGSIZE)
     {
         evalue = addressElem(evalue, tb);
     }
@@ -1931,7 +1931,7 @@ elem *toElem(Expression e, IRState *irs)
                     elem *earray = ExpressionsToStaticArray(ne.loc, ne.arguments, &sdata);
 
                     e = el_pair(TYdarray, el_long(TYsize_t, ne.arguments.dim), el_ptr(sdata));
-                    if (irs.params.isWindows && irs.params.is64bit)
+                    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
                         e = addressElem(e, Type.tsize_t.arrayOf());
                     e = el_param(e, getTypeInfo(ne.loc, ne.type, irs));
                     int rtl = t.isZeroInit(Loc.initial) ? RTLSYM_NEWARRAYMTX : RTLSYM_NEWARRAYMITX;
@@ -2154,7 +2154,7 @@ elem *toElem(Expression e, IRState *irs)
                     size_t len = strlen(id);
                     Symbol *si = toStringSymbol(id, len, 1);
                     elem *efilename = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-                    if (irs.params.isWindows && irs.params.is64bit)
+                    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
                         efilename = addressElem(efilename, Type.tstring, true);
 
                     if (ae.msg)
@@ -2166,7 +2166,7 @@ elem *toElem(Expression e, IRState *irs)
                          */
                         elem *emsg = toElemDtor(ae.msg, irs);
                         emsg = array_toDarray(ae.msg.type, emsg);
-                        if (irs.params.isWindows && irs.params.is64bit)
+                        if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
                             emsg = addressElem(emsg, Type.tvoid.arrayOf(), false);
 
                         ea = el_var(getRtlsym(ud ? RTLSYM_DUNITTEST_MSG : RTLSYM_DASSERT_MSG));
@@ -2325,7 +2325,7 @@ elem *toElem(Expression e, IRState *irs)
         {
             elem *ex = toElem(e, irs);
             ex = array_toDarray(e.type, ex);
-            if (irs.params.isWindows && irs.params.is64bit)
+            if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
             {
                 ex = addressElem(ex, Type.tvoid.arrayOf(), false);
             }
@@ -2375,7 +2375,7 @@ elem *toElem(Expression e, IRState *irs)
                 elem *earr = ElemsToStaticArray(ce.loc, ce.type, &elems, &sdata);
 
                 elem *ep = el_pair(TYdarray, el_long(TYsize_t, elems.dim), el_ptr(sdata));
-                if (irs.params.isWindows && irs.params.is64bit)
+                if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
                     ep = addressElem(ep, Type.tvoid.arrayOf());
                 ep = el_param(ep, getTypeInfo(ce.loc, ta, irs));
                 e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYCATNTX)), ep);
@@ -2951,7 +2951,7 @@ elem *toElem(Expression e, IRState *irs)
                          */
                         el_free(esize);
                         elem *eti = getTypeInfo(ae.e1.loc, t1.nextOf().toBasetype(), irs);
-                        if (irs.params.isWindows && irs.params.is64bit)
+                        if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
                         {
                             eto   = addressElem(eto,   Type.tvoid.arrayOf());
                             efrom = addressElem(efrom, Type.tvoid.arrayOf());
@@ -2966,7 +2966,7 @@ elem *toElem(Expression e, IRState *irs)
                         // Generate:
                         //      _d_arraycopy(eto, efrom, esize)
 
-                        if (irs.params.isWindows && irs.params.is64bit)
+                        if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
                         {
                             eto   = addressElem(eto,   Type.tvoid.arrayOf());
                             efrom = addressElem(efrom, Type.tvoid.arrayOf());
@@ -3259,7 +3259,7 @@ elem *toElem(Expression e, IRState *irs)
                      *      _d_arrayctor(ti, e2, e1)
                      */
                     elem *eti = getTypeInfo(ae.e1.loc, t1b.nextOf().toBasetype(), irs);
-                    if (irs.params.isWindows && irs.params.is64bit)
+                    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
                     {
                         e1 = addressElem(e1, Type.tvoid.arrayOf());
                         e2 = addressElem(e2, Type.tvoid.arrayOf());
@@ -3282,7 +3282,7 @@ elem *toElem(Expression e, IRState *irs)
                      *      _d_arrayassign_r(ti, e2, e1, etmp)
                      */
                     elem *eti = getTypeInfo(ae.e1.loc, t1b.nextOf().toBasetype(), irs);
-                    if (irs.params.isWindows && irs.params.is64bit)
+                    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
                     {
                         e1 = addressElem(e1, Type.tvoid.arrayOf());
                         e2 = addressElem(e2, Type.tvoid.arrayOf());
@@ -3362,7 +3362,7 @@ elem *toElem(Expression e, IRState *irs)
                     assert(tb1n.equals(tb2.nextOf().toBasetype()));
 
                     e1 = el_una(OPaddr, TYnptr, e1);
-                    if (irs.params.isWindows && irs.params.is64bit)
+                    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
                         e2 = addressElem(e2, tb2, true);
                     else
                         e2 = useOPstrpar(e2);
@@ -5594,7 +5594,7 @@ elem *toElem(Expression e, IRState *irs)
 
                 elem *ev = el_pair(TYdarray, el_long(TYsize_t, dim), el_ptr(svalues));
                 elem *ek = el_pair(TYdarray, el_long(TYsize_t, dim), el_ptr(skeys  ));
-                if (irs.params.isWindows && irs.params.is64bit)
+                if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
                 {
                     ev = addressElem(ev, Type.tvoid.arrayOf());
                     ek = addressElem(ek, Type.tvoid.arrayOf());
@@ -5952,7 +5952,7 @@ private elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi)
 
     if (edtors)
     {
-        if (irs.params.isWindows && !irs.params.is64bit) // Win32
+        if (irs.params.targetOS == TargetOS.Windows && !irs.params.is64bit) // Win32
         {
             Blockx *blx = irs.blx;
             nteh_declarvars(blx);
@@ -6060,7 +6060,7 @@ Symbol *toStringSymbol(const(char)* str, size_t len, size_t sz)
     {
         Symbol* si;
 
-        if (global.params.isWindows)
+        if (global.params.targetOS == TargetOS.Windows)
         {
             /* This should be in the back end, but mangleToBuffer() is
              * in the front end.
@@ -6167,7 +6167,7 @@ private elem *filelinefunction(IRState *irs, const ref Loc loc)
     size_t len = strlen(id);
     Symbol *si = toStringSymbol(id, len, 1);
     elem *efilename = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-    if (irs.params.isWindows && irs.params.is64bit)
+    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
         efilename = addressElem(efilename, Type.tstring, true);
 
     elem *elinnum = el_long(TYint, loc.linnum);
@@ -6182,7 +6182,7 @@ private elem *filelinefunction(IRState *irs, const ref Loc loc)
     len = strlen(s);
     si = toStringSymbol(s, len, 1);
     elem *efunction = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-    if (irs.params.isWindows && irs.params.is64bit)
+    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
         efunction = addressElem(efunction, Type.tstring, true);
 
     return el_params(efunction, elinnum, efilename, null);
@@ -6382,7 +6382,7 @@ elem *callCAssert(IRState *irs, const ref Loc loc, Expression exp, Expression em
     auto eline = el_long(TYint, loc.linnum);
 
     elem *ea;
-    if (irs.params.isOSX)
+    if (irs.params.targetOS == TargetOS.OSX)
     {
         // __assert_rtn(func, file, line, msg);
         elem* efunc = getFuncName();
@@ -6401,7 +6401,7 @@ elem *callCAssert(IRState *irs, const ref Loc loc, Expression exp, Expression em
         else
         {
             // [_]_assert(msg, file, line);
-            const rtlsym = (irs.params.isWindows) ? RTLSYM_C_ASSERT : RTLSYM_C__ASSERT;
+            const rtlsym = (irs.params.targetOS == TargetOS.Windows) ? RTLSYM_C_ASSERT : RTLSYM_C__ASSERT;
             auto eassert = el_var(getRtlsym(rtlsym));
             ea = el_bin(OPcall, TYvoid, eassert, el_params(eline, efilename, elmsg, null));
         }

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2184,15 +2184,17 @@ extern Expression* eval_builtin(Loc loc, FuncDeclaration* fd, Array<Expression* 
 
 extern bool canThrow(Expression* e, FuncDeclaration* func, bool mustNotThrow);
 
-enum class TargetOS
+enum class TargetOS : uint8_t
 {
-    all = 2147483647,
-    linux = 1,
-    windows = 2,
-    macOS = 4,
-    freeBSD = 8,
-    solaris = 16,
-    dragonFlyBSD = 32,
+    linux = 1u,
+    Windows = 2u,
+    OSX = 4u,
+    OpenBSD = 8u,
+    FreeBSD = 16u,
+    Solaris = 32u,
+    DragonFlyBSD = 64u,
+    all = 119u,
+    Posix = 117u,
 };
 
 extern Module* rootHasMain;
@@ -6861,6 +6863,19 @@ enum class HIGHLIGHT : uint8_t
     Other = 6u,
 };
 
+enum class TargetOS : uint8_t
+{
+    linux = 1u,
+    Windows = 2u,
+    OSX = 4u,
+    OpenBSD = 8u,
+    FreeBSD = 16u,
+    Solaris = 32u,
+    DragonFlyBSD = 64u,
+    all = 119u,
+    Posix = 117u,
+};
+
 enum class TARGET : bool
 {
     Linux = true,
@@ -6966,13 +6981,7 @@ struct Param
     bool map;
     bool is64bit;
     bool isLP64;
-    bool isLinux;
-    bool isOSX;
-    bool isWindows;
-    bool isFreeBSD;
-    bool isOpenBSD;
-    bool isDragonFlyBSD;
-    bool isSolaris;
+    TargetOS targetOS;
     bool hasObjectiveC;
     bool mscoff;
     DiagnosticReporting useDeprecated;
@@ -7111,13 +7120,6 @@ struct Param
         map(),
         is64bit(true),
         isLP64(),
-        isLinux(),
-        isOSX(),
-        isWindows(),
-        isFreeBSD(),
-        isOpenBSD(),
-        isDragonFlyBSD(),
-        isSolaris(),
         hasObjectiveC(),
         mscoff(false),
         useDeprecated((DiagnosticReporting)1u),

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -17,6 +17,25 @@ import dmd.root.filename;
 import dmd.root.outbuffer;
 import dmd.identifier;
 
+/// Bit decoding of the TargetOS
+enum TargetOS : ubyte
+{
+    /* These are mutually exclusive; one and only one is set.
+     * Match spelling and casing of corresponding version identifiers
+     */
+    linux        = 1,
+    Windows      = 2,
+    OSX          = 4,
+    OpenBSD      = 8,
+    FreeBSD      = 0x10,
+    Solaris      = 0x20,
+    DragonFlyBSD = 0x40,
+
+    // Combination masks
+    all = linux | Windows | OSX | FreeBSD | Solaris | DragonFlyBSD,
+    Posix = linux | OSX | FreeBSD | Solaris | DragonFlyBSD,
+}
+
 template xversion(string s)
 {
     enum xversion = mixin(`{ version (` ~ s ~ `) return true; else return false; }`)();
@@ -145,13 +164,7 @@ extern (C++) struct Param
     bool map;               // generate linker .map file
     bool is64bit = (size_t.sizeof == 8);  // generate 64 bit code; true by default for 64 bit dmd
     bool isLP64;            // generate code for LP64
-    bool isLinux;           // generate code for linux
-    bool isOSX;             // generate code for Mac OSX
-    bool isWindows;         // generate code for Windows
-    bool isFreeBSD;         // generate code for FreeBSD
-    bool isOpenBSD;         // generate code for OpenBSD
-    bool isDragonFlyBSD;    // generate code for DragonFlyBSD
-    bool isSolaris;         // generate code for Solaris
+    TargetOS targetOS;      // operating system to generate code for
     bool hasObjectiveC;     // target supports Objective-C
     bool mscoff = false;    // for Win32: write MsCoff object files instead of OMF
     DiagnosticReporting useDeprecated = DiagnosticReporting.inform;  // how use of deprecated features are handled

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -19,6 +19,26 @@
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;
 
+typedef unsigned char TargetOS;
+enum
+{
+    /* These are mutually exclusive; one and only one is set.
+     * Match spelling and casing of corresponding version identifiers
+     */
+    TargetOS_linux        = 1,
+    TargetOS_Windows      = 2,
+    TargetOS_OSX          = 4,
+    TargetOS_OpenBSD      = 8,
+    TargetOS_FreeBSD      = 0x10,
+    TargetOS_Solaris      = 0x20,
+    TargetOS_DragonFlyBSD = 0x40,
+
+    // Combination masks
+    all = TargetOS_linux | TargetOS_Windows | TargetOS_OSX | TargetOS_FreeBSD | TargetOS_Solaris | TargetOS_DragonFlyBSD,
+    Posix = TargetOS_linux | TargetOS_OSX | TargetOS_FreeBSD | TargetOS_Solaris | TargetOS_DragonFlyBSD,
+};
+
+
 typedef unsigned char Diagnostic;
 enum
 {
@@ -124,13 +144,7 @@ struct Param
     bool map;           // generate linker .map file
     bool is64bit;       // generate 64 bit code
     bool isLP64;        // generate code for LP64
-    bool isLinux;       // generate code for linux
-    bool isOSX;         // generate code for Mac OSX
-    bool isWindows;     // generate code for Windows
-    bool isFreeBSD;     // generate code for FreeBSD
-    bool isOpenBSD;     // generate code for OpenBSD
-    bool isDragonFlyBSD;// generate code for DragonFlyBSD
-    bool isSolaris;     // generate code for Solaris
+    TargetOS targetOS;      // operating system to generate code for
     bool hasObjectiveC; // target supports Objective-C
     bool mscoff;        // for Win32: write COFF object files instead of OMF
     Diagnostic useDeprecated;

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -459,14 +459,14 @@ void genObjFile(Module m, bool multiobj)
         elem *ecov  = el_pair(TYdarray, el_long(TYsize_t, m.numlines), el_ptr(m.cov));
         elem *ebcov = el_pair(TYdarray, el_long(TYsize_t, m.numlines), el_ptr(bcov));
 
-        if (global.params.isWindows && global.params.is64bit)
+        if (global.params.targetOS == TargetOS.Windows && global.params.is64bit)
         {
             ecov  = addressElem(ecov,  Type.tvoid.arrayOf(), false);
             ebcov = addressElem(ebcov, Type.tvoid.arrayOf(), false);
         }
 
         elem *efilename = toEfilename(m);
-        if (global.params.isWindows && global.params.is64bit)
+        if (global.params.targetOS == TargetOS.Windows && global.params.is64bit)
             efilename = addressElem(efilename, Type.tstring, true);
 
         elem *e = el_params(
@@ -655,7 +655,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         // Same as config.ehmethod==EH_NONE, but only for this function
         f.Fflags3 |= Feh_none;
 
-    s.Sclass = global.params.isOSX ? SCcomdat : SCglobal;
+    s.Sclass = global.params.targetOS == TargetOS.OSX ? SCcomdat : SCglobal;
     for (Dsymbol p = fd.parent; p; p = p.parent)
     {
         if (p.isTemplateInstance())
@@ -875,7 +875,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         {
             if (fpr.alloc(sp.Stype, sp.Stype.Tty, &sp.Spreg, &sp.Spreg2))
             {
-                sp.Sclass = (global.params.isWindows && global.params.is64bit) ? SCshadowreg : SCfastpar;
+                sp.Sclass = (global.params.targetOS == TargetOS.Windows && global.params.is64bit) ? SCshadowreg : SCfastpar;
                 sp.Sfl = (sp.Sclass == SCshadowreg) ? FLpara : FLfast;
             }
         }
@@ -905,7 +905,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     {
         // Declare va_argsave
         if (global.params.is64bit &&
-            !global.params.isWindows)
+            global.params.targetOS & TargetOS.Posix)
         {
             type *t = type_struct_class("__va_argsave_t", 16, 8 * 6 + 8 * 16 + 8 * 3, null, null, false, false, true, false);
             // The backend will pick this up by name
@@ -1129,7 +1129,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
         {
             objmod.external_def("main");
         }
-        else if (global.params.isWindows && !global.params.is64bit)
+        else if (global.params.targetOS == TargetOS.Windows && !global.params.is64bit)
         {
             objmod.external_def("_main");
             objmod.external_def("__acrtused_con");
@@ -1153,14 +1153,14 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
                 obj_includelib(global.params.mscrtlib);
             objmod.includelib("OLDNAMES");
         }
-        else if (global.params.isWindows && !global.params.is64bit)
+        else if (global.params.targetOS == TargetOS.Windows && !global.params.is64bit)
         {
             objmod.external_def("__acrtused_con");        // bring in C startup code
             objmod.includelib("snn.lib");          // bring in C runtime library
         }
         s.Sclass = SCglobal;
     }
-    else if (global.params.isWindows && fd.isWinMain() && onlyOneMain(fd.loc))
+    else if (global.params.targetOS == TargetOS.Windows && fd.isWinMain() && onlyOneMain(fd.loc))
     {
         if (global.params.mscoff)
         {
@@ -1179,7 +1179,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
     }
 
     // Pull in RTL startup code
-    else if (global.params.isWindows && fd.isDllMain() && onlyOneMain(fd.loc))
+    else if (global.params.targetOS == TargetOS.Windows && fd.isDllMain() && onlyOneMain(fd.loc))
     {
         if (global.params.mscoff)
         {
@@ -1209,7 +1209,7 @@ private bool onlyOneMain(Loc loc)
         if (global.params.addMain)
             msg = ", -main switch added another `main()`";
         const(char)* otherMainNames = "";
-        if (global.params.isWindows)
+        if (global.params.targetOS == TargetOS.Windows)
             otherMainNames = ", `WinMain`, or `DllMain`";
         error(loc, "only one `main`%s allowed%s. Previously found `main` at %s",
             otherMainNames, msg, lastLoc.toChars());
@@ -1253,7 +1253,7 @@ tym_t totym(Type tx)
         case Tchar:     t = TYchar;     break;
         case Twchar:    t = TYwchar_t;  break;
         case Tdchar:
-            t = (global.params.symdebug == 1 || !global.params.isWindows) ? TYdchar : TYulong;
+            t = (global.params.symdebug == 1 || global.params.targetOS & TargetOS.Posix) ? TYdchar : TYulong;
             break;
 
         case Taarray:   t = TYaarray;   break;
@@ -1334,7 +1334,7 @@ tym_t totym(Type tx)
                 case LINK.cpp:
                 case LINK.objc:
                     t = TYnfunc;
-                    if (global.params.isWindows)
+                    if (global.params.targetOS == TargetOS.Windows)
                     {
                     }
                     else if (!global.params.is64bit && retStyle(tf, false) == RET.stack)

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -835,28 +835,28 @@ public:
         property("size_t", size_t.sizeof);
         propertyStart("platforms");
         arrayStart();
-        if (global.params.isWindows)
+        if (global.params.targetOS == TargetOS.Windows)
         {
             item("windows");
         }
         else
         {
             item("posix");
-            if (global.params.isLinux)
+            if (global.params.targetOS == TargetOS.linux)
                 item("linux");
-            else if (global.params.isOSX)
+            else if (global.params.targetOS == TargetOS.OSX)
                 item("osx");
-            else if (global.params.isFreeBSD)
+            else if (global.params.targetOS == TargetOS.FreeBSD)
             {
                 item("freebsd");
                 item("bsd");
             }
-            else if (global.params.isOpenBSD)
+            else if (global.params.targetOS == TargetOS.OpenBSD)
             {
                 item("openbsd");
                 item("bsd");
             }
-            else if (global.params.isSolaris)
+            else if (global.params.targetOS == TargetOS.Solaris)
             {
                 item("solaris");
                 item("bsd");

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1167,19 +1167,19 @@ private void setDefaultLibrary()
 void setTarget(ref Param params)
 {
     static if (TARGET.Windows)
-        params.isWindows = true;
+        params.targetOS = TargetOS.Windows;
     else static if (TARGET.Linux)
-        params.isLinux = true;
+        params.targetOS = TargetOS.linux;
     else static if (TARGET.OSX)
-        params.isOSX = true;
+        params.targetOS = TargetOS.OSX;
     else static if (TARGET.FreeBSD)
-        params.isFreeBSD = true;
+        params.targetOS = TargetOS.FreeBSD;
     else static if (TARGET.OpenBSD)
-        params.isOpenBSD = true;
+        params.targetOS = TargetOS.OpenBSD;
     else static if (TARGET.Solaris)
-        params.isSolaris = true;
+        params.targetOS = TargetOS.Solaris;
     else static if (TARGET.DragonFlyBSD)
-        params.isDragonFlyBSD = true;
+        params.targetOS = TargetOS.DragonFlyBSD;
     else
         static assert(0, "unknown TARGET");
 }
@@ -1199,7 +1199,7 @@ void setTarget(ref Param params)
 void addDefaultVersionIdentifiers(const ref Param params)
 {
     VersionCondition.addPredefinedGlobalIdent("DigitalMars");
-    if (params.isWindows)
+    if (params.targetOS == TargetOS.Windows)
     {
         VersionCondition.addPredefinedGlobalIdent("Windows");
         if (global.params.mscoff)
@@ -1213,7 +1213,7 @@ void addDefaultVersionIdentifiers(const ref Param params)
             VersionCondition.addPredefinedGlobalIdent("CppRuntime_DigitalMars");
         }
     }
-    else if (params.isLinux)
+    else if (params.targetOS == TargetOS.linux)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("linux");
@@ -1229,7 +1229,7 @@ void addDefaultVersionIdentifiers(const ref Param params)
             VersionCondition.addPredefinedGlobalIdent("CRuntime_Glibc");
         VersionCondition.addPredefinedGlobalIdent("CppRuntime_Gcc");
     }
-    else if (params.isOSX)
+    else if (params.targetOS == TargetOS.OSX)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("OSX");
@@ -1237,7 +1237,7 @@ void addDefaultVersionIdentifiers(const ref Param params)
         // For legacy compatibility
         VersionCondition.addPredefinedGlobalIdent("darwin");
     }
-    else if (params.isFreeBSD)
+    else if (params.targetOS == TargetOS.FreeBSD)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("FreeBSD");
@@ -1245,21 +1245,21 @@ void addDefaultVersionIdentifiers(const ref Param params)
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         VersionCondition.addPredefinedGlobalIdent("CppRuntime_Clang");
     }
-    else if (params.isOpenBSD)
+    else if (params.targetOS == TargetOS.OpenBSD)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("OpenBSD");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         VersionCondition.addPredefinedGlobalIdent("CppRuntime_Gcc");
     }
-    else if (params.isDragonFlyBSD)
+    else if (params.targetOS == TargetOS.DragonFlyBSD)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("DragonFlyBSD");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         VersionCondition.addPredefinedGlobalIdent("CppRuntime_Gcc");
     }
-    else if (params.isSolaris)
+    else if (params.targetOS == TargetOS.Solaris)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("Solaris");
@@ -1287,7 +1287,7 @@ void addDefaultVersionIdentifiers(const ref Param params)
     {
         VersionCondition.addPredefinedGlobalIdent("D_InlineAsm_X86_64");
         VersionCondition.addPredefinedGlobalIdent("X86_64");
-        if (params.isWindows)
+        if (params.targetOS & TargetOS.Windows)
         {
             VersionCondition.addPredefinedGlobalIdent("Win64");
         }
@@ -1297,7 +1297,7 @@ void addDefaultVersionIdentifiers(const ref Param params)
         VersionCondition.addPredefinedGlobalIdent("D_InlineAsm"); //legacy
         VersionCondition.addPredefinedGlobalIdent("D_InlineAsm_X86");
         VersionCondition.addPredefinedGlobalIdent("X86");
-        if (params.isWindows)
+        if (params.targetOS == TargetOS.Windows)
         {
             VersionCondition.addPredefinedGlobalIdent("Win32");
         }

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -1107,7 +1107,7 @@ private extern (C++) class S2irVisitor : Visitor
                 tryblock.appendSucc(bcatch);
                 block_goto(blx, BCjcatch, null);
 
-                if (cs.type && irs.params.isWindows && irs.params.is64bit) // Win64
+                if (cs.type && irs.params.targetOS == TargetOS.Windows && irs.params.is64bit) // Win64
                 {
                     /* The linker will attempt to merge together identical functions,
                      * even if the catch types differ. So add a reference to the

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -729,7 +729,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     /* Disable optimization on Win32 due to
                      * https://issues.dlang.org/show_bug.cgi?id=17997
                      */
-//                    if (!global.params.isWindows || global.params.is64bit)
+//                    if (!global.params.targetOS == TargetOS.Windows || global.params.is64bit)
                         funcdecl.eh_none = true;         // don't generate unwind tables for this function
                 }
 
@@ -1147,7 +1147,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     ClassDeclaration cd = funcdecl.toParentDecl().isClassDeclaration();
                     if (cd)
                     {
-                        if (!global.params.is64bit && global.params.isWindows && !funcdecl.isStatic() && !sbody.usesEH() && !global.params.trace)
+                        if (!global.params.is64bit && global.params.targetOS == TargetOS.Windows && !funcdecl.isStatic() && !sbody.usesEH() && !global.params.trace)
                         {
                             /* The back end uses the "jmonitor" hack for syncing;
                              * no need to do the sync at this level.

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -175,7 +175,7 @@ Symbol *toSymbol(Dsymbol s)
             }
             else if (vd.storage_class & STC.lazy_)
             {
-                if (global.params.isWindows && global.params.is64bit && vd.isParameter())
+                if (global.params.targetOS == TargetOS.Windows && global.params.is64bit && vd.isParameter())
                     t = type_fake(TYnptr);
                 else
                     t = type_fake(TYdelegate);          // Tdelegate as C type
@@ -389,7 +389,7 @@ Symbol *toSymbol(Dsymbol s)
                         break;
                     case LINK.cpp:
                         s.Sflags |= SFLpublic;
-                        if (fd.isThis() && !global.params.is64bit && global.params.isWindows)
+                        if (fd.isThis() && !global.params.is64bit && global.params.targetOS == TargetOS.Windows)
                         {
                             if ((cast(TypeFunction)fd.type).parameterList.varargs == VarArg.variadic)
                             {
@@ -483,21 +483,21 @@ Symbol *toImport(Symbol *sym)
     import core.stdc.stdlib : alloca;
     char *id = cast(char *) alloca(6 + strlen(n) + 1 + type_paramsize(sym.Stype).sizeof*3 + 1);
     int idlen;
-    if (!global.params.isWindows)
+    if (global.params.targetOS & TargetOS.Posix)
     {
         id = n;
         idlen = cast(int)strlen(n);
     }
     else if (sym.Stype.Tmangle == mTYman_std && tyfunc(sym.Stype.Tty))
     {
-        if (global.params.isWindows && global.params.is64bit)
+        if (global.params.targetOS == TargetOS.Windows && global.params.is64bit)
             idlen = sprintf(id,"__imp_%s",n);
         else
             idlen = sprintf(id,"_imp__%s@%u",n,cast(uint)type_paramsize(sym.Stype));
     }
     else
     {
-        idlen = sprintf(id,(global.params.isWindows && global.params.is64bit) ? "__imp_%s" : "_imp__%s",n);
+        idlen = sprintf(id,(global.params.targetOS == TargetOS.Windows && global.params.is64bit) ? "__imp_%s" : "_imp__%s",n);
     }
     auto t = type_alloc(TYnptr | mTYconst);
     t.Tnext = sym.Stype;

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -67,7 +67,7 @@ static void frontend_init()
     gc_disable();
 
     global._init();
-    global.params.isLinux = true;
+    global.params.targetOS = TargetOS_linux;
     global.vendor = "Front-End Tester";
     global.params.objname = NULL;
     global.params.cpu = CPU::native;

--- a/test/dub_package/avg.d
+++ b/test/dub_package/avg.d
@@ -50,7 +50,7 @@ void main()
 
     Id.initialize();
     global._init();
-    global.params.isLinux = true;
+    global.params.targetOS = TargetOS.linux;
     global.params.is64bit = (size_t.sizeof == 8);
     global.params.useUnitTests = true;
     ASTBase.Type._init();

--- a/test/dub_package/impvisitor.d
+++ b/test/dub_package/impvisitor.d
@@ -98,7 +98,7 @@ void main()
 
         Id.initialize();
         global._init();
-        global.params.isLinux = true;
+        global.params.targetOS = TargetOS.linux;
         global.params.is64bit = (size_t.sizeof == 8);
         global.params.useUnitTests = true;
         ASTBase.Type._init();


### PR DESCRIPTION
This refactoring accomplishes:

1. The multiple isXXXX fields suggests that more than one can be simultaneously set. This discourages that.

2. Uses spelling and casing consistent with the corresponding `version` identifiers. I.e. use `OSX` not `macOS`.

3. Add in missing cases for `OpenBSD`.

4. Replace all uses of `if (Not this operating system)` with `if (this operating system)` as the latter is far more maintainable.

5. Adding a new OS is now much easier.

6. More amenable to cross-compilation as now a single variable can be passed to the back end to configure the OS.

7. Use `Posix` for posix attributes.

8. Correctly typed the enum as a `ubyte`.