### PR TITLE
fix Issue 22005 - ICE: Segmentation fault with static foreach and -betterC

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -255,7 +255,8 @@ extern (C++) final class StaticForeach : RootObject
         auto ty = new TypeTypeof(loc, new TupleExp(loc, e));
         sdecl.members.push(new VarDeclaration(loc, ty, fid, null, 0));
         auto r = cast(TypeStruct)sdecl.type;
-        r.vtinfo = TypeInfoStructDeclaration.create(r); // prevent typeinfo from going to object file
+        if (global.params.useTypeInfo && Type.dtypeinfo)
+            r.vtinfo = TypeInfoStructDeclaration.create(r); // prevent typeinfo from going to object file
         return r;
     }
 

--- a/test/compilable/minimal3.d
+++ b/test/compilable/minimal3.d
@@ -11,3 +11,13 @@ void issue19234()
     A[10] b;
     b[] = a[];
 }
+
+/**********************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22005
+void issue22005()
+{
+    enum int[4] foo = [1,2,3,4];
+    static foreach (i, e; foo)
+    {
+    }
+}


### PR DESCRIPTION
Don't generate typeinfo if it wasn't requested.