### PR TITLE
pull addEnumMembers() code into separate function

### DIFF
--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -86,37 +86,12 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
                 printf("    member %s\n", em.toChars());
             }
         }
-        const bool isCEnum = (sc.flags & SCOPE.Cfile) != 0;
-        const bool isAnon = isAnonymous();
-
-        if (!isAnon)
+        if (!isAnonymous())
         {
             ScopeDsymbol.addMember(sc, sds);
         }
 
-        if (members)
-        {
-            if ((isCEnum || !isAnon) && !symtab)
-                symtab = new DsymbolTable();
-
-            for (size_t i = 0; i < members.dim; i++)
-            {
-                EnumMember em = (*members)[i].isEnumMember();
-                em.ed = this;
-                if (isCEnum)
-                {
-                    em.addMember(sc, this);  // add to EnumDeclaration's symbol table
-                    em.addMember(sc, sds);   // add to enclosing symbol table
-                    em.parent = this;        // previous line changed it
-                }
-                else
-                {
-                    //printf("add %s to scope %s\n", em.toChars(), sds.toChars());
-                    em.addMember(sc, isAnon ? sds : this);
-                }
-            }
-        }
-        added = true;
+        addEnumMembers(this, sc, sds);
     }
 
     override void setScope(Scope* sc)


### PR DESCRIPTION
Factors out two sequences of code, in EnumDeclaration.addMember and in the semantic routine for EnumDeclarations, that adds the enum members into the symbol table. The two sequences did things slightly differently but with the same effect. This makes them behave the same, and there's no longer a need to account for the differences.