### PR TITLE
allocretregs: remove dead code, add const

### DIFF
--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -558,7 +558,7 @@ void searchfixlist(Symbol *s) {}
 void outfixlist();
 void code_hydrate(code **pc);
 void code_dehydrate(code **pc);
-regm_t allocretregs(tym_t ty, type* t, tym_t tyf, out reg_t reg1, out reg_t reg2);
+regm_t allocretregs(const tym_t ty, type* t, const tym_t tyf, out reg_t reg1, out reg_t reg2);
 
 extern __gshared
 {


### PR DESCRIPTION
1. The windows code is dead because it isn't Posix
2. add const where we can
3. refactor out redundant uses of tybasic
4. replace `!I64` with `I32`