### PR TITLE
Refactor duplicated code from ASTBase node AliasThis into a mixin template

### DIFF
--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -15,6 +15,7 @@ module dmd.aliasthis;
 
 import core.stdc.stdio;
 import dmd.aggregate;
+import dmd.astmembers;
 import dmd.dscope;
 import dmd.dsymbol;
 import dmd.expression;
@@ -31,17 +32,12 @@ import dmd.visitor;
  */
 extern (C++) final class AliasThis : Dsymbol
 {
-    Identifier ident;
     /// The symbol this `alias this` resolves to
     Dsymbol sym;
     /// Whether this `alias this` is deprecated or not
     bool isDeprecated_;
 
-    extern (D) this(const ref Loc loc, Identifier ident)
-    {
-        super(loc, null);    // it's anonymous (no identifier)
-        this.ident = ident;
-    }
+    mixin parseTimePropertiesAliasThis;
 
     override AliasThis syntaxCopy(Dsymbol s)
     {
@@ -59,11 +55,6 @@ extern (C++) final class AliasThis : Dsymbol
     AliasThis isAliasThis()
     {
         return this;
-    }
-
-    override void accept(Visitor v)
-    {
-        v.visit(this);
     }
 
     override bool isDeprecated() const

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -11,6 +11,7 @@
 module dmd.astbase;
 
 import dmd.astenums;
+import dmd.astmembers;
 import dmd.parsetimevisitor;
 
 /** The ASTBase  family defines a family of AST nodes appropriate for parsing with
@@ -256,19 +257,7 @@ struct ASTBase
 
     extern (C++) class AliasThis : Dsymbol
     {
-        Identifier ident;
-
-        extern (D) this(const ref Loc loc, Identifier ident)
-        {
-            super(null);
-            this.loc = loc;
-            this.ident = ident;
-        }
-
-        override void accept(Visitor v)
-        {
-            v.visit(this);
-        }
+        mixin parseTimePropertiesAliasThis;
     }
 
     extern (C++) final class AliasAssign : Dsymbol

--- a/src/dmd/astmembers.d
+++ b/src/dmd/astmembers.d
@@ -1,0 +1,18 @@
+// This file contains mixin templates that define the parse time fields and methods of AST nodes.
+module dmd.astmembers;
+
+mixin template parseTimePropertiesAliasThis()
+{
+    Identifier ident;
+
+    extern (D) this(const ref Loc loc, Identifier ident)
+    {
+        super(loc, null);    // it's anonymous (no identifier)
+        this.ident = ident;
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}


### PR DESCRIPTION
This is mostly a proposal of getting rid of the duplication in ASTBase. If I get a green light on this, I plan to apply it for all the nodes in ASTBase.

cc @WalterBright 