### PR TITLE
Fix issue 21646: speculative recursive reference to struct with semantic error prints "error: unknown"

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1623,7 +1623,7 @@ private bool preFunctionParameters(Scope* sc, Expressions* exps, const bool repo
 
                 if (arg.op == TOK.type)
                 {
-                    if (reportErrors)
+                    if (reportErrors && !global.gag)
                     {
                         arg.error("cannot pass type `%s` as a function argument", arg.toChars());
                         arg = ErrorExp.get();
@@ -1633,7 +1633,7 @@ private bool preFunctionParameters(Scope* sc, Expressions* exps, const bool repo
             }
             else if (arg.type.toBasetype().ty == Tfunction)
             {
-                if (reportErrors)
+                if (reportErrors && !global.gag)
                 {
                     arg.error("cannot pass function `%s` as a function argument", arg.toChars());
                     arg = ErrorExp.get();

--- a/test/fail_compilation/fail21646.d
+++ b/test/fail_compilation/fail21646.d
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21646.d(9): Error: cannot pass type `Type` as a function argument
+---
+*/
+struct Type {
+  enum a = __traits(compiles, Type());
+  static if (int(Type)) { }
+}


### PR DESCRIPTION
When preprocessing function arguments, only replace args with `ErrorExp`s if we managed to report an error.

Otherwise, if errors are gagged, we'll have ErrorExps with no corresponding error message.
Fixes issue 21646.