### PR TITLE
add vec_numBitsSet()

### DIFF
--- a/src/dmd/backend/dvec.d
+++ b/src/dmd/backend/dvec.d
@@ -179,8 +179,16 @@ __gshared VecGlobal vecGlobal;
 
 private pure vec_base_t MASK(uint b) { return cast(vec_base_t)1 << (b & VECMASK); }
 
+/****
+ * Returns:
+ *      number of bits in the vector
+ */
 @trusted
 pure ref inout(vec_base_t) vec_numbits(inout vec_t v) { return v[-1]; }
+/****
+ * Returns:
+ *      number of bytes in the vector
+ */
 @trusted
 pure ref inout(vec_base_t) vec_dim(inout vec_t v) { return v[-2]; }
 
@@ -362,6 +370,24 @@ size_t vec_index(size_t b, const vec_t vec)
         }
     }
     return vec_numbits(vec);
+}
+
+/********************************
+ * Count number of set bits in vector `v`
+ * Params:
+ *      v = vector
+ * Returns:
+ *      number of set bits
+ */
+@safe
+pure
+uint vec_numBitsSet(const vec_t vec)
+{
+    uint n = 0;
+    size_t length = vec_numbits(vec);
+    for (size_t i = 0; (i = vec_index(i, vec)) < length; ++i)
+        ++n;
+    return n;
 }
 
 /********************************

--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -3734,9 +3734,14 @@ bool loopunroll(ref Loop l)
     /* For simplification, only unroll loops that consist only
      * of a head and tail, and the tail is the exit block.
      */
-    int numblocks = 0;
+    const numblocks = vec_numBitsSet(l.Lloop);
+{   // Ensure no changes
+    if (dfo.length != vec_numbits(l.Lloop)) assert(0);
+    int n = 0;
     for (int i = 0; (i = cast(uint) vec_index(i, l.Lloop)) < dfo.length; ++i)  // for each block in loop
-        ++numblocks;
+        ++n;
+    if (n != numblocks) assert(0);
+}
     if (numblocks != 2)
     {
         if (log) printf("\tnot 2 blocks, but %d\n", numblocks);


### PR DESCRIPTION
Primitive operations on a type should be part of the type. The upper level abstraction should not be concerned with such details.

Note this change also gets rid of a global reference `dfo.length`.