### PR TITLE
Fix Issue 22619 - Missing inout substitution for __copytmp temporaries caused by copy ctors

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -466,7 +466,17 @@ private Expression callCpCtor(Scope* sc, Expression e, Type destinationType)
              */
             auto tmp = copyToTemp(STC.rvalue, "__copytmp", e);
             if (sd.hasCopyCtor && destinationType)
-                tmp.type = destinationType;
+            {
+                // https://issues.dlang.org/show_bug.cgi?id=22619
+                // If the destination type is inout we can preserve it
+                // only if inside an inout function; if we are not inside
+                // an inout function, then we will preserve the type of
+                // the source
+                if (destinationType.hasWild && !(sc.func.storage_class & STC.wild))
+                    tmp.type = e.type;
+                else
+                    tmp.type = destinationType;
+            }
             tmp.storage_class |= STC.nodtor;
             tmp.dsymbolSemantic(sc);
             Expression de = new DeclarationExp(e.loc, tmp);

--- a/test/compilable/test22619.d
+++ b/test/compilable/test22619.d
@@ -1,0 +1,11 @@
+// https://issues.dlang.org/show_bug.cgi?id=22619
+
+struct W1 {
+	int x;
+	this(ref inout W1 rhs) inout { this.x = rhs.x; }
+}
+
+inout(W1) f(inout W1 x) { return x; }
+void g(W1 x) {
+	auto r = f(x);
+}


### PR DESCRIPTION
When calling the copy constructor, the type of the destination is unconditionally slapped on the temporary. This works for all cases, except when a variables is declared inside a non-inout function.

This patch makes it so that in the latter case the type of the temporary is being set to the type of the source.

cc @burner @kinke 