### PR TITLE
Fix issue 22163 - wrong code with static float array and delegate accessing it

### DIFF
--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -4118,8 +4118,8 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc, out regm_
         // This logic is same as FuncParamRegs_alloc function at src/dmd/backend/cod1.d
         //
         // Find suitable SROA based on the element type
-        // (Don't put volatile parameters in registers)
-        if (tyb == TYarray && !(t.Tty & mTYvolatile))
+        // (Don't put volatile parameters in registers on Windows)
+        if (tyb == TYarray && (config.exe != EX_WIN64 || !(t.Tty & mTYvolatile)))
         {
             type *targ1;
             argtypes(t, targ1, t2);

--- a/test/runnable/test22163.d
+++ b/test/runnable/test22163.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=22163
+void fun(float[2] arr)
+{
+    assert(arr[0] == 10.0);
+    assert(arr[1] == 20.0);
+    auto dg = (int x) => arr[0];
+}
+
+void main()
+{
+    float[2] arr = [10.0, 20.0];
+    fun(arr);
+}


### PR DESCRIPTION
Reposting my analysis from bugzilla:

---
The delegate makes the parameter volatile in dmd/tocsym.d
```D
if (vd.nestedrefs.dim)
{
    /* Symbol is accessed by a nested function. Make sure
     * it is not put in a register, and that the optimizer
     * assumes it is modified across function calls and pointer
     * dereferences.
     */
    //printf("\tnested ref, not register\n");
    type_setcv(&t, t.Tty | mTYvolatile);
}
```

Then in dmd/backend/cod1.d:FuncParamRegs_alloc the float[2] is combined into the xmm0 register:

```D
if (tyaggregate(ty))
{
/* ... */
        else if (tybasic(t.Tty) == TYarray)
        {
            if (I64)
                argtypes(t, targ1, targ2);
        }
```

But in dmd/backend/cod3.d:prolog_loadparams this branch isn't taken:
```D
// This logic is same as FuncParamRegs_alloc function at src/dmd/backend/cod1.d
//
// Find suitable SROA based on the element type
// (Don't put volatile parameters in registers)
if (tyb == TYarray && !(t.Tty & mTYvolatile))
{
    type *targ1;
    argtypes(t, targ1, t2);
    if (targ1)
        t = targ1;
}
```
Which makes it load a `double` from xmm0 instead of a `float`. The comment "This logic is same as FuncParamRegs_alloc function" is no longer true, but I'm not certain what the fix is. I doubt `volatile` should affect the abi, but "Don't put volatile parameters in registers" was written for a reason so I don't want to remove that without consideration.

---

So in this PR I remove the check for `mTYvolatile` to see if something in the test suite breaks. If it passes, still be careful with merging: this could really use a review from someone who knows a thing or two about the backend, volatile and the Posix ABI.