### PR TITLE
fix Issue 20565 - Local template declarations in different scopes pro…

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5195,6 +5195,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if ((s.isFuncDeclaration() ||
                      s.isAggregateDeclaration() ||
                      s.isEnumDeclaration() ||
+                     s.isTemplateDeclaration() ||
                      v && v.isDataseg()) && !sc.func.localsymtab.insert(s))
                 {
                     // https://issues.dlang.org/show_bug.cgi?id=18266

--- a/test/compilable/testVRP.d
+++ b/test/compilable/testVRP.d
@@ -423,10 +423,10 @@ void test9617a()
     );
     alias Indices = staticIota!(Repr.length / 2);
 
+    void func(T)(T) {}
     foreach (t; Indices)
     {
         alias T = Repr[t * 2];
-        void func(T)(T) {}
         alias func!T f;
 
         foreach (r; Indices)

--- a/test/fail_compilation/fix20565.d
+++ b/test/fail_compilation/fix20565.d
@@ -1,0 +1,26 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fix20565.d(112): Error: declaration `fix20565.foo.temp(T)()` is already defined in another scope in `foo` at line `106`
+fail_compilation/fix20565.d(114): Error: template instance `temp!int` `temp!int` forward references template declaration `temp(T)()`
+---
+*/
+
+#line 100
+
+// https://issues.dlang.org/show_bug.cgi?id=20565
+
+void foo()
+{
+    {
+        int temp(T)() { return 3; }
+
+        temp!int();
+    }
+
+    {
+        int temp(T)() { return 4; }
+
+        temp!int();
+    }
+}
+


### PR DESCRIPTION
…duce uncaught name collisions

The trouble is the mangled names match, resulting in link errors on Win64, but silent bad code on other platforms. This makes it produce a compilation error. I suspect this may be the cause other weird bugs, let's see what problems making it an error are flushed out.