### PR TITLE
Fix Issue 21927 - ICE (illegal instruction) with static foreach over empty member template

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -71,6 +71,10 @@ public Expression ctfeInterpret(Expression e)
         case TOK.super_:
         case TOK.type:
         case TOK.typeid_:
+        case TOK.template_:              // non-eponymous template/instance
+        case TOK.scope_:                 // ditto
+        case TOK.dotTemplateDeclaration: // ditto, e.e1 doesn't matter here
+        case TOK.dot:                    // ditto
              if (e.type.ty == Terror)
                 return ErrorExp.get();
             goto case TOK.error;

--- a/test/compilable/interpret5.d
+++ b/test/compilable/interpret5.d
@@ -1,0 +1,30 @@
+// https://issues.dlang.org/show_bug.cgi?id=21927
+/*
+TEST_OUTPUT:
+---
+T1(Args...)
+T1!()
+T2(Args2...)
+T2!()
+this.T2(Args2...)
+this.T2!()
+---
+*/
+template T1(Args...) {}
+
+pragma(msg, T1);    // TOK.template_
+pragma(msg, T1!()); // TOK.scope_
+
+struct S
+{
+    template T2(Args2...) {}
+
+    pragma(msg, S.T2);    // TOK.template_
+    pragma(msg, S.T2!()); // TOK.scope_
+
+    void fun()
+    {
+        pragma(msg, this.T2);    // TOK.dotTemplateDeclaration
+        pragma(msg, this.T2!()); // TOK.dot
+    }
+}

--- a/test/fail_compilation/fail238_m32.d
+++ b/test/fail_compilation/fail238_m32.d
@@ -3,7 +3,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail238_m32.d(21): Error: cannot implicitly convert expression `"a"` of type `string` to `uint`
-fail_compilation/fail238_m32.d(24): Error: cannot interpret `X!()` at compile time
+fail_compilation/fail238_m32.d(24): Error: cannot implicitly convert expression `X!()` of type `void` to `const(string)`
 fail_compilation/fail238_m32.d(29): Error: template instance `fail238_m32.A!"a"` error instantiating
 fail_compilation/fail238_m32.d(35):        instantiated from here: `M!(q)`
 fail_compilation/fail238_m32.d(35):        while evaluating `pragma(msg, M!(q))`

--- a/test/fail_compilation/fail238_m64.d
+++ b/test/fail_compilation/fail238_m64.d
@@ -3,7 +3,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail238_m64.d(21): Error: cannot implicitly convert expression `"a"` of type `string` to `ulong`
-fail_compilation/fail238_m64.d(24): Error: cannot interpret `X!()` at compile time
+fail_compilation/fail238_m64.d(24): Error: cannot implicitly convert expression `X!()` of type `void` to `const(string)`
 fail_compilation/fail238_m64.d(29): Error: template instance `fail238_m64.A!"a"` error instantiating
 fail_compilation/fail238_m64.d(35):        instantiated from here: `M!(q)`
 fail_compilation/fail238_m64.d(35):        while evaluating `pragma(msg, M!(q))`

--- a/test/fail_compilation/fail9766.d
+++ b/test/fail_compilation/fail9766.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9766.d(14): Error: cannot interpret `Foo!int` at compile time
+fail_compilation/fail9766.d(14): Error: integer constant expression expected instead of `Foo!int`
+fail_compilation/fail9766.d(14): Error: alignment must be an integer positive power of 2, not Foo!int
 fail_compilation/fail9766.d(17): Error: alignment must be an integer positive power of 2, not -1
 fail_compilation/fail9766.d(20): Error: alignment must be an integer positive power of 2, not 0
 fail_compilation/fail9766.d(23): Error: alignment must be an integer positive power of 2, not 3
@@ -9,6 +10,7 @@ fail_compilation/fail9766.d(26): Error: alignment must be an integer positive po
 ---
 */
 
+#line 12
 template Foo(T) {}
 
 align(Foo!int)

--- a/test/fail_compilation/iasm1.d
+++ b/test/fail_compilation/iasm1.d
@@ -22,8 +22,7 @@ void test100(ulong bar)
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/iasm1.d(213): Error: cannot interpret `opDispatch!"foo"` at compile time
-fail_compilation/iasm1.d(213): Error: bad type/size of operands `__error`
+fail_compilation/iasm1.d(213): Error: bad type/size of operands `opDispatch!"foo"`
 ---
 */
 

--- a/test/fail_compilation/test20549.d
+++ b/test/fail_compilation/test20549.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ----
-fail_compilation/test20549.d(13): Error: variable `test.__a_field_0` variables cannot be of type `void`
-fail_compilation/test20549.d(13): Error: cannot interpret `module test` at compile time
+fail_compilation/test20549.d(12): Error: variable `test.__a_field_0` variables cannot be of type `void`
 ----
 */
 

--- a/test/fail_compilation/test21927.d
+++ b/test/fail_compilation/test21927.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=21927
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test21927.d(19): Error: invalid `foreach` aggregate `this.T2(Args2...)`
+fail_compilation/test21927.d(19): Error: invalid `foreach` aggregate `this.T2(Args2...)`
+fail_compilation/test21927.d(20): Error: invalid `foreach` aggregate `this.T2!()`
+fail_compilation/test21927.d(20): Error: invalid `foreach` aggregate `this.T2!()`
+---
+*/
+
+struct S
+{
+    template T2(Args2...) {}
+
+    void fun()
+    {
+        // original test case
+        static foreach (p; this.T2) {} // ICE
+        static foreach (p; this.T2!()) {} // ICE
+    }
+}


### PR DESCRIPTION
Depends on #12543 to avoid a bogus error message.