### PR TITLE
Remove early error from resolvePropertiesX()

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1356,11 +1356,6 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
             if (checkUnsafeAccess(sc, e1, true, true))
                 return ErrorExp.get();
         }
-        else if (e1.op == TOK.dot)
-        {
-            e1.error("expression has no value");
-            return ErrorExp.get();
-        }
         else if (e1.op == TOK.call)
         {
             CallExp ce = cast(CallExp)e1;

--- a/test/fail_compilation/fail117.d
+++ b/test/fail_compilation/fail117.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail117.d(35): Error: expression has no value
-fail_compilation/fail117.d(36): Error: expression has no value
+fail_compilation/fail117.d(37): Error: expression `foo.mixin MGettor!(a) geta;
+` is `void` and has no value
+fail_compilation/fail117.d(38): Error: expression `foo.mixin MGettor!(b) getb;
+` is `void` and has no value
 ---
 */
 

--- a/test/fail_compilation/ice9406.d
+++ b/test/fail_compilation/ice9406.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9406.d(21): Error: expression has no value
+fail_compilation/ice9406.d(22): Error: `s1.mixin Mixin!() t1;
+` has no effect
 ---
 */
 


### PR DESCRIPTION
This solitary and unneeded error prevents analyzing the expression later in semantics.

Due to another bug, it depends on #12542 to print a correct error message in `fail_compilation/fail117.d `.