### PR TITLE
fix Issue 21514 - [ICE] cod1.d:4015: Assertion `retregs || !*pretregs' failed with -m32

### DIFF
--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -713,7 +713,7 @@ extern (C++) struct Target
             return true;
         }
         else if (params.targetOS & TargetOS.Posix &&
-                 tf.linkage == LINK.c &&
+                 (tf.linkage == LINK.c || tf.linkage == LINK.cpp) &&
                  tns.iscomplex())
         {
             if (tns.ty == Tcomplex32)

--- a/test/compilable/test21514.d
+++ b/test/compilable/test21514.d
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=21514
+// DISABLED: win32 win64
+
+extern(C++) cdouble cpp_cadd1(cdouble c) { return c + 1; }
+extern(C++) creal cpp_cadd1l(creal c) { return c + 1; }
+
+cdouble cadd1(cdouble c) { return cpp_cadd1(c); }
+creal cadd1(creal c) { return cpp_cadd1l(c); }


### PR DESCRIPTION
Both extern(C) and extern(C++) return complex types in the same way.