### PR TITLE
Azure: Replace deprecated vs2017-win2016 image with windows-2019

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,12 @@
 # Learn more: https://aka.ms/yaml
 variables:
-  VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
+  VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
 
 jobs:
   - job: Windows_DMD_bootstrap
     timeoutInMinutes: 60
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-2019'
     variables:
       D_COMPILER: dmd
       HOST_DMD_VERSION: 2.079.0
@@ -26,7 +26,7 @@ jobs:
   - job: Windows_DMD_latest
     timeoutInMinutes: 60
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-2019'
     variables:
       D_COMPILER: dmd
       HOST_DMD_VERSION: LATEST
@@ -47,7 +47,7 @@ jobs:
   - job: Windows_Coverage
     timeoutInMinutes: 60
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-2019'
     variables:
       D_COMPILER: dmd
       HOST_DMD_VERSION: LATEST
@@ -71,7 +71,7 @@ jobs:
   - job: Windows_VisualD_LDC
     timeoutInMinutes: 60
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-2019'
     variables:
       D_COMPILER: ldc
       VISUALD_VER: v0.49.0


### PR DESCRIPTION
See https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/#windows