### PR TITLE
Polish the 2.098 changelog

### DIFF
--- a/changelog/AliasAssign.dd
+++ b/changelog/AliasAssign.dd
@@ -1,4 +1,4 @@
-# Add Alias Assignment
+Add Alias Assignment
 
 This adds the ability for an alias declaration inside a template to be
 assigned a new value. For example, the recursive template:

--- a/changelog/ImportC.dd
+++ b/changelog/ImportC.dd
@@ -1,4 +1,4 @@
-# Accessing C Declarations From D Via ImportC Compiler
+Accessing C Declarations From D Via ImportC Compiler
 
 One of D's best features is easy integration with C code.
 There's almost a one-to-one mapping between C and a subset
@@ -191,10 +191,6 @@ is advisable.
 * Tag symbols are part of the global symbol table, not the special tag
 symbol table like they are supposed to reside in.
 
-* Octal literals are not supported.
-
-* Integer literal suffixes are not correct.
-
 * Multiple chars in char literal are not supported.
 
 * `_Atomic` as type qualifier is ignored.
@@ -289,3 +285,7 @@ No. Use dpp.
 ### ImportObjective-C ?
 
 No. Use DStep.
+
+### Documentation
+
+More info on ImportC will be written on [its page in the specification](https://dlang.org/spec/importc.html).

--- a/changelog/dtorfileds.dd
+++ b/changelog/dtorfileds.dd
@@ -1,4 +1,4 @@
-# -preview=dtorfields is now enabled by default
+-preview=dtorfields is now enabled by default
 
 This preview ensures that partially constructed objects are properly destroyed
 when an exception is thrown inside of an constructor. It was introduced in

--- a/changelog/range-error.dd
+++ b/changelog/range-error.dd
@@ -51,4 +51,4 @@ $(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
 ??:? _Dmain [0x5647250b9751]
 )
 
-The error message for indexing a non-existent key in an Associative Array has not been updated.
+The error messages for an out of bounds slice copy (`arr[a..b] = arr[c..d]`) or indexing a non-existent key in an Associative Array (`table["bad"]`) have not been updated.

--- a/changelog/trait-stc-callexp.dd
+++ b/changelog/trait-stc-callexp.dd
@@ -1,10 +1,10 @@
-# Function calls can now be used in `__traits(getParameterStorageClasses)`
+Function calls can now be used in `__traits(getParameterStorageClasses)`
 
-Parameter storage classes can now be obtained from function calls as in this
-example:
+Parameter storage classes can now be obtained from function calls, which is useful when they depend on the arguments being passed:
 
 ```d
-void func(ref float t) {}
+void func()(auto ref float t) {}
 float f;
 pragma(msg, __traits(getParameterStorageClasses, func(f), 0)); // tuple("ref")
+pragma(msg, __traits(getParameterStorageClasses, func(1.0f), 0)); // tuple()
 ```


### PR DESCRIPTION
- Remove the markdown `#` from the first line (it's rendered as an actual `#` char)
- Clarify / update some information