### PR TITLE
fix Issue 21977 - importC: Global declarations are thread-local by default

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -3802,6 +3802,8 @@ final class CParser(AST) : Parser!AST
             {
                 if (specifier.scw & SCW.xextern)
                    stc = AST.STC.extern_ | AST.STC.gshared;
+                else
+                    stc = AST.STC.gshared;
             }
             else if (level == LVL.local)
             {

--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -149,6 +149,11 @@ struct S21973
 };
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=21977
+int test21977a;
+_Thread_local int test21977b;
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=21982
 
 struct S21982 { int field; };


### PR DESCRIPTION
Always set `__gshared` for global variables that don't have `_Thread_local` storage.