### PR TITLE
Fix 14954 - extern opaque struct instance doesn't compile

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -936,7 +936,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         if (auto ts = tb.isTypeStruct())
         {
-            if (!ts.sym.members)
+            // Require declarations, except when it's just a reference (as done for pointers)
+            if (!ts.sym.members && !(dsym.storage_class & STC.ref_))
             {
                 dsym.error("no definition of struct `%s`", ts.toChars());
             }

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -937,7 +937,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (auto ts = tb.isTypeStruct())
         {
             // Require declarations, except when it's just a reference (as done for pointers)
-            if (!ts.sym.members && !(dsym.storage_class & STC.ref_))
+            // or when the variable is defined externally
+            if (!ts.sym.members && !(dsym.storage_class & (STC.ref_ | STC.extern_)))
             {
                 dsym.error("no definition of struct `%s`", ts.toChars());
             }

--- a/test/compilable/imports/test14954_implementation.d
+++ b/test/compilable/imports/test14954_implementation.d
@@ -1,0 +1,6 @@
+extern(C) struct UndeclaredStruct
+{
+    int i;
+}
+
+extern(C) __gshared UndeclaredStruct blah;

--- a/test/compilable/test14954.d
+++ b/test/compilable/test14954.d
@@ -1,0 +1,12 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=14954
+
+EXTRA_SOURCES: imports/test14954_implementation.d
+LINK:
+*/
+
+extern(C) struct UndeclaredStruct;
+extern(C) __gshared extern UndeclaredStruct blah;
+__gshared auto p = &blah;
+
+void main() {}

--- a/test/compilable/test21668.d
+++ b/test/compilable/test21668.d
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=21668
+
+struct Opaque;
+
+void byPtr(Opaque*) {}
+void byRef(ref Opaque) {} // Fails
+void bySlice(Opaque[]) {}


### PR DESCRIPTION
Don't raise an error if the `VarDeclaration` is marked as `extern`.

---

Based on #12239 to avoid the ugly merge conflict.