### PR TITLE
Replace POST_SCRIPT for several DDoc tests

### DIFF
--- a/test/compilable/ddoc_markdown_breaks.d
+++ b/test/compilable/ddoc_markdown_breaks.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_breaks.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_breaks.html
 
 /++
 # Thematic Breaks

--- a/test/compilable/ddoc_markdown_breaks_verbose.d
+++ b/test/compilable/ddoc_markdown_breaks_verbose.d
@@ -1,15 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -wi -o- -transition=vmarkdown
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-
-/*
-TEST_OUTPUT:
-----
-compilable/ddoc_markdown_breaks_verbose.d(21): Ddoc: converted '___' to a thematic break
-compilable/ddoc_markdown_breaks_verbose.d(21): Ddoc: converted '- - -' to a thematic break
-compilable/ddoc_markdown_breaks_verbose.d(21): Ddoc: converted '***' to a thematic break
-----
-*/
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_breaks_verbose.html
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_breaks_verbose.html
 
 /++
 Thematic Breaks

--- a/test/compilable/ddoc_markdown_code.d
+++ b/test/compilable/ddoc_markdown_code.d
@@ -1,12 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-
-/*
-TEST_OUTPUT:
-----
-----
-*/
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_code.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_code.html
 
 /++
 # Code Blocks

--- a/test/compilable/ddoc_markdown_code_verbose.d
+++ b/test/compilable/ddoc_markdown_code_verbose.d
@@ -1,13 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -transition=vmarkdown
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-
-/*
-TEST_OUTPUT:
-----
-compilable/ddoc_markdown_code_verbose.d(19): Ddoc: adding code block for language 'ruby'
-----
-*/
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_code_verbose.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_code_verbose.html
 
 /++
 Code:

--- a/test/compilable/ddoc_markdown_emphasis.d
+++ b/test/compilable/ddoc_markdown_emphasis.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_emphasis.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_emphasis.html
 
 /++
 Markdown Emphasis:

--- a/test/compilable/ddoc_markdown_emphasis_verbose.d
+++ b/test/compilable/ddoc_markdown_emphasis_verbose.d
@@ -1,14 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -wi -o- -transition=vmarkdown
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-
-/*
-TEST_OUTPUT:
-----
-compilable/ddoc_markdown_emphasis_verbose.d(20): Ddoc: emphasized text 'emphasized text'
-compilable/ddoc_markdown_emphasis_verbose.d(20): Ddoc: emphasized text 'strongly emphasized text'
-----
-*/
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_emphasis_verbose.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_emphasis_verbose.html
 
 /++
 Markdown Emphasis:

--- a/test/compilable/ddoc_markdown_escapes.d
+++ b/test/compilable/ddoc_markdown_escapes.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_escapes.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_escapes.html
 
 /++
 Backslash Escapes:

--- a/test/compilable/ddoc_markdown_headings.d
+++ b/test/compilable/ddoc_markdown_headings.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_headings.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_headings.html
 
 /++
 # ATX-Style Headings

--- a/test/compilable/ddoc_markdown_headings_verbose.d
+++ b/test/compilable/ddoc_markdown_headings_verbose.d
@@ -1,13 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -transition=vmarkdown
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-
-/*
-TEST_OUTPUT:
-----
-compilable/ddoc_markdown_headings_verbose.d(15): Ddoc: added heading 'Heading'
-----
-*/
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_headings_verbose.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_headings_verbose.html
 
 /++
 # Heading

--- a/test/compilable/ddoc_markdown_links.d
+++ b/test/compilable/ddoc_markdown_links.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_links.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_links.html
 
 /++
 # Links

--- a/test/compilable/ddoc_markdown_links_verbose.d
+++ b/test/compilable/ddoc_markdown_links_verbose.d
@@ -1,18 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -transition=vmarkdown
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-
-/*
-TEST_OUTPUT:
-----
-compilable/ddoc_markdown_links_verbose.d(28): Ddoc: found link reference 'dub' to 'https://code.dlang.org'
-compilable/ddoc_markdown_links_verbose.d(28): Ddoc: linking '[Object]' to '$(DOC_ROOT_object)object$(DOC_EXTENSION)#.Object'
-compilable/ddoc_markdown_links_verbose.d(28): Ddoc: linking '[the D homepage](https://dlang.org)' to 'https://dlang.org'
-compilable/ddoc_markdown_links_verbose.d(28): Ddoc: linking '[dub]' to 'https://code.dlang.org'
-compilable/ddoc_markdown_links_verbose.d(28): Ddoc: linking '[dub][]' to 'https://code.dlang.org'
-compilable/ddoc_markdown_links_verbose.d(28): Ddoc: linking '![D-Man](https://dlang.org/images/d3.png)' to 'https://dlang.org/images/d3.png'
-----
-*/
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_links_verbose.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_links_verbose.html
 
 /++
 Links:

--- a/test/compilable/ddoc_markdown_lists.d
+++ b/test/compilable/ddoc_markdown_lists.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_lists.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_lists.html
 
 /++
 # Lists

--- a/test/compilable/ddoc_markdown_lists_verbose.d
+++ b/test/compilable/ddoc_markdown_lists_verbose.d
@@ -1,13 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -transition=vmarkdown
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-
-/*
-TEST_OUTPUT:
-----
-compilable/ddoc_markdown_lists_verbose.d(15): Ddoc: starting list item 'list item'
-----
-*/
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_lists_verbose.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_lists_verbose.html
 
 /++
 - list item

--- a/test/compilable/ddoc_markdown_quote.d
+++ b/test/compilable/ddoc_markdown_quote.d
@@ -1,12 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-
-/*
-TEST_OUTPUT:
-----
-----
-*/
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_quote.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_quote.html
 
 /++
 # Quote Blocks

--- a/test/compilable/ddoc_markdown_quote_verbose.d
+++ b/test/compilable/ddoc_markdown_quote_verbose.d
@@ -1,13 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -transition=vmarkdown
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-
-/*
-TEST_OUTPUT:
-----
-compilable/ddoc_markdown_quote_verbose.d(17): Ddoc: starting quote block with '> Great, just what I need.. another D in programming. -- Segfault'
-----
-*/
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_quote_verbose.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_quote_verbose.html
 
 /++
 Quote Block:

--- a/test/compilable/ddoc_markdown_tables.d
+++ b/test/compilable/ddoc_markdown_tables.d
@@ -1,12 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-
-/*
-TEST_OUTPUT:
-----
-----
-*/
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_tables.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_tables.html
 
 /++
 # Tables

--- a/test/compilable/ddoc_markdown_tables_verbose.d
+++ b/test/compilable/ddoc_markdown_tables_verbose.d
@@ -1,13 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -transition=vmarkdown
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
-
-/*
-TEST_OUTPUT:
-----
-compilable/ddoc_markdown_tables_verbose.d(19): Ddoc: formatting table '| this | that |'
-----
-*/
+// TEST_OUTPUT_FILE: extra-files/ddoc_markdown_tables_verbose.html
+// OUTPUT_FILES: ${RESULTS_DIR}/compilable/ddoc_markdown_tables_verbose.html
 
 /++
 Table:

--- a/test/compilable/extra-files/ddoc_markdown_breaks.html
+++ b/test/compilable/extra-files/ddoc_markdown_breaks.html
@@ -1,4 +1,4 @@
-
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_breaks.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_breaks_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_breaks_verbose.html
@@ -1,4 +1,7 @@
-
+compilable/ddoc_markdown_breaks_verbose.d(13): Ddoc: converted '___' to a thematic break
+compilable/ddoc_markdown_breaks_verbose.d(13): Ddoc: converted '- - -' to a thematic break
+compilable/ddoc_markdown_breaks_verbose.d(13): Ddoc: converted '***' to a thematic break
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_breaks_verbose.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_code.html
+++ b/test/compilable/extra-files/ddoc_markdown_code.html
@@ -1,4 +1,4 @@
-
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_code.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_code_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_code_verbose.html
@@ -1,4 +1,5 @@
-
+compilable/ddoc_markdown_code_verbose.d(13): Ddoc: adding code block for language 'ruby'
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_code_verbose.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_emphasis.html
+++ b/test/compilable/extra-files/ddoc_markdown_emphasis.html
@@ -1,4 +1,4 @@
-
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_emphasis.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_emphasis_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_emphasis_verbose.html
@@ -1,4 +1,6 @@
-
+compilable/ddoc_markdown_emphasis_verbose.d(13): Ddoc: emphasized text 'emphasized text'
+compilable/ddoc_markdown_emphasis_verbose.d(13): Ddoc: emphasized text 'strongly emphasized text'
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_emphasis_verbose.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_escapes.html
+++ b/test/compilable/extra-files/ddoc_markdown_escapes.html
@@ -1,4 +1,4 @@
-
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_escapes.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_headings.html
+++ b/test/compilable/extra-files/ddoc_markdown_headings.html
@@ -1,4 +1,4 @@
-
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_headings.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
@@ -1,4 +1,5 @@
-
+compilable/ddoc_markdown_headings_verbose.d(9): Ddoc: added heading 'Heading'
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_headings_verbose.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_links.html
+++ b/test/compilable/extra-files/ddoc_markdown_links.html
@@ -1,4 +1,4 @@
-
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_links.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_links_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_links_verbose.html
@@ -1,4 +1,10 @@
-
+compilable/ddoc_markdown_links_verbose.d(17): Ddoc: found link reference 'dub' to 'https://code.dlang.org'
+compilable/ddoc_markdown_links_verbose.d(17): Ddoc: linking '[Object]' to '$(DOC_ROOT_object)object$(DOC_EXTENSION)#.Object'
+compilable/ddoc_markdown_links_verbose.d(17): Ddoc: linking '[the D homepage](https://dlang.org)' to 'https://dlang.org'
+compilable/ddoc_markdown_links_verbose.d(17): Ddoc: linking '[dub]' to 'https://code.dlang.org'
+compilable/ddoc_markdown_links_verbose.d(17): Ddoc: linking '[dub][]' to 'https://code.dlang.org'
+compilable/ddoc_markdown_links_verbose.d(17): Ddoc: linking '![D-Man](https://dlang.org/images/d3.png)' to 'https://dlang.org/images/d3.png'
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_links_verbose.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_lists.html
+++ b/test/compilable/extra-files/ddoc_markdown_lists.html
@@ -1,4 +1,4 @@
-
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_lists.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_lists_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_lists_verbose.html
@@ -1,4 +1,5 @@
-
+compilable/ddoc_markdown_lists_verbose.d(9): Ddoc: starting list item 'list item'
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_lists_verbose.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_quote.html
+++ b/test/compilable/extra-files/ddoc_markdown_quote.html
@@ -1,4 +1,4 @@
-
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_quote.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_quote_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_quote_verbose.html
@@ -1,4 +1,5 @@
-
+compilable/ddoc_markdown_quote_verbose.d(11): Ddoc: starting quote block with '> Great, just what I need.. another D in programming. -- Segfault'
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_quote_verbose.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_tables.html
+++ b/test/compilable/extra-files/ddoc_markdown_tables.html
@@ -1,4 +1,4 @@
-
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_tables.html
 <!DOCTYPE html>
 <html>
   <head>

--- a/test/compilable/extra-files/ddoc_markdown_tables_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_tables_verbose.html
@@ -1,4 +1,5 @@
-
+compilable/ddoc_markdown_tables_verbose.d(13): Ddoc: formatting table '| this | that |'
+=== ${RESULTS_DIR}/compilable/ddoc_markdown_tables_verbose.html
 <!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
The current behavior can already be achieved by using `OUTPUT_FILES` + `TEST_OUTPUT_FILE`.