### PR TITLE
Fix Issue 20581 - DIP1000 wrongly flags hidden ref temporary

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1643,12 +1643,37 @@ extern (C++) class VarDeclaration : Declaration
      */
     final bool enclosesLifetimeOf(VarDeclaration v) const pure
     {
-        // FIXME: VarDeclaration's for parameters are created in semantic3, so
-        //        they will have a greater sequence number than local variables.
-        //        Hence reverse the result for mixed comparisons.
-        const exp = this.isParameter() == v.isParameter();
+        // VarDeclaration's with these STC's need special treatment
+        enum special = STC.temp | STC.foreach_;
 
-        return (sequenceNumber < v.sequenceNumber) == exp;
+        // Sequence numbers work when there are no special VarDeclaration's involved
+        if (!((this.storage_class | v.storage_class) & special))
+        {
+            // FIXME: VarDeclaration's for parameters are created in semantic3, so
+            //        they will have a greater sequence number than local variables.
+            //        Hence reverse the result for mixed comparisons.
+            const exp = this.isParameter() == v.isParameter();
+
+            return (this.sequenceNumber < v.sequenceNumber) == exp;
+        }
+
+        // Assume that semantic produces temporaries according to their lifetime
+        // (It won't create a temporary before the actual content)
+        if ((this.storage_class & special) && (v.storage_class & special))
+            return this.sequenceNumber < v.sequenceNumber;
+
+        // Fall back to lexical order
+        assert(this.loc != Loc.initial);
+        assert(v.loc != Loc.initial);
+
+        if (auto ld = this.loc.linnum - v.loc.linnum)
+            return ld < 0;
+
+        if (auto cd = this.loc.charnum - v.loc.charnum)
+            return cd < 0;
+
+        // Default fallback
+        return this.sequenceNumber < v.sequenceNumber;
     }
 
     /***************************************

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -776,8 +776,7 @@ ByRef:
 
         // If va's lifetime encloses v's, then error
         if (va &&
-            (va.enclosesLifetimeOf(v) && !(v.storage_class & STC.parameter) ||
-             va.storage_class & STC.ref_ ||
+            (va.enclosesLifetimeOf(v) && !(v.isParameter() && v.isRef()) ||
              va.isDataseg()) &&
             sc.func.setUnsafe())
         {

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1680,7 +1680,7 @@ extern (C++) final class SwitchStatement : Statement
         {
             for (auto v = vd; v && v != lastVar; v = v.lastVar)
             {
-                if (v.isDataseg() || (v.storage_class & (STC.manifest | STC.temp)) || v._init.isVoidInitializer())
+                if (v.isDataseg() || (v.storage_class & (STC.manifest | STC.temp) && vd.ident != Id.withSym) || v._init.isVoidInitializer())
                     continue;
                 if (vd.ident == Id.withSym)
                     error("`switch` skips declaration of `with` temporary at %s", v.loc.toChars());

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3803,6 +3803,7 @@ else
             {
                 _init = new ExpInitializer(ws.loc, ws.exp);
                 ws.wthis = new VarDeclaration(ws.loc, ws.exp.type, Id.withSym, _init);
+                ws.wthis.storage_class |= STC.temp;
                 ws.wthis.dsymbolSemantic(sc);
 
                 sym = new WithScopeSymbol(ws);
@@ -3833,6 +3834,7 @@ else
                 Expression e = ws.exp.addressOf();
                 _init = new ExpInitializer(ws.loc, e);
                 ws.wthis = new VarDeclaration(ws.loc, e.type, Id.withSym, _init);
+                ws.wthis.storage_class |= STC.temp;
                 ws.wthis.dsymbolSemantic(sc);
                 sym = new WithScopeSymbol(ws);
                 // Need to set the scope to make use of resolveAliasThis

--- a/test/compilable/scope.d
+++ b/test/compilable/scope.d
@@ -165,16 +165,44 @@ void demangle() @safe
     {
         const(char)[] s;
 
+        @safe:
         @property bool empty() const { return !s.length; }
 
-        @property const(char)[] front() const return { return s; }
+        @property const(char)[] front() const return
+        {
+            immutable i = indexOfDot();
+            return s;
+        }
 
         void popFront() {}
+
+        private ptrdiff_t indexOfDot() const
+        {
+            return -1;
+        }
     }
 
     foreach (comp; DotSplitter(""))
     {
         const copy = comp;
+    }
+}
+
+void fileCtor() @safe
+{
+    static struct S
+    {
+        int i;
+    }
+
+    // static S get()
+    // {
+    //     return S();
+    // }
+
+    with (S())
+    {
+        int* ptr = &i;
     }
 }
 

--- a/test/runnable/testassert.d
+++ b/test/runnable/testassert.d
@@ -200,6 +200,24 @@ void test21471()
     }
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=20581
+void test20581() @safe
+{
+    static auto retro(return scope int[] s) @safe
+    {
+        static struct R
+        {
+            int[] source;
+        }
+        return R(s);
+    }
+
+    int[5] a = [ 1, 2, 3, 4, 5 ];
+    // Creates ref temporary __assertTmpXXXX for source
+    // Error: address of variable a assigned to __assertOp27 with longer lifetime
+    assert(retro(a[]).source is a[]);
+}
+
 string getMessage(T)(lazy T expr) @trusted
 {
     try
@@ -353,6 +371,7 @@ void main()
     test20114();
     test20375();
     test21471();
+    test20581();
     testMixinExpression();
     testUnaryFormat();
     testAssignments();


### PR DESCRIPTION
Restrict errors for escaping by ref to `VarDeclaration`'s that actually outlive the referenced `VarDeclaration`.

The only exceptions to this rule are references to other `ref` parameters