### PR TITLE
ImportC: add support for __builtin_va_list

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8279,6 +8279,7 @@ struct Id final
     static Identifier* dllexport;
     static Identifier* vector_size;
     static Identifier* noreturn;
+    static Identifier* builtin_va_list;
     static void initialize();
     Id()
     {

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -501,6 +501,7 @@ immutable Msgtable[] msgtable =
     { "__func__" },
     { "noreturn" },
     { "__pragma", "pragma" },
+    { "builtin_va_list", "__builtin_va_list" },
 ];
 
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3003,6 +3003,16 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
             error(loc, "variable `__ctfe` cannot be read at compile time");
             return returnError();
         }
+        if (mt.ident == Id.builtin_va_list) // gcc has __builtin_va_xxxx for stdarg.h
+        {
+            /* Since we don't support __builtin_va_start, -arg, -end, we don't
+             * have to actually care what -list is. A void* will do.
+             * If we ever do care, import core.stdc.stdarg and pull
+             * the definition out of that, similarly to how std.math is handled for PowExp
+             */
+            pt = Type.tvoidptr;
+            return;
+        }
 
         Dsymbol scopesym;
         Dsymbol s = sc.search(loc, mt.ident, &scopesym);

--- a/test/compilable/valist.c
+++ b/test/compilable/valist.c
@@ -1,0 +1,4 @@
+// https://issues.dlang.org/show_bug.cgi?id=21974
+
+typedef __builtin_va_list va_list;
+


### PR DESCRIPTION
This is a partial fix for https://issues.dlang.org/show_bug.cgi?id=21974

Good enough to `#include <stdio.h>` but not good enough to actually implement `printf()`.

The implementation is problematic because it is very compiler specific and (for gcc) hidden behind builtin intrinsics.