### PR TITLE
 Fix duplicate function detection for extern(C) member funtions 

### DIFF
--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -398,8 +398,10 @@ private extern(C++) final class Semantic2Visitor : Visitor
                 auto tf2 = cast(TypeFunction) f2.type;
 
                 // extern (C) functions always conflict each other.
+                auto parent1 = f1.toParent2();
                 if (f1.ident == f2.ident &&
-                    f1.toParent2() == f2.toParent2() &&
+                    parent1 == f2.toParent2() &&
+                    parent1.isModule() &&
                     (f1.linkage != LINK.d && f1.linkage != LINK.cpp) &&
                     (f2.linkage != LINK.d && f2.linkage != LINK.cpp) &&
 

--- a/test/compilable/test18385b.d
+++ b/test/compilable/test18385b.d
@@ -1,0 +1,29 @@
+/*
+Previous implementation raised errors because it was not
+aware of the special treatment for extern(C) member funtions:
+
+Member functions receive D name mangling...
+Some arguments in favour of this inconsistencies
+- static => useful for callbacks
+- non-static => doesn't exists in C anyways
+*/
+
+extern(C) struct ExternC
+{
+	void foo() {}
+	void foo(int) {}
+
+	static void bar() {}
+	static void bar(int) {}
+}
+
+#line 100
+void main()
+{
+	ExternC.bar();
+	ExternC.bar(1);
+
+	ExternC c;
+	c.foo();
+	c.foo(1);
+}

--- a/test/fail_compilation/test18385.d
+++ b/test/fail_compilation/test18385.d
@@ -3,9 +3,9 @@ REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
 fail_compilation/test18385.d(13): Deprecation: function `test18385.foo` cannot overload `extern(C)` function at fail_compilation/test18385.d(12)
-fail_compilation/test18385.d(18): Deprecation: function `test18385.S.foo` cannot overload `extern(C)` function at fail_compilation/test18385.d(17)
 ---
 */
+
 
 extern (C):
 


### PR DESCRIPTION
`extern(C)` member functions are mangled as `extern(D)` (while still following `C` ABI) because it's deemed more useful for callbacks, etc).

The previous implementation didn't consider this special case and always issued a deprecation message even though there would be no error once the deprecation ends (because the mangling is actually different).

This commit ensures that the deprecation is only issued for non-member functions.