### PR TITLE
ImportC: add implicit array and function conversions

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1339,7 +1339,7 @@ auto sourceFiles()
             ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d dimport.d
             dinterpret.d dmacro.d dmangle.d dmodule.d doc.d dscope.d dstruct.d dsymbol.d dsymbolsem.d
             dtemplate.d dtoh.d dversion.d env.d escape.d expression.d expressionsem.d func.d hdrgen.d impcnvtab.d
-            imphint.d init.d initsem.d inline.d inlinecost.d intrange.d json.d lambdacomp.d
+            imphint.d importc.d init.d initsem.d inline.d inlinecost.d intrange.d json.d lambdacomp.d
             mtype.d nogc.d nspace.d ob.d objc.d opover.d optimize.d
             parse.d parsetimevisitor.d permissivevisitor.d printast.d safe.d sapply.d
             semantic2.d semantic3.d sideeffect.d statement.d statement_rewrite_walker.d

--- a/src/dmd/README.md
+++ b/src/dmd/README.md
@@ -126,6 +126,7 @@ Note that these groups have no strict meaning, the category assignments are a bi
 | [optimize.d](https://github.com/dlang/dmd/blob/master/src/dmd/optimize.d)     | Do constant folding more generally                                                         |
 | [dcast.d](https://github.com/dlang/dmd/blob/master/src/dmd/dcast.d)           | Implicit or explicit cast(), finding common types e.g. in `x ? a : b`, integral promotions |
 | [impcnvtab.d](https://github.com/dlang/dmd/blob/master/src/dmd/impcnvtab.d)   | Define an implicit conversion table for basic types                                        |
+| [importc.d](https://github.com/dlang/dmd/blob/master/src/dmd/importc.d)       | Helpers specific to ImportC
 | [sideeffect.d](https://github.com/dlang/dmd/blob/master/src/dmd/sideeffect.d) | Extract side-effects of expressions for certain lowerings.                                 |
 
 **Compile Time Function Execution (CTFE)**

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -49,6 +49,7 @@ import dmd.hdrgen;
 import dmd.id;
 import dmd.identifier;
 import dmd.imphint;
+import dmd.importc;
 import dmd.init;
 import dmd.initsem;
 import dmd.inline;
@@ -1239,6 +1240,10 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         tthis = dve.e1.type;
         goto Lfd;
     }
+    else if (sc.flags & SCOPE.Cfile && e1.op == TOK.variable && !e2)
+    {
+        // ImportC: do not implicitly call function if no ( ) are present
+    }
     else if (e1.op == TOK.variable && e1.type && (e1.type.toBasetype().ty == Tfunction || (cast(VarExp)e1).var.isOverDeclaration()))
     {
         s = (cast(VarExp)e1).var;
@@ -1599,6 +1604,7 @@ private bool preFunctionParameters(Scope* sc, Expressions* exps, const bool repo
         {
             Expression arg = (*exps)[i];
             arg = resolveProperties(sc, arg);
+            arg = arg.arrayFuncConv(sc);
             if (arg.op == TOK.type)
             {
                 // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684
@@ -8019,6 +8025,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(CommaExp e)
     {
+        //printf("Semantic.CommaExp() %s\n", e.toChars());
         if (e.type)
         {
             result = e;
@@ -8042,10 +8049,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (checkNonAssignmentArrayOp(e.e1))
             return setError();
 
+        // Comma expressions trigger this conversion
+        e.e2 = e.e2.arrayFuncConv(sc);
+
         e.type = e.e2.type;
         if (e.type is Type.tvoid)
             discardValue(e.e1);
-        else if (!e.allowCommaExp && !e.isGenerated)
+        else if (!e.allowCommaExp && !e.isGenerated && !(sc.flags & SCOPE.Cfile))
             e.error("Using the result of a comma expression is not allowed");
         result = e;
     }
@@ -8143,7 +8153,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         // operator overloading should be handled in ArrayExp already.
         if (!exp.e1.type)
-            exp.e1 = exp.e1.expressionSemantic(sc);
+            exp.e1 = exp.e1.expressionSemantic(sc).arrayFuncConv(sc);
         assert(exp.e1.type); // semantic() should already be run on it
         if (exp.e1.op == TOK.type && exp.e1.type.ty != Ttuple)
         {
@@ -8191,7 +8201,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         if (t1b.ty == Ttuple)
             sc = sc.startCTFE();
-        exp.e2 = exp.e2.expressionSemantic(sc);
+        exp.e2 = exp.e2.expressionSemantic(sc).arrayFuncConv(sc);
         exp.e2 = resolveProperties(sc, exp.e2);
         if (t1b.ty == Ttuple)
             sc = sc.endCTFE();
@@ -8515,7 +8525,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (auto e2comma = exp.e2.isCommaExp())
         {
-            if (!e2comma.isGenerated)
+            if (!e2comma.isGenerated && !(sc.flags & SCOPE.Cfile))
                 exp.error("Using the result of a comma expression is not allowed");
 
             /* Rewrite to get rid of the comma from rvalue
@@ -8716,7 +8726,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          */
         {
             Expression e2x = inferType(exp.e2, t1.baseElemOf());
-            e2x = e2x.expressionSemantic(sc);
+            e2x = e2x.expressionSemantic(sc).arrayFuncConv(sc);
             e2x = resolveProperties(sc, e2x);
             if (e2x.op == TOK.type)
                 e2x = resolveAliasThis(sc, e2x); //https://issues.dlang.org/show_bug.cgi?id=17684
@@ -9949,6 +9959,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
+        /* ImportC: convert arrays to pointers, functions to pointers to functions
+         */
+        exp.e1 = exp.e1.arrayFuncConv(sc);
+        exp.e2 = exp.e2.arrayFuncConv(sc);
+
         Type tb1 = exp.e1.type.toBasetype();
         Type tb2 = exp.e2.type.toBasetype();
 
@@ -10049,6 +10064,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = e;
             return;
         }
+
+        /* ImportC: convert arrays to pointers, functions to pointers to functions
+         */
+        exp.e1 = exp.e1.arrayFuncConv(sc);
 
         Type t1 = exp.e1.type.toBasetype();
         Type t2 = exp.e2.type.toBasetype();
@@ -11544,12 +11563,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         ec = ec.toBoolean(sc);
 
         CtorFlow ctorflow_root = sc.ctorflow.clone();
-        Expression e1x = exp.e1.expressionSemantic(sc);
+        Expression e1x = exp.e1.expressionSemantic(sc).arrayFuncConv(sc);
         e1x = resolveProperties(sc, e1x);
 
         CtorFlow ctorflow1 = sc.ctorflow;
         sc.ctorflow = ctorflow_root;
-        Expression e2x = exp.e2.expressionSemantic(sc);
+        Expression e2x = exp.e2.expressionSemantic(sc).arrayFuncConv(sc);
         e2x = resolveProperties(sc, e2x);
 
         sc.merge(exp.loc, ctorflow1);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1240,7 +1240,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         tthis = dve.e1.type;
         goto Lfd;
     }
-    else if (sc.flags & SCOPE.Cfile && e1.op == TOK.variable && !e2)
+    else if (sc && sc.flags & SCOPE.Cfile && e1.op == TOK.variable && !e2)
     {
         // ImportC: do not implicitly call function if no ( ) are present
     }
@@ -8726,7 +8726,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          */
         {
             Expression e2x = inferType(exp.e2, t1.baseElemOf());
-            e2x = e2x.expressionSemantic(sc).arrayFuncConv(sc);
+            e2x = e2x.expressionSemantic(sc);
+            if (!t1.isTypeSArray())
+                e2x = e2x.arrayFuncConv(sc);
             e2x = resolveProperties(sc, e2x);
             if (e2x.op == TOK.type)
                 e2x = resolveAliasThis(sc, e2x); //https://issues.dlang.org/show_bug.cgi?id=17684

--- a/src/dmd/importc.d
+++ b/src/dmd/importc.d
@@ -1,0 +1,55 @@
+/**
+ * Contains semantic routines specific to ImportC
+ *
+ * Specification: C11
+ *
+ * Copyright:   Copyright (C) 2021 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/importc.d, _importc.d)
+ * Documentation:  https://dlang.org/phobos/dmd_importc.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/importc.d
+ */
+
+module dmd.importc;
+
+import core.stdc.stdio;
+
+import dmd.dcast;
+import dmd.dscope;
+import dmd.expression;
+import dmd.expressionsem;
+import dmd.mtype;
+
+/***********************************************
+ * C11 6.3.2.1-3 Convert expression that is an array of type to a pointer to type.
+ * C11 6.3.2.1-4 Convert expression that is a function to a pointer to a function.
+ * Params:
+ *  e = ImportC expression to possibly convert
+ *  sc = context
+ * Returns:
+ *  converted expression
+ */
+Expression arrayFuncConv(Expression e, Scope* sc)
+{
+    //printf("arrayFuncConv() %s\n", e.toChars());
+    if (!(sc.flags & SCOPE.Cfile))
+        return e;
+
+    auto t = e.type.toBasetype();
+    if (auto ta = t.isTypeDArray())
+    {
+        e = e.castTo(sc, ta.next.pointerTo());
+    }
+    else if (auto ts = t.isTypeSArray())
+    {
+        e = e.castTo(sc, ts.next.pointerTo());
+    }
+    else if (t.isTypeFunction())
+    {
+        e = e.addressOf();
+    }
+    else
+        return e;
+    return e.expressionSemantic(sc);
+}

--- a/test/compilable/arraytopointer.c
+++ b/test/compilable/arraytopointer.c
@@ -1,0 +1,63 @@
+
+/* Test conversion of expressions:
+ *    array of T => pointer to T
+ *    function => pointer to function
+ */
+
+int func(int *);
+int burg(int (*fp)());
+int clog();
+
+void testFunctionArguments()
+{
+    int a[3];
+    func(a);
+
+    int b[];
+    func(b);
+
+    burg(clog);
+}
+
+void testIndexing()
+{
+    int a[3];
+    a[0] = 1;
+}
+
+void testAdd()
+{
+    int a[3];
+    int* p = a + 1;
+    p = 1 + 1;
+}
+
+void testMin()
+{
+    int a[3];
+    int* p = a - 1;
+}
+
+void testCond()
+{
+    int i;
+    int a[3];
+    int b[3];
+    int* p = i ? a : b;
+}
+
+void testAssign()
+{
+    int a[3];
+    int *p = a;
+}
+
+void testComma()
+{
+    int a[3];
+    int* p = (1, a) + 1;
+    _Static_assert(sizeof((1, a)) == sizeof(int*), "testComma");
+}
+
+
+


### PR DESCRIPTION
I started a new file, `importc.d`, just for C semantics.

This implements C11 6.3.2.1-3 for arrays and C11 6.3.2.1-4 for functions, where arrays are converted to pointers and functions are converted to pointers to functions.

It implements C's Biggest Mistake:
  https://www.digitalmars.com/articles/C-biggest-mistake.html
