### PR TITLE
Fix 21918 - Segfault for getParameterStorageClasses for invalid funct…

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2502,7 +2502,8 @@ extern (C++) class FuncDeclaration : Declaration
         if (type)
         {
             TypeFunction fdtype = type.isTypeFunction();
-            return fdtype.parameterList;
+            if (fdtype) // Could also be TypeError
+                return fdtype.parameterList;
         }
 
         return ParameterList(null, VarArg.none);

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1432,6 +1432,10 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             return ErrorExp.get();
         }
 
+        // Avoid further analysis for invalid functions leading to misleading error messages
+        if (!fparams.parameters)
+            return ErrorExp.get();
+
         StorageClass stc;
 
         // Set stc to storage class of the ith parameter

--- a/test/fail_compilation/traits.d
+++ b/test/fail_compilation/traits.d
@@ -81,3 +81,16 @@ extern(C++, __traits(getCppNamespaces, foobar1.func2)) void func1 () {}
 extern(C++, foobar1)
 extern(C++, __traits(getCppNamespaces, bar1.func)) void func2 () {}
 
+/********************************************
+https://issues.dlang.org/show_bug.cgi?id=21918
+
+TEST_OUTPUT:
+---
+fail_compilation/traits.d(501): Error: undefined identifier `T`
+fail_compilation/traits.d(502):        while evaluating `pragma(msg, __traits(getParameterStorageClasses, yip, 0))`
+---
+*/
+#line 500
+
+auto yip(int f) {return T[];}
+pragma(msg, __traits(getParameterStorageClasses, yip, 0));


### PR DESCRIPTION
…ions

The type of a `FuncDeclaration` is set to `TypeError` if the `auto`
inference fails. So `getParameters` has to check that the type is
actually a `TypeFunction`.

The additional check in `traits.d` prevents the invalid error message:
```
Error: parameter index must be in range 0..0 not 0
```