### PR TITLE
frontend: propagate error as null instead of exit(1)

### DIFF
--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -407,7 +407,7 @@ Tuple!(Module, "module_", Diagnostics, "diagnostics") parseModule(AST = ASTCodeg
         }
     }
 
-    m.parseModule!AST();
+    m = m.parseModule!AST();
 
     Diagnostics diagnostics = {
         errors: global.errors,


### PR DESCRIPTION
This patch propagates null when Module AST node can't be constructed correctly
instead of doing fatal(), which terminates the program. This is useful if users
use DMD frontend as a library.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>