### PR TITLE
Fix Issue 22329 - DMD and LDC2 Segumentation Faults due to alias this

### DIFF
--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -78,20 +78,26 @@ extern (C++) final class AliasThis : Dsymbol
  *      sc = context
  *      e = expression forming the `this`
  *      gag = if true do not print errors, return null instead
+ *      findOnly = don't do further processing like resolving properties,
+ *                 i.e. just return plain dotExp() result.
  * Returns:
  *      Expression that is `e.aliasthis`
  */
-Expression resolveAliasThis(Scope* sc, Expression e, bool gag = false)
+Expression resolveAliasThis(Scope* sc, Expression e, bool gag = false, bool findOnly = false)
 {
+    import dmd.typesem : dotExp;
     for (AggregateDeclaration ad = isAggregate(e.type); ad;)
     {
         if (ad.aliasthis)
         {
-            uint olderrors = gag ? global.startGagging() : 0;
             Loc loc = e.loc;
             Type tthis = (e.op == TOK.type ? e.type : null);
-            e = new DotIdExp(loc, e, ad.aliasthis.ident);
-            e = e.expressionSemantic(sc);
+            const flags = DotExpFlag.noAliasThis | (gag ? DotExpFlag.gag : 0);
+            e = dotExp(e.type, sc, e, ad.aliasthis.ident, flags);
+            if (!e || findOnly)
+                return e;
+
+            uint olderrors = gag ? global.startGagging() : 0;
             if (tthis && ad.aliasthis.sym.needThis())
             {
                 if (e.op == TOK.variable)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3149,6 +3149,7 @@ enum class DotExpFlag
 {
     gag = 1,
     noDeref = 2,
+    noAliasThis = 4,
 };
 
 enum : int32_t { LOGDEFAULTINIT = 0 };

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -237,6 +237,7 @@ enum DotExpFlag
 {
     gag     = 1,    // don't report "not a property" error and just return null
     noDeref = 2,    // the use of the expression will not attempt a dereference
+    noAliasThis = 4, // don't do 'alias this' resolution
 }
 
 /***********************************************************

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -213,9 +213,13 @@ private Expression checkAliasThisForLhs(AggregateDeclaration ad, Scope* sc, BinE
     if (isRecursiveAliasThis(e.att1, e.e1.type))
         return null;
     //printf("att %s e1 = %s\n", Token::toChars(e.op), e.e1.type.toChars());
-    Expression e1 = new DotIdExp(e.loc, e.e1, ad.aliasthis.ident);
     BinExp be = cast(BinExp)e.copy();
-    be.e1 = e1;
+    // Resolve 'alias this' but in case of assigment don't resolve properties yet
+    // because 'e1 = e2' could mean 'e1(e2)' or 'e1() = e2'
+    bool findOnly = (e.op == TOK.assign);
+    be.e1 = resolveAliasThis(sc, e.e1, true, findOnly);
+    if (!be.e1)
+        return null;
 
     Expression result;
     if (be.op == TOK.concatenateAssign)
@@ -237,9 +241,10 @@ private Expression checkAliasThisForRhs(AggregateDeclaration ad, Scope* sc, BinE
     if (isRecursiveAliasThis(e.att2, e.e2.type))
         return null;
     //printf("att %s e2 = %s\n", Token::toChars(e.op), e.e2.type.toChars());
-    Expression e2 = new DotIdExp(e.loc, e.e2, ad.aliasthis.ident);
     BinExp be = cast(BinExp)e.copy();
-    be.e2 = e2;
+    be.e2 = resolveAliasThis(sc, e.e2, true);
+    if (!be.e2)
+        return null;
 
     Expression result;
     if (be.op == TOK.concatenateAssign)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3755,7 +3755,8 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
      *  sc = context
      *  e = `this` for `ident`
      *  ident = name of member
-     *  flag = if flag & 1, don't report "not a property" error and just return NULL.
+     *  flag = flag & 1, don't report "not a property" error and just return NULL.
+     *         flag & DotExpFlag.noAliasThis, don't do 'alias this' resolution.
      * Returns:
      *  resolved expression if found, otherwise null
      */
@@ -3848,7 +3849,8 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
 
             /* See if we should forward to the alias this.
              */
-            auto alias_e = resolveAliasThis(sc, e, gagError);
+            auto alias_e = flag & DotExpFlag.noAliasThis ? null
+                                                         : resolveAliasThis(sc, e, gagError);
             if (alias_e && alias_e != e)
             {
                 /* Rewrite e.ident as:

--- a/test/fail_compilation/imports/imp22329.d
+++ b/test/fail_compilation/imports/imp22329.d
@@ -1,0 +1,4 @@
+void func(T)(T arg)
+{
+    auto a = arg + 1;
+}

--- a/test/fail_compilation/test22329.d
+++ b/test/fail_compilation/test22329.d
@@ -1,0 +1,21 @@
+// https://issues.dlang.org/show_bug.cgi?id=22329
+// EXTRA_FILES: imports/imp22329.d
+/*
+TEST_OUTPUT:
+---
+fail_compilation/imports/imp22329.d(3): Error: no property `values` for type `test22329.Foo`
+fail_compilation/imports/imp22329.d(3): Error: incompatible types for `(arg) + (1)`: `Foo` and `int`
+fail_compilation/test22329.d(20): Error: template instance `imp22329.func!(Foo)` error instantiating
+---
+*/
+
+public struct Foo {
+    private int values;
+    alias values this;
+}
+
+void main()
+{
+    import imports.imp22329 : func;
+    func(Foo());
+}


### PR DESCRIPTION
… on private field + special names

Some adjustments to `resolveAliasThis()` and `dotExp()` to avoid infinite `alias this` resolving.