### PR TITLE
Fix Issue 22017 - with() on struct method that returns this destroys too early

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3847,7 +3847,12 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             }
             else if (t.ty == Tstruct)
             {
-                if (!ws.exp.isLvalue())
+                // https://issues.dlang.org/show_bug.cgi?id=22017
+                // if the with expression is an lvalue and a CallExp,
+                // the called function must be a ref function. In this
+                // situation we will still create the temporary so that
+                // we can destroy it after the WithStatement.
+                if (!ws.exp.isLvalue() || ws.exp.isCallExp())
                 {
                     /* Re-write to
                      * {

--- a/test/runnable/test22017.d
+++ b/test/runnable/test22017.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=22017
+
+struct S
+{
+    bool destroyed;
+    ~this() { destroyed = true; }
+    ref S foo() return { return this; }
+}
+
+void main()
+{
+    with (S().foo)
+    {
+        assert(!destroyed);
+    }
+}


### PR DESCRIPTION
The result of a dot identifier where the rightmost side of the dot is a function call that returns by ref is seen as an lvalue, so a temporary is not declared for it outside of the with statement. This is the cause of the issue. If the expression is an lvalue and a function call, then the called function returns by ref.