### PR TITLE
Implement throw expressions (DIP 1034)

### DIFF
--- a/changelog/throw_expression.dd
+++ b/changelog/throw_expression.dd
@@ -1,0 +1,32 @@
+Throw expression as proposed by DIP 1034 have been implemented
+
+Prior to this release, `throw` was considered as a statement and hence was not
+allowed to appear inside of other expressions. This was cumbersome e.g. when
+wanting to throw an expression from a lambda:
+
+---
+SumType!(int, string) result;
+
+result.match!(
+    (int num)       => writeln("Found ", num),
+    // (string err) => throw new Exception(err)    // expression expected
+    (string err)     { throw new Exception(err); } // ok, introduces an explicit body
+
+);
+---
+
+`throw` is now treated as an expression as specified by DIP 1034 [1], causing
+it to become more flexible and easier to use.
+
+
+---
+SumType!(int, string) result;
+
+result.match!(
+    (int num)    => writeln("Found ", num),
+    (string err) => throw new Exception(err)   // works
+
+);
+---
+
+[1] https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -5419,6 +5419,25 @@ struct ASTBase
         }
     }
 
+    extern (C++) final class ThrowExp : UnaExp
+    {
+        extern (D) this(const ref Loc loc, Expression e)
+        {
+            super(loc, EXP.throw_, __traits(classInstanceSize, ThrowExp), e);
+            this.type = Type.tnoreturn;
+        }
+
+        override ThrowExp syntaxCopy()
+        {
+            return new ThrowExp(loc, e1.syntaxCopy());
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
     extern (C++) final class MixinExp : Expression
     {
         Expressions* exps;

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -110,8 +110,8 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                 }
                 if (s.exp.type && s.exp.type.toBasetype().isTypeNoreturn())
                     result = BE.halt;
-                if (canThrow(s.exp, func, mustNotThrow))
-                    result |= BE.throw_;
+
+                result |= canThrow(s.exp, func, mustNotThrow);
             }
         }
 
@@ -214,8 +214,8 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                 result = BE.fallthru;
             if (result & BE.fallthru)
             {
-                if (canThrow(s.condition, func, mustNotThrow))
-                    result |= BE.throw_;
+                result |= canThrow(s.condition, func, mustNotThrow);
+
                 if (!(result & BE.break_) && s.condition.toBool().hasValue(true))
                     result &= ~BE.fallthru;
             }
@@ -233,8 +233,8 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             }
             if (s.condition)
             {
-                if (canThrow(s.condition, func, mustNotThrow))
-                    result |= BE.throw_;
+                result |= canThrow(s.condition, func, mustNotThrow);
+
                 const opt = s.condition.toBool();
                 if (opt.hasValue(true))
                     result &= ~BE.fallthru;
@@ -250,15 +250,15 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                     result |= BE.fallthru;
                 result |= r & ~(BE.fallthru | BE.break_ | BE.continue_);
             }
-            if (s.increment && canThrow(s.increment, func, mustNotThrow))
-                result |= BE.throw_;
+            if (s.increment)
+                result |= canThrow(s.increment, func, mustNotThrow);
         }
 
         override void visit(ForeachStatement s)
         {
             result = BE.fallthru;
-            if (canThrow(s.aggr, func, mustNotThrow))
-                result |= BE.throw_;
+            result |= canThrow(s.aggr, func, mustNotThrow);
+
             if (s._body)
                 result |= blockExit(s._body, func, mustNotThrow) & ~(BE.break_ | BE.continue_);
         }
@@ -273,8 +273,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         {
             //printf("IfStatement::blockExit(%p)\n", s);
             result = BE.none;
-            if (canThrow(s.condition, func, mustNotThrow))
-                result |= BE.throw_;
+            result |= canThrow(s.condition, func, mustNotThrow);
 
             const opt = s.condition.toBool();
             if (opt.hasValue(true))
@@ -313,8 +312,8 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         override void visit(SwitchStatement s)
         {
             result = BE.none;
-            if (canThrow(s.condition, func, mustNotThrow))
-                result |= BE.throw_;
+            result |= canThrow(s.condition, func, mustNotThrow);
+
             if (s._body)
             {
                 result |= blockExit(s._body, func, mustNotThrow);
@@ -357,8 +356,8 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         override void visit(ReturnStatement s)
         {
             result = BE.return_;
-            if (s.exp && canThrow(s.exp, func, mustNotThrow))
-                result |= BE.throw_;
+            if (s.exp)
+                result |= canThrow(s.exp, func, mustNotThrow);
         }
 
         override void visit(BreakStatement s)
@@ -380,8 +379,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         override void visit(WithStatement s)
         {
             result = BE.none;
-            if (canThrow(s.exp, func, mustNotThrow))
-                result = BE.throw_;
+            result |= canThrow(s.exp, func, mustNotThrow);
             result |= blockExit(s._body, func, mustNotThrow);
         }
 

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -18,6 +18,7 @@ import dmd.apply;
 import dmd.arraytypes;
 import dmd.attrib;
 import dmd.astenums;
+import dmd.blockexit : BE;
 import dmd.declaration;
 import dmd.dsymbol;
 import dmd.expression;
@@ -29,11 +30,28 @@ import dmd.root.rootobject;
 import dmd.tokens;
 import dmd.visitor;
 
+/**
+ * Status indicating what kind of throwable might be caused by an expression.
+ *
+ * This is a subset of `BE` restricted to the values actually used by `canThrow`.
+ */
+enum CT : BE
+{
+    /// Never throws an `Exception` or `Throwable`
+    none = BE.none,
+
+    /// Might throw an `Exception`
+    exception = BE.throw_,
+
+    // Might throw an `Error`
+    error = BE.errthrow,
+}
+
 /********************************************
  * Returns true if the expression may throw exceptions.
  * If 'mustNotThrow' is true, generate an error if it throws
  */
-extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow)
+extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, bool mustNotThrow)
 {
     //printf("Expression::canThrow(%d) %s\n", mustNotThrow, toChars());
     // stop walking if we determine this expression can throw
@@ -42,6 +60,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
         alias visit = typeof(super).visit;
         FuncDeclaration func;
         bool mustNotThrow;
+        CT result;
 
     public:
         extern (D) this(FuncDeclaration func, bool mustNotThrow)
@@ -62,7 +81,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
 
                     e.checkOverridenDtor(null, f, dd => dd.type.toTypeFunction().isnothrow, "not nothrow");
                 }
-                stop = true;  // if any function throws, then the whole expression throws
+                result |= CT.exception;
             }
         }
 
@@ -72,7 +91,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
 
         override void visit(DeclarationExp de)
         {
-            stop = Dsymbol_canThrow(de.declaration, func, mustNotThrow);
+            result |= Dsymbol_canThrow(de.declaration, func, mustNotThrow);
         }
 
         override void visit(CallExp ce)
@@ -133,7 +152,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
                     e1 = pe.e1;
                 ce.error("`%s` is not `nothrow`", e1.toChars());
             }
-            stop = true;
+            result |= CT.exception;
         }
 
         override void visit(NewExp ne)
@@ -203,18 +222,22 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
     }
 
     scope CanThrow ct = new CanThrow(func, mustNotThrow);
-    return walkPostorder(e, ct);
+    walkPostorder(e, ct);
+    return ct.result;
 }
 
 /**************************************
  * Does symbol, when initialized, throw?
  * Mirrors logic in Dsymbol_toElem().
  */
-private bool Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNotThrow)
+private CT Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNotThrow)
 {
+    CT result;
+
     int symbolDg(Dsymbol s)
     {
-        return Dsymbol_canThrow(s, func, mustNotThrow);
+        result |= Dsymbol_canThrow(s, func, mustNotThrow);
+        return 0;
     }
 
     //printf("Dsymbol_toElem() %s\n", s.toChars());
@@ -234,20 +257,19 @@ private bool Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNotThrow
             if (vd._init)
             {
                 if (auto ie = vd._init.isExpInitializer())
-                    if (canThrow(ie.exp, func, mustNotThrow))
-                        return true;
+                    result |= canThrow(ie.exp, func, mustNotThrow);
             }
             if (vd.needsScopeDtor())
-                return canThrow(vd.edtor, func, mustNotThrow);
+                result |= canThrow(vd.edtor, func, mustNotThrow);
         }
     }
     else if (auto ad = s.isAttribDeclaration())
     {
-        return ad.include(null).foreachDsymbol(&symbolDg) != 0;
+        ad.include(null).foreachDsymbol(&symbolDg);
     }
     else if (auto tm = s.isTemplateMixin())
     {
-        return tm.members.foreachDsymbol(&symbolDg) != 0;
+        tm.members.foreachDsymbol(&symbolDg);
     }
     else if (auto td = s.isTupleDeclaration())
     {
@@ -259,11 +281,10 @@ private bool Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNotThrow
                 Expression eo = cast(Expression)o;
                 if (auto se = eo.isDsymbolExp())
                 {
-                    if (Dsymbol_canThrow(se.s, func, mustNotThrow))
-                        return true;
+                    result |= Dsymbol_canThrow(se.s, func, mustNotThrow);
                 }
             }
         }
     }
-    return false;
+    return result;
 }

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -18,7 +18,7 @@ import dmd.apply;
 import dmd.arraytypes;
 import dmd.attrib;
 import dmd.astenums;
-import dmd.blockexit : BE;
+import dmd.blockexit : BE, checkThrow;
 import dmd.declaration;
 import dmd.dsymbol;
 import dmd.expression;
@@ -213,6 +213,13 @@ extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, bool mustN
             if (auto ts = t.baseElemOf().isTypeStruct())
                 if (auto postblit = ts.sym.postblit)
                     checkFuncThrows(ae, postblit);
+        }
+
+        override void visit(ThrowExp te)
+        {
+            const res = checkThrow(te.loc, te.e1, mustNotThrow);
+            assert((res & ~(CT.exception | CT.error)) == 0);
+            result |= res;
         }
 
         override void visit(NewAnonClassExp)

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -1601,14 +1601,20 @@ public:
             istate.start = null;
         }
 
-        incUsageCtfe(istate, s.loc);
+        interpretThrow(s.exp, s.loc);
+    }
 
-        Expression e = interpretRegion(s.exp, istate);
+    /// Interpret `throw <exp>` found at the specified location `loc`
+    private void interpretThrow(Expression exp, const ref Loc loc)
+    {
+        incUsageCtfe(istate, loc);
+
+        Expression e = interpretRegion(exp, istate);
         if (exceptionOrCant(e))
             return;
 
         assert(e.op == EXP.classReference);
-        result = ctfeEmplaceExp!ThrownExceptionExp(s.loc, e.isClassReferenceExp());
+        result = ctfeEmplaceExp!ThrownExceptionExp(loc, e.isClassReferenceExp());
     }
 
     override void visit(ScopeGuardStatement s)

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1559,6 +1559,16 @@ extern (C++) class ToElemVisitor : Visitor
         result = e;
     }
 
+    override void visit(ThrowExp te)
+    {
+        //printf("ThrowExp.toElem() '%s'\n", te.toChars());
+
+        elem *e = toElemDtor(te.e1, irs);
+        const rtlthrow = config.ehmethod == EHmethod.EH_DWARF ? RTLSYM.THROWDWARF : RTLSYM.THROWC;
+        elem *sym = el_var(getRtlsym(rtlthrow));
+        result = el_bin(OPcall, TYnoreturn, sym, e);
+    }
+
     override void visit(PostExp pe)
     {
         //printf("PostExp.toElem() '%s'\n", pe.toChars());

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4681,6 +4681,31 @@ extern (C++) final class AssertExp : UnaExp
 }
 
 /***********************************************************
+ * `throw <e1>` as proposed by DIP 1034.
+ *
+ * Replacement for the deprecated `ThrowStatement` that can be nested
+ * in other expression.
+ */
+extern (C++) final class ThrowExp : UnaExp
+{
+    extern (D) this(const ref Loc loc, Expression e)
+    {
+        super(loc, EXP.throw_, __traits(classInstanceSize, ThrowExp), e);
+        this.type = Type.tnoreturn;
+    }
+
+    override ThrowExp syntaxCopy()
+    {
+        return new ThrowExp(loc, e1.syntaxCopy());
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+/***********************************************************
  */
 extern (C++) final class DotIdExp : UnaExp
 {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -25,7 +25,6 @@ import dmd.arraytypes;
 import dmd.astenums;
 import dmd.ast_node;
 import dmd.gluelayer;
-import dmd.canthrow;
 import dmd.constfold;
 import dmd.ctfeexpr;
 import dmd.ctorflow;

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -742,6 +742,14 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+class ThrowExp : public UnaExp
+{
+public:
+    ThrowExp *syntaxCopy();
+
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 class DotIdExp : public UnaExp
 {
 public:

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -48,7 +48,9 @@ struct Symbol;          // back end symbol
 void expandTuples(Expressions *exps);
 bool isTrivialExp(Expression *e);
 bool hasSideEffect(Expression *e, bool assumeImpureCalls = false);
-bool canThrow(Expression *e, FuncDeclaration *func, bool mustNotThrow);
+
+enum BE : int32_t;
+BE canThrow(Expression *e, FuncDeclaration *func, bool mustNotThrow);
 
 typedef unsigned char OwnedBy;
 enum

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6396,6 +6396,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             : Expression.combine(temporariesPrefix, exp).expressionSemantic(sc);
     }
 
+    override void visit(ThrowExp te)
+    {
+        import dmd.statementsem;
+
+        if (StatementSemanticVisitor.throwSemantic(te.loc, te.e1, sc))
+            result = te;
+        else
+            setError();
+    }
+
     override void visit(DotIdExp exp)
     {
         static if (LOGSEMANTIC)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1249,6 +1249,20 @@ enum class BUILTIN : uint8_t
     toPrecReal = 35u,
 };
 
+enum class BE
+{
+    none = 0,
+    fallthru = 1,
+    throw_ = 2,
+    return_ = 4,
+    goto_ = 8,
+    halt = 16,
+    break_ = 32,
+    continue_ = 64,
+    errthrow = 128,
+    any = 31,
+};
+
 enum class Include : uint8_t
 {
     notComputed = 0u,
@@ -5457,7 +5471,7 @@ extern BUILTIN isBuiltin(FuncDeclaration* fd);
 
 extern Expression* eval_builtin(const Loc& loc, FuncDeclaration* fd, Array<Expression* >* arguments);
 
-extern bool canThrow(Expression* e, FuncDeclaration* func, bool mustNotThrow);
+extern BE canThrow(Expression* e, FuncDeclaration* func, bool mustNotThrow);
 
 extern bool includeImports;
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2416,6 +2416,7 @@ public:
     virtual void visit(typename AST::CallExp e);
     virtual void visit(typename AST::DotIdExp e);
     virtual void visit(typename AST::AssertExp e);
+    virtual void visit(typename AST::ThrowExp e);
     virtual void visit(typename AST::ImportExp e);
     virtual void visit(typename AST::DotTemplateInstanceExp e);
     virtual void visit(typename AST::ArrayExp e);
@@ -4783,6 +4784,7 @@ struct ASTCodegen final
     using SymbolExp = ::SymbolExp;
     using TemplateExp = ::TemplateExp;
     using ThisExp = ::ThisExp;
+    using ThrowExp = ::ThrowExp;
     using TraitsExp = ::TraitsExp;
     using TupleExp = ::TupleExp;
     using TypeExp = ::TypeExp;
@@ -7042,6 +7044,13 @@ public:
     void accept(Visitor* v);
 };
 
+class ThrowExp final : public UnaExp
+{
+public:
+    ThrowExp* syntaxCopy();
+    void accept(Visitor* v);
+};
+
 class DotIdExp final : public UnaExp
 {
 public:
@@ -7974,6 +7983,7 @@ public:
     void visit(PostExp* e);
     void visit(CondExp* e);
     void visit(GenericExp* e);
+    void visit(ThrowExp* e);
     void visit(TemplateTypeParameter* tp);
     void visit(TemplateThisParameter* tp);
     void visit(TemplateAliasParameter* tp);

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2364,6 +2364,12 @@ public:
         buf.writeByte(')');
     }
 
+    override void visit(ThrowExp e)
+    {
+        buf.writestring("throw ");
+        expToBuffer(e.e1, PREC.unary, buf, hgs);
+    }
+
     override void visit(DotIdExp e)
     {
         expToBuffer(e.e1, PREC.primary, buf, hgs);

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -128,6 +128,7 @@ immutable PREC[EXP.max + 1] precedence =
     EXP.new_ : PREC.unary,
     EXP.newAnonymousClass : PREC.unary,
     EXP.cast_ : PREC.unary,
+    EXP.throw_ : PREC.unary,
 
     EXP.vector : PREC.unary,
     EXP.pow : PREC.pow,
@@ -8473,6 +8474,7 @@ LagainStc:
                 e = new AST.FuncExp(loc, s);
                 break;
             }
+
         default:
             error("expression expected, not `%s`", token.toChars());
         Lerr:
@@ -8766,6 +8768,17 @@ LagainStc:
                 e = parsePostExp(e);
                 break;
             }
+        case TOK.throw_:
+            {
+                nextToken();
+                // Deviation from the DIP:
+                // Parse AssignExpression instead of Expression to avoid conflicts for comma
+                // separated lists, e.g. function arguments
+                AST.Expression exp = parseAssignExp();
+                e = new AST.ThrowExp(loc, exp);
+                break;
+            }
+
         default:
             e = parsePrimaryExp();
             e = parsePostExp(e);

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -220,6 +220,7 @@ public:
     void visit(AST.CallExp e) { visit(cast(AST.UnaExp)e); }
     void visit(AST.DotIdExp e) { visit(cast(AST.UnaExp)e); }
     void visit(AST.AssertExp e) { visit(cast(AST.UnaExp)e); }
+    void visit(AST.ThrowExp e) { visit(cast(AST.UnaExp)e); }
     void visit(AST.ImportExp e) { visit(cast(AST.UnaExp)e); }
     void visit(AST.DotTemplateInstanceExp e) { visit(cast(AST.UnaExp)e); }
     void visit(AST.ArrayExp e) { visit(cast(AST.UnaExp)e); }

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -178,6 +178,7 @@ private bool lambdaHasSideEffect(Expression e, bool assumeImpureCalls = false)
     case EXP.remove:
     case EXP.assert_:
     case EXP.halt:
+    case EXP.throw_:
     case EXP.delete_:
     case EXP.new_:
     case EXP.newAnonymousClass:

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -21,7 +21,6 @@ import dmd.arraytypes;
 import dmd.astenums;
 import dmd.ast_node;
 import dmd.gluelayer;
-import dmd.canthrow;
 import dmd.cond;
 import dmd.dclass;
 import dmd.declaration;

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -45,7 +45,7 @@ struct code;
 
 /* How a statement exits; this is returned by blockExit()
  */
-enum BE
+enum BE : int32_t
 {
     BEnone =     0,
     BEfallthru = 1,

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -148,7 +148,7 @@ extern(C++) Statement statementSemantic(Statement s, Scope* sc)
     return v.result;
 }
 
-private extern (C++) final class StatementSemanticVisitor : Visitor
+package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
 {
     alias visit = Visitor.visit;
 
@@ -3763,8 +3763,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             return false;
         }
 
-        FuncDeclaration fd = sc.parent.isFuncDeclaration();
-        fd.hasReturnExp |= 2;
+        if (FuncDeclaration fd = sc.parent.isFuncDeclaration())
+            fd.hasReturnExp |= 2;
 
         if (exp.op == EXP.new_)
         {

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3732,44 +3732,61 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
          */
 
         //printf("ThrowStatement::semantic()\n");
+        if (throwSemantic(ts.loc, ts.exp, sc))
+            result = ts;
+        else
+            setError();
 
+    }
+
+    /**
+     * Run semantic on `throw <exp>`.
+     *
+     * Params:
+     *   loc = location of the `throw`
+     *   exp = value to be thrown
+     *   sc  = enclosing scope
+     *
+     * Returns: true if the `throw` is valid, or false if an error was found
+     */
+    extern(D) static bool throwSemantic(const ref Loc loc, ref Expression exp, Scope* sc)
+    {
         if (!global.params.useExceptions)
         {
-            ts.error("Cannot use `throw` statements with -betterC");
-            return setError();
+            loc.error("Cannot use `throw` statements with -betterC");
+            return false;
         }
 
         if (!ClassDeclaration.throwable)
         {
-            ts.error("Cannot use `throw` statements because `object.Throwable` was not declared");
-            return setError();
+            loc.error("Cannot use `throw` statements because `object.Throwable` was not declared");
+            return false;
         }
 
         FuncDeclaration fd = sc.parent.isFuncDeclaration();
         fd.hasReturnExp |= 2;
 
-        if (ts.exp.op == EXP.new_)
+        if (exp.op == EXP.new_)
         {
-            NewExp ne = cast(NewExp)ts.exp;
+            NewExp ne = cast(NewExp) exp;
             ne.thrownew = true;
         }
 
-        ts.exp = ts.exp.expressionSemantic(sc);
-        ts.exp = resolveProperties(sc, ts.exp);
-        ts.exp = checkGC(sc, ts.exp);
-        if (ts.exp.op == EXP.error)
-            return setError();
+        exp = exp.expressionSemantic(sc);
+        exp = resolveProperties(sc, exp);
+        exp = checkGC(sc, exp);
+        if (exp.op == EXP.error)
+            return false;
 
-        checkThrowEscape(sc, ts.exp, false);
+        checkThrowEscape(sc, exp, false);
 
-        ClassDeclaration cd = ts.exp.type.toBasetype().isClassHandle();
+        ClassDeclaration cd = exp.type.toBasetype().isClassHandle();
         if (!cd || ((cd != ClassDeclaration.throwable) && !ClassDeclaration.throwable.isBaseOf(cd, null)))
         {
-            ts.error("can only throw class objects derived from `Throwable`, not type `%s`", ts.exp.type.toChars());
-            return setError();
+            loc.error("can only throw class objects derived from `Throwable`, not type `%s`", exp.type.toChars());
+            return false;
         }
-
-        result = ts;
+        return true;
     }
 
     override void visit(DebugStatement ds)

--- a/src/dmd/strictvisitor.d
+++ b/src/dmd/strictvisitor.d
@@ -169,6 +169,7 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.CallExp) { assert(0); }
     override void visit(AST.DotIdExp) { assert(0); }
     override void visit(AST.AssertExp) { assert(0); }
+    override void visit(AST.ThrowExp) { assert(0); }
     override void visit(AST.MixinExp) { assert(0); }
     override void visit(AST.ImportExp) { assert(0); }
     override void visit(AST.DotTemplateInstanceExp) { assert(0); }

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -1141,6 +1141,12 @@ package mixin template ParseVisitMethods(AST)
         }
     }
 
+    override void visit(AST.ThrowExp e)
+    {
+        //printf("Visiting ThrowExp\n");
+        e.e1.accept(this);
+    }
+
 // Template Parameter
 //===========================================================
 

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -220,6 +220,7 @@ class BinAssignExp;
 class MixinExp;
 class ImportExp;
 class AssertExp;
+class ThrowExp;
 class DotIdExp;
 class DotTemplateExp;
 class DotVarExp;
@@ -511,6 +512,7 @@ public:
     virtual void visit(CallExp *e) { visit((UnaExp *)e); }
     virtual void visit(DotIdExp *e) { visit((UnaExp *)e); }
     virtual void visit(AssertExp *e) { visit((UnaExp *)e); }
+    virtual void visit(ThrowExp *e) { visit((UnaExp *)e); }
     virtual void visit(ImportExp *e) { visit((UnaExp *)e); }
     virtual void visit(DotTemplateInstanceExp *e) { visit((UnaExp *)e); }
     virtual void visit(ArrayExp *e) { visit((UnaExp *)e); }

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -539,6 +539,11 @@ void test_cppmangle()
     mangle = cppThunkMangleItanium(fd, b->offset);
     assert(strcmp(mangle, "_ZThn8_N7Derived7MethodDEv") == 0);
 
+    assert(fd->fbody);
+    auto rs = (*fd->fbody->isCompoundStatement()->statements)[0]->isReturnStatement();
+    assert(rs);
+    assert(!canThrow(rs->exp, fd, false));
+
     assert(!global.endGagging(errors));
 }
 

--- a/test/compilable/extra-files/header1.d
+++ b/test/compilable/extra-files/header1.d
@@ -600,3 +600,9 @@ struct Test14UDA4(string v){}
 void test14x(@Test14UDA1 int, @Test14UDA2("1") int, @test14uda3("2") int, @Test14UDA4!"3" int) {}
 
 void test15x(@(20) void delegate(int) @safe dg){}
+
+T throwStuff(T)(T t)
+{
+    if (false) test13x(1, throw new Exception(""), 2);
+    return t ? t : throw new Exception("Bad stuff happens!");
+}

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -531,3 +531,9 @@ struct Test14UDA4(string v)
 }
 void test14x(@(Test14UDA1) int, @Test14UDA2("1") int, @test14uda3("2") int, @(Test14UDA4!"3") int);
 void test15x(@(20) void delegate(int) @safe dg);
+T throwStuff(T)(T t)
+{
+	if (false)
+		test13x(1, throw new Exception(""), 2);
+	return t ? t : throw new Exception("Bad stuff happens!");
+}

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -685,3 +685,9 @@ void test14x(@(Test14UDA1) int, @Test14UDA2("1") int, @test14uda3("2") int, @(Te
 void test15x(@(20) void delegate(int) @safe dg)
 {
 }
+T throwStuff(T)(T t)
+{
+	if (false)
+		test13x(1, throw new Exception(""), 2);
+	return t ? t : throw new Exception("Bad stuff happens!");
+}

--- a/test/compilable/noreturn1.d
+++ b/test/compilable/noreturn1.d
@@ -20,8 +20,7 @@ static assert(!is(noreturn == void));
 
 static assert(is( typeof(assert(0)) == noreturn ));
 
-// Does not parse yet
-// static assert(is( typeof(throw new Exception()) == noreturn ));
+static assert(is( typeof(throw new Exception("")) == noreturn ));
 
 static assert(is(noreturn == noreturn));
 static assert(!is(noreturn == const noreturn));

--- a/test/fail_compilation/noreturn.d
+++ b/test/fail_compilation/noreturn.d
@@ -16,8 +16,8 @@ fail_compilation\noreturn.d(69): Error: `"Accessed expression of type `noreturn`
 fail_compilation\noreturn.d(79):        called from here: `casting(1)`
 fail_compilation\noreturn.d(72): Error: `"Accessed expression of type `noreturn`"`
 fail_compilation\noreturn.d(80):        called from here: `casting(2)`
+fail_compilation/noreturn.d(120): Error: uncaught CTFE exception `object.Exception("")`
 ---
-
 https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md
 */
 
@@ -116,3 +116,5 @@ int inClassRef()
 
 enum forceInClassRef = inClassRef();
 */
+
+enum throwEnum = throw new Exception("");

--- a/test/fail_compilation/noreturn2.d
+++ b/test/fail_compilation/noreturn2.d
@@ -88,3 +88,54 @@ auto returnVoid3(int i)
     else
         return doStuff();
 }
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/noreturn2.d(104): Error: `object.Exception` is thrown but not caught
+fail_compilation/noreturn2.d(100): Error: `nothrow` function `noreturn2.doesNestedThrow` may throw
+---
++/
+
+int doesNestedThrow(int i) nothrow
+{
+    // Weird formatting is intended to check the loc
+    return i ? i++ :
+            throw
+            new
+            Exception("")
+    ;
+}
+
+int doesNestedThrowThrowable(int i) nothrow
+{
+    return i ? i++ : throw new Error("");
+}
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/noreturn2.d(130): Error: cannot create instance of interface `I`
+fail_compilation/noreturn2.d(133): Error: can only throw class objects derived from `Throwable`, not type `int[]`
+fail_compilation/noreturn2.d(138): Error: undefined identifier `UnkownException`
+---
++/
+
+int throwInvalid(int i) nothrow
+{
+    static interface I {}
+    // Weird formatting is intended to check the loc
+    return
+            throw
+            new
+            I()
+        ?
+            throw
+            new
+            int[4]
+        :
+            throw
+            new
+            UnkownException("")
+    ;
+}

--- a/test/unit/semantic/control_flow.d
+++ b/test/unit/semantic/control_flow.d
@@ -25,6 +25,11 @@ unittest { testStatement(`throw new Exception("");`, BE.throw_); }
 
 unittest { testStatement(`throw new Error("");`, BE.errthrow); }
 
+// ENHANCEMENT: Could detect that this expression always throws
+unittest { testStatement(`false || throw new Exception("");`, BE.throw_ | BE.fallthru); }
+
+unittest { testStatement(`false || throw new Error("");`, BE.errthrow | BE.fallthru); }
+
 unittest { testStatement(`assert(0);`, BE.halt); }
 
 unittest { testStatement(`int i; assert(i);`, BE.fallthru); } // Should this include errthrow?


### PR DESCRIPTION
This PR implements throw expressions (`ThrowExp`) as proposed by [DIP 1034](https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md) by hooking into the existing facilities for `ThrowStatement` (which should be deprecated & removed in the future). It is structured in several commits that first make the currently existing code for `ThrowStatements` reusable / extensible before actually implementing parsing/semantic/... for `ThrowExp`'s.

