### PR TITLE
Enable runnable/bitfieldsdm.c for win32 - omf

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -316,8 +316,11 @@ The following is a list of all available settings:
                          considered to be enabled on all platform).
                          default: (none, enabled)
                          Valid platforms: win linux osx freebsd dragonflybsd netbsd
-                         Optionally a MODEL suffix can used for further filtering, e.g.
-                         win32 win64 linux32 linux64 osx32 osx64 freebsd32 freebsd64
+                         Optionally a MODEL suffix can used for further filtering:
+                            - 32
+                            - 32mscoff (windows only)
+                            - 64
+                         E.g. win32mscoff osx64 freebsd32
 
 Environment variables
 ------------------------------

--- a/test/runnable/bitfieldsdm.c
+++ b/test/runnable/bitfieldsdm.c
@@ -1,11 +1,8 @@
 /* test bitfields for Digital Mars C
- * Note that this test is for win32 only. It is marked as DISABLED because
- * Azure insists on adding switches for Microsoft C, which then cause these tests
- * to fail. So, this test doesn't run.
- * Fixing the test runner so -win32mscoff can be DISABLED would be nice,
- * so then this test can be run.
+ * Note that this test is for win32 only
+ *
  * REQUIRED_ARGS:
- * DISABLED: win32 win64 linux32 freebsd32 osx32 linux64 freebsd64 osx64
+ * DISABLED: win32mscoff win64 linux freebsd osx
  * RUN_OUTPUT:
 ---
                 DM |   MS |  P32 |  P64
@@ -164,7 +161,7 @@ int main()
     printf("A8  = %2d %d || 12 4 | 12 4 |  8 4 |  8 8\n", (int)sizeof(struct A8),  (int)_Alignof(struct A8));
     printf("A9  = %2d %d || 32 8 | 32 8 | 16 4 | 16 8\n", (int)sizeof(struct A9),  (int)_Alignof(struct A9));
     printf("A10 = %2d %d ||  4 2 |  4 2 |  2 2 |  2 2\n", (int)sizeof(struct A10), (int)_Alignof(struct A10));
-    printf("A11 = %2d %d || 15 4 | 16 4 | 12 4 | 12 4\n", (int)sizeof(struct A11), (int)_Alignof(struct A11));
+    printf("A11 = %2d %d || 16 4 | 16 4 | 12 4 | 12 4\n", (int)sizeof(struct A11), (int)_Alignof(struct A11));
 
     {
         struct S9 s;
@@ -207,5 +204,3 @@ int main()
 
     return 0;
 }
-
-

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -403,6 +403,26 @@ string getDisabledReason(string[] disabledPlatforms, const ref EnvData envData)
     return null;
 }
 
+unittest
+{
+    immutable EnvData win32         = { os: "windows",  model: "32", };
+    immutable EnvData win32mscoff   = { os: "windows",  model: "32mscoff", };
+    immutable EnvData win64         = { os: "windows",  model: "64", };
+
+    assert(getDisabledReason(null, win64) is null);
+
+    assert(getDisabledReason([ "linux" ], win64) is null);
+    assert(getDisabledReason([ "linux", "win" ], win64) == "on win");
+
+    assert(getDisabledReason([ "linux", "win64" ], win64) == "on win64");
+    assert(getDisabledReason([ "linux", "win32" ], win64) is null);
+
+    assert(getDisabledReason([ "win32mscoff" ], win32mscoff) == "on win32mscoff");
+    assert(getDisabledReason([ "win32mscoff" ], win32) is null);
+
+    assert(getDisabledReason([ "win32" ], win32mscoff) == "on win32");
+    assert(getDisabledReason([ "win32" ], win32) == "on win32");
+}
 /**
  * Reads the test configuration from the source code (using `findTestParameter` and
  * `findOutputParameter`) and initializes `testArgs` accordingly. Also merges


### PR DESCRIPTION
Despite the authors claims, tests can be disabled only for win32 + mscoff.

And to no one's surprise, the test failed and was changed according to the current behaviour.

---

Also updated the `README` and added an unittests that checks the expected behaviour.