### PR TITLE
Fix 19387 - Mark generated postblits as scope

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -280,7 +280,7 @@ private FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         checkShared();
         auto dd = new PostBlitDeclaration(declLoc, Loc.initial, stc, Id.__fieldPostblit);
         dd.generated = true;
-        dd.storage_class |= STC.inference;
+        dd.storage_class |= STC.inference | STC.scope_;
         dd.fbody = (stc & STC.disable) ? null : new CompoundStatement(loc, postblitCalls);
         sd.postblits.shift(dd);
         sd.members.push(dd);

--- a/test/compilable/scope.d
+++ b/test/compilable/scope.d
@@ -79,6 +79,33 @@ struct Constant
     alias Repeat(T...) = T;
 }
 
+
+/************************************/
+
+// https://issues.dlang.org/show_bug.cgi?id=19387
+
+struct C
+{
+  void* u;
+  this(this) @safe
+  {
+  }
+}
+
+struct S
+{
+  C c;
+}
+
+void foo(scope S s) @safe
+{
+}
+
+void bar(scope S s) @safe
+{
+  foo(s);
+}
+
 /************************************/
 
 // https://issues.dlang.org/show_bug.cgi?id=20675


### PR DESCRIPTION
Otherwise the postblit is not callable when compiling with DIP 1000.
(Assigning scope ... to non-scope `this`)