### PR TITLE
[dmd-cxx] Reapply Fix issue 9029: make types match to alias template parameters with priority MATCH.convert.

### DIFF
--- a/src/dtemplate.c
+++ b/src/dtemplate.c
@@ -5176,6 +5176,16 @@ MATCH TemplateAliasParameter::matchArg(Scope *sc, RootObject *oarg,
              *  template X(T) {}        // T => sa
              */
         }
+        else if (ta && ta->ty != Tident)
+        {
+            /* Match any type that's not a TypeIdentifier to alias parameters,
+             * but prefer type parameter.
+             * template X(alias a) { }  // a == ta
+             *
+             * TypeIdentifiers are excluded because they might be not yet resolved aliases.
+             */
+            m = MATCHconvert;
+        }
         else
             goto Lnomatch;
     }

--- a/test/compilable/test9029.d
+++ b/test/compilable/test9029.d
@@ -1,0 +1,39 @@
+// https://issues.dlang.org/show_bug.cgi?id=9029
+enum NameOf(alias S) = S.stringof;
+
+static assert(NameOf!int == "int");
+
+enum BothMatch(alias S) = "alias";
+enum BothMatch(T) = "type";
+
+void foo9029() { }
+
+struct Struct { }
+
+static assert(BothMatch!int == "type");
+static assert(BothMatch!(void function()) == "type");
+static assert(BothMatch!BothMatch == "alias");
+static assert(BothMatch!Struct == "type");
+static assert(BothMatch!foo9029 == "alias");
+static assert(BothMatch!5 == "alias");
+
+// https://issues.dlang.org/show_bug.cgi?id=19884
+mixin template genCtEvaluate()
+{
+    void evaluate(alias op)() { }
+}
+struct S
+{
+    mixin genCtEvaluate!() mixinEval;
+    alias evaluate = mixinEval.evaluate;
+    void evaluate() { }
+}
+alias List(Ops...) = Ops;
+void main()
+{
+    S g;
+    foreach (op; List!(0))
+    {
+        g.evaluate!op();
+    }
+}


### PR DESCRIPTION
Somehow the fix in 5656b0d21 got reverted in fd350dcfa.