### PR TITLE
Fix 21752 - Template constraint breaks nested eponymeous template

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -808,7 +808,9 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
              */
             for (Scope* scx = paramscope.callsc; scx; scx = scx.callsc)
             {
-                if (scx == p.sc)
+                // The first scx might be identical for nested eponymeous templates, e.g.
+                // template foo() { void foo()() {...} }
+                if (scx == p.sc && scx !is paramscope.callsc)
                     return false;
             }
             /* BUG: should also check for ref param differences

--- a/test/compilable/nested_template_constraints.d
+++ b/test/compilable/nested_template_constraints.d
@@ -1,0 +1,27 @@
+// https://issues.dlang.org/show_bug.cgi?id=21752
+
+void foo(A)(A a)
+{}
+
+template foo()
+{
+	void foo()()
+	if (true)  // Comment this constraint to make it pass
+	{}
+}
+
+template bar()
+{
+	template bar()
+	{
+		void bar()()
+		if (true)  // Comment this constraint to make it pass
+		{}
+	}
+}
+
+void main()
+{
+	foo!()();
+	bar!()();
+}


### PR DESCRIPTION
The `callsc` can be identical for deeply nested eponymeous templates or
while doing overload resolution, so ignore the failure if it's the first
checked scope.

CC @rainers because this modifies the check from #10239