### PR TITLE
Nightlies: Use process substitution instead of additional pipe segment

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -203,7 +203,7 @@ jobs:
           ldmd2 -g -m64 --link-defaultlib-debug -version=NoVagrant -i build_all.d
 
           # Determine installed LDC version
-          LDC=$(ldc2 --version | head -n 1 | cut -d'(' -f2 | cut -d')' -f1)
+          LDC=$(head -n 1 < <(ldc2 --version) | cut -d'(' -f2 | cut -d')' -f1)
           echo "::set-output name=host_ldc::$LDC"
 
           # WINDOWS: Fetch additional DM tools

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -225,6 +225,16 @@ jobs:
             export LDC_VSDIR='C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise'
           fi
 
+          # Workaround: Provide ldmd2 as dmd replacement as some tools assume DMD is present:
+          mkdir .pathext
+          ln -s "$(which ldmd2)" .pathext/dmd
+          if [[ "${{ matrix.target }}" == "windows" ]]
+          then
+            PATH="$PATH;$PWD/.pathext"
+          else
+            PATH="$PATH:$PWD/.pathext"
+          fi
+
           # Build the release
           ./build_all --targets=${{ matrix.target }} "v$LDC" master
 


### PR DESCRIPTION
Avoids the race condition w.r.t. `head` as outlined in
https://stackoverflow.com/questions/45195700/curious-case-of-failed-pipe.

---
(Partially) successful run with these changes: https://github.com/dlang/dmd/runs/4287368282?check_suite_focus=true
The upload failed because this PR was raised from an external repository and hence cannot access the releases. It should work as expected when run from schedule.