### PR TITLE
runnable: Remove __extension__ from preprocessed code in importC test

### DIFF
--- a/test/runnable/extra-files/importc_test.c
+++ b/test/runnable/extra-files/importc_test.c
@@ -1,3 +1,4 @@
+#define __extension__ /* remove keyword from preprocessed code. */
 
 #include <stdint.h>
 


### PR DESCRIPTION
At least 32-bit Linux fails otherwise because of not being able to handle code like:
```
__extension__
typedef long long int           int_fast64_t;
__extension__
typedef unsigned long long int  uint_fast64_t;
```