### PR TITLE
Cache the result of FuncDeclaration.isTypeIsolated()... 

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -535,6 +535,8 @@ public:
     VarDeclaration *vresult;            // result variable for out contracts
     LabelDsymbol *returnLabel;          // where the return goes
 
+    void *isTypeIsolatedCache;          // An AA on the D side to cache an expensive check result
+
     // used to prevent symbols in different
     // scopes from having the same name
     DsymbolTable *localsymtab;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1957,6 +1957,7 @@ public:
     bool equals(const RootObject* const o) const;
     bool equivalent(Type* t);
     DYNCAST dyncast() const;
+    size_t getUniqueID() const;
     Covariant covariant(Type* t, uint64_t* pstc = nullptr);
     const char* toChars() const;
     char* toPrettyChars(bool QualifyTypes = false);
@@ -2680,6 +2681,7 @@ public:
     const char* mangleString;
     VarDeclaration* vresult;
     LabelDsymbol* returnLabel;
+    void* isTypeIsolatedCache;
     DsymbolTable* localsymtab;
     VarDeclaration* vthis;
     bool isThis2;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -426,6 +426,13 @@ extern (C++) abstract class Type : ASTNode
         return DYNCAST.type;
     }
 
+    /// Returns a non-zero unique ID for this Type, or returns 0 if the Type does not (yet) have a unique ID.
+    /// If `semantic()` has not been run, 0 is returned.
+    final size_t getUniqueID() const
+    {
+        return cast(size_t) deco;
+    }
+
     extern (D)
     final Mcache* getMcache()
     {

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -224,6 +224,7 @@ public:
     bool equivalent(Type *t);
     // kludge for template.isType()
     DYNCAST dyncast() const { return DYNCAST_TYPE; }
+    size_t getUniqueID() const;
     Covariant covariant(Type *t, StorageClass *pstc = NULL);
     const char *toChars() const;
     char *toPrettyChars(bool QualifyTypes = false);


### PR DESCRIPTION
...because it is potentially a very expensive check.

This resulted in a large compile-time improvement on the large codebase at Weka.io (11min --> 3.5min).

Patch by @EyalIO !