### PR TITLE
DIP1034: tag functions for code generator that don't return

### DIFF
--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1263,6 +1263,7 @@ tym_t totym(Type tx)
         case Tdelegate: t = TYdelegate; break;
         case Tarray:    t = TYdarray;   break;
         case Tsarray:   t = TYstruct;   break;
+        case Tnoreturn: t = TYvoid;     break;
 
         case Tstruct:
             t = TYstruct;

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -779,6 +779,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     }
                     assert(!funcdecl.returnLabel);
                 }
+                else if (f.next.ty == Tnoreturn)
+                {
+                }
                 else
                 {
                     const(bool) inlineAsm = (funcdecl.hasReturnExp & 8) != 0;

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -354,6 +354,9 @@ Symbol *toSymbol(Dsymbol s)
             else if (fd.isMember2() && fd.isStatic())
                 f.Fflags |= Fstatic;
 
+            if (fd.type.toBasetype().isTypeFunction().nextOf().isTypeNoreturn())
+                s.Sflags |= SFLexit;    // the function never returns
+
             f.Fstartline.set(fd.loc.filename, fd.loc.linnum, fd.loc.charnum);
             if (fd.endloc.linnum)
             {

--- a/test/compilable/noreturn1.d
+++ b/test/compilable/noreturn1.d
@@ -7,3 +7,5 @@ noreturn
 
 alias noreturn = typeof(*null);
 pragma(msg, noreturn);
+
+noreturn exits(int* p) { *p = 3; }


### PR DESCRIPTION
This gets us at least to the stage where D can now mark functions as `noreturn` and let the code generator know, which is the most basic use of `noreturn`. After this, we can go through core.stdc and druntime and tag things like `exit()` as `noreturn`.

https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md