### PR TITLE
hdrgen: ob: add support for '@live' string pretty print

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6731,6 +6731,7 @@ struct ASTBase
             SCstring(STC.tls, "__thread"),
             SCstring(STC.gshared, Token.toString(TOK.gshared)),
             SCstring(STC.nogc, "@nogc"),
+            SCstring(STC.live, "@live"),
             SCstring(STC.property, "@property"),
             SCstring(STC.safe, "@safe"),
             SCstring(STC.trusted, "@trusted"),

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1670,6 +1670,8 @@ public:
             buf.writestring("@safe ");
         if (d.storage_class & STC.nogc)
             buf.writestring("@nogc ");
+        if (d.storage_class & STC.live)
+            buf.writestring("@live ");
         if (d.storage_class & STC.disable)
             buf.writestring("@disable ");
 
@@ -2791,6 +2793,7 @@ string stcToString(ref StorageClass stc)
         SCstring(STC.tls, "__thread"),
         SCstring(STC.gshared, Token.toString(TOK.gshared)),
         SCstring(STC.nogc, "@nogc"),
+        SCstring(STC.live, "@live"),
         SCstring(STC.property, "@property"),
         SCstring(STC.safe, "@safe"),
         SCstring(STC.trusted, "@trusted"),

--- a/test/compilable/extra-files/header2.d
+++ b/test/compilable/extra-files/header2.d
@@ -18,7 +18,7 @@ void foo2(const C2 c);
 struct Foo3
 {
    int k;
-   ~this() @trusted @disable @nogc { k = 1; }
+   ~this() @trusted @disable @nogc @live { k = 1; }
    this(this) { k = 2; }
 }
 

--- a/test/compilable/extra-files/header2.di
+++ b/test/compilable/extra-files/header2.di
@@ -9,7 +9,7 @@ void foo2(const C2 c);
 struct Foo3
 {
 	int k;
-	@trusted @nogc @disable ~this();
+	@trusted @nogc @live @disable ~this();
 	this(this);
 }
 class C3

--- a/test/compilable/extra-files/header2i.di
+++ b/test/compilable/extra-files/header2i.di
@@ -13,7 +13,7 @@ void foo2(const C2 c);
 struct Foo3
 {
 	int k;
-	@trusted @nogc @disable ~this()
+	@trusted @nogc @live @disable ~this()
 	{
 		k = 1;
 	}


### PR DESCRIPTION
Added equivalent string representation of '@live' for stcToString() and
DtorDeclaration visitor.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>