### PR TITLE
Make -vtemplates measure the time spent instantiating

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -5741,8 +5741,28 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     TemplateDeclaration tempdecl = tempinst.tempdecl.isTemplateDeclaration();
     assert(tempdecl);
 
-    TemplateStats.incInstance(tempdecl, tempinst);
+    //This will point onto the heap allocated time stat to be written into
+    long* time; //in micro-seconds
+    import core.time : MonoTime;
+    const before = MonoTime.currTime;
 
+    TemplateStats.incInstance(tempdecl, tempinst, &time);
+    /+
+        https://issues.dlang.org/show_bug.cgi?id=22772
+        Measure time of template instantiations.
+
+        This aims to measure the total time of all instantiations of a given
+        Declaration, not the time of each one individually.
+    +/
+    scope(exit) {
+        //If time is null then we shouldn't be timing because incInstance didn't register it.
+        if (time)
+        {
+            const timeElapsed = MonoTime.currTime() - before;
+            //+= because we're measuring the total for the declaration.
+            *time += timeElapsed.total!"usecs";
+        }
+    }
     tempdecl.checkDeprecated(tempinst.loc, sc);
 
     // If tempdecl is a mixin, disallow it

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -585,17 +585,25 @@ else
 
 private void _vmessage(const ref Loc loc, const(char)* format, va_list ap)
 {
+    OutBuffer tmp;
     const p = loc.toChars();
     if (*p)
     {
-        fprintf(stdout, "%s: ", p);
+        tmp.printf("%s: ", p);
         mem.xfree(cast(void*)p);
     }
-    OutBuffer tmp;
     tmp.vprintf(format, ap);
-    fputs(tmp.peekChars(), stdout);
-    fputc('\n', stdout);
-    fflush(stdout);     // ensure it gets written out in case of compiler aborts
+    //If there's no console we're printing to a pipe so no syntax highlighting.
+    if(auto glblCon = cast(Console) global.console)
+    {
+        colorSyntaxHighlight(tmp);
+        writeHighlights(glblCon, tmp);
+    } else
+    {
+        fputs(tmp.peekChars(), stderr);
+    }
+    fputc('\n', stderr);
+    fflush(stderr);     // ensure it gets written out in case of compiler aborts
 }
 
 /**


### PR DESCRIPTION
This times the total time for a given instantiation, but the individual measurements can be done in a followup