### PR TITLE
Fix 21940 - Recognize on/off as valid options for -check

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1612,7 +1612,25 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             }
 
             const(char)[] checkarg = arg[len .. $];
-            if (!(check(checkarg, "assert",    params.useAssert     ) ||
+            if (checkarg == "on")
+            {
+                params.useAssert        = CHECKENABLE.on;
+                params.useArrayBounds   = CHECKENABLE.on;
+                params.useIn            = CHECKENABLE.on;
+                params.useInvariants    = CHECKENABLE.on;
+                params.useOut           = CHECKENABLE.on;
+                params.useSwitchError   = CHECKENABLE.on;
+            }
+            else if (checkarg == "off")
+            {
+                params.useAssert        = CHECKENABLE.off;
+                params.useArrayBounds   = CHECKENABLE.off;
+                params.useIn            = CHECKENABLE.off;
+                params.useInvariants    = CHECKENABLE.off;
+                params.useOut           = CHECKENABLE.off;
+                params.useSwitchError   = CHECKENABLE.off;
+            }
+            else if (!(check(checkarg, "assert",    params.useAssert) ||
                   check(checkarg, "bounds",    params.useArrayBounds) ||
                   check(checkarg, "in",        params.useIn         ) ||
                   check(checkarg, "invariant", params.useInvariants ) ||

--- a/test/runnable/test_dip1006c.d
+++ b/test/runnable/test_dip1006c.d
@@ -1,0 +1,67 @@
+// ARG_SETS: -check=on -version=CheckOn
+// ARG_SETS: -check=off -version=CheckOff
+// PERMUTE_ARGS:
+
+import core.exception : AssertError, SwitchError;
+
+struct S
+{
+    int foo(int a)
+    in(a <= 0)
+    out(res; res >= 0)
+    do
+    {
+        return a;
+    }
+
+    int bar(int a)
+    {
+        assert(a != 0);
+        return 0;
+    }
+
+    invariant
+    {
+        assert(false);
+    }
+}
+
+void main()
+{
+    S s;
+    test(() => s.foo(1));  // Trigger in
+    test(() => s.foo(-1)); // Trigger out
+    test(() => s.bar(1));  // Trigger invariant
+    test(() => s.bar(0));  // Trigger assert
+
+    // Trigger final switch
+    version (CheckOn)
+    {
+        try
+        {
+            int i = 0;
+            final switch (i)
+            {
+                case 1: break;
+            }
+            throw new Exception("Check skipped!");
+        }
+        catch (SwitchError) {}
+    }
+}
+
+void test(int delegate() test)
+{
+    try
+    {
+        test();
+
+        version (CheckOn)
+            throw new Exception("Check skipped!");
+    }
+    catch (AssertError e)
+    {
+        version (CheckOff)
+            throw new Exception("Check not skipped!");
+    }
+}


### PR DESCRIPTION
Check for the special values `"on"` and `"off"` before parsing `<option>=<state>`.