### PR TITLE
Fix issue 22227 - `if (scope f = x())` and `while (scope f = x())` do not parse

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -5560,6 +5560,10 @@ LagainStc:
             stc = STC.ref_;
             goto LagainStc;
 
+        case TOK.scope_:
+            stc = STC.scope_;
+            goto LagainStc;
+
         case TOK.auto_:
             stc = STC.auto_;
             goto LagainStc;

--- a/test/fail_compilation/test22227.d
+++ b/test/fail_compilation/test22227.d
@@ -1,0 +1,16 @@
+/* REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test22227.d(12): Error: scope variable `foo` may not be returned
+fail_compilation/test22227.d(14): Error: scope variable `foo` may not be returned
+---
+*/
+
+int[] foo() @safe
+{
+    if (scope foo = [1])
+        return foo;
+    while (scope foo = [1])
+        return foo;
+    return [];
+}


### PR DESCRIPTION
Spec PR: https://github.com/dlang/dlang.org/pull/3091