### PR TITLE
dmd.semantic3: Set an end date for the revert5710 deprecation process

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -377,6 +377,12 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
             // Reverts: https://issues.dlang.org/show_bug.cgi?id=5710
             // No compiler supports this, and there was never any spec for it.
+            // @@@DEPRECATED_2.116@@@
+            // Deprecated in 2.096, can be made an error in 2.116.
+            // The deprecation period is longer than usual as dual-context
+            // functions may be widely used by dmd-compiled projects.
+            // It also gives more time for the implementation of dual-context
+            // functions to be reworked as a frontend-only feature.
             if (funcdecl.isThis2)
             {
                 funcdecl.deprecation("function requires a dual-context, which is deprecated");


### PR DESCRIPTION
The support code for this feature is substantial, and will take quite some time to unpick, granted that its encompassed a few thousand lines of changes over a dozen or so PRs.

This sets an end date for deciding whether to fix or drop it for good.