### PR TITLE
Fix issue 21912 - delegate assigned to return scope variable needs closure

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -841,7 +841,7 @@ ByRef:
          * then uncount that address of. This is so it won't cause a
          * closure to be allocated.
          */
-        if (va && va.isScope() && fd.tookAddressOf)
+        if (va && va.isScope() && !(va.storage_class & STC.return_) && fd.tookAddressOf)
             --fd.tookAddressOf;
 
         foreach (v; vars)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2066,7 +2066,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                 if (global.params.vsafe)
                     err |= checkParamArgumentEscape(sc, fd, p, arg, false, false);
             }
-            else
+            else if (!(p.storageClass & STC.return_))
             {
                 /* Argument value cannot escape from the called function.
                  */
@@ -2075,7 +2075,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                     a = (cast(CastExp)a).e1;
 
                 ArrayLiteralExp ale;
-                if (p.type.toBasetype().ty == Tarray && !(p.storageClass & STC.return_) &&
+                if (p.type.toBasetype().ty == Tarray &&
                     (ale = a.isArrayLiteralExp()) !is null)
                 {
                     // allocate the array literal as temporary static array on the stack

--- a/test/fail_compilation/test21912.d
+++ b/test/fail_compilation/test21912.d
@@ -1,0 +1,54 @@
+/*
+PERMUTE_ARGS: -preview=dip1000
+TEST_OUTPUT
+---
+fail_compilation/test21912.d(24): Error: function `test21912.escapeParam` is `@nogc` yet allocates closures with the GC
+fail_compilation/test21912.d(26):        test21912.escapeParam.__lambda2 closes over variable i at fail_compilation/test21912.d(24)
+fail_compilation/test21912.d(29): Error: function `test21912.escapeAssign` is `@nogc` yet allocates closures with the GC
+fail_compilation/test21912.d(31):        test21912.escapeAssign.__lambda3 closes over variable i at fail_compilation/test21912.d(29)
+fail_compilation/test21912.d(40): Error: function `test21912.escapeAssignRef` is `@nogc` yet allocates closures with the GC
+fail_compilation/test21912.d(42):        test21912.escapeAssignRef.__lambda3 closes over variable i at fail_compilation/test21912.d(40)
+fail_compilation/test21912.d(51): Error: function `test21912.escapeParamInferred` is `@nogc` yet allocates closures with the GC
+fail_compilation/test21912.d(53):        test21912.escapeParamInferred.__lambda2 closes over variable i at fail_compilation/test21912.d(51)
+---
+*/
+@nogc:
+
+alias Dg = @nogc int delegate();
+
+Dg identity(return scope Dg dg)
+{
+    return dg;
+}
+
+Dg escapeParam(int i)
+{
+    return identity(() => i);
+}
+
+Dg escapeAssign(int i, return scope Dg dg)
+{
+    dg = () => i;
+    return dg;
+}
+
+ref Dg identityR(ref return scope Dg dg)
+{
+    return dg;
+}
+
+ref Dg escapeAssignRef(int i, ref return scope Dg dg)
+{
+    dg = () => i;
+    return dg;
+}
+
+auto identityInferred(Dg dg)
+{
+    return dg;
+}
+
+Dg escapeParamInferred(int i)
+{
+    return identityInferred(() => i);
+}


### PR DESCRIPTION
Passing/assigning a delegate to a `scope` variable means it doesn't need a closure, *unless* that parameter is also `return`. In both cases (parameter, variable assignment) this was forgotten.

The bug happens both with and without -dip1000 for explicit `return scope`, but only with -dip1000 will `return scope` be inferred, so it happens more often then. 

This is a breaking change because `@nogc` code relying on invalid stack closures instead of heap closures will not be `@nogc` anymore, but I think not many people write explicit `return scope` parameters without using `-dip1000`, and the code that breaks is at big risk of memory corruption, so it should be acceptable.