### PR TITLE
Use correct phobos when running C++ tests in GitHub action

### DIFF
--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -293,7 +293,8 @@ jobs:
     ########################################
     - name: Run C++ test suite
       run: |
-        ./dmd/test/run.d --environment runnable_cxx dshell/dll_cxx.d MODEL=64
+        # Reset LD_LIBRARY_PATH when running the tests, so they use the newly built libphobos2.so.
+        LD_LIBRARY_PATH= ./dmd/test/run.d --environment runnable_cxx dshell/dll_cxx.d MODEL=64
         #if [ ${{ matrix.compiler }} == "g++" ]; then
         #  ./dmd/test/run.d clean
         #  ./dmd/test/run.d runnable_cxx MODEL=32


### PR DESCRIPTION
The GitHub workflow is setting LD_LIBRARY_PATH to the host dmd library
folder with libphobos2.so. The tests are built using a new phobos. They
select the library path using -L-rpath, which sets DT_RUNPATH on the
binary, but LD_LIBRARY_PATH has priority over DT_RUNPATH.
For tests/dshell/dll_cxx.d this caused a link failure, because a new
symbol from phobos was not found in the older phobos.
Reseting LD_LIBRARY_PATH while running the tests makes sure, that the
new phobos is used.