### PR TITLE
End deprecation period for 'scope' as a type constraint on interface declarations

### DIFF
--- a/changelog/error_scope_interface.dd
+++ b/changelog/error_scope_interface.dd
@@ -1,0 +1,8 @@
+The deprecation period for `scope` as a type constraint on interface declarations has ended.
+
+Starting with this release, using `scope` as a type constraint on `interface`
+declarations will result in a compiler error.
+
+---
+scope interface I { }  // Error: `scope` as a type constraint is obsolete.  Use `scope` at the usage site.
+---

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -5592,12 +5592,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         assert(idec.type.ty != Tclass || (cast(TypeClass)idec.type).sym == idec);
 
-        // @@@DEPRECATED_2.097@@@https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+        // @@@DEPRECATED_2.120@@@ https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
         // Deprecated in 2.087
-        // Remove in 2.091
+        // Made an error in 2.100, but removal depends on `scope class` being removed too
         // Don't forget to remove code at https://github.com/dlang/dmd/blob/b2f8274ba76358607fc3297a1e9f361480f9bcf9/src/dmd/dsymbolsem.d#L1032-L1036
         if (idec.storage_class & STC.scope_)
-            deprecation(idec.loc, "`scope` as a type constraint is deprecated.  Use `scope` at the usage site.");
+            error(idec.loc, "`scope` as a type constraint is obsolete.  Use `scope` at the usage site.");
     }
 }
 

--- a/test/fail_compilation/scope_type.d
+++ b/test/fail_compilation/scope_type.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/scope_type.d(11): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/scope_type.d(11): Error: `scope` as a type constraint is obsolete.  Use `scope` at the usage site.
 ---
 */
 


### PR DESCRIPTION
This deprecation warning has been around since 2.087, time to make it an error.

Because `scope interface` has ties with `scope class`, I've bumped the removal date to a time in the future which should (knock wood) align with the removal of `scope class` as well.

(NB: I suspect @WalterBright maybe wanted to revert this code in #10717, but it ended up staying in.)