### PR TITLE
Implement the LDC specific `__traits(initSymbol)`

### DIFF
--- a/changelog/traits_initSymbol.dd
+++ b/changelog/traits_initSymbol.dd
@@ -1,0 +1,29 @@
+Added __traits(initSymbol) to obtain aggregate initializers
+
+Using `__traits(initSymbol, A)` where `A` is either a `class` or a `struct`
+will yield a `const(void)[]` that holds the initial state of an instance
+of `A`. The slice either points to the initializer symbol of `A` or `null`
+if `A` is zero-initialised - matching the behaviour of `TypeInfo.initializer()`.
+
+This traits can e.g. be used to initialize `malloc`'ed class instances without
+relying on `TypeInfo`:
+
+---
+class C
+{
+    int i = 4;
+}
+
+void main()
+{
+    const void[] initSym = __traits(initSymbol, C);
+
+    void* ptr = malloc(initSym.length);
+    scope (exit) free(ptr);
+
+    ptr[0..initSym.length] = initSym[];
+
+    C c = cast(C) ptr;
+    assert(c.i == 4);
+}
+---

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1933,9 +1933,9 @@ extern (C++) class BitFieldDeclaration : VarDeclaration
  */
 extern (C++) final class SymbolDeclaration : Declaration
 {
-    StructDeclaration dsym;
+    AggregateDeclaration dsym;
 
-    extern (D) this(const ref Loc loc, StructDeclaration dsym)
+    extern (D) this(const ref Loc loc, AggregateDeclaration dsym)
     {
         super(loc, dsym.ident);
         this.dsym = dsym;

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -303,7 +303,7 @@ public:
 class SymbolDeclaration : public Declaration
 {
 public:
-    StructDeclaration *dsym;
+    AggregateDeclaration *dsym;
 
     // Eliminate need for dynamic_cast
     SymbolDeclaration *isSymbolDeclaration() { return (SymbolDeclaration *)this; }

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2142,6 +2142,14 @@ public:
         }
         else if (SymbolDeclaration s = d.isSymbolDeclaration())
         {
+            // exclude void[]-typed `__traits(initSymbol)`
+            if (auto ta = s.type.toBasetype().isTypeDArray())
+            {
+                assert(ta.next.ty == Tvoid);
+                error(loc, "cannot determine the address of the initializer symbol during CTFE");
+                return CTFEExp.cantexp;
+            }
+
             // Struct static initializers, for example
             e = s.dsym.type.defaultInitLiteral(loc);
             if (e.op == TOK.error)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5705,7 +5705,7 @@ public:
 class SymbolDeclaration final : public Declaration
 {
 public:
-    StructDeclaration* dsym;
+    AggregateDeclaration* dsym;
     SymbolDeclaration* isSymbolDeclaration();
     void accept(Visitor* v);
 };
@@ -8276,6 +8276,7 @@ struct Id final
     static Identifier* getUnitTests;
     static Identifier* getVirtualIndex;
     static Identifier* getPointerBitmap;
+    static Identifier* initSymbol;
     static Identifier* getCppNamespaces;
     static Identifier* isReturnOnStack;
     static Identifier* isZeroInit;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -463,6 +463,7 @@ immutable Msgtable[] msgtable =
     { "getUnitTests" },
     { "getVirtualIndex" },
     { "getPointerBitmap" },
+    { "initSymbol" },
     { "getCppNamespaces" },
     { "isReturnOnStack" },
     { "isZeroInit" },

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -553,11 +553,20 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
         }
 
         if (auto sd = e.var.isSymbolDeclaration())
+        {
             if (sd.dsym)
             {
-                StructDeclaration_toDt(sd.dsym, dtb);
+
+                if (auto s = sd.dsym.isStructDeclaration())
+                    StructDeclaration_toDt(s, dtb);
+                else if (auto c = sd.dsym.isClassDeclaration())
+                    // Should be unreachable ATM, but just to be sure
+                    ClassDeclaration_toDt(c, dtb);
+                else
+                    assert(false);
                 return;
             }
+        }
 
         return nonConstExpError(e);
     }

--- a/test/fail_compilation/traits_initSymbol.d
+++ b/test/fail_compilation/traits_initSymbol.d
@@ -1,0 +1,63 @@
+/********************************************
+TEST_OUTPUT:
+---
+fail_compilation/traits_initSymbol.d(105): Error: struct / class type expected as argument to __traits(initSymbol) instead of `int`
+fail_compilation/traits_initSymbol.d(106): Error: struct / class type expected as argument to __traits(initSymbol) instead of `S[2]`
+fail_compilation/traits_initSymbol.d(107): Error: struct / class type expected as argument to __traits(initSymbol) instead of `123`
+---
+*/
+#line 100
+
+struct S { int i = 4; }
+
+void test1()
+{
+    const void[] initInt   = __traits(initSymbol, int);
+    const void[] initArray = __traits(initSymbol, S[2]);
+    const void[] initValue = __traits(initSymbol, 123);
+}
+
+/********************************************
+TEST_OUTPUT:
+---
+fail_compilation/traits_initSymbol.d(203): Error: cannot determine the address of the initializer symbol during CTFE
+fail_compilation/traits_initSymbol.d(203):        called from here: `(*function () pure nothrow @nogc @safe => S)()`
+---
+*/
+#line 200
+
+void test2()
+{
+    enum initLen = (() => __traits(initSymbol, S))();
+}
+
+/********************************************
+TEST_OUTPUT:
+---
+fail_compilation/traits_initSymbol.d(305): Error: struct / class type expected as argument to __traits(initSymbol) instead of `traits_initSymbol.Interface`
+---
+*/
+#line 300
+
+interface Interface {}
+
+void test3()
+{
+    const void[] initInterface = __traits(initSymbol, Interface);
+}
+
+/********************************************
+TEST_OUTPUT:
+---
+fail_compilation/traits_initSymbol.d(404): Error: expected 1 arguments for `initSymbol` but had 0
+fail_compilation/traits_initSymbol.d(405): Error: expected 1 arguments for `initSymbol` but had 2
+---
+*/
+#line 400
+
+
+void test4()
+{
+    const void[] tmp = __traits(initSymbol);
+    const void[] tmo = __traits(initSymbol, Interface, S);
+}

--- a/test/runnable/traits_initSymbol.d
+++ b/test/runnable/traits_initSymbol.d
@@ -1,0 +1,116 @@
+struct Zero
+{
+    int x;
+}
+
+void testZero()
+{
+    auto zeroInit = __traits(initSymbol, Zero);
+    static assert(is(typeof(zeroInit) == const(void[])));
+
+    assert(zeroInit.ptr is null);
+    assert(zeroInit.length == Zero.sizeof);
+}
+
+struct NonZero
+{
+    long x = 1;
+}
+
+void testNonZero()
+{
+    auto nonZeroInit = __traits(initSymbol, NonZero);
+    static assert(is(typeof(nonZeroInit) == const(void[])));
+
+    assert(nonZeroInit.ptr);
+    assert(nonZeroInit.length == NonZero.sizeof);
+    assert(cast(const(long[])) nonZeroInit == [1L]);
+}
+
+class C
+{
+    short x = 123;
+}
+
+void testClass()
+{
+    auto cInit = __traits(initSymbol, C);
+    static assert(is(typeof(cInit) == const(void[])));
+
+    assert(cInit.ptr);
+    assert(cInit.length == __traits(classInstanceSize, C));
+
+    scope c = new C;
+    assert((cast(void*) c)[0 .. cInit.length] == cInit);
+}
+
+struct AlignedStruct
+{
+    short s = 5;
+    // 2 byte padding
+    align(4) char c = 'c';
+    // 3 byte padding
+    int i = 4;
+    // reduced alignment
+    align(1) long l = 0xDEADBEEF;
+}
+
+void testAlignedStruct()
+{
+    auto init = __traits(initSymbol, AlignedStruct);
+
+    assert(init.ptr);
+    assert(init.length == AlignedStruct.sizeof);
+
+    AlignedStruct exp;
+    assert(init == (cast(void*) &exp)[0 .. AlignedStruct.sizeof]);
+
+}
+
+class AlignedClass : C
+{
+    short s = 5;
+    // 2 byte padding
+    align(4) char c = 'c';
+    // 3 byte padding
+    int i = 4;
+    // reduced alignment
+    align(1) long l = 0xDEADBEEF;
+}
+
+void testAlignedClass()
+{
+    auto init = __traits(initSymbol, AlignedClass);
+
+    assert(init.ptr);
+    assert(init.length == __traits(classInstanceSize, AlignedClass));
+
+    scope ac = new AlignedClass();
+    assert(init == (cast(void*) ac)[0 .. init.length]);
+}
+
+extern (C++) class ExternCppClass
+{
+    int i = 4;
+}
+
+void testExternCppClass()
+{
+    auto init = __traits(initSymbol, ExternCppClass);
+
+    assert(init.ptr);
+    assert(init.length == __traits(classInstanceSize, ExternCppClass));
+
+    scope ac = new ExternCppClass();
+    assert(init == (cast(void*) ac)[0 .. init.length]);
+}
+
+void main()
+{
+    testZero();
+    testNonZero();
+    testClass();
+    testAlignedStruct();
+    testAlignedClass();
+    testExternCppClass();
+}


### PR DESCRIPTION
`__traits(initSymbol, S)` was introduced in ldc-developers/ldc#3774 and
provides access to the initializer symbol of `S` in a way that does not
rely on `TypeInfo` or other hacks.

This commit contains some small adjustments to the initial patch which
improve the user experience:

- generated `VarExp` points to the `TraitsExp` instead of the symbol LoC
- CTFE issues a specific error message
-  rejects interfaces because they don't have an initializer symbol and
   hence cause linker failures
- more extensive tests

Co-authored-by: Nicholas Wilson <iamthewilsonator@hotmail.com>

Spec PR:  dlang/dlang.org#3122

--

CC @thewilsonator @kinke 