### PR TITLE
Improve error message for base class followed by interface

### DIFF
--- a/test/fail_compilation/diag21883.d
+++ b/test/fail_compilation/diag21883.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag21883.d(15): Error: `diag21883.ClassB`: base class must be specified first, before any interfaces.
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=21883
+
+interface InterfaceA {
+}
+
+class ClassA {
+}
+
+class ClassB: InterfaceA, ClassA {
+}


### PR DESCRIPTION
The spec requires base class to be listed first, but if you flip it, the
compiler complains about multiple inheritance instead of just hinting
that you need to reorder your list. This makes the error message a
little more user-friendly.