### PR TITLE
dmd.target: Add TargetCPP.derivedClassOffset

### DIFF
--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -574,9 +574,10 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
             assert(baseClass.sizeok == Sizeok.done);
 
             alignsize = baseClass.alignsize;
-            structsize = baseClass.structsize;
-            if (classKind == ClassKind.cpp && global.params.targetOS == TargetOS.Windows)
-                structsize = (structsize + alignsize - 1) & ~(alignsize - 1);
+            if (classKind == ClassKind.cpp)
+                structsize = target.cpp.derivedClassOffset(baseClass);
+            else
+                structsize = baseClass.structsize;
         }
         else if (classKind == ClassKind.objc)
             structsize = 0; // no hidden member for an Objective-C class

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1576,6 +1576,7 @@ struct TargetCPP
     const char* typeMangle(Type* t);
     Type* parameterType(Parameter* p);
     bool fundamentalType(const Type* const t, bool& isFundamental);
+    uint32_t derivedClassOffset(ClassDeclaration* baseClass);
     TargetCPP() :
         reverseOverloads(),
         exceptions(),

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1093,6 +1093,23 @@ struct TargetCPP
     {
         return false;
     }
+
+    /**
+     * Get the starting offset position for fields of an `extern(C++)` class
+     * that is derived from the given base class.
+     * Params:
+     *      baseClass = base class with C++ linkage
+     * Returns:
+     *      starting offset to lay out derived class fields
+     */
+    extern (C++) uint derivedClassOffset(ClassDeclaration baseClass)
+    {
+        // MSVC adds padding between base and derived fields if required.
+        if (target.params.targetOS == TargetOS.Windows)
+            return (baseClass.structsize + baseClass.alignsize - 1) & ~(baseClass.alignsize - 1);
+        else
+            return baseClass.structsize;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -43,6 +43,7 @@ struct TargetCPP
     const char *typeMangle(Type *t);
     Type *parameterType(Parameter *p);
     bool fundamentalType(const Type *t, bool& isFundamental);
+    unsigned derivedClassOffset(ClassDeclaration *baseClass);
 };
 
 struct TargetObjC


### PR DESCRIPTION
Removes another use of TargetOS in the front-end.  This alignment adjustment is not true for GCC/Clang on MinGW.