### PR TITLE
Create a standalone Statement.flatten function to eliminate virtual methods

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -277,11 +277,14 @@ class ErrorStatement;
 class ExpStatement;
 class CompoundStatement;
 class IfStatement;
+class ConditionalStatement;
+class StaticForeachStatement;
 class DefaultStatement;
 class LabelStatement;
 class GotoDefaultStatement;
 class BreakStatement;
 class DtorExpStatement;
+class CompileStatement;
 class ForwardingStatement;
 class DoStatement;
 class WhileStatement;
@@ -290,6 +293,7 @@ class SwitchStatement;
 class ContinueStatement;
 class TryCatchStatement;
 class ThrowStatement;
+class DebugStatement;
 class TryFinallyStatement;
 class ScopeGuardStatement;
 class SwitchErrorStatement;
@@ -3807,7 +3811,6 @@ public:
     bool usesEH();
     bool comeFrom();
     bool hasCode();
-    virtual Array<Statement* >* flatten(Scope* sc);
     virtual Statement* last();
     void accept(Visitor* v);
     virtual ReturnStatement* endsWithReturnStatement();
@@ -3817,6 +3820,8 @@ public:
     CompoundStatement* isCompoundStatement();
     ReturnStatement* isReturnStatement();
     IfStatement* isIfStatement();
+    ConditionalStatement* isConditionalStatement();
+    StaticForeachStatement* isStaticForeachStatement();
     CaseStatement* isCaseStatement();
     DefaultStatement* isDefaultStatement();
     LabelStatement* isLabelStatement();
@@ -3825,6 +3830,7 @@ public:
     GotoCaseStatement* isGotoCaseStatement();
     BreakStatement* isBreakStatement();
     DtorExpStatement* isDtorExpStatement();
+    CompileStatement* isCompileStatement();
     ForwardingStatement* isForwardingStatement();
     DoStatement* isDoStatement();
     WhileStatement* isWhileStatement();
@@ -3835,6 +3841,7 @@ public:
     WithStatement* isWithStatement();
     TryCatchStatement* isTryCatchStatement();
     ThrowStatement* isThrowStatement();
+    DebugStatement* isDebugStatement();
     TryFinallyStatement* isTryFinallyStatement();
     ScopeGuardStatement* isScopeGuardStatement();
     SwitchErrorStatement* isSwitchErrorStatement();
@@ -3899,7 +3906,6 @@ class CompileStatement final : public Statement
 public:
     Array<Expression* >* exps;
     CompileStatement* syntaxCopy();
-    Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
 
@@ -3909,7 +3915,6 @@ public:
     Array<Statement* >* statements;
     static CompoundStatement* create(Loc loc, Statement* s1, Statement* s2);
     CompoundStatement* syntaxCopy();
-    Array<Statement* >* flatten(Scope* sc);
     ReturnStatement* endsWithReturnStatement();
     Statement* last();
     void accept(Visitor* v);
@@ -3920,7 +3925,6 @@ class CompoundAsmStatement final : public CompoundStatement
 public:
     StorageClass stc;
     CompoundAsmStatement* syntaxCopy();
-    Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
 
@@ -3938,7 +3942,6 @@ public:
     Statement* ifbody;
     Statement* elsebody;
     ConditionalStatement* syntaxCopy();
-    Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
 
@@ -3955,7 +3958,6 @@ class DebugStatement final : public Statement
 public:
     Statement* statement;
     DebugStatement* syntaxCopy();
-    Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
 
@@ -3986,7 +3988,6 @@ public:
     Expression* exp;
     static ExpStatement* create(Loc loc, Expression* exp);
     ExpStatement* syntaxCopy();
-    Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
 
@@ -4062,7 +4063,6 @@ public:
     ForwardingScopeDsymbol* sym;
     Statement* statement;
     ForwardingStatement* syntaxCopy();
-    Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
 
@@ -4169,7 +4169,6 @@ public:
     void* extra;
     bool breaks;
     LabelStatement* syntaxCopy();
-    Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
 
@@ -4234,7 +4233,6 @@ class StaticForeachStatement final : public Statement
 public:
     StaticForeach* sfe;
     StaticForeachStatement* syntaxCopy();
-    Array<Statement* >* flatten(Scope* sc);
     void accept(Visitor* v);
 };
 

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -122,7 +122,6 @@ public:
     bool usesEH();
     bool comeFrom();
     bool hasCode();
-    virtual Statements *flatten(Scope *sc);
     virtual Statement *last();
 
     virtual ReturnStatement *endsWithReturnStatement() { return NULL; }
@@ -133,6 +132,8 @@ public:
     CompoundStatement    *isCompoundStatement()    { return stmt == STMTcompound    ? (CompoundStatement*)this    : NULL; }
     ReturnStatement      *isReturnStatement()      { return stmt == STMTreturn      ? (ReturnStatement*)this      : NULL; }
     IfStatement          *isIfStatement()          { return stmt == STMTif          ? (IfStatement*)this          : NULL; }
+    ConditionalStatement *isConditionalStatement() { return stmt == STMTconditional ? (ConditionalStatement*)this : NULL; }
+    StaticForeachStatement *isStaticForeachStatement() { return stmt == STMTstaticForeach ? (StaticForeachStatement*)this : NULL; }
     CaseStatement        *isCaseStatement()        { return stmt == STMTcase        ? (CaseStatement*)this        : NULL; }
     DefaultStatement     *isDefaultStatement()     { return stmt == STMTdefault     ? (DefaultStatement*)this     : NULL; }
     LabelStatement       *isLabelStatement()       { return stmt == STMTlabel       ? (LabelStatement*)this       : NULL; }
@@ -140,6 +141,7 @@ public:
     GotoCaseStatement    *isGotoCaseStatement()    { return stmt == STMTgotoCase    ? (GotoCaseStatement*)this    : NULL; }
     BreakStatement       *isBreakStatement()       { return stmt == STMTbreak       ? (BreakStatement*)this       : NULL; }
     DtorExpStatement     *isDtorExpStatement()     { return stmt == STMTdtorExp     ? (DtorExpStatement*)this     : NULL; }
+    CompileStatement     *isCompileStatement()     { return stmt == STMTcompile     ? (CompileStatement*)this     : NULL; }
     ForwardingStatement  *isForwardingStatement()  { return stmt == STMTforwarding  ? (ForwardingStatement*)this  : NULL; }
     DoStatement          *isDoStatement()          { return stmt == STMTdo          ? (DoStatement*)this          : NULL; }
     ForStatement         *isForStatement()         { return stmt == STMTfor         ? (ForStatement*)this         : NULL; }
@@ -149,6 +151,7 @@ public:
     WithStatement        *isWithStatement()        { return stmt == STMTwith        ? (WithStatement*)this        : NULL; }
     TryCatchStatement    *isTryCatchStatement()    { return stmt == STMTtryCatch    ? (TryCatchStatement*)this    : NULL; }
     ThrowStatement       *isThrowStatement()       { return stmt == STMTthrow       ? (ThrowStatement*)this       : NULL; }
+    DebugStatement       *isDebugStatement()       { return stmt == STMTdebug       ? (DebugStatement*)this       : NULL; }
     TryFinallyStatement  *isTryFinallyStatement()  { return stmt == STMTtryFinally  ? (TryFinallyStatement*)this  : NULL; }
     ScopeGuardStatement  *isScopeGuardStatement()  { return stmt == STMTscopeGuard  ? (ScopeGuardStatement*)this  : NULL; }
     SwitchErrorStatement  *isSwitchErrorStatement()  { return stmt == STMTswitchError  ? (SwitchErrorStatement*)this  : NULL; }
@@ -185,7 +188,6 @@ public:
 
     static ExpStatement *create(Loc loc, Expression *exp);
     ExpStatement *syntaxCopy();
-    Statements *flatten(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -208,7 +210,6 @@ public:
     Expressions *exps;
 
     CompileStatement *syntaxCopy();
-    Statements *flatten(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -219,7 +220,6 @@ public:
 
     static CompoundStatement *create(Loc loc, Statement *s1, Statement *s2);
     CompoundStatement *syntaxCopy();
-    Statements *flatten(Scope *sc);
     ReturnStatement *endsWithReturnStatement();
     Statement *last();
 
@@ -269,7 +269,6 @@ public:
     Statement *statement;
 
     ForwardingStatement *syntaxCopy();
-    Statements *flatten(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -390,7 +389,6 @@ public:
     Statement *elsebody;
 
     ConditionalStatement *syntaxCopy();
-    Statements *flatten(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -401,7 +399,6 @@ public:
     StaticForeach *sfe;
 
     StaticForeachStatement *syntaxCopy();
-    Statements *flatten(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -656,7 +653,6 @@ public:
     Statement *statement;
 
     DebugStatement *syntaxCopy();
-    Statements *flatten(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -689,7 +685,6 @@ public:
     bool breaks;                // someone did a 'break ident'
 
     LabelStatement *syntaxCopy();
-    Statements *flatten(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -756,7 +751,6 @@ public:
     StorageClass stc; // postfix attributes like nothrow/pure/@trusted
 
     CompoundAsmStatement *syntaxCopy();
-    Statements *flatten(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION

Switch/case seemed like the way to go here since there were a fair number of overrides originally

I'll address @thewilsonator 's review below in a followup PR.  Once this is merged, flatten and a couple of private functions can be moved to statementsem and eliminate imports of semantic modules to statment.d