### PR TITLE
Fix Issue 21538 - Overriding with more attributes on delegate parameter is allowed

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3895,8 +3895,29 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 default:
                     {
                         auto fdv = cast(FuncDeclaration)b.sym.vtbl[vi];
-                        Type ti = null;
 
+                        // https://issues.dlang.org/show_bug.cgi?id=21538
+                        // If `funcdecl` implements an interface function
+                        // the parameters have to be exactly the same.
+                        if (fdv.parent.isInterfaceDeclaration())
+                        {
+                            auto t1 = cast(TypeFunction)funcdecl.type;
+                            auto t2 = cast(TypeFunction)fdv.type;
+                            bool isDifferent = false;
+                            foreach(i, fparam1; t1.parameterList)
+                            {
+                                Parameter fparam2 = t2.parameterList[i];
+                                if (!fparam1.type.equals(fparam2.type))
+                                {
+                                    isDifferent = true;
+                                    break;
+                                }
+                            }
+                            if (isDifferent)
+                                break;
+                        }
+
+                        Type ti = null;
                         foundVtblMatch = true;
 
                         /* Remember which functions this overrides

--- a/test/fail_compilation/fail21538.d
+++ b/test/fail_compilation/fail21538.d
@@ -1,0 +1,26 @@
+// https://issues.dlang.org/show_bug.cgi?id=21538
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21538.d(17): Error: function `const @safe void fail21538.C.f(const(void delegate() @safe) dg)` does not override any function, did you mean to override `const @safe void fail21538.I.f(const(void delegate()) dg)`?
+---
+*/
+
+interface I
+{
+    void f(const void delegate() dg) const @safe;
+}
+
+class C : I
+{
+    // this overrride should not be legal
+    override void f(const void delegate() @safe dg) const @safe { }
+}
+
+void main() @safe
+{
+    const void delegate() @system dg = { };
+    C c = new C;
+    // c.f(dg); // error, expected
+    (cast(I) c).f(dg); // no error
+}


### PR DESCRIPTION
```d
interface I
{
    void f(const void delegate() dg) const @safe;
}

class C : I
{
    // this overrride should not be legal
    override void f(const void delegate() @safe dg) const @safe { }
}

void main() @safe
{
    const void delegate() @system dg = { };
    C c = new C;
    // c.f(dg); // error, expected
    (cast(I) c).f(dg); // no error
}
```

Because dmd allows overriding methods to be covariant with the overriden methods, you can end up with the above case which may lead to the execution of unsafe code in safe contexts (imagine that `dg` is called inside `C.f`).

The issue here is that the rules for overriding a class method should not be the same with the rules for overriding an interface method. This PR fixes this by not accepting parameter covariance in the method that implements an interface method. The parameres should be exaclty the same. Return type covariance is still permitted.

I know that this should target stable, issue a deprecation (as it is possible to break code) and add a changelog entry. I just want to see what the potential breakage is.