### PR TITLE
Replace approxEqual with isClose

### DIFF
--- a/test/compilable/ctfe_math.d
+++ b/test/compilable/ctfe_math.d
@@ -4,10 +4,10 @@ import std.math;
 
 void main()
 {
-    static assert(approxEqual(sin(2.0L), 0.9092974268L));
-    static assert(approxEqual(cos(2.0), -0.4161468365));
-    static assert(approxEqual(tan(2.0f), -2.185040f, 1e-5));
-    static assert(approxEqual(sqrt(2.0L), 1.414213562L));
+    static assert(isClose(sin(2.0L), 0.9092974268L));
+    static assert(isClose(cos(2.0), -0.4161468365));
+    static assert(isClose(tan(2.0f), -2.185040f, 1e-5));
+    static assert(isClose(sqrt(2.0L), 1.4142135623L));
     static assert(fabs(-2.0) == 2.0);
     static assert(ldexp(2.5f, 3) == 20.0f);
 

--- a/test/runnable/builtin.d
+++ b/test/runnable/builtin.d
@@ -19,13 +19,13 @@ void test1()
     auto f = 6.8L;
     writefln("%a", sin(f));
     assert(sin(f) == sin(6.8L));
-    static assert(approxEqual(sin(6.8L), 0x1.f9f8d9aea10fdf1cp-2));
+    static assert(isClose(sin(6.8L), 0x1.f9f8d9aea10fdf1cp-2));
 
     writefln("%a", cos(6.8L));
     f = 6.8L;
     writefln("%a", cos(f));
     assert(cos(f) == cos(6.8L));
-    static assert(approxEqual(cos(6.8L), 0x1.bd21aaf88dcfa13ap-1));
+    static assert(isClose(cos(6.8L), 0x1.bd21aaf88dcfa13ap-1));
 
     writefln("%a", tan(6.8L));
     f = 6.8L;
@@ -34,7 +34,7 @@ void test1()
     { }
     else
         assert(tan(f) == tan(6.8L));
-    static assert(approxEqual(tan(6.8L), 0x1.22fd752af75cd08cp-1));
+    static assert(isClose(tan(6.8L), 0x1.22fd752af75cd08cp-1));
 }
 
 /*******************************************/


### PR DESCRIPTION
`approxEqual` shall be deprecated soon - see [changelog for release 2.091](https://dlang.org/changelog/2.091.0.html#isClose).