### PR TITLE
fix Issue 21934 - importC: Support asm labels to specify the assembler name to use for a C symbol

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -504,6 +504,8 @@ enum class TOK : uint16_t
     __restrict = 257u,
     __declspec = 258u,
     __attribute__ = 259u,
+    __asm__ = 260u,
+    __asm = 261u,
 };
 
 class StringExp;

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -316,6 +316,8 @@ enum TOK : ushort
     __restrict,
     __declspec,
     __attribute__,
+    __asm__,
+    __asm,
 }
 
 enum FirstCKeyword = TOK.inline;
@@ -474,6 +476,8 @@ private immutable TOK[] keywords =
     TOK.__restrict,
     TOK.__declspec,
     TOK.__attribute__,
+    TOK.__asm__,
+    TOK.__asm,
 ];
 
 // Initialize the identifier pool
@@ -499,12 +503,17 @@ static immutable TOK[TOK.max + 1] Ckeywords =
         enum Ckwds = [ auto_, break_, case_, char_, const_, continue_, default_, do_, float64, else_,
                        enum_, extern_, float32, for_, goto_, if_, inline, int32, int64, register,
                        restrict, return_, int16, signed, sizeof_, static_, struct_, switch_, typedef_,
-                       unsigned, void_, volatile, while_,
+                       unsigned, void_, volatile, while_, asm_,
                        _Alignas, _Alignof, _Atomic, _Bool, _Complex, _Generic, _Imaginary, _Noreturn,
                        _Static_assert, _Thread_local, __cdecl, __restrict, __declspec, __attribute__ ];
 
         foreach (kw; Ckwds)
             tab[kw] = cast(TOK) kw;
+
+        // Populate alternate keywords
+        tab[__asm] = asm_;
+        tab[__asm__] = asm_;
+
         return tab;
     }
 } ();
@@ -814,6 +823,8 @@ extern (C++) struct Token
         TOK.__restrict     : "__restrict",
         TOK.__declspec     : "__declspec",
         TOK.__attribute__  : "__attribute__",
+        TOK.__asm          : "__asm",
+        TOK.__asm__        : "__asm__",
     ];
 
     static assert(() {

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -211,6 +211,8 @@ enum
         TOK__restrict,
         TOK__declspec,
         TOK__attribute__,
+        TOK__asm__,
+        TOK__asm,
 
         TOKMAX
 };

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -101,7 +101,7 @@ void test_tokens()
     assert(strcmp(Token::toChars(TOKlparen), "(") == 0);
 
     // Last valid TOK value
-    assert(TOK__attribute__ == TOKMAX - 1);
+    assert(TOK__asm == TOKMAX - 1);
     assert(strcmp(Token::toChars(TOKvectorarray), "vectorarray") == 0);
 }
 

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -266,6 +266,24 @@ typedef long int long_int;
 typedef long_int my_int;
 
 /********************************/
+// https://issues.dlang.org/show_bug.cgi?id=21934
+typedef int type1 asm("realtype1");
+typedef int type2 __asm("realtype2");
+typedef int type3 __asm__("realtype3");
+
+int sym1 asm("realsym1") = 1;
+int sym2 __asm("realsym2") = 2;
+int sym3 __asm__("realsym3") = 3;
+
+int vsym1 asm("realvsym1");
+int vsym2 __asm("realvsym2");
+int vsym3 __asm__("realvsym3");
+
+int fun1() asm("realfun1");
+int fun2() __asm("realfun2");
+int fun3() __asm__("realfun3");
+
+/********************************/
 
 int printf(const char*, ...);
 

--- a/test/unit/lexer/location_offset.d
+++ b/test/unit/lexer/location_offset.d
@@ -538,6 +538,8 @@ enum ignoreTokens
     __restrict,
     __declspec,
     __attribute__,
+    __asm__,
+    __asm,
 
     max_,
 };


### PR DESCRIPTION
Only a few lines of code away from fixing Issue 21937 as well, but that will be in a follow-up.

@WalterBright 