### PR TITLE
dmd.expressionsem: Remove local variable from makeThis2Argument path.

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5163,8 +5163,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
                 }
             }
-            VarDeclaration vthis2 = makeThis2Argument(exp.loc, sc, exp.f);            exp.vthis2 = vthis2;
-            Expression de = new DeclarationExp(exp.loc, vthis2);
+            exp.vthis2 = makeThis2Argument(exp.loc, sc, exp.f);
+            Expression de = new DeclarationExp(exp.loc, exp.vthis2);
             result = Expression.combine(de, result);
             result = result.expressionSemantic(sc);
         }


### PR DESCRIPTION
Flagged because the missing newline in the code just looks weird.  On review, the local is not needed either.