### PR TITLE
Fix Issue 22421 - static foreach introduces semantic difference between indexing and iteration variable

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -452,7 +452,6 @@ extern (C++) final class StaticForeach : RootObject
             sc = sc.startCTFE();
             aggrfe.aggr = aggrfe.aggr.expressionSemantic(sc);
             sc = sc.endCTFE();
-            aggrfe.aggr = aggrfe.aggr.optimize(WANTvalue);
         }
 
         if (aggrfe && aggrfe.aggr.type.toBasetype().ty == Terror)

--- a/test/compilable/test22421.d
+++ b/test/compilable/test22421.d
@@ -1,0 +1,19 @@
+// https://issues.dlang.org/show_bug.cgi?id=22421
+
+alias AliasSeq(T...) = T;
+
+template staticMap(alias fun, args...)
+{
+    alias staticMap = AliasSeq!();
+    static foreach(arg; args)
+        staticMap = AliasSeq!(staticMap, fun!arg);
+}
+
+template id(alias what)
+{
+    enum id = __traits(identifier, what);
+}
+
+enum A { a }
+
+static assert(staticMap!(id, A.a) == AliasSeq!("a"));


### PR DESCRIPTION
This early constant folding of the input destroys `enum` references.