### PR TITLE
Add tests Issue 22061 - importC: Error: alias 'TYPE' conflicts with union 'TYPE'

### DIFF
--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -186,6 +186,15 @@ struct S22060
 };
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22061
+
+union S22061
+{
+    int field;
+};
+typedef union S22061 S22061;
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22063
 
 typedef struct S22063_t

--- a/test/fail_compilation/failcstuff3.c
+++ b/test/fail_compilation/failcstuff3.c
@@ -1,0 +1,15 @@
+// check importAll analysis of C files
+/* TEST_OUTPUT:
+---
+fail_compilation/failcstuff3.c(54): Error: redeclaration of `S22061`
+---
+*/
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22061
+#line 50
+struct S22061
+{
+    int field;
+};
+typedef union S22061 S22061;


### PR DESCRIPTION
Don't issue multiply defined errors for typedefs of already declared types when `SCOPE.Cfile`.  Forwarding collisions in `Dsymbol.addMember` onto `typeSemantic` to either resolve the type, or issue a redeclaration error.