### PR TITLE
fix Issue 21479 - ternary operator returns wrong val with ref return

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -891,6 +891,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             // Function returns a reference
                             exp = exp.toLvalue(sc2, exp);
                             checkReturnEscapeRef(sc2, exp, false);
+                            exp = exp.optimize(WANTvalue, /*keepLvalue*/ true);
                         }
                         else
                         {

--- a/test/runnable/test21479.d
+++ b/test/runnable/test21479.d
@@ -1,0 +1,28 @@
+// https://issues.dlang.org/show_bug.cgi?id=21479
+enum Side
+{
+    left,
+    right
+}
+
+struct Both(T)
+{
+    T left;
+    T right;
+
+    ref T get(Side side)
+    {
+        return side == Side.left ? left : right;
+    }
+}
+
+void main()
+{
+    Both!(int[]) t;
+    t.get(Side.left) ~= 1;
+    assert (t.left.length == 1);
+
+    t.get(Side.right) ~= 1;
+    t.get(Side.right) ~= 2;
+    assert (t.right.length == 2);
+}


### PR DESCRIPTION
The `!f.isref` path was optimizing the return expression, but this was not happening for ref returns.  This led to manifest constant variables being leaked to the code generator, which may not necessarily know what to do with them.