### PR TITLE
move targetOS from global to target

### DIFF
--- a/src/dmd/argtypes_x86.d
+++ b/src/dmd/argtypes_x86.d
@@ -17,6 +17,7 @@ import core.checkedint;
 import dmd.declaration;
 import dmd.globals;
 import dmd.mtype;
+import dmd.target;
 import dmd.visitor;
 
 /****************************************************
@@ -349,7 +350,7 @@ extern (C++) TypeTuple toArgTypes_x86(Type t)
             default:
                 return memory();
             }
-            if (global.params.targetOS == TargetOS.FreeBSD && nfields == 1 &&
+            if (target.os == Target.OS.FreeBSD && nfields == 1 &&
                 (sz == 4 || sz == 8))
             {
                 /* FreeBSD changed their 32 bit ABI at some point before 10.3 for the following:

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6809,28 +6809,5 @@ struct ASTBase
     struct Target
     {
         extern (C++) __gshared int ptrsize;
-
-        extern (C++) static Type va_listType(const ref Loc loc, Scope* sc)
-        {
-            if (global.params.targetOS == TargetOS.Windows)
-            {
-                return Type.tchar.pointerTo();
-            }
-            else if (global.params.targetOS & TargetOS.Posix)
-            {
-                if (global.params.is64bit)
-                {
-                    return (new TypeIdentifier(Loc.initial, Identifier.idPool("__va_list_tag"))).pointerTo();
-                }
-                else
-                {
-                    return Type.tchar.pointerTo();
-                }
-            }
-            else
-            {
-                assert(0);
-            }
-        }
     }
 }

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -107,13 +107,13 @@ bool ISX64REF(Declaration var)
 
     if (var.isParameter())
     {
-        if (global.params.targetOS == TargetOS.Windows && global.params.is64bit)
+        if (target.os == Target.OS.Windows && global.params.is64bit)
         {
             return var.type.size(Loc.initial) > REGSIZE
                 || (var.storage_class & STC.lazy_)
                 || (var.type.isTypeStruct() && !var.type.isTypeStruct().sym.isPOD());
         }
-        else if (global.params.targetOS & TargetOS.Posix)
+        else if (target.os & Target.OS.Posix)
         {
             return !(var.storage_class & STC.lazy_) && var.type.isTypeStruct() && !var.type.isTypeStruct().sym.isPOD();
         }
@@ -126,12 +126,12 @@ bool ISX64REF(Declaration var)
  */
 bool ISX64REF(IRState* irs, Expression exp)
 {
-    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+    if (target.os == Target.OS.Windows && irs.params.is64bit)
     {
         return exp.type.size(Loc.initial) > REGSIZE
             || (exp.type.isTypeStruct() && !exp.type.isTypeStruct().sym.isPOD());
     }
-    else if (irs.params.targetOS & TargetOS.Posix)
+    else if (target.os & Target.OS.Posix)
     {
         return exp.type.isTypeStruct() && !exp.type.isTypeStruct().sym.isPOD();
     }
@@ -269,7 +269,7 @@ private elem *callfunc(const ref Loc loc,
                 continue;
             }
 
-            if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit && tybasic(ea.Ety) == TYcfloat)
+            if (target.os == Target.OS.Windows && irs.params.is64bit && tybasic(ea.Ety) == TYcfloat)
             {
                 /* Treat a cfloat like it was a struct { float re,im; }
                  */
@@ -559,7 +559,7 @@ if (!irs.params.is64bit) assert(tysize(TYnptr) == 4);
     }
     else if (retmethod == RET.stack)
     {
-        if (irs.params.targetOS == TargetOS.OSX && eresult)
+        if (target.os == Target.OS.OSX && eresult)
         {
             /* ABI quirk: hidden pointer is not returned in registers
              */
@@ -1079,10 +1079,10 @@ Lagain:
                     type *t2 = evalue.ET.Ttag.Sstruct.Sarg2type;
                     if (!t1 && !t2)
                     {
-                        if (irs.params.targetOS & TargetOS.Posix || sz > 8)
+                        if (target.os & Target.OS.Posix || sz > 8)
                             r = RTLSYM_MEMSETN;
                     }
-                    else if (irs.params.targetOS & TargetOS.Posix &&
+                    else if (target.os & Target.OS.Posix &&
                              r == RTLSYM_MEMSET128ii &&
                              tyfloating(t1.Tty) &&
                              tyfloating(t2.Tty))
@@ -1108,7 +1108,7 @@ Lagain:
         edim = el_bin(OPmul, TYsize_t, edim, el_long(TYsize_t, sz));
     }
 
-    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit && sz > REGSIZE)
+    if (target.os == Target.OS.Windows && irs.params.is64bit && sz > REGSIZE)
     {
         evalue = addressElem(evalue, tb);
     }
@@ -1945,7 +1945,7 @@ elem *toElem(Expression e, IRState *irs)
                     elem *earray = ExpressionsToStaticArray(ne.loc, ne.arguments, &sdata);
 
                     e = el_pair(TYdarray, el_long(TYsize_t, ne.arguments.dim), el_ptr(sdata));
-                    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+                    if (target.os == Target.OS.Windows && irs.params.is64bit)
                         e = addressElem(e, Type.tsize_t.arrayOf());
                     e = el_param(e, getTypeInfo(ne.loc, ne.type, irs));
                     int rtl = t.isZeroInit(Loc.initial) ? RTLSYM_NEWARRAYMTX : RTLSYM_NEWARRAYMITX;
@@ -2168,7 +2168,7 @@ elem *toElem(Expression e, IRState *irs)
                     size_t len = strlen(id);
                     Symbol *si = toStringSymbol(id, len, 1);
                     elem *efilename = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-                    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+                    if (target.os == Target.OS.Windows && irs.params.is64bit)
                         efilename = addressElem(efilename, Type.tstring, true);
 
                     if (ae.msg)
@@ -2180,7 +2180,7 @@ elem *toElem(Expression e, IRState *irs)
                          */
                         elem *emsg = toElemDtor(ae.msg, irs);
                         emsg = array_toDarray(ae.msg.type, emsg);
-                        if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+                        if (target.os == Target.OS.Windows && irs.params.is64bit)
                             emsg = addressElem(emsg, Type.tvoid.arrayOf(), false);
 
                         ea = el_var(getRtlsym(ud ? RTLSYM_DUNITTEST_MSG : RTLSYM_DASSERT_MSG));
@@ -2339,7 +2339,7 @@ elem *toElem(Expression e, IRState *irs)
         {
             elem *ex = toElem(e, irs);
             ex = array_toDarray(e.type, ex);
-            if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+            if (target.os == Target.OS.Windows && irs.params.is64bit)
             {
                 ex = addressElem(ex, Type.tvoid.arrayOf(), false);
             }
@@ -2389,7 +2389,7 @@ elem *toElem(Expression e, IRState *irs)
                 elem *earr = ElemsToStaticArray(ce.loc, ce.type, &elems, &sdata);
 
                 elem *ep = el_pair(TYdarray, el_long(TYsize_t, elems.dim), el_ptr(sdata));
-                if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+                if (target.os == Target.OS.Windows && irs.params.is64bit)
                     ep = addressElem(ep, Type.tvoid.arrayOf());
                 ep = el_param(ep, getTypeInfo(ce.loc, ta, irs));
                 e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYCATNTX)), ep);
@@ -2965,7 +2965,7 @@ elem *toElem(Expression e, IRState *irs)
                          */
                         el_free(esize);
                         elem *eti = getTypeInfo(ae.e1.loc, t1.nextOf().toBasetype(), irs);
-                        if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+                        if (target.os == Target.OS.Windows && irs.params.is64bit)
                         {
                             eto   = addressElem(eto,   Type.tvoid.arrayOf());
                             efrom = addressElem(efrom, Type.tvoid.arrayOf());
@@ -2980,7 +2980,7 @@ elem *toElem(Expression e, IRState *irs)
                         // Generate:
                         //      _d_arraycopy(eto, efrom, esize)
 
-                        if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+                        if (target.os == Target.OS.Windows && irs.params.is64bit)
                         {
                             eto   = addressElem(eto,   Type.tvoid.arrayOf());
                             efrom = addressElem(efrom, Type.tvoid.arrayOf());
@@ -3286,7 +3286,7 @@ elem *toElem(Expression e, IRState *irs)
                      *      _d_arrayctor(ti, e2, e1)
                      */
                     elem *eti = getTypeInfo(ae.e1.loc, t1b.nextOf().toBasetype(), irs);
-                    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+                    if (target.os == Target.OS.Windows && irs.params.is64bit)
                     {
                         e1 = addressElem(e1, Type.tvoid.arrayOf());
                         e2 = addressElem(e2, Type.tvoid.arrayOf());
@@ -3309,7 +3309,7 @@ elem *toElem(Expression e, IRState *irs)
                      *      _d_arrayassign_r(ti, e2, e1, etmp)
                      */
                     elem *eti = getTypeInfo(ae.e1.loc, t1b.nextOf().toBasetype(), irs);
-                    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+                    if (target.os == Target.OS.Windows && irs.params.is64bit)
                     {
                         e1 = addressElem(e1, Type.tvoid.arrayOf());
                         e2 = addressElem(e2, Type.tvoid.arrayOf());
@@ -3396,7 +3396,7 @@ elem *toElem(Expression e, IRState *irs)
                      * _d_arrayappendT(e2, ev, typeinfo), *ev
                      */
 
-                    if (global.params.targetOS == TargetOS.Windows && global.params.is64bit)
+                    if (target.os == Target.OS.Windows && global.params.is64bit)
                         e2 = addressElem(e2, tb2, true);
                     else
                         e2 = useOPstrpar(e2);
@@ -5660,7 +5660,7 @@ elem *toElem(Expression e, IRState *irs)
 
                 elem *ev = el_pair(TYdarray, el_long(TYsize_t, dim), el_ptr(svalues));
                 elem *ek = el_pair(TYdarray, el_long(TYsize_t, dim), el_ptr(skeys  ));
-                if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+                if (target.os == Target.OS.Windows && irs.params.is64bit)
                 {
                     ev = addressElem(ev, Type.tvoid.arrayOf());
                     ek = addressElem(ek, Type.tvoid.arrayOf());
@@ -6045,7 +6045,7 @@ private elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi)
 
     if (edtors)
     {
-        if (irs.params.targetOS == TargetOS.Windows && !irs.params.is64bit) // Win32
+        if (target.os == Target.OS.Windows && !irs.params.is64bit) // Win32
         {
             Blockx *blx = irs.blx;
             nteh_declarvars(blx);
@@ -6153,7 +6153,7 @@ Symbol *toStringSymbol(const(char)* str, size_t len, size_t sz)
     {
         Symbol* si;
 
-        if (global.params.targetOS == TargetOS.Windows)
+        if (target.os == Target.OS.Windows)
         {
             /* This should be in the back end, but mangleToBuffer() is
              * in the front end.
@@ -6260,7 +6260,7 @@ private elem *filelinefunction(IRState *irs, const ref Loc loc)
     size_t len = strlen(id);
     Symbol *si = toStringSymbol(id, len, 1);
     elem *efilename = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+    if (target.os == Target.OS.Windows && irs.params.is64bit)
         efilename = addressElem(efilename, Type.tstring, true);
 
     elem *elinnum = el_long(TYint, loc.linnum);
@@ -6275,7 +6275,7 @@ private elem *filelinefunction(IRState *irs, const ref Loc loc)
     len = strlen(s);
     si = toStringSymbol(s, len, 1);
     elem *efunction = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-    if (irs.params.targetOS == TargetOS.Windows && irs.params.is64bit)
+    if (target.os == Target.OS.Windows && irs.params.is64bit)
         efunction = addressElem(efunction, Type.tstring, true);
 
     return el_params(efunction, elinnum, efilename, null);
@@ -6475,7 +6475,7 @@ elem *callCAssert(IRState *irs, const ref Loc loc, Expression exp, Expression em
     auto eline = el_long(TYint, loc.linnum);
 
     elem *ea;
-    if (irs.params.targetOS == TargetOS.OSX)
+    if (target.os == Target.OS.OSX)
     {
         // __assert_rtn(func, file, line, msg);
         elem* efunc = getFuncName();
@@ -6494,7 +6494,7 @@ elem *callCAssert(IRState *irs, const ref Loc loc, Expression exp, Expression em
         else
         {
             // [_]_assert(msg, file, line);
-            const rtlsym = (irs.params.targetOS == TargetOS.Windows) ? RTLSYM_C_ASSERT : RTLSYM_C__ASSERT;
+            const rtlsym = (target.os == Target.OS.Windows) ? RTLSYM_C_ASSERT : RTLSYM_C__ASSERT;
             auto eassert = el_var(getRtlsym(rtlsym));
             ea = el_bin(OPcall, TYvoid, eassert, el_params(eline, efilename, elmsg, null));
         }

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -120,10 +120,10 @@ void initDMD(
     import dmd.globals : CHECKENABLE, global;
     import dmd.id : Id;
     import dmd.identifier : Identifier;
-    import dmd.mars : setTarget, addDefaultVersionIdentifiers;
+    import dmd.mars : addDefaultVersionIdentifiers;
     import dmd.mtype : Type;
     import dmd.objc : Objc;
-    import dmd.target : target;
+    import dmd.target : target, defaultTargetOS;
 
     diagnosticHandler = handler;
 
@@ -140,13 +140,13 @@ void initDMD(
     }
 
     versionIdentifiers.each!(VersionCondition.addGlobalIdent);
-    setTarget(global.params);
     addDefaultVersionIdentifiers(global.params);
 
     Type._init();
     Id.initialize();
     Module._init();
     target._init(global.params);
+    target.os = defaultTargetOS();
     Expression._init();
     Objc._init();
     FileCache._init();

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6522,6 +6522,21 @@ enum class CPU
 
 struct Target
 {
+    enum class OS : uint8_t
+    {
+        Freestanding = 0u,
+        linux = 1u,
+        Windows = 2u,
+        OSX = 4u,
+        OpenBSD = 8u,
+        FreeBSD = 16u,
+        Solaris = 32u,
+        DragonFlyBSD = 64u,
+        all = 127u,
+        Posix = 125u,
+    };
+
+    OS os;
     uint32_t ptrsize;
     uint32_t realsize;
     uint32_t realpad;
@@ -6602,6 +6617,7 @@ public:
     bool isCalleeDestroyingArgs(TypeFunction* tf);
     bool libraryObjectMonitors(FuncDeclaration* fd, Statement* fbody);
     Target() :
+        os((OS)1u),
         ptrsize(),
         realsize(),
         realpad(),
@@ -6622,7 +6638,8 @@ public:
         RealProperties()
     {
     }
-    Target(uint32_t ptrsize, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, nullptr), TargetCPP cpp = TargetCPP(false, false, false), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
+    Target(OS os, uint32_t ptrsize = 0u, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, nullptr), TargetCPP cpp = TargetCPP(false, false, false), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
+        os(os),
         ptrsize(ptrsize),
         realsize(realsize),
         realpad(realpad),
@@ -6773,19 +6790,6 @@ enum class HIGHLIGHT : uint8_t
     Other = 6u,
 };
 
-enum class TargetOS : uint8_t
-{
-    linux = 1u,
-    Windows = 2u,
-    OSX = 4u,
-    OpenBSD = 8u,
-    FreeBSD = 16u,
-    Solaris = 32u,
-    DragonFlyBSD = 64u,
-    all = 127u,
-    Posix = 125u,
-};
-
 enum class TARGET : bool
 {
     Linux = true,
@@ -6880,7 +6884,6 @@ struct Param
     bool optimize;
     bool is64bit;
     bool isLP64;
-    TargetOS targetOS;
     bool mscoff;
     DiagnosticReporting useDeprecated;
     bool stackstomp;
@@ -7117,7 +7120,7 @@ struct Param
         mapfile()
     {
     }
-    Param(bool obj, bool link = true, bool dll = false, bool lib = false, bool multiobj = false, bool oneobj = false, bool trace = false, bool tracegc = false, bool verbose = false, bool vcg_ast = false, bool showColumns = false, bool vtls = false, bool vtemplates = false, bool vtemplatesListInstances = false, bool vgc = false, bool vfield = false, bool vcomplex = false, uint8_t symdebug = 0u, bool symdebugref = false, bool optimize = false, bool is64bit = true, bool isLP64 = false, TargetOS targetOS = (TargetOS)1u, bool mscoff = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool stackstomp = false, bool useUnitTests = false, bool useInline = false, FeatureState useDIP25 = (FeatureState)-1, bool useDIP1021 = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, PIC pic = (PIC)0u, bool color = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool nofloat = false, bool ignoreUnsupportedPragmas = false, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool noSharedAccess = false, bool previewIn = false, bool shortenedMethods = false, bool betterC = false, bool addMain = false, bool allInst = false, bool fix16997 = false, bool fixAliasThis = false, bool inclusiveInContracts = false, bool vsafe = false, bool ehnogc = false, FeatureState dtorFields = (FeatureState)-1, bool fieldwise = false, bool rvalueRefParam = false, CppStdRevision cplusplus = (CppStdRevision)201103u, bool markdown = true, bool vmarkdown = false, bool showGaggedErrors = false, bool printErrorContext = false, bool manual = false, bool usage = false, bool mcpuUsage = false, bool transitionUsage = false, bool checkUsage = false, bool checkActionUsage = false, bool revertUsage = false, bool previewUsage = false, bool externStdUsage = false, bool hcUsage = false, bool logo = false, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, uint32_t errorLimit = 20u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >* imppath = nullptr, Array<const char* >* fileImppath = nullptr, _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, bool doDocComments = false, _d_dynamicArray< const char > docdir = {}, _d_dynamicArray< const char > docname = {}, Array<const char* > ddocfiles = Array<const char* >(0LLU, {}, arrayliteral), bool doHdrGeneration = false, _d_dynamicArray< const char > hdrdir = {}, _d_dynamicArray< const char > hdrname = {}, bool hdrStripPlainFunctions = true, CxxHeaderMode doCxxHdrGeneration = (CxxHeaderMode)0u, _d_dynamicArray< const char > cxxhdrdir = {}, _d_dynamicArray< const char > cxxhdrname = {}, bool doJsonGeneration = false, _d_dynamicArray< const char > jsonfilename = {}, JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, OutBuffer* mixinOut = nullptr, const char* mixinFile = nullptr, int32_t mixinLines = 0, uint32_t debuglevel = 0u, Array<const char* >* debugids = nullptr, uint32_t versionlevel = 0u, Array<const char* >* versionids = nullptr, _d_dynamicArray< const char > defaultlibname = {}, _d_dynamicArray< const char > debuglibname = {}, _d_dynamicArray< const char > mscrtlib = {}, _d_dynamicArray< const char > moduleDepsFile = {}, OutBuffer* moduleDeps = nullptr, bool emitMakeDeps = false, _d_dynamicArray< const char > makeDepsFile = {}, Array<const char* > makeDeps = Array<const char* >(0LLU, {}, arrayliteral), MessageStyle messageStyle = (MessageStyle)0u, bool run = false, Array<const char* > runargs = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > objfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > linkswitches = Array<const char* >(0LLU, {}, arrayliteral), Array<bool > linkswitchIsForCC = Array<bool >(0LLU, {}, arrayliteral), Array<const char* > libfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > dllfiles = Array<const char* >(0LLU, {}, arrayliteral), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
+    Param(bool obj, bool link = true, bool dll = false, bool lib = false, bool multiobj = false, bool oneobj = false, bool trace = false, bool tracegc = false, bool verbose = false, bool vcg_ast = false, bool showColumns = false, bool vtls = false, bool vtemplates = false, bool vtemplatesListInstances = false, bool vgc = false, bool vfield = false, bool vcomplex = false, uint8_t symdebug = 0u, bool symdebugref = false, bool optimize = false, bool is64bit = true, bool isLP64 = false, bool mscoff = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool stackstomp = false, bool useUnitTests = false, bool useInline = false, FeatureState useDIP25 = (FeatureState)-1, bool useDIP1021 = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, PIC pic = (PIC)0u, bool color = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool nofloat = false, bool ignoreUnsupportedPragmas = false, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool noSharedAccess = false, bool previewIn = false, bool shortenedMethods = false, bool betterC = false, bool addMain = false, bool allInst = false, bool fix16997 = false, bool fixAliasThis = false, bool inclusiveInContracts = false, bool vsafe = false, bool ehnogc = false, FeatureState dtorFields = (FeatureState)-1, bool fieldwise = false, bool rvalueRefParam = false, CppStdRevision cplusplus = (CppStdRevision)201103u, bool markdown = true, bool vmarkdown = false, bool showGaggedErrors = false, bool printErrorContext = false, bool manual = false, bool usage = false, bool mcpuUsage = false, bool transitionUsage = false, bool checkUsage = false, bool checkActionUsage = false, bool revertUsage = false, bool previewUsage = false, bool externStdUsage = false, bool hcUsage = false, bool logo = false, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, uint32_t errorLimit = 20u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >* imppath = nullptr, Array<const char* >* fileImppath = nullptr, _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, bool doDocComments = false, _d_dynamicArray< const char > docdir = {}, _d_dynamicArray< const char > docname = {}, Array<const char* > ddocfiles = Array<const char* >(0LLU, {}, arrayliteral), bool doHdrGeneration = false, _d_dynamicArray< const char > hdrdir = {}, _d_dynamicArray< const char > hdrname = {}, bool hdrStripPlainFunctions = true, CxxHeaderMode doCxxHdrGeneration = (CxxHeaderMode)0u, _d_dynamicArray< const char > cxxhdrdir = {}, _d_dynamicArray< const char > cxxhdrname = {}, bool doJsonGeneration = false, _d_dynamicArray< const char > jsonfilename = {}, JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, OutBuffer* mixinOut = nullptr, const char* mixinFile = nullptr, int32_t mixinLines = 0, uint32_t debuglevel = 0u, Array<const char* >* debugids = nullptr, uint32_t versionlevel = 0u, Array<const char* >* versionids = nullptr, _d_dynamicArray< const char > defaultlibname = {}, _d_dynamicArray< const char > debuglibname = {}, _d_dynamicArray< const char > mscrtlib = {}, _d_dynamicArray< const char > moduleDepsFile = {}, OutBuffer* moduleDeps = nullptr, bool emitMakeDeps = false, _d_dynamicArray< const char > makeDepsFile = {}, Array<const char* > makeDeps = Array<const char* >(0LLU, {}, arrayliteral), MessageStyle messageStyle = (MessageStyle)0u, bool run = false, Array<const char* > runargs = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > objfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > linkswitches = Array<const char* >(0LLU, {}, arrayliteral), Array<bool > linkswitchIsForCC = Array<bool >(0LLU, {}, arrayliteral), Array<const char* > libfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > dllfiles = Array<const char* >(0LLU, {}, arrayliteral), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
         obj(obj),
         link(link),
         dll(dll),
@@ -7140,7 +7143,6 @@ struct Param
         optimize(optimize),
         is64bit(is64bit),
         isLP64(isLP64),
-        targetOS(targetOS),
         mscoff(mscoff),
         useDeprecated(useDeprecated),
         stackstomp(stackstomp),
@@ -7311,7 +7313,7 @@ struct Global
         debugids()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > mars_ext = { 1, "d" }, _d_dynamicArray< const char > doc_ext = { 4, "html" }, _d_dynamicArray< const char > ddoc_ext = { 4, "ddoc" }, _d_dynamicArray< const char > hdr_ext = { 2, "di" }, _d_dynamicArray< const char > cxxhdr_ext = { 1, "h" }, _d_dynamicArray< const char > json_ext = { 4, "json" }, _d_dynamicArray< const char > map_ext = { 3, "map" }, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, 0u, false, false, true, false, (TargetOS)1u, false, (DiagnosticReporting)1u, false, false, false, (FeatureState)-1, false, false, false, (DiagnosticReporting)2u, (PIC)0u, false, false, 0u, false, false, false, true, true, true, false, false, false, false, false, false, false, false, false, false, false, (FeatureState)-1, false, false, (CppStdRevision)201103u, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKACTION)0u, 20u, {}, Array<const char* >(0LLU, {}, arrayliteral), nullptr, nullptr, {}, {}, {}, false, {}, {}, Array<const char* >(0LLU, {}, arrayliteral), false, {}, {}, true, (CxxHeaderMode)0u, {}, {}, false, {}, (JsonFieldFlags)0u, nullptr, nullptr, 0, 0u, nullptr, 0u, nullptr, {}, {}, {}, {}, nullptr, false, {}, Array<const char* >(0LLU, {}, arrayliteral), (MessageStyle)0u, false, Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<bool >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), {}, {}, {}, {}), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > mars_ext = { 1, "d" }, _d_dynamicArray< const char > doc_ext = { 4, "html" }, _d_dynamicArray< const char > ddoc_ext = { 4, "ddoc" }, _d_dynamicArray< const char > hdr_ext = { 2, "di" }, _d_dynamicArray< const char > cxxhdr_ext = { 1, "h" }, _d_dynamicArray< const char > json_ext = { 4, "json" }, _d_dynamicArray< const char > map_ext = { 3, "map" }, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, 0u, false, false, true, false, false, (DiagnosticReporting)1u, false, false, false, (FeatureState)-1, false, false, false, (DiagnosticReporting)2u, (PIC)0u, false, false, 0u, false, false, false, true, true, true, false, false, false, false, false, false, false, false, false, false, false, (FeatureState)-1, false, false, (CppStdRevision)201103u, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKACTION)0u, 20u, {}, Array<const char* >(0LLU, {}, arrayliteral), nullptr, nullptr, {}, {}, {}, false, {}, {}, Array<const char* >(0LLU, {}, arrayliteral), false, {}, {}, true, (CxxHeaderMode)0u, {}, {}, false, {}, (JsonFieldFlags)0u, nullptr, nullptr, 0, 0u, nullptr, 0u, nullptr, {}, {}, {}, {}, nullptr, false, {}, Array<const char* >(0LLU, {}, arrayliteral), (MessageStyle)0u, false, Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<bool >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), {}, {}, {}, {}), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr) :
         inifilename(inifilename),
         mars_ext(mars_ext),
         doc_ext(doc_ext),

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -17,25 +17,6 @@ import dmd.root.filename;
 import dmd.root.outbuffer;
 import dmd.identifier;
 
-/// Bit decoding of the TargetOS
-enum TargetOS : ubyte
-{
-    /* These are mutually exclusive; one and only one is set.
-     * Match spelling and casing of corresponding version identifiers
-     */
-    linux        = 1,
-    Windows      = 2,
-    OSX          = 4,
-    OpenBSD      = 8,
-    FreeBSD      = 0x10,
-    Solaris      = 0x20,
-    DragonFlyBSD = 0x40,
-
-    // Combination masks
-    all = linux | Windows | OSX | OpenBSD | FreeBSD | Solaris | DragonFlyBSD,
-    Posix = linux | OSX | OpenBSD | FreeBSD | Solaris | DragonFlyBSD,
-}
-
 template xversion(string s)
 {
     enum xversion = mixin(`{ version (` ~ s ~ `) return true; else return false; }`)();
@@ -152,7 +133,6 @@ extern (C++) struct Param
     bool optimize;          // run optimizer
     bool is64bit = (size_t.sizeof == 8);  // generate 64 bit code; true by default for 64 bit dmd
     bool isLP64;            // generate code for LP64
-    TargetOS targetOS;      // operating system to generate code for
     bool mscoff = false;    // for Win32: write MsCoff object files instead of OMF
     DiagnosticReporting useDeprecated = DiagnosticReporting.inform;  // how use of deprecated features are handled
     bool stackstomp;            // add stack stomping code

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -19,26 +19,6 @@
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;
 
-typedef unsigned char TargetOS;
-enum
-{
-    /* These are mutually exclusive; one and only one is set.
-     * Match spelling and casing of corresponding version identifiers
-     */
-    TargetOS_linux        = 1,
-    TargetOS_Windows      = 2,
-    TargetOS_OSX          = 4,
-    TargetOS_OpenBSD      = 8,
-    TargetOS_FreeBSD      = 0x10,
-    TargetOS_Solaris      = 0x20,
-    TargetOS_DragonFlyBSD = 0x40,
-
-    // Combination masks
-    all = TargetOS_linux | TargetOS_Windows | TargetOS_OSX | TargetOS_OpenBSD | TargetOS_FreeBSD | TargetOS_Solaris | TargetOS_DragonFlyBSD,
-    Posix = TargetOS_linux | TargetOS_OSX | TargetOS_OpenBSD | TargetOS_FreeBSD | TargetOS_Solaris | TargetOS_DragonFlyBSD,
-};
-
-
 typedef unsigned char Diagnostic;
 enum
 {
@@ -132,7 +112,6 @@ struct Param
     bool optimize;      // run optimizer
     bool is64bit;       // generate 64 bit code
     bool isLP64;        // generate code for LP64
-    TargetOS targetOS;      // operating system to generate code for
     bool mscoff;        // for Win32: write COFF object files instead of OMF
     Diagnostic useDeprecated;
     bool stackstomp;    // add stack stomping code

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -459,14 +459,14 @@ void genObjFile(Module m, bool multiobj)
         elem *ecov  = el_pair(TYdarray, el_long(TYsize_t, m.numlines), el_ptr(m.cov));
         elem *ebcov = el_pair(TYdarray, el_long(TYsize_t, m.numlines), el_ptr(bcov));
 
-        if (global.params.targetOS == TargetOS.Windows && global.params.is64bit)
+        if (target.os == Target.OS.Windows && global.params.is64bit)
         {
             ecov  = addressElem(ecov,  Type.tvoid.arrayOf(), false);
             ebcov = addressElem(ebcov, Type.tvoid.arrayOf(), false);
         }
 
         elem *efilename = toEfilename(m);
-        if (global.params.targetOS == TargetOS.Windows && global.params.is64bit)
+        if (target.os == Target.OS.Windows && global.params.is64bit)
             efilename = addressElem(efilename, Type.tstring, true);
 
         elem *e = el_params(
@@ -655,7 +655,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         // Same as config.ehmethod==EH_NONE, but only for this function
         f.Fflags3 |= Feh_none;
 
-    s.Sclass = global.params.targetOS == TargetOS.OSX ? SCcomdat : SCglobal;
+    s.Sclass = target.os == Target.OS.OSX ? SCcomdat : SCglobal;
     for (Dsymbol p = fd.parent; p; p = p.parent)
     {
         if (p.isTemplateInstance())
@@ -875,7 +875,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         {
             if (fpr.alloc(sp.Stype, sp.Stype.Tty, &sp.Spreg, &sp.Spreg2))
             {
-                sp.Sclass = (global.params.targetOS == TargetOS.Windows && global.params.is64bit) ? SCshadowreg : SCfastpar;
+                sp.Sclass = (target.os == Target.OS.Windows && global.params.is64bit) ? SCshadowreg : SCfastpar;
                 sp.Sfl = (sp.Sclass == SCshadowreg) ? FLpara : FLfast;
             }
         }
@@ -905,7 +905,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     {
         // Declare va_argsave
         if (global.params.is64bit &&
-            global.params.targetOS & TargetOS.Posix)
+            target.os & Target.OS.Posix)
         {
             type *t = type_struct_class("__va_argsave_t", 16, 8 * 6 + 8 * 16 + 8 * 3, null, null, false, false, true, false);
             // The backend will pick this up by name
@@ -1129,7 +1129,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
         {
             objmod.external_def("main");
         }
-        else if (global.params.targetOS == TargetOS.Windows && !global.params.is64bit)
+        else if (target.os == Target.OS.Windows && !global.params.is64bit)
         {
             objmod.external_def("_main");
             objmod.external_def("__acrtused_con");
@@ -1153,14 +1153,14 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
                 obj_includelib(global.params.mscrtlib);
             objmod.includelib("OLDNAMES");
         }
-        else if (global.params.targetOS == TargetOS.Windows && !global.params.is64bit)
+        else if (target.os == Target.OS.Windows && !global.params.is64bit)
         {
             objmod.external_def("__acrtused_con");        // bring in C startup code
             objmod.includelib("snn.lib");          // bring in C runtime library
         }
         s.Sclass = SCglobal;
     }
-    else if (global.params.targetOS == TargetOS.Windows && fd.isWinMain() && onlyOneMain(fd.loc))
+    else if (target.os == Target.OS.Windows && fd.isWinMain() && onlyOneMain(fd.loc))
     {
         if (global.params.mscoff)
         {
@@ -1179,7 +1179,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
     }
 
     // Pull in RTL startup code
-    else if (global.params.targetOS == TargetOS.Windows && fd.isDllMain() && onlyOneMain(fd.loc))
+    else if (target.os == Target.OS.Windows && fd.isDllMain() && onlyOneMain(fd.loc))
     {
         if (global.params.mscoff)
         {
@@ -1209,7 +1209,7 @@ private bool onlyOneMain(Loc loc)
         if (global.params.addMain)
             msg = ", -main switch added another `main()`";
         const(char)* otherMainNames = "";
-        if (global.params.targetOS == TargetOS.Windows)
+        if (target.os == Target.OS.Windows)
             otherMainNames = ", `WinMain`, or `DllMain`";
         error(loc, "only one `main`%s allowed%s. Previously found `main` at %s",
             otherMainNames, msg, lastLoc.toChars());
@@ -1253,7 +1253,7 @@ tym_t totym(Type tx)
         case Tchar:     t = TYchar;     break;
         case Twchar:    t = TYwchar_t;  break;
         case Tdchar:
-            t = (global.params.symdebug == 1 || global.params.targetOS & TargetOS.Posix) ? TYdchar : TYulong;
+            t = (global.params.symdebug == 1 || target.os & Target.OS.Posix) ? TYdchar : TYulong;
             break;
 
         case Taarray:   t = TYaarray;   break;
@@ -1341,7 +1341,7 @@ tym_t totym(Type tx)
                 case LINK.cpp:
                 case LINK.objc:
                     t = TYnfunc;
-                    if (global.params.targetOS == TargetOS.Windows)
+                    if (target.os == Target.OS.Windows)
                     {
                     }
                     else if (!global.params.is64bit && retStyle(tf, false) == RET.stack)

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -35,6 +35,7 @@ import dmd.mtype;
 import dmd.root.outbuffer;
 import dmd.root.rootobject;
 import dmd.root.string;
+import dmd.target;
 import dmd.visitor;
 
 version(Windows) {
@@ -841,28 +842,28 @@ public:
         property("size_t", size_t.sizeof);
         propertyStart("platforms");
         arrayStart();
-        if (global.params.targetOS == TargetOS.Windows)
+        if (target.os == Target.OS.Windows)
         {
             item("windows");
         }
         else
         {
             item("posix");
-            if (global.params.targetOS == TargetOS.linux)
+            if (target.os == Target.OS.linux)
                 item("linux");
-            else if (global.params.targetOS == TargetOS.OSX)
+            else if (target.os == Target.OS.OSX)
                 item("osx");
-            else if (global.params.targetOS == TargetOS.FreeBSD)
+            else if (target.os == Target.OS.FreeBSD)
             {
                 item("freebsd");
                 item("bsd");
             }
-            else if (global.params.targetOS == TargetOS.OpenBSD)
+            else if (target.os == Target.OS.OpenBSD)
             {
                 item("openbsd");
                 item("bsd");
             }
-            else if (global.params.targetOS == TargetOS.Solaris)
+            else if (target.os == Target.OS.Solaris)
             {
                 item("solaris");
                 item("bsd");

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -262,7 +262,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (params.color)
         global.console = Console.create(core.stdc.stdio.stderr);
 
-    setTarget(params);           // set target operating system
+    target.os = defaultTargetOS();           // set target operating system
     target.setCPU();
 
     if (global.errors)
@@ -289,8 +289,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (params.debugids)
         foreach (charz; *params.debugids)
             DebugCondition.addGlobalIdent(charz.toDString());
-
-    setTarget(params);
 
     setDefaultLibrary();
 
@@ -1264,32 +1262,6 @@ private void setDefaultLibrary()
         global.params.debuglibname = global.params.defaultlibname;
 }
 
-/*************************************
- * Set the `is` target fields of `params` according
- * to the TARGET value.
- * Params:
- *      params = where the `is` fields are
- */
-void setTarget(ref Param params)
-{
-    static if (TARGET.Windows)
-        params.targetOS = TargetOS.Windows;
-    else static if (TARGET.Linux)
-        params.targetOS = TargetOS.linux;
-    else static if (TARGET.OSX)
-        params.targetOS = TargetOS.OSX;
-    else static if (TARGET.FreeBSD)
-        params.targetOS = TargetOS.FreeBSD;
-    else static if (TARGET.OpenBSD)
-        params.targetOS = TargetOS.OpenBSD;
-    else static if (TARGET.Solaris)
-        params.targetOS = TargetOS.Solaris;
-    else static if (TARGET.DragonFlyBSD)
-        params.targetOS = TargetOS.DragonFlyBSD;
-    else
-        static assert(0, "unknown TARGET");
-}
-
 /**
  * Add default `version` identifier for dmd, and set the
  * target platform in `params`.
@@ -1305,7 +1277,7 @@ void setTarget(ref Param params)
 void addDefaultVersionIdentifiers(const ref Param params)
 {
     VersionCondition.addPredefinedGlobalIdent("DigitalMars");
-    if (params.targetOS == TargetOS.Windows)
+    if (target.os == Target.OS.Windows)
     {
         VersionCondition.addPredefinedGlobalIdent("Windows");
         if (global.params.mscoff)
@@ -1319,7 +1291,7 @@ void addDefaultVersionIdentifiers(const ref Param params)
             VersionCondition.addPredefinedGlobalIdent("CppRuntime_DigitalMars");
         }
     }
-    else if (params.targetOS == TargetOS.linux)
+    else if (target.os == Target.OS.linux)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("linux");
@@ -1335,7 +1307,7 @@ void addDefaultVersionIdentifiers(const ref Param params)
             VersionCondition.addPredefinedGlobalIdent("CRuntime_Glibc");
         VersionCondition.addPredefinedGlobalIdent("CppRuntime_Gcc");
     }
-    else if (params.targetOS == TargetOS.OSX)
+    else if (target.os == Target.OS.OSX)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("OSX");
@@ -1343,7 +1315,7 @@ void addDefaultVersionIdentifiers(const ref Param params)
         // For legacy compatibility
         VersionCondition.addPredefinedGlobalIdent("darwin");
     }
-    else if (params.targetOS == TargetOS.FreeBSD)
+    else if (target.os == Target.OS.FreeBSD)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("FreeBSD");
@@ -1351,21 +1323,21 @@ void addDefaultVersionIdentifiers(const ref Param params)
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         VersionCondition.addPredefinedGlobalIdent("CppRuntime_Clang");
     }
-    else if (params.targetOS == TargetOS.OpenBSD)
+    else if (target.os == Target.OS.OpenBSD)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("OpenBSD");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         VersionCondition.addPredefinedGlobalIdent("CppRuntime_Clang");
     }
-    else if (params.targetOS == TargetOS.DragonFlyBSD)
+    else if (target.os == Target.OS.DragonFlyBSD)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("DragonFlyBSD");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         VersionCondition.addPredefinedGlobalIdent("CppRuntime_Gcc");
     }
-    else if (params.targetOS == TargetOS.Solaris)
+    else if (target.os == Target.OS.Solaris)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("Solaris");
@@ -1386,7 +1358,7 @@ void addDefaultVersionIdentifiers(const ref Param params)
     {
         VersionCondition.addPredefinedGlobalIdent("D_InlineAsm_X86_64");
         VersionCondition.addPredefinedGlobalIdent("X86_64");
-        if (params.targetOS & TargetOS.Windows)
+        if (target.os & Target.OS.Windows)
         {
             VersionCondition.addPredefinedGlobalIdent("Win64");
         }
@@ -1396,7 +1368,7 @@ void addDefaultVersionIdentifiers(const ref Param params)
         VersionCondition.addPredefinedGlobalIdent("D_InlineAsm"); //legacy
         VersionCondition.addPredefinedGlobalIdent("D_InlineAsm_X86");
         VersionCondition.addPredefinedGlobalIdent("X86");
-        if (params.targetOS == TargetOS.Windows)
+        if (target.os == Target.OS.Windows)
         {
             VersionCondition.addPredefinedGlobalIdent("Win32");
         }

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -1125,7 +1125,7 @@ private extern (C++) class S2irVisitor : Visitor
                 tryblock.appendSucc(bcatch);
                 block_goto(blx, BCjcatch, null);
 
-                if (cs.type && irs.params.targetOS == TargetOS.Windows && irs.params.is64bit) // Win64
+                if (cs.type && target.os == Target.OS.Windows && irs.params.is64bit) // Win64
                 {
                     /* The linker will attempt to merge together identical functions,
                      * even if the catch types differ. So add a reference to the

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -74,6 +74,27 @@ struct TargetObjC
 
 struct Target
 {
+    typedef unsigned char OS;
+    enum
+    {
+        /* These are mutually exclusive; one and only one is set.
+         * Match spelling and casing of corresponding version identifiers
+         */
+        OS_Freestanding = 0,
+        OS_linux        = 1,
+        OS_Windows      = 2,
+        OS_OSX          = 4,
+        OS_OpenBSD      = 8,
+        OS_FreeBSD      = 0x10,
+        OS_Solaris      = 0x20,
+        OS_DragonFlyBSD = 0x40,
+
+        // Combination masks
+        all = OS_linux | OS_Windows | OS_OSX | OS_OpenBSD | OS_FreeBSD | OS_Solaris | OS_DragonFlyBSD,
+        Posix = OS_linux | OS_OSX | OS_OpenBSD | OS_FreeBSD | OS_Solaris | OS_DragonFlyBSD,
+    };
+
+    OS os;
     // D ABI
     unsigned ptrsize;
     unsigned realsize;           // size a real consumes in memory

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -175,7 +175,7 @@ Symbol *toSymbol(Dsymbol s)
             }
             else if (vd.storage_class & STC.lazy_)
             {
-                if (global.params.targetOS == TargetOS.Windows && global.params.is64bit && vd.isParameter())
+                if (target.os == Target.OS.Windows && global.params.is64bit && vd.isParameter())
                     t = type_fake(TYnptr);
                 else
                     t = type_fake(TYdelegate);          // Tdelegate as C type
@@ -392,7 +392,7 @@ Symbol *toSymbol(Dsymbol s)
                         break;
                     case LINK.cpp:
                         s.Sflags |= SFLpublic;
-                        if (fd.isThis() && !global.params.is64bit && global.params.targetOS == TargetOS.Windows)
+                        if (fd.isThis() && !global.params.is64bit && target.os == Target.OS.Windows)
                         {
                             if ((cast(TypeFunction)fd.type).parameterList.varargs == VarArg.variadic)
                             {
@@ -486,21 +486,21 @@ Symbol *toImport(Symbol *sym)
     import core.stdc.stdlib : alloca;
     char *id = cast(char *) alloca(6 + strlen(n) + 1 + type_paramsize(sym.Stype).sizeof*3 + 1);
     int idlen;
-    if (global.params.targetOS & TargetOS.Posix)
+    if (target.os & Target.OS.Posix)
     {
         id = n;
         idlen = cast(int)strlen(n);
     }
     else if (sym.Stype.Tmangle == mTYman_std && tyfunc(sym.Stype.Tty))
     {
-        if (global.params.targetOS == TargetOS.Windows && global.params.is64bit)
+        if (target.os == Target.OS.Windows && global.params.is64bit)
             idlen = sprintf(id,"__imp_%s",n);
         else
             idlen = sprintf(id,"_imp__%s@%u",n,cast(uint)type_paramsize(sym.Stype));
     }
     else
     {
-        idlen = sprintf(id,(global.params.targetOS == TargetOS.Windows && global.params.is64bit) ? "__imp_%s" : "_imp__%s",n);
+        idlen = sprintf(id,(target.os == Target.OS.Windows && global.params.is64bit) ? "__imp_%s" : "_imp__%s",n);
     }
     auto t = type_alloc(TYnptr | mTYconst);
     t.Tnext = sym.Stype;

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -67,7 +67,7 @@ static void frontend_init()
     gc_disable();
 
     global._init();
-    global.params.targetOS = TargetOS_linux;
+    target.os = Target::OS_linux;
     global.vendor = "Front-End Tester";
     global.params.objname = NULL;
     target.cpu = CPU::native;

--- a/test/dub_package/avg.d
+++ b/test/dub_package/avg.d
@@ -12,6 +12,7 @@ module examples.avg;
 import dmd.astbase;
 import dmd.errors;
 import dmd.parse;
+import dmd.target;
 import dmd.transitivevisitor;
 
 import dmd.globals;
@@ -50,7 +51,7 @@ void main()
 
     Id.initialize();
     global._init();
-    global.params.targetOS = TargetOS.linux;
+    target.os = Target.OS.linux;
     global.params.is64bit = (size_t.sizeof == 8);
     global.params.useUnitTests = true;
     ASTBase.Type._init();

--- a/test/dub_package/impvisitor.d
+++ b/test/dub_package/impvisitor.d
@@ -82,6 +82,7 @@ void main()
     import dmd.id;
     import dmd.globals;
     import dmd.identifier;
+    import dmd.target;
 
     import core.memory;
 
@@ -97,7 +98,7 @@ void main()
 
         Id.initialize();
         global._init();
-        global.params.targetOS = TargetOS.linux;
+        target.os = Target.OS.linux;
         global.params.is64bit = (size_t.sizeof == 8);
         global.params.useUnitTests = true;
         ASTBase.Type._init();

--- a/test/unit/deinitialization.d
+++ b/test/unit/deinitialization.d
@@ -33,14 +33,13 @@ unittest
 @("Type.deinitialize")
 unittest
 {
-    import dmd.mars : addDefaultVersionIdentifiers, setTarget;
+    import dmd.mars : addDefaultVersionIdentifiers;
     import dmd.mtype : Type;
     import dmd.globals : global;
 
     assert(Type.stringtable == Type.stringtable.init);
 
     global._init();
-    setTarget(global.params);
 
     Type._init();
     Type.deinitialize();
@@ -89,7 +88,6 @@ unittest
 unittest
 {
     import dmd.globals : Param;
-    import dmd.mars : setTarget;
     import dmd.target : target, Target;
 
     static bool isFPTypeProperties(T)()
@@ -116,8 +114,6 @@ unittest
     assertStructsEqual(target, init);
 
     Param params;
-    setTarget(params);
-
     target._init(params);
     target.deinitialize();
 


### PR DESCRIPTION
part of a broader effort to move target specific and target dependant parameters from `global.params` to `target` to facilitate cross compilation