### PR TITLE
Fix Issue 21525 - Spurious copying into allocated memory escapes a re…

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1000,7 +1000,6 @@ bool checkThrowEscape(Scope* sc, Expression e, bool gag)
  */
 bool checkNewEscape(Scope* sc, Expression e, bool gag)
 {
-    //printf("[%s] checkNewEscape, e = %s\n", e.loc.toChars(), e.toChars());
     enum log = false;
     if (log) printf("[%s] checkNewEscape, e: `%s`\n", e.loc.toChars(), e.toChars());
     EscapeByResults er;
@@ -1110,6 +1109,26 @@ bool checkNewEscape(Scope* sc, Expression e, bool gag)
         // Only look for errors if in module listed on command line
         if (p == sc.func)
         {
+
+            // https://issues.dlang.org/show_bug.cgi?id=21525
+            if (sc.func.fes && v.storage_class & STC.parameter)
+            {
+                /* If we are inside a foreach body, the ref parameter
+                 * to the foreach generated delegate should still be
+                 * able to escape the foreach scope
+                 */
+                bool isForeachParam;
+                foreach(ref param; *(sc.func.parameters))
+                {
+                    if (param == v)
+                    {
+                        isForeachParam = true;
+                        break;
+                    }
+                }
+                if (isForeachParam)
+                    continue;
+            }
             //printf("escaping reference to local ref variable %s\n", v.toChars());
             //printf("storage class = x%llx\n", v.storage_class);
             escapingRef(v, emitError);

--- a/test/compilable/test21525.d
+++ b/test/compilable/test21525.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=21525
+
+void main()
+{
+    int[string] aa;
+    aa["name"] = 5;
+
+    int*[] pvalues;
+    foreach (name, ref value; aa)
+    {
+        // Deprecation: copying `&value` into allocated memory escapes
+        // a reference to parameter variable `value`
+        pvalues ~= &value;
+    }
+}


### PR DESCRIPTION
…ference to parameter variable with associative array iteration.

A foreach loop has its body converted to a delegate that is called on each of the foreach elements. If we have a ref parameter then it would seem like we can copy the parameter to heap allocated memory. However, the parameter to the delegate is not actually a parameter, therefore the check is bypassed in that case.