### PR TITLE
DIP1034: convert noreturn blocks into BCexit blocks

### DIFF
--- a/src/dmd/backend/blockopt.d
+++ b/src/dmd/backend/blockopt.d
@@ -932,6 +932,22 @@ private void bropt()
                 pn = &((*pn).EV.E2);
 
         elem *n = *pn;
+
+        /* look for conditional that never returns */
+        if (n && tybasic(n.Ety) == TYnoreturn && b.BC != BCexit)
+        {
+            b.BC = BCexit;
+            // Exit block has no successors, so remove them
+            foreach (bp; ListRange(b.Bsucc))
+            {
+                list_subtract(&(list_block(bp).Bpred),b);
+            }
+            list_free(&b.Bsucc, FPNULL);
+            debug if (debugc) printf("CHANGE: noreturn becomes BCexit\n");
+            go.changes++;
+            continue;
+        }
+
         if (b.BC == BCiftrue)
         {
             assert(n);

--- a/test/compilable/noreturn1.d
+++ b/test/compilable/noreturn1.d
@@ -9,3 +9,13 @@ alias noreturn = typeof(*null);
 pragma(msg, noreturn);
 
 noreturn exits(int* p) { *p = 3; }
+
+noreturn exit();
+
+int test1(int i)
+{
+    if (exit())
+        return i + 1;
+    return i - 1;
+}
+


### PR DESCRIPTION
This is an optimization, as it deletes code that is never executed.