### PR TITLE
Fix 21798 - checkaction=context creates temporary of type void

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6101,6 +6101,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // Rewriting CallExp's also avoids some issues with the inliner/debug generation
                 if (op.hasSideEffect(true))
                 {
+                    // Don't create an invalid temporary for void-expressions
+                    // Further semantic will issue an appropriate error
+                    if (op.type.ty == ENUMTY.Tvoid)
+                        return op;
+
                     // https://issues.dlang.org/show_bug.cgi?id=21590
                     // Don't create unnecessary temporaries and detect `assert(a = b)`
                     if (op.isAssignExp() || op.isBinAssignExp())

--- a/test/fail_compilation/dassert.d
+++ b/test/fail_compilation/dassert.d
@@ -5,8 +5,10 @@ TEST_OUTPUT:
 fail_compilation/dassert.d(14): Error: expression `tuple(0, 0)` of type `(int, int)` does not have a boolean value
 fail_compilation/dassert.d(21): Error: assignment cannot be used as a condition, perhaps `==` was meant?
 fail_compilation/dassert.d(29): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/dassert.d(40): Error: expression `issue()` of type `void` does not have a boolean value
 ---
 */
+#line 10
 
 struct Baguette { int bread, floor; }
 void main ()
@@ -32,4 +34,10 @@ void issue21590()
 	int[] arr;
 	assert(arr ~= 1);
 	assert(a += b);
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=21798
+void issue()
+{
+	assert(issue());
 }


### PR DESCRIPTION
Skip temporaries for `void` expressions and defer error messages to further semantic analysis.