### PR TITLE
introduce FieldState

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -174,9 +174,9 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         return Dsymbol.oneMembers(d, ps, ident);
     }
 
-    override void setFieldOffset(AggregateDeclaration ad, uint* poffset, bool isunion)
+    override void setFieldOffset(AggregateDeclaration ad, ref FieldState fieldState, bool isunion)
     {
-        include(null).foreachDsymbol( s => s.setFieldOffset(ad, poffset, isunion) );
+        include(null).foreachDsymbol( s => s.setFieldOffset(ad, fieldState, isunion) );
     }
 
     override final bool hasPointers()
@@ -770,7 +770,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
         return AttribDeclaration.setScope(sc);
     }
 
-    override void setFieldOffset(AggregateDeclaration ad, uint* poffset, bool isunion)
+    override void setFieldOffset(AggregateDeclaration ad, ref FieldState fieldState, bool isunion)
     {
         //printf("\tAnonDeclaration::setFieldOffset %s %p\n", isunion ? "union" : "struct", this);
         if (decl)
@@ -789,12 +789,12 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
             ad.structsize = 0;
             ad.alignsize = 0;
 
-            uint offset = 0;
+            FieldState fs;
             decl.foreachDsymbol( (s)
             {
-                s.setFieldOffset(ad, &offset, this.isunion);
+                s.setFieldOffset(ad, fs, this.isunion);
                 if (this.isunion)
-                    offset = 0;
+                    fs.offset = 0;
             });
 
             /* https://issues.dlang.org/show_bug.cgi?id=13613
@@ -806,7 +806,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
             {
                 ad.structsize = savestructsize;
                 ad.alignsize = savealignsize;
-                *poffset = ad.structsize;
+                fieldState.offset = ad.structsize;
                 return;
             }
 
@@ -829,7 +829,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
              * go ahead and place it.
              */
             anonoffset = AggregateDeclaration.placeField(
-                poffset,
+                &fieldState.offset,
                 anonstructsize, anonalignsize, alignment,
                 &ad.structsize, &ad.alignsize,
                 isunion);

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -32,7 +32,7 @@ public:
     void addComment(const utf8_t *comment);
     const char *kind() const;
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
+    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
     bool hasPointers();
     bool hasStaticCtorOrDtor();
     void checkCtorConstInit();
@@ -141,7 +141,7 @@ public:
 
     AnonDeclaration *syntaxCopy(Dsymbol *s);
     void setScope(Scope *sc);
-    void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
+    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
     const char *kind() const;
     AnonDeclaration *isAnonDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -628,10 +628,11 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         // to calculate each variable offsets. It can be improved later.
         fields.setDim(0);
 
-        uint offset = structsize;
+        FieldState fieldState;
+        fieldState.offset = structsize;
         foreach (s; *members)
         {
-            s.setFieldOffset(this, &offset, false);
+            s.setFieldOffset(this, fieldState, false);
         }
 
         sizeok = Sizeok.done;

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1113,7 +1113,7 @@ extern (C++) class VarDeclaration : Declaration
         return v;
     }
 
-    override final void setFieldOffset(AggregateDeclaration ad, uint* poffset, bool isunion)
+    override final void setFieldOffset(AggregateDeclaration ad, ref FieldState fieldState, bool isunion)
     {
         //printf("VarDeclaration::setFieldOffset(ad = %s) %s\n", ad.toChars(), toChars());
 
@@ -1129,7 +1129,7 @@ extern (C++) class VarDeclaration : Declaration
                 Expression e = cast(Expression)o;
                 assert(e.op == TOK.dSymbol);
                 DsymbolExp se = cast(DsymbolExp)e;
-                se.s.setFieldOffset(ad, poffset, isunion);
+                se.s.setFieldOffset(ad, fieldState, isunion);
             }
             return;
         }
@@ -1146,7 +1146,7 @@ extern (C++) class VarDeclaration : Declaration
         if (offset)
         {
             // already a field
-            *poffset = ad.structsize; // https://issues.dlang.org/show_bug.cgi?id=13613
+            fieldState.offset = ad.structsize; // https://issues.dlang.org/show_bug.cgi?id=13613
             return;
         }
         for (size_t i = 0; i < ad.fields.dim; i++)
@@ -1154,7 +1154,7 @@ extern (C++) class VarDeclaration : Declaration
             if (ad.fields[i] == this)
             {
                 // already a field
-                *poffset = ad.structsize; // https://issues.dlang.org/show_bug.cgi?id=13613
+                fieldState.offset = ad.structsize; // https://issues.dlang.org/show_bug.cgi?id=13613
                 return;
             }
         }
@@ -1191,7 +1191,7 @@ extern (C++) class VarDeclaration : Declaration
         uint memsize = cast(uint)sz;                // size of member
         uint memalignsize = target.fieldalign(t);   // size of member for alignment purposes
         offset = AggregateDeclaration.placeField(
-            poffset,
+            &fieldState.offset,
             memsize, memalignsize, alignment,
             &ad.structsize, &ad.alignsize,
             isunion);

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -260,7 +260,7 @@ public:
 public:
     static VarDeclaration *create(const Loc &loc, Type *t, Identifier *id, Initializer *init, StorageClass storage_class = STCundefined);
     VarDeclaration *syntaxCopy(Dsymbol *);
-    void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
+    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
     const char *kind() const;
     AggregateDeclaration *isThis();
     bool needThis();

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -284,12 +284,12 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         fields.setDim(0);   // workaround
 
         // Set the offsets of the fields and determine the size of the struct
-        uint offset = 0;
+        FieldState fieldState;
         bool isunion = isUnionDeclaration() !is null;
         for (size_t i = 0; i < members.dim; i++)
         {
             Dsymbol s = (*members)[i];
-            s.setFieldOffset(this, &offset, isunion);
+            s.setFieldOffset(this, fieldState, isunion);
         }
         if (type.ty == Terror)
         {

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -219,6 +219,16 @@ enum : int
 }
 
 /***********************************************************
+ * Struct/Class/Union field state.
+ * Used for transitory information when setting field offsets, such
+ * as bit fields.
+ */
+struct FieldState
+{
+    uint offset;        /// offset for next field
+}
+
+/***********************************************************
  */
 extern (C++) class Dsymbol : ASTNode
 {
@@ -1136,7 +1146,7 @@ extern (C++) class Dsymbol : ASTNode
         return true;
     }
 
-    void setFieldOffset(AggregateDeclaration ad, uint* poffset, bool isunion)
+    void setFieldOffset(AggregateDeclaration ad, ref FieldState fieldState, bool isunion)
     {
     }
 

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -139,6 +139,11 @@ enum
     TagNameSpace            = 0x100, // search ImportC tag symbol table
 };
 
+struct FieldState
+{
+    unsigned offset;
+};
+
 class Dsymbol : public ASTNode
 {
 public:
@@ -215,7 +220,7 @@ public:
     virtual Visibility visible();
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     virtual bool oneMember(Dsymbol **ps, Identifier *ident);
-    virtual void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
+    virtual void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();
     virtual void addLocalClass(ClassDeclarations *) { }

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -7670,13 +7670,13 @@ extern (C++) final class TemplateMixin : TemplateInstance
         return members.foreachDsymbol( (s) { return s.hasPointers(); } ) != 0;
     }
 
-    override void setFieldOffset(AggregateDeclaration ad, uint* poffset, bool isunion)
+    override void setFieldOffset(AggregateDeclaration ad, ref FieldState fieldState, bool isunion)
     {
         //printf("TemplateMixin.setFieldOffset() %s\n", toChars());
         if (_scope) // if fwd reference
             dsymbolSemantic(this, null); // try to resolve it
 
-        members.foreachDsymbol( (s) { s.setFieldOffset(ad, poffset, isunion); } );
+        members.foreachDsymbol( (s) { s.setFieldOffset(ad, fieldState, isunion); } );
     }
 
     override const(char)* toChars() const

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -54,6 +54,7 @@ class LabelDsymbol;
 class ClassDeclaration;
 class Type;
 class Package;
+struct FieldState;
 class EnumMember;
 class TemplateDeclaration;
 class TemplateMixin;
@@ -1033,7 +1034,7 @@ public:
     virtual Visibility visible();
     virtual Dsymbol* syntaxCopy(Dsymbol* s);
     virtual bool oneMember(Dsymbol** ps, Identifier* ident);
-    virtual void setFieldOffset(AggregateDeclaration* ad, uint32_t* poffset, bool isunion);
+    virtual void setFieldOffset(AggregateDeclaration* ad, FieldState& fieldState, bool isunion);
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();
     virtual void addLocalClass(Array<ClassDeclaration* >* _param_0);
@@ -2474,6 +2475,18 @@ enum class StructFlags
     hasPointers = 1,
 };
 
+struct FieldState final
+{
+    uint32_t offset;
+    FieldState() :
+        offset()
+    {
+    }
+    FieldState(uint32_t offset) :
+        offset(offset)
+        {}
+};
+
 enum
 {
     IgnoreNone = 0,
@@ -3675,7 +3688,7 @@ public:
     void setScope(Scope* sc);
     Dsymbol* search(const Loc& loc, Identifier* ident, int32_t flags = 8);
     bool hasPointers();
-    void setFieldOffset(AggregateDeclaration* ad, uint32_t* poffset, bool isunion);
+    void setFieldOffset(AggregateDeclaration* ad, FieldState& fieldState, bool isunion);
     const char* kind() const;
     Nspace* isNspace();
     void accept(Visitor* v);
@@ -4473,6 +4486,7 @@ struct ASTCodegen final
     using Dsymbol = ::Dsymbol;
     using DsymbolTable = ::DsymbolTable;
     using ExpressionDsymbol = ::ExpressionDsymbol;
+    using FieldState = ::FieldState;
     using ForwardingScopeDsymbol = ::ForwardingScopeDsymbol;
     using OverloadSet = ::OverloadSet;
     using PASS = ::PASS;
@@ -5012,7 +5026,7 @@ public:
     void addComment(const char* comment);
     const char* kind() const;
     bool oneMember(Dsymbol** ps, Identifier* ident);
-    void setFieldOffset(AggregateDeclaration* ad, uint32_t* poffset, bool isunion);
+    void setFieldOffset(AggregateDeclaration* ad, FieldState& fieldState, bool isunion);
     bool hasPointers();
     bool hasStaticCtorOrDtor();
     void checkCtorConstInit();
@@ -5114,7 +5128,7 @@ public:
     uint32_t anonalignsize;
     AnonDeclaration* syntaxCopy(Dsymbol* s);
     void setScope(Scope* sc);
-    void setFieldOffset(AggregateDeclaration* ad, uint32_t* poffset, bool isunion);
+    void setFieldOffset(AggregateDeclaration* ad, FieldState& fieldState, bool isunion);
     const char* kind() const;
     AnonDeclaration* isAnonDeclaration();
     void accept(Visitor* v);
@@ -5576,7 +5590,7 @@ public:
     bool isArgDtorVar;
     static VarDeclaration* create(const Loc& loc, Type* type, Identifier* ident, Initializer* _init, StorageClass storage_class = static_cast<StorageClass>(STC::undefined_));
     VarDeclaration* syntaxCopy(Dsymbol* s);
-    void setFieldOffset(AggregateDeclaration* ad, uint32_t* poffset, bool isunion);
+    void setFieldOffset(AggregateDeclaration* ad, FieldState& fieldState, bool isunion);
     const char* kind() const;
     AggregateDeclaration* isThis();
     bool needThis();
@@ -6334,7 +6348,7 @@ public:
     const char* kind() const;
     bool oneMember(Dsymbol** ps, Identifier* ident);
     bool hasPointers();
-    void setFieldOffset(AggregateDeclaration* ad, uint32_t* poffset, bool isunion);
+    void setFieldOffset(AggregateDeclaration* ad, FieldState& fieldState, bool isunion);
     const char* toChars() const;
     TemplateMixin* isTemplateMixin();
     void accept(Visitor* v);

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -145,12 +145,12 @@ extern (C++) final class Nspace : ScopeDsymbol
         return members.foreachDsymbol( (s) { return s.hasPointers(); } ) != 0;
     }
 
-    override void setFieldOffset(AggregateDeclaration ad, uint* poffset, bool isunion)
+    override void setFieldOffset(AggregateDeclaration ad, ref FieldState fieldState, bool isunion)
     {
         //printf("Nspace::setFieldOffset() %s\n", toChars());
         if (_scope) // if fwd reference
             dsymbolSemantic(this, null); // try to resolve it
-        members.foreachDsymbol( s => s.setFieldOffset(ad, poffset, isunion) );
+        members.foreachDsymbol( s => s.setFieldOffset(ad, fieldState, isunion) );
     }
 
     override const(char)* kind() const

--- a/src/dmd/nspace.h
+++ b/src/dmd/nspace.h
@@ -25,7 +25,7 @@ class Nspace : public ScopeDsymbol
     void setScope(Scope *sc);
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
     bool hasPointers();
-    void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
+    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
     const char *kind() const;
     Nspace *isNspace() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -299,7 +299,7 @@ public:
     const char *kind() const;
     bool oneMember(Dsymbol **ps, Identifier *ident);
     bool hasPointers();
-    void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
+    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
     const char *toChars() const;
 
     TemplateMixin *isTemplateMixin() { return this; }


### PR DESCRIPTION
This refactoring is because state needed to be carried around for bit fields is more than what is needed for regular fields. So replace the `offset` parameter with `fieldState`. The bit field PR will just add more to `FieldState`.

Doing it as a separate refactoring to practice what I preach :-)