### PR TITLE
Allow `-preview=in` only with `extern(D|C++)`

### DIFF
--- a/changelog/previewInLink.dd
+++ b/changelog/previewInLink.dd
@@ -1,0 +1,11 @@
+`-preview=in` can now be used with `extern(C++)`, disabled for other non-D linkage
+
+The intent of `-preview=in` is to make `in` the go-to storage class for input parameters in D.
+However, it is D centric, as it is an enhanced version of `scope const ref`.
+As non-`extern(D)` functions usually are expected to match a specific ABI,
+using `in` is hardly a good idea.
+
+As C++ also has a "go to" storage class for input parameters (`const T&`),
+`in` can also be applied on `extern(C++)` function in order to bind to `const T&` parameters.
+This also allows to expose a closer API for a function than via `const ref`,
+as `in` will allow to bind rvalues to `const T&`, as in C++.

--- a/test/fail_compilation/previewin2.d
+++ b/test/fail_compilation/previewin2.d
@@ -1,0 +1,18 @@
+/*
+REQUIRED_ARGS: -preview=in -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/previewin2.d(1): Error: cannot use `in` parameters with `extern(C)` functions
+fail_compilation/previewin2.d(1):        parameter `a` declared as `in` here
+fail_compilation/previewin2.d(2): Error: cannot use `in` parameters with `extern(Windows)` functions
+fail_compilation/previewin2.d(2):        parameter `a` declared as `in` here
+fail_compilation/previewin2.d(4): Error: cannot use `in` parameters with `extern(C)` functions
+fail_compilation/previewin2.d(4):        parameter `__anonymous_param` declared as `in` here
+---
+*/
+
+#line 1
+extern(C) void wrongLink1 (in int a);
+extern(Windows) void wrongLink2 (in void* a);
+struct Large { ulong[64] data; }
+extern(C) void wrongLink3 (in Large);

--- a/test/runnable_cxx/cppa.d
+++ b/test/runnable_cxx/cppa.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -preview=in
 // PERMUTE_ARGS: -g
 // EXTRA_CPP_SOURCES: cppb.cpp
 // EXTRA_FILES: extra-files/cppb.h
@@ -1637,12 +1638,28 @@ void test19134()
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=18955
-alias std_string = std.basic_string!(char);
+version (linux)
+    alias std_string = std.basic_string!(char);
+else
+{
+    import core.stdcpp.string : core_basic_string = basic_string;
+    alias std_string = core_basic_string!(char);
+}
 
 extern(C++) void callback18955(ref const(std_string) str)
 {
 }
 extern(C++) void test18955();
+
+/****************************************/
+
+extern(C++) void testPreviewIn();
+
+extern(C++) void previewInFunction(in int a, in std_string b, ref const(std_string) c)
+{
+    assert(a == 42);
+    assert(&b is &c);
+}
 
 /****************************************/
 
@@ -1695,6 +1712,7 @@ void main()
     test18966();
     test19134();
     test18955();
+    testPreviewIn();
 
     printf("Success\n");
 }

--- a/test/runnable_cxx/extra-files/cppb.cpp
+++ b/test/runnable_cxx/extra-files/cppb.cpp
@@ -4,29 +4,7 @@
 #include <exception>
 #include <cstdarg>
 
-#if _WIN32 // otherwise defined in C header files!
-// https://issues.dlang.org/show_bug.cgi?id=18955
-namespace std
-{
-    template<typename Char>
-    struct char_traits
-    {
-    };
-    template<typename Char>
-    class allocator
-    {
-    };
-    template<typename Char, typename Traits, typename Alloc>
-    class basic_string
-    {
-    };
-    typedef basic_string<char, char_traits<char>, allocator<char> > string;
-}
-#else // if POSIX
-
 #include <string>
-
-#endif // _WIN32
 
 #include "cppb.h"
 
@@ -935,4 +913,12 @@ void test18955()
 #if !__APPLE__ && !__FreeBSD__
     callback18955(s);
 #endif
+}
+
+void previewInFunction(const int& a, const std::string& b, const std::string& c);
+
+void testPreviewIn()
+{
+    std::string s = "Hello World";
+    previewInFunction(42, s, s);
 }


### PR DESCRIPTION
```
The intent of `-preview=in` is to make `in` the go-to storage class for input parameters.
In doing so, it makes the ABI less obvious (although still deterministic),
by sometimes degrading the parameter from reference to a value if it is better ABI-wise.
This behavior is obviously at odds with non-`extern(D)` functions,
which expect to match a specific ABI, hence `in` parameters can no longer apply
to non-`extern(D)` or `extern(C++)` functions when `-preview=in` is used.

However, as C++, also have a "go to" storage class for input parameters (`const T&`),
`in` can also be applied on `extern(C++)` function in order to bind to `const T&` parameters.
When doing so, `in` will always mean `ref`. This also allows to expose a closer API
for a function than via `const ref`, as `in` will allow to bind rvalues to `const T&`, as in C++.
```

@kinke @ibuclaw : Any opinion on this ? If this is too much, I can see two other course of action:
- Disabling `in` for anything non-`extern(D)`;
- Making `in` always make `scope const` with `extern(C)`, never `ref`, disable for others;