### PR TITLE
Fix Issue 22214 - [REG 2.097.0] __traits(compiles) doesn't notice invalid getMember that yields type

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8722,7 +8722,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 e2x = resolveAliasThis(sc, e2x); //https://issues.dlang.org/show_bug.cgi?id=17684
             if (e2x.op == TOK.error)
                 return setResult(e2x);
-            // We skip checking the value for structs/classes as these might have
+            // We delay checking the value for structs/classes as these might have
             // an opAssign defined.
             if ((t1.ty != Tstruct && t1.ty != Tclass && e2x.checkValue()) ||
                 e2x.checkSharedAccess(sc))
@@ -9208,6 +9208,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             else
                 assert(exp.op == TOK.blit);
 
+            if (e2x.checkValue())
+                return setError();
+
             exp.e1 = e1x;
             exp.e2 = e2x;
         }
@@ -9223,6 +9226,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return;
                 }
             }
+            if (exp.e2.checkValue())
+                return setError();
         }
         else if (t1.ty == Tsarray)
         {

--- a/test/compilable/test22214.d
+++ b/test/compilable/test22214.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=22214
+
+struct S
+{
+    struct T
+    {
+    }
+}
+
+void main() {
+    const S s;
+    static if (__traits(compiles, { auto t = s.T; }))
+    {
+        auto t = s.T;
+    }
+}

--- a/test/fail_compilation/fail22084.d
+++ b/test/fail_compilation/fail22084.d
@@ -18,6 +18,6 @@ struct Destructor
 
 void test()
 {
-    auto a0 = Destructor;
+    auto a0 = Destructor();
     testVariadic(1, a0);
 }

--- a/test/fail_compilation/fail7173.d
+++ b/test/fail_compilation/fail7173.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7173.d(23): Error: cannot implicitly convert expression `b1._a.opBinary(b2._a).fun()` of type `void` to `B`
+fail_compilation/fail7173.d(23): Error: expression `b1._a.opBinary(b2._a).fun()` is `void` and has no value
 ---
 */
 struct A{


### PR DESCRIPTION
Regression caused by #12389