### PR TITLE
make makeTupleForeach() return a Voldemort type

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -1198,7 +1198,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
 
         // expand static foreach
         import dmd.statementsem: makeTupleForeach;
-        Dsymbols* d = makeTupleForeach!(true,true)(_scope, sfe.aggrfe, decl, sfe.needExpansion);
+        Dsymbols* d = makeTupleForeach!(true,true)(_scope, sfe.aggrfe, decl, sfe.needExpansion).decl;
         if (d) // process generated declarations
         {
             // Add members lazily.


### PR DESCRIPTION
as it eliminates the `MakeTupleForeachRet` template which significantly simplifies the code. It's further simplified by making the return type a Voldemort union.