### PR TITLE
fix Issue 22265 - importC: Error: cannot modify 'const' expression

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2583,6 +2583,11 @@ final class CParser(AST) : Parser!AST
 
             Specifier specifier;
             auto tspec = cparseDeclarationSpecifiers(LVL.prototype, specifier);
+            if (tspec && specifier.mod & MOD.xconst)
+            {
+                tspec = toConst(tspec);
+                specifier.mod = MOD.xnone;      // 'used' it
+            }
 
             Identifier id;
             auto t = cparseDeclarator(DTR.xparameter, tspec, id, specifier);

--- a/test/fail_compilation/fix22265.c
+++ b/test/fail_compilation/fix22265.c
@@ -1,0 +1,17 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fix22265.c(104): Error: cannot modify `const` expression `*buf`
+fail_compilation/fix22265.c(105): Error: cannot modify `const` expression `p`
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=22265
+
+#line 100
+
+void test(const char *buf, char *const p)
+{
+   char a = *buf++;
+   *buf = 'a';          // 104
+   char b = *p++;       // 105
+}


### PR DESCRIPTION
This is a reboot of https://github.com/dlang/dmd/pull/13041 which put the fix in the wrong place. It needed to go into the cparseParameterList() function.