### PR TITLE
cirrusci.sh: Run brew update-reset to fetch binaries from GitHub Packages

### DIFF
--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -28,6 +28,7 @@ if [ "$OS_NAME" == "linux" ]; then
   apt-get install -yq $packages
 elif [ "$OS_NAME" == "darwin" ]; then
   # required for dlang install.sh
+  brew update-reset
   brew install gnupg
 elif [ "$OS_NAME" == "freebsd" ]; then
   packages="git gmake"


### PR DESCRIPTION
OS X pipelines are broken again because the default image provided by CirrusCI has homebrew pointing at the now removed bintray site, and we are now have to build all dependencies from source.  Leaving us at the mercy of the upstream vendors (as of writing, sqlite.org is down).

This here is currently running in `--debug`
1. To see if this works.
2. To compare timings with just a plain `brew update`.  Obviously the method that works in the shortest possible time will be chosen.