### PR TITLE
DWARF debug infos: Don't name ulong 'uint long'

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -2337,7 +2337,7 @@ static if (1)
             case TYint:         p = "int";           goto Lsigned;
             case TYuint:        p = "uint";          goto Lsigned;
             case TYlong:        p = "long";          goto Lsigned;
-            case TYulong:       p = "uint long";        goto Lsigned;
+            case TYulong:       p = "ulong";         goto Lsigned;
             case TYdchar:       p = "dchar";                goto Lsigned;
             case TYfloat:       p = "float";        ate = DW_ATE_float;     goto Lsigned;
             case TYdouble_alias:


### PR DESCRIPTION
For some reason, ulong was named 'uint long' in the debug infos.
Change it to ulong.

<img width="510" alt="Screen Shot 2021-01-05 at 20 03 51" src="https://user-images.githubusercontent.com/2180215/103639112-3308d080-4f91-11eb-8d79-c6f3d3754322.png">
