### PR TITLE
fix Issue 21874 - The test suite fails with most recent GDB versions

### DIFF
--- a/test/runnable/gdb1.d
+++ b/test/runnable/gdb1.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -g
 PERMUTE_ARGS:
 GDB_SCRIPT:
 ---
-b 15
+b gdb1.d:15
 r ARG1 ARG2
 echo RESULT=
 p args

--- a/test/runnable/gdb10311.d
+++ b/test/runnable/gdb10311.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -g
 PERMUTE_ARGS:
 GDB_SCRIPT:
 ---
-b 19
+b gdb10311.d:19
 r
 echo RESULT=
 p x

--- a/test/runnable/gdb14225.d
+++ b/test/runnable/gdb14225.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -g
 PERMUTE_ARGS:
 GDB_SCRIPT:
 ---
-b 17
+b gdb14225.d:17
 r
 echo RESULT=
 p lok

--- a/test/runnable/gdb14276.d
+++ b/test/runnable/gdb14276.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -g
 PERMUTE_ARGS:
 GDB_SCRIPT:
 ---
-b 21
+b gdb14276.d:21
 r
 echo RESULT=
 p v[0] + v[1] + v[2] + v[3]

--- a/test/runnable/gdb14313.d
+++ b/test/runnable/gdb14313.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -g
 PERMUTE_ARGS:
 GDB_SCRIPT:
 ---
-b 21
+b gdb14313.d:21
 r
 echo RESULT=
 p 'gdb.x' + 'gdb.y'

--- a/test/runnable/gdb14330.d
+++ b/test/runnable/gdb14330.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -g
 PERMUTE_ARGS:
 GDB_SCRIPT:
 ---
-b 20
+b gdb14330.d:20
 r
 echo RESULT=
 p str

--- a/test/runnable/gdb4149.d
+++ b/test/runnable/gdb4149.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -g
 PERMUTE_ARGS:
 GDB_SCRIPT:
 ---
-b 17
+b gdb4149.d:17
 r
 echo RESULT=
 p x

--- a/test/runnable/gdb4181.d
+++ b/test/runnable/gdb4181.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -g
 PERMUTE_ARGS:
 GDB_SCRIPT:
 ---
-b 22
+b gdb4181.d:22
 r
 echo RESULT=
 p 'gdb.x' + 'gdb.STest.y'


### PR DESCRIPTION
Use explicit source file name in setting up breakpoints.