### PR TITLE
DIP1034 support noreturn as leaves of ?:

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -11500,11 +11500,19 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         Type t1 = exp.e1.type;
         Type t2 = exp.e2.type;
+        if (t1.ty == Tnoreturn)
+        {
+            exp.type = t2;
+        }
+        else if (t2.ty == Tnoreturn)
+        {
+            exp.type = t1;
+        }
         // If either operand is void the result is void, we have to cast both
         // the expression to void so that we explicitly discard the expression
         // value if any
         // https://issues.dlang.org/show_bug.cgi?id=16598
-        if (t1.ty == Tvoid || t2.ty == Tvoid)
+        else if (t1.ty == Tvoid || t2.ty == Tvoid)
         {
             exp.type = Type.tvoid;
             exp.e1 = exp.e1.castTo(sc, exp.type);

--- a/test/runnable/noreturn1.d
+++ b/test/runnable/noreturn1.d
@@ -1,9 +1,8 @@
-
-/*****************************************/
-
 alias noreturn = typeof(*null);
 
 extern (C) noreturn exit();
+
+/*****************************************/
 
 bool testf(int i)
 {
@@ -15,28 +14,61 @@ bool testt(int i)
     return i || assert(0);
 }
 
-int test3(int i)
+int testa(int i)
 {
     if (i && exit())
         return i + 1;
     return i - 1;
 }
 
-int test4(int i)
+int testb(int i)
 {
     if (i || exit())
         return i + 1;
     return i - 1;
 }
 
-int main()
+void test1()
 {
     assert(testf(0) == false);
     assert(testt(1) == true);
 
-    assert(test3(0) == -1);
-    assert(test4(3) == 4);
-
-    return 0;
+    assert(testa(0) == -1);
+    assert(testb(3) == 4);
 }
 
+/*****************************************/
+
+noreturn exit1() { assert(0); }
+noreturn exit2() { assert(0); }
+
+
+int heli1(int i)
+{
+    return i ? exit1() : i - 1;
+}
+
+int heli2(int i)
+{
+    return i ? i - 1 : exit1();
+}
+
+noreturn heli3(int i)
+{
+    return i ? exit1() : exit2();
+}
+
+void test2()
+{
+    assert(heli1(0) == -1);
+    assert(heli2(1) == 0);
+}
+
+/*****************************************/
+
+int main()
+{
+    test1();
+    test2();
+    return 0;
+}


### PR DESCRIPTION
by rewriting them in terms of && and ||, which is already handled.