### PR TITLE
fix Issue 21946, 21942: Remove __asm and __asm__ tokens

### DIFF
--- a/changelog/ImportC.md
+++ b/changelog/ImportC.md
@@ -217,6 +217,21 @@ functions in imports just like it can for D.
 * Much of C code makes use of extensions provided by the host C compiler.
 None of these are implemented.
 
+* Alternative keywords are not implemented. You can define the alternate
+  keywords as macros to remove or replace them with standard keywords.
+
+```
+#define __attribute __attribute__
+#define __asm       asm
+#define __asm__     asm
+#define __const     const
+#define __const__   const
+#define __inline    inline
+#define __inline__  inline
+#define __extension__
+
+#include <stdlib.h>
+```
 
 ## Future Directions
 

--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2466,7 +2466,7 @@ final class CParser(AST) : Parser!AST
     }
 
     /*************************
-     * Simple __asm__ parser
+     * Simple asm parser
      * https://gcc.gnu.org/onlinedocs/gcc/Asm-Labels.html
      * simple-asm-expr:
      *   asm ( asm-string-literal )
@@ -2476,7 +2476,7 @@ final class CParser(AST) : Parser!AST
      */
     private AST.Expression cparseAsmLabel()
     {
-        nextToken();     // move past __asm__
+        nextToken();     // move past asm
         check(TOK.leftParenthesis);
         if (token.value != TOK.string_)
             error("string literal expected");

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -504,8 +504,6 @@ enum class TOK : uint16_t
     __restrict = 257u,
     __declspec = 258u,
     __attribute__ = 259u,
-    __asm__ = 260u,
-    __asm = 261u,
 };
 
 class StringExp;

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -316,8 +316,6 @@ enum TOK : ushort
     __restrict,
     __declspec,
     __attribute__,
-    __asm__,
-    __asm,
 }
 
 enum FirstCKeyword = TOK.inline;
@@ -476,8 +474,6 @@ private immutable TOK[] keywords =
     TOK.__restrict,
     TOK.__declspec,
     TOK.__attribute__,
-    TOK.__asm__,
-    TOK.__asm,
 ];
 
 // Initialize the identifier pool
@@ -509,10 +505,6 @@ static immutable TOK[TOK.max + 1] Ckeywords =
 
         foreach (kw; Ckwds)
             tab[kw] = cast(TOK) kw;
-
-        // Populate alternate keywords
-        tab[__asm] = asm_;
-        tab[__asm__] = asm_;
 
         return tab;
     }
@@ -823,8 +815,6 @@ extern (C++) struct Token
         TOK.__restrict     : "__restrict",
         TOK.__declspec     : "__declspec",
         TOK.__attribute__  : "__attribute__",
-        TOK.__asm          : "__asm",
-        TOK.__asm__        : "__asm__",
     ];
 
     static assert(() {

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -211,8 +211,6 @@ enum
         TOK__restrict,
         TOK__declspec,
         TOK__attribute__,
-        TOK__asm__,
-        TOK__asm,
 
         TOKMAX
 };

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -101,7 +101,7 @@ void test_tokens()
     assert(strcmp(Token::toChars(TOKlparen), "(") == 0);
 
     // Last valid TOK value
-    assert(TOK__asm == TOKMAX - 1);
+    assert(TOK__attribute__ == TOKMAX - 1);
     assert(strcmp(Token::toChars(TOKvectorarray), "vectorarray") == 0);
 }
 

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -267,21 +267,10 @@ typedef long_int my_int;
 
 /********************************/
 // https://issues.dlang.org/show_bug.cgi?id=21934
-typedef int type1 asm("realtype1");
-typedef int type2 __asm("realtype2");
-typedef int type3 __asm__("realtype3");
-
-int sym1 asm("realsym1") = 1;
-int sym2 __asm("realsym2") = 2;
-int sym3 __asm__("realsym3") = 3;
-
-int vsym1 asm("realvsym1");
-int vsym2 __asm("realvsym2");
-int vsym3 __asm__("realvsym3");
-
-int fun1() asm("realfun1");
-int fun2() __asm("realfun2");
-int fun3() __asm__("realfun3");
+typedef int type asm("realtype");
+int sym asm("realsym") = 1;
+int vsym asm("realvsym");
+int fun() asm("realfun");
 
 /********************************/
 

--- a/test/unit/lexer/location_offset.d
+++ b/test/unit/lexer/location_offset.d
@@ -538,8 +538,6 @@ enum ignoreTokens
     __restrict,
     __declspec,
     __attribute__,
-    __asm__,
-    __asm,
 
     max_,
 };


### PR DESCRIPTION
Add note in changelog about using macro to remove or replace alternate keywords.