### PR TITLE
backend: begin transition to @safe code

### DIFF
--- a/src/dmd/backend/oper.d
+++ b/src/dmd/backend/oper.d
@@ -16,6 +16,7 @@ module dmd.backend.oper;
 extern (C++):
 @nogc:
 nothrow:
+@safe:
 
 alias OPER = int;
 enum

--- a/src/dmd/backend/outbuf.d
+++ b/src/dmd/backend/outbuf.d
@@ -26,6 +26,8 @@ private nothrow void err_nomem();
 
 struct Outbuffer
 {
+  @safe:
+
     ubyte *buf;         // the buffer itself
     ubyte *pend;        // pointer past the end of the buffer
     private ubyte *p;   // current position in buffer
@@ -38,6 +40,7 @@ struct Outbuffer
 
     //~this() { dtor(); }
 
+    @trusted
     void dtor()
     {
         if (auto slice = this.extractSlice())
@@ -86,6 +89,7 @@ struct Outbuffer
     }
 
     // Reserve nbytes in buffer
+    @trusted
     void enlarge(size_t nbytes)
     {
         pragma(inline, false);  // do not inline slow path
@@ -112,6 +116,7 @@ struct Outbuffer
 
 
     // Write n zeros; return pointer to start of zeros
+    @trusted
     void *writezeros(size_t n)
     {
         reserve(n);
@@ -121,6 +126,7 @@ struct Outbuffer
     }
 
     // Position buffer to accept the specified number of bytes at offset
+    @trusted
     void position(size_t offset, size_t nbytes)
     {
         if (offset + nbytes > pend - buf)
@@ -135,6 +141,7 @@ struct Outbuffer
     }
 
     // Write an array to the buffer, no reserve check
+    @trusted
     void writen(const void *b, size_t len)
     {
         memcpy(p,b,len);
@@ -142,6 +149,7 @@ struct Outbuffer
     }
 
     // Write an array to the buffer.
+    @trusted
     extern (D)
     void write(const(void)[] b)
     {
@@ -150,6 +158,7 @@ struct Outbuffer
         p += b.length;
     }
 
+    @trusted
     void write(const(void)* b, size_t len)
     {
         write(b[0 .. len]);
@@ -158,6 +167,7 @@ struct Outbuffer
     /**
      * Writes an 8 bit byte, no reserve check.
      */
+    @trusted
     void writeByten(int v)
     {
         *p++ = cast(ubyte)v;
@@ -166,6 +176,7 @@ struct Outbuffer
     /**
      * Writes an 8 bit byte.
      */
+    @trusted
     void writeByte(int v)
     {
         reserve(1);
@@ -175,6 +186,7 @@ struct Outbuffer
     /**
      * Writes a 16 bit value, no reserve check.
      */
+    @trusted
     void write16n(int v)
     {
         *(cast(ushort *) p) = cast(ushort)v;
@@ -194,6 +206,7 @@ struct Outbuffer
     /**
      * Writes a 32 bit int, no reserve check.
      */
+    @trusted
     void write32n(int v)
     {
         *cast(int *)p = v;
@@ -212,6 +225,7 @@ struct Outbuffer
     /**
      * Writes a 64 bit long, no reserve check
      */
+    @trusted
     void write64n(long v)
     {
         *cast(long *)p = v;
@@ -230,6 +244,7 @@ struct Outbuffer
     /**
      * Writes a 32 bit float.
      */
+    @trusted
     void writeFloat(float v)
     {
         reserve(float.sizeof);
@@ -240,6 +255,7 @@ struct Outbuffer
     /**
      * Writes a 64 bit double.
      */
+    @trusted
     void writeDouble(double v)
     {
         reserve(double.sizeof);
@@ -250,6 +266,7 @@ struct Outbuffer
     /**
      * Writes a String as a sequence of bytes.
      */
+    @trusted
     void write(const(char)* s)
     {
         write(s[0 .. strlen(s)]);
@@ -258,6 +275,7 @@ struct Outbuffer
     /**
      * Writes a 0 terminated String
      */
+    @trusted
     void writeString(const(char)* s)
     {
         write(s[0 .. strlen(s)+1]);
@@ -279,6 +297,7 @@ struct Outbuffer
     /**
      * Inserts string at beginning of buffer.
      */
+    @trusted
     void prependBytes(const(char)* s)
     {
         prepend(s, strlen(s));
@@ -287,6 +306,7 @@ struct Outbuffer
     /**
      * Inserts bytes at beginning of buffer.
      */
+    @trusted
     void prepend(const(void)* b, size_t len)
     {
         reserve(len);
@@ -298,6 +318,7 @@ struct Outbuffer
     /**
      * Bracket buffer contents with c1 and c2.
      */
+    @trusted
     void bracket(char c1,char c2)
     {
         reserve(2);
@@ -318,7 +339,7 @@ struct Outbuffer
     /**
      * Set current size of buffer.
      */
-
+    @trusted
     void setsize(size_t size)
     {
         p = buf + size;

--- a/src/dmd/backend/ptrntab.d
+++ b/src/dmd/backend/ptrntab.d
@@ -38,6 +38,7 @@ import dmd.backend.dlist;
 import dmd.backend.ty;
 
 nothrow:
+@safe:
 
 //
 // NOTE: For 0 operand instructions, the opcode is taken from
@@ -5805,6 +5806,7 @@ extern (C++) const(char)* asm_opstr(OP *pop)
 /*******************************
  */
 
+@trusted
 extern (C++) OP *asm_op_lookup(const(char)* s)
 {
     int i;
@@ -5825,6 +5827,7 @@ extern (C++) OP *asm_op_lookup(const(char)* s)
 /*******************************
  */
 
+@trusted
 extern (C++) void init_optab()
 {   int i;
 
@@ -5839,6 +5842,7 @@ extern (C++) void init_optab()
     }
 }
 
+@trusted
 private int binary(const(char)* p, const OP[] table)
 {
     int low = 0;

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -16,6 +16,7 @@ module dmd.backend.ty;
 extern (C++):
 @nogc:
 nothrow:
+@safe:
 
 alias tym_t = uint;
 
@@ -246,91 +247,121 @@ extern __gshared byte[256] _tysize;
 extern __gshared byte[256] _tyalignsize;
 
 // Give size of type
+@trusted
 byte tysize(tym_t ty)      { return _tysize[ty & 0xFF]; }
+@trusted
 byte tyalignsize(tym_t ty) { return _tyalignsize[ty & 0xFF]; }
 
 
 /* Groupings of types   */
 
+@trusted
 uint tyintegral(tym_t ty) { return tytab[ty & 0xFF] & TYFLintegral; }
 
+@trusted
 uint tyarithmetic(tym_t ty) { return tytab[ty & 0xFF] & (TYFLintegral | TYFLreal | TYFLimaginary | TYFLcomplex); }
 
+@trusted
 uint tyaggregate(tym_t ty) { return tytab[ty & 0xFF] & TYFLaggregate; }
 
+@trusted
 uint tyscalar(tym_t ty) { return tytab[ty & 0xFF] & (TYFLintegral | TYFLreal | TYFLimaginary | TYFLcomplex | TYFLptr | TYFLmptr | TYFLnullptr | TYFLref); }
 
+@trusted
 uint tyfloating(tym_t ty) { return tytab[ty & 0xFF] & (TYFLreal | TYFLimaginary | TYFLcomplex); }
 
+@trusted
 uint tyimaginary(tym_t ty) { return tytab[ty & 0xFF] & TYFLimaginary; }
 
+@trusted
 uint tycomplex(tym_t ty) { return tytab[ty & 0xFF] & TYFLcomplex; }
 
+@trusted
 uint tyreal(tym_t ty) { return tytab[ty & 0xFF] & TYFLreal; }
 
 // Fits into 64 bit register
+@trusted
 bool ty64reg(tym_t ty) { return tytab[ty & 0xFF] & (TYFLintegral | TYFLptr | TYFLref) && tysize(ty) <= _tysize[TYnptr]; }
 
 // Can go in XMM floating point register
+@trusted
 uint tyxmmreg(tym_t ty) { return tytab[ty & 0xFF] & TYFLxmmreg; }
 
 // Is a vector type
+@trusted
 bool tyvector(tym_t ty) { return tybasic(ty) >= TYfloat4 && tybasic(ty) <= TYullong4; }
 
 /* Types that are chars or shorts       */
+@trusted
 uint tyshort(tym_t ty) { return tytab[ty & 0xFF] & TYFLshort; }
 
 /* Detect TYlong or TYulong     */
+@trusted
 bool tylong(tym_t ty) { return tybasic(ty) == TYlong || tybasic(ty) == TYulong; }
 
 /* Use to detect a pointer type */
+@trusted
 uint typtr(tym_t ty) { return tytab[ty & 0xFF] & TYFLptr; }
 
 /* Use to detect a reference type */
+@trusted
 uint tyref(tym_t ty) { return tytab[ty & 0xFF] & TYFLref; }
 
 /* Use to detect a pointer type or a member pointer     */
+@trusted
 uint tymptr(tym_t ty) { return tytab[ty & 0xFF] & (TYFLptr | TYFLmptr); }
 
 // Use to detect a nullptr type or a member pointer
+@trusted
 uint tynullptr(tym_t ty) { return tytab[ty & 0xFF] & TYFLnullptr; }
 
 /* Detect TYfptr or TYvptr      */
+@trusted
 uint tyfv(tym_t ty) { return tytab[ty & 0xFF] & TYFLfv; }
 
 /* All data types that fit in exactly 8 bits    */
+@trusted
 bool tybyte(tym_t ty) { return tysize(ty) == 1; }
 
 /* Types that fit into a single machine register        */
+@trusted
 bool tyreg(tym_t ty) { return tysize(ty) <= _tysize[TYnptr]; }
 
 /* Detect function type */
+@trusted
 uint tyfunc(tym_t ty) { return tytab[ty & 0xFF] & TYFLfunc; }
 
 /* Detect function type where parameters are pushed left to right    */
+@trusted
 uint tyrevfunc(tym_t ty) { return tytab[ty & 0xFF] & TYFLrevparam; }
 
 /* Detect uint types */
+@trusted
 uint tyuns(tym_t ty) { return tytab[ty & 0xFF] & (TYFLuns | TYFLptr); }
 
 /* Target dependent info        */
 alias TYoffset = TYuint;         // offset to an address
 
 /* Detect cpp function type (callee cleans up stack)    */
+@trusted
 uint typfunc(tym_t ty) { return tytab[ty & 0xFF] & TYFLpascal; }
 
 /* Array to convert a type to its unsigned equivalent   */
 extern __gshared tym_t[256] tytouns;
+@trusted
 tym_t touns(tym_t ty) { return tytouns[ty & 0xFF]; }
 
 /* Determine if TYffunc or TYfpfunc (a far function) */
+@trusted
 uint tyfarfunc(tym_t ty) { return tytab[ty & 0xFF] & TYFLfarfunc; }
 
 // Determine if parameter is a SIMD vector type
+@trusted
 uint tysimd(tym_t ty) { return tytab[ty & 0xFF] & TYFLsimd; }
 
 /* Determine relaxed type       */
 extern __gshared ubyte[TYMAX] _tyrelax;
+@trusted
 uint tyrelax(tym_t ty) { return _tyrelax[tybasic(ty)]; }
 
 
@@ -345,7 +376,10 @@ extern __gshared ubyte[TYMAX] dttab;
 extern __gshared ushort[TYMAX] dttab4;
 
 
+@trusted
 bool I16() { return _tysize[TYnptr] == 2; }
+@trusted
 bool I32() { return _tysize[TYnptr] == 4; }
+@trusted
 bool I64() { return _tysize[TYnptr] == 8; }
 


### PR DESCRIPTION
The dmd source code needs to transition to @safe. This starts with the backend. The process is simple - set files as @safe, and every function that fails to compile is marked @trusted. Once the whole program has been done, then each @trusted function can be evaluated individually without the chicken-and-egg problem of the viral nature of @safe.

This PR is a start on this process.