### PR TITLE
test: Remove Posix32 and Posix64 values from RUN_OUTPUT for MS bit-fields

### DIFF
--- a/test/runnable/bitfieldsms.c
+++ b/test/runnable/bitfieldsms.c
@@ -2,34 +2,34 @@
  * DISABLED: win32 linux32 freebsd32 osx32 linux64 freebsd64 osx64
  * RUN_OUTPUT:
 ---
-                DM |   MS |  P32 |  P64
-T0  =  1 1 ||  1 1 |  1 1 |  1 1 |  1 1
-T1  =  2 2 ||  2 2 |  2 2 |  2 2 |  2 2
-T2  =  4 4 ||  4 4 |  4 4 |  4 4 |  4 4
-T3  = 16 8 || 16 8 | 16 8 |  8 4 |  8 8
-T4  = 16 8 || 16 8 | 16 8 | 12 4 | 16 8
-T5  = 16 8 || 16 8 | 16 8 |  8 4 |  8 8
-S1  =  8 8 ||  8 8 |  8 8 |  4 4 |  8 8
-S2  =  4 4 ||  4 4 |  4 4 |  4 4 |  4 4
-S3  =  8 4 ||  8 4 |  8 4 |  4 4 |  4 4
-S4  =  8 4 ||  8 4 |  8 4 |  4 4 |  4 4
-S5  =  8 4 ||  8 4 |  8 4 |  4 4 |  4 4
-S6  =  2 2 ||  2 2 |  2 2 |  2 2 |  2 2
-S7  = 16 8 || 16 8 | 16 8 |  4 4 |  8 8
-S8  =  4 2 ||  4 2 |  4 2 |  2 2 |  2 2
-S8A =  4 2 ||  4 2 |  4 2 |  2 2 |  2 2
-S8B =  6 2 ||  6 2 |  6 2 |  2 2 |  2 2
-S8C =  8 4 ||  8 4 |  8 4 |  4 4 |  4 4
-S9  =  4 2 ||  4 2 |  4 2 |  4 2 |  4 2
-S11 =  4 1 ||  0 0 |  4 1 |  0 1 |  0 1
-S12 =  4 4 ||  4 4 |  4 4 |  4 4 |  4 4
-S13 =  8 4 ||  8 4 |  8 4 |  8 4 |  8 4
-S14 =  8 4 ||  8 4 |  8 4 |  8 4 |  8 4
-S15 =  8 4 ||  8 4 |  8 4 |  4 4 |  4 4
-S16 =  4 4 ||  0 0 |  4 4 |  4 1 |  4 1
-S17 =  4 4 ||  4 4 |  4 4 |  4 4 |  4 4
-S18 =  2 1 ||  2 1 |  2 1 |  5 1 |  9 1
-A0  = 16 8 || 16 8 | 16 8 | 12 4 | 16 8
+                DM |   MS
+T0  =  1 1 ||  1 1 |  1 1
+T1  =  2 2 ||  2 2 |  2 2
+T2  =  4 4 ||  4 4 |  4 4
+T3  = 16 8 || 16 8 | 16 8
+T4  = 16 8 || 16 8 | 16 8
+T5  = 16 8 || 16 8 | 16 8
+S1  =  8 8 ||  8 8 |  8 8
+S2  =  4 4 ||  4 4 |  4 4
+S3  =  8 4 ||  8 4 |  8 4
+S4  =  8 4 ||  8 4 |  8 4
+S5  =  8 4 ||  8 4 |  8 4
+S6  =  2 2 ||  2 2 |  2 2
+S7  = 16 8 || 16 8 | 16 8
+S8  =  4 2 ||  4 2 |  4 2
+S8A =  4 2 ||  4 2 |  4 2
+S8B =  6 2 ||  6 2 |  6 2
+S8C =  8 4 ||  8 4 |  8 4
+S9  =  4 2 ||  4 2 |  4 2
+S11 =  4 1 ||  0 0 |  4 1
+S12 =  4 4 ||  4 4 |  4 4
+S13 =  8 4 ||  8 4 |  8 4
+S14 =  8 4 ||  8 4 |  8 4
+S15 =  8 4 ||  8 4 |  8 4
+S16 =  4 4 ||  0 0 |  4 4
+S17 =  4 4 ||  4 4 |  4 4
+S18 =  2 1 ||  2 1 |  2 1
+A0  = 16 8 || 16 8 | 16 8
 S9 = x30200
 S14 = x300000201
 S15 = x201
@@ -88,35 +88,35 @@ int main()
     /* MS produces identical results for 32 and 64 bit compiles,
      * DM is 32 bit only
      */
-    printf("                DM |   MS |  P32 |  P64\n");
-    printf("T0  = %2d %d ||  1 1 |  1 1 |  1 1 |  1 1\n", (int)sizeof(struct T0), (int)_Alignof(struct T0));
-    printf("T1  = %2d %d ||  2 2 |  2 2 |  2 2 |  2 2\n", (int)sizeof(struct T1), (int)_Alignof(struct T1));
-    printf("T2  = %2d %d ||  4 4 |  4 4 |  4 4 |  4 4\n", (int)sizeof(struct T2), (int)_Alignof(struct T2));
-    printf("T3  = %2d %d || 16 8 | 16 8 |  8 4 |  8 8\n", (int)sizeof(struct T3), (int)_Alignof(struct T3));
-    printf("T4  = %2d %d || 16 8 | 16 8 | 12 4 | 16 8\n", (int)sizeof(struct T4), (int)_Alignof(struct T4));
-    printf("T5  = %2d %d || 16 8 | 16 8 |  8 4 |  8 8\n", (int)sizeof(struct T5), (int)_Alignof(struct T5));
-    printf("S1  = %2d %d ||  8 8 |  8 8 |  4 4 |  8 8\n", (int)sizeof(struct S1), (int)_Alignof(struct S1));
-    printf("S2  = %2d %d ||  4 4 |  4 4 |  4 4 |  4 4\n", (int)sizeof(struct S2), (int)_Alignof(struct S2));
-    printf("S3  = %2d %d ||  8 4 |  8 4 |  4 4 |  4 4\n", (int)sizeof(struct S3), (int)_Alignof(struct S3));
-    printf("S4  = %2d %d ||  8 4 |  8 4 |  4 4 |  4 4\n", (int)sizeof(struct S4), (int)_Alignof(struct S4));
-    printf("S5  = %2d %d ||  8 4 |  8 4 |  4 4 |  4 4\n", (int)sizeof(struct S5), (int)_Alignof(struct S5));
-    printf("S6  = %2d %d ||  2 2 |  2 2 |  2 2 |  2 2\n", (int)sizeof(struct S6), (int)_Alignof(struct S6));
-    printf("S7  = %2d %d || 16 8 | 16 8 |  4 4 |  8 8\n", (int)sizeof(struct S7), (int)_Alignof(struct S7));
-    printf("S8  = %2d %d ||  4 2 |  4 2 |  2 2 |  2 2\n", (int)sizeof(struct S8), (int)_Alignof(struct S8));
-    printf("S8A = %2d %d ||  4 2 |  4 2 |  2 2 |  2 2\n", (int)sizeof(struct S8A), (int)_Alignof(struct S8A));
-    printf("S8B = %2d %d ||  6 2 |  6 2 |  2 2 |  2 2\n", (int)sizeof(struct S8B), (int)_Alignof(struct S8B));
-    printf("S8C = %2d %d ||  8 4 |  8 4 |  4 4 |  4 4\n", (int)sizeof(struct S8C), (int)_Alignof(struct S8C));
-    printf("S9  = %2d %d ||  4 2 |  4 2 |  4 2 |  4 2\n", (int)sizeof(struct S9),  (int)_Alignof(struct S9));
-//    printf("S10 = %2d %d ||  0 0 |  * * |  0 1 |  0 1\n", (int)sizeof(struct S10), (int)_Alignof(struct S10)); // MS doesn't compile
-    printf("S11 = %2d %d ||  0 0 |  4 1 |  0 1 |  0 1\n", (int)sizeof(struct S11), (int)_Alignof(struct S11));
-    printf("S12 = %2d %d ||  4 4 |  4 4 |  4 4 |  4 4\n", (int)sizeof(struct S12), (int)_Alignof(struct S12));
-    printf("S13 = %2d %d ||  8 4 |  8 4 |  8 4 |  8 4\n", (int)sizeof(struct S13), (int)_Alignof(struct S13));
-    printf("S14 = %2d %d ||  8 4 |  8 4 |  8 4 |  8 4\n", (int)sizeof(struct S14), (int)_Alignof(struct S14));
-    printf("S15 = %2d %d ||  8 4 |  8 4 |  4 4 |  4 4\n", (int)sizeof(struct S15), (int)_Alignof(struct S15));
-    printf("S16 = %2d %d ||  0 0 |  4 4 |  4 1 |  4 1\n", (int)sizeof(struct S16), (int)_Alignof(struct S16));
-    printf("S17 = %2d %d ||  4 4 |  4 4 |  4 4 |  4 4\n", (int)sizeof(struct S17), (int)_Alignof(struct S17));
-    printf("S18 = %2d %d ||  2 1 |  2 1 |  5 1 |  9 1\n", (int)sizeof(struct S18), (int)_Alignof(struct S18));
-    printf("A0  = %2d %d || 16 8 | 16 8 | 12 4 | 16 8\n", (int)sizeof(struct A0),  (int)_Alignof(struct A0));
+    printf("                DM |   MS\n");
+    printf("T0  = %2d %d ||  1 1 |  1 1\n", (int)sizeof(struct T0), (int)_Alignof(struct T0));
+    printf("T1  = %2d %d ||  2 2 |  2 2\n", (int)sizeof(struct T1), (int)_Alignof(struct T1));
+    printf("T2  = %2d %d ||  4 4 |  4 4\n", (int)sizeof(struct T2), (int)_Alignof(struct T2));
+    printf("T3  = %2d %d || 16 8 | 16 8\n", (int)sizeof(struct T3), (int)_Alignof(struct T3));
+    printf("T4  = %2d %d || 16 8 | 16 8\n", (int)sizeof(struct T4), (int)_Alignof(struct T4));
+    printf("T5  = %2d %d || 16 8 | 16 8\n", (int)sizeof(struct T5), (int)_Alignof(struct T5));
+    printf("S1  = %2d %d ||  8 8 |  8 8\n", (int)sizeof(struct S1), (int)_Alignof(struct S1));
+    printf("S2  = %2d %d ||  4 4 |  4 4\n", (int)sizeof(struct S2), (int)_Alignof(struct S2));
+    printf("S3  = %2d %d ||  8 4 |  8 4\n", (int)sizeof(struct S3), (int)_Alignof(struct S3));
+    printf("S4  = %2d %d ||  8 4 |  8 4\n", (int)sizeof(struct S4), (int)_Alignof(struct S4));
+    printf("S5  = %2d %d ||  8 4 |  8 4\n", (int)sizeof(struct S5), (int)_Alignof(struct S5));
+    printf("S6  = %2d %d ||  2 2 |  2 2\n", (int)sizeof(struct S6), (int)_Alignof(struct S6));
+    printf("S7  = %2d %d || 16 8 | 16 8\n", (int)sizeof(struct S7), (int)_Alignof(struct S7));
+    printf("S8  = %2d %d ||  4 2 |  4 2\n", (int)sizeof(struct S8), (int)_Alignof(struct S8));
+    printf("S8A = %2d %d ||  4 2 |  4 2\n", (int)sizeof(struct S8A), (int)_Alignof(struct S8A));
+    printf("S8B = %2d %d ||  6 2 |  6 2\n", (int)sizeof(struct S8B), (int)_Alignof(struct S8B));
+    printf("S8C = %2d %d ||  8 4 |  8 4\n", (int)sizeof(struct S8C), (int)_Alignof(struct S8C));
+    printf("S9  = %2d %d ||  4 2 |  4 2\n", (int)sizeof(struct S9),  (int)_Alignof(struct S9));
+//    printf("S10 = %2d %d ||  0 0 |  * *\n", (int)sizeof(struct S10), (int)_Alignof(struct S10)); // MS doesn't compile
+    printf("S11 = %2d %d ||  0 0 |  4 1\n", (int)sizeof(struct S11), (int)_Alignof(struct S11));
+    printf("S12 = %2d %d ||  4 4 |  4 4\n", (int)sizeof(struct S12), (int)_Alignof(struct S12));
+    printf("S13 = %2d %d ||  8 4 |  8 4\n", (int)sizeof(struct S13), (int)_Alignof(struct S13));
+    printf("S14 = %2d %d ||  8 4 |  8 4\n", (int)sizeof(struct S14), (int)_Alignof(struct S14));
+    printf("S15 = %2d %d ||  8 4 |  8 4\n", (int)sizeof(struct S15), (int)_Alignof(struct S15));
+    printf("S16 = %2d %d ||  0 0 |  4 4\n", (int)sizeof(struct S16), (int)_Alignof(struct S16));
+    printf("S17 = %2d %d ||  4 4 |  4 4\n", (int)sizeof(struct S17), (int)_Alignof(struct S17));
+    printf("S18 = %2d %d ||  2 1 |  2 1\n", (int)sizeof(struct S18), (int)_Alignof(struct S18));
+    printf("A0  = %2d %d || 16 8 | 16 8\n", (int)sizeof(struct A0),  (int)_Alignof(struct A0));
 
     {
         struct S9 s;


### PR DESCRIPTION
Feel free to close this @WalterBright, but I couldn't see any benefit of including Posix values here when they are already present in bitfieldsposix32.c and bitfieldsposix64.c respectively.