### PR TITLE
Improve error message for 'out' on foreach

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -5411,6 +5411,11 @@ class Parser(AST) : Lexer
                     stc = STC.scope_;
                     goto Lagain;
 
+                case TOK.out_:
+                    error("cannot declare `out` loop variable, use `ref` instead");
+                    stc = STC.out_;
+                    goto Lagain;
+
                 case TOK.enum_:
                     stc = STC.manifest;
                     goto Lagain;

--- a/test/fail_compilation/foreach.d
+++ b/test/fail_compilation/foreach.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/foreach.d(12): Error: cannot declare `out` loop variable, use `ref` instead
+fail_compilation/foreach.d(13): Error: cannot declare `out` loop variable, use `ref` instead
+fail_compilation/foreach.d(13): Error: cannot declare `out` loop variable, use `ref` instead
+---
+*/
+void main ()
+{
+    int[] array;
+    foreach (out val; array) {}
+    foreach (out idx, out val; array) {}
+}


### PR DESCRIPTION
This hopefully will provide a slightly better user experience,
as many other storage classes are accepted.

Before, the following error message was printed by DMD:
```
test/fail_compilation/foreach.d(12): Error: basic type expected, not `out`
test/fail_compilation/foreach.d(12): Error: no identifier for declarator `_error_`
test/fail_compilation/foreach.d(12): Error: found `out` when expecting `;`
test/fail_compilation/foreach.d(12): Error: found `;` when expecting `)`
test/fail_compilation/foreach.d(12): Error: found `)` when expecting `;` following statement
test/fail_compilation/foreach.d(13): Error: basic type expected, not `out`
test/fail_compilation/foreach.d(13): Error: no identifier for declarator `_error_`
test/fail_compilation/foreach.d(13): Error: found `out` when expecting `;`
test/fail_compilation/foreach.d(13): Error: expression expected, not `out`
test/fail_compilation/foreach.d(13): Error: found `val` when expecting `)`
test/fail_compilation/foreach.d(13): Error: use `{ }` for an empty statement, not `;`
test/fail_compilation/foreach.d(13): Error: found `)` when expecting `;` following statement
```