### PR TITLE
Fix Issue 22292 - REG[2.084.1] Recursive class literal segfaults compiler

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2830,8 +2830,7 @@ public:
             auto se = ctfeEmplaceExp!StructLiteralExp(e.loc, cast(StructDeclaration)cd, elems, e.newtype);
             se.origin = se;
             se.ownedByCtfe = OwnedBy.ctfe;
-            emplaceExp!(ClassReferenceExp)(pue, e.loc, se, e.type);
-            Expression eref = pue.exp();
+            Expression eref = ctfeEmplaceExp!ClassReferenceExp(e.loc, se, e.type);
             if (e.member)
             {
                 // Call constructor

--- a/test/compilable/test22292.d
+++ b/test/compilable/test22292.d
@@ -1,0 +1,91 @@
+// https://issues.dlang.org/show_bug.cgi?id=22292
+
+// Original case
+
+class C1
+{
+    C1 c1;
+    this () pure
+    {
+        c1 = this;
+    }
+}
+immutable x = cast(immutable)r;
+
+auto r()
+{
+    C1 c1 = new C1;
+    return c1;
+}
+
+// Reference stored in another class
+
+template Test2()
+{
+    class C1
+    {
+        C2 c2;
+        this () pure
+        {
+            C1 a = this;
+            c2 = new C2(a);
+        }
+    }
+    class C2
+    {
+        C1 c1;
+        this (C1 c) pure
+        {
+            c1 = c;
+        }
+    }
+    immutable x = cast(immutable)r;
+
+    auto r()
+    {
+        C1 c1 = new C1();
+        return c1;
+    }
+}
+
+alias test2 = Test2!();
+
+// Ditto but using a struct in the middle
+
+template Test3()
+{
+    class C0
+    {
+        S1 s1;
+
+        this()
+        {
+            s1 = S1(this);
+        }
+    }
+    struct S1
+    {
+        C1 c1;
+        this (C0 c)
+        {
+            c1 = new C1(c);
+        }
+    }
+    class C1
+    {
+        C0 c0;
+        this(C0 c)
+        {
+            c0 = c;
+        }
+    }
+    immutable x = cast(immutable)r;
+
+    auto r()
+    {
+        C0 c0 = new C0();
+        return c0;
+    }
+}
+
+alias test3 = Test3!();


### PR DESCRIPTION
We can't use the stack to hold this reference because it could be saved everywhere.

Regression caused by #9183 (Walter did a lot of heap to stack optimizations alongside that commit).