### PR TITLE
use Identifier[] instead of Array!Identifier * for package names

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -594,7 +594,7 @@ struct ASTBase
 
     extern (C++) class Import : Dsymbol
     {
-        Identifiers* packages;
+        Identifier[] packages;
         Identifier id;
         Identifier aliasId;
         int isstatic;
@@ -603,7 +603,7 @@ struct ASTBase
         Identifiers names;
         Identifiers aliases;
 
-        extern (D) this(const ref Loc loc, Identifiers* packages, Identifier id, Identifier aliasId, int isstatic)
+        extern (D) this(const ref Loc loc, Identifier[] packages, Identifier id, Identifier aliasId, int isstatic)
         {
             super(null);
             this.loc = loc;
@@ -618,10 +618,10 @@ struct ASTBase
                 // import [cstdio] = std.stdio;
                 this.ident = aliasId;
             }
-            else if (packages && packages.dim)
+            else if (packages.length > 0)
             {
                 // import [std].stdio;
-                this.ident = (*packages)[0];
+                this.ident = packages[0];
             }
             else
             {
@@ -1399,7 +1399,7 @@ struct ASTBase
     extern (C++) final class VisibilityDeclaration : AttribDeclaration
     {
         Visibility visibility;
-        Identifiers* pkg_identifiers;
+        Identifier[] pkg_identifiers;
 
         extern (D) this(const ref Loc loc, Visibility v, Dsymbols* decl)
         {
@@ -1407,7 +1407,7 @@ struct ASTBase
             this.loc = loc;
             this.visibility = v;
         }
-        extern (D) this(const ref Loc loc, Identifiers* pkg_identifiers, Dsymbols* decl)
+        extern (D) this(const ref Loc loc, Identifier[] pkg_identifiers, Dsymbols* decl)
         {
             super(decl);
             this.loc = loc;
@@ -6570,11 +6570,11 @@ struct ASTBase
     {
         Loc loc;
         Identifier id;
-        Identifiers *packages;
+        Identifier[] packages;
         bool isdeprecated;
         Expression msg;
 
-        extern (D) this(const ref Loc loc, Identifiers* packages, Identifier id, Expression msg, bool isdeprecated)
+        extern (D) this(const ref Loc loc, Identifier[] packages, Identifier id, Expression msg, bool isdeprecated)
         {
             this.loc = loc;
             this.packages = packages;
@@ -6586,14 +6586,10 @@ struct ASTBase
         extern (C++) const(char)* toChars() const
         {
             OutBuffer buf;
-            if (packages && packages.dim)
+            foreach (const pid; packages)
             {
-                for (size_t i = 0; i < packages.dim; i++)
-                {
-                    const Identifier pid = (*packages)[i];
-                    buf.writestring(pid.toString());
-                    buf.writeByte('.');
-                }
+                buf.writestring(pid.toString());
+                buf.writeByte('.');
             }
             buf.writestring(id.toString());
             return buf.extractChars();

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -582,7 +582,7 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
 extern (C++) final class VisibilityDeclaration : AttribDeclaration
 {
     Visibility visibility;          /// the visibility
-    Identifiers* pkg_identifiers;   /// identifiers for `package(foo.bar)` or null
+    Identifier[] pkg_identifiers;   /// identifiers for `package(foo.bar)` or null
 
     /**
      * Params:
@@ -603,12 +603,12 @@ extern (C++) final class VisibilityDeclaration : AttribDeclaration
      *  pkg_identifiers = list of identifiers for a qualified package name
      *  decl = declarations which are affected by this visibility attribute
      */
-    extern (D) this(const ref Loc loc, Identifiers* pkg_identifiers, Dsymbols* decl)
+    extern (D) this(const ref Loc loc, Identifier[] pkg_identifiers, Dsymbols* decl)
     {
         super(loc, null, decl);
         this.visibility.kind = Visibility.Kind.package_;
         this.pkg_identifiers = pkg_identifiers;
-        if (pkg_identifiers !is null && pkg_identifiers.dim > 0)
+        if (pkg_identifiers.length > 0)
         {
             Dsymbol tmp;
             Package.resolve(pkg_identifiers, &tmp, null);

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -107,7 +107,7 @@ class VisibilityDeclaration : public AttribDeclaration
 {
 public:
     Visibility visibility;
-    Identifiers* pkg_identifiers;
+    DArray<Identifier*> pkg_identifiers;
 
     VisibilityDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -92,12 +92,10 @@ BUILTIN determine_builtin(FuncDeclaration func)
     if (id2 != Id.math && id2 != Id.bitop)
         return BUILTIN.unimp;
 
-    if (!md.packages)
-        return BUILTIN.unimp;
     if (md.packages.length != 1)
         return BUILTIN.unimp;
 
-    const id1 = (*md.packages)[0];
+    const id1 = md.packages[0];
     if (id1 != Id.core && id1 != Id.std)
         return BUILTIN.unimp;
     const id3 = fd.ident;

--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -146,9 +146,8 @@ extern (C++) struct Compiler
     {
         if (includeImports)
         {
-            Identifiers empty;
             if (includeImportedModuleCheck(ModuleComponentRange(
-                (m.md && m.md.packages) ? m.md.packages : &empty, m.ident, m.isPackageFile)))
+                m.md ? m.md.packages : [], m.ident, m.isPackageFile)))
             {
                 if (global.params.verbose)
                     message("compileimport (%s)", m.srcfile.toChars);
@@ -186,18 +185,18 @@ extern (C++) struct Compiler
 // A range of component identifiers for a module
 private struct ModuleComponentRange
 {
-    Identifiers* packages;
+    Identifier[] packages;
     Identifier name;
     bool isPackageFile;
     size_t index;
-    @property auto totalLength() const { return packages.dim + 1 + (isPackageFile ? 1 : 0); }
+    @property auto totalLength() const { return packages.length + 1 + (isPackageFile ? 1 : 0); }
 
     @property auto empty() { return index >= totalLength(); }
     @property auto front() const
     {
-        if (index < packages.dim)
-            return (*packages)[index];
-        if (index == packages.dim)
+        if (index < packages.length)
+            return packages[index];
+        if (index == packages.length)
             return name;
         else
             return Identifier.idPool("package");

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -30,7 +30,7 @@ extern (C++) final class Import : Dsymbol
 {
     /* static import aliasId = pkg1.pkg2.id : alias1 = name1, alias2 = name2;
      */
-    Identifiers* packages;  // array of Identifier's representing packages
+    Identifier[] packages;  // array of Identifier's representing packages
     Identifier id;          // module Identifier
     Identifier aliasId;
     int isstatic;           // !=0 if static import
@@ -46,7 +46,7 @@ extern (C++) final class Import : Dsymbol
     // corresponding AliasDeclarations for alias=name pairs
     AliasDeclarations aliasdecls;
 
-    extern (D) this(const ref Loc loc, Identifiers* packages, Identifier id, Identifier aliasId, int isstatic)
+    extern (D) this(const ref Loc loc, Identifier[] packages, Identifier id, Identifier aliasId, int isstatic)
     {
         Identifier selectIdent()
         {
@@ -56,10 +56,10 @@ extern (C++) final class Import : Dsymbol
                 // import [aliasId] = std.stdio;
                 return aliasId;
             }
-            else if (packages && packages.dim)
+            else if (packages.length > 0)
             {
                 // import [std].stdio;
-                return (*packages)[0];
+                return packages[0];
             }
             else
             {
@@ -74,13 +74,9 @@ extern (C++) final class Import : Dsymbol
         version (none)
         {
             printf("Import::Import(");
-            if (packages && packages.dim)
+            foreach (id; packages)
             {
-                for (size_t i = 0; i < packages.dim; i++)
-                {
-                    Identifier id = (*packages)[i];
-                    printf("%s.", id.toChars());
-                }
+                printf("%s.", id.toChars());
             }
             printf("%s)\n", id.toChars());
         }
@@ -252,12 +248,12 @@ extern (C++) final class Import : Dsymbol
     extern (D) void addPackageAccess(ScopeDsymbol scopesym)
     {
         //printf("Import::addPackageAccess('%s') %p\n", toPrettyChars(), this);
-        if (packages)
+        if (packages.length > 0)
         {
             // import a.b.c.d;
             auto p = pkg; // a
             scopesym.addAccessiblePackage(p, visibility);
-            foreach (id; (*packages)[1 .. packages.dim]) // [b, c]
+            foreach (id; packages[1 .. $]) // [b, c]
             {
                 p = cast(Package) p.symtab.lookup(id);
                 // https://issues.dlang.org/show_bug.cgi?id=17991

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -170,11 +170,11 @@ void removeHdrFilesAndFail(ref Param params, ref Modules modules)
  * Returns:
  *  the filename of the child package or module
  */
-private const(char)[] getFilename(Identifiers* packages, Identifier ident)
+private const(char)[] getFilename(Identifier[] packages, Identifier ident)
 {
     const(char)[] filename = ident.toString();
 
-    if (packages == null || packages.dim == 0)
+    if (packages.length == 0)
         return filename;
 
     OutBuffer buf;
@@ -204,7 +204,7 @@ private const(char)[] getFilename(Identifiers* packages, Identifier ident)
         dotmods.writeByte('.');
     }
 
-    foreach (pid; *packages)
+    foreach (pid; packages)
     {
         const p = pid.toString();
         buf.writestring(p);
@@ -270,52 +270,49 @@ extern (C++) class Package : ScopeDsymbol
      *      *pparent        the rightmost package, i.e. pkg2, or NULL if no packages
      *      *ppkg           the leftmost package, i.e. pkg1, or NULL if no packages
      */
-    extern (D) static DsymbolTable resolve(Identifiers* packages, Dsymbol* pparent, Package* ppkg)
+    extern (D) static DsymbolTable resolve(Identifier[] packages, Dsymbol* pparent, Package* ppkg)
     {
         DsymbolTable dst = Module.modules;
         Dsymbol parent = null;
         //printf("Package::resolve()\n");
         if (ppkg)
             *ppkg = null;
-        if (packages)
+        foreach (pid; packages)
         {
-            for (size_t i = 0; i < packages.dim; i++)
+            Package pkg;
+            Dsymbol p = dst.lookup(pid);
+            if (!p)
             {
-                Identifier pid = (*packages)[i];
-                Package pkg;
-                Dsymbol p = dst.lookup(pid);
-                if (!p)
-                {
-                    pkg = new Package(Loc.initial, pid);
-                    dst.insert(pkg);
-                    pkg.parent = parent;
+                pkg = new Package(Loc.initial, pid);
+                dst.insert(pkg);
+                pkg.parent = parent;
+                pkg.symtab = new DsymbolTable();
+            }
+            else
+            {
+                pkg = p.isPackage();
+                assert(pkg);
+                // It might already be a module, not a package, but that needs
+                // to be checked at a higher level, where a nice error message
+                // can be generated.
+                // dot net needs modules and packages with same name
+                // But we still need a symbol table for it
+                if (!pkg.symtab)
                     pkg.symtab = new DsymbolTable();
-                }
-                else
-                {
-                    pkg = p.isPackage();
-                    assert(pkg);
-                    // It might already be a module, not a package, but that needs
-                    // to be checked at a higher level, where a nice error message
-                    // can be generated.
-                    // dot net needs modules and packages with same name
-                    // But we still need a symbol table for it
-                    if (!pkg.symtab)
-                        pkg.symtab = new DsymbolTable();
-                }
-                parent = pkg;
-                dst = pkg.symtab;
-                if (ppkg && !*ppkg)
-                    *ppkg = pkg;
-                if (pkg.isModule())
-                {
-                    // Return the module so that a nice error message can be generated
-                    if (ppkg)
-                        *ppkg = cast(Package)p;
-                    break;
-                }
+            }
+            parent = pkg;
+            dst = pkg.symtab;
+            if (ppkg && !*ppkg)
+                *ppkg = pkg;
+            if (pkg.isModule())
+            {
+                // Return the module so that a nice error message can be generated
+                if (ppkg)
+                    *ppkg = cast(Package)p;
+                break;
             }
         }
+
         if (pparent)
             *pparent = parent;
         return dst;
@@ -389,12 +386,12 @@ extern (C++) class Package : ScopeDsymbol
         if (isPkgMod != PKG.unknown)
             return;
 
-        Identifiers packages;
+        Identifier[] packages;
         for (Dsymbol s = this.parent; s; s = s.parent)
-            packages.insert(0, s.ident);
+            packages = s.ident ~ packages;
 
-        if (lookForSourceFile(getFilename(&packages, ident)))
-            Module.load(Loc(), &packages, this.ident);
+        if (lookForSourceFile(getFilename(packages, ident)))
+            Module.load(Loc(), packages, this.ident);
         else
             isPkgMod = PKG.package_;
     }
@@ -575,7 +572,12 @@ extern (C++) final class Module : Package
         return new Module(Loc.initial, filename, ident, doDocComment, doHdrGen);
     }
 
-    static Module load(Loc loc, Identifiers* packages, Identifier ident)
+    extern (C++) static Module load(Loc loc, Identifiers* packages, Identifier ident)
+    {
+        return load(loc, (*packages)[], ident);
+    }
+
+    extern (D) static Module load(Loc loc, Identifier[] packages, Identifier ident)
     {
         //printf("Module::load(ident = '%s')\n", ident.toChars());
         // Build module filename by turning:
@@ -594,13 +596,10 @@ extern (C++) final class Module : Package
         if (global.params.verbose)
         {
             OutBuffer buf;
-            if (packages)
+            foreach (pid; packages)
             {
-                foreach (pid; *packages)
-                {
-                    buf.writestring(pid.toString());
-                    buf.writeByte('.');
-                }
+                buf.writestring(pid.toString());
+                buf.writeByte('.');
             }
             buf.printf("%s\t(%s)", ident.toChars(), m.srcfile.toChars());
             message("import    %s", buf.peekChars());
@@ -1520,11 +1519,11 @@ extern (C++) struct ModuleDeclaration
 {
     Loc loc;
     Identifier id;
-    Identifiers* packages;  // array of Identifier's representing packages
+    Identifier[] packages;  // array of Identifier's representing packages
     bool isdeprecated;      // if it is a deprecated module
     Expression msg;
 
-    extern (D) this(const ref Loc loc, Identifiers* packages, Identifier id, Expression msg, bool isdeprecated)
+    extern (D) this(const ref Loc loc, Identifier[] packages, Identifier id, Expression msg, bool isdeprecated)
     {
         this.loc = loc;
         this.packages = packages;
@@ -1536,13 +1535,10 @@ extern (C++) struct ModuleDeclaration
     extern (C++) const(char)* toChars() const
     {
         OutBuffer buf;
-        if (packages && packages.dim)
+        foreach (pid; packages)
         {
-            foreach (pid; *packages)
-            {
-                buf.writestring(pid.toString());
-                buf.writeByte('.');
-            }
+            buf.writestring(pid.toString());
+            buf.writeByte('.');
         }
         buf.writestring(id.toString());
         return buf.extractChars();

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -34,6 +34,7 @@ import dmd.globals;
 import dmd.id;
 import dmd.identifier;
 import dmd.parse;
+import dmd.root.array;
 import dmd.root.file;
 import dmd.root.filename;
 import dmd.root.outbuffer;
@@ -388,7 +389,8 @@ extern (C++) class Package : ScopeDsymbol
 
         Identifier[] packages;
         for (Dsymbol s = this.parent; s; s = s.parent)
-            packages = s.ident ~ packages;
+            packages ~= s.ident;
+        reverse(packages);
 
         if (lookForSourceFile(getFilename(packages, ident)))
             Module.load(Loc(), packages, this.ident);

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -790,12 +790,9 @@ private void emitAnchor(ref OutBuffer buf, Dsymbol s, Scope* sc, bool forHeader 
                 // fully qualify imports so `core.stdc.string` doesn't appear as `core`
                 void printFullyQualifiedImport()
                 {
-                    if (imp.packages && imp.packages.dim)
+                    foreach (const pid; imp.packages)
                     {
-                        foreach (const pid; *imp.packages)
-                        {
-                            buf.printf("%s.", pid.toChars());
-                        }
+                        buf.printf("%s.", pid.toChars());
                     }
                     buf.writestring(imp.id.toString());
                 }
@@ -2610,12 +2607,9 @@ private bool isIdentifier(Dsymbols* a, const(char)* p, size_t len)
 
                 // fully qualify imports so `core.stdc.string` doesn't appear as `core`
                 string fullyQualifiedImport;
-                if (imp.packages && imp.packages.dim)
+                foreach (const pid; imp.packages)
                 {
-                    foreach (const pid; *imp.packages)
-                    {
-                        fullyQualifiedImport ~= pid.toString() ~ ".";
-                    }
+                    fullyQualifiedImport ~= pid.toString() ~ ".";
                 }
                 fullyQualifiedImport ~= imp.id.toString();
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1647,6 +1647,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     scopesym.importScope(imp.mod, imp.visibility);
                 }
 
+
                 imp.addPackageAccess(scopesym);
             }
 
@@ -1732,13 +1733,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 ob.writeByte(' ');
             }
             ob.writestring(": ");
-            if (imp.packages)
+            foreach (pid; imp.packages)
             {
-                for (size_t i = 0; i < imp.packages.dim; i++)
-                {
-                    Identifier pid = (*imp.packages)[i];
-                    ob.printf("%s.", pid.toChars());
-                }
+                ob.printf("%s.", pid.toChars());
             }
             ob.writestring(imp.id.toString());
             ob.writestring(" (");

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2486,9 +2486,11 @@ Package resolveIsPackage(Dsymbol sym)
 private Module loadStdMath()
 {
     __gshared Import impStdMath = null;
+    __gshared Identifier[1] stdID;
     if (!impStdMath)
     {
-        auto s = new Import(Loc.initial, [Id.std], Id.math, null, false);
+        stdID[0] = Id.std;
+        auto s = new Import(Loc.initial, stdID[], Id.math, null, false);
         // Module.load will call fatal() if there's no std.math available.
         // Gag the error here, pushing the error handling to the caller.
         uint errors = global.startGagging();

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2488,9 +2488,7 @@ private Module loadStdMath()
     __gshared Import impStdMath = null;
     if (!impStdMath)
     {
-        auto a = new Identifiers();
-        a.push(Id.std);
-        auto s = new Import(Loc.initial, a, Id.math, null, false);
+        auto s = new Import(Loc.initial, [Id.std], Id.math, null, false);
         // Module.load will call fatal() if there's no std.math available.
         // Gag the error here, pushing the error handling to the caller.
         uint errors = global.startGagging();

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7948,3 +7948,4 @@ extern "C" Object* _d_newclass(const TypeInfo_Class* const ci);
 extern "C" void* _d_newitemT(TypeInfo* ti);
 
 extern "C" void* _d_newitemiT(TypeInfo* ti);
+

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2031,7 +2031,7 @@ class VisibilityDeclaration final : public AttribDeclaration
 {
 public:
     Visibility visibility;
-    Array<Identifier* >* pkg_identifiers;
+    _d_dynamicArray< Identifier* > pkg_identifiers;
     VisibilityDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     void addMember(Scope* sc, ScopeDsymbol* sds);
@@ -2897,7 +2897,7 @@ public:
 class Import final : public Dsymbol
 {
 public:
-    Array<Identifier* >* packages;
+    _d_dynamicArray< Identifier* > packages;
     Identifier* id;
     Identifier* aliasId;
     int32_t isstatic;
@@ -3060,7 +3060,7 @@ struct ModuleDeclaration
 {
     Loc loc;
     Identifier* id;
-    Array<Identifier* >* packages;
+    _d_dynamicArray< Identifier* > packages;
     bool isdeprecated;
     Expression* msg;
     const char* toChars() const;
@@ -7948,4 +7948,3 @@ extern "C" Object* _d_newclass(const TypeInfo_Class* const ci);
 extern "C" void* _d_newitemT(TypeInfo* ti);
 
 extern "C" void* _d_newitemiT(TypeInfo* ti);
-

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -862,12 +862,9 @@ public:
         {
             buf.printf("%s = ", imp.aliasId.toChars());
         }
-        if (imp.packages && imp.packages.dim)
+        foreach (const pid; imp.packages)
         {
-            foreach (const pid; *imp.packages)
-            {
-                buf.printf("%s.", pid.toChars());
-            }
+            buf.printf("%s.", pid.toChars());
         }
         buf.writestring(imp.id.toString());
         if (imp.names.dim)

--- a/src/dmd/import.h
+++ b/src/dmd/import.h
@@ -23,7 +23,7 @@ public:
     /* static import aliasId = pkg1.pkg2.id : alias1 = name1, alias2 = name2;
      */
 
-    Identifiers *packages;      // array of Identifier's representing packages
+    DArray<Identifier*> packages;      // array of Identifier's representing packages
     Identifier *id;             // module Identifier
     Identifier *aliasId;
     int isstatic;               // !=0 if static import

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -508,14 +508,9 @@ public:
         objectStart();
         propertyStart("name");
         stringStart();
-        if (s.packages && s.packages.dim)
-        {
-            for (size_t i = 0; i < s.packages.dim; i++)
-            {
-                const pid = (*s.packages)[i];
-                stringPart(pid.toString());
-                buf.writeByte('.');
-            }
+        foreach (const pid; s.packages){
+            stringPart(pid.toString());
+            buf.writeByte('.');
         }
         stringPart(s.id.toString());
         stringEnd();

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -403,14 +403,12 @@ final class Parser(AST) : Lexer
                 goto Lerr;
             }
 
-            AST.Identifiers* a = null;
+            Identifier[] a;
             Identifier id = token.ident;
 
             while (nextToken() == TOK.dot)
             {
-                if (!a)
-                    a = new AST.Identifiers();
-                a.push(id);
+                a ~= id;
                 nextToken();
                 if (token.value != TOK.identifier)
                 {
@@ -1038,7 +1036,7 @@ final class Parser(AST) : Lexer
 
                     // optional qualified package identifier to bind
                     // visibility to
-                    AST.Identifiers* pkg_prot_idents = null;
+                    Identifier[] pkg_prot_idents;
                     if (pAttrs.visibility.kind == AST.Visibility.Kind.package_ && token.value == TOK.leftParentheses)
                     {
                         pkg_prot_idents = parseQualifiedIdentifier("protection package");
@@ -2333,9 +2331,9 @@ final class Parser(AST) : Lexer
      * Returns:
      *     array of identifiers with actual qualified one stored last
      */
-    private AST.Identifiers* parseQualifiedIdentifier(const(char)* entity)
+    private Identifier[] parseQualifiedIdentifier(const(char)* entity)
     {
-        AST.Identifiers* qualified = null;
+        Identifier[] qualified;
 
         do
         {
@@ -2343,13 +2341,11 @@ final class Parser(AST) : Lexer
             if (token.value != TOK.identifier)
             {
                 error("`%s` expected as dot-separated identifiers, got `%s`", entity, token.toChars());
-                return null;
+                return qualified;
             }
 
             Identifier id = token.ident;
-            if (!qualified)
-                qualified = new AST.Identifiers();
-            qualified.push(id);
+            qualified ~= id;
 
             nextToken();
         }
@@ -3480,7 +3476,7 @@ final class Parser(AST) : Lexer
 
             const loc = token.loc;
             Identifier id = token.ident;
-            AST.Identifiers* a = null;
+            Identifier[] a;
             nextToken();
             if (!aliasid && token.value == TOK.assign)
             {
@@ -3489,9 +3485,7 @@ final class Parser(AST) : Lexer
             }
             while (token.value == TOK.dot)
             {
-                if (!a)
-                    a = new AST.Identifiers();
-                a.push(id);
+                a ~= id;
                 nextToken();
                 if (token.value != TOK.identifier)
                 {

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -497,7 +497,7 @@ int intrinsic_op(FuncDeclaration fd)
     const md = m.md;
     const Identifier id2 = md.id;
 
-    if (!md.packages)
+    if (md.packages.length == 0)
         return op;
 
     // get type of first argument
@@ -505,12 +505,12 @@ int intrinsic_op(FuncDeclaration fd)
     auto param1 = tf && tf.parameterList.length > 0 ? tf.parameterList[0] : null;
     auto argtype1 = param1 ? param1.type : null;
 
-    const Identifier id1 = (*md.packages)[0];
+    const Identifier id1 = md.packages[0];
     // ... except std.math package and core.stdc.stdarg.va_start.
-    if (md.packages.dim == 2)
+    if (md.packages.length == 2)
     {
         if (id2 == Id.trig &&
-            (*md.packages)[1] == Id.math &&
+            md.packages[1] == Id.math &&
             id1 == Id.std)
         {
             goto Lstdmath;
@@ -597,7 +597,7 @@ Lva_start:
         fd.toParent().isTemplateInstance() &&
         id3 == Id.va_start &&
         id2 == Id.stdarg &&
-        (*md.packages)[1] == Id.stdc &&
+        md.packages[1] == Id.stdc &&
         id1 == Id.core)
     {
         return OPva_start;

--- a/test/dub_package/impvisitor.d
+++ b/test/dub_package/impvisitor.d
@@ -22,9 +22,8 @@ extern(C++) class ImportVisitor2(AST) : ParseTimeTransitiveVisitor!AST
 
         printf("import ");
 
-        if (imp.packages && imp.packages.dim)
-            foreach (const pid; *imp.packages)
-                printf("%s.", pid.toChars());
+        foreach (const pid; imp.packages)
+            printf("%s.", pid.toChars());
 
         printf("%s", imp.id.toChars());
 


### PR DESCRIPTION
in ProtDeclaration and Imports.

Simplifies some code that has to check if the Array* is null before iterating, etc.  There doesn't seem to be any semantic difference between an empty array or null ptr.  

Performance/memory usage probably won't change since we're replacing indirection -> possibly SSO buffer, so there's a single indirection either way.  Also, all the slices we allocate are being stored in GC allocated AST nodes, so they weren't getting freed without GC before.

There's probably some other places where we can replace pointer to array with slices if this seems like a worthwhile change.