### PR TITLE
impcnv: should use functions, not arrays, as interface

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2855,11 +2855,11 @@ Lagain:
     t1b = t1.toBasetype();
     t2b = t2.toBasetype();
 
-    TY ty = cast(TY)impcnvResult[t1b.ty][t2b.ty];
+    const ty = implicitConvCommonTy(t1b.ty, t2b.ty);
     if (ty != Terror)
     {
-        TY ty1 = cast(TY)impcnvType1[t1b.ty][t2b.ty];
-        TY ty2 = cast(TY)impcnvType2[t1b.ty][t2b.ty];
+        const ty1 = implicitConvTy1(t1b.ty, t2b.ty);
+        const ty2 = implicitConvTy2(t1b.ty, t2b.ty);
 
         if (t1b.ty == ty1) // if no promotions
         {

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -3246,7 +3246,7 @@ private Type rawTypeMerge(Type t1, Type t2)
     if (t1b.equivalent(t2b))
         return t1b.castMod(MODmerge(t1b.mod, t2b.mod));
 
-    auto ty = cast(TY)impcnvResult[t1b.ty][t2b.ty];
+    auto ty = implicitConvCommonTy(t1b.ty, t2b.ty);
     if (ty != Terror)
         return Type.basic[ty];
 

--- a/src/dmd/impcnvtab.d
+++ b/src/dmd/impcnvtab.d
@@ -19,11 +19,57 @@ module dmd.impcnvtab;
 import dmd.astenums;
 import dmd.mtype;
 
+pure @nogc nothrow @safe:
+
+/*************************************************
+ * If ty1 and ty2 are basic types, return the TY that both can
+ * be implicitly converted to.
+ * Params:
+ *      ty1 = first operand type
+ *      ty2 = second operand type
+ * Returns:
+ *      ty = common type, else Terror
+ */
+TY implicitConvCommonTy(TY ty1, TY ty2)
+{
+    return impCnvTab.impcnvResultTab[ty1][ty2];
+}
+
+/*************************************************
+ * If ty1 and ty2 are basic types, return the TY that ty1 can
+ * be implicitly converted to to bring them to a common ty.
+ * Params:
+ *      ty1 = first operand type
+ *      ty2 = second operand type
+ * Returns:
+ *      ty = what ty1 should be converted to, else Terror
+ */
+TY implicitConvTy1(TY ty1, TY ty2)
+{
+    return impCnvTab.impcnvType1Tab[ty1][ty2];
+}
+
+/*************************************************
+ * If ty1 and ty2 are basic types, return the TY that ty2 can
+ * be implicitly converted to to bring them to a common ty.
+ * Params:
+ *      ty1 = first operand type
+ *      ty2 = second operand type
+ * Returns:
+ *      ty = what ty2 should be converted to, else Terror
+ */
+TY implicitConvTy2(TY ty1, TY ty2)
+{
+    return impCnvTab.impcnvType2Tab[ty1][ty2];
+}
+
+/******************************************************************************/
+
+private:
+
 immutable TY[TMAX][TMAX] impcnvResult = impCnvTab.impcnvResultTab;
 immutable TY[TMAX][TMAX] impcnvType1 = impCnvTab.impcnvType1Tab;
 immutable TY[TMAX][TMAX] impcnvType2 = impCnvTab.impcnvType2Tab;
-
-private:
 
 struct ImpCnvTab
 {


### PR DESCRIPTION
The arrays were also completely undocumented.