### PR TITLE
extend PR #11846 to add symbol support for AliasAssign

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -529,13 +529,15 @@ struct ASTBase
     {
         Identifier ident;
         Type type;
+        Dsymbol aliassym;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Type type)
+        extern (D) this(const ref Loc loc, Identifier ident, Type type, Dsymbol aliassym)
         {
             super(null);
             this.loc = loc;
             this.ident = ident;
             this.type = type;
+            this.aliassym = aliassym;
         }
 
         override inout(AliasAssign) isAliasAssign() inout

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -2138,24 +2138,30 @@ extern (C++) final class ExpressionDsymbol : Dsymbol
 /**********************************************
  * Encapsulate assigning to an alias:
  *      `identifier = type;`
+ *      `identifier = symbol;`
  * where `identifier` is an AliasDeclaration in scope.
  */
 extern (C++) final class AliasAssign : Dsymbol
 {
     Identifier ident; /// Dsymbol's ident will be null, as this class is anonymous
     Type type;        /// replace previous RHS of AliasDeclaration with `type`
+    Dsymbol aliassym; /// replace previous RHS of AliasDeclaration with `aliassym`
+                      /// only one of type and aliassym can be != null
 
-    extern (D) this(const ref Loc loc, Identifier ident, Type type)
+    extern (D) this(const ref Loc loc, Identifier ident, Type type, Dsymbol aliasssym)
     {
         super(loc, null);
         this.ident = ident;
         this.type = type;
+        this.aliassym = aliassym;
     }
 
     override AliasAssign syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        AliasAssign aa = new AliasAssign(loc, ident, type.syntaxCopy());
+        AliasAssign aa = new AliasAssign(loc, ident,
+                type     ? type.syntaxCopy()         : null,
+                aliassym ? aliassym.syntaxCopy(null) : null);
         return aa;
     }
 
@@ -2166,7 +2172,7 @@ extern (C++) final class AliasAssign : Dsymbol
 
     override const(char)* kind() const
     {
-        return "aliasAssign";
+        return "alias assignment";
     }
 
     override void accept(Visitor v)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3230,6 +3230,7 @@ class AliasAssign final : public Dsymbol
 public:
     Identifier* ident;
     Type* type;
+    Dsymbol* aliassym;
     AliasAssign* syntaxCopy(Dsymbol* s);
     AliasAssign* isAliasAssign();
     const char* kind() const;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1448,7 +1448,10 @@ public:
     {
         buf.writestring(d.ident.toString());
         buf.writestring(" = ");
-        typeToBuffer(d.type, null, buf, hgs);
+        if (d.aliassym)
+            d.aliassym.accept(this);
+        else // d.type
+            typeToBuffer(d.type, null, buf, hgs);
         buf.writeByte(';');
         buf.writenl();
     }

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -4441,7 +4441,7 @@ final class Parser(AST) : Lexer
             nextToken();
             nextToken();        // advance past =
             auto t = parseType();
-            AST.Dsymbol s = new AST.AliasAssign(loc, ident, t);
+            AST.Dsymbol s = new AST.AliasAssign(loc, ident, t, null);
             check(TOK.semicolon);
             addComment(s, comment);
             auto a = new AST.Dsymbols();

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -784,7 +784,10 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.AliasAssign d)
     {
         //printf("Visting AliasAssign\n");
-        visitType(d.type);
+        if (d.aliassym)
+            d.aliassym.accept(this);
+        else
+            visitType(d.type);
     }
 
     override void visit(AST.VarDeclaration d)

--- a/test/fail_compilation/aliasassign.d
+++ b/test/fail_compilation/aliasassign.d
@@ -1,0 +1,21 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/aliasassign.d(13): Error: `B` must have same parent `Swap!(int, string)` as alias `B`
+fail_compilation/aliasassign.d(14): Error: `A` must have same parent `Swap!(int, string)` as alias `A`
+fail_compilation/aliasassign.d(21): Error: template instance `aliasassign.Swap!(int, string)` error instantiating
+fail_compilation/aliasassign.d(21):        while evaluating: `static assert(Swap!(int, string))`
+---
+*/
+
+template Swap (alias A, alias B)
+{
+    alias C = A;
+    B = A;
+    A = B;
+    enum Swap = true;
+}
+
+alias A = int;
+alias B = string;
+
+static assert(Swap!(A, B));

--- a/test/runnable/aliasassign.d
+++ b/test/runnable/aliasassign.d
@@ -1,0 +1,31 @@
+
+
+template AliasSeq(T...) { alias AliasSeq = T; }
+
+template staticMap(alias F, T...)
+{
+    alias A = AliasSeq!();
+    static foreach (t; T)
+        A = AliasSeq!(A, F!t);
+    alias staticMap = A;
+}
+
+template Qual(alias T)
+{
+    alias Qual = T;
+}
+
+void test()
+{
+    int x = 3;
+    int y = 4;
+
+    alias XY = staticMap!(Qual, x, y);
+    assert(XY[0] == 3);
+    assert(XY[1] == 4);
+}
+
+void main()
+{
+    test();
+}


### PR DESCRIPTION
#11846 only does alias assigns for types. As promised, this extends it for symbols, too, just like `AliasDeclaration`.