### PR TITLE
Windows: Allow enforced ANSI colors for redirected stderr

### DIFF
--- a/src/dmd/console.d
+++ b/src/dmd/console.d
@@ -15,6 +15,21 @@ module dmd.console;
 import core.stdc.stdio;
 extern (C) int isatty(int) nothrow;
 
+version (Windows)
+{
+    import core.sys.windows.winbase;
+    import core.sys.windows.wincon;
+    import core.sys.windows.windef;
+}
+else version (Posix)
+{
+    import core.sys.posix.unistd;
+}
+else
+{
+    static assert(0);
+}
+
 
 enum Color : int
 {
@@ -37,16 +52,37 @@ enum Color : int
     white         = bright | lightGray,
 }
 
-struct Console
+interface Console
 {
   nothrow:
+    @property FILE* fp();
 
+    /**
+     * Turn on/off intensity.
+     * Params:
+     *      bright = turn it on
+     */
+    void setColorBright(bool bright);
+
+    /**
+     * Set color and intensity.
+     * Params:
+     *      color = the color
+     */
+    void setColor(Color color);
+
+    /**
+     * Reset console attributes to what they were
+     * when create() was called.
+     */
+    void resetColor();
+}
+
+private
+{
     version (Windows)
+    final class WindowsConsole : Console
     {
-        import core.sys.windows.winbase;
-        import core.sys.windows.wincon;
-        import core.sys.windows.windef;
-
       private:
         CONSOLE_SCREEN_BUFFER_INFO sbi;
         HANDLE handle;
@@ -56,31 +92,6 @@ struct Console
 
         @property FILE* fp() { return _fp; }
 
-        /**
-         Tries to detect whether DMD has been invoked from a terminal.
-         Returns: `true` if a terminal has been detected, `false` otherwise
-         */
-        static bool detectTerminal()
-        {
-            auto h = GetStdHandle(STD_OUTPUT_HANDLE);
-            CONSOLE_SCREEN_BUFFER_INFO sbi;
-            if (GetConsoleScreenBufferInfo(h, &sbi) == 0) // get initial state of console
-                return false; // no terminal detected
-
-            version (CRuntime_DigitalMars)
-            {
-                return isatty(stdout._file) != 0;
-            }
-            else version (CRuntime_Microsoft)
-            {
-                return isatty(fileno(stdout)) != 0;
-            }
-            else
-            {
-                static assert(0, "Unsupported Windows runtime.");
-            }
-        }
-
         /*********************************
          * Create an instance of Console connected to stream fp.
          * Params:
@@ -89,43 +100,24 @@ struct Console
          *      pointer to created Console
          *      null if failed
          */
-        static Console* create(FILE* fp)
+        this(FILE* fp)
         {
-            /* Determine if stream fp is a console
-             */
-            version (CRuntime_DigitalMars)
-            {
-                if (!isatty(fp._file))
-                    return null;
-            }
-            else version (CRuntime_Microsoft)
-            {
-                if (!isatty(fileno(fp)))
-                    return null;
-            }
-            else
-            {
-                return null;
-            }
-
             DWORD nStdHandle;
             if (fp == stdout)
                 nStdHandle = STD_OUTPUT_HANDLE;
             else if (fp == stderr)
                 nStdHandle = STD_ERROR_HANDLE;
             else
-                return null;
+                assert(false);
 
             auto h = GetStdHandle(nStdHandle);
             CONSOLE_SCREEN_BUFFER_INFO sbi;
             if (GetConsoleScreenBufferInfo(h, &sbi) == 0) // get initial state of console
-                return null;
+                assert(false);
 
-            auto c = new Console();
-            c._fp = fp;
-            c.handle = h;
-            c.sbi = sbi;
-            return c;
+            this._fp = fp;
+            this.handle = h;
+            this.sbi = sbi;
         }
 
         /*******************
@@ -164,7 +156,9 @@ struct Console
             SetConsoleTextAttribute(handle, sbi.wAttributes);
         }
     }
-    else version (Posix)
+
+    version (Posix)
+    final class ANSIConsole : Console
     {
         /* The ANSI escape codes are used.
          * https://en.wikipedia.org/wiki/ANSI_escape_code
@@ -182,31 +176,16 @@ struct Console
          *  8: hidden
          */
 
-        import core.sys.posix.unistd;
-
       private:
         FILE* _fp;
 
       public:
 
         @property FILE* fp() { return _fp; }
-        /**
-         Tries to detect whether DMD has been invoked from a terminal.
-         Returns: `true` if a terminal has been detect, `false` otherwise
-         */
-        static bool detectTerminal()
-        {
-            import core.stdc.stdlib : getenv;
-            const(char)* term = getenv("TERM");
-            import core.stdc.string : strcmp;
-            return isatty(STDERR_FILENO) && term && term[0] && strcmp(term, "dumb") != 0;
-        }
 
-        static Console* create(FILE* fp)
+        this(FILE* fp)
         {
-            auto c = new Console();
-            c._fp = fp;
-            return c;
+            this._fp = fp;
         }
 
         void setColorBright(bool bright)
@@ -224,29 +203,60 @@ struct Console
             fputs("\033[m", _fp);
         }
     }
-    else
+}
+
+
+/**
+ Tries to detect whether DMD has been invoked from a terminal.
+ Returns: `true` if a terminal has been detected, `false` otherwise
+ */
+bool detectTerminal() nothrow
+{
+    version (Windows)
     {
-        @property FILE* fp() { assert(0); }
+        auto h = GetStdHandle(STD_OUTPUT_HANDLE);
+        CONSOLE_SCREEN_BUFFER_INFO sbi;
+        if (GetConsoleScreenBufferInfo(h, &sbi) == 0) // get initial state of console
+            return false; // no terminal detected
 
-        static Console* create(FILE* fp)
+        version (CRuntime_DigitalMars)
         {
-            return null;
+            return isatty(stdout._file) != 0;
         }
-
-        void setColorBright(bool bright)
+        else version (CRuntime_Microsoft)
         {
-            assert(0);
+            return isatty(fileno(stdout)) != 0;
         }
-
-        void setColor(Color color)
+        else
         {
-            assert(0);
-        }
-
-        void resetColor()
-        {
-            assert(0);
+            static assert(0, "Unsupported Windows runtime.");
         }
     }
+    else
+    version (Posix)
+    {
+        import core.stdc.stdlib : getenv;
+        const(char)* term = getenv("TERM");
+        import core.stdc.string : strcmp;
+        return isatty(STDERR_FILENO) && term && term[0] && strcmp(term, "dumb") != 0;
+    }
+}
 
+/**
+ * Creates an instance of Console connected to stream fp.
+ * Params:
+ *      fp = io stream
+ * Returns:
+ *      reference to created Console
+ */
+Console createConsole(FILE* fp)
+{
+    if (detectTerminal())
+    {
+        version (Windows)
+            return new WindowsConsole(fp);
+        version (Posix)
+            return new ANSIConsole(fp);
+    }
+    return null;
 }

--- a/src/dmd/console.d
+++ b/src/dmd/console.d
@@ -78,133 +78,129 @@ interface Console
     void resetColor();
 }
 
-private
+version (Windows)
+private final class WindowsConsole : Console
 {
-    version (Windows)
-    final class WindowsConsole : Console
+  private:
+    CONSOLE_SCREEN_BUFFER_INFO sbi;
+    HANDLE handle;
+    FILE* _fp;
+
+  public:
+
+    @property FILE* fp() { return _fp; }
+
+    /*********************************
+     * Create an instance of Console connected to stream fp.
+     * Params:
+     *      fp = io stream
+     * Returns:
+     *      pointer to created Console
+     *      null if failed
+     */
+    this(FILE* fp)
     {
-      private:
+        DWORD nStdHandle;
+        if (fp == stdout)
+            nStdHandle = STD_OUTPUT_HANDLE;
+        else if (fp == stderr)
+            nStdHandle = STD_ERROR_HANDLE;
+        else
+            assert(false);
+
+        auto h = GetStdHandle(nStdHandle);
         CONSOLE_SCREEN_BUFFER_INFO sbi;
-        HANDLE handle;
-        FILE* _fp;
+        if (GetConsoleScreenBufferInfo(h, &sbi) == 0) // get initial state of console
+            assert(false);
 
-      public:
-
-        @property FILE* fp() { return _fp; }
-
-        /*********************************
-         * Create an instance of Console connected to stream fp.
-         * Params:
-         *      fp = io stream
-         * Returns:
-         *      pointer to created Console
-         *      null if failed
-         */
-        this(FILE* fp)
-        {
-            DWORD nStdHandle;
-            if (fp == stdout)
-                nStdHandle = STD_OUTPUT_HANDLE;
-            else if (fp == stderr)
-                nStdHandle = STD_ERROR_HANDLE;
-            else
-                assert(false);
-
-            auto h = GetStdHandle(nStdHandle);
-            CONSOLE_SCREEN_BUFFER_INFO sbi;
-            if (GetConsoleScreenBufferInfo(h, &sbi) == 0) // get initial state of console
-                assert(false);
-
-            this._fp = fp;
-            this.handle = h;
-            this.sbi = sbi;
-        }
-
-        /*******************
-         * Turn on/off intensity.
-         * Params:
-         *      bright = turn it on
-         */
-        void setColorBright(bool bright)
-        {
-            SetConsoleTextAttribute(handle, sbi.wAttributes | (bright ? FOREGROUND_INTENSITY : 0));
-        }
-
-        /***************************
-         * Set color and intensity.
-         * Params:
-         *      color = the color
-         */
-        void setColor(Color color)
-        {
-            enum FOREGROUND_WHITE = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
-            WORD attr = sbi.wAttributes;
-            attr = (attr & ~(FOREGROUND_WHITE | FOREGROUND_INTENSITY)) |
-                   ((color & Color.red)    ? FOREGROUND_RED   : 0) |
-                   ((color & Color.green)  ? FOREGROUND_GREEN : 0) |
-                   ((color & Color.blue)   ? FOREGROUND_BLUE  : 0) |
-                   ((color & Color.bright) ? FOREGROUND_INTENSITY : 0);
-            SetConsoleTextAttribute(handle, attr);
-        }
-
-        /******************
-         * Reset console attributes to what they were
-         * when create() was called.
-         */
-        void resetColor()
-        {
-            SetConsoleTextAttribute(handle, sbi.wAttributes);
-        }
+        this._fp = fp;
+        this.handle = h;
+        this.sbi = sbi;
     }
 
-    version (Posix)
-    final class ANSIConsole : Console
+    /*******************
+     * Turn on/off intensity.
+     * Params:
+     *      bright = turn it on
+     */
+    void setColorBright(bool bright)
     {
-        /* The ANSI escape codes are used.
-         * https://en.wikipedia.org/wiki/ANSI_escape_code
-         * Foreground colors: 30..37
-         * Background colors: 40..47
-         * Attributes:
-         *  0: reset all attributes
-         *  1: high intensity
-         *  2: low intensity
-         *  3: italic
-         *  4: single line underscore
-         *  5: slow blink
-         *  6: fast blink
-         *  7: reverse video
-         *  8: hidden
-         */
+        SetConsoleTextAttribute(handle, sbi.wAttributes | (bright ? FOREGROUND_INTENSITY : 0));
+    }
 
-      private:
-        FILE* _fp;
+    /***************************
+     * Set color and intensity.
+     * Params:
+     *      color = the color
+     */
+    void setColor(Color color)
+    {
+        enum FOREGROUND_WHITE = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+        WORD attr = sbi.wAttributes;
+        attr = (attr & ~(FOREGROUND_WHITE | FOREGROUND_INTENSITY)) |
+               ((color & Color.red)    ? FOREGROUND_RED   : 0) |
+               ((color & Color.green)  ? FOREGROUND_GREEN : 0) |
+               ((color & Color.blue)   ? FOREGROUND_BLUE  : 0) |
+               ((color & Color.bright) ? FOREGROUND_INTENSITY : 0);
+        SetConsoleTextAttribute(handle, attr);
+    }
 
-      public:
-
-        @property FILE* fp() { return _fp; }
-
-        this(FILE* fp)
-        {
-            this._fp = fp;
-        }
-
-        void setColorBright(bool bright)
-        {
-            fprintf(_fp, "\033[%dm", bright);
-        }
-
-        void setColor(Color color)
-        {
-            fprintf(_fp, "\033[%d;%dm", color & Color.bright ? 1 : 0, 30 + (color & ~Color.bright));
-        }
-
-        void resetColor()
-        {
-            fputs("\033[m", _fp);
-        }
+    /******************
+     * Reset console attributes to what they were
+     * when create() was called.
+     */
+    void resetColor()
+    {
+        SetConsoleTextAttribute(handle, sbi.wAttributes);
     }
 }
 
+version (Posix)
+private final class ANSIConsole : Console
+{
+    /* The ANSI escape codes are used.
+     * https://en.wikipedia.org/wiki/ANSI_escape_code
+     * Foreground colors: 30..37
+     * Background colors: 40..47
+     * Attributes:
+     *  0: reset all attributes
+     *  1: high intensity
+     *  2: low intensity
+     *  3: italic
+     *  4: single line underscore
+     *  5: slow blink
+     *  6: fast blink
+     *  7: reverse video
+     *  8: hidden
+     */
+
+  private:
+    FILE* _fp;
+
+  public:
+
+    @property FILE* fp() { return _fp; }
+
+    this(FILE* fp)
+    {
+        this._fp = fp;
+    }
+
+    void setColorBright(bool bright)
+    {
+        fprintf(_fp, "\033[%dm", bright);
+    }
+
+    void setColor(Color color)
+    {
+        fprintf(_fp, "\033[%d;%dm", color & Color.bright ? 1 : 0, 30 + (color & ~Color.bright));
+    }
+
+    void resetColor()
+    {
+        fputs("\033[m", _fp);
+    }
+}
 
 /**
  Tries to detect whether DMD has been invoked from a terminal.

--- a/src/dmd/console.d
+++ b/src/dmd/console.d
@@ -80,33 +80,59 @@ interface Console
 version (Windows)
 private final class WindowsConsole : Console
 {
+  nothrow:
+
   private:
     CONSOLE_SCREEN_BUFFER_INFO sbi;
     HANDLE handle;
     FILE* _fp;
 
+    static HANDLE getStdHandle(FILE *fp)
+    {
+        /* Determine if stream fp is a console
+         */
+        version (CRuntime_DigitalMars)
+        {
+            if (!isatty(fp._file))
+                return null;
+        }
+        else version (CRuntime_Microsoft)
+        {
+            if (!isatty(fileno(fp)))
+                return null;
+        }
+        else
+        {
+            static assert(0, "Unsupported Windows runtime.");
+        }
+
+        if (fp == stdout)
+            return GetStdHandle(STD_OUTPUT_HANDLE);
+        else if (fp == stderr)
+            return GetStdHandle(STD_ERROR_HANDLE);
+        else
+            return null;
+    }
+
   public:
 
     @property FILE* fp() { return _fp; }
 
-    this(FILE* fp)
+    static WindowsConsole create(FILE* fp)
     {
-        DWORD nStdHandle;
-        if (fp == stdout)
-            nStdHandle = STD_OUTPUT_HANDLE;
-        else if (fp == stderr)
-            nStdHandle = STD_ERROR_HANDLE;
-        else
-            assert(false);
+        auto h = getStdHandle(fp);
+        if (h is null)
+            return null;
 
-        auto h = GetStdHandle(nStdHandle);
         CONSOLE_SCREEN_BUFFER_INFO sbi;
         if (GetConsoleScreenBufferInfo(h, &sbi) == 0) // get initial state of console
-            assert(false);
+            return null;
 
-        this._fp = fp;
-        this.handle = h;
-        this.sbi = sbi;
+        auto c = new WindowsConsole();
+        c._fp = fp;
+        c.handle = h;
+        c.sbi = sbi;
+        return c;
     }
 
     void setColorBright(bool bright)
@@ -147,21 +173,18 @@ private final class WindowsConsole : Console
  *  7: reverse video
  *  8: hidden
  */
-version (Posix)
 private final class ANSIConsole : Console
 {
+  nothrow:
 
   private:
     FILE* _fp;
 
   public:
 
-    @property FILE* fp() { return _fp; }
+    this(FILE* fp) { _fp = fp; }
 
-    this(FILE* fp)
-    {
-        this._fp = fp;
-    }
+    @property FILE* fp() { return _fp; }
 
     void setColorBright(bool bright)
     {
@@ -185,33 +208,21 @@ private final class ANSIConsole : Console
  */
 bool detectTerminal() nothrow
 {
-    version (Windows)
-    {
-        auto h = GetStdHandle(STD_OUTPUT_HANDLE);
-        CONSOLE_SCREEN_BUFFER_INFO sbi;
-        if (GetConsoleScreenBufferInfo(h, &sbi) == 0) // get initial state of console
-            return false; // no terminal detected
-
-        version (CRuntime_DigitalMars)
-        {
-            return isatty(stdout._file) != 0;
-        }
-        else version (CRuntime_Microsoft)
-        {
-            return isatty(fileno(stdout)) != 0;
-        }
-        else
-        {
-            static assert(0, "Unsupported Windows runtime.");
-        }
-    }
-    else
     version (Posix)
     {
         import core.stdc.stdlib : getenv;
         const(char)* term = getenv("TERM");
         import core.stdc.string : strcmp;
         return isatty(STDERR_FILENO) && term && term[0] && strcmp(term, "dumb") != 0;
+    }
+    else version (Windows)
+    {
+        auto h = WindowsConsole.getStdHandle(stderr);
+        if (h is null)
+            return false;
+
+        CONSOLE_SCREEN_BUFFER_INFO sbi;
+        return GetConsoleScreenBufferInfo(h, &sbi) != 0;
     }
 }
 
@@ -222,14 +233,13 @@ bool detectTerminal() nothrow
  * Returns:
  *      reference to created Console
  */
-Console createConsole(FILE* fp)
+Console createConsole(FILE* fp) nothrow
 {
-    if (detectTerminal())
+    version (Windows)
     {
-        version (Windows)
-            return new WindowsConsole(fp);
-        version (Posix)
-            return new ANSIConsole(fp);
+        if (auto c = WindowsConsole.create(fp))
+            return c;
     }
-    return null;
+
+    return new ANSIConsole(fp);
 }

--- a/src/dmd/console.d
+++ b/src/dmd/console.d
@@ -30,7 +30,6 @@ else
     static assert(0);
 }
 
-
 enum Color : int
 {
     black         = 0,
@@ -90,14 +89,6 @@ private final class WindowsConsole : Console
 
     @property FILE* fp() { return _fp; }
 
-    /*********************************
-     * Create an instance of Console connected to stream fp.
-     * Params:
-     *      fp = io stream
-     * Returns:
-     *      pointer to created Console
-     *      null if failed
-     */
     this(FILE* fp)
     {
         DWORD nStdHandle;
@@ -118,61 +109,47 @@ private final class WindowsConsole : Console
         this.sbi = sbi;
     }
 
-    /*******************
-     * Turn on/off intensity.
-     * Params:
-     *      bright = turn it on
-     */
     void setColorBright(bool bright)
     {
         SetConsoleTextAttribute(handle, sbi.wAttributes | (bright ? FOREGROUND_INTENSITY : 0));
     }
 
-    /***************************
-     * Set color and intensity.
-     * Params:
-     *      color = the color
-     */
     void setColor(Color color)
     {
         enum FOREGROUND_WHITE = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
         WORD attr = sbi.wAttributes;
         attr = (attr & ~(FOREGROUND_WHITE | FOREGROUND_INTENSITY)) |
-               ((color & Color.red)    ? FOREGROUND_RED   : 0) |
-               ((color & Color.green)  ? FOREGROUND_GREEN : 0) |
-               ((color & Color.blue)   ? FOREGROUND_BLUE  : 0) |
-               ((color & Color.bright) ? FOREGROUND_INTENSITY : 0);
+                ((color & Color.red)    ? FOREGROUND_RED   : 0) |
+                ((color & Color.green)  ? FOREGROUND_GREEN : 0) |
+                ((color & Color.blue)   ? FOREGROUND_BLUE  : 0) |
+                ((color & Color.bright) ? FOREGROUND_INTENSITY : 0);
         SetConsoleTextAttribute(handle, attr);
     }
 
-    /******************
-     * Reset console attributes to what they were
-     * when create() was called.
-     */
     void resetColor()
     {
         SetConsoleTextAttribute(handle, sbi.wAttributes);
     }
 }
 
+/* Uses the ANSI escape codes.
+ * https://en.wikipedia.org/wiki/ANSI_escape_code
+ * Foreground colors: 30..37
+ * Background colors: 40..47
+ * Attributes:
+ *  0: reset all attributes
+ *  1: high intensity
+ *  2: low intensity
+ *  3: italic
+ *  4: single line underscore
+ *  5: slow blink
+ *  6: fast blink
+ *  7: reverse video
+ *  8: hidden
+ */
 version (Posix)
 private final class ANSIConsole : Console
 {
-    /* The ANSI escape codes are used.
-     * https://en.wikipedia.org/wiki/ANSI_escape_code
-     * Foreground colors: 30..37
-     * Background colors: 40..47
-     * Attributes:
-     *  0: reset all attributes
-     *  1: high intensity
-     *  2: low intensity
-     *  3: italic
-     *  4: single line underscore
-     *  5: slow blink
-     *  6: fast blink
-     *  7: reverse video
-     *  8: hidden
-     */
 
   private:
     FILE* _fp;

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -344,7 +344,7 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
 
     if (global.params.showGaggedErrors && global.gag)
         fprintf(stderr, "(spec:%d) ", global.gag);
-    Console* con = cast(Console*)global.console;
+    Console con = cast(Console) global.console;
     const p = loc.toChars();
     if (con)
         con.setColorBright(true);
@@ -808,7 +808,7 @@ private void colorHighlightCode(ref OutBuffer buf)
  * Params:
  *      buf = highlighted text
  */
-private void writeHighlights(Console* con, ref const OutBuffer buf)
+private void writeHighlights(Console con, ref const OutBuffer buf)
 {
     bool colors;
     scope (exit)

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -365,8 +365,8 @@ extern (C++) struct Global
             vendor = "Digital Mars D";
 
             // -color=auto is the default value
-            import dmd.console : Console;
-            params.color = Console.detectTerminal();
+            import dmd.console : detectTerminal;
+            params.color = detectTerminal();
         }
         else version (IN_GCC)
         {

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -260,7 +260,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     }
 
     if (params.color)
-        global.console = Console.create(core.stdc.stdio.stderr);
+        global.console = cast(void*) createConsole(core.stdc.stdio.stderr);
 
     target.os = defaultTargetOS();           // set target operating system
     target.setCPU();

--- a/test/compilable/testcolor.sh
+++ b/test/compilable/testcolor.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# We never use ANSI codes on Windows, so, we can't test them.
-if [[ $OS = *"win"* ]]; then exit 0; fi
-
 compare()
 {
     local actual="$1"


### PR DESCRIPTION
`-color=on` used to be a no-op on Windows if `stdout` wasn't a terminal. Enable ANSI color codes instead, just like on Posix, enabling colored output for GitLab CI for example.