### PR TITLE
fix Issue 15298 - Can't call nested template function unless it's anonymous

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -7287,7 +7287,20 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 }
                 TemplateInstance ti = sa.isTemplateInstance();
                 Declaration d = sa.isDeclaration();
-                if ((td && td.literal) || (ti && ti.enclosing) || (d && !d.isDataseg() && !(d.storage_class & STC.manifest) && (!d.isFuncDeclaration() || d.isFuncDeclaration().isNested()) && !isTemplateMixin()))
+                /* Have nested arguments when the `alias` parameter...
+                 * 1. `td` is a template function literal
+                 * 2. `ti` is a nested template instantiation
+                 *    (See https://issues.dlang.org/show_bug.cgi?id=9578)
+                 * 3. `d` is a local variable or nested function
+                 * 4. `td` is a nested template function
+                 *    (See https://issues.dlang.org/show_bug.cgi?id=15298)
+                 */
+                if ((td && td.literal) ||
+                    (ti && ti.enclosing) ||
+                    (d && !d.isDataseg() && !(d.storage_class & STC.manifest) &&
+                     (!d.isFuncDeclaration() || d.isFuncDeclaration().isNested()) &&
+                     !isTemplateMixin()) ||
+                    (td && !td.isstatic && td.onemember && td.onemember.isFuncDeclaration()))
                 {
                     Dsymbol dparent = sa.toParent2();
                     if (!dparent)

--- a/test/compilable/issue15298.d
+++ b/test/compilable/issue15298.d
@@ -1,0 +1,27 @@
+// https://issues.dlang.org/show_bug.cgi?id=15298
+
+// Call alias with a parameter.
+void callAlias(alias f)()
+{
+    f(42);
+}
+
+alias Identity(alias X) = X;
+
+void main()
+{
+    int local;
+
+    // Declare an anonymous function template
+    // which writes to a local.
+    alias a = Identity!((i) { local = i; });
+
+    // Declare a function template which does
+    // the same thing.
+    void b(T)(T i) { local = i; }
+
+    callAlias!a; // Works
+    callAlias!b; // Error: function test.main.b!int.b is a
+                 // nested function and cannot be accessed
+                 // from test.callAlias!(b).callAlias
+}

--- a/test/compilable/issue21287.d
+++ b/test/compilable/issue21287.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=21287
+
+struct A {}
+
+alias canMatch(alias handler) = (A arg) => handler(arg);
+
+struct StructuralSumType
+{
+    void opDispatch()
+    {
+        void fun(Value)(Value _) {}
+        alias lambda = (_) {};
+
+        alias ok = canMatch!lambda;
+        alias err = canMatch!fun;
+    }
+}


### PR DESCRIPTION
Treat nested template functions the same as template function literals when passing them by alias.