### PR TITLE
Remove references to the 'trig' math module

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7627,7 +7627,6 @@ struct Id
     static Identifier* etc;
     static Identifier* attribute;
     static Identifier* math;
-    static Identifier* trig;
     static Identifier* sin;
     static Identifier* cos;
     static Identifier* tan;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -359,7 +359,6 @@ immutable Msgtable[] msgtable =
     { "etc" },
     { "attribute" },
     { "math" },
-    { "trig" },
     { "sin" },
     { "cos" },
     { "tan" },

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -509,9 +509,8 @@ int intrinsic_op(FuncDeclaration fd)
     // ... except std.math package and core.stdc.stdarg.va_start.
     if (md.packages.length == 2)
     {
-        if (id2 == Id.trig &&
-            md.packages[1] == Id.math &&
-            id1 == Id.std)
+        // Matches any module in std.math.*
+        if (md.packages[1] == Id.math && id1 == Id.std)
         {
             goto Lstdmath;
         }


### PR DESCRIPTION
This was never pursued, and now the "revamp" of converting std.math into a package uses a more verbose naming convention (dlang/phobos#7924).