### PR TITLE
Fix Issue 14740 - __traits(allMembers) returns erroneous 'this' member for types declared in functions

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1603,6 +1603,9 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 {
                     return 0;
                 }
+                // skip 'this' context pointers
+                else if (decl.isThisDeclaration())
+                    return 0;
             }
 
             // https://issues.dlang.org/show_bug.cgi?id=20915

--- a/test/compilable/test14740.d
+++ b/test/compilable/test14740.d
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=14740
+
+void test()
+{
+    struct S
+    {
+        void fun() {}
+    }
+    static assert([__traits(allMembers, S)] == ["fun"]);
+}


### PR DESCRIPTION
Listing this hidden member serves no purpose because both `hasMember` and `getMember` can't read it.
Furthermore, there is `__traits(isNested)` for checking its existence.