### PR TITLE
test: Replace http:// with https:// for digitalmars.com links

### DIFF
--- a/test/compilable/99bottles.d
+++ b/test/compilable/99bottles.d
@@ -1,5 +1,5 @@
 // written by Don Clugston:
-//    http://www.digitalmars.com/d/archives/digitalmars/D/announce/4374.html
+//    https://www.digitalmars.com/d/archives/digitalmars/D/announce/4374.html
 //    http://www.99-bottles-of-beer.net/language-d-1212.html
 
 // Generates the "99 bottles of beer" song at compile time,

--- a/test/compilable/art4769.d
+++ b/test/compilable/art4769.d
@@ -1,4 +1,4 @@
-// http://www.digitalmars.com/webnews/newsgroups.php?art_group=digitalmars.D.bugs&article_id=4769
+// https://www.digitalmars.com/d/archives/digitalmars/D/bugs/4769.html
 
 // COMPILED_IMPORTS: imports/art4769a.d imports/art4769b.d
 // PERMUTE_ARGS:

--- a/test/compilable/test69.d
+++ b/test/compilable/test69.d
@@ -1,7 +1,7 @@
 // PERMUTE_ARGS:
 
 // ICE(expression.c) DMD 0.110
-// http://www.digitalmars.com/d/archives/digitalmars/D/bugs/2966.html
+// https://www.digitalmars.com/d/archives/digitalmars/D/bugs/2966.html
 
 string str255() { return "\255"; }
 void fromFail49()

--- a/test/fail_compilation/fail15.d
+++ b/test/fail_compilation/fail15.d
@@ -6,7 +6,7 @@ fail_compilation/fail15.d(24): Error: cannot use `[]` operator on expression of 
 */
 /*
 Segfault on DMD 0.095
-http://www.digitalmars.com/d/archives/digitalmars/D/bugs/926.html
+https://www.digitalmars.com/d/archives/digitalmars/D/bugs/926.html
 */
 module test;
 

--- a/test/fail_compilation/fail35.d
+++ b/test/fail_compilation/fail35.d
@@ -5,7 +5,7 @@ fail_compilation/fail35.d(15): Error: variable `t` cannot be read at compile tim
 ---
 */
 
-// http://www.digitalmars.com/d/archives/digitalmars/D/bugs/2372.html
+// https://www.digitalmars.com/d/archives/digitalmars/D/bugs/2372.html
 // allegedly crashes, but cannot reproduce
 
 void main()

--- a/test/fail_compilation/fail73.d
+++ b/test/fail_compilation/fail73.d
@@ -6,7 +6,7 @@ fail_compilation/fail73.d(20): Error: `case` not in `switch` statement
 */
 
 // segfault DMD 0.120
-// http://www.digitalmars.com/d/archives/digitalmars/D/bugs/4634.html
+// https://www.digitalmars.com/d/archives/digitalmars/D/bugs/4634.html
 
 void main()
 {

--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -3,7 +3,7 @@
 // Copyright (c) 1999-2016 by The D Language Foundation
 // All Rights Reserved
 // written by Walter Bright
-// http://www.digitalmars.com
+// https://www.digitalmars.com
 
 import core.stdc.stdio;
 import core.stdc.config;

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -3,7 +3,7 @@
 // Copyright (c) 1999-2016 by The D Language Foundation
 // All Rights Reserved
 // written by Walter Bright
-// http://www.digitalmars.com
+// https://www.digitalmars.com
 
 import core.stdc.stdio;
 import core.stdc.config;

--- a/test/runnable/template1.d
+++ b/test/runnable/template1.d
@@ -1554,7 +1554,7 @@ void test64()
 }
 
 /******************************************/
-// http://www.digitalmars.com/d/archives/28052.html
+// https://www.digitalmars.com/d/archives/28052.html
 
 alias int value_type;
 
@@ -1923,7 +1923,7 @@ specialization:: first int
 
 
 /******************************************/
-// http://www.digitalmars.com/pnews/read.php?server=news.digitalmars.com&group=digitalmars.D.bugs&artnum=2117
+// https://www.digitalmars.com/d/archives/digitalmars/D/bugs/2117.html
 
 class Conversion(T,U){
         alias char Small;

--- a/test/runnable/template2.d
+++ b/test/runnable/template2.d
@@ -1,5 +1,5 @@
 // original post to the D newsgroup:
-//    http://www.digitalmars.com/pnews/read.php?server=news.digitalmars.com&group=D&artnum=10554&header
+//    https://www.digitalmars.com/d/archives/10510.html#N10554
 // Test to manipulate 3D vectors, in D!
 // by Sean L Palmer (seanpalmer@directvinternet.com)
 // This code is released without any warranty.  Use at your own risk.

--- a/test/runnable/template6.d
+++ b/test/runnable/template6.d
@@ -1,5 +1,5 @@
 // This is a copy of the engine here:
-//   http://www.digitalmars.com/d/2.0/templates-revisited.html
+//   https://www.digitalmars.com/d/2.0/templates-revisited.html
 // which is a cut down version of the file here:
 //   http://www.dsource.org/projects/ddl/browser/trunk/meta/regex.d
 // which has this copyright notice:

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -832,7 +832,7 @@ void test38()
 
 
 /**************************************/
-// http://www.digitalmars.com/d/archives/digitalmars/D/bugs/2409.html
+// https://www.digitalmars.com/d/archives/digitalmars/D/bugs/2409.html
 
 class C39
 {

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -515,7 +515,7 @@ void test30()
 
 
 /************************************/
-// http://www.digitalmars.com/d/archives/18204.html
+// https://www.digitalmars.com/d/archives/18204.html
 // DMD0.050 also failed with alias.
 
 alias int recls_bool_t;

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -16,7 +16,7 @@ extern(C)
 
 /*************************************/
 
-// http://www.digitalmars.com/d/archives/digitalmars/D/bugs/4766.html
+// https://www.digitalmars.com/d/archives/digitalmars/D/bugs/4766.html
 // Only with -O
 
 real randx()


### PR DESCRIPTION
Verified that all links works.

A number of links to the newsgroup were broken (namely, the webnews and pnews endpoints), updated them to point at a working link on /d/archives.