### PR TITLE
lexer: remove whitespace on string delimiter error

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -1550,9 +1550,11 @@ class Lexer
         if (*p == '"')
             p++;
         else if (hereid)
-            error("delimited string must end in %s\"", hereid.toChars());
+            error("delimited string must end in `%s\"`", hereid.toChars());
+        else if (isspace(delimright))
+            error("delimited string must end in `\"`");
         else
-            error("delimited string must end in %c\"", delimright);
+            error("delimited string must end in `%c\"`", delimright);
         result.setString(stringbuffer);
         stringPostfix(result);
     }

--- a/test/fail_compilation/diag10805.d
+++ b/test/fail_compilation/diag10805.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10805.d(12): Error: delimited string must end in FOO"
+fail_compilation/diag10805.d(12): Error: delimited string must end in `FOO"`
 fail_compilation/diag10805.d(14): Error: unterminated string constant starting at fail_compilation/diag10805.d(14)
 fail_compilation/diag10805.d(14): Error: Implicit string concatenation is error-prone and disallowed in D
 fail_compilation/diag10805.d(14):        Use the explicit syntax instead (concatenating literals is `@nogc`): "" ~ ""

--- a/test/fail_compilation/fail196.d
+++ b/test/fail_compilation/fail196.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail196.d(27): Error: delimited string must end in )"
+fail_compilation/fail196.d(27): Error: delimited string must end in `)"`
 fail_compilation/fail196.d(27): Error: Implicit string concatenation is error-prone and disallowed in D
 fail_compilation/fail196.d(27):        Use the explicit syntax instead (concatenating literals is `@nogc`): "foo(xxx)" ~ ";\x0a    assert(s == "
 fail_compilation/fail196.d(28): Error: semicolon needed to end declaration of `s`, instead of `foo`

--- a/test/fail_compilation/fail258.d
+++ b/test/fail_compilation/fail258.d
@@ -1,13 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail258.d(11): Error: delimiter cannot be whitespace
-fail_compilation/fail258.d(11): Error: delimited string must end in 
-"
-fail_compilation/fail258.d(11): Error: declaration expected, not `"X"`
-fail_compilation/fail258.d(14): Error: unterminated string constant starting at fail_compilation/fail258.d(14)
+fail_compilation/fail258.d(101): Error: delimiter cannot be whitespace
+fail_compilation/fail258.d(101): Error: delimited string must end in `"`
+fail_compilation/fail258.d(101): Error: declaration expected, not `"X"`
+fail_compilation/fail258.d(104): Error: unterminated string constant starting at fail_compilation/fail258.d(104)
 ---
 */
+
+#line 100
+
 q"
 X
 


### PR DESCRIPTION
This patch removes whitespace from error indicating the string delimiter

Signed-off-by: Luís Ferreira <contact@lsferreira.net>