### PR TITLE
fix Issue 21880 - [REG 2.095] scope variable assigned to non-scope parameter calling function

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2339,7 +2339,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
 
                 /* Declare temporary 'auto __pfx = arg' (needsDtor) or 'auto __pfy = arg' (!needsDtor)
                  */
-                auto tmp = copyToTemp(0,
+                auto tmp = copyToTemp(parameter.storageClass & (STC.scope_),
                     needsDtor ? "__pfx" : "__pfy",
                     !isRef ? arg : arg.addressOf());
                 tmp.dsymbolSemantic(sc);

--- a/test/compilable/issue21880.d
+++ b/test/compilable/issue21880.d
@@ -1,0 +1,23 @@
+// REQUIRED_ARGS: -preview=dip1000
+// https://issues.dlang.org/show_bug.cgi?id=21880
+extern(C++):
+void spawnProcess(scope const(char*)*, File = File()) @safe
+{
+}
+
+void pipeProcess(scope const(char*)* args) @safe
+{
+    pipeProcessImpl!spawnProcess(args);
+}
+
+void pipeProcessImpl(alias spawnFunc, Cmd)(Cmd command) @trusted
+{
+    spawnFunc(command);
+}
+
+struct File
+{
+    ~this() @safe
+    {
+    }
+}


### PR DESCRIPTION
Propagate `scope` from the parameter to the temporary that is being created for it.

However... it does seem suspect that a temporary is being created for a type that doesn't need it, just because another parameter needs destruction.

The inverse of this fix would be to constrain `needsPrefix` to not be true for trivial/pod types, or `scope` parameters.