### PR TITLE
Minor: Move a test from traits compiles to fail compilation

### DIFF
--- a/test/compilable/test4090.d
+++ b/test/compilable/test4090.d
@@ -12,9 +12,6 @@ void test4090a()
         // inference + qualifier + ref
         foreach (          ref x; arr) static assert(is(typeof(x) == int));
         foreach (    const ref x; arr) static assert(is(typeof(x) == const int));
-      static assert(!__traits(compiles, {
-        foreach (immutable ref x; arr) {}
-      }));
 
         // with exact type + qualifier
         foreach (          int x; arr) static assert(is(typeof(x) == int));
@@ -24,25 +21,11 @@ void test4090a()
         // with exact type + qualifier + ref
         foreach (          ref int x; arr) static assert(is(typeof(x) == int));
         foreach (    const ref int x; arr) static assert(is(typeof(x) == const int));
-      static assert(!__traits(compiles, {
-        foreach (immutable ref int x; arr) {}
-      }));
 
         // convertible type + qualifier
         foreach (          double x; arr) static assert(is(typeof(x) == double));
         foreach (    const double x; arr) static assert(is(typeof(x) == const double));
         foreach (immutable double x; arr) static assert(is(typeof(x) == immutable double));
-
-        // convertible type + qualifier + ref
-      static assert(!__traits(compiles, {
-        foreach (          ref double x; arr) {}
-      }));
-      static assert(!__traits(compiles, {
-        foreach (    const ref double x; arr) {}
-      }));
-      static assert(!__traits(compiles, {
-        foreach (immutable ref double x; arr) {}
-      }));
     }
     // for the immutable elements
     {

--- a/test/fail_compilation/foreach2.d
+++ b/test/fail_compilation/foreach2.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/foreach2.d(15): Error: argument type mismatch, `int` to `ref immutable(int)`
+fail_compilation/foreach2.d(16): Error: argument type mismatch, `int` to `ref immutable(int)`
+fail_compilation/foreach2.d(19): Error: argument type mismatch, `int` to `ref double`
+fail_compilation/foreach2.d(20): Error: argument type mismatch, `int` to `ref const(double)`
+fail_compilation/foreach2.d(21): Error: argument type mismatch, `int` to `ref immutable(double)`
+---
+*/
+void test4090 ()
+{
+    // From https://issues.dlang.org/show_bug.cgi?id=4090
+    int[] arr = [1,2,3];
+    foreach (immutable ref x; arr) {}
+    foreach (immutable ref int x; arr) {}
+
+    // convertible type + qualifier + ref
+    foreach (          ref double x; arr) {}
+    foreach (    const ref double x; arr) {}
+    foreach (immutable ref double x; arr) {}
+}


### PR DESCRIPTION
It's better to have tests in fail_compilation, as they ensure the
error message is correct (the test fails for the right reason),
and it makes it easier to find in which condition a certain error triggers.