### PR TITLE
[dmd-cxx] Fix Issue 21898 - Qualifier ignored in alias definition if parentheses are not present

### DIFF
--- a/src/dsymbolsem.c
+++ b/src/dsymbolsem.c
@@ -4880,8 +4880,11 @@ static void aliasInstanceSemantic(TemplateInstance *tempinst, Scope *sc, Templat
 
     TemplateTypeParameter *ttp = (*tempdecl->parameters)[0]->isTemplateTypeParameter();
     Type *ta = isType(tempinst->tdtypes[0]);
-    Declaration *d = new AliasDeclaration(tempinst->loc, ttp->ident, ta->addMod(tempdecl->onemember->isAliasDeclaration()->type->mod));
-    d->storage_class |= STCtemplateparameter;
+    AliasDeclaration *ad = tempdecl->onemember->isAliasDeclaration();
+
+    // Note: qualifiers can be in both 'ad.type.mod' and 'ad.storage_class'
+    Declaration *d = new AliasDeclaration(tempinst->loc, ttp->ident, ta->addMod(ad->type->mod));
+    d->storage_class |= STCtemplateparameter | ad->storage_class;
     dsymbolSemantic(d, sc);
 
     paramscope->pop();

--- a/test/compilable/test21898.d
+++ b/test/compilable/test21898.d
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=21898
+
+alias Works(T) = immutable(T);
+alias Fails(T) = immutable T;
+
+static assert(is(Works!int == immutable int));
+static assert(is(Fails!int == immutable int));


### PR DESCRIPTION
Backport from #12501