### PR TITLE
End deprecation period for the delete keyword

### DIFF
--- a/changelog/delete_keyword.dd
+++ b/changelog/delete_keyword.dd
@@ -1,0 +1,9 @@
+The `delete` keyword now triggers an error.
+
+See the $(LINK2 $(ROOT_DIR)deprecate.html#delete, Deprecated Features) for more information.
+
+Starting with this release, using the `delete` keyword will result in a compiler error.
+
+As a replacement, users are encouraged to use $(REF1 destroy, object)
+if feasible, or $(REF __delete, core,memory) as a last resort.
+

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7196,15 +7196,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DeleteExp exp)
     {
-        if (!sc.isDeprecated)
-        {
-            // @@@DEPRECATED_2019-02@@@
-            // 1. Deprecation for 1 year
-            // 2. Error for 1 year
-            // 3. Removal of keyword, "delete" can be used for other identities
-            if (!exp.isRAII)
-                deprecation(exp.loc, "The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.");
-        }
+        // @@@DEPRECATED_2019-02@@@
+        // 1. Deprecated for 3 years (starting from 2018-02).
+        // 2. Error for 1 year (starting from 2021-07)
+        // 3. Removal of keyword, "delete" can be used for other identities
+        if (!exp.isRAII)
+            error(exp.loc, "The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.");
 
         if (Expression ex = unaSemantic(exp, sc))
         {

--- a/test/compilable/debugInference.d
+++ b/test/compilable/debugInference.d
@@ -1,9 +1,5 @@
 /*
 REQUIRED_ARGS: -debug
-TEST_OUTPUT:
----
-compilable/debugInference.d(35): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
 https://issues.dlang.org/show_bug.cgi?id=20507
 */
 
@@ -32,7 +28,7 @@ void bar()()
         auto f2Ptr = &f2;
 
         S s;
-        delete s;
+        s.destroy();
 
         int* ptr = cast(int*) 0;
         int[] slice = ptr[0 .. 4];

--- a/test/compilable/test17906.d
+++ b/test/compilable/test17906.d
@@ -1,7 +1,0 @@
-// REQUIRED_ARGS: -de
-// https://issues.dlang.org/show_bug.cgi?id=18647
-deprecated void main ()
-{
-    Object o = new Object;
-    delete o;
-}

--- a/test/compilable/vgc1.d
+++ b/test/compilable/vgc1.d
@@ -62,23 +62,3 @@ void testNewScope()
     scope Object o3;
     o3 = o2;                            // no error
 }
-
-/***************** DeleteExp *******************/
-
-/*
-TEST_OUTPUT:
----
-compilable/vgc1.d(81): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-compilable/vgc1.d(81): vgc: `delete` requires the GC
-compilable/vgc1.d(82): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-compilable/vgc1.d(82): vgc: `delete` requires the GC
-compilable/vgc1.d(83): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-compilable/vgc1.d(83): vgc: `delete` requires the GC
----
-*/
-void testDelete(int* p, Object o, S1* s)
-{
-    delete p;
-    delete o;
-    delete s;
-}

--- a/test/fail_compilation/fail14486.d
+++ b/test/fail_compilation/fail14486.d
@@ -3,37 +3,37 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(56): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(56): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail14486.d(56): Error: `delete c0` is not `@safe` but is used in `@safe` function `test1a`
-fail_compilation/fail14486.d(57): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(57): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail14486.d(57): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C1a.~this`
 fail_compilation/fail14486.d(57): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C1a.~this`
 fail_compilation/fail14486.d(43):        `fail14486.C1a.~this` is declared here
 fail_compilation/fail14486.d(57): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(62): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(63): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(62): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(63): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail14486.d(63): Error: destructor `fail14486.C1b.~this` is not `nothrow`
 fail_compilation/fail14486.d(60): Error: `nothrow` function `fail14486.test1b` may throw
-fail_compilation/fail14486.d(68): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(68): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail14486.d(68): Error: `delete s0` is not `@safe` but is used in `@safe` function `test2a`
-fail_compilation/fail14486.d(69): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(69): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail14486.d(69): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S1a.~this`
 fail_compilation/fail14486.d(69): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S1a.~this`
 fail_compilation/fail14486.d(49):        `fail14486.S1a.~this` is declared here
 fail_compilation/fail14486.d(69): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(74): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(75): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(74): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(75): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail14486.d(75): Error: destructor `fail14486.S1b.~this` is not `nothrow`
 fail_compilation/fail14486.d(72): Error: `nothrow` function `fail14486.test2b` may throw
-fail_compilation/fail14486.d(80): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(80): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail14486.d(80): Error: `delete a0` is not `@safe` but is used in `@safe` function `test3a`
-fail_compilation/fail14486.d(81): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(81): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail14486.d(81): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S1a.~this`
 fail_compilation/fail14486.d(81): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S1a.~this`
 fail_compilation/fail14486.d(49):        `fail14486.S1a.~this` is declared here
 fail_compilation/fail14486.d(81): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(86): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(87): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(86): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(87): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail14486.d(87): Error: destructor `fail14486.S1b.~this` is not `nothrow`
 fail_compilation/fail14486.d(84): Error: `nothrow` function `fail14486.test3b` may throw
 ---

--- a/test/fail_compilation/fail17906.d
+++ b/test/fail_compilation/fail17906.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -de
+// https://issues.dlang.org/show_bug.cgi?id=18647
+/* TEST_OUTPUT
+---
+fail_compilation/fail17906.d(11): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
+deprecated void main ()
+{
+    Object o = new Object;
+    delete o;
+}

--- a/test/fail_compilation/fail2361.d
+++ b/test/fail_compilation/fail2361.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2361.d(14): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail2361.d(14): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail2361.d(14): Error: cannot modify `immutable` expression `c`
 ---
 */

--- a/test/fail_compilation/fail_arrayop2.d
+++ b/test/fail_compilation/fail_arrayop2.d
@@ -209,7 +209,7 @@ fail_compilation/fail_arrayop2.d(269): Error: array operation `"abc"[] + '\x01'`
 fail_compilation/fail_arrayop2.d(272): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(275): Error: `([1] * 6)[0..2]` is not an lvalue and cannot be modified
 fail_compilation/fail_arrayop2.d(278): Error: can only `*` a pointer, not a `int[]`
-fail_compilation/fail_arrayop2.d(281): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail_arrayop2.d(281): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail_arrayop2.d(281): Error: `[1] * 6` is not an lvalue and cannot be modified
 fail_compilation/fail_arrayop2.d(284): Error: array operation `da[] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(287): Error: array operation `da[] * 6` without destination memory not allowed

--- a/test/fail_compilation/faildeleteaa.d
+++ b/test/fail_compilation/faildeleteaa.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/faildeleteaa.d(12): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/faildeleteaa.d(12): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/faildeleteaa.d(12): Error: cannot delete type `int`
 ---
 */

--- a/test/fail_compilation/failvgc1.d
+++ b/test/fail_compilation/failvgc1.d
@@ -1,0 +1,26 @@
+// REQUIRED_ARGS: -vgc -o-
+// PERMUTE_ARGS:
+
+/***************** DeleteExp *******************/
+
+struct S1 { }
+struct S2 { this(int); }
+struct S3 { this(int) @nogc; }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/failvgc1.d(23): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/failvgc1.d(23): vgc: `delete` requires the GC
+fail_compilation/failvgc1.d(24): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/failvgc1.d(24): vgc: `delete` requires the GC
+fail_compilation/failvgc1.d(25): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/failvgc1.d(25): vgc: `delete` requires the GC
+---
+*/
+void testDelete(int* p, Object o, S1* s)
+{
+    delete p;
+    delete o;
+    delete s;
+}

--- a/test/fail_compilation/ice11968.d
+++ b/test/fail_compilation/ice11968.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ----
-fail_compilation/ice11968.d(9): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/ice11968.d(9): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/ice11968.d(9): Error: cannot modify string literal `"fail_compilation$?:windows=\\|/$ice11968.d"`
 ----
 */

--- a/test/fail_compilation/nogc1.d
+++ b/test/fail_compilation/nogc1.d
@@ -63,11 +63,11 @@ fail_compilation/nogc1.d(55): Error: cannot use `new` in `@nogc` function `nogc1
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(76): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/nogc1.d(76): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/nogc1.d(76): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
-fail_compilation/nogc1.d(77): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/nogc1.d(77): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/nogc1.d(77): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
-fail_compilation/nogc1.d(78): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/nogc1.d(78): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/nogc1.d(78): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
 ---
 */

--- a/test/fail_compilation/test16195.d
+++ b/test/fail_compilation/test16195.d
@@ -1,7 +1,7 @@
 /*
  * TEST_OUTPUT:
 ---
-fail_compilation/test16195.d(14): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/test16195.d(14): Error: The `delete` keyword has been removed.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/test16195.d(14): Error: `delete p` is not `@safe` but is used in `@safe` function `test`
 ---
  */


### PR DESCRIPTION
First deprecated in February 2018.  The `delete` keyword - similar to `creal` - is a slow burning deprecation that needs extra care taken before we really do remove it from the language.  Let's see how bad the state of affairs really is at this juncture.