### PR TITLE
Convert Type.ty to an enum

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -659,6 +659,58 @@ class WithStatement;
 class Tuple;
 struct TemplatePrevious;
 class TemplateTupleParameter;
+enum class TY : uint8_t
+{
+    Tarray = 0u,
+    Tsarray = 1u,
+    Taarray = 2u,
+    Tpointer = 3u,
+    Treference = 4u,
+    Tfunction = 5u,
+    Tident = 6u,
+    Tclass = 7u,
+    Tstruct = 8u,
+    Tenum = 9u,
+    Tdelegate = 10u,
+    Tnone = 11u,
+    Tvoid = 12u,
+    Tint8 = 13u,
+    Tuns8 = 14u,
+    Tint16 = 15u,
+    Tuns16 = 16u,
+    Tint32 = 17u,
+    Tuns32 = 18u,
+    Tint64 = 19u,
+    Tuns64 = 20u,
+    Tfloat32 = 21u,
+    Tfloat64 = 22u,
+    Tfloat80 = 23u,
+    Timaginary32 = 24u,
+    Timaginary64 = 25u,
+    Timaginary80 = 26u,
+    Tcomplex32 = 27u,
+    Tcomplex64 = 28u,
+    Tcomplex80 = 29u,
+    Tbool = 30u,
+    Tchar = 31u,
+    Twchar = 32u,
+    Tdchar = 33u,
+    Terror = 34u,
+    Tinstance = 35u,
+    Ttypeof = 36u,
+    Ttuple = 37u,
+    Tslice = 38u,
+    Treturn = 39u,
+    Tnull = 40u,
+    Tvector = 41u,
+    Tint128 = 42u,
+    Tuns128 = 43u,
+    Ttraits = 44u,
+    Tmixin = 45u,
+    Tnoreturn = 46u,
+    TMAX = 47u,
+};
+
 struct Mcache;
 struct TYPE;
 class TypeBasic;
@@ -1208,7 +1260,7 @@ public:
 class Type : public ASTNode
 {
 public:
-    uint8_t ty;
+    TY ty;
     uint8_t mod;
     char* deco;
     struct Mcache
@@ -4947,59 +4999,7 @@ extern void json_generate(OutBuffer* buf, Array<Module* >* modules);
 
 extern JsonFieldFlags tryParseJsonField(const char* fieldName);
 
-enum class ENUMTY
-{
-    Tarray = 0,
-    Tsarray = 1,
-    Taarray = 2,
-    Tpointer = 3,
-    Treference = 4,
-    Tfunction = 5,
-    Tident = 6,
-    Tclass = 7,
-    Tstruct = 8,
-    Tenum = 9,
-    Tdelegate = 10,
-    Tnone = 11,
-    Tvoid = 12,
-    Tint8 = 13,
-    Tuns8 = 14,
-    Tint16 = 15,
-    Tuns16 = 16,
-    Tint32 = 17,
-    Tuns32 = 18,
-    Tint64 = 19,
-    Tuns64 = 20,
-    Tfloat32 = 21,
-    Tfloat64 = 22,
-    Tfloat80 = 23,
-    Timaginary32 = 24,
-    Timaginary64 = 25,
-    Timaginary80 = 26,
-    Tcomplex32 = 27,
-    Tcomplex64 = 28,
-    Tcomplex80 = 29,
-    Tbool = 30,
-    Tchar = 31,
-    Twchar = 32,
-    Tdchar = 33,
-    Terror = 34,
-    Tinstance = 35,
-    Ttypeof = 36,
-    Ttuple = 37,
-    Tslice = 38,
-    Treturn = 39,
-    Tnull = 40,
-    Tvector = 41,
-    Tint128 = 42,
-    Tuns128 = 43,
-    Ttraits = 44,
-    Tmixin = 45,
-    Tnoreturn = 46,
-    TMAX = 47,
-};
-
-typedef uint8_t TY;
+typedef TY ENUMTY;
 
 enum class MODFlags
 {

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -233,7 +233,7 @@ private enum TFlags
     complex      = 0x20,
 }
 
-enum ENUMTY : int
+enum TY : ubyte
 {
     Tarray,     // slice array, aka T[]
     Tsarray,    // static array, aka T[dimension]
@@ -338,7 +338,7 @@ alias Tmixin = ENUMTY.Tmixin;
 alias Tnoreturn = ENUMTY.Tnoreturn;
 alias TMAX = ENUMTY.TMAX;
 
-alias TY = ubyte;
+alias ENUMTY = TY;
 
 ///Returns true if ty is char, wchar, or dchar
 bool isSomeChar(TY ty) pure nothrow @nogc @safe

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -44,7 +44,7 @@ void semanticTypeInfo(Scope *sc, Type *t);
 Type *typeSemantic(Type *t, const Loc &loc, Scope *sc);
 Type *merge(Type *type);
 
-enum ENUMTY
+enum class TY : uint8_t
 {
     Tarray,             // slice array, aka T[]
     Tsarray,            // static array, aka T[dimension]
@@ -99,7 +99,6 @@ enum ENUMTY
     Tnoreturn,
     TMAX
 };
-typedef unsigned char TY;       // ENUMTY
 
 #define SIZE_INVALID (~(d_uns64)0)   // error return from size() functions
 
@@ -208,7 +207,7 @@ public:
 
     static TemplateDeclaration *rtinfo;
 
-    static Type *basic[TMAX];
+    static Type *basic[(int)TY::TMAX];
 
     virtual const char *kind();
     Type *copy() const;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -515,7 +515,7 @@ extern (C++) struct Target
         // Whether a vector is really supported depends on the CPU being targeted.
         if (sz == 16)
         {
-            final switch (type.ty)
+            switch (type.ty)
             {
             case Tint32:
             case Tuns32:
@@ -535,6 +535,9 @@ extern (C++) struct Target
                 if (cpu < CPU.sse2)
                     return 3; // no SSE2 vector support
                 break;
+
+            default:
+                assert(0);
             }
         }
         else if (sz == 32)


### PR DESCRIPTION
Alternative to #9913.  The only victim in the D codebase is `final switch` in `target.d`.  The removal of `ENUMTY` can be phased out in smaller steps.

The C++ codebase will be _hugely_ affected by the switch from `enum` to `enum class` however, so give us some time to test against GDC, and maybe allow LDC to weigh in as well.