### PR TITLE
fix Issue 20149 - [DIP1000] Local data escapes inout method if not de…

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -549,9 +549,22 @@ extern (C++) class FuncDeclaration : Declaration
             if (thandle.ty == Tstruct)
             {
                 vthis.storage_class |= STC.ref_;
-                // if member function is marked 'inout', then 'this' is 'return ref'
-                if (type.ty == Tfunction && (cast(TypeFunction)type).isInOutQual())
-                    vthis.storage_class |= STC.return_;
+
+                /* if member function is marked 'inout', then 'this' is 'return ref'
+                 * The same thing is done for `ref inout` parameters in TypeFunction's semantic routine.
+                 */
+                if (auto tf = type.isTypeFunction())
+                {
+                    /* This feature was a mistake, but existing code relies on it.
+                     * So only disable it in @safe code and DIP1000 code
+                     */
+                    if (!(global.params.useDIP1000 == FeatureState.enabled &&
+                          tf.trust == TRUST.safe))
+                    {
+                        if (tf.isInOutQual())
+                            vthis.storage_class |= STC.return_;
+                    }
+                }
             }
         }
 

--- a/test/fail_compilation/fail17927.d
+++ b/test/fail_compilation/fail17927.d
@@ -2,11 +2,11 @@
  * TEST_OUTPUT:
 ---
 fail_compilation/fail17927.d(13): Error: scope variable `this` may not be returned
+fail_compilation/fail17927.d(15): Error: scope variable `this` may not be returned
 fail_compilation/fail17927.d(21): Error: scope variable `ptr` may not be returned
 fail_compilation/fail17927.d(23): Error: scope variable `ptr` may not be returned
 ---
 */
-
 // https://issues.dlang.org/show_bug.cgi?id=17927
 
 struct String {

--- a/test/runnable/sroa13220.d
+++ b/test/runnable/sroa13220.d
@@ -60,7 +60,7 @@ mixin template VectorOps(VectorType, ArrayType: BaseType[N], BaseType, size_t N)
         array[] = x;
     }
 
-    ref inout(BaseType) opIndex(size_t i) inout pure nothrow @safe @nogc
+    ref inout(BaseType) opIndex(size_t i) return inout pure nothrow @safe @nogc
     {
         return array[i];
     }

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1623,7 +1623,7 @@ struct S3748
     const int z = 6;
     C3748 c;
 
-    inout(int)* getX() inout
+    inout(int)* getX() inout return
     {
         static assert(!__traits(compiles, {
             x = 4;
@@ -3348,9 +3348,9 @@ struct S10758
 {
     int x;
         inout(int)   screwUpVal(ref inout(int) _) inout { return x; }
-    ref inout(int)   screwUpRef(ref inout(int) _) inout { return x; }
-        inout(int)*  screwUpPtr(ref inout(int) _) inout { return &x; }
-        inout(int)[] screwUpArr(ref inout(int) _) inout { return (&x)[0 .. 1]; }
+    ref inout(int)   screwUpRef(ref inout(int) _) inout return { return x; }
+        inout(int)*  screwUpPtr(ref inout(int) _) inout return { return &x; }
+        inout(int)[] screwUpArr(ref inout(int) _) inout return { return (&x)[0 .. 1]; }
 }
 
 void test10758(ref inout(int) wx, inout(int)* wp, inout(int)[] wa, inout(S10758) ws)
@@ -3497,14 +3497,14 @@ inout(int)* delegate(inout(int)*) nest10761(inout(int)* x)
 struct S10761
 {
     int x;
-    inout(int)* screwUp() inout { return &x; }
+    inout(int)* screwUp() inout return { return &x; }
 }
 
-inout(int)* delegate() inout memfn10761(inout(int)* x)
+inout(int)* delegate() inout return memfn10761(inout(int)* x)
 {
     auto s = new inout S10761(1);
     auto dg = &s.screwUp;
-    static assert(is(typeof(dg) == inout(int)* delegate() inout));
+    static assert(is(typeof(dg) == inout(int)* delegate() inout return));
     return dg;
 }
 
@@ -3542,7 +3542,7 @@ void test10761()
         auto dg_m = memfn10761(&mx);
         auto dg_c = memfn10761(&cx);
         auto dg_i = memfn10761(&ix);
-        alias DG = const(int)* delegate() const;
+        alias DG = const(int)* delegate() return const;
         static assert(is(typeof(dg_m) == DG));
         static assert(is(typeof(dg_c) == DG));
         static assert(is(typeof(dg_i) == DG));

--- a/test/runnable/testscope2.d
+++ b/test/runnable/testscope2.d
@@ -178,7 +178,7 @@ struct S10
 {
     int x;
 
-    ref inout(int) foo() inout
+    ref inout(int) foo() inout return
     {
         return x;
     }


### PR DESCRIPTION
…corated with return

This is a reboot of https://github.com/dlang/dmd/pull/10390

@JinShil had the right diagnosis, but the fix was in the wrong place. The type shouldn't be altered after it finishes its semantic() routine, so the fix got moved there.