### PR TITLE
Fix issue 20340 - -main inserts D main function even with betterC

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -362,7 +362,8 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     {
         if (params.addMain && m.srcfile.toString() == "__main.d")
         {
-            auto data = arraydup("int main(){return 0;}\0\0\0\0"); // need 2 trailing nulls for sentinel and 2 for lexer
+            // need 2 trailing nulls for sentinel and 2 for lexer
+            auto data = arraydup("version(D_BetterC)extern(C)int main(){return 0;} else int main(){return 0;}\0\0\0\0");
             m.srcBuffer = new FileBuffer(cast(ubyte[]) data[0 .. $-4]);
         }
         else if (m.srcfile.toString() == "__stdin.d")

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -363,7 +363,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         if (params.addMain && m.srcfile.toString() == "__main.d")
         {
             // need 2 trailing nulls for sentinel and 2 for lexer
-            auto data = arraydup("version(D_BetterC)extern(C)int main(){return 0;} else int main(){return 0;}\0\0\0\0");
+            auto data = arraydup("version(D_BetterC)extern(C)int main(){return 0;}else int main(){return 0;}\0\0\0\0");
             m.srcBuffer = new FileBuffer(cast(ubyte[]) data[0 .. $-4]);
         }
         else if (m.srcfile.toString() == "__stdin.d")

--- a/test/runnable/testbcmain.d
+++ b/test/runnable/testbcmain.d
@@ -1,0 +1,5 @@
+
+// REQUIRED_ARGS: -betterC -main
+
+void foo() { }
+

--- a/test/runnable/testbcmain.d
+++ b/test/runnable/testbcmain.d
@@ -1,5 +1,0 @@
-
-// REQUIRED_ARGS: -betterC -main
-
-void foo() { }
-

--- a/test/runnable/testmain.d
+++ b/test/runnable/testmain.d
@@ -1,5 +1,6 @@
 
 // REQUIRED_ARGS: -main
+// PERMUTE_ARGS: -betterC
 
 void foo() { }
 


### PR DESCRIPTION
I'm not able to run dmd's test suite due to std.format errors, but this fixes the error:

```
$ ../../generated/linux/release/64/dmd -betterC -main -run testbcmain.d 
$ ../../generated/linux/release/64/dmd -main -run testmain.d 
$ diff testmain.d testbcmain.d
2c2
< // REQUIRED_ARGS: -main
---
> // REQUIRED_ARGS: -betterC -main
```
I initially fixed this with a test against params.betterC, in https://github.com/jrfondren/dmd/commit/c8c6279d6c7631d620eec9d169e125e5d89ad97d , but thought this might be more robust.