### PR TITLE
Remove -preview=dip25 from the test-suite

### DIFF
--- a/test/fail_compilation/fail_scope.d
+++ b/test/fail_compilation/fail_scope.d
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS: -preview=dip25
+REQUIRED_ARGS:
 TEST_OUTPUT:
 ---
 fail_compilation/fail_scope.d(44): Error: returning `cast(char[])string` escapes a reference to local variable `string`
@@ -11,7 +11,7 @@ fail_compilation/fail_scope.d(68):     `fail_scope.foo8(return ref int x)`
 fail_compilation/fail_scope.d(81): Error: returning `& string` escapes a reference to local variable `string`
 fail_compilation/fail_scope.d(91): Error: returning `cast(int[])a` escapes a reference to local variable `a`
 fail_compilation/fail_scope.d(99): Error: returning `cast(int[])a` escapes a reference to local variable `a`
-fail_compilation/fail_scope.d(107): Error: escaping reference to outer local variable `x`
+fail_compilation/fail_scope.d(107): Deprecation: escaping reference to outer local variable `x`
 fail_compilation/fail_scope.d(126): Error: returning `s.bar()` escapes a reference to local variable `s`
 fail_compilation/fail_scope.d(136): Error: returning `foo16226(i)` escapes a reference to local variable `i`
 ---

--- a/test/fail_compilation/retref2.d
+++ b/test/fail_compilation/retref2.d
@@ -1,11 +1,8 @@
-
-// REQUIRED_ARGS: -preview=dip25
-
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retref2.d(21): Error: function `ref int retref2.D.foo(return ref int)` does not override any function, did you mean to override `ref int retref2.C.foo(ref int)`?
-fail_compilation/retref2.d(22): Error: function `ref scope int retref2.D.bar() return` does not override any function, did you mean to override `ref int retref2.C.bar()`?
+fail_compilation/retref2.d(18): Error: function `ref int retref2.D.foo(return ref int)` does not override any function, did you mean to override `ref int retref2.C.foo(ref int)`?
+fail_compilation/retref2.d(19): Error: function `ref scope int retref2.D.bar() return` does not override any function, did you mean to override `ref int retref2.C.bar()`?
 ---
 */
 

--- a/test/fail_compilation/test16228.d
+++ b/test/fail_compilation/test16228.d
@@ -1,4 +1,4 @@
-/* REQUIRED_ARGS: -preview=dip25
+/* REQUIRED_ARGS:
    TEST_OUTPUT:
 ---
 fail_compilation/test16228.d(23): Error: function `test16228.S.bar` `static` member has no `this` to which `return` can apply
@@ -33,4 +33,3 @@ void bar(int i, void* p)
     Identity(p);
     Identity(i);
 }
-

--- a/test/fail_compilation/test17450.d
+++ b/test/fail_compilation/test17450.d
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS: -preview=dip1000 -preview=dip25
+REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test17450.d(17): Error: returning `&s.bar` escapes a reference to parameter `s`

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS: -inline -O
-// REQUIRED_ARGS: -preview=dip25 -preview=fieldwise
+// REQUIRED_ARGS: -preview=fieldwise
 
 // Test operator overloading
 
@@ -803,7 +803,7 @@ struct T
 
 void test11161()
 {
-    T t1, t2; 
+    T t1, t2;
     assert(t1.tupleof != t2.tupleof);
     assert(t1 != t2); // fails
 }
@@ -2037,4 +2037,3 @@ int main()
     printf("Success\n");
     return 0;
 }
-

--- a/test/runnable/test14874.d
+++ b/test/runnable/test14874.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -preview=dip25
+// REQUIRED_ARGS:
 
 template indexOfReturn(T...)
 {

--- a/test/runnable/test17072.d
+++ b/test/runnable/test17072.d
@@ -1,6 +1,6 @@
 /*
 REQUIRED_ARGS: -inline
-PERMUTE_ARGS: -release -O -preview=dip25
+PERMUTE_ARGS: -release -O
 */
 
 // https://issues.dlang.org/show_bug.cgi?id=17072

--- a/test/runnable/testscope2.d
+++ b/test/runnable/testscope2.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -preview=dip25
+// REQUIRED_ARGS:
 /*
 TEST_OUTPUT:
 ---


### PR DESCRIPTION
Since it is now enabled by default, we can do a simple clean-up and not provide it.