### PR TITLE
Improve 'Consider adding' error message

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -3059,14 +3059,13 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
             return null;
         }
 
-        auto fullFdPretty = fd.toPrettyChars();
         .error(loc, "%smethod `%s` is not callable using a %sobject",
-               funcBuf.peekChars(), fullFdPretty, thisBuf.peekChars());
+               funcBuf.peekChars(), fd.toPrettyChars(), thisBuf.peekChars());
 
         if (mismatches.isNotShared)
-            .errorSupplemental(loc, "Consider adding `shared` to %s", fullFdPretty);
+            .errorSupplemental(fd.loc, "Consider adding `shared` here");
         else if (mismatches.isMutable)
-            .errorSupplemental(loc, "Consider adding `const` or `inout` to %s", fullFdPretty);
+            .errorSupplemental(fd.loc, "Consider adding `const` or `inout` here");
         return null;
     }
 

--- a/test/fail_compilation/diag1730.d
+++ b/test/fail_compilation/diag1730.d
@@ -2,40 +2,40 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag1730.d(51): Error: mutable method `diag1730.S.func` is not callable using a `inout` object
-fail_compilation/diag1730.d(51):        Consider adding `const` or `inout` to diag1730.S.func
+fail_compilation/diag1730.d(43):        Consider adding `const` or `inout` here
 fail_compilation/diag1730.d(53): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `inout` object
 fail_compilation/diag1730.d(54): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a non-shared `inout` object
-fail_compilation/diag1730.d(54):        Consider adding `const` or `inout` to diag1730.S.sFunc
+fail_compilation/diag1730.d(46):        Consider adding `const` or `inout` here
 fail_compilation/diag1730.d(55): Error: `shared` `const` method `diag1730.S.scFunc` is not callable using a non-shared `inout` object
 fail_compilation/diag1730.d(70): Error: `immutable` method `diag1730.S.iFunc` is not callable using a mutable object
 fail_compilation/diag1730.d(71): Error: `shared` method `diag1730.S.sFunc` is not callable using a non-shared object
 fail_compilation/diag1730.d(72): Error: `shared` `const` method `diag1730.S.scFunc` is not callable using a non-shared mutable object
 fail_compilation/diag1730.d(75): Error: mutable method `diag1730.S.func` is not callable using a `const` object
-fail_compilation/diag1730.d(75):        Consider adding `const` or `inout` to diag1730.S.func
+fail_compilation/diag1730.d(43):        Consider adding `const` or `inout` here
 fail_compilation/diag1730.d(77): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `const` object
 fail_compilation/diag1730.d(78): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a non-shared `const` object
-fail_compilation/diag1730.d(78):        Consider adding `const` or `inout` to diag1730.S.sFunc
+fail_compilation/diag1730.d(46):        Consider adding `const` or `inout` here
 fail_compilation/diag1730.d(79): Error: `shared` `const` method `diag1730.S.scFunc` is not callable using a non-shared `const` object
 fail_compilation/diag1730.d(82): Error: mutable method `diag1730.S.func` is not callable using a `immutable` object
-fail_compilation/diag1730.d(82):        Consider adding `const` or `inout` to diag1730.S.func
+fail_compilation/diag1730.d(43):        Consider adding `const` or `inout` here
 fail_compilation/diag1730.d(85): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a `immutable` object
-fail_compilation/diag1730.d(85):        Consider adding `const` or `inout` to diag1730.S.sFunc
+fail_compilation/diag1730.d(46):        Consider adding `const` or `inout` here
 fail_compilation/diag1730.d(89): Error: non-shared method `diag1730.S.func` is not callable using a `shared` object
-fail_compilation/diag1730.d(89):        Consider adding `shared` to diag1730.S.func
+fail_compilation/diag1730.d(43):        Consider adding `shared` here
 fail_compilation/diag1730.d(90): Error: non-shared `const` method `diag1730.S.cFunc` is not callable using a `shared` mutable object
-fail_compilation/diag1730.d(90):        Consider adding `shared` to diag1730.S.cFunc
+fail_compilation/diag1730.d(44):        Consider adding `shared` here
 fail_compilation/diag1730.d(91): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `shared` mutable object
 fail_compilation/diag1730.d(94): Error: non-shared `inout` method `diag1730.S.wFunc` is not callable using a `shared` mutable object
-fail_compilation/diag1730.d(94):        Consider adding `shared` to diag1730.S.wFunc
+fail_compilation/diag1730.d(48):        Consider adding `shared` here
 fail_compilation/diag1730.d(96): Error: non-shared mutable method `diag1730.S.func` is not callable using a `shared` `const` object
-fail_compilation/diag1730.d(96):        Consider adding `shared` to diag1730.S.func
+fail_compilation/diag1730.d(43):        Consider adding `shared` here
 fail_compilation/diag1730.d(97): Error: non-shared `const` method `diag1730.S.cFunc` is not callable using a `shared` `const` object
-fail_compilation/diag1730.d(97):        Consider adding `shared` to diag1730.S.cFunc
+fail_compilation/diag1730.d(44):        Consider adding `shared` here
 fail_compilation/diag1730.d(98): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `shared` `const` object
 fail_compilation/diag1730.d(99): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a `shared` `const` object
-fail_compilation/diag1730.d(99):        Consider adding `const` or `inout` to diag1730.S.sFunc
+fail_compilation/diag1730.d(46):        Consider adding `const` or `inout` here
 fail_compilation/diag1730.d(101): Error: non-shared `inout` method `diag1730.S.wFunc` is not callable using a `shared` `const` object
-fail_compilation/diag1730.d(101):        Consider adding `shared` to diag1730.S.wFunc
+fail_compilation/diag1730.d(48):        Consider adding `shared` here
 ---
 */
 struct S

--- a/test/fail_compilation/diag6707.d
+++ b/test/fail_compilation/diag6707.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag6707.d(17): Error: mutable method `diag6707.Foo.value` is not callable using a `const` object
-fail_compilation/diag6707.d(17):        Consider adding `const` or `inout` to diag6707.Foo.value
+fail_compilation/diag6707.d(13):        Consider adding `const` or `inout` here
 ---
 */
 

--- a/test/fail_compilation/diag8101b.d
+++ b/test/fail_compilation/diag8101b.d
@@ -10,7 +10,7 @@ fail_compilation/diag8101b.d(33): Error: none of the overloads of `foo` are call
 fail_compilation/diag8101b.d(19):        `diag8101b.S.foo(int _param_0)`
 fail_compilation/diag8101b.d(20):        `diag8101b.S.foo(int _param_0, int _param_1)`
 fail_compilation/diag8101b.d(35): Error: mutable method `diag8101b.S.bar` is not callable using a `const` object
-fail_compilation/diag8101b.d(35):        Consider adding `const` or `inout` to diag8101b.S.bar
+fail_compilation/diag8101b.d(22):        Consider adding `const` or `inout` here
 ---
 */
 

--- a/test/fail_compilation/fail217.d
+++ b/test/fail_compilation/fail217.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail217.d(22): Error: mutable method `fail217.Message.this` is not callable using a `immutable` object
-fail_compilation/fail217.d(22):        Consider adding `const` or `inout` to fail217.Message.this
+fail_compilation/fail217.d(13):        Consider adding `const` or `inout` here
 ---
 */
 

--- a/test/fail_compilation/fail241.d
+++ b/test/fail_compilation/fail241.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail241.d(18): Error: mutable method `fail241.Foo.f` is not callable using a `const` object
-fail_compilation/fail241.d(18):        Consider adding `const` or `inout` to fail241.Foo.f
+fail_compilation/fail241.d(13):        Consider adding `const` or `inout` here
 fail_compilation/fail241.d(19): Error: mutable method `fail241.Foo.g` is not callable using a `const` object
-fail_compilation/fail241.d(19):        Consider adding `const` or `inout` to fail241.Foo.g
+fail_compilation/fail241.d(14):        Consider adding `const` or `inout` here
 ---
 */
 

--- a/test/fail_compilation/ice9759.d
+++ b/test/fail_compilation/ice9759.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice9759.d(25): Error: mutable method `ice9759.Json.opAssign` is not callable using a `const` object
-fail_compilation/ice9759.d(25):        Consider adding `const` or `inout` to ice9759.Json.opAssign
+fail_compilation/ice9759.d(17):        Consider adding `const` or `inout` here
 ---
 */
 


### PR DESCRIPTION
```
As a rule of thumb, we should point the user to where the code is,
not only the name of the function, as the function might be a template
instantiation, in a library module, or behind a mixin.
This does just that, and avoid repeating the FQN of the function,
which is spelled in the error itself, and can be quite long.
```

Before:
<img width="958" alt="Screen Shot 2020-11-28 at 18 05 18" src="https://user-images.githubusercontent.com/2180215/100522728-4f079e00-31ab-11eb-808d-fb8e860f18e5.png">

After:
<img width="957" alt="Screen Shot 2020-11-28 at 18 47 00" src="https://user-images.githubusercontent.com/2180215/100522725-4c0cad80-31ab-11eb-93c8-cc4118992219.png">

Also nice to see https://github.com/dlang/dmd/pull/11841 in action :)