### PR TITLE
fix Issue 21963 - importC: Support declaring union types

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2743,7 +2743,7 @@ final class CParser(AST) : Parser!AST
      *    declarator (opt) : constant-expression
      *
      * Params:
-     *  symbols = symbols to add enum declaration to
+     *  symbols = symbols to add struct-or-union declaration to
      * Returns:
      *  type of the struct
      */
@@ -2760,7 +2760,11 @@ final class CParser(AST) : Parser!AST
             nextToken();
         }
 
-        auto stag = new AST.StructDeclaration(loc, tag, false);
+        assert(structOrUnion.value == TOK.struct_ || structOrUnion.value == TOK.union_);
+        auto stag = (structOrUnion.value == TOK.struct_)
+            ? new AST.StructDeclaration(loc, tag, false)
+            : new AST.UnionDeclaration(loc, tag);
+
         if (!symbols)
             symbols = new AST.Dsymbols();
         symbols.push(stag);

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -499,7 +499,7 @@ static immutable TOK[TOK.max + 1] Ckeywords =
         enum Ckwds = [ auto_, break_, case_, char_, const_, continue_, default_, do_, float64, else_,
                        enum_, extern_, float32, for_, goto_, if_, inline, int32, int64, register,
                        restrict, return_, int16, signed, sizeof_, static_, struct_, switch_, typedef_,
-                       unsigned, void_, volatile, while_, asm_,
+                       union_, unsigned, void_, volatile, while_, asm_,
                        _Alignas, _Alignof, _Atomic, _Bool, _Complex, _Generic, _Imaginary, _Noreturn,
                        _Static_assert, _Thread_local, __cdecl, __restrict, __declspec, __attribute__ ];
 

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -335,6 +335,14 @@ typedef enum {
 TypedefEnum typedef_var2;
 
 /********************************/
+// https://issues.dlang.org/show_bug.cgi?id=21963
+union union_type
+{
+  int iv;
+  float fv;
+};
+
+/********************************/
 // https://issues.dlang.org/show_bug.cgi?id=21967
 const int const_int_fn(void);
 const int *const_int_fn_ptr(void);


### PR DESCRIPTION
`union` was being converted to an identifier token.

@WalterBright 