### PR TITLE
add -os=<os> switch

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -626,6 +626,20 @@ dmd -cov -unittest myprog.d
             off when generating an object, interface, or Ddoc file
             name. $(SWLINK -op) will leave it on.`,
         ),
+        Option("os=<os>",
+            "sets target operating system to <os>",
+            `Set the target operating system as other than the host.
+                $(UL
+                    $(LI $(I host): Target the host operating system (default).)
+                    $(LI $(I dragonflybsd): DragonFlyBSD)
+                    $(LI $(I freebsd): FreeBSD)
+                    $(LI $(I linux): Linux)
+                    $(LI $(I openbsd): OpenBSD)
+                    $(LI $(I osx): OSX)
+                    $(LI $(I solaris): Solaris)
+                    $(LI $(I windows): Windows)
+                )`
+        ),
         Option("preview=<name>",
             "enable an upcoming language change identified by 'name'",
             `Preview an upcoming language change identified by $(I id)`,

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -264,7 +264,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (params.color)
         global.console = cast(void*) createConsole(core.stdc.stdio.stderr);
 
-    target.os = defaultTargetOS();           // set target operating system
     target.setCPU();
 
     if (global.errors)
@@ -1970,6 +1969,36 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             {
                 errorInvalidSwitch(p, "Only `baseline`, `avx`, `avx2` or `native` are allowed for `-mcpu`");
                 params.mcpuUsage = true;
+                return false;
+            }
+        }
+        else if (startsWith(p + 1, "os")) // https://dlang.org/dmd.html#switch-os
+        {
+            enum len = "-os=".length;
+            // Parse:
+            //      -os=identifier
+            immutable string msg = "Only `host`, `linux`, `windows`, `osx`,`openbsd`, `freebsd`, `solaris`, `dragonflybsd` allowed for `-os`";
+            if (Identifier.isValidIdentifier(p + len))
+            {
+                const ident = p + len;
+                switch (ident.toDString())
+                {
+                case "host":         target.os = defaultTargetOS();      break;
+                case "linux":        target.os = Target.OS.linux;        break;
+                case "windows":      target.os = Target.OS.Windows;      break;
+                case "osx":          target.os = Target.OS.OSX;          break;
+                case "openbsd":      target.os = Target.OS.OpenBSD;      break;
+                case "freebsd":      target.os = Target.OS.FreeBSD;      break;
+                case "solaris":      target.os = Target.OS.Solaris;      break;
+                case "dragonflybsd": target.os = Target.OS.DragonFlyBSD; break;
+                default:
+                    errorInvalidSwitch(p, msg);
+                    return false;
+                }
+            }
+            else
+            {
+                errorInvalidSwitch(p, msg);
                 return false;
             }
         }

--- a/test/compilable/testos.d
+++ b/test/compilable/testos.d
@@ -1,0 +1,7 @@
+/* PERMUTE_ARGS: -os=host -os=linux -os=osx -os=freebsd -os=solaris
+ * DISABLED: win32 win64
+ */
+
+void test()
+{
+}


### PR DESCRIPTION
Since my PRs to fix triples (they are currently unusable) are DOA,
https://github.com/dlang/dmd/pull/13486 https://github.com/dlang/dmd/pull/13484, I have given up on them.

In order to make cross-compilation work, only the operating system needs to be specified. This adds the support via the `-os=<os>` switch. Very easy.