### PR TITLE
fix Issue 22029 - importC: Parser accepts storage-class specifiers for fields

### DIFF
--- a/test/fail_compilation/failcstuff1.d
+++ b/test/fail_compilation/failcstuff1.d
@@ -4,6 +4,12 @@
 fail_compilation/imports/cstuff1.c(101): Error: attributes should be specified before the function definition
 fail_compilation/imports/cstuff1.c(200): Error: no members for `enum E21962`
 fail_compilation/imports/cstuff1.c(201): Error: no members for anonymous enum
+fail_compilation/imports/cstuff1.c(303): Error: storage class not allowed in specifier-qualified-list
+fail_compilation/imports/cstuff1.c(304): Error: storage class not allowed in specifier-qualified-list
+fail_compilation/imports/cstuff1.c(305): Error: storage class not allowed in specifier-qualified-list
+fail_compilation/imports/cstuff1.c(306): Error: storage class not allowed in specifier-qualified-list
+fail_compilation/imports/cstuff1.c(307): Error: storage class not allowed in specifier-qualified-list
+fail_compilation/imports/cstuff1.c(308): Error: storage class not allowed in specifier-qualified-list
 ---
 */
 import imports.cstuff1;

--- a/test/fail_compilation/imports/cstuff1.c
+++ b/test/fail_compilation/imports/cstuff1.c
@@ -12,3 +12,17 @@ void test21962() __attribute__((noinline))
 #line 200
 enum E21962 { };
 enum { };
+
+/********************************/
+// https://issues.dlang.org/show_bug.cgi?id=22029
+#line 300
+struct S22029
+{
+    int field;
+    typedef int tfield;
+    extern int efield;
+    static int sfield;
+    _Thread_local int lfield;
+    auto int afield;
+    register int rfield;
+};


### PR DESCRIPTION
Parse a `specifier-qualifier-list` for members, not a `declaration-specifiers`.

Perhaps in future, `cparseDeclaration` should be broken out into two functions, one that handles `(6.7) declaration`, and another that handles `(6.7.2.1) member-declaration`