### PR TITLE
Fix 2525: check all parent interfaces for overriden methods

### DIFF
--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -994,19 +994,21 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     }
 
     /****************************************
-     * Gets an array of all implemented interfaces of this class. This includes
-     * all interfaces implemented by parent classes, all interfaces implemented
-     * by this class, and all interfaces which are extended by other interfaces.
+     * Loops over all implemented interfaces of this class. This  all interfaces
+     * implemented by parent classes, all interfaces by this class, and all
+     * interfaces which are extended by other interfaces.
+     * Params:
+     *     callback = A callback which will be executed for each parent interface that is found.
      */
-    final void allInterfaces(ref BaseClasses bases)
+    extern(D) final void forAllInterfaces(scope void delegate(BaseClass*) callback)
     {
         if (baseClass is null)
             return;
-        baseClass.allInterfaces(bases);
+        baseClass.forAllInterfaces(callback);
         foreach (base; interfaces)
         {
-            bases.push(base);
-            base.sym.allInterfaces(bases);
+            callback(base);
+            base.sym.forAllInterfaces(callback);
         }
     }
 }

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -994,8 +994,8 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     }
 
     /****************************************
-     * Loops over all implemented interfaces of this class. This  all interfaces
-     * implemented by parent classes, all interfaces by this class, and all
+     * Loops over all implemented interfaces of this class: interfaces
+     * implemented by parent classes, interfaces implemented by this class, and all
      * interfaces which are extended by other interfaces.
      * Params:
      *     callback = A callback which will be executed for each parent interface that is found.

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -992,6 +992,24 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     {
         v.visit(this);
     }
+
+	/****************************************
+	 * Gets an array of all parents of this class. This includes all parent
+	 * classes, all interfaces implemented by this class, and all interfaces
+	 * implemented by parent classes.
+	 */
+	final BaseClass*[] allParents()
+	{
+		if (baseClass is null)
+			return [];
+		BaseClass*[] parents = baseClass.allParents();
+		foreach (base; interfaces)
+		{
+			parents ~= base;
+			parents ~= base.sym.allParents();
+		}
+		return parents;
+	}
 }
 
 /***********************************************************

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -993,23 +993,22 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         v.visit(this);
     }
 
-	/****************************************
-	 * Gets an array of all parents of this class. This includes all parent
-	 * classes, all interfaces implemented by this class, and all interfaces
-	 * implemented by parent classes.
-	 */
-	final BaseClass*[] allParents()
-	{
-		if (baseClass is null)
-			return [];
-		BaseClass*[] parents = baseClass.allParents();
-		foreach (base; interfaces)
-		{
-			parents ~= base;
-			parents ~= base.sym.allParents();
-		}
-		return parents;
-	}
+    /****************************************
+     * Gets an array of all implemented interfaces of this class. This includes
+     * all interfaces implemented by parent classes, all interfaces implemented
+     * by this class, and all interfaces which are extended by other interfaces.
+     */
+    final void allInterfaces(ref BaseClasses bases)
+    {
+        if (baseClass is null)
+            return;
+        baseClass.allInterfaces(bases);
+        foreach (base; interfaces)
+        {
+            bases.push(base);
+            base.sym.allInterfaces(bases);
+        }
+    }
 }
 
 /***********************************************************

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3890,7 +3890,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         Linterfaces:
             bool foundVtblMatch = false;
 
-            foreach (b; cd.allParents)
+            BaseClasses bases;
+            cd.allInterfaces(bases);
+            foreach (b; bases)
             {
                 vi = funcdecl.findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
                 switch (vi)

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3890,7 +3890,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         Linterfaces:
             bool foundVtblMatch = false;
 
-            foreach (b; cd.interfaces)
+            foreach (b; cd.allParents)
             {
                 vi = funcdecl.findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
                 switch (vi)

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3890,9 +3890,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         Linterfaces:
             bool foundVtblMatch = false;
 
-            BaseClasses bases;
-            cd.allInterfaces(bases);
-            foreach (b; bases)
+            cd.forAllInterfaces((b)
             {
                 vi = funcdecl.findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
                 switch (vi)
@@ -3951,7 +3949,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         }
                     }
                 }
-            }
+            });
             if (foundVtblMatch)
             {
                 goto L2;

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -625,7 +625,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
         /// Checks that the given class implements all methods of its interfaces.
         static void checkInterfaceImplementations(ClassDeclaration cd)
         {
-            foreach (base; cd.interfaces)
+            foreach (base; cd.allParents)
             {
                 // first entry is ClassInfo reference
                 auto methods = base.sym.vtbl[base.sym.vtblOffset .. $];

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -653,7 +653,16 @@ private extern(C++) final class Semantic2Visitor : Visitor
                         // Check that it is current
                         //printf("newinstance = %d fd.toParent() = %s ifd.toParent() = %s\n",
                             //newinstance, fd.toParent().toChars(), ifd.toParent().toChars());
-                        if (fd.toParent() != cd && ifd.toParent() == base.sym)
+                        static bool isImplemented(FuncDeclaration fd, ClassDeclaration cd)
+                        {
+                            if (cd is null)
+                                return false;
+                            else if (fd.toParent() == cd)
+                                return true;
+                            else
+                                return isImplemented(fd, cd.baseClass);
+                        }
+                        if (!isImplemented(fd, cd) && ifd.toParent() == base.sym)
                             cd.error("interface function `%s` is not implemented", ifd.toFullSignature());
                     }
 

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -625,9 +625,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
         /// Checks that the given class implements all methods of its interfaces.
         static void checkInterfaceImplementations(ClassDeclaration cd)
         {
-            BaseClasses bases;
-            cd.allInterfaces(bases);
-            foreach (base; bases)
+            cd.forAllInterfaces((base)
             {
                 // first entry is ClassInfo reference
                 auto methods = base.sym.vtbl[base.sym.vtblOffset .. $];
@@ -688,7 +686,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
                         }
                     }
                 }
-            }
+            });
         }
 
         if (cd.semanticRun >= PASS.semantic2done)

--- a/test/compilable/test2525a.d
+++ b/test/compilable/test2525a.d
@@ -1,0 +1,19 @@
+/*
+*/
+// https://issues.dlang.org/show_bug.cgi?id=2525
+
+interface A
+{
+	void foo();
+}
+
+abstract class B : A
+{
+}
+
+class C : B
+{
+	override void foo()
+	{
+	}
+}

--- a/test/compilable/test2525b.d
+++ b/test/compilable/test2525b.d
@@ -1,0 +1,17 @@
+/*
+*/
+// https://issues.dlang.org/show_bug.cgi?id=2525
+
+interface A
+{
+	void foo();
+}
+
+abstract class B : A
+{
+	override void foo() {}
+}
+
+class C : B
+{
+}

--- a/test/compilable/test2525c.d
+++ b/test/compilable/test2525c.d
@@ -1,0 +1,27 @@
+/*
+*/
+// https://issues.dlang.org/show_bug.cgi?id=2525
+
+interface A
+{
+	void foo();
+}
+
+abstract class B : A
+{
+}
+
+abstract class C : B
+{
+}
+
+class D : C
+{
+	override void foo() {}
+}
+
+void main()
+{
+	auto c = new D();
+	c.foo();
+}

--- a/test/compilable/test2525d.d
+++ b/test/compilable/test2525d.d
@@ -1,0 +1,20 @@
+/*
+TEST_OUTPUT:
+---
+compilable/test2525d.d(18): Deprecation: class `test2525d.C` interface function `void foo()` is not implemented
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=2525
+
+interface A
+{
+	void foo();
+}
+
+abstract class B : A
+{
+}
+
+class C : B
+{
+}

--- a/test/compilable/test2525e.d
+++ b/test/compilable/test2525e.d
@@ -1,0 +1,26 @@
+/*
+TEST_OUTPUT:
+---
+compilable/test2525e.d(24): Deprecation: class `test2525e.B` interface function `void foo()` is not implemented
+compilable/test2525e.d(24): Deprecation: class `test2525e.B` interface function `void bar()` is not implemented
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=2525
+
+interface IA
+{
+	void foo();
+}
+
+interface IB : IA
+{
+	void bar();
+}
+
+abstract class A : IB
+{
+}
+
+class B : A
+{
+}

--- a/test/fail_compilation/fail2525.d
+++ b/test/fail_compilation/fail2525.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail2525.d(14): Error: class `fail2525.B` interface function `void foo()` is not implemented
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=2525
+
+interface A
+{
+	void foo();
+}
+
+class B : A
+{
+}


### PR DESCRIPTION
This PR fixes [issue 2525](https://issues.dlang.org/show_bug.cgi?id=2525).
It will cause the compiler to check whether all methods of all interfaces have been implemented in a non-abstract class, instead of only the methods of interfaces that were directly implemented.
It also requires one to use the `override` keyword when overriding a method from an interface which was implemented by a base class.

For instance, the following which used to compile will no longer compile:

```d
interface I
{
    void foo();
    void bar();
}

abstract class A : I
{
}

class B : A
{
    // This used to be legal, but will now require the 'override' keyword.
    void bar() {}
}

void main()
{
    B b = new B();
    b.foo(); // Causes a segfault as there is no implementation for the function.
}
```

The following which used to not compile will now compile:

```d
interface I
{
    void foo();
    void bar();
}

abstract class A : I
{
}

class B : A
{
    override void foo() {}
    override void bar() {}
}

void main()
{
    B b = new B();
    b.foo(); // Executes the function properly.
}
```