### PR TITLE
hdrgen: add extra space on AlignDeclaration only when needed

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -900,9 +900,7 @@ public:
             buf.writenl();
             return;
         }
-        if (d.decl.dim == 0)
-            buf.writestring("{}");
-        else if (hgs.hdrgen && d.decl.dim == 1 && (*d.decl)[0].isUnitTestDeclaration())
+        if (d.decl.dim == 0 || (hgs.hdrgen && d.decl.dim == 1 && (*d.decl)[0].isUnitTestDeclaration()))
         {
             // hack for bugzilla 8081
             buf.writestring("{}");

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -984,7 +984,13 @@ public:
     {
         buf.writestring("align ");
         if (d.ealign)
-            buf.printf("(%s) ", d.ealign.toChars());
+        {
+            buf.printf("(%s)", d.ealign.toChars());
+            AttribDeclaration ad = cast(AttribDeclaration)d;
+            if (ad.decl && ad.decl.dim < 2)
+                buf.writeByte(' ');
+        }
+
         visit(cast(AttribDeclaration)d);
     }
 

--- a/test/compilable/extra-files/header2.d
+++ b/test/compilable/extra-files/header2.d
@@ -144,11 +144,22 @@ void test13275()
 // https://issues.dlang.org/show_bug.cgi?id=9766
 align (1) struct S9766
 {
+align {}
 align (true ? 2 : 3):
     int var1;
 
 align:
     int var2;
+}
+
+align(2) struct S12200_1
+{
+align:
+}
+
+align(2) struct S12200_2
+{
+align(1):
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=16649

--- a/test/compilable/extra-files/header2.di
+++ b/test/compilable/extra-files/header2.di
@@ -102,11 +102,20 @@ void foo11217()(inout int[] arr)
 void test13275();
 align (1) struct S9766
 {
-	align (true ? 2 : 3) 
+	align {}
+	align (true ? 2 : 3)
 	{
 		int var1;
 		align int var2;
 	}
+}
+align (2) struct S12200_1
+{
+	align {}
+}
+align (2) struct S12200_2
+{
+	align (1) {}
 }
 void leFoo()()
 {

--- a/test/compilable/extra-files/header2i.di
+++ b/test/compilable/extra-files/header2i.di
@@ -204,11 +204,20 @@ void test13275()
 }
 align (1) struct S9766
 {
-	align (true ? 2 : 3) 
+	align {}
+	align (true ? 2 : 3)
 	{
 		int var1;
 		align int var2;
 	}
+}
+align (2) struct S12200_1
+{
+	align {}
+}
+align (2) struct S12200_2
+{
+	align (1) {}
 }
 void leFoo()()
 {


### PR DESCRIPTION
This will avoid trailing whitespaces in some situations, for example, on the
described by the change of the test.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>