### PR TITLE
fix Issue 7925 - extern(C++) delegates

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5106,7 +5106,15 @@ elem *callfunc(const ref Loc loc,
         ec = el_same(&ethis);
         ethis = el_una(target.is64bit ? OP128_64 : OP64_32, TYnptr, ethis); // get this
         ec = array_toPtr(t, ec);                // get funcptr
-        ec = el_una(OPind, totym(tf), ec);
+        tym_t tym;
+        /* Delegates use the same calling convention as member functions.
+         * For extern(C++) on Win32 this differs from other functions.
+         */
+        if (tf.linkage == LINK.cpp && !target.is64bit && target.os == Target.OS.Windows)
+            tym = (tf.parameterList.varargs == VarArg.variadic) ? TYnfunc : TYmfunc;
+        else
+            tym = totym(tf);
+        ec = el_una(OPind, tym, ec);
     }
 
     const ty = fd ? toSymbol(fd).Stype.Tty : ec.Ety;

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -387,7 +387,9 @@ Symbol *toSymbol(Dsymbol s)
                         break;
                     case LINK.cpp:
                         s.Sflags |= SFLpublic;
-                        if (fd.isThis() && !target.is64bit && target.os == Target.OS.Windows)
+                        /* Nested functions use the same calling convention as
+                         * member functions, because both can be used as delegates. */
+                        if ((fd.isThis() || fd.isNested()) && !target.is64bit && target.os == Target.OS.Windows)
                         {
                             if ((cast(TypeFunction)fd.type).parameterList.varargs == VarArg.variadic)
                             {

--- a/test/runnable_cxx/extra-files/cpp7925.cpp
+++ b/test/runnable_cxx/extra-files/cpp7925.cpp
@@ -1,0 +1,103 @@
+#include <stdarg.h>
+#include <assert.h>
+
+class C1
+{
+public:
+    virtual ~C1();
+
+    int i;
+
+    int f0();
+    int f1(int a);
+    int f2(int a, int b);
+    virtual int f3(int a, int b);
+    int f4(int a, ...);
+};
+
+C1::~C1()
+{
+}
+
+int C1::f0()
+{
+    return i;
+}
+
+int C1::f1(int a)
+{
+    return i + a;
+}
+
+int C1::f2(int a, int b)
+{
+    return i + a + b;
+}
+
+int C1::f3(int a, int b)
+{
+    return i + a + b;
+}
+
+int C1::f4(int a, ...)
+{
+    int r = i + a;
+    int last = a;
+
+    va_list argp;
+    va_start(argp, a);
+    while (last)
+    {
+        last = va_arg(argp, int);
+        r += last;
+    }
+    va_end(argp);
+    return r;
+}
+
+C1 *createC1()
+{
+    return new C1();
+}
+
+class C2
+{
+public:
+    virtual ~C2();
+
+    int i;
+
+    int f0();
+    int f1(int a);
+    int f2(int a, int b);
+    virtual int f3(int a, int b);
+    int f4(int a, ...);
+};
+
+C2 *createC2();
+
+void runCPPTests()
+{
+    C2 *c2 = createC2();
+    c2->i = 100;
+    assert(c2->f0() == 100);
+    assert(c2->f1(1) == 101);
+    assert(c2->f2(20, 3) == 123);
+    assert(c2->f3(20, 3) == 123);
+    assert(c2->f4(20, 3, 0) == 123);
+
+    int (C2::*fp0)() = &C2::f0;
+    int (C2::*fp1)(int) = &C2::f1;
+    int (C2::*fp2)(int, int) = &C2::f2;
+    int (C2::*fp3)(int, int) = &C2::f3;
+#ifndef __DMC__
+    int (C2::*fp4)(int, ...) = &C2::f4;
+#endif
+    assert((c2->*(fp0))() == 100);
+    assert((c2->*(fp1))(1) == 101);
+    assert((c2->*(fp2))(20, 3) == 123);
+    assert((c2->*(fp3))(20, 3) == 123);
+#ifndef __DMC__
+    assert((c2->*(fp4))(20, 3, 0) == 123);
+#endif
+}

--- a/test/runnable_cxx/test7925.d
+++ b/test/runnable_cxx/test7925.d
@@ -1,0 +1,143 @@
+// EXTRA_CPP_SOURCES: cpp7925.cpp
+import core.vararg;
+
+extern(C++) class C1
+{
+public:
+    ~this();
+
+    int i;
+
+    final int f0();
+    final int f1(int a);
+    final int f2(int a, int b);
+    int f3(int a, int b);
+    final int f4(int a, ...);
+};
+
+extern(C++) C1 createC1();
+
+extern(C++) class C2
+{
+public:
+    ~this()
+    {
+    }
+
+    int i;
+
+    final int f0()
+    {
+        return i;
+    }
+
+    final int f1(int a)
+    {
+        return i + a;
+    }
+
+    final int f2(int a, int b)
+    {
+        return i + a + b;
+    }
+
+    int f3(int a, int b)
+    {
+        return i + a + b;
+    }
+
+    final int f4(int a, ...)
+    {
+        int r = i + a;
+        int last = a;
+
+        va_list argp;
+        va_start(argp, a);
+        while (last)
+        {
+            last = va_arg!int(argp);
+            r += last;
+        }
+        va_end(argp);
+        return r;
+    }
+};
+
+extern(C++) C2 createC2()
+{
+    return new C2;
+}
+
+auto callMember(alias F, Params...)(__traits(parent, F) obj, Params params)
+{
+    static if(__traits(getFunctionVariadicStyle, F) == "stdarg")
+        enum varargSuffix = ", ...";
+    else
+        enum varargSuffix = "";
+
+    static if(is(typeof(&F) R == return) && is(typeof(F) P == __parameters))
+        mixin("extern(" ~ __traits(getLinkage, F) ~ ") R delegate(P" ~ varargSuffix ~ ") dg;");
+    dg.funcptr = &F;
+    dg.ptr = cast(void*)obj;
+    return dg(params);
+}
+
+extern(C++) void runCPPTests();
+
+void main()
+{
+    C1 c1 = createC1();
+    c1.i = 100;
+    assert(c1.f0() == 100);
+    assert(c1.f1(1) == 101);
+    assert(c1.f2(20, 3) == 123);
+    assert(c1.f3(20, 3) == 123);
+    assert(c1.f4(20, 3, 0) == 123);
+
+    auto dg0 = &c1.f0;
+    auto dg1 = &c1.f1;
+    auto dg2 = &c1.f2;
+    auto dg3 = &c1.f3;
+    auto dg4 = &c1.f4;
+    assert(dg0() == 100);
+    assert(dg1(1) == 101);
+    assert(dg2(20, 3) == 123);
+    assert(dg3(20, 3) == 123);
+    assert(dg4(20, 3, 0) == 123);
+
+    assert(callMember!(C1.f0)(c1) == 100);
+    assert(callMember!(C1.f1)(c1, 1) == 101);
+    assert(callMember!(C1.f2)(c1, 20, 3) == 123);
+    assert(callMember!(C1.f3)(c1, 20, 3) == 123);
+    assert(callMember!(C1.f4)(c1, 20, 3, 0) == 123);
+
+    int i;
+    extern(C++) void delegate() lamdba1 = () {
+        i = 5;
+    };
+    lamdba1();
+    assert(i == 5);
+
+    extern(C++) int function(int, int) lamdba2 = (int a, int b) {
+        return a + b;
+    };
+    assert(lamdba2(3, 4) == 7);
+
+    extern(C++) void delegate(int, ...) lamdba3 = (int a, ...) {
+        i = a;
+        int last = a;
+
+        va_list argp;
+        va_start(argp, a);
+        while (last)
+        {
+            last = va_arg!int(argp);
+            i += last;
+        }
+        va_end(argp);
+    };
+    lamdba3(1000, 200, 30, 4, 0);
+    assert(i == 1234);
+
+    runCPPTests();
+}


### PR DESCRIPTION
The linkage is already part of the type for delegates. Member functions
for extern(C++) on Win32 use a different calling convention than other
functions. This commit changes the calling convention of extern(C++)
delegates for Win32 to match member functions. The calling convention
for nested functions is also changed, because they can become delegates,
too.