### PR TITLE
Don't print ANSII color codes when building on Windows

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -159,6 +159,7 @@ Command-line parameters
     // A more proper solution would be to redirect DMD's output to this script's
     // output using `std.process`', but it's more involved and the following
     // "just works"
+    version(Posix) // UPDATE: only when ANSII color codes are supported, that is. Don't do this on Windows.
     if (!flags["DFLAGS"].canFind("-color=off") &&
         [env["HOST_DMD_RUN"], "-color=on", "-h"].tryRun().status == 0)
         flags["DFLAGS"] ~= "-color=on";


### PR DESCRIPTION
`-color=on` is forced on in build.d since https://github.com/dlang/dmd/pull/10837
When not in a terminal, `-color=on` outputs ANSII color codes on Windows since https://github.com/dlang/dmd/pull/12541
Combine the two and building dmd on Windows yields:
```
-----------------------------------------------------------                                          
←[1msrc\dmd\mars.d(19): ←[1;31mError: ←[mno identifier for declarator `←[0;36m←[m←[1merror←[0;36m←[m`
```

Like the comment says: 
> A more proper solution would be to redirect DMD's output to this script's output using `std.process`'

I appreciate if someone supersedes this PR with something doing that, but this is the quick fix.

