### PR TITLE
move/extract determineFields to dsymbolsem

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -126,7 +126,6 @@ public:
 
     virtual Scope *newScope(Scope *sc);
     void setScope(Scope *sc);
-    bool determineFields();
     size_t nonHiddenFields();
     bool determineSize(Loc loc);
     virtual void finalizeSize() = 0;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -4944,7 +4944,6 @@ public:
     Sizeok sizeok;
     virtual Scope* newScope(Scope* sc);
     void setScope(Scope* sc);
-    bool determineFields();
     size_t nonHiddenFields();
     bool determineSize(Loc loc);
     virtual void finalizeSize() = 0;


### PR DESCRIPTION
This function might fit better in typesem, but I put it in dsymbolsem since it calls symbolsemantic internally.  determineFields is called in a few places,  so I didn't see an obvious right answer based on callers.