### PR TITLE
ImportC: add support for __attribute__((noreturn))

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -517,7 +517,7 @@ struct ASTBase
         ForeachStatement fes;
         FuncDeclaration overnext0;
 
-        final extern (D) this(const ref Loc loc, Loc endloc, Identifier id, StorageClass storage_class, Type type)
+        final extern (D) this(const ref Loc loc, Loc endloc, Identifier id, StorageClass storage_class, Type type, bool noreturn = false)
         {
             super(id);
             this.storage_class = storage_class;

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -603,7 +603,7 @@ public:
     // integration.
     ObjcFuncDeclaration objc;
 
-    static FuncDeclaration *create(const Loc &loc, const Loc &endloc, Identifier *id, StorageClass storage_class, Type *type);
+    static FuncDeclaration *create(const Loc &loc, const Loc &endloc, Identifier *id, StorageClass storage_class, Type *type, bool noreturn = false);
     FuncDeclaration *syntaxCopy(Dsymbol *);
     bool functionSemantic();
     bool functionSemantic3();

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2663,7 +2663,7 @@ public:
     Array<FuncDeclaration* >* inlinedNestedCallees;
     uint32_t flags;
     ObjcFuncDeclaration objc;
-    static FuncDeclaration* create(const Loc& loc, const Loc& endloc, Identifier* id, StorageClass storage_class, Type* type);
+    static FuncDeclaration* create(const Loc& loc, const Loc& endloc, Identifier* id, StorageClass storage_class, Type* type, bool noreturn = false);
     FuncDeclaration* syntaxCopy(Dsymbol* s);
     bool functionSemantic();
     bool functionSemantic3();
@@ -2767,6 +2767,7 @@ enum class FUNCFLAG : uint32_t
     compileTimeOnly = 256u,
     printf = 512u,
     scanf = 1024u,
+    noreturn = 2048u,
 };
 
 class FuncAliasDeclaration final : public FuncDeclaration
@@ -8188,6 +8189,7 @@ struct Id final
     static Identifier* dllimport;
     static Identifier* dllexport;
     static Identifier* vector_size;
+    static Identifier* noreturn;
     static void initialize();
     Id()
     {

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -499,6 +499,7 @@ immutable Msgtable[] msgtable =
     { "dllexport" },
     { "vector_size" },
     { "__func__" },
+    { "noreturn" },
 ];
 
 

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -355,7 +355,7 @@ Symbol *toSymbol(Dsymbol s)
             else if (fd.isMember2() && fd.isStatic())
                 f.Fflags |= Fstatic;
 
-            if (fd.type.toBasetype().isTypeFunction().nextOf().isTypeNoreturn())
+            if (fd.type.toBasetype().isTypeFunction().nextOf().isTypeNoreturn() || fd.flags & FUNCFLAG.noreturn)
                 s.Sflags |= SFLexit;    // the function never returns
 
             f.Fstartline.set(fd.loc.filename, fd.loc.linnum, fd.loc.charnum);

--- a/test/compilable/noreturn.c
+++ b/test/compilable/noreturn.c
@@ -1,0 +1,12 @@
+// Test attribute "noreturn"
+
+__attribute__(( noreturn, noreturn )) int foo();
+
+__attribute__(( noreturn )) int bar() { return 3; }
+
+int test()
+{
+    foo();
+    bar();
+    return 4;
+}


### PR DESCRIPTION
This turned out to be more work than expected, even though the gnu attribute syntax parser was already implemented. Because it had never been used, of course it was all wrong. So this includes a rework of that.

The more interesting issue is that `noreturn` for D is a type, while it is a storage class for C. ImportC has to support nutburger things like:
```
__attribute__((noreturn)) int foo();
```
because `gcc` does. Besides, if it was done as a type in ImportC, then the compiler would complain about unreachable code after the call to the noreturn function, but such code is acceptable to `gcc`. Whatevs, only make it affect the optimizer and code generator, which is done by setting `SFLexit` for dmd.

Will do the corresponding `__declspec(noreturn)` later.