### PR TITLE
[dmd-cxx] fix Issue 22144 - ICE(dcast.d): Floating point exception in castTo::CastTo::visit(Expression*) at dmd/dcast.d:1702

### DIFF
--- a/src/dcast.c
+++ b/src/dcast.c
@@ -1496,13 +1496,16 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                     // cast(U[])sa; // ==> cast(U[])sa[];
                     d_uns64 fsize = t1b->nextOf()->size();
                     d_uns64 tsize = tob->nextOf()->size();
-                    if ((((TypeSArray *)t1b)->dim->toInteger() * fsize) % tsize != 0)
+                    if (fsize != tsize)
                     {
-                        // copied from sarray_toDarray() in e2ir.c
-                        e->error("cannot cast expression %s of type %s to %s since sizes don't line up",
-                            e->toChars(), e->type->toChars(), t->toChars());
-                        result = new ErrorExp();
-                        return;
+                        dinteger_t dim = ((TypeSArray *)t1b)->dim->toInteger();
+                        if (tsize == 0 || (dim * fsize) % tsize != 0)
+                        {
+                            e->error("cannot cast expression `%s` of type `%s` to `%s` since sizes don't line up",
+                                     e->toChars(), e->type->toChars(), t->toChars());
+                            result = new ErrorExp();
+                            return;
+                        }
                     }
                     goto Lok;
                 }

--- a/test/fail_compilation/fail22144.d
+++ b/test/fail_compilation/fail22144.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=22144
+/* TEST_OUTPUT
+---
+fail_compilation/fail22144.d(12): Error: cannot cast expression `zarray1` of type `int[0]` to `int[0][]` since sizes don't line up
+---
+*/
+void main()
+{
+  int[0] zarray1;
+  int[0][0] zarray2;
+
+  auto zslice1 = cast(int[0][])zarray1; // ICE -> Error
+  auto zslice2 = cast(int[0][])zarray2; // ICE -> OK
+}


### PR DESCRIPTION
Backport of #12924 for [PR d/101490](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101490).