### PR TITLE
fix Issue 21830 - Wrong deprecation message when non-deprecated template in static condition

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -841,7 +841,9 @@ Lagain:
     }
     else
     {
-        if (!s.isFuncDeclaration()) // functions are checked after overloading
+        // functions are checked after overloading
+        // templates are checked after matching constraints
+        if (!s.isFuncDeclaration() && !s.isTemplateDeclaration())
         {
             s.checkDeprecated(loc, sc);
             if (d)
@@ -853,7 +855,7 @@ Lagain:
         s = s.toAlias();
 
         //printf("s = '%s', s.kind = '%s', s.needThis() = %p\n", s.toChars(), s.kind(), s.needThis());
-        if (s != olds && !s.isFuncDeclaration())
+        if (s != olds && !s.isFuncDeclaration() && !s.isTemplateDeclaration())
         {
             s.checkDeprecated(loc, sc);
             if (d)

--- a/test/compilable/test21830.d
+++ b/test/compilable/test21830.d
@@ -1,0 +1,25 @@
+// REQUIRED_ARGS: -de -unittest
+
+deprecated struct OldS21830 { }
+
+struct NewS21830 { }
+
+static if (1)
+{
+    auto test21830(T)(T t)
+    if (is(T == NewS21830))
+    {
+        return T.init;
+    }
+}
+
+deprecated auto test21830(T)(T t)
+if (is(T == OldS21830))
+{
+    return T.init;
+}
+
+unittest
+{
+    auto b = test21830(NewS21830()); // error here about using test21830!OldS21830
+}

--- a/test/fail_compilation/fail21830.d
+++ b/test/fail_compilation/fail21830.d
@@ -1,0 +1,36 @@
+/* REQUIRED_ARGS: -de -unittest
+TEST_OUTPUT
+---
+fail_compilation/fail21830.d(24): Deprecation: struct `fail21830.OldS21830` is deprecated - Deprecated type
+fail_compilation/fail21830.d(8): Deprecation: struct `fail21830.OldS21830` is deprecated - Deprecated type
+fail_compilation/fail21830.d(24):        instantiated from here: `test21830!(OldS21830)`
+fail_compilation/fail21830.d(24): Deprecation: template `fail21830.test21830(T)(T t) if (is(T == OldS21830))` is deprecated - Deprecated template
+fail_compilation/fail21830.d(24): Deprecation: struct `fail21830.OldS21830` is deprecated - Deprecated type
+---
+*/
+#line 1
+deprecated("Deprecated type")
+struct OldS21830 { }
+
+struct NewS21830 { }
+
+static if (1)
+{
+    auto test21830(T)(T t)
+    if (is(T == NewS21830))
+    {
+        return T.init;
+    }
+}
+
+deprecated("Deprecated template")
+auto test21830(T)(T t)
+if (is(T == OldS21830))
+{
+    return T.init;
+}
+
+unittest
+{
+    auto b = test21830(OldS21830());
+}


### PR DESCRIPTION
Split out from #12435, test adapted to use a deprecated struct as it's not just complex types that are affected.