### PR TITLE
Fix 21739 - Don't merge `debug case` into previous CaseStatement

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2022,6 +2022,9 @@ struct ASTBase
         nothrow pure @nogc
         inout(ReturnStatement) isReturnStatement() inout { return stmt == STMT.Return ? cast(typeof(return))this : null; }
 
+        nothrow pure @nogc
+        inout(BreakStatement) isBreakStatement() inout { return stmt == STMT.Break ? cast(typeof(return))this : null; }
+
         override void accept(Visitor v)
         {
             v.visit(this);

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -6211,7 +6211,16 @@ LagainStc:
                     auto statements = new AST.Statements();
                     while (token.value != TOK.case_ && token.value != TOK.default_ && token.value != TOK.endOfFile && token.value != TOK.rightCurly)
                     {
-                        statements.push(parseStatement(ParseStatementFlags.semi | ParseStatementFlags.curlyScope));
+                        auto cur = parseStatement(ParseStatementFlags.semi | ParseStatementFlags.curlyScope);
+                        statements.push(cur);
+
+                        // https://issues.dlang.org/show_bug.cgi?id=21739
+                        // Stop at the last break s.t. the following non-case statements are
+                        // not merged into the current case. This can happen for
+                        // case 1: ... break;
+                        // debug { case 2: ... }
+                        if (cur.isBreakStatement())
+                            break;
                     }
                     s = new AST.CompoundStatement(loc, statements);
                 }

--- a/test/fail_compilation/debugCaseDeclaration.d
+++ b/test/fail_compilation/debugCaseDeclaration.d
@@ -1,0 +1,39 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=21739
+
+REQUIRED_ARGS: -debug
+TEST_OUTPUT:
+---
+fail_compilation/debugCaseDeclaration.d(22): Error: undefined identifier `x`
+fail_compilation/debugCaseDeclaration.d(33): Error: undefined identifier `y`
+---
+*/
+
+void main()
+{
+    int i, k;
+    switch (i)
+    {
+        case 0:
+            int x;
+            break;
+
+        case 1:
+            x = 1;
+            break;
+
+        case 2:
+            int y;
+            break;
+
+        debug
+        {
+            case 3:
+                k = 1; // Valid
+                y = 1; // Invalid but accepted
+                break;
+        }
+
+        default:
+    }
+}


### PR DESCRIPTION
The previous implementation assumed that `CaseStatement`s would be seperated by a top-level `case ...`. This is not the case for conditionally compiled cases, e.g. `debug { case ...: }`.

---

Not sure if this is the best solution, maybe it should rather be fixed during semantic instead of the parser.