### PR TITLE
dmd.target: Rename TargetC.twchar_t to wchar_tsize

### DIFF
--- a/src/dmd/chkformat.d
+++ b/src/dmd/chkformat.d
@@ -279,7 +279,7 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
                 break;
 
             case Format.ls:     // pointer to wchar_t string
-                if (!(t.ty == Tpointer && tnext == target.c.twchar_t))
+                if (!(t.ty == Tpointer && tnext.ty.isSomeChar && tnext.size() == target.c.wchar_tsize))
                     errorMsg(null, e, "wchar_t*", t);
                 break;
 
@@ -490,7 +490,7 @@ bool checkScanfFormat(ref const Loc loc, scope const char[] format, scope Expres
 
             case Format.lc:
             case Format.ls:     // pointer to wchar_t string
-                if (!(t.ty == Tpointer && tnext == target.c.twchar_t))
+                if (!(t.ty == Tpointer && tnext.ty.isSomeChar && tnext.size() == target.c.wchar_tsize))
                     errorMsg(null, e, "wchar_t*", t);
                 break;
 

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1062,7 +1062,7 @@ extern (C++) final class Module : Package
             isCFile = true;
 
             scope p = new CParser!AST(this, buf, cast(bool) docfile,
-                cast(ubyte) target.c.longsize, cast(ubyte) target.c.long_doublesize, cast(ubyte) target.c.twchar_t.size());
+                cast(ubyte) target.c.longsize, cast(ubyte) target.c.long_doublesize, cast(ubyte) target.c.wchar_tsize);
             p.nextToken();
             members = p.parseModule();
             md = p.md;

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -593,7 +593,7 @@ struct Scope
         else if (ident == Id.unsigned)
             tok = TOK.uns32;
         else if (ident == Id.wchar_t)
-            tok = target.c.twchar_t.ty == Twchar ? TOK.wchar_ : TOK.dchar_;
+            tok = target.c.wchar_tsize == 2 ? TOK.wchar_ : TOK.dchar_;
         else
             return null;
         return Token.toChars(tok);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1598,18 +1598,18 @@ struct TargetC
 
     uint32_t longsize;
     uint32_t long_doublesize;
-    Type* twchar_t;
+    uint32_t wchar_tsize;
     Runtime runtime;
     TargetC() :
         longsize(),
         long_doublesize(),
-        twchar_t()
+        wchar_tsize()
     {
     }
-    TargetC(uint32_t longsize, uint32_t long_doublesize = 0u, Type* twchar_t = nullptr, Runtime runtime = (Runtime)0u) :
+    TargetC(uint32_t longsize, uint32_t long_doublesize = 0u, uint32_t wchar_tsize = 0u, Runtime runtime = (Runtime)0u) :
         longsize(longsize),
         long_doublesize(long_doublesize),
-        twchar_t(twchar_t),
+        wchar_tsize(wchar_tsize),
         runtime(runtime)
         {}
 };
@@ -6710,7 +6710,7 @@ public:
         RealProperties()
     {
     }
-    Target(OS os, uint32_t ptrsize = 0u, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, nullptr, (Runtime)0u), TargetCPP cpp = TargetCPP(false, false, false, false, (Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool mscoff = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
+    Target(OS os, uint32_t ptrsize = 0u, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, 0u, (Runtime)0u), TargetCPP cpp = TargetCPP(false, false, false, false, (Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool mscoff = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
         os(os),
         ptrsize(ptrsize),
         realsize(realsize),

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1171,7 +1171,7 @@ struct TargetC
 
     uint longsize;            /// size of a C `long` or `unsigned long` type
     uint long_doublesize;     /// size of a C `long double`
-    Type twchar_t;            /// C `wchar_t` type
+    uint wchar_tsize;         /// size of a C `wchar_t` type
     Runtime runtime;          /// vendor of the C runtime to link against
 
     extern (D) void initialize(ref const Param params, ref const Target target)
@@ -1197,9 +1197,9 @@ struct TargetC
         else
             long_doublesize = target.realsize;
         if (os == Target.OS.Windows)
-            twchar_t = Type.twchar;
+            wchar_tsize = 2;
         else
-            twchar_t = Type.tdchar;
+            wchar_tsize = 4;
 
         if (os == Target.OS.Windows)
             runtime = target.mscoff ? Runtime.Microsoft : Runtime.DigitalMars;

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -61,7 +61,7 @@ struct TargetC
     };
     unsigned longsize;            // size of a C 'long' or 'unsigned long' type
     unsigned long_doublesize;     // size of a C 'long double'
-    Type *twchar_t;               // C 'wchar_t' type
+    unsigned wchar_tsize;         // size of a C 'wchar_t' type
     Runtime runtime;
 };
 


### PR DESCRIPTION
Changes twchar_t to a size rather than a Type, as per conversation at https://github.com/dlang/dmd/pull/12507#discussion_r634239452.