### PR TITLE
posix.mak: Invoke bash to run the bootstrap script

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -46,9 +46,9 @@ $(warning ============================== )
 # Forward D compiler bootstrapping to bootstrap.sh
 ifneq (,$(AUTO_BOOTSTRAP))
 default:
-	@./bootstrap.sh
+	@bash ./bootstrap.sh
 .DEFAULT:
-	@./bootstrap.sh "$@"
+	@bash ./bootstrap.sh "$@"
 else
 
 # get OS and MODEL


### PR DESCRIPTION
Not all systems have bash installed in `/bin/bash`.