### PR TITLE
disallow empty struct-declaration-list

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2886,8 +2886,15 @@ final class CParser(AST) : Parser!AST
             symbols = symbolsSave;
             check(TOK.rightCurly);
 
-            if (tag && (*members).length == 0) // C11 6.7.2.1-2
-                error("empty struct-declarator-list for `%s %s`", Token.toChars(structOrUnion), tag.toChars());
+            if ((*members).length == 0) // C11 6.7.2.1-8
+                /* TODO: not strict enough, should really be contains "no named members",
+                 * not just "no members".
+                 * I.e. an unnamed bit field, _Static_assert, etc, are not named members,
+                 * but will pass this check.
+                 * Be careful to detect named members that come anonymous structs.
+                 * Correctly doing this will likely mean moving it to typesem.d.
+                 */
+                error("empty struct-declaration-list for `%s %s`", Token.toChars(structOrUnion), tag ? tag.toChars() : "Anonymous".ptr);
         }
         else if (!tag)
             error("missing tag `identifier` after `%s`", Token.toChars(structOrUnion));

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -332,7 +332,7 @@ int tests4()
 
 int test5()
 {
-    struct { };
+    struct { int a; };
     struct S
     {
         int a;


### PR DESCRIPTION
@thewilsonator got this right. I misread the C11 spec, conflating `struct-declarator-list` with `struct-declaration-list`