### PR TITLE
test: Reduce amount of code generated for test20855 again

### DIFF
--- a/test/runnable/test20855.d
+++ b/test/runnable/test20855.d
@@ -3,7 +3,7 @@
 string exp()
 {
     string s = "a = b + c * d + a;";
-    foreach (i; 0 .. 10)
+    foreach (i; 0 .. 9)
 	s = s ~ s;
     return s;
 }
@@ -21,6 +21,6 @@ int main()
 {
     int a = test();
     printf("a = %d\n", a);
-    assert(test() == 14337);
+    assert(test() == 7169);
     return 0;
 }


### PR DESCRIPTION
See introducing PR:
 - #12409

See pull request that subsequently reduced the amount of code generated due to CI failures:
 - #12454

See possibly related bug report:
 - https://issues.dlang.org/show_bug.cgi?id=22098

See pipelines that have been failing since this morning in master:
 - https://cirrus-ci.com/task/4605506372239360
 - https://cirrus-ci.com/task/5975755894030336
 - https://cirrus-ci.com/task/5629715546374144

I've tried reverting dmd to 8884ad0d2, druntime to 934b4d24, and phobos to 21227390e (all merge_stable PRs), and the test failure still occurs.  Conclusion is that there's an environmental change in the FreeBSD 11 images that affects this test, and this test only.  But why that should be a problem for dmd means that either the dmd fix is wrong, or dmd is incapable of generating correct code for the given test.