### PR TITLE
Improve error message for missing response file

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -722,8 +722,8 @@ bool parseCommandlineAndConfig(size_t argc, const(char)** argv, ref Param params
             return badArgs();
         arguments[i] = argv[i];
     }
-    if (!responseExpand(arguments)) // expand response files
-        error(Loc.initial, "can't open response file");
+    if (const(char)* missingFile = responseExpand(arguments)) // expand response files
+        error(Loc.initial, "cannot open response file '%s'", missingFile);
     //for (size_t i = 0; i < arguments.dim; ++i) printf("arguments[%d] = '%s'\n", i, arguments[i]);
     files.reserve(arguments.dim - 1);
     // Set default values

--- a/test/fail_compilation/responsefile.d
+++ b/test/fail_compilation/responsefile.d
@@ -1,0 +1,8 @@
+// REQUIRED_ARGS: @ABC
+
+/*
+TEST_OUTPUT:
+---
+Error: cannot open response file '@ABC'
+---
+*/


### PR DESCRIPTION
Instead of just telling "can't open response file", it now tells which response file it could not expand. Example:
```
ABC=@def dmd @ABC
Error: cannot open response file '@def'
```
