### PR TITLE
remove TOK.functionString

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -200,7 +200,6 @@ final class CParser(AST) : Parser!AST
         case TOK.not:
         case TOK.plusPlus:
         case TOK.minusMinus:
-        case TOK.functionString:
         case TOK.sizeof_:
         Lexp:
             auto exp = cparseExpression();
@@ -654,11 +653,6 @@ final class CParser(AST) : Parser!AST
 
         case TOK.imaginary80Literal:
             e = new AST.RealExp(loc, token.floatvalue, AST.Type.timaginary80);
-            nextToken();
-            break;
-
-        case TOK.functionString:
-            e = new AST.FuncInitExp(loc);
             nextToken();
             break;
 


### PR DESCRIPTION
This is to support `__FUNCTION__`, which is not used in C (`__func__` instead), so remove it.