### PR TITLE
Fix 21659: Special enums are never forward referenced

### DIFF
--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -144,7 +144,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             dsymbolSemantic(this, _scope);
         }
 
-        if (!members || !symtab || _scope)
+        if (!isSpecial() && (!members || !symtab || _scope))
         {
             error("is forward referenced when looking for `%s`", ident.toChars());
             //*(char*)0=0;

--- a/test/compilable/test21659.d
+++ b/test/compilable/test21659.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=21659
+
+// Compiler-recognized ident
+enum __c_ulonglong : ulong;
+
+private union EndianSwapper(T)
+{
+    T value;
+    ubyte[T.sizeof] array;
+    static assert(T.sizeof == ulong.sizeof);
+}
+
+void main ()
+{
+    EndianSwapper!(__c_ulonglong) val;
+}


### PR DESCRIPTION
The compiler always knows their property, so don't error out on special enums.