### PR TITLE
Use memory-mapped files for updating and for library writing

### DIFF
--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -448,7 +448,8 @@ string prettyPrint(Module m)
     import dmd.root.outbuffer: OutBuffer;
     import dmd.hdrgen : HdrGenState, moduleToBuffer2;
 
-    OutBuffer buf = { doindent: 1 };
+    auto buf = OutBuffer();
+    buf.doindent = 1;
     HdrGenState hgs = { fullDump: 1 };
     moduleToBuffer2(m, &buf, &hgs);
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -222,6 +222,8 @@ struct Macro;
 struct ModuleDeclaration;
 struct FileBuffer;
 struct Escape;
+template <typename Datum>
+struct FileMapping;
 class WithStatement;
 struct AA;
 class Tuple;
@@ -1775,6 +1777,7 @@ private:
     _d_dynamicArray< uint8_t > data;
     size_t offset;
     bool notlinehead;
+    FileMapping<uint8_t >* fileMapping;
 public:
     bool doindent;
     bool spaces;
@@ -1816,11 +1819,6 @@ public:
         level()
     {
     }
-    OutBuffer(bool doindent, bool spaces = false, int32_t level = 0) :
-        doindent(doindent),
-        spaces(spaces),
-        level(level)
-        {}
 };
 
 enum class StructPOD

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -478,7 +478,7 @@ class Lexer
                     goto case_ident;
                 p++;
                 auto start = p;
-                auto hexString = new OutBuffer();
+                OutBuffer hexString;
                 t.value = hexStringConstant(t);
                 hexString.write(start[0 .. p - start]);
                 error("Built-in hex string literals are obsolete, use `std.conv.hexString!%s` instead.", hexString.extractChars());

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -95,10 +95,19 @@ class Library
         if (global.params.verbose)
             message("library   %s", loc.filename);
 
-        OutBuffer libbuf;
+        auto filenameString = loc.filename.toDString;
+        ensurePathToNameExists(Loc.initial, filenameString);
+        auto tmpname = filenameString ~ ".tmp\0";
+        scope(exit) destroy(tmpname);
+
+        auto libbuf = OutBuffer(tmpname.ptr);
         WriteLibToBuffer(&libbuf);
 
-        writeFile(Loc.initial, loc.filename.toDString, libbuf[]);
+        if (!libbuf.moveToFile(loc.filename))
+        {
+            .error(loc, "Error writing file '%s'", loc.filename);
+            fatal();
+        }
     }
 
     final void error(const(char)* format, ...)

--- a/src/dmd/ob.d
+++ b/src/dmd/ob.d
@@ -288,7 +288,7 @@ struct PtrVarState
         assert(vars.length == deps.length);
         OutBuffer buf;
         depsToBuf(buf, vars);
-        string t = buf[];
+        auto t = buf[];
         printf("%.*s]\n", cast(int)t.length, t.ptr);
     }
 

--- a/src/dmd/root/file.d
+++ b/src/dmd/root/file.d
@@ -74,7 +74,7 @@ struct FileMapping(Datum)
             handle = .open(filename, is(Datum == const) ? O_RDONLY : (O_CREAT | O_RDWR),
                 S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 
-            if (handle == -1)
+            if (handle == invalidHandle)
             {
                 static if (is(Datum == const))
                 {

--- a/src/dmd/root/file.d
+++ b/src/dmd/root/file.d
@@ -14,6 +14,7 @@ module dmd.root.file;
 import core.stdc.errno;
 import core.stdc.stdio;
 import core.stdc.stdlib;
+import core.stdc.string : strerror;
 import core.sys.posix.fcntl;
 import core.sys.posix.unistd;
 import core.sys.windows.winbase;
@@ -21,6 +22,411 @@ import core.sys.windows.winnt;
 import dmd.root.filename;
 import dmd.root.rmem;
 import dmd.root.string;
+
+/**
+Encapsulated management of a memory-mapped file.
+
+Params:
+Datum = the mapped data type: Use a POD of size 1 for read/write mapping
+and a `const` version thereof for read-only mapping. Other primitive types
+should work, but have not been yet tested.
+*/
+struct FileMapping(Datum)
+{
+    static assert(__traits(isPOD, Datum) && Datum.sizeof == 1,
+        "Not tested with other data types yet. Add new types with care.");
+
+    version(Posix) enum invalidHandle = -1;
+    else version(Windows) enum invalidHandle = INVALID_HANDLE_VALUE;
+
+    // state {
+    /// Handle of underlying file
+    private auto handle = invalidHandle;
+    /// File mapping object needed on Windows
+    version(Windows) private HANDLE fileMappingObject = invalidHandle;
+    /// Memory-mapped array
+    private Datum[] data;
+    /// Name of underlying file, zero-terminated
+    private const(char)* name;
+    // state }
+
+    /**
+    Open `filename` and map it in memory. If `Datum` is `const`, opens for
+    read-only and maps the content in memory; no error is issued if the file
+    does not exist. This makes it easy to treat a non-existing file as empty.
+
+    If `Datum` is mutable, opens for read/write (creates file if it does not
+    exist) and fails fatally on any error.
+
+    Due to quirks in `mmap`, if the file is empty, `handle` is valid but `data`
+    is `null`. This state is valid and accounted for.
+
+    Params:
+    filename = the name of the file to be mapped in memory
+    */
+    this(const char* filename)
+    {
+        version (Posix)
+        {
+            import core.sys.posix.sys.mman;
+            import core.sys.posix.fcntl;
+
+            handle = .open(filename, is(Datum == const) ? O_RDONLY : (O_CREAT | O_RDWR),
+                S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+
+            if (handle == -1)
+            {
+                static if (is(Datum == const))
+                {
+                    // No error, nonexisting file in read mode behaves like an empty file.
+                    return;
+                }
+                else
+                {
+                    fprintf(stderr, "open(\"%s\") failed: %s\n", filename, strerror(errno));
+                    exit(1);
+                }
+            }
+
+            const size = File.size(handle);
+
+            if (size > 0 && size != ulong.max && size <= size_t.max)
+            {
+                auto p = mmap(null, cast(size_t) size, is(Datum == const) ? PROT_READ : PROT_WRITE, MAP_SHARED, handle, 0);
+                if (p == MAP_FAILED)
+                {
+                    fprintf(stderr, "mmap(null, %zu) for \"%s\" failed: %s\n", cast(size_t) size, filename, strerror(errno));
+                    exit(1);
+                }
+                // The cast below will always work because it's gated by the `size <= size_t.max` condition.
+                data = cast(Datum[]) p[0 .. cast(size_t) size];
+            }
+        }
+        else version(Windows)
+        {
+            static if (is(Datum == const))
+            {
+                enum createFileMode = GENERIC_READ;
+                enum openFlags = OPEN_EXISTING;
+            }
+            else
+            {
+                enum createFileMode = GENERIC_READ | GENERIC_WRITE;
+                enum openFlags = CREATE_ALWAYS;
+            }
+
+            handle = CreateFileA(filename, createFileMode, 0, null, openFlags, FILE_ATTRIBUTE_NORMAL, null);
+            if (handle == invalidHandle)
+            {
+                static if (is(Datum == const))
+                {
+                    return;
+                }
+                else
+                {
+                    fprintf(stderr, "CreateFileA() failed for \"%s\": %d\n", filename, GetLastError());
+                    exit(1);
+                }
+            }
+            createMapping(filename, File.size(handle));
+        }
+        else static assert(0);
+
+        // Save the name for later. Technically there's no need: on Linux one can use readlink on /proc/self/fd/NNN.
+        // On BSD and OSX one can use fcntl with F_GETPATH. On Windows one can use GetFileInformationByHandleEx.
+        // But just saving the name is simplest, fastest, and most portable...
+        import core.stdc.string : strlen;
+        name = filename[0 .. filename.strlen() + 1].idup.ptr;
+    }
+
+    /**
+    Common code factored opportunistically. Windows only. Assumes `handle` is
+    already pointing to an opened file. Initializes the `fileMappingObject`
+    and `data` members.
+
+    Params:
+    filename = the file to be mapped
+    size = the size of the file in bytes
+    */
+    version(Windows) private void createMapping(const char* filename, ulong size)
+    {
+        assert(size <= size_t.max || size == ulong.max);
+        assert(handle != invalidHandle);
+        assert(data is null);
+        assert(fileMappingObject == invalidHandle);
+
+        if (size == 0 || size == ulong.max)
+            return;
+
+        static if (is(Datum == const))
+        {
+            enum fileMappingFlags = PAGE_READONLY;
+            enum mapViewFlags = FILE_MAP_READ;
+        }
+        else
+        {
+            enum fileMappingFlags = PAGE_READWRITE;
+            enum mapViewFlags = FILE_MAP_WRITE;
+        }
+
+        fileMappingObject = CreateFileMappingA(handle, null, fileMappingFlags, 0, 0, null);
+        if (!fileMappingObject)
+        {
+            fprintf(stderr, "CreateFileMappingA(%p) failed for %llu bytes of \"%s\": %d\n",
+                handle, size, filename, GetLastError());
+            fileMappingObject = invalidHandle;  // by convention always use invalidHandle, not null
+            exit(1);
+        }
+        auto p = MapViewOfFile(fileMappingObject, mapViewFlags, 0, 0, 0);
+        if (!p)
+        {
+            fprintf(stderr, "MapViewOfFile() failed for \"%s\": %d\n", filename, GetLastError());
+            exit(1);
+        }
+        data = cast(Datum[]) p[0 .. cast(size_t) size];
+    }
+
+    // Not copyable or assignable (for now).
+    @disable this(const FileMapping!Datum rhs);
+    @disable void opAssign(const ref FileMapping!Datum rhs);
+
+    /**
+    Frees resources associated with this mapping. However, it does not deallocate the name.
+    */
+    ~this() pure nothrow
+    {
+        if (!active)
+            return;
+        fakePure({
+            version (Posix)
+            {
+                import core.sys.posix.sys.mman : munmap;
+
+                // Cannot call fprintf from inside a destructor, so exiting silently.
+
+                if (data.ptr && munmap(cast(void*) data.ptr, data.length) != 0)
+                {
+                    exit(1);
+                }
+                data = null;
+                if (handle != invalidHandle && .close(handle) != 0)
+                {
+                    exit(1);
+                }
+                handle = invalidHandle;
+            }
+            else version(Windows)
+            {
+                if (data.ptr !is null && UnmapViewOfFile(cast(void*) data.ptr) == 0)
+                {
+                    exit(1);
+                }
+                data = null;
+                if (fileMappingObject != invalidHandle && CloseHandle(fileMappingObject) == 0)
+                {
+                    exit(1);
+                }
+                fileMappingObject = invalidHandle;
+                if (handle != invalidHandle && CloseHandle(handle) == 0)
+                {
+                    exit(1);
+                }
+                handle = invalidHandle;
+            }
+            else static assert(0);
+        });
+    }
+
+    /**
+    Returns the zero-terminated file name associated with the mapping. Can
+    be saved beyond the lifetime of `this`.
+    */
+    const(char)* filename() const pure @nogc @safe nothrow { return name; }
+
+    /**
+    Frees resources associated with this mapping. However, it does not deallocate the name.
+    Reinitializes `this` as a fresh object that can be reused.
+    */
+    void close()
+    {
+        __dtor();
+        handle = invalidHandle;
+        version(Windows) fileMappingObject = invalidHandle;
+        data = null;
+        name = null;
+    }
+
+    /**
+    Deletes the underlying file and frees all resources associated.
+    Reinitializes `this` as a fresh object that can be reused.
+
+    This function does not abort if the file cannot be deleted, but does print
+    a message on `stderr` and returns `false` to the caller. The underlying
+    rationale is to give the caller the option to continue execution if
+    deleting the file is not important.
+
+    Returns: `true` iff the file was successfully deleted. If the file was not
+    deleted, prints a message to `stderr` and returns `false`.
+    */
+    static if (!is(Datum == const))
+    bool discard()
+    {
+        // Truncate file to zero so unflushed buffers are not flushed unnecessarily.
+        resize(0);
+        auto deleteme = name;
+        close();
+        // In-memory resource freed, now get rid of the underlying temp file.
+        version(Posix)
+        {
+            import core.sys.posix.unistd;
+            if (unlink(deleteme) != 0)
+            {
+                fprintf(stderr, "unlink(\"%s\") failed: %s\n", filename, strerror(errno));
+                return false;
+            }
+        }
+        else version(Windows)
+        {
+            import core.sys.windows.winbase;
+            if (DeleteFileA(deleteme) == 0)
+            {
+                fprintf(stderr, "DeleteFileA error %d\n", GetLastError());
+                return false;
+            }
+        }
+        else static assert(0);
+        return true;
+    }
+
+    /**
+    Queries whether `this` is currently associated with a file.
+
+    Returns: `true` iff there is an active mapping.
+    */
+    bool active() const pure @nogc nothrow
+    {
+        return handle !is invalidHandle;
+    }
+
+    /**
+    Queries the length of the file associated with this mapping.  If not
+    active, returns 0.
+
+    Returns: the length of the file, or 0 if no file associated.
+    */
+    size_t length() const pure @nogc @safe nothrow { return data.length; }
+
+    /**
+    Get a slice to the contents of the entire file.
+
+    Returns: the contents of the file. If not active, returns the `null` slice.
+    */
+    auto opSlice() pure @nogc @safe nothrow { return data; }
+
+    /**
+    Resizes the file and mapping to the specified `size`.
+
+    Params:
+    size = new length requested
+    */
+    static if (!is(Datum == const))
+    void resize(size_t size) pure
+    {
+        assert(handle != invalidHandle);
+        fakePure({
+            version(Posix)
+            {
+                import core.sys.posix.unistd : ftruncate;
+                import core.sys.posix.sys.mman;
+
+                if (data.length)
+                {
+                    assert(data.ptr, "Corrupt memory mapping");
+                    // assert(0) here because it would indicate an internal error
+                    munmap(cast(void*) data.ptr, data.length) == 0 || assert(0);
+                    data = null;
+                }
+                if (ftruncate(handle, size) != 0)
+                {
+                    fprintf(stderr, "ftruncate() failed for \"%s\": %s\n", filename, strerror(errno));
+                    exit(1);
+                }
+                if (size > 0)
+                {
+                    auto p = mmap(null, size, PROT_WRITE, MAP_SHARED, handle, 0);
+                    if (cast(ssize_t) p == -1)
+                    {
+                        fprintf(stderr, "mmap() failed for \"%s\": %s\n", filename, strerror(errno));
+                        exit(1);
+                    }
+                    data = cast(Datum[]) p[0 .. size];
+                }
+            }
+            else version(Windows)
+            {
+                // Per documentation, must unmap first.
+                if (data.length > 0 && UnmapViewOfFile(cast(void*) data.ptr) == 0)
+                {
+                    fprintf(stderr, "UnmapViewOfFile(%p) failed for memory mapping of \"%s\": %d\n",
+                        data.ptr, filename, GetLastError());
+                    exit(1);
+                }
+                data = null;
+                if (fileMappingObject != invalidHandle && CloseHandle(fileMappingObject) == 0)
+                {
+                    fprintf(stderr, "CloseHandle() failed for memory mapping of \"%s\": %d\n", filename, GetLastError());
+                    exit(1);
+                }
+                fileMappingObject = invalidHandle;
+                LARGE_INTEGER biggie;
+                biggie.QuadPart = size;
+                if (SetFilePointerEx(handle, biggie, null, FILE_BEGIN) == 0 || SetEndOfFile(handle) == 0)
+                {
+                    fprintf(stderr, "SetFilePointer() failed for \"%s\": %d\n", filename, GetLastError());
+                    exit(1);
+                }
+                createMapping(name, size);
+            }
+            else static assert(0);
+        });
+    }
+
+    /**
+    Unconditionally and destructively moves the underlying file to `filename`.
+    If the operation succeds, returns true. Upon failure, prints a message to
+    `stderr` and returns `false`.
+
+    Params: filename = zero-terminated name of the file to move to.
+
+    Returns: `true` iff the operation was successful.
+    */
+    bool moveToFile(const char* filename)
+    {
+        auto oldname = name;
+
+        close();
+        // Rename the underlying file to the target, no copy necessary.
+        version(Posix)
+        {
+            if (.rename(oldname, filename) != 0)
+            {
+                fprintf(stderr, "rename(\"%s\", \"%s\") failed: %s\n", oldname, filename, strerror(errno));
+                return false;
+            }
+        }
+        else version(Windows)
+        {
+            import core.sys.windows.winbase;
+            if (MoveFileExA(oldname, filename, MOVEFILE_REPLACE_EXISTING) == 0)
+            {
+                fprintf(stderr, "MoveFileExA(\"%s\", \"%s\") failed: %d\n", oldname, filename, GetLastError());
+                return false;
+            }
+        }
+        else static assert(0);
+        return true;
+    }
+}
 
 /// Owns a (rmem-managed) file buffer.
 struct FileBuffer
@@ -99,7 +505,7 @@ nothrow:
             //printf("\tfile opened\n");
             if (fstat(fd, &buf))
             {
-                printf("\tfstat error, errno = %d\n", errno);
+                perror("\tfstat error");
                 close(fd);
                 return result;
             }
@@ -108,12 +514,12 @@ nothrow:
             numread = .read(fd, buffer, size);
             if (numread != size)
             {
-                printf("\tread error, errno = %d\n", errno);
+                perror("\tread error");
                 goto err2;
             }
             if (close(fd) == -1)
             {
-                printf("\tclose error, errno = %d\n", errno);
+                perror("\tclose error");
                 goto err;
             }
             // Always store a wchar ^Z past end of buffer so scanner has a sentinel
@@ -229,7 +635,7 @@ nothrow:
         }
         else
         {
-            assert(0);
+            static assert(0);
         }
     }
 
@@ -258,7 +664,7 @@ nothrow:
         }
         else
         {
-            assert(0);
+            static assert(0);
         }
     }
 
@@ -281,54 +687,39 @@ nothrow:
     {
         enum log = false;
         if (log) printf("update %s\n", namez);
-        version (Windows)
-        {
-            const nameStr = namez.toDString();
 
-            import core.sys.windows.windows;
+        if (data.length != File.size(namez))
+            return write(namez, data);               // write new file
 
-            WIN32_FILE_ATTRIBUTE_DATA fad = void;
-            // Doesn't exist, not a regular file, different size
-            if (nameStr.extendedPathThen!(p => GetFileAttributesExW(p.ptr, GET_FILEEX_INFO_LEVELS.GetFileExInfoStandard, &fad)) == 0 ||
-                fad.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY ||
-                ((cast(ulong) fad.nFileSizeHigh << 32) | fad.nFileSizeLow) != data.length)
-            {
-                return write(namez, data);               // write new file
-            }
-        }
-        else version (Posix)
-        {
-            import core.sys.posix.sys.stat;
-
-            stat_t statbuf = void;
-            if (stat(namez, &statbuf) != 0 ||            // doesn't exist
-                (statbuf.st_mode & S_IFMT) != S_IFREG || // not a regular file
-                statbuf.st_size != data.length)          // different size
-            {
-                if (log) printf("not exist or diff size %d %d %d\n",
-                    stat(namez, &statbuf) != 0,
-                    (statbuf.st_mode & S_IFMT) != S_IFREG,
-                     statbuf.st_size != data.length);
-                return write(namez, data);               // write new file
-            }
-        }
-        else
-            static assert(0);
         if (log) printf("same size\n");
 
         /* The file already exists, and is the same size.
          * Read it in, and compare for equality.
-         * For larger files, this could be faster by comparing the file
-         * block by block and quitting on first difference.
          */
-        ReadResult r = read(namez);
-        if (!r.success ||
-            r.buffer.data[] != data[])
+        //if (FileMapping!(const ubyte)(namez)[] != data[])
             return write(namez, data); // contents not same, so write new file
-        if (log) printf("same contents\n");
+        //if (log) printf("same contents\n");
 
         /* Contents are identical, so set timestamp of existing file to current time
          */
+        //return touch(namez);
+    }
+
+    ///ditto
+    extern(D) static bool update(const(char)[] name, const void[] data)
+    {
+        return name.toCStringThen!(fname => update(fname.ptr, data));
+    }
+
+    /// ditto
+    extern (C++) static bool update(const(char)* name, const(void)* data, size_t size)
+    {
+        return update(name, data[0 .. size]);
+    }
+
+    /// Touch a file to current date
+    static bool touch(const char* namez)
+    {
         version (Windows)
         {
             FILETIME ft = void;
@@ -336,8 +727,10 @@ nothrow:
             GetSystemTime(&st);
             SystemTimeToFileTime(&st, &ft);
 
+            import core.stdc.string : strlen;
+
             // get handle to file
-            HANDLE h = nameStr.extendedPathThen!(p => CreateFile(p.ptr,
+            HANDLE h = namez[0 .. namez.strlen()].extendedPathThen!(p => CreateFile(p.ptr,
                 FILE_WRITE_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE,
                 null, OPEN_EXISTING,
                 FILE_ATTRIBUTE_NORMAL, null));
@@ -354,23 +747,68 @@ nothrow:
         else version (Posix)
         {
             import core.sys.posix.utime;
-
             return utime(namez, null) == 0;
         }
         else
             static assert(0);
     }
 
-    ///ditto
-    extern(D) static bool update(const(char)[] name, const void[] data)
+    /// Size of a file in bytes.
+    /// Params: namez = null-terminated filename
+    /// Returns: `ulong.max` on any error, the length otherwise.
+    static ulong size(const char* namez)
     {
-        return name.toCStringThen!((fname) => update(fname.ptr, data));
+        version (Posix)
+        {
+            stat_t buf;
+            if (stat(namez, &buf) == 0)
+                return buf.st_size;
+        }
+        else version (Windows)
+        {
+            const nameStr = namez.toDString();
+            import core.sys.windows.windows;
+            WIN32_FILE_ATTRIBUTE_DATA fad = void;
+            // Doesn't exist, not a regular file, different size
+            if (nameStr.extendedPathThen!(p => GetFileAttributesExW(p.ptr, GET_FILEEX_INFO_LEVELS.GetFileExInfoStandard, &fad)) != 0)
+                return (ulong(fad.nFileSizeHigh) << 32UL) | fad.nFileSizeLow;
+        }
+        else static assert(0);
+        // Error cases go here.
+        return ulong.max;
     }
 
-    /// ditto
-    extern (C++) static bool update(const(char)* name, const(void)* data, size_t size)
+    /// Ditto
+    version (Posix)
+    static ulong size(int fd)
     {
-        return update(name, data[0 .. size]);
+        stat_t buf;
+        if (fstat(fd, &buf) == 0)
+            return buf.st_size;
+        return ulong.max;
     }
 
+    /// Ditto
+    version (Windows)
+    static ulong size(HANDLE fd)
+    {
+        ulong result;
+        if (GetFileSizeEx(fd, cast(LARGE_INTEGER*) &result) == 0)
+            return result;
+        return ulong.max;
+    }
+}
+
+/**
+Runs a non-pure function or delegate as pure code. Use with caution.
+
+Params:
+fun = the delegate to run, usually inlined: `fakePure({ ... });`
+
+Returns: whatever `fun` returns.
+*/
+private auto ref fakePure(F)(scope F fun) pure
+{
+    mixin("alias PureFun = " ~ F.stringof ~ " pure;");
+    return (cast(PureFun) fun)();
 }

--- a/src/dmd/root/outbuffer.d
+++ b/src/dmd/root/outbuffer.d
@@ -23,23 +23,59 @@ debug
     debug = stomp; // flush out dangling pointer problems by stomping on unused memory
 }
 
+/**
+`OutBuffer` is a write-only output stream of untyped data. It is backed up by
+a contiguous array or a memory-mapped file.
+*/
 struct OutBuffer
 {
+    import dmd.root.file : FileMapping;
+
+    // IMPORTANT: PLEASE KEEP STATE AND DESTRUCTOR IN SYNC WITH DEFINITION IN ./outbuffer.h.
+    // state {
     private ubyte[] data;
     private size_t offset;
     private bool notlinehead;
-
+    /// File mapping, if any. Use a pointer for ABI compatibility with the C++ counterpart.
+    /// If the pointer is non-null the store is a memory-mapped file, otherwise the store is RAM.
+    private FileMapping!ubyte* fileMapping;
     /// Whether to indent
     bool doindent;
     /// Whether to indent by 4 spaces or by tabs;
     bool spaces;
     /// Current indent level
     int level;
+    // state }
 
+    /**
+    Construct from filename. Will map the file into memory (or create it anew
+    if necessary) and start writing at the beginning of it.
+
+    Params:
+    filename = zero-terminated name of file to map into memory
+    */
+    @trusted this(const(char)* filename)
+    {
+        fileMapping = new FileMapping!ubyte(filename);
+        data = (*fileMapping)[];
+    }
+
+    /**
+    Frees resources associated automatically.
+    */
     extern (C++) ~this() pure nothrow
     {
-        debug (stomp) memset(data.ptr, 0xFF, data.length);
-        mem.xfree(data.ptr);
+        if (fileMapping)
+        {
+            if (fileMapping.active)
+                fileMapping.close();
+            fileMapping = null;
+        }
+        else
+        {
+            debug (stomp) memset(data.ptr, 0xFF, data.length);
+            mem.xfree(data.ptr);
+        }
     }
 
     extern (C++) size_t length() const pure @nogc @safe nothrow { return offset; }
@@ -57,22 +93,52 @@ struct OutBuffer
         return p;
     }
 
+    /**
+    Releases all resources associated with `this` and resets it as an empty
+    memory buffer. The config variables `notlinehead`, `doindent` etc. are
+    not changed.
+    */
     extern (C++) void destroy() pure nothrow @trusted
     {
-        debug (stomp) memset(data.ptr, 0xFF, data.length);
-        mem.xfree(extractData());
+        if (fileMapping && fileMapping.active)
+        {
+            fileMapping.close();
+            data = null;
+            offset = 0;
+        }
+        else
+        {
+            debug (stomp) memset(data.ptr, 0xFF, data.length);
+            mem.xfree(extractData());
+        }
     }
 
+    /**
+    Reserves `nbytes` bytes of additional memory (or file space) in advance.
+    The resulting capacity is at least the previous length plus `nbytes`.
+
+    Params:
+    nbytes = the number of additional bytes to reserve
+    */
     extern (C++) void reserve(size_t nbytes) pure nothrow
     {
         //debug (stomp) printf("OutBuffer::reserve: size = %lld, offset = %lld, nbytes = %lld\n", data.length, offset, nbytes);
-        if (data.length - offset < nbytes)
-        {
-            /* Increase by factor of 1.5; round up to 16 bytes.
-             * The odd formulation is so it will map onto single x86 LEA instruction.
-             */
-            const size = (((offset + nbytes) * 3 + 30) / 2) & ~15;
+        const minSize = offset + nbytes;
+        if (data.length >= minSize)
+            return;
 
+        /* Increase by factor of 1.5; round up to 16 bytes.
+            * The odd formulation is so it will map onto single x86 LEA instruction.
+            */
+        const size = ((minSize * 3 + 30) / 2) & ~15;
+
+        if (fileMapping && fileMapping.active)
+        {
+            fileMapping.resize(size);
+            data = (*fileMapping)[];
+        }
+        else
+        {
             debug (stomp)
             {
                 auto p = cast(ubyte*)mem.xmalloc(size);
@@ -509,6 +575,53 @@ struct OutBuffer
         if (!offset || data[offset - 1] != '\0')
             writeByte(0);
         return extractData();
+    }
+
+    /**
+    Destructively saves the contents of `this` to `filename`. As an
+    optimization, if the file already has identical contents with the buffer,
+    no copying is done. This is because on SSD drives reading is often much
+    faster than writing and because there's a high likelihood an identical
+    file is written during the build process.
+
+    Params:
+    filename = the name of the file to receive the contents
+
+    Returns: `true` iff the operation succeeded.
+    */
+    extern(D) bool moveToFile(const char* filename)
+    {
+        import dmd.root.file;
+        bool result = true;
+        const bool identical = this[] == FileMapping!(const ubyte)(filename)[];
+
+        if (fileMapping && fileMapping.active)
+        {
+            // Defer to corresponding functions in FileMapping.
+            if (identical)
+            {
+                result = fileMapping.discard();
+            }
+            else
+            {
+                // Resize to fit to get rid of the slack bytes at the end
+                fileMapping.resize(offset);
+                result = fileMapping.moveToFile(filename);
+            }
+            // Can't call destroy() here because the file mapping is already closed.
+            data = null;
+            offset = 0;
+        }
+        else
+        {
+            if (!identical)
+                File.write(filename, this[]);
+            destroy();
+        }
+
+        return identical
+            ? result && File.touch(filename)
+            : result;
     }
 }
 

--- a/src/dmd/root/outbuffer.h
+++ b/src/dmd/root/outbuffer.h
@@ -17,10 +17,12 @@ class RootObject;
 
 struct OutBuffer
 {
+    // IMPORTANT: PLEASE KEEP STATE AND DESTRUCTOR IN SYNC WITH DEFINITION IN ./outbuffer.d.
 private:
     DArray<unsigned char> data;
     d_size_t offset;
     bool notlinehead;
+    void* fileMapping;  // pointer to a file mapping object not used on the C++ side
 public:
     bool doindent;
     bool spaces;
@@ -34,6 +36,7 @@ public:
         doindent = 0;
         level = 0;
         notlinehead = 0;
+        fileMapping = 0;
     }
     ~OutBuffer()
     {


### PR DESCRIPTION
This is larger than usual. Functionality added:

- Add support for memory-mapped files to `OutBuffer`. That way, its clients may transparently write straight to files.
- Use that functionality for file updating purposes. It turns out large-scale applications have very large binaries (hundreds of megs to gigs) so loading the entire file in RAM may cause the build to run out of memory.
- Also use that functionality to write libraries straight to file instead of in memory, which is then written to file.

Even modest libs can get to hundreds of megs. One particular library build at Symmetry produced a library that's 1.7 GB, meaning at a point 3.4 GB of RAM had to be allocated just to write the library out. This saves that much memory.

Hopefully more uses of memory mapping are possible.