### PR TITLE
dmd.clone: Build __xopEquals and __xopCmp as hidden member functions

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -521,9 +521,9 @@ FuncDeclaration buildOpEquals(StructDeclaration sd, Scope* sc)
 
 /******************************************
  * Build __xopEquals for TypeInfo_Struct
- *      static bool __xopEquals(ref const S p, ref const S q)
+ *      bool __xopEquals(ref const S p) const
  *      {
- *          return p == q;
+ *          return this == p;
  *      }
  *
  * This is called by TypeInfo.equals(p1, p2). If the struct does not support
@@ -570,16 +570,17 @@ FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
     Loc declLoc; // loc is unnecessary so __xopEquals is never called directly
     Loc loc; // loc is unnecessary so errors are gagged
     auto parameters = new Parameters();
-    parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.p, null, null))
-              .push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.q, null, null));
-    auto tf = new TypeFunction(ParameterList(parameters), Type.tbool, LINK.d);
+    parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.p, null, null));
+    auto tf = new TypeFunction(ParameterList(parameters), Type.tbool, LINK.d, STC.const_);
+    tf = tf.addSTC(STC.const_).toTypeFunction();
     Identifier id = Id.xopEquals;
-    auto fop = new FuncDeclaration(declLoc, Loc.initial, id, STC.static_, tf);
+    auto fop = new FuncDeclaration(declLoc, Loc.initial, id, 0, tf);
     fop.generated = true;
-    Expression e1 = new IdentifierExp(loc, Id.p);
-    Expression e2 = new IdentifierExp(loc, Id.q);
+    fop.parent = sd;
+    Expression e1 = new IdentifierExp(loc, Id.This);
+    Expression e2 = new IdentifierExp(loc, Id.p);
     // TODO: simplify as soon as `git describe` for DMD master yields v2.099+
-    Expression e = global.versionNumber() >= 2099
+    Expression e = global.versionNumber() < 2099
         ? new EqualExp(EXP.equal, loc, e2, e1)
         : new EqualExp(EXP.equal, loc, e1, e2);
     fop.fbody = new ReturnStatement(loc, e);
@@ -597,9 +598,9 @@ FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
 
 /******************************************
  * Build __xopCmp for TypeInfo_Struct
- *      static bool __xopCmp(ref const S p, ref const S q)
+ *      int __xopCmp(ref const S p) const
  *      {
- *          return p.opCmp(q);
+ *          return this.opCmp(p);
  *      }
  *
  * This is called by TypeInfo.compare(p1, p2). If the struct does not support
@@ -694,14 +695,15 @@ FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
     Loc loc; // loc is unnecessary so errors are gagged
     auto parameters = new Parameters();
     parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.p, null, null));
-    parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.q, null, null));
-    auto tf = new TypeFunction(ParameterList(parameters), Type.tint32, LINK.d);
+    auto tf = new TypeFunction(ParameterList(parameters), Type.tint32, LINK.d, STC.const_);
+    tf = tf.addSTC(STC.const_).toTypeFunction();
     Identifier id = Id.xopCmp;
-    auto fop = new FuncDeclaration(declLoc, Loc.initial, id, STC.static_, tf);
+    auto fop = new FuncDeclaration(declLoc, Loc.initial, id, 0, tf);
     fop.generated = true;
-    Expression e1 = new IdentifierExp(loc, Id.p);
-    Expression e2 = new IdentifierExp(loc, Id.q);
-    Expression e = new CallExp(loc, new DotIdExp(loc, e2, Id.cmp), e1);
+    fop.parent = sd;
+    Expression e1 = new IdentifierExp(loc, Id.This);
+    Expression e2 = new IdentifierExp(loc, Id.p);
+    Expression e = new CallExp(loc, new DotIdExp(loc, e1, Id.cmp), e2);
     fop.fbody = new ReturnStatement(loc, e);
     uint errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8139,7 +8139,6 @@ struct Id final
     static Identifier* line;
     static Identifier* empty;
     static Identifier* p;
-    static Identifier* q;
     static Identifier* gate;
     static Identifier* cpp_type_info_ptr;
     static Identifier* _assert;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -115,7 +115,6 @@ immutable Msgtable[] msgtable =
     { "line" },
     { "empty", "" },
     { "p" },
-    { "q" },
     { "__vptr" },
     { "__monitor" },
     { "gate", "__gate" },


### PR DESCRIPTION
Complimentary to https://github.com/dlang/druntime/pull/3715

Druntime calls these functions as a member functions, so generating them as regular functions means the ABI is potentially mismatched.

Fixes the last difference between DMD and GDC in the shared front-end, where GDC would call `p.opCmp(q)` instead of `q.opCmp(p)` due to ABI differences for _which_ parameter is the `this` parameter in this little hack.  (It caused a regression when dmd swapped it over).

The same probably should be done for __xtoHash as well, but that is not immediately in the firing line for something that breaks GDC due to DMD's `extern(D)` divergence from the system x86 ABI (it'll likely bite us when methods are `thiscall` though).