### PR TITLE
fix Issue 22122 - [REG 2.097][ICE] Segmentation fault in in dmd.access.hasPackageAccess

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -533,7 +533,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         const inLoopSave = sc.inLoop;
         sc.inLoop = true;
         if (ds._body)
-            ds._body = ds._body.semanticScope(sc, ds, ds);
+            ds._body = ds._body.semanticScope(sc, ds, ds, null);
         sc.inLoop = inLoopSave;
 
         if (ds.condition.op == TOK.dotIdentifier)
@@ -2342,7 +2342,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         CtorFlow ctorflow_then = sc.ctorflow;   // move flow results
         sc.ctorflow = ctorflow_root;            // reset flow analysis back to root
         if (ifs.elsebody)
-            ifs.elsebody = ifs.elsebody.semanticScope(sc, null, null);
+            ifs.elsebody = ifs.elsebody.semanticScope(sc, null, null, null);
 
         // Merge 'then' results into 'else' results
         sc.merge(ifs.loc, ctorflow_then);
@@ -3922,13 +3922,9 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         enum FLAGcpp = 1;
         enum FLAGd = 2;
 
-        tcs.tryBody = sc.tryBody;
-
-        scope sc2 = sc.push();
-        sc2.tryBody = tcs;
-        tcs._body = tcs._body.semanticScope(sc2, null, null);
+        tcs.tryBody = sc.tryBody;   // chain on the in-flight tryBody
+        tcs._body = tcs._body.semanticScope(sc, null, null, tcs);
         assert(tcs._body);
-        sc2.pop();
 
         /* Even if body is empty, still do semantic analysis on catches
          */
@@ -4009,12 +4005,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
     override void visit(TryFinallyStatement tfs)
     {
         //printf("TryFinallyStatement::semantic()\n");
-        tfs.tryBody = sc.tryBody;
-
-        auto sc2 = sc.push();
-        sc2.tryBody = tfs;
-        tfs._body = tfs._body.statementSemantic(sc2);
-        sc2.pop();
+        tfs.tryBody = sc.tryBody;   // chain on in-flight tryBody
+        tfs._body = tfs._body.semanticScope(sc, null, null, tfs);
 
         sc = sc.push();
         sc.tf = tfs;
@@ -4445,7 +4437,7 @@ Statement semanticNoScope(Statement s, Scope* sc)
 }
 
 // Same as semanticNoScope(), but do create a new scope
-Statement semanticScope(Statement s, Scope* sc, Statement sbreak, Statement scontinue)
+private Statement semanticScope(Statement s, Scope* sc, Statement sbreak, Statement scontinue, Statement tryBody)
 {
     auto sym = new ScopeDsymbol();
     sym.parent = sc.scopesym;
@@ -4454,6 +4446,8 @@ Statement semanticScope(Statement s, Scope* sc, Statement sbreak, Statement scon
         scd.sbreak = sbreak;
     if (scontinue)
         scd.scontinue = scontinue;
+    if (tryBody)
+        scd.tryBody = tryBody;
     s = s.semanticNoScope(scd);
     scd.pop();
     return s;

--- a/test/compilable/imports/imp22122.d
+++ b/test/compilable/imports/imp22122.d
@@ -1,0 +1,5 @@
+module imports.imp22122;
+
+package struct Imp22122
+{
+}

--- a/test/compilable/test22122.d
+++ b/test/compilable/test22122.d
@@ -1,0 +1,53 @@
+// EXTRA_FILES: imports/imp22122.d
+module imports.test22122;
+
+struct S22122
+{
+    import imports.imp22122;
+    Variant!(Imp22122)[] array;
+}
+
+void test22122_catch(S22122 s)
+{
+    try
+    {
+        foreach(elem; s.array)
+        {
+            import imports.imp22122;
+            with(elem.get!Imp22122)
+            {
+            }
+        }
+    }
+    catch (Exception)
+    {
+    }
+}
+
+void test22122_finally(S22122 s)
+{
+    try
+    {
+        foreach(elem; s.array)
+        {
+            import imports.imp22122;
+            with(elem.get!Imp22122)
+            {
+            }
+        }
+    }
+    finally
+    {
+    }
+}
+
+private struct Variant(T)
+{
+    union Impl
+    {
+    }
+    auto get(E)()
+    {
+        return Impl();
+    }
+}


### PR DESCRIPTION
Due to the change in #12439, the pushed scope for `try` bodies are not set-up correctly, resulting in the `parent` chain of resolved `Dsymbol`'s severed of their enclosing `Package`/`Module`.

This patch changes the regressing commit to go through `semanticScope` instead, which sets up the scope parent properly.