### PR TITLE
[dmd-cxx] fix Issue 18963 - Relax restrictions on 'return' parameters when parameter is not a pointer

### DIFF
--- a/src/typesem.c
+++ b/src/typesem.c
@@ -797,7 +797,7 @@ Type *typeSemantic(Type *type, const Loc &loc, Scope *sc)
 
                 if (tf->isreturn && !tf->isref && !tf->next->hasPointers())
                 {
-                    ::error(loc, "function type `%s` has `return` but does not return any indirections", tf->toChars());
+                    tf->isreturn = false;
                 }
             }
 
@@ -872,7 +872,7 @@ Type *typeSemantic(Type *type, const Loc &loc, Scope *sc)
                             if (0 && !tf->isref)
                             {
                                 StorageClass stc = fparam->storageClass & (STCref | STCout);
-                                ::error(loc, "parameter %s is `return %s` but function does not return by ref",
+                                ::error(loc, "parameter `%s` is `return %s` but function does not return by `ref`",
                                     fparam->ident ? fparam->ident->toChars() : "",
                                     stcToChars(stc));
                                 errors = true;
@@ -886,9 +886,7 @@ Type *typeSemantic(Type *type, const Loc &loc, Scope *sc)
                             }
                             else if (!tf->isref && tf->next && !tf->next->hasPointers())
                             {
-                                ::error(loc, "parameter %s is `return` but function does not return any indirections",
-                                    fparam->ident ? fparam->ident->toChars() : "");
-                                errors = true;
+                                fparam->storageClass &= STCreturn;   // https://issues.dlang.org/show_bug.cgi?id=18963
                             }
                         }
                     }

--- a/test/compilable/issue16044.d
+++ b/test/compilable/issue16044.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -Icompilable/imports
+// EXTRA_FILES: imports/pkg16044/package.d imports/pkg16044/sub/package.d
 module issue16044; // https://issues.dlang.org/show_bug.cgi?id=16044
 
 import pkg16044;

--- a/test/fail_compilation/test16228.d
+++ b/test/fail_compilation/test16228.d
@@ -1,10 +1,10 @@
 /* REQUIRED_ARGS: -dip25
    TEST_OUTPUT:
 ---
-fail_compilation/test16228.d(22): Error: function type 'return int()' has 'return' but does not return any indirections
-fail_compilation/test16228.d(23): Error: function test16228.S.foo static member has no 'this' to which 'return' can apply
+fail_compilation/test16228.d(23): Error: function `test16228.S.bar` `static` member has no `this` to which `return` can apply
 ---
 */
+
 
 
 
@@ -20,5 +20,16 @@ struct S
     int x;
 
     int foo() return { return 3; }
-    static ref int foo() return { return x; }
+    static ref int bar() return { return x; }
+}
+
+
+// https://issues.dlang.org/show_bug.cgi?id=18963
+
+T Identity(T)(return T t) { return t; }
+
+void bar(int i, void* p)
+{
+    Identity(p);
+    Identity(i);
 }


### PR DESCRIPTION
Fix a couple testsuite failures that get flagged by some recently introduced tests.