### PR TITLE
Fix memory corruption bug in DtBuilder.cat

### DIFF
--- a/src/dmd/backend/dt.d
+++ b/src/dmd/backend/dt.d
@@ -209,6 +209,23 @@ nothrow:
         pTail = &head;
     }
 
+    /************************************
+     * Useful for checking if DtBuilder got initialized.
+     */
+    void checkInitialized()
+    {
+        if (!head)
+            assert(pTail == &head);
+    }
+
+    /************************************
+     * Print state of DtBuilder for debugging.
+     */
+    void print()
+    {
+        debug printf("DtBuilder: %p head: %p, pTail: %p\n", &head, head, pTail);
+    }
+
     /*************************
      * Finish and return completed data structure.
      */
@@ -478,10 +495,13 @@ nothrow:
      */
     void cat(ref DtBuilder dtb)
     {
-        assert(!*pTail);
-        *pTail = dtb.head;
-        pTail = dtb.pTail;
-        assert(!*pTail);
+        if (dtb.head) // if non-zero length
+        {
+            assert(!*pTail);
+            *pTail = dtb.head;
+            pTail = dtb.pTail; // if dtb is zero length, this will point pTail to dtb.head, oops
+            assert(!*pTail);
+        }
     }
 
     /**************************************


### PR DESCRIPTION
Cat'ing two empty DtBuilders results in memory corruption. Took me too long to track this down. Don't have a good way to make a test case.