### PR TITLE
fix Issue 22749 - importC: C11 does not allow taking the address of a bit-field

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6922,6 +6922,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.error("cannot take address of `%s`", exp.e1.toChars());
             return setError();
         }
+        if (auto dve = exp.e1.isDotVarExp())
+        {
+            /* https://issues.dlang.org/show_bug.cgi?id=22749
+             * Error about taking address of any bit-field, regardless of
+             * whether SCOPE.Cfile is set.
+             */
+            if (auto bf = dve.var.isBitFieldDeclaration())
+            {
+                exp.error("cannot take address of bit-field `%s`", bf.toChars());
+                return setError();
+            }
+        }
 
         bool hasOverloads;
         if (auto f = isFuncAddress(exp, &hasOverloads))

--- a/test/fail_compilation/fail22749.d
+++ b/test/fail_compilation/fail22749.d
@@ -1,0 +1,13 @@
+// EXTRA_FILES: imports/imp22749.c
+/* TEST_OUTPUT:
+---
+fail_compilation/fail22749.d(12): Error: cannot take address of bit-field `field`
+---
+*/
+import imports.imp22749;
+
+void test22749()
+{
+    S22749 s;
+    void* ptr = &s.field;
+}

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -35,6 +35,7 @@ fail_compilation/failcstuff2.c(354): Error: variable `arr` cannot be read at com
 fail_compilation/failcstuff2.c(360): Error: variable `str` cannot be read at compile time
 fail_compilation/failcstuff2.c(404): Error: undefined identifier `p1`
 fail_compilation/failcstuff2.c(404): Error: undefined identifier `p2`
+fail_compilation/failcstuff2.c(458): Error: cannot take address of bit-field `field`
 ---
 */
 
@@ -154,4 +155,18 @@ long test22584(long p1, long p2);
 long test22584(long, long)
 {
     return p1 + p2;
+}
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22749
+#line 450
+struct S22749
+{
+    int field : 1;
+};
+
+void test22749(void)
+{
+    struct S22749 s; 
+    void *ptr = &s.field;
 }

--- a/test/fail_compilation/imports/imp22749.c
+++ b/test/fail_compilation/imports/imp22749.c
@@ -1,0 +1,4 @@
+struct S22749
+{
+    int field : 1;
+};


### PR DESCRIPTION
@WalterBright said that this wasn't possible at the last DLFM, I tried it, and DMD compiled it.