### PR TITLE
Remove usage of octal literals

### DIFF
--- a/docs/gen_man.d
+++ b/docs/gen_man.d
@@ -92,7 +92,7 @@ void main()
     auto now = Clock.currTime;
     auto diffable = environment.get("DIFFABLE", "0");
     if (diffable == "1")
-        now = SysTime(DateTime(2018, 01, 01));
+        now = SysTime(DateTime(2018, 1, 1));
 
     writefln(header, now.toISOExtString.take(10));
 


### PR DESCRIPTION
Same reasons as https://github.com/dlang/druntime/pull/3519 and https://github.com/dlang/phobos/pull/8168