### PR TITLE
[refactor] dmd.root.array: Call memset directly from pop() when stomping enabled

### DIFF
--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -292,8 +292,8 @@ public:
         debug (stomp)
         {
             assert(length);
-            auto result = data[length - 1];
-            remove(length - 1);
+            auto result = data[--length];
+            memset(data.ptr + length, 0xFF, T.sizeof);
             return result;
         }
         else


### PR DESCRIPTION
`Array.remove` calls `memmove`+`memset`, as this is the last element of the array, the `memmove` is useless.

Ran unittests with `ENABLE_DEBUG=1`.  Though for some reason can't run the testsuite with that flag.