### PR TITLE
replace StructPOD with ThreeState

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -42,11 +42,11 @@ enum class Baseok : uint8_t
     semanticdone  // all base classes semantic done
 };
 
-enum StructPOD
+enum class ThreeState : uint8_t
 {
-    ISPODno,            // struct is not POD
-    ISPODyes,           // struct is POD
-    ISPODfwd            // POD not yet computed
+    none,         // value not yet computed
+    no,           // value is false
+    yes,          // value is true
 };
 
 enum class Abstract : uint8_t
@@ -185,7 +185,7 @@ public:
     static FuncDeclaration *xerrcmp;     // object.xopCmp
 
     structalign_t alignment;    // alignment applied outside of the struct
-    StructPOD ispod;            // if struct is POD
+    ThreeState ispod;           // if struct is POD
 
     // ABI-specific type(s) if the struct can be passed in registers
     TypeTuple *argTypes;

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1318,13 +1318,13 @@ struct ASTBase
     extern (C++) class StructDeclaration : AggregateDeclaration
     {
         int zeroInit;
-        StructPOD ispod;
+        ThreeState ispod;
 
         final extern (D) this(const ref Loc loc, Identifier id, bool inObject)
         {
             super(loc, id);
             zeroInit = 0;
-            ispod = StructPOD.fwd;
+            ispod = ThreeState.none;
             type = new TypeStruct(this);
             if (inObject)
             {

--- a/src/dmd/astenums.d
+++ b/src/dmd/astenums.d
@@ -238,11 +238,11 @@ enum PKG : int
     package_,     /// already determined that's an actual package
 }
 
-enum StructPOD : int
+enum ThreeState : ubyte
 {
-    no,    /// struct is not POD
-    yes,   /// struct is POD
-    fwd,   /// POD not yet computed
+    none,  /// state is not yet computed
+    no,    /// state is false
+    yes,   /// state is true
 }
 
 enum TRUST : ubyte

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -212,7 +212,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     extern (C++) __gshared FuncDeclaration xerrcmp;  // object.xopCmp
 
     structalign_t alignment;    // alignment applied outside of the struct
-    StructPOD ispod;            // if struct is POD
+    ThreeState ispod;           // if struct is POD
 
     // ABI-specific type(s) if the struct can be passed in registers
     TypeTuple argTypes;
@@ -221,7 +221,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     {
         super(loc, id);
         zeroInit = false; // assume false until we do semantic processing
-        ispod = StructPOD.fwd;
+        ispod = ThreeState.none;
         // For forward references
         type = new TypeStruct(this);
 
@@ -378,14 +378,14 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     final bool isPOD()
     {
         // If we've already determined whether this struct is POD.
-        if (ispod != StructPOD.fwd)
-            return (ispod == StructPOD.yes);
+        if (ispod != ThreeState.none)
+            return (ispod == ThreeState.yes);
 
-        ispod = StructPOD.yes;
+        ispod = ThreeState.yes;
 
         if (enclosing || postblit || dtor || hasCopyCtor)
         {
-            ispod = StructPOD.no;
+            ispod = ThreeState.no;
             return false;
         }
 
@@ -395,7 +395,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             VarDeclaration v = fields[i];
             if (v.storage_class & STC.ref_)
             {
-                ispod = StructPOD.no;
+                ispod = ThreeState.no;
                 return false;
             }
 
@@ -406,13 +406,13 @@ extern (C++) class StructDeclaration : AggregateDeclaration
                 StructDeclaration sd = ts.sym;
                 if (!sd.isPOD())
                 {
-                    ispod = StructPOD.no;
+                    ispod = ThreeState.no;
                     return false;
                 }
             }
         }
 
-        return (ispod == StructPOD.yes);
+        return (ispod == ThreeState.yes);
     }
 
     override final inout(StructDeclaration) isStructDeclaration() inout @nogc nothrow pure @safe

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1773,11 +1773,11 @@ struct File final
     }
 };
 
-enum class StructPOD
+enum class ThreeState : uint8_t
 {
-    no = 0,
-    yes = 1,
-    fwd = 2,
+    none = 0u,
+    no = 1u,
+    yes = 2u,
 };
 
 template <typename K, typename V>
@@ -5985,7 +5985,7 @@ public:
     static FuncDeclaration* xerreq;
     static FuncDeclaration* xerrcmp;
     uint32_t alignment;
-    StructPOD ispod;
+    ThreeState ispod;
     TypeTuple* argTypes;
     static StructDeclaration* create(Loc loc, Identifier* id, bool inObject);
     StructDeclaration* syntaxCopy(Dsymbol* s);


### PR DESCRIPTION
This is a three state flag, and it becomes reusable if not labeled so specifically. Also:

1. only needs to occupy a byte
2. use `none` instead of `fwd` to be consistent with other enum declarations
3. default initialization should be `none` instead of `no`