### PR TITLE
test: Remove duplicate main function in testheader17125.d

### DIFF
--- a/test/compilable/extra-files/header17125.d
+++ b/test/compilable/extra-files/header17125.d
@@ -3,7 +3,3 @@ void func2(real value = 520.199e3F);
 void func3(real value = 9.70e5);
 void func4(real value = 1024.5e2F);
 void func5(real value = 41250.2e1L);
-
-int main() {
-        return 0;
-}

--- a/test/compilable/testheader17125.d
+++ b/test/compilable/testheader17125.d
@@ -13,7 +13,6 @@ void func2(real value = 520199.0F);
 void func3(real value = 970000.0);
 void func4(real value = 102450.0F);
 void func5(real value = 412502.0L);
-int main();
 ---
 */
 


### PR DESCRIPTION
It has nothing to do with the bug report and causes testsuite failures with compilers that have always errored about duplicate definitions (dmd is still in deprecation phase).