### PR TITLE
Fix 21538,20904: Correct implicitConvTo order for delegate parameters in `Type.covariant`

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -515,7 +515,7 @@ extern (C++) abstract class Type : ASTNode
                         }
                         else if (tp1.ty == Tdelegate)
                         {
-                            if (tp1.implicitConvTo(tp2))
+                            if (tp2.implicitConvTo(tp1))
                                 goto Lcov;
                         }
                     }
@@ -4988,7 +4988,7 @@ extern (C++) final class TypeFunction : TypeNext
     {
         assert(to);
 
-        if (this == to)
+        if (this.equals(to))
             return MATCH.constant;
 
         if (this.covariant(to) == Covariant.yes)
@@ -5301,7 +5301,7 @@ extern (C++) final class TypeDelegate : TypeNext
         //printf("TypeDelegate.implicitConvTo(this=%p, to=%p)\n", this, to);
         //printf("from: %s\n", toChars());
         //printf("to  : %s\n", to.toChars());
-        if (this == to)
+        if (this.equals(to))
             return MATCH.exact;
 
         if (auto toDg = to.isTypeDelegate())

--- a/test/compilable/covariant_override.d
+++ b/test/compilable/covariant_override.d
@@ -1,0 +1,34 @@
+// https://issues.dlang.org/show_bug.cgi?id=21538
+// REQUIRED_ARGS: -preview=dip1000
+
+interface I
+{
+    void f(void delegate() @safe dg) @safe;
+}
+
+class CI : I
+{
+    override void f(void delegate() @system dg) @safe { }
+}
+
+abstract class A
+{
+    void f(void delegate() @safe dg) @safe;
+}
+
+class CA : A
+{
+    override void f(void delegate() @system dg) @safe { }
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=20904
+auto blah(void delegate())
+{
+}
+
+void delegate()[string] r;
+void main()
+{
+    void delegate() nothrow a;
+    r["v"] = a;
+}

--- a/test/fail_compilation/covariant_override.d
+++ b/test/fail_compilation/covariant_override.d
@@ -1,0 +1,35 @@
+/++
+https://issues.dlang.org/show_bug.cgi?id=21538
+
+TEST_OUTPUT:
+---
+fail_compilation/covariant_override.d(23): Error: function `@safe void covariant_override.CI.f(void delegate() @safe dg)` does not override any function, did you mean to override `@safe void covariant_override.I.f(void delegate() @system dg)`?
+fail_compilation/covariant_override.d(34): Error: function `@safe void covariant_override.CA.f(void delegate() @safe dg)` does not override any function, did you mean to override `@safe void covariant_override.A.f(void delegate() @system dg)`?
+fail_compilation/covariant_override.d(20): Error: class `covariant_override.CI` interface function `void f(void delegate() @system dg) @safe` is not implemented
+---
+++/
+
+static assert(!is(void delegate() @system : void delegate() @safe));
+static assert( is(void delegate() @safe : void delegate() @system));
+
+interface I
+{
+    void f(void delegate() @system dg) @safe;
+}
+
+class CI : I
+{
+    // this overrride should not be legal
+    override void f(void delegate() @safe dg) @safe { }
+}
+
+abstract class A
+{
+    void f(void delegate() @system dg) @safe;
+}
+
+class CA : A
+{
+    // this overrride should not be legal
+    override void f(void delegate() @safe dg) @safe { }
+}

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7923,8 +7923,9 @@ void test17349()
 {
     static struct S
     {
-        int bar(void delegate(ref int*)) { return 1; }
-        int bar(void delegate(ref const int*)) const { return 2; }
+        // Specify attribute inferred for dg1/dg2
+        int bar(void delegate(ref int*) pure nothrow @nogc @safe) { return 1; }
+        int bar(void delegate(ref const int*) pure nothrow @nogc @safe) const { return 2; }
     }
 
     void dg1(ref int*) { }

--- a/test/unit/semantic/covariance.d
+++ b/test/unit/semantic/covariance.d
@@ -226,8 +226,6 @@ unittest
     runTest(test);
 }
 
-// BUG: Note that the results are reversed when compared to function pointers
-//      in "function-pointer-params". To be fixed soon(TM)
 @("delegate-params")
 unittest
 {
@@ -239,11 +237,11 @@ unittest
         },
 
         baseToTarget: {
-            result: Covariant.distinct,
+            result: Covariant.yes,
         },
 
         targetToBase: {
-            result: Covariant.yes
+            result: Covariant.distinct,
         }
     };
     runTest(test);
@@ -721,7 +719,6 @@ unittest
     runTest(test);
 }
 
-// Another difference between function pointers / delegates as mentioned above
 @("xtest46-delegate")
 unittest
 {
@@ -741,7 +738,7 @@ unittest
         },
 
         targetToBase: {
-            result: Covariant.yes
+            result: Covariant.distinct
         }
     };
     runTest(test);


### PR DESCRIPTION
The ordering was inversed when compared to function pointers. That caused
the check to accept e.g. less restrictive attributes for callbacks.

Also changed the equality checks for `TypeFuntion` and `TypeDelegate`
to `equals` because `==` didn't call the former and hence caused problems
for duplicate instances.

---

~~Preliminary check whether this affects projects on BuildKite as this breaks a test case in `runnable/xtest46.d` (which is an accept-invalid when using `delegate` parameters and already rejected for function pointers).~~

The test case in `runnable/xtest46.d` was not found in any project on Buildkite