### PR TITLE
fix Issue 22030 - importC: Wrong error with bad declarator

### DIFF
--- a/test/fail_compilation/failcstuff1.d
+++ b/test/fail_compilation/failcstuff1.d
@@ -10,6 +10,12 @@ fail_compilation/imports/cstuff1.c(305): Error: storage class not allowed in spe
 fail_compilation/imports/cstuff1.c(306): Error: storage class not allowed in specifier-qualified-list
 fail_compilation/imports/cstuff1.c(307): Error: storage class not allowed in specifier-qualified-list
 fail_compilation/imports/cstuff1.c(308): Error: storage class not allowed in specifier-qualified-list
+fail_compilation/imports/cstuff1.c(401): Error: identifier or `(` expected
+fail_compilation/imports/cstuff1.c(402): Error: identifier or `(` expected
+fail_compilation/imports/cstuff1.c(403): Error: identifier or `(` expected
+fail_compilation/imports/cstuff1.c(408): Error: identifier or `(` expected
+fail_compilation/imports/cstuff1.c(409): Error: identifier or `(` expected
+fail_compilation/imports/cstuff1.c(410): Error: identifier or `(` expected
 ---
 */
 import imports.cstuff1;

--- a/test/fail_compilation/imports/cstuff1.c
+++ b/test/fail_compilation/imports/cstuff1.c
@@ -26,3 +26,21 @@ struct S22029
     auto int afield;
     register int rfield;
 };
+
+// https://issues.dlang.org/show_bug.cgi?id=22030
+#line 400
+int;
+int *;
+int &;
+int , int;
+
+struct S22030
+{
+  int;
+  int *;
+  int &;
+  int, int;
+  int _;
+};
+
+void test22030(struct S22030, struct S22030*, struct S22030[4]);


### PR DESCRIPTION
1. Moved `error("identifier or `(` expected"); // )` from `cparseDeclaration` to `cparseDeclarator`
2. Return early for any empty `declaration`, not just `TypeTag` types.
3. Fix token position after issuing function `__attribute__` error.
4. Add new enum `DTR` to distinguish between a direct declarator `int* var`, and an abstract declarator (the type-name in `sizeof(int*)` or parameter-list `int fn(int, int*)`).  Only the first should trigger an error.