### PR TITLE
Fix Issue 21939 - Duplicate error messages for wrong aggregate in 'static foreach'

### DIFF
--- a/test/fail_compilation/test21939.d
+++ b/test/fail_compilation/test21939.d
@@ -1,0 +1,9 @@
+// https://issues.dlang.org/show_bug.cgi?id=21939
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test21939.d(9): Error: invalid `foreach` aggregate `Object`, define `opApply()`, range primitives, or use `.tupleof`
+---
+*/
+
+static foreach (a; Object) {}


### PR DESCRIPTION
From `lowerNonArrayAggregate()` docs:

`static foreach (x; range) { ... }` is lowered to:
```d
static foreach (x; {
    typeof({
        foreach (x; range) return x;
     }())[] __res;
     foreach (x; range) __res ~= x;
     return __res;
}()) { ... }
```
The fix is to run 'typeof' gagged first and if it fails just create an empty `foreach` to show only one error:

```d
static foreach (x; {
     foreach (x; range){}
}()) { ... }
```