### PR TITLE
DIP1034: make lambdaHasSideEffect true for noreturn functions

### DIFF
--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -186,6 +186,9 @@ private bool lambdaHasSideEffect(Expression e, bool assumeImpureCalls = false)
             if (assumeImpureCalls)
                 return true;
 
+            if (e.type && e.type.ty == Tnoreturn)
+                return true;
+
             CallExp ce = cast(CallExp)e;
             /* Calling a function or delegate that is pure nothrow
              * has no side effects.

--- a/test/compilable/noreturn1.d
+++ b/test/compilable/noreturn1.d
@@ -1,4 +1,5 @@
 /*
+REQUIRED_ARGS: -w
 TEST_OUTPUT:
 ---
 noreturn
@@ -11,6 +12,10 @@ pragma(msg, noreturn);
 noreturn exits(int* p) { *p = 3; }
 
 noreturn exit();
+
+noreturn pureexits() @nogc nothrow pure @safe { assert(0); }
+
+noreturn callpureexits() { pureexits(); }
 
 int test1(int i)
 {


### PR DESCRIPTION
Prevents spurious warning `"calling XXX without side effects discards return value of type 'noreturn'; prepend a 'cast(void)' if intentional"`.

Also changes the result of `hasSideEffect` and behavior of `isTrivialExp`.

There appears to be a general inconsistency where a function that performs side-effectful operations may be considered side-effectless but if that is indeed a problem addressing it is beyond the scope of this PR.