### PR TITLE
ImportC C byte promotion behavior

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -3462,7 +3462,7 @@ Expression integralPromotions(Expression e, Scope* sc)
 
 void fix16997(Scope* sc, UnaExp ue)
 {
-    if (global.params.fix16997)
+    if (global.params.fix16997 || sc.flags & SCOPE.Cfile)
         ue.e1 = integralPromotions(ue.e1, sc);          // desired C-like behavor
     else
     {

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -347,6 +347,55 @@ int test5()
 
 /********************************/
 
+int test16997()
+{
+    /* Exhaustively test all signed and unsigned byte promotions for
+     * - + and ~
+     */
+    for (int i = 0; i < 256; ++i)
+    {
+        unsigned char c = (unsigned char)i;
+
+        int i1 = (int) (~c);
+        int i2 = (int) (~(int) c);
+
+        //printf("%d, %d\n", i1, i2);
+        if (i1 != i2) return 0;
+
+        i1 = (int) (+c);
+        i2 = (int) (+(int) c);
+        if (i1 != i2) return 0;
+
+        i1 = (int) (-c);
+        i2 = (int) (-(int) c);
+        if (i1 != i2) return 0;
+    }
+
+    for (int i = 0; i < 256; ++i)
+    {
+        signed char c = (signed char)i;
+
+        int i1 = (int) (~c);
+        int i2 = (int) (~(int) c);
+
+        //printf("%d, %d\n", i1, i2);
+        if (i1 != i2) return 0;
+
+        i1 = (int) (+c);
+        i2 = (int) (+(int) c);
+        if (i1 != i2) return 0;
+
+        i1 = (int) (-c);
+        i2 = (int) (-(int) c);
+        if (i1 != i2) return 0;
+    }
+    return 1;
+}
+
+_Static_assert(test16997(), "in");
+
+/********************************/
+
 int printf(const char*, ...);
 
 int main()


### PR DESCRIPTION
This bug was fixed in DMD, but remains behind a preview switch. It's C integral promotion behavior, so force it on for compiling C code.

The test case is adapted from the same test in https://github.com/dlang/dmd/blob/master/test/runnable/mars1.d#L1605