### PR TITLE
Fix issue 21285 - Delegate covariance broken

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1445,13 +1445,6 @@ private Type arrayExpressionToCommonType(Scope* sc, ref Expressions exps)
             Expression ex = condexp.expressionSemantic(sc);
             if (ex.op == EXP.error)
                 e = ex;
-            else if (e.op == EXP.function_ || e.op == EXP.delegate_)
-            {
-                // https://issues.dlang.org/show_bug.cgi?id=21285
-                // Functions and delegates don't convert correctly with castTo below
-                exps[i] = condexp.e1;
-                e = condexp.e2;
-            }
             else
             {
                 // Convert to common type

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2793,9 +2793,15 @@ bool stcToBuffer(OutBuffer* buf, StorageClass stc)
     bool result = false;
 
     if (stc & STC.scopeinferred)
+    {
+        //buf.writestring("scope-inferred ");
         stc &= ~(STC.scope_ | STC.scopeinferred);
+    }
     if (stc & STC.returninferred)
+    {
+        //buf.writestring("return-inferred ");
         stc &= ~(STC.return_ | STC.returninferred);
+    }
 
     /* Put scope ref return into a standard order
      */

--- a/test/compilable/b21285.d
+++ b/test/compilable/b21285.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -unittest
+// PERMUTE_ARGS: -preview=dip1000
 // Issue 21285 - Delegate covariance broken between 2.092 and 2.094 (git master).
 unittest
 {
@@ -24,4 +25,37 @@ unittest
 
     static assert(is(typeof(a[0]) == dg));
     static assert(is(typeof(ab[0]) == fn));
+}
+
+int f(string s) { throw new Exception(""); }
+void main()
+{
+    string path;
+    int bank, preset;
+    void delegate(string value)[string] aa = [
+        "path": (string arg) {
+            path = arg;
+        },
+        "bank": (string arg) {
+            bank = f(arg);
+        },
+        "preset": (string arg) {
+            preset = f(arg);
+        },
+    ];
+
+    string delegate(string value)[string] aa2 = [
+        "path": (string arg) {
+            path = arg;
+            return arg;
+        },
+        "bank": (string arg) {
+            bank = f(arg);
+            return arg;
+        },
+        "preset": (string arg) {
+            preset = f(arg);
+            return arg;
+        },
+    ];
 }


### PR DESCRIPTION
Reverts the fix from https://github.com/dlang/dmd/pull/11819

When `scope` or `return` are inferred, the `STC.scopeinferred` and `STC.returninferred` flags are set. These turn `scope` and `return` invisible in error messages and name mangling. The latter is necessary to avoid linker errors when e.g. linking -dip1000 Phobos with non-dip1000 code.

When there are multiple function types in an array literal, the compiler tries to find a common type between them by applying the ternary operator (`0 ? T0 : T1`) pair-wise to consecutive elements, but only when T0 and T1 are different in the pair. In the bug's test case, it checks `void delegate($scope string) ?= void delegate(string)`, `$scope` denoting 'inferred `scope`'. 

But how does `Type.equals` work? It compares the `.deco` field (the mangle), which are the same because `scope` is inferred, so it figures "the common type is the first one, `void delegate($scope string)`. Then it casts both expressions to the common type, but `isCovariantScope` isn't too happy about converting a non-scope parameter to a `scope` parameter, so it errors out.

In this PR I'm trying to make `isCovariantScope` ignore inferred `scope` in the destination, which might be undesirable in other cases, so I'll have to look at that. I'm already opening this PR to see how the test suite reacts to it.
