### PR TITLE
Fix Issue 22136 - [REG 2.097.1] hashOf failed to compile because of d…

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6341,7 +6341,7 @@ extern (C++) final class TypeClass : Type
         /* Conversion derived to const(base)
          */
         int offset = 0;
-        if (to.isBaseOf(this, &offset) && offset == 0 && MODimplicitConv(mod, to.mod))
+        if (to.isBaseOf(this, &offset) && MODimplicitConv(mod, to.mod))
         {
             // Disallow:
             //  derived to base

--- a/test/compilable/commontype.d
+++ b/test/compilable/commontype.d
@@ -196,7 +196,8 @@ static assert(is( X!( C***, B*** ) == const(B**)* )); // `B***`
 
 static assert(is( X!( C*, I* ) == I* ));
 static assert(is( X!( I*, C* ) == I* ));
-static assert(Error!( C**, I** ));
+//static assert(Error!( C**, I** ));
+static assert(is( X!( C**, I** ) == const(I*)* ));
 
 static assert(Error!( C*, D* )); // should work
 
@@ -303,13 +304,15 @@ static assert(is( X!(C[4], B[4]) ));
 static assert(Error!( C[4], I[4] ));
 static assert(Error!( C[4], D[4] ));
 static assert(is( X!( C[4], const(B)[4] ) == const(B)[4] ));
-static assert(Error!( C[4], const(I)[4] ));
+//static assert(Error!( C[4], const(I)[4] ));
+static assert(is( X!( C[4], const(I)[4] ) == const(I)[] ));
 static assert(Error!( C[4], const(D)[4] ));
 static assert(Error!( C*[4], B*[4] ));
 static assert(Error!( C*[4], I*[4] ));
 static assert(Error!( C*[4], D*[4] ));
 static assert(is( X!( C*[4], const(B*)[4] ) == const(B*)[] )); // !?
-static assert(Error!( C*[4], const(I*)[4] ));
+//static assert(Error!( C*[4], const(I*)[4] ));
+static assert(is( X!( C*[4], const(I*)[4] ) == const(I*)[] ));
 static assert(Error!( C*[4], const(D*)[4] ));
 static assert(Error!( C*[4], B**[4] ));
 static assert(Error!( C*[4], const(B*)*[4] ));

--- a/test/runnable/test22136.d
+++ b/test/runnable/test22136.d
@@ -1,0 +1,25 @@
+
+interface IObject
+{
+    size_t toHash() @trusted nothrow;
+}
+
+interface Dummy {}
+interface Bug(E) : Dummy, IObject {}
+interface OK(E) : IObject, Dummy {}
+
+void main()
+{
+
+    {
+        Bug!string s;
+        size_t t = hashOf(s);
+    }
+    {
+        OK!string s;
+        size_t t = hashOf(s);
+    }
+
+    static assert(is(immutable Bug!string* : immutable IObject*));
+    static assert(is(immutable OK!string* : immutable IObject*));
+}

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2175,13 +2175,13 @@ void test4251b()
     // derived class to const(base interface) in tail
     interface I {}
     class X : I {}
-    static assert(!is( X[] : const(I)[] ));
+    static assert(is( X[] : const(I)[] ));
 
     // interface to const(base interface) in tail
     interface J {}
     interface K : I, J {}
     static assert( is( K[] : const(I)[] )); // OK, runtime offset is same
-    static assert(!is( K[] : const(J)[] )); // NG, runtime offset is different
+    static assert(is( K[] : const(J)[] )); // !? NG, runtime offset is different
 }
 
 /************************************/


### PR DESCRIPTION
…ifferent inheritance order

druntime's `hashOf` uses the following "idiom"(?) (extracted only the relavant parts)

```
size_t hashOf(T)(T val)
{
    static if (is(__traits(parent, val.toHash) P) && !is(immutable T* : immutable P*))
        return val ? hashOf(__traits(getMember, val, __traits(getAliasThis, T))) : 0;
    [...]
}
```

It seems that it's assuming that if you can access `toHash` through a parent `P`, and `T*` is not implicitly convertible to `P*`
then you're accessing `toHash` through an `alias this`. I'm unsure if this is sound, as the class spec says at point [15.16.2](https://dlang.org/spec/class.html#alias-this): "A class or struct can be implicitly converted to the AliasThis member.".
Either I'm misinterpreting the spec, or the idiom is wrong.

Assuming the idiom is right, the `is(immutable T* : immutable P*)` check fails for the following example
```
interface IObject
{
    size_t toHash() @trusted nothrow;
}

interface Dummy {}
interface Bug(E) : Dummy, IObject {}
interface OK(E) : IObject, Dummy {}

void main()
{

    {
        Bug!string s;
        size_t t = hashOf(s);
    }
    {
        OK!string s;
        size_t t = hashOf(s);
    }

    static assert(is(immutable Bug!string* : immutable IObject*)); // <-- this errors with master
    static assert(is(immutable OK!string* : immutable IObject*));
}
```

As you can see, the order of the interfaces affects the implicit conversion rules.
Before those changes, the implicit conversion check only looked at the declaration (`ClassDeclaration` or `InterfaceDeclaration`) at offset 0.
I don't understand why we wouldn't want to check against all the interfaces that a type implements.
Am I missing something fundamental?