### PR TITLE
test: Remove phobos dependency from old runnable tests

### DIFF
--- a/test/runnable/builtin.d
+++ b/test/runnable/builtin.d
@@ -1,4 +1,4 @@
-import std.math;
+import core.math;
 import core.bitop;
 
 version (DigitalMars)
@@ -7,6 +7,20 @@ version (DigitalMars)
         version = AnyX86;
     else version (X86)
         version = AnyX86;
+}
+
+bool isClose(real lhs, real rhs, real maxRelDiff = 1e-09L, real maxAbsDiff = 0.0)
+{
+    if (lhs == rhs)
+        return true;
+    if (lhs == lhs.infinity || rhs == rhs.infinity ||
+        lhs == -lhs.infinity || rhs == -rhs.infinity)
+        return false;
+
+    auto diff = fabs(lhs - rhs);
+    return diff <= maxRelDiff*fabs(lhs)
+        || diff <= maxRelDiff*fabs(rhs)
+        || diff <= maxAbsDiff;
 }
 
 /*******************************************/
@@ -20,13 +34,6 @@ void test1()
     f = 6.8L;
     assert(cos(f) == cos(6.8L));
     static assert(isClose(cos(6.8L), 0x1.bd21aaf88dcfa13ap-1));
-
-    f = 6.8L;
-    version (Win64)
-    { }
-    else
-        assert(tan(f) == tan(6.8L));
-    static assert(isClose(tan(6.8L), 0x1.22fd752af75cd08cp-1));
 }
 
 /*******************************************/

--- a/test/runnable/complex.d
+++ b/test/runnable/complex.d
@@ -5,10 +5,8 @@ TEST_OUTPUT:
 ---
 */
 
-import core.stdc.math : isnan;
-import std.math : signbit;
+import core.stdc.math : isnan, signbit;
 import core.stdc.stdio;
-import std.stdio;
 
 template AliasSeq(T...) { alias T AliasSeq; }
 
@@ -434,12 +432,9 @@ void test16()
      creal d = n + 3i;
      creal e = m + 3i;
 
-     // should print "111"
-     writeln(signbit(c.re), signbit(d.re), signbit(e.re));
-
-     assert(signbit(c.re) == 1);
-     assert(signbit(d.re) == 1);
-     assert(signbit(e.re) == 1);
+     assert(signbit(c.re) != 0);
+     assert(signbit(d.re) != 0);
+     assert(signbit(e.re) != 0);
 }
 
 /************************************/

--- a/test/runnable/constfold.d
+++ b/test/runnable/constfold.d
@@ -2,8 +2,7 @@
 
 static assert(__LINE__ == 3); // fails as __LINE__ is 2
 
-import std.stdio;
-import std.math : signbit, sqrt;
+import core.stdc.math : signbit;
 
 
 /************************************/
@@ -184,25 +183,6 @@ static assert(['a','b','c','d'] == "abcd");
 static assert("efgh" == ['e','f','g','h']);
 static assert("efgi" != ['e','f','g','h']);
 
-static assert((2 ^^ 8) == 256);
-static assert((3 ^^ 8.0) == 6561);
-static assert((4.0 ^^ 8) == 65536);
-static assert((5.0 ^^ 8.0) == 390625);
-
-static assert((0.5 ^^ 3) == 0.125);
-static assert((1.5 ^^ 3.0) == 3.375);
-static assert((2.5 ^^ 3) == 15.625);
-static assert((3.5 ^^ 3.0) == 42.875);
-
-static assert(((-2) ^^ -5.0) == -0.031250);
-static assert(((-2.0) ^^ -6) == 0.015625);
-static assert(((-2.0) ^^ -7.0) == -0.0078125);
-
-static assert((144 ^^ 0.5) == 12);
-static assert((1089 ^^ 0.5) == 33);
-static assert((1764 ^^ 0.5) == 42);
-static assert((650.25 ^^ 0.5) == 25.5);
-
 
 void test1()
 {
@@ -232,8 +212,6 @@ void test2()
     {
         float f = float.infinity;
         int i = cast(int) f;
-        writeln(i);
-        writeln(cast(int)float.max);
         assert(i == cast(int)float.max);
         assert(i == 0x80000000);
     }
@@ -246,11 +224,8 @@ void test3()
      real n = -0.0;
      const real m = -0.0;
 
-     // should print "11"
-     writeln(signbit(n), signbit(m));
-
-     assert(signbit(n) == 1);
-     assert(signbit(m) == 1);
+     assert(signbit(n) != 0);
+     assert(signbit(m) != 0);
 }
 
 /************************************/
@@ -472,21 +447,6 @@ void test9058()
 }
 
 /************************************/
-// https://issues.dlang.org/show_bug.cgi?id=11159
-
-void test11159()
-{
-    import std.math : pow;
-    enum ulong
-        e_2_pow_64 = 2uL^^64,
-        e_10_pow_19 = 10uL^^19,
-        e_10_pow_20 = 10uL^^20;
-    assert(e_2_pow_64 == pow(2uL, 64));
-    assert(e_10_pow_19 == pow(10uL, 19));
-    assert(e_10_pow_20 == pow(10uL, 20));
-}
-
-/************************************/
 // https://issues.dlang.org/show_bug.cgi?id=12306
 
 void test12306()
@@ -633,11 +593,9 @@ int main()
     test8400();
     test8939();
     test9058();
-    test11159();
     test13977();
     test13978();
     test14459();
 
-    printf("Success\n");
     return 0;
 }

--- a/test/runnable/ctorpowtests.d
+++ b/test/runnable/ctorpowtests.d
@@ -11,10 +11,19 @@ int magicVariable()
 
 static assert(magicVariable()==3);
 
-void main()
+/************************************/
+// https://issues.dlang.org/show_bug.cgi?id=11159
+
+void test11159()
 {
-    assert(!__ctfe);
-    assert(magicVariable()==2);
+    import std.math : pow;
+    enum ulong
+        e_2_pow_64 = 2uL^^64,
+        e_10_pow_19 = 10uL^^19,
+        e_10_pow_20 = 10uL^^20;
+    assert(e_2_pow_64 == pow(2uL, 64));
+    assert(e_10_pow_19 == pow(10uL, 19));
+    assert(e_10_pow_20 == pow(10uL, 20));
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=991 -- invalid.
@@ -30,6 +39,25 @@ static assert( 2.0 ^^ 3 == 8.0);
 
 static assert( 2.0 ^^ 4 == 16.0);
 static assert( 2 ^^ 4 == 16);
+
+static assert((2 ^^ 8) == 256);
+static assert((3 ^^ 8.0) == 6561);
+static assert((4.0 ^^ 8) == 65536);
+static assert((5.0 ^^ 8.0) == 390625);
+
+static assert((0.5 ^^ 3) == 0.125);
+static assert((1.5 ^^ 3.0) == 3.375);
+static assert((2.5 ^^ 3) == 15.625);
+static assert((3.5 ^^ 3.0) == 42.875);
+
+static assert(((-2) ^^ -5.0) == -0.031250);
+static assert(((-2.0) ^^ -6) == 0.015625);
+static assert(((-2.0) ^^ -7.0) == -0.0078125);
+
+static assert((144 ^^ 0.5) == 12);
+static assert((1089 ^^ 0.5) == 33);
+static assert((1764 ^^ 0.5) == 42);
+static assert((650.25 ^^ 0.5) == 25.5);
 
 // Check the typing rules.
 static assert( is (typeof(2.0^^7) == double));
@@ -233,4 +261,13 @@ int anotherPowTest()
 {
    double x = 5.0;
    return x^^4 > 2.0 ? 3: 2;
+}
+
+/************************************/
+
+void main()
+{
+    assert(!__ctfe);
+    assert(magicVariable()==2);
+    test11159();
 }

--- a/test/runnable/imports/std11file.d
+++ b/test/runnable/imports/std11file.d
@@ -1,0 +1,6 @@
+module imports.std11file;
+
+string getcwd() @trusted
+{
+    return "/dlang/test/runnable";
+}

--- a/test/runnable/imports/test24a.d
+++ b/test/runnable/imports/test24a.d
@@ -1,3 +1,3 @@
 module imports.test24a;
 
-public import std.string;
+public import imports.test24c;

--- a/test/runnable/imports/test24b.d
+++ b/test/runnable/imports/test24b.d
@@ -1,3 +1,3 @@
 module imports.test24b;
 
-public import std.string;
+public import imports.test24c;

--- a/test/runnable/imports/test24c.d
+++ b/test/runnable/imports/test24c.d
@@ -1,0 +1,6 @@
+module imports.test24c;
+
+immutable(Char)[] format(Char, Args...)(in Char[] fmt, Args args)
+{
+    return "3";
+}

--- a/test/runnable/imports/test27a.d
+++ b/test/runnable/imports/test27a.d
@@ -1,10 +1,17 @@
 module imports.test27a;
 
-import std.variant;
+struct Variant
+{
+    this(T)(T)
+    {
+    }
+}
 
-class myClass(T) {
+class myClass(T)
+{
 public:
-    void func(T v) {
+    void func(T v)
+    {
         Variant b = Variant(v);
     }
 }

--- a/test/runnable/lazy.d
+++ b/test/runnable/lazy.d
@@ -1,5 +1,5 @@
 import core.vararg;
-import std.stdio;
+import core.stdc.stdio;
 
 /*********************************************************/
 
@@ -104,9 +104,14 @@ void bar3(...)
     assert(va_arg!int(_argptr) == 14);
 }
 
+void arr3(...)
+{
+    assert(_arguments.length == 1);
+    assert(va_arg!(int[])(_argptr) == [1,0,0,0,0,0,0,0,0,9]);
+}
+
 void abc3(int* p)
 {
-    writeln(*p);
     assert(*p == 3);
 }
 
@@ -114,15 +119,13 @@ void test3()
 {
     int x = 3;
     dotimes3(10, abc3(&x));
-    dotimes3(10, write(++x));
-    writeln();
+    dotimes3(10, ++x);
     dotimes3(1, bar3(++x));
 
     int[10] a = new int[10];
     a[0] = 1;
     a[$ - 1] = 9;
-    dotimes3(3, write(a[0..$]));
-    writeln();
+    dotimes3(3, arr3(a[0..$]));
 }
 
 /*********************************************************/
@@ -132,7 +135,6 @@ int p4;
 void foo4(void* delegate()[] dgs...)
 {
     assert(dgs.length == 4);
-    writefln("%s %s", dgs[0](), cast(void*)&p4);
     assert(dgs[0]() == cast(void*)&p4);
     assert(dgs[1]() == cast(void*)&p4);
     assert(dgs[2]() == null);
@@ -143,7 +145,6 @@ void test4()
 {
     void *abc()
     {
-        writeln(cast(void*)&p4);
         return cast(void*)&p4;
     }
 

--- a/test/runnable/test11.d
+++ b/test/runnable/test11.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS:
+// EXTRA_SOURCES: imports/std11file.d
 
 extern(C) int printf(const char*, ...);
 extern(C) size_t strlen(const char*);
@@ -1181,8 +1182,8 @@ void test62()
 
 class A63
 {
-     private import std.file;
-     alias std.file.getcwd getcwd;
+     private import imports.std11file;
+     alias imports.std11file.getcwd getcwd;
 }
 
 void test63()

--- a/test/runnable/test24.d
+++ b/test/runnable/test24.d
@@ -1,4 +1,5 @@
 // EXTRA_SOURCES: imports/test24a.d imports/test24b.d
+// EXTRA_FILES: imports/test24c.d
 // PERMUTE_ARGS:
 // REQUIRED_ARGS:
 
@@ -6,5 +7,5 @@ import imports.test24a, imports.test24b;
 
 void main()
 {
-    string hi = std.string.format("%s", 3);
+    string hi = imports.test24c.format("%s", 3);
 }

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -2,9 +2,6 @@ module test;
 
 import core.stdc.stdio;
 import core.vararg;
-import std.stdio;
-import std.string;
-
 
 /*******************************************/
 
@@ -116,20 +113,18 @@ void test8()
 {
    int[] test;
    test.length = 10;
-   // Show address of array start and its length (10)
-   writefln("%s %s", cast(uint)test.ptr, test.length);
+   assert(test.length == 10);
+   assert(test.ptr != null);
 
    test.length = 1;
-   // Show address of array start and its length (1)
-   writefln("%s %s", cast(uint)test.ptr, test.length);
+   assert(test.length == 1);
+   assert(test.ptr != null);
 
    test.length = 8;
-   // Show address of array start and its length (8)
-   writefln("%s %s", cast(uint)test.ptr, test.length);
+   assert(test.length == 8);
+   assert(test.ptr != null);
 
    test.length = 0;
-   // Shows 0 and 0!
-   writefln("%s %s", cast(uint)test.ptr, test.length);
    assert(test.length == 0);
    assert(test.ptr != null);
 }
@@ -386,11 +381,9 @@ void test22()
 void test23()
 {
     auto t=['a','b','c','d'];
-    writeln(typeid(typeof(t)));
     assert(is(typeof(t) == char[]));
 
     const t2=['a','b','c','d','e'];
-    writeln(typeid(typeof(t2)));
     assert(is(typeof(t2) == const(const(char)[])));
 }
 
@@ -662,7 +655,6 @@ template a34(string name, T...)
         string localchar;
         foreach (a34; T)
         {
-            writefln(`hello`);
             localchar ~= a34.mangleof;
         }
         return localchar;
@@ -671,7 +663,7 @@ template a34(string name, T...)
 
 void test34()
 {
-    writeln(a34!("Adf"[], typeof("adf"),uint)("Adf"[],"adf",1234));
+    assert(a34!("Adf"[], typeof("adf"),uint)("Adf"[],"adf",1234) == "Ayak");
 }
 
 /*******************************************/
@@ -696,7 +688,6 @@ template a36(AnotherT,string name,T...){
         AnotherT localchar;
         foreach(a;T)
         {
-            writefln(`hello`);
             localchar~=a.mangleof;
         }
         return cast(AnotherT)localchar;
@@ -708,7 +699,7 @@ void test36()
     string b="adf";
     uint i=123;
     char[3] c="Adf";
-    writeln(a36!(typeof(b),"Adf")());
+    assert(a36!(typeof(b),"Adf")() == "");
 }
 
 /*******************************************/
@@ -754,8 +745,7 @@ void test39()
 {
     void print(string[] strs)
     {
-        writeln(strs);
-        assert(format("%s", strs) == `["Matt", "Andrew"]`);
+        assert(strs == ["Matt", "Andrew"]);
     }
 
     print(["Matt", "Andrew"]);
@@ -777,7 +767,7 @@ void test40()
 
     with (c.propName)
     {
-        writeln(toString());
+        assert(toString() == "test.test40.C");
     }
 
     auto foo = c.propName;
@@ -803,7 +793,7 @@ void test41()
     assert(x3 == 1);
 
     //test [0 .. 2] = 'b'; // this line should assert
-    writef ("%s\n", test.ptr [0 .. 2]);
+    assert(test.ptr[0 .. 2] == "ba");
 }
 
 /*******************************************/
@@ -820,6 +810,12 @@ void test42()
 
 /*******************************************/
 
+void vararg43(string fmt, ...)
+{
+    assert(_arguments[0] is typeid(const string));
+    assert(va_arg!(const string)(_argptr) == "hello");
+}
+
 struct A43
 {
     static const MY_CONST_STRING = "hello";
@@ -828,7 +824,7 @@ struct A43
     {
         // This will either print garbage or throw a UTF exception.
         // But if never_called() is commented out, then it will work.
-        writefln("%s", MY_CONST_STRING);
+        vararg43("%s", MY_CONST_STRING);
     }
 }
 
@@ -836,7 +832,7 @@ void never_called43()
 {
     // This can be anything; there just needs to be a reference to
     // A43.MY_CONST_STRING somewhere.
-    writefln("%s", A43.MY_CONST_STRING);
+    vararg43("%s", A43.MY_CONST_STRING);
 }
 
 void test43()
@@ -847,6 +843,12 @@ void test43()
 
 /*******************************************/
 
+void vararg44(string fmt, ...)
+{
+    assert(_arguments[0] is typeid(const string));
+    assert(va_arg!(const string)(_argptr) == "hello");
+}
+
 class A44
 {
     static const MY_CONST_STRING = "hello";
@@ -855,7 +857,7 @@ class A44
     {
         // This will either print garbage or throw a UTF exception.
         // But if never_called() is commented out, then it will work.
-        writefln("%s", MY_CONST_STRING);
+        vararg44("%s", MY_CONST_STRING);
     }
 }
 
@@ -863,7 +865,7 @@ void never_called44()
 {
     // This can be anything; there just needs to be a reference to
     // A44.MY_CONST_STRING somewhere.
-    writefln("%s", A44.MY_CONST_STRING);
+    vararg44("%s", A44.MY_CONST_STRING);
 }
 
 void test44()
@@ -1050,13 +1052,11 @@ void test58()
     static S a = {i: 1};
     static S b;
 
-    writefln("a.bar: %s, %s", a.bar, a.abc);
     assert(a.i == 1);
     assert(a.bar[0] == 4);
     assert(a.bar[1] == 4);
     assert(a.bar[2] == 4);
     assert(a.bar[3] == 4);
-    writefln("b.bar: %s, %s", b.bar, b.abc);
     assert(b.i == 0);
     assert(b.bar[0] == 4);
     assert(b.bar[1] == 4);
@@ -1067,10 +1067,18 @@ void test58()
 
 /*******************************************/
 
+void vararg59(...)
+{
+    if (_arguments[0] is typeid(size_t))
+        assert(va_arg!size_t(_argptr) == 454);
+    else
+        assert(va_arg!string(_argptr) == "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234");
+}
+
 void bug59(string s)()
 {
-  writeln(s);
-  writeln(s.length);
+  vararg59(s);
+  vararg59(s.length);
 }
 
 void test59()
@@ -1113,7 +1121,6 @@ void test62()
     Vector62 a;
     a.set(1,2,24);
     a = a * 2;
-    writeln(a.x, a.y, a.z);
     assert(a.x == 2);
     assert(a.y == 4);
     assert(a.z == 48);
@@ -1165,8 +1172,6 @@ void test63()
 {
     Data63 d; d.x = 1; d.y = 2;
     d = frob(d);
-    writeln(d.x);
-    writeln(d.y);
     assert(d.x == 3 && d.y == -1);
 }
 
@@ -1174,8 +1179,8 @@ void test63()
 
 class Foo64
 {
-    this() { writefln("Foo64 created"); }
-    ~this() { writefln("Foo64 destroyed"); }
+    this() { }
+    ~this() { }
 }
 
 template Mix64()

--- a/test/runnable/test34.d
+++ b/test/runnable/test34.d
@@ -1,17 +1,8 @@
-/*
-TEST_OUTPUT:
----
-Object
----
-*/
-
 module test34;
 
-import std.stdio;
-import std.string;
-import std.format;
 import core.exception;
-
+import core.stdc.stdio;
+import core.vararg;
 
 /************************************************/
 
@@ -25,16 +16,12 @@ void test1()
 
     auto hfoo = ti_foo.toHash();
     auto hbar = ti_bar.toHash();
-    writefln("typeid(Foo).toHash: ", hfoo);
-    writefln("typeid(Bar).toHash: ", hbar);
     assert(hfoo != hbar);
 
     auto e = (ti_foo == ti_bar);
-    writefln("opEquals: ", e ? "equal" : "not equal");
     assert(!e);
 
     auto c = (ti_foo.opCmp(ti_bar) == 0);
-    writefln("opCmp: ", c ? "equal" : "not equal");
     assert(!c);
 }
 
@@ -62,7 +49,6 @@ Struct[1] table;
 Struct getfirst()
 {
     foreach(v; table) {
-        writeln(v.langID);
         assert(v.langID == 1);
         return v;
     }
@@ -72,7 +58,6 @@ Struct getfirst()
 Struct getsecond()
 {
     foreach(ref v; table) {
-        writeln(v.langID);
         assert(v.langID == 1);
         return v;
     }
@@ -84,11 +69,9 @@ void test3()
     table[0].langID = 1;
 
     auto v = getfirst();
-    writeln(v.langID);
     assert(v.langID == 1);
 
     v = getsecond();
-    writeln(v.langID);
     assert(v.langID == 1);
 }
 
@@ -197,11 +180,6 @@ template parseInteger(string s)
 
 void test7()
 {
-    writeln(parseUinteger!("1234abc").value);
-    writeln(parseUinteger!("1234abc").rest);
-    writeln(parseInteger!("-1234abc").value);
-    writeln(parseInteger!("-1234abc").rest);
-
     assert(parseUinteger!("1234abc").value == "1234");
     assert(parseUinteger!("1234abc").rest == "abc");
     assert(parseInteger!("-1234abc").value == "-1234");
@@ -283,10 +261,8 @@ class B34 : A34 { }
 void test11()
 {
   A34 test=new B34;
-  writefln("Test is ", test.toString);
   assert(test.toString == "test34.B34");
   A34 test_2=cast(A34)(new B34);
-  writefln("Test 2 is ", test_2.toString);
   assert(test_2.toString == "test34.B34");
 }
 
@@ -356,7 +332,6 @@ struct Iterator16(T : Basic16!(T, U), U)
 {
     static void Foo()
     {
-        writeln(typeid(T), typeid(U));
         assert(is(T == int));
         assert(is(U == float));
     }
@@ -528,11 +503,8 @@ template Mang(alias F)
 
 template moo(alias A)
 {
-    pragma(msg,"   ");
     const string a = Mang!(A).mangledname;
-    pragma(msg,"   ");
     static assert(Mang!(A).mangledname == a); // FAILS !!!
-    pragma(msg,"   ");
 }
 
 void test27()
@@ -657,8 +629,37 @@ struct Vector34
 
     public string toString()
     {
-        return std.string.format("<%f, %f, %f>", x, y, z);
+        return formatImpl("<%f, %f, %f>", x, y, z);
     }
+
+    private static string formatImpl(string fmt, ...)
+    {
+        string ret = "<";
+        bool comma;
+        foreach (arg; _arguments)
+        {
+            assert(arg is typeid(float));
+            if (comma)
+                ret ~= ", ";
+            auto f = va_arg!float(_argptr);
+            if (f == 1)
+                ret ~= "1.000000";
+            else if (f == 0)
+                ret ~= "0.000000";
+            else
+                assert(0);
+            comma = true;
+        }
+        ret ~= ">";
+        return ret;
+    }
+}
+
+string format34(string fmt, ...)
+{
+    assert(_arguments[0] is typeid(Vector34));
+    auto arg = va_arg!Vector34(_argptr);
+    return arg.toString();
 }
 
 class Foo34
@@ -678,17 +679,12 @@ class Foo34
     private void bar()
     {
         auto s = foobar();
-        writef("Returned: %s\n", s);
-        assert(std.string.format("%s", s) == "<1.000000, 0.000000, 0.000000>");
+        assert(format34("%s", s) == "<1.000000, 0.000000, 0.000000>");
     }
 
     public Vector34 foobar()
     {
-        writef("Returning %s\n", v);
-
         return v;
-        Vector34 b = Vector34();
-        return b;
     }
 }
 
@@ -780,37 +776,66 @@ Rect defaultRect() {
 
 /************************************************/
 
+void varargs39(...)
+{
+    if (_arguments[0] is typeid(double[]))
+    {
+        auto arg = va_arg!(double[])(_argptr);
+        assert(arg.length == 1 && arg[0] == 1 || arg[0] == 2);
+    }
+    else if (_arguments[0] is typeid(double[][]))
+    {
+        auto arg = va_arg!(double[][])(_argptr);
+        assert(arg == [[1],[2]]);
+    }
+    else if (_arguments[0] is typeid(double[1][]))
+    {
+        auto arg = va_arg!(double[1][])(_argptr);
+        assert(arg == [[1], [2]]);
+    }
+    else
+        assert(0);
+}
+
 void test39()
 {
    double[][] foo = [[1.0],[2.0]];
 
-   writeln(foo[0]); // --> [1] , ok
-   writeln(foo[1]); // --> [2] , ok
-
-   writeln(foo);       // --> [[1],4.63919e-306]  ack!
-   writefln("%s", foo); // --> ditto
-   auto f = std.string.format("%s", foo);
-   assert(f == "[[1], [2]]");
+   varargs39(foo[0]); // --> [1] , ok
+   varargs39(foo[1]); // --> [2] , ok
+   varargs39(foo);    // --> [[1],4.63919e-306]  ack!
 
    double[1][2] bar;
    bar[0][0] = 1.0;
    bar[1][0] = 2.0;
 
-   writeln(bar);       // Error: Access violation
-   auto r = std.string.format("%s", bar);
-   assert(r == "[[1], [2]]");
+   varargs39(bar);    // Error: Access violation
 }
 
 /************************************************/
+
+void varargs40(...)
+{
+    if (_arguments[0] is typeid(int[char]))
+    {
+        auto x = va_arg!(int[char])(_argptr);
+        assert(x == ['b':123]);
+    }
+    else if (_arguments[0] is typeid(int))
+    {
+        auto x = va_arg!int(_argptr);
+        assert(x == 123);
+    }
+    else
+        assert(0);
+}
 
 void test40()
 {
     int[char] x;
     x['b'] = 123;
-    writeln(x);
-    auto r = std.string.format("%s", x);
-    assert(r == "['b':123]");
-    writeln(x['b']);
+    varargs40(x);
+    varargs40(x['b']);
 }
 
 /************************************************/
@@ -854,12 +879,28 @@ void test44()
 
 /************************************************/
 
+void varargs45(...)
+{
+    if (_arguments[0] is typeid(const(char[3])[]))
+    {
+        auto a = va_arg!(const(char[3])[])(_argptr);
+        assert(a == ["abc", "def"]);
+    }
+    else if (_arguments[0] is typeid(const(char)[][]))
+    {
+        auto b = va_arg!(const(char)[][])(_argptr);
+        assert(b == ["abc", "def"]);
+    }
+    else
+        assert(0);
+}
+
 void test45()
 {
-    //char[3][] a = ["abc", "def"];
-    //writefln(a);
-    //char[][2] b = ["abc", "def"];
-    //writefln(b);
+    const(char)[3][] a = ["abc", "def"];
+    varargs45(a);
+    const(char)[][2] b = ["abc", "def"];
+    varargs45(b);
 }
 
 /************************************************/
@@ -980,26 +1021,22 @@ void test49()
 
   version (all)
   {
-    writefln("Before test 1: ", a.v);
-    if (a == a.init) { writeln(a.v,"(a==a.init)"); assert(0); }
-    else { writeln(a.v,"(a!=a.init)"); assert(a.v == 10); }
+    if (a == a.init) { assert(0); }
+    else { assert(a.v == 10); }
   }
   else
   {
-    writefln("Before test 1: ", a.v);
-    if (a == a.init) { writeln(a.v,"(a==a.init)"); assert(a.v == 10); }
-    else { writeln(a.v,"(a!=a.init)"); assert(0); }
+    if (a == a.init) { assert(a.v == 10); }
+    else { assert(0); }
   }
 
     a.v = 100;
-    writefln("Before test 2: ", a.v);
-    if (a == a.init) { writeln(a.v,"(a==a.init)"); assert(0); }
-    else { writeln(a.v,"(a!=a.init)"); assert(a.v == 100); }
+    if (a == a.init) { assert(0); }
+    else { assert(a.v == 100); }
 
     a = A(1000);
-    writefln("Before test 3: ", a.v);
-    if (a == a.init) { writeln(a.v,"(a==a.init)"); assert(0); }
-    else { writeln(a.v,"(a!=a.init)"); assert(a.v == 1000); }
+    if (a == a.init) { assert(0); }
+    else { assert(a.v == 1000); }
 
   version (all)
     assert(a.init.v == 0);
@@ -1043,14 +1080,6 @@ struct TestStruct
 
 void func53(TestStruct[2] testarg)
 {
-    writeln(testarg[0].dummy0);
-    writeln(testarg[0].dummy1);
-    writeln(testarg[0].dummy2);
-
-    writeln(testarg[1].dummy0);
-    writeln(testarg[1].dummy1);
-    writeln(testarg[1].dummy2);
-
     assert(testarg[0].dummy0 == 0);
     assert(testarg[0].dummy1 == 1);
     assert(testarg[0].dummy2 == 2);
@@ -1064,7 +1093,6 @@ TestStruct[2] m53;
 
 void test53()
 {
-    writeln(&m53);
     func53(m53);
 }
 
@@ -1075,13 +1103,11 @@ void test54()
     double a = 0;
     double b = 1;
     // Internal error: ..\ztc\cg87.c 3233
-//    a += (1? b: 1+1i)*1i;
-    writeln(a);
-//    assert(a == 0);
+    a += ((1? b: 1+1i)*1i).re;
+    assert(a == 0);
     // Internal error: ..\ztc\cod2.c 1680
-//    a += (b?1:b-1i)*1i;
-    writeln(a);
-//    assert(a == 0);
+    a += ((b?1:b-1i)*1i).re;
+    assert(a == 0);
 }
 
 /************************************************/
@@ -1100,7 +1126,7 @@ void test55()
 /************************************************/
 
 template t56() { alias Object t56; }
-pragma(msg, t56!().stringof);
+static assert(t56!().stringof == "Object");
 
 void test56()
 {
@@ -1114,9 +1140,6 @@ void test57()
 
     static if (is(AA T : T[U], U : const char[]))
     {
-        writeln(typeid(T));
-        writeln(typeid(U));
-
         assert(is(T == long));
         assert(is(U == const(char)[]));
     }
@@ -1128,9 +1151,7 @@ void test57()
 
     static if (is(int[10] W : W[V], int V))
     {
-        writeln(typeid(W));
         assert(is(W == int));
-        writeln(V);
         assert(V == 10);
     }
 

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -6,7 +6,6 @@ extern(C) int printf(const char*, ...);
 extern(C) int memcmp(const void *s1, const void *s2, size_t n);
 
 import core.memory;  // for GC.collect
-import std.random;   // for uniform random numbers
 
 /************************************************/
 
@@ -423,13 +422,9 @@ void test16()
 {
     int[int] aa;
 
-    Random gen;
     for (int i = 0; i < 50000; i++)
     {
-        int key = uniform(0, int.max, gen);
-        int value = uniform(0, int.max, gen);
-
-        aa[key] = value;
+        aa[i] = i;
     }
 
     int[] keys = aa.keys;
@@ -441,7 +436,7 @@ void test16()
         assert(k in aa);
         j += aa[k];
     }
-    printf("test16 = %d\n", j);
+    assert(j == 1249975000);
 
     int m;
     foreach (k, v; aa)
@@ -470,10 +465,7 @@ void test16()
 
     for (int i = 0; i < 1000; i++)
     {
-        int key2 = uniform(0, int.max, gen);
-        int value2 = uniform(0, int.max, gen);
-
-        aa[key2] = value2;
+        aa[i] = i;
     }
     foreach(k; aa)
     {

--- a/test/runnable/testline.d
+++ b/test/runnable/testline.d
@@ -6,7 +6,6 @@
 
 module dstress.run.line_token_03;
 
-import std.stdio;
 import core.exception;
 
 int main(){
@@ -20,8 +19,6 @@ int main(){
 
         assert(0);
 }
-
-import std.stdio;
 
 /*
  * @WARNING@: this code depends on the phobos implementation.
@@ -38,6 +35,5 @@ void checkFileSpec(Object o){
                 }
         }
 
-writeln(str);
         assert(str[start .. start+3]=="(1)");
 }


### PR DESCRIPTION
Pretty much all these tests were added with the commit message "add a bunch of tests".

The majority of them that use writefln/format would have been testing the old Phobos implementation that made use of D variadic functions and the TypeInfo va_arg implementation.