### PR TITLE
dmd.cli: Document the -fPIE command-line option

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -349,6 +349,10 @@ dmd -cov -unittest myprog.d
             "generate position independent code",
             cast(TargetOS) (TargetOS.all & ~(TargetOS.Windows | TargetOS.OSX))
         ),
+        Option("fPIE",
+            "generate position independent executables",
+            cast(TargetOS) (TargetOS.all & ~(TargetOS.Windows | TargetOS.OSX))
+        ),
         Option("g",
             "add symbolic debug info",
             `$(WINDOWS


### PR DESCRIPTION
As this is not present of the dlang site.
https://dlang.org/dmd-linux.html#switch-fPIC