### PR TITLE
Implement -target

### DIFF
--- a/changelog/target.md
+++ b/changelog/target.md
@@ -1,0 +1,72 @@
+Add `-target=<triple>` for operating system, c, and c++ runtime cross compilation
+
+The command line switch `-target=<triple>` can be used to specify the target the
+compiler should produce code for. The format for `<triple>` is `<arch>-[<vendor>-]<os>[-<cenv>[-<cppenv]]`. Specific values of the specifiers are 
+shown in the tables below.
+
+`<arch>` 
+---------
+`<arch>` is an Architecture bitness, optionally followed by instruction set (which duplicates the functionality of the `-mcpu` flag)
+| `<arch>`  | Architecture bitness |
+| ---------- |-------------| 
+| `x86_64`  |  64 bit |
+| `x64`        |  64 bit |
+| `x86`        |  32 bit |
+| `x32`        |  64bit with 32 bit pointers |
+
+| subarch features | equivalent `-mcpu` flag |
+| ---------- |-------------| 
+| `+sse2`    | `baseline` |
+| `+avx`      |  `avx` |
+| `+avx2`    |  `avx2` |
+
+The architecture and subarch features are concatenated, so `x86_64+avx2` is 64bit with `avx2` instructions.
+
+
+`<vendor>` 
+---------
+`<vendor>` is always ignored, but supported for easier interoperability with other compilers that report and consume target triples.
+
+`<os>`
+------
+
+`<os>` is the operating system specifier. It may be optionally followed by a version number as in `darwin20.3.0` or `freebsd12`. For Freebsd, this sets the corresponding predefined `version` identifier, e.g. `freebsd12` sets `version(FreeBSD12)`. For other operating systems this is for easier interoperability with other compilers.
+
+| `<os>` | Operating system | 
+| ---------- |-------------| 
+| `freestanding` | No operating system |
+| `darwin` | MacOS | 
+| `dragonfly` | DragonflyBSD | 
+| `freebsd` | FreeBSD |
+| `openbsd` | OpenBSD | 
+| `linux` | Linux |
+| `solaris` | Solaris |
+| `windows` | Windows |
+
+`<cenv>`
+---------
+`<cenv>` is the C runtime environment. This specifier is optional. For MacOS the C runtime environment is always assumed to be the system default.
+
+| `<cenv>` | C runtime environment | Default for OS | 
+| ---------- |------------- |-------------| 
+| `musl` |  musl-libc |        |
+| `msvc` |  MSVC runtime  |  Windows  | 
+| `bionic` | Andriod libc |         | 
+| `digital_mars`|  Digital Mars C runtime for Windows |
+|  `glibc` |  GCC C runtime | linux | 
+| `newlib` | Newlib Libc |  | 
+| `uclibc` |  uclibc |  | 
+
+
+`<cppenv>`
+------------
+
+`<cppenv>` is the C++ runtime environment. This specifier is optional. If this specifier is present the `<cenv>` specifier must also be present.
+
+| `<cppenv>` | C++ runtime environment | Default for OS | 
+| ---------- |------------- |-------------| 
+| `clang` |  LLVM C++ runtime  |   MacOS, FreeBSD, OpenBSD, DragonflyBSD  |
+| `gcc` | GCC  C++ runtime | linux | 
+| `msvc` |  MSVC runtime  |  Windows  | 
+| `digital_mars`|  Digital Mars C++ runtime for Windows |
+| `sun` | Sun C++ runtime | Solaris |

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -671,6 +671,23 @@ dmd -cov -unittest myprog.d
             `$(UNIX Generate shared library)
              $(WINDOWS Generate DLL library)`,
         ),
+        Option("target=<triple>",
+               "use <triple> as <arch>-[<vendor>-]<os>[-<cenv>[-<cppenv]]",
+               "$(I arch) is the architecture: either `x86`, `x64`, `x86_64` or `x32`,
+               $(I vendor) is always ignored, but supported for easier interoperability,
+               $(I os) is the operating system, this may have a trailing version number:
+               `freestanding` for no operating system,
+               `darwin` or `osx` for MacOS, `dragonfly` or `dragonflybsd` for DragonflyBSD,
+               `freebsd`, `openbsd`, `linux`, `solaris` or `windows` for their respective operating systems.
+               $(I cenv) is the C runtime environment and is optional: `musl` for musl-libc,
+               `msvc` for the MSVC runtime (the default for windows with this option),
+               `bionic` for the Andriod libc, `digital_mars` for the Digital Mars runtime for Windows
+               `gnu` or `glibc` for the GCC C runtime, `newlib` or `uclibc` for their respective C runtimes.
+               ($ I cppenv) is the C++ runtime environment: `clang` for the LLVM C++ runtime
+               `gcc` for GCC's C++ runtime, `msvc` for microsoft's MSVC C++ runtime (the default for windows with this switch),
+               `sun` for Sun's C++ runtime and `digital_mars` for the Digital Mars C++ runtime for windows.
+               "
+        ),
         Option("transition=<name>",
             "help with language change identified by 'name'",
             `Show additional info about language change identified by $(I id)`,

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -770,6 +770,7 @@ struct TargetC;
 struct TargetCPP;
 struct TargetObjC;
 struct Param;
+struct Triple;
 struct Target;
 struct Mem;
 class Object;
@@ -6603,6 +6604,7 @@ struct Target
     };
 
     OS os;
+    uint8_t osMajor;
     uint8_t ptrsize;
     uint8_t realsize;
     uint8_t realpad;
@@ -6660,6 +6662,7 @@ private:
 public:
     void _init(const Param& params);
     void setCPU();
+    void setTriple(const Triple& triple);
     void addPredefinedGlobalIdentifiers() const;
     void deinitialize();
     uint32_t alignsize(Type* type);
@@ -6687,6 +6690,7 @@ public:
     bool libraryObjectMonitors(FuncDeclaration* fd, Statement* fbody);
     Target() :
         os((OS)1u),
+        osMajor(),
         ptrsize(),
         realsize(),
         realpad(),
@@ -6710,8 +6714,9 @@ public:
         RealProperties()
     {
     }
-    Target(OS os, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, 0u, (Runtime)0u), TargetCPP cpp = TargetCPP(false, false, false, false, (Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool mscoff = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
+    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, 0u, (Runtime)0u), TargetCPP cpp = TargetCPP(false, false, false, false, (Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool mscoff = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
         os(os),
+        osMajor(osMajor),
         ptrsize(ptrsize),
         realsize(realsize),
         realpad(realpad),

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1838,6 +1838,12 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                 error("unknown error style '%.*s', must be 'digitalmars' or 'gnu'", cast(int) style.length, style.ptr);
             }
         }
+        else if (startsWith(p + 1, "target"))
+        {
+            enum len = "-target=".length;
+            const triple = Triple(p + len);
+            target.setTriple(triple);
+        }
         else if (startsWith(p + 1, "mcpu")) // https://dlang.org/dmd.html#switch-mcpu
         {
             enum len = "-mcpu=".length;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -106,6 +106,7 @@ extern (C++) struct Target
     }
 
     OS os = defaultTargetOS();
+    ubyte osMajor;
 
     // D ABI
     ubyte ptrsize;            /// size of a pointer in bytes
@@ -300,6 +301,17 @@ extern (C++) struct Target
                 break;
         }
     }
+
+    void setTriple(const ref Triple triple)
+    {
+        cpu     = triple.cpu;
+        is64bit = triple.is64bit;
+        isLP64  = triple.isLP64;
+        os      = triple.os;
+        osMajor = triple.osMajor;
+        c.runtime   = triple.cenv;
+        cpp.runtime = triple.cppenv;
+    }
     /**
      * Add predefined global identifiers that are determied by the target
      */
@@ -338,7 +350,13 @@ extern (C++) struct Target
             case OS.FreeBSD:
             {
                 predef("FreeBSD");
-                predef("FreeBSD_" ~ target.FreeBSDMajor);
+                switch (osMajor)
+                {
+                    case 10: predef("FreeBSD_10");  break;
+                    case 11: predef("FreeBSD_11"); break;
+                    case 12: predef("FreeBSD_12"); break;
+                    default: predef("FreeBSD_11"); break;
+                }
                 break;
             }
             default: assert(0);
@@ -366,6 +384,8 @@ extern (C++) struct Target
         }
         if (isLP64)
             VersionCondition.addPredefinedGlobalIdent("D_LP64");
+        else if (is64bit)
+            VersionCondition.addPredefinedGlobalIdent("X32");
     }
     /**
      * Deinitializes the global state of the compiler.
@@ -1127,25 +1147,6 @@ extern (C++) struct Target
     {
         return (os & Target.OS.Posix) != 0;
     }
-
-    /**
-     * Returns:
-     *  FreeBSD major version string being targeted.
-     */
-    extern (D) @property string FreeBSDMajor() scope const nothrow @nogc
-    in { assert(os == Target.OS.FreeBSD); }
-    do
-    {
-        // FIXME: Need better a way to statically set the major FreeBSD version?
-             version (TARGET_FREEBSD12) return "12";
-        else version (TARGET_FREEBSD11) return "11";
-        else version (TARGET_FREEBSD10) return "10";
-        else version (FreeBSD_12)       return "12";
-        else version (FreeBSD_11)       return "11";
-        else version (FreeBSD_10)       return "10";
-        // FIXME: Need a way to dynamically set the major FreeBSD version?
-        else /* default supported */    return "11";
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1203,11 +1204,8 @@ struct TargetC
             runtime = target.mscoff ? Runtime.Microsoft : Runtime.DigitalMars;
         else if (os == Target.OS.linux)
         {
-            // Note: This should be done with a target triplet, to support cross compilation.
-            // However DMD currently does not support it, so this is a simple
-            // fix to make DMD compile on Musl-based systems such as Alpine.
-            // See https://github.com/dlang/dmd/pull/8020
-            // And https://wiki.osdev.org/Target_Triplet
+            // Note: This is overridden later by `-target=<triple>` if supplied.
+            // For now, choose the sensible default.
             version (CRuntime_Musl)
                 runtime = Runtime.Musl;
             else
@@ -1443,6 +1441,205 @@ struct TargetObjC
     {
         if (target.os == Target.OS.OSX && target.is64bit)
             supported = true;
+    }
+}
+
+/**
+ Sets CPU Operating System, and optionally C/C++ runtime environment from the given triple
+ e.g.
+    x86_64+avx2-apple-darwin20.3.0
+    x86-unknown-linux-musl-clang
+    x64-windows-msvc
+    x64-pc-windows-msvc
+ */
+struct Triple
+{
+    private const(char)[] source;
+    CPU               cpu;
+    bool              is64bit;
+    bool              isLP64;
+    Target.OS         os;
+    ubyte             osMajor;
+    TargetC.Runtime   cenv;
+    TargetCPP.Runtime cppenv;
+
+    this(const(char)* _triple)
+    {
+        import dmd.root.string : toDString, toCStringThen;
+        const(char)[] triple = _triple.toDString();
+        const(char)[] next()
+        {
+            size_t i = 0;
+            const tmp = triple;
+            while (triple.length && triple[0] != '-')
+            {
+                triple = triple[1 .. $];
+                ++i;
+            }
+            if (triple.length && triple[0] == '-')
+            {
+                triple = triple[1 .. $];
+            }
+            return tmp[0 .. i];
+        }
+
+        parseArch(next);
+        const(char)[] vendorOrOS = next();
+        const(char)[] _os;
+        if (tryParseVendor(vendorOrOS))
+            _os = next();
+        else
+            _os = vendorOrOS;
+        os = parseOS(_os, osMajor);
+
+        const(char)[] _cenv = next();
+        if (_cenv.length)
+            cenv = parseCEnv(_cenv);
+        else if (this.os == Target.OS.Windows)
+            cenv = TargetC.Runtime.Microsoft;
+        const(char)[] _cppenv = next();
+        if (_cppenv.length)
+            cppenv = parseCPPEnv(_cppenv);
+        else if (this.os == Target.OS.Windows)
+            cppenv = TargetCPP.Runtime.Microsoft;
+    }
+    private extern(D):
+
+    void unknown(const(char)[] unk, const(char)* what)
+    {
+        import dmd.errors : error;
+        import dmd.root.string : toCStringThen;
+        import dmd.globals : Loc;
+        unk.toCStringThen!(p => error(Loc.initial,"unknown %s `%s` for `-target`", what, p.ptr));
+    }
+
+    void parseArch(const(char)[] arch)
+    {
+        bool matches(const(char)[] str)
+        {
+            import dmd.root.string : startsWith;
+            if (!arch.ptr.startsWith(str))
+                return false;
+            arch = arch[str.length-1 .. $-1];
+            return true;
+        }
+
+        if (matches("x86_64"))
+            is64bit = true;
+        else if (matches("x86"))
+            is64bit = false;
+        else if (matches("x64"))
+            is64bit = true;
+        else if (matches("x32"))
+        {
+            is64bit = true;
+            isLP64 = false;
+        }
+        else
+            return unknown(arch, "architecture");
+
+        if (!arch.length)
+            return;
+
+        switch (arch)
+        {
+            case "+sse2": cpu = CPU.sse2; break;
+            case "+avx":  cpu = CPU.avx;  break;
+            case "+avx2": cpu = CPU.avx2; break;
+            default:
+                unknown(arch, "architecture feature");
+        }
+    }
+
+    // try parsing vendor if present
+    bool tryParseVendor(const(char)[] vendor)
+    {
+        switch (vendor)
+        {
+            case "unknown": return true;
+            case "apple":   return true;
+            case "pc":      return true;
+            case "amd":     return true;
+            default:        return false;
+        }
+    }
+
+    Target.OS parseOS(const(char)[] _os, out ubyte _osMajor)
+    {
+        bool matches(const(char)[] str)
+        {
+            import dmd.root.string : startsWith;
+            if (!_os.ptr.startsWith(str))
+                return false;
+            _os = _os[str.length .. $];
+            return true;
+        }
+        if (_os == "freestanding")
+            return Target.OS.Freestanding;
+        Target.OS os;
+        _osMajor = 0;
+        if (matches("darwin"))
+            os = Target.OS.OSX;
+        else if (matches("dragonfly"))
+            os =  Target.OS.DragonFlyBSD;
+        else if (matches("freebsd"))
+            os =  Target.OS.FreeBSD;
+        else if (matches("openbsd"))
+            os =  Target.OS.OpenBSD;
+        else if (matches("linux"))
+            os =  Target.OS.linux;
+        else if (matches("windows"))
+            os =  Target.OS.Windows;
+        else
+        {
+            unknown(_os, "operating system");
+            return Target.OS.Freestanding;
+        }
+        while (_os.length)
+        {
+            if (!('0' < _os[0] && _os[0] < '9'))
+                break;
+            osMajor *= 10;
+            osMajor = cast(ubyte)((_os[0] - '0') + osMajor);
+            _os = _os[1 .. $];
+        }
+        return os;
+    }
+
+    TargetC.Runtime parseCEnv(const(char)[] cenv)
+    {
+        with (TargetC.Runtime) switch (cenv)
+        {
+            case "musl":         return Musl;
+            case "msvc":         return Microsoft;
+            case "bionic":       return Bionic;
+            case "digital_mars": return DigitalMars;
+            case "newlib":       return Newlib;
+            case "uclibc":       return UClibc;
+            case "glibc":        return Glibc;
+            default:
+            {
+                unknown(cenv, "C runtime environment");
+                return Unspecified;
+            }
+        }
+    }
+
+    TargetCPP.Runtime parseCPPEnv(const(char)[] cppenv)
+    {
+        with (TargetCPP.Runtime) switch (cppenv)
+        {
+            case "clang":        return Clang;
+            case "gcc":          return Gcc;
+            case "msvc":         return Microsoft;
+            case "sun":          return Sun;
+            case "digital_mars": return DigitalMars;
+            default:
+            {
+                unknown(cppenv, "C++ runtime environment");
+                return Unspecified;
+            }
+        }
     }
 }
 

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -119,6 +119,7 @@ struct Target
     };
 
     OS os;
+    uint8_t osMajor;
     // D ABI
     uint8_t ptrsize;
     uint8_t realsize;           // size a real consumes in memory
@@ -176,6 +177,7 @@ private:
 public:
     void _init(const Param& params);
     // Type sizes and support.
+    void setTriple(const char* _triple);
     unsigned alignsize(Type *type);
     unsigned fieldalign(Type *type);
     Type *va_listType(const Loc &loc, Scope *sc);  // get type of va_list

--- a/test/unit/triple.d
+++ b/test/unit/triple.d
@@ -1,0 +1,46 @@
+// See ../README.md for information about DMD unit tests.
+
+module triple;
+
+import support : afterEach, defaultImportPaths;
+import dmd.target;
+@afterEach deinitializeFrontend()
+{
+    import dmd.frontend : deinitializeDMD;
+    deinitializeDMD();
+}
+
+@("-target=x86-unknown-windows-msvc")
+unittest
+{
+    auto triple = Triple("x86-unknown-windows-msvc");
+    assert(triple.os == Target.OS.Windows);
+    assert(triple.is64bit == false);
+    assert(triple.cenv == TargetC.Runtime.Microsoft);
+}
+
+@("-target=x64-apple-darwin20.3.0")
+unittest
+{
+    auto triple = Triple("x64-apple-darwin20.3.0");
+    assert(triple.os == Target.OS.OSX);
+    assert(triple.is64bit == true);
+}
+
+@("-target=x86_64-unknown-linux-musl-clang")
+unittest
+{
+    auto triple = Triple("x86_64-unknown-linux-musl-clang");
+    assert(triple.is64bit == true);
+    assert(triple.os == Target.OS.linux);
+    assert(triple.cenv == TargetC.Runtime.Musl);
+    assert(triple.cppenv == TargetCPP.Runtime.Clang);
+}
+
+@("-target=x86_64-freebsd12")
+unittest
+{
+    auto triple = Triple("x86_64-freebsd12");
+    assert(triple.os == Target.OS.FreeBSD);
+    assert(triple.osMajor == 12);
+}


### PR DESCRIPTION
Implement the ability for users of DMD to specify which os/architecture/runtime they wish to target.
Other compilers already implement similar switch. Support for actually generating code will be done in a later PR.
For more informations, see https://wiki.osdev.org/Target_Triplet or the changelog that comes with this PR.