### PR TITLE
fix Issue 22758 - ImportC: parenthesized expression confused with cas…

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7457,12 +7457,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         if ((sc && sc.flags & SCOPE.Cfile) &&
-            exp.to && exp.to.ty == Tident &&
+            exp.to && (exp.to.ty == Tident || exp.to.ty == Tsarray) &&
             (exp.e1.op == EXP.address || exp.e1.op == EXP.star ||
              exp.e1.op == EXP.uadd || exp.e1.op == EXP.negate))
         {
             /* Ambiguous cases arise from CParser if type-name is just an identifier.
              *   ( identifier ) cast-expression
+             *   ( identifier [expression]) cast-expression
              * If we determine that `identifier` is a variable, and cast-expression
              * is one of the unary operators (& * + -), then rewrite this cast
              * as a binary expression.

--- a/src/dmd/printast.d
+++ b/src/dmd/printast.d
@@ -122,6 +122,16 @@ extern (C++) final class PrintASTVisitor : Visitor
         printAST(e.e1, indent + 2);
     }
 
+    override void visit(CastExp e)
+    {
+        printIndent(indent);
+        auto s = EXPtoString(e.op);
+        printf("%.*s %s\n", cast(int)s.length, s.ptr, e.type ? e.type.toChars() : "");
+        printIndent(indent + 2);
+        printf(".to: %s\n", e.to.toChars());
+        printAST(e.e1, indent + 2);
+    }
+
     override void visit(VectorExp e)
     {
         printIndent(indent);

--- a/test/compilable/test22758.c
+++ b/test/compilable/test22758.c
@@ -1,0 +1,6 @@
+
+// https://issues.dlang.org/show_bug.cgi?id=22758
+
+void foo(unsigned* aData){
+    unsigned s = (aData[0]) & 1;
+}


### PR DESCRIPTION
…t-expression

The trouble here is distinguishing the type `identifier[integer]` from the expression `identifier[integer]` without doing semantic analysis.

Another reason why D cast expressions are easily distinguished with the `cast` keyword.