### PR TITLE
add isPtrToFunction()

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -377,7 +377,7 @@ public:
         if (t != rootType)
         {
             if (t.ty == Tfunction || t.ty == Tdelegate ||
-                (t.ty == Tpointer && t.nextOf().ty == Tfunction))
+                t.isPtrToFunction())
             {
                 t = t.merge2();
             }

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2876,7 +2876,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             assert(treq.nextOf().ty == Tfunction);
             if (treq.ty == Tdelegate)
                 fld.tok = TOK.delegate_;
-            else if (treq.ty == Tpointer && treq.nextOf().ty == Tfunction)
+            else if (treq.isPtrToFunction())
                 fld.tok = TOK.function_;
             else
                 assert(0);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1459,6 +1459,7 @@ public:
     virtual bool needsCopyOrPostblit();
     virtual bool needsNested();
     virtual TypeBasic* isTypeBasic();
+    TypeFunction* isPtrToFunction();
     TypeError* isTypeError();
     TypeVector* isTypeVector();
     TypeSArray* isTypeSArray();

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -1284,7 +1284,7 @@ opflag_t asm_determine_operand_flags(ref OPND popnd)
         if (!popnd.ptype)
             return CONSTRUCT_FLAGS(sz, _m, _normal, 0);
         ty = popnd.ptype.ty;
-        if (ty == Tpointer && popnd.ptype.nextOf().ty == Tfunction &&
+        if (popnd.ptype.isPtrToFunction() &&
             !ps.isVarDeclaration())
         {
             return CONSTRUCT_FLAGS(OpndSize._32, _m, _fn16, 0);

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -224,7 +224,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
             auto ie = new ExpInitializer(i.loc, sle);
             return ie.initializerSemantic(sc, t, needInterpret);
         }
-        else if ((t.ty == Tdelegate || t.ty == Tpointer && t.nextOf().ty == Tfunction) && i.value.dim == 0)
+        else if ((t.ty == Tdelegate || t.isPtrToFunction()) && i.value.dim == 0)
         {
             TOK tok = (t.ty == Tdelegate) ? TOK.delegate_ : TOK.function_;
             /* Rewrite as empty delegate literal { }
@@ -1050,7 +1050,7 @@ private bool hasNonConstPointers(Expression e)
         }
         return true;
     }
-    if (e.type.ty == Tpointer && e.type.nextOf().ty != Tfunction)
+    if (e.type.ty == Tpointer && !e.type.isPtrToFunction())
     {
         if (e.op == TOK.symbolOffset) // address of a global is OK
             return false;

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -2058,7 +2058,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
              * any calls to the fp or dg can be inlined.
              */
             if (vfrom.type.ty == Tdelegate ||
-                vfrom.type.ty == Tpointer && vfrom.type.nextOf().ty == Tfunction)
+                vfrom.type.isPtrToFunction())
             {
                 if (auto ve = arg.isVarExp())
                 {

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2704,6 +2704,21 @@ extern (C++) abstract class Type : ASTNode
         return null;
     }
 
+    /****************
+     * Is this type a pointer to a function?
+     * Returns:
+     *  the function type if it is
+     */
+    final pure inout nothrow @nogc
+    {
+        inout(TypeFunction) isPtrToFunction()
+        {
+            return (ty == Tpointer && (cast(TypePointer)this).next.ty == Tfunction)
+                ? cast(typeof(return))(cast(TypePointer)this).next
+                : null;
+        }
+    }
+
     final pure inout nothrow @nogc
     {
         inout(TypeError)      isTypeError()      { return ty == Terror     ? cast(typeof(return))this : null; }

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -313,6 +313,7 @@ public:
 
     // For eliminating dynamic_cast
     virtual TypeBasic *isTypeBasic();
+    TypeFunction *isPtrToFunction();
     TypeError *isTypeError();
     TypeVector *isTypeVector();
     TypeSArray *isTypeSArray();

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -497,8 +497,8 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 return cast(TypeFunction)t;
             else if (t.ty == Tdelegate)
                 return cast(TypeFunction)t.nextOf();
-            else if (t.ty == Tpointer && t.nextOf().ty == Tfunction)
-                return cast(TypeFunction)t.nextOf();
+            else if (auto tf = t.isPtrToFunction())
+                return tf;
         }
 
         return null;


### PR DESCRIPTION
This ugly pattern occurs repeatedly, and doing an optimal version of it is even uglier. Factoring it out into its own function makes it easier to read and mistakes much less likely.