### PR TITLE
Fix 22053: Deprecate typeless catch at the parser level

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -6413,8 +6413,10 @@ LagainStc:
                     const catchloc = token.loc;
 
                     nextToken();
-                    if (token.value == TOK.leftCurly || token.value != TOK.leftParenthesis)
+                    if (token.value != TOK.leftParenthesis)
                     {
+                        deprecation("`catch` statement without an exception specification is deprecated");
+                        deprecationSupplemental(token.loc, "use `catch(Throwable)` for old behavior");
                         t = null;
                         id = null;
                     }

--- a/test/fail_compilation/fail17955.d
+++ b/test/fail_compilation/fail17955.d
@@ -92,7 +92,7 @@ struct SysTime
         try
             SimpleTimeZone.fromISOExtString(zoneStr);
 
-        catch DateTimeException;
+        catch (DateTimeException e) {}
     }
 }
 

--- a/test/fail_compilation/test12558.d
+++ b/test/fail_compilation/test12558.d
@@ -1,10 +1,24 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test12558.d(17): Error: `catch` statement without an exception specification is deprecated
-fail_compilation/test12558.d(17):        use `catch(Throwable)` for old behavior
-fail_compilation/test12558.d(22): Error: `catch` statement without an exception specification is deprecated
-fail_compilation/test12558.d(22):        use `catch(Throwable)` for old behavior
+fail_compilation/test12558.d(32): Deprecation: `catch` statement without an exception specification is deprecated
+fail_compilation/test12558.d(32):        use `catch(Throwable)` for old behavior
+fail_compilation/test12558.d(36): Deprecation: `catch` statement without an exception specification is deprecated
+fail_compilation/test12558.d(36):        use `catch(Throwable)` for old behavior
+fail_compilation/test12558.d(43): Deprecation: `catch` statement without an exception specification is deprecated
+fail_compilation/test12558.d(43):        use `catch(Throwable)` for old behavior
+fail_compilation/test12558.d(47): Deprecation: `catch` statement without an exception specification is deprecated
+fail_compilation/test12558.d(47):        use `catch(Throwable)` for old behavior
+fail_compilation/test12558.d(56): Deprecation: `catch` statement without an exception specification is deprecated
+fail_compilation/test12558.d(56):        use `catch(Throwable)` for old behavior
+fail_compilation/test12558.d(31): Error: `catch` statement without an exception specification is deprecated
+fail_compilation/test12558.d(31):        use `catch(Throwable)` for old behavior
+fail_compilation/test12558.d(36): Error: `catch` statement without an exception specification is deprecated
+fail_compilation/test12558.d(36):        use `catch(Throwable)` for old behavior
+fail_compilation/test12558.d(42): Error: `catch` statement without an exception specification is deprecated
+fail_compilation/test12558.d(42):        use `catch(Throwable)` for old behavior
+fail_compilation/test12558.d(47): Error: `catch` statement without an exception specification is deprecated
+fail_compilation/test12558.d(47):        use `catch(Throwable)` for old behavior
 ---
 */
 
@@ -23,18 +37,21 @@ void main()
         handler();
     }
 
-    // ensure diagnostics are not emitted for verioned-out blocks
-    version (none)
-    {
-        try {
-            assert(0);
-        } catch  // should not emit diagnostics
-            handler();
+    try {
+        assert(0);
+    } catch
+        handler();
 
-        try {
-            assert(0);
-        } catch {  // ditto
-            handler();
-        }
+    try {
+        assert(0);
+    } catch {
+        handler();
     }
+}
+
+void foo()()
+{
+    try {}
+    catch
+        assert(false);
 }

--- a/test/fail_compilation/test17451.d
+++ b/test/fail_compilation/test17451.d
@@ -20,7 +20,7 @@ struct ArraySet(Key)
         ~this()
     {
                 try allocator;
-                catch false; // should never happen
+                catch (Exception e) false; // should never happen
         }
 }
 

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -197,11 +197,6 @@ void safeexception()
         try {}
         catch(Throwable e) {}
     }));
-
-    static assert(!__traits(compiles, () @safe {
-        try {}
-        catch {}
-    }));
 }
 
 @safe
@@ -495,4 +490,3 @@ void main()
 {
     test14162();
 }
-


### PR DESCRIPTION
```
Type-less catch was previously deprecated only at the semantic level.
This is usually good, because it avoids spurious deprecations being triggered
in versioned-out code or generally unused (uninstantiated) code,
or in code that is 'deprecated'.
However, the syntax has been deprecated for years now, and should ultimately
be removed from the parser, but while validating the grammar, it was found that
the deprecation message didn't actually trigger in templated code, even instantiated.
While we could fix it by triggering a deprecation only when the code is instantiated,
this would still prevent us from removing support for parsing it.
Instead, add a deprecation in the parser, so that code that wasn't caught before will be.
The existing error is left in place, ensuring we don't regress.
```