### PR TITLE
dmd.builtin: Match any submodule of the std.math package

### DIFF
--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -86,13 +86,13 @@ BUILTIN determine_builtin(FuncDeclaration func)
     if (!m || !m.md)
         return BUILTIN.unimp;
     const md = m.md;
-    const id2 = md.id;
 
-    // Look for core.math, core.bitop and std.math
+    // Look for core.math, core.bitop, std.math, and std.math.<package>
+    const id2 = (md.packages.length == 2) ? md.packages[1] : md.id;
     if (id2 != Id.math && id2 != Id.bitop)
         return BUILTIN.unimp;
 
-    if (md.packages.length != 1)
+    if (md.packages.length != 1 && !(md.packages.length == 2 && id2 == Id.math))
         return BUILTIN.unimp;
 
     const id1 = md.packages[0];


### PR DESCRIPTION
Unblocks dlang/phobos#7942 and dlang/phobos#7943 (though haven't tested the latter locally).

We are already matching `std.math.*` in the back-end, the fix just wasn't applied to the front-end as well.
https://github.com/dlang/dmd/blob/e658df1cc3a1622dea8e3614a5c3d94742ebbf52/src/dmd/toir.d#L512-L521