### PR TITLE
Add __traits(hasAliasing)

### DIFF
--- a/changelog/add_traits_hasAliasing.dd
+++ b/changelog/add_traits_hasAliasing.dd
@@ -1,0 +1,20 @@
+Add new `__traits(hasAliasing, T)`.
+
+A call `__traits(hasAliasing, T)` is `true` if and only if the type `T` has any
+non-`immutable` indirections.
+
+Specifically `__traits(hasAliasing, T)` is `true` if and only if `T`'s
+representation includes at least one of the following:
+
+1. a raw pointer `U*` and `U` is not immutable;
+2. an array `U[]` and `U` is not immutable;
+3. a reference to a class or interface type `C` and `C` is not immutable.
+4. an associative array that is not immutable.
+5. a delegate.
+
+The call errors if `T` is not a type.
+
+The behaviour of a call `__traits(hasAliasing, T)` for any type `T` exactly
+mimics that of a call `std.traits.hasAliasing!(T)`.
+
+See also: https://dlang.org/phobos/std_traits.html#hasAliasing.

--- a/changelog/add_traits_hasAliasing.dd
+++ b/changelog/add_traits_hasAliasing.dd
@@ -14,7 +14,7 @@ representation includes at least one of the following:
 
 The call errors if `T` is not a type.
 
-The behaviour of a call `__traits(hasAliasing, T)` for any type `T` exactly
+The behavior of a call `__traits(hasAliasing, T)` for any type `T` exactly
 mimics that of a call `std.traits.hasAliasing!(T)`.
 
 See also: https://dlang.org/phobos/std_traits.html#hasAliasing.

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8262,6 +8262,7 @@ struct Id final
     static Identifier* hasPostblit;
     static Identifier* hasCopyConstructor;
     static Identifier* isCopyable;
+    static Identifier* hasAliasing;
     static Identifier* toType;
     static Identifier* allocator;
     static Identifier* basic_string;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8444,3 +8444,4 @@ extern "C" Object* _d_newclass(const TypeInfo_Class* const ci);
 extern "C" void* _d_newitemT(TypeInfo* ti);
 
 extern "C" void* _d_newitemiT(TypeInfo* ti);
+

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8263,7 +8263,6 @@ struct Id final
     static Identifier* hasCopyConstructor;
     static Identifier* isCopyable;
     static Identifier* hasAliasing;
-    static Identifier* Rebindable;
     static Identifier* toType;
     static Identifier* allocator;
     static Identifier* basic_string;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8263,6 +8263,7 @@ struct Id final
     static Identifier* hasCopyConstructor;
     static Identifier* isCopyable;
     static Identifier* hasAliasing;
+    static Identifier* Rebindable;
     static Identifier* toType;
     static Identifier* allocator;
     static Identifier* basic_string;
@@ -8444,4 +8445,3 @@ extern "C" Object* _d_newclass(const TypeInfo_Class* const ci);
 extern "C" void* _d_newitemT(TypeInfo* ti);
 
 extern "C" void* _d_newitemiT(TypeInfo* ti);
-

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -471,6 +471,7 @@ immutable Msgtable[] msgtable =
     { "hasPostblit" },
     { "hasCopyConstructor" },
     { "isCopyable" },
+    { "hasAliasing" },
     { "toType" },
 
     // For C++ mangling

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -472,6 +472,7 @@ immutable Msgtable[] msgtable =
     { "hasCopyConstructor" },
     { "isCopyable" },
     { "hasAliasing" },
+    { "Rebindable" },
     { "toType" },
 
     // For C++ mangling

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -472,7 +472,6 @@ immutable Msgtable[] msgtable =
     { "hasCopyConstructor" },
     { "isCopyable" },
     { "hasAliasing" },
-    { "Rebindable" },
     { "toType" },
 
     // For C++ mangling

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -7367,35 +7367,35 @@ bool hasAliasing(scope Type t)
     t = t.toBasetype();
     if (t.isImmutable)
         return false;
-    else if (auto ts = t.isTypeStruct)
+    else if (auto ts = t.isTypeStruct())
     {
         if (auto ti = ts.sym.isInstantiated())
             if (ti.name.toString == "Rebindable" && // TODO: verify namespace std.typecons?
                 ti.tiargs &&
                 (*ti.tiargs).length == 1)
-                if (auto at = (*ti.tiargs)[0].isType)
-                    return !at.isImmutable;
+                if (auto at = (*ti.tiargs)[0].isType())
+                    return !at.isImmutable();
         foreach (vd; ts.sym.fields)
             if (hasAliasing(vd.type))
                 return true;
     }
-    else if (auto tc = t.isTypeClass)
-        return !tc.isImmutable;
-    else if (auto tp = t.isTypePointer)
+    else if (auto tc = t.isTypeClass())
+        return !tc.isImmutable();
+    else if (auto tp = t.isTypePointer())
     {
-        if (tp.next.isTypeFunction)
+        if (tp.next.isTypeFunction())
             return false;
-        return !tp.next.isImmutable;
+        return !tp.next.isImmutable();
     }
-    else if (auto td = t.isTypeDelegate)
-        return !td.next.isImmutable;
-    else if (auto ta = t.isTypeDArray)
-        return !ta.next.isImmutable;
-    else if (auto ta = t.isTypeAArray)
-        return !ta.next.isImmutable;
-    else if (auto ts = t.isTypeSArray)
+    else if (auto td = t.isTypeDelegate())
+        return !td.next.isImmutable();
+    else if (auto ta = t.isTypeDArray())
+        return !ta.next.isImmutable();
+    else if (auto ta = t.isTypeAArray())
+        return !ta.next.isImmutable();
+    else if (auto ts = t.isTypeSArray())
         return hasAliasing(ts.next);
-    else if (auto tf = t.isTypeFunction)
+    else if (auto tf = t.isTypeFunction())
         return false;
     return false;
 }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -7370,7 +7370,7 @@ bool hasAliasing(scope Type t)
     else if (auto ts = t.isTypeStruct())
     {
         if (auto ti = ts.sym.isInstantiated())
-            if (ti.name.toString == "Rebindable" && // TODO: verify namespace std.typecons?
+            if (ti.name == Id.Rebindable &&
                 ti.tiargs &&
                 (*ti.tiargs).length == 1)
                 if (auto at = (*ti.tiargs)[0].isType())

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -7371,12 +7371,6 @@ bool hasAliasing(scope Type t)
         return false;
     else if (auto ts = t.isTypeStruct())
     {
-        if (auto ti = ts.sym.isInstantiated())
-            if (ti.name == Id.Rebindable &&
-                ti.tiargs &&
-                (*ti.tiargs).length == 1)
-                if (auto at = (*ti.tiargs)[0].isType())
-                    return !at.isImmutable();
         foreach (vd; ts.sym.fields)
             if (hasAliasing(vd.type))
                 return true;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -7354,13 +7354,15 @@ const(char)* toChars(ScopeRef sr) pure nothrow @nogc @safe
     }
 }
 
-/** Returns: `true` iff `t` has any non-`immutable` (mutable or const) indirections.
+/** Aliasing happens when there exists another mutable reference to the same
+ * memory object.  The other references can change the contents of the memory
+ * object.  Immutable references may exist, but cannot change the contents. This
+ * function determines if such aliasing of a type `t` is possible.
  *
- * In other words, if other references to `t` may be able to change it.
  * Params:
  *      t = type to check
  * Returns:
- *      true iff `t` contain non-`immutable` indirections.
+ *      `true` iff `t` contains any non-`immutable` (mutable or const) indirections.
  */
 bool hasAliasing(scope Type t)
 {

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -150,6 +150,7 @@ shared static this()
         "hasPostblit",
         "hasCopyConstructor",
         "isCopyable",
+        "hasAliasing",
     ];
 
     StringTable!(bool)* stringTable = cast(StringTable!(bool)*) &traitsStringTable;
@@ -670,6 +671,22 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         }
 
         return isCopyable(t) ? True() : False();
+    }
+    if (e.ident == Id.hasAliasing)
+    {
+        foreach (o; *e.args)
+        {
+            auto t = isType(o);
+            if (!t)
+            {
+                e.error("type expected as non-first argument of __traits `%s` instead of `%s`",
+                        e.ident.toChars(), o.toChars());
+                return ErrorExp.get();
+            }
+            if (t.hasAliasing)
+                return True();
+        }
+        return False();
     }
 
     if (e.ident == Id.isNested)

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -674,19 +674,19 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     }
     if (e.ident == Id.hasAliasing)
     {
-        foreach (o; *e.args)
+        if (dim != 1)
+            return dimError(1);
+        auto o = (*e.args)[0];
+        if (auto t = isType(o))
         {
-            if (auto t = isType(o))
-            {
-                if (t.hasAliasing)
-                    return True();
-            }
-            else
-            {
-                e.error("type expected as non-first argument of __traits `%s` instead of `%s`",
-                        e.ident.toChars(), o.toChars());
-                return ErrorExp.get();
-            }
+            if (t.hasAliasing)
+                return True();
+        }
+        else
+        {
+            e.error("type expected as non-first argument of __traits `%s` instead of `%s`",
+                    e.ident.toChars(), o.toChars());
+            return ErrorExp.get();
         }
         return False();
     }

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -676,15 +676,17 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     {
         foreach (o; *e.args)
         {
-            auto t = isType(o);
-            if (!t)
+            if (auto t = isType(o))
+            {
+                if (t.hasAliasing)
+                    return True();
+            }
+            else
             {
                 e.error("type expected as non-first argument of __traits `%s` instead of `%s`",
                         e.ident.toChars(), o.toChars());
                 return ErrorExp.get();
             }
-            if (t.hasAliasing)
-                return True();
         }
         return False();
     }

--- a/test/compilable/traits_hasAliasing.d
+++ b/test/compilable/traits_hasAliasing.d
@@ -1,0 +1,108 @@
+module traits_hasAliasing;
+
+@safe pure nothrow @nogc:
+
+/** Verify behaviour of `__traits(hasAliasing, void*)` being same as `std.traits.hasAliasing`.
+ *
+ * Copied from Phobos `std.traits`.
+ */
+void test_hasAliasing()
+{
+    static assert(__traits(hasAliasing, void*));
+    static assert(!__traits(hasAliasing, void function()));
+
+    struct S1 { int a; Object b; }
+    struct S2 { string a; }
+    struct S3 { int a; immutable Object b; }
+    struct S4 { float[3] vals; }
+    struct S41 { int*[3] vals; }
+    struct S42 { immutable(int)*[3] vals; }
+
+    static assert( __traits(hasAliasing, S1));
+    static assert(!__traits(hasAliasing, S2));
+    static assert(!__traits(hasAliasing, S3));
+    static assert(!__traits(hasAliasing, S4));
+    static assert( __traits(hasAliasing, S41));
+    static assert(!__traits(hasAliasing, S42));
+
+    static assert( __traits(hasAliasing, S1, S41)); // multiple arguments, all have aliasing
+    static assert( __traits(hasAliasing, S1, S2)); // multiple arguments, some have aliasing
+    static assert( __traits(hasAliasing, S2, S1)); // multiple arguments, some have aliasing
+    static assert(!__traits(hasAliasing, S2, S4)); // multiple arguments, none have aliasing
+
+    static assert( __traits(hasAliasing, uint[uint]));
+    static assert(!__traits(hasAliasing, immutable(uint[uint])));
+    static assert( __traits(hasAliasing, void delegate()));
+    static assert( __traits(hasAliasing, void delegate() const));
+    static assert(!__traits(hasAliasing, void delegate() immutable));
+    static assert( __traits(hasAliasing, void delegate() shared));
+    static assert( __traits(hasAliasing, void delegate() shared const));
+    static assert( __traits(hasAliasing, const(void delegate())));
+    static assert( __traits(hasAliasing, const(void delegate() const)));
+    static assert(!__traits(hasAliasing, const(void delegate() immutable)));
+    static assert( __traits(hasAliasing, const(void delegate() shared)));
+    static assert( __traits(hasAliasing, const(void delegate() shared const)));
+    static assert(!__traits(hasAliasing, immutable(void delegate())));
+    static assert(!__traits(hasAliasing, immutable(void delegate() const)));
+    static assert(!__traits(hasAliasing, immutable(void delegate() immutable)));
+    static assert(!__traits(hasAliasing, immutable(void delegate() shared)));
+    static assert(!__traits(hasAliasing, immutable(void delegate() shared const)));
+    static assert( __traits(hasAliasing, shared(const(void delegate()))));
+    static assert( __traits(hasAliasing, shared(const(void delegate() const))));
+    static assert(!__traits(hasAliasing, shared(const(void delegate() immutable))));
+    static assert( __traits(hasAliasing, shared(const(void delegate() shared))));
+    static assert( __traits(hasAliasing, shared(const(void delegate() shared const))));
+    static assert(!hasAliasing!(void function()));
+
+    interface I;
+    static assert( __traits(hasAliasing, I));
+
+    import std.typecons : Rebindable;
+    static assert( __traits(hasAliasing, Rebindable!(const Object)));
+    static assert(!__traits(hasAliasing, Rebindable!(immutable Object)));
+    static assert( __traits(hasAliasing, Rebindable!(shared Object)));
+    static assert( __traits(hasAliasing, Rebindable!Object));
+
+    struct S5
+    {
+        void delegate() immutable b;
+        shared(void delegate() immutable) f;
+        immutable(void delegate() immutable) j;
+        shared(const(void delegate() immutable)) n;
+    }
+    struct S6 { typeof(S5.tupleof) a; void delegate() p; }
+    static assert(!__traits(hasAliasing, S5));
+    static assert( __traits(hasAliasing, S6));
+
+    struct S7 { void delegate() a; int b; Object c; }
+    class S8 { int a; int b; }
+    class S9 { typeof(S8.tupleof) a; }
+    class S10 { typeof(S8.tupleof) a; int* b; }
+    static assert( __traits(hasAliasing, S7));
+    static assert( __traits(hasAliasing, S8));
+    static assert( __traits(hasAliasing, S9));
+    static assert( __traits(hasAliasing, S10));
+    struct S11 {}
+    class S12 {}
+    interface S13 {}
+    union S14 {}
+    static assert(!__traits(hasAliasing, S11));
+    static assert( __traits(hasAliasing, S12));
+    static assert( __traits(hasAliasing, S13));
+    static assert(!__traits(hasAliasing, S14));
+
+    class S15 { S15[1] a; }
+    static assert( __traits(hasAliasing, S15));
+    static assert(!__traits(hasAliasing, immutable(S15)));
+}
+
+void test_hasAliasing_enums()
+{
+    enum Ei : string { a = "a", b = "b" }
+    enum Ec : const(char)[] { a = "a", b = "b" }
+    enum Em : char[] { a = null, b = null }
+
+    static assert(!__traits(hasAliasing, Ei));
+    static assert( __traits(hasAliasing, Ec));
+    static assert( __traits(hasAliasing, Em));
+}

--- a/test/compilable/traits_hasAliasing.d
+++ b/test/compilable/traits_hasAliasing.d
@@ -17,6 +17,9 @@ void test_hasAliasing()
     struct S4 { float[3] vals; }
     struct S41 { int*[3] vals; }
     struct S42 { immutable(int)*[3] vals; }
+    struct S5 { int[int] vals; } // not in std.traits
+    struct S6 { const int[int] vals; } // not in std.traits
+    struct S7 { immutable int[int] vals; } // not in std.traits
 
     static assert( __traits(hasAliasing, S1));
     static assert(!__traits(hasAliasing, S2));
@@ -24,6 +27,9 @@ void test_hasAliasing()
     static assert(!__traits(hasAliasing, S4));
     static assert( __traits(hasAliasing, S41));
     static assert(!__traits(hasAliasing, S42));
+    static assert( __traits(hasAliasing, S5));
+    static assert( __traits(hasAliasing, S6));
+    static assert(!__traits(hasAliasing, S7));
 
     static assert( __traits(hasAliasing, S1, S41)); // multiple arguments, all have aliasing
     static assert( __traits(hasAliasing, S1, S2)); // multiple arguments, some have aliasing

--- a/test/compilable/traits_hasAliasing.d
+++ b/test/compilable/traits_hasAliasing.d
@@ -79,12 +79,6 @@ private static void test1()
     static assert( __traits(hasAliasing, CT!C));
     static assert( __traits(hasAliasing, CT!I));
     static assert( __traits(hasAliasing, CT!int));
-
-    import std.typecons : Rebindable;
-    static assert( __traits(hasAliasing, Rebindable!(const Object)));
-    static assert(!__traits(hasAliasing, Rebindable!(immutable Object)));
-    static assert( __traits(hasAliasing, Rebindable!(shared Object)));
-    static assert( __traits(hasAliasing, Rebindable!Object));
 }
 
 private static test2()

--- a/test/compilable/traits_hasAliasing.d
+++ b/test/compilable/traits_hasAliasing.d
@@ -4,12 +4,15 @@ module traits_hasAliasing;
 
 /** Verify behavior of `__traits(hasAliasing, void*)` being same as `std.traits.hasAliasing`.
  *
- * Copied from Phobos `std.traits`.
+ * Copied from Phobos `std.traits` and extended.
  */
-void test_hasAliasing()
+private static void test1()
 {
     static assert(__traits(hasAliasing, void*));
     static assert(!__traits(hasAliasing, void function()));
+
+    class C { int a; }
+    static assert(__traits(hasAliasing, C));
 
     struct S1 { int a; Object b; }
     struct S2 { string a; }
@@ -58,7 +61,7 @@ void test_hasAliasing()
     static assert(!__traits(hasAliasing, shared(const(void delegate() immutable))));
     static assert( __traits(hasAliasing, shared(const(void delegate() shared))));
     static assert( __traits(hasAliasing, shared(const(void delegate() shared const))));
-    static assert(!hasAliasing!(void function()));
+    static assert(!__traits(hasAliasing, void function()));
 
     interface I;
     static assert( __traits(hasAliasing, I));
@@ -68,12 +71,24 @@ void test_hasAliasing()
     static assert( __traits(hasAliasing, T1));
     static assert(!__traits(hasAliasing, T2));
 
+    struct ST(T) { T a; }
+    class CT(T) { T a; }
+    static assert( __traits(hasAliasing, ST!C));
+    static assert( __traits(hasAliasing, ST!I));
+    static assert(!__traits(hasAliasing, ST!int));
+    static assert( __traits(hasAliasing, CT!C));
+    static assert( __traits(hasAliasing, CT!I));
+    static assert( __traits(hasAliasing, CT!int));
+
     import std.typecons : Rebindable;
     static assert( __traits(hasAliasing, Rebindable!(const Object)));
     static assert(!__traits(hasAliasing, Rebindable!(immutable Object)));
     static assert( __traits(hasAliasing, Rebindable!(shared Object)));
     static assert( __traits(hasAliasing, Rebindable!Object));
+}
 
+private static test2()
+{
     struct S5
     {
         void delegate() immutable b;
@@ -107,7 +122,7 @@ void test_hasAliasing()
     static assert(!__traits(hasAliasing, immutable(S15)));
 }
 
-void test_hasAliasing_enums()
+private static test3()
 {
     enum Ei : string { a = "a", b = "b" }
     enum Ec : const(char)[] { a = "a", b = "b" }

--- a/test/compilable/traits_hasAliasing.d
+++ b/test/compilable/traits_hasAliasing.d
@@ -62,6 +62,11 @@ void test_hasAliasing()
 
     interface I;
     static assert( __traits(hasAliasing, I));
+    struct T1 { int a; I b; }
+    struct T2 { int a; immutable I b; }
+
+    static assert( __traits(hasAliasing, T1));
+    static assert(!__traits(hasAliasing, T2));
 
     import std.typecons : Rebindable;
     static assert( __traits(hasAliasing, Rebindable!(const Object)));

--- a/test/compilable/traits_hasAliasing.d
+++ b/test/compilable/traits_hasAliasing.d
@@ -2,7 +2,7 @@ module traits_hasAliasing;
 
 @safe pure nothrow @nogc:
 
-/** Verify behaviour of `__traits(hasAliasing, void*)` being same as `std.traits.hasAliasing`.
+/** Verify behavior of `__traits(hasAliasing, void*)` being same as `std.traits.hasAliasing`.
  *
  * Copied from Phobos `std.traits`.
  */

--- a/test/compilable/traits_hasAliasing.d
+++ b/test/compilable/traits_hasAliasing.d
@@ -34,11 +34,6 @@ private static void test1()
     static assert( __traits(hasAliasing, S6));
     static assert(!__traits(hasAliasing, S7));
 
-    static assert( __traits(hasAliasing, S1, S41)); // multiple arguments, all have aliasing
-    static assert( __traits(hasAliasing, S1, S2)); // multiple arguments, some have aliasing
-    static assert( __traits(hasAliasing, S2, S1)); // multiple arguments, some have aliasing
-    static assert(!__traits(hasAliasing, S2, S4)); // multiple arguments, none have aliasing
-
     static assert( __traits(hasAliasing, uint[uint]));
     static assert(!__traits(hasAliasing, immutable(uint[uint])));
     static assert( __traits(hasAliasing, void delegate()));

--- a/test/fail_compilation/traits_hasAliasing.d
+++ b/test/fail_compilation/traits_hasAliasing.d
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=1654
+
+/*
+  TEST_OUTPUT:
+  ---
+  fail_compilation/traits_hasAliasing.d(10): Error: type expected as non-first argument of __traits `hasAliasing` instead of `""`
+  ---
+*/
+
+enum _ = __traits(hasAliasing, "");


### PR DESCRIPTION
Compiler is in need of `hasAliasing` of this analysis at https://github.com/dlang/dmd/pull/12341.

Because of the DRY-principle and potentially large instantiation depth of `std.traits.hasAliasing` I propose that `hasAliasing` is exposed as a builtin trait that can be used to redefine `std.traits.hasAliasing` as

```d
enum hasAliasing(T) = __traits(hasAliasing, T);
```

. Tests were copied verbatim from `std.traits` to assume compliance with `std.traits.hasAliasing` with the exception of variadic arguments and special-casing of `Rebindable`.