### PR TITLE
Fix 22514 - Don't raise invalid duplicate case errors when the switch...

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2887,64 +2887,69 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         {
             Expression initialExp = cs.exp;
 
-            cs.exp = cs.exp.implicitCastTo(sc, sw.condition.type);
-            cs.exp = cs.exp.optimize(WANTvalue | WANTexpand);
-
-            Expression e = cs.exp;
-            // Remove all the casts the user and/or implicitCastTo may introduce
-            // otherwise we'd sometimes fail the check below.
-            while (e.op == TOK.cast_)
-                e = (cast(CastExp)e).e1;
-
-            /* This is where variables are allowed as case expressions.
-             */
-            if (e.op == TOK.variable)
+            // The switch'ed value has errors and doesn't provide the actual type
+            // Don't touch the case to not replace it with an `ErrorExp` even if it is valid
+            if (sw.condition.type && !sw.condition.type.isTypeError())
             {
-                VarExp ve = cast(VarExp)e;
-                VarDeclaration v = ve.var.isVarDeclaration();
-                Type t = cs.exp.type.toBasetype();
-                if (v && (t.isintegral() || t.ty == Tclass))
+                cs.exp = cs.exp.implicitCastTo(sc, sw.condition.type);
+                cs.exp = cs.exp.optimize(WANTvalue | WANTexpand);
+
+                Expression e = cs.exp;
+                // Remove all the casts the user and/or implicitCastTo may introduce
+                // otherwise we'd sometimes fail the check below.
+                while (e.op == TOK.cast_)
+                    e = (cast(CastExp)e).e1;
+
+                /* This is where variables are allowed as case expressions.
+                */
+                if (e.op == TOK.variable)
                 {
-                    /* Flag that we need to do special code generation
-                     * for this, i.e. generate a sequence of if-then-else
-                     */
-                    sw.hasVars = 1;
-
-                    /* TODO check if v can be uninitialized at that point.
-                     */
-                    if (!v.isConst() && !v.isImmutable())
+                    VarExp ve = cast(VarExp)e;
+                    VarDeclaration v = ve.var.isVarDeclaration();
+                    Type t = cs.exp.type.toBasetype();
+                    if (v && (t.isintegral() || t.ty == Tclass))
                     {
-                        cs.error("`case` variables have to be `const` or `immutable`");
-                    }
+                        /* Flag that we need to do special code generation
+                        * for this, i.e. generate a sequence of if-then-else
+                        */
+                        sw.hasVars = 1;
 
-                    if (sw.isFinal)
-                    {
-                        cs.error("`case` variables not allowed in `final switch` statements");
-                        errors = true;
-                    }
-
-                    /* Find the outermost scope `scx` that set `sw`.
-                     * Then search scope `scx` for a declaration of `v`.
-                     */
-                    for (Scope* scx = sc; scx; scx = scx.enclosing)
-                    {
-                        if (scx.enclosing && scx.enclosing.sw == sw)
-                            continue;
-                        assert(scx.sw == sw);
-
-                        if (!scx.search(cs.exp.loc, v.ident, null))
+                        /* TODO check if v can be uninitialized at that point.
+                        */
+                        if (!v.isConst() && !v.isImmutable())
                         {
-                            cs.error("`case` variable `%s` declared at %s cannot be declared in `switch` body",
-                                v.toChars(), v.loc.toChars());
+                            cs.error("`case` variables have to be `const` or `immutable`");
+                        }
+
+                        if (sw.isFinal)
+                        {
+                            cs.error("`case` variables not allowed in `final switch` statements");
                             errors = true;
                         }
-                        break;
+
+                        /* Find the outermost scope `scx` that set `sw`.
+                        * Then search scope `scx` for a declaration of `v`.
+                        */
+                        for (Scope* scx = sc; scx; scx = scx.enclosing)
+                        {
+                            if (scx.enclosing && scx.enclosing.sw == sw)
+                                continue;
+                            assert(scx.sw == sw);
+
+                            if (!scx.search(cs.exp.loc, v.ident, null))
+                            {
+                                cs.error("`case` variable `%s` declared at %s cannot be declared in `switch` body",
+                                    v.toChars(), v.loc.toChars());
+                                errors = true;
+                            }
+                            break;
+                        }
+                        goto L1;
                     }
-                    goto L1;
                 }
+                else
+                    cs.exp = cs.exp.ctfeInterpret();
             }
-            else
-                cs.exp = cs.exp.ctfeInterpret();
 
             if (StringExp se = cs.exp.toStringExp())
                 cs.exp = se;
@@ -2955,6 +2960,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             }
 
         L1:
+            // // Don't check other cases if this has errors
+            if (!cs.exp.isErrorExp())
             foreach (cs2; *sw.cases)
             {
                 //printf("comparing '%s' with '%s'\n", exp.toChars(), cs.exp.toChars());

--- a/test/fail_compilation/test_switch_error.d
+++ b/test/fail_compilation/test_switch_error.d
@@ -1,0 +1,101 @@
+/++
+https://issues.dlang.org/show_bug.cgi?id=22514
+TEST_OUTPUT:
+---
+fail_compilation/test_switch_error.d(13): Error: undefined identifier `doesNotExist`
+fail_compilation/test_switch_error.d(16): Error: undefined identifier `alsoDoesNotExits`
+fail_compilation/test_switch_error.d(19): Error: duplicate `case 2` in `switch` statement
+---
+++/
+
+void test1()
+{
+    switch (doesNotExist)
+    {
+        case 1:
+            alsoDoesNotExits();
+            break;
+        case 2: break;
+        case 2: break;
+    }
+}
+
+/++
+TEST_OUTPUT:
+---
+fail_compilation/test_switch_error.d(105): Error: undefined identifier `doesNotExist`
+---
+++/
+#line 100
+
+enum foo = 1;
+
+void test2()
+{
+    switch (doesNotExist)
+    {
+        case foo: break;
+    }
+}
+
+/++
+TEST_OUTPUT:
+---
+fail_compilation/test_switch_error.d(206): Error: undefined identifier `a`
+fail_compilation/test_switch_error.d(207): Error: undefined identifier `b`
+---
+++/
+#line 200
+
+void test3()
+{
+
+    switch (1)
+    {
+        case a: break;
+        case b: break;
+    }
+}
+
+/++
+TEST_OUTPUT:
+---
+fail_compilation/test_switch_error.d(303): Error: undefined identifier `doesNotExits`
+---
+++/
+#line 300
+
+void test4()
+{
+    auto foo = doesNotExits();
+    switch (1)
+    {
+        case foo: break;
+        case foo: break;
+    }
+}
+
+/++
+TEST_OUTPUT:
+---
+fail_compilation/test_switch_error.d(405): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/test_switch_error.d(412): Error: `case` variables not allowed in `final switch` statements
+---
+++/
+#line 400
+
+void test5(int i)
+{
+    switch (i)
+    {
+        case i: break;
+        default: break;
+    }
+
+    const int j = i;
+    final switch (i)
+    {
+        case j: break;
+
+    }
+}


### PR DESCRIPTION
... has other errors.

The duplicate case checks triggered because #11467 made `ErrorExp` into
a singleton and hence caused `ErrorExp` == `ErrorExp` to yield true even
if those errors were caused by different expressions.

This situation can arise from two different user errors:

1. the case is faulty, e.g. an unknown variable
2. the switch'ed value is faulty, causing `implicitCastTo` to generate
   an `ErrorExp`.

This commit fixes (1) by simply skipping the ducplicated case check for
`ErrorExp` because it doesn't have enough information. (2) requires the
case expression to not be coerced into the switched type s.t. we can
at least detect some errors while also keeping the actual case
expression to offer helpful diagnostics.

---

Best reviewed while disabling whitespace differences