### PR TITLE
[dmd-cxx] Fix Issue 19234 - betterC TypeInfo error when using slice copy on Structs

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1044,8 +1044,11 @@ bool Expression::checkPostblit(Scope *sc, Type *t)
     t = t->baseElemOf();
     if (t->ty == Tstruct)
     {
-        // Bugzilla 11395: Require TypeInfo generation for array concatenation
-        semanticTypeInfo(sc, t);
+        if (global.params.useTypeInfo)
+        {
+            // Bugzilla 11395: Require TypeInfo generation for array concatenation
+            semanticTypeInfo(sc, t);
+        }
 
         StructDeclaration *sd = ((TypeStruct *)t)->sym;
         if (sd->postblit)

--- a/test/compilable/betterCarray.d
+++ b/test/compilable/betterCarray.d
@@ -15,3 +15,13 @@ int foo(int[] a, int i)
 {
     return a[i];
 }
+
+/**********************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19234
+void issue19234()
+{
+    static struct A {}
+    A[10] a;
+    A[10] b;
+    b[] = a[];
+}


### PR DESCRIPTION
Known limitation: does not work for struct with postblit or dtor.