### PR TITLE
Fix Issue 22510 - Structs with copy constructor can not be heap allocated with default constructor

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3764,7 +3764,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
 
-            if (sd.ctor && nargs)
+            if (sd.hasRegularCtor() && nargs)
             {
                 FuncDeclaration f = resolveFuncCall(exp.loc, sc, sd.ctor, null, tb, exp.arguments, FuncResolveFlag.standard);
                 if (!f || f.errors)

--- a/test/compilable/test22510.d
+++ b/test/compilable/test22510.d
@@ -1,0 +1,18 @@
+// https://issues.dlang.org/show_bug.cgi?id=22510
+
+struct S
+{
+	int b;
+
+    @disable this(this);
+    this (scope ref inout S) inout
+    {
+    	this.b = b;
+    }
+}
+
+void main()
+{
+	auto scoped_s = S(4);
+	auto heap_s = new S(42);
+}


### PR DESCRIPTION
Targeting master because stable tests are failing for no reason.