### PR TITLE
Fix 21957 - Don't crash when aligning noreturn members 

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -537,7 +537,10 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         addu(ofs, sz, overflow);
         if (overflow) assert(0);
 
-        alignmember(alignment, memalignsize, &ofs);
+        // Skip no-op for noreturn without custom aligment
+        if (memsize != 0 || alignment != STRUCTALIGN_DEFAULT)
+            alignmember(alignment, memalignsize, &ofs);
+
         uint memoffset = ofs;
         ofs += memsize;
         if (ofs > *paggsize)

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -620,6 +620,12 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
         assert(0);
     }
 
+    void visitNoreturn(Expression e)
+    {
+        // Noreturn field with default initializer
+        assert(e);
+    }
+
     switch (e.op)
     {
         default:                 return nonConstExpError(e);
@@ -638,6 +644,7 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
         case TOK.vector:         return visitVector        (e.isVectorExp());
         case TOK.classReference: return visitClassReference(e.isClassReferenceExp());
         case TOK.typeid_:        return visitTypeid        (e.isTypeidExp());
+        case TOK.assert_:        return visitNoreturn      (e);
     }
 }
 

--- a/test/compilable/noreturn3.d
+++ b/test/compilable/noreturn3.d
@@ -42,3 +42,108 @@ void inference()
     static assert(is(typeof(c2) == immutable noreturn));
     static assert(is(typeof(n) == noreturn));
 }
+
+
+/******************************************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=21957
+// Calculate proper alignment and size for noreturn members
+
+enum longPad = long.alignof - int.sizeof;
+
+struct BasicStruct
+{
+	int firstInt;
+	noreturn noRet;
+	long lastLong;
+}
+
+static assert(BasicStruct.sizeof == (int.sizeof + longPad + long.sizeof));
+
+static assert(BasicStruct.firstInt.offsetof == 0);
+static assert(BasicStruct.noRet.offsetof == 4);
+static assert(BasicStruct.lastLong.offsetof == (4 + longPad));
+
+struct AlignedStruct
+{
+	int firstInt;
+	align(16) noreturn noRet;
+	long lastLong;
+}
+
+static assert(AlignedStruct.sizeof == 32);
+
+static assert(AlignedStruct.firstInt.offsetof == 0);
+static assert(AlignedStruct.noRet.offsetof == 16);
+static assert(AlignedStruct.lastLong.offsetof == 16);
+
+union BasicUnion
+{
+	int firstInt;
+	noreturn noRet;
+	long lastLong;
+}
+
+static assert(BasicUnion.sizeof == 8);
+
+static assert(BasicUnion.firstInt.offsetof == 0);
+static assert(BasicUnion.noRet.offsetof == 0);
+static assert(BasicUnion.lastLong.offsetof == 0);
+
+union AlignedUnion
+{
+	int firstInt;
+	align(16) noreturn noRet;
+	long lastLong;
+}
+
+static assert(AlignedUnion.sizeof == 16);
+
+static assert(AlignedUnion.firstInt.offsetof == 0);
+static assert(AlignedUnion.noRet.offsetof == 0);
+static assert(AlignedUnion.lastLong.offsetof == 0);
+
+class BasicClass
+{
+	int firstInt;
+	noreturn noRet;
+	long lastLong;
+}
+
+enum objectMemberSize = __traits(classInstanceSize, Object);
+
+static assert(__traits(classInstanceSize, BasicClass) == objectMemberSize + (int.sizeof + longPad + long.sizeof));
+
+static assert(BasicClass.firstInt.offsetof == objectMemberSize + 0);
+static assert(BasicClass.noRet.offsetof == objectMemberSize + 4);
+static assert(BasicClass.lastLong.offsetof == objectMemberSize + (4 + longPad));
+
+class AlignedClass
+{
+	int firstInt;
+	align(16) noreturn noRet;
+	long lastLong;
+}
+
+enum offset = (objectMemberSize + 4 + 16) & ~15;
+
+static assert(__traits(classInstanceSize, AlignedClass) == offset + 8);
+
+static assert(AlignedClass.firstInt.offsetof == objectMemberSize + 0);
+static assert(AlignedClass.noRet.offsetof == offset);
+static assert(AlignedClass.lastLong.offsetof == offset);
+
+struct EmptyStruct
+{
+	noreturn noRet;
+}
+
+static assert(EmptyStruct.sizeof == 1);
+static assert(EmptyStruct.noRet.offsetof == 0);
+
+struct EmptyStruct2
+{
+	noreturn[4] noRet;
+}
+
+static assert(EmptyStruct2.sizeof == 1);
+static assert(EmptyStruct2.noRet.offsetof == 0);

--- a/test/runnable/noreturn1.d
+++ b/test/runnable/noreturn1.d
@@ -66,9 +66,56 @@ void test2()
 
 /*****************************************/
 
+struct BasicStruct
+{
+	int firstInt;
+	noreturn noRet;
+	long lastLong;
+}
+
+struct AlignedStruct
+{
+	int firstInt;
+	align(16) noreturn noRet;
+	long lastLong;
+}
+
+void takeBasic(BasicStruct bs)
+{
+    assert(bs.firstInt == 13);
+    assert(bs.lastLong == 42);
+
+    assert(&bs.noRet == (&bs.firstInt + 1));
+}
+
+void takeAligned(AlignedStruct as)
+{
+    assert(as.firstInt == 99);
+    assert(as.lastLong == 0xDEADBEEF);
+
+    assert(&as.noRet == &as.lastLong);
+}
+
+void test3()
+{
+    {
+        BasicStruct bs;
+        bs.firstInt = 13;
+        bs.lastLong = 42;
+        takeBasic(bs);
+    }
+    {
+        AlignedStruct as;
+        as.firstInt = 99;
+        as.lastLong = 0xDEADBEEF;
+        takeAligned(as);
+    }
+}
+
 int main()
 {
     test1();
     test2();
+    test3();
     return 0;
 }


### PR DESCRIPTION
`alignmember` assumes that every type with default alignment has a size
greater than zero - which obviously does not apply for `noreturn`.

A `noreturn` field with default alignment does not affect the layout of
the aggregate because `noreturn.sizeof = noreturn.alignof = 0`. Hence
skip the `alignmember` call unless a custom alignment was requested.

---

Targeting stable because this is a minor change to prevent an ICE