### PR TITLE
Disable -O for runnable_cxx/test7925.d due to a codegen issue

### DIFF
--- a/test/runnable_cxx/test7925.d
+++ b/test/runnable_cxx/test7925.d
@@ -1,4 +1,12 @@
 // EXTRA_CPP_SOURCES: cpp7925.cpp
+
+/*
+Exclude -O due to a codegen bug on OSX:
+https://issues.dlang.org/show_bug.cgi?id=22556
+
+PERMUTE_ARGS(osx): -inline -release -g
+*/
+
 import core.vararg;
 
 extern(C++) class C1

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -254,6 +254,7 @@ bool findTestParameter(const ref EnvData envData, string file, string token, ref
     auto tokenStart = std.string.indexOf(file, token);
     if (tokenStart == -1) return false;
 
+    bool applied = true;
     file = file[tokenStart + token.length .. $];
 
     auto lineEndR = std.string.indexOf(file, "\r");
@@ -286,7 +287,10 @@ bool findTestParameter(const ref EnvData envData, string file, string token, ref
             if (oss.canFind!(o => o.skipOver(envData.os) && (o.empty || o == envData.model)))
                 result = result[close + 1 .. $];
             else
+            {
                 result = null;
+                applied = false; // Parameter was skipped
+            }
         }
     }
     // skips the :, if present
@@ -305,12 +309,13 @@ bool findTestParameter(const ref EnvData envData, string file, string token, ref
             else
                 result ~= multiLineDelimiter ~ result2;
         }
+        applied = true;
     }
 
     // fix-up separators
     result = result.unifyDirSep(envData.sep);
 
-    return true;
+    return applied;
 }
 
 /**


### PR DESCRIPTION
Also had to modify `d_do_test` s.t. the conditional parameter doesn't affect other platforms.