### PR TITLE
fix Issue 22402 - importC: Error: can't subtract '__tag2[1]' from pointer

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -10130,6 +10130,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         /* ImportC: convert arrays to pointers, functions to pointers to functions
          */
         exp.e1 = exp.e1.arrayFuncConv(sc);
+        exp.e2 = exp.e2.arrayFuncConv(sc);
 
         Type t1 = exp.e1.type.toBasetype();
         Type t2 = exp.e2.type.toBasetype();

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -491,6 +491,34 @@ const S22400_t C22400[1] = { {12} };
 const struct S22400b C22400b = {C22400};
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22402
+
+typedef struct {
+    short c;
+} S22402a;
+
+typedef struct {
+    S22402a *a;
+    S22402a b[1];
+} S22402b;
+
+int test22402a(S22402a *a, S22402a b[1])
+{
+    return a - b;
+}
+
+int test22402b(S22402b *s)
+{
+    return s->a - s->b;
+}
+
+int test22402c(S22402a *a)
+{
+    S22402a b[1];
+    return a - b;
+}
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22405
 
 struct S22405


### PR DESCRIPTION
The left hand side in `e1 - e2` got array to pointer conversion, but not the right hand side.