### PR TITLE
Fix Issue 21570 - Deprecate __traits(isStaticArray, ...) accepts enums...

### DIFF
--- a/changelog/static_array_enum.md
+++ b/changelog/static_array_enum.md
@@ -1,0 +1,29 @@
+Deprecated result of __traits(isStaticArray, ...) for enum types
+
+`__traits(isStaticArray, <some enum>)` currently yields true for enums
+with static arrays as their base type. This is in violation of the
+spec[1] because a named enum creates a distinct type which is implicitly
+convertible to it's base type. Hence `__traits(isStaticArray, <enum>)`
+should yield `false` as done for an equivalent `is(...)` expression.
+
+The compiler will now issue a deprecation when code depends on the
+current behaviour to avoid silent code changes:
+
+```
+enum EnumArray : int[2]
+{
+    a = [ 1, 2 ],
+    b = [ 3, 4 ]
+}
+
+static assert(__traits(isStaticArray, EnumArray));
+```
+
+```
+app.d(7): Deprecation: isStaticArray currently yields `true` for enum `EnumArray`
+app.d(7):        This will change with version 2.105
+```
+
+[1] https://dlang.org/spec/enum.html#named_enums
+
+[2] https://issues.dlang.org/show_bug.cgi?id=21570

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -586,7 +586,17 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     }
     if (e.ident == Id.isStaticArray)
     {
-        return isTypeX(t => t.toBasetype().ty == Tsarray);
+        return isTypeX((t) {
+            // @@@DEPRECATED_2.095_@@@
+            // Deprecated in 2021-01, remove toBasetype() in 2.105
+            const res = t.toBasetype().ty == Tsarray;
+            if (res && t.ty != Tsarray) {
+                assert(t.ty == Tenum);
+                .deprecation(e.loc, "isStaticArray currently yields `true` for enum `%s`", t.toChars());
+                .deprecationSupplemental(e.loc, "This will change with version 2.105");
+            }
+            return res;
+        });
     }
     if (e.ident == Id.isAbstractClass)
     {

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -322,3 +322,23 @@ extern(C++, `inst`)
 mixin GetNamespaceTestTemplatedMixin!() GNTT;
 
 static assert (__traits(getCppNamespaces, GNTT.foo) == Seq!(`inst`,/*`decl`,*/ `f`));
+
+// https://issues.dlang.org/show_bug.cgi?id=21570
+enum EnumArray : int[2] {
+    a = [ 1, 2 ],
+    b = [ 3, 4 ]
+}
+
+/*
+TEST_OUTPUT:
+---
+compilable/traits.d(339): Deprecation: isStaticArray currently yields `true` for enum `EnumArray`
+compilable/traits.d(339):        This will change with version 2.105
+---
+*/
+
+// Deprecated
+static assert( __traits(isStaticArray, EnumArray));
+
+// Equal behaviour of trait and is-expression
+// static assert(!is(EnumArray == T[n], T, size_t n));


### PR DESCRIPTION
...with static array as base type.

The spec[1] states that a named enum creates a distinct type which is
implicitly convertible to it's base type. Hence `__traits(isStaticArray, <enum>)`
should yield `false` as done for an equivalent `is(...)` expression.

[1] https://dlang.org/spec/enum.html#named_enums