### PR TITLE
win32.mak: Remove ENABLE_UNITTEST=1 from debdmd target

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -107,7 +107,7 @@ check-host-dc:
 debdmd: check-host-dc debdmd-make
 
 debdmd-make:
-	$(DMDMAKE) "ENABLE_DEBUG=1" "ENABLE_UNITTEST=1" $(TARGETEXE)
+	$(DMDMAKE) "ENABLE_DEBUG=1" $(TARGETEXE)
 
 reldmd: check-host-dc reldmd-make
 


### PR DESCRIPTION
DMD's unittests are an explicit target and the new default for executables with unittests causes the generated executable to  never run the actual main.