### PR TITLE
test: Only compile 'exits' function with DMD compiler

### DIFF
--- a/test/compilable/noreturn1.d
+++ b/test/compilable/noreturn1.d
@@ -49,7 +49,8 @@ static assert(noreturn.alignof == 0);
 static assert((noreturn*).sizeof == (int*).sizeof);
 static assert((noreturn[]).sizeof == (int[]).sizeof);
 
-noreturn exits(int* p) { *p = 3; }
+version (DigitalMars)
+    noreturn exits(int* p) { *p = 3; }
 
 noreturn exit();
 


### PR DESCRIPTION
This code results in a warning/error (in the back-end) when compiled with GDC.  Looking at the code, the error is right, and this shouldn't be compilable.