### PR TITLE
Fix 21508: Do not look inside imports that shadow a symbol

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -407,14 +407,6 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
         t = s.getType();
         if (t)
             break;
-        // If the symbol is an import, try looking inside the import
-        if (Import si = s.isImport())
-        {
-            s = si.search(loc, s.ident);
-            if (s && s != si)
-                continue;
-            s = si;
-        }
         ps = s;
         return;
     }

--- a/test/fail_compilation/fail21508.d
+++ b/test/fail_compilation/fail21508.d
@@ -1,0 +1,18 @@
+/*
+REQUIRED_ARGS: -Ifail_compilation/imports/
+EXTRA_FILES: imports/import21508.d
+TEST_OUTPUT:
+---
+fail_compilation/fail21508.d(17): Error: import `fail21508.import21508` is used as a type
+---
+*/
+import import21508;
+
+// import21508 is a private class, code should not compile
+// The compiler used to "helpfully" look inside the import,
+// bypassing the shadowing that this introduces.
+
+void main ()
+{
+    auto c = new import21508();
+}

--- a/test/fail_compilation/fail21508_2.d
+++ b/test/fail_compilation/fail21508_2.d
@@ -1,0 +1,11 @@
+/*
+REQUIRED_ARGS: -Ifail_compilation/imports/
+EXTRA_FILES: imports/import21508.d
+TEST_OUTPUT:
+---
+fail_compilation/fail21508_2.d(11): Error: import `fail21508_2.import21508` is used as a type
+---
+*/
+import import21508;
+
+class Other : import21508 { }

--- a/test/fail_compilation/imports/import21508.d
+++ b/test/fail_compilation/imports/import21508.d
@@ -1,0 +1,2 @@
+module import21508;
+private class import21508 {}

--- a/test/runnable/imports/Other.d
+++ b/test/runnable/imports/Other.d
@@ -2,13 +2,12 @@ module imports.Other; // makes no difference if removed
 import Same;
 import core.stdc.stdio;
 
-class Other : Same // segfault
-// class Other : Same.Same //***UGLY ALERT*** but doesn't segfault
+class Other : Same.Same
 {
-this()
-{
-printf("other\n");
-}
+    this()
+    {
+        printf("other\n");
+    }
 }
 
 int main()


### PR DESCRIPTION
There was a special case to look inside an import instead of showing
the conflict. This isn't consistent with the way imports appear to
the user (e.g. `class std {}` will conflict with `import std.stdio`),
so we just remove the special case and that solves the issue.