### PR TITLE
Fix 21518 - delegates not checked for attribute match in const arrays

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5357,6 +5357,7 @@ public:
     StorageClass parameterStorageClass(Type* tthis, Parameter* p);
     Type* addStorageClass(StorageClass stc);
     Type* substWildTo(uint32_t _param_0);
+    MATCH constConv(Type* to);
     bool isnothrow() const;
     void isnothrow(bool v);
     bool isnogc() const;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5025,6 +5025,16 @@ extern (C++) final class TypeFunction : TypeNext
         return MATCH.nomatch;
     }
 
+    /** Extends TypeNext.constConv by also checking for matching attributes **/
+    override MATCH constConv(Type to)
+    {
+        // Attributes need to match exactly, otherwise it's an implicit conversion
+        if (this.ty != to.ty || !this.attributesEqual(cast(TypeFunction) to))
+            return MATCH.nomatch;
+
+        return super.constConv(to);
+    }
+
     extern (D) bool checkRetType(const ref Loc loc)
     {
         Type tb = next.toBasetype();

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -595,6 +595,7 @@ public:
     Type *addStorageClass(StorageClass stc);
 
     Type *substWildTo(unsigned mod);
+    MATCH constConv(Type *to);
 
     bool isnothrow() const;
     void isnothrow(bool v);

--- a/test/fail_compilation/test21518.d
+++ b/test/fail_compilation/test21518.d
@@ -1,0 +1,38 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=21518
+TEST_OUTPUT:
+---
+fail_compilation/test21518.d(19): Error: cannot implicitly convert expression `[dg]` of type `const(void delegate() pure nothrow @nogc @system)[]` to `void delegate() @safe[]`
+fail_compilation/test21518.d(23): Error: cannot implicitly convert expression `[dg]` of type `const(void delegate() pure nothrow @nogc @system)[]` to `const(void delegate() @safe)[]`
+fail_compilation/test21518.d(28): Error: cannot implicitly convert expression `sysA` of type `const(void delegate() @system)[]` to `const(void delegate() @safe)[]`
+fail_compilation/test21518.d(31): Error: cannot implicitly convert expression `sysA` of type `const(void delegate() @system)[]` to `const(void delegate() @safe)`
+fail_compilation/test21518.d(32): Error: cannot implicitly convert expression `dg` of type `const(void delegate() pure nothrow @nogc @system)` to `const(void delegate() @safe)`
+---
+*/
+
+void delegates()
+{
+	const dg = delegate() @system { int* p; int x; p = &x; };
+	// pragma(msg, typeof(dg)); // const(void delegate() pure nothrow @nogc @system)
+
+	// Correctly fails
+	void delegate() @safe[] arg2 = [ dg ];
+	void delegate() @system[] arg3 = [ dg ]; // But doesnt break this
+
+	// Previously ignored
+	const(void delegate() @safe)[] arg = [ dg ];
+	// pragma(msg, typeof(arg)); // const(void delegate() @safe)[]
+
+	// Also for variables, not only array literals
+	const(void delegate() @system)[] sysA = [ dg ];
+	const(void delegate() @safe)[] safeA = sysA;
+
+	// Original bug report:
+	func(sysA);
+	func(dg);
+}
+
+void func(const void delegate() @safe [] paramDGs...) @safe
+{
+	if (paramDGs.length > 0) paramDGs[0]();
+}


### PR DESCRIPTION
Const-conversion checks for delegates are forwarded to the type of
`funcptr`. But `TypeFunction` did not implement `constConv`, causing
the inherited `TypeNext.constConv` (which only checks const`/`shared`/...).
to ignore the missmatched attributes.

The bug was restricted to `const` arrays because checks for (im)mutable
arrays didn't use `constConv` and instead failed due to the missmatched
`deco`.