### PR TITLE
fix Issue 22071 - ImportC: Error: struct literal is not an lvalue

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3329,6 +3329,14 @@ extern (C++) final class StructLiteralExp : Expression
         return this;
     }
 
+    override Expression toLvalue(Scope* sc, Expression e)
+    {
+        if (sc.flags & SCOPE.Cfile)
+            return this;  // C struct literals are lvalues
+        else
+            return Expression.toLvalue(sc, e);
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -462,6 +462,7 @@ public:
     Expression *getField(Type *type, unsigned offset);
     int getFieldIndex(Type *type, unsigned offset);
     Expression *addDtorHook(Scope *sc);
+    Expression *toLvalue(Scope *sc, Expression *e);
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6609,6 +6609,7 @@ public:
     Expression* getField(Type* type, uint32_t offset);
     int32_t getFieldIndex(Type* type, uint32_t offset);
     Expression* addDtorHook(Scope* sc);
+    Expression* toLvalue(Scope* sc, Expression* e);
     void accept(Visitor* v);
 };
 

--- a/test/runnable/test22071.c
+++ b/test/runnable/test22071.c
@@ -1,0 +1,26 @@
+// https://issues.dlang.org/show_bug.cgi?id=22071
+
+int printf(const char *, ...);
+
+struct S { int a, b; };
+
+struct S *abc = &(struct S){ 1, 2 };
+
+int test()
+{
+    struct S *var = &(struct S){ 1, 2 };
+    return var.b;
+}
+
+_Static_assert(test() == 2, "in");
+
+int main()
+{
+    int i = test();
+    if (i != 2)
+        return 1;
+    int j = abc.b;
+    if (j != 2)
+        return 1;
+    return 0;
+}


### PR DESCRIPTION
Remarkably, it worked by simply not issuing an error.