### PR TITLE
importC: Implement C11 bit-fields - front-end semantic only

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -228,6 +228,16 @@ struct ASTBase
             return null;
         }
 
+        inout(BitfieldDeclaration) isBitfieldDeclaration() inout
+        {
+            return null;
+        }
+
+        inout(AnonBitfieldDeclaration) isAnonBitfieldDeclaration() inout
+        {
+            return null;
+        }
+
         inout(ClassDeclaration) isClassDeclaration() inout
         {
             return null;
@@ -497,6 +507,50 @@ struct ASTBase
         }
 
         override final inout(VarDeclaration) isVarDeclaration() inout
+        {
+            return this;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) class BitfieldDeclaration : VarDeclaration
+    {
+        Expression width;
+        VarDeclaration unitfield;
+        dinteger_t bitoffset;
+
+        final extern (D) this(const ref Loc loc, Type type, Expression width, Identifier ident, StorageClass st = STC.undefined_)
+        {
+            super(loc, type, ident, null, st);
+            this.loc = loc;
+            this.storage_class = st | STC.field;
+            this.type = type;
+            this.width = width;
+        }
+
+        override inout(BitfieldDeclaration) isBitfieldDeclaration() inout
+        {
+            return this;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) final class AnonBitfieldDeclaration : BitfieldDeclaration
+    {
+        final extern (D) this(const ref Loc loc, Type type, Expression width, StorageClass st = STC.undefined_)
+        {
+            super(loc, type, width, Identifier.generateId("__anon_bitfield"), st);
+        }
+
+        override inout(AnonBitfieldDeclaration) isAnonBitfieldDeclaration() inout
         {
             return this;
         }
@@ -2524,6 +2578,7 @@ struct ASTBase
                 sizeTy[Tmixin] = __traits(classInstanceSize, TypeMixin);
                 sizeTy[Tnoreturn] = __traits(classInstanceSize, TypeNoreturn);
                 sizeTy[Ttag] = __traits(classInstanceSize, TypeTag);
+                sizeTy[Tbitfield] = __traits(classInstanceSize, TypeBitfield);
                 return sizeTy;
             }();
 
@@ -3656,6 +3711,28 @@ struct ASTBase
         }
 
         override TypeTag syntaxCopy()
+        {
+            return this;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) final class TypeBitfield : Type
+    {
+        Type basetype;
+        uint bitsize;
+
+        extern (D) this(uint bitsize)
+        {
+            super(Tbitfield);
+            this.bitsize = bitsize;
+        }
+
+        override TypeBitfield syntaxCopy()
         {
             return this;
         }

--- a/src/dmd/astenums.d
+++ b/src/dmd/astenums.d
@@ -168,6 +168,7 @@ enum TY : ubyte
     Tmixin,
     Tnoreturn,
     Ttag,
+    Tbitfield,
     TMAX
 }
 
@@ -219,6 +220,7 @@ alias Ttraits = TY.Ttraits;
 alias Tmixin = TY.Tmixin;
 alias Tnoreturn = TY.Tnoreturn;
 alias Ttag = TY.Ttag;
+alias Tbitfield = TY.Tbitfield;
 alias TMAX = TY.TMAX;
 
 enum TFlags

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -266,6 +266,26 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+class BitfieldDeclaration : public VarDeclaration
+{
+public:
+    Expression *width;
+    VarDeclaration *unitfield;
+    unsigned bitoffset;
+
+    BitfieldDeclaration *syntaxCopy(Dsymbol *);
+    void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
+    BitfieldDeclaration *isBitfieldDeclaration() { return this; }
+    void accept(Visitor *v) { v->visit(this); }
+};
+
+class AnonBitfieldDeclaration : public BitfieldDeclaration
+{
+public:
+    AnonBitfieldDeclaration *isAnonBitfieldDeclaration() { return this; }
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 /**************************************************************/
 
 // This is a shell around a back end symbol

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -216,6 +216,7 @@ private immutable char[TMAX] mangleChar =
     Ttraits      : '@',
     Tmixin       : '@',
     Ttag         : '@',
+    Tbitfield    : '@',
     Tnoreturn    : '@',         // becomes 'Nn'
 ];
 

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1229,6 +1229,8 @@ extern (C++) class Dsymbol : ASTNode
     inout(ExpressionDsymbol)           isExpressionDsymbol()           inout { return null; }
     inout(AliasAssign)                 isAliasAssign()                 inout { return null; }
     inout(ThisDeclaration)             isThisDeclaration()             inout { return null; }
+    inout(BitfieldDeclaration)         isBitfieldDeclaration()         inout { return null; }
+    inout(AnonBitfieldDeclaration)     isAnonBitfieldDeclaration()     inout { return null; }
     inout(TypeInfoDeclaration)         isTypeInfoDeclaration()         inout { return null; }
     inout(TupleDeclaration)            isTupleDeclaration()            inout { return null; }
     inout(AliasDeclaration)            isAliasDeclaration()            inout { return null; }

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -22,6 +22,7 @@ struct Scope;
 class DsymbolTable;
 class Declaration;
 class ThisDeclaration;
+class BitfieldDeclaration;
 class TypeInfoDeclaration;
 class TupleDeclaration;
 class AliasDeclaration;
@@ -240,6 +241,8 @@ public:
     virtual ExpressionDsymbol *isExpressionDsymbol() { return NULL; }
     virtual AliasAssign *isAliasAssign() { return NULL; }
     virtual ThisDeclaration *isThisDeclaration() { return NULL; }
+    virtual BitfieldDeclaration *isBitfieldDeclaration() { return NULL; }
+    virtual BitfieldDeclaration *isAnonBitfieldDeclaration() { return NULL; }
     virtual TypeInfoDeclaration *isTypeInfoDeclaration() { return NULL; }
     virtual TupleDeclaration *isTupleDeclaration() { return NULL; }
     virtual AliasDeclaration *isAliasDeclaration() { return NULL; }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1770,6 +1770,28 @@ public:
         bodyToBuffer(d);
     }
 
+    override void visit(BitfieldDeclaration d)
+    {
+        if (stcToBuffer(buf, d.storage_class))
+            buf.writeByte(' ');
+        typeToBuffer(d.type, d.ident, buf, hgs);
+        buf.writestring(" : ");
+        d.width.expressionToBuffer(buf, hgs);
+        buf.writeByte(';');
+        buf.writenl();
+    }
+
+    override void visit(AnonBitfieldDeclaration d)
+    {
+        if (stcToBuffer(buf, d.storage_class))
+            buf.writeByte(' ');
+        typeToBuffer(d.type, null, buf, hgs);
+        buf.writestring(" : ");
+        d.width.expressionToBuffer(buf, hgs);
+        buf.writeByte(';');
+        buf.writenl();
+    }
+
     override void visit(Module m)
     {
         moduleToBuffer2(m, buf, hgs);
@@ -3850,6 +3872,11 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
             buf.writestring(t.id.toChars());
     }
 
+    void visitBitfield(TypeBitfield t)
+    {
+        buf.printf("bit[%u]", cast(uint)t.bitsize);
+    }
+
     void visitTuple(TypeTuple t)
     {
         parametersToBuffer(ParameterList(t.arguments, VarArg.none), buf, hgs);
@@ -3912,5 +3939,6 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
         case Tmixin:     return visitMixin(cast(TypeMixin)t);
         case Tnoreturn:  return visitNoreturn(cast(TypeNoreturn)t);
         case Ttag:       return visitTag(cast(TypeTag)t);
+        case Tbitfield:  return visitBitfield(cast(TypeBitfield)t);
     }
 }

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -97,6 +97,8 @@ enum class TY : uint8_t
     Ttraits,
     Tmixin,
     Tnoreturn,
+    Ttag,
+    Tbitfield,
     TMAX
 };
 
@@ -338,6 +340,7 @@ public:
     TypeTraits *isTypeTraits();
     TypeNoreturn *isTypeNoreturn();
     TypeTag *isTypeTag();
+    TypeBitfield *isTypeBitfield();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -907,7 +910,21 @@ public:
 class TypeTag final : public Type
 {
 public:
+    const char *kind();
     TypeTag *syntaxCopy();
+
+    void accept(Visitor *v) { v->visit(this); }
+};
+
+class TypeBitfield : public Type
+{
+public:
+    Type *basetype;
+    unsigned bitsize;
+
+    const char *kind();
+    TypeBitfield *syntaxCopy();
+    d_uns64 size(const Loc& loc) /* const */;
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -90,6 +90,8 @@ public:
     void visit(AST.ClassDeclaration s) { visit(cast(AST.AggregateDeclaration)s); }
     void visit(AST.InterfaceDeclaration s) { visit(cast(AST.ClassDeclaration)s); }
     void visit(AST.TemplateMixin s) { visit(cast(AST.TemplateInstance)s); }
+    void visit(AST.BitfieldDeclaration s) { visit(cast(AST.VarDeclaration)s); }
+    void visit(AST.AnonBitfieldDeclaration s) { visit(cast(AST.Declaration)s); }
 
     //============================================================================================
     // Statements
@@ -151,6 +153,7 @@ public:
     void visit(AST.TypeTraits t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeMixin t) { visit(cast(AST.Type)t); }
     void visit(AST.TypeTag t) { visit(cast(AST.Type)t); }
+    void visit(AST.TypeBitfield t) { visit(cast(AST.Type)t); }
 
     // TypeNext
     void visit(AST.TypeReference t) { visit(cast(AST.TypeNext)t); }

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -85,6 +85,7 @@ class TypeNoreturn;
 class TypeTraits;
 class TypeMixin;
 class TypeTag;
+class TypeBitfield;
 
 class Dsymbol;
 
@@ -139,6 +140,8 @@ class OverDeclaration;
 class VarDeclaration;
 class SymbolDeclaration;
 class ThisDeclaration;
+class BitfieldDeclaration;
+class AnonBitfieldDeclaration;
 
 class TypeInfoDeclaration;
 class TypeInfoStructDeclaration;
@@ -382,6 +385,8 @@ public:
     virtual void visit(ClassDeclaration *s) { visit((AggregateDeclaration *)s); }
     virtual void visit(InterfaceDeclaration *s) { visit((ClassDeclaration *)s); }
     virtual void visit(TemplateMixin *s) { visit((TemplateInstance *)s); }
+    virtual void visit(BitfieldDeclaration *s) { visit((VarDeclaration *)s); }
+    virtual void visit(AnonBitfieldDeclaration *s) { visit((Declaration *)s); }
 
     // Statements
     virtual void visit(ImportStatement *s) { visit((Statement *)s); }
@@ -441,6 +446,7 @@ public:
     virtual void visit(TypeTraits *t) { visit((Type *)t); }
     virtual void visit(TypeMixin *t) { visit((Type *)t); }
     virtual void visit(TypeTag *t) { visit((Type *)t); }
+    virtual void visit(TypeBitfield *t) { visit((Type *)t); }
 
     // TypeNext
     virtual void visit(TypeReference *t) { visit((TypeNext *)t); }


### PR DESCRIPTION
Currently WIP so there may be more improvements to come if any simpler methods arise, but the initial POC is pretty much complete, so opening up for review.

There's going to be quite a bit of logic that'll have to be moved to the `Target` structure to deal with:
1. MS bit-field layout vs. GCC bit-field layout.
2. MS alignment rules for zero-sized bit-fields vs GCC bit-fields
3. Anonymous bit-fields that alter the alignment of the structure.

Implementation only attempts to be compatible with GCC targeting x86/64.

DMD back-end supports bit-fields, but this is not implemented yet. The front-end just "lowers" bit-fields to their storage unit types.  This obviously should be fixed to have more 1st class support.

Current state of affairs:
```
struct A {
    unsigned a : 11, : 0, b : 16;
};
_Static_assert(_Alignof(struct A) == 4, "ok");
_Static_assert(sizeof(struct A) == 8, "ok");

struct B {
    unsigned a : 11;
    short : 0;
    unsigned b : 16;
};
_Static_assert(_Alignof(struct B) == 4, "ok");
_Static_assert(sizeof(struct B) == 4, "ok");

struct C {
    int : 32, : 32, : 32, : 32, : 32, : 32, : 8;
}
_Static_assert(_Alignof(struct C) == 1, "ok");
_Static_assert(sizeof(struct C) == 25, "ok");
------------------------------------------------------------
(gdb) pt test.A
type = struct test.A {
    ushort __bitfield2;
    ushort __bitfield3;
}
(gdb) pt test.B
type = struct test.B {
    ushort __bitfield4;
    ushort __bitfield5;
}
(gdb) pt test.C
type = struct test.C {
    ubyte __bitfield6[25];
}
(gdb) p &((test.A *)0).__bitfield3
$1 = (ushort *) 0x4
(gdb) p &((test.B *)0).__bitfield5
$2 = (ushort *) 0x2
```
