### PR TITLE
allow custom error message in template constraints

### DIFF
--- a/changelog/custom_constraint_errors.dd
+++ b/changelog/custom_constraint_errors.dd
@@ -1,0 +1,38 @@
+Library authors can now provide error messages for template constraint failures
+
+Constraints like `isInputRange` can now return a custom struct that casts to
+`bool` and defines a `toString` method. When the expression evaluates to false,
+(returns false in the opCast) the toString method is evaluated and printed with
+the template error message when a constraint does not match.
+
+---
+// test.d
+struct ConstraintInfo {
+	bool matches;
+	string errorMessage;
+
+	bool opCast() const { return matches; }
+	string toString() const { return errorMessage; }
+}
+
+enum ConstraintInfo isSmallEnough(T) = ConstraintInfo(T.sizeof <= 4,
+	T.stringof ~ " must be smaller or equal than 4 bytes, but is "
+		~ T.sizeof.stringof ~ " bytes large");
+
+void foo(T)(T arg) if (isSmallEnough!T) {}
+
+void main() {
+	foo(4);
+	foo(long(4));
+}
+---
+
+now results in:
+
+---
+test.d(18): Error: template `test.foo` cannot deduce function from argument types `!()(long)`
+test.d(14):        Candidate is: `foo(T)(T arg)`
+  with `T = long`
+  must satisfy the following constraint:
+`       isSmallEnough!T: long must be smaller or equal than 4 bytes, but is 8LU bytes large
+---

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -574,7 +574,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
     TemplatePrevious* previous;
 
     private Expression lastConstraint; /// the constraint after the last failed evaluation
-    private Array!FailedExpression lastConstraintNegs; /// its negative parts (raw, evaluated)
+    private Array!ConstraintFailResult lastConstraintNegs; /// its negative parts (raw, evaluated)
     private Objects* lastConstraintTiargs; /// template instance arguments for `lastConstraint`
 
     extern (D) this(const ref Loc loc, Identifier ident, TemplateParameters* parameters, Expression constraint, Dsymbols* decldefs, bool ismixin = false, bool literal = false)

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -71,6 +71,7 @@ import dmd.common.outbuffer;
 import dmd.root.rootobject;
 import dmd.semantic2;
 import dmd.semantic3;
+import dmd.staticcond;
 import dmd.tokens;
 import dmd.typesem;
 import dmd.visitor;
@@ -573,7 +574,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
     TemplatePrevious* previous;
 
     private Expression lastConstraint; /// the constraint after the last failed evaluation
-    private Array!Expression lastConstraintNegs; /// its negative parts
+    private Array!FailedExpression lastConstraintNegs; /// its negative parts (raw, evaluated)
     private Objects* lastConstraintTiargs; /// template instance arguments for `lastConstraint`
 
     extern (D) this(const ref Loc loc, Identifier ident, TemplateParameters* parameters, Expression constraint, Dsymbols* decldefs, bool ismixin = false, bool literal = false)
@@ -887,8 +888,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         lastConstraintTiargs = ti.tiargs;
         lastConstraintNegs.setDim(0);
 
-        import dmd.staticcond;
-
         assert(ti.inst is null);
         ti.inst = ti; // temporary instantiation to enable genIdent()
         bool errors;
@@ -915,8 +914,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
      */
     const(char)* getConstraintEvalError(ref const(char)* tip)
     {
-        import dmd.staticcond;
-
         // there will be a full tree view in verbose mode, and more compact list in the usual
         const full = global.params.verbose;
         uint count;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1712,6 +1712,21 @@ struct AssocArray final
     }
 };
 
+struct ConstraintFailResult final
+{
+    Expression* raw;
+    _d_dynamicArray< const char > failMessage;
+    ConstraintFailResult() :
+        raw(),
+        failMessage()
+    {
+    }
+    ConstraintFailResult(Expression* raw, _d_dynamicArray< const char > failMessage = {}) :
+        raw(raw),
+        failMessage(failMessage)
+        {}
+};
+
 enum class TY : uint8_t
 {
     Tarray = 0u,
@@ -6346,7 +6361,7 @@ public:
     TemplatePrevious* previous;
 private:
     Expression* lastConstraint;
-    Array<Expression* > lastConstraintNegs;
+    Array<ConstraintFailResult > lastConstraintNegs;
     Array<RootObject* >* lastConstraintTiargs;
 public:
     TemplateDeclaration* syntaxCopy(Dsymbol* _param_0);

--- a/src/dmd/staticcond.d
+++ b/src/dmd/staticcond.d
@@ -27,7 +27,7 @@ import dmd.tokens;
 
 
 
-struct FailedExpression
+struct ConstraintFailResult
 {
     Expression raw;
     const(char)[] failMessage;
@@ -47,7 +47,7 @@ struct FailedExpression
  * Returns:
  *      true if evaluates to true
  */
-bool evalStaticCondition(Scope* sc, Expression original, Expression e, out bool errors, Array!FailedExpression* negatives = null)
+bool evalStaticCondition(Scope* sc, Expression original, Expression e, out bool errors, Array!ConstraintFailResult* negatives = null)
 {
     if (negatives)
         negatives.setDim(0);
@@ -130,11 +130,11 @@ bool evalStaticCondition(Scope* sc, Expression original, Expression e, out bool 
                 resolved = resolved.callToString(sc);
                 OutBuffer buf;
                 expressionsToString(buf, sc, (&resolved)[0 .. 1]);
-                negatives.push(FailedExpression(before, buf.extractSlice()));
+                negatives.push(ConstraintFailResult(before, buf.extractSlice()));
             }
             else
             {
-                negatives.push(FailedExpression(before));
+                negatives.push(ConstraintFailResult(before));
             }
         }
         return opt.get();
@@ -156,7 +156,7 @@ bool evalStaticCondition(Scope* sc, Expression original, Expression e, out bool 
  *      instantiated expression is not based on the original one
  */
 const(char)* visualizeStaticCondition(Expression original, Expression instantiated,
-    const FailedExpression[] negatives, bool full, ref uint itemCount)
+    const ConstraintFailResult[] negatives, bool full, ref uint itemCount)
 {
     if (!original || !instantiated || original.loc !is instantiated.loc)
         return null;
@@ -172,7 +172,7 @@ const(char)* visualizeStaticCondition(Expression original, Expression instantiat
 }
 
 private uint visualizeFull(Expression original, Expression instantiated,
-    const FailedExpression[] negatives, ref OutBuffer buf)
+    const ConstraintFailResult[] negatives, ref OutBuffer buf)
 {
     // tree-like structure; traverse and format simultaneously
     uint count;
@@ -318,7 +318,7 @@ private uint visualizeFull(Expression original, Expression instantiated,
 }
 
 private uint visualizeShort(Expression original, Expression instantiated,
-    const FailedExpression[] negatives, ref OutBuffer buf)
+    const ConstraintFailResult[] negatives, ref OutBuffer buf)
 {
     // simple list; somewhat similar to long version, so no comments
     // one difference is that it needs to hold items to display in a stack

--- a/test/fail_compilation/custom_constraint_errors.d
+++ b/test/fail_compilation/custom_constraint_errors.d
@@ -1,0 +1,28 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/custom_constraint_errors.d(27): Error: template `custom_constraint_errors.foo` cannot deduce function from argument types `!()(long)`
+fail_compilation/custom_constraint_errors.d(23):        Candidate is: `foo(T)(T arg)`
+  with `T = long`
+  must satisfy the following constraint:
+`       isSmallEnough!T: long must be smaller or equal than 4 bytes`
+---
+*/
+
+struct ConstraintInfo {
+	bool matches;
+	string errorMessage;
+
+	bool opCast() const { return matches; }
+	string toString() const { return errorMessage; }
+}
+
+enum ConstraintInfo isSmallEnough(T) = ConstraintInfo(T.sizeof <= 4,
+	T.stringof ~ " must be smaller or equal than 4 bytes");
+
+void foo(T)(T arg) if (isSmallEnough!T) {}
+
+void main() {
+	foo(4);
+	foo(long(4));
+}


### PR DESCRIPTION
Constraints like `isInputRange` can now return a custom struct that casts to `bool` and defines a `toString` method. When the expression evaluates to false, (returns false in the opCast) the toString method is evaluated and printed with the template error message when a constraint does not match.

The future syntax / semantics is backwards compatible with current dmd.

Just an idea, thought of this because of this forum thread: https://forum.dlang.org/thread/clyiounnxlnupinbafpy@forum.dlang.org

Example with input ranges using the range_primitives_helper library:

```d
import std.stdio;
import std.string;
import range_primitives_helper;

import std.range :
	origIsInputRange = isInputRange,
	origIsRandomAccessRange = isRandomAccessRange
;

struct ConstraintInfo
{
	bool matches;
	string errorMessage;

	bool opCast() const { return matches; }
	string toString() const { return errorMessage; }
}

enum isInputRange(T) = ConstraintInfo(origIsInputRange!T, isInputRangeErrorFormatter!T.replace("\n", "\n\t"));
enum isRandomAccessRange(T) = ConstraintInfo(origIsRandomAccessRange!T, isRandomAccessRangeErrorFormatter!T.replace("\n", "\n\t"));

void fun(T)(T t) if(isInputRange!T && !isRandomAccessRange!T) {}

void fun(T)(T t) if(isRandomAccessRange!T) {}

struct Sample1
{
	auto front() @property { return null; }
	bool empty = true;
}

struct Sample2
{
	auto front() @property { return null; }
	bool empty = true;
	void popFront() {}
}

void test()
{
	Sample1 s1;
	Sample2 s2;
	fun(s1);
	fun(s2);
}
```

outputs:
```
Performing "debug" build using ../dmd/generated/linux/release/64/dmd for x86_64.
range_primitives_helper 1.0.0: target for configuration "library" is up to date.
test_inputrange ~master: building configuration "application"...
source/app.d(43,5): Error: template `app.fun` cannot deduce function from argument types `!()(Sample1)`
source/app.d(22,6):        Candidates are: `fun(T)(T t)`
  with `T = Sample1`
  must satisfy the following constraint:
`       isInputRange!T: Sample1 is not an InputRange because:
                the function 'popFront' does not exist`
source/app.d(24,6):                        `fun(T)(T t)`
  with `T = Sample1`
  must satisfy the following constraint:
`       isRandomAccessRange!T: Sample1 is not an RandomAccessRange because
                the function 'popFront' does not exist
                and the property 'save' does not exist
                and must allow for array indexing, aka. [] access`
../dmd/generated/linux/release/64/dmd failed with exit code 1.
```

What could be improved: the indentation should probably be made on the dmd side instead of in this example in the code, but I would like to suggest the change as-is first.