### PR TITLE
Add .i extension for preprocessed C files to known file extensions

### DIFF
--- a/changelog/ImportC.md
+++ b/changelog/ImportC.md
@@ -121,6 +121,45 @@ dmd hello.c
 hello world!
 ```
 
+For C code using C includes you can preprocess the C source with a C
+preprocessor. Create the file testcode.c:
+
+```
+#include <stdint.h>
+
+uint32_t someCodeInC(uint32_t a, uint32_t b)
+{
+    return a + b;
+}
+```
+
+Preprocess the C code with the C preprocessor:
+```
+gcc -E -P testcode.c >testcode.i
+```
+
+Create D file d_main.d:
+```
+import std.stdio;
+import testcode;
+
+void main()
+{
+    writeln("Result of someCodeInC(3,4) = ", someCodeInC(3, 4) );
+}
+```
+
+Compile and run it:
+```
+dmd d_main.d testcode.i
+./d_main
+Result of someCodeInC(3,4) = 7
+```
+
+The '.i' file extension can be used instead of '.c'. This makes it clear, that
+preprocessed imtermediate C code is in use. The '.i' files can be created by
+some generator script or a Makefile.
+
 ## Implementation Details
 
 ### User Experience

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -82,6 +82,10 @@ private const(char)[] lookForSourceFile(const char[] filename, const char*[] pat
     const sc = FileName.forceExt(filename, c_ext);
     if (FileName.exists(sc) == 1)
         return sc;
+
+    const si = FileName.forceExt(filename, i_ext);
+    if (FileName.exists(si) == 1)
+        return si;
     scope(exit) FileName.free(sc.ptr);
 
     if (FileName.exists(filename) == 2)
@@ -554,6 +558,7 @@ extern (C++) final class Module : Package
         else if (!FileName.equalsExt(srcfilename, mars_ext) &&
                  !FileName.equalsExt(srcfilename, hdr_ext) &&
                  !FileName.equalsExt(srcfilename, c_ext) &&
+                 !FileName.equalsExt(srcfilename, i_ext) &&
                  !FileName.equalsExt(srcfilename, dd_ext))
         {
 
@@ -1041,8 +1046,9 @@ extern (C++) final class Module : Package
         }
 
         /* If it has the extension ".c", it is a "C" file.
+         * If it has the extension ".i", it is a preprocessed "C" file.
          */
-        if (FileName.equalsExt(arg, c_ext))
+        if (FileName.equalsExt(arg, c_ext) || FileName.equalsExt(arg, i_ext))
         {
             isCFile = true;
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -275,6 +275,7 @@ enum hdr_ext  = "di";       // for D 'header' import files
 enum json_ext = "json";     // for JSON files
 enum map_ext  = "map";      // for .map files
 enum c_ext    = "c";        // for C source files
+enum i_ext    = "i";        // for preprocessed C source file
 
 /**
  * Collection of global compiler settings and global state used by the frontend

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -2785,7 +2785,8 @@ Module createModule(const(char)* file, ref Strings libmodules)
     if (FileName.equals(ext, mars_ext) ||
         FileName.equals(ext, hdr_ext ) ||
         FileName.equals(ext, dd_ext  ) ||
-        FileName.equals(ext, c_ext   ))
+        FileName.equals(ext, c_ext   ) ||
+        FileName.equals(ext, i_ext   ))
     {
         name = FileName.removeExt(p);
         if (!name.length || name == ".." || name == ".")

--- a/test/runnable/.gitignore
+++ b/test/runnable/.gitignore
@@ -1,0 +1,2 @@
+# Ignore preprocessed C files
+*.i

--- a/test/runnable/extra-files/importc_main.d
+++ b/test/runnable/extra-files/importc_main.d
@@ -1,0 +1,11 @@
+
+import std.stdio;
+import importc_test;
+
+int main()
+{
+    auto rc = someCodeInC(3, 4);
+    writeln("Result of someCodeInC(3,4) = ", rc );
+    assert( rc == 7, "Wrong result");
+    return 0;
+}

--- a/test/runnable/extra-files/importc_test.c
+++ b/test/runnable/extra-files/importc_test.c
@@ -1,0 +1,7 @@
+
+#include <stdint.h>
+
+uint32_t someCodeInC(uint32_t a, uint32_t b)
+{
+    return a + b;
+}

--- a/test/runnable/extra-files/importc_test.i.in
+++ b/test/runnable/extra-files/importc_test.i.in
@@ -1,0 +1,235 @@
+# 1 "runnable/extra-files/importc_test.c"
+# 1 "<built-in>"
+# 1 "<command-line>"
+# 31 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 32 "<command-line>" 2
+# 1 "runnable/extra-files/importc_test.c"
+
+# 1 "/usr/lib/gcc/x86_64-linux-gnu/10/include/stdint.h" 1 3 4
+# 9 "/usr/lib/gcc/x86_64-linux-gnu/10/include/stdint.h" 3 4
+# 1 "/usr/include/stdint.h" 1 3 4
+# 26 "/usr/include/stdint.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/libc-header-start.h" 1 3 4
+# 33 "/usr/include/x86_64-linux-gnu/bits/libc-header-start.h" 3 4
+# 1 "/usr/include/features.h" 1 3 4
+# 469 "/usr/include/features.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 1 3 4
+# 462 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 463 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 2 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/long-double.h" 1 3 4
+# 464 "/usr/include/x86_64-linux-gnu/sys/cdefs.h" 2 3 4
+# 470 "/usr/include/features.h" 2 3 4
+# 493 "/usr/include/features.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 1 3 4
+# 10 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/gnu/stubs-64.h" 1 3 4
+# 11 "/usr/include/x86_64-linux-gnu/gnu/stubs.h" 2 3 4
+# 494 "/usr/include/features.h" 2 3 4
+# 34 "/usr/include/x86_64-linux-gnu/bits/libc-header-start.h" 2 3 4
+# 27 "/usr/include/stdint.h" 2 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/types.h" 1 3 4
+# 27 "/usr/include/x86_64-linux-gnu/bits/types.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 28 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/timesize.h" 1 3 4
+# 29 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
+
+
+
+# 31 "/usr/include/x86_64-linux-gnu/bits/types.h" 3 4
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+
+
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+
+typedef signed long int __int64_t;
+typedef unsigned long int __uint64_t;
+
+
+
+
+
+
+typedef __int8_t __int_least8_t;
+typedef __uint8_t __uint_least8_t;
+typedef __int16_t __int_least16_t;
+typedef __uint16_t __uint_least16_t;
+typedef __int32_t __int_least32_t;
+typedef __uint32_t __uint_least32_t;
+typedef __int64_t __int_least64_t;
+typedef __uint64_t __uint_least64_t;
+
+
+
+typedef long int __quad_t;
+typedef unsigned long int __u_quad_t;
+
+
+
+
+
+
+
+typedef long int __intmax_t;
+typedef unsigned long int __uintmax_t;
+# 141 "/usr/include/x86_64-linux-gnu/bits/types.h" 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/typesizes.h" 1 3 4
+# 142 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/time64.h" 1 3 4
+# 143 "/usr/include/x86_64-linux-gnu/bits/types.h" 2 3 4
+
+
+typedef unsigned long int __dev_t;
+typedef unsigned int __uid_t;
+typedef unsigned int __gid_t;
+typedef unsigned long int __ino_t;
+typedef unsigned long int __ino64_t;
+typedef unsigned int __mode_t;
+typedef unsigned long int __nlink_t;
+typedef long int __off_t;
+typedef long int __off64_t;
+typedef int __pid_t;
+typedef struct { int __val[2]; } __fsid_t;
+typedef long int __clock_t;
+typedef unsigned long int __rlim_t;
+typedef unsigned long int __rlim64_t;
+typedef unsigned int __id_t;
+typedef long int __time_t;
+typedef unsigned int __useconds_t;
+typedef long int __suseconds_t;
+typedef long int __suseconds64_t;
+
+typedef int __daddr_t;
+typedef int __key_t;
+
+
+typedef int __clockid_t;
+
+
+typedef void * __timer_t;
+
+
+typedef long int __blksize_t;
+
+
+
+
+typedef long int __blkcnt_t;
+typedef long int __blkcnt64_t;
+
+
+typedef unsigned long int __fsblkcnt_t;
+typedef unsigned long int __fsblkcnt64_t;
+
+
+typedef unsigned long int __fsfilcnt_t;
+typedef unsigned long int __fsfilcnt64_t;
+
+
+typedef long int __fsword_t;
+
+typedef long int __ssize_t;
+
+
+typedef long int __syscall_slong_t;
+
+typedef unsigned long int __syscall_ulong_t;
+
+
+
+typedef __off64_t __loff_t;
+typedef char *__caddr_t;
+
+
+typedef long int __intptr_t;
+
+
+typedef unsigned int __socklen_t;
+
+
+
+
+typedef int __sig_atomic_t;
+# 28 "/usr/include/stdint.h" 2 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wchar.h" 1 3 4
+# 29 "/usr/include/stdint.h" 2 3 4
+# 1 "/usr/include/x86_64-linux-gnu/bits/wordsize.h" 1 3 4
+# 30 "/usr/include/stdint.h" 2 3 4
+
+
+
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/stdint-intn.h" 1 3 4
+# 24 "/usr/include/x86_64-linux-gnu/bits/stdint-intn.h" 3 4
+typedef __int8_t int8_t;
+typedef __int16_t int16_t;
+typedef __int32_t int32_t;
+typedef __int64_t int64_t;
+# 35 "/usr/include/stdint.h" 2 3 4
+
+
+# 1 "/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h" 1 3 4
+# 24 "/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h" 3 4
+typedef __uint8_t uint8_t;
+typedef __uint16_t uint16_t;
+typedef __uint32_t uint32_t;
+typedef __uint64_t uint64_t;
+# 38 "/usr/include/stdint.h" 2 3 4
+
+
+
+
+
+typedef __int_least8_t int_least8_t;
+typedef __int_least16_t int_least16_t;
+typedef __int_least32_t int_least32_t;
+typedef __int_least64_t int_least64_t;
+
+
+typedef __uint_least8_t uint_least8_t;
+typedef __uint_least16_t uint_least16_t;
+typedef __uint_least32_t uint_least32_t;
+typedef __uint_least64_t uint_least64_t;
+
+
+
+
+
+typedef signed char int_fast8_t;
+
+typedef long int int_fast16_t;
+typedef long int int_fast32_t;
+typedef long int int_fast64_t;
+# 71 "/usr/include/stdint.h" 3 4
+typedef unsigned char uint_fast8_t;
+
+typedef unsigned long int uint_fast16_t;
+typedef unsigned long int uint_fast32_t;
+typedef unsigned long int uint_fast64_t;
+# 87 "/usr/include/stdint.h" 3 4
+typedef long int intptr_t;
+
+
+typedef unsigned long int uintptr_t;
+# 101 "/usr/include/stdint.h" 3 4
+typedef __intmax_t intmax_t;
+typedef __uintmax_t uintmax_t;
+# 10 "/usr/lib/gcc/x86_64-linux-gnu/10/include/stdint.h" 2 3 4
+# 3 "runnable/extra-files/importc_test.c" 2
+
+
+# 4 "runnable/extra-files/importc_test.c"
+uint32_t someCodeInC(uint32_t a, uint32_t b)
+{
+    return a + b;
+}

--- a/test/runnable/importc-test1.sh
+++ b/test/runnable/importc-test1.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-gcc -E ${EXTRA_FILES}/importc_test.c >${EXTRA_FILES}/importc_test.i
+if [ $OS == "linux" ] ; then
+	gcc -E ${EXTRA_FILES}/importc_test.c >${EXTRA_FILES}/importc_test.i
+else
+	# TODO Find some prepro for MAC and Windows
+	echo "TODO: Add a Windows and Mac C preprocessor!"
+	cp ${EXTRA_FILES}/importc_test.i.in ${EXTRA_FILES}/importc_test.i
+fi
 
 $DMD -m${MODEL} -I${OUTPUT_BASE} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}importc_main.d ${EXTRA_FILES}/importc_test.i
 

--- a/test/runnable/importc-test1.sh
+++ b/test/runnable/importc-test1.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+gcc -E ${EXTRA_FILES}/importc_test.c >${EXTRA_FILES}/importc_test.i
+
+$DMD -m${MODEL} -I${OUTPUT_BASE} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}importc_main.d ${EXTRA_FILES}/importc_test.i
+
+${OUTPUT_BASE}${EXE}
+
+rm_retry ${OUTPUT_BASE}{a${OBJ},${EXE}}


### PR DESCRIPTION
Added .i as extension for preprocessed C files, which can be fed directly
to DMD. The file is then processed as C source file.

Supporting .i as file exzension allows to preprocess C code with GCC -E and
store the output to some file for further processing by DMD.