### PR TITLE
Fix 10619 - Wrong local variable passed as alias arguments to templates

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -326,7 +326,9 @@ extern (C++) class Dsymbol : ASTNode
             return false;
         auto s = cast(Dsymbol)o;
         // Overload sets don't have an ident
-        if (s && ident && s.ident && ident.equals(s.ident))
+        // Function-local declarations may have identical names
+        // if they are declared in different scopes
+        if (s && ident && s.ident && ident.equals(s.ident) && localNum == s.localNum)
             return true;
         return false;
     }

--- a/test/runnable/test10619.d
+++ b/test/runnable/test10619.d
@@ -1,0 +1,40 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=10619
+
+PERMUTE_ARGS:
+RUN_OUTPUT:
+---
+1
+1
+3
+4
+---
+
+print => 2 will be fixed by https://github.com/dlang/dmd/pull/12235
+*/
+
+void main()
+{
+    {
+        int x = 1;
+        print!x();
+    }
+    {
+        int x = 2;
+        print!x();
+    }
+    {
+        static int y = 3;
+        print!y();
+    }
+    {
+        static int y = 4;
+        print!y();
+    }
+}
+
+void print(alias symbol)()
+{
+    import core.stdc.stdio : printf;
+    printf("%d\n", symbol);
+}


### PR DESCRIPTION
PR #12119 introduced `localNum` to differentiate between multiple
symbols with identical names. But `Dsymbol.equals` doesn't consider
this member when comparing two `Dsymbol`'s.

This caused template semantic to treat the second instantiation of
`foo` as a duplice in the following example:

```d
void main()
{
    {
        int x = 1;
        foo!x();
    }
    {
        int x = 2;
        foo!x();
    }
}
```