### PR TITLE
Use $HOME instead of $PWD in the nightly script

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -284,7 +284,7 @@ jobs:
         run: |
           set -euox pipefail
           ls -aul ~ ~/artifacts
-          echo "::set-output name=artifacts_directory::$PWD/artifacts"
+          echo "::set-output name=artifacts_directory::$HOME/artifacts"
 
       #################################################################
       # Create the new release using the downloaded artifacts


### PR DESCRIPTION
The shell script doesn't start in the home directory...

---

Sorry for another PR, the last run failed to upload the artifacts again. But I was able to test this patch using a private repository that only contains the `nightlies.yml`-