### PR TITLE
fix Issue 22597 - importC: Segmentation fault initializing va_list with __builtin_va_start

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -6733,6 +6733,15 @@ elem* builtinC(FuncDeclaration fd, elem* e)
     const id = fd.ident;
     if (id == Id.builtin_va_start)
     {
+        if (target.is64bit)
+        {
+            // https://issues.dlang.org/show_bug.cgi?id=22597
+            // callfunc reverses the parameters, swap them back for the
+            // intrinsic lowering.
+            auto earg = e.EV.E1;
+            e.EV.E1 = e.EV.E2;
+            e.EV.E2 = earg;
+        }
         return constructVa_start(e);
     }
     else if (id == Id.builtin_va_end)

--- a/test/runnable/test22597.c
+++ b/test/runnable/test22597.c
@@ -1,0 +1,25 @@
+// https://issues.dlang.org/show_bug.cgi?id=22597
+
+typedef __builtin_va_list va_list;
+int vsprintf(char *s, const char *format, va_list va);
+int printf(const char *s, ...);
+
+int test22597(const char *format, ...)
+{
+    va_list va;
+    __builtin_va_start(va,format);
+    char buf[32];
+    int ret = vsprintf(buf, format, va);
+    __builtin_va_end(va);
+    return ret;
+}
+
+int main()
+{
+    if (test22597(", %s!", "hello") != 8)
+    {
+        printf("test22597 failed\n");
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Split out from #13424 because it turns out dmd's va intrinsics really don't care what type va_list is.

With this alone, the zlib testsuite passes, and we can now consider building the zlib sources in Phobos with dmd in ImportC mode.