### PR TITLE
fix Issue 16689 - Errors in instantiated mixin templates should show instantiation point

### DIFF
--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -208,6 +208,8 @@ private extern(C++) final class Semantic2Visitor : Visitor
             assert(sc);
             sc = sc.push(tmix.argsym);
             sc = sc.push(tmix);
+            sc.tinst = tmix;
+            sc.minst = tmix.minst;
             for (size_t i = 0; i < tmix.members.dim; i++)
             {
                 Dsymbol s = (*tmix.members)[i];

--- a/test/fail_compilation/fail16689.d
+++ b/test/fail_compilation/fail16689.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail16689.d(3): Error: static assert:  "false"
+fail_compilation/fail16689.d(6):        instantiated from here: `Issue16689!()`
+---
+*/
+#line 1
+mixin template Issue16689()
+{
+    static assert(false, "false");
+}
+
+mixin Issue16689!();

--- a/test/fail_compilation/fail6334.d
+++ b/test/fail_compilation/fail6334.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6334.d(12): Error: static assert:  `0` is false
+fail_compilation/fail6334.d(13): Error: static assert:  `0` is false
+fail_compilation/fail6334.d(11):        instantiated from here: `T2!()`
 ---
 */
 


### PR DESCRIPTION
Template mixins are a kind of enclosing template instance that the Scope was instantiated from.

Setting it in semantic2, same as TemplateInstance, allows static asserts to follow the instantiation context from mixins.

Give this PR a little while to allow time to decide whether this is correct, given that template mixins have a hybrid status between `isTemplateInstance() == true` and `isInstantiated() == false`