### PR TITLE
Fix Issue 21896 - static if test fails after alias assignment

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -756,6 +756,8 @@ extern (C++) final class AliasDeclaration : Declaration
 
     override bool overloadInsert(Dsymbol s)
     {
+        if (s.isAliasAssign())
+            return true;
         //printf("[%s] AliasDeclaration::overloadInsert('%s') s = %s %s @ [%s]\n",
         //       loc.toChars(), toChars(), s.kind(), s.toChars(), s.loc.toChars());
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -6817,8 +6817,13 @@ private void aliasAssignSemantic(AliasAssign ds, Scope* sc)
      */
     AliasDeclaration findAliasDeclaration(AliasAssign ds, Scope* sc)
     {
-        Dsymbol scopesym;
-        Dsymbol as = sc.search(ds.loc, ds.ident, &scopesym);
+        Dsymbol as;
+        for (Scope *sc2 = sc; sc2; sc2 = sc2.enclosing)
+        {
+            as = sc2.search(ds.loc, ds.ident, null);
+            if (!as || !as.isAliasAssign())
+                break;
+        }
         if (!as)
         {
             ds.error("undefined identifier `%s`", ds.ident.toChars());
@@ -6978,6 +6983,8 @@ private void aliasAssignSemantic(AliasAssign ds, Scope* sc)
         aliassym.aliassym = null;
     }
 
+    ds.type = null;
+    ds.aliassym = aliassym;
 
     aliassym.adFlags &= ~Declaration.ignoreRead;
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -621,11 +621,15 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         if (!(parameters && parameters.length == 1))
             return;
 
-        auto ad = s.isAliasDeclaration();
-        if (!ad || !ad.type)
+        Type type;
+        if (auto ad = s.isAliasDeclaration())
+            type = ad.type;
+        if (auto aa = s.isAliasAssign())
+            type = aa.type;
+        if (!type)
             return;
 
-        auto ti = ad.type.isTypeIdentifier();
+        auto ti = type.isTypeIdentifier();
 
         if (!ti || ti.idents.length != 0)
             return;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3067,11 +3067,11 @@ public:
 class AliasAssign final : public Dsymbol
 {
 public:
-    Identifier* ident;
     Type* type;
     Dsymbol* aliassym;
     AliasAssign* syntaxCopy(Dsymbol* s);
     AliasAssign* isAliasAssign();
+    Dsymbol* toAlias();
     const char* kind() const;
     void accept(Visitor* v);
 };

--- a/test/compilable/test21896.d
+++ b/test/compilable/test21896.d
@@ -1,0 +1,19 @@
+template Works(T)
+{
+    static if (is(T U == const U))
+    {
+        alias Works = U;
+    }
+}
+
+template Fails(T)
+{
+    alias Fails = T;
+    static if (is(T U == const U))
+    {
+        Fails = U;
+    }
+}
+
+static assert(is(Works!(const int) == int));
+static assert(is(Fails!(const int) == int));

--- a/test/fail_compilation/aliasassign.d
+++ b/test/fail_compilation/aliasassign.d
@@ -1,7 +1,7 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/aliasassign.d(13): Error: `B` must have same parent `Swap!(int, string)` as alias `B`
 fail_compilation/aliasassign.d(14): Error: `A` must have same parent `Swap!(int, string)` as alias `A`
+fail_compilation/aliasassign.d(13): Error: `B` must have same parent `Swap!(int, string)` as alias `B`
 fail_compilation/aliasassign.d(21): Error: template instance `aliasassign.Swap!(int, string)` error instantiating
 fail_compilation/aliasassign.d(21):        while evaluating: `static assert(Swap!(int, string))`
 ---


### PR DESCRIPTION
This allows an eponymous declaration using the last declared `AliasAssign`.
Need more testing.