### PR TITLE
bring enum LANG into conformance with DMC++

### DIFF
--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -78,15 +78,6 @@ else
     bool LARGECODE() { return (config.memmodel & 5) != 0; }
 }
 
-// Language for error messages
-enum LANG
-{
-    LANGenglish,
-    LANGgerman,
-    LANGfrench,
-    LANGjapanese,
-}
-
 version (SPP)
 {
     enum COMPILER = "Preprocessor";

--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -768,10 +768,11 @@ enum THRESHMAX = 0xFFFF;
 
 // Language for error messages
 enum LANG
-{       LANGenglish,
-        LANGgerman,
-        LANGfrench,
-        LANGjapanese,
+{
+    english,
+    german,
+    french,
+    japanese,
 }
 
 // Configuration that is not saved in precompiled header


### PR DESCRIPTION
LANG isn't use by DMD, but is by DMC++. This PR removes an unnecessary difference.