### PR TITLE
Include coverage from `unit`  tests

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -98,9 +98,9 @@ test() {
 test_dmd() {
     # test fewer compiler argument permutations for PRs to reduce CI load
     if [ "$FULL_BUILD" == "true" ] && [ "$OS_NAME" == "linux"  ]; then
-        make -j1 -C test auto-tester-test MODEL=$MODEL N=$N # all ARGS by default
+        make -j1 -C test MODEL=$MODEL N=$N # all ARGS by default
     else
-        make -j1 -C test auto-tester-test MODEL=$MODEL N=$N ARGS="-O -inline -release"
+        make -j1 -C test MODEL=$MODEL N=$N ARGS="-O -inline -release"
     fi
 }
 

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -11,7 +11,10 @@ then
 fi
 
 # CodeCov gets confused by lst files which it can't match
-rm -rf test/runnable/extra-files test/*.lst
+rm -rf test/runnable/extra-files \
+    test/*.lst \
+    ./*test_results-runner.lst \
+    __main.lst
 
 # Save the file from URL passed as $1 to the location in $2
 doCurl()

--- a/test/run.d
+++ b/test/run.d
@@ -143,7 +143,7 @@ Options:
     {
         verifyCompilerExists(env);
         ensureToolsExists(env, TestTools.unitTestRunner);
-        return spawnProcess(unitTestRunnerCommand ~ args).wait();
+        return spawnProcess(unitTestRunnerCommand ~ args, env, Config.none, scriptDir).wait();
     }
 
     if (args == ["tools"])

--- a/test/tools/unit_test_runner.d
+++ b/test/tools/unit_test_runner.d
@@ -215,6 +215,18 @@ void writeRunnerFile(Range)(Range moduleNames, string path, string filter)
 
             return result;
         }
+
+        version (D_Coverage)
+        shared static this()
+        {
+            import core.runtime;
+
+            static immutable sourcePath = `%s`;
+
+            dmd_coverSourcePath(sourcePath);
+            dmd_coverDestPath(sourcePath);
+            dmd_coverSetMerge(true);
+        }
     }.outdent;
 
     const imports = moduleNames
@@ -227,7 +239,7 @@ void writeRunnerFile(Range)(Range moduleNames, string path, string filter)
         .joiner(",\n")
         .to!string;
 
-    const content = format!codeTemplate(imports, modules, format!`"%s"`(filter));
+    const content = format!codeTemplate(imports, modules, format!`"%s"`(filter), projectRootDir);
     write(path, content);
 }
 

--- a/test/tools/unit_test_runner.d
+++ b/test/tools/unit_test_runner.d
@@ -8,10 +8,10 @@ import std.exception : enforce;
 import std.file : dirEntries, exists, SpanMode, mkdirRecurse, write;
 import std.format : format;
 import std.getopt : getopt;
-import std.path : absolutePath, buildPath, dirSeparator, stripExtension,
+import std.path : absolutePath, buildPath, dirSeparator,  relativePath, stripExtension,
     setExtension;
-import std.process : environment, execute;
-import std.range : empty;
+import std.process : Config, environment, execute;
+import std.range : empty, chain;
 import std.stdio;
 import std.string : join, outdent;
 
@@ -241,7 +241,7 @@ Params:
 */
 string[] buildCmdArgs(string runnerPath, string outputPath, const string[] testFiles)
 {
-    auto flags = [
+    auto flags = chain([
         "-version=NoBackend",
         "-version=GC",
         "-version=NoMain",
@@ -249,14 +249,17 @@ string[] buildCmdArgs(string runnerPath, string outputPath, const string[] testF
         "-version=DMDLIB",
         "-unittest",
         "-J" ~ buildOutputPath,
-        "-J" ~ projectRootDir.buildPath("src/dmd/res"),
-        "-I" ~ projectRootDir.buildPath("src"),
+        "-Jsrc/dmd/res",
+        "-Isrc",
         "-I" ~ unitTestDir,
         "-i",
         "-main",
         "-of" ~ outputPath,
         "-m" ~ model
-    ] ~ testFiles ~ runnerPath;
+    ],
+        testFiles.map!(f => relativePath(f, projectRootDir)),
+        [ runnerPath ]
+    ).array;
 
     // Generate coverage reports if requested
     if (environment.get("DMD_TEST_COVERAGE", "0") == "1")
@@ -310,7 +313,8 @@ int main(string[] args)
     if (missingTestFiles(givenFiles))
         return 1;
 
-    const runnerPath = resultsDir.buildPath("runner.d");
+    const absResultsDir = resultsDir.absolutePath();
+    const runnerPath = absResultsDir.buildPath("runner.d");
     const testFiles = givenFiles.testFiles;
 
     mkdirRecurse(resultsDir);
@@ -318,12 +322,12 @@ int main(string[] args)
         .moduleNames
         .writeRunnerFile(runnerPath, unitTestFilter);
 
-    const cmdfilePath = resultsDir.buildPath("cmdfile");
-    const outputPath = resultsDir.buildPath("runner").setExtension(exeExtension);
+    const cmdfilePath = absResultsDir.buildPath("cmdfile");
+    const outputPath = absResultsDir.buildPath("runner" ~ exeExtension);
     const flags = buildCmdArgs(runnerPath, outputPath, testFiles);
     write(cmdfilePath, flags.join("\n"));
 
-    const dmd = execute([ dmdPath, "@" ~ cmdfilePath ]);
+    const dmd = execute([ dmdPath, "@" ~ cmdfilePath ], null, Config.none, size_t.max, projectRootDir);
     if (dmd.status)
     {
         enum msg = "Failed to compile the `unit` test executable! (exit code %d)


### PR DESCRIPTION
Ensures that the `unit` tests are run for coverage builds and that the resulting coverage date is included in the report.

This required some changes s.t. coverage files are emitted to the right directory + name. See the individual commits for the actual changes + explaination.

CC @ljmf00 