### PR TITLE
Issue 21519 - Generate coverage reports on CirrusCI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,9 +6,19 @@ common_steps_template: &COMMON_STEPS_TEMPLATE
     ln -s $CIRRUS_WORKING_DIR ../dmd
     ./ci.sh setup_repos "${CIRRUS_BASE_BRANCH:-$CIRRUS_BRANCH}"
   build_script: ./ci.sh build
-  test_dmd_script: ./ci.sh test_dmd
-  test_druntime_script: ./ci.sh test_druntime
-  test_phobos_script: ./ci.sh test_phobos
+
+  test_dmd_script: |
+    if [ "${DMD_TEST_COVERAGE:-0}" == "1" ]
+    then
+      OS_NAME=$OS ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ./ci.sh rebuild
+      ./ci.sh test_dmd
+      ./ci.sh codecov
+    else
+      ./ci.sh test_dmd
+    fi
+
+  test_druntime_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci.sh test_druntime
+  test_phobos_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci.sh test_phobos
 
 environment:
   CIRRUS_CLONE_DEPTH: 50
@@ -18,6 +28,10 @@ environment:
   N: 4
   OS_NAME: linux
   FULL_BUILD: true
+
+coverage_environment_template: &COVERAGE_ENVIRONMENT_TEMPLATE
+  DMD_TEST_COVERAGE: 1
+  CODECOV_TOKEN: ENCRYPTED[287a085e100f667a399ab7d8024b7c2290b1a528963c87bc168cf855aeb8c676b001eb7cddc570201a8157c5e650e8a1]
 
 # Linux
 task:
@@ -31,10 +45,16 @@ task:
     matrix:
       - TASK_NAME_SUFFIX: x86, DMD (latest)
         MODEL: 32
+      - TASK_NAME_SUFFIX: x86, DMD (coverage)
+        MODEL: 32
+        << : *COVERAGE_ENVIRONMENT_TEMPLATE
       - TASK_NAME_SUFFIX: x86, DMD (bootstrap)
         MODEL: 32
         HOST_DMD: dmd-2.079.0
       - TASK_NAME_SUFFIX: x64, DMD (latest)
+      # Enable this to replace coverage tests on CircleCI
+      # - TASK_NAME_SUFFIX: x64, DMD (coverage)
+      #   << : *COVERAGE_ENVIRONMENT_TEMPLATE
       - TASK_NAME_SUFFIX: x64, DMD (bootstrap)
         HOST_DMD: dmd-2.079.0
       - TASK_NAME_SUFFIX: x64, LDC
@@ -55,6 +75,8 @@ task:
     OS: osx
     matrix:
       - TASK_NAME_SUFFIX: DMD (latest)
+      - TASK_NAME_SUFFIX: DMD (coverage)
+        << : *COVERAGE_ENVIRONMENT_TEMPLATE
       - TASK_NAME_SUFFIX: DMD (bootstrap)
         # de-facto bootstrap version on OSX
         # See: https://forum.dlang.org/post/qfsgt2$1goc$1@digitalmars.com
@@ -63,7 +85,7 @@ task:
 
 # FreeBSD
 task:
-  name: FreeBSD 12.1 x64, DMD (latest)
+  name: FreeBSD 12.1 x64, DMD ($TASK_NAME_TYPE)
   freebsd_instance:
     image_family: freebsd-12-1
     cpu: 4
@@ -72,6 +94,10 @@ task:
   environment:
     OS_NAME: freebsd
     CI_DFLAGS: -version=TARGET_FREEBSD12
+    matrix:
+      - TASK_NAME_TYPE: latest
+      - TASK_NAME_TYPE: coverage
+        << : *COVERAGE_ENVIRONMENT_TEMPLATE
   install_bash_script: pkg install -y bash
   << : *COMMON_STEPS_TEMPLATE
 

--- a/ci.sh
+++ b/ci.sh
@@ -69,7 +69,7 @@ rebuild() {
     cp $build_path/dmd _${build_path}/host_dmd
     cp $build_path/dmd.conf _${build_path}
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd clean
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd ENABLE_RELEASE=1 ENABLE_WARNINGS=1 all
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd ENABLE_RELEASE=${ENABLE_RELEASE:-1} ENABLE_WARNINGS=1 all
 
     # compare binaries to test reproducible build
     if [ $compare -eq 1 ]; then
@@ -207,6 +207,17 @@ install_host_compiler() {
   fi
 }
 
+# Upload coverage reports
+codecov()
+{
+    # CodeCov gets confused by lst files which it can't match
+    rm -rf test/runnable/extra-files test/*.lst
+    curl -fsSL -A "$CURL_USER_AGENT" --connect-timeout 5 --speed-time 30 --speed-limit 1024 \
+        --retry 5 --retry-delay 5 "https://codecov.io/bash" -o "codecov.sh"
+    bash ./codecov.sh -p . -Z
+    rm codecov.sh
+}
+
 # Define commands
 
 if [ "$#" -gt 0 ]; then
@@ -221,6 +232,7 @@ if [ "$#" -gt 0 ]; then
     test_phobos) test_phobos ;;
     test_dub_package) test_dub_package ;;
     testsuite) testsuite ;;
+    codecov) codecov ;;
     *) echo "Unknown command: $1" >&2; exit 1 ;;
   esac
 fi


### PR DESCRIPTION
This adds coverage reports for several missing targets:
- Linux 32 (64 is already generated on CircleCI)
- MacOS 64
- FreeBSD 64