### PR TITLE
Issue 21693 - Lower scoped destruction of extern(C++) class to destroy/dtor call

### DIFF
--- a/test/runnable/cppdtor.d
+++ b/test/runnable/cppdtor.d
@@ -3,21 +3,39 @@ https://issues.dlang.org/show_bug.cgi?id=21693
 
 RUN_OUTPUT:
 ---
-4: C.~this
-4: B.~this
-4: A.~this
-3: C.~this
-3: B.~this
-3: A.~this
-2: B.~this
-2: A.~this
-1: A.~this
+CppA:
+1: CppA.~this
+CppB:
+2: CppB.~this
+2: CppA.~this
+CppC:
+3: CppC.~this
+3: CppB.~this
+3: CppA.~this
+CppC:
+4: CppC.~this
+4: CppB.~this
+4: CppA.~this
+CppNoDestruct:
+DA:
+1: DA.~this
+DB:
+2: DB.~this
+2: DA.~this
+DC:
+3: DC.~this
+3: DB.~this
+3: DA.~this
+DC:
+4: DC.~this
+4: DB.~this
+4: DA.~this
 ---
 */
 
 extern (C) int printf(scope const char*, ...);
 
-extern (C++) class A
+extern (C++) class CppA
 {
 	int num;
 	this(int num)
@@ -27,11 +45,11 @@ extern (C++) class A
 
 	~this()
 	{
-		printf("%d: A.~this\n", num);
+		printf("%d: CppA.~this\n", num);
 	}
 }
 
-extern (C++) class B : A
+extern (C++) class CppB : CppA
 {
 	this(int num)
 	{
@@ -40,11 +58,11 @@ extern (C++) class B : A
 
 	~this()
 	{
-		printf("%d: B.~this\n", num);
+		printf("%d: CppB.~this\n", num);
 	}
 }
 
-extern (C++) class C : B
+extern (C++) class CppC : CppB
 {
 	this(int num)
 	{
@@ -53,11 +71,51 @@ extern (C++) class C : B
 
 	~this()
 	{
-		printf("%d: C.~this\n", num);
+		printf("%d: CppC.~this\n", num);
 	}
 }
 
-extern (C++) class NoDestruct
+extern (D) class DA
+{
+	int num;
+	this(int num)
+	{
+		this.num = num;
+	}
+
+	~this()
+	{
+		printf("%d: DA.~this\n", num);
+	}
+}
+
+extern (D) class DB : DA
+{
+	this(int num)
+	{
+		super(num);
+	}
+
+	~this()
+	{
+		printf("%d: DB.~this\n", num);
+	}
+}
+
+extern (D) class DC : DB
+{
+	this(int num)
+	{
+		super(num);
+	}
+
+	~this()
+	{
+		printf("%d: DC.~this\n", num);
+	}
+}
+
+extern (C++) class CppNoDestruct
 {
 	int num;
 	this(int num)
@@ -68,13 +126,18 @@ extern (C++) class NoDestruct
 
 void main()
 {
+	printf("CppA:\n"); { scope a = new CppA(1);			}
+	printf("CppB:\n"); { scope CppA b = new CppB(2);	}
+	printf("CppC:\n"); { scope CppA c = new CppC(3);	}
+	printf("CppC:\n"); { scope CppB c2 = new CppC(4);	}
+
+	printf("CppNoDestruct:\n");
 	{
-		scope a = new A(1);
-		scope A b = new B(2);
-		scope A c = new C(3);
-		scope B c2 = new C(4);
+		scope const nd = new CppNoDestruct(1);
 	}
-	{
-		scope const nd = new NoDestruct(1);
-	}
+
+	printf("DA:\n"); { scope a = new DA(1);		}
+	printf("DB:\n"); { scope DA b = new DB(2);	}
+	printf("DC:\n"); { scope DA c = new DC(3);	}
+	printf("DC:\n"); { scope DB c2 = new DC(4);	}
 }

--- a/test/runnable/cppdtor.d
+++ b/test/runnable/cppdtor.d
@@ -1,0 +1,80 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=21693
+
+RUN_OUTPUT:
+---
+4: C.~this
+4: B.~this
+4: A.~this
+3: C.~this
+3: B.~this
+3: A.~this
+2: B.~this
+2: A.~this
+1: A.~this
+---
+*/
+
+extern (C) int printf(scope const char*, ...);
+
+extern (C++) class A
+{
+	int num;
+	this(int num)
+	{
+		this.num = num;
+	}
+
+	~this()
+	{
+		printf("%d: A.~this\n", num);
+	}
+}
+
+extern (C++) class B : A
+{
+	this(int num)
+	{
+		super(num);
+	}
+
+	~this()
+	{
+		printf("%d: B.~this\n", num);
+	}
+}
+
+extern (C++) class C : B
+{
+	this(int num)
+	{
+		super(num);
+	}
+
+	~this()
+	{
+		printf("%d: C.~this\n", num);
+	}
+}
+
+extern (C++) class NoDestruct
+{
+	int num;
+	this(int num)
+	{
+		this.num = num;
+	}
+}
+
+void main()
+{
+	{
+		scope a = new A(1);
+		scope A b = new B(2);
+		scope A c = new C(3);
+		scope B c2 = new C(4);
+	}
+	{
+		scope const nd = new NoDestruct(1);
+	}
+}


### PR DESCRIPTION
Ensures proper RAII behaviour for stack allocated instances but doesn't affect the behaviour for heap allocated instances.

The previous rewrite used `delete` which relies on `TypeInfo` and crashed at runtime. Using `object.destroy` circumvents this issue (and is also beneficial due to the deprecation of `delete`).

`destroy` can be used instead of `delete` because the instances live on the heap and hence don't need to be deallocated.