### PR TITLE
remove unnecessary set of SCOPE.ctor

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3807,7 +3807,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
 
         sc.stc &= ~STC.static_; // not a static constructor
-        sc.flags |= SCOPE.ctor;
 
         funcDeclarationSemantic(ctd);
 


### PR DESCRIPTION
It's set by funcDeclarationSemantic().