### PR TITLE
fix Issue 22710 - CTFE on bitfields does not account for field width

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -3820,6 +3820,21 @@ public:
 
             payload = &(*sle.elements)[fieldi];
             oldval = *payload;
+            if (auto ival = newval.isIntegerExp())
+            {
+                if (auto bf = v.isBitFieldDeclaration())
+                {
+                    sinteger_t value = ival.toInteger();
+                    if (bf.type.isunsigned())
+                        value &= (1L << bf.fieldWidth) - 1; // zero extra bits
+                    else
+                    {   // sign extend extra bits
+                        value = value << (64 - bf.fieldWidth);
+                        value = value >> (64 - bf.fieldWidth);
+                    }
+                    ival.setInteger(value);
+                }
+            }
         }
         else if (auto ie = e1.isIndexExp())
         {

--- a/test/runnable/bitfields.c
+++ b/test/runnable/bitfields.c
@@ -204,6 +204,56 @@ void test6()
 
 /******************************************/
 
+// https://issues.dlang.org/show_bug.cgi?id=22710
+
+struct S7
+{
+    unsigned a:2, b:2;
+    int c:2, d:2;
+};
+
+int test7u()
+{
+    S7 s;
+    s.a = 7;
+    s.b = 1;
+    s.a += 2;
+    return s.a;
+}
+
+int test7s()
+{
+    S7 s;
+    s.c = 7;
+    s.d = 1;
+    s.c += 4;
+    return s.c;
+}
+
+int test7s2()
+{
+    S7 s;
+    s.c = 7;
+    s.d = 2;
+    s.c += 4;
+    return s.d;
+}
+
+void test7()
+{
+    //printf("uns: %d\n", test7u());
+    assert(test7u() == 1, 1);
+    //printf("sig: %d\n", test7s());
+    assert(test7s() == -1, 2);
+    assert(test7s2() == -2, 3);
+}
+
+_Static_assert(test7u() ==  1, "1");
+_Static_assert(test7s() == -1, "2");
+_Static_assert(test7s2() == -2, "3");
+
+/******************************************/
+
 int main()
 {
     test1();
@@ -212,6 +262,7 @@ int main()
     test4();
     test5();
     test6();
+    test7();
 
     return 0;
 }


### PR DESCRIPTION
Need to zero or sign-extend the extra bits of any assignment to a bit field.