### PR TITLE
Fix 21950: Rewrite function calls depending on noreturn arguments 

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5114,6 +5114,13 @@ elem *callfunc(const ref Loc loc,
                                            // (TYnpfunc, TYjfunc, TYfpfunc, TYf16func)
     elem* ep = null;
     const op = fd ? intrinsic_op(fd) : NotIntrinsic;
+
+    // Check for noreturn expression pretending to yield function/delegate pointers
+    if (tybasic(ec.Ety) == TYnoreturn)
+    {
+        // Discard unreachable argument evaluation + function call
+        return ec;
+    }
     if (arguments && arguments.dim)
     {
         if (op == OPvector)
@@ -5135,6 +5142,8 @@ elem *callfunc(const ref Loc loc,
                   ? elems_array.ptr
                   : cast(elem**)Mem.check(malloc(arguments.dim * (elem*).sizeof));
         elem*[] elems = pe[0 .. n];
+        scope (exit) if (elems.ptr != elems_array.ptr)
+            free(elems.ptr);
 
         /* Fill elems[] with arguments converted to elems
          */
@@ -5227,6 +5236,15 @@ elem *callfunc(const ref Loc loc,
             }
 
             elems[i] = ea;
+
+            // Passing an expression of noreturn, meaning that the argument
+            // evaluation will throw / abort / loop indefinetly. Hence skip the
+            // call and only evaluate up to the current argument
+            if (tybasic(ea.Ety) == TYnoreturn)
+            {
+                return el_combines(cast(void**) elems.ptr, cast(int) i + 1);
+            }
+
         }
         if (!left_to_right)
         {
@@ -5242,9 +5260,6 @@ elem *callfunc(const ref Loc loc,
             reverse(elems);
 
         ep = el_params(cast(void**)elems.ptr, cast(int)n);
-
-        if (elems.ptr != elems_array.ptr)
-            free(elems.ptr);
     }
 
     objc.setupMethodSelector(fd, &esel);

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -4766,6 +4766,7 @@ Expression defaultInit(Type mt, const ref Loc loc)
         }
         auto cond = IntegerExp.createBool(false);
         auto msg = new StringExp(loc, "Accessed expression of type `noreturn`");
+        msg.type = Type.tstring;
         auto ae = new AssertExp(loc, cond, msg);
         ae.type = mt;
         return ae;

--- a/test/runnable/noreturn2.d
+++ b/test/runnable/noreturn2.d
@@ -1,0 +1,220 @@
+/*
+PERMUTE_ARGS: -O -inline
+RUN_OUTPUT:
+---
+getAndPrintS
+---
+*/
+
+import core.stdc.stdio;
+import core.exception : AssertError;
+
+/*****************************************/
+
+// noreturn is inferred for functions that always throw
+// The code must not strip the destructor when calling a noreturn function
+
+struct WithDtor
+{
+    __gshared int destroyed;
+
+    int num;
+
+    int acceptNoreturn(int a, int b, int c)
+    {
+        puts("unreachable");
+        return num + a + b + c;
+    }
+
+    ~this()
+    {
+        destroyed += num;
+    }
+}
+
+noreturn doesThrow()
+{
+    WithDtor wd = WithDtor(1);
+    throw new Exception("");
+}
+
+noreturn callDoesThrow()
+{
+    WithDtor wd = WithDtor(2);
+    doesThrow();
+}
+
+
+void testDtors()
+{
+    try
+    {
+        callDoesThrow();
+        assert(0);
+    } catch (Exception e) {}
+
+    assert(WithDtor.destroyed == 3);
+}
+
+/*****************************************************************************/
+
+/// Verifies that `func` throws a `Throwable` with `message` at `line`
+void testAssertFailure(size_t expLine, string expMsg, void function() func, size_t callLine = __LINE__)
+{
+    void enforce(bool check, string error)
+    {
+        if (!check)
+            throw new AssertError(error, __FILE__, callLine);
+    }
+
+    bool caught;
+    try
+    {
+        func();
+    }
+    catch (Throwable t)
+    {
+        // Save members because t might be overwritten by an Assertion failure below
+        string actFile = t.file;
+        size_t actLine = t.line;
+        string actMsg = t.msg;
+        caught = true;
+
+        scope (failure)
+        {
+            printf("\nfile = \"%.*s\"\nline = %zu\nmsg = \"%.*s\"\n\n",
+                cast(int) actFile.length, actFile.ptr,
+                actLine,
+                cast(int) actMsg.length, actMsg.ptr
+            );
+            fflush(stdout);
+        }
+
+        enforce(actFile == __FILE__, "Wrong file");
+        enforce(actLine == expLine, "Wrong line");
+        enforce(actMsg == expMsg, "Wrong message");
+    }
+
+    enforce(caught, "No Throwable was thrown!");
+}
+
+void testAccess()
+{
+    enum msg = "Accessed expression of type `noreturn`";
+
+    // FIXME: Another assertion failure in the backend trying to generate noreturn.sizeof = 0 byte assignment
+    version (FIXME)
+    testAssertFailure(__LINE__ + 3, msg, function noreturn()
+    {
+        noreturn a;
+        noreturn b = a;
+    });
+
+    if (false) // read does not assert!
+    testAssertFailure(__LINE__ + 3, msg, function noreturn()
+    {
+        noreturn a;
+        int b = a;
+        assert(false, "Unreachable!"); // Statement above not detected as noreturn
+    });
+
+    testAssertFailure(__LINE__ + 2, msg, function noreturn()
+    {
+        cast(noreturn) 1;
+    });
+
+    version (FIXME)
+    testAssertFailure(__LINE__ + 3, msg, function noreturn()
+    {
+        noreturn a;
+        noreturn b = cast(noreturn) 1;
+    });
+
+    if (false) // Read does not assert
+    testAssertFailure(__LINE__ + 3, msg, function noreturn()
+    {
+        noreturn a;
+        return a;
+    });
+
+    if (false) // Read does not assert
+    testAssertFailure(__LINE__ + 4, msg, function noreturn()
+    {
+        static void foo(noreturn) {}
+        noreturn a;
+        foo(a);
+        assert(false, "Unreachable!"); // Ditto
+    });
+}
+
+/*****************************************/
+
+void testFuncCall()
+{
+    enum msg = "Called abort()";
+    enum line = __LINE__ + 1;
+    static noreturn abort() { assert(0, msg); }
+
+    // Canaries to check for side effects
+    __gshared int countLeft, countRight;
+
+    scope (failure) printf("countLeft = %d\ncountRight = %d\n", countLeft, countRight);
+
+
+    // D function arguments are evaluated left to right
+    testAssertFailure(line, msg, function()
+    {
+        static void acceptNoreturnD(int, int, int) { puts("unreachable"); }
+
+        acceptNoreturnD(countLeft++, abort(), countRight++);
+    });
+
+    assert(countLeft == 1);
+    assert(countRight == 0);
+
+//     // C function arguments are still evaluated left to right
+//     // Despite them being push in reverse order
+    testAssertFailure(line, msg, function()
+    {
+        static extern(C) void acceptNoreturnC(int, int, int) { puts("unreachable"); }
+
+        acceptNoreturnC(countLeft++, abort(), countRight++);
+
+        assert(false);
+    });
+
+    assert(countLeft == 2);
+    assert(countRight == 0);
+
+    WithDtor.destroyed = 0;
+
+    testAssertFailure(__LINE__ + 2, "Error", function()
+    {
+        static WithDtor getS() { assert(false, "Error"); }
+
+        getS().acceptNoreturn(countLeft++, abort(), countRight++);
+    });
+
+    assert(countLeft == 2); // No changes
+    assert(countRight == 0);
+    assert(WithDtor.destroyed == 0); // No temporary to destruct
+
+    testAssertFailure(line, msg, function()
+    {
+        static WithDtor getAndPrintS() { puts("getAndPrintS"); return WithDtor(1); }
+
+        getAndPrintS().acceptNoreturn(countLeft++, abort(), countRight++);
+    });
+
+    assert(countLeft == 3);
+    assert(countRight == 0);
+    assert(WithDtor.destroyed == 1);
+}
+
+int main()
+{
+    testDtors();
+    testAccess();
+    testFuncCall();
+    return 0;
+}


### PR DESCRIPTION
Replaces the function call with the evaluation of the arguments up to
the first `noreturn` parameter. The remaining arguments / the function
call will never be executed anyways and the backend cannot handle
`noreturn` parameters.

---

Also added a bunch of test not strictly related to this change. Some of them are currently disabled because they require further changes - but I think it's worthwhile to upstream them as is.