### PR TITLE
Cache mangle for Dsymbols

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -1047,11 +1047,27 @@ public:
                 printf("  parent = %s %s", s.parent.kind(), s.parent.toChars());
             printf("\n");
         }
+
+        if (s.mangle.length) // do we have a cached mangle?
+        {
+              buf.write(s.mangle);
+              return;
+        }
+
         mangleParent(s);
         if (s.ident)
             mangleIdentifier(s.ident, s);
         else
             toBuffer(s.toString(), s);
+
+        auto mangleSlice = buf.peekSlice();
+        auto len = mangleSlice.length;
+        import dmd.root.rmem;
+        auto mangleMem = cast(char*)allocmemoryNoFree(len + 1);
+        mangleMem[0 .. len] = mangleSlice[0 .. len];
+        mangleMem[len] = '\0';
+        s.mangle = cast(const(char)[])(mangleMem[0 .. len]);
+
         //printf("Dsymbol.mangle() %s = %s\n", s.toChars(), id);
     }
 

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -245,6 +245,7 @@ extern (C++) class Dsymbol : ASTNode
     bool errors;            // this symbol failed to pass semantic()
     PASS semanticRun = PASS.init;
     ushort localNum;        /// perturb mangled name to avoid collisions with those in FuncDeclaration.localsymtab
+    const(char)[] mangle;   /// cached version of the mangle
 
     DeprecatedDeclaration depdecl;           // customized deprecation message
     UserAttributeDeclaration userAttribDecl;    // user defined attributes

--- a/src/dmd/root/outbuffer.d
+++ b/src/dmd/root/outbuffer.d
@@ -558,6 +558,12 @@ struct OutBuffer
         return extractData()[0 .. length];
     }
 
+    // peek slice is currently only used for mangling
+    extern(D) const(char)[] peekSlice()
+    {
+        return (cast(const(char)*)data.ptr)[0 .. offset];
+    }
+
     // Append terminating null if necessary and get view of internal buffer
     extern (C++) char* peekChars() pure nothrow
     {


### PR DESCRIPTION
I have noticed that mangles for Dsymbols are not cached ...
This change should make excessive template instantiation cheaper.

@John-Colvin @JohanEngelen if you could test it on your codebases? 