### PR TITLE
Fix Issue 21742 - dot template expressions don't have the void type like any template

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6379,11 +6379,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DotTemplateExp e)
     {
+        if (e.type)
+        {
+            result = e;
+            return;
+        }
         if (Expression ex = unaSemantic(e, sc))
         {
             result = ex;
             return;
         }
+        // 'void' like TemplateExp
+        e.type = Type.tvoid;
         result = e;
     }
 

--- a/test/compilable/test21742.d
+++ b/test/compilable/test21742.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=21742
+
+int foo()() { return 0; }
+
+struct B
+{
+    int foo()() { return 0; }
+}
+
+static assert(is(typeof(foo) == void));
+
+// failed, gagged error: expression B().foo()() has no type
+static assert(is(typeof(B().foo) == void));

--- a/test/fail_compilation/fail7424b.d
+++ b/test/fail_compilation/fail7424b.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424b.d(10): Error: cannot resolve type for this.g()()
+fail_compilation/fail7424b.d(10): Error: expression `this.g()()` is `void` and has no value
 ---
 */
 struct S7424b

--- a/test/fail_compilation/fail7424c.d
+++ b/test/fail_compilation/fail7424c.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424c.d(10): Error: cannot resolve type for this.g()()
+fail_compilation/fail7424c.d(10): Error: expression `this.g()()` is `void` and has no value
 ---
 */
 struct S7424c

--- a/test/fail_compilation/fail7424d.d
+++ b/test/fail_compilation/fail7424d.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424d.d(10): Error: cannot resolve type for this.g()()
+fail_compilation/fail7424d.d(10): Error: expression `this.g()()` is `void` and has no value
 ---
 */
 struct S7424d

--- a/test/fail_compilation/fail7424e.d
+++ b/test/fail_compilation/fail7424e.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424e.d(10): Error: cannot resolve type for this.g()()
+fail_compilation/fail7424e.d(10): Error: expression `this.g()()` is `void` and has no value
 ---
 */
 struct S7424e

--- a/test/fail_compilation/fail7424f.d
+++ b/test/fail_compilation/fail7424f.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424f.d(10): Error: cannot resolve type for this.g()()
+fail_compilation/fail7424f.d(10): Error: expression `this.g()()` is `void` and has no value
 ---
 */
 struct S7424f

--- a/test/fail_compilation/fail7424g.d
+++ b/test/fail_compilation/fail7424g.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424g.d(10): Error: cannot resolve type for this.g()()
+fail_compilation/fail7424g.d(10): Error: expression `this.g()()` is `void` and has no value
 ---
 */
 struct S7424g

--- a/test/fail_compilation/fail7424h.d
+++ b/test/fail_compilation/fail7424h.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424h.d(10): Error: cannot resolve type for this.g()()
+fail_compilation/fail7424h.d(10): Error: expression `this.g()()` is `void` and has no value
 ---
 */
 struct S7424g

--- a/test/fail_compilation/fail7424i.d
+++ b/test/fail_compilation/fail7424i.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424i.d(10): Error: cannot resolve type for this.g()()
+fail_compilation/fail7424i.d(10): Error: expression `this.g()()` is `void` and has no value
 ---
 */
 struct S7424g


### PR DESCRIPTION
Note: There is a line of code on phobos depending on this bug.