### PR TITLE
Fix Issue 22118 - Const union causes false multiple-initialization error in constructor

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4817,13 +4817,17 @@ extern (C++) final class DotVarExp : UnaExp
                                 /* checkModify will consider that this is an initialization
                                  * of v while it is actually an assignment of a field of v
                                  */
-                                scope modifyLevel = v.checkModify(loc, sc, dve.e1, flag);
-                                // reflect that assigning a field of v is not initialization of v
-                                // unless v is a (potentially nested) union
-                                if (!onlyUnion)
-                                    v.ctorinit = false;
+                                scope modifyLevel = v.checkModify(loc, sc, dve.e1, !onlyUnion ? (flag | 2) : flag);
                                 if (modifyLevel == Modifiable.initialization)
+                                {
+                                    // https://issues.dlang.org/show_bug.cgi?id=22118
+                                    // v is a union type field that was assigned
+                                    // a variable, therefore it counts as initialization
+                                    if (v.ctorinit)
+                                        return Modifiable.initialization;
+
                                     return Modifiable.yes;
+                                }
                                 return modifyLevel;
                             }
                         }

--- a/test/fail_compilation/fail22118.d
+++ b/test/fail_compilation/fail22118.d
@@ -1,0 +1,36 @@
+// https://issues.dlang.org/show_bug.cgi?id=22118
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail22118.d(33): Error: cannot modify `this.v.a` in `const` function
+---
+*/
+
+struct NeedsInit
+{
+    int n;
+    @disable this();
+}
+
+union U
+{
+    NeedsInit a;
+}
+
+struct V
+{
+    NeedsInit a;
+}
+
+struct S
+{
+    U u;
+    V v;
+    this(const NeedsInit arg) const
+    {
+        u.a = arg;   // this should compile
+        v.a = arg;   // this should not
+    }
+}
+


### PR DESCRIPTION
Re-submission of: https://github.com/dlang/dmd/pull/12875. Revert PR that contains the discussion: https://github.com/dlang/dmd/pull/12881

- applied Walter's feedback

> Why can't fieldInit be set correctly in modifyFieldVar?

- Because modifyFieldVar is called from different contexts for VarDeclarations. This patch is regarding only DotVarExps and it requires information that is specific to this AST node. IMO it should be placed in checkModifiable of DotVarExp so that other Expressions do not suffer from useless checks and possible overturns.

> Change subverts the AST.

- I think that this is an exaggeration. It does not do anything like creating or deleting nodes, it simply corrects a field that keeps track of the initialization status of variable.

I understand that the merge was hasty, so thank you for reconsidering this.

cc @ibuclaw , @WalterBright 