### PR TITLE
Extract ClassDeclaration.isBaseOf

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -325,7 +325,6 @@ public:
     InterfaceDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     bool isBaseOf(ClassDeclaration *cd, int *poffset);
-    bool isBaseOf(BaseClass *bc, int *poffset);
     const char *kind() const;
     int vtblOffset() const;
     bool isCPPinterface() const;

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -291,7 +291,6 @@ public:
 
     #define OFFSET_RUNTIME 0x76543210
     #define OFFSET_FWDREF 0x76543211
-    virtual bool isBaseOf(ClassDeclaration *cd, int *poffset);
 
     bool isBaseInfoComplete();
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
@@ -324,7 +323,6 @@ class InterfaceDeclaration : public ClassDeclaration
 public:
     InterfaceDeclaration *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    bool isBaseOf(ClassDeclaration *cd, int *poffset);
     const char *kind() const;
     int vtblOffset() const;
     bool isCPPinterface() const;
@@ -333,3 +331,5 @@ public:
     InterfaceDeclaration *isInterfaceDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
+
+bool isBaseOf(ClassDeclaration* derived, ClassDeclaration* cd, int* poffset);

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -1061,38 +1061,11 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
                 // printf("\tfound at offset %d\n", b.offset);
                 return true;
             }
-            if (isBaseOf(b, poffset))
+            if (baseClassImplementsInterface(this, b, poffset))
                 return true;
         }
         if (cd.baseClass && isBaseOf(cd.baseClass, poffset))
             return true;
-
-        if (poffset)
-            *poffset = 0;
-        return false;
-    }
-
-    bool isBaseOf(BaseClass* bc, int* poffset)
-    {
-        //printf("%s.InterfaceDeclaration.isBaseOf(bc = '%s')\n", toChars(), bc.sym.toChars());
-        for (size_t j = 0; j < bc.baseInterfaces.length; j++)
-        {
-            BaseClass* b = &bc.baseInterfaces[j];
-            //printf("\tY base %s\n", b.sym.toChars());
-            if (this == b.sym)
-            {
-                //printf("\tfound at offset %d\n", b.offset);
-                if (poffset)
-                {
-                    *poffset = b.offset;
-                }
-                return true;
-            }
-            if (isBaseOf(b, poffset))
-            {
-                return true;
-            }
-        }
 
         if (poffset)
             *poffset = 0;
@@ -1138,4 +1111,44 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
     {
         v.visit(this);
     }
+}
+
+
+/**
+ * Returns whether `bc` implements `id`, including indirectly (`bc` implements an interfaces
+ * that inherits from `id`)
+ *
+ * Params:
+ *    id = the interface
+ *    bc = the base class
+ *    poffset = out parameter, offset of the interface in an object
+ *
+ * Returns:
+ *    true if the `bc` implements `id`, false otherwise
+ **/
+private bool baseClassImplementsInterface(InterfaceDeclaration id, BaseClass* bc, int* poffset)
+{
+    //printf("%s.InterfaceDeclaration.isBaseOf(bc = '%s')\n", toChars(), bc.sym.toChars());
+    for (size_t j = 0; j < bc.baseInterfaces.length; j++)
+    {
+        BaseClass* b = &bc.baseInterfaces[j];
+        //printf("\tY base %s\n", b.sym.toChars());
+        if (id == b.sym)
+        {
+            //printf("\tfound at offset %d\n", b.offset);
+            if (poffset)
+            {
+                *poffset = b.offset;
+            }
+            return true;
+        }
+        if (baseClassImplementsInterface(id, b, poffset))
+        {
+            return true;
+        }
+    }
+
+    if (poffset)
+        *poffset = 0;
+    return false;
 }

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5394,7 +5394,6 @@ public:
 
     enum : int32_t { OFFSET_FWDREF = 1985229329 };
 
-    virtual bool isBaseOf(ClassDeclaration* cd, int32_t* poffset);
     bool isBaseInfoComplete() const;
     Dsymbol* search(const Loc& loc, Identifier* ident, int32_t flags = 8);
     ClassDeclaration* searchBase(Identifier* ident);
@@ -5423,7 +5422,6 @@ class InterfaceDeclaration final : public ClassDeclaration
 public:
     InterfaceDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
-    bool isBaseOf(ClassDeclaration* cd, int32_t* poffset);
     const char* kind() const;
     int32_t vtblOffset() const;
     bool isCPPinterface() const;
@@ -5432,6 +5430,8 @@ public:
     void accept(Visitor* v);
     ~InterfaceDeclaration();
 };
+
+extern bool isBaseOf(ClassDeclaration* derived, ClassDeclaration* cd, int32_t* poffset);
 
 extern void ObjectNotFound(Identifier* id);
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5424,7 +5424,6 @@ public:
     InterfaceDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     bool isBaseOf(ClassDeclaration* cd, int32_t* poffset);
-    bool isBaseOf(BaseClass* bc, int32_t* poffset);
     const char* kind() const;
     int32_t vtblOffset() const;
     bool isCPPinterface() const;


### PR DESCRIPTION
There's a few sort of unrelated overloads of that method (one for types, one for class decls, one for base classes), which was a little confusing to me.  I renamed the base class one because I think there was an issue with overloading a method and a function with UFCS.

Moving this to typesemantic will eliminate another call to symbolsemantic in an AST module.