### PR TITLE
fix Issue 22413 - importC: Error: array index 0 is out of bounds

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -983,6 +983,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         ei = new ExpInitializer(dsym._init.loc, e);
                         dsym._init = ei;
                     }
+                    else if (sc.flags & SCOPE.Cfile && dsym.type.isTypeSArray() &&
+                             dsym.type.isTypeSArray().isIncomplete())
+                    {
+                        // C11 6.7.9-22 determine the size of the incomplete array,
+                        // or issue an error that the initializer is invalid.
+                        dsym._init = dsym._init.initializerSemantic(sc, dsym.type, INITinterpret);
+                    }
 
                     Expression exp = ei.exp;
                     Expression e1 = new VarExp(dsym.loc, dsym);

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -377,7 +377,7 @@ typedef struct S22182 { int x; } S22182;
 
 int test22182b(S22182* b)
 {
-  return ((S22182*)(b))->x;
+    return ((S22182*)(b))->x;
 }
 
 /***************************************************/
@@ -404,14 +404,14 @@ int test22245()
 
 void test22262(unsigned char *buf)
 {
-  if (buf == 0)
-    return;
-  if (0 == buf)
-    return;
-  if (buf == 1)
-    return;
-  if (2 == buf)
-    return;
+    if (buf == 0)
+        return;
+    if (0 == buf)
+        return;
+    if (buf == 1)
+        return;
+    if (2 == buf)
+        return;
 }
 
 /***************************************************/
@@ -495,13 +495,13 @@ const struct S22400b C22400b = {C22400};
 
 int test22406(int a)
 {
-  switch (a)
-  {
-      case 1: return -1;
-      case 2: return -2;
-      case 3: return -3;
-  }
-  return 0;
+    switch (a)
+    {
+        case 1: return -1;
+        case 2: return -2;
+        case 3: return -3;
+    }
+    return 0;
 }
 
 /***************************************************/
@@ -522,6 +522,15 @@ typedef struct S22409
 {
     int f1;
 } S22409_t;
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22413
+
+int test22413(void)
+{
+    char msg[] = "ok";
+    return msg[0] | msg[1];
+}
 
 /***************************************************/
 

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -30,6 +30,8 @@ fail_compilation/failcstuff2.c(205): Error: variable `var` is used as a type
 fail_compilation/failcstuff2.c(203):        variable `var` is declared here
 fail_compilation/failcstuff2.c(254): Error: identifier or `(` expected before `)`
 fail_compilation/failcstuff2.c(255): Error: identifier or `(` expected
+fail_compilation/failcstuff2.c(354): Error: variable `arr` cannot be read at compile time
+fail_compilation/failcstuff2.c(360): Error: variable `str` cannot be read at compile time
 ---
 */
 
@@ -109,6 +111,22 @@ void test22102()
 {
     int22102();
     int22102(0);
+}
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22413
+#line 350
+
+void test22413a()
+{
+    int arr[6] = {1,2,3,4,5,6};
+    int arr2[] = arr;
+}
+
+void test22413b()
+{
+    const char *str = "hello";
+    char msg[] = str;
 }
 
 /***************************************************/


### PR DESCRIPTION
initializerSemantic completes the array type of the var declaration, but this wasn't being ran for locals.