### PR TITLE
[stable] Avoid deprecations when compiling dmd.root.ctfloat

### DIFF
--- a/src/dmd/root/ctfloat.d
+++ b/src/dmd/root/ctfloat.d
@@ -64,6 +64,7 @@ extern (C++) struct CTFloat
 
     static if (!is(real_t == real))
     {
+        static import dmd.root.longdouble;
         alias sin = dmd.root.longdouble.sinl;
         alias cos = dmd.root.longdouble.cosl;
         alias tan = dmd.root.longdouble.tanl;


### PR DESCRIPTION
With a host compiler based on 2.097+ and `real_t != real`, e.g., LDC on Windows.