### PR TITLE
Fix 22516 - Set TypeError as return type if inference was skipped...

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4006,7 +4006,7 @@ extern (C++) final class FuncExp : Expression
         }
         else
         {
-            assert(tok == TOK.function_ || tok == TOK.reserved && type.ty == Tpointer);
+            assert(tok == TOK.function_ || tok == TOK.reserved && type.ty == Tpointer || fd.errors);
             tx = tfx.pointerTo();
         }
         //printf("\ttx = %s, to = %s\n", tx.toChars(), to.toChars());

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -235,6 +235,18 @@ private extern(C++) final class Semantic3Visitor : Visitor
         if (funcdecl.errors || isError(funcdecl.parent))
         {
             funcdecl.errors = true;
+
+            // Mark that the return type could not be inferred
+            if (funcdecl.inferRetType)
+            {
+                assert(funcdecl.type);
+                auto tf = funcdecl.type.isTypeFunction();
+
+                // Only change the return type s.t. other analysis is
+                // still possible e.g. missmatched parameter types
+                if (tf && !tf.next)
+                    tf.next = Type.terror;
+            }
             return;
         }
         //printf("FuncDeclaration::semantic3('%s.%s', %p, sc = %p, loc = %s)\n", funcdecl.parent.toChars(), funcdecl.toChars(), funcdecl, sc, funcdecl.loc.toChars());

--- a/test/fail_compilation/ice22516.d
+++ b/test/fail_compilation/ice22516.d
@@ -1,0 +1,21 @@
+/++
+https://issues.dlang.org/show_bug.cgi?id=22516
+
+TEST_OUTPUT:
+---
+fail_compilation/ice22516.d(18): Error: undefined identifier `X`
+---
++/
+
+struct Data
+{
+    void function() eval;
+
+}
+
+struct Builtins
+{
+    X x;
+
+    Data myData = { (){} };
+}


### PR DESCRIPTION
... due to previous errors in the parent.

This ensures that further code doesn't have to check for unset
return type while still keeping the other information (paramter types,
...) available.