### PR TITLE
dmd.typesem: Remove usage of 'this' and 'super' as types

### DIFF
--- a/changelog/super_type_gone.dd
+++ b/changelog/super_type_gone.dd
@@ -1,0 +1,6 @@
+Usage of `this` and `super` as types has been removed
+
+Prior to this release, using `this` or `super` as a type resulted in a compiler
+error suggesting to use `typeof(this)` or `typeof(super)` instead. This has now
+been completely removed from the language, and the parser won't recognize this
+wrong code anymore.

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -692,7 +692,7 @@ struct Scope
     }
 
     /********************************************
-     * Search enclosing scopes for ClassDeclaration.
+     * Search enclosing scopes for ClassDeclaration or StructDeclaration.
      */
     extern (C++) AggregateDeclaration getStructClassScope()
     {

--- a/test/fail_compilation/fail18228.d
+++ b/test/fail_compilation/fail18228.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18228.d(12): Error: Using `this` as a type is obsolete. Use `typeof(this)` instead
-fail_compilation/fail18228.d(13): Error: Using `this` as a type is obsolete. Use `typeof(this)` instead
-fail_compilation/fail18228.d(14): Error: Using `super` as a type is obsolete. Use `typeof(super)` instead
+fail_compilation/fail18228.d(12): Error: undefined identifier `this`, did you mean `typeof(this)`?
+fail_compilation/fail18228.d(13): Error: undefined identifier `this`, did you mean `typeof(this)`?
+fail_compilation/fail18228.d(14): Error: undefined identifier `super`, did you mean `typeof(super)`?
 ---
 */
 

--- a/test/fail_compilation/fail_typeof.d
+++ b/test/fail_compilation/fail_typeof.d
@@ -1,0 +1,82 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fail_typeof.d(18): Error: undefined identifier `this`
+fail_compilation/fail_typeof.d(23): Error: `this` is not in a class or struct scope
+fail_compilation/fail_typeof.d(23): Error: `this` is only defined in non-static member functions, not `fail_typeof`
+fail_compilation/fail_typeof.d(28): Error: undefined identifier `super`
+fail_compilation/fail_typeof.d(33): Error: `super` is not in a class scope
+fail_compilation/fail_typeof.d(33): Error: `super` is only allowed in non-static class member functions
+fail_compilation/fail_typeof.d(40): Error: undefined identifier `this`, did you mean `typeof(this)`?
+fail_compilation/fail_typeof.d(50): Error: undefined identifier `super`
+fail_compilation/fail_typeof.d(55): Error: `super` is not in a class scope
+fail_compilation/fail_typeof.d(55): Error: `super` is only allowed in non-static class member functions
+fail_compilation/fail_typeof.d(63): Error: undefined identifier `this`, did you mean `typeof(this)`?
+fail_compilation/fail_typeof.d(73): Error: undefined identifier `super`, did you mean `typeof(super)`?
+---
+*/
+
+enum E1 : this
+{
+    fail,
+}
+
+enum E2 : typeof(this)
+{
+    fail,
+}
+
+enum E3 : super
+{
+    fail,
+}
+
+enum E4 : typeof(super)
+{
+    fail,
+}
+
+struct S1
+{
+    enum E1 : this
+    {
+        fail,
+    }
+
+    enum E2 : typeof(this)
+    {
+        ok = S1(),
+    }
+
+    enum E3 : super
+    {
+        fail,
+    }
+
+    enum E4 : typeof(super)
+    {
+        fail,
+    }
+}
+
+class C1
+{
+    enum E1 : this
+    {
+        fail,
+    }
+
+    enum E2 : typeof(this)
+    {
+        ok = new C1,
+    }
+
+    enum E3 : super
+    {
+        fail,
+    }
+
+    enum E4 : typeof(super)
+    {
+        ok = new C1,
+    }
+}

--- a/test/fail_compilation/test12228.d
+++ b/test/fail_compilation/test12228.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test12228.d(13): Error: Using `this` as a type is obsolete. Use `typeof(this)` instead
+fail_compilation/test12228.d(13): Error: undefined identifier `this`, did you mean `typeof(this)`?
 fail_compilation/test12228.d(18): Error: no property `x` for type `object.Object`
-fail_compilation/test12228.d(19): Error: Using `super` as a type is obsolete. Use `typeof(super)` instead
-fail_compilation/test12228.d(20): Error: Using `super` as a type is obsolete. Use `typeof(super)` instead
+fail_compilation/test12228.d(19): Error: undefined identifier `super`, did you mean `typeof(super)`?
+fail_compilation/test12228.d(20): Error: undefined identifier `super`, did you mean `typeof(super)`?
 ---
 */
 


### PR DESCRIPTION
This has been an error since 2.086.