### PR TITLE
Add Ddoc headers in dmd/backend modules

### DIFF
--- a/src/dmd/backend/aarray.d
+++ b/src/dmd/backend/aarray.d
@@ -1,4 +1,6 @@
 /**
+ * Associative Array implementation
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -1,4 +1,6 @@
 /**
+ * Configure the back end (optimizer and code generator)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -7,8 +9,6 @@
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/backconfig.d, backend/backconfig.d)
  */
-
-// Configure the back end (optimizer and code generator)
 
 module dmd.backend.backconfig;
 

--- a/src/dmd/backend/backend.d
+++ b/src/dmd/backend/backend.d
@@ -1,4 +1,6 @@
 /**
+ * Internal header file for the backend
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/barray.d
+++ b/src/dmd/backend/barray.d
@@ -1,4 +1,6 @@
 /**
+ * Generic resizeable array
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/bcomplex.d
+++ b/src/dmd/backend/bcomplex.d
@@ -1,4 +1,6 @@
 /**
+ * A complex number implementation
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/blockopt.d
+++ b/src/dmd/backend/blockopt.d
@@ -12,10 +12,6 @@
 
 module dmd.backend.blockopt;
 
-/****************************************************************
- * Handle basic blocks.
- */
-
 version (SPP) {} else
 {
 

--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -1,4 +1,6 @@
 /**
+ * Common definitions
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -1,4 +1,6 @@
 /**
+ * Configuration enums/variables for different targets
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -1,4 +1,6 @@
 /**
+ * x87 FPU code generation
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cgcs.d
+++ b/src/dmd/backend/cgcs.d
@@ -1,4 +1,6 @@
 /**
+ * Compute common subexpressions for non-optimized code generation
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cgcse.d
+++ b/src/dmd/backend/cgcse.d
@@ -1,8 +1,8 @@
 /**
+ * Manage the memory allocated on the runtime stack to save Common Subexpressions (CSE).
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
- *
- * Manage the memory allocated on the runtime stack to save Common Subexpressions (CSE).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cgcv.d
+++ b/src/dmd/backend/cgcv.d
@@ -1,4 +1,6 @@
 /**
+ * Interface for CodeView symbol debug info generation
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -1,4 +1,6 @@
 /**
+ * Local optimizations of elem trees
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cgreg.d
+++ b/src/dmd/backend/cgreg.d
@@ -1,4 +1,6 @@
 /**
+ * Register allocator
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cgsched.d
+++ b/src/dmd/backend/cgsched.d
@@ -1,4 +1,6 @@
 /**
+ * Instruction scheduler
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cgxmm.d
+++ b/src/dmd/backend/cgxmm.d
@@ -1,4 +1,6 @@
 /**
+ * xmm specific code generation
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -1,4 +1,8 @@
 /**
+ * Code generation 1
+ *
+ * Handles function calls: putting arguments in registers / on the stack, and jumping to the function.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -1,4 +1,12 @@
 /**
+ * Code generation 2
+ *
+ * Includes:
+ * - math operators (+ - * / %) and functions (abs, cos, sqrt)
+ * - 'string' functions (strlen, memcpy, memset)
+ * - pointers (address of / dereference)
+ * - struct assign, constructor, destructor
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -1,4 +1,11 @@
 /**
+ * Code generation 3
+ *
+ * Includes:
+ * - generating a function prolog (pushing return address, loading paramters)
+ * - generating a function epilog (restoring registers, returning)
+ * - generation / peephole optimizations of jump / branch instructions
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -1,4 +1,12 @@
 /**
+ * Code generation 4
+ *
+ * Includes:
+ * - assignemt variations of operators (+= -= *= /= %= <<= >>=)
+ * - integer comparison (< > <= >=)
+ * - converting integers to a different size (e.g. short to int)
+ * - bit instructions (bit scan, population count)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cod5.d
+++ b/src/dmd/backend/cod5.d
@@ -1,4 +1,8 @@
 /**
+ * Code generation 5
+ *
+ * Handles finding out which blocks need a function prolog / epilog attached
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -1,4 +1,6 @@
 /**
+ * Define registers, register masks, and the CPU instruction linked list
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/codebuilder.d
+++ b/src/dmd/backend/codebuilder.d
@@ -1,4 +1,6 @@
 /**
+ * Construct linked list of generated code
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/compress.d
+++ b/src/dmd/backend/compress.d
@@ -1,4 +1,6 @@
 /**
+ * Identifier comperssion
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/cv4.d
+++ b/src/dmd/backend/cv4.d
@@ -1,5 +1,6 @@
 /**
- * Codeview 4 stuff
+ * CodeView 4 symbolic debug info declarations
+ *
  * See "Microsoft Symbol and Type OMF" document
  *
  * Compiler implementation of the

--- a/src/dmd/backend/cv8.d
+++ b/src/dmd/backend/cv8.d
@@ -1,4 +1,9 @@
 /**
+ * CodeView 8 symbolic debug info generation
+ *
+ * This module generates the `.debug$S` and ``.debug$T` sections for Win64,
+ * which are the MS-Coff symbolic debug info and type debug info sections.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -7,9 +12,6 @@
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cv8.d, backend/cv8.d)
  */
-
-// This module generates the .debug$S and .debug$T sections for Win64,
-// which are the MS-Coff symbolic debug info and type debug info sections.
 
 module dmd.backend.cv8;
 

--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -1,4 +1,6 @@
 /**
+ * CodeView 4 symbolic debug info generation
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/dcode.d
+++ b/src/dmd/backend/dcode.d
@@ -1,4 +1,6 @@
 /**
+ * Allocate and free code blocks
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/debugprint.d
+++ b/src/dmd/backend/debugprint.d
@@ -1,4 +1,6 @@
 /**
+ * Pretty print data structures
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/divcoeff.d
+++ b/src/dmd/backend/divcoeff.d
@@ -1,4 +1,7 @@
 /**
+ * Algorithms from "Division by Invariant Integers using Multiplication"
+ * by Torbjoern Granlund and Peter L. Montgomery
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -6,11 +9,6 @@
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/divcoeff.d, backend/divcoeff.d)
- */
-
-/***************************************************
- * Algorithms from "Division by Invariant Integers using Multiplication"
- * by Torbjoern Granlund and Peter L. Montgomery
  */
 
 import core.stdc.stdio;

--- a/src/dmd/backend/drtlsym.d
+++ b/src/dmd/backend/drtlsym.d
@@ -1,4 +1,6 @@
 /**
+ * Compiler runtime function symbols
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/dt.d
+++ b/src/dmd/backend/dt.d
@@ -1,4 +1,6 @@
 /**
+ * Intermediate representation for static data
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/dvarstats.d
+++ b/src/dmd/backend/dvarstats.d
@@ -1,4 +1,6 @@
 /**
+ * Support for lexical scope of local variables
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -9,10 +11,6 @@
  */
 
 module dmd.backend.dvarstats;
-
-/******************************************
- * support for lexical scope of local variables
- */
 
 import core.stdc.string;
 import core.stdc.stdlib;

--- a/src/dmd/backend/dwarf2.d
+++ b/src/dmd/backend/dwarf2.d
@@ -1,5 +1,6 @@
 
-/* Reflects declarations from the DWARF 3 to 5 specification, not the The D Language Foundation
+/**
+ * Reflects declarations from the DWARF 3 to 5 specification, not the The D Language Foundation
  * dwarf implementation
  *
  * Source: $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dwarf2.d, backend/_dwarf2.d)

--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -1,4 +1,6 @@
 /**
+ * Emit Dwarf symbolic debug info
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -9,7 +11,6 @@
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/dwarfdbginf.d
  */
 
-// Emit Dwarf symbolic debug info
 
 /*
 Some generic information for debug info on macOS:

--- a/src/dmd/backend/dwarfeh.d
+++ b/src/dmd/backend/dwarfeh.d
@@ -1,5 +1,4 @@
 /**
- * Compiler implementation of the D programming language.
  * Implements LSDA (Language Specific Data Area) table generation
  * for Dwarf Exception Handling.
  *

--- a/src/dmd/backend/ee.d
+++ b/src/dmd/backend/ee.d
@@ -1,4 +1,6 @@
 /**
+ * Code to handle debugger expression evaluation
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -9,10 +11,6 @@
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/ee.d, backend/ee.d)
  */
 module dmd.backend.ee;
-
-/*
- * Code to handle debugger expression evaluation
- */
 
 version (SPP) {} else
 {

--- a/src/dmd/backend/el.d
+++ b/src/dmd/backend/el.d
@@ -1,4 +1,6 @@
 /**
+ * Expression trees (intermediate representation)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -1,4 +1,6 @@
 /**
+ * Routines to handle elems.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -8,8 +10,6 @@
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/elem.d, backend/elem.d)
  */
-
-/* Routines to handle elems.                    */
 
 module dmd.backend.elem;
 

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -1,4 +1,8 @@
 /**
+ * Output to ELF object files
+ *
+ * http://www.sco.com/developers/gabi/2003-12-17/ch4.sheader.html
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -10,11 +14,6 @@
  */
 
 module dmd.backend.elfobj;
-
-/****
- * Output to ELF object files
- * http://www.sco.com/developers/gabi/2003-12-17/ch4.sheader.html
- */
 
 version (SCPP)
     version = COMPILE;

--- a/src/dmd/backend/evalu8.d
+++ b/src/dmd/backend/evalu8.d
@@ -1,4 +1,6 @@
 /**
+ * Constant folding
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/exh.d
+++ b/src/dmd/backend/exh.d
@@ -1,4 +1,6 @@
 /**
+ * Interface for exception handling support
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/gdag.d
+++ b/src/dmd/backend/gdag.d
@@ -1,4 +1,6 @@
 /**
+ * Directed acyclic graphs and global optimizer common subexpressions
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -1,4 +1,6 @@
 /**
+ * Declarations for back end
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/glocal.d
+++ b/src/dmd/backend/glocal.d
@@ -1,4 +1,6 @@
 /**
+ * Local optimizations
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -1,4 +1,6 @@
 /**
+ * Global loop optimizations
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -9,7 +11,6 @@
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/gloop.d, backend/gloop.d)
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/gloop.d
  */
-
 
 module dmd.backend.gloop;
 

--- a/src/dmd/backend/go.d
+++ b/src/dmd/backend/go.d
@@ -1,4 +1,6 @@
 /**
+ * Global optimizer main loop
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/goh.d
+++ b/src/dmd/backend/goh.d
@@ -1,4 +1,6 @@
 /**
+ * Global optimizer declarations
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/gother.d
+++ b/src/dmd/backend/gother.d
@@ -1,5 +1,5 @@
 /**
- * Other data flow analysis based optimizations.
+ * Other global optimizations
  *
  * Copyright:   Copyright (C) 1986-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/gsroa.d
+++ b/src/dmd/backend/gsroa.d
@@ -1,4 +1,10 @@
 /**
+ * SROA structured replacement of aggregate optimization
+ *
+ * This 'slices' a two register wide aggregate into two separate register-sized variables,
+ * enabling much better enregistering.
+ * SROA (Scalar Replacement Of Aggregates) is the common term for this.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -45,11 +51,6 @@ int REGSIZE();
 
 alias SLICESIZE = REGSIZE;  // slices are all register-sized
 enum MAXSLICES = 2;         // max # of pieces we can slice an aggregate into
-
-/* This 'slices' a two register wide aggregate into two separate register-sized variables,
- * enabling much better enregistering.
- * SROA (Scalar Replacement Of Aggregates) is the common term for this.
- */
 
 struct SymInfo
 {

--- a/src/dmd/backend/mach.d
+++ b/src/dmd/backend/mach.d
@@ -1,5 +1,6 @@
-
-/* Mach-O object file format
+/**
+ * Mach-O object file format
+ *
  * Translated to D from mach.h
  */
 

--- a/src/dmd/backend/machobj.d
+++ b/src/dmd/backend/machobj.d
@@ -1,4 +1,6 @@
 /**
+ * Generate Mach-O object files
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/melf.d
+++ b/src/dmd/backend/melf.d
@@ -1,5 +1,7 @@
 
 /**
+ * Declarations for ELF file format
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/mscoff.d
+++ b/src/dmd/backend/mscoff.d
@@ -1,4 +1,5 @@
-/** Microsoft COFF object file format
+/**
+ * Microsoft COFF object file format
  *
  * Source: $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/mscoff.d, backend/_mscoff.d)
  */

--- a/src/dmd/backend/newman.d
+++ b/src/dmd/backend/newman.d
@@ -1,4 +1,6 @@
 /**
+ * "new" C++ name mangling scheme
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/nteh.d
+++ b/src/dmd/backend/nteh.d
@@ -1,4 +1,6 @@
 /**
+ * Support for NT exception handling
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -9,8 +11,6 @@
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/nteh.d, backend/nteh.d)
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/nteh.d
  */
-
-// Support for NT exception handling
 
 module dmd.backend.nteh;
 

--- a/src/dmd/backend/os.d
+++ b/src/dmd/backend/os.d
@@ -1,4 +1,9 @@
 /**
+ * Operating system specific routines.
+ *
+ * Placed here to avoid cluttering
+ * up code with OS files.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -9,11 +14,7 @@
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/os.d, backend/os.d)
  */
 
-/*
- * Operating system specific routines.
- * Placed here to avoid cluttering
- * up code with OS files.
- */
+module dmd.backend.os;
 
 import core.stdc.stdio;
 import core.stdc.time;

--- a/src/dmd/backend/out.d
+++ b/src/dmd/backend/out.d
@@ -1,4 +1,6 @@
 /**
+ * Transition from intermediate representation to code generator
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -8,7 +10,6 @@
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/out.d, backend/out.d)
  */
-
 
 module dmd.backend.dout;
 

--- a/src/dmd/backend/outbuf.d
+++ b/src/dmd/backend/outbuf.d
@@ -1,4 +1,6 @@
 /**
+ * Output buffer
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -16,7 +18,6 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
 
-// Output buffer
 
 // (This used to be called OutBuffer, renamed to avoid name conflicts with Mars.)
 

--- a/src/dmd/backend/pdata.d
+++ b/src/dmd/backend/pdata.d
@@ -1,4 +1,6 @@
 /**
+ * Generates the .pdata and .xdata sections for Win64
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -7,8 +9,6 @@
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/pdata.d, backend/pdata.d)
  */
-
-// This module generates the .pdata and .xdata sections for Win64
 
 module dmd.backend.pdata;
 

--- a/src/dmd/backend/ph2.d
+++ b/src/dmd/backend/ph2.d
@@ -1,4 +1,9 @@
 /**
+ * A leaking bump-the-pointer allocator
+ *
+ * This is only for dmd, not dmc.
+ * It implements a heap allocator that never frees.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -6,10 +11,6 @@
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/ph2.d, backend/ph2.d)
- */
-
-/* This is only for dmd, not dmc.
- * It implements a heap allocator that never frees.
  */
 
 module dmd.backend.ph2;

--- a/src/dmd/backend/rtlsym.d
+++ b/src/dmd/backend/rtlsym.d
@@ -1,4 +1,6 @@
 /**
+ * Compiler runtime function symbols
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -1,4 +1,6 @@
 /**
+ * Symbols for the back end
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -1,4 +1,6 @@
 /**
+ * Define basic types and type masks
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/type.d
+++ b/src/dmd/backend/type.d
@@ -1,4 +1,6 @@
 /**
+ * Types for the back end
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/backend/util2.d
+++ b/src/dmd/backend/util2.d
@@ -1,4 +1,8 @@
 /**
+ * Utility subroutines
+ *
+ * Only used for DMD
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -9,11 +13,7 @@
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/util2.d, backend/util2.d)
  */
 
-// Only used for DMD
-
 module dmd.backend.util2;
-
-// Utility subroutines
 
 import core.stdc.stdio;
 import core.stdc.stdlib;

--- a/src/dmd/backend/var.d
+++ b/src/dmd/backend/var.d
@@ -1,4 +1,6 @@
 /**
+ * Global variables for PARSER
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -10,8 +12,6 @@
  */
 
 module dmd.backend.var;
-
-/* Global variables for PARSER  */
 
 import core.stdc.stdio;
 

--- a/src/dmd/backend/xmm.d
+++ b/src/dmd/backend/xmm.d
@@ -1,4 +1,6 @@
 /**
+ * XMM opcodes
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -13,8 +15,6 @@ module dmd.backend.xmm;
 // Online documentation: https://dlang.org/phobos/dmd_backend_xmm.html
 
 @safe:
-
-// XMM opcodes
 
 enum
 {


### PR DESCRIPTION
I started this after https://github.com/dlang/dmd/pull/10903 but only now did I follow up on it. 

Descriptions were taken from the table of contents, non-DDoc comments, or created based on looking at the module contents. I'm not familiar with the backend code so feel free to correct or suggest improvements.