### PR TITLE
d_do_test: Remove duplication between findTestParameter and findOutputParameter

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -188,6 +188,24 @@ void main(string[] args)
 }
 ```
 
+Test parameters can be restricted to certain targets by adding a brace-enclosed
+condition after the name, i.e. `REQUIRED_ARGS(<condition>): ...`. The `<condition>`
+consists of the target operating system followed by an optional model suffix,
+e.g. `linux`, `win32mscoff`, `freebsd64`.
+
+Valid platforms:
+- win
+- linux
+- osx
+- freebsd
+- dragonflybsd
+- netbsd
+
+Valid models:
+- 32
+- 32mscoff  (windows only)
+- 64
+
 The following is a list of all available settings:
 
     ARG_SETS:            sets off extra arguments to invoke $(DMD) with (seperated by ';').
@@ -215,14 +233,11 @@ The following is a list of all available settings:
                          empty.
 
     DISABLED:            selectively disable the test on specific platforms (if empty, the test is
-                         considered to be enabled on all platform).
+                         considered to be enabled on all platform). Target platforms are specified
+                         using nearly the same syntax as conditions of optional parameters, except for
+                         `win` instead of `windows`.
+                         Potential filters are `win32`, `linux`, ...
                          default: (none, enabled)
-                         Valid platforms: win linux osx freebsd dragonflybsd netbsd
-                         Optionally a MODEL suffix can used for further filtering:
-                            - 32
-                            - 32mscoff (windows only)
-                            - 64
-                         E.g. win32mscoff osx64 freebsd32
 
     EXECUTE_ARGS:        parameters to add to the execution of the test
                          default: (none)

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -407,14 +407,9 @@ bool findOutputParameter(string file, string token, out string result, string se
 {
     bool found = false;
 
-    while (true)
+    while (consumeNextToken(file, token))
     {
-        const istart = std.string.indexOf(file, token);
-        if (istart == -1)
-            break;
         found = true;
-
-        file = file[istart + token.length .. $];
 
         enum embed_sep = "---";
         auto n = std.string.indexOf(file, embed_sep);
@@ -498,6 +493,29 @@ INCOMPLETE:
     ex = collectException(findOutputParameter(file, "INCOMPLETE", found, "/"));
     assert(ex);
     assert(ex.msg == "invalid TEST_OUTPUT format");
+}
+
+/++
+ + Reads the file content to find the next parameter specified by `token`.
+ +
+ + Params:
+ +   file  = file content, set after the colon if the parameter was found
+ +   token = requested parameter
+ +
+ + Returns: true if `token` was found
+ +/
+private bool consumeNextToken(ref string file, const string token)
+{
+    while (true)
+    {
+        const istart = std.string.indexOf(file, token);
+        if (istart == -1)
+            return false;
+
+        file = file[istart + token.length .. $];
+
+        return true;
+    }
 }
 
 /// Replaces the placeholer `${RESULTS_DIR}` with the actual path

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -251,11 +251,8 @@ immutable(EnvData) processEnvironment()
  */
 bool findTestParameter(const ref EnvData envData, string file, string token, ref string result, string multiLineDelimiter = " ")
 {
-    auto tokenStart = std.string.indexOf(file, token);
-    if (tokenStart == -1) return false;
-
-    bool applied = true;
-    file = file[tokenStart + token.length .. $];
+    if (!consumeNextToken(file, token, envData))
+        return false;
 
     auto lineEndR = std.string.indexOf(file, "\r");
     auto lineEndN = std.string.indexOf(file, "\n");
@@ -263,41 +260,11 @@ bool findTestParameter(const ref EnvData envData, string file, string token, ref
         (lineEndN == -1 ? file.length : lineEndN) :
         (lineEndN == -1 ? lineEndR    : min(lineEndR, lineEndN));
 
-    //writeln("found ", token, " in line: ", file.length, ", ", tokenStart, ", ", tokenStart+lineEnd);
-    //writeln("found ", token, " in line: '", file[tokenStart .. tokenStart+lineEnd], "'");
-
     result = file[0 .. lineEnd];
     const commentStart = std.string.indexOf(result, "//");
     if (commentStart != -1)
         result = result[0 .. commentStart];
     result = strip(result);
-
-    // filter by OS specific setting (os1 os2 ...)
-    if (result.startsWith("("))
-    {
-        auto close = std.string.indexOf(result, ")");
-        if (close >= 0)
-        {
-            string[] oss = split(result[1 .. close], " ");
-
-            // Check if the current environment matches an entry in oss, which can either
-            // be an OS (e.g. "linux") or a combination of OS + MODEL (e.g. "windows32").
-            // The latter is important on windows because m32 might require other
-            // parameters than m32mscoff/m64.
-            if (oss.canFind!(o => o.skipOver(envData.os) && (o.empty || o == envData.model)))
-                result = result[close + 1 .. $];
-            else
-            {
-                result = null;
-                applied = false; // Parameter was skipped
-            }
-        }
-    }
-    // skips the :, if present
-    if (result.startsWith(":"))
-        result = strip(result[1 .. $]);
-
-    //writeln("arg: '", result, "'");
 
     string result2;
     if (findTestParameter(envData, file[lineEnd .. $], token, result2, multiLineDelimiter))
@@ -309,13 +276,12 @@ bool findTestParameter(const ref EnvData envData, string file, string token, ref
             else
                 result ~= multiLineDelimiter ~ result2;
         }
-        applied = true;
     }
 
     // fix-up separators
     result = result.unifyDirSep(envData.sep);
 
-    return applied;
+    return true;
 }
 
 unittest
@@ -337,6 +303,9 @@ int i;
 /* REQUIRED_ARGS: -O
  * PERMUTE_ARGS:
  */
+
+// COMPILE_SEPERATELY
+import foo.bar;
 `;
     immutable EnvData win32 = {
         os: "windows",
@@ -382,6 +351,10 @@ int i;
     found = null;
     assert(findTestParameter(linux, file, "REQUIRED_ARGS", found));
     assert(found == "-O");
+
+    found = null;
+    assert(findTestParameter(linux, file, "COMPILE_SEPERATELY", found));
+    assert(found == "");
 }
 
 /**
@@ -407,7 +380,7 @@ bool findOutputParameter(string file, string token, out string result, ref const
 {
     bool found = false;
 
-    while (consumeNextToken(file, token))
+    while (consumeNextToken(file, token, envData))
     {
         found = true;
 
@@ -441,7 +414,7 @@ bool findOutputParameter(string file, string token, out string result, ref const
 
 unittest
 {
-    immutable EnvData linux = { sep: "/ " };
+    immutable EnvData linux = { os: "linux", model: "64", sep: "/ " };
     immutable file = `
 /*
 Here's a link
@@ -454,9 +427,16 @@ Hello, World
 void main() {}
 
 /*
-TEST_OUTPUT:
+TEST_OUTPUT(linux):
 ---
 Have a nice day
+---
+*/
+
+/*
+TEST_OUTPUT(linux32):
+---
+Ignored
 ---
 */
 
@@ -498,14 +478,17 @@ INCOMPLETE:
 
 /++
  + Reads the file content to find the next parameter specified by `token`.
+ + Ignores conditional parameters that don't apply to the current environment.
  +
  + Params:
- +   file  = file content, set after the colon if the parameter was found
- +   token = requested parameter
+ +   file    = file content, will be advanced to the first non-whitespace character
+ +             of the parameter value - if `token` was found
+ +   token   = requested parameter
+ +   envData = environment data
  +
  + Returns: true if `token` was found
  +/
-private bool consumeNextToken(ref string file, const string token)
+private bool consumeNextToken(ref string file, const string token, ref const EnvData envData)
 {
     while (true)
     {
@@ -514,6 +497,31 @@ private bool consumeNextToken(ref string file, const string token)
             return false;
 
         file = file[istart + token.length .. $];
+        file = file.stripLeft!(ch => ch == ' '); // Don't read line breaks
+
+        // filter by OS specific setting (os1 os2 ...)
+        if (file.startsWith("("))
+        {
+            auto close = std.string.indexOf(file, ")");
+            if (close >= 0)
+            {
+                // Remove the (<oss>) list from the front of `file``
+                const oss = split(file[1 .. close], " ");
+                file = file[close + 1 .. $];
+                file = file.stripLeft!(ch => ch == ' '); // Don't read line breaks
+
+                // Check if the current environment matches an entry in oss, which can either
+                // be an OS (e.g. "linux") or a combination of OS + MODEL (e.g. "windows32").
+                // The latter is important on windows because m32 might require other
+                // parameters than m32mscoff/m64.
+                if (!oss.canFind!(o => o.skipOver(envData.os) && (o.empty || o == envData.model)))
+                    continue; // Parameter was skipped
+            }
+        }
+
+        // Skip a trailing colon
+        if (file.skipOver(":"))
+            file = file.stripLeft!(ch => ch == ' '); // Don't read line breaks
 
         return true;
     }


### PR DESCRIPTION
This removes most of the duplication between both methods and ensures that both methods enforce the same rules for all test parameters.

This propagates the capability to define conditional test parameters (read by `findTestParameter`) to output parameters (read by `findOutputParamter`).

Also added a documentation for conditional parameters which was missing before.

---

Didn't split this into multiple PR's because the commits don't provide much value on their own (even though they are valid and pass all tests).