### PR TITLE
Fix Issue 20828 - __traits(getFunctionAttributes) doesn't support scope

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3097,13 +3097,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (ad && ad.isClassDeclaration() && (tf.isreturn || sc.stc & STC.return_) && !(sc.stc & STC.static_))
                 sc.stc |= STC.scope_;
 
-            // If 'this' has no pointers, remove 'scope' as it has no meaning
-            if (sc.stc & STC.scope_ && ad && ad.isStructDeclaration() && !ad.type.hasPointers())
-            {
-                sc.stc &= ~STC.scope_;
-                tf.isScopeQual = false;
-            }
-
             sc.linkage = funcdecl.linkage;
 
             if (!tf.isNaked() && !(funcdecl.isThis() || funcdecl.isNested()))

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1775,7 +1775,10 @@ void escapeByValue(Expression e, EscapeByResults* er, bool live = false)
                 AggregateDeclaration ad;
                 if (global.params.useDIP1000 == FeatureState.enabled && tf.isreturn && fd && (ad = fd.isThis()) !is null)
                 {
-                    if (ad.isClassDeclaration() || tf.isScopeQual)       // this is 'return scope'
+                    if (ad.isClassDeclaration() ||
+                        // https://issues.dlang.org/show_bug.cgi?id=17049
+                        // if the struct has no pointers, `scope` has no meaning
+                       (tf.isScopeQual && (!ad.isStructDeclaration || ad.type.hasPointers())))       // this is 'return scope'
                         dve.e1.accept(this);
                     else if (ad.isStructDeclaration()) // this is 'return ref'
                     {

--- a/test/compilable/test20828.d
+++ b/test/compilable/test20828.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=20828
+
+/*
+TEST_OUTPUT:
+---
+tuple("scope", "@safe")
+---
+*/
+
+struct Struct
+{
+    void fun() @safe scope;
+}
+
+pragma(msg, __traits(getFunctionAttributes, Struct.fun));


### PR DESCRIPTION
#6577 fixed [Issue 17049](https://issues.dlang.org/show_bug.cgi?id=17049) by removing the `scope` qualifier from struct member functions if it does not have any indirection in it. This had the side effect of making utilities such as `__traits(getAttributes)` issue a confusing output (see the bug report example).

In this patch, the `scope` qualifier is not erased, but rather ignored for member functions of structs that do not contain any indirections.

An alternative approach would be to issue a deprecation stating that `scope` is useless if the struct does not contain any indirections, however, that would make it impossible to preemptively use scope (e.g a `struct` starts by not containing any inderections, but methods are marked as scope just in case; later on, an indirection is added).

cc @WalterBright as you are the author of #6577