### PR TITLE
fix Issue 22780 - [REG 2.090] variable reference to scope class must be scope

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -848,10 +848,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
 
             // @@@DEPRECATED@@@  https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
-            // Deprecated in 2.087
-            // Remove this when the feature is removed from the language
-            if (0 &&          // deprecation disabled for now to accommodate existing extensive use
-               !(dsym.storage_class & STC.scope_))
+            // Scope as a type constraint will soon be deprecated.
+            // Remove this when the feature is removed from the language.
+            if (!(dsym.storage_class & STC.scope_))
             {
                 if (!(dsym.storage_class & STC.parameter) && dsym.ident != Id.withSym)
                     dsym.error("reference to `scope class` must be `scope`");

--- a/test/compilable/test7172.d
+++ b/test/compilable/test7172.d
@@ -7,7 +7,7 @@ void main()
     static assert(!__traits(compiles, { class D : FinalC{} }));
 
     scope class ScopeC{}
-//    static assert(!__traits(compiles, { auto  sc = new ScopeC(); }));
+    static assert(!__traits(compiles, { auto  sc = new ScopeC(); }));
     static assert( __traits(compiles, { scope sc = new ScopeC(); }));
 
     synchronized class SyncC{ void f(){} }

--- a/test/fail_compilation/fail22780.d
+++ b/test/fail_compilation/fail22780.d
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=22780
+/* TEST_OUTPUT:
+---
+fail_compilation/fail22780.d(11): Error: variable `fail22780.test10717.c` reference to `scope class` must be `scope`
+---
+*/
+scope class C10717 { }
+
+void test10717()
+{
+    C10717 c;
+}


### PR DESCRIPTION
Partially revert #10717 Deprecate scope as a type constraint on class declarations.

This code has always been an error until 2.090 when it was suddenly not due to a botched revert.