### PR TITLE
fix sizeof for pthread_mutex_t on Solaris

### DIFF
--- a/src/dmd/backend/os.d
+++ b/src/dmd/backend/os.d
@@ -972,7 +972,7 @@ else version(Solaris)
 {
 int os_critsecsize32()
 {
-    return sizeof(pthread_mutex_t);
+    return pthread_mutex_t.sizeof;
 }
 
 int os_critsecsize64()


### PR DESCRIPTION
Hello,

sizeof is a property, not a function call. This pull request fixes it for pthread_mutex_t on Solaris/Illumos systems.
I successfully tested it on a recent OpenIndiana system.