### PR TITLE
adjust os_critsecsize on 32 and 64 bit Solaris

### DIFF
--- a/src/dmd/backend/os.d
+++ b/src/dmd/backend/os.d
@@ -972,13 +972,14 @@ else version(Solaris)
 {
 int os_critsecsize32()
 {
-    return pthread_mutex_t.sizeof;
+    assert(pthread_mutex_t.sizeof == 24);
+    return 24;
 }
 
 int os_critsecsize64()
 {
-    assert(0);
-    return 0;
+    assert(pthread_mutex_t.sizeof == 24);
+    return 24;
 }
 }
 


### PR DESCRIPTION
Hello,

the `os_critsecsize64` function did only `assert(0)` before and therefore broke compilation on 64 bit Solaris/Illumos.
This patch correctly returns the size of `pthread_mutex_t` and asserts it's size. It also changes the corresponding `os_critsecsize32` function accordingly.

I tested this change successfully on a recent OpenIndiana machine.