### PR TITLE
fix Issue 22513 - ImportC: address of member of struct cannot be take…

### DIFF
--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -432,11 +432,22 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
                 return i;
             }
             if (sc.flags & SCOPE.Cfile)
+            {
                 /* the interpreter turns (char*)"string" into &"string"[0] which then
                  * it cannot interpret. Resolve that case by doing optimize() first
                  */
                 i.exp = i.exp.optimize(WANTvalue);
-            i.exp = i.exp.ctfeInterpret();
+                if (i.exp.isSymOffExp())
+                {
+                    /* `static variable cannot be read at compile time`
+                     * https://issues.dlang.org/show_bug.cgi?id=22513
+                     * Maybe this would be better addressed in ctfeInterpret()?
+                     */
+                    needInterpret = NeedInterpret.INITnointerpret;
+                }
+            }
+            if (needInterpret)
+                i.exp = i.exp.ctfeInterpret();
             if (i.exp.op == TOK.voidExpression)
                 error(i.loc, "variables cannot be initialized with an expression of type `void`. Use `void` initialization instead.");
         }

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -26,6 +26,7 @@ import dmd.expressionsem;
 import dmd.globals;
 import dmd.init;
 import dmd.mtype;
+import dmd.printast;
 import dmd.root.ctfloat;
 import dmd.sideeffect;
 import dmd.tokens;
@@ -265,6 +266,8 @@ package void setLengthVarIfKnown(VarDeclaration lengthVar, Type type)
  */
 Expression Expression_optimize(Expression e, int result, bool keepLvalue)
 {
+    //printf("Expression_optimize() %s\n", e.toChars());
+
     extern (C++) final class OptimizeVisitor : Visitor
     {
         alias visit = Visitor.visit;
@@ -468,6 +471,61 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
                     return;
                 }
             }
+
+            if (e.e1.isDotVarExp())
+            {
+                /******************************
+                 * Run down the left side of the a.b.c expression to determine the
+                 * leftmost variable being addressed (`a`), and accumulate the offsets of the `.b` and `.c`.
+                 * Params:
+                 *      e = the DotVarExp or VarExp
+                 *      var = set to the VarExp at the end, or null if doesn't end in VarExp
+                 *      offset = accumulation of all the .var offsets encountered
+                 * Returns: true on error
+                 */
+                static bool getVarAndOffset(Expression e, ref VarDeclaration var, ref uint offset)
+                {
+                    if (e.type.size() == SIZE_INVALID)  // trigger computation of v.offset
+                        return true;
+
+                    if (auto dve = e.isDotVarExp())
+                    {
+                        auto v = dve.var.isVarDeclaration();
+                        if (!v || !v.isField() || v.isBitFieldDeclaration())
+                            return false;
+
+                        if (getVarAndOffset(dve.e1, var, offset))
+                            return true;
+                        offset += v.offset;
+                    }
+                    else if (auto ve = e.isVarExp())
+                    {
+                        if (!ve.var.isReference() &&
+                            !ve.var.isImportedSymbol() &&
+                            ve.var.isDataseg() &&
+                            ve.var.isCsymbol())
+                        {
+                            var = ve.var.isVarDeclaration();
+                        }
+                    }
+                    return false;
+                }
+
+                uint offset;
+                VarDeclaration var;
+                if (getVarAndOffset(e.e1, var, offset))
+                {
+                    ret = ErrorExp.get();
+                    return;
+                }
+                if (var)
+                {
+                    ret = new SymOffExp(e.loc, var, offset, false);
+                    ret.type = e.type;
+                    return;
+                }
+            }
+
             if (e.e1.op == TOK.index)
             {
                 // Convert &array[n] to &array+n

--- a/src/dmd/printast.d
+++ b/src/dmd/printast.d
@@ -79,6 +79,24 @@ extern (C++) final class PrintASTVisitor : Visitor
         printf(".var: %s\n", e.var ? e.var.toChars() : "");
     }
 
+    override void visit(SymOffExp e)
+    {
+        printIndent(indent);
+        printf("SymOff %s\n", e.type ? e.type.toChars() : "");
+        printIndent(indent + 2);
+        printf(".var: %s\n", e.var ? e.var.toChars() : "");
+        printIndent(indent + 2);
+        printf(".offset: %llx\n", e.offset);
+    }
+
+    override void visit(VarExp e)
+    {
+        printIndent(indent);
+        printf("Var %s\n", e.type ? e.type.toChars() : "");
+        printIndent(indent + 2);
+        printf(".var: %s\n", e.var ? e.var.toChars() : "");
+    }
+
     override void visit(DsymbolExp e)
     {
         visit(cast(Expression)e);
@@ -114,6 +132,15 @@ extern (C++) final class PrintASTVisitor : Visitor
     {
         printIndent(indent);
         printf("VectorArray %s\n", e.type ? e.type.toChars() : "");
+        printAST(e.e1, indent + 2);
+    }
+
+    override void visit(DotVarExp e)
+    {
+        printIndent(indent);
+        printf("DotVar %s\n", e.type ? e.type.toChars() : "");
+        printIndent(indent + 2);
+        printf(".var: %s\n", e.var.toChars());
         printAST(e.e1, indent + 2);
     }
 

--- a/test/runnable/test22513.c
+++ b/test/runnable/test22513.c
@@ -1,0 +1,26 @@
+// https://issues.dlang.org/show_bug.cgi?id=22513
+
+int printf(const char *s, ...);
+void exit(int);
+
+void assert(int b, int line)
+{
+    if (!b)
+    {
+        printf("failed test %d\n", line);
+        exit(1);
+    }
+}
+
+struct S s;
+int* p = &s.t.x;
+
+struct S { int a; struct T t; };
+struct T { int b; int x; };
+
+int main()
+{
+    s.t.x = 5;
+    assert(*p == 5, 1);
+    return 0;
+}


### PR DESCRIPTION
…n at compile time

This extends the `&x` constant folding to be able to handle `&s.x`. Unfortunately, CTFE cannot handle adding a non-zero offset to the address of a symbol. The kludgy solution here is to avoid calling CTFE if it's C code attempting to do `&s.x`. We could allow this in D in the future, but for the moment I prefer to be more modest and restrict it to C.

This also improves printast.d to do a better job of printing the ASTs.