### PR TITLE
Make ternary "__cond" flag 'const' for consistency of the final AST

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -6710,7 +6710,7 @@ extern (C++) final class CondExp : BinExp
                     {
                         if (!vcond)
                         {
-                            vcond = copyToTemp(STC.volatile_, "__cond", ce.econd);
+                            vcond = copyToTemp(STC.volatile_ | STC.const_, "__cond", ce.econd);
                             vcond.dsymbolSemantic(sc);
 
                             Expression de = new DeclarationExp(ce.econd.loc, vcond);


### PR DESCRIPTION
This helps the optimizer to reduce both of the following cases to the same result (dead branch removed).

```
struct A { int x; this(int a){} }
struct B { int x; this(int a){} ~this(){} }

void main()
{
    A a = true ? A(1) : A(2);    // optimized to  ->  'A a = A(1);'
    B b = true ? B(1) : B(2);    // not here
}
```

Of course backend is able to remove the dead branch but it doesn't get rid of the volatile var (it inserts an useless extra mov instruction), this looks like a defect/bug.
Also there is currently an assertion when generating debug info because of the previous statement, see #10630.