### PR TITLE
[stable] cirrusci.sh: Run brew update-reset to fetch binaries from GitHub Packages

### DIFF
--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -28,6 +28,7 @@ if [ "$OS_NAME" == "linux" ]; then
   apt-get install -yq $packages
 elif [ "$OS_NAME" == "darwin" ]; then
   # required for dlang install.sh
+  brew update-reset
   brew install gnupg
 elif [ "$OS_NAME" == "freebsd" ]; then
   packages="git gmake"


### PR DESCRIPTION
Speeds up macOS pipelines on Cirrus by > 30 minutes (#12904).