### PR TITLE
Fix 3 space indentation

### DIFF
--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -2291,9 +2291,9 @@ void opass87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         case TYcdouble:
         case TYcldouble:
             if (e.Eoper == OPmodass)
-               opmod_complex87(cdb, e, pretregs);
+                opmod_complex87(cdb, e, pretregs);
             else
-               opass_complex87(cdb, e, pretregs);
+                opass_complex87(cdb, e, pretregs);
             return;
 
         default:

--- a/src/dmd/backend/cgcs.d
+++ b/src/dmd/backend/cgcs.d
@@ -414,7 +414,7 @@ void ecom(ref CGCS cgcs, ref elem* pe)
 
         default:                            /* other operators */
             if (!OTbinary(e.Eoper))
-               WROP(e.Eoper);
+                WROP(e.Eoper);
             assert(OTbinary(e.Eoper));
             goto case OPadd;
 

--- a/src/dmd/backend/dvarstats.d
+++ b/src/dmd/backend/dvarstats.d
@@ -132,7 +132,7 @@ private static extern(D) SYMIDX findParentScope(ref Barray!LifeTime lifetimes, S
     {
         for(SYMIDX sj = si; sj; --sj)
             if(isParentScope(lifetimes, sj - 1, si))
-               return sj;
+                return sj;
     }
     return SYMIDX.max;
 }

--- a/src/dmd/chkformat.d
+++ b/src/dmd/chkformat.d
@@ -690,8 +690,8 @@ Format parsePrintfFormatSpecifier(scope const char[] format, ref size_t idx,
                 return error();
             while ('0' <= format[i] && format[i] <= '9')
             {
-               ++i;
-               if (i == length)
+                ++i;
+                if (i == length)
                     return error();
             }
         }
@@ -720,8 +720,8 @@ Format parsePrintfFormatSpecifier(scope const char[] format, ref size_t idx,
                 return error();
             while ('0' <= format[i] && format[i] <= '9')
             {
-               ++i;
-               if (i == length)
+                ++i;
+                if (i == length)
                     return error();
             }
         }

--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -4186,19 +4186,19 @@ final class CParser(AST) : Parser!AST
             if (level == LVL.global)
             {
                 if (specifier.scw & SCW.xextern)
-                   stc = AST.STC.extern_;
+                    stc = AST.STC.extern_;
             }
             else if (level == LVL.local)
             {
                 if (specifier.scw & SCW.xextern)
-                   stc = AST.STC.extern_;
+                    stc = AST.STC.extern_;
                 else if (specifier.scw & SCW.xstatic)
                     stc = AST.STC.static_;
             }
             else if (level == LVL.member)
             {
                 if (specifier.scw & SCW.xextern)
-                   stc = AST.STC.extern_;
+                    stc = AST.STC.extern_;
                 else if (specifier.scw & SCW.xstatic)
                     stc = AST.STC.static_;
             }
@@ -4208,23 +4208,23 @@ final class CParser(AST) : Parser!AST
             if (level == LVL.global)
             {
                 if (specifier.scw & SCW.xextern)
-                   stc = AST.STC.extern_ | AST.STC.gshared;
+                    stc = AST.STC.extern_ | AST.STC.gshared;
                 else if (specifier.scw & SCW.xstatic)
-                   stc = AST.STC.gshared | AST.STC.static_;
+                    stc = AST.STC.gshared | AST.STC.static_;
                 else
-                   stc = AST.STC.gshared;
+                    stc = AST.STC.gshared;
             }
             else if (level == LVL.local)
             {
                 if (specifier.scw & SCW.xextern)
-                   stc = AST.STC.extern_ | AST.STC.gshared;
+                    stc = AST.STC.extern_ | AST.STC.gshared;
                 else if (specifier.scw & SCW.xstatic)
                     stc = AST.STC.gshared;
             }
             else if (level == LVL.member)
             {
                 if (specifier.scw & SCW.xextern)
-                   stc = AST.STC.extern_ | AST.STC.gshared;
+                    stc = AST.STC.extern_ | AST.STC.gshared;
                 else if (specifier.scw & SCW.xstatic)
                     stc = AST.STC.gshared;
             }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1754,10 +1754,10 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             {
                 // if there was an error evaluating the symbol, it might actually
                 // be a type. Avoid misleading error messages.
-               .error(loc, "`%s` had previous errors", mtype.toChars());
+                .error(loc, "`%s` had previous errors", mtype.toChars());
             }
             else
-               .error(loc, "`%s` is used as a type", mtype.toChars());
+                .error(loc, "`%s` is used as a type", mtype.toChars());
             return error();
         }
         return t;


### PR DESCRIPTION
Each indentation level should be 4 spaces, but I came across some 3-space indentation in cparse.d, and then found a few other cases as well.