### PR TITLE
ImportC implement bit fields

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -221,6 +221,11 @@ struct ASTBase
             return null;
         }
 
+        inout(BitFieldDeclaration) isBitFieldDeclaration() inout
+        {
+            return null;
+        }
+
         inout(ClassDeclaration) isClassDeclaration() inout
         {
             return null;
@@ -490,6 +495,32 @@ struct ASTBase
         }
 
         override final inout(VarDeclaration) isVarDeclaration() inout
+        {
+            return this;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) class BitFieldDeclaration : VarDeclaration
+    {
+        Expression width;
+
+        uint fieldWidth;
+        uint bitOffset;
+
+        final extern (D) this(const ref Loc loc, Type type, Identifier id, Expression width)
+        {
+            super(loc, type, id, cast(Initializer)null, cast(StorageClass)STC.undefined_);
+
+            this.width = width;
+            this.storage_class |= STC.field;
+        }
+
+        override final inout(BitFieldDeclaration) isBitFieldDeclaration() inout
         {
             return this;
         }

--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -494,11 +494,11 @@ void symbol_func(Symbol *s)
 
 /***************************************
  * Add a field to a struct s.
- * Input:
- *      s       the struct symbol
- *      name    field name
- *      t       the type of the field
- *      offset  offset of the field
+ * Params:
+ *      s      = the struct symbol
+ *      name   = field name
+ *      t      = the type of the field
+ *      offset = offset of the field
  */
 
 @trusted
@@ -507,6 +507,40 @@ void symbol_struct_addField(Symbol *s, const(char)* name, type *t, uint offset)
     Symbol *s2 = symbol_name(name, SCmember, t);
     s2.Smemoff = offset;
     list_append(&s.Sstruct.Sfldlst, s2);
+}
+
+/***************************************
+ * Add a bit field to a struct s.
+ * Params:
+ *      s      = the struct symbol
+ *      name   = field name
+ *      t      = the type of the field
+ *      offset = offset of the field
+ *      fieldWidth = width of bit field
+ *      bitOffset  = bit number of start of field
+ */
+
+@trusted
+void symbol_struct_addBitField(Symbol *s, const(char)* name, type *t, uint offset, uint fieldWidth, uint bitOffset)
+{
+    //printf("symbol_struct_addBitField() s: %s\n", s.Sident.ptr);
+    Symbol *s2 = symbol_name(name, SCfield, t);
+    s2.Smemoff = offset;
+    s2.Swidth = cast(ubyte)fieldWidth;
+    s2.Sbit = cast(ubyte)bitOffset;
+    list_append(&s.Sstruct.Sfldlst, s2);
+    symbol_struct_hasBitFields(s);
+}
+
+/***************************************
+ * Mark struct s as having bit fields
+ * Params:
+ *      s      = the struct symbol
+ */
+@trusted
+void symbol_struct_hasBitFields(Symbol *s)
+{
+    s.Sstruct.Sflags |= STRbitfields;
 }
 
 /***************************************

--- a/src/dmd/backend/type.d
+++ b/src/dmd/backend/type.d
@@ -64,6 +64,8 @@ void type_incCount(type* t);
 void type_setIdent(type* t, char* ident);
 
 void symbol_struct_addField(Symbol* s, const(char)* name, type* t, uint offset);
+void symbol_struct_addBitField(Symbol* s, const(char)* name, type* t, uint offset, uint fieldWidth, uint bitOffset);
+void symbol_struct_hasBitFields(Symbol* s);
 void symbol_struct_addBaseClass(Symbol* s, type* t, uint offset);
 
 // Return true if type is a struct, class or union

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -283,6 +283,21 @@ public:
 
 /**************************************************************/
 
+class BitFieldDeclaration : public VarDeclaration
+{
+public:
+    Expression *width;
+
+    unsigned fieldWidth;
+    unsigned bitOffset;
+
+    BitFieldDeclaration *syntaxCopy(Dsymbol*);
+    BitFieldDeclaration *isBitFieldDeclaration() { return this; }
+    void accept(Visitor *v) { v->visit(this); }
+};
+
+/**************************************************************/
+
 // This is a shell around a back end symbol
 
 class SymbolDeclaration : public Declaration

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -226,6 +226,11 @@ enum : int
 struct FieldState
 {
     uint offset;        /// offset for next field
+
+    uint fieldOffset;   /// offset for the start of the bit field
+    uint bitOffset;     /// bit offset for field
+    uint fieldSize;     /// size of field in bytes
+    bool inFlight;      /// bit field is in flight
 }
 
 /***********************************************************
@@ -1239,6 +1244,7 @@ extern (C++) class Dsymbol : ASTNode
     inout(ExpressionDsymbol)           isExpressionDsymbol()           inout { return null; }
     inout(AliasAssign)                 isAliasAssign()                 inout { return null; }
     inout(ThisDeclaration)             isThisDeclaration()             inout { return null; }
+    inout(BitFieldDeclaration)         isBitFieldDeclaration()         inout { return null; }
     inout(TypeInfoDeclaration)         isTypeInfoDeclaration()         inout { return null; }
     inout(TupleDeclaration)            isTupleDeclaration()            inout { return null; }
     inout(AliasDeclaration)            isAliasDeclaration()            inout { return null; }

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -22,6 +22,7 @@ struct Scope;
 class DsymbolTable;
 class Declaration;
 class ThisDeclaration;
+class BitFieldDeclaration;
 class TypeInfoDeclaration;
 class TupleDeclaration;
 class AliasDeclaration;
@@ -142,6 +143,11 @@ enum
 struct FieldState
 {
     unsigned offset;
+
+    unsigned fieldOffset;
+    unsigned bitOffset;
+    unsigned fieldSice;
+    bool inFlight;
 };
 
 class Dsymbol : public ASTNode
@@ -245,6 +251,7 @@ public:
     virtual ExpressionDsymbol *isExpressionDsymbol() { return NULL; }
     virtual AliasAssign *isAliasAssign() { return NULL; }
     virtual ThisDeclaration *isThisDeclaration() { return NULL; }
+    virtual BitFieldDeclaration *isBitFieldDeclaration() { return NULL; }
     virtual TypeInfoDeclaration *isTypeInfoDeclaration() { return NULL; }
     virtual TupleDeclaration *isTupleDeclaration() { return NULL; }
     virtual AliasDeclaration *isAliasDeclaration() { return NULL; }

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2340,7 +2340,7 @@ extern (C++) class ToElemVisitor : Visitor
         }
 
         // Create a reference to e1.
-        if (e1.Eoper == OPvar)
+        if (e1.Eoper == OPvar || e1.Eoper == OPbit)
             e1x = el_copytree(e1);
         else
         {
@@ -3059,6 +3059,12 @@ extern (C++) class ToElemVisitor : Visitor
         if (v.storage_class & (STC.out_ | STC.ref_))
             e = el_una(OPind, TYnptr, e);
         e = el_una(OPind, totym(dve.type), e);
+        if (auto bf = v.isBitFieldDeclaration())
+        {
+            // Insert special bitfield operator
+            auto mos = el_long(TYuint, bf.fieldWidth * 256 + bf.bitOffset);
+            e = el_bin(OPbit, e.Ety, e, mos);
+        }
         if (tybasic(e.Ety) == TYstruct)
         {
             e.ET = Type_toCtype(dve.type);

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1766,6 +1766,18 @@ public:
         bodyToBuffer(d);
     }
 
+    override void visit(BitFieldDeclaration d)
+    {
+        if (stcToBuffer(buf, d.storage_class))
+            buf.writeByte(' ');
+        Identifier id = d.isAnonymous() ? null : d.ident;
+        typeToBuffer(d.type, id, buf, hgs);
+        buf.writestring(" : ");
+        d.width.expressionToBuffer(buf, hgs);
+        buf.writeByte(';');
+        buf.writenl();
+    }
+
     override void visit(NewDeclaration d)
     {
         if (stcToBuffer(buf, d.storage_class & ~STC.static_))

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -90,6 +90,7 @@ public:
     void visit(AST.ClassDeclaration s) { visit(cast(AST.AggregateDeclaration)s); }
     void visit(AST.InterfaceDeclaration s) { visit(cast(AST.ClassDeclaration)s); }
     void visit(AST.TemplateMixin s) { visit(cast(AST.TemplateInstance)s); }
+    void visit(AST.BitFieldDeclaration s) { visit(cast(AST.VarDeclaration)s); }
 
     //============================================================================================
     // Statements

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -173,7 +173,21 @@ public:
             {
                 foreach (v; sym.fields)
                 {
-                    symbol_struct_addField(cast(Symbol*)t.ctype.Ttag, v.ident.toChars(), Type_toCtype(v.type), v.offset);
+                    if (auto bf = v.isBitFieldDeclaration())
+                        symbol_struct_addBitField(cast(Symbol*)t.ctype.Ttag, v.ident.toChars(), Type_toCtype(v.type), v.offset, bf.fieldWidth, bf.bitOffset);
+                    else
+                        symbol_struct_addField(cast(Symbol*)t.ctype.Ttag, v.ident.toChars(), Type_toCtype(v.type), v.offset);
+                }
+            }
+            else
+            {
+                foreach (v; sym.fields)
+                {
+                    if (auto bf = v.isBitFieldDeclaration())
+                    {
+                        symbol_struct_hasBitFields(cast(Symbol*)t.ctype.Ttag);
+                        break;
+                    }
                 }
             }
 

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -139,6 +139,7 @@ class OverDeclaration;
 class VarDeclaration;
 class SymbolDeclaration;
 class ThisDeclaration;
+class BitFieldDeclaration;
 
 class TypeInfoDeclaration;
 class TypeInfoStructDeclaration;
@@ -383,6 +384,7 @@ public:
     virtual void visit(ClassDeclaration *s) { visit((AggregateDeclaration *)s); }
     virtual void visit(InterfaceDeclaration *s) { visit((ClassDeclaration *)s); }
     virtual void visit(TemplateMixin *s) { visit((TemplateInstance *)s); }
+    virtual void visit(BitFieldDeclaration *s) { visit((VarDeclaration *)s); }
 
     // Statements
     virtual void visit(ImportStatement *s) { visit((Statement *)s); }

--- a/test/fail_compilation/alignas2.c
+++ b/test/fail_compilation/alignas2.c
@@ -7,9 +7,7 @@ fail_compilation/alignas2.c(110): Error: no alignment-specifier for parameters
 fail_compilation/alignas2.c(115): Error: no alignment-specifier for parameters
 fail_compilation/alignas2.c(116): Error: no declaration for identifier `x`
 fail_compilation/alignas2.c(121): Error: no alignment-specifier for bit field declaration
-fail_compilation/alignas2.c(121): Error: bit fields are not supported
 fail_compilation/alignas2.c(122): Error: no alignment-specifier for bit field declaration
-fail_compilation/alignas2.c(122): Error: unnamed bit fields are not supported
 ---
  */
 

--- a/test/fail_compilation/bitfields1.c
+++ b/test/fail_compilation/bitfields1.c
@@ -1,0 +1,19 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/bitfields1.c(103): Error: no alignment-specifier for bit field declaration
+fail_compilation/bitfields1.c(109): Error: empty struct-declaration-list for `struct T`
+---
+ */
+
+#line 100
+
+struct S
+{
+    _Alignas(4) int a:3;
+};
+
+struct T
+{
+    :3;
+};
+

--- a/test/fail_compilation/bitfields2.c
+++ b/test/fail_compilation/bitfields2.c
@@ -1,0 +1,18 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/bitfields2.c(103): Error: bit-field type `float` is not an integer type
+fail_compilation/bitfields2.c(104): Error: bit-field width `3.0` is not an integer constant
+fail_compilation/bitfields2.c(105): Error: bit-field `c` has zero width
+fail_compilation/bitfields2.c(106): Error: width `60` of bit-field `d` does not fit in type `int`
+---
+ */
+
+#line 100
+
+struct S
+{
+    float a:3;
+    int b:3.0;
+    int c:0;
+    int d:60;
+};

--- a/test/runnable/bitfields.c
+++ b/test/runnable/bitfields.c
@@ -1,0 +1,29 @@
+int printf(const char *fmt, ...);
+void exit(int);
+
+struct S
+{
+    int a:2, b:4;
+};
+
+_Static_assert(sizeof(struct S) == 4, "in");
+
+int main()
+{
+    struct S s;
+    s.a = 3;
+    if (s.a != -1)
+    {
+        printf("error %d\n", s.a);
+        exit(1);
+    }
+
+    s.b = 4;
+    if (s.b != 4)
+    {
+        printf("error %d\n", s.b);
+        exit(1);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This is a reboot of https://github.com/dlang/dmd/pull/12722

1. It does not have the `AnonBitFieldDeclaration`, this is handled by using anonymous declarations
2. It does not have the `TypeBitField`, but uses `FieldState` instead
3. It is hooked up to the code in the DMC back end that does bit fields already (being a C compiler), so they work
4. static initialization of bit fields is not implemented
5. the rather complicated layout of non-trivial bit fields for Posix is not implemented. There's some stub code here for that that is disabled. This is complicated enough that it merits its own PR
6. symbolic debug info is there for Win32, but not the other platforms

This is enough code for one PR.