### PR TITLE
Faster test run, saves about 30 seconds off of 4 minutes

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -81,7 +81,7 @@ int main(string[] args)
 int tryMain(string[] args)
 {
     bool runUnitTests, dumpEnvironment;
-    int jobs = totalCPUs;
+    int jobs = 2 * totalCPUs;
     auto res = getopt(args,
         std.getopt.config.passThrough,
         "j|jobs", "Specifies the number of jobs (commands) to run simultaneously (default: %d)".format(totalCPUs), &jobs,


### PR DESCRIPTION
This goes with the classic recommended 2x oversubscription, with good effect.