### PR TITLE
dmd.cparse: Add support more C targets

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5044,21 +5044,33 @@ struct TargetC final
     };
 
     bool crtDestructorsSupported;
+    uint8_t boolsize;
+    uint8_t shortsize;
+    uint8_t intsize;
     uint8_t longsize;
+    uint8_t long_longsize;
     uint8_t long_doublesize;
     uint8_t wchar_tsize;
     Runtime runtime;
     BitFieldStyle bitFieldStyle;
     TargetC() :
         crtDestructorsSupported(true),
+        boolsize(),
+        shortsize(),
+        intsize(),
         longsize(),
+        long_longsize(),
         long_doublesize(),
         wchar_tsize()
     {
     }
-    TargetC(bool crtDestructorsSupported, uint8_t longsize = 0u, uint8_t long_doublesize = 0u, uint8_t wchar_tsize = 0u, Runtime runtime = (Runtime)0u, BitFieldStyle bitFieldStyle = (BitFieldStyle)0u) :
+    TargetC(bool crtDestructorsSupported, uint8_t boolsize = 0u, uint8_t shortsize = 0u, uint8_t intsize = 0u, uint8_t longsize = 0u, uint8_t long_longsize = 0u, uint8_t long_doublesize = 0u, uint8_t wchar_tsize = 0u, Runtime runtime = (Runtime)0u, BitFieldStyle bitFieldStyle = (BitFieldStyle)0u) :
         crtDestructorsSupported(crtDestructorsSupported),
+        boolsize(boolsize),
+        shortsize(shortsize),
+        intsize(intsize),
         longsize(longsize),
+        long_longsize(long_longsize),
         long_doublesize(long_doublesize),
         wchar_tsize(wchar_tsize),
         runtime(runtime),
@@ -7835,7 +7847,7 @@ public:
         RealProperties()
     {
     }
-    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(true, 0u, 0u, 0u, (TargetC::Runtime)0u, (TargetC::BitFieldStyle)0u), TargetCPP cpp = TargetCPP(false, false, false, false, false, (TargetCPP::Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11u, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool omfobj = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 0LL, 0LL, 0LL, 0LL, 0LL, 0LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 0LL, 0LL, 0LL, 0LL, 0LL, 0LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 0LL, 0LL, 0LL, 0LL, 0LL, 0LL)) :
+    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(true, 0u, 0u, 0u, 0u, 0u, 0u, 0u, (TargetC::Runtime)0u, (TargetC::BitFieldStyle)0u), TargetCPP cpp = TargetCPP(false, false, false, false, false, (TargetCPP::Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11u, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool omfobj = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 0LL, 0LL, 0LL, 0LL, 0LL, 0LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 0LL, 0LL, 0LL, 0LL, 0LL, 0LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 0LL, 0LL, 0LL, 0LL, 0LL, 0LL)) :
         os(os),
         osMajor(osMajor),
         ptrsize(ptrsize),

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -60,7 +60,11 @@ class Lexer
     bool Ccompile;              /// true if compiling ImportC
 
     // The following are valid only if (Ccompile == true)
+    ubyte boolsize;             /// size of a C _Bool, default 1
+    ubyte shortsize;            /// size of a C short, default 2
+    ubyte intsize;              /// size of a C int, default 4
     ubyte longsize;             /// size of C long, 4 or 8
+    ubyte long_longsize;        /// size of a C long long, default 8
     ubyte long_doublesize;      /// size of C long double, 8 or D real.sizeof
     ubyte wchar_tsize;          /// size of C wchar_t, 2 or 4
 
@@ -2312,7 +2316,7 @@ class Lexer
             case FLAGS.decimal | FLAGS.long_:
                 /* First that fits: long, long long
                  */
-                if (longsize == 4)
+                if (longsize == 4 || long_longsize == 4)
                 {
                     if (n & 0xFFFFFFFF_80000000L)
                         result = TOK.int64Literal;
@@ -2329,7 +2333,7 @@ class Lexer
                 /* First that fits: long, unsigned long, long long,
                  * unsigned long long
                  */
-                if (longsize == 4)
+                if (longsize == 4 || long_longsize == 4)
                 {
                     if (n & 0x8000000000000000L)
                         result = TOK.uns64Literal;
@@ -2353,7 +2357,7 @@ class Lexer
             case FLAGS.decimal  | FLAGS.unsigned | FLAGS.long_:
                 /* First that fits: unsigned long, unsigned long long
                  */
-                if (longsize == 4)
+                if (longsize == 4 || long_longsize == 4)
                 {
                     if (n & 0xFFFFFFFF00000000L)
                         result = TOK.uns64Literal;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1148,7 +1148,11 @@ struct TargetC
         Gcc_Clang,            /// gcc and clang
     }
     bool  crtDestructorsSupported = true; /// Not all platforms support crt_destructor
+    ubyte boolsize;           /// size of a C `_Bool` type
+    ubyte shortsize;          /// size of a C `short` or `unsigned short` type
+    ubyte intsize;            /// size of a C `int` or `unsigned int` type
     ubyte longsize;           /// size of a C `long` or `unsigned long` type
+    ubyte long_longsize;      /// size of a C `long long` or `unsigned long long` type
     ubyte long_doublesize;    /// size of a C `long double`
     ubyte wchar_tsize;        /// size of a C `wchar_t` type
     Runtime runtime;          /// vendor of the C runtime to link against
@@ -1157,6 +1161,10 @@ struct TargetC
     extern (D) void initialize(ref const Param params, ref const Target target)
     {
         const os = target.os;
+        boolsize = 1;
+        shortsize = 2;
+        intsize = 4;
+        long_longsize = 8;
         if (os & (Target.OS.linux | Target.OS.FreeBSD | Target.OS.OpenBSD | Target.OS.DragonFlyBSD | Target.OS.Solaris))
             longsize = 4;
         else if (os == Target.OS.OSX)

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -70,7 +70,11 @@ struct TargetC
     };
 
     uint8_t crtDestructorsSupported; // Not all platforms support crt_destructor
+    uint8_t boolsize;            // size of a C '_Bool' type
+    uint8_t shortsize;           // size of a C 'short' or 'unsigned short' type
+    uint8_t intsize;             // size of a C 'int' or 'unsigned int' type
     uint8_t longsize;            // size of a C 'long' or 'unsigned long' type
+    uint8_t long_longsize;       // size of a C 'long long' or 'unsigned long long' type
     uint8_t long_doublesize;     // size of a C 'long double'
     uint8_t wchar_tsize;         // size of a C 'wchar_t' type
     Runtime runtime;


### PR DESCRIPTION
C Integer sizes are not fixed, with notable variations being:
 - `boolsize`: 4 bytes on PowerPC. Otherwise 1 byte.
 - `shortsize`: 1 byte on AVR (`-mint8`). Otherwise 2 bytes.
 - `intsize`: 2 bytes on AVR, CR16, H8300, M32C, M68000 (`-mshort`), MSP430, PDP11 (`-mint16`), RL78, XSTORMY16. Otherwise 4 bytes.
 - `longsize`: 2 bytes on AVR (`-mint8`). Otherwise 4 or 8 bytes.
 - `long_longsize`: 4 bytes on AVR (`-mint8`). Otherwise 8 bytes.

This follows on from #12537. As per https://github.com/dlang/dmd/pull/12507#issuecomment-841729977, this allows GDC to set C type sizes as requested from the target backend we are compiling for, so there isn't a mismatch.

The `wchar_tsize` field has been removed as it is unused in CParser.  I don't expect it ever to be, as `wchar_t` is a C++ keyword.

@WalterBright 