### PR TITLE
ImportC: add CompoundLiteralExp

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -823,10 +823,9 @@ final class CParser(AST) : Parser!AST
 
                 if (token.value == TOK.leftCurly)
                 {
-                    // ( type-name ) { initializer-list }
-                    cparseInitializer();
-                    error(" `(type-name ) { initializer-list }` is not supported");  // TODO
-                    e = new AST.IntegerExp(loc, 0, AST.Type.tint32);
+                    // C11 6.5.2.5 ( type-name ) { initializer-list }
+                    auto ci = cparseInitializer();
+                    e = new AST.CompoundLiteralExp(loc, t, ci);
                     break;
                 }
                 else

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -49,6 +49,7 @@ import dmd.globals;
 import dmd.hdrgen;
 import dmd.id;
 import dmd.identifier;
+import dmd.init;
 import dmd.inline;
 import dmd.mtype;
 import dmd.nspace;
@@ -541,6 +542,7 @@ private:
         char[__traits(classInstanceSize, ArrayLiteralExp)] arrayliteralexp;
         char[__traits(classInstanceSize, AssocArrayLiteralExp)] assocarrayliteralexp;
         char[__traits(classInstanceSize, StructLiteralExp)] structliteralexp;
+        char[__traits(classInstanceSize, CompoundLiteralExp)] compoundliteralexp;
         char[__traits(classInstanceSize, NullExp)] nullexp;
         char[__traits(classInstanceSize, DotVarExp)] dotvarexp;
         char[__traits(classInstanceSize, AddrExp)] addrexp;
@@ -1681,6 +1683,7 @@ extern (C++) abstract class Expression : ASTNode
         inout(ArrayLiteralExp) isArrayLiteralExp() { return op == TOK.arrayLiteral ? cast(typeof(return))this : null; }
         inout(AssocArrayLiteralExp) isAssocArrayLiteralExp() { return op == TOK.assocArrayLiteral ? cast(typeof(return))this : null; }
         inout(StructLiteralExp) isStructLiteralExp() { return op == TOK.structLiteral ? cast(typeof(return))this : null; }
+        inout(CompoundLiteralExp) isCompoundLiteralExp() { return op == TOK.compoundLiteral ? cast(typeof(return))this : null; }
         inout(TypeExp)      isTypeExp() { return op == TOK.type ? cast(typeof(return))this : null; }
         inout(ScopeExp)     isScopeExp() { return op == TOK.scope_ ? cast(typeof(return))this : null; }
         inout(TemplateExp)  isTemplateExp() { return op == TOK.template_ ? cast(typeof(return))this : null; }
@@ -3373,6 +3376,28 @@ extern (C++) final class StructLiteralExp : Expression
             return e;
         }
         return this;
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+/***********************************************************
+ * C11 6.5.2.5
+ * ( type-name ) { initializer-list }
+ */
+extern (C++) final class CompoundLiteralExp : Expression
+{
+    Initializer initializer; /// initializer-list
+
+    extern (D) this(const ref Loc loc, Type type_name, Initializer initializer)
+    {
+        super(loc, TOK.compoundLiteral, __traits(classInstanceSize, CompoundLiteralExp));
+        super.type = type_name;
+        this.initializer = initializer;
+        //printf("CompoundLiteralExp::CompoundLiteralExp(%s)\n", toChars());
     }
 
     override void accept(Visitor v)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -143,6 +143,7 @@ class NullExp;
 class ArrayLiteralExp;
 class AssocArrayLiteralExp;
 class StructLiteralExp;
+class CompoundLiteralExp;
 class TypeExp;
 class ScopeExp;
 class TemplateExp;
@@ -1508,27 +1509,28 @@ enum class TOK : uint16_t
     arrow = 235u,
     colonColon = 236u,
     wchar_tLiteral = 237u,
-    inline_ = 238u,
-    register_ = 239u,
-    restrict = 240u,
-    signed_ = 241u,
-    sizeof_ = 242u,
-    typedef_ = 243u,
-    unsigned_ = 244u,
-    volatile_ = 245u,
-    _Alignas = 246u,
-    _Alignof = 247u,
-    _Atomic = 248u,
-    _Bool = 249u,
-    _Complex = 250u,
-    _Generic = 251u,
-    _Imaginary = 252u,
-    _Noreturn = 253u,
-    _Static_assert = 254u,
-    _Thread_local = 255u,
-    __cdecl = 256u,
-    __declspec = 257u,
-    __attribute__ = 258u,
+    compoundLiteral = 238u,
+    inline_ = 239u,
+    register_ = 240u,
+    restrict = 241u,
+    signed_ = 242u,
+    sizeof_ = 243u,
+    typedef_ = 244u,
+    unsigned_ = 245u,
+    volatile_ = 246u,
+    _Alignas = 247u,
+    _Alignof = 248u,
+    _Atomic = 249u,
+    _Bool = 250u,
+    _Complex = 251u,
+    _Generic = 252u,
+    _Imaginary = 253u,
+    _Noreturn = 254u,
+    _Static_assert = 255u,
+    _Thread_local = 256u,
+    __cdecl = 257u,
+    __declspec = 258u,
+    __attribute__ = 259u,
 };
 
 enum class MATCH
@@ -1607,6 +1609,7 @@ public:
     ArrayLiteralExp* isArrayLiteralExp();
     AssocArrayLiteralExp* isAssocArrayLiteralExp();
     StructLiteralExp* isStructLiteralExp();
+    CompoundLiteralExp* isCompoundLiteralExp();
     TypeExp* isTypeExp();
     ScopeExp* isScopeExp();
     TemplateExp* isTemplateExp();
@@ -2354,6 +2357,7 @@ public:
     virtual void visit(ErrorExp* e);
     virtual void visit(ComplexExp* e);
     virtual void visit(StructLiteralExp* e);
+    virtual void visit(CompoundLiteralExp* e);
     virtual void visit(ObjcClassReferenceExp* e);
     virtual void visit(SymOffExp* e);
     virtual void visit(OverExp* e);
@@ -4141,6 +4145,7 @@ private:
         char arrayliteralexp[57LLU];
         char assocarrayliteralexp[57LLU];
         char structliteralexp[95LLU];
+        char compoundliteralexp[48LLU];
         char nullexp[40LLU];
         char dotvarexp[65LLU];
         char addrexp[56LLU];
@@ -4375,6 +4380,13 @@ public:
     Expression* getField(Type* type, uint32_t offset);
     int32_t getFieldIndex(Type* type, uint32_t offset);
     Expression* addDtorHook(Scope* sc);
+    void accept(Visitor* v);
+};
+
+class CompoundLiteralExp final : public Expression
+{
+public:
+    Initializer* initializer;
     void accept(Visitor* v);
 };
 
@@ -7019,6 +7031,7 @@ public:
     void visit(DebugStatement* s);
     void visit(ForwardingStatement* s);
     void visit(StructLiteralExp* e);
+    void visit(CompoundLiteralExp* e);
     void visit(DotTemplateExp* e);
     void visit(DotVarExp* e);
     void visit(DelegateExp* e);

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -88,6 +88,7 @@ immutable PREC[TOK.max + 1] precedence =
     TOK.variable : PREC.primary,
     TOK.symbolOffset : PREC.primary,
     TOK.structLiteral : PREC.primary,
+    TOK.compoundLiteral : PREC.primary,
     TOK.arrayLength : PREC.primary,
     TOK.delegatePointer : PREC.primary,
     TOK.delegateFunctionPointer : PREC.primary,

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -290,6 +290,7 @@ enum TOK : ushort
     arrow,      // ->
     colonColon, // ::
     wchar_tLiteral,
+    compoundLiteral, // ( type-name ) { initializer-list }
 
     // C only keywords
     inline,
@@ -776,6 +777,7 @@ extern (C++) struct Token
         TOK.wcharLiteral: "wcharv",
         TOK.dcharLiteral: "dcharv",
         TOK.wchar_tLiteral: "wchar_tv",
+        TOK.compoundLiteral: "compoundliteral",
 
         TOK.halt: "halt",
         TOK.hexadecimalString: "xstring",

--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -65,6 +65,7 @@ public:
     void visit(ASTCodegen.ErrorExp e) { visit(cast(ASTCodegen.Expression)e); }
     void visit(ASTCodegen.ComplexExp e) { visit(cast(ASTCodegen.Expression)e); }
     void visit(ASTCodegen.StructLiteralExp e) { visit(cast(ASTCodegen.Expression)e); }
+    void visit(ASTCodegen.CompoundLiteralExp e) { visit(cast(ASTCodegen.Expression)e); }
     void visit(ASTCodegen.ObjcClassReferenceExp e) { visit(cast(ASTCodegen.Expression)e); }
     void visit(ASTCodegen.SymOffExp e) { visit(cast(ASTCodegen.SymbolExp)e); }
     void visit(ASTCodegen.OverExp e) { visit(cast(ASTCodegen.Expression)e); }
@@ -157,6 +158,12 @@ extern (C++) class SemanticTimeTransitiveVisitor : SemanticTimePermissiveVisitor
                     el.accept(this);
             e.stageflags = old;
         }
+    }
+
+    override void visit(ASTCodegen.CompoundLiteralExp e)
+    {
+        if (e.initializer)
+            e.initializer.accept(this);
     }
 
     override void visit(ASTCodegen.DotTemplateExp e)

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -196,6 +196,7 @@ class TupleExp;
 class ArrayLiteralExp;
 class AssocArrayLiteralExp;
 class StructLiteralExp;
+class CompoundLiteralExp;
 class ObjcClassReferenceExp;
 class TypeExp;
 class ScopeExp;
@@ -622,6 +623,7 @@ public:
     virtual void visit(ErrorExp *e) { visit((Expression *)e); }
     virtual void visit(ComplexExp *e) { visit((Expression *)e); }
     virtual void visit(StructLiteralExp *e) { visit((Expression *)e); }
+    virtual void visit(CompoundLiteralExp *e) { visit((Expression *)e); }
     virtual void visit(ObjcClassReferenceExp *e) { visit((Expression *)e); }
     virtual void visit(SymOffExp *e) { visit((SymbolExp *)e); }
     virtual void visit(OverExp *e) { visit((Expression *)e); }

--- a/test/unit/lexer/location_offset.d
+++ b/test/unit/lexer/location_offset.d
@@ -482,6 +482,7 @@ enum ignoreTokens
     arrayLiteral,
     assocArrayLiteral,
     structLiteral,
+    compoundLiteral,
     classReference,
     thrownException,
     delegatePointer,


### PR DESCRIPTION
For `( type-name ) { initializer-list }`.

Not enough code to actually use it, just the data structure. It doesn't need to be in the .h files because the semantic code should convert it to a D expression. (That's not written yet.)