### PR TITLE
WIP: fix Issue 20150 - -dip1000 return attribute must be explicit in pure (use deprecation instead of error)

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1219,15 +1219,18 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
 
         Dsymbol p = v.toParent2();
 
-        if ((v.isScope() || (v.storage_class & STC.maybescope)) &&
-            !(v.storage_class & STC.return_) &&
+        bool needsReturn = false;
+        if (!(v.storage_class & STC.return_) &&
             v.isParameter() &&
-            !v.doNotInferReturn &&
-            sc.func.flags & FUNCFLAG.returnInprocess &&
             p == sc.func)
         {
-            inferReturn(sc.func, v);        // infer addition of 'return'
-            continue;
+            if ((v.isScope() || (v.storage_class & STC.maybescope)) &&
+                sc.func.flags & FUNCFLAG.returnInprocess)
+            {
+                inferReturn(sc.func, v);        // infer addition of 'return'
+                continue;
+            }
+            needsReturn = true;                 // needs 'return' annotation on parameter
         }
 
         if (v.isScope())
@@ -1274,6 +1277,17 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
                     error(e.loc, "returning `%s` escapes a reference to variadic parameter `%s`", e.toChars(), v.toChars());
                 result = false;
             }
+        }
+        else if (needsReturn && sc.func.type.isTypeFunction().purity != PURE.impure && global.params.vsafe &&
+                 sc._module && sc._module.isRoot())
+        {
+            /* Pure functions assume their parameters are `scope`, but they don't assume `return`.
+             * Hence, the annotation needs to be explicit.
+             */
+            if (!gag)
+                deprecation(e.loc, "`pure` function `%s` returns parameter `%s`, annotate with `return`",
+                            sc.func.ident.toChars(), v.toChars());
+            result = true;
         }
         else
         {

--- a/test/fail_compilation/fail20108.d
+++ b/test/fail_compilation/fail20108.d
@@ -2,10 +2,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20108.d(15): Error: address of variable `y` assigned to `x` with longer lifetime
-fail_compilation/fail20108.d(16): Error: scope variable `x` may not be returned
-fail_compilation/fail20108.d(23): Error: address of variable `y` assigned to `x` with longer lifetime
-fail_compilation/fail20108.d(24): Error: scope variable `x` may not be returned
+fail_compilation/fail20108.d(14): Error: address of variable `y` assigned to `x` with longer lifetime
+fail_compilation/fail20108.d(22): Error: address of variable `y` assigned to `x` with longer lifetime
+fail_compilation/fail20108.d(23): Error: scope variable `x` may not be returned
 ---
 */
 

--- a/test/fail_compilation/retscope6.d
+++ b/test/fail_compilation/retscope6.d
@@ -173,6 +173,7 @@ T9 testfred()
 /* TEST_OUTPUT:
 ---
 fail_compilation/retscope6.d(10003): Error: scope variable `values` assigned to non-scope parameter `values` calling retscope6.escape
+fail_compilation/retscope6.d(10012): Deprecation: `pure` function `escapePtr` returns parameter `r`, annotate with `return`
 ---
 */
 
@@ -184,6 +185,13 @@ void variadicCaller(int[] values...)
 }
 
 void escape(int[] values) {}
+
+// https://issues.dlang.org/show_bug.cgi?id=20150
+
+int* escapePtr(int* r) @safe pure
+{
+    return r;
+}
 
 /* TEST_OUTPUT:
 ---


### PR DESCRIPTION
Adjust https://github.com/dlang/dmd/pull/10924 to emit a deprecation instead of error and see how that goes.

After this gets merged the adding of @trusted qualifiers in the changes at

- https://github.com/dlang/phobos/pull/8088

need to be reverted.