### PR TITLE
ImportC: add semantic() for compound literals

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3238,6 +3238,24 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         result = e;
     }
 
+    override void visit(CompoundLiteralExp cle)
+    {
+        static if (LOGSEMANTIC)
+        {
+            printf("CompoundLiteralExp::semantic('%s')\n", cle.toChars());
+        }
+        Type t = cle.type.typeSemantic(cle.loc, sc);
+        auto init = initializerSemantic(cle.initializer, sc, t, INITnointerpret);
+        auto e = initializerToExpression(init, t);
+        if (!e)
+        {
+            error(cle.loc, "cannot convert initializer `%s` to expression", init.toChars());
+            return setError();
+        }
+        result = e;
+        return;
+    }
+
     override void visit(TypeExp exp)
     {
         if (exp.type.ty == Terror)

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2044,6 +2044,14 @@ public:
         buf.writeByte(')');
     }
 
+    override void visit(CompoundLiteralExp e)
+    {
+        buf.writeByte('(');
+        typeToBuffer(e.type, null, buf, hgs);
+        buf.writeByte(')');
+        e.initializer.initializerToBuffer(buf, hgs);
+    }
+
     override void visit(TypeExp e)
     {
         typeToBuffer(e.type, null, buf, hgs);

--- a/test/runnable/cstuff2.c
+++ b/test/runnable/cstuff2.c
@@ -188,6 +188,15 @@ void test11()
 
 /*********************************/
 
+void test12()
+{
+    int i;
+    i = (int) { 3 };
+    if (i != 3) { printf("test12\n"); exit(1); }
+}
+
+/*********************************/
+
 int main()
 {
     test1();
@@ -201,6 +210,7 @@ int main()
     test9();
     test10();
     test11();
+    test12();
 
     return 0;
 }


### PR DESCRIPTION
Also added hdrgen for compound literals so they can be pretty-printed.

The semantic routine relies on initializers getting better at being converted to an Expression.