### PR TITLE
Fix Issue 22228 - [CTFE] taking address of immutable in frame function causes ICE on Unix platform

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2213,6 +2213,16 @@ public:
             return;
         }
         result = getVarExp(e.loc, istate, e.var, goal);
+        /*
+         * https://issues.dlang.org/show_bug.cgi?id=22228
+         *
+         * getVarExp may return an expression that is an
+         * rvalue even if the goal is LValue. This is problematic
+         * for parent AST nodes such as AddrExp that explicitly
+         * expect an lvalue from interpretation
+         */
+        if (goal == CTFEGoal.LValue && !result.isLvalue())
+            result = e;
         if (exceptionOrCant(result))
             return;
 

--- a/test/compilable/test22228.d
+++ b/test/compilable/test22228.d
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=22228
+
+auto f()
+{   immutable int i;
+    auto p = (() => &i)();
+
+    return 0;
+}
+
+enum ctfeInvocation = f;


### PR DESCRIPTION
```d
auto f()
{   immutable int i;
    auto p = (() => &i)();

    return 0;
}

enum ctfeInvocation = f;
```

`&i` is viewed as a SymOffExp before being rewritten to an `AddrExp`. If the delegate is not present, this code never calls `visit(AddrExp)` and therefore the bug does not manifest. In the delegate scenario, the `FuncExp` is interpreted and it peels of the delegate, returning `&i`, but then, a subsequent call to interpret is made which rewrites the expression to `&0` that in turn fails the assert.

I don't really understand the subtleties of why certain calls to `interpret` are made, so this fix might not be the best. But to me it seems that it is wrong that `visit(VarExp)` with `goal = LValue` is allowed to return an rvalue. Fixing this, seems to pass the testsuite.