### PR TITLE
fix Issue 21684 - Assert fail for Win32 with a struct larger than 64k…

### DIFF
--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -2764,8 +2764,6 @@ static uint storelength(uint length,uint i)
     if (length >= 128)  // Microsoft docs say 129, but their linker
                         // won't take >=128, so accommodate it
     {   obj.extdata[i] = 129;
-        debug
-        assert(length <= 0xFFFF);
 
         TOWORD(obj.extdata.ptr + i + 1,length);
         if (length >= 0x10000)

--- a/test/compilable/fix21684.d
+++ b/test/compilable/fix21684.d
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=21684
+
+
+struct S
+{
+    int[100_000] a;
+}


### PR DESCRIPTION
… in size

It was just a debug assert tripping with a debug build of the compiler.