### PR TITLE
remove TARGET

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6826,17 +6826,6 @@ enum class HIGHLIGHT : uint8_t
     Other = 6u,
 };
 
-enum class TARGET : bool
-{
-    Linux = true,
-    OSX = false,
-    FreeBSD = false,
-    OpenBSD = false,
-    Solaris = false,
-    Windows = false,
-    DragonFlyBSD = false,
-};
-
 enum class DiagnosticReporting : uint8_t
 {
     error = 0u,

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -17,22 +17,6 @@ import dmd.root.filename;
 import dmd.root.outbuffer;
 import dmd.identifier;
 
-template xversion(string s)
-{
-    enum xversion = mixin(`{ version (` ~ s ~ `) return true; else return false; }`)();
-}
-
-enum TARGET : bool
-{
-    Linux        = xversion!`linux`,
-    OSX          = xversion!`OSX`,
-    FreeBSD      = xversion!`FreeBSD`,
-    OpenBSD      = xversion!`OpenBSD`,
-    Solaris      = xversion!`Solaris`,
-    Windows      = xversion!`Windows`,
-    DragonFlyBSD = xversion!`DragonFlyBSD`,
-}
-
 enum DiagnosticReporting : ubyte
 {
     error,        // generate an error

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -25,23 +25,10 @@ import dmd.root.file;
 import dmd.root.filename;
 import dmd.root.string;
 
-static if (TARGET.Windows)
-{
-    import dmd.libomf;
-    import dmd.libmscoff;
-}
-else static if (TARGET.Linux || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
-{
-    import dmd.libelf;
-}
-else static if (TARGET.OSX)
-{
-    import dmd.libmach;
-}
-else
-{
-    static assert(0, "unsupported system");
-}
+import dmd.libomf;
+import dmd.libmscoff;
+import dmd.libelf;
+import dmd.libmach;
 
 private enum LOG = false;
 
@@ -49,18 +36,19 @@ class Library
 {
     static Library factory()
     {
-        static if (TARGET.Windows)
+        if (target.os == Target.OS.Windows)
         {
             return (target.mscoff || target.is64bit) ? LibMSCoff_factory() : LibOMF_factory();
         }
-        else static if (TARGET.Linux || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
+        else if (target.os & (Target.OS.linux | Target.OS.FreeBSD | Target.OS.OpenBSD | Target.OS.Solaris | Target.OS.DragonFlyBSD))
         {
             return LibElf_factory();
         }
-        else static if (TARGET.OSX)
+        else if (target.os == Target.OS.OSX)
         {
             return LibMach_factory();
         }
+        assert(0);
     }
 
     abstract void addObject(const(char)[] module_name, const ubyte[] buf);

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -70,19 +70,19 @@ enum CPU
 
 Target.OS defaultTargetOS()
 {
-    static if (TARGET.Windows)
+    version (Windows)
         return Target.OS.Windows;
-    else static if (TARGET.Linux)
+    else version (linux)
         return Target.OS.linux;
-    else static if (TARGET.OSX)
+    else version (OSX)
         return Target.OS.OSX;
-    else static if (TARGET.FreeBSD)
+    else version (FreeBSD)
         return Target.OS.FreeBSD;
-    else static if (TARGET.OpenBSD)
+    else version (OpenBSD)
         return Target.OS.OpenBSD;
-    else static if (TARGET.Solaris)
+    else version (Solaris)
         return Target.OS.Solaris;
-    else static if (TARGET.DragonFlyBSD)
+    else version (DragonFlyBSD)
         return Target.OS.DragonFlyBSD;
     else
         static assert(0, "unknown TARGET");
@@ -1289,12 +1289,12 @@ struct TargetCPP
      */
     extern (C++) const(char)* toMangle(Dsymbol s)
     {
-        static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.DragonFlyBSD || TARGET.Solaris)
+        if (target.os & (Target.OS.linux | Target.OS.OSX | Target.OS.FreeBSD | Target.OS.OpenBSD | Target.OS.Solaris | Target.OS.DragonFlyBSD))
             return toCppMangleItanium(s);
-        else static if (TARGET.Windows)
+        if (target.os == Target.OS.Windows)
             return toCppMangleMSVC(s);
         else
-            static assert(0, "fix this");
+            assert(0, "fix this");
     }
 
     /**
@@ -1306,12 +1306,12 @@ struct TargetCPP
      */
     extern (C++) const(char)* typeInfoMangle(ClassDeclaration cd)
     {
-        static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
+        if (target.os & (Target.OS.linux | Target.OS.OSX | Target.OS.FreeBSD | Target.OS.OpenBSD | Target.OS.Solaris | Target.OS.DragonFlyBSD))
             return cppTypeInfoMangleItanium(cd);
-        else static if (TARGET.Windows)
+        if (target.os == Target.OS.Windows)
             return cppTypeInfoMangleMSVC(cd);
         else
-            static assert(0, "fix this");
+            assert(0, "fix this");
     }
 
     /**


### PR DESCRIPTION
as this is no longer needed. All subsequent uses should use `dmd.target.target.os` instead