### PR TITLE
fix Issue 22103 - importC: Parser accepts wrong syntax for array declarators

### DIFF
--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -321,6 +321,12 @@ void test22088()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22103
+
+void test22103a(char *const argv[restrict]);
+void test22103b(char *const argv[restrict 4]);
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22106
 
 typedef struct S22106
@@ -343,4 +349,3 @@ void testS22106()
 int S22106; // not a redeclaration of 'struct S22106'
 
 /***************************************************/
-

--- a/test/fail_compilation/failcstuff1.c
+++ b/test/fail_compilation/failcstuff1.c
@@ -26,6 +26,20 @@ fail_compilation/failcstuff1.c(301): Error: illegal type combination
 fail_compilation/failcstuff1.c(352): Error: found `2` when expecting `:`
 fail_compilation/failcstuff1.c(352): Error: found `:` instead of statement
 fail_compilation/failcstuff1.c(400): Error: `enum ENUM` has no members
+fail_compilation/failcstuff1.c(450): Error: static array parameters are not supported
+fail_compilation/failcstuff1.c(450): Error: static or type qualifier used in non-outermost array type derivation
+fail_compilation/failcstuff1.c(451): Error: static or type qualifier used in non-outermost array type derivation
+fail_compilation/failcstuff1.c(451): Error: array type has incomplete element type `int[]`
+fail_compilation/failcstuff1.c(452): Error: array type has incomplete element type `int[]`
+fail_compilation/failcstuff1.c(453): Error: array type has incomplete element type `int[]`
+fail_compilation/failcstuff1.c(454): Error: found `const` when expecting `,`
+fail_compilation/failcstuff1.c(458): Error: static array parameters are not supported
+fail_compilation/failcstuff1.c(458): Error: static or type qualifier used outside of function prototype
+fail_compilation/failcstuff1.c(459): Error: static or type qualifier used outside of function prototype
+fail_compilation/failcstuff1.c(460): Error: variable length arrays are not supported
+fail_compilation/failcstuff1.c(460): Error: variable length array used outside of function prototype
+fail_compilation/failcstuff1.c(461): Error: array type has incomplete element type `int[]`
+fail_compilation/failcstuff1.c(462): Error: `=`, `;` or `,` expected
 ---
 */
 
@@ -101,3 +115,20 @@ void test22035()
 // https://issues.dlang.org/show_bug.cgi?id=21932
 #line 400
 enum ENUM;
+
+// https://issues.dlang.org/show_bug.cgi?id=22103
+#line 450
+void test22103a(int array[4][static 4]);
+void test22103b(int array[4][restrict]);
+void test22103c(int array[4][]);
+void test22103d(int array[][]);
+void test22103e(int array[4] const);
+
+void test22103e()
+{
+    int array1[static volatile 4];
+    int array2[restrict 4];
+    int array3[4][*];
+    int array4[][];
+    int array4[4] const;
+}

--- a/test/fail_compilation/failcstuff3.c
+++ b/test/fail_compilation/failcstuff3.c
@@ -2,7 +2,8 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/failcstuff3.c(54): Error: redeclaration of `S22061`
-fail_compilation/failcstuff3.c(107): Error: variable `failcstuff3.T22106.f1` no definition of struct `S22106_t`
+fail_compilation/failcstuff3.c(100): Error: can only `*` a pointer, not a `int`
+fail_compilation/failcstuff3.c(157): Error: variable `failcstuff3.T22106.f1` no definition of struct `S22106_t`
 ---
 */
 
@@ -16,8 +17,13 @@ struct S22061
 typedef union S22061 S22061;
 
 /***************************************************/
-// https://issues.dlang.org/show_bug.cgi?id=22106
+// https://issues.dlang.org/show_bug.cgi?id=22103
 #line 100
+int test22103(int array[*4]);
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22106
+#line 150
 typedef struct S22106
 {
     int field;


### PR DESCRIPTION
Implements correct grammar as per C11 6.7.6.2, and issues errors where there is a violation.

@WalterBright is there any reason why `static` is rejected?  As far as I can tell, it's only a keyword that enforces that a valid array size is given.

Arrays parsed by importC do not currently saturate to a pointer, that should be dealt with later though.