### PR TITLE
build.d: Enable -cov=ctfe for recent host compilers

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -2,7 +2,7 @@
 
 set -uexo pipefail
 
-HOST_DMD_VER=2.088.0 # same as in dmd/src/posix.mak
+HOST_DMD_VER=2.095.0 # same as in dmd/src/bootstrap.sh
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=4
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}

--- a/src/bootstrap.sh
+++ b/src/bootstrap.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-HOST_DMD_VER="${HOST_DMD_VER:-2.088.0}"
+HOST_DMD_VER="${HOST_DMD_VER:-2.095.0}"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 GENERATED="$( cd "$DIR/.." >/dev/null 2>&1 && pwd )/generated"
@@ -44,13 +44,13 @@ fi
 
 HOST_DMD_ROOT="${GENERATED}/host_dmd-${HOST_DMD_VER}"
 if [ "$OS" == "freebsd" ] ; then
-    # dmd.2.088.0.freebsd-64.tar.xz
+    # dmd.2.095.0.freebsd-64.tar.xz
     HOST_DMD_BASENAME=dmd.${HOST_DMD_VER}.${OS}-${MODEL}
 else
-    # dmd.2.088.0.osx.zip or dmd.2.088.0.linux.tar.xz
+    # dmd.2.095.0.osx.zip or dmd.2.095.0.linux.tar.xz
     HOST_DMD_BASENAME=dmd.${HOST_DMD_VER}.${OS}
 fi
-# http://downloads.dlang.org/releases/2.x/2.088.0/dmd.2.088.0.linux.tar.xz
+# http://downloads.dlang.org/releases/2.x/2.095.0/dmd.2.095.0.linux.tar.xz
 HOST_DMD_URL=http://downloads.dlang.org/releases/2.x/${HOST_DMD_VER}/${HOST_DMD_BASENAME}
 HOST_RDMD="${HOST_DMD_ROOT}/dmd2/${OS}/${MODEL_PATH}/rdmd"
 HOST_DMD="${HOST_DMD_ROOT}/dmd2/${OS}/${MODEL_PATH}/dmd" # required by build.d

--- a/src/build.d
+++ b/src/build.d
@@ -1075,7 +1075,7 @@ void parseEnvironment()
     // Auto-bootstrapping of a specific host compiler
     if (env.getNumberedBool("AUTO_BOOTSTRAP"))
     {
-        auto hostDMDVer = env.getDefault("HOST_DMD_VER", "2.088.0");
+        auto hostDMDVer = env.getDefault("HOST_DMD_VER", "2.095.0");
         writefln("Using Bootstrap compiler: %s", hostDMDVer);
         auto hostDMDRoot = env["G"].buildPath("host_dmd-"~hostDMDVer);
         auto hostDMDBase = hostDMDVer~"."~(os == "freebsd" ? os~"-"~model : os);

--- a/src/build.d
+++ b/src/build.d
@@ -350,8 +350,8 @@ alias backend = makeRuleWithArgs!((MethodInitializer!BuildRule builder, BuildRul
         .chain(
             (
                 // Only use -betterC when it doesn't break other features
-                extraFlags.canFind("-unittest", "-cov") ||
-                flags["DFLAGS"].canFind("-unittest", "-cov")
+                extraFlags.canFind("-unittest", env["COVERAGE_FLAG"]) ||
+                flags["DFLAGS"].canFind("-unittest", env["COVERAGE_FLAG"])
             ) ? [] : ["-betterC"],
             flags["DFLAGS"], extraFlags,
 
@@ -1196,9 +1196,14 @@ void processEnvironment()
     {
         dflags ~= ["-profile"];
     }
+
+    // Enable CTFE coverage for recent host compilers
+    const cov = env["HOST_DMD_VERSION"] >= "2.094.0" ? "-cov=ctfe" : "-cov";
+    env["COVERAGE_FLAG"] = cov;
+
     if (env.getNumberedBool("ENABLE_COVERAGE"))
     {
-        dflags ~= ["-cov"];
+        dflags ~= [ cov ];
     }
     const sanitizers = env.getDefault("ENABLE_SANITIZERS", "");
     if (!sanitizers.empty)


### PR DESCRIPTION
This should make coverage reports for dmd more reliable (even though it doesn't make much use of CTFE).

Also bumps the bootstrap version for CircleCI/build.d/bootstrap.sh from `2.088.0` to `2.095.0` because this feature was introduced in `2.094.0`.