### PR TITLE
default to `CppRuntime_Gcc` on Solaris

### DIFF
--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1451,7 +1451,7 @@ struct TargetCPP
         case DigitalMars: return predef("CppRuntime_DigitalMars");
         case Gcc:         return predef("CppRuntime_Gcc");
         case Microsoft:   return predef("CppRuntime_Microsoft");
-        case Sun:         return predef("CppRuntime_Sun");
+        case Sun:         return predef("CppRuntime_Gcc");
         }
     }
 }

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1306,7 +1306,7 @@ struct TargetCPP
         else if (os & (Target.OS.OSX | Target.OS.FreeBSD | Target.OS.OpenBSD))
             runtime = Runtime.Clang;
         else if (os == Target.OS.Solaris)
-            runtime = Runtime.Sun;
+            runtime = Runtime.Gcc;
         else
             assert(0);
         // C++ and D ABI incompatible on all (?) x86 32-bit platforms

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1451,7 +1451,7 @@ struct TargetCPP
         case DigitalMars: return predef("CppRuntime_DigitalMars");
         case Gcc:         return predef("CppRuntime_Gcc");
         case Microsoft:   return predef("CppRuntime_Microsoft");
-        case Sun:         return predef("CppRuntime_Gcc");
+        case Sun:         return predef("CppRuntime_Sun");
         }
     }
 }


### PR DESCRIPTION
Hello, 

I tried to compile druntime using DMD on a recent OpenIndiana machine. I ran into a problem, because on Solaris `CppRuntime_Sun` gets predefined in DMD. However, Developer Studio has been replaced by gcc in [OpenIndiana](https://www.openindiana.org/documentation/faq/#how-does-openindiana-differ-from-opensolaris), in [OmniOS also](https://github.com/omniosorg/omnios-build/blob/r151040/doc/ReleaseNotes.md) and I suppose in SmartOS too. The only Solaris system still using Developer Studio is the official Oracle Solaris, where Gcc is also available.

This patch would predefine `CppRuntime_Gcc` on Solaris systems, instead of `CppRuntime_Sun`. Some further discussion about this can be found [here](https://github.com/dlang/druntime/pull/3624#issuecomment-979449343)

Another possible solution could be to let the build script detect and define an `Illumos` version. One could insert a case for `Illumos` into the switch statement before the `Sun` case. I would need some help here, as I have not tinkered with the build scripts before. Appending this to the end of `osmodel.mak` might work:

```sh
ifeq ($(OS), solaris)
  ILLUMOS?=$(shell uname -a | grep -i illumos)
  ifneq (, $(ILLUMOS))
    DFLAGS+="-version=Illumos"
  endif
endif
```

I would really appreciate feedback and help with this.