### PR TITLE
Fix Issue 16635 - Alias this for implicit conversion to "ref const(typeof(this))" causes dmd to segfault

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -3105,7 +3105,7 @@ Lagain:
             }
             else if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.aliasthis)
             {
-                if (att1 && e1.type == att1)
+                if (att1 && e1.type.equivalent(att1))
                     return null;
                 if (!att1 && e1.type.checkAliasThisRec())
                     att1 = e1.type;
@@ -3116,7 +3116,7 @@ Lagain:
             }
             else if (t2.ty == Tstruct && (cast(TypeStruct)t2).sym.aliasthis)
             {
-                if (att2 && e2.type == att2)
+                if (att2 && e2.type.equivalent(att2))
                     return null;
                 if (!att2 && e2.type.checkAliasThisRec())
                     att2 = e2.type;
@@ -3157,7 +3157,7 @@ Lagain:
             Expression e2b = null;
             if (ts2.sym.aliasthis)
             {
-                if (att2 && e2.type == att2)
+                if (att2 && e2.type.equivalent(att2))
                     return null;
                 if (!att2 && e2.type.checkAliasThisRec())
                     att2 = e2.type;
@@ -3167,7 +3167,7 @@ Lagain:
             }
             if (ts1.sym.aliasthis)
             {
-                if (att1 && e1.type == att1)
+                if (att1 && e1.type.equivalent(att1))
                     return null;
                 if (!att1 && e1.type.checkAliasThisRec())
                     att1 = e1.type;
@@ -3202,7 +3202,7 @@ Lagain:
     {
         if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.aliasthis)
         {
-            if (att1 && e1.type == att1)
+            if (att1 && e1.type.equivalent(att1))
                 return null;
             if (!att1 && e1.type.checkAliasThisRec())
                 att1 = e1.type;
@@ -3214,7 +3214,7 @@ Lagain:
         }
         if (t2.ty == Tstruct && (cast(TypeStruct)t2).sym.aliasthis)
         {
-            if (att2 && e2.type == att2)
+            if (att2 && e2.type.equivalent(att2))
                 return null;
             if (!att2 && e2.type.checkAliasThisRec())
                 att2 = e2.type;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1904,7 +1904,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     if (m == MATCH.nomatch)
                     {
                         AggregateDeclaration ad = isAggregate(farg.type);
-                        if (ad && ad.aliasthis && argtype != att)
+                        if (ad && ad.aliasthis && !(att && argtype.equivalent(att)))
                         {
                             if (!att && argtype.checkAliasThisRec())   // https://issues.dlang.org/show_bug.cgi?id=12537
                                 att = argtype;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1573,7 +1573,7 @@ extern (C++) abstract class Expression : ASTNode
                 }
 
                 // Forward to aliasthis.
-                if (ad.aliasthis && tb != att)
+                if (ad.aliasthis && !(att && tb.equivalent(att)))
                 {
                     if (!att && tb.checkAliasThisRec())
                         att = tb;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4507,7 +4507,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // overload of opCall, therefore it's a call
                 if (exp.e1.op != TOK.type)
                 {
-                    if (sd.aliasthis && exp.e1.type != exp.att1)
+                    if (sd.aliasthis && !(exp.att1 && exp.e1.type.equivalent(exp.att1)))
                     {
                         if (!exp.att1 && exp.e1.type.checkAliasThisRec())
                             exp.att1 = exp.e1.type;
@@ -8453,7 +8453,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 // No operator overloading member function found yet, but
                 // there might be an alias this to try.
-                if (ad.aliasthis && t1b != ae.att1)
+                if (ad.aliasthis && !(ae.att1 && t1b.equivalent(ae.att1)))
                 {
                     if (!ae.att1 && t1b.checkAliasThisRec())
                         ae.att1 = t1b;
@@ -8840,10 +8840,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     if (!e2x.implicitConvTo(t1))
                     {
                         AggregateDeclaration ad2 = isAggregate(e2x.type);
-                        if (ad2 && ad2.aliasthis && !(exp.att2 && e2x.type == exp.att2))
+                        if (ad2 && ad2.aliasthis && !(exp.att2 && e2x.type.equivalent(exp.att2)))
                         {
                             if (!exp.att2 && exp.e2.type.checkAliasThisRec())
-                            exp.att2 = exp.e2.type;
+                                exp.att2 = exp.e2.type;
                             /* Rewrite (e1 op e2) as:
                              *      (e1 op e2.aliasthis)
                              */
@@ -8927,7 +8927,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 else // https://issues.dlang.org/show_bug.cgi?id=11355
                 {
                     AggregateDeclaration ad2 = isAggregate(e2x.type);
-                    if (ad2 && ad2.aliasthis && !(exp.att2 && e2x.type == exp.att2))
+                    if (ad2 && ad2.aliasthis && !(exp.att2 && e2x.type.equivalent(exp.att2)))
                     {
                         if (!exp.att2 && exp.e2.type.checkAliasThisRec())
                             exp.att2 = exp.e2.type;
@@ -9698,7 +9698,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 /* Rewrite (e1 op e2) as:
                  *      (e1.aliasthis op e2)
                  */
-                if (exp.att1 && exp.e1.type == exp.att1)
+                if (exp.att1 && exp.e1.type.equivalent(exp.att1))
                     return null;
                 //printf("att %s e1 = %s\n", Token::toChars(e.op), e.e1.type.toChars());
                 Expression e1 = new DotIdExp(exp.loc, exp.e1, ad1.aliasthis.ident);
@@ -9718,7 +9718,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 /* Rewrite (e1 op e2) as:
                  *      (e1 op e2.aliasthis)
                  */
-                if (exp.att2 && exp.e2.type == exp.att2)
+                if (exp.att2 && exp.e2.type.equivalent(exp.att2))
                     return null;
                 //printf("att %s e2 = %s\n", Token::toChars(e.op), e.e2.type.toChars());
                 Expression e2 = new DotIdExp(exp.loc, exp.e2, ad2.aliasthis.ident);

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -209,7 +209,7 @@ private Expression checkAliasThisForLhs(AggregateDeclaration ad, Scope* sc, BinE
     /* Rewrite (e1 op e2) as:
      *      (e1.aliasthis op e2)
      */
-    if (e.att1 && e.e1.type == e.att1)
+    if (e.att1 && e.e1.type.equivalent(e.att1))
         return null;
     //printf("att %s e1 = %s\n", Token::toChars(e.op), e.e1.type.toChars());
     Expression e1 = new DotIdExp(e.loc, e.e1, ad.aliasthis.ident);
@@ -235,7 +235,7 @@ private Expression checkAliasThisForRhs(AggregateDeclaration ad, Scope* sc, BinE
     /* Rewrite (e1 op e2) as:
      *      (e1 op e2.aliasthis)
      */
-    if (e.att2 && e.e2.type == e.att2)
+    if (e.att2 && e.e2.type.equivalent(e.att2))
         return null;
     //printf("att %s e2 = %s\n", Token::toChars(e.op), e.e2.type.toChars());
     Expression e2 = new DotIdExp(e.loc, e.e2, ad.aliasthis.ident);
@@ -367,7 +367,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                         return;
                     }
                     // Didn't find it. Forward to aliasthis
-                    if (ad.aliasthis && t1b != ae.att1)
+                    if (ad.aliasthis && !(ae.att1 && t1b.equivalent(ae.att1)))
                     {
                         if (!ae.att1 && t1b.checkAliasThisRec())
                             ae.att1 = t1b;
@@ -423,7 +423,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                     }
                 }
                 // Didn't find it. Forward to aliasthis
-                if (ad.aliasthis && e.e1.type != e.att1)
+                if (ad.aliasthis && !(e.att1 && e.e1.type.equivalent(e.att1)))
                 {
                     /* Rewrite op(e1) as:
                      *      op(e1.aliasthis)
@@ -542,7 +542,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                     return;
                 }
                 // Didn't find it. Forward to aliasthis
-                if (ad.aliasthis && t1b != ae.att1)
+                if (ad.aliasthis && !(ae.att1 && t1b.equivalent(ae.att1)))
                 {
                     if (!ae.att1 && t1b.checkAliasThisRec())
                         ae.att1 = t1b;
@@ -1037,8 +1037,8 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                  * also compare the parent class's equality. Otherwise, compares
                  * the identity of parent context through void*.
                  */
-                if (e.att1 && t1 == e.att1) return;
-                if (e.att2 && t2 == e.att2) return;
+                if (e.att1 && t1.equivalent(e.att1)) return;
+                if (e.att2 && t2.equivalent(e.att2)) return;
 
                 e = cast(EqualExp)e.copy();
                 if (!e.att1) e.att1 = t1;
@@ -1209,7 +1209,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                         return;
                     }
                     // Didn't find it. Forward to aliasthis
-                    if (ad.aliasthis && t1b != ae.att1)
+                    if (ad.aliasthis && !(ae.att1 && t1b.equivalent(ae.att1)))
                     {
                         if (!ae.att1 && t1b.checkAliasThisRec())
                             ae.att1 = t1b;
@@ -1535,7 +1535,7 @@ bool inferForeachAggregate(Scope* sc, bool isForeach, ref Expression feaggr, out
             }
             if (ad.aliasthis)
             {
-                if (att == tab)         // error, circular alias this
+                if (att && tab.equivalent(att))         // error, circular alias this
                     return false;
                 if (!att && tab.checkAliasThisRec())
                     att = tab;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2545,7 +2545,7 @@ else
                 break;
 
             auto ad = isAggregate(ss.condition.type);
-            if (ad && ad.aliasthis && ss.condition.type != att)
+            if (ad && ad.aliasthis && !(att && ss.condition.type.equivalent(att)))
             {
                 if (!att && ss.condition.type.checkAliasThisRec())
                     att = ss.condition.type;

--- a/test/compilable/test16635.d
+++ b/test/compilable/test16635.d
@@ -1,0 +1,56 @@
+// https://issues.dlang.org/show_bug.cgi?id=16635
+
+struct A
+{
+    alias get this;
+
+    const(A) get() const
+    {
+        return A();
+    }
+}
+
+static assert(!__traits(compiles, A() + A()));
+
+// Original test (covers another path)
+
+struct Vector2
+{
+    float x;
+    float y;
+
+    alias byRef this;
+
+    ref const(Vector2) byRef() const
+    {
+        static Vector2 v;
+        return v;
+    }
+
+    Vector2 opBinary(string op : "+")(ref const(Vector2) a) const
+    {
+        return Vector2(x + a.x, y + a.y);
+    }
+}
+
+void test16635_1()
+{
+    Vector2 a = Vector2(1, 2);
+    Vector2 b = Vector2(3, 4);
+
+    // this line causes application to run infinitely
+    // Already fixed. It was issue 16621
+    Vector2 c = a + b;
+
+    // OK <- this line seg faults without the above line
+    Vector2 d = a + Vector2(5, 6);
+}
+
+void test16635_2()
+{
+    Vector2 a = Vector2(1, 2);
+    Vector2 b = Vector2(3, 4);
+
+    // just this line alone
+    Vector2 d = a + Vector2(5, 6);
+}


### PR DESCRIPTION
Types `att1` and `att2` are used to detect a recursive `alias this`, they are compared to the next `alias this` type to stop the recursion, however, it's done using a pointer comparison that it will fail if types are equal but have different type qualifiers.

Fix: Do not take into account type qualifiers.