### PR TITLE
DIP1034 add TypeNoreturn to astbase.d and mtype.d

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -204,6 +204,7 @@ struct ASTBase
         Tuns128,
         Ttraits,
         Tmixin,
+        Tnoreturn,
         TMAX
     }
 
@@ -253,6 +254,7 @@ struct ASTBase
     alias Tuns128 = ENUMTY.Tuns128;
     alias Ttraits = ENUMTY.Ttraits;
     alias Tmixin = ENUMTY.Tmixin;
+    alias Tnoreturn = ENUMTY.Tnoreturn;
     alias TMAX = ENUMTY.TMAX;
 
     alias TY = ubyte;
@@ -2766,6 +2768,7 @@ struct ASTBase
         extern (C++) __gshared Type tdstring;    // immutable(dchar)[]
         extern (C++) __gshared Type terror;      // for error recovery
         extern (C++) __gshared Type tnull;       // for null type
+        extern (C++) __gshared Type tnoreturn;   // for bottom type
 
         extern (C++) __gshared Type tsize_t;     // matches size_t alias
         extern (C++) __gshared Type tptrdiff_t;  // matches ptrdiff_t alias
@@ -2814,6 +2817,7 @@ struct ASTBase
                 sizeTy[Tnull] = __traits(classInstanceSize, TypeNull);
                 sizeTy[Tvector] = __traits(classInstanceSize, TypeVector);
                 sizeTy[Tmixin] = __traits(classInstanceSize, TypeMixin);
+                sizeTy[Tnoreturn] = __traits(classInstanceSize, TypeNoreturn);
                 return sizeTy;
             }();
 
@@ -2889,6 +2893,7 @@ struct ASTBase
                 basic[basetab[i]] = t;
             }
             basic[Terror] = new TypeError();
+            basic[Tnoreturn] = new TypeNoreturn();
 
             tvoid = basic[Tvoid];
             tint8 = basic[Tint8];
@@ -2920,6 +2925,7 @@ struct ASTBase
 
             tshiftcnt = tint32;
             terror = basic[Terror];
+            tnoreturn = basic[Tnoreturn];
             tnull = new TypeNull();
             tnull.deco = tnull.merge().deco;
 
@@ -3760,6 +3766,25 @@ struct ASTBase
         }
 
         override TypeNull syntaxCopy()
+        {
+            // No semantic analysis done, no need to copy
+            return this;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) final class TypeNoreturn : Type
+    {
+        extern (D) this()
+        {
+            super(Tnoreturn);
+        }
+
+        override TypeNoreturn syntaxCopy()
         {
             // No semantic analysis done, no need to copy
             return this;

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -210,6 +210,7 @@ private immutable char[TMAX] mangleChar =
     Tvector      : '@',
     Ttraits      : '@',
     Tmixin       : '@',
+    Tnoreturn    : '@',  // fix later
 ];
 
 unittest

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -655,6 +655,7 @@ class TypeSlice;
 class TypeNull;
 class TypeMixin;
 class TypeTraits;
+class TypeNoreturn;
 class TemplateTypeParameter;
 class TemplateValueParameter;
 class TemplateAliasParameter;
@@ -1256,6 +1257,7 @@ public:
     static Type* tdstring;
     static Type* terror;
     static Type* tnull;
+    static Type* tnoreturn;
     static Type* tsize_t;
     static Type* tptrdiff_t;
     static Type* thash_t;
@@ -1277,7 +1279,7 @@ public:
     static ClassDeclaration* typeinfoshared;
     static ClassDeclaration* typeinfowild;
     static TemplateDeclaration* rtinfo;
-    static Type* basic[46LLU];
+    static Type* basic[47LLU];
     virtual const char* kind() const;
     Type* copy() const;
     virtual Type* syntaxCopy();
@@ -1395,6 +1397,7 @@ public:
     TypeNull* isTypeNull();
     TypeMixin* isTypeMixin();
     TypeTraits* isTypeTraits();
+    TypeNoreturn* isTypeNoreturn();
     void accept(Visitor* v);
     TypeFunction* toTypeFunction();
 };
@@ -4918,7 +4921,8 @@ enum class ENUMTY
     Tuns128 = 43,
     Ttraits = 44,
     Tmixin = 45,
-    TMAX = 46,
+    Tnoreturn = 46,
+    TMAX = 47,
 };
 
 typedef uint8_t TY;
@@ -5419,6 +5423,18 @@ public:
     bool hasPointers();
     bool isBoolean() /* const */;
     d_uns64 size(const Loc& loc) /* const */;
+    void accept(Visitor* v);
+};
+
+class TypeNoreturn final : public Type
+{
+public:
+    const char* kind() const;
+    TypeNoreturn* syntaxCopy();
+    MATCH implicitConvTo(Type* to);
+    bool isBoolean() /* const */;
+    d_uns64 size(const Loc& loc) /* const */;
+    uint32_t alignsize();
     void accept(Visitor* v);
 };
 


### PR DESCRIPTION
First step to implement https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md

Adds the TypeNoreturn type.

None of this code can be accessed yet, so no test cases.