### PR TITLE
emit ref return scope in canonical order

### DIFF
--- a/test/fail_compilation/fail20730b.d
+++ b/test/fail_compilation/fail20730b.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 ---
 (spec:1) fail_compilation/fail20730b.d-mixin-43(43): Error: C style cast illegal, use `cast(int)mod`
 fail_compilation/fail20730b.d(26): Error: template `fail20730b.atomicOp` cannot deduce function from argument types `!("+=")(shared(uint), int)`, candidates are:
-fail_compilation/fail20730b.d(41):        `atomicOp(string op, T, V1)(ref shared T val, V1 mod)`
+fail_compilation/fail20730b.d(41):        `atomicOp(string op, T, V1)(shared ref T val, V1 mod)`
   with `op = "+=",
        T = uint,
        V1 = int`

--- a/test/fail_compilation/pull12941.d
+++ b/test/fail_compilation/pull12941.d
@@ -1,0 +1,31 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/pull12941.d(110): Error: `pull12941.foo` called with argument types `(int*)` matches both:
+fail_compilation/pull12941.d(101):     `pull12941.foo(ref return scope int* p)`
+and:
+fail_compilation/pull12941.d(102):     `pull12941.foo(out return scope int* p)`
+fail_compilation/pull12941.d(111): Error: function `pull12941.bar(return scope int* p)` is not callable using argument types `(int)`
+fail_compilation/pull12941.d(111):        cannot pass argument `1` of type `int` to parameter `return scope int* p`
+fail_compilation/pull12941.d(112): Error: function `pull12941.abc(return ref int* p)` is not callable using argument types `(int)`
+fail_compilation/pull12941.d(112):        cannot pass rvalue argument `1` of type `int` to parameter `return ref int* p`
+---
+ */
+
+/*********************************/
+// Tests for https://github.com/dlang/dmd/pull/12941
+
+#line 100
+
+int* foo(ref scope return int* p);
+int* foo(out scope return int* p);
+
+int* bar(scope return int* p);
+int* abc(ref return int* p);
+
+void test()
+{
+    int* p;
+    foo(p);
+    bar(1);
+    abc(1);
+}


### PR DESCRIPTION
Currently, storage classes are emitted in a completely arbitrary order. I am slowly working towards resolving the `ref return scope` ambiguity, and this means emitting `ref return scope` in an order depending on whether `return ref` or `return scope` is meant.

The order is changed only if all three of `ref return scope` are present.