### PR TITLE
Remove eager parsing error, move it to semantic

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1664,7 +1664,6 @@ final class Parser(AST) : Lexer
         // Get array of TemplateParameters
         if (flag || token.value != TOK.rightParentheses)
         {
-            int isvariadic = 0;
             while (token.value != TOK.rightParentheses)
             {
                 AST.TemplateParameter tp;
@@ -1746,9 +1745,6 @@ final class Parser(AST) : Lexer
                 else if (token.value == TOK.identifier && tv == TOK.dotDotDot)
                 {
                     // ident...
-                    if (isvariadic)
-                        error("variadic template parameter must be last");
-                    isvariadic = 1;
                     loc = token.loc;
                     tp_ident = token.ident;
                     nextToken();

--- a/test/fail_compilation/fail222.d
+++ b/test/fail_compilation/fail222.d
@@ -1,9 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail222.d(10): Error: template `fail222.getMixin(TArg..., int i = 0)()` template tuple parameter must be last one
-fail_compilation/fail222.d(17): Error: template instance `getMixin!()` does not match template declaration `getMixin(TArg..., int i = 0)()`
-fail_compilation/fail222.d(20): Error: template instance `fail222.Thing!()` error instantiating
+fail_compilation/fail222.d(11): Error: template `fail222.getMixin(TArg..., int i = 0)()` template tuple parameter must be last one
+fail_compilation/fail222.d(18): Error: template instance `getMixin!()` does not match template declaration `getMixin(TArg..., int i = 0)()`
+fail_compilation/fail222.d(21): Error: template instance `fail222.Thing!()` error instantiating
+fail_compilation/fail222.d(23): Error: template `fail222.fooBar(A..., B...)()` template tuple parameter must be last one
 ---
 */
 
@@ -18,3 +19,5 @@ class Thing(TArg...)
 }
 
 public Thing!() stuff;
+
+void fooBar (A..., B...)() {}


### PR DESCRIPTION
This is already checked in semantic, and this special case
only handle the rare case of having two successive variadic
template parameters.

The message will change from:
```
test.d(42): Error: variadic template parameter must be last
```

to:
```
test.d(42): Error: template `test.myTemplate(A..., B...)(A a, B b)` template tuple parameter must be last one
```