### PR TITLE
dinterpret.d: eliminate many casts

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1785,6 +1785,7 @@ extern (C++) abstract class Expression : ASTNode
         inout(FuncInitExp)       isFuncInitExp() { return op == TOK.functionString ? cast(typeof(return))this : null; }
         inout(PrettyFuncInitExp) isPrettyFuncInitExp() { return op == TOK.prettyFunction ? cast(typeof(return))this : null; }
         inout(ClassReferenceExp) isClassReferenceExp() { return op == TOK.classReference ? cast(typeof(return))this : null; }
+        inout(ThrownExceptionExp) isThrownExceptionExp() { return op == TOK.thrownException ? cast(typeof(return))this : null; }
     }
 
     override void accept(Visitor v)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -593,6 +593,7 @@ class ModuleInitExp;
 class FuncInitExp;
 class PrettyFuncInitExp;
 class ClassReferenceExp;
+class ThrownExceptionExp;
 class TypeInfoClassDeclaration;
 struct ObjcClassDeclaration;
 class TypeFunction;
@@ -709,7 +710,6 @@ class DtorExpStatement;
 class ForwardingStatement;
 class ErrorInitializer;
 class ObjcClassReferenceExp;
-class ThrownExceptionExp;
 struct ASTCodegen;
 union __AnonStruct__u;
 struct ObjcFuncDeclaration;
@@ -1129,6 +1129,7 @@ public:
     FuncInitExp* isFuncInitExp();
     PrettyFuncInitExp* isPrettyFuncInitExp();
     ClassReferenceExp* isClassReferenceExp();
+    ThrownExceptionExp* isThrownExceptionExp();
     void accept(Visitor* v);
 };
 


### PR DESCRIPTION
The result is easier to read and more robust.