### PR TITLE
fix Issue 21932 ImportC: enum ENUM conflicts with enum ENUM

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -464,7 +464,7 @@ struct Scope
                     if (flags & TagNameSpace)
                     {
                         // ImportC: if symbol is not a tag, look for it in tag table
-                        if (!s.isStructDeclaration())
+                        if (!s.isScopeDsymbol())
                         {
                             auto ps = cast(void*)s in sc._module.tagSymTab;
                             if (!ps)

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -2305,8 +2305,8 @@ Dsymbol handleTagSymbols(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsymbol sds)
 {
     enum log = false;
     if (log) printf("handleTagSymbols('%s')\n", s.toChars());
-    auto sd = s.isStructDeclaration(); // new declaration
-    auto sd2 = s2.isStructDeclaration(); // existing declaration
+    auto sd = s.isScopeDsymbol(); // new declaration
+    auto sd2 = s2.isScopeDsymbol(); // existing declaration
 
     if (!sd2)
     {
@@ -2316,7 +2316,7 @@ Dsymbol handleTagSymbols(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsymbol sds)
         if (auto p = cast(void*)s2 in sc._module.tagSymTab)
         {
             Dsymbol s2tag = *p;
-            sd2 = s2tag.isStructDeclaration();
+            sd2 = s2tag.isScopeDsymbol();
             assert(sd2);        // only tags allowed in tag symbol table
         }
     }
@@ -2324,6 +2324,10 @@ Dsymbol handleTagSymbols(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsymbol sds)
     if (sd && sd2) // `s` is a tag, `sd2` is the same tag
     {
         if (log) printf(" tag is already defined\n");
+
+        if (sd.kind() != sd2.kind())  // being enum/struct/union must match
+            return null;              // conflict
+
         /* Not a redeclaration if one is a forward declaration.
          * Move members to the first declared type, which is sd2.
          */
@@ -2362,4 +2366,5 @@ Dsymbol handleTagSymbols(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsymbol sds)
     if (log) printf(" collision\n");
     return null;
 }
+
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1890,8 +1890,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(EnumDeclaration ed)
     {
-        //printf("EnumDeclaration::semantic(sd = %p, '%s') %s\n", sc.scopesym, sc.scopesym.toChars(), toChars());
-        //printf("EnumDeclaration::semantic() %p %s\n", this, toChars());
+        //printf("EnumDeclaration::semantic(sd = %p, '%s') %s\n", sc.scopesym, sc.scopesym.toChars(), ed.toChars());
+        //printf("EnumDeclaration::semantic() %p %s\n", this, ed.toChars());
         if (ed.semanticRun >= PASS.semanticdone)
             return; // semantic() already completed
         if (ed.semanticRun == PASS.semantic)
@@ -2072,7 +2072,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(EnumMember em)
     {
-        //printf("EnumMember::semantic() %s\n", toChars());
+        //printf("EnumMember::semantic() %s\n", em.toChars());
 
         void errorReturn()
         {

--- a/test/fail_compilation/cenums.c
+++ b/test/fail_compilation/cenums.c
@@ -1,0 +1,60 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/cenums.c(202): Error: `enum E2` is incomplete without members
+fail_compilation/cenums.c(303): Error: redeclaring `union E3` as `enum E3`
+fail_compilation/cenums.c(502): Error: enum member `cenums.test5.F.a` conflicts with enum member `cenums.test5.F.a` at fail_compilation/cenums.c(502)
+fail_compilation/cenums.c(502): Error: declaration `a` is already defined
+fail_compilation/cenums.c(502):        `alias` `a` is defined here
+---
+*/
+
+#line 100
+enum E1 { a };
+void test1()
+{
+    enum E1 e1;
+}
+
+#line 200
+void test2()
+{
+    enum E2 e2;
+}
+
+#line 300
+union E3;
+void test3()
+{
+    enum E3 e3;
+}
+
+#line 400
+void test4()
+{
+    enum E4 { a, b, c = 3, d };
+    _Static_assert(sizeof(enum E4) == 4, "in");
+    _Static_assert(a == 0, "in");
+    _Static_assert(b == 1, "in");
+    _Static_assert(c == 3, "in");
+    _Static_assert(d == 4, "in");
+}
+
+#line 500
+void test5()
+{
+    enum F { a, a };
+}
+
+#line 600
+enum E6 { a6, b6 } c6;
+_Static_assert(a6 == 0, "in");
+_Static_assert(b6 == 1, "in");
+
+#line 700
+void test()
+{
+    enum E { a, b } c;
+    _Static_assert(a == 0, "in");
+    _Static_assert(b == 1, "in");
+}
+

--- a/test/fail_compilation/failcstuff1.c
+++ b/test/fail_compilation/failcstuff1.c
@@ -34,6 +34,7 @@ fail_compilation/failcstuff1.c(408): Error: decrement operand is not assignable
 fail_compilation/failcstuff1.c(409): Error: cannot take address of unary operand
 fail_compilation/failcstuff1.c(453): Error: increment operand is not assignable
 fail_compilation/failcstuff1.c(454): Error: decrement operand is not assignable
+fail_compilation/failcstuff1.c(600): Error: `enum ENUM` has no members
 ---
 */
 
@@ -132,3 +133,6 @@ void test22068()
 // https://issues.dlang.org/show_bug.cgi?id=22086
 #line 500
 typedef union U22086 U22086;
+
+#line 600
+enum ENUM;


### PR DESCRIPTION
Fixing the bug meant revamping how enums were done:

1. Treat them analogously to structs
2. Fix errors with redeclaring a union tag as an enum tag
3. Instead of manifest constant declarations, use alias declarations
4. Give errors for incomplete enum declarations
5. Fix failure to distinguish union tags from struct tags
6. Uses D's semantic analyzer for enums, which gives the D side access to things like the .max property

Todo: enum base types are still `int`. Need to figure out just what gcc's wrongly documented rule is for determining the base type (it doesn't match gcc's behavior). The C11 spec is self-contradictory on this issue.