### PR TITLE
test/runnable/test22342.c: Use counter to verify that side-effects are executed

### DIFF
--- a/test/runnable/test22342.c
+++ b/test/runnable/test22342.c
@@ -1,29 +1,28 @@
-/* RUN_OUTPUT:
----
-B
-A
-B
----
- */
-
 // https://issues.dlang.org/show_bug.cgi?id=22342
 
 int printf(const char *, ...);
+int counter = 0;
 
 int foo()
 {
-  printf("A\n");
-  return 0;
+    counter += 1;
+    return counter;
 }
 
 int bar()
 {
-  printf("B\n");
-  return 0;
+    counter += 2;
+    return counter;
 }
 
 int main()
 {
-  int v;
-  return bar(1, &v, foo(), "str", bar());
+    int v;
+    int res = bar(1, &v, foo(), "str", bar());
+    if (res != 5)
+    {
+        printf("bar() = %d != 5\n", res);
+        return 1;
+    }
+    return 0;
 }


### PR DESCRIPTION
The use of RUN_OUTPUT relied on undefined behaviour - see https://github.com/dlang/dmd/pull/13132#discussion_r808606851