### PR TITLE
Disable Github actions workflows for forks

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -20,6 +20,7 @@ jobs:
   # Build the documentation used by all releases
   build-docs:
     name: Build documentation for all repos
+    if: github.repository == 'dlang/dmd'
 
     steps:
       # Clone all required repos
@@ -78,6 +79,7 @@ jobs:
   # Build and package a new release for each platform
   build-all-releases:
     name: Build nightly for ${{ matrix.target }}  on ${{ matrix.os }}
+    if: github.repository == 'dlang/dmd'
     needs: build-docs
     timeout-minutes: 60
 
@@ -264,6 +266,7 @@ jobs:
   # Bundles and publishes the entire release
   generate_release:
     name: "Publish artifacts on the release page"
+    if: github.repository == 'dlang/dmd'
     needs: build-all-releases
     steps:
       #################################################################

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -47,6 +47,8 @@ on:
 jobs:
   main:
     name: Run
+    if: github.repository == 'dlang/dmd'
+
     strategy:
       # Since those tests takes very little time, don't use `fail-fast`.
       # If runtime expand, we might want to comment this out,


### PR DESCRIPTION
Don't waste resources for each fork.
As suggested in https://github.community/t/stop-github-actions-running-on-a-fork/17965/2

CC @Geod24, @CyberShadow 