### PR TITLE
dmd.globals: Change StorageClass type from uinteger_t to ulong

### DIFF
--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -655,7 +655,7 @@ enum PINLINE : ubyte
     always,   /// always inline
 }
 
-alias StorageClass = uinteger_t;
+alias StorageClass = ulong;
 
 /// Collection of global state
 extern (C++) __gshared Global global;


### PR DESCRIPTION
Matches `enum STC` definition, and brings us one step closer to having `dmd.root.ctinteger` (i.e: 128-bit CT integers).