### PR TITLE
fix Issue 21674 - [REG v2.086] 'alias this' triggers wrong deprecation message on function call

### DIFF
--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -880,19 +880,23 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                      * one of the members, hence the `ad1.fields.dim == 2 && ad1.vthis`
                      * condition.
                      */
-                    if (e.op != EXP.assign || e.e1.op == EXP.type)
-                        return;
+                    if (result.op != EXP.assign)
+                        return;     // i.e: Rewrote `e1 = e2` -> `e1(e2)`
 
-                    if (ad1.fields.dim == 1 || (ad1.fields.dim == 2 && ad1.vthis))
+                    auto ae = result.isAssignExp();
+                    if (ae.e1.op != EXP.dotVariable)
+                        return;     // i.e: Rewrote `e1 = e2` -> `e1() = e2`
+
+                    auto dve = ae.e1.isDotVarExp();
+                    if (auto ad = dve.var.isMember2())
                     {
-                        auto var = ad1.aliasthis.sym.isVarDeclaration();
-                        if (var && var.type == ad1.fields[0].type)
-                            return;
-
-                        auto func = ad1.aliasthis.sym.isFuncDeclaration();
-                        auto tf = cast(TypeFunction)(func.type);
-                        if (tf.isref && ad1.fields[0].type == tf.next)
-                            return;
+                        // i.e: Rewrote `e1 = e2` -> `e1.some.var = e2`
+                        // Ensure that `var` is the only field member in `ad`
+                        if (ad.fields.dim == 1 || (ad.fields.dim == 2 && ad.vthis))
+                        {
+                            if (dve.var == ad.aliasthis.sym)
+                                return;
+                        }
                     }
                     tempResult = result;
                 }

--- a/test/compilable/test21196.d
+++ b/test/compilable/test21196.d
@@ -1,0 +1,71 @@
+// https://issues.dlang.org/show_bug.cgi?id=21674
+// REQUIRED_ARGS: -de
+
+struct Module
+{
+    CachedString data;
+}
+
+struct CachedString
+{
+    private size_t len;
+
+    this (string data) { this.len = data.length; }
+    public string str () const { return null; }
+    public void str (string value) { this.len = value.length; }
+
+    alias str this;
+}
+
+void test21674a()
+{
+    Module m;
+    m.data = "Hello World";
+}
+
+//////////////////////////////////////////
+
+struct StaticGetter(T)
+{
+    private static T _impl;
+    static ref T value() { return _impl; }
+    alias value this;
+}
+
+struct StaticWrapper
+{
+    StaticGetter!int get;
+    alias get this;
+}
+
+void test21674b()
+{
+    StaticGetter!float sg;
+    sg = 4.2;
+
+    StaticWrapper sw;
+    sw = 42;
+}
+
+//////////////////////////////////////////
+
+EntryType arr;
+auto getPtr() { return &arr; }
+
+struct EntryType
+{
+    bool _state;
+    alias _state this;
+}
+
+struct S19441
+{
+    @property auto ref entry() { return *getPtr(); }
+    alias entry this;
+}
+
+void test19441()
+{
+    S19441 s19441;
+    s19441 = true;
+}


### PR DESCRIPTION
Tested on master in #13673 with no pipeline regressions.  The deprecation period can end after the stable->master merge.