### PR TITLE
fix Issue 22534 - ImportC: const pointer (not pointer to const) is tr…

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2495,7 +2495,18 @@ final class CParser(AST) : Parser!AST
                 return t;
             }
 
-            t = constApply(t);
+            if (declarator == DTR.xparameter &&
+                t.isTypePointer())
+            {
+                /* Because there are instances in .h files of "const pointer to mutable",
+                 * skip applying transitive `const`
+                 * https://issues.dlang.org/show_bug.cgi?id=22534
+                 */
+                auto tn = cast(AST.TypeNext)t;
+                tn.next = constApply(tn.next);
+            }
+            else
+                t = constApply(t);
         }
 
         //printf("result: %s\n", t.toChars());

--- a/test/compilable/test22534.c
+++ b/test/compilable/test22534.c
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=22534
+
+struct S { int x; };
+
+void test(struct S *const p)
+{
+    p->x = 1;
+}

--- a/test/fail_compilation/fix22265.c
+++ b/test/fail_compilation/fix22265.c
@@ -1,7 +1,6 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/fix22265.c(104): Error: cannot modify `const` expression `*buf`
-fail_compilation/fix22265.c(105): Error: cannot modify `const` expression `p`
 ---
  */
 
@@ -13,5 +12,4 @@ void test(const char *buf, char *const p)
 {
    char a = *buf++;
    *buf = 'a';          // 104
-   char b = *p++;       // 105
 }


### PR DESCRIPTION
…eated as transitive const

This is a hackish solution, to ignore `const` in a particular circumstance. The only real solution would be to implement "head const" in D.