### PR TITLE
Add error message when warnings-as-errors is enabled and a warning occurs

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -288,6 +288,15 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     }
 
     /*
+    Print a message to make it clear when warnings are treated as errors.
+    */
+    static void errorOnWarning()
+    {
+        error(Loc.initial, "warnings are treated as errors");
+        errorSupplemental(Loc.initial, "Use -wi if you wish to treat warnings only as informational.");
+    }
+
+    /*
     Generates code to check for all `params` whether any usage page
     has been requested.
     If so, the generated code will print the help page of the flag
@@ -625,6 +634,9 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         }
     }
 
+    if (global.warnings)
+        errorOnWarning();
+
     // Do not attempt to generate output files if errors or warnings occurred
     if (global.errors || global.warnings)
         removeHdrFilesAndFail(params, modules);
@@ -771,6 +783,9 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     // Output the makefile dependencies
     if (params.emitMakeDeps)
         emitMakeDeps(params, library);
+
+    if (global.warnings)
+        errorOnWarning();
 
     if (global.errors || global.warnings)
         removeHdrFilesAndFail(params, modules);

--- a/test/fail_compilation/b3841.d
+++ b/test/fail_compilation/b3841.d
@@ -3,21 +3,23 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/b3841.d-mixin-30(30): Warning: `char += float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `int += float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `long += double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `char -= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `int -= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `long -= double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `char *= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `int *= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `long *= double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `char /= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `int /= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `long /= double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `char %= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `int %= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-30(30): Warning: `long %= double` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `char += float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `int += float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `long += double` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `char -= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `int -= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `long -= double` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `char *= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `int *= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `long *= double` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `char /= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `int /= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `long /= double` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `char %= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `int %= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-32(32): Warning: `long %= double` is performing truncating conversion
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/ddoc_18083.d
+++ b/test/fail_compilation/ddoc_18083.d
@@ -1,8 +1,10 @@
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/fail_compilation -o- -w -c
 /* TEST_OUTPUT:
 ---
-fail_compilation/ddoc_18083.d(12): Warning: Ddoc: function declaration has no parameter 'this'
-fail_compilation/ddoc_18083.d(12): Warning: Ddoc: parameter count mismatch, expected 0, got 1
+fail_compilation/ddoc_18083.d(14): Warning: Ddoc: function declaration has no parameter 'this'
+fail_compilation/ddoc_18083.d(14): Warning: Ddoc: parameter count mismatch, expected 0, got 1
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 /**

--- a/test/fail_compilation/fail3882.d
+++ b/test/fail_compilation/fail3882.d
@@ -33,8 +33,10 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3882.d(46): Warning: calling `fail3882.f1` without side effects discards return value of type `int`; prepend a `cast(void)` if intentional
-fail_compilation/fail3882.d(47): Warning: calling `fail3882.f2` without side effects discards return value of type `int`; prepend a `cast(void)` if intentional
+fail_compilation/fail3882.d(48): Warning: calling `fail3882.f1` without side effects discards return value of type `int`; prepend a `cast(void)` if intentional
+fail_compilation/fail3882.d(49): Warning: calling `fail3882.f2` without side effects discards return value of type `int`; prepend a `cast(void)` if intentional
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375a.d
+++ b/test/fail_compilation/fail4375a.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375a.d(14): Warning: else is dangling, add { } after condition at fail_compilation/fail4375a.d(11)
+fail_compilation/fail4375a.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375a.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375b.d
+++ b/test/fail_compilation/fail4375b.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375b.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375b.d(12)
+fail_compilation/fail4375b.d(18): Warning: else is dangling, add { } after condition at fail_compilation/fail4375b.d(14)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375c.d
+++ b/test/fail_compilation/fail4375c.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375c.d(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375c.d(11)
+fail_compilation/fail4375c.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375c.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375d.d
+++ b/test/fail_compilation/fail4375d.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375d.d(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375d.d(11)
+fail_compilation/fail4375d.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375d.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375e.d
+++ b/test/fail_compilation/fail4375e.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375e.d(14): Warning: else is dangling, add { } after condition at fail_compilation/fail4375e.d(11)
+fail_compilation/fail4375e.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375e.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375f.d
+++ b/test/fail_compilation/fail4375f.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375f.d(14): Warning: else is dangling, add { } after condition at fail_compilation/fail4375f.d(11)
+fail_compilation/fail4375f.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375f.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375g.d
+++ b/test/fail_compilation/fail4375g.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375g.d(14): Warning: else is dangling, add { } after condition at fail_compilation/fail4375g.d(11)
+fail_compilation/fail4375g.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375g.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375h.d
+++ b/test/fail_compilation/fail4375h.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375h.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375h.d(13)
+fail_compilation/fail4375h.d(18): Warning: else is dangling, add { } after condition at fail_compilation/fail4375h.d(15)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375i.d
+++ b/test/fail_compilation/fail4375i.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375i.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375i.d(11)
+fail_compilation/fail4375i.d(18): Warning: else is dangling, add { } after condition at fail_compilation/fail4375i.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375j.d
+++ b/test/fail_compilation/fail4375j.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375j.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375j.d(11)
+fail_compilation/fail4375j.d(18): Warning: else is dangling, add { } after condition at fail_compilation/fail4375j.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375k.d
+++ b/test/fail_compilation/fail4375k.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375k.d-mixin-11(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375k.d-mixin-11(12)
+fail_compilation/fail4375k.d-mixin-13(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375k.d-mixin-13(14)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375l.d
+++ b/test/fail_compilation/fail4375l.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375l.d(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375l.d(11)
+fail_compilation/fail4375l.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375l.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375m.d
+++ b/test/fail_compilation/fail4375m.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375m.d(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375m.d(12)
+fail_compilation/fail4375m.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375m.d(14)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375o.d
+++ b/test/fail_compilation/fail4375o.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375o.d(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375o.d(11)
+fail_compilation/fail4375o.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375o.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375r.d
+++ b/test/fail_compilation/fail4375r.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375r.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375r.d(11)
+fail_compilation/fail4375r.d(19): Warning: else is dangling, add { } after condition at fail_compilation/fail4375r.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375s.d
+++ b/test/fail_compilation/fail4375s.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375s.d(17): Warning: else is dangling, add { } after condition at fail_compilation/fail4375s.d(11)
+fail_compilation/fail4375s.d(19): Warning: else is dangling, add { } after condition at fail_compilation/fail4375s.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375t.d
+++ b/test/fail_compilation/fail4375t.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375t.d(14): Warning: else is dangling, add { } after condition at fail_compilation/fail4375t.d(11)
+fail_compilation/fail4375t.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375t.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375u.d
+++ b/test/fail_compilation/fail4375u.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375u.d(13): Warning: else is dangling, add { } after condition at fail_compilation/fail4375u.d(11)
+fail_compilation/fail4375u.d(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375u.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375v.d
+++ b/test/fail_compilation/fail4375v.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375v.d(13): Warning: else is dangling, add { } after condition at fail_compilation/fail4375v.d(11)
+fail_compilation/fail4375v.d(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375v.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375w.d
+++ b/test/fail_compilation/fail4375w.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375w.d(13): Warning: else is dangling, add { } after condition at fail_compilation/fail4375w.d(11)
+fail_compilation/fail4375w.d(15): Warning: else is dangling, add { } after condition at fail_compilation/fail4375w.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375x.d
+++ b/test/fail_compilation/fail4375x.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375x.d(14): Warning: else is dangling, add { } after condition at fail_compilation/fail4375x.d(11)
+fail_compilation/fail4375x.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375x.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/fail4375y.d
+++ b/test/fail_compilation/fail4375y.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4375y.d(16): Warning: else is dangling, add { } after condition at fail_compilation/fail4375y.d(11)
+fail_compilation/fail4375y.d(18): Warning: else is dangling, add { } after condition at fail_compilation/fail4375y.d(13)
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/testpull1810.d
+++ b/test/fail_compilation/testpull1810.d
@@ -2,7 +2,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/testpull1810.d(19): Warning: statement is not reachable
+fail_compilation/testpull1810.d(21): Warning: statement is not reachable
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/warn12809.d
+++ b/test/fail_compilation/warn12809.d
@@ -41,6 +41,8 @@ TEST_OUTPUT:
 fail_compilation/warn12809.d(108): Warning: statement is not reachable
 fail_compilation/warn12809.d(115): Warning: statement is not reachable
 fail_compilation/warn12809.d(122): Warning: statement is not reachable
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 

--- a/test/fail_compilation/warn13679.d
+++ b/test/fail_compilation/warn13679.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/warn13679.d(13): Warning: cannot use `foreach_reverse` with an associative array
+fail_compilation/warn13679.d(15): Warning: cannot use `foreach_reverse` with an associative array
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
 ---
 */
 


### PR DESCRIPTION
When a warning is present and `-w` or `-wi` are specified, there's no distinguishable difference between the two other than the exit code.

For experienced users, this may not be an issue. But for those new to dlang, this is confusing especially when a build system sits between the actual dmd call and the user. For example, dub will set `-w` by default (arguably a good idea!), so any project with a warning will fail to build. Consider this minimal example:
```
mkdir temp && cd temp
dub init   # follow prompts
echo "void main() { return; return; }" > source/app.d
dub build
```
outputs:
```
Performing "debug" build using /home/jasonbcox/dlang/dmd-2.095.1/linux/bin64/dmd for x86_64.
temp ~master: building configuration "application"...
source/app.d(1,23): Warning: statement is not reachable
/home/jasonbcox/dlang/dmd-2.095.1/linux/bin64/dmd failed with exit code 1.
```

Note how the setting of `-w` was entirely transparent to the user. `dub --verbose build` reveals this:
```
...
/home/jasonbcox/dlang/dmd-2.095.1/linux/bin64/dmd -c -of.dub/build/application-debug-linux.posix-x86_64-dmd_v2.095.1-8E4EC762B1E2DF13226E5C3C5525727C/temp.o -debug -g -w -version=Have_temp -Isource/ source/app.d -vcolumns
...
```

Notice the `-w` tucked away in there? Ya, I missed it the first time too. In a larger project, my first instinct was to hunt for some other issue that was causing the compiler to fail. It wasn't until I narrowed down the culprit lines that I realized the warning was causing a failure.

This patch amends the situation by providing a loud-and-clear message that the warnings are treated as errors when `-w` is set.