### PR TITLE
DIP 1034: add name mangling

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2893,7 +2893,10 @@ struct ASTBase
                 basic[basetab[i]] = t;
             }
             basic[Terror] = new TypeError();
-            basic[Tnoreturn] = new TypeNoreturn();
+
+            tnoreturn = new TypeNoreturn();
+            tnoreturn.deco = tnoreturn.merge().deco;
+            basic[Tnoreturn] = tnoreturn;
 
             tvoid = basic[Tvoid];
             tint8 = basic[Tint8];

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1623,6 +1623,14 @@ extern(C++):
         writeBasicType(t, 'D', 'n');
     }
 
+    override void visit(TypeNoreturn t)
+    {
+        if (t.isImmutable() || t.isShared())
+            return error(t);
+
+        writeBasicType(t, 0, 'v');      // mangle like `void`
+    }
+
     override void visit(TypeBasic t)
     {
         if (t.isImmutable() || t.isShared())

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -145,6 +145,18 @@ public:
         flags &= ~IGNORE_CONST;
     }
 
+    override void visit(TypeNoreturn type)
+    {
+        if (checkImmutableShared(type))
+            return;
+        if (checkTypeSaved(type))
+            return;
+
+        buf.writeByte('X');             // yes, mangle it like `void`
+        flags &= ~IS_NOT_TOP_TYPE;
+        flags &= ~IGNORE_CONST;
+    }
+
     override void visit(TypeBasic type)
     {
         //printf("visit(TypeBasic); is_not_top_type = %d\n", (int)(flags & IS_NOT_TOP_TYPE));

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -186,7 +186,7 @@ private immutable char[TMAX] mangleChar =
     //              K   // ref
     //              L   // lazy
     //              M   // has this, or scope
-    //              N   // Nh:vector Ng:wild
+    //              N   // Nh:vector Ng:wild Nn:noreturn
     //              O   // shared
     Tpointer     : 'P',
     //              Q   // Type/symbol/identifier backward reference
@@ -210,7 +210,7 @@ private immutable char[TMAX] mangleChar =
     Tvector      : '@',
     Ttraits      : '@',
     Tmixin       : '@',
-    Tnoreturn    : '@',  // fix later
+    Tnoreturn    : '@',         // becomes 'Nn'
 ];
 
 unittest
@@ -586,6 +586,11 @@ public:
     override void visit(TypeNull t)
     {
         visit(cast(Type)t);
+    }
+
+    override void visit(TypeNoreturn t)
+    {
+        buf.writestring("Nn");
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5696,6 +5696,7 @@ public:
     virtual void visit(typename AST::TypeBasic t);
     virtual void visit(typename AST::TypeError t);
     virtual void visit(typename AST::TypeNull t);
+    virtual void visit(typename AST::TypeNoreturn t);
     virtual void visit(typename AST::TypeVector t);
     virtual void visit(typename AST::TypeEnum t);
     virtual void visit(typename AST::TypeTuple t);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -865,7 +865,10 @@ extern (C++) abstract class Type : ASTNode
             basic[basetab[i]] = t;
         }
         basic[Terror] = new TypeError();
-        basic[Tnoreturn] = new TypeNoreturn();
+
+        tnoreturn = new TypeNoreturn();
+        tnoreturn.deco = tnoreturn.merge().deco;
+        basic[Tnoreturn] = tnoreturn;
 
         tvoid = basic[Tvoid];
         tint8 = basic[Tint8];

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -140,6 +140,7 @@ public:
     void visit(AST.TypeBasic t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeError t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeNull t) { visit(cast(AST.Type)t); }
+    void visit(AST.TypeNoreturn t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeVector t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeEnum t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeTuple t) { visit(cast(AST.Type)t); }

--- a/src/dmd/strictvisitor.d
+++ b/src/dmd/strictvisitor.d
@@ -105,6 +105,7 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.TypeBasic) { assert(0); }
     override void visit(AST.TypeError) { assert(0); }
     override void visit(AST.TypeNull) { assert(0); }
+    override void visit(AST.TypeNoreturn) { assert(0); }
     override void visit(AST.TypeVector) { assert(0); }
     override void visit(AST.TypeEnum) { assert(0); }
     override void visit(AST.TypeTuple) { assert(0); }

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -81,6 +81,7 @@ class TypeClass;
 class TypeTuple;
 class TypeSlice;
 class TypeNull;
+class TypeNoreturn;
 class TypeTraits;
 class TypeMixin;
 
@@ -426,6 +427,7 @@ public:
     virtual void visit(TypeBasic *t) { visit((Type *)t); }
     virtual void visit(TypeError *t) { visit((Type *)t); }
     virtual void visit(TypeNull *t) { visit((Type *)t); }
+    virtual void visit(TypeNoreturn *t) { visit((Type *)t); }
     virtual void visit(TypeVector *t) { visit((Type *)t); }
     virtual void visit(TypeEnum *t) { visit((Type *)t); }
     virtual void visit(TypeTuple *t) { visit((Type *)t); }

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1275,3 +1275,22 @@ version (Win64) extern(C++)
     extern(C++, struct) class DefaultClass20700_2 {}
     static assert(test20700_4.mangleof == `?test20700_4@@YAXPEAU?$TStruct20700_2@PEAUDefaultClass20700_2@@VDefaultStruct20700_2@@@@@Z`);
 }
+
+/*****************************************/
+
+alias noreturn = typeof(*null);
+
+extern (C++)
+{
+    alias fpcpp = noreturn function();
+    int funccpp(fpcpp);
+
+    version (Posix)
+        static assert(funccpp.mangleof == "_Z7funccppPFvvE");
+
+    version (Win32)
+        static assert(funccpp.mangleof == "?funccpp@@YAHP6AXXZ@Z");
+
+    version (Win64)
+        static assert(funccpp.mangleof == "?funccpp@@YAHP6AXXZ@Z");
+}

--- a/test/runnable/mangle.d
+++ b/test/runnable/mangle.d
@@ -611,6 +611,13 @@ static assert(testLive.mangleof == "_D6mangle8testLiveFNmZi");
 
 /***************************************************/
 
+alias noreturn = typeof(*null);
+alias fpd = noreturn function();
+int funcd(fpd);
+static assert(funcd.mangleof == "_D6mangle5funcdFPFZNnZi");
+
+/***************************************************/
+
 void main()
 {
     test10077h();


### PR DESCRIPTION
DIP1034 says `b` is unused, but it is for `bool`. Mangle with `Nn` instead.

For C++, mangle `noreturn` like `void`