### PR TITLE
Fix Issue 13009 - [REG2.064] inout overload conflicts with non-inout when used via alias this

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4664,15 +4664,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             UnaExp ue = cast(UnaExp)exp.e1;
 
-            Expression ue1 = ue.e1;
-            Expression ue1old = ue1; // need for 'right this' check
-            VarDeclaration v;
-            if (ue1.op == TOK.variable && (v = (cast(VarExp)ue1).var.isVarDeclaration()) !is null && v.needThis())
-            {
-                ue.e1 = new TypeExp(ue1.loc, ue1.type);
-                ue1 = null;
-            }
-
+            Expression ue1old = ue.e1; // need for 'right this' check
             DotVarExp dve;
             DotTemplateExp dte;
             Dsymbol s;
@@ -4691,7 +4683,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
 
             // Do overload resolution
-            exp.f = resolveFuncCall(exp.loc, sc, s, tiargs, ue1 ? ue1.type : null, exp.arguments, FuncResolveFlag.standard);
+            exp.f = resolveFuncCall(exp.loc, sc, s, tiargs, ue.e1.type, exp.arguments, FuncResolveFlag.standard);
             if (!exp.f || exp.f.errors || exp.f.type.ty == Terror)
                 return setError();
 
@@ -4703,7 +4695,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 auto ad2 = b.sym;
                 ue.e1 = ue.e1.castTo(sc, ad2.type.addMod(ue.e1.type.mod));
                 ue.e1 = ue.e1.expressionSemantic(sc);
-                ue1 = ue.e1;
                 auto vi = exp.f.findVtblIndex(&ad2.vtbl, cast(int)ad2.vtbl.dim);
                 assert(vi >= 0);
                 exp.f = ad2.vtbl[vi].isFuncDeclaration();

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -2102,6 +2102,42 @@ void test16633()
     root.populate;
 }
 
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=13009
+
+struct RefCounted13009_2(T)
+{
+    ref T refCountedPayload()
+    {
+        assert(false);
+    }
+
+    ref inout(T) refCountedPayload() inout
+    {
+        assert(false);
+    }
+
+    alias refCountedPayload this;
+}
+
+struct S13009_2
+{
+    struct Payload
+    {
+        int[] data;
+    }
+
+    RefCounted13009_2!Payload payload;
+    alias X = typeof(payload.data[0]);
+
+    void foo()
+    {
+        payload.data[0] = 0;
+    }
+}
+
+/***************************************************/
+
 int main()
 {
     test1();


### PR DESCRIPTION
This reverts #971 (not the test case, of course), it was a hack to force a compile-time evaluation at the cost of not passing the
`tthis` (type of `this`) argument to `resolveFuncCall()`, without that information it couldn't determine the function with the right qualifier.