### PR TITLE
Reuse build_release_template for the nightly build

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -5,9 +5,8 @@
 # nightly build on the Gitbub release page.
 #
 # Job overview:
-# 1. Generates the documentation included in each release
-# 2. Builds the actual release (using a matrix over all targets)
-# 3. Publishes all artifacts from (2) to the release page on GitHub
+# 1. Builds the actual release using `build_release_template` from dlang/installer
+# 2. Publishes all artifacts from (1) to the release page on GitHub
 
 name: build-nightly
 
@@ -17,286 +16,21 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  # Build the documentation used by all releases
-  build-docs:
-    name: Build documentation for all repos
-    if: github.repository == 'dlang/dmd'
-
-    outputs:
-      dmd-revision: ${{ steps.get-revisions.outputs.dmd-revision }}
-      druntime-revision: ${{ steps.get-revisions.outputs.druntime-revision }}
-      phobos-revision: ${{ steps.get-revisions.outputs.phobos-revision }}
-
-    steps:
-      # Clone all required repos
-      - name: Clone dmd
-        uses: actions/checkout@v2
-        with:
-          repository: 'dlang/dmd'
-          path: 'dmd'
-
-      - name: Clone druntime
-        uses: actions/checkout@v2
-        with:
-          repository: 'dlang/druntime'
-          path: 'druntime'
-
-      - name: Clone phobos
-        uses: actions/checkout@v2
-        with:
-          repository: 'dlang/phobos'
-          path: 'phobos'
-
-      - name: Clone dlang.org
-        uses: actions/checkout@v2
-        with:
-          repository: 'dlang/dlang.org'
-          path: 'dlang.org'
-
-      # Fetch host compiler
-      - uses: dlang-community/setup-dlang@v1
-        name: Install host DMD
-
-      # Actually build the docs
-      - name: Build docs and man pages
-        shell: bash
-        run: |
-          set -euox pipefail
-
-          # Build minimal host compiler (sometimes not triggered by dlang.org/posix.mak)
-          make -f posix.mak -j2 -C druntime
-
-          # Build docs and include the man pages
-          make -f posix.mak -j2 -C dlang.org release
-          cp -r dmd/generated/docs/man dlang.org/web/
-
-      # Save the generated documentation for the target-specific builds
-      - name: Upload generated docs as a temporary artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: dmd-nightly-docs
-          path: dlang.org/web
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Determine revisions
-        id: get-revisions
-        shell: bash
-        run: |
-          set -euox pipefail
-
-          for REPO in dmd druntime phobos
-          do
-            REV=$( git -C $REPO rev-parse HEAD )
-            echo "::set-output name=$REPO-revision::$REV"
-          done
-
-    runs-on: ubuntu-latest
-
-  # Build and package a new release for each platform
+  # Build and package a new release for all supported platforms
   build-all-releases:
-    name: Build nightly for ${{ matrix.target }}  on ${{ matrix.os }}
+    name: Build nightly from master
     if: github.repository == 'dlang/dmd'
-    needs: build-docs
-    timeout-minutes: 60
-
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-20.04
-            target: linux
-          - os: macos-10.15
-            target: osx
-          - os: windows-2019
-            target: windows
-          # FreeBSD is built on an additional VM
-          - os: macos-10.15
-            target: freebsd
-
-    steps:
-
-      #################################################################
-      # Install the system dependencies required to build and run
-      # the actual release scripts
-      #
-      # Linux implementation based on `linux_both` in build_all.d and
-      # some additional experimentation to get curl working
-      #
-      - name: Install dependencies for linux
-        if: matrix.target == 'linux'
-        shell: bash
-        run: |
-          set -euox pipefail
-
-          # Install base dependencies (including multlib support)
-          sudo dpkg --add-architecture i386
-          sudo apt -y update
-          sudo apt -y install --no-install-recommends \
-              build-essential \
-              ca-certificates \
-              curl \
-              dpkg-dev \
-              fakeroot \
-              g++ \
-              g++-multilib \
-              gcc \
-              git \
-              gpg \
-              gpg-agent \
-              libcurl4 \
-              libcurl4-openssl-dev \
-              libcurl4:i386 \
-              libxml2 \
-              make \
-              p7zip-full \
-              rpm \
-              rsync \
-              unzip \
-              xz-utils
-
-          # Save some space
-          sudo apt clean
-
-      #################################################################
-      # Install latest LDC used to compile the release scripts and to
-      # determine the currently available version number
-      #
-      - uses: dlang-community/setup-dlang@v1
-        name: Install latest LDC
-        if: matrix.target != 'freebsd'
-        with:
-          compiler: ldc-latest
-
-      #################################################################
-      # Clone dlang/installer which provides the actual build scripts
-      #
-      - name: Clone installer repo
-        uses: actions/checkout@v2
-        with:
-          repository: 'dlang/installer'
-
-      #################################################################
-      # Load the generated documentation in the create_dmd_release folder
-      #
-      - name: Download docs generated by the previous job
-        uses: actions/download-artifact@v2
-        with:
-          name: dmd-nightly-docs
-          path: create_dmd_release/docs
-
-      #################################################################
-      # Build for the current target using build_all.d from installer
-      #
-      - name: Fetch common resources and run build_all.d for ${{ matrix.target }}
-        id: build
-        if: matrix.target != 'freebsd'
-        shell: bash
-        run: |
-          set -euox pipefail
-
-          # Fetch GPG key used to sign the generated binaries
-          curl https://dlang.org/d-keyring.gpg -o d-keyring.gpg
-          gpg --import d-keyring.gpg
-
-          # Compile release builder
-          cd create_dmd_release
-          ldmd2 -g -m64 --link-defaultlib-debug -version=NoVagrant -i build_all.d
-
-          # Determine installed LDC version
-          LDC=$(head -n 1 < <(ldc2 --version) | cut -d'(' -f2 | cut -d')' -f1)
-          echo "::set-output name=host_ldc::$LDC"
-
-          # WINDOWS: Fetch additional DM tools
-          if [[ "${{ matrix.target }}" == "windows" ]]
-          then
-
-            # Fetch DM make
-            curl http://downloads.dlang.org/other/dm857c.zip -o dmc.zip
-            7z x dmc.zip
-
-            # Fetch implib
-            curl http://ftp.digitalmars.com/bup.zip -o bup.zip
-            7z x bup.zip dm/bin/implib.exe
-
-            # Add DM binaries to the path
-            export PATH="$PWD/dm/bin;$PATH"
-
-            # Export VS dir
-            export LDC_VSDIR='C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise'
-          fi
-
-          # Workaround: Provide ldmd2 as dmd replacement as some tools assume DMD is present:
-          mkdir .pathext
-          ln -s "$(which ldmd2)" .pathext/dmd
-          if [[ "${{ matrix.target }}" == "windows" ]]
-          then
-            PATH="$PATH;$PWD/.pathext"
-          else
-            PATH="$PATH:$PWD/.pathext"
-          fi
-
-          # Build the release
-          ./build_all --targets=${{ matrix.target }} "v$LDC" master
-
-      #################################################################
-      # FREEBSD: Build for the current target using build_all.d from installer
-      #
-      - name: Run build_all.d for FreeBSD in a dedicated VM
-        if: matrix.target == 'freebsd'
-        uses: vmactions/freebsd-vm@v0.1.3
-        with:
-          usesh: true
-          # Need more RAM than the default 1G
-          mem: 4096
-          prepare: pkg install -y bash curl curlpp git gmake pkgconf gnupg rsync llvm90
-          run: |
-            set -eux
-
-            # Import key used to sign binaries
-            curl https://dlang.org/d-keyring.gpg -o d-keyring.gpg
-            gpg d-keyring.gpg
-
-            # Install ldc
-            curl https://dlang.org/install.sh -o install.sh
-            bash install.sh ldc -p .
-
-            # Use absolute paths because activate doesn't work correctly
-            LDC_BIN=$PWD/ldc-*/bin
-
-            # Determine installed LDC version
-            LDC=$($LDC_BIN/ldc2 --version | head -n 1 | cut -d'(' -f2 | cut -d')' -f1)
-
-            # Determine additional linker flags to make -lcurl work
-            EXTRA_FLAGS="-L$(pkg-config --libs-only-L libcurl)"
-
-            # Actually build the release
-            cd create_dmd_release
-            $LDC_BIN/ldmd2 -g -m64 --link-defaultlib-debug -version=NoVagrant -i build_all.d $EXTRA_FLAGS
-            ./build_all --targets=${{ matrix.target }} "v$LDC" master
-
-      #################################################################
-      # Save the target-specific release as a artifact s.t. the next
-      # job can bundle the entire release for all supported targets
-      #
-      - name: Upload generated release as a temporary artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: dmd-nightly
-          path: |
-            ${{ github.workspace }}/create_dmd_release/build/*
-            !${{ github.workspace }}/create_dmd_release/build/*.zip
-          retention-days: 1
-          if-no-files-found: error
-
-    runs-on: ${{ matrix.os }}
+    uses: dlang/installer/.github/workflows/build_release_template.yml@master
+    with:
+      release_branch: master
 
   # Bundles and publishes the entire release
   generate_release:
     name: "Publish artifacts on the release page"
-    if: github.repository == 'dlang/dmd'
     needs:
-      - build-docs
       - build-all-releases
+    runs-on: ubuntu-latest
+
     steps:
       #################################################################
       # Fetch all artifacts from the jobs defined above
@@ -304,7 +38,7 @@ jobs:
       - name: Download generated releases from the artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dmd-nightly
+          name: dmd-release
           path: ~/artifacts/
 
       #################################################################
@@ -335,9 +69,9 @@ jobs:
 
             | Component | Revision                                                         |
             | --------- | ---------------------------------------------------------------- |
-            | DMD       | dlang/dmd@${{ needs.build-docs.outputs.dmd-revision }}           |
-            | DRuntime  | dlang/druntime@${{ needs.build-docs.outputs.druntime-revision }} |
-            | Phobos    | dlang/phobos@${{ needs.build-docs.outputs.phobos-revision }}     |
+            | DMD       | dlang/dmd@${{ needs.build-all-releases.outputs.dmd-revision }}           |
+            | DRuntime  | dlang/druntime@${{ needs.build-all-releases.outputs.druntime-revision }} |
+            | Phobos    | dlang/phobos@${{ needs.build-all-releases.outputs.phobos-revision }}     |
 
           artifacts:  ${{ steps.list-artifacts.outputs.artifacts_directory }}/*
           artifactErrorsFailBuild: true
@@ -346,5 +80,3 @@ jobs:
           tag: nightly
           commit: f01bc99e87ad9d04b47a5323f6ccb1fd728eae8c
           allowUpdates: true
-
-    runs-on: ubuntu-latest


### PR DESCRIPTION
The action was generalized into a reuseable workflow and transferred to dlang/installer (see [`build_release_template.yml`](https://github.com/dlang/installer/blob/master/.github/workflows/build_release_template.yml)).

[Last run from my fork](https://github.com/MoonlightSentinel/dmd/runs/5163560925?check_suite_focus=true)