### PR TITLE
fix Issue 22409 - importC: [ICE] Error: struct no size because of forward reference

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2137,6 +2137,15 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                      * struct S { int a; } *s;
                      */
                     sd.members = mtype.members;
+                    if (sd.semanticRun == PASS.semanticdone)
+                    {
+                        /* The first semantic pass marked `sd` as an opaque struct.
+                         * Re-run semantic so that all newly assigned members are
+                         * picked up and added to the symtab.
+                         */
+                        sd.semanticRun = PASS.semantic;
+                        sd.dsymbolSemantic(sc);
+                    }
                 }
                 else
                 {

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -514,6 +514,16 @@ int test22407(int a);
 T22407 table22407[1] = { test22407 };
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22409
+
+struct S22409;
+
+typedef struct S22409
+{
+    int f1;
+} S22409_t;
+
+/***************************************************/
 
 int test(char *dest)
 {


### PR DESCRIPTION
Because struct declarations are merged in importC, I don't see a better way except for reverting the semanticRun value.  All semantic initialization of StructDeclaration is guarded by `PASS.init`, as a struct's semantic is expected to be recursively called in normal D code.  So there's no harm in doing this here.