### PR TITLE
dtoh: Mark structs as final by default

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -11,6 +11,7 @@ experimental C++ header generator:
 - Complex types are emitted as `_Complex`.
 - Initializers of `union` variables/parameters omit non-active members
 - Typecasts are emitted as C style, not D's `cast(...) ...`
+- Structs are always tagged as `final` because D disallows `struct` inheritance
 
 Note: The header generator is still considerer experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -103,7 +103,7 @@ extern(C++) void genCppHdrFiles(ref Modules ms)
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -1230,6 +1230,10 @@ public:
             buf.writenl();
             return;
         }
+
+        // D structs are always final
+        if (!sd.isUnionDeclaration())
+            buf.writestring(" final");
 
         buf.writenl();
         buf.writestring("{");

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -12,7 +12,7 @@
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -404,7 +404,7 @@ public:
 
 extern Global global;
 
-struct Loc
+struct Loc final
 {
     const char* filename;
     uint32_t linnum;
@@ -577,7 +577,7 @@ enum class Kind : uint8_t
     export_ = 6u,
 };
 
-struct BitArray
+struct BitArray final
 {
     typedef uint64_t Chunk_t;
     enum : uint64_t { ChunkSize = 8LLU };
@@ -622,7 +622,7 @@ public:
 };
 
 template <typename T>
-struct Array
+struct Array final
 {
     // Ignoring var length alignment 0
     size_t length;
@@ -670,7 +670,7 @@ enum class CPPMANGLE : uint8_t
     asClass = 2u,
 };
 
-struct Visibility
+struct Visibility final
 {
     Kind kind;
     Package* pkg;
@@ -1202,7 +1202,7 @@ enum class Baseok : uint8_t
     semanticdone = 3u,
 };
 
-struct ObjcClassDeclaration
+struct ObjcClassDeclaration final
 {
     bool isMeta;
     bool isExtern;
@@ -1229,7 +1229,7 @@ enum class PKG
     package_ = 2,
 };
 
-struct FileName
+struct FileName final
 {
 private:
     _d_dynamicArray< const char > str;
@@ -1268,7 +1268,7 @@ enum class StructPOD
 };
 
 template <typename K, typename V>
-struct AssocArray
+struct AssocArray final
 {
     // Ignoring var aa alignment 0
     AA* aa;
@@ -1336,7 +1336,7 @@ public:
     TY ty;
     uint8_t mod;
     char* deco;
-    struct Mcache
+    struct Mcache final
     {
         Type* cto;
         Type* ito;
@@ -1914,7 +1914,7 @@ enum class ILS : uint8_t
     yes = 2u,
 };
 
-struct ObjcFuncDeclaration
+struct ObjcFuncDeclaration final
 {
     ObjcSelector* selector;
     VarDeclaration* selectorParameter;
@@ -1948,7 +1948,7 @@ enum class VarArg : uint8_t
     typesafe = 2u,
 };
 
-struct ParameterList
+struct ParameterList final
 {
     Array<Parameter* >* parameters;
     StorageClass stc;
@@ -2064,7 +2064,7 @@ enum class STMT : uint8_t
     Import = 43u,
 };
 
-struct TargetC
+struct TargetC final
 {
     enum class Runtime : uint8_t
     {
@@ -2097,7 +2097,7 @@ struct TargetC
         {}
 };
 
-struct TargetCPP
+struct TargetCPP final
 {
     enum class Runtime : uint8_t
     {
@@ -2137,7 +2137,7 @@ struct TargetCPP
         {}
 };
 
-struct TargetObjC
+struct TargetObjC final
 {
     bool supported;
     TargetObjC() :
@@ -2533,7 +2533,7 @@ extern Array<const char* > includeModulePatterns;
 
 extern Array<Module* > compiledImports;
 
-struct Compiler
+struct Compiler final
 {
     static Expression* paintAsType(UnionExp* pue, Expression* e, Type* type);
     static void onParseModule(Module* m);
@@ -2543,7 +2543,7 @@ struct Compiler
     }
 };
 
-struct complex_t
+struct complex_t final
 {
     _d_real re;
     _d_real im;
@@ -2656,7 +2656,7 @@ public:
 
 extern bool arrayTypeCompatibleWithoutCasting(Type* t1, Type* t2);
 
-struct BaseClass
+struct BaseClass final
 {
     Type* type;
     ClassDeclaration* sym;
@@ -3137,7 +3137,7 @@ extern Expression* getValue(VarDeclaration* vd);
 
 extern void printCtfePerformanceStats();
 
-struct MacroTable
+struct MacroTable final
 {
 private:
     Macro* mactab;
@@ -3261,7 +3261,7 @@ public:
     ~Module();
 };
 
-struct ModuleDeclaration
+struct ModuleDeclaration final
 {
     Loc loc;
     Identifier* id;
@@ -3676,7 +3676,7 @@ public:
 
 extern void expandTuples(Array<Expression* >* exps);
 
-struct UnionExp
+struct UnionExp final
 {
     Expression* exp();
     Expression* copy();
@@ -4717,7 +4717,7 @@ public:
     void visit(TryFinallyStatement* s);
 };
 
-struct Ensure
+struct Ensure final
 {
     Identifier* id;
     Statement* ensure;
@@ -6272,7 +6272,7 @@ public:
     void accept(Visitor* v);
 };
 
-struct Target
+struct Target final
 {
     enum class OS : uint8_t
     {
@@ -6309,7 +6309,7 @@ struct Target
     bool run_noext;
     bool mscoff;
     template <typename T>
-    struct FPTypeProperties
+    struct FPTypeProperties final
     {
         // Ignoring var max alignment 0
         real_t max;
@@ -6629,7 +6629,7 @@ extern void fatal();
 
 extern void halt();
 
-struct Param
+struct Param final
 {
     bool obj;
     bool link;
@@ -7012,7 +7012,7 @@ struct Param
         {}
 };
 
-struct Global
+struct Global final
 {
     _d_dynamicArray< const char > inifilename;
     _d_dynamicArray< const char > copyright;
@@ -7075,7 +7075,7 @@ struct Global
         {}
 };
 
-struct Id
+struct Id final
 {
     static Identifier* IUnknown;
     static Identifier* Object;
@@ -7503,7 +7503,7 @@ public:
     static bool isValidIdentifier(const char* str);
 };
 
-struct Token
+struct Token final
 {
     Token* next;
     Loc loc;
@@ -7550,7 +7550,7 @@ struct Token
 
 using real_t = longdouble;
 
-struct CTFloat
+struct CTFloat final
 {
     enum : bool { yl2x_supported = true };
 
@@ -7596,7 +7596,7 @@ struct CTFloat
     }
 };
 
-struct Port
+struct Port final
 {
     static int32_t memicmp(const char* const s1, const char* const s2, size_t n);
     static char* strupr(char* s);
@@ -7614,7 +7614,7 @@ struct Port
     }
 };
 
-struct Mem
+struct Mem final
 {
     static char* xstrdup(const char* s);
     static void xfree(void* p);

--- a/test/compilable/dtoh_21217.d
+++ b/test/compilable/dtoh_21217.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -39,7 +39,7 @@ struct _d_dynamicArray
 };
 #endif
 
-struct Foo
+struct Foo final
 {
     int32_t a;
     enum : int32_t { b = 2 };

--- a/test/compilable/dtoh_AliasDeclaration.d
+++ b/test/compilable/dtoh_AliasDeclaration.d
@@ -19,7 +19,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -79,7 +79,7 @@ typedef C2* aliasC2;
 typedef size_t(*F)(size_t x);
 
 template <typename T, typename U>
-struct TS
+struct TS final
 {
     TS()
     {

--- a/test/compilable/dtoh_AliasDeclaration_98.d
+++ b/test/compilable/dtoh_AliasDeclaration_98.d
@@ -16,7 +16,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -39,7 +39,7 @@ struct _d_dynamicArray
 #endif
 
 template <typename T, typename U>
-struct TS
+struct TS final
 {
     TS()
     {

--- a/test/compilable/dtoh_AnonDeclaration.d
+++ b/test/compilable/dtoh_AnonDeclaration.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -39,7 +39,7 @@ struct _d_dynamicArray
 };
 #endif
 
-struct S
+struct S final
 {
     union
     {

--- a/test/compilable/dtoh_CPPNamespaceDeclaration.d
+++ b/test/compilable/dtoh_CPPNamespaceDeclaration.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;

--- a/test/compilable/dtoh_ClassDeclaration.d
+++ b/test/compilable/dtoh_ClassDeclaration.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -90,7 +90,7 @@ public:
         int32_t u1;
         char u2[4$?:32=u|64=LLU$];
     };
-    struct Inner
+    struct Inner final
     {
         int32_t x;
         Inner() :

--- a/test/compilable/dtoh_StructDeclaration.d
+++ b/test/compilable/dtoh_StructDeclaration.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -42,7 +42,7 @@ struct _d_dynamicArray
 struct S;
 struct Inner;
 
-struct S
+struct S final
 {
     int8_t a;
     int32_t b;
@@ -63,7 +63,7 @@ struct S
         {}
 };
 
-struct S2
+struct S2 final
 {
     int32_t a;
     int32_t b;
@@ -79,7 +79,7 @@ struct S2
     }
 };
 
-struct S3
+struct S3 final
 {
     int32_t a;
     int32_t b;
@@ -93,7 +93,7 @@ struct S3
     }
 };
 
-struct S4
+struct S4 final
 {
     int32_t a;
     int64_t b;
@@ -115,7 +115,7 @@ struct S4
 };
 
 #pragma pack(push, 1)
-struct Aligned
+struct Aligned final
 {
     int8_t a;
     int32_t b;
@@ -130,7 +130,7 @@ struct Aligned
 };
 #pragma pack(pop)
 
-struct Null
+struct Null final
 {
     void* field;
     Null() :
@@ -142,7 +142,7 @@ struct Null
         {}
 };
 
-struct A
+struct A final
 {
     int32_t a;
     S s;
@@ -158,7 +158,7 @@ struct A
         int32_t u1;
         char u2[4$?:32=u|64=LLU$];
     };
-    struct Inner
+    struct Inner final
     {
         int32_t x;
         Inner() :

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -40,7 +40,7 @@ struct _d_dynamicArray
 #endif
 
 template <typename T>
-struct A
+struct A final
 {
     // Ignoring var x alignment 0
     T x;
@@ -50,7 +50,7 @@ struct A
     }
 };
 
-struct B
+struct B final
 {
     A<int32_t > x;
     B() :
@@ -63,7 +63,7 @@ struct B
 };
 
 template <typename T>
-struct Foo
+struct Foo final
 {
     // Ignoring var val alignment 0
     T val;
@@ -73,7 +73,7 @@ struct Foo
 };
 
 template <typename T>
-struct Bar
+struct Bar final
 {
     // Ignoring var v alignment 0
     Foo<T > v;
@@ -83,7 +83,7 @@ struct Bar
 };
 
 template <typename T>
-struct Array
+struct Array final
 {
     typedef Array This;
     typedef typeof(1 + 2) Int;
@@ -137,7 +137,7 @@ class ChildInt : public Parent<int32_t >
 {
 };
 
-struct HasMixins
+struct HasMixins final
 {
     void foo(int32_t t);
     HasMixins()
@@ -146,7 +146,7 @@ struct HasMixins
 };
 
 template <typename T>
-struct HasMixinsTemplate
+struct HasMixinsTemplate final
 {
     void foo(T t);
     HasMixinsTemplate()

--- a/test/compilable/dtoh_UnionDeclaration.d
+++ b/test/compilable/dtoh_UnionDeclaration.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -54,7 +54,7 @@ union U2
     char* ptr;
 };
 
-struct S
+struct S final
 {
     int32_t i;
     U1 u1;

--- a/test/compilable/dtoh_VarDeclaration.d
+++ b/test/compilable/dtoh_VarDeclaration.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;

--- a/test/compilable/dtoh_cpp98_compat.d
+++ b/test/compilable/dtoh_cpp98_compat.d
@@ -19,7 +19,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -47,7 +47,7 @@ class ImportsC
 {
 };
 
-struct Null
+struct Null final
 {
     void* field;
     _d_dynamicArray< const char > null_;
@@ -69,7 +69,7 @@ extern void* typeof_null;
 
 extern void* inferred_null;
 
-struct MyString
+struct MyString final
 {
     _d_dynamicArray< const char > str;
     MyString() :
@@ -81,7 +81,7 @@ struct MyString
         {}
 };
 
-struct Wrapper
+struct Wrapper final
 {
     MyString s1;
     MyString s2;

--- a/test/compilable/dtoh_enum.d
+++ b/test/compilable/dtoh_enum.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -121,7 +121,7 @@ enum class STC
 
 static STC const STC_D = (STC)3;
 
-struct Foo
+struct Foo final
 {
     int32_t i;
     Foo() :
@@ -141,7 +141,7 @@ namespace MyEnum
 
 static /* MyEnum */ Foo const test = Foo(42);
 
-struct FooCpp
+struct FooCpp final
 {
     int32_t i;
     FooCpp() :

--- a/test/compilable/dtoh_enum_cpp98.d
+++ b/test/compilable/dtoh_enum_cpp98.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -109,7 +109,7 @@ enum STC
 
 static STC const STC_D = (STC)3;
 
-struct Foo
+struct Foo final
 {
     int32_t i;
     Foo() :
@@ -129,7 +129,7 @@ namespace MyEnum
 
 static /* MyEnum */ Foo const test = Foo(42);
 
-struct FooCpp
+struct FooCpp final
 {
     int32_t i;
     FooCpp() :

--- a/test/compilable/dtoh_expressions.d
+++ b/test/compilable/dtoh_expressions.d
@@ -16,7 +16,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;

--- a/test/compilable/dtoh_extern_type.d
+++ b/test/compilable/dtoh_extern_type.d
@@ -18,7 +18,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -45,7 +45,7 @@ struct _d_dynamicArray
 
 struct Null;
 
-class ClassFromStruct
+class ClassFromStruct final
 {
 public:
     void foo();
@@ -60,7 +60,7 @@ public:
     virtual void foo();
 };
 
-struct StructFromStruct
+struct StructFromStruct final
 {
     void foo();
     StructFromStruct()
@@ -73,7 +73,7 @@ struct StructFromClass
     virtual void foo();
 };
 
-struct Floats
+struct Floats final
 {
     float f;
     double d;
@@ -100,7 +100,7 @@ struct Floats
         {}
 };
 
-struct Null
+struct Null final
 {
     _d_dynamicArray< const char > null_;
     Null() :
@@ -112,7 +112,7 @@ struct Null
         {}
 };
 
-struct Wrapper
+struct Wrapper final
 {
     Null n1;
     Null n2;

--- a/test/compilable/dtoh_functions.d
+++ b/test/compilable/dtoh_functions.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -75,7 +75,7 @@ namespace MSN
     static S const s = S(42);
 };
 
-struct W1
+struct W1 final
 {
     MS ms;
     /* MSN */ S msn;
@@ -88,7 +88,7 @@ struct W1
         {}
 };
 
-struct W2
+struct W2 final
 {
     W1 w1;
     W2() :
@@ -104,7 +104,7 @@ extern W2 w2;
 
 extern void enums(uint64_t e = $?:32=1LLU|64=static_cast<uint64_t>(E::m)$, uint8_t e2 = static_cast<uint8_t>(w2.w1.ms), S s = static_cast<S>(w2.w1.msn));
 
-struct S
+struct S final
 {
     int32_t i;
     int32_t get(int32_t , int32_t );
@@ -123,10 +123,10 @@ extern S s;
 
 extern void aggregates(int32_t a = s.i, int32_t b = s.get(1, 2), int32_t c = S::get(), int32_t d = S::staticVar);
 
-struct S2
+struct S2 final
 {
     S s;
-    struct S3
+    struct S3 final
     {
         static int32_t i;
         S3()

--- a/test/compilable/dtoh_ignored.d
+++ b/test/compilable/dtoh_ignored.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -60,7 +60,7 @@ private:
 };
 
 template <typename T>
-struct WithImaginaryTemplate
+struct WithImaginaryTemplate final
 {
     // Ignoring var member alignment 0
     float member;

--- a/test/compilable/dtoh_invalid_identifiers.d
+++ b/test/compilable/dtoh_invalid_identifiers.d
@@ -24,7 +24,7 @@ compilable/dtoh_invalid_identifiers.d(123): Warning: alias `char8_t` is a keywor
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -58,7 +58,7 @@ namespace const_cast
 
 }
 template <typename register_>
-struct S
+struct S final
 {
     // Ignoring var x alignment 0
     register_ x;
@@ -67,7 +67,7 @@ struct S
     }
 };
 
-struct S2
+struct S2 final
 {
     int32_t register_;
     void and();
@@ -104,7 +104,7 @@ class Alias : public typename_
 extern void user(Alias* i);
 
 template <typename typename_>
-struct InvalidNames
+struct InvalidNames final
 {
     // Ignoring var register alignment 0
     typename_ register_;

--- a/test/compilable/dtoh_protection.d
+++ b/test/compilable/dtoh_protection.d
@@ -18,7 +18,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -40,7 +40,7 @@ struct _d_dynamicArray
 };
 #endif
 
-struct S1
+struct S1 final
 {
     int32_t a;
 protected:
@@ -55,7 +55,7 @@ public:
     }
 };
 
-class S2
+class S2 final
 {
 public:
     int32_t af();
@@ -90,12 +90,12 @@ protected:
     int32_t df();
 };
 
-struct Outer
+struct Outer final
 {
 private:
     int32_t privateOuter;
 public:
-    struct PublicInnerStruct
+    struct PublicInnerStruct final
     {
     private:
         int32_t privateInner;
@@ -111,7 +111,7 @@ public:
     };
 
 private:
-    struct PrivateInnerClass
+    struct PrivateInnerClass final
     {
     private:
         int32_t privateInner;

--- a/test/compilable/dtoh_required_symbols.d
+++ b/test/compilable/dtoh_required_symbols.d
@@ -16,7 +16,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -41,7 +41,7 @@ struct _d_dynamicArray
 struct ExternDStruct;
 class ExternDClass;
 
-struct ExternDStruct
+struct ExternDStruct final
 {
     int32_t i;
     double d;
@@ -62,7 +62,7 @@ enum class ExternDEnum
 };
 
 template <>
-struct ExternDStructTemplate
+struct ExternDStructTemplate final
 {
     // Ignoring var i alignment 0
     int32_t i;
@@ -73,7 +73,7 @@ struct ExternDStructTemplate
     }
 };
 
-struct ExternCppStruct
+struct ExternCppStruct final
 {
     ExternDStruct s;
     ExternDEnum e;

--- a/test/compilable/dtoh_special_enum.d
+++ b/test/compilable/dtoh_special_enum.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;

--- a/test/compilable/dtoh_unittest_block.d
+++ b/test/compilable/dtoh_unittest_block.d
@@ -17,7 +17,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;

--- a/test/compilable/dtoh_verbose.d
+++ b/test/compilable/dtoh_verbose.d
@@ -19,7 +19,7 @@ TEST_OUTPUT:
 #else
 /// Represents a D [] array
 template<typename T>
-struct _d_dynamicArray
+struct _d_dynamicArray final
 {
     size_t length;
     T *ptr;
@@ -54,7 +54,7 @@ extern void importFunc();
 // Ignored alias dtoh_verbose.inst because of linkage
 // Ignored enum dtoh_verbose.arrayOpaque because of its base type
 // Ignored renamed import `myFunc = importFunc` because `using` only supports types
-struct A
+struct A final
 {
     // Ignored local __anonymous
     A()
@@ -62,7 +62,7 @@ struct A
     }
 };
 
-struct Hidden
+struct Hidden final
 {
     // Ignored function dtoh_verbose.Hidden.hidden because it is private
     Hidden()


### PR DESCRIPTION
Because D disallows struct inheritance.

---

Not strictly necessary, as the exported functions are not marked as virtual (or at least should not be marked), but ensures that the header matches the D semantics.