### PR TITLE
Fix issue 22549 - float literal should support leading zero

### DIFF
--- a/test/fail_compilation/numliteral.c
+++ b/test/fail_compilation/numliteral.c
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/numliteral.c(10): Error: binary constants not allowed
+fail_compilation/numliteral.c(11): Error: embedded `_` not allowed
+---
+*/
+
+// Test C-specific errors
+int x = 0b00;
+int y = 0_1;
+
+// https://issues.dlang.org/show_bug.cgi?id=22549
+int z = 078.0 + 008. + 009e1;


### PR DESCRIPTION
Defer errors about digits >= base to after `Ldone:`.
This way they won't appear when the `Lreal:` branch is taken.

This also allows such literals for D, since the grammar allows it: https://issues.dlang.org/show_bug.cgi?id=3251