### PR TITLE
[SAoC] ProtoObject: add ProtoObject as the root of Object

### DIFF
--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -145,6 +145,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     extern (C++) __gshared
     {
         // Names found by reading object.d in druntime
+        ClassDeclaration protoObject;
         ClassDeclaration object;
         ClassDeclaration throwable;
         ClassDeclaration exception;
@@ -331,6 +332,13 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
                     error("%s", msg);
                 Type.typeinfovector = this;
             }
+        }
+
+        if (id == Id.ProtoObject)
+        {
+            if (!inObject)
+                error("%s", msg);
+            protoObject = this;
         }
 
         if (id == Id.Object)

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4827,8 +4827,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (cldec.classKind == ClassKind.objc || (cldec.baseClass && cldec.baseClass.classKind == ClassKind.objc))
                 cldec.classKind = ClassKind.objc; // Objective-C classes do not inherit from Object
 
-            // If no base class, and this is not an Object, use Object as base class
-            if (!cldec.baseClass && cldec.ident != Id.Object && cldec.object && cldec.classKind == ClassKind.d)
+            void setBaseClass(ref ClassDeclaration cldec, ClassDeclaration base)
             {
                 void badObjectDotD()
                 {
@@ -4836,10 +4835,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     fatal();
                 }
 
-                if (!cldec.object || cldec.object.errors)
+                if (!base || base.errors)
                     badObjectDotD();
 
-                Type t = cldec.object.type;
+                Type t = base.type;
                 t = t.typeSemantic(cldec.loc, sc).toBasetype();
                 if (t.ty == Terror)
                     badObjectDotD();
@@ -4852,6 +4851,17 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 cldec.baseClass = tc.sym;
                 assert(!cldec.baseClass.isInterfaceDeclaration());
                 b.sym = cldec.baseClass;
+            }
+
+            // Object has ProtoObject at its base
+            if (!cldec.baseClass && cldec.ident == Id.Object && cldec.protoObject && cldec.classKind == ClassKind.d)
+            {
+                setBaseClass(cldec, cldec.protoObject);
+            }
+            // If no base class, and this is not an Object, use Object as base class
+            if (!cldec.baseClass && cldec.ident != Id.Object && cldec.ident != Id.ProtoObject && cldec.object && cldec.classKind == ClassKind.d)
+            {
+                setBaseClass(cldec, cldec.object);
             }
             if (cldec.baseClass)
             {

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -511,6 +511,8 @@ immutable Msgtable[] msgtable =
     { "show" },
     { "push" },
     { "pop" },
+
+    { "ProtoObject" },
 ];
 
 

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -616,7 +616,7 @@ public:
         ClassDeclaration cd = d.isClassDeclaration();
         if (cd)
         {
-            if (cd.baseClass && cd.baseClass.ident != Id.Object)
+            if (cd.baseClass && (cd.baseClass.ident != Id.Object || cd.baseClass.ident != Id.ProtoObject))
             {
                 property("base", cd.baseClass.toPrettyChars(true).toDString);
             }

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -699,8 +699,8 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
                 ClassDeclaration cdto = e.type.isClassHandle();
                 if (cdfrom.errors || cdto.errors)
                     return error();
-                if (cdto == ClassDeclaration.object && !cdfrom.isInterfaceDeclaration())
-                    goto L1;    // can always convert a class to Object
+                if (cdto == ClassDeclaration.protoObject && !cdfrom.isInterfaceDeclaration())
+                    goto L1;    // can always convert a class to ProtoObject
                 // Need to determine correct offset before optimizing away the cast.
                 // https://issues.dlang.org/show_bug.cgi?id=16980
                 cdfrom.size(e.loc);

--- a/test/compilable/commontype.d
+++ b/test/compilable/commontype.d
@@ -431,7 +431,7 @@ static assert(Error!( const(C), SI )); // should work
 static assert(is( X!( const(SI), const(C) ) == const(I) )); // should work
 static assert(is( X!( const(C), SB ) == const(B)));
 static assert(is( X!( const(C), SD ) == const(B)));
-static assert(is( X!( const(C), SK ) == Object)); // `const`
+static assert(is( X!( const(C), SK ) == const(Object))); // `const`
 
 static assert(is( X!( SiC, SC ) == const(C) ));
 

--- a/test/compilable/dtoh_required_symbols.d
+++ b/test/compilable/dtoh_required_symbols.d
@@ -74,7 +74,11 @@ struct ExternDStructTemplate final
     }
 };
 
-class Object
+class ProtoObject
+{
+};
+
+class Object : public ProtoObject
 {
     virtual void __vtable_slot_0();
     virtual void __vtable_slot_1();

--- a/test/compilable/extra-files/json.json
+++ b/test/compilable/extra-files/json.json
@@ -123,6 +123,7 @@
                 "protection": "public"
             },
             {
+                "base": "object.Object",
                 "char": 1,
                 "kind": "class",
                 "line": 23,
@@ -707,6 +708,7 @@
                 "protection": "package"
             },
             {
+                "base": "object.Object",
                 "char": 1,
                 "kind": "class",
                 "line": 114,

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7942,7 +7942,7 @@ void test17349()
 
 void test17915()
 {
-    static class MyClass
+    static class MyClass : ProtoObject
     {
         S17915!MyClass m_member;
     }


### PR DESCRIPTION
### What's new

Make `ProtoObject` root of `Object`

[DIP](https://github.com/dlang/DIPs/pull/219)

- [ ] Wait for [druntime PR](https://github.com/dlang/druntime/pull/3621)