### PR TITLE
Reduce TupleDeclaration size

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -589,8 +589,6 @@ extern (C++) abstract class Declaration : Dsymbol
 extern (C++) final class TupleDeclaration : Declaration
 {
     Objects* objects;
-    bool isexp;             // true: expression tuple
-    TypeTuple tupletype;    // !=null if this is a type tuple
 
     extern (D) this(const ref Loc loc, Identifier ident, Objects* objects)
     {
@@ -608,6 +606,23 @@ extern (C++) final class TupleDeclaration : Declaration
         return "tuple";
     }
 
+    /**
+     * Set as expression tuple, i.e. getType() returns null.
+     * Actually only used as property function
+     */
+    extern (D) @property void isexp(bool b)
+    {
+        if (b)
+            type = Type.tnone;
+        else
+            assert(0); // Never unset
+    }
+
+    extern (D) @property bool isexp()
+    {
+        return type is Type.tnone;
+    }
+
     override Type getType()
     {
         /* If this tuple represents a type, return that type
@@ -616,7 +631,7 @@ extern (C++) final class TupleDeclaration : Declaration
         //printf("TupleDeclaration::getType() %s\n", toChars());
         if (isexp)
             return null;
-        if (!tupletype)
+        if (!type)
         {
             /* It's only a type tuple if all the Object's are types
              */
@@ -657,11 +672,11 @@ extern (C++) final class TupleDeclaration : Declaration
                     hasdeco = 0;
             }
 
-            tupletype = new TypeTuple(args);
+            type = new TypeTuple(args);
             if (hasdeco)
-                return tupletype.typeSemantic(Loc.initial, null);
+                return type.typeSemantic(Loc.initial, null);
         }
-        return tupletype;
+        return type;
     }
 
     override Dsymbol toAlias2()

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -147,9 +147,6 @@ class TupleDeclaration : public Declaration
 {
 public:
     Objects *objects;
-    bool isexp;                 // true: expression tuple
-
-    TypeTuple *tupletype;       // !=NULL if this is a type tuple
 
     TupleDeclaration *syntaxCopy(Dsymbol *);
     const char *kind() const;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -636,6 +636,7 @@ class TemplateTupleParameter;
 struct Mcache;
 struct TYPE;
 class TypeBasic;
+class TypeNone;
 class TypeError;
 class TypeVector;
 class TypeSArray;
@@ -1256,6 +1257,7 @@ public:
     static Type* tdstring;
     static Type* terror;
     static Type* tnull;
+    static Type* tnone;
     static Type* tsize_t;
     static Type* tptrdiff_t;
     static Type* thash_t;
@@ -1374,6 +1376,7 @@ public:
     virtual bool needsCopyOrPostblit();
     virtual bool needsNested();
     virtual TypeBasic* isTypeBasic();
+    TypeNone* isTypeNone();
     TypeError* isTypeError();
     TypeVector* isTypeVector();
     TypeSArray* isTypeSArray();
@@ -2391,8 +2394,6 @@ class TupleDeclaration final : public Declaration
 {
 public:
     Array<RootObject* >* objects;
-    bool isexp;
-    TypeTuple* tupletype;
     TupleDeclaration* syntaxCopy(Dsymbol* s);
     const char* kind() const;
     Type* getType();
@@ -4937,6 +4938,12 @@ enum class DotExpFlag
 {
     gag = 1,
     noDeref = 2,
+};
+
+class TypeNone final : public Type
+{
+public:
+    const char* kind() const;
 };
 
 class TypeError final : public Type

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3599,6 +3599,11 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
         assert(0);
     }
 
+    void visitNone(TypeNone t)
+    {
+        buf.writestring("_none_");
+    }
+
     void visitError(TypeError t)
     {
         buf.writestring("_error_");
@@ -3806,6 +3811,7 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
                                 visitBasic(cast(TypeBasic)t) :
                                 visitType(t);
 
+        case Tnone:      return visitNone(cast(TypeNone)t);
         case Terror:     return visitError(cast(TypeError)t);
         case Ttraits:    return visitTraits(cast(TypeTraits)t);
         case Tvector:    return visitVector(cast(TypeVector)t);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -449,6 +449,7 @@ extern (C++) abstract class Type : ASTNode
     extern (C++) __gshared Type tdstring;    // immutable(dchar)[]
     extern (C++) __gshared Type terror;      // for error recovery
     extern (C++) __gshared Type tnull;       // for null type
+    extern (C++) __gshared Type tnone;       // no type
 
     extern (C++) __gshared Type tsize_t;     // matches size_t alias
     extern (C++) __gshared Type tptrdiff_t;  // matches ptrdiff_t alias
@@ -894,6 +895,7 @@ extern (C++) abstract class Type : ASTNode
         terror = basic[Terror];
         tnull = new TypeNull();
         tnull.deco = tnull.merge().deco;
+        tnone = new TypeNone();
 
         tvoidptr = tvoid.pointerTo();
         tstring = tchar.immutableOf().arrayOf();
@@ -2678,6 +2680,7 @@ extern (C++) abstract class Type : ASTNode
 
     final pure inout nothrow @nogc
     {
+        inout(TypeNone)       isTypeNone()       { return ty == Tnone      ? cast(typeof(return))this : null; }
         inout(TypeError)      isTypeError()      { return ty == Terror     ? cast(typeof(return))this : null; }
         inout(TypeVector)     isTypeVector()     { return ty == Tvector    ? cast(typeof(return))this : null; }
         inout(TypeSArray)     isTypeSArray()     { return ty == Tsarray    ? cast(typeof(return))this : null; }
@@ -2711,6 +2714,21 @@ extern (C++) abstract class Type : ASTNode
         if (ty != Tfunction)
             assert(0);
         return cast(TypeFunction)this;
+    }
+}
+
+/***********************************************************
+ */
+extern (C++) final class TypeNone : Type
+{
+    extern (D) this()
+    {
+        super(Tnone);
+    }
+
+    override const(char)* kind() const
+    {
+        return "none";
     }
 }
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -307,7 +307,7 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
                 if (s.isDeclaration()) // var, func, or tuple declaration?
                 {
                     t = s.isDeclaration().type;
-                    if (!t && s.isTupleDeclaration()) // expression tuple?
+                    if (s.isTupleDeclaration()) // expression tuple?
                         return helper3();
                 }
                 else if (s.isTemplateInstance() ||


### PR DESCRIPTION
Reduced from 216 to 200 bytes according to `_traits(classInstanceSize, TupleDeclaration)`.

Now it's using `type` member variable to hold the value and I've created `TypeNone` with the corresponding `Tnone` tag to indicate the intent of not returning a type with `getType()` member.