### PR TITLE
Do not issue internal error message for -checkaction=context

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6217,6 +6217,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.e1 = exp.e1.optimize(WANTvalue);
         exp.e1 = exp.e1.toBoolean(sc);
 
+        if (exp.e1.op == TOK.error)
+        {
+            result = exp.e1;
+            return;
+        }
+
         if (exp.msg)
         {
             exp.msg = expressionSemantic(exp.msg, sc);
@@ -6226,11 +6232,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             checkParamArgumentEscape(sc, null, null, exp.msg, true, false);
         }
 
-        if (exp.e1.op == TOK.error)
-        {
-            result = exp.e1;
-            return;
-        }
         if (exp.msg && exp.msg.op == TOK.error)
         {
             result = exp.msg;

--- a/test/fail_compilation/dassert.d
+++ b/test/fail_compilation/dassert.d
@@ -1,0 +1,12 @@
+/*
+REQUIRED_ARGS: -checkaction=context
+TEST_OUTPUT:
+---
+fail_compilation/dassert.d(11): Error: expression `tuple(0, 0)` of type `(int, int)` does not have a boolean value
+---
+*/
+struct Baguette { int bread, floor; }
+void main ()
+{
+    assert(Baguette.init.tupleof);
+}


### PR DESCRIPTION
```
Before this change, the test case in this commit would output the following:
---
test.d(6): Error: expression tuple(v.a, v.b) of type (int, int) does not have a boolean value
/usr/local/opt/dmd/include/dlang/dmd/core/internal/dassert.d(304): Error: "Invalid comparison operator: "
/usr/local/opt/dmd/include/dlang/dmd/core/internal/dassert.d(27):        called from here: invertCompToken("")
---

Now only the first line, the one relevant to user code, is printed.
```