### PR TITLE
comments and whitespace for ElfObj_term()

### DIFF
--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -272,6 +272,14 @@ void obj_start(const(char)* srcfile)
 }
 
 
+/****************************************
+ * Finish creating the object module and writing it to objbuf[].
+ * Then either write the object module to an actual file,
+ * or add it to a library.
+ * Params:
+ *      objfilename = what to call the object module
+ *      library = if non-null, add object module to this library
+ */
 void obj_end(Library library, const(char)* objfilename)
 {
     objmod.term(objfilename);


### PR DESCRIPTION
* Add/improve function header comments
* Unscramble some version statements.
* Make whitespace consistent.
* Line up comments.
* Use `/* */` for block comments, not `//`