### PR TITLE
DWARF: Implement `.debug_line` header v4 and v5

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -1311,6 +1311,40 @@ static if (1)
         return *pidx;
     }
 
+    /**
+     * Extracts the file name from `path`.
+     *
+     * Params:
+     *      path = Full path containing the filename and the directory
+     * Returns:
+     *      The file name
+     */
+    extern(D) const(char)[] retrieveFilename(const(char)[] path)
+    {
+        assert(path);
+        immutable SEP = '/';
+        // Retrieve filename from path
+        char* lastSep = strrchr(cast(char*) path.ptr, SEP);
+        return lastSep ? path[lastSep - path.ptr + 1 .. $] : path;
+    }
+
+    /**
+     * Extracts the directory from `path`.
+     *
+     * Params:
+     *      path = Full path containing the filename and the directory
+     * Returns:
+     *      The directory name
+     */
+    extern(D) const(char)[] retrieveDirectory(const(char)[] path)
+    {
+        assert(path);
+        immutable SEP = '/';
+        // Retrieve directory from path
+        char* lastSep = strrchr(cast(char*) path.ptr, SEP);
+        return lastSep ? path[0 .. lastSep - path.ptr] : ".";
+    }
+
     void dwarf_initmodule(const(char)* filename, const(char)* modname)
     {
         dwarf_initmodule(filename ? filename[0 .. strlen(filename)] : null,

--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -1387,41 +1387,52 @@ static if (1)
     {
         //printf("dwarf_termfile()\n");
 
-        /* ======================================== */
-
-        // Put out line number info
-
-        // file_names
-        uint last_filenumber = 0;
-        const(char)* last_filename = null;
-        for (uint seg = 1; seg < SegData.length; seg++)
+        /* *********************************************************************
+         *      6.2.4 The Line Number Program Header - Remaining fields
+         ******************************************************************** */
         {
-            for (uint i = 0; i < SegData[seg].SDlinnum_data.length; i++)
+
+            // Put out line number info
+
+            // file_names
+            uint last_filenumber = 0;
+            const(char)* last_filename = null;
+            for (uint seg = 1; seg < SegData.length; seg++)
             {
-                linnum_data *ld = &SegData[seg].SDlinnum_data[i];
-                const(char)* filename;
-
-                version (MARS)
-                    filename = ld.filename;
-                else
+                for (uint i = 0; i < SegData[seg].SDlinnum_data.length; i++)
                 {
-                    Sfile *sf = ld.filptr;
-                    if (sf)
-                        filename = sf.SFname;
+                    linnum_data *ld = &SegData[seg].SDlinnum_data[i];
+                    const(char)* filename;
+
+                    version (MARS)
+                        filename = ld.filename;
                     else
-                        filename = .filename;
-                }
+                    {
+                        Sfile *sf = ld.filptr;
+                        if (sf)
+                            filename = sf.SFname;
+                        else
+                            filename = .filename;
+                    }
 
-                if (last_filename == filename)
-                {
-                    ld.filenumber = last_filenumber;
-                }
-                else
-                {
-                    ld.filenumber = dwarf_line_addfile(filename);
+                    if (last_filename == filename)
+                    {
+                        ld.filenumber = last_filenumber;
+                    }
+                    else
+                    {
+                        ld.filenumber = dwarf_line_addfile(filename);
 
-                    last_filenumber = ld.filenumber;
-                    last_filename = filename;
+                        last_filenumber = ld.filenumber;
+                        last_filename = filename;
+                    }
+                }
+            }
+
+                {
+                }
+                {
+
                 }
             }
         }


### PR DESCRIPTION
The last commit changes how the `file_names` field is emitted, because the new field `file_names_count` is required in the v5.
I also fixed the `include_directory` field - it was not emitted for DMD.

Online doc: [DWARF5.pdf](http://www.dwarfstd.org/doc/DWARF5.pdf), chapter 6.2.4.