### PR TITLE
fix Issue 21826 - MSCOFF output for Win32 should not use EBP for anyt…

### DIFF
--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -111,6 +111,8 @@ static if (TARGET_WINDOS)
         config.exe = EX_WIN32;
         config.ehmethod = useExceptions ? EHmethod.EH_WIN32 : EHmethod.EH_NONE;
         config.objfmt = mscoff ? OBJ_MSCOFF : OBJ_OMF;
+        if (mscoff)
+            config.flags |= CFGnoebp;    // test suite fails without this
     }
 
     if (exe)

--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -533,7 +533,7 @@ void cdorth(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         }
     }
 
-    regm_t posregs = (isbyte) ? BYTEREGS : (mES | ALLREGS | mBP);
+    regm_t posregs = (isbyte) ? BYTEREGS : (mES | allregs);
     regm_t retregs = *pretregs & posregs;
     if (retregs == 0)                   /* if no return regs speced     */
                                         /* (like if wanted flags only)  */


### PR DESCRIPTION
…hing other than the frame pointer

This is causing problems with https://github.com/dlang/dmd/pull/12409 but is not the purpose of that PR, so I separated it out.

The 114-115 fix disables use of EBP for general register use for the Win32 mscoff model.

The 536 just fixes a bug where it might wrongly select EBP. No test case known to trigger it, very hard to devise a test case that does as it is hyper sensitive to how registers are allocated.