### PR TITLE
Fix issue 17977 - destructor allows escaping reference to a temporary struct instance

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1674,11 +1674,11 @@ extern (C++) class VarDeclaration : Declaration
         assert(this.loc != Loc.initial);
         assert(v.loc != Loc.initial);
 
-        if (auto ld = this.loc.linnum - v.loc.linnum)
-            return ld < 0;
+        if (this.loc.linnum != v.loc.linnum)
+            return this.loc.linnum < v.loc.linnum;
 
-        if (auto cd = this.loc.charnum - v.loc.charnum)
-            return cd < 0;
+        if (this.loc.charnum != v.loc.charnum)
+            return this.loc.charnum < v.loc.charnum;
 
         // Default fallback
         return this.sequenceNumber < v.sequenceNumber;

--- a/test/fail_compilation/test17977.d
+++ b/test/fail_compilation/test17977.d
@@ -1,0 +1,20 @@
+/*
+https://issues.dlang.org/show_bug.cgi?id=15399
+REQUIRED_ARGS -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test17977.d(19): Error: address of variable `__slList3` assigned to `elem` with longer lifetime
+---
+*/
+
+@safe:
+struct List {
+    int* data;
+    ~this();
+    int* front() return;
+}
+
+void test()
+{
+    auto elem = List().front;
+}


### PR DESCRIPTION

The presence of a destructor means that `addDtorHook` creates a comma expression where the expression `List().front` is assigned to a temporary `__slList3`. This variable is 'special', so `enclosesLifetimeOf` doesn't use the `sequenceNumber` but the lexical order (added in https://github.com/dlang/dmd/pull/12258). However, `Loc.linnum` and `Loc.charnum` are unsigned integers, so the check `(this.loc.linnum - v.loc.linnum) < 0` doesn't work, the result has type `uint` and unsigned integers are always >= 0.

The error message "address of variable `__slList3` assigned to `elem` with longer lifetime" is not particularly pretty, but that's out of scope for this PR.