### PR TITLE
fix Issue 22144 - ICE(dcast.d): Floating point exception in castTo::CastTo::visit(Expression*) at dmd/dcast.d:1702

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1665,14 +1665,18 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                 {
                     // T[n] sa;
                     // cast(U[])sa; // ==> cast(U[])sa[];
-                    d_uns64 fsize = t1b.nextOf().size();
-                    d_uns64 tsize = tob.nextOf().size();
-                    if (((cast(TypeSArray)t1b).dim.toInteger() * fsize) % tsize != 0)
+                    const fsize = t1b.nextOf().size();
+                    const tsize = tob.nextOf().size();
+                    if (fsize != tsize)
                     {
-                        // copied from sarray_toDarray() in e2ir.c
-                        e.error("cannot cast expression `%s` of type `%s` to `%s` since sizes don't line up", e.toChars(), e.type.toChars(), t.toChars());
-                        result = ErrorExp.get();
-                        return;
+                        const dim = t1b.isTypeSArray().dim.toInteger();
+                        if (tsize == 0 || (dim * fsize) % tsize != 0)
+                        {
+                            e.error("cannot cast expression `%s` of type `%s` to `%s` since sizes don't line up",
+                                    e.toChars(), e.type.toChars(), t.toChars());
+                            result = ErrorExp.get();
+                            return;
+                        }
                     }
                     goto Lok;
                 }

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -918,11 +918,8 @@ elem *sarray_toDarray(const ref Loc loc, Type tfrom, Type tto, elem *e)
         uint fsize = cast(uint)tfrom.nextOf().size();
         uint tsize = cast(uint)tto.nextOf().size();
 
-        if ((dim * fsize) % tsize != 0)
-        {
-            // have to change to Internal Compiler Error?
-            error(loc, "cannot cast %s to %s since sizes don't line up", tfrom.toChars(), tto.toChars());
-        }
+        // Should have been caught by Expression::castTo
+        assert(tsize != 0 && (dim * fsize) % tsize == 0);
         dim = (dim * fsize) / tsize;
     }
     elem *elen = el_long(TYsize_t, dim);

--- a/test/fail_compilation/fail22144.d
+++ b/test/fail_compilation/fail22144.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=22144
+/* TEST_OUTPUT
+---
+fail_compilation/fail22144.d(12): Error: cannot cast expression `zarray1` of type `int[0]` to `int[0][]` since sizes don't line up
+---
+*/
+void main()
+{
+  int[0] zarray1;
+  int[0][0] zarray2;
+
+  auto zslice1 = cast(int[0][])zarray1; // ICE -> Error
+  auto zslice2 = cast(int[0][])zarray2; // ICE -> OK
+}


### PR DESCRIPTION
Missing tests in `castTo` for `T[N]` -> `T[]`.
1. Elem type sizes are equal.
2. To type size is != 0

The sarray_toDarray check is redundant, and has been converted into an assert.

FYI @kinke - as I have not yet seen a 2.097.2 tag from @MartinNowak just yet.