### PR TITLE
fix Issue 22069 - importC: Error: found '&' instead of statement

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -187,9 +187,11 @@ final class CParser(AST) : Parser!AST
         case TOK.imaginary64Literal:
         case TOK.imaginary80Literal:
         case TOK.leftParenthesis:
+        case TOK.and:
         case TOK.mul:
         case TOK.min:
         case TOK.add:
+        case TOK.tilde:
         case TOK.not:
         case TOK.plusPlus:
         case TOK.minusMinus:

--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -195,3 +195,18 @@ void test22063()
     S22063 v3 = { 0 };
     S22063 *v4 = 0;
 }
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22069
+
+void test22069()
+{
+    int var;
+    int *ptr;
+    &var;
+    *ptr;
+    +var;
+    -var;
+    ~var;
+    !var;
+}


### PR DESCRIPTION
the unary operators `&` and `~` were not being handled in `cparseStatement`.