### PR TITLE
Fix Issue 22575 - putting -run in dmd.conf causes a segfault

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -2394,7 +2394,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         else if (arg == "-run")              // https://dlang.org/dmd.html#switch-run
         {
             params.run = true;
-            size_t length = argc - i - 1;
+            size_t length = arguments.dim - i - 1;
             if (length)
             {
                 const(char)[] runarg = arguments[i + 1].toDString();


### PR DESCRIPTION
Length in "-run" code only considers command line args, causing an underflow here. This fixes the segfault, but breaks everything else, because it eats the rest of the arguments, and then it can't compile. So I'm not sure if it's easily possible to allow "-run" in a dmd.conf file, and maybe it should just error upon encountering it.