### PR TITLE
fix Issue 22623 - ImportC: typedef'd struct definition tag not put in…

### DIFF
--- a/test/compilable/fix22623.c
+++ b/test/compilable/fix22623.c
@@ -1,0 +1,18 @@
+// https://issues.dlang.org/show_bug.cgi?id=22623
+
+struct S {
+    struct T *child;
+};
+
+typedef
+struct T {
+    int xyz;
+} U;
+
+void fn()
+{
+    struct S s;
+    struct T t;
+    if (s.child != &t)
+	;
+}

--- a/test/fail_compilation/failcstuff3.c
+++ b/test/fail_compilation/failcstuff3.c
@@ -1,9 +1,7 @@
 // check importAll analysis of C files
 /* TEST_OUTPUT:
 ---
-fail_compilation/failcstuff3.c(54): Error: redeclaration of `S22061`
-fail_compilation/failcstuff3.c(100): Error: can only `*` a pointer, not a `int`
-fail_compilation/failcstuff3.c(157): Error: variable `failcstuff3.T22106.f1` no definition of struct `S22106_t`
+fail_compilation/failcstuff3.c(54): Error: union `failcstuff3.S22061` conflicts with struct `failcstuff3.S22061` at fail_compilation/failcstuff3.c(50)
 ---
 */
 
@@ -16,20 +14,3 @@ struct S22061
 };
 typedef union S22061 S22061;
 
-/***************************************************/
-// https://issues.dlang.org/show_bug.cgi?id=22103
-#line 100
-int test22103(int array[*4]);
-
-/***************************************************/
-// https://issues.dlang.org/show_bug.cgi?id=22106
-#line 150
-typedef struct S22106
-{
-    int field;
-} S22106_t;
-
-struct T22106
-{
-    struct S22106_t f1;
-};

--- a/test/fail_compilation/failcstuff4.c
+++ b/test/fail_compilation/failcstuff4.c
@@ -1,0 +1,25 @@
+// check importAll analysis of C files
+/* TEST_OUTPUT:
+---
+fail_compilation/failcstuff4.c(100): Error: can only `*` a pointer, not a `int`
+fail_compilation/failcstuff4.c(157): Error: variable `failcstuff4.T22106.f1` no definition of struct `S22106_t`
+---
+*/
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22103
+#line 100
+int test22103(int array[*4]);
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22106
+#line 150
+typedef struct S22106
+{
+    int field;
+} S22106_t;
+
+struct T22106
+{
+    struct S22106_t f1;
+};


### PR DESCRIPTION
… symbol table

Pretty much copy the code that would insert it into the symbol table if the `typedef` was absent.