### PR TITLE
refactor structalign_t

### DIFF
--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -608,7 +608,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
                 if (!b.sym.alignsize)
                     b.sym.alignsize = target.ptrsize;
-                alignmember(structalign_t(b.sym.alignsize), b.sym.alignsize, &offset);
+                alignmember(structalign_t(cast(ushort)b.sym.alignsize), b.sym.alignsize, &offset);
                 assert(bi < vtblInterfaces.dim);
 
                 BaseClass* bv = (*vtblInterfaces)[bi];

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -141,7 +141,7 @@ AlignDeclaration getAlignment(AlignDeclaration ad, Scope* sc)
             if (sc.flags & SCOPE.Cfile && n == 0)       // C11 6.7.5-6 allows 0 for alignment
                 continue;
 
-            if (n < 1 || n & (n - 1) || uint.max < n || !e.type.isintegral())
+            if (n < 1 || n & (n - 1) || ushort.max < n || !e.type.isintegral())
             {
                 error(ad.loc, "alignment must be an integer positive power of 2, not 0x%llx", cast(ulong)n);
                 errors = true;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1181,7 +1181,7 @@ enum class LINK : uint8_t
 struct structalign_t final
 {
 private:
-    uint32_t value;
+    uint16_t value;
     bool pack;
 public:
     bool isDefault() const;

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -264,8 +264,8 @@ extern (C++) struct Param
 extern (C++) struct structalign_t
 {
   private:
-    uint value = 0;  // unknown
-    enum STRUCTALIGN_DEFAULT = ~0;   // default = match whatever the corresponding C compiler does
+    ushort value = 0;  // unknown
+    enum STRUCTALIGN_DEFAULT = 1234;   // default = match whatever the corresponding C compiler does
     bool pack;         // use #pragma pack semantics
 
   public:
@@ -274,7 +274,7 @@ extern (C++) struct structalign_t
     void setDefault()      { value = STRUCTALIGN_DEFAULT; }
     bool isUnknown() const { return value == 0; }  // value is not set
     void setUnknown()      { value = 0; }
-    void set(uint value)   { this.value = value; }
+    void set(uint value)   { this.value = cast(ushort)value; }
     uint get() const       { return value; }
     bool isPack() const    { return pack; }
     void setPack(bool pack) { this.pack = pack; }

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -240,7 +240,7 @@ struct Param
 
 struct structalign_t
 {
-    unsigned value;
+    unsigned short value;
     bool pack;
 
     bool isDefault() const;

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -2973,7 +2973,7 @@ class Lexer
         void setPackAlign(ref const Token t)
         {
             const n = t.unsvalue;
-            if (n < 1 || n & (n - 1) || uint.max < n)
+            if (n < 1 || n & (n - 1) || ushort.max < n)
                 error(loc, "pack must be an integer positive power of 2, not 0x%llx", cast(ulong)n);
             packalign.set(cast(uint)n);
             packalign.setPack(true);
@@ -2991,7 +2991,10 @@ class Lexer
          */
         if (n.value == TOK.identifier && n.ident == Id.show)
         {
-            warning(startloc, "current pack attribute is %d", packalign.get());
+            if (packalign.isDefault())
+                warning(startloc, "current pack attribute is default");
+            else
+                warning(startloc, "current pack attribute is %d", packalign.get());
             scan(&n);
             return closingParen();
         }

--- a/test/compilable/test9766.d
+++ b/test/compilable/test9766.d
@@ -69,9 +69,9 @@ static assert(U9766.var4.offsetof == 40);
 
 struct TestMaxAlign
 {
-align(1u << 31):
+align(1u << 15):
     ubyte a;
     ubyte b;
 }
 
-static assert(TestMaxAlign.b.offsetof == 2147483648u);
+static assert(TestMaxAlign.b.offsetof == (1 << 15));

--- a/test/fail_compilation/pragma2.c
+++ b/test/fail_compilation/pragma2.c
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -w
 TEST_OUTPUT:
 ---
-fail_compilation/pragma2.c(11): Warning: current pack attribute is -1
+fail_compilation/pragma2.c(11): Warning: current pack attribute is default
 fail_compilation/pragma2.c(14): Error: unrecognized `#pragma pack(&)`
 fail_compilation/pragma2.c(13): Error: right parenthesis expected to close `#pragma pack(`
 fail_compilation/pragma2.c(12): Error: left parenthesis expected to follow `#pragma pack`


### PR DESCRIPTION
Address some of my unhappiness with structalign_t. For one thing, the hidden dependencies on the value of STRUCTALIGN_DEFAULT.