### PR TITLE
treewide: remove trailing whitespaces

### DIFF
--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -223,7 +223,7 @@ jobs:
       run: |
         if [ "${{ matrix.cxx-version }}" == "8.0.0" -o "${{ matrix.cxx-version }}" == "9.0.0" ]; then
           wget --quiet --directory-prefix=${{ github.workspace }} https://releases.llvm.org/${{ matrix.cxx-version }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}.tar.xz
-        else 
+        else
           wget --quiet --directory-prefix=${{ github.workspace }} https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ matrix.cxx-version }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}.tar.xz
         fi
         tar -x -C ${{ github.workspace }} -f ${{ github.workspace }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}.tar.xz

--- a/src/README.md
+++ b/src/README.md
@@ -27,8 +27,8 @@ or see the list of major targets below.
 
 ### Prerequisites
 
-To bootstrap `dmd` on posix you need to have a `C++` compiler installed, 
-such as gcc, when using the default `$CC` setting. 
+To bootstrap `dmd` on posix you need to have a `C++` compiler installed,
+such as gcc, when using the default `$CC` setting.
 
 ### Bootstrapping
 

--- a/test/compilable/b18242.d
+++ b/test/compilable/b18242.d
@@ -5,14 +5,14 @@ module object;
 class Object { }
 
 class TypeInfo { }
-class TypeInfo_Class : TypeInfo 
-{ 
+class TypeInfo_Class : TypeInfo
+{
     version(D_LP64) { ubyte[136] _x; } else { ubyte[68] _x; }
 }
 
 class Throwable { }
 
-int _d_run_main() 
+int _d_run_main()
 {
     try { } catch(Throwable e) { return 1; }
     return 0;

--- a/test/compilable/b19294.d
+++ b/test/compilable/b19294.d
@@ -51,19 +51,19 @@ void test()
     MT s = MyStruct!int(1);
     MT[] arr = [s, 2 * s, 3 * s, 4 * s, 5 * s, 6 * s];
     MT[] result = new MT[arr.length];
-    
+
     result[] = arr[] + s;
     result[] = s + arr[];
-    
+
     result[] = arr[] - s;
     result[] = s - arr[];
-    
+
     result[] = arr[] * s;
     result[] = s * arr[];
-    
+
     result[] = arr[] / s;
     result[] = s / arr[];
-    
+
     result[] = arr[] ^^ s;
     result[] = s ^^ arr[];
 }

--- a/test/compilable/b20938.d
+++ b/test/compilable/b20938.d
@@ -12,11 +12,11 @@ void fun() {
     immutable S _is;
     Object o;
     immutable Object io;
-    
+
     auto a = [pi, ipi];
-    auto b = [ai, iai];    
+    auto b = [ai, iai];
     auto c = [s, _is];
     auto d = [o, io];
-    
+
     auto e = [A.a, B.b];
 }

--- a/test/compilable/b21285.d
+++ b/test/compilable/b21285.d
@@ -1,27 +1,27 @@
 // REQUIRED_ARGS: -unittest
-// Issue 21285 - Delegate covariance broken between 2.092 and 2.094 (git master). 
+// Issue 21285 - Delegate covariance broken between 2.092 and 2.094 (git master).
 unittest
 {
     string path;
     int bank;
     static string path2;
     static int bank2;
-    
+
     // delegates
     auto a = [
         (string arg) { path = arg; },
         (string arg) { bank = 1; throw new Exception(""); }
     ];
-    
+
     // functions
     auto ab = [
         (string arg) { path2 = arg; },
         (string arg) { bank2 = 1; throw new Exception(""); }
     ];
-    
+
     alias dg = void delegate(string) pure @safe;
     alias fn = void function(string) @safe;
-    
+
     static assert(is(typeof(a[0]) == dg));
     static assert(is(typeof(ab[0]) == fn));
 }

--- a/test/compilable/ddoc10.d
+++ b/test/compilable/ddoc10.d
@@ -171,7 +171,7 @@ struct T
     /****
      */
     this(A...)(A args) { }
-    
+
     ///
     this(int){}
 }

--- a/test/compilable/ddoc11.d
+++ b/test/compilable/ddoc11.d
@@ -49,7 +49,7 @@ struct lldiv_t { long quot,rem; }
 
 
 
-    void *calloc(size_t, size_t);	/// 
+    void *calloc(size_t, size_t);	///
     void *malloc(size_t);	/// dittx
 
 /**

--- a/test/compilable/ddoc14.d
+++ b/test/compilable/ddoc14.d
@@ -77,7 +77,7 @@ interface Interface {
     V mColon(lazy P p) ; /// 10
 }
 +/
-    
+
 public P variable;  /// 0
 V mNone(lazy P p) {}  /// 1
 pure nothrow V mPrefix(lazy P p) {}   /// 2

--- a/test/compilable/ddoc3.d
+++ b/test/compilable/ddoc3.d
@@ -42,7 +42,7 @@
  *	$(TROW 4, 5, 6)
  *	)
  *
- * $(D_CODE 
+ * $(D_CODE
       $(B pragma)( $(I name) );
       $(B pragma)( $(I name) , $(I option) [ $(I option) ] );
       $(U $(LPAREN))

--- a/test/compilable/ddoc5.d
+++ b/test/compilable/ddoc5.d
@@ -15,10 +15,10 @@ class TestMembers(TemplateArg)
   public:
     /**
 
-       a static method 
+       a static method
 
        Params: idx = index
-   
+
     */
     static void PublicStaticMethod(int  idx)
     {

--- a/test/compilable/ddoc5446.d
+++ b/test/compilable/ddoc5446.d
@@ -30,41 +30,41 @@ struct Bar
 {
     /** */
     alias A_Foo Bar_A_Foo;
-    
+
     /** */
     alias A_Foo_Alias Bar_A_Foo_Alias;
-    
+
     /** */
     alias A_Int Bar_A_Int;
-    
+
     /** */
     alias This_Foo Bar_This_Foo;
-    
+
     /** */
     alias This_Foo_Alias Bar_This_Foo_Alias;
-    
+
     /** */
     alias This_Int Bar_This_Int;
-    
+
     /** */
     alias Nested Nested_Alias;
-    
+
     /** */
     alias .Nested Fake_Nested;
-    
+
     /** */
     struct Nested
     {
         /** */
         alias Bar Bar_Nested_Bar_Alias;
-        
+
         /** */
         alias .Bar Bar_Alias;
-        
+
         /** */
         struct Bar
         {
-            
+
         }
     }
 }

--- a/test/compilable/ddoc9155.d
+++ b/test/compilable/ddoc9155.d
@@ -12,12 +12,12 @@ module ddoc9155;
  +  ---
  +  import std.stdio;   //&
  +  writeln("Hello world!");
- +  if (test) {  
+ +  if (test) {
  +    writefln("D programming language");
  +  }
  +
  +      algorithm;
- +  
+ +
  +  xxx;    //comment
  +      yyy;
  +  /* test
@@ -28,7 +28,7 @@ module ddoc9155;
  +File f = File("./text.txt", "r");
  +uint line = 0;
  + // The ElementType of data is not aggregation type
- +foreach (encoded; Base64.encoder(data)) 
+ +foreach (encoded; Base64.encoder(data))
  +  ---
  +/
 
@@ -45,12 +45,12 @@ module ddoc9155;
  *  ---
  *  import std.stdio;   //&
  *  writeln("Hello world!");
- *  if (test) {  
+ *  if (test) {
  *    writefln("D programming language");
  *  }
  *
  *      algorithm;
- *  
+ *
  *  xxx;    //comment
  *      yyy;
  *  /+ test

--- a/test/compilable/defa.d
+++ b/test/compilable/defa.d
@@ -3,7 +3,7 @@
 module defa;
 
 private import imports.defaa;
-	
+
 public abstract class A
 {
 	Display d;

--- a/test/compilable/iasm_labeloperand.d
+++ b/test/compilable/iasm_labeloperand.d
@@ -17,19 +17,19 @@ version (TestInlineAsm)
 			nop;
 			nop;
 			nop;
-			
+
 			mov EAX, dword ptr L1; // Check back references
 			mov EAX, dword ptr L2; // Check forward references
 			mov EAX, dword ptr DS:L1; // Not really useful in standard use, but who knows.
 			mov EAX, dword ptr FS:L2; // Once again, not really useful, but it is valid.
 			mov EAX, dword ptr CS:L1; // This is what the first test case should implicitly be.
-			
+
 		L2:
 			nop;
 			nop;
 			nop;
 			nop;
-			
+
         }
     }
 }

--- a/test/compilable/imports/b33a.d
+++ b/test/compilable/imports/b33a.d
@@ -6,10 +6,10 @@ struct IsEqual( T )
     {
 	return p1 == p2;
     }
-}    
+}
 
 template find_( Elem, Pred = IsEqual!(Elem) )
-{    
+{
     size_t fn( char[] buf, Pred pred = Pred.init )
     {
         return 3;

--- a/test/compilable/imports/testcov1a.d
+++ b/test/compilable/imports/testcov1a.d
@@ -2,7 +2,7 @@ module testcov1a;
 
 import testcov1b;
 
-alias ArraySet!(int,3) IntegerSet;  
+alias ArraySet!(int,3) IntegerSet;
 
 
 

--- a/test/compilable/imports/testcov1b.d
+++ b/test/compilable/imports/testcov1b.d
@@ -3,7 +3,7 @@ module testcov1b;
 class ArraySet(Key, int div = 1)
 {
   private Key[][div] polje;
-  
+
   public this(in ArraySet a)
   {
     foreach(Key k, uint i; a)

--- a/test/compilable/issue21340.d
+++ b/test/compilable/issue21340.d
@@ -5,7 +5,7 @@ version (CppRuntime_Sun)   version = CppMangle_Itanium;
 template ScopeClass(C)
 if (is(C == class) && __traits(getLinkage, C) == "C++")
 {
-    
+
     extern(C++, class)
     extern(C++, __traits(getCppNamespaces,C))
     extern(C++, (ns))
@@ -35,4 +35,4 @@ alias ns = AliasSeq!();
 immutable ns2 = AliasSeq!();
 extern(C++,(ns)) class Bar {}
 extern(C++,) class Baz {}
-extern(C++, (ns2)) class Quux {} 
+extern(C++, (ns2)) class Quux {}

--- a/test/compilable/issue21813b.d
+++ b/test/compilable/issue21813b.d
@@ -4,7 +4,7 @@ Target.OS defaultTargetOS()
     return Target.OS.linux;
 }
 
-struct Target 
+struct Target
 {
     enum OS { linux }
     OS os = defaultTargetOS();

--- a/test/compilable/minimal.d
+++ b/test/compilable/minimal.d
@@ -10,7 +10,7 @@
 
 struct S { }
 
-enum E 
+enum E
 {
     e0 = 0,
     e1 = 1

--- a/test/compilable/test10993.d
+++ b/test/compilable/test10993.d
@@ -19,7 +19,7 @@ auto fun()
 {
 	auto x = foo!()(test!(a=>a)());
 //	pragma(msg, "fun: " ~ typeof(x).mangleof);
-	
+
 	return x;
 }
 

--- a/test/compilable/test16107.d
+++ b/test/compilable/test16107.d
@@ -3,12 +3,12 @@
 bool check()
 {
     bool result = false;
-    
+
     result |= false;
     if (result) goto ret;
-    
+
     result |= false;
     if (result) {}
-    
+
     ret: return true;
 }

--- a/test/compilable/test17545.d
+++ b/test/compilable/test17545.d
@@ -12,5 +12,5 @@ struct Attrib {}
 
 @Attrib enum TEST = 123;
 
-pragma(msg, __traits(getAttributes, 
+pragma(msg, __traits(getAttributes,
                      __traits(getMember, example, "TEST")));

--- a/test/compilable/test18030.d
+++ b/test/compilable/test18030.d
@@ -9,6 +9,6 @@ struct S(T)
 class C
 {
 	alias Al = S!C;
-	
+
 	static void func(U)(U var) { }
 }

--- a/test/compilable/test19014.d
+++ b/test/compilable/test19014.d
@@ -8,5 +8,5 @@ void main()
     {
     	static import core.stdc.math;
     }
-    static assert(!__traits(compiles, core.stdc.math.cos(0))); 
+    static assert(!__traits(compiles, core.stdc.math.cos(0)));
 }

--- a/test/compilable/test19315.d
+++ b/test/compilable/test19315.d
@@ -1,5 +1,5 @@
 //https://issues.dlang.org/show_bug.cgi?id=19315
-void main() 
+void main()
 {
     #line 100 "file.d"
     enum code = q{

--- a/test/compilable/test19557.d
+++ b/test/compilable/test19557.d
@@ -1,6 +1,6 @@
 // https://issues.dlang.org/show_bug.cgi?id=19557
 // Error: redundant linkage `extern (C++)`
-    
+
 extern(C++, "ns")
 extern(C++, class)
 struct test {}

--- a/test/compilable/test21177.d
+++ b/test/compilable/test21177.d
@@ -30,7 +30,7 @@ void main()
         printf("%a", 2.);
         printf("%m %m %s");
         printf("%*m");
-        
+
         char* a, b;
         sscanf("salut poilu", "%a %m", a, b);
         assert(!strcmp(a, b));
@@ -71,6 +71,6 @@ void main()
         sscanf("205", "%ms", c);
         sscanf("206", "%a", c);
         sscanf("207", "%as", c);
-        
+
     }
 }

--- a/test/compilable/test22224.d
+++ b/test/compilable/test22224.d
@@ -1,4 +1,4 @@
 // REQUIRED_ARGS: -profile -c
 
-import core.stdc.stdarg; 
+import core.stdc.stdarg;
 void error(...) { }

--- a/test/compilable/test4375.d
+++ b/test/compilable/test4375.d
@@ -256,7 +256,7 @@ label1:
                         else
                             assert(89);
     else
-        assert(12); 
+        assert(12);
 
 
     with (x)
@@ -299,7 +299,7 @@ label1:
             if (true)
                 assert(110);
             else
-                assert(112);                
+                assert(112);
         finally
             assert(111);
 
@@ -316,7 +316,7 @@ label1:
             int w;
 
         static if (true)
-            int t; 
+            int t;
         else static if (false)
             int u;
         else

--- a/test/compilable/test8296.d
+++ b/test/compilable/test8296.d
@@ -10,7 +10,7 @@ struct bar2
 
 class InnerBar {
   bar2 b;
-  
+
   this()
   {
     b = bar2(0);
@@ -21,7 +21,7 @@ struct bar1
 {
   InnerBar b;
 }
-  
+
 class Foo
 {
   bar1 m_bar1;

--- a/test/compilable/test8513.d
+++ b/test/compilable/test8513.d
@@ -5,25 +5,25 @@ class Bar
 {
     interface I_Foo { void i_inner(); }
     class C_Foo { void c_inner() { } }
-    
+
     class Impl1 : C_Foo, I_Foo
     {
         override void i_inner() { }
         override void c_inner() { }
     }
-    
+
     class Impl2 : C_Foo, .I_Foo
     {
         override void i_outer() { }
         override void c_inner() { }
     }
-    
+
     class Impl3 : .C_Foo, I_Foo
     {
         override void i_inner() { }
         override void c_outer() { }
     }
-    
+
     class Impl4 : .C_Foo, .I_Foo
     {
         override void i_outer() { }

--- a/test/compilable/testpostblit.d
+++ b/test/compilable/testpostblit.d
@@ -14,4 +14,4 @@ struct Test1c
 {
     const Test1b b;
     @disable this(this);
-} 
+}

--- a/test/compilable/typeid_name.d
+++ b/test/compilable/typeid_name.d
@@ -9,6 +9,6 @@ class Panzer {}
 class Tiger : Panzer {}
 
 static assert (() {
-    Panzer p = new Tiger(); return classname(p); 
+    Panzer p = new Tiger(); return classname(p);
 } () == "Tiger");
 

--- a/test/dub_package/testfiles/correct.d
+++ b/test/dub_package/testfiles/correct.d
@@ -18,7 +18,7 @@ struct Foo {
  * Params:
  *      x = something cool
  */
-int foo(int x) { 
+int foo(int x) {
     int a = 0;
 
     if (a == 1) {

--- a/test/fail_compilation/b20011.d
+++ b/test/fail_compilation/b20011.d
@@ -37,4 +37,4 @@ void main()
     assignableByRef(s1.member);
     assignableByOut(s1.member);
     assignableByConstRef(s1.member);
-} 
+}

--- a/test/fail_compilation/b3841.d
+++ b/test/fail_compilation/b3841.d
@@ -47,7 +47,7 @@ void main()
         f!(op, long, short)();
         f!(op, float, long)();
         f!(op, double, float)();
-        
+
         // Should that really be OK ?
         f!(op, short, int)();
         f!(op, float, double)();

--- a/test/fail_compilation/bug16165.d
+++ b/test/fail_compilation/bug16165.d
@@ -7,7 +7,7 @@ void g()
 	f(5, 6, 404);
 }
 
-/* 
+/*
 TEST_OUTPUT:
 ---
 fail_compilation/bug16165.d(6): Error: function `bug16165.f(int x, Object y)` is not callable using argument types `(Object, Object, int)`

--- a/test/fail_compilation/ccast.d
+++ b/test/fail_compilation/ccast.d
@@ -1,4 +1,4 @@
-/* 
+/*
 TEST_OUTPUT:
 ---
 fail_compilation/ccast.d(9): Error: C style cast illegal, use `cast(byte)i`

--- a/test/fail_compilation/diag16977.d
+++ b/test/fail_compilation/diag16977.d
@@ -13,7 +13,7 @@ fail_compilation/diag16977.d(30): Error: template instance `diag16977.test.funcT
 ---
 */
 
-// when copying the expression of a default argument, location information is 
+// when copying the expression of a default argument, location information is
 //   replaced by the location of the caller to improve debug information
 // verify error messages are displayed for the original location only
 
@@ -26,7 +26,7 @@ void test()
     void badOp(int x, int y = 1 ~ "string") {}
     void lazyTemplate(int x, lazy int y = 4.templ) {}
     void funcTemplate(T)(T y = 5) {}
-    
+
     funcTemplate!string();
     undefinedId(1);
     badOp(2);

--- a/test/fail_compilation/fail14554.d
+++ b/test/fail_compilation/fail14554.d
@@ -25,6 +25,6 @@ struct issue14554_2 {
 
 void test14554()
 {
-     issue14554_1.foo!bool(1);    
-     issue14554_2.foo!bool(1);    
+     issue14554_1.foo!bool(1);
+     issue14554_2.foo!bool(1);
 }

--- a/test/fail_compilation/fail160.d
+++ b/test/fail_compilation/fail160.d
@@ -14,7 +14,7 @@ template Wrapper(B, alias Func, int func)
     alias typeof(&Func) FuncPtr;
 
     private static FuncPtr get_funcptr() { return func; }
-} 
+}
 
 
 int main(char[][] args)

--- a/test/fail_compilation/fail17969.d
+++ b/test/fail_compilation/fail17969.d
@@ -4,7 +4,7 @@ fail_compilation/fail17969.d(9): Error: no property `sum` for type `fail17969.__
 ---
  * https://issues.dlang.org/show_bug.cgi?id=17969
  */
- 
+
 
 alias fun = a => MapResult2!(b => b).sum;
 

--- a/test/fail_compilation/fail19911b.d
+++ b/test/fail_compilation/fail19911b.d
@@ -1,4 +1,4 @@
-/* 
+/*
 DFLAGS:
 EXTRA_SOURCES: extra-files/minimal/object.d
 TEST_OUTPUT:

--- a/test/fail_compilation/fail19911c.d
+++ b/test/fail_compilation/fail19911c.d
@@ -1,4 +1,4 @@
-/* 
+/*
 DFLAGS:
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/fail19922.d
+++ b/test/fail_compilation/fail19922.d
@@ -1,4 +1,4 @@
-/* 
+/*
 DFLAGS:
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/fail19923.d
+++ b/test/fail_compilation/fail19923.d
@@ -1,4 +1,4 @@
-/* 
+/*
 DFLAGS:
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/fail20.d
+++ b/test/fail_compilation/fail20.d
@@ -14,6 +14,6 @@ void main()
     FOO one;
     FOO two;
     if (one < two){} // This should tell me that there
-                     // is no opCmp() defined instead 
+                     // is no opCmp() defined instead
                      // of crashing.
 }

--- a/test/fail_compilation/fail20800.d
+++ b/test/fail_compilation/fail20800.d
@@ -15,7 +15,7 @@ struct RegexMatch
 }
 static m() { return RegexMatch(); }
 
-void fun(int a); 
+void fun(int a);
 
 void initCommands()
 {

--- a/test/fail_compilation/fail332.d
+++ b/test/fail_compilation/fail332.d
@@ -21,7 +21,7 @@ void test()
 {
     foo();
     foo(null);
-    
+
     baz("");
     baz(3, null);
 }

--- a/test/fail_compilation/fail354.d
+++ b/test/fail_compilation/fail354.d
@@ -10,4 +10,4 @@ struct S(int N)
 {
     this(T!N) { }
 }
-alias S!1 M; 
+alias S!1 M;

--- a/test/fail_compilation/fail4269a.d
+++ b/test/fail_compilation/fail4269a.d
@@ -10,6 +10,6 @@ enum bool WWW = is(typeof(A.x));
 
 interface A {
     B blah;
-    void foo(B b){} 
+    void foo(B b){}
 }
 

--- a/test/fail_compilation/fail4269b.d
+++ b/test/fail_compilation/fail4269b.d
@@ -9,6 +9,6 @@ enum bool WWW = is(typeof(A.x));
 
 struct A {
     B blah;
-    void foo(B b){} 
+    void foo(B b){}
 }
 

--- a/test/fail_compilation/fail4269c.d
+++ b/test/fail_compilation/fail4269c.d
@@ -9,6 +9,6 @@ enum bool WWW = is(typeof(A.x));
 
 class A {
     B blah;
-    void foo(B b){} 
+    void foo(B b){}
 }
 

--- a/test/fail_compilation/fail4375d.d
+++ b/test/fail_compilation/fail4375d.d
@@ -14,7 +14,7 @@ void main() {
 label2:
         if (true)
             assert(15);
-    else 
+    else
         assert(16);
 }
 

--- a/test/fail_compilation/fail6968.d
+++ b/test/fail_compilation/fail6968.d
@@ -29,4 +29,4 @@ template PredAny(A, B...)
 void main()
 {
     pragma(msg, PredAny!(int, long, float));
-} 
+}

--- a/test/fail_compilation/fail80_m32.d
+++ b/test/fail_compilation/fail80_m32.d
@@ -23,7 +23,7 @@ class Test
 
     static Image[] images;
 
-    static void initIcons() 
+    static void initIcons()
     {
         images["progress_rem"]  = ResourceManager.getImage("progress_rem.gif"); // delete_obj_dis
         images["redo"]          = ResourceManager.getImage("redo.gif");

--- a/test/fail_compilation/fail80_m64.d
+++ b/test/fail_compilation/fail80_m64.d
@@ -23,7 +23,7 @@ class Test
 
     static Image[] images;
 
-    static void initIcons() 
+    static void initIcons()
     {
         images["progress_rem"]  = ResourceManager.getImage("progress_rem.gif"); // delete_obj_dis
         images["redo"]          = ResourceManager.getImage("redo.gif");

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -167,6 +167,6 @@ struct S22749
 
 void test22749(void)
 {
-    struct S22749 s; 
+    struct S22749 s;
     void *ptr = &s.field;
 }

--- a/test/fail_compilation/ice18753.d
+++ b/test/fail_compilation/ice18753.d
@@ -14,7 +14,7 @@ struct ChunkByImpl
 {
     struct Group
     { }
-    
+
     static assert(isForwardRange!Group);
 }
 

--- a/test/fail_compilation/no_Throwable.d
+++ b/test/fail_compilation/no_Throwable.d
@@ -1,4 +1,4 @@
-/* 
+/*
 DFLAGS:
 REQUIRED_ARGS: -c
 EXTRA_SOURCES: extra-files/minimal/object.d

--- a/test/fail_compilation/no_TypeInfo.d
+++ b/test/fail_compilation/no_TypeInfo.d
@@ -1,4 +1,4 @@
-/* 
+/*
 DFLAGS:
 REQUIRED_ARGS: -c
 EXTRA_SOURCES: extra-files/minimal/object.d

--- a/test/fail_compilation/test17307.d
+++ b/test/fail_compilation/test17307.d
@@ -1,4 +1,4 @@
-/* 
+/*
 TEST_OUTPUT:
 ---
 fail_compilation/test17307.d(9): Error: anonymous struct can only be a part of an aggregate, not module `test17307`

--- a/test/runnable/b18034.d
+++ b/test/runnable/b18034.d
@@ -3,22 +3,22 @@ import core.simd;
 
 static if (__traits(compiles, { void16 a; ushort8 b; }))
 {
-    void check(void16 a) 
+    void check(void16 a)
     {
-        foreach (x; (cast(ushort8)a).array) 
+        foreach (x; (cast(ushort8)a).array)
         {
 	        assert(x == 1);
         }
     }
 
-    void make(ushort x) 
+    void make(ushort x)
     {
         ushort8 v = ushort8(x);
         check(v);
     }
 
-    void main() 
-    {	
+    void main()
+    {
         make(1);
     }
 }

--- a/test/runnable/cstuff3.i
+++ b/test/runnable/cstuff3.i
@@ -17,15 +17,15 @@ void exit(int);
 
 
 # 10 "runnable/extra-files/cstuff3.c" 3 4
-_Bool 
+_Bool
 # 10 "runnable/extra-files/cstuff3.c"
     useBoolAnd(
 # 10 "runnable/extra-files/cstuff3.c" 3 4
-               _Bool 
+               _Bool
 # 10 "runnable/extra-files/cstuff3.c"
-                    a, 
+                    a,
 # 10 "runnable/extra-files/cstuff3.c" 3 4
-                       _Bool 
+                       _Bool
 # 10 "runnable/extra-files/cstuff3.c"
                             b)
 {
@@ -34,15 +34,15 @@ _Bool
 
 
 # 15 "runnable/extra-files/cstuff3.c" 3 4
-_Bool 
+_Bool
 # 15 "runnable/extra-files/cstuff3.c"
     useBoolOr(
 # 15 "runnable/extra-files/cstuff3.c" 3 4
-              _Bool 
+              _Bool
 # 15 "runnable/extra-files/cstuff3.c"
-                   a, 
+                   a,
 # 15 "runnable/extra-files/cstuff3.c" 3 4
-                      _Bool 
+                      _Bool
 # 15 "runnable/extra-files/cstuff3.c"
                            b)
 {
@@ -51,15 +51,15 @@ _Bool
 
 
 # 20 "runnable/extra-files/cstuff3.c" 3 4
-_Bool 
+_Bool
 # 20 "runnable/extra-files/cstuff3.c"
     useBoolXor(
 # 20 "runnable/extra-files/cstuff3.c" 3 4
-               _Bool 
+               _Bool
 # 20 "runnable/extra-files/cstuff3.c"
-                    a, 
+                    a,
 # 20 "runnable/extra-files/cstuff3.c" 3 4
-                       _Bool 
+                       _Bool
 # 20 "runnable/extra-files/cstuff3.c"
                             b)
 {
@@ -70,190 +70,190 @@ _Bool
 
 int main()
 {
- 
+
 # 29 "runnable/extra-files/cstuff3.c" 3 4
-_Bool 
+_Bool
 # 29 "runnable/extra-files/cstuff3.c"
      baf, bat;
- bat = useBoolAnd( 
+ bat = useBoolAnd(
 # 30 "runnable/extra-files/cstuff3.c" 3 4
                   1
 # 30 "runnable/extra-files/cstuff3.c"
-                      , 
+                      ,
 # 30 "runnable/extra-files/cstuff3.c" 3 4
-                        1 
+                        1
 # 30 "runnable/extra-files/cstuff3.c"
                              );
- if ( bat != 
+ if ( bat !=
 # 31 "runnable/extra-files/cstuff3.c" 3 4
-            1 
+            1
 # 31 "runnable/extra-files/cstuff3.c"
                  ) { printf("error 1"); exit(1); }
- baf = useBoolAnd( 
+ baf = useBoolAnd(
 # 32 "runnable/extra-files/cstuff3.c" 3 4
                   1
 # 32 "runnable/extra-files/cstuff3.c"
-                      , 
+                      ,
 # 32 "runnable/extra-files/cstuff3.c" 3 4
-                        0 
+                        0
 # 32 "runnable/extra-files/cstuff3.c"
                               );
- if ( baf == 
+ if ( baf ==
 # 33 "runnable/extra-files/cstuff3.c" 3 4
-            1 
+            1
 # 33 "runnable/extra-files/cstuff3.c"
                  ) { printf("error 1a"); exit(1); }
- baf = useBoolAnd( 
+ baf = useBoolAnd(
 # 34 "runnable/extra-files/cstuff3.c" 3 4
                   0
 # 34 "runnable/extra-files/cstuff3.c"
-                       , 
+                       ,
 # 34 "runnable/extra-files/cstuff3.c" 3 4
-                         1 
+                         1
 # 34 "runnable/extra-files/cstuff3.c"
                               );
- if ( baf == 
+ if ( baf ==
 # 35 "runnable/extra-files/cstuff3.c" 3 4
-            1 
+            1
 # 35 "runnable/extra-files/cstuff3.c"
                  ) { printf("error 1b"); exit(1); }
- baf = useBoolAnd( 
+ baf = useBoolAnd(
 # 36 "runnable/extra-files/cstuff3.c" 3 4
                   0
 # 36 "runnable/extra-files/cstuff3.c"
-                       , 
+                       ,
 # 36 "runnable/extra-files/cstuff3.c" 3 4
-                         0 
+                         0
 # 36 "runnable/extra-files/cstuff3.c"
                                );
- if ( baf == 
+ if ( baf ==
 # 37 "runnable/extra-files/cstuff3.c" 3 4
-            1 
+            1
 # 37 "runnable/extra-files/cstuff3.c"
                  ) { printf("error 1c"); exit(1); }
 
- 
+
 # 39 "runnable/extra-files/cstuff3.c" 3 4
-_Bool 
+_Bool
 # 39 "runnable/extra-files/cstuff3.c"
      bbf, bbt;
- bbt = useBoolOr( 
+ bbt = useBoolOr(
 # 40 "runnable/extra-files/cstuff3.c" 3 4
                  1
 # 40 "runnable/extra-files/cstuff3.c"
-                     , 
+                     ,
 # 40 "runnable/extra-files/cstuff3.c" 3 4
-                       1 
+                       1
 # 40 "runnable/extra-files/cstuff3.c"
                             );
- if ( bbt != 
+ if ( bbt !=
 # 41 "runnable/extra-files/cstuff3.c" 3 4
-            1 
+            1
 # 41 "runnable/extra-files/cstuff3.c"
                  ) { printf("error 2a"); exit(1); }
- bbt = useBoolOr( 
+ bbt = useBoolOr(
 # 42 "runnable/extra-files/cstuff3.c" 3 4
                  1
 # 42 "runnable/extra-files/cstuff3.c"
-                     , 
+                     ,
 # 42 "runnable/extra-files/cstuff3.c" 3 4
-                       0 
+                       0
 # 42 "runnable/extra-files/cstuff3.c"
                              );
- if ( bbt != 
+ if ( bbt !=
 # 43 "runnable/extra-files/cstuff3.c" 3 4
-            1 
+            1
 # 43 "runnable/extra-files/cstuff3.c"
                  ) { printf("error 2b"); exit(1); }
- bbt = useBoolOr( 
+ bbt = useBoolOr(
 # 44 "runnable/extra-files/cstuff3.c" 3 4
                  0
 # 44 "runnable/extra-files/cstuff3.c"
-                      , 
+                      ,
 # 44 "runnable/extra-files/cstuff3.c" 3 4
-                        1 
+                        1
 # 44 "runnable/extra-files/cstuff3.c"
                              );
- if ( bbt != 
+ if ( bbt !=
 # 45 "runnable/extra-files/cstuff3.c" 3 4
-            1 
+            1
 # 45 "runnable/extra-files/cstuff3.c"
                  ) { printf("error 2c"); exit(1); }
- bbf = useBoolOr( 
+ bbf = useBoolOr(
 # 46 "runnable/extra-files/cstuff3.c" 3 4
                  0
 # 46 "runnable/extra-files/cstuff3.c"
-                      , 
+                      ,
 # 46 "runnable/extra-files/cstuff3.c" 3 4
-                        0 
+                        0
 # 46 "runnable/extra-files/cstuff3.c"
                               );
- if ( bbf != 
+ if ( bbf !=
 # 47 "runnable/extra-files/cstuff3.c" 3 4
-            0 
+            0
 # 47 "runnable/extra-files/cstuff3.c"
                   ) { printf("error 2"); exit(1); }
 
- 
+
 # 49 "runnable/extra-files/cstuff3.c" 3 4
-_Bool 
+_Bool
 # 49 "runnable/extra-files/cstuff3.c"
      bcf, bct;
- bct = useBoolXor( 
+ bct = useBoolXor(
 # 50 "runnable/extra-files/cstuff3.c" 3 4
                   1
 # 50 "runnable/extra-files/cstuff3.c"
-                      , 
+                      ,
 # 50 "runnable/extra-files/cstuff3.c" 3 4
-                        0 
+                        0
 # 50 "runnable/extra-files/cstuff3.c"
                               );
- if ( bct != 
+ if ( bct !=
 # 51 "runnable/extra-files/cstuff3.c" 3 4
-            1 
+            1
 # 51 "runnable/extra-files/cstuff3.c"
                  ) { printf("error 3a"); exit(1); }
- bct = useBoolXor( 
+ bct = useBoolXor(
 # 52 "runnable/extra-files/cstuff3.c" 3 4
                   0
 # 52 "runnable/extra-files/cstuff3.c"
-                       , 
+                       ,
 # 52 "runnable/extra-files/cstuff3.c" 3 4
-                         1 
+                         1
 # 52 "runnable/extra-files/cstuff3.c"
                               );
- if ( bct == 
+ if ( bct ==
 # 53 "runnable/extra-files/cstuff3.c" 3 4
-            0 
+            0
 # 53 "runnable/extra-files/cstuff3.c"
                   ) { printf("error 3b"); exit(1); }
 
- bcf = useBoolXor( 
+ bcf = useBoolXor(
 # 55 "runnable/extra-files/cstuff3.c" 3 4
                   1
 # 55 "runnable/extra-files/cstuff3.c"
-                      , 
+                      ,
 # 55 "runnable/extra-files/cstuff3.c" 3 4
-                        1 
+                        1
 # 55 "runnable/extra-files/cstuff3.c"
                              );
- if ( bcf != 
+ if ( bcf !=
 # 56 "runnable/extra-files/cstuff3.c" 3 4
-            0 
+            0
 # 56 "runnable/extra-files/cstuff3.c"
                   ) { printf("error 3c"); exit(1); }
- bcf = useBoolXor( 
+ bcf = useBoolXor(
 # 57 "runnable/extra-files/cstuff3.c" 3 4
                   0
 # 57 "runnable/extra-files/cstuff3.c"
-                       , 
+                       ,
 # 57 "runnable/extra-files/cstuff3.c" 3 4
-                         0 
+                         0
 # 57 "runnable/extra-files/cstuff3.c"
                                );
- if ( bcf == 
+ if ( bcf ==
 # 58 "runnable/extra-files/cstuff3.c" 3 4
-            1 
+            1
 # 58 "runnable/extra-files/cstuff3.c"
                  ) { printf("error 3d"); exit(1); }
 

--- a/test/runnable/imports/a19a.d
+++ b/test/runnable/imports/a19a.d
@@ -11,5 +11,5 @@ struct TemplatedStruct(Param)
 
 void foo()
 {
-        alias TemplatedStruct!(Dummy) X;        
+        alias TemplatedStruct!(Dummy) X;
 }

--- a/test/runnable/imports/test11745b.d
+++ b/test/runnable/imports/test11745b.d
@@ -1,17 +1,17 @@
 module imports.test11745b;
 
-unittest 
+unittest
 {
-		
+
 }
 
-private unittest 
+private unittest
 {
-	
+
 }
 
 private:
-unittest 
+unittest
 {
-	
+
 }

--- a/test/runnable/imports/test46c.d
+++ b/test/runnable/imports/test46c.d
@@ -3,5 +3,5 @@ module imports.test46c;
 class C(T)
 {
     void foo() { }
-} 
+}
 

--- a/test/runnable/test11934.d
+++ b/test/runnable/test11934.d
@@ -5,7 +5,7 @@ void main()
         this(int i) { instances++; }
         this(this) { instances++; }
         ~this() { instances--; }
-        static size_t instances = 0;	
+        static size_t instances = 0;
     }
 
     struct Range11934

--- a/test/runnable/test17684.d
+++ b/test/runnable/test17684.d
@@ -7,17 +7,17 @@ struct StructField(T)
 struct StructProperty(T)
 {
     static T Field;
-	
+
 	static @property T property()
 	{
-		return Field;	
+		return Field;
 	}
-	
+
 	static @property void property(T value)
 	{
-		Field = value;	
+		Field = value;
 	}
-	
+
     static alias property this;
 }
 
@@ -30,17 +30,17 @@ class ClassField(T)
 class ClassProperty(T)
 {
     static T Field;
-	
+
 	static @property T property()
 	{
-		return Field;	
+		return Field;
 	}
-	
+
 	static @property void property(T value)
 	{
-		Field = value;	
+		Field = value;
 	}
-	
+
     static alias property this;
 }
 

--- a/test/runnable/test17899.d
+++ b/test/runnable/test17899.d
@@ -1,7 +1,7 @@
 module test17899;
 
 // Test that the ICE in 13259 does not ICE but produces correct code
-auto dg = delegate {}; 
+auto dg = delegate {};
 
 int setme = 0;
 void delegate() bar1 = (){ setme = 1;};

--- a/test/runnable/testpdb.d
+++ b/test/runnable/testpdb.d
@@ -251,12 +251,12 @@ IDiaSymbol testClosureVar(IDiaSymbol globals, wstring funcName, wstring[] varNam
 
         if (v + 1 == varNames.length)
             return varSym;
-            
+
         IDiaSymbol varType;
         varSym.get_type(&varType) == S_OK || assert(false, toUTF8(varName ~ ": no type"));
         varType.get_type(&varType) == S_OK || assert(false, toUTF8(varName ~ ": no ptrtype"));
         parentSym = varType;
-    }    
+    }
     return parentSym;
 }
 

--- a/test/runnable/testptrref.d
+++ b/test/runnable/testptrref.d
@@ -21,7 +21,7 @@ version(CRuntime_Microsoft)
                                               void[] function(string name) nothrow @nogc);
         dataSection = findImageSection(".data");
     }
-    
+
     void[] tlsRange;
     static this()
     {
@@ -30,7 +30,7 @@ version(CRuntime_Microsoft)
                                               void[] function() nothrow @nogc);
         tlsRange = initTLSRanges();
     }
-    
+
     version = ptrref_supported;
 }
 else version(Win32)
@@ -126,7 +126,7 @@ bool findDataPtr(const(void)* ptr)
             void* addr = dataSection.ptr + *p;
         else
             void* addr = *p;
-        
+
         if (addr == ptr)
             return true;
     }
@@ -158,7 +158,7 @@ void testRefPtr()
 
     assert(!findTlsPtr(cast(size_t*)&tlsStr)); // length
     assert(findTlsPtr(cast(size_t*)&tlsStr + 1)); // ptr
-    
+
     // monitor is manually managed
     assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
     assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
@@ -167,7 +167,7 @@ void testRefPtr()
     assert(!findTlsPtr(&arr));
     assert(!findDataPtr(cast(size_t*)&arr + 1));
     assert(!findTlsPtr(cast(size_t*)&arr + 1));
-    
+
     assert(findDataPtr(cast(size_t*)&strArr[0] + 1)); // ptr in _DATA!
     assert(findDataPtr(cast(size_t*)&strArr[1] + 1)); // ptr in _DATA!
     strArr[1] = "c";

--- a/test/runnable/xpostblit.d
+++ b/test/runnable/xpostblit.d
@@ -86,7 +86,7 @@ struct FieldThrow
 
     bool throwExcept;
     this(this)
-    { 
+    {
         if (throwExcept)
         {
             throw new Exception("");

--- a/test/runnable_cxx/cppa.d
+++ b/test/runnable_cxx/cppa.d
@@ -469,7 +469,7 @@ extern (C++, std)
         static if (__traits(getTargetInfo, "cppStd") >= 201703)
         {
             // std::allocator no longer derives from __gnu_cxx::new_allocator,
-            // it derives from std::__new_allocator instead. 
+            // it derives from std::__new_allocator instead.
             struct __new_allocator(T)
             {
                 alias size_type = size_t;


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

This patch is intended to remove all trailing whitespaces and add a CI check for that in an upcoming PR.