### PR TITLE
fix Issue 20150 - -dip1000 defeated by pure

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4428,8 +4428,6 @@ extern (C++) final class TypeFunction : TypeNext
             }
         }
 
-        stc |= STC.scope_;
-
         /* Inferring STC.return_ here has false positives
          * for pure functions, producing spurious error messages
          * about escaping references.
@@ -4437,6 +4435,8 @@ extern (C++) final class TypeFunction : TypeNext
          */
         version (none)
         {
+            stc |= STC.scope_;
+
             Type tret = nextOf().toBasetype();
             if (isref || tret.hasPointers())
             {
@@ -4445,6 +4445,17 @@ extern (C++) final class TypeFunction : TypeNext
                  */
                 stc |= STC.return_;
             }
+        }
+        else
+        {
+            // Check escaping through return value
+            Type tret = nextOf().toBasetype();
+            if (isref || tret.hasPointers())
+            {
+                return stc;
+            }
+
+            stc |= STC.scope_;
         }
 
         return stc;

--- a/test/fail_compilation/retscope6.d
+++ b/test/fail_compilation/retscope6.d
@@ -198,3 +198,36 @@ void hmac(scope ubyte[] secret)
     ubyte[10] buffer;
     secret = buffer[];
 }
+
+/* TEST_OUTPUT:
+---
+fail_compilation/retscope6.d(12011): Error: reference to local variable `x` assigned to non-scope parameter `r` calling retscope6.escape_m_20150
+fail_compilation/retscope6.d(12022): Error: reference to local variable `x` assigned to non-scope parameter `r` calling retscope6.escape_c_20150
+---
+*/
+
+#line 12000
+
+// https://issues.dlang.org/show_bug.cgi?id=20150
+
+int* escape_m_20150(int* r) @safe pure
+{
+    return r;
+}
+
+int* f_m_20150() @safe
+{
+    int x = 42;
+    return escape_m_20150(&x);
+}
+
+const(int)* escape_c_20150(const int* r) @safe pure
+{
+    return r;
+}
+
+const(int)* f_c_20150() @safe
+{
+    int x = 42;
+    return escape_c_20150(&x);
+}


### PR DESCRIPTION
This is an alternative to #10924, fixing [issue 20150](https://issues.dlang.org/show_bug.cgi?id=20150) without introducing a rejects-valid regression.

Phobos relies on issue 20150, so this is expected to fail the test suite.