### PR TITLE
dtoh: Resolve symbols from TypeIdentifier

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -7,6 +7,7 @@ experimental C++ header generator:
 - (Superclass) methods aliases are emitted as `using ...` instead of `typedef ...`
 - `extern(D)` symbols are no longer emitted by accident in certain situations
 - `extern(D)` structs and classes are emitted if referenced by an exported symbol
+- Symbols referenced from template declarations are emitted before their first use
 - Forward declarations consistently include `template<...>`
 - `extern(C++, class)`, `extern(C++, struct)` affects forward declarations
 - Renamed or local imports are emitted as `using ...` when possible

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1760,6 +1760,11 @@ public:
             printf("[AST.TypeIdentifier enter] %s\n", t.toChars());
             scope(exit) printf("[AST.TypeIdentifier exit] %s\n", t.toChars());
         }
+
+        // Try to resolve the referenced symbol
+        if (auto sym = findSymbol(t.ident))
+            ensureDeclared(outermostSymbol(sym));
+
         if (t.idents.length)
             buf.writestring("typename ");
 
@@ -2186,14 +2191,38 @@ public:
      */
     private AST.Dsymbol findSymbol(Identifier name, AST.Dsymbol context)
     {
-        for (auto par = context; par; par = par.toParent())
+        // Follow the declaration context
+        for (auto par = context; par; par = par.toParentDecl())
         {
+            // Check that `name` doesn't refer to a template parameter
+            if (auto td = par.isTemplateDeclaration())
+            {
+                foreach (const p; *td.parameters)
+                {
+                    if (p.ident == name)
+                        return null;
+                }
+            }
+
             if (auto mem = findMember(par, name))
             {
                 return mem;
             }
         }
         return null;
+    }
+
+    /// ditto
+    private AST.Dsymbol findSymbol(Identifier name)
+    {
+        AST.Dsymbol sym;
+        if (adparent)
+            sym = findSymbol(name, adparent);
+
+        if (!sym && tdparent)
+            sym = findSymbol(name, tdparent);
+
+        return sym;
     }
 
     /// Finds the template declaration for instance `ti`
@@ -2856,7 +2885,7 @@ public:
 
         // Eagerly include the symbol if we cannot create a valid forward declaration
         // Forwarding of scoped enums requires C++11 or above
-        if (!forwarding || !par.isModule() || (ed && global.params.cplusplus < CppStdRevision.cpp11))
+        if (!forwarding || (par && !par.isModule()) || (ed && global.params.cplusplus < CppStdRevision.cpp11))
         {
             // Emit the entire enclosing declaration if any
             includeSymbol(outermostSymbol(sym));

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -223,6 +223,7 @@ struct ModuleDeclaration;
 struct FileBuffer;
 struct Escape;
 class WithStatement;
+struct AA;
 class Tuple;
 class Parameter;
 class TemplateParameter;
@@ -378,6 +379,8 @@ enum class CHECKACTION : uint8_t
     halt = 2u,
     context = 3u,
 };
+
+typedef uint64_t size_t;
 
 template <typename T>
 struct Array final
@@ -925,6 +928,8 @@ struct Ungag final
     }
 };
 
+typedef uint64_t d_uns64;
+
 struct Visibility final
 {
     enum class Kind : uint8_t
@@ -1122,6 +1127,8 @@ public:
     void accept(Visitor* v);
     ~ScopeDsymbol();
 };
+
+typedef uint64_t StorageClass;
 
 enum class ClassKind : uint8_t
 {
@@ -1474,6 +1481,10 @@ enum class TOK : uint16_t
     __declspec = 258u,
     __attribute__ = 259u,
 };
+
+typedef uint64_t dinteger_t;
+
+typedef uint64_t uinteger_t;
 
 enum class MATCH
 {

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -39,7 +39,36 @@ struct _d_dynamicArray final
 };
 #endif
 
+typedef uint$?:32=32|64=64$_t size_t;
+
+struct Outer final
+{
+    int32_t a;
+    struct Member final
+    {
+        typedef int32_t Nested;
+        Member()
+        {
+        }
+    };
+
+    Outer() :
+        a()
+    {
+    }
+    Outer(int32_t a) :
+        a(a)
+        {}
+};
+
 enum : int32_t { SomeOtherLength = 1 };
+
+struct ActualBuffer final
+{
+    ActualBuffer()
+    {
+    }
+};
 
 template <typename T>
 struct A final
@@ -191,6 +220,27 @@ struct NotAA final
     {
     }
 };
+
+template <typename Buffer>
+struct BufferTmpl final
+{
+    // Ignoring var buffer alignment 0
+    Buffer buffer;
+    // Ignoring var buffer2 alignment 0
+    Buffer buffer2;
+    BufferTmpl()
+    {
+    }
+};
+
+struct ImportedBuffer final
+{
+    typedef ActualBuffer Buffer;
+    ActualBuffer buffer2;
+    ImportedBuffer()
+    {
+    }
+};
 ---
 */
 
@@ -251,7 +301,6 @@ extern (C++) struct Array(T)
     void visit(T.Member.Nested i) {}
 }
 
-// Not emitted yet even though it is used above
 struct Outer
 {
     int a;
@@ -328,4 +377,25 @@ struct NotAA(T)
     T[length] buffer;
     T[SomeOtherLength] otherBuffer;
     T[foo(1)] calcBuffer;
+}
+
+// Same name but hidden by the template paramter
+extern (D) struct Buffer {}
+extern (D) struct ActualBuffer {}
+
+struct BufferTmpl(Buffer)
+{
+    Buffer buffer;
+    mixin BufferMixin!();
+}
+
+struct ImportedBuffer
+{
+    alias Buffer = ActualBuffer;
+    mixin BufferMixin!();
+}
+
+mixin template BufferMixin()
+{
+    Buffer buffer2;
 }


### PR DESCRIPTION
Ensures that the referenced symbol is emitted into the header file if possible.