### PR TITLE
fix Issue 22326 - ImportC: struct with flexible array member is incor…

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2384,8 +2384,9 @@ final class CParser(AST) : Parser!AST
                         }
                         else
                         {
-                            // An array of unknown size, fake it with a DArray
-                            ta = new AST.TypeDArray(t); // []
+                            /* C11 6.7.6.2-4 An [ ] array is an incomplete array type
+                             */
+                            ta = new AST.TypeSArray(t);
                         }
                         check(TOK.rightBracket);
 
@@ -2420,7 +2421,7 @@ final class CParser(AST) : Parser!AST
                             /* C11 6.7.6.2-1: the element type shall not be an incomplete or
                              * function type.
                              */
-                            if (ta.isTypeDArray() && !isVLA)
+                            if (ta.isTypeSArray() && ta.isTypeSArray().isIncomplete() && !isVLA)
                                 error("array type has incomplete element type `%s`", ta.toChars());
                         }
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3572,6 +3572,7 @@ public:
     Expression* dim;
     const char* kind() const;
     TypeSArray* syntaxCopy();
+    bool isIncomplete();
     d_uns64 size(const Loc& loc);
     uint32_t alignsize();
     bool isString();

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -3528,6 +3528,13 @@ extern (C++) final class TypeSArray : TypeArray
         this.dim = dim;
     }
 
+    extern (D) this(Type t)  // for incomplete type
+    {
+        super(Tsarray, t);
+        //printf("TypeSArray()\n");
+        this.dim = new IntegerExp(0);
+    }
+
     override const(char)* kind() const
     {
         return "sarray";
@@ -3540,6 +3547,15 @@ extern (C++) final class TypeSArray : TypeArray
         auto result = new TypeSArray(t, e);
         result.mod = mod;
         return result;
+    }
+
+    /***
+     * C11 6.7.6.2-4 incomplete array type
+     * Returns: true if incomplete type
+     */
+    bool isIncomplete()
+    {
+        return dim.isIntegerExp() && dim.isIntegerExp().getInteger() == 0;
     }
 
     override d_uns64 size(const ref Loc loc)

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -438,6 +438,7 @@ public:
 
     const char *kind();
     TypeSArray *syntaxCopy();
+    bool isIncomplete();
     d_uns64 size(const Loc &loc);
     unsigned alignsize();
     bool isString();

--- a/test/fail_compilation/failcstuff1.c
+++ b/test/fail_compilation/failcstuff1.c
@@ -28,16 +28,16 @@ fail_compilation/failcstuff1.c(400): Error: `enum ENUM` has no members
 fail_compilation/failcstuff1.c(450): Error: static array parameters are not supported
 fail_compilation/failcstuff1.c(450): Error: static or type qualifier used in non-outermost array type derivation
 fail_compilation/failcstuff1.c(451): Error: static or type qualifier used in non-outermost array type derivation
-fail_compilation/failcstuff1.c(451): Error: array type has incomplete element type `int[]`
-fail_compilation/failcstuff1.c(452): Error: array type has incomplete element type `int[]`
-fail_compilation/failcstuff1.c(453): Error: array type has incomplete element type `int[]`
+fail_compilation/failcstuff1.c(451): Error: array type has incomplete element type `int[0]`
+fail_compilation/failcstuff1.c(452): Error: array type has incomplete element type `int[0]`
+fail_compilation/failcstuff1.c(453): Error: array type has incomplete element type `int[0]`
 fail_compilation/failcstuff1.c(454): Error: found `const` when expecting `,`
 fail_compilation/failcstuff1.c(458): Error: static array parameters are not supported
 fail_compilation/failcstuff1.c(458): Error: static or type qualifier used outside of function prototype
 fail_compilation/failcstuff1.c(459): Error: static or type qualifier used outside of function prototype
 fail_compilation/failcstuff1.c(460): Error: variable length arrays are not supported
 fail_compilation/failcstuff1.c(460): Error: variable length array used outside of function prototype
-fail_compilation/failcstuff1.c(461): Error: array type has incomplete element type `int[]`
+fail_compilation/failcstuff1.c(461): Error: array type has incomplete element type `int[0]`
 fail_compilation/failcstuff1.c(462): Error: `=`, `;` or `,` expected
 fail_compilation/failcstuff1.c(502): Error: identifier or `(` expected
 fail_compilation/failcstuff1.c(502): Error: found `;` when expecting `)`

--- a/test/runnable/test22326.c
+++ b/test/runnable/test22326.c
@@ -1,0 +1,25 @@
+/* RUN_OUTPUT:
+---
+36
+4
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22326
+
+struct S {
+    char c;
+    int x[0]; // incomplete array type
+};
+
+int printf(const char*, ...);
+
+int main(){
+    _Alignas(int) char buff[sizeof(struct S) + sizeof(int[8])];
+    struct S* s = (struct S*)buff;
+    printf("%u\n", (unsigned)sizeof(buff));     // should print 36
+    printf("%u\n", (unsigned)sizeof(struct S)); // should print 4
+    for(int i = 0; i < 8; i++)
+        s->x[i] = i; // program segfaults here
+    return 0;
+}


### PR DESCRIPTION
…rectly handled

It's no longer tenable to have incomplete C array types represented as D dynamic arrays.