### PR TITLE
Fix Issue 22254 - Template instantiated twice results in different immutable qualifier

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -565,6 +565,18 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
     override final Type getType()
     {
+        /* Apply storage classes to forward references. (Issue 22254)
+         * Note: Avoid interfaces for now. Implementing qualifiers on interface
+         * definitions exposed some issues in their TypeInfo generation in DMD.
+         * Related PR: https://github.com/dlang/dmd/pull/13312
+         */
+        if (semanticRun == PASS.init && !isInterfaceDeclaration())
+        {
+            auto stc = storage_class;
+            if (_scope)
+                stc |= _scope.stc;
+            type = type.addSTC(stc);
+        }
         return type;
     }
 

--- a/test/compilable/test22254.d
+++ b/test/compilable/test22254.d
@@ -1,0 +1,19 @@
+// https://issues.dlang.org/show_bug.cgi?id=22254
+
+struct Template(T) { T t; }
+
+Template!Bar a;
+Template!Bar b;
+
+immutable struct Bar { }
+
+static assert(is(typeof(a) == typeof(b)));
+static assert(is(typeof(a) == Template!(immutable Bar)));
+
+Template!C c1;
+Template!C c2;
+
+immutable class C { }
+
+static assert(is(typeof(c1) == typeof(c2)));
+static assert(is(typeof(c1) == Template!(immutable C)));


### PR DESCRIPTION
Targeting master because it depends on #13312.