### PR TITLE
Fix issue 22685: Symbol nested in both function and module? Not a problem.

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -7311,7 +7311,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 if ((td && td.literal) || (ti && ti.enclosing) || (d && !d.isDataseg() && !(d.storage_class & STC.manifest) && (!d.isFuncDeclaration() || d.isFuncDeclaration().isNested()) && !isTemplateMixin()))
                 {
                     Dsymbol dparent = sa.toParent2();
-                    if (!dparent)
+                    if (!dparent || dparent.isModule)
                         goto L1;
                     else if (!enclosing)
                         enclosing = dparent;

--- a/test/compilable/imports/test22685b.d
+++ b/test/compilable/imports/test22685b.d
@@ -1,0 +1,5 @@
+module imports.test22685b;
+
+import imports.test22685c : overloaded;
+
+void overloaded()() { }

--- a/test/compilable/imports/test22685c.d
+++ b/test/compilable/imports/test22685c.d
@@ -1,0 +1,3 @@
+module imports.test22685c;
+
+void overloaded()() { }

--- a/test/compilable/test22685.d
+++ b/test/compilable/test22685.d
@@ -1,0 +1,9 @@
+module test22685;
+
+import imports.test22685b;
+
+void twoArgs(alias a, alias b)() { }
+
+void main() {
+    twoArgs!(a => 1, overloaded);
+}


### PR DESCRIPTION
When finding template argument context for creating a nested instance, ignore symbols in modules, as symbols in modules can be used regardless of runtime context.