### PR TITLE
Fix Issue 20133 - [REG2.084.0] Bogus slice assignment in recursive CTFE call

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2196,7 +2196,7 @@ public:
                     Expression ev = getValue(v);
                     if (ev.op == TOK.variable ||
                         ev.op == TOK.index ||
-                        ev.op == TOK.slice ||
+                        (ev.op == TOK.slice && ev.type.toBasetype().ty == Tsarray) ||
                         ev.op == TOK.dotVariable)
                     {
                         result = interpret(pue, ev, istate, goal);

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -3605,6 +3605,62 @@ void test21878()
 }
 
 /************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=20133
+
+void bar20133(ref string text)
+{
+    text = text[1 .. $];
+    assert(text.length < 3);
+    if (text.length == 2) assert(text == "oo");
+    if (text.length == 1) assert(text == "o");
+    if (text.length == 0) assert(text == "");
+    string tcopy = text;
+    if (tcopy.length > 0)
+        bar20133(tcopy);
+    assert(tcopy.length < 2);
+    if (tcopy.length == 1) assert(tcopy == "o");
+    if (tcopy.length == 0) assert(tcopy == "");
+}
+
+void bar20133_2(ref string text)
+{
+    auto ptext = &text;
+    *ptext = text[1 .. $];
+    assert(text.length < 3);
+    if (text.length == 2) assert(text == "oo");
+    if (text.length == 1) assert(text == "o");
+    if (text.length == 0) assert(text == "");
+    string tcopy = text;
+    if (tcopy.length > 0)
+        bar20133_2(tcopy);
+    assert(tcopy.length < 2);
+    if (tcopy.length == 1) assert(tcopy == "o");
+    if (tcopy.length == 0) assert(tcopy == "");
+}
+
+alias fun20133 = {
+    string input = "foo";
+    bar20133(input);
+    assert(input == "oo");
+    return input;
+};
+
+alias fun20133_2 = {
+    string input = "foo";
+    bar20133_2(input);
+    assert(input == "oo");
+    return input;
+};
+
+void test20133()
+{
+    enum ctest = fun20133();
+    enum ctest2 = fun20133_2();
+    auto rtest = fun20133();
+    auto rtest2 = fun20133_2();
+}
+
+/************************************************/
 
 int main()
 {
@@ -3732,6 +3788,7 @@ int main()
     test20366();
     test20400();
     test21878();
+    test20133();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Regression caused by #9071.

Solution: Expand a ref slice only if it represents a static array.