### PR TITLE
remove dead function dmd.backend.util:util_assert

### DIFF
--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -120,16 +120,12 @@ elem *exp2_copytotemp(elem *e);
 /* util.c */
 //#if __clang__
 //void util_exit(int) __attribute__((noreturn));
-//void util_assert(const(char)*, int) __attribute__((noreturn));
 //#elif _MSC_VER
 //__declspec(noreturn) void util_exit(int);
-//__declspec(noreturn) void util_assert(const(char)*, int);
 //#else
 void util_exit(int);
-void util_assert(const(char)*, int);
 //#if __DMC__
 //#pragma ZTC noreturn(util_exit)
-//#pragma ZTC noreturn(util_assert)
 //#endif
 //#endif
 

--- a/src/dmd/backend/util2.d
+++ b/src/dmd/backend/util2.d
@@ -35,26 +35,8 @@ void *ph_calloc(size_t nbytes);
 void ph_free(void *p);
 void *ph_realloc(void *p , size_t nbytes);
 
-extern (C) void printInternalFailure(FILE* stream); // from dmd/mars.d
-
-
 void file_progress()
 {
-}
-
-/*******************************
- * Alternative assert failure.
- */
-@trusted
-void util_assert(const(char)* file, int line)
-{
-    fflush(stdout);
-    printInternalFailure(stdout);
-    printf("Internal error: %s %d\n",file,line);
-    err_exit();
-//#if __clang__
-//    __builtin_unreachable();
-//#endif
 }
 
 /****************************

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -86,7 +86,7 @@ Print DMD's logo with more debug information and error-reporting pointers.
 Params:
     stream = output stream to print the information on
 */
-extern(C) void printInternalFailure(FILE* stream)
+private void printInternalFailure(FILE* stream)
 {
     fputs(("---\n" ~
     "ERROR: This is a compiler bug.\n" ~


### PR DESCRIPTION
and make printInternalFailure `private extern(D)` to `dmd.mars`

The backend should not depend on the frontend.