### PR TITLE
fix Issue 21882 - [ICE, dip1021] src/dmd/escape.d(1850): Assertion failure

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1862,9 +1862,10 @@ void escapeByRef(Expression e, EscapeByResults* er, bool live = false)
                      */
                     if (ExpInitializer ez = v._init.isExpInitializer())
                     {
-                        assert(ez.exp && ez.exp.op == TOK.construct);
-                        Expression ex = (cast(ConstructExp)ez.exp).e2;
-                        ex.accept(this);
+                        if (auto ce = ez.exp.isConstructExp())
+                            ce.e2.accept(this);
+                        else
+                            ez.exp.accept(this);
                     }
                 }
                 else

--- a/test/compilable/issue21882.d
+++ b/test/compilable/issue21882.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -preview=dip1021
+// https://issues.dlang.org/show_bug.cgi?id=21882
+bool buildPath()
+{
+    struct ByCodeUnitImpl
+    {
+        auto opIndex(size_t) { }
+    }
+    return isRandomAccessRange!ByCodeUnitImpl;
+}
+
+enum isRandomAccessRange(R) = is(typeof(lvalueOf!R[1]));
+
+ref T lvalueOf(T)();


### PR DESCRIPTION
`ref` temporaries are not necessarily initialized by a construct expression, as the assert assumes.