### PR TITLE
dmd.chkformat: Use ptrsize comparison for 'size_t' and 'ptrdiff_t' formats

### DIFF
--- a/src/dmd/chkformat.d
+++ b/src/dmd/chkformat.d
@@ -144,7 +144,7 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
         auto t = e.type.toBasetype();
         auto tnext = t.nextOf();
         const c_longsize = target.c.longsize;
-        const isLP64 = global.params.isLP64;
+        const ptrsize = target.ptrsize;
 
         // Types which are promoted to int are allowed.
         // Spec: C99 6.5.2.2.7
@@ -197,12 +197,12 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
                 break;
 
             case Format.zd:     // size_t
-                if (!(t.isintegral() && t.size() == (isLP64 ? 8 : 4)))
+                if (!(t.isintegral() && t.size() == ptrsize))
                     errorMsg(null, e, "size_t", t);
                 break;
 
             case Format.td:     // ptrdiff_t
-                if (!(t.isintegral() && t.size() == (isLP64 ? 8 : 4)))
+                if (!(t.isintegral() && t.size() == ptrsize))
                     errorMsg(null, e, "ptrdiff_t", t);
                 break;
 
@@ -254,12 +254,12 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
                 break;
 
             case Format.zn:     // pointer to size_t
-                if (!(t.ty == Tpointer && tnext.ty == (isLP64 ? Tuns64 : Tuns32)))
+                if (!(t.ty == Tpointer && tnext.isintegral() && tnext.isunsigned() && tnext.size() == ptrsize))
                     errorMsg(null, e, "size_t*", t);
                 break;
 
             case Format.tn:     // pointer to ptrdiff_t
-                if (!(t.ty == Tpointer && tnext.ty == (isLP64 ? Tint64 : Tint32)))
+                if (!(t.ty == Tpointer && tnext.isintegral() && !tnext.isunsigned() && tnext.size() == ptrsize))
                     errorMsg(null, e, "ptrdiff_t*", t);
                 break;
 
@@ -383,7 +383,7 @@ bool checkScanfFormat(ref const Loc loc, scope const char[] format, scope Expres
         auto t = e.type.toBasetype();
         auto tnext = t.nextOf();
         const c_longsize = target.c.longsize;
-        const isLP64 = global.params.isLP64;
+        const ptrsize = target.ptrsize;
 
         final switch (fmt)
         {
@@ -425,13 +425,13 @@ bool checkScanfFormat(ref const Loc loc, scope const char[] format, scope Expres
 
             case Format.zn:
             case Format.zd:     // pointer to size_t
-                if (!(t.ty == Tpointer && tnext.ty == (isLP64 ? Tuns64 : Tuns32)))
+                if (!(t.ty == Tpointer && tnext.isintegral() && tnext.isunsigned() && tnext.size() == ptrsize))
                     errorMsg(null, e, "size_t*", t);
                 break;
 
             case Format.tn:
             case Format.td:     // pointer to ptrdiff_t
-                if (!(t.ty == Tpointer && tnext.ty == (isLP64 ? Tint64 : Tint32)))
+                if (!(t.ty == Tpointer && tnext.isintegral() && !tnext.isunsigned() && tnext.size() == ptrsize))
                     errorMsg(null, e, "ptrdiff_t*", t);
                 break;
 


### PR DESCRIPTION
Target already has the size information, no need to use another flag to guess it.  This allows `pragma(printf)` to work correctly with 16-bit platforms too.