### PR TITLE
test: Add test to ensure static foreach errors about bad input array at the correct location

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 
 jobs:
   - job: Windows_DMD_bootstrap
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
     pool:
       vmImage: 'vs2017-win2016'
     variables:
@@ -24,7 +24,7 @@ jobs:
       - template: .azure-pipelines/windows.yml
 
   - job: Windows_DMD_latest
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
     pool:
       vmImage: 'vs2017-win2016'
     variables:
@@ -45,7 +45,7 @@ jobs:
       - template: .azure-pipelines/windows-artifact.yml
 
   - job: Windows_Coverage
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
     pool:
       vmImage: 'vs2017-win2016'
     variables:
@@ -68,7 +68,7 @@ jobs:
       - template: .azure-pipelines/windows.yml
 
   - job: Windows_VisualD_LDC
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
     pool:
       vmImage: 'vs2017-win2016'
     variables:

--- a/test/fail_compilation/staticforeach4.d
+++ b/test/fail_compilation/staticforeach4.d
@@ -1,0 +1,17 @@
+/*
+REQUIRED_ARGS: -verrors=context
+TEST_OUTPUT:
+---
+fail_compilation/staticforeach4.d(16): Error: index type `byte` cannot cover index range 0..257
+static foreach (byte a, int b; data) { }
+                               ^
+fail_compilation/staticforeach4.d(17): Error: index type `byte` cannot cover index range 0..257
+static foreach (byte a, int b; fn()) { }
+                                 ^
+---
+*/
+immutable int[257] data = 1;
+int[257] fn() { return data; }
+
+static foreach (byte a, int b; data) { }
+static foreach (byte a, int b; fn()) { }


### PR DESCRIPTION
For example:

```
immutable int[257] data = 1;

void test()
{
    static foreach (byte a, int b; data) { }
    static foreach (byte a, int b; data) { }
    static foreach (byte a, int b; data) { }
    static foreach (byte a, int b; data) { }
}
```
Will report a diagnostic about the bad static foreach on the line where `data` is defined.

Haven't got a good test for this, as all the diagnostics that I were able to trigger are themselves compiler bugs.  So apart from a small improvement in stepping through a program in gdb, the benefit won't be seen until the diagnostic bugs are fixed.