### PR TITLE
fix Issue 22067 - importC: cast-expression accepted as lvalue in assignment-expression

### DIFF
--- a/src/dmd/astcodegen.d
+++ b/src/dmd/astcodegen.d
@@ -41,6 +41,7 @@ struct ASTCodegen
     alias typeToExpression          = dmd.typesem.typeToExpression;
     alias UserAttributeDeclaration  = dmd.attrib.UserAttributeDeclaration;
     alias Ensure                    = dmd.func.Ensure; // workaround for bug in older DMD frontends
+    alias ErrorExp                  = dmd.expression.ErrorExp;
 
     alias MODFlags                  = dmd.mtype.MODFlags;
     alias Type                      = dmd.mtype.Type;

--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -755,11 +755,11 @@ final class CParser(AST) : Parser!AST
                 break;
 
             case TOK.plusPlus:
-                e = new AST.PostExp(TOK.plusPlus, loc, e);
+                e = new AST.PostExp(TOK.plusPlus, loc, toCLvalue(e, LVAL.increment));
                 break;
 
             case TOK.minusMinus:
-                e = new AST.PostExp(TOK.minusMinus, loc, e);
+                e = new AST.PostExp(TOK.minusMinus, loc, toCLvalue(e, LVAL.decrement));
                 break;
 
             case TOK.leftParenthesis:
@@ -813,19 +813,19 @@ final class CParser(AST) : Parser!AST
         case TOK.plusPlus:
             nextToken();
             e = cparseUnaryExp();
-            e = new AST.PreExp(TOK.prePlusPlus, loc, e);
+            e = new AST.PreExp(TOK.prePlusPlus, loc, toCLvalue(e, LVAL.increment));
             break;
 
         case TOK.minusMinus:
             nextToken();
             e = cparseUnaryExp();
-            e = new AST.PreExp(TOK.preMinusMinus, loc, e);
+            e = new AST.PreExp(TOK.preMinusMinus, loc, toCLvalue(e, LVAL.decrement));
             break;
 
         case TOK.and:
             nextToken();
             e = cparseCastExp();
-            e = new AST.AddrExp(loc, e);
+            e = new AST.AddrExp(loc, toCLvalue(e, LVAL.address));
             break;
 
         case TOK.mul:
@@ -1257,7 +1257,7 @@ final class CParser(AST) : Parser!AST
         case TOK.assign:
             nextToken();
             auto e2 = cparseAssignExp();
-            e = new AST.AssignExp(loc, e, e2);
+            e = new AST.AssignExp(loc, toCLvalue(e, LVAL.assign), e2);
             break;
 
         case TOK.addAssign:
@@ -3911,6 +3911,85 @@ final class CParser(AST) : Parser!AST
         else
             t = t.addSTC(STC.const_);
         return t;
+    }
+
+    /// Types of expressions where an lvalue is required.
+    enum LVAL
+    {
+        assign,     // 6.5.16 assignment operator
+        increment,  // 6.5.3.1 and 6.5.2.4 increment operator
+        decrement,  // 6.5.3.1 and 6.5.2.4 decrement operator
+        address,    // 6.5.3.2 address operator
+    }
+
+    /**************************
+     * C11 6.3.2.1
+     * Check to see if expression is a valid lvalue for C11.
+     * Prints an error message if it's not.
+     * Params:
+     *    e = expression to check
+     *    lvalue = how the lvalue is used
+     * Returns:
+     *    the expression if an lvalue, otherwise ErrorExp
+     */
+    private AST.Expression toCLvalue(AST.Expression e, LVAL lvalue)
+    {
+        switch (e.op)
+        {
+            /* References:
+            /* C11 6.5.2.5-4:
+             *  The result of a compound literal is an lvalue.
+             * C11 6.5.1-4:
+             *  A string literal is an lvalue.
+             */
+            case TOK.compoundLiteral:
+            case TOK.string_:
+                return e;
+
+            /* C11 6.5.3.2-4:
+             *  The unary '*' operator is an lvalue if it points to an object.
+             * C11 6.5.2.1-2:
+             *  The subscript operator '[]' is identical to '*((E1) + (E2))'.
+             * C11 6.5.1-2:
+             *  An identifier is an lvalue provided it is designating an object.
+             * Whether any of these expressions point to an object or function
+             * is deferred to semantic when types get resolved.
+             */
+            case TOK.star:
+            case TOK.array:
+            case TOK.identifier:
+                return e;
+
+            /* C11 6.5.2.3-3:
+             *  A postfix expression followed by the '.' or '->' operator is an
+             *  lvalue if the first expression is an lvalue.
+             */
+            case TOK.dotIdentifier:
+                auto e1 = toCLvalue(e.isDotIdExp().e1, lvalue);
+                if (e1.op == TOK.error)
+                    return e1;
+                return e;
+
+            default:
+                break;
+        }
+        // No match against known lvalues, print and return an error.
+        final switch (lvalue)
+        {
+            case LVAL.assign:
+                e.error("left operand is not assignable");
+                break;
+            case LVAL.increment:
+                e.error("increment operand is not assignable");
+                break;
+            case LVAL.decrement:
+                e.error("decrement operand is not assignable");
+                break;
+            case LVAL.address:
+                e.error("cannot take address of unary operand");
+                break;
+        }
+        return AST.ErrorExp.get();
     }
 
     //}

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -4738,6 +4738,7 @@ struct ASTCodegen final
     using ThrownExceptionExp = ::ThrownExceptionExp;
     typedef UserAttributeDeclaration* UserAttributeDeclaration;
     typedef Ensure Ensure;
+    typedef ErrorExp* ErrorExp;
     typedef MODFlags MODFlags;
     typedef Type* Type;
     typedef Parameter* Parameter;

--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -197,6 +197,24 @@ void test22063()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22067
+
+void test22067()
+{
+    union U {
+        int value;
+        char *ptr;
+        char array[4];
+    } var;
+    union U *pvar = &var;
+    var.value = 0xabcdef;
+    var.array[0]++;
+    (*var.ptr)--;
+    ++(*pvar).value;
+    --(*pvar).array[3];
+}
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22069
 
 void test22069()

--- a/test/fail_compilation/failcstuff1.d
+++ b/test/fail_compilation/failcstuff1.d
@@ -25,10 +25,21 @@ fail_compilation/imports/cstuff1.c(410): Error: identifier or `(` expected
 fail_compilation/imports/cstuff1.c(451): Error: illegal type combination
 fail_compilation/imports/cstuff1.c(502): Error: found `2` when expecting `:`
 fail_compilation/imports/cstuff1.c(502): Error: found `:` instead of statement
+fail_compilation/imports/cstuff1.c(553): Error: left operand is not assignable
+fail_compilation/imports/cstuff1.c(554): Error: left operand is not assignable
+fail_compilation/imports/cstuff1.c(555): Error: expression expected, not `short`
+fail_compilation/imports/cstuff1.c(555): Error: increment operand is not assignable
+fail_compilation/imports/cstuff1.c(555): Error: found `3` when expecting `;` following statement
+fail_compilation/imports/cstuff1.c(556): Error: decrement operand is not assignable
+fail_compilation/imports/cstuff1.c(557): Error: increment operand is not assignable
+fail_compilation/imports/cstuff1.c(558): Error: decrement operand is not assignable
+fail_compilation/imports/cstuff1.c(559): Error: cannot take address of unary operand
 fail_compilation/imports/cstuff1.c(603): Error: expression expected, not `short`
+fail_compilation/imports/cstuff1.c(603): Error: increment operand is not assignable
 fail_compilation/imports/cstuff1.c(603): Error: found `var` when expecting `;` following statement
 fail_compilation/imports/cstuff1.c(604): Error: expression expected, not `long`
 fail_compilation/imports/cstuff1.c(604): Error: found `long` when expecting `)`
+fail_compilation/imports/cstuff1.c(604): Error: decrement operand is not assignable
 fail_compilation/imports/cstuff1.c(604): Error: found `)` when expecting `;` following statement
 ---
 */

--- a/test/fail_compilation/imports/cstuff1.c
+++ b/test/fail_compilation/imports/cstuff1.c
@@ -69,6 +69,20 @@ void test22035()
     case 1 2:
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=22067
+#line 550
+void test22067()
+{
+    int var;
+    (int) var = 1;
+    sizeof(var) = 2;
+    ++(short)3;
+    --4;
+    (5)++;
+    ((int)var)--;
+    (&6);
+}
+
 // https://issues.dlang.org/show_bug.cgi?id=22068
 #line 600
 void test22068()


### PR DESCRIPTION
Without having to go though the D semantic and modify each place where there's deviation from C, just check that each kind of expression is a valid lvalue in C11 if used in one of the contexts where an lvalue is required during CParse.  This only deals with `op` codes, the Expression semantic pass can deal with more complex errors later - such as wrong type or assigning to `const`.