### PR TITLE
fix Issue 10445 - add .min, .max, etc. properties for vector types

### DIFF
--- a/changelog/fix10445.md
+++ b/changelog/fix10445.md
@@ -1,0 +1,15 @@
+Add .min, .max, etc. properties for vector types.
+
+For integral vector types, add the `.min` and `.max` properties.
+
+For floating point vector types, add the `.min`, `.max`, `.min_normal`,
+`.nan`, `.infinity`, and `.epsilon` properties.
+
+The value of those properties is the value corresponsing to the vector
+element type broadcast to the vector type. I.e.:
+
+---
+import core.simd;
+
+static assert(float4.max == cast(float4)float.max);
+---

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3347,6 +3347,16 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             // stringof should not add a cast to the output
             return visitType(mt);
         }
+
+        // Properties based on the vector element type and are values of the element type
+        if (ident == Id.max || ident == Id.min || ident == Id.min_normal ||
+            ident == Id.nan || ident == Id.infinity || ident == Id.epsilon)
+        {
+            auto vet = mt.basetype.isTypeSArray().next; // vector element type
+            if (auto ev = getProperty(vet, sc, e.loc, ident, DotExpFlag.gag))
+                return ev.castTo(sc, mt); // 'broadcast' ev to the vector elements
+        }
+
         return mt.basetype.dotExp(sc, e.castTo(sc, mt.basetype), ident, flag);
     }
 

--- a/test/runnable/test10445.d
+++ b/test/runnable/test10445.d
@@ -1,0 +1,53 @@
+/*
+ */
+
+import core.simd;
+
+int main()
+{
+    version (D_SIMD)
+    {
+	{
+	    auto m = ubyte16.max;
+	    auto n = cast(ubyte16)ubyte.max;
+	    assert(m.array == n.array);
+	}
+
+	{
+	    auto m = ubyte16.min;
+	    auto n = cast(ubyte16)ubyte.min;
+	    assert(m.array == n.array);
+	}
+
+	{
+	    auto m = float4.max;
+	    auto n = cast(float4)float.max;
+	    assert(m.array == n.array);
+	}
+
+	{
+	    auto m = float4.min_normal;
+	    auto n = cast(float4)float.min_normal;
+	    assert(m.array == n.array);
+	}
+
+	{
+	    auto m = float4.epsilon;
+	    auto n = cast(float4)float.epsilon;
+	    assert(m.array == n.array);
+	}
+
+	{
+	    auto m = float4.infinity;
+	    auto n = cast(float4)float.infinity;
+	    assert(m.array == n.array);
+	}
+
+	{
+	    auto m = float4.nan;
+	    auto n = cast(float4)float.nan;
+	    assert(m.array != n.array);
+	}
+    }
+    return 0;
+}


### PR DESCRIPTION
Because one would expect these to work.