### PR TITLE
Remove complex and imaginary types from language in Edition v2024

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -79,6 +79,14 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         this.doUnittests = doUnittests;
     }
 
+    /******************
+     * Language edition that is in force
+     */
+    override bool hasEdition(Edition edition) const pure @nogc @safe
+    {
+        return this.mod && this.mod.edition >= edition;
+    }
+
     /++
      + Parse a module, i.e. the optional `module x.y.z` declaration and all declarations
      + found in the current file.

--- a/compiler/test/compilable/edition_complex.d
+++ b/compiler/test/compilable/edition_complex.d
@@ -1,0 +1,23 @@
+@__edition_latest_do_not_use
+module edition_complex;
+
+struct cfloat
+{
+    float re;
+    ifloat im;
+}
+alias ifloat = float;
+
+struct cdouble
+{
+    double re;
+    idouble im;
+}
+alias idouble = double;
+
+struct creal
+{
+    real re;
+    ireal im;
+}
+alias ireal = real;

--- a/compiler/test/compilable/edition_complex2.d
+++ b/compiler/test/compilable/edition_complex2.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -edition=2024
+struct _Complex
+{
+    double re = 0;
+    double im = 0;
+}
+
+enum __c_complex_double : _Complex;
+alias complex = __c_complex_double;
+
+double creal(complex z)
+{
+    return z.re;
+}

--- a/compiler/test/fail_compilation/edition_complex.d
+++ b/compiler/test/fail_compilation/edition_complex.d
@@ -1,0 +1,23 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/edition_complex.d(17): Error: undefined identifier `ifloat`
+fail_compilation/edition_complex.d(18): Error: undefined identifier `cfloat`
+fail_compilation/edition_complex.d(19): Error: undefined identifier `idouble`
+fail_compilation/edition_complex.d(20): Error: undefined identifier `cdouble`
+fail_compilation/edition_complex.d(21): Error: undefined identifier `ireal`
+fail_compilation/edition_complex.d(22): Error: undefined identifier `creal`
+---
+ */
+@__edition_latest_do_not_use
+module edition_complex;
+
+void main()
+{
+    ifloat fi;
+    cfloat fc;
+    idouble di;
+    cdouble dc;
+    ireal ri;
+    creal rc;
+}

--- a/compiler/test/fail_compilation/edition_complex2.d
+++ b/compiler/test/fail_compilation/edition_complex2.d
@@ -1,0 +1,13 @@
+/*
+REQUIRED_ARGS: -edition=2024
+TEST_OUTPUT:
+---
+fail_compilation/edition_complex2.d(11): Error: semicolon expected following auto declaration, not `i`
+fail_compilation/edition_complex2.d(12): Error: semicolon expected following auto declaration, not `i`
+---
+ */
+void main()
+{
+    auto cv = 1.0+0.0i;
+    auto iv = 1.0i;
+}


### PR DESCRIPTION
Add `-preview=complex`, an option that removes `cfloat`, `cdouble`, and `creal` from the D language.

For C/C++ compatibility, new special enums have been added - and will likely be used for a `std.complex.Complex!(T).toNative()` function.

Example implementation:
```d
// ABI layout of native complex
struct _Complex(T) { T re; T im; }

// Special enum definitions.
version (Posix)
{
    align(float.alignof)  enum __c_complex_float : _Complex!float;
    align(double.alignof) enum __c_complex_double : _Complex!double;
    align(real.alignof)   enum __c_complex_long_double : _Complex!real;
}
else
{
    align(float.sizeof * 2)  enum __c_complex_float : _Complex!float;
    align(double.sizeof * 2) enum __c_complex_double : _Complex!double;
    align(real.alignof)      enum __c_complex_long_double : _Complex!real;
}

// Backwards compatibility aliases
alias cfloat = __c_complex_float;
alias ifloat = float;
alias cdouble = __c_complex_double;
alias idouble = double;
alias creal = __c_complex_long_double;
alias ireal = real;

// Test can still call extern C++ functions.
extern(C++) creal cadd1(creal a);

int main()
{
    creal a = creal(1, 0);
    auto b = cadd1(a);
    version (DigitalMars)  // ??? DMD bug with native complex numbers.
        assert(b.re == 0 && b.im == 2);
    else
        assert(b.re == 2 && b.im == 0);
    return 0;
}
```