### PR TITLE
dtoh: Use `writeIdentifier` when writing `VarExp` that refer to...

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -20,6 +20,7 @@ experimental C++ header generator:
   when required
 - Properly emits (static / enum) members of templated aggregates
 - Properly emits static arrays in template declarations
+- No longer omits the parent aggregate when referencing `__gshared` variables
 
 Note: The header generator is still considerer experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -2453,13 +2453,14 @@ public:
             scope(exit) printf("[AST.VarExp exit] %s\n", e.toChars());
         }
 
-        // Static members are not represented as DotVarExp, hence
-        // manually print the full name here
-        if (e.var.storage_class & AST.STC.static_)
-            printPrefix(e.var.parent);
-
-        includeSymbol(e.var);
-        writeIdentifier(e.var, !!e.var.isThis());
+        // Local members don't need another prefix and might've been renamed
+        if (e.var.isThis())
+        {
+            includeSymbol(e.var);
+            writeIdentifier(e.var, true);
+        }
+        else
+            writeFullName(e.var);
     }
 
     /// Partially prints the FQN including parent aggregates

--- a/test/compilable/dtoh_functions.d
+++ b/test/compilable/dtoh_functions.d
@@ -45,6 +45,15 @@ struct S final
     int32_t get(int32_t , int32_t );
     static int32_t get();
     static const int32_t staticVar;
+    void useVars(int32_t pi = i, int32_t psv = staticVar);
+    struct Nested final
+    {
+        void useStaticVar(int32_t i = staticVar);
+        Nested()
+        {
+        }
+    };
+
     S() :
         i()
     {
@@ -230,7 +239,14 @@ struct S
     int i;
     int get(int, int);
     static int get();
-    static const int staticVar;
+    __gshared const int staticVar;
+
+    void useVars(int pi = i, int psv = staticVar) {}
+
+    struct Nested
+    {
+        void useStaticVar(int i = staticVar) {}
+    }
 }
 
 S s;

--- a/test/compilable/dtoh_names.d
+++ b/test/compilable/dtoh_names.d
@@ -39,8 +39,6 @@ struct _d_dynamicArray final
 };
 #endif
 
-extern double bar();
-
 struct Outer final
 {
     static Outer* outerPtr;


### PR DESCRIPTION
... static members.

This ensures that the header generator writes the required prefix for
`__gshared` variables and also prevents the emission of static functions
outside of the enclosing aggregate.