### PR TITLE
Move lib and scan modules into a package

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1324,8 +1324,9 @@ auto sourceFiles()
             dmsc.d e2ir.d eh.d iasm.d iasmdmd.d iasmgcc.d glue.d objc_glue.d
             s2ir.d tocsym.d toctype.d tocvdebug.d todt.d toir.d toobj.d
         "),
-        driver: fileArray(env["D"], "dinifile.d gluelayer.d lib.d libelf.d libmach.d libmscoff.d libomf.d
-            link.d mars.d scanelf.d scanmach.d scanmscoff.d scanomf.d vsoptions.d
+        driver: fileArray(env["D"], "dinifile.d gluelayer.d link.d mars.d vsoptions.d") ~
+                fileArray(buildPath(env["D"],"lib"), "scanelf.d scanmach.d scanmscoff.d scanomf.d
+                          package.d elf.d mach.d mscoff.d omf.d
         "),
         frontend: fileArray(env["D"], "
             access.d aggregate.d aliasthis.d apply.d argtypes_x86.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d

--- a/src/dmd/README.md
+++ b/src/dmd/README.md
@@ -183,15 +183,15 @@ Note that these groups have no strict meaning, the category assignments are a bi
 
 | File                                                                          | Purpose                                              |
 |-------------------------------------------------------------------------------|------------------------------------------------------|
-| [lib.d](https://github.com/dlang/dmd/blob/master/src/dmd/lib.d)               | Abstract library class                               |
-| [libelf.d](https://github.com/dlang/dmd/blob/master/src/dmd/libelf.d)         | Library in ELF format (Unix)                         |
-| [libmach.d](https://github.com/dlang/dmd/blob/master/src/dmd/libmach.d)       | Library in Mach-O format (macOS)                     |
-| [libmscoff.d](https://github.com/dlang/dmd/blob/master/src/dmd/libmscoff.d)   | Library in COFF format (32/64-bit Windows)           |
-| [libomf.d](https://github.com/dlang/dmd/blob/master/src/dmd/libomf.d)         | Library in OMF format (legacy 32-bit Windows)        |
-| [scanelf.d](https://github.com/dlang/dmd/blob/master/src/dmd/scanelf.d)       | Extract symbol names from a library in ELF format    |
-| [scanmach.d](https://github.com/dlang/dmd/blob/master/src/dmd/scanmach.d)     | Extract symbol names from a library in Mach-O format |
-| [scanmscoff.d](https://github.com/dlang/dmd/blob/master/src/dmd/scanmscoff.d) | Extract symbol names from a library in COFF format   |
-| [scanomf.d](https://github.com/dlang/dmd/blob/master/src/dmd/scanomf.d)       | Extract symbol names from a library in OMF format    |
+| [lib/package.d](https://github.com/dlang/dmd/blob/master/src/dmd/lib/package.d)               | Abstract library class                               |
+| [lib/elf.d](https://github.com/dlang/dmd/blob/master/src/dmd/lib/elf.d)         | Library in ELF format (Unix)                         |
+| [lib/mach.d](https://github.com/dlang/dmd/blob/master/src/dmd/lib/mach.d)       | Library in Mach-O format (macOS)                     |
+| [lib/mscoff.d](https://github.com/dlang/dmd/blob/master/src/dmd/lib/mscoff.d)   | Library in COFF format (32/64-bit Windows)           |
+| [lib/omf.d](https://github.com/dlang/dmd/blob/master/src/dmd/lib/omf.d)         | Library in OMF format (legacy 32-bit Windows)        |
+| [lib/scanelf.d](https://github.com/dlang/dmd/blob/master/src/dmd/lib/scanelf.d)       | Extract symbol names from a library in ELF format    |
+| [lib/scanmach.d](https://github.com/dlang/dmd/blob/master/src/dmd/lib/scanmach.d)     | Extract symbol names from a library in Mach-O format |
+| [lib/scanmscoff.d](https://github.com/dlang/dmd/blob/master/src/dmd/lib/scanmscoff.d) | Extract symbol names from a library in COFF format   |
+| [lib/scanomf.d](https://github.com/dlang/dmd/blob/master/src/dmd/lib/scanomf.d)       | Extract symbol names from a library in OMF format    |
 
 ### Code generation / back-end interfacing
 

--- a/src/dmd/lib/elf.d
+++ b/src/dmd/lib/elf.d
@@ -4,12 +4,12 @@
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/libelf.d, _libelf.d)
- * Documentation:  https://dlang.org/phobos/dmd_libelf.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/libelf.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lib/elf.d, _elf.d)
+ * Documentation:  https://dlang.org/phobos/dmd_lib_elf.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lib/elf.d
  */
 
-module dmd.libelf;
+module dmd.lib.elf;
 
 import core.stdc.time;
 import core.stdc.string;
@@ -38,10 +38,10 @@ import dmd.root.rmem;
 import dmd.root.string;
 import dmd.root.stringtable;
 
-import dmd.scanelf;
+import dmd.lib.scanelf;
 
 // Entry point (only public symbol in this module).
-public extern (C++) Library LibElf_factory()
+package extern (C++) Library LibElf_factory()
 {
     return new LibElf();
 }

--- a/src/dmd/lib/mach.d
+++ b/src/dmd/lib/mach.d
@@ -4,12 +4,12 @@
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/libmach.d, _libmach.d)
- * Documentation:  https://dlang.org/phobos/dmd_libmach.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/libmach.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lib/mach.d, _mach.d)
+ * Documentation:  https://dlang.org/phobos/dmd_lib_mach.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lib/mach.d
  */
 
-module dmd.libmach;
+module dmd.lib.mach;
 
 import core.stdc.time;
 import core.stdc.string;
@@ -40,10 +40,10 @@ import dmd.root.rmem;
 import dmd.root.string;
 import dmd.root.stringtable;
 
-import dmd.scanmach;
+import dmd.lib.scanmach;
 
 // Entry point (only public symbol in this module).
-public extern (C++) Library LibMach_factory()
+package extern (C++) Library LibMach_factory()
 {
     return new LibMach();
 }

--- a/src/dmd/lib/mscoff.d
+++ b/src/dmd/lib/mscoff.d
@@ -4,12 +4,12 @@
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/libmscoff.d, _libmscoff.d)
- * Documentation:  https://dlang.org/phobos/dmd_libmscoff.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/libmscoff.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lib/mscoff.d, _mscoff.d)
+ * Documentation:  https://dlang.org/phobos/dmd_lib_mscoff.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lib/mscoff.d
  */
 
-module dmd.libmscoff;
+module dmd.lib.mscoff;
 
 import core.stdc.stdlib;
 import core.stdc.string;
@@ -40,10 +40,10 @@ import dmd.root.rmem;
 import dmd.root.string;
 import dmd.root.stringtable;
 
-import dmd.scanmscoff;
+import dmd.lib.scanmscoff;
 
 // Entry point (only public symbol in this module).
-public extern (C++) Library LibMSCoff_factory()
+package extern (C++) Library LibMSCoff_factory()
 {
     return new LibMSCoff();
 }

--- a/src/dmd/lib/omf.d
+++ b/src/dmd/lib/omf.d
@@ -4,12 +4,12 @@
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/libomf.d, _libomf.d)
- * Documentation:  https://dlang.org/phobos/dmd_libomf.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/libomf.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lib/omf.d, _omf.d)
+ * Documentation:  https://dlang.org/phobos/dmd_lib_omf.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lib/omf.d
  */
 
-module dmd.libomf;
+module dmd.lib.omf;
 
 import core.stdc.stdio;
 import core.stdc.string;
@@ -28,10 +28,10 @@ import dmd.root.outbuffer;
 import dmd.root.string;
 import dmd.root.stringtable;
 
-import dmd.scanomf;
+import dmd.lib.scanomf;
 
 // Entry point (only public symbol in this module).
-extern (C++) Library LibOMF_factory()
+package extern (C++) Library LibOMF_factory()
 {
     return new LibOMF();
 }

--- a/src/dmd/lib/package.d
+++ b/src/dmd/lib/package.d
@@ -1,13 +1,13 @@
 /**
  * A module defining an abstract library.
- * Implementations for various formats are in separate `libXXX.d` modules.
+ * Implementations for various formats are in `src/dmd/lib/` modules.
  *
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lib.d, _lib.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lib/package.d, _package.d)
  * Documentation:  https://dlang.org/phobos/dmd_lib.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lib.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lib/package.d
  */
 
 module dmd.lib;
@@ -25,10 +25,10 @@ import dmd.root.file;
 import dmd.root.filename;
 import dmd.root.string;
 
-import dmd.libomf;
-import dmd.libmscoff;
-import dmd.libelf;
-import dmd.libmach;
+import dmd.lib.omf;
+import dmd.lib.mscoff;
+import dmd.lib.elf;
+import dmd.lib.mach;
 
 private enum LOG = false;
 

--- a/src/dmd/lib/scanelf.d
+++ b/src/dmd/lib/scanelf.d
@@ -4,12 +4,12 @@
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/scanelf.d, _scanelf.d)
- * Documentation:  https://dlang.org/phobos/dmd_scanelf.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/scanelf.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lib/scanelf.d, _scanelf.d)
+ * Documentation:  https://dlang.org/phobos/dmd_lib_scanelf.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lib/scanelf.d
  */
 
-module dmd.scanelf;
+module dmd.lib.scanelf;
 
 import core.stdc.string;
 import core.stdc.stdint;
@@ -19,6 +19,8 @@ import dmd.globals;
 import dmd.errors;
 
 enum LOG = false;
+
+package:
 
 /*****************************************
  * Reads an object module from base[] and passes the names

--- a/src/dmd/lib/scanmach.d
+++ b/src/dmd/lib/scanmach.d
@@ -4,12 +4,12 @@
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/scanmach.d, _scanmach.d)
- * Documentation:  https://dlang.org/phobos/dmd_scanmach.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/scanmach.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lib/scanmach.d, _scanmach.d)
+ * Documentation:  https://dlang.org/phobos/dmd_lib_scanmach.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lib/scanmach.d
  */
 
-module dmd.scanmach;
+module dmd.lib.scanmach;
 
 import core.stdc.string;
 import core.stdc.stdint;
@@ -20,6 +20,8 @@ import dmd.errors;
 import dmd.backend.mach;
 
 private enum LOG = false;
+
+package:
 
 /*****************************************
  * Reads an object module from base[] and passes the names

--- a/src/dmd/lib/scanmscoff.d
+++ b/src/dmd/lib/scanmscoff.d
@@ -4,12 +4,12 @@
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/scanmscoff.d, _scanmscoff.d)
- * Documentation:  https://dlang.org/phobos/dmd_scanmscoff.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/scanmscoff.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lib/scanmscoff.d, _scanmscoff.d)
+ * Documentation:  https://dlang.org/phobos/dmd_lib_scanmscoff.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lib/scanmscoff.d
  */
 
-module dmd.scanmscoff;
+module dmd.lib.scanmscoff;
 
 import core.stdc.string, core.stdc.stdlib;
 
@@ -28,6 +28,8 @@ import dmd.root.string;
 import dmd.globals, dmd.errors;
 
 private enum LOG = false;
+
+package:
 
 /*****************************************
  * Reads an object module from base[] and passes the names

--- a/src/dmd/lib/scanomf.d
+++ b/src/dmd/lib/scanomf.d
@@ -4,12 +4,12 @@
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/scanomf.d, _scanomf.d)
- * Documentation:  https://dlang.org/phobos/dmd_scanomf.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/scanomf.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/lib/scanomf.d, _scanomf.d)
+ * Documentation:  https://dlang.org/phobos/dmd_lib_scanomf.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/lib/scanomf.d
  */
 
-module dmd.scanomf;
+module dmd.lib.scanomf;
 
 import core.stdc.string;
 import core.stdc.stdlib;
@@ -21,6 +21,8 @@ import dmd.arraytypes;
 import dmd.errors;
 
 private enum LOG = false;
+
+package:
 
 /*****************************************
  * Reads an object module from base[] and passes the names


### PR DESCRIPTION

The only symbols declared in these modules used outside them are declared in `src/lib.d`.

This commit changes:
* `lib{elf,mach,mscoff,omf}.d` => `lib/{elf,mach,mscoff,omf}.d`: Those files are only imported by a single module, dmd.lib;
* `lib.d` => `lib/package.d`: The single module importing `lib*.d`, which provides the single entry point for this package;
`scan*.d` => `lib/scan*.d`: Those files are never imported by modules except for the corresponding `lib/{elf,mach,mscoff,omf}.d`;

This increases encapsulation by:
* reducing the visibility of symbols in `scan*.d` to `dmd.lib`, so the context one needs looking at the module in isolation is reduced;
* it reduces the visibility of symbols in `{elf,mach,...}.d`;
* It signals to the reader that `package.d` is the entry point, based on a language feature, not coding convention

I hope I have all the doc links correct.