### PR TITLE
fix Issue 19136 - is expressions don't work as documented

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5749,6 +5749,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
              * is(targ id == tspec, tpl)
              * is(targ id : tspec, tpl)
              */
+
+            if (e.targ.isTypeBasic() && e.tspec.isTypeBasic() && e.targ != e.tspec)
+            {
+                return no();
+            }
+
             Identifier tid = e.id ? e.id : Identifier.generateId("__isexp_id");
             e.parameters.insert(0, new TemplateTypeParameter(e.loc, tid, null, null));
 

--- a/test/compilable/b19136.d
+++ b/test/compilable/b19136.d
@@ -1,0 +1,53 @@
+// REQUIRED_ARGS: -c
+
+/* --------------------------------------- */
+static assert(!is(int T == void));
+static assert(!is(int T == bool));
+static assert(!is(int T == byte));
+static assert(!is(int T == ubyte));
+static assert(!is(int T == short));
+static assert(!is(int T == ushort));
+// static assert(!is(int T == int));
+static assert(!is(int T == uint));
+static assert(!is(int T == long));
+static assert(!is(int T == ulong));
+static assert(!is(int T == cent));
+static assert(!is(int T == ucent));
+static assert(!is(int T == float));
+static assert(!is(int T == double));
+static assert(!is(int T == real));
+static assert(!is(int T == ifloat));
+static assert(!is(int T == idouble));
+static assert(!is(int T == ireal));
+static assert(!is(int T == cfloat));
+static assert(!is(int T == cdouble));
+static assert(!is(int T == creal));
+static assert(!is(int T == char));
+static assert(!is(int T == wchar));
+static assert(!is(int T == dchar));
+
+/* --------------------------------------- */
+static assert(!is(int T : void));
+static assert(!is(int T : bool));
+static assert(!is(int T : byte));
+static assert(!is(int T : ubyte));
+static assert(!is(int T : short));
+static assert(!is(int T : ushort));
+// static assert(!is(int T : int));
+static assert(!is(int T : uint));
+static assert(!is(int T : long));
+static assert(!is(int T : ulong));
+static assert(!is(int T : cent));
+static assert(!is(int T : ucent));
+static assert(!is(int T : float));
+static assert(!is(int T : double));
+static assert(!is(int T : real));
+static assert(!is(int T : ifloat));
+static assert(!is(int T : idouble));
+static assert(!is(int T : ireal));
+static assert(!is(int T : cfloat));
+static assert(!is(int T : cdouble));
+static assert(!is(int T : creal));
+static assert(!is(int T : char));
+static assert(!is(int T : wchar));
+static assert(!is(int T : dchar));


### PR DESCRIPTION
Before this patch, `is ( Type Identifier : TypeSpecialization )` expressions would evaluate to _true_ with basic types, like this:
```static assert(!is(int T : uint));
static assert(!is(int T : long));
static assert(!is(int T : float));
static assert(!is(int T : double));
static assert(!is(int T : dchar));
..
static assert(!is(bool T : byte));
static assert(!is(byte T : bool));
..
```
..and many more - you can replace the two types inside the isExpression however you like; the only cases where this would correctly evaluate to false seem to be when one of the types is `void` or `Type` has a size strictly bigger than `TypeSpecialization`.

This fix makes it so that, as per spec, if both `Type` and `TypeSpecialization` are basic types, the isExpressions defined like above will evaluate to _false_ if the types are not identical.