### PR TITLE
replace TOK.max_ with proper TOK.max+1

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -481,7 +481,6 @@ enum class TOK : uint8_t
     vectorArray = 234u,
     arrow = 235u,
     colonColon = 236u,
-    max_ = 237u,
 };
 
 class StringExp;

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -284,7 +284,7 @@ enum ADDFWAIT = false;
 alias ASMTK = int;
 enum
 {
-    ASMTKlocalsize = TOK.max_ + 1,
+    ASMTKlocalsize = TOK.max + 1,
     ASMTKdword,
     ASMTKeven,
     ASMTKfar,
@@ -294,7 +294,7 @@ enum
     ASMTKqword,
     ASMTKseg,
     ASMTKword,
-    ASMTKmax = ASMTKword-(TOK.max_+1)+1
+    ASMTKmax = ASMTKword - ASMTKlocalsize + 1
 }
 
 immutable char*[ASMTKmax] apszAsmtk =
@@ -3446,7 +3446,7 @@ void asm_token_trans(Token *tok)
             {
                 ASMTK asmtk = cast(ASMTK) binary(id.ptr, cast(const(char)**)apszAsmtk.ptr, ASMTKmax);
                 if (cast(int)asmtk >= 0)
-                    asmstate.tokValue = cast(TOK) (asmtk + TOK.max_ + 1);
+                    asmstate.tokValue = cast(TOK) (asmtk + ASMTKlocalsize);
             }
         }
     }

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -49,7 +49,7 @@ private enum CARRAYDECL = 1;
  *
  * Used by hdrgen
  */
-immutable PREC[TOK.max_] precedence =
+immutable PREC[TOK.max + 1] precedence =
 [
     TOK.type : PREC.expr,
     TOK.error : PREC.expr,

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -289,8 +289,6 @@ enum TOK : ubyte
 
     arrow,      // ->
     colonColon, // ::
-
-    max_,
 }
 
 // Assert that all token enum members have consecutive values and
@@ -464,7 +462,7 @@ extern (C++) struct Token
         Identifier ident;
     }
 
-    extern (D) private static immutable string[TOK.max_] tochars =
+    extern (D) private static immutable string[TOK.max + 1] tochars =
     [
         // Keywords
         TOK.this_: "this",

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -184,6 +184,9 @@ enum
         TOKobjc_class_reference,
         TOKvectorarray,
 
+        TOKarrow,
+        TOKcolonColon,
+
         TOKMAX
 };
 

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -101,7 +101,7 @@ void test_tokens()
     assert(strcmp(Token::toChars(TOKlparen), "(") == 0);
 
     // Last valid TOK value
-    assert(TOKvectorarray == TOKMAX - 1);
+    assert(TOKcolonColon == TOKMAX - 1);
     assert(strcmp(Token::toChars(TOKvectorarray), "vectorarray") == 0);
 }
 


### PR DESCRIPTION
The `max_` member is an anachronism from when the code was in C++ and enums did not have a `.max` property.

Note that `TOK.max_ == TOK.max + 1` since `.max` is the value of the largest enum member.