### PR TITLE
[dmd-cxx] Missing call to va_end in getMatchError

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5220,6 +5220,7 @@ static const char *getMatchError(const char *format, ...)
     va_list ap;
     va_start(ap, format);
     buf.vprintf(format, ap);
+    va_end(ap);
     return buf.extractChars();
 }
 


### PR DESCRIPTION
Fixes errors relating to va_list 'ap' was opened but not closed by va_end(). [va_end_missing]