### PR TITLE
Fix Issue 22198 - Compile time bounds checking for static arrays

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7993,11 +7993,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         exp.error("in slice `%s[%llu .. %llu]`, lower bound is greater than upper bound", exp.e1.toChars, exp.lwr.toInteger(), exp.upr.toInteger());
                         return setError();
                     }
-                   if (exp.upr.op == TOK.int64 && exp.upr.toInteger() > length)
-                   {
-                       exp.error("in slice `%s[%llu .. %llu]`, upper bound is greater than array length `%llu`", exp.e1.toChars, exp.lwr.toInteger(), exp.upr.toInteger(), length);
-                       return setError();
-                   }
+                    if (exp.upr.op == TOK.int64 && exp.upr.toInteger() > length)
+                    {
+                        exp.error("in slice `%s[%llu .. %llu]`, upper bound is greater than array length `%llu`", exp.e1.toChars, exp.lwr.toInteger(), exp.upr.toInteger(), length);
+                        return setError();
+                    }
                 }
                 else if (exp.upr.op == TOK.int64 && exp.upr.toInteger() == 0)
                 {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7729,6 +7729,27 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             printf("SliceExp::semantic('%s')\n", exp.toChars());
         }
+
+        if (exp.lwr && exp.lwr.op == TOK.negate)
+        {
+            auto ue = cast(UnaExp) exp.lwr;
+            sinteger_t sliceLen = -1 * ue.e1.toInteger();
+            exp.error("slice lower bound %ld should be greater than or equal to 0", sliceLen);
+            return setError();
+        }
+
+        if (exp.upr)
+        {
+            TypeSArray tsa = cast(TypeSArray)exp.e1.type.toBasetype();
+            uinteger_t arrLen = tsa.dim.toInteger();
+            uinteger_t sliceLen = exp.upr.toInteger();
+            if (sliceLen > arrLen)
+            {
+                exp.error("slice upper bound %llu is greater than array length `%s[0 .. %llu]`", sliceLen, exp.e1.toChars(), arrLen);
+                return setError();
+            }
+        }
+
         if (exp.type)
         {
             result = exp;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7730,20 +7730,20 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             printf("SliceExp::semantic('%s')\n", exp.toChars());
         }
 
-        if (exp.lwr && exp.upr)
+        if (exp.e1.type.ty != Tsarray)
         {
-            if (exp.lwr.op == TOK.negate || exp.upr.op == TOK.negate)
-            {
-                exp.error("slice index should be greater than or equal to 0");
-                return setError();
-            }
+            exp.error("trying to slice non-static array %s[]", exp.e1.toChars());
+            return setError();
+        }
 
+        if (exp.lwr && exp.upr && exp.lwr.isIntegerExp() && exp.upr.isIntegerExp())
+        {
             uinteger_t lwrSliceLen = exp.lwr.toInteger();
             uinteger_t uprSliceLen = exp.upr.toInteger();
 
             if (lwrSliceLen > uprSliceLen)
             {
-                exp.error("slice lower bound can't be greater than upper bound");
+                exp.error("slice lower bound %llu can't be greater than upper bound %llu", lwrSliceLen, uprSliceLen);
                 return setError();
             }
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7729,7 +7729,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             printf("SliceExp::semantic('%s')\n", exp.toChars());
         }
-
         if (exp.type)
         {
             result = exp;
@@ -7989,18 +7988,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     dinteger_t length = el.toInteger();
                     auto bounds = IntRange(SignExtendedNumber(0), SignExtendedNumber(length));
                     exp.upperIsInBounds = bounds.contains(uprRange);
-
-                    if (exp.lwr.op == TOK.int64)
+                    if (exp.lwr.op == TOK.int64 && exp.upr.op == TOK.int64 && exp.lwr.toInteger() > exp.upr.toInteger())
                     {
-                       if (exp.upr.op == TOK.int64 && exp.lwr.toInteger() > exp.upr.toInteger())
-                       {
-                           exp.error("in slice `%s[%s...%s]`, lower bound is greater than upper bound", exp.e1.toChars, exp.lwr.toChars, exp.upr.toChars);
-                           return setError();
-                       }
+                        exp.error("in slice `%s[%llu .. %llu]`, lower bound is greater than upper bound", exp.e1.toChars, exp.lwr.toInteger(), exp.upr.toInteger());
+                        return setError();
                     }
                    if (exp.upr.op == TOK.int64 && exp.upr.toInteger() > length)
                    {
-                       exp.error("in slice `%s[%s...%s]`, upper bound is greater than array length `%s`", exp.e1.toChars, exp.lwr.toChars, exp.upr.toChars, el.toChars);
+                       exp.error("in slice `%s[%llu .. %llu]`, upper bound is greater than array length `%llu`", exp.e1.toChars, exp.lwr.toInteger(), exp.upr.toInteger(), length);
                        return setError();
                    }
                 }

--- a/test/fail_compilation/fail20618.d
+++ b/test/fail_compilation/fail20618.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20618.d(13): Error: in slice `a[1LU...12LU]`, upper bound is greater than array length `10LU`
-fail_compilation/fail20618.d(14): Error: in slice `a[18446744073709551615LU...3LU]`, lower bound is greater than upper bound
-fail_compilation/fail20618.d(15): Error: in slice `a[0LU...11LU]`, upper bound is greater than array length `10LU`
+fail_compilation/fail20618.d(13): Error: in slice `a[1 .. 12]`, upper bound is greater than array length `10`
+fail_compilation/fail20618.d(14): Error: in slice `a[4 .. 3]`, lower bound is greater than upper bound
+fail_compilation/fail20618.d(15): Error: in slice `a[0 .. 11]`, upper bound is greater than array length `10`
 ---
 */
 
@@ -11,6 +11,6 @@ void main()
 {
     int[10] a;
     auto b = a[1..12];
-    auto c = a[-1..3];
+    auto c = a[4..3];
     auto d = a[0..$ + 1];
 }

--- a/test/fail_compilation/fail20618.d
+++ b/test/fail_compilation/fail20618.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20618.d(13): Error: in slice `a[1LU...12LU]`, upper bound is greater than array length `10LU`
+fail_compilation/fail20618.d(14): Error: in slice `a[18446744073709551615LU...3LU]`, lower bound is greater than upper bound
+fail_compilation/fail20618.d(15): Error: in slice `a[0LU...11LU]`, upper bound is greater than array length `10LU`
+---
+*/
+
+void main()
+{
+    int[10] a;
+    auto b = a[1..12];
+    auto c = a[-1..3];
+    auto d = a[0..$ + 1];
+}


### PR DESCRIPTION
This PR is aimed to catch bad indexes when slicing an array at compile time, not at runtime as it currently is.