### PR TITLE
add more error propagation in statementsem

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -250,6 +250,12 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 (*cs.statements)[i] = s;
                 if (s)
                 {
+                    if (s.isErrorStatement())
+                    {
+                        result = s;     // propagate error up the AST
+                        ++i;
+                        continue;       // look for errors in rest of statements
+                    }
                     Statement sentry;
                     Statement sexception;
                     Statement sfinally;
@@ -2484,6 +2490,8 @@ else
     override void visit(StaticAssertStatement s)
     {
         s.sa.semantic2(sc);
+        if (s.sa.errors)
+            return setError();
     }
 
     override void visit(SwitchStatement ss)


### PR DESCRIPTION
Fixes a couple cases where errors weren't propagated in statementsem.d. Don't have a test case because the semantic analysis only partially relies on this. Snipped out of https://github.com/dlang/dmd/pull/12014/ where it is actually needed.