### PR TITLE
Fix issue 22632 - Crash happens when CTFE compares an associative arr…

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -1362,6 +1362,15 @@ private int ctfeRawCmp(const ref Loc loc, Expression e1, Expression e2, bool ide
         mem.xfree(used);
         return 0;
     }
+    else if (e1.op == EXP.assocArrayLiteral && e2.op == EXP.null_)
+    {
+        return e1.isAssocArrayLiteralExp.keys.dim != 0;
+    }
+    else if (e1.op == EXP.null_ && e2.op == EXP.assocArrayLiteral)
+    {
+        return e2.isAssocArrayLiteralExp.keys.dim != 0;
+    }
+
     error(loc, "CTFE internal error: bad compare of `%s` and `%s`", e1.toChars(), e2.toChars());
     assert(0);
 }

--- a/test/compilable/test22632.d
+++ b/test/compilable/test22632.d
@@ -1,0 +1,4 @@
+// https://issues.dlang.org/show_bug.cgi?id=22632
+
+static assert(["one": 1] != null);
+static assert(null != ["one": 1]);


### PR DESCRIPTION
…ay to `null` using `==`