### PR TITLE
Revert "Fix Issue 22019 - `case 1,:` allowed by grammar but not DMD"

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -6202,16 +6202,14 @@ LagainStc:
                 AST.Expressions cases; // array of Expression's
                 AST.Expression last = null;
 
-                nextToken();
-                do
+                while (1)
                 {
+                    nextToken();
                     exp = parseAssignExp();
                     cases.push(exp);
                     if (token.value != TOK.comma)
                         break;
-                    nextToken(); //comma
                 }
-                while (token.value != TOK.colon && token.value != TOK.endOfFile);
                 check(TOK.colon);
 
                 /* case exp: .. case last:

--- a/test/compilable/testparse.d
+++ b/test/compilable/testparse.d
@@ -179,15 +179,3 @@ void testIfConditionWithSTCandType()
 // https://issues.dlang.org/show_bug.cgi?id=20791
 extern(C++, "foo", )
 struct S {}
-
-/***************************************************/
-// https://issues.dlang.org/show_bug.cgi?id=22019
-void test22019()
-{
-    final switch (1)
-    {
-        case 1,:
-        case 2,3,:
-            break;
-    }
-}


### PR DESCRIPTION
Reverts dlang/dmd#12677

No evidence that it is needed, and it's ugly.