### PR TITLE
fix Issue 22577 - ImportC: decay of function to typedef'd const funct…

### DIFF
--- a/src/dmd/importc.d
+++ b/src/dmd/importc.d
@@ -89,7 +89,7 @@ Expression arrayFuncConv(Expression e, Scope* sc)
     }
     else if (t.isTypeFunction())
     {
-        e = e.addressOf();
+        e = new AddrExp(e.loc, e);
     }
     else
         return e;

--- a/test/compilable/test22577.c
+++ b/test/compilable/test22577.c
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=22577
+
+typedef int(func)(void);
+
+int one(void) { return 1; }
+
+func* const fp1 = &one;
+
+func* const fp2 = one;
+


### PR DESCRIPTION
…ion pointer causes ICE

The fix is to not set e.type, and then the expressionSemantic() call will run properly.