### PR TITLE
dtoh: Don't emit integral enums as `(<Enum>) <Integer>`

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -1,0 +1,9 @@
+Improvements for the C++ header generation
+
+The following features/bugfixes/improvements were implemented for the
+experimental C++ header generator:
+
+- Integral enums are no longer emitted as `(<Enum>) <Integer>`
+
+Note: The header generator is still considerer experimental, so please submit
+      any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2203,6 +2203,10 @@ public:
         result = getVarExp(e.loc, istate, e.var, goal);
         if (exceptionOrCant(result))
             return;
+
+        if (auto ie = result.isIntegerExp())
+            ie.setSource(e);
+
         if ((e.var.storage_class & (STC.ref_ | STC.out_)) == 0 && e.type.baseElemOf().ty != Tstruct)
         {
             /* Ultimately, STC.ref_|STC.out_ check should be enough to see the

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -226,6 +226,7 @@ public:
 class IntegerExp : public Expression
 {
 public:
+    Expression* original;
     dinteger_t value;
 
     static IntegerExp *create(Loc loc, dinteger_t value, Type *type);
@@ -240,6 +241,8 @@ public:
     void accept(Visitor *v) { v->visit(this); }
     dinteger_t getInteger() { return value; }
     void setInteger(dinteger_t value);
+    IntegerExp* syntaxCopy();
+    void setSource(Expression* e);
     template<int v>
     static IntegerExp literal();
 };

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3445,7 +3445,7 @@ private:
     union __AnonStruct__u
     {
         char exp[40LLU];
-        char integerexp[48LLU];
+        char integerexp[56LLU];
         char errorexp[40LLU];
         char realexp[64LLU];
         char complexexp[80LLU];
@@ -3480,6 +3480,9 @@ enum class OwnedBy : uint8_t
 
 class IntegerExp final : public Expression
 {
+public:
+    Expression* original;
+private:
     dinteger_t value;
 public:
     static IntegerExp* create(Loc loc, dinteger_t value, Type* type);
@@ -3495,6 +3498,7 @@ public:
     dinteger_t getInteger();
     void setInteger(dinteger_t value);
     IntegerExp* syntaxCopy();
+    void setSource(Expression* e);
     static IntegerExp* createBool(bool b);
 };
 

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -196,6 +196,10 @@ private Expression fromConstInitializer(int result, Expression e1)
                 e = e.copy();
                 e.type = e1.type;
             }
+
+            if (auto ie = e.isIntegerExp())
+                ie.setSource(ve);
+
             e.loc = e1.loc;
         }
         else
@@ -908,7 +912,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             {
                 // This only applies to floating point, or positive integral powers.
                 if (e.e1.type.isfloating() || cast(sinteger_t)e.e2.toInteger() >= 0)
-                    e.e2 = new IntegerExp(e.loc, e.e2.toInteger(), Type.tint64);
+                    e.e2 = new IntegerExp(e.loc, e.e2.toInteger(), Type.tint64, e.e2);
             }
             if (e.e1.isConst() == 1 && e.e2.isConst() == 1)
             {
@@ -1085,7 +1089,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
                 {
                     bool n1 = e.e1.isBool(true);
                     bool n2 = e.e2.isBool(true);
-                    ret = new IntegerExp(e.loc, oror ? (n1 || n2) : (n1 && n2), e.type);
+                    ret = new IntegerExp(e.loc, oror ? (n1 || n2) : (n1 && n2), e.type, e);
                 }
                 else if (e.e1.isBool(!oror))
                 {

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -328,6 +328,10 @@ void test_expression()
 {
     Loc loc;
     IntegerExp *ie = IntegerExp::create(loc, 42, Type::tint32);
+
+    IntegerExp *scr = ie->syntaxCopy();
+    assert(ie == scr); // returns the instance
+
     Expression *e = ie->ctfeInterpret();
 
     assert(e);

--- a/test/compilable/dtoh_enum.d
+++ b/test/compilable/dtoh_enum.d
@@ -39,28 +39,16 @@ struct _d_dynamicArray
 };
 #endif
 
-struct Foo;
-struct FooCpp;
-
-enum : int32_t { Anon = 10 };
-
-enum : bool { Anon2 = true };
-
-static const char* const Anon3 = "wow";
-
 enum class Enum
 {
     One = 0,
     Two = 1,
 };
 
-extern const Enum constEnum;
+struct Foo;
+struct FooCpp;
 
-enum class EnumDefaultType
-{
-    One = 1,
-    Two = 2,
-};
+extern const Enum constEnum;
 
 enum class EnumWithType : int8_t
 {
@@ -72,6 +60,22 @@ enum
 {
     AnonOne = 1,
     AnonTwo = 2,
+};
+
+extern void forward(Enum e1 = Enum::One, Enum e2 = constEnum);
+
+extern void forwardConstant(int8_t b = static_cast<int8_t>(EnumWithType::One), int32_t l = AnonOne);
+
+enum : int32_t { Anon = 10 };
+
+enum : bool { Anon2 = true };
+
+static const char* const Anon3 = "wow";
+
+enum class EnumDefaultType
+{
+    One = 1,
+    Two = 2,
 };
 
 enum : int64_t
@@ -151,8 +155,27 @@ static /* MyEnum */ Foo const testCpp = Foo(42);
 
 enum class opaque;
 enum class typedOpaque : int64_t;
+struct S
+{
+    enum class Nested
+    {
+        Member = 1,
+    };
+
+    S()
+    {
+    }
+};
+
+static Nested const OfNested = S::Nested::Member;
+
+enum : bool { is64bit = true };
 ---
 +/
+
+extern(C++) void forward(Enum e1 = Enum.One, Enum e2 = constEnum) {}
+
+extern(C++) void forwardConstant(byte b = EnumWithType.One, int l = AnonOne) {}
 
 extern(C++) enum Anon = 10;
 extern(C++) enum Anon2 = true;
@@ -256,3 +279,17 @@ enum typedOpaque : long;
 enum arrayOpaque : int[4]; // Cannot be exported to C++
 
 extern(D) enum hidden_d = 42; // Linkage prevents being exported to C++
+
+extern(C++):
+
+struct S
+{
+    enum Nested
+    {
+        Member = 1
+    }
+}
+
+enum OfNested = S.Nested.Member;
+
+enum is64bit = size_t.sizeof <= 20;


### PR DESCRIPTION
Implements means to track the original expression that was const-folded into an `IntegerExp` and detect's those in `dtoh`.

WIP because some cases are not detected yet