### PR TITLE
fix Issue 22315 - ImportC: #pragma pack is not implemented

### DIFF
--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -334,7 +334,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         // Round struct size up to next alignsize boundary.
         // This will ensure that arrays of structs will get their internals
         // aligned properly.
-        if (alignment.isDefault())
+        if (alignment.isDefault() || alignment.isPack())
             structsize = (structsize + alignsize - 1) & ~(alignsize - 1);
         else
             structsize = (structsize + alignment.get() - 1) & ~(alignment.get() - 1);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -12966,7 +12966,7 @@ private bool fit(StructDeclaration sd, const ref Loc loc, Scope* sc, Expressions
         const hasPointers = tb.hasPointers();
         if (hasPointers)
         {
-            if ((stype.alignment.get() < target.ptrsize ||
+            if ((!stype.alignment.isDefault() && stype.alignment.get() < target.ptrsize ||
                  (v.offset & (target.ptrsize - 1))) &&
                 (sc.func && sc.func.setUnsafe()))
             {

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1182,6 +1182,7 @@ struct structalign_t final
 {
 private:
     uint32_t value;
+    bool pack;
 public:
     bool isDefault() const;
     void setDefault();
@@ -1189,6 +1190,8 @@ public:
     void setUnknown();
     void set(uint32_t value);
     uint32_t get() const;
+    bool isPack() const;
+    void setPack(bool pack);
     structalign_t()
     {
     }

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -265,15 +265,19 @@ extern (C++) struct structalign_t
 {
   private:
     uint value = 0;  // unknown
+    enum STRUCTALIGN_DEFAULT = ~0;   // default = match whatever the corresponding C compiler does
+    bool pack;         // use #pragma pack semantics
 
   public:
   pure @safe @nogc nothrow:
-    bool isDefault() const { return value == ~0; }
-    void setDefault()      { value = ~0; }   // default = match whatever the corresponding C compiler does
+    bool isDefault() const { return value == STRUCTALIGN_DEFAULT; }
+    void setDefault()      { value = STRUCTALIGN_DEFAULT; }
     bool isUnknown() const { return value == 0; }  // value is not set
     void setUnknown()      { value = 0; }
     void set(uint value)   { this.value = value; }
     uint get() const       { return value; }
+    bool isPack() const    { return pack; }
+    void setPack(bool pack) { this.pack = pack; }
 }
 //alias structalign_t = uint;
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -241,6 +241,7 @@ struct Param
 struct structalign_t
 {
     unsigned value;
+    bool pack;
 
     bool isDefault() const;
     void setDefault();
@@ -248,6 +249,8 @@ struct structalign_t
     void setUnknown();
     void set(unsigned value);
     unsigned get() const;
+    bool isPack() const;
+    void setPack(bool pack);
 };
 
 // magic value means "match whatever the underlying C compiler does"

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -193,7 +193,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
                 // Check for @safe violations
                 if (vd.type.hasPointers)
                 {
-                    if ((t.alignment.get() < target.ptrsize ||
+                    if ((!t.alignment.isDefault() && t.alignment.get() < target.ptrsize ||
                          (vd.offset & (target.ptrsize - 1))) &&
                         sc.func && sc.func.setUnsafe())
                     {

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -2976,6 +2976,7 @@ class Lexer
             if (n < 1 || n & (n - 1) || uint.max < n)
                 error(loc, "pack must be an integer positive power of 2, not 0x%llx", cast(ulong)n);
             packalign.set(cast(uint)n);
+            packalign.setPack(true);
         }
 
         scan(&n);

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -1185,7 +1185,7 @@ private:
             dtb.xoff(Symbols.getIVarOffset(classDeclaration, var, true), 0); // pointer to ivar offset
             dtb.xoff(Symbols.getMethVarName(var.ident), 0); // name
             dtb.xoff(Symbols.getMethVarType(var.type), 0); // type string
-            dtb.dword(var.alignment.get());
+            dtb.dword(var.alignment.isDefault() ? -1 : var.alignment.get());
             dtb.dword(cast(int) var.size(var.loc));
         }
 

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -89,7 +89,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
 
         if (hasPointers && v.type.toBasetype().ty != Tstruct)
         {
-            if ((ad.type.alignment.get() < target.ptrsize ||
+            if ((!ad.type.alignment.isDefault() && ad.type.alignment.get() < target.ptrsize ||
                  (v.offset & (target.ptrsize - 1))) &&
                 sc.func.setUnsafe())
             {

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -162,7 +162,7 @@ Symbol *toSymbol(Dsymbol s)
                 }
             }
             Symbol *s = symbol_calloc(id.ptr, cast(uint)id.length);
-            s.Salignment = vd.alignment.get();
+            s.Salignment = vd.alignment.isDefault() ? -1 : vd.alignment.get();
             if (vd.storage_class & STC.temp)
                 s.Sflags |= SFLartifical;
             if (isNRVO)
@@ -608,7 +608,13 @@ Symbol *toInitializer(AggregateDeclaration ad)
         static structalign_t alignOf(Type t)
         {
             const explicitAlignment = t.alignment();
-            return explicitAlignment.isDefault() ? structalign_t(t.alignsize()) : explicitAlignment;
+            if (!explicitAlignment.isDefault()) // if overriding default alignment
+                return explicitAlignment;
+
+            // Use the default alignment for type t
+            structalign_t sa;
+            sa.set(t.alignsize());
+            return sa;
         }
 
         auto sd = ad.isStructDeclaration();
@@ -633,7 +639,7 @@ Symbol *toInitializer(AggregateDeclaration ad)
             s.Sfl = FLextern;
             s.Sflags |= SFLnodebug;
             if (sd)
-                s.Salignment = sd.alignment.get();
+                s.Salignment = sd.alignment.isDefault() ? -1 : sd.alignment.get();
             ad.sinit = s;
         }
     }

--- a/test/compilable/pragmapack.c
+++ b/test/compilable/pragmapack.c
@@ -18,7 +18,17 @@ struct S2
 };
 #pragma pack(pop)
 
-_Static_assert(sizeof(struct S2) == 8 + 8, "2");
+_Static_assert(sizeof(struct S2) == 1 + 1, "2");
+
+#pragma pack(push, 8)
+struct S3
+{
+    unsigned short u;
+    char a;
+};
+#pragma pack(pop)
+
+_Static_assert(sizeof(struct S3) == 4, "3");
 
 #pragma pack()
 #pragma pack(show)


### PR DESCRIPTION
Getting alignment right is always tricky.

Here we added a `pack` member so the different `#pragma pack` algorithm can be triggered. Kept the `structalign_t` fitting into 4 bytes.

A future refactoring should move more of the alignment logic into structalign_t. But let's wait until it works, first.