### PR TITLE
fix Issue 22406 - importC: Error: 'switch' statement without a 'default'; use 'final switch' or add 'default: assert(0);' or add 'default: break;'

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2727,7 +2727,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 needswitcherror = true;
         }
 
-        if (!sc.sw.sdefault && (!ss.isFinal || needswitcherror || global.params.useAssert == CHECKENABLE.on))
+        if (!sc.sw.sdefault && !(sc.flags & SCOPE.Cfile) &&
+            (!ss.isFinal || needswitcherror || global.params.useAssert == CHECKENABLE.on))
         {
             ss.hasNoDefault = 1;
 

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -459,6 +459,20 @@ static const S22375 s22375[10] =
 };
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22406
+
+int test22406(int a)
+{
+  switch (a)
+  {
+      case 1: return -1;
+      case 2: return -2;
+      case 3: return -3;
+  }
+  return 0;
+}
+
+/***************************************************/
 
 int test(char *dest)
 {


### PR DESCRIPTION
Don't generate a default case for importC code.