### PR TITLE
fix Issue 21948 - importC: Support declaring local variables of typedef types

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2871,14 +2871,14 @@ final class CParser(AST) : Parser!AST
         {
             if (!skipBraces(t))
                 return false;
-            t = peek(t);
+            pt = t;
             return true;
         }
 
         // skip over assignment-expression, ending before comma or semiColon or EOF
         if (!isAssignmentExpression(t))
             return false;
-        t = peek(t);
+        pt = t;
         return true;
     }
 

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -315,9 +315,8 @@ void test21934()
     asmreg r2 asm("r2");
 
     register asmreg r3 asm("r3") = 3;
-    // Uncomment when bug fixed https://issues.dlang.org/show_bug.cgi?id=21948
     // asm ignored by C compiler, should be disallowed?
-    //asmreg r4 asm("r4") = 4;
+    asmreg r4 asm("r4") = 4;
 }
 
 /********************************/
@@ -331,6 +330,20 @@ typedef enum {
     E21945_member,
 } E21945;
 E21945 test21945b;
+
+/********************************/
+// https://issues.dlang.org/show_bug.cgi?id=21948
+void test21948()
+{
+    typedef int myint;
+    typedef struct { int f; } mystruct;
+
+    myint var1;
+    myint var2 = 12;
+    mystruct var3;
+    // Uncomment when bug fixed https://issues.dlang.org/show_bug.cgi?id=21979
+    //mystruct var4 = { 34 };
+}
 
 /********************************/
 // https://issues.dlang.org/show_bug.cgi?id=21963


### PR DESCRIPTION
The issue was that `pt` was not assigned back to after parsing,  ~have changed the if conditions to a switch to make it more obvious,~ and removed the unnecessary `t = peek(t)`.

@WalterBright 