### PR TITLE
fix Issue 21835 - Operation on float should use XMM register, not x87

### DIFF
--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -4390,6 +4390,30 @@ private elem * elcmp(elem *e, goal_t goal)
             }
         }
 
+        if (e1.Eoper == OPf_d && tysize(e1.Ety) == 8 && cast(targ_float)e2.EV.Vdouble == e2.EV.Vdouble)
+        {
+            /* Remove unnecessary OPf_d operator
+             */
+            e.EV.E1 = e1.EV.E1;
+            e1.EV.E1 = null;
+            el_free(e1);
+            e2.Ety = e.EV.E1.Ety;
+            e2.EV.Vfloat = cast(targ_float)e2.EV.Vdouble;
+            return optelem(e,GOALvalue);
+        }
+
+        if (e1.Eoper == OPd_ld && tysize(e1.Ety) == tysize(TYldouble) && cast(targ_double)e2.EV.Vldouble == e2.EV.Vldouble)
+        {
+            /* Remove unnecessary OPd_ld operator
+             */
+            e.EV.E1 = e1.EV.E1;
+            e1.EV.E1 = null;
+            el_free(e1);
+            e2.Ety = e.EV.E1.Ety;
+            e2.EV.Vdouble = cast(targ_double)e2.EV.Vldouble;
+            return optelem(e,GOALvalue);
+        }
+
         /* Convert (ulong > uint.max) to (msw(ulong) != 0)
          */
         if (OPTIMIZER && I32 && e.Eoper == OPgt && sz == LLONGSIZE && e2.EV.Vullong == 0xFFFFFFFF)

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -2408,6 +2408,40 @@ void test21816()
 }
 
 ////////////////////////////////////////////////////////////////////////
+// https://issues.dlang.org/show_bug.cgi?id=21835
+
+struct Point21835
+{
+    float  f = 3.0;
+    double d = 4.0;
+    real   r = 5.0;
+}
+
+void test21835y()
+{
+    Point21835[1] arr;
+    if (arr[0].f != 3.0) assert(0);
+    if (arr[0].d != 4.0) assert(0);
+    if (arr[0].r != 5.0) assert(0);
+}
+
+struct Point21835x
+{
+    float  f = 0.0;
+    double d = 0.0;
+    real   r = 0.0;
+}
+
+void test21835()
+{
+    test21835y();
+    Point21835x[1] arr;
+    if (arr[0].f != 0.0) assert(0);
+    if (arr[0].d != 0.0) assert(0);
+    if (arr[0].r != 0.0) assert(0);
+}
+
+////////////////////////////////////////////////////////////////////////
 
 int main()
 {
@@ -2504,6 +2538,7 @@ int main()
     test21513();
     test21256();
     test21816();
+    test21835();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Not much to it. Removes unnecessary floating conversion operators when doing comparisons.