### PR TITLE
fix Issue 21831 - Wrong deprecation message in template parameters before evaluating constraints

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -398,6 +398,10 @@ extern (C++) class Dsymbol : ASTNode
         // Don't complain if we're inside a deprecated symbol's scope
         if (sc.isDeprecated())
             return false;
+        // Don't complain if we're inside a template constraint
+        // https://issues.dlang.org/show_bug.cgi?id=21831
+        if (sc.flags & SCOPE.constraint)
+            return false;
 
         const(char)* message = null;
         for (Dsymbol p = this; p; p = p.parent)

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -827,6 +827,11 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         scx.parent = ti;
         scx.tinst = null;
         scx.minst = null;
+        // Set SCOPE.constraint before declaring function parameters for the static condition
+        // (previously, this was immediately before calling evalStaticCondition), so the
+        // semantic pass knows not to issue deprecation warnings for these throw-away decls.
+        // https://issues.dlang.org/show_bug.cgi?id=21831
+        scx.flags |= SCOPE.constraint;
 
         assert(!ti.symtab);
         if (fd)
@@ -882,7 +887,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         assert(ti.inst is null);
         ti.inst = ti; // temporary instantiation to enable genIdent()
-        scx.flags |= SCOPE.constraint;
         bool errors;
         const bool result = evalStaticCondition(scx, constraint, lastConstraint, errors, &lastConstraintNegs);
         if (result || errors)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2640,6 +2640,10 @@ extern (C++) abstract class Type : ASTNode
     {
         if (sc.isDeprecated())
             return false;
+        // Don't complain if we're inside a template constraint
+        // https://issues.dlang.org/show_bug.cgi?id=21831
+        if (sc.flags & SCOPE.constraint)
+            return false;
 
         Type t = baseElemOf();
         while (t.ty == Tpointer || t.ty == Tarray)

--- a/test/compilable/test21831.d
+++ b/test/compilable/test21831.d
@@ -1,0 +1,20 @@
+// REQUIRED_ARGS: -de -unittest
+
+deprecated struct S21831 { }
+
+auto test21831(T)(T t)    // error: struct `S21831` is deprecated
+if (!__traits(isDeprecated, T))
+{
+    return T.init;
+}
+
+deprecated auto test21831(T)(T t)
+if (__traits(isDeprecated, T))
+{
+    return T.init;
+}
+
+deprecated unittest
+{
+    auto b = test21831(S21831()); // instantiated from here
+}

--- a/test/fail_compilation/fail21831.d
+++ b/test/fail_compilation/fail21831.d
@@ -1,0 +1,29 @@
+/* REQUIRED_ARGS: -de -unittest
+TEST_OUTPUT
+---
+fail_compilation/fail21831.d(19): Deprecation: struct `fail21831.S21831` is deprecated - Deprecated type
+fail_compilation/fail21831.d(19): Deprecation: template `fail21831.test21831(T)(T t) if (__traits(isDeprecated, T))` is deprecated - Deprecated template
+fail_compilation/fail21831.d(19): Deprecation: struct `fail21831.S21831` is deprecated - Deprecated type
+---
+*/
+#line 1
+deprecated("Deprecated type")
+struct S21831 { }
+
+auto test21831(T)(T t)
+if (!__traits(isDeprecated, T))
+{
+    return T.init;
+}
+
+deprecated("Deprecated template")
+auto test21831(T)(T t)
+if (__traits(isDeprecated, T))
+{
+    return T.init;
+}
+
+unittest
+{
+    auto b = test21831(S21831());
+}


### PR DESCRIPTION
Split out from #12435, test adapted to use a deprecated struct as it's not just complex types that are affected.