### PR TITLE
Fix Issue 22536 - CTFE: Missing destruction of array literal argument for scope slice parameter

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -734,6 +734,11 @@ private Expression interpretFunction(UnionExp* pue, FuncDeclaration fd, InterSta
             e = CTFEExp.cantexp;
             break;
         }
+        if (CTFEExp.isCantExp(res))
+        {
+            e = res;
+            break;
+        }
     }
 
     return e;

--- a/test/fail_compilation/fail22536.d
+++ b/test/fail_compilation/fail22536.d
@@ -1,0 +1,29 @@
+// https://issues.dlang.org/show_bug.cgi?id=22536
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail22536.d(22): Error: uncaught CTFE exception `object.Exception("exception")`
+fail_compilation/fail22536.d(25):        called from here: `foo(((S[2] __arrayliteral_on_stack3 = [S(1), S(2)];) , cast(S[])__arrayliteral_on_stack3))`
+fail_compilation/fail22536.d(29):        called from here: `bar()`
+fail_compilation/fail22536.d(29):        while evaluating: `static assert(bar())`
+---
+*/
+
+void foo(T)(scope T[]) {}
+
+int bar()
+{
+    int numDtor;
+
+    struct S
+    {
+        int x;
+        ~this() { throw new Exception("exception");}
+    }
+
+    foo([S(1), S(2)]);
+    return numDtor;
+}
+
+static assert(bar()); // fails, returns 0

--- a/test/fail_compilation/fail22536.d
+++ b/test/fail_compilation/fail22536.d
@@ -3,10 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22536.d(22): Error: uncaught CTFE exception `object.Exception("exception")`
-fail_compilation/fail22536.d(25):        called from here: `foo(((S[2] __arrayliteral_on_stack3 = [S(1), S(2)];) , cast(S[])__arrayliteral_on_stack3))`
-fail_compilation/fail22536.d(29):        called from here: `bar()`
-fail_compilation/fail22536.d(29):        while evaluating: `static assert(bar())`
+fail_compilation/fail22536.d(21): Error: uncaught CTFE exception `object.Exception("exception")`
+fail_compilation/fail22536.d(28): Error: static assert:  `bar()` is false
+
 ---
 */
 

--- a/test/runnable/previewin.d
+++ b/test/runnable/previewin.d
@@ -116,6 +116,23 @@ void testForeach() @safe pure
         testMsg(k_loop, v_loop);
 }
 
+// test proper destruction at CTFE
+static assert(previewIn() == 1);
+int previewIn()
+{
+    int numDtor;
+
+    struct S
+    {
+        int x;
+        ~this() { ++numDtor; }
+    }
+
+    static accept(in S s) {}
+    accept(S(1));
+    return numDtor;
+}
+
 struct ValueT { int value; }
 struct RefT   { ulong[64] value; }
 

--- a/test/runnable/test22536.d
+++ b/test/runnable/test22536.d
@@ -1,0 +1,43 @@
+// https://issues.dlang.org/show_bug.cgi?id=22536
+
+void foo(T)(scope T[]) {}
+
+void foo(T)(scope T[], scope T[]) {}
+
+int bar()
+{
+    int numDtor;
+
+    struct S
+    {
+        int x;
+        ~this() { ++numDtor; }
+    }
+
+    foo([S(1), S(2)]);
+    return numDtor;
+}
+
+int bar2()
+{
+
+    int numDtor;
+
+    struct S
+    {
+        int x;
+        ~this() { ++numDtor; }
+    }
+
+    foo([S(1), S(2)], [S(3), S(4)]);
+    return numDtor;
+}
+
+void main()
+{
+    assert(bar() == 2);
+    assert(bar2() == 4);
+}
+
+static assert(bar() == 2);
+static assert(bar2() == 4);

--- a/test/runnable/test22536.d
+++ b/test/runnable/test22536.d
@@ -32,11 +32,38 @@ int bar2()
     return numDtor;
 }
 
+static assert(bar() == 2);
+static assert(bar2() == 4);
+
+// Test proper destruction at end of statement
+
+struct Inc
+{
+    int* ptr;
+    ~this()
+    {
+        (*ptr)++;
+    }
+}
+
+int* boo(scope Inc[] arr)
+{
+    return arr[0].ptr;
+}
+
+int boo()
+{
+    int i;
+    assert(*boo([ Inc(&i) ]) == 0);
+    return 0;
+}
+
+static assert(boo() == 0);
+
+// test that the runnable behavior matches CTFE
 void main()
 {
     assert(bar() == 2);
     assert(bar2() == 4);
+    assert(boo() == 0);
 }
-
-static assert(bar() == 2);
-static assert(bar2() == 4);

--- a/test/runnable/test22536.d
+++ b/test/runnable/test22536.d
@@ -1,7 +1,6 @@
 // https://issues.dlang.org/show_bug.cgi?id=22536
 
 void foo(T)(scope T[]) {}
-
 void foo(T)(scope T[], scope T[]) {}
 
 int bar()


### PR DESCRIPTION
It appears that CTFE does not know how to destroy array literal temporaries that are put on stack. My solution first collects the temporary destructors that are created here [1] and interprets them after the function call was interpreted.

[1] https://github.com/dlang/dmd/blob/master/src/dmd/expressionsem.d#L2074