### PR TITLE
backend: dwarfdbginf: associative arrays should report a pretty name

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -2559,20 +2559,7 @@ static if (1)
                 code = dwarf_abbrev_code(abbrevTypeStruct.ptr, (abbrevTypeStruct).sizeof);
                 idx = cast(uint)debug_info.buf.length();
                 debug_info.buf.writeuLEB128(code);        // abbreviation code
-                debug_info.buf.write("_AArray_".ptr, 8);      // DW_AT_name
-                if (tybasic(t.Tkey.Tty))
-                    p = tystring[tybasic(t.Tkey.Tty)];
-                else
-                    p = "key";
-                debug_info.buf.write(p, cast(uint)strlen(p));
-
-                debug_info.buf.writeByte('_');
-                if (tybasic(t.Tnext.Tty))
-                    p = tystring[tybasic(t.Tnext.Tty)];
-                else
-                    p = "value";
-                debug_info.buf.writeString(p);
-
+                debug_info.buf.writeString(t.Tident);      // DW_AT_name
                 debug_info.buf.writeByte(tysize(t.Tty)); // DW_AT_byte_size
 
                 // ptr

--- a/test/dshell/extra-files/dwarf/excepted_results/fix22508.txt
+++ b/test/dshell/extra-files/dwarf/excepted_results/fix22508.txt
@@ -1,0 +1,6 @@
+DW_AT_name        : fix22508.istr_a
+DW_AT_name        : int[string]
+DW_AT_name        : fix22508.stri_a
+DW_AT_name        : string[int]
+DW_AT_name        : fix22508.ii_a
+DW_AT_name        : int[int]

--- a/test/dshell/extra-files/dwarf/fix22508.d
+++ b/test/dshell/extra-files/dwarf/fix22508.d
@@ -1,0 +1,7 @@
+/*
+EXTRA_ARGS: -g -defaultlib= -main -c
+*/
+
+int[string] istr_a;
+string[int] stri_a;
+int[int] ii_a;


### PR DESCRIPTION
Fixes 22508.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>