### PR TITLE
Fix 22389 - Check that noreturn functions don't return normally

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -777,8 +777,14 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     }
                     assert(!funcdecl.returnLabel);
                 }
-                else if (f.next.ty == Tnoreturn)
+                else if (f.next.toBasetype().ty == Tnoreturn)
                 {
+                    // Fallthrough despite being declared as noreturn? return is already rejected when evaluating the ReturnStatement
+                    if (blockexit & BE.fallthru)
+                    {
+                        funcdecl.error("is typed as `%s` but does return", f.next.toChars());
+                        funcdecl.loc.errorSupplemental("`noreturn` functions must either throw, abort or loop indefinitely");
+                    }
                 }
                 else
                 {

--- a/test/compilable/dtoh_ignored.d
+++ b/test/compilable/dtoh_ignored.d
@@ -144,4 +144,7 @@ __gshared void function(ifloat) onVariableFunctionParam;
 
 __gshared ifloat delegate() onVariableDelegate;
 
-noreturn myExit() {}
+noreturn myExit()
+{
+    assert(false);
+}

--- a/test/compilable/noreturn1.d
+++ b/test/compilable/noreturn1.d
@@ -50,7 +50,11 @@ static assert((noreturn*).sizeof == (int*).sizeof);
 static assert((noreturn[]).sizeof == (int[]).sizeof);
 
 version (DigitalMars)
-    noreturn exits(int* p) { *p = 3; }
+    noreturn exits(int* p)
+    {
+        *p = 3;
+        assert(false); // *p could be valid
+    }
 
 noreturn exit();
 

--- a/test/fail_compilation/noreturn.d
+++ b/test/fail_compilation/noreturn.d
@@ -72,7 +72,7 @@ noreturn casting(int i)
             return cast() n;
         }
     }
-
+    assert(false);
 }
 
 enum forceCasting0 = casting(0);

--- a/test/fail_compilation/noreturn2.d
+++ b/test/fail_compilation/noreturn2.d
@@ -36,3 +36,30 @@ auto missmatch(int i)
     if (i > 0)
         return "";
 }
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/noreturn2.d(50): Error: function `noreturn2.returns` is typed as `NR` but does return
+fail_compilation/noreturn2.d(50):        `noreturn` functions must either throw, abort or loop indefinitely
+---
++/
+
+enum NR : noreturn;
+
+NR returns()
+{
+    // Fallthrough despite noreturn
+}
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/noreturn2.d(64): Error: cannot implicitly convert expression `1` of type `int` to `noreturn`
+---
++/
+
+noreturn returnsValue()
+{
+    return 1;
+}


### PR DESCRIPTION
Such functions are malformed and hence could cause undefined behavior
at the call site.