### PR TITLE
dtoh: Ensure that parent aggregates are emitted when referencing...

### DIFF
--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -2841,8 +2841,12 @@ public:
     /**
      * Writes the qualified name of `sym` into `buf` including parent
      * symbols and template parameters.
+     *
+     * Params:
+     *   sym         = the symbol
+     *   mustInclude = whether sym may not be forward declared
      */
-    private void writeFullName(AST.Dsymbol sym)
+    private void writeFullName(AST.Dsymbol sym, const bool mustInclude = false)
     in
     {
         assert(sym);
@@ -2886,13 +2890,20 @@ public:
             nested = !par.isModule();
             if (nested && !isNestedIn(par, adparent))
             {
-                writeFullName(par);
+                writeFullName(par, true);
                 buf.writestring("::");
             }
         }
 
         if (!nested)
-            ensureDeclared(sym);
+        {
+            // Cannot forward the symbol when called recursively
+            // for a nested symbol
+            if (mustInclude)
+                includeSymbol(sym);
+            else
+                ensureDeclared(sym);
+        }
 
         if (ti)
             visitTi(ti);

--- a/test/compilable/dtoh_forwarding.d
+++ b/test/compilable/dtoh_forwarding.d
@@ -42,7 +42,6 @@ struct _d_dynamicArray final
 struct Child;
 class Struct;
 enum class Enum;
-struct OuterStruct;
 class ExternDClass;
 struct ExternDStruct;
 template <typename T>
@@ -55,6 +54,20 @@ class ExternDTemplClass;
 struct Parent
 {
     virtual void bar();
+};
+
+struct OuterStruct final
+{
+    struct NestedStruct final
+    {
+        NestedStruct()
+        {
+        }
+    };
+
+    OuterStruct()
+    {
+    }
 };
 
 struct ExternDStructRequired final
@@ -103,20 +116,6 @@ enum class Enum
 };
 
 extern OuterStruct::NestedStruct* nestedStrPtr;
-
-struct OuterStruct final
-{
-    struct NestedStruct final
-    {
-        NestedStruct()
-        {
-        }
-    };
-
-    OuterStruct()
-    {
-    }
-};
 
 extern ExternDClass* externDClassPtr;
 


### PR DESCRIPTION
... nested types

Track whether `writeSymbol` was called recursively to detect nested types.

---

Extracted from #12797 
Didn't add a changelog entry because this is a followup to #12696 