### PR TITLE
fix Issue 22314 - ImportC: fails to parse gnu attributes on enum members

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2990,6 +2990,15 @@ final class CParser(AST) : Parser!AST
                     // TODO C11 6.7.2.2-2 value must fit into an int
                 }
 
+                if (token.value == TOK.__attribute__)
+                {
+                    /* gnu-attributes can appear here, but just scan and ignore them
+                     * https://gcc.gnu.org/onlinedocs/gcc/Enumerator-Attributes.html
+                     */
+                    Specifier specifierx;
+                    cparseGnuAttributes(specifierx);
+                }
+
                 auto em = new AST.EnumMember(mloc, ident, value, null, 0, null, null);
                 members.push(em);
 

--- a/test/compilable/fix22314.c
+++ b/test/compilable/fix22314.c
@@ -1,0 +1,6 @@
+// https://issues.dlang.org/show_bug.cgi?id=22314
+
+enum E {
+    oldval __attribute__((deprecated)),
+    newval
+};


### PR DESCRIPTION
Just parse and ignore the `__attribute__`