### PR TITLE
run.d: Dump env directly after processing environment variables...

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -134,7 +134,16 @@ Options:
     unitTestRunnerCommand = resultsDir.buildPath("unit_test_runner").exeName;
 
     // bootstrap all needed environment variables
-    auto env = getEnvironment;
+    const env = getEnvironment();
+
+    // Dump environnment
+    if (verbose || dumpEnvironment)
+    {
+        writefln("================================================================================");
+        foreach (key, value; env)
+            writefln("%s=%s", key, value);
+        writefln("================================================================================");
+    }
 
     if (runUnitTests)
     {
@@ -184,14 +193,6 @@ Options:
     {
         verifyCompilerExists(env);
 
-        if (verbose || dumpEnvironment)
-        {
-            writefln("================================================================================");
-            foreach (key, value; env)
-                writefln("%s=%s", key, value);
-            writefln("================================================================================");
-        }
-
         string[] failedTargets;
         ensureToolsExists(env, EnumMembers!TestTools);
         foreach (target; parallel(targets, 1))
@@ -218,7 +219,7 @@ Options:
 }
 
 /// Verify that the compiler has been built.
-void verifyCompilerExists(string[string] env)
+void verifyCompilerExists(const string[string] env)
 {
     if (!env["DMD"].exists)
     {
@@ -231,7 +232,7 @@ void verifyCompilerExists(string[string] env)
 Builds the binary of the tools required by the testsuite.
 Does nothing if the tools already exist and are newer than their source.
 */
-void ensureToolsExists(string[string] env, const TestTool[] tools ...)
+void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
 {
     resultsDir.mkdirRecurse;
 
@@ -255,7 +256,7 @@ void ensureToolsExists(string[string] env, const TestTool[] tools ...)
         else
         {
             string[] command;
-            string[string] commandEnv = null;
+            bool overrideEnv;
             if (tool.linksWithTests)
             {
                 // This will compile the dshell library thus needs the actual
@@ -268,7 +269,7 @@ void ensureToolsExists(string[string] env, const TestTool[] tools ...)
                     "-c",
                     sourceFile
                 ] ~ getPicFlags(env);
-                commandEnv = env;
+                overrideEnv = true;
             }
             else
             {
@@ -282,7 +283,7 @@ void ensureToolsExists(string[string] env, const TestTool[] tools ...)
 
             writefln("Executing: %-(%s %)", command);
             stdout.flush();
-            if (spawnProcess(command, commandEnv).wait)
+            if (spawnProcess(command, overrideEnv ? env : null).wait)
             {
                 stderr.writefln("failed to build '%s'", targetBin);
                 atomicOp!"+="(failCount, 1);
@@ -417,7 +418,7 @@ auto predefinedTargets(string[] targets)
 }
 
 // Removes targets that do not need updating (i.e. their .out file exists and is newer than the source file)
-auto filterTargets(Target[] targets, string[string] env)
+auto filterTargets(Target[] targets, const string[string] env)
 {
     bool error;
     foreach (target; targets)
@@ -569,7 +570,7 @@ auto objName(T)(T name)
 }
 
 /// Return the correct pic flags as an array of strings
-string[] getPicFlags(string[string] env)
+string[] getPicFlags(const string[string] env)
 {
     version(Windows) {} else
     {


### PR DESCRIPTION
... s.t. `--environment` is respected for non-default targets
(tools, specific unittests, ...) and printed before building the tools.

Also const-qualified `env` to ensure that the environment is not
modified afterwards.