### PR TITLE
test: Adapt tests that to use alternatives for the 'delete' keyword

### DIFF
--- a/test/compilable/debugInference.d
+++ b/test/compilable/debugInference.d
@@ -1,9 +1,5 @@
 /*
 REQUIRED_ARGS: -debug
-TEST_OUTPUT:
----
-compilable/debugInference.d(35): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
 https://issues.dlang.org/show_bug.cgi?id=20507
 */
 
@@ -32,7 +28,7 @@ void bar()()
         auto f2Ptr = &f2;
 
         S s;
-        delete s;
+        destroy(s);
 
         int* ptr = cast(int*) 0;
         int[] slice = ptr[0 .. 4];

--- a/test/compilable/test17906.d
+++ b/test/compilable/test17906.d
@@ -3,5 +3,5 @@
 deprecated void main ()
 {
     Object o = new Object;
-    delete o;
+    destroy(o);
 }

--- a/test/compilable/vgc1.d
+++ b/test/compilable/vgc1.d
@@ -65,20 +65,9 @@ void testNewScope()
 
 /***************** DeleteExp *******************/
 
-/*
-TEST_OUTPUT:
----
-compilable/vgc1.d(81): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-compilable/vgc1.d(81): vgc: `delete` requires the GC
-compilable/vgc1.d(82): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-compilable/vgc1.d(82): vgc: `delete` requires the GC
-compilable/vgc1.d(83): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-compilable/vgc1.d(83): vgc: `delete` requires the GC
----
-*/
 void testDelete(int* p, Object o, S1* s)
 {
-    delete p;
-    delete o;
-    delete s;
+    destroy(p);
+    destroy(o);
+    destroy(s);
 }

--- a/test/runnable/class_destructors.d
+++ b/test/runnable/class_destructors.d
@@ -2,7 +2,6 @@
 https://issues.dlang.org/show_bug.cgi?id=21799
 
 PERMUTE_ARGS:
-TRANSFORM_OUTPUT: remove_lines( Deprecation: The `delete` keyword has been deprecated)
 **/
 
 int main()
@@ -44,9 +43,11 @@ void testDeleteD()
 	char[] res;
 	ChildD cd = new ChildD();
 	cd.ptr = &res;
-	delete cd;
-
-	assert(res == "BA", cast(string) res);
+	if (!__ctfe)
+	{
+		destroy(cd);
+		assert(res == "BA", cast(string) res);
+	}
 }
 
 void testDeleteDScope()
@@ -68,9 +69,11 @@ void testDeleteWithoutD()
 	char[] res;
 	ChildWithoutDtorD cd = new ChildWithoutDtorD();
 	cd.ptr = &res;
-	delete cd;
-
-	assert(res == "BA", cast(string) res);
+	if (!__ctfe)
+	{
+		destroy(cd);
+		assert(res == "BA", cast(string) res);
+	}
 }
 
 /*************************************************/
@@ -106,9 +109,11 @@ void testDeleteCpp()
 	char[] res;
 	ChildCpp cc = new ChildCpp();
 	cc.ptr = &res;
-	delete cc;
-
-	assert(res == "DC", cast(string) res);
+	if (!__ctfe)
+	{
+		destroy(cc);
+		assert(res == "DC", cast(string) res);
+	}
 }
 
 void testDeleteCppScope()
@@ -138,9 +143,11 @@ void testDeleteWithoutCpp()
 	char[] res;
 	ChildWithoutDtorCpp cd = new ChildWithoutDtorCpp();
 	cd.ptr = &res;
-	delete cd;
-
-	assert(res == "DC", cast(string) res);
+	if (!__ctfe)
+	{
+		destroy(cd);
+		assert(res == "DC", cast(string) res);
+	}
 }
 
 /*************************************************/
@@ -164,15 +171,18 @@ void testThrowingDtor()
 	ThrowingChildD tcd = new ThrowingChildD();
 	tcd.ptr = &res;
 
-	try
+	if (!__ctfe)
 	{
-		delete tcd;
-		assert(false, "No exception thrown!");
-	}
-	catch (Exception e)
-	{
-		assert(e is ThrowingChildD.ex);
-	}
+		try
+		{
+			destroy(tcd);
+			assert(false, "No exception thrown!");
+		}
+		catch (Exception e)
+		{
+			assert(e is ThrowingChildD.ex);
+		}
 
-	assert(res == "", cast(string) res);
+		assert(res == "", cast(string) res);
+	}
 }

--- a/test/runnable/imports/link12144a.d
+++ b/test/runnable/imports/link12144a.d
@@ -28,7 +28,7 @@ void fun()()
     { alias P = S3*; auto p = new P; }
     { S4[int] aa; auto b = (aa == aa); }
     { S5[] a; a.length = 10; }
-    { S6[] a; delete a; }
+    { S6[] a; destroy(a); }
     { S7[] a = []; }
     { S8[] a = [S8.init]; }
     { S9[int] aa = [1:S9.init]; }

--- a/test/runnable/interface.d
+++ b/test/runnable/interface.d
@@ -1,11 +1,3 @@
-/*
-TEST_OUTPUT:
----
-runnable/interface.d(41): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/interface.d(55): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
-*/
-
 import core.stdc.stdio;
 
 /*******************************************/
@@ -38,7 +30,7 @@ void test1()
     IO io = new IO();
     printf("io = %p\n", io);
     foo(io, io);
-    delete io;
+    destroy(io);
 }
 
 /*******************************************/
@@ -52,7 +44,7 @@ class C : I
 void test2()
 {
     I i = new C();
-    delete i;
+    destroy(i);
 
   {
     scope I j = new C();

--- a/test/runnable/interface2.d
+++ b/test/runnable/interface2.d
@@ -1,11 +1,4 @@
 // PERMUTE_ARGS:
-/*
-TEST_OUTPUT:
----
-runnable/interface2.d(47): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/interface2.d(98): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
-*/
 
 extern(C) int printf(const char*, ...);
 
@@ -44,7 +37,7 @@ void test1()
     printf("cast(Bar)f = %p\n", b2);
     assert(b is b2);
 
-    delete f;
+    destroy(f);
 }
 
 /*******************************************************/
@@ -95,7 +88,7 @@ class E3 : D3, C3
 void test3()
 {
     C3 c = new E3();
-    delete c;
+    destroy(c);
 }
 
 

--- a/test/runnable/link12144.d
+++ b/test/runnable/link12144.d
@@ -1,11 +1,5 @@
 // COMPILE_SEPARATELY: -g
 // EXTRA_SOURCES: imports/link12144a.d
-/*
-TEST_OUTPUT:
----
-runnable/imports/link12144a.d(31): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
-*/
 
 import imports.link12144a;
 

--- a/test/runnable/link15017.d
+++ b/test/runnable/link15017.d
@@ -1,11 +1,5 @@
 // COMPILE_SEPARATELY:
 // EXTRA_SOURCES: imports/std15017variant.d
-/*
-TEST_OUTPUT:
----
-runnable/link15017.d(48): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
-*/
 
 import imports.std15017variant;
 
@@ -45,7 +39,7 @@ void test()
 
     // OK <- in DeleteExp::semantic
     Variant10* p10;
-    delete p10;
+    destroy(p10);
     static assert(Variant10.__dtor.mangleof == "_D7imports15std15017variant__T8VariantNVki10ZQp6__dtorMFNaNbNiNfZv");
 }
 

--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -1,9 +1,4 @@
 /*
-TEST_OUTPUT:
----
-runnable/mixin1.d(948): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
-
 RUN_OUTPUT:
 ---
 Foo3.func()
@@ -945,7 +940,7 @@ class Outer38
 void test38()
 {
     Outer38 o = new Outer38();
-    delete o;
+    destroy(o);
     assert(Outer38.c == 3);
 }
 

--- a/test/runnable/newdel.d
+++ b/test/runnable/newdel.d
@@ -1,10 +1,4 @@
 // PERMUTE_ARGS:
-/*
-TEST_OUTPUT:
----
-runnable/newdel.d(46): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
-*/
 
 import core.stdc.stdio;
 import core.stdc.stdlib;
@@ -43,7 +37,7 @@ void test1()
     assert(f.d == 56);
     assert(Foo.flags == 0);
 
-    delete f;
+    destroy(f);
     assert(Foo.flags == 1);
 }
 

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -3,19 +3,13 @@
 /*
 TEST_OUTPUT:
 ---
-runnable/sdtor.d(36): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/sdtor.d(59): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/sdtor.d(93): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/sdtor.d(117): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/sdtor.d(143): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/sdtor.d(177): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/sdtor.d(203): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/sdtor.d(276): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 S7353
 ---
 */
 
 import core.vararg;
+// FIXME: Shouldn't tests that use this go in core.memory now that `delete` has been removed?
+import core.memory : __delete;
 
 extern (C) int printf(const(char*) fmt, ...) nothrow;
 
@@ -33,7 +27,7 @@ struct S1
 void test1()
 {
     S1* s = new S1();
-    delete s;
+    __delete(s);
     assert(sdtor == 1);
 }
 
@@ -56,7 +50,7 @@ void test3()
 {
     T3* s = new T3();
     s.s.a = 3;
-    delete s;
+    __delete(s);
     assert(sdtor3 == 1);
 }
 
@@ -90,7 +84,7 @@ void test4()
 {
     T4* s = new T4();
     s.s.a = 4;
-    delete s;
+    __delete(s);
     assert(sdtor4 == 3);
 }
 
@@ -114,7 +108,7 @@ struct T5
 void test5()
 {
     T5* s = new T5();
-    delete s;
+    __delete(s);
     assert(sdtor5 == 2);
 }
 
@@ -140,7 +134,7 @@ class T6
 void test6()
 {
     T6 s = new T6();
-    delete s;
+    __delete(s);
     assert(sdtor6 == 2);
 }
 
@@ -174,7 +168,7 @@ struct T7
 void test7()
 {
     T7* s = new T7();
-    delete s;
+    __delete(s);
     assert(sdtor7 == 4);
 }
 
@@ -200,7 +194,7 @@ void test8()
     s[0].c = 2;
     s[1].c = 1;
     s[2].c = 0;
-    delete s;
+    __delete(s);
     assert(sdtor8 == 3);
 }
 
@@ -273,7 +267,7 @@ class T11
 void test11()
 {
     T11 s = new T11();
-    delete s;
+    __delete(s);
     assert(sdtor11 == 2);
 }
 

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -1,9 +1,3 @@
-/*
-TEST_OUTPUT:
----
-runnable/test20.d(448): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
-*/
 import core.vararg;
 
 extern(C) int printf(const char*, ...);
@@ -445,7 +439,7 @@ class Buffer
 void test20()
 {
     Buffer b = new Buffer();
-    delete b;
+    destroy(b);
 }
 
 /*****************************************/

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -1,11 +1,5 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS:
-/*
-TEST_OUTPUT:
----
-runnable/test4.d(717): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
-*/
 
 import core.exception;
 import core.stdc.math;
@@ -714,7 +708,7 @@ void test29()
 
     Foo29 f = new Foo29();
 
-    delete f;
+    destroy(f);
     assert(x29 == 3);
 }
 

--- a/test/runnable/testappend.d
+++ b/test/runnable/testappend.d
@@ -1,13 +1,5 @@
 /*
 PERMUTE_ARGS:
-TEST_OUTPUT:
----
-runnable/testappend.d(54): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/testappend.d(55): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/testappend.d(76): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-runnable/testappend.d(77): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
-
 RUN_OUTPUT:
 ---
 Success
@@ -51,8 +43,8 @@ int main()
     {
         assert(isnan(v));
     }
-    delete a;
-    delete b;
+    destroy(a);
+    destroy(b);
 
     a = null;
     for (int i = 0; i < 100000; i++)
@@ -73,8 +65,8 @@ int main()
     {
         assert(v == k);
     }
-    delete a;
-    delete b;
+    destroy(a);
+    destroy(b);
 
     test12826();
     printf("Success\n");

--- a/test/runnable/testdstress.d
+++ b/test/runnable/testdstress.d
@@ -1,10 +1,4 @@
 // PERMUTE_ARGS:
-/*
-TEST_OUTPUT:
----
-runnable/testdstress.d(666): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
-*/
 
 module run.module_01;
 
@@ -663,7 +657,7 @@ void test30()
 
         assert(status30 == 1);
 
-        delete m;   // _d_callfinalizer
+        destroy(m);   // _d_callfinalizer
     }
     catch (Error e) // FinalizeError
     {


### PR DESCRIPTION
Because of the non-triviality of some rewrites, it's better to fix the bulk of the tests ahead of removing the `delete` keyword for good (follow-up).