### PR TITLE
Fix 21765 - Assignment-as-condition error with checkaction=context

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6121,7 +6121,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             return left;
 
                         // Sanity check that `op` can be converted to boolean
-                        op.toBoolean(sc);
+                        // But don't raise errors for assignments enclosed in another expression
+                        if (op is exp.e1)
+                            op.toBoolean(sc);
                     }
 
                     // Tuples with side-effects already receive a temporary during semantic

--- a/test/compilable/test20100.d
+++ b/test/compilable/test20100.d
@@ -40,3 +40,11 @@ void main() {
     assert(!arr.ptr);
     assert(arr.ptr is arr.ptr);
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=21765
+ref int func21765(int);
+void test21765()
+{
+    assert((func21765(1) = 2) == 2);
+    assert((1.func21765 = 2) == 2);
+}


### PR DESCRIPTION
Don't eagerly check `toBoolean` if `op` is nested in another expression.
This still catches `assert((a = 1))` but prevents invalid errors for
assignments in `assert((a = 1) == 1)`.