### PR TITLE
[DSSv3] Fix Issue 21685: add clearer message for private constructor

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -60,13 +60,7 @@ bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymbol smember)
                 return false;
         }
 
-        import std.conv;
-        if (smember.kind().to!string() == "constructor") {
-            ad.error(loc, "`Constructor` is not accessible%s", (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
-        }
-        else {
-            ad.error(loc, "member `%s` is not accessible%s", smember.toChars(), (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
-        }
+        ad.error(loc, "`%s %s` is not accessible%s", smember.kind(), smember.toChars, (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
         //printf("smember = %s %s, vis = %d, semanticRun = %d\n",
         //        smember.kind(), smember.toPrettyChars(), smember.visible() smember.semanticRun);
         return true;

--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -60,7 +60,13 @@ bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymbol smember)
                 return false;
         }
 
-        ad.error(loc, "member `%s` is not accessible%s", smember.toChars(), (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
+        import std.conv;
+        if (smember.kind().to!string() == "constructor") {
+            ad.error(loc, "`Constructor` is not accessible%s", (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
+        }
+        else {
+            ad.error(loc, "member `%s` is not accessible%s", smember.toChars(), (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
+        }
         //printf("smember = %s %s, vis = %d, semanticRun = %d\n",
         //        smember.kind(), smember.toPrettyChars(), smember.visible() smember.semanticRun);
         return true;

--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -60,7 +60,7 @@ bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymbol smember)
                 return false;
         }
 
-        ad.error(loc, "`%s %s` is not accessible%s", smember.kind(), smember.toChars, (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
+        ad.error(loc, "%s `%s` is not accessible%s", smember.kind(), smember.toChars, (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
         //printf("smember = %s %s, vis = %d, semanticRun = %d\n",
         //        smember.kind(), smember.toPrettyChars(), smember.visible() smember.semanticRun);
         return true;

--- a/test/fail_compilation/imports/issue21685.d
+++ b/test/fail_compilation/imports/issue21685.d
@@ -1,0 +1,6 @@
+module issue21685;
+
+class E
+{
+    private this() {}
+}

--- a/test/fail_compilation/issue21685_main.d
+++ b/test/fail_compilation/issue21685_main.d
@@ -1,0 +1,12 @@
+/* REQUIRED_ARGS: -preview=dip1000 -Ifail_compilation/imports
+TEST_OUTPUT:
+---
+fail_compilation/issue21685_main.d(11): Error: class `issue21685.E` `constructor this` is not accessible
+---
+*/
+import issue21685;
+
+void main()
+{
+    new E;
+}

--- a/test/fail_compilation/issue21685_main.d
+++ b/test/fail_compilation/issue21685_main.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000 -Ifail_compilation/imports
 TEST_OUTPUT:
 ---
-fail_compilation/issue21685_main.d(11): Error: class `issue21685.E` `constructor this` is not accessible
+fail_compilation/issue21685_main.d(11): Error: class `issue21685.E` constructor `this` is not accessible
 ---
 */
 import issue21685;

--- a/test/fail_compilation/issue21936.d
+++ b/test/fail_compilation/issue21936.d
@@ -1,8 +1,8 @@
 /* REQUIRED_ARGS: -preview=dip1000 -Ifail_compilation/imports
 TEST_OUTPUT:
 ---
-fail_compilation/issue21936.d(15): Error: struct `issue21936s.S` member `field` is not accessible from `@safe` code
-fail_compilation/issue21936.d(15): Error: struct `issue21936s.S` member `field` is not accessible from `@safe` code
+fail_compilation/issue21936.d(15): Error: struct `issue21936s.S` `variable field` is not accessible from `@safe` code
+fail_compilation/issue21936.d(15): Error: struct `issue21936s.S` `variable field` is not accessible from `@safe` code
 fail_compilation/issue21936.d(11): Error: template instance `issue21936.constructImplicit!(S)` error instantiating
 fail_compilation/issue21936.d(7):        instantiated from here: `registerConstructors!(S)`
 fail_compilation/issue21936.d(21):        instantiated from here: `registerType!(S)`

--- a/test/fail_compilation/issue21936.d
+++ b/test/fail_compilation/issue21936.d
@@ -1,8 +1,8 @@
 /* REQUIRED_ARGS: -preview=dip1000 -Ifail_compilation/imports
 TEST_OUTPUT:
 ---
-fail_compilation/issue21936.d(15): Error: struct `issue21936s.S` `variable field` is not accessible from `@safe` code
-fail_compilation/issue21936.d(15): Error: struct `issue21936s.S` `variable field` is not accessible from `@safe` code
+fail_compilation/issue21936.d(15): Error: struct `issue21936s.S` variable `field` is not accessible from `@safe` code
+fail_compilation/issue21936.d(15): Error: struct `issue21936s.S` variable `field` is not accessible from `@safe` code
 fail_compilation/issue21936.d(11): Error: template instance `issue21936.constructImplicit!(S)` error instantiating
 fail_compilation/issue21936.d(7):        instantiated from here: `registerConstructors!(S)`
 fail_compilation/issue21936.d(21):        instantiated from here: `registerType!(S)`

--- a/test/fail_compilation/test18554.d
+++ b/test/fail_compilation/test18554.d
@@ -2,7 +2,7 @@
 EXTRA_FILES: imports/imp18554.d
 TEST_OUTPUT:
 ---
-fail_compilation/test18554.d(16): Error: struct `imp18554.S` `variable i` is not accessible from `@safe` code
+fail_compilation/test18554.d(16): Error: struct `imp18554.S` variable `i` is not accessible from `@safe` code
 ---
 */
 

--- a/test/fail_compilation/test18554.d
+++ b/test/fail_compilation/test18554.d
@@ -2,7 +2,7 @@
 EXTRA_FILES: imports/imp18554.d
 TEST_OUTPUT:
 ---
-fail_compilation/test18554.d(16): Error: struct `imp18554.S` member `i` is not accessible from `@safe` code
+fail_compilation/test18554.d(16): Error: struct `imp18554.S` `variable i` is not accessible from `@safe` code
 ---
 */
 


### PR DESCRIPTION
The error message for accessing the private constructor is clear now.
Old message:
`Error: class `<class_name>` member `this` is not accessible`

Current message:
`Error: class `<class_name>` `Constructor` is not accessible`