### PR TITLE
ImportC: parse initializers into CInitializer

### DIFF
--- a/src/dmd/arraytypes.d
+++ b/src/dmd/arraytypes.d
@@ -52,3 +52,6 @@ alias ReturnStatements = Array!(ReturnStatement);
 alias GotoStatements = Array!(GotoStatement);
 alias TemplateInstances = Array!(TemplateInstance);
 alias Ensures = Array!(Ensure);
+alias Designators = Array!(Designator);
+alias DesigInits = Array!(DesigInit);
+

--- a/src/dmd/arraytypes.h
+++ b/src/dmd/arraytypes.h
@@ -63,3 +63,8 @@ typedef Array<class GotoStatement *> GotoStatements;
 typedef Array<class TemplateInstance *> TemplateInstances;
 
 typedef Array<struct Ensure> Ensures;
+
+typedef Array<struct Designator> Designators;
+
+typedef Array<struct DesigInit> DesigInits;
+

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -51,6 +51,8 @@ struct ASTBase
     alias Identifiers           = Array!(Identifier);
     alias Initializers          = Array!(Initializer);
     alias Ensures               = Array!(Ensure);
+    alias Designators           = Array!(Designator);
+    alias DesigInits            = Array!(DesigInit);
 
     enum Sizeok : ubyte
     {
@@ -6507,6 +6509,7 @@ struct ASTBase
         struct_,
         array,
         exp,
+        C_,
     }
 
     extern (C++) class Initializer : ASTNode
@@ -6606,6 +6609,36 @@ struct ASTBase
         extern (D) this(const ref Loc loc)
         {
             super(loc, InitKind.void_);
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    struct Designator
+    {
+        Expression exp;         /// [ constant-expression ]
+        Identifier ident;       /// . identifier
+
+        this(Expression exp) { this.exp = exp; }
+        this(Identifier ident) { this.ident = ident; }
+    }
+
+    struct DesigInit
+    {
+        Designators* designatorList; /// designation (opt)
+        Initializer initializer;     /// initializer
+    }
+
+    extern (C++) final class CInitializer : Initializer
+    {
+        DesigInits initializerList; /// initializer-list
+
+        extern (D) this(const ref Loc loc)
+        {
+            super(loc, InitKind.C_);
         }
 
         override void accept(Visitor v)

--- a/src/dmd/astcodegen.d
+++ b/src/dmd/astcodegen.d
@@ -34,6 +34,7 @@ struct ASTCodegen
     public import dmd.staticassert;
     public import dmd.typesem;
     public import dmd.ctfeexpr;
+    public import dmd.init : Designator;
 
 
     alias initializerToExpression   = dmd.initsem.initializerToExpression;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -166,6 +166,8 @@ class GotoCaseStatement;
 class ReturnStatement;
 class GotoStatement;
 struct Ensure;
+struct Designator;
+struct DesigInit;
 enum class LINK : uint8_t
 {
     default_ = 0u,
@@ -789,6 +791,7 @@ class VoidInitializer;
 class StructInitializer;
 class ArrayInitializer;
 class ExpInitializer;
+class CInitializer;
 enum class JsonFieldFlags : uint32_t
 {
     none = 0u,
@@ -1871,6 +1874,10 @@ typedef Array<GotoStatement* > GotoStatements;
 typedef Array<TemplateInstance* > TemplateInstances;
 
 typedef Array<Ensure > Ensures;
+
+typedef Array<Designator > Designators;
+
+typedef Array<DesigInit > DesigInits;
 
 class AttribDeclaration : public Dsymbol
 {
@@ -4932,6 +4939,7 @@ enum class InitKind : uint8_t
     struct_ = 2u,
     array = 3u,
     exp = 4u,
+    C_ = 5u,
 };
 
 class Initializer : public ASTNode
@@ -4945,6 +4953,7 @@ public:
     StructInitializer* isStructInitializer();
     ArrayInitializer* isArrayInitializer();
     ExpInitializer* isExpInitializer();
+    CInitializer* isCInitializer();
     void accept(Visitor* v);
 };
 
@@ -4989,6 +4998,14 @@ public:
     bool expandTuples;
     Expression* exp;
     void accept(Visitor* v);
+};
+
+class CInitializer final : public Initializer
+{
+public:
+    Array<DesigInit > initializerList;
+    void accept(Visitor* v);
+    ~CInitializer();
 };
 
 extern Initializer* initializerSemantic(Initializer* init, Scope* sc, Type* t, NeedInterpret needInterpret);
@@ -5907,6 +5924,7 @@ public:
     virtual void visit(typename AST::StructInitializer i);
     virtual void visit(typename AST::ArrayInitializer i);
     virtual void visit(typename AST::VoidInitializer i);
+    virtual void visit(typename AST::CInitializer i);
 };
 
 template <typename AST>
@@ -6830,6 +6848,7 @@ public:
     void visit(StructInitializer* si);
     void visit(ArrayInitializer* ai);
     void visit(ExpInitializer* ei);
+    void visit(CInitializer* ci);
     void visit(ArrayLiteralExp* e);
     void visit(AssocArrayLiteralExp* e);
     void visit(TypeExp* e);

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3609,6 +3609,11 @@ private void initializerToBuffer(Initializer inx, OutBuffer* buf, HdrGenState* h
         ei.exp.expressionToBuffer(buf, hgs);
     }
 
+    void visitC(CInitializer ci)
+    {
+        buf.writestring("hdrgen C initializers TODO");
+    }
+
     final switch (inx.kind)
     {
         case InitKind.error:   return visitError (inx.isErrorInitializer ());
@@ -3616,6 +3621,7 @@ private void initializerToBuffer(Initializer inx, OutBuffer* buf, HdrGenState* h
         case InitKind.struct_: return visitStruct(inx.isStructInitializer());
         case InitKind.array:   return visitArray (inx.isArrayInitializer ());
         case InitKind.exp:     return visitExp   (inx.isExpInitializer   ());
+        case InitKind.C_:      return visitC     (inx.isCInitializer     ());
     }
 }
 

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -23,6 +23,7 @@ class VoidInitializer;
 class StructInitializer;
 class ArrayInitializer;
 class ExpInitializer;
+class CInitializer;
 
 enum NeedInterpret { INITnointerpret, INITinterpret };
 
@@ -39,6 +40,7 @@ public:
     StructInitializer  *isStructInitializer();
     ArrayInitializer   *isArrayInitializer();
     ExpInitializer     *isExpInitializer();
+    CInitializer       *isCInitializer();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -86,6 +88,26 @@ class ExpInitializer : public Initializer
 public:
     bool expandTuples;
     Expression *exp;
+
+    void accept(Visitor *v) { v->visit(this); }
+};
+
+struct Designator
+{
+    Expression *exp;
+    Identifier *ident;
+};
+
+struct DesigInit
+{
+    Designators *designatorList;
+    Initializer *initializer;
+};
+
+class CInitializer : public Initializer
+{
+public:
+    DesigInits initializerList;
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -544,6 +544,13 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
         return i;
     }
 
+    Initializer visitC(CInitializer i)
+    {
+        //printf("CInitializer::semantic()\n");
+        error(i.loc, "C initializers not supported yet");
+        return new ErrorInitializer();
+    }
+
     final switch (init.kind)
     {
         case InitKind.void_:   return visitVoid  (cast(  VoidInitializer)init);
@@ -551,6 +558,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
         case InitKind.struct_: return visitStruct(cast(StructInitializer)init);
         case InitKind.array:   return visitArray (cast( ArrayInitializer)init);
         case InitKind.exp:     return visitExp   (cast(   ExpInitializer)init);
+        case InitKind.C_:      return visitC     (cast(     CInitializer)init);
     }
 }
 
@@ -702,6 +710,13 @@ Initializer inferType(Initializer init, Scope* sc)
         return init;
     }
 
+    Initializer visitC(CInitializer i)
+    {
+        //printf(CInitializer::inferType()\n");
+        error(i.loc, "TODO C inferType initializers not supported yet");
+        return new ErrorInitializer();
+    }
+
     final switch (init.kind)
     {
         case InitKind.void_:   return visitVoid  (cast(  VoidInitializer)init);
@@ -709,6 +724,7 @@ Initializer inferType(Initializer init, Scope* sc)
         case InitKind.struct_: return visitStruct(cast(StructInitializer)init);
         case InitKind.array:   return visitArray (cast( ArrayInitializer)init);
         case InitKind.exp:     return visitExp   (cast(   ExpInitializer)init);
+        case InitKind.C_:      return visitC     (cast(     CInitializer)init);
     }
 }
 
@@ -900,6 +916,11 @@ extern (C++) Expression initializerToExpression(Initializer init, Type itype = n
         return i.exp;
     }
 
+    Expression visitC(CInitializer i)
+    {
+        //printf("CInitializer.initializerToExpression()\n");
+        return null;
+    }
 
     final switch (init.kind)
     {
@@ -908,6 +929,7 @@ extern (C++) Expression initializerToExpression(Initializer init, Type itype = n
         case InitKind.struct_: return visitStruct(cast(StructInitializer)init);
         case InitKind.array:   return visitArray (cast( ArrayInitializer)init);
         case InitKind.exp:     return visitExp   (cast(   ExpInitializer)init);
+        case InitKind.C_:      return visitC     (cast(     CInitializer)init);
     }
 }
 

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -291,4 +291,5 @@ public:
     void visit(AST.StructInitializer i) { visit(cast(AST.Initializer)i); }
     void visit(AST.ArrayInitializer i) { visit(cast(AST.Initializer)i); }
     void visit(AST.VoidInitializer i) { visit(cast(AST.Initializer)i); }
+    void visit(AST.CInitializer i) { visit(cast(AST.CInitializer)i); }
 }

--- a/src/dmd/strictvisitor.d
+++ b/src/dmd/strictvisitor.d
@@ -230,4 +230,5 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.StructInitializer) { assert(0); }
     override void visit(AST.ArrayInitializer) { assert(0); }
     override void visit(AST.VoidInitializer) { assert(0); }
+    override void visit(AST.CInitializer) { assert(0); }
 }

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -204,6 +204,7 @@ extern (C++) void Initializer_toDt(Initializer init, ref DtBuilder dtb)
         case InitKind.struct_: return visitStruct(cast(StructInitializer)init);
         case InitKind.array:   return visitArray (cast( ArrayInitializer)init);
         case InitKind.exp:     return visitExp   (cast(   ExpInitializer)init);
+        case InitKind.C_:      assert(0);
     }
 }
 

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -894,6 +894,20 @@ package mixin template ParseVisitMethods(AST)
         ei.exp.accept(this);
     }
 
+    override void visit(AST.CInitializer ci)
+    {
+        //printf("Visiting CInitializer\n");
+        foreach (di; ci.initializerList)
+        {
+            foreach (des; (*di.designatorList)[])
+            {
+                if (des.exp)
+                    des.exp.accept(this);
+            }
+            di.initializer.accept(this);
+        }
+    }
+
 //      Expressions
 //===================================================
 

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -178,6 +178,7 @@ class ErrorInitializer;
 class StructInitializer;
 class ArrayInitializer;
 class ExpInitializer;
+class CInitializer;
 
 class Expression;
 class IntegerExp;
@@ -575,6 +576,7 @@ public:
     virtual void visit(StructInitializer *i) { visit((Initializer *)i); }
     virtual void visit(ArrayInitializer *i) { visit((Initializer *)i); }
     virtual void visit(VoidInitializer *i) { visit((Initializer *)i); }
+    virtual void visit(CInitializer *i) { visit((Initializer *)i); }
 };
 
 class Visitor : public ParseTimeVisitor


### PR DESCRIPTION
Instead of just parsing initializers, now the data structure `CInitializer` is created and populated with the initializer data.

Nothing further is done with it.