### PR TITLE
array.h: Default initialize Array with zeroes

### DIFF
--- a/src/dmd/root/array.h
+++ b/src/dmd/root/array.h
@@ -27,9 +27,9 @@ struct Array
   public:
     Array()
     {
-        data.ptr = SMALLARRAYCAP ? &smallarray[0] : NULL;
+        data.ptr = NULL;
         length = 0;
-        data.length = SMALLARRAYCAP;
+        data.length = 0;
     }
 
     ~Array()


### PR DESCRIPTION
The reserve() member function already handles setting the stack array on the first index assignment.  Setting the default values in this way aligns the implementation with the D version.