### PR TITLE
[EXPERIMENT] trailing comma in argument list should be an error

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -9214,6 +9214,8 @@ LagainStc:
                 break;
 
             nextToken(); //comma
+            if (token.value == endtok)
+                error("trailing comma in argument list");
         }
 
         check(endtok);


### PR DESCRIPTION
@ibuclaw discovered that trailing commas in argument lists are allowed. This was never intended. This PR is an experiment so see if code depends on it.