### PR TITLE
Fix 21229 - Accept construction of union member as initialization

### DIFF
--- a/test/compilable/union_initialization.d
+++ b/test/compilable/union_initialization.d
@@ -1,0 +1,31 @@
+
+/**************************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=21229
+
+struct NeedsInit
+{
+	int var;
+	@disable this();
+}
+
+union Union
+{
+	NeedsInit ni;
+}
+
+union Proxy
+{
+	Union union_;
+}
+
+struct S
+{
+	Union union_;
+	Proxy proxy;
+
+	this(NeedsInit arg)
+	{
+		union_.ni = arg;
+		proxy.union_.ni = arg;
+	}
+}

--- a/test/fail_compilation/union_initialization.d
+++ b/test/fail_compilation/union_initialization.d
@@ -1,0 +1,40 @@
+
+/*
+https://issues.dlang.org/show_bug.cgi?id=21229
+
+TEST_OUTPUT:
+---
+fail_compilation/union_initialization.d(223): Error: field `union_` must be initialized in constructor
+fail_compilation/union_initialization.d(223): Error: field `proxy` must be initialized in constructor
+---
+*/
+#line 200
+
+struct NeedsInit
+{
+	int var;
+	long lo;
+	@disable this();
+}
+
+union Union
+{
+	NeedsInit ni;
+}
+
+union Proxy
+{
+	Union union_;
+}
+
+struct S
+{
+	Union union_;
+	Proxy proxy;
+
+	this(int arg)
+	{
+		union_.ni.var = arg;
+		proxy.union_.ni.var = arg;
+	}
+}


### PR DESCRIPTION
Because the `union` is initialised when one of its members has been constructed.

CC @pbackus, @RazvanN7  