### PR TITLE
DIP1034 move support for noreturn to backend

### DIFF
--- a/src/dmd/backend/blockopt.d
+++ b/src/dmd/backend/blockopt.d
@@ -2390,6 +2390,9 @@ private void blassertsplit()
             goto L1;
         }
         b.Belem = bl_delist2(earray);
+        if (b.BC == BCretexp && !b.Belem)
+            b.Belem = el_long(TYint, 1);
+
     }
     elems.dtor();
 }

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -471,6 +471,16 @@ void genstackclean(ref CodeBuilder cdb,uint numpara,regm_t keepmsk)
 void logexp(ref CodeBuilder cdb, elem *e, int jcond, uint fltarg, code *targ)
 {
     //printf("logexp(e = %p, jcond = %d)\n", e, jcond);
+    if (tybasic(e.Ety) == TYnoreturn)
+    {
+        con_t regconsave = regcon;
+        regm_t retregs = 0;
+        codelem(cdb,e,&retregs,0);
+        regconsave.used |= regcon.used;
+        regcon = regconsave;
+        return;
+    }
+
     int no87 = (jcond & 2) == 0;
     docommas(cdb, &e);             // scan down commas
     cgstate.stackclean++;

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -612,6 +612,7 @@ regm_t regmask(tym_t tym, tym_t tyf)
     switch (tybasic(tym))
     {
         case TYvoid:
+        case TYnoreturn:
         case TYstruct:
         case TYarray:
             return 0;
@@ -1352,7 +1353,7 @@ regm_t allocretregs(const tym_t ty, type* t, const tym_t tyf, out reg_t reg1, ou
      */
 
     const tyb = tybasic(ty);
-    if (tyb == TYvoid)
+    if (tyb == TYvoid || tyb == TYnoreturn)
         return 0;
 
     tym_t ty1 = tyb;

--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -1936,6 +1936,7 @@ L1:
             break;
 
         case TYvoid:
+        case TYnoreturn:
         case TYchar:
         case TYschar:
         case TYuchar:

--- a/src/dmd/backend/evalu8.d
+++ b/src/dmd/backend/evalu8.d
@@ -258,6 +258,9 @@ int iftrue(elem *e)
             case OPstring:
                 return boolres(e);
 
+            case OPoror:
+                return tybasic(e.EV.E2.Ety) == TYnoreturn;
+
             default:
                 return false;
         }
@@ -283,6 +286,9 @@ int iffalse(elem *e)
 
             case OPconst:
                 return !boolres(e);
+
+            case OPandand:
+                return tybasic(e.EV.E2.Ety) == TYnoreturn;
 
             default:
                 return false;

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2176,12 +2176,12 @@ elem *toElem(Expression e, IRState *irs)
                             emsg = addressElem(emsg, Type.tvoid.arrayOf(), false);
 
                         ea = el_var(getRtlsym(ud ? RTLSYM_DUNITTEST_MSG : RTLSYM_DASSERT_MSG));
-                        ea = el_bin(OPcall, TYvoid, ea, el_params(el_long(TYint, ae.loc.linnum), efilename, emsg, null));
+                        ea = el_bin(OPcall, TYnoreturn, ea, el_params(el_long(TYint, ae.loc.linnum), efilename, emsg, null));
                     }
                     else
                     {
                         ea = el_var(getRtlsym(ud ? RTLSYM_DUNITTEST : RTLSYM_DASSERT));
-                        ea = el_bin(OPcall, TYvoid, ea, el_param(el_long(TYint, ae.loc.linnum), efilename));
+                        ea = el_bin(OPcall, TYnoreturn, ea, el_param(el_long(TYint, ae.loc.linnum), efilename));
                     }
                 }
                 else
@@ -2189,7 +2189,7 @@ elem *toElem(Expression e, IRState *irs)
                     auto eassert = el_var(getRtlsym(ud ? RTLSYM_DUNITTESTP : RTLSYM_DASSERTP));
                     auto efile = toEfilenamePtr(m);
                     auto eline = el_long(TYint, ae.loc.linnum);
-                    ea = el_bin(OPcall, TYvoid, eassert, el_param(eline, efile));
+                    ea = el_bin(OPcall, TYnoreturn, eassert, el_param(eline, efile));
                 }
                 if (einv)
                 {
@@ -3540,14 +3540,6 @@ elem *toElem(Expression e, IRState *irs)
 
             if (irs.params.cov && aae.e2.loc.linnum)
                 e.EV.E2 = el_combine(incUsageElem(irs, aae.e2.loc), e.EV.E2);
-
-            /* Until the backend understands TYnoreturn,
-             * resort to a workaround here.
-             * If aae.e2 is Tnoreturn, rewrite e as:
-             *   (e,false) for &&, and (e,true) for ||
-             */
-            if (aae.e2.type.ty == Tnoreturn)
-                e = el_combine(e, el_long(TYbool, aae.op == TOK.orOr));
 
             result = e;
         }
@@ -6474,7 +6466,7 @@ elem *callCAssert(IRState *irs, const ref Loc loc, Expression exp, Expression em
 elem *genHalt(const ref Loc loc)
 {
     elem *e = el_calloc();
-    e.Ety = TYvoid;
+    e.Ety = TYnoreturn;
     e.Eoper = OPhalt;
     elem_setLoc(e, loc);
     return e;

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1263,7 +1263,7 @@ tym_t totym(Type tx)
         case Tdelegate: t = TYdelegate; break;
         case Tarray:    t = TYdarray;   break;
         case Tsarray:   t = TYstruct;   break;
-        case Tnoreturn: t = TYvoid;     break;
+        case Tnoreturn: t = TYnoreturn; break;
 
         case Tstruct:
             t = TYstruct;

--- a/test/runnable/noreturn1.d
+++ b/test/runnable/noreturn1.d
@@ -3,6 +3,8 @@
 
 alias noreturn = typeof(*null);
 
+extern (C) noreturn exit();
+
 bool testf(int i)
 {
     return i && assert(0);
@@ -13,9 +15,28 @@ bool testt(int i)
     return i || assert(0);
 }
 
-void main()
+int test3(int i)
+{
+    if (i && exit())
+        return i + 1;
+    return i - 1;
+}
+
+int test4(int i)
+{
+    if (i || exit())
+        return i + 1;
+    return i - 1;
+}
+
+int main()
 {
     assert(testf(0) == false);
     assert(testt(1) == true);
+
+    assert(test3(0) == -1);
+    assert(test4(3) == 4);
+
+    return 0;
 }
 


### PR DESCRIPTION
and handles returning values from `e && noreturn` and `e || noreturn`, as seen in the added test cases