### PR TITLE
Fix 13815 - Use correct scope during statementSemantic on try-block

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3926,7 +3926,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
 
         scope sc2 = sc.push();
         sc2.tryBody = tcs;
-        tcs._body = tcs._body.semanticScope(sc, null, null);
+        tcs._body = tcs._body.semanticScope(sc2, null, null);
         assert(tcs._body);
         sc2.pop();
 
@@ -4012,8 +4012,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         tfs.tryBody = sc.tryBody;
 
         auto sc2 = sc.push();
-        sc.tryBody = tfs;
-        tfs._body = tfs._body.statementSemantic(sc);
+        sc2.tryBody = tfs;
+        tfs._body = tfs._body.statementSemantic(sc2);
         sc2.pop();
 
         sc = sc.push();

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -6811,27 +6811,6 @@ static assert(md5_digest11535(`TEST`) == [84, 69, 83, 84, 0, 0]);
 
 static assert(()
 {
-    // enter to TryCatchStatement.body
-    {
-        bool c = false;
-        try
-        {
-            if (c)  // need to bypass front-end optimization
-                throw new Exception("");
-            else
-            {
-                goto Lx;
-              L1:
-                c = true;
-            }
-        }
-        catch (Exception e) {}
-
-      Lx:
-        if (!c)
-            goto L1;
-    }
-
     // jump inside TryCatchStatement.body
     {
         bool c = false;
@@ -6923,23 +6902,6 @@ static assert(()
 
 static assert(()
 {
-    // enter back to TryFinallyStatement.body
-    {
-        bool c = false;
-        try
-        {
-            goto Lx;
-          L1:
-            c = true;
-        }
-        finally {
-        }
-
-      Lx:
-        if (!c)
-            goto L1;
-    }
-
     // jump inside TryFinallyStatement.body
     {
         try

--- a/test/fail_compilation/goto2.d
+++ b/test/fail_compilation/goto2.d
@@ -48,3 +48,96 @@ void test1()
             break;
     }
 }
+
+/**************************************************
+https://issues.dlang.org/show_bug.cgi?id=11540
+goto label + try-catch-finally / with statement
+
+TEST_OUTPUT:
+---
+fail_compilation/goto2.d(1121): Error: cannot `goto` into `try` block
+---
+*/
+#line 1100
+
+int interpret3a()
+{
+    // enter to TryCatchStatement.body
+    {
+        bool c = false;
+        try
+        {
+            if (c)  // need to bypass front-end optimization
+                throw new Exception("");
+            else
+            {
+                goto Lx;
+              L1:
+                c = true;
+            }
+        }
+        catch (Exception e) {}
+
+      Lx:
+        if (!c)
+            goto L1;
+    }
+    return 1;
+}
+
+/**************************************************
+https://issues.dlang.org/show_bug.cgi?id=11540
+goto label + try-catch-finally / with statement
+
+TEST_OUTPUT:
+---
+fail_compilation/goto2.d(1217): Error: cannot `goto` into `try` block
+---
+*/
+#line 1200
+
+int interpret3b()
+{
+    // enter back to TryFinallyStatement.body
+    {
+        bool c = false;
+        try
+        {
+            goto Lx;
+          L1:
+            c = true;
+        }
+        finally {
+        }
+
+      Lx:
+        if (!c)
+            goto L1;
+    }
+
+    return 1;
+}
+
+/**************************************************
+https://issues.dlang.org/show_bug.cgi?id=13815
+
+TEST_OUTPUT:
+---
+fail_compilation/goto2.d(1234): Error: cannot `goto` into `try` block
+---
+*/
+
+bool f()
+{
+    goto L;
+    try
+    {
+L:                                  // line 7
+        throw new Exception("");    // line 8
+    }
+    catch (Exception e)
+    {
+        return true;
+    }
+    return false;
+}


### PR DESCRIPTION
`sc2` was created but never used (probably a typo).

While the code doesn't cause errors in CTFE, it does trigger an assert in backend.