### PR TITLE
fix Issue 22274 - importC: [ICE]: 4 identifiers does not match 3 declarations using K&R syntax

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1686,6 +1686,8 @@ final class CParser(AST) : Parser!AST
                     return;
 
                 case TOK.comma:
+                    if (!symbolsSave)
+                        symbolsSave = symbols;
                     nextToken();
                     break;
 
@@ -1768,7 +1770,10 @@ final class CParser(AST) : Parser!AST
                     }
                 }
                 if (!p.type)
+                {
                     error("no declaration for identifier `%s`", p.ident.toChars());
+                    p.type = AST.Type.terror;
+                }
             }
         }
 

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -411,3 +411,12 @@ void test22262(unsigned char *buf)
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22274
+
+void test22274(compr, comprLen, uncompr, uncomprLen)
+    unsigned *compr, *uncompr;
+    signed comprLen, uncomprLen;
+{
+}
+
+/***************************************************/


### PR DESCRIPTION
When parsing comma delimited declarations, store the current symbols back to symbolsSave, otherwise on the next loop, it'll get set back to `null` again, losing the parameter.

Set parameter type to TypeError in cparseFunctionDefinition for error recovery, because otherwise a segfault occurs when it is looped over again in the next index of parameterList (yes, indexing the parameterList inside a foreach is quadratic).