### PR TITLE
test: Add missing EXTRA_FILES directives

### DIFF
--- a/test/compilable/test22625.d
+++ b/test/compilable/test22625.d
@@ -1,3 +1,4 @@
 // https://issues.dlang.org/show_bug.cgi?id=22625
+// EXTRA_FILES: imports/imp22625.c
 
 import imports.imp22625 : S, T;

--- a/test/compilable/test22665.d
+++ b/test/compilable/test22665.d
@@ -1,4 +1,4 @@
-// EXTRA_FILES: imports/imp22665.d
+// EXTRA_FILES: imports/imp22665.c
 
 // https://issues.dlang.org/show_bug.cgi?id=22665
 

--- a/test/compilable/test22685.d
+++ b/test/compilable/test22685.d
@@ -1,3 +1,5 @@
+// EXTRA_FILES: imports/test22685b.d imports/test22685c.d
+
 module test22685;
 
 import imports.test22685b;

--- a/test/compilable/test22734.d
+++ b/test/compilable/test22734.d
@@ -1,4 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=22734
+// EXTRA_FILES: imports/imp22734.c
 
 import imports.imp22734;
 

--- a/test/runnable/fix22624.d
+++ b/test/runnable/fix22624.d
@@ -1,4 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=22624
+// EXTRA_FILES: imports/imp22624.c
 
 import core.stdc.stdio;
 import imports.imp22624;


### PR DESCRIPTION
Fixes testsuite run for gdc.