### PR TITLE
test: Move "must fail" part of compilable/traits.d to fail_compilation

### DIFF
--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -155,12 +155,6 @@ static assert(!__traits(hasPostblit, NoCpCtor));
 static assert(!__traits(hasPostblit, C19902));
 static assert(!__traits(hasPostblit, int));
 
-// Check that invalid use cases don't compile
-static assert(!__traits(compiles, __traits(hasCopyConstructor)));
-static assert(!__traits(compiles, __traits(hasCopyConstructor, S())));
-static assert(!__traits(compiles, __traits(hasPostblit)));
-static assert(!__traits(compiles, __traits(hasPostblit, S())));
-
 static assert(__traits(isCopyable, int));
 static assert(!__traits(isCopyable, DisabledPostblit));
 struct S1 {}                        // Fine. Can be copied

--- a/test/fail_compilation/traits.d
+++ b/test/fail_compilation/traits.d
@@ -94,3 +94,25 @@ fail_compilation/traits.d(502):        while evaluating `pragma(msg, __traits(ge
 
 auto yip(int f) {return T[];}
 pragma(msg, __traits(getParameterStorageClasses, yip, 0));
+
+
+/********************************************
+TEST_OUTPUT:
+---
+fail_compilation/traits.d(602): Error: expected 1 arguments for `hasCopyConstructor` but had 0
+fail_compilation/traits.d(602):        while evaluating `pragma(msg, __traits(hasCopyConstructor))`
+fail_compilation/traits.d(603): Error: type expected as second argument of __traits `hasCopyConstructor` instead of `S()`
+fail_compilation/traits.d(603):        while evaluating `pragma(msg, __traits(hasCopyConstructor, S()))`
+fail_compilation/traits.d(604): Error: expected 1 arguments for `hasPostblit` but had 0
+fail_compilation/traits.d(604):        while evaluating `pragma(msg, __traits(hasPostblit))`
+fail_compilation/traits.d(605): Error: type expected as second argument of __traits `hasPostblit` instead of `S()`
+fail_compilation/traits.d(605):        while evaluating `pragma(msg, __traits(hasPostblit, S()))`
+---
+*/
+#line 600
+
+struct S { this (ref S rhs) {} }
+pragma(msg, __traits(hasCopyConstructor));
+pragma(msg, __traits(hasCopyConstructor, S()));
+pragma(msg, __traits(hasPostblit));
+pragma(msg, __traits(hasPostblit, S()));


### PR DESCRIPTION
```
According to the official grammar, traits such as hasCopyConstructor
and hasPostblit expect a single argument. As such, code such as
__traits(hasPostblit) is invalid, even inside a __traits(compiles,
...).

Since DMD does not forbid such invalid trait syntax during parsing, it
does allow such invalid programs (and simply lets __traits(compiles,
...) to evaluate to false). However, since it never makes sense to
write such code in the first place (outside a compiler test suite),
this behavior can be described as an implementation detail.

As such, there is no reason why we can't unwrap these lines out of
their static asserts and move them to fail_compilation. Not only does
this help further the goal of validating the compiler test suite
against the official grammar and vice versa, but it also allows us to
verify the error messages, i.e. check that the tested code does not
compile for the right reasons.
```