### PR TITLE
fix Issue 13165 - Using -profile does extra control flow analysis, le…

### DIFF
--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -156,7 +156,8 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
 
                     if (!(result & BE.fallthru) && !s.comeFrom())
                     {
-                        if (blockExit(s, func, mustNotThrow) != BE.halt && s.hasCode())
+                        if (blockExit(s, func, mustNotThrow) != BE.halt && s.hasCode() &&
+                            s.loc != Loc.initial) // don't emit warning for generated code
                             s.warning("statement is not reachable");
                     }
                     else

--- a/test/compilable/fix13165.d
+++ b/test/compilable/fix13165.d
@@ -1,0 +1,12 @@
+/* REQUIRED_ARGS: -w -profile
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=13165
+
+void main()
+{
+    int i;
+    if (!i)
+        throw new Exception("Error");
+    assert(0);
+}


### PR DESCRIPTION
…ading to spurious statement is not reachable warning

The bug is caused by the compiler (helpfully) inserting a `return 0;` statement at the end of `main()` if there isn't one there already. Since the statement in some cases is not reachable, then the warning is emitted. The inserted code is known by not having a line number, so it's easy to just avoid printing the warning if there's no line number.