### PR TITLE
fix Issue 22407 - importC: Error: cannot implicitly convert expression of type 'extern (C) int(int a)' to 'const(extern (C) int function(int))'

### DIFF
--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -31,6 +31,7 @@ import dmd.func;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
+import dmd.importc;
 import dmd.init;
 import dmd.mtype;
 import dmd.opover;
@@ -398,6 +399,13 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
         if (i.exp.op == TOK.error)
             return err();
         uint olderrors = global.errors;
+
+        /* ImportC: convert arrays to pointers, functions to pointers to functions
+         */
+        Type tb = t.toBasetype();
+        if (tb.isTypePointer())
+            i.exp = i.exp.arrayFuncConv(sc);
+
         /* Save the expression before ctfe
          * Otherwise the error message would contain for example "&[0][0]" instead of "new int"
          * Regression: https://issues.dlang.org/show_bug.cgi?id=21687
@@ -451,7 +459,6 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
             i.exp.error("cannot use non-constant CTFE pointer in an initializer `%s`", currExp.toChars());
             return err();
         }
-        Type tb = t.toBasetype();
         Type ti = i.exp.type.toBasetype();
         if (i.exp.op == TOK.tuple && i.expandTuples && !i.exp.implicitConvTo(t))
         {

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -473,6 +473,15 @@ int test22406(int a)
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22407
+
+typedef int (*T22407) (int a);
+
+int test22407(int a);
+
+T22407 table22407[1] = { test22407 };
+
+/***************************************************/
 
 int test(char *dest)
 {

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -459,6 +459,22 @@ static const S22375 s22375[10] =
 };
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22400
+
+typedef struct S22400
+{
+    unsigned short f1;
+} S22400_t;
+
+struct S22400b
+{
+    const S22400_t *f1;
+};
+
+const S22400_t C22400[1] = { {12} };
+const struct S22400b C22400b = {C22400};
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22406
 
 int test22406(int a)

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -459,6 +459,22 @@ static const S22375 s22375[10] =
 };
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22399
+
+struct S22399a
+{
+    unsigned short f1;
+};
+
+struct S22399b
+{
+    const struct S22399a *f1;
+};
+
+const struct S22399a C22399[1] = { {12} };
+const struct S22399b C22399b = {C22399};
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22400
 
 typedef struct S22400


### PR DESCRIPTION
If an initializer is an array or function symbol, and the target object is a pointer, then C11 6.3.2.1-4 conversion rules apply.