### PR TITLE
Fix Issue 2450 - Error using operators from named template mixin (version 2)

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7935,7 +7935,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = e.expressionSemantic(sc);
             return;
         }
-        if (!exp.type || exp.e1.op == TOK.this_)
+        if (!exp.type)
             exp.type = exp.e2.type;
         result = exp;
     }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3776,9 +3776,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         TemplateMixin tm = s.isTemplateMixin();
         if (tm)
         {
-            Expression de = new DotExp(e.loc, e, new ScopeExp(e.loc, tm));
-            de.type = e.type;
-            return de;
+            return new DotExp(e.loc, e, new ScopeExp(e.loc, tm)).expressionSemantic(sc);
         }
 
         TemplateDeclaration td = s.isTemplateDeclaration();
@@ -4186,9 +4184,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         TemplateMixin tm = s.isTemplateMixin();
         if (tm)
         {
-            Expression de = new DotExp(e.loc, e, new ScopeExp(e.loc, tm));
-            de.type = e.type;
-            return de;
+            return new DotExp(e.loc, e, new ScopeExp(e.loc, tm)).expressionSemantic(sc);
         }
 
         TemplateDeclaration td = s.isTemplateDeclaration();

--- a/test/fail_compilation/fail2450.d
+++ b/test/fail_compilation/fail2450.d
@@ -2,7 +2,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2450.d(20): Error: function expected before `()`, not `this.mixin Event!() clicked;
+fail_compilation/fail2450.d(22): Error: function expected before `()`, not `this.mixin Event!() clicked;
+` of type `void`
+fail_compilation/fail2450.d(25): Error: function expected before `()`, not `b.mixin Event!() clicked;
 ` of type `void`
 ---
 */
@@ -18,5 +20,8 @@ class Button {
     {
 		clicked.opCall(); // works
 		this.clicked();   // works
+
+		auto b = new Button();
+		b.clicked();      // works
 	}
 }

--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-runnable/mixin1.d(959): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/mixin1.d(948): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 ---
 
 RUN_OUTPUT:
@@ -41,8 +41,6 @@ int
 int
 foo 1
 foo 2
-opCall 1
-opCall 2
 0 0
 two
 one
@@ -804,11 +802,6 @@ template T33( int i )
         printf("foo %d\n", i );
         return i;
     }
-    int opCall()
-    {
-        printf("opCall %d\n", i );
-        return i;
-    }
 }
 
 
@@ -825,10 +818,6 @@ void test33()
     i = c1.t1.foo();
     assert(i == 1);
     i = c1.t2.foo();
-    assert(i == 2);
-    i = c1.t1();
-    assert(i == 1);
-    i = c1.t2();
     assert(i == 2);
 }
 


### PR DESCRIPTION
Previous fix #10406 

My reply there:
> While I was trying to fix another issue I discovered a test that is not fixed by this pull, so I'm pushing a patch touching the root of the problem and moving the other test (part of test33() from runnable/mixin1.d) to fail_compilation/fail2450.d.