### PR TITLE
ImportC: replace AliasDeclarations

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1459,20 +1459,6 @@ final class CParser(AST) : Parser!AST
             {
                 if (!tt.members)
                     error(tt.loc, "`enum %s` has no members", stag.toChars());
-                else
-                {
-                    /* C promotes enum members to the enclosing scope,
-                     * do it by making alias declarations.
-                     * C doesn't have enum.member capability, so can only
-                     * see the members as the aliases.
-                     * D can see the members either way.
-                     */
-                    foreach (m; (*tt.members)[])
-                    {
-                        auto ad = new AST.AliasDeclaration(m.loc, m.ident, m);
-                        symbols.push(ad);
-                    }
-                }
             }
             return;
         }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2001,7 +2001,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
          */
         void declareTag()
         {
-            ScopeDsymbol declare(ScopeDsymbol sd)
+            void declare(ScopeDsymbol sd)
             {
                 sd.members = mtype.members;
                 auto scopesym = sc.inner().scopesym;
@@ -2009,33 +2009,14 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                     scopesym.members.push(sd);
                 sd.parent = sc.parent;
                 sd.dsymbolSemantic(sc);
-                return scopesym;
             }
 
             switch (mtype.tok)
             {
                 case TOK.enum_:
                     auto ed = new EnumDeclaration(mtype.loc, mtype.id, Type.tint32);
-                    auto scopesym = declare(ed);
+                    declare(ed);
                     mtype.resolved = visitEnum(new TypeEnum(ed));
-
-                    // promote each enum member to enclosing scope with alias declarations
-                    if (ed.members)
-                    {
-                        foreach (m; (*ed.members)[])
-                        {
-                            auto ad = new AliasDeclaration(m.loc, m.ident, m);
-                            if (!scopesym.members)
-                                scopesym.members = new Dsymbols();
-                            scopesym.members.push(ad);
-                            ad.setScope(sc);
-                            ad.parent = sc.parent;
-                            if (!scopesym.symtab)
-                                scopesym.symtab = new DsymbolTable();
-                            ad.addMember(sc, scopesym);
-                            ad.dsymbolSemantic(sc);
-                        }
-                    }
                     break;
 
                 case TOK.struct_:

--- a/test/fail_compilation/cenums.c
+++ b/test/fail_compilation/cenums.c
@@ -3,8 +3,7 @@
 fail_compilation/cenums.c(202): Error: `enum E2` is incomplete without members
 fail_compilation/cenums.c(303): Error: redeclaring `union E3` as `enum E3`
 fail_compilation/cenums.c(502): Error: enum member `cenums.test5.F.a` conflicts with enum member `cenums.test5.F.a` at fail_compilation/cenums.c(502)
-fail_compilation/cenums.c(502): Error: declaration `a` is already defined
-fail_compilation/cenums.c(502):        `alias` `a` is defined here
+fail_compilation/cenums.c(502): Error: enum member `cenums.test5.F.a` conflicts with enum member `cenums.test5.F.a` at fail_compilation/cenums.c(502)
 ---
 */
 


### PR DESCRIPTION
Instead of using AliasDeclarations for enum members, put the members into two different symbol tables. This simplifies the code somewhat.

If it works, I can do some refactoring to merge common code, and simplify it more.