### PR TITLE
[DSSv3] Fix issue 21637: Allow trailing comma in the ImportList

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -3489,6 +3489,7 @@ class Parser(AST) : Lexer
     {
         auto decldefs = new AST.Dsymbols();
         Identifier aliasid = null;
+        auto trailing_comma = 0;
 
         int isstatic = token.value == TOK.static_;
         if (isstatic)
@@ -3539,10 +3540,14 @@ class Parser(AST) : Lexer
                 do
                 {
                     nextToken();
-                    if (token.value != TOK.identifier)
+                    if (token.value != TOK.identifier && token.value != TOK.semicolon)
                     {
                         error("identifier expected following `:`");
                         break;
+                    }
+                    if (token.value == TOK.semicolon)
+                    {
+                        trailing_comma = 1;
                     }
                     Identifier _alias = token.ident;
                     Identifier name;
@@ -3571,13 +3576,15 @@ class Parser(AST) : Lexer
             aliasid = null;
         }
         while (token.value == TOK.comma);
-
-        if (token.value == TOK.semicolon)
-            nextToken();
-        else
+        if (trailing_comma == 0)
         {
-            error("`;` expected");
-            nextToken();
+            if (token.value == TOK.semicolon)
+                nextToken();
+            else
+            {
+                error("`;` expected");
+                nextToken();
+            }
         }
 
         return decldefs;

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -3529,16 +3529,17 @@ class Parser(AST) : Lexer
             }
 
             auto s = new AST.Import(loc, a, id, aliasid, isstatic);
-            decldefs.push(s);
 
             /* Look for
              *      : alias=name, alias=name;
              * syntax.
              */
+            int count = 0;
             if (token.value == TOK.colon)
             {
                 do
                 {
+                    count++;
                     nextToken();
                     if (token.value != TOK.identifier && token.value != TOK.semicolon)
                     {
@@ -3568,10 +3569,23 @@ class Parser(AST) : Lexer
                         name = _alias;
                         _alias = null;
                     }
-                    s.addAlias(name, _alias);
+                    if (count == 1 && trailing_comma == 1)
+                    {
+                        break;                        
+                    }
+                    else
+                    {
+                        if (count == 1)
+                            decldefs.push(s);
+                        s.addAlias(name, _alias);
+                    }
                 }
                 while (token.value == TOK.comma);
                 break; // no comma-separated imports of this form
+            }
+            else
+            {
+                decldefs.push(s);
             }
             aliasid = null;
         }

--- a/test/compilable/test21637.d
+++ b/test/compilable/test21637.d
@@ -1,13 +1,23 @@
-void a()
+void foo()
 {
 	import std.stdio: writeln, write,;
+	write("foo");
 }
 
-void b()
+void bar()
 {
 	import std.stdio: writeln,;
+	writeln("bar");
+}
+
+void foobar()
+{
+	import std.stdio: ;
 }
 
 int main() {
+	foobar();
+	foo();
+	bar();
 	return 1;
 }

--- a/test/compilable/test21637.d
+++ b/test/compilable/test21637.d
@@ -1,0 +1,13 @@
+void a()
+{
+	import std.stdio: writeln, write,;
+}
+
+void b()
+{
+	import std.stdio: writeln,;
+}
+
+int main() {
+	return 1;
+}


### PR DESCRIPTION
Modified parse.d as to avoid the error of having a trailing comma, used an auxiliary variable