### PR TITLE
fix DMC breakage from PR 10200

### DIFF
--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -4007,11 +4007,7 @@ static if (0)
 }
 
     reg_t reg1 = NOREG, reg2 = NOREG;
-
-    if (config.exe == EX_WIN64) // Win64 is currently broken
-        retregs = regmask(e.Ety, tym1);
-    else
-        retregs = allocretregs(e.Ety, e.ET, tym1, &reg1, &reg2);
+    retregs = allocretregs(e.Ety, e.ET, tym1, &reg1, &reg2);
 
     assert(retregs || !*pretregs);
 


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/10200 broke DMC's use of the backend, specifically for 16 bit code generation and complex numbers for 32 bit code. This went undetected because D's test suite doesn't test 16 bit code gen nor builtin complex types. This fixes it by, for those cases, using the older method.