### PR TITLE
DWARF: Bump `.debug_line` to version 3

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -570,7 +570,7 @@ static if (1)
 
         const byte line_base = -5;
         const ubyte line_range = 14;
-        const ubyte opcode_base = 10;
+        const ubyte opcode_base = 13;
 
         public uint[TYMAX] typidx_tab;
     }
@@ -1056,10 +1056,8 @@ static if (1)
 
             debug_line.initialize();
 
-            auto getDebugLineHeader(ushort hversion)()
+            void writeDebugLineHeader(ushort hversion)()
             {
-                static assert(hversion == 3);
-
                 struct DebugLineHeader
                 {
                 align (1):
@@ -1071,7 +1069,7 @@ static if (1)
                     byte line_base = .line_base;
                     ubyte line_range = .line_range;
                     ubyte opcode_base = .opcode_base;
-                    ubyte[9] sol =
+                    ubyte[12] standard_opcode_lengths =
                     [
                         0,      // DW_LNS_copy
                         1,      // DW_LNS_advance_pc
@@ -1082,19 +1080,29 @@ static if (1)
                         0,      // DW_LNS_set_basic_block
                         0,      // DW_LNS_const_add_pc
                         1,      // DW_LNS_fixed_advance_pc
+                        0,      // DW_LNS_set_prologue_end
+                        0,      // DW_LNS_set_epilogue_begin
+                        0,      // DW_LNS_set_isa
                     ];
                 }
-                static assert(DebugLineHeader.sizeof == 24);
-                // 6.2.5.2 Standard Opcodes
-                static assert(DebugLineHeader.sol.length == opcode_base - 1);
 
-                return DebugLineHeader.init;
+                static if (hversion == 3)
+                    static assert(DebugLineHeader.sizeof == 27);
+                else
+                    static assert(0);
+
+                auto lineHeader = DebugLineHeader.init;
+
+                // 6.2.5.2 Standard Opcodes
+                static assert(DebugLineHeader.standard_opcode_lengths.length == opcode_base - 1);
+
+                lineHeaderLengthOffset = lineHeader.header_length.offsetof;
+
+                debug_line.buf.writen(&lineHeader, lineHeader.sizeof);
             }
 
-            auto lineHeader = getDebugLineHeader!3();
-            debug_line.buf.writen(&lineHeader, lineHeader.sizeof);
+            writeDebugLineHeader!3();
 
-            lineHeaderLengthOffset = lineHeader.header_length.offsetof;
 
             // include_directories
             version (SCPP)
@@ -1371,7 +1379,8 @@ static if (1)
         assert(debug_line.buf.length() == linebuf_filetab_end);
         debug_line.buf.writeByte(0);              // end of file_names
 
-        rewrite32(debug_line.buf, lineHeaderLengthOffset, cast(uint) debug_line.buf.length() - 10);
+        rewrite32(debug_line.buf, lineHeaderLengthOffset, cast(uint) (debug_line.buf.length() - lineHeaderLengthOffset - 4));
+        // end of debug_line header
 
         for (uint seg = 1; seg < SegData.length; seg++)
         {

--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -566,7 +566,7 @@ static if (1)
 
         // .debug_line
         size_t linebuf_filetab_end;
-        size_t linePrologueLengthOffset;
+        size_t lineHeaderLengthOffset;
 
         const byte line_base = -5;
         const ubyte line_range = 14;
@@ -1065,7 +1065,7 @@ static if (1)
                 align (1):
                     uint length;
                     ushort version_= hversion;
-                    uint prologue_length;
+                    uint header_length;
                     ubyte minimum_instruction_length = 1;
                     bool default_is_stmt = true;
                     byte line_base = .line_base;
@@ -1094,7 +1094,7 @@ static if (1)
             auto lineHeader = getDebugLineHeader!3();
             debug_line.buf.writen(&lineHeader, lineHeader.sizeof);
 
-            linePrologueLengthOffset = lineHeader.prologue_length.offsetof;
+            lineHeaderLengthOffset = lineHeader.header_length.offsetof;
 
             // include_directories
             version (SCPP)
@@ -1371,7 +1371,7 @@ static if (1)
         assert(debug_line.buf.length() == linebuf_filetab_end);
         debug_line.buf.writeByte(0);              // end of file_names
 
-        rewrite32(debug_line.buf, linePrologueLengthOffset, cast(uint) debug_line.buf.length() - 10);
+        rewrite32(debug_line.buf, lineHeaderLengthOffset, cast(uint) debug_line.buf.length() - 10);
 
         for (uint seg = 1; seg < SegData.length; seg++)
         {
@@ -1466,7 +1466,7 @@ static if (1)
 
         // Bugzilla 3502, workaround OSX's ld64-77 bug.
         // Don't emit the the debug_line section if nothing has been written to the line table.
-        if (*cast(uint*) &debug_line.buf.buf[linePrologueLengthOffset] + 10 == debug_line.buf.length())
+        if (*cast(uint*) &debug_line.buf.buf[lineHeaderLengthOffset] + 10 == debug_line.buf.length())
             debug_line.buf.reset();
 
         /* ================================================= */


### PR DESCRIPTION
The field `version` of `.debug_line` was specified as 3, but in fact, emitted the version 2.
That was not causing any issues because the `opcode_base` and the `standard opcode lengths` fields are backward-compatible. The only difference between v2 and v3 are those fields.