### PR TITLE
fix Issue 22253 - ImportC expressions inadvertently supporting D properties

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6412,6 +6412,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
+        if (sc.flags & SCOPE.Cfile && exp.ident != Id.__sizeof)
+        {
+            result = fieldLookup(exp.e1, sc, exp.ident);
+            return;
+        }
+
         Expression e = exp.semanticY(sc, 1);
 
         if (e && isDotOpDispatch(e))
@@ -8706,6 +8712,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
 
                 e1x = e;
+            }
+            else if (sc.flags & SCOPE.Cfile && e1x.isDotIdExp())
+            {
+                auto die = e1x.isDotIdExp();
+                e1x = fieldLookup(die.e1, sc, die.ident);
             }
             else if (auto die = e1x.isDotIdExp())
             {

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -8,7 +8,7 @@ fail_compilation/failcstuff2.c(57): Error: `-var` has no effect
 fail_compilation/failcstuff2.c(58): Error: `~var` has no effect
 fail_compilation/failcstuff2.c(59): Error: `!var` has no effect
 fail_compilation/failcstuff2.c(113): Error: `cast(int)var` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(114): Error: cannot modify constant `var.sizeof`
+fail_compilation/failcstuff2.c(114): Error: `sizeof` is not a member of `int`
 fail_compilation/failcstuff2.c(115): Error: `cast(short)3` is not an lvalue and cannot be modified
 fail_compilation/failcstuff2.c(116): Error: cannot modify constant `4`
 fail_compilation/failcstuff2.c(117): Error: cannot modify constant `5`

--- a/test/fail_compilation/fix22253.c
+++ b/test/fail_compilation/fix22253.c
@@ -1,0 +1,27 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fix22253.c(106): Error: `ptr` is not a member of `char[10]`
+fail_compilation/fix22253.c(107): Error: `length` is not a member of `char[10]`
+fail_compilation/fix22253.c(108): Error: `dup` is not a member of `char[10]`
+fail_compilation/fix22253.c(109): Error: `init` is not a member of `char`
+fail_compilation/fix22253.c(113): Error: `tupleof` is not a member of `S`
+---
+ */
+// https://issues.dlang.org/show_bug.cgi?id=22253
+
+#line 100
+
+void foo(int, int);
+
+void test()
+{
+    char a[10];
+    char *p = a.ptr;
+    unsigned i = a.length;
+    char *q = a.dup.ptr;
+    p = p.init;
+    struct S { int a, b; };
+    struct S s;
+    s.a = s.b;
+    foo(s.tupleof);
+}

--- a/test/runnable/test22071.c
+++ b/test/runnable/test22071.c
@@ -9,7 +9,7 @@ struct S *abc = &(struct S){ 1, 2 };
 int test()
 {
     struct S *var = &(struct S){ 1, 2 };
-    return var.b;
+    return var->b;
 }
 
 _Static_assert(test() == 2, "in");


### PR DESCRIPTION
The idea here is to prevent the compiler from looking up properties for C structs. Unfortunately, the property code lookup is a byzantine mess. So, what this fix does is short-circuit the mess and do its own lookup in importc.d.

A future PR could add spell checking to it.