### PR TITLE
dmd.cppmanglewin: Use target.isLP64 as the gate for following x64 ABI on Windows

### DIFF
--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -333,7 +333,7 @@ public:
                 buf.writeByte('Q'); // const
             else
                 buf.writeByte('P'); // mutable
-            if (target.is64bit)
+            if (target.isLP64)
                 buf.writeByte('E');
             flags |= IS_NOT_TOP_TYPE;
             mangleArray(cast(TypeSArray)type.next);
@@ -352,7 +352,7 @@ public:
             {
                 buf.writeByte('P'); // mutable
             }
-            if (target.is64bit)
+            if (target.isLP64)
                 buf.writeByte('E');
             flags |= IS_NOT_TOP_TYPE;
             type.next.accept(this);
@@ -369,7 +369,7 @@ public:
             return;
 
         buf.writeByte('A'); // mutable
-        if (target.is64bit)
+        if (target.isLP64)
             buf.writeByte('E');
         flags |= IS_NOT_TOP_TYPE;
         assert(type.next);
@@ -473,7 +473,7 @@ public:
             buf.writeByte('Q');
         else
             buf.writeByte('P');
-        if (target.is64bit)
+        if (target.isLP64)
             buf.writeByte('E');
         flags |= IS_NOT_TOP_TYPE;
         mangleModifier(type);
@@ -541,7 +541,7 @@ extern(D):
             {
                 mangleVisibility(d, "AIQ");
             }
-            if (target.is64bit)
+            if (target.isLP64)
                 buf.writeByte('E');
             if (d.type.isConst())
             {
@@ -601,7 +601,7 @@ extern(D):
         if (t.ty != Tpointer)
             t = t.mutableOf();
         t.accept(this);
-        if ((t.ty == Tpointer || t.ty == Treference || t.ty == Tclass) && target.is64bit)
+        if ((t.ty == Tpointer || t.ty == Treference || t.ty == Tclass) && target.isLP64)
         {
             buf.writeByte('E');
         }
@@ -1177,7 +1177,7 @@ extern(D):
     {
         scope VisualCPPMangler tmp = new VisualCPPMangler(this);
         // Calling convention
-        if (target.is64bit) // always Microsoft x64 calling convention
+        if (target.isLP64) // always Microsoft x64 calling convention
         {
             tmp.buf.writeByte('A');
         }


### PR DESCRIPTION
The `is64bit` flag really means "is x86_64 architecture", which is a bit too specific for the semantic front-end to use for making decisions.  As such `is64bit` will eventually be confided to a dmd-specific part of the code base once all wrong uses have been cleared up.