### PR TITLE
Fix Issue 21319 - DMD crashes on immutable circular reference

### DIFF
--- a/test/fail_compilation/test21319.d
+++ b/test/fail_compilation/test21319.d
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=21319
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test21319.d(11): Error: circular reference to `test21319.C.c`
+---
+*/
+
+class C
+{
+    immutable C c = new C();
+}


### PR DESCRIPTION
```d
class C
{
    immutable C c = new C();
}
```

This code ends up calling `implicitConvTo` for a `NewExp` [1]. It cannot trivially convert the `NewExp` so it does additional checks, that consequently fail until the code reaches a segment where `C` is checked whether it is a zero initialized class [2].
To do that, all initializers of the class fields are checked and in our case we reach this line [3]. At this point we are redundantly checking if the type of `new C()` is implicitly convertible to `immutable(C)`. In fact, looking at `implicitMOD` [4], we can see that it internally calls `implicitConvTo` with the same parameters as at the beginning of this explanation. Hence the infinite loop and stack overflow.

The patch simply checks whether the `ExpInitializer` is the same as the new expression that we are analyzing. If that is the case, then we do not need to start over with the analysis.

[1] https://github.com/dlang/dmd/blob/master/src/dmd/dcast.d#L1170
[2] https://github.com/dlang/dmd/blob/master/src/dmd/dcast.d#L1316
[3] https://github.com/dlang/dmd/blob/master/src/dmd/dcast.d#L1349
[4] https://github.com/dlang/dmd/blob/master/src/dmd/dcast.d#L316