### PR TITLE
Simplify a few usages of `Expression.toBool`

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1093,19 +1093,14 @@ UnionExp Cast(const ref Loc loc, Type type, Type to, Expression e1)
     }
     else if (tb.ty == Tbool)
     {
-        bool val = void;
         const opt = e1.toBool();
-        if (opt.hasValue(true))
-            val = true;
-        else if (opt.hasValue(false))
-            val = false;
-        else
+        if (opt.isEmpty())
         {
             cantExp(ue);
             return ue;
         }
 
-        emplaceExp!(IntegerExp)(&ue, loc, val, type);
+        emplaceExp!(IntegerExp)(&ue, loc, opt.get(), type);
     }
     else if (type.isintegral())
     {

--- a/src/dmd/staticcond.d
+++ b/src/dmd/staticcond.d
@@ -109,18 +109,16 @@ bool evalStaticCondition(Scope* sc, Expression original, Expression e, out bool 
         e = e.ctfeInterpret();
 
         const opt = e.toBool();
-        if (opt.hasValue(true))
-            return true;
-        else if (opt.hasValue(false))
+        if (opt.isEmpty())
         {
-            if (negatives)
-                negatives.push(before);
+            e.error("expression `%s` is not constant", e.toChars());
+            errors = true;
             return false;
         }
 
-        e.error("expression `%s` is not constant", e.toChars());
-        errors = true;
-        return false;
+        if (negatives && !opt.get())
+            negatives.push(before);
+        return opt.get();
     }
     return impl(e);
 }


### PR DESCRIPTION
The new code is smaller and easier to understand.