### PR TITLE
fix Issue 18190 - [asan] heap-buffer-overflow in Module.load.checkModFileAlias

### DIFF
--- a/src/dmodule.c
+++ b/src/dmodule.c
@@ -195,7 +195,7 @@ static void checkModFileAlias(OutBuffer *buf, OutBuffer *dotmods,
         const char *m = (*ms)[j];
         const char *q = strchr(m, '=');
         assert(q);
-        if (dotmods->length() <= (size_t)(q - m) && memcmp(dotmods->peekChars(), m, q - m) == 0)
+        if (dotmods->length() == (size_t)(q - m) && memcmp(dotmods->peekChars(), m, q - m) == 0)
         {
             buf->reset();
             size_t qlen = strlen(q + 1);


### PR DESCRIPTION
It got picked up by asan testing gdc: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99337