### PR TITLE
dmd.target: Move target independent logic of TargetCPP.parameterType back to cppmangle

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1315,7 +1315,18 @@ private final class CppMangleVisitor : Visitor
 
         foreach (n, fparam; parameterList)
         {
-            Type t = target.cpp.parameterType(fparam);
+            Type t = fparam.type.merge2();
+            if (fparam.isReference())
+                t = t.referenceTo();
+            else if (fparam.storageClass & STC.lazy_)
+            {
+                // Mangle as delegate
+                auto tf = new TypeFunction(ParameterList(), t, LINK.d);
+                auto td = new TypeDelegate(tf);
+                t = td.merge();
+            }
+            else if (Type cpptype = target.cpp.parameterType(t))
+                t = cpptype;
             if (t.ty == Tsarray)
             {
                 // Static arrays in D are passed by value; no counterpart in C++

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1258,7 +1258,18 @@ extern(D):
         {
             foreach (n, p; type.parameterList)
             {
-                Type t = target.cpp.parameterType(p);
+                Type t = p.type.merge2();
+                if (p.isReference())
+                    t = t.referenceTo();
+                else if (p.storageClass & STC.lazy_)
+                {
+                    // Mangle as delegate
+                    auto tf = new TypeFunction(ParameterList(), t, LINK.d);
+                    auto td = new TypeDelegate(tf);
+                    t = td.merge();
+                }
+                else if (Type cpptype = target.cpp.parameterType(t))
+                    t = cpptype;
                 if (t.ty == Tsarray)
                 {
                     error(loc, "Internal Compiler Error: unable to pass static array to `extern(C++)` function.");

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5077,7 +5077,7 @@ struct TargetCPP final
     const char* typeInfoMangle(ClassDeclaration* cd);
     const char* thunkMangle(FuncDeclaration* fd, int32_t offset);
     const char* typeMangle(Type* t);
-    Type* parameterType(Parameter* p);
+    Type* parameterType(Type* t);
     bool fundamentalType(const Type* const t, bool& isFundamental);
     uint32_t derivedClassOffset(ClassDeclaration* baseClass);
     TargetCPP() :

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -1200,7 +1200,7 @@ struct TargetCPP
     import dmd.dsymbol : Dsymbol;
     import dmd.dclass : ClassDeclaration;
     import dmd.func : FuncDeclaration;
-    import dmd.mtype : Parameter, Type;
+    import dmd.mtype : Type;
 
     enum Runtime : ubyte
     {
@@ -1326,29 +1326,15 @@ struct TargetCPP
 
     /**
      * Get the type that will really be used for passing the given argument
-     * to an `extern(C++)` function.
+     * to an `extern(C++)` function, or `null` if unhandled.
      * Params:
-     *      p = parameter to be passed.
+     *      t = type to be passed.
      * Returns:
-     *      `Type` to use for parameter `p`.
+     *      `Type` to use for type `t`.
      */
-    extern (C++) Type parameterType(Parameter p)
+    extern (C++) Type parameterType(Type t)
     {
-        import dmd.astenums : LINK, STC;
-        import dmd.mtype : ParameterList, TypeDelegate, TypeFunction;
-        import dmd.typesem : merge;
-
-        Type t = p.type.merge2();
-        if (p.isReference())
-            t = t.referenceTo();
-        else if (p.storageClass & STC.lazy_)
-        {
-            // Mangle as delegate
-            auto tf = new TypeFunction(ParameterList(), t, LINK.d);
-            auto td = new TypeDelegate(tf);
-            t = td.merge();
-        }
-        return t;
+        return null;
     }
 
     /**

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -20,7 +20,6 @@ class ClassDeclaration;
 class Dsymbol;
 class Expression;
 class FuncDeclaration;
-class Parameter;
 class Statement;
 class Type;
 class TypeTuple;
@@ -100,7 +99,7 @@ struct TargetCPP
     const char *typeInfoMangle(ClassDeclaration *cd);
     const char *thunkMangle(FuncDeclaration *fd, int offset);
     const char *typeMangle(Type *t);
-    Type *parameterType(Parameter *p);
+    Type *parameterType(Type *p);
     bool fundamentalType(const Type *t, bool& isFundamental);
     unsigned derivedClassOffset(ClassDeclaration *baseClass);
 };


### PR DESCRIPTION
This still needs to be kept around because it _is_ used by GDC for fixing up `va_list` types.