### PR TITLE
fix Issue 21970 - importC: Error: variable extern symbols cannot have initializers

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1541,8 +1541,6 @@ final class CParser(AST) : Parser!AST
                     hasInitializer = true;
                     initializer = cparseInitializer();
                 }
-                else
-                    initializer = new AST.VoidInitializer(token.loc);
                 // declare the symbol
                 assert(id);
                 if (dt.isTypeFunction())
@@ -1553,6 +1551,10 @@ final class CParser(AST) : Parser!AST
                 }
                 else
                 {
+                    // Give non-extern variables an implicit void initializer
+                    // if one has not been explicitly set.
+                    if (!hasInitializer && !(specifier.scw & SCW.xextern))
+                        initializer = new AST.VoidInitializer(token.loc);
                     s = new AST.VarDeclaration(token.loc, dt, id, initializer, specifiersToSTC(level, specifier));
                 }
             }

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -346,6 +346,11 @@ const int test21967a(void);
 const int *test21967b(void);
 
 /********************************/
+// https://issues.dlang.org/show_bug.cgi?id=21970
+extern int test21970a;
+extern char *test21970b;
+
+/********************************/
 
 void test__func__()
 {


### PR DESCRIPTION
The `initializer` variable was also being set for function declarations, which was subsequently ignored.  @WalterBright 