### PR TITLE
importC: Move abstract-declarator error to cparseDeclarator

### DIFF
--- a/test/fail_compilation/failcstuff1.d
+++ b/test/fail_compilation/failcstuff1.d
@@ -9,6 +9,7 @@ fail_compilation/imports/cstuff1.c(253): Error: `void` has no value
 fail_compilation/imports/cstuff1.c(253): Error: missing comma
 fail_compilation/imports/cstuff1.c(253): Error: `;` or `,` expected
 fail_compilation/imports/cstuff1.c(254): Error: empty struct-declaration-list for `struct Anonymous`
+fail_compilation/imports/cstuff1.c(257): Error: identifier not allowed in abstract-declarator
 fail_compilation/imports/cstuff1.c(303): Error: storage class not allowed in specifier-qualified-list
 fail_compilation/imports/cstuff1.c(304): Error: storage class not allowed in specifier-qualified-list
 fail_compilation/imports/cstuff1.c(305): Error: storage class not allowed in specifier-qualified-list

--- a/test/fail_compilation/imports/cstuff1.c
+++ b/test/fail_compilation/imports/cstuff1.c
@@ -23,6 +23,8 @@ struct S22028
     struct { };
 };
 
+int test22028 = sizeof(struct S22028 ident);
+
 /********************************/
 // https://issues.dlang.org/show_bug.cgi?id=22029
 #line 300


### PR DESCRIPTION
Following on from #12692, added a third declarator kind `xparameter`, used for `parameter-declaration`, where the declarator can be either direct or abstract. 

`isCDeclarator` now uses DTR for the declarator kind, and no longer checks for bit-fields, which improves its accuracy.