### PR TITLE
(Mostly) Enable compilation with macOS arm64 emulated x64

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1476,7 +1476,7 @@ auto detectModel()
     else
         uname = ["uname", "-m"].execute.output;
 
-    if (uname.canFind("x86_64", "amd64", "64-bit", "64-Bit", "64 bit"))
+    if (uname.canFind("x86_64", "amd64", /* rosetta on macOS */"arm64", "64-bit", "64-Bit", "64 bit"))
         return "64";
     if (uname.canFind("i386", "i586", "i686", "32-bit", "32-Bit", "32 bit"))
         return "32";

--- a/src/dmd/backend/bcomplex.d
+++ b/src/dmd/backend/bcomplex.d
@@ -11,7 +11,7 @@ module dmd.backend.bcomplex;
 
 public import dmd.root.longdouble : targ_ldouble = longdouble;
 import core.stdc.math : fabs, fabsl, sqrt;
-import dmd.root.longdouble : fabsl, sqrt; // needed if longdouble is longdouble_soft
+import dmd.root.longdouble/* : fabsl, sqrt*/; // needed if longdouble is longdouble_soft
 
 extern (C++):
 @nogc:

--- a/src/dmd/backend/bcomplex.d
+++ b/src/dmd/backend/bcomplex.d
@@ -11,8 +11,7 @@ module dmd.backend.bcomplex;
 
 public import dmd.root.longdouble : targ_ldouble = longdouble;
 import core.stdc.math : fabs, fabsl, sqrt;
-version(CRuntime_Microsoft)
-    private import dmd.root.longdouble : fabsl, sqrt; // needed if longdouble is longdouble_soft
+import dmd.root.longdouble : fabsl, sqrt; // needed if longdouble is longdouble_soft
 
 extern (C++):
 @nogc:

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -64,7 +64,7 @@ version (SCPP_HTOD)
     import precomp;
 }
 
-version (CRuntime_Microsoft)
+static if (real.sizeof == double.sizeof)
 {
     import dmd.root.longdouble;
 }
@@ -1719,7 +1719,7 @@ void shrinkLongDoubleConstantIfPossible(elem *e)
         auto v = e.EV.Vldouble;
         double vDouble;
 
-        version (CRuntime_Microsoft)
+        static if (real.sizeof == double.sizeof)
         {
             static if (is(typeof(v) == real))
                 *(&vDouble) = v;
@@ -3025,7 +3025,7 @@ case_tym:
 
         case TYldouble:
         {
-            version (CRuntime_Microsoft)
+            static if (real.sizeof == 8)
             {
                 char[3 + 3 * (targ_ldouble).sizeof + 1] buffer = void;
                 static if (is(typeof(e.EV.Vldouble) == real))

--- a/src/dmd/backend/evalu8.d
+++ b/src/dmd/backend/evalu8.d
@@ -36,6 +36,8 @@ import dmd.backend.el;
 import dmd.backend.ty;
 import dmd.backend.type;
 
+import dmd.root.longdouble;
+
 version (SCPP)
 {
 import msgs2;

--- a/src/dmd/backend/os.d
+++ b/src/dmd/backend/os.d
@@ -950,7 +950,7 @@ else version (OSX)
 {
 int os_critsecsize32()
 {
-    version(X86_64)
+    version(D_LP64)
     {
         assert(pthread_mutex_t.sizeof == 64);
     }

--- a/src/dmd/root/ctfloat.d
+++ b/src/dmd/root/ctfloat.d
@@ -185,7 +185,7 @@ extern (C++) struct CTFloat
         version(CRuntime_DigitalMars) __locale_decpoint = save;
         if (isOutOfRange)
             *isOutOfRange = (errno == ERANGE);
-        return r;
+        return cast(typeof(return))r;
     }
 
     @system

--- a/src/dmd/root/ctfloat.d
+++ b/src/dmd/root/ctfloat.d
@@ -28,7 +28,7 @@ private
 
     version(CRuntime_Microsoft) extern (C++)
     {
-        public import dmd.root.longdouble : longdouble_soft, ld_sprint;
+        public import dmd.root.longdouble/* : longdouble_soft, ld_sprint*/;
         import dmd.root.strtold;
     }
 }

--- a/src/dmd/root/longdouble.d
+++ b/src/dmd/root/longdouble.d
@@ -13,7 +13,7 @@ module dmd.root.longdouble;
 
 static if (real.sizeof > 8)
     alias longdouble = real;
-else:
+else
     alias longdouble = longdouble_soft;
 
 import core.stdc.config;

--- a/src/dmd/root/longdouble.d
+++ b/src/dmd/root/longdouble.d
@@ -89,7 +89,11 @@ void ld_clearfpu()
 pure:
 @trusted: // LDC: LLVM __asm is @system AND requires taking the address of variables
 
-struct longdouble_soft
+version(CRuntime_Microsoft)
+    private enum ldalign = 2;
+else
+    private enum ldalign = 16;
+align (ldalign) struct longdouble_soft
 {
 nothrow @nogc pure:
     // DMD's x87 `real` on Windows is packed (alignof = 2 -> sizeof = 10).

--- a/src/dmd/root/strtold.d
+++ b/src/dmd/root/strtold.d
@@ -14,7 +14,7 @@ import dmd.root.longdouble;
 import core.stdc.ctype;
 import core.stdc.errno;
 
-version(CRuntime_Microsoft):
+static if (real.sizeof == double.sizeof):
 @nogc:
 nothrow:
 


### PR DESCRIPTION
as is this will still trip ` static assert(false, "longdouble_soft not supported on this platform");` because neither of `D_InlineAsm_X86_64` or` D_InlineAsm_X86` are defined, but apart from that. building DMD with LDC on the M1 succeeds.

This is getting rather annoying to deal commit juggling with so I'm pushing these changes upstream.

cc @jacob-carlborg 