### PR TITLE
glue: object Outbuffer is being destroyed in the wrong place

### DIFF
--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -121,6 +121,7 @@ void generateCodeAndWrite(Module[] modules, const(char)*[] libmodules,
         if (!global.errors && firstm)
         {
             obj_end(library, firstm.objfile.toChars());
+            objbuf.dtor();
         }
     }
     else
@@ -138,6 +139,7 @@ void generateCodeAndWrite(Module[] modules, const(char)*[] libmodules,
             if (global.errors && !lib)
                 m.deleteObjFile();
         }
+        objbuf.dtor();
     }
     if (lib && !global.errors)
         library.write();
@@ -370,7 +372,6 @@ private void obj_end(Library library, const(char)* objfilename)
         //printf("write obj %s\n", objfilename);
         writeFile(Loc.initial, objfilename.toDString, objbuf[]);
     }
-    objbuf.dtor();
 }
 
 bool obj_includelib(const(char)* name) nothrow

--- a/test/compilable/emptygenmain.d
+++ b/test/compilable/emptygenmain.d
@@ -1,0 +1,3 @@
+// REQUIRED_ARGS: -main -c
+
+void foo() { }


### PR DESCRIPTION
Since the introduction of PR #12832, `dtor` got uncommented and introduced heap
usage after a free() call. This patch moves the dtor to the right place.

It also adds some tests with `-main -c` to prevent this to happen again, since
those args triggers the issue.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>