### PR TITLE
dtoh: Traverse UnaExp / BinExp instead of relying on toChars

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -22,6 +22,7 @@ experimental C++ header generator:
 - Properly emits (static / enum) members of templated aggregates
 - Properly emits static arrays in template declarations
 - No longer omits the parent aggregate when referencing `__gshared` variables
+- No longer uses D syntax for expressions nested in unary / binary expressions
 
 Note: The header generator is still considerer experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -2613,6 +2613,21 @@ public:
         buf.writestring(e.ident.toChars());
     }
 
+    override void visit(AST.ScopeExp e)
+    {
+        debug (Debug_DtoH)
+        {
+            printf("[AST.ScopeExp enter] %s\n", e.toChars());
+            scope(exit) printf("[AST.ScopeExp exit] %s\n", e.toChars());
+        }
+
+        // Usually a template instance in a TemplateDeclaration
+        if (auto ti = e.sds.isTemplateInstance())
+            visitTi(ti);
+        else
+            writeFullName(e.sds);
+    }
+
     override void visit(AST.NullExp e)
     {
         debug (Debug_DtoH)

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -2474,6 +2474,45 @@ public:
         buf.writestring(e.toString());
     }
 
+    override void visit(AST.UnaExp e)
+    {
+        debug (Debug_DtoH)
+        {
+            printf("[AST.UnaExp enter] %s\n", e.toChars());
+            scope(exit) printf("[AST.UnaExp exit] %s\n", e.toChars());
+        }
+
+        buf.writestring(tokToString(e.op));
+        e.e1.accept(this);
+    }
+
+    override void visit(AST.BinExp e)
+    {
+        debug (Debug_DtoH)
+        {
+            printf("[AST.BinExp enter] %s\n", e.toChars());
+            scope(exit) printf("[AST.BinExp exit] %s\n", e.toChars());
+        }
+
+        e.e1.accept(this);
+        buf.writeByte(' ');
+        buf.writestring(tokToString(e.op));
+        buf.writeByte(' ');
+        e.e2.accept(this);
+    }
+
+    /// Translates operator `op` into the C++ representation
+    private extern(D) static string tokToString(const TOK op)
+    {
+        switch (op) with (TOK)
+        {
+            case identity:      return "==";
+            case notIdentity:   return "!=";
+            default:
+                return Token.toString(op);
+        }
+    }
+
     override void visit(AST.VarExp e)
     {
         debug (Debug_DtoH)

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -179,7 +179,7 @@ public:
 extern void withDefTempl(A<int32_t > a = A<int32_t >(2, 13));
 
 template <typename T>
-extern void withDefTempl2(A<T > a = static_cast<A<T >>(A!T(2)));
+extern void withDefTempl2(A<T > a = static_cast<A<T >>(A<T >(2)));
 
 class ChildInt : public Parent<int32_t >
 {

--- a/test/compilable/dtoh_expressions.d
+++ b/test/compilable/dtoh_expressions.d
@@ -96,3 +96,32 @@ T requiredTmpl(T)(void* ptr = cast(void*) foo()) {}
 T stcCastTmpl(T)(const int* ci = cast(immutable) somePtr) {}
 
 T paramCastTmpl(T)(const int* ci = cast(T) somePtr) {}
+
+/+
+TEST_OUTPUT:
+---
+
+struct Data final
+{
+    static Data* pt;
+    static int32_t* bar();
+    Data()
+    {
+    }
+};
+
+extern void useData(bool a = !Data::pt, bool b = Data::bar() == nullptr, bool c = Data::bar() != nullptr);
+---
++/
+
+struct Data
+{
+    static Data* pt;
+    static int* bar() { return null; }
+}
+
+void useData(
+    bool a = !Data.pt,
+    bool b = Data.bar() is null,
+    bool c = Data.bar() !is null
+) {}


### PR DESCRIPTION
This ensures that expressions requiring special handling are properly
emitted when nested into one of those expressions.

Also added a method to write `ScopeExp` as C++ template instances.