### PR TITLE
Fix Issue 22075 - [Reg 2.068] AA key type S should have size_t toHash…

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -426,8 +426,6 @@ bool needOpEquals(StructDeclaration sd)
                 continue;
             if (needOpEquals(ts.sym))
                 goto Lneed;
-            if (ts.sym.aliasthis) // https://issues.dlang.org/show_bug.cgi?id=14806
-                goto Lneed;
         }
         if (tvbase.isfloating())
         {
@@ -728,7 +726,7 @@ private bool needToHash(StructDeclaration sd)
     if (sd.xhash)
         goto Lneed;
 
-    /* If any of the fields has an opEquals, then we
+    /* If any of the fields has an toHash, then we
      * need it too.
      */
     for (size_t i = 0; i < sd.fields.dim; i++)
@@ -746,8 +744,6 @@ private bool needToHash(StructDeclaration sd)
             if (ts.sym.isUnionDeclaration())
                 continue;
             if (needToHash(ts.sym))
-                goto Lneed;
-            if (ts.sym.aliasthis) // https://issues.dlang.org/show_bug.cgi?id=14948
                 goto Lneed;
         }
         if (tvbase.isfloating())

--- a/test/fail_compilation/fail22075.d
+++ b/test/fail_compilation/fail22075.d
@@ -1,0 +1,30 @@
+// https://issues.dlang.org/show_bug.cgi?id=22075
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail22075.d(25): Error: AA key type `S` should have `extern (D) size_t toHash() const nothrow @safe` if `opEquals` defined
+fail_compilation/fail22075.d(26): Error: AA key type `S` should have `extern (D) size_t toHash() const nothrow @safe` if `opEquals` defined
+---
+*/
+
+struct HasAliasThis { int a; alias a this; }
+
+struct LacksAliasThis { int a; }
+
+struct S(T)
+{
+    private T a;
+
+    bool opEquals(const S rhs) const @nogc nothrow @safe
+    {
+        return rhs is this;
+    }
+}
+
+int[S!HasAliasThis] aa1; // Compiles but should not.
+int[S!LacksAliasThis] aa2; // Correctly fails to compile with "Error: AA key
+     // type `S` should have `extern (D) size_t toHash() const nothrow @safe`
+     // if `opEquals` defined"".
+
+void main() {}


### PR DESCRIPTION
opEquals and toHash were generated if an alias this was defined for any of the struct fields. That did not make any sense and deleting the hacks did not make any code fail in the test suite. Let's see if anything breaks in the wild.

I suggest merging this as is. Even if code out there breaks, it was arguably broken anyway since the user-defined opEquals and generated toHash probably where not synced. Otherwise, it could be difficult to issue a deprecation for instances of structs that have fields with an alias this that are used as AA keys.