### PR TITLE
dtoh: Do not emit aliases to declarations as typedef

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -26,6 +26,7 @@ experimental C++ header generator:
 - No longer omits the parent aggregate when referencing `__gshared` variables
 - No longer uses D syntax for expressions nested in unary / binary expressions
 - Does not emit `public:`, ... inside of anonymous structs/unions
+- Does not emit `typedef` for aliases to declaration symbols
 
 Note: The header generator is still considerer experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -840,7 +840,7 @@ public:
         if (vd.type && vd.type.isTypeTuple())
             return;
 
-        if (vd.type == AST.Type.tsize_t)
+        if (vd.originalType && vd.type == AST.Type.tsize_t)
             origType = &vd.originalType;
         scope(exit) origType = null;
 
@@ -998,14 +998,14 @@ public:
 
         if (auto t = ad.type)
         {
-            if (t.ty == AST.Tdelegate)
+            if (t.ty == AST.Tdelegate || t.ty == AST.Tident)
             {
                 visit(cast(AST.Dsymbol)ad);
                 return;
             }
 
             // for function pointers we need to original type
-            if (ad.type.ty == AST.Tpointer &&
+            if (ad.originalType && ad.type.ty == AST.Tpointer &&
                 (cast(AST.TypePointer)t).nextOf.ty == AST.Tfunction)
             {
                 origType = &ad.originalType;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -417,8 +417,6 @@ struct Array final
     void shift(T ptr);
     void zero();
     T pop();
-    typedef length opDollar;
-    typedef length dim;
     Array()
     {
     }

--- a/test/compilable/dtoh_AliasDeclaration.d
+++ b/test/compilable/dtoh_AliasDeclaration.d
@@ -121,6 +121,18 @@ struct PrivateImport final
 };
 
 typedef /* noreturn */ char Impossible[0];
+
+template <typename T>
+struct Array final
+{
+    // Ignoring var length alignment 0
+    uint32_t length;
+    Array()
+    {
+    }
+};
+
+typedef Array<char > DString;
 ---
 +/
 
@@ -195,3 +207,11 @@ struct PrivateImport
 }
 
 alias Impossible = noreturn;
+
+struct Array(T)
+{
+    uint length;
+    alias opDollar = length;
+    alias dim = length;
+}
+alias DString = Array!(char);


### PR DESCRIPTION
The test case also revealed an ICE where `originalType` can be null even though `type == Type.tsize_t`.  i.e: `uint` or `ulong` was used instead of `size_t`.