### PR TITLE
Fix issue 22776 - string literal printing fails on non-ASCII/non-printable chars

### DIFF
--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -2545,29 +2545,9 @@ public:
             buf.writeByte('U');
         buf.writeByte('"');
 
-        for (size_t i = 0; i < e.len; i++)
+        foreach (i; 0 .. e.len)
         {
-            uint c = e.charAt(i);
-            switch (c)
-            {
-                case '"':
-                case '\\':
-                    buf.writeByte('\\');
-                    goto default;
-                default:
-                    if (c <= 0xFF)
-                    {
-                        if (c >= 0x20 && c < 0x80)
-                            buf.writeByte(c);
-                        else
-                            buf.printf("\\x%02x", c);
-                    }
-                    else if (c <= 0xFFFF)
-                        buf.printf("\\u%04x", c);
-                    else
-                        buf.printf("\\U%08x", c);
-                    break;
-            }
+            writeCharLiteral(*buf, e.charAt(i));
         }
         buf.writeByte('"');
     }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1984,29 +1984,9 @@ public:
     {
         buf.writeByte('"');
         const o = buf.length;
-        for (size_t i = 0; i < e.len; i++)
+        foreach (i; 0 .. e.len)
         {
-            const c = e.charAt(i);
-            switch (c)
-            {
-            case '"':
-            case '\\':
-                buf.writeByte('\\');
-                goto default;
-            default:
-                if (c <= 0xFF)
-                {
-                    if (c <= 0x7F && isprint(c))
-                        buf.writeByte(c);
-                    else
-                        buf.printf("\\x%02x", c);
-                }
-                else if (c <= 0xFFFF)
-                    buf.printf("\\x%02x\\x%02x", c & 0xFF, c >> 8);
-                else
-                    buf.printf("\\x%02x\\x%02x\\x%02x\\x%02x", c & 0xFF, (c >> 8) & 0xFF, (c >> 16) & 0xFF, c >> 24);
-                break;
-            }
+            writeCharLiteral(*buf, e.charAt(i));
         }
         if (hgs.ddoc)
             escapeDdocString(buf, o);

--- a/test/fail_compilation/diag15713.d
+++ b/test/fail_compilation/diag15713.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag15713.d(19): Error: no property `widthSign` for type `diag15713.WrData.Data`
-fail_compilation/diag15713.d(39): Error: template instance `diag15713.conwritefImpl!("parse-int", "width", "\x0a", Data(null))` error instantiating
-fail_compilation/diag15713.d(44):        instantiated from here: `conwritefImpl!("main", "\x0a", Data(null))`
+fail_compilation/diag15713.d(39): Error: template instance `diag15713.conwritefImpl!("parse-int", "width", "\n", Data(null))` error instantiating
+fail_compilation/diag15713.d(44):        instantiated from here: `conwritefImpl!("main", "\n", Data(null))`
 fail_compilation/diag15713.d(49):        instantiated from here: `fdwritef!()`
 ---
 */

--- a/test/fail_compilation/fail196.d
+++ b/test/fail_compilation/fail196.d
@@ -3,12 +3,12 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail196.d(27): Error: delimited string must end in `)"`
 fail_compilation/fail196.d(27): Error: Implicit string concatenation is error-prone and disallowed in D
-fail_compilation/fail196.d(27):        Use the explicit syntax instead (concatenating literals is `@nogc`): "foo(xxx)" ~ ";\x0a    assert(s == "
+fail_compilation/fail196.d(27):        Use the explicit syntax instead (concatenating literals is `@nogc`): "foo(xxx)" ~ ";\n    assert(s == "
 fail_compilation/fail196.d(28): Error: semicolon needed to end declaration of `s`, instead of `foo`
 fail_compilation/fail196.d(27):        `s` declared here
-fail_compilation/fail196.d(28): Error: found `");\x0a\x0a    s = q"` when expecting `;` following statement
-fail_compilation/fail196.d(30): Error: found `";\x0a    assert(s == "` when expecting `;` following statement
-fail_compilation/fail196.d(31): Error: found `");\x0a\x0a    s = q"` when expecting `;` following statement
+fail_compilation/fail196.d(28): Error: found `");\n\n    s = q"` when expecting `;` following statement
+fail_compilation/fail196.d(30): Error: found `";\n    assert(s == "` when expecting `;` following statement
+fail_compilation/fail196.d(31): Error: found `");\n\n    s = q"` when expecting `;` following statement
 fail_compilation/fail196.d(33): Error: found `{` when expecting `;` following statement
 fail_compilation/fail196.d(33): Error: found `}` when expecting `;` following statement
 fail_compilation/fail196.d(34): Error: found `foo` when expecting `;` following statement

--- a/test/fail_compilation/lexer1.d
+++ b/test/fail_compilation/lexer1.d
@@ -13,7 +13,7 @@ fail_compilation/lexer1.d(37): Error: declaration expected, not `0.1Li`
 fail_compilation/lexer1.d(38): Error: declaration expected, not `' '`
 fail_compilation/lexer1.d(39): Error: declaration expected, not `55295U`
 fail_compilation/lexer1.d(40): Error: declaration expected, not `65536U`
-fail_compilation/lexer1.d(41): Error: declaration expected, not `"ab\\c\"\u1234a\U00011100a"d`
+fail_compilation/lexer1.d(41): Error: declaration expected, not `"ab\\c\"\u1234a\U00011100a\0ab"d`
 fail_compilation/lexer1.d(43): Error: declaration expected, not `module`
 fail_compilation/lexer1.d(45): Error: escape hex sequence has 1 hex digits instead of 2
 fail_compilation/lexer1.d(46): Error: undefined escape hex sequence \xG


### PR DESCRIPTION
The logic of formatting characters is duplicated many times, so I extracted it to a separate function.