### PR TITLE
Fix 21952 - Don't assert for global / tls variables of type noreturn

### DIFF
--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -600,8 +600,13 @@ void toObjFile(Dsymbol ds, bool multiobj)
             } while (parent);
             s.Sfl = FLdata;
 
-            if (!sz && vd.type.toBasetype().ty != Tsarray)
-                assert(0); // this shouldn't be possible
+            // Size 0 should only be possible for T[0] and noreturn
+            if (!sz)
+            {
+                const ty = vd.type.toBasetype().ty;
+                if (ty != Tsarray && ty != Tnoreturn)
+                    assert(0); // this shouldn't be possible
+            }
 
             auto dtb = DtBuilder(0);
             if (config.objfmt == OBJ_MACH && target.is64bit && (s.Stype.Tty & mTYLINK) == mTYthread)

--- a/test/compilable/noreturn1.d
+++ b/test/compilable/noreturn1.d
@@ -85,3 +85,20 @@ int test1(int i)
         return i + 1;
     return i - 1;
 }
+
+noreturn tlsNoreturn;
+__gshared noreturn globalNoreturn;
+
+template CreateTLS(A)
+{
+    A a;
+}
+
+void* useTls()
+{
+    alias Tnr = CreateTLS!noreturn;
+    void* a1 = &Tnr.a;
+    void* a2 = &tlsNoreturn;
+    void* a3 = &globalNoreturn;
+    return a1 < a2 ? a2 : a3;
+}


### PR DESCRIPTION
The old code assumed variables of size 0 must be static arrays `T[0]` but `noreturn.sizeof` is 0.