### PR TITLE
Translate `_d_arrayappend{T,cTX}` to templates

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -370,7 +370,7 @@ extern (C++) final class StaticForeach : RootObject
         Type ety = new TypeTypeof(aloc, wrapAndCall(aloc, new CompoundStatement(aloc, s1)));
         auto aty = ety.arrayOf();
         auto idres = Identifier.generateId("__res");
-        auto vard = new VarDeclaration(aloc, aty, idres, null);
+        auto vard = new VarDeclaration(aloc, aty, idres, null, STC.temp);
         auto s2 = new Statements();
 
         // Run 'typeof' gagged to avoid duplicate errors and if it fails just create

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -4837,6 +4837,10 @@ public:
                 result = interpret(ce, istate);
                 return;
             }
+            else if (fd.ident == Id._d_arrayappendT)
+                assert(0, "CTFE cannot interpret _d_arrayappendT!");
+            else if (fd.ident == Id._d_arrayappendcTX)
+                assert(0, "CTFE cannot interpret _d_arrayappendcTX!");
         }
         else if (auto soe = ecall.isSymOffExp())
         {

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -1049,6 +1049,21 @@ public:
         if (exceptionOrCant(e))
             return;
 
+        /**
+         * Interpret `return a ~= b` (i.e. `return _d_arrayappendT{,Trace}(a, b)`) as:
+         *     a ~= b;
+         *     return a;
+         * This is needed because `a ~= b` has to be interpreted as an lvalue, in order to avoid
+         * assigning a larger array into a smaller one, such as:
+         *    `a = [1, 2], a ~= [3]` => `[1, 2] ~= [3]` => `[1, 2] = [1, 2, 3]`
+         */
+        if (isRuntimeHook(s.exp, Id._d_arrayappendT) || isRuntimeHook(s.exp, Id._d_arrayappendTTrace))
+        {
+            auto rs = new ReturnStatement(s.loc, e);
+            rs.accept(this);
+            return;
+        }
+
         // Disallow returning pointers to stack-allocated variables (bug 7876)
         if (!stopPointersEscaping(s.loc, e))
         {
@@ -4837,8 +4852,31 @@ public:
                 result = interpret(ce, istate);
                 return;
             }
-            else if (fd.ident == Id._d_arrayappendT)
-                assert(0, "CTFE cannot interpret _d_arrayappendT!");
+            else if (fd.ident == Id._d_arrayappendT || fd.ident == Id._d_arrayappendTTrace)
+            {
+                // In expressionsem.d `ea ~= eb` was lowered to `_d_arrayappendT{,Trace}({file, line, funcname}, ea, eb);`.
+                // The following code will rewrite it back to `ea ~= eb` and then interpret that expression.
+                Expression lhs, rhs;
+
+                if (fd.ident == Id._d_arrayappendT)
+                {
+                    assert(e.arguments.dim == 2);
+                    lhs = (*e.arguments)[0];
+                    rhs = (*e.arguments)[1];
+                }
+                else
+                {
+                    assert(e.arguments.dim == 5);
+                    lhs = (*e.arguments)[3];
+                    rhs = (*e.arguments)[4];
+                }
+
+                auto cae = new CatAssignExp(e.loc, lhs, rhs);
+                cae.type = e.type;
+
+                result = interpretRegion(cae, istate, CTFEGoal.LValue);
+                return;
+            }
             else if (fd.ident == Id._d_arrayappendcTX)
                 assert(0, "CTFE cannot interpret _d_arrayappendcTX!");
         }
@@ -4960,6 +4998,25 @@ public:
         debug (LOG)
         {
             printf("%s CommaExp::interpret() %s\n", e.loc.toChars(), e.toChars());
+        }
+
+        if (auto ce = isRuntimeHook(e.e1, Id._d_arrayappendcTX))
+        {
+            // In expressionsem.d `arr ~= elem` was lowered to
+            // `_d_arrayappendcTX(arr, elem), arr[arr.length - 1] = elem, elem;`.
+            // The following code will rewrite it back to `arr ~= elem`
+            // and then interpret that expression.
+            assert(ce.arguments.dim == 2);
+
+            auto arr = (*ce.arguments)[0];
+            auto elem = e.e2.isConstructExp().e2;
+            assert(elem);
+
+            auto cae = new CatAssignExp(e.loc, arr, elem);
+            cae.type = arr.type;
+
+            result = interpret(cae, istate);
+            return;
         }
 
         // If it creates a variable, and there's no context for
@@ -6373,6 +6430,33 @@ public:
     override void visit(ThrownExceptionExp e)
     {
         assert(0); // This should never be interpreted
+    }
+
+    /*********************************************
+     * Checks if the given expresion is a call to the runtime hook `id`.
+     * Params:
+     *    e = the expression to check
+     *    id = the identifier of the runtime hook
+     * Returns:
+     *    `e` cast to `CallExp` if it's the hook, `null` otherwise
+     */
+    private CallExp isRuntimeHook(Expression e, Identifier id)
+    {
+        if (auto ce = e.isCallExp())
+        {
+            if (auto ve = ce.e1.isVarExp())
+            {
+                if (auto fd = ve.var.isFuncDeclaration())
+                {
+                    // If `_d_HookTraceImpl` is found, resolve the underlying
+                    // hook and replace `e` and `fd` with it.
+                    removeHookTraceImpl(ce, fd);
+                    return fd.ident == id ? ce : null;
+                }
+            }
+        }
+
+        return null;
     }
 }
 

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2903,19 +2903,6 @@ elem* toElem(Expression e, IRState *irs)
 
     elem* visitCond(CondExp ce)
     {
-        if (auto ve = ce.econd.isVarExp)
-            if (ve.var.ident == Id.ctfe)
-            {
-                elem *e = toElem(ce.e2, irs);
-                if (irs.params.cov && ce.e2.loc.linnum)
-                    e = el_combine(incUsageElem(irs, ce.e2.loc), e);
-                if (tybasic(e.Ety) == TYstruct)
-                    e.ET = Type_toCtype(ce.e2.type);
-                elem_setLoc(e, ce.loc);
-                result = e;
-                return;
-            }
-
         elem *ec = toElem(ce.econd, irs);
 
         elem *eleft = toElem(ce.e1, irs);
@@ -4129,8 +4116,7 @@ elem *Dsymbol_toElem(Dsymbol s, IRState* irs)
         else
         {
             Symbol *sp = toSymbol(s);
-            if (sp.Ssymnum == -1)
-                symbol_add(sp);
+            symbol_add(sp);
             //printf("\tadding symbol '%s'\n", sp.Sident);
             if (vd._init)
             {

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2959,6 +2959,19 @@ elem* toElem(Expression e, IRState *irs)
 
     elem* visitCond(CondExp ce)
     {
+        if (auto ve = ce.econd.isVarExp)
+            if (ve.var.ident == Id.ctfe)
+            {
+                elem *e = toElem(ce.e2, irs);
+                if (irs.params.cov && ce.e2.loc.linnum)
+                    e = el_combine(incUsageElem(irs, ce.e2.loc), e);
+                if (tybasic(e.Ety) == TYstruct)
+                    e.ET = Type_toCtype(ce.e2.type);
+                elem_setLoc(e, ce.loc);
+                result = e;
+                return;
+            }
+
         elem *ec = toElem(ce.econd, irs);
 
         elem *eleft = toElem(ce.e1, irs);

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -4172,7 +4172,8 @@ elem *Dsymbol_toElem(Dsymbol s, IRState* irs)
         else
         {
             Symbol *sp = toSymbol(s);
-            symbol_add(sp);
+            if (sp.Ssymnum == -1)
+                symbol_add(sp);
             //printf("\tadding symbol '%s'\n", sp.Sident);
             if (vd._init)
             {

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2709,68 +2709,12 @@ elem* toElem(Expression e, IRState *irs)
 
             case EXP.concatenateAssign:
             {
-                // Append array
-                assert(tb2.ty == Tarray || tb2.ty == Tsarray);
-
-                assert(tb1n.equals(tb2.nextOf().toBasetype()));
-
-                /* e1 ~= e2 becomes
-                 * _d_arrayappendT(e2, ev, typeinfo), *ev
-                 */
-
-                if (irs.target.os == Target.OS.Windows && target.is64bit)
-                    e2 = addressElem(e2, tb2, true);
-                else
-                    e2 = useOPstrpar(e2);
-                elem *ep = el_params(e2, el_copytree(ev), getTypeInfo(ce.e1.loc, ce.e1.type, irs), null);
-                e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM.ARRAYAPPENDT)), ep);
-                toTraceGC(irs, e, ce.loc);
-                break;
+                assert(0, "This case should have been rewritten to `_d_arrayappendT` in the semantic phase");
             }
 
             case EXP.concatenateElemAssign:
             {
-                // Append element
-                assert(tb1n.equals(tb2));
-
-                elem *e2x = null;
-
-                if (e2.Eoper != OPvar && e2.Eoper != OPconst)
-                {
-                    // Evaluate e2 and assign result to temporary s2.
-                    // Do this because of:
-                    //    a ~= a[$-1]
-                    // because $ changes its value
-                    type* tx = Type_toCtype(tb2);
-                    Symbol *s2 = symbol_genauto(tx);
-                    e2x = elAssign(el_var(s2), e2, tb1n, tx);
-
-                    e2 = el_var(s2);
-                }
-
-                // Extend array with _d_arrayappendcTX(TypeInfo ti, e1, 1)
-                elem *ep = el_param(el_copytree(ev), getTypeInfo(ce.e1.loc, ce.e1.type, irs));
-                ep = el_param(el_long(TYsize_t, 1), ep);
-                e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM.ARRAYAPPENDCTX)), ep);
-                toTraceGC(irs, e, ce.loc);
-                Symbol *stmp = symbol_genauto(Type_toCtype(tb1));
-                e = el_bin(OPeq, TYdarray, el_var(stmp), e);
-
-                // Assign e2 to last element in stmp[]
-                // *(stmp.ptr + (stmp.length - 1) * szelem) = e2
-
-                elem *eptr = array_toPtr(tb1, el_var(stmp));
-                elem *elength = el_una(target.is64bit ? OP128_64 : OP64_32, TYsize_t, el_var(stmp));
-                elength = el_bin(OPmin, TYsize_t, elength, el_long(TYsize_t, 1));
-                elength = el_bin(OPmul, TYsize_t, elength, el_long(TYsize_t, ce.e2.type.size()));
-                eptr = el_bin(OPadd, TYnptr, eptr, elength);
-                elem *ederef = el_una(OPind, e2.Ety, eptr);
-
-                elem *eeq = elAssign(ederef, e2, tb1n, null);
-                e = el_combine(e2x, e);
-                e = el_combine(e, eeq);
-                e = el_combine(e, el_var(stmp));
-                break;
+                assert(0, "This case should have been rewritten to `_d_arrayappendcTX` in the semantic phase");
             }
 
             default:

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -6257,7 +6257,6 @@ extern (C++) final class UshrAssignExp : BinAssignExp
  */
 extern (C++) class CatAssignExp : BinAssignExp
 {
-    bool isCTFEHookPart;
     extern (D) this(const ref Loc loc, Expression e1, Expression e2)
     {
         super(loc, EXP.concatenateAssign, __traits(classInstanceSize, CatAssignExp), e1, e2);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -6256,6 +6256,7 @@ extern (C++) final class UshrAssignExp : BinAssignExp
  */
 extern (C++) class CatAssignExp : BinAssignExp
 {
+    bool isCTFEHookPart;
     extern (D) this(const ref Loc loc, Expression e1, Expression e2)
     {
         super(loc, EXP.concatenateAssign, __traits(classInstanceSize, CatAssignExp), e1, e2);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1457,7 +1457,8 @@ extern (C++) abstract class Expression : ASTNode
 
                 // Lowered non-@nogc'd hooks will print their own error message inside of nogc.d (NOGCVisitor.visit(CallExp e)),
                 // so don't print anything to avoid double error messages.
-                if (!(f.ident == Id._d_HookTraceImpl || f.ident == Id._d_arraysetlengthT))
+                if (!(f.ident == Id._d_HookTraceImpl || f.ident == Id._d_arraysetlengthT
+                    || f.ident == Id._d_arrayappendT || f.ident == Id._d_arrayappendcTX))
                     error("`@nogc` %s `%s` cannot call non-@nogc %s `%s`",
                         sc.func.kind(), sc.func.toPrettyChars(), f.kind(), f.toPrettyChars());
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8250,6 +8250,11 @@ struct Id final
     static Identifier* _d_arraysetlengthTImpl;
     static Identifier* _d_arraysetlengthT;
     static Identifier* _d_arraysetlengthTTrace;
+    static Identifier* _d_arrayappendT;
+    static Identifier* _d_arrayappendTTrace;
+    static Identifier* _d_arrayappendcTXImpl;
+    static Identifier* _d_arrayappendcTX;
+    static Identifier* _d_arrayappendcTXTrace;
     static Identifier* stdc;
     static Identifier* stdarg;
     static Identifier* va_start;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -349,7 +349,6 @@ immutable Msgtable[] msgtable =
     { "_d_arraysetlengthTImpl"},
     { "_d_arraysetlengthT"},
     { "_d_arraysetlengthTTrace"},
-    { "_d_arrayappendTImpl" },
     { "_d_arrayappendT" },
     { "_d_arrayappendTTrace" },
     { "_d_arrayappendcTXImpl" },

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -349,6 +349,12 @@ immutable Msgtable[] msgtable =
     { "_d_arraysetlengthTImpl"},
     { "_d_arraysetlengthT"},
     { "_d_arraysetlengthTTrace"},
+    { "_d_arrayappendTImpl" },
+    { "_d_arrayappendT" },
+    { "_d_arrayappendTTrace" },
+    { "_d_arrayappendcTXImpl" },
+    { "_d_arrayappendcTX" },
+    { "_d_arrayappendcTXTrace" },
 
     // varargs implementation
     { "stdc" },

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -84,6 +84,17 @@ public:
             }
             f.printGCUsage(e.loc, "setting `length` may cause a GC allocation");
         }
+        else if (fd.ident == Id._d_arrayappendT || fd.ident == Id._d_arrayappendcTX)
+        {
+            if (f.setGC())
+            {
+                e.error("cannot use operator `~=` in `@nogc` %s `%s`",
+                    f.kind(), f.toPrettyChars());
+                err = true;
+                return;
+            }
+            f.printGCUsage(e.loc, "operator `~=` may cause a GC allocation");
+        }
     }
 
     override void visit(ArrayLiteralExp e)
@@ -181,14 +192,15 @@ public:
 
     override void visit(CatAssignExp e)
     {
+        /* CatAssignExp will exist in `__traits(compiles, ...)` and in the `.e1` branch of a `__ctfe ? :` CondExp.
+         * The other branch will be `_d_arrayappendcTX(e1, 1), e1[$-1]=e2` which will generate the warning about
+         * GC usage. See visit(CallExp).
+         */
         if (f.setGC())
         {
-            e.error("cannot use operator `~=` in `@nogc` %s `%s`",
-                f.kind(), f.toPrettyChars());
             err = true;
             return;
         }
-        f.printGCUsage(e.loc, "operator `~=` may cause a GC allocation");
     }
 
     override void visit(CatExp e)

--- a/test/compilable/extra-files/vcg-ast.d.cg
+++ b/test/compilable/extra-files/vcg-ast.d.cg
@@ -90,8 +90,7 @@ enum __c_wchar_t : dchar;
 alias wchar_t = __c_wchar_t;
 T[] values(T)()
 {
-	T[] values;
-	values ~= T();
+	T[] values = [T()];
 	return values;
 }
 void main()
@@ -139,8 +138,7 @@ values!(__c_wchar_t)
 {
 	pure nothrow @safe __c_wchar_t[] values()
 	{
-		__c_wchar_t[] values = null;
-		values ~= cast(__c_wchar_t)'\uffff';
+		__c_wchar_t[] values = [cast(__c_wchar_t)'\uffff'];
 		return values;
 	}
 
@@ -150,3 +148,4 @@ RTInfo!(_R)
 	enum immutable(void)* RTInfo = null;
 
 }
+

--- a/test/compilable/test3004.d
+++ b/test/compilable/test3004.d
@@ -1,13 +1,15 @@
 // https://issues.dlang.org/show_bug.cgi?id=3004
 /*
 REQUIRED_ARGS: -ignore -v
-TRANSFORM_OUTPUT: remove_lines("^(predefs|binary|version|config|DFLAG|parse|import|semantic|entry|function  object|\s*$)")
+TRANSFORM_OUTPUT: remove_lines("^(predefs|binary|version|config|DFLAG|parse|import|semantic|entry|library|function  object|\s*$)")
 TEST_OUTPUT:
 ---
 pragma    GNU_attribute (__error)
 pragma    GNU_attribute (__error)
 code      test3004
 function  test3004.test
+function  core.internal.array.appending._d_arrayappendcTXImpl!(char[], char)._d_arrayappendcTX
+function  core.internal.array.utils._d_HookTraceImpl!(char[], _d_arrayappendcTX, "Cannot append to array if compiling without support for runtime type information!")._d_HookTraceImpl
 ---
 */
 

--- a/test/compilable/vcg-ast.d
+++ b/test/compilable/vcg-ast.d
@@ -52,8 +52,7 @@ alias wchar_t = __c_wchar_t;
 
 T[] values(T)()
 {
-    T[] values;
-    values ~= T();
+    T[] values = [T()];
     return values;
 }
 

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -3454,6 +3454,21 @@ void test113()
 }
 
 /************************************************/
+
+bool test114()
+{
+    string fizzBuzz()
+    {
+        string result = "fizz ";
+        return result ~= "buzz";
+    }
+
+    assert(fizzBuzz() == "fizz buzz");
+    return true;
+}
+static assert(test114());
+
+/************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=14140
 
 struct S14140
@@ -3852,6 +3867,7 @@ int main()
     test109();
     test112();
     test113();
+    test114();
     test6439();
     test6504();
     test8818();


### PR DESCRIPTION
This PR lowers expressions such as `a ~= b` to:
```d
_d_arrayappendcTX(a, 1), a[a.length - 1] = b, a;
// Note that the assignment above is actually a construction.
```
when `b` is a single element, or
```d
_d_arrayappendT(a, b);
```
when `b` is an array. These lowerings are now moved to the compiler's frontend, as opposed to e2ir.d.

This revives https://github.com/dlang/dmd/pull/9982.