### PR TITLE
Fix issue 21687 - Confusing error message for CTFE

### DIFF
--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -382,7 +382,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
             return new ErrorInitializer();
         }
         uint olderrors = global.errors;
-        Expression currExp = i.exp;     // Save current Expression
+        Expression currExp = i.exp;     // Save current Expression (https://issues.dlang.org/show_bug.cgi?id=21687)
         if (needInterpret)
         {
             // If the result will be implicitly cast, move the cast into CTFE

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -382,6 +382,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
             return new ErrorInitializer();
         }
         uint olderrors = global.errors;
+        Expression currExp = i.exp;
         if (needInterpret)
         {
             // If the result will be implicitly cast, move the cast into CTFE
@@ -421,7 +422,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
         // Make sure all pointers are constants
         if (needInterpret && hasNonConstPointers(i.exp))
         {
-            i.exp.error("cannot use non-constant CTFE pointer in an initializer `%s`", i.exp.toChars());
+            i.exp.error("cannot use non-constant CTFE pointer in an initializer `%s`", currExp.toChars());
             return new ErrorInitializer();
         }
         Type tb = t.toBasetype();

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -382,7 +382,11 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
             return new ErrorInitializer();
         }
         uint olderrors = global.errors;
-        Expression currExp = i.exp;     // Save current Expression (https://issues.dlang.org/show_bug.cgi?id=21687)
+        /* Save the expression before ctfe
+         * Otherwise the error message would contain for example "&[0][0]" instead of "new int"
+         * Regression: https://issues.dlang.org/show_bug.cgi?id=21687
+         */
+        Expression currExp = i.exp;
         if (needInterpret)
         {
             // If the result will be implicitly cast, move the cast into CTFE

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -382,7 +382,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
             return new ErrorInitializer();
         }
         uint olderrors = global.errors;
-        Expression currExp = i.exp;
+        Expression currExp = i.exp;     // Save current Expression
         if (needInterpret)
         {
             // If the result will be implicitly cast, move the cast into CTFE

--- a/test/fail_compilation/test15989.d
+++ b/test/fail_compilation/test15989.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/test15989.d(39): Error: variable `test15989.main.ctRegex` : Unable to initialize enum with class or pointer to struct. Use static const variable instead.
 fail_compilation/test15989.d(48): Error: variable `test15989.test.c` : Unable to initialize enum with class or pointer to struct. Use static const variable instead.
-fail_compilation/test15989.d(49): Error: cannot use non-constant CTFE pointer in an initializer `&[3][0]`
+fail_compilation/test15989.d(49): Error: cannot use non-constant CTFE pointer in an initializer `new int(3)`
 ---
 */
 


### PR DESCRIPTION
Probably needs a "proper" fix, but this works for now.

The initializer expression appears in the source code as `new int`, but is printed as `&[0][0]`

This patch changes the error message to show the expression before ctfeInterpret, for example `new int` instead of `&[0][0]`