### PR TITLE
Fix issue 22733: hdrgen generates inconsistent order of STC attributes for ~this()

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1693,17 +1693,8 @@ public:
 
     override void visit(DtorDeclaration d)
     {
-        if (d.storage_class & STC.trusted)
-            buf.writestring("@trusted ");
-        if (d.storage_class & STC.safe)
-            buf.writestring("@safe ");
-        if (d.storage_class & STC.nogc)
-            buf.writestring("@nogc ");
-        if (d.storage_class & STC.live)
-            buf.writestring("@live ");
-        if (d.storage_class & STC.disable)
-            buf.writestring("@disable ");
-
+        if (stcToBuffer(buf, d.storage_class))
+            buf.writeByte(' ');
         buf.writestring("~this()");
         bodyToBuffer(d);
     }

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -478,7 +478,7 @@ class TestClass
 	{
 		return aa;
 	}
-	@trusted @nogc @disable ~this();
+	@nogc @trusted @disable ~this();
 }
 class FooA
 {

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -590,7 +590,7 @@ class TestClass
 	{
 		return aa;
 	}
-	@trusted @nogc @disable ~this()
+	@nogc @trusted @disable ~this()
 	{
 	}
 }

--- a/test/compilable/extra-files/header2.di
+++ b/test/compilable/extra-files/header2.di
@@ -11,7 +11,7 @@ void foo2(const C2 c);
 struct Foo3
 {
 	int k;
-	@trusted @nogc @live @disable ~this();
+	@nogc @live @trusted @disable ~this();
 	this(this);
 }
 class C3

--- a/test/compilable/extra-files/header2i.di
+++ b/test/compilable/extra-files/header2i.di
@@ -15,7 +15,7 @@ void foo2(const C2 c);
 struct Foo3
 {
 	int k;
-	@trusted @nogc @live @disable ~this()
+	@nogc @live @trusted @disable ~this()
 	{
 		k = 1;
 	}


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>