### PR TITLE
Document the `-run -` feature reading from standard in

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -659,12 +659,21 @@ dmd -cov -unittest myprog.d
         Option("revert=[h|help|?]",
             "list all revertable language changes"
         ),
-        Option("run <srcfile>",
+        Option("run <srcfile> args...",
             "compile, link, and run the program srcfile",
             `Compile, link, and run the program $(I srcfile) with the
             rest of the
             command line, $(I args...), as the arguments to the program.
             No .$(OBJEXT) or executable file is left behind.`
+        ),
+        Option("run - args...",
+            "compile, link, and run the program from standard input",
+            `Similar to $(I -run <srcfile>), but takes its input from
+            the standard input stream instead of a file from the file system.
+            Example:
+---
+echo "void main(){}" | dmd -run -
+---`
         ),
         Option("shared",
             "generate shared library (DLL)",


### PR DESCRIPTION
There's an undocumented feature of `-run` that a dash `-` gets converted to the special file `__stdin.d` which reads from standard in. It doesn't look like something internal that needs to be undocumented. If it is, this can be closed.