### PR TITLE
Replace http:// with https:// for github.com links

### DIFF
--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1923,7 +1923,7 @@ void test20050()
 
 ////////////////////////////////////////////////////////////////////////
 
-// http://github.com/dlang/dmd/pull/11238
+// https://github.com/dlang/dmd/pull/11238
 
 int testCpStatic1(int y)
 {
@@ -1960,7 +1960,7 @@ void test7()
 
 ////////////////////////////////////////////////////////////////////////
 
-// http://github.com/dlang/dmd/pull/11388
+// https://github.com/dlang/dmd/pull/11388
 
 ushort byteswap(ushort x) pure
 {


### PR DESCRIPTION
Verified links work.  (Though this is now scraping the bottom of the pile).