### PR TITLE
Fix null pointer dereference in hdrgen

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2259,21 +2259,26 @@ public:
         // are used for other constructs
         auto vd = ve.var.isVarDeclaration();
         assert(vd && vd._init);
-        auto exp = vd._init.isExpInitializer.exp;
-        assert(exp);
-        Expression commaExtract;
-        if (auto ce = exp.isConstructExp())
-            commaExtract = ce.e2;
-        else if (auto se = exp.isStructLiteralExp)
-            commaExtract = se;
+
+        if (auto ei = vd._init.isExpInitializer())
+        {
+            Expression commaExtract;
+            auto exp = ei.exp;
+            if (auto ce = exp.isConstructExp())
+                commaExtract = ce.e2;
+            else if (auto se = exp.isStructLiteralExp())
+                commaExtract = se;
+
+            if (commaExtract)
+            {
+                expToBuffer(commaExtract, precedence[exp.op], buf, hgs);
+                return;
+            }
+        }
 
         // not one of the known cases, go on the old path
-        if (!commaExtract)
-        {
-            visit(cast(BinExp)e);
-            return;
-        }
-        expToBuffer(commaExtract, precedence[exp.op], buf, hgs);
+        visit(cast(BinExp)e);
+        return;
     }
 
     override void visit(MixinExp e)


### PR DESCRIPTION
The code assumed that the initializer of a variable would
always be an expression; that however is not true.
Therefore we now check if that is the case before executing
code which relies on it.

I know this has no testcase.
This condition needs an awful lot of gnarly code to occur, which I have not been able to minimize.