### PR TITLE
fix Issue 22106 - importC: Error: variable 'var' no definition of struct 'type'

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2007,6 +2007,11 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                 auto scopesym = sc.inner().scopesym;
                 if (scopesym.members)
                     scopesym.members.push(sd);
+                if (scopesym.symtab && !scopesym.symtabInsert(sd))
+                {
+                    Dsymbol s2 = scopesym.symtabLookup(sd, mtype.id);
+                    handleTagSymbols(*sc, sd, s2, scopesym);
+                }
                 sd.parent = sc.parent;
                 sd.dsymbolSemantic(sc);
             }

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -321,4 +321,26 @@ void test22088()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22106
+
+typedef struct S22106
+{
+    int field;
+} S22106_t;
+
+struct T22106
+{
+    struct S22106 f1;
+    S22106_t f2;
+};
+
+void testS22106()
+{
+    struct S22106 v1;
+    S22106_t v2;
+}
+
+int S22106; // not a redeclaration of 'struct S22106'
+
+/***************************************************/
 

--- a/test/fail_compilation/failcstuff3.c
+++ b/test/fail_compilation/failcstuff3.c
@@ -2,6 +2,7 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/failcstuff3.c(54): Error: redeclaration of `S22061`
+fail_compilation/failcstuff3.c(107): Error: variable `failcstuff3.T22106.f1` no definition of struct `S22106_t`
 ---
 */
 
@@ -13,3 +14,16 @@ struct S22061
     int field;
 };
 typedef union S22061 S22061;
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22106
+#line 100
+typedef struct S22106
+{
+    int field;
+} S22106_t;
+
+struct T22106
+{
+    struct S22106_t f1;
+};


### PR DESCRIPTION
The resolved TypeTag was not pushed into the scope's symtab, so subsequent scope searches failed.