### PR TITLE
ImportC: recognize {exp} initializers as just exp

### DIFF
--- a/test/compilable/imports/cstuff1.c
+++ b/test/compilable/imports/cstuff1.c
@@ -188,6 +188,18 @@ void tokens()
 
 /********************************/
 
+int testexpinit()
+{
+    int i = 1;
+    int j = { 2 };
+    int k = { 3 , };
+    return i + j + k;
+}
+
+_Static_assert(testexpinit() == 1 + 2 + 3, "ok");
+
+/********************************/
+
 // Character literals
 _Static_assert(sizeof('a') == 4, "ok");
 _Static_assert(sizeof(u'a') == 4, "ok");


### PR DESCRIPTION
Makes for a nice shortcut for a common case. Still need to do general case for initializers.