### PR TITLE
[stable] Fix Issue 21591 - missed backrefs in mangled names wrt. unmerged function types

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -179,10 +179,12 @@ public:
     AssocArray!(Type, size_t) types;        // Type => (offset+1) in buf
     AssocArray!(Identifier, size_t) idents; // Identifier => (offset+1) in buf
     OutBuffer* buf;
+    Type rootType;
 
-    extern (D) this(OutBuffer* buf)
+    extern (D) this(OutBuffer* buf, Type rootType = null)
     {
         this.buf = buf;
+        this.rootType = rootType;
     }
 
     /**
@@ -228,9 +230,29 @@ public:
     */
     bool backrefType(Type t)
     {
-        if (!t.isTypeBasic())
-            return backrefImpl(types, t);
-        return false;
+        if (t.isTypeBasic())
+            return false;
+
+        /**
+         * https://issues.dlang.org/show_bug.cgi?id=21591
+         *
+         * Special case for unmerged TypeFunctions: use the generic merged
+         * function type as backref cache key to avoid missed backrefs.
+         *
+         * Merging is based on mangling, so we need to avoid an infinite
+         * recursion by excluding the case where `t` is the root type passed to
+         * `mangleToBuffer()`.
+         */
+        if (t != rootType)
+        {
+            if (t.ty == Tfunction || t.ty == Tdelegate ||
+                (t.ty == Tpointer && t.nextOf().ty == Tfunction))
+            {
+                t = t.merge2();
+            }
+        }
+
+        return backrefImpl(types, t);
     }
 
     /**
@@ -1178,7 +1200,7 @@ extern (C++) void mangleToBuffer(Type t, OutBuffer* buf)
         buf.writestring(t.deco);
     else
     {
-        scope Mangler v = new Mangler(buf);
+        scope Mangler v = new Mangler(buf, t);
         v.visitWithMask(t, 0);
     }
 }

--- a/test/compilable/test21591.d
+++ b/test/compilable/test21591.d
@@ -1,0 +1,46 @@
+// https://issues.dlang.org/show_bug.cgi?id=21591
+
+alias F = void function();
+
+void fn1(void function(), void function());
+void fr1(F, F);
+static assert(fn1.mangleof == "_D9test215913fn1FPFZvQeZv");
+static assert(fr1.mangleof == "_D9test215913fr1FPFZvQeZv");
+
+void fn2(void function()*, void function()*);
+void fr2(F*, F*);
+static assert(fn2.mangleof == "_D9test215913fn2FPPFZvQfZv");
+static assert(fr2.mangleof == "_D9test215913fr2FPPFZvQfZv");
+
+void function() fn3(void function()**, void function()*);
+F fr3(F**, F*);
+static assert(fn3.mangleof == "_D9test215913fn3FPPPFZvQfZQh");
+static assert(fr3.mangleof == "_D9test215913fr3FPPPFZvQfZQh");
+
+void function()** fn4(ref void function(), ref void function()*);
+F** fr4(ref F, ref F*);
+static assert(fn4.mangleof == "_D9test215913fn4FKPFZvKPQgZPQf");
+static assert(fr4.mangleof == "_D9test215913fr4FKPFZvKPQgZPQf");
+
+
+alias D = void delegate();
+
+void dg1(void delegate(), void delegate());
+void dr1(D, D);
+static assert(dg1.mangleof == "_D9test215913dg1FDFZvQeZv");
+static assert(dr1.mangleof == "_D9test215913dr1FDFZvQeZv");
+
+void dg2(void delegate()*, void delegate()*);
+void dr2(D*, D*);
+static assert(dg2.mangleof == "_D9test215913dg2FPDFZvQfZv");
+static assert(dr2.mangleof == "_D9test215913dr2FPDFZvQfZv");
+
+void delegate() dg3(void delegate()**, void delegate()*);
+D dr3(D**, D*);
+static assert(dg3.mangleof == "_D9test215913dg3FPPDFZvQfZQh");
+static assert(dr3.mangleof == "_D9test215913dr3FPPDFZvQfZQh");
+
+void delegate()** dg4(ref void delegate(), ref void delegate()*);
+D** dr4(ref D, ref D*);
+static assert(dg4.mangleof == "_D9test215913dg4FKDFZvKPQgZPQf");
+static assert(dr4.mangleof == "_D9test215913dr4FKDFZvKPQgZPQf");


### PR DESCRIPTION
`TypeFunctions` are apparently special and not merged (see https://github.com/dlang/dmd/pull/1102), so make sure to use the generic merged function type as backref cache key.

Unfortunately, this requires special care to prevent an infinite recursion, as merging is based on mangling.