### PR TITLE
d_do_test: Rerun tests when an output section was updated

### DIFF
--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -1603,15 +1603,16 @@ int tryMain(string[] args)
 
                 auto existingText = input_file.readText;
                 auto updatedText = existingText.replace(ce.expected, ce.actual);
+                const type = ce.fromRun ? `RUN`:  `TEST`;
                 if (existingText != updatedText)
                 {
                     std.file.write(input_file, updatedText);
-                    writefln("\n==> `TEST_OUTPUT` of %s has been updated", input_file);
+                    writefln("\n==> `%s_OUTPUT` of %s has been updated", type, input_file);
                     return Result.returnRerun;
                 }
                 else
                 {
-                    writefln("\nWARNING: %s has multiple `TEST_OUTPUT` blocks and can't be auto-updated", input_file);
+                    writefln("\nWARNING: %s has multiple `%s_OUTPUT` blocks and can't be auto-updated", input_file, type);
                     return Result.return0;
                 }
             }


### PR DESCRIPTION
Running tests with `AUTO_UPDATE=1` will update any `TEST_OUTPUT` and
`RUN_OUTPUT` section that doesn't match the current output.

This can add / remove lines and thus change the line numbers that are
included in the expected output. Rerunning the test allows the test
runner to update modified line numbers in that case.

This behaviour has caused a lot of confusion / frustration for
contributers not aware of this possibility... .