### PR TITLE
replace hardcoded extensions with enums

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1562,7 +1562,7 @@ struct ASTBase
         {
             super(ident);
             this.arg = filename;
-            srcfile = FileName(FileName.defaultExt(filename.toDString, global.mars_ext));
+            srcfile = FileName(FileName.defaultExt(filename.toDString, mars_ext));
         }
 
         override void accept(Visitor v)

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -361,7 +361,7 @@ private TemplateDeclaration getEponymousParent(Dsymbol s)
     return (td && getEponymousMember(td)) ? td : null;
 }
 
-private immutable ddoc_default = import("default_ddoc_theme.ddoc");
+private immutable ddoc_default = import("default_ddoc_theme." ~ ddoc_ext);
 private immutable ddoc_decl_s = "$(DDOC_DECL ";
 private immutable ddoc_decl_e = ")\n";
 private immutable ddoc_decl_dd_s = "$(DDOC_DECL_DD ";

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7279,13 +7279,6 @@ typedef uint32_t structalign_t;
 struct Global
 {
     _d_dynamicArray< const char > inifilename;
-    _d_dynamicArray< const char > mars_ext;
-    _d_dynamicArray< const char > doc_ext;
-    _d_dynamicArray< const char > ddoc_ext;
-    _d_dynamicArray< const char > hdr_ext;
-    _d_dynamicArray< const char > cxxhdr_ext;
-    _d_dynamicArray< const char > json_ext;
-    _d_dynamicArray< const char > map_ext;
     _d_dynamicArray< const char > copyright;
     _d_dynamicArray< const char > written;
     Array<const char* >* path;
@@ -7311,13 +7304,6 @@ struct Global
     ~Global();
     Global() :
         inifilename(),
-        mars_ext(1, "d"),
-        doc_ext(4, "html"),
-        ddoc_ext(4, "ddoc"),
-        hdr_ext(2, "di"),
-        cxxhdr_ext(1, "h"),
-        json_ext(4, "json"),
-        map_ext(3, "map"),
         copyright(73, "Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved"),
         written(24, "written by Walter Bright"),
         path(),
@@ -7334,15 +7320,8 @@ struct Global
         debugids()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > mars_ext = { 1, "d" }, _d_dynamicArray< const char > doc_ext = { 4, "html" }, _d_dynamicArray< const char > ddoc_ext = { 4, "ddoc" }, _d_dynamicArray< const char > hdr_ext = { 2, "di" }, _d_dynamicArray< const char > cxxhdr_ext = { 1, "h" }, _d_dynamicArray< const char > json_ext = { 4, "json" }, _d_dynamicArray< const char > map_ext = { 3, "map" }, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, 0u, false, false, (DiagnosticReporting)1u, false, false, false, (FeatureState)-1, false, false, false, (DiagnosticReporting)2u, (PIC)0u, false, false, 0u, false, false, false, true, true, true, false, false, false, false, false, false, false, false, false, false, false, (FeatureState)-1, false, false, (CppStdRevision)201103u, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKACTION)0u, 20u, {}, Array<const char* >(0LLU, {}, arrayliteral), nullptr, nullptr, {}, {}, {}, false, {}, {}, Array<const char* >(0LLU, {}, arrayliteral), false, {}, {}, true, (CxxHeaderMode)0u, {}, {}, false, {}, (JsonFieldFlags)0u, nullptr, nullptr, 0, 0u, nullptr, 0u, nullptr, {}, {}, {}, {}, nullptr, false, {}, Array<const char* >(0LLU, {}, arrayliteral), (MessageStyle)0u, false, Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<bool >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), {}, {}, {}, {}), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, 0u, false, false, (DiagnosticReporting)1u, false, false, false, (FeatureState)-1, false, false, false, (DiagnosticReporting)2u, (PIC)0u, false, false, 0u, false, false, false, true, true, true, false, false, false, false, false, false, false, false, false, false, false, (FeatureState)-1, false, false, (CppStdRevision)201103u, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKACTION)0u, 20u, {}, Array<const char* >(0LLU, {}, arrayliteral), nullptr, nullptr, {}, {}, {}, false, {}, {}, Array<const char* >(0LLU, {}, arrayliteral), false, {}, {}, true, (CxxHeaderMode)0u, {}, {}, false, {}, (JsonFieldFlags)0u, nullptr, nullptr, 0, 0u, nullptr, 0u, nullptr, {}, {}, {}, {}, nullptr, false, {}, Array<const char* >(0LLU, {}, arrayliteral), (MessageStyle)0u, false, Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<bool >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), {}, {}, {}, {}), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr) :
         inifilename(inifilename),
-        mars_ext(mars_ext),
-        doc_ext(doc_ext),
-        ddoc_ext(ddoc_ext),
-        hdr_ext(hdr_ext),
-        cxxhdr_ext(cxxhdr_ext),
-        json_ext(json_ext),
-        map_ext(map_ext),
         copyright(copyright),
         written(written),
         path(path),

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -261,16 +261,17 @@ alias structalign_t = uint;
 // other values are all powers of 2
 enum STRUCTALIGN_DEFAULT = (cast(structalign_t)~0);
 
+enum mars_ext = "d";
+enum doc_ext  = "html";     // for Ddoc generated files
+enum ddoc_ext = "ddoc";     // for Ddoc macro include files
+enum dd_ext   = "dd";       // for Ddoc source files
+enum hdr_ext  = "di";       // for D 'header' import files
+enum json_ext = "json";     // for JSON files
+enum map_ext  = "map";      // for .map files
+
 extern (C++) struct Global
 {
     const(char)[] inifilename;
-    string mars_ext = "d";
-    string doc_ext = "html";      // for Ddoc generated files
-    string ddoc_ext = "ddoc";     // for Ddoc macro include files
-    string hdr_ext = "di";        // for D 'header' import files
-    string cxxhdr_ext = "h";      // for C/C++ 'header' files
-    string json_ext = "json";     // for JSON files
-    string map_ext = "map";       // for .map files
 
     string copyright = "Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved";
     string written = "written by Walter Bright";

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -243,17 +243,17 @@ typedef unsigned structalign_t;
 // other values are all powers of 2
 #define STRUCTALIGN_DEFAULT ((structalign_t) ~0)
 
+const DString mars_ext = "d";
+const DString doc_ext  = "html";     // for Ddoc generated files
+const DString ddoc_ext = "ddoc";     // for Ddoc macro include files
+const DString dd_ext   = "dd";       // for Ddoc source files
+const DString hdr_ext  = "di";       // for D 'header' import files
+const DString json_ext = "json";     // for JSON files
+const DString map_ext  = "map";      // for .map files
+
 struct Global
 {
     DString inifilename;
-    const DString mars_ext;
-    const DString doc_ext;      // for Ddoc generated files
-    const DString ddoc_ext;     // for Ddoc macro include files
-    const DString hdr_ext;      // for D 'header' import files
-    const DString cxxhdr_ext;   // for C/C++ 'header' files
-    const DString json_ext;     // for JSON files
-    const DString map_ext;      // for .map files
-
 
     const DString copyright;
     const DString written;

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -216,7 +216,7 @@ public int runLINK()
 
     const(char)[] getMapFilename()
     {
-        const(char)[] fn = FileName.forceExt(global.params.exefile, "map");
+        const(char)[] fn = FileName.forceExt(global.params.exefile, map_ext);
         const(char)[] path = FileName.path(global.params.exefile);
         return path.length ? fn : FileName.combine(global.params.objdir, fn);
     }
@@ -593,7 +593,7 @@ public int runLINK()
             }
             if (!global.params.mapfile.length)
             {
-                const(char)[] fn = FileName.forceExt(global.params.exefile, "map");
+                const(char)[] fn = FileName.forceExt(global.params.exefile, map_ext);
                 const(char)[] path = FileName.path(global.params.exefile);
                 global.params.mapfile = path.length ? fn : FileName.combine(global.params.objdir, fn);
             }

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -919,7 +919,7 @@ extern (C++) void generateJson(Modules* modules)
         const(char)[] jsonfilename;
         if (name)
         {
-            jsonfilename = FileName.defaultExt(name, global.json_ext);
+            jsonfilename = FileName.defaultExt(name, json_ext);
         }
         else
         {
@@ -933,7 +933,7 @@ extern (C++) void generateJson(Modules* modules)
             n = FileName.name(n);
             //if (!FileName::absolute(name))
             //    name = FileName::combine(dir, name);
-            jsonfilename = FileName.forceExt(n, global.json_ext);
+            jsonfilename = FileName.forceExt(n, json_ext);
         }
         writeFile(Loc.initial, jsonfilename, buf[]);
     }
@@ -2420,7 +2420,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             {
                 const(char)[] runarg = arguments[i + 1].toDString();
                 const(char)[] ext = FileName.ext(runarg);
-                if (ext && FileName.equals(ext, "d") == 0 && FileName.equals(ext, "di") == 0)
+                if (ext && FileName.equals(ext, mars_ext) == 0 && FileName.equals(ext, hdr_ext) == 0)
                 {
                     error("-run must be followed by a source file, not '%s'", arguments[i + 1]);
                     break;
@@ -2718,18 +2718,18 @@ Module createModule(const(char)* file, ref Strings libmodules)
             return null;
         }
     }
-    if (ext == global.ddoc_ext)
+    if (ext == ddoc_ext)
     {
         global.params.ddocfiles.push(file);
         return null;
     }
-    if (FileName.equals(ext, global.json_ext))
+    if (FileName.equals(ext, json_ext))
     {
         global.params.doJsonGeneration = true;
         global.params.jsonfilename = file.toDString;
         return null;
     }
-    if (FileName.equals(ext, global.map_ext))
+    if (FileName.equals(ext, map_ext))
     {
         global.params.mapfile = file.toDString;
         return null;
@@ -2754,7 +2754,7 @@ Module createModule(const(char)* file, ref Strings libmodules)
     /* Examine extension to see if it is a valid
         * D source file extension
         */
-    if (FileName.equals(ext, global.mars_ext) || FileName.equals(ext, global.hdr_ext) || FileName.equals(ext, "dd"))
+    if (FileName.equals(ext, mars_ext) || FileName.equals(ext, hdr_ext) || FileName.equals(ext, dd_ext))
     {
         name = FileName.removeExt(p);
         if (!name.length || name == ".." || name == ".")


### PR DESCRIPTION
1. this makes them much easier to unambiguously grep for
2. enums enable constant folding in some cases
3. removed unused `cxxhdr_ext`
4. added `dd_ext`
5. enums are immutable