### PR TITLE
fix Issue 22079 - importC: Error: '=', ';' or ',' expected taking sizeof compound literal

### DIFF
--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -217,6 +217,17 @@ void test22069()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22079
+
+struct S22079
+{
+    int a, b, c;
+};
+
+_Static_assert(sizeof(struct S22079){1,2,3} == sizeof(int)*3, "ok");
+_Static_assert(sizeof(struct S22079){1,2,3}.a == sizeof(int), "ok");
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22080
 
 int F22080(const char *);


### PR DESCRIPTION
Doesn't parse postfix operators after consuming the compound literal, that is what #12740 does.