### PR TITLE
Refactor Expression.isBool to return an optional value 

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1418,11 +1418,11 @@ auto sourceFiles()
             outbuffer.h
         "),
         root: fileArray(env["ROOT"], "
-            aav.d longdouble.d man.d response.d speller.d string.d strtold.d
+            aav.d longdouble.d man.d optional.d response.d speller.d string.d strtold.d
         "),
         rootHeaders: fileArray(env["ROOT"], "
             array.h bitarray.h ctfloat.h dcompat.h dsystem.h file.h filename.h longdouble.h
-            object.h port.h rmem.h root.h
+            object.h optional.h port.h rmem.h root.h
         "),
         backend: fileArray(env["C"], "
             backend.d bcomplex.d evalu8.d divcoeff.d dvec.d go.d gsroa.d glocal.d gdag.d gother.d gflow.d

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -929,12 +929,13 @@ extern (C++) final class PragmaDeclaration : AttribDeclaration
             (*args)[0] = e;
         }
 
-        if (e.isBool(true))
-            return PINLINE.always;
-        else if (e.isBool(false))
-            return PINLINE.never;
-        else
+        const opt = e.toBool();
+        if (opt.isEmpty())
             return PINLINE.default_;
+        else if (opt.get())
+            return PINLINE.always;
+        else
+            return PINLINE.never;
     }
 
     override const(char)* kind() const

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -102,7 +102,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                 if (s.exp.op == TOK.assert_)
                 {
                     AssertExp a = cast(AssertExp)s.exp;
-                    if (a.e1.isBool(false)) // if it's an assert(0)
+                    if (a.e1.toBool().hasValue(false)) // if it's an assert(0)
                     {
                         result = BE.halt;
                         return;
@@ -216,7 +216,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             {
                 if (canThrow(s.condition, func, mustNotThrow))
                     result |= BE.throw_;
-                if (!(result & BE.break_) && s.condition.isBool(true))
+                if (!(result & BE.break_) && s.condition.toBool().hasValue(true))
                     result &= ~BE.fallthru;
             }
             result &= ~(BE.break_ | BE.continue_);
@@ -235,9 +235,10 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             {
                 if (canThrow(s.condition, func, mustNotThrow))
                     result |= BE.throw_;
-                if (s.condition.isBool(true))
+                const opt = s.condition.toBool();
+                if (opt.hasValue(true))
                     result &= ~BE.fallthru;
-                else if (s.condition.isBool(false))
+                else if (opt.hasValue(false))
                     return;
             }
             else
@@ -274,11 +275,13 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             result = BE.none;
             if (canThrow(s.condition, func, mustNotThrow))
                 result |= BE.throw_;
-            if (s.condition.isBool(true))
+
+            const opt = s.condition.toBool();
+            if (opt.hasValue(true))
             {
                 result |= blockExit(s.ifbody, func, mustNotThrow);
             }
-            else if (s.condition.isBool(false))
+            else if (opt.hasValue(false))
             {
                 result |= blockExit(s.elsebody, func, mustNotThrow);
             }
@@ -534,4 +537,3 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
     s.accept(be);
     return be.result;
 }
-

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -120,7 +120,7 @@ UnionExp Not(Type type, Expression e1)
 {
     UnionExp ue = void;
     Loc loc = e1.loc;
-    emplaceExp!(IntegerExp)(&ue, loc, e1.isBool(false) ? 1 : 0, type);
+    emplaceExp!(IntegerExp)(&ue, loc, e1.toBool().hasValue(false) ? 1 : 0, type);
     return ue;
 }
 
@@ -128,7 +128,7 @@ private UnionExp Bool(Type type, Expression e1)
 {
     UnionExp ue = void;
     Loc loc = e1.loc;
-    emplaceExp!(IntegerExp)(&ue, loc, e1.isBool(true) ? 1 : 0, type);
+    emplaceExp!(IntegerExp)(&ue, loc, e1.toBool().hasValue(true) ? 1 : 0, type);
     return ue;
 }
 
@@ -1303,7 +1303,7 @@ UnionExp Index(Type type, Expression e1, Expression e2)
             ue = Equal(TOK.equal, loc, Type.tbool, ekey, e2);
             if (CTFEExp.isCantExp(ue.exp()))
                 return ue;
-            if (ue.exp().isBool(true))
+            if (ue.exp().toBool().hasValue(true))
             {
                 Expression e = (*ae.values)[i];
                 e.type = type;

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -667,7 +667,7 @@ bool isPointer(Type t)
 // For CTFE only. Returns true if 'e' is true or a non-null pointer.
 bool isTrueBool(Expression e)
 {
-    return e.isBool(true) || ((e.type.ty == Tpointer || e.type.ty == Tclass) && e.op != TOK.null_);
+    return e.toBool().hasValue(true) || ((e.type.ty == Tpointer || e.type.ty == Tclass) && e.op != TOK.null_);
 }
 
 /* Is it safe to convert from srcPointee* to destPointee* ?

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -894,7 +894,7 @@ public:
 
         if (isTrueBool(e))
             result = interpret(pue, s.ifbody, istate);
-        else if (e.isBool(false))
+        else if (e.toBool().hasValue(false))
             result = interpret(pue, s.elsebody, istate);
         else
         {
@@ -1158,7 +1158,7 @@ public:
                 result = CTFEExp.cantexp;
                 return;
             }
-            if (e.isBool(false))
+            if (e.toBool().hasValue(false))
                 break;
             assert(isTrueBool(e));
         }
@@ -1189,7 +1189,7 @@ public:
                 Expression e = interpret(&ue, s.condition, istate);
                 if (exceptionOrCant(e))
                     return;
-                if (e.isBool(false))
+                if (e.toBool().hasValue(false))
                     break;
                 assert(isTrueBool(e));
             }
@@ -4634,9 +4634,9 @@ public:
 
         bool res;
         const andand = e.op == TOK.andAnd;
-        if (andand ? result.isBool(false) : isTrueBool(result))
+        if (andand ? result.toBool().hasValue(false) : isTrueBool(result))
             res = !andand;
-        else if (andand ? isTrueBool(result) : result.isBool(false))
+        else if (andand ? isTrueBool(result) : result.toBool().hasValue(false))
         {
             UnionExp ue2 = void;
             result = interpret(&ue2, e.e2, istate);
@@ -4648,7 +4648,7 @@ public:
                 result = null;
                 return;
             }
-            if (result.isBool(false))
+            if (result.toBool().hasValue(false))
                 res = false;
             else if (isTrueBool(result))
                 res = true;
@@ -5018,7 +5018,7 @@ public:
             result = interpret(pue, e.e1, istate, goal);
             incUsageCtfe(istate, e.e1.loc);
         }
-        else if (econd.isBool(false))
+        else if (econd.toBool().hasValue(false))
         {
             result = interpret(pue, e.e2, istate, goal);
             incUsageCtfe(istate, e.e2.loc);
@@ -6059,7 +6059,7 @@ public:
         if (isTrueBool(e1))
         {
         }
-        else if (e1.isBool(false))
+        else if (e1.toBool().hasValue(false))
         {
             if (e.msg)
             {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1605,16 +1605,6 @@ extern (C++) abstract class Expression : ASTNode
         return typeof(return)();
     }
 
-    /* LEGACY: To be removed in a seperate commit
-     *
-     * Does this expression statically evaluate to a boolean 'result' (true or false)?
-     */
-    final bool isBool(bool result)
-    {
-        const val = this.toBool();
-        return val.isPresent && val.get() == result;
-    }
-
     bool hasCode()
     {
         return true;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -60,6 +60,7 @@ import dmd.optimize;
 import dmd.root.ctfloat;
 import dmd.root.filename;
 import dmd.common.outbuffer;
+import dmd.root.optional;
 import dmd.root.rmem;
 import dmd.root.rootobject;
 import dmd.root.string;
@@ -1597,12 +1598,21 @@ extern (C++) abstract class Expression : ASTNode
         return .isConst(this);
     }
 
-    /********************************
+    /// Statically evaluate this expression to a `bool` if possible
+    /// Returns: an optional thath either contains the value or is empty
+    Optional!bool toBool()
+    {
+        return typeof(return)();
+    }
+
+    /* LEGACY: To be removed in a seperate commit
+     *
      * Does this expression statically evaluate to a boolean 'result' (true or false)?
      */
-    bool isBool(bool result)
+    final bool isBool(bool result)
     {
-        return false;
+        const val = this.toBool();
+        return val.isPresent && val.get() == result;
     }
 
     bool hasCode()
@@ -1827,10 +1837,10 @@ extern (C++) final class IntegerExp : Expression
         return complex_t(toReal());
     }
 
-    override bool isBool(bool result)
+    override Optional!bool toBool()
     {
         bool r = toInteger() != 0;
-        return result ? r : !r;
+        return typeof(return)(r);
     }
 
     override Expression toLvalue(Scope* sc, Expression e)
@@ -2096,9 +2106,9 @@ extern (C++) final class RealExp : Expression
         return complex_t(toReal(), toImaginary());
     }
 
-    override bool isBool(bool result)
+    override Optional!bool toBool()
     {
-        return result ? cast(bool)value : !cast(bool)value;
+        return typeof(return)(!!value);
     }
 
     override void accept(Visitor v)
@@ -2171,12 +2181,9 @@ extern (C++) final class ComplexExp : Expression
         return value;
     }
 
-    override bool isBool(bool result)
+    override Optional!bool toBool()
     {
-        if (result)
-            return cast(bool)value;
-        else
-            return !value;
+        return typeof(return)(!!value);
     }
 
     override void accept(Visitor v)
@@ -2292,9 +2299,10 @@ extern (C++) class ThisExp : Expression
         return r;
     }
 
-    override final bool isBool(bool result)
+    override Optional!bool toBool()
     {
-        return result;
+        // `this` is never null (what about structs?)
+        return typeof(return)(true);
     }
 
     override final bool isLvalue()
@@ -2358,9 +2366,10 @@ extern (C++) final class NullExp : Expression
         return false;
     }
 
-    override bool isBool(bool result)
+    override Optional!bool toBool()
     {
-        return result ? false : true;
+        // null in any type is false
+        return typeof(return)(false);
     }
 
     override StringExp toStringExp()
@@ -2681,9 +2690,11 @@ extern (C++) final class StringExp : Expression
         return cast(int)(len1 - len2);
     }
 
-    override bool isBool(bool result)
+    override Optional!bool toBool()
     {
-        return result;
+        // Keep the old behaviour for this refactoring
+        // Should probably match language spec instead and check for length
+        return typeof(return)(true);
     }
 
     override bool isLvalue()
@@ -3000,10 +3011,10 @@ extern (C++) final class ArrayLiteralExp : Expression
         return el ? el : basis;
     }
 
-    override bool isBool(bool result)
+    override Optional!bool toBool()
     {
         size_t dim = elements ? elements.dim : 0;
-        return result ? (dim != 0) : (dim == 0);
+        return typeof(return)(dim != 0);
     }
 
     override StringExp toStringExp()
@@ -3119,10 +3130,10 @@ extern (C++) final class AssocArrayLiteralExp : Expression
         return new AssocArrayLiteralExp(loc, arraySyntaxCopy(keys), arraySyntaxCopy(values));
     }
 
-    override bool isBool(bool result)
+    override Optional!bool toBool()
     {
         size_t dim = keys.dim;
-        return result ? (dim != 0) : (dim == 0);
+        return typeof(return)(dim != 0);
     }
 
     override void accept(Visitor v)
@@ -3622,9 +3633,9 @@ extern (C++) final class SymOffExp : SymbolExp
         this.offset = offset;
     }
 
-    override bool isBool(bool result)
+    override Optional!bool toBool()
     {
-        return result ? true : false;
+        return typeof(return)(true);
     }
 
     override void accept(Visitor v)
@@ -5476,9 +5487,9 @@ extern (C++) final class SliceExp : UnaExp
         return this;
     }
 
-    override bool isBool(bool result)
+    override Optional!bool toBool()
     {
-        return e1.isBool(result);
+        return e1.toBool();
     }
 
     override void accept(Visitor v)
@@ -5608,9 +5619,9 @@ extern (C++) final class CommaExp : BinExp
         return this;
     }
 
-    override bool isBool(bool result)
+    override Optional!bool toBool()
     {
-        return e2.isBool(result);
+        return e2.toBool();
     }
 
     override Expression addDtorHook(Scope* sc)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -123,7 +123,6 @@ public:
     Expression *ctfeInterpret();
     int isConst();
     virtual Optional<bool> toBool();
-    bool isBool(bool result);
     virtual bool hasCode()
     {
         return true;

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -18,6 +18,7 @@
 #include "tokens.h"
 
 #include "root/dcompat.h"
+#include "root/optional.h"
 
 class Type;
 class TypeVector;
@@ -121,8 +122,8 @@ public:
     // A compile-time result is required. Give an error if not possible
     Expression *ctfeInterpret();
     int isConst();
-    virtual bool isBool(bool result);
-
+    virtual Optional<bool> toBool();
+    bool isBool(bool result);
     virtual bool hasCode()
     {
         return true;
@@ -249,7 +250,7 @@ public:
     real_t toReal();
     real_t toImaginary();
     complex_t toComplex();
-    bool isBool(bool result);
+    Optional<bool> toBool();
     Expression *toLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }
     dinteger_t getInteger() { return value; }
@@ -280,7 +281,7 @@ public:
     real_t toReal();
     real_t toImaginary();
     complex_t toComplex();
-    bool isBool(bool result);
+    Optional<bool> toBool();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -297,7 +298,7 @@ public:
     real_t toReal();
     real_t toImaginary();
     complex_t toComplex();
-    bool isBool(bool result);
+    Optional<bool> toBool();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -336,7 +337,7 @@ public:
     VarDeclaration *var;
 
     ThisExp *syntaxCopy();
-    bool isBool(bool result);
+    Optional<bool> toBool();
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
 
@@ -353,7 +354,7 @@ class NullExp : public Expression
 {
 public:
     bool equals(const RootObject *o) const;
-    bool isBool(bool result);
+    Optional<bool> toBool();
     StringExp *toStringExp();
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -374,7 +375,7 @@ public:
     bool equals(const RootObject *o) const;
     StringExp *toStringExp();
     StringExp *toUTF8(Scope *sc);
-    bool isBool(bool result);
+    Optional<bool> toBool();
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
@@ -420,7 +421,7 @@ public:
     bool equals(const RootObject *o) const;
     Expression *getElement(d_size_t i); // use opIndex instead
     Expression *opIndex(d_size_t i);
-    bool isBool(bool result);
+    Optional<bool> toBool();
     StringExp *toStringExp();
 
     void accept(Visitor *v) { v->visit(this); }
@@ -435,7 +436,7 @@ public:
 
     bool equals(const RootObject *o) const;
     AssocArrayLiteralExp *syntaxCopy();
-    bool isBool(bool result);
+    Optional<bool> toBool();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -567,7 +568,7 @@ class SymOffExp : public SymbolExp
 public:
     dinteger_t offset;
 
-    bool isBool(bool result);
+    Optional<bool> toBool();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -926,7 +927,7 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
-    bool isBool(bool result);
+    Optional<bool> toBool();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -997,7 +998,7 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
-    bool isBool(bool result);
+    Optional<bool> toBool();
     Expression *addDtorHook(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6369,7 +6369,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (f1 || f2)
             return setError();
 
-        if (exp.e1.isBool(false))
+        if (exp.e1.toBool().hasValue(false))
         {
             /* This is an `assert(0)` which means halt program execution
              */
@@ -11141,7 +11141,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             /* If in static if, don't evaluate e2 if we don't have to.
              */
             e1x = e1x.optimize(WANTvalue);
-            if (e1x.isBool(exp.op == TOK.orOr))
+            if (e1x.toBool().hasValue(exp.op == TOK.orOr))
             {
                 result = IntegerExp.createBool(exp.op == TOK.orOr);
                 return;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1531,6 +1531,24 @@ enum class MATCH
     exact = 3,
 };
 
+template <typename T>
+struct Optional final
+{
+    // Ignoring var value alignment 0
+    T value;
+    // Ignoring var present alignment 0
+    bool present;
+    Optional(T value);
+    static Optional<T > create(T val);
+    bool isPresent() const;
+    bool isEmpty() const;
+    T get();
+    bool hasValue(T exp) const;
+    Optional()
+    {
+    }
+};
+
 class Expression : public ASTNode
 {
 public:
@@ -1572,7 +1590,8 @@ public:
     Expression* optimize(int32_t result, bool keepLvalue = false);
     Expression* ctfeInterpret();
     int32_t isConst();
-    virtual bool isBool(bool result);
+    virtual Optional<bool > toBool();
+    bool isBool(bool result);
     virtual bool hasCode();
     IntegerExp* isIntegerExp();
     ErrorExp* isErrorExp();
@@ -6486,7 +6505,7 @@ public:
     _d_real toReal();
     _d_real toImaginary();
     complex_t toComplex();
-    bool isBool(bool result);
+    Optional<bool > toBool();
     Expression* toLvalue(Scope* sc, Expression* e);
     void accept(Visitor* v);
     dinteger_t getInteger();
@@ -6524,7 +6543,7 @@ public:
     _d_real toReal();
     _d_real toImaginary();
     complex_t toComplex();
-    bool isBool(bool result);
+    Optional<bool > toBool();
     void accept(Visitor* v);
 };
 
@@ -6540,7 +6559,7 @@ public:
     _d_real toReal();
     _d_real toImaginary();
     complex_t toComplex();
-    bool isBool(bool result);
+    Optional<bool > toBool();
     void accept(Visitor* v);
 };
 
@@ -6576,7 +6595,7 @@ public:
     VarDeclaration* var;
     ThisExp(const Loc& loc, const TOK tok);
     ThisExp* syntaxCopy();
-    bool isBool(bool result);
+    Optional<bool > toBool();
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
     void accept(Visitor* v);
@@ -6592,7 +6611,7 @@ class NullExp final : public Expression
 {
 public:
     bool equals(const RootObject* const o) const;
-    bool isBool(bool result);
+    Optional<bool > toBool();
     StringExp* toStringExp();
     void accept(Visitor* v);
 };
@@ -6624,7 +6643,7 @@ public:
     StringExp* toStringExp();
     StringExp* toUTF8(Scope* sc);
     int32_t compare(const StringExp* const se2) const;
-    bool isBool(bool result);
+    Optional<bool > toBool();
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
     Expression* modifiableLvalue(Scope* sc, Expression* e);
@@ -6656,7 +6675,7 @@ public:
     bool equals(const RootObject* const o) const;
     Expression* getElement(size_t i);
     Expression* opIndex(size_t i);
-    bool isBool(bool result);
+    Optional<bool > toBool();
     StringExp* toStringExp();
     void accept(Visitor* v);
 };
@@ -6669,7 +6688,7 @@ public:
     OwnedBy ownedByCtfe;
     bool equals(const RootObject* const o) const;
     AssocArrayLiteralExp* syntaxCopy();
-    bool isBool(bool result);
+    Optional<bool > toBool();
     void accept(Visitor* v);
 };
 
@@ -6774,7 +6793,7 @@ class SymOffExp final : public SymbolExp
 {
 public:
     dinteger_t offset;
-    bool isBool(bool result);
+    Optional<bool > toBool();
     void accept(Visitor* v);
 };
 
@@ -7086,7 +7105,7 @@ public:
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
     Expression* modifiableLvalue(Scope* sc, Expression* e);
-    bool isBool(bool result);
+    Optional<bool > toBool();
     void accept(Visitor* v);
 };
 
@@ -7122,7 +7141,7 @@ public:
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
     Expression* modifiableLvalue(Scope* sc, Expression* e);
-    bool isBool(bool result);
+    Optional<bool > toBool();
     Expression* addDtorHook(Scope* sc);
     void accept(Visitor* v);
     static void allow(Expression* exp);
@@ -7879,24 +7898,6 @@ public:
 };
 
 extern void browse(const char* url);
-
-template <typename T>
-struct Optional final
-{
-    // Ignoring var value alignment 0
-    T value;
-    // Ignoring var present alignment 0
-    bool present;
-    Optional(T value);
-    static Optional<T > create(T val);
-    bool isPresent() const;
-    bool isEmpty() const;
-    T get();
-    bool hasValue(T exp) const;
-    Optional()
-    {
-    }
-};
 
 extern void error(const Loc& loc, const char* format, ...);
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7880,6 +7880,24 @@ public:
 
 extern void browse(const char* url);
 
+template <typename T>
+struct Optional final
+{
+    // Ignoring var value alignment 0
+    T value;
+    // Ignoring var present alignment 0
+    bool present;
+    Optional(T value);
+    static Optional<T > create(T val);
+    bool isPresent() const;
+    bool isEmpty() const;
+    T get();
+    bool hasValue(T exp) const;
+    Optional()
+    {
+    }
+};
+
 extern void error(const Loc& loc, const char* format, ...);
 
 extern void error(const char* filename, uint32_t linnum, uint32_t charnum, const char* format, ...);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1591,7 +1591,6 @@ public:
     Expression* ctfeInterpret();
     int32_t isConst();
     virtual Optional<bool > toBool();
-    bool isBool(bool result);
     virtual bool hasCode();
     IntegerExp* isIntegerExp();
     ErrorExp* isErrorExp();

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6225,7 +6225,7 @@ extern (C++) final class TypeEnum : Type
 
     override bool isZeroInit(const ref Loc loc)
     {
-        return sym.getDefaultValue(loc).isBool(false);
+        return sym.getDefaultValue(loc).toBool().hasValue(false);
     }
 
     override bool hasPointers()

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -1068,7 +1068,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             if (expOptimize(e.e1, WANTvalue))
                 return;
             const oror = e.op == TOK.orOr;
-            if (e.e1.isBool(oror))
+            if (e.e1.toBool().hasValue(oror))
             {
                 // Replace with (e1, oror)
                 ret = IntegerExp.createBool(oror);
@@ -1084,13 +1084,14 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             expOptimize(e.e2, WANTvalue);
             if (e.e1.isConst())
             {
+                const e1Opt = e.e1.toBool();
                 if (e.e2.isConst())
                 {
-                    bool n1 = e.e1.isBool(true);
-                    bool n2 = e.e2.isBool(true);
+                    bool n1 = e1Opt.hasValue(true);
+                    bool n2 = e.e2.toBool().hasValue(true);
                     ret = new IntegerExp(e.loc, oror ? (n1 || n2) : (n1 && n2), e.type);
                 }
-                else if (e.e1.isBool(!oror))
+                else if (e1Opt.hasValue(!oror))
                 {
                     if (e.type.toBasetype().ty == Tvoid)
                         ret = e.e2;
@@ -1156,9 +1157,10 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
         {
             if (expOptimize(e.econd, WANTvalue))
                 return;
-            if (e.econd.isBool(true))
+            const opt = e.econd.toBool();
+            if (opt.hasValue(true))
                 ret = Expression_optimize(e.e1, result, keepLvalue);
-            else if (e.econd.isBool(false))
+            else if (opt.hasValue(false))
                 ret = Expression_optimize(e.e2, result, keepLvalue);
             else
             {

--- a/src/dmd/root/optional.d
+++ b/src/dmd/root/optional.d
@@ -84,6 +84,3 @@ extern (C++) struct Optional(T)
         return present && value == exp;
     }
 }
-
-/// To enable C++ tests until Optional is used
-private alias Inst = Optional!bool;

--- a/src/dmd/root/optional.d
+++ b/src/dmd/root/optional.d
@@ -1,0 +1,89 @@
+/**
+ * Optional implementation.
+ *
+ * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/optional.d, root/_optional.d)
+ * Documentation:  https://dlang.org/phobos/dmd_root_optional.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/optional.d
+ */
+module dmd.root.optional;
+
+///
+unittest
+{
+    import core.exception : AssertError;
+
+    Optional!int opt;
+    assert( opt.isEmpty());
+    assert(!opt.isPresent());
+    assert(!opt.hasValue(1));
+    assert(!opt.hasValue(2));
+
+    bool caught;
+    try
+        cast(void) opt.get();
+    catch (AssertError)
+        caught = true;
+    assert(caught);
+
+    opt = Optional!int(1);
+    assert(!opt.isEmpty());
+    assert( opt.isPresent());
+    assert( opt.get() == 1);
+    assert( opt.hasValue(1));
+    assert(!opt.hasValue(2));
+}
+
+/// Optional type that is either `empty` or contains a value of type `T`
+extern (C++) struct Optional(T)
+{
+    /// the value (if present)
+    private T value;
+
+    /// whether `value` is set
+    private bool present;
+
+    /// Creates an `Optional` with the given value
+    this(T value)
+    {
+        this.value = value;
+        this.present = true;
+    }
+
+    // Ctor wrapper for the C++ interface (required by older host compilers)
+    /// ditto
+    static Optional!T create(T val)
+    {
+        return Optional!T(val);
+    }
+
+    /// Returns: Whether this `Optional` contains a value
+    bool isPresent() const
+    {
+        return this.present;
+    }
+
+    /// Returns: Whether this `Optional` does not contain a value
+    bool isEmpty() const
+    {
+        return !this.present;
+    }
+
+    /// Returns: The value if present
+    inout(T) get() inout
+    {
+        assert(present);
+        return value;
+    }
+
+    /// Returns: Whether this `Optional` contains the supplied value
+    bool hasValue(const T exp) const
+    {
+        return present && value == exp;
+    }
+}
+
+/// To enable C++ tests until Optional is used
+private alias Inst = Optional!bool;

--- a/src/dmd/root/optional.h
+++ b/src/dmd/root/optional.h
@@ -1,0 +1,42 @@
+#pragma once
+
+/**
+ * Optional implementation.
+ *
+ * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/optional.h, root/_optional.h)
+ * Documentation:  https://dlang.org/phobos/dmd_root_optional.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/optional.h
+ */
+
+/// Optional type that is either `empty` or contains a value of type `T`
+template<typename T>
+struct Optional final
+{
+private:
+    /** the value (if present) **/
+    T value;
+
+    /** whether `value` is set **/
+    bool present;
+
+public:
+    /** Creates an `Optional` with the given value **/
+    Optional(T);
+
+    /** Creates an `Optional` with the given value **/
+    static Optional<T> create(T);
+
+    /** Checks whether this `Optional` contains a value **/
+    bool isPresent() const;
+
+    /** Checks whether this `Optional` does not contain a value **/
+    bool isEmpty() const;
+
+    /** Returns: The value if present **/
+    T get();
+
+    bool hasValue(const T) const;
+};

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2506,9 +2506,10 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     return setError();
                 }
 
-                if (e.isBool(true))
+                const opt = e.toBool();
+                if (opt.hasValue(true))
                     inlining = PINLINE.always;
-                else if (e.isBool(false))
+                else if (opt.hasValue(false))
                     inlining = PINLINE.never;
 
                     FuncDeclaration fd = sc.func;

--- a/src/dmd/staticcond.d
+++ b/src/dmd/staticcond.d
@@ -108,9 +108,10 @@ bool evalStaticCondition(Scope* sc, Expression original, Expression e, out bool 
 
         e = e.ctfeInterpret();
 
-        if (e.isBool(true))
+        const opt = e.toBool();
+        if (opt.hasValue(true))
             return true;
-        else if (e.isBool(false))
+        else if (opt.hasValue(false))
         {
             if (negatives)
                 negatives.push(before);

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -149,7 +149,7 @@ extern (C++) void Initializer_toDt(Initializer init, ref DtBuilder dtb)
                 size_t tadim = cast(size_t)ta.dim.toInteger();
                 if (ai.dim < tadim)
                 {
-                    if (edefault.isBool(false))
+                    if (edefault.toBool().hasValue(false))
                     {
                         // pad out end of array
                         dtbarray.nzeros(cast(uint)(size * (tadim - ai.dim)));

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -569,7 +569,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
     {
         if (global.params.vcomplex)
         {
-            if (isTypeX(t => t.iscomplex() || t.isimaginary()).isBool(true))
+            if (isTypeX(t => t.iscomplex() || t.isimaginary()).toBool().hasValue(true))
                 return True();
         }
         return isDsymX(t => t.isDeprecated());
@@ -998,7 +998,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 e.error("`bool` expected as third argument of `__traits(getOverloads)`, not `%s` of type `%s`", b.toChars(), b.type.toChars());
                 return ErrorExp.get();
             }
-            includeTemplates = b.isBool(true);
+            includeTemplates = b.toBool().hasValue(true);
         }
 
         StringExp se = ex.toStringExp();

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -17,6 +17,7 @@
 #include "root/filename.h"
 #include "root/longdouble.h"
 #include "root/object.h"
+#include "root/optional.h"
 #include "common/outbuffer.h"
 #include "root/port.h"
 #include "root/rmem.h"
@@ -546,6 +547,15 @@ void test_module()
     assert(global.endGagging(errors));
 }
 
+void test_optional()
+{
+    Optional<bool> opt = Optional<bool>::create(true);
+    assert(!opt.isEmpty());
+    assert(opt.isPresent());
+    assert(opt.get() == true);
+    assert(opt.hasValue(true));
+}
+
 /**********************************/
 
 int main(int argc, char **argv)
@@ -567,6 +577,7 @@ int main(int argc, char **argv)
     test_outbuffer();
     test_cppmangle();
     test_module();
+    test_optional();
 
     frontend_term();
 

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -336,6 +336,9 @@ void test_expression()
 
     assert(e);
     assert(e->isConst());
+
+    Optional<bool> res = e->toBool();
+    assert(res.get());
 }
 
 /**********************************/


### PR DESCRIPTION
The old implementation error prone because it returns the same value for
`unknown value` and `other value`. It's also cumbersome to use because
a full check requires two calls (one for `true` and `false`).

Returning an `Optional!bool` documents the intention and requires
proper handling at the call site.

---

Best reviewed per commit.