### PR TITLE
fix Issue 22262 - importC: Error: incompatible types for '(buf) is (0)': 'ubyte*' and 'int'

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -11397,6 +11397,25 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return false;
         }
 
+        if (sc && sc.flags & SCOPE.Cfile)
+        {
+            // https://issues.dlang.org/show_bug.cgi?id=22262
+            // In C11, zero implicitly casts to a null pointer.
+            if ((t1.ty == Tpointer) != (t2.ty == Tpointer))
+            {
+                if (auto ie = exp.e1.isIntegerExp())
+                {
+                    if (ie.toInteger() == 0)
+                        exp.e1 = new NullExp(ie.loc, t2);
+                }
+                else if (auto ie = exp.e2.isIntegerExp())
+                {
+                    if (ie.toInteger() == 0)
+                        exp.e2 = new NullExp(ie.loc, t1);
+                }
+            }
+        }
+
         if (auto e = exp.op_overload(sc))
         {
             result = e;

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -400,3 +400,14 @@ int test22245()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22262
+
+void test22262(unsigned char *buf)
+{
+  if (buf == 0)
+    return;
+  if (0 == buf)
+    return;
+}
+
+/***************************************************/

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -30,6 +30,8 @@ fail_compilation/failcstuff2.c(205): Error: variable `var` is used as a type
 fail_compilation/failcstuff2.c(203):        variable `var` is declared here
 fail_compilation/failcstuff2.c(254): Error: identifier or `(` expected before `)`
 fail_compilation/failcstuff2.c(255): Error: identifier or `(` expected
+fail_compilation/failcstuff2.c(302): Error: incompatible types for `(buf) is (1)`: `ubyte*` and `int`
+fail_compilation/failcstuff2.c(304): Error: incompatible types for `(2) is (buf)`: `int` and `ubyte*`
 ---
 */
 
@@ -110,3 +112,15 @@ void test22102()
     int22102();
     int22102(0);
 }
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22262
+#line 300
+void test22262(unsigned char *buf)
+{
+  if (buf == 1)
+    return;
+  if (2 == buf)
+    return;
+}
+


### PR DESCRIPTION
Zero is special, and is allowed  to implicitly convert to a NULL pointer expression,