### PR TITLE
escape.d: Remove special casing for Id.withSym

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -892,7 +892,7 @@ ByRef:
         }
 
         if (ee.op == TOK.call && ee.type.toBasetype().ty == Tstruct &&
-            (!va || (!(va.storage_class & STC.temp) && va.ident != Id.withSym)) &&
+            (!va || !(va.storage_class & STC.temp)) &&
             sc.func.setUnsafe())
         {
             if (!gag)
@@ -903,7 +903,7 @@ ByRef:
         }
 
         if (ee.op == TOK.structLiteral &&
-            (!va || (!(va.storage_class & STC.temp) && va.ident != Id.withSym)) &&
+            (!va || !(va.storage_class & STC.temp)) &&
             sc.func.setUnsafe())
         {
             if (!gag)


### PR DESCRIPTION
The hidden temporary for `with (...)` has STC.temp nowadays (see #12258 )