### PR TITLE
Fix Issue 16215 - Nested class unable to resolve outer class variables in certain scenarios

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4964,7 +4964,16 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     }
                 }
                 else
+                {
+                    // https://issues.dlang.org/show_bug.cgi?id=16215
+                    //
+                    // Previously, enclosing and vthis were set to point to the baseclass
+                    // however, in the case of nested classes they should point to the enclosing
+                    // symbol. `makeNested` will appropriately set these values.
+                    cldec.enclosing = null;
+                    cldec.vthis = null;
                     cldec.makeNested2();
+                }
             }
             else
                 cldec.makeNested();

--- a/test/compilable/test16215.d
+++ b/test/compilable/test16215.d
@@ -1,0 +1,37 @@
+// https://issues.dlang.org/show_bug.cgi?id=16215
+
+class Base
+{
+    class BaseInner {}
+}
+
+final class Derived: Base
+{
+    bool someMethod() { return false; }
+
+    final class DerivedInner: BaseInner
+    {
+     	 void func()
+         {
+             someMethod();
+         }
+    }
+}
+
+class Foo
+{
+    class FooInner {}
+}
+
+class Bar: Foo
+{
+    byte foo;
+    class BarInner(T): Foo.FooInner
+    {
+        byte zoo()
+        {
+            return foo;
+        }
+    }
+    alias BarInnerThis = BarInner!Bar;
+}

--- a/test/runnable/traits_getPointerBitmap.d
+++ b/test/runnable/traits_getPointerBitmap.d
@@ -233,7 +233,7 @@ void testRTInfo()
         _testType!(Large)          ([ 0x4000_0000, 0x1000_0000, 0x0001_0000 ]);
 
     _testType!(N.CNested)     ([ 0b101000 ]);
-    _testType!(N.CNestedDerived) ([ 0b1000101000 ]);
+    _testType!(N.CNestedDerived) ([ 0b11000101000 ]);
 
     testType!(N.Nested)       ([ 0b110 ]);
 


### PR DESCRIPTION
I am not sure this is the right fix, but hopefully someone that understands the logic better can help.

Here [1] the class's enclosing dsymbol is set to the baseclass's one. Here [2] the class's context pointer is set the baseclass's one. And then, they remain the same. This code might be ok if we assume that a nested class can only be the ancestor of another class in the same scope, however, that is not true for the case in the bug report.

My fix is to reset the enclosing and the context before trying another time to set them appropriately. 

[1] https://github.com/dlang/dmd/blob/master/src/dmd/dsymbolsem.d#L4846
[2] https://github.com/dlang/dmd/blob/master/src/dmd/dsymbolsem.d#L4928