### PR TITLE
Fix 20068 - Treat initialization of unions in constructors as @safe

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4769,8 +4769,6 @@ extern (C++) final class DotVarExp : UnaExp
     override Modifiable checkModifiable(Scope* sc, int flag)
     {
         //printf("DotVarExp::checkModifiable %s %s\n", toChars(), type.toChars());
-        if (checkUnsafeAccess(sc, this, false, !flag))
-            return Modifiable.initialization;
 
         if (e1.op == TOK.this_)
             return var.checkModify(loc, sc, e1, flag);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8764,7 +8764,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         if (exp.op == TOK.assign)  // skip TOK.blit and TOK.construct, which are initializations
+        {
             exp.e1.checkSharedAccess(sc);
+            checkUnsafeAccess(sc, exp.e1, false, true);
+        }
+
+        checkUnsafeAccess(sc, exp.e2, true, true); // Initializer must always be checked
 
         /* If it is an assignment from a 'foreign' type,
          * check for operator overloading.

--- a/test/compilable/union_initialization.d
+++ b/test/compilable/union_initialization.d
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=20068
+
+union B
+{
+	int i;
+	int* p;
+	@safe this(int* p)
+	{
+		// Error: cannot access pointers in @safe code that overlap other fields
+		this.p = p;
+	}
+}

--- a/test/fail_compilation/union_initialization.d
+++ b/test/fail_compilation/union_initialization.d
@@ -1,0 +1,48 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=20068
+
+TEST_OUTPUT:
+---
+fail_compilation/union_initialization.d(19): Error: field `B.p` cannot access pointers in `@safe` code that overlap other fields
+fail_compilation/union_initialization.d(25): Error: field `B.p` cannot access pointers in `@safe` code that overlap other fields
+---
+*/
+
+union B
+{
+	int i;
+	int* p;
+
+	@safe this(int* p)
+	{
+		this.p = p;
+		int* x = this.p;
+	}
+
+	@safe this(int** i)
+	{
+		this.p = null;
+		this.p = *i;
+	}
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/union_initialization.d(109): Error: immutable field `p` initialized multiple times
+fail_compilation/union_initialization.d(108):        Previous initialization is here.
+---
+*/
+#line 100
+
+union C
+{
+	int i;
+	immutable int* p;
+
+	@safe this(immutable int* p)
+	{
+		this.p = p;
+		this.p = null;
+	}
+}


### PR DESCRIPTION
Don't eagerly check the safety of a `DotVarExp` when determining whether it's modifiable and instead defer it after the 
 ConstructExp` lowering.

This also ensures proper error messages when initializing an immutable/const member twice.

CC @pbackus 