### PR TITLE
Fix Issue 21414 - Spurious `non-constant` expression error with immutable constructors

### DIFF
--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -272,10 +272,29 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
     {
         version (none)
         {
-            printf("Expression.toDt() %d\n", e.op);
+            printf("Expression.toDt() op = %d e = %s \n", e.op, e.toChars());
         }
         e.error("non-constant expression `%s`", e.toChars());
         dtb.nzeros(1);
+    }
+
+    void visitSlice(SliceExp e)
+    {
+        version (none)
+        {
+            printf("SliceExp.toDt() %d from %s to %s\n", e.op, e.e1.type.toChars(), e.type.toChars());
+        }
+        if (!e.lwr && !e.upr)
+            return Expression_toDt(e.e1, dtb);
+        if (auto strExp = e.e1.isStringExp())
+        {
+            auto lwr = e.lwr.isIntegerExp();
+            auto upr = e.upr.isIntegerExp();
+            if (lwr && upr && lwr.toInteger() == 0 && upr.toInteger() == strExp.len)
+                return Expression_toDt(e.e1, dtb);
+        }
+
+        nonConstExpError(e);
     }
 
     void visitCast(CastExp e)
@@ -645,6 +664,7 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
         case TOK.classReference: return visitClassReference(e.isClassReferenceExp());
         case TOK.typeid_:        return visitTypeid        (e.isTypeidExp());
         case TOK.assert_:        return visitNoreturn      (e);
+        case TOK.slice:          return visitSlice         (e.isSliceExp());
     }
 }
 

--- a/test/compilable/test21414.d
+++ b/test/compilable/test21414.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=21414
+
+struct State
+{
+    string s;
+
+    immutable this(string s)
+    {
+        this.s = s;
+    }
+}
+
+immutable rootState = new immutable State("b");


### PR DESCRIPTION
When Kenji submitted: https://github.com/dlang/dmd/pull/4719, he made some assumptions in the optimization pass [1]: "Assume that the backend codegen will handle the form `e[]` as an equal to `e` itself". Well, that assumption was not met by the part of the compiler that puts the ctfe initializers in the data segment, hence the spurious error.

This patch extends the dt_builder to treat SliceExps that slice a StringExp and for which the `lwr` and `upr`  indexes are known as a simple StringExp.

[1] https://github.com/dlang/dmd/pull/4719/files#diff-11001f388b1d82b2a9178cd2ad3a0fdcce3d8e6b530fb58e53949fc0b9d72329R1081