### PR TITLE
DIP1034: type assert(0) as noreturn instead of void

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -3540,6 +3540,15 @@ elem *toElem(Expression e, IRState *irs)
 
             if (irs.params.cov && aae.e2.loc.linnum)
                 e.EV.E2 = el_combine(incUsageElem(irs, aae.e2.loc), e.EV.E2);
+
+            /* Until the backend understands TYnoreturn,
+             * resort to a workaround here.
+             * If aae.e2 is Tnoreturn, rewrite e as:
+             *   (e,false) for &&, and (e,true) for ||
+             */
+            if (aae.e2.type.ty == Tnoreturn)
+                e = el_combine(e, el_long(TYbool, aae.op == TOK.orOr));
+
             result = e;
         }
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5399,7 +5399,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             printf("HaltExp::semantic()\n");
         }
-        e.type = Type.tvoid;
+        e.type = Type.tnoreturn;
         result = e;
     }
 
@@ -6310,9 +6310,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 result = e;
                 return;
             }
+            exp.type = Type.tnoreturn;
         }
-
-        exp.type = Type.tvoid;
+        else
+            exp.type = Type.tvoid;
 
         result = !temporariesPrefix
             ? exp
@@ -10936,7 +10937,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.error("`%s` is not an expression", exp.e2.toChars());
             return setError();
         }
-        if (e1x.op == TOK.error)
+        if (e1x.op == TOK.error || e1x.type.ty == Tnoreturn)
         {
             result = e1x;
             return;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6697,7 +6697,7 @@ extern (C++) final class TypeNoreturn : Type
 
     override bool isBoolean() const
     {
-        return false;
+        return true;  // bottom type can be implicitly converted to any other type
     }
 
     override d_uns64 size(const ref Loc loc) const

--- a/test/runnable/noreturn1.d
+++ b/test/runnable/noreturn1.d
@@ -1,0 +1,21 @@
+
+/*****************************************/
+
+alias noreturn = typeof(*null);
+
+bool testf(int i)
+{
+    return i && assert(0);
+}
+
+bool testt(int i)
+{
+    return i || assert(0);
+}
+
+void main()
+{
+    assert(testf(0) == false);
+    assert(testt(1) == true);
+}
+


### PR DESCRIPTION
`assert(0)` gets rewritten as a HaltExp by the semantic pass, so a convenient place to set the type to noreturn.