### PR TITLE
Fix Issue 20236 - spurious deprecation warnings on function calls wit…

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1798,7 +1798,7 @@ extern (C++) final class WithScopeSymbol : ScopeDsymbol
         // Acts as proxy to the with class declaration
         Dsymbol s = null;
         Expression eold = null;
-        for (Expression e = withstate.exp; e != eold; e = resolveAliasThis(_scope, e))
+        for (Expression e = withstate.exp; e && e != eold; e = resolveAliasThis(_scope, e, true))
         {
             if (e.op == TOK.scope_)
             {

--- a/test/compilable/test20236.d
+++ b/test/compilable/test20236.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=20236
+
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+struct X
+{
+    alias y this;
+    deprecated int y() { return 5; }
+    int x() { return 5; }
+}
+
+void main()
+{
+    static void func(int) {}
+    with(X.init) {
+        func(x);
+    }
+}


### PR DESCRIPTION
…hin with(X) blocks while X has a deprecated alias this target