### PR TITLE
Fix Issue 16140 -  while(auto x = y) does not behave like if(auto x = y)

### DIFF
--- a/changelog/while-condition-assignment.dd
+++ b/changelog/while-condition-assignment.dd
@@ -1,0 +1,17 @@
+`while (auto n = expression)` is now supported
+
+Up until this release, `while (auto n = expression)` was not
+supported, although the `if` counterpart: `if (auto n = expression)`
+compiled succesfully. Starting with the current compiler version,
+`while (auto n = expression)` is accepted, having the exact
+same semantics as:
+
+---
+while (true)
+{
+    if (auto n = expression)
+    { /* loop body */ }
+    else
+    { break; }
+}
+---

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2130,11 +2130,12 @@ struct ASTBase
 
     extern (C++) final class WhileStatement : Statement
     {
+        Parameter param;
         Expression condition;
         Statement _body;
         Loc endloc;
 
-        extern (D) this(const ref Loc loc, Expression c, Statement b, Loc endloc)
+        extern (D) this(const ref Loc loc, Expression c, Statement b, Loc endloc, Parameter param = null)
         {
             super(loc, STMT.While);
             condition = c;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6070,6 +6070,7 @@ public:
 class WhileStatement final : public Statement
 {
 public:
+    Parameter* param;
     Expression* condition;
     Statement* _body;
     Loc endloc;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -250,6 +250,20 @@ public:
     override void visit(WhileStatement s)
     {
         buf.writestring("while (");
+        if (auto p = s.param)
+        {
+            // Print condition assignment
+            StorageClass stc = p.storageClass;
+            if (!p.type && !stc)
+                stc = STC.auto_;
+            if (stcToBuffer(buf, stc))
+                buf.writeByte(' ');
+            if (p.type)
+                typeToBuffer(p.type, p.ident, buf, hgs);
+            else
+                buf.writestring(p.ident.toString());
+            buf.writestring(" = ");
+        }
         s.condition.expressionToBuffer(buf, hgs);
         buf.writeByte(')');
         buf.writenl();

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1155,16 +1155,18 @@ extern (C++) final class ForwardingStatement : Statement
  */
 extern (C++) final class WhileStatement : Statement
 {
+    Parameter param;
     Expression condition;
     Statement _body;
     Loc endloc;             // location of closing curly bracket
 
-    extern (D) this(const ref Loc loc, Expression condition, Statement _body, Loc endloc)
+    extern (D) this(const ref Loc loc, Expression condition, Statement _body, Loc endloc, Parameter param = null)
     {
         super(loc, STMT.While);
         this.condition = condition;
         this._body = _body;
         this.endloc = endloc;
+        this.param = param;
     }
 
     override WhileStatement syntaxCopy()
@@ -1172,7 +1174,7 @@ extern (C++) final class WhileStatement : Statement
         return new WhileStatement(loc,
             condition.syntaxCopy(),
             _body ? _body.syntaxCopy() : null,
-            endloc);
+            endloc, param ? param.syntaxCopy() : null);
     }
 
     override bool hasBreak() const pure nothrow

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -277,6 +277,7 @@ public:
 class WhileStatement : public Statement
 {
 public:
+    Parameter *param;
     Expression *condition;
     Statement *_body;
     Loc endloc;                 // location of closing curly bracket

--- a/test/compilable/extra-files/header2.d
+++ b/test/compilable/extra-files/header2.d
@@ -162,6 +162,17 @@ align(2) struct S12200_2
 align(1):
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=16140
+void gun()()
+{
+    int[] res;
+    while (auto va = fun()) {}  // expression expected, not 'auto'
+
+    while (true)
+        if (auto va = fun()) {}
+        else break;
+}
+
 // https://issues.dlang.org/show_bug.cgi?id=16649
 void leFoo()()
 {

--- a/test/compilable/extra-files/header2.di
+++ b/test/compilable/extra-files/header2.di
@@ -117,6 +117,19 @@ align (2) struct S12200_2
 {
 	align (1) {}
 }
+void gun()()
+{
+	int[] res;
+	while (auto va = fun())
+	{
+	}
+	while (true)
+	if (auto va = fun())
+	{
+	}
+	else
+		break;
+}
 void leFoo()()
 {
 	sign = a == 2 ? false : (y < 0) ^ sign;

--- a/test/compilable/extra-files/header2i.di
+++ b/test/compilable/extra-files/header2i.di
@@ -219,6 +219,19 @@ align (2) struct S12200_2
 {
 	align (1) {}
 }
+void gun()()
+{
+	int[] res;
+	while (auto va = fun())
+	{
+	}
+	while (true)
+	if (auto va = fun())
+	{
+	}
+	else
+		break;
+}
 void leFoo()()
 {
 	sign = a == 2 ? false : (y < 0) ^ sign;

--- a/test/runnable/test16140.d
+++ b/test/runnable/test16140.d
@@ -1,0 +1,32 @@
+// https://issues.dlang.org/show_bug.cgi?id=16140
+
+int fun()
+{
+    static int count = 0;
+    if (count == 3)
+    {
+        count = 0;
+        return 0;
+    }
+    ++count;
+    return count;
+}
+
+void main()
+{
+    uint[] res;
+    while(auto value = fun())
+        res ~= value;
+    assert(res == [1, 2, 3]);
+
+    res.length = 0;
+    while(uint value = fun())
+        res ~= value;
+    assert(res == [1, 2, 3]);
+
+    res.length = 0;
+    while(const value = fun())
+        res ~= value;
+    assert(res == [1, 2, 3]);
+}
+


### PR DESCRIPTION
This includes:

 - make parser recognize `while(auto a = exp)`
 - add a field to `WhileStatement` to keep track of the defined variable
 - ~~rewrite the `while` loop to `for(auto a = exp; a; a = exp)`~~
 - update C++ headers
 - rewrite `while(auto a = exp)` to `while(true) if (auto a = exp) {/* loop body */ } else break;` as suggested by @schveiguy (thanks!). ~~The lowering is handled in the parser.~~ The lowering takes place during semantic analysis.
 - Update `hdrgen.d` to properly output the introduced `while` version.
 - Update `astbase.d`


I think a changelog entry might be necessary. What do you think?