### PR TITLE
dmd.typesem: Remove self referenced import

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -60,7 +60,6 @@ import dmd.semantic3;
 import dmd.sideeffect;
 import dmd.target;
 import dmd.tokens;
-import dmd.typesem;
 
 /**************************
  * This evaluates exp while setting length to be the number


### PR DESCRIPTION
This got added in #7217, possibly mechanically.