### PR TITLE
fix Issue 22160 - importC: Error: redeclaring `module test` as `struct test`

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2085,7 +2085,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
          */
         Dsymbol scopesym;
         auto s = sc.search(mtype.loc, mtype.id, &scopesym, IgnoreErrors | TagNameSpace);
-        if (!s)
+        if (!s || s.isModule())
         {
             // no pre-existing declaration, so declare it
             if (mtype.tok == TOK.enum_ && !mtype.members)

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -361,6 +361,11 @@ void testS22106()
 int S22106; // not a redeclaration of 'struct S22106'
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22160
+
+typedef struct testcstuff2 testcstuff2;
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22182
 
 int test22182a(int x)


### PR DESCRIPTION
Tag names should not conflict with the modules that we put them.