### PR TITLE
Fix issue 22754: Header generator shouldn't generate trailing whitespace on visibility declaration

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -991,8 +991,9 @@ public:
     override void visit(VisibilityDeclaration d)
     {
         visibilityToBuffer(buf, d.visibility);
-        buf.writeByte(' ');
         AttribDeclaration ad = cast(AttribDeclaration)d;
+        if (ad.decl.dim <= 1)
+            buf.writeByte(' ');
         if (ad.decl.dim == 1 && (*ad.decl)[0].isVisibilityDeclaration)
             visit(cast(AttribDeclaration)(*ad.decl)[0]);
         else

--- a/test/compilable/header18364.d
+++ b/test/compilable/header18364.d
@@ -8,7 +8,7 @@ TEST_OUTPUT:
 === ${RESULTS_DIR}/compilable/header18364.di
 // D import file generated from 'compilable/header18364.d'
 module foo.bar.ba;
-nothrow pure @nogc @safe package(foo) 
+nothrow pure @nogc @safe package(foo)
 {
 	void foo();
 	nothrow pure @nogc @safe package(foo.bar) void foo2();


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>