### PR TITLE
[dmd-cxx] Remove typedef d_size_t from headers and code

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4340,7 +4340,7 @@ Expression *ArrayLiteralExp::syntaxCopy()
         arraySyntaxCopy(elements));
 }
 
-Expression *ArrayLiteralExp::getElement(d_size_t i)
+Expression *ArrayLiteralExp::getElement(size_t i)
 {
     Expression *el = (*elements)[i];
     if (!el)

--- a/src/expression.h
+++ b/src/expression.h
@@ -523,7 +523,7 @@ public:
     static ArrayLiteralExp *create(Loc loc, Expressions *elements);
     Expression *syntaxCopy();
     bool equals(RootObject *o);
-    Expression *getElement(d_size_t i);
+    Expression *getElement(size_t i);
     static Expressions* copyElements(Expression *e1, Expression *e2 = NULL);
     bool isBool(bool result);
     StringExp *toStringExp();

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -12,7 +12,6 @@
 
 #include "root/root.h"
 #include "root/stringtable.h"
-#include "root/dcompat.h" // for d_size_t
 
 #include "arraytypes.h"
 #include "ast_node.h"
@@ -635,7 +634,7 @@ public:
 
     static Parameters *arraySyntaxCopy(Parameters *parameters);
     static size_t dim(Parameters *parameters);
-    static Parameter *getNth(Parameters *parameters, d_size_t nth, d_size_t *pn = NULL);
+    static Parameter *getNth(Parameters *parameters, size_t nth, size_t *pn = NULL);
     const char *toChars();
     bool isCovariant(bool returnByRef, const Parameter *p) const;
     static bool isCovariantScope(bool returnByRef, StorageClass from, StorageClass to);

--- a/src/root/array.h
+++ b/src/root/array.h
@@ -16,7 +16,7 @@
 template <typename TYPE>
 struct Array
 {
-    d_size_t length;
+    size_t length;
 
   private:
     DArray<TYPE> data;
@@ -42,8 +42,8 @@ struct Array
     char *toChars() const
     {
         const char **buf = (const char **)mem.xmalloc(length * sizeof(const char *));
-        d_size_t len = 2;
-        for (d_size_t u = 0; u < length; u++)
+        size_t len = 2;
+        for (size_t u = 0; u < length; u++)
         {
             buf[u] = ((RootObject *)data.ptr[u])->toChars();
             len += strlen(buf[u]) + 1;
@@ -52,7 +52,7 @@ struct Array
 
         str[0] = '[';
         char *p = str + 1;
-        for (d_size_t u = 0; u < length; u++)
+        for (size_t u = 0; u < length; u++)
         {
             if (u)
                 *p++ = ',';
@@ -77,7 +77,7 @@ struct Array
         insert(length, a);
     }
 
-    void reserve(d_size_t nentries)
+    void reserve(size_t nentries)
     {
         //printf("Array::reserve: length = %d, data.length = %d, nentries = %d\n", (int)length, (int)data.length, (int)nentries);
         if (data.length - length < nentries)
@@ -106,7 +106,7 @@ struct Array
             {
                 /* Increase size by 1.5x to avoid excessive memory fragmentation
                  */
-                d_size_t increment = length / 2;
+                size_t increment = length / 2;
                 if (nentries > increment)       // if 1.5 is not enough
                     increment = nentries;
                 data.length = length + increment;
@@ -115,18 +115,18 @@ struct Array
         }
     }
 
-    void remove(d_size_t i)
+    void remove(size_t i)
     {
         if (length - i - 1)
             memmove(data.ptr + i, data.ptr + i + 1, (length - i - 1) * sizeof(TYPE));
         length--;
     }
 
-    void insert(d_size_t index, Array *a)
+    void insert(size_t index, Array *a)
     {
         if (a)
         {
-            d_size_t d = a->length;
+            size_t d = a->length;
             reserve(d);
             if (length != index)
                 memmove(data.ptr + index + d, data.ptr + index, (length - index) * sizeof(TYPE));
@@ -135,7 +135,7 @@ struct Array
         }
     }
 
-    void insert(d_size_t index, TYPE ptr)
+    void insert(size_t index, TYPE ptr)
     {
         reserve(1);
         memmove(data.ptr + index + 1, data.ptr + index, (length - index) * sizeof(TYPE));
@@ -143,7 +143,7 @@ struct Array
         length++;
     }
 
-    void setDim(d_size_t newdim)
+    void setDim(size_t newdim)
     {
         if (length < newdim)
         {
@@ -152,9 +152,9 @@ struct Array
         length = newdim;
     }
 
-    d_size_t find(TYPE ptr) const
+    size_t find(TYPE ptr) const
     {
-        for (d_size_t i = 0; i < length; i++)
+        for (size_t i = 0; i < length; i++)
         {
             if (data.ptr[i] == ptr)
                 return i;
@@ -167,7 +167,7 @@ struct Array
         return find(ptr) != SIZE_MAX;
     }
 
-    TYPE& operator[] (d_size_t index)
+    TYPE& operator[] (size_t index)
     {
 #ifdef DEBUG
         assert(index < length);

--- a/src/root/bitarray.h
+++ b/src/root/bitarray.h
@@ -24,8 +24,8 @@ struct BitArray
         mem.xfree(ptr);
     }
 
-    d_size_t len;
-    d_size_t *ptr;
+    size_t len;
+    size_t *ptr;
 
 private:
     BitArray(const BitArray&);

--- a/src/root/dcompat.h
+++ b/src/root/dcompat.h
@@ -34,15 +34,3 @@ struct DString : public DArray<const char>
     DString(size_t length, const char *ptr)
         : DArray<const char>(length, ptr) { }
 };
-
-/// Corresponding C++ type that maps to D size_t
-#if __APPLE__ && __i386__
-// size_t is 'unsigned long', which makes it mangle differently than D's 'uint'
-typedef unsigned d_size_t;
-#elif MARS && DMD_VERSION >= 2079 && DMD_VERSION <= 2081 && \
-        __APPLE__ && __SIZEOF_SIZE_T__ == 8
-// DMD versions between 2.079 and 2.081 mapped D ulong to uint64_t on OS X.
-typedef uint64_t d_size_t;
-#else
-typedef size_t d_size_t;
-#endif

--- a/src/root/outbuffer.h
+++ b/src/root/outbuffer.h
@@ -39,13 +39,13 @@ public:
         mem.xfree(data.ptr);
     }
     const DArray<unsigned char> slice() const { return data; }
-    d_size_t length() const { return offset; }
+    size_t length() const { return offset; }
     char *extractData();
 
     void reserve(size_t nbytes);
     void setsize(size_t size);
     void reset();
-    void write(const void *data, d_size_t nbytes);
+    void write(const void *data, size_t nbytes);
     void writestring(const char *string);
     void prependstring(const char *string);
     void writenl();                     // write newline

--- a/src/root/rmem.h
+++ b/src/root/rmem.h
@@ -8,18 +8,18 @@
 
 #pragma once
 
-#include "dcompat.h"    // for d_size_t
+#include "dsystem.h"    // for size_t
 
 struct Mem
 {
     Mem() { }
 
     static char *xstrdup(const char *s);
-    static void *xmalloc(d_size_t size);
-    static void *xcalloc(d_size_t size, d_size_t n);
-    static void *xrealloc(void *p, d_size_t size);
+    static void *xmalloc(size_t size);
+    static void *xcalloc(size_t size, size_t n);
+    static void *xrealloc(void *p, size_t size);
     static void xfree(void *p);
-    static void *xmallocdup(void *o, d_size_t size);
+    static void *xmallocdup(void *o, size_t size);
     static void error();
 };
 

--- a/src/root/stringtable.h
+++ b/src/root/stringtable.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "root.h"
-#include "dcompat.h" // for d_size_t
 
 struct StringEntry;
 
@@ -40,13 +39,13 @@ private:
     size_t count;
 
 public:
-    void _init(d_size_t size = 0);
-    void reset(d_size_t size = 0);
+    void _init(size_t size = 0);
+    void reset(size_t size = 0);
     ~StringTable();
 
-    StringValue *lookup(const char *s, d_size_t len);
+    StringValue *lookup(const char *s, size_t len);
     StringValue *insert(const char *s, size_t len, void *ptrvalue);
-    StringValue *update(const char *s, d_size_t len);
+    StringValue *update(const char *s, size_t len);
     int apply(int (*fp)(StringValue *));
 
 private:


### PR DESCRIPTION
This was added at a time when I wanted to keep the headers aligned with upstream dmd - this meant that I could test both the C++ and D implementations using the same gdc "glue" code.

Now the D implementation has been ported to gdc, this typedef only serves to hurt the bootstrap process (note that only the headers were altered to use d_size_t, not the source files).