### PR TITLE
Fix 5309 - Support `extern(D)` symbol refs

### DIFF
--- a/changelog/externd.md
+++ b/changelog/externd.md
@@ -1,0 +1,17 @@
+# Added support for `extern(D)` declarations from another module (`extern(D, pkg.mod)`)
+
+`extern(D)` symbols were previously assumed to be in the same module, which was of limited use.
+Multiple projects (including druntime itself) worked around that limitation by using
+`pragma(mangle)` on symbols, along with `core.demangle : mangle`.
+
+This release adds proper support for `extern(D)` symbols defined in another module,
+by allowing one to specify the module name as an optional second argument:
+```
+module awesomelib.awesomemod;
+
+extern(D, secretlib.secretmodule) void initializeDLL();
+```
+
+Note that the functionality was previously possible by using header (`.di`) files,
+however it required adding a new file to one's project, and wasn't as convenient
+to use as other `extern` (C, C++, Objective-C) declarations.

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -147,7 +147,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         sc2.explicitVisibility = 0;
         sc2.aligndecl = null;
         sc2.userAttribDecl = null;
-        sc2.namespace = null;
+        sc2.mangleParent = typeof(Scope.mangleParent).init;
         return sc2;
     }
 

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1060,9 +1060,9 @@ struct ASTBase
     {
         LINK linkage;
 
-        extern (D) this(const ref Loc loc, LINK p, Dsymbols* decl)
+        extern (D) this(const ref Loc loc, LINK p, Dsymbols* decl, Identifier id = null)
         {
-            super(loc, null, decl);
+            super(loc, id, decl);
             this.linkage = p;
         }
 

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -924,7 +924,7 @@ extern(D):
                     {
                         writeName(ag.mangleOverride.id);
                         if (sym.parent && !sym.parent.needThis())
-                            for (auto ns = ag.mangleOverride.agg.toAlias().cppnamespace; ns !is null && ns.ident !is null; ns = ns.cppnamespace)
+                            for (auto ns = ag.mangleOverride.agg.toAlias().mangleParent.hasCPPNamespace; ns !is null && ns.ident !is null; ns = ns.mangleParent.hasCPPNamespace)
                                 writeName(ns.ident);
                         return;
                     }
@@ -935,7 +935,7 @@ extern(D):
                 else
                 {
                     writeName(ag.mangleOverride.id);
-                    for (auto ns = ti.toAlias().cppnamespace; ns !is null && ns.ident !is null; ns = ns.cppnamespace)
+                    for (auto ns = ti.toAlias().mangleParent.hasCPPNamespace; ns !is null && ns.ident !is null; ns = ns.mangleParent.hasCPPNamespace)
                         writeName(ns.ident);
                     return;
                 }
@@ -997,7 +997,7 @@ extern(D):
         writeName(Identifier.idPool(tmp.buf.extractSlice()));
         if (needNamespaces && actualti != ti)
         {
-            for (auto ns = ti.toAlias().cppnamespace; ns !is null && ns.ident !is null; ns = ns.cppnamespace)
+            for (auto ns = ti.toAlias().mangleParent.hasCPPNamespace; ns !is null && ns.ident !is null; ns = ns.mangleParent.hasCPPNamespace)
                 writeName(ns.ident);
         }
     }
@@ -1060,7 +1060,7 @@ extern(D):
         {
             mangleName(p, dont_use_back_reference);
             // Mangle our string namespaces as well
-            for (auto ns = p.cppnamespace; ns !is null && ns.ident !is null; ns = ns.cppnamespace)
+            for (auto ns = p.mangleParent.hasCPPNamespace; ns !is null && ns.ident !is null; ns = ns.mangleParent.hasCPPNamespace)
                 mangleName(ns, dont_use_back_reference);
 
             p = p.toParent();

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -623,7 +623,15 @@ public:
         if (TemplateInstance ti = s.isTemplateInstance())
             p = ti.isTemplateMixin() ? ti.parent : ti.tempdecl.parent;
         else
-            p = s.parent;
+        {
+            // `extern(D, some.parent.here)`
+            auto ld = s.mangleParent.hasLink();
+            if (ld && ld.linkage == LINK.d && ld.ident !is null)
+                p = ld;
+            else
+                p = s.parent;
+        }
+
         if (p)
         {
             uint localNum = s.localNum;

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -113,8 +113,8 @@ struct Scope
     /// alignment for struct members
     AlignDeclaration aligndecl;
 
-    /// C++ namespace this symbol is in
-    CPPNamespaceDeclaration namespace;
+    /// C++ namespace or `extern(D, mod)` this symbol is in
+    ParentSymbolAttribute mangleParent;
 
     /// linkage for external functions
     LINK linkage = LINK.d;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -224,8 +224,8 @@ extern (C++) class Dsymbol : ASTNode
 {
     Identifier ident;
     Dsymbol parent;
-    /// C++ namespace this symbol belongs to
-    CPPNamespaceDeclaration cppnamespace;
+    /// C++ namespace or `extern(D, module)` this symbol belongs to
+    ParentSymbolAttribute mangleParent;
     Symbol* csym;           // symbol for code generator
     Symbol* isym;           // import version of csym
     const(char)* comment;   // documentation comment for this Dsymbol
@@ -2366,5 +2366,3 @@ Dsymbol handleTagSymbols(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsymbol sds)
     if (log) printf(" collision\n");
     return null;
 }
-
-

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -17,6 +17,7 @@
 #include "visitor.h"
 
 class CPPNamespaceDeclaration;
+class LinkDeclaration;
 class Identifier;
 struct Scope;
 class DsymbolTable;
@@ -89,6 +90,21 @@ void dsymbolSemantic(Dsymbol *dsym, Scope *sc);
 void semantic2(Dsymbol *dsym, Scope *sc);
 void semantic3(Dsymbol *dsym, Scope* sc);
 
+struct ParentSymbolAttribute
+{
+private:
+    union {
+        LinkDeclaration *link;
+        CPPNamespaceDeclaration *cpp;
+    };
+    bool isLinkDecl;
+
+    void accept(Visitor* v);
+    CPPNamespaceDeclaration* hasCPPNamespace();
+    LinkDeclaration* hasLink();
+    AttribDeclaration* asAttribute();
+};
+
 struct Visibility
 {
     enum Kind
@@ -144,8 +160,8 @@ class Dsymbol : public ASTNode
 public:
     Identifier *ident;
     Dsymbol *parent;
-    /// C++ namespace this symbol belongs to
-    CPPNamespaceDeclaration *namespace_;
+    /// C++ namespace or `extern(D, module)` this symbol belongs to
+    ParentSymbolAttribute mangleParent;
     Symbol *csym;               // symbol for code generator
     Symbol *isym;               // import version of csym
     const utf8_t *comment;      // documentation comment for this Dsymbol

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -348,7 +348,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym.error("extern symbols cannot have initializers");
 
         dsym.userAttribDecl = sc.userAttribDecl;
-        dsym.cppnamespace = sc.namespace;
+        dsym.mangleParent = sc.mangleParent;
 
         AggregateDeclaration ad = dsym.isThis();
         if (ad)
@@ -1766,7 +1766,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (ns.ident is null)
         {
-            ns.cppnamespace = sc.namespace;
+            ns.mangleParent = sc.mangleParent;
             sc = sc.startCTFE();
             ns.exp = ns.exp.expressionSemantic(sc);
             ns.exp = resolveProperties(sc, ns.exp);
@@ -1776,16 +1776,16 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (auto te = ns.exp.isTupleExp())
             {
                 expandTuples(te.exps);
-                CPPNamespaceDeclaration current = ns.cppnamespace;
+                CPPNamespaceDeclaration current = ns.mangleParent.hasCPPNamespace;
                 for (size_t d = 0; d < te.exps.dim; ++d)
                 {
                     auto exp = (*te.exps)[d];
-                    auto prev = d ? current : ns.cppnamespace;
+                    auto prev = d ? current : ns.mangleParent.hasCPPNamespace;
                     current = (d + 1) != te.exps.dim
                         ? new CPPNamespaceDeclaration(ns.loc, exp, null)
                         : ns;
                     current.exp = exp;
-                    current.cppnamespace = prev;
+                    current.mangleParent = ParentSymbolAttribute(prev);
                     if (auto se = exp.toStringExp())
                     {
                         current.ident = identFromSE(se);
@@ -1808,6 +1808,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                              ns.exp.toChars());
         }
         attribSemantic(ns);
+    }
+
+    override void visit(LinkDeclaration ld)
+    {
+        if (auto prev = sc.mangleParent.hasLink())
+            ld.mangleParent = prev;
+        return attribSemantic(ld);
     }
 
     override void visit(UserAttributeDeclaration uad)
@@ -1915,7 +1922,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (sc.stc & STC.deprecated_)
             ed.isdeprecated = true;
         ed.userAttribDecl = sc.userAttribDecl;
-        ed.cppnamespace = sc.namespace;
+        ed.mangleParent = sc.mangleParent;
 
         ed.semanticRun = PASS.semantic;
         UserAttributeDeclaration.checkGNUABITag(ed, sc.linkage);
@@ -2312,7 +2319,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         tempdecl.parent = sc.parent;
         tempdecl.visibility = sc.visibility;
-        tempdecl.cppnamespace = sc.namespace;
+        tempdecl.mangleParent = sc.mangleParent;
         tempdecl.isstatic = tempdecl.toParent().isModule() || (tempdecl._scope.stc & STC.static_);
         tempdecl.deprecated_ = !!(sc.stc & STC.deprecated_);
 
@@ -2794,7 +2801,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!sc || funcdecl.errors)
             return;
 
-        funcdecl.cppnamespace = sc.namespace;
+        funcdecl.mangleParent = sc.mangleParent;
         funcdecl.parent = sc.parent;
         Dsymbol parent = funcdecl.toParent();
 
@@ -4255,7 +4262,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (sc.linkage == LINK.cpp)
                 sd.classKind = ClassKind.cpp;
-            sd.cppnamespace = sc.namespace;
+            sd.mangleParent = sc.mangleParent;
             sd.cppmangle = sc.cppmangle;
         }
         else if (sd.symtab && !scx)
@@ -4469,7 +4476,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (sc.linkage == LINK.cpp)
                 cldec.classKind = ClassKind.cpp;
-            cldec.cppnamespace = sc.namespace;
+            cldec.mangleParent = sc.mangleParent;
             cldec.cppmangle = sc.cppmangle;
             if (sc.linkage == LINK.objc)
                 objc.setObjc(cldec);
@@ -5185,7 +5192,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (!idec.baseclasses.dim && sc.linkage == LINK.cpp)
                 idec.classKind = ClassKind.cpp;
-            idec.cppnamespace = sc.namespace;
+            idec.mangleParent = sc.mangleParent;
             UserAttributeDeclaration.checkGNUABITag(idec, sc.linkage);
 
             if (sc.linkage == LINK.objc)
@@ -5520,9 +5527,9 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
         goto Lerror;
 
     // Copy the tempdecl namespace (not the scope one)
-    tempinst.cppnamespace = tempdecl.cppnamespace;
-    if (tempinst.cppnamespace)
-        tempinst.cppnamespace.dsymbolSemantic(sc);
+    tempinst.mangleParent = tempdecl.mangleParent;
+    if (auto attr = tempinst.mangleParent.asAttribute())
+        attr.dsymbolSemantic(sc);
 
     /* Greatly simplified semantic processing for AliasSeq templates
      */

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -39,7 +39,9 @@ struct _d_dynamicArray final
 
 class Visitor;
 class Identifier;
+class LinkDeclaration;
 class CPPNamespaceDeclaration;
+class AttribDeclaration;
 struct Symbol;
 struct OutBuffer;
 struct Scope;
@@ -90,7 +92,6 @@ class ArrayScopeSymbol;
 class Import;
 class EnumDeclaration;
 class SymbolDeclaration;
-class AttribDeclaration;
 class AnonDeclaration;
 class VisibilityDeclaration;
 class OverloadSet;
@@ -337,6 +338,27 @@ class ASTNode : public RootObject
 public:
     virtual void accept(Visitor* v) = 0;
     ASTNode();
+};
+
+struct ParentSymbolAttribute final
+{
+    union
+    {
+        LinkDeclaration* link;
+        CPPNamespaceDeclaration* cpp;
+    };
+private:
+    bool isLinkDecl;
+public:
+    void accept(Visitor* v);
+    ParentSymbolAttribute& opAssign(CPPNamespaceDeclaration* cpp);
+    ParentSymbolAttribute& opAssign(LinkDeclaration* link);
+    CPPNamespaceDeclaration* hasCPPNamespace();
+    LinkDeclaration* hasLink();
+    AttribDeclaration* asAttribute();
+    ParentSymbolAttribute()
+    {
+    }
 };
 
 enum class DiagnosticReporting : uint8_t
@@ -961,7 +983,7 @@ class Dsymbol : public ASTNode
 public:
     Identifier* ident;
     Dsymbol* parent;
-    CPPNamespaceDeclaration* cppnamespace;
+    ParentSymbolAttribute mangleParent;
     Symbol* csym;
     Symbol* isym;
     const char* comment;
@@ -4358,6 +4380,7 @@ struct ASTCodegen final
     using DeprecatedDeclaration = ::DeprecatedDeclaration;
     using ForwardingAttribDeclaration = ::ForwardingAttribDeclaration;
     using LinkDeclaration = ::LinkDeclaration;
+    using ParentSymbolAttribute = ::ParentSymbolAttribute;
     using PragmaDeclaration = ::PragmaDeclaration;
     using StaticForeachDeclaration = ::StaticForeachDeclaration;
     using StaticIfDeclaration = ::StaticIfDeclaration;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -397,7 +397,7 @@ extern (C++) class FuncDeclaration : Declaration
         if (!_scope)
             return !errors;
 
-        this.cppnamespace = _scope.namespace;
+        this.mangleParent = _scope.mangleParent;
 
         if (!originalType) // semantic not yet run
         {

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -958,6 +958,11 @@ public:
     {
         buf.writestring("extern (");
         buf.writestring(linkageToString(d.linkage));
+        if (d.ident !is null)
+        {
+            buf.writestring(", ");
+            buf.writestring(d.ident.toString());
+        }
         buf.writestring(") ");
         visit(cast(AttribDeclaration)d);
     }

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -966,7 +966,6 @@ class Parser(AST) : Lexer
                     a = parseBlock(pLastDecl, pAttrs);
                     if (res.idents)
                     {
-                        assert(res.link == LINK.cpp);
                         assert(res.idents.dim);
                         for (size_t i = res.idents.dim; i;)
                         {
@@ -976,7 +975,12 @@ class Parser(AST) : Lexer
                                 a = new AST.Dsymbols();
                                 a.push(s);
                             }
-                            s = new AST.Nspace(linkLoc, id, null, a);
+                            if (res.link == LINK.cpp)
+                                s = new AST.Nspace(linkLoc, id, null, a);
+                            else if (res.link == LINK.d)
+                                s = new AST.LinkDeclaration(linkLoc, LINK.d, a, id);
+                            else
+                                assert(0);
                         }
                         pAttrs.link = LINK.default_;
                     }
@@ -2253,7 +2257,33 @@ class Parser(AST) : Lexer
         if (id == Id.Windows)
             return returnLinkage(LINK.windows);
         else if (id == Id.D)
+        {
+            if (token.value != TOK.comma) // Simple `extern(D)` without module decl
+                return returnLinkage(LINK.d);
+            nextToken();
+            // `extern(D,)`
+            if (token.value == TOK.rightParenthesis)
+                return returnLinkage(LINK.d);
+
+            result.idents = new AST.Identifiers();
+            while (1)
+            {
+                if (token.value != TOK.identifier)
+                {
+                    error("fully-qualified module name expected for `extern(D)` declaration, not `%s`",
+                          token.toChars());
+                    result.idents = null;
+                    break;
+                }
+                result.idents.push(token.ident);
+                nextToken();
+                if (token.value == TOK.rightParenthesis)
+                    break;
+                if (token.value == TOK.dot)
+                    nextToken();
+            }
             return returnLinkage(LINK.d);
+        }
         else if (id == Id.System)
             return returnLinkage(LINK.system);
         else if (id == Id.Objective) // Looking for tokens "Objective-C"

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -24,7 +24,6 @@ class UserAttributeDeclaration;
 struct DocComment;
 struct AA;
 class TemplateInstance;
-class CPPNamespaceDeclaration;
 
 #include "dsymbol.h"
 
@@ -105,7 +104,7 @@ struct Scope
     AlignDeclaration *aligndecl;    // alignment for struct members
 
     /// C++ namespace this symbol belongs to
-    CPPNamespaceDeclaration *namespace_;
+    ParentSymbolAttribute parentMangle;
 
     LINK linkage;               // linkage for external functions
     CPPMANGLE cppmangle;        // C++ mangle type

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -2003,7 +2003,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             // into `extern(C++, "a") extern(C++, "b") extern(C++, "c")`,
             // creating a linked list what `a`'s `cppnamespace` points to `b`,
             // and `b`'s points to `c`. Our entry point is `a`.
-            for (; ns !is null; ns = ns.cppnamespace)
+            for (; ns !is null; ns = ns.mangleParent.hasCPPNamespace)
             {
                 ns.dsymbolSemantic(sc);
 
@@ -2026,14 +2026,14 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             auto pp = p.toParent();
             if (pp.isTemplateInstance())
             {
-                if (!p.cppnamespace)
+                if (!p.mangleParent.hasCPPNamespace)
                     continue;
                 //if (!p.toParent().cppnamespace)
                 //    continue;
                 auto inner = new Expressions(0);
                 auto outer = new Expressions(0);
-                if (prependNamespaces(inner,  p.cppnamespace)) return ErrorExp.get();
-                if (prependNamespaces(outer, pp.cppnamespace)) return ErrorExp.get();
+                if (prependNamespaces(inner,  p.mangleParent.hasCPPNamespace)) return ErrorExp.get();
+                if (prependNamespaces(outer, pp.mangleParent.hasCPPNamespace)) return ErrorExp.get();
 
                 size_t i = 0;
                 while(i < outer.dim && ((*inner)[i]) == (*outer)[i])
@@ -2047,7 +2047,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             if (p.isNspace())
                 exps.insert(0, new StringExp(p.loc, p.ident.toString()));
 
-            if (prependNamespaces(exps, p.cppnamespace))
+            if (prependNamespaces(exps, p.mangleParent.hasCPPNamespace))
                 return ErrorExp.get();
         }
         if (auto d = s.isDeclaration())

--- a/test/fail_compilation/test5309.d
+++ b/test/fail_compilation/test5309.d
@@ -1,0 +1,16 @@
+/**
+  TEST_OUTPUT:
+  ---
+fail_compilation/test5309.d(14): Error: fully-qualified module name expected for `extern(D)` declaration, not `ref`
+fail_compilation/test5309.d(14): Error: found `ref` when expecting `)`
+fail_compilation/test5309.d(14): Error: declaration expected, not `)`
+fail_compilation/test5309.d(15): Error: fully-qualified module name expected for `extern(D)` declaration, not `)`
+fail_compilation/test5309.d(16): Error: fully-qualified module name expected for `extern(D)` declaration, not `,`
+fail_compilation/test5309.d(16): Error: found `,` when expecting `)`
+fail_compilation/test5309.d(16): Error: no identifier for declarator `foo.bar`
+fail_compilation/test5309.d(16): Error: declaration expected, not `)`
+  ---
+ */
+extern(D, ref) void invalid();
+extern(D, pkg.mod.) void also();
+extern(D, pkg.mod, foo.bar) void nope();

--- a/test/runnable/imports/test5309.d
+++ b/test/runnable/imports/test5309.d
@@ -1,0 +1,14 @@
+module imports.test5309;
+
+class FooBar
+{
+    int i;
+}
+
+__gshared int global = 84;
+
+int foo (FooBar f)
+{
+    assert(f is null);
+    return 42;
+}

--- a/test/runnable/test5309.d
+++ b/test/runnable/test5309.d
@@ -1,0 +1,22 @@
+/**
+  EXTRA_SOURCES: imports/test5309.d
+*/
+module test5309;
+
+extern(D, imports.test5309) {
+    extern class FooBar;
+    extern int foo(FooBar f);
+}
+
+extern(D,) void notreferenced();
+
+extern(D, imports)
+{
+    extern(D, test5309) extern __gshared int global;
+}
+
+void main ()
+{
+    assert(foo(null) == 42);
+    assert(global == 84);
+}


### PR DESCRIPTION
```
Currently, `extern(D)` is quite incomplete: An `extern(D)` symbol is mangled
as if it was in the module it is declared in, while users usually want to
declare a function or type that lives in another module.

Borrowing from the syntax that was adopted for `extern(C++, name.space)`, we introduce `extern(D, pkg.mod)`.
Note that, unlike `extern(C++)`, no string alternative is needed:
the motivation for the string variant was that C++ namespaces could be D keywords,
hence some namespaces could not be bound with the identifier variant,
a problem which obviously does not apply to `extern(D)` symbols.

The need for this functionality is easily demonstrated by druntime's `externDFunc`.
`core.internal.traits : externDFunc` is a template that defines an `extern(D)` symbol in another module.
This is currently done by using `pragma(mangle)` along with `core.demangle : mangleFunc`.

And as it turns out, the only reason for `core.demangle : mangleFunc` to exists is for `externDFunc`.
Hence, implementing this functionality will greatly simplify a core piece of druntime:
`core.demangle : mangle` (and its derivatives, including `mangleFunc` and `externDFunc`) can be removed
and replaced by `XXX.mangleof`, relying on the compiler instead of a library function which have to be
kept in sync with the compiler implementation.
```

TL;DR: While we should do things in libraries as much as possible, replicating in a library complex compiler logic (in this case, symbol mangling) is bad. With this in mind, I was puzzled as to why `core.demangle : mangle` existed in the first place (also consider that the module is called `demangle` but holds a mangle function, so it was clearly an afterthought). Issue 5309 held the answer, and hopefully after this is merged we can greatly simply `core.demangle` ("fun" fact: the demangling code is re-used for the mangler, with added boolean logic here and there).