### PR TITLE
End deprecation period for allocators

### DIFF
--- a/changelog/remove_alloc.dd
+++ b/changelog/remove_alloc.dd
@@ -1,0 +1,39 @@
+Class allocators have been removed from the language
+
+Class allocators have been deprecated since v2.080.0.
+
+```
+class C
+{
+    new(size_t size)
+    {
+        return malloc(size);
+    }
+}
+```
+
+Starting with this release all class allocators not annotated with `@disable`
+will result in a compilation error. As the grammar will also be changing, there
+are new deprecation messages for the old-style allocator syntax, which accepted
+a non-empty parameter list and function body.
+
+```
+class C
+{
+    @disable new(size_t size)   // Deprecation: non-empty parameter list
+    {
+        return malloc(size);    // Deprecation: function definition
+    }
+}
+```
+
+Example of corrective action:
+```
+class C
+{
+    @disable new();
+}
+```
+
+See the $(LINK2 https://dlang.org/deprecate.html#Class%20allocators%20and%20deallocators, deprecated features page)
+for more information.

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -103,7 +103,6 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     // Special member functions
     FuncDeclarations invs;  /// Array of invariants
     FuncDeclaration inv;    /// Merged invariant calling all members of invs
-    NewDeclaration aggNew;  /// allocator
 
     /// CtorDeclaration or TemplateDeclaration
     Dsymbol ctor;
@@ -125,6 +124,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     ///
     Visibility visibility;
     bool noDefaultCtor;             /// no default construction
+    bool disableNew;                /// disallow allocations using `new`
     Sizeok sizeok = Sizeok.none;    /// set when structsize contains valid data
 
     final extern (D) this(const ref Loc loc, Identifier id)

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -21,7 +21,6 @@ class Expression;
 class FuncDeclaration;
 class CtorDeclaration;
 class DtorDeclaration;
-class NewDeclaration;
 class InterfaceDeclaration;
 class TypeInfoClassDeclaration;
 class VarDeclaration;
@@ -102,7 +101,6 @@ public:
     // Special member functions
     FuncDeclarations invs;              // Array of invariants
     FuncDeclaration *inv;               // invariant
-    NewDeclaration *aggNew;             // allocator
 
     Dsymbol *ctor;                      // CtorDeclaration or TemplateDeclaration
 
@@ -122,6 +120,7 @@ public:
 
     Visibility visibility;
     bool noDefaultCtor;         // no default construction
+    bool disableNew;            // disallow allocations using `new`
     Sizeok sizeok;              // set when structsize contains valid data
 
     virtual Scope *newScope(Scope *sc);

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -708,12 +708,9 @@ struct ASTBase
 
     extern (C++) final class NewDeclaration : FuncDeclaration
     {
-        ParameterList parameterList;
-
-        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, ref ParameterList parameterList)
+        extern (D) this(const ref Loc loc, StorageClass stc)
         {
-            super(loc, endloc, Id.classNew, STC.static_ | stc, null);
-            this.parameterList = parameterList;
+            super(loc, Loc.initial, Id.classNew, STC.static_ | stc, null);
         }
 
         override void accept(Visitor v)

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -115,10 +115,6 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
         {
             if (ne.member)
             {
-                if (ne.allocator)
-                    // https://issues.dlang.org/show_bug.cgi?id=14407
-                    checkFuncThrows(ne, ne.allocator);
-
                 // See if constructor call can throw
                 checkFuncThrows(ne, ne.member);
             }

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2742,12 +2742,6 @@ public:
         {
             printf("%s NewExp::interpret() %s\n", e.loc.toChars(), e.toChars());
         }
-        if (e.allocator)
-        {
-            e.error("member allocators not supported by CTFE");
-            result = CTFEExp.cantexp;
-            return;
-        }
 
         Expression epre = interpret(pue, e.argprefix, istate, CTFEGoal.Nothing);
         if (exceptionOrCant(epre))

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3511,7 +3511,6 @@ extern (C++) final class NewExp : Expression
 
     Expression argprefix;       // expression to be evaluated just before arguments[]
     CtorDeclaration member;     // constructor function
-    NewDeclaration allocator;   // allocator function
     bool onstack;               // allocate on stack
     bool thrownew;              // this NewExp is the expression of a ThrowStatement
 

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -27,7 +27,6 @@ class VarDeclaration;
 class FuncDeclaration;
 class FuncLiteralDeclaration;
 class CtorDeclaration;
-class NewDeclaration;
 class Dsymbol;
 class ScopeDsymbol;
 class Expression;
@@ -512,7 +511,6 @@ public:
     Expression *argprefix;      // expression to be evaluated just before arguments[]
 
     CtorDeclaration *member;    // constructor function
-    NewDeclaration *allocator;  // allocator function
     bool onstack;               // allocate on stack
     bool thrownew;              // this NewExp is the expression of a ThrowStatement
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3683,28 +3683,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
 
-            if (cd.aggNew)
+            if (cd.disableNew)
             {
-                // Prepend the size argument to newargs[]
-                Expression e = new IntegerExp(exp.loc, cd.size(exp.loc), Type.tsize_t);
-                if (!exp.newargs)
-                    exp.newargs = new Expressions();
-                exp.newargs.shift(e);
-
-                FuncDeclaration f = resolveFuncCall(exp.loc, sc, cd.aggNew, null, tb, exp.newargs, FuncResolveFlag.standard);
-                if (!f || f.errors)
-                    return setError();
-
-                checkFunctionAttributes(exp, sc, f);
-                checkAccess(cd, exp.loc, sc, f);
-
-                TypeFunction tf = cast(TypeFunction)f.type;
-                Type rettype;
-                if (functionParameters(exp.loc, sc, tf, null, null, exp.newargs, f, &rettype, &newprefix))
-                    return setError();
-
-                exp.allocator = f.isNewDeclaration();
-                assert(exp.allocator);
+                exp.error("cannot allocate `class %s` with `new` because it is annotated with `@disable new()`",
+                          originalNewtype.toChars());
+                return setError();
             }
             else
             {
@@ -3773,28 +3756,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             // checkDeprecated() is already done in newtype.typeSemantic().
 
-            if (sd.aggNew)
+            if (sd.disableNew)
             {
-                // Prepend the uint size argument to newargs[]
-                Expression e = new IntegerExp(exp.loc, sd.size(exp.loc), Type.tsize_t);
-                if (!exp.newargs)
-                    exp.newargs = new Expressions();
-                exp.newargs.shift(e);
-
-                FuncDeclaration f = resolveFuncCall(exp.loc, sc, sd.aggNew, null, tb, exp.newargs, FuncResolveFlag.standard);
-                if (!f || f.errors)
-                    return setError();
-
-                checkFunctionAttributes(exp, sc, f);
-                checkAccess(sd, exp.loc, sc, f);
-
-                TypeFunction tf = cast(TypeFunction)f.type;
-                Type rettype;
-                if (functionParameters(exp.loc, sc, tf, null, null, exp.newargs, f, &rettype, &newprefix))
-                    return setError();
-
-                exp.allocator = f.isNewDeclaration();
-                assert(exp.allocator);
+                exp.error("cannot allocate `struct %s` with `new` because it is annotated with `@disable new()`",
+                          originalNewtype.toChars());
+                return setError();
             }
             else
             {

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2901,7 +2901,6 @@ public:
 class NewDeclaration final : public FuncDeclaration
 {
 public:
-    ParameterList parameterList;
     NewDeclaration* syntaxCopy(Dsymbol* s);
     const char* kind() const;
     bool isVirtual() const;
@@ -4929,7 +4928,6 @@ public:
     VarDeclaration* vthis2;
     Array<FuncDeclaration* > invs;
     FuncDeclaration* inv;
-    NewDeclaration* aggNew;
     Dsymbol* ctor;
     CtorDeclaration* defaultCtor;
     AliasThis* aliasthis;
@@ -4941,6 +4939,7 @@ public:
     Expression* getRTInfo;
     Visibility visibility;
     bool noDefaultCtor;
+    bool disableNew;
     Sizeok sizeok;
     virtual Scope* newScope(Scope* sc);
     void setScope(Scope* sc);
@@ -6659,7 +6658,6 @@ public:
     Array<Expression* >* arguments;
     Expression* argprefix;
     CtorDeclaration* member;
-    NewDeclaration* allocator;
     bool onstack;
     bool thrownew;
     static NewExp* create(Loc loc, Expression* thisexp, Array<Expression* >* newargs, Type* newtype, Array<Expression* >* arguments);

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -4015,19 +4015,15 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
  */
 extern (C++) final class NewDeclaration : FuncDeclaration
 {
-    ParameterList parameterList;
-
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, ref ParameterList parameterList)
+    extern (D) this(const ref Loc loc, StorageClass stc)
     {
-        super(loc, endloc, Id.classNew, STC.static_ | stc, null);
-        this.parameterList = parameterList;
+        super(loc, Loc.initial, Id.classNew, STC.static_ | stc, null);
     }
 
     override NewDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        auto parameterList = parameterList.syntaxCopy();
-        auto f = new NewDeclaration(loc, endloc, storage_class, parameterList);
+        auto f = new NewDeclaration(loc, storage_class);
         FuncDeclaration.syntaxCopy(f);
         return f;
     }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1765,9 +1765,7 @@ public:
     {
         if (stcToBuffer(buf, d.storage_class & ~STC.static_))
             buf.writeByte(' ');
-        buf.writestring("new");
-        parametersToBuffer(d.parameterList, buf, hgs);
-        bodyToBuffer(d);
+        buf.writestring("new();");
     }
 
     override void visit(Module m)

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -122,8 +122,6 @@ public:
         }
         if (e.onstack)
             return;
-        if (e.allocator)
-            return;
         if (global.params.ehnogc && e.thrownew)
             return;                     // separate allocator is called for this, not the GC
         if (f.setGC())

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -879,8 +879,6 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.NewDeclaration d)
     {
         //printf("Visiting NewDeclaration\n");
-        visitParameters(d.parameterList.parameters);
-        visitFuncBody(d);
     }
 
 //   Initializers

--- a/test/fail_compilation/diag_class_alloc.d
+++ b/test/fail_compilation/diag_class_alloc.d
@@ -1,7 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag_class_alloc.d(13): Error: class allocators are obsolete, consider moving the allocation strategy outside of the class
+fail_compilation/diag_class_alloc.d(15): Error: `new` allocator must be annotated with `@disabled`
+fail_compilation/diag_class_alloc.d(16): Deprecation: `new` allocator with non-empty parameter list is deprecated
+fail_compilation/diag_class_alloc.d(16): Deprecation: `new` allocator with function definition is deprecated
 ---
 */
 

--- a/test/fail_compilation/disable_new.d
+++ b/test/fail_compilation/disable_new.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/disable_new.d(23): Error: allocator `disable_new.C.new` cannot be used because it is annotated with `@disable`
-fail_compilation/disable_new.d(24): Error: allocator `disable_new.S.new` cannot be used because it is annotated with `@disable`
+fail_compilation/disable_new.d(23): Error: cannot allocate `class C` with `new` because it is annotated with `@disable new()`
+fail_compilation/disable_new.d(24): Error: cannot allocate `struct S` with `new` because it is annotated with `@disable new()`
 ---
 */
 


### PR DESCRIPTION
This was made into a semantic error in 2019-05.  The error has now been moved to the grammar and dependent AST fields pruned.

However:
1. There are new deprecations for when the only remaining allowed use of allocators is not explicitly `@disable new();`
2. Because of the deprecations, the grammar now discards any parsed parameters, contracts, and bodies.  The semantic analysis explicitly doesn't check for it.
3. `NewDeclaration aggNew` has been replaced with `bool disableNew`, because the grammar rejects any allocator that isn't `@disable`.
