### PR TITLE
Fixup for #12528 - Add changelog, improve message, fix tests

### DIFF
--- a/changelog/ambiguous-lambda.dd
+++ b/changelog/ambiguous-lambda.dd
@@ -1,0 +1,11 @@
+Using the syntax `(args) => {}` now triggers a deprecation message
+
+Newcomers from languages with built-in delegates (such as JavaScript and C#)
+would often use `(args) => { /* body */ }` for delegate/function literals.
+
+However, in D, this syntax results in a `delegate` that returns a `delegate`,
+without any other side effects. This may trigger hard-to-debug bugs,
+therefore it is now deprecated.
+
+If a delegate returning a delegate is indeed the intended usage,
+use either `(args) { return () => /* body */; }` or `(args) => () { /* body */ }`.

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -5098,7 +5098,7 @@ class Parser(AST) : Lexer
             check(TOK.goesTo);
             if (token.value == TOK.leftCurly)
             {
-                deprecation("`(args) => { ... }` is a lambda that returns a delegate, not a multi-line lambda.");
+                deprecation("Using `(args) => { ... }` to create a delegate that returns a delegate is error-prone.");
                 deprecationSupplemental(token.loc, "Use `(args) { ... }` for a multi-statement function literal or use `(args) => () { }` if you intended for the lambda to return a delegate.");
             }
             const returnloc = token.loc;

--- a/test/fail_compilation/fail16001.d
+++ b/test/fail_compilation/fail16001.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail16001.d(10): Deprecation: `(args) => { ... }` is a lambda that returns a delegate, not a multi-line lambda.
+fail_compilation/fail16001.d(10): Deprecation: Using `(args) => { ... }` to create a delegate that returns a delegate is error-prone.
 fail_compilation/fail16001.d(10):        Use `(args) { ... }` for a multi-statement function literal or use `(args) => () { }` if you intended for the lambda to return a delegate.
 ---
 */

--- a/test/fail_compilation/ice10212.d
+++ b/test/fail_compilation/ice10212.d
@@ -1,10 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10212.d(15): Deprecation: `(args) => { ... }` is a lambda that returns a delegate, not a multi-line lambda.
-fail_compilation/ice10212.d(15):        Use `(args) { ... }` for a multi-statement function literal or use `(args) => () { }` if you intended for the lambda to return a delegate.
-fail_compilation/ice10212.d(15): Error: Expected return type of `int`, not `int function() pure nothrow @nogc @safe`:
-fail_compilation/ice10212.d(15):        Return type of `int` inferred here.
+fail_compilation/ice10212.d(13): Error: Expected return type of `int`, not `int function() pure nothrow @nogc @safe`:
+fail_compilation/ice10212.d(13):        Return type of `int` inferred here.
 ---
 */
 
@@ -12,7 +10,7 @@ int delegate() foo()
 {
     // returns "int function() pure nothrow @safe function() pure nothrow @safe"
     // and it mismatches to "int delegate()"
-    return () => {
+    return () => () {
         return 1;
     };
 }

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -1,8 +1,6 @@
 /*
 TEST_OUTPUT:
 ---
-runnable/funclit.d(417): Deprecation: `(args) => { ... }` is a lambda that returns a delegate, not a multi-line lambda.
-runnable/funclit.d(417):        Use `(args) { ... }` for a multi-statement function literal or use `(args) => () { }` if you intended for the lambda to return a delegate.
 int delegate() pure nothrow @nogc @safe delegate() pure nothrow @nogc @safe delegate() pure nothrow @safe
 int delegate() pure nothrow @nogc @safe delegate() pure nothrow @nogc @safe delegate() pure nothrow @safe
 int
@@ -414,7 +412,7 @@ void test7288()
     auto foo()
     {
         int x;
-        return () => { return x; };
+        return () { return () => x; };
     }
     pragma(msg, typeof(&foo));
     alias int delegate() pure nothrow @nogc @safe delegate() pure nothrow @nogc @safe delegate() pure nothrow @safe Dg;


### PR DESCRIPTION
```
Most deprecations should be explained to the users.
Deprecations that trigger on valid user code absolutely must be explained to the user,
so this adds a changelog entry, instead of relying on the one-liner that comes with
the bugzilla entry.

Additionally, the message wasn't enlighting: Since it triggers on possibly valid code
(the user might have intended to write a delegate returning a delegate, or might have not),
the message should state why the syntax is disallowed, not merely what the deprecated syntax is doing.

Lastly, out of the three tests affected by PR12528, two of them used the syntax correctly:
the test was actually checking that there was a correct match with a function type.
Hence, instead of mindlessly adding the deprecation message to the test,
kicking the can down the road to the person that will actually turn this into an error,
the deprecation should have fixed those error messages in the first place.
```

CC @ibuclaw : Not too happy with the wording of the changelog, I take suggestions.