### PR TITLE
Fix Issue 22205 - catch(Exception) not longer working in debug blocks

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -4014,7 +4014,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 /* If catch exception type is derived from Exception
                  */
                 if (c.type.toBasetype().implicitConvTo(ClassDeclaration.exception.type) &&
-                    (!c.handler || !c.handler.comeFrom()))
+                    (!c.handler || !c.handler.comeFrom()) && !(sc.flags & SCOPE.debug_))
                 {
                     // Remove c from the array of catches
                     tcs.catches.remove(i);

--- a/test/runnable/test22205.d
+++ b/test/runnable/test22205.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -debug
+
+void main() nothrow
+{
+    debug
+    {
+        try
+        {
+            throw new Exception("2");
+        }
+        catch (Exception) {}
+        catch (Throwable)
+        {
+            assert(0);
+        }
+    }
+}


### PR DESCRIPTION
#8449 made it so that throw statements inside debug version blocks as marked as `internalThrow` [1], however,
when the block exit analysis is done [2] the throw statement is seen as being `fallthrough`, not throw in this case.
This makes it so that semantic analysis thinks that the try block never throws and optimizes it away [3].

This patch makes it so that the catch statement is optimized away only if it is not in a debug scope. This has the disadvantage
that try blocks that never throw inside debug blocks will not have their catches optimized away. However, I think that this is a good trade-off as taking care of that case would require changes that would make the code more ugly.

cc @wilzbach 

[1] https://github.com/dlang/dmd/blob/master/src/dmd/statementsem.d#L4984
[2] https://github.com/dlang/dmd/blob/master/src/dmd/blockexit.d#L475
[3] https://github.com/dlang/dmd/blob/master/src/dmd/statementsem.d#L4008