### PR TITLE
Fix Issue 21380 - A case of compiler crash when using auto ref

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -76,6 +76,7 @@ public Expression ctfeInterpret(Expression e)
         case TOK.template_:              // non-eponymous template/instance
         case TOK.scope_:                 // ditto
         case TOK.dotTemplateDeclaration: // ditto, e.e1 doesn't matter here
+        case TOK.dotTemplateInstance:    // ditto
         case TOK.dot:                    // ditto
              if (e.type.ty == Terror)
                 return ErrorExp.get();

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4989,6 +4989,31 @@ extern (C++) final class DotTemplateInstanceExp : UnaExp
         return ti.updateTempDecl(sc, s);
     }
 
+    override bool checkType()
+    {
+        // Same logic as ScopeExp.checkType()
+        if (ti.tempdecl &&
+            ti.semantictiargsdone &&
+            ti.semanticRun == PASS.init)
+        {
+            error("partial %s `%s` has no type", ti.kind(), toChars());
+            return true;
+        }
+        return false;
+    }
+
+    override bool checkValue()
+    {
+        if (ti.tempdecl &&
+            ti.semantictiargsdone &&
+            ti.semanticRun == PASS.init)
+
+            error("partial %s `%s` has no value", ti.kind(), toChars());
+        else
+            error("%s `%s` has no value", ti.kind(), ti.toChars());
+        return true;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -784,6 +784,8 @@ public:
 
     DotTemplateInstanceExp *syntaxCopy();
     bool findTempDecl(Scope *sc);
+    bool checkType();
+    bool checkValue();
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6971,6 +6971,8 @@ public:
     TemplateInstance* ti;
     DotTemplateInstanceExp* syntaxCopy();
     bool findTempDecl(Scope* sc);
+    bool checkType();
+    bool checkValue();
     void accept(Visitor* v);
 };
 

--- a/test/fail_compilation/test21380.d
+++ b/test/fail_compilation/test21380.d
@@ -1,0 +1,46 @@
+// https://issues.dlang.org/show_bug.cgi?id=21380
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test21380.d(39): Error: partial template instance `MySerializer().serializeSinkType!int` has no value
+fail_compilation/test21380.d(44): Error: template instance `test21380.SupportSinkTypeSer!(MySerializer!int)` error instantiating
+---
+*/
+
+template isSomeFunction(T...)
+if (T.length == 1)
+{
+    static if (is(typeof(& T[0]) U : U*) && is(U == function) || is(typeof(& T[0]) U == delegate))
+    {
+        // T is a (nested) function symbol.
+        enum bool isSomeFunction = true;
+    }
+    else static if (is(T[0] W) || is(typeof(T[0]) W))
+    {
+        // T is an expression or a type.  Take the type of it and examine.
+        static if (is(W F : F*) && is(F == function))
+            enum bool isSomeFunction = true; // function pointer
+        else
+            enum bool isSomeFunction = is(W == function) || is(W == delegate);
+    }
+    else
+        enum bool isSomeFunction = false;
+}
+
+struct MySerializer (T)
+{
+	void serializeSinkType(T2) (scope auto ref T2 record) {}
+}
+
+template SupportSinkTypeSer(SerT)
+{
+    /* Note: Partial template instance because it needs inference, in this case
+       it cannot infer 'auto ref' parameter */
+	enum SupportSinkTypeSer = isSomeFunction!(SerT.init.serializeSinkType!int);
+}
+
+int main()
+{
+	enum x = SupportSinkTypeSer!(MySerializer!int);
+	return 0;
+}


### PR DESCRIPTION
Setting the type of an unresolved (needs inference) `DotTemplateInstanceExp` as `void` like an unresolved `ScopeExp`.
There's a tiny adjustment to `opDispatch` logic because it was depending on `exp.type` set to `null` in `resolvePropertiesX`, this function shouldn't error out if something needs inference to be resolved, just return the same exp.