### PR TITLE
importC: Parse prefix increment and decrement operators as an unary operator

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -812,13 +812,16 @@ final class CParser(AST) : Parser!AST
         {
         case TOK.plusPlus:
             nextToken();
-            e = cparseUnaryExp();
+            // Parse `++` as an unary operator so that cast expressions only give
+            // an error for being non-lvalues.
+            e = cparseCastExp();
             e = new AST.PreExp(TOK.prePlusPlus, loc, toCLvalue(e, LVAL.increment));
             break;
 
         case TOK.minusMinus:
             nextToken();
-            e = cparseUnaryExp();
+            // Parse `--` as an unary operator, same as prefix increment.
+            e = cparseCastExp();
             e = new AST.PreExp(TOK.preMinusMinus, loc, toCLvalue(e, LVAL.decrement));
             break;
 

--- a/test/fail_compilation/failcstuff1.c
+++ b/test/fail_compilation/failcstuff1.c
@@ -27,20 +27,13 @@ fail_compilation/failcstuff1.c(352): Error: found `2` when expecting `:`
 fail_compilation/failcstuff1.c(352): Error: found `:` instead of statement
 fail_compilation/failcstuff1.c(403): Error: left operand is not assignable
 fail_compilation/failcstuff1.c(404): Error: left operand is not assignable
-fail_compilation/failcstuff1.c(405): Error: expression expected, not `short`
 fail_compilation/failcstuff1.c(405): Error: increment operand is not assignable
-fail_compilation/failcstuff1.c(405): Error: found `3` when expecting `;` following statement
 fail_compilation/failcstuff1.c(406): Error: decrement operand is not assignable
 fail_compilation/failcstuff1.c(407): Error: increment operand is not assignable
 fail_compilation/failcstuff1.c(408): Error: decrement operand is not assignable
 fail_compilation/failcstuff1.c(409): Error: cannot take address of unary operand
-fail_compilation/failcstuff1.c(453): Error: expression expected, not `short`
 fail_compilation/failcstuff1.c(453): Error: increment operand is not assignable
-fail_compilation/failcstuff1.c(453): Error: found `var` when expecting `;` following statement
-fail_compilation/failcstuff1.c(454): Error: expression expected, not `long`
-fail_compilation/failcstuff1.c(454): Error: found `long` when expecting `)`
 fail_compilation/failcstuff1.c(454): Error: decrement operand is not assignable
-fail_compilation/failcstuff1.c(454): Error: found `)` when expecting `;` following statement
 ---
 */
 


### PR DESCRIPTION
While not strictly C11 grammar, but on the off-chance we do encounter a cast-expression, it gives a better error.

More importantly though, because compound literals are not handled by `cparseUnaryExp`, this allows us to be able to parse the following as valid code.
```
struct S { int value; };
++(struct S) { 123 }.value;
```
Can't add a test because of issue 22072 (and possibly 22071) however.  So that will be done when compound literals are made into lvalues during semantic.