### PR TITLE
[perf] Only sort relocations once before object file emission

### DIFF
--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -257,8 +257,6 @@ struct seg_data
     //ELFOBJ
     IDXSYM           SDsymidx;          // each section is in the symbol table
     IDXSEC           SDrelidx;          // section header for relocation info
-    targ_size_t      SDrelmaxoff;       // maximum offset encountered
-    int              SDrelindex;        // maximum offset encountered
     int              SDrelcnt;          // number of relocations added
     IDXSEC           SDshtidxout;       // final section header table index
     Symbol          *SDsym;             // if !=NULL, comdat symbol

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -28,6 +28,9 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
 
+// qsort is only nothrow in newer versions of druntime (since 2.081.0)
+private extern(C) void qsort(scope void* base, size_t nmemb, size_t size, _compare_fp_t compar) nothrow @nogc;
+
 import dmd.backend.barray;
 import dmd.backend.cc;
 import dmd.backend.cdef;


### PR DESCRIPTION
Before this patch the backend would run an insertion sort,
every time a new relocation was added which has O(N^2) behavior
this is currently the biggest bottleneck when generating code with
a huge number of symbols.

cc @WalterBright 