### PR TITLE
Add -extern-std=c++20 and set value for __traits(getTargetInfo)

### DIFF
--- a/changelog/extern-std-cpp20.dd
+++ b/changelog/extern-std-cpp20.dd
@@ -1,0 +1,5 @@
+The compiler now accepts `-extern-std=c++20`
+
+The compiler now accepts c++20 as a supported standard for `-extern-std=`.
+Currently this only changes the value of `__traits(getTargetInfo, "cppStd")`,
+though new types may be added in the future.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -334,6 +334,8 @@ dmd -cov -unittest myprog.d
                     Sets `__traits(getTargetInfo, \"cppStd\")` to `201402`)
                 $(LI $(I c++17): Use C++17 name mangling,
                     Sets `__traits(getTargetInfo, \"cppStd\")` to `201703`)
+                $(LI $(I c++20): Use C++20 name mangling,
+                    Sets `__traits(getTargetInfo, \"cppStd\")` to `202002`)
             )",
         ),
         Option("extern-std=[h|help|?]",
@@ -912,6 +914,7 @@ struct CLIUsage
   =c++11                Sets `__traits(getTargetInfo, \"cppStd\")` to `201103`
   =c++14                Sets `__traits(getTargetInfo, \"cppStd\")` to `201402`
   =c++17                Sets `__traits(getTargetInfo, \"cppStd\")` to `201703`
+  =c++20                Sets `__traits(getTargetInfo, \"cppStd\")` to `202002`
 ";
 
     /// Options supported by -HC

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6971,6 +6971,7 @@ enum class CppStdRevision : uint32_t
     cpp11 = 201103u,
     cpp14 = 201402u,
     cpp17 = 201703u,
+    cpp20 = 202002u,
 };
 
 enum class CxxHeaderMode : uint32_t

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -126,7 +126,8 @@ enum CppStdRevision : uint
     cpp98 = 1997_11,
     cpp11 = 2011_03,
     cpp14 = 2014_02,
-    cpp17 = 2017_03
+    cpp17 = 2017_03,
+    cpp20 = 2020_02,
 }
 
 /// Configuration for the C++ header generator

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -106,7 +106,8 @@ enum CppStdRevision
     CppStdRevisionCpp98 = 199711,
     CppStdRevisionCpp11 = 201103,
     CppStdRevisionCpp14 = 201402,
-    CppStdRevisionCpp17 = 201703
+    CppStdRevisionCpp17 = 201703,
+    CppStdRevisionCpp20 = 202002
 };
 
 /// Configuration for the C++ header generator

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1993,6 +1993,9 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             case "c++17":
                 params.cplusplus = CppStdRevision.cpp17;
                 break;
+            case "c++20":
+                params.cplusplus = CppStdRevision.cpp20;
+                break;
             default:
                 error("Switch `%s` is invalid", p);
                 params.externStdUsage = true;


### PR DESCRIPTION
It's past time to add this option, and set CppStdRevision to the specified value for C++20.

https://www.iso.org/standard/79358.html

http://eel.is/c++draft/cpp.predefined#1.1