### PR TITLE
test: Remove empty TEST_OUTPUT directives

### DIFF
--- a/test/compilable/callconv.d
+++ b/test/compilable/callconv.d
@@ -1,10 +1,4 @@
 // PERMUTE_ARGS:
-/*
-TEST_OUTPUT:
----
----
-*/
-
 import core.stdc.stdarg;
 
 struct ABC

--- a/test/compilable/checkimports3.d
+++ b/test/compilable/checkimports3.d
@@ -1,9 +1,6 @@
 /*
 REQUIRED_ARGS: -de
 EXTRA_FILES: imports/checkimports3a.d imports/checkimports3b.d imports/checkimports3c.d
-TEST_OUTPUT:
----
----
 */
 import imports.checkimports3a;
 import imports.checkimports3b;

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1,9 +1,4 @@
-/**
-EXTRA_FILES: cppmangle2.d
-TEST_OUTPUT:
----
----
-*/
+// EXTRA_FILES: cppmangle2.d
 // Test C++ name mangling.
 // https://issues.dlang.org/show_bug.cgi?id=4059
 // https://issues.dlang.org/show_bug.cgi?id=5148

--- a/test/compilable/cppmangle3.d
+++ b/test/compilable/cppmangle3.d
@@ -1,8 +1,6 @@
-/**
-TEST_OUTPUT:
----
----
-*/
+// https://issues.dlang.org/show_bug.cgi?id=15512
+// https://issues.dlang.org/show_bug.cgi?id=19893
+// https://issues.dlang.org/show_bug.cgi?id=19920
 module cppmangle3;
 
 

--- a/test/compilable/ddoc14633.d
+++ b/test/compilable/ddoc14633.d
@@ -1,12 +1,6 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -w -o-
 
-/*
-TEST_OUTPUT:
----
----
-*/
-
 /** Blah
  Params:
     T = some type

--- a/test/compilable/ddoc15475.d
+++ b/test/compilable/ddoc15475.d
@@ -1,9 +1,6 @@
 /* PERMUTE_ARGS:
 REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-TEST_OUTPUT:
----
----
 */
 
 /**

--- a/test/compilable/deprecate14283.d
+++ b/test/compilable/deprecate14283.d
@@ -1,11 +1,5 @@
 // REQUIRED_ARGS: -dw
 // PERMUTE_ARGS:
-/*
-TEST_OUTPUT:
----
----
-*/
-
 class C
 {
     void bug()

--- a/test/compilable/diag11066.d
+++ b/test/compilable/diag11066.d
@@ -1,10 +1,4 @@
 // REQUIRED_ARGS: -w -profile
-/*
-TEST_OUTPUT:
----
----
-*/
-
 void main()
 {
     string s;

--- a/test/compilable/diag12598.d
+++ b/test/compilable/diag12598.d
@@ -1,9 +1,6 @@
 /*
 REQUIRED_ARGS:
 EXTRA_FILES: imports/diag12598a.d
-TEST_OUTPUT:
----
----
 */
 
 class C

--- a/test/compilable/diag3243.d
+++ b/test/compilable/diag3243.d
@@ -1,11 +1,5 @@
 // REQUIRED_ARGS: -vtls
 // PERMUTE_ARGS:
-/*
-TEST_OUTPUT:
----
----
-*/
-
 template T()
 {
     static this() {}

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -7,10 +7,10 @@
                 "char": 1,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "endchar": 23,
-                "endline": 12,
+                "endline": 8,
                 "kind": "shared static constructor",
-                "line": 12,
-                "name": "_sharedStaticCtor_L12_C1",
+                "line": 8,
+                "name": "_sharedStaticCtor_L8_C1",
                 "protection": "public",
                 "storageClass": [
                     "static"
@@ -20,10 +20,10 @@
                 "char": 1,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "endchar": 16,
-                "endline": 13,
+                "endline": 9,
                 "kind": "static constructor",
-                "line": 13,
-                "name": "_staticCtor_L13_C1",
+                "line": 9,
+                "name": "_staticCtor_L9_C1",
                 "protection": "public",
                 "storageClass": [
                     "static"
@@ -33,10 +33,10 @@
                 "char": 1,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "endchar": 24,
-                "endline": 14,
+                "endline": 10,
                 "kind": "shared static destructor",
-                "line": 14,
-                "name": "_sharedStaticDtor_L14_C1",
+                "line": 10,
+                "name": "_sharedStaticDtor_L10_C1",
                 "protection": "public",
                 "storageClass": [
                     "static"
@@ -46,10 +46,10 @@
                 "char": 1,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "endchar": 17,
-                "endline": 15,
+                "endline": 11,
                 "kind": "static destructor",
-                "line": 15,
-                "name": "_staticDtor_L15_C1",
+                "line": 11,
+                "name": "_staticDtor_L11_C1",
                 "protection": "public",
                 "storageClass": [
                     "static"
@@ -58,15 +58,15 @@
             {
                 "char": 1,
                 "kind": "template",
-                "line": 17,
+                "line": 13,
                 "members": [
                     {
                         "char": 5,
                         "endchar": 27,
-                        "endline": 19,
+                        "endline": 15,
                         "kind": "shared static constructor",
-                        "line": 19,
-                        "name": "_sharedStaticCtor_L19_C5",
+                        "line": 15,
+                        "name": "_sharedStaticCtor_L15_C5",
                         "storageClass": [
                             "static"
                         ]
@@ -74,10 +74,10 @@
                     {
                         "char": 5,
                         "endchar": 20,
-                        "endline": 20,
+                        "endline": 16,
                         "kind": "static constructor",
-                        "line": 20,
-                        "name": "_staticCtor_L20_C5",
+                        "line": 16,
+                        "name": "_staticCtor_L16_C5",
                         "storageClass": [
                             "static"
                         ]
@@ -85,10 +85,10 @@
                     {
                         "char": 5,
                         "endchar": 28,
-                        "endline": 21,
+                        "endline": 17,
                         "kind": "shared static destructor",
-                        "line": 21,
-                        "name": "_sharedStaticDtor_L21_C5",
+                        "line": 17,
+                        "name": "_sharedStaticDtor_L17_C5",
                         "storageClass": [
                             "static"
                         ]
@@ -96,10 +96,10 @@
                     {
                         "char": 5,
                         "endchar": 21,
-                        "endline": 22,
+                        "endline": 18,
                         "kind": "static destructor",
-                        "line": 22,
-                        "name": "_staticDtor_L22_C5",
+                        "line": 18,
+                        "name": "_staticDtor_L18_C5",
                         "storageClass": [
                             "static"
                         ]
@@ -117,7 +117,7 @@
             {
                 "char": 1,
                 "kind": "alias",
-                "line": 25,
+                "line": 21,
                 "name": "SSCDX",
                 "originalType": "X!int",
                 "protection": "public"
@@ -125,16 +125,16 @@
             {
                 "char": 1,
                 "kind": "class",
-                "line": 27,
+                "line": 23,
                 "members": [
                     {
                         "char": 5,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 27,
-                        "endline": 29,
+                        "endline": 25,
                         "kind": "shared static constructor",
-                        "line": 29,
-                        "name": "_sharedStaticCtor_L29_C5",
+                        "line": 25,
+                        "name": "_sharedStaticCtor_L25_C5",
                         "protection": "public",
                         "storageClass": [
                             "static"
@@ -144,10 +144,10 @@
                         "char": 5,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 20,
-                        "endline": 30,
+                        "endline": 26,
                         "kind": "static constructor",
-                        "line": 30,
-                        "name": "_staticCtor_L30_C5",
+                        "line": 26,
+                        "name": "_staticCtor_L26_C5",
                         "protection": "public",
                         "storageClass": [
                             "static"
@@ -157,10 +157,10 @@
                         "char": 5,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 28,
-                        "endline": 31,
+                        "endline": 27,
                         "kind": "shared static destructor",
-                        "line": 31,
-                        "name": "_sharedStaticDtor_L31_C5",
+                        "line": 27,
+                        "name": "_sharedStaticDtor_L27_C5",
                         "protection": "public",
                         "storageClass": [
                             "static"
@@ -170,10 +170,10 @@
                         "char": 5,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 21,
-                        "endline": 32,
+                        "endline": 28,
                         "kind": "static destructor",
-                        "line": 32,
-                        "name": "_staticDtor_L32_C5",
+                        "line": 28,
+                        "name": "_staticDtor_L28_C5",
                         "protection": "public",
                         "storageClass": [
                             "static"

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -2,10 +2,6 @@
 // REQUIRED_ARGS: -d -preview=dip1000 -o- -X -Xf${RESULTS_DIR}/compilable/json.out
 // POST_SCRIPT: compilable/extra-files/json-postscript.sh
 // EXTRA_FILES: imports/jsonimport1.d imports/jsonimport2.d imports/jsonimport3.d imports/jsonimport4.d
-/* TEST_OUTPUT:
----
----
-*/
 
 module json;
 

--- a/test/compilable/readmodify_structclass.d
+++ b/test/compilable/readmodify_structclass.d
@@ -1,9 +1,4 @@
-/*
-REQUIRED_ARGS:
-TEST_OUTPUT:
----
----
-*/
+// REQUIRED_ARGS:
 shared struct S
 {
     int x = 0;

--- a/test/compilable/test1170.d
+++ b/test/compilable/test1170.d
@@ -1,9 +1,3 @@
-/*
-TEST_OUTPUT:
----
----
-*/
-
 // https://issues.dlang.org/show_bug.cgi?id=1170
 type x;
 mixin("alias int type;");

--- a/test/compilable/test12567a.d
+++ b/test/compilable/test12567a.d
@@ -1,10 +1,5 @@
 // REQUIRED_ARGS:
 // PERMUTE_ARGS:
-/*
-TEST_OUTPUT:
----
----
-*/
 deprecated
 module test12567a;
 

--- a/test/compilable/test12567b.d
+++ b/test/compilable/test12567b.d
@@ -1,10 +1,5 @@
 // REQUIRED_ARGS:
 // PERMUTE_ARGS:
-/*
-TEST_OUTPUT:
----
----
-*/
 deprecated("message")
 module test12567b;
 

--- a/test/compilable/test12567d.d
+++ b/test/compilable/test12567d.d
@@ -1,11 +1,6 @@
 // REQUIRED_ARGS: -d
 // EXTRA_FILES: imports/a12567.d
 // PERMUTE_ARGS:
-/*
-TEST_OUTPUT:
----
----
-*/
 import imports.a12567;
 
 void main() { foo(); }

--- a/test/compilable/test12567e.d
+++ b/test/compilable/test12567e.d
@@ -1,7 +1,2 @@
 // REQUIRED_ARGS: -o-
-/*
-TEST_OUTPUT:
----
----
-*/
 deprecated("a" ~ "b") module fail12567;

--- a/test/compilable/test13053.d
+++ b/test/compilable/test13053.d
@@ -1,10 +1,4 @@
 // PERMUTE_ARGS: -w -wi
-/*
-TEST_OUTPUT:
----
----
-*/
-
 @system:
 
 struct S

--- a/test/compilable/test14375.d
+++ b/test/compilable/test14375.d
@@ -1,8 +1,4 @@
-/*
-TEST_OUTPUT:
----
----
- */
+// https://issues.dlang.org/show_bug.cgi?id=14375
 interface IKeysAPI(string greetings) {
     static assert(greetings == "Hello world", greetings);
 }

--- a/test/compilable/test15371.d
+++ b/test/compilable/test15371.d
@@ -1,10 +1,4 @@
-/*
-EXTRA_FILES: imports/test15371.d
-TEST_OUTPUT:
----
----
-*/
-
+// EXTRA_FILES: imports/test15371.d
 import imports.test15371;
 
 void main()

--- a/test/compilable/test1547.d
+++ b/test/compilable/test1547.d
@@ -1,9 +1,4 @@
 // https://issues.dlang.org/show_bug.cgi?id=1547
-/*
-TEST_OUTPUT:
----
----
-*/
 
 struct A
 {

--- a/test/compilable/test15785.d
+++ b/test/compilable/test15785.d
@@ -1,11 +1,6 @@
 // REQUIRED_ARGS: -de
 // EXTRA_FILES: imports/test15785.d
 // PERMUTE_ARGS:
-/*
-TEST_OUTPUT:
----
----
-*/
 import imports.test15785;
 
 class Derived : Base, IBase2

--- a/test/compilable/test15856.d
+++ b/test/compilable/test15856.d
@@ -1,12 +1,6 @@
 // REQUIRED_ARGS: -de
 // PERMUTE_ARGS:
 // EXTRA_FILES: imports/a15856.d
-/*
-TEST_OUTPUT:
----
----
-*/
-
 class Foo
 {
     import imports.a15856;

--- a/test/compilable/test17419.d
+++ b/test/compilable/test17419.d
@@ -1,10 +1,5 @@
 // REQUIRED_ARGS: -d
 // https://issues.dlang.org/show_bug.cgi?id=17419
-/* TEST_OUTPUT:
----
----
-*/
-
 
 extern (C) int fooc();
 alias aliasc = fooc;

--- a/test/compilable/test17752.d
+++ b/test/compilable/test17752.d
@@ -1,10 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=17752
 // REQUIRED_ARGS: -de
-/*
-TEST_OUTPUT:
----
----
-*/
 void main (string[] args)
 {
     switch (args.length)

--- a/test/compilable/test17791.d
+++ b/test/compilable/test17791.d
@@ -1,9 +1,4 @@
-/*
-REQUIRED_ARGS: -de
-TEST_OUTPUT:
----
----
-*/
+// REQUIRED_ARGS: -de
 deprecated("A deprecated class") {
 class DepClass
 {

--- a/test/compilable/test19809.d
+++ b/test/compilable/test19809.d
@@ -1,9 +1,4 @@
-/*
-TEST_OUTPUT:
----
----
-*/
-
+// https://issues.dlang.org/show_bug.cgi?id=19809
 mixin template Impl(M...)
 {
     int opCmp(Object o) { return 0; }

--- a/test/compilable/test20051.d
+++ b/test/compilable/test20051.d
@@ -1,11 +1,4 @@
 // https://issues.dlang.org/show_bug.cgi?id=20051
-
-/*
-TEST_OUTPUT:
----
----
-*/
-
 struct Templ2(Args...)
 {
 }

--- a/test/compilable/test20100.d
+++ b/test/compilable/test20100.d
@@ -1,9 +1,4 @@
 // REQUIRED_ARGS: -checkaction=context
-/*
-TEST_OUTPUT:
----
----
-*/
 struct STuple {
 	bool opEquals(STuple) { return false; }
 }

--- a/test/compilable/test20136.d
+++ b/test/compilable/test20136.d
@@ -1,10 +1,4 @@
 // https://issues.dlang.org/show_bug.cgi?id=20136
-/*
-TEST_OUTPUT:
----
----
-*/
-
 class Context
 {
     size_t[const(Key)] aa;

--- a/test/compilable/test20406.d
+++ b/test/compilable/test20406.d
@@ -1,9 +1,4 @@
 // https://issues.dlang.org/show_bug.cgi?id=20406
-/* TEST_OUTPUT:
----
----
-*/
-
 struct S
 {
 	@disable this();

--- a/test/compilable/test7815.d
+++ b/test/compilable/test7815.d
@@ -1,10 +1,4 @@
 // REQUIRED_ARGS: -o-
-/*
-TEST_OUTPUT:
----
----
-*/
-
 mixin template Helpers()
 {
     static if (is(Flags!Move))

--- a/test/compilable/test9029.d
+++ b/test/compilable/test9029.d
@@ -1,7 +1,4 @@
-/* TEST_OUTPUT:
----
----
-*/
+// https://issues.dlang.org/show_bug.cgi?id=9029
 enum NameOf(alias S) = S.stringof;
 
 static assert(NameOf!int == "int");

--- a/test/compilable/test930.d
+++ b/test/compilable/test930.d
@@ -1,10 +1,4 @@
 // https://issues.dlang.org/show_bug.cgi?id=930
-
-/*
-TEST_OUTPUT:
----
----
-*/
 template ATemplate(T)
 {
    template ATemplate()

--- a/test/compilable/testCpCtor.d
+++ b/test/compilable/testCpCtor.d
@@ -1,7 +1,4 @@
-/* TEST_OUTPUT:
----
----
-*/
+// https://issues.dlang.org/show_bug.cgi?id=19870
 struct T
 {
     int i;

--- a/test/compilable/testcheckimports.d
+++ b/test/compilable/testcheckimports.d
@@ -1,10 +1,5 @@
 // REQUIRED_ARGS:
 // EXTRA_FILES: imports/test15857a.d imports/test15857b.d imports/test15857c.d
-/*
-TEST_OUTPUT:
----
----
-*/
 
 // https://issues.dlang.org/show_bug.cgi?id=15825
 

--- a/test/compilable/warn3882.d
+++ b/test/compilable/warn3882.d
@@ -1,10 +1,4 @@
 // PERMUTE_ARGS: -w -wi -debug
-/*
-TEST_OUTPUT:
----
----
-*/
-
 @safe pure nothrow void strictVoidReturn(T)(T x) {}
 @safe pure nothrow void nonstrictVoidReturn(T)(ref T x) {}
 

--- a/test/runnable/argufilem.d
+++ b/test/runnable/argufilem.d
@@ -1,9 +1,5 @@
 /*
 EXTRA_SOURCES: imports/argufile.d
-TEST_OUTPUT:
----
----
-
 RUN_OUTPUT:
 ---
 bob is 7 years old

--- a/test/runnable/b10562.d
+++ b/test/runnable/b10562.d
@@ -1,8 +1,3 @@
-/*
-TEST_OUTPUT:
----
----
-*/
 void main()
 {
     {

--- a/test/runnable/foreach4.d
+++ b/test/runnable/foreach4.d
@@ -1,9 +1,3 @@
-/*
-TEST_OUTPUT:
----
----
-*/
-
 import core.stdc.stdio;
 
 alias bool bit;

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -1,9 +1,6 @@
 /*
 REQUIRED_ARGS:
 EXTRA_FILES: extra-files/test15.txt
-TEST_OUTPUT:
----
----
 */
 
 import std.array;

--- a/test/runnable/test19122.d
+++ b/test/runnable/test19122.d
@@ -1,9 +1,4 @@
-/*
-TEST_OUTPUT:
----
----
-*/
-
+// https://issues.dlang.org/show_bug.cgi?id=19122
 struct HasDestructor
 {
     ~this()

--- a/test/runnable/test19441.d
+++ b/test/runnable/test19441.d
@@ -1,8 +1,4 @@
-/* TEST_OUTPUT:
----
----
-*/
-
+// https://issues.dlang.org/show_bug.cgi?id=19441
 struct S1
 {
     int a;

--- a/test/runnable/test19774.d
+++ b/test/runnable/test19774.d
@@ -1,9 +1,4 @@
-/*
-TEST_OUTPUT:
----
----
-*/
-
+// https://issues.dlang.org/show_bug.cgi?id=19774
 C bar()
 {
     return C(42);

--- a/test/runnable/test19782.d
+++ b/test/runnable/test19782.d
@@ -1,7 +1,4 @@
-/* TEST_OUTPUT:
----
----
-*/
+// https://issues.dlang.org/show_bug.cgi?id=19782
 class Inner
 {
     int a;

--- a/test/runnable/test19822.d
+++ b/test/runnable/test19822.d
@@ -1,9 +1,4 @@
-/*
-TEST_OUTPUT:
----
----
-*/
-
+// https://issues.dlang.org/show_bug.cgi?id=19822
 struct Quat
 {
     static struct Vec { int x; }

--- a/test/runnable/test20025.d
+++ b/test/runnable/test20025.d
@@ -1,10 +1,4 @@
 // https://issues.dlang.org/show_bug.cgi?id=20025
-/*
-TEST_OUTPUT:
----
----
-*/
-
 struct B
 {
         static int value = 77;

--- a/test/runnable/test711.d
+++ b/test/runnable/test711.d
@@ -1,8 +1,4 @@
-/*
-TEST_OUTPUT:
----
----
-*/
+// https://issues.dlang.org/show_bug.cgi?id=711
 string result;
 
 template Mixer()

--- a/test/runnable/test809.d
+++ b/test/runnable/test809.d
@@ -1,9 +1,4 @@
 // https://issues.dlang.org/show_bug.cgi?id=809
-/* TEST_OUTPUT:
----
----
-*/
-
 void test(lazy int dg)
 {
     int delegate() dg_ = &dg;

--- a/test/runnable/testargtypes.d
+++ b/test/runnable/testargtypes.d
@@ -1,8 +1,5 @@
 /*
 DISABLED: win32 win64 osx32 linux32 freebsd32
-TEST_OUTPUT:
----
----
 */
 
 void chkArgTypes(S, V...)()


### PR DESCRIPTION
The testsuite complains about any compiler message by default, so these are redundant.

@MoonlightSentinel  correct me if my memory is wrong here.