### PR TITLE
Fix Issue 15711 - Incorrect type inferring of [char]/string when passed via recursive template

### DIFF
--- a/test/compilable/test15711.d
+++ b/test/compilable/test15711.d
@@ -1,0 +1,31 @@
+// https://issues.dlang.org/show_bug.cgi?id=15711
+
+struct Quu {
+    string val;
+}
+
+string[] result = foo!(0, [Quu(['z']), Quu("")]);
+
+template foo(size_t i, Quu[] data, string[] results = []) {
+    static if (i < data.length) {
+        enum def = data[i];
+        enum foo = foo!(i+1, data, results ~ def.val);
+    }
+    else {
+        enum foo = results;
+    }
+}
+
+// Run-time version already works
+
+string[] result_rt = foo_rt(0, [Quu(['z']), Quu("")]);
+
+string[] foo_rt(size_t i, Quu[] data, string[] results = []) {
+    if (i < data.length) {
+        auto def = data[i];
+        return foo_rt(i+1, data, results ~ def.val);
+    }
+    else {
+        return results;
+    }
+}


### PR DESCRIPTION
…, extracting it from a structure field.

There was a forced semantic re-running that ruined the type painting of array literals.