### PR TITLE
Add missing change after using .max instead of MAX

### DIFF
--- a/src/dmd/backend/drtlsym.d
+++ b/src/dmd/backend/drtlsym.d
@@ -284,7 +284,7 @@ version (MARS)
 void rtlsym_reset()
 {
     clib_inited = 0;            // reset CLIB symbols, too
-    for (size_t i = 0; i < RTLSYM.max; i++)
+    for (size_t i = 0; i <= RTLSYM.max; i++)
     {
         if (rtlsym[i])
         {


### PR DESCRIPTION
The commit 0a26693 used .max instead of MAX but .max == MAX - 1. So to
pass through all the array in the loop, it should do one more iteration.

See https://github.com/dlang/dmd/pull/13233#discussion_r739196773