### PR TITLE
Print instantiation for template constraint deprecations too

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -419,6 +419,8 @@ extern (C++) class Dsymbol : ASTNode
 
         if (auto ti = sc.parent ? sc.parent.isInstantiated() : null)
             ti.printInstantiationTrace(Classification.deprecation);
+        else if (auto ti = sc.parent ? sc.parent.isTemplateInstance() : null)
+            ti.printInstantiationTrace(Classification.deprecation);
 
         return true;
     }

--- a/test/compilable/diag20916.d
+++ b/test/compilable/diag20916.d
@@ -1,18 +1,21 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/diag20916.d(36): Deprecation: `alias fb this` is deprecated
-compilable/diag20916.d(41):        instantiated from here: `jump2!(Foo)`
-compilable/diag20916.d(46):        instantiated from here: `jump1!(Foo)`
-compilable/diag20916.d(36): Deprecation: function `diag20916.FooBar.toString` is deprecated
-compilable/diag20916.d(41):        instantiated from here: `jump2!(Foo)`
-compilable/diag20916.d(46):        instantiated from here: `jump1!(Foo)`
-compilable/diag20916.d(36): Deprecation: function `diag20916.Bar.toString!().toString` is deprecated
-compilable/diag20916.d(41):        instantiated from here: `jump2!(Bar)`
-compilable/diag20916.d(47):        instantiated from here: `jump1!(Bar)`
+compilable/diag20916.d(32): Deprecation: `alias fb this` is deprecated
+compilable/diag20916.d(37):        instantiated from here: `jump2!(Foo)`
+compilable/diag20916.d(42):        instantiated from here: `jump1!(Foo)`
+compilable/diag20916.d(32): Deprecation: function `diag20916.FooBar.toString` is deprecated
+compilable/diag20916.d(37):        instantiated from here: `jump2!(Foo)`
+compilable/diag20916.d(42):        instantiated from here: `jump1!(Foo)`
+compilable/diag20916.d(32): Deprecation: function `diag20916.Bar.toString!().toString` is deprecated
+compilable/diag20916.d(37):        instantiated from here: `jump2!(Bar)`
+compilable/diag20916.d(43):        instantiated from here: `jump1!(Bar)`
+compilable/diag20916.d(21): Deprecation: variable `diag20916.Something.something` is deprecated
+compilable/diag20916.d(24):        instantiated from here: `nestedCheck!(Something)`
 ---
  */
 
+#line 1
 struct FooBar
 {
     deprecated string toString() const { return "42"; }
@@ -31,6 +34,17 @@ struct Bar
     int value = 42;
 }
 
+template nestedCheck(T)
+{
+    enum nestedCheck = T.something.init == 0;
+}
+
+struct Constraint (T) if(nestedCheck!T)
+{
+    T value;
+}
+struct Something { deprecated int something; }
+
 void jump2(T) (T value)
 {
     assert(value.toString() == "42");
@@ -45,4 +59,5 @@ void main ()
 {
     jump1(Foo.init);
     jump1(Bar.init);
+    Constraint!Something c1;
 }

--- a/test/fail_compilation/deprecations.d
+++ b/test/fail_compilation/deprecations.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
 fail_compilation/deprecations.d(43): Deprecation: struct `deprecations.S` is deprecated
-fail_compilation/deprecations.d(64): Error: template instance `deprecations.otherPar!()` error instantiating
+fail_compilation/deprecations.d(64):        instantiated from here: `otherPar!()`
 fail_compilation/deprecations.d(55): Deprecation: struct `deprecations.S` is deprecated
 fail_compilation/deprecations.d(65):        instantiated from here: `otherVar!()`
 fail_compilation/deprecations.d(55): Deprecation: struct `deprecations.S` is deprecated

--- a/test/fail_compilation/diag14875.d
+++ b/test/fail_compilation/diag14875.d
@@ -36,11 +36,16 @@ template Baz(T)
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag14875.d(47): Deprecation: class `diag14875.Dep` is deprecated
-fail_compilation/diag14875.d(51): Deprecation: variable `diag14875.depVar` is deprecated
+fail_compilation/diag14875.d(52): Deprecation: class `diag14875.Dep` is deprecated
+fail_compilation/diag14875.d(56): Deprecation: variable `diag14875.depVar` is deprecated
+fail_compilation/diag14875.d(52):        instantiated from here: `Voo!(Dep)`
 4: Dep
-fail_compilation/diag14875.d(58): Deprecation: variable `diag14875.depVar` is deprecated
-fail_compilation/diag14875.d(59): Deprecation: template `diag14875.Vaz(T)` is deprecated
+fail_compilation/diag14875.d(63): Deprecation: variable `diag14875.depVar` is deprecated
+fail_compilation/diag14875.d(59):        instantiated from here: `Var!(Dep)`
+fail_compilation/diag14875.d(52):        instantiated from here: `Voo!(Dep)`
+fail_compilation/diag14875.d(64): Deprecation: template `diag14875.Vaz(T)` is deprecated
+fail_compilation/diag14875.d(59):        instantiated from here: `Var!(Dep)`
+fail_compilation/diag14875.d(52):        instantiated from here: `Voo!(Dep)`
 ---
 */
 
@@ -67,7 +72,7 @@ deprecated template Vaz(T)
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag14875.d(75): Error: static assert:  `0` is false
+fail_compilation/diag14875.d(80): Error: static assert:  `0` is false
 ---
 */
 void main()


### PR DESCRIPTION
```
Before this change, only the deprecation inside the template constraint was shown,
not where the constraint was instantiated from.
The feature is still not perfect, as the source of a constraint instantiation is not
shown, since the parent is actually the module, but that is a more general problem
that needs to be solved on its own.
```

No changelog or issue, since it's a fix for a not-yet-released feature.