### PR TITLE
Fix Issue 21073 - Rebindable does not work when class has alias this to inout property

### DIFF
--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -596,11 +596,13 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                     /* Rewrite op(e1) as:
                      *      op(e1.aliasthis)
                      */
-                    Expression e1 = resolveAliasThis(sc, e.e1);
-                    result = e.copy();
-                    (cast(UnaExp)result).e1 = e1;
-                    result = result.op_overload(sc);
-                    return;
+                    if (auto e1 = resolveAliasThis(sc, e.e1, true))
+                    {
+                        result = e.copy();
+                        (cast(UnaExp)result).e1 = e1;
+                        result = result.op_overload(sc);
+                        return;
+                    }
                 }
             }
         }

--- a/test/compilable/test21073.d
+++ b/test/compilable/test21073.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=21073
+
+class C
+{
+    auto internal() const
+    {
+        return 5;
+    }
+    alias internal this;
+}
+
+void main() pure
+{
+    const c = new C;
+    auto r = cast(C)c;
+}


### PR DESCRIPTION
The cast expression was trying an 'alias this' but without error gagging.