### PR TITLE
Remove dead members from NewExp, NewAnonClassExp, and VarDeclaration

### DIFF
--- a/src/dmd/apply.d
+++ b/src/dmd/apply.d
@@ -110,13 +110,13 @@ public:
     override void visit(NewExp e)
     {
         //printf("NewExp::apply(): %s\n", toChars());
-        doCond(e.thisexp) || doCond(e.newargs) || doCond(e.arguments) || applyTo(e);
+        doCond(e.thisexp) || doCond(e.arguments) || applyTo(e);
     }
 
     override void visit(NewAnonClassExp e)
     {
         //printf("NewAnonClassExp::apply(): %s\n", toChars());
-        doCond(e.thisexp) || doCond(e.newargs) || doCond(e.arguments) || applyTo(e);
+        doCond(e.thisexp) || doCond(e.arguments) || applyTo(e);
     }
 
     override void visit(TypeidExp e)

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -4608,15 +4608,13 @@ struct ASTBase
     extern (C++) final class NewAnonClassExp : Expression
     {
         Expression thisexp;     // if !=null, 'this' for class being allocated
-        Expressions* newargs;   // Array of Expression's to call new operator
         ClassDeclaration cd;    // class being instantiated
         Expressions* arguments; // Array of Expression's to call class constructor
 
-        extern (D) this(const ref Loc loc, Expression thisexp, Expressions* newargs, ClassDeclaration cd, Expressions* arguments)
+        extern (D) this(const ref Loc loc, Expression thisexp, ClassDeclaration cd, Expressions* arguments)
         {
             super(loc, EXP.newAnonymousClass, __traits(classInstanceSize, NewAnonClassExp));
             this.thisexp = thisexp;
-            this.newargs = newargs;
             this.cd = cd;
             this.arguments = arguments;
         }
@@ -4799,15 +4797,13 @@ struct ASTBase
     extern (C++) class NewExp : Expression
     {
         Expression thisexp;         // if !=null, 'this' for class being allocated
-        Expressions* newargs;       // Array of Expression's to call new operator
         Type newtype;
         Expressions* arguments;     // Array of Expression's
 
-        extern (D) this(const ref Loc loc, Expression thisexp, Expressions* newargs, Type newtype, Expressions* arguments)
+        extern (D) this(const ref Loc loc, Expression thisexp, Type newtype, Expressions* arguments)
         {
             super(loc, EXP.new_, __traits(classInstanceSize, NewExp));
             this.thisexp = thisexp;
-            this.newargs = newargs;
             this.newtype = newtype;
             this.arguments = arguments;
         }

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1151,7 +1151,6 @@ MATCH implicitConvTo(Expression e, Type t)
          * return from new() to t using the same algorithm as in CallExp, with the function
          * 'arguments' being:
          *    thisexp
-         *    newargs
          *    arguments
          *    .init
          * 'member' need to be pure.

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1064,9 +1064,8 @@ extern (C++) class VarDeclaration : Declaration
     // Both these mean the var is not rebindable once assigned,
     // and the destructor gets run when it goes out of scope
     bool onstack;                   // it is a class that was allocated on the stack
-    bool mynew;                     // it is a class new'd with custom operator new
 
-    byte canassign;                  // it can be assigned to
+    byte canassign;                 // it can be assigned to
     bool overlapped;                // if it is a field and has overlapping
     bool overlapUnsafe;             // if it is an overlapping field and the overlaps are unsafe
     bool doNotInferScope;           // do not infer 'scope' for this variable
@@ -1452,7 +1451,7 @@ extern (C++) class VarDeclaration : Declaration
                 //if (cd.isInterfaceDeclaration())
                 //    error("interface `%s` cannot be scope", cd.toChars());
 
-                if (mynew || onstack) // if any destructors
+                if (onstack) // if any destructors
                 {
                     // delete'ing C++ classes crashes (and delete is deprecated anyway)
                     if (cd.classKind == ClassKind.cpp)

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -248,7 +248,6 @@ public:
     bool isowner;               // this is an Owner, despite it being `scope`
     bool setInCtorOnly;         // field can only be set in a constructor, as it is const or immutable
     bool onstack;               // it is a class that was allocated on the stack
-    bool mynew;                 // it is a class new'd with custom operator new
     char canassign;             // it can be assigned to
     bool overlapped;            // if it is a field and has overlapping
     bool overlapUnsafe;         // if it is an overlapping field and the overlaps are unsafe

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1040,15 +1040,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                             // See if initializer is a NewExp that can be allocated on the stack
                             if (dsym.type.toBasetype().ty == Tclass)
                             {
-                                if (ne.newargs && ne.newargs.dim > 1)
-                                {
-                                    dsym.mynew = true;
-                                }
-                                else
-                                {
-                                    ne.onstack = 1;
-                                    dsym.onstack = true;
-                                }
+                                ne.onstack = 1;
+                                dsym.onstack = true;
                             }
                         }
                         else if (auto fe = ex.isFuncExp())

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5125,15 +5125,6 @@ private bool reliesOnTemplateParameters(Expression e, TemplateParameter[] tparam
             //printf("NewExp.reliesOnTemplateParameters('%s')\n", e.toChars());
             if (e.thisexp)
                 e.thisexp.accept(this);
-            if (!result && e.newargs)
-            {
-                foreach (ea; *e.newargs)
-                {
-                    ea.accept(this);
-                    if (result)
-                        return;
-                }
-            }
             result = e.newtype.reliesOnTemplateParameters(tparams);
             if (!result && e.arguments)
             {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3526,12 +3526,11 @@ extern (C++) final class TemplateExp : Expression
 }
 
 /***********************************************************
- * thisexp.new(newargs) newtype(arguments)
+ * newtype(arguments)
  */
 extern (C++) final class NewExp : Expression
 {
     Expression thisexp;         // if !=null, 'this' for class being allocated
-    Expressions* newargs;       // Array of Expression's to call new operator
     Type newtype;
     Expressions* arguments;     // Array of Expression's
 
@@ -3540,25 +3539,23 @@ extern (C++) final class NewExp : Expression
     bool onstack;               // allocate on stack
     bool thrownew;              // this NewExp is the expression of a ThrowStatement
 
-    extern (D) this(const ref Loc loc, Expression thisexp, Expressions* newargs, Type newtype, Expressions* arguments)
+    extern (D) this(const ref Loc loc, Expression thisexp, Type newtype, Expressions* arguments)
     {
         super(loc, EXP.new_, __traits(classInstanceSize, NewExp));
         this.thisexp = thisexp;
-        this.newargs = newargs;
         this.newtype = newtype;
         this.arguments = arguments;
     }
 
-    static NewExp create(const ref Loc loc, Expression thisexp, Expressions* newargs, Type newtype, Expressions* arguments)
+    static NewExp create(const ref Loc loc, Expression thisexp, Type newtype, Expressions* arguments)
     {
-        return new NewExp(loc, thisexp, newargs, newtype, arguments);
+        return new NewExp(loc, thisexp, newtype, arguments);
     }
 
     override NewExp syntaxCopy()
     {
         return new NewExp(loc,
             thisexp ? thisexp.syntaxCopy() : null,
-            arraySyntaxCopy(newargs),
             newtype.syntaxCopy(),
             arraySyntaxCopy(arguments));
     }
@@ -3570,27 +3567,25 @@ extern (C++) final class NewExp : Expression
 }
 
 /***********************************************************
- * thisexp.new(newargs) class baseclasses { } (arguments)
+ * class baseclasses { } (arguments)
  */
 extern (C++) final class NewAnonClassExp : Expression
 {
     Expression thisexp;     // if !=null, 'this' for class being allocated
-    Expressions* newargs;   // Array of Expression's to call new operator
     ClassDeclaration cd;    // class being instantiated
     Expressions* arguments; // Array of Expression's to call class constructor
 
-    extern (D) this(const ref Loc loc, Expression thisexp, Expressions* newargs, ClassDeclaration cd, Expressions* arguments)
+    extern (D) this(const ref Loc loc, Expression thisexp, ClassDeclaration cd, Expressions* arguments)
     {
         super(loc, EXP.newAnonymousClass, __traits(classInstanceSize, NewAnonClassExp));
         this.thisexp = thisexp;
-        this.newargs = newargs;
         this.cd = cd;
         this.arguments = arguments;
     }
 
     override NewAnonClassExp syntaxCopy()
     {
-        return new NewAnonClassExp(loc, thisexp ? thisexp.syntaxCopy() : null, arraySyntaxCopy(newargs), cd.syntaxCopy(null), arraySyntaxCopy(arguments));
+        return new NewAnonClassExp(loc, thisexp ? thisexp.syntaxCopy() : null, cd.syntaxCopy(null), arraySyntaxCopy(arguments));
     }
 
     override void accept(Visitor v)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -519,10 +519,9 @@ public:
 class NewExp : public Expression
 {
 public:
-    /* thisexp.new(newargs) newtype(arguments)
+    /* newtype(arguments)
      */
     Expression *thisexp;        // if !NULL, 'this' for class being allocated
-    Expressions *newargs;       // Array of Expression's to call new operator
     Type *newtype;
     Expressions *arguments;     // Array of Expression's
 
@@ -532,7 +531,7 @@ public:
     bool onstack;               // allocate on stack
     bool thrownew;              // this NewExp is the expression of a ThrowStatement
 
-    static NewExp *create(const Loc &loc, Expression *thisexp, Expressions *newargs, Type *newtype, Expressions *arguments);
+    static NewExp *create(const Loc &loc, Expression *thisexp, Type *newtype, Expressions *arguments);
     NewExp *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
@@ -541,10 +540,9 @@ public:
 class NewAnonClassExp : public Expression
 {
 public:
-    /* thisexp.new(newargs) class baseclasses { } (arguments)
+    /* class baseclasses { } (arguments)
      */
     Expression *thisexp;        // if !NULL, 'this' for class being allocated
-    Expressions *newargs;       // Array of Expression's to call new operator
     ClassDeclaration *cd;       // class being instantiated
     Expressions *arguments;     // Array of Expression's to call class constructor
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1842,7 +1842,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                         auto args = new Expressions(nargs - i);
                         foreach (u; i .. nargs)
                             (*args)[u - i] = (*arguments)[u];
-                        arg = new NewExp(loc, null, null, p.type, args);
+                        arg = new NewExp(loc, null, p.type, args);
                         break;
                     }
                 default:
@@ -3513,11 +3513,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.newtype = exp.type; // in case type gets cast to something else
         Type tb = exp.type.toBasetype();
         //printf("tb: %s, deco = %s\n", tb.toChars(), tb.deco);
-        if (arrayExpressionSemantic(exp.newargs, sc) ||
-            preFunctionParameters(sc, exp.newargs))
-        {
-            return setError();
-        }
         if (arrayExpressionSemantic(exp.arguments, sc))
         {
             return setError();
@@ -3683,14 +3678,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                           originalNewtype.toChars());
                 return setError();
             }
-            else
-            {
-                if (exp.newargs && exp.newargs.dim)
-                {
-                    exp.error("no allocator for `%s`", cd.toChars());
-                    return setError();
-                }
-            }
 
             if (cd.ctor)
             {
@@ -3755,14 +3742,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.error("cannot allocate `struct %s` with `new` because it is annotated with `@disable new()`",
                           originalNewtype.toChars());
                 return setError();
-            }
-            else
-            {
-                if (exp.newargs && exp.newargs.dim)
-                {
-                    exp.error("no allocator for `%s`", sd.toChars());
-                    return setError();
-                }
             }
 
             if (sd.hasRegularCtor() && nargs)
@@ -3915,7 +3894,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             sds.members.push(e.cd);
         }
 
-        Expression n = new NewExp(e.loc, e.thisexp, e.newargs, e.cd.type, e.arguments);
+        Expression n = new NewExp(e.loc, e.thisexp, e.cd.type, e.arguments);
 
         Expression c = new CommaExp(e.loc, d, n);
         result = c.expressionSemantic(sc);
@@ -9878,7 +9857,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             VarExp ve = cast(VarExp)exp.e1;
             VarDeclaration vd = ve.var.isVarDeclaration();
-            if (vd && (vd.onstack || vd.mynew))
+            if (vd && vd.onstack)
             {
                 assert(t1.ty == Tclass);
                 exp.error("cannot rebind scope variables");

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5804,7 +5804,6 @@ public:
     bool isowner;
     bool setInCtorOnly;
     bool onstack;
-    bool mynew;
     int8_t canassign;
     bool overlapped;
     bool overlapUnsafe;
@@ -6884,14 +6883,13 @@ class NewExp final : public Expression
 {
 public:
     Expression* thisexp;
-    Array<Expression* >* newargs;
     Type* newtype;
     Array<Expression* >* arguments;
     Expression* argprefix;
     CtorDeclaration* member;
     bool onstack;
     bool thrownew;
-    static NewExp* create(const Loc& loc, Expression* thisexp, Array<Expression* >* newargs, Type* newtype, Array<Expression* >* arguments);
+    static NewExp* create(const Loc& loc, Expression* thisexp, Type* newtype, Array<Expression* >* arguments);
     NewExp* syntaxCopy();
     void accept(Visitor* v);
 };
@@ -6900,7 +6898,6 @@ class NewAnonClassExp final : public Expression
 {
 public:
     Expression* thisexp;
-    Array<Expression* >* newargs;
     ClassDeclaration* cd;
     Array<Expression* >* arguments;
     NewAnonClassExp* syntaxCopy();

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2105,12 +2105,6 @@ public:
             buf.writeByte('.');
         }
         buf.writestring("new ");
-        if (e.newargs && e.newargs.dim)
-        {
-            buf.writeByte('(');
-            argsToBuffer(e.newargs, buf, hgs);
-            buf.writeByte(')');
-        }
         typeToBuffer(e.newtype, null, buf, hgs);
         if (e.arguments && e.arguments.dim)
         {
@@ -2128,12 +2122,6 @@ public:
             buf.writeByte('.');
         }
         buf.writestring("new");
-        if (e.newargs && e.newargs.dim)
-        {
-            buf.writeByte('(');
-            argsToBuffer(e.newargs, buf, hgs);
-            buf.writeByte(')');
-        }
         buf.writestring(" class ");
         if (e.arguments && e.arguments.dim)
         {

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -722,7 +722,6 @@ public:
             auto ne = e.copy().isNewExp();
             ne.thisexp = doInlineAs!Expression(e.thisexp, ids);
             ne.argprefix = doInlineAs!Expression(e.argprefix, ids);
-            ne.newargs = arrayExpressionDoInline(e.newargs);
             ne.arguments = arrayExpressionDoInline(e.arguments);
             result = ne;
 

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -631,13 +631,6 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
     {
         expOptimize(e.thisexp, WANTvalue);
         // Optimize parameters
-        if (e.newargs)
-        {
-            for (size_t i = 0; i < e.newargs.dim; i++)
-            {
-                expOptimize((*e.newargs)[i], WANTvalue);
-            }
-        }
         if (e.arguments)
         {
             for (size_t i = 0; i < e.arguments.dim; i++)

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -9176,12 +9176,7 @@ LagainStc:
         const loc = token.loc;
 
         nextToken();
-        AST.Expressions* newargs = null;
         AST.Expressions* arguments = null;
-        if (token.value == TOK.leftParenthesis)
-        {
-            newargs = parseArguments();
-        }
 
         // An anonymous nested class starts with "class"
         if (token.value == TOK.class_)
@@ -9211,7 +9206,7 @@ LagainStc:
             }
 
             auto cd = new AST.ClassDeclaration(loc, id, baseclasses, members, false);
-            auto e = new AST.NewAnonClassExp(loc, thisexp, newargs, cd, arguments);
+            auto e = new AST.NewAnonClassExp(loc, thisexp, cd, arguments);
             return e;
         }
 
@@ -9236,7 +9231,7 @@ LagainStc:
             arguments = parseArguments();
         }
 
-        auto e = new AST.NewExp(loc, thisexp, newargs, t, arguments);
+        auto e = new AST.NewExp(loc, thisexp, t, arguments);
         return e;
     }
 

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -961,8 +961,6 @@ package mixin template ParseVisitMethods(AST)
         //printf("Visiting NewExp\n");
         if (e.thisexp)
             e.thisexp.accept(this);
-        if (e.newargs && e.newargs.dim)
-            visitArgs(e.newargs);
         visitType(e.newtype);
         if (e.arguments && e.arguments.dim)
             visitArgs(e.arguments);
@@ -973,8 +971,6 @@ package mixin template ParseVisitMethods(AST)
         //printf("Visiting NewAnonClassExp\n");
         if (e.thisexp)
             e.thisexp.accept(this);
-        if (e.newargs && e.newargs.dim)
-            visitArgs(e.newargs);
         if (e.arguments && e.arguments.dim)
             visitArgs(e.arguments);
         if (e.cd)

--- a/test/fail_compilation/fail_arrayop2.d
+++ b/test/fail_compilation/fail_arrayop2.d
@@ -252,7 +252,7 @@ void test15407exp()
     // StructLiteralExp.elements <- preFunctionParameters in CallExp
     { auto r = S([1] * 6); }
 
-    // NewExp.newargs/arguments <- preFunctionParameters
+    // NewExp.arguments <- preFunctionParameters
     { auto r = new S([1] * 6); }
 
     // TODO: TypeidExp


### PR DESCRIPTION
Custom allocators have been removed from the language.  This cleans up the implementation to discard them entirely from the internal AST/semantic pass.