### PR TITLE
cgcs: replace globals with refs

### DIFF
--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -35,6 +35,7 @@ import dmd.backend.type;
 import dmd.backend.barray;
 
 nothrow:
+@safe:
 
 extern __gshared
 {


### PR DESCRIPTION
This refactor:
1. replaces global `cgcsdata` with `ref cgcs`
2. split off `comsub2()` from `comsub()` so the former doesn't have global references
3. use `ref pe` instead of `*pe`
4. needs `@safe` in global.d

Still can't make functions `@safe`, though, because of unions and printf. But it's a lot better.