### PR TITLE
Fix Issue 21850 - [REG2.093] Template inference of pure not working

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1920,7 +1920,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                              * eg purity(https://issues.dlang.org/show_bug.cgi?id=7295),
                              * just regard it as not a match.
                              */
-                            if (auto e = resolveAliasThis(sc, farg, true))
+                            if (auto e = resolveAliasThis(paramscope, farg, true))
                             {
                                 farg = e;
                                 goto Lretry;

--- a/test/compilable/test21850.d
+++ b/test/compilable/test21850.d
@@ -1,0 +1,35 @@
+// https://issues.dlang.org/show_bug.cgi?id=21850
+
+struct Strukt2 {
+    this(int* _block) {  }
+}
+
+struct Strukt {
+    int* block;
+    Strukt2 foo() { return Strukt2(null); }
+    alias foo this;
+}
+
+bool wrapper(T)(ref T a, ref T b)
+{
+    return doesPointTo(a, b);
+}
+
+void johan() pure {
+    Strukt a;
+    Strukt b;
+    assert(wrapper(a, b));         // error wrapper is not pure
+    assert(doesPointTo(a, b));     // fine
+}
+
+bool doesPointTo(S, T)(S , T) {
+    return false;
+}
+
+bool doesPointTo(S)(shared S) {
+    return false;
+}
+
+bool mayPointTo(){
+    return false;
+}


### PR DESCRIPTION
This was wrongly passing the original scope when checking for `alias this` on parameters.