### PR TITLE
fix Issue 22060 - importC: Multiple forward declarations result in error struct conflicts with struct

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -774,6 +774,26 @@ extern (C++) class Dsymbol : ASTNode
             if (isAliasDeclaration() && !_scope)
                 setScope(sc);
             Dsymbol s2 = sds.symtabLookup(this,ident);
+
+            // If using C prototype/forward declaration rules.
+            if (sc.flags & SCOPE.Cfile)
+            {
+                if (auto sd = isStructDeclaration())
+                {
+                    if (auto sd2 = s2.isStructDeclaration())
+                    {
+                        // Not a redeclaration if one is a forward declaration.
+                        // Move members to the first declared type.
+                        if (!sd.members || !sd2.members)
+                        {
+                            if (!sd2.members)
+                                sd2.members = sd.members;
+                            sd.members = null;
+                            return;
+                        }
+                    }
+                }
+            }
             if (!s2.overloadInsert(this))
             {
                 sds.multiplyDefined(Loc.initial, this, s2);

--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -166,3 +166,16 @@ struct S22028
     const int cfield;
     _Static_assert(1 == 1, "ok");
 };
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22060
+
+struct S22060;
+typedef struct S22060 T22060a;
+struct S22060;
+typedef struct S22060 T22060b;
+struct S22060;
+struct S22060
+{
+    int _flags;
+};


### PR DESCRIPTION
~The fix for both struct and enums turned out to be in the same place, so bundling both together.~

Just fixing structs.

Looking at the type semantic for TypeTag, the same thing is done.