### PR TITLE
dmd.chkformat: Use type with correct signedness in pragma(printf) errors

### DIFF
--- a/src/dmd/chkformat.d
+++ b/src/dmd/chkformat.d
@@ -153,37 +153,47 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
             case Format.u:      // unsigned int
             case Format.d:      // int
                 if (t.ty != Tint32 && t.ty != Tuns32)
-                    errorMsg(null, e, "int", t);
+                    errorMsg(null, e, fmt == Format.u ? "uint" : "int", t);
                 break;
 
             case Format.hhu:    // unsigned char
             case Format.hhd:    // signed char
                 if (t.ty != Tint32 && t.ty != Tuns32 && t.ty != Tint8 && t.ty != Tuns8)
-                    errorMsg(null, e, "byte", t);
+                    errorMsg(null, e, fmt == Format.hhu ? "ubyte" : "byte", t);
                 break;
 
             case Format.hu:     // unsigned short int
             case Format.hd:     // short int
                 if (t.ty != Tint32 && t.ty != Tuns32 && t.ty != Tint16 && t.ty != Tuns16)
-                    errorMsg(null, e, "short", t);
+                    errorMsg(null, e, fmt == Format.hu ? "ushort" : "short", t);
                 break;
 
             case Format.lu:     // unsigned long int
             case Format.ld:     // long int
                 if (!(t.isintegral() && t.size() == c_longsize))
-                    errorMsg(null, e, (c_longsize == 4 ? "int" : "long"), t);
+                {
+                    if (fmt == Format.lu)
+                        errorMsg(null, e, (c_longsize == 4 ? "uint" : "ulong"), t);
+                    else
+                        errorMsg(null, e, (c_longsize == 4 ? "int" : "long"), t);
+                }
                 break;
 
             case Format.llu:    // unsigned long long int
             case Format.lld:    // long long int
                 if (t.ty != Tint64 && t.ty != Tuns64)
-                    errorMsg(null, e, "long", t);
+                    errorMsg(null, e, fmt == Format.llu ? "ulong" : "long", t);
                 break;
 
             case Format.ju:     // uintmax_t
             case Format.jd:     // intmax_t
                 if (t.ty != Tint64 && t.ty != Tuns64)
-                    errorMsg(null, e, "core.stdc.stdint.intmax_t", t);
+                {
+                    if (fmt == Format.ju)
+                        errorMsg(null, e, "core.stdc.stdint.uintmax_t", t);
+                    else
+                        errorMsg(null, e, "core.stdc.stdint.intmax_t", t);
+                }
                 break;
 
             case Format.zd:     // size_t

--- a/test/fail_compilation/chkformat.d
+++ b/test/fail_compilation/chkformat.d
@@ -137,3 +137,35 @@ void test302() { va_list vargs; vscanf("%Q", vargs); }
 //void test() { vscanf(); }
 //void test() { vfscanf(); }
 //void test() { vsscanf(); }
+
+/* TEST_OUTPUT:
+---
+fail_compilation/chkformat.d(401): Deprecation: argument `p` for format specification `"%u"` must be `uint`, not `char*`
+fail_compilation/chkformat.d(402): Deprecation: argument `p` for format specification `"%d"` must be `int`, not `char*`
+fail_compilation/chkformat.d(403): Deprecation: argument `p` for format specification `"%hhu"` must be `ubyte`, not `char*`
+fail_compilation/chkformat.d(404): Deprecation: argument `p` for format specification `"%hhd"` must be `byte`, not `char*`
+fail_compilation/chkformat.d(405): Deprecation: argument `p` for format specification `"%hu"` must be `ushort`, not `char*`
+fail_compilation/chkformat.d(406): Deprecation: argument `p` for format specification `"%hd"` must be `short`, not `char*`
+fail_compilation/chkformat.d(407): Deprecation: argument `p` for format specification `"%lu"` must be `$?:windows=uint|32=uint|64=ulong$`, not `char*`
+fail_compilation/chkformat.d(408): Deprecation: argument `p` for format specification `"%ld"` must be `$?:windows=int|32=int|64=long$`, not `char*`
+fail_compilation/chkformat.d(409): Deprecation: argument `p` for format specification `"%llu"` must be `ulong`, not `char*`
+fail_compilation/chkformat.d(410): Deprecation: argument `p` for format specification `"%lld"` must be `long`, not `char*`
+fail_compilation/chkformat.d(411): Deprecation: argument `p` for format specification `"%ju"` must be `core.stdc.stdint.uintmax_t`, not `char*`
+fail_compilation/chkformat.d(412): Deprecation: argument `p` for format specification `"%jd"` must be `core.stdc.stdint.intmax_t`, not `char*`
+---
+*/
+
+#line 400
+
+void test401() { char* p; printf("%u", p); }
+void test402() { char* p; printf("%d", p); }
+void test403() { char* p; printf("%hhu", p); }
+void test404() { char* p; printf("%hhd", p); }
+void test405() { char* p; printf("%hu", p); }
+void test406() { char* p; printf("%hd", p); }
+void test407() { char* p; printf("%lu", p); }
+void test408() { char* p; printf("%ld", p); }
+void test409() { char* p; printf("%llu", p); }
+void test410() { char* p; printf("%lld", p); }
+void test411() { char* p; printf("%ju", p); }
+void test412() { char* p; printf("%jd", p); }


### PR DESCRIPTION
There's quite a bit more wrong with this code, but splitting into multiple PRs for ease of review.