### PR TITLE
Fix Issue 16579 - Corrupted runtime on missed manifest constant propagation

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3293,9 +3293,6 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             if (rs.exp.op == TOK.call)
                 rs.exp = valueNoDtor(rs.exp);
 
-            if (e0)
-                e0 = e0.optimize(WANTvalue);
-
             /* Void-return function can have void / noreturn typed expression
              * on return statement.
              */
@@ -3320,7 +3317,10 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 rs.exp = null;
             }
             if (e0)
+            {
+                e0 = e0.optimize(WANTvalue);
                 e0 = checkGC(sc, e0);
+            }
         }
 
         if (rs.exp)

--- a/test/runnable/test16579.d
+++ b/test/runnable/test16579.d
@@ -1,0 +1,57 @@
+// REQUIRED_ARGS: -unittest
+// PERMUTE_ARGS:
+// https://issues.dlang.org/show_bug.cgi?id=16579
+
+struct Thing
+{
+    enum Instance = Thing();
+    int a = 42;
+
+    void iter()
+    {
+        assert(this.a == 42);
+    }
+}
+
+void main()
+{
+    return Thing.Instance.iter;   // Added 'return'
+}
+
+// From https://issues.dlang.org/show_bug.cgi?id=16576
+
+alias a = test2!();
+alias b = test3!();
+
+
+template test2()
+{
+    struct Thing{
+        static enum Instance = Thing([0, 1, 2, 3]);
+        int[] array;
+        void iter(in string str) const{
+            foreach(j, tup; this.array) assert(tup == j);
+            assert(this.array && this.array.length == 4);
+        }
+    }
+    unittest{
+        auto test(in string str){return Thing.Instance.iter(str);}
+        test("?");
+    }
+}
+
+template test3()
+{
+    struct Thing{
+        static enum Instance = Thing([0, 1, 2, 3]);
+        int[] array;
+        void iter() const{
+            foreach(j, tup; this.array) assert(tup == j);
+            assert(this.array && this.array.length == 4);
+        }
+    }
+    unittest{
+        auto test(){return Thing.Instance.iter();}
+        test();
+    }
+}


### PR DESCRIPTION
Specifically on a ReturnStatement[CallExp(DotVarExp)] statement. 

A void returning statement 'return exp;' is rewritten to 'exp; return;'
but in that case an optimize() call was missing, which was just a little above.