### PR TITLE
fix Issue 21490 - Optimizer can add SSE integer multiply for machines…

### DIFF
--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -1000,7 +1000,8 @@ L1:
         return e;
     }
     // Replace (e + e) with (e * 2)
-    else if (el_match(e1,e2) && !el_sideeffect(e1) && !tyfloating(e1.Ety))
+    else if (el_match(e1,e2) && !el_sideeffect(e1) && !tyfloating(e1.Ety) &&
+        !tyvector(e1.Ety))      // not all CPUs support XMM multiply
     {
         e.Eoper = OPmul;
         el_free(e2);


### PR DESCRIPTION
… less than SSE4.1 which do not have it

The test case is adding `-O` to dmd/test/runnable/testxmm.d, but both this PR and https://github.com/dlang/dmd/pull/12035 are necessary for that to work. So they are mutually blocking each other. One has to be pulled first. I suggest this one.