### PR TITLE
fix Issue 22080 - ImportC: Error: cannot implicitly convert expression of type 'extern(C) function' to 'function'

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1584,6 +1584,14 @@ final class CParser(AST) : Parser!AST
             }
             if (s !is null)
             {
+                if (level == LVL.local)
+                {
+                    // Wrap the declaration in `extern (C) { declaration }`
+                    // Necessary for function pointers, but harmless to apply to all.
+                    auto decls = new AST.Dsymbols(1);
+                    (*decls)[0] = s;
+                    s = new AST.LinkDeclaration(s.loc, linkage, decls);
+                }
                 // Saw `asm("name")` in the function, type, or variable definition.
                 // This maps directly to `pragma(mangle, "name")`
                 if (asmname)

--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -210,3 +210,13 @@ void test22069()
     ~var;
     !var;
 }
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22080
+
+int F22080(const char *);
+
+int test22080()
+{
+    int (*fun)(const char *) = &F22080;
+}


### PR DESCRIPTION
In D, the declaration `extern(C) int function() var` is represented as `Link(C, Var(Pointer(Function(C, int, ())), var))`.
In CParser, we were forgetting to add in the `LinkDeclaration` to ensure that `extern(C)` is applied to local function variables.

Here, I just apply `extern(C)` to all locally defined variables, regardless of type and storage as it's harmless to do so.  To be more strict, this can be adjusted to only apply to function pointers, and all variables with static storage.  The only necessary kind of declaration that needs this though are function pointers, so I'm open to being more restrictive.