### PR TITLE
dmd: Update deprecated comment tags to reflect which release to remove them

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -847,7 +847,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 dsym.error("globals, statics, fields, manifest constants, ref and out parameters cannot be `scope`");
             }
 
-            // @@@DEPRECATED@@@  https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+            // @@@DEPRECATED_2.097@@@  https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
             // Deprecated in 2.087
             // Remove this when the feature is removed from the language
             if (0 &&          // deprecation disabled for now to accommodate existing extensive use
@@ -5292,7 +5292,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         //printf("-ClassDeclaration.dsymbolSemantic(%s), type = %p, sizeok = %d, this = %p\n", toChars(), type, sizeok, this);
 
-        // @@@DEPRECATED@@@ https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+        // @@@DEPRECATED_2.097@@@ https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
         // Deprecated in 2.087
         // Make an error in 2.091
         // Don't forget to remove code at https://github.com/dlang/dmd/blob/b2f8274ba76358607fc3297a1e9f361480f9bcf9/src/dmd/dsymbolsem.d#L1032-L1036
@@ -5599,7 +5599,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         assert(idec.type.ty != Tclass || (cast(TypeClass)idec.type).sym == idec);
 
-        // @@@DEPRECATED@@@https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+        // @@@DEPRECATED_2.097@@@https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
         // Deprecated in 2.087
         // Remove in 2.091
         // Don't forget to remove code at https://github.com/dlang/dmd/blob/b2f8274ba76358607fc3297a1e9f361480f9bcf9/src/dmd/dsymbolsem.d#L1032-L1036

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1272,7 +1272,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                     return ErrorExp.get();
                 if (!checkSymbolAccess(sc, fd))
                 {
-                    // @@@DEPRECATED_2020-10@@@
+                    // @@@DEPRECATED_2.105@@@
                     // When turning into error, uncomment the return statement
                     TypeFunction tf = fd.type.isTypeFunction();
                     deprecation(loc, "Function `%s` of type `%s` is not accessible from module `%s`",
@@ -1295,7 +1295,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                 {
                     if (!checkSymbolAccess(sc, fd))
                     {
-                        // @@@DEPRECATED_2020-10@@@
+                        // @@@DEPRECATED_2.105@@@
                         // When turning into error, uncomment the return statement
                         deprecation(loc, "Function `%s` of type `%s` is not accessible from module `%s`",
                                     fd.toPrettyChars(), tf.toChars, sc._module.toChars);
@@ -7348,7 +7348,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         if (!sc.isDeprecated)
         {
-            // @@@DEPRECATED_2019-02@@@
+            // @@@DEPRECATED_2.089@@@
             // 1. Deprecation for 1 year
             // 2. Error for 1 year
             // 3. Removal of keyword, "delete" can be used for other identities

--- a/src/dmd/iasmgcc.d
+++ b/src/dmd/iasmgcc.d
@@ -84,7 +84,7 @@ int parseExtAsmOperands(Parser)(Parser p, GccAsmStatement s)
 
             case TOK.string_:
                 constraint = p.parsePrimaryExp();
-                // @@@DEPRECATED@@@
+                // @@@DEPRECATED_2.101@@@
                 // Old parser allowed omitting parentheses around the expression.
                 // Deprecated in 2.091. Can be made permanent error after 2.100
                 if (p.token.value != TOK.leftParenthesis)

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -904,7 +904,7 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                     return;
             }
 
-            // @@@DEPRECATED_2019-02@@@
+            // @@@DEPRECATED_2.096@@@
             // 1. Deprecation for 1 year
             // 2. Turn to error after
             if (tempResult)

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -675,7 +675,7 @@ class Parser(AST) : Lexer
                      tk.value == TOK.out_ || tk.value == TOK.do_ || tk.value == TOK.goesTo ||
                      tk.value == TOK.identifier && tk.ident == Id._body))
                 {
-                    // @@@DEPRECATED@@@
+                    // @@@DEPRECATED_2.117@@@
                     // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
                     // Deprecated in 2.097 - Can be removed from 2.117
                     // The deprecation period is longer than usual as `body`
@@ -2646,7 +2646,7 @@ class Parser(AST) : Lexer
         }
         nextToken();
 
-        /* @@@DEPRECATED_2.098@@@
+        /* @@@DEPRECATED_2.108@@@
          * After deprecation period (2.108), remove all code in the version(all) block.
          */
         version (all)
@@ -4375,7 +4375,7 @@ class Parser(AST) : Lexer
                     (tk.value == TOK.leftParenthesis || tk.value == TOK.leftCurly || tk.value == TOK.in_ || tk.value == TOK.out_ || tk.value == TOK.goesTo ||
                      tk.value == TOK.do_ || tk.value == TOK.identifier && tk.ident == Id._body))
                 {
-                    // @@@DEPRECATED@@@
+                    // @@@DEPRECATED_2.117@@@
                     // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
                     // Deprecated in 2.097 - Can be removed from 2.117
                     // The deprecation period is longer than usual as `body`
@@ -4827,7 +4827,7 @@ class Parser(AST) : Lexer
                         {
                             OutBuffer buf;
                             AST.stcToBuffer(&buf, remStc);
-                            // @@@DEPRECATED_2.093@@@
+                            // @@@DEPRECATED_2.103@@@
                             // Deprecated in 2020-07, can be made an error in 2.103
                             deprecation("storage class `%s` has no effect in type aliases", buf.peekChars());
                         }
@@ -5054,7 +5054,7 @@ class Parser(AST) : Lexer
         case TOK.identifier:
             if (token.ident == Id._body)
             {
-                // @@@DEPRECATED@@@
+                // @@@DEPRECATED_2.117@@@
                 // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
                 // Deprecated in 2.097 - Can be removed from 2.117
                 // The deprecation period is longer than usual as `body`
@@ -7374,7 +7374,7 @@ LagainStc:
             case TOK.identifier:
                 if (t.ident == Id._body)
                 {
-                    // @@@DEPRECATED@@@
+                    // @@@DEPRECATED_2.117@@@
                     // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
                     // Deprecated in 2.097 - Can be removed from 2.117
                     // The deprecation period is longer than usual as `body`

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -422,7 +422,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
                 const sameParams = tf1.parameterList == tf2.parameterList;
 
                 // Allow the hack to declare overloads with different parameters/STC's
-                // @@@DEPRECATED_2.094@@@
+                // @@@DEPRECATED_2.104@@@
                 // Deprecated in 2020-08, make this an error in 2.104
                 if (parent1.isModule() &&
                     f1.linkage != LINK.d && f1.linkage != LINK.cpp &&

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1404,7 +1404,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
         auto sexp = new ExpStatement(ctor.loc, ce);
         auto ss = new ScopeStatement(ctor.loc, sexp, ctor.loc);
 
-        // @@@DEPRECATED_2096@@@
+        // @@@DEPRECATED_2.106@@@
         // Allow negligible attribute violations to allow for a smooth
         // transition. Remove this after the usual deprecation period
         // after 2.106.

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -273,7 +273,7 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
             // Same check as in Expression.semanticY(DotIdExp)
             else if (sm.isPackage() && checkAccess(sc, sm.isPackage()))
             {
-                // @@@DEPRECATED_2.096@@@
+                // @@@DEPRECATED_2.106@@@
                 // Should be an error in 2.106. Just remove the deprecation call
                 // and uncomment the null assignment
                 deprecation(loc, "%s %s is not accessible here, perhaps add 'static import %s;'", sm.kind(), sm.toPrettyChars(), sm.toPrettyChars());
@@ -3003,14 +3003,14 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
         //printf("TypeIdentifier::resolve(sc = %p, idents = '%s')\n", sc, mt.toChars());
         if ((mt.ident.equals(Id._super) || mt.ident.equals(Id.This)) && !hasThis(sc))
         {
-            // @@@DEPRECATED_v2.091@@@.
+            // @@@DEPRECATED_2.091@@@.
             // Made an error in 2.086.
             // Eligible for removal in 2.091.
             if (mt.ident.equals(Id._super))
             {
                 error(mt.loc, "Using `super` as a type is obsolete. Use `typeof(super)` instead");
             }
-             // @@@DEPRECATED_v2.091@@@.
+             // @@@DEPRECATED_2.091@@@.
             // Made an error in 2.086.
             // Eligible for removal in 2.091.
             if (mt.ident.equals(Id.This))
@@ -3847,7 +3847,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                  *  e.opDot().ident
                  */
                 e = build_overload(e.loc, sc, e, null, fd);
-                // @@@DEPRECATED_2.087@@@.
+                // @@@DEPRECATED_2.092@@@.
                 e.deprecation("`opDot` is deprecated. Use `alias this`");
                 e = new DotIdExp(e.loc, e, ident);
                 return returnExp(e.expressionSemantic(sc));


### PR DESCRIPTION
Some were absent, some where using the old time-based deprecation system (2 years->error), some were referring to the release they began being deprecated, some just picked a random release to mark them for removal.

This makes all `@@@DEPRECATED@@@` tags in the comments consistent in that they now refer to their `error()` date, and follow the DIP1013 process.

Note, some of these are pointing at releases in the past, that will be dealt with in a follow-up.