### PR TITLE
Fix issue 21868 - conflation of return-ref and return-scope

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -476,6 +476,16 @@ extern (C++) abstract class Declaration : Dsymbol
         return (storage_class & STC.scope_) != 0;
     }
 
+    final bool isReturn() const pure nothrow @nogc @safe
+    {
+        return (storage_class & STC.return_) != 0;
+    }
+
+    final bool isReturnInferred() const pure nothrow @nogc @safe
+    {
+        return (storage_class & STC.returninferred) != 0;
+    }
+
     final bool isSynchronized() const pure nothrow @nogc @safe
     {
         return (storage_class & STC.synchronized_) != 0;

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -124,6 +124,8 @@ public:
     bool isWild() const         { return (storage_class & STCwild) != 0; }
     bool isAuto() const         { return (storage_class & STCauto) != 0; }
     bool isScope() const        { return (storage_class & STCscope) != 0; }
+    bool isReturn() const       { return (storage_class & STCreturn) != 0; }
+    bool isReturnInferred() const { return (storage_class & STCreturninferred) != 0; }
     bool isSynchronized() const { return (storage_class & STCsynchronized) != 0; }
     bool isParameter() const    { return (storage_class & STCparameter) != 0; }
     bool isDeprecated() const   { return (storage_class & STCdeprecated) != 0; }

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1219,7 +1219,8 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
             continue;
 
         Dsymbol p = v.toParent2();
-        const returnAppliesToValue = !(!v.isScope && v.isRef) && !(v.isScope && refs && v.isRef);
+        const returnAppliesToValue =
+            !(!v.isScope && (v.isRef || v.isOut)) && !(v.isScope && refs && (v.isRef || v.isOut));
 
         if ((v.isScope() || (v.storage_class & STC.maybescope)) &&
             !v.isReturn() && returnAppliesToValue &&
@@ -1303,7 +1304,7 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
     foreach (VarDeclaration v; er.byref)
     {
         if (log) printf("byref `%s`\n", v.toChars());
-        const returnAppliesToRef = (!v.isScope && v.isRef) || (v.isScope && refs && v.isRef);
+        const returnAppliesToRef = (!v.isScope && (v.isRef || v.isOut)) || (v.isScope && refs && (v.isRef || v.isOut));
 
         // 'featureState' tells us whether to emit an error or a deprecation,
         // depending on the flag passed to the CLI for DIP25

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5542,6 +5542,8 @@ public:
     bool isWild() const;
     bool isAuto() const;
     bool isScope() const;
+    bool isReturn() const;
+    bool isReturnInferred() const;
     bool isSynchronized() const;
     bool isParameter() const;
     bool isDeprecated() const;

--- a/test/fail_compilation/dip25.d
+++ b/test/fail_compilation/dip25.d
@@ -2,11 +2,12 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/dip25.d(17): Deprecation: returning `this.buffer[]` escapes a reference to parameter `this`
-fail_compilation/dip25.d(17):        perhaps annotate the parameter with `return`
-fail_compilation/dip25.d(22): Error: returning `identity(x)` escapes a reference to local variable `x`
-fail_compilation/dip25.d(23): Deprecation: returning `identity(x)` escapes a reference to parameter `x`
-fail_compilation/dip25.d(23):        perhaps annotate the parameter with `return`
+fail_compilation/dip25.d(18): Deprecation: returning `this.buffer[]` escapes a reference to parameter `this`
+fail_compilation/dip25.d(18):        perhaps annotate the function with `return`
+fail_compilation/dip25.d(23): Error: returning `identity(x)` escapes a reference to parameter `x`
+fail_compilation/dip25.d(23):        note that `return` applies to the value of `x`, not its address
+fail_compilation/dip25.d(24): Deprecation: returning `identity(x)` escapes a reference to parameter `x`
+fail_compilation/dip25.d(24):        perhaps annotate the parameter with `return`
 ---
 */
 struct Data

--- a/test/fail_compilation/fail13902.d
+++ b/test/fail_compilation/fail13902.d
@@ -54,14 +54,14 @@ int* testEscape1()
 TEST_OUTPUT:
 ---
 fail_compilation/fail13902.d(88): Error: Using the result of a comma expression is not allowed
-fail_compilation/fail13902.d(75): Error: returning `& x` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(76): Error: returning `&s1.v` escapes a reference to local variable `s1`
-fail_compilation/fail13902.d(81): Error: returning `& sa1` escapes a reference to local variable `sa1`
-fail_compilation/fail13902.d(82): Error: returning `&sa2[0][0]` escapes a reference to local variable `sa2`
-fail_compilation/fail13902.d(83): Error: returning `& x` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(84): Error: returning `(& x+4)` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(85): Error: returning `& x + cast(long)x * 4L` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(88): Error: returning `& y` escapes a reference to local variable `y`
+fail_compilation/fail13902.d(75): Error: returning `& x` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(76): Error: returning `&s1.v` escapes a reference to parameter `s1`
+fail_compilation/fail13902.d(81): Error: returning `& sa1` escapes a reference to parameter `sa1`
+fail_compilation/fail13902.d(82): Error: returning `&sa2[0][0]` escapes a reference to parameter `sa2`
+fail_compilation/fail13902.d(83): Error: returning `& x` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(84): Error: returning `(& x+4)` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(85): Error: returning `& x + cast(long)x * 4L` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(88): Error: returning `& y` escapes a reference to parameter `y`
 ---
 */
 int* testEscape2(
@@ -134,9 +134,9 @@ int* testEscape3(
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(150): Error: returning `cast(int[])sa1` escapes a reference to local variable `sa1`
-fail_compilation/fail13902.d(151): Error: returning `cast(int[])sa1` escapes a reference to local variable `sa1`
-fail_compilation/fail13902.d(152): Error: returning `sa1[]` escapes a reference to local variable `sa1`
+fail_compilation/fail13902.d(150): Error: returning `cast(int[])sa1` escapes a reference to parameter `sa1`
+fail_compilation/fail13902.d(151): Error: returning `cast(int[])sa1` escapes a reference to parameter `sa1`
+fail_compilation/fail13902.d(152): Error: returning `sa1[]` escapes a reference to parameter `sa1`
 fail_compilation/fail13902.d(155): Error: returning `cast(int[])sa2` escapes a reference to local variable `sa2`
 fail_compilation/fail13902.d(156): Error: returning `cast(int[])sa2` escapes a reference to local variable `sa2`
 fail_compilation/fail13902.d(157): Error: returning `sa2[]` escapes a reference to local variable `sa2`
@@ -223,14 +223,14 @@ ref int testEscapeRef1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(240): Error: returning `x` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(241): Error: returning `s1.v` escapes a reference to local variable `s1`
-fail_compilation/fail13902.d(245): Error: returning `sa1[0]` escapes a reference to local variable `sa1`
-fail_compilation/fail13902.d(246): Error: returning `sa2[0][0]` escapes a reference to local variable `sa2`
-fail_compilation/fail13902.d(247): Error: returning `x = 1` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(248): Error: returning `x += 1` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(249): Error: returning `s1.v = 1` escapes a reference to local variable `s1`
-fail_compilation/fail13902.d(250): Error: returning `s1.v += 1` escapes a reference to local variable `s1`
+fail_compilation/fail13902.d(240): Error: returning `x` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(241): Error: returning `s1.v` escapes a reference to parameter `s1`
+fail_compilation/fail13902.d(245): Error: returning `sa1[0]` escapes a reference to parameter `sa1`
+fail_compilation/fail13902.d(246): Error: returning `sa2[0][0]` escapes a reference to parameter `sa2`
+fail_compilation/fail13902.d(247): Error: returning `x = 1` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(248): Error: returning `x += 1` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(249): Error: returning `s1.v = 1` escapes a reference to parameter `s1`
+fail_compilation/fail13902.d(250): Error: returning `s1.v += 1` escapes a reference to parameter `s1`
 ---
 */
 ref int testEscapeRef2(
@@ -323,8 +323,7 @@ int[] testSlice2() { int[3] sa; int n; return sa[n..2][1..2]; }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(324): Error: returning `vda[0]` escapes a reference to parameter `vda`
-fail_compilation/fail13902.d(324):        perhaps annotate the parameter with `return`
+fail_compilation/fail13902.d(323): Error: returning `vda[0]` escapes a reference to parameter `vda`
 ---
 */
 ref int testDynamicArrayVariadic1(int[] vda...) { return vda[0]; }
@@ -334,8 +333,8 @@ int[3]  testDynamicArrayVariadic3(int[] vda...) { return vda[0..3]; }   // no er
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(335): Error: returning `vsa[0]` escapes a reference to local variable `vsa`
-fail_compilation/fail13902.d(336): Error: returning `vsa[]` escapes a reference to variadic parameter `vsa`
+fail_compilation/fail13902.d(334): Error: returning `vsa[0]` escapes a reference to parameter `vsa`
+fail_compilation/fail13902.d(335): Error: returning `vsa[]` escapes a reference to variadic parameter `vsa`
 ---
 */
 ref int testStaticArrayVariadic1(int[3] vsa...) { return vsa[0]; }

--- a/test/fail_compilation/fail17927.d
+++ b/test/fail_compilation/fail17927.d
@@ -1,9 +1,12 @@
 /* REQUIRED_ARGS: -preview=dip1000
  * TEST_OUTPUT:
 ---
-fail_compilation/fail17927.d(13): Error: scope variable `this` may not be returned
-fail_compilation/fail17927.d(21): Error: scope variable `ptr` may not be returned
-fail_compilation/fail17927.d(23): Error: scope variable `ptr` may not be returned
+fail_compilation/fail17927.d(16): Error: scope parameter `this` may not be returned
+fail_compilation/fail17927.d(16):        perhaps annotate the function with `return`
+fail_compilation/fail17927.d(24): Error: scope parameter `ptr` may not be returned
+fail_compilation/fail17927.d(24):        perhaps annotate the parameter with `return`
+fail_compilation/fail17927.d(26): Error: scope parameter `ptr` may not be returned
+fail_compilation/fail17927.d(26):        perhaps annotate the parameter with `return`
 ---
 */
 

--- a/test/fail_compilation/fail20084.d
+++ b/test/fail_compilation/fail20084.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail20084.d(109): Error: returning `v.front()` escapes a reference to local variable `v`
+fail_compilation/fail20084.d(109): Error: returning `v.front()` escapes a reference to parameter `v`
 ---
 */
 

--- a/test/fail_compilation/fail20108.d
+++ b/test/fail_compilation/fail20108.d
@@ -2,10 +2,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20108.d(15): Error: address of variable `y` assigned to `x` with longer lifetime
-fail_compilation/fail20108.d(16): Error: scope variable `x` may not be returned
-fail_compilation/fail20108.d(23): Error: address of variable `y` assigned to `x` with longer lifetime
-fail_compilation/fail20108.d(24): Error: scope variable `x` may not be returned
+fail_compilation/fail20108.d(16): Error: address of variable `y` assigned to `x` with longer lifetime
+fail_compilation/fail20108.d(17): Error: scope parameter `x` may not be returned
+fail_compilation/fail20108.d(17):        perhaps annotate the parameter with `return`
+fail_compilation/fail20108.d(24): Error: address of variable `y` assigned to `x` with longer lifetime
+fail_compilation/fail20108.d(25): Error: scope variable `x` may not be returned
 ---
 */
 

--- a/test/fail_compilation/fail20448.d
+++ b/test/fail_compilation/fail20448.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20448.d(16): Error: returning `p.x` escapes a reference to local variable `p`
+fail_compilation/fail20448.d(16): Error: returning `p.x` escapes a reference to parameter `p`
 fail_compilation/fail20448.d(22): Error: template instance `fail20448.member!"x"` error instantiating
 ---
 */

--- a/test/fail_compilation/fix18575.d
+++ b/test/fail_compilation/fix18575.d
@@ -1,10 +1,10 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fix18575.d(27): Error: returning `s.foo()` escapes a reference to local variable `s`
-fail_compilation/fix18575.d(31): Error: returning `s.foo()` escapes a reference to local variable `s`
-fail_compilation/fix18575.d(35): Error: returning `s.abc()` escapes a reference to local variable `s`
-fail_compilation/fix18575.d(39): Error: returning `s.ghi(t)` escapes a reference to local variable `t`
+fail_compilation/fix18575.d(27): Error: returning `s.foo()` escapes a reference to parameter `s`
+fail_compilation/fix18575.d(31): Error: returning `s.foo()` escapes a reference to parameter `s`
+fail_compilation/fix18575.d(35): Error: returning `s.abc()` escapes a reference to parameter `s`
+fail_compilation/fix18575.d(39): Error: returning `s.ghi(t)` escapes a reference to parameter `t`
 ---
 */
 

--- a/test/fail_compilation/previewin.d
+++ b/test/fail_compilation/previewin.d
@@ -10,7 +10,8 @@ fail_compilation/previewin.d(6): Error: function `previewin.takeFunction(void fu
 fail_compilation/previewin.d(6):        cannot pass argument `__lambda3` of type `void function(ref const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
 fail_compilation/previewin.d(15): Error: scope variable `arg` assigned to non-scope `myGlobal`
 fail_compilation/previewin.d(16): Error: scope variable `arg` assigned to non-scope `myGlobal`
-fail_compilation/previewin.d(17): Error: scope variable `arg` may not be returned
+fail_compilation/previewin.d(17): Error: scope parameter `arg` may not be returned
+fail_compilation/previewin.d(17):        perhaps annotate the parameter with `return`
 fail_compilation/previewin.d(18): Error: scope variable `arg` assigned to `escape` with longer lifetime
 fail_compilation/previewin.d(22): Error: returning `arg` escapes a reference to parameter `arg`
 fail_compilation/previewin.d(22):        perhaps annotate the parameter with `return`

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -2,7 +2,8 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(22): Error: scope variable `p` may not be returned
+fail_compilation/retscope.d(22): Error: scope parameter `p` may not be returned
+fail_compilation/retscope.d(22):        perhaps annotate the parameter with `return`
 fail_compilation/retscope.d(32): Error: returning `b ? nested1(& i) : nested2(& j)` escapes a reference to local variable `j`
 fail_compilation/retscope.d(45): Error: scope variable `p` assigned to non-scope `q`
 fail_compilation/retscope.d(47): Error: address of variable `i` assigned to `q` with longer lifetime
@@ -10,7 +11,6 @@ fail_compilation/retscope.d(48): Error: scope variable `a` assigned to non-scope
 fail_compilation/retscope.d(49): Error: address of struct temporary returned by `(*fp2)()` assigned to longer lived variable `q`
 ---
 */
-
 
 
 
@@ -149,10 +149,10 @@ S10* test10()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(158): Error: scope variable `this` may not be returned
+fail_compilation/retscope.d(158): Error: scope parameter `this` may not be returned
+fail_compilation/retscope.d(158):        perhaps annotate the function with `return`
 ---
 */
-
 class C11
 {
     @safe C11 foo() scope { return this; }
@@ -218,10 +218,10 @@ void* escape3 (scope void* p) @safe {
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(229): Error: scope variable `ptr` may not be returned
+fail_compilation/retscope.d(229): Error: scope parameter `ptr` may not be returned
+fail_compilation/retscope.d(229):        perhaps annotate the parameter with `return`
 ---
 */
-
 alias dg_t = void* delegate () return scope @safe;
 
 void* funretscope(scope dg_t ptr) @safe

--- a/test/fail_compilation/retscope_matrix.d
+++ b/test/fail_compilation/retscope_matrix.d
@@ -1,0 +1,147 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+---
+*/
+
+// naming scheme: return by Value/Ref, parameter Value/Ref, return parameter value/address, return? scope?
+// https://issues.dlang.org/show_bug.cgi?id=21868
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope_matrix.d(1000): Error: returning `&this.x` escapes a reference to parameter `this`
+fail_compilation/retscope_matrix.d(1000):        perhaps annotate the function with `return`
+fail_compilation/retscope_matrix.d(1004): Error: returning `&this.x` escapes a reference to parameter `this`
+fail_compilation/retscope_matrix.d(1004):        note that `return` applies to the value of `this`, not its address
+fail_compilation/retscope_matrix.d(1006): Error: returning `&this.x` escapes a reference to parameter `this`
+fail_compilation/retscope_matrix.d(1007): Error: scope parameter `this` may not be returned
+fail_compilation/retscope_matrix.d(1007):        perhaps annotate the function with `return`
+fail_compilation/retscope_matrix.d(1008): Error: returning `this.x` escapes a reference to parameter `this`
+fail_compilation/retscope_matrix.d(1008):        perhaps annotate the function with `return`
+fail_compilation/retscope_matrix.d(1013): Error: scope parameter `this` may not be returned
+fail_compilation/retscope_matrix.d(1013):        note that `return` applies to `ref`, not the value
+fail_compilation/retscope_matrix.d(1014): Error: returning `this.x` escapes a reference to parameter `this`
+fail_compilation/retscope_matrix.d(1014):        perhaps annotate the function with `return`
+fail_compilation/retscope_matrix.d(1015): Error: scope parameter `this` may not be returned
+---
+*/
+
+struct Node
+{
+    private int x;
+    private Node* next;
+#line 1000
+/*1000*/     int* vt_adr_  ()              {return &this.x;     } // X
+/*1001*/     int* vt_val_  ()              {return &this.next.x;} // V
+/*1002*/     int* vt_adr_r () return       {return &this.x;     } // V
+/*1003*/     int* vt_val_r () return       {return &this.next.x;} // V
+/*1004*/     int* vt_adr_rs() return scope {return &this.x;     } // X ACCEPTS_INVALID
+/*1005*/     int* vt_val_rs() return scope {return &this.next.x;} // V
+/*1006*/     int* vt_adr_s ()        scope {return &this.x;     } // X
+/*1007*/     int* vt_val_s ()        scope {return &this.next.x;} // X
+/*1008*/ ref int  rt_adr_  ()              {return  this.x;     } // X
+/*1009*/ ref int  rt_val_  ()              {return  this.next.x;} // V
+/*1010*/ ref int  rt_adr_r () return       {return  this.x;     } // V
+/*1011*/ ref int  rt_val_r () return       {return  this.next.x;} // V
+/*1012*/ ref int  rt_adr_rs() return scope {return  this.x;     } // V
+/*1013*/ ref int  rt_val_rs() return scope {return  this.next.x;} // X ACCEPTS_INVALID
+/*1014*/ ref int  rt_adr_s ()        scope {return  this.x;     } // X
+/*1015*/ ref int  rt_val_s ()        scope {return  this.next.x;} // X
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope_matrix.d(1100): Error: returning `&node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1100):        perhaps annotate the parameter with `return`
+fail_compilation/retscope_matrix.d(1104): Error: returning `&node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1104):        note that `return` applies to the value of `node`, not its address
+fail_compilation/retscope_matrix.d(1106): Error: returning `&node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1107): Error: scope parameter `node` may not be returned
+fail_compilation/retscope_matrix.d(1107):        perhaps annotate the parameter with `return`
+fail_compilation/retscope_matrix.d(1108): Error: returning `node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1108):        perhaps annotate the parameter with `return`
+fail_compilation/retscope_matrix.d(1113): Error: scope parameter `node` may not be returned
+fail_compilation/retscope_matrix.d(1113):        note that `return` applies to `ref`, not the value
+fail_compilation/retscope_matrix.d(1114): Error: returning `node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1114):        perhaps annotate the parameter with `return`
+fail_compilation/retscope_matrix.d(1115): Error: scope parameter `node` may not be returned
+---
+*/
+#line 1100
+/*1100*/     int* vr_adr_  (ref              Node node) {return &node.x;     } // X
+/*1101*/     int* vr_val_  (ref              Node node) {return &node.next.x;} // V
+/*1102*/     int* vr_adr_r (ref return       Node node) {return &node.x;     } // V
+/*1103*/     int* vr_val_r (ref return       Node node) {return &node.next.x;} // V
+/*1104*/     int* vr_adr_rs(ref return scope Node node) {return &node.x;     } // X ACCEPTS_INVALID
+/*1105*/     int* vr_val_rs(ref return scope Node node) {return &node.next.x;} // V
+/*1106*/     int* vr_adr_s (ref        scope Node node) {return &node.x;     } // X
+/*1107*/     int* vr_val_s (ref        scope Node node) {return &node.next.x;} // X
+/*1108*/ ref int  rr_adr_  (ref              Node node) {return  node.x;     } // X
+/*1109*/ ref int  rr_val_  (ref              Node node) {return  node.next.x;} // V
+/*1110*/ ref int  rr_adr_r (ref return       Node node) {return  node.x;     } // V
+/*1111*/ ref int  rr_val_r (ref return       Node node) {return  node.next.x;} // V
+/*1112*/ ref int  rr_adr_rs(ref return scope Node node) {return  node.x;     } // V
+/*1113*/ ref int  rr_val_rs(ref return scope Node node) {return  node.next.x;} // X ACCEPTS_INVALID
+/*1114*/ ref int  rr_adr_s (ref        scope Node node) {return  node.x;     } // X
+/*1115*/ ref int  rr_val_s (ref        scope Node node) {return  node.next.x;} // X
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope_matrix.d(1200): Error: returning `&node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1202): Error: returning `&node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1202):        note that `return` applies to the value of `node`, not its address
+fail_compilation/retscope_matrix.d(1204): Error: returning `&node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1204):        note that `return` applies to the value of `node`, not its address
+fail_compilation/retscope_matrix.d(1206): Error: returning `&node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1207): Error: scope parameter `node` may not be returned
+fail_compilation/retscope_matrix.d(1207):        perhaps annotate the parameter with `return`
+fail_compilation/retscope_matrix.d(1208): Error: returning `node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1210): Error: returning `node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1210):        note that `return` applies to the value of `node`, not its address
+fail_compilation/retscope_matrix.d(1212): Error: returning `node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1212):        note that `return` applies to the value of `node`, not its address
+fail_compilation/retscope_matrix.d(1214): Error: returning `node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1215): Error: scope parameter `node` may not be returned
+fail_compilation/retscope_matrix.d(1215):        perhaps annotate the parameter with `return`
+---
+*/
+#line 1200
+/*1200*/     int* vv_adr_  (                 Node node) {return &node.x;     } // X WRONG_ERROR
+/*1201*/     int* vv_val_  (                 Node node) {return &node.next.x;} // V
+/*1202*/     int* vv_adr_r (    return       Node node) {return &node.x;     } // X
+/*1203*/     int* vv_val_r (    return       Node node) {return &node.next.x;} // V
+/*1204*/     int* vv_adr_rs(    return scope Node node) {return &node.x;     } // X
+/*1205*/     int* vv_val_rs(    return scope Node node) {return &node.next.x;} // V
+/*1206*/     int* vv_adr_s (           scope Node node) {return &node.x;     } // X
+/*1207*/     int* vv_val_s (           scope Node node) {return &node.next.x;} // X
+/*1208*/ ref int  rv_adr_  (                 Node node) {return  node.x;     } // X
+/*1209*/ ref int  rv_val_  (                 Node node) {return  node.next.x;} // V
+/*1210*/ ref int  rv_adr_r (    return       Node node) {return  node.x;     } // X
+/*1211*/ ref int  rv_val_r (    return       Node node) {return  node.next.x;} // V
+/*1212*/ ref int  rv_adr_rs(    return scope Node node) {return  node.x;     } // X
+/*1213*/ ref int  rv_val_rs(    return scope Node node) {return  node.next.x;} // V
+/*1214*/ ref int  rv_adr_s (           scope Node node) {return  node.x;     } // X
+/*1215*/ ref int  rv_val_s (           scope Node node) {return  node.next.x;} // X
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope_matrix.d(1304): Error: returning `node.x` escapes a reference to parameter `node`
+fail_compilation/retscope_matrix.d(1306): Error: returning `&node.x` escapes a reference to parameter `node`
+---
+*/
+void infer() {
+#line 1300
+/*1300*/ ref int  rr_adr_i(ref Node node) @safe {return  node.x;     } // V
+/*1301*/ ref int  rr_val_i(ref Node node) @safe {return  node.next.x;} // V
+/*1302*/     int* vr_adr_i(ref Node node) @safe {return &node.x;     } // V
+/*1303*/     int* vr_val_i(ref Node node) @safe {return &node.next.x;} // V
+/*1304*/ ref int  rv_adr_i(    Node node) @safe {return  node.x;     } // X - WRONG_ERROR
+/*1305*/ ref int  rv_val_i(    Node node) @safe {return  node.next.x;} // V
+/*1306*/     int* vv_adr_i(    Node node) @safe {return &node.x;     } // X - WRONG_ERROR
+/*1307*/     int* vv_val_i(    Node node) @safe {return &node.next.x;} // V
+}

--- a/test/fail_compilation/shared.d
+++ b/test/fail_compilation/shared.d
@@ -91,7 +91,6 @@ fail_compilation/shared.d(2194): Error: direct access to shared `(new shared(K2)
 fail_compilation/shared.d(2202): Error: direct access to shared `c` is not allowed, see `core.atomic`
 fail_compilation/shared.d(2206): Error: function `shared.test_inference_2` function returns `shared` but cannot be inferred `ref`
 fail_compilation/shared.d(2208): Error: returning `c` escapes a reference to parameter `c`
-fail_compilation/shared.d(2208):        perhaps annotate the parameter with `return`
 fail_compilation/shared.d(2214): Error: function `shared.test_inference_3` function returns `shared` but cannot be inferred `ref`
 fail_compilation/shared.d(2216):        return value `getSharedObject()` is not an lvalue
 fail_compilation/shared.d(2222): Error: direct access to shared `a` is not allowed, see `core.atomic`

--- a/test/fail_compilation/test14238.d
+++ b/test/fail_compilation/test14238.d
@@ -1,8 +1,9 @@
 /* REQUIRED_ARGS: -preview=dip1000
    TEST_OUTPUT:
 ---
-fail_compilation/test14238.d(20): Error: scope variable `fn` may not be returned
-fail_compilation/test14238.d(28): Error: escaping reference to stack allocated value returned by `&baz`
+fail_compilation/test14238.d(21): Error: scope parameter `fn` may not be returned
+fail_compilation/test14238.d(21):        perhaps annotate the parameter with `return`
+fail_compilation/test14238.d(29): Error: escaping reference to stack allocated value returned by `&baz`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=14238

--- a/test/fail_compilation/test16589.d
+++ b/test/fail_compilation/test16589.d
@@ -3,15 +3,15 @@ REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test16589.d(26): Error: returning `&this.data` escapes a reference to parameter `this`
-fail_compilation/test16589.d(26):        perhaps annotate the parameter with `return`
+fail_compilation/test16589.d(26):        perhaps annotate the function with `return`
 fail_compilation/test16589.d(31): Error: returning `&this` escapes a reference to parameter `this`
-fail_compilation/test16589.d(31):        perhaps annotate the parameter with `return`
+fail_compilation/test16589.d(31):        perhaps annotate the function with `return`
 fail_compilation/test16589.d(37): Error: returning `&s.data` escapes a reference to parameter `s`
 fail_compilation/test16589.d(37):        perhaps annotate the parameter with `return`
 fail_compilation/test16589.d(42): Error: returning `&s` escapes a reference to parameter `s`
 fail_compilation/test16589.d(42):        perhaps annotate the parameter with `return`
-fail_compilation/test16589.d(47): Error: returning `&s.data` escapes a reference to local variable `s`
-fail_compilation/test16589.d(52): Error: returning `& s` escapes a reference to local variable `s`
+fail_compilation/test16589.d(47): Error: returning `&s.data` escapes a reference to parameter `s`
+fail_compilation/test16589.d(52): Error: returning `& s` escapes a reference to parameter `s`
 ---
 */
 

--- a/test/fail_compilation/test17450.d
+++ b/test/fail_compilation/test17450.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 fail_compilation/test17450.d(17): Error: returning `&s.bar` escapes a reference to parameter `s`
 fail_compilation/test17450.d(17):        perhaps annotate the parameter with `return`
 fail_compilation/test17450.d(20): Error: returning `&this.bar` escapes a reference to parameter `this`
-fail_compilation/test17450.d(20):        perhaps annotate the parameter with `return`
+fail_compilation/test17450.d(20):        perhaps annotate the function with `return`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=17450
@@ -33,8 +33,10 @@ struct S {
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test17450.d(103): Error: scope variable `c` may not be returned
-fail_compilation/test17450.d(106): Error: scope variable `this` may not be returned
+fail_compilation/test17450.d(103): Error: scope parameter `c` may not be returned
+fail_compilation/test17450.d(103):        perhaps annotate the parameter with `return`
+fail_compilation/test17450.d(106): Error: scope parameter `this` may not be returned
+fail_compilation/test17450.d(106):        perhaps annotate the function with `return`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=17450


### PR DESCRIPTION
Attempts to fix 21868 and more. The problem is that escape.d checks for `return`, infers `return` and suggests to add `return` without ever checking if it's actually the right `return`, e.g. Return-Ref vs. Return-Scope. In the bug report it happens from value->ref with `&var`, but it also goes wrong with ref->value with `*var`.

I added a test for all combinations of ref/non-ref return, and return/scope/ref parameters. I still have to check whether this works with constructors ([which return by `ref` but not really or something](https://github.com/dlang/dmd/blob/a9efb98285713dac64a35e9eb166119d33d5fdc2/src/dmd/typesem.d#L1486)), `out`, `ref` in foreach and `auto ref`.

Note: it still breaks if you assign the parameter to a local variable, but that's [a separate issue (20245)](https://issues.dlang.org/show_bug.cgi?id=20245)

Since this is an accepts-invalid bug, it might break Druntime and Phobos again, we'll see.