### PR TITLE
Add tests for importC issues 21933, 21965, 21968, 21973.

### DIFF
--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -7,6 +7,12 @@ typedef long int T21931a;
 typedef T21931a T21931b;
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=21933
+
+struct S21933 { void *opaque; };
+int test21933(struct S21933 *);
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=21934
 
 typedef int T21934 asm("realtype");

--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -111,6 +111,12 @@ union U21963
 };
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=21965
+
+struct { int var; };
+typedef struct { int var; };
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=21967
 
 const int test21967a(void);

--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -123,6 +123,14 @@ const int test21967a(void);
 const int *test21967b(void);
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=21968
+
+struct S21968
+{
+    struct inner *data[16];
+};
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=21970
 
 extern int test21970a;

--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -135,3 +135,15 @@ struct S21968
 
 extern int test21970a;
 extern char *test21970b;
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=21973
+
+struct S21973
+{
+    int field;
+    struct
+    {
+        int nested;
+    };
+};


### PR DESCRIPTION
As of #12594, none of these tests are causing an ICE in the compiler.  However there seems to be a issue resolving names in some cases.