### PR TITLE
Improve testing under Windows/WSL2

### DIFF
--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -580,8 +580,8 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     findOutputParameter(file, "GDB_SCRIPT", testArgs.gdbScript, envData.sep);
     findTestParameter(envData, file, "GDB_MATCH", testArgs.gdbMatch);
 
-    if (findTestParameter(envData, file, "POST_SCRIPT", testArgs.postScript))
-        testArgs.postScript = replace(testArgs.postScript, "/", to!string(envData.sep));
+    // if (findTestParameter(envData, file, "POST_SCRIPT", testArgs.postScript))
+    //     testArgs.postScript = replace(testArgs.postScript, "/", to!string(envData.sep));
 
     return true;
 }

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -580,6 +580,7 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     findOutputParameter(file, "GDB_SCRIPT", testArgs.gdbScript, envData.sep);
     findTestParameter(envData, file, "GDB_MATCH", testArgs.gdbMatch);
 
+    // Commenting these out because WSL2 under Windows interprets backslash as an escape char.
     // if (findTestParameter(envData, file, "POST_SCRIPT", testArgs.postScript))
     //     testArgs.postScript = replace(testArgs.postScript, "/", to!string(envData.sep));
 

--- a/test/tools/postscript.sh
+++ b/test/tools/postscript.sh
@@ -3,16 +3,36 @@
 
 set -euo pipefail
 
-if [ "${RESULTS_DIR}" == "" ]; then
-    echo Note: this program is normally called through the Makefile, it
-    echo is not meant to be called directly by the user.
-    exit 1
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+if [ -z ${RESULTS_DIR+x} ]; then
+    RESULTS_DIR="$DIR/../results_dir"
+    echo >&2 Warning [$0]: RESULTS_DIR not set, this run will use RESULTS_DIR="$RESULTS_DIR"
 fi
 
 script_file="$1"
 shift
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+# Was the OS set?
+if [ -z ${OS+x} ]; then
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        OS=linux
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        OS=osx
+    elif [[ "$OSTYPE" == "cygwin" ]]; then
+        OS=windows
+    elif [[ "$OSTYPE" == "msys" ]]; then
+        OS=windows
+    elif [[ "$OSTYPE" == "win32" ]]; then
+        OS=win32
+    elif [[ "$OSTYPE" == "freebsd"* ]]; then
+        OS=freebsd
+    else
+        # Unknown, assume Windows
+        OS=windows
+    fi
+    echo >&2 Warning [$0]: OS not set, this run will use OS="$OS"
+fi
 
 # export common variables
 source "$DIR/exported_vars.sh"

--- a/test/tools/postscript.sh
+++ b/test/tools/postscript.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 if [ -z ${RESULTS_DIR+x} ]; then
-    RESULTS_DIR="$DIR/../results_dir"
+    RESULTS_DIR="$DIR/../test_results"
     echo >&2 Warning [$0]: RESULTS_DIR not set, this run will use RESULTS_DIR="$RESULTS_DIR"
 fi
 


### PR DESCRIPTION
These changes allowed me to run individual tests on Windows like this:

```
cd \path\to\dmd
rdmd test\run.d runnable\a20.d
```

Without these changes, I couldn't get that code to run;; it would complain about RESULTS_DIR and OS not being set. Also, it would get confused about the backslashes.