### PR TITLE
fix issue 15631 - gdb: Parent's scope not considered for symbol lookup

### DIFF
--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -509,6 +509,25 @@ void symbol_struct_addField(Symbol *s, const(char)* name, type *t, uint offset)
     list_append(&s.Sstruct.Sfldlst, s2);
 }
 
+/***************************************
+ * Add a base class to a struct s.
+ * Input:
+ *      s       the struct/class symbol
+ *      t       the type of the base class
+ *      offset  offset of the base class in the struct/class
+ */
+
+@trusted
+void symbol_struct_addBaseClass(Symbol *s, type *t, uint offset)
+{
+    assert(t && t.Tty == TYstruct);
+    auto bc = cast(baseclass_t*)mem_fmalloc(baseclass_t.sizeof);
+    bc.BCbase = t.Ttag;
+    bc.BCoffset = offset;
+    bc.BCnext = s.Sstruct.Sbase;
+    s.Sstruct.Sbase = bc;
+}
+
 /********************************
  * Define symbol in specified symbol table.
  * Returns:

--- a/src/dmd/backend/type.d
+++ b/src/dmd/backend/type.d
@@ -64,6 +64,7 @@ void type_incCount(type* t);
 void type_setIdent(type* t, char* ident);
 
 void symbol_struct_addField(Symbol* s, const(char)* name, type* t, uint offset);
+void symbol_struct_addBaseClass(Symbol* s, type* t, uint offset);
 
 // Return true if type is a struct, class or union
 bool type_struct(const type* t) { return tybasic(t.Tty) == TYstruct; }

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -264,6 +264,12 @@ public:
                 {
                     symbol_struct_addField(cast(Symbol*)tc.Ttag, v.ident.toChars(), Type_toCtype(v.type), v.offset);
                 }
+                if (auto bc = t.sym.baseClass)
+                {
+                    auto ptr_to_basetype = Type_toCtype(bc.type);
+                    assert(ptr_to_basetype .Tty == TYnptr);
+                    symbol_struct_addBaseClass(cast(Symbol*)tc.Ttag, ptr_to_basetype.Tnext, 0);
+                }
             }
 
             if (global.params.symdebugref)

--- a/test/runnable/gdb_baseclass_fields.d
+++ b/test/runnable/gdb_baseclass_fields.d
@@ -1,0 +1,31 @@
+/*
+REQUIRED_ARGS: -g
+PERMUTE_ARGS:
+GDB_SCRIPT:
+---
+b 30
+r
+set print pretty off
+echo RESULT=
+p *c
+---
+GDB_MATCH: RESULT=.*a = 1.* b = 2
+*/
+
+class B {
+  uint a;
+}
+
+class C : B {
+  int b;
+}
+
+
+void main()
+{
+  C c = new C();
+  c.a = 1;
+  c.b = 2;
+
+  int bp = 1;
+}


### PR DESCRIPTION
add basic inheritance information to class type dwarf debug info

Alternative to https://github.com/dlang/dmd/pull/12925

