### PR TITLE
importC: Move lvalue checking from parse to semantic

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4878,6 +4878,14 @@ extern (C++) final class DotVarExp : UnaExp
     override Expression toLvalue(Scope* sc, Expression e)
     {
         //printf("DotVarExp::toLvalue(%s)\n", toChars());
+        if (sc && sc.flags & SCOPE.Cfile)
+        {
+            /* C11 6.5.2.3-3: A postfix expression followed by the '.' or '->' operator
+             * is an lvalue if the first expression is an lvalue.
+             */
+            if (!e1.isLvalue())
+                return Expression.toLvalue(sc, e);
+        }
         if (!isLvalue())
             return Expression.toLvalue(sc, e);
         if (e1.op == TOK.this_ && sc.ctorflow.fieldinit.length && !(sc.ctorflow.callSuper & CSX.any_ctor))
@@ -5415,6 +5423,12 @@ extern (C++) final class CastExp : UnaExp
 
     override Expression toLvalue(Scope* sc, Expression e)
     {
+        if (sc && sc.flags & SCOPE.Cfile)
+        {
+            /* C11 6.5.4-5: A cast does not yield an lvalue.
+             */
+            return Expression.toLvalue(sc, e);
+        }
         if (isLvalue())
             return this;
         return Expression.toLvalue(sc, e);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7496,6 +7496,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
+        if (sc && sc.flags & SCOPE.Cfile)
+        {
+            /* C11 6.5.4-5: A cast does not yield an lvalue.
+             * So ensure that castTo does not strip away the cast so that this
+             * can be enforced in other semantic visitor methods.
+             */
+            if (!ex.isCastExp())
+            {
+                ex = new CastExp(exp.loc, ex, exp.to);
+                ex.type = exp.to;
+            }
+        }
         result = ex;
     }
 

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -270,6 +270,10 @@ int test22080()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22086
+typedef union U22086 U22086;
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22088
 
 void test22088()

--- a/test/fail_compilation/failcstuff1.c
+++ b/test/fail_compilation/failcstuff1.c
@@ -25,16 +25,7 @@ fail_compilation/failcstuff1.c(260): Error: identifier or `(` expected
 fail_compilation/failcstuff1.c(301): Error: illegal type combination
 fail_compilation/failcstuff1.c(352): Error: found `2` when expecting `:`
 fail_compilation/failcstuff1.c(352): Error: found `:` instead of statement
-fail_compilation/failcstuff1.c(403): Error: left operand is not assignable
-fail_compilation/failcstuff1.c(404): Error: left operand is not assignable
-fail_compilation/failcstuff1.c(405): Error: increment operand is not assignable
-fail_compilation/failcstuff1.c(406): Error: decrement operand is not assignable
-fail_compilation/failcstuff1.c(407): Error: increment operand is not assignable
-fail_compilation/failcstuff1.c(408): Error: decrement operand is not assignable
-fail_compilation/failcstuff1.c(409): Error: cannot take address of unary operand
-fail_compilation/failcstuff1.c(453): Error: increment operand is not assignable
-fail_compilation/failcstuff1.c(454): Error: decrement operand is not assignable
-fail_compilation/failcstuff1.c(600): Error: `enum ENUM` has no members
+fail_compilation/failcstuff1.c(400): Error: `enum ENUM` has no members
 ---
 */
 
@@ -107,32 +98,6 @@ void test22035()
     case 1 2:
 }
 
-// https://issues.dlang.org/show_bug.cgi?id=22067
+// https://issues.dlang.org/show_bug.cgi?id=21932
 #line 400
-void test22067()
-{
-    int var;
-    (int) var = 1;
-    sizeof(var) = 2;
-    ++(short)3;
-    --4;
-    (5)++;
-    ((int)var)--;
-    (&6);
-}
-
-// https://issues.dlang.org/show_bug.cgi?id=22068
-#line 450
-void test22068()
-{
-    int var;
-    ++(short) var;
-    --(long long) var;
-}
-
-// https://issues.dlang.org/show_bug.cgi?id=22086
-#line 500
-typedef union U22086 U22086;
-
-#line 600
 enum ENUM;

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -7,6 +7,23 @@ fail_compilation/failcstuff2.c(56): Error: `var` has no effect
 fail_compilation/failcstuff2.c(57): Error: `-var` has no effect
 fail_compilation/failcstuff2.c(58): Error: `~var` has no effect
 fail_compilation/failcstuff2.c(59): Error: `!var` has no effect
+fail_compilation/failcstuff2.c(113): Error: `cast(int)var` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(114): Error: cannot modify constant `var.sizeof`
+fail_compilation/failcstuff2.c(115): Error: `cast(short)3` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(116): Error: cannot modify constant `4`
+fail_compilation/failcstuff2.c(117): Error: cannot modify constant `5`
+fail_compilation/failcstuff2.c(118): Error: cannot modify constant `6`
+fail_compilation/failcstuff2.c(119): Error: `cast(int)var` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(120): Error: `cast(int)var` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(121): Error: `cast(int)var` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(122): Error: `cast(int)var` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(123): Error: `cast(int)var` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(124): Error: `makeS22067().field` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(125): Error: `makeS22067().field` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(126): Error: `makeS22067().field` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(127): Error: `makeS22067().field` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(153): Error: `cast(short)var` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(154): Error: `cast(long)var` is not an lvalue and cannot be modified
 ---
 */
 
@@ -23,4 +40,47 @@ void test22069()
     -var;
     ~var;
     !var;
+}
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22067
+#line 100
+struct S22067
+{
+    int field;
+};
+
+struct S22067 makeS22067()
+{
+    return (struct S22067) { 42 };
+}
+
+void test22067()
+{
+    int var;
+    (int) var = 1;
+    sizeof(var) = 2;
+    ++(short)3;
+    --4;
+    (5)++;
+    (&6);
+    ((int)var)++;
+    ((int)var)--;
+    ++(int)var;
+    --(int)var;
+    &(int)var;
+    &makeS22067().field;
+    makeS22067().field = 1;
+    makeS22067().field++;
+    --makeS22067().field;
+}
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22068
+#line 150
+void test22068()
+{
+    int var;
+    ++(short) var;
+    --(long long) var;
 }


### PR DESCRIPTION
String and struct literals are not treated as lvalues in semantic, but that will be covered by fixing issues 22070, 22071, and 22072.