### PR TITLE
Fix regression in ParseTimeVisitor C++ headers

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2189,7 +2189,6 @@ public:
     virtual void visit(typename AST::TypeError t);
     virtual void visit(typename AST::TypeNull t);
     virtual void visit(typename AST::TypeNoreturn t);
-    virtual void visit(typename AST::TypeTag t);
     virtual void visit(typename AST::TypeVector t);
     virtual void visit(typename AST::TypeEnum t);
     virtual void visit(typename AST::TypeTuple t);
@@ -2199,6 +2198,7 @@ public:
     virtual void visit(typename AST::TypeQualified t);
     virtual void visit(typename AST::TypeTraits t);
     virtual void visit(typename AST::TypeMixin t);
+    virtual void visit(typename AST::TypeTag t);
     virtual void visit(typename AST::TypeReference t);
     virtual void visit(typename AST::TypeSlice t);
     virtual void visit(typename AST::TypeDelegate t);

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -141,7 +141,6 @@ public:
     void visit(AST.TypeError t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeNull t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeNoreturn t) { visit(cast(AST.Type)t); }
-    void visit(AST.TypeTag t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeVector t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeEnum t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeTuple t) { visit(cast(AST.Type)t); }
@@ -151,6 +150,7 @@ public:
     void visit(AST.TypeQualified t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeTraits t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeMixin t) { visit(cast(AST.Type)t); }
+    void visit(AST.TypeTag t) { visit(cast(AST.Type)t); }
 
     // TypeNext
     void visit(AST.TypeReference t) { visit(cast(AST.TypeNext)t); }


### PR DESCRIPTION
#12594 added the visitor entry to the wrong location.