### PR TITLE
Ensure that Dsymbol.search never raises an error with IgnoreErrors...

### DIFF
--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -497,7 +497,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         if (!members || !symtab) // opaque or addMember is not yet done
         {
             // .stringof is always defined (but may be hidden by some other symbol)
-            if (ident != Id.stringof)
+            if (ident != Id.stringof && !(flags & IgnoreErrors))
                 error("is forward referenced when looking for `%s`", ident.toChars());
             //*(char*)0=0;
             return null;

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -315,7 +315,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         if (!members || !symtab) // opaque or semantic() is not yet called
         {
             // .stringof is always defined (but may be hidden by some other symbol)
-            if(ident != Id.stringof)
+            if(ident != Id.stringof && !(flags & IgnoreErrors))
                 error("is forward referenced when looking for `%s`", ident.toChars());
             return null;
         }

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -131,7 +131,8 @@ extern (C++) final class Nspace : ScopeDsymbol
 
         if (!members || !symtab) // opaque or semantic() is not yet called
         {
-            error("is forward referenced when looking for `%s`", ident.toChars());
+            if (!(flags & IgnoreErrors))
+                error("is forward referenced when looking for `%s`", ident.toChars());
             return null;
         }
 

--- a/test/unit/compilable/searching.d
+++ b/test/unit/compilable/searching.d
@@ -1,0 +1,181 @@
+// See ../../README.md for information about DMD unit tests.
+//
+// Verify that searches using Dsymbol.search inside of templates respect
+// the IgnoreErrors flag (instead of raising an error)
+
+module compilable.searching;
+
+import support : afterEach, beforeEach, compiles;
+
+import dmd.dsymbol;
+import dmd.dclass : ClassDeclaration;
+import dmd.declaration : VarDeclaration;
+import dmd.dtemplate : TemplateDeclaration;
+import dmd.globals : global, Loc;
+import dmd.identifier : Identifier;
+
+@beforeEach initializeFrontend()
+{
+    import dmd.frontend : initDMD;
+    initDMD();
+}
+
+@afterEach deinitializeFrontend()
+{
+    import dmd.frontend : deinitializeDMD;
+    deinitializeDMD();
+}
+
+@("Test searching templated class members")
+unittest
+{
+    doTest(q{
+
+class Clazz(T)
+{
+    T member;
+}
+
+    }, "Clazz");
+}
+
+@("Test searching templated struct members")
+unittest
+{
+    doTest(q{
+
+class Structure(T)
+{
+    T member;
+}
+
+    }, "Structure");
+}
+
+@("Test searching templated namespace members")
+unittest
+{
+    doTest(q{
+
+template Namespace(T)
+{
+    extern(C++, Namespace)
+    {
+        T member;
+    }
+}
+
+    }, "Namespace");
+}
+
+@("Test searching templated enum members")
+unittest
+{
+    doTest(q{
+
+template Enumeration(T)
+{
+    enum Enumeration : T
+    {
+        member
+    }
+}
+
+    }, "Enumeration");
+}
+
+@("Test searching templated alias")
+unittest
+{
+    doTest(q{
+
+    alias Alias(T) = int;
+
+    }, "Alias");
+}
+
+@("Test searching templated import")
+unittest
+{
+    doTest(q{
+
+template Import(T)
+{
+    import object;
+}
+
+    }, "Import");
+}
+
+@("Test searching templated renamed import")
+unittest
+{
+    doTest(q{
+
+template Import(T)
+{
+    import core.stdc.stdint : member = int32_t;
+}
+
+    }, "Import");
+}
+
+private:
+
+/**
+ * Compiles `code` and searches for `symbol` as well as it's member `member`.
+ *
+ * `symbol` must be found and the fronted may never raise errors because this
+ * method uses the `IgnoreErrors` flag.
+ */
+void doTest(const string code, const string symbol, const string member = "member")
+{
+    auto res = compiles(code);
+    assert(res, res.toString());
+
+    auto mod = cast() res.module_;
+
+    auto td = mod.find!TemplateDeclaration(symbol);
+
+    // Search doesn't work on uninstantiated templates
+    assert(td.members);
+    assert(td.members.length == 1);
+    auto cl = (*td.members)[0];
+
+    cl.find!VarDeclaration(member, true);
+}
+
+/**
+ * Wrapper for `Dsymbol.search` that finds an AST node.
+ *
+ * Params:
+ *   T            = expected type of the node
+ *   name         = name of the symbol
+ *   allowMissing = search is allowed yield no results
+ *
+ * Returns: the symbol or `null` if `allowMissing` is true
+*           (otherwise triggers an assertion failure)
+ */
+T find(T)(Dsymbol sym, string name, bool allowMissing = false)
+{
+    Dsymbol found = findSymbol(sym, name, allowMissing);
+    if (allowMissing && !found)
+        return null;
+    T res = mixin("found.is" ~ T.stringof);
+    assert(res, found.toString() ~ " is not a " ~ T.stringof);
+    return res;
+}
+
+/// ditto
+Dsymbol findSymbol(Dsymbol sym, string name, bool allowMissing = false)
+{
+    assert(sym, "Missing symbol while searching for: " ~ name);
+
+    const oldErrors = global.errors;
+    Identifier id = Identifier.idPool(name);
+    Dsymbol found = sym.search(Loc.initial, id, IgnoreErrors);
+
+    assert(global.errors == oldErrors, "Searching " ~ name ~ " caused errors!");
+    assert(allowMissing || found, name ~ " not found!");
+    return found;
+}

--- a/test/unit/support.d
+++ b/test/unit/support.d
@@ -54,7 +54,10 @@ string stripDelimited(string str)
 
 const struct CompilationResult
 {
+    import dmd.dmodule : Module;
+
     Diagnostic[] diagnostics;
+    Module module_;
 
     alias diagnostics this;
 
@@ -101,7 +104,7 @@ CompilationResult compiles(string code, string filename = "test.d")
 
     t.module_.fullSemantic();
 
-    return CompilationResult(diagnosticCollector.diagnostics);
+    return CompilationResult(diagnosticCollector.diagnostics, t.module_);
 }
 
 class NoopDiagnosticReporter : DiagnosticReporter


### PR DESCRIPTION
... inside of `TemplateDeclaration`s.

The flag indicates that error should be ignored and simply be treated
as "Not found". This is especially important for users of DMD as a
library (e.g. `dtoh`) that want to search symbols indiscriminant of
their actual type.

The `search` implementations of `StructDeclaration`, `ClassDeclaration`
and `Nspace` raised an error when trying to search inside of an
uninstantiated `TemplateDeclaration`.