### PR TITLE
fix Issue 21665 - Void initialization should not be allowed for insta…

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -847,6 +847,12 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         return type;
     }
 
+    // Does this class have an invariant function?
+    final bool hasInvariant()
+    {
+        return invs.length != 0;
+    }
+
     // Back end
     Symbol* stag;   /// tag symbol for debug data
     Symbol* sinit;  /// initializer symbol

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -144,6 +144,8 @@ public:
     // 'this' type
     Type *handleType() { return type; }
 
+    bool hasInvariant();
+
     // Back end
     Symbol *stag;               // tag symbol for debug data
     Symbol *sinit;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1285,10 +1285,16 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         // Calculate type size + safety checks
         if (sc.func && !sc.intypeof)
         {
-            if (dsym._init && dsym._init.isVoidInitializer() && dsym.type.hasPointers()) // get type size
+            if (dsym._init && dsym._init.isVoidInitializer() &&
+                (dsym.type.hasPointers() || dsym.type.hasInvariant())) // also computes type size
             {
                 if (sc.func.setUnsafe())
-                    dsym.error("`void` initializers for pointers not allowed in safe functions");
+                {
+                    if (dsym.type.hasPointers())
+                        dsym.error("`void` initializers for pointers not allowed in safe functions");
+                    else
+                        dsym.error("`void` initializers for structs with invariants are not allowed in safe functions");
+                }
             }
             else if (!dsym._init &&
                      !(dsym.storage_class & (STC.static_ | STC.extern_ | STC.tls | STC.gshared | STC.manifest | STC.field | STC.parameter)) &&

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1370,6 +1370,7 @@ public:
     virtual int32_t hasWild() const;
     virtual bool hasPointers();
     virtual bool hasVoidInitPointers();
+    virtual bool hasInvariant();
     virtual Type* nextOf();
     Type* baseElemOf();
     uint32_t numberOfElems(const Loc& loc);
@@ -1674,6 +1675,7 @@ public:
     Dsymbol* searchCtor();
     Visibility visible();
     Type* handleType();
+    bool hasInvariant();
     Symbol* stag;
     Symbol* sinit;
     AggregateDeclaration* isAggregateDeclaration();
@@ -5049,6 +5051,7 @@ public:
     MATCH implicitConvTo(Type* to);
     Expression* defaultInitLiteral(const Loc& loc);
     bool hasPointers();
+    bool hasInvariant();
     bool needsDestruction();
     bool needsCopyOrPostblit();
     bool needsNested();
@@ -5335,6 +5338,7 @@ public:
     bool needsNested();
     bool hasPointers();
     bool hasVoidInitPointers();
+    bool hasInvariant();
     MATCH implicitConvTo(Type* to);
     MATCH constConv(Type* to);
     uint8_t deduceWild(Type* t, bool isRef);
@@ -5370,6 +5374,7 @@ public:
     bool isZeroInit(const Loc& loc);
     bool hasPointers();
     bool hasVoidInitPointers();
+    bool hasInvariant();
     Type* nextOf();
     void accept(Visitor* v);
 };

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -302,6 +302,7 @@ public:
     virtual int hasWild() const;
     virtual bool hasPointers();
     virtual bool hasVoidInitPointers();
+    virtual bool hasInvariant();
     virtual Type *nextOf();
     Type *baseElemOf();
     uinteger_t sizemask();
@@ -443,6 +444,7 @@ public:
     MATCH implicitConvTo(Type *to);
     Expression *defaultInitLiteral(const Loc &loc);
     bool hasPointers();
+    bool hasInvariant();
     bool needsDestruction();
     bool needsCopyOrPostblit();
     bool needsNested();
@@ -774,6 +776,7 @@ public:
     bool needsNested();
     bool hasPointers();
     bool hasVoidInitPointers();
+    bool hasInvariant();
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
     unsigned char deduceWild(Type *t, bool isRef);
@@ -811,6 +814,7 @@ public:
     bool isZeroInit(const Loc &loc);
     bool hasPointers();
     bool hasVoidInitPointers();
+    bool hasInvariant();
     Type *nextOf();
 
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -61,11 +61,21 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
         const hasPointers = v.type.hasPointers();
         if (hasPointers)
         {
-
             if (v.overlapped && sc.func.setUnsafe())
             {
                 if (printmsg)
                     e.error("field `%s.%s` cannot access pointers in `@safe` code that overlap other fields",
+                        ad.toChars(), v.toChars());
+                return true;
+            }
+        }
+
+        if (v.type.hasInvariant())
+        {
+            if (v.overlapped && sc.func.setUnsafe())
+            {
+                if (printmsg)
+                    e.error("field `%s.%s` cannot access structs with invariants in `@safe` code that overlap other fields",
                         ad.toChars(), v.toChars());
                 return true;
             }

--- a/test/fail_compilation/test21665.d
+++ b/test/fail_compilation/test21665.d
@@ -1,0 +1,31 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test21665.d(18): Error: variable `test21665.test1.s` `void` initializers for structs with invariants are not allowed in safe functions
+fail_compilation/test21665.d(30): Error: field `U.s` cannot access structs with invariants in `@safe` code that overlap other fields
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=21665
+
+struct ShortString {
+    private ubyte length;
+    private char[15] data;
+
+    invariant { assert(length <= data.length); }
+}
+
+@safe void test1() {
+    ShortString s = void;
+}
+
+union U
+{
+    int n;
+    ShortString s;
+}
+
+@safe void test2()
+{
+    U u;
+    u.s.length = 3;
+}


### PR DESCRIPTION
…nces of struct with invariant

The bug report mentions two problems - the one in the title and when a union field has a struct with an invariant. This fixes both.

The code added is very similar to the implementation and checks for `hasPointers()`.