### PR TITLE
fix Issue 21969 - importC: Error: bit fields are not supported

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1896,6 +1896,7 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
 
         if (!isunion)
         {
+            fieldState.offset = offset + fieldState.fieldSize;
             fieldState.bitOffset = pastField;
         }
 

--- a/test/runnable/bitfieldsms.c
+++ b/test/runnable/bitfieldsms.c
@@ -30,6 +30,17 @@ S16 =  4 4 ||  0 0 |  4 4 |  4 1 |  4 1
 S17 =  4 4 ||  4 4 |  4 4 |  4 4 |  4 4
 S18 =  2 1 ||  2 1 |  2 1 |  5 1 |  9 1
 A0  = 16 8 || 16 8 | 16 8 | 12 4 | 16 8
+A1  = 12 4 ||  * * | 12 4
+A2  = 12 4 ||  * * | 12 4
+A3  = 16 4 ||  * * | 16 4
+A4  = 12 4 ||  * * | 12 4
+A5  =  2 1 ||  * * |  2 1
+A6  =  4 2 ||  * * |  4 2
+A7  = 16 4 ||  * * | 16 4
+A8  = 12 4 ||  * * | 12 4
+A9  = 32 8 ||  * * | 32 8
+A10 =  4 2 ||  * * |  4 2
+A11 = 16 4 ||  * * | 16 4
 S9 = x30200
 S14 = x300000201
 S15 = x201
@@ -82,6 +93,25 @@ struct S16 { int :32; };                             //
 struct S17 { int a:32; };                            //
 struct S18 { char a; long long :0; char b; };        //
 struct A0  { int a; long long b:34, c:4; };          //
+struct A1  { int a; unsigned b:11; int c; };         //
+struct A2  { int a; unsigned b:11, c:5, d:16;        //
+             int e; };
+struct A3  { int a; unsigned b:11, c:5, :0, d:16;    //
+             int e; };
+struct A4  { int a:8; short b:7;                     //
+             unsigned int c:29; };
+struct A5  { char a:7, b:2; };                       //
+struct A6  { char a:7; short b:2; };                 //
+struct A7  { short a:8; long b:16; int c;            //
+             char d:7; };
+struct A8  { short a:8; long b:16; int :0;           //
+             char c:7; };
+struct A9  { unsigned short a:8; long b:16;          //
+             unsigned long c:29; long long d:9;
+             unsigned long e:2, f:31; };
+struct A10 { unsigned short a:8; char b; };          //
+struct A11 { char a; int b:5, c:11, :0, d:8;         //
+             struct { int ee:8; } e; };
 
 int main()
 {
@@ -117,6 +147,17 @@ int main()
     printf("S17 = %2d %d ||  4 4 |  4 4 |  4 4 |  4 4\n", (int)sizeof(struct S17), (int)_Alignof(struct S17));
     printf("S18 = %2d %d ||  2 1 |  2 1 |  5 1 |  9 1\n", (int)sizeof(struct S18), (int)_Alignof(struct S18));
     printf("A0  = %2d %d || 16 8 | 16 8 | 12 4 | 16 8\n", (int)sizeof(struct A0),  (int)_Alignof(struct A0));
+    printf("A1  = %2d %d ||  * * | 12 4\n", (int)sizeof(struct A1),  (int)_Alignof(struct A1));
+    printf("A2  = %2d %d ||  * * | 12 4\n", (int)sizeof(struct A2),  (int)_Alignof(struct A2));
+    printf("A3  = %2d %d ||  * * | 16 4\n", (int)sizeof(struct A3),  (int)_Alignof(struct A3));
+    printf("A4  = %2d %d ||  * * | 12 4\n", (int)sizeof(struct A4),  (int)_Alignof(struct A4));
+    printf("A5  = %2d %d ||  * * |  2 1\n", (int)sizeof(struct A5),  (int)_Alignof(struct A5));
+    printf("A6  = %2d %d ||  * * |  4 2\n", (int)sizeof(struct A6),  (int)_Alignof(struct A6));
+    printf("A7  = %2d %d ||  * * | 16 4\n", (int)sizeof(struct A7),  (int)_Alignof(struct A7));
+    printf("A8  = %2d %d ||  * * | 12 4\n", (int)sizeof(struct A8),  (int)_Alignof(struct A8));
+    printf("A9  = %2d %d ||  * * | 32 8\n", (int)sizeof(struct A9),  (int)_Alignof(struct A9));
+    printf("A10 = %2d %d ||  * * |  4 2\n", (int)sizeof(struct A10), (int)_Alignof(struct A10));
+    printf("A11 = %2d %d ||  * * | 16 4\n", (int)sizeof(struct A11), (int)_Alignof(struct A11));
 
     {
         struct S9 s;

--- a/test/runnable/bitfieldsposix32.c
+++ b/test/runnable/bitfieldsposix32.c
@@ -5,9 +5,9 @@
 T0 = 1 1 | 1 1
 T1 = 2 2 | 2 2
 T2 = 4 4 | 4 4
-T3 = 8 4 | 8 8
-T4 = 12 4 | 16 8
-T5 = 8 4 | 8 8
+T3 = 8 4 | 8 4
+T4 = 12 4 | 12 4
+T5 = 8 4 | 8 4
 S1 = 4 4 | 8 8
 S2 = 4 4 | 4 4
 S3 = 4 4 | 4 4
@@ -28,8 +28,19 @@ S14 = 8 4 | 8 4
 S15 = 4 4 | 4 4
 S16 = 4 1 | 4 1
 S17 = 4 4 | 4 4
-S18 = 5 1 | 9 1
-A0  = 12 4 | 16 8
+S18 = 5 1 | 5 1
+A0  = 12 4 | 12 4
+A1  = 12 4 | 12 4
+A2  = 12 4 | 12 4
+A3  = 16 4 | 16 4
+A4  = 8 4 | 8 4
+A5  = 2 1 | 2 1
+A6  = 2 2 | 2 2
+A7  = 12 4 | 12 4
+A8  = 8 4 | 8 4
+A9  = 16 4 | 16 4
+A10 = 2 2 | 2 2
+A11 = 12 4 | 12 4
 S9 = x30200
 S14 = x300000201
 S15 = xe01
@@ -57,16 +68,16 @@ int is64bit() { return sizeof(long) == 8; }  // otherwise assume 32 bit
 struct T0  { char x:1; };                            // 1 1
 struct T1  { short x:1; };                           // 2 2
 struct T2  { int x:1; };                             // 4 4
-struct T3  { char a,b,c,d; long long x:1; };         // 8 8
-struct T4  { char a,b,c,d,e,f,g,h; long long x:1; }; // 16 8
-struct T5  { char a,b,c,d,e,f,g; long long x:1; };   // 8 8
-struct S1  { long long int f:1; };                   // 8 8
+struct T3  { char a,b,c,d; long long x:1; };         // 8 4 (32 bit) 8 8 (64 bit)
+struct T4  { char a,b,c,d,e,f,g,h; long long x:1; }; // 12 4 (32 bit) 16 8 (64 bit)
+struct T5  { char a,b,c,d,e,f,g; long long x:1; };   // 8 4 (32 bit) 8 8 (64 bit)
+struct S1  { long long int f:1; };                   // 4 4 (32 bit) 8 8 (64 bit)
 struct S2  { int x:1; int y:1; };                    // 4 4
 struct S3  { short c; int x:1; unsigned y:1; };      // 4 4
 struct S4  { int x:1; short y:1; };                  // 4 4
 struct S5  { short x:1; int y:1; };                  // 4 4
 struct S6  { short x:1; short y:1; };                // 2 2
-struct S7  { short x:1; int y:1; long long z:1; };   // 8 8
+struct S7  { short x:1; int y:1; long long z:1; };   // 4 4 (32 bit) 8 8 (64 bit)
 struct S8  { char a; char b:1; short c:2; };         // 2 2
 struct S8A { char b:1; short c:2; };                 // 2 2
 struct S8B { char a; short b:1; char c:2; };         // 2 2
@@ -82,15 +93,34 @@ struct S16 { int :32; };                             // 4 1
 struct S17 { int a:32; };                            // 4 4
 struct S18 { char a; long long :0; char b; };        // 5 1 (32 bit) 9 1 (64 bit)
 struct A0  { int a; long long b:34, c:4; };          // 12 4 (32 bit) 16 8 (64 bit)
+struct A1  { int a; unsigned b:11; int c; };         // 12 4
+struct A2  { int a; unsigned b:11, c:5, d:16;        // 12 4
+             int e; };
+struct A3  { int a; unsigned b:11, c:5, :0, d:16;    // 16 4
+             int e; };
+struct A4  { int a:8; short b:7;                     // 8 4
+             unsigned int c:29; };
+struct A5  { char a:7, b:2; };                       // 2 1
+struct A6  { char a:7; short b:2; };                 // 2 2
+struct A7  { short a:8; long b:16; int c;            // 12 4 (32 bit) 16 8 (64 bit)
+             char d:7; };
+struct A8  { short a:8; long b:16; int :0;           // 8 4 (32 bit) 8 8 (64 bit)
+             char c:7; };
+struct A9  { unsigned short a:8; long b:16;          // 16 4 (32 bit) 16 8 (64 bit)
+             unsigned long c:29; long long d:9;
+             unsigned long e:2, f:31; };
+struct A10 { unsigned short a:8; char b; };          // 2 2
+struct A11 { char a; int b:5, c:11, :0, d:8;         // 12 4
+             struct { int ee:8; } e; };
 
 int main()
 {
     printf("T0 = %d %d | 1 1\n", (int)sizeof(struct T0), (int)_Alignof(struct T0));
     printf("T1 = %d %d | 2 2\n", (int)sizeof(struct T1), (int)_Alignof(struct T1));
     printf("T2 = %d %d | 4 4\n", (int)sizeof(struct T2), (int)_Alignof(struct T2));
-    printf("T3 = %d %d | 8 8\n", (int)sizeof(struct T3), (int)_Alignof(struct T3));
-    printf("T4 = %d %d | 16 8\n", (int)sizeof(struct T4), (int)_Alignof(struct T4));
-    printf("T5 = %d %d | 8 8\n", (int)sizeof(struct T5), (int)_Alignof(struct T5));
+    printf("T3 = %d %d | 8 4\n", (int)sizeof(struct T3), (int)_Alignof(struct T3));
+    printf("T4 = %d %d | 12 4\n", (int)sizeof(struct T4), (int)_Alignof(struct T4));
+    printf("T5 = %d %d | 8 4\n", (int)sizeof(struct T5), (int)_Alignof(struct T5));
     printf("S1 = %d %d | 8 8\n", (int)sizeof(struct S1), (int)_Alignof(struct S1));
     printf("S2 = %d %d | 4 4\n", (int)sizeof(struct S2), (int)_Alignof(struct S2));
     printf("S3 = %d %d | 4 4\n", (int)sizeof(struct S3), (int)_Alignof(struct S3));
@@ -111,8 +141,19 @@ int main()
     printf("S15 = %d %d | 4 4\n", (int)sizeof(struct S15), (int)_Alignof(struct S15));
     printf("S16 = %d %d | 4 1\n", (int)sizeof(struct S16), (int)_Alignof(struct S16));
     printf("S17 = %d %d | 4 4\n", (int)sizeof(struct S17), (int)_Alignof(struct S17));
-    printf("S18 = %d %d | 9 1\n", (int)sizeof(struct S18), (int)_Alignof(struct S18));
-    printf("A0  = %d %d | 16 8\n", (int)sizeof(struct A0),  (int)_Alignof(struct A0));
+    printf("S18 = %d %d | 5 1\n", (int)sizeof(struct S18), (int)_Alignof(struct S18));
+    printf("A0  = %d %d | 12 4\n", (int)sizeof(struct A0), (int)_Alignof(struct A0));
+    printf("A1  = %d %d | 12 4\n", (int)sizeof(struct A1), (int)_Alignof(struct A1));
+    printf("A2  = %d %d | 12 4\n", (int)sizeof(struct A2), (int)_Alignof(struct A2));
+    printf("A3  = %d %d | 16 4\n", (int)sizeof(struct A3), (int)_Alignof(struct A3));
+    printf("A4  = %d %d | 8 4\n", (int)sizeof(struct A4), (int)_Alignof(struct A4));
+    printf("A5  = %d %d | 2 1\n", (int)sizeof(struct A5), (int)_Alignof(struct A5));
+    printf("A6  = %d %d | 2 2\n", (int)sizeof(struct A6), (int)_Alignof(struct A6));
+    printf("A7  = %d %d | 12 4\n", (int)sizeof(struct A7), (int)_Alignof(struct A7));
+    printf("A8  = %d %d | 8 4\n", (int)sizeof(struct A8), (int)_Alignof(struct A8));
+    printf("A9  = %d %d | 16 4\n", (int)sizeof(struct A9), (int)_Alignof(struct A9));
+    printf("A10 = %d %d | 2 2\n", (int)sizeof(struct A10), (int)_Alignof(struct A10));
+    printf("A11 = %d %d | 12 4\n", (int)sizeof(struct A11), (int)_Alignof(struct A11));
 
     {
         struct S9 s;

--- a/test/runnable/bitfieldsposix64.c
+++ b/test/runnable/bitfieldsposix64.c
@@ -30,6 +30,17 @@ S16 = 4 1 | 4 1
 S17 = 4 4 | 4 4
 S18 = 9 1 | 9 1
 A0  = 16 8 | 16 8
+A1  = 12 4 | 12 4
+A2  = 12 4 | 12 4
+A3  = 16 4 | 16 4
+A4  = 8 4 | 8 4
+A5  = 2 1 | 2 1
+A6  = 2 2 | 2 2
+A7  = 16 8 | 16 8
+A8  = 8 8 | 8 8
+A9  = 16 8 | 16 8
+A10 = 2 2 | 2 2
+A11 = 12 4 | 12 4
 S9 = x30200
 S14 = x300000201
 S15 = xe01
@@ -57,16 +68,16 @@ int is64bit() { return sizeof(long) == 8; }  // otherwise assume 32 bit
 struct T0  { char x:1; };                            // 1 1
 struct T1  { short x:1; };                           // 2 2
 struct T2  { int x:1; };                             // 4 4
-struct T3  { char a,b,c,d; long long x:1; };         // 8 8
-struct T4  { char a,b,c,d,e,f,g,h; long long x:1; }; // 16 8
-struct T5  { char a,b,c,d,e,f,g; long long x:1; };   // 8 8
-struct S1  { long long int f:1; };                   // 8 8
+struct T3  { char a,b,c,d; long long x:1; };         // 8 4 (32 bit) 8 8 (64 bit)
+struct T4  { char a,b,c,d,e,f,g,h; long long x:1; }; // 12 4 (32 bit) 16 8 (64 bit)
+struct T5  { char a,b,c,d,e,f,g; long long x:1; };   // 8 4 (32 bit) 8 8 (64 bit)
+struct S1  { long long int f:1; };                   // 4 4 (32 bit) 8 8 (64 bit)
 struct S2  { int x:1; int y:1; };                    // 4 4
 struct S3  { short c; int x:1; unsigned y:1; };      // 4 4
 struct S4  { int x:1; short y:1; };                  // 4 4
 struct S5  { short x:1; int y:1; };                  // 4 4
 struct S6  { short x:1; short y:1; };                // 2 2
-struct S7  { short x:1; int y:1; long long z:1; };   // 8 8
+struct S7  { short x:1; int y:1; long long z:1; };   // 4 4 (32 bit) 8 8 (64 bit)
 struct S8  { char a; char b:1; short c:2; };         // 2 2
 struct S8A { char b:1; short c:2; };                 // 2 2
 struct S8B { char a; short b:1; char c:2; };         // 2 2
@@ -82,6 +93,25 @@ struct S16 { int :32; };                             // 4 1
 struct S17 { int a:32; };                            // 4 4
 struct S18 { char a; long long :0; char b; };        // 5 1 (32 bit) 9 1 (64 bit)
 struct A0  { int a; long long b:34, c:4; };          // 12 4 (32 bit) 16 8 (64 bit)
+struct A1  { int a; unsigned b:11; int c; };         // 12 4
+struct A2  { int a; unsigned b:11, c:5, d:16;        // 12 4
+             int e; };
+struct A3  { int a; unsigned b:11, c:5, :0, d:16;    // 16 4
+             int e; };
+struct A4  { int a:8; short b:7;                     // 8 4
+             unsigned int c:29; };
+struct A5  { char a:7, b:2; };                       // 2 1
+struct A6  { char a:7; short b:2; };                 // 2 2
+struct A7  { short a:8; long b:16; int c;            // 12 4 (32 bit) 16 8 (64 bit)
+             char d:7; };
+struct A8  { short a:8; long b:16; int :0;           // 8 4 (32 bit) 8 8 (64 bit)
+             char c:7; };
+struct A9  { unsigned short a:8; long b:16;          // 16 4 (32 bit) 16 8 (64 bit)
+             unsigned long c:29; long long d:9;
+             unsigned long e:2, f:31; };
+struct A10 { unsigned short a:8; char b; };          // 2 2
+struct A11 { char a; int b:5, c:11, :0, d:8;         // 12 4
+             struct { int ee:8; } e; };
 
 int main()
 {
@@ -112,7 +142,18 @@ int main()
     printf("S16 = %d %d | 4 1\n", (int)sizeof(struct S16), (int)_Alignof(struct S16));
     printf("S17 = %d %d | 4 4\n", (int)sizeof(struct S17), (int)_Alignof(struct S17));
     printf("S18 = %d %d | 9 1\n", (int)sizeof(struct S18), (int)_Alignof(struct S18));
-    printf("A0  = %d %d | 16 8\n", (int)sizeof(struct A0),  (int)_Alignof(struct A0));
+    printf("A0  = %d %d | 16 8\n", (int)sizeof(struct A0), (int)_Alignof(struct A0));
+    printf("A1  = %d %d | 12 4\n", (int)sizeof(struct A1), (int)_Alignof(struct A1));
+    printf("A2  = %d %d | 12 4\n", (int)sizeof(struct A2), (int)_Alignof(struct A2));
+    printf("A3  = %d %d | 16 4\n", (int)sizeof(struct A3), (int)_Alignof(struct A3));
+    printf("A4  = %d %d | 8 4\n", (int)sizeof(struct A4), (int)_Alignof(struct A4));
+    printf("A5  = %d %d | 2 1\n", (int)sizeof(struct A5), (int)_Alignof(struct A5));
+    printf("A6  = %d %d | 2 2\n", (int)sizeof(struct A6), (int)_Alignof(struct A6));
+    printf("A7  = %d %d | 16 8\n", (int)sizeof(struct A7), (int)_Alignof(struct A7));
+    printf("A8  = %d %d | 8 8\n", (int)sizeof(struct A8), (int)_Alignof(struct A8));
+    printf("A9  = %d %d | 16 8\n", (int)sizeof(struct A9), (int)_Alignof(struct A9));
+    printf("A10 = %d %d | 2 2\n", (int)sizeof(struct A10), (int)_Alignof(struct A10));
+    printf("A11 = %d %d | 12 4\n", (int)sizeof(struct A11), (int)_Alignof(struct A11));
 
     {
         struct S9 s;


### PR DESCRIPTION
Issue was closed by #13031 and #13027, but after adding some more tests, found a problem with the implementation where `fieldState.offset` is not adjusted after the initial call to `startNewField`, even though more bit-fields were added.

This meant that in the second call to `startNewField` (see test A9 or A10), the `nextoffset` value was wrong.

Values for MS Bitfields are pulled from godbolt, I've no idea if the MS path is correct in DMD: https://godbolt.org/z/6G4aWG8eG

I also have no idea what DM Bitfields do for the added tests, maybe @WalterBright can fill in those gaps.