### PR TITLE
Fix 21949 - Implement conversion/covariance rules for TypeNoreturn

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5509,6 +5509,7 @@ public:
     const char* kind() const;
     TypeNoreturn* syntaxCopy();
     MATCH implicitConvTo(Type* to);
+    MATCH constConv(Type* to);
     bool isBoolean() /* const */;
     d_uns64 size(const Loc& loc) /* const */;
     uint32_t alignsize();

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -894,6 +894,7 @@ public:
     const char *kind();
     TypeNoreturn *syntaxCopy();
     MATCH implicitConvTo(Type* to);
+    MATCH constConv(Type* to);
     bool isBoolean() /* const */;
     d_uns64 size(const Loc& loc) /* const */;
     unsigned alignsize();

--- a/test/compilable/noreturn1.d
+++ b/test/compilable/noreturn1.d
@@ -4,10 +4,50 @@ TEST_OUTPUT:
 ---
 noreturn
 ---
+
+Basic properties and usage mentioned in the DIP:
+https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md
 */
 
 alias noreturn = typeof(*null);
 pragma(msg, noreturn);
+
+static assert(!is(noreturn == void));
+
+// Fails
+// static assert(is( typeof([]) == noreturn[] ));
+// static assert(is( typeof([][0]) == noreturn ));
+
+static assert(is( typeof(assert(0)) == noreturn ));
+
+// Does not parse yet
+// static assert(is( typeof(throw new Exception()) == noreturn ));
+
+static assert(is(noreturn == noreturn));
+static assert(!is(noreturn == const noreturn));
+static assert(is(noreturn : const noreturn));
+
+static assert(!is(noreturn == int));
+static assert(is(noreturn : int));
+
+// Covariance
+static assert(is(noreturn[] : int[]));
+static assert(is(noreturn* : int*));
+static assert(is(noreturn function() : int function()));
+static assert(is(noreturn delegate() : int delegate()));
+
+// Reject inverse conversions
+static assert(!is(int[]          : noreturn[]));
+static assert(!is(int*           : noreturn*));
+static assert(!is(int function() : noreturn function()));
+static assert(!is(int delegate() : noreturn delegate()));
+
+static assert(noreturn.mangleof == "Nn"); // Changed from b due to conflicts with bool
+static assert(noreturn.sizeof == 0);
+static assert(noreturn.alignof == 0);
+
+static assert((noreturn*).sizeof == (int*).sizeof);
+static assert((noreturn[]).sizeof == (int[]).sizeof);
 
 noreturn exits(int* p) { *p = 3; }
 
@@ -23,4 +63,3 @@ int test1(int i)
         return i + 1;
     return i - 1;
 }
-


### PR DESCRIPTION
Ensure that `TypeNoreturn.implicitConv` and `TypeNoreturn.constConv`
always return `Match.convert` for other types because the bottom type
is convertible to any type.

Also make `covariant` accept `TypeNoreturn` as a substitute for any other
type because the return value will never actually be returned.

This behaviour is explicitly specified by DIP 1034.

---

Also added some more test that check the specification from the DIP (the commented ones don't work yet)