### PR TITLE
Fix Issue 22016 - [REG2.067] Wrong code with enum comparison in void ternary with side effects

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3286,6 +3286,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                  * with:
                  *      exp; return;
                  */
+                rs.exp = rs.exp.optimize(WANTvalue);
                 e0 = Expression.combine(e0, rs.exp);
                 rs.exp = null;
             }

--- a/test/runnable/test22016.d
+++ b/test/runnable/test22016.d
@@ -1,0 +1,20 @@
+// https://issues.dlang.org/show_bug.cgi?id=22016
+
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+enum E { one = 1 }
+int i;
+void gun(int n)
+{
+    return n == E.one ? ++i : (){}();
+}
+
+void main()
+{
+    gun(1);
+    assert(i == 1);
+}


### PR DESCRIPTION
The issue was that the original return expression did not get optimized before being rewritten. This lead to compile time values not being substituted with actual values.

I am currently targeting master just to see if the fix is correct. If all checks pass I will switch to stable. I'm doing so because typically when trying to target stable random CI failures occur.