### PR TITLE
Fix mangling ambiguity, follow-up to #12300

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -1269,6 +1269,7 @@ public:
 
     override void visit(FuncExp e)
     {
+        buf.writeByte('f');
         if (e.td)
             mangleSymbol(e.td);
         else

--- a/test/runnable/mangle.d
+++ b/test/runnable/mangle.d
@@ -621,7 +621,7 @@ static assert(funcd.mangleof == "_D6mangle5funcdFPFZNnZi");
 struct S21753 { void function() f1; }
 void fun21753(S21753 v)() {}
 alias fl21753 = (){};
-static assert((fun21753!(S21753(fl21753))).mangleof == "_D6mangle__T8fun21753VSQv6S21753S1_DQBi10" ~ fl21753.stringof ~ "MFNaNbNiNfZvZQCaQp");
+static assert((fun21753!(S21753(fl21753))).mangleof == "_D6mangle__T8fun21753VSQv6S21753S1f_DQBj10" ~ fl21753.stringof ~ "MFNaNbNiNfZvZQCbQp");
 
 /***************************************************/
 void main()


### PR DESCRIPTION
Added `'f'` before mangled name as requested by @rainers in https://github.com/dlang/dmd/pull/12300#issuecomment-805544964