### PR TITLE
Fix Issue 22127 - compiler assertion failure parser on UDA and function literal

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -4605,12 +4605,18 @@ class Parser(AST) : Lexer
                             // parseAttributes shouldn't have set these variables
                             assert(link == linkage && !setAlignment && ealign is null);
                             auto tpl_ = cast(AST.TemplateDeclaration) s;
-                            assert(tpl_ !is null && tpl_.members.dim == 1);
-                            auto fd = cast(AST.FuncLiteralDeclaration) (*tpl_.members)[0];
-                            auto tf = cast(AST.TypeFunction) fd.type;
-                            assert(tf.parameterList.parameters.dim > 0);
-                            auto as = new AST.Dsymbols();
-                            (*tf.parameterList.parameters)[0].userAttribDecl = new AST.UserAttributeDeclaration(udas, as);
+                            if (tpl_ is null || tpl_.members.dim != 1)
+                            {
+                                error("user-defined attributes are not allowed on `alias` declarations");
+                            }
+                            else
+                            {
+                                auto fd = cast(AST.FuncLiteralDeclaration) (*tpl_.members)[0];
+                                auto tf = cast(AST.TypeFunction) fd.type;
+                                assert(tf.parameterList.parameters.dim > 0);
+                                auto as = new AST.Dsymbols();
+                                (*tf.parameterList.parameters)[0].userAttribDecl = new AST.UserAttributeDeclaration(udas, as);
+                            }
                         }
 
                         v = new AST.AliasDeclaration(loc, ident, s);

--- a/test/fail_compilation/fail22127.d
+++ b/test/fail_compilation/fail22127.d
@@ -1,0 +1,11 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fail22127.d(101): Error: user-defined attributes are not allowed on `alias` declarations
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=22127
+
+#line 100
+
+alias getOne = @(0) function int () => 1;


### PR DESCRIPTION
Rebase of #13368 after I accidentally screwed up the rebase on stable.