### PR TITLE
Tag name space

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -3507,6 +3507,23 @@ final class CParser(AST) : Parser!AST
         return new AST.ExpStatement(loc, e);
     }
 
+    /******************************************
+     * Tag names are placed into a separate symbol table.
+     * Accomplish this by prefixing tag names with `__tag` so they
+     * do not conflict with other non-tag identifiers, and get away with only
+     * one symbol table.
+     * Params:
+     *   id = identifer to convert to tag identifier
+     * Returns:
+     *   tag identifier
+     */
+    private Identifier toTagIdentifier(Identifier id)
+    {
+        OutBuffer buf;
+        buf.printf("__tag%s", id.toChars());
+        return Identifier.idPool(buf[]);
+    }
+
     /************************
      * After encountering an error, scan forward until a right brace or ; is found
      * or the end of the file.

--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2623,7 +2623,7 @@ final class CParser(AST) : Parser!AST
             nextToken();
         }
 
-        auto etag = new AST.EnumDeclaration(loc, tag, AST.Type.tint32);
+        auto etag = new AST.EnumDeclaration(loc, toTagIdentifier(tag), AST.Type.tint32);
         if (!symbols)
             symbols = new AST.Dsymbols();
         symbols.push(etag);
@@ -2706,7 +2706,7 @@ final class CParser(AST) : Parser!AST
      *    declarator (opt) : constant-expression
      *
      * Params:
-     *  symbols = symbols to add enum declaration to
+     *  symbols = symbols to add struct declaration to
      * Returns:
      *  type of the struct
      */
@@ -2723,7 +2723,7 @@ final class CParser(AST) : Parser!AST
             nextToken();
         }
 
-        auto stag = new AST.StructDeclaration(loc, tag, false);
+        auto stag = new AST.StructDeclaration(loc, toTagIdentifier(tag), false);
         if (!symbols)
             symbols = new AST.Dsymbols();
         symbols.push(stag);
@@ -3508,20 +3508,41 @@ final class CParser(AST) : Parser!AST
     }
 
     /******************************************
-     * Tag names are placed into a separate symbol table.
+     * Tag names are placed into a separate, parallel symbol table.
      * Accomplish this by prefixing tag names with `__tag` so they
      * do not conflict with other non-tag identifiers, and get away with only
      * one symbol table.
      * Params:
-     *   id = identifer to convert to tag identifier
+     *   id = identifier to convert to tag identifier, can be null
      * Returns:
      *   tag identifier
      */
-    private Identifier toTagIdentifier(Identifier id)
+    private Identifier toTagIdentifier(Identifier id) @trusted
     {
-        OutBuffer buf;
-        buf.printf("__tag%s", id.toChars());
-        return Identifier.idPool(buf[]);
+        if (!id)
+            return null;
+
+        enum prefix = "__tag";
+        enum format = prefix ~ "%s";
+
+        debug enum len = 1;  // small size so we'll exceed it
+        else  enum len = 31; // don't exceed very often
+
+        char[len + 1] tmp = void;  // +1 for 0
+        const idlen = id.toString().length;
+        const taglen = prefix.length + idlen;
+        if (taglen <= len)
+        {
+            // use tmp[] instead of allocation
+            sprintf(tmp.ptr, format, id.toChars());
+            return Identifier.idPool(tmp[0 .. taglen]);
+        }
+        else
+        {
+            OutBuffer buf;
+            buf.printf(format, id.toChars());
+            return Identifier.idPool(buf[]);
+        }
     }
 
     /************************

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -266,6 +266,19 @@ typedef long int long_int;
 typedef long_int my_int;
 
 /********************************/
+
+int tags()
+{
+    struct S { int a; };
+    int S = 3;
+    enum E { b };
+    int E = 2;
+    return S + E;
+}
+
+_Static_assert(tags() == 5, "ok");
+
+/********************************/
 // https://issues.dlang.org/show_bug.cgi?id=21934
 typedef int type1 asm("realtype1");
 typedef int type2 __asm("realtype2");


### PR DESCRIPTION
By prefixing tag names with `__tab`, a separate name space can be created for them without having to create a separate symbol table.