### PR TITLE
Allocate the escape table lazily

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -545,7 +545,7 @@ extern (C++) final class Module : Package
     Identifiers* versionidsNot; // forward referenced version identifiers
 
     MacroTable macrotable;      // document comment macros
-    Escape* escapetable;        // document comment escapes
+    Escape* _escapetable;       // document comment escapes
 
     size_t nameoffset;          // offset of module name from start of ModuleInfo
     size_t namelen;             // length of module name in characters
@@ -583,7 +583,6 @@ extern (C++) final class Module : Package
             setDocfile();
         if (doHdrGen)
             hdrfile = setOutfilename(global.params.hdrname, global.params.hdrdir, arg, hdr_ext);
-        escapetable = new Escape();
     }
 
     extern (D) this(const(char)[] filename, Identifier ident, int doDocComment, int doHdrGen)
@@ -1564,6 +1563,16 @@ extern (C++) final class Module : Package
             buf.prependstring(".");
             buf.prependstring(package_.ident.toChars());
         }
+    }
+
+    /** Lazily initializes and returns the escape table.
+    Turns out it eats a lot of memory.
+    */
+    extern(D) Escape* escapetable()
+    {
+        if (!_escapetable)
+            _escapetable = new Escape();
+        return _escapetable;
     }
 }
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2887,7 +2887,7 @@ public:
     Array<Identifier* >* versionids;
     Array<Identifier* >* versionidsNot;
     MacroTable macrotable;
-    Escape* escapetable;
+    Escape* _escapetable;
     size_t nameoffset;
     size_t namelen;
     static Module* create(const char* filename, Identifier* ident, int32_t doDocComment, int32_t doHdrGen);


### PR DESCRIPTION
According to [heaptrack](http://manpages.ubuntu.com/manpages/bionic/man1/heaptrack.1.html), the `EscapeTable` allocations count for hundreds of megabytes in large builds. This reduces such a large build's peak memory consumption from 22.18 GB to 21.70 GB.