### PR TITLE
Move semantic analysis of pragma(crt) from toobj to dsymbolsem

### DIFF
--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -796,38 +796,6 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
                 obj_linkerdirective(directive);
             }
-            else if (pd.ident == Id.crt_constructor || pd.ident == Id.crt_destructor)
-            {
-                immutable isCtor = pd.ident == Id.crt_constructor;
-
-                static uint recurse(Dsymbol s, bool isCtor)
-                {
-                    if (auto ad = s.isAttribDeclaration())
-                    {
-                        uint nestedCount;
-                        auto decls = ad.include(null);
-                        if (decls)
-                        {
-                            for (size_t i = 0; i < decls.dim; ++i)
-                                nestedCount += recurse((*decls)[i], isCtor);
-                        }
-                        return nestedCount;
-                    }
-                    else if (auto f = s.isFuncDeclaration())
-                    {
-                        f.isCrtCtorDtor |= isCtor ? 1 : 2;
-                        if (f.linkage != LINK.c)
-                            f.error("must be `extern(C)` for `pragma(%s)`", isCtor ? "crt_constructor".ptr : "crt_destructor".ptr);
-                        return 1;
-                    }
-                    else
-                        return 0;
-                    assert(0);
-                }
-
-                if (recurse(pd, isCtor) > 1)
-                    pd.error("can only apply to a single declaration");
-            }
 
             visit(cast(AttribDeclaration)pd);
         }

--- a/test/fail_compilation/test17868b.d
+++ b/test/fail_compilation/test17868b.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ----
+fail_compilation/test17868b.d(9): Error: pragma `crt_constructor` can only apply to a single declaration
 fail_compilation/test17868b.d(10): Error: function `test17868b.foo` must be `extern(C)` for `pragma(crt_constructor)`
 fail_compilation/test17868b.d(14): Error: function `test17868b.bar` must be `extern(C)` for `pragma(crt_constructor)`
-fail_compilation/test17868b.d(9): Error: pragma `crt_constructor` can only apply to a single declaration
 ----
  */
 pragma(crt_constructor):


### PR DESCRIPTION
There is nothing codegen-specific about this code, it is pure semantic, and can be evaluated earlier.