### PR TITLE
dtoh: Don't write visibilities inside of anonymous structs/unions

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -25,6 +25,7 @@ experimental C++ header generator:
 - Properly emits static arrays in template declarations
 - No longer omits the parent aggregate when referencing `__gshared` variables
 - No longer uses D syntax for expressions nested in unary / binary expressions
+- Does not emit `public:`, ... inside of anonymous structs/unions
 
 Note: The header generator is still considerer experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -271,6 +271,9 @@ public:
 
         /// Processing a type that can be forward referenced
         bool forwarding;
+
+        /// Inside of an anonymous struct/union (AnonDeclaration)
+        bool inAnonymousDecl;
     }
 
     /// Informations about the current context in the AST
@@ -378,7 +381,7 @@ public:
     private void writeProtection(const AST.Visibility.Kind kind)
     {
         // Don't write visibility for global declarations
-        if (!adparent)
+        if (!adparent || inAnonymousDecl)
             return;
 
         string token;
@@ -1139,6 +1142,10 @@ public:
     override void visit(AST.AnonDeclaration ad)
     {
         debug (Debug_DtoH) mixin(traceVisit!ad);
+
+        const anonStash = inAnonymousDecl;
+        inAnonymousDecl = true;
+        scope (exit) inAnonymousDecl = anonStash;
 
         buf.writestringln(ad.isunion ? "union" : "struct");
         buf.writestringln("{");

--- a/test/compilable/dtoh_AnonDeclaration.d
+++ b/test/compilable/dtoh_AnonDeclaration.d
@@ -53,6 +53,15 @@ struct S final
         extern "C" void foo();
         void bar();
     };
+    struct
+    {
+        int32_t outerPrivate;
+    };
+    struct
+    {
+        int32_t innerPrivate;
+        int32_t innerBar;
+    };
     S()
     {
     }
@@ -76,6 +85,18 @@ extern (C++) struct S
         double z;
         extern(C) void foo() {}
         extern(C++) void bar() {}
+    }
+
+    // Private not emitted because AnonDeclaration has no protection
+    private struct
+    {
+        int outerPrivate;
+    }
+
+    public struct {
+        // Private cannot be exported to C++
+        private int innerPrivate;
+        int innerBar;
     }
 }
 


### PR DESCRIPTION
Because C++ rejects any declaration that is not a variable.