### PR TITLE
Fix Issue 22361 - Failed import gives misleading error message

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -737,7 +737,12 @@ extern (C++) final class Module : Package
             if (isPackageMod)
                 .error(loc, "importing package '%s' requires a 'package.d' file which cannot be found in '%s'", toChars(), srcfile.toChars());
             else
-                error(loc, "is in file '%s' which cannot be read", srcfile.toChars());
+            {
+                .error(loc, "unable to read module `%s`", toChars());
+                const pkgfile = FileName.combine(FileName.removeExt(srcfile.toString()), package_d);
+                .errorSupplemental(loc, "Expected '%s' or '%s' in one of the following import paths:",
+                    srcfile.toChars(), pkgfile.ptr);
+            }
         }
         if (!global.gag)
         {

--- a/test/fail_compilation/diag10327.d
+++ b/test/fail_compilation/diag10327.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10327.d(11): Error: module `test10327` is in file 'imports/test10327.d' which cannot be read
+fail_compilation/diag10327.d(12): Error: unable to read module `test10327`
+fail_compilation/diag10327.d(12):        Expected 'imports/test10327.d' or 'imports/test10327/package.d' in one of the following import paths:
 import path[0] = fail_compilation
 import path[1] = $p:druntime/import$
 import path[2] = $p:phobos$

--- a/test/fail_compilation/fail21091a.d
+++ b/test/fail_compilation/fail21091a.d
@@ -3,7 +3,8 @@
 /*
 TEST_OUTPUT:
 ----
-fail_compilation/fail21091a.d(15): Error: module `Ternary` is in file 'Ternary.d' which cannot be read
+fail_compilation/fail21091a.d(16): Error: unable to read module `Ternary`
+fail_compilation/fail21091a.d(16):        Expected 'Ternary.d' or 'Ternary/package.d' in one of the following import paths:
 import path[0] = fail_compilation
 import path[1] = $p:druntime/import$
 import path[2] = $p:phobos$

--- a/test/fail_compilation/fail21091b.d
+++ b/test/fail_compilation/fail21091b.d
@@ -3,7 +3,8 @@
 /*
 TEST_OUTPUT:
 ----
-fail_compilation/fail21091b.d(15): Error: module `Tid` is in file 'Tid.d' which cannot be read
+fail_compilation/fail21091b.d(16): Error: unable to read module `Tid`
+fail_compilation/fail21091b.d(16):        Expected 'Tid.d' or 'Tid/package.d' in one of the following import paths:
 import path[0] = fail_compilation
 import path[1] = $p:druntime/import$
 import path[2] = $p:phobos$

--- a/test/fail_compilation/ice7782.d
+++ b/test/fail_compilation/ice7782.d
@@ -2,7 +2,8 @@
 EXTRA_FILES: imports/ice7782algorithm.d imports/ice7782range.d
 TEST_OUTPUT:
 ----
-fail_compilation/ice7782.d(13): Error: module `ice7782math` is in file 'imports/ice7782range/imports/ice7782math.d' which cannot be read
+fail_compilation/ice7782.d(14): Error: unable to read module `ice7782math`
+fail_compilation/ice7782.d(14):        Expected 'imports/ice7782range/imports/ice7782math.d' or 'imports/ice7782range/imports/ice7782math/package.d' in one of the following import paths:
 import path[0] = fail_compilation
 import path[1] = $p:druntime/import$
 import path[2] = $p:phobos$

--- a/test/fail_compilation/test22361.d
+++ b/test/fail_compilation/test22361.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test22361.d(11): Error: unable to read module `this_module_does_not_exist`
+fail_compilation/test22361.d(11):        Expected 'this_module_does_not_exist.d' or 'this_module_does_not_exist/package.d' in one of the following import paths:
+import path[0] = fail_compilation
+import path[1] = $p:druntime/import$
+import path[2] = $p:phobos$
+---
+*/
+import this_module_does_not_exist;


### PR DESCRIPTION
There is room for further improvement here (different messages for "not found", "permission denied", etc.), but this at least fixes the most egregious problem.