### PR TITLE
Use -preview flags instead of old -dipXXXX flags

### DIFF
--- a/test/compilable/scopeinfer.d
+++ b/test/compilable/scopeinfer.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -dip1000
+// PERMUTE_ARGS: -preview=dip1000
 
 // Mangling should be the same with or without inference of `return scope`
 

--- a/test/compilable/test19097.d
+++ b/test/compilable/test19097.d
@@ -1,4 +1,4 @@
-/* REQUIRED_ARGS: -dip1000
+/* REQUIRED_ARGS: -preview=dip1000
  */
 
 // Related to: https://github.com/dlang/dmd/pull/8504

--- a/test/compilable/test19463.sh
+++ b/test/compilable/test19463.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-$DMD -c -dip1008 -m${MODEL} -of${OUTPUT_BASE}${OBJ} -I${EXTRA_FILES} ${EXTRA_FILES}/${TEST_NAME}.d
+$DMD -c -preview=dip1008 -m${MODEL} -of${OUTPUT_BASE}${OBJ} -I${EXTRA_FILES} ${EXTRA_FILES}/${TEST_NAME}.d
 !(nm ${OUTPUT_BASE}${OBJ} | grep _d_newclass)
 
 rm_retry ${OUTPUT_BASE}${OBJ}

--- a/test/compilable/test20795.d
+++ b/test/compilable/test20795.d
@@ -1,6 +1,6 @@
 // https://issues.dlang.org/show_bug.cgi?id=20795
 
-// REQUIRED_ARGS: -dip1000
+// REQUIRED_ARGS: -preview=dip1000
 
 struct Foo
 {

--- a/test/compilable/test20868.d
+++ b/test/compilable/test20868.d
@@ -1,5 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=20868
-// REQUIRED_ARGS: -dip1000
+// REQUIRED_ARGS: -preview=dip1000
 
 void scoped (scope void delegate() dg)
 {

--- a/test/fail_compilation/fail19881.d
+++ b/test/fail_compilation/fail19881.d
@@ -1,4 +1,4 @@
-/* REQUIRED_ARGS: -dip1000
+/* REQUIRED_ARGS: -preview=dip1000
  * TEST_OUTPUT:
 ---
 fail_compilation/fail19881.d(12): Error: address of local variable `local` assigned to return scope `input`

--- a/test/fail_compilation/fail20108.d
+++ b/test/fail_compilation/fail20108.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -dip1000
+// REQUIRED_ARGS: -preview=dip1000
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/test19097.d
+++ b/test/fail_compilation/test19097.d
@@ -1,4 +1,4 @@
-/* REQUIRED_ARGS: -dip1000
+/* REQUIRED_ARGS: -preview=dip1000
  * TEST_OUTPUT:
 ---
 fail_compilation/test19097.d(35): Error: scope variable `s` may not be returned

--- a/test/runnable/test19317.d
+++ b/test/runnable/test19317.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -dip1008
+// REQUIRED_ARGS: -preview=dip1008
 // https://issues.dlang.org/show_bug.cgi?id=19317
 
 class MyException: Exception {

--- a/test/runnable/testassert.d
+++ b/test/runnable/testassert.d
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS: -checkaction=context -dip25 -dip1000
+REQUIRED_ARGS: -checkaction=context -preview=dip1000
 PERMUTE_ARGS: -O -g -inline
 */
 


### PR DESCRIPTION
The `-dip1000` flag has been superseded by `-preview=dip1000`, but some tests still use the old undocumented flag. This change makes it easy to find all dip1000 tests by searching for `-preview=dip1000`. Same for `-dip1008` and `-preview=dip1008`.

I also removed the `-dip25` flag from `testassert.d` since it's superseded by `-preview=dip25`, implied by `-preview=dip1000`, and the default now.