### PR TITLE
ctfeexpr: support reinterpreting cast when switching safe/pure/nothrow in both directions

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -686,7 +686,7 @@ bool isSafePointerCast(Type srcPointee, Type destPointee)
         return true;
     // It's OK if function pointers differ only in safe/pure/nothrow
     if (srcPointee.ty == Tfunction && destPointee.ty == Tfunction)
-        return srcPointee.covariant(destPointee) == 1;
+        return srcPointee.covariant(destPointee) == 1 || destPointee.covariant(srcPointee) == 1;
     // it's OK to cast to void*
     if (destPointee.ty == Tvoid)
         return true;

--- a/test/compilable/reinterpretctfe.d
+++ b/test/compilable/reinterpretctfe.d
@@ -1,0 +1,34 @@
+// https://issues.dlang.org/show_bug.cgi?id=21997
+
+int nonPureFunc(int i)
+{
+    return 2 * i;
+}
+
+int mainCtfe()
+{
+    auto pureFunc = cast(int function(int) pure) &nonPureFunc;
+    assert(pureFunc(2) == 4);
+
+    auto baseFunc = cast(int function(int)) pureFunc;
+    assert(baseFunc(3) == 6);
+
+    /*
+    Still missing delegates: https://issues.dlang.org/show_bug.cgi?id=17487
+
+    static struct S {
+        int i;
+        int f(int j) { return i * j; }
+    }
+
+    S s = S(5);
+    auto pureDel = cast(int delegate(int) pure) &s.f;
+    assert(pureDel(3) == 15);
+
+    auto baseDel = cast(int delegate(int)) pureDel;
+    assert(baseDel(4) == 20);
+    */
+    return 0;
+}
+
+enum forceCTFE = mainCtfe();


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>