### PR TITLE
fix Issue 22007 - static foreach: cannot implicitly convert expression Tuple4(0LU, 1) of type Tuple4 to int

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -906,9 +906,6 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     else
                     {
                         e = resolveProperties(sc, e);
-                        type = e.type;
-                        if (paramtype)
-                            type = paramtype;
                         Initializer ie = new ExpInitializer(Loc.initial, e);
                         auto v = new VarDeclaration(loc, type, ident, ie, storageClass);
                         if (storageClass & STC.ref_)

--- a/test/compilable/staticforeach.d
+++ b/test/compilable/staticforeach.d
@@ -116,6 +116,7 @@ T
 foo2
 T2
 TestStaticForeach2
+issue22007
 1 2 '3'
 2 3 '4'
 0 1
@@ -868,4 +869,12 @@ static:
     {
         static assert(0);
     }
+}
+
+//https://issues.dlang.org/show_bug.cgi?id=22007
+void issue22007()
+{
+    immutable int[32] array = 1;
+    foreach (size_t a, int b; array) {}
+    static foreach (size_t a, int b; array) { }
 }


### PR DESCRIPTION
Firstly, `paramtype` is the value key type in a (static) `foreach` statement.  In the `static foreach` path, when both the index and value keys are present, `declareVariable` is called three times:
1. To declare a `Tuple(index, value)` variable.
2. To declare the key parameter, initialized with `Tuple(index, value).index`
3. To declare the value parameter, initialized with `Tuple(index, value).value`

Secondly, as per function documentation of this function, the `type` parameter is already initialized:
```
type = The declared type of the variable.
e = The initializer of the variable (i.e. the current element of the looped over aggregate).
```
It makes no sense to ever modify the type parameter then, the initializer is not guaranteed to be the same type as the declared index type (see issue 5435), and setting the type to `paramtype` only works if `declareVariable` is restricted to only single-argument foreach statements (issue 22007).