### PR TITLE
ImportC: refactor structalign_t from uint to struct

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -696,12 +696,9 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
 {
     Expressions* exps;                              /// Expression(s) yielding the desired alignment,
                                                     /// the largest value wins
-    enum structalign_t UNKNOWN = 0;                 /// alignment not yet computed
-    static assert(STRUCTALIGN_DEFAULT != UNKNOWN);
-
-    /// the actual alignment, `UNKNOWN` until it's either set to the value of `ealign`
-    /// or `STRUCTALIGN_DEFAULT` if `ealign` is null ( / an error ocurred)
-    structalign_t salign = UNKNOWN;
+    /// the actual alignment is Unknown until it's either set to the value of `ealign`
+    /// or the default if `ealign` is null ( / an error ocurred)
+    structalign_t salign;
 
 
     extern (D) this(const ref Loc loc, Expression exp, Dsymbols* decl)

--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2523,6 +2523,7 @@ final class CParser(AST) : Parser!AST
     AST.Type cparseTypeName()
     {
         Specifier specifier;
+        specifier.packalign.setDefault();
         auto tspec = cparseSpecifierQualifierList(LVL.global, specifier);
         Identifier id;
         return cparseDeclarator(DTR.xabstract, tspec, id, specifier);
@@ -2582,6 +2583,7 @@ final class CParser(AST) : Parser!AST
             }
 
             Specifier specifier;
+            specifier.packalign.setDefault();
             auto tspec = cparseDeclarationSpecifiers(LVL.prototype, specifier);
             if (tspec && specifier.mod & MOD.xconst)
             {
@@ -2959,6 +2961,7 @@ final class CParser(AST) : Parser!AST
          *    enum gnu-attributes (opt) identifier
          */
         Specifier specifier;
+        specifier.packalign.setDefault();
         if (token.value == TOK.__attribute__)
             cparseGnuAttributes(specifier);
 
@@ -2995,6 +2998,7 @@ final class CParser(AST) : Parser!AST
                      * https://gcc.gnu.org/onlinedocs/gcc/Enumerator-Attributes.html
                      */
                     Specifier specifierx;
+                    specifierx.packalign.setDefault();
                     cparseGnuAttributes(specifierx);
                 }
 
@@ -3012,6 +3016,7 @@ final class CParser(AST) : Parser!AST
                      * https://gcc.gnu.org/onlinedocs/gcc/Enumerator-Attributes.html
                      */
                     Specifier specifierx;
+                    specifierx.packalign.setDefault();
                     cparseGnuAttributes(specifierx);
                 }
 
@@ -4146,7 +4151,7 @@ final class CParser(AST) : Parser!AST
         SCW scw;        /// storage-class specifiers
         MOD mod;        /// type qualifiers
         AST.Expressions*  alignExps;  /// alignment
-        structalign_t packalign = STRUCTALIGN_DEFAULT;  /// #pragma pack alignment value
+        structalign_t packalign;  /// #pragma pack alignment value
     }
 
     /***********************
@@ -4322,7 +4327,7 @@ final class CParser(AST) : Parser!AST
             (*decls)[0] = s;
             s = new AST.AlignDeclaration(s.loc, specifier.alignExps, decls);
         }
-        else if (specifier.packalign != STRUCTALIGN_DEFAULT)
+        else if (!specifier.packalign.isDefault())
         {
             //printf("  applying packalign %d\n", cast(int)specifier.packalign);
             // Wrap #pragma pack in an AlignDeclaration

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -608,7 +608,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
                 if (!b.sym.alignsize)
                     b.sym.alignsize = target.ptrsize;
-                alignmember(b.sym.alignsize, b.sym.alignsize, &offset);
+                alignmember(structalign_t(b.sym.alignsize), b.sym.alignsize, &offset);
                 assert(bi < vtblInterfaces.dim);
 
                 BaseClass* bv = (*vtblInterfaces)[bi];

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1964,7 +1964,7 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
         storage_class = STC.static_ | STC.gshared;
         visibility = Visibility(Visibility.Kind.public_);
         linkage = LINK.c;
-        alignment = target.ptrsize;
+        alignment.set(target.ptrsize);
     }
 
     static TypeInfoDeclaration create(Type tinfo)

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -740,7 +740,11 @@ struct Scope
             return ad.salign;
         }
         else
-            return STRUCTALIGN_DEFAULT;
+        {
+            structalign_t sa;
+            sa.setDefault();
+            return sa;
+        }
     }
 
     /**********************************

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -334,10 +334,10 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         // Round struct size up to next alignsize boundary.
         // This will ensure that arrays of structs will get their internals
         // aligned properly.
-        if (alignment == STRUCTALIGN_DEFAULT)
+        if (alignment.isDefault())
             structsize = (structsize + alignsize - 1) & ~(alignsize - 1);
         else
-            structsize = (structsize + alignment - 1) & ~(alignment - 1);
+            structsize = (structsize + alignment.get() - 1) & ~(alignment.get() - 1);
 
         sizeok = Sizeok.done;
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -113,12 +113,12 @@ extern(C++) void dsymbolSemantic(Dsymbol dsym, Scope* sc)
  */
 AlignDeclaration getAlignment(AlignDeclaration ad, Scope* sc)
 {
-    if (ad.salign != ad.UNKNOWN)   // UNKNOWN is 0
+    if (!ad.salign.isUnknown())   // UNKNOWN is 0
         return ad;
 
     if (!ad.exps)
     {
-        ad.salign = STRUCTALIGN_DEFAULT;
+        ad.salign.setDefault();
         return ad;
     }
 
@@ -141,7 +141,7 @@ AlignDeclaration getAlignment(AlignDeclaration ad, Scope* sc)
             if (sc.flags & SCOPE.Cfile && n == 0)       // C11 6.7.5-6 allows 0 for alignment
                 continue;
 
-            if (n < 1 || n & (n - 1) || structalign_t.max < n || !e.type.isintegral())
+            if (n < 1 || n & (n - 1) || uint.max < n || !e.type.isintegral())
             {
                 error(ad.loc, "alignment must be an integer positive power of 2, not 0x%llx", cast(ulong)n);
                 errors = true;
@@ -151,9 +151,11 @@ AlignDeclaration getAlignment(AlignDeclaration ad, Scope* sc)
         }
     }
 
-    ad.salign = (errors || strictest == 0)  // C11 6.7.5-6 says alignment of 0 means no effect
-                ? STRUCTALIGN_DEFAULT
-                : cast(structalign_t) strictest;
+    if (errors || strictest == 0)  // C11 6.7.5-6 says alignment of 0 means no effect
+        ad.salign.setDefault();
+    else
+        ad.salign.set(cast(uint) strictest);
+
     return ad;
 }
 
@@ -441,7 +443,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
          * otherwise the scope overrrides.
          */
         dsym.alignment = sc.alignment();
-        if (dsym.alignment == STRUCTALIGN_DEFAULT)
+        if (dsym.alignment.isDefault())
             dsym.alignment = dsym.type.alignment(); // use type's alignment
 
         //printf("sc.stc = %x\n", sc.stc);

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -845,9 +845,9 @@ public:
             origType = &vd.originalType;
         scope(exit) origType = null;
 
-        if (vd.alignment != STRUCTALIGN_DEFAULT)
+        if (!vd.alignment.isDefault())
         {
-            buf.printf("// Ignoring var %s alignment %u", vd.toChars(), vd.alignment);
+            buf.printf("// Ignoring var %s alignment %d", vd.toChars(), vd.alignment.get());
             buf.writenl();
         }
 
@@ -1347,7 +1347,7 @@ public:
 
     /// Starts a custom alignment section using `#pragma pack` if
     /// `alignment` specifies a custom alignment
-    private void pushAlignToBuffer(uint alignment)
+    private void pushAlignToBuffer(structalign_t alignment)
     {
         // DMD ensures alignment is a power of two
         //assert(alignment > 0 && ((alignment & (alignment - 1)) == 0),
@@ -1355,20 +1355,20 @@ public:
 
         // When no alignment is specified, `uint.max` is the default
         // FIXME: alignment is 0 for structs templated members
-        if (alignment == STRUCTALIGN_DEFAULT || (tdparent && alignment == 0))
+        if (alignment.isDefault() || (tdparent && alignment.isUnknown()))
         {
             return;
         }
 
-        buf.printf("#pragma pack(push, %d)", alignment);
+        buf.printf("#pragma pack(push, %d)", alignment.get());
         buf.writenl();
     }
 
     /// Ends a custom alignment section using `#pragma pack` if
     /// `alignment` specifies a custom alignment
-    private void popAlignToBuffer(uint alignment)
+    private void popAlignToBuffer(structalign_t alignment)
     {
-        if (alignment == STRUCTALIGN_DEFAULT || (tdparent && alignment == 0))
+        if (alignment.isDefault() || (tdparent && alignment.isUnknown()))
             return;
 
         buf.writestringln("#pragma pack(pop)");

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -12375,12 +12375,12 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
     else if (exp.ident == Id.__xalignof &&
              exp.e1.isVarExp() &&
              exp.e1.isVarExp().var.isVarDeclaration() &&
-             exp.e1.isVarExp().var.isVarDeclaration().alignment)
+             !exp.e1.isVarExp().var.isVarDeclaration().alignment.isUnknown())
     {
         // For `x.alignof` get the alignment of the variable, not the alignment of its type
         const explicitAlignment = exp.e1.isVarExp().var.isVarDeclaration().alignment;
         const naturalAlignment = exp.e1.type.alignsize();
-        const actualAlignment = explicitAlignment == STRUCTALIGN_DEFAULT ? naturalAlignment : explicitAlignment;
+        const actualAlignment = explicitAlignment.isDefault() ? naturalAlignment : explicitAlignment.get();
         e = new IntegerExp(exp.loc, actualAlignment, Type.tsize_t);
         return e;
     }
@@ -12966,7 +12966,7 @@ private bool fit(StructDeclaration sd, const ref Loc loc, Scope* sc, Expressions
         const hasPointers = tb.hasPointers();
         if (hasPointers)
         {
-            if ((stype.alignment() < target.ptrsize ||
+            if ((stype.alignment.get() < target.ptrsize ||
                  (v.offset & (target.ptrsize - 1))) &&
                 (sc.func && sc.func.setUnsafe()))
             {

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1178,6 +1178,22 @@ enum class LINK : uint8_t
     system = 6u,
 };
 
+struct structalign_t final
+{
+private:
+    uint32_t value;
+public:
+    bool isDefault() const;
+    void setDefault();
+    bool isUnknown() const;
+    void setUnknown();
+    void set(uint32_t value);
+    uint32_t get() const;
+    structalign_t()
+    {
+    }
+};
+
 enum class PINLINE : uint8_t
 {
     default_ = 0u,
@@ -2036,7 +2052,7 @@ public:
     Type* unqualify(uint32_t m);
     virtual Type* toHeadMutable();
     virtual ClassDeclaration* isClassHandle();
-    virtual uint32_t alignment();
+    virtual structalign_t alignment();
     virtual Expression* defaultInitLiteral(const Loc& loc);
     virtual bool isZeroInit(const Loc& loc);
     Identifier* getTypeInfoIdent();
@@ -3578,7 +3594,7 @@ public:
     uint32_t alignsize();
     bool isString();
     bool isZeroInit(const Loc& loc);
-    uint32_t alignment();
+    structalign_t alignment();
     MATCH constConv(Type* to);
     MATCH implicitConvTo(Type* to);
     Expression* defaultInitLiteral(const Loc& loc);
@@ -3612,7 +3628,7 @@ public:
     uint32_t alignsize();
     TypeStruct* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
-    uint32_t alignment();
+    structalign_t alignment();
     Expression* defaultInitLiteral(const Loc& loc);
     bool isZeroInit(const Loc& loc);
     bool isAssignable();
@@ -5148,9 +5164,7 @@ class AlignDeclaration final : public AttribDeclaration
 {
 public:
     Array<Expression* >* exps;
-    enum : uint32_t { UNKNOWN = 0u };
-
-    uint32_t salign;
+    structalign_t salign;
     AlignDeclaration* syntaxCopy(Dsymbol* s);
     Scope* newScope(Scope* sc);
     void accept(Visitor* v);
@@ -5611,7 +5625,7 @@ public:
     uint32_t offset;
     uint32_t sequenceNumber;
     static uint32_t nextSequenceNumber;
-    uint32_t alignment;
+    structalign_t alignment;
     enum : uint32_t { AdrOnStackNone = 4294967295u };
 
     uint32_t ctfeAdrOnStack;
@@ -6064,7 +6078,7 @@ public:
     FuncDeclaration* xhash;
     static FuncDeclaration* xerreq;
     static FuncDeclaration* xerrcmp;
-    uint32_t alignment;
+    structalign_t alignment;
     ThreeState ispod;
     TypeTuple* argTypes;
     static StructDeclaration* create(Loc loc, Identifier* id, bool inObject);

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -261,11 +261,25 @@ extern (C++) struct Param
     const(char)[] mapfile;
 }
 
-alias structalign_t = uint;
+extern (C++) struct structalign_t
+{
+  private:
+    uint value = 0;  // unknown
+
+  public:
+  pure @safe @nogc nothrow:
+    bool isDefault() const { return value == ~0; }
+    void setDefault()      { value = ~0; }   // default = match whatever the corresponding C compiler does
+    bool isUnknown() const { return value == 0; }  // value is not set
+    void setUnknown()      { value = 0; }
+    void set(uint value)   { this.value = value; }
+    uint get() const       { return value; }
+}
+//alias structalign_t = uint;
 
 // magic value means "match whatever the underlying C compiler does"
 // other values are all powers of 2
-enum STRUCTALIGN_DEFAULT = (cast(structalign_t)~0);
+//enum STRUCTALIGN_DEFAULT = (cast(structalign_t)~0);
 
 enum mars_ext = "d";        // for D source files
 enum doc_ext  = "html";     // for Ddoc generated files

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -238,10 +238,21 @@ struct Param
     DString mapfile;
 };
 
-typedef unsigned structalign_t;
+struct structalign_t
+{
+    unsigned value;
+
+    bool isDefault() const;
+    void setDefault();
+    bool isUnknown() const;
+    void setUnknown();
+    void set(unsigned value);
+    unsigned get() const;
+};
+
 // magic value means "match whatever the underlying C compiler does"
 // other values are all powers of 2
-#define STRUCTALIGN_DEFAULT ((structalign_t) ~0)
+//#define STRUCTALIGN_DEFAULT ((structalign_t) ~0)
 
 const DString mars_ext = "d";
 const DString doc_ext  = "html";     // for Ddoc generated files

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -193,7 +193,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
                 // Check for @safe violations
                 if (vd.type.hasPointers)
                 {
-                    if ((t.alignment() < target.ptrsize ||
+                    if ((t.alignment.get() < target.ptrsize ||
                          (vd.offset & (target.ptrsize - 1))) &&
                         sc.func && sc.func.setUnsafe())
                     {

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -794,8 +794,8 @@ public:
             property("init", d._init.toString());
         if (d.isField())
             property("offset", d.offset);
-        if (d.alignment && d.alignment != STRUCTALIGN_DEFAULT)
-            property("align", d.alignment);
+        if (!d.alignment.isUnknown() && !d.alignment.isDefault())
+            property("align", d.alignment.get());
         objectEnd();
     }
 

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -280,7 +280,7 @@ class Lexer
         this.commentToken = commentToken;
         this.inTokenStringConstant = 0;
         this.lastDocLine = 0;
-        this.packalign = STRUCTALIGN_DEFAULT;
+        this.packalign.setDefault();
         //initKeywords();
         /* If first line starts with '#!', ignore the line
          */
@@ -2973,9 +2973,9 @@ class Lexer
         void setPackAlign(ref const Token t)
         {
             const n = t.unsvalue;
-            if (n < 1 || n & (n - 1) || structalign_t.max < n)
+            if (n < 1 || n & (n - 1) || uint.max < n)
                 error(loc, "pack must be an integer positive power of 2, not 0x%llx", cast(ulong)n);
-            packalign = cast(structalign_t)n;
+            packalign.set(cast(uint)n);
         }
 
         scan(&n);
@@ -2990,7 +2990,7 @@ class Lexer
          */
         if (n.value == TOK.identifier && n.ident == Id.show)
         {
-            warning(startloc, "current pack attribute is %d", cast(uint)packalign);
+            warning(startloc, "current pack attribute is %d", packalign.get());
             scan(&n);
             return closingParen();
         }
@@ -3085,7 +3085,7 @@ class Lexer
          */
         if (n.value == TOK.rightParenthesis)
         {
-            packalign = STRUCTALIGN_DEFAULT;
+            packalign.setDefault();
             return closingParen();
         }
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2295,7 +2295,9 @@ extern (C++) abstract class Type : ASTNode
      */
     structalign_t alignment()
     {
-        return STRUCTALIGN_DEFAULT;
+        structalign_t s;
+        s.setDefault();
+        return s;
     }
 
     /***************************************
@@ -5750,7 +5752,7 @@ extern (C++) final class TypeStruct : Type
 
     override structalign_t alignment()
     {
-        if (sym.alignment == 0)
+        if (sym.alignment.isUnknown())
             sym.size(sym.loc);
         return sym.alignment;
     }

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -1185,7 +1185,7 @@ private:
             dtb.xoff(Symbols.getIVarOffset(classDeclaration, var, true), 0); // pointer to ivar offset
             dtb.xoff(Symbols.getMethVarName(var.ident), 0); // name
             dtb.xoff(Symbols.getMethVarType(var.type), 0); // type string
-            dtb.dword(var.alignment);
+            dtb.dword(var.alignment.get());
             dtb.dword(cast(int) var.size(var.loc));
         }
 

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -89,7 +89,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
 
         if (hasPointers && v.type.toBasetype().ty != Tstruct)
         {
-            if ((ad.type.alignment() < target.ptrsize ||
+            if ((ad.type.alignment.get() < target.ptrsize ||
                  (v.offset & (target.ptrsize - 1))) &&
                 sc.func.setUnsafe())
             {

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -162,7 +162,7 @@ Symbol *toSymbol(Dsymbol s)
                 }
             }
             Symbol *s = symbol_calloc(id.ptr, cast(uint)id.length);
-            s.Salignment = vd.alignment;
+            s.Salignment = vd.alignment.get();
             if (vd.storage_class & STC.temp)
                 s.Sflags |= SFLartifical;
             if (isNRVO)
@@ -608,12 +608,12 @@ Symbol *toInitializer(AggregateDeclaration ad)
         static structalign_t alignOf(Type t)
         {
             const explicitAlignment = t.alignment();
-            return explicitAlignment == STRUCTALIGN_DEFAULT ? t.alignsize() : explicitAlignment;
+            return explicitAlignment.isDefault() ? structalign_t(t.alignsize()) : explicitAlignment;
         }
 
         auto sd = ad.isStructDeclaration();
         if (sd &&
-            alignOf(sd.type) <= 16 &&
+            alignOf(sd.type).get() <= 16 &&
             sd.type.size() <= 128 &&
             sd.zeroInit &&
             config.objfmt != OBJ_MACH && // same reason as in toobj.d toObjFile()
@@ -633,7 +633,7 @@ Symbol *toInitializer(AggregateDeclaration ad)
             s.Sfl = FLextern;
             s.Sflags |= SFLnodebug;
             if (sd)
-                s.Salignment = sd.alignment;
+                s.Salignment = sd.alignment.get();
             ad.sinit = s;
         }
     }

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -721,14 +721,14 @@ void setClosureVarOffset(FuncDeclaration fd)
              */
             memsize = target.ptrsize * 2;
             memalignsize = memsize;
-            xalign = STRUCTALIGN_DEFAULT;
+            xalign.setDefault();
         }
         else if (v.storage_class & (STC.out_ | STC.ref_))
         {
             // reference parameters are just pointers
             memsize = target.ptrsize;
             memalignsize = memsize;
-            xalign = STRUCTALIGN_DEFAULT;
+            xalign.setDefault();
         }
         else
         {

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2364,7 +2364,7 @@ Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier iden
         {
             const explicitAlignment = mt.alignment();
             const naturalAlignment = mt.alignsize();
-            const actualAlignment = (explicitAlignment == STRUCTALIGN_DEFAULT ? naturalAlignment : explicitAlignment);
+            const actualAlignment = (explicitAlignment.isDefault() ? naturalAlignment : explicitAlignment.get());
             e = new IntegerExp(loc, actualAlignment, Type.tsize_t);
         }
         else if (ident == Id._init)


### PR DESCRIPTION
structalign_t has two magic values and cannot adjust to different kinds of packing. So this PR refactors it into a struct where we can centrally control its behavior.

The intent is to get it to the point where we can have different kinds of packing behavior.