### PR TITLE
ImportC: move { exp } optimization from parser to semantic()

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1832,31 +1832,15 @@ final class CParser(AST) : Parser!AST
             }
 
             desigInit.initializer = cparseInitializer();
-            const justExp = !ci &&
-                            !desigInit.designatorList &&
-                            desigInit.initializer.isExpInitializer();
-            if (token.value == TOK.comma)
-            {
-                nextToken();
-                if (token.value == TOK.rightCurly)
-                {
-                    nextToken();
-                    if (justExp)
-                        return desigInit.initializer;  // treat `{ exp , }` as just `exp`
-                }
-                if (!ci)
-                    ci = new AST.CInitializer(loc);
-                ci.initializerList.push(desigInit);
-                continue;
-            }
-            if (token.value == TOK.rightCurly && justExp)
-            {
-                nextToken();
-                return desigInit.initializer;  // treat `{ exp }` as just `exp`
-            }
             if (!ci)
                 ci = new AST.CInitializer(loc);
             ci.initializerList.push(desigInit);
+            if (token.value == TOK.comma)
+            {
+                nextToken();
+                if (token.value != TOK.rightCurly)
+                    continue;
+            }
             break;
         }
         check(TOK.rightCurly);

--- a/test/runnable/cstuff2.c
+++ b/test/runnable/cstuff2.c
@@ -143,6 +143,19 @@ void test8()
 
 /*********************************/
 
+void test9()
+{
+    int i = 1;            if (i != 1) { printf("error 9i\n"); exit(1); }
+    int j = { 2 };        if (j != 2) { printf("error 9j\n"); exit(1); }
+    int k = { 3,};        if (k != 3) { printf("error 9k\n"); exit(1); }
+
+    static int l = 4;     if (l != 4) { printf("error 9l\n"); exit(1); }
+    static int m = { 5 }; if (m != 5) { printf("error 9m\n"); exit(1); }
+    static int n = { 6,}; if (n != 6) { printf("error 9n\n"); exit(1); }
+}
+
+/*********************************/
+
 int main()
 {
     test1();
@@ -153,6 +166,7 @@ int main()
     test6();
     test7();
     test8();
+    test9();
 
     return 0;
 }


### PR DESCRIPTION
This is necessary as the type the initializer is for is needed to determine if the { } are superfluous as not.

Note that string initializers for arrays is still undone.