### PR TITLE
Fix 22365 - Don't crash for conditionally empty body of a TryStatement

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3981,7 +3981,6 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
 
         tcs.tryBody = sc.tryBody;   // chain on the in-flight tryBody
         tcs._body = tcs._body.semanticScope(sc, null, null, tcs);
-        assert(tcs._body);
 
         /* Even if body is empty, still do semantic analysis on catches
          */
@@ -4023,6 +4022,11 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
 
         if (catchErrors)
             return setError();
+
+        // No actual code in the try (i.e. omitted any conditionally compiled code)
+        // Could also be extended to check for hasCode
+        if (!tcs._body)
+            return;
 
         if (tcs._body.isErrorStatement())
         {

--- a/test/compilable/dlangui_crash.d
+++ b/test/compilable/dlangui_crash.d
@@ -1,0 +1,34 @@
+// https://issues.dlang.org/show_bug.cgi?id=22365
+
+class DrawableCache
+{
+    Ref _nullDrawable;
+
+    this()
+    {
+        debug Log;
+    }
+}
+
+class DrawableCacheEmpty
+{
+    Ref _nullDrawable;
+
+    this() {}
+}
+
+struct Ref
+{
+
+    ~this()
+    {
+    }
+}
+
+void foo()
+{
+    try
+        debug Log;
+    catch (Exception)
+        assert(false);
+}


### PR DESCRIPTION
The body may end up empty / null after `statementSemantic` if it only
contains conditionally compiled statements (`version`, `debug`, ...)
whose conditions are not met.

This only triggered for the `-preview=dtorfields` rewrite because it
didn't wrap the empty body into an additional `ScopeStatement`. But it
should be sufficient to check during `TryStatement` semantic instead
of unconditionally allocating an additional node for this rare case.