### PR TITLE
dmd.dclass: Make isBaseOf pure nothrow @nogc

### DIFF
--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -418,7 +418,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
      * Determine if 'this' is a base class of cd.
      * This is used to detect circular inheritance only.
      */
-    final bool isBaseOf2(ClassDeclaration cd)
+    final bool isBaseOf2(ClassDeclaration cd) pure nothrow @nogc
     {
         if (!cd)
             return false;
@@ -438,22 +438,13 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     /*******************************************
      * Determine if 'this' is a base class of cd.
      */
-    bool isBaseOf(ClassDeclaration cd, int* poffset)
+    bool isBaseOf(ClassDeclaration cd, int* poffset) pure nothrow @nogc
     {
         //printf("ClassDeclaration.isBaseOf(this = '%s', cd = '%s')\n", toChars(), cd.toChars());
         if (poffset)
             *poffset = 0;
         while (cd)
         {
-            /* cd.baseClass might not be set if cd is forward referenced.
-             */
-            if (!cd.baseClass && cd.semanticRun < PASS.semanticdone && !cd.isInterfaceDeclaration())
-            {
-                cd.dsymbolSemantic(null);
-                if (!cd.baseClass && cd.semanticRun < PASS.semanticdone)
-                    cd.error("base class is forward referenced by `%s`", toChars());
-            }
-
             if (this == cd.baseClass)
                 return true;
 
@@ -1037,7 +1028,7 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
      *      false   not a base
      *      true    is a base
      */
-    override bool isBaseOf(ClassDeclaration cd, int* poffset)
+    override bool isBaseOf(ClassDeclaration cd, int* poffset) pure nothrow @nogc
     {
         //printf("%s.InterfaceDeclaration.isBaseOf(cd = '%s')\n", toChars(), cd.toChars());
         assert(!baseClass);
@@ -1120,7 +1111,7 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
  * Returns:
  *    true if the `bc` implements `id`, false otherwise
  **/
-private bool baseClassImplementsInterface(InterfaceDeclaration id, BaseClass* bc, int* poffset)
+private bool baseClassImplementsInterface(InterfaceDeclaration id, BaseClass* bc, int* poffset) pure nothrow @nogc
 {
     //printf("%s.InterfaceDeclaration.isBaseOf(bc = '%s')\n", id.toChars(), bc.sym.toChars());
     for (size_t j = 0; j < bc.baseInterfaces.length; j++)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5689,6 +5689,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     || global.params.useDeprecated != DiagnosticReporting.error;
                 const bool preventAliasThis = e.targ.hasDeprecatedAliasThis && !deprecationAllowed;
 
+                // baseClass might not be set if either targ or tspec is forward referenced.
+                if (auto tc = e.targ.isTypeClass())
+                    tc.sym.dsymbolSemantic(null);
+                if (auto tc = e.tspec.isTypeClass())
+                    tc.sym.dsymbolSemantic(null);
+
                 if (preventAliasThis && e.targ.ty == Tstruct)
                 {
                     if ((cast(TypeStruct) e.targ).implicitConvToWithoutAliasThis(e.tspec))


### PR DESCRIPTION
Pull 2/2 (previous #12996).

Removes call to `dsymbolSemantic` and the `error` from `isBaseOf`.  Rationale being that all `isXXX` methods and functions should not have any hidden side-effects.

The only found place that depended on lazy semantic analysis was `IsExp`, so the call to `dsymbolSemantic` has been moved there instead.  If any regressions found as a result of this, please raise an issue and ping me immediately. :-)

FYI @benjones 