### PR TITLE
Deprecate 'body' as a keyword

### DIFF
--- a/changelog/body-deprecation.dd
+++ b/changelog/body-deprecation.dd
@@ -1,0 +1,7 @@
+Usage of the `body` keyword has been deprecated
+
+Using `body` to indicate the body of a function or method
+in the presence of contracts is now deprecated.
+Any leftover usage of `body` can be replaced with `do`.
+This replacement, introduced by $(LINK2 DIP1003, https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1003.md),
+has been available since $(LINK2 DMD v2.075.0 (July 2017), https://github.com/dlang/dmd/pull/6855).

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -850,15 +850,14 @@ final class Parser(AST) : Lexer
                      tk.value == TOK.out_ || tk.value == TOK.do_ || tk.value == TOK.goesTo ||
                      tk.value == TOK.identifier && tk.ident == Id._body))
                 {
-                    version (none)
-                    {
-                        // This deprecation has been disabled for the time being, see PR10763
-                        // @@@DEPRECATED@@@
-                        // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
-                        // Deprecated in 2.091 - Can be removed from 2.101
-                        if (tk.value == TOK.identifier && tk.ident == Id._body)
-                            deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
-                    }
+                    // @@@DEPRECATED@@@
+                    // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                    // Deprecated in 2.097 - Can be removed from 2.117
+                    // The deprecation period is longer than usual as `body`
+                    // was quite widely used.
+                    if (tk.value == TOK.identifier && tk.ident == Id._body)
+                        deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
+
                     a = parseDeclarations(true, pAttrs, pAttrs.comment);
                     if (a && a.dim)
                         *pLastDecl = (*a)[a.dim - 1];
@@ -4758,15 +4757,14 @@ final class Parser(AST) : Lexer
                     (tk.value == TOK.leftParentheses || tk.value == TOK.leftCurly || tk.value == TOK.in_ || tk.value == TOK.out_ || tk.value == TOK.goesTo ||
                      tk.value == TOK.do_ || tk.value == TOK.identifier && tk.ident == Id._body))
                 {
-                    version (none)
-                    {
-                        // This deprecation has been disabled for the time being, see PR10763
-                        // @@@DEPRECATED@@@
-                        // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
-                        // Deprecated in 2.091 - Can be removed from 2.101
-                        if (tk.value == TOK.identifier && tk.ident == Id._body)
-                            deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
-                    }
+                    // @@@DEPRECATED@@@
+                    // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                    // Deprecated in 2.097 - Can be removed from 2.117
+                    // The deprecation period is longer than usual as `body`
+                    // was quite widely used.
+                    if (tk.value == TOK.identifier && tk.ident == Id._body)
+                        deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
+
                     ts = null;
                 }
                 else
@@ -5143,14 +5141,12 @@ final class Parser(AST) : Lexer
         case TOK.identifier:
             if (token.ident == Id._body)
             {
-                version (none)
-                {
-                    // This deprecation has been disabled for the time being, see PR10763
-                    // @@@DEPRECATED@@@
-                    // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
-                    // Deprecated in 2.091 - Can be removed from 2.101
-                    deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
-                }
+                // @@@DEPRECATED@@@
+                // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                // Deprecated in 2.097 - Can be removed from 2.117
+                // The deprecation period is longer than usual as `body`
+                // was quite widely used.
+                deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
                 goto case TOK.do_;
             }
             goto default;
@@ -7372,14 +7368,12 @@ final class Parser(AST) : Lexer
             case TOK.identifier:
                 if (t.ident == Id._body)
                 {
-                    version (none)
-                    {
-                        // This deprecation has been disabled for the time being, see PR10763
-                        // @@@DEPRECATED@@@
-                        // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
-                        // Deprecated in 2.091 - Can be removed from 2.101
-                        deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
-                    }
+                    // @@@DEPRECATED@@@
+                    // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                    // Deprecated in 2.097 - Can be removed from 2.117
+                    // The deprecation period is longer than usual as `body`
+                    // was quite widely used.
+                    deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
                     goto case TOK.do_;
                 }
                 goto default;

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -1,5 +1,21 @@
-// PERMUTE_ARGS: -inline -g -O
-
+/* PERMUTE_ARGS: -inline -g -O
+TEST_OUTPUT:
+---
+runnable/testcontracts.d(323): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(324): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(325): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(326): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(328): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(329): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(330): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(331): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(502): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(503): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(504): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(505): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+runnable/testcontracts.d(505): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+---
+*/
 extern(C) int printf(const char*, ...);
 
 /*******************************************/


### PR DESCRIPTION
Take 2! Below is the commit message:

This was first deprecated in #10693 (December 2019),
but was then reverted in #10763 to extend the transition period.
Since the replacement will have been available for 22 releases
(almost 4 years), it should be safe to deprecate now.