### PR TITLE
ImportC: character constants

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -186,9 +186,6 @@ final class CParser(AST) : Parser!AST
         case TOK.imaginary32Literal:
         case TOK.imaginary64Literal:
         case TOK.imaginary80Literal:
-        case TOK.charLiteral:
-        case TOK.wcharLiteral:
-        case TOK.dcharLiteral:
         case TOK.leftParenthesis:
         case TOK.mul:
         case TOK.min:
@@ -648,16 +645,6 @@ final class CParser(AST) : Parser!AST
 
         case TOK.imaginary80Literal:
             e = new AST.RealExp(loc, token.floatvalue, AST.Type.timaginary80);
-            nextToken();
-            break;
-
-        case TOK.charLiteral:
-            e = new AST.IntegerExp(loc, token.unsvalue, AST.Type.tchar);
-            nextToken();
-            break;
-
-        case TOK.wchar_tLiteral:
-            e = new AST.IntegerExp(loc, token.unsvalue, AST.Type.twchar); // correct to twchar_t in semantic()
             nextToken();
             break;
 

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -188,6 +188,23 @@ void tokens()
 
 /********************************/
 
+// Character literals
+_Static_assert(sizeof('a') == 4, "ok");
+_Static_assert(sizeof(u'a') == 4, "ok");
+_Static_assert(sizeof(U'a') == 4, "ok");
+_Static_assert('a' == 0x61, "ok");
+_Static_assert('ab' == 0x6162, "ok");
+_Static_assert('abc' == 0x616263, "ok");
+_Static_assert('abcd' == 0x61626364, "ok");
+_Static_assert(u'a' == 0x61, "ok");
+_Static_assert(u'ab' == 0x610062, "ok");
+_Static_assert(U'a' == 0x61, "ok");
+_Static_assert(u'\u1234' == 0x1234, "ok");
+_Static_assert(U'\U00011234' == 0x11234, "ok");
+_Static_assert(L'\u1234' == 0x1234, "ok");
+
+/********************************/
+
 void test__func__()
 {
     _Static_assert((sizeof __func__) == 13, "ok");


### PR DESCRIPTION
They're subtly different from D character constants. For example, they are always of type `int`, and more than one can be fit into the `int`. This means that escapeStringConstant() can do most of the work.