### PR TITLE
[DSSv3] Fix Issue 15828 - DMD should refuse comparing unions

### DIFF
--- a/changelog/union-comparison.dd
+++ b/changelog/union-comparison.dd
@@ -1,0 +1,23 @@
+Comparing unions that do not overload opEquals now triggers an error
+
+Previously, DMD would compare unions that did not define `opEquals` by using
+`memcmp`. This was problematic because:
+1. The comparison would be nonsense between variables that use different fields
+of the union
+2. If some of the members of the union did define `opEquals`, DMD would not know
+which of them to call, as it would not know which of them was valid.
+
+In order to avoid these scenarios, DMD can no longer compile unions without
+`opEquals` and outputs an error that suggests implementing `opEquals`.
+
+Example:
+```
+union U(T1, T2)
+{
+    T1 a;
+    T2 b;
+}
+
+U!(int, float) u1, u2;
+u1 == u2;  // this triggers the error
+```

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1007,6 +1007,19 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 if (sd != (cast(TypeStruct)t2).sym)
                     return;
 
+                 /* https://issues.dlang.org/show_bug.cgi?id=15828
+                 * Do not allow comparisons between union types unless opEquals
+                 * is defined.
+                 */
+                if (sd.isUnionDeclaration())
+                {
+                    e.error("union type `%s` should define opEquals",
+                        t1.toChars(), t2.toChars());
+                    result = ErrorExp.get();
+
+                    return;
+                }
+
                 import dmd.clone : needOpEquals;
                 if (!global.params.fieldwise && !needOpEquals(sd))
                 {

--- a/test/fail_compilation/test15828.d
+++ b/test/fail_compilation/test15828.d
@@ -1,0 +1,20 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test15828.d(19): Error: union type `U!(int, float)` should define opEquals
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=15828
+
+union U(T1, T2)
+{
+    T1 a;
+    T2 b;
+}
+
+void main()
+{
+    U!(int, float) u1, u2;
+    assert (u1 == u2);
+}

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -728,16 +728,13 @@ bool test3789()
         auto ua2 = UnionA([1,2,3]);
         assert(ua1.u.x is ua2.u.x);
         assert(ua1.u.x != ua2.u.x);
-        assert(ua1 != ua2);
         ua1.u.x = 1.0;
         ua2.u.x = 1.0;
         assert(ua1.u.x is ua2.u.x);
         assert(ua1.u.x == ua2.u.x);
-        assert(ua1 == ua2);
         ua1.u.x = double.nan;
         assert(ua1.u.x !is ua2.u.x);
         assert(ua1.u.x !=  ua2.u.x);
-        assert(ua1 != ua2);
 
         union U2
         {
@@ -750,16 +747,13 @@ bool test3789()
         }
         auto ub1 = UnionB(1.0);
         auto ub2 = UnionB(1.0);
-        assert(ub1 == ub2);
         ub1.u.a = [1,2,3].dup;
         ub2.u.a = [1,2,3].dup;
         assert(ub1.u.a !is ub2.u.a);
         assert(ub1.u.a  == ub2.u.a);
-        assert(ub1 == ub2);
         ub2.u.a = ub1.u.a;
         assert(ub1.u.a is ub2.u.a);
         assert(ub1.u.a == ub2.u.a);
-        assert(ub1 == ub2);
     }
 
     if (!__ctfe)


### PR DESCRIPTION
Changes:
- Add check in `dmd/opover.d` to verify if the compared structs are
unions and output an error if the check passes
- Verify the error by `tests/fail_compilation/test15828.d`
- Add `changelog/union-comparison.dd` to explain these changes