### PR TITLE
Fix 21709 - Don't generate try-catch in betterC code for dtorfields

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1376,7 +1376,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
          * https://issues.dlang.org/show_bug.cgi?id=14246
          */
         AggregateDeclaration ad = ctor.isMemberDecl();
-        if (ctor.fbody && ad && ad.fieldDtor && global.params.dtorFields && !ctor.type.toTypeFunction.isnothrow)
+        if (ctor.fbody && ad && ad.fieldDtor && global.params.dtorFields && !global.params.betterC && !ctor.type.toTypeFunction.isnothrow)
         {
             /* Generate:
              *   this.fieldDtor()

--- a/test/compilable/dtorfields.d
+++ b/test/compilable/dtorfields.d
@@ -1,4 +1,7 @@
 // REQUIRED_ARGS: -preview=dtorfields
+//
+// https://issues.dlang.org/show_bug.cgi?id=21709
+// PERMUTE_ARGS: -betterC
 
 /******************************************
  * https://issues.dlang.org/show_bug.cgi?id=20934


### PR DESCRIPTION
The code may never throw exceptions in betterC mode, so it cannot abort the ctor with an uncaught exception.