### PR TITLE
Print warning if not using either preview or revert DIP1000 switches

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -765,6 +765,7 @@ dmd -cov -unittest myprog.d
     static immutable reverts = [
         Feature("dip25", "noDIP25", "revert DIP25 changes https://github.com/dlang/DIPs/blob/master/DIPs/archive/DIP25.md"),
         Feature("markdown", "markdown", "disable Markdown replacements in Ddoc"),
+        Feature("dip1000", "noVsafe", "revert DIP1000 changes https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1000.md"),
     ];
 
     /// Returns all available previews

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -202,6 +202,7 @@ extern (C++) struct Param
      * before becoming default.
      */
     bool vsafe;             // use enhanced @safe checking
+    bool noVsafe;           // revert to pre-DIP1000 behavior
     bool ehnogc;            // use @nogc exception handling
     bool dtorFields;        // destruct fields of partially constructed objects
                             // https://issues.dlang.org/show_bug.cgi?id=14246

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -177,6 +177,7 @@ struct Param
     bool fixAliasThis;  // if the current scope has an alias this, check it before searching upper scopes
     bool inclusiveInContracts;   // 'in' contracts of overridden methods must be a superset of parent contract
     bool vsafe;         // use enhanced @safe checking
+    bool noVsafe;       // revert to pre-DIP1000 behavior
     bool ehnogc;        // use @nogc exception handling
     bool dtorFields;        // destruct fields of partially constructed objects
                             // https://issues.dlang.org/show_bug.cgi?id=14246

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -2579,6 +2579,20 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             continue;
         }
     }
+
+    if (!params.vsafe && !params.noVsafe)
+    {
+        deprecation(
+            Loc.initial,
+            "-preview=dip1000 will become the default then deprecated.");
+        deprecationSupplemental(
+            Loc.initial,
+            "Please use -revert=dip1000 to maintain current behavior.");
+        deprecationSupplemental(
+            Loc.initial,
+            "https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1000.md");
+    }
+
     return errors;
 }
 


### PR DESCRIPTION
If we transition to enabling DIP1000 by default (which we want to do), users will have to add `-preview=dip1000` to maintain the current behaviour, with possible code breakage for those who don't. This might be a problem in dependencies.

To gently nudge the transition, this PR prints out a deprecation warning so that users are encouraged to user either preview or revert switches explicitly. After a grace period we can deprecate `-preview=dip1000`.

Nothing changes for now except for the annoying message.
