### PR TITLE
Revert "cirrusci.sh: Run brew style --fix before installing gnupg"

### DIFF
--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -29,12 +29,8 @@ if [ "$OS_NAME" == "linux" ]; then
   apt-get install -yq $packages
 elif [ "$OS_NAME" == "darwin" ]; then
   # required for dlang install.sh
-  # run brew update-reset twice, it seems to fix 
-  # https://github.com/Homebrew/brew/pull/12170#issuecomment-933976753
   brew update-reset
-  brew update-reset
-  brew upgrade
-  brew list gnupg || brew install gnupg
+  brew install gnupg
 elif [ "$OS_NAME" == "freebsd" ]; then
   packages="git gmake"
   if [ "$HOST_DMD" == "dmd-2.079.0" ] ; then


### PR DESCRIPTION
Reverts dlang/dmd#13124

This particular issue has been fixed upstream at https://github.com/Homebrew/brew/pull/12186