### PR TITLE
Fix Issue 22118 - Const union causes false multiple-initialization error in constructor

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4828,7 +4828,29 @@ extern (C++) final class DotVarExp : UnaExp
                                 if (!onlyUnion)
                                     v.ctorinit = false;
                                 if (modifyLevel == Modifiable.initialization)
+                                {
+                                    // https://issues.dlang.org/show_bug.cgi?id=22118
+                                    // v is a union type field that was assigned
+                                    // a variable, therefore it counts as initialization
+                                    if (v.ctorinit)
+                                        return Modifiable.initialization;
+
+                                    // if v is of struct type, then we need to undo
+                                    // the information that was stored in fieldInit
+                                    // to get rid of the wrong error messages
+                                    auto ad = sc.func.isMemberDecl();
+                                    assert(ad);
+                                    size_t i;
+                                    for (i = 0; i < sc.ctorflow.fieldinit.length; i++)
+                                    {
+                                        if (ad.fields[i] == v)
+                                            break;
+                                    }
+                                    auto fieldInit = &sc.ctorflow.fieldinit[i];
+                                    fieldInit.csx &= CSX.none;
+                                    fieldInit.loc = Loc();
                                     return Modifiable.yes;
+                                }
                                 return modifyLevel;
                             }
                         }

--- a/test/fail_compilation/fail22118.d
+++ b/test/fail_compilation/fail22118.d
@@ -1,0 +1,35 @@
+// https://issues.dlang.org/show_bug.cgi?id=22118
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail22118.d(33): Error: cannot modify `this.v.a` in `const` function
+---
+*/
+
+struct NeedsInit
+{
+    int n;
+    @disable this();
+}
+
+union U
+{
+    NeedsInit a;
+}
+
+struct V
+{
+    NeedsInit a;
+}
+
+struct S
+{
+    U u;
+    V v;
+    this(const NeedsInit arg) const
+    {
+        u.a = arg;   // this should compile
+        v.a = arg;   // this should not
+    }
+}


### PR DESCRIPTION
This patch fixes the issue for both unions (do not issue error message when union is initialized) and structs (issue error message when a field is initialized)