### PR TITLE
Replace SCOPE.ctor with FunctionFlag.isctor

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2995,7 +2995,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (funcdecl.isCtorDeclaration())
             {
-                sc.flags |= SCOPE.ctor;
+                tf.isctor = true;
                 Type tret = ad.handleType();
                 assert(tret);
                 tret = tret.addStorageClass(funcdecl.storage_class | sc.stc);

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -2404,7 +2404,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         {
             // For constructors, emitting return type is necessary for
             // isReturnIsolated() in functionResolve.
-            scx.flags |= SCOPE.ctor;
+            tf.isctor = true;
 
             Dsymbol parent = toParentDecl();
             Type tret;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3371,6 +3371,7 @@ private:
         incomplete = 512u,
         inoutParam = 1024u,
         inoutQual = 2048u,
+        isctor = 4096u,
     };
 
 public:
@@ -3416,6 +3417,8 @@ public:
     bool isInOutQual() const;
     void isInOutQual(bool v);
     bool iswild() const;
+    bool isctor() const;
+    void isctor(bool v);
     bool attributesEqual(const TypeFunction* const other) const;
     void accept(Visitor* v);
 };

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4108,6 +4108,7 @@ extern (C++) final class TypeFunction : TypeNext
         incomplete      = 0x0200, // return type or default arguments removed
         inoutParam      = 0x0400, // inout on the parameters
         inoutQual       = 0x0800, // inout on the qualifier
+        isctor          = 0x1000, // the function is a constructor
     }
 
     LINK linkage;               // calling convention
@@ -4186,6 +4187,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isInOutQual = isInOutQual;
         t.trust = trust;
         t.fargs = fargs;
+        t.isctor = isctor;
         return t;
     }
 
@@ -4460,6 +4462,7 @@ extern (C++) final class TypeFunction : TypeNext
             tf.trust = t.trust;
             tf.isInOutParam = t.isInOutParam;
             tf.isInOutQual = t.isInOutQual;
+            tf.isctor = t.isctor;
 
             if (stc & STC.pure_)
                 tf.purity = PURE.fwdref;
@@ -4526,6 +4529,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isInOutQual = false;
         t.trust = trust;
         t.fargs = fargs;
+        t.isctor = isctor;
         return t.merge();
     }
 
@@ -5124,6 +5128,18 @@ extern (C++) final class TypeFunction : TypeNext
     bool iswild() const pure nothrow @safe @nogc
     {
         return (funcFlags & (FunctionFlag.inoutParam | FunctionFlag.inoutQual)) != 0;
+    }
+
+    /// set or get if the function is a constructor
+    bool isctor() const pure nothrow @safe @nogc
+    {
+        return (funcFlags & FunctionFlag.isctor) != 0;
+    }
+    /// ditto
+    void isctor(bool v) pure nothrow @safe @nogc
+    {
+        if (v) funcFlags |= FunctionFlag.isctor;
+        else funcFlags &= ~FunctionFlag.isctor;
     }
 
     /// Returns: whether `this` function type has the same attributes (`@safe`,...) as `other`

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1326,7 +1326,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
         {
             sc = sc.push();
             if (funcdecl.isCtorDeclaration()) // https://issues.dlang.org/show_bug.cgi?id=#15665
-                sc.flags |= SCOPE.ctor;
+                f.isctor = true;
             sc.stc = 0;
             sc.linkage = funcdecl.linkage; // https://issues.dlang.org/show_bug.cgi?id=8496
             funcdecl.type = f.typeSemantic(funcdecl.loc, sc);

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1238,7 +1238,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             tf.next = tf.next.typeSemantic(loc, sc);
             sc = sc.pop();
             errors |= tf.checkRetType(loc);
-            if (tf.next.isscope() && !(sc.flags & SCOPE.ctor))
+            if (tf.next.isscope() && !tf.isctor)
             {
                 .error(loc, "functions cannot return `scope %s`", tf.next.toChars());
                 errors = true;
@@ -1482,9 +1482,8 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                  */
                 /* Constructors are treated as if they are being returned through the hidden parameter,
                  * which is by ref, and the ref there is ignored.
-                 * TODO: check buildScopeRef() inconsistent behavior on SCOPE.ctor
                  */
-                const returnByRef = tf.isref && !(sc.flags & SCOPE.ctor);
+                const returnByRef = tf.isref && !tf.isctor;
                 const sr = buildScopeRef(returnByRef, fparam.storageClass);
                 switch (sr)
                 {


### PR DESCRIPTION
The only purpose of `SCOPE.ctor` is to pass a flag to the semantic routines. But this is clumsy and brittle, and causes problems when later passes need to check if the type is a constructor or not. I replaced it with a bit in the type itself.