### PR TITLE
Explicitly set the base ref for CodeCov reports 

### DIFF
--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -137,7 +137,9 @@ if [ "${DMD_TEST_COVERAGE:-0}" = "1" ] ; then
     # CodeCov gets confused by lst files which it can't match
     rm -rf test/runnable/extra-files test/*.lst
     download "https://codecov.io/bash" "codecov.sh"
-    bash ./codecov.sh -p . -Z
+    git fetch origin $SYSTEM_PULLREQUEST_TARGETBRANCH
+    TAG=$(git rev-parse origin/$SYSTEM_PULLREQUEST_TARGETBRANCH)
+    bash ./codecov.sh -p . -Z -C "$TAG"
     rm codecov.sh
 
     # Skip druntime & phobos tests

--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -137,9 +137,9 @@ if [ "${DMD_TEST_COVERAGE:-0}" = "1" ] ; then
     # CodeCov gets confused by lst files which it can't match
     rm -rf test/runnable/extra-files test/*.lst
     download "https://codecov.io/bash" "codecov.sh"
-    git fetch origin $SYSTEM_PULLREQUEST_TARGETBRANCH
-    TAG=$(git rev-parse origin/$SYSTEM_PULLREQUEST_TARGETBRANCH)
-    bash ./codecov.sh -p . -Z -C "$TAG"
+    # git fetch origin $SYSTEM_PULLREQUEST_TARGETBRANCH
+    # TAG=$(git rev-parse origin/$SYSTEM_PULLREQUEST_TARGETBRANCH)
+    bash ./codecov.sh -p . -Z -v
     rm codecov.sh
 
     # Skip druntime & phobos tests

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -195,7 +195,7 @@ codecov()
     # CodeCov gets confused by lst files which it can't match
     rm -rf test/runnable/extra-files
     download "https://codecov.io/bash" "https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov" "codecov.sh"
-    bash ./codecov.sh -p . -Z -C "$CIRCLE_SHA1" || echo "Failed to upload coverage reports!"
+    bash ./codecov.sh -p . -Z -v || echo "Failed to upload coverage reports!"
     rm codecov.sh
 }
 

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -195,7 +195,7 @@ codecov()
     # CodeCov gets confused by lst files which it can't match
     rm -rf test/runnable/extra-files
     download "https://codecov.io/bash" "https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov" "codecov.sh"
-    bash ./codecov.sh -p . -Z || echo "Failed to upload coverage reports!"
+    bash ./codecov.sh -p . -Z -C "$CIRCLE_SHA1" || echo "Failed to upload coverage reports!"
     rm codecov.sh
 }
 

--- a/ci.sh
+++ b/ci.sh
@@ -215,7 +215,7 @@ codecov()
     rm -rf test/runnable/extra-files test/*.lst
     curl -fsSL -A "$CURL_USER_AGENT" --connect-timeout 5 --speed-time 30 --speed-limit 1024 \
         --retry 5 --retry-delay 5 "https://codecov.io/bash" -o "codecov.sh"
-    bash ./codecov.sh -p . -Z -C "$CIRRUS_BASE_SHA"
+    bash ./codecov.sh -p . -Z -v
     rm codecov.sh
 }
 

--- a/ci.sh
+++ b/ci.sh
@@ -215,7 +215,7 @@ codecov()
     rm -rf test/runnable/extra-files test/*.lst
     curl -fsSL -A "$CURL_USER_AGENT" --connect-timeout 5 --speed-time 30 --speed-limit 1024 \
         --retry 5 --retry-delay 5 "https://codecov.io/bash" -o "codecov.sh"
-    bash ./codecov.sh -p . -Z
+    bash ./codecov.sh -p . -Z -C "$CIRRUS_BASE_SHA"
     rm codecov.sh
 }
 


### PR DESCRIPTION
Their default algorithm apparenlty determines the wrong base.