### PR TITLE
Fix issue 14064 - Error message about @ attributes incomplete

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1482,7 +1482,11 @@ class Parser(AST) : Lexer
             return 0;
         }
 
-        error("`@identifier` or `@(ArgumentList)` expected, not `@%s`", token.toChars());
+        if (token.isKeyword())
+            error("`%s` is a keyword, not an `@` attribute", token.toChars());
+        else
+            error("`@identifier` or `@(ArgumentList)` expected, not `@%s`", token.toChars());
+
         return 0;
     }
 

--- a/test/fail_compilation/test14064.d
+++ b/test/fail_compilation/test14064.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test14064.d(11): Error: `private` is a keyword, not an `@` attribute
+fail_compilation/test14064.d(12): Error: `deprecated` is a keyword, not an `@` attribute
+fail_compilation/test14064.d(13): Error: `pure` is a keyword, not an `@` attribute
+fail_compilation/test14064.d(14): Error: `nothrow` is a keyword, not an `@` attribute
+fail_compilation/test14064.d(15): Error: `in` is a keyword, not an `@` attribute
+---
+*/
+@private int v;
+@deprecated void foo();
+int goo() @pure;
+@nothrow unittest {};
+void zoom(@in int x);


### PR DESCRIPTION
> Ideally, I would think that the error message would treat the problem a bit like happens with a spelling error for variables, and ask if you meant `deprecated` instead of `@deprecated` - at least as long as `@deprecated` hasn't been declared as a UDA anyway

I've made the `@deprecated` mistake before as well. For this fix I just check any keyword in case someone accidentally writes `@nothrow` or `@pure`. The message doesn't straight up suggest a replacement because e.g. suggesting `foreach` instead of `@foreach` in a function signature is nonsensical.