### PR TITLE
Azure: Fix CodeCov upload by using a proper login shell

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -13,10 +13,10 @@ steps:
       sh --login .azure-pipelines/windows.sh
     displayName: Build and test
 
-  - bash: |
-      set -eux
-      source .azure-pipelines/lib.sh
-      OS_NAME=windows source ci/codecov.sh
+  # Try to upload the coverage files from the previous step to CodeCov
+  # This job is allowed to fail s.t. it does not block PR's in case of
+  # environmental issues
+  - script: bash --login -c "OS_NAME=windows source ci/codecov.sh"
     displayName: "Upload coverage report"
     condition: eq( variables.DMD_TEST_COVERAGE, 1)
     continueOnError: true

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
+set -euox pipefail
 
 # Uploads coverage reports to CodeCov
+
+# Check whether this script was called on it's own
+if [[ "${CURL_USER_AGENT:-}" == "" ]]
+then
+    CI_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    source "$CI_DIR/../.azure-pipelines/lib.sh"
+fi
 
 # CodeCov gets confused by lst files which it can't match
 rm -rf test/runnable/extra-files test/*.lst
@@ -57,8 +65,11 @@ fi
 gpg --verify "$UPLOADER.SHA256SUM.sig" "$UPLOADER.SHA256SUM"
 shasum -a 256 -c "$UPLOADER.SHA256SUM"
 
+# Remove signature files as the uploader apparently includes them...
+rm $UPLOADER.*
+
 # Upload the sources
 chmod +x "$UPLOADER"
 "./$UPLOADER" -p . -Z $UPLOADER_ARGS
 
-rm codecov*
+rm "$UPLOADER"


### PR DESCRIPTION
The CodeCov script needs to be run with a `--login` shell s.t. it has access to `shasum`,... .

(The previous draft PR was merged with an allowed failure...)