### PR TITLE
fix Issue 22006 - static foreach and foreach over tuple doesn't work on 16-bit

### DIFF
--- a/test/compilable/minimal3.d
+++ b/test/compilable/minimal3.d
@@ -21,3 +21,16 @@ void issue22005()
     {
     }
 }
+
+/**********************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22006
+void issue22006()
+{
+    alias size_t = typeof(int.sizeof);
+    alias AliasSeq(T...) = T;
+
+    foreach (size_t i, e; [0, 1, 2, 3]) { }
+    static foreach (size_t i, e; [0, 1, 2, 3]) { }
+    foreach (size_t i, e; AliasSeq!(0, 1, 2, 3)) { }
+    static foreach (size_t i, e; AliasSeq!(0, 1, 2, 3)) { }
+}

--- a/test/compilable/test22006.d
+++ b/test/compilable/test22006.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=22006
+void test22006()
+{
+    alias AliasSeq(TList...) = TList;
+    {
+        alias aseq = AliasSeq!(0, 1, 2, 3);
+        static foreach (ubyte i; 0 .. aseq.length) {}
+        static foreach (ubyte i, x; aseq) {}
+    }
+    {
+        static foreach (ubyte i; 0 .. [0, 1, 2, 3].length) {}
+        static foreach (ubyte i, x; [0, 1, 2, 3]) {}
+    }
+}

--- a/test/fail_compilation/diag16976.d
+++ b/test/fail_compilation/diag16976.d
@@ -1,21 +1,37 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/diag16976.d(28): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(29): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(30): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(31): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(32): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(33): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(34): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(35): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(36): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(37): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(38): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(39): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(40): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(41): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(42): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(43): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(44): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(45): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(46): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(47): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(48): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(49): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(50): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(51): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(52): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(53): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(54): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(55): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(56): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(57): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(58): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(59): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(65): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(66): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(67): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(68): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(69): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(70): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(71): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(72): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(73): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(74): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(75): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(76): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(77): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(78): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(79): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(80): Error: foreach: key cannot be of non-integral type `float`
 ---
 */
 
@@ -41,4 +57,25 @@ void main()
     foreach_reverse(float f, dchar i; sta) {}
     foreach_reverse(float f, dchar i; str) {}
     foreach_reverse(float f, dchar i; chr) {}
+
+    immutable int[]  idyn = [1,2,3,4,5];
+    immutable int[5] ista = [1,2,3,4,5];
+    immutable char[]  istr = ['1','2','3','4','5'];
+    immutable char[5] ichr = ['1','2','3','4','5'];
+    static foreach(float f, i; idyn) {}
+    static foreach(float f, i; ista) {}
+    static foreach(float f, i; istr) {}
+    static foreach(float f, i; ichr) {}
+    static foreach(float f, dchar i; idyn) {}
+    static foreach(float f, dchar i; ista) {}
+    static foreach(float f, dchar i; istr) {}
+    static foreach(float f, dchar i; ichr) {}
+    static foreach_reverse(float f, i; idyn) {}
+    static foreach_reverse(float f, i; ista) {}
+    static foreach_reverse(float f, i; istr) {}
+    static foreach_reverse(float f, i; ichr) {}
+    static foreach_reverse(float f, dchar i; idyn) {}
+    static foreach_reverse(float f, dchar i; ista) {}
+    static foreach_reverse(float f, dchar i; istr) {}
+    static foreach_reverse(float f, dchar i; ichr) {}
 }

--- a/test/fail_compilation/fail22006.d
+++ b/test/fail_compilation/fail22006.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail22006.d(15): Error: cannot implicitly convert expression `4$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `bool`
+fail_compilation/fail22006.d(16): Error: index type `bool` cannot cover index range 0..4
+fail_compilation/fail22006.d(19): Error: cannot implicitly convert expression `4$?:32=u|64=LU$` of type `$?:32=uint|64=ulong$` to `bool`
+fail_compilation/fail22006.d(20): Error: index type `bool` cannot cover index range 0..4
+---
+*/
+void test22006()
+{
+    alias AliasSeq(TList...) = TList;
+    {
+        alias aseq = AliasSeq!(0, 1, 2, 3);
+        static foreach (bool i; 0 .. aseq.length) {}
+        static foreach (bool i, x; aseq) {}
+    }
+    {
+        static foreach (bool i; 0 .. [0, 1, 2, 3].length) {}
+        static foreach (bool i, x; [0, 1, 2, 3]) {}
+    }
+}


### PR DESCRIPTION
Rather than restricting the `static foreach` index to a reduced set of types that excludes targets with a 16-bit size_t from working properly.  Do the similar checks as regular `foreach` and error for all non-integral types, and types that cannot represent the full range of index values.