### PR TITLE
set backend up for cross compilation for windows

### DIFF
--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -56,7 +56,8 @@ extern (C) void out_config_init(
         bool useTypeInfo,       // implement TypeInfo
         bool useExceptions,     // implement exception handling
         ubyte dwarf,            // DWARF version used
-        string _version         // Compiler version
+        string _version,         // Compiler version
+        exefmt_t exefmt            // Executable file format
         )
 {
 version (MARS)
@@ -73,6 +74,7 @@ version (MARS)
     config.inline8087 = 1;
     config.memmodel = 0;
     config.flags |= CFGuchar;   // make sure TYchar is unsigned
+    config.exe = exefmt;
     tytab[TYchar] |= TYFLuns;
     bool mscoff = model & 1;
     model &= 32 | 64;
@@ -93,10 +95,10 @@ version (MARS)
         config.dwarf = dwarf;
     }
 
-static if (TARGET_WINDOS)
+if (config.exe & EX_windos)
 {
     if (model == 64)
-    {   config.exe = EX_WIN64;
+    {
         config.fpxmmregs = true;
         config.avx = avx;
         config.ehmethod = useExceptions ? EHmethod.EH_DM : EHmethod.EH_NONE;
@@ -108,7 +110,6 @@ static if (TARGET_WINDOS)
     }
     else
     {
-        config.exe = EX_WIN32;
         config.ehmethod = useExceptions ? EHmethod.EH_WIN32 : EHmethod.EH_NONE;
         if (mscoff)
             config.flags |= CFGnoebp;       // test suite fails without this
@@ -301,7 +302,7 @@ static if (SYMDEB_DWARF)
         configv.addlinenumbers = 1;
         config.fulltypes = (symdebug == 1) ? CVDWARF_D : CVDWARF_C;
 }
-static if (SYMDEB_CODEVIEW)
+if (SYMDEB_CODEVIEW)
 {
         if (config.objfmt == OBJ_MSCOFF)
         {
@@ -432,16 +433,13 @@ else static if (TARGET_OSX)
     _tysize[TYildouble] = 16;
     _tysize[TYcldouble] = 32;
 }
-else static if (TARGET_WINDOS)
+if (config.exe & EX_windos)
 {
     _tysize[TYldouble] = 10;
     _tysize[TYildouble] = 10;
     _tysize[TYcldouble] = 20;
 }
-else
-{
-    assert(0);
-}
+
     _tysize[TYsptr] = LONGSIZE;
     _tysize[TYcptr] = LONGSIZE;
     _tysize[TYfptr] = 6;     // NOTE: There are codgen test that check
@@ -466,16 +464,13 @@ else static if (TARGET_OSX)
     _tyalignsize[TYildouble] = 16;
     _tyalignsize[TYcldouble] = 16;
 }
-else static if (TARGET_WINDOS)
+if (config.exe & EX_windos)
 {
     _tyalignsize[TYldouble] = 2;
     _tyalignsize[TYildouble] = 2;
     _tyalignsize[TYcldouble] = 2;
 }
-else
-{
-    assert(0);
-}
+
     _tyalignsize[TYsptr] = LONGSIZE;
     _tyalignsize[TYcptr] = LONGSIZE;
     _tyalignsize[TYfptr] = LONGSIZE;     // NOTE: There are codgen test that check
@@ -518,16 +513,12 @@ static if (TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_DRAGONFLYB
     _tysize[TYildouble] = 16;
     _tysize[TYcldouble] = 32;
 }
-else static if (TARGET_WINDOS)
-{
-    _tysize[TYldouble] = 10;
-    _tysize[TYildouble] = 10;
-    _tysize[TYcldouble] = 20;
-}
-else
-{
-    assert(0);
-}
+    if (config.exe & EX_windos)
+    {
+        _tysize[TYldouble] = 10;
+        _tysize[TYildouble] = 10;
+        _tysize[TYcldouble] = 20;
+    }
     _tysize[TYsptr] = 8;
     _tysize[TYcptr] = 8;
     _tysize[TYfptr] = 10;    // NOTE: There are codgen test that check
@@ -552,16 +543,12 @@ else static if (TARGET_OSX)
     _tyalignsize[TYildouble] = 16;
     _tyalignsize[TYcldouble] = 16;
 }
-else static if (TARGET_WINDOS)
-{
-    _tyalignsize[TYldouble] = 2;
-    _tyalignsize[TYildouble] = 2;
-    _tyalignsize[TYcldouble] = 2;
-}
-else
-{
-    assert(0);
-}
+    if (config.exe & EX_windos)
+    {
+        _tyalignsize[TYldouble] = 2;
+        _tyalignsize[TYildouble] = 2;
+        _tyalignsize[TYcldouble] = 2;
+    }
     _tyalignsize[TYsptr] = 8;
     _tyalignsize[TYcptr] = 8;
     _tyalignsize[TYfptr] = 8;

--- a/src/dmd/backend/cgen.d
+++ b/src/dmd/backend/cgen.d
@@ -388,7 +388,7 @@ static if (TARGET_OSX)
 }
 
         size_t numbytes;
-static if (TARGET_SEGMENTED)
+if (TARGET_SEGMENTED)
 {
         switch (flags & (CFoff | CFseg))
         {
@@ -404,7 +404,7 @@ else
         if (I64 && !(flags & CFoffset64))
             numbytes = 4;
 
-static if (TARGET_WINDOS)
+if (config.exe & EX_windos)
 {
         /* This can happen when generating CV8 data
          */

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -53,7 +53,8 @@ extern (C) void out_config_init(
         bool useTypeInfo,       // implement TypeInfo
         bool useExceptions,     // implement exception handling
         ubyte dwarf,            // DWARF version used
-        string _version         // Compiler version
+        string _version,        // Compiler version
+        exefmt_t exefmt         // Executable file format
         );
 
 void out_config_debug(
@@ -74,6 +75,18 @@ void backend_init()
 {
     //printf("out_config_init()\n");
     Param *params = &global.params;
+    exefmt_t exfmt;
+    switch (target.os)
+    {
+        case Target.OS.Windows: exfmt = target.is64bit ? EX_WIN64 : EX_WIN32;       break;
+        case Target.OS.linux:   exfmt = target.is64bit ? EX_LINUX64 : EX_LINUX;     break;
+        case Target.OS.OSX:     exfmt = target.is64bit ? EX_OSX64 : EX_OSX;         break;
+        case Target.OS.FreeBSD: exfmt = target.is64bit ? EX_FREEBSD64 : EX_FREEBSD; break;
+        case Target.OS.OpenBSD: exfmt = target.is64bit ? EX_OPENBSD64 : EX_OPENBSD; break;
+        case Target.OS.Solaris: exfmt = target.is64bit ? EX_SOLARIS64 : EX_SOLARIS; break;
+        case Target.OS.DragonFlyBSD: exfmt = EX_DRAGONFLYBSD64; break;
+        default: assert(0);
+    }
 
     bool exe;
     if (params.dll || params.pic != PIC.fixed)
@@ -104,7 +117,8 @@ void backend_init()
         params.useTypeInfo && Type.dtypeinfo,
         params.useExceptions && ClassDeclaration.throwable,
         dmdParams.dwarf,
-        global.versionString()
+        global.versionString(),
+        exfmt
     );
 
     debug


### PR DESCRIPTION
this removes the use of `static if (TARGET_WINDOS)` and replaces it with a runtime check instead
also changes `out_config_init` to accept an `exefmt_t` to configure the backend

I'm doing this one here now because only windows seems to pass on https://github.com/dlang/dmd/pull/12429 and I'm trying to reduce surface area of that diff to fond out where POSIX seems to have gone wrong