### PR TITLE
Fix Issue 21719 -  [REG 2.072] "auto" methods of classes do not infer attributes correctly.

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1306,7 +1306,14 @@ extern (C++) class FuncDeclaration : Declaration
         if (!fbody)
             return false;
 
-        if (isVirtualMethod())
+        if (isVirtualMethod() &&
+            /*
+             * https://issues.dlang.org/show_bug.cgi?id=21719
+             *
+             * If we have an auto virtual function we can infer
+             * the attributes.
+             */
+            !(inferRetType && !isCtorDeclaration()))
             return false;               // since they may be overridden
 
         if (sc.func &&

--- a/test/compilable/test21719.d
+++ b/test/compilable/test21719.d
@@ -1,0 +1,21 @@
+// https://issues.dlang.org/show_bug.cgi?id=21719
+
+struct S
+{
+    auto f()
+    {
+    } // inferred to be @safe @nogc pure nothrow
+}
+
+class C
+{
+    auto f() // should also infer the same attributes
+    {
+    }
+}
+
+pure @nogc nothrow @safe void test(S s, C c)
+{
+    s.f;
+    c.f;
+}

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4903,7 +4903,7 @@ static assert(is(typeof(S5933d.x) == FuncType5933));
 
 
 class C5933a { auto x() { return 0; } }
-static assert(is(typeof(&(new C5933b()).x) == int delegate()));
+static assert(is(typeof(&(new C5933b()).x) == int delegate() pure nothrow @nogc @safe));
 
 class C5933b { auto x() { return 0; } }
 //static assert(is(typeof((new C5933b()).x) == FuncType5933));


### PR DESCRIPTION
It seems that the reason that the regression was introduced was that virtual functions may be overriden therefore if inference occurs and determines that the function is `@safe nothrow @nogc pure` you cannot override with less restrictive attributes.

This is a sensible argument, however, it lets the user confused when auto virtual functions do not infer any attributes. I think that the rule to not allow overriding virtual functions with more relaxed attributes is the fundamental problem here, however, that is another discussion.

The current fix makes it so that auto virtual functions do get their attributes inferred. This might break code that used to override auto functions, however, there shouldn't be too many cases, if any, because it is hard to override an auto function anyway:

```d
class A
{
     auto fun() {}
}

class B : A
{
    override void fun()  {} // does not work
    override auto fun()  {} // does not work
    override typeof(A.fun()) fun() {} // works 
}
```

This happens because auto functions need to examine the body to determine the return type (semantic3), whereas overriding is analysed during the first semantic pass.

Given that this change might be controversial, I did not target stable.

cc @WalterBright as you introduced this behavior/regression in https://github.com/dlang/dmd/pull/5881