### PR TITLE
run.d: Improve error message for failed `unit` tests

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -194,7 +194,10 @@ Options:
             int status = spawnProcess(target.args, env, Config.none, scriptDir).wait;
             if (status != 0)
             {
-                const name = target.normalizedTestName;
+                const string name = target.filename
+                            ? target.normalizedTestName
+                            : "`unit` tests";
+
                 writeln(">>> TARGET FAILED: ", name);
                 failedTargets ~= name;
             }


### PR DESCRIPTION
The `filename` isn't set for `unit` tests because they are delegated
to another test tool instead of `d_do_test`. That caused `run.d` to
emit `.` instead of a meaningful error message when a `unit` test failed.

Before:
```
[...]

Failed tests:
dmd/test/unit/interfaces/check_implementations_20861.d:52

>>> TARGET FAILED: .
FAILED targets:
- .
```

After
```
[...]

Failed tests:
dmd/test/unit/interfaces/check_implementations_20861.d:52

>>> TARGET FAILED: `unit` tests
FAILED targets:
- `unit` tests
```

---

CC @RazvanN7 to fix the "cryptic error message"