### PR TITLE
Fix 21993 - Implement cast(noreturn)

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2565,6 +2565,23 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
         }
     }
 
+    // Casting to noreturn isn't an actual cast
+    // Rewrite cast(<qual> noreturn) <exp>
+    // as      <exp>, assert(false)
+    if (t.isTypeNoreturn())
+    {
+        // Don't generate an unreachable assert(false) if e will abort
+        if (e.type.isTypeNoreturn())
+        {
+            // Paint e to accomodate for different type qualifiers
+            e.type = t;
+            return e;
+        }
+
+        auto ini = t.defaultInitLiteral(e.loc);
+        return Expression.combine(e, ini);
+    }
+
     scope CastTo v = new CastTo(sc, t);
     e.accept(v);
     return v.result;

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -4545,7 +4545,7 @@ Expression defaultInit(Type mt, const ref Loc loc)
             printf("TypeNoreturn::defaultInit() '%s'\n", mt.toChars());
         }
         auto cond = IntegerExp.createBool(false);
-        auto msg = new StringExp(loc, "Accessed variable of type `noreturn`!");
+        auto msg = new StringExp(loc, "Accessed expression of type `noreturn`");
         auto ae = new AssertExp(loc, cond, msg);
         ae.type = mt;
         return ae;

--- a/test/compilable/noreturn3.d
+++ b/test/compilable/noreturn3.d
@@ -26,3 +26,19 @@ void overloads()
 
     foo(bar());
 }
+
+void inference()
+{
+    auto inf = cast(noreturn) 1;
+    static assert(is(typeof(inf) == noreturn));
+
+    noreturn n;
+    auto c = cast(const shared noreturn) n;
+    static assert(is(typeof(c) == const shared noreturn));
+    static assert(is(typeof(n) == noreturn));
+
+    auto c2 = cast(immutable noreturn) n;
+    static assert(is(typeof(c) == const shared noreturn));
+    static assert(is(typeof(c2) == immutable noreturn));
+    static assert(is(typeof(n) == noreturn));
+}

--- a/test/fail_compilation/noreturn.d
+++ b/test/fail_compilation/noreturn.d
@@ -3,13 +3,19 @@ REQUIRED_ARGS: -w -o-
 
 TEST_OUTPUT:
 ---
-fail_compilation\noreturn.d(32): Error: `"Accessed variable of type `noreturn`!"`
-fail_compilation\noreturn.d(36):        called from here: `assign()`
-fail_compilation\noreturn.d(43): Error: `"Accessed variable of type `noreturn`!"`
-fail_compilation\noreturn.d(43):        called from here: `foo(n)`
-fail_compilation\noreturn.d(47):        called from here: `calling()`
-fail_compilation\noreturn.d(53): Error: `"Accessed variable of type `noreturn`!"`
-fail_compilation\noreturn.d(56):        called from here: `nested()`
+fail_compilation\noreturn.d(38): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(42):        called from here: `assign()`
+fail_compilation\noreturn.d(49): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(49):        called from here: `foo(n)`
+fail_compilation\noreturn.d(53):        called from here: `calling()`
+fail_compilation\noreturn.d(59): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(62):        called from here: `nested()`
+fail_compilation\noreturn.d(68): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(78):        called from here: `casting(0)`
+fail_compilation\noreturn.d(69): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(79):        called from here: `casting(1)`
+fail_compilation\noreturn.d(72): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(80):        called from here: `casting(2)`
 ---
 
 https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md
@@ -54,6 +60,24 @@ int nested()
 }
 
 enum forceNested = nested();
+
+noreturn casting(int i)
+{
+    final switch (i)
+    {
+        case 0: return cast(noreturn) i;
+        case 1: return cast(typeof(assert(0))) cast(double) i;
+        case 2, 3: {
+            noreturn n;
+            return cast() n;
+        }
+    }
+
+}
+
+enum forceCasting0 = casting(0);
+enum forceCasting1 = casting(1);
+enum forceCasting2 = casting(2);
 
 /*
 struct HasNoreturnStruct


### PR DESCRIPTION
Rewrite `cast(<qual> noreturn) <exp>` as `<exp>, assert(false)`.

DIP:
> Every type is allowed to be explicitly cast to noreturn. (Not to be
> confused with noreturn implicitly casting to every type.) It generates
> an assert(0):