### PR TITLE
Fix issue 21431 - Incorrect maximum and actual number of cases in a switch case range is reported

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3061,7 +3061,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
 
         if (lval - fval > 256)
         {
-            crs.error("had %llu cases which is more than 256 cases in case range", lval - fval);
+            crs.error("had %llu cases which is more than 257 cases in case range", 1 + lval - fval);
             errors = true;
             lval = fval + 256;
         }

--- a/test/fail_compilation/fail287.d
+++ b/test/fail_compilation/fail287.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail287.d(14): Error: had 299 cases which is more than 256 cases in case range
+fail_compilation/fail287.d(14): Error: had 300 cases which is more than 257 cases in case range
 ---
 */
 


### PR DESCRIPTION
Because it's an inclusive upper bound, add 1. I could also change it to `lval - fval >= 256`, but that's technically a breaking change.