### PR TITLE
Fix Issue 21978 - Error: CTFE internal error: painting  / array of pointers in heap allocated struct not null initialized

### DIFF
--- a/test/compilable/test21978.d
+++ b/test/compilable/test21978.d
@@ -1,0 +1,26 @@
+// https://issues.dlang.org/show_bug.cgi?id=21978
+
+/*
+TEST_OUTPUT:
+---
+&TrieNode([null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null])
+----
+*/
+
+struct TrieNode
+{
+    TrieNode*[256] childs;
+    void insert()
+    {
+        if (childs[0] is null) {}
+    }
+}
+
+TrieNode* build_trie()
+{
+    TrieNode* t = new TrieNode(null);
+    t.insert();
+    return t;
+}
+
+pragma(msg, build_trie());


### PR DESCRIPTION
```d
struct TrieNode {
  TrieNode*[256] childs;
  void insert() {
    if (childs[0] is null) {}
  }
}
TrieNode* build_trie() {
  TrieNode* t = new TrieNode();   // problem line
  t.insert();
  return t;
}
pragma(msg, build_trie());
```

The "problem line" is rewritten to `new TrieNode(null)` instead of `new TrieNode([null, null, ... , null])`. I fixed it by adding the code to ctfe allocate a static array initialized with null pointers.