### PR TITLE
Fix Issue 22617 - CTFE rejects modification of copied static array

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2502,15 +2502,19 @@ public:
             ale.ownedByCtfe = OwnedBy.ctfe;
             result = ale;
         }
-        else if ((cast(TypeNext)e.type).next.mod & (MODFlags.const_ | MODFlags.immutable_))
-        {
-            // If it's immutable, we don't need to dup it
-            result = e;
-        }
         else
         {
-            *pue = copyLiteral(e);
-            result = pue.exp();
+            auto elemType = (cast(TypeNext)e.type).next;
+            if (elemType.mod & (MODFlags.const_ | MODFlags.immutable_) && elemType.hasPointers())
+            {
+                // If it's immutable and contains indirections, we don't need to dup it
+                result = e;
+            }
+            else
+            {
+                *pue = copyLiteral(e);
+                result = pue.exp();
+            }
         }
     }
 

--- a/test/compilable/test22617.d
+++ b/test/compilable/test22617.d
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=22617
+
+int countWins(const uint[2] arr)
+{
+	uint[2] copy = arr;
+        copy[0] = 0;
+	return 0;
+}
+
+enum force = countWins([4, 8]);


### PR DESCRIPTION
```d
int countWins(const uint[2] arr)
{
	uint[2] copy = arr;
        copy[0] = 0;
	return 0;
}

enum force = countWins([4, 8]);
```

When passing `[4, 8]` to `countWins` the interpreter thinks that if
the parameter is constant, then there is no need to create a copy
for CTFE, however, this is true only if the variable never gets modified.
In this case, the `arr` is correctly assigned to a mutable static array, but
since the interpreter thinks that the original array literal will never get
modifier it simply initializes copy to a slice of it. Hence the error.

This patch fixes the issue by copying the initial array literal on the ctfe stack.
The copy is elided only if the array element type contains indirections.