### PR TITLE
fix Issue 22589 - importC: Error: undefined reference to '__builtin_va_start' and '__builtin_va_end'

### DIFF
--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -100,6 +100,7 @@ struct IRState
         mayThrow = global.params.useExceptions
             && ClassDeclaration.throwable
             && !(fd && fd.eh_none);
+        this.Cfile = m.isCFile;
     }
 
     FuncDeclaration getFunc()

--- a/test/compilable/vastartend.c
+++ b/test/compilable/vastartend.c
@@ -1,18 +1,25 @@
+// REQUIRED_ARGS: -main
+// LINK:
 
 // test __builtin_va_start and __builtin_va_end
+// https://issues.dlang.org/show_bug.cgi?id=21974
+// https://issues.dlang.org/show_bug.cgi?id=22589
 
 typedef __builtin_va_list __gnuc_va_list;
 typedef __gnuc_va_list va_list;
 
-int gzvprintf(const char *format, va_list va);
+int test21974a(const char *format, va_list va)
+{
+    return 0;
+}
 
-int gzprintf(const char *format, ...)
+int test21974(const char *format, ...)
 {
     va_list va;
     int ret;
 
     __builtin_va_start(va,format);
-    ret = gzvprintf(format, va);
+    ret = test21974a(format, va);
     __builtin_va_end(va);
     return ret;
 }


### PR DESCRIPTION
Recognition of C built-ins are behind the conditional `irs.Cfile`, but this was never set.