### PR TITLE
dmd.declaration: Fix syntax highlighting on 'this' parameter in message

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -419,7 +419,7 @@ extern (C++) abstract class Declaration : Dsymbol
                 if (scx.func == vthis.parent && (scx.flags & SCOPE.contract))
                 {
                     if (!flag)
-                        error(loc, "cannot modify parameter 'this' in contract");
+                        error(loc, "cannot modify parameter `this` in contract");
                     return Modifiable.initialization; // do not report type related errors
                 }
             }

--- a/test/fail_compilation/fail18143.d
+++ b/test/fail_compilation/fail18143.d
@@ -1,14 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18143.d(20): Error: variable `fail18143.S.a` cannot modify parameter 'this' in contract
-fail_compilation/fail18143.d(21): Error: variable `fail18143.S.a` cannot modify parameter 'this' in contract
-fail_compilation/fail18143.d(25): Error: variable `fail18143.S.a` cannot modify parameter 'this' in contract
-fail_compilation/fail18143.d(26): Error: variable `fail18143.S.a` cannot modify parameter 'this' in contract
-fail_compilation/fail18143.d(35): Error: variable `fail18143.C.a` cannot modify parameter 'this' in contract
-fail_compilation/fail18143.d(36): Error: variable `fail18143.C.a` cannot modify parameter 'this' in contract
-fail_compilation/fail18143.d(40): Error: variable `fail18143.C.a` cannot modify parameter 'this' in contract
-fail_compilation/fail18143.d(41): Error: variable `fail18143.C.a` cannot modify parameter 'this' in contract
+fail_compilation/fail18143.d(20): Error: variable `fail18143.S.a` cannot modify parameter `this` in contract
+fail_compilation/fail18143.d(21): Error: variable `fail18143.S.a` cannot modify parameter `this` in contract
+fail_compilation/fail18143.d(25): Error: variable `fail18143.S.a` cannot modify parameter `this` in contract
+fail_compilation/fail18143.d(26): Error: variable `fail18143.S.a` cannot modify parameter `this` in contract
+fail_compilation/fail18143.d(35): Error: variable `fail18143.C.a` cannot modify parameter `this` in contract
+fail_compilation/fail18143.d(36): Error: variable `fail18143.C.a` cannot modify parameter `this` in contract
+fail_compilation/fail18143.d(40): Error: variable `fail18143.C.a` cannot modify parameter `this` in contract
+fail_compilation/fail18143.d(41): Error: variable `fail18143.C.a` cannot modify parameter `this` in contract
 ---
 */
 


### PR DESCRIPTION
This one appears to have been left behind during the big push to get all messages properly highlighted.