### PR TITLE
Fix 21668 - Cannot declare ref parameter of opaque type

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -936,7 +936,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         if (auto ts = tb.isTypeStruct())
         {
-            if (!ts.sym.members)
+            // Require declarations, except when it's just a reference (as done for pointers)
+            if (!ts.sym.members && !(dsym.storage_class & STC.ref_))
             {
                 dsym.error("no definition of struct `%s`", ts.toChars());
             }

--- a/test/compilable/test21668.d
+++ b/test/compilable/test21668.d
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=21668
+
+struct Opaque;
+
+void byPtr(Opaque*) {}
+void byRef(ref Opaque) {} // Fails
+void bySlice(Opaque[]) {}


### PR DESCRIPTION
Don't raise errors for `VarDeclarations` that are marked as ref