### PR TITLE
[dmd-cxx] fix issue 19002 - __FUNCTION__ and __PRETTY_FUNCTION__ cannot be used as C string literals

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -5620,7 +5620,7 @@ Expression *FuncInitExp::resolveLoc(Loc loc, Scope *sc)
         s = "";
     Expression *e = new StringExp(loc, const_cast<char *>(s));
     e = expressionSemantic(e, sc);
-    e = e->castTo(sc, type);
+    e->type = Type::tstring;
     return e;
 }
 
@@ -5654,7 +5654,7 @@ Expression *PrettyFuncInitExp::resolveLoc(Loc loc, Scope *sc)
 
     Expression *e = new StringExp(loc, const_cast<char *>(s));
     e = expressionSemantic(e, sc);
-    e = e->castTo(sc, type);
+    e->type = Type::tstring;
     return e;
 }
 

--- a/test/compilable/b19002.d
+++ b/test/compilable/b19002.d
@@ -1,0 +1,12 @@
+module b19002;
+
+void printf(scope const char* format){}
+
+void main()
+{
+    printf(__FILE__);
+    printf(__FILE_FULL_PATH__);
+    printf(__FUNCTION__);
+    printf(__PRETTY_FUNCTION__);
+    printf(__MODULE__);
+}


### PR DESCRIPTION
Backport of #9920 for [PR d/101441](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101441).