### PR TITLE
runnable_cxx: Enable tests on Apple / FreeBSD

### DIFF
--- a/test/runnable_cxx/cppa.d
+++ b/test/runnable_cxx/cppa.d
@@ -13,6 +13,8 @@ import core.stdc.stdarg;
 import core.stdc.config;
 import core.stdc.stdint;
 
+import core.stdcpp.xutility;
+
 extern (C++)
         int foob(int i, int j, int k);
 
@@ -475,23 +477,6 @@ extern (C++, std)
     {
     }
 
-    // https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
-    version (none)
-    {
-        extern (C++, __cxx11)
-        {
-            struct basic_string(T, C = char_traits!T, A = allocator!T)
-            {
-            }
-        }
-    }
-    else
-    {
-        extern (C++, class) struct basic_string(T, C = char_traits!T, A = allocator!T)
-        {
-        }
-    }
-
     struct basic_istream(T, C = char_traits!T)
     {
     }
@@ -513,18 +498,35 @@ extern (C++, std)
     }
 }
 
+// https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
+version (all)
+{
+    extern (C++, (StdNamespace))
+    {
+        struct basic_string(T, C = char_traits!T, A = allocator!T)
+        {
+        }
+    }
+}
+else
+{
+    extern (C++, class) struct basic_string(T, C = char_traits!T, A = allocator!T)
+    {
+    }
+}
+
 extern (C++)
 {
     version (linux)
     {
         void foo14(std.vector!(int) p);
-        void foo14a(std.basic_string!(char) *p);
-        void foo14b(std.basic_string!(int) *p);
+        void foo14a(basic_string!(char) *p);
+        void foo14b(basic_string!(int) *p);
         void foo14c(std.basic_istream!(char) *p);
         void foo14d(std.basic_ostream!(char) *p);
         void foo14e(std.basic_iostream!(char) *p);
 
-        void foo14f(std.char_traits!char* x, std.basic_string!char* p, std.basic_string!char* q);
+        void foo14f(std.char_traits!char* x, basic_string!char* p, basic_string!char* q);
     }
 }
 
@@ -1594,7 +1596,7 @@ void test19134()
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=18955
-alias std_string = std.basic_string!(char);
+alias std_string = basic_string!(char);
 
 extern(C++) void callback18955(ref const(std_string) str)
 {

--- a/test/runnable_cxx/extra-files/cppb.cpp
+++ b/test/runnable_cxx/extra-files/cppb.cpp
@@ -1,36 +1,3 @@
-/*
-GCC 5.1 introduced new implementations of std::string and std::list:
-
-https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
-
-This causes e.g. std::string to be actually defined as
-std::__cxx11::string.
-
-On machines with GCC 5.1, this manifests as a linker error when
-running the cppa.d / cppb.cpp test:
-
-cppa.o: In function `_D4cppa6test14FZv':
-cppa.d:(.text._D4cppa6test14FZv+0x11): undefined reference to `foo14a(std::string*)'
-cppa.d:(.text._D4cppa6test14FZv+0x18): undefined reference to `foo14b(std::basic_string<int, std::char_traits<int>, std::allocator<int> >*)'
-cppa.d:(.text._D4cppa6test14FZv+0x3a): undefined reference to `foo14f(std::char_traits<char>*, std::string*, std::string*)'
-cppa.o: In function `_D4cppa7testeh3FZv':
-cppa.d:(.text._D4cppa7testeh3FZv+0x19): undefined reference to `throwle()'
-collect2: error: ld returned 1 exit status
---- errorlevel 1
-
-When the .cpp file is compiled with g++ 5.3.0, the actual function
-signatures in the cppb.o object file are:
-
-foo14a(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*)
-foo14b(std::__cxx11::basic_string<int, std::char_traits<int>, std::allocator<int> >*)
-foo14f(std::char_traits<char>*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*)
-
-Fortunately, it is easily possible to disable the new feature
-by defining _GLIBCXX_USE_CXX11_ABI as 0 before including any standard
-headers.
-*/
-#define _GLIBCXX_USE_CXX11_ABI 0
-
 #include <stdio.h>
 #include <stdint.h>
 #include <assert.h>
@@ -961,8 +928,5 @@ void callback18955(const std::string& s);
 void test18955()
 {
     std::string s;
-// TODO: on OSX and FreeBSD, std is mangled as std::__1
-#if !__APPLE__ && !__FreeBSD__
     callback18955(s);
-#endif
 }


### PR DESCRIPTION
xutility contains StdNamespace which is used to work around the issue mentioned.