### PR TITLE
Implement __ctfeWrite builtin

### DIFF
--- a/changelog/ctfeWrite.md
+++ b/changelog/ctfeWrite.md
@@ -1,0 +1,24 @@
+# Add `__ctfeWrite` to write output from CTFE
+
+The special function `__ctfeWrite` can now be used to write custom messages to
+`stderr` during CTFE. The function is available in `object.d` and accepts any
+value implicitly convertible to `const char[]`.
+
+For example:
+
+```d
+int greeting()
+{
+	__ctfeWrite("Hello from CTFE. Today is ");
+	__ctfeWrite(__DATE__);
+	return 0;
+}
+
+enum forceCTFE = greeting();
+```
+
+Compiling his program will generate the following output:
+
+```
+Hello from CTFE. Today is <current date>
+```

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -454,12 +454,15 @@ Expression eval_ctfeWrite(Loc loc, FuncDeclaration fd, Expressions* arguments)
     assert(arguments.length == 1);
 
     Expression arg0 = (*arguments)[0];
+    assert(arg0);
 
     if (StringExp se = arg0.toStringExp())
     {
         auto str = se.peekString();
         fprintf(stderr, "%.*s".ptr, cast(int) str.length, str.ptr);
     }
+    else
+        arg0.error("cannot write `%s` during CTFE", arg0.toChars());
 
     return arg0;
 }

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -450,6 +450,7 @@ Expression eval_toPrecReal(Loc loc, FuncDeclaration fd, Expressions* arguments)
 Expression eval_ctfeWrite(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     import core.stdc.stdio : fprintf, stderr;
+    import dmd.ctfeexpr : CTFEExp;
 
     assert(arguments.length == 1);
 
@@ -464,7 +465,7 @@ Expression eval_ctfeWrite(Loc loc, FuncDeclaration fd, Expressions* arguments)
     else
         arg0.error("cannot write `%s` during CTFE", arg0.toChars());
 
-    return arg0;
+    return CTFEExp.voidexp;
 }
 
 // These built-ins are reserved for GDC and LDC.

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -475,7 +475,8 @@ enum class BUILTIN : unsigned char
     yl2xp1,
     toPrecFloat,
     toPrecDouble,
-    toPrecReal
+    toPrecReal,
+    ctfeWrite
 };
 
 Expression *eval_builtin(Loc loc, FuncDeclaration *fd, Expressions *arguments);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5545,6 +5545,15 @@ extern (C++) final class SliceExp : UnaExp
         return e1.isBool(result);
     }
 
+    override StringExp toStringExp()
+    {
+        if (e1.op == TOK.string_)
+        {
+            return e1.toStringExp();
+        }
+        return null;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -914,7 +914,7 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     bool isBool(bool result);
-
+    StringExp* toStringExp();
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -232,6 +232,7 @@ enum class BUILTIN : uint8_t
     toPrecFloat = 33u,
     toPrecDouble = 34u,
     toPrecReal = 35u,
+    ctfeWrite = 36u,
 };
 
 struct UnionExp;
@@ -4087,6 +4088,7 @@ public:
     Expression* toLvalue(Scope* sc, Expression* e);
     Expression* modifiableLvalue(Scope* sc, Expression* e);
     bool isBool(bool result);
+    StringExp* toStringExp();
     void accept(Visitor* v);
 };
 
@@ -7653,6 +7655,7 @@ struct Id
     static Identifier* core;
     static Identifier* etc;
     static Identifier* attribute;
+    static Identifier* builtins;
     static Identifier* math;
     static Identifier* sin;
     static Identifier* cos;
@@ -7706,6 +7709,7 @@ struct Id
     static Identifier* outp;
     static Identifier* outpl;
     static Identifier* outpw;
+    static Identifier* __ctfeWrite;
     static Identifier* isAbstractClass;
     static Identifier* isArithmetic;
     static Identifier* isAssociativeArray;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -102,7 +102,8 @@ enum BUILTIN : ubyte
     yl2xp1,
     toPrecFloat,
     toPrecDouble,
-    toPrecReal
+    toPrecReal,
+    ctfeWrite
 }
 
 /* Tweak all return statements and dtor call for nrvo_var, for correct NRVO.

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -358,6 +358,7 @@ immutable Msgtable[] msgtable =
     { "core" },
     { "etc" },
     { "attribute" },
+    { "builtins" },
     { "math" },
     { "sin" },
     { "cos" },
@@ -411,6 +412,7 @@ immutable Msgtable[] msgtable =
     { "outp"},
     { "outpl"},
     { "outpw"},
+    { "__ctfeWrite" },
 
     // Traits
     { "isAbstractClass" },

--- a/test/compilable/testCTFEWrite.d
+++ b/test/compilable/testCTFEWrite.d
@@ -1,0 +1,56 @@
+/*
+TEST_OUTPUT:
+---
+0^^2 == 0
+1^^2 == 1
+2^^2 == 4
+3^^2 == 9
+result == 14
+---
+*/
+int sum_of_sq(int x) pure nothrow @safe
+{
+    const string newline = "\n";
+
+    int result = 0;
+    foreach (i; 0 .. x)
+    {
+        __ctfeWrite(toString(i));
+        __ctfeWrite("^^2 == ");
+        int power = i ^^ 2;
+        __ctfeWrite(toString(power));
+        __ctfeWrite(newline);
+        result += power;
+    }
+    __ctfeWrite("result == ");
+    __ctfeWrite(toString(result));
+    __ctfeWrite(newline);
+
+    return result;
+}
+
+static assert(sum_of_sq(4) == 14);
+
+// Naive toString to avoid phobos
+string toString(int number) pure nothrow @safe
+{
+    if (number == 0)
+        return "0";
+
+    string res;
+    const isNeg = number < 0;
+    if (isNeg)
+        number = -number;
+
+    while (number)
+    {
+        const dig = number % 10;
+        number /= 10;
+        res = "0123456789"[dig] ~ res;
+    }
+
+    if (isNeg)
+        res = "-" ~ res;
+
+    return res;
+}

--- a/test/compilable/testCTFEWrite.d
+++ b/test/compilable/testCTFEWrite.d
@@ -1,56 +1,47 @@
 /*
 TEST_OUTPUT:
 ---
-0^^2 == 0
-1^^2 == 1
-2^^2 == 4
-3^^2 == 9
-result == 14
+Hello
+World
+from
+CTFE
+Hello[1 .. 3] = el
+abcdefghij[2 .. 6] = cdef
 ---
 */
-int sum_of_sq(int x) pure nothrow @safe
+
+int greeting(scope const char[][] values) pure nothrow @safe @nogc
 {
     const string newline = "\n";
 
-    int result = 0;
-    foreach (i; 0 .. x)
+    foreach (const val; values)
     {
-        __ctfeWrite(toString(i));
-        __ctfeWrite("^^2 == ");
-        int power = i ^^ 2;
-        __ctfeWrite(toString(power));
+        __ctfeWrite(val);
         __ctfeWrite(newline);
-        result += power;
     }
-    __ctfeWrite("result == ");
-    __ctfeWrite(toString(result));
+
+    // Test slices
+    const val = values[0];
+    __ctfeWrite(val[]);
+    __ctfeWrite("[1 .. 3] = ");
+    __ctfeWrite(val[1 .. 3]);
     __ctfeWrite(newline);
 
-    return result;
+    // Test mutable slices
+    char[10] buffer;
+    fill(buffer); // Avoid potential shortcuts for literals
+    __ctfeWrite(buffer[0 .. $]);
+    __ctfeWrite("[2 .. 6] = ");
+    __ctfeWrite(buffer[2 .. 6]);
+    __ctfeWrite(newline);
+
+    return 0;
 }
 
-static assert(sum_of_sq(4) == 14);
-
-// Naive toString to avoid phobos
-string toString(int number) pure nothrow @safe
+void fill(ref char[10] buffer) pure nothrow @safe @nogc
 {
-    if (number == 0)
-        return "0";
-
-    string res;
-    const isNeg = number < 0;
-    if (isNeg)
-        number = -number;
-
-    while (number)
-    {
-        const dig = number % 10;
-        number /= 10;
-        res = "0123456789"[dig] ~ res;
-    }
-
-    if (isNeg)
-        res = "-" ~ res;
-
-    return res;
+    foreach (const idx, ref ch; buffer)
+        ch = cast(char)('a' + idx);
 }
+
+enum forceCTFE = greeting(["Hello", "World", "from", "CTFE"]);


### PR DESCRIPTION
Rebase of the stalled PR #7082 but
- using newer builtin handling
- no phobos in the test suite
- bug fixes w.r.t. mutable char arrays and slices

---

### Abstract

The `__ctfeWrite` builtin allows functions to write to `stderr` during CTFE:

```d
void foo(int x)
{
   // Error: variable `x` cannot be read at compile time
   // pragma(msg, "foo was called with ", x);

   import std.conv : to;
   __ctfeWrite("Foo was called with ");
   __ctfeWrite(to!string(x));
   __ctfeWrite("\n");
}

int main()
{
   foreach (i; 0 .. 100)
      foo(i);

   return 0;
}

enum forceCTFE = main();
```

Output:
```
Foo was called with 0
Foo was called with 1
...
```

---

### Rationale

Functions run via CTFE cannot do this directly at the moment and users have to resort to `pragma(msg, ...)` + intermediate enums. The current workaround has several drawbacks in comparison to `__ctfeWrite`:

1. code must conform to a certain pattern
```d
Result func(...) { .... }
enum tmp = func(....);
pragma(msg, tmp);
// Use tmp for further CTFE calls
```
2.  only supports return values, not parameters, local variables, ...
```d
// Naive logging example 
// Implementing this using the current approach requires a lot of instrusive changes

Result func(Foo[] param)
{
    // at the beginning of each function
    writeln("foo(", param, ')');

   foreach (ref val; param)
   {
       writeln("Processing ", val);
       // some complex computation...
   }
}
```
3. intermediate enums pollute the namespace
4. `static foreach` is required to emulate normal loops

Calling a dedicated builtin is easy and doesn't have any of the aforementioned drawbacks. This also reduces the differences between CTFE and runtime when used via an appropriate wrapper (see the enhancement section).


---

### Alternatives

- Recognize `std.stdio.write` / `core.stc.stdio` / ...
  - doesn't work well with attributes (the runtime version might violate attributes while CTFE does not)
  - the chosen IO utility may not be appropriate for everyone, creating a hard dependency to druntime/phobos/.. for CTFE-only
    - also currently implies a link dependency
---

### Future enhancements?

- use `__ctfeWrite` in `std.stdio.writeln` & friends
```d
// Now works during CTFE!
void say(int i)
{
    writeln("i = ", i);
}
```
- add templated wrapper in druntime to support arbitrary types, e.g.

```d
void ctfeWrite(T)(auto ref T arg)
{
    import core.internal.dassert : miniFormat; // used by -checkaction=context
    __ctfeWrite(miniFormat(arg));
}
```