### PR TITLE
test: Reduce runnable/test15568.d to remove Phobos dependency

### DIFF
--- a/test/runnable/test15568.d
+++ b/test/runnable/test15568.d
@@ -1,8 +1,22 @@
 // REQUIRED_ARGS: -unittest -main -O
 // https://issues.dlang.org/show_bug.cgi?id=15568
 
-import std.algorithm;
-import std.array;
+auto filter(alias pred)(D[])
+{
+    struct FilterResult
+    {
+        void popFront()
+        {
+            pred(null);
+        }
+
+        D[] array()
+        {
+            return null;
+        }
+    }
+    return FilterResult();
+}
 
 class A
 {


### PR DESCRIPTION
Verified with dmd 2.069.0
```
# /dlang/dmd2/linux/bin64/dmd --version
DMD64 D Compiler v2.069.0
Copyright (c) 1999-2015 by Digital Mars written by Walter Bright
# /dlang/dmd2/linux/bin64/dmd -main -unittest -O -run test15568.d
core.exception.AssertError@test15568.d(26): Assertion failure
----------------
??:? _d_assert [0x420b5b]
??:? void test15568.__assert(int) [0x41fd1c]
??:? _D9test155681A3fooMFC9test155681CAS9test155681DbZ9__requireMFZv [0x41fbac]
??:? test15568.B test15568.A.foo(test15568.C, test15568.D[], bool) [0x41faf3]
??:? void test15568.__unittestL51_2() [0x41fbea]
??:? void test15568.__modtest() [0x41fcc8]
??:? int core.runtime.runModuleUnitTests().__foreachbody2(object.ModuleInfo*) [0x42447a]
??:? int object.ModuleInfo.opApply(scope int delegate(object.ModuleInfo*)).__lambda2(immutable(object.ModuleInfo*)) [0x42095b]
??:? int rt.minfo.moduleinfos_apply(scope int delegate(immutable(object.ModuleInfo*))).__foreachbody2(ref rt.sections_elf_shared.DSO) [0x4219a2]
??:? int rt.sections_elf_shared.DSO.opApply(scope int delegate(ref rt.sections_elf_shared.DSO)) [0x421a31]
??:? int rt.minfo.moduleinfos_apply(scope int delegate(immutable(object.ModuleInfo*))) [0x421933]
??:? int object.ModuleInfo.opApply(scope int delegate(object.ModuleInfo*)) [0x420937]
??:? runModuleUnitTests [0x4242ed]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [0x42160e]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x4215bc]
??:? _d_run_main [0x421519]
??:? main [0x41fde5]
??:? __libc_start_main [0xec769f44]
```