### PR TITLE
fix Issue 22727 ImportC: add __stdcall Windows calling convention

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -264,6 +264,7 @@ final class CParser(AST) : Parser!AST
         case TOK.const_:
         case TOK.volatile:
         case TOK.restrict:
+	case TOK.__stdcall:
 
         // alignment-specifier
         case TOK._Alignas:
@@ -2063,6 +2064,7 @@ final class CParser(AST) : Parser!AST
                 case TOK.typedef_:   scwx = SCW.xtypedef;   break;
                 case TOK.inline:     scwx = SCW.xinline;    break;
                 case TOK._Noreturn:  scwx = SCW.x_Noreturn; break;
+                case TOK.__stdcall:  scwx = SCW.x__stdcall; break;
                 case TOK._Thread_local: scwx = SCW.x_Thread_local; break;
 
                 // Type qualifiers
@@ -4271,6 +4273,8 @@ final class CParser(AST) : Parser!AST
         // C11 6.7.4 Function specifiers
         xinline    = 0x40,
         x_Noreturn = 0x80,
+	// extensions
+	x__stdcall = 0x100,	// Windows linkage
     }
 
     /// C11 6.7.3 Type qualifiers

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2244,7 +2244,8 @@ enum class TOK : uint8_t
     _import = 214u,
     __cdecl_ = 215u,
     __declspec_ = 216u,
-    __attribute___ = 217u,
+    __stdcall_ = 217u,
+    __attribute___ = 218u,
 };
 
 enum class MemorySet

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -271,6 +271,7 @@ enum TOK : ubyte
     _import,
     __cdecl,
     __declspec,
+    __stdcall,
     __attribute__,
 }
 
@@ -579,6 +580,7 @@ private immutable TOK[] keywords =
     TOK._import,
     TOK.__cdecl,
     TOK.__declspec,
+    TOK.__stdcall,
     TOK.__attribute__,
 ];
 
@@ -607,7 +609,7 @@ static immutable TOK[TOK.max + 1] Ckeywords =
                        restrict, return_, int16, signed, sizeof_, static_, struct_, switch_, typedef_,
                        union_, unsigned, void_, volatile, while_, asm_,
                        _Alignas, _Alignof, _Atomic, _Bool, _Complex, _Generic, _Imaginary, _Noreturn,
-                       _Static_assert, _Thread_local, _import, __cdecl, __declspec, __attribute__ ];
+                       _Static_assert, _Thread_local, _import, __cdecl, __declspec, __stdcall, __attribute__ ];
 
         foreach (kw; Ckwds)
             tab[kw] = cast(TOK) kw;
@@ -876,6 +878,7 @@ extern (C++) struct Token
         TOK._import       : "__import",
         TOK.__cdecl        : "__cdecl",
         TOK.__declspec     : "__declspec",
+        TOK.__stdcall      : "__stdcall",
         TOK.__attribute__  : "__attribute__",
     ];
 

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -280,6 +280,7 @@ enum class TOK : unsigned char
     _import,
     cdecl,
     declspec,
+    stdcall,
     attribute__,
 
     MAX,

--- a/test/compilable/test22727.c
+++ b/test/compilable/test22727.c
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=22727
+
+int fooc(int a) { return a; }
+
+__stdcall int foostdcall(int a) { return a; }
+
+int __stdcall foostdcall2(int a) { return a; }
+
+int __stdcall (*fp1)(int a) = &foostdcall;
+
+int (__stdcall *fp2)(int a) = &foostdcall2;
+

--- a/test/unit/lexer/location_offset.d
+++ b/test/unit/lexer/location_offset.d
@@ -538,6 +538,7 @@ enum ignoreTokens
     _import,
     __cdecl,
     __declspec,
+    __stdcall,
     __attribute__,
 
     max_,


### PR DESCRIPTION
Works same as `extern (Windows)` in D.

This is a partial fix for https://issues.dlang.org/show_bug.cgi?id=22727 in that it does not implement `__fastcall`. There are no plans to implement `__fastcall`.

`__stdcall` is poorly documented by Microsoft. Figuring out where it can appear in the grammar is the result of trial and error.