### PR TITLE
importC: Give C functions correct start and end locations

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1738,7 +1738,7 @@ final class CParser(AST) : Parser!AST
         auto body = cparseStatement(ParseStatementFlags.curly);  // don't start a new scope; continue with parameter scope
         Specifier specifier;
         specifier.scw = scw;
-        auto fd = new AST.FuncDeclaration(token.loc, Loc.initial, id, specifiersToSTC(LVL.global, specifier), ft);
+        auto fd = new AST.FuncDeclaration(locFunc, prevloc, id, specifiersToSTC(LVL.global, specifier), ft);
 
         if (addFuncName)
         {

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -25,9 +25,9 @@ fail_compilation/failcstuff2.c(127): Error: `makeS22067().field` is not an lvalu
 fail_compilation/failcstuff2.c(153): Error: `cast(short)var` is not an lvalue and cannot be modified
 fail_compilation/failcstuff2.c(154): Error: `cast(long)var` is not an lvalue and cannot be modified
 fail_compilation/failcstuff2.c(204): Error: variable `var` is used as a type
-fail_compilation/failcstuff2.c(207):        variable `var` is declared here
+fail_compilation/failcstuff2.c(203):        variable `var` is declared here
 fail_compilation/failcstuff2.c(205): Error: variable `var` is used as a type
-fail_compilation/failcstuff2.c(207):        variable `var` is declared here
+fail_compilation/failcstuff2.c(203):        variable `var` is declared here
 ---
 */
 


### PR DESCRIPTION
`locFunc` is the position of the opening `{`, and `prevloc` is the position of the closing `}` that was consumed by`cparseStatement`.