### PR TITLE
fix Issue 22264 - importC: Error: '=', ';' or ',' expected using K&R function syntax

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -3444,6 +3444,7 @@ final class CParser(AST) : Parser!AST
 
         auto t = pt;
 
+        bool seenType;
         bool any;
         while (1)
         {
@@ -3462,9 +3463,19 @@ final class CParser(AST) : Parser!AST
                 case TOK._Bool:
                 //case TOK._Imaginary:
                 case TOK._Complex:
-                case TOK.identifier: // typedef-name
                     t = peek(t);
+                    seenType = true;
                     any = true;
+                    continue;
+
+                case TOK.identifier: // typedef-name
+                    if (!seenType)
+                    {
+                        t = peek(t);
+                        seenType = true;
+                        any = true;
+                        continue;
+                    }
                     break;
 
                 case TOK.struct_:

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -411,6 +411,19 @@ void test22262(unsigned char *buf)
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22264
+
+typedef int T22264;
+
+unsigned long test22264(crc, buf, len)
+    unsigned long crc;
+    const T22264 *buf;
+    T22264 len;
+{
+    return len;
+}
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22274
 
 void test22274(compr, comprLen, uncompr, uncomprLen)


### PR DESCRIPTION
Consume all type-specifiers, not just the first when looking ahead for a declaration-speciifer.  Ensure to only peek past the first identifier (the second identifier is handled by cparseDeclarator).