### PR TITLE
implement cent conversion operators OPs64_128, OPu64_128, OP128_64 in backend

### DIFF
--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -3613,7 +3613,8 @@ void cdshtlng(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     else if (
              op == OPnp_fp ||
              (I16 && op == OPu16_32) ||
-             (I32 && op == OPu32_64)
+             (I32 && op == OPu32_64) ||
+             (I64 && op == OPu64_128)
             )
     {
         /* Result goes into a register pair.
@@ -3808,7 +3809,7 @@ void cdshtlng(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     }
     else
     {
-        // OPs16_32, OPs32_64
+        // OPs16_32, OPs32_64, OPs64_128
         uint msreg,lsreg;
 
         retregs = *pretregs & mLSW;


### PR DESCRIPTION
It turns out that 128 bit support for I64 is just like 64 bit support for I32. So we can easily support `cent` operations for 64 bit compilations.

But not so easy for I32, which requires 4 registers to hold a value. That will need https://github.com/dlang/druntime/pull/3663

This change gets the cast operators to work for cents on 64 bit targets. Can't test it yet, because blocked by https://github.com/dlang/dmd/pull/13506