### PR TITLE
Pipe output of cd to /dev/null in postscript.sh

### DIFF
--- a/test/tools/postscript.sh
+++ b/test/tools/postscript.sh
@@ -12,7 +12,7 @@ fi
 script_file="$1"
 shift
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # export common variables
 source "$DIR/exported_vars.sh"


### PR DESCRIPTION
Prevents setting of incorrect `DIR` value when environment defines `CDPATH`.

See https://superuser.com/questions/90535/how-do-i-turn-of-auto-echo-in-bash-when-i-cd