### PR TITLE
Fix 21985 - Ensure that LabelDsymbols have an explicit location

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -599,7 +599,7 @@ public:
     bool overloadInsert(Dsymbol *s);
     bool inUnittest();
     MATCH leastAsSpecialized(FuncDeclaration *g);
-    LabelDsymbol *searchLabel(Identifier *ident);
+    LabelDsymbol *searchLabel(Identifier *ident, const Loc &loc);
     int getLevel(FuncDeclaration *fd, int intypeof); // lexical nesting level difference
     int getLevelAndCheck(const Loc &loc, Scope *sc, FuncDeclaration *fd);
     const char *toPrettyChars(bool QualifyTypes = false);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -4692,7 +4692,7 @@ public:
     bool overloadInsert(Dsymbol* s);
     bool inUnittest();
     MATCH leastAsSpecialized(FuncDeclaration* g);
-    LabelDsymbol* searchLabel(Identifier* ident);
+    LabelDsymbol* searchLabel(Identifier* ident, const Loc& loc = Loc::initial);
     int32_t getLevel(FuncDeclaration* fd, int32_t intypeof);
     int32_t getLevelAndCheck(const Loc& loc, Scope* sc, FuncDeclaration* fd, Declaration* decl);
     enum : int32_t { LevelError = -2 };

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1063,9 +1063,16 @@ extern (C++) class FuncDeclaration : Declaration
     }
 
     /********************************
-     * Labels are in a separate scope, one per function.
+     * Searches for a label with the given identifier. This function will insert a new
+     * `LabelDsymbol` into `labtab` if it does not contain a mapping for `ident`.
+     *
+     * Params:
+     *   ident = identifier of the requested label
+     *   loc   = location used when creating a new `LabelDsymbol`
+     *
+     * Returns: the `LabelDsymbol` for `ident`
      */
-    final LabelDsymbol searchLabel(Identifier ident)
+    final LabelDsymbol searchLabel(Identifier ident, const ref Loc loc = Loc.initial)
     {
         Dsymbol s;
         if (!labtab)
@@ -1074,7 +1081,7 @@ extern (C++) class FuncDeclaration : Declaration
         s = labtab.lookup(ident);
         if (!s)
         {
-            s = new LabelDsymbol(ident);
+            s = new LabelDsymbol(ident, loc);
             labtab.insert(s);
         }
         return cast(LabelDsymbol)s;

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -3508,7 +3508,7 @@ code *asm_da_parse(OP *pop)
     {
         if (asmstate.tokValue == TOK.identifier)
         {
-            LabelDsymbol label = asmstate.sc.func.searchLabel(asmstate.tok.ident);
+            LabelDsymbol label = asmstate.sc.func.searchLabel(asmstate.tok.ident, asmstate.loc);
             if (!label)
             {
                 asmerr("label `%s` not found", asmstate.tok.ident.toChars());
@@ -4421,7 +4421,7 @@ void asm_primary_exp(out OPND o1)
                 if (!s)
                 {
                     // Assume it is a label, and define that label
-                    s = asmstate.sc.func.searchLabel(asmstate.tok.ident);
+                    s = asmstate.sc.func.searchLabel(asmstate.tok.ident, asmstate.loc);
                 }
                 if (auto label = s.isLabel())
                 {

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1192,7 +1192,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     LabelDsymbol label = cast(LabelDsymbol)keyValue.value;
                     if (!label.statement && (!label.deleted || label.iasm))
                     {
-                        funcdecl.error("label `%s` is undefined", label.toChars());
+                        funcdecl.error(label.loc, "label `%s` is undefined", label.toChars());
                     }
                 }
 

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -2441,9 +2441,9 @@ extern (C++) final class LabelDsymbol : Dsymbol
     bool deleted;           // set if rewritten to return in foreach delegate
     bool iasm;              // set if used by inline assembler
 
-    extern (D) this(Identifier ident)
+    extern (D) this(Identifier ident, const ref Loc loc = Loc.initial)
     {
-        super(ident);
+        super(loc, ident);
     }
 
     static LabelDsymbol create(Identifier ident)

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -4160,7 +4160,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         FuncDeclaration fd = sc.func;
 
         gs.ident = fixupLabelName(sc, gs.ident);
-        gs.label = fd.searchLabel(gs.ident);
+        gs.label = fd.searchLabel(gs.ident, gs.loc);
         gs.tryBody = sc.tryBody;
         gs.tf = sc.tf;
         gs.os = sc.os;
@@ -4205,7 +4205,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         ls.os = sc.os;
         ls.lastVar = sc.lastVar;
 
-        LabelDsymbol ls2 = fd.searchLabel(ls.ident);
+        LabelDsymbol ls2 = fd.searchLabel(ls.ident, ls.loc);
         if (ls2.statement)
         {
             ls.error("label `%s` already defined", ls2.toChars());
@@ -4253,7 +4253,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             {
                 if (auto ls = s.isLabelStatement())
                 {
-                    sc.func.searchLabel(ls.ident);
+                    sc.func.searchLabel(ls.ident, ls.loc);
                 }
             }
         }

--- a/test/fail_compilation/fail11552.d
+++ b/test/fail_compilation/fail11552.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -o-
 TEST_OUTPUT:
 ---
-fail_compilation/fail11552.d(9): Error: function `D main` label `label` is undefined
+fail_compilation/fail11552.d(11): Error: function `D main` label `label` is undefined
 ---
 */
 

--- a/test/fail_compilation/iasm1.d
+++ b/test/fail_compilation/iasm1.d
@@ -97,7 +97,7 @@ void test4()
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/iasm1.d(501): Error: function `iasm1.test5` label `L1` is undefined
+fail_compilation/iasm1.d(505): Error: function `iasm1.test5` label `L1` is undefined
 ---
 */
 
@@ -117,7 +117,7 @@ void test5()
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/iasm1.d(611): Error: delegate `iasm1.test6.__foreachbody1` label `L1` is undefined
+fail_compilation/iasm1.d(615): Error: delegate `iasm1.test6.__foreachbody1` label `L1` is undefined
 ---
 */
 

--- a/test/fail_compilation/ice11552.d
+++ b/test/fail_compilation/ice11552.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -o-
 TEST_OUTPUT:
 ---
-fail_compilation/ice11552.d(11): Error: function `ice11552.test11552` label `label` is undefined
+fail_compilation/ice11552.d(13): Error: function `ice11552.test11552` label `label` is undefined
 fail_compilation/ice11552.d(16):        called from here: `test11552()`
 fail_compilation/ice11552.d(16):        while evaluating: `static assert(test11552())`
 ---


### PR DESCRIPTION
This allows the error reporting to point to the first usage of an
unknown label.