### PR TITLE
Fix issue 19178 - Static initialization of 2d static arrays in structs

### DIFF
--- a/compiler/test/compilable/extra-files/vcg-ast.d.cg
+++ b/compiler/test/compilable/extra-files/vcg-ast.d.cg
@@ -133,7 +133,7 @@ RTInfo!(C)
 }
 NoPointersBitmapPayload!1$?:32=u|64=LU$
 {
-	enum $?:32=uint|64=ulong$[1] NoPointersBitmapPayload = 0$?:32=u|64=LU$;
+	enum $?:32=uint|64=ulong$[1] NoPointersBitmapPayload = [0$?:32=u|64=LU$];
 
 }
 values!(__c_wchar_t)

--- a/compiler/test/runnable/test8.d
+++ b/compiler/test/runnable/test8.d
@@ -592,6 +592,44 @@ void test34()
 }
 
 /***********************************/
+// https://issues.dlang.org/show_bug.cgi?id=19178
+
+float[3][4] arr2f = 10;
+Int3_4[1] arr3i = 20;
+short[3][4][1][1] arr4s = 30;
+
+enum Int3 : int[3] {
+    a = [0, 1, 2],
+}
+
+enum Int3_4 : Int3[4] {
+    b = Int3[4].init,
+}
+
+struct S35
+{
+    int[3][3] arr = [2, 1];
+}
+
+void test35()
+{
+    for (int i = 0; i < 4; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            // printf("[%d %d]: %f %d %d\n", i, j, arr2f[i][j], arr3i[0][i][j], arr4s[0][0][i][j]);
+            assert(arr2f[i][j] == 10);
+            assert(arr3i[0][i][j] == 20);
+            assert(arr4s[0][0][i][j] == 30);
+        }
+    }
+
+    S35 t = S35.init;
+    assert(t.arr[0] == [2, 2, 2]);
+    assert(t.arr[1] == [1, 1, 1]);
+    assert(t.arr[2] == [0, 0, 0]);
+}
+/***********************************/
 
 string itoa(int i)
 {
@@ -868,6 +906,7 @@ int main()
     test32();
     test33();
     test34();
+    test35();
     test36();
     test37();
     test38();


### PR DESCRIPTION
`initSem` only looks at the top level static array, I made it look deeper in a for loop.

> If the variable is not actually used in compile time, array creation is
> redundant. So delay it until invocation of toExpression() or toDt().

~~Currently the logic for detecting the case of initializing a static array with an element is duplicated in `toExpression` and `toDt`, so I created a `RepeatInitializer` class so that the logic (which is now more complex) does not need to be duplicated there anymore.~~

~~I am a bit skeptical of the benefit of lazily generating the initializer in case it's not used, instead of simply eagerly turning it into an `ArrayInitializer`, but I decided to keep it for now.~~

Edit: it now just creates an `ArrayInitializer`