### PR TITLE
Fix duplicate function detection for overloads introduced by aliases

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -1200,25 +1200,3 @@ extern (C++) void mangleToBuffer(TemplateInstance ti, OutBuffer* buf)
     scope Mangler v = new Mangler(buf);
     v.mangleTemplateInstance(ti);
 }
-
-/******************************************************************************
- * Mangle function signatures ('this' qualifier, and parameter types)
- * to check conflicts in function overloads.
- * It's different from fd.type.deco. For example, fd.type.deco would be null
- * if fd is an auto function.
- *
- * Params:
- *    buf = `OutBuffer` to write the mangled function signature to
-*     fd  = `FuncDeclaration` to mangle
- */
-void mangleToFuncSignature(ref OutBuffer buf, FuncDeclaration fd)
-{
-    auto tf = fd.type.isTypeFunction();
-
-    scope Mangler v = new Mangler(&buf);
-
-    MODtoDecoBuffer(&buf, tf.mod);
-    foreach (idx, param; tf.parameterList)
-        param.accept(v);
-    buf.writeByte('Z' - tf.parameterList.varargs);
-}

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -7065,6 +7065,12 @@ extern (C++) final class Parameter : ASTNode
     }
 
     extern (D) private static immutable bool[SR.max + 1][SR.max + 1] covariant = covariantInit();
+
+    extern (D) bool opEquals(const Parameter other) const
+    {
+        return this.storageClass == other.storageClass
+            && this.type == other.type;
+    }
 }
 
 /*************************************************************

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -350,8 +350,6 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
     override void visit(FuncDeclaration fd)
     {
-        import dmd.dmangle : mangleToFuncSignature;
-
         if (fd.semanticRun >= PASS.semantic2done)
             return;
         assert(fd.semanticRun <= PASS.semantic2);
@@ -365,14 +363,11 @@ private extern(C++) final class Semantic2Visitor : Visitor
         // void foo();
         if (fd.fbody && fd.overnext && !fd.errors)
         {
-            OutBuffer buf1;
-            OutBuffer buf2;
-
             // Always starts the lookup from 'this', because the conflicts with
             // previous overloads are already reported.
             alias f1 = fd;
             auto tf1 = cast(TypeFunction) f1.type;
-            mangleToFuncSignature(buf1, f1);
+            auto parent1 = f1.toParent2();
 
             overloadApply(f1, (Dsymbol s)
             {
@@ -382,6 +377,20 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
                 // Don't have to check conflict between declaration and definition.
                 if (f2.fbody is null)
+                    return 0;
+
+                // Functions with different manglings can never conflict
+                if (f1.linkage != f2.linkage)
+                    return 0;
+
+                // Functions with different names never conflict
+                // (they can form overloads sets introduced by an alias)
+                if (f1.ident != f2.ident)
+                    return 0;
+
+                // Functions with different parents never conflict
+                // (E.g. when aliasing a free function into a struct)
+                if (parent1 != f2.toParent2())
                     return 0;
 
                 /* Check for overload merging with base class member functions.
@@ -397,46 +406,42 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
                 auto tf2 = cast(TypeFunction) f2.type;
 
-                // extern (C) functions always conflict each other.
-                auto parent1 = f1.toParent2();
-                if (f1.ident == f2.ident &&
-                    parent1 == f2.toParent2() &&
-                    parent1.isModule() &&
-                    (f1.linkage != LINK.d && f1.linkage != LINK.cpp) &&
-                    (f2.linkage != LINK.d && f2.linkage != LINK.cpp) &&
+                // Overloading based on storage classes
+                if (tf1.mod != tf2.mod || ((f1.storage_class ^ f2.storage_class) & STC.static_))
+                    return 0;
 
-                    // But allow the hack to declare overloads with different parameters/STC's
-                    (!tf1.attributesEqual(tf2) || tf1.parameterList != tf2.parameterList))
+                const sameAttr = tf1.attributesEqual(tf2);
+                const sameParams = tf1.parameterList == tf2.parameterList;
+
+                // Allow the hack to declare overloads with different parameters/STC's
+                // @@@DEPRECATED_2.094@@@
+                // Deprecated in 2020-08, make this an error in 2.104
+                if (parent1.isModule() &&
+                    f1.linkage != LINK.d && f1.linkage != LINK.cpp &&
+                    (!sameAttr || !sameParams)
+                )
                 {
-                    // @@@DEPRECATED_2.094@@@
-                    // Deprecated in 2020-08, make this an error in 2.104
                     f2.deprecation("cannot overload `extern(%s)` function at %s",
                             linkageToChars(f1.linkage),
                             f1.loc.toChars());
-
-                    // Enable this when turning the deprecation into an error
-                    // f2.type = Type.terror;
-                    // f2.errors = true;
                     return 0;
                 }
 
-                buf2.reset();
-                mangleToFuncSignature(buf2, f2);
+                // Different parameters don't conflict in extern(C++/D)
+                if (!sameParams)
+                    return 0;
 
-                auto s1 = buf1.peekChars();
-                auto s2 = buf2.peekChars();
+                // Different attributes don't conflict in extern(D)
+                if (!sameAttr && f1.linkage == LINK.d)
+                    return 0;
 
-                //printf("+%s\n\ts1 = %s\n\ts2 = %s @ [%s]\n", toChars(), s1, s2, f2.loc.toChars());
-                if (strcmp(s1, s2) == 0)
-                {
-                    error(f2.loc, "%s `%s%s` conflicts with previous declaration at %s",
-                            f2.kind(),
-                            f2.toPrettyChars(),
-                            parametersTypeToChars(tf2.parameterList),
-                            f1.loc.toChars());
-                    f2.type = Type.terror;
-                    f2.errors = true;
-                }
+                error(f2.loc, "%s `%s%s` conflicts with previous declaration at %s",
+                        f2.kind(),
+                        f2.toPrettyChars(),
+                        parametersTypeToChars(tf2.parameterList),
+                        f1.loc.toChars());
+                f2.type = Type.terror;
+                f2.errors = true;
                 return 0;
             });
         }

--- a/test/fail_compilation/fail2789.d
+++ b/test/fail_compilation/fail2789.d
@@ -4,7 +4,6 @@ https://issues.dlang.org/show_bug.cgi?id=18385
 TEST_OUTPUT:
 ---
 fail_compilation/fail2789.d(15): Error: function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(10)
-fail_compilation/fail2789.d(25): Error: function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(10)
 ---
 */
 #line 7
@@ -26,7 +25,7 @@ class A2789
         return 3.0;
     }
 
-    static void m() // conflict
+    static void m() // no conflict
     {
     }
 }
@@ -35,10 +34,10 @@ class A2789
 TEST_OUTPUT:
 ---
 fail_compilation/fail2789.d(49): Error: function `fail2789.f4()` conflicts with previous declaration at fail_compilation/fail2789.d(48)
-fail_compilation/fail2789.d(52): Error: function `fail2789.f5()` conflicts with previous declaration at fail_compilation/fail2789.d(51)
 fail_compilation/fail2789.d(55): Error: function `fail2789.f6()` conflicts with previous declaration at fail_compilation/fail2789.d(54)
 ---
 */
+
 
 void f1();
 void f1() {}    // ok
@@ -53,7 +52,7 @@ void f4() {}
 void f4() {}    // conflict
 
 void f5() @safe {}
-void f5() @system {}    // conflict
+void f5() @system {}    // no conflict because of attribute based overloading in in extern(D)
 
 auto f6() { return 10; }    // int()
 auto f6() { return ""; }    // string(), conflict
@@ -64,9 +63,9 @@ TEST_OUTPUT:
 fail_compilation/fail2789.d(67): Error: function `fail2789.f_ExternC1()` conflicts with previous declaration at fail_compilation/fail2789.d(66)
 fail_compilation/fail2789.d(70): Deprecation: function `fail2789.f_ExternC2` cannot overload `extern(C)` function at fail_compilation/fail2789.d(69)
 fail_compilation/fail2789.d(73): Deprecation: function `fail2789.f_ExternC3` cannot overload `extern(C)` function at fail_compilation/fail2789.d(72)
-fail_compilation/fail2789.d(76): Error: function `fail2789.f_MixExtern1()` conflicts with previous declaration at fail_compilation/fail2789.d(75)
 ---
 */
+
 extern(C) void f_ExternC1() {}
 extern(C) void f_ExternC1() {}      // conflict
 
@@ -77,7 +76,7 @@ extern(C) void f_ExternC3(int) {}
 extern(C) void f_ExternC3() {}      // conflict
 
 extern (D) void f_MixExtern1() {}
-extern (C) void f_MixExtern1() {}   // conflict
+extern (C) void f_MixExtern1() {}   // no conflict because of different mangling
 
 extern (D) void f_MixExtern2(int) {}
 extern (C) void f_MixExtern2() {}   // no error

--- a/test/fail_compilation/test18385b.d
+++ b/test/fail_compilation/test18385b.d
@@ -1,0 +1,47 @@
+/*
+Previous implementation raised errors for overloads using alias declarations
+because they ignored the actual function name
+
+TEST_OUTPUT:
+---
+fail_compilation/test18385b.d(13): Error: `test18385b.S.foo` called with argument types `(int)` matches both:
+fail_compilation/test18385b.d(8):     `test18385b.S.foo(int s)`
+and:
+fail_compilation/test18385b.d(3):     `test18385b.foo(int s)`
+fail_compilation/test18385b.d(102): Error: `test18385b.bar` called with argument types `(int)` matches both:
+fail_compilation/test18385b.d(2):     `test18385b.bar(int s)`
+and:
+fail_compilation/test18385b.d(3):     `test18385b.foo(int s)`
+---
+*/
+#line 1
+
+void bar(int s) {}
+void foo(int s) {}
+alias bar = foo;
+
+struct S
+{
+	void foo(int s) {}
+	alias foo = bar;
+
+	void useEm()
+	{
+		foo(1);
+	}
+}
+
+// False positive in mutex.d when building druntime
+class Mutex
+{
+	this() {}
+	this() shared {}
+	this(Object obj) {}
+}
+
+#line 100
+void main()
+{
+	bar(0);
+	new Mutex();
+}


### PR DESCRIPTION
    The previous implementation compared small parts of the function mangling
    to detect duplicate functions. This approach had several flaws manifesting
    in the referenced issue as well as other false positives for (static)
    members, `alias`ing into different scopes, ... .

    Issue 21505 was caused by the assumption that all functions visited by
    `overloadApply` have the same name. This doesn't hold for overloads
    introduced by an `alias`.

    A reliable mangling-based implementation would need to compare most of
    the mangled name while also omitting severel aspects e.g. the return type
    to detect `int foo()` and `void foo()`.

    Hence the current implementation was replaced by actually comparing the
    `FuncDeclaration`s because it allows for more fine grained checks (and
    also should save some memory allocations).

---

Added [the intial report](https://github.com/dlang/dmd/pull/8429#issuecomment-749815607) as a bugzilla reference