### PR TITLE
refactor parseOS(), check for overflow

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7692,7 +7692,7 @@ struct Target final
 {
     enum class OS : uint8_t
     {
-        Freestanding = 0u,
+        none = 0u,
         linux = 1u,
         Windows = 2u,
         OSX = 4u,

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1285,7 +1285,7 @@ void addPredefinedGlobalIdentifiers(const ref Target tgt)
             predef("ELFv1");
         switch (tgt.os)
         {
-            case OS.Freestanding: { predef("FreeStanding"); break; }
+            case OS.none:         { predef("FreeStanding"); break; }
             case OS.linux:        { predef("linux");        break; }
             case OS.OpenBSD:      { predef("OpenBSD");      break; }
             case OS.DragonFlyBSD: { predef("DragonFlyBSD"); break; }


### PR DESCRIPTION
1. remove OS.Freestanding, because the backend doesn't support that. I'll remove the predefined version for it later.
2. separate the integer parsing code into its own function, parseNumber(), because such foundational operations should be in their own functions
3. check for integer overflow before we get a bug report that it didn't
4. add comments
5. the `_osMajor` parameter actually did nothing - now it works properly
