### PR TITLE
[stable] C++ headers: Rename TOK::cdecl to TOK::cdecl_

### DIFF
--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -278,7 +278,7 @@ enum class TOK : unsigned char
 
     // C only extended keywords
     _import,
-    cdecl,
+    cdecl_,
     declspec,
     stdcall,
     attribute__,


### PR DESCRIPTION
As `cdecl` is an MSVC keyword, see https://docs.microsoft.com/en-us/cpp/cpp/keywords-cpp?view=msvc-170#microsoft-specific-c-keywords:

> The `__cdecl` keyword is available with no leading underscore.