### PR TITLE
fix Issue 21553 - incorrect call to expressionSemantic() in statement…

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2090,9 +2090,9 @@ Expression castTo(Expression e, Scope* sc, Type t)
                 {
                     f.tookAddressOf++;
                     auto se = new SymOffExp(e.loc, f, 0, false);
-                    se.expressionSemantic(sc);
+                    auto se2 = se.expressionSemantic(sc);
                     // Let SymOffExp::castTo() do the heavy lifting
-                    visit(se);
+                    visit(se2);
                     return;
                 }
             }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2688,7 +2688,7 @@ else
                     (*args)[1] = new IntegerExp(ss.loc.linnum);
 
                     sl = new CallExp(ss.loc, sl, args);
-                    sl.expressionSemantic(sc);
+                    sl = sl.expressionSemantic(sc);
 
                     s = new SwitchErrorStatement(ss.loc, sl);
                 }
@@ -2775,7 +2775,7 @@ else
             sl = new DotTemplateInstanceExp(ss.loc, sl, Id.__switch, compileTimeArgs);
 
             sl = new CallExp(ss.loc, sl, arguments);
-            sl.expressionSemantic(sc);
+            sl = sl.expressionSemantic(sc);
             ss.condition = sl;
 
             auto i = 0;


### PR DESCRIPTION
…sem.d

Noticed this while working on https://github.com/dlang/dmd/pull/12012/

Don't have a test case for it, but it is just wrong.