### PR TITLE
Fix Issue 19320 - -cov and -O yield variable used before set

### DIFF
--- a/src/dmd/backend/gother.d
+++ b/src/dmd/backend/gother.d
@@ -476,7 +476,8 @@ private void chkrd(elem *n, Barray!(elem*) rdlist)
         }
     }
 
-    version (MARS)
+    //version (MARS)
+    version(none)
     {
         /* Watch out for:
             void test()

--- a/test/compilable/test19320.d
+++ b/test/compilable/test19320.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=19320
+
+// REQUIRED_ARGS: -O -cov
+
+auto staticArray(U, T)(T)
+{
+    U[] theArray = void;
+    return theArray;
+}
+
+
+void main()
+{
+    staticArray!(int, int)(3);
+}


### PR DESCRIPTION
A few things to consider here:

- I tried debugging the backend for a few hours but I do not understand it sufficiently
  to fix this properly. It seems that the code works correctly if  `-O` is used without `-cov`.
   While I was digging, it seems that [numdefelems](https://github.com/dlang/dmd/blob/master/src/dmd/backend/gflow.d#L222) does not return
  the correct result when the coverage code is analysed. I am not entirely sure if coverage
 code should simply be skipped when performing this optimization step or if this bug
 may manifest in other user-provided code too.
- The backend emitting errors is just plain weird. We should probably not do that at all.
- This PR disables the emitted error for now. If this solution is accepted, the function `chkrd`
  should be deleted alltogether.
- The deleted error is not covered by any tests.

Thoughts?

cc @WalterBright 