### PR TITLE
fix Issue 22558 - [REG 2.098] Error: function 'core.stdc.stdio.vfprintf' 'pragma(printf)' functions must be 'extern(C) int vfprintf([parameters...], const(char)*, va_list)'

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3029,7 +3029,7 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
              * If we ever do care, import core.stdc.stdarg and pull
              * the definition out of that, similarly to how std.math is handled for PowExp
              */
-            pt = Type.tvoidptr;
+            pt = target.va_listType(loc, sc);
             return;
         }
 

--- a/test/compilable/test22558.d
+++ b/test/compilable/test22558.d
@@ -1,0 +1,37 @@
+// https://issues.dlang.org/show_bug.cgi?id=22558
+module core.stdc.stdio;
+
+version (X86_64)
+{
+    version (Posix)
+    {
+        struct __va_list_tag
+        {
+            uint gp_offset;
+            uint fp_offset;
+            void* overflow_arg_area;
+            void* reg_save_area;
+        }
+        alias __builtin_va_list = __va_list_tag*;
+    }
+    else version (Windows)
+    {
+        alias __builtin_va_list = char*;
+    }
+}
+else version (X86)
+{
+    alias __builtin_va_list = char*;
+}
+
+static if (__traits(compiles, __builtin_va_list))
+{
+    alias va_list = __builtin_va_list;
+    struct FILE;
+
+    extern(C)
+    {
+        pragma(printf)
+        int vfprintf(FILE* stream, scope const char* format, va_list arg);
+    }
+}


### PR DESCRIPTION
Removes the code that caused the regression.  ImportC now uses the `va_list` constructed by Target.

Now `va_start` and `va_end` work properly, and zlib passes the testsuite.
```
importc (main) $ ../dmd/generated/linux/release/64/dmd -g -betterC -vcolumns \
    generated/etc/c/zlib/example.c generated/etc/c/zlib/adler32.c \
    generated/etc/c/zlib/compress.c generated/etc/c/zlib/crc32.c \
    generated/etc/c/zlib/deflate.c generated/etc/c/zlib/gzclose.c \
    generated/etc/c/zlib/gzlib.c generated/etc/c/zlib/gzread.c \
    generated/etc/c/zlib/gzwrite.c generated/etc/c/zlib/infback.c \
    generated/etc/c/zlib/inffast.c generated/etc/c/zlib/inflate.c \
    generated/etc/c/zlib/inftrees.c generated/etc/c/zlib/trees.c \
    generated/etc/c/zlib/uncompr.c generated/etc/c/zlib/zutil.c

importc (main) $ ./example
zlib version 1.2.11 = 0x12b0, compile flags = 0xa9
uncompress(): hello, hello!
gzread(): hello, hello!
gzgets() after gzseek:  hello!
inflate(): hello, hello!
large_inflate(): OK
after inflateSync(): hello, hello!
inflate with dictionary: hello, hello!
```