### PR TITLE
Fix issue 21648: remove two lines from dsymbolsem.d.

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -5963,8 +5963,6 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     }
 
     tempinst.hasNestedArgs(tempinst.tiargs, tempdecl.isstatic);
-    if (tempinst.errors)
-        goto Lerror;
 
     // Copy the tempdecl namespace (not the scope one)
     tempinst.cppnamespace = tempdecl.cppnamespace;

--- a/test/fail_compilation/fail21648.d
+++ b/test/fail_compilation/fail21648.d
@@ -1,0 +1,16 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21648.d(10): Error: undefined identifier `semantics`
+---
+*/
+
+template bla() {
+    semantics error;
+}
+
+struct Type {
+    enum e = __traits(compiles, Type.init);
+    static if (bla!()) { }
+}


### PR DESCRIPTION
I don't know what they do but it fixes the bug.
And doesn't break the testsuite, so ¯\\\_(ツ)\_/¯