### PR TITLE
Fix Issue 22533 - OpenBSD: Use correct size_t compat for 32-bit

### DIFF
--- a/src/dmd/common/outbuffer.h
+++ b/src/dmd/common/outbuffer.h
@@ -49,7 +49,7 @@ public:
     void reserve(d_size_t nbytes);
     void setsize(d_size_t size);
     void reset();
-    void write(const void *data, size_t nbytes);
+    void write(const void *data, d_size_t nbytes);
     void writestring(const char *string);
     void prependstring(const char *string);
     void writenl();                     // write newline

--- a/src/dmd/root/dcompat.h
+++ b/src/dmd/root/dcompat.h
@@ -43,6 +43,9 @@ typedef unsigned d_size_t;
         __APPLE__ && __SIZEOF_SIZE_T__ == 8
 // DMD versions between 2.079 and 2.081 mapped D ulong to uint64_t on OS X.
 typedef uint64_t d_size_t;
+#elif defined(__OpenBSD__) && !defined(__LP64__)
+// size_t is 'unsigned long', which makes it mangle differently than D's 'uint'
+typedef unsigned d_size_t;
 #else
 typedef size_t d_size_t;
 #endif


### PR DESCRIPTION
Yes, I know I'm off master rather than stable. That's fine for this.