### PR TITLE
Fix Issue 21861 - ctfe fails when a nested enum or function has a UDA

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2225,6 +2225,12 @@ public:
             printf("%s DeclarationExp::interpret() %s\n", e.loc.toChars(), e.toChars());
         }
         Dsymbol s = e.declaration;
+        while (s.isAttribDeclaration())
+        {
+            auto ad = cast(AttribDeclaration)s;
+            assert(ad.decl && ad.decl.dim == 1); // Currently, only one allowed when parsing
+            s = (*ad.decl)[0];
+        }
         if (VarDeclaration v = s.isVarDeclaration())
         {
             if (TupleDeclaration td = v.toAlias().isTupleDeclaration())
@@ -2307,20 +2313,8 @@ public:
             }
             return;
         }
-        if (s.isAttribDeclaration() || s.isTemplateMixin() || s.isTupleDeclaration())
+        if (s.isTemplateMixin() || s.isTupleDeclaration())
         {
-            // Check for static struct declarations, which aren't executable
-            AttribDeclaration ad = e.declaration.isAttribDeclaration();
-            if (ad && ad.decl && ad.decl.dim == 1)
-            {
-                Dsymbol sparent = (*ad.decl)[0];
-                if (sparent.isAggregateDeclaration() || sparent.isTemplateDeclaration() || sparent.isAliasDeclaration())
-                {
-                    result = null;
-                    return; // static (template) struct declaration. Nothing to do.
-                }
-            }
-
             // These can be made to work, too lazy now
             e.error("declaration `%s` is not yet implemented in CTFE", e.toChars());
             result = CTFEExp.cantexp;

--- a/test/compilable/test21861.d
+++ b/test/compilable/test21861.d
@@ -1,0 +1,38 @@
+// https://issues.dlang.org/show_bug.cgi?id=21861
+
+int f() {
+    @("S")
+    struct S {}
+
+    @("U")
+    union U {}
+
+    @("C")
+    class C {}
+
+    // OK <- CTFE fails on this:
+    @("E")
+    enum E { X }
+
+    // OK <- CTFE fails on this:
+    @("f")
+    int f(int x) { return x + 2; }
+
+    // OK <- CTFE fails on this:
+    @(&f) int a;
+    @(1) @(2) int b = 4, c;
+    @(3) extern(C) int d = 3;
+
+    enum uda1 = __traits(getAttributes, a);
+    enum uda2 = __traits(getAttributes, b);
+    enum uda3 = __traits(getAttributes, c);
+
+    // These are to trigger a compiler assert if parser is updated in the future
+    static assert(!__traits(compiles, mixin("{ @(1) { int x; int y; } }")));
+    static assert(!__traits(compiles, mixin("{ @(1): int x; int y; }")));
+
+    //        3+2         1         2       4      1      3
+    return uda1[0](3) + uda2[0] + uda2[1] + b + uda3[0] + d;
+}
+
+static assert(f() == 16);


### PR DESCRIPTION
If declaration is an UDA just eval the symbol it contains.