### PR TITLE
Implement DIP1029: Add `throw` as Function Attribute

### DIFF
--- a/src/dmd/astenums.d
+++ b/src/dmd/astenums.d
@@ -110,11 +110,13 @@ enum STC : ulong  // transfer changes to declaration.h
     live                = 0x10_0000_0000_0000,   /// function `@live` attribute
     register            = 0x20_0000_0000_0000,   /// `register` storage class (ImportC)
     volatile_           = 0x40_0000_0000_0000,   /// destined for volatile in the back end
+    throw_              = 0x80_0000_0000_0000,   /// throws exception
 
     safeGroup = STC.safe | STC.trusted | STC.system,
+    throwGroup = STC.throw_ | STC.nothrow_,
     IOR  = STC.in_ | STC.ref_ | STC.out_,
     TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
-    FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.live |
+    FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.throw_ | STC.nogc | STC.pure_ | STC.property | STC.live |
                 safeGroup),
 
     /* These are visible to the user, i.e. are expressed by the user
@@ -122,7 +124,7 @@ enum STC : ulong  // transfer changes to declaration.h
     visibleStorageClasses =
         (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ |
          STC.deprecated_ | STC.future | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest |
-         STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared |
+         STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.throw_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared |
          STC.property | STC.safeGroup | STC.disable | STC.local | STC.live),
 
     /* These storage classes "flow through" to the inner scope of a Dsymbol
@@ -130,7 +132,7 @@ enum STC : ulong  // transfer changes to declaration.h
     flowThruAggregate = STC.safeGroup,    /// for an AggregateDeclaration
     flowThruFunction = ~(STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.abstract_ | STC.deprecated_ | STC.override_ |
                          STC.TYPECTOR | STC.final_ | STC.tls | STC.gshared | STC.ref_ | STC.return_ | STC.property |
-                         STC.nothrow_ | STC.pure_ | STC.safe | STC.trusted | STC.system), /// for a FuncDeclaration
+                         STC.nothrow_ | STC.throw_ | STC.pure_ | STC.safe | STC.trusted | STC.system), /// for a FuncDeclaration
 
 }
 
@@ -156,7 +158,7 @@ extern (C++) __gshared const(StorageClass) STCStorageClass =
     (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ |
      STC.abstract_ | STC.synchronized_ | STC.deprecated_ | STC.override_ | STC.lazy_ |
      STC.alias_ | STC.out_ | STC.in_ | STC.manifest | STC.immutable_ | STC.shared_ |
-     STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls |
+     STC.wild | STC.nothrow_ | STC.throw_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls |
      STC.gshared | STC.property | STC.live |
      STC.safeGroup | STC.disable);
 
@@ -297,6 +299,13 @@ enum TRUST : ubyte
     system     = 1,    // @system (same as TRUST.default)
     trusted    = 2,    // @trusted
     safe       = 3,    // @safe
+}
+
+enum THROW : ubyte
+{
+    default_   = 0,
+    throw_     = 1, // has throw
+    nothrow_   = 2, // has nothrow
 }
 
 enum PURE : ubyte

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -72,14 +72,14 @@ extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, bool mustN
         void checkFuncThrows(Expression e, FuncDeclaration f)
         {
             auto tf = f.type.toBasetype().isTypeFunction();
-            if (tf && !tf.isnothrow)
+            if (tf && tf.throw_ != THROW.nothrow_)
             {
                 if (mustNotThrow)
                 {
                     e.error("%s `%s` is not `nothrow`",
                         f.kind(), f.toPrettyChars());
 
-                    e.checkOverridenDtor(null, f, dd => dd.type.toTypeFunction().isnothrow, "not nothrow");
+                    e.checkOverridenDtor(null, f, dd => dd.type.toTypeFunction().throw_ == THROW.nothrow_, "not nothrow");
                 }
                 result |= CT.exception;
             }
@@ -134,12 +134,12 @@ extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, bool mustN
                 return;
             Type t = ce.e1.type.toBasetype();
             auto tf = t.isTypeFunction();
-            if (tf && tf.isnothrow)
+            if (tf && tf.throw_ == THROW.nothrow_)
                 return;
             else
             {
                 auto td = t.isTypeDelegate();
-                if (td && td.nextOf().isTypeFunction().isnothrow)
+                if (td && td.nextOf().isTypeFunction().throw_ == THROW.nothrow_)
                     return;
             }
 

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -63,10 +63,13 @@ StorageClass mergeFuncAttrs(StorageClass s1, const FuncDeclaration f) pure
     else if (tf.trust == TRUST.trusted)
         s2 |= STC.trusted;
 
+    if (tf.throw_ == THROW.nothrow_)
+        s2 |= STC.nothrow_;
+    else if (tf.throw_ == THROW.throw_)
+        s2 |= STC.throw_;
+
     if (tf.purity != PURE.impure)
         s2 |= STC.pure_;
-    if (tf.isnothrow)
-        s2 |= STC.nothrow_;
     if (tf.isnogc)
         s2 |= STC.nogc;
 
@@ -1250,7 +1253,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         // if this field's postblit is not `nothrow`, add a `scope(failure)`
         // block to destroy any prior successfully postblitted fields should
         // this field's postblit fail
-        if (fieldsToDestroy.length > 0 && !(cast(TypeFunction)sdv.postblit.type).isnothrow)
+        if (fieldsToDestroy.length > 0 && !((cast(TypeFunction)sdv.postblit.type).throw_ == THROW.nothrow_))
         {
              // create a list of destructors that need to be called
             Expression[] dtorCalls;

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -3004,8 +3004,14 @@ Lagain:
                 d.purity = PURE.impure;
             assert(d.purity != PURE.fwdref);
 
-            d.isnothrow = (tf1.isnothrow && tf2.isnothrow);
             d.isnogc = (tf1.isnogc && tf2.isnogc);
+
+            if (tf1.throw_ == tf2.throw_)
+                d.throw_ = tf1.throw_;
+            else if (tf1.throw_ <= THROW.throw_ || tf2.throw_ <= THROW.throw_)
+                d.throw_ = THROW.throw_;
+            else
+                d.throw_ = THROW.nothrow_;
 
             if (tf1.trust == tf2.trust)
                 d.trust = tf1.trust;

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -510,7 +510,7 @@ public:
 
         if (ta.purity)
             buf.writestring("Na");
-        if (ta.isnothrow)
+        if (ta.throw_ == THROW.nothrow_)
             buf.writestring("Nb");
         if (ta.isref)
             buf.writestring("Nc");

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3139,8 +3139,16 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 sc.stc |= STC.ref_;
             if (tf.isScopeQual)
                 sc.stc |= STC.scope_;
-            if (tf.isnothrow)
-                sc.stc |= STC.nothrow_;
+
+            if (tf.throw_ != THROW.default_)
+            {
+                sc.stc &= ~STC.throwGroup;
+                if (tf.throw_ == THROW.nothrow_)
+                    sc.stc |= STC.nothrow_;
+                else if (tf.throw_ == THROW.throw_)
+                    sc.stc |= STC.throw_;
+            }
+
             if (tf.isnogc)
                 sc.stc |= STC.nogc;
             if (tf.isproperty)
@@ -3230,7 +3238,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             tfo.isreturninferred = tfx.isreturninferred;
             tfo.isscopeinferred = tfx.isscopeinferred;
             tfo.isref = tfx.isref;
-            tfo.isnothrow = tfx.isnothrow;
+            tfo.throw_ = tfx.throw_;
             tfo.isnogc = tfx.isnogc;
             tfo.isproperty = tfx.isproperty;
             tfo.purity = tfx.purity;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3973,7 +3973,7 @@ extern (C++) final class FuncExp : Expression
                         tfx.linkage, STC.undefined_);
             tfy.mod = tfx.mod;
             tfy.trust = tfx.trust;
-            tfy.isnothrow = tfx.isnothrow;
+            tfy.throw_ = tfx.throw_;
             tfy.isnogc = tfx.isnogc;
             tfy.purity = tfx.purity;
             tfy.isproperty = tfx.isproperty;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3352,6 +3352,12 @@ enum class ScopeRef
     Return = 8,
 };
 
+enum class THROWformat
+{
+    THROWformatDefault = 0,
+    THROWformatThrow = 1,
+};
+
 enum class TRUSTformat
 {
     TRUSTformatDefault = 0,
@@ -3540,6 +3546,13 @@ enum class TRUST : uint8_t
     safe = 3u,
 };
 
+enum class THROW : uint8_t
+{
+    default_ = 0u,
+    throw_ = 1u,
+    nothrow_ = 2u,
+};
+
 class TypeFunction final : public TypeNext
 {
 public:
@@ -3548,25 +3561,25 @@ private:
     enum class FunctionFlag : uint32_t
     {
         none = 0u,
-        isnothrow = 1u,
-        isnogc = 2u,
-        isproperty = 4u,
-        isref = 8u,
-        isreturn = 16u,
-        isscope = 32u,
-        isreturninferred = 64u,
-        isscopeinferred = 128u,
-        islive = 256u,
-        incomplete = 512u,
-        inoutParam = 1024u,
-        inoutQual = 2048u,
-        isctor = 4096u,
+        isnogc = 1u,
+        isproperty = 2u,
+        isref = 4u,
+        isreturn = 8u,
+        isscope = 16u,
+        isreturninferred = 32u,
+        isscopeinferred = 64u,
+        islive = 128u,
+        incomplete = 256u,
+        inoutParam = 512u,
+        inoutQual = 1024u,
+        isctor = 2048u,
     };
 
 public:
     LINK linkage;
     FunctionFlag funcFlags;
     TRUST trust;
+    THROW throw_;
     PURE purity;
     int8_t inuse;
     Array<Expression* >* fargs;
@@ -3581,8 +3594,6 @@ public:
     Type* addStorageClass(StorageClass stc);
     Type* substWildTo(uint32_t _param_0);
     MATCH constConv(Type* to);
-    bool isnothrow() const;
-    void isnothrow(bool v);
     bool isnogc() const;
     void isnogc(bool v);
     bool isproperty() const;
@@ -4555,13 +4566,15 @@ enum class STC : uint64_t
     live = 4503599627370496LLU,
     register_ = 9007199254740992LLU,
     volatile_ = 18014398509481984LLU,
+    throw_ = 36028797018963968LLU,
     safeGroup = 962072674304LLU,
+    throwGroup = 36028797555834880LLU,
     IOR = 268288LLU,
     TYPECTOR = 42983227396LLU,
-    FUNCATTR = 4575000774574080LLU,
-    visibleStorageClasses = 7954966262857631LLU,
+    FUNCATTR = 40603797793538048LLU,
+    visibleStorageClasses = 43983763281821599LLU,
     flowThruAggregate = 962072674304LLU,
-    flowThruFunction = 18446742978991225440LLU,
+    flowThruFunction = 18410714181972261472LLU,
 };
 
 struct ASTCodegen final
@@ -4848,6 +4861,7 @@ struct ASTCodegen final
     using ParameterList = ::ParameterList;
     using RET = ::RET;
     using ScopeRef = ::ScopeRef;
+    using THROWformat = ::THROWformat;
     using TRUSTformat = ::TRUSTformat;
     using Type = ::Type;
     using TypeAArray = ::TypeAArray;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1349,7 +1349,7 @@ extern (C++) class FuncDeclaration : Declaration
         if (tf.trust == TRUST.default_)
             flags |= FUNCFLAG.safetyInprocess;
 
-        if (!tf.isnothrow)
+        if (tf.throw_ == THROW.default_)
             flags |= FUNCFLAG.nothrowInprocess;
 
         if (!tf.isnogc)
@@ -2411,7 +2411,7 @@ extern (C++) class FuncDeclaration : Declaration
             auto fo = cast(TypeFunction)(originalType ? originalType : f);
             auto fparams = toRefCopy(fo.parameterList);
             auto tf = new TypeFunction(ParameterList(fparams), Type.tvoid, LINK.d);
-            tf.isnothrow = f.isnothrow;
+            tf.throw_ = f.throw_;
             tf.isnogc = f.isnogc;
             tf.purity = f.purity;
             tf.trust = f.trust;
@@ -2454,7 +2454,7 @@ extern (C++) class FuncDeclaration : Declaration
             auto fo = cast(TypeFunction)(originalType ? originalType : f);
             fparams.pushSlice((*toRefCopy(fo.parameterList))[]);
             auto tf = new TypeFunction(ParameterList(fparams), Type.tvoid, LINK.d);
-            tf.isnothrow = f.isnothrow;
+            tf.throw_ = f.throw_;
             tf.isnogc = f.isnogc;
             tf.purity = f.purity;
             tf.trust = f.trust;

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1532,7 +1532,7 @@ tym_t totym(Type tx)
                     printf("linkage = %d\n", tf.linkage);
                     assert(0);
             }
-            if (tf.isnothrow)
+            if (tf.throw_ == THROW.nothrow_)
                 t |= mTYnothrow;
             return t;
         }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2870,6 +2870,7 @@ string stcToString(ref StorageClass stc)
         SCstring(STC.immutable_, Token.toString(TOK.immutable_)),
         SCstring(STC.shared_, Token.toString(TOK.shared_)),
         SCstring(STC.nothrow_, Token.toString(TOK.nothrow_)),
+        SCstring(STC.throw_, Token.toString(TOK.throw_)),
         SCstring(STC.wild, Token.toString(TOK.inout_)),
         SCstring(STC.pure_, Token.toString(TOK.pure_)),
         SCstring(STC.ref_, Token.toString(TOK.ref_)),

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -541,6 +541,13 @@ enum class TRUST : unsigned char
     safe = 3       // @safe
 };
 
+enum class THROW : unsigned char
+{
+    default_ = 0,
+    throw_ = 1,   // has throw
+    nothrow_ = 2, // has nothrow
+};
+
 enum TRUSTformat
 {
     TRUSTformatDefault,  // do not emit @system when trust == TRUSTdefault
@@ -598,6 +605,7 @@ public:
     LINK linkage;                // calling convention
     unsigned funcFlags;
     TRUST trust;                 // level of trust
+    THROW throw_;                // whether throw, nothrow or default
     PURE purity;                 // PURExxxx
     char inuse;
     Expressions *fargs;          // function arguments
@@ -615,8 +623,6 @@ public:
     Type *substWildTo(unsigned mod);
     MATCH constConv(Type *to);
 
-    bool isnothrow() const;
-    void isnothrow(bool v);
     bool isnogc() const;
     void isnogc(bool v);
     bool isproperty() const;

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -622,6 +622,10 @@ class Parser(AST) : Lexer
                 stc = STC.nothrow_;
                 goto Lstc;
 
+            case TOK.throw_:
+                stc = STC.throw_;
+                goto Lstc;
+
             case TOK.pure_:
                 stc = STC.pure_;
                 goto Lstc;
@@ -1233,6 +1237,12 @@ class Parser(AST) : Lexer
             if (u & (u - 1))
                 error("conflicting attribute `%s`", Token.toChars(token.value));
         }
+        if (added & STC.throwGroup)
+        {
+            StorageClass u = orig & STC.throwGroup;
+            if (u & (u - 1))
+                error("conflicting attribute `%s`", Token.toChars(token.value));
+        }
         if (added & STC.safeGroup)
         {
             StorageClass u = orig & STC.safeGroup;
@@ -1327,6 +1337,10 @@ class Parser(AST) : Lexer
 
             case TOK.nothrow_:
                 stc = STC.nothrow_;
+                break;
+
+            case TOK.throw_:
+                stc = STC.throw_;
                 break;
 
             case TOK.pure_:
@@ -4168,6 +4182,10 @@ class Parser(AST) : Lexer
 
             case TOK.nothrow_:
                 stc = STC.nothrow_;
+                goto L1;
+
+            case TOK.throw_:
+                stc = STC.throw_;
                 goto L1;
 
             case TOK.pure_:

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -107,7 +107,7 @@ int callSideEffectLevel(FuncDeclaration f)
         return 0;
     assert(f.type.ty == Tfunction);
     TypeFunction tf = cast(TypeFunction)f.type;
-    if (!tf.isnothrow)
+    if (tf.throw_ != THROW.nothrow_)
         return 0;
     final switch (f.isPure())
     {
@@ -132,7 +132,7 @@ int callSideEffectLevel(Type t)
         assert(t.ty == Tfunction);
         tf = cast(TypeFunction)t;
     }
-    if (!tf.isnothrow)  // function can throw
+    if (tf.throw_ != THROW.nothrow_)  // function can throw
         return 0;
 
     tf.purityLevel();

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -1478,7 +1478,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
              * function with the name "toHash".
              * So I'm leaving this here as an experiment for the moment.
              */
-            if (!tf.isnothrow || tf.trust == TRUST.system /*|| tf.purity == PURE.impure*/)
+            if (tf.throw_ != THROW.nothrow_ || tf.trust == TRUST.system /*|| tf.purity == PURE.impure*/)
                 warning(fd.loc, "toHash() must be declared as extern (D) size_t toHash() const nothrow @safe, not %s", tf.toChars());
         }
         else

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1327,7 +1327,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             mods.push(new StringExp(Loc.initial, str));
         }
         tf.modifiersApply(&addToMods);
-        tf.attributesApply(&addToMods, TRUSTformatSystem);
+        tf.attributesApply(&addToMods, TRUSTformatSystem, THROWformatThrow);
 
         auto tup = new TupleExp(e.loc, mods);
         return tup.expressionSemantic(sc);
@@ -1790,7 +1790,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                     if (sc2.func && sc2.func.type.ty == Tfunction)
                     {
                         const tf = cast(TypeFunction)sc2.func.type;
-                        err |= tf.isnothrow && canThrow(ex, sc2.func, false);
+                        err |= tf.throw_ == THROW.nothrow_ && canThrow(ex, sc2.func, false);
                     }
                     ex = checkGC(sc2, ex);
                     if (ex.op == EXP.error)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1177,8 +1177,6 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
         if (sc.stc & STC.pure_)
             tf.purity = PURE.fwdref;
-        if (sc.stc & STC.nothrow_)
-            tf.isnothrow = true;
         if (sc.stc & STC.nogc)
             tf.isnogc = true;
         if (sc.stc & STC.ref_)
@@ -1194,6 +1192,14 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
 //        if (tf.isreturn && !tf.isref)
 //            tf.isScopeQual = true;                                  // return by itself means 'return scope'
+
+        if (tf.throw_ == THROW.default_)
+        {
+            if (sc.stc & STC.nothrow_)
+                tf.throw_ = THROW.nothrow_;
+            else if (sc.stc & STC.throw_)
+                tf.throw_ = THROW.throw_;
+        }
 
         if (tf.trust == TRUST.default_)
         {
@@ -3715,7 +3721,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 fd_aaLen = FuncDeclaration.genCfunc(fparams, Type.tsize_t, Id.aaLen);
                 TypeFunction tf = fd_aaLen.type.toTypeFunction();
                 tf.purity = PURE.const_;
-                tf.isnothrow = true;
+                tf.throw_ = THROW.nothrow_;
                 tf.isnogc = false;
             }
             Expression ev = new VarExp(e.loc, fd_aaLen, false);

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -395,7 +395,7 @@ void test_types()
     StorageClass stc = STCnothrow|STCproperty|STCreturn|STCreturninferred|STCtrusted;
     TypeFunction *tfunction = TypeFunction::create(args, Type::tvoid, VARARGnone, LINK::d, stc);
 
-    assert(tfunction->isnothrow());
+    assert(tfunction->throw_ == THROW::nothrow_);
     assert(!tfunction->isnogc());
     assert(tfunction->isproperty());
     assert(!tfunction->isref());

--- a/test/compilable/dip1029.d
+++ b/test/compilable/dip1029.d
@@ -1,0 +1,109 @@
+
+void foo() {}
+
+void foobar() throw {}
+void bar() nothrow {}
+
+nothrow {
+    void n_t() throw;
+    void n();
+}
+
+void _t();
+void t() throw;
+
+
+struct S {
+    void foo() {
+        _t();
+        t();
+        n_t();
+    }
+}
+
+static assert(is(typeof(&S.foo) == void function()));
+
+// class inheritance
+class CA {
+    void foo() throw;
+}
+
+class CB : CA {
+    override void foo() @nogc;
+}
+
+static assert(is(typeof(&CA.foo) == void function() throw));
+static assert(is(typeof(&CB.foo) == void function() throw @nogc));
+
+
+// inferred types and attributes for lambdas
+static assert(is(typeof(() {}) == void function() pure nothrow @nogc @safe));
+static assert(is(typeof(() { throw new Exception(""); }) == void function() pure @safe));
+static assert(is(typeof(function() throw { throw new Exception(""); }) == void function() pure throw @safe));
+
+// check if default throw is the same as with explicit throw
+static assert(is(void function() pure throw @safe == void function() pure @safe));
+
+auto abc()
+{
+    int localvar;
+    static assert(is(typeof(() => localvar) == int delegate() pure nothrow @nogc @safe));
+    static assert(is(typeof(delegate() throw => localvar) == int delegate() pure throw @nogc @safe));
+
+    return localvar;
+}
+
+// check if functions has correct types
+static assert(is(typeof(&foo) == void function()));
+static assert(is(typeof(&foobar) == void function() throw));
+static assert(is(typeof(&bar) == void function() nothrow));
+static assert(is(typeof(&n_t) == void function() throw));
+static assert(is(typeof(&n) == void function() nothrow));
+static assert(is(typeof(&_t) == void function()));
+static assert(is(typeof(&t) == void function() throw));
+static assert(is(typeof(&t2) == void function() throw));
+static assert(is(typeof(&n2) == void function() nothrow));
+
+void funcDefault() @system pure @nogc;
+void funcThrow() @system pure @nogc throw;
+void funcNothrow() @system pure @nogc nothrow;
+
+// test getFunctionAttributes
+static assert([__traits(getFunctionAttributes, funcDefault)] == ["pure", "throw", "@nogc", "@system"]);
+static assert([__traits(getFunctionAttributes, funcThrow)] == ["pure", "throw", "@nogc", "@system"]);
+static assert([__traits(getFunctionAttributes, funcNothrow)] == ["pure", "nothrow", "@nogc", "@system"]);
+
+void func()
+{
+    alias FnT = void function() throw;
+    alias FnN = void function() nothrow;
+
+    FnN fnn = () {};
+    FnT fnt = () { throw new Exception(""); };
+
+    static assert(!__traits(compiles, { fnn = fnt; })); // throw -> nothrow
+    static assert(__traits(compiles, { fnt = fnn; }));  // nothrow -> throw
+}
+
+// check template inference
+void funcNothrowT()() {}
+static assert(is(typeof(&funcNothrowT!()) == void function() nothrow @nogc @safe pure));
+void funcExplicitThrowT()() throw {}
+static assert(is(typeof(&funcExplicitThrowT!()) == void function() throw @nogc @safe pure));
+// should be the same without throw
+static assert(is(typeof(&funcExplicitThrowT!()) == void function() @nogc @safe pure));
+
+void funcThrowT()() {
+    throw new Exception("");
+}
+static assert(is(typeof(&funcThrowT!()) == void function() throw @safe pure));
+// should be the same without throw
+static assert(is(typeof(&funcThrowT!()) == void function() @safe pure));
+
+
+nothrow:
+    void t2() throw;
+
+throw:
+    void n2() nothrow;
+

--- a/test/compilable/hdrgen_dip1029.d
+++ b/test/compilable/hdrgen_dip1029.d
@@ -1,0 +1,61 @@
+/*
+REQUIRED_ARGS: -o- -Hf${RESULTS_DIR}/compilable/hdrgen_dip1029.di
+PERMUTE_ARGS:
+OUTPUT_FILES: ${RESULTS_DIR}/compilable/hdrgen_dip1029.di
+
+TEST_OUTPUT:
+---
+=== ${RESULTS_DIR}/compilable/hdrgen_dip1029.di
+// D import file generated from 'compilable/hdrgen_dip1029.d'
+module foo.bar.foobar.baz;
+void foo();
+throw void foobar();
+nothrow void bar();
+nothrow
+{
+	throw void n_t();
+	void n();
+}
+void _t();
+throw void t();
+struct S
+{
+	throw void foo();
+}
+class C
+{
+	throw void foo();
+}
+throw
+{
+	void t2();
+	nothrow void n2();
+}
+---
+*/
+module foo.bar.foobar.baz;
+
+void foo() {}
+
+void foobar() throw {}
+void bar() nothrow {}
+
+nothrow {
+    void n_t() throw;
+    void n();
+}
+
+void _t();
+void t() throw;
+
+struct S {
+    void foo() throw;
+}
+
+class C {
+    void foo() throw;
+}
+
+throw:
+    void t2();
+    void n2() nothrow;

--- a/test/fail_compilation/dip1029_1.d
+++ b/test/fail_compilation/dip1029_1.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/dip1029_1.d(101): Error: redundant attribute `throw`
+fail_compilation/dip1029_1.d(102): Error: conflicting attribute `nothrow`
+---
+ */
+
+#line 100
+
+void tt() throw throw;
+void tn() throw nothrow;
+

--- a/test/fail_compilation/dip1029_2.d
+++ b/test/fail_compilation/dip1029_2.d
@@ -1,0 +1,29 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/dip1029_2.d(211): Error: function `dip1029_2._t` is not `nothrow`
+fail_compilation/dip1029_2.d(212): Error: function `dip1029_2.t` is not `nothrow`
+fail_compilation/dip1029_2.d(213): Error: function `dip1029_2.n_t` is not `nothrow`
+fail_compilation/dip1029_2.d(210): Error: `nothrow` function `dip1029_2.S1.foo` may throw
+---
+ */
+
+#line 200
+
+nothrow {
+    void n_t() throw;
+    void n_n();
+}
+
+void _t();
+void t() throw;
+
+struct S1 {
+    nothrow void foo() {
+        _t();
+        t();
+        n_t();
+        n_n();
+    }
+}
+


### PR DESCRIPTION
https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1029.md

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

- [x] Specification PR (https://github.com/dlang/dlang.org/pull/3082)
- [x] DMD Implementation
- [x] Tests
  - [x] Header generation of `throw`
  - [x] Templated functions: do they infer default or `throw`? how does that interact with toplevel `throw`/`nothrow`?
  - [ ] throw virtual functions that are overriden with `nothrow`
  - [x] more cases for `throw:`/`nothrow:` interacting with function/template declarations
  - [x] Add tests with `__traits(getFunctionAttributes, func)`
  - [ ] Cast `nothrow` to `throw`
  - [ ] Check for forbidden cast of `throw` to `nothrow`

CC: @WalterBright 