### PR TITLE
Fix Issue 21806 - Overload selection ignores slice

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1400,7 +1400,13 @@ MATCH implicitConvTo(Expression e, Type t)
             {
                 typeb = toStaticArrayType(e);
                 if (typeb)
+                {
+                    // Try: T[] -> T[dim]
+                    // (Slice with compile-time known boundaries to static array)
                     result = typeb.implicitConvTo(t);
+                    if (result > MATCH.convert)
+                        result = MATCH.convert; // match with implicit conversion at most
+                }
                 return;
             }
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -4863,6 +4863,8 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 if (Type tsa = toStaticArrayType(e))
                 {
                     tsa.accept(this);
+                    if (result > MATCH.convert)
+                        result = MATCH.convert; // match with implicit conversion at most
                     return;
                 }
             }

--- a/test/compilable/test21806.d
+++ b/test/compilable/test21806.d
@@ -1,0 +1,24 @@
+// https://issues.dlang.org/show_bug.cgi?id=21806
+
+void main()
+{
+    ubyte[16] arr;
+    static assert(is(typeof(  fun(arr[])) == char));
+    static assert(is(typeof(funtp(arr[])) == char));
+    static assert(is(typeof(  bar(arr[])) == char));
+}
+
+// functions
+char fun(ubyte[] arr) { return 'X'; }
+
+int fun(ubyte[16] arr) { return 123; }
+
+// function templates
+char funtp()(ubyte[] arr) { return 'X'; }
+
+int funtp(size_t N)(ubyte[N] arr) { return 123; }
+
+// original case with 'in'
+char bar()(in ubyte[] arr) { return 'X'; }
+
+int bar(size_t N)(in ubyte[N] arr) { return 123; }


### PR DESCRIPTION
Currently both overloads have the same match and then due to partial ordering the static array overload is taken.
The problem is that the conversion `T[] -> T[N]` incorrectly returns an exact match but according to the spec it should be an implicit conversion match.

https://dlang.org/spec/expression.html#slice_expressions

> 6. If the slice bounds can be known at compile time, the slice expression is implicitly convertible to an lvalue of static array.