### PR TITLE
Fix 21792 - Enum using itself as base type crashes dmd 

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2433,6 +2433,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     ed.semanticRun = PASS.init;
                     return;
                 }
+                else
+                    // Ensure that semantic is run to detect. e.g. invalid forward references
+                    sym.dsymbolSemantic(sc);
             }
             if (ed.memtype.ty == Tvoid)
             {

--- a/test/fail_compilation/enum_init.d
+++ b/test/fail_compilation/enum_init.d
@@ -85,3 +85,21 @@ void forwardRef()
         a = Foo.init
     }
 }
+
+/*
+https://issues.dlang.org/show_bug.cgi?id=21792
+
+TEST_OUTPUT:
+---
+fail_compilation/enum_init.d(503): Error: circular reference to enum base type `Bar`
+---
+*/
+#line 500
+
+void forwardRef2()
+{
+    enum Bar : Bar
+    {
+        a
+    }
+}


### PR DESCRIPTION
Run semantic on the base type to resolve all missing properties and to detect invalid forward references.