### PR TITLE
posix.mak: Run unittest directly via `build.d`

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -126,8 +126,8 @@ endif
 auto-tester-test: $(GENERATED)/build
 	$(RUN_BUILD) unittest $(HEADER_TEST)
 
-unittest: $G/dmd-unittest
-	$<
+unittest: $(GENERATED)/build
+	$(RUN_BUILD) $@
 
 ######## Manual cleanup
 


### PR DESCRIPTION
`build.d` will rerun a failing test with `gdb` in case of a segfault,...