### PR TITLE
Fix 21956 - Handle assignments for noreturn values in the backend

### DIFF
--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -385,6 +385,14 @@ void cdeq(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     tym_t tyml = tybasic(e1.Ety);              // type of lvalue
     regm_t retregs = *pretregs;
 
+    // Don't need to generate the assignment if any `noreturn` appears
+    // on either side - the operand evaluation prevents the assignment
+    if (tyml == TYnoreturn || tybasic(e2.Ety) == TYnoreturn)
+    {
+        codelem(cdb, e1, pretregs, false);
+        codelem(cdb, e2, pretregs, false);
+        return;
+    }
     if (tyxmmreg(tyml) && config.fpxmmregs)
     {
         xmmeq(cdb, e, CMP, e1, e2, pretregs);


### PR DESCRIPTION
Omit the store and simply evaluate the operands - avoiding the assertion
that the assigned value has a size > 0.

Also added some tests from 22390 that work already (excluding noreturn
array comparison).