### PR TITLE
add -> and :: tokens

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -479,7 +479,9 @@ enum class TOK : uint8_t
     showCtfeContext = 232u,
     objcClassReference = 233u,
     vectorArray = 234u,
-    max_ = 235u,
+    arrow = 235u,
+    colonColon = 236u,
+    max_ = 237u,
 };
 
 class StringExp;

--- a/src/dmd/iasmgcc.d
+++ b/src/dmd/iasmgcc.d
@@ -429,9 +429,24 @@ unittest
         {
             if (p.token.value == TOK.rightCurly || p.token.value == TOK.endOfFile)
                 break;
-            *ptoklist = p.allocateToken();
-            memcpy(*ptoklist, &p.token, Token.sizeof);
-            ptoklist = &(*ptoklist).next;
+            if (p.token.value == TOK.colonColon)
+            {
+                *ptoklist = p.allocateToken();
+                memcpy(*ptoklist, &p.token, Token.sizeof);
+                (*ptoklist).value = TOK.colon;
+                ptoklist = &(*ptoklist).next;
+
+                *ptoklist = p.allocateToken();
+                memcpy(*ptoklist, &p.token, Token.sizeof);
+                (*ptoklist).value = TOK.colon;
+                ptoklist = &(*ptoklist).next;
+            }
+            else
+            {
+                *ptoklist = p.allocateToken();
+                memcpy(*ptoklist, &p.token, Token.sizeof);
+                ptoklist = &(*ptoklist).next;
+            }
             *ptoklist = null;
             p.nextToken();
         }
@@ -483,6 +498,12 @@ unittest
         // Likewise mixins, permissible so long as the result is a string.
         q{ asm { mixin(`"repne"`, `~ "scasb"`);
         } },
+
+        // :: token tests
+        q{ asm { "" : : : "memory"; } },
+        q{ asm { "" :: : "memory"; } },
+        q{ asm { "" : :: "memory"; } },
+        q{ asm { "" ::: "memory"; } },
     ];
 
     immutable string[] failAsmTests = [

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -844,6 +844,11 @@ class Lexer
                     p++;
                     t.value = TOK.minusMinus;
                 }
+                else if (*p == '>')
+                {
+                    ++p;
+                    t.value = TOK.arrow;
+                }
                 else
                     t.value = TOK.min;
                 return;
@@ -1009,7 +1014,13 @@ class Lexer
                 return;
             case ':':
                 p++;
-                t.value = TOK.colon;
+                if (*p == ':')
+                {
+                    ++p;
+                    t.value = TOK.colonColon;
+                }
+                else
+                    t.value = TOK.colon;
                 return;
             case '$':
                 p++;

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -287,6 +287,9 @@ enum TOK : ubyte
     objcClassReference,
     vectorArray,
 
+    arrow,      // ->
+    colonColon, // ::
+
     max_,
 }
 
@@ -651,6 +654,8 @@ extern (C++) struct Token
         TOK.powAssign: "^^=",
         TOK.goesTo: "=>",
         TOK.pound: "#",
+        TOK.arrow: "->",
+        TOK.colonColon: "::",
 
         // For debugging
         TOK.error: "error",

--- a/test/unit/lexer/location_offset.d
+++ b/test/unit/lexer/location_offset.d
@@ -450,6 +450,9 @@ enum Test[string] tests = [
     "goesTo" : Test("fat arrow", "=>"),
     "vector" : Test("__vector"),
     "pound" : Test("pound", "#"),
+
+    "arrow" : Test("arrow", "->"),
+    "colonColon" : Test("colonColon", "::"),
 ];
 
 // Ignore tokens not produced by the lexer or tested above


### PR DESCRIPTION
Makes the detection of code mis-translated from C and C++ to D less hackish.