### PR TITLE
ImportC: string literals are typed as pointers

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2083,7 +2083,7 @@ final class CParser(AST) : Parser!AST
             case TKW.xshort | TKW.xint:         t = AST.Type.tint16; break;
 
             case TKW.xunsigned | TKW.xshort | TKW.xint:
-            case TKW.xunsigned | TKW.xshort:    t = AST.Type.tint16; break;
+            case TKW.xunsigned | TKW.xshort:    t = AST.Type.tuns16; break;
 
             case TKW.xint:
             case TKW.xsigned:
@@ -3704,6 +3704,8 @@ final class CParser(AST) : Parser!AST
         auto ifn = new AST.ExpInitializer(loc, efn);
         auto lenfn = new AST.IntegerExp(loc, fn.length + 1, AST.Type.tuns32); // +1 for terminating 0
         auto tfn = new AST.TypeSArray(AST.Type.tchar, lenfn);
+        efn.type = tfn.immutableOf();
+        efn.committed = 1;
         auto sfn = new AST.VarDeclaration(loc, tfn, Id.__func__, ifn, STC.gshared | STC.immutable_);
         auto e = new AST.DeclarationExp(loc, sfn);
         return new AST.ExpStatement(loc, e);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3015,7 +3015,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             buffer.write4(0);
             e.setData(buffer.extractData(), newlen, 4);
-            e.type = new TypeDArray(Type.tdchar.immutableOf());
+            if (sc && sc.flags & SCOPE.Cfile)
+                e.type = Type.tuns32.pointerTo();
+            else
+                e.type = Type.tdchar.immutableOf().arrayOf();
             e.committed = 1;
             break;
 
@@ -3037,7 +3040,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             buffer.writeUTF16(0);
             e.setData(buffer.extractData(), newlen, 2);
-            e.type = new TypeDArray(Type.twchar.immutableOf());
+            if (sc && sc.flags & SCOPE.Cfile)
+                e.type = Type.tuns16.pointerTo();
+            else
+                e.type = Type.twchar.immutableOf().arrayOf();
             e.committed = 1;
             break;
 
@@ -3046,7 +3052,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             goto default;
 
         default:
-            e.type = new TypeDArray(Type.tchar.immutableOf());
+            if (sc && sc.flags & SCOPE.Cfile)
+                e.type = Type.tchar.pointerTo();
+            else
+                e.type = Type.tchar.immutableOf().arrayOf();
             break;
         }
         e.type = e.type.typeSemantic(e.loc, sc);

--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -210,6 +210,13 @@ void test__func__()
     _Static_assert((sizeof __func__) == 13, "ok");
 }
 
+void teststringtype()
+{
+    char* p = "hello";
+    unsigned short* up = u"hello";
+    unsigned int* Up = U"hello";
+}
+
 /********************************/
 
 struct SA { int a, b, *const c, d[50]; };


### PR DESCRIPTION
Note that C doesn't actually have wchar_t, char16_t, or char32_t types. They are typedefs for the underlying integer types. String literals are typed as pointers to those (mutable!) types, not character types. (D strings are typed as arrays of immutable characters.)

Sometimes I forget all the little things that D fixed :-)