### PR TITLE
Disable Azure Codecov for Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,8 @@ jobs:
     variables:
       D_COMPILER: dmd
       HOST_DMD_VERSION: LATEST
-      DMD_TEST_COVERAGE: 1
+      # Disable actual coverage because of issues with the codecov uploader
+      # DMD_TEST_COVERAGE: 1
     strategy:
       matrix:
         x64:


### PR DESCRIPTION
This attempts to fix the currently failing code coverage test for windows, let's see if it works. We can re-enable the fix once we upgrade to the new codecov uploader [1] 

[1] https://about.codecov.io/blog/introducing-codecovs-new-uploader/