### PR TITLE
add STC.returnScope

### DIFF
--- a/src/dmd/astenums.d
+++ b/src/dmd/astenums.d
@@ -90,18 +90,33 @@ enum STC : ulong
     inference           = (1L << 46),   // do attribute inference
     exptemp             = (1L << 47),   // temporary variable that has lifetime restricted to an expression
     maybescope          = (1L << 48),   // parameter might be 'scope'
-    scopeinferred       = (1L << 49),   // 'scope' has been inferred and should not be part of mangling
+    scopeinferred       = (1L << 49),   // 'scope' has been inferred and should not be part of mangling, `scope_` must also be set
     future              = (1L << 50),   // introducing new base class function
     local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
-    returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
+    returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling, `return_` must also be set
     live                = (1L << 53),   // function @live attribute
-    register            = (1L << 54),   // `register` storage class
+    register            = (1L << 54),   // `register` storage class (ImportC)
+    returnScope         = (1L << 55),   // if `ref return scope` then resolve to `ref` and `return scope`
 
     safeGroup = STC.safe | STC.trusted | STC.system,
     IOR  = STC.in_ | STC.ref_ | STC.out_,
     TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
     FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.live |
                 safeGroup),
+}
+
+/********
+ * Determine if it's the ambigous case of where `return` attaches to.
+ * Params:
+ *   stc = STC flags
+ * Returns:
+ *   true if (`ref` | `out`) and `scope` and `return`
+ */
+@safe pure @nogc nothrow
+bool isRefReturnScope(const ulong stc)
+{
+    return (stc & (STC.scope_ | STC.return_)) == (STC.scope_ | STC.return_) &&
+           stc & (STC.ref_ | STC.out_);
 }
 
 /* This is different from the one in declaration.d, make that fix a separate PR */

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1336,7 +1336,19 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
         if (v.isDataseg())
             continue;
 
-        const vsr = buildScopeRef(refs, v.storage_class);
+        if (isRefReturnScope(v.storage_class))
+        {
+            const scr = (v.storage_class & STC.returnScope) != 0;
+            if (refs == scr)
+            {
+                /* Match the old behavior, where being a constructor is sometimes ignored.
+                 * Figure out how to fix it later
+                 */
+                //error(e.loc, "buildScopeRef: sc.func: %s refs: %d e: %s, v: %s\n", sc.func.toChars(), refs, e.toChars(), v.toChars());
+                v.storage_class ^= STC.returnScope;
+            }
+        }
+        const vsr = buildScopeRef(v.storage_class);
 
         Dsymbol p = v.toParent2();
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2513,6 +2513,7 @@ enum class STC : uint64_t
     returninferred = 4503599627370496LLU,
     live = 9007199254740992LLU,
     register_ = 18014398509481984LLU,
+    returnScope = 36028797018963968LLU,
     safeGroup = 60129542144LLU,
     IOR = 2103296LLU,
     TYPECTOR = 2685403140LLU,

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -462,7 +462,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if ((funcdecl.flags & FUNCFLAG.inferScope) && !(fparam.storageClass & STC.scope_))
                         stc |= STC.maybescope;
 
-                    stc |= fparam.storageClass & (STC.IOR | STC.return_ | STC.scope_ | STC.lazy_ | STC.final_ | STC.TYPECTOR | STC.nodtor);
+                    stc |= fparam.storageClass & (STC.IOR | STC.return_ | STC.scope_ | STC.lazy_ | STC.final_ | STC.TYPECTOR | STC.nodtor | STC.returnScope);
                     v.storage_class = stc;
                     v.dsymbolSemantic(sc2);
                     if (!sc2.insert(v))


### PR DESCRIPTION
Part of my ongoing effort to find a resolution to the `ref return scope` ambiguity. This change makes the decision set on `STC.returnScope` rather than whether the function returns by `ref` or is a constructor. This centralizes the decision in one place rather than be distributed around the code.
