### PR TITLE
Fix path for nightly artifacts

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -279,10 +279,12 @@ jobs:
       # Debug: Check that all required artifacts are present
       #
       - name: Display all files included in the artifacts
+        id: list-artifacts
         shell: bash
         run: |
           set -euox pipefail
           ls -aul ~ ~/artifacts
+          echo "::set-output name=artifacts_directory::$PWD/artifacts"
 
       #################################################################
       # Create the new release using the downloaded artifacts
@@ -294,6 +296,6 @@ jobs:
           automatic_release_tag: nightly
           title: DMD nightly
           prerelease: true
-          files:  ~/artifacts/*
+          files:  ${{ steps.list-artifacts.outputs.artifacts_directory }}/*
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
N.B.: The first nightly release was empty, I've manually added the generated artifacts.

---

The `glob` package used by `action-automatic-releases` doesn't support tilde expansion yet (see isaacs/node-glob#416).

Use an absolute path extracted from the previous shell step instead.