### PR TITLE
OverDeclaration: Remove unused hasOverloads field

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -992,23 +992,11 @@ extern (C++) final class OverDeclaration : Declaration
 {
     Dsymbol overnext;   // next in overload list
     Dsymbol aliassym;
-    bool hasOverloads;
 
-    extern (D) this(Identifier ident, Dsymbol s, bool hasOverloads = true)
+    extern (D) this(Identifier ident, Dsymbol s)
     {
         super(ident);
         this.aliassym = s;
-        this.hasOverloads = hasOverloads;
-        if (hasOverloads)
-        {
-            if (OverDeclaration od = aliassym.isOverDeclaration())
-                this.hasOverloads = od.hasOverloads;
-        }
-        else
-        {
-            // for internal use
-            assert(!aliassym.isOverDeclaration());
-        }
     }
 
     override const(char)* kind() const
@@ -1025,25 +1013,9 @@ extern (C++) final class OverDeclaration : Declaration
         if (!s)
             return false;
 
-        auto od1 = this;
         if (auto od2 = s.isOverDeclaration())
-        {
-            return od1.aliassym.equals(od2.aliassym) && od1.hasOverloads == od2.hasOverloads;
-        }
-        if (aliassym == s)
-        {
-            if (hasOverloads)
-                return true;
-            if (auto fd = s.isFuncDeclaration())
-            {
-                return fd.isUnique();
-            }
-            if (auto td = s.isTemplateDeclaration())
-            {
-                return td.overnext is null;
-            }
-        }
-        return false;
+            return this.aliassym.equals(od2.aliassym);
+        return this.aliassym == s;
     }
 
     override bool overloadInsert(Dsymbol s)
@@ -1064,15 +1036,6 @@ extern (C++) final class OverDeclaration : Declaration
 
     Dsymbol isUnique()
     {
-        if (!hasOverloads)
-        {
-            if (aliassym.isFuncDeclaration() ||
-                aliassym.isTemplateDeclaration())
-            {
-                return aliassym;
-            }
-        }
-
         Dsymbol result = null;
         overloadApply(aliassym, (Dsymbol s)
         {

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -190,7 +190,6 @@ class OverDeclaration : public Declaration
 public:
     Dsymbol *overnext;          // next in overload list
     Dsymbol *aliassym;
-    bool hasOverloads;
 
     const char *kind() const;
     bool equals(const RootObject *o) const;

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -677,7 +677,7 @@ public:
         }
         if (FuncDeclaration fd = od.aliassym.isFuncDeclaration())
         {
-            if (!od.hasOverloads || fd.isUnique())
+            if (fd.isUnique())
             {
                 mangleExact(fd);
                 return;
@@ -685,7 +685,7 @@ public:
         }
         if (TemplateDeclaration td = od.aliassym.isTemplateDeclaration())
         {
-            if (!od.hasOverloads || td.overnext is null)
+            if (td.overnext is null)
             {
                 mangleSymbol(td);
                 return;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2630,7 +2630,6 @@ class OverDeclaration final : public Declaration
 public:
     Dsymbol* overnext;
     Dsymbol* aliassym;
-    bool hasOverloads;
     const char* kind() const;
     bool equals(const RootObject* const o) const;
     bool overloadInsert(Dsymbol* s);

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2708,30 +2708,22 @@ extern (D) int overloadApply(Dsymbol fstart, scope int delegate(Dsymbol) dg, Sco
         import dmd.access : checkSymbolAccess;
         if (auto od = d.isOverDeclaration())
         {
-            if (od.hasOverloads)
+            /* The scope is needed here to check whether a function in
+               an overload set was added by means of a private alias (or a
+               selective import). If the scope where the alias is created
+               is imported somewhere, the overload set is visible, but the private
+               alias is not.
+            */
+            if (sc)
             {
-                /* The scope is needed here to check whether a function in
-                   an overload set was added by means of a private alias (or a
-                   selective import). If the scope where the alias is created
-                   is imported somewhere, the overload set is visible, but the private
-                   alias is not.
-                 */
-                if (sc)
+                if (checkSymbolAccess(sc, od))
                 {
-                    if (checkSymbolAccess(sc, od))
-                    {
-                        if (int r = overloadApply(od.aliassym, dg, sc))
-                            return r;
-                    }
+                    if (int r = overloadApply(od.aliassym, dg, sc))
+                        return r;
                 }
-                else if (int r = overloadApply(od.aliassym, dg, sc))
-                    return r;
             }
-            else
-            {
-                if (int r = dg(od.aliassym))
-                    return r;
-            }
+            else if (int r = overloadApply(od.aliassym, dg, sc))
+                return r;
             next = od.overnext;
         }
         else if (auto fa = d.isFuncAliasDeclaration())


### PR DESCRIPTION
It was always true.