### PR TITLE
dmd.toobj: Move the toObjFile call in genTypeInfo to DMD gluelayer

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5946,7 +5946,7 @@ elem *sarray_toDarray(const ref Loc loc, Type tfrom, Type tto, elem *e)
 elem *getTypeInfo(Loc loc, Type t, IRState *irs)
 {
     assert(t.ty != Terror);
-    genTypeInfo(loc, t, null);
+    genTypeInfoForType(loc, t);
     elem *e = el_ptr(toSymbol(t.vtinfo));
     return e;
 }

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -640,7 +640,7 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
     {
         if (Type t = isType(e.obj))
         {
-            genTypeInfo(e.loc, t, null);
+            genTypeInfoForType(e.loc, t);
             Symbol *s = toSymbol(t.vtinfo);
             dtb.xoff(s, 0);
             return;
@@ -1170,7 +1170,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             dtb.size(0);                                  // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
-        genTypeInfo(d.loc, tm, null);
+        genTypeInfoForType(d.loc, tm);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1184,7 +1184,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             dtb.size(0);                                      // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
-        genTypeInfo(d.loc, tm, null);
+        genTypeInfoForType(d.loc, tm);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1198,7 +1198,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             dtb.size(0);                                 // monitor
         Type tm = d.tinfo.unSharedOf();
         tm = tm.merge();
-        genTypeInfo(d.loc, tm, null);
+        genTypeInfoForType(d.loc, tm);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1212,7 +1212,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             dtb.size(0);                              // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
-        genTypeInfo(d.loc, tm, null);
+        genTypeInfoForType(d.loc, tm);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1239,7 +1239,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         // TypeInfo for enum members
         if (sd.memtype)
         {
-            genTypeInfo(d.loc, sd.memtype, null);
+            genTypeInfoForType(d.loc, sd.memtype);
             dtb.xoff(toSymbol(sd.memtype.vtinfo), 0);
         }
         else
@@ -1279,7 +1279,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypePointer();
 
-        genTypeInfo(d.loc, tc.next, null);
+        genTypeInfoForType(d.loc, tc.next);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0); // TypeInfo for type being pointed to
     }
 
@@ -1294,7 +1294,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeDArray();
 
-        genTypeInfo(d.loc, tc.next, null);
+        genTypeInfoForType(d.loc, tc.next);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0); // TypeInfo for array of type
     }
 
@@ -1309,7 +1309,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeSArray();
 
-        genTypeInfo(d.loc, tc.next, null);
+        genTypeInfoForType(d.loc, tc.next);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0);   // TypeInfo for array of type
 
         dtb.size(tc.dim.toInteger());          // length
@@ -1326,7 +1326,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeVector();
 
-        genTypeInfo(d.loc, tc.basetype, null);
+        genTypeInfoForType(d.loc, tc.basetype);
         dtb.xoff(toSymbol(tc.basetype.vtinfo), 0); // TypeInfo for equivalent static array
     }
 
@@ -1341,10 +1341,10 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeAArray();
 
-        genTypeInfo(d.loc, tc.next, null);
+        genTypeInfoForType(d.loc, tc.next);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0);   // TypeInfo for array of type
 
-        genTypeInfo(d.loc, tc.index, null);
+        genTypeInfoForType(d.loc, tc.index);
         dtb.xoff(toSymbol(tc.index.vtinfo), 0);  // TypeInfo for array of type
     }
 
@@ -1359,7 +1359,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeFunction();
 
-        genTypeInfo(d.loc, tc.next, null);
+        genTypeInfoForType(d.loc, tc.next);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0); // TypeInfo for function return value
 
         const name = d.tinfo.deco;
@@ -1383,7 +1383,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeDelegate();
 
-        genTypeInfo(d.loc, tc.next.nextOf(), null);
+        genTypeInfoForType(d.loc, tc.next.nextOf());
         dtb.xoff(toSymbol(tc.next.nextOf().vtinfo), 0); // TypeInfo for delegate return value
 
         const name = d.tinfo.deco;
@@ -1538,7 +1538,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
                 // m_argi
                 if (auto t = sd.argType(i))
                 {
-                    genTypeInfo(d.loc, t, null);
+                    genTypeInfoForType(d.loc, t);
                     dtb.xoff(toSymbol(t.vtinfo), 0);
                 }
                 else
@@ -1600,7 +1600,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         auto dtbargs = DtBuilder(0);
         foreach (arg; *tu.arguments)
         {
-            genTypeInfo(d.loc, arg.type, null);
+            genTypeInfoForType(d.loc, arg.type);
             Symbol* s = toSymbol(arg.type.vtinfo);
             dtbargs.xoff(s, 0);
         }

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -385,7 +385,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
             // Put out the TypeInfo
             if (gentypeinfo)
-                genTypeInfo(cd.loc, cd.type, null);
+                genTypeInfoForType(cd.loc, cd.type);
             //toObjFile(cd.type.vtinfo, multiobj);
 
             if (genclassinfo)
@@ -463,7 +463,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             // Put out the TypeInfo
             if (global.params.useTypeInfo && Type.dtypeinfo)
             {
-                genTypeInfo(id.loc, id.type, null);
+                genTypeInfoForType(id.loc, id.type);
                 id.type.vtinfo.accept(this);
             }
 
@@ -498,7 +498,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                     toDebug(sd);
 
                 if (global.params.useTypeInfo && Type.dtypeinfo)
-                    genTypeInfo(sd.loc, sd.type, null);
+                    genTypeInfoForType(sd.loc, sd.type);
 
                 // Generate static initializer
                 auto sinit = toInitializer(sd);
@@ -675,7 +675,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 toDebug(ed);
 
             if (global.params.useTypeInfo && Type.dtypeinfo)
-                genTypeInfo(ed.loc, ed.type, null);
+                genTypeInfoForType(ed.loc, ed.type);
 
             TypeEnum tc = cast(TypeEnum)ed.type;
             if (!tc.sym.members || ed.type.isZeroInit(Loc.initial))
@@ -1166,6 +1166,18 @@ private size_t emitVtbl(ref DtBuilder dtb, BaseClass *b, ref FuncDeclarations bv
     return id_vtbl_dim * target.ptrsize;
 }
 
+
+/**
+ * Generate the TypeInfo for a type, and write it to the object file
+ * Params:
+ *      loc = the location for reporting line numbers in errors
+ *      type = the type to generate `TypeInfo` for
+ */
+void genTypeInfoForType(const ref Loc loc, Type type)
+{
+    if (auto tinfo = genTypeInfo(loc, type))
+        toObjFile(tinfo, global.params.multiobj);
+}
 
 /******************************************************
  * Generate the ClassInfo for a Class (__classZ) symbol.


### PR DESCRIPTION
Almost all code in typinf.d is common front-end semantic logic for all compilers, with exception to the `toObjFile()` call into DMD's gluelayer.

This moves that call to a new helper function `genTypeInfoForType` in the dmd-specific toobj.d module.

With this, GDC no longer needs to patch any DMD front-end sources in order for it to work with the GCC glue.