### PR TITLE
Revert "Backend: Cleanup dlist"

### DIFF
--- a/src/dmd/backend/dlist.d
+++ b/src/dmd/backend/dlist.d
@@ -26,7 +26,10 @@ import core.stdc.string;
 extern (C++):
 
 nothrow:
-@nogc:
+@nogc
+{
+
+/* **************** TYPEDEFS AND DEFINES ****************** */
 
 struct LIST
 {
@@ -50,9 +53,31 @@ alias list_free_fp = void function(void*) @nogc nothrow;
 
 enum FPNULL = cast(list_free_fp)null;
 
-private __gshared list_t list_freelist;
+/* **************** PUBLIC VARIABLES ********************* */
+
+__gshared
+{
+    int list_inited;         // != 0 if list package is initialized
+    list_t list_freelist;
+    int nlist;
+}
 
 /* **************** PUBLIC FUNCTIONS ********************* */
+
+/********************************
+ * Create link to existing list, that is, share the list with
+ * somebody else.
+ *
+ * Returns:
+ *    pointer to that list entry.
+ */
+
+list_t list_link(list_t list)
+{
+    if (list)
+        ++list.count;
+    return list;
+}
 
 /********************************
  * Returns:
@@ -76,6 +101,15 @@ inout(void)* list_ptr(inout list_t list) { return list.ptr; }
 int list_data(list_t list) { return list.data; }
 
 /********************************
+ * Append integer item to list.
+ */
+
+void list_appenddata(list_t* plist, int d)
+{
+    list_append(plist, null).data = d;
+}
+
+/********************************
  * Prepend integer item to list.
  */
 
@@ -83,6 +117,47 @@ void list_prependdata(list_t *plist,int d)
 {
     list_prepend(plist, null).data = d;
 }
+
+/**********************
+ * Initialize list package.
+ * Output:
+ *      list_inited = 1
+ */
+
+void list_init()
+{
+    if (list_inited == 0)
+    {
+        nlist = 0;
+        list_inited++;
+    }
+}
+
+/*******************
+ * Terminate list package.
+ * Output:
+ *      list_inited = 0
+ */
+
+void list_term()
+{
+    if (list_inited)
+    {
+        debug printf("Max # of lists = %d\n",nlist);
+        while (list_freelist)
+        {
+            list_t list = list_next(list_freelist);
+            list_delete(list_freelist);
+            list_freelist = list;
+            nlist--;
+        }
+        debug if (nlist)
+            printf("nlist = %d\n",nlist);
+        assert(nlist == 0);
+        list_inited = 0;
+    }
+}
+
 
 list_t list_alloc()
 {
@@ -96,10 +171,17 @@ list_t list_alloc()
     }
     else
     {
+        nlist++;
         list = list_new();
     }
     return list;
 }
+
+list_t list_alloc(const(char)* file, int line)
+{
+    return list_alloc();
+}
+
 
 list_t list_new() { return cast(list_t)malloc(LIST.sizeof); }
 void list_delete(list_t list) { free(list); }
@@ -200,6 +282,11 @@ list_t list_append(list_t* plist, void* ptr)
     return list;
 }
 
+list_t list_append_debug(list_t* plist, void* ptr, const(char)* file, int line)
+{
+    return list_append(plist, ptr);
+}
+
 /*************************
  * Prepend ptr to *plist.
  * Returns:
@@ -251,6 +338,52 @@ list_t list_nth(list_t list, int n)
     return list;
 }
 
+/***********************
+ * Returns:
+ *    last list entry in list.
+ */
+
+list_t list_last(list_t list)
+{
+    if (list)
+        while (list_next(list))
+            list = list_next(list);
+    return list;
+}
+
+/********************************
+ * Returns:
+ *    pointer to previous item in list.
+ */
+
+list_t list_prev(list_t start, list_t list)
+{
+    if (start)
+    {
+        if (start == list)
+            start = null;
+        else
+            while (list_next(start) != list)
+            {
+                start = list_next(start);
+                assert(start);
+            }
+    }
+    return start;
+}
+
+/***********************
+ * Copy a list and return it.
+ */
+
+list_t list_copy(list_t list)
+{
+    list_t c = null;
+    for (; list; list = list_next(list))
+        list_append(&c,list_ptr(list));
+    return c;
+}
+
 /************************
  * Compare two lists.
  * Returns:
@@ -269,6 +402,37 @@ int list_equal(list_t list1, list_t list2)
     return list1 == list2;
 }
 
+/************************
+ * Compare two lists using the comparison function fp.
+ * The comparison function is the same as used for qsort().
+ * Returns:
+ *    If they compare equal, return 0 else value returned by fp.
+ */
+
+int list_cmp(list_t list1, list_t list2, int function(void*, void*) @nogc nothrow fp)
+{
+    int result = 0;
+
+    while (1)
+    {
+        if (!list1)
+        {   if (list2)
+                result = -1;    /* list1 < list2        */
+            break;
+        }
+        if (!list2)
+        {   result = 1;         /* list1 > list2        */
+            break;
+        }
+        result = (*fp)(list_ptr(list1),list_ptr(list2));
+        if (result)
+            break;
+        list1 = list_next(list1);
+        list2 = list_next(list2);
+    }
+    return result;
+}
+
 /*************************
  * Search for ptr in list.
  * Returns:
@@ -281,6 +445,23 @@ list_t list_inlist(list_t list, void* ptr)
         if (l.ptr == ptr)
             return l;
     return null;
+}
+
+/*************************
+ * Concatenate two lists (l2 appended to l1).
+ * Output:
+ *      *pl1 updated to be start of concatenated list.
+ * Returns:
+ *      *pl1
+ */
+
+list_t list_cat(list_t *pl1, list_t l2)
+{
+    list_t *pl;
+    for (pl = pl1; *pl; pl = &(*pl).next)
+    { }
+    *pl = l2;
+    return *pl1;
 }
 
 /***************************************
@@ -313,6 +494,45 @@ list_t list_reverse(list_t l)
     return r;
 }
 
+
+/**********************************************
+ * Copy list of pointers into an array of pointers.
+ */
+
+void list_copyinto(list_t l, void *pa)
+{
+    void **ppa = cast(void **)pa;
+    for (; l; l = l.next)
+    {
+        *ppa = l.ptr;
+        ++ppa;
+    }
+}
+
+/**********************************************
+ * Insert item into list at nth position.
+ */
+
+list_t list_insert(list_t *pl,void *ptr,int n)
+{
+    list_t list;
+
+    while (n)
+    {
+        pl = &(*pl).next;
+        n--;
+    }
+    list = list_alloc();
+    if (list)
+    {
+        list.next = *pl;
+        *pl = list;
+        list.ptr = ptr;
+        list.count = 1;
+    }
+    return list;
+}
+
 /********************************
  * Range for Lists.
  */
@@ -332,3 +552,39 @@ struct ListRange
   private:
     list_t li;
 }
+
+}
+
+/* The following function should be nothrow @nogc, too, but on
+ * some platforms core.stdc.stdarg is not fully nothrow @nogc.
+ */
+
+/*************************
+ * Build a list out of the null-terminated argument list.
+ * Returns:
+ *      generated list
+ */
+
+list_t list_build(void *p,...)
+{
+    va_list ap;
+
+    list_t alist = null;
+    list_t *pe = &alist;
+    for (va_start(ap,p); p; p = va_arg!(void*)(ap))
+    {
+        list_t list = list_alloc();
+        if (list)
+        {
+            list.next = null;
+            list.ptr = p;
+            list.count = 1;
+            *pe = list;
+            pe = &list.next;
+        }
+    }
+    va_end(ap);
+    return alist;
+}
+
+


### PR DESCRIPTION
Reverts dlang/dmd#10926 as it removed code used by the Digital Mars C++ compiler which shares the back end with dmd.