### PR TITLE
Make __gshared var.d tables immutable

### DIFF
--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -19,6 +19,7 @@ extern (C++):
 @nogc:
 nothrow:
 @safe:
+pure:
 
 alias tym_t = uint;
 
@@ -216,11 +217,10 @@ enum
     mTYTFF          = 0xFF000000,
 }
 
-pure
 tym_t tybasic(tym_t ty) { return ty & mTYbasic; }
 
 /* Flags in tytab[] array       */
-extern __gshared uint[256] tytab;
+extern immutable uint[256] tytab;
 enum
 {
     TYFLptr         = 1,
@@ -245,143 +245,110 @@ enum
 }
 
 /* Array to give the size in bytes of a type, -1 means error    */
-extern __gshared byte[256] _tysize;
-extern __gshared byte[256] _tyalignsize;
+extern immutable byte[256] _tysize;
+extern immutable byte[256] _tyalignsize;
 
 // Give size of type
-@trusted
 byte tysize(tym_t ty)      { return _tysize[ty & 0xFF]; }
-@trusted
 byte tyalignsize(tym_t ty) { return _tyalignsize[ty & 0xFF]; }
 
 
 /* Groupings of types   */
 
-@trusted
 uint tyintegral(tym_t ty) { return tytab[ty & 0xFF] & TYFLintegral; }
 
-@trusted
 uint tyarithmetic(tym_t ty) { return tytab[ty & 0xFF] & (TYFLintegral | TYFLreal | TYFLimaginary | TYFLcomplex); }
 
-@trusted
 uint tyaggregate(tym_t ty) { return tytab[ty & 0xFF] & TYFLaggregate; }
 
-@trusted
 uint tyscalar(tym_t ty) { return tytab[ty & 0xFF] & (TYFLintegral | TYFLreal | TYFLimaginary | TYFLcomplex | TYFLptr | TYFLmptr | TYFLnullptr | TYFLref); }
 
-@trusted
 uint tyfloating(tym_t ty) { return tytab[ty & 0xFF] & (TYFLreal | TYFLimaginary | TYFLcomplex); }
 
-@trusted
 uint tyimaginary(tym_t ty) { return tytab[ty & 0xFF] & TYFLimaginary; }
 
-@trusted
 uint tycomplex(tym_t ty) { return tytab[ty & 0xFF] & TYFLcomplex; }
 
-@trusted
 uint tyreal(tym_t ty) { return tytab[ty & 0xFF] & TYFLreal; }
 
 // Fits into 64 bit register
-@trusted
 bool ty64reg(tym_t ty) { return tytab[ty & 0xFF] & (TYFLintegral | TYFLptr | TYFLref) && tysize(ty) <= _tysize[TYnptr]; }
 
 // Can go in XMM floating point register
-@trusted
 uint tyxmmreg(tym_t ty) { return tytab[ty & 0xFF] & TYFLxmmreg; }
 
 // Is a vector type
-@trusted
 bool tyvector(tym_t ty) { return tybasic(ty) >= TYfloat4 && tybasic(ty) <= TYullong4; }
 
 /* Types that are chars or shorts       */
-@trusted
 uint tyshort(tym_t ty) { return tytab[ty & 0xFF] & TYFLshort; }
 
 /* Detect TYlong or TYulong     */
-@trusted
 bool tylong(tym_t ty) { return tybasic(ty) == TYlong || tybasic(ty) == TYulong; }
 
 /* Use to detect a pointer type */
-@trusted
 uint typtr(tym_t ty) { return tytab[ty & 0xFF] & TYFLptr; }
 
 /* Use to detect a reference type */
-@trusted
 uint tyref(tym_t ty) { return tytab[ty & 0xFF] & TYFLref; }
 
 /* Use to detect a pointer type or a member pointer     */
-@trusted
 uint tymptr(tym_t ty) { return tytab[ty & 0xFF] & (TYFLptr | TYFLmptr); }
 
 // Use to detect a nullptr type or a member pointer
-@trusted
 uint tynullptr(tym_t ty) { return tytab[ty & 0xFF] & TYFLnullptr; }
 
 /* Detect TYfptr or TYvptr      */
-@trusted
 uint tyfv(tym_t ty) { return tytab[ty & 0xFF] & TYFLfv; }
 
 /* All data types that fit in exactly 8 bits    */
-@trusted
 bool tybyte(tym_t ty) { return tysize(ty) == 1; }
 
 /* Types that fit into a single machine register        */
-@trusted
 bool tyreg(tym_t ty) { return tysize(ty) <= _tysize[TYnptr]; }
 
 /* Detect function type */
-@trusted
 uint tyfunc(tym_t ty) { return tytab[ty & 0xFF] & TYFLfunc; }
 
 /* Detect function type where parameters are pushed left to right    */
-@trusted
 uint tyrevfunc(tym_t ty) { return tytab[ty & 0xFF] & TYFLrevparam; }
 
 /* Detect uint types */
-@trusted
 uint tyuns(tym_t ty) { return tytab[ty & 0xFF] & (TYFLuns | TYFLptr); }
 
 /* Target dependent info        */
 alias TYoffset = TYuint;         // offset to an address
 
 /* Detect cpp function type (callee cleans up stack)    */
-@trusted
 uint typfunc(tym_t ty) { return tytab[ty & 0xFF] & TYFLpascal; }
 
 /* Array to convert a type to its unsigned equivalent   */
-extern __gshared tym_t[256] tytouns;
-@trusted
+extern immutable tym_t[256] tytouns;
 tym_t touns(tym_t ty) { return tytouns[ty & 0xFF]; }
 
 /* Determine if TYffunc or TYfpfunc (a far function) */
-@trusted
 uint tyfarfunc(tym_t ty) { return tytab[ty & 0xFF] & TYFLfarfunc; }
 
 // Determine if parameter is a SIMD vector type
-@trusted
 uint tysimd(tym_t ty) { return tytab[ty & 0xFF] & TYFLsimd; }
 
 /* Determine relaxed type       */
-extern __gshared ubyte[TYMAX] _tyrelax;
-@trusted
+extern immutable ubyte[TYMAX] _tyrelax;
 uint tyrelax(tym_t ty) { return _tyrelax[tybasic(ty)]; }
 
 
 /* Determine functionally equivalent type       */
-extern __gshared ubyte[TYMAX] tyequiv;
+extern immutable ubyte[TYMAX] tyequiv;
 
 /* Give an ascii string for a type      */
-extern (C) { extern __gshared const(char)*[TYMAX] tystring; }
+extern (C) { extern immutable const(char)*[TYMAX] tystring; }
 
 /* Debugger value for type      */
-extern __gshared ubyte[TYMAX] dttab;
-extern __gshared ushort[TYMAX] dttab4;
+extern immutable ubyte[TYMAX] dttab;
+extern immutable ushort[TYMAX] dttab4;
 
 
-@trusted
 bool I16() { return _tysize[TYnptr] == 2; }
-@trusted
 bool I32() { return _tysize[TYnptr] == 4; }
-@trusted
 bool I64() { return _tysize[TYnptr] == 8; }
 

--- a/src/dmd/backend/var.d
+++ b/src/dmd/backend/var.d
@@ -75,7 +75,7 @@ int linkage_spec = 0;           /* using the default                    */
 /* LINK_MAXDIM = C,C++,Pascal,FORTRAN,syscall,stdcall,Mars */
 static if (MEMMODELS == 1)
 {
-tym_t[LINK_MAXDIM] functypetab =
+immutable tym_t[LINK_MAXDIM] functypetab =
 [
     TYnfunc,
     TYnpfunc,
@@ -85,7 +85,7 @@ tym_t[LINK_MAXDIM] functypetab =
 }
 else
 {
-tym_t[MEMMODELS][LINK_MAXDIM] functypetab =
+immutable tym_t[MEMMODELS][LINK_MAXDIM] functypetab =
 [
     [ TYnfunc,  TYffunc,  TYnfunc,  TYffunc,  TYffunc  ],
     [ TYnfunc,  TYffunc,  TYnfunc,  TYffunc,  TYffunc  ],
@@ -99,7 +99,7 @@ tym_t[MEMMODELS][LINK_MAXDIM] functypetab =
 
 /* Function mangling    */
 /* LINK_MAXDIM = C,C++,Pascal,FORTRAN,syscall,stdcall */
-mangle_t[LINK_MAXDIM] funcmangletab =
+immutable mangle_t[LINK_MAXDIM] funcmangletab =
 [
     mTYman_c,
     mTYman_cpp,
@@ -111,7 +111,7 @@ mangle_t[LINK_MAXDIM] funcmangletab =
 ];
 
 /* Name mangling for global variables   */
-mangle_t[LINK_MAXDIM] varmangletab =
+immutable mangle_t[LINK_MAXDIM] varmangletab =
 [
     mTYman_c,
     mTYman_cpp,
@@ -195,7 +195,7 @@ tym_t pointertype = TYnptr;     /* default data pointer type            */
 version (SPP) { } else
 {
 
-char[SCMAX] sytab =
+immutable char[SCMAX] sytab =
 [
     /* unde */     SCEXP|SCKEP|SCSCT,      /* undefined                            */
     /* auto */     SCEXP|SCSS|SCRD  ,      /* automatic (stack)                    */
@@ -265,7 +265,7 @@ type *chartype;                 /* default 'char' type                  */
 
 Obj objmod = null;
 
-__gshared uint[256] tytab =
+immutable uint[256] tytab =
 () {
     uint[256] tab;
     foreach (i; TXptr)        { tab[i] |= TYFLptr; }
@@ -295,7 +295,7 @@ __gshared uint[256] tytab =
 } ();
 
 
-extern (C) __gshared const(char)*[TYMAX] tystring =
+extern (C) immutable const(char)*[TYMAX] tystring =
 [
     TYbool    : "bool",
     TYchar    : "char",
@@ -406,7 +406,7 @@ extern (C) __gshared const(char)*[TYMAX] tystring =
 ];
 
 /// Map to unsigned version of type
-__gshared tym_t[256] tytouns =
+immutable tym_t[256] tytouns =
 () {
     tym_t[256] tab;
     foreach (ty; 0 .. TYMAX)
@@ -449,7 +449,7 @@ __gshared tym_t[256] tytouns =
 } ();
 
 /// Map to relaxed version of type
-__gshared ubyte[TYMAX] _tyrelax =
+immutable ubyte[TYMAX] _tyrelax =
 () {
     ubyte[TYMAX] tab;
     foreach (ty; 0 .. TYMAX)
@@ -485,7 +485,7 @@ __gshared ubyte[TYMAX] _tyrelax =
 } ();
 
 /// Map to equivalent version of type
-__gshared ubyte[TYMAX] tyequiv =
+immutable ubyte[TYMAX] tyequiv =
 () {
     ubyte[TYMAX] tab;
     foreach (ty; 0 .. TYMAX)
@@ -505,7 +505,7 @@ __gshared ubyte[TYMAX] tyequiv =
 } ();
 
 /// Map to Codeview 1 type in debugger record
-__gshared ubyte[TYMAX] dttab =
+ubyte[TYMAX] dttab =
 [
     TYbool    : 0x80,
     TYchar    : 0x80,
@@ -616,7 +616,7 @@ __gshared ubyte[TYMAX] dttab =
 ];
 
 /// Map to Codeview 4 type in debugger record
-__gshared ushort[TYMAX] dttab4 =
+ushort[TYMAX] dttab4 =
 [
     TYbool    : 0x30,
     TYchar    : 0x70,
@@ -727,7 +727,7 @@ __gshared ushort[TYMAX] dttab4 =
 ];
 
 /// Size of a type
-__gshared byte[256] _tysize =
+immutable byte[256] _tysize =
 [
     TYbool    : 1,
     TYchar    : 1,
@@ -841,7 +841,7 @@ __gshared byte[256] _tysize =
 enum SET_ALIGN = -1;
 
 /// Size of a type to use for alignment
-__gshared byte[256] _tyalignsize =
+immutable byte[256] _tyalignsize =
 [
     TYbool    : 1,
     TYchar    : 1,


### PR DESCRIPTION
By using `immutable` instead of `__gshared`, functions in `ty.d` can be `pure @safe` instead of `@trusted`.