### PR TITLE
dmd: Replace http:// with https:// for dlang.org links

### DIFF
--- a/src/dmd/README.md
+++ b/src/dmd/README.md
@@ -2,7 +2,7 @@
 
 This is the source code to the DMD compiler
 for the D Programming Language defined in the documents at
-http://dlang.org/
+https://dlang.org/
 
 These sources are free, they are redistributable and modifiable
 under the terms of the Boost Software License, Version 1.0.

--- a/src/dmd/backend/aarray.d
+++ b/src/dmd/backend/aarray.d
@@ -2,7 +2,7 @@
  * Associative Array implementation
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright), Dave Fladebo

--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -2,7 +2,7 @@
  * Configure the back end (optimizer and code generator)
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/backend.d
+++ b/src/dmd/backend/backend.d
@@ -2,7 +2,7 @@
  * Internal header file for the backend
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved
  *

--- a/src/dmd/backend/barray.d
+++ b/src/dmd/backend/barray.d
@@ -2,7 +2,7 @@
  * Generic resizeable array
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2018-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/bcomplex.d
+++ b/src/dmd/backend/bcomplex.d
@@ -2,7 +2,7 @@
  * A complex number implementation
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   public domain
  * License:     public domain

--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -2,7 +2,7 @@
  * Common definitions
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -2,7 +2,7 @@
  * Configuration enums/variables for different targets
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cg.d
+++ b/src/dmd/backend/cg.d
@@ -2,7 +2,7 @@
  * Various global symbols.
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1995 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -2,7 +2,7 @@
  * x87 FPU code generation
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1987-1995 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cgcs.d
+++ b/src/dmd/backend/cgcs.d
@@ -2,7 +2,7 @@
  * Compute common subexpressions for non-optimized code generation
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Compute common subexpressions for non-optimized builds.
  *

--- a/src/dmd/backend/cgcse.d
+++ b/src/dmd/backend/cgcse.d
@@ -2,7 +2,7 @@
  * Manage the memory allocated on the runtime stack to save Common Subexpressions (CSE).
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cgcv.d
+++ b/src/dmd/backend/cgcv.d
@@ -2,7 +2,7 @@
  * Interface for CodeView symbol debug info generation
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -2,7 +2,7 @@
  * Local optimizations of elem trees
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Does strength reduction optimizations on the elem trees,
  * i.e. rewriting trees to less expensive trees.

--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -1,6 +1,6 @@
 /**
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cgreg.d
+++ b/src/dmd/backend/cgreg.d
@@ -2,7 +2,7 @@
  * Register allocator
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cgsched.d
+++ b/src/dmd/backend/cgsched.d
@@ -2,7 +2,7 @@
  * Instruction scheduler
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1995-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cgxmm.d
+++ b/src/dmd/backend/cgxmm.d
@@ -2,7 +2,7 @@
  * xmm specific code generation
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2011-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -4,7 +4,7 @@
  * Handles function calls: putting arguments in registers / on the stack, and jumping to the function.
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -8,7 +8,7 @@
  * - struct assign, constructor, destructor
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -7,7 +7,7 @@
  * - generation / peephole optimizations of jump / branch instructions
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -8,7 +8,7 @@
  * - bit instructions (bit scan, population count)
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Mostly code generation for assignment operators.
  *

--- a/src/dmd/backend/cod5.d
+++ b/src/dmd/backend/cod5.d
@@ -4,7 +4,7 @@
  * Handles finding out which blocks need a function prolog / epilog attached
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1995-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -2,7 +2,7 @@
  * Define registers, register masks, and the CPU instruction linked list
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/codebuilder.d
+++ b/src/dmd/backend/codebuilder.d
@@ -2,7 +2,7 @@
  * Construct linked list of generated code
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/compress.d
+++ b/src/dmd/backend/compress.d
@@ -2,7 +2,7 @@
  * Identifier comperssion
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/cv4.d
+++ b/src/dmd/backend/cv4.d
@@ -4,7 +4,7 @@
  * See "Microsoft Symbol and Type OMF" document
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cv4.d, backend/_cv4.d)
  */

--- a/src/dmd/backend/cv8.d
+++ b/src/dmd/backend/cv8.d
@@ -5,7 +5,7 @@
  * which are the MS-Coff symbolic debug info and type debug info sections.
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:    Copyright (C) 2012-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -2,7 +2,7 @@
  * CodeView 4 symbolic debug info generation
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1995 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/dcode.d
+++ b/src/dmd/backend/dcode.d
@@ -2,7 +2,7 @@
  * Allocate and free code blocks
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1987-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/debugprint.d
+++ b/src/dmd/backend/debugprint.d
@@ -2,7 +2,7 @@
  * Pretty print data structures
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/divcoeff.d
+++ b/src/dmd/backend/divcoeff.d
@@ -3,7 +3,7 @@
  * by Torbjoern Granlund and Peter L. Montgomery
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2013-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/drtlsym.d
+++ b/src/dmd/backend/drtlsym.d
@@ -2,7 +2,7 @@
  * Compiler runtime function symbols
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1996-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/dt.d
+++ b/src/dmd/backend/dt.d
@@ -2,7 +2,7 @@
  * Intermediate representation for static data
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/dtype.d
+++ b/src/dmd/backend/dtype.d
@@ -1,6 +1,6 @@
 /**
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/dvarstats.d
+++ b/src/dmd/backend/dvarstats.d
@@ -2,7 +2,7 @@
  * Support for lexical scope of local variables
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2015-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     Rainer Schuetze

--- a/src/dmd/backend/dvec.d
+++ b/src/dmd/backend/dvec.d
@@ -1,6 +1,6 @@
 /**
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Simple bit vector implementation.
  *

--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -2,7 +2,7 @@
  * Emit Dwarf symbolic debug info
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/ee.d
+++ b/src/dmd/backend/ee.d
@@ -2,7 +2,7 @@
  * Code to handle debugger expression evaluation
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1995-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/el.d
+++ b/src/dmd/backend/el.d
@@ -2,7 +2,7 @@
  * Expression trees (intermediate representation)
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -2,7 +2,7 @@
  * Routines to handle elems.
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -4,7 +4,7 @@
  * http://www.sco.com/developers/gabi/2003-12-17/ch4.sheader.html
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) ?-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/elpicpie.d
+++ b/src/dmd/backend/elpicpie.d
@@ -2,7 +2,7 @@
  * Generate elems for fixed, PIC, and PIE code generation.
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/errors.di
+++ b/src/dmd/backend/errors.di
@@ -1,6 +1,6 @@
 /**
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/evalu8.d
+++ b/src/dmd/backend/evalu8.d
@@ -2,7 +2,7 @@
  * Constant folding
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/exh.d
+++ b/src/dmd/backend/exh.d
@@ -2,7 +2,7 @@
  * Interface for exception handling support
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1993-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/fp.d
+++ b/src/dmd/backend/fp.d
@@ -1,6 +1,6 @@
 /**
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/gdag.d
+++ b/src/dmd/backend/gdag.d
@@ -2,7 +2,7 @@
  * Directed acyclic graphs and global optimizer common subexpressions
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1986-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -2,7 +2,7 @@
  * Declarations for back end
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/glocal.d
+++ b/src/dmd/backend/glocal.d
@@ -2,7 +2,7 @@
  * Local optimizations
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1993-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -2,7 +2,7 @@
  * Global loop optimizations
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/go.d
+++ b/src/dmd/backend/go.d
@@ -2,7 +2,7 @@
  * Global optimizer main loop
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1986-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/goh.d
+++ b/src/dmd/backend/goh.d
@@ -2,7 +2,7 @@
  * Global optimizer declarations
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1986-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/gsroa.d
+++ b/src/dmd/backend/gsroa.d
@@ -6,7 +6,7 @@
  * SROA (Scalar Replacement Of Aggregates) is the common term for this.
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2016-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/machobj.d
+++ b/src/dmd/backend/machobj.d
@@ -2,7 +2,7 @@
  * Generate Mach-O object files
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2009-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/melf.d
+++ b/src/dmd/backend/melf.d
@@ -3,7 +3,7 @@
  * Declarations for ELF file format
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Translation to D of Linux's melf.h
  *

--- a/src/dmd/backend/mem.d
+++ b/src/dmd/backend/mem.d
@@ -1,6 +1,6 @@
 /**
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/mscoffobj.d
+++ b/src/dmd/backend/mscoffobj.d
@@ -1,6 +1,6 @@
 /**
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2009-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/newman.d
+++ b/src/dmd/backend/newman.d
@@ -2,7 +2,7 @@
  * "new" C++ name mangling scheme
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1992-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/nteh.d
+++ b/src/dmd/backend/nteh.d
@@ -2,7 +2,7 @@
  * Support for NT exception handling
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/obj.d
+++ b/src/dmd/backend/obj.d
@@ -1,6 +1,6 @@
 /**
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/oper.d
+++ b/src/dmd/backend/oper.d
@@ -1,6 +1,6 @@
 /**
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/os.d
+++ b/src/dmd/backend/os.d
@@ -5,7 +5,7 @@
  * up code with OS files.
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/out.d
+++ b/src/dmd/backend/out.d
@@ -2,7 +2,7 @@
  * Transition from intermediate representation to code generator
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/pdata.d
+++ b/src/dmd/backend/pdata.d
@@ -2,7 +2,7 @@
  * Generates the .pdata and .xdata sections for Win64
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2012-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/ph2.d
+++ b/src/dmd/backend/ph2.d
@@ -5,7 +5,7 @@
  * It implements a heap allocator that never frees.
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/backend/rtlsym.d
+++ b/src/dmd/backend/rtlsym.d
@@ -2,7 +2,7 @@
  * Compiler runtime function symbols
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -2,7 +2,7 @@
  * Symbols for the back end
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -2,7 +2,7 @@
  * Define basic types and type masks
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1983-1998 by Symantec
  *              Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/type.d
+++ b/src/dmd/backend/type.d
@@ -2,7 +2,7 @@
  * Types for the back end
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 1999-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/util2.d
+++ b/src/dmd/backend/util2.d
@@ -4,7 +4,7 @@
  * Only used for DMD
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/var.d
+++ b/src/dmd/backend/var.d
@@ -2,7 +2,7 @@
  * Global variables for PARSER
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
  *              Copyright (C) 2000-2021 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/backend/xmm.d
+++ b/src/dmd/backend/xmm.d
@@ -2,7 +2,7 @@
  * XMM opcodes
  *
  * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) ?-2021 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -357,7 +357,7 @@ dmd -cov -unittest myprog.d
             "add symbolic debug info",
             `$(WINDOWS
                 Add CodeView symbolic debug info. See
-                $(LINK2 http://dlang.org/windbg.html, Debugging on Windows).
+                $(LINK2 https://dlang.org/windbg.html, Debugging on Windows).
             )
             $(UNIX
                 Add symbolic debug info in DWARF format

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1688,7 +1688,7 @@ extern (C++) class ToElemVisitor : Visitor
     }
 
     /***************************************
-     * http://dlang.org/spec/expression.html#cat_expressions
+     * https://dlang.org/spec/expression.html#cat_expressions
      */
 
     override void visit(CatExp ce)

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -659,7 +659,7 @@ enum WANTvalue  = 0;    // default
 enum WANTexpand = 1;    // expand const/immutable variables if possible
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#expression
+ * https://dlang.org/spec/expression.html#expression
  */
 extern (C++) abstract class Expression : ASTNode
 {
@@ -2262,7 +2262,7 @@ extern (C++) final class DsymbolExp : Expression
 }
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#this
+ * https://dlang.org/spec/expression.html#this
  */
 extern (C++) class ThisExp : Expression
 {
@@ -2318,7 +2318,7 @@ extern (C++) class ThisExp : Expression
 }
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#super
+ * https://dlang.org/spec/expression.html#super
  */
 extern (C++) final class SuperExp : ThisExp
 {
@@ -2334,7 +2334,7 @@ extern (C++) final class SuperExp : ThisExp
 }
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#null
+ * https://dlang.org/spec/expression.html#null
  */
 extern (C++) final class NullExp : Expression
 {
@@ -2380,7 +2380,7 @@ extern (C++) final class NullExp : Expression
 }
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#string_literals
+ * https://dlang.org/spec/expression.html#string_literals
  */
 extern (C++) final class StringExp : Expression
 {
@@ -2904,7 +2904,7 @@ extern (C++) final class TupleExp : Expression
 /***********************************************************
  * [ e1, e2, e3, ... ]
  *
- * http://dlang.org/spec/expression.html#array_literals
+ * https://dlang.org/spec/expression.html#array_literals
  */
 extern (C++) final class ArrayLiteralExp : Expression
 {
@@ -3069,7 +3069,7 @@ extern (C++) final class ArrayLiteralExp : Expression
 /***********************************************************
  * [ key0 : value0, key1 : value1, ... ]
  *
- * http://dlang.org/spec/expression.html#associative_array_literals
+ * https://dlang.org/spec/expression.html#associative_array_literals
  */
 extern (C++) final class AssocArrayLiteralExp : Expression
 {
@@ -5423,7 +5423,7 @@ extern (C++) final class VectorArrayExp : UnaExp
 /***********************************************************
  * e1 [lwr .. upr]
  *
- * http://dlang.org/spec/expression.html#slice_expressions
+ * https://dlang.org/spec/expression.html#slice_expressions
  */
 extern (C++) final class SliceExp : UnaExp
 {
@@ -5506,7 +5506,7 @@ extern (C++) final class ArrayLengthExp : UnaExp
 /***********************************************************
  * e1 [ a0, a1, a2, a3 ,... ]
  *
- * http://dlang.org/spec/expression.html#index_expressions
+ * https://dlang.org/spec/expression.html#index_expressions
  */
 extern (C++) final class ArrayExp : UnaExp
 {
@@ -6208,7 +6208,7 @@ extern (C++) final class CatDcharAssignExp : CatAssignExp
 }
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#add_expressions
+ * https://dlang.org/spec/expression.html#add_expressions
  */
 extern (C++) final class AddExp : BinExp
 {
@@ -6239,7 +6239,7 @@ extern (C++) final class MinExp : BinExp
 }
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#cat_expressions
+ * https://dlang.org/spec/expression.html#cat_expressions
  */
 extern (C++) final class CatExp : BinExp
 {
@@ -6262,7 +6262,7 @@ extern (C++) final class CatExp : BinExp
 }
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#mul_expressions
+ * https://dlang.org/spec/expression.html#mul_expressions
  */
 extern (C++) final class MulExp : BinExp
 {
@@ -6278,7 +6278,7 @@ extern (C++) final class MulExp : BinExp
 }
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#mul_expressions
+ * https://dlang.org/spec/expression.html#mul_expressions
  */
 extern (C++) final class DivExp : BinExp
 {
@@ -6294,7 +6294,7 @@ extern (C++) final class DivExp : BinExp
 }
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#mul_expressions
+ * https://dlang.org/spec/expression.html#mul_expressions
  */
 extern (C++) final class ModExp : BinExp
 {
@@ -6310,7 +6310,7 @@ extern (C++) final class ModExp : BinExp
 }
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#pow_expressions
+ * https://dlang.org/spec/expression.html#pow_expressions
  */
 extern (C++) final class PowExp : BinExp
 {
@@ -6416,8 +6416,8 @@ extern (C++) final class XorExp : BinExp
 }
 
 /***********************************************************
- * http://dlang.org/spec/expression.html#andand_expressions
- * http://dlang.org/spec/expression.html#oror_expressions
+ * https://dlang.org/spec/expression.html#andand_expressions
+ * https://dlang.org/spec/expression.html#oror_expressions
  */
 extern (C++) final class LogicalExp : BinExp
 {
@@ -6437,7 +6437,7 @@ extern (C++) final class LogicalExp : BinExp
  * `op` is one of:
  *      EXP.lessThan, EXP.lessOrEqual, EXP.greaterThan, EXP.greaterOrEqual
  *
- * http://dlang.org/spec/expression.html#relation_expressions
+ * https://dlang.org/spec/expression.html#relation_expressions
  */
 extern (C++) final class CmpExp : BinExp
 {
@@ -6490,7 +6490,7 @@ extern (C++) final class RemoveExp : BinExp
  *
  * EXP.equal and EXP.notEqual
  *
- * http://dlang.org/spec/expression.html#equality_expressions
+ * https://dlang.org/spec/expression.html#equality_expressions
  */
 extern (C++) final class EqualExp : BinExp
 {
@@ -6511,7 +6511,7 @@ extern (C++) final class EqualExp : BinExp
  *
  * EXP.identity and EXP.notIdentity
  *
- *  http://dlang.org/spec/expression.html#identity_expressions
+ *  https://dlang.org/spec/expression.html#identity_expressions
  */
 extern (C++) final class IdentityExp : BinExp
 {
@@ -6530,7 +6530,7 @@ extern (C++) final class IdentityExp : BinExp
 /***********************************************************
  * `econd ? e1 : e2`
  *
- * http://dlang.org/spec/expression.html#conditional_expressions
+ * https://dlang.org/spec/expression.html#conditional_expressions
  */
 extern (C++) final class CondExp : BinExp
 {

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -233,29 +233,29 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     {
         version (Windows)
         {
-            browse("http://dlang.org/dmd-windows.html");
+            browse("https://dlang.org/dmd-windows.html");
         }
         version (linux)
         {
-            browse("http://dlang.org/dmd-linux.html");
+            browse("https://dlang.org/dmd-linux.html");
         }
         version (OSX)
         {
-            browse("http://dlang.org/dmd-osx.html");
+            browse("https://dlang.org/dmd-osx.html");
         }
         version (FreeBSD)
         {
-            browse("http://dlang.org/dmd-freebsd.html");
+            browse("https://dlang.org/dmd-freebsd.html");
         }
         /*NOTE: No regular builds for openbsd/dragonflybsd (yet) */
         /*
         version (OpenBSD)
         {
-            browse("http://dlang.org/dmd-openbsd.html");
+            browse("https://dlang.org/dmd-openbsd.html");
         }
         version (DragonFlyBSD)
         {
-            browse("http://dlang.org/dmd-dragonflybsd.html");
+            browse("https://dlang.org/dmd-dragonflybsd.html");
         }
         */
         return EXIT_SUCCESS;

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -72,7 +72,7 @@ TypeIdentifier getException()
 }
 
 /***********************************************************
- * Specification: http://dlang.org/spec/statement.html
+ * Specification: https://dlang.org/spec/statement.html
  */
 extern (C++) abstract class Statement : ASTNode
 {


### PR DESCRIPTION
Verified all links work.

The only change that isn't documentation-related are the urls that `browse()` opens in dmd/mars.d.