### PR TITLE
Fix 21590 - assignment inside assert accepted for -checkaction=context

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1787,6 +1787,11 @@ extern (C++) abstract class Expression : ASTNode
         inout(ClassReferenceExp) isClassReferenceExp() { return op == TOK.classReference ? cast(typeof(return))this : null; }
     }
 
+    inout(BinAssignExp) isBinAssignExp() pure inout nothrow @nogc
+    {
+        return null;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -4608,6 +4613,11 @@ extern (C++) class BinAssignExp : BinExp
     {
         // should check e1.checkModifiable() ?
         return toLvalue(sc, this);
+    }
+
+    override inout(BinAssignExp) isBinAssignExp() pure inout nothrow @nogc
+    {
+        return this;
     }
 
     override void accept(Visitor v)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -218,6 +218,7 @@ public:
     FuncInitExp* isFuncInitExp();
     PrettyFuncInitExp* isPrettyFuncInitExp();
     ClassReferenceExp* isClassReferenceExp();
+    virtual BinAssignExp* isBinAssignExp();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -701,6 +702,7 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *ex);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
+    BinAssignExp* isBinAssignExp();
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -593,6 +593,7 @@ class ModuleInitExp;
 class FuncInitExp;
 class PrettyFuncInitExp;
 class ClassReferenceExp;
+class BinAssignExp;
 class TypeInfoClassDeclaration;
 struct ObjcClassDeclaration;
 class TypeFunction;
@@ -693,7 +694,6 @@ class UnaExp;
 class BinExp;
 class SymbolExp;
 class CmpExp;
-class BinAssignExp;
 class StaticIfCondition;
 class DVCondition;
 class ExpInitializer;
@@ -1129,6 +1129,7 @@ public:
     FuncInitExp* isFuncInitExp();
     PrettyFuncInitExp* isPrettyFuncInitExp();
     ClassReferenceExp* isClassReferenceExp();
+    virtual BinAssignExp* isBinAssignExp();
     void accept(Visitor* v);
 };
 
@@ -4056,6 +4057,7 @@ public:
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* ex);
     Expression* modifiableLvalue(Scope* sc, Expression* e);
+    BinAssignExp* isBinAssignExp();
     void accept(Visitor* v);
 };
 

--- a/test/fail_compilation/dassert.d
+++ b/test/fail_compilation/dassert.d
@@ -2,11 +2,34 @@
 REQUIRED_ARGS: -checkaction=context
 TEST_OUTPUT:
 ---
-fail_compilation/dassert.d(11): Error: expression `tuple(0, 0)` of type `(int, int)` does not have a boolean value
+fail_compilation/dassert.d(14): Error: expression `tuple(0, 0)` of type `(int, int)` does not have a boolean value
+fail_compilation/dassert.d(21): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/dassert.d(29): Error: assignment cannot be used as a condition, perhaps `==` was meant?
 ---
 */
+
 struct Baguette { int bread, floor; }
 void main ()
 {
     assert(Baguette.init.tupleof);
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=21590
+void issue21590()
+{
+   int a, b = 1;
+   assert (a = b);
+
+   static ref int get()
+   {
+	   static int i;
+	   return i;
+   }
+
+	assert(get() = 1);
+
+	// No errors for binary assignments (regardless of -checkaction=context)
+	int[] arr;
+	assert(arr ~= 1);
+	assert(a += b);
 }

--- a/test/runnable/testassert.d
+++ b/test/runnable/testassert.d
@@ -221,6 +221,22 @@ void testUnaryFormat()
     assert(getMessage(assert(--(++zero))) == "0 != true");
 }
 
+void testAssignments()
+{
+    int a = 1;
+    int b = 2;
+    assert(getMessage(assert(a -= --b)) == "0 != true");
+
+    static ref int c()
+    {
+        static int counter;
+        counter++;
+        return counter;
+    }
+
+    assert(getMessage(assert(--c())) == "0 != true");
+}
+
 void main()
 {
     test8765();
@@ -229,4 +245,5 @@ void main()
     test20375();
     testMixinExpression();
     testUnaryFormat();
+    testAssignments();
 }


### PR DESCRIPTION
The rewrite introduced a temporary which hid the assignment inside of
`assert(...)` and hence prevented the error.

The fix is to omit the additional temporary for `(Bin)AssignExp` and use
the assigned variable directly. The temporary is unecessary anyways
and the following semantic analysis will raise an appropriate error.