### PR TITLE
fix Issue 22294 - importC: enums aren.t placed in surrounding namespace

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1471,7 +1471,8 @@ final class CParser(AST) : Parser!AST
         {
             nextToken();
             auto tt = tspec.isTypeTag();
-            if (!tt || !tt.id)
+            if (!tt ||
+                !tt.id && (tt.tok == TOK.struct_ || tt.tok == TOK.union_))
                 return; // legal but meaningless empty declaration, ignore it
 
             /* `struct tag;` and `struct tag { ... };`

--- a/test/compilable/fix22294.c
+++ b/test/compilable/fix22294.c
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=22294
+
+enum { A, B, C };
+
+_Static_assert(A == 0 && B == 1 && C == 2, "in");
+
+int array[C];


### PR DESCRIPTION
Another subtle difference between how enums and struct/union tags are handled.