### PR TITLE
Fix Issue 22515 - Aggregate definition with qualifiers has inconsistencies between structs and classes

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4619,6 +4619,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (cldec.errors)
             cldec.type = Type.terror;
+        if (cldec.semanticRun == PASS.init)
+            cldec.type = cldec.type.addSTC(sc.stc | cldec.storage_class);
         cldec.type = cldec.type.typeSemantic(cldec.loc, sc);
         if (auto tc = cldec.type.isTypeClass())
             if (tc.sym != cldec)

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2860,9 +2860,11 @@ static assert(is(S7038b == shared));
 immutable struct S7038c{ int x; }
 static assert(is(S7038c == immutable));
 
-static assert(!is(C7038 == const));
+// https://issues.dlang.org/show_bug.cgi?id=22515
+// Classes fixed for consistency with structs
+static assert(is(C7038 == const));
 const class C7038{ int x; }
-static assert(!is(C7038 == const));
+static assert(is(C7038 == const));
 
 void test7038()
 {
@@ -2871,7 +2873,7 @@ void test7038()
     static assert(is(typeof(s.x) == const int));
 
     C7038 c;
-    static assert(!is(typeof(c) == const));
+    static assert(is(typeof(c) == const));
     static assert(is(typeof(c.x) == const int));
 }
 


### PR DESCRIPTION
This broken behavior started in #783, then Walter fixed it in #6958 but unfortunately only for structs. Here I'm doing it for classes ~and interfaces~.

~There is a small change in `src/dmd/typinf.d` because what is said in the comment is not happening for interfaces.~

Edit: Doing the change to `interfaces` exposed some issues in their TypeInfo generation, so I'm fixing only `structs` for now.