### PR TITLE
Fix Issue 21845 - Make `in` take precedence in getParameterStorageClasses

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1442,10 +1442,10 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
         if (stc & STC.out_)
             push("out");
-        else if (stc & STC.ref_)
-            push("ref");
         else if (stc & STC.in_)
             push("in");
+        else if (stc & STC.ref_)
+            push("ref");
         else if (stc & STC.lazy_)
             push("lazy");
         else if (stc & STC.alias_)

--- a/test/compilable/previewin.d
+++ b/test/compilable/previewin.d
@@ -7,6 +7,14 @@ void fun(in int* inParam) @safe;
 static assert([__traits(getParameterStorageClasses, fun, 0)] == ["in"]);
 static assert (is(typeof(fun) P == __parameters) && is(P[0] == const int*));
 
+struct Foo
+{
+    int a;
+    double[100] b;
+}
+void fun2(in Foo inParam) @safe;
+static assert([__traits(getParameterStorageClasses, fun2, 0)] == ["in"]);
+static assert (is(typeof(fun2) P == __parameters) && is(P[0] == const Foo));
 
 void test()
 {


### PR DESCRIPTION
Just a cherry-pick of https://github.com/dlang/dmd/pull/12457 which should not confuse the CI scripts.