### PR TITLE
fix Issue 22084 - [REG 2.097] Segmentation fault passing non-pod struct as variadic argument

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2341,7 +2341,8 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
 
                 /* Declare temporary 'auto __pfx = arg' (needsDtor) or 'auto __pfy = arg' (!needsDtor)
                  */
-                auto tmp = copyToTemp(parameter.storageClass & (STC.scope_),
+                auto tmp = copyToTemp(
+                    (parameter ? parameter.storageClass : tf.parameterList.stc) & (STC.scope_),
                     needsDtor ? "__pfx" : "__pfy",
                     !isRef ? arg : arg.addressOf());
                 tmp.dsymbolSemantic(sc);

--- a/test/fail_compilation/fail22084.d
+++ b/test/fail_compilation/fail22084.d
@@ -1,0 +1,23 @@
+// https://issues.dlang.org/show_bug.cgi?id=22084
+/*
+TEST_OUTPUT
+---
+fail_compilation/fail22084.d(22): Error: cannot pass types that need destruction as variadic arguments
+---
+*/
+import core.stdc.stdarg;
+
+extern(C++) void testVariadic(int a, ...)
+{
+}
+
+struct Destructor
+{
+    ~this() { }
+}
+
+void test()
+{
+    auto a0 = Destructor;
+    testVariadic(1, a0);
+}


### PR DESCRIPTION
Use variadic storage class for variadic parameters.