### PR TITLE
add -O to test/runnable/testxmm.d

### DIFF
--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -1,5 +1,5 @@
 // REQUIRED_ARGS:
-// PERMUTE_ARGS: -mcpu=native -inline
+// PERMUTE_ARGS: -mcpu=native -inline -O
 
 version (D_SIMD)
 {


### PR DESCRIPTION
XMM code should be tested with `-O`

Blocked by PRs https://github.com/dlang/dmd/pull/12035 and https://github.com/dlang/dmd/pull/12038