### PR TITLE
fix Issue 22073 - importC: Error: found '.' when expecting ';' following compound literal

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -938,7 +938,8 @@ final class CParser(AST) : Parser!AST
                 {
                     // C11 6.5.2.5 ( type-name ) { initializer-list }
                     auto ci = cparseInitializer();
-                    return new AST.CompoundLiteralExp(loc, t, ci);
+                    auto ce = new AST.CompoundLiteralExp(loc, t, ci);
+                    return cparsePostfixOperators(ce);
                 }
                 else
                 {

--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -235,6 +235,15 @@ void test22069()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22073
+
+struct S22073a { int field; };
+struct S22073b { const char *field; };
+
+_Static_assert((struct S22073a){6789}.field == 6789, "ok");
+_Static_assert((struct S22073b){"zxcv"}.field[2] == 'c', "ok");
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22079
 
 struct S22079


### PR DESCRIPTION
This fixes the parsing of postfix operators in cast-expression, #12741 deals with fixing postfix operators in sizeof expressions.