### PR TITLE
dmd.target: Add Target.libraryObjectMonitors for backends that handle synchronizing monitors inline

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6567,6 +6567,7 @@ private:
 public:
     Expression* getTargetInfo(const char* name, const Loc& loc);
     bool isCalleeDestroyingArgs(TypeFunction* tf);
+    bool libraryObjectMonitors(FuncDeclaration* fd, Statement* fbody);
     Target() :
         ptrsize(),
         realsize(),

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -736,11 +736,10 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 if (!(blockexit & (BE.throw_ | BE.halt) || funcdecl.flags & FUNCFLAG.hasCatches))
                 {
-                    /* Disable optimization on Win32 due to
+                    /* Don't generate unwind tables for this function
                      * https://issues.dlang.org/show_bug.cgi?id=17997
                      */
-//                    if (!global.params.targetOS == TargetOS.Windows || global.params.is64bit)
-                        funcdecl.eh_none = true;         // don't generate unwind tables for this function
+                    funcdecl.eh_none = true;
                 }
 
                 if (funcdecl.flags & FUNCFLAG.nothrowInprocess)
@@ -1153,13 +1152,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     ClassDeclaration cd = funcdecl.toParentDecl().isClassDeclaration();
                     if (cd)
                     {
-                        if (!global.params.is64bit && global.params.targetOS == TargetOS.Windows && !funcdecl.isStatic() && !sbody.usesEH() && !global.params.trace)
-                        {
-                            /* The back end uses the "jmonitor" hack for syncing;
-                             * no need to do the sync at this level.
-                             */
-                        }
-                        else
+                        if (target.libraryObjectMonitors(funcdecl, sbody))
                         {
                             Expression vsync;
                             if (funcdecl.isStatic())

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -21,6 +21,7 @@ class Dsymbol;
 class Expression;
 class FuncDeclaration;
 class Parameter;
+class Statement;
 class Type;
 class TypeTuple;
 class TypeFunction;
@@ -112,6 +113,7 @@ public:
     bool preferPassByRef(Type *t);
     Expression *getTargetInfo(const char* name, const Loc& loc);
     bool isCalleeDestroyingArgs(TypeFunction* tf);
+    bool libraryObjectMonitors(FuncDeclaration *fd, Statement *fbody);
 };
 
 extern Target target;


### PR DESCRIPTION
Another removal of TargetOS from the front-end.  This "jmonitor" hack only applies to the DMD Win32 backend, not the GDC or LDC Win32 backends.