### PR TITLE
dmd.cparse: Templatize CParser constructor to accept a TargetC interface

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -40,8 +40,8 @@ final class CParser(AST) : Parser!AST
 
     bool addFuncName;             /// add declaration of __func__ to function symbol table
 
-    extern (D) this(AST.Module _module, const(char)[] input, bool doDocComment,
-        ubyte longsize, ubyte long_doublesize, ubyte wchar_tsize)
+    extern (D) this(TARGET)(AST.Module _module, const(char)[] input, bool doDocComment,
+                            const ref TARGET target)
     {
         super(_module, input, doDocComment);
 
@@ -51,9 +51,9 @@ final class CParser(AST) : Parser!AST
         Ccompile = true;
 
         // Configure sizes for C `long`, `long double`, `wchar_t`
-        this.longsize = longsize;
-        this.long_doublesize = long_doublesize;
-        this.wchar_tsize = wchar_tsize;
+        this.longsize = target.longsize;
+        this.long_doublesize = target.long_doublesize;
+        this.wchar_tsize = target.wchar_tsize;
 
         // C `char` is always unsigned in ImportC
     }

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1060,8 +1060,7 @@ extern (C++) final class Module : Package
         {
             isCFile = true;
 
-            scope p = new CParser!AST(this, buf, cast(bool) docfile,
-                target.c.longsize, target.c.long_doublesize, target.c.wchar_tsize);
+            scope p = new CParser!AST(this, buf, cast(bool) docfile, target.c);
             p.nextToken();
             members = p.parseModule();
             md = p.md;


### PR DESCRIPTION
This is what I meant in https://github.com/dlang/dmd/pull/12507#discussion_r634246110.  This allows more type sizes to be passed to the CParser so long as they conform to the `TargetC` interface.

The change I have coming up adds: `boolsize`, `shortsize`, `intsize` and `long_longsize`.  I did have a look into `charsize`, but in reality, it's never going to be anything other than 8 bits - even though a proprietary GCC compiler could override it (I'm looking at you, DSP microcontrollers).