### PR TITLE
test: Reduce runnable/link11931.d to remove Phobos dependency

### DIFF
--- a/test/runnable/imports/test11931a.d
+++ b/test/runnable/imports/test11931a.d
@@ -1,7 +1,5 @@
 module imports.test11931a;
 
-import std.stdio;
-
 import imports.test11931d;
 import imports.test11931b;
 

--- a/test/runnable/imports/test11931d.d
+++ b/test/runnable/imports/test11931d.d
@@ -1,7 +1,20 @@
 module imports.test11931d;
 
-import std.array;
-import std.algorithm;
+template filter(alias pred)
+{
+    auto filter(Range)(Range r)
+    {
+        struct FilterResult
+        {
+            Range array()
+            {
+                return data;
+            }
+            Range data;
+        }
+        return FilterResult(r);
+    }
+}
 
 struct ConnectionPoint
 {


### PR DESCRIPTION
Verified on 2.065-b1.
```
# /dlang/dmd2065b1/linux/bin64/dmd -v | head -n1
DMD64 D Compiler v2.065
# /dlang/dmd2065b1/linux/bin64/dmd -g -c link11931.d 
# /dlang/dmd2065b1/linux/bin64/dmd -g -c imports/test11931a.d
# /dlang/dmd2065b1/linux/bin64/dmd -g -c imports/test11931b.d
# /dlang/dmd2065b1/linux/bin64/dmd -g -c imports/test11931c.d
# /dlang/dmd2065b1/linux/bin64/dmd -g -c imports/test11931d.d
# /dlang/dmd2065b1/linux/bin64/dmd -g *.o
test11931a.o: In function `_D7imports10test11931a6Engine8__mixin23fooMFZv':
/dlang/test/imports/test11931b.d:17: undefined reference to `_D7imports10test11931d13__T6SignalTvZ6Signal3addMFNaNbNfDFZvZS7imports10test11931d15ConnectionPoint'
collect2: error: ld returned 1 exit status
--- errorlevel 1
```
vs. the 2.065.0 release binary.
```
# /dlang/dmd2065/linux/bin64/dmd -v | head -n1
DMD64 D Compiler v2.065
# /dlang/dmd2065/linux/bin64/dmd -g -c link11931.d 
# /dlang/dmd2065/linux/bin64/dmd -g -c imports/test11931a.d
# /dlang/dmd2065/linux/bin64/dmd -g -c imports/test11931b.d
# /dlang/dmd2065/linux/bin64/dmd -g -c imports/test11931c.d
# /dlang/dmd2065/linux/bin64/dmd -g -c imports/test11931d.d
# /dlang/dmd2065/linux/bin64/dmd -g *.o
# ./link11931 
```