### PR TITLE
Fix issue 22550 - tail const C++ class not usable on Windows

### DIFF
--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -462,6 +462,7 @@ public:
 
     // D class mangled as pointer to C++ class
     // const(Object) mangled as Object const* const
+    // except for class types at top, where it is mangled as Object const*
     override void visit(TypeClass type)
     {
         //printf("visit(TypeClass); is_not_top_type = %d\n", (int)(flags & IS_NOT_TOP_TYPE));
@@ -469,7 +470,7 @@ public:
             return;
         if (flags & IS_NOT_TOP_TYPE)
             mangleModifier(type);
-        if (type.isConst())
+        if ((flags & IS_NOT_TOP_TYPE) && type.isConst())
             buf.writeByte('Q');
         else
             buf.writeByte('P');

--- a/test/runnable_cxx/externmangle.d
+++ b/test/runnable_cxx/externmangle.d
@@ -213,6 +213,10 @@ class C1
     }
 }
 
+const(char)* getC1DataTailConst(const C1 c);
+const(char)* getC1DataTailConstRef(ref const C1 c);
+const(C1) getC1Identity(const C1 c);
+
 extern(C++, struct)
 class C2(T)
 {
@@ -231,6 +235,9 @@ void test39()
     C1 c1 = C1.init(ptr);
     assert(c1.getDataCPP() == ptr);
     assert(c1.getDataD() == ptr);
+    assert(getC1DataTailConst(c1) == ptr);
+    assert(getC1DataTailConstRef(c1) == ptr);
+    assert(getC1Identity(c1) == c1);
     C2!char c2 = C2!char.init(ptr);
     assert(c2.getData() == ptr);
     auto result = test39cpp(c2, S2!int.init(43));

--- a/test/runnable_cxx/extra-files/externmangle.cpp
+++ b/test/runnable_cxx/extra-files/externmangle.cpp
@@ -143,12 +143,12 @@ int Test20::test20 = 20;
 int Test20::test21 = 21;
 int Test20::test22 = 22;
 
-int test23(Test10**, Test10*, Test10***, Test10 const *const)
+int test23(Test10**, Test10*, Test10***, Test10 const *)
 {
     return 1;
 }
 
-int test23b(Test10 const *const *const,  Test10 const* const, Test10*)
+int test23b(Test10 const *const *const,  Test10 const*, Test10*)
 {
     return 1;
 }
@@ -375,6 +375,21 @@ C1* C1::init(const char *p)
 const char* C1::getDataCPP()
 {
     return data;
+}
+
+const char *getC1DataTailConst(const C1 *c)
+{
+    return c->data;
+}
+
+const char *getC1DataTailConstRef(const C1 *const &c)
+{
+    return c->data;
+}
+
+const C1 *getC1Identity(const C1 *c)
+{
+    return c;
 }
 
 template<class T>


### PR DESCRIPTION
This changes the C++ mangling of const(Class) from "Class const * const"
to "Class const *" for Windows, but only if the class type is used at the
top of a type. It is a breaking change for code using "Class const * const"
in C++, but this code seems to be less common.