### PR TITLE
Use covariant return type for `syntaxCopy`

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -183,7 +183,7 @@ public:
     TypeTuple *argTypes;
 
     static StructDeclaration *create(Loc loc, Identifier *id, bool inObject);
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    StructDeclaration *syntaxCopy(Dsymbol *s);
     void semanticTypeInfoMembers();
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
     const char *kind() const;
@@ -201,7 +201,7 @@ public:
 class UnionDeclaration : public StructDeclaration
 {
 public:
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    UnionDeclaration *syntaxCopy(Dsymbol *s);
     const char *kind() const;
 
     UnionDeclaration *isUnionDeclaration() { return this; }
@@ -277,7 +277,7 @@ public:
     Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
     static ClassDeclaration *create(Loc loc, Identifier *id, BaseClasses *baseclasses, Dsymbols *members, bool inObject);
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    ClassDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     bool isBaseOf2(ClassDeclaration *cd);
 
@@ -314,7 +314,7 @@ public:
 class InterfaceDeclaration : public ClassDeclaration
 {
 public:
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    InterfaceDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     bool isBaseOf(ClassDeclaration *cd, int *poffset);
     bool isBaseOf(BaseClass *bc, int *poffset);

--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -43,7 +43,7 @@ extern (C++) final class AliasThis : Dsymbol
         this.ident = ident;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override AliasThis syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto at = new AliasThis(loc, ident);

--- a/src/dmd/aliasthis.h
+++ b/src/dmd/aliasthis.h
@@ -23,7 +23,7 @@ public:
     Dsymbol    *sym;
     bool       isDeprecated_;
 
-    Dsymbol *syntaxCopy(Dsymbol *);
+    AliasThis *syntaxCopy(Dsymbol *);
     const char *kind() const;
     AliasThis *isAliasThis() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -231,7 +231,7 @@ extern (C++) class StorageClassDeclaration : AttribDeclaration
         this.stc = stc;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override StorageClassDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new StorageClassDeclaration(stc, Dsymbol.arraySyntaxCopy(decl));
@@ -344,7 +344,7 @@ extern (C++) final class DeprecatedDeclaration : StorageClassDeclaration
         this.msg = msg;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override DeprecatedDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new DeprecatedDeclaration(msg.syntaxCopy(), Dsymbol.arraySyntaxCopy(decl));
@@ -405,7 +405,7 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
         return new LinkDeclaration(p, decl);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override LinkDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new LinkDeclaration(linkage, Dsymbol.arraySyntaxCopy(decl));
@@ -452,7 +452,7 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
         this.cppmangle = cppmangle;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override CPPMangleDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new CPPMangleDeclaration(cppmangle, Dsymbol.arraySyntaxCopy(decl));
@@ -536,7 +536,7 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
         this.cppnamespace = parent;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override CPPNamespaceDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new CPPNamespaceDeclaration(
@@ -616,7 +616,7 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
         }
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override ProtDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         if (protection.kind == Prot.Kind.package_)
@@ -709,7 +709,7 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
         this.ealign = ealign;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override AlignDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new AlignDeclaration(loc,
@@ -745,7 +745,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
         this.isunion = isunion;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override AnonDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new AnonDeclaration(loc, isunion, Dsymbol.arraySyntaxCopy(decl));
@@ -865,7 +865,7 @@ extern (C++) final class PragmaDeclaration : AttribDeclaration
         this.args = args;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override PragmaDeclaration syntaxCopy(Dsymbol s)
     {
         //printf("PragmaDeclaration::syntaxCopy(%s)\n", toChars());
         assert(!s);
@@ -953,7 +953,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
         this.elsedecl = elsedecl;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override ConditionalDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new ConditionalDeclaration(loc, condition.syntaxCopy(), Dsymbol.arraySyntaxCopy(decl), Dsymbol.arraySyntaxCopy(elsedecl));
@@ -1029,7 +1029,7 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
         //printf("StaticIfDeclaration::StaticIfDeclaration()\n");
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override StaticIfDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new StaticIfDeclaration(loc, condition.syntaxCopy(), Dsymbol.arraySyntaxCopy(decl), Dsymbol.arraySyntaxCopy(elsedecl));
@@ -1138,7 +1138,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
         this.sfe = sfe;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override StaticForeachDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new StaticForeachDeclaration(
@@ -1317,7 +1317,7 @@ extern (C++) final class CompileDeclaration : AttribDeclaration
         this.exps = exps;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override CompileDeclaration syntaxCopy(Dsymbol s)
     {
         //printf("CompileDeclaration::syntaxCopy('%s')\n", toChars());
         return new CompileDeclaration(loc, Expression.arraySyntaxCopy(exps));
@@ -1365,7 +1365,7 @@ extern (C++) final class UserAttributeDeclaration : AttribDeclaration
         this.atts = atts;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override UserAttributeDeclaration syntaxCopy(Dsymbol s)
     {
         //printf("UserAttributeDeclaration::syntaxCopy('%s')\n", toChars());
         assert(!s);

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -47,7 +47,7 @@ class StorageClassDeclaration : public AttribDeclaration
 public:
     StorageClass stc;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    StorageClassDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     void addMember(Scope *sc, ScopeDsymbol *sds);
@@ -62,7 +62,7 @@ public:
     Expression *msg;
     const char *msgstr;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    DeprecatedDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void setScope(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
@@ -74,7 +74,7 @@ public:
     LINK linkage;
 
     static LinkDeclaration *create(LINK p, Dsymbols *decl);
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    LinkDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     const char *toChars() const;
     void accept(Visitor *v) { v->visit(this); }
@@ -85,7 +85,7 @@ class CPPMangleDeclaration : public AttribDeclaration
 public:
     CPPMANGLE cppmangle;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    CPPMangleDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void setScope(Scope *sc);
     const char *toChars() const;
@@ -97,7 +97,7 @@ class CPPNamespaceDeclaration : public AttribDeclaration
 public:
     Expression *exp;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    CPPNamespaceDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     const char *toChars() const;
     void accept(Visitor *v) { v->visit(this); }
@@ -109,7 +109,7 @@ public:
     Prot protection;
     Identifiers* pkg_identifiers;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    ProtDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     const char *kind() const;
@@ -125,7 +125,7 @@ public:
     structalign_t salign;
 
     AlignDeclaration(const Loc &loc, Expression *ealign, Dsymbols *decl);
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    AlignDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -139,7 +139,7 @@ public:
     unsigned anonstructsize;    // size of anonymous struct
     unsigned anonalignsize;     // size of anonymous struct for alignment purposes
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    AnonDeclaration *syntaxCopy(Dsymbol *s);
     void setScope(Scope *sc);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     const char *kind() const;
@@ -152,7 +152,7 @@ class PragmaDeclaration : public AttribDeclaration
 public:
     Expressions *args;          // array of Expression's
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    PragmaDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     PINLINE evalPragmaInline(Scope* sc);
     const char *kind() const;
@@ -165,7 +165,7 @@ public:
     Condition *condition;
     Dsymbols *elsedecl; // array of Dsymbol's for else block
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    ConditionalDeclaration *syntaxCopy(Dsymbol *s);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     Dsymbols *include(Scope *sc);
     void addComment(const utf8_t *comment);
@@ -180,7 +180,7 @@ public:
     bool addisdone;
     bool onStack;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    StaticIfDeclaration *syntaxCopy(Dsymbol *s);
     Dsymbols *include(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);
@@ -198,7 +198,7 @@ public:
     bool cached;
     Dsymbols *cache;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    StaticForeachDeclaration *syntaxCopy(Dsymbol *s);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     Dsymbols *include(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
@@ -230,7 +230,7 @@ public:
     ScopeDsymbol *scopesym;
     bool compiled;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    CompileDeclaration *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);
     const char *kind() const;
@@ -246,7 +246,7 @@ class UserAttributeDeclaration : public AttribDeclaration
 public:
     Expressions *atts;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    UserAttributeDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void setScope(Scope *sc);
     Expressions *getAttributes();

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -130,8 +130,8 @@ extern (C++) final class StaticForeach : RootObject
     {
         return new StaticForeach(
             loc,
-            aggrfe ? cast(ForeachStatement)aggrfe.syntaxCopy() : null,
-            rangefe ? cast(ForeachRangeStatement)rangefe.syntaxCopy() : null
+            aggrfe ? aggrfe.syntaxCopy() : null,
+            rangefe ? rangefe.syntaxCopy() : null
         );
     }
 
@@ -491,7 +491,7 @@ extern (C++) class DVCondition : Condition
         this.ident = ident;
     }
 
-    override final Condition syntaxCopy()
+    override final DVCondition syntaxCopy()
     {
         return this; // don't need to copy
     }
@@ -894,7 +894,7 @@ extern (C++) final class StaticIfCondition : Condition
         this.exp = exp;
     }
 
-    override Condition syntaxCopy()
+    override StaticIfCondition syntaxCopy()
     {
         return new StaticIfCondition(loc, exp.syntaxCopy());
     }

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -62,7 +62,7 @@ public:
     Identifier *ident;
     Module *mod;
 
-    Condition *syntaxCopy();
+    DVCondition *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -92,7 +92,7 @@ class StaticIfCondition : public Condition
 public:
     Expression *exp;
 
-    Condition *syntaxCopy();
+    StaticIfCondition *syntaxCopy();
     int include(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2882,7 +2882,7 @@ Lagain:
             tf1.purityLevel();
             tf2.purityLevel();
 
-            TypeFunction d = cast(TypeFunction)tf1.syntaxCopy();
+            TypeFunction d = tf1.syntaxCopy();
 
             if (tf1.purity != tf2.purity)
                 d.purity = PURE.impure;

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -388,7 +388,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         return super.toPrettyChars(qualifyTypes);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override ClassDeclaration syntaxCopy(Dsymbol s)
     {
         //printf("ClassDeclaration.syntaxCopy('%s')\n", toChars());
         ClassDeclaration cd =
@@ -405,7 +405,8 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
             (*cd.baseclasses)[i] = b2;
         }
 
-        return ScopeDsymbol.syntaxCopy(cd);
+        ScopeDsymbol.syntaxCopy(cd);
+        return cd;
     }
 
     override Scope* newScope(Scope* sc)
@@ -1007,12 +1008,13 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
         }
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override InterfaceDeclaration syntaxCopy(Dsymbol s)
     {
         InterfaceDeclaration id =
             s ? cast(InterfaceDeclaration)s
               : new InterfaceDeclaration(loc, ident, null);
-        return ClassDeclaration.syntaxCopy(id);
+        ClassDeclaration.syntaxCopy(id);
+        return id;
     }
 
 

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -598,7 +598,7 @@ extern (C++) final class TupleDeclaration : Declaration
         this.objects = objects;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override TupleDeclaration syntaxCopy(Dsymbol s)
     {
         assert(0);
     }
@@ -744,7 +744,7 @@ extern (C++) final class AliasDeclaration : Declaration
         return new AliasDeclaration(loc, id, type);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override AliasDeclaration syntaxCopy(Dsymbol s)
     {
         //printf("AliasDeclaration::syntaxCopy()\n");
         assert(!s);
@@ -1172,7 +1172,7 @@ extern (C++) class VarDeclaration : Declaration
         return new VarDeclaration(loc, type, ident, _init, storage_class);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override VarDeclaration syntaxCopy(Dsymbol s)
     {
         //printf("VarDeclaration::syntaxCopy(%s)\n", toChars());
         assert(!s);
@@ -1742,7 +1742,7 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
         return new TypeInfoDeclaration(tinfo);
     }
 
-    override final Dsymbol syntaxCopy(Dsymbol s)
+    override final TypeInfoDeclaration syntaxCopy(Dsymbol s)
     {
         assert(0); // should never be produced by syntax
     }
@@ -2179,7 +2179,7 @@ extern (C++) final class ThisDeclaration : VarDeclaration
         storage_class |= STC.nodtor;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override ThisDeclaration syntaxCopy(Dsymbol s)
     {
         assert(0); // should never be produced by syntax
     }

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -151,7 +151,7 @@ public:
 
     TypeTuple *tupletype;       // !=NULL if this is a type tuple
 
-    Dsymbol *syntaxCopy(Dsymbol *);
+    TupleDeclaration *syntaxCopy(Dsymbol *);
     const char *kind() const;
     Type *getType();
     Dsymbol *toAlias2();
@@ -171,7 +171,7 @@ public:
     Dsymbol *_import;           // !=NULL if unresolved internal alias for selective import
 
     static AliasDeclaration *create(Loc loc, Identifier *id, Type *type);
-    Dsymbol *syntaxCopy(Dsymbol *);
+    AliasDeclaration *syntaxCopy(Dsymbol *);
     bool overloadInsert(Dsymbol *s);
     const char *kind() const;
     Type *getType();
@@ -241,7 +241,7 @@ public:
 
 public:
     static VarDeclaration *create(const Loc &loc, Type *t, Identifier *id, Initializer *init, StorageClass storage_class = STCundefined);
-    Dsymbol *syntaxCopy(Dsymbol *);
+    VarDeclaration *syntaxCopy(Dsymbol *);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     const char *kind() const;
     AggregateDeclaration *isThis();
@@ -283,7 +283,7 @@ public:
     Type *tinfo;
 
     static TypeInfoDeclaration *create(Type *tinfo);
-    Dsymbol *syntaxCopy(Dsymbol *);
+    TypeInfoDeclaration *syntaxCopy(Dsymbol *);
     const char *toChars() const;
 
     TypeInfoDeclaration *isTypeInfoDeclaration() { return this; }
@@ -423,7 +423,7 @@ public:
 class ThisDeclaration : public VarDeclaration
 {
 public:
-    Dsymbol *syntaxCopy(Dsymbol *);
+    ThisDeclaration *syntaxCopy(Dsymbol *);
     ThisDeclaration *isThisDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -586,7 +586,7 @@ public:
     ObjcFuncDeclaration objc;
 
     static FuncDeclaration *create(const Loc &loc, const Loc &endloc, Identifier *id, StorageClass storage_class, Type *type);
-    Dsymbol *syntaxCopy(Dsymbol *);
+    FuncDeclaration *syntaxCopy(Dsymbol *);
     bool functionSemantic();
     bool functionSemantic3();
     bool equals(const RootObject *o) const;
@@ -667,7 +667,7 @@ public:
     // backend
     bool deferToObj;
 
-    Dsymbol *syntaxCopy(Dsymbol *);
+    FuncLiteralDeclaration *syntaxCopy(Dsymbol *);
     bool isNested() const;
     AggregateDeclaration *isThis();
     bool isVirtual() const;
@@ -686,7 +686,7 @@ class CtorDeclaration : public FuncDeclaration
 {
 public:
     bool isCpCtor;
-    Dsymbol *syntaxCopy(Dsymbol *);
+    CtorDeclaration *syntaxCopy(Dsymbol *);
     const char *kind() const;
     const char *toChars() const;
     bool isVirtual() const;
@@ -700,7 +700,7 @@ public:
 class PostBlitDeclaration : public FuncDeclaration
 {
 public:
-    Dsymbol *syntaxCopy(Dsymbol *);
+    PostBlitDeclaration *syntaxCopy(Dsymbol *);
     bool isVirtual() const;
     bool addPreInvariant();
     bool addPostInvariant();
@@ -713,7 +713,7 @@ public:
 class DtorDeclaration : public FuncDeclaration
 {
 public:
-    Dsymbol *syntaxCopy(Dsymbol *);
+    DtorDeclaration *syntaxCopy(Dsymbol *);
     const char *kind() const;
     const char *toChars() const;
     bool isVirtual() const;
@@ -728,7 +728,7 @@ public:
 class StaticCtorDeclaration : public FuncDeclaration
 {
 public:
-    Dsymbol *syntaxCopy(Dsymbol *);
+    StaticCtorDeclaration *syntaxCopy(Dsymbol *);
     AggregateDeclaration *isThis();
     bool isVirtual() const;
     bool addPreInvariant();
@@ -742,7 +742,7 @@ public:
 class SharedStaticCtorDeclaration : public StaticCtorDeclaration
 {
 public:
-    Dsymbol *syntaxCopy(Dsymbol *);
+    SharedStaticCtorDeclaration *syntaxCopy(Dsymbol *);
 
     SharedStaticCtorDeclaration *isSharedStaticCtorDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -753,7 +753,7 @@ class StaticDtorDeclaration : public FuncDeclaration
 public:
     VarDeclaration *vgate;      // 'gate' variable
 
-    Dsymbol *syntaxCopy(Dsymbol *);
+    StaticDtorDeclaration *syntaxCopy(Dsymbol *);
     AggregateDeclaration *isThis();
     bool isVirtual() const;
     bool hasStaticCtorOrDtor();
@@ -767,7 +767,7 @@ public:
 class SharedStaticDtorDeclaration : public StaticDtorDeclaration
 {
 public:
-    Dsymbol *syntaxCopy(Dsymbol *);
+    SharedStaticDtorDeclaration *syntaxCopy(Dsymbol *);
 
     SharedStaticDtorDeclaration *isSharedStaticDtorDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -776,7 +776,7 @@ public:
 class InvariantDeclaration : public FuncDeclaration
 {
 public:
-    Dsymbol *syntaxCopy(Dsymbol *);
+    InvariantDeclaration *syntaxCopy(Dsymbol *);
     bool isVirtual() const;
     bool addPreInvariant();
     bool addPostInvariant();
@@ -793,7 +793,7 @@ public:
     // toObjFile() these nested functions after this one
     FuncDeclarations deferredNested;
 
-    Dsymbol *syntaxCopy(Dsymbol *);
+    UnitTestDeclaration *syntaxCopy(Dsymbol *);
     AggregateDeclaration *isThis();
     bool isVirtual() const;
     bool addPreInvariant();
@@ -809,7 +809,7 @@ public:
     Parameters *parameters;
     VarArg varargs;
 
-    Dsymbol *syntaxCopy(Dsymbol *);
+    NewDeclaration *syntaxCopy(Dsymbol *);
     const char *kind() const;
     bool isVirtual() const;
     bool addPreInvariant();

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -67,11 +67,12 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         protection = Prot(Prot.Kind.undefined);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override EnumDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto ed = new EnumDeclaration(loc, ident, memtype ? memtype.syntaxCopy() : null);
-        return ScopeDsymbol.syntaxCopy(ed);
+        ScopeDsymbol.syntaxCopy(ed);
+        return ed;
     }
 
     override void addMember(Scope* sc, ScopeDsymbol sds)
@@ -407,7 +408,7 @@ extern (C++) final class EnumMember : VarDeclaration
         depdecl = dd;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override EnumMember syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new EnumMember(
@@ -415,8 +416,8 @@ extern (C++) final class EnumMember : VarDeclaration
             value ? value.syntaxCopy() : null,
             origType ? origType.syntaxCopy() : null,
             storage_class,
-            userAttribDecl ? cast(UserAttributeDeclaration)userAttribDecl.syntaxCopy(s) : null,
-            depdecl ? cast(DeprecatedDeclaration)depdecl.syntaxCopy(s) : null);
+            userAttribDecl ? userAttribDecl.syntaxCopy(s) : null,
+            depdecl ? depdecl.syntaxCopy(s) : null);
     }
 
     override const(char)* kind() const

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -112,7 +112,7 @@ extern (C++) final class Import : Dsymbol
     }
 
     // copy only syntax trees
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override Import syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto si = new Import(loc, packages, id, aliasId, isstatic);

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -245,12 +245,13 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         return new StructDeclaration(loc, id, inObject);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override StructDeclaration syntaxCopy(Dsymbol s)
     {
         StructDeclaration sd =
             s ? cast(StructDeclaration)s
               : new StructDeclaration(loc, ident, false);
-        return ScopeDsymbol.syntaxCopy(sd);
+        ScopeDsymbol.syntaxCopy(sd);
+        return sd;
     }
 
     final void semanticTypeInfoMembers()
@@ -740,11 +741,12 @@ extern (C++) final class UnionDeclaration : StructDeclaration
         super(loc, id, false);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override UnionDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto ud = new UnionDeclaration(loc, ident);
-        return StructDeclaration.syntaxCopy(ud);
+        StructDeclaration.syntaxCopy(ud);
+        return ud;
     }
 
     override const(char)* kind() const

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1295,7 +1295,7 @@ public:
         super(loc, ident);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override ScopeDsymbol syntaxCopy(Dsymbol s)
     {
         //printf("ScopeDsymbol::syntaxCopy('%s')\n", toChars());
         ScopeDsymbol sds = s ? cast(ScopeDsymbol)s : new ScopeDsymbol(ident);
@@ -2152,7 +2152,7 @@ extern (C++) final class AliasAssign : Dsymbol
         this.type = type;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override AliasAssign syntaxCopy(Dsymbol s)
     {
         assert(!s);
         AliasAssign aa = new AliasAssign(loc, ident, type.syntaxCopy());

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -298,7 +298,7 @@ private:
     BitArray accessiblePackages, privateAccessiblePackages;
 
 public:
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    ScopeDsymbol *syntaxCopy(Dsymbol *s);
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
     virtual void importScope(Dsymbol *s, Prot protection);
     virtual bool isPackageAccessible(Package *p, Prot protection, int flags = 0);

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -649,7 +649,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         }
     }
 
-    override Dsymbol syntaxCopy(Dsymbol)
+    override TemplateDeclaration syntaxCopy(Dsymbol)
     {
         //printf("TemplateDeclaration.syntaxCopy()\n");
         TemplateParameters* p = null;
@@ -1160,7 +1160,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             if (fd)
             {
                 assert(fd.type.ty == Tfunction);
-                TypeFunction tf = cast(TypeFunction)fd.type.syntaxCopy();
+                TypeFunction tf = (cast(TypeFunction) fd.type).syntaxCopy();
 
                 fd = new FuncDeclaration(fd.loc, fd.endloc, fd.ident, fd.storage_class, tf);
                 fd.parent = ti;
@@ -5373,7 +5373,7 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
         return this;
     }
 
-    override TemplateParameter syntaxCopy()
+    override TemplateTypeParameter syntaxCopy()
     {
         return new TemplateTypeParameter(loc, ident, specType ? specType.syntaxCopy() : null, defaultType ? defaultType.syntaxCopy() : null);
     }
@@ -5459,7 +5459,7 @@ extern (C++) final class TemplateThisParameter : TemplateTypeParameter
         return this;
     }
 
-    override TemplateParameter syntaxCopy()
+    override TemplateThisParameter syntaxCopy()
     {
         return new TemplateThisParameter(loc, ident, specType ? specType.syntaxCopy() : null, defaultType ? defaultType.syntaxCopy() : null);
     }
@@ -5497,7 +5497,7 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
         return this;
     }
 
-    override TemplateParameter syntaxCopy()
+    override TemplateValueParameter syntaxCopy()
     {
         return new TemplateValueParameter(loc, ident,
             valType.syntaxCopy(),
@@ -5600,7 +5600,7 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
         return this;
     }
 
-    override TemplateParameter syntaxCopy()
+    override TemplateAliasParameter syntaxCopy()
     {
         return new TemplateAliasParameter(loc, ident, specType ? specType.syntaxCopy() : null, objectSyntaxCopy(specAlias), objectSyntaxCopy(defaultAlias));
     }
@@ -5682,7 +5682,7 @@ extern (C++) final class TemplateTupleParameter : TemplateParameter
         return this;
     }
 
-    override TemplateParameter syntaxCopy()
+    override TemplateTupleParameter syntaxCopy()
     {
         return new TemplateTupleParameter(loc, ident);
     }
@@ -5869,7 +5869,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         return a;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override TemplateInstance syntaxCopy(Dsymbol s)
     {
         TemplateInstance ti = s ? cast(TemplateInstance)s : new TemplateInstance(loc, name, null);
         ti.tiargs = arraySyntaxCopy(tiargs);
@@ -7593,9 +7593,9 @@ extern (C++) final class TemplateMixin : TemplateInstance
         this.tqual = tqual;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override TemplateInstance syntaxCopy(Dsymbol s)
     {
-        auto tm = new TemplateMixin(loc, ident, cast(TypeQualified)tqual.syntaxCopy(), tiargs);
+        auto tm = new TemplateMixin(loc, ident, tqual.syntaxCopy(), tiargs);
         return TemplateInstance.syntaxCopy(tm);
     }
 

--- a/src/dmd/dversion.d
+++ b/src/dmd/dversion.d
@@ -45,7 +45,7 @@ extern (C++) final class DebugSymbol : Dsymbol
         this.level = level;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override DebugSymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto ds = new DebugSymbol(loc, ident);
@@ -139,7 +139,7 @@ extern (C++) final class VersionSymbol : Dsymbol
         this.level = level;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override VersionSymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto ds = ident ? new VersionSymbol(loc, ident)

--- a/src/dmd/enum.h
+++ b/src/dmd/enum.h
@@ -40,7 +40,7 @@ public:
     bool added;
     int inuse;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    EnumDeclaration *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);
@@ -79,7 +79,7 @@ public:
 
     EnumDeclaration *ed;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    EnumMember *syntaxCopy(Dsymbol *s);
     const char *kind() const;
     Expression *getVarExp(const Loc &loc, Scope *sc);
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1967,7 +1967,7 @@ extern (C++) final class IntegerExp : Expression
         return result;
     }
 
-    override Expression syntaxCopy()
+    override IntegerExp syntaxCopy()
     {
         return this;
     }
@@ -2331,7 +2331,7 @@ extern (C++) class ThisExp : Expression
         //printf("ThisExp::ThisExp() loc = %d\n", loc.linnum);
     }
 
-    override Expression syntaxCopy()
+    override ThisExp syntaxCopy()
     {
         auto r = cast(ThisExp) super.syntaxCopy();
         // require new semantic (possibly new `var` etc.)
@@ -2915,7 +2915,7 @@ extern (C++) final class TupleExp : Expression
         return this;
     }
 
-    override Expression syntaxCopy()
+    override TupleExp syntaxCopy()
     {
         return new TupleExp(loc, e0 ? e0.syntaxCopy() : null, arraySyntaxCopy(exps));
     }
@@ -2999,7 +2999,7 @@ extern (C++) final class ArrayLiteralExp : Expression
         emplaceExp!(ArrayLiteralExp)(pue, loc, null, elements);
     }
 
-    override Expression syntaxCopy()
+    override ArrayLiteralExp syntaxCopy()
     {
         return new ArrayLiteralExp(loc,
             null,
@@ -3162,7 +3162,7 @@ extern (C++) final class AssocArrayLiteralExp : Expression
         return false;
     }
 
-    override Expression syntaxCopy()
+    override AssocArrayLiteralExp syntaxCopy()
     {
         return new AssocArrayLiteralExp(loc, arraySyntaxCopy(keys), arraySyntaxCopy(values));
     }
@@ -3259,7 +3259,7 @@ extern (C++) final class StructLiteralExp : Expression
         return false;
     }
 
-    override Expression syntaxCopy()
+    override StructLiteralExp syntaxCopy()
     {
         auto exp = new StructLiteralExp(loc, sd, arraySyntaxCopy(elements), type ? type : stype);
         exp.origin = this;
@@ -3390,7 +3390,7 @@ extern (C++) final class TypeExp : Expression
         this.type = type;
     }
 
-    override Expression syntaxCopy()
+    override TypeExp syntaxCopy()
     {
         return new TypeExp(loc, type.syntaxCopy());
     }
@@ -3434,9 +3434,9 @@ extern (C++) final class ScopeExp : Expression
         assert(!sds.isTemplateDeclaration());   // instead, you should use TemplateExp
     }
 
-    override Expression syntaxCopy()
+    override ScopeExp syntaxCopy()
     {
-        return new ScopeExp(loc, cast(ScopeDsymbol)sds.syntaxCopy(null));
+        return new ScopeExp(loc, sds.syntaxCopy(null));
     }
 
     override bool checkType()
@@ -3550,7 +3550,7 @@ extern (C++) final class NewExp : Expression
         return new NewExp(loc, thisexp, newargs, newtype, arguments);
     }
 
-    override Expression syntaxCopy()
+    override NewExp syntaxCopy()
     {
         return new NewExp(loc,
             thisexp ? thisexp.syntaxCopy() : null,
@@ -3584,9 +3584,9 @@ extern (C++) final class NewAnonClassExp : Expression
         this.arguments = arguments;
     }
 
-    override Expression syntaxCopy()
+    override NewAnonClassExp syntaxCopy()
     {
-        return new NewAnonClassExp(loc, thisexp ? thisexp.syntaxCopy() : null, arraySyntaxCopy(newargs), cast(ClassDeclaration)cd.syntaxCopy(null), arraySyntaxCopy(arguments));
+        return new NewAnonClassExp(loc, thisexp ? thisexp.syntaxCopy() : null, arraySyntaxCopy(newargs), cd.syntaxCopy(null), arraySyntaxCopy(arguments));
     }
 
     override void accept(Visitor v)
@@ -3740,12 +3740,6 @@ extern (C++) final class VarExp : SymbolExp
     {
         v.visit(this);
     }
-
-    override Expression syntaxCopy()
-    {
-        auto ret = super.syntaxCopy();
-        return ret;
-    }
 }
 
 /***********************************************************
@@ -3864,7 +3858,7 @@ extern (C++) final class FuncExp : Expression
         }
     }
 
-    override Expression syntaxCopy()
+    override FuncExp syntaxCopy()
     {
         if (td)
             return new FuncExp(loc, td.syntaxCopy(null));
@@ -4092,7 +4086,7 @@ extern (C++) final class DeclarationExp : Expression
         this.declaration = declaration;
     }
 
-    override Expression syntaxCopy()
+    override DeclarationExp syntaxCopy()
     {
         return new DeclarationExp(loc, declaration.syntaxCopy(null));
     }
@@ -4125,7 +4119,7 @@ extern (C++) final class TypeidExp : Expression
         this.obj = o;
     }
 
-    override Expression syntaxCopy()
+    override TypeidExp syntaxCopy()
     {
         return new TypeidExp(loc, objectSyntaxCopy(obj));
     }
@@ -4151,7 +4145,7 @@ extern (C++) final class TraitsExp : Expression
         this.args = args;
     }
 
-    override Expression syntaxCopy()
+    override TraitsExp syntaxCopy()
     {
         return new TraitsExp(loc, ident, TemplateInstance.arraySyntaxCopy(args));
     }
@@ -4201,7 +4195,7 @@ extern (C++) final class IsExp : Expression
         this.parameters = parameters;
     }
 
-    override Expression syntaxCopy()
+    override IsExp syntaxCopy()
     {
         // This section is identical to that in TemplateDeclaration::syntaxCopy()
         TemplateParameters* p = null;
@@ -4233,7 +4227,7 @@ extern (C++) abstract class UnaExp : Expression
         this.e1 = e1;
     }
 
-    override Expression syntaxCopy()
+    override UnaExp syntaxCopy()
     {
         UnaExp e = cast(UnaExp)copy();
         e.type = null;
@@ -4306,7 +4300,7 @@ extern (C++) abstract class BinExp : Expression
         this.e2 = e2;
     }
 
-    override Expression syntaxCopy()
+    override BinExp syntaxCopy()
     {
         BinExp e = cast(BinExp)copy();
         e.type = null;
@@ -4630,7 +4624,7 @@ extern (C++) final class MixinExp : Expression
         this.exps = exps;
     }
 
-    override Expression syntaxCopy()
+    override MixinExp syntaxCopy()
     {
         return new MixinExp(loc, arraySyntaxCopy(exps));
     }
@@ -4691,7 +4685,7 @@ extern (C++) final class AssertExp : UnaExp
         this.msg = msg;
     }
 
-    override Expression syntaxCopy()
+    override AssertExp syntaxCopy()
     {
         return new AssertExp(loc, e1.syntaxCopy(), msg ? msg.syntaxCopy() : null);
     }
@@ -4895,7 +4889,7 @@ extern (C++) final class DotTemplateInstanceExp : UnaExp
         this.ti = ti;
     }
 
-    override Expression syntaxCopy()
+    override DotTemplateInstanceExp syntaxCopy()
     {
         return new DotTemplateInstanceExp(loc, e1.syntaxCopy(), ti.name, TemplateInstance.arraySyntaxCopy(ti.tiargs));
     }
@@ -5067,7 +5061,7 @@ extern (C++) final class CallExp : UnaExp
         return new CallExp(loc, fd, earg1);
     }
 
-    override Expression syntaxCopy()
+    override CallExp syntaxCopy()
     {
         return new CallExp(loc, e1.syntaxCopy(), arraySyntaxCopy(arguments));
     }
@@ -5348,7 +5342,7 @@ extern (C++) final class CastExp : UnaExp
         this.mod = mod;
     }
 
-    override Expression syntaxCopy()
+    override CastExp syntaxCopy()
     {
         return to ? new CastExp(loc, e1.syntaxCopy(), to.syntaxCopy()) : new CastExp(loc, e1.syntaxCopy(), mod);
     }
@@ -5408,7 +5402,7 @@ extern (C++) final class VectorExp : UnaExp
         emplaceExp!(VectorExp)(pue, loc, e, type);
     }
 
-    override Expression syntaxCopy()
+    override VectorExp syntaxCopy()
     {
         return new VectorExp(loc, e1.syntaxCopy(), to.syntaxCopy());
     }
@@ -5478,7 +5472,7 @@ extern (C++) final class SliceExp : UnaExp
         this.lwr = lwr;
     }
 
-    override Expression syntaxCopy()
+    override SliceExp syntaxCopy()
     {
         auto se = new SliceExp(loc, e1.syntaxCopy(), lwr ? lwr.syntaxCopy() : null, upr ? upr.syntaxCopy() : null);
         se.lengthVar = this.lengthVar; // bug7871
@@ -5567,7 +5561,7 @@ extern (C++) final class ArrayExp : UnaExp
         arguments = args;
     }
 
-    override Expression syntaxCopy()
+    override ArrayExp syntaxCopy()
     {
         auto ae = new ArrayExp(loc, e1.syntaxCopy(), arraySyntaxCopy(arguments));
         ae.lengthVar = this.lengthVar; // bug7871
@@ -5811,7 +5805,7 @@ extern (C++) final class IndexExp : BinExp
         //printf("IndexExp::IndexExp('%s')\n", toChars());
     }
 
-    override Expression syntaxCopy()
+    override IndexExp syntaxCopy()
     {
         auto ie = new IndexExp(loc, e1.syntaxCopy(), e2.syntaxCopy());
         ie.lengthVar = this.lengthVar; // bug7871
@@ -6626,7 +6620,7 @@ extern (C++) final class CondExp : BinExp
         this.econd = econd;
     }
 
-    override Expression syntaxCopy()
+    override CondExp syntaxCopy()
     {
         return new CondExp(loc, econd.syntaxCopy(), e1.syntaxCopy(), e2.syntaxCopy());
     }

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -309,7 +309,7 @@ public:
     Dsymbol *s;
     bool hasOverloads;
 
-    Expression *syntaxCopy();
+    DsymbolExp *syntaxCopy();
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }
@@ -320,7 +320,7 @@ class ThisExp : public Expression
 public:
     VarDeclaration *var;
 
-    Expression *syntaxCopy();
+    ThisExp *syntaxCopy();
     bool isBool(bool result);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -387,7 +387,7 @@ public:
 
     static TupleExp *create(Loc loc, Expressions *exps);
     TupleExp *toTupleExp();
-    Expression *syntaxCopy();
+    TupleExp *syntaxCopy();
     bool equals(const RootObject *o) const;
 
     void accept(Visitor *v) { v->visit(this); }
@@ -402,7 +402,7 @@ public:
 
     static ArrayLiteralExp *create(Loc loc, Expressions *elements);
     static void emplace(UnionExp *pue, Loc loc, Expressions *elements);
-    Expression *syntaxCopy();
+    ArrayLiteralExp *syntaxCopy();
     bool equals(const RootObject *o) const;
     Expression *getElement(d_size_t i); // use opIndex instead
     Expression *opIndex(d_size_t i);
@@ -420,7 +420,7 @@ public:
     OwnedBy ownedByCtfe;
 
     bool equals(const RootObject *o) const;
-    Expression *syntaxCopy();
+    AssocArrayLiteralExp *syntaxCopy();
     bool isBool(bool result);
 
     void accept(Visitor *v) { v->visit(this); }
@@ -458,7 +458,7 @@ public:
 
     static StructLiteralExp *create(Loc loc, StructDeclaration *sd, void *elements, Type *stype = NULL);
     bool equals(const RootObject *o) const;
-    Expression *syntaxCopy();
+    StructLiteralExp *syntaxCopy();
     Expression *getField(Type *type, unsigned offset);
     int getFieldIndex(Type *type, unsigned offset);
     Expression *addDtorHook(Scope *sc);
@@ -469,7 +469,7 @@ public:
 class TypeExp : public Expression
 {
 public:
-    Expression *syntaxCopy();
+    TypeExp *syntaxCopy();
     bool checkType();
     bool checkValue();
     void accept(Visitor *v) { v->visit(this); }
@@ -480,7 +480,7 @@ class ScopeExp : public Expression
 public:
     ScopeDsymbol *sds;
 
-    Expression *syntaxCopy();
+    ScopeExp *syntaxCopy();
     bool checkType();
     bool checkValue();
     void accept(Visitor *v) { v->visit(this); }
@@ -517,7 +517,7 @@ public:
     bool thrownew;              // this NewExp is the expression of a ThrowStatement
 
     static NewExp *create(Loc loc, Expression *thisexp, Expressions *newargs, Type *newtype, Expressions *arguments);
-    Expression *syntaxCopy();
+    NewExp *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -532,7 +532,7 @@ public:
     ClassDeclaration *cd;       // class being instantiated
     Expressions *arguments;     // Array of Expression's to call class constructor
 
-    Expression *syntaxCopy();
+    NewAnonClassExp *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -596,7 +596,7 @@ public:
     TOK tok;
 
     bool equals(const RootObject *o) const;
-    Expression *syntaxCopy();
+    FuncExp *syntaxCopy();
     const char *toChars() const;
     bool checkType();
     bool checkValue();
@@ -614,7 +614,7 @@ class DeclarationExp : public Expression
 public:
     Dsymbol *declaration;
 
-    Expression *syntaxCopy();
+    DeclarationExp *syntaxCopy();
 
     bool hasCode();
 
@@ -626,7 +626,7 @@ class TypeidExp : public Expression
 public:
     RootObject *obj;
 
-    Expression *syntaxCopy();
+    TypeidExp *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -636,7 +636,7 @@ public:
     Identifier *ident;
     Objects *args;
 
-    Expression *syntaxCopy();
+    TraitsExp *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -659,7 +659,7 @@ public:
     TOK tok;       // ':' or '=='
     TOK tok2;      // 'struct', 'union', etc.
 
-    Expression *syntaxCopy();
+    IsExp *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -671,7 +671,7 @@ public:
     Expression *e1;
     Type *att1; // Save alias this type to detect recursion
 
-    Expression *syntaxCopy();
+    UnaExp *syntaxCopy();
     Expression *incompatibleTypes();
     Expression *resolveLoc(const Loc &loc, Scope *sc);
 
@@ -687,7 +687,7 @@ public:
     Type *att1; // Save alias this type to detect recursion
     Type *att2; // Save alias this type to detect recursion
 
-    Expression *syntaxCopy();
+    BinExp *syntaxCopy();
     Expression *incompatibleTypes();
 
     Expression *reorderSettingAAElem(Scope *sc);
@@ -723,7 +723,7 @@ class AssertExp : public UnaExp
 public:
     Expression *msg;
 
-    Expression *syntaxCopy();
+    AssertExp *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -765,7 +765,7 @@ class DotTemplateInstanceExp : public UnaExp
 public:
     TemplateInstance *ti;
 
-    Expression *syntaxCopy();
+    DotTemplateInstanceExp *syntaxCopy();
     bool findTempDecl(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -803,7 +803,7 @@ public:
     static CallExp *create(Loc loc, Expression *e, Expression *earg1);
     static CallExp *create(Loc loc, FuncDeclaration *fd, Expression *earg1);
 
-    Expression *syntaxCopy();
+    CallExp *syntaxCopy();
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *addDtorHook(Scope *sc);
@@ -867,7 +867,7 @@ public:
     Type *to;                   // type to cast to
     unsigned char mod;          // MODxxxxx
 
-    Expression *syntaxCopy();
+    CastExp *syntaxCopy();
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
 
@@ -883,7 +883,7 @@ public:
 
     static VectorExp *create(Loc loc, Expression *e, Type *t);
     static void emplace(UnionExp *pue, Loc loc, Expression *e, Type *t);
-    Expression *syntaxCopy();
+    VectorExp *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -905,7 +905,7 @@ public:
     bool lowerIsLessThanUpper;  // true if lwr <= upr
     bool arrayop;               // an array operation, rather than a slice
 
-    Expression *syntaxCopy();
+    SliceExp *syntaxCopy();
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -927,7 +927,7 @@ public:
     Expression *lwr;
     Expression *upr;
 
-    Expression *syntaxCopy();
+    IntervalExp *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -958,7 +958,7 @@ public:
     size_t currentDimension;            // for opDollar
     VarDeclaration *lengthVar;
 
-    Expression *syntaxCopy();
+    ArrayExp *syntaxCopy();
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
 
@@ -995,7 +995,7 @@ public:
     bool modifiable;
     bool indexIsInBounds;       // true if 0 <= e2 && e2 <= e1.length - 1
 
-    Expression *syntaxCopy();
+    IndexExp *syntaxCopy();
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -1255,7 +1255,7 @@ class CondExp : public BinExp
 public:
     Expression *econd;
 
-    Expression *syntaxCopy();
+    CondExp *syntaxCopy();
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -596,7 +596,7 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
                 if (alias_e && alias_e != die.e1)
                 {
                     die.e1 = alias_e;
-                    CallExp ce2 = cast(CallExp)ce.syntaxCopy();
+                    CallExp ce2 = ce.syntaxCopy();
                     ce2.e1 = die;
                     e = cast(CallExp)ce2.trySemantic(sc);
                     if (e)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -177,6 +177,9 @@ enum class LINK : uint8_t
 };
 
 class LinkDeclaration;
+class CPPMangleDeclaration;
+class AlignDeclaration;
+class PragmaDeclaration;
 enum class PINLINE : uint8_t
 {
     default_ = 0u,
@@ -185,7 +188,10 @@ enum class PINLINE : uint8_t
 };
 
 class Condition;
+class ConditionalDeclaration;
+class StaticIfDeclaration;
 class StaticForeach;
+class StaticForeachDeclaration;
 enum class BUILTIN : uint8_t
 {
     unknown = 255u,
@@ -233,6 +239,8 @@ class DebugCondition;
 class VersionCondition;
 class ForeachStatement;
 class ForeachRangeStatement;
+class DVCondition;
+class StaticIfCondition;
 enum class TOK : uint8_t
 {
     reserved = 0u,
@@ -653,12 +661,6 @@ class TemplateAliasParameter;
 class TemplateThisParameter;
 class TypeQualified;
 class StaticAssert;
-class AlignDeclaration;
-class CPPMangleDeclaration;
-class PragmaDeclaration;
-class ConditionalDeclaration;
-class StaticForeachDeclaration;
-class StaticIfDeclaration;
 class ImportStatement;
 class LabelStatement;
 class StaticAssertStatement;
@@ -695,8 +697,6 @@ class BinExp;
 class SymbolExp;
 class CmpExp;
 class BinAssignExp;
-class StaticIfCondition;
-class DVCondition;
 class ExpInitializer;
 class StructInitializer;
 class ArrayInitializer;
@@ -950,7 +950,7 @@ private:
     BitArray accessiblePackages;
     BitArray privateAccessiblePackages;
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    ScopeDsymbol* syntaxCopy(Dsymbol* s);
     Dsymbol* search(const Loc& loc, Identifier* ident, int32_t flags = 8);
     virtual void importScope(Dsymbol* s, Prot protection);
     virtual bool isPackageAccessible(Package* p, Prot protection, int32_t flags = 0);
@@ -1882,7 +1882,7 @@ public:
     Identifier* ident;
     Dsymbol* sym;
     bool isDeprecated_;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    AliasThis* syntaxCopy(Dsymbol* s);
     const char* kind() const;
     AliasThis* isAliasThis();
     void accept(Visitor* v);
@@ -1977,7 +1977,7 @@ class StorageClassDeclaration : public AttribDeclaration
 {
 public:
     StorageClass stc;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    StorageClassDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     bool oneMember(Dsymbol** ps, Identifier* ident);
     void addMember(Scope* sc, ScopeDsymbol* sds);
@@ -1990,7 +1990,7 @@ class DeprecatedDeclaration final : public StorageClassDeclaration
 public:
     Expression* msg;
     const char* msgstr;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    DeprecatedDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     void setScope(Scope* sc);
     void accept(Visitor* v);
@@ -2001,7 +2001,7 @@ class LinkDeclaration final : public AttribDeclaration
 public:
     LINK linkage;
     static LinkDeclaration* create(LINK p, Array<Dsymbol* >* decl);
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    LinkDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     const char* toChars() const;
     void accept(Visitor* v);
@@ -2011,7 +2011,7 @@ class CPPMangleDeclaration final : public AttribDeclaration
 {
 public:
     CPPMANGLE cppmangle;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    CPPMangleDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     void setScope(Scope* sc);
     const char* toChars() const;
@@ -2022,7 +2022,7 @@ class CPPNamespaceDeclaration final : public AttribDeclaration
 {
 public:
     Expression* exp;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    CPPNamespaceDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     const char* toChars() const;
     void accept(Visitor* v);
@@ -2034,7 +2034,7 @@ class ProtDeclaration final : public AttribDeclaration
 public:
     Prot protection;
     Array<Identifier* >* pkg_identifiers;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    ProtDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     void addMember(Scope* sc, ScopeDsymbol* sds);
     const char* kind() const;
@@ -2050,7 +2050,7 @@ public:
     enum : uint32_t { UNKNOWN = 0u };
 
     uint32_t salign;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    AlignDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     void accept(Visitor* v);
 };
@@ -2063,7 +2063,7 @@ public:
     uint32_t anonoffset;
     uint32_t anonstructsize;
     uint32_t anonalignsize;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    AnonDeclaration* syntaxCopy(Dsymbol* s);
     void setScope(Scope* sc);
     void setFieldOffset(AggregateDeclaration* ad, uint32_t* poffset, bool isunion);
     const char* kind() const;
@@ -2075,7 +2075,7 @@ class PragmaDeclaration final : public AttribDeclaration
 {
 public:
     Array<Expression* >* args;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    PragmaDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     PINLINE evalPragmaInline(Scope* sc);
     const char* kind() const;
@@ -2087,7 +2087,7 @@ class ConditionalDeclaration : public AttribDeclaration
 public:
     Condition* condition;
     Array<Dsymbol* >* elsedecl;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    ConditionalDeclaration* syntaxCopy(Dsymbol* s);
     bool oneMember(Dsymbol** ps, Identifier* ident);
     Array<Dsymbol* >* include(Scope* sc);
     void addComment(const char* comment);
@@ -2103,7 +2103,7 @@ private:
     bool addisdone;
     bool onStack;
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    StaticIfDeclaration* syntaxCopy(Dsymbol* s);
     Array<Dsymbol* >* include(Scope* sc);
     void addMember(Scope* sc, ScopeDsymbol* sds);
     void setScope(Scope* sc);
@@ -2120,7 +2120,7 @@ public:
     bool onStack;
     bool cached;
     Array<Dsymbol* >* cache;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    StaticForeachDeclaration* syntaxCopy(Dsymbol* s);
     bool oneMember(Dsymbol** ps, Identifier* ident);
     Array<Dsymbol* >* include(Scope* sc);
     void addMember(Scope* sc, ScopeDsymbol* sds);
@@ -2148,7 +2148,7 @@ public:
     Array<Expression* >* exps;
     ScopeDsymbol* scopesym;
     bool compiled;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    CompileDeclaration* syntaxCopy(Dsymbol* s);
     void addMember(Scope* sc, ScopeDsymbol* sds);
     void setScope(Scope* sc);
     const char* kind() const;
@@ -2160,7 +2160,7 @@ class UserAttributeDeclaration final : public AttribDeclaration
 {
 public:
     Array<Expression* >* atts;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    UserAttributeDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     void setScope(Scope* sc);
     Array<Expression* >* getAttributes();
@@ -2271,7 +2271,7 @@ public:
     uint32_t level;
     Identifier* ident;
     Module* mod;
-    Condition* syntaxCopy();
+    DVCondition* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -2300,7 +2300,7 @@ class StaticIfCondition final : public Condition
 {
 public:
     Expression* exp;
-    Condition* syntaxCopy();
+    StaticIfCondition* syntaxCopy();
     int32_t include(Scope* sc);
     void accept(Visitor* v);
     const char* toChars() const;
@@ -2434,7 +2434,7 @@ public:
     Symbol* cpp_type_info_ptr_sym;
     static ClassDeclaration* create(Loc loc, Identifier* id, Array<BaseClass* >* baseclasses, Array<Dsymbol* >* members, bool inObject);
     const char* toPrettyChars(bool qualifyTypes = false);
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    ClassDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     bool isBaseOf2(ClassDeclaration* cd);
     enum : int32_t { OFFSET_RUNTIME = 1985229328 };
@@ -2468,7 +2468,7 @@ public:
 class InterfaceDeclaration final : public ClassDeclaration
 {
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    InterfaceDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     bool isBaseOf(ClassDeclaration* cd, int32_t* poffset);
     bool isBaseOf(BaseClass* bc, int32_t* poffset);
@@ -2598,7 +2598,7 @@ public:
     Array<RootObject* >* objects;
     bool isexp;
     TypeTuple* tupletype;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    TupleDeclaration* syntaxCopy(Dsymbol* s);
     const char* kind() const;
     Type* getType();
     Dsymbol* toAlias2();
@@ -2614,7 +2614,7 @@ public:
     Dsymbol* overnext;
     Dsymbol* _import;
     static AliasDeclaration* create(Loc loc, Identifier* id, Type* type);
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    AliasDeclaration* syntaxCopy(Dsymbol* s);
     bool overloadInsert(Dsymbol* s);
     const char* kind() const;
     Type* getType();
@@ -2671,7 +2671,7 @@ public:
     bool doNotInferReturn;
     uint8_t isdataseg;
     static VarDeclaration* create(const Loc& loc, Type* type, Identifier* ident, Initializer* _init, StorageClass storage_class = static_cast<StorageClass>(STC::undefined_));
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    VarDeclaration* syntaxCopy(Dsymbol* s);
     void setFieldOffset(AggregateDeclaration* ad, uint32_t* poffset, bool isunion);
     const char* kind() const;
     AggregateDeclaration* isThis();
@@ -2707,7 +2707,7 @@ class TypeInfoDeclaration : public VarDeclaration
 public:
     Type* tinfo;
     static TypeInfoDeclaration* create(Type* tinfo);
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    TypeInfoDeclaration* syntaxCopy(Dsymbol* s);
     const char* toChars() const;
     TypeInfoDeclaration* isTypeInfoDeclaration();
     void accept(Visitor* v);
@@ -2845,7 +2845,7 @@ public:
 class ThisDeclaration final : public VarDeclaration
 {
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    ThisDeclaration* syntaxCopy(Dsymbol* s);
     ThisDeclaration* isThisDeclaration();
     void accept(Visitor* v);
     ~ThisDeclaration();
@@ -2863,7 +2863,7 @@ public:
     bool isdeprecated;
     bool added;
     int32_t inuse;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    EnumDeclaration* syntaxCopy(Dsymbol* s);
     void addMember(Scope* sc, ScopeDsymbol* sds);
     void setScope(Scope* sc);
     bool oneMember(Dsymbol** ps, Identifier* ident);
@@ -2889,7 +2889,7 @@ public:
     Expression* origValue;
     Type* origType;
     EnumDeclaration* ed;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    EnumMember* syntaxCopy(Dsymbol* s);
     const char* kind() const;
     Expression* getVarExp(const Loc& loc, Scope* sc);
     EnumMember* isEnumMember();
@@ -2912,7 +2912,7 @@ public:
     Array<AliasDeclaration* > aliasdecls;
     const char* kind() const;
     Prot prot();
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    Import* syntaxCopy(Dsymbol* s);
     bool load(Scope* sc);
     void importAll(Scope* sc);
     Dsymbol* toAlias();
@@ -3139,7 +3139,7 @@ public:
     StructPOD ispod;
     TypeTuple* argTypes;
     static StructDeclaration* create(Loc loc, Identifier* id, bool inObject);
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    StructDeclaration* syntaxCopy(Dsymbol* s);
     void semanticTypeInfoMembers();
     Dsymbol* search(const Loc& loc, Identifier* ident, int32_t flags = 8);
     const char* kind() const;
@@ -3157,7 +3157,7 @@ public:
 class UnionDeclaration final : public StructDeclaration
 {
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    UnionDeclaration* syntaxCopy(Dsymbol* s);
     const char* kind() const;
     UnionDeclaration* isUnionDeclaration();
     void accept(Visitor* v);
@@ -3233,7 +3233,7 @@ class AliasAssign final : public Dsymbol
 public:
     Identifier* ident;
     Type* type;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    AliasAssign* syntaxCopy(Dsymbol* s);
     AliasAssign* isAliasAssign();
     const char* kind() const;
     void accept(Visitor* v);
@@ -3301,7 +3301,7 @@ private:
     Array<Expression* > lastConstraintNegs;
     Array<RootObject* >* lastConstraintTiargs;
 public:
-    Dsymbol* syntaxCopy(Dsymbol* _param_0);
+    TemplateDeclaration* syntaxCopy(Dsymbol* _param_0);
     bool overloadInsert(Dsymbol* s);
     bool hasStaticCtorOrDtor();
     const char* kind() const;
@@ -3362,7 +3362,7 @@ public:
     Type* specType;
     Type* defaultType;
     TemplateTypeParameter* isTemplateTypeParameter();
-    TemplateParameter* syntaxCopy();
+    TemplateTypeParameter* syntaxCopy();
     bool declareParameter(Scope* sc);
     void print(RootObject* oarg, RootObject* oded);
     RootObject* specialization();
@@ -3376,7 +3376,7 @@ class TemplateThisParameter final : public TemplateTypeParameter
 {
 public:
     TemplateThisParameter* isTemplateThisParameter();
-    TemplateParameter* syntaxCopy();
+    TemplateThisParameter* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -3387,7 +3387,7 @@ public:
     Expression* specValue;
     Expression* defaultValue;
     TemplateValueParameter* isTemplateValueParameter();
-    TemplateParameter* syntaxCopy();
+    TemplateValueParameter* syntaxCopy();
     bool declareParameter(Scope* sc);
     void print(RootObject* oarg, RootObject* oded);
     RootObject* specialization();
@@ -3404,7 +3404,7 @@ public:
     RootObject* specAlias;
     RootObject* defaultAlias;
     TemplateAliasParameter* isTemplateAliasParameter();
-    TemplateParameter* syntaxCopy();
+    TemplateAliasParameter* syntaxCopy();
     bool declareParameter(Scope* sc);
     void print(RootObject* oarg, RootObject* oded);
     RootObject* specialization();
@@ -3418,7 +3418,7 @@ class TemplateTupleParameter final : public TemplateParameter
 {
 public:
     TemplateTupleParameter* isTemplateTupleParameter();
-    TemplateParameter* syntaxCopy();
+    TemplateTupleParameter* syntaxCopy();
     bool declareParameter(Scope* sc);
     void print(RootObject* oarg, RootObject* oded);
     RootObject* specialization();
@@ -3461,7 +3461,7 @@ private:
     };
 
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    TemplateInstance* syntaxCopy(Dsymbol* s);
     Dsymbol* toAlias();
     const char* kind() const;
     bool oneMember(Dsymbol** ps, Identifier* ident);
@@ -3481,7 +3481,7 @@ class TemplateMixin final : public TemplateInstance
 {
 public:
     TypeQualified* tqual;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    TemplateInstance* syntaxCopy(Dsymbol* s);
     const char* kind() const;
     bool oneMember(Dsymbol** ps, Identifier* ident);
     bool hasPointers();
@@ -3579,7 +3579,7 @@ class DebugSymbol final : public Dsymbol
 {
 public:
     uint32_t level;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    DebugSymbol* syntaxCopy(Dsymbol* s);
     const char* toChars() const;
     void addMember(Scope* sc, ScopeDsymbol* sds);
     const char* kind() const;
@@ -3591,7 +3591,7 @@ class VersionSymbol final : public Dsymbol
 {
 public:
     uint32_t level;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    VersionSymbol* syntaxCopy(Dsymbol* s);
     const char* toChars() const;
     void addMember(Scope* sc, ScopeDsymbol* sds);
     const char* kind() const;
@@ -3659,7 +3659,7 @@ public:
     void accept(Visitor* v);
     dinteger_t getInteger();
     void setInteger(dinteger_t value);
-    Expression* syntaxCopy();
+    IntegerExp* syntaxCopy();
     static IntegerExp* createBool(bool b);
 };
 
@@ -3743,7 +3743,7 @@ class ThisExp : public Expression
 public:
     VarDeclaration* var;
     ThisExp(const Loc& loc, const TOK tok);
-    Expression* syntaxCopy();
+    ThisExp* syntaxCopy();
     bool isBool(bool result);
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
@@ -3807,7 +3807,7 @@ public:
     Array<Expression* >* exps;
     static TupleExp* create(Loc loc, Array<Expression* >* exps);
     TupleExp* toTupleExp();
-    Expression* syntaxCopy();
+    TupleExp* syntaxCopy();
     bool equals(const RootObject* const o) const;
     void accept(Visitor* v);
 };
@@ -3820,7 +3820,7 @@ public:
     OwnedBy ownedByCtfe;
     static ArrayLiteralExp* create(Loc loc, Array<Expression* >* elements);
     static void emplace(UnionExp* pue, Loc loc, Array<Expression* >* elements);
-    Expression* syntaxCopy();
+    ArrayLiteralExp* syntaxCopy();
     bool equals(const RootObject* const o) const;
     Expression* getElement(size_t i);
     Expression* opIndex(size_t i);
@@ -3836,7 +3836,7 @@ public:
     Array<Expression* >* values;
     OwnedBy ownedByCtfe;
     bool equals(const RootObject* const o) const;
-    Expression* syntaxCopy();
+    AssocArrayLiteralExp* syntaxCopy();
     bool isBool(bool result);
     void accept(Visitor* v);
 };
@@ -3856,7 +3856,7 @@ public:
     OwnedBy ownedByCtfe;
     static StructLiteralExp* create(Loc loc, StructDeclaration* sd, void* elements, Type* stype = nullptr);
     bool equals(const RootObject* const o) const;
-    Expression* syntaxCopy();
+    StructLiteralExp* syntaxCopy();
     Expression* getField(Type* type, uint32_t offset);
     int32_t getFieldIndex(Type* type, uint32_t offset);
     Expression* addDtorHook(Scope* sc);
@@ -3866,7 +3866,7 @@ public:
 class TypeExp final : public Expression
 {
 public:
-    Expression* syntaxCopy();
+    TypeExp* syntaxCopy();
     bool checkType();
     bool checkValue();
     void accept(Visitor* v);
@@ -3876,7 +3876,7 @@ class ScopeExp final : public Expression
 {
 public:
     ScopeDsymbol* sds;
-    Expression* syntaxCopy();
+    ScopeExp* syntaxCopy();
     bool checkType();
     bool checkValue();
     void accept(Visitor* v);
@@ -3907,7 +3907,7 @@ public:
     bool onstack;
     bool thrownew;
     static NewExp* create(Loc loc, Expression* thisexp, Array<Expression* >* newargs, Type* newtype, Array<Expression* >* arguments);
-    Expression* syntaxCopy();
+    NewExp* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -3918,7 +3918,7 @@ public:
     Array<Expression* >* newargs;
     ClassDeclaration* cd;
     Array<Expression* >* arguments;
-    Expression* syntaxCopy();
+    NewAnonClassExp* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -3950,7 +3950,6 @@ public:
     Expression* toLvalue(Scope* sc, Expression* e);
     Expression* modifiableLvalue(Scope* sc, Expression* e);
     void accept(Visitor* v);
-    Expression* syntaxCopy();
 };
 
 class OverExp final : public Expression
@@ -3969,7 +3968,7 @@ public:
     TemplateDeclaration* td;
     TOK tok;
     bool equals(const RootObject* const o) const;
-    Expression* syntaxCopy();
+    FuncExp* syntaxCopy();
     const char* toChars() const;
     bool checkType();
     bool checkValue();
@@ -3980,7 +3979,7 @@ class DeclarationExp final : public Expression
 {
 public:
     Dsymbol* declaration;
-    Expression* syntaxCopy();
+    DeclarationExp* syntaxCopy();
     bool hasCode();
     void accept(Visitor* v);
 };
@@ -3989,7 +3988,7 @@ class TypeidExp final : public Expression
 {
 public:
     RootObject* obj;
-    Expression* syntaxCopy();
+    TypeidExp* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -3998,7 +3997,7 @@ class TraitsExp final : public Expression
 public:
     Identifier* ident;
     Array<RootObject* >* args;
-    Expression* syntaxCopy();
+    TraitsExp* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -4017,7 +4016,7 @@ public:
     Array<TemplateParameter* >* parameters;
     TOK tok;
     TOK tok2;
-    Expression* syntaxCopy();
+    IsExp* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -4026,7 +4025,7 @@ class UnaExp : public Expression
 public:
     Expression* e1;
     Type* att1;
-    Expression* syntaxCopy();
+    UnaExp* syntaxCopy();
     Expression* incompatibleTypes();
     void setNoderefOperand();
     Expression* resolveLoc(const Loc& loc, Scope* sc);
@@ -4044,7 +4043,7 @@ public:
     Expression* e2;
     Type* att1;
     Type* att2;
-    Expression* syntaxCopy();
+    BinExp* syntaxCopy();
     Expression* incompatibleTypes();
     void setNoderefOperands();
     Expression* reorderSettingAAElem(Scope* sc);
@@ -4064,7 +4063,7 @@ class MixinExp final : public Expression
 {
 public:
     Array<Expression* >* exps;
-    Expression* syntaxCopy();
+    MixinExp* syntaxCopy();
     bool equals(const RootObject* const o) const;
     void accept(Visitor* v);
 };
@@ -4079,7 +4078,7 @@ class AssertExp final : public UnaExp
 {
 public:
     Expression* msg;
-    Expression* syntaxCopy();
+    AssertExp* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -4116,7 +4115,7 @@ class DotTemplateInstanceExp final : public UnaExp
 {
 public:
     TemplateInstance* ti;
-    Expression* syntaxCopy();
+    DotTemplateInstanceExp* syntaxCopy();
     bool findTempDecl(Scope* sc);
     void accept(Visitor* v);
 };
@@ -4149,7 +4148,7 @@ public:
     static CallExp* create(Loc loc, Expression* e);
     static CallExp* create(Loc loc, Expression* e, Expression* earg1);
     static CallExp* create(Loc loc, FuncDeclaration* fd, Expression* earg1);
-    Expression* syntaxCopy();
+    CallExp* syntaxCopy();
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
     Expression* addDtorHook(Scope* sc);
@@ -4209,7 +4208,7 @@ class CastExp final : public UnaExp
 public:
     Type* to;
     uint8_t mod;
-    Expression* syntaxCopy();
+    CastExp* syntaxCopy();
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
     Expression* addDtorHook(Scope* sc);
@@ -4224,7 +4223,7 @@ public:
     OwnedBy ownedByCtfe;
     static VectorExp* create(Loc loc, Expression* e, Type* t);
     static void emplace(UnionExp* pue, Loc loc, Expression* e, Type* type);
-    Expression* syntaxCopy();
+    VectorExp* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -4245,7 +4244,7 @@ public:
     bool upperIsInBounds;
     bool lowerIsLessThanUpper;
     bool arrayop;
-    Expression* syntaxCopy();
+    SliceExp* syntaxCopy();
     Modifiable checkModifiable(Scope* sc, int32_t flag);
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
@@ -4266,7 +4265,7 @@ public:
     Array<Expression* >* arguments;
     size_t currentDimension;
     VarDeclaration* lengthVar;
-    Expression* syntaxCopy();
+    ArrayExp* syntaxCopy();
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
     void accept(Visitor* v);
@@ -4327,7 +4326,7 @@ public:
     VarDeclaration* lengthVar;
     bool modifiable;
     bool indexIsInBounds;
-    Expression* syntaxCopy();
+    IndexExp* syntaxCopy();
     Modifiable checkModifiable(Scope* sc, int32_t flag);
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
@@ -4587,7 +4586,7 @@ class CondExp final : public BinExp
 {
 public:
     Expression* econd;
-    Expression* syntaxCopy();
+    CondExp* syntaxCopy();
     Modifiable checkModifiable(Scope* sc, int32_t flag);
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* ex);
@@ -4752,7 +4751,7 @@ public:
     uint32_t flags;
     ObjcFuncDeclaration objc;
     static FuncDeclaration* create(const Loc& loc, const Loc& endloc, Identifier* id, StorageClass storage_class, Type* type);
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    FuncDeclaration* syntaxCopy(Dsymbol* s);
     bool functionSemantic();
     bool functionSemantic3();
     bool equals(const RootObject* const o) const;
@@ -4837,7 +4836,7 @@ public:
     TOK tok;
     Type* treq;
     bool deferToObj;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    FuncLiteralDeclaration* syntaxCopy(Dsymbol* s);
     bool isNested() const;
     AggregateDeclaration* isThis();
     bool isVirtual() const;
@@ -4855,7 +4854,7 @@ class CtorDeclaration final : public FuncDeclaration
 {
 public:
     bool isCpCtor;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    CtorDeclaration* syntaxCopy(Dsymbol* s);
     const char* kind() const;
     const char* toChars() const;
     bool isVirtual() const;
@@ -4869,7 +4868,7 @@ public:
 class PostBlitDeclaration final : public FuncDeclaration
 {
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    PostBlitDeclaration* syntaxCopy(Dsymbol* s);
     bool isVirtual() const;
     bool addPreInvariant();
     bool addPostInvariant();
@@ -4882,7 +4881,7 @@ public:
 class DtorDeclaration final : public FuncDeclaration
 {
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    DtorDeclaration* syntaxCopy(Dsymbol* s);
     const char* kind() const;
     const char* toChars() const;
     bool isVirtual() const;
@@ -4897,7 +4896,7 @@ public:
 class StaticCtorDeclaration : public FuncDeclaration
 {
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    StaticCtorDeclaration* syntaxCopy(Dsymbol* s);
     AggregateDeclaration* isThis();
     bool isVirtual() const;
     bool addPreInvariant();
@@ -4911,7 +4910,7 @@ public:
 class SharedStaticCtorDeclaration final : public StaticCtorDeclaration
 {
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    SharedStaticCtorDeclaration* syntaxCopy(Dsymbol* s);
     SharedStaticCtorDeclaration* isSharedStaticCtorDeclaration();
     void accept(Visitor* v);
     ~SharedStaticCtorDeclaration();
@@ -4921,7 +4920,7 @@ class StaticDtorDeclaration : public FuncDeclaration
 {
 public:
     VarDeclaration* vgate;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    StaticDtorDeclaration* syntaxCopy(Dsymbol* s);
     AggregateDeclaration* isThis();
     bool isVirtual() const;
     bool hasStaticCtorOrDtor();
@@ -4935,7 +4934,7 @@ public:
 class SharedStaticDtorDeclaration final : public StaticDtorDeclaration
 {
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    SharedStaticDtorDeclaration* syntaxCopy(Dsymbol* s);
     SharedStaticDtorDeclaration* isSharedStaticDtorDeclaration();
     void accept(Visitor* v);
     ~SharedStaticDtorDeclaration();
@@ -4944,7 +4943,7 @@ public:
 class InvariantDeclaration final : public FuncDeclaration
 {
 public:
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    InvariantDeclaration* syntaxCopy(Dsymbol* s);
     bool isVirtual() const;
     bool addPreInvariant();
     bool addPostInvariant();
@@ -4958,7 +4957,7 @@ class UnitTestDeclaration final : public FuncDeclaration
 public:
     char* codedoc;
     Array<FuncDeclaration* > deferredNested;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    UnitTestDeclaration* syntaxCopy(Dsymbol* s);
     AggregateDeclaration* isThis();
     bool isVirtual() const;
     bool addPreInvariant();
@@ -4972,7 +4971,7 @@ class NewDeclaration final : public FuncDeclaration
 {
 public:
     ParameterList parameterList;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    NewDeclaration* syntaxCopy(Dsymbol* s);
     const char* kind() const;
     bool isVirtual() const;
     bool addPreInvariant();
@@ -5145,7 +5144,7 @@ class TypeError final : public Type
 {
 public:
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeError* syntaxCopy();
     d_uns64 size(const Loc& loc);
     Expression* defaultInitLiteral(const Loc& loc);
     void accept(Visitor* v);
@@ -5179,7 +5178,7 @@ public:
     const char* dstring;
     uint32_t flags;
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeBasic* syntaxCopy();
     d_uns64 size(const Loc& loc) /* const */;
     uint32_t alignsize();
     bool isintegral();
@@ -5201,7 +5200,7 @@ public:
     Type* basetype;
     static TypeVector* create(Type* basetype);
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeVector* syntaxCopy();
     d_uns64 size(const Loc& loc);
     uint32_t alignsize();
     bool isintegral();
@@ -5227,7 +5226,7 @@ class TypeSArray final : public TypeArray
 public:
     Expression* dim;
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeSArray* syntaxCopy();
     d_uns64 size(const Loc& loc);
     uint32_t alignsize();
     bool isString();
@@ -5247,7 +5246,7 @@ class TypeDArray final : public TypeArray
 {
 public:
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeDArray* syntaxCopy();
     d_uns64 size(const Loc& loc) /* const */;
     uint32_t alignsize() /* const */;
     bool isString();
@@ -5265,7 +5264,7 @@ public:
     Loc loc;
     static TypeAArray* create(Type* t, Type* index);
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeAArray* syntaxCopy();
     d_uns64 size(const Loc& loc) /* const */;
     bool isZeroInit(const Loc& loc) /* const */;
     bool isBoolean() /* const */;
@@ -5280,7 +5279,7 @@ class TypePointer final : public TypeNext
 public:
     static TypePointer* create(Type* t);
     const char* kind() const;
-    Type* syntaxCopy();
+    TypePointer* syntaxCopy();
     d_uns64 size(const Loc& loc) /* const */;
     MATCH implicitConvTo(Type* to);
     MATCH constConv(Type* to);
@@ -5294,7 +5293,7 @@ class TypeReference final : public TypeNext
 {
 public:
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeReference* syntaxCopy();
     d_uns64 size(const Loc& loc) /* const */;
     bool isZeroInit(const Loc& loc) /* const */;
     void accept(Visitor* v);
@@ -5351,7 +5350,7 @@ public:
     Array<Expression* >* fargs;
     static TypeFunction* create(Array<Parameter* >* parameters, Type* treturn, uint8_t varargs, LINK linkage, StorageClass stc = 0);
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeFunction* syntaxCopy();
     void purityLevel();
     bool hasLazyParameters();
     bool isDstyleVariadic() const;
@@ -5393,7 +5392,7 @@ class TypeDelegate final : public TypeNext
 public:
     static TypeDelegate* create(Type* t);
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeDelegate* syntaxCopy();
     Type* addStorageClass(StorageClass stc);
     d_uns64 size(const Loc& loc) /* const */;
     uint32_t alignsize() /* const */;
@@ -5411,7 +5410,7 @@ public:
     TraitsExp* exp;
     Dsymbol* sym;
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeTraits* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
     void accept(Visitor* v);
     d_uns64 size(const Loc& loc);
@@ -5423,7 +5422,7 @@ public:
     Loc loc;
     Array<Expression* >* exps;
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeMixin* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
     void accept(Visitor* v);
 };
@@ -5433,6 +5432,7 @@ class TypeQualified : public Type
 public:
     Loc loc;
     Array<RootObject* > idents;
+    TypeQualified* syntaxCopy() = 0;
     void syntaxCopyHelper(TypeQualified* t);
     void addIdent(Identifier* ident);
     void addInst(TemplateInstance* inst);
@@ -5448,7 +5448,7 @@ public:
     Identifier* ident;
     Dsymbol* originalSymbol;
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeIdentifier* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
     void accept(Visitor* v);
     ~TypeIdentifier();
@@ -5459,7 +5459,7 @@ class TypeInstance final : public TypeQualified
 public:
     TemplateInstance* tempinst;
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeInstance* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
     void accept(Visitor* v);
     ~TypeInstance();
@@ -5471,7 +5471,7 @@ public:
     Expression* exp;
     int32_t inuse;
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeTypeof* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
     d_uns64 size(const Loc& loc);
     void accept(Visitor* v);
@@ -5482,7 +5482,7 @@ class TypeReturn final : public TypeQualified
 {
 public:
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeReturn* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
     void accept(Visitor* v);
     ~TypeReturn();
@@ -5508,7 +5508,7 @@ public:
     const char* kind() const;
     d_uns64 size(const Loc& loc);
     uint32_t alignsize();
-    Type* syntaxCopy();
+    TypeStruct* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
     uint32_t alignment();
     Expression* defaultInitLiteral(const Loc& loc);
@@ -5532,7 +5532,7 @@ class TypeEnum final : public Type
 public:
     EnumDeclaration* sym;
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeEnum* syntaxCopy();
     d_uns64 size(const Loc& loc);
     Type* memType(const Loc& loc = Loc::initial);
     uint32_t alignsize();
@@ -5567,7 +5567,7 @@ public:
     CPPMANGLE cppmangle;
     const char* kind() const;
     d_uns64 size(const Loc& loc) /* const */;
-    Type* syntaxCopy();
+    TypeClass* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
     ClassDeclaration* isClassHandle();
     bool isBaseOf(Type* t, int32_t* poffset);
@@ -5592,7 +5592,7 @@ public:
     static TypeTuple* create(Type* t1);
     static TypeTuple* create(Type* t1, Type* t2);
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeTuple* syntaxCopy();
     bool equals(const RootObject* const o) const;
     void accept(Visitor* v);
 };
@@ -5603,7 +5603,7 @@ public:
     Expression* lwr;
     Expression* upr;
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeSlice* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -5611,7 +5611,7 @@ class TypeNull final : public Type
 {
 public:
     const char* kind() const;
-    Type* syntaxCopy();
+    TypeNull* syntaxCopy();
     MATCH implicitConvTo(Type* to);
     bool hasPointers();
     bool isBoolean() /* const */;
@@ -5677,7 +5677,7 @@ class Nspace final : public ScopeDsymbol
 {
 public:
     Expression* identExp;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    Nspace* syntaxCopy(Dsymbol* s);
     void addMember(Scope* sc, ScopeDsymbol* sds);
     void setScope(Scope* sc);
     Dsymbol* search(const Loc& loc, Identifier* ident, int32_t flags = 8);
@@ -6154,7 +6154,7 @@ public:
 class ErrorStatement final : public Statement
 {
 public:
-    Statement* syntaxCopy();
+    ErrorStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6170,7 +6170,7 @@ class ExpStatement : public Statement
 public:
     Expression* exp;
     static ExpStatement* create(Loc loc, Expression* exp);
-    Statement* syntaxCopy();
+    ExpStatement* syntaxCopy();
     Statement* scopeCode(Scope* sc, Statement** sentry, Statement** sexception, Statement** sfinally);
     Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
@@ -6180,7 +6180,7 @@ class DtorExpStatement final : public ExpStatement
 {
 public:
     VarDeclaration* var;
-    Statement* syntaxCopy();
+    DtorExpStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6188,7 +6188,7 @@ class CompileStatement final : public Statement
 {
 public:
     Array<Expression* >* exps;
-    Statement* syntaxCopy();
+    CompileStatement* syntaxCopy();
     Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
@@ -6198,7 +6198,7 @@ class CompoundStatement : public Statement
 public:
     Array<Statement* >* statements;
     static CompoundStatement* create(Loc loc, Statement* s1, Statement* s2);
-    Statement* syntaxCopy();
+    CompoundStatement* syntaxCopy();
     Array<Statement* >* flatten(Scope* sc);
     ReturnStatement* endsWithReturnStatement();
     Statement* last();
@@ -6208,7 +6208,7 @@ public:
 class CompoundDeclarationStatement final : public CompoundStatement
 {
 public:
-    Statement* syntaxCopy();
+    CompoundDeclarationStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6216,7 +6216,7 @@ class UnrolledLoopStatement final : public Statement
 {
 public:
     Array<Statement* >* statements;
-    Statement* syntaxCopy();
+    UnrolledLoopStatement* syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
     void accept(Visitor* v);
@@ -6227,7 +6227,7 @@ class ScopeStatement : public Statement
 public:
     Statement* statement;
     Loc endloc;
-    Statement* syntaxCopy();
+    ScopeStatement* syntaxCopy();
     ReturnStatement* endsWithReturnStatement();
     bool hasBreak() const;
     bool hasContinue() const;
@@ -6239,7 +6239,7 @@ class ForwardingStatement final : public Statement
 public:
     ForwardingScopeDsymbol* sym;
     Statement* statement;
-    Statement* syntaxCopy();
+    ForwardingStatement* syntaxCopy();
     Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
@@ -6250,7 +6250,7 @@ public:
     Expression* condition;
     Statement* _body;
     Loc endloc;
-    Statement* syntaxCopy();
+    WhileStatement* syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
     void accept(Visitor* v);
@@ -6262,7 +6262,7 @@ public:
     Statement* _body;
     Expression* condition;
     Loc endloc;
-    Statement* syntaxCopy();
+    DoStatement* syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
     void accept(Visitor* v);
@@ -6277,7 +6277,7 @@ public:
     Statement* _body;
     Loc endloc;
     Statement* relatedLabeled;
-    Statement* syntaxCopy();
+    ForStatement* syntaxCopy();
     Statement* scopeCode(Scope* sc, Statement** sentry, Statement** sexception, Statement** sfinally);
     Statement* getRelatedLabeled();
     bool hasBreak() const;
@@ -6298,7 +6298,7 @@ public:
     FuncDeclaration* func;
     Array<Statement* >* cases;
     Array<ScopeStatement* >* gotos;
-    Statement* syntaxCopy();
+    ForeachStatement* syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
     void accept(Visitor* v);
@@ -6314,7 +6314,7 @@ public:
     Statement* _body;
     Loc endloc;
     VarDeclaration* key;
-    Statement* syntaxCopy();
+    ForeachRangeStatement* syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
     void accept(Visitor* v);
@@ -6329,7 +6329,7 @@ public:
     Statement* elsebody;
     VarDeclaration* match;
     Loc endloc;
-    Statement* syntaxCopy();
+    IfStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6339,7 +6339,7 @@ public:
     Condition* condition;
     Statement* ifbody;
     Statement* elsebody;
-    Statement* syntaxCopy();
+    ConditionalStatement* syntaxCopy();
     Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
@@ -6348,7 +6348,7 @@ class StaticForeachStatement final : public Statement
 {
 public:
     StaticForeach* sfe;
-    Statement* syntaxCopy();
+    StaticForeachStatement* syntaxCopy();
     Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
@@ -6359,7 +6359,7 @@ public:
     const Identifier* const ident;
     Array<Expression* >* args;
     Statement* _body;
-    Statement* syntaxCopy();
+    PragmaStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6367,7 +6367,7 @@ class StaticAssertStatement final : public Statement
 {
 public:
     StaticAssert* sa;
-    Statement* syntaxCopy();
+    StaticAssertStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6385,7 +6385,7 @@ public:
     int32_t hasNoDefault;
     int32_t hasVars;
     VarDeclaration* lastVar;
-    Statement* syntaxCopy();
+    SwitchStatement* syntaxCopy();
     bool hasBreak() const;
     void accept(Visitor* v);
     ~SwitchStatement();
@@ -6399,7 +6399,7 @@ public:
     int32_t index;
     VarDeclaration* lastVar;
     void* extra;
-    Statement* syntaxCopy();
+    CaseStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6409,7 +6409,7 @@ public:
     Expression* first;
     Expression* last;
     Statement* statement;
-    Statement* syntaxCopy();
+    CaseRangeStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6418,7 +6418,7 @@ class DefaultStatement final : public Statement
 public:
     Statement* statement;
     VarDeclaration* lastVar;
-    Statement* syntaxCopy();
+    DefaultStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6426,7 +6426,7 @@ class GotoDefaultStatement final : public Statement
 {
 public:
     SwitchStatement* sw;
-    Statement* syntaxCopy();
+    GotoDefaultStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6435,7 +6435,7 @@ class GotoCaseStatement final : public Statement
 public:
     Expression* exp;
     CaseStatement* cs;
-    Statement* syntaxCopy();
+    GotoCaseStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6451,7 +6451,7 @@ class ReturnStatement final : public Statement
 public:
     Expression* exp;
     size_t caseDim;
-    Statement* syntaxCopy();
+    ReturnStatement* syntaxCopy();
     ReturnStatement* endsWithReturnStatement();
     void accept(Visitor* v);
 };
@@ -6460,7 +6460,7 @@ class BreakStatement final : public Statement
 {
 public:
     Identifier* ident;
-    Statement* syntaxCopy();
+    BreakStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6468,7 +6468,7 @@ class ContinueStatement final : public Statement
 {
 public:
     Identifier* ident;
-    Statement* syntaxCopy();
+    ContinueStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6477,7 +6477,7 @@ class SynchronizedStatement final : public Statement
 public:
     Expression* exp;
     Statement* _body;
-    Statement* syntaxCopy();
+    SynchronizedStatement* syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
     void accept(Visitor* v);
@@ -6490,7 +6490,7 @@ public:
     Statement* _body;
     VarDeclaration* wthis;
     Loc endloc;
-    Statement* syntaxCopy();
+    WithStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6500,7 +6500,7 @@ public:
     Statement* _body;
     Array<Catch* >* catches;
     Statement* tryBody;
-    Statement* syntaxCopy();
+    TryCatchStatement* syntaxCopy();
     bool hasBreak() const;
     void accept(Visitor* v);
 };
@@ -6526,7 +6526,7 @@ public:
     Statement* tryBody;
     bool bodyFallsThru;
     static TryFinallyStatement* create(Loc loc, Statement* _body, Statement* finalbody);
-    Statement* syntaxCopy();
+    TryFinallyStatement* syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
     void accept(Visitor* v);
@@ -6537,7 +6537,7 @@ class ScopeGuardStatement final : public Statement
 public:
     TOK tok;
     Statement* statement;
-    Statement* syntaxCopy();
+    ScopeGuardStatement* syntaxCopy();
     Statement* scopeCode(Scope* sc, Statement** sentry, Statement** sexception, Statement** sfinally);
     void accept(Visitor* v);
 };
@@ -6547,7 +6547,7 @@ class ThrowStatement final : public Statement
 public:
     Expression* exp;
     bool internalThrow;
-    Statement* syntaxCopy();
+    ThrowStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6555,7 +6555,7 @@ class DebugStatement final : public Statement
 {
 public:
     Statement* statement;
-    Statement* syntaxCopy();
+    DebugStatement* syntaxCopy();
     Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
@@ -6569,7 +6569,7 @@ public:
     TryFinallyStatement* tf;
     ScopeGuardStatement* os;
     VarDeclaration* lastVar;
-    Statement* syntaxCopy();
+    GotoStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6585,7 +6585,7 @@ public:
     Statement* gotoTarget;
     void* extra;
     bool breaks;
-    Statement* syntaxCopy();
+    LabelStatement* syntaxCopy();
     Array<Statement* >* flatten(Scope* sc);
     Statement* scopeCode(Scope* sc, Statement** sentry, Statement** sexit, Statement** sfinally);
     void accept(Visitor* v);
@@ -6606,7 +6606,7 @@ class AsmStatement : public Statement
 {
 public:
     Token* tokens;
-    Statement* syntaxCopy();
+    AsmStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6618,7 +6618,7 @@ public:
     uint32_t regs;
     bool refparam;
     bool naked;
-    Statement* syntaxCopy();
+    InlineAsmStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6634,7 +6634,7 @@ public:
     Array<Expression* >* clobbers;
     Array<Identifier* >* labels;
     Array<GotoStatement* >* gotos;
-    Statement* syntaxCopy();
+    GccAsmStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6651,7 +6651,7 @@ class ImportStatement final : public Statement
 {
 public:
     Array<Dsymbol* >* imports;
-    Statement* syntaxCopy();
+    ImportStatement* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -6662,7 +6662,7 @@ class StaticAssert final : public Dsymbol
 public:
     Expression* exp;
     Expression* msg;
-    Dsymbol* syntaxCopy(Dsymbol* s);
+    StaticAssert* syntaxCopy(Dsymbol* s);
     void addMember(Scope* sc, ScopeDsymbol* sds);
     bool oneMember(Dsymbol** ps, Identifier* ident);
     const char* kind() const;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -374,7 +374,7 @@ extern (C++) class FuncDeclaration : Declaration
         return new FuncDeclaration(loc, endloc, id, storage_class, type);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override FuncDeclaration syntaxCopy(Dsymbol s)
     {
         //printf("FuncDeclaration::syntaxCopy('%s')\n", toChars());
         FuncDeclaration f = s ? cast(FuncDeclaration)s : new FuncDeclaration(loc, endloc, ident, storage_class, type.syntaxCopy());
@@ -3451,13 +3451,14 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
         //printf("FuncLiteralDeclaration() id = '%s', type = '%s'\n", this.ident.toChars(), type.toChars());
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override FuncLiteralDeclaration syntaxCopy(Dsymbol s)
     {
         //printf("FuncLiteralDeclaration::syntaxCopy('%s')\n", toChars());
         assert(!s);
         auto f = new FuncLiteralDeclaration(loc, endloc, type.syntaxCopy(), tok, fes, ident);
         f.treq = treq; // don't need to copy
-        return FuncDeclaration.syntaxCopy(f);
+        FuncDeclaration.syntaxCopy(f);
+        return f;
     }
 
     override bool isNested() const
@@ -3578,11 +3579,12 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
         //printf("CtorDeclaration(loc = %s) %s\n", loc.toChars(), toChars());
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override CtorDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto f = new CtorDeclaration(loc, endloc, storage_class, type.syntaxCopy());
-        return FuncDeclaration.syntaxCopy(f);
+        FuncDeclaration.syntaxCopy(f);
+        return f;
     }
 
     override const(char)* kind() const
@@ -3630,11 +3632,12 @@ extern (C++) final class PostBlitDeclaration : FuncDeclaration
         super(loc, endloc, id, stc, null);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override PostBlitDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto dd = new PostBlitDeclaration(loc, endloc, storage_class, ident);
-        return FuncDeclaration.syntaxCopy(dd);
+        FuncDeclaration.syntaxCopy(dd);
+        return dd;
     }
 
     override bool isVirtual() const
@@ -3682,11 +3685,12 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
         super(loc, endloc, id, stc, null);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override DtorDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto dd = new DtorDeclaration(loc, endloc, storage_class, ident);
-        return FuncDeclaration.syntaxCopy(dd);
+        FuncDeclaration.syntaxCopy(dd);
+        return dd;
     }
 
     override const(char)* kind() const
@@ -3746,11 +3750,12 @@ extern (C++) class StaticCtorDeclaration : FuncDeclaration
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override StaticCtorDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto scd = new StaticCtorDeclaration(loc, endloc, storage_class);
-        return FuncDeclaration.syntaxCopy(scd);
+        FuncDeclaration.syntaxCopy(scd);
+        return scd;
     }
 
     override final inout(AggregateDeclaration) isThis() inout
@@ -3798,11 +3803,12 @@ extern (C++) final class SharedStaticCtorDeclaration : StaticCtorDeclaration
         super(loc, endloc, "_sharedStaticCtor", stc);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override SharedStaticCtorDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto scd = new SharedStaticCtorDeclaration(loc, endloc, storage_class);
-        return FuncDeclaration.syntaxCopy(scd);
+        FuncDeclaration.syntaxCopy(scd);
+        return scd;
     }
 
     override inout(SharedStaticCtorDeclaration) isSharedStaticCtorDeclaration() inout
@@ -3832,11 +3838,12 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override StaticDtorDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto sdd = new StaticDtorDeclaration(loc, endloc, storage_class);
-        return FuncDeclaration.syntaxCopy(sdd);
+        FuncDeclaration.syntaxCopy(sdd);
+        return sdd;
     }
 
     override final inout(AggregateDeclaration) isThis() inout
@@ -3884,11 +3891,12 @@ extern (C++) final class SharedStaticDtorDeclaration : StaticDtorDeclaration
         super(loc, endloc, "_sharedStaticDtor", stc);
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override SharedStaticDtorDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto sdd = new SharedStaticDtorDeclaration(loc, endloc, storage_class);
-        return FuncDeclaration.syntaxCopy(sdd);
+        FuncDeclaration.syntaxCopy(sdd);
+        return sdd;
     }
 
     override inout(SharedStaticDtorDeclaration) isSharedStaticDtorDeclaration() inout
@@ -3912,11 +3920,12 @@ extern (C++) final class InvariantDeclaration : FuncDeclaration
         this.fbody = fbody;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override InvariantDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto id = new InvariantDeclaration(loc, endloc, storage_class, null, null);
-        return FuncDeclaration.syntaxCopy(id);
+        FuncDeclaration.syntaxCopy(id);
+        return id;
     }
 
     override bool isVirtual() const
@@ -3961,11 +3970,12 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
         this.codedoc = codedoc;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override UnitTestDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto utd = new UnitTestDeclaration(loc, endloc, storage_class, codedoc);
-        return FuncDeclaration.syntaxCopy(utd);
+        FuncDeclaration.syntaxCopy(utd);
+        return utd;
     }
 
     override inout(AggregateDeclaration) isThis() inout
@@ -4011,12 +4021,13 @@ extern (C++) final class NewDeclaration : FuncDeclaration
         this.parameterList = parameterList;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override NewDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         auto parameterList = parameterList.syntaxCopy();
         auto f = new NewDeclaration(loc, endloc, storage_class, parameterList);
-        return FuncDeclaration.syntaxCopy(f);
+        FuncDeclaration.syntaxCopy(f);
+        return f;
     }
 
     override const(char)* kind() const

--- a/src/dmd/import.h
+++ b/src/dmd/import.h
@@ -40,7 +40,7 @@ public:
 
     const char *kind() const;
     Prot prot();
-    Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
+    Import *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     void load(Scope *sc);
     void importAll(Scope *sc);
     Dsymbol *toAlias();

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2728,7 +2728,7 @@ extern (C++) final class TypeError : Type
         return "error";
     }
 
-    override Type syntaxCopy()
+    override TypeError syntaxCopy()
     {
         // No semantic analysis done, no need to copy
         return this;
@@ -3195,7 +3195,7 @@ extern (C++) final class TypeBasic : Type
         return dstring;
     }
 
-    override Type syntaxCopy()
+    override TypeBasic syntaxCopy()
     {
         // No semantic analysis done on basic types, no need to copy
         return this;
@@ -3471,7 +3471,7 @@ extern (C++) final class TypeVector : Type
         return "vector";
     }
 
-    override Type syntaxCopy()
+    override TypeVector syntaxCopy()
     {
         return new TypeVector(basetype.syntaxCopy());
     }
@@ -3600,13 +3600,13 @@ extern (C++) final class TypeSArray : TypeArray
         return "sarray";
     }
 
-    override Type syntaxCopy()
+    override TypeSArray syntaxCopy()
     {
         Type t = next.syntaxCopy();
         Expression e = dim.syntaxCopy();
-        t = new TypeSArray(t, e);
-        t.mod = mod;
-        return t;
+        auto result = new TypeSArray(t, e);
+        result.mod = mod;
+        return result;
     }
 
     override d_uns64 size(const ref Loc loc)
@@ -3792,17 +3792,15 @@ extern (C++) final class TypeDArray : TypeArray
         return "darray";
     }
 
-    override Type syntaxCopy()
+    override TypeDArray syntaxCopy()
     {
         Type t = next.syntaxCopy();
         if (t == next)
-            t = this;
-        else
-        {
-            t = new TypeDArray(t);
-            t.mod = mod;
-        }
-        return t;
+            return this;
+
+        auto result = new TypeDArray(t);
+        result.mod = mod;
+        return result;
     }
 
     override d_uns64 size(const ref Loc loc) const
@@ -3897,18 +3895,16 @@ extern (C++) final class TypeAArray : TypeArray
         return "aarray";
     }
 
-    override Type syntaxCopy()
+    override TypeAArray syntaxCopy()
     {
         Type t = next.syntaxCopy();
         Type ti = index.syntaxCopy();
         if (t == next && ti == index)
-            t = this;
-        else
-        {
-            t = new TypeAArray(t, ti);
-            t.mod = mod;
-        }
-        return t;
+            return this;
+
+        auto result = new TypeAArray(t, ti);
+        result.mod = mod;
+        return result;
     }
 
     override d_uns64 size(const ref Loc loc) const
@@ -3992,17 +3988,15 @@ extern (C++) final class TypePointer : TypeNext
         return "pointer";
     }
 
-    override Type syntaxCopy()
+    override TypePointer syntaxCopy()
     {
         Type t = next.syntaxCopy();
         if (t == next)
-            t = this;
-        else
-        {
-            t = new TypePointer(t);
-            t.mod = mod;
-        }
-        return t;
+            return this;
+
+        auto result = new TypePointer(t);
+        result.mod = mod;
+        return result;
     }
 
     override d_uns64 size(const ref Loc loc) const
@@ -4125,17 +4119,15 @@ extern (C++) final class TypeReference : TypeNext
         return "reference";
     }
 
-    override Type syntaxCopy()
+    override TypeReference syntaxCopy()
     {
         Type t = next.syntaxCopy();
         if (t == next)
-            t = this;
-        else
-        {
-            t = new TypeReference(t);
-            t.mod = mod;
-        }
-        return t;
+            return this;
+
+        auto result = new TypeReference(t);
+        result.mod = mod;
+        return result;
     }
 
     override d_uns64 size(const ref Loc loc) const
@@ -4268,7 +4260,7 @@ extern (C++) final class TypeFunction : TypeNext
         return "function";
     }
 
-    override Type syntaxCopy()
+    override TypeFunction syntaxCopy()
     {
         Type treturn = next ? next.syntaxCopy() : null;
         auto t = new TypeFunction(parameterList.syntaxCopy(), treturn, linkage);
@@ -5251,17 +5243,15 @@ extern (C++) final class TypeDelegate : TypeNext
         return "delegate";
     }
 
-    override Type syntaxCopy()
+    override TypeDelegate syntaxCopy()
     {
         Type t = next.syntaxCopy();
         if (t == next)
-            t = this;
-        else
-        {
-            t = new TypeDelegate(t);
-            t.mod = mod;
-        }
-        return t;
+            return this;
+
+        auto result = new TypeDelegate(t);
+        result.mod = mod;
+        return result;
     }
 
     override Type addStorageClass(StorageClass stc)
@@ -5377,9 +5367,9 @@ extern (C++) final class TypeTraits : Type
         return "traits";
     }
 
-    override Type syntaxCopy()
+    override TypeTraits syntaxCopy()
     {
-        TraitsExp te = cast(TraitsExp) exp.syntaxCopy();
+        TraitsExp te = exp.syntaxCopy();
         TypeTraits tt = new TypeTraits(loc, te);
         tt.mod = mod;
         return tt;
@@ -5432,7 +5422,7 @@ extern (C++) final class TypeMixin : Type
         return "mixin";
     }
 
-    override Type syntaxCopy()
+    override TypeMixin syntaxCopy()
     {
         return new TypeMixin(loc, Expression.arraySyntaxCopy(exps));
     }
@@ -5473,6 +5463,10 @@ extern (C++) abstract class TypeQualified : Type
         this.loc = loc;
     }
 
+    // abstract override so that using `TypeQualified.syntaxCopy` gets
+    // us a `TypeQualified`
+    abstract override TypeQualified syntaxCopy();
+
     final void syntaxCopyHelper(TypeQualified t)
     {
         //printf("TypeQualified::syntaxCopyHelper(%s) %s\n", t.toChars(), toChars());
@@ -5491,7 +5485,7 @@ extern (C++) abstract class TypeQualified : Type
                 break;
             case dsymbol:
                 TemplateInstance ti = cast(TemplateInstance)id;
-                ti = cast(TemplateInstance)ti.syntaxCopy(null);
+                ti = ti.syntaxCopy(null);
                 id = ti;
                 break;
             case type:
@@ -5557,7 +5551,7 @@ extern (C++) final class TypeIdentifier : TypeQualified
         return "identifier";
     }
 
-    override Type syntaxCopy()
+    override TypeIdentifier syntaxCopy()
     {
         auto t = new TypeIdentifier(loc, ident);
         t.syntaxCopyHelper(this);
@@ -5611,10 +5605,10 @@ extern (C++) final class TypeInstance : TypeQualified
         return "instance";
     }
 
-    override Type syntaxCopy()
+    override TypeInstance syntaxCopy()
     {
         //printf("TypeInstance::syntaxCopy() %s, %d\n", toChars(), idents.dim);
-        auto t = new TypeInstance(loc, cast(TemplateInstance)tempinst.syntaxCopy(null));
+        auto t = new TypeInstance(loc, tempinst.syntaxCopy(null));
         t.syntaxCopyHelper(this);
         t.mod = mod;
         return t;
@@ -5656,7 +5650,7 @@ extern (C++) final class TypeTypeof : TypeQualified
         return "typeof";
     }
 
-    override Type syntaxCopy()
+    override TypeTypeof syntaxCopy()
     {
         //printf("TypeTypeof::syntaxCopy() %s\n", toChars());
         auto t = new TypeTypeof(loc, exp.syntaxCopy());
@@ -5703,7 +5697,7 @@ extern (C++) final class TypeReturn : TypeQualified
         return "return";
     }
 
-    override Type syntaxCopy()
+    override TypeReturn syntaxCopy()
     {
         auto t = new TypeReturn(loc);
         t.syntaxCopyHelper(this);
@@ -5772,7 +5766,7 @@ extern (C++) final class TypeStruct : Type
         return sym.alignsize;
     }
 
-    override Type syntaxCopy()
+    override TypeStruct syntaxCopy()
     {
         return this;
     }
@@ -6094,7 +6088,7 @@ extern (C++) final class TypeEnum : Type
         return "enum";
     }
 
-    override Type syntaxCopy()
+    override TypeEnum syntaxCopy()
     {
         return this;
     }
@@ -6266,7 +6260,7 @@ extern (C++) final class TypeClass : Type
         return target.ptrsize;
     }
 
-    override Type syntaxCopy()
+    override TypeClass syntaxCopy()
     {
         return this;
     }
@@ -6512,10 +6506,10 @@ extern (C++) final class TypeTuple : Type
         return "tuple";
     }
 
-    override Type syntaxCopy()
+    override TypeTuple syntaxCopy()
     {
         Parameters* args = Parameter.arraySyntaxCopy(arguments);
-        Type t = new TypeTuple(args);
+        auto t = new TypeTuple(args);
         t.mod = mod;
         return t;
     }
@@ -6570,9 +6564,9 @@ extern (C++) final class TypeSlice : TypeNext
         return "slice";
     }
 
-    override Type syntaxCopy()
+    override TypeSlice syntaxCopy()
     {
-        Type t = new TypeSlice(next.syntaxCopy(), lwr.syntaxCopy(), upr.syntaxCopy());
+        auto t = new TypeSlice(next.syntaxCopy(), lwr.syntaxCopy(), upr.syntaxCopy());
         t.mod = mod;
         return t;
     }
@@ -6598,7 +6592,7 @@ extern (C++) final class TypeNull : Type
         return "null";
     }
 
-    override Type syntaxCopy()
+    override TypeNull syntaxCopy()
     {
         // No semantic analysis done, no need to copy
         return this;
@@ -6757,7 +6751,7 @@ extern (C++) final class Parameter : ASTNode
 
     Parameter syntaxCopy()
     {
-        return new Parameter(storageClass, type ? type.syntaxCopy() : null, ident, defaultArg ? defaultArg.syntaxCopy() : null, userAttribDecl ? cast(UserAttributeDeclaration) userAttribDecl.syntaxCopy(null) : null);
+        return new Parameter(storageClass, type ? type.syntaxCopy() : null, ident, defaultArg ? defaultArg.syntaxCopy() : null, userAttribDecl ? userAttribDecl.syntaxCopy(null) : null);
     }
 
     /****************************************************

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -339,7 +339,7 @@ class TypeError : public Type
 {
 public:
     const char *kind();
-    Type *syntaxCopy();
+    TypeError *syntaxCopy();
 
     d_uns64 size(const Loc &loc);
     Expression *defaultInitLiteral(const Loc &loc);
@@ -376,7 +376,7 @@ public:
     unsigned flags;
 
     const char *kind();
-    Type *syntaxCopy();
+    TypeBasic *syntaxCopy();
     d_uns64 size(const Loc &loc) /*const*/;
     unsigned alignsize();
     bool isintegral();
@@ -401,7 +401,7 @@ public:
 
     static TypeVector *create(Type *basetype);
     const char *kind();
-    Type *syntaxCopy();
+    TypeVector *syntaxCopy();
     d_uns64 size(const Loc &loc);
     unsigned alignsize();
     bool isintegral();
@@ -430,7 +430,7 @@ public:
     Expression *dim;
 
     const char *kind();
-    Type *syntaxCopy();
+    TypeSArray *syntaxCopy();
     d_uns64 size(const Loc &loc);
     unsigned alignsize();
     bool isString();
@@ -452,7 +452,7 @@ class TypeDArray : public TypeArray
 {
 public:
     const char *kind();
-    Type *syntaxCopy();
+    TypeDArray *syntaxCopy();
     d_uns64 size(const Loc &loc) /*const*/;
     unsigned alignsize() /*const*/;
     bool isString();
@@ -472,7 +472,7 @@ public:
 
     static TypeAArray *create(Type *t, Type *index);
     const char *kind();
-    Type *syntaxCopy();
+    TypeAArray *syntaxCopy();
     d_uns64 size(const Loc &loc);
     bool isZeroInit(const Loc &loc) /*const*/;
     bool isBoolean() /*const*/;
@@ -488,7 +488,7 @@ class TypePointer : public TypeNext
 public:
     static TypePointer *create(Type *t);
     const char *kind();
-    Type *syntaxCopy();
+    TypePointer *syntaxCopy();
     d_uns64 size(const Loc &loc) /*const*/;
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
@@ -503,7 +503,7 @@ class TypeReference : public TypeNext
 {
 public:
     const char *kind();
-    Type *syntaxCopy();
+    TypeReference *syntaxCopy();
     d_uns64 size(const Loc &loc) /*const*/;
     bool isZeroInit(const Loc &loc) /*const*/;
     void accept(Visitor *v) { v->visit(this); }
@@ -586,7 +586,7 @@ public:
 
     static TypeFunction *create(Parameters *parameters, Type *treturn, VarArg varargs, LINK linkage, StorageClass stc = 0);
     const char *kind();
-    Type *syntaxCopy();
+    TypeFunction *syntaxCopy();
     void purityLevel();
     bool hasLazyParameters();
     bool isDstyleVariadic() const;
@@ -632,7 +632,7 @@ public:
 
     static TypeDelegate *create(Type *t);
     const char *kind();
-    Type *syntaxCopy();
+    TypeDelegate *syntaxCopy();
     Type *addStorageClass(StorageClass stc);
     d_uns64 size(const Loc &loc) /*const*/;
     unsigned alignsize() /*const*/;
@@ -653,7 +653,7 @@ class TypeTraits : public Type
     Dsymbol *sym;
 
     const char *kind();
-    Type *syntaxCopy();
+    TypeTraits *syntaxCopy();
     d_uns64 size(const Loc &loc);
     Dsymbol *toDsymbol(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
@@ -665,7 +665,7 @@ class TypeMixin : public Type
     Expressions *exps;
 
     const char *kind();
-    Type *syntaxCopy();
+    TypeMixin *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -694,7 +694,7 @@ public:
     Dsymbol *originalSymbol; // The symbol representing this identifier, before alias resolution
 
     const char *kind();
-    Type *syntaxCopy();
+    TypeIdentifier *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -707,7 +707,7 @@ public:
     TemplateInstance *tempinst;
 
     const char *kind();
-    Type *syntaxCopy();
+    TypeInstance *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -719,7 +719,7 @@ public:
     int inuse;
 
     const char *kind();
-    Type *syntaxCopy();
+    TypeTypeof *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
     d_uns64 size(const Loc &loc);
     void accept(Visitor *v) { v->visit(this); }
@@ -729,7 +729,7 @@ class TypeReturn : public TypeQualified
 {
 public:
     const char *kind();
-    Type *syntaxCopy();
+    TypeReturn *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -757,7 +757,7 @@ public:
     const char *kind();
     d_uns64 size(const Loc &loc);
     unsigned alignsize();
-    Type *syntaxCopy();
+    TypeStruct *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
     structalign_t alignment();
     Expression *defaultInitLiteral(const Loc &loc);
@@ -783,7 +783,7 @@ public:
     EnumDeclaration *sym;
 
     const char *kind();
-    Type *syntaxCopy();
+    TypeEnum *syntaxCopy();
     d_uns64 size(const Loc &loc);
     unsigned alignsize();
     Type *memType(const Loc &loc = Loc());
@@ -820,7 +820,7 @@ public:
 
     const char *kind();
     d_uns64 size(const Loc &loc) /*const*/;
-    Type *syntaxCopy();
+    TypeClass *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
     ClassDeclaration *isClassHandle();
     bool isBaseOf(Type *t, int *poffset);
@@ -849,7 +849,7 @@ public:
     static TypeTuple *create(Type *t1);
     static TypeTuple *create(Type *t1, Type *t2);
     const char *kind();
-    Type *syntaxCopy();
+    TypeTuple *syntaxCopy();
     bool equals(const RootObject *o) const;
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -861,7 +861,7 @@ public:
     Expression *upr;
 
     const char *kind();
-    Type *syntaxCopy();
+    TypeSlice *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -870,7 +870,7 @@ class TypeNull : public Type
 public:
     const char *kind();
 
-    Type *syntaxCopy();
+    TypeNull *syntaxCopy();
     MATCH implicitConvTo(Type *to);
     bool isBoolean() /*const*/;
 

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -75,10 +75,11 @@ extern (C++) final class Nspace : ScopeDsymbol
         this.identExp = identExp;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override Nspace syntaxCopy(Dsymbol s)
     {
         auto ns = new Nspace(loc, ident, identExp, null);
-        return ScopeDsymbol.syntaxCopy(ns);
+        ScopeDsymbol.syntaxCopy(ns);
+        return ns;
     }
 
     override void addMember(Scope* sc, ScopeDsymbol sds)

--- a/src/dmd/nspace.h
+++ b/src/dmd/nspace.h
@@ -20,7 +20,7 @@ class Nspace : public ScopeDsymbol
 {
   public:
     Expression *identExp;
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    Nspace *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -490,7 +490,7 @@ extern (C++) final class ErrorStatement : Statement
         assert(global.gaggedErrors || global.errors);
     }
 
-    override Statement syntaxCopy()
+    override ErrorStatement syntaxCopy()
     {
         return this;
     }
@@ -707,7 +707,7 @@ extern (C++) class ExpStatement : Statement
         return new ExpStatement(loc, exp);
     }
 
-    override Statement syntaxCopy()
+    override ExpStatement syntaxCopy()
     {
         return new ExpStatement(loc, exp ? exp.syntaxCopy() : null);
     }
@@ -793,7 +793,7 @@ extern (C++) final class DtorExpStatement : ExpStatement
         this.var = var;
     }
 
-    override Statement syntaxCopy()
+    override DtorExpStatement syntaxCopy()
     {
         return new DtorExpStatement(loc, exp ? exp.syntaxCopy() : null, var);
     }
@@ -824,7 +824,7 @@ extern (C++) final class CompileStatement : Statement
         this.exps = exps;
     }
 
-    override Statement syntaxCopy()
+    override CompileStatement syntaxCopy()
     {
         return new CompileStatement(loc, Expression.arraySyntaxCopy(exps));
     }
@@ -923,7 +923,7 @@ extern (C++) class CompoundStatement : Statement
         return new CompoundStatement(loc, s1, s2);
     }
 
-    override Statement syntaxCopy()
+    override CompoundStatement syntaxCopy()
     {
         return new CompoundStatement(loc, Statement.arraySyntaxCopy(statements));
     }
@@ -977,7 +977,7 @@ extern (C++) final class CompoundDeclarationStatement : CompoundStatement
         super(loc, statements, STMT.CompoundDeclaration);
     }
 
-    override Statement syntaxCopy()
+    override CompoundDeclarationStatement syntaxCopy()
     {
         auto a = new Statements(statements.dim);
         foreach (i, s; *statements)
@@ -1007,7 +1007,7 @@ extern (C++) final class UnrolledLoopStatement : Statement
         this.statements = statements;
     }
 
-    override Statement syntaxCopy()
+    override UnrolledLoopStatement syntaxCopy()
     {
         auto a = new Statements(statements.dim);
         foreach (i, s; *statements)
@@ -1046,7 +1046,8 @@ extern (C++) class ScopeStatement : Statement
         this.statement = statement;
         this.endloc = endloc;
     }
-    override Statement syntaxCopy()
+
+    override ScopeStatement syntaxCopy()
     {
         return new ScopeStatement(loc, statement ? statement.syntaxCopy() : null, endloc);
     }
@@ -1104,7 +1105,7 @@ extern (C++) final class ForwardingStatement : Statement
         this(loc, sym, statement);
     }
 
-    override Statement syntaxCopy()
+    override ForwardingStatement syntaxCopy()
     {
         return new ForwardingStatement(loc, statement.syntaxCopy());
     }
@@ -1166,7 +1167,7 @@ extern (C++) final class WhileStatement : Statement
         this.endloc = endloc;
     }
 
-    override Statement syntaxCopy()
+    override WhileStatement syntaxCopy()
     {
         return new WhileStatement(loc,
             condition.syntaxCopy(),
@@ -1207,7 +1208,7 @@ extern (C++) final class DoStatement : Statement
         this.endloc = endloc;
     }
 
-    override Statement syntaxCopy()
+    override DoStatement syntaxCopy()
     {
         return new DoStatement(loc,
             _body ? _body.syntaxCopy() : null,
@@ -1257,7 +1258,7 @@ extern (C++) final class ForStatement : Statement
         this.endloc = endloc;
     }
 
-    override Statement syntaxCopy()
+    override ForStatement syntaxCopy()
     {
         return new ForStatement(loc,
             _init ? _init.syntaxCopy() : null,
@@ -1325,7 +1326,7 @@ extern (C++) final class ForeachStatement : Statement
         this.endloc = endloc;
     }
 
-    override Statement syntaxCopy()
+    override ForeachStatement syntaxCopy()
     {
         return new ForeachStatement(loc, op,
             Parameter.arraySyntaxCopy(parameters),
@@ -1375,7 +1376,7 @@ extern (C++) final class ForeachRangeStatement : Statement
         this.endloc = endloc;
     }
 
-    override Statement syntaxCopy()
+    override ForeachRangeStatement syntaxCopy()
     {
         return new ForeachRangeStatement(loc, op, prm.syntaxCopy(), lwr.syntaxCopy(), upr.syntaxCopy(), _body ? _body.syntaxCopy() : null, endloc);
     }
@@ -1418,7 +1419,7 @@ extern (C++) final class IfStatement : Statement
         this.endloc = endloc;
     }
 
-    override Statement syntaxCopy()
+    override IfStatement syntaxCopy()
     {
         return new IfStatement(loc,
             prm ? prm.syntaxCopy() : null,
@@ -1451,7 +1452,7 @@ extern (C++) final class ConditionalStatement : Statement
         this.elsebody = elsebody;
     }
 
-    override Statement syntaxCopy()
+    override ConditionalStatement syntaxCopy()
     {
         return new ConditionalStatement(loc, condition.syntaxCopy(), ifbody.syntaxCopy(), elsebody ? elsebody.syntaxCopy() : null);
     }
@@ -1538,7 +1539,7 @@ extern (C++) final class StaticForeachStatement : Statement
         this.sfe = sfe;
     }
 
-    override Statement syntaxCopy()
+    override StaticForeachStatement syntaxCopy()
     {
         return new StaticForeachStatement(loc, sfe.syntaxCopy());
     }
@@ -1590,7 +1591,7 @@ extern (C++) final class PragmaStatement : Statement
         this._body = _body;
     }
 
-    override Statement syntaxCopy()
+    override PragmaStatement syntaxCopy()
     {
         return new PragmaStatement(loc, ident, Expression.arraySyntaxCopy(args), _body ? _body.syntaxCopy() : null);
     }
@@ -1614,9 +1615,9 @@ extern (C++) final class StaticAssertStatement : Statement
         this.sa = sa;
     }
 
-    override Statement syntaxCopy()
+    override StaticAssertStatement syntaxCopy()
     {
-        return new StaticAssertStatement(cast(StaticAssert)sa.syntaxCopy(null));
+        return new StaticAssertStatement(sa.syntaxCopy(null));
     }
 
     override void accept(Visitor v)
@@ -1651,7 +1652,7 @@ extern (C++) final class SwitchStatement : Statement
         this.isFinal = isFinal;
     }
 
-    override Statement syntaxCopy()
+    override SwitchStatement syntaxCopy()
     {
         return new SwitchStatement(loc, condition.syntaxCopy(), _body.syntaxCopy(), isFinal);
     }
@@ -1726,7 +1727,7 @@ extern (C++) final class CaseStatement : Statement
         this.statement = statement;
     }
 
-    override Statement syntaxCopy()
+    override CaseStatement syntaxCopy()
     {
         return new CaseStatement(loc, exp.syntaxCopy(), statement.syntaxCopy());
     }
@@ -1754,7 +1755,7 @@ extern (C++) final class CaseRangeStatement : Statement
         this.statement = statement;
     }
 
-    override Statement syntaxCopy()
+    override CaseRangeStatement syntaxCopy()
     {
         return new CaseRangeStatement(loc, first.syntaxCopy(), last.syntaxCopy(), statement.syntaxCopy());
     }
@@ -1780,7 +1781,7 @@ extern (C++) final class DefaultStatement : Statement
         this.statement = statement;
     }
 
-    override Statement syntaxCopy()
+    override DefaultStatement syntaxCopy()
     {
         return new DefaultStatement(loc, statement.syntaxCopy());
     }
@@ -1803,7 +1804,7 @@ extern (C++) final class GotoDefaultStatement : Statement
         super(loc, STMT.GotoDefault);
     }
 
-    override Statement syntaxCopy()
+    override GotoDefaultStatement syntaxCopy()
     {
         return new GotoDefaultStatement(loc);
     }
@@ -1829,7 +1830,7 @@ extern (C++) final class GotoCaseStatement : Statement
         this.exp = exp;
     }
 
-    override Statement syntaxCopy()
+    override GotoCaseStatement syntaxCopy()
     {
         return new GotoCaseStatement(loc, exp ? exp.syntaxCopy() : null);
     }
@@ -1877,7 +1878,7 @@ extern (C++) final class ReturnStatement : Statement
         this.exp = exp;
     }
 
-    override Statement syntaxCopy()
+    override ReturnStatement syntaxCopy()
     {
         return new ReturnStatement(loc, exp ? exp.syntaxCopy() : null);
     }
@@ -1906,7 +1907,7 @@ extern (C++) final class BreakStatement : Statement
         this.ident = ident;
     }
 
-    override Statement syntaxCopy()
+    override BreakStatement syntaxCopy()
     {
         return new BreakStatement(loc, ident);
     }
@@ -1930,7 +1931,7 @@ extern (C++) final class ContinueStatement : Statement
         this.ident = ident;
     }
 
-    override Statement syntaxCopy()
+    override ContinueStatement syntaxCopy()
     {
         return new ContinueStatement(loc, ident);
     }
@@ -1956,7 +1957,7 @@ extern (C++) final class SynchronizedStatement : Statement
         this._body = _body;
     }
 
-    override Statement syntaxCopy()
+    override SynchronizedStatement syntaxCopy()
     {
         return new SynchronizedStatement(loc, exp ? exp.syntaxCopy() : null, _body ? _body.syntaxCopy() : null);
     }
@@ -1995,7 +1996,7 @@ extern (C++) final class WithStatement : Statement
         this.endloc = endloc;
     }
 
-    override Statement syntaxCopy()
+    override WithStatement syntaxCopy()
     {
         return new WithStatement(loc, exp.syntaxCopy(), _body ? _body.syntaxCopy() : null, endloc);
     }
@@ -2023,7 +2024,7 @@ extern (C++) final class TryCatchStatement : Statement
         this.catches = catches;
     }
 
-    override Statement syntaxCopy()
+    override TryCatchStatement syntaxCopy()
     {
         auto a = new Catches(catches.dim);
         foreach (i, c; *catches)
@@ -2101,7 +2102,7 @@ extern (C++) final class TryFinallyStatement : Statement
         return new TryFinallyStatement(loc, _body, finalbody);
     }
 
-    override Statement syntaxCopy()
+    override TryFinallyStatement syntaxCopy()
     {
         return new TryFinallyStatement(loc, _body.syntaxCopy(), finalbody.syntaxCopy());
     }
@@ -2137,7 +2138,7 @@ extern (C++) final class ScopeGuardStatement : Statement
         this.statement = statement;
     }
 
-    override Statement syntaxCopy()
+    override ScopeGuardStatement syntaxCopy()
     {
         return new ScopeGuardStatement(loc, tok, statement.syntaxCopy());
     }
@@ -2210,7 +2211,7 @@ extern (C++) final class ThrowStatement : Statement
         this.exp = exp;
     }
 
-    override Statement syntaxCopy()
+    override ThrowStatement syntaxCopy()
     {
         auto s = new ThrowStatement(loc, exp.syntaxCopy());
         s.internalThrow = internalThrow;
@@ -2235,7 +2236,7 @@ extern (C++) final class DebugStatement : Statement
         this.statement = statement;
     }
 
-    override Statement syntaxCopy()
+    override DebugStatement syntaxCopy()
     {
         return new DebugStatement(loc, statement ? statement.syntaxCopy() : null);
     }
@@ -2277,7 +2278,7 @@ extern (C++) final class GotoStatement : Statement
         this.ident = ident;
     }
 
-    override Statement syntaxCopy()
+    override GotoStatement syntaxCopy()
     {
         return new GotoStatement(loc, ident);
     }
@@ -2383,7 +2384,7 @@ extern (C++) final class LabelStatement : Statement
         this.statement = statement;
     }
 
-    override Statement syntaxCopy()
+    override LabelStatement syntaxCopy()
     {
         return new LabelStatement(loc, ident, statement ? statement.syntaxCopy() : null);
     }
@@ -2479,7 +2480,7 @@ extern (C++) class AsmStatement : Statement
         this.tokens = tokens;
     }
 
-    override Statement syntaxCopy()
+    override AsmStatement syntaxCopy()
     {
         return new AsmStatement(loc, tokens);
     }
@@ -2506,7 +2507,7 @@ extern (C++) final class InlineAsmStatement : AsmStatement
         super(loc, tokens, STMT.InlineAsm);
     }
 
-    override Statement syntaxCopy()
+    override InlineAsmStatement syntaxCopy()
     {
         return new InlineAsmStatement(loc, tokens);
     }
@@ -2538,7 +2539,7 @@ extern (C++) final class GccAsmStatement : AsmStatement
         super(loc, tokens, STMT.GccAsm);
     }
 
-    override Statement syntaxCopy()
+    override GccAsmStatement syntaxCopy()
     {
         return new GccAsmStatement(loc, tokens);
     }
@@ -2596,7 +2597,7 @@ extern (C++) final class ImportStatement : Statement
         this.imports = imports;
     }
 
-    override Statement syntaxCopy()
+    override ImportStatement syntaxCopy()
     {
         auto m = new Dsymbols(imports.dim);
         foreach (i, s; *imports)

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -165,7 +165,7 @@ public:
 class ErrorStatement : public Statement
 {
 public:
-    Statement *syntaxCopy();
+    ErrorStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -184,7 +184,7 @@ public:
     Expression *exp;
 
     static ExpStatement *create(Loc loc, Expression *exp);
-    Statement *syntaxCopy();
+    ExpStatement *syntaxCopy();
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
     Statements *flatten(Scope *sc);
 
@@ -199,7 +199,7 @@ public:
 
     VarDeclaration *var;
 
-    Statement *syntaxCopy();
+    DtorExpStatement *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -208,7 +208,7 @@ class CompileStatement : public Statement
 public:
     Expressions *exps;
 
-    Statement *syntaxCopy();
+    CompileStatement *syntaxCopy();
     Statements *flatten(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -219,7 +219,7 @@ public:
     Statements *statements;
 
     static CompoundStatement *create(Loc loc, Statement *s1, Statement *s2);
-    Statement *syntaxCopy();
+    CompoundStatement *syntaxCopy();
     Statements *flatten(Scope *sc);
     ReturnStatement *endsWithReturnStatement();
     Statement *last();
@@ -230,7 +230,7 @@ public:
 class CompoundDeclarationStatement : public CompoundStatement
 {
 public:
-    Statement *syntaxCopy();
+    CompoundDeclarationStatement *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -242,7 +242,7 @@ class UnrolledLoopStatement : public Statement
 public:
     Statements *statements;
 
-    Statement *syntaxCopy();
+    UnrolledLoopStatement *syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
 
@@ -255,7 +255,7 @@ public:
     Statement *statement;
     Loc endloc;                 // location of closing curly bracket
 
-    Statement *syntaxCopy();
+    ScopeStatement *syntaxCopy();
     ReturnStatement *endsWithReturnStatement();
     bool hasBreak() const;
     bool hasContinue() const;
@@ -269,7 +269,7 @@ public:
     ForwardingScopeDsymbol *sym;
     Statement *statement;
 
-    Statement *syntaxCopy();
+    ForwardingStatement *syntaxCopy();
     Statements *flatten(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -281,7 +281,7 @@ public:
     Statement *_body;
     Loc endloc;                 // location of closing curly bracket
 
-    Statement *syntaxCopy();
+    WhileStatement *syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
 
@@ -295,7 +295,7 @@ public:
     Expression *condition;
     Loc endloc;                 // location of ';' after while
 
-    Statement *syntaxCopy();
+    DoStatement *syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
 
@@ -316,7 +316,7 @@ public:
     // treat that label as referring to this loop.
     Statement *relatedLabeled;
 
-    Statement *syntaxCopy();
+    ForStatement *syntaxCopy();
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
     Statement *getRelatedLabeled() { return relatedLabeled ? relatedLabeled : this; }
     bool hasBreak() const;
@@ -342,7 +342,7 @@ public:
     Statements *cases;          // put breaks, continues, gotos and returns here
     ScopeStatements *gotos;     // forward referenced goto's go here
 
-    Statement *syntaxCopy();
+    ForeachStatement *syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
 
@@ -361,7 +361,7 @@ public:
 
     VarDeclaration *key;
 
-    Statement *syntaxCopy();
+    ForeachRangeStatement *syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
 
@@ -378,7 +378,7 @@ public:
     VarDeclaration *match;      // for MatchExpression results
     Loc endloc;                 // location of closing curly bracket
 
-    Statement *syntaxCopy();
+    IfStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -390,7 +390,7 @@ public:
     Statement *ifbody;
     Statement *elsebody;
 
-    Statement *syntaxCopy();
+    ConditionalStatement *syntaxCopy();
     Statements *flatten(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
@@ -401,7 +401,7 @@ class StaticForeachStatement : public Statement
 public:
     StaticForeach *sfe;
 
-    Statement *syntaxCopy();
+    StaticForeachStatement *syntaxCopy();
     Statements *flatten(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
@@ -414,7 +414,7 @@ public:
     Expressions *args;          // array of Expression's
     Statement *_body;
 
-    Statement *syntaxCopy();
+    PragmaStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -424,7 +424,7 @@ class StaticAssertStatement : public Statement
 public:
     StaticAssert *sa;
 
-    Statement *syntaxCopy();
+    StaticAssertStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -445,7 +445,7 @@ public:
     int hasVars;                // !=0 if has variable case values
     VarDeclaration *lastVar;
 
-    Statement *syntaxCopy();
+    SwitchStatement *syntaxCopy();
     bool hasBreak() const;
 
     void accept(Visitor *v) { v->visit(this); }
@@ -461,7 +461,7 @@ public:
     VarDeclaration *lastVar;
     void* extra;            // for use by Statement_toIR()
 
-    Statement *syntaxCopy();
+    CaseStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -474,7 +474,7 @@ public:
     Expression *last;
     Statement *statement;
 
-    Statement *syntaxCopy();
+    CaseRangeStatement *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -485,7 +485,7 @@ public:
     Statement *statement;
     VarDeclaration *lastVar;
 
-    Statement *syntaxCopy();
+    DefaultStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -495,7 +495,7 @@ class GotoDefaultStatement : public Statement
 public:
     SwitchStatement *sw;
 
-    Statement *syntaxCopy();
+    GotoDefaultStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -506,7 +506,7 @@ public:
     Expression *exp;            // NULL, or which case to goto
     CaseStatement *cs;          // case statement it resolves to
 
-    Statement *syntaxCopy();
+    GotoCaseStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -525,7 +525,7 @@ public:
     Expression *exp;
     size_t caseDim;
 
-    Statement *syntaxCopy();
+    ReturnStatement *syntaxCopy();
 
     ReturnStatement *endsWithReturnStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -536,7 +536,7 @@ class BreakStatement : public Statement
 public:
     Identifier *ident;
 
-    Statement *syntaxCopy();
+    BreakStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -546,7 +546,7 @@ class ContinueStatement : public Statement
 public:
     Identifier *ident;
 
-    Statement *syntaxCopy();
+    ContinueStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -557,7 +557,7 @@ public:
     Expression *exp;
     Statement *_body;
 
-    Statement *syntaxCopy();
+    SynchronizedStatement *syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
 
@@ -572,7 +572,7 @@ public:
     VarDeclaration *wthis;
     Loc endloc;
 
-    Statement *syntaxCopy();
+    WithStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -585,7 +585,7 @@ public:
 
     Statement *tryBody;   /// set to enclosing TryCatchStatement or TryFinallyStatement if in _body portion
 
-    Statement *syntaxCopy();
+    TryCatchStatement *syntaxCopy();
     bool hasBreak() const;
 
     void accept(Visitor *v) { v->visit(this); }
@@ -620,7 +620,7 @@ public:
     bool bodyFallsThru;   // true if _body falls through to finally
 
     static TryFinallyStatement *create(Loc loc, Statement *body, Statement *finalbody);
-    Statement *syntaxCopy();
+    TryFinallyStatement *syntaxCopy();
     bool hasBreak() const;
     bool hasContinue() const;
 
@@ -633,7 +633,7 @@ public:
     TOK tok;
     Statement *statement;
 
-    Statement *syntaxCopy();
+    ScopeGuardStatement *syntaxCopy();
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
 
     void accept(Visitor *v) { v->visit(this); }
@@ -647,7 +647,7 @@ public:
     // wasn't present in source code
     bool internalThrow;
 
-    Statement *syntaxCopy();
+    ThrowStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -657,7 +657,7 @@ class DebugStatement : public Statement
 public:
     Statement *statement;
 
-    Statement *syntaxCopy();
+    DebugStatement *syntaxCopy();
     Statements *flatten(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -672,7 +672,7 @@ public:
     ScopeGuardStatement *os;
     VarDeclaration *lastVar;
 
-    Statement *syntaxCopy();
+    GotoStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -690,7 +690,7 @@ public:
     void* extra;                // used by Statement_toIR()
     bool breaks;                // someone did a 'break ident'
 
-    Statement *syntaxCopy();
+    LabelStatement *syntaxCopy();
     Statements *flatten(Scope *sc);
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
 
@@ -717,7 +717,7 @@ class AsmStatement : public Statement
 public:
     Token *tokens;
 
-    Statement *syntaxCopy();
+    AsmStatement *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -730,7 +730,7 @@ public:
     bool refparam;              // true if function parameter is referenced
     bool naked;                 // true if function is to be naked
 
-    Statement *syntaxCopy();
+    InlineAsmStatement *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -748,7 +748,7 @@ public:
     Identifiers *labels;        // list of goto labels
     GotoStatements *gotos;      // of the goto labels, the equivalent statements they represent
 
-    Statement *syntaxCopy();
+    GccAsmStatement *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -769,7 +769,7 @@ class ImportStatement : public Statement
 public:
     Dsymbols *imports;          // Array of Import's
 
-    Statement *syntaxCopy();
+    ImportStatement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/staticassert.d
+++ b/src/dmd/staticassert.d
@@ -36,7 +36,7 @@ extern (C++) final class StaticAssert : Dsymbol
         this.msg = msg;
     }
 
-    override Dsymbol syntaxCopy(Dsymbol s)
+    override StaticAssert syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new StaticAssert(loc, exp.syntaxCopy(), msg ? msg.syntaxCopy() : null);

--- a/src/dmd/staticassert.h
+++ b/src/dmd/staticassert.h
@@ -20,7 +20,7 @@ public:
     Expression *exp;
     Expression *msg;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    StaticAssert *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     const char *kind() const;

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -74,7 +74,7 @@ public:
 
     TemplatePrevious *previous;         // threaded list of previous instantiation attempts on stack
 
-    Dsymbol *syntaxCopy(Dsymbol *);
+    TemplateDeclaration *syntaxCopy(Dsymbol *);
     bool overloadInsert(Dsymbol *s);
     bool hasStaticCtorOrDtor();
     const char *kind() const;
@@ -150,7 +150,7 @@ public:
     Type *defaultType;
 
     TemplateTypeParameter *isTemplateTypeParameter();
-    TemplateParameter *syntaxCopy();
+    TemplateTypeParameter *syntaxCopy();
     bool declareParameter(Scope *sc);
     void print(RootObject *oarg, RootObject *oded);
     RootObject *specialization();
@@ -167,7 +167,7 @@ class TemplateThisParameter : public TemplateTypeParameter
 {
 public:
     TemplateThisParameter *isTemplateThisParameter();
-    TemplateParameter *syntaxCopy();
+    TemplateThisParameter *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -182,7 +182,7 @@ public:
     Expression *defaultValue;
 
     TemplateValueParameter *isTemplateValueParameter();
-    TemplateParameter *syntaxCopy();
+    TemplateValueParameter *syntaxCopy();
     bool declareParameter(Scope *sc);
     void print(RootObject *oarg, RootObject *oded);
     RootObject *specialization();
@@ -203,7 +203,7 @@ public:
     RootObject *defaultAlias;
 
     TemplateAliasParameter *isTemplateAliasParameter();
-    TemplateParameter *syntaxCopy();
+    TemplateAliasParameter *syntaxCopy();
     bool declareParameter(Scope *sc);
     void print(RootObject *oarg, RootObject *oded);
     RootObject *specialization();
@@ -220,7 +220,7 @@ class TemplateTupleParameter : public TemplateParameter
 {
 public:
     TemplateTupleParameter *isTemplateTupleParameter();
-    TemplateParameter *syntaxCopy();
+    TemplateTupleParameter *syntaxCopy();
     bool declareParameter(Scope *sc);
     void print(RootObject *oarg, RootObject *oded);
     RootObject *specialization();
@@ -275,7 +275,7 @@ private:
 public:
     unsigned char inuse;                 // for recursive expansion detection
 
-    Dsymbol *syntaxCopy(Dsymbol *);
+    TemplateInstance *syntaxCopy(Dsymbol *);
     Dsymbol *toAlias();                 // resolve real symbol
     const char *kind() const;
     bool oneMember(Dsymbol **ps, Identifier *ident);
@@ -295,7 +295,7 @@ class TemplateMixin : public TemplateInstance
 public:
     TypeQualified *tqual;
 
-    Dsymbol *syntaxCopy(Dsymbol *s);
+    TemplateMixin *syntaxCopy(Dsymbol *s);
     const char *kind() const;
     bool oneMember(Dsymbol **ps, Identifier *ident);
     bool hasPointers();

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1135,7 +1135,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                                     td.instances[tib] = null;
                                     td.instances.clear();
                                 }
-                                td = cast(TemplateDeclaration) td.syntaxCopy(null);
+                                td = td.syntaxCopy(null);
                                 import core.stdc.string : memcpy;
                                 memcpy(cast(void*) td, cast(void*) s,
                                         __traits(classInstanceSize, TemplateDeclaration));

--- a/src/dmd/version.h
+++ b/src/dmd/version.h
@@ -17,7 +17,7 @@ class DebugSymbol : public Dsymbol
 public:
     unsigned level;
 
-    Dsymbol *syntaxCopy(Dsymbol *);
+    DebugSymbol *syntaxCopy(Dsymbol *);
 
     const char *toChars() const;
     void addMember(Scope *sc, ScopeDsymbol *sds);
@@ -31,7 +31,7 @@ class VersionSymbol : public Dsymbol
 public:
     unsigned level;
 
-    Dsymbol *syntaxCopy(Dsymbol *);
+    VersionSymbol *syntaxCopy(Dsymbol *);
 
     const char *toChars() const;
     void addMember(Scope *sc, ScopeDsymbol *sds);


### PR DESCRIPTION
```
Both D and C++ allow for override to have a covariant return type.
This allow to give more information to the caller, and in particular
permit to avoid `cast`.
```