### PR TITLE
Add getVisibility trait as an alias to getProtection

### DIFF
--- a/changelog/getVisibility.dd
+++ b/changelog/getVisibility.dd
@@ -1,0 +1,9 @@
+Introduced `__traits(getVisibility, Sym)` as an alias to `getProtection`
+
+Since the changes in v2.071.0, attributes such as `private`, `protected`, `public`,
+etc... are visibility attributes, and not protection attributes.
+However, the name of this trait predates such change and was thus inconsistent with
+all the other documentation.
+This change only introduce the new name, and `getProtection` has been left un-deprecated,
+and while using the new name is reccommended for users that only supports the latest
+version of the language, there is no plan to deprecate it.

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7714,6 +7714,7 @@ struct Id
     static Identifier* hasMember;
     static Identifier* identifier;
     static Identifier* getProtection;
+    static Identifier* getVisibility;
     static Identifier* parent;
     static Identifier* child;
     static Identifier* getMember;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -440,6 +440,7 @@ immutable Msgtable[] msgtable =
     { "hasMember" },
     { "identifier" },
     { "getProtection" },
+    { "getVisibility" },
     { "parent" },
     { "child" },
     { "getMember" },

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -122,6 +122,7 @@ shared static this()
         "hasMember",
         "identifier",
         "getProtection",
+        "getVisibility",
         "parent",
         "child",
         "getLinkage",
@@ -428,7 +429,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     if (e.ident != Id.compiles &&
         e.ident != Id.isSame &&
         e.ident != Id.identifier &&
-        e.ident != Id.getProtection &&
+        e.ident != Id.getProtection && e.ident != Id.getVisibility &&
         e.ident != Id.getAttributes)
     {
         // Pretend we're in a deprecated scope so that deprecation messages
@@ -821,7 +822,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto se = new StringExp(e.loc, id.toString());
         return se.expressionSemantic(sc);
     }
-    if (e.ident == Id.getProtection)
+    if (e.ident == Id.getProtection || e.ident == Id.getVisibility)
     {
         if (dim != 1)
             return dimError(1);

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -636,7 +636,7 @@ struct Test24
     private void test24(int, int){}
 }
 
-static assert(__traits(getProtection, __traits(getOverloads, Test24, "test24")[1]) == "private");
+static assert(__traits(getVisibility, __traits(getOverloads, Test24, "test24")[1]) == "private");
 
 /********************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=1369
@@ -891,7 +891,7 @@ protected struct TestProt3 {}
 public    struct TestProt4 {}
 export    struct TestProt5 {}
 
-void getProtection()
+void getVisibility()
 {
     class Test
     {
@@ -904,52 +904,52 @@ void getProtection()
     Test t;
 
     // TOKvar and VarDeclaration
-    static assert(__traits(getProtection, Test.va) == "private");
-    static assert(__traits(getProtection, Test.vb) == "package");
-    static assert(__traits(getProtection, Test.vc) == "protected");
-    static assert(__traits(getProtection, Test.vd) == "public");
-    static assert(__traits(getProtection, Test.ve) == "export");
+    static assert(__traits(getVisibility, Test.va) == "private");
+    static assert(__traits(getVisibility, Test.vb) == "package");
+    static assert(__traits(getVisibility, Test.vc) == "protected");
+    static assert(__traits(getVisibility, Test.vd) == "public");
+    static assert(__traits(getVisibility, Test.ve) == "export");
 
     // TOKdotvar and VarDeclaration
-    static assert(__traits(getProtection, t.va) == "private");
-    static assert(__traits(getProtection, t.vb) == "package");
-    static assert(__traits(getProtection, t.vc) == "protected");
-    static assert(__traits(getProtection, t.vd) == "public");
-    static assert(__traits(getProtection, t.ve) == "export");
+    static assert(__traits(getVisibility, t.va) == "private");
+    static assert(__traits(getVisibility, t.vb) == "package");
+    static assert(__traits(getVisibility, t.vc) == "protected");
+    static assert(__traits(getVisibility, t.vd) == "public");
+    static assert(__traits(getVisibility, t.ve) == "export");
 
     // TOKvar and FuncDeclaration
-    static assert(__traits(getProtection, Test.fa) == "private");
-    static assert(__traits(getProtection, Test.fb) == "package");
-    static assert(__traits(getProtection, Test.fc) == "protected");
-    static assert(__traits(getProtection, Test.fd) == "public");
-    static assert(__traits(getProtection, Test.fe) == "export");
+    static assert(__traits(getVisibility, Test.fa) == "private");
+    static assert(__traits(getVisibility, Test.fb) == "package");
+    static assert(__traits(getVisibility, Test.fc) == "protected");
+    static assert(__traits(getVisibility, Test.fd) == "public");
+    static assert(__traits(getVisibility, Test.fe) == "export");
 
     // TOKdotvar and FuncDeclaration
-    static assert(__traits(getProtection, t.fa) == "private");
-    static assert(__traits(getProtection, t.fb) == "package");
-    static assert(__traits(getProtection, t.fc) == "protected");
-    static assert(__traits(getProtection, t.fd) == "public");
-    static assert(__traits(getProtection, t.fe) == "export");
+    static assert(__traits(getVisibility, t.fa) == "private");
+    static assert(__traits(getVisibility, t.fb) == "package");
+    static assert(__traits(getVisibility, t.fc) == "protected");
+    static assert(__traits(getVisibility, t.fd) == "public");
+    static assert(__traits(getVisibility, t.fe) == "export");
 
     // TOKtype
-    static assert(__traits(getProtection, TestProt1) == "private");
-    static assert(__traits(getProtection, TestProt2) == "package");
-    static assert(__traits(getProtection, TestProt3) == "protected");
-    static assert(__traits(getProtection, TestProt4) == "public");
-    static assert(__traits(getProtection, TestProt5) == "export");
+    static assert(__traits(getVisibility, TestProt1) == "private");
+    static assert(__traits(getVisibility, TestProt2) == "package");
+    static assert(__traits(getVisibility, TestProt3) == "protected");
+    static assert(__traits(getVisibility, TestProt4) == "public");
+    static assert(__traits(getVisibility, TestProt5) == "export");
 
     // This specific pattern is important to ensure it always works
     // through reflection, however that becomes implemented
-    static assert(__traits(getProtection, __traits(getMember, t, "va")) == "private");
-    static assert(__traits(getProtection, __traits(getMember, t, "vb")) == "package");
-    static assert(__traits(getProtection, __traits(getMember, t, "vc")) == "protected");
-    static assert(__traits(getProtection, __traits(getMember, t, "vd")) == "public");
-    static assert(__traits(getProtection, __traits(getMember, t, "ve")) == "export");
-    static assert(__traits(getProtection, __traits(getMember, t, "fa")) == "private");
-    static assert(__traits(getProtection, __traits(getMember, t, "fb")) == "package");
-    static assert(__traits(getProtection, __traits(getMember, t, "fc")) == "protected");
-    static assert(__traits(getProtection, __traits(getMember, t, "fd")) == "public");
-    static assert(__traits(getProtection, __traits(getMember, t, "fe")) == "export");
+    static assert(__traits(getVisibility, __traits(getMember, t, "va")) == "private");
+    static assert(__traits(getVisibility, __traits(getMember, t, "vb")) == "package");
+    static assert(__traits(getVisibility, __traits(getMember, t, "vc")) == "protected");
+    static assert(__traits(getVisibility, __traits(getMember, t, "vd")) == "public");
+    static assert(__traits(getVisibility, __traits(getMember, t, "ve")) == "export");
+    static assert(__traits(getVisibility, __traits(getMember, t, "fa")) == "private");
+    static assert(__traits(getVisibility, __traits(getMember, t, "fb")) == "package");
+    static assert(__traits(getVisibility, __traits(getMember, t, "fc")) == "protected");
+    static assert(__traits(getVisibility, __traits(getMember, t, "fd")) == "public");
+    static assert(__traits(getVisibility, __traits(getMember, t, "fe")) == "export");
 }
 
 /********************************************************/
@@ -960,47 +960,47 @@ void test9546()
     import imports.a9546 : S;
 
     S s;
-    static assert(__traits(getProtection, s.privA) == "private");
-    static assert(__traits(getProtection, s.protA) == "protected");
-    static assert(__traits(getProtection, s.packA) == "package");
-    static assert(__traits(getProtection, S.privA) == "private");
-    static assert(__traits(getProtection, S.protA) == "protected");
-    static assert(__traits(getProtection, S.packA) == "package");
+    static assert(__traits(getVisibility, s.privA) == "private");
+    static assert(__traits(getVisibility, s.protA) == "protected");
+    static assert(__traits(getVisibility, s.packA) == "package");
+    static assert(__traits(getVisibility, S.privA) == "private");
+    static assert(__traits(getVisibility, S.protA) == "protected");
+    static assert(__traits(getVisibility, S.packA) == "package");
 
-    static assert(__traits(getProtection, mixin("s.privA")) == "private");
-    static assert(__traits(getProtection, mixin("s.protA")) == "protected");
-    static assert(__traits(getProtection, mixin("s.packA")) == "package");
-    static assert(__traits(getProtection, mixin("S.privA")) == "private");
-    static assert(__traits(getProtection, mixin("S.protA")) == "protected");
-    static assert(__traits(getProtection, mixin("S.packA")) == "package");
+    static assert(__traits(getVisibility, mixin("s.privA")) == "private");
+    static assert(__traits(getVisibility, mixin("s.protA")) == "protected");
+    static assert(__traits(getVisibility, mixin("s.packA")) == "package");
+    static assert(__traits(getVisibility, mixin("S.privA")) == "private");
+    static assert(__traits(getVisibility, mixin("S.protA")) == "protected");
+    static assert(__traits(getVisibility, mixin("S.packA")) == "package");
 
-    static assert(__traits(getProtection, __traits(getMember, s, "privA")) == "private");
-    static assert(__traits(getProtection, __traits(getMember, s, "protA")) == "protected");
-    static assert(__traits(getProtection, __traits(getMember, s, "packA")) == "package");
-    static assert(__traits(getProtection, __traits(getMember, S, "privA")) == "private");
-    static assert(__traits(getProtection, __traits(getMember, S, "protA")) == "protected");
-    static assert(__traits(getProtection, __traits(getMember, S, "packA")) == "package");
+    static assert(__traits(getVisibility, __traits(getMember, s, "privA")) == "private");
+    static assert(__traits(getVisibility, __traits(getMember, s, "protA")) == "protected");
+    static assert(__traits(getVisibility, __traits(getMember, s, "packA")) == "package");
+    static assert(__traits(getVisibility, __traits(getMember, S, "privA")) == "private");
+    static assert(__traits(getVisibility, __traits(getMember, S, "protA")) == "protected");
+    static assert(__traits(getVisibility, __traits(getMember, S, "packA")) == "package");
 
-    static assert(__traits(getProtection, s.privF) == "private");
-    static assert(__traits(getProtection, s.protF) == "protected");
-    static assert(__traits(getProtection, s.packF) == "package");
-    static assert(__traits(getProtection, S.privF) == "private");
-    static assert(__traits(getProtection, S.protF) == "protected");
-    static assert(__traits(getProtection, S.packF) == "package");
+    static assert(__traits(getVisibility, s.privF) == "private");
+    static assert(__traits(getVisibility, s.protF) == "protected");
+    static assert(__traits(getVisibility, s.packF) == "package");
+    static assert(__traits(getVisibility, S.privF) == "private");
+    static assert(__traits(getVisibility, S.protF) == "protected");
+    static assert(__traits(getVisibility, S.packF) == "package");
 
-    static assert(__traits(getProtection, mixin("s.privF")) == "private");
-    static assert(__traits(getProtection, mixin("s.protF")) == "protected");
-    static assert(__traits(getProtection, mixin("s.packF")) == "package");
-    static assert(__traits(getProtection, mixin("S.privF")) == "private");
-    static assert(__traits(getProtection, mixin("S.protF")) == "protected");
-    static assert(__traits(getProtection, mixin("S.packF")) == "package");
+    static assert(__traits(getVisibility, mixin("s.privF")) == "private");
+    static assert(__traits(getVisibility, mixin("s.protF")) == "protected");
+    static assert(__traits(getVisibility, mixin("s.packF")) == "package");
+    static assert(__traits(getVisibility, mixin("S.privF")) == "private");
+    static assert(__traits(getVisibility, mixin("S.protF")) == "protected");
+    static assert(__traits(getVisibility, mixin("S.packF")) == "package");
 
-    static assert(__traits(getProtection, __traits(getMember, s, "privF")) == "private");
-    static assert(__traits(getProtection, __traits(getMember, s, "protF")) == "protected");
-    static assert(__traits(getProtection, __traits(getMember, s, "packF")) == "package");
-    static assert(__traits(getProtection, __traits(getMember, S, "privF")) == "private");
-    static assert(__traits(getProtection, __traits(getMember, S, "protF")) == "protected");
-    static assert(__traits(getProtection, __traits(getMember, S, "packF")) == "package");
+    static assert(__traits(getVisibility, __traits(getMember, s, "privF")) == "private");
+    static assert(__traits(getVisibility, __traits(getMember, s, "protF")) == "protected");
+    static assert(__traits(getVisibility, __traits(getMember, s, "packF")) == "package");
+    static assert(__traits(getVisibility, __traits(getMember, S, "privF")) == "private");
+    static assert(__traits(getVisibility, __traits(getMember, S, "protF")) == "protected");
+    static assert(__traits(getVisibility, __traits(getMember, S, "packF")) == "package");
 }
 
 /********************************************************/


### PR DESCRIPTION
The name is more accurate and can be recommended in the documentation in the future.