### PR TITLE
add TypeTag for C struct/union/enum

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -206,6 +206,7 @@ struct ASTBase
         Ttraits,
         Tmixin,
         Tnoreturn,
+        Ttag,
         TMAX
     }
 
@@ -256,6 +257,7 @@ struct ASTBase
     alias Ttraits = ENUMTY.Ttraits;
     alias Tmixin = ENUMTY.Tmixin;
     alias Tnoreturn = ENUMTY.Tnoreturn;
+    alias Ttag = ENUMTY.Ttag;
     alias TMAX = ENUMTY.TMAX;
 
     alias TY = ubyte;
@@ -2823,6 +2825,7 @@ struct ASTBase
                 sizeTy[Tvector] = __traits(classInstanceSize, TypeVector);
                 sizeTy[Tmixin] = __traits(classInstanceSize, TypeMixin);
                 sizeTy[Tnoreturn] = __traits(classInstanceSize, TypeNoreturn);
+                sizeTy[Ttag] = __traits(classInstanceSize, TypeTag);
                 return sizeTy;
             }();
 
@@ -3588,6 +3591,7 @@ struct ASTBase
             inout(TypeNull)       isTypeNull()       { return ty == Tnull      ? cast(typeof(return))this : null; }
             inout(TypeMixin)      isTypeMixin()      { return ty == Tmixin     ? cast(typeof(return))this : null; }
             inout(TypeTraits)     isTypeTraits()     { return ty == Ttraits    ? cast(typeof(return))this : null; }
+            inout(TypeTag)        isTypeTag()        { return ty == Ttag       ? cast(typeof(return))this : null; }
         }
 
         override void accept(Visitor v)
@@ -3924,6 +3928,36 @@ struct ASTBase
         }
 
         override TypeStruct syntaxCopy()
+        {
+            return this;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) final class TypeTag : Type
+    {
+        Loc loc;
+        TOK tok;
+        Identifier id;
+        Dsymbols* members;
+
+        Type resolved;
+
+        extern (D) this(const ref Loc loc, TOK tok, Identifier id, Dsymbols* members)
+        {
+            //printf("TypeTag %p\n", this);
+            super(Ttag);
+            this.loc = loc;
+            this.tok = tok;
+            this.id = id;
+            this.members = members;
+        }
+
+        override TypeTag syntaxCopy()
         {
             return this;
         }

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -236,6 +236,7 @@ private immutable char[TMAX] mangleChar =
     Tvector      : '@',
     Ttraits      : '@',
     Tmixin       : '@',
+    Ttag         : '@',
     Tnoreturn    : '@',         // becomes 'Nn'
 ];
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4290,7 +4290,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         int errors = global.errors;
 
-        //printf("+StructDeclaration::semantic(this=%p, '%s', sizeok = %d)\n", this, toPrettyChars(), sizeok);
+        //printf("+StructDeclaration::semantic(this=%p, '%s', sizeok = %d)\n", this, sd.toPrettyChars(), sd.sizeok);
         Scope* scx = null;
         if (sd._scope)
         {

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -707,7 +707,8 @@ enum class TY : uint8_t
     Ttraits = 44u,
     Tmixin = 45u,
     Tnoreturn = 46u,
-    TMAX = 47u,
+    Ttag = 47u,
+    TMAX = 48u,
 };
 
 struct Mcache;
@@ -733,6 +734,7 @@ class TypeNull;
 class TypeMixin;
 class TypeTraits;
 class TypeNoreturn;
+class TypeTag;
 class TemplateTypeParameter;
 class TemplateValueParameter;
 class TemplateAliasParameter;
@@ -1355,7 +1357,7 @@ public:
     static ClassDeclaration* typeinfoshared;
     static ClassDeclaration* typeinfowild;
     static TemplateDeclaration* rtinfo;
-    static Type* basic[47LLU];
+    static Type* basic[48LLU];
     virtual const char* kind() const;
     Type* copy() const;
     virtual Type* syntaxCopy();
@@ -1475,6 +1477,7 @@ public:
     TypeMixin* isTypeMixin();
     TypeTraits* isTypeTraits();
     TypeNoreturn* isTypeNoreturn();
+    TypeTag* isTypeTag();
     void accept(Visitor* v);
     TypeFunction* toTypeFunction();
 };
@@ -5514,6 +5517,19 @@ public:
     void accept(Visitor* v);
 };
 
+class TypeTag final : public Type
+{
+public:
+    Loc loc;
+    TOK tok;
+    Identifier* id;
+    Array<Dsymbol* >* members;
+    Type* resolved;
+    const char* kind() const;
+    TypeTag* syntaxCopy();
+    void accept(Visitor* v);
+};
+
 class Parameter final : public ASTNode
 {
 public:
@@ -5771,6 +5787,7 @@ public:
     virtual void visit(typename AST::TypeError t);
     virtual void visit(typename AST::TypeNull t);
     virtual void visit(typename AST::TypeNoreturn t);
+    virtual void visit(typename AST::TypeTag t);
     virtual void visit(typename AST::TypeVector t);
     virtual void visit(typename AST::TypeEnum t);
     virtual void visit(typename AST::TypeTuple t);

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3802,6 +3802,14 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
             buf.writestring(hgs.fullQual ? t.sym.toPrettyChars() : t.sym.toChars());
     }
 
+    void visitTag(TypeTag t)
+    {
+        buf.writestring(Token.toChars(t.tok));
+        buf.writeByte(' ');
+        if (t.id)
+            buf.writestring(t.id.toChars());
+    }
+
     void visitTuple(TypeTuple t)
     {
         parametersToBuffer(ParameterList(t.arguments, VarArg.none), buf, hgs);
@@ -3863,5 +3871,6 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
         case Tnull:      return visitNull(cast(TypeNull)t);
         case Tmixin:     return visitMixin(cast(TypeMixin)t);
         case Tnoreturn:  return visitNoreturn(cast(TypeNoreturn)t);
+        case Ttag:       return visitTag(cast(TypeTag)t);
     }
 }

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -335,6 +335,7 @@ public:
     TypeMixin *isTypeMixin();
     TypeTraits *isTypeTraits();
     TypeNoreturn *isTypeNoreturn();
+    TypeTag *isTypeTag();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -897,6 +898,14 @@ public:
     bool isBoolean() /* const */;
     d_uns64 size(const Loc& loc) /* const */;
     unsigned alignsize();
+
+    void accept(Visitor *v) { v->visit(this); }
+};
+
+class TypeTag final : public Type
+{
+public:
+    TypeTag *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -141,6 +141,7 @@ public:
     void visit(AST.TypeError t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeNull t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeNoreturn t) { visit(cast(AST.Type)t); }
+    void visit(AST.TypeTag t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeVector t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeEnum t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeTuple t) { visit(cast(AST.Type)t); }

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -84,6 +84,7 @@ class TypeNull;
 class TypeNoreturn;
 class TypeTraits;
 class TypeMixin;
+class TypeTag;
 
 class Dsymbol;
 
@@ -437,6 +438,7 @@ public:
     virtual void visit(TypeQualified *t) { visit((Type *)t); }
     virtual void visit(TypeTraits *t) { visit((Type *)t); }
     virtual void visit(TypeMixin *t) { visit((Type *)t); }
+    virtual void visit(TypeTag *t) { visit((Type *)t); }
 
     // TypeNext
     virtual void visit(TypeReference *t) { visit((TypeNext *)t); }

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -184,6 +184,13 @@ void tokens()
 
 /********************************/
 
+void test__func__()
+{
+    _Static_assert((sizeof __func__) == 13, "ok");
+}
+
+/********************************/
+
 struct SA { int a, b, *const c, d[50]; };
 
 int test1(int i)
@@ -289,14 +296,38 @@ void test4(int i)
     long long ll = 12L;
     ll = 12UL;
     long double ld = 1.0L;
-    char* s = "hello" "betty";
+    const char* s = "hello" "betty";
 }
 
 /********************************/
 
-void test__func__()
+struct SS { int a; };
+
+int tests1()
 {
-    _Static_assert((sizeof __func__) == 13, "ok");
+    struct SS s;
+    return s.a;
+}
+
+int tests2()
+{
+    struct T { int a; };
+    struct T t;
+    return t.a;
+}
+
+void* tests3()
+{
+    struct T1 *p;
+    return p;
+}
+
+int tests4()
+{
+    struct S { int b; } a, *p;
+    a.b = 3;
+    p = &a;
+    return p->b;
 }
 
 /********************************/


### PR DESCRIPTION
D can only declare structs as separate declarations. C can declare them in declarators, and can also re-declare them in order to add the `{ members }`. Much of this cannot be done without the symbol table, so I added a `TypeTag` to collect the information to be processed later in the semantic() pass.

D's way of dealing with this is much simpler :-) but hey, that's why we have D.

Not done:

1. putting tags into a separate namespace
2. C enum tags, which have their own wacky semantics
3. anonymous structs and unions used for layout in structs/unions (much like D, actually, hmmm!!)
