### PR TITLE
Extend Issue 19234 - betterC TypeInfo error when using slice copy on Structs

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1457,7 +1457,7 @@ extern (C++) abstract class Expression : ASTNode
     {
         if (auto ts = t.baseElemOf().isTypeStruct())
         {
-            if (global.params.useTypeInfo)
+            if (global.params.useTypeInfo && Type.dtypeinfo)
             {
                 // https://issues.dlang.org/show_bug.cgi?id=11395
                 // Require TypeInfo generation for array concatenation

--- a/test/compilable/minimal3.d
+++ b/test/compilable/minimal3.d
@@ -1,0 +1,13 @@
+// DFLAGS:
+// REQUIRED_ARGS: -defaultlib=
+// EXTRA_SOURCES: extra-files/minimal/object.d
+
+/**********************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19234
+void issue19234()
+{
+    static struct A {}
+    A[10] a;
+    A[10] b;
+    b[] = a[];
+}


### PR DESCRIPTION
As with other tests, also allow compilation to succeed when `TypeInfo` is non-existent.