### PR TITLE
dtoh: Allow forward declaration of types used in ref parameters 

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -10,6 +10,7 @@ experimental C++ header generator:
 - Symbols referenced from template declarations are emitted before their first use
 - Forward declarations consistently include `template<...>`
 - `extern(C++, class)`, `extern(C++, struct)` affects forward declarations
+- Types used in reference parameters are forward declared if possible
 - Renamed or local imports are emitted as `using ...` when possible
 - Complex types are emitted as `_Complex`.
 - Declarations are emitted before the first member access

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -3014,8 +3014,12 @@ public:
     /**
      * Writes the qualified name of `sym` into `buf` including parent
      * symbols and template parameters.
+     *
+     * Params:
+     *   sym         = the symbol
+     *   mustInclude = whether sym may not be forward declared
      */
-    private void writeFullName(AST.Dsymbol sym)
+    private void writeFullName(AST.Dsymbol sym, const bool mustInclude = false)
     in
     {
         assert(sym);
@@ -3059,13 +3063,20 @@ public:
             nested = !par.isModule();
             if (nested && !isNestedIn(par, adparent))
             {
-                writeFullName(par);
+                writeFullName(par, true);
                 buf.writestring("::");
             }
         }
 
         if (!nested)
-            ensureDeclared(sym);
+        {
+            // Cannot forward the symbol when called recursively
+            // for a nested symbol
+            if (mustInclude)
+                includeSymbol(sym);
+            else
+                ensureDeclared(sym);
+        }
 
         if (ti)
             visitTi(ti);

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -2346,7 +2346,15 @@ public:
             scope(exit) printf("[AST.Parameter exit] %s\n", p.toChars());
         }
         ident = p.ident;
-        p.type.accept(this);
+
+        {
+            // Reference parameters can be forwarded
+            const fwdStash = this.forwarding;
+            this.forwarding = !!(p.storageClass & AST.STC.ref_);
+            p.type.accept(this);
+            this.forwarding = fwdStash;
+        }
+
         if (p.storageClass & AST.STC.ref_)
             buf.writeByte('&');
         buf.writeByte(' ');

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -222,8 +222,6 @@ struct Macro;
 struct ModuleDeclaration;
 struct FileBuffer;
 struct Escape;
-template <typename Datum>
-struct FileMapping;
 class WithStatement;
 struct AA;
 class Tuple;
@@ -298,6 +296,7 @@ class CompoundDeclarationStatement;
 struct Token;
 struct code;
 class StaticAssert;
+struct Triple;
 class Object;
 class TypeInfo_Class;
 class TypeInfo;
@@ -1767,56 +1766,6 @@ struct File final
     static void remove(const char* name);
     static bool update(const char* name, const void* data, size_t size);
     File()
-    {
-    }
-};
-
-struct OutBuffer final
-{
-private:
-    _d_dynamicArray< uint8_t > data;
-    size_t offset;
-    bool notlinehead;
-    FileMapping<uint8_t >* fileMapping;
-public:
-    bool doindent;
-    bool spaces;
-    int32_t level;
-    ~OutBuffer();
-    size_t length() const;
-    char* extractData();
-    void destroy();
-    void reserve(size_t nbytes);
-    void setsize(size_t size);
-    void reset();
-    void write(const void* data, size_t nbytes);
-    void writestring(const char* string);
-    void prependstring(const char* string);
-    void writenl();
-    void writeByte(uint32_t b);
-    void writeUTF8(uint32_t b);
-    void prependbyte(uint32_t b);
-    void writewchar(uint32_t w);
-    void writeword(uint32_t w);
-    void writeUTF16(uint32_t w);
-    void write4(uint32_t w);
-    void write(const OutBuffer* const buf);
-    void write(RootObject* obj);
-    void fill0(size_t nbytes);
-    void vprintf(const char* format, va_list args);
-    void printf(const char* format, ...);
-    void print(uint64_t u);
-    void bracket(char left, char right);
-    size_t bracket(size_t i, const char* left, size_t j, const char* right);
-    void spread(size_t offset, size_t nbytes);
-    size_t insert(size_t offset, const void* p, size_t nbytes);
-    void remove(size_t offset, size_t nbytes);
-    char* peekChars();
-    char* extractChars();
-    OutBuffer() :
-        doindent(),
-        spaces(),
-        level()
     {
     }
 };
@@ -4962,26 +4911,6 @@ enum class CPU
     avx512 = 10,
     baseline = 11,
     native = 12,
-};
-
-struct Triple final
-{
-private:
-    _d_dynamicArray< const char > source;
-public:
-    CPU cpu;
-    bool is64bit;
-    bool isLP64;
-    Target::OS os;
-    uint8_t osMajor;
-    TargetC::Runtime cenv;
-    TargetCPP::Runtime cppenv;
-    Triple() :
-        is64bit(),
-        isLP64(),
-        osMajor()
-    {
-    }
 };
 
 typedef _d_real longdouble;

--- a/test/compilable/dtoh_forwarding.d
+++ b/test/compilable/dtoh_forwarding.d
@@ -42,7 +42,6 @@ struct _d_dynamicArray final
 struct Child;
 class Struct;
 enum class Enum;
-struct OuterStruct;
 class ExternDClass;
 struct ExternDStruct;
 template <typename T>
@@ -55,6 +54,20 @@ class ExternDTemplClass;
 struct Parent
 {
     virtual void bar();
+};
+
+struct OuterStruct final
+{
+    struct NestedStruct final
+    {
+        NestedStruct()
+        {
+        }
+    };
+
+    OuterStruct()
+    {
+    }
 };
 
 struct ExternDStructRequired final
@@ -103,20 +116,6 @@ enum class Enum
 };
 
 extern OuterStruct::NestedStruct* nestedStrPtr;
-
-struct OuterStruct final
-{
-    struct NestedStruct final
-    {
-        NestedStruct()
-        {
-        }
-    };
-
-    OuterStruct()
-    {
-    }
-};
 
 extern ExternDClass* externDClassPtr;
 

--- a/test/compilable/dtoh_forwarding.d
+++ b/test/compilable/dtoh_forwarding.d
@@ -50,6 +50,7 @@ template <typename T>
 class TemplStruct;
 template <typename T>
 class ExternDTemplClass;
+struct OnlyByRef;
 
 struct Parent
 {
@@ -146,6 +147,8 @@ public:
 extern ExternDTemplClass<int32_t >* externTemplClass;
 
 extern ExternDTemplStruct<int32_t > externTemplStruct;
+
+extern void foo(OnlyByRef& obr);
 
 ---
 */
@@ -254,3 +257,9 @@ extern(D) struct ExternDTemplStruct(T)
 {
     T member;
 }
+
+//******************************************************
+
+extern(D) struct OnlyByRef {}
+
+void foo(ref OnlyByRef obr) {}


### PR DESCRIPTION
They act like pointers and don't require a full declaration.