### PR TITLE
Coverage: Don't fail if reports could not be uploaded to CodeCov

### DIFF
--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -133,9 +133,6 @@ CC="$CC" ./run --environment --jobs=$N "${targets[@]}" "${args[@]}"
 ################################################################################
 
 if [ "${DMD_TEST_COVERAGE:-0}" = "1" ] ; then
-    cd $DMD_DIR
-    OS_NAME=windows source ci/codecov.sh
-
     # Skip druntime & phobos tests
     exit 0
 fi

--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -12,3 +12,11 @@ steps:
       bash --version
       sh --login .azure-pipelines/windows.sh
     displayName: Build and test
+
+  - bash: |
+      set -eux
+      source .azure-pipelines/lib.sh
+      OS_NAME=windows source ci/codecov.sh
+    displayName: "Upload coverage report"
+    condition: eq( variables.DMD_TEST_COVERAGE, 1)
+    continueOnError: true

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -59,12 +59,6 @@ shasum -a 256 -c "$UPLOADER.SHA256SUM"
 
 # Upload the sources
 chmod +x "$UPLOADER"
-if ! "./$UPLOADER" -p . -Z $UPLOADER_ARGS
-then
-    echo "Failed to upload the coverage report!"
-
-    # Ensure that it failed due to network / remote issues
-    "./$UPLOADER" --dry-run -p . -Z $UPLOADER_ARGS
-fi
+"./$UPLOADER" -p . -Z $UPLOADER_ARGS
 
 rm codecov*

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -59,6 +59,12 @@ shasum -a 256 -c "$UPLOADER.SHA256SUM"
 
 # Upload the sources
 chmod +x "$UPLOADER"
-"./$UPLOADER" -p . -Z $UPLOADER_ARGS
+if ! "./$UPLOADER" -p . -Z $UPLOADER_ARGS
+then
+    echo "Failed to upload the coverage report!"
+
+    # Ensure that it failed due to network / remote issues
+    "./$UPLOADER" --dry-run -p . -Z $UPLOADER_ARGS
+fi
 
 rm codecov*


### PR DESCRIPTION
Allow the uploader to pass when the upload failed due to network /
remote issues. Print a warning insteaad and verify that the local
configuration is correct.