### PR TITLE
[refactor] dmd.traits: Remove dead isEnumMemX helper

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -22,7 +22,6 @@ import dmd.attrib;
 import dmd.canthrow;
 import dmd.dclass;
 import dmd.declaration;
-import dmd.denum;
 import dmd.dimport;
 import dmd.dmangle;
 import dmd.dmodule;
@@ -521,8 +520,6 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 auto y = s.isDeclaration();
             static if (is(T == FuncDeclaration))
                 auto y = s.isFuncDeclaration();
-            static if (is(T == EnumMember))
-                auto y = s.isEnumMember();
 
             if (!y || !fp(y))
                 return False();
@@ -534,7 +531,6 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     alias isDsymX = isX!Dsymbol;
     alias isDeclX = isX!Declaration;
     alias isFuncX = isX!FuncDeclaration;
-    alias isEnumMemX = isX!EnumMember;
 
     Expression isPkgX(bool function(Package) fp)
     {


### PR DESCRIPTION
This was added as part of the UDA for enum members in #8404 - but it was never used from the start.