### PR TITLE
Fix 22042 - Merge `funcptr` type before merging `TypeDelegate`'s

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2302,6 +2302,14 @@ Type merge(Type type)
                 return type;
             goto default;
 
+        case Tdelegate:
+        {
+            // Ensure that the TypeFunction is merged before (if possible)
+            auto td = type.isTypeDelegate();
+            td.next = td.next.merge();
+            goto default;
+        }
+
         default:
             if (type.nextOf() && !type.nextOf().deco)
                 return type;

--- a/test/compilable/test22042.d
+++ b/test/compilable/test22042.d
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=22042
+
+shared(void delegate()[]) onRelease;
+
+void main()
+{
+	onRelease ~= (){};
+}


### PR DESCRIPTION
Ensures that `deco` is set for the `funcptr` (`next`) whenever possible
s.t. `merge` doesn't exit early in the `default` case.

Previously `TypeDelegate`s without `deco` could reach the `TypeInfo`
generation and trigger the assertion due to the missing mangling string.
Also could cause problems with non-unique types but didn't find a
test case (yet?).