### PR TITLE
fix Issue 21931 - importC: 'alias time_t = time_t;' cannot alias itself, use a qualified name to create an overload set

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1735,6 +1735,7 @@ final class CParser(AST) : Parser!AST
         SCW scw = pscw & SCW.xtypedef;
         MOD mod;
         Identifier id;
+        Identifier previd;
 
     Lwhile:
         while (1)
@@ -1851,6 +1852,11 @@ final class CParser(AST) : Parser!AST
                     // 2nd identifier can't be a typedef
                     break Lwhile; // leave parser on the identifier for the following declarator
                 }
+                else if (tkwx & TKW.xident)
+                {
+                    // 1st identifier, save it for TypeIdentifier
+                    previd = id;
+                }
                 if (tkw & TKW.xident && tkwx ||  // typedef-name followed by type-specifier
                     tkw & tkwx)                  // duplicate type-specifiers
                 {
@@ -1957,7 +1963,7 @@ final class CParser(AST) : Parser!AST
             case TKW.xcomplex | TKW.xdouble:               t = AST.Type.tcomplex64; break;
             case TKW.xcomplex | TKW.xlong | TKW.xdouble:   t = realType(RTFlags.complex); break;
 
-            case TKW.xident:                    t = new AST.TypeIdentifier(loc, id);
+            case TKW.xident:                    t = new AST.TypeIdentifier(loc, previd);
                 break;
 
             case TKW.xtag:

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -261,6 +261,11 @@ void test4(int i)
 }
 
 /********************************/
+// https://issues.dlang.org/show_bug.cgi?id=21931
+typedef long int long_int;
+typedef long_int my_int;
+
+/********************************/
 
 int printf(const char*, ...);
 


### PR DESCRIPTION
When parsing `typedef ident1 ident2`, the first identifier got dropped, and a `TypeIdentifer` to `ident2` is returned.  This resulted in the bogus error `alias ident2 = ident2; cannot alias itself`.