### PR TITLE
Do not recommend un-approved preview switches

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1298,16 +1298,10 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             e = e.implicitCastTo(sc, fparam.type);
 
             // default arg must be an lvalue
-            if (isRefOrOut && !isAuto)
-            {
-                if (!(global.params.previewIn && (fparam.storageClass & STC.in_)) &&
-                    !(global.params.rvalueRefParam))
-                {
-                    e = e.toLvalue(sc, e);
-                    if (e.op == TOK.error)
-                        errorSupplemental(e.loc, "use `-preview=in` or `preview=rvaluerefparam`");
-                }
-            }
+            if (isRefOrOut && !isAuto &&
+                !(global.params.previewIn && (fparam.storageClass & STC.in_)) &&
+                !(global.params.rvalueRefParam))
+                e = e.toLvalue(sc, e);
 
             fparam.defaultArg = e;
             return (e.op != TOK.error);

--- a/test/fail_compilation/fail7603a.d
+++ b/test/fail_compilation/fail7603a.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7603a.d(8): Error: cannot modify constant `true`
-       use `-preview=in` or `preview=rvaluerefparam`
+fail_compilation/fail7603a.d(7): Error: cannot modify constant `true`
 ---
 */
 void test(ref bool val = true) { }

--- a/test/fail_compilation/fail7603b.d
+++ b/test/fail_compilation/fail7603b.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7603b.d(8): Error: cannot modify constant `true`
-       use `-preview=in` or `preview=rvaluerefparam`
+fail_compilation/fail7603b.d(7): Error: cannot modify constant `true`
 ---
 */
 void test(out bool val = true) { }

--- a/test/fail_compilation/fail7603c.d
+++ b/test/fail_compilation/fail7603c.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7603c.d(9): Error: cannot modify constant `3`
-       use `-preview=in` or `preview=rvaluerefparam`
+fail_compilation/fail7603c.d(8): Error: cannot modify constant `3`
 ---
 */
 enum x = 3;

--- a/test/fail_compilation/fail9773.d
+++ b/test/fail_compilation/fail9773.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9773.d(8): Error: `""` is not an lvalue and cannot be modified
-       use `-preview=in` or `preview=rvaluerefparam`
+fail_compilation/fail9773.d(7): Error: `""` is not an lvalue and cannot be modified
 ---
 */
 void f(ref string a = "")

--- a/test/fail_compilation/fail9891.d
+++ b/test/fail_compilation/fail9891.d
@@ -1,10 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9891.d(14): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `ref int` of parameter `n`
-fail_compilation/fail9891.d(19): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `out int` of parameter `n`
-fail_compilation/fail9891.d(24): Error: `prop()` is not an lvalue and cannot be modified
-       use `-preview=in` or `preview=rvaluerefparam`
+fail_compilation/fail9891.d(13): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `ref int` of parameter `n`
+fail_compilation/fail9891.d(18): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `out int` of parameter `n`
+fail_compilation/fail9891.d(23): Error: `prop()` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/issue20704.d
+++ b/test/fail_compilation/issue20704.d
@@ -1,17 +1,13 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/issue20704.d(21): Error: cannot modify constant `0`
-       use `-preview=in` or `preview=rvaluerefparam`
-fail_compilation/issue20704.d(32): Error: template instance `issue20704.f2!int` error instantiating
-fail_compilation/issue20704.d(23): Error: cannot modify constant `0`
-       use `-preview=in` or `preview=rvaluerefparam`
-fail_compilation/issue20704.d(34): Error: template instance `issue20704.f4!int` error instantiating
-fail_compilation/issue20704.d(21): Error: `S(0)` is not an lvalue and cannot be modified
-       use `-preview=in` or `preview=rvaluerefparam`
-fail_compilation/issue20704.d(40): Error: template instance `issue20704.f2!(S)` error instantiating
-fail_compilation/issue20704.d(21): Error: `null` is not an lvalue and cannot be modified
-       use `-preview=in` or `preview=rvaluerefparam`
-fail_compilation/issue20704.d(42): Error: template instance `issue20704.f2!(C)` error instantiating
+fail_compilation/issue20704.d(17): Error: cannot modify constant `0`
+fail_compilation/issue20704.d(28): Error: template instance `issue20704.f2!int` error instantiating
+fail_compilation/issue20704.d(19): Error: cannot modify constant `0`
+fail_compilation/issue20704.d(30): Error: template instance `issue20704.f4!int` error instantiating
+fail_compilation/issue20704.d(17): Error: `S(0)` is not an lvalue and cannot be modified
+fail_compilation/issue20704.d(36): Error: template instance `issue20704.f2!(S)` error instantiating
+fail_compilation/issue20704.d(17): Error: `null` is not an lvalue and cannot be modified
+fail_compilation/issue20704.d(38): Error: template instance `issue20704.f2!(C)` error instantiating
 ---
 */
 


### PR DESCRIPTION
Neither '-preview=in' nor '-previiew=revaluerefparam' has been approved by the BDFL.
'-preview=in' will require a proper DIP process before being made the default,
and DIP1016 which '-preview=revaluerefparam' implements has been rejected.
Moreover, such a message would only show up in a very narrow corner case:
in the semantic of a default argument which is 'ref' but has a rvalue.