### PR TITLE
test/compilable/test19754: Fix incorrect IsExpression

### DIFF
--- a/test/compilable/test19754.d
+++ b/test/compilable/test19754.d
@@ -21,7 +21,7 @@ void test19754()
     (cast(long[2]) a)[0] = 5;
     (cast(long[2]) a)[0] += 3;
 
-    static if (is(typeof(__vector(int[4]))))
+    static if (is(__vector(int[4])))
     {
         __vector(int[4]) v;
         (cast(int[4]) v)[0] = 5;


### PR DESCRIPTION
```
Specifying a type in `typeof` is actually invalid according to the
grammar (though in DMD in an IsExpression it silently evaluates to
`false`).
```