### PR TITLE
fix Issue 22182 - importC: Error: expression expected, not `)` when casting pointer with redundant parens

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -959,7 +959,7 @@ final class CParser(AST) : Parser!AST
                 }
                 else
                 {
-                    // (type-name) cast-expression
+                    // ( type-name ) cast-expression
                     auto ce = cparseCastExp();
                     return new AST.CastExp(loc, ce, t);
                 }
@@ -3806,18 +3806,24 @@ final class CParser(AST) : Parser!AST
                         goto default; // could be ( type-name ) ( unary-expression )
                     return false;
                 }
-                t = peek(tk);  // move past right parenthesis
+                tk = peek(tk);  // move past right parenthesis
 
-                if (t.value == TOK.leftCurly)
+                if (tk.value == TOK.leftCurly)
                 {
                     // ( type-name ) { initializer-list }
-                    if (!isInitializer(t))
+                    if (!isInitializer(tk))
                         return false;
+                    t = tk;
                     break;
                 }
-                if (!isCastExpression(t, true))
+                if (!isCastExpression(tk, true))
+                {
+                    if (afterParenType) // could be ( type-name ) ( unary-expression )
+                        goto default;   // where unary-expression also matched type-name
                     return false;
+                }
                 // ( type-name ) cast-expression
+                t = tk;
                 break;
 
             default:

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -361,3 +361,18 @@ void testS22106()
 int S22106; // not a redeclaration of 'struct S22106'
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22182
+
+int test22182a(int x)
+{
+    return (int)(x);
+}
+
+typedef struct S22182 { int x; } S22182;
+
+int test22182b(S22182* b)
+{
+  return ((S22182*)(b))->x;
+}
+
+/***************************************************/


### PR DESCRIPTION
`isCastExpression` didn't correctly match `( type-name ) ( primary-expression )`.