### PR TITLE
[dmd-cxx] fix Issue 22133 - [REG2.097] Breaking change in DotTemplateExp type semantics leading to e.g. isInputRange regression

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4200,6 +4200,18 @@ DotTemplateExp::DotTemplateExp(Loc loc, Expression *e, TemplateDeclaration *td)
     this->td = td;
 }
 
+bool DotTemplateExp::checkType()
+{
+    error("%s %s has no type", td->kind(), toChars());
+    return true;
+}
+
+bool DotTemplateExp::checkValue()
+{
+    error("%s %s has no value", td->kind(), toChars());
+    return true;
+}
+
 /************************************************************/
 
 DotVarExp::DotVarExp(Loc loc, Expression *e, Declaration *var, bool hasOverloads)

--- a/src/expression.h
+++ b/src/expression.h
@@ -930,6 +930,8 @@ public:
     TemplateDeclaration *td;
 
     DotTemplateExp(Loc loc, Expression *e, TemplateDeclaration *td);
+    bool checkType();
+    bool checkValue();
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/test/compilable/test22133.d
+++ b/test/compilable/test22133.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=22133
+
+struct Slice
+{
+    bool empty() const;
+    int front() const;
+    void popFront()() // note: requires a mutable Slice
+    {}
+}
+
+enum isInputRange1(R) = is(typeof((R r) => r.popFront));
+enum isInputRange2(R) = __traits(compiles, (R r) => r.popFront);
+static assert(isInputRange1!(      Slice) == true);
+static assert(isInputRange1!(const Slice) == false);
+static assert(isInputRange2!(      Slice) == true);
+static assert(isInputRange2!(const Slice) == false);

--- a/test/fail_compilation/fail22133.d
+++ b/test/fail_compilation/fail22133.d
@@ -1,0 +1,24 @@
+// https://issues.dlang.org/show_bug.cgi?id=22133
+/*
+TEST_OUTPUT
+---
+fail_compilation/fail22133.d(16): Error: `s.popFront()()` has no effect
+fail_compilation/fail22133.d(17): Error: template `s.popFront()()` has no type
+---
+*/
+struct Slice
+{
+    void popFront()() {}
+}
+
+auto fail22133(const Slice s)
+{
+    s.popFront;
+    return s.popFront;
+}
+
+auto ok22133(Slice s)
+{
+    s.popFront;
+    return s.popFront;
+}

--- a/test/fail_compilation/fail7424b.d
+++ b/test/fail_compilation/fail7424b.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424b.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424b.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424b

--- a/test/fail_compilation/fail7424c.d
+++ b/test/fail_compilation/fail7424c.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424c.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424c.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424c

--- a/test/fail_compilation/fail7424d.d
+++ b/test/fail_compilation/fail7424d.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424d.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424d.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424d

--- a/test/fail_compilation/fail7424e.d
+++ b/test/fail_compilation/fail7424e.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424e.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424e.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424e

--- a/test/fail_compilation/fail7424f.d
+++ b/test/fail_compilation/fail7424f.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424f.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424f.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424f

--- a/test/fail_compilation/fail7424g.d
+++ b/test/fail_compilation/fail7424g.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424g.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424g.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424g

--- a/test/fail_compilation/fail7424h.d
+++ b/test/fail_compilation/fail7424h.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424h.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424h.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424g

--- a/test/fail_compilation/fail7424i.d
+++ b/test/fail_compilation/fail7424i.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424i.d(10): Error: expression `this.g()()` is `void` and has no value
+fail_compilation/fail7424i.d(10): Error: template `this.g()()` has no value
 ---
 */
 struct S7424g


### PR DESCRIPTION
Backport of #12897.