### PR TITLE
Fix issue 14188 - implement makefile compatible dependency file

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -496,6 +496,12 @@ dmd -cov -unittest myprog.d
             unittesting a library, as it enables running the unittests
             in a library without having to manually define an entry-point function.`,
         ),
+        Option("makedeps",
+            "print module dependencies in Makefile compatible format to stdout"
+        ),
+        Option("makedeps=<filename>",
+            "write module dependencies in Makefile compatible format to filename (only imports)"
+        ),
         Option("man",
             "open web browser on manual page",
             `$(WINDOWS

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -43,6 +43,7 @@ import dmd.root.rootobject;
 import dmd.root.string;
 import dmd.semantic2;
 import dmd.semantic3;
+import dmd.utils;
 import dmd.visitor;
 
 version(Windows) {
@@ -735,6 +736,9 @@ extern (C++) final class Module : Package
     /**
      * Reads the file from `srcfile` and loads the source buffer.
      *
+     * If makefile module dependency is requested, we add this module
+     * to the list of dependencies from here.
+     *
      * Params:
      *  loc = the location
      *
@@ -748,6 +752,14 @@ extern (C++) final class Module : Package
 
         //printf("Module::read('%s') file '%s'\n", toChars(), srcfile.toChars());
         auto readResult = File.read(srcfile.toChars());
+
+        if (global.params.makeDeps && global.params.oneobj)
+        {
+            OutBuffer* ob = global.params.makeDeps;
+            ob.writestringln(" \\");
+            ob.writestring("  ");
+            ob.writestring(toPosixPath(srcfile.toString()));
+        }
 
         return loadSourceBuffer(loc, readResult);
     }

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5981,6 +5981,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             ob.writestring(")");
             ob.writenl();
         }
+        if (global.params.makeDeps && global.params.oneobj)
+        {
+            OutBuffer* ob = global.params.makeDeps;
+            ob.writestringln(" \\");
+            ob.writestring("  ");
+            escapePath(ob, toPosixPath(name));
+        }
 
         {
             auto readResult = File.read(name);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7076,6 +7076,8 @@ struct Param
     _d_dynamicArray< const char > mscrtlib;
     _d_dynamicArray< const char > moduleDepsFile;
     OutBuffer* moduleDeps;
+    _d_dynamicArray< const char > makeDepsFile;
+    OutBuffer* makeDeps;
     MessageStyle messageStyle;
     bool debugb;
     bool debugc;
@@ -7212,6 +7214,8 @@ struct Param
         mscrtlib(),
         moduleDepsFile(),
         moduleDeps(),
+        makeDepsFile(),
+        makeDeps(),
         messageStyle((MessageStyle)0u),
         debugb(),
         debugc(),

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -287,6 +287,10 @@ extern (C++) struct Param
 
     const(char)[] moduleDepsFile;        // filename for deps output
     OutBuffer* moduleDeps;              // contents to be written to deps file
+
+    const(char)[] makeDepsFile;          // filename for makedeps output
+    OutBuffer* makeDeps;                 // contents to be written to makedeps file
+
     MessageStyle messageStyle = MessageStyle.digitalmars; // style of file/line annotations on messages
 
     // Hidden debug switches

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -255,6 +255,10 @@ struct Param
 
     DString moduleDepsFile;     // filename for deps output
     OutBuffer *moduleDeps;      // contents to be written to deps file
+
+    DString makeDepsFile;       // filename for makedeps output
+    OutBuffer *makeDeps;        // contents to be written to makedeps file
+
     MessageStyle messageStyle;  // style of file/line annotations on messages
 
     // Hidden debug switches

--- a/src/dmd/utils.d
+++ b/src/dmd/utils.d
@@ -44,6 +44,76 @@ const(char)* toWinPath(const(char)* src)
     return result;
 }
 
+/**
+ * Normalize path by turning backslashes into forward slashes
+ *
+ * Params:
+ *   src = Source path, using window-style ('\') or mixed path separators
+ *
+ * Returns:
+ *   A newly-allocated string with '\' turned into '/'
+ */
+@trusted nothrow const(char)* toPosixPath(const(char)* src)
+{
+    if (src is null)
+        return null;
+    char* result = strdup(src);
+    char* p = result;
+    while (*p != '\0')
+    {
+        if (*p == '\\')
+            *p = '/';
+        p++;
+    }
+    return result;
+}
+
+/**
+ * ditto
+ */
+@safe pure nothrow const(char)[] toPosixPath(const(char)[] src)
+{
+    if (!src)
+        return null;
+    char[] result = src.dup;
+    foreach (ref c; result)
+    {
+        if (c == '\\')
+            c = '/';
+    }
+    return result;
+}
+
+///
+@safe nothrow unittest
+{
+    const(char)[] nullStr;
+    const(char)* nullStrP;
+
+    assert(toPosixPath(nullStrP) == null);
+    assert(toPosixPath(nullStr) == null);
+
+    @trusted nothrow void assertion(const(char)[] s1, const(char)[] s2)
+    {
+        assert(toPosixPath(s1) == s2);
+        assert(strcmp(toPosixPath(s1.ptr), s2.ptr) == 0);
+    }
+
+    const posixAbsPath = `/some/path`;
+    const posixRelPath = `some/path`;
+
+    const windowsAbsPath = `C:\some\path`;
+    const windowsAbsMixedPath = `C:\some/path`;
+    const windowsAbsPosixPath = `C:/some/path`;
+    const windowsRelPath = `some\path`;
+
+    assertion(posixAbsPath, posixAbsPath);
+    assertion(posixRelPath, posixRelPath);
+    assertion(windowsAbsPath, windowsAbsPosixPath);
+    assertion(windowsAbsMixedPath, windowsAbsPosixPath);
+    assertion(windowsAbsPosixPath, windowsAbsPosixPath);
+    assertion(windowsRelPath, posixRelPath);
+}
 
 /**
  * Reads a file, terminate the program on error

--- a/test/compilable/extra-files/makedeps-import.txt
+++ b/test/compilable/extra-files/makedeps-import.txt
@@ -1,0 +1,1 @@
+Imported text

--- a/test/compilable/extra-files/makedeps.sh
+++ b/test/compilable/extra-files/makedeps.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+DEPFILE=${RESULTS_DIR}/compilable/makedeps.dep
+grep  'makedeps_[0-9]*.o:' ${DEPFILE} || # some platforms use .obj instead of .o for object files.
+grep  'makedeps_[0-9]*.obj:' ${DEPFILE}
+# The test runner will generate a single object file from both source files, hence the same target name
+grep  'makedeps.d' ${DEPFILE}
+grep  'makedeps_a.d' ${DEPFILE}
+grep  'makedeps-import.txt' ${DEPFILE}
+grep  'object.d' ${DEPFILE}
+! grep  '__entrypoint' ${DEPFILE}
+rm -f ${DEPFILE}

--- a/test/compilable/extra-files/makedeps_a.d
+++ b/test/compilable/extra-files/makedeps_a.d
@@ -1,0 +1,3 @@
+module makedeps_a;
+
+void a_func() {}

--- a/test/compilable/makedeps-stdout.sh
+++ b/test/compilable/makedeps-stdout.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+mkdir -p $OUTPUT_BASE
+
+cat >$OUTPUT_BASE/makedeps.d <<EOF
+module makedeps;
+
+// Test import statement
+import makedeps_a;
+
+// Test import expression
+enum text = import("makedeps-import.txt");
+static assert(text == "Imported text");
+
+void main()
+{
+    a_func();
+}
+EOF
+
+DEPFILE=${OUTPUT_BASE}/depfile.dep
+
+${DMD} -c -of=${OUTPUT_BASE}/makedeps.o -makedeps \
+    -Jcompilable/extra-files -Icompilable/extra-files \
+    $OUTPUT_BASE/makedeps.d > ${DEPFILE}
+
+set -e
+grep  'makedeps*.o:' ${DEPFILE} || # some platforms use .obj instead of .o for object files.
+grep  'makedeps*.obj:' ${DEPFILE}
+# The test runner will generate a single object file from both source files, hence the same target name
+grep  'makedeps.d' ${DEPFILE}
+grep  'makedeps-import.txt' ${DEPFILE}
+grep  'makedeps_a.d' ${DEPFILE}
+grep  'object.d' ${DEPFILE}
+! grep  '__entrypoint' ${DEPFILE}
+rm -f ${DEPFILE}

--- a/test/compilable/makedeps.d
+++ b/test/compilable/makedeps.d
@@ -1,0 +1,17 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -makedeps=${RESULTS_DIR}/compilable/makedeps.dep -Jcompilable/extra-files -Icompilable/extra-files
+// POST_SCRIPT: compilable/extra-files/makedeps.sh
+
+module makedeps;
+
+// Test import statement
+import makedeps_a;
+
+// Test import expression
+enum text = import("makedeps-import.txt");
+static assert(text == "Imported text");
+
+void main()
+{
+    a_func();
+}

--- a/test/fail_compilation/extra-files/makedeps-import.txt
+++ b/test/fail_compilation/extra-files/makedeps-import.txt
@@ -1,0 +1,1 @@
+Imported text

--- a/test/fail_compilation/extra-files/makedeps_a.d
+++ b/test/fail_compilation/extra-files/makedeps_a.d
@@ -1,0 +1,3 @@
+module makedeps_a;
+
+void a_func() {}

--- a/test/fail_compilation/makedeps_doubleparam.d
+++ b/test/fail_compilation/makedeps_doubleparam.d
@@ -1,0 +1,23 @@
+/*
+PERMUTE_ARGS:
+REQUIRED_ARGS: -makedeps=${RESULTS_DIR}/compilable/makedeps.dep -makedeps=other-file.dep -Jcompilable/extra-files -Icompilable/extra-files
+TEST_OUTPUT:
+---
+Error: -makedeps[=file] can only be provided once!
+       run `dmd` to print the compiler manual
+       run `dmd -man` to open browser on manual
+---
+*/
+module makedeps_doubleparam;
+
+// Test import statement
+import makedeps_a;
+
+// Test import expression
+enum text = import("makedeps-import.txt");
+static assert(text == "Imported text");
+
+void main()
+{
+    a_func();
+}

--- a/test/fail_compilation/makedeps_multiobj.d
+++ b/test/fail_compilation/makedeps_multiobj.d
@@ -1,0 +1,22 @@
+/*
+PERMUTE_ARGS:
+REQUIRED_ARGS: -lib -makedeps=${TEST_RESULTS}/depfile.dep -Jfail_compilation/extra-files -Ifail_compilation/extra-files
+EXTRA_SOURCES: extra-files/makedeps_a.d
+TEST_OUTPUT:
+---
+Error: -makedeps switch is not compatible with multiple objects mode
+---
+*/
+module makedeps_multiobj;
+
+// Test import statement
+import makedeps_a;
+
+// Test import expression
+enum text = import("makedeps-import.txt");
+static assert(text == "Imported text");
+
+void main()
+{
+    a_func();
+}

--- a/test/fail_compilation/makedeps_nofile.d
+++ b/test/fail_compilation/makedeps_nofile.d
@@ -1,0 +1,23 @@
+/*
+PERMUTE_ARGS:
+REQUIRED_ARGS: -makedeps= -Jcompilable/extra-files -Icompilable/extra-files
+TEST_OUTPUT:
+---
+Error: expected filename after -makedeps=
+       run `dmd` to print the compiler manual
+       run `dmd -man` to open browser on manual
+---
+*/
+module makedeps_nofile;
+
+// Test import statement
+import makedeps_a;
+
+// Test import expression
+enum text = import("makedeps-import.txt");
+static assert(text == "Imported text");
+
+void main()
+{
+    a_func();
+}

--- a/test/fail_compilation/makedeps_wrongflag.d
+++ b/test/fail_compilation/makedeps_wrongflag.d
@@ -1,0 +1,23 @@
+/*
+PERMUTE_ARGS:
+REQUIRED_ARGS: -makedepsbla -Jcompilable/extra-files -Icompilable/extra-files
+TEST_OUTPUT:
+---
+Error: unrecognized switch '-makedepsbla'
+       run `dmd` to print the compiler manual
+       run `dmd -man` to open browser on manual
+---
+*/
+module makedeps_wrongflag;
+
+// Test import statement
+import makedeps_a;
+
+// Test import expression
+enum text = import("makedeps-import.txt");
+static assert(text == "Imported text");
+
+void main()
+{
+    a_func();
+}


### PR DESCRIPTION
This PR fixes issue [14188](https://issues.dlang.org/show_bug.cgi?id=14188) to allow emitting makefile compatible dependency file and enable proper D builds with ninja.
I am aware #6961 and #11357.
IMO #6961 is too complex, introducing many switches and stales for nearly two years.
This one is closer in spirit to #11137, but with simpler and more efficient implementation.
In particular, it follows advice given by @rainers to not use the same semantics than the current `-deps` switch, which do much more than collecting depending modules (it triggers additional semantic pass).

Only one switch is introduced: `-makefiledeps`, which can take an optional filename argument. if filename is omitted, dependencies are printed to stdout.

I collect module dependencies in `dmodule.Module.read`.
I collect in addition imported files (with the `-J` switch) in the expression semantics visitor.
Nothing else is collected or analysed, compilation time should not be affected more than strictly necessary.

I've tested this to work with Ninja.