### PR TITLE
Improve time complexity of `traverseIndirections`

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -45,6 +45,7 @@ import dmd.identifier;
 import dmd.init;
 import dmd.mtype;
 import dmd.objc;
+import dmd.root.aav;
 import dmd.root.outbuffer;
 import dmd.root.rootobject;
 import dmd.root.string;
@@ -3256,17 +3257,7 @@ private bool traverseIndirections(Type ta, Type tb)
 {
     //printf("traverseIndirections(%s, %s)\n", ta.toChars(), tb.toChars());
 
-    /* Threaded list of aggregate types already examined,
-     * used to break cycles.
-     * Cycles in type graphs can only occur with aggregates.
-     */
-    static struct Ctxt
-    {
-        Ctxt* prev;
-        Type type;      // an aggregate type
-    }
-
-    static bool traverse(Type ta, Type tb, Ctxt* ctxt, bool reversePass)
+    static bool traverse(Type ta, Type tb, ref scope AssocArray!(const(char)*, bool) table, bool reversePass)
     {
         //printf("traverse(%s, %s)\n", ta.toChars(), tb.toChars());
         ta = ta.baseElemOf();
@@ -3296,28 +3287,27 @@ private bool traverseIndirections(Type ta, Type tb)
 
         if (tb.ty == Tclass || tb.ty == Tstruct)
         {
-            for (Ctxt* c = ctxt; c; c = c.prev)
-                if (tb == c.type)
-                    return true;
-            Ctxt c;
-            c.prev = ctxt;
-            c.type = tb;
-
             /* Traverse the type of each field of the aggregate
              */
+            bool* found = table.getLvalue(tb.deco);
+            if (*found == true)
+                return true; // We have already seen this symbol, break the cycle
+            else
+                *found = true;
+
             AggregateDeclaration sym = tb.toDsymbol(null).isAggregateDeclaration();
             foreach (v; sym.fields)
             {
                 Type tprmi = v.type.addMod(tb.mod);
                 //printf("\ttb = %s, tprmi = %s\n", tb.toChars(), tprmi.toChars());
-                if (!traverse(ta, tprmi, &c, reversePass))
+                if (!traverse(ta, tprmi, table, reversePass))
                     return false;
             }
         }
         else if (tb.ty == Tarray || tb.ty == Taarray || tb.ty == Tpointer)
         {
             Type tind = tb.nextOf();
-            if (!traverse(ta, tind, ctxt, reversePass))
+            if (!traverse(ta, tind, table, reversePass))
                 return false;
         }
         else if (tb.hasPointers())
@@ -3328,7 +3318,10 @@ private bool traverseIndirections(Type ta, Type tb)
 
         // Still no match, so try breaking up ta if we have not done so yet.
         if (!reversePass)
-            return traverse(tb, ta, ctxt, true);
+        {
+            scope newTable = AssocArray!(const(char)*, bool)();
+            return traverse(tb, ta, newTable, true);
+        }
 
         return true;
     }
@@ -3336,7 +3329,8 @@ private bool traverseIndirections(Type ta, Type tb)
     // To handle arbitrary levels of indirections in both parameters, we
     // recursively descend into aggregate members/levels of indirection in both
     // `ta` and `tb` while avoiding cycles. Start with the original types.
-    const result = traverse(ta, tb, null, false);
+    scope table = AssocArray!(const(char)*, bool)();
+    const result = traverse(ta, tb, table, false);
     //printf("  returns %d\n", result);
     return result;
 }


### PR DESCRIPTION
I was profiling the build time of DMD and noticed the host compiler spent a very long time on `StructDeclaration.finalizeSize`.

![image](https://user-images.githubusercontent.com/14114684/126047115-9b7319f4-ba6e-4b25-962f-0c374c178d24.png)

It turns out that 300 ms of semantic analysis time is spent on the following line:
```D
bool isunion = isUnionDeclaration() !is null;
```
When using my self-built dmd instead of an official release as host compiler, it's even 800 ms.

So I walked down the call stack of the function that analysed that line, looking for the culprit:
```D
expressionsem.visit(IdentityExp exp)
expressionsem.typeCombine(exp, sc)
dcast.typeMerge()
dcast.implicitConvTo(Expression e, Type t)
FuncDeclaration.isReturnIsolated()
FuncDeclaration.isTypeIsolatedIndirect()
traverseIndirections()
```

And there you had it: `traverseIndirections(inout(UnionDeclaration), inout(Dsymbol))` took all the time. What's happening is that all fields of `Dsymbol` are recursively walked looking for `UnionDeclaration`, which can take a while, since `Dsymbol` is huge and `UnionDeclaration` is pretty deep in the hierarchy:
```
UnionDeclaration : StructDeclaration : AggregateDeclaration : ScopeDsymbol : Dsymbol
```

But the worst thing is that there is no memoization. There is a simple cycle checker that walks back a linked list, but if `Dsymbol` can reach a field of e.g. type `Symbol*` in 50 different ways, it will walk down all fields of `Symbol` 50 times, and do that recursively in the same inefficient way.

This PR tries to solve it by inserting fields it visits into a `DsymbolTable`, and quitting when it's already there. This not only replaces the old cycle checker, but also prunes redundant branches. The amount of calls to `traverse` went down from 1145127 to 1041. The frontend build time of dmd (no codegen) went down from 3.4 to 2.6 seconds, measured with this command:

```console
time dmd -version=MARS -Jdmd/res -J.. -i -o- dmd/mars.d
```

I have yet to test it on other codebases, I'm open for suggestions of codebases that you suspect have super complex aggregate definitions like `Dsymbol`.

I hope the algorithm is still correct, I assumed `type.toDsymbol()` and `DsymbolTable` handle type modifiers (`inout` in this case) like I expect, but I have yet to check.