### PR TITLE
fix Issue 18251 - deprecate + transition=complex shouldn't look at functions with non-matching if constraints

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -4907,13 +4907,24 @@ final class Parser(AST) : Lexer
                     auto tempdecl = new AST.TemplateDeclaration(loc, tplIdent, tpl, constraint, decldefs);
                     s = tempdecl;
 
+                    StorageClass stc2 = STC.undefined_;
                     if (storage_class & STC.static_)
                     {
                         assert(f.storage_class & STC.static_);
                         f.storage_class &= ~STC.static_;
+                        stc2 |= STC.static_;
+                    }
+                    if (storage_class & STC.deprecated_)
+                    {
+                        assert(f.storage_class & STC.deprecated_);
+                        f.storage_class &= ~STC.deprecated_;
+                        stc2 |= STC.deprecated_;
+                    }
+                    if (stc2 != STC.undefined_)
+                    {
                         auto ax = new AST.Dsymbols();
                         ax.push(s);
-                        s = new AST.StorageClassDeclaration(STC.static_, ax);
+                        s = new AST.StorageClassDeclaration(stc2, ax);
                     }
                 }
                 a.push(s);

--- a/test/compilable/diag20916.d
+++ b/test/compilable/diag20916.d
@@ -7,7 +7,7 @@ compilable/diag20916.d(42):        instantiated from here: `jump1!(Foo)`
 compilable/diag20916.d(32): Deprecation: function `diag20916.FooBar.toString` is deprecated
 compilable/diag20916.d(37):        instantiated from here: `jump2!(Foo)`
 compilable/diag20916.d(42):        instantiated from here: `jump1!(Foo)`
-compilable/diag20916.d(32): Deprecation: function `diag20916.Bar.toString!().toString` is deprecated
+compilable/diag20916.d(32): Deprecation: template `diag20916.Bar.toString()()` is deprecated
 compilable/diag20916.d(37):        instantiated from here: `jump2!(Bar)`
 compilable/diag20916.d(43):        instantiated from here: `jump1!(Bar)`
 compilable/diag20916.d(21): Deprecation: variable `diag20916.Something.something` is deprecated

--- a/test/compilable/test18251.d
+++ b/test/compilable/test18251.d
@@ -1,0 +1,23 @@
+// REQUIRED_ARGS: -unittest -transition=complex -de
+
+auto test18251(T)(T t)
+if (!__traits(isDeprecated, T))
+{
+    return T.init;
+}
+
+unittest
+{
+    auto b = test18251(2);
+}
+
+deprecated auto test18251(T)(T t)  // deprecated storage class got lost when expanding.
+if (__traits(isDeprecated, T))
+{
+    return T.init;
+}
+
+deprecated unittest
+{
+    auto b = test18251(2 + 2i);
+}


### PR DESCRIPTION
One workaround for the issue was to put deprecated templates into a code block.
```
deprecated
{
    auto issue18251(T)(T t)
    if (__traits(isDeprecated, T))
    {
        return T.init;
    }
}
```
This patch makes it so that the test for issue 18251 has no difference to the above at an AST level.