### PR TITLE
parseAssignExp should be cparseAssignExp

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -436,7 +436,7 @@ final class CParser(AST) : Parser!AST
         {
 
             nextToken();
-            auto exp = parseAssignExp();
+            auto exp = cparseAssignExp();
             check(TOK.colon);
 
             if (flags & ParseStatementFlags.curlyScope)
@@ -2324,7 +2324,7 @@ final class CParser(AST) : Parser!AST
         auto arguments = new AST.Expressions();
         while (token.value != TOK.rightParenthesis && token.value != TOK.endOfFile)
         {
-            auto arg = parseAssignExp();
+            auto arg = cparseAssignExp();
             arguments.push(arg);
             if (token.value != TOK.comma)
                 break;


### PR DESCRIPTION
As identified by @dkorpel here https://github.com/dlang/dmd/pull/12507#discussion_r634391694 and here https://github.com/dlang/dmd/pull/12507#discussion_r634392019