### PR TITLE
Fix Issue 22646 - [REG2.099] CT bounds checking ignores short circuit evaluation

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8032,7 +8032,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expression el = new ArrayLengthExp(exp.loc, exp.e1);
                 el = el.expressionSemantic(sc);
                 el = el.optimize(WANTvalue);
-                if (el.op == EXP.int64)
+                if (el.op == EXP.int64 && t1b.ty == Tsarray)
                 {
                     // Array length is known at compile-time. Upper is in bounds if it fits length.
                     dinteger_t length = el.toInteger();

--- a/test/compilable/test22646.d
+++ b/test/compilable/test22646.d
@@ -1,0 +1,21 @@
+// https://issues.dlang.org/show_bug.cgi?id=22646
+
+/*
+TEST_OUTPUT:
+---
+true
+true
+false
+false
+---
+*/
+
+static template Bug(string name)
+{
+    enum bool ok = name.length < 3 || name[0..3] != "pad";
+}
+
+pragma(msg, Bug!"x".ok);
+pragma(msg, Bug!"foo".ok);
+pragma(msg, Bug!"pad".ok);
+pragma(msg, Bug!"pad123".ok);


### PR DESCRIPTION
Targeting master since the change did not make it in stable.