### PR TITLE
hdrgen: remove trailing whitespace on enum declarations

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1324,11 +1324,10 @@ public:
         if (d.ident)
         {
             buf.writestring(d.ident.toString());
-            buf.writeByte(' ');
         }
         if (d.memtype)
         {
-            buf.writestring(": ");
+            buf.writestring(" : ");
             typeToBuffer(d.memtype, null, buf, hgs);
         }
         if (!d.members)

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -114,7 +114,7 @@ template Foo(T, int V)
 				break;
 			}
 		}
-		enum Label 
+		enum Label
 		{
 			A,
 			B,
@@ -520,7 +520,7 @@ struct SafeS
 	}
 }
 void test13x(@(10) int a, @(20) int, @(tuple(30), tuple(40)) int[] arr...);
-enum Test14UDA1 ;
+enum Test14UDA1;
 struct Test14UDA2
 {
 	string str;

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -132,7 +132,7 @@ template Foo(T, int V)
 				break;
 			}
 		}
-		enum Label 
+		enum Label
 		{
 			A,
 			B,
@@ -667,7 +667,7 @@ struct SafeS
 void test13x(@(10) int a, @(20) int, @(tuple(30), tuple(40)) int[] arr...)
 {
 }
-enum Test14UDA1 ;
+enum Test14UDA1;
 struct Test14UDA2
 {
 	string str;


### PR DESCRIPTION
Fixes Issue 22354.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>