### PR TITLE
End deprecation period for using 'alias this' for partial assignment.

### DIFF
--- a/changelog/alias_this_assignment.dd
+++ b/changelog/alias_this_assignment.dd
@@ -1,0 +1,30 @@
+End deprecation period for using `alias this` for partial assignment.
+
+Starting with this release, `alias this` may not be used for the partial
+assignment of a left-hand side operand. Any such assignment will result in a
+compiler error.
+
+If a struct has a single member which is aliased this directly or aliased to a
+ref getter function that returns the mentioned member, then alias this may be
+used since the object will be fully initialised.
+
+---
+struct Allowed
+{
+    int onemember;
+    alias onemember this;
+}
+
+struct Rejected
+{
+    int aliased;
+    long other;
+    alias aliased this;
+}
+
+void fun(Allowed a, Rejected r)
+{
+    a = 0; // OK, struct has only one member.
+    r = 0; // Error, cannot use `alias this` to partially initialize variable `r` of type `Rejected`. Use `r.aliased`
+}
+---

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -839,11 +839,10 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                 }
             }
 
-            Expression tempResult;
+            Expression rewrittenLhs;
             if (!(e.op == EXP.assign && ad2 && ad1 == ad2)) // https://issues.dlang.org/show_bug.cgi?id=2943
             {
-                Expression result = checkAliasThisForLhs(ad1, sc, e);
-                if (result)
+                if (Expression result = checkAliasThisForLhs(ad1, sc, e))
                 {
                     /* https://issues.dlang.org/show_bug.cgi?id=19441
                      *
@@ -874,25 +873,19 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                                 return result;
                         }
                     }
-                    tempResult = result;
+                    rewrittenLhs = ae.e1;
                 }
             }
             if (!(e.op == EXP.assign && ad1 && ad1 == ad2)) // https://issues.dlang.org/show_bug.cgi?id=2943
             {
-                Expression result = checkAliasThisForRhs(ad2, sc, e);
-                if (result)
+                if (Expression result = checkAliasThisForRhs(ad2, sc, e))
                     return result;
             }
-
-            // @@@DEPRECATED_2.096@@@
-            // 1. Deprecation for 1 year
-            // 2. Turn to error after
-            if (tempResult)
+            if (rewrittenLhs)
             {
-                // move this line where tempResult is assigned to result and turn to error when derecation period is over
-                e.deprecation("Cannot use `alias this` to partially initialize variable `%s` of type `%s`. Use `%s`", e.e1.toChars(), ad1.toChars(), (cast(BinExp)tempResult).e1.toChars());
-                // delete this line when deprecation period is over
-                return tempResult;
+                e.error("cannot use `alias this` to partially initialize variable `%s` of type `%s`. Use `%s`",
+                        e.e1.toChars(), ad1.toChars(), rewrittenLhs.toChars());
+                return ErrorExp.get();
             }
             return null;
         }

--- a/test/fail_compilation/fail19441.d
+++ b/test/fail_compilation/fail19441.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail19441.d(44): Deprecation: Cannot use `alias this` to partially initialize variable `wrap[0]` of type `Wrap10595`. Use `wrap[0].i`
+fail_compilation/fail19441.d(44): Error: cannot use `alias this` to partially initialize variable `wrap[0]` of type `Wrap10595`. Use `wrap[0].i`
 ---
 */
 


### PR DESCRIPTION
This has been deprecated in 2.086, time move it on to be a permanent error.

The comments were wrong, we still need to check the RHS for `alias this` first.  If that succeeds with a match, then that takes precedence over the partially constructed LHS `alias this` rewrite.