### PR TITLE
Revert "[dmd-cxx] Detect and shortcut Alias and AliasSeq template patterns"

### DIFF
--- a/src/dsymbolsem.c
+++ b/src/dsymbolsem.c
@@ -4843,54 +4843,6 @@ public:
     }
 };
 
-/******************************************************
- * Do template instance semantic for isAliasSeq templates.
- * This is a greatly simplified version of TemplateInstance::semantic().
- */
-static void aliasSeqInstanceSemantic(TemplateInstance *tempinst, Scope *sc, TemplateDeclaration *tempdecl)
-{
-    //printf("[%s] aliasSeqInstanceSemantic('%s')\n", tempinst->loc.toChars(), tempinst->toChars());
-    Scope *paramscope = sc->push();
-    paramscope->stc = 0;
-    paramscope->protection = Prot(Prot::public_);
-
-    TemplateTupleParameter *ttp = (*tempdecl->parameters)[0]->isTemplateTupleParameter();
-    Tuple *va = isTuple(tempinst->tdtypes[0]);
-    Declaration *d = new TupleDeclaration(tempinst->loc, ttp->ident, &va->objects);
-    d->storage_class |= STCtemplateparameter;
-    dsymbolSemantic(d, sc);
-
-    paramscope->pop();
-
-    tempinst->aliasdecl = d;
-
-    tempinst->semanticRun = PASSsemanticdone;
-}
-
-/******************************************************
- * Do template instance semantic for isAlias templates.
- * This is a greatly simplified version of TemplateInstance::semantic().
- */
-static void aliasInstanceSemantic(TemplateInstance *tempinst, Scope *sc, TemplateDeclaration *tempdecl)
-{
-    //printf("[%s] aliasInstanceSemantic('%s')\n", tempinst->loc.toChars(), tempinst->toChars());
-    Scope *paramscope = sc->push();
-    paramscope->stc = 0;
-    paramscope->protection = Prot(Prot::public_);
-
-    TemplateTypeParameter *ttp = (*tempdecl->parameters)[0]->isTemplateTypeParameter();
-    Type *ta = isType(tempinst->tdtypes[0]);
-    Declaration *d = new AliasDeclaration(tempinst->loc, ttp->ident, ta->addMod(tempdecl->onemember->isAliasDeclaration()->type->mod));
-    d->storage_class |= STCtemplateparameter;
-    dsymbolSemantic(d, sc);
-
-    paramscope->pop();
-
-    tempinst->aliasdecl = d;
-
-    tempinst->semanticRun = PASSsemanticdone;
-}
-
 void templateInstanceSemantic(TemplateInstance *tempinst, Scope *sc, Expressions *fargs)
 {
     //printf("[%s] TemplateInstance::semantic('%s', this=%p, gag = %d, sc = %p)\n", tempinst->loc.toChars(), tempinst->toChars(), tempinst, global.gag, sc);
@@ -4960,21 +4912,6 @@ Lerror:
     tempinst->hasNestedArgs(tempinst->tiargs, tempdecl->isstatic);
     if (tempinst->errors)
         goto Lerror;
-
-    /* Greatly simplified semantic processing for AliasSeq templates
-     */
-    if (tempdecl->isTrivialAliasSeq)
-    {
-        tempinst->inst = tempinst;
-        return aliasSeqInstanceSemantic(tempinst, sc, tempdecl);
-    }
-    /* Greatly simplified semantic processing for Alias templates
-     */
-    else if (tempdecl->isTrivialAlias)
-    {
-        tempinst->inst = tempinst;
-        return aliasInstanceSemantic(tempinst, sc, tempdecl);
-    }
 
     /* See if there is an existing TemplateInstantiation that already
      * implements the typeargs. If so, just refer to that one instead.

--- a/src/dtemplate.c
+++ b/src/dtemplate.c
@@ -6770,7 +6770,8 @@ Dsymbols *TemplateInstance::appendToModuleMember()
 {
     Module *mi = minst;     // instantiated -> inserted module
 
-    if (global.params.useUnitTests)
+    if (global.params.useUnitTests ||
+        global.params.debuglevel)
     {
         // Turn all non-root instances to speculative
         if (mi && !mi->isRoot())

--- a/src/dtemplate.c
+++ b/src/dtemplate.c
@@ -531,8 +531,6 @@ TemplateDeclaration::TemplateDeclaration(Loc loc, Identifier *id,
     this->literal = literal;
     this->ismixin = ismixin;
     this->isstatic = true;
-    this->isTrivialAliasSeq = false;
-    this->isTrivialAlias = false;
     this->previous = NULL;
     this->protection = Prot(Prot::undefined);
     this->inuse = 0;
@@ -540,46 +538,13 @@ TemplateDeclaration::TemplateDeclaration(Loc loc, Identifier *id,
 
     // Compute in advance for Ddoc's use
     // Bugzilla 11153: ident could be NULL if parsing fails.
-    if (!members || !ident)
-        return;
-
-    Dsymbol *s;
-    if (!Dsymbol::oneMembers(members, &s, ident) || !s)
-        return;
-
-    onemember = s;
-    s->parent = this;
-
-    /* Set isTrivialAliasSeq if this fits the pattern:
-     *   template AliasSeq(T...) { alias AliasSeq = T; }
-     * or set isTrivialAlias if this fits the pattern:
-     *   template Alias(T) { alias Alias = qualifiers(T); }
-     */
-    if (!(parameters && parameters->length == 1))
-        return;
-
-    AliasDeclaration *ad = s->isAliasDeclaration();
-    if (!ad || !ad->type)
-        return;
-
-    TypeIdentifier *ti = ad->type->isTypeIdentifier();
-    if (!ti || ti->idents.length != 0)
-        return;
-
-    if (TemplateTupleParameter *ttp = (*parameters)[0]->isTemplateTupleParameter())
+    if (members && ident)
     {
-        if (ti->ident == ttp->ident && ti->mod == 0)
+        Dsymbol *s;
+        if (Dsymbol::oneMembers(members, &s, ident) && s)
         {
-            //printf("found isAliasSeq %s %s\n", s->toChars(), ad->type->toChars());
-            isTrivialAliasSeq = true;
-        }
-    }
-    else if (TemplateTypeParameter *ttp = (*parameters)[0]->isTemplateTypeParameter())
-    {
-        if (ti->ident == ttp->ident)
-        {
-            //printf("found isAlias %s %s\n", s->toChars(), ad->type->toChars());
-            isTrivialAlias = true;
+            onemember = s;
+            s->parent = this;
         }
     }
 }

--- a/src/template.h
+++ b/src/template.h
@@ -77,8 +77,6 @@ public:
     bool literal;               // this template declaration is a literal
     bool ismixin;               // template declaration is only to be used as a mixin
     bool isstatic;              // this is static template declaration
-    bool isTrivialAliasSeq;     // matches `template AliasSeq(T...) { alias AliasSeq = T; }
-    bool isTrivialAlias;        // matches `template Alias(T) { alias Alias = T; }
     Prot protection;
     int inuse;                  // for recursive expansion detection
 

--- a/test/runnable/extra-files/linkdebug.d
+++ b/test/runnable/extra-files/linkdebug.d
@@ -1,0 +1,16 @@
+module linkdebug;
+
+void main()
+{
+    import linkdebug_uni;
+    import linkdebug_range;
+
+    // OK
+    //SortedRangeX!(uint[], "a <= b") SR;
+
+    CodepointSet set;
+    set.addInterval(1, 2);
+
+    // NG, order dependent.
+    SortedRange!(uint[], "a <= b") SR;
+}

--- a/test/runnable/extra-files/linkdebug_primitives.d
+++ b/test/runnable/extra-files/linkdebug_primitives.d
@@ -1,0 +1,13 @@
+module linkdebug_primitives;
+
+size_t popBackN(R)(ref R r, size_t n)
+{
+    n = cast(size_t) (n < r.length ? n : r.length);
+    r = r[0 .. $ - n];
+    return n;
+}
+
+auto moveAt(R, I)(R r, I i)
+{
+    return r[i];
+}

--- a/test/runnable/extra-files/linkdebug_range.d
+++ b/test/runnable/extra-files/linkdebug_range.d
@@ -1,0 +1,48 @@
+module linkdebug_range;
+
+import linkdebug_primitives : popBackN, moveAt;
+
+auto stride(R)(R r)
+{
+    static struct Result
+    {
+        R source;
+
+        void popBack()
+        {
+            popBackN(source, 0);
+        }
+
+        uint moveAt(size_t n)
+        {
+            return .moveAt(source, n);
+        }
+    }
+    return Result(r);
+}
+
+struct SortedRange(Range, alias pred = "a < b")
+{
+    this(Range input)
+    out
+    {
+        dbgVerifySorted();
+    }
+    body
+    {
+    }
+
+    void dbgVerifySorted()
+    {
+        debug
+        {
+            uint[] _input;
+            auto st = stride(_input);
+        }
+    }
+}
+
+auto assumeSorted(alias pred = "a < b", R)(R r)
+{
+    return SortedRange!(R, pred)(r);
+}

--- a/test/runnable/extra-files/linkdebug_uni.d
+++ b/test/runnable/extra-files/linkdebug_uni.d
@@ -1,0 +1,19 @@
+module linkdebug_uni;
+
+import linkdebug_range;
+
+struct GcPolicy {}
+
+alias CodepointSet = InversionList!();
+
+struct InversionList(SP = GcPolicy)
+{
+@trusted:
+    size_t addInterval(int a, int b, size_t hint = 0)
+    {
+        auto data = new uint[](0);        // affects to the number of missimg symbol
+        auto range = assumeSorted(data[]);  // NG
+        //SortedRange!(uint[], "a < b") SR; // OK
+        return 1;
+    }
+}

--- a/test/runnable/linkdebug.sh
+++ b/test/runnable/linkdebug.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+src=runnable${SEP}extra-files
+dir=${RESULTS_DIR}${SEP}runnable
+output_file=${dir}/linkdebug.sh.out
+
+if [ $OS == "win32" -o  $OS == "win64" ]; then
+	LIBEXT=.lib
+else
+	LIBEXT=.a
+fi
+libname=${dir}${SEP}libX${LIBEXT}
+
+$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}linkdebug_uni.d ${src}${SEP}linkdebug_range.d ${src}${SEP}linkdebug_primitives.d || exit 1
+
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}linkdebug${EXE} -g -debug ${src}${SEP}linkdebug.d ${libname} || exit 1
+
+rm ${libname}
+rm ${dir}/{linkdebug${OBJ},linkdebug${EXE}}
+
+echo Success > ${output_file}


### PR DESCRIPTION
Reverts dlang/dmd#12405

PR was merged too eagerly. Either this broke the bootstrap, or one of the recent changes broke it, let's find out what.