### PR TITLE
Fix Issue 21802 - opAssign and opOpAssign treat lazy void parameters inconsistently

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8632,7 +8632,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 e2x = resolveAliasThis(sc, e2x); //https://issues.dlang.org/show_bug.cgi?id=17684
             if (e2x.op == TOK.error)
                 return setResult(e2x);
-            if (e2x.checkValue() || e2x.checkSharedAccess(sc))
+            // We skip checking the value for structs/classes as these might have
+            // an opAssign defined.
+            if ((t1.ty != Tstruct && t1.ty != Tclass && e2x.checkValue()) ||
+                e2x.checkSharedAccess(sc))
                 return setError();
             exp.e2 = e2x;
         }

--- a/test/compilable/test21802.d
+++ b/test/compilable/test21802.d
@@ -1,0 +1,38 @@
+// https://issues.dlang.org/show_bug.cgi?id=21802
+
+struct A
+{
+    auto opAssign(lazy void foo)
+    {
+        foo();
+    }
+    auto opOpAssign(string op)(lazy void foo)
+    {
+        foo();
+    }
+}
+
+class C
+{
+    auto opAssign(lazy void foo)
+    {
+        foo();
+    }
+    auto opOpAssign(string op)(lazy void foo)
+    {
+        foo();
+    }
+}
+
+void bar(int x) { }
+
+void main ()
+{
+    A a;
+    a ~= bar (1); // OK
+    a = bar (1); // Error: expression bar(1) is void and has no value
+
+    C c = new C;
+    c ~= bar(1);
+    c = bar(1);
+}

--- a/test/fail_compilation/fail7173.d
+++ b/test/fail_compilation/fail7173.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7173.d(23): Error: expression `b1._a.opBinary(b2._a).fun()` is `void` and has no value
+fail_compilation/fail7173.d(23): Error: cannot implicitly convert expression `b1._a.opBinary(b2._a).fun()` of type `void` to `B`
 ---
 */
 struct A{


### PR DESCRIPTION
Prior to this patch, the `rhs` of an assignment is checked if it has a value before the compiler gets the chance to check whether the `lhs` has an `opAssign`. The patch simply skips this check for structs to give the compiler to do this check. If the struct does not have an `opAssign` then the failure message will be stating that `void` cannot be implicitly convertible to the type of `lhs`.

This regression is really old, so I think we should merge with master.