### PR TITLE
Fix 21472 - Support tuple comparison with `-checkaction=context` (2/2)

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6158,7 +6158,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 isEqualsCallExpression)
             {
                 es = new Expressions(3);
-                tiargs = new Objects(2);
+                tiargs = new Objects(1);
 
                 if (isEqualsCallExpression)
                 {
@@ -6198,7 +6198,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 comp = comp.expressionSemantic(sc);
                 (*es)[0] = comp;
                 (*tiargs)[0] = (*es)[1].type;
-                (*tiargs)[1] = (*es)[2].type;
             }
 
             // Format exp.e1 before any additional boolean conversion

--- a/test/runnable/testassert.d
+++ b/test/runnable/testassert.d
@@ -267,6 +267,37 @@ void testAssignments()
     assert(getMessage(assert(--c())) == "0 != true");
 }
 
+/// https://issues.dlang.org/show_bug.cgi?id=21472
+void testTupleFormat()
+{
+    alias AliasSeq(T...) = T;
+
+    // Default usage
+    {
+        alias a = AliasSeq!(1, "ab");
+        alias b = AliasSeq!(false, "xyz");
+        assert(getMessage(assert(a == b)) == `(1, "ab") != (false, "xyz")`);
+    }
+
+    // Single elements work but are not formatted as tuples
+    // Is this acceptable? (a workaround would probably require a
+    // different name for the tuple formatting hook)
+    {
+        alias a = AliasSeq!(1, "ab", []);
+        alias b = AliasSeq!(false, "xyz", [1]);
+        assert(getMessage(assert(a == b)) == `(1, "ab", []) != (false, "xyz", [1])`);
+    }
+
+    // Also works with tupleof (as taken from the bug report)
+    {
+        static struct Var { int a, b; }
+        const a = Var(1, 2);
+        const b = Var(3, 4);
+        const msg = getMessage(assert(a.tupleof == b.tupleof));
+        assert(msg == `(1, 2) != (3, 4)`);
+    }
+}
+
 void main()
 {
     test8765();
@@ -277,4 +308,5 @@ void main()
     testMixinExpression();
     testUnaryFormat();
     testAssignments();
+    testTupleFormat();
 }


### PR DESCRIPTION
Detect `TupleExp` used inside the `assert` and redirect them to a new variadic hook in druntime (see dlang/druntime#3318).

Example:
```d
alias a = AliasSeq!(...);
alias b = AliasSeq!(...);
assert(a == b);
```

This assertion will call:
```d
_d_assert_fail_tuple!(typeof(a))(("==", a, b);
```