### PR TITLE
fix Issue 22245 - importC: Error: found `.` when expecting `)`

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -3691,15 +3691,20 @@ final class CParser(AST) : Parser!AST
             return false;
         }
 
-        if (t.value == TOK.leftBracket)
+        while (1)
         {
-            if (!skipBrackets(t))
-                return false;
-        }
-        else if (t.value == TOK.leftParenthesis)
-        {
-            if (!skipParens(t, &t))
-                 return false;
+            if (t.value == TOK.leftBracket)
+            {
+                if (!skipBrackets(t))
+                    return false;
+            }
+            else if (t.value == TOK.leftParenthesis)
+            {
+                if (!skipParens(t, &t))
+                    return false;
+            }
+            else
+                break;
         }
         pt = t;
         return true;
@@ -3750,6 +3755,8 @@ final class CParser(AST) : Parser!AST
         if (!isSpecifierQualifierList(t))
             return false;
         if (!isCDeclarator(t, DTR.xabstract))
+            return false;
+        if (t.value != TOK.rightParenthesis)
             return false;
         pt = t;
         return true;

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -389,3 +389,14 @@ __attribute__((static, unsigned, long, const, extern, register, typedef, short,
 int test22196();
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22245
+
+struct S22245 { int i; };
+
+int test22245()
+{
+    struct S22245 s;
+    return sizeof(s.i);
+}
+
+/***************************************************/


### PR DESCRIPTION
Make the `isTypeName` lookahead parser more strict so as to not confuse an `unary-expression` for a `type-name`.