### PR TITLE
fix Issue 22035 - [REG 2.097][ICE] Segmentation fault parsing invalid case statement

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -6230,7 +6230,7 @@ LagainStc:
                         // not merged into the current case. This can happen for
                         // case 1: ... break;
                         // debug { case 2: ... }
-                        if (cur.isBreakStatement())
+                        if (cur && cur.isBreakStatement())
                             break;
                     }
                     s = new AST.CompoundStatement(loc, statements);

--- a/test/fail_compilation/fail22035.d
+++ b/test/fail_compilation/fail22035.d
@@ -1,0 +1,11 @@
+// https://issues.dlang.org/show_bug.cgi?id=22035
+/* TEST_OUTPUT
+---
+fail_compilation/fail22035.d(10): Error: found `2` when expecting `:`
+fail_compilation/fail22035.d(10): Error: found `:` instead of statement
+---
+*/
+int test22035()
+{
+    case 1 2:
+}


### PR DESCRIPTION
Just the stable fix, bug is still present in importC though, that'll be tackled in adjacent PR.