### PR TITLE
Deprecate 'scope' as a type constraint on class declarations

### DIFF
--- a/changelog/dep_scope_class.dd
+++ b/changelog/dep_scope_class.dd
@@ -1,0 +1,12 @@
+`scope` as a type constraint on class declarations is deprecated.
+
+`scope` as a type constraint on class declarations has been scheduled for
+deprecation for quite some time. However, starting with this release, the
+compiler will emit a deprecation warning if used.
+
+---
+scope class C { }  // Deprecation: `scope` as a type constraint is deprecated. Use `scope` at the usage site.
+---
+
+Note that this does not apply to structs. Deprecation of `scope` as a type
+constraint on structs is still awaiting a decision.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -5292,12 +5292,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         //printf("-ClassDeclaration.dsymbolSemantic(%s), type = %p, sizeok = %d, this = %p\n", toChars(), type, sizeok, this);
 
-        // @@@DEPRECATED_2.097@@@ https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
-        // Deprecated in 2.087
-        // Make an error in 2.091
+        // @@@DEPRECATED_2.110@@@ https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+        // Deprecated in 2.100
+        // Make an error in 2.110
         // Don't forget to remove code at https://github.com/dlang/dmd/blob/b2f8274ba76358607fc3297a1e9f361480f9bcf9/src/dmd/dsymbolsem.d#L1032-L1036
-        if (0 &&          // deprecation disabled for now to accommodate existing extensive use
-            cldec.storage_class & STC.scope_)
+        if (cldec.storage_class & STC.scope_)
             deprecation(cldec.loc, "`scope` as a type constraint is deprecated.  Use `scope` at the usage site.");
     }
 

--- a/test/compilable/test7172.d
+++ b/test/compilable/test7172.d
@@ -1,3 +1,8 @@
+/* TEST_OUTPUT:
+---
+compilable/test7172.d(14): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+---
+*/
 void main()
 {
     abstract class AbstractC{}

--- a/test/fail_compilation/fail22780.d
+++ b/test/fail_compilation/fail22780.d
@@ -1,7 +1,8 @@
 // https://issues.dlang.org/show_bug.cgi?id=22780
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail22780.d(11): Error: variable `fail22780.test10717.c` reference to `scope class` must be `scope`
+fail_compilation/fail22780.d(8): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/fail22780.d(12): Error: variable `fail22780.test10717.c` reference to `scope class` must be `scope`
 ---
 */
 scope class C10717 { }

--- a/test/fail_compilation/scope_class.d
+++ b/test/fail_compilation/scope_class.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/scope_class.d(11): Error: functions cannot return `scope scope_class.C`
+fail_compilation/scope_class.d(10): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/scope_class.d(12): Error: functions cannot return `scope scope_class.C`
 ---
 */
 

--- a/test/fail_compilation/scope_type.d
+++ b/test/fail_compilation/scope_type.d
@@ -2,7 +2,8 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/scope_type.d(11): Error: `scope` as a type constraint is obsolete.  Use `scope` at the usage site.
+fail_compilation/scope_type.d(11): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/scope_type.d(12): Error: `scope` as a type constraint is obsolete.  Use `scope` at the usage site.
 ---
 */
 

--- a/test/fail_compilation/typeerrors.d
+++ b/test/fail_compilation/typeerrors.d
@@ -1,22 +1,23 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/typeerrors.d(36): Error: tuple index 4 exceeds 4
-fail_compilation/typeerrors.d(38): Error: variable `x` cannot be read at compile time
-fail_compilation/typeerrors.d(39): Error: cannot have array of `void()`
-fail_compilation/typeerrors.d(40): Error: cannot have array of scope `typeerrors.C`
+fail_compilation/typeerrors.d(32): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/typeerrors.d(37): Error: tuple index 4 exceeds 4
+fail_compilation/typeerrors.d(39): Error: variable `x` cannot be read at compile time
+fail_compilation/typeerrors.d(40): Error: cannot have array of `void()`
 fail_compilation/typeerrors.d(41): Error: cannot have array of scope `typeerrors.C`
-fail_compilation/typeerrors.d(44): Error: `int[5]` is not an expression
-fail_compilation/typeerrors.d(46): Error: variable `x` is used as a type
-fail_compilation/typeerrors.d(37):        variable `x` is declared here
-fail_compilation/typeerrors.d(47): Error: cannot have associative array key of `void()`
-fail_compilation/typeerrors.d(48): Error: cannot have associative array key of `void`
-fail_compilation/typeerrors.d(49): Error: cannot have array of scope `typeerrors.C`
-fail_compilation/typeerrors.d(50): Error: cannot have associative array of `void`
-fail_compilation/typeerrors.d(51): Error: cannot have associative array of `void()`
-fail_compilation/typeerrors.d(53): Error: cannot have parameter of type `void`
-fail_compilation/typeerrors.d(55): Error: slice `[1..5]` is out of range of [0..4]
-fail_compilation/typeerrors.d(56): Error: slice `[2..1]` is out of range of [0..4]
+fail_compilation/typeerrors.d(42): Error: cannot have array of scope `typeerrors.C`
+fail_compilation/typeerrors.d(45): Error: `int[5]` is not an expression
+fail_compilation/typeerrors.d(47): Error: variable `x` is used as a type
+fail_compilation/typeerrors.d(38):        variable `x` is declared here
+fail_compilation/typeerrors.d(48): Error: cannot have associative array key of `void()`
+fail_compilation/typeerrors.d(49): Error: cannot have associative array key of `void`
+fail_compilation/typeerrors.d(50): Error: cannot have array of scope `typeerrors.C`
+fail_compilation/typeerrors.d(51): Error: cannot have associative array of `void`
+fail_compilation/typeerrors.d(52): Error: cannot have associative array of `void()`
+fail_compilation/typeerrors.d(54): Error: cannot have parameter of type `void`
+fail_compilation/typeerrors.d(56): Error: slice `[1..5]` is out of range of [0..4]
+fail_compilation/typeerrors.d(57): Error: slice `[2..1]` is out of range of [0..4]
 ---
 */
 

--- a/test/runnable/auto1.d
+++ b/test/runnable/auto1.d
@@ -16,7 +16,7 @@ import core.stdc.stdio;
 
 /******************************************/
 
-scope class Foo
+class Foo
 {
     static int x;
 
@@ -65,7 +65,7 @@ void test1()
 
 int ax;
 
-scope class A2
+class A2
 {
   this()
   {
@@ -96,11 +96,11 @@ void test2()
 
 int status3;
 
-scope class Parent3
+class Parent3
 {
 }
 
-scope class Child3 : Parent3
+class Child3 : Parent3
 {
         this(){
                 assert(status3==0);

--- a/test/runnable/sctor2.d
+++ b/test/runnable/sctor2.d
@@ -1,5 +1,10 @@
-// REQUIRED_ARGS: -w -de
+// REQUIRED_ARGS: -w -dw
 // PERMUTE_ARGS:
+/* TEST_OUTPUT:
+---
+runnable/sctor2.d(12): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+---
+*/
 
 /***************************************************/
 // 15665


### PR DESCRIPTION
https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint

Sociomantic is dead, so the one business user who this mostly affected is no longer a blocker for progressing this deprecation. @Geod24 @donc.

As this is _really_ deprecated in 2.100 - not 2.087 - the version numbers in the comments have been bumped accordingly.