### PR TITLE
Fix 21791 - Stack overflow for forward-referenced enum initializer

### DIFF
--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -299,19 +299,16 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             dsymbolSemantic(this, _scope);
         if (errors)
             return handleErrors();
-        if (semanticRun == PASS.init || !members)
+        if (!members)
         {
             if (isSpecial())
             {
                 /* Allow these special enums to not need a member list
                  */
-                return memtype.defaultInit(loc);
+                return defaultval = memtype.defaultInit(loc);
             }
 
-            if (semanticRun >= PASS.semanticdone)
-                error(loc, "is opaque and has no default initializer");
-            else
-                error(loc, "forward reference of `%s.init`", toChars());
+            error(loc, "is opaque and has no default initializer");
             return handleErrors();
         }
 
@@ -320,6 +317,12 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             EnumMember em = (*members)[i].isEnumMember();
             if (em)
             {
+                if (em.semanticRun < PASS.semanticdone)
+                {
+                    error(loc, "forward reference of `%s.init`", toChars());
+                    return handleErrors();
+                }
+
                 defaultval = em.value;
                 return defaultval;
             }

--- a/test/fail_compilation/enum_init.d
+++ b/test/fail_compilation/enum_init.d
@@ -69,3 +69,19 @@ void fooOB()
 {
 	OpaqueBase ob;
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/enum_init.d(405): Error: enum `enum_init.forwardRef.Foo` forward reference of `Foo.init`
+---
+*/
+#line 400
+
+void forwardRef()
+{
+    enum Foo
+    {
+        a = Foo.init
+    }
+}


### PR DESCRIPTION
Ensure that semantic for the `EnumMember` chosen as `.init` was already done.

The previous check was never hit because `sematicRun` is changed before analyzing the enum body.