### PR TITLE
Turn deprecation for ambiguous operations in ternary into errors

### DIFF
--- a/changelog/ambiguous-ternary.dd
+++ b/changelog/ambiguous-ternary.dd
@@ -1,0 +1,25 @@
+Deprecation period for ambiguous ternary expressions has ended
+
+In D, the ternary operator (`?:`) has a higher precedence than
+the assignment operator (`=`), hence:
+---
+true ? stt = "AA" : stt = "BB"
+---
+
+actually means:
+---
+(true ? (stt = "AA") : stt) = "BB",
+---
+
+This is in line with C, and many other languages (except C++),
+but comes at a surprise to many, which is why this specific combination
+of ternary and assignment was deprecated in v2.082.0 (2018-09-01).
+
+The deprecation instructs the user to use parenthesis to make the
+intent explicit, so the above snippet should read as:
+---
+true ? (stt = "AA") : (stt = "BB")
+---
+
+This deprecation period has now ended and the compiler will now issue
+an error for ambiguous code.

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -9010,10 +9010,8 @@ final class Parser(AST) : Lexer
             return e;
 
         // require parens for e.g. `t ? a = 1 : b = 2`
-        // Deprecated in 2018-05.
-        // @@@DEPRECATED_2.091@@@.
         if (e.op == TOK.question && !e.parens && precedence[token.value] == PREC.assign)
-            dmd.errors.deprecation(e.loc, "`%s` must be surrounded by parentheses when next to operator `%s`",
+            dmd.errors.error(e.loc, "`%s` must be surrounded by parentheses when next to operator `%s`",
                 e.toChars(), Token.toChars(token.value));
 
         const loc = token.loc;

--- a/test/fail_compilation/bug18743.d
+++ b/test/fail_compilation/bug18743.d
@@ -1,9 +1,9 @@
-// REQUIRED_ARGS: -de
+// REQUIRED_ARGS:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug18743.d(18): Deprecation: `a ? a = 4 : a` must be surrounded by parentheses when next to operator `=`
-fail_compilation/bug18743.d(19): Deprecation: `a ? --a : a` must be surrounded by parentheses when next to operator `+=`
+fail_compilation/bug18743.d(18): Error: `a ? a = 4 : a` must be surrounded by parentheses when next to operator `=`
+fail_compilation/bug18743.d(19): Error: `a ? --a : a` must be surrounded by parentheses when next to operator `+=`
 ---
 */
 


### PR DESCRIPTION
Those have been deprecated for a while, time to move it into an error.