### PR TITLE
Fix issue 22770: C++ header generator generates trailing newlines

### DIFF
--- a/src/dmd/common/outbuffer.d
+++ b/src/dmd/common/outbuffer.d
@@ -662,6 +662,8 @@ struct OutBuffer
         return cast(char)data[i];
     }
 
+    alias opDollar = length;
+
     /***********************************
      * Extract the data as a slice and take ownership of it.
      *

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -180,6 +180,15 @@ struct _d_dynamicArray final
 `);
     }
 
+    // prevent trailing newlines
+    version (Windows)
+        while (buf.length >= 4 && buf[$-4..$] == "\r\n\r\n")
+            buf.remove(buf.length - 2, 2);
+    else
+        while (buf.length >= 2 && buf[$-2..$] == "\n\n")
+            buf.remove(buf.length - 1, 1);
+
+
     if (global.params.cxxhdrname is null)
     {
         // Write to stdout; assume it succeeds

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -8644,4 +8644,3 @@ extern "C" Object* _d_newclass(const TypeInfo_Class* const ci);
 extern "C" void* _d_newitemT(TypeInfo* ti);
 
 extern "C" void* _d_newitemiT(TypeInfo* ti);
-


### PR DESCRIPTION
This patch adds logic to check for trailing newlines in dtoh generator and
remove them.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Related to #13638 .