### PR TITLE
azure-pipelines.yml: Reduce timeout time to 60 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 
 jobs:
   - job: Windows_DMD_bootstrap
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
     pool:
       vmImage: 'vs2017-win2016'
     variables:
@@ -24,7 +24,7 @@ jobs:
       - template: .azure-pipelines/windows.yml
 
   - job: Windows_DMD_latest
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
     pool:
       vmImage: 'vs2017-win2016'
     variables:
@@ -45,7 +45,7 @@ jobs:
       - template: .azure-pipelines/windows-artifact.yml
 
   - job: Windows_Coverage
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
     pool:
       vmImage: 'vs2017-win2016'
     variables:
@@ -68,7 +68,7 @@ jobs:
       - template: .azure-pipelines/windows.yml
 
   - job: Windows_VisualD_LDC
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
     pool:
       vmImage: 'vs2017-win2016'
     variables:


### PR DESCRIPTION
Working pipelines finish within 30 minutes, this prevents choking up the PR queue when there are real issues going on that cause Azure CI to stop and stall until the timeout limit.