### PR TITLE
Minor refactoring to arrayExpressionToCommonType

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2817,15 +2817,6 @@ Type typeMerge(Scope* sc, TOK op, ref Expression pe1, ref Expression pe2)
     Type att1 = null;
     Type att2 = null;
 
-    //if (t1) printf("\tt1 = %s\n", t1.toChars());
-    //if (t2) printf("\tt2 = %s\n", t2.toChars());
-    debug
-    {
-        if (!t2)
-            printf("\te2 = '%s'\n", e2.toChars());
-    }
-    assert(t2);
-
     if (t1.mod != t2.mod &&
         t1.ty == Tenum && t2.ty == Tenum &&
         (cast(TypeEnum)t1).sym == (cast(TypeEnum)t2).sym)

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -44,11 +44,22 @@ import dmd.visitor;
 
 enum LOG = false;
 
-/**************************************
- * Do an implicit cast.
- * Issue error if it can't be done.
+/**
+ * Attempt to implicitly cast the `from` expression into `target` type.
+ *
+ * This routine will change `from`. To check the matching level,
+ * use `implicitConvTo`.
+ *
+ * Params:
+ *   from = Expression that is to be casted
+ *   sc = Current scope
+ *   target = Expected resulting type
+ *
+ * Returns:
+ *   The resulting casted expression (mutating `from`), or `ErrorExp`
+ *    if such an implicit conversion is not possible.
  */
-Expression implicitCastTo(Expression e, Scope* sc, Type t)
+Expression implicitCastTo(Expression from, Scope* sc, Type target)
 {
     extern (C++) final class ImplicitCastTo : Visitor
     {
@@ -201,16 +212,26 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
         }
     }
 
-    scope ImplicitCastTo v = new ImplicitCastTo(sc, t);
-    e.accept(v);
+    scope ImplicitCastTo v = new ImplicitCastTo(sc, target);
+    from.accept(v);
     return v.result;
 }
 
-/*******************************************
- * Return MATCH level of implicitly converting e to type t.
- * Don't do the actual cast; don't change e.
+/**
+ * Checks whether or not an expression can be implicitly converted
+ * to the `target` type.
+ *
+ * Unlike `implicitCastTo`, this routine does not perform the actual cast,
+ * but only checks up to what `MATCH` level the conversion would be possible.
+ *
+ * Params:
+ *   from = Expression that is to be casted
+ *   target = Expected resulting type
+ *
+ * Returns:
+ *   The `MATCH` level between `from.type` and `target`.
  */
-MATCH implicitConvTo(Expression e, Type t)
+MATCH implicitConvTo(Expression from, Type target)
 {
     extern (C++) final class ImplicitConvTo : Visitor
     {
@@ -1418,8 +1439,8 @@ MATCH implicitConvTo(Expression e, Type t)
         }
     }
 
-    scope ImplicitConvTo v = new ImplicitConvTo(t);
-    e.accept(v);
+    scope ImplicitConvTo v = new ImplicitConvTo(target);
+    from.accept(v);
     return v.result;
 }
 
@@ -1469,9 +1490,9 @@ private Expression tryAliasThisCast(Expression e, Scope* sc, Type tob, Type t1b,
 
 /**************************************
  * Do an explicit cast.
- * Assume that the 'this' expression does not have any indirections.
+ * Assume that the `from` expression does not have any indirections.
  */
-Expression castTo(Expression e, Scope* sc, Type t)
+Expression castTo(Expression from, Scope* sc, Type target)
 {
     extern (C++) final class CastTo : Visitor
     {
@@ -2537,8 +2558,8 @@ Expression castTo(Expression e, Scope* sc, Type t)
         }
     }
 
-    scope CastTo v = new CastTo(sc, t);
-    e.accept(v);
+    scope CastTo v = new CastTo(sc, target);
+    from.accept(v);
     return v.result;
 }
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1390,7 +1390,7 @@ extern (C++) Expression resolveProperties(Scope* sc, Expression e)
  * Returns:
  *      The common type, or `null` if an error has occured
  */
-private Type arrayExpressionToCommonType(Scope* sc, Expressions* exps)
+private Type arrayExpressionToCommonType(Scope* sc, ref Expressions exps)
 {
     /* Still have a problem with:
      *  ubyte[][] = [ cast(ubyte[])"hello", [1]];
@@ -1409,7 +1409,7 @@ private Type arrayExpressionToCommonType(Scope* sc, Expressions* exps)
 
     for (size_t i = 0; i < exps.dim; i++)
     {
-        Expression e = (*exps)[i];
+        Expression e = exps[i];
         if (!e)
             continue;
 
@@ -1457,13 +1457,13 @@ private Type arrayExpressionToCommonType(Scope* sc, Expressions* exps)
             {
                 // https://issues.dlang.org/show_bug.cgi?id=21285
                 // Functions and delegates don't convert correctly with castTo below
-                (*exps)[j0] = condexp.e1;
+                exps[j0] = condexp.e1;
                 e = condexp.e2;
             }
             else
             {
                 // Convert to common type
-                (*exps)[j0] = condexp.e1.castTo(sc, condexp.type);
+                exps[j0] = condexp.e1.castTo(sc, condexp.type);
                 e = condexp.e2.castTo(sc, condexp.type);
             }
         }
@@ -1471,7 +1471,7 @@ private Type arrayExpressionToCommonType(Scope* sc, Expressions* exps)
         e0 = e;
         t0 = e.type;
         if (e.op != TOK.error)
-            (*exps)[i] = e;
+            exps[i] = e;
     }
 
     if (!t0)
@@ -1480,7 +1480,7 @@ private Type arrayExpressionToCommonType(Scope* sc, Expressions* exps)
     {
         for (size_t i = 0; i < exps.dim; i++)
         {
-            Expression e = (*exps)[i];
+            Expression e = exps[i];
             if (!e)
                 continue;
 
@@ -1496,7 +1496,7 @@ private Type arrayExpressionToCommonType(Scope* sc, Expressions* exps)
                 t0 = Type.terror;
                 break;
             }
-            (*exps)[i] = e;
+            exps[i] = e;
         }
     }
     return (t0 && t0 != Type.terror) ? t0 : null;
@@ -3093,7 +3093,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (e.basis)
             e.elements.push(e.basis);
-        Type t0 = arrayExpressionToCommonType(sc, e.elements);
+        Type t0 = arrayExpressionToCommonType(sc, *e.elements);
         if (e.basis)
             e.basis = e.elements.pop();
         if (t0 is null)
@@ -3143,8 +3143,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
         }
 
-        Type tkey = arrayExpressionToCommonType(sc, e.keys);
-        Type tvalue = arrayExpressionToCommonType(sc, e.values);
+        Type tkey = arrayExpressionToCommonType(sc, *e.keys);
+        Type tvalue = arrayExpressionToCommonType(sc, *e.values);
         if (tkey is null || tvalue is null)
             return setError();
 


### PR DESCRIPTION
Since `arrayExpressionToCommonType` is highly correlated to `typeMerge` (and should probably call it directly), it seems reasonable the changes made to `typeMerge` propagate here as well.