### PR TITLE
add necessary libraries to the default config on Solaris

### DIFF
--- a/ini/solaris/bin32/dmd.conf
+++ b/ini/solaris/bin32/dmd.conf
@@ -1,5 +1,5 @@
 [Environment32]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic -L-lsocket -L-lnsl
 
 [Environment64]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic -L-lsocket -L-lnsl

--- a/ini/solaris/bin64/dmd.conf
+++ b/ini/solaris/bin64/dmd.conf
@@ -1,5 +1,5 @@
 [Environment32]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic -L-lsocket -L-lnsl
 
 [Environment64]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic -L-lsocket -L-lnsl


### PR DESCRIPTION
Hello,

I tried to build dub with DMD on OpenIndiana, a descendant of Solaris.
For this I chose the following procedure:

1. build gdc
2. use gdc to build dmd from the github master branch (necessary because of some recent Solaris specific fixes)
3. use dmd to compile druntime and phobos from master branches
4. try to compile dub using dmd

Without further configuration, this fails because at least on Solaris using netdb.h requires linking with "-lsocket -lnsl", see [here](https://docs.oracle.com/cd/E26502_01/html/E29035/getaddrinfo-3socket.html).
socket.d of phobos imports netdb.d of druntime which is the conversion of the C-header to D. But the linking flags do not get added automatically on Solaris.
Manually adding those libraries to the DFLAGS made it possible to successfully build dub with dmd.

gdc solves this issue using a libgphobos.spec file which gets generated upon compiling gdc. It adds the necessary linking flags unconditionally for all linking targets.

This patch does the equivalent for DMD on 32- and 64-bit Solaris/Illumos and has been successfully tested on my OpenIndiana machine.