### PR TITLE
ImportC: implement e->id

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -756,7 +756,6 @@ final class CParser(AST) : Parser!AST
             switch (token.value)
             {
             case TOK.dot:
-            case TOK.arrow:
                 nextToken();
                 if (token.value == TOK.identifier)
                 {
@@ -765,6 +764,19 @@ final class CParser(AST) : Parser!AST
                     break;
                 }
                 error("identifier expected following `.`, not `%s`", token.toChars());
+                break;
+
+            case TOK.arrow:
+                nextToken();
+                if (token.value == TOK.identifier)
+                {
+                    Identifier id = token.ident;
+                    auto die = new AST.DotIdExp(loc, e, id);
+                    die.arrow = true;
+                    e = die;
+                    break;
+                }
+                error("identifier expected following `->`, not `%s`", token.toChars());
                 break;
 
             case TOK.plusPlus:

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4707,6 +4707,7 @@ extern (C++) final class DotIdExp : UnaExp
     Identifier ident;
     bool noderef;       // true if the result of the expression will never be dereferenced
     bool wantsym;       // do not replace Symbol with its initializer during semantic()
+    bool arrow;         // ImportC: if -> instead of .
 
     extern (D) this(const ref Loc loc, Expression e, Identifier ident)
     {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6380,7 +6380,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             printf("DotIdExp::semantic(this = %p, '%s')\n", exp, exp.toChars());
             //printf("e1.op = %d, '%s'\n", e1.op, Token::toChars(e1.op));
         }
+        if (exp.arrow) // ImportC only
+            exp.e1 = exp.e1.expressionSemantic(sc).arrayFuncConv(sc);
         Expression e = exp.semanticY(sc, 1);
+
         if (e && isDotOpDispatch(e))
         {
             uint errors = global.startGagging();

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6919,6 +6919,7 @@ public:
     Identifier* ident;
     bool noderef;
     bool wantsym;
+    bool arrow;
     static DotIdExp* create(Loc loc, Expression* e, Identifier* ident);
     void accept(Visitor* v);
 };

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2362,7 +2362,10 @@ public:
     override void visit(DotIdExp e)
     {
         expToBuffer(e.e1, PREC.primary, buf, hgs);
-        buf.writeByte('.');
+        if (e.arrow)
+            buf.writestring("->");
+        else
+            buf.writeByte('.');
         buf.writestring(e.ident.toString());
     }
 

--- a/test/compilable/arraytopointer.c
+++ b/test/compilable/arraytopointer.c
@@ -59,5 +59,13 @@ void testComma()
     _Static_assert(sizeof((1, a)) == sizeof(int*), "testComma");
 }
 
+int testArrow()
+{
+    struct S { int m, n; };
+
+    struct S a[3];
+    return a->m;
+}
+
 
 


### PR DESCRIPTION
It turns out that `e->id` is subtly different from `e.id`. That is due to `e`, if it is an array, being implicitly converted to a pointer if it is the `->` syntax.

C++ has more differences, such as for operator overloading, but we don't care about that.

I originally wrote this as adding an `ArrowIdExp` type, but adding the flag to `DotIdExp` turned out to be so much simpler.