### PR TITLE
[stable] Fix Issue 21464 - Purity check depending on semantic order

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1269,11 +1269,16 @@ extern (C++) abstract class Expression : ASTNode
         if (v.storage_class & STC.manifest)
             return false; // ...or manifest constants
 
+        // accessing empty structs is pure
         if (v.type.ty == Tstruct)
         {
             StructDeclaration sd = (cast(TypeStruct)v.type).sym;
-            if (sd.hasNoFields)
-                return false;
+            if (sd.members) // not opaque
+            {
+                sd.determineSize(v.loc);
+                if (sd.hasNoFields)
+                    return false;
+            }
         }
 
         bool err = false;

--- a/test/compilable/imports/test21464a.d
+++ b/test/compilable/imports/test21464a.d
@@ -1,0 +1,4 @@
+struct Mallocator
+{
+    static shared Mallocator instance;
+}

--- a/test/compilable/test21464.d
+++ b/test/compilable/test21464.d
@@ -1,0 +1,6 @@
+// https://issues.dlang.org/show_bug.cgi?id=21464
+void foo() pure
+{
+    import imports.test21464a : Mallocator;
+    auto a = Mallocator.instance; // mutable static, but empty struct
+}


### PR DESCRIPTION
Accessing a mutable static but empty struct is pure. The check relied on `StructDeclaration.hasNoFields` but didn't make sure the struct size has already been determined.