### PR TITLE
Azure/CodeCov: Remove workaround for token-less coverage upload

### DIFF
--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -30,9 +30,6 @@ UPLOADER_ARGS=""
 case "$UPLOADER_OS" in
 
     windows)
-        # -C workaround proposed in https://github.com/codecov/codecov-bash/issues/287
-        UPLOADER_ARGS="-C \"$BUILD_SOURCEVERSION\""
-
         UPLOADER="$UPLOADER.exe"
     ;;
 


### PR DESCRIPTION
`coverage.sh` used to explicitly specify the commit associated with the  coverage report as a workaround to an issue when uploading without  `CODECOV_TOKEN` from a public Azure pipeline[1]. The workaround is not  required anymore as the uploads now succeeds with the default settings.

The upload to CodeCov probably broke because `$BUILD_SOURCEVERSION` now points to a local merge commit (PR branch => target branch).

  [1] https://github.com/codecov/codecov-bash/issues/287