### PR TITLE
fix Issue 22625 - ImportC: original name of typedefed struct not visi…

### DIFF
--- a/test/compilable/imports/imp22625.c
+++ b/test/compilable/imports/imp22625.c
@@ -1,0 +1,1 @@
+typedef struct S { int x; } T;

--- a/test/compilable/test22625.d
+++ b/test/compilable/test22625.d
@@ -1,0 +1,3 @@
+// https://issues.dlang.org/show_bug.cgi?id=22625
+
+import imports.imp22625 : S, T;


### PR DESCRIPTION
…ble in D when compiling separately

This worked for me, so I'm just adding the test case for it.