### PR TITLE
Fix Issue 20661 - opEquals not recognized for AA key (take two)

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -963,13 +963,15 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
             // duplicate a part of StructDeclaration::semanticTypeInfoMembers
             //printf("AA = %s, key: xeq = %p, xerreq = %p xhash = %p\n", toChars(), sd.xeq, sd.xerreq, sd.xhash);
-            if (sd.xeq && sd.xeq._scope && sd.xeq.semanticRun < PASS.semantic3done)
+
+            if (sd.xeq && sd.xeq.generated && sd.xeq._scope && sd.xeq.semanticRun < PASS.semantic3done)
             {
                 uint errors = global.startGagging();
                 sd.xeq.semantic3(sd.xeq._scope);
                 if (global.endGagging(errors))
                     sd.xeq = sd.xerreq;
             }
+
 
             //printf("AA = %s, key: xeq = %p, xhash = %p\n", toChars(), sd.xeq, sd.xhash);
             const(char)* s = (mtype.index.toBasetype().ty != Tstruct) ? "bottom of " : "";

--- a/test/compilable/test20661.d
+++ b/test/compilable/test20661.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=20661
+
+class Context
+{
+    size_t[const(Key)] aa; /* Error: AA key type Key does not have bool opEquals(ref const Key) const */
+    bool* checkAll;
+}
+
+struct Key
+{
+    Context context;
+    bool opEquals(ref const Key other) @safe const
+    {
+        auto c = context.checkAll;
+        return true;
+    }
+}


### PR DESCRIPTION
```d
class Context
{
    size_t[const(Key)] aa; /* Error: AA key type Key does not have bool opEquals(ref const Key) const */
    bool* checkAll;
}

struct Key
{
    Context context;
    bool opEquals(ref const Key other) @safe const
    {
        auto c = context.checkAll;
        return true;
    }
}
```

When `size_t[const(Key)] aa;` is analyzed the compiler proceeds to do semantic on `Key` [1] to see if there is an `opEquals` that needs to be used. In the process it also generates the typeinfo specific `xeq`, `xcmp`, `xhash` [2]. Later, it uses those to determine whether a struct can be used as an AA key [3]. Now, the problem is that you might have templated `opEquals`: in this situation, the compiler generates an `xeq` that simply does an equality comparison in its body [4]. If we have a matching template `opEquals` it should be fine, otherwise, we issue the errors in [3]. The fact that we eagerly analyze the body is problematic because in this situation we end up analyzing `auto c = context.checkAll;`. This means that we have to analyze `class Context` again leading to a forward reference error.

The fix is quite simple: we don't need to eagerly analyze the xeq function when it is user-defined. The only case where `xeq` is generated is whether `opEquals` is templated or it does not match the expected signature.

[1] https://github.com/dlang/dmd/blob/master/src/dmd/typesem.d#L962
[2] https://github.com/dlang/dmd/blob/master/src/dmd/dsymbolsem.d#L4835
[3] https://github.com/dlang/dmd/blob/master/src/dmd/typesem.d#L984
[4] https://github.com/dlang/dmd/blob/master/src/dmd/clone.d#L569