### PR TITLE
fix Issue 21585 - add __traits(totype, string) to convert mangled typ…

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -111,6 +111,31 @@ unittest
     assert(!'\\'.isValidMangling);
 }
 
+/**********************************************
+ * Convert a string representing a type (the deco) and
+ * return its equivalent Type.
+ * Params:
+ *      deco = string containing the deco
+ * Returns:
+ *      null for failed to convert
+ *      Type for succeeded
+ */
+
+public Type decoToType(const(char)[] deco)
+{
+    //printf("decoToType(): %.*s\n", cast(int)deco.length, deco.ptr);
+    if (auto sv = Type.stringtable.lookup(deco))
+    {
+        if (sv.value)
+        {
+            Type t = cast(Type)sv.value;
+            assert(t.deco);
+            return t;
+        }
+    }
+    return null;
+}
+
 
 /***************************************** private ***************************************/
 
@@ -138,6 +163,7 @@ import dmd.root.ctfloat;
 import dmd.root.outbuffer;
 import dmd.root.aav;
 import dmd.root.string;
+import dmd.root.stringtable;
 import dmd.target;
 import dmd.tokens;
 import dmd.utf;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7737,6 +7737,7 @@ struct Id
     static Identifier* hasPostblit;
     static Identifier* hasCopyConstructor;
     static Identifier* isCopyable;
+    static Identifier* toType;
     static Identifier* allocator;
     static Identifier* basic_string;
     static Identifier* basic_istream;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -472,6 +472,7 @@ immutable Msgtable[] msgtable =
     { "hasPostblit" },
     { "hasCopyConstructor" },
     { "isCopyable" },
+    { "toType" },
 
     // For C++ mangling
     { "allocator" },

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1764,6 +1764,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             mtype.exp.ident != Id.getMember &&
             mtype.exp.ident != Id.parent &&
             mtype.exp.ident != Id.child &&
+            mtype.exp.ident != Id.toType &&
             mtype.exp.ident != Id.getOverloads &&
             mtype.exp.ident != Id.getVirtualFunctions &&
             mtype.exp.ident != Id.getVirtualMethods &&

--- a/test/compilable/fix21585.d
+++ b/test/compilable/fix21585.d
@@ -1,0 +1,24 @@
+/* TEST_OUTPUT:
+---
+i int
+d double
+Pi int*
+---
+*/
+
+pragma(msg, 1.mangleof, " ", __traits(toType, 1.mangleof));
+pragma(msg, (1.0).mangleof, " ", __traits(toType, (1.0).mangleof));
+pragma(msg, (int*).mangleof, " ", __traits(toType, (int*).mangleof));
+
+template Type(T) { alias Type = T; }
+
+Type!(__traits(toType, 1.mangleof)) j = 3;
+
+alias T = Type!(__traits(toType, 1.mangleof));
+static assert(is(T == int));
+
+__traits(toType, "i") x = 7;
+
+static assert(is(Type!(__traits(toType, 1.mangleof)) == int));
+static assert(is(Type!(__traits(toType, (1.0).mangleof)) == double));
+static assert(is(Type!(__traits(toType, (int*).mangleof)) == int*));

--- a/test/fail_compilation/fix21585.d
+++ b/test/fail_compilation/fix21585.d
@@ -1,0 +1,19 @@
+/* https://issues.dlang.org/show_bug.cgi?id=21585
+TEST_OUTPUT:
+---
+fail_compilation/fix21585.d(103): Error: expected 1 arguments for `toType` but had 0
+fail_compilation/fix21585.d(104): Error: expression expected as second argument of __traits `toType`
+fail_compilation/fix21585.d(105): Error: `string` expected for __traits(toType, string), not `(1)` of type `int`
+fail_compilation/fix21585.d(106): Error: cannot determine `__traits(toType, "hello betty")`
+---
+*/
+
+#line 100
+
+template Type(T) { alias Type = T; }
+
+alias T1 = Type!(__traits(toType));
+alias T2 = Type!(__traits(toType, int));
+alias T3 = Type!(__traits(toType, 1));
+alias T4 = Type!(__traits(toType, "hello betty"));
+


### PR DESCRIPTION
…e string to an existing type

This is quite a bit simpler than its previous incarnation https://github.com/dlang/dmd/pull/11797

But it has a problem. @andralex wrote https://github.com/dlang/dmd/pull/11797#issuecomment-700298532 that __traits can return a type. Oops, it cannot, it only returns an Expression. So, there are two options:

1. Return a string. This means to turn the string into a type requires a `mixin` which can fail if the symbols making up the type are not in scope. Besides, doing a mixin is expensive at compile time, especially when we already have the desired type.
2. Return a TypeExp. TypeExp is a hack in the compiler to treat a type as if it were an expression. But oops, that doesn't work when a type is demanded by the grammar. The solution you can see in the test case is to pass the TypeExp through a template to convert it to an actual Type that can be used wherever a Type is in the grammar. This is what I chose. We can hide this wacky thing inside a nice template and put it in Phobos.

In the future we can perhaps enhance the grammar to extend Type to include __traits(toType, string).

I'll do a spec PR if this is approved.