### PR TITLE
Switch to the new CodeCov uploader

### DIFF
--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -134,11 +134,7 @@ CC="$CC" ./run --environment --jobs=$N "${targets[@]}" "${args[@]}"
 
 if [ "${DMD_TEST_COVERAGE:-0}" = "1" ] ; then
     cd $DMD_DIR
-    # CodeCov gets confused by lst files which it can't match
-    rm -rf test/runnable/extra-files test/*.lst
-    download "https://codecov.io/bash" "codecov.sh"
-    bash ./codecov.sh -p . -Z
-    rm codecov.sh
+    OS_NAME=windows source ci/codecov.sh
 
     # Skip druntime & phobos tests
     exit 0

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -192,11 +192,7 @@ test_cxx()
 
 codecov()
 {
-    # CodeCov gets confused by lst files which it can't match
-    rm -rf test/runnable/extra-files
-    download "https://codecov.io/bash" "https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov" "codecov.sh"
-    bash ./codecov.sh -p . -Z || echo "Failed to upload coverage reports!"
-    rm codecov.sh
+    OS_NAME=linux source ci/codecov.sh
 }
 
 case $1 in

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
       D_COMPILER: dmd
       HOST_DMD_VERSION: LATEST
       # Disable actual coverage because of issues with the codecov uploader
-      # DMD_TEST_COVERAGE: 1
+      DMD_TEST_COVERAGE: 1
     strategy:
       matrix:
         x64:

--- a/ci.sh
+++ b/ci.sh
@@ -213,12 +213,7 @@ install_host_compiler() {
 # Upload coverage reports
 codecov()
 {
-    # CodeCov gets confused by lst files which it can't match
-    rm -rf test/runnable/extra-files test/*.lst
-    curl -fsSL -A "$CURL_USER_AGENT" --connect-timeout 5 --speed-time 30 --speed-limit 1024 \
-        --retry 5 --retry-delay 5 "https://codecov.io/bash" -o "codecov.sh"
-    bash ./codecov.sh -p . -Z
-    rm codecov.sh
+    source ci/codecov.sh
 }
 
 # Define commands

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Uploads coverage reports to CodeCov
+
+# CodeCov gets confused by lst files which it can't match
+rm -rf test/runnable/extra-files test/*.lst
+
+# Save the file from URL passed as $1 to the location in $2
+doCurl()
+{
+    curl -fsSL -A "$CURL_USER_AGENT" --connect-timeout 5 --speed-time 30 --speed-limit 1024 --retry 5 --retry-delay 5 "$1" -o "$2"
+}
+
+# Determine the correct uploader + url + arguments
+UPLOADER="codecov"
+UPLOADER_OS="$OS_NAME"
+UPLOADER_ARGS=""
+
+case "$UPLOADER_OS" in
+
+    windows)
+        # -C workaround proposed in https://github.com/codecov/codecov-bash/issues/287
+        UPLOADER_ARGS="-C \"$BUILD_SOURCEVERSION\""
+
+        UPLOADER="$UPLOADER.exe"
+    ;;
+
+    darwin | osx)
+        UPLOADER_OS="macos"
+    ;;
+
+    # No FreeBSD support for the new uploader (yet?)
+    freebsd)
+        doCurl "https://codecov.io/bash" "codecov.sh"
+        bash ./codecov.sh -p . -Z
+        rm codecov.sh
+        return 0
+    ;;
+esac
+
+# Determine the host name
+for file in "$UPLOADER" "$UPLOADER.SHA256SUM" "$UPLOADER.SHA256SUM.sig"
+do
+    doCurl "https://uploader.codecov.io/latest/$UPLOADER_OS/$file" "$file"
+done
+
+# Obtain the key if missing
+if ! gpg --list-keys ED779869
+then
+    echo "Importing CodeCov key..."
+    doCurl "https://keybase.io/codecovsecurity/pgp_keys.asc" "pgp_keys.asc"
+    gpg --import pgp_keys.asc
+    rm pgp_keys.asc
+fi
+
+# Verify the uploader
+gpg --verify "$UPLOADER.SHA256SUM.sig" "$UPLOADER.SHA256SUM"
+shasum -a 256 -c "$UPLOADER.SHA256SUM"
+
+# Upload the sources
+chmod +x "$UPLOADER"
+"./$UPLOADER" -p . -Z $UPLOADER_ARGS
+
+rm codecov*

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -16,7 +16,7 @@ if [ -z ${HOST_DMD+x} ] ; then echo "Variable 'HOST_DMD' needs to be set."; exit
 
 if [ "$OS_NAME" == "linux" ]; then
   export DEBIAN_FRONTEND=noninteractive
-  packages="git-core make g++ gdb curl libcurl4 tzdata zip unzip xz-utils"
+  packages="git-core make g++ gdb gnupg curl libcurl4 tzdata zip unzip xz-utils"
   if [ "$MODEL" == "32" ]; then
     dpkg --add-architecture i386
     packages="$packages g++-multilib libcurl4:i386"


### PR DESCRIPTION
The currently used bash uploader is deprecated and will be removed in
the future[1]. This commit replaces the existing setup with the new
uploader for all currently supported platforms as proposed in [2].

Additional notes:
- FreeBSD support isn't supported yet and keeps using the old uploader
- Moved the new implementation into a dedicated file `source`d by
  all coverage CI's (instead of changing each individual configuration)

[1] https://about.codecov.io/blog/codecov-uploader-deprecation-plan
[2] https://about.codecov.io/blog/introducing-codecovs-new-uploader