### PR TITLE
CirrusCI: Bump Ubuntu image to 18.04

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,9 +42,9 @@ coverage_environment_template: &COVERAGE_ENVIRONMENT_TEMPLATE
 
 # Linux
 task:
-  name: Ubuntu 16.04 $TASK_NAME_SUFFIX
+  name: Ubuntu 18.04 $TASK_NAME_SUFFIX
   container:
-    image: ubuntu:16.04
+    image: ubuntu:18.04
     cpu: 4
     memory: 8G
   timeout_in: 60m
@@ -57,7 +57,7 @@ task:
         << : *COVERAGE_ENVIRONMENT_TEMPLATE
       - TASK_NAME_SUFFIX: x86, DMD (bootstrap)
         MODEL: 32
-        HOST_DMD: dmd-2.079.0
+        HOST_DMD: dmd-2.097.1
       - TASK_NAME_SUFFIX: x64, DMD (latest)
       # Enable this to replace coverage tests on CircleCI
       # - TASK_NAME_SUFFIX: x64, DMD (coverage)
@@ -65,9 +65,7 @@ task:
       - TASK_NAME_SUFFIX: x64, DMD (bootstrap)
         HOST_DMD: dmd-2.079.0
       - TASK_NAME_SUFFIX: x64, LDC
-        # Starting from LDC v1.27.0, a symbol for GLIBC_2.27 is required,
-        # which doesn't work on 16.04 anymore.
-        HOST_DC: ldc-1.26.0 #TODO: Update to HOST_DMD when support for HOST_DC is removed
+        HOST_DC: ldc #TODO: Update to HOST_DMD when support for HOST_DC is removed
       - TASK_NAME_SUFFIX: x64, GDC
         HOST_DMD: gdmd-9
   << : *COMMON_STEPS_TEMPLATE

--- a/ci.sh
+++ b/ci.sh
@@ -22,13 +22,15 @@ if [ -z ${CI_DFLAGS+x} ] ; then CI_DFLAGS=""; fi
 CURL_USER_AGENT="DMD-CI $(curl --version | head -n 1)"
 build_path=generated/$OS_NAME/release/$MODEL
 
-# use faster ld.gold linker on linux
 if [ "$OS_NAME" == "linux" ]; then
-    mkdir -p linker
-    rm -f linker/ld
-    ln -s /usr/bin/ld.gold linker/ld
+    # use faster ld.gold linker on x86_64-linux
+    if [ "$MODEL" == "64" ]; then
+        mkdir -p linker
+        rm -f linker/ld
+        ln -s /usr/bin/ld.gold linker/ld
+        export PATH="$PWD/linker:$PATH"
+    fi
     NM="nm --print-size"
-    export PATH="$PWD/linker:$PATH"
 else
     NM=nm
 fi

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -15,10 +15,11 @@ if [ ! -z ${HOST_DC+x} ] ; then HOST_DMD=${HOST_DC}; fi
 if [ -z ${HOST_DMD+x} ] ; then echo "Variable 'HOST_DMD' needs to be set."; exit 1; fi
 
 if [ "$OS_NAME" == "linux" ]; then
-  packages="git-core make g++ gdb curl libcurl3 tzdata zip unzip xz-utils"
+  export DEBIAN_FRONTEND=noninteractive
+  packages="git-core make g++ gdb curl libcurl4 tzdata zip unzip xz-utils"
   if [ "$MODEL" == "32" ]; then
     dpkg --add-architecture i386
-    packages="$packages g++-multilib libcurl3-gnutls:i386"
+    packages="$packages g++-multilib libcurl4:i386"
   fi
   if [ "${HOST_DMD:0:4}" == "gdmd" ]; then
     # ci.sh uses `sudo add-apt-repository ...` to add a PPA repo


### PR DESCRIPTION
Assessing the damage and how long we may have to wait until enough releases have occurred for it to be trusted.

The assumption is that the first capable release of supporting Ubuntu 18.04 on all architectures DMD supports will be 2.097.2.