### PR TITLE
test: Fix typos ("PREMUTE")

### DIFF
--- a/test/compilable/test9278a.d
+++ b/test/compilable/test9278a.d
@@ -1,4 +1,4 @@
-// PREMUTE_ARGS:
+// PERMUTE_ARGS:
 
 // Works fine here
 struct datum { float num = 0.0; }

--- a/test/compilable/test9278b.d
+++ b/test/compilable/test9278b.d
@@ -1,4 +1,4 @@
-// PREMUTE_ARGS:
+// PERMUTE_ARGS:
 
 // Works fine here
 //struct datum { float num = 0.0; }

--- a/test/compilable/test9613.d
+++ b/test/compilable/test9613.d
@@ -1,4 +1,4 @@
-// PREMUTE_ARGS:
+// PERMUTE_ARGS:
 struct S9613
 {
     int f(

--- a/test/fail_compilation/fail9613.d
+++ b/test/fail_compilation/fail9613.d
@@ -1,4 +1,4 @@
-// PREMUTE_ARGS:
+// PERMUTE_ARGS:
 /*
 TEST_OUTPUT:
 ---


### PR DESCRIPTION
Fixing the typo does change the behavior of the test suite, but as far as I can see, the intention matches the test case is all four instances.