### PR TITLE
Refactor expressionsem using debug condition

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -77,7 +77,7 @@ import dmd.utf;
 import dmd.utils;
 import dmd.visitor;
 
-
+// debug = LOGSEMANTIC;
 /********************************************************
  * Perform semantic analysis and CTFE on expressions to produce
  * a string.

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -77,7 +77,6 @@ import dmd.utf;
 import dmd.utils;
 import dmd.visitor;
 
-enum LOGSEMANTIC = false;
 
 /********************************************************
  * Perform semantic analysis and CTFE on expressions to produce
@@ -724,7 +723,10 @@ private Expression resolveUFCSProperties(Scope* sc, Expression e1, Expression e2
  */
 Expression resolvePropertiesOnly(Scope* sc, Expression e1)
 {
-    //printf("e1 = %s %s\n", Token::toChars(e1.op), e1.toChars());
+    debug (LOGSEMANTIC)
+    {
+      printf("e1 = %s %s\n", Token.toChars(e1.op), e1.toChars());
+    }
 
     Expression handleOverloadSet(OverloadSet os)
     {
@@ -823,7 +825,7 @@ Expression resolvePropertiesOnly(Scope* sc, Expression e1)
  */
 Expression symbolToExp(Dsymbol s, const ref Loc loc, Scope *sc, bool hasOverloads)
 {
-    static if (LOGSEMANTIC)
+    debug (LOGSEMANTIC)
     {
         printf("DsymbolExp::resolve(%s %s)\n", s.kind(), s.toChars());
     }
@@ -2557,7 +2559,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
      */
     override void visit(Expression e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("Expression::semantic() %s\n", e.toChars());
         }
@@ -2599,7 +2601,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(IdentifierExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("IdentifierExp::semantic('%s')\n", exp.ident.toChars());
         }
@@ -2819,7 +2821,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(ThisExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("ThisExp::semantic()\n");
         }
@@ -2886,7 +2888,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(SuperExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("SuperExp::semantic('%s')\n", e.toChars());
         }
@@ -2966,7 +2968,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(NullExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("NullExp::semantic('%s')\n", e.toChars());
         }
@@ -2982,7 +2984,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(StringExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("StringExp::semantic() %s\n", e.toChars());
         }
@@ -3058,7 +3060,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(TupleExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("+TupleExp::semantic(%s)\n", exp.toChars());
         }
@@ -3100,7 +3102,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(ArrayLiteralExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("ArrayLiteralExp::semantic('%s')\n", e.toChars());
         }
@@ -3147,7 +3149,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(AssocArrayLiteralExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("AssocArrayLiteralExp::semantic('%s')\n", e.toChars());
         }
@@ -3193,7 +3195,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(StructLiteralExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("StructLiteralExp::semantic('%s')\n", e.toChars());
         }
@@ -3285,7 +3287,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(ScopeExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("+ScopeExp::semantic(%p '%s')\n", exp, exp.toChars());
         }
@@ -3430,7 +3432,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(NewExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("NewExp::semantic() %s\n", exp.toChars());
             if (exp.thisexp)
@@ -3914,7 +3916,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(NewAnonClassExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("NewAnonClassExp::semantic() %s\n", e.toChars());
             //printf("thisexp = %p\n", thisexp);
@@ -3943,7 +3945,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(SymOffExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("SymOffExp::semantic('%s')\n", e.toChars());
         }
@@ -3967,7 +3969,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(VarExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("VarExp::semantic(%s)\n", e.toChars());
         }
@@ -4028,7 +4030,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(FuncExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("FuncExp::semantic(%s)\n", exp.toChars());
             if (exp.fd.treq)
@@ -4219,7 +4221,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(CallExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("CallExp::semantic() %s\n", exp.toChars());
         }
@@ -5172,7 +5174,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = e;
             return;
         }
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("DeclarationExp::semantic() %s\n", e.toChars());
         }
@@ -5308,7 +5310,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(TypeidExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("TypeidExp::semantic() %s\n", exp.toChars());
         }
@@ -5395,7 +5397,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(HaltExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("HaltExp::semantic()\n");
         }
@@ -5449,7 +5451,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             //printf("no\n");
         }
 
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("IsExp::semantic(%s)\n", e.toChars());
         }
@@ -5917,7 +5919,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         /* https://dlang.org/spec/expression.html#mixin_expressions
          */
 
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("MixinExp::semantic('%s')\n", exp.toChars());
         }
@@ -5930,7 +5932,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(ImportExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("ImportExp::semantic('%s')\n", e.toChars());
         }
@@ -6037,7 +6039,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     override void visit(AssertExp exp)
     {
         // https://dlang.org/spec/expression.html#assert_expressions
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("AssertExp::semantic('%s')\n", exp.toChars());
         }
@@ -6351,7 +6353,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DotIdExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("DotIdExp::semantic(this = %p, '%s')\n", exp, exp.toChars());
             //printf("e1.op = %d, '%s'\n", e1.op, Token::toChars(e1.op));
@@ -6400,7 +6402,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DotVarExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("DotVarExp::semantic('%s')\n", exp.toChars());
         }
@@ -6558,7 +6560,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DotTemplateInstanceExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("DotTemplateInstanceExp::semantic('%s')\n", exp.toChars());
         }
@@ -6571,7 +6573,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DelegateExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("DelegateExp::semantic('%s')\n", e.toChars());
         }
@@ -6651,7 +6653,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DotTypeExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("DotTypeExp::semantic('%s')\n", exp.toChars());
         }
@@ -6673,7 +6675,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(AddrExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("AddrExp::semantic('%s')\n", exp.toChars());
         }
@@ -6965,7 +6967,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(PtrExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("PtrExp::semantic('%s')\n", exp.toChars());
         }
@@ -7018,7 +7020,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(NegExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("NegExp::semantic('%s')\n", exp.toChars());
         }
@@ -7064,7 +7066,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(UAddExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("UAddExp::semantic('%s')\n", exp.toChars());
         }
@@ -7275,7 +7277,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(CastExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("CastExp::semantic('%s')\n", exp.toChars());
         }
@@ -7490,7 +7492,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(VectorExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("VectorExp::semantic('%s')\n", exp.toChars());
         }
@@ -7541,7 +7543,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(VectorArrayExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("VectorArrayExp::semantic('%s')\n", e.toChars());
         }
@@ -7563,7 +7565,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(SliceExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("SliceExp::semantic('%s')\n", exp.toChars());
         }
@@ -7855,7 +7857,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(ArrayLengthExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("ArrayLengthExp::semantic('%s')\n", e.toChars());
         }
@@ -7878,7 +7880,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(ArrayExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("ArrayExp::semantic('%s')\n", exp.toChars());
         }
@@ -7904,7 +7906,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DotExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("DotExp::semantic('%s')\n", exp.toChars());
             if (exp.type)
@@ -7970,7 +7972,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(IntervalExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("IntervalExp::semantic('%s')\n", e.toChars());
         }
@@ -8008,7 +8010,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DelegatePtrExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("DelegatePtrExp::semantic('%s')\n", e.toChars());
         }
@@ -8029,7 +8031,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DelegateFuncptrExp e)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("DelegateFuncptrExp::semantic('%s')\n", e.toChars());
         }
@@ -8049,7 +8051,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(IndexExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("IndexExp::semantic('%s')\n", exp.toChars());
         }
@@ -8258,7 +8260,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(PostExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("PostExp::semantic('%s')\n", exp.toChars());
         }
@@ -8412,7 +8414,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(AssignExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("AssignExp::semantic('%s')\n", exp.toChars());
         }
@@ -9851,7 +9853,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(AddExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("AddExp::semantic('%s')\n", exp.toChars());
         }
@@ -9952,7 +9954,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(MinExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("MinExp::semantic('%s')\n", exp.toChars());
         }
@@ -10910,7 +10912,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(LogicalExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("LogicalExp::semantic() %s\n", exp.toChars());
         }
@@ -10994,7 +10996,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(CmpExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("CmpExp::semantic('%s')\n", exp.toChars());
         }
@@ -11450,7 +11452,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(CondExp exp)
     {
-        static if (LOGSEMANTIC)
+        debug (LOGSEMANTIC)
         {
             printf("CondExp::semantic('%s')\n", exp.toChars());
         }
@@ -11661,7 +11663,7 @@ Expression trySemantic(Expression exp, Scope* sc)
  */
 Expression unaSemantic(UnaExp e, Scope* sc)
 {
-    static if (LOGSEMANTIC)
+    debug (LOGSEMANTIC)
     {
         printf("UnaExp::semantic('%s')\n", e.toChars());
     }
@@ -11678,7 +11680,7 @@ Expression unaSemantic(UnaExp e, Scope* sc)
  */
 Expression binSemantic(BinExp e, Scope* sc)
 {
-    static if (LOGSEMANTIC)
+    debug (LOGSEMANTIC)
     {
         printf("BinExp::semantic('%s')\n", e.toChars());
     }
@@ -12132,7 +12134,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
 // If flag == 1, stop "not a property" error and return NULL.
 Expression semanticY(DotTemplateInstanceExp exp, Scope* sc, int flag)
 {
-    static if (LOGSEMANTIC)
+    debug (LOGSEMANTIC)
     {
         printf("DotTemplateInstanceExpY::semantic('%s')\n", exp.toChars());
     }


### PR DESCRIPTION
First step of implementing a log audit for dmd.
https://github.com/dlang/projects/issues/79

Rational: You should not have to modify the code in order to enable logging to see what is going on behind the scene when working in dmd. The logging system needs to be triggered by a compiler command when compiling dmd. The current logging  code itself is inconstant as some of them rely on using ```version(none)``` while others are just marked as ```//printf```. Using the debug condition allows this to be triggered by a compiler command. Which then can be documented and easy to use.

The first step is to wrap the printf statements in a debug condition statement. Then replace the printf statements with the log function that allows you to select the type of information that you would like to see by using the compiler flags that are created by the debug condition.

cc @RazvanN7 