### PR TITLE
Fix Issue 222708 - switch statement with an undefined symbol results …

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2242,7 +2242,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
         ss._body = ss._body.statementSemantic(sc);
         sc.inLoop = inLoopSave;
 
-        if ((ss._body && ss._body.isErrorStatement()))
+        if (ss._body && ss._body.isErrorStatement())
         {
             sc.pop();
             return setError();

--- a/test/fail_compilation/diag10783.d
+++ b/test/fail_compilation/diag10783.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag10783.d(14): Error: no property `type` for type `diag10783.Event`
-fail_compilation/diag10783.d(14): Error: undefined identifier `En`
+fail_compilation/diag10783.d(14): Error: The condition expression in this switch statement failed to compile
 ---
 */
 

--- a/test/fail_compilation/fail_arrayop2.d
+++ b/test/fail_compilation/fail_arrayop2.d
@@ -323,18 +323,20 @@ void test15407exp()
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(342): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(345): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(348): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(349): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(350): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(353): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(356): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(359): Error: array operation `"str"[] + cast(immutable(char))1` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(367): Error: CTFE internal error: non-constant value `"uvt"`
-fail_compilation/fail_arrayop2.d(367): Error: `"uvt"[] - '\x01'` cannot be interpreted at compile time
+fail_compilation/fail_arrayop2.d(404): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(407): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(410): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(411): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(412): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(415): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(418): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(421): Error: array operation `"str"[] + cast(immutable(char))1` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(421): Error: The condition expression in this switch statement failed to compile
+fail_compilation/fail_arrayop2.d(429): Error: CTFE internal error: non-constant value `"uvt"`
+fail_compilation/fail_arrayop2.d(429): Error: `"uvt"[] - '\x01'` cannot be interpreted at compile time
 ---
 */
+#line 400
 // Test all statements, which can take arrays as their operands.
 void test15407stmt()
 {

--- a/test/fail_compilation/test_switch_error.d
+++ b/test/fail_compilation/test_switch_error.d
@@ -2,12 +2,12 @@
 https://issues.dlang.org/show_bug.cgi?id=22514
 TEST_OUTPUT:
 ---
-fail_compilation/test_switch_error.d(13): Error: undefined identifier `doesNotExist`
-fail_compilation/test_switch_error.d(16): Error: undefined identifier `alsoDoesNotExits`
-fail_compilation/test_switch_error.d(19): Error: duplicate `case 2` in `switch` statement
+fail_compilation/test_switch_error.d(52): Error: undefined identifier `doesNotExist`
+fail_compilation/test_switch_error.d(52): Error: The condition expression in this switch statement failed to compile
 ---
 ++/
 
+#line 50
 void test1()
 {
     switch (doesNotExist)
@@ -24,6 +24,7 @@ void test1()
 TEST_OUTPUT:
 ---
 fail_compilation/test_switch_error.d(105): Error: undefined identifier `doesNotExist`
+fail_compilation/test_switch_error.d(105): Error: The condition expression in this switch statement failed to compile
 ---
 ++/
 #line 100


### PR DESCRIPTION
…in many errors

The fix proposed bails out of the semantic analysis early.
This reduces the false errors to nil at the expense of delaying some error messages to the next compile e.g. duplicate cases