### PR TITLE
fix Issue 22246 - ImportC: C11 does not allow _Alignof (expression)

### DIFF
--- a/test/compilable/alignas.c
+++ b/test/compilable/alignas.c
@@ -3,10 +3,10 @@
 int printf(const char *, ...);
 
 _Alignas(4) _Alignas(8) _Alignas(0) int x = 5;
-_Static_assert(_Alignof(x) == 8, "in");
+//_Static_assert(_Alignof(x) == 8, "in");
 
 _Alignas(int) short y = 6;
-_Static_assert(_Alignof(y) == 4, "in");
+//_Static_assert(_Alignof(y) == 4, "in");
 
 struct S
 {

--- a/test/fail_compilation/test22246.c
+++ b/test/fail_compilation/test22246.c
@@ -1,0 +1,17 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test22246.c(106): Error: argument to `_Alignof` must be a type
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22246
+
+#line 100
+
+struct S { int m; };
+
+int test()
+{
+    struct S s;
+    return _Alignof(s);
+}


### PR DESCRIPTION
C11 really should work like `sizeof` in accepting types *or* expressions, but c'est la vie