### PR TITLE
[stable] Disentangle initialization issue for Type and Target wrt. isLP64, 2nd attempt

### DIFF
--- a/src/dmd/chkformat.d
+++ b/src/dmd/chkformat.d
@@ -279,7 +279,7 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
                 break;
 
             case Format.ls:     // pointer to wchar_t string
-                if (!(t.ty == Tpointer && tnext == target.c.twchar_t))
+                if (!(t.ty == Tpointer && tnext.ty.isSomeChar && tnext.size() == target.c.wchar_tsize))
                     errorMsg(null, e, "wchar_t*", t);
                 break;
 
@@ -490,7 +490,7 @@ bool checkScanfFormat(ref const Loc loc, scope const char[] format, scope Expres
 
             case Format.lc:
             case Format.ls:     // pointer to wchar_t string
-                if (!(t.ty == Tpointer && tnext == target.c.twchar_t))
+                if (!(t.ty == Tpointer && tnext.ty.isSomeChar && tnext.size() == target.c.wchar_tsize))
                     errorMsg(null, e, "wchar_t*", t);
                 break;
 

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -590,7 +590,7 @@ struct Scope
         else if (ident == Id.unsigned)
             tok = TOK.uns32;
         else if (ident == Id.wchar_t)
-            tok = target.c.twchar_t.ty == Twchar ? TOK.wchar_ : TOK.dchar_;
+            tok = target.c.wchar_tsize == 2 ? TOK.wchar_ : TOK.dchar_;
         else
             return null;
         return Token.toChars(tok);

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -140,18 +140,17 @@ void initDMD(
     }
 
     versionIdentifiers.each!(VersionCondition.addGlobalIdent);
-    addDefaultVersionIdentifiers(global.params, target);
 
+    target.os = defaultTargetOS();
+    target._init(global.params);
     Type._init();
     Id.initialize();
     Module._init();
-    target._init(global.params);
-    target.os = defaultTargetOS();
     Expression._init();
     Objc._init();
     FileCache._init();
 
-    addDefaultVersionIdentifiers(global.params,target);
+    addDefaultVersionIdentifiers(global.params, target);
 
     version (CRuntime_Microsoft)
         initFPU();

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1569,18 +1569,18 @@ struct TargetC
 
     uint32_t longsize;
     uint32_t long_doublesize;
-    Type* twchar_t;
+    uint32_t wchar_tsize;
     Runtime runtime;
     TargetC() :
         longsize(),
         long_doublesize(),
-        twchar_t()
+        wchar_tsize()
     {
     }
-    TargetC(uint32_t longsize, uint32_t long_doublesize = 0u, Type* twchar_t = nullptr, Runtime runtime = (Runtime)0u) :
+    TargetC(uint32_t longsize, uint32_t long_doublesize = 0u, uint32_t wchar_tsize = 0u, Runtime runtime = (Runtime)0u) :
         longsize(longsize),
         long_doublesize(long_doublesize),
-        twchar_t(twchar_t),
+        wchar_tsize(wchar_tsize),
         runtime(runtime)
         {}
 };
@@ -6673,7 +6673,7 @@ public:
         RealProperties()
     {
     }
-    Target(OS os, uint32_t ptrsize = 0u, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, nullptr, (Runtime)0u), TargetCPP cpp = TargetCPP(false, false, false, false, (Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool mscoff = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
+    Target(OS os, uint32_t ptrsize = 0u, uint32_t realsize = 0u, uint32_t realpad = 0u, uint32_t realalignsize = 0u, uint32_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(0u, 0u, 0u, (Runtime)0u), TargetCPP cpp = TargetCPP(false, false, false, false, (Runtime)0u), TargetObjC objc = TargetObjC(false), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool mscoff = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(NAN, NAN, NAN, NAN, NAN, 6LL, 24LL, 128LL, -125LL, 38LL, -37LL), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(NAN, NAN, NAN, NAN, NAN, 15LL, 53LL, 1024LL, -1021LL, 308LL, -307LL), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(NAN, NAN, NAN, NAN, NAN, 18LL, 64LL, 16384LL, -16381LL, 4932LL, -4931LL)) :
         os(os),
         ptrsize(ptrsize),
         realsize(realsize),

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -293,10 +293,10 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     setDefaultLibrary();
 
     // Initialization
+    target._init(params);
     Type._init();
     Id.initialize();
     Module._init();
-    target._init(params);
     Expression._init();
     Objc._init();
     import dmd.filecache : FileCache;
@@ -2540,10 +2540,6 @@ private void reconcileCommands(ref Param params)
         if (params.mscrtlib)
             error(Loc.initial, "`-mscrtlib` can only be used when targetting windows");
     }
-
-    // Target uses 64bit pointers.
-    // FIXME: X32 is 64bit but uses 32 bit pointers
-    target.isLP64 = target.is64bit;
 
     if (params.boundscheck != CHECKENABLE._default)
     {

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1171,7 +1171,7 @@ struct TargetC
 
     uint longsize;            /// size of a C `long` or `unsigned long` type
     uint long_doublesize;     /// size of a C `long double`
-    Type twchar_t;            /// C `wchar_t` type
+    uint wchar_tsize;         /// size of a C `wchar_t` type
     Runtime runtime;          /// vendor of the C runtime to link against
 
     extern (D) void initialize(ref const Param params, ref const Target target)
@@ -1197,9 +1197,9 @@ struct TargetC
         else
             long_doublesize = target.realsize;
         if (os == Target.OS.Windows)
-            twchar_t = Type.twchar;
+            wchar_tsize = 2;
         else
-            twchar_t = Type.tdchar;
+            wchar_tsize = 4;
 
         if (os == Target.OS.Windows)
             runtime = target.mscoff ? Runtime.Microsoft : Runtime.DigitalMars;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -191,11 +191,15 @@ extern (C++) struct Target
      */
     extern (C++) void _init(ref const Param params)
     {
+        // is64bit, mscoff and cpu are initialized in parseCommandLine
+
         this.params = &params;
 
         FloatProperties.initialize();
         DoubleProperties.initialize();
         RealProperties.initialize();
+
+        isLP64 = is64bit;
 
         // These have default values for 32 bit code, they get
         // adjusted for 64 bit code.

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -61,7 +61,7 @@ struct TargetC
     };
     unsigned longsize;            // size of a C 'long' or 'unsigned long' type
     unsigned long_doublesize;     // size of a C 'long double'
-    Type *twchar_t;               // C 'wchar_t' type
+    unsigned wchar_tsize;         // size of a C 'wchar_t' type
     Runtime runtime;
 };
 

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -67,17 +67,19 @@ static void frontend_init()
     gc_disable();
 
     global._init();
-    target.os = Target::OS_linux;
     global.vendor = "Front-End Tester";
     global.params.objname = NULL;
+
+    target.os = Target::OS_linux;
+    target.is64bit = true;
     target.cpu = CPU::native;
+    target._init(global.params);
 
     Type::_init();
     Id::initialize();
     Module::_init();
     Expression::_init();
     Objc::_init();
-    target._init(global.params);
     CTFloat::initialize();
 }
 
@@ -525,12 +527,12 @@ void test_cppmangle()
     fd = (*cd->members)[0]->isFuncDeclaration();
     assert(fd);
     mangle = cppThunkMangleItanium(fd, b->offset);
-    assert(strcmp(mangle, "_ZThn4_N7Derived9MethodCPPEv") == 0);
+    assert(strcmp(mangle, "_ZThn8_N7Derived9MethodCPPEv") == 0);
 
     fd = (*cd->members)[1]->isFuncDeclaration();
     assert(fd);
     mangle = cppThunkMangleItanium(fd, b->offset);
-    assert(strcmp(mangle, "_ZThn4_N7Derived7MethodDEv") == 0);
+    assert(strcmp(mangle, "_ZThn8_N7Derived7MethodDEv") == 0);
 
     assert(!global.endGagging(errors));
 }

--- a/test/dub_package/frontend_file.d
+++ b/test/dub_package/frontend_file.d
@@ -3,6 +3,7 @@
 dependency "dmd" path="../.."
 +/
 import std.stdio;
+import std.string : replace;
 
 // test frontend
 void main()
@@ -49,7 +50,7 @@ void main()
 import object;
 double average(int[] array)
 {
-    immutable immutable(uint) initialLength = array.length;
+    immutable immutable(SIZE_T) initialLength = array.length;
     double accumulator = 0.0;
     for (; array.length;)
     {
@@ -60,7 +61,7 @@ double average(int[] array)
     }
     return accumulator / cast(double)initialLength;
 }
-};
+}.replace("SIZE_T", size_t.sizeof == 8 ? "ulong" : "uint");
 
     assert(generated.canFind(expected));
 }
@@ -73,6 +74,5 @@ This is required because this file is stored with Unix line endings but the
 */
 string toUnixLineEndings(string str)
 {
-    import std.string : replace;
     return str.replace("\r\n", "\n");
 }


### PR DESCRIPTION
Alternative version of #12604, based on cherry-picked #12533, which eliminates the dependency on initialized `Type` when initializing `Target`.