### PR TITLE
Issue 22004 - Allow noreturn returns from void functions

### DIFF
--- a/test/compilable/noreturn1.d
+++ b/test/compilable/noreturn1.d
@@ -58,6 +58,21 @@ noreturn pureexits() @nogc nothrow pure @safe { assert(0); }
 
 noreturn callpureexits() { pureexits(); }
 
+noreturn returnExits()
+{
+    return pureexits();
+}
+
+void alsoExits()
+{
+    return assert(0);
+}
+
+int thisAlsoExits()
+{
+    return assert(0);
+}
+
 int test1(int i)
 {
     if (exit())

--- a/test/fail_compilation/noreturn2.d
+++ b/test/fail_compilation/noreturn2.d
@@ -1,0 +1,19 @@
+/*
+REQUIRED_ARGS: -w -o-
+
+TEST_OUTPUT:
+---
+fail_compilation/noreturn2.d(18): Error: `return` expression expected
+---
+
+https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md
+*/
+
+alias noreturn = typeof(*null);
+
+void doStuff();
+
+noreturn returnVoid()
+{
+    return doStuff();
+}


### PR DESCRIPTION
This is valid because
- `noreturn` is convertible to any type (incl. `void`)
- the program will abort/throw while evaluating the expression and hence
  never actually return a value

This means that the `ReturnStatement` can be replaced by the standalone
expression without changing the behaviour of the program.

---

Doesn't fix 22004 because the supplied example requires further changes
to accomodate for `return <noreturn>;` and subsequent `return;`'s during 
return type inference.