### PR TITLE
[DSSv3] Fix Issue 17400: new line before candidates in error messages

### DIFF
--- a/test/fail_compilation/b19717a.d
+++ b/test/fail_compilation/b19717a.d
@@ -3,9 +3,9 @@
 ---
 fail_compilation/b19717a.d(14): Error: forward reference to template `a`
 fail_compilation/b19717a.d(14): Error: forward reference to template `a`
-fail_compilation/b19717a.d(14): Error: none of the overloads of `a` are callable using argument types `()`, candidates are:
-fail_compilation/b19717a.d(13):        `b19717a.a(int b)`
-fail_compilation/b19717a.d(14):        `b19717a.a(int b = a)`
+fail_compilation/b19717a.d(14): Error: none of the overloads of `a` are callable using argument types `()`
+fail_compilation/b19717a.d(13):        Candidates are: `b19717a.a(int b)`
+fail_compilation/b19717a.d(14):                        `b19717a.a(int b = a)`
 ---
 */
 module b19717a;

--- a/test/fail_compilation/bug9631.d
+++ b/test/fail_compilation/bug9631.d
@@ -91,10 +91,10 @@ TEST_OUTPUT:
 ---
 fail_compilation/bug9631.d(106): Error: function `bug9631.targ.ft!().ft(S _param_0)` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(106):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S _param_0`
-fail_compilation/bug9631.d(107): Error: template `bug9631.targ.ft` cannot deduce function from argument types `!()(S)`, candidates are:
-fail_compilation/bug9631.d(105):        `ft()(tem!().S)`
-fail_compilation/bug9631.d(109): Error: template `bug9631.targ.ft2` cannot deduce function from argument types `!()(S, int)`, candidates are:
-fail_compilation/bug9631.d(108):        `ft2(T)(S, T)`
+fail_compilation/bug9631.d(107): Error: template `bug9631.targ.ft` cannot deduce function from argument types `!()(S)`
+fail_compilation/bug9631.d(105):        Candidate is: `ft()(tem!().S)`
+fail_compilation/bug9631.d(109): Error: template `bug9631.targ.ft2` cannot deduce function from argument types `!()(S, int)`
+fail_compilation/bug9631.d(108):        Candidate is: `ft2(T)(S, T)`
 ---
 */
 void targ()

--- a/test/fail_compilation/constraints_aggr.d
+++ b/test/fail_compilation/constraints_aggr.d
@@ -2,13 +2,13 @@
 EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_aggr.d(32): Error: template `imports.constraints.C.f` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(60):        `f(T)(T v)`
+fail_compilation/constraints_aggr.d(32): Error: template `imports.constraints.C.f` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(60):        Candidate is: `f(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_aggr.d(33): Error: template `imports.constraints.C.g` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/imports/constraints.d(63):        `g(this T)()`
+fail_compilation/constraints_aggr.d(33): Error: template `imports.constraints.C.g` cannot deduce function from argument types `!()()`
+fail_compilation/imports/constraints.d(63):        Candidate is: `g(this T)()`
   with `T = imports.constraints.C`
   must satisfy the following constraint:
 `       N!T`

--- a/test/fail_compilation/constraints_func1.d
+++ b/test/fail_compilation/constraints_func1.d
@@ -2,73 +2,73 @@
 EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func1.d(79): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(9):        `test1(T)(T v)`
+fail_compilation/constraints_func1.d(79): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(9):        Candidate is: `test1(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(80): Error: template `imports.constraints.test2` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(10):        `test2(T)(T v)`
+fail_compilation/constraints_func1.d(80): Error: template `imports.constraints.test2` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(10):        Candidate is: `test2(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(81): Error: template `imports.constraints.test3` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(11):        `test3(T)(T v)`
+fail_compilation/constraints_func1.d(81): Error: template `imports.constraints.test3` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(11):        Candidate is: `test3(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(82): Error: template `imports.constraints.test4` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(12):        `test4(T)(T v)`
+fail_compilation/constraints_func1.d(82): Error: template `imports.constraints.test4` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(12):        Candidate is: `test4(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(83): Error: template `imports.constraints.test5` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(13):        `test5(T)(T v)`
+fail_compilation/constraints_func1.d(83): Error: template `imports.constraints.test5` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(13):        Candidate is: `test5(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func1.d(84): Error: template `imports.constraints.test6` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(14):        `test6(T)(T v)`
+fail_compilation/constraints_func1.d(84): Error: template `imports.constraints.test6` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(14):        Candidate is: `test6(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T
        !P!T`
-fail_compilation/constraints_func1.d(85): Error: template `imports.constraints.test7` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(15):        `test7(T)(T v)`
+fail_compilation/constraints_func1.d(85): Error: template `imports.constraints.test7` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(15):        Candidate is: `test7(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func1.d(86): Error: template `imports.constraints.test8` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(16):        `test8(T)(T v)`
+fail_compilation/constraints_func1.d(86): Error: template `imports.constraints.test8` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(16):        Candidate is: `test8(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(87): Error: template `imports.constraints.test9` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(17):        `test9(T)(T v)`
+fail_compilation/constraints_func1.d(87): Error: template `imports.constraints.test9` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(17):        Candidate is: `test9(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(88): Error: template `imports.constraints.test10` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(18):        `test10(T)(T v)`
+fail_compilation/constraints_func1.d(88): Error: template `imports.constraints.test10` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(18):        Candidate is: `test10(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(89): Error: template `imports.constraints.test11` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(19):        `test11(T)(T v)`
+fail_compilation/constraints_func1.d(89): Error: template `imports.constraints.test11` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(19):        Candidate is: `test11(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T`
-fail_compilation/constraints_func1.d(90): Error: template `imports.constraints.test12` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(20):        `test12(T)(T v)`
+fail_compilation/constraints_func1.d(90): Error: template `imports.constraints.test12` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(20):        Candidate is: `test12(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(92): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int, int)`, candidates are:
-fail_compilation/imports/constraints.d(9):        `test1(T)(T v)`
+fail_compilation/constraints_func1.d(92): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int, int)`
+fail_compilation/imports/constraints.d(9):        Candidate is: `test1(T)(T v)`
 ---
 */
 

--- a/test/fail_compilation/constraints_func2.d
+++ b/test/fail_compilation/constraints_func2.d
@@ -2,84 +2,84 @@
 EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func2.d(94): Error: template `imports.constraints.test13` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(23):        `test13(T)(T v)`
+fail_compilation/constraints_func2.d(94): Error: template `imports.constraints.test13` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(23):        Candidate is: `test13(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T`
-fail_compilation/constraints_func2.d(95): Error: template `imports.constraints.test14` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(24):        `test14(T)(T v)`
+fail_compilation/constraints_func2.d(95): Error: template `imports.constraints.test14` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(24):        Candidate is: `test14(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        N!T`
-fail_compilation/constraints_func2.d(96): Error: template `imports.constraints.test15` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(25):        `test15(T)(T v)`
+fail_compilation/constraints_func2.d(96): Error: template `imports.constraints.test15` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(25):        Candidate is: `test15(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        !P!T`
-fail_compilation/constraints_func2.d(97): Error: template `imports.constraints.test16` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(26):        `test16(T)(T v)`
+fail_compilation/constraints_func2.d(97): Error: template `imports.constraints.test16` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(26):        Candidate is: `test16(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(98): Error: template `imports.constraints.test17` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(27):        `test17(T)(T v)`
+fail_compilation/constraints_func2.d(98): Error: template `imports.constraints.test17` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(27):        Candidate is: `test17(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(99): Error: template `imports.constraints.test18` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(28):        `test18(T)(T v)`
+fail_compilation/constraints_func2.d(99): Error: template `imports.constraints.test18` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(28):        Candidate is: `test18(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(100): Error: template `imports.constraints.test19` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(29):        `test19(T)(T v)`
+fail_compilation/constraints_func2.d(100): Error: template `imports.constraints.test19` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(29):        Candidate is: `test19(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T
        N!T`
-fail_compilation/constraints_func2.d(101): Error: template `imports.constraints.test20` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(30):        `test20(T)(T v)`
+fail_compilation/constraints_func2.d(101): Error: template `imports.constraints.test20` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(30):        Candidate is: `test20(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(102): Error: template `imports.constraints.test21` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(31):        `test21(T)(T v)`
+fail_compilation/constraints_func2.d(102): Error: template `imports.constraints.test21` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(31):        Candidate is: `test21(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(103): Error: template `imports.constraints.test22` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(32):        `test22(T)(T v)`
+fail_compilation/constraints_func2.d(103): Error: template `imports.constraints.test22` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(32):        Candidate is: `test22(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        !P!T`
-fail_compilation/constraints_func2.d(104): Error: template `imports.constraints.test23` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(33):        `test23(T)(T v)`
+fail_compilation/constraints_func2.d(104): Error: template `imports.constraints.test23` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(33):        Candidate is: `test23(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        N!T
        !P!T`
-fail_compilation/constraints_func2.d(105): Error: template `imports.constraints.test24` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(34):        `test24(R)(R r)`
+fail_compilation/constraints_func2.d(105): Error: template `imports.constraints.test24` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(34):        Candidate is: `test24(R)(R r)`
   with `R = int`
   must satisfy the following constraint:
 `       __traits(hasMember, R, "stuff")`
-fail_compilation/constraints_func2.d(106): Error: template `imports.constraints.test25` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/imports/constraints.d(35):        `test25(T)(T v)`
+fail_compilation/constraints_func2.d(106): Error: template `imports.constraints.test25` cannot deduce function from argument types `!()(int)`
+fail_compilation/imports/constraints.d(35):        Candidate is: `test25(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(107): Error: template `imports.constraints.test26` cannot deduce function from argument types `!(float)(int)`, candidates are:
-fail_compilation/imports/constraints.d(36):        `test26(T, U)(U u)`
+fail_compilation/constraints_func2.d(107): Error: template `imports.constraints.test26` cannot deduce function from argument types `!(float)(int)`
+fail_compilation/imports/constraints.d(36):        Candidate is: `test26(T, U)(U u)`
   with `T = float,
        U = int`
   must satisfy the following constraint:

--- a/test/fail_compilation/constraints_func4.d
+++ b/test/fail_compilation/constraints_func4.d
@@ -1,48 +1,85 @@
 /*
 EXTRA_FILES: imports/constraints.d
+REQUIRED_ARGS: -verrors=context
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func3.d(53): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func4.d(90): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int)`
+    overload(0);
+            ^
 fail_compilation/imports/constraints.d(39):        Candidates are: `overload(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
+void overload(T)(T v) if (N!T);
+     ^
 fail_compilation/imports/constraints.d(40):                        `overload(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
+void overload(T)(T v) if (!P!T);
+     ^
 fail_compilation/imports/constraints.d(41):                        `overload(T)(T v1, T v2)`
+void overload(T)(T v1, T v2) if (N!T);
+     ^
 fail_compilation/imports/constraints.d(42):                        `overload(T, V)(T v1, V v2)`
-fail_compilation/constraints_func3.d(54): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int, string)`
+void overload(T, V)(T v1, V v2) if (N!T || N!V);
+     ^
+fail_compilation/constraints_func4.d(91): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int, string)`
+    overload(0, "");
+            ^
 fail_compilation/imports/constraints.d(39):        Candidates are: `overload(T)(T v)`
+void overload(T)(T v) if (N!T);
+     ^
 fail_compilation/imports/constraints.d(40):                        `overload(T)(T v)`
+void overload(T)(T v) if (!P!T);
+     ^
 fail_compilation/imports/constraints.d(41):                        `overload(T)(T v1, T v2)`
+void overload(T)(T v1, T v2) if (N!T);
+     ^
 fail_compilation/imports/constraints.d(42):                        `overload(T, V)(T v1, V v2)`
   with `T = int,
        V = string`
   must satisfy one of the following constraints:
 `       N!T
        N!V`
-fail_compilation/constraints_func3.d(56): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()()`
+void overload(T, V)(T v1, V v2) if (N!T || N!V);
+     ^
+fail_compilation/constraints_func4.d(93): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()()`
+    variadic();
+            ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
-fail_compilation/constraints_func3.d(57): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int)`
+void variadic(A, T...)(A a, T v) if (N!int);
+     ^
+fail_compilation/constraints_func4.d(94): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int)`
+    variadic(0);
+            ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = ()`
   must satisfy the following constraint:
 `       N!int`
-fail_compilation/constraints_func3.d(58): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int)`
+void variadic(A, T...)(A a, T v) if (N!int);
+     ^
+fail_compilation/constraints_func4.d(95): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int)`
+    variadic(0, 1);
+            ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = (int)`
   must satisfy the following constraint:
 `       N!int`
-fail_compilation/constraints_func3.d(59): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int, int)`
+void variadic(A, T...)(A a, T v) if (N!int);
+     ^
+fail_compilation/constraints_func4.d(96): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int, int)`
+    variadic(0, 1, 2);
+            ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = (int, int)`
   must satisfy the following constraint:
 `       N!int`
+void variadic(A, T...)(A a, T v) if (N!int);
+     ^
 ---
 */
 

--- a/test/fail_compilation/diag10415.d
+++ b/test/fail_compilation/diag10415.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10415.d(36): Error: none of the overloads of `x` are callable using argument types `(int) const`, candidates are:
-fail_compilation/diag10415.d(13):        `diag10415.C.x()`
-fail_compilation/diag10415.d(18):        `diag10415.C.x(int _param_0)`
+fail_compilation/diag10415.d(36): Error: none of the overloads of `x` are callable using argument types `(int) const`
+fail_compilation/diag10415.d(13):        Candidates are: `diag10415.C.x()`
+fail_compilation/diag10415.d(18):                        `diag10415.C.x(int _param_0)`
 fail_compilation/diag10415.d(39): Error: d.x is not an lvalue
 ---
 */

--- a/test/fail_compilation/diag11078.d
+++ b/test/fail_compilation/diag11078.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag11078.d(19): Error: none of the overloads of `value` are callable using argument types `(double)`, candidates are:
-fail_compilation/diag11078.d(12):        `diag11078.S1.value()`
-fail_compilation/diag11078.d(13):        `diag11078.S1.value(int n)`
+fail_compilation/diag11078.d(19): Error: none of the overloads of `value` are callable using argument types `(double)`
+fail_compilation/diag11078.d(12):        Candidates are: `diag11078.S1.value()`
+fail_compilation/diag11078.d(13):                        `diag11078.S1.value(int n)`
 ---
 */
 

--- a/test/fail_compilation/diag13942.d
+++ b/test/fail_compilation/diag13942.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag13942.d(18): Error: template instance `isRawStaticArray!()` does not match template declaration `isRawStaticArray(T, A...)`
-fail_compilation/diag13942.d(26): Error: template `diag13942.to!double.to` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/diag13942.d(17):        `to(A...)(A args)`
+fail_compilation/diag13942.d(26): Error: template `diag13942.to!double.to` cannot deduce function from argument types `!()()`
+fail_compilation/diag13942.d(17):        Candidate is: `to(A...)(A args)`
 ---
 */
 

--- a/test/fail_compilation/diag14818.d
+++ b/test/fail_compilation/diag14818.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag14818.d(34): Error: none of the overloads of `func` are callable using argument types `(string)`, candidates are:
-fail_compilation/diag14818.d(12):        `diag14818.foo(int _param_0)`
-fail_compilation/diag14818.d(13):        `diag14818.bar(double _param_0)`
+fail_compilation/diag14818.d(34): Error: none of the overloads of `func` are callable using argument types `(string)`
+fail_compilation/diag14818.d(12):        Candidate is: `diag14818.foo(int _param_0)`
+fail_compilation/diag14818.d(13):                        `diag14818.bar(double _param_0)`
 fail_compilation/diag14818.d(35): Error: overload alias `diag14818.X` does not match any template declaration
 fail_compilation/diag14818.d(36): Error: overloadset `diag14818.M` does not match any template declaration
 ---

--- a/test/fail_compilation/diag16977.d
+++ b/test/fail_compilation/diag16977.d
@@ -3,8 +3,8 @@ TEST_OUTPUT:
 ---
 fail_compilation/diag16977.d(25): Error: undefined identifier `undefined`, did you mean function `undefinedId`?
 fail_compilation/diag16977.d(26): Error: cannot implicitly convert expression `"\x01string"` of type `string` to `int`
-fail_compilation/diag16977.d(27): Error: template `diag16977.templ` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/diag16977.d(20):        `templ(S)(S s)`
+fail_compilation/diag16977.d(27): Error: template `diag16977.templ` cannot deduce function from argument types `!()(int)`
+fail_compilation/diag16977.d(20):        Candidate is: `templ(S)(S s)`
   with `S = int`
   must satisfy the following constraint:
 `       false`

--- a/test/fail_compilation/diag8101.d
+++ b/test/fail_compilation/diag8101.d
@@ -3,27 +3,27 @@ TEST_OUTPUT:
 ---
 fail_compilation/diag8101.d(57): Error: function `diag8101.f_0(int)` is not callable using argument types `()`
 fail_compilation/diag8101.d(57):        missing argument for parameter #1: `int`
-fail_compilation/diag8101.d(58): Error: none of the overloads of `f_1` are callable using argument types `()`, candidates are:
-fail_compilation/diag8101.d(33):        `diag8101.f_1(int)`
-fail_compilation/diag8101.d(34):        `diag8101.f_1(int, int)`
-fail_compilation/diag8101.d(59): Error: none of the overloads of `f_2` are callable using argument types `()`, candidates are:
-fail_compilation/diag8101.d(36):        `diag8101.f_2(int)`
-fail_compilation/diag8101.d(37):        `diag8101.f_2(int, int)`
-fail_compilation/diag8101.d(38):        `diag8101.f_2(int, int, int)`
-fail_compilation/diag8101.d(39):        `diag8101.f_2(int, int, int, int)`
-fail_compilation/diag8101.d(40):        `diag8101.f_2(int, int, int, int, int)`
+fail_compilation/diag8101.d(58): Error: none of the overloads of `f_1` are callable using argument types `()`
+fail_compilation/diag8101.d(33):        Candidates are: `diag8101.f_1(int)`
+fail_compilation/diag8101.d(34):                        `diag8101.f_1(int, int)`
+fail_compilation/diag8101.d(59): Error: none of the overloads of `f_2` are callable using argument types `()`
+fail_compilation/diag8101.d(36):        Candidates are: `diag8101.f_2(int)`
+fail_compilation/diag8101.d(37):                        `diag8101.f_2(int, int)`
+fail_compilation/diag8101.d(38):                        `diag8101.f_2(int, int, int)`
+fail_compilation/diag8101.d(39):                        `diag8101.f_2(int, int, int, int)`
+fail_compilation/diag8101.d(40):                        `diag8101.f_2(int, int, int, int, int)`
 fail_compilation/diag8101.d(59):        ... (1 more, -v to show) ...
-fail_compilation/diag8101.d(61): Error: template `diag8101.t_0` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/diag8101.d(43):        `t_0(T1)()`
-fail_compilation/diag8101.d(62): Error: template `diag8101.t_1` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/diag8101.d(45):        `t_1(T1)()`
-fail_compilation/diag8101.d(46):        `t_1(T1, T2)()`
-fail_compilation/diag8101.d(63): Error: template `diag8101.t_2` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/diag8101.d(48):        `t_2(T1)()`
-fail_compilation/diag8101.d(49):        `t_2(T1, T2)()`
-fail_compilation/diag8101.d(50):        `t_2(T1, T2, T3)()`
-fail_compilation/diag8101.d(51):        `t_2(T1, T2, T3, T4)()`
-fail_compilation/diag8101.d(52):        `t_2(T1, T2, T3, T4, T5)()`
+fail_compilation/diag8101.d(61): Error: template `diag8101.t_0` cannot deduce function from argument types `!()()`
+fail_compilation/diag8101.d(43):        Candidate is: `t_0(T1)()`
+fail_compilation/diag8101.d(62): Error: template `diag8101.t_1` cannot deduce function from argument types `!()()`
+fail_compilation/diag8101.d(45):        Candidates are: `t_1(T1)()`
+fail_compilation/diag8101.d(46):                        `t_1(T1, T2)()`
+fail_compilation/diag8101.d(63): Error: template `diag8101.t_2` cannot deduce function from argument types `!()()`
+fail_compilation/diag8101.d(48):        Candidates are: `t_2(T1)()`
+fail_compilation/diag8101.d(49):                        `t_2(T1, T2)()`
+fail_compilation/diag8101.d(50):                        `t_2(T1, T2, T3)()`
+fail_compilation/diag8101.d(51):                        `t_2(T1, T2, T3, T4)()`
+fail_compilation/diag8101.d(52):                        `t_2(T1, T2, T3, T4, T5)()`
 fail_compilation/diag8101.d(63):        ... (1 more, -v to show) ...
 ---
 */

--- a/test/fail_compilation/diag8101b.d
+++ b/test/fail_compilation/diag8101b.d
@@ -1,14 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8101b.d(28): Error: none of the overloads of `foo` are callable using argument types `(double)`, candidates are:
-fail_compilation/diag8101b.d(19):        `diag8101b.S.foo(int _param_0)`
-fail_compilation/diag8101b.d(20):        `diag8101b.S.foo(int _param_0, int _param_1)`
+fail_compilation/diag8101b.d(28): Error: none of the overloads of `foo` are callable using argument types `(double)`
+fail_compilation/diag8101b.d(19):        Candidates are: `diag8101b.S.foo(int _param_0)`
+fail_compilation/diag8101b.d(20):                        `diag8101b.S.foo(int _param_0, int _param_1)`
 fail_compilation/diag8101b.d(30): Error: function `diag8101b.S.bar(int _param_0)` is not callable using argument types `(double)`
 fail_compilation/diag8101b.d(30):        cannot pass argument `1.0` of type `double` to parameter `int _param_0`
-fail_compilation/diag8101b.d(33): Error: none of the overloads of `foo` are callable using a `const` object, candidates are:
-fail_compilation/diag8101b.d(19):        `diag8101b.S.foo(int _param_0)`
-fail_compilation/diag8101b.d(20):        `diag8101b.S.foo(int _param_0, int _param_1)`
+fail_compilation/diag8101b.d(33): Error: none of the overloads of `foo` are callable using a `const` object
+fail_compilation/diag8101b.d(19):        Candidates are: `diag8101b.S.foo(int _param_0)`
+fail_compilation/diag8101b.d(20):                        `diag8101b.S.foo(int _param_0, int _param_1)`
 fail_compilation/diag8101b.d(35): Error: mutable method `diag8101b.S.bar` is not callable using a `const` object
 fail_compilation/diag8101b.d(22):        Consider adding `const` or `inout` here
 ---

--- a/test/fail_compilation/diag8648.d
+++ b/test/fail_compilation/diag8648.d
@@ -2,14 +2,14 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag8648.d(18): Error: undefined identifier `X`
-fail_compilation/diag8648.d(29): Error: template `diag8648.foo` cannot deduce function from argument types `!()(Foo!(int, 1))`, candidates are:
-fail_compilation/diag8648.d(18):        `foo(T, n)(X!(T, n))`
+fail_compilation/diag8648.d(29): Error: template `diag8648.foo` cannot deduce function from argument types `!()(Foo!(int, 1))`
+fail_compilation/diag8648.d(18):        Candidate is: `foo(T, n)(X!(T, n))`
 fail_compilation/diag8648.d(20): Error: undefined identifier `a`
-fail_compilation/diag8648.d(31): Error: template `diag8648.bar` cannot deduce function from argument types `!()(Foo!(int, 1))`, candidates are:
-fail_compilation/diag8648.d(20):        `bar(T)(Foo!(T, a))`
+fail_compilation/diag8648.d(31): Error: template `diag8648.bar` cannot deduce function from argument types `!()(Foo!(int, 1))`
+fail_compilation/diag8648.d(20):        Candidate is: `bar(T)(Foo!(T, a))`
 fail_compilation/diag8648.d(20): Error: undefined identifier `a`
-fail_compilation/diag8648.d(32): Error: template `diag8648.bar` cannot deduce function from argument types `!()(Foo!(int, f))`, candidates are:
-fail_compilation/diag8648.d(20):        `bar(T)(Foo!(T, a))`
+fail_compilation/diag8648.d(32): Error: template `diag8648.bar` cannot deduce function from argument types `!()(Foo!(int, f))`
+fail_compilation/diag8648.d(20):        Candidate is: `bar(T)(Foo!(T, a))`
 ---
 */
 

--- a/test/fail_compilation/diag9004.d
+++ b/test/fail_compilation/diag9004.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9004.d(21): Error: template `diag9004.bar` cannot deduce function from argument types `!()(Foo!int, int)`, candidates are:
-fail_compilation/diag9004.d(14):        `bar(FooT)(FooT foo, FooT.T x)`
+fail_compilation/diag9004.d(21): Error: template `diag9004.bar` cannot deduce function from argument types `!()(Foo!int, int)`
+fail_compilation/diag9004.d(14):        Candidate is: `bar(FooT)(FooT foo, FooT.T x)`
 ---
 */
 

--- a/test/fail_compilation/diagin.d
+++ b/test/fail_compilation/diagin.d
@@ -4,8 +4,8 @@ TEST_OUTPUT:
 ---
 fail_compilation/diagin.d(14): Error: function `diagin.foo(in int)` is not callable using argument types `()`
 fail_compilation/diagin.d(14):        missing argument for parameter #1: `in int`
-fail_compilation/diagin.d(16): Error: template `diagin.foo1` cannot deduce function from argument types `!()(bool[])`, candidates are:
-fail_compilation/diagin.d(20):        `foo1(T)(in T v, string)`
+fail_compilation/diagin.d(16): Error: template `diagin.foo1` cannot deduce function from argument types `!()(bool[])`
+fail_compilation/diagin.d(20):        Candidate is: `foo1(T)(in T v, string)`
 ---
  */
 

--- a/test/fail_compilation/fail12744.d
+++ b/test/fail_compilation/fail12744.d
@@ -14,11 +14,11 @@ fail_compilation/fail12744.d(61): Error: template instance `fail12744.bar12744L!
 fail_compilation/fail12744.d(40): Error: incompatible parameter storage classes `lazy` and `out`
 fail_compilation/fail12744.d(62): Error: template instance `fail12744.bar12744L!(foo12744O)` error instantiating
 fail_compilation/fail12744.d(41): Error: incompatible parameter storage classes `auto ref` and `out`
-fail_compilation/fail12744.d(67): Error: template `fail12744.bar12744A` cannot deduce function from argument types `!(foo12744O)(int)`, candidates are:
-fail_compilation/fail12744.d(41):        `bar12744A(alias f)(auto ref PTT12744!f args)`
+fail_compilation/fail12744.d(67): Error: template `fail12744.bar12744A` cannot deduce function from argument types `!(foo12744O)(int)`
+fail_compilation/fail12744.d(41):        Candidate is: `bar12744A(alias f)(auto ref PTT12744!f args)`
 fail_compilation/fail12744.d(41): Error: incompatible parameter storage classes `auto ref` and `lazy`
-fail_compilation/fail12744.d(68): Error: template `fail12744.bar12744A` cannot deduce function from argument types `!(foo12744L)(int)`, candidates are:
-fail_compilation/fail12744.d(41):        `bar12744A(alias f)(auto ref PTT12744!f args)`
+fail_compilation/fail12744.d(68): Error: template `fail12744.bar12744A` cannot deduce function from argument types `!(foo12744L)(int)`
+fail_compilation/fail12744.d(41):        Candidate is: `bar12744A(alias f)(auto ref PTT12744!f args)`
 ---
 */
 template PTT12744(func...)

--- a/test/fail_compilation/fail14669.d
+++ b/test/fail_compilation/fail14669.d
@@ -4,8 +4,8 @@ TEST_OUTPUT:
 fail_compilation/fail14669.d(11): Error: `auto` can only be used as part of `auto ref` for template function parameters
 fail_compilation/fail14669.d(16): Error: template instance `fail14669.foo1!()` error instantiating
 fail_compilation/fail14669.d(12): Error: `auto` can only be used as part of `auto ref` for template function parameters
-fail_compilation/fail14669.d(17): Error: template `fail14669.foo2` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/fail14669.d(12):        `foo2()(auto int a)`
+fail_compilation/fail14669.d(17): Error: template `fail14669.foo2` cannot deduce function from argument types `!()(int)`
+fail_compilation/fail14669.d(12):        Candidate is: `foo2()(auto int a)`
 ---
 */
 void foo1()(auto int a) {}

--- a/test/fail_compilation/fail14997.d
+++ b/test/fail_compilation/fail14997.d
@@ -3,9 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14997.d(19): Error: none of the overloads of `this` are callable using argument types `()`, candidates are:
-fail_compilation/fail14997.d(14):        `fail14997.Foo.this(int a)`
-fail_compilation/fail14997.d(15):        `fail14997.Foo.this(string a)`
+fail_compilation/fail14997.d(19): Error: none of the overloads of `this` are callable using argument types `()`
+fail_compilation/fail14997.d(14):        Candidates are: `fail14997.Foo.this(int a)`
+fail_compilation/fail14997.d(15):                        `fail14997.Foo.this(string a)`
 ---
 */
 

--- a/test/fail_compilation/fail15616a.d
+++ b/test/fail_compilation/fail15616a.d
@@ -1,12 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail15616a.d(41): Error: none of the overloads of `foo` are callable using argument types `(double)`, candidates are:
-fail_compilation/fail15616a.d(14):        `fail15616a.foo(int a)`
-fail_compilation/fail15616a.d(17):        `fail15616a.foo(int a, int b)`
-fail_compilation/fail15616a.d(26):        `fail15616a.foo(int a, int b, int c)`
-fail_compilation/fail15616a.d(29):        `fail15616a.foo(string a)`
-fail_compilation/fail15616a.d(32):        `fail15616a.foo(string a, string b)`
+fail_compilation/fail15616a.d(41): Error: none of the overloads of `foo` are callable using argument types `(double)`
+fail_compilation/fail15616a.d(14):        Candidates are: `fail15616a.foo(int a)`
+fail_compilation/fail15616a.d(17):                        `fail15616a.foo(int a, int b)`
+fail_compilation/fail15616a.d(26):                        `fail15616a.foo(int a, int b, int c)`
+fail_compilation/fail15616a.d(29):                        `fail15616a.foo(string a)`
+fail_compilation/fail15616a.d(32):                        `fail15616a.foo(string a, string b)`
 fail_compilation/fail15616a.d(41):        ... (3 more, -v to show) ...
 ---
 */

--- a/test/fail_compilation/fail15616b.d
+++ b/test/fail_compilation/fail15616b.d
@@ -3,20 +3,20 @@ REQUIRED_ARGS: -v
 TRANSFORM_OUTPUT: remove_lines("^(predefs|binary|version|config|DFLAG|parse|import|semantic|entry|\s*$)")
 TEST_OUTPUT:
 ---
-fail_compilation/fail15616b.d(44): Error: none of the overloads of `foo` are callable using argument types `(double)`, candidates are:
-fail_compilation/fail15616b.d(17):        `fail15616b.foo(int a)`
-fail_compilation/fail15616b.d(20):        `fail15616b.foo(int a, int b)`
-fail_compilation/fail15616b.d(29):        `fail15616b.foo(int a, int b, int c)`
-fail_compilation/fail15616b.d(32):        `fail15616b.foo(string a)`
-fail_compilation/fail15616b.d(35):        `fail15616b.foo(string a, string b)`
-fail_compilation/fail15616b.d(38):        `fail15616b.foo(string a, string b, string c)`
-fail_compilation/fail15616b.d(23):        `foo(T)(T a)`
+fail_compilation/fail15616b.d(44): Error: none of the overloads of `foo` are callable using argument types `(double)`
+fail_compilation/fail15616b.d(17):        Candidates are: `fail15616b.foo(int a)`
+fail_compilation/fail15616b.d(20):                        `fail15616b.foo(int a, int b)`
+fail_compilation/fail15616b.d(29):                        `fail15616b.foo(int a, int b, int c)`
+fail_compilation/fail15616b.d(32):                        `fail15616b.foo(string a)`
+fail_compilation/fail15616b.d(35):                        `fail15616b.foo(string a, string b)`
+fail_compilation/fail15616b.d(38):                        `fail15616b.foo(string a, string b, string c)`
+fail_compilation/fail15616b.d(23):                        `foo(T)(T a)`
   with `T = double`
   whose parameters have the following constraints:
   `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
 `  > is(T == float)
 `  `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
-fail_compilation/fail15616b.d(26):        `foo(T)(T a)`
+fail_compilation/fail15616b.d(26):                        `foo(T)(T a)`
   with `T = double`
   whose parameters have the following constraints:
   `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`

--- a/test/fail_compilation/fail162.d
+++ b/test/fail_compilation/fail162.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail162.d(25): Error: template `fail162.testHelper` cannot deduce function from argument types `!()(string, string)`, candidates are:
-fail_compilation/fail162.d(10):        `testHelper(A...)()`
+fail_compilation/fail162.d(25): Error: template `fail162.testHelper` cannot deduce function from argument types `!()(string, string)`
+fail_compilation/fail162.d(10):        Candidate is: `testHelper(A...)()`
 fail_compilation/fail162.d(30): Error: template instance `fail162.test!("hello", "world")` error instantiating
 ---
 */

--- a/test/fail_compilation/fail20609.d
+++ b/test/fail_compilation/fail20609.d
@@ -1,17 +1,17 @@
 /*
   TEST_OUTPUT:
   ---
-  fail_compilation/fail20609.d(26): Error: none of the overloads of `this` are callable using argument types `(int)`, candidates are:
-fail_compilation/fail20609.d(23):        `fail20609.Foo.this(string[] args)`
-fail_compilation/fail20609.d(27): Error: none of the overloads of `this` are callable using argument types `(int)`, candidates are:
-fail_compilation/fail20609.d(22):        `fail20609.Foo.this(Object _param_0)`
-fail_compilation/fail20609.d(23):        `fail20609.Foo.this(string[] args)`
-fail_compilation/fail20609.d(37): Error: none of the overloads of `this` are callable using argument types `(int)`, candidates are:
+fail_compilation/fail20609.d(26): Error: none of the overloads of `this` are callable using argument types `(int)`
+fail_compilation/fail20609.d(23):        Candidate is: `fail20609.Foo.this(string[] args)`
+fail_compilation/fail20609.d(27): Error: none of the overloads of `this` are callable using argument types `(int)`
+fail_compilation/fail20609.d(22):        Candidates are: `fail20609.Foo.this(Object _param_0)`
+fail_compilation/fail20609.d(23):                        `fail20609.Foo.this(string[] args)`
+fail_compilation/fail20609.d(37): Error: none of the overloads of `this` are callable using argument types `(int)`
 fail_compilation/fail20609.d(37):        All possible candidates are marked as `deprecated` or `@disable`
 fail_compilation/fail20609.d(43): Error: undefined identifier `deprecatedTypo_`
 fail_compilation/fail20609.d(44): Error: undefined identifier `deprecatedTypo_`, did you mean function `deprecatedTypo`?
 fail_compilation/fail20609.d(45): Error: undefined identifier `disabledTypo_`
-  ---
+---
  */
 
 // Only show `this(string[])` in non-deprecated context.

--- a/test/fail_compilation/fail20730b.d
+++ b/test/fail_compilation/fail20730b.d
@@ -3,8 +3,8 @@ REQUIRED_ARGS: -verrors=spec -o-
 TEST_OUTPUT:
 ---
 (spec:1) fail_compilation/fail20730b.d-mixin-43(43): Error: C style cast illegal, use `cast(int)mod`
-fail_compilation/fail20730b.d(26): Error: template `fail20730b.atomicOp` cannot deduce function from argument types `!("+=")(shared(uint), int)`, candidates are:
-fail_compilation/fail20730b.d(41):        `atomicOp(string op, T, V1)(shared ref T val, V1 mod)`
+fail_compilation/fail20730b.d(26): Error: template `fail20730b.atomicOp` cannot deduce function from argument types `!("+=")(shared(uint), int)`
+fail_compilation/fail20730b.d(41):        Candidate is: `atomicOp(string op, T, V1)(shared ref T val, V1 mod)`
   with `op = "+=",
        T = uint,
        V1 = int`

--- a/test/fail_compilation/fail236.d
+++ b/test/fail_compilation/fail236.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail236.d(14): Error: undefined identifier `x`
-fail_compilation/fail236.d(22): Error: template `fail236.Templ2` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/fail236.d(12):        `Templ2(alias a)(x)`
+fail_compilation/fail236.d(22): Error: template `fail236.Templ2` cannot deduce function from argument types `!()(int)`
+fail_compilation/fail236.d(12):        Candidate is: `Templ2(alias a)(x)`
 ---
 */
 

--- a/test/fail_compilation/fail8009.d
+++ b/test/fail_compilation/fail8009.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail8009.d(9): Error: template `fail8009.filter` cannot deduce function from argument types `!()(void)`, candidates are:
-fail_compilation/fail8009.d(8):        `filter(R)(scope bool delegate(ref BAD!R) func)`
+fail_compilation/fail8009.d(9): Error: template `fail8009.filter` cannot deduce function from argument types `!()(void)`
+fail_compilation/fail8009.d(8):        Candidate is: `filter(R)(scope bool delegate(ref BAD!R) func)`
 ---
 */
 void filter(R)(scope bool delegate(ref BAD!R) func) { }

--- a/test/fail_compilation/fail95.d
+++ b/test/fail_compilation/fail95.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail95.d(19): Error: template `fail95.A` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/fail95.d(11):        `A(alias T)(T)`
+fail_compilation/fail95.d(19): Error: template `fail95.A` cannot deduce function from argument types `!()(int)`
+fail_compilation/fail95.d(11):        Candidate is: `A(alias T)(T)`
 ---
 */
 

--- a/test/fail_compilation/ice11856_0.d
+++ b/test/fail_compilation/ice11856_0.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11856_0.d(19): Error: template `ice11856_0.f` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/ice11856_0.d(13):        `f(T)(T t)`
-fail_compilation/ice11856_0.d(16):        `f(T)(T t)`
+fail_compilation/ice11856_0.d(19): Error: template `ice11856_0.f` cannot deduce function from argument types `!()(int)`
+fail_compilation/ice11856_0.d(13):        Candidates are: `f(T)(T t)`
+fail_compilation/ice11856_0.d(16):                        `f(T)(T t)`
   with `T = int`
   must satisfy the following constraint:
 `       !__traits(compiles, .f!T)`

--- a/test/fail_compilation/ice11856_1.d
+++ b/test/fail_compilation/ice11856_1.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11856_1.d(13): Error: template `ice11856_1.g` cannot deduce function from argument types `!()(A)`, candidates are:
-fail_compilation/ice11856_1.d(11):        `g(T)(T x)`
+fail_compilation/ice11856_1.d(13): Error: template `ice11856_1.g` cannot deduce function from argument types `!()(A)`
+fail_compilation/ice11856_1.d(11):        Candidate is: `g(T)(T x)`
 ---
 */
 struct A {}

--- a/test/fail_compilation/ice13459.d
+++ b/test/fail_compilation/ice13459.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice13459.d(12): Error: undefined identifier `B`
-fail_compilation/ice13459.d(18): Error: none of the overloads of `opSlice` are callable using argument types `(int, int)`, candidates are:
-fail_compilation/ice13459.d(11):        `ice13459.A.opSlice()`
+fail_compilation/ice13459.d(18): Error: none of the overloads of `opSlice` are callable using argument types `(int, int)`
+fail_compilation/ice13459.d(11):        Candidates are: `ice13459.A.opSlice()`
 ---
 */
 struct A

--- a/test/fail_compilation/ice14130.d
+++ b/test/fail_compilation/ice14130.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice14130.d(10): Error: undefined identifier `Undef`
-fail_compilation/ice14130.d(14): Error: template `ice14130.foo` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/ice14130.d(10):        `foo(R, F = Undef)(R r, F s = 0)`
+fail_compilation/ice14130.d(14): Error: template `ice14130.foo` cannot deduce function from argument types `!()(int)`
+fail_compilation/ice14130.d(10):        Candidate is: `foo(R, F = Undef)(R r, F s = 0)`
 ---
 */
 

--- a/test/fail_compilation/ice14907.d
+++ b/test/fail_compilation/ice14907.d
@@ -6,8 +6,8 @@ fail_compilation/ice14907.d(19):        while looking for match for `S!()`
 fail_compilation/ice14907.d(15): Error: template `ice14907.f(int v = f)()` recursive template expansion
 fail_compilation/ice14907.d(20):        while looking for match for `f!()`
 fail_compilation/ice14907.d(15): Error: template `ice14907.f(int v = f)()` recursive template expansion
-fail_compilation/ice14907.d(21): Error: template `ice14907.f` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/ice14907.d(15):        `f(int v = f)()`
+fail_compilation/ice14907.d(21): Error: template `ice14907.f` cannot deduce function from argument types `!()()`
+fail_compilation/ice14907.d(15):        Candidate is: `f(int v = f)()`
 ---
 */
 

--- a/test/fail_compilation/ice6538.d
+++ b/test/fail_compilation/ice6538.d
@@ -7,8 +7,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice6538.d(23): Error: expression `super` is not a valid template value argument
-fail_compilation/ice6538.d(28): Error: template `ice6538.D.foo` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/ice6538.d(23):        `foo()()`
+fail_compilation/ice6538.d(28): Error: template `ice6538.D.foo` cannot deduce function from argument types `!()()`
+fail_compilation/ice6538.d(23):        Candidate is: `foo()()`
 ---
 */
 

--- a/test/fail_compilation/ice9284.d
+++ b/test/fail_compilation/ice9284.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9284.d(14): Error: template `ice9284.C.__ctor` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/ice9284.d(12):        `__ctor()(string)`
+fail_compilation/ice9284.d(14): Error: template `ice9284.C.__ctor` cannot deduce function from argument types `!()(int)`
+fail_compilation/ice9284.d(12):        Candidate is: `__ctor()(string)`
 fail_compilation/ice9284.d(20): Error: template instance `ice9284.C.__ctor!()` error instantiating
 ---
 */

--- a/test/fail_compilation/test19107.d
+++ b/test/fail_compilation/test19107.d
@@ -2,8 +2,8 @@
 EXTRA_FILES: imports/imp19661.d imports/test19107a.d imports/test19107b.d
 TEST_OUTPUT:
 ---
-fail_compilation/test19107.d(24): Error: template `test19107.all` cannot deduce function from argument types `!((c) => c)(string[])`, candidates are:
-fail_compilation/test19107.d(18):        `all(alias pred, T)(T t)`
+fail_compilation/test19107.d(24): Error: template `test19107.all` cannot deduce function from argument types `!((c) => c)(string[])`
+fail_compilation/test19107.d(18):        Candidate is: `all(alias pred, T)(T t)`
   with `pred = __lambda2,
        T = string[]`
   must satisfy the following constraint:


### PR DESCRIPTION
Add 2 new lines before candidates in error messages so the text is easier to read.

Before:
```
fail_compilation/fail14997.d(19): Error: none of the overloads of `this` are callable using argument types `()`, candidates are:
fail_compilation/fail14997.d(14):        `fail14997.Foo.this(int a)`
fail_compilation/fail14997.d(15):        `fail14997.Foo.this(string a)`
```

After:
```
test/fail_compilation/fail14997.d(19): Error: none of the overloads of `this` are callable using argument types `()`

Candidates are:
test/fail_compilation/fail14997.d(14):        `fail14997.Foo.this(int a)`
test/fail_compilation/fail14997.d(15):        `fail14997.Foo.this(string a)`
```