### PR TITLE
Fix 22373 - Handle casts from noreturn in e2ir.d 

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -3902,6 +3902,11 @@ extern (C++) class ToElemVisitor : Visitor
             case Twchar:    fty = Tuns16;   break;
             case Tdchar:    fty = Tuns32;   break;
 
+            // noreturn expression will throw/abort and never produce a
+            //  value to cast, hence we discard the cast
+            case Tnoreturn:
+                return Lret(ce, e);
+
             default:
                 break;
         }

--- a/test/compilable/noreturn1.d
+++ b/test/compilable/noreturn1.d
@@ -73,6 +73,12 @@ int thisAlsoExits()
     return assert(0);
 }
 
+void cast_()
+{
+    noreturn n;
+    int i = n;
+}
+
 int test1(int i)
 {
     if (exit())


### PR DESCRIPTION
Ignore the cast and only emit the `noreturn` expression - which will
abort / throw and hence never reach the cast.