### PR TITLE
Replace http:// with https:// for msdn links

### DIFF
--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3489,7 +3489,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
         assert(numpara == ((np < 4) ? 4 * REGSIZE : np * REGSIZE));
 
         // Allocate stack space for four entries anyway
-        // http://msdn.microsoft.com/en-US/library/ew5tede7(v=vs.80)
+        // https://msdn.microsoft.com/en-US/library/ew5tede7(v=vs.100)
     }
 
     int[XMM7 + 1] regsaved = void;
@@ -3711,7 +3711,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
 
     if (config.exe == EX_WIN64)
     {   // Allocate stack space for four entries anyway
-        // http://msdn.microsoft.com/en-US/library/ew5tede7(v=vs.80)
+        // https://msdn.microsoft.com/en-US/library/ew5tede7(v=vs.100)
         {   uint sz = 4 * REGSIZE;
             if (usefuncarg)
             {

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3489,7 +3489,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
         assert(numpara == ((np < 4) ? 4 * REGSIZE : np * REGSIZE));
 
         // Allocate stack space for four entries anyway
-        // https://msdn.microsoft.com/en-US/library/ew5tede7(v=vs.100)
+        // https://msdn.microsoft.com/en-US/library/ew5tede7%28v=vs.100%29
     }
 
     int[XMM7 + 1] regsaved = void;
@@ -3711,7 +3711,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
 
     if (config.exe == EX_WIN64)
     {   // Allocate stack space for four entries anyway
-        // https://msdn.microsoft.com/en-US/library/ew5tede7(v=vs.100)
+        // https://msdn.microsoft.com/en-US/library/ew5tede7%28v=vs.100%29
         {   uint sz = 4 * REGSIZE;
             if (usefuncarg)
             {

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -4068,7 +4068,7 @@ void prolog_genvarargs(ref CodeBuilder cdb, Symbol* sv, regm_t namedargs)
 void prolog_gen_win64_varargs(ref CodeBuilder cdb)
 {
     /* The Microsoft scheme.
-     * https://msdn.microsoft.com/en-US/library/dd2wa36c(v=vs.100)
+     * https://msdn.microsoft.com/en-US/library/dd2wa36c%28v=vs.100%29
      * Copy registers onto stack.
          mov     8[RSP],RCX
          mov     010h[RSP],RDX
@@ -4222,7 +4222,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc, out regm_
     if (config.exe == EX_WIN64 && variadic(funcsym_p.Stype))
     {
         /* The Microsoft scheme.
-         * https://msdn.microsoft.com/en-US/library/dd2wa36c(v=vs.100)
+         * https://msdn.microsoft.com/en-US/library/dd2wa36c%28v=vs.100%29
          * Copy registers onto stack.
              mov     8[RSP],RCX or XMM0
              mov     010h[RSP],RDX or XMM1
@@ -4543,7 +4543,7 @@ void epilog(block *b)
                     cdbx.gen1(0x58 + BP);                                 // POP BP
                 }
                 else if (config.exe == EX_WIN64)
-                {   // See https://msdn.microsoft.com/en-us/library/tawsa7cb(v=vs.100).aspx
+                {   // See https://msdn.microsoft.com/en-us/library/tawsa7cb%28v=vs.100%29.aspx
                     // LEA RSP,0[RBP]
                     cdbx.genc1(LEA,(REX_W<<16)|modregrm(2,SP,BPRM),FLconst,0);
                     cdbx.gen1(0x58 + BP);      // POP RBP

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -4068,7 +4068,7 @@ void prolog_genvarargs(ref CodeBuilder cdb, Symbol* sv, regm_t namedargs)
 void prolog_gen_win64_varargs(ref CodeBuilder cdb)
 {
     /* The Microsoft scheme.
-     * http://msdn.microsoft.com/en-US/library/dd2wa36c(v=vs.80)
+     * https://msdn.microsoft.com/en-US/library/dd2wa36c(v=vs.100)
      * Copy registers onto stack.
          mov     8[RSP],RCX
          mov     010h[RSP],RDX
@@ -4222,7 +4222,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc, out regm_
     if (config.exe == EX_WIN64 && variadic(funcsym_p.Stype))
     {
         /* The Microsoft scheme.
-         * http://msdn.microsoft.com/en-US/library/dd2wa36c(v=vs.80)
+         * https://msdn.microsoft.com/en-US/library/dd2wa36c(v=vs.100)
          * Copy registers onto stack.
              mov     8[RSP],RCX or XMM0
              mov     010h[RSP],RDX or XMM1
@@ -4543,7 +4543,7 @@ void epilog(block *b)
                     cdbx.gen1(0x58 + BP);                                 // POP BP
                 }
                 else if (config.exe == EX_WIN64)
-                {   // See http://msdn.microsoft.com/en-us/library/tawsa7cb(v=vs.80).aspx
+                {   // See https://msdn.microsoft.com/en-us/library/tawsa7cb(v=vs.100).aspx
                     // LEA RSP,0[RBP]
                     cdbx.genc1(LEA,(REX_W<<16)|modregrm(2,SP,BPRM),FLconst,0);
                     cdbx.gen1(0x58 + BP);      // POP RBP

--- a/src/dmd/backend/pdata.d
+++ b/src/dmd/backend/pdata.d
@@ -60,7 +60,7 @@ enum ALLOCA_LIMIT = 0x10000;
  * to walk the stack and unwind exceptions.
  * Absent it, it is assumed to be a "leaf function" where [RSP] is the return address.
  * Creates an instance of struct RUNTIME_FUNCTION:
- *   https://msdn.microsoft.com/en-US/library/ft9x1kdx(v=vs.100).aspx
+ *   https://msdn.microsoft.com/en-US/library/ft9x1kdx%28v=vs.100%29.aspx
  *
  * Params:
  *      sf = function to generate unwind data for
@@ -139,7 +139,7 @@ private Symbol *win64_unwind(Symbol *sf)
 
 /************************************************************************
  * Creates an instance of struct UNWIND_INFO:
- *   https://msdn.microsoft.com/en-US/library/ddssxxy8(v=vs.100).aspx
+ *   https://msdn.microsoft.com/en-US/library/ddssxxy8%28v=vs.100%29.aspx
  */
 
 enum UWOP

--- a/src/dmd/backend/pdata.d
+++ b/src/dmd/backend/pdata.d
@@ -60,7 +60,7 @@ enum ALLOCA_LIMIT = 0x10000;
  * to walk the stack and unwind exceptions.
  * Absent it, it is assumed to be a "leaf function" where [RSP] is the return address.
  * Creates an instance of struct RUNTIME_FUNCTION:
- *   http://msdn.microsoft.com/en-US/library/ft9x1kdx(v=vs.80).aspx
+ *   https://msdn.microsoft.com/en-US/library/ft9x1kdx(v=vs.100).aspx
  *
  * Params:
  *      sf = function to generate unwind data for
@@ -139,7 +139,7 @@ private Symbol *win64_unwind(Symbol *sf)
 
 /************************************************************************
  * Creates an instance of struct UNWIND_INFO:
- *   http://msdn.microsoft.com/en-US/library/ddssxxy8(v=vs.80).aspx
+ *   https://msdn.microsoft.com/en-US/library/ddssxxy8(v=vs.100).aspx
  */
 
 enum UWOP

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -819,7 +819,7 @@ extern (C++) struct Target
 
         if (os == Target.OS.Windows && is64bit)
         {
-            // http://msdn.microsoft.com/en-us/library/7572ztz4.aspx
+            // https://msdn.microsoft.com/en-us/library/7572ztz4(v=vs.100).aspx
             if (tns.ty == TY.Tcomplex32)
                 return true;
             if (tns.isscalar())

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -819,7 +819,7 @@ extern (C++) struct Target
 
         if (os == Target.OS.Windows && is64bit)
         {
-            // https://msdn.microsoft.com/en-us/library/7572ztz4(v=vs.100).aspx
+            // https://msdn.microsoft.com/en-us/library/7572ztz4%28v=vs.100%29.aspx
             if (tns.ty == TY.Tcomplex32)
                 return true;
             if (tns.isscalar())

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -249,7 +249,7 @@ Symbol *toSymbol(Dsymbol s)
                 /* if it's global or static, then it needs to have a qualified but unmangled name.
                  * This gives some explanation of the separation in treating name mangling.
                  * It applies to PDB format, but should apply to CV as PDB derives from CV.
-                 *    http://msdn.microsoft.com/en-us/library/ff553493(VS.85).aspx
+                 *    https://msdn.microsoft.com/en-us/library/ff553493(VS.85).aspx
                  */
                 s.prettyIdent = vd.toPrettyChars(true);
             }

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -249,7 +249,7 @@ Symbol *toSymbol(Dsymbol s)
                 /* if it's global or static, then it needs to have a qualified but unmangled name.
                  * This gives some explanation of the separation in treating name mangling.
                  * It applies to PDB format, but should apply to CV as PDB derives from CV.
-                 *    https://msdn.microsoft.com/en-us/library/ff553493(VS.85).aspx
+                 *    https://msdn.microsoft.com/en-us/library/ff553493%28VS.85%29.aspx
                  */
                 s.prettyIdent = vd.toPrettyChars(true);
             }


### PR DESCRIPTION
Verified all links work.

MSDN itself though seems to be a deprecated site, and all links redirect to docs.microsoft.com.  The linked for VS.80 are all retired documentation, so the version has been bumped (I guess it'll all be retired again in a couple years though).