### PR TITLE
Remove purity hack allowing char[12] => string

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -855,8 +855,8 @@ MATCH implicitConvTo(Expression e, Type t)
              * convert to immutable
              */
             if (e.f && e.f.isReturnIsolated() &&
-                (!global.params.vsafe ||        // lots of legacy code breaks with the following purity check
-                 e.f.isPure() >= PURE.strong ||
+                (
+                 e.f.isPure() >= PURE.const_ ||
                  // Special case exemption for Object.dup() which we assume is implemented correctly
                  e.f.ident == Id.dup &&
                  e.f.toParent2() == ClassDeclaration.object.toParent())

--- a/src/dmd/ob.d
+++ b/src/dmd/ob.d
@@ -287,7 +287,7 @@ struct PtrVarState
         assert(vars.length == deps.length);
         OutBuffer buf;
         depsToBuf(buf, vars);
-        string t = buf[];
+        const t = buf[];
         printf("%.*s]\n", cast(int)t.length, t.ptr);
     }
 

--- a/test/unit/support.d
+++ b/test/unit/support.d
@@ -137,7 +137,7 @@ const struct Diagnostic
         buffer.printf("%s: %.*s", location.toChars(true),
             cast(int) message.length, message.ptr);
 
-        return buffer.extractSlice;
+        return cast(immutable) buffer.extractSlice;
     }
 }
 
@@ -184,7 +184,7 @@ struct DiagnosticCollector
 
         buffer.vprintf(messageFormat, args);
 
-        const string message = buffer
+        const string message = cast(immutable) buffer
             .extractSlice
             .replace("`", "")
             .strip;


### PR DESCRIPTION
Just curious what breaks