### PR TITLE
[stable] Fix compilable/ctfe_math.d regression on hosts with quadruple real precision

### DIFF
--- a/test/compilable/ctfe_math.d
+++ b/test/compilable/ctfe_math.d
@@ -4,10 +4,10 @@ import std.math;
 
 void main()
 {
-    static assert(isClose(sin(2.0L), 0.9092974268L));
+    static assert(isClose(sin(2.0L), 0.9092974268));
     static assert(isClose(cos(2.0), -0.4161468365));
     static assert(isClose(tan(2.0f), -2.185040f, 1e-5));
-    static assert(isClose(sqrt(2.0L), 1.4142135623L));
+    static assert(isClose(sqrt(2.0L), 1.4142135623));
     static assert(fabs(-2.0) == 2.0);
     static assert(ldexp(2.5f, 3) == 20.0f);
 


### PR DESCRIPTION
These tests have regressed on Linux/AArch64 since #12164.