### PR TITLE
backend: dwarfdbginf: use distinguishable type names for delegate types

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -2508,14 +2508,14 @@ static if (1)
 
                 code = dwarf_abbrev_code(abbrevTypeStruct.ptr, (abbrevTypeStruct).sizeof);
                 idx = cast(uint)debug_info.buf.length();
-                debug_info.buf.writeuLEB128(code);        // abbreviation code
-                debug_info.buf.writeString("_Delegate");  // DW_AT_name
+                debug_info.buf.writeuLEB128(code);       // abbreviation code
+                debug_info.buf.writeString(t.Tident);    // DW_AT_name
                 debug_info.buf.writeByte(tysize(t.Tty)); // DW_AT_byte_size
 
-                // ctxptr
+                // ptr
                 code = dwarf_abbrev_code(abbrevTypeMember.ptr, (abbrevTypeMember).sizeof);
                 debug_info.buf.writeuLEB128(code);        // abbreviation code
-                debug_info.buf.writeString("ctxptr");     // DW_AT_name
+                debug_info.buf.writeString("ptr");        // DW_AT_name
                 debug_info.buf.write32(pvoididx);         // DW_AT_type
 
                 debug_info.buf.writeByte(2);              // DW_AT_data_member_location

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -143,6 +143,7 @@ public:
                 // Mangle as delegate
                 type* tf = type_function(TYnfunc, null, false, tp);
                 tp = type_delegate(tf);
+                tp.Tident = t.toPrettyChars(true);
             }
             types[i] = tp;
         }
@@ -154,6 +155,7 @@ public:
     override void visit(TypeDelegate t)
     {
         t.ctype = type_delegate(Type_toCtype(t.next));
+        t.ctype.Tident = t.toPrettyChars(true);
     }
 
     override void visit(TypeStruct t)

--- a/test/dshell/extra-files/dwarf/delegates.d
+++ b/test/dshell/extra-files/dwarf/delegates.d
@@ -1,0 +1,11 @@
+/*
+EXTRA_ARGS: -defaultlib=
+*/
+
+void main()
+{
+    auto dg = delegate() @safe pure nothrow @nogc {};
+    auto dg_gc_sys = delegate() @system pure nothrow { new int[10]; };
+    auto dg_lazy = delegate(lazy void f) {};
+}
+

--- a/test/dshell/extra-files/dwarf/excepted_results/delegates.txt
+++ b/test/dshell/extra-files/dwarf/excepted_results/delegates.txt
@@ -1,0 +1,9 @@
+DW_AT_name        : dg
+DW_AT_name        : void delegate() pure nothrow @nogc @safe
+DW_AT_name        : dg_gc_sys
+DW_AT_name        : void delegate() pure nothrow @system
+DW_AT_name        : dg_lazy
+DW_AT_name        : void delegate(lazy void f) pure nothrow @nogc @safe
+DW_AT_name        : pure nothrow @nogc @safe void(lazy void f)
+DW_AT_name        : ptr
+DW_AT_name        : funcptr


### PR DESCRIPTION
    According to the specification, the memory layout for delegates have the
    context pointer as `ptr` instead of `ctxptr` and this also matches the compiler
    behaviour so debug info should also report correct member names.
    
    Delegates are currently reported as `_Delegate` which is not distinguishable
    among other delegate types with different return types and parameters, so name
    these types with their qualified name is desirable.
    
    Fixes #22459.
    
    Signed-off-by: Luís Ferreira <contact@lsferreira.net>