### PR TITLE
dtoh: Consistently emit VarDeclaration's inside of templated aggregates

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -18,6 +18,7 @@ experimental C++ header generator:
 - Structs are always tagged as `final` because D disallows `struct` inheritance
 - Symbol names always include template parameters and enclosing declarations
   when required
+- Properly emits (static / enum) members of templated aggregates
 
 Note: The header generator is still considerer experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -387,6 +387,8 @@ struct Array final
     // Ignoring var data alignment 0
     _d_dynamicArray< T > data;
     // Ignoring var SMALLARRAYCAP alignment 0
+    enum : int32_t { SMALLARRAYCAP = 1 };
+
     // Ignoring var smallarray alignment 0
     void* smallarray;
     Array(size_t dim);

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -44,8 +44,25 @@ struct A final
 {
     // Ignoring var x alignment 0
     T x;
+    // Ignoring var Enum alignment 0
+    enum : int32_t { Enum = 42 };
+
+    // Ignoring var GsharedNum alignment 0
+    static int32_t GsharedNum;
+    // Ignoring var MemNum alignment 0
+    const int32_t MemNum;
     void foo();
     A()
+    {
+    }
+};
+
+template <typename T>
+struct NotInstantiated final
+{
+    // Ignoring var noInit alignment 0
+    // Ignoring var missingSem alignment 0
+    NotInstantiated()
     {
     }
 };
@@ -128,7 +145,7 @@ public:
     T childFinal();
 };
 
-extern void withDefTempl(A<int32_t > a = A<int32_t >(2));
+extern void withDefTempl(A<int32_t > a = A<int32_t >(2, 13));
 
 template <typename T>
 extern void withDefTempl2(A<T > a = static_cast<A<T >>(A!T(2)));
@@ -161,9 +178,17 @@ extern HasMixinsTemplate<bool > hmti;
 extern (C++) struct A(T)
 {
     T x;
-    // enum Num = 42; // dtoh segfaults at enum
-
+    enum Enum = 42;
+    __gshared GsharedNum = 43;
+    immutable MemNum = 13;
     void foo() {}
+}
+
+// Invalid declarations accepted because it's not instantiated
+extern (C++) struct NotInstantiated(T)
+{
+    enum T noInit;
+    enum missingSem = T.init;
 }
 
 extern (C++) struct B

--- a/test/compilable/dtoh_ignored.d
+++ b/test/compilable/dtoh_ignored.d
@@ -67,7 +67,7 @@ struct WithImaginaryTemplate final
     // Ignored function onReturn because its return type cannot be mapped to C++
     // Ignored function onParam because one of its parameters has type `ifloat` which cannot be mapped to C++
     // Ignoring var onVariable alignment 0
-    // Ignored variable onVariable because of linkage
+    // Ignored variable onVariable because its type cannot be mapped to C++
     WithImaginaryTemplate()
     {
     }

--- a/test/compilable/dtoh_names.d
+++ b/test/compilable/dtoh_names.d
@@ -66,13 +66,13 @@ struct Outer final
         struct InnerTmpl final
         {
             // Ignoring var innerTmplOuterPtr alignment 0
-            Outer* innerTmplOuterPtr;
+            static Outer* innerTmplOuterPtr;
             // Ignoring var innerTmplPtr alignment 0
-            Middle* innerTmplPtr;
+            static Middle* innerTmplPtr;
             // Ignoring var innerTmplInnerPtr alignment 0
-            Inner* innerTmplInnerPtr;
+            static Inner* innerTmplInnerPtr;
             // Ignoring var innerTmplInnerTmplPtr alignment 0
-            InnerTmpl* innerTmplInnerTmplPtr;
+            static InnerTmpl* innerTmplInnerTmplPtr;
             InnerTmpl()
             {
             }
@@ -87,15 +87,15 @@ struct Outer final
     struct MiddleTmpl final
     {
         // Ignoring var middleTmplPtr alignment 0
-        MiddleTmpl<T >* middleTmplPtr;
+        static MiddleTmpl<T >* middleTmplPtr;
         // Ignoring var middleTmplInnerTmplPtr alignment 0
-        MiddleTmpl<T >* middleTmplInnerTmplPtr;
+        static MiddleTmpl<T >* middleTmplInnerTmplPtr;
         struct Inner final
         {
             // Ignoring var ptr alignment 0
-            Inner* ptr;
+            static Inner* ptr;
             // Ignoring var ptr2 alignment 0
-            MiddleTmpl<T >* ptr2;
+            static MiddleTmpl<T >* ptr2;
             Inner()
             {
             }
@@ -105,13 +105,13 @@ struct Outer final
         struct InnerTmpl final
         {
             // Ignoring var innerTmplPtr alignment 0
-            InnerTmpl* innerTmplPtr;
+            static InnerTmpl* innerTmplPtr;
             // Ignoring var innerTmplPtrDiff alignment 0
-            InnerTmpl<char >* innerTmplPtrDiff;
+            static InnerTmpl<char >* innerTmplPtrDiff;
             // Ignoring var middleTmplInnerTmplPtr alignment 0
-            MiddleTmpl<T >* middleTmplInnerTmplPtr;
+            static MiddleTmpl<T >* middleTmplInnerTmplPtr;
             // Ignoring var a alignment 0
-            T a;
+            static T a;
             static U bar();
             InnerTmpl()
             {


### PR DESCRIPTION
The header generator previously omitted `VarDeclaration`'s in templated
aggregates in several scenarios because they missing semantic didn't
set the expected values (e.g. missing type, linkage, ...).

This patch changes the code to infer a missing type from an initializer
(which must be defined in valid D code) and cross-validate linkage with
the internal data.

This also simplifies the code because the special case for `tdparent`
is now obsolete.