### PR TITLE
Fix 22494 - Search paths for dmd.conf missing from dmd man page

### DIFF
--- a/docs/gen_man.d
+++ b/docs/gen_man.d
@@ -43,10 +43,22 @@ The actual linking is done by running \fBgcc\fR.
 This ensures compatibility with modules compiled with
 \fBgcc\fR.
 .SH FILES
+.TP
 .I /etc/dmd.conf
-dmd will look for the initialization file
+\fBdmd\fR will look for the initialization file
 .I dmd.conf
-in the directory \fI/etc\fR.
+in the following directories:
+.RS
+.IP 1. 3
+The current working directory.
+.IP 2. 3
+\fB$HOME\fR
+.IP 3. 3
+The directory containing the \fBdmd\fR executable.
+.IP 4. 3
+\fI/etc\fR
+.RE
+.IP
 If found, environment variable settings in the file will
 override any existing settings.
 .SH ENVIRONMENT

--- a/docs/gen_man.d
+++ b/docs/gen_man.d
@@ -45,22 +45,9 @@ This ensures compatibility with modules compiled with
 .SH FILES
 .TP
 .I /etc/dmd.conf
-\fBdmd\fR will look for the initialization file
-.I dmd.conf
-in the following directories:
-.RS
-.IP 1. 3
-The current working directory.
-.IP 2. 3
-\fB$HOME\fR
-.IP 3. 3
-The directory containing the \fBdmd\fR executable.
-.IP 4. 3
-\fI/etc\fR
-.RE
-.IP
-If found, environment variable settings in the file will
-override any existing settings.
+System wide \fBdmd\fR config file. See
+.BR dmd.conf(5)
+for details.
 .SH ENVIRONMENT
 The D compiler dmd uses the following environment
 variables:

--- a/docs/man/man5/dmd.conf.5
+++ b/docs/man/man5/dmd.conf.5
@@ -9,8 +9,18 @@ dmd.conf \- configuration file for
 .SH DESCRIPTION
 dmd will look for the initialization file
 .I dmd.conf
-in the directory \fI/etc\fR. If found, environment variable
-settings in the file will override any existing settings.
+in the following directories:
+.IP 1. 3
+The current working directory.
+.IP 2. 3
+\fB$HOME\fR
+.IP 3. 3
+The directory containing the \fBdmd\fR executable.
+.IP 4. 3
+\fI/etc\fR
+.PP
+If found, environment variable settings in the file will override any
+existing settings.
 .PP
 
 This is handy to make dmd independent of programs with

--- a/docs/man/man5/dmd.conf.5
+++ b/docs/man/man5/dmd.conf.5
@@ -1,7 +1,7 @@
 .TH DMD.CONF 5 "2006-03-12" "Digital Mars" "Digital Mars D"
 .SH NAME
 dmd.conf \- configuration file for
-\BR dmd (1)
+.BR dmd (1)
 
 .SH SYNOPSIS
 .I /etc/dmd.conf


### PR DESCRIPTION
---

Rendered versions of the relevant sections are copy-pasted below, for ease of review.

#### man dmd

```
FILES
       /etc/dmd.conf
              dmd will look for the initialization file dmd.conf in  the  fol‐
              lowing directories:

              1. The current working directory.

              2. $HOME

              3. The directory containing the dmd executable.

              4. /etc

              If  found,  environment variable settings in the file will over‐
              ride any existing settings.
```

#### man dmd.conf

```
DESCRIPTION
       dmd will look for the initialization file dmd.conf in the following di‐
       rectories:

       1. The current working directory.

       2. $HOME

       3. The directory containing the dmd executable.

       4. /etc

       If found, environment variable settings in the file will  override  any
       existing settings.

       This  is handy to make dmd independent of programs with conflicting use
       of environment variables.
```