### PR TITLE
static foreach: Delay running ctfeInterpret until the lowering stage

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -173,6 +173,7 @@ extern (C++) final class StaticForeach : RootObject
             aggrfe.aggr = new TupleExp(aggr.loc, es);
             aggrfe.aggr = aggrfe.aggr.expressionSemantic(sc);
             aggrfe.aggr = aggrfe.aggr.optimize(WANTvalue);
+            aggrfe.aggr = aggrfe.aggr.ctfeInterpret();
         }
         else
         {
@@ -450,11 +451,6 @@ extern (C++) final class StaticForeach : RootObject
             aggrfe.aggr = aggrfe.aggr.expressionSemantic(sc);
             sc = sc.endCTFE();
             aggrfe.aggr = aggrfe.aggr.optimize(WANTvalue);
-            auto tab = aggrfe.aggr.type.toBasetype();
-            if (tab.ty != Ttuple)
-            {
-                aggrfe.aggr = aggrfe.aggr.ctfeInterpret();
-            }
         }
 
         if (aggrfe && aggrfe.aggr.type.toBasetype().ty == Terror)

--- a/test/compilable/b12504.d
+++ b/test/compilable/b12504.d
@@ -21,4 +21,24 @@ void main()
         foreach (short i; 0 .. sta.length) {}
         foreach (short i, x; sta) {}
     }
+    {
+        immutable int[0xFF + 1] sta;
+        static foreach (ubyte i; 0 .. sta.length) {}
+        static foreach (ubyte i, x; sta) {}
+    }
+    {
+        immutable int[0x7F + 1] sta;
+        static foreach (byte i; 0 .. sta.length) {}
+        static foreach (byte i, x; sta) {}
+    }
+    {
+        immutable int[0xFFFF + 1] sta;
+        static foreach (ushort i; 0 .. sta.length) {}
+        static foreach (ushort i, x; sta) {}
+    }
+    {
+        immutable int[0x7FFF + 1] sta;
+        static foreach (short i; 0 .. sta.length) {}
+        static foreach (short i, x; sta) {}
+    }
 }

--- a/test/fail_compilation/b12504.d
+++ b/test/fail_compilation/b12504.d
@@ -1,14 +1,22 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/b12504.d(18): Error: cannot implicitly convert expression `257$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `ubyte`
-fail_compilation/b12504.d(19): Error: index type `ubyte` cannot cover index range 0..257
-fail_compilation/b12504.d(23): Error: cannot implicitly convert expression `129$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `byte`
-fail_compilation/b12504.d(24): Error: index type `byte` cannot cover index range 0..129
-fail_compilation/b12504.d(28): Error: cannot implicitly convert expression `65537$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `ushort`
-fail_compilation/b12504.d(29): Error: index type `ushort` cannot cover index range 0..65537
-fail_compilation/b12504.d(33): Error: cannot implicitly convert expression `32769$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `short`
-fail_compilation/b12504.d(34): Error: index type `short` cannot cover index range 0..32769
+fail_compilation/b12504.d(26): Error: cannot implicitly convert expression `257$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `ubyte`
+fail_compilation/b12504.d(27): Error: index type `ubyte` cannot cover index range 0..257
+fail_compilation/b12504.d(31): Error: cannot implicitly convert expression `129$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `byte`
+fail_compilation/b12504.d(32): Error: index type `byte` cannot cover index range 0..129
+fail_compilation/b12504.d(36): Error: cannot implicitly convert expression `65537$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `ushort`
+fail_compilation/b12504.d(37): Error: index type `ushort` cannot cover index range 0..65537
+fail_compilation/b12504.d(41): Error: cannot implicitly convert expression `32769$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `short`
+fail_compilation/b12504.d(42): Error: index type `short` cannot cover index range 0..32769
+fail_compilation/b12504.d(46): Error: cannot implicitly convert expression `257$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `ubyte`
+fail_compilation/b12504.d(47): Error: index type `ubyte` cannot cover index range 0..257
+fail_compilation/b12504.d(51): Error: cannot implicitly convert expression `129$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `byte`
+fail_compilation/b12504.d(52): Error: index type `byte` cannot cover index range 0..129
+fail_compilation/b12504.d(56): Error: cannot implicitly convert expression `65537$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `ushort`
+fail_compilation/b12504.d(57): Error: index type `ushort` cannot cover index range 0..65537
+fail_compilation/b12504.d(61): Error: cannot implicitly convert expression `32769$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `short`
+fail_compilation/b12504.d(62): Error: index type `short` cannot cover index range 0..32769
 ---
 */
 void main()
@@ -32,5 +40,25 @@ void main()
         int[0x7FFF + 2] sta;
         foreach (short i; 0 .. sta.length) {}
         foreach (short i, x; sta) {}
+    }
+    {
+        immutable int[0xFF + 2] sta;
+        static foreach (ubyte i; 0 .. sta.length) {}
+        static foreach (ubyte i, x; sta) {}
+    }
+    {
+        immutable int[0x7F + 2] sta;
+        static foreach (byte i; 0 .. sta.length) {}
+        static foreach (byte i, x; sta) {}
+    }
+    {
+        immutable int[0xFFFF + 2] sta;
+        static foreach (ushort i; 0 .. sta.length) {}
+        static foreach (ushort i, x; sta) {}
+    }
+    {
+        immutable int[0x7FFF + 2] sta;
+        static foreach (short i; 0 .. sta.length) {}
+        static foreach (short i, x; sta) {}
     }
 }


### PR DESCRIPTION
Doesn't do much for speed, though when running through the memory profiler, there's a marginal gain on memory, as it requires more work to use `ctfeInterpret` to convert/copy a static array `[0, 1, 2, 3]` into a `tuple(0, 1, 2, 3)` vs. directly using the elements of the array for the `TupleExp` creation.

Bonus, a bunch of errors that occur when using `foreach` wrongly now also get the same diagnostic with `static foreach` as well.