### PR TITLE
[stable] Fix runnable_cxx/test21515.d for clang

### DIFF
--- a/test/runnable_cxx/extra-files/test21515.cpp
+++ b/test/runnable_cxx/extra-files/test21515.cpp
@@ -7,17 +7,17 @@ union cdouble_t { _Complex double z; struct { double re; double im; }; };
 union creal_t { _Complex long double z; struct { long double re; long double im; }; };
 
 // extern(C) tests
-extern "C" _Complex float ccomplexf() { return 2.0f+I; }
-extern "C" _Complex double ccomplex() { return 2.0+I; }
-extern "C" _Complex long double ccomplexl() { return 2.0L+I; }
+extern "C" _Complex float ccomplexf() { return {2.0f, 1.0f}; }
+extern "C" _Complex double ccomplex() { return {2.0, 1.0}; }
+extern "C" _Complex long double ccomplexl() { return {2.0L, 1.0L}; }
 extern "C" void ccomplexf2(_Complex float c) { cfloat_t z = {c}; assert(z.re == 2 && z.im == 1); }
 extern "C" void ccomplex2(_Complex double c) { cdouble_t z = {c}; assert(z.re == 2 && z.im == 1); }
 extern "C" void ccomplexl2(_Complex long double c) { creal_t z = {c}; assert(z.re == 2 && z.im == 1); }
 
 // extern(C++) tests
-_Complex float cpcomplexf() { return 2.0f+I; }
-_Complex double cpcomplex() { return 2.0+I; }
-_Complex long double cpcomplexl() { return 2.0L+I; }
+_Complex float cpcomplexf() { return {2.0f, 1.0f}; }
+_Complex double cpcomplex() { return {2.0, 1.0}; }
+_Complex long double cpcomplexl() { return {2.0L, 1.0L}; }
 void cpcomplexf(_Complex float c) { cfloat_t z = {c}; assert(z.re == 2 && z.im == 1); }
 void cpcomplex(_Complex double c) { cdouble_t z = {c}; assert(z.re == 2 && z.im == 1); }
 void cpcomplexl(_Complex long double c) { creal_t z = {c}; assert(z.re == 2 && z.im == 1); }
@@ -30,21 +30,21 @@ struct wrap_complexl { _Complex long double c; };
 wrap_complexf wcomplexf()
 {
     wrap_complexf s;
-    s.c = 2.0f+I;
+    s.c = {2.0f, 1.0f};
     return s;
 }
 
 wrap_complex wcomplex()
 {
     wrap_complex s;
-    s.c = 2.0+I;
+    s.c = {2.0, 1.0};
     return s;
 }
 
 wrap_complexl wcomplexl()
 {
     wrap_complexl s;
-    s.c = 2.0L+I;
+    s.c = {2.0L, 1.0L};
     return s;
 }
 

--- a/test/runnable_cxx/test21515.d
+++ b/test/runnable_cxx/test21515.d
@@ -1,5 +1,6 @@
 // https://issues.dlang.org/show_bug.cgi?id=21515
 // EXTRA_CPP_SOURCES: test21515.cpp
+// CXXFLAGS: -std=c++11
 // DISABLED: win32 win64
 
 // ABI layout of native complex


### PR DESCRIPTION
The previous .cpp code was GNU-specific and required something like `-std=gnu++11` to compile with clang. Switch to C++11 and initializer lists instead.