### PR TITLE
fix Issue 21868 - DIP1000 does not catch pointer to struct temporary

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -7233,6 +7233,7 @@ ScopeRef buildScopeRef(bool returnByRef, StorageClass stc) pure nothrow @nogc @s
     ScopeRef result;
     final switch (stc & (STC.ref_ | STC.scope_ | STC.return_))
     {
+        case STC.return_:
         case 0:                        result = ScopeRef.None;        break;
         case STC.ref_:                 result = ScopeRef.Ref;         break;
         case STC.scope_:               result = ScopeRef.Scope;       break;

--- a/test/fail_compilation/fail21868b.d
+++ b/test/fail_compilation/fail21868b.d
@@ -1,0 +1,22 @@
+/* REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/fail21868b.d(19): Error: returning `&s.x` escapes a reference to parameter `s`
+fail_compilation/fail21868b.d(19):        perhaps remove `scope` parameter annotation so `return` applies to `ref`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=21868
+
+struct S
+{
+    int x;
+    int* y;
+}
+
+int* test(ref return scope S s)
+{
+    return &s.x;
+}
+
+


### PR DESCRIPTION
Switch to using buildScopeRef() as it takes into account whether `return` applies to `scope` or `ref`. For the purpose of the bug fix, I limited its use to just the bug fix. Will roll it out more generally in a later PR.