### PR TITLE
fix Issue 22138 - foreach cannot declare the loop variables as scope

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -5411,6 +5411,10 @@ class Parser(AST) : Lexer
                     stc = STC.ref_;
                     goto Lagain;
 
+                case TOK.scope_:
+                    stc = STC.scope_;
+                    goto Lagain;
+
                 case TOK.enum_:
                     stc = STC.manifest;
                     goto Lagain;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1437,7 +1437,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     Parameter p = (*fs.parameters)[dim - 1];
                     auto var = new VarDeclaration(loc, p.type, p.ident, null);
                     var.storage_class |= STC.foreach_;
-                    var.storage_class |= p.storageClass & (STC.IOR | STC.TYPECTOR);
+                    var.storage_class |= p.storageClass & (STC.scope_ | STC.IOR | STC.TYPECTOR);
                     if (var.isReference())
                         var.storage_class |= STC.nodtor;
 
@@ -1699,7 +1699,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     auto p = (*fs.parameters)[0];
                     auto ve = new VarDeclaration(loc, p.type, p.ident, new ExpInitializer(loc, einit));
                     ve.storage_class |= STC.foreach_;
-                    ve.storage_class |= p.storageClass & (STC.IOR | STC.TYPECTOR);
+                    ve.storage_class |= p.storageClass & (STC.scope_ | STC.IOR | STC.TYPECTOR);
 
                     if (ignoreRef)
                         ve.storage_class &= ~STC.ref_;

--- a/test/fail_compilation/fail22138.d
+++ b/test/fail_compilation/fail22138.d
@@ -1,0 +1,21 @@
+/* REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/fail22138.d(107): Error: scope variable `e` may not be returned
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=22138
+
+#line 100
+
+@safe
+int* test()
+{
+    int*[] a;
+    foreach (scope e; a)
+    {
+        return e;
+    }
+    return null;
+}


### PR DESCRIPTION
This came up in the quarterly meeting, but I couldn't find a bugzilla for it, so I created one.