### PR TITLE
Fix typo (__gshared -> static) in compilable/dtoh_expressions.d

### DIFF
--- a/test/compilable/dtoh_expressions.d
+++ b/test/compilable/dtoh_expressions.d
@@ -116,7 +116,7 @@ extern void useData(bool a = !Data::pt, bool b = Data::bar() == nullptr, bool c 
 
 struct Data
 {
-    static Data* pt;
+    __gshared Data* pt;
     static int* bar() { return null; }
 }
 


### PR DESCRIPTION
Because static variables are rejected in the glue layer