### PR TITLE
Remove inappropriate array index error on slice copy

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2245,7 +2245,7 @@ extern (C++) class ToElemVisitor : Visitor
                         }
 
                         // Construct: (c || arrayBoundsError)
-                        echeck = el_bin(OPoror, TYvoid, c, buildArrayIndexError(irs, ae.loc, el_copytree(eleny), el_copytree(elen)));
+                        echeck = el_bin(OPoror, TYvoid, c, buildRangeError(irs, ae.loc));
                     }
                     else
                     {


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/12871#issuecomment-904620951

Reverts back to an uninformative "Range Error". Slice copy was completely overlooked in https://github.com/dlang/druntime/pull/3517, new druntime support has to be added before it can be improved again.