### PR TITLE
dtoh: Properly emit static arrays in template declarations whose...

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -19,6 +19,7 @@ experimental C++ header generator:
 - Symbol names always include template parameters and enclosing declarations
   when required
 - Properly emits (static / enum) members of templated aggregates
+- Properly emits static arrays in template declarations
 
 Note: The header generator is still considerer experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/astcodegen.d
+++ b/src/dmd/astcodegen.d
@@ -96,4 +96,6 @@ struct ASTCodegen
     alias isExpression              = dmd.dtemplate.isExpression;
     alias isTuple                   = dmd.dtemplate.isTuple;
 
+    alias IgnoreErrors              = dmd.dsymbol.IgnoreErrors;
+    alias PASS                      = dmd.dsymbol.PASS;
 }

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -390,7 +390,7 @@ struct Array final
     enum : int32_t { SMALLARRAYCAP = 1 };
 
     // Ignoring var smallarray alignment 0
-    void* smallarray;
+    T smallarray[SMALLARRAYCAP];
     Array(size_t dim);
     ~Array();
     const char* toChars() const;
@@ -4734,6 +4734,7 @@ struct ASTCodegen final
     typedef Dsymbol* Dsymbol;
     typedef Array<Dsymbol* > Dsymbols;
     typedef Visibility Visibility;
+    typedef PASS PASS;
     ASTCodegen()
     {
     }

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -39,6 +39,8 @@ struct _d_dynamicArray final
 };
 #endif
 
+enum : int32_t { SomeOtherLength = 1 };
+
 template <typename T>
 struct A final
 {
@@ -172,6 +174,23 @@ struct HasMixinsTemplate final
 };
 
 extern HasMixinsTemplate<bool > hmti;
+
+template <typename T>
+struct NotAA final
+{
+    // Ignoring var length alignment 0
+    enum : int32_t { length = 12 };
+
+    // Ignoring var buffer alignment 0
+    T buffer[length];
+    // Ignoring var otherBuffer alignment 0
+    T otherBuffer[SomeOtherLength];
+    // Ignoring var calcBuffer alignment 0
+    T calcBuffer[foo(1)];
+    NotAA()
+    {
+    }
+};
 ---
 */
 
@@ -296,3 +315,17 @@ struct HasMixinsTemplate(T)
 }
 
 __gshared HasMixinsTemplate!bool hmti;
+
+/// Declarations that look like associative arrays
+
+extern(D) enum SomeOtherLength = 1;
+
+struct NotAA(T)
+{
+    private:
+    enum length = 12;
+    public:
+    T[length] buffer;
+    T[SomeOtherLength] otherBuffer;
+    T[foo(1)] calcBuffer;
+}


### PR DESCRIPTION
...  length is a constant (instead of a literal).

`int[SomeLength]` is parsed as `TypeAArray` even if `SomeLength` is later
resolved to be an integral constant instead of a type. This caused the
visitor to emit such symbols as `void*`.

This commit checks for such types and tries to resolve the "key" to
determine if it's actually an associative array.