### PR TITLE
fix Issue 22236 - sizeof an empty C struct should be 0, not 1

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -52,6 +52,8 @@ enum ClassKind : ubyte
     cpp,
     /// the aggregate is an Objective-C class/interface
     objc,
+    /// the aggregate is a C struct
+    c,
 }
 
 /**

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -57,7 +57,9 @@ enum class ClassKind : uint8_t
   /// the aggregate is a C++ struct/class/interface
   cpp,
   /// the aggregate is an Objective-C class/interface
-  objc
+  objc,
+  /// the aggregate is a C struct
+  c,
 };
 
 struct MangleOverride

--- a/src/dmd/backend/dt.d
+++ b/src/dmd/backend/dt.d
@@ -156,7 +156,7 @@ uint dt_size(const(dt_t)* dtstart)
 
 bool dtallzeros(const(dt_t)* dt)
 {
-    return dt.dt == DT_azeros && !dt.DTnext;
+    return dt && dt.dt == DT_azeros && !dt.DTnext;
 }
 
 /************************************

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -301,8 +301,9 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         if (structsize == 0)
         {
             hasNoFields = true;
-            structsize = 1;
             alignsize = 1;
+            if (classKind != classKind.c) // C gets a struct size of 0
+                structsize = 1;
         }
 
         // Round struct size up to next alignsize boundary.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4342,6 +4342,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (sc.linkage == LINK.cpp)
                 sd.classKind = ClassKind.cpp;
+            else if (sc.linkage == LINK.c)
+                sd.classKind = ClassKind.c;
             sd.cppnamespace = sc.namespace;
             sd.cppmangle = sc.cppmangle;
         }

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1149,6 +1149,7 @@ enum class ClassKind : uint8_t
     d = 0u,
     cpp = 1u,
     objc = 2u,
+    c = 3u,
 };
 
 enum class CPPMANGLE : uint8_t

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1543,6 +1543,9 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                     case ClassKind.objc:
                         link = LINK.objc;
                         break;
+                    case ClassKind.c:
+                        link = LINK.c;
+                        break;
                 }
             }
         }

--- a/test/compilable/zerosize.d
+++ b/test/compilable/zerosize.d
@@ -1,0 +1,12 @@
+
+extern (C) struct S { }
+
+static assert(S.sizeof == 0);
+static assert(S.alignof == 1);
+
+extern (C++) struct T { }
+
+static assert(T.sizeof == 1);
+static assert(T.alignof == 1);
+
+


### PR DESCRIPTION
I'd forgotten about this little incompatibility between C and C++. Rediscovered it while working on ImportC. I'm surprised it has not been reported yet.

Anyhow, this is needed for ImportC as well.

Note: This is not just for ImportC. It is also for:
```
extern (C) struct S { }
```