### PR TITLE
[dip1000] remove special case for class member assignment

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -693,9 +693,6 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
             // If va's lifetime encloses v's, then error
             if (va && !va.isDataseg() &&
                 (va.enclosesLifetimeOf(v) && !(v.storage_class & STC.temp) ||
-                 // va is class reference
-                 ae.e1.isDotVarExp() && va.type.toBasetype().isTypeClass() && (va.enclosesLifetimeOf(v) ||
-                 !va.isScope()) ||
                  vaIsRef ||
                  va.isReference() && !(v.storage_class & (STC.parameter | STC.temp))) &&
                 fd.setUnsafe())


### PR DESCRIPTION
The case was added in https://github.com/dlang/dmd/pull/7025 to prevent assigning a `scope` variable to a class field (which is never `scope`), but then made redundant by https://github.com/dlang/dmd/pull/8008