### PR TITLE
Make base type of PASS enum ubyte

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -187,7 +187,7 @@ struct Visibility
     }
 }
 
-enum PASS : int
+enum PASS : ubyte
 {
     init,           // initial state
     semantic,       // semantic() started

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -108,7 +108,21 @@ struct Visibility
 
 /* State of symbol in winding its way through the passes of the compiler
  */
-enum PASS
+enum class PASS : uint8_t
+{
+    init,           // initial state
+    semantic,       // semantic() started
+    semanticdone,   // semantic() done
+    semantic2,      // semantic2() started
+    semantic2done,  // semantic2() done
+    semantic3,      // semantic3() started
+    semantic3done,  // semantic3() done
+    inline_,         // inline started
+    inlinedone,     // inline done
+    obj             // toObjFile() run
+};
+
+enum
 {
     PASSinit,           // initial state
     PASSsemantic,       // semantic() started

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -918,18 +918,18 @@ struct Loc final
     }
 };
 
-enum class PASS
+enum class PASS : uint8_t
 {
-    init = 0,
-    semantic = 1,
-    semanticdone = 2,
-    semantic2 = 3,
-    semantic2done = 4,
-    semantic3 = 5,
-    semantic3done = 6,
-    inline_ = 7,
-    inlinedone = 8,
-    obj = 9,
+    init = 0u,
+    semantic = 1u,
+    semanticdone = 2u,
+    semantic2 = 3u,
+    semantic2done = 4u,
+    semantic3 = 5u,
+    semantic3done = 6u,
+    inline_ = 7u,
+    inlinedone = 8u,
+    obj = 9u,
 };
 
 struct Ungag final


### PR DESCRIPTION
With this, `__traits(classInstanceSize, Dsymbol)` goes down from 128 to 120, which should reduce memory usage.