### PR TITLE
dmd.chkformat: Remove unused specifier argument in errorMsg

### DIFF
--- a/src/dmd/chkformat.d
+++ b/src/dmd/chkformat.d
@@ -103,7 +103,7 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
             return args[n++];
         }
 
-        void errorMsg(const char* prefix, const char[] specifier, Expression arg, const char* texpect, Type tactual)
+        void errorMsg(const char* prefix, Expression arg, const char* texpect, Type tactual)
         {
             deprecation(arg.loc, "%sargument `%s` for format specification `\"%.*s\"` must be `%s`, not `%s`",
                   prefix ? prefix : "", arg.toChars(), cast(int)slice.length, slice.ptr, texpect, tactual.toChars());
@@ -119,7 +119,7 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
                 return true;
             auto t = e.type.toBasetype();
             if (t.ty != Tint32 && t.ty != Tuns32)
-                errorMsg("width ", slice, e, "int", t);
+                errorMsg("width ", e, "int", t);
         }
 
         if (precisionStar)
@@ -132,7 +132,7 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
                 return true;
             auto t = e.type.toBasetype();
             if (t.ty != Tint32 && t.ty != Tuns32)
-                errorMsg("precision ", slice, e, "int", t);
+                errorMsg("precision ", e, "int", t);
         }
 
         bool skip;
@@ -153,124 +153,124 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
             case Format.u:      // unsigned int
             case Format.d:      // int
                 if (t.ty != Tint32 && t.ty != Tuns32)
-                    errorMsg(null, slice, e, "int", t);
+                    errorMsg(null, e, "int", t);
                 break;
 
             case Format.hhu:    // unsigned char
             case Format.hhd:    // signed char
                 if (t.ty != Tint32 && t.ty != Tuns32 && t.ty != Tint8 && t.ty != Tuns8)
-                    errorMsg(null, slice, e, "byte", t);
+                    errorMsg(null, e, "byte", t);
                 break;
 
             case Format.hu:     // unsigned short int
             case Format.hd:     // short int
                 if (t.ty != Tint32 && t.ty != Tuns32 && t.ty != Tint16 && t.ty != Tuns16)
-                    errorMsg(null, slice, e, "short", t);
+                    errorMsg(null, e, "short", t);
                 break;
 
             case Format.lu:     // unsigned long int
             case Format.ld:     // long int
                 if (!(t.isintegral() && t.size() == c_longsize))
-                    errorMsg(null, slice, e, (c_longsize == 4 ? "int" : "long"), t);
+                    errorMsg(null, e, (c_longsize == 4 ? "int" : "long"), t);
                 break;
 
             case Format.llu:    // unsigned long long int
             case Format.lld:    // long long int
                 if (t.ty != Tint64 && t.ty != Tuns64)
-                    errorMsg(null, slice, e, "long", t);
+                    errorMsg(null, e, "long", t);
                 break;
 
             case Format.ju:     // uintmax_t
             case Format.jd:     // intmax_t
                 if (t.ty != Tint64 && t.ty != Tuns64)
-                    errorMsg(null, slice, e, "core.stdc.stdint.intmax_t", t);
+                    errorMsg(null, e, "core.stdc.stdint.intmax_t", t);
                 break;
 
             case Format.zd:     // size_t
                 if (!(t.isintegral() && t.size() == (is64bit ? 8 : 4)))
-                    errorMsg(null, slice, e, "size_t", t);
+                    errorMsg(null, e, "size_t", t);
                 break;
 
             case Format.td:     // ptrdiff_t
                 if (!(t.isintegral() && t.size() == (is64bit ? 8 : 4)))
-                    errorMsg(null, slice, e, "ptrdiff_t", t);
+                    errorMsg(null, e, "ptrdiff_t", t);
                 break;
 
             case Format.GNU_a:  // Format.GNU_a is only for scanf
             case Format.lg:
             case Format.g:      // double
                 if (t.ty != Tfloat64 && t.ty != Timaginary64)
-                    errorMsg(null, slice, e, "double", t);
+                    errorMsg(null, e, "double", t);
                 break;
 
             case Format.Lg:     // long double
                 if (t.ty != Tfloat80 && t.ty != Timaginary80)
-                    errorMsg(null, slice, e, "real", t);
+                    errorMsg(null, e, "real", t);
                 break;
 
             case Format.p:      // pointer
                 if (t.ty != Tpointer && t.ty != Tnull && t.ty != Tclass && t.ty != Tdelegate && t.ty != Taarray)
-                    errorMsg(null, slice, e, "void*", t);
+                    errorMsg(null, e, "void*", t);
                 break;
 
             case Format.n:      // pointer to int
                 if (!(t.ty == Tpointer && tnext.ty == Tint32))
-                    errorMsg(null, slice, e, "int*", t);
+                    errorMsg(null, e, "int*", t);
                 break;
 
             case Format.ln:     // pointer to long int
                 if (!(t.ty == Tpointer && tnext.isintegral() && tnext.size() == c_longsize))
-                    errorMsg(null, slice, e, (c_longsize == 4 ? "int*" : "long*"), t);
+                    errorMsg(null, e, (c_longsize == 4 ? "int*" : "long*"), t);
                 break;
 
             case Format.lln:    // pointer to long long int
                 if (!(t.ty == Tpointer && tnext.ty == Tint64))
-                    errorMsg(null, slice, e, "long*", t);
+                    errorMsg(null, e, "long*", t);
                 break;
 
             case Format.hn:     // pointer to short
                 if (!(t.ty == Tpointer && tnext.ty == Tint16))
-                    errorMsg(null, slice, e, "short*", t);
+                    errorMsg(null, e, "short*", t);
                 break;
 
             case Format.hhn:    // pointer to signed char
                 if (!(t.ty == Tpointer && tnext.ty == Tint16))
-                    errorMsg(null, slice, e, "byte*", t);
+                    errorMsg(null, e, "byte*", t);
                 break;
 
             case Format.jn:     // pointer to intmax_t
                 if (!(t.ty == Tpointer && tnext.ty == Tint64))
-                    errorMsg(null, slice, e, "core.stdc.stdint.intmax_t*", t);
+                    errorMsg(null, e, "core.stdc.stdint.intmax_t*", t);
                 break;
 
             case Format.zn:     // pointer to size_t
                 if (!(t.ty == Tpointer && tnext.ty == (is64bit ? Tuns64 : Tuns32)))
-                    errorMsg(null, slice, e, "size_t*", t);
+                    errorMsg(null, e, "size_t*", t);
                 break;
 
             case Format.tn:     // pointer to ptrdiff_t
                 if (!(t.ty == Tpointer && tnext.ty == (is64bit ? Tint64 : Tint32)))
-                    errorMsg(null, slice, e, "ptrdiff_t*", t);
+                    errorMsg(null, e, "ptrdiff_t*", t);
                 break;
 
             case Format.c:      // char
                 if (t.ty != Tint32 && t.ty != Tuns32)
-                    errorMsg(null, slice, e, "char", t);
+                    errorMsg(null, e, "char", t);
                 break;
 
             case Format.lc:     // wint_t
                 if (t.ty != Tint32 && t.ty != Tuns32)
-                    errorMsg(null, slice, e, "wchar_t", t);
+                    errorMsg(null, e, "wchar_t", t);
                 break;
 
             case Format.s:      // pointer to char string
                 if (!(t.ty == Tpointer && (tnext.ty == Tchar || tnext.ty == Tint8 || tnext.ty == Tuns8)))
-                    errorMsg(null, slice, e, "char*", t);
+                    errorMsg(null, e, "char*", t);
                 break;
 
             case Format.ls:     // pointer to wchar_t string
                 if (!(t.ty == Tpointer && tnext == target.c.twchar_t))
-                    errorMsg(null, slice, e, "wchar_t*", t);
+                    errorMsg(null, e, "wchar_t*", t);
                 break;
 
             case Format.error:
@@ -360,7 +360,7 @@ bool checkScanfFormat(ref const Loc loc, scope const char[] format, scope Expres
             return args[n++];
         }
 
-        void errorMsg(const char* prefix, const char[] specifier, Expression arg, const char* texpect, Type tactual)
+        void errorMsg(const char* prefix, Expression arg, const char* texpect, Type tactual)
         {
             deprecation(arg.loc, "%sargument `%s` for format specification `\"%.*s\"` must be `%s`, not `%s`",
                   prefix ? prefix : "", arg.toChars(), cast(int)slice.length, slice.ptr, texpect, tactual.toChars());
@@ -380,94 +380,94 @@ bool checkScanfFormat(ref const Loc loc, scope const char[] format, scope Expres
             case Format.n:
             case Format.d:      // pointer to int
                 if (!(t.ty == Tpointer && tnext.ty == Tint32))
-                    errorMsg(null, slice, e, "int*", t);
+                    errorMsg(null, e, "int*", t);
                 break;
 
             case Format.hhn:
             case Format.hhd:    // pointer to signed char
                 if (!(t.ty == Tpointer && tnext.ty == Tint16))
-                    errorMsg(null, slice, e, "byte*", t);
+                    errorMsg(null, e, "byte*", t);
                 break;
 
             case Format.hn:
             case Format.hd:     // pointer to short
                 if (!(t.ty == Tpointer && tnext.ty == Tint16))
-                    errorMsg(null, slice, e, "short*", t);
+                    errorMsg(null, e, "short*", t);
                 break;
 
             case Format.ln:
             case Format.ld:     // pointer to long int
                 if (!(t.ty == Tpointer && tnext.isintegral() && tnext.size() == c_longsize))
-                    errorMsg(null, slice, e, (c_longsize == 4 ? "int*" : "long*"), t);
+                    errorMsg(null, e, (c_longsize == 4 ? "int*" : "long*"), t);
                 break;
 
             case Format.lln:
             case Format.lld:    // pointer to long long int
                 if (!(t.ty == Tpointer && tnext.ty == Tint64))
-                    errorMsg(null, slice, e, "long*", t);
+                    errorMsg(null, e, "long*", t);
                 break;
 
             case Format.jn:
             case Format.jd:     // pointer to intmax_t
                 if (!(t.ty == Tpointer && tnext.ty == Tint64))
-                    errorMsg(null, slice, e, "core.stdc.stdint.intmax_t*", t);
+                    errorMsg(null, e, "core.stdc.stdint.intmax_t*", t);
                 break;
 
             case Format.zn:
             case Format.zd:     // pointer to size_t
                 if (!(t.ty == Tpointer && tnext.ty == (is64bit ? Tuns64 : Tuns32)))
-                    errorMsg(null, slice, e, "size_t*", t);
+                    errorMsg(null, e, "size_t*", t);
                 break;
 
             case Format.tn:
             case Format.td:     // pointer to ptrdiff_t
                 if (!(t.ty == Tpointer && tnext.ty == (is64bit ? Tint64 : Tint32)))
-                    errorMsg(null, slice, e, "ptrdiff_t*", t);
+                    errorMsg(null, e, "ptrdiff_t*", t);
                 break;
 
             case Format.u:      // pointer to unsigned int
                 if (!(t.ty == Tpointer && tnext.ty == Tuns32))
-                    errorMsg(null, slice, e, "uint*", t);
+                    errorMsg(null, e, "uint*", t);
                 break;
 
             case Format.hhu:    // pointer to unsigned char
                 if (!(t.ty == Tpointer && tnext.ty == Tuns8))
-                    errorMsg(null, slice, e, "ubyte*", t);
+                    errorMsg(null, e, "ubyte*", t);
                 break;
 
             case Format.hu:     // pointer to unsigned short int
                 if (!(t.ty == Tpointer && tnext.ty == Tuns16))
-                    errorMsg(null, slice, e, "ushort*", t);
+                    errorMsg(null, e, "ushort*", t);
                 break;
 
             case Format.lu:     // pointer to unsigned long int
                 if (!(t.ty == Tpointer && tnext.ty == (is64bit ? Tuns64 : Tuns32)))
-                    errorMsg(null, slice, e, (c_longsize == 4 ? "uint*" : "ulong*"), t);
+                    errorMsg(null, e, (c_longsize == 4 ? "uint*" : "ulong*"), t);
                 break;
 
             case Format.llu:    // pointer to unsigned long long int
                 if (!(t.ty == Tpointer && tnext.ty == Tuns64))
-                    errorMsg(null, slice, e, "ulong*", t);
+                    errorMsg(null, e, "ulong*", t);
                 break;
 
             case Format.ju:     // pointer to uintmax_t
                 if (!(t.ty == Tpointer && tnext.ty == (is64bit ? Tuns64 : Tuns32)))
-                    errorMsg(null, slice, e, "ulong*", t);
+                    errorMsg(null, e, "ulong*", t);
                 break;
 
             case Format.g:      // pointer to float
                 if (!(t.ty == Tpointer && tnext.ty == Tfloat32))
-                    errorMsg(null, slice, e, "float*", t);
+                    errorMsg(null, e, "float*", t);
                 break;
 
             case Format.lg:     // pointer to double
                 if (!(t.ty == Tpointer && tnext.ty == Tfloat64))
-                    errorMsg(null, slice, e, "double*", t);
+                    errorMsg(null, e, "double*", t);
                 break;
 
             case Format.Lg:     // pointer to long double
                 if (!(t.ty == Tpointer && tnext.ty == Tfloat80))
-                    errorMsg(null, slice, e, "real*", t);
+                    errorMsg(null, e, "real*", t);
                 break;
 
             case Format.GNU_a:
@@ -475,18 +475,18 @@ bool checkScanfFormat(ref const Loc loc, scope const char[] format, scope Expres
             case Format.c:
             case Format.s:      // pointer to char string
                 if (!(t.ty == Tpointer && (tnext.ty == Tchar || tnext.ty == Tint8 || tnext.ty == Tuns8)))
-                    errorMsg(null, slice, e, "char*", t);
+                    errorMsg(null, e, "char*", t);
                 break;
 
             case Format.lc:
             case Format.ls:     // pointer to wchar_t string
                 if (!(t.ty == Tpointer && tnext == target.c.twchar_t))
-                    errorMsg(null, slice, e, "wchar_t*", t);
+                    errorMsg(null, e, "wchar_t*", t);
                 break;
 
             case Format.p:      // double pointer
                 if (!(t.ty == Tpointer && tnext.ty == Tpointer))
-                    errorMsg(null, slice, e, "void**", t);
+                    errorMsg(null, e, "void**", t);
                 break;
 
             case Format.error:


### PR DESCRIPTION
`slice` is being used directly via the closure pointer.