### PR TITLE
cirrusci.sh: Run brew style --fix before installing gnupg

### DIFF
--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -42,7 +42,7 @@ elif [ "$OS_NAME" == "darwin" ]; then
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/pkg-config.rb
   #brew style --fix ...
   #brew update --force --quiet
-  brew install gnupg
+  brew list gnupg || brew install gnupg
 elif [ "$OS_NAME" == "freebsd" ]; then
   packages="git gmake"
   if [ "$HOST_DMD" == "dmd-2.079.0" ] ; then

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -33,6 +33,7 @@ elif [ "$OS_NAME" == "darwin" ]; then
   brew update-reset
   brew upgrade
   git -C `brew --repository` rev-parse HEAD
+  sed '90,110 p' /usr/local/Homebrew/Library/Homebrew/brew.sh
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/adns.rb
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/autoconf.rb
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/automake.rb

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -30,21 +30,11 @@ if [ "$OS_NAME" == "linux" ]; then
 elif [ "$OS_NAME" == "darwin" ]; then
   # required for dlang install.sh
   which git
+  # run brew update-reset twice, it seems to fix 
+  # https://github.com/Homebrew/brew/pull/12170#issuecomment-933976753
   brew update-reset
   brew update-reset
   brew upgrade
-  git -C `brew --repository` rev-parse HEAD
-  sed -n '90,110 p' /usr/local/Homebrew/Library/Homebrew/brew.sh
-  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/adns.rb
-  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/autoconf.rb
-  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/automake.rb
-  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gettext.rb
-  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gmp.rb
-  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gnutls.rb
-  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gnupg.rb
-  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/pkg-config.rb
-  #brew style --fix ...
-  #brew update --force --quiet
   brew list gnupg || brew install gnupg
 elif [ "$OS_NAME" == "freebsd" ]; then
   packages="git gmake"

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -31,6 +31,7 @@ elif [ "$OS_NAME" == "darwin" ]; then
   # required for dlang install.sh
   which git
   brew update-reset
+  brew update-reset
   brew upgrade
   git -C `brew --repository` rev-parse HEAD
   sed -n '90,110 p' /usr/local/Homebrew/Library/Homebrew/brew.sh

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -31,6 +31,7 @@ elif [ "$OS_NAME" == "darwin" ]; then
   # required for dlang install.sh
   which git
   brew update-reset
+  brew upgrade
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/adns.rb
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/autoconf.rb
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/automake.rb

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -29,7 +29,18 @@ if [ "$OS_NAME" == "linux" ]; then
   apt-get install -yq $packages
 elif [ "$OS_NAME" == "darwin" ]; then
   # required for dlang install.sh
+  which git
   brew update-reset
+  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/adns.rb
+  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/autoconf.rb
+  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/automake.rb
+  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gettext.rb
+  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gmp.rb
+  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gnutls.rb
+  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gnupg.rb
+  #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/pkg-config.rb
+  #brew style --fix ...
+  #brew update --force --quiet
   brew install gnupg
 elif [ "$OS_NAME" == "freebsd" ]; then
   packages="git gmake"

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -33,7 +33,7 @@ elif [ "$OS_NAME" == "darwin" ]; then
   brew update-reset
   brew upgrade
   git -C `brew --repository` rev-parse HEAD
-  sed '90,110 p' /usr/local/Homebrew/Library/Homebrew/brew.sh
+  sed -n '90,110 p' /usr/local/Homebrew/Library/Homebrew/brew.sh
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/adns.rb
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/autoconf.rb
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/automake.rb

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -29,7 +29,6 @@ if [ "$OS_NAME" == "linux" ]; then
   apt-get install -yq $packages
 elif [ "$OS_NAME" == "darwin" ]; then
   # required for dlang install.sh
-  which git
   # run brew update-reset twice, it seems to fix 
   # https://github.com/Homebrew/brew/pull/12170#issuecomment-933976753
   brew update-reset

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -32,6 +32,7 @@ elif [ "$OS_NAME" == "darwin" ]; then
   which git
   brew update-reset
   brew upgrade
+  git -C `brew --repository` rev-parse HEAD
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/adns.rb
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/autoconf.rb
   #brew style --fix /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/automake.rb


### PR DESCRIPTION
CirrusCI OSX is failing again, seeing if this resolves it.

https://cirrus-ci.com/task/5219352065605632?logs=install_prerequisites#L95