### PR TITLE
test: Fix a number of broken directives

### DIFF
--- a/test/compilable/test21299a.d
+++ b/test/compilable/test21299a.d
@@ -1,4 +1,4 @@
-// EXTRA_SOURCES: imports/test21299/mtype.d imports/test21299/rootstringtable.d
+// EXTRA_SOURCES: imports/test21299/mtype.d imports/test21299/func.d imports/test21299/rootstringtable.d
 // REQUIRED_ARGS: -main
 // LINK
 module test21299a;

--- a/test/compilable/test21299b.d
+++ b/test/compilable/test21299b.d
@@ -1,4 +1,4 @@
-// EXTRA_SOURCES: imports/test21299/func.d imports/test21299/rootstringtable.d
+// EXTRA_SOURCES: imports/test21299/mtype.d imports/test21299/func.d imports/test21299/rootstringtable.d
 // REQUIRED_ARGS: -main
 // LINK:
 module test21299b;

--- a/test/fail_compilation/test17977.d
+++ b/test/fail_compilation/test17977.d
@@ -1,6 +1,6 @@
 /*
 https://issues.dlang.org/show_bug.cgi?id=15399
-REQUIRED_ARGS -preview=dip1000
+REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test17977.d(19): Error: address of variable `__slList3` assigned to `elem` with longer lifetime


### PR DESCRIPTION
A couple were missing files in their EXTRA_SOURCES, and a recent addition didn't have the `:` separator between directive and argument.