### PR TITLE
Infer noreturn for auto functions

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -594,9 +594,14 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 if (funcdecl.inferRetType)
                 {
-                    // If no return type inferred yet, then infer a void
+                    // If no return type was inferred yet, then infer as void if the
+                    // control flow can leave the function normally or noreturn if not.
                     if (!f.next)
-                        f.next = Type.tvoid;
+                    {
+                        const be = blockExit(funcdecl.fbody, funcdecl, false);
+                        const returns = be & (BE.fallthru | BE.return_);
+                        f.next = returns ? Type.tvoid : Type.tnoreturn;
+                    }
                     if (f.checkRetType(funcdecl.loc))
                         funcdecl.fbody = new ErrorStatement();
                     else if (funcdecl.isMain())

--- a/test/compilable/noreturn2.d
+++ b/test/compilable/noreturn2.d
@@ -1,0 +1,143 @@
+/*
+REQUIRED_ARGS: -w -o-
+
+Type inference by usage as mentioned in the DIP:
+https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md
+*/
+
+alias noreturn = typeof(*null);
+static assert (!is(noreturn == void));
+
+auto assert0()
+{
+    assert(0);
+}
+
+static assert(is(typeof(assert0()) == noreturn));
+
+/**************************************************************/
+
+auto callAssert0()
+{
+    assert0();
+}
+
+static assert(is(typeof(callAssert0()) == noreturn));
+
+/**************************************************************/
+
+auto maybeCallAssert0(int i)
+{
+    if (i)
+        assert0();
+}
+
+static assert(is(typeof(maybeCallAssert0(1)) == void));
+static assert(is(typeof(maybeCallAssert0(0)) == void));
+
+/**************************************************************/
+
+auto accessNoreturn()
+{
+    noreturn nr;
+    return nr;
+}
+
+static assert(is(typeof(accessNoreturn()) == noreturn));
+
+/**************************************************************/
+
+auto loop()
+{
+    while (true) {}
+}
+
+static assert(is(typeof(loop()) == noreturn));
+
+/**************************************************************/
+
+auto exThrow()
+{
+    throw new Exception("");
+}
+
+static assert(is(typeof(exThrow()) == noreturn));
+
+/**************************************************************/
+
+auto errThrow()
+{
+    throw new Error("");
+}
+
+static assert(is(typeof(errThrow()) == noreturn));
+
+/**************************************************************/
+
+auto thrThrow()
+{
+    throw new Throwable("");
+}
+
+static assert(is(typeof(thrThrow()) == noreturn));
+
+/**************************************************************/
+
+auto cast_()
+{
+    return cast(noreturn) 1;
+}
+
+static assert(is(typeof(cast_()) == noreturn));
+
+/**************************************************************/
+
+auto none()
+{
+}
+
+static assert(is(typeof(none()) == void));
+
+/**************************************************************/
+
+auto callNone()
+{
+    none();
+}
+
+static assert(is(typeof(callNone()) == void));
+
+/**************************************************************/
+
+auto nestedNoreturn()
+{
+    auto var = assert(0) + assert(0);
+    static assert(is(typeof(var) == noreturn));
+}
+
+// FIXME: The DeclarationExp is typed as void and hence not recognized by blockexit
+// static assert(is(typeof(nestedNoreturn()) == noreturn));
+
+/**************************************************************
+ * Lambdas
+ */
+
+static assert(is(typeof({ assert(0); }()) == noreturn));
+
+/**************************************************************
+ * DIP example
+ */
+
+auto foo(int x) {
+    if (x > 0) {
+        throw new Exception("");
+    } else if (x < 0) {
+        while(true) {}
+    } else {
+        cast(noreturn) /* main */ none();
+    }
+}
+
+static assert(is(typeof(foo(-1)) == noreturn));
+static assert(is(typeof(foo( 0)) == noreturn));
+static assert(is(typeof(foo( 1)) == noreturn));

--- a/test/fail_compilation/fail17955.d
+++ b/test/fail_compilation/fail17955.d
@@ -13,10 +13,10 @@ fail_compilation/fail17955.d(32):        instantiated from here: `indicesOf!(isR
 fail_compilation/fail17955.d(67):        instantiated from here: `RedisStripped!(User, true)`
 fail_compilation/fail17955.d(93): Error: need `this` for `fromISOExtString` of type `pure nothrow @nogc @safe immutable(SimpleTimeZone)(dstring _param_0)`
 fail_compilation/fail17955.d(95): Error: undefined identifier `DateTimeException`
-fail_compilation/fail17955.d(25): Error: variable `fail17955.isISOExtStringSerializable!(SysTime).isISOExtStringSerializable` type `void` is inferred from initializer `fromISOExtString("")`, and variables cannot be of type `void`
 fail_compilation/fail17955.d(54): Error: function `fail17955.toRedis!(SysTime).toRedis` has no `return` statement, but is expected to return a value of type `string`
 ---
 */
+
 
 alias Alias(alias a) = a;
 

--- a/test/fail_compilation/noreturn3.d
+++ b/test/fail_compilation/noreturn3.d
@@ -1,0 +1,74 @@
+// REQUIRED_ARGS: -w -o-
+
+alias noreturn = typeof(*null);
+
+
+/++
+TEST_OUTPUT:
+---
+fail_compilation/noreturn3.d(106): Error: none of the overloads of `callback` are callable using argument types `(void function() pure nothrow @nogc @safe)`
+fail_compilation/noreturn3.d(101):        Candidates are: `noreturn3.callback(noreturn function() f)`
+fail_compilation/noreturn3.d(102):                        `noreturn3.callback(noreturn delegate() dg)`
+fail_compilation/noreturn3.d(109): Error: none of the overloads of `callback` are callable using argument types `(void delegate() pure nothrow @nogc @safe)`
+fail_compilation/noreturn3.d(101):        Candidates are: `noreturn3.callback(noreturn function() f)`
+fail_compilation/noreturn3.d(102):                        `noreturn3.callback(noreturn delegate() dg)`
+---
++/
+#line 100
+
+void callback(noreturn function() f);
+void callback(noreturn delegate() dg);
+
+void useCallback()
+{
+    callback(() {});
+
+    int res;
+    callback(() {
+        res++;
+    });
+}
+
+/++
+TEST_OUTPUT:
+---
+fail_compilation/noreturn3.d(206): Error: `noreturn3.callbackVP` called with argument types `(int* function() pure nothrow @nogc @safe)` matches both:
+fail_compilation/noreturn3.d(201):     `noreturn3.callbackVP(void* function() f)`
+and:
+fail_compilation/noreturn3.d(202):     `noreturn3.callbackVP(void* delegate() dg)`
+fail_compilation/noreturn3.d(208): Error: `noreturn3.callbackVP` called with argument types `(noreturn* function() pure nothrow @nogc @safe)` matches both:
+fail_compilation/noreturn3.d(201):     `noreturn3.callbackVP(void* function() f)`
+and:
+fail_compilation/noreturn3.d(202):     `noreturn3.callbackVP(void* delegate() dg)`
+---
++/
+#line 200
+
+int callbackVP(void* function() f);
+void* callbackVP(void* delegate() dg);
+
+void useCallback2()
+{
+    callbackVP(() => (int*).init);
+
+    callbackVP(() => (noreturn*).init);
+}
+
+/++
+TEST_OUTPUT:
+---
+fail_compilation\noreturn3.d(306): Error: `noreturn3.callback3` called with argument types `(noreturn function() pure nothrow @nogc @safe)` matches both:
+fail_compilation\noreturn3.d(301):     `noreturn3.callback3(void function() f)`
+and:
+fail_compilation\noreturn3.d(302):     `noreturn3.callback3(void delegate() dg)`
+---
++/
+#line 300
+
+int callback3(void function() f);
+void* callback3(void delegate() dg);
+
+void useCallback3()
+{
+    callback3(() => assert(0));
+}

--- a/test/runnable/noreturn1.d
+++ b/test/runnable/noreturn1.d
@@ -112,10 +112,54 @@ void test3()
     }
 }
 
+/*****************************************/
+
+// noreturn is inferred for functions that always throw
+// The code must not strip the destructor when calling a noreturn function
+
+struct WithDtor
+{
+    __gshared int destroyed;
+
+    int num;
+
+    ~this()
+    {
+        destroyed += num;
+    }
+}
+
+noreturn doesThrow()
+{
+    WithDtor wd = WithDtor(1);
+    throw new Exception("");
+}
+
+noreturn callDoesThrow()
+{
+    WithDtor wd = WithDtor(2);
+    doesThrow();
+}
+
+
+void testDtors()
+{
+    try
+    {
+        callDoesThrow();
+        assert(0);
+    } catch (Exception e) {}
+
+    assert(WithDtor.destroyed == 3);
+}
+
+/*****************************************/
+
 int main()
 {
     test1();
     test2();
     test3();
+    testDtors();
     return 0;
 }

--- a/test/runnable/test15779.d
+++ b/test/runnable/test15779.d
@@ -18,5 +18,5 @@ int main()
 
 void bar()
 {
-    new Fiber({ throw new Exception("fly"); }).call();
+    new Fiber(function() { throw new Exception("fly"); }).call();
 }


### PR DESCRIPTION
Infer noreturn whenever the function body is never exited normally.

Also added a bunch of tests from the DIP that really should've been added in the initial PR's... (because many of them don't work)

---

Required changes:

- [x] #13170 (*fixes Vibe-D tests*)
- [x] dlang/druntime#3581
- [x] dlang/phobos#8264
- [x] dlang/phobos#8265
- [x] dlang/phobos#8266
- [x] dlang/phobos#8270
- [x] dlang/phobos#8273
- [x] libmir/mir-core#49
- [ ] vibe-d/vibe-core#299

Related changes:

- [x] #13135 
- [x] #13168 
- [x] dlang/phobos#8276