### PR TITLE
fix Issue 22584 - importC: Error: undefined reference to 'parameter' when no parameter names in forward declaration

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -2501,6 +2501,10 @@ Dsymbol handleSymbolRedeclarations(ref Scope sc, Dsymbol s, Dsymbol s2, ScopeDsy
         {
             fd2.fbody = fd.fbody;       // transfer body to existing declaration
             fd.fbody = null;
+
+            auto tf = fd.type.toTypeFunction();
+            auto tf2 = fd2.type.toTypeFunction();
+            tf2.parameterList = tf.parameterList;   // transfer parameter list.
         }
 
         /* BUG: just like with VarDeclaration, the types should match, which needs semantic() to be run on it.

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -637,3 +637,13 @@ int test(char *dest)
 // https://issues.dlang.org/show_bug.cgi?id=22512
 
 extern char *tzname[];
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22584
+
+long test22584(long, long);
+
+long test22584(long a, long b)
+{
+    return a + b;
+}

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -33,6 +33,8 @@ fail_compilation/failcstuff2.c(255): Error: identifier or `(` expected
 fail_compilation/failcstuff2.c(308): Error: cannot modify `const` expression `(*s).p`
 fail_compilation/failcstuff2.c(354): Error: variable `arr` cannot be read at compile time
 fail_compilation/failcstuff2.c(360): Error: variable `str` cannot be read at compile time
+fail_compilation/failcstuff2.c(404): Error: undefined identifier `p1`
+fail_compilation/failcstuff2.c(404): Error: undefined identifier `p2`
 ---
 */
 
@@ -145,3 +147,11 @@ void test22413b()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22584
+#line 400
+long test22584(long p1, long p2);
+
+long test22584(long, long)
+{
+    return p1 + p2;
+}


### PR DESCRIPTION
Previous fix in #13399 transferred the body from definition to the original declaration, but didn't transfer the parameter list too.

It doesn't matter what names are given to parameters in declarations, the definition is authoritative.