### PR TITLE
Translate _d_array{,set}ctor to templates

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -4813,6 +4813,40 @@ public:
                 result = interpretRegion(ae, istate);
                 return;
             }
+            else if (fd.ident == Id._d_arrayctor)
+            {
+                assert(e.arguments.dim == 2);
+
+                Expression ea = (*e.arguments)[0];
+                assert(ea.isCastExp);
+                ea = ea.isCastExp.e1;
+                Expression eb = (*e.arguments)[1];
+                assert(eb.isCastExp);
+                eb = eb.isCastExp.e1;
+
+                // Rewrite ea = eb
+                ConstructExp ce = new ConstructExp(e.loc, ea, eb);
+                ce.type = ea.type;
+
+                result = interpret(ce, istate);
+                return;
+            }
+            else if (fd.ident == Id._d_arraysetctor)
+            {
+                assert(e.arguments.dim == 2);
+
+                Expression ea = (*e.arguments)[0];
+                assert(ea.isCastExp);
+                ea = ea.isCastExp.e1;
+                Expression eb = (*e.arguments)[1];
+
+                // Rewrite ea = eb
+                ConstructExp ce = new ConstructExp(e.loc, ea, eb);
+                ce.type = ea.type;
+
+                result = interpret(ce, istate);
+                return;
+            }
         }
         else if (auto soe = ecall.isSymOffExp())
         {

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2840,8 +2840,7 @@ public:
             auto se = ctfeEmplaceExp!StructLiteralExp(e.loc, cast(StructDeclaration)cd, elems, e.newtype);
             se.origin = se;
             se.ownedByCtfe = OwnedBy.ctfe;
-            emplaceExp!(ClassReferenceExp)(pue, e.loc, se, e.type);
-            Expression eref = pue.exp();
+            Expression eref = ctfeEmplaceExp!ClassReferenceExp(e.loc, se, e.type);
             if (e.member)
             {
                 // Call constructor

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -4815,7 +4815,12 @@ public:
             }
             else if (fd.ident == Id._d_arrayctor || fd.ident == Id._d_arraysetctor)
             {
-                assert(e.arguments.dim == 2);
+                // In expressionsem.d `T[x] ea = eb;` was lowered to `_d_array{,set}ctor(ea[], eb[]);`.
+                // The following code will rewrite it back to `ea = eb` and then interpret that expression.
+                if (fd.ident == Id._d_arraysetctor)
+                    assert(e.arguments.dim == 2);
+                else
+                    assert(e.arguments.dim == 3);
 
                 Expression ea = (*e.arguments)[0];
                 if (ea.isCastExp)
@@ -4825,7 +4830,6 @@ public:
                 if (eb.isCastExp && fd.ident == Id._d_arrayctor)
                     eb = eb.isCastExp.e1;
 
-                // Rewrite ea = eb
                 ConstructExp ce = new ConstructExp(e.loc, ea, eb);
                 ce.type = ea.type;
 

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2311,7 +2311,7 @@ extern (C++) class ToElemVisitor : Visitor
                         efrom = addressElem(efrom, Type.tvoid.arrayOf());
                     }
                     elem *ep = el_params(eto, efrom, eti, null);
-                    int rtl = RTLSYM_ARRAYASSIGN;
+                    auto rtl = RTLSYM.ARRAYASSIGN;
                     elem* e = el_bin(OPcall, totym(ae.type), el_var(getRtlsym(rtl)), ep);
                     return setResult(e);
                 }
@@ -5959,7 +5959,7 @@ Lagain:
                      *   void *_d_arraysetassign(void *p, void *value, int dim, TypeInfo ti);
                      */
                     assert(op != EXP.construct, "Trying reference _d_arraysetctor, this should not happen!");
-                    r = RTLSYM_ARRAYSETASSIGN;
+                    r = RTLSYM.ARRAYSETASSIGN;
                     evalue = el_una(OPaddr, TYnptr, evalue);
                     // This is a hack so we can call postblits on const/immutable objects.
                     elem *eti = getTypeInfo(exp.loc, tb.unSharedOf().mutableOf(), irs);

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2296,12 +2296,12 @@ extern (C++) class ToElemVisitor : Visitor
                     e = el_combine(el_combine(eto, efrom), el_combine(echeck, e));
                     return setResult(e);
                 }
-                else if ((postblit || destructor) && ae.op != EXP.blit)
+                else if ((postblit || destructor) &&
+                    ae.op != EXP.blit &&
+                    ae.op != EXP.construct)
                 {
                     /* Generate:
-                     *      _d_arrayassign(ti, efrom, eto)
-                     * or:
-                     *      _d_arrayctor(ti, efrom, eto)
+                     *     _d_arrayassign(ti, efrom, eto)
                      */
                     el_free(esize);
                     elem *eti = getTypeInfo(ae.e1.loc, t1.nextOf().toBasetype(), irs);
@@ -2311,7 +2311,7 @@ extern (C++) class ToElemVisitor : Visitor
                         efrom = addressElem(efrom, Type.tvoid.arrayOf());
                     }
                     elem *ep = el_params(eto, efrom, eti, null);
-                    const rtl = (ae.op == EXP.construct) ? RTLSYM.ARRAYCTOR : RTLSYM.ARRAYASSIGN;
+                    int rtl = RTLSYM_ARRAYASSIGN;
                     elem* e = el_bin(OPcall, totym(ae.type), el_var(getRtlsym(rtl)), ep);
                     return setResult(e);
                 }
@@ -2619,21 +2619,7 @@ extern (C++) class ToElemVisitor : Visitor
             }
             else if (ae.op == EXP.construct)
             {
-                e1 = sarray_toDarray(ae.e1.loc, ae.e1.type, null, e1);
-                e2 = sarray_toDarray(ae.e2.loc, ae.e2.type, null, e2);
-
-                /* Generate:
-                 *      _d_arrayctor(ti, e2, e1)
-                 */
-                elem *eti = getTypeInfo(ae.e1.loc, t1b.nextOf().toBasetype(), irs);
-                if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
-                {
-                    e1 = addressElem(e1, Type.tvoid.arrayOf());
-                    e2 = addressElem(e2, Type.tvoid.arrayOf());
-                }
-                elem *ep = el_params(e1, e2, eti, null);
-                elem* e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM.ARRAYCTOR)), ep);
-                return setResult2(e);
+                assert(0, "Trying reference _d_arrayctor, this should not happen!");
             }
             else
             {
@@ -5972,7 +5958,8 @@ Lagain:
                     /* Need to do postblit/destructor.
                      *   void *_d_arraysetassign(void *p, void *value, int dim, TypeInfo ti);
                      */
-                    r = (op == EXP.construct) ? RTLSYM.ARRAYSETCTOR : RTLSYM.ARRAYSETASSIGN;
+                    assert(op != EXP.construct, "Trying reference _d_arraysetctor, this should not happen!");
+                    r = RTLSYM_ARRAYSETASSIGN;
                     evalue = el_una(OPaddr, TYnptr, evalue);
                     // This is a hack so we can call postblits on const/immutable objects.
                     elem *eti = getTypeInfo(exp.loc, tb.unSharedOf().mutableOf(), irs);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -12494,11 +12494,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
         // For `x.alignof` get the alignment of the variable, not the alignment of its type
         const explicitAlignment = exp.e1.isVarExp().var.isVarDeclaration().alignment;
         const naturalAlignment = exp.e1.type.alignsize();
-<<<<<<< HEAD
         const actualAlignment = explicitAlignment.isDefault() ? naturalAlignment : explicitAlignment.get();
-=======
-        const actualAlignment = explicitAlignment == STRUCTALIGN_DEFAULT ? naturalAlignment : explicitAlignment;
->>>>>>> 739679fe7... Fix failing test errors
         Expression e = new IntegerExp(exp.loc, actualAlignment, Type.tsize_t);
         return e;
     }

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8170,6 +8170,8 @@ struct Id final
     static Identifier* dup;
     static Identifier* _aaApply;
     static Identifier* _aaApply2;
+    static Identifier* _d_arrayctor;
+    static Identifier* _d_arraysetctor;
     static Identifier* Pinline;
     static Identifier* lib;
     static Identifier* linkerDirective;
@@ -8190,8 +8192,6 @@ struct Id final
     static Identifier* _d_arraysetlengthTImpl;
     static Identifier* _d_arraysetlengthT;
     static Identifier* _d_arraysetlengthTTrace;
-    static Identifier* _d_arrayctor;
-    static Identifier* _d_arraysetctor;
     static Identifier* stdc;
     static Identifier* stdarg;
     static Identifier* va_start;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8190,6 +8190,8 @@ struct Id final
     static Identifier* _d_arraysetlengthTImpl;
     static Identifier* _d_arraysetlengthT;
     static Identifier* _d_arraysetlengthTTrace;
+    static Identifier* _d_arrayctor;
+    static Identifier* _d_arraysetctor;
     static Identifier* stdc;
     static Identifier* stdarg;
     static Identifier* va_start;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -315,6 +315,8 @@ immutable Msgtable[] msgtable =
     { "dup" },
     { "_aaApply" },
     { "_aaApply2" },
+    { "_d_arrayctor" },
+    { "_d_arraysetctor" },
 
     // For pragma's
     { "Pinline", "inline" },

--- a/test/fail_compilation/fail10964.d
+++ b/test/fail_compilation/fail10964.d
@@ -5,8 +5,8 @@ fail_compilation/fail10964.d(28): Error: function `fail10964.S.__postblit` is no
 fail_compilation/fail10964.d(29): Error: function `fail10964.S.__postblit` is not `nothrow`
 fail_compilation/fail10964.d(30): Error: function `fail10964.S.__postblit` is not `nothrow`
 fail_compilation/fail10964.d(33): Error: function `fail10964.S.__postblit` is not `nothrow`
-fail_compilation/fail10964.d(34): Error: function `fail10964.S.__postblit` is not `nothrow`
-fail_compilation/fail10964.d(35): Error: function `fail10964.S.__postblit` is not `nothrow`
+fail_compilation/fail10964.d(34): Error: function `core.internal.array.construction._d_arraysetctor!(S[], S)._d_arraysetctor` is not `nothrow`
+fail_compilation/fail10964.d(35): Error: function `core.internal.array.construction._d_arrayctor!(S[], S)._d_arrayctor` is not `nothrow`
 fail_compilation/fail10964.d(22): Error: `nothrow` function `fail10964.foo` may throw
 ---
 */

--- a/test/fail_compilation/fail10968.d
+++ b/test/fail_compilation/fail10968.d
@@ -1,24 +1,26 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10968.d(39): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(39): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
-fail_compilation/fail10968.d(40): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(40): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
 fail_compilation/fail10968.d(41): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(41): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
-fail_compilation/fail10968.d(44): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(44): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
-fail_compilation/fail10968.d(45): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(45): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(29):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(42): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(42): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(29):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(43): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(43): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(29):        `fail10968.SA.__postblit` is declared here
 fail_compilation/fail10968.d(46): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(46): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(29):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(47): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(47): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(29):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(47): Error: `pure` function `fail10968.bar` cannot call impure function `core.internal.array.construction._d_arraysetctor!(SA[], SA)._d_arraysetctor`
+fail_compilation/fail10968.d(48): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(48): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(29):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(48): Error: `pure` function `fail10968.bar` cannot call impure function `core.internal.array.construction._d_arrayctor!(SA[], SA)._d_arrayctor`
 ---
 */
 
@@ -49,12 +51,12 @@ void bar() pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10968.d(72): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
-fail_compilation/fail10968.d(73): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
 fail_compilation/fail10968.d(74): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
-fail_compilation/fail10968.d(77): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
-fail_compilation/fail10968.d(78): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
+fail_compilation/fail10968.d(75): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
+fail_compilation/fail10968.d(76): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
 fail_compilation/fail10968.d(79): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
+fail_compilation/fail10968.d(80): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
+fail_compilation/fail10968.d(81): Error: struct `fail10968.SD` is not copyable because it has a disabled postblit
 ---
 */
 


### PR DESCRIPTION
This PR is part of replacing runtime hooks in DMD with templates, as described in [this project](https://github.com/dlang/projects/issues/25).
I also provided a short description of this project in [this forum post](https://forum.dlang.org/post/bbhmgddyabnuxajlxgqp@forum.dlang.org).

This PR concludes Dan Printzell's previous work:
- https://github.com/dlang/dmd/pull/10102
- https://github.com/dlang/druntime/pull/2655 