### PR TITLE
Fix 21569: Set RES path relative to build.d's directory

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1038,7 +1038,7 @@ void parseEnvironment()
     env.setDefault("GIT_HOME", "https://github.com/dlang");
     env.setDefault("SYSCONFDIR", "/etc");
     env.setDefault("TMP", tempDir);
-    env.setDefault("RES", dmdRepo.buildPath("src/dmd/res"));
+    env.setDefault("RES", srcDir.buildPath("dmd", "res"));
     env.setDefault("MAKE", "make");
 
     version (Windows)


### PR DESCRIPTION
This ensures the resulting path is correct even for the sources distributed alongside the official releases.

The issues is a regression introduced by #11269.