### PR TITLE
DWARF debug infos: "handle" multi dimensional arrays

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -2192,8 +2192,16 @@ static if (1)
                     idx = cast(uint)debug_info.buf.length();
                     debug_info.buf.writeuLEB128(code);        // abbreviation code
                     debug_info.buf.write("_Array_".ptr, 7);       // DW_AT_name
-                    if (tybasic(t.Tnext.Tty))
-                        debug_info.buf.writeString(tystring[tybasic(t.Tnext.Tty)]);
+                    // Handles multi-dimensional array
+                    auto lastdim = t.Tnext;
+                    while (lastdim.Tty == TYucent && lastdim.Tnext)
+                    {
+                        debug_info.buf.write("Array_".ptr, 6);
+                        lastdim = lastdim.Tnext;
+                    }
+
+                    if (tybasic(lastdim.Tty))
+                        debug_info.buf.writeString(tystring[tybasic(lastdim.Tty)]);
                     else
                         debug_info.buf.writeByte(0);
                     debug_info.buf.writeByte(tysize(t.Tty)); // DW_AT_byte_size


### PR DESCRIPTION
```
We should really be using DW_TAG_array_type for this instead of piggybacking
on DW_TAG_structure_type, but at least the name will somewhat make sense now.
```

Before:
<img width="531" alt="Screen Shot 2021-01-05 at 21 05 05" src="https://user-images.githubusercontent.com/2180215/103644481-cb0ab800-4f99-11eb-981a-6f321d18a8cb.png">

After:
<img width="543" alt="Screen Shot 2021-01-05 at 21 04 39" src="https://user-images.githubusercontent.com/2180215/103644463-c5ad6d80-4f99-11eb-9f93-ab51da89a3a5.png">