### PR TITLE
test: Replace http:// with https:// for dlang.org links

### DIFF
--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -1,6 +1,6 @@
 /**
  * Test the C++ compiler interface of the
- * $(LINK2 http://www.dlang.org, D programming language).
+ * $(LINK2 https://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 2017-2019 by The D Language Foundation, All Rights Reserved
  * Authors:     Iain Buclaw

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -4706,7 +4706,7 @@ void test14735()
 {
     char[64] buf;
 
-    // Supported from 2.063: (http://dlang.org/changelog#implicitarraycast)
+    // Supported from 2.063: (https://dlang.org/changelog/2.063.html#implicitarraycast)
     assert(indexOf14735a(buf[0..32], '\0') == 2);
     assert(indexOf14735b(buf[0..32], '\0') == 2);
 


### PR DESCRIPTION
Verified all links work.