### PR TITLE
Fix compiler frontend examples from crashing

### DIFF
--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -398,7 +398,8 @@ Tuple!(Module, "module_", Diagnostics, "diagnostics") parseModule(AST = ASTCodeg
     {
         import dmd.root.filename : FileName;
 
-        auto fb = new FileBuffer(cast(ubyte[]) code.dup ~ '\0');
+        auto buf = cast(ubyte[]) (code.dup ~ "\0\0\0\0");
+        auto fb = new FileBuffer(buf[0 .. $-4]);
         global.fileManager.add(FileName(fileName), fb);
         m.src = fb.data;
     }

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -98,7 +98,8 @@ class Lexer
      *
      * Params:
      *  filename = used for error messages
-     *  base = source code, must be terminated by a null (0) or EOF (0x1A) character
+     *  base = source code, must be terminated by a null (0) or EOF (0x1A) plus 3 characters
+               because the skipping 4 spaces optimization. (e.g. source ~ "\0\0\0\0")
      *  begoffset = starting offset into base[]
      *  endoffset = the last offset to read into base[]
      *  doDocComment = handle documentation comments

--- a/test/dub_package/avg.d
+++ b/test/dub_package/avg.d
@@ -59,7 +59,10 @@ void main()
 
     auto id = Identifier.idPool(fname);
     auto m = new ASTBase.Module(&(fname.dup)[0], id, false, false);
-    auto input = readText(fname);
+    auto file = File(fname, "rb");
+    // Create a buffer with four '\0' past the end for lexer
+    auto input = cast(char[]) new ubyte[file.size() + 4];
+    input = file.rawRead(input);
 
     scope p = new Parser!ASTBase(m, input, false);
     p.nextToken();

--- a/test/dub_package/avg.d
+++ b/test/dub_package/avg.d
@@ -61,7 +61,7 @@ void main()
     auto m = new ASTBase.Module(&(fname.dup)[0], id, false, false);
     auto file = File(fname, "rb");
     // Create a buffer with four '\0' past the end for lexer
-    auto input = cast(char[]) new ubyte[file.size() + 4];
+    auto input = cast(char[]) new ubyte[cast(size_t) file.size() + 4];
     input = file.rawRead(input);
 
     scope p = new Parser!ASTBase(m, input, false);

--- a/test/dub_package/impvisitor.d
+++ b/test/dub_package/impvisitor.d
@@ -108,7 +108,7 @@ void main()
         auto m = new ASTBase.Module(fn.toStringz, id, false, false);
         auto file = File(fn, "rb");
         // Create a buffer with four '\0' past the end for lexer
-        auto input = cast(char[]) new ubyte[file.size() + 4];
+        auto input = cast(char[]) new ubyte[cast(size_t) file.size() + 4];
         input = file.rawRead(input);
 
         //writeln("Started parsing...");

--- a/test/dub_package/impvisitor.d
+++ b/test/dub_package/impvisitor.d
@@ -73,6 +73,7 @@ extern(C++) class ImportVisitor(AST) : PermissiveVisitor!AST
 void main()
 {
     import std.stdio;
+    import std.string : toStringz;
     import std.file;
     import std.path : buildPath, dirName;
 
@@ -104,8 +105,11 @@ void main()
         ASTBase.Type._init();
 
         auto id = Identifier.idPool(fn);
-        auto m = new ASTBase.Module(&(fn.dup)[0], id, false, false);
-        auto input = readText(fn);
+        auto m = new ASTBase.Module(fn.toStringz, id, false, false);
+        auto file = File(fn, "rb");
+        // Create a buffer with four '\0' past the end for lexer
+        auto input = cast(char[]) new ubyte[file.size() + 4];
+        input = file.rawRead(input);
 
         //writeln("Started parsing...");
         scope p = new Parser!ASTBase(m, input, false);

--- a/test/dub_package/lexer.d
+++ b/test/dub_package/lexer.d
@@ -17,8 +17,8 @@ void main()
         TOK.rightCurly
     ];
 
-    immutable sourceCode = "void test() {} // foobar";
-    scope lexer = new Lexer("test", sourceCode.ptr, 0, sourceCode.length, 0, 0);
+    immutable sourceCode = "void test() {} // foobar\0\0\0\0";
+    scope lexer = new Lexer("test", sourceCode.ptr, 0, sourceCode.length - 4, 0, 0);
     lexer.nextToken;
 
     TOK[] result;

--- a/test/dub_package/retrieveScope.d
+++ b/test/dub_package/retrieveScope.d
@@ -63,8 +63,8 @@ int main()
 {
     auto dmdParentDir = dirName(dirName(dirName(__FILE_FULL_PATH__)));
     global.path = new Strings();
-    global.path.push((dmdParentDir ~ "/phobos").ptr);
-    global.path.push((dmdParentDir ~ "/druntime/import").ptr);
+    global.path.push((dmdParentDir ~ "/phobos\0").ptr);
+    global.path.push((dmdParentDir ~ "/druntime/import\0").ptr);
 
     /* comment for error output in parsing & semantic */
     diagnosticHandler = (const ref Loc location,
@@ -78,7 +78,7 @@ int main()
     initDMD(diagnosticHandler);
 
     Strings libmodules;
-    Module m = createModule((dirName(__FILE_FULL_PATH__) ~ "/testfiles/correct.d").ptr,
+    Module m = createModule((dirName(__FILE_FULL_PATH__) ~ "/testfiles/correct.d\0").ptr,
                                 libmodules);
     m.importedFrom = m; // m.isRoot() == true
 


### PR DESCRIPTION
impvisitor.d and retrieveScope.d are crashing on my system, because:
1. A few strings are not null-terminated where they are required
2. The lexer needs 4 bytes after the end of the buffer.