### PR TITLE
dmd.dmangle: Fix mangling of nested functions with collisions in their name

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -654,7 +654,7 @@ public:
                     n /= 10;
                     ++ndigits;
                 }
-                buf.printf("%u__S%u", ndigits + 4, localNum);
+                buf.printf("%u__S%u", ndigits + 3, localNum);
             }
         }
     }

--- a/test/compilable/test14831.d
+++ b/test/compilable/test14831.d
@@ -8,7 +8,7 @@ void main()
     }
     {
         int x;
-        static assert(x.mangleof == "_D9test148314mainFZ5__S11xi");
+        static assert(x.mangleof == "_D9test148314mainFZ4__S11xi");
     }
 
     {
@@ -17,7 +17,7 @@ void main()
     }
     {
         static int y = 0;
-        static assert(y.mangleof == "_D9test148314mainFZ5__S11yi");
+        static assert(y.mangleof == "_D9test148314mainFZ4__S11yi");
     }
 
     {
@@ -26,7 +26,7 @@ void main()
     }
     {
         void f() {}
-        static assert(f.mangleof == "_D9test148314mainFZ5__S11fMFNaNbNiNfZv");
+        static assert(f.mangleof == "_D9test148314mainFZ4__S11fMFNaNbNiNfZv");
     }
 
     {
@@ -35,7 +35,7 @@ void main()
     }
     {
         struct S {}
-        static assert(S.mangleof == "S9test148314mainFZ5__S11S");
+        static assert(S.mangleof == "S9test148314mainFZ4__S11S");
     }
 
     {
@@ -44,7 +44,7 @@ void main()
     }
     {
         class C {}
-        static assert(C.mangleof == "C9test148314mainFZ5__S11C");
+        static assert(C.mangleof == "C9test148314mainFZ4__S11C");
     }
 
     {
@@ -54,7 +54,7 @@ void main()
     }
     {
         enum E { a }
-        static assert(E.mangleof == "E9test148314mainFZ5__S11E");
-        static assert(E.a.mangleof == "_D9test148314mainFZ5__S11E1aEQBbQuFZ5__S1Qr");
+        static assert(E.mangleof == "E9test148314mainFZ4__S11E");
+        static assert(E.a.mangleof == "_D9test148314mainFZ4__S11E1aEQBbQuFZ4__S1Qr");
     }
 }


### PR DESCRIPTION
e.g: `_D3mod4funcFZ__T6nestedTiZ5__S1QpMFNaNbNiNfZi` can not be demangled because the fake parent has the wrong prefixing identifier length (`5__S1` is an encoded length followed by a 4 character symbol).

If this was deliberate, then this needs to be added to the spec, and vetted that no ambiguities occur as a result of its introduction, cc @rainers.