### PR TITLE
Fix 21471,21598 - Always create a temporary for calls with checkactio…

### DIFF
--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -47,7 +47,7 @@ struct Symbol;          // back end symbol
 
 void expandTuples(Expressions *exps);
 bool isTrivialExp(Expression *e);
-bool hasSideEffect(Expression *e);
+bool hasSideEffect(Expression *e, bool assumeImpureCalls = false);
 bool canThrow(Expression *e, FuncDeclaration *func, bool mustNotThrow);
 
 typedef unsigned char OwnedBy;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6086,7 +6086,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 op = op.expressionSemantic(sc);
                 op = resolveProperties(sc, op);
-                if (op.hasSideEffect)
+
+                // Create a temporary for expressions with side effects
+                // Defensively assume that function calls may have side effects even
+                // though it's not detected by hasSideEffect (e.g. `debug puts("Hello")` )
+                // Rewriting CallExp's also avoids some issues with the inliner/debug generation
+                if (op.hasSideEffect(true))
                 {
                     const stc = op.isLvalue() ? STC.ref_ : 0;
                     auto tmp = copyToTemp(stc, "__assertOp", op);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5850,7 +5850,7 @@ extern void semantic3(Dsymbol* dsym, Scope* sc);
 
 extern bool isTrivialExp(Expression* e);
 
-extern bool hasSideEffect(Expression* e);
+extern bool hasSideEffect(Expression* e, bool assumeImpureCalls = false);
 
 enum class STMT : uint8_t
 {

--- a/test/runnable/testassert.d
+++ b/test/runnable/testassert.d
@@ -170,6 +170,36 @@ void test20375() @safe
     RefCounted.postblits = 0;
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=21471
+void test21471()
+{
+    {
+        static struct S
+        {
+            S get()() const { return this; }
+        }
+
+        static auto f(S s) { return s; }
+
+        auto s = S();
+        assert(f(s.get) == s);
+    }
+    {
+        pragma(inline, true)
+        real exp(real x) pure nothrow
+        {
+            return x;
+        }
+
+        bool isClose(int lhs, real rhs) pure nothrow
+        {
+            return false;
+        }
+        auto c = 0;
+        assert(!isClose(c, exp(1)));
+    }
+}
+
 string getMessage(T)(lazy T expr) @trusted
 {
     try
@@ -227,6 +257,7 @@ void main()
     test9255();
     test20114();
     test20375();
+    test21471();
     testMixinExpression();
     testUnaryFormat();
 }

--- a/test/runnable/testassert_debug.d
+++ b/test/runnable/testassert_debug.d
@@ -1,0 +1,26 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=21598
+
+REQUIRED_ARGS: -checkaction=context -debug
+PERMUTE_ARGS:
+*/
+
+void main()
+{
+	bool caught;
+	try
+		assert(foo(1));
+	catch (Throwable)
+		caught = true;
+
+	assert(caught);
+	assert(counter == 1);
+}
+
+__gshared int counter;
+
+int foo(int i) pure nothrow
+{
+	debug counter++;
+	return i - 1;
+}


### PR DESCRIPTION
…n=context

Using a temporary for every expression that calls another function
avoids problems with the inliner and avoids an unexpected secondary
function call for `pure` functions (which might have side effects
in `debug` blocks).

See [bugzilla](https://issues.dlang.org/show_bug.cgi?id=21471) for a
more complete writeup of the inliner issue.