### PR TITLE
[backend/cgen.d] remove use of static if(TARGET_OSX)

### DIFF
--- a/src/dmd/backend/cgen.d
+++ b/src/dmd/backend/cgen.d
@@ -358,10 +358,7 @@ struct Fixup
     int         flags;      // CFxxxx
     targ_size_t offset;     // addr of reference to Symbol
     targ_size_t val;        // value to add into location
-static if (TARGET_OSX)
-{
     Symbol      *funcsym;   // function the Symbol goes in
-}
 }
 
 private __gshared Barray!Fixup fixups;
@@ -382,10 +379,7 @@ size_t addtofixlist(Symbol *s,targ_size_t offset,int seg,targ_size_t val,int fla
         f.seg = seg;
         f.flags = flags;
         f.val = val;
-static if (TARGET_OSX)
-{
         f.funcsym = funcsym_p;
-}
 
         size_t numbytes;
 if (TARGET_SEGMENTED)
@@ -486,7 +480,7 @@ else // MARS
         }
     }
 
-static if (TARGET_OSX)
+if (config.exe & (EX_OSX | EX_OSX64))
 {
     Symbol *funcsymsave = funcsym_p;
     funcsym_p = f.funcsym;


### PR DESCRIPTION
part of the effort to make DMD a cross compiler