### PR TITLE
Fix Issue 21807 - Non-immutable data can be converted to immutable using function call in ctor

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -857,7 +857,7 @@ MATCH implicitConvTo(Expression e, Type t)
              * convert to immutable
              */
             if (e.f &&
-                (global.params.useDIP1000 != FeatureState.enabled ||        // lots of legacy code breaks with the following purity check
+                (global.params.useDIP1000 != FeatureState.enabled &&        // lots of legacy code breaks with the following purity check
                  e.f.isPure() >= PURE.strong ||
                  // Special case exemption for Object.dup() which we assume is implemented correctly
                  e.f.ident == Id.dup &&

--- a/test/fail_compilation/test21807.d
+++ b/test/fail_compilation/test21807.d
@@ -52,3 +52,21 @@ class Foo2
 		ptr = addr(S().i);  // struct temporary
 	}
 }
+
+#line 200
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test21807.d(208): Error: cannot implicitly convert expression `bb()` of type `char[12]` to `string`
+---
+*/
+void fun()
+{
+    string a = bb();
+}
+
+char[12] bb()
+{
+    char[12] b;
+    return b;
+}

--- a/test/unit/support.d
+++ b/test/unit/support.d
@@ -140,7 +140,7 @@ const struct Diagnostic
         buffer.printf("%s: %.*s", location.toChars(true),
             cast(int) message.length, message.ptr);
 
-        return buffer.extractSlice;
+        return buffer.extractSlice.idup;
     }
 }
 
@@ -190,7 +190,8 @@ struct DiagnosticCollector
         const string message = buffer
             .extractSlice
             .replace("`", "")
-            .strip;
+            .strip
+            .idup;
 
         diagnostics_ ~= Diagnostic(location, message);
 


### PR DESCRIPTION
I know that this should be a deprecation, however, it seems that the path affected by this PR is taken many times and when I tried issuing the deprecation it seems to outputted spuriously. What are the changes of this getting in without a deprecation message since the breakage should be fairly small?

Let's see what's happening in the wild.