### PR TITLE
add checkUnsafeDotExp()

### DIFF
--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -210,7 +210,7 @@ bool isSafeCast(Expression e, Type tfrom, Type tto)
  * Returns:
  *      true if error
  */
-bool checkUnsafeDotExp(Scope* sc, Expression e, Identifier id, DotExpFlag flag)
+bool checkUnsafeDotExp(Scope* sc, Expression e, Identifier id, int flag)
 {
     if (!(flag & DotExpFlag.noDeref) && // this use is attempting a dereference
         sc.func &&                      // inside a function

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -198,3 +198,29 @@ bool isSafeCast(Expression e, Type tfrom, Type tto)
     return false;
 }
 
+/*************************************************
+ * Check for unsafe use of `.ptr` or `.funcptr`
+ * Params:
+ *      sc = context
+ *      e = expression for error messages
+ *      id = `ptr` or `funcptr`
+ *      flag = DotExpFlag
+ * Returns:
+ *      true if error
+ */
+bool checkUnsafeDotExp(Scope* sc, Expression e, Identifier id, DotExpFlag flag)
+{
+    if (!(flag & DotExpFlag.noDeref) && // this use is attempting a dereference
+        sc.func &&                      // inside a function
+        !sc.intypeof &&                 // allow unsafe code in typeof expressions
+        !(sc.flags & SCOPE.debug_) &&   // allow unsafe code in debug statements
+        sc.func.setUnsafe())            // infer this function to be unsafe
+    {
+        if (id == Id.ptr)
+            e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
+        else
+            e.error("`%s.%s` cannot be used in `@safe` code", e.toChars(), id.toChars());
+        return true;
+    }
+    return false;
+}

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -21,6 +21,8 @@ import dmd.dclass;
 import dmd.declaration;
 import dmd.dscope;
 import dmd.expression;
+import dmd.id;
+import dmd.identifier;
 import dmd.mtype;
 import dmd.target;
 import dmd.tokens;

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -57,6 +57,7 @@ import dmd.root.outbuffer;
 import dmd.root.rootobject;
 import dmd.root.string;
 import dmd.root.stringtable;
+import dmd.safe;
 import dmd.semantic3;
 import dmd.sideeffect;
 import dmd.target;
@@ -3580,7 +3581,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 e.error("`%s` is not an expression", e.toChars());
                 return ErrorExp.get();
             }
-            else if (checkUnsafeDotExp(sc, e, id, flag))
+            else if (checkUnsafeDotExp(sc, e, ident, flag))
             {
                 return ErrorExp.get();
             }
@@ -3627,7 +3628,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         }
         else if (ident == Id.ptr)
         {
-            if (checkUnsafeDotExp(sc, e, id, flag))
+            if (checkUnsafeDotExp(sc, e, ident, flag))
                 return ErrorExp.get();
             return e.castTo(sc, mt.next.pointerTo());
         }
@@ -3690,7 +3691,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         }
         else if (ident == Id.funcptr)
         {
-            if (checkUnsafePtr(sc, e, id, flag))
+            if (checkUnsafeDotExp(sc, e, ident, flag))
             {
                 return ErrorExp.get();
             }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3580,9 +3580,8 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 e.error("`%s` is not an expression", e.toChars());
                 return ErrorExp.get();
             }
-            else if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
+            else if (checkUnsafeDotExp(sc, e, id, flag))
             {
-                e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
                 return ErrorExp.get();
             }
             e = e.castTo(sc, e.type.nextOf().pointerTo());
@@ -3628,11 +3627,8 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         }
         else if (ident == Id.ptr)
         {
-            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
-            {
-                e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
+            if (checkUnsafeDotExp(sc, e, id, flag))
                 return ErrorExp.get();
-            }
             return e.castTo(sc, mt.next.pointerTo());
         }
         else
@@ -3694,9 +3690,8 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         }
         else if (ident == Id.funcptr)
         {
-            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
+            if (checkUnsafePtr(sc, e, id, flag))
             {
-                e.error("`%s.funcptr` cannot be used in `@safe` code", e.toChars());
                 return ErrorExp.get();
             }
             e = new DelegateFuncptrExp(e.loc, e);


### PR DESCRIPTION
Move complex copy/pasta logic to a single function for consistency, document it, and put it in `safe.d` where `@safe` semantics should go.