### PR TITLE
fix Issue 22631 - ImportC: support C++11 unscoped enums with underlyi…

### DIFF
--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -61,7 +61,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
     extern (D) this(const ref Loc loc, Identifier ident, Type memtype)
     {
         super(loc, ident);
-        //printf("EnumDeclaration() %s\n", toChars());
+        //printf("EnumDeclaration() %p %s : %s\n", this, toChars(), memtype.toChars());
         type = new TypeEnum(this);
         this.memtype = memtype;
         visibility = Visibility(Visibility.Kind.undefined);

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2179,7 +2179,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             /* C11 6.7.2.2
              */
-            ed.memtype = Type.tint32; // C11 6.7.2.2-4 implementation defined
+            assert(ed.memtype);
             int nextValue = 0;        // C11 6.7.2.2-3 first member value defaults to 0
 
             void emSemantic(EnumMember em, ref int nextValue)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3798,6 +3798,7 @@ public:
     Loc loc;
     TOK tok;
     Identifier* id;
+    Type* base;
     Array<Dsymbol* >* members;
     Type* resolved;
     const char* kind() const;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3902,6 +3902,11 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
         buf.writeByte(' ');
         if (t.id)
             buf.writestring(t.id.toChars());
+        if (t.base.ty != TY.Tint32)
+        {
+            buf.writestring(" : ");
+            visitWithMask(t.base, t.mod, buf, hgs);
+        }
     }
 
     void visitTuple(TypeTuple t)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6761,19 +6761,21 @@ extern (C++) final class TypeTag : Type
     Loc loc;                /// location of declaration
     TOK tok;                /// TOK.struct_, TOK.union_, TOK.enum_
     Identifier id;          /// tag name identifier
+    Type base;              /// base type for enums otherwise null
     Dsymbols* members;      /// members of struct, null if none
 
     Type resolved;          /// type after semantic() in case there are more others
                             /// pointing to this instance, which can happen with
                             ///   struct S { int a; } s1, *s2;
 
-    extern (D) this(const ref Loc loc, TOK tok, Identifier id, Dsymbols* members)
+    extern (D) this(const ref Loc loc, TOK tok, Identifier id, Type base, Dsymbols* members)
     {
         //printf("TypeTag %p\n", this);
         super(Ttag);
         this.loc = loc;
         this.tok = tok;
         this.id = id;
+        this.base = base;
         this.members = members;
     }
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2062,7 +2062,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             switch (mtype.tok)
             {
                 case TOK.enum_:
-                    auto ed = new EnumDeclaration(mtype.loc, mtype.id, Type.tint32);
+                    auto ed = new EnumDeclaration(mtype.loc, mtype.id, mtype.base);
                     declare(ed);
                     mtype.resolved = visitEnum(new TypeEnum(ed));
                     break;

--- a/test/compilable/enumbase.c
+++ b/test/compilable/enumbase.c
@@ -1,0 +1,6 @@
+// https://issues.dlang.org/show_bug.cgi?id=22631
+
+enum E : char { A = 3, B };
+
+_Static_assert(sizeof(enum E) == 1, "1");
+_Static_assert(A == 3, "2");


### PR DESCRIPTION
…ng type

Easier to implement it than argue about it being an extension.