### PR TITLE
[dmd-cxx] Fix misspelling identifer -> identifier

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -1184,7 +1184,7 @@ struct Symbol
     unsigned Ssequence;         // sequence number (used for 2 level lookup)
                                 // also used as 'parameter number' for SCTtemparg
 #elif MARS
-    const char *prettyIdent;    // the symbol identifer as the user sees it
+    const char *prettyIdent;    // the symbol identifier as the user sees it
 #endif
 
 #if TARGET_OSX

--- a/src/dmangle.c
+++ b/src/dmangle.c
@@ -152,7 +152,7 @@ public:
     *  using upper case letters for all digits but the last digit which uses
     *  a lower case letter.
     * The decoder has to look up the referenced position to determine
-    *  whether the back reference is an identifer (starts with a digit)
+    *  whether the back reference is an identifier (starts with a digit)
     *  or a type (starts with a letter).
     *
     * Params:

--- a/src/parse.c
+++ b/src/parse.c
@@ -1334,7 +1334,7 @@ LINK Parser::parseLinkage(Identifiers **pidents, CPPMANGLE *pcppmangle, bool *pc
                             }
                             else if (!Identifier::isValidIdentifier(name))
                             {
-                                error("expected valid identifer for C++ namespace but got `%s`", name);
+                                error("expected valid identifier for C++ namespace but got `%s`", name);
                                 idents = NULL;
                                 break;
                             }
@@ -3611,7 +3611,7 @@ Type *Parser::parseDeclarator(Type *t, int *palt, Identifier **pident,
             if (pident)
                 *pident = token.ident;
             else
-                error("unexpected identifer `%s` in declarator", token.ident->toChars());
+                error("unexpected identifier `%s` in declarator", token.ident->toChars());
             ts = t;
             nextToken();
             break;

--- a/test/fail_compilation/cppmangle.d
+++ b/test/fail_compilation/cppmangle.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/cppmangle.d(10): Error: invalid zero length C++ namespace
-fail_compilation/cppmangle.d(14): Error: expected valid identifer for C++ namespace but got `0num`
+fail_compilation/cppmangle.d(14): Error: expected valid identifier for C++ namespace but got `0num`
 fail_compilation/cppmangle.d(18): Error: string expected following `,` for C++ namespace, not `)`
 ---
 */


### PR DESCRIPTION
C++ backport of #12336.