### PR TITLE
Give diagnostic to use `-preview=rvaluerefparam` for rvalue parameter…

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4662,6 +4662,8 @@ extern (C++) final class TypeFunction : TypeNext
         buf.printf("cannot pass %sargument `%s` of type `%s` to parameter `%s`",
             rv ? "rvalue ".ptr : "".ptr, arg.toChars(), at,
             parameterToChars(par, this, qual));
+        if (rv)
+            buf.printf(", use `-preview=rvaluerefparam` to allow this conversion");
         return buf.extractChars();
     }
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4662,7 +4662,7 @@ extern (C++) final class TypeFunction : TypeNext
         buf.printf("cannot pass %sargument `%s` of type `%s` to parameter `%s`",
             rv ? "rvalue ".ptr : "".ptr, arg.toChars(), at,
             parameterToChars(par, this, qual));
-        if (rv)
+        if (!arg.isLvalue() && (par.storageClass & STC.ref_) && par.type.isConst())
             buf.printf(", use `-preview=rvaluerefparam` to allow this conversion");
         return buf.extractChars();
     }

--- a/test/fail_compilation/b20011.d
+++ b/test/fail_compilation/b20011.d
@@ -10,7 +10,7 @@ fail_compilation/b20011.d(37):        cannot pass rvalue argument `S1(cast(ubyte
 fail_compilation/b20011.d(38): Error: function `b20011.main.assignableByOut(out ubyte p)` is not callable using argument types `(ubyte)`
 fail_compilation/b20011.d(38):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `out ubyte p`
 fail_compilation/b20011.d(39): Error: function `b20011.main.assignableByConstRef(ref const(ubyte) p)` is not callable using argument types `(ubyte)`
-fail_compilation/b20011.d(39):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref const(ubyte) p`
+fail_compilation/b20011.d(39):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref const(ubyte) p`, use `-preview=rvaluerefparam` to allow this conversion
 ---
 */
 module b20011;


### PR DESCRIPTION
… mismatches

see https://github.com/dlang/dmd/pull/12425