### PR TITLE
Reintroduce the fix for the reverted PR: Postblit has priority over copy constructor

### DIFF
--- a/changelog/copy-constructor-priority.dd
+++ b/changelog/copy-constructor-priority.dd
@@ -1,0 +1,43 @@
+Having both a copy constructor and a generated postblit is now deprecated
+
+Up until this release, the postblit had priority over the copy constructor,
+no matter if the former was user-defined or generated. This prevented new
+code that uses the copy constructor to interact with library code that uses
+the postblit. To enable this interaction, having a generated postblit
+and a copy constructor (user-defined or generated) is now deprecated.
+For example:
+
+---
+// library code using postblit
+struct A
+{
+    this(this) {}
+}
+
+// new code using copy constructor
+struct B
+{
+    A a;
+    this(const scope ref B) {}
+}
+---
+
+Up until this release, in the above code, `struct B` had a generated postblit
+that had priority over the user defined copy constructor. With this release,
+a deprecation will be issued at the definition of ` structB`, stating that the
+postblit is going to be preferred to the copy constructor. If `B` has both a
+user-defined postblit and a copy constructor (generated or user-defined),
+the postblit will continue to have priority.
+
+To get rid of the deprecation, the user can either:
+
+1. Explicitly `@disable this(this)` in `struct B`. That will instruct
+the compiler that the copy constructor is preferred over the postblit.
+
+2. Define a postblit for `struct B`. That will instruct the compiler
+that the postblit is preferred over the postblit.
+
+3. Remove all copy constructors from `struct B`. In this case the postblit
+will be used for copy constructing instances of `struct B`.
+
+

--- a/test/fail_compilation/fail20714.d
+++ b/test/fail_compilation/fail20714.d
@@ -1,0 +1,32 @@
+// https://issues.dlang.org/show_bug.cgi?id=20714
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20714.d(19): Deprecation: `struct Adder` implicitly-generated postblit hides copy constructor.
+fail_compilation/fail20714.d(19):        The field postblit will have priority over the copy constructor.
+fail_compilation/fail20714.d(19):        To change this, the postblit should be disabled for `struct Adder`
+---
+*/
+
+
+struct Blitter
+{
+    int payload;
+    this(this){}
+}
+
+struct Adder
+{
+    Blitter blitter;
+    this(int payload) {this.blitter.payload = payload;}
+    this(ref Adder rhs) {this.blitter.payload = rhs.blitter.payload + 1;}
+}
+
+void main()
+{
+    Adder piece1 = 1;
+    auto piece2 = piece1;
+
+    assert(piece2.blitter.payload == 2);
+}

--- a/test/fail_compilation/fail20965.d
+++ b/test/fail_compilation/fail20965.d
@@ -1,0 +1,27 @@
+// https://issues.dlang.org/show_bug.cgi?id=20965
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20965.d(17): Deprecation: `struct S` implicitly-generated postblit hides copy constructor.
+fail_compilation/fail20965.d(17):        The field postblit will have priority over the copy constructor.
+fail_compilation/fail20965.d(17):        To change this, the postblit should be disabled for `struct S`
+---
+*/
+
+struct C
+{
+    this(this) {}
+}
+
+struct S
+{
+    C c;
+    @disable this(ref typeof(this));
+}
+
+void main()
+{
+    S s1;
+    auto s2 = s1; // problem
+}


### PR DESCRIPTION
This reintroduces the changes reverted in #11947 , however, it does no longer silently change code behavior.

Spec PR: https://github.com/dlang/dlang.org/pull/2931

cc @Geod24 