### PR TITLE
fix Issue 22233 - importC: (identifier)() incorrectly parsed as a cas…

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -3878,6 +3878,10 @@ final class CParser(AST) : Parser!AST
                     t = tk;
                     break;
                 }
+
+                if (tk.value == TOK.leftParenthesis && peek(tk).value == TOK.rightParenthesis)
+                    return false;    // (type-name)() is not a cast (it might be a function call)
+
                 if (!isCastExpression(tk, true))
                 {
                     if (afterParenType) // could be ( type-name ) ( unary-expression )

--- a/test/compilable/test22233.c
+++ b/test/compilable/test22233.c
@@ -1,0 +1,9 @@
+
+// https://issues.dlang.org/show_bug.cgi?id=22233
+
+int foo();
+
+void test()
+{
+    (foo)();
+}


### PR DESCRIPTION
…t-expression

An empty `( )` cannot be an expression.