### PR TITLE
fix Issue 19443 - core.simd generates MOVLPS instead of MOVHLPS

### DIFF
--- a/src/dmd/backend/xmm.d
+++ b/src/dmd/backend/xmm.d
@@ -74,7 +74,6 @@ enum
     LODDQU   = 0xF30F6F,        // MOVDQU xmm1, xmm2/mem128  F3 0F 6F /r
     STODQU   = 0xF30F7F,        // MOVDQU xmm1/mem128, xmm2  F3 0F 7F /r
     MOVDQ2Q  = 0xF20FD6,        // MOVDQ2Q mmx, xmm          F2 0F D6 /r
-    MOVHLPS  = 0x0F12,          // MOVHLPS xmm1, xmm2        0F 12 /r
     LODHPD   = 0x660F16,        // MOVHPD xmm, mem64         66 0F 16 /r
     STOHPD   = 0x660F17,        // MOVHPD mem64, xmm         66 0F 17 /r
     LODHPS   = 0x0F16,          // MOVHPS xmm, mem64         0F 16 /r
@@ -82,6 +81,7 @@ enum
     MOVLHPS  = 0x0F16,          // MOVLHPS xmm1, xmm2        0F 16 /r
     LODLPD   = 0x660F12,        // MOVLPD xmm, mem64         66 0F 12 /r
     STOLPD   = 0x660F13,        // MOVLPD mem64, xmm         66 0F 13 /r
+    MOVHLPS  = 0x0F12,          // MOVHLPS xmm1, xmm2        0F 12 /r
     LODLPS   = 0x0F12,          // MOVLPS xmm, mem64         0F 12 /r
     STOLPS   = 0x0F13,          // MOVLPS mem64, xmm         0F 13 /r
     MOVMSKPD = 0x660F50,        // MOVMSKPD reg32, xmm 66 0F 50 /r

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -2217,6 +2217,19 @@ void test19788()
 }
 
 /*****************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19443
+
+void test19443()
+{
+    float4 a = [1.0f, 2.0f, 3.0f, 4.0f];
+    float4 b = [5.0f, 6.0f, 7.0f, 8.0f];
+    float4 r = cast(float4) __simd(XMM.MOVHLPS, a, b);
+    float[4] correct = [7.0f, 8.0f, 3.0f, 4.0f];
+    assert(r.array == correct); // FAIL, produces [5, 6, 3, 4] instead
+}
+
+
+/*****************************************/
 
 int main()
 {
@@ -2266,6 +2279,7 @@ int main()
     test21364();
     test19632();
     test19788();
+    test19443();
 
     return 0;
 }


### PR DESCRIPTION
cdvector() failed to distinguish between LODLPS and MOVHPS instructions, which differ in the second operand rather than in the opcode.