### PR TITLE
Use %llu instead of %zu as a format specifier in errors

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -1553,7 +1553,7 @@ Expression ctfeIndex(UnionExp* pue, const ref Loc loc, Type type, Expression e1,
     {
         if (indx >= es1.len)
         {
-            error(loc, "string index %llu is out of bounds `[0 .. %zu]`", indx, es1.len);
+            error(loc, "string index %llu is out of bounds `[0 .. %llu]`", indx, cast(ulong)es1.len);
             return CTFEExp.cantexp;
         }
         emplaceExp!IntegerExp(pue, loc, es1.charAt(indx), type);
@@ -1564,7 +1564,7 @@ Expression ctfeIndex(UnionExp* pue, const ref Loc loc, Type type, Expression e1,
     {
         if (indx >= ale.elements.dim)
         {
-            error(loc, "array index %llu is out of bounds `%s[0 .. %zu]`", indx, e1.toChars(), ale.elements.dim);
+            error(loc, "array index %llu is out of bounds `%s[0 .. %llu]`", indx, e1.toChars(), cast(ulong)ale.elements.dim);
             return CTFEExp.cantexp;
         }
         Expression e = (*ale.elements)[cast(size_t)indx];

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6013,7 +6013,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 const attr = FileName.exists(path);
                 const(char)* err = attr == 2 ? "" :
                     (attr == 1 ? " (not a directory)" : " (path not found)");
-                e.errorSupplemental("[%zu]: `%s`%s", idx, path, err);
+                e.errorSupplemental("[%llu]: `%s`%s", cast(ulong)idx, path, err);
             }
             return setError();
         }
@@ -13108,7 +13108,7 @@ private bool fit(StructDeclaration sd, const ref Loc loc, Scope* sc, Expressions
                 // CTFE sometimes creates null as hidden pointer; we'll allow this.
                 continue;
             }
-                .error(loc, "more initializers than fields (%zu) of `%s`", nfields, sd.toChars());
+                .error(loc, "more initializers than fields (%llu) of `%s`", cast(ulong)nfields, sd.toChars());
             return false;
         }
         VarDeclaration v = sd.fields[i];

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -161,7 +161,7 @@ private void resolveTupleIndex(const ref Loc loc, Scope* sc, Dsymbol s, out Expr
     const(uinteger_t) d = eindex.toUInteger();
     if (d >= tup.objects.dim)
     {
-        .error(loc, "tuple index `%llu` exceeds length %zu", d, tup.objects.dim);
+        .error(loc, "tuple index `%llu` exceeds length %llu", d, cast(ulong)tup.objects.dim);
         pt = Type.terror;
         return;
     }


### PR DESCRIPTION
%zu is not recognized as being a client independent format specifier.