### PR TITLE
Skip over return parameters for return destination

### DIFF
--- a/test/fail_compilation/test19097.d
+++ b/test/fail_compilation/test19097.d
@@ -1,7 +1,8 @@
 /* REQUIRED_ARGS: -dip1000
  * TEST_OUTPUT:
 ---
-fail_compilation/test19097.d(35): Error: scope variable `s` may not be returned
+fail_compilation/test19097.d(25): Error: scope variable `p` assigned to `r` with longer lifetime
+fail_compilation/test19097.d(46): Error: scope variable `s` may not be returned
 ---
  */
 
@@ -10,6 +11,16 @@ fail_compilation/test19097.d(35): Error: scope variable `s` may not be returned
 @safe:
 
 void betty(ref scope int* r, return scope int* p)
+{
+    r = p;
+}
+
+void tabby(return scope int* p, ref scope int* r)
+{
+    r = p;
+}
+
+void kitty(return scope int* p, int intermediate, ref scope int* r)
 {
     r = p;
 }


### PR DESCRIPTION
Extension of https://github.com/dlang/dmd/pull/8504 in an attempt to make `core.lifetime: move` compatible with -dip1000. 
Additional context: [DIP1000: The return of 'Extend Return Scope Semantics'](https://forum.dlang.org/thread/zzovywgswjmwneqwbdnm@forum.dlang.org)

The idea is: instead of only considering the first parameter as the return destination, skip over parameters already determined to be `return`. After all, in the signature of move:
```D
void move(T)(ref return scope T source, ref scope T destination);
```
Making `return` parameter `source` its own return destination accomplishes nothing.
This could be further extended to skip over parameters without pointer types, e.g.:
```D
void move(T)(ref return scope T p, int intermediate, ref scope T r);
```
But it deliberately does not do that to keep it a bit simpler.

@WalterBright @atilaneves 