### PR TITLE
fix Issue 22602 - importC: Error: cannot convert string literal to 'void*'

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1852,7 +1852,8 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
 
             //printf("StringExp::castTo(t = %s), '%s' committed = %d\n", t.toChars(), e.toChars(), e.committed);
 
-            if (!e.committed && t.ty == Tpointer && t.nextOf().ty == Tvoid)
+            if (!e.committed && t.ty == Tpointer && t.nextOf().ty == Tvoid &&
+                (!sc || !(sc.flags & SCOPE.Cfile)))
             {
                 e.error("cannot convert string literal to `void*`");
                 result = ErrorExp.get();

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -647,3 +647,12 @@ long test22584(long a, long b)
 {
     return a + b;
 }
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22602
+
+void test22602()
+{
+    unsigned char *data;
+    data = (void *)"\0\0\xff\xff";
+}


### PR DESCRIPTION
This error only applies to D code.

Change allows zlib's coverage tests to be compilable, and pass.
```
importc (main) $ ../dmd/generated/linux/release/64/dmd -g -vcolumns \
    generated/etc/c/zlib/infcover.c generated/etc/c/zlib/adler32.c \
    generated/etc/c/zlib/compress.c generated/etc/c/zlib/crc32.c \
    generated/etc/c/zlib/deflate.c generated/etc/c/zlib/gzclose.c \
    generated/etc/c/zlib/gzlib.c generated/etc/c/zlib/gzread.c \
    generated/etc/c/zlib/gzwrite.c generated/etc/c/zlib/infback.c \
    generated/etc/c/zlib/inffast.c generated/etc/c/zlib/inflate.c \
    generated/etc/c/zlib/inftrees.c generated/etc/c/zlib/trees.c \
    generated/etc/c/zlib/uncompr.c generated/etc/c/zlib/zutil.c 

importc (main) $ ./infcover 
1.2.11
inflate init: 7160 allocated
prime: 7160 high water mark
force window allocation: 79856 high water mark
force window replacement: 14832 high water mark
force split window update: 14832 high water mark
use fixed blocks: 7160 high water mark
bad window size: 7160 high water mark
wrong version: 0 high water mark
inflate built-in memory routines
inflate bad parameters
bad gzip method: 7160 high water mark
bad gzip flags: 7160 high water mark
bad zlib method: 7160 high water mark
set window size from header: 14320 high water mark
bad zlib window size: 7160 high water mark
check adler32: 7160 high water mark
bad header crc: 7160 high water mark
check gzip length: 7160 high water mark
bad zlib header check: 7160 high water mark
need dictionary: 14832 high water mark
compute adler32: 79856 high water mark
miscellaneous, force memory errors: 14576 high water mark
inflateBack bad parameters
inflateBack bad state: 7160 high water mark
inflateBack built-in memory routines
invalid stored block lengths-late: 7160 high water mark
invalid stored block lengths-back: 7160 high water mark
fixed-late: 7160 high water mark
fixed-back: 7160 high water mark
invalid block type-late: 7160 high water mark
invalid block type-back: 7160 high water mark
stored-late: 39928 high water mark
stored-back: 7160 high water mark
too many length or distance symbols-late: 7160 high water mark
too many length or distance symbols-back: 7160 high water mark
invalid code lengths set-late: 7160 high water mark
invalid code lengths set-back: 7160 high water mark
invalid bit length repeat-late: 7160 high water mark
invalid bit length repeat-back: 7160 high water mark
invalid bit length repeat-late: 7160 high water mark
invalid bit length repeat-back: 7160 high water mark
invalid code -- missing end-of-block-late: 7160 high water mark
invalid code -- missing end-of-block-back: 7160 high water mark
invalid literal/lengths set-late: 7160 high water mark
invalid literal/lengths set-back: 7160 high water mark
invalid distances set-late: 7160 high water mark
invalid distances set-back: 7160 high water mark
invalid literal/length code-late: 7160 high water mark
invalid literal/length code-back: 7160 high water mark
invalid distance code-late: 7160 high water mark
invalid distance code-back: 7160 high water mark
invalid distance too far back-late: 7160 high water mark
invalid distance too far back-back: 7160 high water mark
incorrect data check-late: 7160 high water mark
incorrect length check-late: 7160 high water mark
pull 17-late: 7160 high water mark
pull 17-back: 7160 high water mark
long code-late: 7160 high water mark
long code-back: 7160 high water mark
length extra-late: 39928 high water mark
length extra-back: 7160 high water mark
long distance and extra-late: 39928 high water mark
long distance and extra-back: 7160 high water mark
window end-late: 39928 high water mark
window end-back: 7160 high water mark
inflate_fast TYPE return: 7160 high water mark
window wrap: 14832 high water mark
inflate_table not enough errors
fast length extra bits: 7160 high water mark
fast distance extra bits: 7160 high water mark
fast invalid distance code: 7160 high water mark
fast invalid literal/length code: 7160 high water mark
fast 2nd level codes and too far back: 7160 high water mark
very common case: 14832 high water mark
contiguous and wrap around window: 14832 high water mark
copy direct from output: 7416 high water mark

importc (main) $ echo $?
0
```