### PR TITLE
move dstruct.semanticTypeInfoMembers to semantic3 which is the only caller

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -193,7 +193,6 @@ public:
 
     static StructDeclaration *create(Loc loc, Identifier *id, bool inObject);
     StructDeclaration *syntaxCopy(Dsymbol *s);
-    void semanticTypeInfoMembers();
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
     const char *kind() const;
     void finalizeSize();

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -31,7 +31,6 @@ import dmd.id;
 import dmd.identifier;
 import dmd.mtype;
 import dmd.opover;
-import dmd.semantic3;
 import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
@@ -246,58 +245,6 @@ extern (C++) class StructDeclaration : AggregateDeclaration
               : new StructDeclaration(loc, ident, false);
         ScopeDsymbol.syntaxCopy(sd);
         return sd;
-    }
-
-    final void semanticTypeInfoMembers()
-    {
-        if (xeq &&
-            xeq._scope &&
-            xeq.semanticRun < PASS.semantic3done)
-        {
-            uint errors = global.startGagging();
-            xeq.semantic3(xeq._scope);
-            if (global.endGagging(errors))
-                xeq = xerreq;
-        }
-
-        if (xcmp &&
-            xcmp._scope &&
-            xcmp.semanticRun < PASS.semantic3done)
-        {
-            uint errors = global.startGagging();
-            xcmp.semantic3(xcmp._scope);
-            if (global.endGagging(errors))
-                xcmp = xerrcmp;
-        }
-
-        FuncDeclaration ftostr = search_toString(this);
-        if (ftostr &&
-            ftostr._scope &&
-            ftostr.semanticRun < PASS.semantic3done)
-        {
-            ftostr.semantic3(ftostr._scope);
-        }
-
-        if (xhash &&
-            xhash._scope &&
-            xhash.semanticRun < PASS.semantic3done)
-        {
-            xhash.semantic3(xhash._scope);
-        }
-
-        if (postblit &&
-            postblit._scope &&
-            postblit.semanticRun < PASS.semantic3done)
-        {
-            postblit.semantic3(postblit._scope);
-        }
-
-        if (dtor &&
-            dtor._scope &&
-            dtor.semanticRun < PASS.semantic3done)
-        {
-            dtor.semantic3(dtor._scope);
-        }
     }
 
     override final Dsymbol search(const ref Loc loc, Identifier ident, int flags = SearchLocalsOnly)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6066,7 +6066,6 @@ public:
     TypeTuple* argTypes;
     static StructDeclaration* create(Loc loc, Identifier* id, bool inObject);
     StructDeclaration* syntaxCopy(Dsymbol* s);
-    void semanticTypeInfoMembers();
     Dsymbol* search(const Loc& loc, Identifier* ident, int32_t flags = 8);
     const char* kind() const;
     void finalizeSize();

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1570,3 +1570,55 @@ private struct FuncDeclSem3
         }
     }
 }
+
+private void semanticTypeInfoMembers(StructDeclaration sd)
+{
+    if (sd.xeq &&
+        sd.xeq._scope &&
+        sd.xeq.semanticRun < PASS.semantic3done)
+    {
+        uint errors = global.startGagging();
+        sd.xeq.semantic3(sd.xeq._scope);
+        if (global.endGagging(errors))
+            sd.xeq = sd.xerreq;
+    }
+
+    if (sd.xcmp &&
+        sd.xcmp._scope &&
+        sd.xcmp.semanticRun < PASS.semantic3done)
+    {
+        uint errors = global.startGagging();
+        sd.xcmp.semantic3(sd.xcmp._scope);
+        if (global.endGagging(errors))
+            sd.xcmp = sd.xerrcmp;
+    }
+
+    FuncDeclaration ftostr = search_toString(sd);
+    if (ftostr &&
+        ftostr._scope &&
+        ftostr.semanticRun < PASS.semantic3done)
+    {
+        ftostr.semantic3(ftostr._scope);
+    }
+
+    if (sd.xhash &&
+        sd.xhash._scope &&
+        sd.xhash.semanticRun < PASS.semantic3done)
+    {
+        sd.xhash.semantic3(sd.xhash._scope);
+    }
+
+    if (sd.postblit &&
+        sd.postblit._scope &&
+        sd.postblit.semanticRun < PASS.semantic3done)
+    {
+        sd.postblit.semantic3(sd.postblit._scope);
+    }
+
+    if (sd.dtor &&
+        sd.dtor._scope &&
+        sd.dtor.semanticRun < PASS.semantic3done)
+    {
+        sd.dtor.semantic3(sd.dtor._scope);
+    }
+}


### PR DESCRIPTION
Eliminates importing semantic3 into dstruct.

This could use `with` instead of adding a bunch of `sd.` if folks think that's more readable