### PR TITLE
fix Issue 21726 - Wrong comparison in package(...) visibilities

### DIFF
--- a/changelog/package-visibility.dd
+++ b/changelog/package-visibility.dd
@@ -1,0 +1,18 @@
+Explicit package visibility attribute is now always applied to new scopes
+
+If a less restrictive package attribute appeared within the scope of another
+package attribute, the more restrictive parent would override any explicit
+child visibility.
+
+Example:
+---
+module pkg.foo;
+
+package(pkg.foo):           // analogous to "private" or plain "package"
+
+package(pkg) int bar();     // package(pkg) was being ignored
+---
+
+Starting from this version, the package visibility attribute is now always
+applied as long as it is valid.  In the given example, this allows any module
+in the package `pkg` to import and use the symbol `bar`.

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -88,8 +88,8 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         if (stc != sc.stc ||
             linkage != sc.linkage ||
             cppmangle != sc.cppmangle ||
-            !visibility.isSubsetOf(sc.visibility) ||
             explicitVisibility != sc.explicitVisibility ||
+            visibility != sc.visibility ||
             aligndecl !is sc.aligndecl ||
             inlining != sc.inlining)
         {

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -184,34 +184,6 @@ struct Visibility
         }
         return false;
     }
-
-    extern (C++):
-
-    /**
-     * Checks if parent defines different access restrictions than this one.
-     *
-     * Params:
-     *  parent = visibility attribute for scope that hosts this one
-     *
-     * Returns:
-     *  'true' if parent is already more restrictive than this one and thus
-     *  no differentiation is needed.
-     */
-    bool isSubsetOf(ref const Visibility parent) const
-    {
-        if (this.kind != parent.kind)
-            return false;
-        if (this.kind == Visibility.Kind.package_)
-        {
-            if (!this.pkg)
-                return true;
-            if (!parent.pkg)
-                return false;
-            if (parent.pkg.isAncestorPackageOf(this.pkg))
-                return true;
-        }
-        return true;
-    }
 }
 
 enum PASS : int

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -103,8 +103,6 @@ struct Visibility
     };
     Kind kind;
     Package *pkg;
-
-    bool isSubsetOf(const Visibility& other) const;
 };
 
 /* State of symbol in winding its way through the passes of the compiler

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -968,7 +968,6 @@ struct Visibility
 {
     Kind kind;
     Package* pkg;
-    bool isSubsetOf(const Visibility& parent) const;
     Visibility() :
         pkg()
     {

--- a/test/compilable/issue21726.d
+++ b/test/compilable/issue21726.d
@@ -1,0 +1,2 @@
+// EXTRA_SOURCES: protection/issue21726/typecons.d
+// https://issues.dlang.org/show_bug.cgi?id=21726

--- a/test/compilable/protection/issue21726/format/package.d
+++ b/test/compilable/protection/issue21726/format/package.d
@@ -1,0 +1,7 @@
+module protection.issue21726.format;
+
+package(protection.issue21726.format):
+
+package(protection.issue21726) int issuePkgSym;
+package(protection) int protectionPkgSym();
+int formatPkgSym;

--- a/test/compilable/protection/issue21726/package.d
+++ b/test/compilable/protection/issue21726/package.d
@@ -1,0 +1,1 @@
+module protection.issue21726;

--- a/test/compilable/protection/issue21726/typecons.d
+++ b/test/compilable/protection/issue21726/typecons.d
@@ -1,0 +1,6 @@
+module protection.issue21726.typecons;
+
+import protection.issue21726.format : issuePkgSym;
+import protection.issue21726.format : protectionPkgSym;
+static assert(!__traits(compiles,
+                        { import protection.issue21726.format : formatPkgSym; }));


### PR DESCRIPTION
For the purpose of creating a new scope, it makes no sense to let the most restrictive package attributes override any other nested visibility attributes.  As there is no other use of isSubsetOf(), the entire function has been removed.