### PR TITLE
backend: dwarf: add DW_AT_decl attributes to variables

### DIFF
--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -1436,7 +1436,7 @@ struct Symbol
     }
     regm_t      Sregsaved;      // mask of registers not affected by this func
 
-    uint lnoscopestart;         // life time of var
+    Srcpos lposscopestart;        // life time of var
     uint lnoscopeend;           // the line after the scope
 
     /**

--- a/src/dmd/backend/dvarstats.d
+++ b/src/dmd/backend/dvarstats.d
@@ -95,11 +95,11 @@ public void startFunction()
 //  no support for gathering stats from different files)
 private bool isLexicalScopeVar(Symbol* sa)
 {
-    if (sa.lnoscopestart <= 0 || sa.lnoscopestart > sa.lnoscopeend)
+    if (sa.lposscopestart.Slinnum <= 0 || sa.lposscopestart.Slinnum > sa.lnoscopeend)
         return false;
 
     // is it inside the function? Unfortunately we cannot verify the source file in case of inlining
-    if (sa.lnoscopestart < funcsym_p.Sfunc.Fstartline.Slinnum)
+    if (sa.lposscopestart.Slinnum < funcsym_p.Sfunc.Fstartline.Slinnum)
         return false;
     if (sa.lnoscopeend > funcsym_p.Sfunc.Fendline.Slinnum)
         return false;
@@ -236,7 +236,7 @@ private symtab_t* calcLexicalScope(return ref symtab_t symtab) return
     for (SYMIDX si = 0; si < dupcnt; si++)
     {
         lifeTimes[si].sym = sortedSymtab[uniquecnt + si];
-        lifeTimes[si].offCreate = cast(int)getLineOffset(lifeTimes[si].sym.lnoscopestart);
+        lifeTimes[si].offCreate = cast(int)getLineOffset(lifeTimes[si].sym.lposscopestart.Slinnum);
         lifeTimes[si].offDestroy = cast(int)getLineOffset(lifeTimes[si].sym.lnoscopeend);
     }
     qsort(lifeTimes[].ptr, dupcnt, (lifeTimes[0]).sizeof, &cmpLifeTime);

--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -1826,14 +1826,17 @@ static if (1)
             version (MARS)
                 if (sa.Sflags & SFLnodebug) continue;
 
-            __gshared ubyte[12] formal =
+            __gshared ubyte[18] formal =
             [
                 DW_TAG_formal_parameter,
                 0,
-                DW_AT_name,       DW_FORM_string,
-                DW_AT_type,       DW_FORM_ref4,
-                DW_AT_artificial, DW_FORM_flag,
-                DW_AT_location,   DW_FORM_block1,
+                DW_AT_name,        DW_FORM_string,
+                DW_AT_type,        DW_FORM_ref4,
+                DW_AT_artificial,  DW_FORM_flag,
+                DW_AT_decl_file,   DW_FORM_data1,
+                DW_AT_decl_line,   DW_FORM_data2,
+                DW_AT_decl_column, DW_FORM_data2,
+                DW_AT_location,    DW_FORM_block1,
                 0,                0,
             ];
 
@@ -1978,6 +1981,9 @@ static if (1)
                         debug_info.buf.writeString(getSymName(sa));   // DW_AT_name
                         debug_info.buf.write32(tidx);                 // DW_AT_type
                         debug_info.buf.writeByte(sa.Sflags & SFLartifical ? 1 : 0); // DW_FORM_tag
+                        debug_info.buf.writeByte(filenum);            // DW_AT_decl_file
+                        debug_info.buf.write16(sa.lposscopestart.Slinnum);   // DW_AT_decl_line
+                        debug_info.buf.write16(sa.lposscopestart.Scharnum);   // DW_AT_decl_column
                         soffset = cast(uint)debug_info.buf.length();
                         debug_info.buf.writeByte(2);                  // DW_FORM_block1
                         if (sa.Sfl == FLreg || sa.Sclass == SCpseudo)

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -314,7 +314,7 @@ Symbol *toSymbol(Dsymbol s)
             type_setmangle(&t, m);
             s.Stype = t;
 
-            s.lnoscopestart = vd.loc.linnum;
+            s.lposscopestart = toSrcpos(vd.loc);
             s.lnoscopeend = vd.endlinnum;
             result = s;
         }
@@ -358,15 +358,8 @@ Symbol *toSymbol(Dsymbol s)
             if (fd.type.toBasetype().isTypeFunction().nextOf().isTypeNoreturn() || fd.flags & FUNCFLAG.noreturn)
                 s.Sflags |= SFLexit;    // the function never returns
 
-            f.Fstartline.set(fd.loc.filename, fd.loc.linnum, fd.loc.charnum);
-            if (fd.endloc.linnum)
-            {
-                f.Fendline.set(fd.endloc.filename, fd.endloc.linnum, fd.endloc.charnum);
-            }
-            else
-            {
-                f.Fendline = f.Fstartline;
-            }
+            f.Fstartline = toSrcpos(fd.loc);
+            f.Fendline = fd.endloc.linnum ? toSrcpos(fd.endloc) : f.Fstartline;
 
             auto t = Type_toCtype(fd.type);
             const msave = t.Tmangle;
@@ -793,4 +786,16 @@ Symbol *toSymbolCppTypeInfo(ClassDeclaration cd)
     t.Tcount++;
     s.Stype = t;
     return s;
+}
+
+/**********************************
+ * Converts a Loc to backend Srcpos
+ * Params:
+ *      loc = Source code location
+ * Returns:
+ *      Srcpos backend struct corresponding to the given location
+ */
+Srcpos toSrcpos(Loc loc)
+{
+    return Srcpos.create(loc.filename, loc.linnum, loc.charnum);
 }

--- a/test/dshell/extra-files/dwarf/excepted_results/fix21157.txt
+++ b/test/dshell/extra-files/dwarf/excepted_results/fix21157.txt
@@ -1,0 +1,4 @@
+DW_AT_decl_line   : 1002
+DW_AT_decl_column : 17
+DW_AT_decl_line   : 1003
+DW_AT_decl_column : 9

--- a/test/dshell/extra-files/dwarf/fix21157.d
+++ b/test/dshell/extra-files/dwarf/fix21157.d
@@ -1,0 +1,10 @@
+/*
+EXTRA_ARGS: -main
+*/
+
+#line 1000
+void foo()
+{
+    int var1; // col: 9 (4 spaces + 3 chars + 1 space)
+          float var2; // col: 17 (10 spaces + 5 chars + 1 space)
+}


### PR DESCRIPTION
This patch aims to provide more debug information to the backend symbol struct,
allowing debug generators to generate more precise symbol location.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Fix issue 21157 .