### PR TITLE
fix Issue 22703 - importC: C++11 unscoped enums with underlying type …

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -3105,7 +3105,7 @@ final class CParser(AST) : Parser!AST
         if (token.value == TOK.colon)
         {
             nextToken();
-            base = parseType();
+            base = cparseTypeName();
         }
 
         AST.Dsymbols* members;

--- a/test/compilable/enumbase.c
+++ b/test/compilable/enumbase.c
@@ -4,3 +4,23 @@ enum E : char { A = 3, B };
 
 _Static_assert(sizeof(enum E) == 1, "1");
 _Static_assert(A == 3, "2");
+
+
+// https://issues.dlang.org/show_bug.cgi?id=22705
+
+enum L: long long {
+    L_A = 1,
+};
+
+enum U: unsigned long long {
+    U_A = 1,
+};
+
+enum U2: unsigned {
+    U2_A = 1,
+};
+
+enum U3: unsigned long {
+    U3_A = 1,
+};
+


### PR DESCRIPTION
…rejects some C types

That's what I get for copy/pasting code from the D parser.