### PR TITLE
ImportC: allow multiple alignment-specifiers

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -694,7 +694,8 @@ extern (C++) final class VisibilityDeclaration : AttribDeclaration
  */
 extern (C++) final class AlignDeclaration : AttribDeclaration
 {
-    Expression ealign;                              /// expression yielding the actual alignment
+    Expressions* exps;                              /// Expression(s) yielding the desired alignment,
+                                                    /// the largest value wins
     enum structalign_t UNKNOWN = 0;                 /// alignment not yet computed
     static assert(STRUCTALIGN_DEFAULT != UNKNOWN);
 
@@ -703,17 +704,28 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
     structalign_t salign = UNKNOWN;
 
 
-    extern (D) this(const ref Loc loc, Expression ealign, Dsymbols* decl)
+    extern (D) this(const ref Loc loc, Expression exp, Dsymbols* decl)
     {
         super(loc, null, decl);
-        this.ealign = ealign;
+        if (exp)
+        {
+            if (!exps)
+                exps = new Expressions();
+            exps.push(exp);
+        }
+    }
+
+    extern (D) this(const ref Loc loc, Expressions* exps, Dsymbols* decl)
+    {
+        super(loc, null, decl);
+        this.exps = exps;
     }
 
     override AlignDeclaration syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new AlignDeclaration(loc,
-            ealign ? ealign.syntaxCopy() : null,
+            Expression.arraySyntaxCopy(exps),
             Dsymbol.arraySyntaxCopy(decl));
     }
 

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -121,7 +121,7 @@ public:
 class AlignDeclaration : public AttribDeclaration
 {
 public:
-    Expression *ealign;
+    Expressions *alignExps;
     structalign_t salign;
 
     AlignDeclaration(const Loc &loc, Expression *ealign, Dsymbols *decl);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5073,7 +5073,7 @@ public:
 class AlignDeclaration final : public AttribDeclaration
 {
 public:
-    Expression* ealign;
+    Array<Expression* >* exps;
     enum : uint32_t { UNKNOWN = 0u };
 
     uint32_t salign;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -995,16 +995,21 @@ public:
 
     override void visit(AlignDeclaration d)
     {
-        buf.writestring("align ");
-        if (d.ealign)
+        if (d.exps)
         {
-            buf.printf("(%s)", d.ealign.toChars());
-            AttribDeclaration ad = cast(AttribDeclaration)d;
-            if (ad.decl && ad.decl.dim < 2)
+            foreach (i, exp; (*d.exps)[])
+            {
+                if (i)
+                    buf.writeByte(' ');
+                buf.printf("align (%s)", exp.toChars());
+            }
+            if (d.decl && d.decl.dim < 2)
                 buf.writeByte(' ');
         }
+        else
+            buf.writestring("align ");
 
-        visit(cast(AttribDeclaration)d);
+        visit(d.isAttribDeclaration());
     }
 
     override void visit(AnonDeclaration d)

--- a/test/compilable/alignas.c
+++ b/test/compilable/alignas.c
@@ -2,7 +2,7 @@
 
 int printf(const char *, ...);
 
-_Alignas(8) int x = 5;
+_Alignas(4) _Alignas(8) _Alignas(0) int x = 5;
 _Static_assert(_Alignof(x) == 8, "in");
 
 _Alignas(int) short y = 6;

--- a/test/fail_compilation/fail9766.d
+++ b/test/fail_compilation/fail9766.d
@@ -2,11 +2,11 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail9766.d(14): Error: integer constant expression expected instead of `Foo!int`
-fail_compilation/fail9766.d(14): Error: alignment must be an integer positive power of 2, not Foo!int
-fail_compilation/fail9766.d(17): Error: alignment must be an integer positive power of 2, not -1
-fail_compilation/fail9766.d(20): Error: alignment must be an integer positive power of 2, not 0
-fail_compilation/fail9766.d(23): Error: alignment must be an integer positive power of 2, not 3
-fail_compilation/fail9766.d(26): Error: alignment must be an integer positive power of 2, not 2147483649u
+fail_compilation/fail9766.d(14): Error: alignment must be an integer positive power of 2, not 0x0
+fail_compilation/fail9766.d(17): Error: alignment must be an integer positive power of 2, not 0xffffffffffffffff
+fail_compilation/fail9766.d(20): Error: alignment must be an integer positive power of 2, not 0x0
+fail_compilation/fail9766.d(23): Error: alignment must be an integer positive power of 2, not 0x3
+fail_compilation/fail9766.d(26): Error: alignment must be an integer positive power of 2, not 0x80000001
 ---
 */
 


### PR DESCRIPTION
Because C11 6.7.5-6 says so.

Take care of some tricky differences with D vs C11 as C11 allows alignments of 0, D does not.

A remaining problem is C11 doesn's allow alignments smaller than the default for the type being aligned. That'll have to be handled elsewhere in the compiler, as getAttribute() does not know which object it will be applied to.

Will add some tests after this doesn't break anything, so WIP.