### PR TITLE
Update osmodel.mak to support arm64

### DIFF
--- a/src/osmodel.mak
+++ b/src/osmodel.mak
@@ -54,7 +54,7 @@ ifeq (,$(MODEL))
   else
     uname_M:=$(shell uname -m)
   endif
-  ifneq (,$(findstring $(uname_M),x86_64 amd64))
+  ifneq (,$(findstring $(uname_M),x86_64 amd64 arm64))
     MODEL:=64
   endif
   ifneq (,$(findstring $(uname_M),i386 i586 i686))


### PR DESCRIPTION
DMD doesn't build on `arm64`, but `osmodel.mak` is being used from the tools repo, https://github.com/dlang/tools/blob/master/posix.mak#L15, which builds fine using `ldc` on Apple M1 machines once this change is in.

Arguably, the tools repo could easily have its own copy of `osmodel.mak` instead of relying on the `dmd` repo for just that one file.