### PR TITLE
fix Issue 22032 - importC: infinite loop: illegal combination of type specifiers

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1997,7 +1997,7 @@ final class CParser(AST) : Parser!AST
                     tkwx = TKW.init;
                 }
                 tkw |= tkwx;
-                if (!(tkw & TKW.xtag))  // if parser already advanced
+                if (!(tkwx & TKW.xtag)) // if parser already advanced
                     nextToken();
                 continue;
             }

--- a/test/fail_compilation/failcstuff1.d
+++ b/test/fail_compilation/failcstuff1.d
@@ -21,6 +21,7 @@ fail_compilation/imports/cstuff1.c(403): Error: identifier or `(` expected
 fail_compilation/imports/cstuff1.c(408): Error: identifier or `(` expected
 fail_compilation/imports/cstuff1.c(409): Error: identifier or `(` expected
 fail_compilation/imports/cstuff1.c(410): Error: identifier or `(` expected
+fail_compilation/imports/cstuff1.c(451): Error: illegal type combination
 fail_compilation/imports/cstuff1.c(502): Error: found `2` when expecting `:`
 fail_compilation/imports/cstuff1.c(502): Error: found `:` instead of statement
 ---

--- a/test/fail_compilation/imports/cstuff1.c
+++ b/test/fail_compilation/imports/cstuff1.c
@@ -55,6 +55,11 @@ struct S22030
 
 void test22030(struct S22030, struct S22030*, struct S22030[4]);
 
+// https://issues.dlang.org/show_bug.cgi?id=22032
+#line 450
+struct S22032 { int field; }
+int test22032;
+
 // https://issues.dlang.org/show_bug.cgi?id=22035
 #line 500
 void test22035()


### PR DESCRIPTION
Don't look at the merged `TKW` flags, check the one that was just read in, otherwise an infinite-loop ensues if a tag-like type was read which is followed by a storage class, type qualifier, or other kind of token that doesn't advance the parser on its own.