### PR TITLE
Fix Issue 21438 - Compiler segfault on static array in a struct at CTFE

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -6311,7 +6311,7 @@ public:
             auto tsa = cast(TypeSArray)v.type;
             auto len = cast(size_t)tsa.dim.toInteger();
             UnionExp ue = void;
-            result = createBlockDuplicatedArrayLiteral(&ue, ex.loc, v.type, ex, len);
+            result = createBlockDuplicatedArrayLiteral(&ue, e.loc, v.type, result, len);
             if (result == ue.exp())
                 result = ue.copy();
             (*se.elements)[i] = result;

--- a/test/compilable/test21438.d
+++ b/test/compilable/test21438.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=21438
+
+int genGBPLookup() {
+    static struct Table {
+        int[1] entries;
+    }
+
+    auto table = new Table;
+    auto x = table.entries[0];
+
+    static assert(is(typeof(x) == int));
+    return 0;
+}
+
+enum x = genGBPLookup;


### PR DESCRIPTION
Regression caused by [commit](https://github.com/dlang/dmd/pull/4227/commits/60fa9e5021c205572f9b8ae33916a4278d54351e#diff-724d64049415cc284ecd12ef23ec5b94b8eed6d3d050cabc3dde1e881a3620a6L6048-R5903).

Possibly a copy paste error, `ex` instead of `result`.