### PR TITLE
Cirrus CI Mac: Exploit all 12 newly available CPU cores

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,6 +73,8 @@ task:
     OS_NAME: darwin
     # override Cirrus default OS (`darwin`)
     OS: osx
+    # 12 CPU cores and 24 GB of memory are available
+    N: 12
     matrix:
       - TASK_NAME_SUFFIX: DMD (latest)
       - TASK_NAME_SUFFIX: DMD (coverage)


### PR DESCRIPTION
They recently tripled (!) the available CPU cores: https://medium.com/cirruslabs/new-macos-task-execution-architecture-for-cirrus-ci-604250627c94