### PR TITLE
fix Issue 22196 - importC: Error: found `const` when expecting `)`in __attribute__

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2754,6 +2754,9 @@ final class CParser(AST) : Parser!AST
         bool dllimport;  // TODO implement
         bool dllexport;  // TODO implement
 
+        if (!isGnuAttributeName())
+            return;
+
         if (token.value == TOK.identifier)
         {
             if (token.ident == Id.dllimport)
@@ -2784,6 +2787,53 @@ final class CParser(AST) : Parser!AST
                 if (token.value == TOK.leftParenthesis)
                     cparseParens();
             }
+        }
+        else
+        {
+            nextToken();
+            if (token.value == TOK.leftParenthesis)
+                cparseParens();
+        }
+    }
+
+    /*************************
+     * See if match for GNU attribute name, which may be any identifier,
+     * storage-class-specifier, type-specifier, or type-qualifier.
+     * Returns:
+     *  true if a valid GNU attribute name
+     */
+    private bool isGnuAttributeName()
+    {
+        switch (token.value)
+        {
+            case TOK.identifier:
+            case TOK.static_:
+            case TOK.unsigned:
+            case TOK.int64:
+            case TOK.const_:
+            case TOK.extern_:
+            case TOK.register:
+            case TOK.typedef_:
+            case TOK.int16:
+            case TOK.inline:
+            case TOK._Noreturn:
+            case TOK.volatile:
+            case TOK.signed:
+            case TOK.auto_:
+            case TOK.restrict:
+            case TOK._Complex:
+            case TOK._Thread_local:
+            case TOK.int32:
+            case TOK.char_:
+            case TOK.float32:
+            case TOK.float64:
+            case TOK.void_:
+            case TOK._Bool:
+            case TOK._Atomic:
+                return true;
+
+            default:
+                return false;
         }
     }
 

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -381,3 +381,11 @@ int test22182b(S22182* b)
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22196
+
+__attribute__((static, unsigned, long, const, extern, register, typedef, short,
+               inline, _Noreturn, volatile, signed, auto, restrict, _Complex,
+               _Thread_local, int, char, float, double, void, _Bool, _Atomic))
+int test22196();
+
+/***************************************************/


### PR DESCRIPTION
GNU attribute names may be any identifier, storage-class-specifier, type-specifier, or type-qualifier.