### PR TITLE
Bitfields posix

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -3037,14 +3037,9 @@ final class CParser(AST) : Parser!AST
             check(TOK.rightCurly);
 
             if ((*members).length == 0) // C11 6.7.2.1-8
-                /* TODO: not strict enough, should really be contains "no named members",
-                 * not just "no members".
-                 * I.e. an unnamed bit field, _Static_assert, etc, are not named members,
-                 * but will pass this check.
-                 * Be careful to detect named members that come anonymous structs.
-                 * Correctly doing this will likely mean moving it to typesem.d.
-                 */
-                error("empty struct-declaration-list for `%s %s`", Token.toChars(structOrUnion), tag ? tag.toChars() : "Anonymous".ptr);
+            {
+                // allow empty structs as an extension
+            }
         }
         else if (!tag)
             error("missing tag `identifier` after `%s`", Token.toChars(structOrUnion));
@@ -3139,12 +3134,14 @@ final class CParser(AST) : Parser!AST
                 dt = tspec;
             }
             else
-                dt = cparseDeclarator(DTR.xdirect, tspec, id);
-            if (!dt)
             {
-                panic();
-                nextToken();
-                break;          // error recovery
+                dt = cparseDeclarator(DTR.xdirect, tspec, id);
+                if (!dt)
+                {
+                    panic();
+                    nextToken();
+                    break;          // error recovery
+                }
             }
 
             AST.Expression width;

--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -3038,7 +3038,10 @@ final class CParser(AST) : Parser!AST
 
             if ((*members).length == 0) // C11 6.7.2.1-8
             {
-                // allow empty structs as an extension
+                /* allow empty structs as an extension
+                 *  struct-declarator-list:
+                 *    struct-declarator (opt)
+                 */
             }
         }
         else if (!tag)

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1192,7 +1192,7 @@ extern (C++) class VarDeclaration : Declaration
         /* If coming after a bit field in progress,
          * advance past the field
          */
-	fieldState.inFlight = false;
+        fieldState.inFlight = false;
 
         const sz = t.size(loc);
         assert(sz != SIZE_INVALID && sz < uint.max);
@@ -1778,7 +1778,7 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
         }
         else if (target.os & Target.OS.Posix)
         {
-	    if (fieldState.fieldSize == 8 &&
+            if (fieldState.fieldSize == 8 &&
                 fieldState.bitOffset + fieldWidth > 64)
             {
                 startNewField();
@@ -1796,18 +1796,18 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
                 startNewField();
             }
         }
-	else
-	    assert(0);
+        else
+            assert(0);
 
         offset = fieldState.fieldOffset;
         bitOffset = fieldState.bitOffset;
 
-	const pastField = bitOffset + fieldWidth;
-	if (target.os & Target.OS.Posix)
-	{
-	    fieldState.fieldSize = (pastField + 7) / 8;
-	    ad.structsize = offset + fieldState.fieldSize;
-	}
+        const pastField = bitOffset + fieldWidth;
+        if (target.os & Target.OS.Posix)
+        {
+            fieldState.fieldSize = (pastField + 7) / 8;
+            ad.structsize = offset + fieldState.fieldSize;
+        }
 
         //fieldState.fieldSize = memsize;
         if (!isunion)

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -225,11 +225,13 @@ enum : int
  */
 struct FieldState
 {
-    uint offset;        /// offset for next field
+    uint offset;        /// byte offset for next field
 
-    uint fieldOffset;   /// offset for the start of the bit field
+    uint fieldOffset;   /// byte offset for the start of the bit field
+    uint fieldSize;     /// byte size of field
+    uint fieldAlign;    /// byte alignment of field
     uint bitOffset;     /// bit offset for field
-    uint fieldSize;     /// size of field in bytes
+
     bool inFlight;      /// bit field is in flight
 }
 

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -145,8 +145,10 @@ struct FieldState
     unsigned offset;
 
     unsigned fieldOffset;
+    unsigned fieldSize;
+    unsigned fieldAlign;
     unsigned bitOffset;
-    unsigned fieldSice;
+
     bool inFlight;
 };
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2483,22 +2483,25 @@ struct FieldState final
 {
     uint32_t offset;
     uint32_t fieldOffset;
-    uint32_t bitOffset;
     uint32_t fieldSize;
+    uint32_t fieldAlign;
+    uint32_t bitOffset;
     bool inFlight;
     FieldState() :
         offset(),
         fieldOffset(),
-        bitOffset(),
         fieldSize(),
+        fieldAlign(),
+        bitOffset(),
         inFlight()
     {
     }
-    FieldState(uint32_t offset, uint32_t fieldOffset = 0u, uint32_t bitOffset = 0u, uint32_t fieldSize = 0u, bool inFlight = false) :
+    FieldState(uint32_t offset, uint32_t fieldOffset = 0u, uint32_t fieldSize = 0u, uint32_t fieldAlign = 0u, uint32_t bitOffset = 0u, bool inFlight = false) :
         offset(offset),
         fieldOffset(fieldOffset),
-        bitOffset(bitOffset),
         fieldSize(fieldSize),
+        fieldAlign(fieldAlign),
+        bitOffset(bitOffset),
         inFlight(inFlight)
         {}
 };

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -900,7 +900,13 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
             finishInFlightBitField();
         }
         // This relies on all bit fields in the same storage location have the same type
-        bitFieldSize = cast(uint)vd.type.size();
+        if (bf)
+        {
+            if (target.c.bitFieldStyle == TargetC.BitFieldStyle.Gcc_Clang)
+                bitFieldSize = (bitOffset + bf.fieldWidth + 7) / 8;
+            else
+                bitFieldSize = cast(uint)vd.type.size();
+        }
 
         assert(offset <= vd.offset);
         if (offset < vd.offset)

--- a/test/compilable/zerosize.d
+++ b/test/compilable/zerosize.d
@@ -8,5 +8,3 @@ extern (C++) struct T { }
 
 static assert(T.sizeof == 1);
 static assert(T.alignof == 1);
-
-

--- a/test/fail_compilation/bitfields1.c
+++ b/test/fail_compilation/bitfields1.c
@@ -1,7 +1,9 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/bitfields1.c(103): Error: no alignment-specifier for bit field declaration
-fail_compilation/bitfields1.c(109): Error: empty struct-declaration-list for `struct T`
+fail_compilation/bitfields1.c(108): Error: specifier-qualifier-list required
+fail_compilation/bitfields1.c(111): Error: specifier-qualifier-list required
+fail_compilation/bitfields1.c(112): Error: specifier-qualifier-list required
 ---
  */
 
@@ -16,4 +18,7 @@ struct T
 {
     :3;
 };
+
+struct E1 { :0; int x; };
+struct E2 { int x; :0; };
 

--- a/test/fail_compilation/failcstuff1.c
+++ b/test/fail_compilation/failcstuff1.c
@@ -8,7 +8,6 @@ fail_compilation/failcstuff1.c(152): Error: `;` or `,` expected
 fail_compilation/failcstuff1.c(153): Error: `void` has no value
 fail_compilation/failcstuff1.c(153): Error: missing comma
 fail_compilation/failcstuff1.c(153): Error: `;` or `,` expected
-fail_compilation/failcstuff1.c(154): Error: empty struct-declaration-list for `struct Anonymous`
 fail_compilation/failcstuff1.c(157): Error: identifier not allowed in abstract-declarator
 fail_compilation/failcstuff1.c(203): Error: storage class not allowed in specifier-qualified-list
 fail_compilation/failcstuff1.c(204): Error: storage class not allowed in specifier-qualified-list

--- a/test/runnable/bitfieldsposix32.c
+++ b/test/runnable/bitfieldsposix32.c
@@ -1,0 +1,155 @@
+/* test bitfields
+ * DISABLED: win32 win64 linux64 freebsd64 osx64
+ * RUN_OUTPUT:
+---
+T0 = 1 1 | 1 1
+T1 = 2 2 | 2 2
+T2 = 4 4 | 4 4
+T3 = 8 4 | 8 8
+T4 = 12 4 | 16 8
+T5 = 8 4 | 8 8
+S1 = 4 4 | 8 8
+S2 = 4 4 | 4 4
+S3 = 4 4 | 4 4
+S4 = 4 4 | 4 4
+S5 = 4 4 | 4 4
+S6 = 2 2 | 2 2
+S7 = 4 4 | 8 8
+S8 = 2 2 | 2 2
+S8A = 2 2 | 2 2
+S8B = 2 2 | 2 2
+S8C = 4 4 | 4 4
+S9  = 4 2 | 4 2
+S10 = 0 1 | 0 1
+S11 = 0 1 | 0 1
+S12 = 4 4 | 4 4
+S13 = 8 4 | 8 4
+S14 = 8 4 | 8 4
+S15 = 4 4 | 4 4
+S16 = 4 1 | 4 1
+S17 = 4 4 | 4 4
+S18 = 5 1 | 9 1
+A0  = 12 4 | 16 8
+S9 = x30200
+S14 = x300000201
+S15 = xe01
+S18 = 4 should be 4
+A0 = xf00000001
+---
+ */
+
+int printf(const char *fmt, ...);
+void exit(int);
+
+void assert(int n, int b)
+{
+    if (!b)
+    {
+        printf("assert fail %d\n", n);
+        exit(1);
+    }
+}
+
+int is64bit() { return sizeof(long) == 8; }  // otherwise assume 32 bit
+
+/*************************************************************/
+
+struct T0  { char x:1; };                            // 1 1
+struct T1  { short x:1; };                           // 2 2
+struct T2  { int x:1; };                             // 4 4
+struct T3  { char a,b,c,d; long long x:1; };         // 8 8
+struct T4  { char a,b,c,d,e,f,g,h; long long x:1; }; // 16 8
+struct T5  { char a,b,c,d,e,f,g; long long x:1; };   // 8 8
+struct S1  { long long int f:1; };                   // 8 8
+struct S2  { int x:1; int y:1; };                    // 4 4
+struct S3  { short c; int x:1; unsigned y:1; };      // 4 4
+struct S4  { int x:1; short y:1; };                  // 4 4
+struct S5  { short x:1; int y:1; };                  // 4 4
+struct S6  { short x:1; short y:1; };                // 2 2
+struct S7  { short x:1; int y:1; long long z:1; };   // 8 8
+struct S8  { char a; char b:1; short c:2; };         // 2 2
+struct S8A { char b:1; short c:2; };                 // 2 2
+struct S8B { char a; short b:1; char c:2; };         // 2 2
+struct S8C { char a; int b:1; };                     // 4 4
+struct S9  { char a; char b:2; short c:9; };         // 4 2 x30201
+struct S10 { };                                      // 0 1
+struct S11 { int :0; };                              // 0 1
+struct S12 { int :0; int x; };                       // 4 4
+struct S13 { unsigned x:12; unsigned x1:1; unsigned x2:1; unsigned x3:1; unsigned x4:1; int w; }; // 8 4
+struct S14 { char a; char b:4; int c:30; };          // 8 4
+struct S15 { char a; char b:2; int c:9; };           // 4 4 xe01
+struct S16 { int :32; };                             // 4 1
+struct S17 { int a:32; };                            // 4 4
+struct S18 { char a; long long :0; char b; };        // 5 1 (32 bit) 9 1 (64 bit)
+struct A0  { int a; long long b:34, c:4; };          // 12 4 (32 bit) 16 8 (64 bit)
+
+int main()
+{
+    printf("T0 = %d %d | 1 1\n", (int)sizeof(struct T0), (int)_Alignof(struct T0));
+    printf("T1 = %d %d | 2 2\n", (int)sizeof(struct T1), (int)_Alignof(struct T1));
+    printf("T2 = %d %d | 4 4\n", (int)sizeof(struct T2), (int)_Alignof(struct T2));
+    printf("T3 = %d %d | 8 8\n", (int)sizeof(struct T3), (int)_Alignof(struct T3));
+    printf("T4 = %d %d | 16 8\n", (int)sizeof(struct T4), (int)_Alignof(struct T4));
+    printf("T5 = %d %d | 8 8\n", (int)sizeof(struct T5), (int)_Alignof(struct T5));
+    printf("S1 = %d %d | 8 8\n", (int)sizeof(struct S1), (int)_Alignof(struct S1));
+    printf("S2 = %d %d | 4 4\n", (int)sizeof(struct S2), (int)_Alignof(struct S2));
+    printf("S3 = %d %d | 4 4\n", (int)sizeof(struct S3), (int)_Alignof(struct S3));
+    printf("S4 = %d %d | 4 4\n", (int)sizeof(struct S4), (int)_Alignof(struct S4));
+    printf("S5 = %d %d | 4 4\n", (int)sizeof(struct S5), (int)_Alignof(struct S5));
+    printf("S6 = %d %d | 2 2\n", (int)sizeof(struct S6), (int)_Alignof(struct S6));
+    printf("S7 = %d %d | 8 8\n", (int)sizeof(struct S7), (int)_Alignof(struct S7));
+    printf("S8 = %d %d | 2 2\n", (int)sizeof(struct S8), (int)_Alignof(struct S8));
+    printf("S8A = %d %d | 2 2\n", (int)sizeof(struct S8A), (int)_Alignof(struct S8A));
+    printf("S8B = %d %d | 2 2\n", (int)sizeof(struct S8B), (int)_Alignof(struct S8B));
+    printf("S8C = %d %d | 4 4\n", (int)sizeof(struct S8C), (int)_Alignof(struct S8C));
+    printf("S9  = %d %d | 4 2\n", (int)sizeof(struct S9),  (int)_Alignof(struct S9));
+    printf("S10 = %d %d | 0 1\n", (int)sizeof(struct S10), (int)_Alignof(struct S10));
+    printf("S11 = %d %d | 0 1\n", (int)sizeof(struct S11), (int)_Alignof(struct S11));
+    printf("S12 = %d %d | 4 4\n", (int)sizeof(struct S12), (int)_Alignof(struct S12));
+    printf("S13 = %d %d | 8 4\n", (int)sizeof(struct S13), (int)_Alignof(struct S13));
+    printf("S14 = %d %d | 8 4\n", (int)sizeof(struct S14), (int)_Alignof(struct S14));
+    printf("S15 = %d %d | 4 4\n", (int)sizeof(struct S15), (int)_Alignof(struct S15));
+    printf("S16 = %d %d | 4 1\n", (int)sizeof(struct S16), (int)_Alignof(struct S16));
+    printf("S17 = %d %d | 4 4\n", (int)sizeof(struct S17), (int)_Alignof(struct S17));
+    printf("S18 = %d %d | 9 1\n", (int)sizeof(struct S18), (int)_Alignof(struct S18));
+    printf("A0  = %d %d | 16 8\n", (int)sizeof(struct A0),  (int)_Alignof(struct A0));
+
+    {
+        struct S9 s;
+        *(unsigned *)&s = 0;
+        s.b = 2; s.c = 3;
+        unsigned x = *(unsigned *)&s;
+        printf("S9 = x%x\n", x);
+    }
+    {
+        struct S14 s = { 1, 2, 3 };
+        *(long long *)&s = 0;
+        s.a = 1;
+        s.b = 2;
+        s.c = 3;
+        unsigned long long v = *(unsigned long long *)&s;
+        printf("S14 = x%llx\n", v);
+    }
+    {
+        struct S15 s = { 1,2,3 };
+        *(unsigned *)&s = 0;
+        s.a = 1; s.b = 2; s.c = 3;
+        unsigned x = *(unsigned *)&s;
+        printf("S15 = x%x\n", x);
+    }
+    {
+        struct S18 s;
+        printf("S18 = %d should be %d\n", (int)(&s.b - &s.a), is64bit() ? 8 : 4);
+    }
+    {
+        struct A0 s;
+        *(long long *)&s = 0;
+        s.a = 1; s.b = 15;
+        long long x = *(long long *)&s;
+        printf("A0 = x%llx\n", x);
+    }
+
+    return 0;
+}
+
+

--- a/test/runnable/bitfieldsposix64.c
+++ b/test/runnable/bitfieldsposix64.c
@@ -1,0 +1,155 @@
+/* test bitfields
+ * DISABLED: win32 win64 linux32 freebsd32 osx32
+ * RUN_OUTPUT:
+---
+T0 = 1 1 | 1 1
+T1 = 2 2 | 2 2
+T2 = 4 4 | 4 4
+T3 = 8 8 | 8 8
+T4 = 16 8 | 16 8
+T5 = 8 8 | 8 8
+S1 = 8 8 | 8 8
+S2 = 4 4 | 4 4
+S3 = 4 4 | 4 4
+S4 = 4 4 | 4 4
+S5 = 4 4 | 4 4
+S6 = 2 2 | 2 2
+S7 = 8 8 | 8 8
+S8 = 2 2 | 2 2
+S8A = 2 2 | 2 2
+S8B = 2 2 | 2 2
+S8C = 4 4 | 4 4
+S9  = 4 2 | 4 2
+S10 = 0 1 | 0 1
+S11 = 0 1 | 0 1
+S12 = 4 4 | 4 4
+S13 = 8 4 | 8 4
+S14 = 8 4 | 8 4
+S15 = 4 4 | 4 4
+S16 = 4 1 | 4 1
+S17 = 4 4 | 4 4
+S18 = 9 1 | 9 1
+A0  = 16 8 | 16 8
+S9 = x30200
+S14 = x300000201
+S15 = xe01
+S18 = 8 should be 8
+A0 = x1
+---
+ */
+
+int printf(const char *fmt, ...);
+void exit(int);
+
+void assert(int n, int b)
+{
+    if (!b)
+    {
+        printf("assert fail %d\n", n);
+        exit(1);
+    }
+}
+
+int is64bit() { return sizeof(long) == 8; }  // otherwise assume 32 bit
+
+/*************************************************************/
+
+struct T0  { char x:1; };                            // 1 1
+struct T1  { short x:1; };                           // 2 2
+struct T2  { int x:1; };                             // 4 4
+struct T3  { char a,b,c,d; long long x:1; };         // 8 8
+struct T4  { char a,b,c,d,e,f,g,h; long long x:1; }; // 16 8
+struct T5  { char a,b,c,d,e,f,g; long long x:1; };   // 8 8
+struct S1  { long long int f:1; };                   // 8 8
+struct S2  { int x:1; int y:1; };                    // 4 4
+struct S3  { short c; int x:1; unsigned y:1; };      // 4 4
+struct S4  { int x:1; short y:1; };                  // 4 4
+struct S5  { short x:1; int y:1; };                  // 4 4
+struct S6  { short x:1; short y:1; };                // 2 2
+struct S7  { short x:1; int y:1; long long z:1; };   // 8 8
+struct S8  { char a; char b:1; short c:2; };         // 2 2
+struct S8A { char b:1; short c:2; };                 // 2 2
+struct S8B { char a; short b:1; char c:2; };         // 2 2
+struct S8C { char a; int b:1; };                     // 4 4
+struct S9  { char a; char b:2; short c:9; };         // 4 2 x30201
+struct S10 { };                                      // 0 1
+struct S11 { int :0; };                              // 0 1
+struct S12 { int :0; int x; };                       // 4 4
+struct S13 { unsigned x:12; unsigned x1:1; unsigned x2:1; unsigned x3:1; unsigned x4:1; int w; }; // 8 4
+struct S14 { char a; char b:4; int c:30; };          // 8 4
+struct S15 { char a; char b:2; int c:9; };           // 4 4 xe01
+struct S16 { int :32; };                             // 4 1
+struct S17 { int a:32; };                            // 4 4
+struct S18 { char a; long long :0; char b; };        // 5 1 (32 bit) 9 1 (64 bit)
+struct A0  { int a; long long b:34, c:4; };          // 12 4 (32 bit) 16 8 (64 bit)
+
+int main()
+{
+    printf("T0 = %d %d | 1 1\n", (int)sizeof(struct T0), (int)_Alignof(struct T0));
+    printf("T1 = %d %d | 2 2\n", (int)sizeof(struct T1), (int)_Alignof(struct T1));
+    printf("T2 = %d %d | 4 4\n", (int)sizeof(struct T2), (int)_Alignof(struct T2));
+    printf("T3 = %d %d | 8 8\n", (int)sizeof(struct T3), (int)_Alignof(struct T3));
+    printf("T4 = %d %d | 16 8\n", (int)sizeof(struct T4), (int)_Alignof(struct T4));
+    printf("T5 = %d %d | 8 8\n", (int)sizeof(struct T5), (int)_Alignof(struct T5));
+    printf("S1 = %d %d | 8 8\n", (int)sizeof(struct S1), (int)_Alignof(struct S1));
+    printf("S2 = %d %d | 4 4\n", (int)sizeof(struct S2), (int)_Alignof(struct S2));
+    printf("S3 = %d %d | 4 4\n", (int)sizeof(struct S3), (int)_Alignof(struct S3));
+    printf("S4 = %d %d | 4 4\n", (int)sizeof(struct S4), (int)_Alignof(struct S4));
+    printf("S5 = %d %d | 4 4\n", (int)sizeof(struct S5), (int)_Alignof(struct S5));
+    printf("S6 = %d %d | 2 2\n", (int)sizeof(struct S6), (int)_Alignof(struct S6));
+    printf("S7 = %d %d | 8 8\n", (int)sizeof(struct S7), (int)_Alignof(struct S7));
+    printf("S8 = %d %d | 2 2\n", (int)sizeof(struct S8), (int)_Alignof(struct S8));
+    printf("S8A = %d %d | 2 2\n", (int)sizeof(struct S8A), (int)_Alignof(struct S8A));
+    printf("S8B = %d %d | 2 2\n", (int)sizeof(struct S8B), (int)_Alignof(struct S8B));
+    printf("S8C = %d %d | 4 4\n", (int)sizeof(struct S8C), (int)_Alignof(struct S8C));
+    printf("S9  = %d %d | 4 2\n", (int)sizeof(struct S9),  (int)_Alignof(struct S9));
+    printf("S10 = %d %d | 0 1\n", (int)sizeof(struct S10), (int)_Alignof(struct S10));
+    printf("S11 = %d %d | 0 1\n", (int)sizeof(struct S11), (int)_Alignof(struct S11));
+    printf("S12 = %d %d | 4 4\n", (int)sizeof(struct S12), (int)_Alignof(struct S12));
+    printf("S13 = %d %d | 8 4\n", (int)sizeof(struct S13), (int)_Alignof(struct S13));
+    printf("S14 = %d %d | 8 4\n", (int)sizeof(struct S14), (int)_Alignof(struct S14));
+    printf("S15 = %d %d | 4 4\n", (int)sizeof(struct S15), (int)_Alignof(struct S15));
+    printf("S16 = %d %d | 4 1\n", (int)sizeof(struct S16), (int)_Alignof(struct S16));
+    printf("S17 = %d %d | 4 4\n", (int)sizeof(struct S17), (int)_Alignof(struct S17));
+    printf("S18 = %d %d | 9 1\n", (int)sizeof(struct S18), (int)_Alignof(struct S18));
+    printf("A0  = %d %d | 16 8\n", (int)sizeof(struct A0),  (int)_Alignof(struct A0));
+
+    {
+        struct S9 s;
+        *(unsigned *)&s = 0;
+        s.b = 2; s.c = 3;
+        unsigned x = *(unsigned *)&s;
+        printf("S9 = x%x\n", x);
+    }
+    {
+        struct S14 s = { 1, 2, 3 };
+        *(long long *)&s = 0;
+        s.a = 1;
+        s.b = 2;
+        s.c = 3;
+        unsigned long long v = *(unsigned long long *)&s;
+        printf("S14 = x%llx\n", v);
+    }
+    {
+        struct S15 s = { 1,2,3 };
+        *(unsigned *)&s = 0;
+        s.a = 1; s.b = 2; s.c = 3;
+        unsigned x = *(unsigned *)&s;
+        printf("S15 = x%x\n", x);
+    }
+    {
+        struct S18 s;
+        printf("S18 = %d should be %d\n", (int)(&s.b - &s.a), is64bit() ? 8 : 4);
+    }
+    {
+        struct A0 s;
+        *(long long *)&s = 0;
+        s.a = 1; s.b = 15;
+        long long x = *(long long *)&s;
+        printf("A0 = x%llx\n", x);
+    }
+
+    return 0;
+}
+
+


### PR DESCRIPTION
I had a lot of grief with this, due to the way Posix lays out bit fields not being documented.

The two test files are actually identical, except for the TEST_OUTPUT section. That section is generated by compiling the code with an actual C compiler, and inserting its output into that section.

I'll make a win32 and win64 version in a later PR.

@ibuclaw you have a good handle on how gcc works with this, so your review is especially appreciated. I'm not terribly confident everything is 100% right.