### PR TITLE
Put isReturnIsolated check after cheaper checks

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -855,12 +855,13 @@ MATCH implicitConvTo(Expression e, Type t)
             /* Allow the result of strongly pure functions to
              * convert to immutable
              */
-            if (e.f && e.f.isReturnIsolated() &&
+            if (e.f &&
                 (global.params.useDIP1000 != FeatureState.enabled ||        // lots of legacy code breaks with the following purity check
                  e.f.isPure() >= PURE.strong ||
                  // Special case exemption for Object.dup() which we assume is implemented correctly
                  e.f.ident == Id.dup &&
-                 e.f.toParent2() == ClassDeclaration.object.toParent())
+                 e.f.toParent2() == ClassDeclaration.object.toParent()) &&
+                 e.f.isReturnIsolated() // check isReturnIsolated last, because it is potentially expensive.
                )
             {
                 result = e.type.immutableOf().implicitConvTo(t);


### PR DESCRIPTION
Extracts the re-ordering part of https://github.com/dlang/dmd/pull/12930, since that PR is stalled and this should be a simple uncontroversial change that improves codebases using dip1000.