### PR TITLE
ImportC: implement #pragma pack

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -21,6 +21,7 @@ import dmd.aliasthis;
 import dmd.apply;
 import dmd.arraytypes;
 import dmd.astenums;
+import dmd.attrib;
 import dmd.declaration;
 import dmd.dscope;
 import dmd.dstruct;

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1112,13 +1112,25 @@ struct ASTBase
 
     extern (C++) final class AlignDeclaration : AttribDeclaration
     {
-        Expression ealign;
+        Expressions* exps;
+        structalign_t salign;
 
-        extern (D) this(const ref Loc loc, Expression ealign, Dsymbols* decl)
+        extern (D) this(const ref Loc loc, Expression exp, Dsymbols* decl)
         {
             super(decl);
             this.loc = loc;
-            this.ealign = ealign;
+            if (exp)
+            {
+                exps = new Expressions();
+                exps.push(exp);
+            }
+        }
+
+        extern (D) this(const ref Loc loc, Expressions* exps, Dsymbols* decl)
+        {
+            super(decl);
+            this.loc = loc;
+            this.exps = exps;
         }
 
         override void accept(Visitor v)

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -709,8 +709,7 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
         super(loc, null, decl);
         if (exp)
         {
-            if (!exps)
-                exps = new Expressions();
+            exps = new Expressions();
             exps.push(exp);
         }
     }
@@ -719,6 +718,12 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
     {
         super(loc, null, decl);
         this.exps = exps;
+    }
+
+    extern (D) this(const ref Loc loc, structalign_t salign, Dsymbols* decl)
+    {
+        super(loc, null, decl);
+        this.salign = salign;
     }
 
     override AlignDeclaration syntaxCopy(Dsymbol s)

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -20,6 +20,7 @@ import dmd.aggregate;
 import dmd.apply;
 import dmd.arraytypes;
 import dmd.astenums;
+import dmd.attrib;
 import dmd.gluelayer;
 import dmd.declaration;
 import dmd.dscope;

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -16,6 +16,7 @@ import core.stdc.stdio;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astenums;
+import dmd.attrib;
 import dmd.ctorflow;
 import dmd.dclass;
 import dmd.delegatize;

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -730,10 +730,15 @@ struct Scope
         }
     }
 
+    /******************************
+     */
     structalign_t alignment()
     {
         if (aligndecl)
-            return aligndecl.getAlignment(&this);
+        {
+            auto ad = aligndecl.getAlignment(&this);
+            return ad.salign;
+        }
         else
             return STRUCTALIGN_DEFAULT;
     }

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -16,6 +16,7 @@ module dmd.dstruct;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astenums;
+import dmd.attrib;
 import dmd.declaration;
 import dmd.dmodule;
 import dmd.dscope;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -109,17 +109,18 @@ extern(C++) void dsymbolSemantic(Dsymbol dsym, Scope* sc)
  *      ad = AlignmentDeclaration
  *      sc = context
  * Returns:
- *      alignment as numerical value that is never 0.
- *      STRUCTALIGN_DEFAULT is used instead.
- *      STRUCTALIGN_DEFAULT is returned for errors
+ *      ad with alignment value determined
  */
-structalign_t getAlignment(AlignDeclaration ad, Scope* sc)
+AlignDeclaration getAlignment(AlignDeclaration ad, Scope* sc)
 {
     if (ad.salign != ad.UNKNOWN)   // UNKNOWN is 0
-        return ad.salign;
+        return ad;
 
     if (!ad.exps)
-        return ad.salign = STRUCTALIGN_DEFAULT;
+    {
+        ad.salign = STRUCTALIGN_DEFAULT;
+        return ad;
+    }
 
     dinteger_t strictest = 0;   // strictest alignment
     bool errors;
@@ -153,7 +154,7 @@ structalign_t getAlignment(AlignDeclaration ad, Scope* sc)
     ad.salign = (errors || strictest == 0)  // C11 6.7.5-6 says alignment of 0 means no effect
                 ? STRUCTALIGN_DEFAULT
                 : cast(structalign_t) strictest;
-    return ad.salign;
+    return ad;
 }
 
 const(char)* getMessage(DeprecatedDeclaration dd)

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -17,6 +17,7 @@ import core.stdc.ctype;
 
 import dmd.astcodegen;
 import dmd.arraytypes;
+import dmd.attrib;
 import dmd.dsymbol;
 import dmd.errors;
 import dmd.globals;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -12380,7 +12380,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
         // For `x.alignof` get the alignment of the variable, not the alignment of its type
         const explicitAlignment = exp.e1.isVarExp().var.isVarDeclaration().alignment;
         const naturalAlignment = exp.e1.type.alignsize();
-        const actualAlignment = (explicitAlignment == STRUCTALIGN_DEFAULT ? naturalAlignment : explicitAlignment);
+        const actualAlignment = explicitAlignment == STRUCTALIGN_DEFAULT ? naturalAlignment : explicitAlignment;
         e = new IntegerExp(exp.loc, actualAlignment, Type.tsize_t);
         return e;
     }

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8280,6 +8280,10 @@ struct Id final
     static Identifier* vector_size;
     static Identifier* noreturn;
     static Identifier* builtin_va_list;
+    static Identifier* pack;
+    static Identifier* show;
+    static Identifier* push;
+    static Identifier* pop;
     static void initialize();
     Id()
     {

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -502,6 +502,10 @@ immutable Msgtable[] msgtable =
     { "noreturn" },
     { "__pragma", "pragma" },
     { "builtin_va_list", "__builtin_va_list" },
+    { "pack" },
+    { "show" },
+    { "push" },
+    { "pop" },
 ];
 
 

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -26,6 +26,7 @@ import dmd.errors;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
+import dmd.root.array;
 import dmd.root.ctfloat;
 import dmd.root.outbuffer;
 import dmd.root.port;
@@ -229,6 +230,8 @@ class Lexer
     ubyte long_doublesize;      /// size of C long double, 8 or D real.sizeof
     ubyte wchar_tsize;          /// size of C wchar_t, 2 or 4
 
+    structalign_t packalign;    /// current state of #pragma pack alignment (ImportC)
+
     private
     {
         const(char)* base;      // pointer to start of buffer
@@ -242,6 +245,10 @@ class Lexer
         int lastDocLine;        // last line of previous doc comment
 
         Token* tokenFreelist;
+
+        // ImportC #pragma pack stack
+        Array!Identifier* records;      // identifers (or null)
+        Array!structalign_t* packs;     // parallel alignment values
     }
 
   nothrow:
@@ -273,6 +280,7 @@ class Lexer
         this.commentToken = commentToken;
         this.inTokenStringConstant = 0;
         this.lastDocLine = 0;
+        this.packalign = STRUCTALIGN_DEFAULT;
         //initKeywords();
         /* If first line starts with '#!', ignore the line
          */
@@ -1148,7 +1156,7 @@ class Lexer
                         }
                         else if (n.ident == Id.__pragma && Ccompile)
                         {
-                            pragmaDirective();
+                            pragmaDirective(scanloc);
                             continue;
                         }
                         else
@@ -2923,7 +2931,172 @@ class Lexer
      * the preprocessed output. Ignore them.
      * Upon return, p is at start of next line.
      */
-    private void pragmaDirective()
+    private void pragmaDirective(const ref Loc loc)
+    {
+        Token n;
+        scan(&n);
+        if (n.value == TOK.identifier && n.ident == Id.pack)
+            return pragmaPack(loc);
+        skipToNextLine();
+    }
+
+    /*********
+     * ImportC
+     * # pragma pack
+     * https://gcc.gnu.org/onlinedocs/gcc-4.4.4/gcc/Structure_002dPacking-Pragmas.html
+     * https://docs.microsoft.com/en-us/cpp/preprocessor/pack
+     * Scanner is on the `pack`
+     * Params:
+     *  startloc = location to use for error messages
+     */
+    private void pragmaPack(const ref Loc startloc)
+    {
+        const loc = startloc;
+        Token n;
+        scan(&n);
+        if (n.value != TOK.leftParenthesis)
+        {
+            error(loc, "left parenthesis expected to follow `#pragma pack`");
+            skipToNextLine();
+            return;
+        }
+
+        void closingParen()
+        {
+            if (n.value != TOK.rightParenthesis)
+            {
+                error(loc, "right parenthesis expected to close `#pragma pack(`");
+            }
+            skipToNextLine();
+        }
+
+        void setPackAlign(ref const Token t)
+        {
+            const n = t.unsvalue;
+            if (n < 1 || n & (n - 1) || structalign_t.max < n)
+                error(loc, "pack must be an integer positive power of 2, not 0x%llx", cast(ulong)n);
+            packalign = cast(structalign_t)n;
+        }
+
+        scan(&n);
+
+        if (!records)
+        {
+            records = new Array!Identifier;
+            packs = new Array!structalign_t;
+        }
+
+        /* # pragma pack ( show )
+         */
+        if (n.value == TOK.identifier && n.ident == Id.show)
+        {
+            warning(startloc, "current pack attribute is %d", cast(uint)packalign);
+            scan(&n);
+            return closingParen();
+        }
+        /* # pragma pack ( push )
+         * # pragma pack ( push , identifier )
+         * # pragma pack ( push , integer )
+         * # pragma pack ( push , identifier , integer )
+         */
+        if (n.value == TOK.identifier && n.ident == Id.push)
+        {
+            scan(&n);
+            Identifier record = null;
+            if (n.value == TOK.comma)
+            {
+                scan(&n);
+                if (n.value == TOK.identifier)
+                {
+                    record = n.ident;
+                    scan(&n);
+                    if (n.value == TOK.comma)
+                    {
+                        scan(&n);
+                        if (n.value == TOK.int32Literal)
+                        {
+                            setPackAlign(n);
+                            scan(&n);
+                        }
+                        else
+                            error(loc, "alignment value expected, not `%s`", n.toChars());
+                    }
+                }
+                else if (n.value == TOK.int32Literal)
+                {
+                    setPackAlign(n);
+                    scan(&n);
+                }
+                else
+                    error(loc, "alignment value expected, not `%s`", n.toChars());
+            }
+            this.records.push(record);
+            this.packs.push(packalign);
+            return closingParen();
+        }
+        /* # pragma pack ( pop )
+         * # pragma pack ( pop PopList )
+         * PopList :
+         *    , IdentifierOrInteger
+         *    , IdentifierOrInteger PopList
+         * IdentifierOrInteger:
+         *      identifier
+         *      integer
+         */
+        if (n.value == TOK.identifier && n.ident == Id.pop)
+        {
+            scan(&n);
+            while (n.value == TOK.comma)
+            {
+                scan(&n);
+                if (n.value == TOK.identifier)
+                {
+                    for (size_t len = this.records.length; len; --len)
+                    {
+                        if ((*this.records)[len - 1] == n.ident)
+                        {
+                            packalign = (*this.packs)[len - 1];
+                            this.records.setDim(len - 1);
+                            this.packs.setDim(len - 1);
+                            break;
+                        }
+                    }
+                    scan(&n);
+                }
+                else if (n.value == TOK.int32Literal)
+                {
+                    setPackAlign(n);
+                    this.records.push(null);
+                    this.packs.push(packalign);
+                    scan(&n);
+                }
+            }
+            return closingParen();
+        }
+        /* # pragma pack ( integer )
+         */
+        if (n.value == TOK.int32Literal)
+        {
+            setPackAlign(n);
+            scan(&n);
+            return closingParen();
+        }
+        /* # pragma pack ( )
+         */
+        if (n.value == TOK.rightParenthesis)
+        {
+            packalign = STRUCTALIGN_DEFAULT;
+            return closingParen();
+        }
+
+        error(loc, "unrecognized `#pragma pack(%s)`", n.toChars());
+        skipToNextLine();
+    }
+
+    /***************************************
+     * Scan forward to start of next line.
+     */
+    private void skipToNextLine()
     {
         while (1)
         {

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -34,6 +34,7 @@ import dmd.backend.type;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astenums;
+import dmd.attrib;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dmangle;

--- a/test/compilable/pragma.c
+++ b/test/compilable/pragma.c
@@ -1,0 +1,35 @@
+// Test #pragma pack
+
+#pragma pack(2)
+struct S
+{
+    int i;
+    short j;
+    double k;
+};
+#pragma pack()
+
+_Static_assert(sizeof(struct S) == 4 + 2 + 8, "1");
+
+#pragma pack(push, 8)
+struct S2
+{
+    char a, b;
+};
+#pragma pack(pop)
+
+_Static_assert(sizeof(struct S2) == 8 + 8, "2");
+
+#pragma pack()
+#pragma pack(show)
+#pragma pack(2)
+#pragma pack(push)
+#pragma pack(push,2)
+#pragma pack(push,abc)
+#pragma pack(push,abc,2)
+#pragma pack(pop)
+#pragma pack(pop,a)
+#pragma pack(pop,2)
+#pragma pack(pop,a,b,4,8,c)
+
+int x;

--- a/test/fail_compilation/pragma2.c
+++ b/test/fail_compilation/pragma2.c
@@ -1,0 +1,17 @@
+/* REQUIRED_ARGS: -w
+TEST_OUTPUT:
+---
+fail_compilation/pragma2.c(11): Warning: current pack attribute is -1
+fail_compilation/pragma2.c(14): Error: unrecognized `#pragma pack(&)`
+fail_compilation/pragma2.c(13): Error: right parenthesis expected to close `#pragma pack(`
+fail_compilation/pragma2.c(12): Error: left parenthesis expected to follow `#pragma pack`
+---
+*/
+
+#pragma pack(show)
+#pragma pack
+#pragma pack(pop,a,b,4,8,c
+#pragma pack(&)
+#pragma pack() ;a
+
+int x;


### PR DESCRIPTION
It took a fair amount of code to parse all the variations of this.

The #pragma system in C is an awful hack, it's really hard to define what the interactions are. As far as I can tell, nobody has even tried. They just hack it in, and whatever happens happens.

This is, of course, why C11 ditched it for `_Alignas`, doing what D did 10 years earlier.

I suppose I shouldn't complain too much, after all, the whole point of D is to fix this stuff!