### PR TITLE
dmd.cparse: Add asm() detection to isCDeclaration

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2803,6 +2803,12 @@ final class CParser(AST) : Parser!AST
             }
             if (!isCDeclarator(t, false))
                 return false;
+            if (t.value == TOK.asm_)
+            {
+                t = peek(t);
+                if (t.value != TOK.leftParenthesis || !skipParens(t, &t))
+                    return false;
+            }
             if (t.value == TOK.assign)
             {
                 t = peek(t);

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -283,6 +283,21 @@ int fun1() asm("realfun1");
 int fun2() __asm("realfun2");
 int fun3() __asm__("realfun3");
 
+typedef int asmreg;
+void test_asm()
+{
+  register asmreg r1 asm("r1");
+
+  // asm ignored by C compiler, should be disallowed?
+  asmreg r2 asm("r2");
+
+  register asmreg r3 asm("r3") = 3;
+
+  // Uncomment when bug fixed https://issues.dlang.org/show_bug.cgi?id=21948
+  // asm ignored by C compiler, should be disallowed?
+  //asmreg r4 asm("r4") = 4;
+}
+
 /********************************/
 
 void test__func__()


### PR DESCRIPTION
As per https://github.com/dlang/dmd/pull/12546#discussion_r636721715 @WalterBright.

Though the only time this is valid is when the declaration started with `register`, which doesn't trigger the `isCDeclaration` code path.  It should be a warning, but the test instead just tickles the code to make sure it's doing the right thing.