### PR TITLE
refactor allocretregs to use out

### DIFF
--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -4006,8 +4006,8 @@ static if (0)
     }
 }
 
-    reg_t reg1 = NOREG, reg2 = NOREG;
-    retregs = allocretregs(e.Ety, e.ET, tym1, &reg1, &reg2);
+    reg_t reg1, reg2;
+    retregs = allocretregs(e.Ety, e.ET, tym1, reg1, reg2);
 
     assert(retregs || !*pretregs);
 

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -558,7 +558,7 @@ void searchfixlist(Symbol *s) {}
 void outfixlist();
 void code_hydrate(code **pc);
 void code_dehydrate(code **pc);
-regm_t allocretregs(tym_t ty, type *t, tym_t tyf, reg_t *reg1, reg_t *reg2);
+regm_t allocretregs(tym_t ty, type* t, tym_t tyf, out reg_t reg1, out reg_t reg2);
 
 extern __gshared
 {


### PR DESCRIPTION
1. instead of faking `out`, use `out`
2. replace loop with nested function
3. immutable arrays should be immutable
4. simplified the flow