### PR TITLE
fix Issue 22133 - [REG2.097] Breaking change in DotTemplateExp type semantics leading to e.g. isInputRange regression

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4742,6 +4742,18 @@ extern (C++) final class DotTemplateExp : UnaExp
         this.td = td;
     }
 
+    override bool checkType()
+    {
+        error("%s `%s` has no type", td.kind(), toChars());
+        return true;
+    }
+
+    override bool checkValue()
+    {
+        error("%s `%s` has no value", td.kind(), toChars());
+        return true;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -746,6 +746,8 @@ class DotTemplateExp : public UnaExp
 public:
     TemplateDeclaration *td;
 
+    bool checkType();
+    bool checkValue();
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3934,6 +3934,8 @@ class DotTemplateExp final : public UnaExp
 {
 public:
     TemplateDeclaration* td;
+    bool checkType();
+    bool checkValue();
     void accept(Visitor* v);
 };
 

--- a/test/compilable/test22133.d
+++ b/test/compilable/test22133.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=22133
+
+struct Slice
+{
+    bool empty() const;
+    int front() const;
+    void popFront()() // note: requires a mutable Slice
+    {}
+}
+
+enum isInputRange1(R) = is(typeof((R r) => r.popFront));
+enum isInputRange2(R) = __traits(compiles, (R r) => r.popFront);
+static assert(isInputRange1!(      Slice) == true);
+static assert(isInputRange1!(const Slice) == false);
+static assert(isInputRange2!(      Slice) == true);
+static assert(isInputRange2!(const Slice) == false);

--- a/test/fail_compilation/fail22133.d
+++ b/test/fail_compilation/fail22133.d
@@ -1,0 +1,24 @@
+// https://issues.dlang.org/show_bug.cgi?id=22133
+/*
+TEST_OUTPUT
+---
+fail_compilation/fail22133.d(16): Error: `s.popFront()()` has no effect
+fail_compilation/fail22133.d(17): Error: template `s.popFront()()` has no type
+---
+*/
+struct Slice
+{
+    void popFront()() {}
+}
+
+auto fail22133(const Slice s)
+{
+    s.popFront;
+    return s.popFront;
+}
+
+auto ok22133(Slice s)
+{
+    s.popFront;
+    return s.popFront;
+}

--- a/test/fail_compilation/fail7424b.d
+++ b/test/fail_compilation/fail7424b.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424b.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424b.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424b

--- a/test/fail_compilation/fail7424c.d
+++ b/test/fail_compilation/fail7424c.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424c.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424c.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424c

--- a/test/fail_compilation/fail7424d.d
+++ b/test/fail_compilation/fail7424d.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424d.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424d.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424d

--- a/test/fail_compilation/fail7424e.d
+++ b/test/fail_compilation/fail7424e.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424e.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424e.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424e

--- a/test/fail_compilation/fail7424f.d
+++ b/test/fail_compilation/fail7424f.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424f.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424f.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424f

--- a/test/fail_compilation/fail7424g.d
+++ b/test/fail_compilation/fail7424g.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424g.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424g.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424g

--- a/test/fail_compilation/fail7424h.d
+++ b/test/fail_compilation/fail7424h.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424h.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424h.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424g

--- a/test/fail_compilation/fail7424i.d
+++ b/test/fail_compilation/fail7424i.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424i.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424i.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424g


### PR DESCRIPTION
Reverts dlang/dmd#12294

This change had other surprising side effects.

```
import std.range.primitives : isInputRange;
struct Slice
{
    bool empty() const;
    int front() const;
    void popFront()()
    {
    }
}
static assert(isInputRange!(      Slice) == true);
static assert(isInputRange!(const Slice) == false);  // fails since 2.097.0
```