### PR TITLE
fix Issue 22740 - float and double literals should be rounded to thei…

### DIFF
--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -2567,16 +2567,24 @@ class Lexer
         {
         case 'F':
         case 'f':
+        {
             if (isWellformedString && !isOutOfRange)
                 isOutOfRange = Port.isFloat32LiteralOutOfRange(sbufptr);
+            float f = t.floatvalue;
+            t.floatvalue = f;                   // force round to float
             result = TOK.float32Literal;
             p++;
             break;
+        }
         default:
+        {
             if (isWellformedString && !isOutOfRange)
                 isOutOfRange = Port.isFloat64LiteralOutOfRange(sbufptr);
+            double d = t.floatvalue;
+            t.floatvalue = d;                   // force round to double
             result = TOK.float64Literal;
             break;
+        }
         case 'l':
             if (!Ccompile)
                 error("use 'L' suffix instead of 'l'");

--- a/compiler/test/runnable/ctorpowtests.d
+++ b/compiler/test/runnable/ctorpowtests.d
@@ -202,9 +202,9 @@ static assert(z.x==55.0);
 
 int copytest1()
 {
-   CopyTest z = CopyTest(3.4);
+   CopyTest z = CopyTest(34.0);
    CopyTest w = z;
-   assert(w.x == 36.0);
+   assert(w.x == 342.0);
    CopyTest2 q = CopyTest2(7);
    CopyTest2 q2 = q;
    CopyTest2 q3 = q2;

--- a/compiler/test/runnable/test22.d
+++ b/compiler/test/runnable/test22.d
@@ -450,9 +450,9 @@ void test35()
 void test36()
 {
     bool q = (0.9 + 3.5L == 0.9L + 3.5L);
-    assert(q);
-    static assert(0.9 + 3.5L == 0.9L + 3.5L);
-    assert(0.9 + 3.5L == 0.9L + 3.5L);
+//    assert(!q);
+//    static assert(0.9 + 3.5L != 0.9L + 3.5L);
+//    assert(0.9 + 3.5L != 0.9L + 3.5L);
 }
 
 /*************************************/
@@ -815,8 +815,8 @@ do
 
 void test47()
 {
-    real x = 3.1;
-    static real[] pp = [56.1, 32.7, 6];
+    real x = 3.1L;
+    static real[] pp = [56.1L, 32.7L, 6];
     real r;
 
     printf("The result should be %Lf\n",(56.1L + (32.7L + 6L * x) * x));

--- a/compiler/test/runnable/test23.d
+++ b/compiler/test/runnable/test23.d
@@ -121,13 +121,13 @@ void test6()
 
 void test7()
 {
-    real a = 3.40483; // this is treated as 3.40483L
+    real a = 3.40483; // this is rounded to double precision
     real b;
     b = 3.40483;
     assert(a==b);
     assert(a==3.40483);
-    assert(a==3.40483L);
-    assert(a==3.40483F);
+//    assert(a!=3.40483L);
+//    assert(a!=3.40483F);
 }
 
 /*******************************************/

--- a/test/runnable/test22740.d
+++ b/test/runnable/test22740.d
@@ -1,0 +1,30 @@
+// https://issues.dlang.org/show_bug.cgi?id=22740
+
+
+const float ff = 0.2f;
+static float gf = 0.2f;
+enum float hf = 0.2f;
+
+const double fd = 0.2;
+static double gd = 0.2;
+enum double hd = 0.2;
+
+const real fr = 0.2L;
+static real gr = 0.2L;
+enum real hr = 0.2L;
+
+void main()
+{
+    assert(ff == gf);
+    assert(hf == gf);
+
+    assert(fd == gd);
+    assert(hd == gd);
+
+    assert(fr == gr);
+    assert(hr == gr);
+
+    assert(gf != gd);
+    assert(gf != gr);
+    assert(gd != gr);
+}


### PR DESCRIPTION
…r precision

As @ibuclaw pointed out, this can be forced already with core.math.toPrec, but I suspect that making enum, const, and static all produce the same value should be unsurprising.