### PR TITLE
End deprecation period for incorrect initialization of union when first member isn't marked (Issues 19919 and 19917)

### DIFF
--- a/changelog/union_initialization.md
+++ b/changelog/union_initialization.md
@@ -1,0 +1,17 @@
+Default initialization of `union` field that isn't the first member now triggers an error
+
+The following code has been deprecated since 2.088.0
+
+```
+union U
+{
+    int a;
+    long b = 4;
+}
+```
+
+This is problematic because unions are default initialized to whatever the
+initializer for the first field is, any other initializers present are ignored.
+
+The corrective action is to declare the `union` field with the default
+initialization as the first field.

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -310,10 +310,9 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                 }
                 else if (v2._init && i < j)
                 {
-                    // @@@DEPRECATED_v2.086@@@.
-                    .deprecation(v2.loc, "union field `%s` with default initialization `%s` must be before field `%s`",
+                    .error(v2.loc, "union field `%s` with default initialization `%s` must be before field `%s`",
                         v2.toChars(), v2._init.toChars(), vd.toChars());
-                    //errors = true;
+                    errors = true;
                 }
             }
         }

--- a/test/fail_compilation/fail19919.d
+++ b/test/fail_compilation/fail19919.d
@@ -1,9 +1,8 @@
-// REQUIRED_ARGS: -de
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail19919.d(17): Deprecation: union field `f` with default initialization `3.14F` must be before field `n`
-fail_compilation/fail19919.d(24): Deprecation: union field `f` with default initialization `3.14F` must be before field `n`
+fail_compilation/fail19919.d(16): Error: union field `f` with default initialization `3.14F` must be before field `n`
+fail_compilation/fail19919.d(23): Error: union field `f` with default initialization `3.14F` must be before field `n`
 ---
 */
 


### PR DESCRIPTION
First deprecated in July 2019, 2 years has now passed so is ready to be turned into an error.