### PR TITLE
fix Issue 17105 - [ICE] SIMD Internal error with optimizations: backe…

### DIFF
--- a/src/dmd/backend/cgxmm.d
+++ b/src/dmd/backend/cgxmm.d
@@ -1210,21 +1210,30 @@ static if (0)
         }
 
         getregs(cdb,retregs);
+
+        switch (op)
+        {
+            case CMPPD:   case CMPSS:   case CMPSD:   case CMPPS:
+            case PSHUFD:  case PSHUFHW: case PSHUFLW:
+            case BLENDPD: case BLENDPS: case DPPD:    case DPPS:
+            case MPSADBW: case PBLENDW:
+            case ROUNDPD: case ROUNDPS: case ROUNDSD: case ROUNDSS:
+            case SHUFPD:  case SHUFPS:
+                if (n == 3)
+                {
+                    version (MARS)
+                        if (pass == PASSfinal)
+                            error(e.Esrcpos.Sfilename, e.Esrcpos.Slinnum, e.Esrcpos.Scharnum, "missing 4th parameter to `__simd()`");
+                    cs.IFL2 = FLconst;
+                    cs.IEV2.Vsize_t = 0;
+                }
+                break;
+            default:
+                break;
+        }
+
         if (n == 4)
         {
-            switch (op)
-            {
-                case CMPPD:   case CMPSS:   case CMPSD:   case CMPPS:
-                case PSHUFD:  case PSHUFHW: case PSHUFLW:
-                case BLENDPD: case BLENDPS: case DPPD:    case DPPS:
-                case MPSADBW: case PBLENDW:
-                case ROUNDPD: case ROUNDPS: case ROUNDSD: case ROUNDSS:
-                case SHUFPD:  case SHUFPS:
-                    break;
-                default:
-                    printf("op = x%x\n", op);
-                    assert(0);
-            }
             elem *imm8 = params[3];
             cs.IFL2 = FLconst;
 version (MARS)
@@ -1658,6 +1667,7 @@ void checkSetVex3(code *c)
 
 void checkSetVex(code *c, tym_t ty)
 {
+    //printf("checkSetVex() %d %x\n", tysize(ty), c.Iop);
     if (config.avx || tysize(ty) == 32)
     {
         uint vreg = (c.Irm >> 3) & 7;
@@ -1786,6 +1796,8 @@ void cloadxmm(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
 
         return;
     }
+
+    // See test/complex.d for cases winding up here
     cload87(cdb, e, pretregs);
 }
 

--- a/test/fail_compilation/fail17105.d
+++ b/test/fail_compilation/fail17105.d
@@ -1,0 +1,29 @@
+/* REQUIRED_ARGS: -m64
+DISABLED: win32 linux32 osx32 freebsd32
+TEST_OUTPUT:
+---
+fail_compilation/fail17105.d(20): Error: missing 4th parameter to `__simd()`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=17105
+
+module foo;
+import core.simd;
+
+struct bug {
+    version (D_SIMD)
+    {
+        float4 value;
+        auto normalize() {
+            value = cast(float4) __simd(XMM.DPPS, value, value, 0xFF);
+            value = cast(float4) __simd(XMM.DPPS, value, value);
+        }
+    }
+}
+
+/*
+https://www.felixcloutier.com/x86/dpps
+
+66 0F 3A 40 /r ib DPPS xmm1, xmm2/m128, imm8
+*/


### PR DESCRIPTION
…nd\cod3.c 6807

The trouble is that the missing argument was ignored and wound up as garbage. The fix is to detect the missing argument and issue an error.