### PR TITLE
Partial fix issue 19294 - Support for array operations with Complex! is incomplete

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -3307,29 +3307,26 @@ Lagain:
         }
     }
 
-    if (t1.ty == Tstruct || t2.ty == Tstruct)
+    if (t1.ty == Tstruct && t1.isTypeStruct().sym.aliasthis)
     {
-        if (t1.ty == Tstruct && t1.isTypeStruct().sym.aliasthis)
-        {
-            if (isRecursiveAliasThis(att1, e1.type))
-                return null;
-            //printf("att tmerge(s || s) e1 = %s\n", e1.type.toChars());
-            e1 = resolveAliasThis(sc, e1);
-            t1 = e1.type;
-            t = t1;
-            goto Lagain;
-        }
-        if (t2.ty == Tstruct && t2.isTypeStruct().sym.aliasthis)
-        {
-            if (isRecursiveAliasThis(att2, e2.type))
-                return null;
-            //printf("att tmerge(s || s) e2 = %s\n", e2.type.toChars());
-            e2 = resolveAliasThis(sc, e2);
-            t2 = e2.type;
-            t = t2;
-            goto Lagain;
-        }
-        return null;
+        if (isRecursiveAliasThis(att1, e1.type))
+            return null;
+        //printf("att tmerge(s || s) e1 = %s\n", e1.type.toChars());
+        e1 = resolveAliasThis(sc, e1);
+        t1 = e1.type;
+        t = t1;
+        goto Lagain;
+    }
+
+    if (t2.ty == Tstruct && t2.isTypeStruct().sym.aliasthis)
+    {
+        if (isRecursiveAliasThis(att2, e2.type))
+            return null;
+        //printf("att tmerge(s || s) e2 = %s\n", e2.type.toChars());
+        e2 = resolveAliasThis(sc, e2);
+        t2 = e2.type;
+        t = t2;
+        goto Lagain;
     }
 
     if ((e1.op == TOK.string_ || e1.op == TOK.null_) && e1.implicitConvTo(t2))

--- a/test/compilable/b19294.d
+++ b/test/compilable/b19294.d
@@ -1,0 +1,26 @@
+import std.stdio;
+import std.complex;
+
+void main()
+{
+    alias T = Complex!float;
+
+    T iV = complex(1.0f, 1.0f);
+    T[] arr = [iV, 2 * iV, 3 * iV, 4 * iV, 5 * iV, 6 * iV];
+    Complex!float[] result = new T[arr.length];
+    
+    result[] = arr[] + iV;
+    result[] = iV + arr[];
+    
+    result[] = arr[] - iV;
+    result[] = iV - arr[];
+    
+    result[] = arr[] * iV;
+    result[] = iV * arr[];
+    
+    result[] = arr[] / iV;
+    result[] = iV / arr[];
+    
+    result[] = arr[] ^^ iV;
+    result[] = iV ^^ arr[];
+}

--- a/test/compilable/b19294.d
+++ b/test/compilable/b19294.d
@@ -1,26 +1,69 @@
-import std.stdio;
-import std.complex;
+alias MT = MyStruct!int;
 
-void main()
+struct MyStruct(T)
 {
-    alias T = Complex!float;
+    T x;
 
-    T iV = complex(1.0f, 1.0f);
-    T[] arr = [iV, 2 * iV, 3 * iV, 4 * iV, 5 * iV, 6 * iV];
-    Complex!float[] result = new T[arr.length];
+    this(T y)
+    {
+        x = y;
+    }
+
+    MyStruct!T opBinary(string op)(MyStruct!T y) const
+    {
+        alias C = typeof(return);
+        auto w = C(this.x);
+        return w.opOpAssign!(op)(y);
+    }
+
+    MyStruct!T opBinaryRight(string op)(MyStruct!T y) const
+    {
+        return opBinary!(op)(y);
+    }
+
+    ref MyStruct opOpAssign(string op, T)(const MyStruct!T z)
+    {
+        mixin ("x "~op~"= z.x;");
+        return this;
+    }
+
+    MyStruct!T opBinary(string op)(T y) const
+    {
+        alias C = typeof(return);
+        auto w = C(this.x);
+        return w.opOpAssign!(op)(y);
+    }
+
+    MyStruct!T opBinaryRight(string op)(T y) const
+    {
+        return opBinary!(op)(y);
+    }
+
+    ref MyStruct opOpAssign(string op, T)(const T z)
+    {
+        mixin ("x "~op~"= z;");
+        return this;
+    }
+}
+
+void test()
+{
+    MT s = MyStruct!int(1);
+    MT[] arr = [s, 2 * s, 3 * s, 4 * s, 5 * s, 6 * s];
+    MT[] result = new MT[arr.length];
     
-    result[] = arr[] + iV;
-    result[] = iV + arr[];
+    result[] = arr[] + s;
+    result[] = s + arr[];
     
-    result[] = arr[] - iV;
-    result[] = iV - arr[];
+    result[] = arr[] - s;
+    result[] = s - arr[];
     
-    result[] = arr[] * iV;
-    result[] = iV * arr[];
+    result[] = arr[] * s;
+    result[] = s * arr[];
     
-    result[] = arr[] / iV;
-    result[] = iV / arr[];
+    result[] = arr[] / s;
+    result[] = s / arr[];
     
-    result[] = arr[] ^^ iV;
-    result[] = iV ^^ arr[];
+    result[] = arr[] ^^ s;
+    result[] = s ^^ arr[];
 }


### PR DESCRIPTION
…plete (partial fix, only for operands of the same type)


The git diff isn't very helpful here, as the only real changes are the removal of the return statement and the outer if condition. The if condition is redundant and the early return caused the compiler to throw errors for array operations like `T[] op T` or `T op T[]`

This is a partial fix for the issue, as `T[] op U`, `U op T[]` or `T[] op U[]` still aren't covered, even when op overload is defined.