### PR TITLE
fix Issue 22512 - importC: incomplete array type must have initializer

### DIFF
--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -634,4 +634,6 @@ int test(char *dest)
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22512
 
+extern char *tzname[];


### PR DESCRIPTION
This worked when I tried it. Add it to the test suite and see how it goes.