### PR TITLE
Fix typo in AliasAssign constructor

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -2170,7 +2170,7 @@ extern (C++) final class AliasAssign : Dsymbol
     Dsymbol aliassym; /// replace previous RHS of AliasDeclaration with `aliassym`
                       /// only one of type and aliassym can be != null
 
-    extern (D) this(const ref Loc loc, Identifier ident, Type type, Dsymbol aliasssym)
+    extern (D) this(const ref Loc loc, Identifier ident, Type type, Dsymbol aliassym)
     {
         super(loc, null);
         this.ident = ident;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -6621,7 +6621,7 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
     // pass to distinguish.
     // If it is a type, then `.type` is set and getType() will return that
     // type. If it is a symbol, then `.aliassym` is set and type is `null` -
-    // toAlias() will return `.aliasssym`
+    // toAlias() will return `.aliassym`
 
     const errors = global.errors;
     Type oldtype = ds.type;


### PR DESCRIPTION
In theory `AliasAssign.syntaxCopy` could trigger faulty behavior, so targeting stable.
Fixed the same typo in a comment elsewhere.