### PR TITLE
Fix 21779 - Don't generate messages for disabled assertions

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6045,7 +6045,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             printf("AssertExp::semantic('%s')\n", exp.toChars());
         }
 
-        const generateMsg = !exp.msg && global.params.checkAction == CHECKACTION.context;
+        const generateMsg = !exp.msg && global.params.checkAction == CHECKACTION.context && global.params.useAssert == CHECKENABLE.on;
         Expression temporariesPrefix;
 
         if (generateMsg)

--- a/test/runnable/testassert_release.d
+++ b/test/runnable/testassert_release.d
@@ -1,0 +1,18 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=21779
+
+PERMUTE_ARGS: -checkaction=context
+ARG_SETS: -release
+ARG_SETS: -check=assert=off
+*/
+
+int boo()
+{
+	assert(false);
+}
+
+extern(C) int main()
+{
+	assert(boo());
+	return 0;
+}


### PR DESCRIPTION
Only generate messages when the assert is not omitted due to `-release` or `-check=assert=off`. 
The rewrite to create a temporary seems to prevent the ellision (and is a waste of time anyways).