### PR TITLE
Fix build for Solaris/Illumos

### DIFF
--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -239,7 +239,7 @@ if (config.exe == EX_DRAGONFLYBSD64)
     }
     config.objfmt = OBJ_ELF;
 }
-if (config.exe & (EX_SOLARIS | EX_SOLARIS))
+if (config.exe & (EX_SOLARIS | EX_SOLARIS64))
 {
     if (model == 64)
     {
@@ -256,7 +256,7 @@ if (config.exe & (EX_SOLARIS | EX_SOLARIS))
     if (!exe)
         config.flags3 |= CFG3pic;
     config.objfmt = OBJ_ELF;
-    config.ehmethod = useExceptions ? EHmethod.EH_DM : EHmethod.EH_NONE;
+    config.ehmethod = useExceptions ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
 }
     config.flags2 |= CFG2nodeflib;      // no default library
     config.flags3 |= CFG3eseqds;


### PR DESCRIPTION
Fix Issue 22573 - DMD compiler errors on Illumos/Solaris

Hello --

This diff gets dmd to be able to successfully build phobos on a modern 64-bit Illumos.
No further testing was done, but this is better than where we were.