### PR TITLE
fix issue 22630 - It is possible for VS to be installed and providing…

### DIFF
--- a/src/dmd/vsoptions.d
+++ b/src/dmd/vsoptions.d
@@ -423,11 +423,17 @@ public:
     */
     const(char)* getVCLibDir(bool x64) const
     {
+        const(char)* proposed;
+
         if (VCToolsInstallDir !is null)
-            return FileName.combine(VCToolsInstallDir, x64 ? r"lib\x64" : r"lib\x86");
-        if (VCInstallDir !is null)
-            return FileName.combine(VCInstallDir, x64 ? r"lib\amd64" : "lib");
-        return null;
+            proposed = FileName.combine(VCToolsInstallDir, x64 ? r"lib\x64" : r"lib\x86");
+        else if (VCInstallDir !is null)
+            proposed = FileName.combine(VCInstallDir, x64 ? r"lib\amd64" : "lib");
+
+        // Due to the possibility of VS being installed with VC directory without the libraries
+        // we must check that the expected directory does exist.
+        // It is possible that this isn't the only location a file check is required.
+        return FileName.exists(proposed) ? proposed : null;
     }
 
     /**


### PR DESCRIPTION
… VC directory without VC libraries being installed

The origin of this issue is from a user on Discord who was new to D.
They did have VS 2022 installed but no VC.
So dmd tried to use lld-link but of course failed as the VC directory did in fact exist, just no the libs to go with it.

It has been tested by the user using the 2.098.1 tag as a basis.