### PR TITLE
test: Fix dtoh tests to be compilable to object file

### DIFF
--- a/test/compilable/dtoh_ClassDeclaration.d
+++ b/test/compilable/dtoh_ClassDeclaration.d
@@ -131,6 +131,7 @@ public:
 class B : public A, public I1, public I2
 {
 public:
+    using A::bar;
     void foo();
     void bar();
 };
@@ -273,6 +274,7 @@ interface I2 : I1
 
 class B : A, I1, I2
 {
+    alias bar = A.bar;
     override void foo() {}
     override void bar() {}
 }

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -265,7 +265,7 @@ struct Outer
 
 extern(C++) T foo(T, U)(U u) { return T.init; }
 
-extern(C++) A!(A!int) aaint;
+extern(C++) __gshared A!(A!int) aaint;
 
 extern(C++) class Parent(T)
 {

--- a/test/compilable/dtoh_enum.d
+++ b/test/compilable/dtoh_enum.d
@@ -261,7 +261,7 @@ extern(C++) enum c = [2: 3];
 extern(C) void foo();
 extern(C++) enum d = &foo;
 
-immutable bool e_b;
+__gshared immutable bool e_b;
 extern(C++) enum e = &e_b;
 
 enum opaque;

--- a/test/compilable/dtoh_enum_cpp98.d
+++ b/test/compilable/dtoh_enum_cpp98.d
@@ -233,7 +233,7 @@ extern(C++) enum c = [2: 3];
 extern(C) void foo();
 extern(C++) enum d = &foo;
 
-immutable bool e_b;
+__gshared immutable bool e_b;
 extern(C++) enum e = &e_b;
 
 // Opaque enums require C++ 11

--- a/test/compilable/dtoh_functions.d
+++ b/test/compilable/dtoh_functions.d
@@ -230,7 +230,7 @@ enum MS : ubyte { dm }
 enum MSN : S { s = S(42) }
 struct W1 { MS ms; MSN msn; }
 struct W2 { W1 w1; }
-W2 w2;
+__gshared W2 w2;
 
 void enums(ulong e = E.m, ubyte e2 = w2.w1.ms, S s = w2.w1.msn) {}
 
@@ -249,7 +249,7 @@ struct S
     }
 }
 
-S s;
+__gshared S s;
 
 void aggregates(int a = s.i, int b = s.get(1, 2), int c = S.get(), int d = S.staticVar) {}
 
@@ -259,16 +259,16 @@ struct S2
     S s;
     static struct S3
     {
-        static int i = 3;
+        __gshared int i = 3;
     }
 }
 
-S2 s2;
+__gshared S2 s2;
 
 void chains(int a = s2.s.i, int b = S2.S3.i) {}
 
-S* ptr;
-int function(int) f;
+__gshared S* ptr;
+__gshared int function(int) f;
 
 void special(int a = ptr.i, int b = ptr.get(1, 2), int j = f(1)) {}
 

--- a/test/compilable/dtoh_names.d
+++ b/test/compilable/dtoh_names.d
@@ -177,7 +177,7 @@ struct Outer
             __gshared InnerTmpl!char* innerTmplPtrDiff;
             __gshared MiddleTmpl!T.Inner* middleTmplInnerTmplPtr;
 
-            static T a;
+            __gshared T a;
             static U bar() { return U.init; }
         }
     }


### PR DESCRIPTION
The missing `__gshared` is probably a bug in dtoh @MoonlightSentinel?  C++ cannot interact with D TLS symbols.