### PR TITLE
Remove unused file test/compilable/extra-files/header17125.di

### DIFF
--- a/test/compilable/extra-files/header17125.di
+++ b/test/compilable/extra-files/header17125.di
@@ -1,6 +1,0 @@
-void func1(real value = 103500.0L);
-void func2(real value = 520199.0F);
-void func3(real value = 970000.0);
-void func4(real value = 102450.0F);
-void func5(real value = 412502.0L);
-int main();


### PR DESCRIPTION
The test uses an inline `TEST_OUTPUT` section instead of this file.