### PR TITLE
Issue 22300 - Allow shared <-> unshared reinterpreting casts during CTFE

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -685,6 +685,11 @@ bool isSafePointerCast(Type srcPointee, Type destPointee)
     // It's OK if both are the same (modulo const)
     if (srcPointee.constConv(destPointee))
         return true;
+
+    // It's ok to cast from/to shared because CTFE is single threaded anyways
+    if (srcPointee.unSharedOf() == destPointee.unSharedOf())
+        return true;
+
     // It's OK if function pointers differ only in safe/pure/nothrow
     if (srcPointee.ty == Tfunction && destPointee.ty == Tfunction)
         return srcPointee.covariant(destPointee) == 1 || destPointee.covariant(srcPointee) == 1;

--- a/test/compilable/reinterpretctfe.d
+++ b/test/compilable/reinterpretctfe.d
@@ -1,5 +1,11 @@
 // https://issues.dlang.org/show_bug.cgi?id=21997
 
+struct Strukt
+{
+    int i;
+    string s;
+}
+
 int nonPureFunc(int i)
 {
     return 2 * i;
@@ -28,6 +34,14 @@ int mainCtfe()
     auto baseDel = cast(int delegate(int)) pureDel;
     assert(baseDel(4) == 20);
     */
+
+    {
+        shared Strukt shStr;
+        Strukt str = *cast(Strukt*) &shStr;
+
+        shared(Strukt)* ptr = cast(shared(Strukt)*) &str;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
CTFE evaluation is single threaded only, hence it's safe to discard the
`shared` qualifier in a reinterpreting cast.

This change allows `-checkaction=context` to use a reinterpreting cast
for compile and runtime - which removes the problematic workaround
that caused the regression.

CC @Geod24 