### PR TITLE
dmd: backend: trust printf call introduced by PR #13000

### DIFF
--- a/src/dmd/backend/dt.d
+++ b/src/dmd/backend/dt.d
@@ -221,7 +221,7 @@ nothrow:
     /************************************
      * Print state of DtBuilder for debugging.
      */
-    void print()
+    void print() @trusted
     {
         debug printf("DtBuilder: %p head: %p, pTail: %p\n", &head, head, pTail);
     }


### PR DESCRIPTION
Bootstrapping the compiler with versions erlier than 2.082 makes it fail
because it uses `debug` to bypass `@safe`, a feature that was introduced in
2.082.

Since `printf` is @safe with "%p" formatter, according to C99 standard, it can
be marked as @trusted.

Co-authored-by: Paul Backus <snarwin@gmail.com>
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

CC @ibuclaw @pbackus 