### PR TITLE
Fix Issue 15459 - [REG2.065.0] stdin.byLine.each!(map!somefunc) compiles, fails to link with ld

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -5723,6 +5723,9 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
         tempinst.minst = null;
     }
 
+    if (sc.intypeof || tempinst.tinst && tempinst.tinst.generatedByTypeof)
+        tempinst.generatedByTypeof = true;
+
     tempinst.gagged = (global.gag > 0);
 
     tempinst.semanticRun = PASS.semantic;
@@ -6128,7 +6131,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     if (global.errors != errorsave)
         goto Laftersemantic;
 
-    if ((sc.func || (sc.flags & SCOPE.fullinst)) && !tempinst.tinst)
+    if ((sc.func || tempinst.generatedByTypeof || (sc.flags & SCOPE.fullinst)) && !tempinst.tinst)
     {
         /* If a template is instantiated inside function, the whole instantiation
          * should be done at that position. But, immediate running semantic3 of

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5809,6 +5809,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     ScopeDsymbol argsym;        // argument symbol table
     size_t hash;                // cached result of toHash()
     Expressions* fargs;         // for function template, these are the function arguments
+    bool generatedByTypeof;     // whether this template instance was generated as a result of
+                                // a typeof evaluation
 
     TemplateInstances* deferred;
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6524,6 +6524,7 @@ public:
     ScopeDsymbol* argsym;
     size_t hash;
     Array<Expression* >* fargs;
+    bool generatedByTypeof;
     Array<TemplateInstance* >* deferred;
     Module* memberOf;
     TemplateInstance* tinst;

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -259,6 +259,9 @@ public:
     ScopeDsymbol *argsym;               // argument symbol table
     hash_t hash;                        // cached result of toHash()
     Expressions *fargs;                 // for function template, these are the function arguments
+    bool generatedByTypeof;             // whether this template instance was generated as a result of
+                                        // a typeof evaluation
+
 
     TemplateInstances* deferred;
 

--- a/test/compilable/extra-files/vcg-ast.d.cg
+++ b/test/compilable/extra-files/vcg-ast.d.cg
@@ -106,6 +106,16 @@ R!int
 		int elem;
 	}
 }
+RTInfo!(_R)
+{
+	enum immutable(void)* RTInfo = null;
+
+}
+NoPointersBitmapPayload!1LU
+{
+	enum ulong[1] NoPointersBitmapPayload = 0LU;
+
+}
 mixin _d_cmain!();
 {
 	extern (C) 
@@ -130,11 +140,6 @@ RTInfo!(C)
 	enum immutable(void)* RTInfo = null;
 
 }
-NoPointersBitmapPayload!1$?:32=u|64=LU$
-{
-	enum $?:32=uint|64=ulong$[1] NoPointersBitmapPayload = 0$?:32=u|64=LU$;
-
-}
 values!(__c_wchar_t)
 {
 	pure nothrow @safe __c_wchar_t[] values()
@@ -143,10 +148,5 @@ values!(__c_wchar_t)
 		values ~= cast(__c_wchar_t)'\U0000ffff';
 		return values;
 	}
-
-}
-RTInfo!(_R)
-{
-	enum immutable(void)* RTInfo = null;
 
 }

--- a/test/fail_compilation/fail15459.d
+++ b/test/fail_compilation/fail15459.d
@@ -1,0 +1,37 @@
+// https://issues.dlang.org/show_bug.cgi?id=15459
+
+/*
+TEST_OUTPUT:
+---
+false
+fail_compilation/fail15459.d(25): Error: cannot implicitly convert expression `d` of type `dchar` to `char`
+fail_compilation/fail15459.d(31): Error: template instance `fail15459.MapResult!()` error instantiating
+fail_compilation/fail15459.d(36):        instantiated from here: `map!()`
+---
+*/
+
+enum e = is(typeof(map()));
+
+pragma(msg, e);
+
+
+struct MapResult()
+{
+    this(char[] a) {}
+
+    char front()
+    {
+        dchar d;
+        return d; /* should fail compilation */
+    }
+}
+
+void map()()
+{
+    auto mr = MapResult!()([]);
+}
+
+void main()
+{
+    map();
+}


### PR DESCRIPTION
```d
enum e = is(typeof(map()));

struct MapResult()
{
    this(char[] a) {}
    
    char front()
    {
        dchar d;
        return d; /* should fail compilation */
    }
}

void map()()
{
    auto mr = MapResult!()([]);
}

void main()
{
    map();
}
```

When the `is(typeof(map())` expression is compiled, `map` instantiated, however semantic3 is not done on the `MapResult` template instance. This leads `typeof(map())` to return `void` and `is(void)` evaluates to `true`. Later on, when `map` is used in `main`, the template instance is not re-analyzed because we already have a "valid" instantiation. When semantic3 is performed this, this time it is also gagged for some reason.

My patch builds on the fact that full semantic needs to be performed in the situations where the root instantiating expression is inside a typeof context. To do that, I am adding a field to the `TemplateInstance` AST node that keeps track whether the instantiation subtree's root inside a `typeof` context.

Targeting master as this is a very old regression and the fix might be controversial.