### PR TITLE
dtoh: Emit template arguments for instantiated base classes 

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -5,6 +5,7 @@ experimental C++ header generator:
 
 - Generate fieldwise constructors for aggregates
 - Don't emit instantiated classes as unique class declarations
+- Emit template arguments for instantiated base classes
 
 Note: The header generator is still considerer experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1247,9 +1247,13 @@ public:
             // e.g. class A(T) : B!T { ... }
             if (base.sym is null)
             {
-                auto ti = base.type.isTypeInstance();
-                assert(ti);
-                visitTi(ti.tempinst);
+                base.type.accept(this);
+            }
+            // base.type references onemember for template instances
+            // and hence skips the TypeInstance...
+            else if (auto ti = base.sym.isInstantiated())
+            {
+                visitTi(ti);
             }
             else
             {

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -660,6 +660,7 @@ class TemplateValueParameter;
 class TemplateAliasParameter;
 class TemplateThisParameter;
 class TypeQualified;
+struct ASTCodegen;
 class ErrorStatement;
 class PeelStatement;
 class UnrolledLoopStatement;
@@ -669,7 +670,6 @@ class DtorExpStatement;
 class ForwardingStatement;
 class ErrorInitializer;
 class ObjcClassReferenceExp;
-struct ASTCodegen;
 union __AnonStruct__u;
 class UnaExp;
 class BinExp;
@@ -1399,7 +1399,7 @@ public:
     TypeFunction* toTypeFunction();
 };
 
-class Visitor : public ParseTimeVisitor
+class Visitor : public ParseTimeVisitor<ASTCodegen >
 {
 public:
     virtual void visit(ErrorStatement* s);

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -133,7 +133,7 @@ extern void withDefTempl(A<int32_t > a = A<int32_t >(2));
 template <typename T>
 extern void withDefTempl2(A<T > a = static_cast<A<T >>(A!T(2)));
 
-class ChildInt : public Parent
+class ChildInt : public Parent<int32_t >
 {
 };
 ---


### PR DESCRIPTION
Check whether the base class is instantiated and visit the `TemplateInstance` to write template arguments and include the template declaration.
