### PR TITLE
Fix issue 21209 - scope attribute inference fails on foreach

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1460,9 +1460,9 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                  */
                 auto id = Identifier.generateId("__r");
                 auto ie = new ExpInitializer(loc, new SliceExp(loc, fs.aggr, null, null));
+                const valueIsRef = cast(bool) ((*fs.parameters)[dim - 1].storageClass & STC.ref_);
                 VarDeclaration tmp;
-                if (fs.aggr.op == TOK.arrayLiteral &&
-                    !((*fs.parameters)[dim - 1].storageClass & STC.ref_))
+                if (fs.aggr.op == TOK.arrayLiteral && !valueIsRef)
                 {
                     auto ale = cast(ArrayLiteralExp)fs.aggr;
                     size_t edim = ale.elements ? ale.elements.dim : 0;
@@ -1479,7 +1479,11 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     tmp = new VarDeclaration(loc, fs.aggr.type, id, ie);
                 }
                 else
+                {
                     tmp = new VarDeclaration(loc, tab.nextOf().arrayOf(), id, ie);
+                    if (!valueIsRef)
+                        tmp.storage_class |= STC.scope_;
+                }
                 tmp.storage_class |= STC.temp;
 
                 Expression tmp_length = new DotIdExp(loc, new VarExp(loc, tmp), Id.length);

--- a/test/compilable/scope.d
+++ b/test/compilable/scope.d
@@ -224,3 +224,32 @@ int*[4] testArray() @safe
 {
     return typeof(return).init;
 }
+
+/************************************/
+
+// https://issues.dlang.org/show_bug.cgi?id=21209
+void testForeach(T)(const(T)[] ts)
+{
+    static int g;
+    g++; // force impure for https://issues.dlang.org/show_bug.cgi?id=20150
+    foreach (c; ts)
+    {
+
+    }
+    foreach_reverse(c0; ts)
+    {
+        foreach(c1; ts)
+        {
+
+        }
+    }
+}
+
+@safe
+void main21209()
+{
+    char[10] cs;
+    float[10] fs;
+    testForeach(cs);
+    testForeach(fs);
+}


### PR DESCRIPTION
Scope inference fails as soon as you do:
```D
auto foo(int[] arr) {
    int[] tmp = arr; // tmp must be marked explicitly `scope`
}
```
A `foreach` on an array gets rewritten to:
```D
int[] __r83 = arr[];
ulong __key84 = 0LU;
for (; __key84 < __r83.length; __key84 += 1LU)
{
	int c = __r83[__key84];
	// body
}
```
This fix explicitly marks the temporary `__r83` `scope`. It can't escape since it's hidden.

This does not fix `foreach` on an AliasSeq (which gets lowered to a special "unrolled" with the same temporary problem). If this fix gets accepted, I'll open a follow-up issue for that case, which is a bit harder since the temporary is not hidden, so you cannot just mark it `scope`.
