### PR TITLE
Make TypeDelegate ctor/create accept a TypeFunction

### DIFF
--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1241,18 +1241,7 @@ extern(D):
         {
             foreach (n, p; type.parameterList)
             {
-                Type t = p.type;
-                if (p.isReference())
-                {
-                    t = t.referenceTo();
-                }
-                else if (p.storageClass & STC.lazy_)
-                {
-                    // Mangle as delegate
-                    Type td = new TypeFunction(ParameterList(), t, LINK.d);
-                    td = new TypeDelegate(td);
-                    t = merge(t);
-                }
+                Type t = target.cpp.parameterType(p);
                 if (t.ty == Tsarray)
                 {
                     error(Loc.initial, "Internal Compiler Error: unable to pass static array to `extern(C++)` function.");

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4113,7 +4113,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // Type is a "delegate to" or "pointer to" the function literal
         if ((exp.fd.isNested() && exp.fd.tok == TOK.delegate_) || (exp.tok == TOK.reserved && exp.fd.treq && exp.fd.treq.ty == Tdelegate))
         {
-            exp.type = new TypeDelegate(exp.fd.type);
+            exp.type = new TypeDelegate(exp.fd.type.isTypeFunction());
             exp.type = exp.type.typeSemantic(exp.loc, sc);
 
             exp.fd.tok = TOK.delegate_;
@@ -6588,7 +6588,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         e.e1 = e.e1.expressionSemantic(sc);
 
-        e.type = new TypeDelegate(e.func.type);
+        e.type = new TypeDelegate(e.func.type.isTypeFunction());
         e.type = e.type.typeSemantic(e.loc, sc);
 
         FuncDeclaration f = e.func.toAliasFunc();

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5270,7 +5270,7 @@ public:
 class TypeDelegate final : public TypeNext
 {
 public:
-    static TypeDelegate* create(Type* t);
+    static TypeDelegate* create(TypeFunction* t);
     const char* kind() const;
     TypeDelegate* syntaxCopy();
     Type* addStorageClass(StorageClass stc);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2332,7 +2332,7 @@ extern (C++) abstract class Type : ASTNode
                 }
                 else if (ty == Tdelegate)
                 {
-                    t = new TypeDelegate(t);
+                    t = new TypeDelegate(t.isTypeFunction());
                 }
                 else
                     assert(0);
@@ -5270,13 +5270,13 @@ extern (C++) final class TypeDelegate : TypeNext
 {
     // .next is a TypeFunction
 
-    extern (D) this(Type t)
+    extern (D) this(TypeFunction t)
     {
         super(Tfunction, t);
         ty = Tdelegate;
     }
 
-    static TypeDelegate create(Type t)
+    static TypeDelegate create(TypeFunction t)
     {
         return new TypeDelegate(t);
     }
@@ -5288,11 +5288,11 @@ extern (C++) final class TypeDelegate : TypeNext
 
     override TypeDelegate syntaxCopy()
     {
-        Type t = next.syntaxCopy();
-        if (t == next)
+        auto tf = next.syntaxCopy().isTypeFunction();
+        if (tf == next)
             return this;
 
-        auto result = new TypeDelegate(t);
+        auto result = new TypeDelegate(tf);
         result.mod = mod;
         return result;
     }

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -636,7 +636,7 @@ class TypeDelegate : public TypeNext
 public:
     // .next is a TypeFunction
 
-    static TypeDelegate *create(Type *t);
+    static TypeDelegate *create(TypeFunction *t);
     const char *kind();
     TypeDelegate *syntaxCopy();
     Type *addStorageClass(StorageClass stc);

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1379,8 +1379,8 @@ struct TargetCPP
         else if (p.storageClass & STC.lazy_)
         {
             // Mangle as delegate
-            Type td = new TypeFunction(ParameterList(), t, LINK.d);
-            td = new TypeDelegate(td);
+            auto tf = new TypeFunction(ParameterList(), t, LINK.d);
+            auto td = new TypeDelegate(tf);
             t = merge(t);
         }
         return t;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1381,7 +1381,7 @@ struct TargetCPP
             // Mangle as delegate
             auto tf = new TypeFunction(ParameterList(), t, LINK.d);
             auto td = new TypeDelegate(tf);
-            t = merge(t);
+            t = td.merge();
         }
         return t;
     }


### PR DESCRIPTION
```
A TypeFunction is the only legal type that can be passed as argument
to TypeDelegate constructor, however the constructor wasn't aware of this.
```