### PR TITLE
test: Add missing EXTRA_FILES to compilable/test21464.d

### DIFF
--- a/test/compilable/test21464.d
+++ b/test/compilable/test21464.d
@@ -1,4 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=21464
+// EXTRA_FILES: imports/test21464a.d
 void foo() pure
 {
     import imports.test21464a : Mallocator;


### PR DESCRIPTION
Self explanatory.  Used by the dejagnu testsuite, which processes and runs tests outside of the source tree (or even on a remote device).