### PR TITLE
test: Fix EXTRA_FILES directive for a few tests

### DIFF
--- a/test/compilable/issue21726.d
+++ b/test/compilable/issue21726.d
@@ -1,2 +1,3 @@
 // EXTRA_SOURCES: protection/issue21726/typecons.d
+// EXTRA_FILES: protection/issue21726/format/package.d protection/issue21726/package.d
 // https://issues.dlang.org/show_bug.cgi?id=21726

--- a/test/compilable/test11847.d
+++ b/test/compilable/test11847.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -Icompilable/imports
+// EXTRA_FILES: imports/pkg11847/mod11847.d imports/pkg11847/package.d
 import pkg11847;
 import pkg11847.mod11847;
 

--- a/test/fail_compilation/test21246.d
+++ b/test/fail_compilation/test21246.d
@@ -1,5 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=21246
-// EXTRA_FILES: imports.test21246
+// EXTRA_FILES: imports/test21246.d
 /*
 TEST_OUTPUT:
 ---


### PR DESCRIPTION
One typo, and a few more files that didn't get copied to remote.  There might be a couple more for runnable tests, but haven't gotten that far yet.