### PR TITLE
Fix 16001 - forbid lambda syntax followed by FunctionLiteralBody

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -5094,6 +5094,11 @@ final class Parser(AST) : Lexer
         if (token.value == TOK.goesTo)
         {
             check(TOK.goesTo);
+            if (token.value == TOK.leftCurly)
+            {
+                deprecation("`(args) => { ... }` is a lambda that returns a delegate, not a multi-line lambda.");
+                deprecationSupplemental(token.loc, "Use `(args) { ... }` for a multi-statement function literal or use `(args) => () { }` if you intended for the lambda to return a delegate.");
+            }
             const returnloc = token.loc;
             AST.Expression ae = parseAssignExp();
             fd.fbody = new AST.ReturnStatement(returnloc, ae);

--- a/test/fail_compilation/fail16001.d
+++ b/test/fail_compilation/fail16001.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail16001.d(10): Deprecation: `(args) => { ... }` is a lambda that returns a delegate, not a multi-line lambda.
+fail_compilation/fail16001.d(10):        Use `(args) { ... }` for a multi-statement function literal or use `(args) => () { }` if you intended for the lambda to return a delegate.
+---
+*/
+void main() {
+	auto fail = () => {};
+	auto ok = () => () {};
+}
+

--- a/test/fail_compilation/ice10212.d
+++ b/test/fail_compilation/ice10212.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10212.d(13): Error: Expected return type of `int`, not `int function() pure nothrow @nogc @safe`:
-fail_compilation/ice10212.d(13):        Return type of `int` inferred here.
+fail_compilation/ice10212.d(15): Deprecation: `(args) => { ... }` is a lambda that returns a delegate, not a multi-line lambda.
+fail_compilation/ice10212.d(15):        Use `(args) { ... }` for a multi-statement function literal or use `(args) => () { }` if you intended for the lambda to return a delegate.
+fail_compilation/ice10212.d(15): Error: Expected return type of `int`, not `int function() pure nothrow @nogc @safe`:
+fail_compilation/ice10212.d(15):        Return type of `int` inferred here.
 ---
 */
 

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -1,6 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
+runnable/funclit.d(417): Deprecation: `(args) => { ... }` is a lambda that returns a delegate, not a multi-line lambda.
+runnable/funclit.d(417):        Use `(args) { ... }` for a multi-statement function literal or use `(args) => () { }` if you intended for the lambda to return a delegate.
 int delegate() pure nothrow @nogc @safe delegate() pure nothrow @nogc @safe delegate() pure nothrow @safe
 int delegate() pure nothrow @nogc @safe delegate() pure nothrow @nogc @safe delegate() pure nothrow @safe
 int


### PR DESCRIPTION
This trips up so many people and the alternatives are easy - more often than not, you just want to delete the `=>`.

Time to go ahead and get proactive.