### PR TITLE
fix Issue 22070 - importC: Error: string literal is not an lvalue

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -6139,6 +6139,9 @@ public:
             return;
         }
 
+        if (result.isStringExp())
+            return;
+
         if (result.op != TOK.address)
         {
             if (result.op == TOK.null_)

--- a/test/runnable/test22070_2.c
+++ b/test/runnable/test22070_2.c
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=22070
+
+int printf(const char *, ...);
+
+char(*var)[4] = &"123";
+
+char test()
+{
+   char(*bar)[4] = &"456";
+   return (*bar)[1];
+}
+
+int main()
+{
+    if ((*var)[2] != '3')
+        return 1;
+    if (test() != '5')
+        return 1;
+    return 0;
+}
+
+_Static_assert(test() == '5', "in");


### PR DESCRIPTION
Simpler fix than https://github.com/dlang/dmd/pull/12888

All we do is adjust the type as a special case. Then patch up the interpreter so it can handle strings as lvalues.

Test for static initialization, dynamic initialization, and CTFE.