### PR TITLE
fix Issue 21937 - importC: Support parsing __attribute__ specifiers

### DIFF
--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -323,6 +323,46 @@ void test_asm()
 }
 
 /********************************/
+// https://issues.dlang.org/show_bug.cgi?id=21937
+__attribute__(()) int test21937a();
+int test21937b() __attribute__(( , nothrow, hot, aligned(2), ));
+int test21937c() __attribute__((nothrow , leaf)) __attribute__((noreturn));
+
+__attribute__((noinline))
+void test21937d()
+{
+  typedef int attr_var_t;
+  attr_var_t attr_local __attribute__((unused));
+}
+
+__attribute__((aligned)) int test21937e;
+int test21937f __attribute__((aligned));
+
+struct __attribute__((packed)) S21937a
+{
+  __attribute__((deprecated("msg"))) char c;
+  int i __attribute__((deprecated));
+};
+
+struct S21937b
+{
+  __attribute__((deprecated("msg"))) char c;
+  int i __attribute__((deprecated));
+} __attribute__((packed));
+
+enum __attribute__((aligned)) E21937a
+{
+  E21937a_A,
+};
+
+enum E21937b
+{
+  E21937b_A,
+} __attribute__((aligned));
+
+typedef int T21937a __attribute__((unused));
+
+/********************************/
 // https://issues.dlang.org/show_bug.cgi?id=21945
 typedef struct {
     long var;

--- a/test/fail_compilation/failcstuff1.d
+++ b/test/fail_compilation/failcstuff1.d
@@ -1,8 +1,9 @@
 // EXTRA_FILES: imports/cstuff1.c
 /* TEST_OUTPUT
 ---
-fail_compilation/imports/cstuff1.c(5): Error: no members for `enum empty_enum`
-fail_compilation/imports/cstuff1.c(6): Error: no members for anonymous enum
+fail_compilation/imports/cstuff1.c(101): Error: attributes should be specified before the function definition
+fail_compilation/imports/cstuff1.c(200): Error: no members for `enum E21962`
+fail_compilation/imports/cstuff1.c(201): Error: no members for anonymous enum
 ---
 */
 import imports.cstuff1;

--- a/test/fail_compilation/imports/cstuff1.c
+++ b/test/fail_compilation/imports/cstuff1.c
@@ -1,6 +1,14 @@
 // check the expression parser
 
 /********************************/
+// https://issues.dlang.org/show_bug.cgi?id=21937
+#line 100
+void test21962() __attribute__((noinline))
+{
+}
+
+/********************************/
 // https://issues.dlang.org/show_bug.cgi?id=21962
-enum empty_enum { };
+#line 200
+enum E21962 { };
 enum { };


### PR DESCRIPTION
Only parses `__attribute__`, ignored its contents for now. @WalterBright 