### PR TITLE
Add openbsd to ignore list

### DIFF
--- a/test/fail_compilation/fail3753.d
+++ b/test/fail_compilation/fail3753.d
@@ -1,5 +1,5 @@
 /*
-DISABLED: dragonflybsd freebsd linux osx win32
+DISABLED: dragonflybsd freebsd linux osx win32 openbsd
 TEST_OUTPUT:
 ---
 Error: cannot mix `core.std.stdlib.alloca()` and exception handling in `_Dmain()`


### PR DESCRIPTION
Fix Issue 22477 - OpenBSD: Add to fail_compilation/fail3753.d ignore list