### PR TITLE
Replace usages of Optional.hasValue(...) assuming a value with get()

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -120,6 +120,9 @@ UnionExp Not(Type type, Expression e1)
 {
     UnionExp ue = void;
     Loc loc = e1.loc;
+    // BUG: Should be replaced with e1.toBool().get(), but this is apparently
+    //      executed for some expressions that cannot be const-folded
+    //      To be fixed in another PR
     emplaceExp!(IntegerExp)(&ue, loc, e1.toBool().hasValue(false) ? 1 : 0, type);
     return ue;
 }
@@ -128,7 +131,7 @@ private UnionExp Bool(Type type, Expression e1)
 {
     UnionExp ue = void;
     Loc loc = e1.loc;
-    emplaceExp!(IntegerExp)(&ue, loc, e1.toBool().hasValue(true) ? 1 : 0, type);
+    emplaceExp!(IntegerExp)(&ue, loc, e1.toBool().get() ? 1 : 0, type);
     return ue;
 }
 

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -127,14 +127,6 @@ UnionExp Not(Type type, Expression e1)
     return ue;
 }
 
-private UnionExp Bool(Type type, Expression e1)
-{
-    UnionExp ue = void;
-    Loc loc = e1.loc;
-    emplaceExp!(IntegerExp)(&ue, loc, e1.toBool().get() ? 1 : 0, type);
-    return ue;
-}
-
 UnionExp Add(const ref Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue = void;

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -1130,8 +1130,8 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             const e1Opt = e.e1.toBool();
             if (e.e2.isConst())
             {
-                bool n1 = e1Opt.hasValue(true);
-                bool n2 = e.e2.toBool().hasValue(true);
+                bool n1 = e1Opt.get();
+                bool n2 = e.e2.toBool().get();
                 ret = new IntegerExp(e.loc, oror ? (n1 || n2) : (n1 && n2), e.type);
             }
             else if (e1Opt.hasValue(!oror))

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -998,7 +998,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 e.error("`bool` expected as third argument of `__traits(getOverloads)`, not `%s` of type `%s`", b.toChars(), b.type.toChars());
                 return ErrorExp.get();
             }
-            includeTemplates = b.toBool().hasValue(true);
+            includeTemplates = b.toBool().get();
         }
 
         StringExp se = ex.toStringExp();


### PR DESCRIPTION
The modified lines assumed that the returned optional always contains
a value. Using `get` enforces this assumption and simplifies the code.