### PR TITLE
fix Issue 22028 - importC: Parser accepts initializers for struct members

### DIFF
--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -42,8 +42,8 @@ int test21937c() __attribute__((nothrow , leaf)) __attribute__((noreturn));
 __attribute__((noinline))
 void test21937d()
 {
-  typedef int attr_var_t;
-  attr_var_t attr_local __attribute__((unused));
+    typedef int attr_var_t;
+    attr_var_t attr_local __attribute__((unused));
 }
 
 __attribute__((aligned)) int test21937e;
@@ -51,24 +51,24 @@ int test21937f __attribute__((aligned));
 
 struct __attribute__((packed)) S21937a
 {
-  __attribute__((deprecated("msg"))) char c;
-  int i __attribute__((deprecated));
+    __attribute__((deprecated("msg"))) char c;
+    int i __attribute__((deprecated));
 };
 
 struct S21937b
 {
-  __attribute__((deprecated("msg"))) char c;
-  int i __attribute__((deprecated));
+    __attribute__((deprecated("msg"))) char c;
+    int i __attribute__((deprecated));
 } __attribute__((packed));
 
 enum __attribute__((aligned)) E21937a
 {
-  E21937a_A,
+    E21937a_A,
 };
 
 enum E21937b
 {
-  E21937b_A,
+    E21937b_A,
 } __attribute__((aligned));
 
 typedef int T21937a __attribute__((unused));
@@ -153,3 +153,16 @@ struct S21973
 
 struct S21982 { int field; };
 struct S21982 test21982;
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22028
+
+struct S22028
+{
+    struct nested
+    {
+        int field;
+    };
+    const int cfield;
+    _Static_assert(1 == 1, "ok");
+};

--- a/test/fail_compilation/failcstuff1.d
+++ b/test/fail_compilation/failcstuff1.d
@@ -4,6 +4,11 @@
 fail_compilation/imports/cstuff1.c(101): Error: attributes should be specified before the function definition
 fail_compilation/imports/cstuff1.c(200): Error: no members for `enum E21962`
 fail_compilation/imports/cstuff1.c(201): Error: no members for anonymous enum
+fail_compilation/imports/cstuff1.c(252): Error: `;` or `,` expected
+fail_compilation/imports/cstuff1.c(253): Error: `void` has no value
+fail_compilation/imports/cstuff1.c(253): Error: missing comma
+fail_compilation/imports/cstuff1.c(253): Error: `;` or `,` expected
+fail_compilation/imports/cstuff1.c(254): Error: empty struct-declaration-list for `struct Anonymous`
 fail_compilation/imports/cstuff1.c(303): Error: storage class not allowed in specifier-qualified-list
 fail_compilation/imports/cstuff1.c(304): Error: storage class not allowed in specifier-qualified-list
 fail_compilation/imports/cstuff1.c(305): Error: storage class not allowed in specifier-qualified-list

--- a/test/fail_compilation/imports/cstuff1.c
+++ b/test/fail_compilation/imports/cstuff1.c
@@ -14,6 +14,16 @@ enum E21962 { };
 enum { };
 
 /********************************/
+// https://issues.dlang.org/show_bug.cgi?id=22028
+#line 250
+struct S22028
+{
+    int init = 1;
+    void vfield nocomma;
+    struct { };
+};
+
+/********************************/
 // https://issues.dlang.org/show_bug.cgi?id=22029
 #line 300
 struct S22029


### PR DESCRIPTION
Adds `cparseStructDeclaration`, a stripped down version of `cparseDeclaration` that only deals with parsing a `struct-declaration` as per C11 6.7.2 (renamed to `member-declaration` in C2X 6.7.2).

Removing dead code from `cparseDeclaration` to be done in a follow-up PR.  There's also room for de-duplicating the two, but again such refactoring will be done in subsequent follow-ups if it makes sense.