### PR TITLE
Fix issue 10584 - Unhelpful error default constructing nested class

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3604,16 +3604,21 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     if (!cdthis)
                     {
+                        if (!sc.hasThis)
+                        {
+                            string msg = "cannot construct " ~
+                            (cd.isAnonymous ? "anonymous nested class" : "nested class `%s`") ~
+                            " because no implicit `this` reference to outer class" ~
+                            (cdn.isAnonymous ? "" : " `%s`") ~ " is available\0";
+
+                            exp.error(msg.ptr, cd.toChars, cdn.toChars);
+                            return setError();
+                        }
+
                         // Supply an implicit 'this' and try again
                         exp.thisexp = new ThisExp(exp.loc);
                         for (Dsymbol sp = sc.parent; 1; sp = sp.toParentLocal())
                         {
-                            if (!sp)
-                            {
-                                exp.error("outer class `%s` `this` needed to `new` nested class `%s`",
-                                    cdn.toChars(), cd.toChars());
-                                return setError();
-                            }
                             ClassDeclaration cdp = sp.isClassDeclaration();
                             if (!cdp)
                                 continue;

--- a/test/fail_compilation/fail132.d
+++ b/test/fail_compilation/fail132.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail132.d(19): Error: outer class `A` `this` needed to `new` nested class `B`
+fail_compilation/fail132.d(19): Error: cannot construct nested class `B` because no implicit `this` reference to outer class `A` is available
 ---
 */
 

--- a/test/fail_compilation/fail276.d
+++ b/test/fail_compilation/fail276.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail276.d(19): Error: `this` has no effect
-fail_compilation/fail276.d(15): Error: `this` is only defined in non-static member functions, not `__anonclass2`
+fail_compilation/fail276.d(15): Error: cannot construct anonymous nested class because no implicit `this` reference to outer class is available
 ---
 */
 

--- a/test/fail_compilation/fail59.d
+++ b/test/fail_compilation/fail59.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail59.d(50): Error: outer class `C1` `this` needed to `new` nested class `C2`
+fail_compilation/fail59.d(50): Error: cannot construct nested class `C2` because no implicit `this` reference to outer class `C1` is available
 ---
 */
 

--- a/test/fail_compilation/fail60.d
+++ b/test/fail_compilation/fail60.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail60.d(14): Error: `this` is only defined in non-static member functions, not `A`
+fail_compilation/fail60.d(14): Error: cannot construct nested class `B` because no implicit `this` reference to outer class `A` is available
 ---
 */
 class A


### PR DESCRIPTION
The new error message is more verbose, but also more suitable considering `this` is added implicitly. The wording "default constructing" in the Bugzilla issue refers to this mechanism rather than a default constructor.