### PR TITLE
Prepend baseclass fields to symbol for debugging

### DIFF
--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -260,6 +260,23 @@ public:
              */
             if (global.params.symdebug)
             {
+                // TODO ideally we would store CType of the baseClass inside the Symbol.
+                // However that requires more invasive surgery.
+                // Windows has that information but on non-windows compilers the relevant fields are null
+                import dmd.target;
+                // windows debug information somehow has access to the baseclass in Symbol
+                if (target.os != Target.OS.Windows)
+                {
+                    auto base = t.sym.baseClass;
+                    while (base)
+                    {
+                        foreach(v; base.fields)
+                        {
+                            symbol_struct_addField(cast(Symbol*)tc.Ttag, v.ident.toChars(), Type_toCtype(v.type), v.offset);
+                        }
+                        base = base.baseClass;
+                    }
+                }
                 foreach (v; t.sym.fields)
                 {
                     symbol_struct_addField(cast(Symbol*)tc.Ttag, v.ident.toChars(), Type_toCtype(v.type), v.offset);

--- a/test/runnable/gdb_baseclass_fields.d
+++ b/test/runnable/gdb_baseclass_fields.d
@@ -1,0 +1,32 @@
+/*
+REQUIRED_ARGS: -g
+PERMUTE_ARGS:
+GDB_SCRIPT:
+---
+b 30
+r
+set print pretty off
+echo RESULT=
+p *c
+---
+GDB_MATCH: RESULT=.*\{a = 1, b = 2\}
+*/
+
+class B {
+  uint a;
+}
+
+class C : B {
+  int b;
+}
+
+
+void main()
+{
+  C c = new C();
+  c.a = 1;
+  c.b = 2;
+
+  int bp = 1;
+}
+


### PR DESCRIPTION
This does not solve the problem of a class not knowing their parent.
but at least you can see the parent fields in the debug info.