### PR TITLE
Fix Issue 21593 - Only update file time if file to be written already exists

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -486,8 +486,8 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         if (!Module.rootModule)
             Module.rootModule = m;
         m.importedFrom = m; // m.isRoot() == true
-        if (!params.oneobj || modi == 0 || m.isDocFile)
-            m.deleteObjFile();
+//        if (!params.oneobj || modi == 0 || m.isDocFile)
+//            m.deleteObjFile();
 
         m.parse();
         if (m.isHdrFile)

--- a/src/dmd/root/file.d
+++ b/src/dmd/root/file.d
@@ -261,4 +261,116 @@ nothrow:
             assert(0);
         }
     }
+
+    /***************************************************
+     * Update file
+     *
+     * If the file exists and is identical to what is to be written,
+     * merely update the timestamp on the file.
+     * Otherwise, write the file.
+     *
+     * The idea is writes are much slower than reads, and build systems
+     * often wind up generating identical files.
+     * Params:
+     *  name = name of file to update
+     *  data = updated contents of file
+     * Returns:
+     *  `true` on success
+     */
+    extern (D) static bool update(const(char)* namez, const void[] data)
+    {
+        enum log = false;
+        if (log) printf("update %s\n", namez);
+        version (Windows)
+        {
+            const nameStr = namez.toDString();
+
+            import core.sys.windows.windows;
+
+            WIN32_FILE_ATTRIBUTE_DATA fad = void;
+            // Doesn't exist, not a regular file, different size
+            if (nameStr.extendedPathThen!(p => GetFileAttributesExW(p.ptr, GET_FILEEX_INFO_LEVELS.GetFileExInfoStandard, &fad)) == 0 ||
+                fad.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY ||
+                ((cast(ulong) fad.nFileSizeHigh << 32) | fad.nFileSizeLow) != data.length)
+            {
+                return write(namez, data);               // write new file
+            }
+        }
+        else version (Posix)
+        {
+            import core.sys.posix.sys.stat;
+
+            stat_t statbuf = void;
+            if (stat(namez, &statbuf) != 0 ||            // doesn't exist
+                (statbuf.st_mode & S_IFMT) != S_IFREG || // not a regular file
+                statbuf.st_size != data.length)          // different size
+            {
+                if (log) printf("not exist or diff size %d %d %d\n",
+                    stat(namez, &statbuf) != 0,
+                    (statbuf.st_mode & S_IFMT) != S_IFREG,
+                     statbuf.st_size != data.length);
+                return write(namez, data);               // write new file
+            }
+        }
+        else
+            static assert(0);
+        if (log) printf("same size\n");
+
+        /* The file already exists, and is the same size.
+         * Read it in, and compare for equality.
+         * For larger files, this could be faster by comparing the file
+         * block by block and quitting on first difference.
+         */
+        ReadResult r = read(namez);
+        if (!r.success ||
+            r.buffer.data[] != data[])
+            return write(namez, data); // contents not same, so write new file
+        if (log) printf("same contents\n");
+
+        /* Contents are identical, so set timestamp of existing file to current time
+         */
+        version (Windows)
+        {
+            FILETIME ft = void;
+            SYSTEMTIME st = void;
+            GetSystemTime(&st);
+            SystemTimeToFileTime(&st, &ft);
+
+            // get handle to file
+            HANDLE h = nameStr.extendedPathThen!(p => CreateFile(p.ptr,
+                FILE_WRITE_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                null, OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL, null));
+            if (h == INVALID_HANDLE_VALUE)
+                return false;
+
+            const f = SetFileTime(h, null, null, &ft); // set last write time
+
+            if (!CloseHandle(h))
+                return false;
+
+            return f != 0;
+        }
+        else version (Posix)
+        {
+            import core.sys.posix.utime;
+
+            return utime(namez, null) == 0;
+        }
+        else
+            static assert(0);
+    }
+
+    ///ditto
+    extern(D) static bool update(const(char)[] name, const void[] data)
+    {
+        return name.toCStringThen!((fname) => update(fname.ptr, data));
+    }
+
+    /// ditto
+    extern (C++) static bool update(const(char)* name, const(void)* data, size_t size)
+    {
+        return update(name, data[0 .. size]);
+    }
+
 }

--- a/src/dmd/utils.d
+++ b/src/dmd/utils.d
@@ -151,7 +151,7 @@ FileBuffer readFile(Loc loc, const(char)[] filename)
 extern (D) void writeFile(Loc loc, const(char)[] filename, const void[] data)
 {
     ensurePathToNameExists(Loc.initial, filename);
-    if (!File.write(filename, data))
+    if (!File.update(filename, data))
     {
         error(loc, "Error writing file '%*.s'", cast(int) filename.length, filename.ptr);
         fatal();


### PR DESCRIPTION
This is a suggestion from Andrei.

Because file writes are so much slower than reads, and because of weak dependency management in build systems, the compiler will often generate the same files again and again. This changes file writes to first see if the file already exists and is identical. If so, it just updates the last written time on that file instead of writing a new one.

We discussed whether to "touch" the file or not, and decided if it wasn't touched, it would likely break many build systems.