### PR TITLE
Issue 21807 - Missing deprecation when slicing static array temporary...

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -882,34 +882,34 @@ ByRef:
 
         /* Do not allow slicing of a static array returned by a function
          */
-        if (va && ee.op == TOK.call && ee.type.toBasetype().ty == Tsarray && va.type.toBasetype().ty == Tarray &&
-            !(va.storage_class & STC.temp))
+        if (ee.op == TOK.call && ee.type.toBasetype().ty == Tsarray && e1.type.toBasetype().ty == Tarray &&
+            !(va && va.storage_class & STC.temp))
         {
             if (!gag)
                 deprecation(ee.loc, "slice of static array temporary returned by `%s` assigned to longer lived variable `%s`",
-                    ee.toChars(), va.toChars());
+                    ee.toChars(), e1.toChars());
             //result = true;
             continue;
         }
 
-        if (va && ee.op == TOK.call && ee.type.toBasetype().ty == Tstruct &&
-            !(va.storage_class & STC.temp) && va.ident != Id.withSym &&
+        if (ee.op == TOK.call && ee.type.toBasetype().ty == Tstruct &&
+            (!va || (!(va.storage_class & STC.temp) && va.ident != Id.withSym)) &&
             sc.func.setUnsafe())
         {
             if (!gag)
                 error(ee.loc, "address of struct temporary returned by `%s` assigned to longer lived variable `%s`",
-                    ee.toChars(), va.toChars());
+                    ee.toChars(), e1.toChars());
             result = true;
             continue;
         }
 
-        if (va && ee.op == TOK.structLiteral &&
-            !(va.storage_class & STC.temp) && va.ident != Id.withSym &&
+        if (ee.op == TOK.structLiteral &&
+            (!va || (!(va.storage_class & STC.temp) && va.ident != Id.withSym)) &&
             sc.func.setUnsafe())
         {
             if (!gag)
                 error(ee.loc, "address of struct literal `%s` assigned to longer lived variable `%s`",
-                    ee.toChars(), va.toChars());
+                    ee.toChars(), e1.toChars());
             result = true;
             continue;
         }

--- a/test/compilable/scope.d
+++ b/test/compilable/scope.d
@@ -95,6 +95,19 @@ void test(scope ref D d) @safe
     da ~= D(d.pos, null);
 }
 
+/************************************/
+
+void withEscapes()
+{
+    static D get() @safe;
+
+    with (get())
+    {
+    }
+}
+
+/************************************/
+
 // https://issues.dlang.org/show_bug.cgi?id=20682
 
 int f1_20682(return scope ref D d) @safe

--- a/test/fail_compilation/fail20183.d
+++ b/test/fail_compilation/fail20183.d
@@ -27,3 +27,21 @@ void test()
     int* p = addr(S().i);  // struct literal
     int* q = addr(s().i);  // struct temporary
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20183.d(1107): Error: address of struct temporary returned by `s()` assigned to longer lived variable `this.ptr`
+---
+ */
+#line 1100
+
+class Foo
+{
+    int* ptr;
+
+    this() @safe
+    {
+        ptr = addr(s().i);  // struct literal
+    }
+}

--- a/test/fail_compilation/test21807.d
+++ b/test/fail_compilation/test21807.d
@@ -1,0 +1,54 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=21807
+
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/test21807.d(11): Deprecation: slice of static array temporary returned by `getSArray()` assigned to longer lived variable `this.str`
+fail_compilation/test21807.d(12): Deprecation: slice of static array temporary returned by `getSArray()` assigned to longer lived variable `this.ca`
+---
+*/
+#line 1
+
+char[12] getSArray() pure;
+
+class Foo
+{
+	string str;
+	char[] ca;
+
+	this()
+	{
+		str = getSArray(); // Should probably be a type error
+		ca = getSArray();
+	}
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test21807.d(117): Error: function `test21807.addr(return ref int b)` is not callable using argument types `(int)`
+fail_compilation/test21807.d(117):        cannot pass rvalue argument `S(0).i` of type `int` to parameter `return ref int b`
+---
+*/
+#line 100
+
+struct S
+{
+	int i;
+}
+
+int* addr(return ref int b)
+{
+	return &b;
+}
+
+class Foo2
+{
+	int* ptr;
+
+	this()
+	{
+		ptr = addr(S().i);  // struct temporary
+	}
+}


### PR DESCRIPTION
...in class methods.

The checks for such slices relied on `va` while actually just caring
about the current type. This was broken by [1] which clears `va` for
class members to detect escapes of delegates.

This also applied to the checks for struct temporaries / literals.

[1] https://github.com/dlang/dmd/pull/8008

---

Does not fix issue 21807 because the coversion `char[12] => string` should be rejected.