### PR TITLE
End deprecation period for modifying immutable variable from `static this`

### DIFF
--- a/changelog/static_this_immutable_initialization.md
+++ b/changelog/static_this_immutable_initialization.md
@@ -1,0 +1,19 @@
+Initialization of `immutable` global data from `static this` now triggers an error
+
+The following code has been deprecated since 2.087.0.
+
+```
+module foo;
+immutable int bar;
+static this()
+{
+    bar = 42;
+}
+```
+
+This is problematic because module constructors (`static this`) run each time a
+thread is spawned, and `immutable` data is implicitly `shared`, which led to
+`immutable` value being overriden every time a new thread was spawned.
+
+The corrective action for any code that still does this is to use `shared
+static this` over `static this`, as the former is only run once per process.

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -171,6 +171,13 @@ bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
                         MODtoChars(var.type.mod), p, var.toChars(), sc.func.toChars());
                 }
             }
+            else if (fd.isStaticCtorDeclaration() && !fd.isSharedStaticCtorDeclaration() &&
+                     var.type.isImmutable())
+            {
+                .error(loc, "%s %s `%s` initialization is not allowed in `static this`",
+                    MODtoChars(var.type.mod), var.kind(), var.toChars());
+                errorSupplemental(loc, "Use `shared static this` instead.");
+            }
             return result;
         }
         else

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8836,15 +8836,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp = new ConstructExp(exp.loc, exp.e1, exp.e2);
             exp.type = t;
 
-            // @@@DEPRECATED_2020-06@@@
-            // When removing, alter `checkModifiable` to return the correct value.
-            if (sc.func.isStaticCtorDeclaration() && !sc.func.isSharedStaticCtorDeclaration() &&
-                exp.e1.type.isImmutable())
-            {
-                deprecation(exp.loc, "initialization of `immutable` variable from `static this` is deprecated.");
-                deprecationSupplemental(exp.loc, "Use `shared static this` instead.");
-            }
-
             // https://issues.dlang.org/show_bug.cgi?id=13515
             // set Index::modifiable flag for complex AA element initialization
             if (auto ie1 = exp.e1.isIndexExp())

--- a/test/fail_compilation/fail4923.d
+++ b/test/fail_compilation/fail4923.d
@@ -1,8 +1,7 @@
 /*
-REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/fail4923.d(4): Deprecation: initialization of `immutable` variable from `static this` is deprecated.
+fail_compilation/fail4923.d(4): Error: immutable variable `bar` initialization is not allowed in `static this`
 fail_compilation/fail4923.d(4):        Use `shared static this` instead.
 ---
 */


### PR DESCRIPTION
This was deprecated in 2019-05.