### PR TITLE
dmd.target: Change size field types from `uint` to `ubyte`

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1062,7 +1062,7 @@ extern (C++) final class Module : Package
             isCFile = true;
 
             scope p = new CParser!AST(this, buf, cast(bool) docfile,
-                cast(ubyte) target.c.longsize, cast(ubyte) target.c.long_doublesize, cast(ubyte) target.c.wchar_tsize);
+                target.c.longsize, target.c.long_doublesize, target.c.wchar_tsize);
             p.nextToken();
             members = p.parseModule();
             md = p.md;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1596,9 +1596,9 @@ struct TargetC
         WASI = 8u,
     };
 
-    uint32_t longsize;
-    uint32_t long_doublesize;
-    uint32_t wchar_tsize;
+    uint8_t longsize;
+    uint8_t long_doublesize;
+    uint8_t wchar_tsize;
     Runtime runtime;
     TargetC() :
         longsize(),
@@ -1606,7 +1606,7 @@ struct TargetC
         wchar_tsize()
     {
     }
-    TargetC(uint32_t longsize, uint32_t long_doublesize = 0u, uint32_t wchar_tsize = 0u, Runtime runtime = (Runtime)0u) :
+    TargetC(uint8_t longsize, uint8_t long_doublesize = 0u, uint8_t wchar_tsize = 0u, Runtime runtime = (Runtime)0u) :
         longsize(longsize),
         long_doublesize(long_doublesize),
         wchar_tsize(wchar_tsize),
@@ -6603,11 +6603,11 @@ struct Target
     };
 
     OS os;
-    uint32_t ptrsize;
-    uint32_t realsize;
-    uint32_t realpad;
-    uint32_t realalignsize;
-    uint32_t classinfosize;
+    uint8_t ptrsize;
+    uint8_t realsize;
+    uint8_t realpad;
+    uint8_t realalignsize;
+    uint8_t classinfosize;
     uint64_t maxStaticDataSize;
     TargetC c;
     TargetCPP cpp;
@@ -6710,7 +6710,7 @@ public:
         RealProperties()
     {
     }
-    Target(OS os, uint32_t ptrsize = 0u, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, 0u, (Runtime)0u), TargetCPP cpp = TargetCPP(false, false, false, false, (Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool mscoff = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
+    Target(OS os, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, 0u, (Runtime)0u), TargetCPP cpp = TargetCPP(false, false, false, false, (Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool mscoff = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
         os(os),
         ptrsize(ptrsize),
         realsize(realsize),

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -122,11 +122,11 @@ extern (C++) struct Target
     OS os = defaultTargetOS();
 
     // D ABI
-    uint ptrsize;             /// size of a pointer in bytes
-    uint realsize;            /// size a real consumes in memory
-    uint realpad;             /// padding added to the CPU real size to bring it up to realsize
-    uint realalignsize;       /// alignment for reals
-    uint classinfosize;       /// size of `ClassInfo`
+    ubyte ptrsize;            /// size of a pointer in bytes
+    ubyte realsize;           /// size a real consumes in memory
+    ubyte realpad;            /// padding added to the CPU real size to bring it up to realsize
+    ubyte realalignsize;      /// alignment for reals
+    ubyte classinfosize;      /// size of `ClassInfo`
     ulong maxStaticDataSize;  /// maximum size of static data
 
     /// C ABI
@@ -1169,9 +1169,9 @@ struct TargetC
         WASI,
     }
 
-    uint longsize;            /// size of a C `long` or `unsigned long` type
-    uint long_doublesize;     /// size of a C `long double`
-    uint wchar_tsize;         /// size of a C `wchar_t` type
+    ubyte longsize;           /// size of a C `long` or `unsigned long` type
+    ubyte long_doublesize;    /// size of a C `long double`
+    ubyte wchar_tsize;        /// size of a C `wchar_t` type
     Runtime runtime;          /// vendor of the C runtime to link against
 
     extern (D) void initialize(ref const Param params, ref const Target target)

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -59,9 +59,9 @@ struct TargetC
         UClibc,
         WASI,
     };
-    unsigned longsize;            // size of a C 'long' or 'unsigned long' type
-    unsigned long_doublesize;     // size of a C 'long double'
-    unsigned wchar_tsize;         // size of a C 'wchar_t' type
+    uint8_t longsize;            // size of a C 'long' or 'unsigned long' type
+    uint8_t long_doublesize;     // size of a C 'long double'
+    uint8_t wchar_tsize;         // size of a C 'wchar_t' type
     Runtime runtime;
 };
 
@@ -120,11 +120,11 @@ struct Target
 
     OS os;
     // D ABI
-    unsigned ptrsize;
-    unsigned realsize;           // size a real consumes in memory
-    unsigned realpad;            // 'padding' added to the CPU real size to bring it up to realsize
-    unsigned realalignsize;      // alignment for reals
-    unsigned classinfosize;      // size of 'ClassInfo'
+    uint8_t ptrsize;
+    uint8_t realsize;           // size a real consumes in memory
+    uint8_t realpad;            // 'padding' added to the CPU real size to bring it up to realsize
+    uint8_t realalignsize;      // alignment for reals
+    uint8_t classinfosize;      // size of 'ClassInfo'
     unsigned long long maxStaticDataSize;  // maximum size of static data
 
     // C ABI

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -125,7 +125,7 @@ struct Target
     uint8_t realpad;            // 'padding' added to the CPU real size to bring it up to realsize
     uint8_t realalignsize;      // alignment for reals
     uint8_t classinfosize;      // size of 'ClassInfo'
-    unsigned long long maxStaticDataSize;  // maximum size of static data
+    uint64_t maxStaticDataSize; // maximum size of static data
 
     // C ABI
     TargetC c;


### PR DESCRIPTION
Type size fields are unlikely to be any value greater than `32`.  The ClassInfo size has been fixed at `152` for decades.