### PR TITLE
fix Issue 22624 - ImportC: struct members in static initializer misal…

### DIFF
--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -774,6 +774,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
         }
     }
     dtb.checkInitialized();
+    //printf("+dtb.length: %d\n", dtb.length);
 
     /* Order:
      *  { base class } or { __vptr, __monitor }
@@ -863,6 +864,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
     {
         if (bitOffset)
         {
+            //printf("finishInFlightBitField() offset %d bitOffset %d bitFieldSize %d\n", offset, bitOffset, bitFieldSize);
             assert(bitFieldSize);
             dtb.nbytes(bitFieldSize, cast(char*)&bitFieldValue);
             offset += bitFieldSize;
@@ -957,7 +959,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
         assert(offset <= vd.offset);
         if (offset < vd.offset)
             dtb.nzeros(vd.offset - offset);
-        //printf("vd: %s offset: %u, vd.offset: %u\n", vd.toChars(), offset, vd.offset);
+        //printf("offset: %u, vd: %s vd.offset: %u\n", offset, vd.toChars(), vd.offset);
 
         auto dtbx = DtBuilder(0);
         if (elements)
@@ -979,7 +981,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
             else
                 Expression_toDt(e, dtbx);    // convert e to an initializer dt
         }
-        else
+        else if (!bf)
         {
             if (Initializer init = vd._init)
             {
@@ -1021,6 +1023,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
 
     if (offset < ad.structsize)
         dtb.nzeros(ad.structsize - offset);
+    //printf("-dtb.length: %d\n", dtb.length);
 }
 
 

--- a/test/runnable/fix22624.d
+++ b/test/runnable/fix22624.d
@@ -1,0 +1,18 @@
+// https://issues.dlang.org/show_bug.cgi?id=22624
+
+import core.stdc.stdio;
+import imports.imp22624;
+
+struct S
+{
+    B b;
+    ulong y = 0x1234_0000_5678;
+}
+
+int main()
+{
+    S s;
+    //printf("%llx\n", s.y);
+    assert(s.y == 0x1234_0000_5678);
+    return 0;
+}

--- a/test/runnable/imports/imp22624.c
+++ b/test/runnable/imports/imp22624.c
@@ -1,0 +1,6 @@
+
+struct B
+{
+    unsigned int x : 1;
+//    unsigned int x;
+};


### PR DESCRIPTION
…igned following bit field

I like one line bug fixes. (The bit field was being double-initialized.)