### PR TITLE
Restore OMF builds and adapt windows.sh to MODEL=32omf

### DIFF
--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -98,9 +98,6 @@ done
 # Run DMD testsuite
 ################################################################################
 
-# Temporarily disabled because other components need to be updated as well
-if [ "$MODEL" != "32omf" ] ; then
-
 cd "$DMD_DIR/test"
 
 # build run.d testrunner and its tools while host compiler is untampered
@@ -133,8 +130,6 @@ if [ "$HOST_DMD_VERSION" = "2.079.0" ] ; then
     args=() # use default set of args
 fi
 CC="$CC" ./run --environment --jobs=$N "${targets[@]}" "${args[@]}"
-
-fi
 
 ###############################################################################
 # Upload coverage reports and exit if ENABLE_COVERAGE is specified

--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -102,7 +102,14 @@ cd "$DMD_DIR/test"
 
 # build run.d testrunner and its tools while host compiler is untampered
 cd ../test
-"$HOST_DC" -m$MODEL -g -i run.d
+
+if [ "$MODEL" == "32omf" ] ; then
+    TOOL_MODEL=32;
+else
+    TOOL_MODEL="$MODEL"
+fi
+
+"$HOST_DC" -m$TOOL_MODEL -g -i run.d
 ./run tools
 
 # Rebuild dmd with ENABLE_COVERAGE for coverage tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,10 @@ jobs:
           OS: Win_64
           MODEL: 64
           ARCH: x64
+        x86-OMF:
+          OS: Win_32
+          MODEL: 32omf
+          ARCH: x86
     steps:
       - template: .azure-pipelines/windows.yml
       - template: .azure-pipelines/windows-artifact.yml

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1819,15 +1819,18 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         }
         else if (arg == "-m32") // https://dlang.org/dmd.html#switch-m32
         {
-                target.is64bit = false;
+            target.is64bit = false;
+            target.omfobj = false;
         }
         else if (arg == "-m64") // https://dlang.org/dmd.html#switch-m64
         {
             target.is64bit = true;
+            target.omfobj = false;
         }
         else if (arg == "-m32mscoff") // https://dlang.org/dmd.html#switch-m32mscoff
         {
             target.is64bit = false;
+            target.omfobj = false;
         }
         else if (arg == "-m32omf") // https://dlang.org/dmd.html#switch-m32omfobj
         {

--- a/test/dshell/dll.d
+++ b/test/dshell/dll.d
@@ -2,7 +2,7 @@ import dshell;
 
 int main()
 {
-    version (Windows) if (Vars.MODEL == "32") // Avoid optlink
+    version (Windows) if (Vars.MODEL == "32omf") // Avoid optlink
         return DISABLED;
 
     Vars.set(`SRC`, `$EXTRA_FILES/dll`);

--- a/test/dshell/dll_cxx.d
+++ b/test/dshell/dll_cxx.d
@@ -28,9 +28,9 @@ int main()
     version (Windows)
     {
         Vars.set(`DLL_LIB`, `$OUTPUT_BASE${SEP}mydll.lib`);
-        if (Vars.MODEL == "32")
+        if (Vars.MODEL == "32omf")
         {
-            // CC should be dmc for win32.
+            // CC should be dmc for win32omf.
             dllCmd ~= [`-mn`, `-L/implib:` ~ Vars.DLL_LIB, `-WD`, `-o` ~ Vars.DLL, `kernel32.lib`, `user32.lib`];
             mainExtra = `$DLL_LIB`;
         }

--- a/test/dshell/linker_flag_with_spaces.d
+++ b/test/dshell/linker_flag_with_spaces.d
@@ -4,7 +4,7 @@ int main()
 {
     version (DigitalMars)
     {
-        if (OS == "windows" && MODEL == "32")
+        if (OS == "windows" && MODEL == "32omf")
         {
             writeln("Skipping test when using Optlink.");
             return DISABLED;

--- a/test/run.d
+++ b/test/run.d
@@ -295,9 +295,12 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
             }
             else
             {
+                string model = env["MODEL"];
+                if (model == "32omf") model = "32";
+
                 command = [
                     hostDMD,
-                    "-m"~env["MODEL"],
+                    "-m"~model,
                     "-of"~targetBin,
                     sourceFile
                 ] ~ getPicFlags(env) ~ tool.extraArgs;

--- a/test/run.d
+++ b/test/run.d
@@ -133,9 +133,10 @@ Options:
     if (verbose || dumpEnvironment)
     {
         writefln("================================================================================");
-        foreach (key, value; env)
-            writefln("%s=%s", key, value);
+        foreach (key; env.keys.sort())
+            writefln("%s=%s", key, env[key]);
         writefln("================================================================================");
+        stdout.flush();
     }
 
     if (runUnitTests)

--- a/test/runnable_cxx/cppa.d
+++ b/test/runnable_cxx/cppa.d
@@ -9,6 +9,9 @@
 
 // N.B MSVC doesn't have a C++11 switch, but it defaults to the latest fully-supported standard
 
+// Broken for unknown reasons since the OMF => MsCOFF switch
+// DISABLED: win32omf
+
 import core.stdc.stdio;
 import core.stdc.stdarg;
 import core.stdc.config;

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -186,7 +186,7 @@ immutable(EnvData) processEnvironment()
     {
         if (envData.os != "windows")
             envData.ccompiler = "c++";
-        else if (envData.model == "32")
+        else if (envData.model == "32omf")
             envData.ccompiler = "dmc";
         else if (envData.model == "64")
             envData.ccompiler = `C:\"Program Files (x86)"\"Microsoft Visual Studio 10.0"\VC\bin\amd64\cl.exe`;
@@ -984,7 +984,7 @@ bool collectExtraSources (in string input_dir, in string output_dir, in string[]
         {
             command ~= ` /c /nologo `~curSrc~` /Fo`~curObj;
         }
-        else if (envData.compiler == "dmd" && envData.os == "windows" && envData.model == "32")
+        else if (envData.compiler == "dmd" && envData.os == "windows" && envData.model == "32omf")
         {
             command ~= " -c "~curSrc~" -o"~curObj;
         }


### PR DESCRIPTION
To restore the coverage until the deprecation ends