### PR TITLE
test: runnable_cxx/cppa.d: Update test to be compilable with GCC 12 (development)

### DIFF
--- a/test/runnable_cxx/cppa.d
+++ b/test/runnable_cxx/cppa.d
@@ -442,28 +442,54 @@ void test13161()
 
 version (linux)
 {
-    extern(C++, __gnu_cxx)
+    static if (__traits(getTargetInfo, "cppStd") < 201703)
     {
-        struct new_allocator(T)
+        // See note on std::allocator below.
+        extern(C++, __gnu_cxx)
         {
-            alias size_type = size_t;
-            static if (is(T : char))
-                void deallocate(T*, size_type) { }
-            else
-                void deallocate(T*, size_type);
+            struct new_allocator(T)
+            {
+                alias size_type = size_t;
+                static if (is(T : char))
+                    void deallocate(T*, size_type) { }
+                else
+                    void deallocate(T*, size_type);
+            }
         }
     }
 }
 
 extern (C++, std)
 {
+    version (linux)
+    {
+        static if (__traits(getTargetInfo, "cppStd") >= 201703)
+        {
+            // std::allocator no longer derives from __gnu_cxx::new_allocator,
+            // it derives from std::__new_allocator instead. 
+            struct __new_allocator(T)
+            {
+                alias size_type = size_t;
+                static if (is(T : char))
+                    void deallocate(T*, size_type) { }
+                else
+                    void deallocate(T*, size_type);
+            }
+        }
+    }
+
     extern (C++, class) struct allocator(T)
     {
         version (linux)
         {
             alias size_type = size_t;
             void deallocate(T* p, size_type sz)
-            {   (cast(__gnu_cxx.new_allocator!T*)&this).deallocate(p, sz); }
+            {
+                static if (__traits(getTargetInfo, "cppStd") >= 201703)
+                    (cast(std.__new_allocator!T*)&this).deallocate(p, sz);
+                else
+                    (cast(__gnu_cxx.new_allocator!T*)&this).deallocate(p, sz);
+            }
         }
     }
 


### PR DESCRIPTION
The test for `cppStd >= 201703` isn't really correct, because the ABI change is really in GCC 12.  But this fixes a test that started failing since the 1st December as a result of [this commit to libstdc++-v3](https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=fe9571a35db53e5203326f854f73e432691d67f6;hp=f157c5362b4844f7676cae2aba81a4cf75bd68d5).

Ultimately, this test is a bit of a smell, because it appears to be calling the (public) internals of libstdc++ from D.  I suspect that we should instead be mirroring what `core.stdcpp.allocator` does, but that would involve unpicking a great deal more into this test.