### PR TITLE
fix Issue 22403 - importC: Error: cannot pass argument '0' of type 'int' to parameter 'const(char)*'

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4775,7 +4775,12 @@ extern (C++) final class TypeFunction : TypeNext
                             }
                         }
                         else
-                            m = arg.implicitConvTo(tprm);
+                        {
+                            import dmd.dcast : cimplicitConvTo;
+                            m = (sc && sc.flags & SCOPE.Cfile)
+                                ? arg.cimplicitConvTo(tprm)
+                                : arg.implicitConvTo(tprm);
+                        }
                     }
                     //printf("match %d\n", m);
                 }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4777,9 +4777,7 @@ extern (C++) final class TypeFunction : TypeNext
                         else
                         {
                             import dmd.dcast : cimplicitConvTo;
-                            m = (sc && sc.flags & SCOPE.Cfile)
-                                ? arg.cimplicitConvTo(tprm)
-                                : arg.implicitConvTo(tprm);
+                            m = (sc && sc.flags & SCOPE.Cfile) ? arg.cimplicitConvTo(tprm) : arg.implicitConvTo(tprm);
                         }
                     }
                     //printf("match %d\n", m);

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -519,6 +519,16 @@ int test22402c(S22402a *a)
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22403
+
+extern unsigned test22403a(const char *p);
+
+void test22403()
+{
+    test22403a(0);
+}
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22405
 
 struct S22405

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -529,6 +529,21 @@ void test22403()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22404
+
+typedef enum
+{
+    E22404_FLAG
+} E22404;
+
+int test22404a(E22404 e);
+
+int test22404()
+{
+    test22404a(E22404_FLAG);
+}
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22405
 
 struct S22405


### PR DESCRIPTION
Use C rules for argument passing.  Logic is the same as `implicitCastTo.visit(Expression)`.