### PR TITLE
Deprecate `-m32mscoff`

### DIFF
--- a/.azure-pipelines/windows-msbuild.bat
+++ b/.azure-pipelines/windows-msbuild.bat
@@ -6,7 +6,7 @@ call "%VSINSTALLDIR%\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
 set DMD_DIR=%cd%
 if "%CONFIGURATION%" == "" set CONFIGURATION=RelWithAsserts
 set PLATFORM=Win32
-set MODEL=32mscoff
+set MODEL=32
 if "%ARCH%"=="x64" set PLATFORM=x64
 if "%ARCH%"=="x64" set MODEL=64
 set DMD=%DMD_DIR%\generated\Windows\%CONFIGURATION%\%PLATFORM%\dmd.exe
@@ -96,7 +96,7 @@ rem FIXME: lld-link fails to link phobos unittests ("error: relocation against s
 if "%C_RUNTIME%" == "mingw" exit /B 0
 cd "%DMD_DIR%\..\phobos"
 if "%D_COMPILER%_%MODEL%" == "ldc_64" copy %LDC_DIR%\lib64\libcurl.dll .
-if "%D_COMPILER%_%MODEL%" == "ldc_32mscoff" copy %LDC_DIR%\lib32\libcurl.dll .
+if "%D_COMPILER%_%MODEL%" == "ldc_32" copy %LDC_DIR%\lib32\libcurl.dll .
 if "%D_COMPILER%_%MODEL%" == "dmd_64" copy %DMD_DIR%\dmd2\windows\bin64\libcurl.dll .
-if "%D_COMPILER%_%MODEL%" == "dmd_32mscoff" copy %DMD_DIR%\dmd2\windows\bin\libcurl.dll .
+if "%D_COMPILER%_%MODEL%" == "dmd_32" copy %DMD_DIR%\dmd2\windows\bin\libcurl.dll .
 "%DM_MAKE%" -f win64.mak MODEL=%MODEL% "DMD=%DMD%" "VCDIR=%VCINSTALLDIR%." "CC=%MSVC_CC%" "MAKE=%DM_MAKE%" unittest || exit /B 7

--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -61,7 +61,7 @@ clone_repos
 if [ "$MODEL" == "64" ] ; then
     MAKE_FILE="win64.mak"
     LIBNAME=phobos64.lib
-elif [ "$MODEL" == "32mscoff" ] ; then
+elif [ "$MODEL" == "32mscoff" || "$MODEL" == "32" ] ; then
     MAKE_FILE="win64.mak"
     LIBNAME=phobos32mscoff.lib
 else

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,11 +81,11 @@ jobs:
           CONFIGURATION: Debug
         x86-mscoff:
           OS: Win_32
-          MODEL: 32mscoff
+          MODEL: 32
           ARCH: x86
         x86-mscoff_MinGW:
           OS: Win_32
-          MODEL: 32mscoff
+          MODEL: 32
           ARCH: x86
           C_RUNTIME: mingw
     steps:

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1829,6 +1829,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         }
         else if (arg == "-m32mscoff") // https://dlang.org/dmd.html#switch-m32mscoff
         {
+            deprecation(Loc.initial, "`-m32mscoff` is deprecated, use `-m32`");
             target.is64bit = false;
             target.omfobj = false;
         }


### PR DESCRIPTION
It is synonymous with `-m32` on Windows and cannot be used for other platforms.