### PR TITLE
Fix 21797 - Stack overflow for forward-referenced enum min / max

### DIFF
--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -210,7 +210,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             dsymbolSemantic(this, _scope);
         if (errors)
             return errorReturn();
-        if (semanticRun == PASS.init || !members)
+        if (!members)
         {
             if (isSpecial())
             {
@@ -219,7 +219,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
                 return memtype.getProperty(_scope, loc, id, 0);
             }
 
-            error("is forward referenced looking for `.%s`", id.toChars());
+            error(loc, "is opaque and has no `.%s`", id.toChars());
             return errorReturn();
         }
         if (!(memtype && memtype.isintegral()))
@@ -236,6 +236,13 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
                 continue;
             if (em.errors)
             {
+                errors = true;
+                continue;
+            }
+
+            if (em.semanticRun < PASS.semanticdone)
+            {
+                em.error("is forward referenced looking for `.%s`", id.toChars());
                 errors = true;
                 continue;
             }

--- a/test/fail_compilation/enum_init.d
+++ b/test/fail_compilation/enum_init.d
@@ -103,3 +103,70 @@ void forwardRef2()
         a
     }
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/enum_init.d(606): Error: enum member `enum_init.forwardRef3.Foo.b` is forward referenced looking for `.min`
+fail_compilation/enum_init.d(607): Error: enum member `enum_init.forwardRef3.Foo.c` is forward referenced looking for `.min`
+---
+*/
+#line 600
+
+void forwardRef3()
+{
+    enum Foo
+    {
+        a,
+        b = Foo.min,
+        c
+    }
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/enum_init.d(711): Error: circular reference to enum base type `int[Bar.sizeof]`
+---
+*/
+#line 700
+
+void forwardRef4()
+{
+    enum Foo
+    {
+        a = Foo.sizeof,
+        c
+    }
+    // pragma(msg, typeof(Foo.sizeof));
+    // static assert(is(Foo Base == enum) && is(Base == int));
+
+    enum Bar : int[Bar.sizeof]
+    {
+        a
+    }
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/enum_init.d(803): Error: enum `enum_init.opaqueProperties.Foo` is forward referenced when looking for `sizeof`
+fail_compilation/enum_init.d(803): Error: enum `enum_init.opaqueProperties.Foo` is forward referenced when looking for `init`
+fail_compilation/enum_init.d(803): Error: enum `enum_init.opaqueProperties.Foo` is forward referenced when looking for `min`
+fail_compilation/enum_init.d(803): Error: enum `enum_init.opaqueProperties.Foo` is forward referenced when looking for `max`
+---
+*/
+#line 800
+
+void opaqueProperties()
+{
+    enum Foo;
+
+    // Valid
+    enum size = Foo.sizeof;
+    enum s = Foo.mangleof;
+
+    Foo f = Foo.init;
+    int min = Foo.min;
+    int max = Foo.max;
+}

--- a/test/fail_compilation/fail109.d
+++ b/test/fail_compilation/fail109.d
@@ -53,10 +53,10 @@ enum B
 /* https://issues.dlang.org/show_bug.cgi?id=11849
 TEST_OUTPUT:
 ---
-fail_compilation/fail109.d(72): Error: enum `fail109.RegValueType1a` recursive definition of `.max` property
-fail_compilation/fail109.d(79): Error: enum `fail109.RegValueType1b` recursive definition of `.max` property
-fail_compilation/fail109.d(84): Error: enum `fail109.RegValueType2a` recursive definition of `.min` property
-fail_compilation/fail109.d(91): Error: enum `fail109.RegValueType2b` recursive definition of `.min` property
+fail_compilation/fail109.d(72): Error: enum member `fail109.RegValueType1a.Unknown` is forward referenced looking for `.max`
+fail_compilation/fail109.d(79): Error: enum member `fail109.RegValueType1b.Unknown` is forward referenced looking for `.max`
+fail_compilation/fail109.d(84): Error: enum member `fail109.RegValueType2a.Unknown` is forward referenced looking for `.min`
+fail_compilation/fail109.d(91): Error: enum member `fail109.RegValueType2b.Unknown` is forward referenced looking for `.min`
 ---
 */
 


### PR DESCRIPTION
Apply the fix for `.init` to `.min` / `.max`.
See 54805374b0043a38c50f1ea13412004901e5797d