### PR TITLE
Fix issue 21928: pass Loc to Cat() explicitly.

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1497,11 +1497,10 @@ private Expressions* copyElements(Expression e1, Expression e2 = null)
 
 /* Also return TOK.cantExpression if this fails
  */
-UnionExp Cat(Type type, Expression e1, Expression e2)
+UnionExp Cat(const ref Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;
     Expression e = CTFEExp.cantexp;
-    Loc loc = e1.loc;
     Type t;
     Type t1 = e1.type.toBasetype();
     Type t2 = e2.type.toBasetype();
@@ -1731,7 +1730,7 @@ UnionExp Cat(Type type, Expression e1, Expression e2)
                 ? copyElements(e1) : new Expressions();
         elems.push(e2);
 
-        emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, cast(Type)null, elems);
+        emplaceExp!(ArrayLiteralExp)(&ue, loc, cast(Type)null, elems);
 
         e = ue.exp();
         if (type.toBasetype().ty == Tsarray)
@@ -1747,7 +1746,7 @@ UnionExp Cat(Type type, Expression e1, Expression e2)
     {
         auto elems = copyElements(e1, e2);
 
-        emplaceExp!(ArrayLiteralExp)(&ue, e2.loc, cast(Type)null, elems);
+        emplaceExp!(ArrayLiteralExp)(&ue, loc, cast(Type)null, elems);
 
         e = ue.exp();
         if (type.toBasetype().ty == Tsarray)

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -1510,7 +1510,7 @@ UnionExp ctfeCat(const ref Loc loc, Type type, Expression e1, Expression e2)
         ue = paintTypeOntoLiteralCopy(type, copyLiteral(e2).copy());
         return ue;
     }
-    ue = Cat(type, e1, e2);
+    ue = Cat(loc, type, e1, e2);
     return ue;
 }
 

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -1144,7 +1144,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
                 if (se2.e1.op == TOK.string_ && !se2.lwr)
                     e.e2 = se2.e1;
             }
-            ret = Cat(e.type, e.e1, e.e2).copy();
+            ret = Cat(e.loc, e.type, e.e1, e.e2).copy();
             if (CTFEExp.isCantExp(ret))
                 ret = e;
         }

--- a/test/fail_compilation/fail21928.d
+++ b/test/fail_compilation/fail21928.d
@@ -1,0 +1,19 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21928.d(18): Error: array literal in `@nogc` function `D main` may cause a GC allocation
+---
+*/
+
+@nogc:
+
+
+struct Shape
+{
+    immutable size_t[] dims = [];
+}
+
+void main()
+{
+    auto s = Shape(2 ~ Shape.init.dims);
+}

--- a/test/fail_compilation/fail21928b.d
+++ b/test/fail_compilation/fail21928b.d
@@ -1,0 +1,19 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail21928b.d(18): Error: array literal in `@nogc` function `D main` may cause a GC allocation
+---
+*/
+
+@nogc:
+
+
+struct Shape
+{
+    immutable size_t[] dims = [];
+}
+
+void main()
+{
+    auto s = Shape(Shape.init.dims ~ 2);
+}


### PR DESCRIPTION
Use location of concatenation for newly-created array literal, in the cases element ~ literal and literal ~ element.