### PR TITLE
Turn mutable case variables into an error

### DIFF
--- a/changelog/mutable-cases.dd
+++ b/changelog/mutable-cases.dd
@@ -1,0 +1,16 @@
+Using a mutable variable as a switch case now triggers an error
+
+Variables that are `const` or `immutable` can be used as switch cases even if they are initialized at run-time, but using variables that are mutable has been deprecated since dmd 2.073.2.
+This deprecation has now been turned into an error:
+-------
+void foo(int s, int x, const int y, immutable int z) {
+    switch (s) {
+        case x: // error
+        case y: // allowed
+        case z: // allowed
+        default:
+    }
+}
+-------
+It is advised to only use compile-time known values in `case` statements, because the presence of any run-time variable (even a `const` or `immutable` one) results in the entire switch being lowered to a series of if-else statements before code generation, instead of an efficient jump table.
+Prefer regular if-statements for comparing pairs of run-time known variables.

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2913,7 +2913,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                      */
                     if (!v.isConst() && !v.isImmutable())
                     {
-                        cs.deprecation("`case` variables have to be `const` or `immutable`");
+                        cs.error("`case` variables have to be `const` or `immutable`");
                     }
 
                     if (sw.isFinal)

--- a/test/compilable/b17111.d
+++ b/test/compilable/b17111.d
@@ -1,16 +1,7 @@
-/*
-TEST_OUTPUT:
----
-compilable/b17111.d(16): Deprecation: `case` variables have to be `const` or `immutable`
-compilable/b17111.d(17): Deprecation: `case` variables have to be `const` or `immutable`
----
-*/
 alias TestType = ubyte;
 
-void test()
+void test(immutable TestType a, immutable TestType b, TestType c)
 {
-    TestType a,b,c;
-
     switch(c)
     {
         case a: break;

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2,8 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/interpret3.d(2914): Deprecation: `case` variables have to be `const` or `immutable`
-compilable/interpret3.d(6351): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
+compilable/interpret3.d(6350): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
 ---
 */
 
@@ -2904,16 +2903,16 @@ static assert(bug4448b() == 3);
 
 /**************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=6985
-// non-constant case
+// Formerly, non-constant case, but switch cases with mutable cases now error
+// Currently: run-time constant variable case
 
 int bug6985(int z)
 {
-    int q = z * 2 - 6;
+    const int q = z * 2 - 6;
     switch(z)
     {
     case q:
-        q = 87;
-        break;
+        return 87;
     default:
     }
     return q;

--- a/test/fail_compilation/ice17831.d
+++ b/test/fail_compilation/ice17831.d
@@ -1,12 +1,16 @@
-// REQUIRED_ARGS: -d
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice17831.d(19): Error: `case` variable `i` declared at fail_compilation/ice17831.d(17) cannot be declared in `switch` body
-fail_compilation/ice17831.d(33): Error: `case` variable `i` declared at fail_compilation/ice17831.d(31) cannot be declared in `switch` body
-fail_compilation/ice17831.d(48): Error: `case` variable `i` declared at fail_compilation/ice17831.d(45) cannot be declared in `switch` body
-fail_compilation/ice17831.d(61): Error: `case` variable `i` declared at fail_compilation/ice17831.d(60) cannot be declared in `switch` body
-fail_compilation/ice17831.d(73): Error: `case` variable `i` declared at fail_compilation/ice17831.d(72) cannot be declared in `switch` body
+fail_compilation/ice17831.d(23): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/ice17831.d(23): Error: `case` variable `i` declared at fail_compilation/ice17831.d(21) cannot be declared in `switch` body
+fail_compilation/ice17831.d(37): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/ice17831.d(37): Error: `case` variable `i` declared at fail_compilation/ice17831.d(35) cannot be declared in `switch` body
+fail_compilation/ice17831.d(52): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/ice17831.d(52): Error: `case` variable `i` declared at fail_compilation/ice17831.d(49) cannot be declared in `switch` body
+fail_compilation/ice17831.d(65): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/ice17831.d(65): Error: `case` variable `i` declared at fail_compilation/ice17831.d(64) cannot be declared in `switch` body
+fail_compilation/ice17831.d(77): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/ice17831.d(77): Error: `case` variable `i` declared at fail_compilation/ice17831.d(76) cannot be declared in `switch` body
 ---
  */
 

--- a/test/fail_compilation/test16523.d
+++ b/test/fail_compilation/test16523.d
@@ -1,8 +1,7 @@
-// REQUIRED_ARGS: -de
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test16523.d(13): Deprecation: `case` variables have to be `const` or `immutable`
+fail_compilation/test16523.d(12): Error: `case` variables have to be `const` or `immutable`
 ---
 */
 


### PR DESCRIPTION
They have been deprecated for nearly 5 years now: https://github.com/dlang/dmd/pull/6146