### PR TITLE
Fix 22004 - Subsequent return statements override inferred noreturn return type

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3417,7 +3417,14 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             // infer return type
             if (fd.inferRetType)
             {
-                if (tf.next && tf.next.ty != Tvoid)
+                // 1. First `return <noreturn exp>?`
+                // 2. Potentially found a returning branch, update accordingly
+                if (!tf.next || tf.next.toBasetype().isTypeNoreturn())
+                {
+                    tf.next = resType; // infer void or noreturn
+                }
+                // Found an actual return value before
+                else if (tf.next.ty != Tvoid && !resType.toBasetype().isTypeNoreturn())
                 {
                     if (tf.next.ty != Terror)
                     {
@@ -3426,10 +3433,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     errors = true;
                     tf.next = Type.terror;
                 }
-                else
-                    tf.next = Type.tvoid;
 
-                    tret = tf.next;
+                tret = tf.next;
                 tbret = tret.toBasetype();
             }
 

--- a/test/compilable/noreturn3.d
+++ b/test/compilable/noreturn3.d
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS: -w -o-
+REQUIRED_ARGS: -w -o- -d
 
 More complex examples from the DIP
 https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md
@@ -26,6 +26,88 @@ void overloads()
 
     foo(bar());
 }
+
+// /*****************************************************************************/
+
+auto inferNoreturn(int i)
+{
+    if (i < 0)
+        return assert(false);
+    else if (i == 0)
+        return assert(false);
+    else
+        return assert(false);
+}
+
+auto inferReturn(int i)
+{
+    if (i < 0)
+        return assert(false);
+    else if (i == 0)
+        return i;
+    else
+        return assert(false);
+}
+
+// /*****************************************************************************/
+// // https://issues.dlang.org/show_bug.cgi?id=22004
+
+alias fun22004 = _ => {}();
+alias gun22004 = _ => assert(0);
+auto bun22004(bool b)
+{
+    if (b)
+        return gun22004(0);
+    else
+        return fun22004(0);
+}
+
+static assert(is(typeof(bun22004(true)) == void));
+
+// // Reversed order
+auto bun22004_reversed(bool b)
+{
+    if (b)
+        return fun22004(0);
+    else
+        return gun22004(0);
+}
+
+static assert(is(typeof(bun22004_reversed(true)) == void));
+
+// /*****************************************************************************/
+
+// // Also works fine with non-void types and ref inference
+
+int global;
+
+auto ref forwardOrExit(ref int num)
+{
+    if (num)
+        return num;
+    else
+        return assert(false);
+}
+
+static assert( is(typeof(forwardOrExit(global)) == int));
+
+// // Must not infer ref due to the noreturn rvalue
+static assert(!is(typeof(&forwardOrExit(global))));
+
+auto ref forwardOrExit2(ref int num)
+{
+    if (num)
+        return assert(false);
+    else
+        return num;
+}
+
+static assert( is(typeof(forwardOrExit2(global)) == int));
+
+// // Must not infer ref due to the noreturn rvalue
+static assert(!is(typeof(&forwardOrExit2(global))));
+
+/*****************************************************************************/
 
 void inference()
 {

--- a/test/fail_compilation/noreturn2.d
+++ b/test/fail_compilation/noreturn2.d
@@ -17,3 +17,22 @@ noreturn returnVoid()
 {
     return doStuff();
 }
+
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/noreturn2.d(37): Error: Expected return type of `int`, not `string`:
+fail_compilation/noreturn2.d(35):        Return type of `int` inferred here.
+---
++/
+
+auto missmatch(int i)
+{
+    if (i < 0)
+        return assert(false);
+    if (i == 0)
+        return i;
+    if (i > 0)
+        return "";
+}


### PR DESCRIPTION
Return type inference used to commit to `noreturn` when encountering
a return statement producing a `noreturn` value. This was problematic
when the function contained subsequent `void` returns, raising an error
regarding missmatched function type inference even though `void` and
`noreturn` are compatible (neither produce an actual value).

This patch changes the code to let `noreturn` be overriden by `void`.