### PR TITLE
Change module source filename search order

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -67,7 +67,7 @@ enum package_di = "package." ~ hdr_ext;
 private const(char)[] lookForSourceFile(const char[] filename, const char*[] path)
 {
     //printf("lookForSourceFile(`%.*s`)\n", cast(int)filename.length, filename.ptr);
-    /* Search along path[] for .di file, then .d file.
+    /* Search along path[] for .di file, then .d file, then .i file, then .c file.
      */
     const sdi = FileName.forceExt(filename, hdr_ext);
     if (FileName.exists(sdi) == 1)
@@ -79,13 +79,14 @@ private const(char)[] lookForSourceFile(const char[] filename, const char*[] pat
         return sd;
     scope(exit) FileName.free(sd.ptr);
 
-    const sc = FileName.forceExt(filename, c_ext);
-    if (FileName.exists(sc) == 1)
-        return sc;
-
     const si = FileName.forceExt(filename, i_ext);
     if (FileName.exists(si) == 1)
         return si;
+    scope(exit) FileName.free(si.ptr);
+
+    const sc = FileName.forceExt(filename, c_ext);
+    if (FileName.exists(sc) == 1)
+        return sc;
     scope(exit) FileName.free(sc.ptr);
 
     if (FileName.exists(filename) == 2)
@@ -119,6 +120,12 @@ private const(char)[] lookForSourceFile(const char[] filename, const char*[] pat
         FileName.free(n.ptr);
 
         n = FileName.combine(p, sd);
+        if (FileName.exists(n) == 1) {
+            return n;
+        }
+        FileName.free(n.ptr);
+
+        n = FileName.combine(p, si);
         if (FileName.exists(n) == 1) {
             return n;
         }

--- a/test/runnable/extra-files/importc_main2.d
+++ b/test/runnable/extra-files/importc_main2.d
@@ -1,0 +1,9 @@
+
+import std.stdio;
+import importc_test;
+
+int main()
+{
+    intptr_t iptr;
+    return 0;
+}

--- a/test/runnable/importc-test1.sh
+++ b/test/runnable/importc-test1.sh
@@ -8,8 +8,19 @@ else
 	cp ${EXTRA_FILES}/importc_test.i.in ${EXTRA_FILES}/importc_test.i
 fi
 
-$DMD -m${MODEL} -I${OUTPUT_BASE} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}importc_main.d ${EXTRA_FILES}/importc_test.i
+# Case1: The referenced .i is passed on commandline
+$DMD -m${MODEL} -I${OUTPUT_BASE} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}importc_main.d ${EXTRA_FILES}${SEP}importc_test.i
 
 ${OUTPUT_BASE}${EXE}
 
-rm_retry ${OUTPUT_BASE}{a${OBJ},${EXE}}
+# Case2: The referenced module compiled from an .i file is NOT passed on commandline
+#        and the compiler has to guess the right name.
+#        Note: object is passed to keep linker happy
+#        Note: if the module object created from the .i file just contains DECLARATIONS, you can omit the .o file.
+#              There is no code to link in this case. This work e.g. for preprocessed C headers, e.g. /usr/include/zstd.h
+$DMD -c -m${MODEL} -I${OUTPUT_BASE} ${EXTRA_FILES}${SEP}importc_test.i -of=${EXTRA_FILES}${SEP}importc_test.o
+$DMD -m${MODEL} -I${OUTPUT_BASE} -of${OUTPUT_BASE}${EXE} -I${EXTRA_FILES} ${EXTRA_FILES}${SEP}importc_test.o ${EXTRA_FILES}${SEP}importc_main2.d
+
+${OUTPUT_BASE}${EXE}
+
+rm_retry ${OUTPUT_BASE}{a${OBJ},${EXE}} ${EXTRA_FILES}${SEP}importc_test.o ${EXTRA_FILES}/importc_test.i


### PR DESCRIPTION
Change: Check for preprocessed .i file before checking .c file
    
When a module is referenced by an 'import' statement from D source, but
the referenced module source isn't passed on the commandline to the D
compiler, the compiler tries to guess the right filename.
   
Like for D sources, where .di files have higher priority as .d files, the
same should be true for C files, where .i files should be tested before .c
files.
    
This allows to store the .i files beside the related .c files and the D
compiler will pick the .i before it tries to use a .c file.
    
Additional fixes and changes:
    - Fixed memory leak
    - Fixed also check for .i in searched paths
    - Existing testcase enhanced to test filename guessing
    - Updated comments in source
