### PR TITLE
fix Issue 22108 - parameter mistakenly interpreted as return scope instead of scope

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1185,6 +1185,8 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
         if (v.isDataseg())
             continue;
 
+        const vsr = buildScopeRef(v.storage_class);
+
         Dsymbol p = v.toParent2();
 
         if ((v.isScope() || (v.storage_class & STC.maybescope)) &&
@@ -1200,8 +1202,13 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
 
         if (v.isScope())
         {
-            if (v.storage_class & STC.return_)
+            /* If `return scope` applies to v.
+             */
+            if (vsr == ScopeRef.ReturnScope ||
+                vsr == ScopeRef.Ref_ReturnScope)
+            {
                 continue;
+            }
 
             auto pfunc = p.isFuncDeclaration();
             if (pfunc &&

--- a/test/fail_compilation/fix22108.d
+++ b/test/fail_compilation/fix22108.d
@@ -1,0 +1,13 @@
+/* REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/fix22108.d(12): Error: scope variable `p` may not be returned
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22108
+
+@safe ref int test(ref scope return int* p)
+{
+    return *p;
+}

--- a/test/fail_compilation/test20881.d
+++ b/test/fail_compilation/test20881.d
@@ -2,6 +2,7 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
+fail_compilation/test20881.d(20): Error: scope variable `this` may not be returned
 fail_compilation/test20881.d(27): Error: address of variable `s` assigned to `global` with longer lifetime
 fail_compilation/test20881.d(28): Error: address of variable `s` assigned to `global` with longer lifetime
 fail_compilation/test20881.d(29): Error: address of variable `s` assigned to `global` with longer lifetime
@@ -10,7 +11,6 @@ fail_compilation/test20881.d(29): Error: address of variable `s` assigned to `gl
 @safe:
 
 // https://issues.dlang.org/show_bug.cgi?id=20881
-
 struct S
 {
     int* ptr;


### PR DESCRIPTION
Consider the ambiguity of a `return ref scope` parameter. Which is it:

1. `return ref` and `scope`
2. `ref` and `return scope`

? The ambiguity is resolved by looking at the function return. If it returns
by `ref`, then it's (1), otherwise (2). This is evident in the table above.
This rule is arbitrary, precluding things like creating a `return ref` and
`return scope` for the same parameter.