### PR TITLE
Issue 21488 - Always compile dmd with -fPIC on POSIX targets

### DIFF
--- a/ini/linux/bin32/dmd.conf
+++ b/ini/linux/bin32/dmd.conf
@@ -1,5 +1,5 @@
 [Environment32]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic -fPIC
 
 [Environment64]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic -fPIC

--- a/ini/linux/bin64/dmd.conf
+++ b/ini/linux/bin64/dmd.conf
@@ -1,5 +1,5 @@
 [Environment32]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic -fPIC
 
 [Environment64]
 DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic -fPIC

--- a/src/build.d
+++ b/src/build.d
@@ -315,7 +315,7 @@ DFLAGS=%DFLAGS% -L/OPT:NOICF
     {
         enum confFile = "dmd.conf";
         enum conf = `[Environment32]
-DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/{OS}/{BUILD}/32{exportDynamic}
+DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/{OS}/{BUILD}/32{exportDynamic} -fPIC
 
 [Environment64]
 DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/{OS}/{BUILD}/64{exportDynamic} -fPIC
@@ -1020,14 +1020,9 @@ void parseEnvironment()
     // detect PIC
     version(Posix)
     {
-        // default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
+        // default to PIC if the host compiler supports, use PIC=1/0 to en-/disable PIC.
         // Note that shared libraries and C files are always compiled with PIC.
-        bool pic;
-        if (model == "64")
-            pic = true;
-        else if (model == "32")
-            pic = false;
-
+        bool pic = true;
         const picValue = env.getDefault("PIC", "");
         switch (picValue)
         {
@@ -1036,6 +1031,15 @@ void parseEnvironment()
             case "1": pic = true; break;
             default:
                 throw abortBuild(format("Variable 'PIC' should be '0', '1' or <empty> but got '%s'", picValue));
+        }
+        version (X86)
+        {
+            // https://issues.dlang.org/show_bug.cgi?id=20466
+            static if (__VERSION__ < 2090)
+            {
+                pragma(msg, "Warning: PIC will be off by default for this build of DMD because of Issue 20466!");
+                pic = false;
+            }
         }
 
         env["PIC_FLAG"]  = pic ? "-fPIC" : "";

--- a/test/Makefile
+++ b/test/Makefile
@@ -72,14 +72,10 @@ else
     endif
     export DMD=../generated/$(OS)/$(BUILD)/$(DMD_MODEL)/dmd
 
-    # default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
+    # default to PIC, use PIC=1/0 to en-/disable PIC.
     # Note that shared libraries and C files are always compiled with PIC.
     ifeq ($(PIC),)
-        ifeq ($(MODEL),64) # x86_64
-            PIC:=1
-        else
-            PIC:=0
-        endif
+        PIC:=1
     endif
     ifeq ($(PIC),1)
         export PIC_FLAG:=-fPIC

--- a/test/run.d
+++ b/test/run.d
@@ -278,7 +278,7 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
                     "-m"~env["MODEL"],
                     "-of"~targetBin,
                     sourceFile
-                ] ~ tool.extraArgs;
+                ] ~ getPicFlags(env) ~ tool.extraArgs;
             }
 
             writefln("Executing: %-(%s %)", command);
@@ -518,15 +518,11 @@ string[string] getEnvironment()
         auto druntimePath = environment.get("DRUNTIME_PATH", testPath(`../../druntime`));
         auto phobosPath = environment.get("PHOBOS_PATH", testPath(`../../phobos`));
 
-        // default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
+        // default to PIC, use PIC=1/0 to en-/disable PIC.
         // Note that shared libraries and C files are always compiled with PIC.
-        bool pic;
-        version(X86_64)
-            pic = true;
-        else version(X86)
+        bool pic = true;
+        if (environment.get("PIC", "") == "0")
             pic = false;
-        if (environment.get("PIC", "0") == "1")
-            pic = true;
 
         env["PIC_FLAG"]  = pic ? "-fPIC" : "";
         env["DFLAGS"] = "-I%s/import -I%s".format(druntimePath, phobosPath)


### PR DESCRIPTION
Segmentation faults or linker errors occur on 32-bit PIE platforms if any object is not compiled with -fPIC.