### PR TITLE
fix Issue 21672 - [REG][ICE][SIMD] accessing SIMD type as a short cau…

### DIFF
--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -1578,6 +1578,11 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                     s.Sflags &= ~GTregcand;
                 }
             }
+            else if (sz == 2 && tyxmmreg(s.ty()) && config.fpxmmregs)
+            {
+                debug if (debugr) printf("'%s' not XMM reg cand due to short access\n", s.Sident.ptr);
+                s.Sflags &= ~GTregcand;
+            }
             else if (e.EV.Voffset || sz > tysize(s.Stype.Tty))
             {
                 debug if (debugr) printf("'%s' not reg cand due to offset or size\n", s.Sident.ptr);

--- a/test/compilable/test21672.d
+++ b/test/compilable/test21672.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -mcpu=avx2 -O
+// DISABLED: win32 linux32 freebsd32
+
+// https://issues.dlang.org/show_bug.cgi?id=21672
+
+import core.simd;
+
+int4 _mm_loadu_si16(const(void)* mem_addr) pure @trusted
+{
+    int r = *cast(short*)(mem_addr);
+    short8 result = [0, 0, 0, 0, 0, 0, 0, 0];
+    result.ptr[0] = cast(short)r;
+    return cast(int4)result;
+}


### PR DESCRIPTION
…ses compiler ice

The problem here is there is no instruction to access an XMM register by a short, so the compiler would assert. The fix is to not enregister a variable accessed via a short into an XMM register.

This problem didn't crop up with byte access because GTbyte would get set for those symbols, and inadvertently the register allocator didn't regard XMM registers as having byte access.