### PR TITLE
Move AST enums defined in dmd.global to astenums

### DIFF
--- a/src/dmd/astenums.d
+++ b/src/dmd/astenums.d
@@ -134,6 +134,8 @@ enum STC : ulong  // transfer changes to declaration.h
 
 }
 
+alias StorageClass = ulong;
+
 /********
  * Determine if it's the ambigous case of where `return` attaches to.
  * Params:
@@ -389,3 +391,43 @@ enum InitKind : ubyte
     C_,
 }
 
+/// A linkage attribute as defined by `extern(XXX)`
+///
+/// https://dlang.org/spec/attribute.html#linkage
+enum LINK : ubyte
+{
+    default_,
+    d,
+    c,
+    cpp,
+    windows,
+    objc,
+    system,
+}
+
+/// Whether to mangle an external aggregate as a struct or class, as set by `extern(C++, struct)`
+enum CPPMANGLE : ubyte
+{
+    def,      /// default
+    asStruct, /// `extern(C++, struct)`
+    asClass,  /// `extern(C++, class)`
+}
+
+/// Function match levels
+///
+/// https://dlang.org/spec/function.html#function-overloading
+enum MATCH : int
+{
+    nomatch,   /// no match
+    convert,   /// match with conversions
+    constant,  /// match with conversion to const
+    exact,     /// exact match
+}
+
+/// Inline setting as defined by `pragma(inline, XXX)`
+enum PINLINE : ubyte
+{
+    default_, /// as specified on the command line
+    never,    /// never inline
+    always,   /// always inline
+}

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -16,6 +16,7 @@ module dmd.denum;
 
 import core.stdc.stdio;
 
+import dmd.astenums;
 import dmd.attrib;
 import dmd.gluelayer;
 import dmd.declaration;

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -16,6 +16,7 @@ import core.stdc.string;
 import core.stdc.ctype;
 
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.arraytypes;
 import dmd.attrib;
 import dmd.dsymbol;

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -614,48 +614,5 @@ nothrow:
     }
 }
 
-/// A linkage attribute as defined by `extern(XXX)`
-///
-/// https://dlang.org/spec/attribute.html#linkage
-enum LINK : ubyte
-{
-    default_,
-    d,
-    c,
-    cpp,
-    windows,
-    objc,
-    system,
-}
-
-/// Whether to mangle an external aggregate as a struct or class, as set by `extern(C++, struct)`
-enum CPPMANGLE : ubyte
-{
-    def,      /// default
-    asStruct, /// `extern(C++, struct)`
-    asClass,  /// `extern(C++, class)`
-}
-
-/// Function match levels
-///
-/// https://dlang.org/spec/function.html#function-overloading
-enum MATCH : int
-{
-    nomatch,   /// no match
-    convert,   /// match with conversions
-    constant,  /// match with conversion to const
-    exact,     /// exact match
-}
-
-/// Inline setting as defined by `pragma(inline, XXX)`
-enum PINLINE : ubyte
-{
-    default_, /// as specified on the command line
-    never,    /// never inline
-    always,   /// always inline
-}
-
-alias StorageClass = ulong;
-
 /// Collection of global state
 extern (C++) __gshared Global global;

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -48,6 +48,7 @@ module dmd.nspace;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.astenums;
 import dmd.dscope;
 import dmd.dsymbol;
 import dmd.dsymbolsem;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -80,8 +80,8 @@ extern (C++) struct Target
     import dmd.dscope : Scope;
     import dmd.expression : Expression;
     import dmd.func : FuncDeclaration;
-    import dmd.globals : LINK, Loc, d_int64;
-    import dmd.astenums : TY;
+    import dmd.globals : Loc, d_int64;
+    import dmd.astenums : LINK, TY;
     import dmd.mtype : Type, TypeFunction, TypeTuple;
     import dmd.root.ctfloat : real_t;
     import dmd.statement : Statement;
@@ -1310,8 +1310,7 @@ struct TargetCPP
      */
     extern (C++) Type parameterType(Parameter p)
     {
-        import dmd.astenums : STC;
-        import dmd.globals : LINK;
+        import dmd.astenums : LINK, STC;
         import dmd.mtype : ParameterList, TypeDelegate, TypeFunction;
         import dmd.typesem : merge;
 

--- a/test/unit/semantic/covariance.d
+++ b/test/unit/semantic/covariance.d
@@ -4,9 +4,8 @@
 
 module semantic.covariance;
 
-import dmd.astenums : STC;
+import dmd.astenums : STC, StorageClass;
 import dmd.func : FuncDeclaration;
-import dmd.globals : StorageClass;
 import dmd.mtype : Covariant, Type;
 
 import support;


### PR DESCRIPTION
These have nothing to do with either `struct Global` nor `struct Params` and everything to do with the AST.