### PR TITLE
dmd.dmodule: Check whether packages is set to null in Module::load

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -593,7 +593,7 @@ extern (C++) final class Module : Package
 
     extern (C++) static Module load(Loc loc, Identifiers* packages, Identifier ident)
     {
-        return load(loc, (*packages)[], ident);
+        return load(loc, packages ? (*packages)[] : null, ident);
     }
 
     extern (D) static Module load(Loc loc, Identifier[] packages, Identifier ident)

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -537,6 +537,14 @@ void test_cppmangle()
     assert(!global.endGagging(errors));
 }
 
+void test_module()
+{
+    unsigned errors = global.startGagging();
+    Module *mod = Module::load(Loc(), NULL, Identifier::idPool("doesnotexist.d"));
+    assert(mod == NULL);
+    assert(global.endGagging(errors));
+}
+
 /**********************************/
 
 int main(int argc, char **argv)
@@ -557,6 +565,7 @@ int main(int argc, char **argv)
     test_array();
     test_outbuffer();
     test_cppmangle();
+    test_module();
 
     frontend_term();
 


### PR DESCRIPTION
The change from `Identifiers*` to `Identifier[]` caused a regression in the C++ interface.