### PR TITLE
Fix Issue 22366 - [dip1000] scope variable can be assigned to associative array

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -9749,7 +9749,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.type = exp.e1.type;
         assert(exp.type);
         auto res = exp.op == TOK.assign ? exp.reorderSettingAAElem(sc) : exp;
-        checkAssignEscape(sc, res, false);
+        Expression tmp;
+        /* https://issues.dlang.org/show_bug.cgi?id=22366
+         *
+         * `reorderSettingAAElem` creates a tree of comma expressions, however,
+         * `checkAssignExp` expects only AssignExps.
+         */
+        checkAssignEscape(sc, Expression.extractLast(res, tmp), false);
         return setResult(res);
     }
 

--- a/test/fail_compilation/fail22366.d
+++ b/test/fail_compilation/fail22366.d
@@ -1,0 +1,15 @@
+// REQUIRED_ARGS: -dip1000
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail22366.d(13): Error: scope variable `__aaval2` assigned to non-scope `aa[0]`
+---
+*/
+
+int* fun(scope int* x) @safe
+{
+    int*[int] aa;
+    aa[0] = x; // should give an error
+    return aa[0];
+}


### PR DESCRIPTION
The error message could be improved, however, that should be the subject of a different PR.