### PR TITLE
move is64bit and isLP64 from global.params to target

### DIFF
--- a/src/dmd/argtypes_sysv_x64.d
+++ b/src/dmd/argtypes_sysv_x64.d
@@ -14,6 +14,7 @@ module dmd.argtypes_sysv_x64;
 import dmd.declaration;
 import dmd.globals;
 import dmd.mtype;
+import dmd.target;
 import dmd.visitor;
 
 /****************************************************
@@ -263,14 +264,14 @@ extern (C++) final class ToClassesVisitor : Visitor
 
     override void visit(TypeDArray)
     {
-        if (!global.params.isLP64)
+        if (!target.isLP64)
             return one(Class.integer);
         return two(Class.integer, Class.integer);
     }
 
     override void visit(TypeDelegate)
     {
-        if (!global.params.isLP64)
+        if (!target.isLP64)
             return one(Class.integer);
         return two(Class.integer, Class.integer);
     }
@@ -360,7 +361,7 @@ extern (C++) final class ToClassesVisitor : Visitor
                 {
                     assert(foffset % 8 == 0 ||
                         fEightbyteEnd - fEightbyteStart <= 1 ||
-                        !global.params.isLP64,
+                        !target.isLP64,
                         "Field not aligned at eightbyte boundary but contributing to multiple eightbytes?"
                     );
                     foreach (i, fclass; classify(ftype, fsize).slice())

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2941,7 +2941,7 @@ struct ASTBase
             twstring = twchar.immutableOf().arrayOf();
             tdstring = tdchar.immutableOf().arrayOf();
 
-            const isLP64 = global.params.isLP64;
+            const isLP64 = Target.isLP64;
 
             tsize_t    = basic[isLP64 ? Tuns64 : Tuns32];
             tptrdiff_t = basic[isLP64 ? Tint64 : Tint32];
@@ -6809,5 +6809,6 @@ struct ASTBase
     struct Target
     {
         extern (C++) __gshared int ptrsize;
+        extern (C++) __gshared bool isLP64;
     }
 }

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -1111,7 +1111,7 @@ DtorDeclaration buildExternDDtor(AggregateDeclaration ad, Scope* sc)
         return null;
 
     // ABI incompatible on all (?) x86 32-bit platforms
-    if (ad.classKind != ClassKind.cpp || global.params.is64bit)
+    if (ad.classKind != ClassKind.cpp || target.is64bit)
         return dtor;
 
     // generate member function that adjusts calling convention

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -41,7 +41,7 @@ extern (C++):
 
 const(char)* toCppMangleMSVC(Dsymbol s)
 {
-    scope VisualCPPMangler v = new VisualCPPMangler(!global.params.mscoff);
+    scope VisualCPPMangler v = new VisualCPPMangler(!target.mscoff);
     return v.mangleOf(s);
 }
 
@@ -329,7 +329,7 @@ public:
                 buf.writeByte('Q'); // const
             else
                 buf.writeByte('P'); // mutable
-            if (global.params.is64bit)
+            if (target.is64bit)
                 buf.writeByte('E');
             flags |= IS_NOT_TOP_TYPE;
             mangleArray(cast(TypeSArray)type.next);
@@ -348,7 +348,7 @@ public:
             {
                 buf.writeByte('P'); // mutable
             }
-            if (global.params.is64bit)
+            if (target.is64bit)
                 buf.writeByte('E');
             flags |= IS_NOT_TOP_TYPE;
             type.next.accept(this);
@@ -365,7 +365,7 @@ public:
             return;
 
         buf.writeByte('A'); // mutable
-        if (global.params.is64bit)
+        if (target.is64bit)
             buf.writeByte('E');
         flags |= IS_NOT_TOP_TYPE;
         assert(type.next);
@@ -469,7 +469,7 @@ public:
             buf.writeByte('Q');
         else
             buf.writeByte('P');
-        if (global.params.is64bit)
+        if (target.is64bit)
             buf.writeByte('E');
         flags |= IS_NOT_TOP_TYPE;
         mangleModifier(type);
@@ -537,7 +537,7 @@ extern(D):
             {
                 mangleVisibility(d, "AIQ");
             }
-            if (global.params.is64bit)
+            if (target.is64bit)
                 buf.writeByte('E');
             if (d.type.isConst())
             {
@@ -597,7 +597,7 @@ extern(D):
         if (t.ty != Tpointer)
             t = t.mutableOf();
         t.accept(this);
-        if ((t.ty == Tpointer || t.ty == Treference || t.ty == Tclass) && global.params.is64bit)
+        if ((t.ty == Tpointer || t.ty == Treference || t.ty == Tclass) && target.is64bit)
         {
             buf.writeByte('E');
         }
@@ -1173,7 +1173,7 @@ extern(D):
     {
         scope VisualCPPMangler tmp = new VisualCPPMangler(this);
         // Calling convention
-        if (global.params.is64bit) // always Microsoft x64 calling convention
+        if (target.is64bit) // always Microsoft x64 calling convention
         {
             tmp.buf.writeByte('A');
         }

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -89,7 +89,7 @@ void backend_init()
         exe = true;         // if writing out EXE file
 
     out_config_init(
-        (params.is64bit ? 64 : 32) | (params.mscoff ? 1 : 0),
+        (target.is64bit ? 64 : 32) | (target.mscoff ? 1 : 0),
         exe,
         false, //params.trace,
         params.nofloat,

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1996,7 +1996,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         // Should be merged with PragmaStatement
         //printf("\tPragmaDeclaration::semantic '%s'\n", pd.toChars());
-        if (global.params.mscoff)
+        if (target.mscoff)
         {
             if (pd.ident == Id.linkerDirective)
             {
@@ -3753,7 +3753,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
                 /* These quirky conditions mimic what VC++ appears to do
                  */
-                if (global.params.mscoff && cd.classKind == ClassKind.cpp &&
+                if (target.mscoff && cd.classKind == ClassKind.cpp &&
                     cd.baseClass && cd.baseClass.vtbl.dim)
                 {
                     /* if overriding an interface function, then this is not

--- a/src/dmd/eh.d
+++ b/src/dmd/eh.d
@@ -19,6 +19,7 @@ import core.stdc.string;
 
 import dmd.globals;
 import dmd.errors;
+import dmd.target;
 
 import dmd.root.rmem;
 
@@ -113,7 +114,7 @@ void except_fillInEHTable(Symbol *s)
  */
     uint GUARD_SIZE;
     if (config.ehmethod == EHmethod.EH_DM)
-        GUARD_SIZE = (global.params.is64bit ? 3*8 : 5*4);
+        GUARD_SIZE = (target.is64bit ? 3*8 : 5*4);
     else if (config.ehmethod == EHmethod.EH_WIN32)
         GUARD_SIZE = 3*4;
     else

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -140,7 +140,7 @@ void initDMD(
     }
 
     versionIdentifiers.each!(VersionCondition.addGlobalIdent);
-    addDefaultVersionIdentifiers(global.params);
+    addDefaultVersionIdentifiers(global.params, target);
 
     Type._init();
     Id.initialize();
@@ -150,6 +150,8 @@ void initDMD(
     Expression._init();
     Objc._init();
     FileCache._init();
+
+    addDefaultVersionIdentifiers(global.params,target);
 
     version (CRuntime_Microsoft)
         initFPU();

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6575,10 +6575,13 @@ struct Target
     TargetObjC objc;
     _d_dynamicArray< const char > architectureName;
     CPU cpu;
+    bool is64bit;
+    bool isLP64;
     _d_dynamicArray< const char > obj_ext;
     _d_dynamicArray< const char > lib_ext;
     _d_dynamicArray< const char > dll_ext;
     bool run_noext;
+    bool mscoff;
     template <typename T>
     struct FPTypeProperties
     {
@@ -6618,7 +6621,7 @@ private:
 public:
     void _init(const Param& params);
     void setCPU();
-    void addPredefinedGlobalIdentifiers();
+    void addPredefinedGlobalIdentifiers() const;
     void deinitialize();
     uint32_t alignsize(Type* type);
     uint32_t fieldalign(Type* type);
@@ -6656,16 +6659,19 @@ public:
         objc(),
         architectureName(),
         cpu((CPU)11),
+        is64bit(true),
+        isLP64(),
         obj_ext(),
         lib_ext(),
         dll_ext(),
         run_noext(),
+        mscoff(false),
         FloatProperties(),
         DoubleProperties(),
         RealProperties()
     {
     }
-    Target(OS os, uint32_t ptrsize = 0u, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, nullptr, (Runtime)0u), TargetCPP cpp = TargetCPP(false, false, false, (Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
+    Target(OS os, uint32_t ptrsize = 0u, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, nullptr, (Runtime)0u), TargetCPP cpp = TargetCPP(false, false, false, (Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool mscoff = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
         os(os),
         ptrsize(ptrsize),
         realsize(realsize),
@@ -6678,10 +6684,13 @@ public:
         objc(objc),
         architectureName(architectureName),
         cpu(cpu),
+        is64bit(is64bit),
+        isLP64(isLP64),
         obj_ext(obj_ext),
         lib_ext(lib_ext),
         dll_ext(dll_ext),
         run_noext(run_noext),
+        mscoff(mscoff),
         FloatProperties(FloatProperties),
         DoubleProperties(DoubleProperties),
         RealProperties(RealProperties)
@@ -6909,9 +6918,6 @@ struct Param
     uint8_t symdebug;
     bool symdebugref;
     bool optimize;
-    bool is64bit;
-    bool isLP64;
-    bool mscoff;
     DiagnosticReporting useDeprecated;
     bool stackstomp;
     bool useUnitTests;
@@ -7040,9 +7046,6 @@ struct Param
         symdebug(),
         symdebugref(),
         optimize(),
-        is64bit(true),
-        isLP64(),
-        mscoff(false),
         useDeprecated((DiagnosticReporting)1u),
         stackstomp(),
         useUnitTests(),
@@ -7147,7 +7150,7 @@ struct Param
         mapfile()
     {
     }
-    Param(bool obj, bool link = true, bool dll = false, bool lib = false, bool multiobj = false, bool oneobj = false, bool trace = false, bool tracegc = false, bool verbose = false, bool vcg_ast = false, bool showColumns = false, bool vtls = false, bool vtemplates = false, bool vtemplatesListInstances = false, bool vgc = false, bool vfield = false, bool vcomplex = false, uint8_t symdebug = 0u, bool symdebugref = false, bool optimize = false, bool is64bit = true, bool isLP64 = false, bool mscoff = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool stackstomp = false, bool useUnitTests = false, bool useInline = false, FeatureState useDIP25 = (FeatureState)-1, bool useDIP1021 = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, PIC pic = (PIC)0u, bool color = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool nofloat = false, bool ignoreUnsupportedPragmas = false, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool noSharedAccess = false, bool previewIn = false, bool shortenedMethods = false, bool betterC = false, bool addMain = false, bool allInst = false, bool fix16997 = false, bool fixAliasThis = false, bool inclusiveInContracts = false, bool vsafe = false, bool ehnogc = false, FeatureState dtorFields = (FeatureState)-1, bool fieldwise = false, bool rvalueRefParam = false, CppStdRevision cplusplus = (CppStdRevision)201103u, bool markdown = true, bool vmarkdown = false, bool showGaggedErrors = false, bool printErrorContext = false, bool manual = false, bool usage = false, bool mcpuUsage = false, bool transitionUsage = false, bool checkUsage = false, bool checkActionUsage = false, bool revertUsage = false, bool previewUsage = false, bool externStdUsage = false, bool hcUsage = false, bool logo = false, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, uint32_t errorLimit = 20u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >* imppath = nullptr, Array<const char* >* fileImppath = nullptr, _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, bool doDocComments = false, _d_dynamicArray< const char > docdir = {}, _d_dynamicArray< const char > docname = {}, Array<const char* > ddocfiles = Array<const char* >(0LLU, {}, arrayliteral), bool doHdrGeneration = false, _d_dynamicArray< const char > hdrdir = {}, _d_dynamicArray< const char > hdrname = {}, bool hdrStripPlainFunctions = true, CxxHeaderMode doCxxHdrGeneration = (CxxHeaderMode)0u, _d_dynamicArray< const char > cxxhdrdir = {}, _d_dynamicArray< const char > cxxhdrname = {}, bool doJsonGeneration = false, _d_dynamicArray< const char > jsonfilename = {}, JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, OutBuffer* mixinOut = nullptr, const char* mixinFile = nullptr, int32_t mixinLines = 0, uint32_t debuglevel = 0u, Array<const char* >* debugids = nullptr, uint32_t versionlevel = 0u, Array<const char* >* versionids = nullptr, _d_dynamicArray< const char > defaultlibname = {}, _d_dynamicArray< const char > debuglibname = {}, _d_dynamicArray< const char > mscrtlib = {}, _d_dynamicArray< const char > moduleDepsFile = {}, OutBuffer* moduleDeps = nullptr, bool emitMakeDeps = false, _d_dynamicArray< const char > makeDepsFile = {}, Array<const char* > makeDeps = Array<const char* >(0LLU, {}, arrayliteral), MessageStyle messageStyle = (MessageStyle)0u, bool run = false, Array<const char* > runargs = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > objfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > linkswitches = Array<const char* >(0LLU, {}, arrayliteral), Array<bool > linkswitchIsForCC = Array<bool >(0LLU, {}, arrayliteral), Array<const char* > libfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > dllfiles = Array<const char* >(0LLU, {}, arrayliteral), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
+    Param(bool obj, bool link = true, bool dll = false, bool lib = false, bool multiobj = false, bool oneobj = false, bool trace = false, bool tracegc = false, bool verbose = false, bool vcg_ast = false, bool showColumns = false, bool vtls = false, bool vtemplates = false, bool vtemplatesListInstances = false, bool vgc = false, bool vfield = false, bool vcomplex = false, uint8_t symdebug = 0u, bool symdebugref = false, bool optimize = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool stackstomp = false, bool useUnitTests = false, bool useInline = false, FeatureState useDIP25 = (FeatureState)-1, bool useDIP1021 = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, PIC pic = (PIC)0u, bool color = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool nofloat = false, bool ignoreUnsupportedPragmas = false, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool noSharedAccess = false, bool previewIn = false, bool shortenedMethods = false, bool betterC = false, bool addMain = false, bool allInst = false, bool fix16997 = false, bool fixAliasThis = false, bool inclusiveInContracts = false, bool vsafe = false, bool ehnogc = false, FeatureState dtorFields = (FeatureState)-1, bool fieldwise = false, bool rvalueRefParam = false, CppStdRevision cplusplus = (CppStdRevision)201103u, bool markdown = true, bool vmarkdown = false, bool showGaggedErrors = false, bool printErrorContext = false, bool manual = false, bool usage = false, bool mcpuUsage = false, bool transitionUsage = false, bool checkUsage = false, bool checkActionUsage = false, bool revertUsage = false, bool previewUsage = false, bool externStdUsage = false, bool hcUsage = false, bool logo = false, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, uint32_t errorLimit = 20u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >* imppath = nullptr, Array<const char* >* fileImppath = nullptr, _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, bool doDocComments = false, _d_dynamicArray< const char > docdir = {}, _d_dynamicArray< const char > docname = {}, Array<const char* > ddocfiles = Array<const char* >(0LLU, {}, arrayliteral), bool doHdrGeneration = false, _d_dynamicArray< const char > hdrdir = {}, _d_dynamicArray< const char > hdrname = {}, bool hdrStripPlainFunctions = true, CxxHeaderMode doCxxHdrGeneration = (CxxHeaderMode)0u, _d_dynamicArray< const char > cxxhdrdir = {}, _d_dynamicArray< const char > cxxhdrname = {}, bool doJsonGeneration = false, _d_dynamicArray< const char > jsonfilename = {}, JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, OutBuffer* mixinOut = nullptr, const char* mixinFile = nullptr, int32_t mixinLines = 0, uint32_t debuglevel = 0u, Array<const char* >* debugids = nullptr, uint32_t versionlevel = 0u, Array<const char* >* versionids = nullptr, _d_dynamicArray< const char > defaultlibname = {}, _d_dynamicArray< const char > debuglibname = {}, _d_dynamicArray< const char > mscrtlib = {}, _d_dynamicArray< const char > moduleDepsFile = {}, OutBuffer* moduleDeps = nullptr, bool emitMakeDeps = false, _d_dynamicArray< const char > makeDepsFile = {}, Array<const char* > makeDeps = Array<const char* >(0LLU, {}, arrayliteral), MessageStyle messageStyle = (MessageStyle)0u, bool run = false, Array<const char* > runargs = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > objfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > linkswitches = Array<const char* >(0LLU, {}, arrayliteral), Array<bool > linkswitchIsForCC = Array<bool >(0LLU, {}, arrayliteral), Array<const char* > libfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > dllfiles = Array<const char* >(0LLU, {}, arrayliteral), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
         obj(obj),
         link(link),
         dll(dll),
@@ -7168,9 +7171,6 @@ struct Param
         symdebug(symdebug),
         symdebugref(symdebugref),
         optimize(optimize),
-        is64bit(is64bit),
-        isLP64(isLP64),
-        mscoff(mscoff),
         useDeprecated(useDeprecated),
         stackstomp(stackstomp),
         useUnitTests(useUnitTests),
@@ -7340,7 +7340,7 @@ struct Global
         debugids()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > mars_ext = { 1, "d" }, _d_dynamicArray< const char > doc_ext = { 4, "html" }, _d_dynamicArray< const char > ddoc_ext = { 4, "ddoc" }, _d_dynamicArray< const char > hdr_ext = { 2, "di" }, _d_dynamicArray< const char > cxxhdr_ext = { 1, "h" }, _d_dynamicArray< const char > json_ext = { 4, "json" }, _d_dynamicArray< const char > map_ext = { 3, "map" }, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, 0u, false, false, true, false, false, (DiagnosticReporting)1u, false, false, false, (FeatureState)-1, false, false, false, (DiagnosticReporting)2u, (PIC)0u, false, false, 0u, false, false, false, true, true, true, false, false, false, false, false, false, false, false, false, false, false, (FeatureState)-1, false, false, (CppStdRevision)201103u, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKACTION)0u, 20u, {}, Array<const char* >(0LLU, {}, arrayliteral), nullptr, nullptr, {}, {}, {}, false, {}, {}, Array<const char* >(0LLU, {}, arrayliteral), false, {}, {}, true, (CxxHeaderMode)0u, {}, {}, false, {}, (JsonFieldFlags)0u, nullptr, nullptr, 0, 0u, nullptr, 0u, nullptr, {}, {}, {}, {}, nullptr, false, {}, Array<const char* >(0LLU, {}, arrayliteral), (MessageStyle)0u, false, Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<bool >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), {}, {}, {}, {}), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > mars_ext = { 1, "d" }, _d_dynamicArray< const char > doc_ext = { 4, "html" }, _d_dynamicArray< const char > ddoc_ext = { 4, "ddoc" }, _d_dynamicArray< const char > hdr_ext = { 2, "di" }, _d_dynamicArray< const char > cxxhdr_ext = { 1, "h" }, _d_dynamicArray< const char > json_ext = { 4, "json" }, _d_dynamicArray< const char > map_ext = { 3, "map" }, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, 0u, false, false, (DiagnosticReporting)1u, false, false, false, (FeatureState)-1, false, false, false, (DiagnosticReporting)2u, (PIC)0u, false, false, 0u, false, false, false, true, true, true, false, false, false, false, false, false, false, false, false, false, false, (FeatureState)-1, false, false, (CppStdRevision)201103u, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKACTION)0u, 20u, {}, Array<const char* >(0LLU, {}, arrayliteral), nullptr, nullptr, {}, {}, {}, false, {}, {}, Array<const char* >(0LLU, {}, arrayliteral), false, {}, {}, true, (CxxHeaderMode)0u, {}, {}, false, {}, (JsonFieldFlags)0u, nullptr, nullptr, 0, 0u, nullptr, 0u, nullptr, {}, {}, {}, {}, nullptr, false, {}, Array<const char* >(0LLU, {}, arrayliteral), (MessageStyle)0u, false, Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<bool >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), {}, {}, {}, {}), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr) :
         inifilename(inifilename),
         mars_ext(mars_ext),
         doc_ext(doc_ext),

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -131,9 +131,6 @@ extern (C++) struct Param
     ubyte symdebug;         // insert debug symbolic information
     bool symdebugref;       // insert debug information for all referenced types, too
     bool optimize;          // run optimizer
-    bool is64bit = (size_t.sizeof == 8);  // generate 64 bit code; true by default for 64 bit dmd
-    bool isLP64;            // generate code for LP64
-    bool mscoff = false;    // for Win32: write MsCoff object files instead of OMF
     DiagnosticReporting useDeprecated = DiagnosticReporting.inform;  // how use of deprecated features are handled
     bool stackstomp;            // add stack stomping code
     bool useUnitTests;          // generate unittest code
@@ -357,10 +354,6 @@ extern (C++) struct Global
         version (MARS)
         {
             vendor = "Digital Mars D";
-            static if (TARGET.Windows)
-            {
-                params.mscoff = params.is64bit;
-            }
 
             // -color=auto is the default value
             import dmd.console : Console;

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -110,9 +110,6 @@ struct Param
     unsigned char symdebug;  // insert debug symbolic information
     bool symdebugref;   // insert debug information for all referenced types, too
     bool optimize;      // run optimizer
-    bool is64bit;       // generate 64 bit code
-    bool isLP64;        // generate code for LP64
-    bool mscoff;        // for Win32: write COFF object files instead of OMF
     Diagnostic useDeprecated;
     bool stackstomp;    // add stack stomping code
     bool useUnitTests;  // generate unittest code

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -763,7 +763,7 @@ RETRY:
     switch (usActual)
     {
         case 0:
-            if (global.params.is64bit && (pop.ptb.pptb0.usFlags & _i64_bit))
+            if (target.is64bit && (pop.ptb.pptb0.usFlags & _i64_bit))
             {
                 asmerr("opcode `%s` is unavailable in 64bit mode", asm_opstr(pop));  // illegal opcode in 64bit mode
                 break;
@@ -806,7 +806,7 @@ RETRY:
                         continue;
 
                     // Check if match is invalid in 64bit mode
-                    if (global.params.is64bit && (table1.usFlags & _i64_bit))
+                    if (target.is64bit && (table1.usFlags & _i64_bit))
                     {
                         bInvalid64bit = true;
                         continue;
@@ -873,7 +873,7 @@ RETRY:
             {
                 if (log) { printf("table1   = "); asm_output_flags(table2.usOp1); printf("\n"); }
                 if (log) { printf("table2   = "); asm_output_flags(table2.usOp2); printf("\n"); }
-                if (global.params.is64bit && (table2.usFlags & _i64_bit))
+                if (target.is64bit && (table2.usFlags & _i64_bit))
                     asmerr("opcode `%s` is unavailable in 64bit mode", asm_opstr(pop));
 
                 const bMatch1 = asm_match_flags(opflags[0], table2.usOp1);
@@ -1368,7 +1368,7 @@ code *asm_emit(Loc loc,
     {
         emit(0x67);
         pc.Iflags |= CFaddrsize;
-        if (!global.params.is64bit)
+        if (!target.is64bit)
             amods[i] = _addr16;
         else
             amods[i] = _addr32;
@@ -1489,10 +1489,10 @@ code *asm_emit(Loc loc,
 
     asmstate.statement.regs |= asm_modify_regs(ptb, opnds);
 
-    if (ptb.pptb0.usFlags & _64_bit && !global.params.is64bit)
+    if (ptb.pptb0.usFlags & _64_bit && !target.is64bit)
         asmerr("use -m64 to compile 64 bit instructions");
 
-    if (global.params.is64bit && (ptb.pptb0.usFlags & _64_bit))
+    if (target.is64bit && (ptb.pptb0.usFlags & _64_bit))
     {
         emit(REX | REX_W);
         pc.Irex |= REX_W;
@@ -1517,7 +1517,7 @@ code *asm_emit(Loc loc,
         // an immediate and does not affect operation size
         case 3:
         case 2:
-            if ((!global.params.is64bit &&
+            if ((!target.is64bit &&
                   (amods[1] == _addr16 ||
                    (isOneOf(OpndSize._16, uSizemaskTable[1]) && aoptyTable[1] == _rel ) ||
                    (isOneOf(OpndSize._32, uSizemaskTable[1]) && aoptyTable[1] == _mnoi) ||
@@ -1536,7 +1536,7 @@ code *asm_emit(Loc loc,
             goto case;
 
         case 1:
-            if ((!global.params.is64bit &&
+            if ((!target.is64bit &&
                   (amods[0] == _addr16 ||
                    (isOneOf(OpndSize._16, uSizemaskTable[0]) && aoptyTable[0] == _rel ) ||
                    (isOneOf(OpndSize._32, uSizemaskTable[0]) && aoptyTable[0] == _mnoi) ||
@@ -1887,7 +1887,7 @@ L3:
                 {
                     reg &= 7;
                     pc.Irex |= REX_B;
-                    assert(global.params.is64bit);
+                    assert(target.is64bit);
                 }
                 if (asmstate.ucItype == ITfloat)
                     pc.Irm += reg;
@@ -1969,12 +1969,12 @@ L3:
                 {
                     reg &= 7;
                     pc.Irex |= REX_B;
-                    assert(global.params.is64bit);
+                    assert(target.is64bit);
                 }
                 else if (opnds[0].base.isSIL_DIL_BPL_SPL())
                 {
                     pc.Irex |= REX;
-                    assert(global.params.is64bit);
+                    assert(target.is64bit);
                 }
                 if (asmstate.ucItype == ITfloat)
                     pc.Irm += reg;
@@ -1991,12 +1991,12 @@ L3:
                 {
                     reg &= 7;
                     pc.Irex |= REX_B;
-                    assert(global.params.is64bit);
+                    assert(target.is64bit);
                 }
                 else if (opnds[0].base.isSIL_DIL_BPL_SPL())
                 {
                     pc.Irex |= REX;
-                    assert(global.params.is64bit);
+                    assert(target.is64bit);
                 }
                 if (asmstate.ucItype == ITfloat)
                     pc.Irm += reg;
@@ -2068,7 +2068,7 @@ L3:
                     {
                         reg &= 7;
                         pc.Irex |= REX_B;
-                        assert(global.params.is64bit);
+                        assert(target.is64bit);
                     }
                     if (asmstate.ucItype == ITfloat)
                         pc.Irm += reg;
@@ -2544,7 +2544,7 @@ void asm_make_modrm_byte(
                 }
                 else
                 {
-                    pc.IFL1 = global.params.is64bit ? FLblock : FLblockoff;
+                    pc.IFL1 = target.is64bit ? FLblock : FLblockoff;
                     pc.IEV1.Vlsym = cast(_LabelDsymbol*)label;
                 }
                 pc.Iflags |= CFoff;
@@ -2598,7 +2598,7 @@ void asm_make_modrm_byte(
             assert(d);
             if (d.isDataseg() || d.isCodeseg())
             {
-                if (!global.params.is64bit && amod == _addr16)
+                if (!target.is64bit && amod == _addr16)
                 {
                     asmerr("cannot have 16 bit addressing mode in 32 bit code");
                     return;
@@ -2685,7 +2685,7 @@ void asm_make_modrm_byte(
             bOffsetsym = true;
 
     }
-    else if (amod == _addr32 || (amod == _flbl && !global.params.is64bit))
+    else if (amod == _addr32 || (amod == _flbl && !target.is64bit))
     {
         bool bModset = false;
 
@@ -3406,7 +3406,7 @@ immutable(REG)* asm_reg_lookup(const(char)[] s)
             return &regtab[i];
         }
     }
-    if (global.params.is64bit)
+    if (target.is64bit)
     {
         for (int i = 0; i < regtab64.length; i++)
         {
@@ -3471,7 +3471,7 @@ OpndSize asm_type_size(Type ptype, bool bPtr)
             case 4:     u = OpndSize._32;        break;
             case 6:     u = OpndSize._48;        break;
 
-            case 8:     if (global.params.is64bit || bPtr)
+            case 8:     if (target.is64bit || bPtr)
                             u = OpndSize._64;
                         break;
 

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -51,7 +51,7 @@ class Library
     {
         static if (TARGET.Windows)
         {
-            return (global.params.mscoff || global.params.is64bit) ? LibMSCoff_factory() : LibOMF_factory();
+            return (target.mscoff || target.is64bit) ? LibMSCoff_factory() : LibOMF_factory();
         }
         else static if (TARGET.Linux || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
         {

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -226,7 +226,7 @@ public int runLINK()
         if (phobosLibname)
             global.params.libfiles.push(phobosLibname.xarraydup.ptr);
 
-        if (global.params.mscoff)
+        if (target.mscoff)
         {
             OutBuffer cmdbuf;
             cmdbuf.writestring("/NOLOGO");
@@ -301,21 +301,21 @@ public int runLINK()
                 global.params.mscrtlib[0..6] != "msvcrt" || !isdigit(global.params.mscrtlib[6]))
                 vsopt.initialize();
 
-            const(char)* lflags = vsopt.linkOptions(global.params.is64bit);
+            const(char)* lflags = vsopt.linkOptions(target.is64bit);
             if (lflags)
             {
                 cmdbuf.writeByte(' ');
                 cmdbuf.writestring(lflags);
             }
 
-            const(char)* linkcmd = getenv(global.params.is64bit ? "LINKCMD64" : "LINKCMD");
+            const(char)* linkcmd = getenv(target.is64bit ? "LINKCMD64" : "LINKCMD");
             if (!linkcmd)
                 linkcmd = getenv("LINKCMD"); // backward compatible
             if (!linkcmd)
-                linkcmd = vsopt.linkerPath(global.params.is64bit);
+                linkcmd = vsopt.linkerPath(target.is64bit);
 
             // object files not SAFESEH compliant, but LLD is more picky than MS link
-            if (!global.params.is64bit)
+            if (!target.is64bit)
                 if (FileName.equals(FileName.name(linkcmd), "lld-link.exe"))
                     cmdbuf.writestring(" /SAFESEH:NO");
 
@@ -555,7 +555,7 @@ public int runLINK()
         ensurePathToNameExists(Loc.initial, global.params.exefile);
         if (global.params.symdebug)
             argv.push("-g");
-        if (global.params.is64bit)
+        if (target.is64bit)
             argv.push("-m64");
         else
             argv.push("-m32");
@@ -833,7 +833,7 @@ version (Windows)
         size_t len;
         if (global.params.verbose)
             message("%s %s", cmd, args);
-        if (!global.params.mscoff)
+        if (!target.mscoff)
         {
             if ((len = strlen(args)) > 255)
             {

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -909,7 +909,7 @@ extern (C++) abstract class Type : ASTNode
         twstring = twchar.immutableOf().arrayOf();
         tdstring = tdchar.immutableOf().arrayOf();
 
-        const isLP64 = global.params.isLP64;
+        const isLP64 = target.isLP64;
 
         tsize_t    = basic[isLP64 ? Tuns64 : Tuns32];
         tptrdiff_t = basic[isLP64 ? Tint64 : Tint32];

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -1125,7 +1125,7 @@ private extern (C++) class S2irVisitor : Visitor
                 tryblock.appendSucc(bcatch);
                 block_goto(blx, BCjcatch, null);
 
-                if (cs.type && irs.target.os == Target.OS.Windows && irs.params.is64bit) // Win64
+                if (cs.type && irs.target.os == Target.OS.Windows && irs.target.is64bit) // Win64
                 {
                     /* The linker will attempt to merge together identical functions,
                      * even if the catch types differ. So add a reference to the

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -798,7 +798,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 TY keyty = p.type.ty;
                 if (keyty != Tint32 && keyty != Tuns32)
                 {
-                    if (global.params.isLP64)
+                    if (target.isLP64)
                     {
                         if (keyty != Tint64 && keyty != Tuns64)
                         {

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -137,12 +137,15 @@ struct Target
 
     DString architectureName;    // name of the platform architecture (e.g. X86_64)
     CPU cpu;                // CPU instruction set to target
+    bool is64bit;           // generate 64 bit code for x86_64; true by default for 64 bit dmd
+    bool isLP64;            // pointers are 64 bits
 
     // Environmental
     DString obj_ext;    /// extension for object files
     DString lib_ext;    /// extension for static library files
     DString dll_ext;    /// extension for dynamic library files
     bool run_noext;     /// allow -run sources without extensions
+    bool mscoff;        /// for Win32: write COFF object files instead of OMF
 
     template <typename T>
     struct FPTypeProperties
@@ -186,6 +189,7 @@ public:
     Expression *getTargetInfo(const char* name, const Loc& loc);
     bool isCalleeDestroyingArgs(TypeFunction* tf);
     bool libraryObjectMonitors(FuncDeclaration *fd, Statement *fbody);
+    void addPredefinedGlobalIdentifiers() const;
 };
 
 extern Target target;

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -175,7 +175,7 @@ Symbol *toSymbol(Dsymbol s)
             }
             else if (vd.storage_class & STC.lazy_)
             {
-                if (target.os == Target.OS.Windows && global.params.is64bit && vd.isParameter())
+                if (target.os == Target.OS.Windows && target.is64bit && vd.isParameter())
                     t = type_fake(TYnptr);
                 else
                     t = type_fake(TYdelegate);          // Tdelegate as C type
@@ -286,7 +286,7 @@ Symbol *toSymbol(Dsymbol s)
             final switch (vd.linkage)
             {
                 case LINK.windows:
-                    m = global.params.is64bit ? mTYman_c : mTYman_std;
+                    m = target.is64bit ? mTYman_c : mTYman_std;
                     break;
 
                 case LINK.objc:
@@ -379,7 +379,7 @@ Symbol *toSymbol(Dsymbol s)
                 final switch (fd.linkage)
                 {
                     case LINK.windows:
-                        t.Tmangle = global.params.is64bit ? mTYman_c : mTYman_std;
+                        t.Tmangle = target.is64bit ? mTYman_c : mTYman_std;
                         break;
 
                     case LINK.c:
@@ -392,7 +392,7 @@ Symbol *toSymbol(Dsymbol s)
                         break;
                     case LINK.cpp:
                         s.Sflags |= SFLpublic;
-                        if (fd.isThis() && !global.params.is64bit && target.os == Target.OS.Windows)
+                        if (fd.isThis() && !target.is64bit && target.os == Target.OS.Windows)
                         {
                             if ((cast(TypeFunction)fd.type).parameterList.varargs == VarArg.variadic)
                             {
@@ -493,14 +493,14 @@ Symbol *toImport(Symbol *sym)
     }
     else if (sym.Stype.Tmangle == mTYman_std && tyfunc(sym.Stype.Tty))
     {
-        if (target.os == Target.OS.Windows && global.params.is64bit)
+        if (target.os == Target.OS.Windows && target.is64bit)
             idlen = sprintf(id,"__imp_%s",n);
         else
             idlen = sprintf(id,"_imp__%s@%u",n,cast(uint)type_paramsize(sym.Stype));
     }
     else
     {
-        idlen = sprintf(id,(target.os == Target.OS.Windows && global.params.is64bit) ? "__imp_%s" : "_imp__%s",n);
+        idlen = sprintf(id,(target.os == Target.OS.Windows && target.is64bit) ? "__imp_%s" : "_imp__%s",n);
     }
     auto t = type_alloc(TYnptr | mTYconst);
     t.Tnext = sym.Stype;
@@ -616,7 +616,7 @@ Symbol *toInitializer(AggregateDeclaration ad)
             sd.type.size() <= 128 &&
             sd.zeroInit &&
             config.objfmt != OBJ_MACH && // same reason as in toobj.d toObjFile()
-            !(config.objfmt == OBJ_MSCOFF && !global.params.is64bit)) // -m32mscoff relocations are wrong
+            !(config.objfmt == OBJ_MSCOFF && !target.is64bit)) // -m32mscoff relocations are wrong
         {
             auto bzsave = bzeroSymbol;
             ad.sinit = getBzeroSymbol();

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -1198,7 +1198,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoStructDeclaration d)
     {
         //printf("TypeInfoStructDeclaration.toDt() '%s'\n", d.toChars());
-        if (global.params.is64bit)
+        if (target.is64bit)
             verifyStructSize(Type.typeinfostruct, 17 * target.ptrsize);
         else
             verifyStructSize(Type.typeinfostruct, 15 * target.ptrsize);
@@ -1330,7 +1330,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         // uint m_align;
         dtb.size(tc.alignsize());
 
-        if (global.params.is64bit)
+        if (target.is64bit)
         {
             foreach (i; 0 .. 2)
             {

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -586,7 +586,7 @@ int intrinsic_op(FuncDeclaration fd)
         }
     }
 
-    if (!global.params.is64bit)
+    if (!target.is64bit)
     // No 64-bit bsf bsr in 32bit mode
     {
         if ((op == OPbsf || op == OPbsr) && argtype1 is Type.tuns64)
@@ -595,7 +595,7 @@ int intrinsic_op(FuncDeclaration fd)
     return op;
 
 Lva_start:
-    if (global.params.is64bit &&
+    if (target.is64bit &&
         fd.toParent().isTemplateInstance() &&
         id3 == Id.va_start &&
         id2 == Id.stdarg &&
@@ -641,7 +641,7 @@ elem *resolveLengthVar(VarDeclaration lengthVar, elem **pe, Type t1)
         {
             elength = *pe;
             *pe = el_same(&elength);
-            elength = el_una(global.params.is64bit ? OP128_64 : OP64_32, TYsize_t, elength);
+            elength = el_una(target.is64bit ? OP128_64 : OP64_32, TYsize_t, elength);
 
         L3:
             slength = toSymbol(lengthVar);
@@ -937,7 +937,7 @@ void buildCapture(FuncDeclaration fd)
 {
     if (!global.params.symdebug)
         return;
-    if (!global.params.mscoff)  // toDebugClosure only implemented for CodeView,
+    if (!target.mscoff)  // toDebugClosure only implemented for CodeView,
         return;                 //  but optlink crashes for negative field offsets
 
     if (fd.closureVars.dim && !fd.needsClosure)

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -603,7 +603,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 assert(0); // this shouldn't be possible
 
             auto dtb = DtBuilder(0);
-            if (config.objfmt == OBJ_MACH && global.params.is64bit && (s.Stype.Tty & mTYLINK) == mTYthread)
+            if (config.objfmt == OBJ_MACH && target.is64bit && (s.Stype.Tty & mTYLINK) == mTYthread)
             {
                 tlsToDt(vd, s, sz, dtb);
             }
@@ -934,7 +934,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
          */
         static void tlsToDt(VarDeclaration vd, Symbol *s, uint sz, ref DtBuilder dtb)
         {
-            assert(config.objfmt == OBJ_MACH && global.params.is64bit && (s.Stype.Tty & mTYLINK) == mTYthread);
+            assert(config.objfmt == OBJ_MACH && target.is64bit && (s.Stype.Tty & mTYLINK) == mTYthread);
 
             Symbol *tlvInit = createTLVDataSymbol(vd, s);
             auto tlvInitDtb = DtBuilder(0);
@@ -949,7 +949,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             tlvInit.Sdt = tlvInitDtb.finish();
             outdata(tlvInit);
 
-            if (global.params.is64bit)
+            if (target.is64bit)
                 tlvInit.Sclass = SCextern;
 
             Symbol* tlvBootstrap = objmod.tlv_bootstrap();
@@ -969,7 +969,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
          */
         static Symbol *createTLVDataSymbol(VarDeclaration vd, Symbol *s)
         {
-            assert(config.objfmt == OBJ_MACH && global.params.is64bit && (s.Stype.Tty & mTYLINK) == mTYthread);
+            assert(config.objfmt == OBJ_MACH && target.is64bit && (s.Stype.Tty & mTYLINK) == mTYthread);
 
             // Compute identifier for tlv symbol
             OutBuffer buffer;
@@ -1005,7 +1005,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             final switch (vd.linkage)
             {
                 case LINK.windows:
-                    return global.params.is64bit ? mTYman_c : mTYman_std;
+                    return target.is64bit ? mTYman_c : mTYman_std;
 
                 case LINK.objc:
                 case LINK.c:

--- a/test/dub_package/avg.d
+++ b/test/dub_package/avg.d
@@ -18,6 +18,7 @@ import dmd.transitivevisitor;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
+import dmd.target;
 
 import std.stdio;
 import std.file;
@@ -52,7 +53,7 @@ void main()
     Id.initialize();
     global._init();
     target.os = Target.OS.linux;
-    global.params.is64bit = (size_t.sizeof == 8);
+    target.is64bit = (size_t.sizeof == 8);
     global.params.useUnitTests = true;
     ASTBase.Type._init();
 

--- a/test/dub_package/impvisitor.d
+++ b/test/dub_package/impvisitor.d
@@ -99,7 +99,7 @@ void main()
         Id.initialize();
         global._init();
         target.os = Target.OS.linux;
-        global.params.is64bit = (size_t.sizeof == 8);
+        target.is64bit = (size_t.sizeof == 8);
         global.params.useUnitTests = true;
         ASTBase.Type._init();
 


### PR DESCRIPTION
Information pertaining to the target should be kept encapsulated/private only to the dmd backend, or the target module that the frontend interacts with - especially flags such as isLinux or is64bit which are tied to one specific platform or architecture - leaving the frontend and IR passes having to only deal with language semantic decisions.

For example, gdc no longer needs to set is64bit as of #12357.