### PR TITLE
Turn switch case fallthrough into an error

### DIFF
--- a/changelog/switch_fallthrough_error.dd
+++ b/changelog/switch_fallthrough_error.dd
@@ -1,0 +1,27 @@
+Falling through switch cases is now an error
+
+This was deprectated in 2.072.2 because it is a common mistake to forget a `break` statement at the end of a switch case.
+The deprecation warning has now been turned into an error.
+
+If you intend to let control flow continue from one case to the next, use the `goto case;` statement.
+
+---
+void parseNumFmt(char c, out int base, out bool uppercase)
+{
+    switch (c)
+    {
+        case 'B': // fallthrough allowed, case has no code
+        case 'b':
+            base = 2;
+            // error, accidental fallthrough to case 'X'
+        case 'X':
+            uppercase = true;
+            goto case; // allowed, explicit fallthrough
+        case 'x':
+            base = 16;
+            break;
+        default:
+            break;
+    }
+}
+---

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -149,7 +149,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                             else if (!func.getModule().isCFile)
                             {
                                 const(char)* gototype = s.isCaseStatement() ? "case" : "default";
-                                s.deprecation("switch case fallthrough - use 'goto %s;' if intended", gototype);
+                                s.error("switch case fallthrough - use 'goto %s;' if intended", gototype);
                             }
                         }
                     }

--- a/test/fail_compilation/b16967.d
+++ b/test/fail_compilation/b16967.d
@@ -1,9 +1,8 @@
 /*
- * REQUIRED_ARGS: -c
  * TEST_OUTPUT:
 ---
-compilable/b16967.d(16): Deprecation: switch case fallthrough - use 'goto default;' if intended
-compilable/b16967.d(26): Deprecation: switch case fallthrough - use 'goto default;' if intended
+fail_compilation/b16967.d(15): Error: switch case fallthrough - use 'goto default;' if intended
+fail_compilation/b16967.d(25): Error: switch case fallthrough - use 'goto default;' if intended
 ---
 */
 int foo(int x)

--- a/test/fail_compilation/fail11653.d
+++ b/test/fail_compilation/fail11653.d
@@ -1,9 +1,8 @@
-// REQUIRED_ARGS: -de
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11653.d(19): Deprecation: switch case fallthrough - use 'goto case;' if intended
-fail_compilation/fail11653.d(24): Deprecation: switch case fallthrough - use 'goto default;' if intended
+fail_compilation/fail11653.d(18): Error: switch case fallthrough - use 'goto case;' if intended
+fail_compilation/fail11653.d(23): Error: switch case fallthrough - use 'goto default;' if intended
 ---
 */
 


### PR DESCRIPTION
This was deprecated in 2016: https://github.com/dlang/dmd/pull/6206
I think that's long enough.