### PR TITLE
tocsym: simplify ctype conversion branch on VarDeclaration visitor

### DIFF
--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -182,18 +182,10 @@ Symbol *toSymbol(Dsymbol s)
                     t = type_fake(TYdelegate);          // Tdelegate as C type
                 t.Tcount++;
             }
-            else if (vd.isParameter())
+            else if (vd.isParameter() && ISX64REF(vd))
             {
-                if (ISX64REF(vd))
-                {
-                    t = type_allocn(TYnref, Type_toCtype(vd.type));
-                    t.Tcount++;
-                }
-                else
-                {
-                    t = Type_toCtype(vd.type);
-                    t.Tcount++;
-                }
+                t = type_allocn(TYnref, Type_toCtype(vd.type));
+                t.Tcount++;
             }
             else
             {


### PR DESCRIPTION
Since the outer default branch is the same of the inner default branch, there
is no need to have code duplication here.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>