### PR TITLE
fix Issue 21614 - AssertError@src/dmd/semantic3.d(812): Assertion failure

### DIFF
--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -352,6 +352,16 @@ private extern(C++) final class Semantic2Visitor : Visitor
     {
         if (fd.semanticRun >= PASS.semantic2done)
             return;
+
+        if (fd.semanticRun < PASS.semanticdone && !fd.errors)
+        {
+            /* https://issues.dlang.org/show_bug.cgi?id=21614
+             *
+             * Template instances may import modules that have not
+             * finished semantic1.
+             */
+            fd.dsymbolSemantic(sc);
+        }
         assert(fd.semanticRun <= PASS.semantic2);
         fd.semanticRun = PASS.semantic2;
 

--- a/test/compilable/imports/issue21614a.d
+++ b/test/compilable/imports/issue21614a.d
@@ -1,0 +1,22 @@
+module imports.issue21614a;
+
+struct FormatSpec(Char)
+{
+    import imports.issue21614a;
+}
+
+template Tuple(Specs...)
+{
+    struct Tuple
+    {
+        alias spec = FormatSpec!char();
+        this(Specs)
+        {
+        }
+    }
+}
+
+auto findRoot(T)(T)
+{
+    return Tuple!(T)();
+}

--- a/test/compilable/issue21614.d
+++ b/test/compilable/issue21614.d
@@ -1,0 +1,10 @@
+// EXTRA_FILES: imports/issue21614a.d
+// REQUIRED_ARGS: -i
+
+// https://issues.dlang.org/show_bug.cgi?id=21614
+
+void logmdigammaInverse(real y)
+{
+    import imports.issue21614a;
+    findRoot(y);
+}


### PR DESCRIPTION
Template instances may import modules that have not finished semantic1, and in the case of cyclic imports, semantic2 could be ran on a function symbol before semantic1 has begun, which can lead to auto functions given the wrong return type.