### PR TITLE
runnable/noreturn2.d: extern(C) functions have no defined order of parameter evaluation

### DIFF
--- a/test/runnable/noreturn2.d
+++ b/test/runnable/noreturn2.d
@@ -172,19 +172,24 @@ void testFuncCall()
     assert(countLeft == 1);
     assert(countRight == 0);
 
-//     // C function arguments are still evaluated left to right
-//     // Despite them being push in reverse order
-    testAssertFailure(line, msg, function()
+    version (DigitalMars)
     {
-        static extern(C) void acceptNoreturnC(int, int, int) { puts("unreachable"); }
+        // ???: C function arguments are still evaluated left to right
+        // ???: Despite them being push in reverse order
+        testAssertFailure(line, msg, function()
+        {
+            static extern(C) void acceptNoreturnC(int, int, int) { puts("unreachable"); }
 
-        acceptNoreturnC(countLeft++, abort(), countRight++);
+            acceptNoreturnC(countLeft++, abort(), countRight++);
 
-        assert(false);
-    });
+            assert(false);
+        });
 
-    assert(countLeft == 2);
-    assert(countRight == 0);
+        assert(countLeft == 2);
+        assert(countRight == 0);
+    }
+    else
+        countLeft++;
 
     WithDtor.destroyed = 0;
 


### PR DESCRIPTION
This test doesn't make any sense, there is no defined order that parameters are evaluated in when it comes to non-externD code  -> make the test dmd-only.