### PR TITLE
ImportC: add error checking for _Alignas

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1532,6 +1532,11 @@ final class CParser(AST) : Parser!AST
                     break;
             }
 
+            if (specifier.ealign && dt.isTypeFunction())
+                error("no alignment-specifier for function declaration"); // C11 6.7.5-2
+            if (specifier.ealign && specifier.scw == SCW.xregister)
+                error("no alignment-specifier for `register` storage class"); // C11 6.7.5-2
+
             /* C11 6.9.1 Function Definitions
              * function-definition:
              *   declaration-specifiers declarator declaration-list (opt) compound-statement
@@ -1564,6 +1569,8 @@ final class CParser(AST) : Parser!AST
             {
                 if (token.value == TOK.assign)
                     error("no initializer for typedef declaration");
+                if (specifier.ealign)
+                    error("no alignment-specifier for typedef declaration"); // C11 6.7.5-2
 
                 bool isalias = true;
                 if (auto ts = dt.isTypeStruct())
@@ -1732,7 +1739,7 @@ final class CParser(AST) : Parser!AST
                 foreach (s; (*symbols)[]) // yes, quadratic
                 {
                     auto d = s.isDeclaration();
-                    if (p.ident == d.ident && d.type)
+                    if (d && p.ident == d.ident && d.type)
                     {
                         p.type = d.type;
                         p.storageClass = d.storage_class;
@@ -2002,6 +2009,10 @@ final class CParser(AST) : Parser!AST
                      * _Alignas ( type-name )
                      * _Alignas ( constant-expression )
                      */
+
+                    if (level & (LVL.parameter | LVL.prototype))
+                        error("no alignment-specifier for parameters"); // C11 6.7.5-2
+
                     nextToken();
                     check(TOK.leftParenthesis);
                     auto tk = &token;
@@ -3057,6 +3068,8 @@ final class CParser(AST) : Parser!AST
             if (token.value == TOK.colon)
             {
                 // C11 6.7.2.1-12 unnamed bit-field
+                if (specifier.ealign)
+                    error("no alignment-specifier for bit field declaration"); // C11 6.7.5-2
                 nextToken();
                 cparseConstantExp();
                 error("unnamed bit fields are not supported"); // TODO
@@ -3073,8 +3086,13 @@ final class CParser(AST) : Parser!AST
             if (id && token.value == TOK.colon)
             {
                 // C11 6.7.2.1-10 bit-field
+
+                if (specifier.ealign)
+                    error("no alignment-specifier for bit field declaration"); // C11 6.7.5-2
+
                 nextToken();
                 cparseConstantExp();
+
                 error("bit fields are not supported"); // TODO
             }
 

--- a/test/fail_compilation/alignas2.c
+++ b/test/fail_compilation/alignas2.c
@@ -1,0 +1,41 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/alignas2.c(101): Error: no alignment-specifier for typedef declaration
+fail_compilation/alignas2.c(103): Error: no alignment-specifier for function declaration
+fail_compilation/alignas2.c(107): Error: no alignment-specifier for `register` storage class
+fail_compilation/alignas2.c(110): Error: no alignment-specifier for parameters
+fail_compilation/alignas2.c(115): Error: no alignment-specifier for parameters
+fail_compilation/alignas2.c(116): Error: no declaration for identifier `x`
+fail_compilation/alignas2.c(121): Error: no alignment-specifier for bit field declaration
+fail_compilation/alignas2.c(121): Error: bit fields are not supported
+fail_compilation/alignas2.c(122): Error: no alignment-specifier for bit field declaration
+fail_compilation/alignas2.c(122): Error: unnamed bit fields are not supported
+---
+ */
+
+#line 100
+
+typedef _Alignas(4) int x;
+
+_Alignas(8) int mercury();
+
+void venus()
+{
+    register _Alignas(8) int x;
+}
+
+void earth(_Alignas(4) int x)
+{
+}
+
+void mars(x)
+_Alignas(4) int x;
+{
+}
+
+struct B
+{
+    _Alignas(4) int bf : 3;
+    _Alignas(8) int : 0;
+};
+


### PR DESCRIPTION
Supposed to also be an error for bit fields too, but bit fields aren't implemented yet.