### PR TITLE
Fix 22472 - Correct error message for invalid `void` return

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3348,7 +3348,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     }
                     else if (rs.exp.op != TOK.error)
                     {
-                        rs.error("Expected return type of `%s`, not `%s`:",
+                        rs.error("expected return type of `%s`, not `%s`:",
                                  tret.toChars(),
                                  rs.exp.type.toChars());
                         errorSupplemental((fd.returns) ? (*fd.returns)[0].loc : fd.loc,
@@ -3445,7 +3445,12 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             if (tbret.ty != Tvoid && !resType.isTypeNoreturn()) // if non-void return
             {
                 if (tbret.ty != Terror)
-                    rs.error("`return` expression expected");
+                {
+                    if (e0)
+                        rs.error("expected return type of `%s`, not `%s`", tret.toChars(), resType.toChars());
+                    else
+                        rs.error("`return` expression expected");
+                }
                 errors = true;
             }
             else if (fd.isMain())

--- a/test/fail_compilation/diag20059.d
+++ b/test/fail_compilation/diag20059.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag20059.d(15): Error: Expected return type of `string`, not `string[]`:
+fail_compilation/diag20059.d(15): Error: expected return type of `string`, not `string[]`:
 fail_compilation/diag20059.d(13):        Return type of `string` inferred here.
 ---
 */

--- a/test/fail_compilation/ice10212.d
+++ b/test/fail_compilation/ice10212.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10212.d(13): Error: Expected return type of `int`, not `int function() pure nothrow @nogc @safe`:
+fail_compilation/ice10212.d(13): Error: expected return type of `int`, not `int function() pure nothrow @nogc @safe`:
 fail_compilation/ice10212.d(13):        Return type of `int` inferred here.
 ---
 */

--- a/test/fail_compilation/noreturn2.d
+++ b/test/fail_compilation/noreturn2.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -w -o-
 
 TEST_OUTPUT:
 ---
-fail_compilation/noreturn2.d(18): Error: `return` expression expected
+fail_compilation/noreturn2.d(18): Error: expected return type of `noreturn`, not `void`
 ---
 
 https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1034.md
@@ -22,7 +22,7 @@ noreturn returnVoid()
 /+
 TEST_OUTPUT:
 ---
-fail_compilation/noreturn2.d(37): Error: Expected return type of `int`, not `string`:
+fail_compilation/noreturn2.d(37): Error: expected return type of `int`, not `string`:
 fail_compilation/noreturn2.d(35):        Return type of `int` inferred here.
 ---
 +/
@@ -62,4 +62,29 @@ fail_compilation/noreturn2.d(64): Error: cannot implicitly convert expression `1
 noreturn returnsValue()
 {
     return 1;
+}
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/noreturn2.d(75): Error: expected return type of `int`, not `void`
+---
++/
+int returnVoid2()
+{
+    return doStuff();
+}
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/noreturn2.d(89): Error: mismatched function return type inference of `void` and `int`
+---
++/
+auto returnVoid3(int i)
+{
+    if (i > 0)
+        return i;
+    else
+        return doStuff();
 }


### PR DESCRIPTION
The old error message (`return expression expected`) ignored the
possibility that `void` and `noreturn` expressions are moved into `e0`.
This caused misleading error messages when errors are detected after
the move, claiming that the expression found in the source code is
missing.

Small improvement to #13135 because this is more likely to happen for
`noreturn` functions.