### PR TITLE
Deduplicate StringExp.charAt and getCodeUnit functions

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -827,9 +827,9 @@ UnionExp Equal(EXP op, const ref Loc loc, Type type, Expression e1, Expression e
         else
         {
             cmp = 1; // if dim1 winds up being 0
-            for (size_t i = 0; i < dim1; i++)
+            foreach (i; 0 .. dim1)
             {
-                uinteger_t c = es1.charAt(i);
+                uinteger_t c = es1.getCodeUnit(i);
                 auto ee2 = es2[i];
                 if (ee2.isConst() != 1)
                 {
@@ -1247,7 +1247,7 @@ UnionExp Index(Type type, Expression e1, Expression e2)
         }
         else
         {
-            emplaceExp!(IntegerExp)(&ue, loc, es1.charAt(i), type);
+            emplaceExp!(IntegerExp)(&ue, loc, es1.getCodeUnit(cast(size_t) i), type);
         }
     }
     else if (e1.type.toBasetype().ty == Tsarray && e2.op == EXP.int64)

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -1565,7 +1565,7 @@ Expression ctfeIndex(UnionExp* pue, const ref Loc loc, Type type, Expression e1,
             error(loc, "string index %llu is out of bounds `[0 .. %llu]`", indx, cast(ulong)es1.len);
             return CTFEExp.cantexp;
         }
-        emplaceExp!IntegerExp(pue, loc, es1.charAt(indx), type);
+        emplaceExp!IntegerExp(pue, loc, es1.getCodeUnit(cast(size_t) indx), type);
         return pue.exp();
     }
 

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -2547,7 +2547,7 @@ public:
 
         foreach (i; 0 .. e.len)
         {
-            writeCharLiteral(*buf, e.charAt(i));
+            writeCharLiteral(*buf, e.getCodeUnit(i));
         }
         buf.writeByte('"');
     }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2726,27 +2726,10 @@ extern (C++) final class StringExp : Expression
         return ErrorExp.get();
     }
 
+    // Superseded by getCodeUnit
     uint charAt(uinteger_t i) const
     {
-        uint value;
-        switch (sz)
-        {
-        case 1:
-            value = (cast(char*)string)[cast(size_t)i];
-            break;
-
-        case 2:
-            value = (cast(ushort*)string)[cast(size_t)i];
-            break;
-
-        case 4:
-            value = (cast(uint*)string)[cast(size_t)i];
-            break;
-
-        default:
-            assert(0);
-        }
-        return value;
+        return getCodeUnit(cast(size_t) i);
     }
 
     /********************************

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2726,12 +2726,6 @@ extern (C++) final class StringExp : Expression
         return ErrorExp.get();
     }
 
-    // Superseded by getCodeUnit
-    uint charAt(uinteger_t i) const
-    {
-        return getCodeUnit(cast(size_t) i);
-    }
-
     /********************************
      * Convert string contents to a 0 terminated string,
      * allocated by mem.xmalloc().

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -377,13 +377,14 @@ public:
     static StringExp *create(const Loc &loc, const void *s, size_t len);
     static void emplace(UnionExp *pue, const Loc &loc, const char *s);
     bool equals(const RootObject *o) const;
+    char32_t getCodeUnit(size_t i) const;
+    void setCodeUnit(size_t i, char32_t c);
     StringExp *toStringExp();
     StringExp *toUTF8(Scope *sc);
     Optional<bool> toBool();
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
-    unsigned charAt(uinteger_t i) const;
     void accept(Visitor *v) { v->visit(this); }
     size_t numberOfCodeUnits(int tynto = 0) const;
     void writeTo(void* dest, bool zero, int tyto = 0) const;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6773,7 +6773,6 @@ public:
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
     Expression* modifiableLvalue(Scope* sc, Expression* e);
-    uint32_t charAt(uinteger_t i) const;
     void accept(Visitor* v);
 };
 

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1986,7 +1986,7 @@ public:
         const o = buf.length;
         foreach (i; 0 .. e.len)
         {
-            writeCharLiteral(*buf, e.charAt(i));
+            writeCharLiteral(*buf, e.getCodeUnit(i));
         }
         if (hgs.ddoc)
             escapeDdocString(buf, o);


### PR DESCRIPTION
getCodeUnit was added in https://github.com/dlang/dmd/pull/5427 to encapsulate code unit access, but there already was a function for this: `charAt`. Here I keep the newer one, since it's better named and documented.