### PR TITLE
Replace d.puremagic.com links with issues.dlang.org

### DIFF
--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -239,7 +239,7 @@ void test6()
 /*******************************************/
 
 /+
-// http://d.puremagic.com/issues/show_bug.cgi?id=3722
+// https://issues.dlang.org/show_bug.cgi?id=3722
 
 class Bug3722A
 {

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -1,6 +1,6 @@
 // PERMUTE_ARGS:
 
-//http://d.puremagic.com/issues/show_bug.cgi?id=5415
+//https://issues.dlang.org/show_bug.cgi?id=5415
 
 @safe
 void pointercast()
@@ -31,7 +31,7 @@ void pointercast2()
 
 @safe
 void pointerarithmetic()
-{//http://d.puremagic.com/issues/show_bug.cgi?id=4132
+{//https://issues.dlang.org/show_bug.cgi?id=4132
     void* a;
     int b;
 
@@ -273,7 +273,7 @@ void use__gshared()
 
 @safe
 void voidinitializers()
-{//http://d.puremagic.com/issues/show_bug.cgi?id=4885
+{//https://issues.dlang.org/show_bug.cgi?id=4885
     static assert(!__traits(compiles, () @safe { uint* ptr = void; } ));
     static assert( __traits(compiles, () @safe { uint i = void; } ));
     static assert( __traits(compiles, () @safe { uint[2] a = void; } ));
@@ -290,14 +290,14 @@ void voidinitializers()
 
 @safe
 void pointerindex()
-{//http://d.puremagic.com/issues/show_bug.cgi?id=9195
+{//https://issues.dlang.org/show_bug.cgi?id=9195
     static assert(!__traits(compiles, () @safe { int* p; auto a = p[30]; }));
     static assert( __traits(compiles, () @safe{ int* p; auto a = p[0]; }));
 }
 
 @safe
 void basiccast()
-{//http://d.puremagic.com/issues/show_bug.cgi?id=5088
+{//https://issues.dlang.org/show_bug.cgi?id=5088
     auto a = cast(int)cast(const int)1;
     auto b = cast(real)cast(const int)1;
     auto c = cast(real)cast(const real)2.0;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5063,7 +5063,7 @@ class Bar6847 : Foo6847
 }
 
 /***************************************************/
-// http://d.puremagic.com/issues/show_bug.cgi?id=6488
+// https://issues.dlang.org/show_bug.cgi?id=6488
 
 struct TickDuration
 {
@@ -6727,14 +6727,14 @@ void test9477()
     static bool isEq (T1, T2)(T1 s1, T2 s2) { return s1 == s2; }
     static bool isNeq(T1, T2)(T1 s1, T2 s2) { return s1 != s2; }
 
-    // Must be outside the loop due to http://d.puremagic.com/issues/show_bug.cgi?id=9748
+    // Must be outside the loop due to https://issues.dlang.org/show_bug.cgi?id=9748
     int order;
-    // Must be outside the loop due to http://d.puremagic.com/issues/show_bug.cgi?id=9756
+    // Must be outside the loop due to https://issues.dlang.org/show_bug.cgi?id=9756
     auto checkOrder(bool dyn, uint expected)()
     {
         assert(order==expected);
         order++;
-        // Use temporary ("v") to work around http://d.puremagic.com/issues/show_bug.cgi?id=9402
+        // Use temporary ("v") to work around https://issues.dlang.org/show_bug.cgi?id=9402
         auto v = cast(Select9477!(dyn, string, char[1]))"a";
         return v;
     }
@@ -6742,7 +6742,7 @@ void test9477()
     foreach (b1; Tuple9477!(false, true))
         foreach (b2; Tuple9477!(false, true))
         {
-            version (D_PIC) {} else version (D_PIE) {}  else // Work around http://d.puremagic.com/issues/show_bug.cgi?id=9754
+            version (D_PIC) {} else version (D_PIE) {}  else // Work around https://issues.dlang.org/show_bug.cgi?id=9754
             {
                 assert( isEq (cast(Select9477!(b1, string, char[0]))"" , cast(Select9477!(b2, string, char[0]))""  ));
                 assert(!isNeq(cast(Select9477!(b1, string, char[0]))"" , cast(Select9477!(b2, string, char[0]))""  ));


### PR DESCRIPTION
The old bugzilla URLs are not guaranteed to still exist moving forward with our infrastructure roadmap.

Also replaces http:// with https:// as part of the broader series of mechanical renames.

Verified all new links work.