### PR TITLE
dmd.dtoh: Fix building dtoh with soft ctfloat type

### DIFF
--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -2351,7 +2351,7 @@ public:
         }
         else if (CTFloat.isInfinity(e.value))
         {
-            if (e.value < 0)
+            if (e.value < CTFloat.zero)
                 buf.writeByte('-');
             buf.writestring("INFINITY");
         }


### PR DESCRIPTION
This fixes a use that was introduced in #7698.