### PR TITLE
Fix Issue 21743 - getOverloads fails to propagate 'this' expression …

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1169,7 +1169,10 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                                 td.overroot = null;
                                 td.overnext = null;
                             }
-                            exps.push(new DsymbolExp(Loc.initial, td, false));
+
+                            auto e = ex ? new DotTemplateExp(Loc.initial, ex, td)
+                                        : new DsymbolExp(Loc.initial, td);
+                            exps.push(e);
                         }
                     }
                     return 0;

--- a/test/compilable/test21743.d
+++ b/test/compilable/test21743.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=21743
+
+struct A
+{
+    int foo(int a) { return a; }
+    string foo()(string b) { return b; }
+}
+
+alias ov = __traits(getOverloads, A.init, "foo", true);
+
+// member function works
+static assert(ov[0](1) == 1);
+
+// member template failed, gagged error:
+// 'need this for foo of type pure nothrow @nogc @safe string(string b)'
+static assert(ov[1]("a") == "a");

--- a/test/compilable/test21743.d
+++ b/test/compilable/test21743.d
@@ -11,6 +11,6 @@ alias ov = __traits(getOverloads, A.init, "foo", true);
 // member function works
 static assert(ov[0](1) == 1);
 
-// member template failed, gagged error:
+// member template used to fail with the gagged error:
 // 'need this for foo of type pure nothrow @nogc @safe string(string b)'
 static assert(ov[1]("a") == "a");


### PR DESCRIPTION
…for template member.

This fix depends on #12294 