### PR TITLE
Improve error messages for missing attribute inference

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1329,7 +1329,7 @@ auto sourceFiles()
         "),
         frontend: fileArray(env["D"], "
             access.d aggregate.d aliasthis.d apply.d argtypes_x86.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d
-            arraytypes.d ast_node.d astcodegen.d asttypename.d attrib.d blockexit.d builtin.d canthrow.d chkformat.d
+            arraytypes.d ast_node.d astcodegen.d asttypename.d attrib.d attribute_diagnostic.d blockexit.d builtin.d canthrow.d chkformat.d
             cli.d clone.d compiler.d complex.d cond.d constfold.d cppmangle.d cppmanglewin.d ctfeexpr.d
             ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d dimport.d
             dinterpret.d dmacro.d dmangle.d dmodule.d doc.d dscope.d dstruct.d dsymbol.d dsymbolsem.d

--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -48,7 +48,7 @@ bool checkAccess(AggregateDeclaration ad, Expression e, Scope* sc, Dsymbol smemb
         return false; // for backward compatibility
     }
 
-    if (!symbolIsVisible(sc, smember) && (!(sc.flags & SCOPE.onlysafeaccess) || sc.func.setUnsafe()))
+    if (!symbolIsVisible(sc, smember) && (!(sc.flags & SCOPE.onlysafeaccess) || sc.func.setUnsafe(e)))
     {
         ad.error(e.loc, "member `%s` is not accessible%s", smember.toChars(), (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
         //printf("smember = %s %s, vis = %d, semanticRun = %d\n",

--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -35,7 +35,7 @@ private enum LOG = false;
  * type of the 'this' pointer used to access smember.
  * Returns true if the member is not accessible.
  */
-bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymbol smember)
+bool checkAccess(AggregateDeclaration ad, Expression e, Scope* sc, Dsymbol smember)
 {
     static if (LOG)
     {
@@ -50,7 +50,7 @@ bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymbol smember)
 
     if (!symbolIsVisible(sc, smember) && (!(sc.flags & SCOPE.onlysafeaccess) || sc.func.setUnsafe()))
     {
-        ad.error(loc, "member `%s` is not accessible%s", smember.toChars(), (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
+        ad.error(e.loc, "member `%s` is not accessible%s", smember.toChars(), (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
         //printf("smember = %s %s, vis = %d, semanticRun = %d\n",
         //        smember.kind(), smember.toPrettyChars(), smember.visible() smember.semanticRun);
         return true;
@@ -197,13 +197,13 @@ bool checkAccess(Loc loc, Scope* sc, Expression e, Dsymbol d)
             if (ClassDeclaration cd2 = sc.func.toParent().isClassDeclaration())
                 cd = cd2;
         }
-        return checkAccess(cd, loc, sc, d);
+        return checkAccess(cd, e, sc, d);
     }
     else if (e.type.ty == Tstruct)
     {
         // Do access check
         StructDeclaration cd = (cast(TypeStruct)e.type).sym;
-        return checkAccess(cd, loc, sc, d);
+        return checkAccess(cd, e, sc, d);
     }
     return false;
 }

--- a/src/dmd/attribute_diagnostic.d
+++ b/src/dmd/attribute_diagnostic.d
@@ -1,0 +1,237 @@
+/**
+ * Implements reports for expressions/statements that affected attribute interference.
+ *
+ * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/attribute_diagnostic.d, _attribute_diagnostic.d)
+ * Documentation:  https://dlang.org/phobos/dmd_attribute_diagnostic.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/attribute_diagnostic.d
+ */
+
+module dmd.attribute_diagnostic;
+
+import core.stdc.stdio : printf, puts;
+
+import dmd.apply : walkPostorder;
+import dmd.declaration : STC;
+import dmd.dsymbol : Dsymbol;
+import dmd.errors : errorSupplemental;
+import dmd.expression;
+import dmd.func : FuncDeclaration;
+import dmd.globals : global, Loc;
+import dmd.sapply : walkPostorder;
+import dmd.statement;
+import dmd.visitor;
+
+// debug = VIOLATIONS;
+
+/**
+ * Reports statements/expression that prohibited attribute inference.
+ *
+ * Params:
+ *   f = function to check
+ *   v = attribute violation
+ */
+void reportViolations(FuncDeclaration f, Violation v)
+{
+    if (!f || !f.fbody || global.gag)
+        return;
+
+    scope vv = new ViolationVisitor(v);
+    vv.enter(f);
+}
+
+private:
+
+/// Detects attribute violations
+extern (C++) final class ViolationVisitor : StoppableVisitor
+{
+    const Violation filter; /// Selected attribute
+    const char* message;    /// error message for matched nodes
+    ubyte depth;            /// current recursion depth
+    bool ignored;           /// whether certain nodes were skipped
+    FuncDeclaration current;/// currently diagnosed function
+
+    /// Initialize this visitor for the specified attribute
+    this(Violation filter)
+    {
+        this.filter = filter;
+        with (Violation)
+        {
+            if (filter == nogc)
+                message = "@nogc";
+            else if (filter == safe)
+                message = "@safe";
+            else if (filter == nothrow_)
+                message = "nothrow";
+            else if (filter == pure_)
+                message = "pure";
+            else
+            {
+                printf("Unknown violation: %x", filter);
+                assert(false);
+            }
+        }
+    }
+
+    /// Returns: Whether `t` violates the attribute specified in `filter`
+    private bool hasViolations(T)(T t) const pure /* nothrow */ @safe @nogc
+    {
+        if (t.violation & this.filter)
+            return true;
+
+        debug (VIOLATIONS) printf("Ignoring `%s`\n", t.toChars());
+        return false;
+    }
+
+    /// Recursively check `fd` for attribute violations according to `filter`
+    private void enter(FuncDeclaration fd)
+    {
+        // Don't spam the user with too many errors at once
+        if (depth > 5 && !global.params.verbose)
+        {
+            ignored = true;
+            return;
+        }
+
+        // Trace functions exactly once
+        if (fd.inferenceTraced & this.filter)
+        {
+            // TODO: Maybe print a message here?
+            debug (VIOLATIONS) printf("Skipping already visited `%s`\n", fd.toPrettyChars());
+            return;
+        }
+
+        // Skip functions without attribute inference
+        if (!fd.isInstantiated() && !fd.isFuncLiteralDeclaration() && !(fd.storage_class & STC.inference) || fd.ident.startsWith("_d_")) // Druntime hooks
+            return;
+
+        fd.inferenceTraced |= this.filter;
+
+        fd.loc.errorSupplemental("%-*s  could not infer `%s` for `%s` because:", 2 * depth, "".ptr, message, fd.toPrettyChars());
+
+        auto currentSave = current;
+        current = fd;
+        depth++;
+        walkPostorder(fd.fbody, this);
+        depth--;
+        current = currentSave;
+    }
+
+    /// Checks whether calling `fd` causes attribute violation according to `filter`
+    private void check(CallExp e, FuncDeclaration fd)
+    {
+        assert(e);
+        assert(fd);
+        assert(fd.ident);
+
+        // Detect foreach lowerings including autodecoding
+        // Analyse them as if the delegate was part of the current function
+        if (fd.ident.startsWith("_aApply"))
+        {
+            assert(e.arguments);
+            assert(e.arguments.length == 2);
+
+            auto fe = (*e.arguments)[1].isFuncExp();
+            assert(fe);
+
+            walkPostorder(fe.fd.fbody, this);
+        }
+        else if (!hasViolations(cast(Expression) e))
+        {
+            // Ignore
+        }
+        else if (fd.ident.startsWith("_d_")) // Druntime hooks
+        {
+            // TODO: better messages for rewritten expression
+            printExpressionViolation(e);
+        }
+        else
+        {
+            const loc = e.loc != Loc.initial ? e.loc : current.loc;
+            loc.errorSupplemental("%-*s- calling `%s` which is not `%s`", 2 * depth, "".ptr, fd.toPrettyChars(), message);
+            enter(fd);
+        }
+    }
+
+    /// Prints a message for `t` violating `filter`
+    private void printExpressionViolation(T)(T t) const
+    {
+        t.loc.errorSupplemental("%-*s- `%s` is not `%s`", 2 * depth, "".ptr, t.toChars(), message);
+    }
+
+    // Visitor implementation below
+
+    alias visit = typeof(super).visit;
+
+    /// Check expressions for violations
+    override void visit(Expression e)
+    {
+        if (!hasViolations(e))
+            return;
+
+        // Special case certain statements for better diagnostic messages:
+        if (auto ve = e.isVarExp())
+        {
+            e.errorSupplemental("%-*s- accessing `%s` is not `%s`", 2 * depth, "".ptr, ve.toChars(), message);
+            return;
+        }
+
+        printExpressionViolation(e);
+    }
+
+    /// Check function calls for violations and potentially enter into the function body
+    override void visit(CallExp e)
+    {
+        if (e.f)
+        {
+            check(e, e.f);
+            return;
+        }
+
+        // The function declaration might be wrapped in a VarExp as e1 for certain lowerings
+        if (auto ve = e.e1.isVarExp())
+        {
+            if (auto fd = ve.var.isFuncDeclaration())
+                check(e, fd);
+        }
+    }
+
+    /// Check statements for violations
+    override void visit(Statement s)
+    {
+        if (!hasViolations(s))
+            return;
+
+        // Special case certain statements for better diagnostic messages:
+
+        if (auto ts = s.isThrowStatement())
+        {
+            assert(this.filter & Violation.nothrow_);
+            s.loc.errorSupplemental("%-*s- throwing `%s` here", 2 * depth, "".ptr, ts.exp.type.toChars());
+            return;
+        }
+
+        printExpressionViolation(s);
+    }
+
+    /// Check the internal expressions
+    override void visit(ExpStatement s)
+    {
+        walkPostorder(s.exp, this);
+    }
+
+    /// Check expressions in return statements
+    override void visit(ReturnStatement s)
+    {
+        s.exp.accept(this);
+    }
+
+    /// Check symbols (aka VarDeclarations) for violations
+    override void visit(Dsymbol s)
+    {
+        if (hasViolations(s))
+            printExpressionViolation(s);
+    }
+}

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -489,7 +489,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             }
             if (mustNotThrow)
                 s.error("`%s` is thrown but not caught", s.exp.type.toChars());
-
+            s.violation |= Violation.nothrow_;
             result = BE.throw_;
         }
 

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -59,8 +59,17 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
                     e.error("%s `%s` is not `nothrow`",
                         f.kind(), f.toPrettyChars());
 
-                    e.checkOverridenDtor(null, f, dd => dd.type.toTypeFunction().isnothrow, "not nothrow");
+                    if (f.isDtorDeclaration())
+                        e.checkOverridenDtor(null, f, dd => dd.type.toTypeFunction().isnothrow, "not nothrow");
+                    else
+                    {
+                        import dmd.attribute_diagnostic;
+                        reportViolations(f, Violation.nothrow_);
+                    }
                 }
+                else
+                    e.violation |= Violation.nothrow_;
+
                 stop = true;  // if any function throws, then the whole expression throws
             }
         }

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -107,6 +107,9 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
                     e1 = pe.e1;
                 ce.error("`%s` is not `nothrow`", e1.toChars());
             }
+            else
+                ce.violation |= Violation.nothrow_;
+
             stop = true;
         }
 

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2705,7 +2705,7 @@ Expression scaleFactor(BinExp be, Scope* sc)
         if (eoff.op == TOK.int64 && eoff.toInteger() == 0)
         {
         }
-        else if (sc.func.setUnsafe())
+        else if (sc.func.setUnsafe(be))
         {
             be.error("pointer arithmetic not allowed in @safe functions");
             return ErrorExp.get();

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -529,6 +529,8 @@ public:
     int inlineNest;                     // !=0 if nested inline
     bool eh_none;                       /// true if no exception unwinding is needed
 
+    Violation inferenceTraced;          /// Visitied this function from ViolationsVistior (see attribute_diagnostic.d)
+
     // true if errors in semantic3 this function's frame ptr
     bool semantic3Errors;
     ForeachStatement *fes;              // if foreach body, this is the foreach

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -483,7 +483,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             {
                 if ((stype.alignment() < target.ptrsize ||
                      (v.offset & (target.ptrsize - 1))) &&
-                    (sc.func && sc.func.setUnsafe()))
+                    (sc.func && sc.func.setUnsafe(e)))
                 {
                     .error(loc, "field `%s.%s` cannot assign to misaligned pointers in `@safe` code",
                         toChars(), v.toChars());

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -231,6 +231,7 @@ extern (C++) class Dsymbol : ASTNode
     Scope* _scope;          // !=null means context to use for semantic()
     const(char)* prettystring;  // cached value of toPrettyChars()
     bool errors;            // this symbol failed to pass semantic()
+    Violation violation;    /// Violation of attributes reported for this node
     PASS semanticRun = PASS.init;
     ushort localNum;        /// perturb mangled name to avoid collisions with those in FuncDeclaration.localsymtab
 

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -15,6 +15,7 @@
 #include "globals.h"
 #include "arraytypes.h"
 #include "visitor.h"
+#include "expression.h"
 
 class CPPNamespaceDeclaration;
 class Identifier;
@@ -152,6 +153,7 @@ public:
     Scope *_scope;               // !=NULL means context to use for semantic()
     const utf8_t *prettystring;
     bool errors;                // this symbol failed to pass semantic()
+    Violation violation;        // Violation of attributes reported for this node
     PASS semanticRun;
     unsigned short localNum;        // perturb mangled name to avoid collisions with those in FuncDeclaration.localsymtab
     DeprecatedDeclaration *depdecl; // customized deprecation message

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -908,7 +908,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (dsym.storage_class & STC.gshared && !dsym.isMember())
             {
-                if (sc.func.setUnsafe())
+                if (sc.func.setUnsafe(dsym))
                     dsym.error("__gshared not allowed in safe functions; use shared");
             }
         }
@@ -1300,7 +1300,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (dsym._init && dsym._init.isVoidInitializer() &&
                 (dsym.type.hasPointers() || dsym.type.hasInvariant())) // also computes type size
             {
-                if (sc.func.setUnsafe())
+                if (sc.func.setUnsafe(dsym))
                 {
                     if (dsym.type.hasPointers())
                         dsym.error("`void` initializers for pointers not allowed in safe functions");
@@ -1312,7 +1312,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                      !(dsym.storage_class & (STC.static_ | STC.extern_ | STC.tls | STC.gshared | STC.manifest | STC.field | STC.parameter)) &&
                      dsym.type.hasVoidInitPointers())
             {
-                if (sc.func.setUnsafe())
+                if (sc.func.setUnsafe(dsym))
                     dsym.error("`void` initializers for pointers not allowed in safe functions");
             }
         }

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -58,12 +58,21 @@ enum
     OWNEDcache      // constant value cached for CTFE
 };
 
+enum class Violation : uint8_t
+{
+    safe     = 1u,
+    pure_    = 2u,
+    nogc     = 4u,
+    nothrow_ = 8u,
+};
+
 class Expression : public ASTNode
 {
 public:
     TOK op;                     // to minimize use of dynamic_cast
     unsigned char size;         // # of bytes in Expression so we can copy() it
     unsigned char parens;       // if this is a parenthesized expression
+    Violation violation;        // Violation of attributes reported for this node
     Type *type;                 // !=NULL means that semantic() has been run
     Loc loc;                    // file location
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3681,7 +3681,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
 
                 checkFunctionAttributes(exp, sc, f);
-                checkAccess(cd, exp.loc, sc, f);
+                checkAccess(cd, exp, sc, f);
 
                 TypeFunction tf = cast(TypeFunction)f.type;
                 Type rettype;
@@ -3707,7 +3707,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
 
                 checkFunctionAttributes(exp, sc, f);
-                checkAccess(cd, exp.loc, sc, f);
+                checkAccess(cd, exp, sc, f);
 
                 TypeFunction tf = cast(TypeFunction)f.type;
                 if (!exp.arguments)
@@ -3771,7 +3771,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
 
                 checkFunctionAttributes(exp, sc, f);
-                checkAccess(sd, exp.loc, sc, f);
+                checkAccess(sd, exp, sc, f);
 
                 TypeFunction tf = cast(TypeFunction)f.type;
                 Type rettype;
@@ -3797,7 +3797,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
 
                 checkFunctionAttributes(exp, sc, f);
-                checkAccess(sd, exp.loc, sc, f);
+                checkAccess(sd, exp, sc, f);
 
                 TypeFunction tf = cast(TypeFunction)f.type;
                 if (!exp.arguments)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -4584,6 +4584,7 @@ public:
     PINLINE inlining;
     int32_t inlineNest;
     bool eh_none;
+    Violation inferenceTraced;
     bool semantic3Errors;
     ForeachStatement* fes;
     BaseClass* interfaceVirtual;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -60,6 +60,14 @@ struct Symbol;
 struct Loc;
 struct Global;
 struct Scope;
+enum class Violation : uint8_t
+{
+    safe = 1u,
+    pure_ = 2u,
+    nogc = 4u,
+    nothrow_ = 8u,
+};
+
 enum class PASS
 {
     init = 0,
@@ -803,6 +811,7 @@ public:
     Scope* _scope;
     const char* prettystring;
     bool errors;
+    Violation violation;
     PASS semanticRun;
     uint16_t localNum;
     DeprecatedDeclaration* depdecl;
@@ -983,6 +992,7 @@ public:
     const TOK op;
     uint8_t size;
     uint8_t parens;
+    Violation violation;
     Type* type;
     Loc loc;
     static void _init();
@@ -5967,6 +5977,7 @@ class Statement : public ASTNode
 public:
     const Loc loc;
     const STMT stmt;
+    Violation violation;
     DYNCAST dyncast() const;
     virtual Statement* syntaxCopy();
     static Array<Statement* >* arraySyntaxCopy(Array<Statement* >* a);

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -286,7 +286,7 @@ extern (C++) class FuncDeclaration : Declaration
 
     int inlineNest;                     /// !=0 if nested inline
     bool eh_none;                       /// true if no exception unwinding is needed
-
+    Violation inferenceTraced;          /// Visitied this function from ViolationsVistior (see attribute_diagnostic.d)
     bool semantic3Errors;               /// true if errors in semantic3 this function's frame ptr
     ForeachStatement fes;               /// if foreach body, this is the foreach
     BaseClass* interfaceVirtual;        /// if virtual, but only appears in base interface vtbl[]

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -141,6 +141,14 @@ nothrow:
         return DYNCAST.identifier;
     }
 
+    /// Returns `true` if this is not anonymous and starts with `prefix`
+    extern(D) final bool startsWith(scope const char[] prefix) const pure @nogc @safe
+    {
+        return !isAnonymous_
+            && name.length >= prefix.length
+            && name[0 .. prefix.length] == prefix;
+    }
+
     private extern (D) __gshared StringTable!Identifier stringtable;
 
     /**

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -177,7 +177,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
                 {
                     if ((t.alignment() < target.ptrsize ||
                          (vd.offset & (target.ptrsize - 1))) &&
-                        sc.func && sc.func.setUnsafe())
+                        sc.func && sc.func.setUnsafe(vd))
                     {
                         error(i.loc, "field `%s.%s` cannot assign to misaligned pointers in `@safe` code",
                             sd.toChars(), vd.toChars());

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -73,7 +73,7 @@ public:
         auto fd = stripHookTraceImpl(e.f);
         if (fd.ident == Id._d_arraysetlengthT)
         {
-            if (f.setGC())
+            if (f.setGC(e))
             {
                 e.error("setting `length` in `@nogc` %s `%s` may cause a GC allocation",
                     f.kind(), f.toPrettyChars());
@@ -88,7 +88,7 @@ public:
     {
         if (e.type.ty != Tarray || !e.elements || !e.elements.dim)
             return;
-        if (f.setGC())
+        if (f.setGC(e))
         {
             e.error("array literal in `@nogc` %s `%s` may cause a GC allocation",
                 f.kind(), f.toPrettyChars());
@@ -102,7 +102,7 @@ public:
     {
         if (!e.keys.dim)
             return;
-        if (f.setGC())
+        if (f.setGC(e))
         {
             e.error("associative array literal in `@nogc` %s `%s` may cause a GC allocation",
                 f.kind(), f.toPrettyChars());
@@ -114,7 +114,7 @@ public:
 
     override void visit(NewExp e)
     {
-        if (e.member && !e.member.isNogc() && f.setGC())
+        if (e.member && !e.member.isNogc() && f.setGC(e))
         {
             // @nogc-ness is already checked in NewExp::semantic
             return;
@@ -125,7 +125,7 @@ public:
             return;
         if (global.params.ehnogc && e.thrownew)
             return;                     // separate allocator is called for this, not the GC
-        if (f.setGC())
+        if (f.setGC(e))
         {
             e.error("cannot use `new` in `@nogc` %s `%s`",
                 f.kind(), f.toPrettyChars());
@@ -162,7 +162,7 @@ public:
             break;
         }
 
-        if (f.setGC())
+        if (f.setGC(e))
         {
             e.error("cannot use `delete` in `@nogc` %s `%s`",
                 f.kind(), f.toPrettyChars());
@@ -177,7 +177,7 @@ public:
         Type t1b = e.e1.type.toBasetype();
         if (t1b.ty == Taarray)
         {
-            if (f.setGC())
+            if (f.setGC(e))
             {
                 e.error("indexing an associative array in `@nogc` %s `%s` may cause a GC allocation",
                     f.kind(), f.toPrettyChars());
@@ -192,7 +192,7 @@ public:
     {
         if (e.e1.op == TOK.arrayLength)
         {
-            if (f.setGC())
+            if (f.setGC(e))
             {
                 e.error("setting `length` in `@nogc` %s `%s` may cause a GC allocation",
                     f.kind(), f.toPrettyChars());
@@ -205,7 +205,7 @@ public:
 
     override void visit(CatAssignExp e)
     {
-        if (f.setGC())
+        if (f.setGC(e))
         {
             e.error("cannot use operator `~=` in `@nogc` %s `%s`",
                 f.kind(), f.toPrettyChars());
@@ -217,7 +217,7 @@ public:
 
     override void visit(CatExp e)
     {
-        if (f.setGC())
+        if (f.setGC(e))
         {
             e.error("cannot use operator `~` in `@nogc` %s `%s`",
                 f.kind(), f.toPrettyChars());

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -61,7 +61,8 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
         const hasPointers = v.type.hasPointers();
         if (hasPointers)
         {
-            if (v.overlapped && sc.func.setUnsafe())
+
+            if (v.overlapped && sc.func.setUnsafe(e))
             {
                 if (printmsg)
                     e.error("field `%s.%s` cannot access pointers in `@safe` code that overlap other fields",
@@ -88,7 +89,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
         {
             if ((ad.type.alignment() < target.ptrsize ||
                  (v.offset & (target.ptrsize - 1))) &&
-                sc.func.setUnsafe())
+                sc.func.setUnsafe(e))
             {
                 if (printmsg)
                     e.error("field `%s.%s` cannot modify misaligned pointers in `@safe` code",
@@ -97,7 +98,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
             }
         }
 
-        if (v.overlapUnsafe && sc.func.setUnsafe())
+        if (v.overlapUnsafe && sc.func.setUnsafe(e))
         {
              if (printmsg)
                  e.error("field `%s.%s` cannot modify fields in `@safe` code that overlap fields with other storage classes",
@@ -196,4 +197,3 @@ bool isSafeCast(Expression e, Type tfrom, Type tto)
     }
     return false;
 }
-

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -131,6 +131,7 @@ extern (C++) abstract class Statement : ASTNode
 {
     const Loc loc;
     const STMT stmt;
+    Violation violation; /// Violation of attributes reported for this node
 
     override final DYNCAST dyncast() const
     {

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -108,6 +108,7 @@ class Statement : public ASTNode
 public:
     Loc loc;
     STMT stmt;
+    Violation violation; // Violation of attributes reported for this node
 
     virtual Statement *syntaxCopy();
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -4270,7 +4270,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             cas.deprecation("`asm` statement is assumed to be impure - mark it with `pure` if it is not");
         if (!(cas.stc & STC.nogc) && sc.func.isNogcBypassingInference())
             cas.deprecation("`asm` statement is assumed to use the GC - mark it with `@nogc` if it does not");
-        if (!(cas.stc & (STC.trusted | STC.safe)) && sc.func.setUnsafe())
+        if (!(cas.stc & (STC.trusted | STC.safe)) && sc.func.setUnsafe(cas))
             cas.error("`asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not");
 
         sc.pop();
@@ -4372,7 +4372,7 @@ void catchSemantic(Catch c, Scope* sc)
                 error(c.loc, "catching C++ class objects not supported for this target");
                 c.errors = true;
             }
-            if (sc.func && !sc.intypeof && !c.internalCatch && sc.func.setUnsafe())
+            if (sc.func && !sc.intypeof && !c.internalCatch && sc.func.setUnsafe(c.var))
             {
                 error(c.loc, "cannot catch C++ class objects in `@safe` code");
                 c.errors = true;
@@ -4385,7 +4385,7 @@ void catchSemantic(Catch c, Scope* sc)
         }
         else if (sc.func && !sc.intypeof && !c.internalCatch && ClassDeclaration.exception &&
                  cd != ClassDeclaration.exception && !ClassDeclaration.exception.isBaseOf(cd, null) &&
-                 sc.func.setUnsafe())
+                 sc.func.setUnsafe(c.var))
         {
             error(c.loc, "can only catch class objects derived from `Exception` in `@safe` code, not `%s`", c.type.toChars());
             c.errors = true;

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3421,7 +3421,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 e.error("`%s` is not an expression", e.toChars());
                 return ErrorExp.get();
             }
-            else if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
+            else if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe(e))
             {
                 e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
                 return ErrorExp.get();
@@ -3469,7 +3469,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         }
         else if (ident == Id.ptr)
         {
-            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
+            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe(e))
             {
                 e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
                 return ErrorExp.get();
@@ -3535,7 +3535,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         }
         else if (ident == Id.funcptr)
         {
-            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
+            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe(e))
             {
                 e.error("`%s.funcptr` cannot be used in `@safe` code", e.toChars());
                 return ErrorExp.get();

--- a/test/fail_compilation/diag10319.d
+++ b/test/fail_compilation/diag10319.d
@@ -5,14 +5,18 @@ fail_compilation/diag10319.d(27): Error: `pure` function `D main` cannot call im
 fail_compilation/diag10319.d(27): Error: `@safe` function `D main` cannot call `@system` function `diag10319.foo`
 fail_compilation/diag10319.d(16):        `diag10319.foo` is declared here
 fail_compilation/diag10319.d(28): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int.bar`
+fail_compilation/diag10319.d(18):          could not infer `pure` for `diag10319.bar!int.bar` because:
+fail_compilation/diag10319.d(20):          - accessing `g` is not `pure`
 fail_compilation/diag10319.d(28): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar`
 fail_compilation/diag10319.d(18):        `diag10319.bar!int.bar` is declared here
 fail_compilation/diag10319.d(27): Error: function `diag10319.foo` is not `nothrow`
 fail_compilation/diag10319.d(28): Error: function `diag10319.bar!int.bar` is not `nothrow`
+fail_compilation/diag10319.d(18):          could not infer `nothrow` for `diag10319.bar!int.bar` because:
+fail_compilation/diag10319.d(22):          - throwing `object.Exception` here
 fail_compilation/diag10319.d(25): Error: `nothrow` function `D main` may throw
 ---
 */
-
+#line 16
 void foo() {}
 
 void bar(T)()

--- a/test/fail_compilation/diag9620.d
+++ b/test/fail_compilation/diag9620.d
@@ -3,9 +3,11 @@ TEST_OUTPUT:
 ---
 fail_compilation/diag9620.d(18): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo1`
 fail_compilation/diag9620.d(19): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo2!().foo2`
+fail_compilation/diag9620.d(12):          could not infer `pure` for `diag9620.foo2!().foo2` because:
+fail_compilation/diag9620.d(12):          - accessing `x` is not `pure`
 ---
 */
-
+#line 9
 int x;
 
 void foo1() { x = 3; }

--- a/test/fail_compilation/fail11375.d
+++ b/test/fail_compilation/fail11375.d
@@ -2,10 +2,12 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail11375.d(17): Error: constructor `fail11375.D!().D.this` is not `nothrow`
+fail_compilation/fail11375.d(13):          could not infer `nothrow` for `fail11375.D!().D.this` because:
+fail_compilation/fail11375.d(13):          - calling `fail11375.B.this` which is not `nothrow`
 fail_compilation/fail11375.d(15): Error: `nothrow` function `D main` may throw
 ---
 */
-
+#line 9
 class B {
     this() {}
 }

--- a/test/fail_compilation/fail13120.d
+++ b/test/fail_compilation/fail13120.d
@@ -17,11 +17,16 @@ void g1(char[] s) pure @nogc
 TEST_OUTPUT:
 ---
 fail_compilation/fail13120.d(35): Error: `pure` function `fail13120.h2` cannot call impure function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(27):          could not infer `pure` for `fail13120.g2!().g2` because:
+fail_compilation/fail13120.d(30):          - calling `fail13120.f2` which is not `pure`
 fail_compilation/fail13120.d(35): Error: `@safe` function `fail13120.h2` cannot call `@system` function `fail13120.g2!().g2`
 fail_compilation/fail13120.d(27):        `fail13120.g2!().g2` is declared here
 fail_compilation/fail13120.d(35): Error: `@nogc` function `fail13120.h2` cannot call non-@nogc function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(27):          could not infer `@nogc` for `fail13120.g2!().g2` because:
+fail_compilation/fail13120.d(30):          - calling `fail13120.f2` which is not `@nogc`
 ---
 */
+#line 25
 void f2() {}
 
 void g2()(char[] s)

--- a/test/fail_compilation/testInference.d
+++ b/test/fail_compilation/testInference.d
@@ -138,8 +138,10 @@ immutable(void)* g10063(inout int* p) pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(154): Error: `pure` function `testInference.bar14049` cannot call impure function `testInference.foo14049!int.foo14049`
+fail_compilation\testInference.d(145):          could not infer `pure` for `testInference.foo14049!int.foo14049` because:
 ---
 */
+#line 143
 auto impure14049() { static int i = 1; return i; }
 
 void foo14049(T)(T val)
@@ -170,8 +172,11 @@ int* f14160() pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(180): Error: `pure` function `testInference.test12422` cannot call impure function `testInference.test12422.bar12422!().bar12422`
+fail_compilation/testInference.d(179):          could not infer `pure` for `testInference.test12422.bar12422!().bar12422` because:
+fail_compilation/testInference.d(179):          - calling `testInference.foo12422` which is not `pure`
 ---
 */
+#line 175
 int g12422;
 void foo12422() { ++g12422; }
 void test12422() pure
@@ -185,8 +190,11 @@ TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(198): Error: `pure` function `testInference.test13729a` cannot call impure function `testInference.test13729a.foo`
 fail_compilation/testInference.d(206): Error: `pure` function `testInference.test13729b` cannot call impure function `testInference.test13729b.foo!().foo`
+fail_compilation/testInference.d(202):          could not infer `pure` for `testInference.test13729b.foo!().foo` because:
+fail_compilation/testInference.d(204):          - accessing `g13729` is not `pure`
 ---
 */
+#line 190
 int g13729;
 
 void test13729a() pure

--- a/test/fail_compilation/trace_inference.d
+++ b/test/fail_compilation/trace_inference.d
@@ -1,0 +1,184 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/trace_inference.d(18): Error: `@nogc` function `trace_inference.foo` cannot call non-@nogc function `trace_inference.bar!int.bar`
+fail_compilation/trace_inference.d(22):          could not infer `@nogc` for `trace_inference.bar!int.bar` because:
+fail_compilation/trace_inference.d(24):          - calling `trace_inference.factory!int.factory` which is not `@nogc`
+fail_compilation/trace_inference.d(29):            could not infer `@nogc` for `trace_inference.factory!int.factory` because:
+fail_compilation/trace_inference.d(31):            - calling `trace_inference.helper!().helper` which is not `@nogc`
+fail_compilation/trace_inference.d(35):              could not infer `@nogc` for `trace_inference.helper!().helper` because:
+fail_compilation/trace_inference.d(37):              - `[1:1]` is not `@nogc`
+fail_compilation/trace_inference.d(26):          - `_d_arraysetlengthT(arr, 1LU)` is not `@nogc`
+fail_compilation/trace_inference.d(19): Error: `@nogc` function `trace_inference.foo` cannot call non-@nogc function `trace_inference.factory!int.factory`
+---
+*/
+
+void foo() @nogc
+{
+    bar!int();
+    factory!int();
+}
+
+void bar(T)()
+{
+    factory!T();
+    T[] arr;
+    arr.length = 1;
+}
+
+auto factory(T)()
+{
+    helper();
+    return new T();
+}
+
+auto helper()()
+{
+    return [ 1: 1 ];
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/trace_inference.d(103): Error: `@nogc` function `trace_inference.entry` cannot call non-@nogc function `trace_inference.g2!().g2`
+fail_compilation/trace_inference.d(108):          could not infer `@nogc` for `trace_inference.g2!().g2` because:
+fail_compilation/trace_inference.d(111):          - calling `trace_inference.f2` which is not `@nogc`
+---
+*/
+#line 100
+
+void entry() @nogc
+{
+    g2(null);
+}
+
+void f2() {}
+
+void g2()(char[] s)
+{
+    foreach (dchar dc; s)
+        f2();
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/trace_inference.d(203): Error: `@nogc` function `trace_inference.entryRec` cannot call non-@nogc function `trace_inference.rec!().rec`
+fail_compilation/trace_inference.d(206):          could not infer `@nogc` for `trace_inference.rec!().rec` because:
+fail_compilation/trace_inference.d(208):          - `new int(1)` is not `@nogc`
+---
+*/
+#line 200
+
+void entryRec() @nogc
+{
+    rec();
+}
+
+void rec()()
+{
+    new int(1);
+    rec();
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/trace_inference.d(303): Error: function `trace_inference.doesThrow!().doesThrow` is not `nothrow`
+fail_compilation/trace_inference.d(307):          could not infer `nothrow` for `trace_inference.doesThrow!().doesThrow` because:
+fail_compilation/trace_inference.d(309):          - throwing `object.Exception` here
+fail_compilation/trace_inference.d(304): Error: function `trace_inference.doesCallThrow!().doesCallThrow` is not `nothrow`
+fail_compilation/trace_inference.d(312):          could not infer `nothrow` for `trace_inference.doesCallThrow!().doesCallThrow` because:
+fail_compilation/trace_inference.d(314):          - calling `trace_inference.entryRec` which is not `nothrow`
+fail_compilation/trace_inference.d(301): Error: `nothrow` function `trace_inference.entryRec300` may throw
+---
+*/
+#line 300
+
+void entryRec300() nothrow
+{
+    doesThrow();
+    doesCallThrow();
+}
+
+void doesThrow()()
+{
+    throw new Exception("");
+}
+
+void doesCallThrow()()
+{
+    entryRec();
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/trace_inference.d(403): Error: function `trace_inference.doesThrowInTry!().doesThrowInTry` is not `nothrow`
+fail_compilation/trace_inference.d(406):          could not infer `nothrow` for `trace_inference.doesThrowInTry!().doesThrowInTry` because:
+fail_compilation/trace_inference.d(415):          - throwing `object.Exception` here
+fail_compilation/trace_inference.d(401): Error: `nothrow` function `trace_inference.entryRec400` may throw
+---
+
+The following hints are emitted because the current implementation of blockExit makes
+it impossible to determine whether a throw in a try-catch is caught.
+---
+fail_compilation/trace_inference.d(420):          - throwing `object.Exception` here
+---
+*/
+#line 400
+
+void entryRec400() nothrow
+{
+    doesThrowInTry(1);
+}
+
+void doesThrowInTry()(int i)
+{
+    try
+        // Must not be reported!
+        throw new Exception("");
+    catch (Exception e) {}
+
+    try
+        // Must be reported!
+        throw new Exception("");
+    catch (Custom e) {}
+}
+
+class Custom : Exception
+{
+    this() { super(""); }
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/trace_inference.d(503): Error: function `trace_inference.doesCallThrowInTry!().doesCallThrowInTry` is not `nothrow`
+fail_compilation/trace_inference.d(506):          could not infer `nothrow` for `trace_inference.doesCallThrowInTry!().doesCallThrowInTry` because:
+fail_compilation/trace_inference.d(513):          - calling `trace_inference.entryRec` which is not `nothrow`
+fail_compilation/trace_inference.d(501): Error: `nothrow` function `trace_inference.entryRec500` may throw
+---
+
+See above for an explanation of:
+---
+fail_compilation/trace_inference.d(509):          - calling `trace_inference.entryRec` which is not `nothrow`
+---
+*/
+#line 500
+
+void entryRec500() nothrow
+{
+    doesCallThrowInTry(1);
+}
+
+void doesCallThrowInTry()(int i)
+{
+    try
+        entryRec();
+    catch (Exception e) {}
+
+    try
+        entryRec();
+    catch (Custom e) {}
+}


### PR DESCRIPTION
Provide an explanaition why a required attribute could not be inferred when calling a templated function that violates it.

---

Alternative to #12360,  more general implementation but not as specific error messages.

---

`nothrow` is blocked by #12452 (or another solution to that bug report) to prevent false positives.