### PR TITLE
backend: dwarfdbginf: add UTF encoding to dchar types

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -2602,7 +2602,7 @@ static if (1)
             case TYuint:        p = "uint";          goto Lsigned;
             case TYlong:        p = "long";          goto Lsigned;
             case TYulong:       p = "ulong";         goto Lsigned;
-            case TYdchar:       p = "dchar";                goto Lsigned;
+            case TYdchar:       p = "dchar";         ate = DW_ATE_UTF;                     goto Lsigned;
             case TYfloat:       p = "float";        ate = DW_ATE_float;     goto Lsigned;
             case TYdouble_alias:
             case TYdouble:      p = "double";       ate = DW_ATE_float;     goto Lsigned;

--- a/test/dshell/extra-files/dwarf/excepted_results/fix22468.txt
+++ b/test/dshell/extra-files/dwarf/excepted_results/fix22468.txt
@@ -1,0 +1,4 @@
+DW_AT_name        : fix22468.dcharVar
+DW_AT_name        : dchar
+DW_AT_byte_size   : 4
+DW_AT_encoding    : 16	(unicode string)

--- a/test/dshell/extra-files/dwarf/fix22468.d
+++ b/test/dshell/extra-files/dwarf/fix22468.d
@@ -1,0 +1,5 @@
+/*
+EXTRA_ARGS: -g -defaultlib= -betterC -c
+*/
+
+dchar dcharVar;


### PR DESCRIPTION
Currently `dchar` types are exported as signed encoding which is wrong, because
`dchar` is supposed to represent UTF-32 encoded characters, so we should export
the right encoding to the debug info.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>