### PR TITLE
Fix Issue 22672 - Allow casting from TypeTuple to TypeTuple

### DIFF
--- a/changelog/allow_casting_from_typetuple_to_typetuple.dd
+++ b/changelog/allow_casting_from_typetuple_to_typetuple.dd
@@ -1,0 +1,20 @@
+Casting between compatible tuples
+
+Prior to this release, casting between built-in tuples of the same type was not allowed.
+
+Starting with this release, casting between tuples of the same length is accepted provided that the underlying types of the casted tuple are implicitly convertible to the target tuple types.
+
+---
+alias Tuple(T...) = T;
+
+void foo()
+{
+    Tuple!(int, int) tup;
+
+    auto foo = cast(long) tup;
+    pragma(msg, typeof(foo)); // (int, int)
+
+    auto bar = cast(Tuple!(long, int)) tup; // allowed
+    pragma(msg, typeof(bar)); // (long, int)
+}
+---

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2245,9 +2245,12 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                 ex = ex.castTo(sc, totuple ? (*totuple.arguments)[i].type : t);
                 (*te.exps)[i] = ex;
             }
+            if (totuple)
+                te.type = totuple;
             result = te;
 
-            /* Questionable behavior: In here, result.type is not set to t.
+            /* Questionable behavior: In here, result.type is not set to t
+             *  if target type is not a tuple of same length.
              * Therefoe:
              *  TypeTuple!(int, int) values;
              *  auto values2 = cast(long)values;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7511,6 +7511,17 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // https://issues.dlang.org/show_bug.cgi?id=19954
         if (exp.e1.type.ty == Ttuple)
         {
+            if (exp.to)
+            {
+                if (TypeTuple tt = exp.to.isTypeTuple())
+                {
+                    if (exp.e1.type.implicitConvTo(tt))
+                    {
+                        result = exp.e1.castTo(sc, tt);
+                        return;
+                    }
+                }
+            }
             TupleExp te = exp.e1.isTupleExp();
             if (te.exps.dim == 1)
                 exp.e1 = (*te.exps)[0];
@@ -7531,7 +7542,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (exp.to.ty == Ttuple)
         {
-            exp.error("cannot cast `%s` to tuple type `%s`", exp.e1.toChars(), exp.to.toChars());
+            exp.error("cannot cast `%s` of type `%s` to tuple type `%s`", exp.e1.toChars(), exp.e1.type.toChars(), exp.to.toChars());
             return setError();
         }
 

--- a/test/compilable/casttuple.d
+++ b/test/compilable/casttuple.d
@@ -1,0 +1,31 @@
+alias tuple(T...) = T;
+
+void exactMatch()
+{
+    tuple!int tup_1;
+
+    auto i = cast() tup_1;
+    static assert(is(typeof(i) == int));
+    const i_const = cast(const) tup_1;
+    static assert(is(typeof(i_const) == const int));
+
+    auto totup_1 = cast(tuple!int) tup_1;
+    static assert(is(typeof(totup_1) == tuple!int));
+
+    tuple!(int, int) tup_2;
+    auto totup_2 = cast(tuple!(int, int)) tup_2;
+    static assert(is(typeof(totup_2) == tuple!(int, int)));
+}
+
+void implicitConv()
+{
+    tuple!short tup_1;
+    auto totup_1 = cast(tuple!int) tup_1;
+    static assert(is(typeof(tup_1) == tuple!short));
+    static assert(is(typeof(totup_1) == tuple!int));
+
+    tuple!(short, short) tup_2;
+    auto totup_2 = cast(tuple!(int, int)) tup_2;
+    static assert(is(typeof(tup_2) == tuple!(short, short)));
+    static assert(is(typeof(totup_2) == tuple!(int, int)));
+}

--- a/test/fail_compilation/casttuple.d
+++ b/test/fail_compilation/casttuple.d
@@ -1,0 +1,25 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/casttuple.d(104): Error: cannot cast `__tup1_field_0` of type `int` to tuple type `(string)`
+fail_compilation/casttuple.d(107): Error: cannot cast `tuple(__tup2_field_0, __tup2_field_1)` of type `(int, int)` to tuple type `(string, string)`
+fail_compilation/casttuple.d(111): Error: cannot cast `tuple(foo, 123)` of type `(int, int)` to tuple type `(string, string)`
+---
+ */
+
+alias tuple(T...) = T;
+
+#line 100
+
+void nomatch()
+{
+    tuple!int tup1;
+    auto x = cast(tuple!string) tup1;
+
+    tuple!(int, int) tup2;
+    auto y = cast(tuple!(string, string)) tup2;
+
+    int foo;
+    alias tup3 = tuple!(foo, 123);
+    auto z = cast(tuple!(string, string)) tup3;
+}


### PR DESCRIPTION
Currently DMD does not allow casting to TypeTuple even if they
are the same type is.
This is a bit odd, so only allow it in certain case.