### PR TITLE
fix Issue 21832 - Wrong deprecation message when importing non-deprecated template in static condition

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -219,7 +219,10 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
     else
     {
         // check for deprecated or disabled aliases
-        s.checkDeprecated(loc, sc);
+        // functions are checked after overloading
+        // templates are checked after matching constraints
+        if (!s.isFuncDeclaration() && !s.isTemplateDeclaration())
+            s.checkDeprecated(loc, sc);
         if (d)
             d.checkDisabled(loc, sc, true);
     }

--- a/test/compilable/imports/imp21832.d
+++ b/test/compilable/imports/imp21832.d
@@ -1,0 +1,24 @@
+module imports.imp21832;
+static if(1)
+{
+    int fun(int a)
+    {
+        return a;
+    }
+    int tpl()(int a)
+    {
+        return a;
+    }
+}
+
+deprecated
+{
+    int fun(char a)
+    {
+        return a;
+    }
+    int tpl()(char a)
+    {
+        return a;
+    }
+}

--- a/test/compilable/test21832.d
+++ b/test/compilable/test21832.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -de
+// EXTRA_FILES: imports/imp21832.d
+int test21832a()
+{
+    import imports.imp21832 : fun; // function 'fun' is deprecated
+    return fun(0);
+}
+
+int test21832b()
+{
+    import imports.imp21832 : tpl; // template 'tpl' is deprecated
+    return tpl(0);
+}

--- a/test/fail_compilation/fail21830.d
+++ b/test/fail_compilation/fail21830.d
@@ -2,8 +2,6 @@
 TEST_OUTPUT
 ---
 fail_compilation/fail21830.d(24): Deprecation: struct `fail21830.OldS21830` is deprecated - Deprecated type
-fail_compilation/fail21830.d(8): Deprecation: struct `fail21830.OldS21830` is deprecated - Deprecated type
-fail_compilation/fail21830.d(24):        instantiated from here: `test21830!(OldS21830)`
 fail_compilation/fail21830.d(24): Deprecation: template `fail21830.test21830(T)(T t) if (is(T == OldS21830))` is deprecated - Deprecated template
 fail_compilation/fail21830.d(24): Deprecation: struct `fail21830.OldS21830` is deprecated - Deprecated type
 ---

--- a/test/fail_compilation/fail21832.d
+++ b/test/fail_compilation/fail21832.d
@@ -1,0 +1,21 @@
+// REQUIRED_ARGS: -de
+// EXTRA_FILES: imports/imp21832.d
+/*
+TEST_OUTPUT
+---
+fail_compilation/fail21832.d(4): Deprecation: function `imports.imp21832.fun` is deprecated
+fail_compilation/fail21832.d(10): Deprecation: template `imports.imp21832.tpl()(char a)` is deprecated
+---
+*/
+#line 1
+int test21832a()
+{
+    import imports.imp21832 : fun;
+    return fun('a');
+}
+
+int test21832b()
+{
+    import imports.imp21832 : tpl;
+    return tpl('a');
+}

--- a/test/fail_compilation/imports/imp21832.d
+++ b/test/fail_compilation/imports/imp21832.d
@@ -1,0 +1,24 @@
+module imports.imp21832;
+static if(1)
+{
+    int fun(int a)
+    {
+        return a;
+    }
+    int tpl()(int a)
+    {
+        return a;
+    }
+}
+
+deprecated
+{
+    int fun(char a)
+    {
+        return a;
+    }
+    int tpl()(char a)
+    {
+        return a;
+    }
+}


### PR DESCRIPTION
Depends on  #12441 for fixing another deprecation message that gets emitted.