### PR TITLE
Use SmallBuffer instead of manual malloc/free

### DIFF
--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -1261,16 +1261,15 @@ void OmfObj_dosseg()
 @trusted
 private void obj_comment(ubyte x, const(char)* string, size_t len)
 {
+    import dmd.common.string : SmallBuffer;
     char[128] buf = void;
+    auto sb = SmallBuffer!char(2 + len, buf[]);
+    char *library = sb.ptr;
 
-    char *library = (2 + len <= buf.sizeof) ? buf.ptr : cast(char *) malloc(2 + len);
-    assert(library);
     library[0] = 0;
     library[1] = x;
     memcpy(library + 2,string,len);
     objrecord(COMENT,library,cast(uint)(len + 2));
-    if (library != buf.ptr)
-        free(library);
 }
 
 /*******************************

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -2686,18 +2686,17 @@ void ElfObj_addrel(int seg, targ_size_t offset, uint type,
             relidx = SHN_RELDATA;
         else
         {
+            import dmd.common.string : SmallBuffer;
             // Get the section name, and make a copy because
             // elf_newsection() may reallocate the string buffer.
             char *section_name = cast(char *)GET_SECTION_NAME(secidx);
             size_t len = strlen(section_name) + 1;
             char[20] buf2 = void;
-            char *p = len <= buf2.sizeof ? &buf2[0] : cast(char *)malloc(len);
-            assert(p);
+            auto sb = SmallBuffer!char(len, buf2[]);
+            char *p = sb.ptr;
             memcpy(p, section_name, len);
 
             relidx = elf_newsection(I64 ? ".rela" : ".rel", p, I64 ? SHT_RELA : SHT_REL, 0);
-            if (p != &buf2[0])
-                free(p);
             segdata.SDrelidx = relidx;
             addSectionToComdat(relidx,seg);
         }

--- a/src/dmd/backend/gsroa.d
+++ b/src/dmd/backend/gsroa.d
@@ -353,14 +353,10 @@ if (1)
     else
         enum tmp_length = 6;
     SymInfo[tmp_length] tmp = void;
-    SymInfo* sip;
-    if (sia_length <= tmp.length / 3)
-        sip = tmp.ptr;
-    else
-    {
-        sip = cast(SymInfo *)malloc(3 * sia_length * SymInfo.sizeof);
-        assert(sip);
-    }
+
+    import dmd.common.string : SmallBuffer;
+    auto sb = SmallBuffer!(SymInfo)(3 * sia_length, tmp[]);
+    SymInfo* sip = sb.ptr;
     memset(sip, 0, 3 * sia_length * SymInfo.sizeof);
     SymInfo[] sia = sip[0 .. sia_length];
     SymInfo[] sia2 = sip[sia_length .. sia_length * 3];
@@ -428,12 +424,12 @@ if (1)
     }
 
     if (!anySlice)
-        goto Ldone;
+        return;
 
     foreach (b; BlockRange(startblock))
     {
         if (b.BC == BCasm)
-            goto Ldone;
+            return;
         if (b.Belem)
             sliceStructs_Gather(symtab, sia, b.Belem);
     }
@@ -494,7 +490,7 @@ if (1)
             }
         }
         if (!any)
-            goto Ldone;
+            return;
     }
 
     foreach (si; 0 .. symtab.length)
@@ -520,9 +516,6 @@ if (1)
         printf("after slicing done\n");
     }
 
-Ldone:
-    if (sip != tmp.ptr)
-        free(sip);
 }
 }
 

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5265,13 +5265,10 @@ elem *callfunc(const ref Loc loc,
             elem*[2] elems_array = void;
         else
             elem*[10] elems_array = void;
-        import core.stdc.stdlib : malloc, free;
-        auto pe = (n <= elems_array.length)
-                  ? elems_array.ptr
-                  : cast(elem**)Mem.check(malloc(arguments.dim * (elem*).sizeof));
-        elem*[] elems = pe[0 .. n];
-        scope (exit) if (elems.ptr != elems_array.ptr)
-            free(elems.ptr);
+
+        import dmd.common.string : SmallBuffer;
+        auto pe = SmallBuffer!(elem*)(n, elems_array[]);
+        elem*[] elems = pe[];
 
         /* Fill elems[] with arguments converted to elems
          */

--- a/src/dmd/root/speller.d
+++ b/src/dmd/root/speller.d
@@ -42,6 +42,7 @@ private:
 
 import core.stdc.stdlib;
 import core.stdc.string;
+import dmd.common.string : SmallBuffer;
 
 enum isSearchFunction(alias fun) = is(searchFunctionType!fun);
 alias searchFunctionType(alias fun) = typeof(() {int x; return fun("", x);}());
@@ -63,15 +64,8 @@ auto spellerX(alias dg)(const(char)[] seed, bool flag)
     /* Need buffer to store trial strings in
      */
     char[30] tmp = void;
-    char[] buf;
-    if (seed.length <= tmp.sizeof - 1)
-        buf = tmp;
-    else
-    {
-        buf = (cast(char*)alloca(seed.length + 1))[0 .. seed.length + 1]; // leave space for extra char
-        if (!buf.ptr)
-            return null; // no matches
-    }
+    auto sb = SmallBuffer!char(seed.length + 1, tmp[]);
+    char[] buf = sb[];
 
     int cost = int.max;
     searchFunctionType!dg p = null;
@@ -164,15 +158,8 @@ auto spellerY(alias dg)(const(char)[] seed, size_t index, out int cost)
      * space for an extra char for insertions
      */
     char[30] tmp = void;        // stack allocations are fastest
-    char[] buf;
-    if (seed.length <= tmp.sizeof - 1)
-        buf = tmp;
-    else
-    {
-        buf = (cast(char*)alloca(seed.length + 1))[0 .. seed.length + 1]; // leave space for extra char
-        if (!buf.ptr)
-            return null; // no matches
-    }
+    auto sb = SmallBuffer!char(seed.length + 1, tmp[]);
+    char[] buf = sb[];
     buf[0 .. index] = seed[0 .. index];
 
     cost = int.max;             // start with worst possible match

--- a/src/dmd/root/string.d
+++ b/src/dmd/root/string.d
@@ -69,17 +69,12 @@ The return value of `T`
 auto toCStringThen(alias dg)(const(char)[] src) nothrow
 {
     import dmd.root.rmem : mem;
+    import dmd.common.string : SmallBuffer;
 
     const len = src.length + 1;
     char[512] small = void;
-    scope ptr = (src.length < (small.length - 1))
-                    ? small[0 .. len]
-                    : (cast(char*)mem.xmalloc(len))[0 .. len];
-    scope (exit)
-    {
-        if (&ptr[0] != &small[0])
-            mem.xfree(&ptr[0]);
-    }
+    auto sb = SmallBuffer!char(len, small[]);
+    scope ptr = sb[];
     ptr[0 .. src.length] = src[];
     ptr[src.length] = '\0';
     return dg(ptr);

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1286,17 +1286,13 @@ private extern(C++) final class Semantic3Visitor : Visitor
         // Eliminate maybescope's
         {
             // Create and fill array[] with maybe candidates from the `this` and the parameters
-            VarDeclaration[] array = void;
-
             VarDeclaration[10] tmp = void;
             size_t dim = (funcdecl.vthis !is null) + (funcdecl.parameters ? funcdecl.parameters.dim : 0);
-            if (dim <= tmp.length)
-                array = tmp[0 .. dim];
-            else
-            {
-                auto ptr = cast(VarDeclaration*)mem.xmalloc(dim * VarDeclaration.sizeof);
-                array = ptr[0 .. dim];
-            }
+
+            import dmd.common.string : SmallBuffer;
+            auto sb = SmallBuffer!VarDeclaration(dim, tmp[]);
+            VarDeclaration[] array = sb[];
+
             size_t n = 0;
             if (funcdecl.vthis)
                 array[n++] = funcdecl.vthis;
@@ -1307,11 +1303,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     array[n++] = v;
                 }
             }
-
             eliminateMaybeScopes(array[0 .. n]);
-
-            if (dim > tmp.length)
-                mem.xfree(array.ptr);
         }
 
         // Infer STC.scope_

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -68,7 +68,7 @@ extern (C++):
 Symbol *toSymbolX(Dsymbol ds, const(char)* prefix, int sclass, type *t, const(char)* suffix)
 {
     //printf("Dsymbol::toSymbolX('%s')\n", prefix);
-    import core.stdc.stdlib : malloc, free;
+    import dmd.common.string : SmallBuffer;
     import dmd.common.outbuffer : OutBuffer;
 
     OutBuffer buf;
@@ -83,11 +83,8 @@ Symbol *toSymbolX(Dsymbol ds, const(char)* prefix, int sclass, type *t, const(ch
     size_t idlen = 2 + nlen + size_t.sizeof * 3 + prefixlen + suffixlen + 1;
 
     char[64] idbuf = void;
-    char *id = &idbuf[0];
-    if (idlen > idbuf.sizeof)
-    {
-        id = cast(char *)Mem.check(malloc(idlen));
-    }
+    auto sb = SmallBuffer!(char)(idlen, idbuf[]);
+    char *id = sb.ptr;
 
     int nwritten = sprintf(id,"_D%.*s%d%.*s%.*s",
         cast(int)nlen, n,
@@ -96,9 +93,6 @@ Symbol *toSymbolX(Dsymbol ds, const(char)* prefix, int sclass, type *t, const(ch
     assert(cast(uint)nwritten < idlen);         // nwritten does not include the terminating 0 char
 
     Symbol *s = symbol_name(id, nwritten, sclass, t);
-
-    if (id != &idbuf[0])
-        free(id);
 
     //printf("-Dsymbol::toSymbolX() %s\n", id);
     return s;

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -126,11 +126,10 @@ public:
     override void visit(TypeFunction t)
     {
         const nparams = t.parameterList.length;
+        import dmd.common.string : SmallBuffer;
         type*[10] tmp = void;
-        type** ptypes = (nparams <= tmp.length)
-                        ? tmp.ptr
-                        : cast(type**)Mem.check(malloc((type*).sizeof * nparams));
-        type*[] types = ptypes[0 .. nparams];
+        auto sb = SmallBuffer!(type*)(nparams, tmp[]);
+        type*[] types = sb[];
 
         foreach (i; 0 .. nparams)
         {
@@ -148,8 +147,6 @@ public:
             types[i] = tp;
         }
         t.ctype = type_function(totym(t), types, t.parameterList.varargs == VarArg.variadic, Type_toCtype(t.next));
-        if (types.ptr != tmp.ptr)
-            free(types.ptr);
     }
 
     override void visit(TypeDelegate t)


### PR DESCRIPTION
There's an allocation strategy of using stack memory for small array sizes, and malloc + free for larger array sizes. This is efficient, but not `@safe` and it results in ugly, error-prone code. I thought it was particularly ugly seeing it in the middle of the already humongous semantic3 visitor `visit(FuncDeclaration funcdecl)`.

I found that there's already a struct encapsulating this logic in dmd, `SmallBuffer` in dmd.common.string, so I replaced it with that. I've also found other instances of this pattern in other modules, so I replaced those as well.