### PR TITLE
ImportC: add pretty-printing of C initializers

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1824,9 +1824,11 @@ final class CParser(AST) : Parser!AST
                     nextToken();
                 }
                 else
+                {
+                    if (desigInit.designatorList)
+                        check(TOK.assign);
                     break;
-
-                check(TOK.assign);
+                }
             }
 
             desigInit.initializer = cparseInitializer();
@@ -1858,6 +1860,7 @@ final class CParser(AST) : Parser!AST
             break;
         }
         check(TOK.rightCurly);
+        //printf("ci: %s\n", ci.toChars());
         return ci;
     }
 

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3611,7 +3611,32 @@ private void initializerToBuffer(Initializer inx, OutBuffer* buf, HdrGenState* h
 
     void visitC(CInitializer ci)
     {
-        buf.writestring("hdrgen C initializers TODO");
+        buf.writeByte('{');
+        foreach (i, ref DesigInit di; ci.initializerList)
+        {
+            if (i)
+                buf.writestring(", ");
+            if (di.designatorList)
+            {
+                foreach (ref Designator d; (*di.designatorList)[])
+                {
+                    if (d.exp)
+                    {
+                        buf.writeByte('[');
+                        toCBuffer(d.exp, buf, hgs);
+                        buf.writeByte(']');
+                    }
+                    else
+                    {
+                        buf.writeByte('.');
+                        buf.writestring(d.ident.toString());
+                    }
+                }
+                buf.writeByte('=');
+            }
+            initializerToBuffer(di.initializer, buf, hgs);
+        }
+        buf.writeByte('}');
     }
 
     final switch (inx.kind)


### PR DESCRIPTION
Pretty simple, just walk the data structure and format it.

As a result, found/fixed an initializer parse error in cparse.d