### PR TITLE
fix Issue 20652 - extern(C++) doesn't seem to mangle the types in core.simd right

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1731,15 +1731,11 @@ extern(C++):
         else
         {
             assert(t.basetype && t.basetype.ty == Tsarray);
-            assert((cast(TypeSArray)t.basetype).dim);
-            version (none)
-            {
-                buf.writestring("Dv");
-                buf.print((cast(TypeSArray *)t.basetype).dim.toInteger()); // -- Gnu ABI v.4
-                buf.writeByte('_');
-            }
-            else
-                buf.writestring("U8__vector"); //-- Gnu ABI v.3
+            auto tsa = t.basetype.isTypeSArray();
+            assert(tsa.dim);
+            buf.writestring("Dv");          // -- Gnu ABI v.4
+            buf.print(tsa.dim.toInteger());
+            buf.writeByte('_');
             t.basetype.nextOf().accept(this);
         }
     }

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -251,6 +251,7 @@ public:
         //printf("visit(TypeVector); is_not_top_type = %d\n", (int)(flags & IS_NOT_TOP_TYPE));
         if (checkTypeSaved(type))
             return;
+        mangleModifier(type);
         buf.writestring("T__m128@@"); // may be better as __m128i or __m128d?
         flags &= ~IS_NOT_TOP_TYPE;
         flags &= ~IGNORE_CONST;

--- a/test/runnable_cxx/extra-files/test20652.cpp
+++ b/test/runnable_cxx/extra-files/test20652.cpp
@@ -1,0 +1,34 @@
+#if defined(__DMC__)	// DMC doesn't support immintrin.h
+#else
+
+#include <assert.h>
+
+// Inline the typedef of __m128 instead of including immintrin.h.
+#if defined(__GNUC__) || defined(__clang__)
+typedef float __m128 __attribute__((__vector_size__(16), __may_alias__));
+
+#elif defined(_MSC_VER)
+typedef union __declspec(intrin_type) __declspec(align(16)) __m128 {
+    float m128_f32[4];
+} __m128;
+
+#else
+#error "Unknown vendor"
+#endif
+
+void test20652(const __m128& a)
+{
+    union
+    {
+        __m128 value;
+        float array[4];
+    } b;
+    b.value = a;
+
+    assert(b.array[0] == 1);
+    assert(b.array[1] == 1);
+    assert(b.array[2] == 1);
+    assert(b.array[3] == 1);
+}
+
+#endif

--- a/test/runnable_cxx/test20652.d
+++ b/test/runnable_cxx/test20652.d
@@ -1,0 +1,23 @@
+// https://issues.dlang.org/show_bug.cgi?id=20652
+// EXTRA_CPP_SOURCES: test20652.cpp
+
+import core.simd;
+
+version (CRuntime_DigitalMars)  // DMC doesn't support immintrin.h
+{
+    void main() {}
+}
+else static if (!__traits(compiles, float4)) // No __vector support
+{
+    void main() {}
+}
+else
+{
+    extern(C++) void test20652(ref const float4);
+
+    void main()
+    {
+        float4 f4 = 1;
+        test20652(f4);
+    }
+}


### PR DESCRIPTION
The V4 ABI first appeared in g++ 4.5, and became the default in g++ 5.  `target.cpp.typeMangle` can handle GNU-specific (or LLVM-specific) ABI versioning if need be.

Let the default always assume the latest is in effect.