### PR TITLE
fix Issue 21982 - importC: Error: variable no definition of struct

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2815,11 +2815,12 @@ final class CParser(AST) : Parser!AST
         Identifier tag;
 
         // declare `tag` as symbol
-        AST.Type declareTag()
+        AST.Type declareTag(AST.Dsymbols* members)
         {
             auto stag = (structOrUnion == TOK.struct_)
                 ? new AST.StructDeclaration(loc, tag, false)
                 : new AST.UnionDeclaration(loc, tag);
+            stag.members = members;
             if (!symbols)
                 symbols = new AST.Dsymbols();
             symbols.push(stag);
@@ -2835,7 +2836,7 @@ final class CParser(AST) : Parser!AST
                 /* `struct tag;` always results in a declaration
                  * in the current scope
                  */
-                return declareTag();
+                return declareTag(null);
             }
         }
 
@@ -2877,7 +2878,7 @@ final class CParser(AST) : Parser!AST
             /* `struct tag { ... };` always results in a declaration
              * in the current scope
              */
-            return declareTag();
+            return declareTag(members);
         }
         /* Need semantic information to determine if this is a declaration,
          * redeclaration, or reference to existing declaration.

--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -147,3 +147,9 @@ struct S21973
         int nested;
     };
 };
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=21982
+
+struct S21982 { int field; };
+struct S21982 test21982;


### PR DESCRIPTION
PR #12594 introduced a regression that meant that struct definitions "lost" their members.

See https://github.com/dlang/dmd/pull/12594/files#diff-2fc171ca9f600bfba68ca8a62af0d4ec031d09cf65b9649900cca773379def6fL2843-R2860 for the introducing line.

~Not immediately sure how to write a test for this, as the issue is reproducible with the existing cstuff1.c test.  The difference between triggering and not triggering is whether you use dmd to compile the C source file directly.~

Edit: Never-mind, got a test.

@WalterBright 