### PR TITLE
Improve error message for when equality expression requires TypeInfo when using -betterC

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1932,6 +1932,13 @@ extern (C++) class ToElemVisitor : Visitor
                 return;
             }
 
+            if (irs.params.betterC)
+            {
+                error(ee.loc, "Expression `%s` requires 'TypeInfo' wich is not available with -betterC", ee.toChars());
+                result = el_long(TYint, 0);
+                return;
+            }
+
             elem *ea1 = eval_Darray(ee.e1);
             elem *ea2 = eval_Darray(ee.e2);
 


### PR DESCRIPTION
That'll help people who run into this specific issue: https://issues.dlang.org/show_bug.cgi?id=22082

If someone know how to fix it, that would be great! 

It blocks me for this: https://github.com/ldc-developers/ldc/issues/3875