### PR TITLE
traits: add support for CallExp when using getParameterStorageClasses

### DIFF
--- a/changelog/trait-stc-callexp.md
+++ b/changelog/trait-stc-callexp.md
@@ -1,0 +1,10 @@
+# Function calls can now be used in `__traits(getParameterStorageClasses)`
+
+Parameter storage classes can now be obtained from function calls as in this
+example:
+
+```d
+void func(ref float t) {}
+float f;
+pragma(msg, __traits(getParameterStorageClasses, func(f), 0)); // tuple("ref")
+```

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1410,19 +1410,30 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto o = (*e.args)[0];
         auto o1 = (*e.args)[1];
 
-        FuncDeclaration fd;
-        TypeFunction tf = toTypeFunction(o, fd);
-
         ParameterList fparams;
-        if (tf)
-            fparams = tf.parameterList;
-        else if (fd)
-            fparams = fd.getParameterList();
+
+        CallExp ce;
+        if (auto exp = isExpression(o))
+            ce = exp.isCallExp();
+
+        if (ce)
+        {
+            fparams = ce.f.getParameterList();
+        }
         else
         {
-            e.error("first argument to `__traits(getParameterStorageClasses, %s, %s)` is not a function",
-                o.toChars(), o1.toChars());
-            return ErrorExp.get();
+            FuncDeclaration fd;
+            auto tf = toTypeFunction(o, fd);
+            if (tf)
+                fparams = tf.parameterList;
+            else if (fd)
+                fparams = fd.getParameterList();
+            else
+            {
+                e.error("first argument to `__traits(getParameterStorageClasses, %s, %s)` is not a function or a function call",
+                    o.toChars(), o1.toChars());
+                return ErrorExp.get();
+            }
         }
 
         // Avoid further analysis for invalid functions leading to misleading error messages

--- a/test/compilable/stc_traits.d
+++ b/test/compilable/stc_traits.d
@@ -1,0 +1,172 @@
+// REQUIRED_ARGS: -preview=dip1000 -preview=in
+/*
+TEST_OUTPUT:
+---
+100 tuple()
+101 tuple("return", "ref")
+102 tuple("ref")
+103 tuple()
+104 tuple("ref")
+105 tuple()
+106 tuple()
+107 tuple("ref")
+108 tuple("ref")
+109 tuple("ref")
+110 tuple("ref")
+111 tuple()
+112 tuple("ref")
+113 tuple("ref")
+114 tuple("ref")
+115 tuple("ref")
+116 tuple()
+117 tuple("ref")
+118 tuple("ref")
+119 tuple()
+120 tuple("ref")
+121 tuple()
+122 tuple("ref")
+123 tuple("in")
+124 tuple("in")
+m       tuple("ref")
+m-mixin tuple("ref")
+m       tuple("ref")
+m-mixin tuple("ref")
+m       tuple("ref")
+m-mixin tuple("ref")
+m       tuple("return", "ref")
+m-mixin tuple("return", "ref")
+m       tuple("ref")
+m-mixin tuple("ref")
+m       tuple("ref")
+m-mixin tuple("ref")
+m       tuple()
+m-mixin tuple()
+m       tuple("ref")
+m-mixin tuple("ref")
+m       tuple("ref")
+m-mixin tuple("ref")
+m       tuple("ref")
+m-mixin tuple("ref")
+m       tuple("ref")
+m-mixin tuple("ref")
+m       tuple("ref")
+m-mixin tuple("ref")
+m       tuple("ref")
+m-mixin tuple("ref")
+m       tuple("in")
+m-mixin tuple("in")
+---
+*/
+
+void func(int i) {}
+void func(return ref bool i) {}
+void func(ref float a, int b) {}
+void get(T : int)(ref T t) {}
+void get()(float t) {}
+void get(T)(ref T[] t) {}
+void funcautoi()(auto ref int i) {}
+void funcauto(T)(auto ref T a) {}
+void funcin(in int i) {}
+
+struct Foo {
+	void foo(int i) {}
+	void foo(ref bool i) {}
+	static void sfoo(ref int i) {}
+}
+
+struct FooT(T) {
+	void foo(ref T i) {}
+	static void sfoo(ref T i) {}
+}
+
+class Bar {
+	void bar(int i) {}
+	void bar(ref bool i) {}
+	static void sbar(ref int i) {}
+}
+
+class BarT(T) {
+	void bar(ref T i) {}
+	static void sbar(ref T i) {}
+}
+
+int i;
+
+template match(handlers...)
+{
+	static foreach(h; handlers)
+	{
+		// should give the same result
+		pragma(msg, "m       ", __traits(getParameterStorageClasses, h(i), 0));
+		pragma(msg, "m-mixin ", __traits(getParameterStorageClasses, mixin("h(i)"), 0));
+	}
+
+	enum match = (){};
+}
+
+void funcT(T)(ref T t) {}
+
+void main() {
+	int i;
+	bool b;
+	float f;
+	int[] ia;
+	Foo foo;
+	FooT!int foot;
+	Bar bar = new Bar;
+	BarT!int bart = new BarT!int;
+
+	ref int _foo(return ref const int* p, scope int* a, out int b, lazy int c);
+
+	// From SPEC_RUNNABLE_EXAMPLE_COMPILE:
+	int* p, a;
+	int _b, c;
+
+	static assert(__traits(getParameterStorageClasses, _foo(p, a, _b, c), 1)[0] == "scope");
+	static assert(__traits(getParameterStorageClasses, _foo(p, a, _b, c), 2)[0] == "out");
+	static assert(__traits(getParameterStorageClasses, _foo(p, a, _b, c), 3)[0] == "lazy");
+
+#line 100
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, func(0), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, func(b), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, func(f, i), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, func(f, i), 1));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, get(i), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, get(0.0), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, get(f), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, get(ia), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, mixin("get(i)"), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, Foo.sfoo(i), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, FooT!int.sfoo(i), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, foo.foo(0), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, foo.foo(b), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, foot.foo(i), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, Bar.sbar(i), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, BarT!int.sbar(i), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, bar.bar(0), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, bar.bar(b), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, bart.bar(i), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, funcautoi(10), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, funcautoi(i), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, funcauto(10), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, funcauto(i), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, funcin(1), 0));
+	pragma(msg, __LINE__, " ", __traits(getParameterStorageClasses, funcin(i), 0));
+
+	cast(void) match!(
+		function(ref int i) => true,
+		delegate(ref int i) => true,
+		(ref int i) => true,
+		(return ref int i) => &i,
+		get,
+		funcT,
+		(int i) => true,
+		FooT!int.sfoo,
+		Foo.sfoo,
+		BarT!int.sbar,
+		Bar.sbar,
+		funcautoi,
+		funcauto,
+		funcin,
+	);
+}

--- a/test/fail_compilation/test17425.d
+++ b/test/fail_compilation/test17425.d
@@ -1,7 +1,7 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/test17425.d(24): Error: parameter index must be in range 0..4 not 4
-fail_compilation/test17425.d(27): Error: first argument to `__traits(getParameterStorageClasses, i, 4)` is not a function
+fail_compilation/test17425.d(27): Error: first argument to `__traits(getParameterStorageClasses, i, 4)` is not a function or a function call
 fail_compilation/test17425.d(29): Error: expression expected as second argument of `__traits(getParameterStorageClasses, foo, int)`
 fail_compilation/test17425.d(31): Error: expected 2 arguments for `getParameterStorageClasses` but had 3
 ---


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Spec PR: https://github.com/dlang/dlang.org/pull/3022 .
Dependency of https://github.com/dlang/phobos/pull/8146 .

## Rationale

Currently, it is not possible to get STCs of a function when the types are inferred. The alternative would be to use FunctionTypeof, although:

(a) when types are inferred and forward references happens it is impossible to know its types, but possible to know STCs.
(b) when templates arguments are inferred on CallExp, creating template instantiations manually is sometimes impractical.

```d
void funcauto(T)(auto ref T a) {}
```

In that case, it is not possible to get the type of a `funcauto` instantiation and when calling `funcauto` with an argument with forward references only STCs are known, not its type.

The real-world example is present on the referred dependency.