### PR TITLE
Link with -lexecinfo on OpenBSD for backtrace symbols

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -751,6 +751,8 @@ public int runLINK()
         {
             // Link against -lc++abi for Unwind symbols
             argv.push("-lc++abi");
+            // Link against -lexecinfo for backtrace symbols
+            argv.push("-lexecinfo");
         }
         if (global.params.verbose)
         {


### PR DESCRIPTION
Fix Issue 22379 - OpenBSD: link -lexecinfo to get backtrace symbols