### PR TITLE
Fix Issue 21451 - __traits(compiles, ...) is wrong on overloaded temp…

### DIFF
--- a/test/compilable/test21451.d
+++ b/test/compilable/test21451.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=21451
+
+void f(int a : 1)() { }
+void f(int b : 2)(int x) { }
+
+void main()
+{
+    static assert( __traits(compiles, f!1 ));
+    static assert( __traits(compiles, f!1() ));
+    static assert( __traits(compiles, f!2(2) ));
+    static assert(!__traits(compiles, f!(1, 2) ));
+    static assert(!__traits(compiles, f!() )); // ???
+    static assert(!__traits(compiles, { f!(); }));
+}


### PR DESCRIPTION
…lates instantiated with empty parens

I am not sure this is the right fix. Essentially, what is going on here is that `ScopeExp`, as far as I could tell, is a placeholder for template instances (and others, but not relevant for this PR). For template instances, if they require IFTI, the ScopeExp visiting method simply returns the ScopeExp (after it sets a few additional fields). This is fine because in most of the cases the caller takes care of what the template instance represents, however, in the case of traits(compiles) no additional checks are performed. Thus the code in the bug report simply compiles.

My fix checks if we are in traits(compiles) scope and if that is so it simply creates a CallExp wrapper around the template instance. This seems to fix the bug report and also passes the test suite on my machine, but it might brake compilation for
some other cases.

Any ideas of a better fix? 