### PR TITLE
dmd.target: Add TargetC.twchar_t for representing C wchar_t type

### DIFF
--- a/src/dmd/chkformat.d
+++ b/src/dmd/chkformat.d
@@ -269,8 +269,7 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
                 break;
 
             case Format.ls:     // pointer to wchar_t string
-                const twchar_t = global.params.targetOS == TargetOS.Windows ? Twchar : Tdchar;
-                if (!(t.ty == Tpointer && tnext.ty == twchar_t))
+                if (!(t.ty == Tpointer && tnext == target.c.twchar_t))
                     errorMsg(null, slice, e, "wchar_t*", t);
                 break;
 
@@ -481,8 +480,7 @@ bool checkScanfFormat(ref const Loc loc, scope const char[] format, scope Expres
 
             case Format.lc:
             case Format.ls:     // pointer to wchar_t string
-                const twchar_t = global.params.targetOS == TargetOS.Windows ? Twchar : Tdchar;
-                if (!(t.ty == Tpointer && tnext.ty == twchar_t))
+                if (!(t.ty == Tpointer && tnext == target.c.twchar_t))
                     errorMsg(null, slice, e, "wchar_t*", t);
                 break;
 

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -36,6 +36,7 @@ import dmd.root.outbuffer;
 import dmd.root.rmem;
 import dmd.root.speller;
 import dmd.statement;
+import dmd.target;
 import dmd.tokens;
 
 //version=LOGSEARCH;
@@ -578,6 +579,7 @@ struct Scope
      */
     extern (D) static const(char)* search_correct_C(Identifier ident)
     {
+        import dmd.mtype : Twchar;
         TOK tok;
         if (ident == Id.NULL)
             tok = TOK.null_;
@@ -588,7 +590,7 @@ struct Scope
         else if (ident == Id.unsigned)
             tok = TOK.uns32;
         else if (ident == Id.wchar_t)
-            tok = global.params.targetOS == TargetOS.Windows ? TOK.wchar_ : TOK.dchar_;
+            tok = target.c.twchar_t.ty == Twchar ? TOK.wchar_ : TOK.dchar_;
         else
             return null;
         return Token.toChars(tok);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1554,14 +1554,17 @@ struct TargetC
 {
     uint32_t longsize;
     uint32_t long_doublesize;
+    Type* twchar_t;
     TargetC() :
         longsize(),
-        long_doublesize()
+        long_doublesize(),
+        twchar_t()
     {
     }
-    TargetC(uint32_t longsize, uint32_t long_doublesize = 0u) :
+    TargetC(uint32_t longsize, uint32_t long_doublesize = 0u, Type* twchar_t = nullptr) :
         longsize(longsize),
-        long_doublesize(long_doublesize)
+        long_doublesize(long_doublesize),
+        twchar_t(twchar_t)
         {}
 };
 
@@ -6583,7 +6586,7 @@ public:
         RealProperties()
     {
     }
-    Target(uint32_t ptrsize, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u), TargetCPP cpp = TargetCPP(false, false, false), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
+    Target(uint32_t ptrsize, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, nullptr), TargetCPP cpp = TargetCPP(false, false, false), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
         ptrsize(ptrsize),
         realsize(realsize),
         realpad(realpad),

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -949,6 +949,7 @@ struct TargetC
 {
     uint longsize;            /// size of a C `long` or `unsigned long` type
     uint long_doublesize;     /// size of a C `long double`
+    Type twchar_t;            /// C `wchar_t` type
 
     extern (D) void initialize(ref const Param params, ref const Target target)
     {
@@ -971,6 +972,10 @@ struct TargetC
             long_doublesize = 8;
         else
             long_doublesize = target.realsize;
+        if (params.targetOS == TargetOS.Windows)
+            twchar_t = Type.twchar;
+        else
+            twchar_t = Type.tdchar;
     }
 }
 

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -29,6 +29,7 @@ struct TargetC
 {
     unsigned longsize;            // size of a C 'long' or 'unsigned long' type
     unsigned long_doublesize;     // size of a C 'long double'
+    Type *twchar_t;               // C 'wchar_t' type
 };
 
 struct TargetCPP


### PR DESCRIPTION
Replaces unwanted checks for `TargetOS.Windows` in the front-end.