### PR TITLE
fix Issue 22568 - -target option does nothing in compilation

### DIFF
--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -84,7 +84,7 @@ extern (C) void out_config_init(
 {
 version (MARS)
 {
-    //printf("out_config_init()\n");
+    //printf("out_config_init() exefmt: %x\n", exefmt);
 
     auto cfg = &config;
 

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -74,7 +74,7 @@ void out_config_debug(
 
 void backend_init()
 {
-    printf("out_config_init() os: %d\n", target.os);
+    //printf("out_config_init() os: %d\n", target.os);
     Param *params = &global.params;
     exefmt_t exfmt;
     switch (target.os)

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -74,7 +74,7 @@ void out_config_debug(
 
 void backend_init()
 {
-    //printf("out_config_init()\n");
+    printf("out_config_init() os: %d\n", target.os);
     Param *params = &global.params;
     exefmt_t exfmt;
     switch (target.os)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -264,7 +264,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (params.color)
         global.console = cast(void*) createConsole(core.stdc.stdio.stderr);
 
-    target.os = defaultTargetOS();           // set target operating system
+    //target.os = defaultTargetOS();           // set target operating system
     target.setCPU();
 
     if (global.errors)
@@ -1935,6 +1935,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             enum len = "-target=".length;
             const triple = Triple(p + len);
             target.setTriple(triple);
+printf("target.os: %d\n", target.os);
         }
         else if (startsWith(p + 1, "mcpu")) // https://dlang.org/dmd.html#switch-mcpu
         {

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -264,7 +264,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (params.color)
         global.console = cast(void*) createConsole(core.stdc.stdio.stderr);
 
-    //target.os = defaultTargetOS();           // set target operating system
     target.setCPU();
 
     if (global.errors)
@@ -1935,7 +1934,6 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             enum len = "-target=".length;
             const triple = Triple(p + len);
             target.setTriple(triple);
-printf("target.os: %d\n", target.os);
         }
         else if (startsWith(p + 1, "mcpu")) // https://dlang.org/dmd.html#switch-mcpu
         {
@@ -2616,7 +2614,7 @@ private void reconcileCommands(ref Param params)
                 params.mscrtlib = vsopt.defaultRuntimeLibrary(target.is64bit).toDString;
             }
             else
-                error(Loc.initial, "must supply `-mscrtlib` manually when cross compiling to windows");
+                error(Loc.initial, "must supply `-mscrtlib=<libname>` manually when cross compiling to Windows");
         }
     }
     else

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -187,7 +187,7 @@ extern (C++) struct Target
      */
     extern (C++) void _init(ref const Param params)
     {
-	//printf("Target._init() os: %d\n", os);
+        //printf("Target._init() os: %d\n", os);
 
         // is64bit, mscoff and cpu are initialized in parseCommandLine
 

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -25,6 +25,7 @@
 
 module dmd.target;
 
+import core.stdc.stdio;
 import dmd.globals : Param;
 
 enum CPU : ubyte
@@ -186,6 +187,8 @@ extern (C++) struct Target
      */
     extern (C++) void _init(ref const Param params)
     {
+	//printf("Target._init() os: %d\n", os);
+
         // is64bit, mscoff and cpu are initialized in parseCommandLine
 
         this.params = &params;
@@ -316,6 +319,7 @@ extern (C++) struct Target
 
     void setTriple(const ref Triple triple)
     {
+        //printf("setTriple() os: %d\n", triple.os);
         cpu     = triple.cpu;
         is64bit = triple.is64bit;
         isLP64  = triple.isLP64;
@@ -1395,6 +1399,7 @@ struct Triple
 
     this(const(char)* _triple)
     {
+        //printf("Triple.ctor\n");
         import dmd.root.string : toDString, toCStringThen;
         const(char)[] triple = _triple.toDString();
         const(char)[] next()

--- a/test/compilable/triple.d
+++ b/test/compilable/triple.d
@@ -1,0 +1,12 @@
+/* The following arguments to the autotester do not work because it is
+ * determined to add -fPICx, even though the documentation says xERMUTE_ARGSx
+ * with no arguments will prevent it.
+ */
+/* EQUIRED_ARGSx -m64 -target=x64-windows-msvc -mscrtlib=whatever.lib
+ * ERMUTE_ARGSx
+ */
+
+int func(int x)
+{
+    return x + 1;
+}


### PR DESCRIPTION
At least it can now generate a Windows 64 object file.