### PR TITLE
fix Issue 21515 extern(C) and extern(C++) returns creal in wrong order

### DIFF
--- a/changelog/abi-fix-creal.dd
+++ b/changelog/abi-fix-creal.dd
@@ -1,0 +1,7 @@
+D ABI change on x86_64 Posix targets
+
+The compiler has been updated to return the real part of `creal` numbers in
+ST0, and the imaginary part in ST1, to match the x86_64 System V ABI.
+
+This is an ABI breaking change and requires recompiling libraries that make use
+of the `creal` type.

--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -771,7 +771,7 @@ ubyte loadconst(elem *e, int im)
  */
 
 
-void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs)
+void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs, bool isReturnValue = false)
 {
     //printf("fixresult87(e = %p, retregs = x%x, *pretregs = x%x)\n", e,retregs,*pretregs);
     //printf("fixresult87(e = %p, retregs = %s, *pretregs = %s)\n", e,regm_str(retregs),regm_str(*pretregs));
@@ -779,7 +779,7 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs)
 
     if ((*pretregs | retregs) & mST01)
     {
-        fixresult_complex87(cdb, e, retregs, pretregs);
+        fixresult_complex87(cdb, e, retregs, pretregs, isReturnValue);
         return;
     }
 
@@ -3604,7 +3604,7 @@ private void genctst(ref CodeBuilder cdb,elem *e,int pop)
  */
 
 
-void fixresult_complex87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs)
+void fixresult_complex87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs, bool isReturnValue = false)
 {
     static if (0)
     {
@@ -3615,6 +3615,17 @@ void fixresult_complex87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pret
     assert(!*pretregs || retregs);
     tym_t tym = tybasic(e.Ety);
     uint sz = _tysize[tym];
+
+    if (isReturnValue)
+    {
+        // In loadComplex and complex_eq87, complex numbers have the real part
+        // pushed to the FPU stack first (ST1), then the imaginary part (ST0).
+        // However, the Intel 64 bit ABI scheme requires that types classified
+        // as complex x87 instead have the real part returned in ST0, and the
+        // imaginary part in ST1.
+        if (retregs == mST01 && I64 && (config.exe & EX_posix))
+            cdb.genf2(0xD9, 0xC8 + 1);          // FXCH ST(1)
+    }
 
     if (*pretregs == 0 && retregs == mST01)
     {

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -4082,7 +4082,7 @@ static if (0)
             assert(global87.stackused == 0);
             push87(cdb);
             push87(cdb);                // two items on 8087 stack
-            fixresult_complex87(cdb, e, retregs, pretregs);
+            fixresult_complex87(cdb, e, retregs, pretregs, true);
             return;
         }
         else

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -1175,6 +1175,8 @@ static if (NTEXCEPTIONS)
             else if ((mask(reg1) | mask(reg2)) & (mST0 | mST01))
             {
                 assert(reg1 == lreg && reg2 == NOREG);
+                regm_t pretregs = mask(reg1) | mask(reg2);
+                fixresult87(cdb, e, retregs, &pretregs, true);
             }
             // fix return registers
             else if (tybasic(e.Ety) == TYcfloat)
@@ -1207,7 +1209,7 @@ static if (NTEXCEPTIONS)
                 {
                     assert(reg1 == AX && reg2 == DX);
                     regm_t pretregs = mask(reg1) | mask(reg2);
-                    fixresult_complex87(cdb, e, retregs, &pretregs);
+                    fixresult_complex87(cdb, e, retregs, &pretregs, true);
                 }
             }
             else if (reg2 == NOREG)

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -630,8 +630,8 @@ void gensaverestore87(regm_t, ref CodeBuilder cdbsave, ref CodeBuilder cdbrestor
 //code *genfltreg(code *c,opcode_t opcode,uint reg,targ_size_t offset);
 void genfwait(ref CodeBuilder cdb);
 void comsub87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void fixresult87(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs);
-void fixresult_complex87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs);
+void fixresult87(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs, bool isReturnValue = false);
+void fixresult_complex87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs, bool isReturnValue = false);
 void orth87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void load87(ref CodeBuilder cdb, elem *e, uint eoffset, regm_t *pretregs, elem *eleft, int op);
 int cmporder87 (elem *e );

--- a/test/runnable/test21515.d
+++ b/test/runnable/test21515.d
@@ -1,0 +1,60 @@
+// https://issues.dlang.org/show_bug.cgi?id=21515
+// DISABLED: win32 win64
+extern(D) cfloat  dcomplexf() { return 2.0f+1.0i; }
+extern(D) cdouble dcomplex()  { return 2.0+1.0i; }
+extern(D) creal   dcomplexl() { return 2.0L+1.0Li; }
+
+extern(D) void dcomplexf(cfloat c) { assert(c.re == 2 && c.im == 1); }
+extern(D) void dcomplex(cdouble c) { assert(c.re == 2 && c.im == 1); }
+extern(D) void dcomplexl(creal c)  { assert(c.re == 2 && c.im == 1); }
+
+extern(C) cfloat  ccomplexf() { return 2.0f+1.0fi; }
+extern(C) cdouble ccomplex()  { return 2.0+1.0i; }
+extern(C) creal   ccomplexl() { return 2.0L+1.0Li; }
+
+extern(C) void ccomplexf2(cfloat c) { assert(c.re == 2 && c.im == 1); }
+extern(C) void ccomplex2(cdouble c) { assert(c.re == 2 && c.im == 1); }
+extern(C) void ccomplexl2(creal c)  { assert(c.re == 2 && c.im == 1); }
+
+extern(C++) cfloat  cpcomplexf() { return 2.0f+1.0fi; }
+extern(C++) cdouble cpcomplex()  { return 2.0+1.0i; }
+extern(C++) creal   cpcomplexl() { return 2.0L+1.0Li; }
+
+extern(C++) void cpcomplexf(cfloat c) { assert(c.re == 2 && c.im == 1); }
+extern(C++) void cpcomplex(cdouble c) { assert(c.re == 2 && c.im == 1); }
+extern(C++) void cpcomplexl(creal c)  { assert(c.re == 2 && c.im == 1); }
+
+int main()
+{
+    auto a1 = dcomplexf();
+    auto b1 = dcomplex();
+    auto c1 = dcomplexl();
+    assert(a1.re == 2 && a1.im == 1);
+    assert(b1.re == 2 && b1.im == 1);
+    assert(c1.re == 2 && c1.im == 1);
+    dcomplexf(a1);
+    dcomplex(b1);
+    dcomplexl(c1);
+
+    auto a2 = ccomplexf();
+    auto b2 = ccomplex();
+    auto c2 = ccomplexl();
+    assert(a2.re == 2 && a2.im == 1);
+    assert(b2.re == 2 && b2.im == 1);
+    assert(c2.re == 2 && c2.im == 1);
+    ccomplexf2(a2);
+    ccomplex2(b2);
+    ccomplexl2(c2);
+
+    auto a3 = cpcomplexf();
+    auto b3 = cpcomplex();
+    auto c3 = cpcomplexl();
+    assert(a3.re == 2 && a3.im == 1);
+    assert(b3.re == 2 && b3.im == 1);
+    assert(c3.re == 2 && c3.im == 1);
+    cpcomplexf(a3);
+    cpcomplex(b3);
+    cpcomplexl(c3);
+
+    return 0;
+}

--- a/test/runnable_cxx/extra-files/test21515.cpp
+++ b/test/runnable_cxx/extra-files/test21515.cpp
@@ -1,0 +1,82 @@
+#include <assert.h>
+#include <complex.h>
+
+// Use custom types for inspecting parts instead of including tgmath.h
+union cfloat_t { _Complex float z; struct { float re; float im; }; };
+union cdouble_t { _Complex double z; struct { double re; double im; }; };
+union creal_t { _Complex long double z; struct { long double re; long double im; }; };
+
+// extern(C) tests
+extern "C" _Complex float ccomplexf() { return 2.0f+I; }
+extern "C" _Complex double ccomplex() { return 2.0+I; }
+extern "C" _Complex long double ccomplexl() { return 2.0L+I; }
+extern "C" void ccomplexf2(_Complex float c) { cfloat_t z = {c}; assert(z.re == 2 && z.im == 1); }
+extern "C" void ccomplex2(_Complex double c) { cdouble_t z = {c}; assert(z.re == 2 && z.im == 1); }
+extern "C" void ccomplexl2(_Complex long double c) { creal_t z = {c}; assert(z.re == 2 && z.im == 1); }
+
+// extern(C++) tests
+_Complex float cpcomplexf() { return 2.0f+I; }
+_Complex double cpcomplex() { return 2.0+I; }
+_Complex long double cpcomplexl() { return 2.0L+I; }
+void cpcomplexf(_Complex float c) { cfloat_t z = {c}; assert(z.re == 2 && z.im == 1); }
+void cpcomplex(_Complex double c) { cdouble_t z = {c}; assert(z.re == 2 && z.im == 1); }
+void cpcomplexl(_Complex long double c) { creal_t z = {c}; assert(z.re == 2 && z.im == 1); }
+
+// Struct tests
+struct wrap_complexf { _Complex float c; };
+struct wrap_complex { _Complex double c; };
+struct wrap_complexl { _Complex long double c; };
+
+wrap_complexf wcomplexf()
+{
+    wrap_complexf s;
+    s.c = 2.0f+I;
+    return s;
+}
+
+wrap_complex wcomplex()
+{
+    wrap_complex s;
+    s.c = 2.0+I;
+    return s;
+}
+
+wrap_complexl wcomplexl()
+{
+    wrap_complexl s;
+    s.c = 2.0L+I;
+    return s;
+}
+
+void wcomplexf(wrap_complexf s) { cfloat_t z = {s.c}; assert(z.re == 2 && z.im == 1); }
+void wcomplex(wrap_complex s)   { cdouble_t z = {s.c}; assert(z.re == 2 && z.im == 1); }
+void wcomplexl(wrap_complexl s) { creal_t z = {s.c}; assert(z.re == 2 && z.im == 1); }
+
+struct soft_complexf { float re; float im; };
+struct soft_complex { double re; double im; };
+struct soft_complexl { long double re; long double im; };
+
+soft_complexf scomplexf()
+{
+    soft_complexf s;
+    s.re = 2.0f; s.im = 1.0f;
+    return s;
+}
+
+soft_complex scomplex()
+{
+    soft_complex s;
+    s.re = 2.0; s.im = 1.0;
+    return s;
+}
+
+soft_complexl scomplexl()
+{
+    soft_complexl s;
+    s.re = 2.0L; s.im = 1.0L;
+    return s;
+}
+
+void scomplexf(soft_complexf s) { assert(s.re == 2 && s.im == 1); }
+void scomplex(soft_complex s)   { assert(s.re == 2 && s.im == 1); }
+void scomplexl(soft_complexl s) { assert(s.re == 2 && s.im == 1); }

--- a/test/runnable_cxx/test21515.d
+++ b/test/runnable_cxx/test21515.d
@@ -1,0 +1,83 @@
+// https://issues.dlang.org/show_bug.cgi?id=21515
+// EXTRA_CPP_SOURCES: test21515.cpp
+// DISABLED: win32 win64
+extern(C) cfloat  ccomplexf();
+extern(C) cdouble ccomplex();
+extern(C) creal   ccomplexl();
+extern(C) void    ccomplexf2(cfloat c);
+extern(C) void    ccomplex2(cdouble c);
+extern(C) void    ccomplexl2(creal c);
+
+extern(C++) cfloat  cpcomplexf();
+extern(C++) cdouble cpcomplex();
+extern(C++) creal   cpcomplexl();
+extern(C++) void    cpcomplexf(cfloat c);
+extern(C++) void    cpcomplex(cdouble c);
+extern(C++) void    cpcomplexl(creal c);
+
+struct wrap_complexf { cfloat c; alias c this; };
+struct wrap_complex  { cdouble c; alias c this; };
+struct wrap_complexl { creal c; alias c this; };
+
+extern(C++) wrap_complexf wcomplexf();
+extern(C++) wrap_complex  wcomplex();
+extern(C++) wrap_complexl wcomplexl();
+extern(C++) void          wcomplexf(wrap_complexf c);
+extern(C++) void          wcomplex(wrap_complex c);
+extern(C++) void          wcomplexl(wrap_complexl c);
+
+struct soft_complexf { float re; float im; };
+struct soft_complex  { double re; double im; };
+struct soft_complexl { real re; real im; };
+
+extern(C++) soft_complexf scomplexf();
+extern(C++) soft_complex  scomplex();
+extern(C++) soft_complexl scomplexl();
+extern(C++) void          scomplexf(soft_complexf c);
+extern(C++) void          scomplex(soft_complex c);
+extern(C++) void          scomplexl(soft_complexl c);
+
+int main()
+{
+    auto a1 = ccomplexf();
+    auto b1 = ccomplex();
+    auto c1 = ccomplexl();
+    assert(a1.re == 2 && a1.im == 1);
+    assert(b1.re == 2 && b1.im == 1);
+    assert(c1.re == 2 && c1.im == 1);
+    ccomplexf2(a1);
+    ccomplex2(b1);
+    ccomplexl2(c1);
+
+    auto a2 = cpcomplexf();
+    auto b2 = cpcomplex();
+    auto c2 = cpcomplexl();
+    assert(a2.re == 2 && a2.im == 1);
+    assert(b2.re == 2 && b2.im == 1);
+    assert(c2.re == 2 && c2.im == 1);
+    cpcomplexf(a2);
+    cpcomplex(b2);
+    cpcomplexl(c2);
+
+    auto a3 = wcomplexf();
+    auto b3 = wcomplex();
+    auto c3 = wcomplexl();
+    assert(a3.re == 2 && a3.im == 1);
+    assert(b3.re == 2 && b3.im == 1);
+    assert(c3.re == 2 && c3.im == 1);
+    wcomplexf(a3);
+    wcomplex(b3);
+    wcomplexl(c3);
+
+    auto a4 = scomplexf();
+    auto b4 = scomplex();
+    auto c4 = scomplexl();
+    assert(a4.re == 2 && a4.im == 1);
+    assert(b4.re == 2 && b4.im == 1);
+    assert(c4.re == 2 && c4.im == 1);
+    scomplexf(a4);
+    scomplex(b4);
+    scomplexl(c4);
+
+    return 0;
+}


### PR DESCRIPTION
@WalterBright this works when the `extern(C)` or `extern(C++)` function is external.
i.e:
```D
extern(C++) creal cpp_twol();

extern(C) int main()
{
    auto a = cpp_twol();
    assert(a.re == 2 && a.im == 0);
    auto b = a;
    assert(b.re == 2 && b.im == 0);
    return 0;
}
```

But fails when the function is implemented in D.
```D
extern(C++) creal cpp_twol() { return 2+0Li; }

extern(C) int main()
{
    auto a = cpp_twol();
    assert(a.re == 2 && a.im == 0);
    auto b = a;
    assert(b.re == 2 && b.im == 0);
    return 0;
}
```
Is this enough of a hint to do the fix proper?
