### PR TITLE
Fix Issue 21794 - ICE: Assertion hit in dinterpret.d

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -42,6 +42,7 @@ import dmd.mtype;
 import dmd.printast;
 import dmd.root.rmem;
 import dmd.root.array;
+import dmd.root.ctfloat;
 import dmd.root.region;
 import dmd.root.rootobject;
 import dmd.statement;
@@ -6017,9 +6018,20 @@ public:
         }
         if (e.to.ty == Tsarray)
             e1 = resolveSlice(e1);
-        if (e.to.toBasetype().ty == Tbool && e1.type.ty == Tpointer)
+
+        auto tobt = e.to.toBasetype();
+        if (tobt.ty == Tbool && e1.type.ty == Tpointer)
         {
             emplaceExp!(IntegerExp)(pue, e.loc, e1.op != TOK.null_, e.to);
+            result = pue.exp();
+            return;
+        }
+        else if (tobt.isTypeBasic() && e1.op == TOK.null_)
+        {
+            if (tobt.isintegral())
+                emplaceExp!(IntegerExp)(pue, e.loc, 0, e.to);
+            else if (tobt.isreal())
+                emplaceExp!(RealExp)(pue, e.loc, CTFloat.zero, e.to);
             result = pue.exp();
             return;
         }

--- a/test/compilable/test21794.d
+++ b/test/compilable/test21794.d
@@ -1,0 +1,52 @@
+// https://issues.dlang.org/show_bug.cgi?id=21794
+/*
+TEST_OUTPUT:
+---
+0
+0u
+0L
+0LU
+0.0F
+0.0
+0.0L
+---
+*/
+
+bool fun(void* p) {
+    const x = cast(ulong)p;
+    return 1;
+}
+
+static assert(fun(null));
+
+T fun2(T)(void* p) {
+    const x = cast(T)p;
+    return x;
+}
+
+// These were an error before, they were returning a NullExp instead of IntegerExp/RealExp
+
+static assert(fun2!int(null)    == 0);
+static assert(fun2!uint(null)   == 0);
+static assert(fun2!long(null)   == 0);
+static assert(fun2!ulong(null)  == 0);
+static assert(fun2!float(null)  == 0);
+static assert(fun2!double(null) == 0);
+static assert(fun2!real(null)   == 0);
+
+// These were printing 'null' instead of the corresponding number
+
+const i = cast(int)null;
+const ui = cast(uint)null;
+const l = cast(long)null;
+const ul = cast(ulong)null;
+const f = cast(float)null;
+const d = cast(double)null;
+const r = cast(real)null;
+pragma(msg, i);
+pragma(msg, ui);
+pragma(msg, l);
+pragma(msg, ul);
+pragma(msg, f);
+pragma(msg, d);
+pragma(msg, r);


### PR DESCRIPTION
When casting `null` to integer/real instead of painting the type on the NullExp, we emplace an `IntegerExp/RealExp` with value zero like when casting from `NullExp` to `bool`.