### PR TITLE
Fix 22113 - Allow `noreturn` as a type for main function

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2594,9 +2594,9 @@ extern (C++) class FuncDeclaration : Declaration
         }
 
         if (!tf.nextOf())
-            error("must return `int` or `void`");
-        else if (tf.nextOf().ty != Tint32 && tf.nextOf().ty != Tvoid)
-            error("must return `int` or `void`, not `%s`", tf.nextOf().toChars());
+            error("must return `int`, `void` or `noreturn`");
+        else if (tf.nextOf().ty != Tint32 && tf.nextOf().ty != Tvoid && tf.nextOf().ty != Tnoreturn)
+            error("must return `int`, `void` or `noreturn`, not `%s`", tf.nextOf().toChars());
         else if (tf.parameterList.varargs || nparams >= 2 || argerr)
             error("parameters must be `main()` or `main(string[] args)`");
     }

--- a/test/compilable/noreturn_main.d
+++ b/test/compilable/noreturn_main.d
@@ -1,0 +1,51 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=22113
+Allow main to return noreturn.
+
+ARG_SETS: -version=Use_D_Main
+ARG_SETS: -version=Use_C_Main
+ARG_SETS(windows64): -version=Use_Win_Main
+ARG_SETS(windows64): -version=Use_Dll_Main -shared
+
+LINK:
+*/
+
+// import core.stdc.stdio;
+
+version (Use_D_Main)
+noreturn main()
+{
+	// puts("Hello, World!");
+	assert(false);
+}
+
+version (Use_C_Main)
+extern(C) noreturn main(int* argc, const char** argv)
+{
+	// puts("Hello, World!");
+	assert(false);
+}
+
+version (Use_Win_Main)
+{
+	import core.sys.windows.windef;
+
+	extern(Windows)
+	noreturn WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int iCmdShow)
+	{
+		// puts("Hello, World!");
+		assert(false);
+	}
+}
+
+version (Use_Dll_Main)
+{
+	import core.sys.windows.windef;
+
+	extern (Windows)
+	noreturn DllMain(HINSTANCE hInstance, ULONG ulReason, LPVOID pvReserved)
+	{
+		// puts("Hello, World!");
+		assert(false);
+	}
+}

--- a/test/fail_compilation/fail318.d
+++ b/test/fail_compilation/fail318.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail318.d(8): Error: function `D main` must return `int` or `void`
+fail_compilation/fail318.d(8): Error: function `D main` must return `int`, `void` or `noreturn`
 ---
 */
 

--- a/test/fail_compilation/fail318_b.d
+++ b/test/fail_compilation/fail318_b.d
@@ -1,0 +1,8 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail318_b.d(8): Error: function `D main` must return `int`, `void` or `noreturn`, not `string`
+---
+*/
+
+string main() { }


### PR DESCRIPTION
`noreturn` is a valid because it's a subtype of `int`/`void` and also
guarantees that the function will never actually return to the caller.

The motivation as stated on bugzilla:

>> What advantage can one derive from it over `void` ?
>
> Smaller codegen, statically knowing the endless loop doesn't have any
> breaks. Could be useful for embedded applications that are supposed to
> run forever until the power is cut off.