### PR TITLE
Use isReference for ref/out checks

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -526,6 +526,12 @@ extern (C++) abstract class Declaration : Dsymbol
         return (storage_class & STC.ref_) != 0;
     }
 
+    /// Returns: Whether the variable is a reference, annotated with `out` or `ref`
+    final bool isReference() const pure nothrow @nogc @safe
+    {
+        return (storage_class & (STC.ref_ | STC.out_)) != 0;
+    }
+
     final bool isFuture() const pure nothrow @nogc @safe
     {
         return (storage_class & STC.future) != 0;

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -134,6 +134,7 @@ public:
     bool isIn()  const  { return (storage_class & STCin) != 0; }
     bool isOut() const  { return (storage_class & STCout) != 0; }
     bool isRef() const  { return (storage_class & STCref) != 0; }
+    bool isReference() const { return (storage_class & (STCref | STCout)) != 0; }
 
     bool isFuture() const { return (storage_class & STCfuture) != 0; }
 

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -351,7 +351,7 @@ public:
     extern (C++) void pop(VarDeclaration v)
     {
         assert(!v.isDataseg() || v.isCTFE());
-        assert(!(v.storage_class & (STC.ref_ | STC.out_)));
+        assert(!v.isReference());
         const oldid = v.ctfeAdrOnStack;
         v.ctfeAdrOnStack = cast(uint)cast(size_t)savedId[oldid];
         if (v.ctfeAdrOnStack == values.dim - 1)
@@ -2132,7 +2132,7 @@ public:
                     errorSupplemental(vie.var.loc, "`%s` was uninitialized and used before set", vie.var.toChars());
                     return CTFEExp.cantexp;
                 }
-                if (goal != CTFEGoal.LValue && (v.isRef() || v.isOut()))
+                if (goal != CTFEGoal.LValue && v.isReference())
                     e = interpret(e, istate, goal);
             }
             if (!e)

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1842,7 +1842,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
                     // https://issues.dlang.org/show_bug.cgi?id=12876
                     // Optimize argument to allow CT-known length matching
-                    farg = farg.optimize(WANTvalue, (fparam.storageClass & (STC.ref_ | STC.out_)) != 0);
+                    farg = farg.optimize(WANTvalue, fparam.isReference());
                     //printf("farg = %s %s\n", farg.type.toChars(), farg.toChars());
 
                     RootObject oarg = farg;

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -89,7 +89,7 @@ void* mem_malloc2(uint);
  */
 bool ISREF(Declaration var)
 {
-    if (var.isOut() || var.isRef())
+    if (var.isReference())
     {
         return true;
     }
@@ -101,7 +101,7 @@ bool ISREF(Declaration var)
  */
 bool ISX64REF(Declaration var)
 {
-    if (var.isOut() || var.isRef())
+    if (var.isReference())
     {
         return false;
     }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -6071,7 +6071,7 @@ extern (C++) final class ConstructExp : AssignExp
 
         super(loc, TOK.construct, ve, e2);
 
-        if (v.storage_class & (STC.ref_ | STC.out_))
+        if (v.isReference())
             memset = MemorySet.referenceInit;
     }
 
@@ -6099,7 +6099,7 @@ extern (C++) final class BlitExp : AssignExp
 
         super(loc, TOK.blit, ve, e2);
 
-        if (v.storage_class & (STC.ref_ | STC.out_))
+        if (v.isReference())
             memset = MemorySet.referenceInit;
     }
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1872,8 +1872,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
         L1:
             if (!(p.storageClass & STC.lazy_ && p.type.ty == Tvoid))
             {
-                const isRef = (p.storageClass & (STC.ref_ | STC.out_)) != 0;
-                if (ubyte wm = arg.type.deduceWild(p.type, isRef))
+                if (ubyte wm = arg.type.deduceWild(p.type, p.isReference()))
                 {
                     wildmatch = wildmatch ? MODmerge(wildmatch, wm) : wm;
                     //printf("[%d] p = %s, a = %s, wm = %d, wildmatch = %d\n", i, p.type.toChars(), arg.type.toChars(), wm, wildmatch);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5552,6 +5552,7 @@ public:
     bool isIn() const;
     bool isOut() const;
     bool isRef() const;
+    bool isReference() const;
     bool isFuture() const;
     Visibility visible();
     Declaration* isDeclaration();

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -461,7 +461,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             if (e.e1.op == TOK.variable)
             {
                 VarExp ve = cast(VarExp)e.e1;
-                if (!ve.var.isOut() && !ve.var.isRef() && !ve.var.isImportedSymbol())
+                if (!ve.var.isReference() && !ve.var.isImportedSymbol())
                 {
                     ret = new SymOffExp(e.loc, ve.var, 0, ve.hasOverloads);
                     ret.type = e.type;

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1112,7 +1112,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                     foreach (v; *funcdecl.parameters)
                     {
-                        if (v.storage_class & (STC.ref_ | STC.out_ | STC.lazy_))
+                        if (v.isReference() || (v.storage_class & STC.lazy_))
                             continue;
                         if (v.needsScopeDtor())
                         {

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1433,7 +1433,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     auto var = new VarDeclaration(loc, p.type, p.ident, null);
                     var.storage_class |= STC.foreach_;
                     var.storage_class |= p.storageClass & (STC.IOR | STC.TYPECTOR);
-                    if (var.storage_class & (STC.ref_ | STC.out_))
+                    if (var.isReference())
                         var.storage_class |= STC.nodtor;
 
                     fs.value = var;

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -849,7 +849,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
         typeof(Type.size()) lastsize;
         if (vlast.storage_class & STC.lazy_)
             lastsize = target.ptrsize * 2;
-        else if (vlast.isRef() || vlast.isOut())
+        else if (vlast.isReference)
             lastsize = target.ptrsize;
         else
             lastsize = vlast.type.size();


### PR DESCRIPTION
Expands https://github.com/dlang/dmd/pull/11419 for var declarations. Mainly done to make escape.d more readable.
I did encounter some dubious cases where `out` is not treated as `ref`, but this PR is purely a refactoring and not changing behavior.