### PR TITLE
Remove most usages of json-postscript.sh

### DIFF
--- a/test/compilable/extra-files/jsonNoOutFile.json
+++ b/test/compilable/extra-files/jsonNoOutFile.json
@@ -1,9 +1,0 @@
-{
-    "compilerInfo": {
-        "binary": "VALUE_REMOVED_FOR_TEST",
-        "supportedFeatures": {
-            "includeImports": true
-        },
-        "version": "VALUE_REMOVED_FOR_TEST"
-    }
-}

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -1,8 +1,8 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -d -preview=dip1000 -o- -X -Xf${RESULTS_DIR}/compilable/json.out
-// POST_SCRIPT: compilable/extra-files/json-postscript.sh
+// REQUIRED_ARGS: -d -preview=dip1000 -o- -X -Xf-
 // EXTRA_FILES: imports/jsonimport1.d imports/jsonimport2.d imports/jsonimport3.d imports/jsonimport4.d
-
+// TRANSFORM_OUTPUT: sanitize_json
+// TEST_OUTPUT_FILE: extra-files/json.json
 module json;
 
 shared static this() {}

--- a/test/compilable/jsonCompilerInfo.d
+++ b/test/compilable/jsonCompilerInfo.d
@@ -1,3 +1,4 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -o- -Xi=compilerInfo -Xf${RESULTS_DIR}/compilable/jsonCompilerInfo.out
-// POST_SCRIPT: compilable/extra-files/json-postscript.sh
+// REQUIRED_ARGS: -o- -Xi=compilerInfo -Xf-
+// TRANSFORM_OUTPUT: sanitize_json
+// TEST_OUTPUT_FILE: extra-files/jsonCompilerInfo.json

--- a/test/compilable/jsonNoOutFile.d
+++ b/test/compilable/jsonNoOutFile.d
@@ -1,0 +1,33 @@
+/*
+REQUIRED_ARGS: -Xi=compilerInfo
+PERMUTE_ARGS:
+OUTPUT_FILES: jsonNoOutFile_0.json
+TRANSFORM_OUTPUT: sanitize_json
+TEST_OUTPUT:
+---
+=== jsonNoOutFile_0.json
+{
+    "compilerInfo": {
+        "__VERSION__": 0,
+        "architectures": [
+            "VALUES_REMOVED_FOR_TEST"
+        ],
+        "interface": "dmd",
+        "platforms": [
+            "VALUES_REMOVED_FOR_TEST"
+        ],
+        "predefinedVersions": [
+            "VALUES_REMOVED_FOR_TEST"
+        ],
+        "size_t": 0,
+        "supportedFeatures": {
+            "includeImports": true
+        },
+        "vendor": "VALUE_REMOVED_FOR_TEST",
+        "version": "VALUE_REMOVED_FOR_TEST"
+    }
+}
+---
+*/
+
+void main() {}

--- a/test/compilable/jsonNoOutFile.sh
+++ b/test/compilable/jsonNoOutFile.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-$DMD -c -od=${RESULTS_TEST_DIR} -Xi=compilerInfo ${EXTRA_FILES}/emptymain.d
-rm_retry emptymain.json


### PR DESCRIPTION
The only remaining use tests the JSON feature without a source file
and hence needs an explicit script.