### PR TITLE
dmd.mtype: Set an end date for the complex/imaginary deprecation process

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2630,6 +2630,10 @@ extern (C++) abstract class Type : ASTNode
             default:
                 assert(0);
             }
+            // @@@DEPRECATED_2.117@@@
+            // Deprecated in 2.097 - Can be made an error from 2.117.
+            // The deprecation period is longer than usual as `cfloat`,
+            // `cdouble`, and `creal` were quite widely used.
             if (t.iscomplex())
             {
                 deprecation(loc, "use of complex type `%s` is deprecated, use `std.complex.Complex!(%s)` instead",


### PR DESCRIPTION
Deprecation of all complex types became the default in 2.097.  Setting 2.117 as the last release before it is made into a hard error.