### PR TITLE
Fix  14831 - Each function local symbols should have unique mangled name

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5225,12 +5225,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             else if (sc.func)
             {
                 // https://issues.dlang.org/show_bug.cgi?id=11720
-                // include Dataseg variables
                 if ((s.isFuncDeclaration() ||
                      s.isAggregateDeclaration() ||
                      s.isEnumDeclaration() ||
                      s.isTemplateDeclaration() ||
-                     v && v.isDataseg()) && !sc.func.localsymtab.insert(s))
+                     v
+                    ) && !sc.func.localsymtab.insert(s))
                 {
                     // Get the previous symbol
                     Dsymbol originalSymbol = sc.func.localsymtab.lookup(s.ident);

--- a/test/compilable/test14831.d
+++ b/test/compilable/test14831.d
@@ -1,0 +1,60 @@
+// https://issues.dlang.org/show_bug.cgi?id=14831
+
+void main()
+{
+    {
+        int x;
+        static assert(x.mangleof == "_D9test148314mainFZ1xi");
+    }
+    {
+        int x;
+        static assert(x.mangleof == "_D9test148314mainFZ5__S11xi");
+    }
+
+    {
+        static int y = 0;
+        static assert(y.mangleof == "_D9test148314mainFZ1yi");
+    }
+    {
+        static int y = 0;
+        static assert(y.mangleof == "_D9test148314mainFZ5__S11yi");
+    }
+
+    {
+        void f() {}
+        static assert(f.mangleof == "_D9test148314mainFZ1fMFNaNbNiNfZv");
+    }
+    {
+        void f() {}
+        static assert(f.mangleof == "_D9test148314mainFZ5__S11fMFNaNbNiNfZv");
+    }
+
+    {
+        struct S {}
+        static assert(S.mangleof == "S9test148314mainFZ1S");
+    }
+    {
+        struct S {}
+        static assert(S.mangleof == "S9test148314mainFZ5__S11S");
+    }
+
+    {
+        class C {}
+        static assert(C.mangleof == "C9test148314mainFZ1C");
+    }
+    {
+        class C {}
+        static assert(C.mangleof == "C9test148314mainFZ5__S11C");
+    }
+
+    {
+        enum E { a }
+        static assert(E.mangleof == "E9test148314mainFZ1E");
+        static assert(E.a.mangleof == "_D9test148314mainFZ1E1aEQwQoFZQl");
+    }
+    {
+        enum E { a }
+        static assert(E.mangleof == "E9test148314mainFZ5__S11E");
+        static assert(E.a.mangleof == "_D9test148314mainFZ5__S11E1aEQBbQuFZ5__S1Qr");
+    }
+}

--- a/test/fail_compilation/b19523.d
+++ b/test/fail_compilation/b19523.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/b19523.d(12): Error: undefined identifier `SomeStruct`
 fail_compilation/b19523.d(13): Error: function `b19523.foo(int delegate() arg)` is not callable using argument types `(_error_)`
-fail_compilation/b19523.d(13):        cannot pass argument `__lambda1` of type `_error_` to parameter `int delegate() arg`
+fail_compilation/b19523.d(13):        cannot pass argument `__lambda2` of type `_error_` to parameter `int delegate() arg`
 ---
 */
 module b19523;
@@ -16,4 +16,3 @@ void bar () {
 }
 
 void foo (int delegate() arg) {}
-

--- a/test/fail_compilation/bug9631.d
+++ b/test/fail_compilation/bug9631.d
@@ -64,7 +64,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/bug9631.d(79): Error: function `bug9631.arg.f(int i, S s)` is not callable using argument types `(int, S)`
 fail_compilation/bug9631.d(79):        cannot pass argument `y` of type `bug9631.tem!().S` to parameter `bug9631.S s`
-fail_compilation/bug9631.d(80): Error: function literal `__lambda2(S s)` is not callable using argument types `(S)`
+fail_compilation/bug9631.d(80): Error: function literal `__lambda4(S s)` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(80):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S s`
 fail_compilation/bug9631.d(86): Error: constructor `bug9631.arg.A.this(S _param_0)` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(86):        cannot pass argument `S(0)` of type `bug9631.tem!().S` to parameter `bug9631.S _param_0`

--- a/test/fail_compilation/diag12829.d
+++ b/test/fail_compilation/diag12829.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag12829.d(12): Error: function `diag12829.test1` is `@nogc` yet allocates closures with the GC
-fail_compilation/diag12829.d(15):        diag12829.test1.__lambda1 closes over variable x at fail_compilation/diag12829.d(14)
+fail_compilation/diag12829.d(15):        diag12829.test1.__lambda2 closes over variable x at fail_compilation/diag12829.d(14)
 fail_compilation/diag12829.d(19):        diag12829.test1.bar closes over variable x at fail_compilation/diag12829.d(14)
 fail_compilation/diag12829.d(26): Error: function `diag12829.test2` is `@nogc` yet allocates closures with the GC
 fail_compilation/diag12829.d(31):        diag12829.test2.S.foo closes over variable x at fail_compilation/diag12829.d(28)

--- a/test/fail_compilation/diag15411.d
+++ b/test/fail_compilation/diag15411.d
@@ -2,9 +2,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag15411.d(17): Error: function `diag15411.test15411.__funcliteral1` cannot access variable `i` in frame of function `diag15411.test15411`
+fail_compilation/diag15411.d(17): Error: function `diag15411.test15411.__funcliteral2` cannot access variable `i` in frame of function `diag15411.test15411`
 fail_compilation/diag15411.d(16):        `i` declared here
-fail_compilation/diag15411.d(18): Error: function `diag15411.test15411.__funcliteral2` cannot access variable `i` in frame of function `diag15411.test15411`
+fail_compilation/diag15411.d(18): Error: function `diag15411.test15411.__funcliteral4` cannot access variable `i` in frame of function `diag15411.test15411`
 fail_compilation/diag15411.d(16):        `i` declared here
 fail_compilation/diag15411.d(26): Error: `static` function `diag15411.testNestedFunction.myFunc2` cannot access function `myFunc1` in frame of function `diag15411.testNestedFunction`
 fail_compilation/diag15411.d(25):        `myFunc1` declared here

--- a/test/fail_compilation/diag9831.d
+++ b/test/fail_compilation/diag9831.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9831.d(13): Error: function `diag9831.main.__lambda1` cannot access variable `c` in frame of function `D main`
+fail_compilation/diag9831.d(13): Error: function `diag9831.main.__lambda3` cannot access variable `c` in frame of function `D main`
 fail_compilation/diag9831.d(11):        `c` declared here
 ---
 */

--- a/test/fail_compilation/ice11822.d
+++ b/test/fail_compilation/ice11822.d
@@ -5,8 +5,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11822.d(33): Deprecation: function `ice11822.d` is deprecated
-fail_compilation/ice11822.d(16):        instantiated from here: `__lambda1!int`
-fail_compilation/ice11822.d(22):        instantiated from here: `S!(__lambda1)`
+fail_compilation/ice11822.d(16):        instantiated from here: `__lambda2!int`
+fail_compilation/ice11822.d(22):        instantiated from here: `S!(__lambda2)`
 fail_compilation/ice11822.d(33):        instantiated from here: `g!((n) => d(i))`
 ---
 */

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -234,10 +234,10 @@ void* funretscope(scope dg_t ptr) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `__lambda1` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() @safe`
-fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `__lambda1` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() @safe`
-fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() @safe`
-fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() @safe`
+fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() @safe`
+fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() @safe`
+fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda4` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() @safe`
+fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda4` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() @safe`
 ---
 */
 

--- a/test/fail_compilation/test15306.d
+++ b/test/fail_compilation/test15306.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test15306.d(15): Error: `immutable` delegate `test15306.main.__dgliteral1` cannot access mutable data `i`
-fail_compilation/test15306.d(19): Error: `shared` delegate `test15306.main.__dgliteral2` cannot access non-shared data `p`
+fail_compilation/test15306.d(15): Error: `immutable` delegate `test15306.main.__dgliteral2` cannot access mutable data `i`
+fail_compilation/test15306.d(19): Error: `shared` delegate `test15306.main.__dgliteral5` cannot access non-shared data `p`
 ---
 */
 

--- a/test/fail_compilation/test16193.d
+++ b/test/fail_compilation/test16193.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test16193.d(38): Error: function `test16193.abc` is `@nogc` yet allocates closures with the GC
-fail_compilation/test16193.d(40):        test16193.abc.__foreachbody1 closes over variable x at fail_compilation/test16193.d(39)
+fail_compilation/test16193.d(40):        test16193.abc.__foreachbody2 closes over variable x at fail_compilation/test16193.d(39)
 ---
 */
 //fail_compilation/test16193.d(22): To enforce `@safe`, the compiler allocates a closure unless `opApply()` uses `scope`

--- a/test/runnable/test10619.d
+++ b/test/runnable/test10619.d
@@ -5,12 +5,10 @@ PERMUTE_ARGS:
 RUN_OUTPUT:
 ---
 1
-1
+2
 3
 4
 ---
-
-print => 2 will be fixed by https://github.com/dlang/dmd/pull/12235
 */
 
 void main()

--- a/test/runnable/testkeyword.d
+++ b/test/runnable/testkeyword.d
@@ -97,8 +97,8 @@ void main(string[] args) nothrow
 
     auto funcLiteral = (int x, int y)
     {
-        enum thisFunc  = "testkeyword.main.__lambda3";
-        enum thisFunc2 = "testkeyword.main.__lambda3(int x, int y)";
+        enum thisFunc  = "testkeyword.main.__lambda5";
+        enum thisFunc2 = "testkeyword.main.__lambda5(int x, int y)";
 
         static assert(getFuncArgFile()  == thisFile);
         static assert(getFuncArgLine()  == 104);


### PR DESCRIPTION
PR #12119 already fixed collisions for several declarations but missed
local variables.

The check for `isDataSeg` was a remnant of the old error raised for
`static`/`__gshared` variables. Removing it enables the mangling fixup
for local variables.

~~Note that this doesn't fix https://issues.dlang.org/show_bug.cgi?id=10619
which is not directly related to the mangling. See #12236.~~

---

Changes to other `TEST_OUTPUT` sections are caused by different sizes of `localsymtab` which defines the sequence number for anonymous symbols.