### PR TITLE
dmd.target: Begin making some target internals private to D or the target module

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7652,7 +7652,6 @@ private:
     const Param* params;
 public:
     void _init(const Param& params);
-    void setCPU();
     void setTriple(const Triple& triple);
     void addPredefinedGlobalIdentifiers() const;
     void deinitialize();
@@ -7680,7 +7679,6 @@ public:
     bool isCalleeDestroyingArgs(TypeFunction* tf);
     bool libraryObjectMonitors(FuncDeclaration* fd, Statement* fbody);
     Target() :
-        os((OS)1u),
         osMajor(),
         ptrsize(),
         realsize(),

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -264,7 +264,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (params.color)
         global.console = cast(void*) createConsole(core.stdc.stdio.stderr);
 
-    target.os = defaultTargetOS();           // set target operating system
+    target.setTargetOS();           // set target operating system
     target.setCPU();
 
     if (global.errors)


### PR DESCRIPTION
The original intent of the Target struct was to be an interface that itself doesn't know anything about what it is targeting, so long as something was implementing the hooks it exposed, the introduction of public fields and types such as `CPU cpu` and `OS os` obviously threw a wrench at that plan, but that doesn't mean that these very target (and very dmd) centric fields can't be internalized so that the rest of the frontend/codegen no longer directly interacts with them.