### PR TITLE
Rename ProtDeclaration to VisibilityDeclaration

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1396,7 +1396,7 @@ struct ASTBase
         }
     }
 
-    extern (C++) final class ProtDeclaration : AttribDeclaration
+    extern (C++) final class VisibilityDeclaration : AttribDeclaration
     {
         Prot protection;
         Identifiers* pkg_identifiers;

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -579,7 +579,7 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
  * `<protection> <decl...>` or
  * `package(<pkg_identifiers>) <decl...>` if `pkg_identifiers !is null`
  */
-extern (C++) final class ProtDeclaration : AttribDeclaration
+extern (C++) final class VisibilityDeclaration : AttribDeclaration
 {
     Prot protection;                /// the visibility
     Identifiers* pkg_identifiers;   /// identifiers for `package(foo.bar)` or null
@@ -616,13 +616,13 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
         }
     }
 
-    override ProtDeclaration syntaxCopy(Dsymbol s)
+    override VisibilityDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         if (protection.kind == Prot.Kind.package_)
-            return new ProtDeclaration(this.loc, pkg_identifiers, Dsymbol.arraySyntaxCopy(decl));
+            return new VisibilityDeclaration(this.loc, pkg_identifiers, Dsymbol.arraySyntaxCopy(decl));
         else
-            return new ProtDeclaration(this.loc, protection, Dsymbol.arraySyntaxCopy(decl));
+            return new VisibilityDeclaration(this.loc, protection, Dsymbol.arraySyntaxCopy(decl));
     }
 
     override Scope* newScope(Scope* sc)
@@ -675,7 +675,7 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
         return buf.extractChars();
     }
 
-    override inout(ProtDeclaration) isProtDeclaration() inout
+    override inout(VisibilityDeclaration) isVisibilityDeclaration() inout
     {
         return this;
     }

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -103,18 +103,18 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
-class ProtDeclaration : public AttribDeclaration
+class VisibilityDeclaration : public AttribDeclaration
 {
 public:
     Prot protection;
     Identifiers* pkg_identifiers;
 
-    ProtDeclaration *syntaxCopy(Dsymbol *s);
+    VisibilityDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     const char *kind() const;
     const char *toPrettyChars(bool unused);
-    ProtDeclaration *isProtDeclaration() { return this; }
+    VisibilityDeclaration *isVisibilityDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -1183,7 +1183,7 @@ private void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
             }
         }
 
-        override void visit(ProtDeclaration pd)
+        override void visit(VisibilityDeclaration pd)
         {
             if (pd.decl)
             {

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -513,7 +513,7 @@ extern (C++) class Dsymbol : ASTNode
      *  module mod;
      *  template Foo(alias a) { mixin Bar!(); }
      *  mixin template Bar() {
-     *    public {  // ProtDeclaration
+     *    public {  // VisibilityDeclaration
      *      void baz() { a = 2; }
      *    }
      *  }
@@ -1258,7 +1258,7 @@ extern (C++) class Dsymbol : ASTNode
     inout(AttribDeclaration)           isAttribDeclaration()           inout { return null; }
     inout(AnonDeclaration)             isAnonDeclaration()             inout { return null; }
     inout(CPPNamespaceDeclaration)     isCPPNamespaceDeclaration()     inout { return null; }
-    inout(ProtDeclaration)             isProtDeclaration()             inout { return null; }
+    inout(VisibilityDeclaration)             isVisibilityDeclaration()             inout { return null; }
     inout(OverloadSet)                 isOverloadSet()                 inout { return null; }
     inout(CompileDeclaration)          isCompileDeclaration()          inout { return null; }
 }

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -47,7 +47,7 @@ class UnitTestDeclaration;
 class NewDeclaration;
 class VarDeclaration;
 class AttribDeclaration;
-class ProtDeclaration;
+class VisibilityDeclaration;
 class Package;
 class Module;
 class Import;
@@ -276,7 +276,7 @@ public:
     virtual AttribDeclaration *isAttribDeclaration() { return NULL; }
     virtual AnonDeclaration *isAnonDeclaration() { return NULL; }
     virtual CPPNamespaceDeclaration *isCPPNamespaceDeclaration() { return NULL; }
-    virtual ProtDeclaration *isProtDeclaration() { return NULL; }
+    virtual VisibilityDeclaration *isVisibilityDeclaration() { return NULL; }
     virtual OverloadSet *isOverloadSet() { return NULL; }
     virtual CompileDeclaration *isCompileDeclaration() { return NULL; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -127,7 +127,7 @@ class EnumDeclaration;
 class SymbolDeclaration;
 class AttribDeclaration;
 class AnonDeclaration;
-class ProtDeclaration;
+class VisibilityDeclaration;
 class OverloadSet;
 class CompileDeclaration;
 class DsymbolTable;
@@ -917,7 +917,7 @@ public:
     virtual AttribDeclaration* isAttribDeclaration();
     virtual AnonDeclaration* isAnonDeclaration();
     virtual CPPNamespaceDeclaration* isCPPNamespaceDeclaration();
-    virtual ProtDeclaration* isProtDeclaration();
+    virtual VisibilityDeclaration* isVisibilityDeclaration();
     virtual OverloadSet* isOverloadSet();
     virtual CompileDeclaration* isCompileDeclaration();
 };
@@ -1443,7 +1443,7 @@ public:
     virtual void visit(AlignDeclaration* s);
     virtual void visit(CPPMangleDeclaration* s);
     virtual void visit(CPPNamespaceDeclaration* s);
-    virtual void visit(ProtDeclaration* s);
+    virtual void visit(VisibilityDeclaration* s);
     virtual void visit(PragmaDeclaration* s);
     virtual void visit(StorageClassDeclaration* s);
     virtual void visit(ConditionalDeclaration* s);
@@ -2029,17 +2029,17 @@ public:
     CPPNamespaceDeclaration* isCPPNamespaceDeclaration();
 };
 
-class ProtDeclaration final : public AttribDeclaration
+class VisibilityDeclaration final : public AttribDeclaration
 {
 public:
     Prot protection;
     Array<Identifier* >* pkg_identifiers;
-    ProtDeclaration* syntaxCopy(Dsymbol* s);
+    VisibilityDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     void addMember(Scope* sc, ScopeDsymbol* sds);
     const char* kind() const;
     const char* toPrettyChars(bool _param_0);
-    ProtDeclaration* isProtDeclaration();
+    VisibilityDeclaration* isVisibilityDeclaration();
     void accept(Visitor* v);
 };
 
@@ -5820,7 +5820,7 @@ public:
     virtual void visit(typename AST::AlignDeclaration s);
     virtual void visit(typename AST::CPPMangleDeclaration s);
     virtual void visit(typename AST::CPPNamespaceDeclaration s);
-    virtual void visit(typename AST::ProtDeclaration s);
+    virtual void visit(typename AST::VisibilityDeclaration s);
     virtual void visit(typename AST::PragmaDeclaration s);
     virtual void visit(typename AST::StorageClassDeclaration s);
     virtual void visit(typename AST::ConditionalDeclaration s);

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -972,12 +972,12 @@ public:
         visit(cast(AttribDeclaration)d);
     }
 
-    override void visit(ProtDeclaration d)
+    override void visit(VisibilityDeclaration d)
     {
         protectionToBuffer(buf, d.protection);
         buf.writeByte(' ');
         AttribDeclaration ad = cast(AttribDeclaration)d;
-        if (ad.decl.dim == 1 && (*ad.decl)[0].isProtDeclaration)
+        if (ad.decl.dim == 1 && (*ad.decl)[0].isVisibilityDeclaration)
             visit(cast(AttribDeclaration)(*ad.decl)[0]);
         else
             visit(cast(AttribDeclaration)d);

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1058,9 +1058,9 @@ final class Parser(AST) : Lexer
                     if (pAttrs.protection.kind != AST.Prot.Kind.undefined)
                     {
                         if (pAttrs.protection.kind == AST.Prot.Kind.package_ && pkg_prot_idents)
-                            s = new AST.ProtDeclaration(attrloc, pkg_prot_idents, a);
+                            s = new AST.VisibilityDeclaration(attrloc, pkg_prot_idents, a);
                         else
-                            s = new AST.ProtDeclaration(attrloc, pAttrs.protection, a);
+                            s = new AST.VisibilityDeclaration(attrloc, pAttrs.protection, a);
 
                         pAttrs.protection = AST.Prot(AST.Prot.Kind.undefined);
                     }

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -73,7 +73,7 @@ public:
     void visit(AST.AlignDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.CPPMangleDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.CPPNamespaceDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
-    void visit(AST.ProtDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
+    void visit(AST.VisibilityDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.PragmaDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.StorageClassDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.ConditionalDeclaration s) { visit(cast(AST.AttribDeclaration)s); }

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -620,7 +620,7 @@ private Statement toStatement(Dsymbol s)
             result = visitMembers(d.loc, d.decl);
         }
 
-        override void visit(ProtDeclaration d)
+        override void visit(VisibilityDeclaration d)
         {
             result = visitMembers(d.loc, d.decl);
         }

--- a/src/dmd/strictvisitor.d
+++ b/src/dmd/strictvisitor.d
@@ -51,7 +51,7 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.AnonDeclaration) { assert(0); }
     override void visit(AST.AlignDeclaration) { assert(0); }
     override void visit(AST.CPPMangleDeclaration) { assert(0); }
-    override void visit(AST.ProtDeclaration) { assert(0); }
+    override void visit(AST.VisibilityDeclaration) { assert(0); }
     override void visit(AST.PragmaDeclaration) { assert(0); }
     override void visit(AST.StorageClassDeclaration) { assert(0); }
     override void visit(AST.ConditionalDeclaration) { assert(0); }

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -529,9 +529,9 @@ package mixin template ParseVisitMethods(AST)
         visitAttribDeclaration(cast(AST.AttribDeclaration)d);
     }
 
-    override void visit(AST.ProtDeclaration d)
+    override void visit(AST.VisibilityDeclaration d)
     {
-        //printf("Visiting ProtDeclaration\n");
+        //printf("Visiting VisibilityDeclaration\n");
         visitAttribDeclaration(cast(AST.AttribDeclaration)d);
     }
 

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -101,7 +101,7 @@ class DeprecatedDeclaration;
 class LinkDeclaration;
 class CPPMangleDeclaration;
 class CPPNamespaceDeclaration;
-class ProtDeclaration;
+class VisibilityDeclaration;
 class AlignDeclaration;
 class AnonDeclaration;
 class PragmaDeclaration;
@@ -362,7 +362,7 @@ public:
     virtual void visit(AlignDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(CPPMangleDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(CPPNamespaceDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(ProtDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(VisibilityDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(PragmaDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(StorageClassDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(ConditionalDeclaration *s) { visit((AttribDeclaration *)s); }


### PR DESCRIPTION
```
D does not use protection anymore, but rather visibility for symbol.
This has been in place for a while, but the internal types were never
renamed to match the actual meaning of it, and 'protection' is still
all over the place. Renaming the AST node is a first step into fixing this.
```

Note that I didn't touch the comments and the `Prot` struct yet, as this change is much more invasive. `ProtDeclaration` is rather self-contained and easy to do, hence why I suggest to start here. This should also reduce the potential for conflicts.