### PR TITLE
ci: move ci.sh and cirrusci.sh script to ci/ folder

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 common_steps_template: &COMMON_STEPS_TEMPLATE
-  install_prerequisites_script: ./cirrusci.sh
-  install_host_compiler_script: ./ci.sh install_host_compiler
+  install_prerequisites_script: ./ci/cirrusci.sh
+  install_host_compiler_script: ./ci/run.sh install_host_compiler
   setup_repos_script: |
     set -uexo pipefail
     ln -s $CIRRUS_WORKING_DIR ../dmd
@@ -22,25 +22,25 @@ common_steps_template: &COMMON_STEPS_TEMPLATE
       fi
     fi
 
-    ./ci.sh setup_repos "$REPO_BRANCH"
-  build_script: ./ci.sh build
+    ./ci/run.sh setup_repos "$REPO_BRANCH"
+  build_script: ./ci/run.sh build
 
   test_dmd_script: |
     if [ "${DMD_TEST_COVERAGE:-0}" == "1" ]
     then
-      OS_NAME=$OS ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ./ci.sh rebuild
-      ./ci.sh test_dmd
-      ./ci.sh codecov
+      OS_NAME=$OS ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ./ci/run.sh rebuild
+      ./ci/run.sh test_dmd
+      ./ci/run.sh codecov
     else
-      ./ci.sh test_dmd
+      ./ci/run.sh test_dmd
     fi
 
-  test_druntime_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci.sh test_druntime
-  test_phobos_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci.sh test_phobos
+  test_druntime_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci/run.sh test_druntime
+  test_phobos_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci/run.sh test_phobos
 
 environment:
   CIRRUS_CLONE_DEPTH: 50
-  # for ci.sh:
+  # for ci/run.sh:
   MODEL: 64
   HOST_DMD: dmd
   N: 4

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+source ci/run.sh

--- a/ci/cirrusci.sh
+++ b/ci/cirrusci.sh
@@ -2,7 +2,7 @@
 
 # Installs the OS-specific prerequisites for Cirrus CI jobs.
 # This file is invoked by DMD, druntime and Phobos' .cirrus.yml
-# and sets up the machine for the later steps with ci.sh.
+# and sets up the machine for the later steps with ci/run.sh.
 
 set -uexo pipefail
 
@@ -22,7 +22,7 @@ if [ "$OS_NAME" == "linux" ]; then
     packages="$packages g++-multilib libcurl4:i386"
   fi
   if [ "${HOST_DMD:0:4}" == "gdmd" ]; then
-    # ci.sh uses `sudo add-apt-repository ...` to add a PPA repo
+    # ci/run.sh uses `sudo add-apt-repository ...` to add a PPA repo
     packages="$packages sudo software-properties-common"
   fi
   apt-get -q update

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -221,9 +221,9 @@ codecov()
 if [ "$#" -gt 0 ]; then
   case $1 in
     install_host_compiler) install_host_compiler ;;
-    setup_repos) setup_repos "$2" ;; # ci.sh setup_repos <git branch>
+    setup_repos) setup_repos "$2" ;; # ci/run.sh setup_repos <git branch>
     build) build ;;
-    rebuild) rebuild "${2:-}" ;; # ci.sh rebuild [1] (use `1` to compare binaries to test reproducible build)
+    rebuild) rebuild "${2:-}" ;; # ci/run.sh rebuild [1] (use `1` to compare binaries to test reproducible build)
     test) test ;;
     test_dmd) test_dmd ;;
     test_druntime) test_druntime ;;

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+source ci/cirrusci.sh

--- a/test/Makefile
+++ b/test/Makefile
@@ -137,7 +137,7 @@ export HOST_DMD:=$(subst \,/,$(HOST_DMD))
 RUNNER:=$(RESULTS_DIR)/run$(EXE)
 EXECUTE_RUNNER:=$(RUNNER) --environment
 
-# N determines the amount of parallel jobs, see ci.sh
+# N determines the amount of parallel jobs, see ci/run.sh
 ifneq ($(N),)
     EXECUTE_RUNNER:=$(EXECUTE_RUNNER) --jobs=$N
 endif


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

This organizes everything in one place, rather than being at the root of the project.