### PR TITLE
fix Issue 21944 - importC: Add `-P` to C preprocessor invocation example

### DIFF
--- a/changelog/ImportC.md
+++ b/changelog/ImportC.md
@@ -83,7 +83,7 @@ In detail:
 the C preprocessor. To import stdio.h into a D program,
 the build script would be:
 
-     gcc -E stdio.h >stdio.c
+     gcc -E -P stdio.h >stdio.c
 
 and in the D source file:
 


### PR DESCRIPTION
The recommendation for using a preprocessor does not generate compilable code due to GCC-specific `#line` directives not being supported by importC.