### PR TITLE
speller.d: tighten up code and interfaces

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -513,8 +513,13 @@ struct Scope
         /************************************************
          * Given the failed search attempt, try to find
          * one with a close spelling.
+         * Params:
+         *      seed = identifier to search for
+         *      cost = set to the cost, which rises with each outer scope
+         * Returns:
+         *      Dsymbol if found, null if not
          */
-        extern (D) Dsymbol scope_search_fp(const(char)[] seed, ref int cost)
+        extern (D) Dsymbol scope_search_fp(const(char)[] seed, out int cost)
         {
             //printf("scope_search_fp('%s')\n", seed);
             /* If not in the lexer's string table, it certainly isn't in the symbol table.

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -830,7 +830,7 @@ extern (C++) class Dsymbol : ASTNode
         /***************************************************
          * Search for symbol with correct spelling.
          */
-        extern (D) Dsymbol symbol_search_fp(const(char)[] seed, ref int cost)
+        extern (D) Dsymbol symbol_search_fp(const(char)[] seed, out int cost)
         {
             /* If not in the lexer's string table, it certainly isn't in the symbol table.
              * Doing this first is a lot faster.
@@ -840,7 +840,7 @@ extern (C++) class Dsymbol : ASTNode
             Identifier id = Identifier.lookup(seed);
             if (!id)
                 return null;
-            cost = 0;
+            cost = 0;   // all the same cost
             Dsymbol s = this;
             Module.clearCache();
             return s.search(Loc.initial, id, IgnoreErrors);

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -2028,12 +2028,12 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         return tup.expressionSemantic(sc);
     }
 
-    static const(char)[] trait_search_fp(const(char)[] seed, ref int cost)
+    static const(char)[] trait_search_fp(const(char)[] seed, out int cost)
     {
         //printf("trait_search_fp('%s')\n", seed);
         if (!seed.length)
             return null;
-        cost = 0;
+        cost = 0;       // all the same cost
         const sv = traitsStringTable.lookup(seed);
         return sv ? sv.toString() : null;
     }


### PR DESCRIPTION
1. improve comments
2. use `out` instead of `ref`
3. use `foreach` when practical
4. use single assignment of variables
5. check error return of `alloc()`
6. clarify order of evaluation in call to `combineSpellerResult()`
7. minimize lifetime of variables
