### PR TITLE
Fix Issue 21039 - `alias this` returns 'null' for ref types when put into array initializer

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -3174,6 +3174,14 @@ Lagain:
     Lcc:
         while (1)
         {
+            MATCH i1woat = MATCH.exact;
+            MATCH i2woat = MATCH.exact;
+
+            if (auto t2c = t2.isTypeClass())
+                i1woat = t2c.implicitConvToWithoutAliasThis(t1);
+            if (auto t1c = t1.isTypeClass())
+                i2woat = t1c.implicitConvToWithoutAliasThis(t2);
+
             MATCH i1 = e2.implicitConvTo(t1);
             MATCH i2 = e1.implicitConvTo(t2);
 
@@ -3186,10 +3194,25 @@ Lagain:
                     i2 = MATCH.nomatch;
             }
 
-            if (i2)
+            // Match but without 'alias this' on classes
+            if (i2 && i2woat)
                 return coerce(t2);
-            if (i1)
+            if (i1 && i1woat)
                 return coerce(t1);
+
+            // Here use implicitCastTo() instead of castTo() to try 'alias this' on classes
+            Type coerceImplicit(Type towards)
+            {
+                e1 = e1.implicitCastTo(sc, towards);
+                e2 = e2.implicitCastTo(sc, towards);
+                return Lret(towards);
+            }
+
+            // Implicit conversion with 'alias this'
+            if (i2)
+                return coerceImplicit(t2);
+            if (i1)
+                return coerceImplicit(t1);
 
             if (t1.ty == Tclass && t2.ty == Tclass)
             {

--- a/test/runnable/test21039.d
+++ b/test/runnable/test21039.d
@@ -1,0 +1,27 @@
+// https://issues.dlang.org/show_bug.cgi?id=21039
+
+class Inner {}
+
+class Outer {
+    Inner inner;
+    alias inner this;
+    this(Inner i) { inner = i; }
+}
+
+void main() {
+  auto inner = new Inner;
+  auto outer = new Outer(new Inner);
+
+  // implicit cast goes through 'alias this'
+
+  Inner inner1 = outer;  // Already does it
+  assert(inner1);
+
+  Inner[] inners = [inner, outer]; // Fixed
+
+  assert(inners[0], "first element is null");
+  assert(inners[1], "second element is null");
+
+  Inner inner2 = 1 ? outer : inner; // Fixed
+  assert(inner2);
+}


### PR DESCRIPTION
Fix `typeMerge()` to use implicit conversion instead of explicit cast on classes to allow going through `alias this`.