### PR TITLE
Remove unused getcwd import/declaration in dmodule

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -49,14 +49,6 @@ import dmd.target;
 import dmd.utils;
 import dmd.visitor;
 
-version(Windows) {
-    extern (C) char* getcwd(char* buffer, size_t maxlen);
-} else {
-    import core.sys.posix.unistd : getcwd;
-}
-
-/* ===========================  ===================== */
-
 enum package_d  = "package." ~ mars_ext;
 enum package_di = "package." ~ hdr_ext;
 


### PR DESCRIPTION
It was added in https://github.com/dlang/dmd/pull/5959, since then the need has been replaced by `FileName.toAbsolute`.