### PR TITLE
Fix Issue 20860 - OpDispatch does not work for structs with constructor and destructor

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -535,15 +535,15 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
                 ce.e1 = ey;
                 if (isDotOpDispatch(ey))
                 {
-                    uint errors = global.startGagging();
-                    e = ce.syntaxCopy().expressionSemantic(sc);
-                    if (!global.endGagging(errors))
-                        return e;
-
                     // even opDispatch and UFCS must have valid arguments,
                     // so now that we've seen indication of a problem,
                     // check them for issues.
                     Expressions* originalArguments = Expression.arraySyntaxCopy(ce.arguments);
+
+                    uint errors = global.startGagging();
+                    e = ce.expressionSemantic(sc);
+                    if (!global.endGagging(errors))
+                        return e;
 
                     if (arrayExpressionSemantic(originalArguments, sc))
                         return ErrorExp.get();

--- a/test/compilable/test20860.d
+++ b/test/compilable/test20860.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=20860
+
+struct A
+{
+    this(int a) {}
+  ///
+  void opDispatch(string methodName, Params...)(Params params) {
+  }
+
+  ~this() {}
+}
+
+void main()
+{
+    A(3).test();
+}


### PR DESCRIPTION
The issue is that because of the syntax copy, the generated temporary for the struct literal is introduced in the scope twice. Since the error is gagged, an opDispatch error is reported (wrongfully). I fixed this by not making a syntax copy and doing semantic analysis directly on the callExp.