### PR TITLE
fix Issue 22422 - ImportC: parse gnu attributes after a function para…

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2595,6 +2595,8 @@ final class CParser(AST) : Parser!AST
 
             Identifier id;
             auto t = cparseDeclarator(DTR.xparameter, tspec, id, specifier);
+            if (token.value == TOK.__attribute__)
+                cparseGnuAttributes(specifier);
             if (specifier.mod & MOD.xconst)
                 t = toConst(t);
             auto param = new AST.Parameter(STC.parameter, t, id, null, null);

--- a/test/compilable/test22422.c
+++ b/test/compilable/test22422.c
@@ -1,0 +1,5 @@
+// https://issues.dlang.org/show_bug.cgi?id=22422
+
+int foo(void *p __attribute__((align_value(64))))
+{
+}


### PR DESCRIPTION
…meter