### PR TITLE
dmd.expression: Call optimize after modifiableLvalue

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -6706,7 +6706,11 @@ extern (C++) final class CondExp : BinExp
 
     override Expression modifiableLvalue(Scope* sc, Expression e)
     {
-        //error("conditional expression %s is not a modifiable lvalue", toChars());
+        if (!e1.isLvalue() && !e2.isLvalue())
+        {
+            error("conditional expression `%s` is not a modifiable lvalue", toChars());
+            return ErrorExp.get();
+        }
         e1 = e1.modifiableLvalue(sc, e1);
         e2 = e2.modifiableLvalue(sc, e2);
         return toLvalue(sc, this);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5827,8 +5827,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         exp.e1 = exp.e1.expressionSemantic(sc);
-        exp.e1 = exp.e1.optimize(WANTvalue, /*keepLvalue*/ true);
         exp.e1 = exp.e1.modifiableLvalue(sc, exp.e1);
+        exp.e1 = exp.e1.optimize(WANTvalue, /*keepLvalue*/ true);
         exp.type = exp.e1.type;
 
         if (auto ad = isAggregate(exp.e1.type))
@@ -8307,8 +8307,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
         }
 
-        exp.e1 = exp.e1.optimize(WANTvalue, /*keepLvalue*/ true);
-
         Type t1 = exp.e1.type.toBasetype();
         if (t1.ty == Tclass || t1.ty == Tstruct || exp.e1.op == TOK.arrayLength)
         {
@@ -8349,6 +8347,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         exp.e1 = exp.e1.modifiableLvalue(sc, exp.e1);
+        exp.e1 = exp.e1.optimize(WANTvalue, /*keepLvalue*/ true);
 
         e = exp;
         if (exp.e1.checkScalar() ||
@@ -9103,8 +9102,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             Expression ex;
                             ex = new IndexExp(exp.loc, ea, ek);
                             ex = ex.expressionSemantic(sc);
-                            ex = ex.optimize(WANTvalue);
                             ex = ex.modifiableLvalue(sc, ex); // allocate new slot
+                            ex = ex.optimize(WANTvalue);
 
                             ey = new ConstructExp(exp.loc, ex, ey);
                             ey = ey.expressionSemantic(sc);
@@ -9375,12 +9374,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Expression e1x = exp.e1;
 
             // Try to do a decent error message with the expression
-            // before it got constant folded
-
-            e1x = e1x.optimize(WANTvalue, /*keepLvalue*/ true);
-
+            // before it gets constant folded
             if (exp.op == TOK.assign)
                 e1x = e1x.modifiableLvalue(sc, e1old);
+
+            e1x = e1x.optimize(WANTvalue, /*keepLvalue*/ true);
 
             if (e1x.op == TOK.error)
             {

--- a/test/fail_compilation/diag4596.d
+++ b/test/fail_compilation/diag4596.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag4596.d(15): Error: `this` is not an lvalue and cannot be modified
-fail_compilation/diag4596.d(16): Error: `1 ? this : this` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(16): Error: conditional expression `1 ? this : this` is not a modifiable lvalue
 fail_compilation/diag4596.d(18): Error: `super` is not an lvalue and cannot be modified
-fail_compilation/diag4596.d(19): Error: `1 ? super : super` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(19): Error: conditional expression `1 ? super : super` is not a modifiable lvalue
 ---
 */
 

--- a/test/fail_compilation/diag8178.d
+++ b/test/fail_compilation/diag8178.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8178.d(14): Error: cannot modify string literal `""`
+fail_compilation/diag8178.d(14): Error: cannot modify manifest constant `s`
 ---
 */
 

--- a/test/fail_compilation/test12385.d
+++ b/test/fail_compilation/test12385.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test12385.d(29): Error: cannot modify `immutable` expression `BundledState("bla", 3).x`
+fail_compilation/test12385.d(29): Error: cannot modify `immutable` expression `unbundled.x`
 ---
 */
 


### PR DESCRIPTION
There are a couple cases - especially `CastExp`, where `optimize` strips the outer cast - that involve silently converting an rvalue into an lvalue.
For example:
```
int a = 0;
++cast(int)a;  // both castTo and optimize rewrite this as `++a`
```
While this is apparently fine and acceptable for D, it is not for C.

To make it simpler to issue errors during semantic, this delays the calling of `optimize` until after lvalue checking has been done.  The worse alternative would be to make `optimize` aware of importC, possibly with a `keepRvalue` parameter alongside `keepLvalue`.

More generally, based off the changes in fail_compilation as a result of this, it's quite clear that error reporting becomes obfuscated after `optimize` to the detriment of diagnostics. So the use of optimize should really be deferred as a last step of semantic (not to be confused with `ctfeInterpret` where a value is required on demand).