### PR TITLE
Partial fix for issue 14892: define D_ProfileGC for -profile=gc

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1239,6 +1239,9 @@ void addDefaultVersionIdentifiers(const ref Param params, const ref Target tgt)
     }
 
     VersionCondition.addPredefinedGlobalIdent("D_HardFloat");
+
+    if (params.tracegc)
+        VersionCondition.addPredefinedGlobalIdent("D_ProfileGC");
 }
 
 /**


### PR DESCRIPTION
To enable Phobos to propagate file/line/function information from user code to the trace functions. Even though this ultimately relies on druntime/Phobos to do the Right Thing(tm), after further consideration I think this is a superior solution to a dmd-only solution, because this will allow e.g. Phobos to pass in the file/line/function of the user code that calls, e.g., `std.array.array`, instead of dmd tracing an allocation coming from deep inside Phobos internals that the end user probably won't understand.

The exact version identifier can be changed, of course, e.g., to some internal identifier to discourage user code from depending on it.

Depends on: https://github.com/dlang/phobos/pull/8361, https://github.com/dlang/druntime/pull/3681
