### PR TITLE
Revert "aggregate.d for -> foreach"

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -727,8 +727,11 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                 }
             }
 
-            foreach (sm; *members)
+            foreach (const i; 0 .. members.dim)
+            {
+                auto sm = (*members)[i];
                 sm.apply(&SearchCtor.fp, null);
+            }
         }
         return s;
     }

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -727,7 +727,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                 }
             }
 
-            foreach (const i; 0 .. members.dim)
+            for (size_t i = 0; i < members.dim; i++)
             {
                 auto sm = (*members)[i];
                 sm.apply(&SearchCtor.fp, null);


### PR DESCRIPTION
Reverts dlang/dmd#12868

We don't do this optimization for members because the elements can be added to members[] in the loop body, and foreach assumes a fixed array length. I'm going to have to revert this. There have been many weird bugs caused by this. For some loops it's ok, others not, and it often isn't obvious. The loop body can also change its behavior later, causing weird breakages.