### PR TITLE
Skip final switch member check if unncessary

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2691,7 +2691,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 ed = ds.isEnumDeclaration(); // typedef'ed enum
             if (!ed && te && ((ds = te.toDsymbol(sc)) !is null))
                 ed = ds.isEnumDeclaration();
-            if (ed)
+            if (ed && ss.cases.length < ed.members.length)
             {
                 int missingMembers = 0;
                 const maxShown = !global.params.verbose ? 6 : int.max;


### PR DESCRIPTION
I recently found out that statement semantic of a switch statement has quadratic time complexity in the number of cases, because the checking for duplicate cases use a simple linear search for each case before it, and `final switch`'s check for duplicate cases does a linear scan for each enum member. This is disconcerting me since I use switch statements a lot and some of my enums get pretty large (the record probably going to 'MipsOpcode' with 230 members). See also [Dawson’s first law of computing](https://twitter.com/BruceDawson0xB/status/1120381406700429312).

I'm thinking this can be optimized to `O(n log(n))` by doing the following:
- Let `EnumDeclaration` have a sorted list of its members
- Let a `SwitchStatement` sort its cases
- Scan for duplicates similar to `uniq`, and scan for missing members similar to merge sort

That's a bit of an undertaking, this PR does none of that yet. :stuck_out_tongue: 
Instead, it starts with a simple improvement to the common case of a `final switch` over an enum with unique members: the missing member check can be skipped when the number of switch cases is equal to the number of enum members.

My test setup looks like this:
```D
enum A {
	f0, f1, /*..*/ fn,
}

string toString(int rep)(A a) {
	with(A) final switch (a) {
		static foreach(string mem; __traits(allMembers, A)) {
			case mixin(mem): return mem;
		}
	}
}

void main() {
	static foreach(i; 0..200) {
		toString!(i)(A.init);
	}
}
```
I run the release build (using dmd as host instead of ldmd2 though) on Debian Linux with:
```
time dmd -o- testswitch.d
```
For 100 enum members, time went down from 0.5s to 0.4s
For 200 enum members, time went down from 1.4s to 0.7s
Of course this test is catering to the specific scenario, but for 1 line of code, not bad I think.
