### PR TITLE
Improve wording of error message for IFTI failure

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -3052,7 +3052,7 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
         // all of overloads are templates
         if (td)
         {
-            .error(loc, "%s `%s.%s` cannot deduce function from argument types `!(%s)%s`",
+            .error(loc, "none of the overloads of %s `%s.%s` are callable using argument types `!(%s)%s`",
                    td.kind(), td.parent.toPrettyChars(), td.ident.toChars(),
                    tiargsBuf.peekChars(), fargsBuf.peekChars());
 

--- a/test/fail_compilation/bug9631.d
+++ b/test/fail_compilation/bug9631.d
@@ -91,9 +91,9 @@ TEST_OUTPUT:
 ---
 fail_compilation/bug9631.d(106): Error: function `bug9631.targ.ft!().ft(S _param_0)` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(106):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S _param_0`
-fail_compilation/bug9631.d(107): Error: template `bug9631.targ.ft` cannot deduce function from argument types `!()(S)`
+fail_compilation/bug9631.d(107): Error: none of the overloads of template `bug9631.targ.ft` are callable using argument types `!()(S)`
 fail_compilation/bug9631.d(105):        Candidate is: `ft()(tem!().S)`
-fail_compilation/bug9631.d(109): Error: template `bug9631.targ.ft2` cannot deduce function from argument types `!()(S, int)`
+fail_compilation/bug9631.d(109): Error: none of the overloads of template `bug9631.targ.ft2` are callable using argument types `!()(S, int)`
 fail_compilation/bug9631.d(108):        Candidate is: `ft2(T)(S, T)`
 ---
 */

--- a/test/fail_compilation/constraints_aggr.d
+++ b/test/fail_compilation/constraints_aggr.d
@@ -2,12 +2,12 @@
 EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_aggr.d(32): Error: template `imports.constraints.C.f` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_aggr.d(32): Error: none of the overloads of template `imports.constraints.C.f` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(60):        Candidate is: `f(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_aggr.d(33): Error: template `imports.constraints.C.g` cannot deduce function from argument types `!()()`
+fail_compilation/constraints_aggr.d(33): Error: none of the overloads of template `imports.constraints.C.g` are callable using argument types `!()()`
 fail_compilation/imports/constraints.d(63):        Candidate is: `g(this T)()`
   with `T = imports.constraints.C`
   must satisfy the following constraint:

--- a/test/fail_compilation/constraints_func1.d
+++ b/test/fail_compilation/constraints_func1.d
@@ -2,72 +2,72 @@
 EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func1.d(79): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(79): Error: none of the overloads of template `imports.constraints.test1` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(9):        Candidate is: `test1(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(80): Error: template `imports.constraints.test2` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(80): Error: none of the overloads of template `imports.constraints.test2` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(10):        Candidate is: `test2(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(81): Error: template `imports.constraints.test3` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(81): Error: none of the overloads of template `imports.constraints.test3` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(11):        Candidate is: `test3(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(82): Error: template `imports.constraints.test4` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(82): Error: none of the overloads of template `imports.constraints.test4` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(12):        Candidate is: `test4(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(83): Error: template `imports.constraints.test5` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(83): Error: none of the overloads of template `imports.constraints.test5` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(13):        Candidate is: `test5(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func1.d(84): Error: template `imports.constraints.test6` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(84): Error: none of the overloads of template `imports.constraints.test6` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(14):        Candidate is: `test6(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T
        !P!T`
-fail_compilation/constraints_func1.d(85): Error: template `imports.constraints.test7` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(85): Error: none of the overloads of template `imports.constraints.test7` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(15):        Candidate is: `test7(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func1.d(86): Error: template `imports.constraints.test8` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(86): Error: none of the overloads of template `imports.constraints.test8` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(16):        Candidate is: `test8(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(87): Error: template `imports.constraints.test9` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(87): Error: none of the overloads of template `imports.constraints.test9` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(17):        Candidate is: `test9(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(88): Error: template `imports.constraints.test10` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(88): Error: none of the overloads of template `imports.constraints.test10` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(18):        Candidate is: `test10(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(89): Error: template `imports.constraints.test11` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(89): Error: none of the overloads of template `imports.constraints.test11` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(19):        Candidate is: `test11(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T`
-fail_compilation/constraints_func1.d(90): Error: template `imports.constraints.test12` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func1.d(90): Error: none of the overloads of template `imports.constraints.test12` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(20):        Candidate is: `test12(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(92): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int, int)`
+fail_compilation/constraints_func1.d(92): Error: none of the overloads of template `imports.constraints.test1` are callable using argument types `!()(int, int)`
 fail_compilation/imports/constraints.d(9):        Candidate is: `test1(T)(T v)`
 ---
 */

--- a/test/fail_compilation/constraints_func2.d
+++ b/test/fail_compilation/constraints_func2.d
@@ -2,83 +2,83 @@
 EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func2.d(94): Error: template `imports.constraints.test13` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(94): Error: none of the overloads of template `imports.constraints.test13` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(23):        Candidate is: `test13(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T`
-fail_compilation/constraints_func2.d(95): Error: template `imports.constraints.test14` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(95): Error: none of the overloads of template `imports.constraints.test14` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(24):        Candidate is: `test14(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        N!T`
-fail_compilation/constraints_func2.d(96): Error: template `imports.constraints.test15` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(96): Error: none of the overloads of template `imports.constraints.test15` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(25):        Candidate is: `test15(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        !P!T`
-fail_compilation/constraints_func2.d(97): Error: template `imports.constraints.test16` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(97): Error: none of the overloads of template `imports.constraints.test16` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(26):        Candidate is: `test16(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(98): Error: template `imports.constraints.test17` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(98): Error: none of the overloads of template `imports.constraints.test17` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(27):        Candidate is: `test17(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(99): Error: template `imports.constraints.test18` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(99): Error: none of the overloads of template `imports.constraints.test18` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(28):        Candidate is: `test18(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(100): Error: template `imports.constraints.test19` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(100): Error: none of the overloads of template `imports.constraints.test19` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(29):        Candidate is: `test19(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T
        N!T`
-fail_compilation/constraints_func2.d(101): Error: template `imports.constraints.test20` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(101): Error: none of the overloads of template `imports.constraints.test20` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(30):        Candidate is: `test20(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(102): Error: template `imports.constraints.test21` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(102): Error: none of the overloads of template `imports.constraints.test21` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(31):        Candidate is: `test21(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(103): Error: template `imports.constraints.test22` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(103): Error: none of the overloads of template `imports.constraints.test22` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(32):        Candidate is: `test22(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        !P!T`
-fail_compilation/constraints_func2.d(104): Error: template `imports.constraints.test23` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(104): Error: none of the overloads of template `imports.constraints.test23` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(33):        Candidate is: `test23(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        N!T
        !P!T`
-fail_compilation/constraints_func2.d(105): Error: template `imports.constraints.test24` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(105): Error: none of the overloads of template `imports.constraints.test24` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(34):        Candidate is: `test24(R)(R r)`
   with `R = int`
   must satisfy the following constraint:
 `       __traits(hasMember, R, "stuff")`
-fail_compilation/constraints_func2.d(106): Error: template `imports.constraints.test25` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func2.d(106): Error: none of the overloads of template `imports.constraints.test25` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(35):        Candidate is: `test25(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(107): Error: template `imports.constraints.test26` cannot deduce function from argument types `!(float)(int)`
+fail_compilation/constraints_func2.d(107): Error: none of the overloads of template `imports.constraints.test26` are callable using argument types `!(float)(int)`
 fail_compilation/imports/constraints.d(36):        Candidate is: `test26(T, U)(U u)`
   with `T = float,
        U = int`

--- a/test/fail_compilation/constraints_func3.d
+++ b/test/fail_compilation/constraints_func3.d
@@ -2,7 +2,7 @@
 EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func3.d(53): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func3.d(53): Error: none of the overloads of template `imports.constraints.overload` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(39):        Candidates are: `overload(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
@@ -13,7 +13,7 @@ fail_compilation/imports/constraints.d(40):                        `overload(T)(
 `       !P!T`
 fail_compilation/imports/constraints.d(41):                        `overload(T)(T v1, T v2)`
 fail_compilation/imports/constraints.d(42):                        `overload(T, V)(T v1, V v2)`
-fail_compilation/constraints_func3.d(54): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int, string)`
+fail_compilation/constraints_func3.d(54): Error: none of the overloads of template `imports.constraints.overload` are callable using argument types `!()(int, string)`
 fail_compilation/imports/constraints.d(39):        Candidates are: `overload(T)(T v)`
 fail_compilation/imports/constraints.d(40):                        `overload(T)(T v)`
 fail_compilation/imports/constraints.d(41):                        `overload(T)(T v1, T v2)`
@@ -23,21 +23,21 @@ fail_compilation/imports/constraints.d(42):                        `overload(T, 
   must satisfy one of the following constraints:
 `       N!T
        N!V`
-fail_compilation/constraints_func3.d(56): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()()`
+fail_compilation/constraints_func3.d(56): Error: none of the overloads of template `imports.constraints.variadic` are callable using argument types `!()()`
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
-fail_compilation/constraints_func3.d(57): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func3.d(57): Error: none of the overloads of template `imports.constraints.variadic` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = ()`
   must satisfy the following constraint:
 `       N!int`
-fail_compilation/constraints_func3.d(58): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int)`
+fail_compilation/constraints_func3.d(58): Error: none of the overloads of template `imports.constraints.variadic` are callable using argument types `!()(int, int)`
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = (int)`
   must satisfy the following constraint:
 `       N!int`
-fail_compilation/constraints_func3.d(59): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int, int)`
+fail_compilation/constraints_func3.d(59): Error: none of the overloads of template `imports.constraints.variadic` are callable using argument types `!()(int, int, int)`
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = (int, int)`

--- a/test/fail_compilation/constraints_func4.d
+++ b/test/fail_compilation/constraints_func4.d
@@ -3,7 +3,7 @@ EXTRA_FILES: imports/constraints.d
 REQUIRED_ARGS: -verrors=context
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func4.d(90): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func4.d(90): Error: none of the overloads of template `imports.constraints.overload` are callable using argument types `!()(int)`
     overload(0);
             ^
 fail_compilation/imports/constraints.d(39):        Candidates are: `overload(T)(T v)`
@@ -24,7 +24,7 @@ void overload(T)(T v1, T v2) if (N!T);
 fail_compilation/imports/constraints.d(42):                        `overload(T, V)(T v1, V v2)`
 void overload(T, V)(T v1, V v2) if (N!T || N!V);
      ^
-fail_compilation/constraints_func4.d(91): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int, string)`
+fail_compilation/constraints_func4.d(91): Error: none of the overloads of template `imports.constraints.overload` are callable using argument types `!()(int, string)`
     overload(0, "");
             ^
 fail_compilation/imports/constraints.d(39):        Candidates are: `overload(T)(T v)`
@@ -44,13 +44,13 @@ fail_compilation/imports/constraints.d(42):                        `overload(T, 
        N!V`
 void overload(T, V)(T v1, V v2) if (N!T || N!V);
      ^
-fail_compilation/constraints_func4.d(93): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()()`
+fail_compilation/constraints_func4.d(93): Error: none of the overloads of template `imports.constraints.variadic` are callable using argument types `!()()`
     variadic();
             ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
 void variadic(A, T...)(A a, T v) if (N!int);
      ^
-fail_compilation/constraints_func4.d(94): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int)`
+fail_compilation/constraints_func4.d(94): Error: none of the overloads of template `imports.constraints.variadic` are callable using argument types `!()(int)`
     variadic(0);
             ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
@@ -60,7 +60,7 @@ fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T.
 `       N!int`
 void variadic(A, T...)(A a, T v) if (N!int);
      ^
-fail_compilation/constraints_func4.d(95): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int)`
+fail_compilation/constraints_func4.d(95): Error: none of the overloads of template `imports.constraints.variadic` are callable using argument types `!()(int, int)`
     variadic(0, 1);
             ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
@@ -70,7 +70,7 @@ fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T.
 `       N!int`
 void variadic(A, T...)(A a, T v) if (N!int);
      ^
-fail_compilation/constraints_func4.d(96): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int, int)`
+fail_compilation/constraints_func4.d(96): Error: none of the overloads of template `imports.constraints.variadic` are callable using argument types `!()(int, int, int)`
     variadic(0, 1, 2);
             ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`

--- a/test/fail_compilation/diag13942.d
+++ b/test/fail_compilation/diag13942.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag13942.d(18): Error: template instance `isRawStaticArray!()` does not match template declaration `isRawStaticArray(T, A...)`
-fail_compilation/diag13942.d(26): Error: template `diag13942.to!double.to` cannot deduce function from argument types `!()()`
+fail_compilation/diag13942.d(26): Error: none of the overloads of template `diag13942.to!double.to` are callable using argument types `!()()`
 fail_compilation/diag13942.d(17):        Candidate is: `to(A...)(A args)`
 ---
 */

--- a/test/fail_compilation/diag16977.d
+++ b/test/fail_compilation/diag16977.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/diag16977.d(25): Error: undefined identifier `undefined`, did you mean function `undefinedId`?
 fail_compilation/diag16977.d(26): Error: cannot implicitly convert expression `"\x01string"` of type `string` to `int`
-fail_compilation/diag16977.d(27): Error: template `diag16977.templ` cannot deduce function from argument types `!()(int)`
+fail_compilation/diag16977.d(27): Error: none of the overloads of template `diag16977.templ` are callable using argument types `!()(int)`
 fail_compilation/diag16977.d(20):        Candidate is: `templ(S)(S s)`
   with `S = int`
   must satisfy the following constraint:

--- a/test/fail_compilation/diag8101.d
+++ b/test/fail_compilation/diag8101.d
@@ -13,12 +13,12 @@ fail_compilation/diag8101.d(38):                        `diag8101.f_2(int, int, 
 fail_compilation/diag8101.d(39):                        `diag8101.f_2(int, int, int, int)`
 fail_compilation/diag8101.d(40):                        `diag8101.f_2(int, int, int, int, int)`
 fail_compilation/diag8101.d(59):        ... (1 more, -v to show) ...
-fail_compilation/diag8101.d(61): Error: template `diag8101.t_0` cannot deduce function from argument types `!()()`
+fail_compilation/diag8101.d(61): Error: none of the overloads of template `diag8101.t_0` are callable using argument types `!()()`
 fail_compilation/diag8101.d(43):        Candidate is: `t_0(T1)()`
-fail_compilation/diag8101.d(62): Error: template `diag8101.t_1` cannot deduce function from argument types `!()()`
+fail_compilation/diag8101.d(62): Error: none of the overloads of template `diag8101.t_1` are callable using argument types `!()()`
 fail_compilation/diag8101.d(45):        Candidates are: `t_1(T1)()`
 fail_compilation/diag8101.d(46):                        `t_1(T1, T2)()`
-fail_compilation/diag8101.d(63): Error: template `diag8101.t_2` cannot deduce function from argument types `!()()`
+fail_compilation/diag8101.d(63): Error: none of the overloads of template `diag8101.t_2` are callable using argument types `!()()`
 fail_compilation/diag8101.d(48):        Candidates are: `t_2(T1)()`
 fail_compilation/diag8101.d(49):                        `t_2(T1, T2)()`
 fail_compilation/diag8101.d(50):                        `t_2(T1, T2, T3)()`

--- a/test/fail_compilation/diag8648.d
+++ b/test/fail_compilation/diag8648.d
@@ -2,13 +2,13 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag8648.d(18): Error: undefined identifier `X`
-fail_compilation/diag8648.d(29): Error: template `diag8648.foo` cannot deduce function from argument types `!()(Foo!(int, 1))`
+fail_compilation/diag8648.d(29): Error: none of the overloads of template `diag8648.foo` are callable using argument types `!()(Foo!(int, 1))`
 fail_compilation/diag8648.d(18):        Candidate is: `foo(T, n)(X!(T, n))`
 fail_compilation/diag8648.d(20): Error: undefined identifier `a`
-fail_compilation/diag8648.d(31): Error: template `diag8648.bar` cannot deduce function from argument types `!()(Foo!(int, 1))`
+fail_compilation/diag8648.d(31): Error: none of the overloads of template `diag8648.bar` are callable using argument types `!()(Foo!(int, 1))`
 fail_compilation/diag8648.d(20):        Candidate is: `bar(T)(Foo!(T, a))`
 fail_compilation/diag8648.d(20): Error: undefined identifier `a`
-fail_compilation/diag8648.d(32): Error: template `diag8648.bar` cannot deduce function from argument types `!()(Foo!(int, f))`
+fail_compilation/diag8648.d(32): Error: none of the overloads of template `diag8648.bar` are callable using argument types `!()(Foo!(int, f))`
 fail_compilation/diag8648.d(20):        Candidate is: `bar(T)(Foo!(T, a))`
 ---
 */

--- a/test/fail_compilation/diag9004.d
+++ b/test/fail_compilation/diag9004.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9004.d(21): Error: template `diag9004.bar` cannot deduce function from argument types `!()(Foo!int, int)`
+fail_compilation/diag9004.d(21): Error: none of the overloads of template `diag9004.bar` are callable using argument types `!()(Foo!int, int)`
 fail_compilation/diag9004.d(14):        Candidate is: `bar(FooT)(FooT foo, FooT.T x)`
 ---
 */

--- a/test/fail_compilation/diagin.d
+++ b/test/fail_compilation/diagin.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/diagin.d(14): Error: function `diagin.foo(in int)` is not callable using argument types `()`
 fail_compilation/diagin.d(14):        missing argument for parameter #1: `in int`
-fail_compilation/diagin.d(16): Error: template `diagin.foo1` cannot deduce function from argument types `!()(bool[])`
+fail_compilation/diagin.d(16): Error: none of the overloads of template `diagin.foo1` are callable using argument types `!()(bool[])`
 fail_compilation/diagin.d(20):        Candidate is: `foo1(T)(in T v, string)`
 ---
  */

--- a/test/fail_compilation/fail12744.d
+++ b/test/fail_compilation/fail12744.d
@@ -14,10 +14,10 @@ fail_compilation/fail12744.d(61): Error: template instance `fail12744.bar12744L!
 fail_compilation/fail12744.d(40): Error: incompatible parameter storage classes `lazy` and `out`
 fail_compilation/fail12744.d(62): Error: template instance `fail12744.bar12744L!(foo12744O)` error instantiating
 fail_compilation/fail12744.d(41): Error: incompatible parameter storage classes `auto ref` and `out`
-fail_compilation/fail12744.d(67): Error: template `fail12744.bar12744A` cannot deduce function from argument types `!(foo12744O)(int)`
+fail_compilation/fail12744.d(67): Error: none of the overloads of template `fail12744.bar12744A` are callable using argument types `!(foo12744O)(int)`
 fail_compilation/fail12744.d(41):        Candidate is: `bar12744A(alias f)(auto ref PTT12744!f args)`
 fail_compilation/fail12744.d(41): Error: incompatible parameter storage classes `auto ref` and `lazy`
-fail_compilation/fail12744.d(68): Error: template `fail12744.bar12744A` cannot deduce function from argument types `!(foo12744L)(int)`
+fail_compilation/fail12744.d(68): Error: none of the overloads of template `fail12744.bar12744A` are callable using argument types `!(foo12744L)(int)`
 fail_compilation/fail12744.d(41):        Candidate is: `bar12744A(alias f)(auto ref PTT12744!f args)`
 ---
 */

--- a/test/fail_compilation/fail14669.d
+++ b/test/fail_compilation/fail14669.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/fail14669.d(11): Error: `auto` can only be used as part of `auto ref` for template function parameters
 fail_compilation/fail14669.d(16): Error: template instance `fail14669.foo1!()` error instantiating
 fail_compilation/fail14669.d(12): Error: `auto` can only be used as part of `auto ref` for template function parameters
-fail_compilation/fail14669.d(17): Error: template `fail14669.foo2` cannot deduce function from argument types `!()(int)`
+fail_compilation/fail14669.d(17): Error: none of the overloads of template `fail14669.foo2` are callable using argument types `!()(int)`
 fail_compilation/fail14669.d(12):        Candidate is: `foo2()(auto int a)`
 ---
 */

--- a/test/fail_compilation/fail162.d
+++ b/test/fail_compilation/fail162.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail162.d(25): Error: template `fail162.testHelper` cannot deduce function from argument types `!()(string, string)`
+fail_compilation/fail162.d(25): Error: none of the overloads of template `fail162.testHelper` are callable using argument types `!()(string, string)`
 fail_compilation/fail162.d(10):        Candidate is: `testHelper(A...)()`
 fail_compilation/fail162.d(30): Error: template instance `fail162.test!("hello", "world")` error instantiating
 ---

--- a/test/fail_compilation/fail20730b.d
+++ b/test/fail_compilation/fail20730b.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -verrors=spec -o-
 TEST_OUTPUT:
 ---
 (spec:1) fail_compilation/fail20730b.d-mixin-43(43): Error: C style cast illegal, use `cast(int)mod`
-fail_compilation/fail20730b.d(26): Error: template `fail20730b.atomicOp` cannot deduce function from argument types `!("+=")(shared(uint), int)`
+fail_compilation/fail20730b.d(26): Error: none of the overloads of template `fail20730b.atomicOp` are callable using argument types `!("+=")(shared(uint), int)`
 fail_compilation/fail20730b.d(41):        Candidate is: `atomicOp(string op, T, V1)(shared ref T val, V1 mod)`
   with `op = "+=",
        T = uint,

--- a/test/fail_compilation/fail236.d
+++ b/test/fail_compilation/fail236.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail236.d(14): Error: undefined identifier `x`
-fail_compilation/fail236.d(22): Error: template `fail236.Templ2` cannot deduce function from argument types `!()(int)`
+fail_compilation/fail236.d(22): Error: none of the overloads of template `fail236.Templ2` are callable using argument types `!()(int)`
 fail_compilation/fail236.d(12):        Candidate is: `Templ2(alias a)(x)`
 ---
 */

--- a/test/fail_compilation/fail8009.d
+++ b/test/fail_compilation/fail8009.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail8009.d(9): Error: template `fail8009.filter` cannot deduce function from argument types `!()(void)`
+fail_compilation/fail8009.d(9): Error: none of the overloads of template `fail8009.filter` are callable using argument types `!()(void)`
 fail_compilation/fail8009.d(8):        Candidate is: `filter(R)(scope bool delegate(ref BAD!R) func)`
 ---
 */

--- a/test/fail_compilation/fail95.d
+++ b/test/fail_compilation/fail95.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail95.d(19): Error: template `fail95.A` cannot deduce function from argument types `!()(int)`
+fail_compilation/fail95.d(19): Error: none of the overloads of template `fail95.A` are callable using argument types `!()(int)`
 fail_compilation/fail95.d(11):        Candidate is: `A(alias T)(T)`
 ---
 */

--- a/test/fail_compilation/ice11856_0.d
+++ b/test/fail_compilation/ice11856_0.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11856_0.d(19): Error: template `ice11856_0.f` cannot deduce function from argument types `!()(int)`
+fail_compilation/ice11856_0.d(19): Error: none of the overloads of template `ice11856_0.f` are callable using argument types `!()(int)`
 fail_compilation/ice11856_0.d(13):        Candidates are: `f(T)(T t)`
 fail_compilation/ice11856_0.d(16):                        `f(T)(T t)`
   with `T = int`

--- a/test/fail_compilation/ice11856_1.d
+++ b/test/fail_compilation/ice11856_1.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11856_1.d(13): Error: template `ice11856_1.g` cannot deduce function from argument types `!()(A)`
+fail_compilation/ice11856_1.d(13): Error: none of the overloads of template `ice11856_1.g` are callable using argument types `!()(A)`
 fail_compilation/ice11856_1.d(11):        Candidate is: `g(T)(T x)`
 ---
 */

--- a/test/fail_compilation/ice14130.d
+++ b/test/fail_compilation/ice14130.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice14130.d(10): Error: undefined identifier `Undef`
-fail_compilation/ice14130.d(14): Error: template `ice14130.foo` cannot deduce function from argument types `!()(int)`
+fail_compilation/ice14130.d(14): Error: none of the overloads of template `ice14130.foo` are callable using argument types `!()(int)`
 fail_compilation/ice14130.d(10):        Candidate is: `foo(R, F = Undef)(R r, F s = 0)`
 ---
 */

--- a/test/fail_compilation/ice14907.d
+++ b/test/fail_compilation/ice14907.d
@@ -6,7 +6,7 @@ fail_compilation/ice14907.d(19):        while looking for match for `S!()`
 fail_compilation/ice14907.d(15): Error: template `ice14907.f(int v = f)()` recursive template expansion
 fail_compilation/ice14907.d(20):        while looking for match for `f!()`
 fail_compilation/ice14907.d(15): Error: template `ice14907.f(int v = f)()` recursive template expansion
-fail_compilation/ice14907.d(21): Error: template `ice14907.f` cannot deduce function from argument types `!()()`
+fail_compilation/ice14907.d(21): Error: none of the overloads of template `ice14907.f` are callable using argument types `!()()`
 fail_compilation/ice14907.d(15):        Candidate is: `f(int v = f)()`
 ---
 */

--- a/test/fail_compilation/ice6538.d
+++ b/test/fail_compilation/ice6538.d
@@ -7,7 +7,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice6538.d(23): Error: expression `super` is not a valid template value argument
-fail_compilation/ice6538.d(28): Error: template `ice6538.D.foo` cannot deduce function from argument types `!()()`
+fail_compilation/ice6538.d(28): Error: none of the overloads of template `ice6538.D.foo` are callable using argument types `!()()`
 fail_compilation/ice6538.d(23):        Candidate is: `foo()()`
 ---
 */

--- a/test/fail_compilation/ice9284.d
+++ b/test/fail_compilation/ice9284.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9284.d(14): Error: template `ice9284.C.__ctor` cannot deduce function from argument types `!()(int)`
+fail_compilation/ice9284.d(14): Error: none of the overloads of template `ice9284.C.__ctor` are callable using argument types `!()(int)`
 fail_compilation/ice9284.d(12):        Candidate is: `__ctor()(string)`
 fail_compilation/ice9284.d(20): Error: template instance `ice9284.C.__ctor!()` error instantiating
 ---

--- a/test/fail_compilation/test19107.d
+++ b/test/fail_compilation/test19107.d
@@ -2,7 +2,7 @@
 EXTRA_FILES: imports/imp19661.d imports/test19107a.d imports/test19107b.d
 TEST_OUTPUT:
 ---
-fail_compilation/test19107.d(24): Error: template `test19107.all` cannot deduce function from argument types `!((c) => c)(string[])`
+fail_compilation/test19107.d(24): Error: none of the overloads of template `test19107.all` are callable using argument types `!((c) => c)(string[])`
 fail_compilation/test19107.d(18):        Candidate is: `all(alias pred, T)(T t)`
   with `pred = __lambda2,
        T = string[]`


### PR DESCRIPTION
The new wording is based on the analogous message for non-template
functions.