### PR TITLE
Fix 22419 - Allow inferred return type for main

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2594,7 +2594,8 @@ extern (C++) class FuncDeclaration : Declaration
         }
 
         if (!tf.nextOf())
-            error("must return `int`, `void` or `noreturn`");
+            // auto main(), check after semantic
+            assert(this.inferRetType);
         else if (tf.nextOf().ty != Tint32 && tf.nextOf().ty != Tvoid && tf.nextOf().ty != Tnoreturn)
             error("must return `int`, `void` or `noreturn`, not `%s`", tf.nextOf().toChars());
         else if (tf.parameterList.varargs || nparams >= 2 || argerr)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -599,7 +599,10 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         f.next = Type.tvoid;
                     if (f.checkRetType(funcdecl.loc))
                         funcdecl.fbody = new ErrorStatement();
+                    else if (funcdecl.isMain())
+                        funcdecl.checkDmain();       // Check main() parameters and return type
                 }
+
                 if (global.params.vcomplex && f.next !is null)
                     f.next.checkComplexTransition(funcdecl.loc, sc);
 

--- a/test/compilable/test318.d
+++ b/test/compilable/test318.d
@@ -1,0 +1,19 @@
+// LINK:
+// PERMUTE_ARGS: -version=C_Main
+
+version (C_Main)
+{
+    // Fine, infers int
+    extern(C) auto main(int argc, const char** argv)
+    {
+        return argc;
+    }
+}
+else
+{
+    // Fine, infers void
+    auto main()
+    {
+
+    }
+}

--- a/test/fail_compilation/fail318.d
+++ b/test/fail_compilation/fail318.d
@@ -1,8 +1,0 @@
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail318.d(8): Error: function `D main` must return `int`, `void` or `noreturn`
----
-*/
-
-auto main() { }

--- a/test/fail_compilation/fail318_b.d
+++ b/test/fail_compilation/fail318_b.d
@@ -5,4 +5,7 @@ fail_compilation/fail318_b.d(8): Error: function `D main` must return `int`, `vo
 ---
 */
 
-string main() { }
+auto main()
+{
+    return "";
+}


### PR DESCRIPTION
`auto main()` is fine iff return type inference resolves `auto` to one
of the allowed return types (`void`, `int`, `noreturn`). Deferring the
check after the return type inference removes this arbitrary limitation
and allows for more flexible code.

E.g. to use the upcoming `noreturn` inference and the associated
codegen improvements.