### PR TITLE
Update osmodel.mak with ARCH

### DIFF
--- a/src/osmodel.mak
+++ b/src/osmodel.mak
@@ -5,6 +5,7 @@
 #   OS         = one of {osx,linux,freebsd,openbsd,netbsd,dragonflybsd,solaris}
 #   MODEL      = one of { 32, 64 }
 #   MODEL_FLAG = one of { -m32, -m64 }
+#   ARCH       = one of { x86, x86_64, aarch64 }
 #
 # Note:
 #   Keep this file in sync between druntime, phobos, and dmd repositories!
@@ -54,14 +55,20 @@ ifeq (,$(MODEL))
   else
     uname_M:=$(shell uname -m)
   endif
-  ifneq (,$(findstring $(uname_M),x86_64 amd64 arm64))
+  ifneq (,$(findstring $(uname_M),x86_64 amd64))
     MODEL:=64
+    ARCH:=x86_64
+  endif
+  ifneq (,$(findstring $(uname_M),aarch64 arm64))
+    MODEL:=64
+    ARCH:=aarch64
   endif
   ifneq (,$(findstring $(uname_M),i386 i586 i686))
     MODEL:=32
+    ARCH:=x86
   endif
   ifeq (,$(MODEL))
-    $(error Cannot figure 32/64 model from uname -m: $(uname_M))
+    $(error Cannot figure 32/64 model and arch from uname -m: $(uname_M))
   endif
 endif
 


### PR DESCRIPTION
Copied here from https://github.com/dlang/tools/pull/441. This will allow sharing between all other D repos.

This PR adds a new make macro `ARCH` which is the llvm/dub compatible architecture (ie. `x86_64`, `x86`, or `aarch64`), because we can never recover the architecture from just the `MODEL` 64.

