### PR TITLE
test: Add EXTRA_FILES to compilable/issue16044.d

### DIFF
--- a/test/compilable/issue16044.d
+++ b/test/compilable/issue16044.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -Icompilable/imports
+// EXTRA_FILES: imports/pkg16044/package.d imports/pkg16044/sub/package.d
 module issue16044; // https://issues.dlang.org/show_bug.cgi?id=16044
 
 import pkg16044;


### PR DESCRIPTION
So that the gdc testsuite knows to copy them to the (possibly remote) target location where the test is compiled from.