### PR TITLE
dmd.root.port: Adjust Port::valcpy signature to avoid C++ long vs long long mangling

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5024,6 +5024,8 @@ struct StringTable final
 
 typedef _d_real longdouble;
 
+typedef uint64_t uint64_t;
+
 class AggregateDeclaration : public ScopeDsymbol
 {
 public:

--- a/src/dmd/root/port.d
+++ b/src/dmd/root/port.d
@@ -14,6 +14,7 @@ module dmd.root.port;
 import core.stdc.ctype;
 import core.stdc.errno;
 import core.stdc.string;
+import core.stdc.stdint;
 import core.stdc.stdio;
 import core.stdc.stdlib;
 
@@ -164,8 +165,9 @@ extern (C++) struct Port
         return (p[0] << 8) | p[1];
     }
 
-    static void valcpy(scope void *dst, ulong val, size_t size) pure
+    static void valcpy(scope void *dst, uint64_t val, size_t size) pure
     {
+        assert((cast(size_t)dst) % size == 0);
         switch (size)
         {
             case 1: *cast(ubyte *)dst = cast(ubyte)val; break;


### PR DESCRIPTION
Despite some past fixes to improve the situation, Mac OS X still has issues with getting the mangling of `long` and `long long` right (i.e: D's `ulong` vs. `uint64_t`).

Assert has been added to ensure we never trip up strict alignment targets as well.