### PR TITLE
replace Abstract with ThreeState

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -48,13 +48,6 @@ enum class ThreeState : uint8_t
     yes,          // value is true
 };
 
-enum class Abstract : uint8_t
-{
-    fwdref = 0,      // whether an abstract class is not yet computed
-    yes,             // is abstract class
-    no               // is not abstract class
-};
-
 FuncDeclaration *search_toString(StructDeclaration *sd);
 
 enum class ClassKind : uint8_t
@@ -277,7 +270,7 @@ public:
     int cppDtorVtblIndex;               // slot reserved for the virtual destructor [extern(C++)]
     bool inuse;                         // to prevent recursive attempts
 
-    Abstract isabstract;                // 0: fwdref, 1: is abstract class, 2: not abstract
+    ThreeState isabstract;              // if abstract class
     Baseok baseok;                      // set the progress of base classes resolving
     ObjcClassDeclaration objc;          // Data for a class declaration that is needed for the Objective-C integration
     Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -35,13 +35,6 @@ import dmd.root.rmem;
 import dmd.target;
 import dmd.visitor;
 
-enum Abstract : ubyte
-{
-    fwdref = 0,      // whether an abstract class is not yet computed
-    yes,             // is abstract class
-    no,              // is not abstract class
-}
-
 /***********************************************************
  */
 extern (C++) struct BaseClass
@@ -189,7 +182,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     /// to prevent recursive attempts
     private bool inuse;
 
-    Abstract isabstract;
+    ThreeState isabstract;
 
     /// set the progress of base classes resolving
     Baseok baseok;
@@ -817,13 +810,13 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     final bool isAbstract()
     {
         enum log = false;
-        if (isabstract != Abstract.fwdref)
-            return isabstract == Abstract.yes;
+        if (isabstract != ThreeState.none)
+            return isabstract == ThreeState.yes;
 
         if (log) printf("isAbstract(%s)\n", toChars());
 
-        bool no()  { if (log) printf("no\n");  isabstract = Abstract.no;  return false; }
-        bool yes() { if (log) printf("yes\n"); isabstract = Abstract.yes; return true;  }
+        bool no()  { if (log) printf("no\n");  isabstract = ThreeState.no;  return false; }
+        bool yes() { if (log) printf("yes\n"); isabstract = ThreeState.yes; return true;  }
 
         if (storage_class & STC.abstract_ || _scope && _scope.stc & STC.abstract_)
             return yes();

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3225,7 +3225,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
 
             if (funcdecl.storage_class & STC.abstract_)
-                cd.isabstract = Abstract.yes;
+                cd.isabstract = ThreeState.yes;
 
             // if static function, do not put in vtbl[]
             if (!funcdecl.isVirtual())
@@ -4487,7 +4487,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (cldec.storage_class & STC.scope_)
                 cldec.stack = true;
             if (cldec.storage_class & STC.abstract_)
-                cldec.isabstract = Abstract.yes;
+                cldec.isabstract = ThreeState.yes;
 
             cldec.userAttribDecl = sc.userAttribDecl;
 
@@ -5026,10 +5026,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         /* isAbstract() is undecidable in some cases because of circular dependencies.
          * Now that semantic is finished, get a definitive result, and error if it is not the same.
          */
-        if (cldec.isabstract != Abstract.fwdref)    // if evaluated it before completion
+        if (cldec.isabstract != ThreeState.none)    // if evaluated it before completion
         {
             const isabstractsave = cldec.isabstract;
-            cldec.isabstract = Abstract.fwdref;
+            cldec.isabstract = ThreeState.none;
             cldec.isAbstract();               // recalculate
             if (cldec.isabstract != isabstractsave)
             {

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1661,11 +1661,11 @@ public:
     void accept(Visitor* v);
 };
 
-enum class Abstract : uint8_t
+enum class ThreeState : uint8_t
 {
-    fwdref = 0u,
-    yes = 1u,
-    no = 2u,
+    none = 0u,
+    no = 1u,
+    yes = 2u,
 };
 
 enum class Baseok : uint8_t
@@ -1771,13 +1771,6 @@ struct File final
     File()
     {
     }
-};
-
-enum class ThreeState : uint8_t
-{
-    none = 0u,
-    no = 1u,
-    yes = 2u,
 };
 
 template <typename K, typename V>
@@ -4372,7 +4365,6 @@ struct ASTCodegen final
     using StaticForeach = ::StaticForeach;
     using StaticIfCondition = ::StaticIfCondition;
     using VersionCondition = ::VersionCondition;
-    using Abstract = ::Abstract;
     using BaseClass = ::BaseClass;
     using ClassDeclaration = ::ClassDeclaration;
     using ClassFlags = ::ClassFlags;
@@ -5382,7 +5374,7 @@ public:
 private:
     bool inuse;
 public:
-    Abstract isabstract;
+    ThreeState isabstract;
     Baseok baseok;
     ObjcClassDeclaration objc;
     Symbol* cpp_type_info_ptr_sym;


### PR DESCRIPTION
Now that `ThreeState` exists, there is no purpose to `Abstract`.