### PR TITLE
Fix Issue 21828 - Using enum of struct (containing another enum) before its declaration fails

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -363,6 +363,9 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
         s = sm.toAlias();
     }
 
+    if (auto ed = s.isEnumDeclaration())
+        s.dsymbolSemantic(sc);
+
     if (auto em = s.isEnumMember())
     {
         // It's not a type, it's an expression

--- a/test/compilable/test21828.d
+++ b/test/compilable/test21828.d
@@ -1,0 +1,18 @@
+// https://issues.dlang.org/show_bug.cgi?id=21828
+
+struct S
+{
+    enum E
+    {
+        e1 = 0,
+    }
+    E e;
+    enum S s1 = S(E.e1);
+}
+
+SE se;
+
+enum SE
+{
+    e1 = S.s1
+}


### PR DESCRIPTION
This is blocking: https://github.com/dlang/phobos/pull/7766