### PR TITLE
Fix Issue 22309 - Taking the address of a stack variable struct with this is wrongly seen as @safe

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6952,7 +6952,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
         }
-        else if ((exp.e1.op == TOK.this_ || exp.e1.op == TOK.super_) && global.params.useDIP1000 == FeatureState.enabled)
+        else if (exp.e1.op == TOK.this_ || exp.e1.op == TOK.super_)
         {
             if (VarDeclaration v = expToVariable(exp.e1))
             {

--- a/test/fail_compilation/test22309.d
+++ b/test/fail_compilation/test22309.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test22309.d(19): Error: cannot take address of parameter `this` in `@safe` function `wrap`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22309
+
+struct Wrap
+{
+    this(S* s) @safe {}
+}
+
+struct S
+{
+    Wrap wrap() @safe
+    {
+        return Wrap(&this);
+    }
+}


### PR DESCRIPTION
Signed-off-by: João Lourenço <jlourenco5691@gmail.com>