### PR TITLE
Fix 18054 - Use isBool instead of toInteger when const-folding cast(bool)

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1087,7 +1087,18 @@ UnionExp Cast(const ref Loc loc, Type type, Type to, Expression e1)
     }
     else if (tb.ty == Tbool)
     {
-        emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() != 0, type);
+        bool val = void;
+        if (e1.isBool(true))
+            val = true;
+        else if (e1.isBool(false))
+            val = false;
+        else
+        {
+            cantExp(ue);
+            return ue;
+        }
+
+        emplaceExp!(IntegerExp)(&ue, loc, val, type);
     }
     else if (type.isintegral())
     {

--- a/test/runnable/test18054.d
+++ b/test/runnable/test18054.d
@@ -1,0 +1,41 @@
+/+
+REQUIRED_ARGS: -d
+RUN_OUTPUT:
+---
+float: 1 == 1
+double: 1 == 1
+real: 1 == 1
+ifloat: 1 == 1
+idouble: 1 == 1
+ireal: 1 == 1
+cfloat: 1 == 1
+cdouble: 1 == 1
+creal: 1 == 1
+---
++/
+
+import core.stdc.stdio : printf;
+
+void test(T, string lit)()
+{
+    T d = mixin(lit);
+    bool runtime = cast(bool) d;
+    bool folded  = cast(bool) mixin(lit);
+
+    printf((T.stringof ~ ": %d == %d\n\0").ptr, runtime, folded);
+}
+
+void main()
+{
+    test!(float,  "0.5f");
+    test!(double, "0.5" );
+    test!(real,   "0.5L");
+
+    test!(ifloat,  "0.5i");
+    test!(idouble, "0.5i");
+    test!(ireal,   "0.5i");
+
+    test!(cfloat,  "0.3 + 0.5i");
+    test!(cdouble, "0.3 + 0.5i");
+    test!(creal,   "0.3 + 0.5i");
+}


### PR DESCRIPTION
`RealExp` / `ComplexExp` may hold values that don't have a matching
integer value (unlike `IntegerExp`). Switching to `toBool` ensures
proper boolean conversion according to the current type.

The test output shown below (before this change) was caused by the
invalid const-folding for floating point literals.

```
float: 1 == 0
double: 1 == 0
real: 1 == 0
ifloat: 1 == 0
idouble: 1 == 0
ireal: 1 == 0
cfloat: 1 == 0
cdouble: 1 == 0
creal: 1 == 0
```