### PR TITLE
Improve error messages for min/max of opaque enums

### DIFF
--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -144,13 +144,6 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             dsymbolSemantic(this, _scope);
         }
 
-        if (!isSpecial() && (!members || !symtab || _scope))
-        {
-            error("is forward referenced when looking for `%s`", ident.toChars());
-            //*(char*)0=0;
-            return null;
-        }
-
         Dsymbol s = ScopeDsymbol.search(loc, ident, flags);
         return s;
     }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3894,23 +3894,6 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
 
         if (mt.sym.semanticRun < PASS.semanticdone)
             mt.sym.dsymbolSemantic(null);
-        if (!mt.sym.members)
-        {
-            if (mt.sym.isSpecial())
-            {
-                /* Special enums forward to the base type
-                 */
-                e = mt.sym.memtype.dotExp(sc, e, ident, flag);
-            }
-            else if (!(flag & 1))
-            {
-                mt.sym.error("is forward referenced when looking for `%s`", ident.toChars());
-                e = ErrorExp.get();
-            }
-            else
-                e = null;
-            return e;
-        }
 
         Dsymbol s = mt.sym.search(e.loc, ident);
         if (!s)

--- a/test/fail_compilation/enum_init.d
+++ b/test/fail_compilation/enum_init.d
@@ -150,10 +150,9 @@ void forwardRef4()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/enum_init.d(803): Error: enum `enum_init.opaqueProperties.Foo` is forward referenced when looking for `sizeof`
-fail_compilation/enum_init.d(803): Error: enum `enum_init.opaqueProperties.Foo` is forward referenced when looking for `init`
-fail_compilation/enum_init.d(803): Error: enum `enum_init.opaqueProperties.Foo` is forward referenced when looking for `min`
-fail_compilation/enum_init.d(803): Error: enum `enum_init.opaqueProperties.Foo` is forward referenced when looking for `max`
+fail_compilation/enum_init.d(809): Error: enum `enum_init.opaqueProperties.Foo` is opaque and has no default initializer
+fail_compilation/enum_init.d(810): Error: enum `enum_init.opaqueProperties.Foo` is opaque and has no `.min`
+fail_compilation/enum_init.d(811): Error: enum `enum_init.opaqueProperties.Foo` is opaque and has no `.max`
 ---
 */
 #line 800


### PR DESCRIPTION
Remove old special casing for opaque enums that is now obsolete and prevents proper error messages.