### PR TITLE
dmd.cparse: Move addBuiltinDeclarations to target module

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5028,6 +5028,7 @@ struct TargetC final
     uint8_t wchar_tsize;
     Runtime runtime;
     BitFieldStyle bitFieldStyle;
+    void addBuiltinDeclarations(Array<Dsymbol* >* symbols) const;
     TargetC() :
         crtDestructorsSupported(true),
         longsize(),

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -76,6 +76,8 @@ struct TargetC
     uint8_t wchar_tsize;         // size of a C 'wchar_t' type
     Runtime runtime;
     BitFieldStyle bitFieldStyle; // different C compilers do it differently
+
+    void addBuiltinDeclarations(Array<Dsymbol*> *symbols) const;
 };
 
 struct TargetCPP


### PR DESCRIPTION
Symbols pushed by DMD only apply to DMD-specific built-ins and types.

GDC meanwhile has its own built-ins that should be pushed into importC code, so let other compilers override.