### PR TITLE
Fix issue 17041 - foreach ref fails with static array in sequence

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -856,7 +856,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     Dsymbol ds = null;
                     if (!(storageClass & STC.manifest))
                     {
-                        if ((isStatic || tb.ty == Tfunction || tb.ty == Tsarray || storageClass&STC.alias_) && e.op == TOK.variable)
+                        if ((isStatic || tb.ty == Tfunction || storageClass&STC.alias_) && e.op == TOK.variable)
                             ds = (cast(VarExp)e).var;
                         else if (e.op == TOK.template_)
                             ds = (cast(TemplateExp)e).td;

--- a/test/runnable/foreach5.d
+++ b/test/runnable/foreach5.d
@@ -1141,6 +1141,41 @@ void test15777()
 }
 
 /***************************************/
+// https://issues.dlang.org/show_bug.cgi?id=17041
+
+auto ref int[2] foo17041(A...)(auto ref A args)
+{
+    foreach(a; args)
+    {
+        a = [12, 22];
+    }
+    foreach(ref a; args)
+    {
+        a = [31, 41];
+        return args[0];
+    }
+}
+
+void test17041()
+{
+    int[2] x = [10, 20];
+    foreach(a; AliasSeq!(x))
+    {
+        a = [11, 21];
+    }
+    assert(x == [10, 20]); // test by value
+    foreach(ref a; AliasSeq!(x))
+    {
+        a = [30, 40];
+    }
+    assert(x == [30, 40]); // test by ref value
+
+    assert(foo17041(x) == [31, 41]); // test lvalue
+    assert(x == [31, 41]);
+    assert(foo17041(cast(int[2]) [10, 20]) == [31, 41]); // test rvalue
+}
+
+/***************************************/
 
 int main()
 {
@@ -1168,10 +1203,10 @@ int main()
     test11291();
     test12103();
     test12739();
-    printf("test12932()\n");
     test12932();
     test13756();
     test14653();
+    test17041();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
I have no idea why it was decided to treat a static array like an `alias` symbol instead of a variable in unrolled loops. It dates back all the way to [dmd 2.007](https://github.com/dlang/dmd/commit/cd9ae56c0ddbfbb4213786603bc9d9be6b4b4c3c#diff-42906a7b8f790d4d3298be2abfa1218c04bd725743d256e77e6ea245e82a2a96R1188)!! I looked at the [changelog](https://dlang.org/changelog/2.007.html) but couldn't find a bug or enhancement that looked like it needed the change.
Here's an attempt to change it back.