### PR TITLE
fix Issue 22286 - importC: (identifier)(other_identifier) incorrectly…

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4425,6 +4425,26 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else if (exp.e1.op == TOK.type && (sc && sc.flags & SCOPE.Cfile))
             {
+                const numArgs = exp.arguments ? exp.arguments.length : 0;
+                if (e1org.parens && numArgs >= 1)
+                {
+                    /* Ambiguous cases arise from CParser where there is not enough
+                     * information to determine if we have a function call or a cast.
+                     *   ( type-name ) ( identifier ) ;
+                     *   ( identifier ) ( identifier ) ;
+                     * If exp.e1 is a type-name, then this is a cast.
+                     */
+                    Expression arg;
+                    foreach (a; (*exp.arguments)[])
+                    {
+                        arg = arg ? new CommaExp(a.loc, arg, a) : a;
+                    }
+                    auto t = exp.e1.isTypeExp().type;
+                    auto e = new CastExp(exp.loc, arg, t);
+                    result = e.expressionSemantic(sc);
+                    return;
+                }
+
                 /* Ambiguous cases arise from CParser where there is not enough
                  * information to determine if we have a function call or declaration.
                  *   type-name ( identifier ) ;
@@ -4432,7 +4452,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                  * If exp.e1 is a type-name, then this is a declaration. C11 does not
                  * have type construction syntax, so don't convert this to a cast().
                  */
-                if (exp.arguments && exp.arguments.dim == 1)
+                if (numArgs == 1)
                 {
                     Expression arg = (*exp.arguments)[0];
                     if (auto ie = (*exp.arguments)[0].isIdentifierExp())

--- a/test/compilable/test22286.c
+++ b/test/compilable/test22286.c
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=22286
+
+int foo1(int);
+int foo2(int, int);
+typedef int Int;
+
+void test()
+{
+    Int b;
+    int x = (foo1)(3);
+    x = (foo2)(3,4);
+    x = (Int)(3);
+    x = (Int)(3,4);
+}


### PR DESCRIPTION
… parsed as a cast-expression

This is yet another grammar ambiguity we have to fix in the semantic pass. (This is why D uses the `cast` keyword!)

Took me a while to figure out how to fix this.