### PR TITLE
use out for lvelem() rather than pointers

### DIFF
--- a/src/dmd/backend/gflow.d
+++ b/src/dmd/backend/gflow.d
@@ -48,7 +48,7 @@ void vec_setclear(size_t b, vec_t vs, vec_t vc) { vec_setbit(b, vs); vec_clearbi
 bool Eunambig(elem* e) { return OTassign(e.Eoper) && e.EV.E1.Eoper == OPvar; }
 
 @trusted
-char symbol_isintab(Symbol *s) { return sytab[s.Sclass] & SCSS; }
+char symbol_isintab(const Symbol* s) { return sytab[s.Sclass] & SCSS; }
 
 @trusted
 void util_free(void* p) { if (p) free(p); }
@@ -1351,7 +1351,7 @@ private void lvgenkill()
     {
         vec_free(b.Bgen);
         vec_free(b.Bkill);
-        lvelem(&(b.Bgen),&(b.Bkill), b.Belem, ambigsym);
+        lvelem(b.Bgen,b.Bkill, b.Belem, ambigsym);
         if (b.BC == BCasm)
         {
             vec_set(b.Bgen);
@@ -1369,15 +1369,20 @@ private void lvgenkill()
 
 /*****************************
  * Allocate and compute KILL and GEN for live variables.
+ * Params:
+ *      gen = create and fill in
+ *      kill = create and fill in
+ *      e = elem used to fill in gen and kill
+ *      ambigsym = vector of symbols with ambiguous references
  */
 
 @trusted
-private void lvelem(vec_t *pgen,vec_t *pkill,elem *n, const vec_t ambigsym)
+private void lvelem(out vec_t gen, out vec_t kill, const elem* n, const vec_t ambigsym)
 {
-    *pgen = vec_calloc(globsym.length);
-    *pkill = vec_calloc(globsym.length);
+    gen = vec_calloc(globsym.length);
+    kill = vec_calloc(globsym.length);
     if (n && globsym.length)
-        accumlv(*pgen, *pkill, n, ambigsym);
+        accumlv(gen, kill, n, ambigsym);
 }
 
 /**********************************************
@@ -1385,7 +1390,7 @@ private void lvelem(vec_t *pgen,vec_t *pkill,elem *n, const vec_t ambigsym)
  */
 
 @trusted
-private void accumlv(vec_t GEN,vec_t KILL,elem *n,const vec_t ambigsym)
+private void accumlv(vec_t GEN, vec_t KILL, const(elem)* n, const vec_t ambigsym)
 {
     assert(GEN && KILL && n);
 
@@ -1410,8 +1415,8 @@ private void accumlv(vec_t GEN,vec_t KILL,elem *n,const vec_t ambigsym)
             case OPcolon2:
             {
                 vec_t Gl,Kl,Gr,Kr;
-                lvelem(&Gl,&Kl,n.EV.E1,ambigsym);
-                lvelem(&Gr,&Kr,n.EV.E2,ambigsym);
+                lvelem(Gl,Kl, n.EV.E1,ambigsym);
+                lvelem(Gr,Kr, n.EV.E2,ambigsym);
 
                 /* GEN |= (Gl | Gr) - KILL      */
                 /* KILL |= (Kl & Kr) - GEN      */
@@ -1435,7 +1440,7 @@ private void accumlv(vec_t GEN,vec_t KILL,elem *n,const vec_t ambigsym)
             {
                 vec_t Gr,Kr;
                 accumlv(GEN,KILL,n.EV.E1,ambigsym);
-                lvelem(&Gr,&Kr,n.EV.E2,ambigsym);
+                lvelem(Gr,Kr, n.EV.E2,ambigsym);
 
                 /* GEN |= Gr - KILL     */
                 /* KILL |= 0            */
@@ -1477,12 +1482,12 @@ private void accumlv(vec_t GEN,vec_t KILL,elem *n,const vec_t ambigsym)
             {
                 /* Avoid GENing the lvalue of an =      */
                 accumlv(GEN,KILL,n.EV.E2,ambigsym);
-                elem *t = n.EV.E1;
+                const t = n.EV.E1;
                 if (t.Eoper != OPvar)
                     accumlv(GEN,KILL,t.EV.E1,ambigsym);
                 else /* unambiguous assignment */
                 {
-                    Symbol* s = t.EV.Vsym;
+                    const s = t.EV.Vsym;
                     symbol_debug(s);
 
                     uint tsz = tysize(t.Ety);

--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -47,7 +47,7 @@ nothrow:
 @safe:
 
 @trusted
-char symbol_isintab(Symbol *s) { return sytab[s.Sclass] & SCSS; }
+char symbol_isintab(const Symbol *s) { return sytab[s.Sclass] & SCSS; }
 
 extern (C++):
 

--- a/src/dmd/backend/gother.d
+++ b/src/dmd/backend/gother.d
@@ -45,7 +45,7 @@ nothrow:
 @safe:
 
 @trusted
-char symbol_isintab(Symbol *s) { return sytab[s.Sclass] & SCSS; }
+char symbol_isintab(const Symbol *s) { return sytab[s.Sclass] & SCSS; }
 
 extern (C++):
 


### PR DESCRIPTION
Because `out` is self-documenting and works with `@safe`.

Also add some delicious `const`.