### PR TITLE
fix issue 5096: bad unmatched closing brace messages

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -443,6 +443,13 @@ class Parser(AST) : Lexer
         }
 
         decldefs = parseDeclDefs(0, &lastDecl);
+
+        if (token.value == TOK.rightCurly)
+        {
+            error(token.loc, "unmatched closing brace");
+            goto Lerr;
+        }
+
         if (token.value != TOK.endOfFile)
         {
             error(token.loc, "unrecognized declaration");

--- a/test/fail_compilation/bug5096.d
+++ b/test/fail_compilation/bug5096.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/bug5096.d(13): Error: unmatched closing brace
+---
+*/
+void foo(int x)
+    in {
+        assert(x > 0);
+    } do {
+        x++;
+    }
+}
+void main() {}

--- a/test/fail_compilation/diag19225.d
+++ b/test/fail_compilation/diag19225.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/diag19225.d(14): Error: basic type expected, not `else`
 fail_compilation/diag19225.d(14):        There's no `static else`, use `else` instead.
 fail_compilation/diag19225.d(14): Error: found `else` without a corresponding `if`, `version` or `debug` statement
-fail_compilation/diag19225.d(15): Error: unrecognized declaration
+fail_compilation/diag19225.d(15): Error: unmatched closing brace
 ---
 */
 

--- a/test/fail_compilation/fail220.d
+++ b/test/fail_compilation/fail220.d
@@ -5,7 +5,7 @@ fail_compilation/fail220.d(12): Error: identifier expected for template value pa
 fail_compilation/fail220.d(12): Error: found `==` when expecting `)`
 fail_compilation/fail220.d(12): Error: found `class` when expecting `)`
 fail_compilation/fail220.d(12): Error: declaration expected, not `)`
-fail_compilation/fail220.d(16): Error: unrecognized declaration
+fail_compilation/fail220.d(16): Error: unmatched closing brace
 ---
 */
 template types (T) {

--- a/test/fail_compilation/test16188.d
+++ b/test/fail_compilation/test16188.d
@@ -2,7 +2,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/test16188.d(1): Error: no identifier for declarator `TEST_OUTPUT`
 fail_compilation/test16188.d(1): Error: declaration expected, not `:`
-fail_compilation/test16188.d(18): Error: unrecognized declaration
+fail_compilation/test16188.d(18): Error: unmatched closing brace
 ---
  */
 

--- a/test/fail_compilation/test17284.d
+++ b/test/fail_compilation/test17284.d
@@ -2,7 +2,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/test17284.d(1): Error: no identifier for declarator `TEST_OUTPUT`
 fail_compilation/test17284.d(1): Error: declaration expected, not `:`
-fail_compilation/test17284.d(12): Error: unrecognized declaration
+fail_compilation/test17284.d(12): Error: unmatched closing brace
 ---
 */
 


### PR DESCRIPTION
This is sort of a special case, but it's kind of the most common.  Not sure if it's worth looking back for a brace at the same indentation level, or maybe the opening brace for the last declaration for a supplemental error.  Suggestions welcome