### PR TITLE
fix Issue 21945 - importC AssertError@src/dmd/dsymbolsem.d(4787): Assertion failure

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1494,7 +1494,29 @@ final class CParser(AST) : Parser!AST
             {
                 if (token.value == TOK.assign)
                     error("no initializer for typedef declaration");
-                s = new AST.AliasDeclaration(token.loc, id, dt);
+
+                bool isalias = true;
+                if (auto ts = dt.isTypeStruct())
+                {
+                    if (ts.sym.isAnonymous())
+                    {
+                        // This is a typedef for an anonymous struct-or-union.
+                        // Directly set the ident for the struct-or-union.
+                        ts.sym.ident = id;
+                        isalias = false;
+                    }
+                }
+                else if (auto te = dt.isTypeEnum())
+                {
+                    if (te.sym.isAnonymous())
+                    {
+                        // This is a typedef for an anonymous enum.
+                        te.sym.ident = id;
+                        isalias = false;
+                    }
+                }
+                if (isalias)
+                    s = new AST.AliasDeclaration(token.loc, id, dt);
             }
             else if (id)
             {

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -323,6 +323,19 @@ void test_asm()
 }
 
 /********************************/
+// https://issues.dlang.org/show_bug.cgi?id=21945
+typedef struct {
+    long var;
+} TypedefStruct;
+TypedefStruct typedef_var1;
+
+typedef enum {
+    typedef_enum_member,
+} TypedefEnum;
+TypedefEnum typedef_var2;
+
+
+/********************************/
 
 void test__func__()
 {


### PR DESCRIPTION
Translates typedefs to anonymous struct, union, and enum types into a named struct, union or enum type.