### PR TITLE
Fix 21682 - checkaction=context fails for expressions using static...

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6084,6 +6084,17 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 op = op.expressionSemantic(sc);
                 op = resolveProperties(sc, op);
 
+                // Detect assert's using static operator overloads (e.g. `"var" in environment`)
+                if (auto te = op.isTypeExp())
+                {
+                    // Replace the TypeExp with it's textual representation
+                    // Including "..." in the error message isn't quite right but
+                    // proper solutions require more drastic changes, e.g. directly
+                    // using miniFormat and combine instead of calling _d_assert_fail
+                    auto name = new StringExp(te.loc, te.toString());
+                    return name.expressionSemantic(sc);
+                }
+
                 // Create a temporary for expressions with side effects
                 // Defensively assume that function calls may have side effects even
                 // though it's not detected by hasSideEffect (e.g. `debug puts("Hello")` )

--- a/test/runnable/testassert.d
+++ b/test/runnable/testassert.d
@@ -324,6 +324,28 @@ void testTupleFormat()
     }
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=21682
+void testStaticOperators()
+{
+    static class environment {
+        static bool opCmp(scope const(char)[] name)
+        {
+            return false;
+        }
+
+        static bool opBinaryRight(string op : "in")(scope const(char)[] name)
+        {
+            return false;
+        }
+    }
+
+    string msg = getMessage(assert(environment < "Hello"));
+    assert(msg == `"environment" >= "Hello"`);
+
+    msg = getMessage(assert("Hello" in environment));
+    assert(msg == `"Hello" !in "environment"`);
+}
+
 void main()
 {
     test8765();
@@ -335,4 +357,5 @@ void main()
     testUnaryFormat();
     testAssignments();
     testTupleFormat();
+    testStaticOperators();
 }


### PR DESCRIPTION
... operator overloads.

Detect `TypeExp`'s and replace them with their identifiers.