### PR TITLE
Fix Issue 21812 - __traits(allMembers) on types with value tuples return ghost members

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1088,7 +1088,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 else
                     ti = dsym._init ? dsym._init.syntaxCopy() : null;
 
-                StorageClass storage_class = STC.temp | dsym.storage_class;
+                StorageClass storage_class = STC.temp | STC.local | dsym.storage_class;
                 if ((dsym.storage_class & STC.parameter) && (arg.storageClass & STC.parameter))
                     storage_class |= arg.storageClass;
                 auto v = new VarDeclaration(dsym.loc, arg.type, id, ti, storage_class);

--- a/test/compilable/test21812.d
+++ b/test/compilable/test21812.d
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=21812
+
+struct S(A...)
+{
+   A args;
+}
+
+static assert(__traits(allMembers, S!(int, float)) == AliasSeq!("args"));
+
+alias AliasSeq(T...) = T;


### PR DESCRIPTION
Another side effect is that `-vcg-ast` will output:

```
S!(int, float)
{
    struct S
    {
        (int, float) args;
    }
}
```
instead of:
```
S!(int, float)
{
    struct S
    {
        (int, float) args;
        int __args_field_0;
        float __args_field_1;
    }
}
```
which looks more correctly I think.