### PR TITLE
ImportC: add GenericExp

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -44,6 +44,7 @@ struct ASTBase
     alias Dsymbols              = Array!(Dsymbol);
     alias Objects               = Array!(RootObject);
     alias Expressions           = Array!(Expression);
+    alias Types                 = Array!(Type);
     alias TemplateParameters    = Array!(TemplateParameter);
     alias BaseClasses           = Array!(BaseClass*);
     alias Parameters            = Array!(Parameter);
@@ -5982,6 +5983,26 @@ struct ASTBase
         extern (D) this(const ref Loc loc, Expression e1, Expression e2)
         {
             super(loc, TOK.concatenateAssign, __traits(classInstanceSize, CatAssignExp), e1, e2);
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) final class GenericExp : Expression
+    {
+        Expression cntlExp;
+        Types* types;
+        Expressions* exps;
+
+        extern (D) this(const ref Loc loc, Expression cntlExp, Types* types, Expressions* exps)
+        {
+            super(loc, TOK._Generic, __traits(classInstanceSize, GenericExp));
+            this.cntlExp = cntlExp;
+            this.types = types;
+            this.exps = exps;
         }
 
         override void accept(Visitor v)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -209,6 +209,7 @@ public:
     EqualExp* isEqualExp();
     IdentityExp* isIdentityExp();
     CondExp* isCondExp();
+    GenericExp* isGenericExp();
     DefaultInitExp* isDefaultInitExp();
     FileInitExp* isFileInitExp();
     LineInitExp* isLineInitExp();
@@ -1260,6 +1261,17 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     void hookDtors(Scope *sc);
+
+    void accept(Visitor *v) { v->visit(this); }
+};
+
+class GenericExp : Expression
+{
+    Expression cntlExp;
+    Types *types;
+    Expressions *exps;
+
+    GenericExp *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -11657,6 +11657,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         result = exp;
     }
 
+    override void visit(GenericExp exp)
+    {
+        static if (LOGSEMANTIC)
+        {
+            printf("GenericExp::semantic('%s')\n", exp.toChars());
+        }
+        error(exp.loc, "`_Generic` not supported");  // TODO
+        setError();
+    }
+
     override void visit(FileInitExp e)
     {
         //printf("FileInitExp::semantic()\n");

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -208,6 +208,7 @@ class RemoveExp;
 class EqualExp;
 class IdentityExp;
 class CondExp;
+class GenericExp;
 class DefaultInitExp;
 class FileInitExp;
 class LineInitExp;
@@ -1654,6 +1655,7 @@ public:
     EqualExp* isEqualExp();
     IdentityExp* isIdentityExp();
     CondExp* isCondExp();
+    GenericExp* isGenericExp();
     DefaultInitExp* isDefaultInitExp();
     FileInitExp* isFileInitExp();
     LineInitExp* isLineInitExp();
@@ -2235,6 +2237,7 @@ public:
     virtual void visit(typename AST::SymbolExp e);
     virtual void visit(typename AST::TupleExp e);
     virtual void visit(typename AST::ThisExp e);
+    virtual void visit(typename AST::GenericExp e);
     virtual void visit(typename AST::VarExp e);
     virtual void visit(typename AST::DollarExp e);
     virtual void visit(typename AST::SuperExp e);
@@ -4542,6 +4545,7 @@ struct ASTCodegen final
     using FileInitExp = ::FileInitExp;
     using FuncExp = ::FuncExp;
     using FuncInitExp = ::FuncInitExp;
+    using GenericExp = ::GenericExp;
     using HaltExp = ::HaltExp;
     using IdentifierExp = ::IdentifierExp;
     using IdentityExp = ::IdentityExp;
@@ -7397,6 +7401,16 @@ public:
     void accept(Visitor* v);
 };
 
+class GenericExp final : public Expression
+{
+public:
+    Expression* cntlExp;
+    Array<Type* >* types;
+    Array<Expression* >* exps;
+    GenericExp* syntaxCopy();
+    void accept(Visitor* v);
+};
+
 extern Expression* resolveProperties(Scope* sc, Expression* e);
 
 extern Expression* expressionSemantic(Expression* e, Scope* sc);
@@ -7763,6 +7777,7 @@ public:
     void visit(ArrayExp* e);
     void visit(PostExp* e);
     void visit(CondExp* e);
+    void visit(GenericExp* e);
     void visit(TemplateTypeParameter* tp);
     void visit(TemplateThisParameter* tp);
     void visit(TemplateAliasParameter* tp);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2631,6 +2631,20 @@ extern (C++) abstract class Type : ASTNode
             assert(0);
         return cast(TypeFunction)this;
     }
+
+    extern (D) static Types* arraySyntaxCopy(Types* types)
+    {
+        Types* a = null;
+        if (types)
+        {
+            a = new Types(types.length);
+            foreach (i, t; *types)
+            {
+                (*a)[i] = t ? t.syntaxCopy() : null;
+            }
+        }
+        return a;
+    }
 }
 
 /***********************************************************

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -100,6 +100,7 @@ immutable PREC[TOK.max + 1] precedence =
     TOK.overloadSet : PREC.primary,
     TOK.void_ : PREC.primary,
     TOK.vectorArray : PREC.primary,
+    TOK._Generic : PREC.primary,
 
     // post
     TOK.dotTemplateInstance : PREC.primary,

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -199,6 +199,7 @@ public:
     void visit(AST.SymbolExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.TupleExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.ThisExp e) { visit(cast(AST.Expression)e); }
+    void visit(AST.GenericExp e) { visit(cast(AST.Expression)e); }
 
     // Miscellaneous
     void visit(AST.VarExp e) { visit(cast(AST.SymbolExp)e); }

--- a/src/dmd/strictvisitor.d
+++ b/src/dmd/strictvisitor.d
@@ -214,6 +214,7 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.ShrAssignExp) { assert(0); }
     override void visit(AST.UshrAssignExp) { assert(0); }
     override void visit(AST.CatAssignExp) { assert(0); }
+    override void visit(AST.GenericExp) { assert(0); }
     override void visit(AST.TemplateParameter) { assert(0); }
     override void visit(AST.TemplateAliasParameter) { assert(0); }
     override void visit(AST.TemplateTypeParameter) { assert(0); }

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -1129,6 +1129,18 @@ package mixin template ParseVisitMethods(AST)
         e.e2.accept(this);
     }
 
+    override void visit(AST.GenericExp e)
+    {
+        //printf("Visiting GenericExp\n");
+        e.cntlExp.accept(this);
+        foreach (i; 0 .. (*e.types).length)
+        {
+            if (auto t = (*e.types)[i])  // null means default case
+                t.accept(this);
+            (*e.exps )[i].accept(this);
+        }
+    }
+
 // Template Parameter
 //===========================================================
 

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -292,6 +292,7 @@ class PrettyFuncInitExp;
 class ClassReferenceExp;
 class VoidInitExp;
 class ThrownExceptionExp;
+class GenericExp;
 
 class TemplateParameter;
 class TemplateTypeParameter;
@@ -488,6 +489,7 @@ public:
     virtual void visit(SymbolExp *e) { visit((Expression *)e); }
     virtual void visit(TupleExp *e) { visit((Expression *)e); }
     virtual void visit(ThisExp *e) { visit((Expression *)e); }
+    virtual void visit(GenericExp *e) { visit((Expression *)e); }
 
     // Miscellaneous
     virtual void visit(VarExp *e) { visit((SymbolExp *)e); }


### PR DESCRIPTION
`_Generic` expressions cannot be evaluated until the semantic pass, so added `GenericExp` to support that. This is just all the boilerplate for the new Expression type, it doesn't do anything yet.