### PR TITLE
ImportC: MOD bits only apply before declarator, not after

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1423,6 +1423,12 @@ final class CParser(AST) : Parser!AST
             return;
         }
 
+        if (tspec && specifier.mod & MOD.xconst)
+        {
+            tspec = toConst(tspec);
+            specifier.mod = MOD.xnone;          // 'used' it
+        }
+
         bool first = true;
         while (1)
         {
@@ -1434,11 +1440,6 @@ final class CParser(AST) : Parser!AST
                 panic();
                 nextToken();
                 break;          // error recovery
-            }
-
-            if (specifier.mod & MOD.xconst)
-            {
-                dt = toConst(dt);
             }
 
             /* GNU Extensions


### PR DESCRIPTION
The MOD bits that are applied after are done inside cparseDeclarator()