### PR TITLE
Draft: Fix 1654 - Array concatenation result should be implicitly castable between mutable and immutable if the elements support it.

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -840,9 +840,10 @@ MATCH implicitConvTo(Expression e, Type t)
             }
         }
 
+        /** Checks whether or not a `CatExp e` can be implicitly converted to type `t`.
+         */
         override void visit(CatExp e)
         {
-            enum LOG = false;
             static if (LOG)
             {
                 printf("CatExp::implicitConvTo(this=%s, type=%s, t=%s)\n", e.toChars(), e.type.toChars(), t.toChars());

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -595,7 +595,7 @@ extern (C++) class Dsymbol : ASTNode
         return followInstantiationContext(p1, p2) ? toParent2() : toParentLocal();
     }
 
-    final inout(TemplateInstance) isInstantiated() inout pure nothrow
+    final inout(TemplateInstance) isInstantiated() inout
     {
         if (!parent)
             return null;
@@ -2384,5 +2384,3 @@ Dsymbol handleTagSymbols(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsymbol sds)
     if (log) printf(" collision\n");
     return null;
 }
-
-

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -595,7 +595,7 @@ extern (C++) class Dsymbol : ASTNode
         return followInstantiationContext(p1, p2) ? toParent2() : toParentLocal();
     }
 
-    final inout(TemplateInstance) isInstantiated() inout
+    final inout(TemplateInstance) isInstantiated() inout pure nothrow
     {
         if (!parent)
             return null;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8262,6 +8262,7 @@ struct Id final
     static Identifier* hasPostblit;
     static Identifier* hasCopyConstructor;
     static Identifier* isCopyable;
+    static Identifier* hasAliasing;
     static Identifier* toType;
     static Identifier* allocator;
     static Identifier* basic_string;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -471,6 +471,7 @@ immutable Msgtable[] msgtable =
     { "hasPostblit" },
     { "hasCopyConstructor" },
     { "isCopyable" },
+    { "hasAliasing" },
     { "toType" },
 
     // For C++ mangling

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -150,6 +150,7 @@ shared static this()
         "hasPostblit",
         "hasCopyConstructor",
         "isCopyable",
+        "hasAliasing",
     ];
 
     StringTable!(bool)* stringTable = cast(StringTable!(bool)*) &traitsStringTable;
@@ -670,6 +671,22 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         }
 
         return isCopyable(t) ? True() : False();
+    }
+    if (e.ident == Id.hasAliasing)
+    {
+        foreach (o; *e.args)
+        {
+            auto t = isType(o);
+            if (!t)
+            {
+                e.error("type expected as non-first argument of __traits `%s` instead of `%s`",
+                        e.ident.toChars(), o.toChars());
+                return ErrorExp.get();
+            }
+            if (t.hasAliasing)
+                return True();
+        }
+        return False();
     }
 
     if (e.ident == Id.isNested)

--- a/test/compilable/traits_hasAliasing.d
+++ b/test/compilable/traits_hasAliasing.d
@@ -1,0 +1,102 @@
+module traits_hasAliasing;
+
+@safe pure nothrow @nogc:
+
+/** Verify behaviour of `__traits(hasAliasing, void*)` being same as `std.traits.hasAliasing`.
+ *
+ * Copied from Phobos `std.traits`.
+ */
+void test_hasAliasing()
+{
+    static assert(__traits(hasAliasing, void*));
+    static assert(!__traits(hasAliasing, void function()));
+
+    struct S1 { int a; Object b; }
+    struct S2 { string a; }
+    struct S3 { int a; immutable Object b; }
+    struct S4 { float[3] vals; }
+    struct S41 { int*[3] vals; }
+    struct S42 { immutable(int)*[3] vals; }
+
+    static assert( __traits(hasAliasing, S1));
+    static assert(!__traits(hasAliasing, S2));
+    static assert(!__traits(hasAliasing, S3));
+    static assert(!__traits(hasAliasing, S4));
+    static assert( __traits(hasAliasing, S41));
+    static assert(!__traits(hasAliasing, S42));
+
+    static assert( __traits(hasAliasing, uint[uint]));
+    static assert(!__traits(hasAliasing, immutable(uint[uint])));
+    static assert( __traits(hasAliasing, void delegate()));
+    static assert( __traits(hasAliasing, void delegate() const));
+    static assert(!__traits(hasAliasing, void delegate() immutable));
+    static assert( __traits(hasAliasing, void delegate() shared));
+    static assert( __traits(hasAliasing, void delegate() shared const));
+    static assert( __traits(hasAliasing, const(void delegate())));
+    static assert( __traits(hasAliasing, const(void delegate() const)));
+    static assert(!__traits(hasAliasing, const(void delegate() immutable)));
+    static assert( __traits(hasAliasing, const(void delegate() shared)));
+    static assert( __traits(hasAliasing, const(void delegate() shared const)));
+    static assert(!__traits(hasAliasing, immutable(void delegate())));
+    static assert(!__traits(hasAliasing, immutable(void delegate() const)));
+    static assert(!__traits(hasAliasing, immutable(void delegate() immutable)));
+    static assert(!__traits(hasAliasing, immutable(void delegate() shared)));
+    static assert(!__traits(hasAliasing, immutable(void delegate() shared const)));
+    static assert( __traits(hasAliasing, shared(const(void delegate()))));
+    static assert( __traits(hasAliasing, shared(const(void delegate() const))));
+    static assert(!__traits(hasAliasing, shared(const(void delegate() immutable))));
+    static assert( __traits(hasAliasing, shared(const(void delegate() shared))));
+    static assert( __traits(hasAliasing, shared(const(void delegate() shared const))));
+
+    interface I;
+    static assert( __traits(hasAliasing, I));
+
+    import std.typecons : Rebindable;
+    static assert( __traits(hasAliasing, Rebindable!(const Object)));
+    static assert(!__traits(hasAliasing, Rebindable!(immutable Object)));
+    static assert( __traits(hasAliasing, Rebindable!(shared Object)));
+    static assert( __traits(hasAliasing, Rebindable!Object));
+
+    struct S5
+    {
+        void delegate() immutable b;
+        shared(void delegate() immutable) f;
+        immutable(void delegate() immutable) j;
+        shared(const(void delegate() immutable)) n;
+    }
+    struct S6 { typeof(S5.tupleof) a; void delegate() p; }
+    static assert(!__traits(hasAliasing, S5));
+    static assert( __traits(hasAliasing, S6));
+
+    struct S7 { void delegate() a; int b; Object c; }
+    class S8 { int a; int b; }
+    class S9 { typeof(S8.tupleof) a; }
+    class S10 { typeof(S8.tupleof) a; int* b; }
+    static assert( __traits(hasAliasing, S7));
+    static assert( __traits(hasAliasing, S8));
+    static assert( __traits(hasAliasing, S9));
+    static assert( __traits(hasAliasing, S10));
+    struct S11 {}
+    class S12 {}
+    interface S13 {}
+    union S14 {}
+    static assert(!__traits(hasAliasing, S11));
+    static assert( __traits(hasAliasing, S12));
+    static assert( __traits(hasAliasing, S13));
+    static assert(!__traits(hasAliasing, S14));
+
+    class S15 { S15[1] a; }
+    static assert( __traits(hasAliasing, S15));
+    static assert(!__traits(hasAliasing, immutable(S15)));
+}
+
+void test_hasAliasing_enums()
+{
+    enum Ei : string { a = "a", b = "b" }
+    enum Ec : const(char)[] { a = "a", b = "b" }
+    enum Em : char[] { a = null, b = null }
+
+    static assert(!__traits(hasAliasing, Ei));
+    static assert( __traits(hasAliasing, Ec));
+    static assert( __traits(hasAliasing, Em));
+}

--- a/test/fail_compilation/impconv_array.d
+++ b/test/fail_compilation/impconv_array.d
@@ -1,0 +1,183 @@
+// https://issues.dlang.org/show_bug.cgi?id=1654
+
+/*
+  TEST_OUTPUT:
+  ---
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ y` of type `char[][]` to `immutable(string)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(char[][], char[][], immutable(string)[])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(char[])[])x ~ y` of type `const(char)[][]` to `char[][]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(char[][], const(char[])[], char[][])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(char[])[])x ~ y` of type `const(char)[][]` to `immutable(string)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(char[][], const(char[])[], immutable(string)[])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(char[])[])x ~ cast(const(char[])[])cast(const(string)[])y` of type `const(char)[][]` to `char[][]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(char[][], immutable(string)[], char[][])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(char[])[])x ~ cast(const(char[])[])cast(const(string)[])y` of type `const(char)[][]` to `immutable(string)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(char[][], immutable(string)[], immutable(string)[])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(char[])[])y` of type `const(char)[][]` to `char[][]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(char[])[], char[][], char[][])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(char[])[])y` of type `const(char)[][]` to `immutable(string)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(char[])[], char[][], immutable(string)[])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ y` of type `const(char[])[]` to `char[][]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(char[])[], const(char[])[], char[][])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ y` of type `const(char[])[]` to `immutable(string)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(char[])[], const(char[])[], immutable(string)[])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(char[])[])cast(const(string)[])y` of type `const(char)[][]` to `char[][]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(char[])[], immutable(string)[], char[][])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(char[])[])cast(const(string)[])y` of type `const(char)[][]` to `immutable(string)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(char[])[], immutable(string)[], immutable(string)[])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(char[])[])cast(const(string)[])x ~ cast(const(char[])[])y` of type `const(char)[][]` to `char[][]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(string)[], char[][], char[][])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(char[])[])cast(const(string)[])x ~ cast(const(char[])[])y` of type `const(char)[][]` to `immutable(string)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(string)[], char[][], immutable(string)[])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(char[])[])cast(const(string)[])x ~ y` of type `const(char)[][]` to `char[][]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(string)[], const(char[])[], char[][])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(char[])[])cast(const(string)[])x ~ y` of type `const(char)[][]` to `immutable(string)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(string)[], const(char[])[], immutable(string)[])` error instantiating
+fail_compilation/impconv_array.d(179):        instantiated from here: `test!(char[])`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ y` of type `S2[]` to `immutable(S2)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(S2[], S2[], immutable(S2)[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S2)[])x ~ y` of type `const(S2)[]` to `S2[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(S2[], const(S2)[], S2[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S2)[])x ~ y` of type `const(S2)[]` to `immutable(S2)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(S2[], const(S2)[], immutable(S2)[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S2)[])x ~ cast(const(S2)[])y` of type `const(S2)[]` to `S2[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(S2[], immutable(S2)[], S2[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S2)[])x ~ cast(const(S2)[])y` of type `const(S2)[]` to `immutable(S2)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(S2[], immutable(S2)[], immutable(S2)[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(S2)[])y` of type `const(S2)[]` to `S2[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S2)[], S2[], S2[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(S2)[])y` of type `const(S2)[]` to `immutable(S2)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S2)[], S2[], immutable(S2)[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ y` of type `const(S2)[]` to `S2[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S2)[], const(S2)[], S2[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ y` of type `const(S2)[]` to `immutable(S2)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S2)[], const(S2)[], immutable(S2)[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(S2)[])y` of type `const(S2)[]` to `S2[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S2)[], immutable(S2)[], S2[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(S2)[])y` of type `const(S2)[]` to `immutable(S2)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S2)[], immutable(S2)[], immutable(S2)[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S2)[])x ~ cast(const(S2)[])y` of type `const(S2)[]` to `S2[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(S2)[], S2[], S2[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S2)[])x ~ cast(const(S2)[])y` of type `const(S2)[]` to `immutable(S2)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(S2)[], S2[], immutable(S2)[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S2)[])x ~ y` of type `const(S2)[]` to `S2[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(S2)[], const(S2)[], S2[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S2)[])x ~ y` of type `const(S2)[]` to `immutable(S2)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(S2)[], const(S2)[], immutable(S2)[])` error instantiating
+fail_compilation/impconv_array.d(180):        instantiated from here: `test!(S2)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ y` of type `S3[]` to `immutable(S3)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(S3[], S3[], immutable(S3)[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S3)[])x ~ y` of type `const(S3)[]` to `S3[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(S3[], const(S3)[], S3[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S3)[])x ~ y` of type `const(S3)[]` to `immutable(S3)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(S3[], const(S3)[], immutable(S3)[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S3)[])x ~ cast(const(S3)[])y` of type `const(S3)[]` to `S3[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(S3[], immutable(S3)[], S3[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S3)[])x ~ cast(const(S3)[])y` of type `const(S3)[]` to `immutable(S3)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(S3[], immutable(S3)[], immutable(S3)[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(S3)[])y` of type `const(S3)[]` to `S3[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S3)[], S3[], S3[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(S3)[])y` of type `const(S3)[]` to `immutable(S3)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S3)[], S3[], immutable(S3)[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ y` of type `const(S3)[]` to `S3[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S3)[], const(S3)[], S3[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ y` of type `const(S3)[]` to `immutable(S3)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S3)[], const(S3)[], immutable(S3)[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(S3)[])y` of type `const(S3)[]` to `S3[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S3)[], immutable(S3)[], S3[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `x ~ cast(const(S3)[])y` of type `const(S3)[]` to `immutable(S3)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(const(S3)[], immutable(S3)[], immutable(S3)[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S3)[])x ~ cast(const(S3)[])y` of type `const(S3)[]` to `S3[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(S3)[], S3[], S3[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S3)[])x ~ cast(const(S3)[])y` of type `const(S3)[]` to `immutable(S3)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(S3)[], S3[], immutable(S3)[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S3)[])x ~ y` of type `const(S3)[]` to `S3[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(S3)[], const(S3)[], S3[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(153): Error: cannot implicitly convert expression `cast(const(S3)[])x ~ y` of type `const(S3)[]` to `immutable(S3)[]`
+fail_compilation/impconv_array.d(164): Error: template instance `impconv_array.test1!(immutable(S3)[], const(S3)[], immutable(S3)[])` error instantiating
+fail_compilation/impconv_array.d(181):        instantiated from here: `test!(S3)`
+fail_compilation/impconv_array.d(182): Error: undefined identifier `_`
+  ---
+*/
+
+alias AliasSeq(TList...) = TList;
+
+@safe pure:
+
+void test1(X, Y, Z)()
+{
+    X x;
+    Y y;
+    Z z = x ~ y;
+}
+
+void test(T)()
+{
+    alias M = T[];
+    alias C = const(T)[];
+    alias I = immutable(T)[];
+    static foreach (X; AliasSeq!(M, C, I))
+        static foreach (Y; AliasSeq!(M, C, I))
+            static foreach (Z; AliasSeq!(M, C, I))
+                test1!(X,Y,Z)();
+}
+
+void test1654_ok()
+{
+    struct S1 { immutable(int)* x; }
+    test!(int);                 // ok, no indirections
+    test!(string);              // ok, immutable indirections
+    test!(S1);                  // ok, immutable indirections
+}
+
+void test1654_fail()
+{
+    struct S2 { int* x; }
+    struct S3 { const(int)* x; }
+    test!(char[]);              // fail, non-immutable indirections
+    test!(S2);                  // fail, non-immutable indirections
+    test!(S3);                  // fail, non-immutable indirections
+    _;                          // to always trigger an error during development
+}

--- a/test/fail_compilation/impconv_array.d
+++ b/test/fail_compilation/impconv_array.d
@@ -179,5 +179,4 @@ void test1654_fail()
     test!(char[]);              // fail, non-immutable indirections
     test!(S2);                  // fail, non-immutable indirections
     test!(S3);                  // fail, non-immutable indirections
-    _;                          // to always trigger an error during development
 }

--- a/test/fail_compilation/traits_hasAliasing.d
+++ b/test/fail_compilation/traits_hasAliasing.d
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=1654
+
+/*
+  TEST_OUTPUT:
+  ---
+  fail_compilation/traits_hasAliasing.d(10): Error: type expected as non-first argument of __traits `hasAliasing` instead of `""`
+  ---
+*/
+
+enum _ = __traits(hasAliasing, "");


### PR DESCRIPTION
## Specification

Allow array concatenation result (`CatExp`), of type `$M(T)[]`, to implicitly convert in any direction between mutable, const and immutable iff `T`s all indirections are immutable, meaning `std.traits.hasAliasing!(T)` is `false`. Given `$M(T)[]` is a wildcard for either

- `T[]`
- `const(T)[]`
- `immutable(T)[]`

.

Optionally extend to other r-value expressions of type `T[]` such as `X.dup` and `X.idup`.

## Implementation

This solution depends on `hasAliasing` in `mtype.d` that exactly mimics behaviour of `std.traits.hasAliasing` according to all the unittests currently present in `std.traits`.

I've also exposed `hasAliasing` as a builtin trait for now for easier testing. If we want to keep it as a builtin we should add it as a separate trait. If not, I can convert the `__traits` tests for `hasAlasing` into unittests.

## References

Bugzilla issue: https://issues.dlang.org/show_bug.cgi?id=1654

Also see discussion at https://forum.dlang.org/thread/omfkmlsqamxjtktnaqic@forum.dlang.org?page=1
