### PR TITLE
Fix Issue 21220 - [DIP1000] scope variable may escape through scope dynamic array parameter

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1649,7 +1649,9 @@ void escapeByValue(Expression e, EscapeByResults* er, bool live = false)
 
         override void visit(IndexExp e)
         {
-            if (e.e1.type.toBasetype().ty == Tsarray ||
+            auto arrayType = e.e1.type.toBasetype().ty;
+            if (arrayType == Tsarray ||
+                (arrayType == Tarray && !live) ||
                 live && e.type.hasPointers())
             {
                 e.e1.accept(this);

--- a/test/fail_compilation/test18282.d
+++ b/test/fail_compilation/test18282.d
@@ -1,13 +1,14 @@
 /* REQUIRED_ARGS: -preview=dip1000
    TEST_OUTPUT:
 ---
-fail_compilation/test18282.d(25): Error: scope variable `aa` may not be returned
-fail_compilation/test18282.d(34): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
+fail_compilation/test18282.d(20): Error: scope variable `ls` may not be returned
+fail_compilation/test18282.d(26): Error: scope variable `aa` may not be returned
 fail_compilation/test18282.d(35): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
-fail_compilation/test18282.d(36): Error: scope variable `staa` may not be returned
-fail_compilation/test18282.d(44): Error: copying `S2000(& i)` into allocated memory escapes a reference to local variable `i`
-fail_compilation/test18282.d(53): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
-fail_compilation/test18282.d(53): Error: copying `& c` into allocated memory escapes a reference to local variable `c`
+fail_compilation/test18282.d(36): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
+fail_compilation/test18282.d(37): Error: scope variable `staa` may not be returned
+fail_compilation/test18282.d(45): Error: copying `S2000(& i)` into allocated memory escapes a reference to local variable `i`
+fail_compilation/test18282.d(54): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
+fail_compilation/test18282.d(54): Error: copying `& c` into allocated memory escapes a reference to local variable `c`
 ---
  */
 


### PR DESCRIPTION
```d
@safe:

struct A
{
    char[] value;                                                                                                                             
}

A f(scope A[] array)
{
    return array[0]; //  this line here escapes the `value`
}
```

It seems that [1] introduced this behavior on purpose, but I don't understand why. If `array` is made into a static array then returning `array[0]` is going to issue an error. However, it does not make any sense to me that the behavior is changed for dynamic arrays.

cc @WalterBright 

[1] https://github.com/dlang/dmd/pull/8030