### PR TITLE
Fix 21951 - Add missing defaultInit literal for `noreturn`

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2214,6 +2214,15 @@ public:
         result = getVarExp(e.loc, istate, e.var, goal);
         if (exceptionOrCant(result))
             return;
+
+        // Visit the default initializer for noreturn variables
+        // (Custom initializers would abort the current function call and exit above)
+        if (result.type.ty == Tnoreturn)
+        {
+            result.accept(this);
+            return;
+        }
+
         if ((e.var.storage_class & (STC.ref_ | STC.out_)) == 0 && e.type.baseElemOf().ty != Tstruct)
         {
             /* Ultimately, STC.ref_|STC.out_ check should be enough to see the

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -4538,6 +4538,19 @@ Expression defaultInit(Type mt, const ref Loc loc)
         return new TupleExp(loc, exps);
     }
 
+    Expression visitNoreturn(TypeNoreturn mt)
+    {
+        static if (LOGDEFAULTINIT)
+        {
+            printf("TypeNoreturn::defaultInit() '%s'\n", mt.toChars());
+        }
+        auto cond = IntegerExp.createBool(false);
+        auto msg = new StringExp(loc, "Accessed variable of type `noreturn`!");
+        auto ae = new AssertExp(loc, cond, msg);
+        ae.type = mt;
+        return ae;
+    }
+
     switch (mt.ty)
     {
         case Tvector:   return visitVector  (cast(TypeVector)mt);
@@ -4557,6 +4570,7 @@ Expression defaultInit(Type mt, const ref Loc loc)
         case Treference:
         case Tdelegate:
         case Tclass:    return new NullExp(loc, mt);
+        case Tnoreturn: return visitNoreturn(cast(TypeNoreturn) mt);
 
         default:        return mt.isTypeBasic() ?
                                 visitBasic(cast(TypeBasic)mt) :

--- a/test/compilable/noreturn3.d
+++ b/test/compilable/noreturn3.d
@@ -1,0 +1,28 @@
+/*
+REQUIRED_ARGS: -w -o-
+
+More complex examples from the DIP
+https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md
+*/
+
+alias noreturn = typeof(*null);
+static assert (!is(noreturn == void));
+
+void initialize()
+{
+    noreturn a;
+    noreturn b = noreturn.init;
+}
+
+void foo(const noreturn);
+void foo(const int);
+
+noreturn bar();
+
+void overloads()
+{
+    noreturn n;
+    foo(n);
+
+    foo(bar());
+}

--- a/test/fail_compilation/noreturn.d
+++ b/test/fail_compilation/noreturn.d
@@ -1,0 +1,94 @@
+/*
+REQUIRED_ARGS: -w -o-
+
+TEST_OUTPUT:
+---
+fail_compilation\noreturn.d(32): Error: `"Accessed variable of type `noreturn`!"`
+fail_compilation\noreturn.d(36):        called from here: `assign()`
+fail_compilation\noreturn.d(43): Error: `"Accessed variable of type `noreturn`!"`
+fail_compilation\noreturn.d(43):        called from here: `foo(n)`
+fail_compilation\noreturn.d(47):        called from here: `calling()`
+fail_compilation\noreturn.d(53): Error: `"Accessed variable of type `noreturn`!"`
+fail_compilation\noreturn.d(56):        called from here: `nested()`
+---
+
+https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md
+*/
+
+alias noreturn = typeof(*null);
+
+int pass()
+{
+    noreturn n;
+    noreturn m;
+    return 0;
+}
+
+enum forcePass = pass();
+
+int assign()
+{
+    noreturn n;
+    noreturn m = n;
+    return 0;
+}
+
+enum forceAss = assign();
+
+void foo(const noreturn) {}
+
+int calling()
+{
+    noreturn n;
+    foo(n);
+    return 0;
+}
+
+enum forceCall = calling();
+
+int nested()
+{
+    int[4] arr;
+    noreturn n;
+    return arr[n ? n : n];
+}
+
+enum forceNested = nested();
+
+/*
+struct HasNoreturnStruct
+{
+    noreturn n;
+}
+
+int inStruct()
+{
+    HasNoreturnStruct hn;
+    return hn.n;
+}
+
+enum forceInStruct = inStruct();
+
+class HasNoreturnClass
+{
+    noreturn n;
+}
+
+int inClass()
+{
+    HasNoreturnClass hn = new HasNoreturnClass();
+    return hn.n;
+}
+
+enum forceInClass = inClass();
+
+int inClassRef()
+{
+    static void byRef(ref noreturn n) {}
+    HasNoreturnClass hn = new HasNoreturnClass();
+    byRef(hn.n);
+    return 0;
+}
+
+enum forceInClassRef = inClassRef();
+*/


### PR DESCRIPTION
 Otherwise further semantic for `noreturn` variables / overload resultion will segfault.

The default initializer is defined as `assert(false)` for now. This
might need to be revised to satisfy [1] once the backend is adapted to
handle `noreturn` outside of return values (currently either crashes or
hits assertion failures).

[1]:
> Defining a noreturn variable with no initialization expression
> generates an assert(0) only if the variable is accessed, which can be
> useful in generic code where unused noreturn variables may be declared