### PR TITLE
ImportC: add enum member semantics

### DIFF
--- a/test/fail_compilation/enumtype.c
+++ b/test/fail_compilation/enumtype.c
@@ -1,0 +1,23 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/enumtype.c(111): Error: enum member `enumtype.E2.A2` enum member value `549755813889L` does not fit in an `int`
+fail_compilation/enumtype.c(112): Error: circular reference to enum base type `int`
+---
+ */
+
+#line 100
+
+enum E1 { A1 = 0, B1 = sizeof(A1), C1 = 1LL, D1 = sizeof(C1), F1 = -1U, G1 };
+
+_Static_assert(A1 == 0, "in");
+_Static_assert(B1 == 4, "in");
+_Static_assert(C1 == 1, "in");
+_Static_assert(D1 == 4, "in");
+_Static_assert(F1 == -1, "in");
+_Static_assert(G1 == 0, "in");
+_Static_assert(sizeof(enum E1) == 4, "in");
+
+enum E2 { A2 = 0x8000000001LL };
+enum E3 { A3 = sizeof(enum E3) };
+
+


### PR DESCRIPTION
C11 has its own odd rules for enum member types and values.

gcc and clang are more permissive in what they allow for enum values, but this pedantically follows the C11 spec. If this proves inadequate, we can adjust later.

This should finish up the implementation of enums.