### PR TITLE
fix Issue 22066 - importC: Error: expression expected, not ';' using (postfix-expression)++

### DIFF
--- a/test/compilable/imports/cstuff2.c
+++ b/test/compilable/imports/cstuff2.c
@@ -202,6 +202,15 @@ void test22063()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22066
+
+void test22066()
+{
+  int var = 0;
+  (var)++;
+}
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22067
 
 void test22067()


### PR DESCRIPTION
Takes what @WalterBright started with in fixing Issue 21976 (#12627) and just goes the whole hog in looking ahead and completing the entire cast-expression before deciding "Yes, we have a cast".

Doesn't fix the more ambiguous edge cases such as Issue 21992, but those can be corrected during semantic when we resolve identifiers as say "Whoops! That isn't a type, lets rebuild this as a binary expression and try again".