### PR TITLE
dmd.cparse: Remove __restrict keyword

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -242,7 +242,6 @@ final class CParser(AST) : Parser!AST
         case TOK.const_:
         case TOK.volatile:
         case TOK.restrict:
-        case TOK.__restrict:
 
         // alignment-specifier
         case TOK._Alignas:
@@ -1831,7 +1830,6 @@ final class CParser(AST) : Parser!AST
                 // Type qualifiers
                 case TOK.const_:     modx = MOD.xconst;     break;
                 case TOK.volatile:   modx = MOD.xvolatile;  break;
-                case TOK.__restrict:
                 case TOK.restrict:   modx = MOD.xrestrict;  break;
 
                 // Type specifiers
@@ -2275,7 +2273,6 @@ final class CParser(AST) : Parser!AST
             {
                 case TOK.const_:     mod |= MOD.xconst;     break;
                 case TOK.volatile:   mod |= MOD.xvolatile;  break;
-                case TOK.__restrict:
                 case TOK.restrict:   mod |= MOD.xrestrict;  break;
                 case TOK._Atomic:    mod |= MOD.x_Atomic;   break;
 
@@ -3013,7 +3010,6 @@ final class CParser(AST) : Parser!AST
                 case TOK.const_:
                 case TOK.volatile:
                 case TOK.restrict:
-                case TOK.__restrict:
                     t = peek(t);
                     any = true;
                     continue;
@@ -3259,7 +3255,6 @@ final class CParser(AST) : Parser!AST
             {
                 case TOK.const_:
                 case TOK.restrict:
-                case TOK.__restrict:
                 case TOK.volatile:
                 case TOK._Atomic:
                     t = peek(t);
@@ -3310,7 +3305,6 @@ final class CParser(AST) : Parser!AST
                 // Type Qualifiers
                 case TOK.const_:
                 case TOK.restrict:
-                case TOK.__restrict:
                 case TOK.volatile:
 
                 // Type Specifiers

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -501,9 +501,8 @@ enum class TOK : uint16_t
     _Static_assert = 254u,
     _Thread_local = 255u,
     __cdecl = 256u,
-    __restrict = 257u,
-    __declspec = 258u,
-    __attribute__ = 259u,
+    __declspec = 257u,
+    __attribute__ = 258u,
 };
 
 class StringExp;

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -313,7 +313,6 @@ enum TOK : ushort
 
     // C only extended keywords
     __cdecl,
-    __restrict,
     __declspec,
     __attribute__,
 }
@@ -471,7 +470,6 @@ private immutable TOK[] keywords =
 
     // C only extended keywords
     TOK.__cdecl,
-    TOK.__restrict,
     TOK.__declspec,
     TOK.__attribute__,
 ];
@@ -501,7 +499,7 @@ static immutable TOK[TOK.max + 1] Ckeywords =
                        restrict, return_, int16, signed, sizeof_, static_, struct_, switch_, typedef_,
                        unsigned, void_, volatile, while_, asm_,
                        _Alignas, _Alignof, _Atomic, _Bool, _Complex, _Generic, _Imaginary, _Noreturn,
-                       _Static_assert, _Thread_local, __cdecl, __restrict, __declspec, __attribute__ ];
+                       _Static_assert, _Thread_local, __cdecl, __declspec, __attribute__ ];
 
         foreach (kw; Ckwds)
             tab[kw] = cast(TOK) kw;
@@ -812,7 +810,6 @@ extern (C++) struct Token
 
         // C only extended keywords
         TOK.__cdecl        : "__cdecl",
-        TOK.__restrict     : "__restrict",
         TOK.__declspec     : "__declspec",
         TOK.__attribute__  : "__attribute__",
     ];

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -208,7 +208,6 @@ enum
         TOK_Thread_local,
 
         TOK__cdecl,
-        TOK__restrict,
         TOK__declspec,
         TOK__attribute__,
 

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -203,7 +203,6 @@ void test2()
     int (*xi);
     int (*fp)(void);
     int (* const volatile restrict fp2)(void);
-    int (* __restrict fp3)(void*);
     void* pv;
     char c, d;
     short sh;
@@ -222,13 +221,11 @@ void test2()
     const int ci;
     volatile int vi;
     restrict int ri;
-    __restrict int rri;
 
 //    _Atomic(int) ai;
 //    _Alignas(c) ac;
 
     void * const volatile restrict q;
-    void * __restrict r;
 
     inline int f();
     _Noreturn void g();

--- a/test/unit/lexer/location_offset.d
+++ b/test/unit/lexer/location_offset.d
@@ -535,7 +535,6 @@ enum ignoreTokens
     _Thread_local,
 
     __cdecl,
-    __restrict,
     __declspec,
     __attribute__,
 


### PR DESCRIPTION
Same rationale as #12552 with the removal of `__asm`.  This extension can be handled with a macro
```
#define __restrict restrict
```
@WalterBright 