### PR TITLE
fix Issue 22068 - importC: cast-expression accepted as lvalue in unary-expression

### DIFF
--- a/test/fail_compilation/failcstuff1.d
+++ b/test/fail_compilation/failcstuff1.d
@@ -25,6 +25,11 @@ fail_compilation/imports/cstuff1.c(410): Error: identifier or `(` expected
 fail_compilation/imports/cstuff1.c(451): Error: illegal type combination
 fail_compilation/imports/cstuff1.c(502): Error: found `2` when expecting `:`
 fail_compilation/imports/cstuff1.c(502): Error: found `:` instead of statement
+fail_compilation/imports/cstuff1.c(603): Error: expression expected, not `short`
+fail_compilation/imports/cstuff1.c(603): Error: found `var` when expecting `;` following statement
+fail_compilation/imports/cstuff1.c(604): Error: expression expected, not `long`
+fail_compilation/imports/cstuff1.c(604): Error: found `long` when expecting `)`
+fail_compilation/imports/cstuff1.c(604): Error: found `)` when expecting `;` following statement
 ---
 */
 import imports.cstuff1;

--- a/test/fail_compilation/imports/cstuff1.c
+++ b/test/fail_compilation/imports/cstuff1.c
@@ -68,3 +68,12 @@ void test22035()
 {
     case 1 2:
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=22068
+#line 600
+void test22068()
+{
+    int var;
+    ++(short) var;
+    --(long long) var;
+}


### PR DESCRIPTION
Disentangles `cast-expression` and `postfix-expression` from `cparseUnaryExp`.