### PR TITLE
"Fix" bug 22175: cdstreq should always use ES:DI for 16-size structs (DO NOT MERGE- but, please, help?)

### DIFF
--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -4554,8 +4554,7 @@ else
 
         cdb.genc2(0x81,(rex << 16) | modregrm(3,5,DI), type_size(e.ET));   // SUB DI,numbytes
         regm_t retregs = mDI;
-        if (*pretregs & mMSW && !(config.exe & EX_flat))
-            retregs |= mES;
+        if (*pretregs & mMSW) retregs |= mES;
         fixresult(cdb,e,retregs,pretregs);
     }
 }

--- a/test/compilable/test22175.d
+++ b/test/compilable/test22175.d
@@ -1,0 +1,19 @@
+// https://issues.dlang.org/show_bug.cgi?id=22175
+struct Struct
+{
+    short a, b, c, d;
+    bool e;
+}
+
+Struct foo()
+{
+    return Struct.init;
+}
+
+void main()
+{
+    int i = 0;
+    Struct var = i ? Struct.init : foo;
+
+    Struct test() { return var; }
+}


### PR DESCRIPTION
**Do not merge!** I definitely don't understand what I'm doing here! This is presented as a request for comments!

Okay.

Something very weird is going on with [22175](https://issues.dlang.org/show_bug.cgi?id=22175). It needs to do a struct assignment from AX|DX, because it's trying to `?:` merge a 9-byte (that is, rounded up to 16-byte) struct. But it falls into a codepath in `cdstreq` where I think it thinks it's trying to work with pointers? So it does some sort of weird fixup and then decides to only use DI, not DI|ES, because we're on x86_64 and we don't need segment addressing (ES:DI) there. But we're working with a `streq` elem, and the result of that isn't a pointer to begin with?? So then we're stuck trying to fit a 16-byte result in a 8-byte register and crash.

The PR just removes that EX_flat check, which gives it enough space to fit AX|DX into. This seems to pass the testsuite, so _technically_ it's a fix, but the goal here is more to get some eyes on that codepath than to get this PR merged.

Help pls? 🥺