### PR TITLE
mtype: make sizeTy static immutable instead of __gshared

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2541,7 +2541,7 @@ struct ASTBase
         extern (C++) __gshared ClassDeclaration typeinfoshared;
         extern (C++) __gshared ClassDeclaration typeinfowild;
         extern (C++) __gshared StringTable!Type stringtable;
-        extern (C++) __gshared ubyte[TMAX] sizeTy = ()
+        extern (D) private static immutable ubyte[TMAX] sizeTy = ()
             {
                 ubyte[TMAX] sizeTy = __traits(classInstanceSize, TypeBasic);
                 sizeTy[Tsarray] = __traits(classInstanceSize, TypeSArray);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -400,7 +400,7 @@ extern (C++) abstract class Type : ASTNode
     extern (C++) __gshared Type[TMAX] basic;
 
     extern (D) __gshared StringTable!Type stringtable;
-    extern (D) private __gshared ubyte[TMAX] sizeTy = ()
+    extern (D) private static immutable ubyte[TMAX] sizeTy = ()
         {
             ubyte[TMAX] sizeTy = __traits(classInstanceSize, TypeBasic);
             sizeTy[Tsarray] = __traits(classInstanceSize, TypeSArray);


### PR DESCRIPTION
Since sizeTy is never modified and can by initialized at compile-time, lets
make it static immutable in order to make compiler functions @safe and pure.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>