### PR TITLE
dmd.compiler: Remove unused rootHasMain global

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -37,9 +37,6 @@ version (DMDLIB)
 
 extern (C++) __gshared
 {
-    /// Module in which the D main is
-    Module rootHasMain = null;
-
     bool includeImports = false;
     // array of module patterns used to include/exclude imported modules
     Array!(const(char)*) includeModulePatterns;

--- a/src/dmd/compiler.h
+++ b/src/dmd/compiler.h
@@ -22,9 +22,6 @@ class Type;
 struct Scope;
 struct UnionExp;
 
-// Module in which the D main is
-extern Module *rootHasMain;
-
 extern bool includeImports;
 // array of module patterns used to include/exclude imported modules
 extern Array<const char*> includeModulePatterns;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4211,8 +4211,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 auto tm = new TemplateMixin(funcdecl.loc, null, tqual, null);
                 sc._module.members.push(tm);
             }
-
-            rootHasMain = sc._module;
         }
 
         assert(funcdecl.type.ty != Terror || funcdecl.errors);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2041,8 +2041,6 @@ enum class TargetOS : uint8_t
     Posix = 125u,
 };
 
-extern Module* rootHasMain;
-
 extern bool includeImports;
 
 extern Array<const char* > includeModulePatterns;


### PR DESCRIPTION
It was made redundant (internally) by #10351.  Library front-ends may still find it useful, but I'd rather that they add it back in with the relevant `version (DMDLIB)` blocks.