### PR TITLE
move enumMember.getVarExp to expresionsem

### DIFF
--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -23,7 +23,6 @@ import dmd.dscope;
 import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.expression;
-import dmd.expressionsem;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
@@ -297,23 +296,6 @@ extern (C++) final class EnumMember : VarDeclaration
     override const(char)* kind() const
     {
         return "enum member";
-    }
-
-    Expression getVarExp(const ref Loc loc, Scope* sc)
-    {
-        dsymbolSemantic(this, sc);
-        if (errors)
-            return ErrorExp.get();
-        checkDisabled(loc, sc);
-
-        if (depdecl && !depdecl._scope)
-            depdecl._scope = sc;
-        checkDeprecated(loc, sc);
-
-        if (errors)
-            return ErrorExp.get();
-        Expression e = new VarExp(loc, this);
-        return e.expressionSemantic(sc);
     }
 
     override inout(EnumMember) isEnumMember() inout

--- a/src/dmd/enum.h
+++ b/src/dmd/enum.h
@@ -80,7 +80,6 @@ public:
 
     EnumMember *syntaxCopy(Dsymbol *s);
     const char *kind() const;
-    Expression *getVarExp(const Loc &loc, Scope *sc);
 
     EnumMember *isEnumMember() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -12836,3 +12836,30 @@ private bool fit(StructDeclaration sd, const ref Loc loc, Scope* sc, Expressions
     }
     return true;
 }
+
+
+/**
+ * Returns `em` as a VariableExp
+ * Params:
+ *     em = the EnumMember to wrap
+ *     loc = location of use of em
+ *     sc = scope of use of em
+ * Returns:
+ *     VarExp referenceing `em` or ErrorExp if `em` if disabled/deprecated
+ */
+Expression getVarExp(EnumMember em, const ref Loc loc, Scope* sc)
+{
+    dsymbolSemantic(em, sc);
+    if (em.errors)
+        return ErrorExp.get();
+    em.checkDisabled(loc, sc);
+
+    if (em.depdecl && !em.depdecl._scope)
+        em.depdecl._scope = sc;
+    em.checkDeprecated(loc, sc);
+
+    if (em.errors)
+        return ErrorExp.get();
+    Expression e = new VarExp(loc, em);
+    return e.expressionSemantic(sc);
+}

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5855,7 +5855,6 @@ public:
     EnumDeclaration* ed;
     EnumMember* syntaxCopy(Dsymbol* s);
     const char* kind() const;
-    Expression* getVarExp(const Loc& loc, Scope* sc);
     EnumMember* isEnumMember();
     void accept(Visitor* v);
     ~EnumMember();


### PR DESCRIPTION
This is called from a few places, but expressionsem seems like the right home for it.  Eliminates an import of expressionsem from denum.