### PR TITLE
Draft: Add new __traits(isSame2) that mimics the sane parts of std.meta.isSame

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8259,6 +8259,7 @@ struct Id final
     static Identifier* allMembers;
     static Identifier* derivedMembers;
     static Identifier* isSame;
+    static Identifier* isSame2;
     static Identifier* compiles;
     static Identifier* getAliasThis;
     static Identifier* getAttributes;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -453,6 +453,7 @@ immutable Msgtable[] msgtable =
     { "allMembers" },
     { "derivedMembers" },
     { "isSame" },
+    { "isSame2" },
     { "compiles" },
     { "getAliasThis" },
     { "getAttributes" },

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -135,6 +135,7 @@ shared static this()
         "allMembers",
         "derivedMembers",
         "isSame",
+        "isSame2",
         "compiles",
         "getAliasThis",
         "getAttributes",
@@ -428,6 +429,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
     if (e.ident != Id.compiles &&
         e.ident != Id.isSame &&
+        e.ident != Id.isSame2 &&
         e.ident != Id.identifier &&
         e.ident != Id.getProtection && e.ident != Id.getVisibility &&
         e.ident != Id.getAttributes)
@@ -1838,6 +1840,35 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 return False();
         return True();
     }
+    if (e.ident == Id.isSame2)
+    {
+        /* Determine if two symbols are the same
+         */
+        if (dim != 2)
+            return dimError(2);
+
+        // https://issues.dlang.org/show_bug.cgi?id=20761
+        // tiarg semantic may expand in place the list of arguments, for example:
+        //
+        //     before tiarg sema:  __traits(isSame2, seq!(0,0), seq!(1,1))
+        //     after            :  __traits(isSame2, 0, 0, 1, 1)
+        //
+        // so we split in two lists
+        Objects ob1;
+        ob1.push((*e.args)[0]);
+        Objects ob2;
+        ob2.push((*e.args)[1]);
+        if (!TemplateInstance.semanticTiargs(e.loc, sc, &ob1, 0))
+            return ErrorExp.get();
+        if (!TemplateInstance.semanticTiargs(e.loc, sc, &ob2, 0))
+            return ErrorExp.get();
+        if (ob1.dim != ob2.dim)
+            return False();
+        foreach (immutable i; 0 .. ob1.dim)
+            if (!ob1[i].isSame2(ob2[i], sc))
+                return False();
+        return True();
+    }
     if (e.ident == Id.getUnitTests)
     {
         if (dim != 1)
@@ -2089,6 +2120,131 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
 /// compare arguments of __traits(isSame)
 private bool isSame(RootObject o1, RootObject o2, Scope* sc)
+{
+    static FuncLiteralDeclaration isLambda(RootObject oarg)
+    {
+        if (auto t = isDsymbol(oarg))
+        {
+            if (auto td = t.isTemplateDeclaration())
+            {
+                if (td.members && td.members.dim == 1)
+                {
+                    if (auto fd = (*td.members)[0].isFuncLiteralDeclaration())
+                        return fd;
+                }
+            }
+        }
+        else if (auto ea = isExpression(oarg))
+        {
+            if (ea.op == TOK.function_)
+            {
+                if (auto fe = cast(FuncExp)ea)
+                    return fe.fd;
+            }
+        }
+        return null;
+    }
+
+    auto l1 = isLambda(o1);
+    auto l2 = isLambda(o2);
+
+    if (l1 && l2)
+    {
+        import dmd.lambdacomp : isSameFuncLiteral;
+        if (isSameFuncLiteral(l1, l2, sc))
+            return true;
+    }
+
+    // issue 12001, allow isSame, <BasicType>, <BasicType>
+    Type t1 = isType(o1);
+    Type t2 = isType(o2);
+    if (t1 && t2 && t1.equals(t2))
+        return true;
+
+    auto s1 = getDsymbol(o1);
+    auto s2 = getDsymbol(o2);
+    //printf("isSame: %s, %s\n", o1.toChars(), o2.toChars());
+    version (none)
+    {
+        printf("o1: %p\n", o1);
+        printf("o2: %p\n", o2);
+        if (!s1)
+        {
+            if (auto ea = isExpression(o1))
+                printf("%s\n", ea.toChars());
+            if (auto ta = isType(o1))
+                printf("%s\n", ta.toChars());
+            return false;
+        }
+        else
+            printf("%s %s\n", s1.kind(), s1.toChars());
+    }
+    if (!s1 && !s2)
+    {
+        auto ea1 = isExpression(o1);
+        auto ea2 = isExpression(o2);
+        if (ea1 && ea2)
+        {
+            if (ea1.equals(ea2))
+                return true;
+        }
+    }
+    if (!s1 || !s2)
+        return false;
+
+    s1 = s1.toAlias();
+    s2 = s2.toAlias();
+
+    if (auto fa1 = s1.isFuncAliasDeclaration())
+        s1 = fa1.toAliasFunc();
+    if (auto fa2 = s2.isFuncAliasDeclaration())
+        s2 = fa2.toAliasFunc();
+
+    // https://issues.dlang.org/show_bug.cgi?id=11259
+    // compare import symbol to a package symbol
+    static bool cmp(Dsymbol s1, Dsymbol s2)
+    {
+        auto imp = s1.isImport();
+        return imp && imp.pkg && imp.pkg == s2.isPackage();
+    }
+
+    if (cmp(s1,s2) || cmp(s2,s1))
+        return true;
+
+    if (s1 == s2)
+        return true;
+
+    // https://issues.dlang.org/show_bug.cgi?id=18771
+    // OverloadSets are equal if they contain the same functions
+    auto overSet1 = s1.isOverloadSet();
+    if (!overSet1)
+        return false;
+
+    auto overSet2 = s2.isOverloadSet();
+    if (!overSet2)
+        return false;
+
+    if (overSet1.a.dim != overSet2.a.dim)
+        return false;
+
+    // OverloadSets contain array of Dsymbols => O(n*n)
+    // to compare for equality as the order of overloads
+    // might not be the same
+Lnext:
+    foreach(overload1; overSet1.a)
+    {
+        foreach(overload2; overSet2.a)
+        {
+            if (overload1 == overload2)
+                continue Lnext;
+        }
+        return false;
+    }
+    return true;
+}
+
+/// compare arguments of __traits(isSame2)
+private bool isSame2(RootObject o1, RootObject o2, Scope* sc)
 {
     static FuncLiteralDeclaration isLambda(RootObject oarg)
     {

--- a/test/compilable/testlambdacomp2.d
+++ b/test/compilable/testlambdacomp2.d
@@ -1,0 +1,216 @@
+// EXTRA_FILES: imports/testlambda1.d imports/testlambda2.d
+module testlambdacomp;
+
+void test1()
+{
+    static assert(__traits(isSame2, (a, b) => a + b, (c, d) => c + d));
+    static assert(__traits(isSame2, a => ++a, b => ++b));
+    static assert(!__traits(isSame2, (int a, int b) => a + b, (a, b) => a + b));
+    static assert(__traits(isSame2, (a, b) => a + b + 10, (c, d) => c + d + 10));
+}
+
+class Y
+{
+    static int r = 5;
+    int x;
+    this(int x)
+    {
+        this.x = x;
+    }
+}
+
+class A
+{
+    Y a;
+    this(Y a)
+    {
+        this.a = a;
+    }
+}
+
+void foo3(alias pred)()
+{
+    static assert(!__traits(isSame2, pred, (A x, A y) => ++x.a.x + (--y.a.x)));
+}
+
+void test2()
+{
+
+    int b;
+    static assert(!__traits(isSame2, a => a + b, a => a + b));
+
+    int f() { return 3;}
+    static assert(__traits(isSame2, a => a + f(), a => a + f()));
+
+    class A
+    {
+        Y a;
+        this(Y a)
+        {
+            this.a = a;
+        }
+    }
+
+    class B
+    {
+        int a;
+        this(int a)
+        {
+            this.a = a;
+        }
+    }
+
+    B q = new B(7);
+    alias pred = (A a, A b) => ++a.a.x + (--b.a.x);
+    foo3!pred();
+    static assert(!__traits(isSame2, (A a) => ++a.a.x + 2, (A b) => ++b.a.x + 3));
+    static assert(__traits(isSame2,  pred, (A x, A y) => ++x.a.x + (--y.a.x)));
+    static assert(!__traits(isSame2, (B a) => ++a.a + 2, (B b) => ++b.a + 3));
+    static assert(__traits(isSame2, (B a) => ++a.a, (B a) => ++a.a));
+
+    B cl = new B(7);
+    static assert(!__traits(isSame2, a => a + q.a, c => c + cl.a));
+
+    class C(G)
+    {
+        G a;
+        this(int a)
+        {
+            this.a = a;
+        }
+    }
+    static assert(!__traits(isSame2, (C!int a) => ++a.a, (C!int a) => ++a.a));
+
+    struct X
+    {
+        int a;
+    }
+    static assert(__traits(isSame2, (X a) => a.a + 2, (X b) => b.a + 2));
+
+    struct T(G)
+    {
+        G a;
+    }
+    static assert(!__traits(isSame2, (T!int a) => ++a.a, (T!int a) => ++a.a));
+
+}
+
+void test3()
+{
+    enum q = 10;
+    static assert(__traits(isSame2, (a, b) => a + b + q, (c, d) => c + d + 10));
+
+    struct Bar
+    {
+        int a;
+    }
+    enum r1 = Bar(1);
+    enum r2 = Bar(1);
+    static assert(__traits(isSame2, a => a + r1.a, b => b + r2.a));
+
+    enum X { A, B, C}
+    static assert(__traits(isSame2, a => a + X.A, a => a + 0));
+}
+
+void foo(alias pred)()
+{
+    static assert(__traits(isSame2, pred, (c, d) => c + d));
+    static assert(__traits(isSame2, (c, d) => c + d, pred));
+}
+
+void bar(alias pred)()
+{
+    static assert(__traits(isSame2, pred, (c, d) => c < d + 7));
+
+    enum q = 7;
+    static assert(__traits(isSame2, pred, (c, d) => c < d + q));
+
+    int r = 7;
+    static assert(!__traits(isSame2, pred, (c, d) => c < d + r));
+}
+void test4()
+{
+    foo!((a, b) => a + b)();
+    bar!((a, b) => a < b + 7);
+}
+
+int bar()
+{
+    return 2;
+}
+
+void testImportedFunctions(alias pred)()
+{
+    // imports.testalambda1.bar != imports.testlambda2.bar
+    import imports.testlambda2 : bar;
+    static assert(!__traits(isSame2, pred, (int a) => a + bar()));
+}
+
+void testLocalGlobalFunctionScopes(alias pred)()
+{
+    // testlambdacomp.bar != testlambdacomp.test5.bar
+    static assert(!__traits(isSame2, pred, (int a) => a + bar()));
+
+    // imports.testlambda1.bar != testlambdacomp.test5.bar
+    import imports.testlambda1 : bar;
+    static assert(!__traits(isSame2, pred, (int a) => a + bar()));
+
+    // functions imported from different modules are not equal
+    testImportedFunctions!((int a) => a + bar())();
+}
+
+// lambda functions which contain function calls
+void test5()
+{
+
+    int bar()
+    {
+        return 3;
+    }
+
+    // functions in the same scope
+    alias pred = a => a + bar();
+    alias pred2 = b => b + bar();
+    static assert(__traits(isSame2, pred, pred2));
+
+    // functions in different scopes
+    testLocalGlobalFunctionScopes!((int a) => a + bar())();
+
+    int foo(int a, int b)
+    {
+        return 2 + a + b;
+    }
+
+    // functions with different kind of parameters
+    alias preda23 = a => a + foo(2, 3);
+    alias predb23 = b => b + foo(2, 3);
+    alias predc24 = c => c + foo(2, 4);
+    alias predd23 = (int d) => d + foo(2, 3);
+    alias prede23 = (int e) => e + foo(2, 3);
+    alias predf24 = (int f) => f + foo(2, 4);
+    static assert(__traits(isSame2, preda23, predb23));
+    static assert(!__traits(isSame2, predc24, predd23));
+    static assert(__traits(isSame2, predd23, prede23));
+    static assert(!__traits(isSame2, prede23, predf24));
+
+    // functions with function calls as parameters
+    static assert(!__traits(isSame2, (int a, int b) => foo(foo(1, a), foo(1, b)), (int a, int b) => foo(foo(1, a), foo(2, b))));
+    static assert(!__traits(isSame2, (a, b) => foo(foo(1, a), foo(1, b)), (int a, int b) => foo(foo(1, a), foo(2, b))));
+
+    float floatFunc(float a, float b)
+    {
+        return a + b;
+    }
+
+    static assert(__traits(isSame2, a => floatFunc(a, 1.0), b => floatFunc(b, 1.0)));
+    static assert(!__traits(isSame2, a => floatFunc(a, 1.0), b => floatFunc(b, 2.0)));
+}
+
+void main()
+{
+    test1();
+    test2();
+    test3();
+    test4();
+    test5();
+}


### PR DESCRIPTION
Naming `isSame2` is obviously a temporary placeholder for the real name that is to be decided in some kind of democratic process.

This commit is just an implementation of isSame2 being a copy isSame. Adjustments to mimic phobos will happen in subsequent commits.

I had a discussion with @andralex about the discrepancies between `std.meta.isSame` and `__traits(isSame)` and he proposed the following:

1. Add a `__traits(identical)` (original proposed as `__traits(isSame2)`) that mimic `std.meta.isSame`
2. Use `enum identical(T, U) = __traits(isSame, T, U);`
3. Deprecate `__traits(isSame)`