### PR TITLE
Fix 22540 - Copy parameter types / defaults of dependant template...

### DIFF
--- a/src/dmd/templateparamsem.d
+++ b/src/dmd/templateparamsem.d
@@ -75,6 +75,7 @@ private extern (C++) final class TemplateParameterSemanticVisitor : Visitor
 
     override void visit(TemplateValueParameter tvp)
     {
+        // .syntaxCopy() ?
         tvp.valType = tvp.valType.typeSemantic(tvp.loc, sc);
         version (none)
         {

--- a/test/compilable/template_value_param_reuse.d
+++ b/test/compilable/template_value_param_reuse.d
@@ -1,0 +1,96 @@
+/+
+https://issues.dlang.org/show_bug.cgi?id=22540
+TEST_OUTPUT:
+---
+Value:
+double: double* => null
+int: int* => null
+char: char* => null
+
+Explicit but identical:
+
+Explicit not null:
+double: double* => cast(double*)1$?:32=u|64=LU$
+int: int* => cast(int*)1$?:32=u|64=LU$
+char: char* => cast(char*)1$?:32=u|64=LU$
+
+Arrays:
+int: int[][][] => [[[0]]]
+string: string[][][] => [[[null]]]
+double: double[][][] => [[[1.0]]]
+
+Alias:
+double: double* => null
+int: int* => null
+char: char* => null
+
+Explicit but identical:
+
+Explicit not null:
+double: double* => cast(double*)1$?:32=u|64=LU$
+int: int* => cast(int*)1$?:32=u|64=LU$
+char: char* => cast(char*)1$?:32=u|64=LU$
+---
++/
+
+
+pragma(msg, "\nValue:");
+
+template Value(T = int, T* ptr = (T*).init)
+{
+    pragma(msg, T, ": ", typeof(ptr), " => ", ptr);
+}
+
+alias v1 = Value!(double);
+alias v2 = Value!(int);
+alias v3 = Value!(char);
+
+pragma(msg, "\nExplicit but identical:");
+
+alias v1n = Value!(double, null);
+alias v2n = Value!(int, null);
+alias v3n = Value!(char, null);
+
+pragma(msg, "\nExplicit not null:");
+
+enum double* dv = cast(double*) 1;
+enum int* iv = cast(int*) 1;
+enum char* cv = cast(char*) 1;
+
+alias v4 = Value!(double, dv);
+alias v5 = Value!(int, iv);
+alias v6 = Value!(char, cv);
+
+pragma(msg, "\nArrays:");
+
+template Arrays(T = int, T[][][] ptr = [[[ T.init ]]])
+{
+    pragma(msg, T, ": ", typeof(ptr), " => ", ptr);
+}
+
+alias b1 = Arrays!();
+alias b2 = Arrays!(string);
+alias b3 = Arrays!(double, [[[ 1.0 ]]]);
+
+pragma(msg, "\nAlias:");
+
+template Alias(T = int, alias T* ptr = (T*).init)
+{
+    pragma(msg, T, ": ", typeof(ptr), " => ", ptr);
+}
+
+alias a1 = Alias!(double);
+alias a2 = Alias!(int);
+alias a3 = Alias!(char);
+
+pragma(msg, "\nExplicit but identical:");
+
+alias a1n = Alias!(double, cast(double*) null); // Explicit cast because exact match is required instead of TypeNull
+alias a2n = Alias!(int, cast(int*) null);
+alias a3n = Alias!(char, cast(char*) null);
+
+pragma(msg, "\nExplicit not null:");
+
+alias a4 = Alias!(double, dv);
+alias a5 = Alias!(int, iv);
+alias a6 = Alias!(char, cv);


### PR DESCRIPTION
... value / alias parameters.

The introduced copies ensure that the initialized parameters of the
instantiation do not share objects with the template declaration.

Previously, sharing could occur in the following scenarios:

- type parameter appears inside of value type, e.g. `foo(T, T* val)`
  Later semantic resolves `T` to the concrete type and hence changes
  the type of `val` in the template declaration.
- alias parameter default value isn't copied and manifested according to
  the first template instance.

---

TODO:
- [ ] Investigate https://issues.dlang.org/show_bug.cgi?id=22526 which seems related