### PR TITLE
Fix enclosesLifetimeOf for function parameters

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1643,7 +1643,12 @@ extern (C++) class VarDeclaration : Declaration
      */
     final bool enclosesLifetimeOf(VarDeclaration v) const pure
     {
-        return sequenceNumber < v.sequenceNumber;
+        // FIXME: VarDeclaration's for parameters are created in semantic3, so
+        //        they will have a greater sequence number than local variables.
+        //        Hence reverse the result for mixed comparisons.
+        const exp = this.isParameter() == v.isParameter();
+
+        return (sequenceNumber < v.sequenceNumber) == exp;
     }
 
     /***************************************

--- a/test/compilable/scope.d
+++ b/test/compilable/scope.d
@@ -114,3 +114,45 @@ void test_20682(scope ref D d) @safe
     a ~= f2_20682(d);
     a ~= cast(int) d.p;
 }
+
+// Phobos failure
+void formattedWrite(immutable char[2] args) @safe
+{
+    scope immutable char[] val = args;
+}
+
+void ctfeRead(const ubyte[2] array) @safe
+{
+    short result;
+
+    foreach_reverse (b; array)
+        result = cast(short) ((result << 8) | b);
+
+    foreach (b; array)
+        result = cast(short) ((result << 8) | b);
+}
+
+void demangle() @safe
+{
+    static struct DotSplitter
+    {
+        const(char)[] s;
+
+        @property bool empty() const { return !s.length; }
+
+        @property const(char)[] front() const return { return s; }
+
+        void popFront() {}
+    }
+
+    foreach (comp; DotSplitter(""))
+    {
+        const copy = comp;
+    }
+}
+
+// Missing test coverage
+int*[4] testArray() @safe
+{
+    return typeof(return).init;
+}

--- a/test/fail_compilation/fail20108.d
+++ b/test/fail_compilation/fail20108.d
@@ -2,7 +2,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20108.d(13): Error: scope variable `x` may not be returned
+fail_compilation/fail20108.d(15): Error: address of variable `y` assigned to `x` with longer lifetime
+fail_compilation/fail20108.d(16): Error: scope variable `x` may not be returned
+fail_compilation/fail20108.d(23): Error: address of variable `y` assigned to `x` with longer lifetime
+fail_compilation/fail20108.d(24): Error: scope variable `x` may not be returned
 ---
 */
 
@@ -13,7 +16,16 @@ fail_compilation/fail20108.d(13): Error: scope variable `x` may not be returned
     return x;
 }
 
+@safe auto test2()
+{
+    scope int* x;
+    int y = 69;
+    x = &y; //bad
+    return x;
+}
+
 void main()
 {
     auto y = test(null);
+    auto z = test2();
 }

--- a/test/fail_compilation/retscope6.d
+++ b/test/fail_compilation/retscope6.d
@@ -170,3 +170,31 @@ T9 testfred()
     return fred(&i);   // error
 }
 
+/* TEST_OUTPUT:
+---
+fail_compilation/retscope6.d(10003): Error: scope variable `values` assigned to non-scope parameter `values` calling retscope6.escape
+---
+*/
+
+#line 10000
+
+void variadicCaller(int[] values...)
+{
+    escape(values);
+}
+
+void escape(int[] values) {}
+
+/* TEST_OUTPUT:
+---
+fail_compilation/retscope6.d(11004): Error: address of variable `buffer` assigned to `secret` with longer lifetime
+---
+*/
+
+#line 11000
+
+void hmac(scope ubyte[] secret)
+{
+    ubyte[10] buffer;
+    secret = buffer[];
+}


### PR DESCRIPTION
Extracted from #12258 because other parts of DIP1000 rely on this bug.

CC @RazvanN7, the fix for [bug 20108](https://issues.dlang.org/show_bug.cgi?id=20108) implemented in #10285 is affected. 