### PR TITLE
Improve error messages for missing @nogc inference

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1438,11 +1438,18 @@ extern (C++) abstract class Expression : ASTNode
                 // Lowered non-@nogc'd hooks will print their own error message inside of nogc.d (NOGCVisitor.visit(CallExp e)),
                 // so don't print anything to avoid double error messages.
                 if (!(f.ident == Id._d_HookTraceImpl || f.ident == Id._d_arraysetlengthT))
+                {
                     error("`@nogc` %s `%s` cannot call non-@nogc %s `%s`",
                         sc.func.kind(), sc.func.toPrettyChars(), f.kind(), f.toPrettyChars());
 
-                checkOverridenDtor(sc, f, dd => dd.type.toTypeFunction().isnogc, "non-@nogc");
-
+                    if (f.isDtorDeclaration())
+                        checkOverridenDtor(sc, f, dd => dd.type.toTypeFunction().isnogc, "non-@nogc");
+                    else
+                    {
+                        import dmd.nogc;
+                        notifyGcStatements(this, f);
+                    }
+                }
                 return true;
             }
         }

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -721,11 +721,11 @@ enum class JsonFieldFlags : uint32_t
     semantics = 8u,
 };
 
+class ExpStatement;
 struct ObNode;
 class StoppableVisitor;
 class PragmaStatement;
 class ScopeGuardStatement;
-class ExpStatement;
 class GotoDefaultStatement;
 class BreakStatement;
 class ContinueStatement;
@@ -4540,6 +4540,7 @@ public:
     PINLINE inlining;
     int32_t inlineNest;
     bool eh_none;
+    uint8_t inferenceTraced;
     bool semantic3Errors;
     ForeachStatement* fes;
     BaseClass* interfaceVirtual;
@@ -5486,6 +5487,9 @@ class NOGCVisitor final : public StoppableVisitor
 public:
     FuncDeclaration* f;
     bool err;
+    bool traceInference;
+    bool ignored;
+    uint8_t depth;
     void doCond(Expression* exp);
     void visit(Expression* e);
     void visit(DeclarationExp* e);
@@ -5498,6 +5502,9 @@ public:
     void visit(AssignExp* e);
     void visit(CatAssignExp* e);
     void visit(CatExp* e);
+    void visit(Statement* cs);
+    void visit(ExpStatement* s);
+    void visit(ReturnStatement* s);
 };
 
 class Nspace final : public ScopeDsymbol

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -286,6 +286,7 @@ extern (C++) class FuncDeclaration : Declaration
 
     int inlineNest;                     /// !=0 if nested inline
     bool eh_none;                       /// true if no exception unwinding is needed
+    ubyte inferenceTraced;              /// Bitflag for inference backtracking
 
     bool semantic3Errors;               /// true if errors in semantic3 this function's frame ptr
     ForeachStatement fes;               /// if foreach body, this is the foreach
@@ -2540,6 +2541,7 @@ extern (C++) class FuncDeclaration : Declaration
         {
             tf = new TypeFunction(ParameterList(fparams), treturn, LINK.c, stc);
             fd = new FuncDeclaration(Loc.initial, Loc.initial, id, STC.static_, tf);
+            fd.generated = true;
             fd.visibility = Visibility(Visibility.Kind.public_);
             fd.linkage = LINK.c;
 

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -141,6 +141,14 @@ nothrow:
         return DYNCAST.identifier;
     }
 
+    /// Returns `true` if this is not anonymous and starts with `prefix`
+    extern(D) final bool startsWith(const scope string prefix) const pure @nogc @safe
+    {
+        return !isAnonymous_
+            && name.length >= prefix.length
+            && name[0 .. prefix.length] == prefix;
+    }
+
     private extern (D) __gshared StringTable!Identifier stringtable;
 
     /**

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -14,7 +14,7 @@
 module dmd.nogc;
 
 import dmd.aggregate;
-import dmd.apply;
+import dmd.apply : walkPostorder;
 import dmd.declaration;
 import dmd.dscope;
 import dmd.expression;
@@ -22,6 +22,7 @@ import dmd.func;
 import dmd.globals;
 import dmd.init;
 import dmd.mtype;
+import dmd.sapply : walkPostorder;
 import dmd.tokens;
 import dmd.visitor;
 
@@ -34,6 +35,9 @@ extern (C++) final class NOGCVisitor : StoppableVisitor
 public:
     FuncDeclaration f;
     bool err;
+    bool traceInference; /// Tracing violations that prohibit @nogc inference
+    bool ignored;        /// Exceeded recursion limit with `traceInference`
+    ubyte depth;         /// Current recursion depth
 
     extern (D) this(FuncDeclaration f)
     {
@@ -67,8 +71,18 @@ public:
     {
         import dmd.id : Id;
         import core.stdc.stdio : printf;
+
         if (!e.f)
+        {
+            // The function declaration might be wrapped in a VarExp as e1 for certain lowerings
+            if (traceInference && e.e1)
+            {
+                auto ve = e.e1.isVarExp();
+                if (ve && ve.var)
+                    check(e, ve.var.isFuncDeclaration());
+            }
             return;
+        }
 
         auto fd = stripHookTraceImpl(e.f);
         if (fd.ident == Id._d_arraysetlengthT)
@@ -80,8 +94,63 @@ public:
                 err = true;
                 return;
             }
-            f.printGCUsage(e.loc, "setting `length` may cause a GC allocation");
+            printGCUsage(e, "setting `length` may cause a GC allocation");
         }
+        else if (traceInference)
+            check(e, e.f);
+    }
+
+    /// Search fd for violations of `@nogc`
+    private void enter(CallExp e, FuncDeclaration fd)
+    {
+        import dmd.errors;
+
+        // Don't spam the user with too many errors at once
+        if (depth > 5 && !global.params.verbose)
+        {
+            ignored = true;
+            return;
+        }
+
+        // Skip functions without attribute inference
+        if ((fd.inferenceTraced & 1) || !fd.isInstantiated() && !fd.isFuncLiteralDeclaration() && !(fd.storage_class & STC.inference))
+            return;
+
+        fd.inferenceTraced |= 1;
+
+        fd.loc.error("|"); // N.B.: Temporary spacing, remove later
+        fd.loc.errorSupplemental("%-*s  inferred non-`@nogc` for `%s` because:", 2 * depth, "".ptr, fd.toPrettyChars());
+
+        depth++;
+        walkPostorder(fd.fbody, this);
+        depth--;
+
+        fd.loc.error("|"); // N.B.: Temporary spacing, remove later
+    }
+
+    /// Checks whether calling fd causes a @nogc violation
+    private void check(CallExp e, FuncDeclaration fd)
+    {
+        // Doesn't violate @nogc
+        if (!fd || fd.type.isTypeFunction().isnogc)
+            return;
+
+        // Detect foreach lowerings including autodecoding
+        // Analyze them as if the delegate was part of the current function
+        if (fd.ident && fd.ident.startsWith("_aApply"))
+        {
+            assert(e.arguments);
+            assert(e.arguments.length == 2);
+
+            auto fe = (*e.arguments)[1].isFuncExp();
+            assert(fe);
+
+            walkPostorder(fe.fd.fbody, this);
+            return;
+        }
+
+        e.errorSupplemental("%-*s- calling %s `%s` may cause a GC allocation", 2 * depth, "".ptr, fd.kind(), fd.toPrettyChars());
+        enter(e, fd);
     }
 
     override void visit(ArrayLiteralExp e)
@@ -95,7 +164,7 @@ public:
             err = true;
             return;
         }
-        f.printGCUsage(e.loc, "array literal may cause a GC allocation");
+        printGCUsage(e, "array literal may cause a GC allocation");
     }
 
     override void visit(AssocArrayLiteralExp e)
@@ -109,7 +178,7 @@ public:
             err = true;
             return;
         }
-        f.printGCUsage(e.loc, "associative array literal may cause a GC allocation");
+        printGCUsage(e, "associative array literal may cause a GC allocation");
     }
 
     override void visit(NewExp e)
@@ -132,7 +201,7 @@ public:
             err = true;
             return;
         }
-        f.printGCUsage(e.loc, "`new` causes a GC allocation");
+        printGCUsage(e, "`new` causes a GC allocation");
     }
 
     override void visit(DeleteExp e)
@@ -169,7 +238,7 @@ public:
             err = true;
             return;
         }
-        f.printGCUsage(e.loc, "`delete` requires the GC");
+        printGCUsage(e, "`delete` requires the GC");
     }
 
     override void visit(IndexExp e)
@@ -184,7 +253,7 @@ public:
                 err = true;
                 return;
             }
-            f.printGCUsage(e.loc, "indexing an associative array may cause a GC allocation");
+            printGCUsage(e, "indexing an associative array may cause a GC allocation");
         }
     }
 
@@ -199,7 +268,7 @@ public:
                 err = true;
                 return;
             }
-            f.printGCUsage(e.loc, "setting `length` may cause a GC allocation");
+            printGCUsage(e, "setting `length` may cause a GC allocation");
         }
     }
 
@@ -212,7 +281,7 @@ public:
             err = true;
             return;
         }
-        f.printGCUsage(e.loc, "operator `~=` may cause a GC allocation");
+        printGCUsage(e, "operator `~=` may cause a GC allocation");
     }
 
     override void visit(CatExp e)
@@ -224,7 +293,39 @@ public:
             err = true;
             return;
         }
-        f.printGCUsage(e.loc, "operator `~` may cause a GC allocation");
+        printGCUsage(e, "operator `~` may cause a GC allocation");
+    }
+
+    /**
+     * Prints a hint regarding GC usage
+     *
+     * Params:
+     *   e   = expression triggering this message
+     *   msg = the hint
+     */
+    private void printGCUsage(Expression e, const char* msg)
+    {
+        if (traceInference)
+            e.errorSupplemental("%-*s- %s", 2 * depth, "".ptr, msg);
+        else
+            f.printGCUsage(e.loc, msg);
+    }
+
+    import dmd.statement : ExpStatement, ReturnStatement, Statement;
+
+    // Ignore other statements
+    override void visit(Statement cs) {}
+
+    // Check actual expressions
+    override void visit(ExpStatement s)
+    {
+        walkPostorder(s.exp, this);
+    }
+
+    // Check expressions in return statements
+    override void visit(ReturnStatement s)
+    {
+        s.exp.accept(this);
     }
 }
 
@@ -242,6 +343,26 @@ Expression checkGC(Scope* sc, Expression e)
             return ErrorExp.get();
     }
     return e;
+}
+
+/**
+ * Prints supplemental messages indicating why `f` was inferred as non-@nogc.
+ *
+ * Params:
+ *   e = expression where f was used
+ *   f = function to check
+ */
+void notifyGcStatements(Expression e, FuncDeclaration f)
+{
+    if (!f || !f.fbody || global.gag)
+        return;
+
+    scope NOGCVisitor gcv = new NOGCVisitor(f);
+    gcv.traceInference = true;
+    gcv.enter(e.isCallExp(), f);
+
+    if (gcv.ignored && !global.params.verbose)
+        e.errorSupplemental("  (use `-v` to print remaining errors)");
 }
 
 /**

--- a/test/fail_compilation/fail13120.d
+++ b/test/fail_compilation/fail13120.d
@@ -20,8 +20,13 @@ fail_compilation/fail13120.d(35): Error: `pure` function `fail13120.h2` cannot c
 fail_compilation/fail13120.d(35): Error: `@safe` function `fail13120.h2` cannot call `@system` function `fail13120.g2!().g2`
 fail_compilation/fail13120.d(27):        `fail13120.g2!().g2` is declared here
 fail_compilation/fail13120.d(35): Error: `@nogc` function `fail13120.h2` cannot call non-@nogc function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(27): Error: |
+fail_compilation/fail13120.d(27):          inferred non-`@nogc` for `fail13120.g2!().g2` because:
+fail_compilation/fail13120.d(30):          - calling function `fail13120.f2` may cause a GC allocation
+fail_compilation/fail13120.d(27): Error: |
 ---
 */
+#line 25
 void f2() {}
 
 void g2()(char[] s)

--- a/test/fail_compilation/trace_inference.d
+++ b/test/fail_compilation/trace_inference.d
@@ -1,0 +1,94 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/trace_inference.d(25): Error: `@nogc` function `trace_inference.foo` cannot call non-@nogc function `trace_inference.bar!int.bar`
+fail_compilation/trace_inference.d(29): Error: |
+fail_compilation/trace_inference.d(29):          inferred non-`@nogc` for `trace_inference.bar!int.bar` because:
+fail_compilation/trace_inference.d(31):          - calling function `trace_inference.factory!int.factory` may cause a GC allocation
+fail_compilation/trace_inference.d(36): Error: |
+fail_compilation/trace_inference.d(36):            inferred non-`@nogc` for `trace_inference.factory!int.factory` because:
+fail_compilation/trace_inference.d(38):            - calling function `trace_inference.helper!().helper` may cause a GC allocation
+fail_compilation/trace_inference.d(42): Error: |
+fail_compilation/trace_inference.d(42):              inferred non-`@nogc` for `trace_inference.helper!().helper` because:
+fail_compilation/trace_inference.d(44):              - associative array literal may cause a GC allocation
+fail_compilation/trace_inference.d(42): Error: |
+fail_compilation/trace_inference.d(39):            - `new` causes a GC allocation
+fail_compilation/trace_inference.d(36): Error: |
+fail_compilation/trace_inference.d(33):          - setting `length` may cause a GC allocation
+fail_compilation/trace_inference.d(29): Error: |
+fail_compilation/trace_inference.d(26): Error: `@nogc` function `trace_inference.foo` cannot call non-@nogc function `trace_inference.factory!int.factory`
+---
+*/
+
+void foo() @nogc
+{
+    bar!int();
+    factory!int();
+}
+
+void bar(T)()
+{
+    factory!T();
+    T[] arr;
+    arr.length = 1;
+}
+
+auto factory(T)()
+{
+    helper();
+    return new T();
+}
+
+auto helper()()
+{
+    return [ 1: 1 ];
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/trace_inference.d(103): Error: `@nogc` function `trace_inference.entry` cannot call non-@nogc function `trace_inference.g2!().g2`
+fail_compilation/trace_inference.d(108): Error: |
+fail_compilation/trace_inference.d(108):          inferred non-`@nogc` for `trace_inference.g2!().g2` because:
+fail_compilation/trace_inference.d(111):          - calling function `trace_inference.f2` may cause a GC allocation
+fail_compilation/trace_inference.d(108): Error: |
+---
+*/
+#line 100
+
+void entry() @nogc
+{
+    g2(null);
+}
+
+void f2() {}
+
+void g2()(char[] s)
+{
+    foreach (dchar dc; s)
+        f2();
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/trace_inference.d(203): Error: `@nogc` function `trace_inference.entryRec` cannot call non-@nogc function `trace_inference.rec!().rec`
+fail_compilation/trace_inference.d(206): Error: |
+fail_compilation/trace_inference.d(206):          inferred non-`@nogc` for `trace_inference.rec!().rec` because:
+fail_compilation/trace_inference.d(208):          - `new` causes a GC allocation
+fail_compilation/trace_inference.d(209):          - calling function `trace_inference.rec!().rec` may cause a GC allocation
+fail_compilation/trace_inference.d(206): Error: |
+---
+*/
+#line 200
+
+void entryRec() @nogc
+{
+    rec();
+}
+
+void rec()()
+{
+    new int(1);
+    rec();
+}


### PR DESCRIPTION
Provide an explanaition why `@nogc` could not be inferred when calling a templated function that violates `@nogc`.

TODO:
- evaluate other implementations (especially w.r.t. implementing hints for other attributes)
  - See #12383
- more tests
- update C++ headers
- changelog?