### PR TITLE
Fix Issue 22310 - Cache failed template instantiations

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5805,6 +5805,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
     private ushort _nest;       // for recursive pretty printing detection, 3 MSBs reserved for flags (below)
     ubyte inuse;                // for recursive expansion detection
+    ubyte numFailedGagged;
 
     private enum Flag : uint
     {
@@ -6086,6 +6087,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         /* Template functions may have different instantiations based on
          * "auto ref" parameters.
          */
+        if (ti.inst || ti._scope) // FIXME: hack around forward reference errors for cached TemplateInstances with inst = null
         if (auto fd = ti.toAlias().isFuncDeclaration())
         {
             if (!fd.errors)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6381,6 +6381,7 @@ private:
     uint16_t _nest;
 public:
     uint8_t inuse;
+    uint8_t numFailedGagged;
 private:
     enum class Flag : uint32_t
     {

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -274,6 +274,7 @@ private:
     unsigned short _nest;                // for recursive pretty printing detection, 3 MSBs reserved for flags
 public:
     unsigned char inuse;                 // for recursive expansion detection
+    unsigned char numFailedGagged;
 
     TemplateInstance *syntaxCopy(Dsymbol *);
     Dsymbol *toAlias();                 // resolve real symbol

--- a/test/compilable/test22310.d
+++ b/test/compilable/test22310.d
@@ -1,0 +1,47 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=22310
+
+REQUIRED_ARGS: -vtemplates
+TEST_OUTPUT:
+---
+compilable/test22310.d(24): vtemplate: 50000 (19 distinct) instantiation(s) of template `BooleanTypeOf(T)` found
+compilable/test22310.d(22): vtemplate: 19 (19 distinct) instantiation(s) of template `AliasThisTypeOf(T)` found
+compilable/test22310.d(14): vtemplate: 19 (10 distinct) instantiation(s) of template `OriginalType(T)` found
+compilable/test22310.d(37): vtemplate: 1 (0 distinct) instantiation(s) of template `AliasSeq(T...)` found
+---
+*/
+
+template OriginalType(T)
+{
+    static if (is(T == enum))
+        static assert(0); // for simplification
+    else
+        alias OriginalType = T;
+}
+
+alias AliasThisTypeOf(T) = typeof(__traits(getMember, T.init, __traits(getAliasThis, T)[0]));
+
+template BooleanTypeOf(T)
+{
+    static if (is(AliasThisTypeOf!T AT) && !is(AT[] == AT))
+        alias X = BooleanTypeOf!AT;
+    else
+        alias X = OriginalType!T;
+
+    static if (is(immutable X == immutable bool))
+        alias BooleanTypeOf = X;
+    else
+        static assert(0, T.stringof~" is not boolean type");
+}
+
+alias AliasSeq(T...) = T;
+// 10 types
+alias SampleTypes = AliasSeq!(bool, char, wchar, dchar, byte, ubyte, short, ushort, int, uint);
+
+void main()
+{
+    enum count = 5_000;
+    static foreach (i; 0 .. count)
+        foreach (T; SampleTypes)
+            enum _ = is(BooleanTypeOf!T);
+}


### PR DESCRIPTION
Only allow one retry attempt for gagged (speculative) instantiations, which seems to be crucial to make Phobos unittests compile.

This seems to be a more promising approach than #13075.