### PR TITLE
fix Issue 22512 - importC: incomplete array type must have initializer

### DIFF
--- a/src/dmd/importc.d
+++ b/src/dmd/importc.d
@@ -181,9 +181,9 @@ Expression carraySemantic(ArrayExp ae, Scope* sc)
 void addDefaultCInitializer(VarDeclaration dsym)
 {
     //printf("addDefaultCInitializer() %s\n", dsym.toChars());
-    if (!(dsym.storage_class & (STC.static_ | STC.gshared | STC.extern_)))
+    if (!(dsym.storage_class & (STC.static_ | STC.gshared)))
         return;
-    if (dsym.storage_class & (STC.field | STC.in_ | STC.foreach_ | STC.parameter | STC.result))
+    if (dsym.storage_class & (STC.extern_ | STC.field | STC.in_ | STC.foreach_ | STC.parameter | STC.result))
         return;
 
     Type t = dsym.type;

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -634,4 +634,6 @@ int test(char *dest)
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22512
 
+extern char *tzname[];


### PR DESCRIPTION
`extern` variables were being given a `VoidInitializer`, that looks wrong to me, and inverting the test for `STC.extern_` fixes the regression.

The test that was applied to master has been cherry-picked here.