### PR TITLE
[dmd-cxx] T.alignof: Respect explicit align(N) type alignment

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2040,7 +2040,10 @@ Expression *Type::getProperty(Loc loc, Identifier *ident, int flag)
     }
     else if (ident == Id::__xalignof)
     {
-        e = new IntegerExp(loc, alignsize(), Type::tsize_t);
+        unsigned explicitAlignment = alignment();
+        unsigned naturalAlignment = alignsize();
+        unsigned actualAlignment = (explicitAlignment == STRUCTALIGN_DEFAULT ? naturalAlignment : explicitAlignment);
+        e = new IntegerExp(loc, actualAlignment, Type::tsize_t);
     }
     else if (ident == Id::_init)
     {

--- a/test/compilable/aggr_alignment.d
+++ b/test/compilable/aggr_alignment.d
@@ -27,6 +27,26 @@ static assert(C2.int1.offsetof == payloadOffset + 8);
 static assert(C2.alignof == size_t.sizeof);
 static assert(__traits(classInstanceSize, C2) == payloadOffset + 12);
 
+align(8) struct PaddedStruct
+{
+    bool flag;
+    align(2) S1 s1;
+}
+
+static assert(PaddedStruct.s1.offsetof == 2);
+static assert(PaddedStruct.alignof == 8);
+static assert(PaddedStruct.sizeof == 16);
+
+align(1) struct UglyStruct
+{
+    bool flag;
+    int i;
+    ubyte u;
+}
+
+static assert(UglyStruct.i.offsetof == 4);
+static assert(UglyStruct.alignof == 1);
+static assert(UglyStruct.sizeof == 9);
 
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=19914


### PR DESCRIPTION
It was previously the natural type alignment, defined as the maximum of the field alignments for an aggregate. Make sure an explicit `align(N)` overrides it.

fix Issue 17857