### PR TITLE
fix Issue 22411 - importC: Error: cannot implicitly convert expression of type 'const(char*)' to 'char*'

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1500,12 +1500,8 @@ MATCH cimplicitConvTo(Expression e, Type t)
         return MATCH.convert;
     if (tb.isintegral() && typeb.ty == Tpointer) // C11 6.3.2.3-6
         return MATCH.convert;
-    if (tb.ty == Tpointer && typeb.ty == Tpointer)
-    {
-        if (tb.isTypePointer().next.ty == Tvoid ||
-            typeb.isTypePointer().next.ty == Tvoid)
-            return MATCH.convert;       // convert to/from void* C11 6.3.2.3-1
-    }
+    if (tb.ty == Tpointer && typeb.ty == Tpointer) // C11 6.3.2.3-7
+        return MATCH.convert;
 
     return implicitConvTo(e, t);
 }

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -591,6 +591,32 @@ typedef struct S22409
 } S22409_t;
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22411
+
+extern char * const var22411[10];
+
+void test22411()
+{
+    char *cptr;
+    int *iptr;
+    float *fptr;
+    struct { int f1; int f2; } *sptr;
+    void (*fnptr)(void);
+
+    cptr = var22411[0];
+    iptr = var22411[1];
+    fptr = var22411[2];
+    sptr = var22411[3];
+    fnptr = var22411[4];
+
+    iptr = cptr;
+    fptr = sptr;
+    fnptr = iptr;
+    cptr = fptr;
+    sptr = fnptr;
+}
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22413
 
 int test22413(void)


### PR DESCRIPTION
GCC complains about discarding qualifiers in the `const char*` case, but otherwise it is completely valid.