### PR TITLE
add another case to SROA optimization

### DIFF
--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -1132,6 +1132,7 @@ static if (NTEXCEPTIONS)
         case BCretexp:
             reg_t reg1, reg2, lreg, mreg;
             retregs = allocretregs(e.Ety, e.ET, funcsym_p.ty(), reg1, reg2);
+            //printf("allocretregs returns %s\n", regm_str(mask(reg1) | mask(reg2)));
 
             lreg = mreg = NOREG;
             if (reg1 == NOREG)

--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -4591,6 +4591,7 @@ void cdpair(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     }
 
     //printf("\ncdpair(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
+    //WRTYxx(e.Ety);printf("\n");
     //printf("Ecount = %d\n", e.Ecount);
 
     regm_t retregs = *pretregs;
@@ -4636,7 +4637,6 @@ void cdpair(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
 
     codelem(cdb,e.EV.E1, &regs1, false);
     scodelem(cdb,e.EV.E2, &regs2, regs1, false);
-    //printf("2: regs1 = %s, regs2 = %s\n", regm_str(regs1), regm_str(regs2));
 
     if (e.EV.E1.Ecount)
         getregs(cdb,regs1);

--- a/src/dmd/backend/dtype.d
+++ b/src/dmd/backend/dtype.d
@@ -656,6 +656,20 @@ type *type_enum(const(char)* name, type *tbase)
 type *type_struct_class(const(char)* name, uint alignsize, uint structsize,
         type *arg1type, type *arg2type, bool isUnion, bool isClass, bool isPOD, bool is0size)
 {
+    static if (0)
+    {
+        printf("type_struct_class(%s, %p, %p)\n", name, arg1type, arg2type);
+        if (arg1type)
+        {
+            printf("arg1type:\n");
+            type_print(arg1type);
+        }
+        if (arg2type)
+        {
+            printf("arg2type:\n");
+            type_print(arg2type);
+        }
+    }
     Symbol *s = symbol_calloc(name);
     s.Sclass = SCstruct;
     s.Sstruct = struct_calloc();

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -2887,7 +2887,7 @@ void elem_print(const elem* e, int nestlevel = 0)
             e.Ety == TYstruct || e.Ety == TYarray)
             if (e.ET)
                 printf("%d ", cast(int)type_size(e.ET));
-        printf("%s\n", tym_str(e.Ety));
+        printf("%s ", tym_str(e.Ety));
     }
     if (OTunary(e.Eoper))
     {
@@ -2922,7 +2922,7 @@ void elem_print(const elem* e, int nestlevel = 0)
 
             case OPasm:
             case OPstring:
-                printf(" '%s',%lld\n",e.EV.Vstring,cast(ulong)e.EV.Voffset);
+                printf(" '%s',%lld",e.EV.Vstring,cast(ulong)e.EV.Voffset);
                 break;
 
             case OPconst:

--- a/test/compilable/sroa.d
+++ b/test/compilable/sroa.d
@@ -1,0 +1,55 @@
+/* REQUIRED_ARGS: -O -release -inline
+This compares two different ways to do a for loop. The range
+version should SROA the VecRange struct into two register variables.
+*/
+
+extern (C):
+
+nothrow:
+@nogc:
+@safe:
+
+alias vec_base_t = size_t;                     // base type of vector
+alias vec_t = vec_base_t*;
+
+@trusted
+pure
+size_t vec_index(size_t b, const vec_t vec);
+
+@trusted
+pure ref inout(vec_base_t) vec_numbits(inout vec_t v) { return v[-1]; }
+@trusted
+pure ref inout(vec_base_t) vec_dim(inout vec_t v) { return v[-2]; }
+
+struct VecRange
+{
+    size_t i;
+    const vec_t v;
+
+  @nogc @safe nothrow pure:
+    this(const vec_t v) { this.v = v; i = vec_index(0, v); }
+    bool empty() const { return i == vec_numbits(v); }
+    size_t front() const { return i; }
+    void popFront() { i = vec_index(i + 1, v); }
+}
+
+@safe
+pure
+uint vec_numBitsSet(const vec_t vec)
+{
+    uint n = 0;
+    size_t length = vec_numbits(vec);
+    for (size_t i = 0; (i = vec_index(i, vec)) < length; ++i)
+        ++n;
+    return n;
+}
+
+@safe
+pure
+uint vec_numBitsSet2(const vec_t vec)
+{
+    uint n = 0;
+    foreach (j; VecRange(vec))
+        ++n;
+    return n;
+}

--- a/test/runnable/sroa13220.d
+++ b/test/runnable/sroa13220.d
@@ -1,0 +1,103 @@
+/* REQUIRED_ARGS: -O -inline -noboundscheck
+ */
+// https://github.com/dlang/pull/13220
+
+version (D_SIMD)
+{
+
+mixin template VectorOps(VectorType, ArrayType: BaseType[N], BaseType, size_t N)
+{
+    enum Count = N;
+    alias Base = BaseType;
+
+    BaseType* ptr() return pure nothrow @nogc
+    {
+        return array.ptr;
+    }
+
+    // Unary operators
+    VectorType opUnary(string op)() pure nothrow @safe @nogc
+    {
+        VectorType res = void;
+        mixin("res.array[] = " ~ op ~ "array[];");
+        return res;
+    }
+
+    // Binary operators
+    VectorType opBinary(string op)(VectorType other) pure const nothrow @safe @nogc
+    {
+        VectorType res = void;
+        mixin("res.array[] = array[] " ~ op ~ " other.array[];");
+        return res;
+    }
+
+    // Assigning a BaseType value
+    void opAssign(BaseType e) pure nothrow @safe @nogc
+    {
+        array[] = e;
+    }
+
+    // Assigning a static array
+    void opAssign(ArrayType v) pure nothrow @safe @nogc
+    {
+        array[] = v[];
+    }
+
+    void opOpAssign(string op)(VectorType other) pure nothrow @safe @nogc
+    {
+        mixin("array[] "  ~ op ~ "= other.array[];");
+    }
+
+    // Assigning a dyn array
+    this(ArrayType v) pure nothrow @safe @nogc
+    {
+        array[] = v[];
+    }
+
+    // Broadcast constructor
+    this(BaseType x) pure nothrow @safe @nogc
+    {
+        array[] = x;
+    }
+
+    ref inout(BaseType) opIndex(size_t i) inout pure nothrow @safe @nogc
+    {
+        return array[i];
+    }
+}
+
+// Note: can't be @safe with this signature
+Vec loadUnaligned(Vec)(const(BaseType!Vec)* pvec) @trusted
+{
+    // Since this vector is emulated, it doesn't have alignement constraints
+    // and as such we can just cast it.
+    return *cast(Vec*)(pvec);
+}
+
+private template BaseType(V)
+{
+    alias typeof( ( { V v; return v; }()).array[0]) BaseType;
+}
+
+struct int4
+{
+    int[4] array;
+    mixin VectorOps!(int4, int[4]);
+}
+
+alias __m128i = int4;
+}
+
+int main()
+{
+  version (D_SIMD)
+  {
+    int4 A = [1, 2, 3, 4];
+    int4 ia = A;
+    ia.ptr[2] = 5;
+    int4 C = ia;
+    int[4] result = [1, 2, 5, 4];
+    assert(C.array == result);
+  }
+    return 0;
+}


### PR DESCRIPTION
Found a case where the SROA should have sliced a struct into two register variables, but didn't. So I fixed it so it did. There were two problems:

1. a < should have been <=
2. A long initializer to a two-int struct should be done as two int initializers

Added some logging instrumentation.