### PR TITLE
dtoh: Omit global variables with invalid identifiers

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -10,6 +10,7 @@ experimental C++ header generator:
 - Renamed imports are emitted as `using ...`
 - Complex types are emitted as `_Complex`.
 - Declarations are emitted before the first member access
+- Global variables with invalid names in C++ are omitted
 - Initializers of `union` variables/parameters omit non-active members
 - Typecasts are emitted as C style, not D's `cast(...) ...`
 - Structs are always tagged as `final` because D disallows `struct` inheritance

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -457,79 +457,8 @@ public:
         if (global.params.warnings != DiagnosticReporting.off || canFix)
         {
             // Warn about identifiers that are keywords in C++.
-            switch (ident.toString())
-            {
-                // C++ operators
-                case "and":
-                case "and_eq":
-                case "bitand":
-                case "bitor":
-                case "compl":
-                case "not":
-                case "not_eq":
-                case "or":
-                case "or_eq":
-                case "xor":
-                case "xor_eq":
-                    warnCxxCompat("special operator in C++");
-                    break;
-
-                // C++ keywords
-                case "const_cast":
-                case "delete":
-                case "dynamic_cast":
-                case "explicit":
-                case "friend":
-                case "inline":
-                case "mutable":
-                case "namespace":
-                case "operator":
-                case "register":
-                case "reinterpret_cast":
-                case "signed":
-                case "static_cast":
-                case "typedef":
-                case "typename":
-                case "unsigned":
-                case "using":
-                case "virtual":
-                case "volatile":
-                    warnCxxCompat("keyword in C++");
-                    break;
-
-                // C++11 keywords
-                case "alignas":
-                case "alignof":
-                case "char16_t":
-                case "char32_t":
-                case "constexpr":
-                case "decltype":
-                case "noexcept":
-                case "nullptr":
-                case "static_assert":
-                case "thread_local":
-                    if (global.params.cplusplus >= CppStdRevision.cpp11)
-                        warnCxxCompat("keyword in C++11");
-                    break;
-
-                // C++20 keywords
-                case "char8_t":
-                case "consteval":
-                case "constinit":
-                // Concepts-related keywords
-                case "concept":
-                case "requires":
-                // Coroutines-related keywords
-                case "co_await":
-                case "co_yield":
-                case "co_return":
-                    if (global.params.cplusplus >= CppStdRevision.cpp20)
-                        warnCxxCompat("keyword in C++20");
-                    break;
-
-                default:
-                    break;
-            }
+            if (auto kc = keywordClass(ident))
+                warnCxxCompat(kc);
         }
         buf.writestring(ident.toString());
         if (needsFix)
@@ -2922,6 +2851,86 @@ void hashInclude(ref OutBuffer buf, string content)
 {
     buf.writestring("#include ");
     buf.writestringln(content);
+}
+
+/// Determines whether `ident` is a reserved keyword in C++
+/// Returns: the kind of keyword or `null`
+const(char*) keywordClass(const Identifier ident)
+{
+    if (!ident)
+        return null;
+
+    switch (ident.toString())
+    {
+        // C++ operators
+        case "and":
+        case "and_eq":
+        case "bitand":
+        case "bitor":
+        case "compl":
+        case "not":
+        case "not_eq":
+        case "or":
+        case "or_eq":
+        case "xor":
+        case "xor_eq":
+            return "special operator in C++";
+
+        // C++ keywords
+        case "const_cast":
+        case "delete":
+        case "dynamic_cast":
+        case "explicit":
+        case "friend":
+        case "inline":
+        case "mutable":
+        case "namespace":
+        case "operator":
+        case "register":
+        case "reinterpret_cast":
+        case "signed":
+        case "static_cast":
+        case "typedef":
+        case "typename":
+        case "unsigned":
+        case "using":
+        case "virtual":
+        case "volatile":
+            return "keyword in C++";
+
+        // C++11 keywords
+        case "alignas":
+        case "alignof":
+        case "char16_t":
+        case "char32_t":
+        case "constexpr":
+        case "decltype":
+        case "noexcept":
+        case "nullptr":
+        case "static_assert":
+        case "thread_local":
+            if (global.params.cplusplus >= CppStdRevision.cpp11)
+                return "keyword in C++11";
+            return null;
+
+        // C++20 keywords
+        case "char8_t":
+        case "consteval":
+        case "constinit":
+        // Concepts-related keywords
+        case "concept":
+        case "requires":
+        // Coroutines-related keywords
+        case "co_await":
+        case "co_yield":
+        case "co_return":
+            if (global.params.cplusplus >= CppStdRevision.cpp20)
+                return "keyword in C++20";
+            return null;
+
+        default:
+            return null;
+    }
 }
 
 /// Finds the outermost symbol if `sym` is nested.

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -897,6 +897,11 @@ public:
                 ignored("variable %s because its type cannot be mapped to C++", vd.toPrettyChars());
                 return;
             }
+            if (auto kc = keywordClass(vd.ident))
+            {
+                ignored("variable %s because its name is a %s", vd.toPrettyChars(), kc);
+                return;
+            }
             writeProtection(vd.visibility.kind);
             if (vd.linkage == LINK.c)
                 buf.writestring("extern \"C\" ");

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7393,7 +7393,6 @@ struct Id final
     static Identifier* btr;
     static Identifier* bts;
     static Identifier* bswap;
-    static Identifier* volatile;
     static Identifier* volatileLoad;
     static Identifier* volatileStore;
     static Identifier* _popcnt;
@@ -7474,7 +7473,6 @@ struct Id final
     static Identifier* NULL;
     static Identifier* TRUE;
     static Identifier* FALSE;
-    static Identifier* unsigned;
     static Identifier* wchar_t;
     static Identifier* __tag;
     static Identifier* dllimport;

--- a/test/compilable/dtoh_invalid_identifiers.d
+++ b/test/compilable/dtoh_invalid_identifiers.d
@@ -3,9 +3,8 @@ REQUIRED_ARGS: -HC -c -o- -wi -extern-std=c++20
 PERMUTE_ARGS:
 TEST_OUTPUT:
 ---
-compilable/dtoh_invalid_identifiers.d(102): Warning: variable `and` is a special operator in C++
-compilable/dtoh_invalid_identifiers.d(102):        The generated C++ header will contain identifiers that are keywords in C++
 compilable/dtoh_invalid_identifiers.d(103): Warning: function `register` is a keyword in C++
+compilable/dtoh_invalid_identifiers.d(103):        The generated C++ header will contain identifiers that are keywords in C++
 compilable/dtoh_invalid_identifiers.d(105): Warning: namespace `const_cast` is a keyword in C++
 compilable/dtoh_invalid_identifiers.d(116): Warning: function `and` is a special operator in C++
 compilable/dtoh_invalid_identifiers.d(121): Warning: enum `mutable` is a keyword in C++
@@ -48,8 +47,6 @@ struct _d_dynamicArray final
 
 class Alias;
 class Base;
-
-extern bool and;
 
 extern void register(int32_t* ptr);
 

--- a/test/compilable/dtoh_verbose.d
+++ b/test/compilable/dtoh_verbose.d
@@ -80,6 +80,8 @@ public:
 };
 
 extern void unused();
+
+// Ignored variable dtoh_verbose.and because its name is a special operator in C++
 ---
 */
 
@@ -136,3 +138,5 @@ extern(C++) class Visitor
 }
 
 extern(C++) void unused() {}
+
+extern(C++) __gshared bool and;


### PR DESCRIPTION
Ignoring those globals is unlikely to cause issues for the generated
headers (in contrast to e.g. user-defined types).

---

Could also apply this for all symbols by moving this check into `shouldEmit` s.t. it omits all optional symbols with invalid identifiers. But other symbols are more likely to be referenced from other declarations.