### PR TITLE
Translate `_d_newThrowable` hook to template

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -4879,6 +4879,8 @@ public:
             }
             else if (fd.ident == Id._d_arrayappendcTX)
                 assert(0, "CTFE cannot interpret _d_arrayappendcTX!");
+            else if (fd.ident == Id._d_newThrowable)
+                assert(0, "CTFE cannot interpret `_d_newThrowable`!");
         }
         else if (auto soe = ecall.isSymOffExp())
         {

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2906,19 +2906,6 @@ elem* toElem(Expression e, IRState *irs)
 
     elem* visitCond(CondExp ce)
     {
-        if (auto ve = ce.econd.isVarExp)
-            if (ve.var.ident == Id.ctfe)
-            {
-                elem *e = toElem(ce.e2, irs);
-                if (irs.params.cov && ce.e2.loc.linnum)
-                    e = el_combine(incUsageElem(irs, ce.e2.loc), e);
-                if (tybasic(e.Ety) == TYstruct)
-                    e.ET = Type_toCtype(ce.e2.type);
-                elem_setLoc(e, ce.loc);
-                result = e;
-                return;
-            }
-
         elem *ec = toElem(ce.econd, irs);
 
         elem *eleft = toElem(ce.e1, irs);

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1072,8 +1072,11 @@ elem* toElem(Expression e, IRState *irs)
             }
             else
             {
+                assert(!(global.params.ehnogc && ne.thrownew),
+                    "This should have been rewritten to `_d_newThrowable` in the semantic phase.");
+
                 Symbol *csym = toSymbol(cd);
-                const rtl = global.params.ehnogc && ne.thrownew ? RTLSYM.NEWTHROW : RTLSYM.NEWCLASS;
+                const rtl = RTLSYM.NEWCLASS;
                 ex = el_bin(OPcall,TYnptr,el_var(getRtlsym(rtl)),el_ptr(csym));
                 toTraceGC(irs, ex, ne.loc);
                 ectype = null;
@@ -2903,6 +2906,19 @@ elem* toElem(Expression e, IRState *irs)
 
     elem* visitCond(CondExp ce)
     {
+        if (auto ve = ce.econd.isVarExp)
+            if (ve.var.ident == Id.ctfe)
+            {
+                elem *e = toElem(ce.e2, irs);
+                if (irs.params.cov && ce.e2.loc.linnum)
+                    e = el_combine(incUsageElem(irs, ce.e2.loc), e);
+                if (tybasic(e.Ety) == TYstruct)
+                    e.ET = Type_toCtype(ce.e2.type);
+                elem_setLoc(e, ce.loc);
+                result = e;
+                return;
+            }
+
         elem *ec = toElem(ce.econd, irs);
 
         elem *eleft = toElem(ce.e1, irs);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3722,6 +3722,37 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     }
                 }
             }
+
+            // When using `@nogc` exception handling, lower `throw new E(...)` to
+            // `throw (__ctfe ? new E(...) : __tmp = _d_newThrowable!E(), __tmp.__ctor(...), __tmp)`.
+            if (global.params.ehnogc && exp.thrownew &&
+                !cd.isCOMclass() && !cd.isCPPclass())
+            {
+                assert(cd.ctor);
+
+                Expression id = new IdentifierExp(exp.loc, Id.empty);
+                id = new DotIdExp(exp.loc, id, Id.object);
+
+                auto tiargs = new Objects();
+                tiargs.push(exp.newtype);
+                id = new DotTemplateInstanceExp(exp.loc, id, Id._d_newThrowable, tiargs);
+                id = new CallExp(exp.loc, id).expressionSemantic(sc);
+
+                Expression idVal;
+                Expression tmp = extractSideEffect(sc, "__tmpThrowable", idVal, id, true);
+                auto castTmp = new CastExp(exp.loc, tmp, exp.type);
+
+                auto ctor = new DotIdExp(exp.loc, castTmp, exp.member.ident).expressionSemantic(sc);
+                auto ctorCall = new CallExp(exp.loc, ctor, exp.arguments);
+
+                id = Expression.combine(idVal, exp.argprefix).expressionSemantic(sc);
+                id = Expression.combine(id, ctorCall).expressionSemantic(sc);
+                id = Expression.combine(id, castTmp).expressionSemantic(sc);
+                id = new CondExp(exp.loc, new IdentifierExp(exp.loc, Id.ctfe), exp, id);
+
+                result = id.expressionSemantic(sc);
+                return;
+            }
         }
         else if (auto ts = tb.isTypeStruct())
         {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3724,17 +3724,30 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
 
             // When using `@nogc` exception handling, lower `throw new E(args)` to
-            // `throw _d_newThrowable!E(args)`.
+            // `throw (__tmp = _d_newThrowable!E(), __tmp.__ctor(args), __tmp)`.
             if (global.params.ehnogc && exp.thrownew &&
                 !cd.isCOMclass() && !cd.isCPPclass())
             {
+                assert(cd.ctor);
+
                 Expression id = new IdentifierExp(exp.loc, Id.empty);
                 id = new DotIdExp(exp.loc, id, Id.object);
 
                 auto tiargs = new Objects();
                 tiargs.push(exp.newtype);
                 id = new DotTemplateInstanceExp(exp.loc, id, Id._d_newThrowable, tiargs);
-                id = new CallExp(exp.loc, id, exp.arguments);
+                id = new CallExp(exp.loc, id).expressionSemantic(sc);
+
+                Expression idVal;
+                Expression tmp = extractSideEffect(sc, "__tmpThrowable", idVal, id, true);
+                // auto castTmp = new CastExp(exp.loc, tmp, exp.type);
+
+                auto ctor = new DotIdExp(exp.loc, tmp, Id.ctor).expressionSemantic(sc);
+                auto ctorCall = new CallExp(exp.loc, ctor, exp.arguments);
+
+                id = Expression.combine(idVal, exp.argprefix).expressionSemantic(sc);
+                id = Expression.combine(id, ctorCall).expressionSemantic(sc);
+                // id = Expression.combine(id, castTmp).expressionSemantic(sc);
 
                 result = id.expressionSemantic(sc);
                 return;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8306,6 +8306,7 @@ struct Id final
     static Identifier* criticalenter;
     static Identifier* criticalexit;
     static Identifier* _d_delThrowable;
+    static Identifier* _d_newThrowable;
     static Identifier* _d_assert_fail;
     static Identifier* dup;
     static Identifier* _aaApply;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -311,6 +311,7 @@ immutable Msgtable[] msgtable =
     { "__ArrayPostblit" },
     { "__ArrayDtor" },
     { "_d_delThrowable" },
+    { "_d_newThrowable" },
     { "_d_assert_fail" },
     { "dup" },
     { "_aaApply" },

--- a/test/compilable/testdip1008.d
+++ b/test/compilable/testdip1008.d
@@ -13,9 +13,28 @@ int bar()
     }
 }
 
+void throwQualifiers() @safe @nogc pure
+{
+    throw new Exception("baz");
+}
+
+bool testThrowQualifiers()
+{
+    try
+    {
+        throwQualifiers();
+    } catch (Exception e)
+    {
+        return true;
+    }
+
+    return false;
+}
 
 void foo()
 {
     enum r = bar();
     static assert(r == 7);
+
+    static assert(testThrowQualifiers());
 }


### PR DESCRIPTION
This PR lowers expressions such as `throw new E(args)` to:
```d
throw _d_newThrowable!E(args);
``` 
when compiling with `-dip1008`.

The DRuntime PRs which implement the template `_d_newThrowable` are:
- https://github.com/dlang/druntime/pull/3661
- https://github.com/dlang/druntime/pull/3692