### PR TITLE
fix Issue 22788 - [REG master] Expression header out of sync

### DIFF
--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -234,7 +234,10 @@ public:
     FuncInitExp* isFuncInitExp();
     PrettyFuncInitExp* isPrettyFuncInitExp();
     ClassReferenceExp* isClassReferenceExp();
-    virtual BinAssignExp* isBinAssignExp();
+    ThrownExceptionExp* isThrownExceptionExp();
+    UnaExp* isUnaExp();
+    BinExp* isBinExp();
+    BinAssignExp* isBinAssignExp();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -714,7 +717,6 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *ex);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
-    BinAssignExp* isBinAssignExp();
     void accept(Visitor *v) { v->visit(this); }
 };
 


### PR DESCRIPTION
Fixes silent corruption in gdc bootstrap.