### PR TITLE
Split up MSVC and DigitalMars C++ mangling into separate functions

### DIFF
--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -42,11 +42,23 @@ extern (C++):
 
 const(char)* toCppMangleMSVC(Dsymbol s)
 {
-    scope VisualCPPMangler v = new VisualCPPMangler(!target.mscoff, s.loc);
+    scope VisualCPPMangler v = new VisualCPPMangler(false, s.loc);
     return v.mangleOf(s);
 }
 
 const(char)* cppTypeInfoMangleMSVC(Dsymbol s)
+{
+    //printf("cppTypeInfoMangle(%s)\n", s.toChars());
+    assert(0);
+}
+
+const(char)* toCppMangleDMC(Dsymbol s)
+{
+    scope VisualCPPMangler v = new VisualCPPMangler(true, s.loc);
+    return v.mangleOf(s);
+}
+
+const(char)* cppTypeInfoMangleDMC(Dsymbol s)
 {
     //printf("cppTypeInfoMangle(%s)\n", s.toChars());
     assert(0);
@@ -62,7 +74,7 @@ const(char)* cppTypeInfoMangleMSVC(Dsymbol s)
  *      true if type is shared or immutable
  *      false otherwise
  */
-private bool checkImmutableShared(Type type, Loc loc)
+private extern (D) bool checkImmutableShared(Type type, Loc loc)
 {
     if (type.isImmutable() || type.isShared())
     {
@@ -72,6 +84,7 @@ private bool checkImmutableShared(Type type, Loc loc)
     }
     return false;
 }
+
 private final class VisualCPPMangler : Visitor
 {
     enum VC_SAVED_TYPE_CNT = 10u;
@@ -751,7 +764,7 @@ extern(D):
      *      tv              = template value
      *      is_dmc_template = use DMC mangling
      */
-    void manlgeTemplateValue(RootObject o,TemplateValueParameter tv, Dsymbol sym,bool is_dmc_template)
+    void mangleTemplateValue(RootObject o, TemplateValueParameter tv, Dsymbol sym, bool is_dmc_template)
     {
         if (!tv.valType.isintegral())
         {
@@ -979,7 +992,7 @@ extern(D):
             }
             if (tv)
             {
-                tmp.manlgeTemplateValue(o, tv, actualti, is_dmc_template);
+                tmp.mangleTemplateValue(o, tv, actualti, is_dmc_template);
             }
             else
             if (!tp || tp.isTemplateTypeParameter())

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5550,6 +5550,10 @@ extern const char* toCppMangleMSVC(Dsymbol* s);
 
 extern const char* cppTypeInfoMangleMSVC(Dsymbol* s);
 
+extern const char* toCppMangleDMC(Dsymbol* s);
+
+extern const char* cppTypeInfoMangleDMC(Dsymbol* s);
+
 class ClassReferenceExp final : public Expression
 {
 public:

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1257,12 +1257,17 @@ struct TargetCPP
     extern (C++) const(char)* toMangle(Dsymbol s)
     {
         import dmd.cppmangle : toCppMangleItanium;
-        import dmd.cppmanglewin : toCppMangleMSVC;
+        import dmd.cppmanglewin : toCppMangleDMC, toCppMangleMSVC;
 
         if (target.os & (Target.OS.linux | Target.OS.OSX | Target.OS.FreeBSD | Target.OS.OpenBSD | Target.OS.Solaris | Target.OS.DragonFlyBSD))
             return toCppMangleItanium(s);
         if (target.os == Target.OS.Windows)
-            return toCppMangleMSVC(s);
+        {
+            if (target.mscoff)
+                return toCppMangleMSVC(s);
+            else
+                return toCppMangleDMC(s);
+        }
         else
             assert(0, "fix this");
     }
@@ -1277,12 +1282,17 @@ struct TargetCPP
     extern (C++) const(char)* typeInfoMangle(ClassDeclaration cd)
     {
         import dmd.cppmangle : cppTypeInfoMangleItanium;
-        import dmd.cppmanglewin : cppTypeInfoMangleMSVC;
+        import dmd.cppmanglewin : cppTypeInfoMangleDMC, cppTypeInfoMangleMSVC;
 
         if (target.os & (Target.OS.linux | Target.OS.OSX | Target.OS.FreeBSD | Target.OS.OpenBSD | Target.OS.Solaris | Target.OS.DragonFlyBSD))
             return cppTypeInfoMangleItanium(cd);
         if (target.os == Target.OS.Windows)
-            return cppTypeInfoMangleMSVC(cd);
+        {
+            if (target.mscoff)
+                return cppTypeInfoMangleMSVC(cd);
+            else
+                return cppTypeInfoMangleDMC(cd);
+        }
         else
             assert(0, "fix this");
     }


### PR DESCRIPTION
The `target.mscoff` logic that determined which to use has been moved to the target module so that the mscoff flag can remain private to `dmd.target`, rather than accessed from a possibly shared front-end module.