### PR TITLE
add astenums.d, removing over 230 lines of redundant code

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1329,7 +1329,7 @@ auto sourceFiles()
         "),
         frontend: fileArray(env["D"], "
             access.d aggregate.d aliasthis.d apply.d argtypes_x86.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d
-            arraytypes.d ast_node.d astcodegen.d asttypename.d attrib.d blockexit.d builtin.d canthrow.d chkformat.d
+            arraytypes.d astenums.d ast_node.d astcodegen.d asttypename.d attrib.d blockexit.d builtin.d canthrow.d chkformat.d
             cli.d clone.d compiler.d complex.d cond.d constfold.d cppmangle.d cppmanglewin.d ctfeexpr.d
             ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d dimport.d
             dinterpret.d dmacro.d dmangle.d dmodule.d doc.d dscope.d dstruct.d dsymbol.d dsymbolsem.d

--- a/src/dmd/README.md
+++ b/src/dmd/README.md
@@ -77,6 +77,7 @@ Note that these groups have no strict meaning, the category assignments are a bi
 | [ast_node.d](https://github.com/dlang/dmd/blob/master/src/dmd/ast_node.d)         | Define an abstract AST node class                           |
 | [astbase.d](https://github.com/dlang/dmd/blob/master/src/dmd/astbase.d)           | Namespace of AST nodes that can be produced by the parser   |
 | [astcodegen.d](https://github.com/dlang/dmd/blob/master/src/dmd/astcodegen.d)     | Namespace of AST nodes of a AST ready for code generation   |
+| [astenums.d](https://github.com/dlang/dmd/blob/master/src/dmd/astenums.d)         | Enums common to DMD and AST                                 |
 | [expression.d](https://github.com/dlang/dmd/blob/master/src/dmd/expression.d)     | Define expression AST nodes                                 |
 | [statement.d](https://github.com/dlang/dmd/blob/master/src/dmd/statement.d)       | Define statement AST nodes                                  |
 | [staticassert.d](https://github.com/dlang/dmd/blob/master/src/dmd/staticassert.d) | Define a `static assert` AST node                           |

--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -14,6 +14,7 @@
 module dmd.access;
 
 import dmd.aggregate;
+import dmd.astenums;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dmodule;

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -20,6 +20,7 @@ import core.checkedint;
 import dmd.aliasthis;
 import dmd.apply;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.gluelayer : Symbol;
 import dmd.declaration;
 import dmd.dscope;
@@ -37,22 +38,6 @@ import dmd.mtype;
 import dmd.tokens;
 import dmd.typesem : defaultInit;
 import dmd.visitor;
-
-enum Sizeok : ubyte
-{
-    none,           /// size of aggregate is not yet able to compute
-    fwd,            /// size of aggregate is ready to compute
-    inProcess,      /// in the midst of computing the size
-    done,           /// size of aggregate is set correctly
-}
-
-enum Baseok : ubyte
-{
-    none,             /// base classes not computed yet
-    start,            /// in process of resolving base classes
-    done,             /// all base classes are resolved
-    semanticdone,     /// all base classes semantic done
-}
 
 /**
  * The ClassKind enum is used in AggregateDeclaration AST nodes to

--- a/src/dmd/argtypes_aarch64.d
+++ b/src/dmd/argtypes_aarch64.d
@@ -11,6 +11,7 @@
 
 module dmd.argtypes_aarch64;
 
+import dmd.astenums;
 import dmd.mtype;
 
 /****************************************************

--- a/src/dmd/argtypes_sysv_x64.d
+++ b/src/dmd/argtypes_sysv_x64.d
@@ -11,6 +11,7 @@
 
 module dmd.argtypes_sysv_x64;
 
+import dmd.astenums;
 import dmd.declaration;
 import dmd.globals;
 import dmd.mtype;

--- a/src/dmd/argtypes_x86.d
+++ b/src/dmd/argtypes_x86.d
@@ -14,6 +14,7 @@ module dmd.argtypes_x86;
 import core.stdc.stdio;
 import core.checkedint;
 
+import dmd.astenums;
 import dmd.declaration;
 import dmd.globals;
 import dmd.mtype;

--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -15,6 +15,7 @@ module dmd.arrayop;
 
 import core.stdc.stdio;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.declaration;
 import dmd.dscope;
 import dmd.dsymbol;

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -10,6 +10,7 @@
 
 module dmd.astbase;
 
+import dmd.astenums;
 import dmd.parsetimevisitor;
 
 /** The ASTBase  family defines a family of AST nodes appropriate for parsing with
@@ -54,99 +55,6 @@ struct ASTBase
     alias Designators           = Array!(Designator);
     alias DesigInits            = Array!(DesigInit);
 
-    enum Sizeok : ubyte
-    {
-        none,               // size of aggregate is not yet able to compute
-        fwd,                // size of aggregate is ready to compute
-        done,               // size of aggregate is set correctly
-    }
-
-    enum Baseok : ubyte
-    {
-        none,               // base classes not computed yet
-        start,              // in process of resolving base classes
-        done,               // all base classes are resolved
-        semanticdone,       // all base classes semantic done
-    }
-
-    enum MODFlags : int
-    {
-        const_       = 1,    // type is const
-        immutable_   = 4,    // type is immutable
-        shared_      = 2,    // type is shared
-        wild         = 8,    // type is wild
-        wildconst    = (MODFlags.wild | MODFlags.const_), // type is wild const
-        mutable      = 0x10, // type is mutable (only used in wildcard matching)
-    }
-
-    alias MOD = ubyte;
-
-    enum STC : ulong
-    {
-        undefined_          = 0L,
-        static_             = (1L << 0),
-        extern_             = (1L << 1),
-        const_              = (1L << 2),
-        final_              = (1L << 3),
-        abstract_           = (1L << 4),
-        parameter           = (1L << 5),
-        field               = (1L << 6),
-        override_           = (1L << 7),
-        auto_               = (1L << 8),
-        synchronized_       = (1L << 9),
-        deprecated_         = (1L << 10),
-        in_                 = (1L << 11),   // in parameter
-        out_                = (1L << 12),   // out parameter
-        lazy_               = (1L << 13),   // lazy parameter
-        foreach_            = (1L << 14),   // variable for foreach loop
-                              //(1L << 15)
-        variadic            = (1L << 16),   // the 'variadic' parameter in: T foo(T a, U b, V variadic...)
-        ctorinit            = (1L << 17),   // can only be set inside constructor
-        templateparameter   = (1L << 18),   // template parameter
-        scope_              = (1L << 19),
-        immutable_          = (1L << 20),
-        ref_                = (1L << 21),
-        init                = (1L << 22),   // has explicit initializer
-        manifest            = (1L << 23),   // manifest constant
-        nodtor              = (1L << 24),   // don't run destructor
-        nothrow_            = (1L << 25),   // never throws exceptions
-        pure_               = (1L << 26),   // pure function
-        tls                 = (1L << 27),   // thread local
-        alias_              = (1L << 28),   // alias parameter
-        shared_             = (1L << 29),   // accessible from multiple threads
-        gshared             = (1L << 30),   // accessible from multiple threads, but not typed as "shared"
-        wild                = (1L << 31),   // for "wild" type constructor
-        property            = (1L << 32),
-        safe                = (1L << 33),
-        trusted             = (1L << 34),
-        system              = (1L << 35),
-        ctfe                = (1L << 36),   // can be used in CTFE, even if it is static
-        disable             = (1L << 37),   // for functions that are not callable
-        result              = (1L << 38),   // for result variables passed to out contracts
-        nodefaultctor       = (1L << 39),   // must be set inside constructor
-        temp                = (1L << 40),   // temporary variable
-        rvalue              = (1L << 41),   // force rvalue for variables
-        nogc                = (1L << 42),   // @nogc
-        volatile_           = (1L << 43),   // destined for volatile in the back end
-        return_             = (1L << 44),   // 'return ref' or 'return scope' for function parameters
-        autoref             = (1L << 45),   // Mark for the already deduced 'auto ref' parameter
-        inference           = (1L << 46),   // do attribute inference
-        exptemp             = (1L << 47),   // temporary variable that has lifetime restricted to an expression
-        maybescope          = (1L << 48),   // parameter might be 'scope'
-        scopeinferred       = (1L << 49),   // 'scope' has been inferred and should not be part of mangling
-        future              = (1L << 50),   // introducing new base class function
-        local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
-        returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
-        live                = (1L << 53),   // function @live attribute
-        register            = (1L << 54),   // `register` storage class
-
-        safeGroup = STC.safe | STC.trusted | STC.system,
-        IOR  = STC.in_ | STC.ref_ | STC.out_,
-        TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
-        FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.live |
-                    safeGroup),
-    }
-
     extern (C++) __gshared const(StorageClass) STCStorageClass =
         (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ |
          STC.abstract_ | STC.synchronized_ | STC.deprecated_ | STC.override_ | STC.lazy_ |
@@ -154,172 +62,6 @@ struct ASTBase
          STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls |
          STC.gshared | STC.property | STC.future | STC.local | STC.live |
          STC.safeGroup | STC.disable);
-
-    enum TY : ubyte
-    {
-        Tarray,     // slice array, aka T[]
-        Tsarray,    // static array, aka T[dimension]
-        Taarray,    // associative array, aka T[type]
-        Tpointer,
-        Treference,
-        Tfunction,
-        Tident,
-        Tclass,
-        Tstruct,
-        Tenum,
-
-        Tdelegate,
-        Tnone,
-        Tvoid,
-        Tint8,
-        Tuns8,
-        Tint16,
-        Tuns16,
-        Tint32,
-        Tuns32,
-        Tint64,
-
-        Tuns64,
-        Tfloat32,
-        Tfloat64,
-        Tfloat80,
-        Timaginary32,
-        Timaginary64,
-        Timaginary80,
-        Tcomplex32,
-        Tcomplex64,
-        Tcomplex80,
-
-        Tbool,
-        Tchar,
-        Twchar,
-        Tdchar,
-        Terror,
-        Tinstance,
-        Ttypeof,
-        Ttuple,
-        Tslice,
-        Treturn,
-
-        Tnull,
-        Tvector,
-        Tint128,
-        Tuns128,
-        Ttraits,
-        Tmixin,
-        Tnoreturn,
-        Ttag,
-        TMAX
-    }
-
-    alias Tarray = TY.Tarray;
-    alias Tsarray = TY.Tsarray;
-    alias Taarray = TY.Taarray;
-    alias Tpointer = TY.Tpointer;
-    alias Treference = TY.Treference;
-    alias Tfunction = TY.Tfunction;
-    alias Tident = TY.Tident;
-    alias Tclass = TY.Tclass;
-    alias Tstruct = TY.Tstruct;
-    alias Tenum = TY.Tenum;
-    alias Tdelegate = TY.Tdelegate;
-    alias Tnone = TY.Tnone;
-    alias Tvoid = TY.Tvoid;
-    alias Tint8 = TY.Tint8;
-    alias Tuns8 = TY.Tuns8;
-    alias Tint16 = TY.Tint16;
-    alias Tuns16 = TY.Tuns16;
-    alias Tint32 = TY.Tint32;
-    alias Tuns32 = TY.Tuns32;
-    alias Tint64 = TY.Tint64;
-    alias Tuns64 = TY.Tuns64;
-    alias Tfloat32 = TY.Tfloat32;
-    alias Tfloat64 = TY.Tfloat64;
-    alias Tfloat80 = TY.Tfloat80;
-    alias Timaginary32 = TY.Timaginary32;
-    alias Timaginary64 = TY.Timaginary64;
-    alias Timaginary80 = TY.Timaginary80;
-    alias Tcomplex32 = TY.Tcomplex32;
-    alias Tcomplex64 = TY.Tcomplex64;
-    alias Tcomplex80 = TY.Tcomplex80;
-    alias Tbool = TY.Tbool;
-    alias Tchar = TY.Tchar;
-    alias Twchar = TY.Twchar;
-    alias Tdchar = TY.Tdchar;
-    alias Terror = TY.Terror;
-    alias Tinstance = TY.Tinstance;
-    alias Ttypeof = TY.Ttypeof;
-    alias Ttuple = TY.Ttuple;
-    alias Tslice = TY.Tslice;
-    alias Treturn = TY.Treturn;
-    alias Tnull = TY.Tnull;
-    alias Tvector = TY.Tvector;
-    alias Tint128 = TY.Tint128;
-    alias Tuns128 = TY.Tuns128;
-    alias Ttraits = TY.Ttraits;
-    alias Tmixin = TY.Tmixin;
-    alias Tnoreturn = TY.Tnoreturn;
-    alias Ttag = TY.Ttag;
-    alias TMAX = TY.TMAX;
-
-    enum TFlags
-    {
-        integral     = 1,
-        floating     = 2,
-        unsigned     = 4,
-        real_        = 8,
-        imaginary    = 0x10,
-        complex      = 0x20,
-    }
-
-    enum PKG : int
-    {
-        unknown,     // not yet determined whether it's a package.d or not
-        module_,      // already determined that's an actual package.d
-        package_,     // already determined that's an actual package
-    }
-
-    enum StructPOD : int
-    {
-        no,    // struct is not POD
-        yes,   // struct is POD
-        fwd,   // POD not yet computed
-    }
-
-    enum TRUST : ubyte
-    {
-        default_   = 0,
-        system     = 1,    // @system (same as TRUST.default)
-        trusted    = 2,    // @trusted
-        safe       = 3,    // @safe
-    }
-
-    enum PURE : ubyte
-    {
-        impure      = 0,    // not pure at all
-        fwdref      = 1,    // it's pure, but not known which level yet
-        weak        = 2,    // no mutable globals are read or written
-        const_      = 3,    // parameters are values or const
-        strong      = 4,    // parameters are values or immutable
-    }
-
-    enum AliasThisRec : int
-    {
-        no           = 0,    // no alias this recursion
-        yes          = 1,    // alias this has recursive dependency
-        fwdref       = 2,    // not yet known
-        typeMask     = 3,    // mask to read no/yes/fwdref
-        tracing      = 0x4,  // mark in progress of implicitConvTo/deduceWild
-        tracingDT    = 0x8,  // mark in progress of deduceType
-    }
-
-    enum VarArg : ubyte
-    {
-        none     = 0,  /// fixed number of arguments
-        variadic = 1,  /// T t, ...)  can be C-style (core.stdc.stdarg) or D-style (core.vararg)
-        typesafe = 2,  /// T t ...) typesafe https://dlang.org/spec/function.html#typesafe_variadic_functions
-                       ///   or https://dlang.org/spec/function.html#typesafe_variadic_functions
-    }
 
     alias Visitor = ParseTimeVisitor!ASTBase;
 
@@ -1959,49 +1701,6 @@ struct ASTBase
             return params;
         }
 
-    }
-
-    enum STMT : ubyte
-    {
-        Error,
-        Peel,
-        Exp, DtorExp,
-        Compile,
-        Compound, CompoundDeclaration, CompoundAsm,
-        UnrolledLoop,
-        Scope,
-        Forwarding,
-        While,
-        Do,
-        For,
-        Foreach,
-        ForeachRange,
-        If,
-        Conditional,
-        StaticForeach,
-        Pragma,
-        StaticAssert,
-        Switch,
-        Case,
-        CaseRange,
-        Default,
-        GotoDefault,
-        GotoCase,
-        SwitchError,
-        Return,
-        Break,
-        Continue,
-        Synchronized,
-        With,
-        TryCatch,
-        TryFinally,
-        ScopeGuard,
-        Throw,
-        Debug,
-        Goto,
-        Label,
-        Asm, InlineAsm, GccAsm,
-        Import,
     }
 
     extern (C++) abstract class Statement : ASTNode
@@ -6497,16 +6196,6 @@ struct ASTBase
         {
             v.visit(this);
         }
-    }
-
-    enum InitKind : ubyte
-    {
-        void_,
-        error,
-        struct_,
-        array,
-        exp,
-        C_,
     }
 
     extern (C++) class Initializer : ASTNode

--- a/src/dmd/astenums.d
+++ b/src/dmd/astenums.d
@@ -1,0 +1,347 @@
+/**
+ * Defines enums common to dmd and dmd as parse library.
+ *
+ * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/astenums.d, _astenums.d)
+ * Documentation:  https://dlang.org/phobos/dmd_astenums.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/astenums.d
+ */
+
+module dmd.astenums;
+
+enum Sizeok : ubyte
+{
+    none,               /// size of aggregate is not yet able to compute
+    fwd,                /// size of aggregate is ready to compute
+    inProcess,          /// in the midst of computing the size
+    done,               /// size of aggregate is set correctly
+}
+
+enum Baseok : ubyte
+{
+    none,               /// base classes not computed yet
+    start,              /// in process of resolving base classes
+    done,               /// all base classes are resolved
+    semanticdone,       /// all base classes semantic done
+}
+
+enum MODFlags : int
+{
+    const_       = 1,    // type is const
+    immutable_   = 4,    // type is immutable
+    shared_      = 2,    // type is shared
+    wild         = 8,    // type is wild
+    wildconst    = (MODFlags.wild | MODFlags.const_), // type is wild const
+    mutable      = 0x10, // type is mutable (only used in wildcard matching)
+}
+
+alias MOD = ubyte;
+
+enum STC : ulong
+{
+    undefined_          = 0L,
+    static_             = (1L << 0),
+    extern_             = (1L << 1),
+    const_              = (1L << 2),
+    final_              = (1L << 3),
+    abstract_           = (1L << 4),
+    parameter           = (1L << 5),
+    field               = (1L << 6),
+    override_           = (1L << 7),
+    auto_               = (1L << 8),
+    synchronized_       = (1L << 9),
+    deprecated_         = (1L << 10),
+    in_                 = (1L << 11),   // in parameter
+    out_                = (1L << 12),   // out parameter
+    lazy_               = (1L << 13),   // lazy parameter
+    foreach_            = (1L << 14),   // variable for foreach loop
+                          //(1L << 15)
+    variadic            = (1L << 16),   // the 'variadic' parameter in: T foo(T a, U b, V variadic...)
+    ctorinit            = (1L << 17),   // can only be set inside constructor
+    templateparameter   = (1L << 18),   // template parameter
+    scope_              = (1L << 19),
+    immutable_          = (1L << 20),
+    ref_                = (1L << 21),
+    init                = (1L << 22),   // has explicit initializer
+    manifest            = (1L << 23),   // manifest constant
+    nodtor              = (1L << 24),   // don't run destructor
+    nothrow_            = (1L << 25),   // never throws exceptions
+    pure_               = (1L << 26),   // pure function
+    tls                 = (1L << 27),   // thread local
+    alias_              = (1L << 28),   // alias parameter
+    shared_             = (1L << 29),   // accessible from multiple threads
+    gshared             = (1L << 30),   // accessible from multiple threads, but not typed as "shared"
+    wild                = (1L << 31),   // for "wild" type constructor
+    property            = (1L << 32),
+    safe                = (1L << 33),
+    trusted             = (1L << 34),
+    system              = (1L << 35),
+    ctfe                = (1L << 36),   // can be used in CTFE, even if it is static
+    disable             = (1L << 37),   // for functions that are not callable
+    result              = (1L << 38),   // for result variables passed to out contracts
+    nodefaultctor       = (1L << 39),   // must be set inside constructor
+    temp                = (1L << 40),   // temporary variable
+    rvalue              = (1L << 41),   // force rvalue for variables
+    nogc                = (1L << 42),   // @nogc
+    volatile_           = (1L << 43),   // destined for volatile in the back end
+    return_             = (1L << 44),   // 'return ref' or 'return scope' for function parameters
+    autoref             = (1L << 45),   // Mark for the already deduced 'auto ref' parameter
+    inference           = (1L << 46),   // do attribute inference
+    exptemp             = (1L << 47),   // temporary variable that has lifetime restricted to an expression
+    maybescope          = (1L << 48),   // parameter might be 'scope'
+    scopeinferred       = (1L << 49),   // 'scope' has been inferred and should not be part of mangling
+    future              = (1L << 50),   // introducing new base class function
+    local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
+    returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
+    live                = (1L << 53),   // function @live attribute
+    register            = (1L << 54),   // `register` storage class
+
+    safeGroup = STC.safe | STC.trusted | STC.system,
+    IOR  = STC.in_ | STC.ref_ | STC.out_,
+    TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
+    FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.live |
+                safeGroup),
+}
+
+/* This is different from the one in declaration.d, make that fix a separate PR */
+static if (0)
+extern (C++) __gshared const(StorageClass) STCStorageClass =
+    (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ |
+     STC.abstract_ | STC.synchronized_ | STC.deprecated_ | STC.override_ | STC.lazy_ |
+     STC.alias_ | STC.out_ | STC.in_ | STC.manifest | STC.immutable_ | STC.shared_ |
+     STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls |
+     STC.gshared | STC.property | STC.live |
+     STC.safeGroup | STC.disable);
+
+enum TY : ubyte
+{
+    Tarray,     // slice array, aka T[]
+    Tsarray,    // static array, aka T[dimension]
+    Taarray,    // associative array, aka T[type]
+    Tpointer,
+    Treference,
+    Tfunction,
+    Tident,
+    Tclass,
+    Tstruct,
+    Tenum,
+
+    Tdelegate,
+    Tnone,
+    Tvoid,
+    Tint8,
+    Tuns8,
+    Tint16,
+    Tuns16,
+    Tint32,
+    Tuns32,
+    Tint64,
+
+    Tuns64,
+    Tfloat32,
+    Tfloat64,
+    Tfloat80,
+    Timaginary32,
+    Timaginary64,
+    Timaginary80,
+    Tcomplex32,
+    Tcomplex64,
+    Tcomplex80,
+
+    Tbool,
+    Tchar,
+    Twchar,
+    Tdchar,
+    Terror,
+    Tinstance,
+    Ttypeof,
+    Ttuple,
+    Tslice,
+    Treturn,
+
+    Tnull,
+    Tvector,
+    Tint128,
+    Tuns128,
+    Ttraits,
+    Tmixin,
+    Tnoreturn,
+    Ttag,
+    TMAX
+}
+
+alias Tarray = TY.Tarray;
+alias Tsarray = TY.Tsarray;
+alias Taarray = TY.Taarray;
+alias Tpointer = TY.Tpointer;
+alias Treference = TY.Treference;
+alias Tfunction = TY.Tfunction;
+alias Tident = TY.Tident;
+alias Tclass = TY.Tclass;
+alias Tstruct = TY.Tstruct;
+alias Tenum = TY.Tenum;
+alias Tdelegate = TY.Tdelegate;
+alias Tnone = TY.Tnone;
+alias Tvoid = TY.Tvoid;
+alias Tint8 = TY.Tint8;
+alias Tuns8 = TY.Tuns8;
+alias Tint16 = TY.Tint16;
+alias Tuns16 = TY.Tuns16;
+alias Tint32 = TY.Tint32;
+alias Tuns32 = TY.Tuns32;
+alias Tint64 = TY.Tint64;
+alias Tuns64 = TY.Tuns64;
+alias Tfloat32 = TY.Tfloat32;
+alias Tfloat64 = TY.Tfloat64;
+alias Tfloat80 = TY.Tfloat80;
+alias Timaginary32 = TY.Timaginary32;
+alias Timaginary64 = TY.Timaginary64;
+alias Timaginary80 = TY.Timaginary80;
+alias Tcomplex32 = TY.Tcomplex32;
+alias Tcomplex64 = TY.Tcomplex64;
+alias Tcomplex80 = TY.Tcomplex80;
+alias Tbool = TY.Tbool;
+alias Tchar = TY.Tchar;
+alias Twchar = TY.Twchar;
+alias Tdchar = TY.Tdchar;
+alias Terror = TY.Terror;
+alias Tinstance = TY.Tinstance;
+alias Ttypeof = TY.Ttypeof;
+alias Ttuple = TY.Ttuple;
+alias Tslice = TY.Tslice;
+alias Treturn = TY.Treturn;
+alias Tnull = TY.Tnull;
+alias Tvector = TY.Tvector;
+alias Tint128 = TY.Tint128;
+alias Tuns128 = TY.Tuns128;
+alias Ttraits = TY.Ttraits;
+alias Tmixin = TY.Tmixin;
+alias Tnoreturn = TY.Tnoreturn;
+alias Ttag = TY.Ttag;
+alias TMAX = TY.TMAX;
+
+enum TFlags
+{
+    integral     = 1,
+    floating     = 2,
+    unsigned     = 4,
+    real_        = 8,
+    imaginary    = 0x10,
+    complex      = 0x20,
+}
+
+enum PKG : int
+{
+    unknown,      /// not yet determined whether it's a package.d or not
+    module_,      /// already determined that's an actual package.d
+    package_,     /// already determined that's an actual package
+}
+
+enum StructPOD : int
+{
+    no,    /// struct is not POD
+    yes,   /// struct is POD
+    fwd,   /// POD not yet computed
+}
+
+enum TRUST : ubyte
+{
+    default_   = 0,
+    system     = 1,    // @system (same as TRUST.default)
+    trusted    = 2,    // @trusted
+    safe       = 3,    // @safe
+}
+
+enum PURE : ubyte
+{
+    impure      = 0,    // not pure at all
+    fwdref      = 1,    // it's pure, but not known which level yet
+    weak        = 2,    // no mutable globals are read or written
+    const_      = 3,    // parameters are values or const
+    strong      = 4,    // parameters are values or immutable
+}
+
+// Whether alias this dependency is recursive or not
+enum AliasThisRec : int
+{
+    no           = 0,    // no alias this recursion
+    yes          = 1,    // alias this has recursive dependency
+    fwdref       = 2,    // not yet known
+    typeMask     = 3,    // mask to read no/yes/fwdref
+    tracing      = 0x4,  // mark in progress of implicitConvTo/deduceWild
+    tracingDT    = 0x8,  // mark in progress of deduceType
+}
+
+/***************
+ * Variadic argument lists
+ * https://dlang.org/spec/function.html#variadic
+ */
+enum VarArg : ubyte
+{
+    none     = 0,  /// fixed number of arguments
+    variadic = 1,  /// (T t, ...)  can be C-style (core.stdc.stdarg) or D-style (core.vararg)
+    typesafe = 2,  /// (T t ...) typesafe https://dlang.org/spec/function.html#typesafe_variadic_functions
+                   ///   or https://dlang.org/spec/function.html#typesafe_variadic_functions
+}
+
+/*************************
+ * Identify Statement types with this enum rather than
+ * virtual functions
+ */
+enum STMT : ubyte
+{
+    Error,
+    Peel,
+    Exp, DtorExp,
+    Compile,
+    Compound, CompoundDeclaration, CompoundAsm,
+    UnrolledLoop,
+    Scope,
+    Forwarding,
+    While,
+    Do,
+    For,
+    Foreach,
+    ForeachRange,
+    If,
+    Conditional,
+    StaticForeach,
+    Pragma,
+    StaticAssert,
+    Switch,
+    Case,
+    CaseRange,
+    Default,
+    GotoDefault,
+    GotoCase,
+    SwitchError,
+    Return,
+    Break,
+    Continue,
+    Synchronized,
+    With,
+    TryCatch,
+    TryFinally,
+    ScopeGuard,
+    Throw,
+    Debug,
+    Goto,
+    Label,
+    Asm, InlineAsm, GccAsm,
+    Import,
+}
+
+/**********************
+ * Discriminant for which kind of initializer
+ */
+enum InitKind : ubyte
+{
+    void_,
+    error,
+    struct_,
+    array,
+    exp,
+    C_,
+}
+

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -26,6 +26,7 @@ module dmd.attrib;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.cond;
 import dmd.declaration;
 import dmd.dmodule;

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -14,6 +14,7 @@ module dmd.blockexit;
 import core.stdc.stdio;
 
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.canthrow;
 import dmd.dclass;
 import dmd.declaration;

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -15,7 +15,9 @@ module dmd.builtin;
 
 import core.stdc.math;
 import core.stdc.string;
+
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.dmangle;
 import dmd.errors;
 import dmd.expression;

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -17,6 +17,7 @@ import dmd.aggregate;
 import dmd.apply;
 import dmd.arraytypes;
 import dmd.attrib;
+import dmd.astenums;
 import dmd.declaration;
 import dmd.dsymbol;
 import dmd.expression;

--- a/src/dmd/chkformat.d
+++ b/src/dmd/chkformat.d
@@ -13,6 +13,7 @@ module dmd.chkformat;
 //import core.stdc.stdio : printf, scanf;
 import core.stdc.ctype : isdigit;
 
+import dmd.astenums;
 import dmd.cond;
 import dmd.errors;
 import dmd.expression;

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -15,6 +15,7 @@ module dmd.clone;
 import core.stdc.stdio;
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dscope;

--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -12,6 +12,7 @@
 module dmd.compiler;
 
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.arraytypes;
 import dmd.dmodule;
 import dmd.dscope;

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -15,6 +15,7 @@ module dmd.cond;
 
 import core.stdc.string;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.ast_node;
 import dmd.dcast;
 import dmd.dmodule;

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -18,6 +18,7 @@ module dmd.constfold;
 import core.stdc.string;
 import core.stdc.stdio;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.complex;
 import dmd.ctfeexpr;
 import dmd.declaration;

--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -15,6 +15,7 @@ module dmd.cparse;
 
 import core.stdc.stdio;
 import core.stdc.string;
+import dmd.astenums;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -27,6 +27,7 @@ import core.stdc.string;
 import core.stdc.stdio;
 
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.declaration;
 import dmd.dsymbol;

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -15,6 +15,7 @@ import core.stdc.string;
 import core.stdc.stdio;
 
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.cppmangle : isPrimaryDtor, isCppOperator, CppOperator;
 import dmd.dclass;
 import dmd.declaration;

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -15,6 +15,7 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.complex;
 import dmd.constfold;
 import dmd.compiler;

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -17,6 +17,7 @@ import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arrayop;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dscope;

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -19,6 +19,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.apply;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.gluelayer;
 import dmd.declaration;
 import dmd.dscope;

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -15,6 +15,7 @@ module dmd.declaration;
 import core.stdc.stdio;
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.ctorflow;
 import dmd.dclass;
 import dmd.delegatize;
@@ -191,76 +192,6 @@ extern (C++) void ObjectNotFound(Identifier id)
 {
     error(Loc.initial, "`%s` not found. object.d may be incorrectly installed or corrupt.", id.toChars());
     fatal();
-}
-
-enum STC : ulong
-{
-    undefined_          = 0L,
-    static_             = (1L << 0),
-    extern_             = (1L << 1),
-    const_              = (1L << 2),
-    final_              = (1L << 3),
-    abstract_           = (1L << 4),
-    parameter           = (1L << 5),
-    field               = (1L << 6),
-    override_           = (1L << 7),
-    auto_               = (1L << 8),
-    synchronized_       = (1L << 9),
-    deprecated_         = (1L << 10),
-    in_                 = (1L << 11),   // in parameter
-    out_                = (1L << 12),   // out parameter
-    lazy_               = (1L << 13),   // lazy parameter
-    foreach_            = (1L << 14),   // variable for foreach loop
-                          //(1L << 15)
-    variadic            = (1L << 16),   // the 'variadic' parameter in: T foo(T a, U b, V variadic...)
-    ctorinit            = (1L << 17),   // can only be set inside constructor
-    templateparameter   = (1L << 18),   // template parameter
-    scope_              = (1L << 19),
-    immutable_          = (1L << 20),
-    ref_                = (1L << 21),
-    init                = (1L << 22),   // has explicit initializer
-    manifest            = (1L << 23),   // manifest constant
-    nodtor              = (1L << 24),   // don't run destructor
-    nothrow_            = (1L << 25),   // never throws exceptions
-    pure_               = (1L << 26),   // pure function
-    tls                 = (1L << 27),   // thread local
-    alias_              = (1L << 28),   // alias parameter
-    shared_             = (1L << 29),   // accessible from multiple threads
-    gshared             = (1L << 30),   // accessible from multiple threads, but not typed as "shared"
-    wild                = (1L << 31),   // for "wild" type constructor
-    property            = (1L << 32),
-    safe                = (1L << 33),
-    trusted             = (1L << 34),
-    system              = (1L << 35),
-    ctfe                = (1L << 36),   // can be used in CTFE, even if it is static
-    disable             = (1L << 37),   // for functions that are not callable
-    result              = (1L << 38),   // for result variables passed to out contracts
-    nodefaultctor       = (1L << 39),   // must be set inside constructor
-    temp                = (1L << 40),   // temporary variable
-    rvalue              = (1L << 41),   // force rvalue for variables
-    nogc                = (1L << 42),   // @nogc
-    volatile_           = (1L << 43),   // destined for volatile in the back end
-    return_             = (1L << 44),   // 'return ref' or 'return scope' for function parameters
-    autoref             = (1L << 45),   // Mark for the already deduced 'auto ref' parameter
-    inference           = (1L << 46),   // do attribute inference
-    exptemp             = (1L << 47),   // temporary variable that has lifetime restricted to an expression
-    maybescope          = (1L << 48),   // parameter might be 'scope'
-    scopeinferred       = (1L << 49),   // 'scope' has been inferred and should not be part of mangling
-    future              = (1L << 50),   // introducing new base class function
-    local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
-    returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
-    live                = (1L << 53),   // function @live attribute
-    register            = (1L << 54),   // `register` storage class
-
-    // Group members are mutually exclusive (there can be only one)
-    safeGroup = STC.safe | STC.trusted | STC.system,
-
-    /// Group for `in` / `out` / `ref` storage classes on parameter
-    IOR  = STC.in_ | STC.ref_ | STC.out_,
-
-    TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
-    FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.live |
-                STC.safeGroup),
 }
 
 enum STCStorageClass =

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -15,6 +15,7 @@ module dmd.delegatize;
 
 import core.stdc.stdio;
 import dmd.apply;
+import dmd.astenums;
 import dmd.declaration;
 import dmd.dscope;
 import dmd.dsymbol;

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -12,6 +12,7 @@
 module dmd.dimport;
 
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.declaration;
 import dmd.dmodule;
 import dmd.dscope;

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -18,6 +18,7 @@ import core.stdc.stdlib;
 import core.stdc.string;
 import dmd.apply;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.builtin;
 import dmd.constfold;

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -14,6 +14,8 @@
 
 module dmd.dmangle;
 
+import dmd.astenums;
+
 /******************************************************************************
  * Returns exact mangled name of function.
  */

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -19,6 +19,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.compiler;
 import dmd.gluelayer;
 import dmd.dimport;
@@ -241,13 +242,6 @@ private const(char)[] getFilename(Identifier[] packages, Identifier ident)
     filename = buf.extractSlice()[0 .. $ - 1];
 
     return filename;
-}
-
-enum PKG : int
-{
-    unknown,     // not yet determined whether it's a package.d or not
-    module_,      // already determined that's an actual package.d
-    package_,     // already determined that's an actual package
 }
 
 /***********************************************************

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -20,6 +20,7 @@ import core.stdc.string;
 import core.stdc.time;
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.cond;
 import dmd.dclass;

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -17,6 +17,7 @@ import core.stdc.stdio;
 import core.stdc.string;
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.ctorflow;
 import dmd.dclass;
@@ -576,7 +577,7 @@ struct Scope
      */
     extern (D) static const(char)* search_correct_C(Identifier ident)
     {
-        import dmd.mtype : Twchar;
+        import dmd.astenums : Twchar;
         TOK tok;
         if (ident == Id.NULL)
             tok = TOK.null_;

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -15,6 +15,7 @@ module dmd.dstruct;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.declaration;
 import dmd.dmodule;
 import dmd.dscope;
@@ -185,13 +186,6 @@ enum StructFlags : int
 {
     none        = 0x0,
     hasPointers = 0x1, // NB: should use noPointers as in ClassFlags
-}
-
-enum StructPOD : int
-{
-    no,    // struct is not POD
-    yes,   // struct is POD
-    fwd,   // POD not yet computed
 }
 
 /***********************************************************

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -20,6 +20,7 @@ import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arraytypes;
 import dmd.attrib;
+import dmd.astenums;
 import dmd.ast_node;
 import dmd.gluelayer;
 import dmd.dclass;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -19,6 +19,7 @@ import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arraytypes;
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.blockexit;
 import dmd.clone;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -43,6 +43,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.ast_node;
 import dmd.dcast;
 import dmd.dclass;

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -24,6 +24,7 @@ import dmd.root.stringtable;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.canthrow;
 import dmd.ctfeexpr;

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -18,6 +18,7 @@ import core.stdc.string;
 import dmd.root.rmem;
 
 import dmd.aggregate;
+import dmd.astenums;
 import dmd.declaration;
 import dmd.dscope;
 import dmd.dsymbol;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -22,6 +22,7 @@ import dmd.aliasthis;
 import dmd.apply;
 import dmd.arrayop;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.ast_node;
 import dmd.gluelayer;
 import dmd.canthrow;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -22,6 +22,7 @@ import dmd.arrayop;
 import dmd.arraytypes;
 import dmd.attrib;
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.canthrow;
 import dmd.chkformat;
 import dmd.ctorflow;

--- a/src/dmd/foreachvar.d
+++ b/src/dmd/foreachvar.d
@@ -17,6 +17,7 @@ import core.stdc.string;
 
 import dmd.apply;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.dclass;
 import dmd.declaration;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3154,16 +3154,6 @@ extern Initializer* initializerSemantic(Initializer* init, Scope* sc, Type*& tx,
 
 extern Expression* initializerToExpression(Initializer* init, Type* itype = nullptr);
 
-enum class AliasThisRec
-{
-    no = 0,
-    yes = 1,
-    fwdref = 2,
-    typeMask = 3,
-    tracing = 4,
-    tracingDT = 8,
-};
-
 enum class DotExpFlag
 {
     gag = 1,
@@ -3173,18 +3163,6 @@ enum class DotExpFlag
 enum : int32_t { LOGDEFAULTINIT = 0 };
 
 enum : int32_t { LOGDOTEXP = 0 };
-
-typedef uint8_t MOD;
-
-enum class MODFlags
-{
-    const_ = 1,
-    immutable_ = 4,
-    shared_ = 2,
-    wild = 8,
-    wildconst = 9,
-    mutable_ = 16,
-};
 
 class Parameter final : public ASTNode
 {
@@ -3226,14 +3204,6 @@ enum class RET
 };
 
 enum : uint64_t { SIZE_INVALID = 18446744073709551615LLU };
-
-enum class TRUST : uint8_t
-{
-    default_ = 0u,
-    system = 1u,
-    trusted = 2u,
-    safe = 3u,
-};
 
 enum class TRUSTformat
 {
@@ -3306,6 +3276,16 @@ public:
     bool isZeroInit(const Loc& loc) /* const */;
     TypeBasic* isTypeBasic();
     void accept(Visitor* v);
+};
+
+enum class AliasThisRec
+{
+    no = 0,
+    yes = 1,
+    fwdref = 2,
+    typeMask = 3,
+    tracing = 4,
+    tracingDT = 8,
 };
 
 class TypeClass final : public Type
@@ -3403,6 +3383,14 @@ public:
     d_uns64 size(const Loc& loc);
     Expression* defaultInitLiteral(const Loc& loc);
     void accept(Visitor* v);
+};
+
+enum class TRUST : uint8_t
+{
+    default_ = 0u,
+    system = 1u,
+    trusted = 2u,
+    safe = 3u,
 };
 
 class TypeFunction final : public TypeNext
@@ -4360,13 +4348,21 @@ public:
 
 extern Type* typeSemantic(Type* type, const Loc& loc, Scope* sc);
 
+enum class MODFlags
+{
+    const_ = 1,
+    immutable_ = 4,
+    shared_ = 2,
+    wild = 8,
+    wildconst = 9,
+    mutable_ = 16,
+};
+
 struct ASTCodegen final
 {
     using AggregateDeclaration = ::AggregateDeclaration;
-    using Baseok = ::Baseok;
     using ClassKind = ::ClassKind;
     using MangleOverride = ::MangleOverride;
-    using Sizeok = ::Sizeok;
     using AliasThis = ::AliasThis;
     using AliasDeclarations = ::AliasDeclarations;
     using BaseClasses = ::BaseClasses;
@@ -4429,7 +4425,6 @@ struct ASTCodegen final
     using Declaration = ::Declaration;
     using MatchAccumulator = ::MatchAccumulator;
     using OverDeclaration = ::OverDeclaration;
-    using STC = ::STC;
     using SymbolDeclaration = ::SymbolDeclaration;
     using ThisDeclaration = ::ThisDeclaration;
     using TupleDeclaration = ::TupleDeclaration;
@@ -4456,11 +4451,9 @@ struct ASTCodegen final
     using Import = ::Import;
     using Module = ::Module;
     using ModuleDeclaration = ::ModuleDeclaration;
-    using PKG = ::PKG;
     using Package = ::Package;
     using StructDeclaration = ::StructDeclaration;
     using StructFlags = ::StructFlags;
-    using StructPOD = ::StructPOD;
     using UnionDeclaration = ::UnionDeclaration;
     using AliasAssign = ::AliasAssign;
     using ArrayScopeSymbol = ::ArrayScopeSymbol;
@@ -4635,22 +4628,15 @@ struct ASTCodegen final
     using Designator = ::Designator;
     using ErrorInitializer = ::ErrorInitializer;
     using ExpInitializer = ::ExpInitializer;
-    using InitKind = ::InitKind;
     using Initializer = ::Initializer;
     using NeedInterpret = ::NeedInterpret;
     using StructInitializer = ::StructInitializer;
     using VoidInitializer = ::VoidInitializer;
-    using AliasThisRec = ::AliasThisRec;
     using DotExpFlag = ::DotExpFlag;
-    using MOD = ::MOD;
-    using MODFlags = ::MODFlags;
-    using PURE = ::PURE;
     using Parameter = ::Parameter;
     using ParameterList = ::ParameterList;
     using RET = ::RET;
-    using TRUST = ::TRUST;
     using TRUSTformat = ::TRUSTformat;
-    using TY = ::TY;
     using Type = ::Type;
     using TypeAArray = ::TypeAArray;
     using TypeArray = ::TypeArray;
@@ -4679,7 +4665,6 @@ struct ASTCodegen final
     using TypeTuple = ::TypeTuple;
     using TypeTypeof = ::TypeTypeof;
     using TypeVector = ::TypeVector;
-    using VarArg = ::VarArg;
     using Nspace = ::Nspace;
     using AsmStatement = ::AsmStatement;
     using BreakStatement = ::BreakStatement;
@@ -4714,7 +4699,6 @@ struct ASTCodegen final
     using PeelStatement = ::PeelStatement;
     using PragmaStatement = ::PragmaStatement;
     using ReturnStatement = ::ReturnStatement;
-    using STMT = ::STMT;
     using ScopeGuardStatement = ::ScopeGuardStatement;
     using ScopeStatement = ::ScopeStatement;
     using Statement = ::Statement;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -22,6 +22,7 @@ import core.stdc.stdio;
 import core.stdc.string;
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.blockexit;
 import dmd.gluelayer;
 import dmd.dclass;

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -38,6 +38,7 @@ import dmd.backend.type;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.blockexit;
 import dmd.dclass;
 import dmd.declaration;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -19,6 +19,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.complex;
 import dmd.cond;

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -18,6 +18,7 @@ import core.stdc.stdarg;
 import core.stdc.stdlib;
 import core.stdc.string;
 
+import dmd.astenums;
 import dmd.declaration;
 import dmd.denum;
 import dmd.dscope;

--- a/src/dmd/impcnvtab.d
+++ b/src/dmd/impcnvtab.d
@@ -16,6 +16,7 @@
 
 module dmd.impcnvtab;
 
+import dmd.astenums;
 import dmd.mtype;
 
 immutable TY[TMAX][TMAX] impcnvResult = impCnvTab.impcnvResultTab;

--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -15,6 +15,7 @@ import core.stdc.stdio;
 import core.checkedint;
 
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.ast_node;
 import dmd.dsymbol;
 import dmd.expression;
@@ -35,19 +36,6 @@ enum NeedInterpret : int
 
 alias INITnointerpret = NeedInterpret.INITnointerpret;
 alias INITinterpret = NeedInterpret.INITinterpret;
-
-/*************
- * Discriminant for which kind of initializer
- */
-enum InitKind : ubyte
-{
-    void_,
-    error,
-    struct_,
-    array,
-    exp,
-    C_,
-}
 
 /***********************************************************
  */

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -17,6 +17,7 @@ import core.checkedint;
 import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.dcast;
 import dmd.declaration;
 import dmd.dscope;

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -20,6 +20,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.apply;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.declaration;
 import dmd.dmodule;

--- a/src/dmd/inlinecost.d
+++ b/src/dmd/inlinecost.d
@@ -17,6 +17,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.apply;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.dclass;
 import dmd.declaration;

--- a/src/dmd/intrange.d
+++ b/src/dmd/intrange.d
@@ -13,6 +13,7 @@ module dmd.intrange;
 
 import core.stdc.stdio;
 
+import dmd.astenums;
 import dmd.mtype;
 import dmd.expression;
 import dmd.globals;

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -15,6 +15,7 @@ import core.stdc.stdio;
 import core.stdc.string;
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.cond;
 import dmd.dclass;

--- a/src/dmd/lambdacomp.d
+++ b/src/dmd/lambdacomp.d
@@ -18,6 +18,7 @@ module dmd.lambdacomp;
 import core.stdc.stdio;
 import core.stdc.string;
 
+import dmd.astenums;
 import dmd.declaration;
 import dmd.denum;
 import dmd.dsymbol;

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -15,6 +15,7 @@ module dmd.nogc;
 
 import dmd.aggregate;
 import dmd.apply;
+import dmd.astenums;
 import dmd.declaration;
 import dmd.dscope;
 import dmd.expression;

--- a/src/dmd/ob.d
+++ b/src/dmd/ob.d
@@ -22,6 +22,7 @@ import dmd.root.rmem;
 import dmd.aggregate;
 import dmd.apply;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.declaration;
 import dmd.dscope;
 import dmd.dsymbol;

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -15,6 +15,7 @@ module dmd.objc;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.cond;
 import dmd.dclass;

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -17,6 +17,7 @@ import core.stdc.string;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dmodule;

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -17,6 +17,7 @@ import core.stdc.stdio;
 import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dscope;

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -13,6 +13,7 @@ module dmd.optimize;
 
 import core.stdc.stdio;
 
+import dmd.astenums;
 import dmd.constfold;
 import dmd.ctfeexpr;
 import dmd.dclass;
@@ -691,7 +692,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             }
             if (e.type.ty == Tclass && e.e1.type.ty == Tclass)
             {
-                import dmd.aggregate : Sizeok;
+                import dmd.astenums : Sizeok;
 
                 // See if we can remove an unnecessary cast
                 ClassDeclaration cdfrom = e.e1.type.isClassHandle();

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -15,6 +15,7 @@ module dmd.parse;
 
 import core.stdc.stdio;
 import core.stdc.string;
+import dmd.astenums;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
@@ -231,11 +232,11 @@ struct ParsedLinkage(AST)
  */
 private StorageClass getStorageClass(AST)(PrefixAttributes!(AST)* pAttrs)
 {
-    StorageClass stc = AST.STC.undefined_;
+    StorageClass stc = STC.undefined_;
     if (pAttrs)
     {
         stc = pAttrs.storageClass;
-        pAttrs.storageClass = AST.STC.undefined_;
+        pAttrs.storageClass = STC.undefined_;
     }
     return stc;
 }
@@ -294,7 +295,6 @@ private bool writeMixin(const(char)[] s, ref Loc loc)
 class Parser(AST) : Lexer
 {
     AST.ModuleDeclaration* md;
-    alias STC = AST.STC;
 
     protected
     {
@@ -2517,7 +2517,7 @@ class Parser(AST) : Lexer
         auto parameterList = parseParameterList(null);
         stc = parsePostfix(stc, &udas);
 
-        if (parameterList.varargs != AST.VarArg.none || AST.Parameter.dim(parameterList.parameters) != 0)
+        if (parameterList.varargs != VarArg.none || AST.Parameter.dim(parameterList.parameters) != 0)
         {
             if (stc & STC.static_)
                 error(loc, "constructor cannot be static");
@@ -2849,7 +2849,7 @@ class Parser(AST) : Lexer
     private AST.ParameterList parseParameterList(AST.TemplateParameters** tpl)
     {
         auto parameters = new AST.Parameters();
-        AST.VarArg varargs = AST.VarArg.none;
+        VarArg varargs = VarArg.none;
         int hasdefault = 0;
         StorageClass varargsStc;
 
@@ -2876,7 +2876,7 @@ class Parser(AST) : Lexer
                     break;
 
                 case TOK.dotDotDot:
-                    varargs = AST.VarArg.variadic;
+                    varargs = VarArg.variadic;
                     varargsStc = storageClass;
                     if (varargsStc & ~VarArgsStc)
                     {
@@ -3075,7 +3075,7 @@ class Parser(AST) : Lexer
                              */
                             if (storageClass & (STC.out_ | STC.ref_))
                                 error("variadic argument cannot be `out` or `ref`");
-                            varargs = AST.VarArg.typesafe;
+                            varargs = VarArg.typesafe;
                             parameters.push(param);
                             nextToken();
                             break;
@@ -3876,14 +3876,14 @@ class Parser(AST) : Lexer
                         AST.Type t = maybeArray;
                         while (true)
                         {
-                            if (t.ty == AST.Tsarray)
+                            if (t.ty == Tsarray)
                             {
                                 // The index expression is an Expression.
                                 AST.TypeSArray a = cast(AST.TypeSArray)t;
                                 dimStack.push(a.dim.syntaxCopy());
                                 t = a.next.syntaxCopy();
                             }
-                            else if (t.ty == AST.Taarray)
+                            else if (t.ty == Taarray)
                             {
                                 // The index expression is a Type. It will be interpreted as an expression at semantic time.
                                 AST.TypeAArray a = cast(AST.TypeAArray)t;
@@ -4808,7 +4808,7 @@ class Parser(AST) : Lexer
             else if (t != tfirst)
                 error("multiple declarations must have the same type, not `%s` and `%s`", tfirst.toChars(), t.toChars());
 
-            bool isThis = (t.ty == AST.Tident && (cast(AST.TypeIdentifier)t).ident == Id.This && token.value == TOK.assign);
+            bool isThis = (t.ty == Tident && (cast(AST.TypeIdentifier)t).ident == Id.This && token.value == TOK.assign);
             if (ident)
                 checkCstyleTypeSyntax(loc, t, alt, ident);
             else if (!isThis && (t != AST.Type.terror))
@@ -4880,7 +4880,7 @@ class Parser(AST) : Lexer
                     break;
                 }
             }
-            else if (t.ty == AST.Tfunction)
+            else if (t.ty == Tfunction)
             {
                 AST.Expression constraint = null;
                 //printf("%s funcdecl t = %s, storage_class = x%lx\n", loc.toChars(), t.toChars(), storage_class);
@@ -8528,28 +8528,28 @@ LagainStc:
                     case TOK.const_:
                         if (peekNext() == TOK.leftParenthesis)
                             break; // const as type constructor
-                        m |= AST.MODFlags.const_; // const as storage class
+                        m |= MODFlags.const_; // const as storage class
                         nextToken();
                         continue;
 
                     case TOK.immutable_:
                         if (peekNext() == TOK.leftParenthesis)
                             break;
-                        m |= AST.MODFlags.immutable_;
+                        m |= MODFlags.immutable_;
                         nextToken();
                         continue;
 
                     case TOK.shared_:
                         if (peekNext() == TOK.leftParenthesis)
                             break;
-                        m |= AST.MODFlags.shared_;
+                        m |= MODFlags.shared_;
                         nextToken();
                         continue;
 
                     case TOK.inout_:
                         if (peekNext() == TOK.leftParenthesis)
                             break;
-                        m |= AST.MODFlags.wild;
+                        m |= MODFlags.wild;
                         nextToken();
                         continue;
 
@@ -9281,7 +9281,7 @@ LagainStc:
         auto t = parseBasicType(true);
         t = parseTypeSuffixes(t);
         t = t.addSTC(stc);
-        if (t.ty == AST.Taarray)
+        if (t.ty == Taarray)
         {
             AST.TypeAArray taa = cast(AST.TypeAArray)t;
             AST.Type index = taa.index;
@@ -9293,7 +9293,7 @@ LagainStc:
             }
             t = new AST.TypeSArray(taa.next, edim);
         }
-        else if (token.value == TOK.leftParenthesis && t.ty != AST.Tsarray)
+        else if (token.value == TOK.leftParenthesis && t.ty != Tsarray)
         {
             arguments = parseArguments();
         }
@@ -9328,26 +9328,26 @@ LagainStc:
      */
     static StorageClass isBuiltinAtAttribute(Identifier ident)
     {
-        return (ident == Id.property) ? AST.STC.property :
-               (ident == Id.nogc)     ? AST.STC.nogc     :
-               (ident == Id.safe)     ? AST.STC.safe     :
-               (ident == Id.trusted)  ? AST.STC.trusted  :
-               (ident == Id.system)   ? AST.STC.system   :
-               (ident == Id.live)     ? AST.STC.live     :
-               (ident == Id.future)   ? AST.STC.future   :
-               (ident == Id.disable)  ? AST.STC.disable  :
+        return (ident == Id.property) ? STC.property :
+               (ident == Id.nogc)     ? STC.nogc     :
+               (ident == Id.safe)     ? STC.safe     :
+               (ident == Id.trusted)  ? STC.trusted  :
+               (ident == Id.system)   ? STC.system   :
+               (ident == Id.live)     ? STC.live     :
+               (ident == Id.future)   ? STC.future   :
+               (ident == Id.disable)  ? STC.disable  :
                0;
     }
 
     enum StorageClass atAttrGroup =
-                AST.STC.property |
-                AST.STC.nogc     |
-                AST.STC.safe     |
-                AST.STC.trusted  |
-                AST.STC.system   |
-                AST.STC.live     |
-                /*AST.STC.future   |*/ // probably should be included
-                AST.STC.disable;
+                STC.property |
+                STC.nogc     |
+                STC.safe     |
+                STC.trusted  |
+                STC.system   |
+                STC.live     |
+                /*STC.future   |*/ // probably should be included
+                STC.disable;
     }
 
 enum PREC : int

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -22,6 +22,7 @@ import dmd.root.rmem;
 import dmd.root.rootobject;
 
 import dmd.aggregate;
+import dmd.astenums;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.denum;

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -16,6 +16,7 @@ module dmd.safe;
 import core.stdc.stdio;
 
 import dmd.aggregate;
+import dmd.astenums;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dscope;

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -18,6 +18,7 @@ import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arraytypes;
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.blockexit;
 import dmd.clone;

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -18,6 +18,7 @@ import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arraytypes;
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.blockexit;
 import dmd.clone;

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -12,6 +12,7 @@
 module dmd.sideeffect;
 
 import dmd.apply;
+import dmd.astenums;
 import dmd.declaration;
 import dmd.dscope;
 import dmd.expression;

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -20,6 +20,7 @@ import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.attrib;
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.ast_node;
 import dmd.gluelayer;
 import dmd.canthrow;
@@ -74,55 +75,6 @@ TypeIdentifier getException()
     tid.addIdent(Id.Exception);
     return tid;
 }
-
-/********************************
- * Identify Statement types with this enum rather than
- * virtual functions.
- */
-
-enum STMT : ubyte
-{
-    Error,
-    Peel,
-    Exp, DtorExp,
-    Compile,
-    Compound, CompoundDeclaration, CompoundAsm,
-    UnrolledLoop,
-    Scope,
-    Forwarding,
-    While,
-    Do,
-    For,
-    Foreach,
-    ForeachRange,
-    If,
-    Conditional,
-    StaticForeach,
-    Pragma,
-    StaticAssert,
-    Switch,
-    Case,
-    CaseRange,
-    Default,
-    GotoDefault,
-    GotoCase,
-    SwitchError,
-    Return,
-    Break,
-    Continue,
-    Synchronized,
-    With,
-    TryCatch,
-    TryFinally,
-    ScopeGuard,
-    Throw,
-    Debug,
-    Goto,
-    Label,
-    Asm, InlineAsm, GccAsm,
-    Import,
-}
-
 
 /***********************************************************
  * Specification: http://dlang.org/spec/statement.html

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -19,6 +19,7 @@ import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arrayop;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.blockexit;
 import dmd.clone;
 import dmd.cond;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -81,7 +81,8 @@ extern (C++) struct Target
     import dmd.expression : Expression;
     import dmd.func : FuncDeclaration;
     import dmd.globals : LINK, Loc, d_int64;
-    import dmd.mtype : TY, Type, TypeFunction, TypeTuple;
+    import dmd.astenums : TY;
+    import dmd.mtype : Type, TypeFunction, TypeTuple;
     import dmd.root.ctfloat : real_t;
     import dmd.statement : Statement;
 
@@ -1019,7 +1020,7 @@ extern (C++) struct Target
 
                 TypeTuple getArgTypes()
                 {
-                    import dmd.aggregate : Sizeok;
+                    import dmd.astenums : Sizeok;
                     if (auto ts = t.toBasetype().isTypeStruct())
                     {
                         auto sd = ts.sym;
@@ -1370,7 +1371,7 @@ struct TargetCPP
      */
     extern (C++) Type parameterType(Parameter p)
     {
-        import dmd.declaration : STC;
+        import dmd.astenums : STC;
         import dmd.globals : LINK;
         import dmd.mtype : ParameterList, TypeDelegate, TypeFunction;
         import dmd.typesem : merge;

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -19,6 +19,7 @@ import dmd.root.rmem;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.complex;
 import dmd.ctfeexpr;
 import dmd.declaration;

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -20,6 +20,7 @@ import dmd.backend.type;
 
 import dmd.root.rmem;
 
+import dmd.astenums;
 import dmd.declaration;
 import dmd.denum;
 import dmd.dstruct;

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -25,6 +25,7 @@ import dmd.root.rmem;
 
 import dmd.aggregate;
 import dmd.apply;
+import dmd.astenums;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.denum;

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -20,6 +20,7 @@ import dmd.root.rmem;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.backend.type;
 import dmd.complex;
 import dmd.ctfeexpr;

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -33,6 +33,7 @@ import dmd.backend.type;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dmangle;

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -23,6 +23,7 @@ import dmd.root.rootobject;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.dclass;
 import dmd.declaration;

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -18,6 +18,7 @@ import core.stdc.stdio;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.attrib;
 import dmd.canthrow;
 import dmd.dclass;

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -5,6 +5,7 @@
 
 module dmd.transitivevisitor;
 
+import dmd.astenums;
 import dmd.permissivevisitor;
 import dmd.tokens;
 import dmd.root.rootobject;
@@ -315,7 +316,7 @@ package mixin template ParseVisitMethods(AST)
         //printf("Visiting Type\n");
         if (!t)
             return;
-        if (t.ty == AST.Tfunction)
+        if (t.ty == Tfunction)
         {
             visitFunctionType(cast(AST.TypeFunction)t, null);
             return;
@@ -379,7 +380,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.TypePointer t)
     {
         //printf("Visiting TypePointer\n");
-        if (t.next.ty == AST.Tfunction)
+        if (t.next.ty == Tfunction)
         {
             visitFunctionType(cast(AST.TypeFunction)t.next, null);
         }
@@ -807,7 +808,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.FuncLiteralDeclaration f)
     {
         //printf("Visiting FuncLiteralDeclaration\n");
-        if (f.type.ty == AST.Terror)
+        if (f.type.ty == Terror)
             return;
         AST.TypeFunction tf = cast(AST.TypeFunction)f.type;
         if (!f.inferRetType && tf.next)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -21,6 +21,7 @@ import dmd.aliasthis;
 import dmd.arrayop;
 import dmd.arraytypes;
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.complex;
 import dmd.dcast;
 import dmd.dclass;

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -11,6 +11,7 @@
 
 module dmd.typinf;
 
+import dmd.astenums;
 import dmd.declaration;
 import dmd.dmodule;
 import dmd.dscope;

--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -12,6 +12,7 @@
 module dmd.visitor;
 
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.parsetimevisitor;
 import dmd.tokens;
 import dmd.transitivevisitor;


### PR DESCRIPTION
It's an endless source of irritation and inconsistencies to have several enums re-defined in multiple files. This pulls them out into a new file, astenums.d