### PR TITLE
dmd.mars: Combine DMD driver options with DMD language options for command-line processing

### DIFF
--- a/src/dmd/dmdparams.d
+++ b/src/dmd/dmdparams.d
@@ -27,4 +27,4 @@ struct DMDparams
     bool debugy;
 }
 
-shared DMDparams dmdParams = dmdParams.init;
+__gshared DMDparams dmdParams = dmdParams.init;


### PR DESCRIPTION
This begins a migration path for many dmd driver/codegen flags to be moved from `global.params` to `dmdParams.`