### PR TITLE
fix Issue 21849 - UTF8: -verrors=context doesn't respect multibyte characters

### DIFF
--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -368,9 +368,18 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
             if (loc.charnum < line.length)
             {
                 fprintf(stderr, "%.*s\n", cast(int)line.length, line.ptr);
-                foreach (_; 1 .. loc.charnum)
+                // The number of column bytes and the number of display columns
+                // occupied by a character are not the same for non-ASCII charaters.
+                // https://issues.dlang.org/show_bug.cgi?id=21849
+                size_t c = 0;
+                while (c < loc.charnum - 1)
+                {
+                    import dmd.utf : utf_decodeChar;
+                    dchar u;
+                    const msg = utf_decodeChar(line, c, u);
+                    assert(msg is null, msg);
                     fputc(' ', stderr);
-
+                }
                 fputc('^', stderr);
                 fputc('\n', stderr);
             }

--- a/test/fail_compilation/fail21849.d
+++ b/test/fail_compilation/fail21849.d
@@ -1,0 +1,36 @@
+// https://issues.dlang.org/show_bug.cgi?id=21849
+// REQUIRED_ARGS: -verrors=context -vcolumns
+/* TEST_OUTPUT:
+---
+fail_compilation/fail21849.d(21,17): Error: cannot implicitly convert expression `1` of type `int` to `string`
+    string ß = 1;
+               ^
+fail_compilation/fail21849.d(25,42): Error: cannot implicitly convert expression `cast(ushort)65535u` of type `ushort` to `byte`
+    string s = "ß☺-oneline"; byte S = ushort.max;
+                                      ^
+fail_compilation/fail21849.d(30,10): Error: undefined identifier `undefined_identifier`
+ß-utf"; undefined_identifier;
+        ^
+fail_compilation/fail21849.d(35,15): Error: `s[0..9]` has no effect
+☺-smiley"; s[0 .. 9];
+            ^
+---
+*/
+void fail21849a()
+{
+    string ß = 1;
+}
+void fail21849b()
+{
+    string s = "ß☺-oneline"; byte S = ushort.max;
+}
+void fail21849c()
+{
+    string s = "
+ß-utf"; undefined_identifier;
+}
+void fail21849d()
+{
+    string s = "
+☺-smiley"; s[0 .. 9];
+}


### PR DESCRIPTION
`utf_decodeChar` already deals with incrementing the current byte column position by 1, 2 or 4, so `verrorPrint` doesn't have to worry about printing the correct number of leading spaces counting the number of display columns itself.