### PR TITLE
Detect noreturn statements

### DIFF
--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -107,6 +107,8 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                         return;
                     }
                 }
+                if (s.exp.type.toBasetype().isTypeNoreturn())
+                    result = BE.halt;
                 if (canThrow(s.exp, func, mustNotThrow))
                     result |= BE.throw_;
             }

--- a/test/fail_compilation/warn12809.d
+++ b/test/fail_compilation/warn12809.d
@@ -32,3 +32,42 @@ void test_unrachable3()
 
     int x = 1;      // unreachable
 }
+
+/********************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/warn12809.d(108): Warning: statement is not reachable
+fail_compilation/warn12809.d(115): Warning: statement is not reachable
+fail_compilation/warn12809.d(122): Warning: statement is not reachable
+---
+*/
+
+#line 100
+
+alias noreturn = typeof(*null);
+
+noreturn foo();
+
+void test1(ref int i)
+{
+    foo();
+    i = 3;
+}
+
+void test2()
+{
+    try foo();
+    finally { }
+    int x = 1;
+}
+
+void test3()
+{
+    try { }
+    finally foo();
+    int x = 1;
+}
+
+


### PR DESCRIPTION
```
This re-introduce commit 0fc1fc0539659d03acb9f39d01415778391bfcda,
which was merged in #12222 and subsequently reverted in commit
3c845329c2282a8c374d53a91c520f433afa2628 (PR #12228) as it broke
some projects on Buildkite. The project has had a new release,
so it should be safe to re-introduce.
```

Actually I'm not 100% sure,  because some projects depend on Ocean, so let's see what Buildkite says.