### PR TITLE
Fix 22388 - Don't discard function safety when matching lambdas

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3984,6 +3984,7 @@ extern (C++) final class FuncExp : Expression
             auto tfy = new TypeFunction(tfx.parameterList, tof.next,
                         tfx.linkage, STC.undefined_);
             tfy.mod = tfx.mod;
+            tfy.trust = tfx.trust;
             tfy.isnothrow = tfx.isnothrow;
             tfy.isnogc = tfx.isnogc;
             tfy.purity = tfx.purity;

--- a/test/compilable/test22388.d
+++ b/test/compilable/test22388.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=22388
+
+void setTimer(void delegate()) @system;
+void setTimer(void delegate() @safe) @safe;
+
+void setTimer2(void delegate() @safe) @safe;
+void setTimer2(void delegate()) @system;
+
+void main() @safe
+{
+    setTimer(() => assert(false));
+
+    alias lambda = () => assert(false);
+    setTimer(lambda);
+
+    // Reversed order
+
+    setTimer2(() => assert(false));
+
+    alias lambda2 = () => assert(false);
+    setTimer2(lambda2);
+}


### PR DESCRIPTION
The code intended to copy the `TypeFunction` and change the return
type but also dropped the safety level.

---

That code really belongs into a copy constructor, but that's for another PR.