### PR TITLE
make Vstrlen a size_t

### DIFF
--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -925,7 +925,7 @@ union eve
         {
             targ_size_t Voffset3;// offset from string
             char* Vstring;      // pointer to string (OPstring or OPasm)
-            targ_size_t Vstrlen;// length of string
+            size_t Vstrlen;     // length of string
         }
         struct
         {

--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -4097,7 +4097,7 @@ void cdasm(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 {
     // Assume only regs normally destroyed by a function are destroyed
     getregs(cdb,(ALLREGS | mES) & ~fregsaved);
-    cdb.genasm(cast(char *)e.EV.Vstring, cast(uint)e.EV.Vstrlen);
+    cdb.genasm(cast(char *)e.EV.Vstring, cast(uint) e.EV.Vstrlen);
     fixresult(cdb,e,(I16 ? mDX | mAX : mAX),pretregs);
 }
 

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -671,8 +671,8 @@ static if (0)
                 break;
 }
             case OPasm:
-                d.EV.Vstring = cast(char *) mem_malloc(cast(uint)d.EV.Vstrlen);
-                memcpy(d.EV.Vstring,e.EV.Vstring,cast(uint)e.EV.Vstrlen);
+                d.EV.Vstring = cast(char *) mem_malloc(d.EV.Vstrlen);
+                memcpy(d.EV.Vstring,e.EV.Vstring,e.EV.Vstrlen);
                 break;
 
             default:
@@ -1578,14 +1578,13 @@ elem *el_convstring(elem *e)
     int i;
     Symbol *s;
     char *p;
-    targ_size_t len;
 
     assert(!PARSER);
     elem_debug(e);
     assert(e.Eoper == OPstring);
     p = e.EV.Vstring;
     e.EV.Vstring = null;
-    len = e.EV.Vstrlen;
+    size_t len = e.EV.Vstrlen;
 
     // Handle strings that go into the code segment
     if (tybasic(e.Ety) == TYcptr ||
@@ -1617,7 +1616,7 @@ elem *el_convstring(elem *e)
     for (i = 0; i < stable.length; i++)
     {
         if (stable[i].str.length == len &&
-            memcmp(stable[i].str.ptr,p,cast(uint)len) == 0)
+            memcmp(stable[i].str.ptr,p,len) == 0)
         {
             // Replace e with that symbol
             MEM_PH_FREE(p);
@@ -2359,7 +2358,7 @@ else
                 const n = n2.EV.Vstrlen;
                 if (n1.EV.Vstrlen != n ||
                     n1.EV.Voffset != n2.EV.Voffset ||
-                    memcmp(n1.EV.Vstring, n2.EV.Vstring, cast(size_t)n))
+                    memcmp(n1.EV.Vstring, n2.EV.Vstring, n))
                         return false;   /* check bytes in the string    */
                 break;
             }

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -838,12 +838,12 @@ elem *array_toDarray(Type t, elem *e)
             {
                 case OPconst:
                 {
-                    size_t len = tysize(e.Ety);
+                    const size_t len = tysize(e.Ety);
                     elem *es = el_calloc();
                     es.Eoper = OPstring;
 
                     // freed in el_free
-                    es.EV.Vstring = cast(char*)mem_malloc2(cast(uint)len);
+                    es.EV.Vstring = cast(char*)mem_malloc2(cast(uint) len);
                     memcpy(es.EV.Vstring, &e.EV, len);
 
                     es.EV.Vstrlen = len;
@@ -1642,8 +1642,8 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_calloc();
                 e.Eoper = OPstring;
                 // freed in el_free
-                uint len = cast(uint)((se.numberOfCodeUnits() + 1) * se.sz);
-                e.EV.Vstring = cast(char *)mem_malloc2(cast(uint)len);
+                const len = cast(size_t)((se.numberOfCodeUnits() + 1) * se.sz);
+                e.EV.Vstring = cast(char *)mem_malloc2(cast(uint) len);
                 se.writeTo(e.EV.Vstring, true);
                 e.EV.Vstrlen = len;
                 e.Ety = TYnptr;


### PR DESCRIPTION
Since it is the length of a string in the compiler, not the target, it should be a size_t. There is other confusion in the backend w.r.t. integral types, and getting these all fixed should reduce the number of casts required and make the code more pedantically correct, but that is for later.

If you really want to have a string literal larger than 4Gb in your D code, you'll just have to use the 64 bit build of DMD.