### PR TITLE
hdrgen: move trustToString function to mtype module

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2900,22 +2900,6 @@ string stcToString(ref StorageClass stc)
     return null;
 }
 
-/// Ditto
-extern (D) string trustToString(TRUST trust) pure nothrow
-{
-    final switch (trust)
-    {
-    case TRUST.default_:
-        return null;
-    case TRUST.system:
-        return "@system";
-    case TRUST.trusted:
-        return "@trusted";
-    case TRUST.safe:
-        return "@safe";
-    }
-}
-
 private void linkageToBuffer(OutBuffer* buf, LINK linkage)
 {
     const s = linkageToString(linkage);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -206,6 +206,32 @@ string MODtoString(MOD mod) nothrow pure
     }
 }
 
+/*************************************************
+ * Pick off one of the trust flags from trust,
+ * and return a string representation of it.
+ */
+string trustToString(TRUST trust) pure nothrow @nogc @safe
+{
+    final switch (trust)
+    {
+    case TRUST.default_:
+        return null;
+    case TRUST.system:
+        return "@system";
+    case TRUST.trusted:
+        return "@trusted";
+    case TRUST.safe:
+        return "@safe";
+    }
+}
+
+unittest
+{
+    assert(trustToString(TRUST.default_) == "");
+    assert(trustToString(TRUST.system) == "@system");
+    assert(trustToString(TRUST.trusted) == "@trusted");
+    assert(trustToString(TRUST.safe) == "@safe");
+}
 
 /************************************
  * Convert MODxxxx to STCxxx


### PR DESCRIPTION
Since hdrgen uses stoToString with a StorageClass to detect the presence of an
STC, trustToString is useless on hdrgen module. `trustToString` is also only
used on mtype module. This patch moves `trustToString` to mtype module and also
annotates missing attributes.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>