### PR TITLE
fix Issue 22263 - ImportC: function and variable re-declarations shou…

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -4155,8 +4155,10 @@ final class CParser(AST) : Parser!AST
             {
                 if (specifier.scw & SCW.xextern)
                    stc = AST.STC.extern_ | AST.STC.gshared;
+                else if (specifier.scw & SCW.xstatic)
+                   stc = AST.STC.gshared | AST.STC.static_;
                 else
-                    stc = AST.STC.gshared;
+                   stc = AST.STC.gshared;
             }
             else if (level == LVL.local)
             {

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -795,9 +795,17 @@ extern (C++) class Dsymbol : ASTNode
             Dsymbol s2 = sds.symtabLookup(this,ident);
 
             // If using C tag/prototype/forward declaration rules
-            if (sc.flags & SCOPE.Cfile &&
-                handleTagSymbols(*sc, this, s2, sds))
+            if (sc.flags & SCOPE.Cfile)
+            {
+                if (handleTagSymbols(*sc, this, s2, sds))
                     return;
+                if (handleSymbolRedeclarations(*sc, this, s2, sds))
+                    return;
+
+                sds.multiplyDefined(Loc.initial, this, s2);  // ImportC doesn't allow overloading
+                errors = true;
+                return;
+            }
 
             if (!s2.overloadInsert(this))
             {
@@ -2386,3 +2394,81 @@ Dsymbol handleTagSymbols(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsymbol sds)
 }
 
 
+/**********************************************
+ * ImportC allows redeclarations of variables and functions.
+ *    extern int x;
+ *    int x = 3;
+ * and:
+ *    extern void f();
+ *    void f() { }
+ * Attempt to merge them.
+ * Params:
+ *      sc = context
+ *      s = symbol to add to symbol table
+ *      s2 = existing declaration
+ *      sds = symbol table
+ * Returns:
+ *      if s and s2 are successfully put in symbol table then return the merged symbol,
+ *      null if they conflict
+ */
+Dsymbol handleSymbolRedeclarations(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsymbol sds)
+{
+    enum log = false;
+    if (log) printf("handleSymbolRedeclarations('%s')\n", s.toChars());
+
+    static Dsymbol collision()
+    {
+        if (log) printf(" collision\n");
+        return null;
+    }
+
+    auto vd = s.isVarDeclaration(); // new declaration
+    auto vd2 = s2.isVarDeclaration(); // existing declaration
+    if (vd && vd2)
+    {
+        // if one is `static` and the other isn't
+        if ((vd.storage_class ^ vd2.storage_class) & STC.static_)
+            return collision();
+
+        const i1 =  vd._init && ! vd._init.isVoidInitializer();
+        const i2 = vd2._init && !vd2._init.isVoidInitializer();
+
+        if (i1 && i2)
+            return collision();         // can't both have initializers
+
+        if (i1)
+            return vd;
+
+        /* BUG: the types should match, which needs semantic() to be run on it
+         *    extern int x;
+         *    int x;  // match
+         *    typedef int INT;
+         *    INT x;  // match
+         *    long x; // collision
+         * We incorrectly ignore these collisions
+         */
+        return vd2;
+    }
+
+    auto fd = s.isFuncDeclaration(); // new declaration
+    auto fd2 = s2.isFuncDeclaration(); // existing declaration
+    if (fd && fd2)
+    {
+        // if one is `static` and the other isn't
+        if ((fd.storage_class ^ fd2.storage_class) & STC.static_)
+            return collision();
+
+        if (fd.fbody && fd2.fbody)
+            return collision();         // can't both have bodies
+
+        if (fd.fbody)
+            return fd;
+
+        /* BUG: just like with VarDeclaration, the types should match, which needs semantic() to be run on it.
+         * FuncDeclaration::semantic2() can detect this, but it relies overnext being set.
+         */
+        return fd2;
+    }
+
+    return collision();
+}

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -363,7 +363,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
         assert(fd.semanticRun <= PASS.semantic2);
         fd.semanticRun = PASS.semantic2;
 
-        //printf("FuncDeclaration::semantic2 [%s] fd0 = %s %s\n", loc.toChars(), toChars(), type.toChars());
+        //printf("FuncDeclaration::semantic2 [%s] fd: %s type: %s\n", fd.loc.toChars(), fd.toChars(), fd.type ? fd.type.toChars() : "".ptr);
 
         // Only check valid functions which have a body to avoid errors
         // for multiple declarations, e.g.

--- a/test/fail_compilation/fix22263.c
+++ b/test/fail_compilation/fix22263.c
@@ -1,0 +1,46 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fix22263.c(108): Error: function `fix22263.f3` conflicts with function `fix22263.f3` at fail_compilation/fix22263.c(107)
+fail_compilation/fix22263.c(127): Error: variable `fix22263.x4` conflicts with variable `fix22263.x4` at fail_compilation/fix22263.c(126)
+fail_compilation/fix22263.c(133): Error: variable `fix22263.x6` conflicts with variable `fix22263.x6` at fail_compilation/fix22263.c(132)
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=22263
+
+#line 100
+
+extern void f1(int);
+void f1(int a) { }
+
+static void f2(int);
+static void f2(int a) { }
+
+static void f3(int) { }
+static void f3(int a) { }
+
+void foo()
+{
+    f1(42);
+    f2(42);
+    f3(42);
+}
+
+extern const int x1;
+const int x1 = 1;
+
+int x2 = 2;
+extern int x2;
+
+static int x3;
+static int x3 = 3;
+
+static int x4;
+int x4;
+
+int x5;
+int x5;
+
+int x6 = 6;
+int x6 = 6;
+


### PR DESCRIPTION
…ld be allowed

This is another one of those problems due to C wants to do semantic and symbol tables at the same time, while D does it separately. I.e. we do not have type information available when inserting things into the symbol table.

So this assumes the types match when building the symbol table. A future PR can distinguish the types in the semantic2 pass, and here's the bug report on it:

https://issues.dlang.org/show_bug.cgi?id=22316

This PR should at least get correct code compiling correctly. 22316 just adds more error checking.