### PR TITLE
dmd.cparse: Use cparseAssignExp instead of parseAssignExp

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -436,7 +436,7 @@ final class CParser(AST) : Parser!AST
         {
 
             nextToken();
-            auto exp = parseAssignExp();
+            auto exp = cparseAssignExp();
             check(TOK.colon);
 
             if (flags & ParseStatementFlags.curlyScope)
@@ -2324,7 +2324,7 @@ final class CParser(AST) : Parser!AST
         auto arguments = new AST.Expressions();
         while (token.value != TOK.rightParenthesis && token.value != TOK.endOfFile)
         {
-            auto arg = parseAssignExp();
+            auto arg = cparseAssignExp();
             arguments.push(arg);
             if (token.value != TOK.comma)
                 break;


### PR DESCRIPTION
Picked up in review that this is likely wrong.  The D parser shouldn't be used here as far as I can tell.