### PR TITLE
dwarfdbginf: DWARF array tags should not be ambiguous

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -2418,19 +2418,12 @@ static if (1)
                     code = dwarf_abbrev_code(abbrevTypeStruct.ptr, (abbrevTypeStruct).sizeof);
                     idx = cast(uint)debug_info.buf.length();
                     debug_info.buf.writeuLEB128(code);        // abbreviation code
-                    debug_info.buf.write("_Array_".ptr, 7);       // DW_AT_name
-                    // Handles multi-dimensional array
-                    auto lastdim = t.Tnext;
-                    while (lastdim.Tty == TYucent && lastdim.Tnext)
-                    {
-                        debug_info.buf.write("Array_".ptr, 6);
-                        lastdim = lastdim.Tnext;
-                    }
 
-                    if (tybasic(lastdim.Tty))
-                        debug_info.buf.writeString(tystring[tybasic(lastdim.Tty)]);
-                    else
-                        debug_info.buf.writeByte(0);
+                    // FIXME: provide a better way to fetch length of a pretty
+                    // name on the backend API which is dependent on the
+                    // frontend C++ exported API
+                    debug_info.buf.write(t.Tident, strlen(t.Tident));       // DW_AT_name
+                    debug_info.buf.writeByte(0);
                     debug_info.buf.writeByte(tysize(t.Tty)); // DW_AT_byte_size
 
                     // length

--- a/test/dshell/extra-files/dwarf/excepted_results/fix22352.txt
+++ b/test/dshell/extra-files/dwarf/excepted_results/fix22352.txt
@@ -1,0 +1,6 @@
+DW_AT_name        : fix22352.Foo
+DW_AT_name        : foo
+DW_AT_name        : fix22352.Foo[]
+D main
+fix22352._d_cmain!().main
+

--- a/test/dshell/extra-files/dwarf/fix22352.d
+++ b/test/dshell/extra-files/dwarf/fix22352.d
@@ -1,0 +1,8 @@
+struct Foo
+{}
+
+
+void main()
+{
+	Foo[] foo;
+}

--- a/test/runnable/gdb_slice_debuginfo_32.d
+++ b/test/runnable/gdb_slice_debuginfo_32.d
@@ -3,7 +3,7 @@ https://issues.dlang.org/show_bug.cgi?id=22311
 REQUIRED_ARGS: -g -c -m32
 GDB_SCRIPT:
 ---
-print sizeof(_Array_int::length)
+print sizeof('int[]'::length)
 ---
 GDB_MATCH: \$1 = 4
 */

--- a/test/runnable/gdb_slice_debuginfo_64.d
+++ b/test/runnable/gdb_slice_debuginfo_64.d
@@ -3,7 +3,7 @@ https://issues.dlang.org/show_bug.cgi?id=22311
 REQUIRED_ARGS: -g -c -m64
 GDB_SCRIPT:
 ---
-print sizeof(_Array_int::length)
+print sizeof('int[]'::length)
 ---
 GDB_MATCH: \$1 = 8
 */


### PR DESCRIPTION
Fixes Issue 22352.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Please read the issue report for more context.