### PR TITLE
test/compilable/sw_transition_complex: Fix bad syntax in unittest block

### DIFF
--- a/test/compilable/sw_transition_complex.d
+++ b/test/compilable/sw_transition_complex.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS:
+// REQUIRED_ARGS: -unittest
 
 /*
 TEST_OUTPUT:
@@ -147,8 +147,8 @@ void test14488c(E *e, S *s)
 deprecated void test18212(creal c){}
 deprecated unittest
 {
-    ireal = 2i;
-    creal = 2 + 3i;
+    ireal a = 2i;
+    creal b = 2 + 3i;
 }
 deprecated struct Foo
 {


### PR DESCRIPTION
```
The unittest block contained invalid syntax. However, because the test
was never compiled with -unittest, this error was never observed.
(This also missed the intent of this part of the test.)
```
