### PR TITLE
Fix issue 22709 - [dip1000] slice of static array can be escaped in @safe using ref arguments

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -765,7 +765,6 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
         }
     }
 
-ByRef:
     foreach (VarDeclaration v; er.byref)
     {
         if (log) printf("byref: %s\n", v.toChars());
@@ -794,34 +793,13 @@ ByRef:
 
         // If va's lifetime encloses v's, then error
         if (va &&
-            (va.enclosesLifetimeOf(v) && !(v.isParameter() && v.isRef()) ||
-             va.isDataseg()) &&
+            (va.enclosesLifetimeOf(v) || (va.isRef() && !(va.storage_class & STC.temp)) || va.isDataseg()) &&
             fd.setUnsafe())
         {
             if (!gag)
                 error(ae.loc, "address of variable `%s` assigned to `%s` with longer lifetime", v.toChars(), va.toChars());
             result = true;
             continue;
-        }
-
-        if (va && v.isReference())
-        {
-            Dsymbol pva = va.toParent2();
-            for (Dsymbol pv = p; pv; )
-            {
-                pv = pv.toParent2();
-                if (pva == pv)  // if v is nested inside pva
-                {
-                    if (fd.setUnsafe())
-                    {
-                        if (!gag)
-                            error(ae.loc, "reference `%s` assigned to `%s` with longer lifetime", v.toChars(), va.toChars());
-                        result = true;
-                        continue ByRef;
-                    }
-                    break;
-                }
-            }
         }
 
         if (!(va && va.isScope()))

--- a/test/fail_compilation/retscope5.d
+++ b/test/fail_compilation/retscope5.d
@@ -5,7 +5,7 @@ REQUIRED_ARGS: -preview=dip1000
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope5.d(5010): Error: reference `t` assigned to `p` with longer lifetime
+fail_compilation/retscope5.d(5010): Error: address of variable `t` assigned to `p` with longer lifetime
 ---
 */
 

--- a/test/fail_compilation/test22709.d
+++ b/test/fail_compilation/test22709.d
@@ -1,0 +1,29 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test22709.d(15): Error: address of variable `local` assigned to `arr` with longer lifetime
+fail_compilation/test22709.d(20): Error: address of variable `local` assigned to `arr` with longer lifetime
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22709
+@safe:
+
+void escape(ref ubyte[] arr, ref ubyte[64] local)
+{
+    arr = local[];
+}
+
+void escape1(ref ubyte[64] local, ref ubyte[] arr)
+{
+    arr = local[];
+}
+
+ubyte[] getArr()
+{
+    ubyte[64] blob;
+    ubyte[] arr;
+    escape(arr, blob[]);
+    return arr;
+}


### PR DESCRIPTION
Looks like the check for assigning a reference was wrongly rewritten in https://github.com/dlang/dmd/pull/12258/files 

```diff
-            (va.enclosesLifetimeOf(v) && !(v.storage_class & STC.parameter) ||
-             va.storage_class & STC.ref_ ||
+            (va.enclosesLifetimeOf(v) && !(v.isParameter() && v.isRef()) ||
```
The check for `va` being a `ref` was removed, and the case wasn't tested either, so it slipped by.