### PR TITLE
fix Issue 22405 - importC: Error: cannot modify 'const' expression '(*s).field'

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -3145,6 +3145,11 @@ final class CParser(AST) : Parser!AST
         Specifier specifier;
         specifier.packalign = this.packalign;
         auto tspec = cparseSpecifierQualifierList(LVL.member, specifier);
+        if (tspec && specifier.mod & MOD.xconst)
+        {
+            tspec = toConst(tspec);
+            specifier.mod = MOD.xnone;          // 'used' it
+        }
 
         /* If a declarator does not follow, it is unnamed
          */
@@ -3217,9 +3222,6 @@ final class CParser(AST) : Parser!AST
                 nextToken();
                 width = cparseConstantExp();
             }
-
-            if (specifier.mod & MOD.xconst)
-                dt = toConst(dt);
 
             /* GNU Extensions
              * struct-declarator:

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -491,6 +491,20 @@ const S22400_t C22400[1] = { {12} };
 const struct S22400b C22400b = {C22400};
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22405
+
+struct S22405
+{
+    int const * p;
+    int *q;
+};
+
+void test22405(struct S22405 *s)
+{
+    s->p = (const int *)(s->q);
+}
+
+/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22406
 
 int test22406(int a)

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -30,6 +30,7 @@ fail_compilation/failcstuff2.c(205): Error: variable `var` is used as a type
 fail_compilation/failcstuff2.c(203):        variable `var` is declared here
 fail_compilation/failcstuff2.c(254): Error: identifier or `(` expected before `)`
 fail_compilation/failcstuff2.c(255): Error: identifier or `(` expected
+fail_compilation/failcstuff2.c(308): Error: cannot modify `const` expression `(*s).p`
 fail_compilation/failcstuff2.c(354): Error: variable `arr` cannot be read at compile time
 fail_compilation/failcstuff2.c(360): Error: variable `str` cannot be read at compile time
 ---
@@ -111,6 +112,20 @@ void test22102()
 {
     int22102();
     int22102(0);
+}
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22405
+#line 300
+struct S22405
+{
+    int * const p;
+    int *q;
+};
+
+void test22405(struct S22405 *s)
+{
+    s->p = (const int *)(s->q);
 }
 
 /***************************************************/


### PR DESCRIPTION
`MOD.xconst` is already handled by `cparseDeclarator`, calling `toConst` after it is redundant for the `T * const` case.
For the `T const *` case however, this constructs the field type as `const(T*)` instead of `const(T)*`.

The fix is to move it to immediately after `cparseSpecifierQualifierList`.  This mirrors same logic as `cparseDeclaration` and `cparseParameterList`.