### PR TITLE
dmd.dsymbolsem: Assign return value of Scope.createGlobal to 'sc'

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1208,7 +1208,7 @@ extern (C++) final class Module : Package
             s.importAll(sc);
         }
         sc = sc.pop();
-        sc.pop(); // 2 pops because Scope::createGlobal() created 2
+        sc.pop(); // 2 pops because Scope.createGlobal() created 2
     }
 
     /**********************************

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2278,7 +2278,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         Scope* sc = m._scope; // see if already got one from importAll()
         if (!sc)
         {
-            Scope.createGlobal(m); // create root scope
+            sc = Scope.createGlobal(m); // create root scope
         }
 
         //printf("Module = %p, linkage = %d\n", sc.scopesym, sc.linkage);
@@ -2297,7 +2297,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!m._scope)
         {
             sc = sc.pop();
-            sc.pop(); // 2 pops because Scope::createGlobal() created 2
+            sc.pop(); // 2 pops because Scope.createGlobal() created 2
         }
         m.semanticRun = PASS.semanticdone;
         //printf("-Module::semantic(this = %p, '%s'): parent = %p\n", this, toChars(), parent);

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -298,6 +298,32 @@ void test_semantic()
 
 /**********************************/
 
+void test_skip_importall()
+{
+    /* Similar to test_semantic(), but importAll step is skipped.  */
+    const char *buf =
+        "module rootobject;\n"
+        "class RootObject : Object { }";
+
+    FileBuffer *srcBuffer = FileBuffer::create(); // free'd in Module::parse()
+    srcBuffer->data = DArray<unsigned char>(strlen(buf), (unsigned char *)mem.xstrdup(buf));
+
+    Module *m = Module::create("rootobject.d", Identifier::idPool("rootobject"), 0, 0);
+
+    unsigned errors = global.startGagging();
+
+    m->srcBuffer = srcBuffer;
+    m->parse();
+    m->importedFrom = m;
+    dsymbolSemantic(m, NULL);
+    semantic2(m, NULL);
+    semantic3(m, NULL);
+
+    assert(!global.endGagging(errors));
+}
+
+/**********************************/
+
 void test_expression()
 {
     Loc loc;
@@ -519,6 +545,7 @@ int main(int argc, char **argv)
     test_compiler_globals();
     test_visitors();
     test_semantic();
+    test_skip_importall();
     test_expression();
     test_target();
     test_emplace();


### PR DESCRIPTION
Looks like a logic bug, if `sc` isn't set, then a segfault will occur if not during semantic pass, then when `sc.pop()` is called.