### PR TITLE
fix Issue 21994 (char*)expression fails to compile

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -3337,7 +3337,10 @@ final class CParser(AST) : Parser!AST
             t = peek(t);
         }
         else
+        {
+            pt = t;
             return true;        // declarator is optional
+        }
 
         if (t.value == TOK.leftBracket)
         {
@@ -3401,6 +3404,7 @@ final class CParser(AST) : Parser!AST
     private bool isTypeName(ref Token* pt)
     {
         auto t = pt;
+        //printf("isTypeName() %s\n", t.toChars());
         if (!isSpecifierQualifierList(t))
             return false;
         if (!isCDeclarator(t, true))

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -307,6 +307,7 @@ void test4(int i)
 
 void parenExp(int a, int b)
 {
+    char* q = (char*)"hello";
     if (!(a == b))
         a = b;
     if ((int)3 == 3);


### PR DESCRIPTION
Forgot to advance the lookahead pointer.