### PR TITLE
[stable] Disentangle initialization issue for Type and Target wrt. isLP64

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2856,7 +2856,7 @@ struct ASTBase
             return "type";
         }
 
-        static void _init()
+        static void _init(bool isLP64)
         {
             stringtable._init(14_000);
 
@@ -2940,8 +2940,6 @@ struct ASTBase
             tstring = tchar.immutableOf().arrayOf();
             twstring = twchar.immutableOf().arrayOf();
             tdstring = tdchar.immutableOf().arrayOf();
-
-            const isLP64 = Target.isLP64;
 
             tsize_t    = basic[isLP64 ? Tuns64 : Tuns32];
             tptrdiff_t = basic[isLP64 ? Tint64 : Tint32];

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -140,9 +140,10 @@ void initDMD(
     }
 
     versionIdentifiers.each!(VersionCondition.addGlobalIdent);
-    addDefaultVersionIdentifiers(global.params, target);
 
-    Type._init();
+    const isLP64 = target.is64bit;
+
+    Type._init(isLP64);
     Id.initialize();
     Module._init();
     target._init(global.params);
@@ -151,7 +152,9 @@ void initDMD(
     Objc._init();
     FileCache._init();
 
-    addDefaultVersionIdentifiers(global.params,target);
+    assert(target.isLP64 == isLP64);
+
+    addDefaultVersionIdentifiers(global.params, target);
 
     version (CRuntime_Microsoft)
         initFPU();

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1292,7 +1292,7 @@ public:
     int32_t covariant(Type* t, uint64_t* pstc = nullptr);
     const char* toChars() const;
     char* toPrettyChars(bool QualifyTypes = false);
-    static void _init();
+    static void _init(bool isLP64);
     static void deinitialize();
     d_uns64 size();
     virtual d_uns64 size(const Loc& loc);
@@ -6662,7 +6662,7 @@ public:
         architectureName(),
         cpu((CPU)11),
         is64bit(true),
-        isLP64(),
+        isLP64(true),
         obj_ext(),
         lib_ext(),
         dll_ext(),

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -292,8 +292,10 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
 
     setDefaultLibrary();
 
+    const isLP64 = target.is64bit; // pre-initialized in parseCommandLine()
+
     // Initialization
-    Type._init();
+    Type._init(isLP64);
     Id.initialize();
     Module._init();
     target._init(params);
@@ -301,6 +303,8 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     Objc._init();
     import dmd.filecache : FileCache;
     FileCache._init();
+
+    assert(target.isLP64 == isLP64);
 
     reconcileLinkRunLib(params, files.dim);
     version(CRuntime_Microsoft)
@@ -2540,10 +2544,6 @@ private void reconcileCommands(ref Param params)
         if (params.mscrtlib)
             error(Loc.initial, "`-mscrtlib` can only be used when targetting windows");
     }
-
-    // Target uses 64bit pointers.
-    // FIXME: X32 is 64bit but uses 32 bit pointers
-    target.isLP64 = target.is64bit;
 
     if (params.boundscheck != CHECKENABLE._default)
     {

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -824,7 +824,7 @@ extern (C++) abstract class Type : ASTNode
         return buf.extractChars();
     }
 
-    static void _init()
+    static void _init(bool isLP64)
     {
         stringtable._init(14_000);
 
@@ -908,8 +908,6 @@ extern (C++) abstract class Type : ASTNode
         tstring = tchar.immutableOf().arrayOf();
         twstring = twchar.immutableOf().arrayOf();
         tdstring = tdchar.immutableOf().arrayOf();
-
-        const isLP64 = target.isLP64;
 
         tsize_t    = basic[isLP64 ? Tuns64 : Tuns32];
         tptrdiff_t = basic[isLP64 ? Tint64 : Tint32];

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -220,7 +220,7 @@ public:
     int covariant(Type *t, StorageClass *pstc = NULL);
     const char *toChars() const;
     char *toPrettyChars(bool QualifyTypes = false);
-    static void _init();
+    static void _init(bool isLP64);
 
     d_uns64 size();
     virtual d_uns64 size(const Loc &loc);

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -142,7 +142,7 @@ extern (C++) struct Target
     const(char)[] architectureName;
     CPU cpu = CPU.baseline; // CPU instruction set to target
     bool is64bit = (size_t.sizeof == 8);  // generate 64 bit code for x86_64; true by default for 64 bit dmd
-    bool isLP64;            // pointers are 64 bits
+    bool isLP64 = (size_t.sizeof == 8);   // pointers are 64 bits
 
     // Environmental
     const(char)[] obj_ext;    /// extension for object files
@@ -191,11 +191,15 @@ extern (C++) struct Target
      */
     extern (C++) void _init(ref const Param params)
     {
+        // is64bit, mscoff and cpu are initialized in parseCommandLine
+
         this.params = &params;
 
         FloatProperties.initialize();
         DoubleProperties.initialize();
         RealProperties.initialize();
+
+        isLP64 = is64bit;
 
         // These have default values for 32 bit code, they get
         // adjusted for 64 bit code.

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -72,7 +72,7 @@ static void frontend_init()
     global.params.objname = NULL;
     target.cpu = CPU::native;
 
-    Type::_init();
+    Type::_init(sizeof(size_t) == 8);
     Id::initialize();
     Module::_init();
     Expression::_init();

--- a/test/dub_package/avg.d
+++ b/test/dub_package/avg.d
@@ -55,7 +55,7 @@ void main()
     target.os = Target.OS.linux;
     target.is64bit = (size_t.sizeof == 8);
     global.params.useUnitTests = true;
-    ASTBase.Type._init();
+    ASTBase.Type._init(target.is64bit);
 
     auto id = Identifier.idPool(fname);
     auto m = new ASTBase.Module(&(fname.dup)[0], id, false, false);

--- a/test/dub_package/impvisitor.d
+++ b/test/dub_package/impvisitor.d
@@ -101,7 +101,7 @@ void main()
         target.os = Target.OS.linux;
         target.is64bit = (size_t.sizeof == 8);
         global.params.useUnitTests = true;
-        ASTBase.Type._init();
+        ASTBase.Type._init(target.is64bit);
 
         auto id = Identifier.idPool(fn);
         auto m = new ASTBase.Module(&(fn.dup)[0], id, false, false);

--- a/test/unit/deinitialization.d
+++ b/test/unit/deinitialization.d
@@ -41,7 +41,7 @@ unittest
 
     global._init();
 
-    Type._init();
+    Type._init(size_t.sizeof == 8);
     Type.deinitialize();
 
     global.deinitialize();


### PR DESCRIPTION
`Type._init()` depends on `Target.isLP64`, and `Target._init()` depends on `Type.{twchar,tdchar}` (set by `Type._init()`). `Type` is initialized before `Target`.

Before 2.097, `isLP64` was in `global.params`, which are initialized very early. Shuffling some fields to `Target` brought init issues like this, especially for cross-compilers like LDC, which of course doesn't set `target.isLP64` in `reconcileCommands()` (!) - which, for DMD, accesses `target` quite a few times before initializing it.