### PR TITLE
Fix issue 20704 - -preview=rvaluerefparam does not work with init as default parameter

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1298,10 +1298,16 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             e = e.implicitCastTo(sc, fparam.type);
 
             // default arg must be an lvalue
-            if (isRefOrOut && !isAuto &&
-                !(global.params.previewIn && (fparam.storageClass & STC.in_)) &&
-                !(global.params.rvalueRefParam))
-                e = e.toLvalue(sc, e);
+            if (isRefOrOut && !isAuto)
+            {
+                if (!(global.params.previewIn && (fparam.storageClass & STC.in_)) ||
+                    !(global.params.rvalueRefParam))
+                {
+                    e = e.toLvalue(sc, e);
+                    if (e.op == TOK.error)
+                        errorSupplemental(e.loc, "use `-preview=in` or `preview=rvaluerefparam`");
+                }
+            }
 
             fparam.defaultArg = e;
             return (e.op != TOK.error);

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1300,7 +1300,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             // default arg must be an lvalue
             if (isRefOrOut && !isAuto)
             {
-                if (!(global.params.previewIn && (fparam.storageClass & STC.in_)) ||
+                if (!(global.params.previewIn && (fparam.storageClass & STC.in_)) &&
                     !(global.params.rvalueRefParam))
                 {
                     e = e.toLvalue(sc, e);

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1299,7 +1299,8 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
             // default arg must be an lvalue
             if (isRefOrOut && !isAuto &&
-                !(global.params.previewIn && (fparam.storageClass & STC.in_)))
+                !(global.params.previewIn && (fparam.storageClass & STC.in_)) &&
+                !(global.params.rvalueRefParam))
                 e = e.toLvalue(sc, e);
 
             fparam.defaultArg = e;

--- a/test/compilable/issue20704.d
+++ b/test/compilable/issue20704.d
@@ -8,6 +8,9 @@ void f2(T)(const      ref T arg = T.init) {}
 void f3(T)(const auto ref T arg = 0) {}
 void f4(T)(const      ref T arg = 0) {}
 
+struct S { int _; }
+class C { int _; }
+
 void main ()
 {
     int i;
@@ -19,4 +22,8 @@ void main ()
     f2!int();
     f3!int();
     f4!int();
+    f1!S();
+    f2!S();
+    f1!C();
+    f2!C();
 }

--- a/test/compilable/issue20704.d
+++ b/test/compilable/issue20704.d
@@ -3,12 +3,20 @@ https://issues.dlang.org/show_bug.cgi?id=20704
 REQUIRED_ARGS: -preview=rvaluerefparam
  */
 
-void foo (T) (const auto ref T arg = T.init) {}
-void bar (T) (const      ref T arg = T.init) {}
+void f1(T)(const auto ref T arg = T.init) {}
+void f2(T)(const      ref T arg = T.init) {}
+void f3(T)(const auto ref T arg = 0) {}
+void f4(T)(const      ref T arg = 0) {}
 
 void main ()
 {
     int i;
-    foo!int();
-    bar!int(i);
+    f1!int(i);
+    f2!int(i);
+    f3!int(i);
+    f4!int(i);
+    f1!int();
+    f2!int();
+    f3!int();
+    f4!int();
 }

--- a/test/compilable/issue20704.d
+++ b/test/compilable/issue20704.d
@@ -1,0 +1,14 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=20704
+REQUIRED_ARGS: -preview=rvaluerefparam
+ */
+
+void foo (T) (const auto ref T arg = T.init) {}
+void bar (T) (const      ref T arg = T.init) {}
+
+void main ()
+{
+    int i;
+    foo!int();
+    bar!int(i);
+}

--- a/test/fail_compilation/fail7603a.d
+++ b/test/fail_compilation/fail7603a.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7603a.d(7): Error: cannot modify constant `true`
+fail_compilation/fail7603a.d(8): Error: cannot modify constant `true`
        use `-preview=in` or `preview=rvaluerefparam`
 ---
 */

--- a/test/fail_compilation/fail7603a.d
+++ b/test/fail_compilation/fail7603a.d
@@ -2,6 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail7603a.d(7): Error: cannot modify constant `true`
+       use `-preview=in` or `preview=rvaluerefparam`
 ---
 */
 void test(ref bool val = true) { }

--- a/test/fail_compilation/fail7603b.d
+++ b/test/fail_compilation/fail7603b.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7603b.d(7): Error: cannot modify constant `true`
+fail_compilation/fail7603b.d(8): Error: cannot modify constant `true`
        use `-preview=in` or `preview=rvaluerefparam`
 ---
 */

--- a/test/fail_compilation/fail7603b.d
+++ b/test/fail_compilation/fail7603b.d
@@ -2,6 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail7603b.d(7): Error: cannot modify constant `true`
+       use `-preview=in` or `preview=rvaluerefparam`
 ---
 */
 void test(out bool val = true) { }

--- a/test/fail_compilation/fail7603c.d
+++ b/test/fail_compilation/fail7603c.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7603c.d(8): Error: cannot modify constant `3`
+fail_compilation/fail7603c.d(9): Error: cannot modify constant `3`
        use `-preview=in` or `preview=rvaluerefparam`
 ---
 */

--- a/test/fail_compilation/fail7603c.d
+++ b/test/fail_compilation/fail7603c.d
@@ -2,6 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail7603c.d(8): Error: cannot modify constant `3`
+       use `-preview=in` or `preview=rvaluerefparam`
 ---
 */
 enum x = 3;

--- a/test/fail_compilation/fail9773.d
+++ b/test/fail_compilation/fail9773.d
@@ -2,6 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail9773.d(7): Error: `""` is not an lvalue and cannot be modified
+       use `-preview=in` or `preview=rvaluerefparam`
 ---
 */
 void f(ref string a = "")

--- a/test/fail_compilation/fail9773.d
+++ b/test/fail_compilation/fail9773.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9773.d(7): Error: `""` is not an lvalue and cannot be modified
+fail_compilation/fail9773.d(8): Error: `""` is not an lvalue and cannot be modified
        use `-preview=in` or `preview=rvaluerefparam`
 ---
 */

--- a/test/fail_compilation/fail9891.d
+++ b/test/fail_compilation/fail9891.d
@@ -4,6 +4,7 @@ TEST_OUTPUT:
 fail_compilation/fail9891.d(13): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `ref int` of parameter `n`
 fail_compilation/fail9891.d(18): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `out int` of parameter `n`
 fail_compilation/fail9891.d(23): Error: `prop()` is not an lvalue and cannot be modified
+       use `-preview=in` or `preview=rvaluerefparam`
 ---
 */
 

--- a/test/fail_compilation/fail9891.d
+++ b/test/fail_compilation/fail9891.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9891.d(13): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `ref int` of parameter `n`
-fail_compilation/fail9891.d(18): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `out int` of parameter `n`
-fail_compilation/fail9891.d(23): Error: `prop()` is not an lvalue and cannot be modified
+fail_compilation/fail9891.d(14): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `ref int` of parameter `n`
+fail_compilation/fail9891.d(19): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `out int` of parameter `n`
+fail_compilation/fail9891.d(24): Error: `prop()` is not an lvalue and cannot be modified
        use `-preview=in` or `preview=rvaluerefparam`
 ---
 */

--- a/test/fail_compilation/issue20704.d
+++ b/test/fail_compilation/issue20704.d
@@ -1,0 +1,39 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/issue20704.d(17): Error: cannot modify constant `0`
+fail_compilation/issue20704.d(28): Error: template instance `issue20704.f2!int` error instantiating
+fail_compilation/issue20704.d(19): Error: cannot modify constant `0`
+fail_compilation/issue20704.d(30): Error: template instance `issue20704.f4!int` error instantiating
+fail_compilation/issue20704.d(17): Error: `S(0)` is not an lvalue and cannot be modified
+fail_compilation/issue20704.d(36): Error: template instance `issue20704.f2!(S)` error instantiating
+fail_compilation/issue20704.d(17): Error: `null` is not an lvalue and cannot be modified
+fail_compilation/issue20704.d(38): Error: template instance `issue20704.f2!(C)` error instantiating
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=20704
+
+void f1(T)(const auto ref T arg = T.init) {}
+void f2(T)(const      ref T arg = T.init) {}
+void f3(T)(const auto ref T arg = 0) {}
+void f4(T)(const      ref T arg = 0) {}
+
+struct S { int _; }
+class C { int _; }
+
+void main ()
+{
+    int i;
+    f1!int(i);
+    f2!int(i);
+    f3!int(i);
+    f4!int(i);
+    f1!int();
+    f2!int();
+    f3!int();
+    f4!int();
+    f1!S();
+    f2!S();
+    f1!C();
+    f2!C();
+}

--- a/test/fail_compilation/issue20704.d
+++ b/test/fail_compilation/issue20704.d
@@ -1,13 +1,17 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/issue20704.d(17): Error: cannot modify constant `0`
-fail_compilation/issue20704.d(28): Error: template instance `issue20704.f2!int` error instantiating
-fail_compilation/issue20704.d(19): Error: cannot modify constant `0`
-fail_compilation/issue20704.d(30): Error: template instance `issue20704.f4!int` error instantiating
-fail_compilation/issue20704.d(17): Error: `S(0)` is not an lvalue and cannot be modified
-fail_compilation/issue20704.d(36): Error: template instance `issue20704.f2!(S)` error instantiating
-fail_compilation/issue20704.d(17): Error: `null` is not an lvalue and cannot be modified
-fail_compilation/issue20704.d(38): Error: template instance `issue20704.f2!(C)` error instantiating
+fail_compilation/issue20704.d(21): Error: cannot modify constant `0`
+       use `-preview=in` or `preview=rvaluerefparam`
+fail_compilation/issue20704.d(32): Error: template instance `issue20704.f2!int` error instantiating
+fail_compilation/issue20704.d(23): Error: cannot modify constant `0`
+       use `-preview=in` or `preview=rvaluerefparam`
+fail_compilation/issue20704.d(34): Error: template instance `issue20704.f4!int` error instantiating
+fail_compilation/issue20704.d(21): Error: `S(0)` is not an lvalue and cannot be modified
+       use `-preview=in` or `preview=rvaluerefparam`
+fail_compilation/issue20704.d(40): Error: template instance `issue20704.f2!(S)` error instantiating
+fail_compilation/issue20704.d(21): Error: `null` is not an lvalue and cannot be modified
+       use `-preview=in` or `preview=rvaluerefparam`
+fail_compilation/issue20704.d(42): Error: template instance `issue20704.f2!(C)` error instantiating
 ---
 */
 


### PR DESCRIPTION
This PR fixes build errors with defaulted ref parameters in general, not just the ref parameters defaulted to `T.init`.