### PR TITLE
d_do_test: Add --DRT-testmode=run-main even without `EXECUTE_ARGS`

### DIFF
--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -474,13 +474,12 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     testArgs.permuteArgs = strip(replace(testArgs.permuteArgs, "  ", " "));
 
     if (findTestParameter(envData, file, "EXECUTE_ARGS", testArgs.executeArgs))
-    {
         replaceResultsDir(testArgs.executeArgs, envData);
-        // Always run main even if compiled with '-unittest' but let
-        // tests switch to another behaviour if necessary
-        if (!testArgs.executeArgs.canFind("--DRT-testmode"))
-            testArgs.executeArgs ~= " --DRT-testmode=run-main";
-    }
+
+    // Always run main even if compiled with '-unittest' but let
+    // tests switch to another behaviour if necessary
+    if (!testArgs.executeArgs.canFind("--DRT-testmode"))
+        testArgs.executeArgs ~= " --DRT-testmode=run-main";
 
     string extraSourcesStr;
     findTestParameter(envData, file, "EXTRA_SOURCES", extraSourcesStr);


### PR DESCRIPTION
The runtime flags is necessary based on the compiler flags and hence
can be required when there are no runtime arguments.

Cherry-picks #13282 to master