### PR TITLE
Fix Issue 21885 - Bad diagnostic: struct is not copyable because it is annotated @disable

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -348,11 +348,42 @@ extern (C++) abstract class Declaration : Dsymbol
         if (sc.func && sc.func.storage_class & STC.disable)
             return true;
 
-        auto p = toParent();
-        if (p && isPostBlitDeclaration())
+        if (auto p = toParent())
         {
-            p.error(loc, "is not copyable because it is annotated with `@disable`");
-            return true;
+            if (auto postblit = isPostBlitDeclaration())
+            {
+                /* https://issues.dlang.org/show_bug.cgi?id=21885
+                 *
+                 * If the generated postblit is disabled, it
+                 * means that one of the fields has a disabled
+                 * postblit. Print the first field that has
+                 * a disabled postblit.
+                 */
+                if (postblit.generated)
+                {
+                    auto sd = p.isStructDeclaration();
+                    assert(sd);
+                    for (size_t i = 0; i < sd.fields.dim; i++)
+                    {
+                        auto structField = sd.fields[i];
+                        if (structField.overlapped)
+                            continue;
+                        Type tv = structField.type.baseElemOf();
+                        if (tv.ty != Tstruct)
+                            continue;
+                        auto sdv = (cast(TypeStruct)tv).sym;
+                        if (!sdv.postblit)
+                            continue;
+                        if (sdv.postblit.isDisabled())
+                        {
+                            p.error(loc, "is not copyable because field `%s` is not copyable", structField.toChars());
+                            return true;
+                        }
+                    }
+                }
+                p.error(loc, "is not copyable because it has a disabled postblit");
+                return true;
+            }
         }
 
         // if the function is @disabled, maybe there

--- a/test/fail_compilation/fail10968.d
+++ b/test/fail_compilation/fail10968.d
@@ -49,12 +49,12 @@ void bar() pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10968.d(72): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(73): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(74): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(77): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(78): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(79): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(72): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
+fail_compilation/fail10968.d(73): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
+fail_compilation/fail10968.d(74): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
+fail_compilation/fail10968.d(77): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
+fail_compilation/fail10968.d(78): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
+fail_compilation/fail10968.d(79): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
 ---
 */
 

--- a/test/fail_compilation/fail11355.d
+++ b/test/fail_compilation/fail11355.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11355.d(28): Error: struct `fail11355.A` is not copyable because it is annotated with `@disable`
+fail_compilation/fail11355.d(28): Error: struct `fail11355.A` is not copyable because it has a disabled postblit
 ---
 */
 

--- a/test/fail_compilation/fail18994.d
+++ b/test/fail_compilation/fail18994.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18994.d(19): Error: struct `fail18994.Type1` is not copyable because it is annotated with `@disable`
+fail_compilation/fail18994.d(19): Error: struct `fail18994.Type1` is not copyable because it has a disabled postblit
 ---
 */
 struct Type2

--- a/test/fail_compilation/fail21885.d
+++ b/test/fail_compilation/fail21885.d
@@ -1,0 +1,25 @@
+// https://issues.dlang.org/show_bug.cgi?id=21885
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21885.d(24): Error: struct `fail21885.Outer` is not copyable because field `i` is not copyable
+---
+*/
+
+struct Outer
+{
+    Inner i;
+}
+
+struct Inner
+{
+    @disable this(this);
+}
+
+void main()
+{
+    Outer o1;
+    Outer o2;
+    o1 = o2;
+}

--- a/test/fail_compilation/fail341.d
+++ b/test/fail_compilation/fail341.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail341.d(26): Error: struct `fail341.S` is not copyable because it is annotated with `@disable`
+fail_compilation/fail341.d(26): Error: struct `fail341.S` is not copyable because field `t` is not copyable
 fail_compilation/fail341.d(27): Error: function `fail341.foo` cannot be used because it is annotated with `@disable`
 ---
 */

--- a/test/fail_compilation/fail9346.d
+++ b/test/fail_compilation/fail9346.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9346.d(26): Error: struct `fail9346.S` is not copyable because it is annotated with `@disable`
-fail_compilation/fail9346.d(27): Error: struct `fail9346.S` is not copyable because it is annotated with `@disable`
+fail_compilation/fail9346.d(26): Error: struct `fail9346.S` is not copyable because it has a disabled postblit
+fail_compilation/fail9346.d(27): Error: struct `fail9346.S` is not copyable because it has a disabled postblit
 ---
 */
 


### PR DESCRIPTION
I had to fix a few tests, but IMHO the errors are more accurate now.

In case a struct has a generated postblit that is disabled, it means that the struct has a field that has a disabled postblit. The patch searches for the first field that has a disabled postblit and outputs it. This code is similar to the one in `buildPostblit`, therefore an alternative solution could store the fields with disabled postblits when the postblit is constructed, however, I think it's better to redo the work since we are on a failing branch.