### PR TITLE
Fix issue 20881, 22790 - make ref-return-scope consistent

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1282,6 +1282,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 if (funcdecl.type == f)
                     f = cast(TypeFunction)f.copy();
                 f.isreturn = true;
+                f.isreturnscope = cast(bool) (funcdecl.storage_class & STC.returnScope);
                 if (funcdecl.storage_class & STC.returninferred)
                     f.isreturninferred = true;
             }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1504,16 +1504,6 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
                 /* Scope attribute is not necessary if the parameter type does not have pointers
                  */
-                /* Constructors are treated as if they are being returned through the hidden parameter,
-                 * which is by ref, and the ref there is ignored.
-                 */
-                const returnByRef = tf.isref && !tf.isctor;
-                if (!returnByRef && isRefReturnScope(fparam.storageClass))
-                {
-                    /* if `ref return scope`, evaluate to `ref` `return scope`
-                     */
-                    fparam.storageClass |= STC.returnScope;
-                }
                 const sr = buildScopeRef(fparam.storageClass);
                 switch (sr)
                 {
@@ -1532,17 +1522,6 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
                     default:
                         break;
-                }
-
-                /* now set STC.returnScope based only on tf.isref. This is inconsistent, as mentioned above,
-                 * but necessary for compatibility for now.
-                 */
-                fparam.storageClass &= ~STC.returnScope;
-                if (!tf.isref && isRefReturnScope(fparam.storageClass))
-                {
-                    /* if `ref return scope`, evaluate to `ref` `return scope`
-                     */
-                    fparam.storageClass |= STC.returnScope;
                 }
 
                 // Remove redundant storage classes for type, they are already applied

--- a/test/compilable/scope.d
+++ b/test/compilable/scope.d
@@ -142,7 +142,7 @@ int f1_20682(return scope ref D d) @safe
     return d.pos;
 }
 
-ref int f2_20682(return scope ref D d) @safe
+ref int f2_20682(return ref scope D d) @safe
 {
     return d.pos;
 }

--- a/test/fail_compilation/pull12941.d
+++ b/test/fail_compilation/pull12941.d
@@ -1,9 +1,9 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/pull12941.d(110): Error: `pull12941.foo` called with argument types `(int*)` matches both:
-fail_compilation/pull12941.d(101):     `pull12941.foo(ref return scope int* p)`
+fail_compilation/pull12941.d(101):     `pull12941.foo(return ref scope int* p)`
 and:
-fail_compilation/pull12941.d(102):     `pull12941.foo(out return scope int* p)`
+fail_compilation/pull12941.d(102):     `pull12941.foo(return out scope int* p)`
 fail_compilation/pull12941.d(111): Error: function `pull12941.bar(return scope int* p)` is not callable using argument types `(int)`
 fail_compilation/pull12941.d(111):        cannot pass argument `1` of type `int` to parameter `return scope int* p`
 fail_compilation/pull12941.d(112): Error: function `pull12941.abc(return ref int* p)` is not callable using argument types `(int)`

--- a/test/fail_compilation/retscope2.d
+++ b/test/fail_compilation/retscope2.d
@@ -130,7 +130,7 @@ fail_compilation/retscope2.d(721): Error: returning `s.get1()` escapes a referen
 
 struct S700
 {
-    @safe S700* get1() return scope
+    @safe S700* get1() scope return
     {
         return &this;
     }

--- a/test/fail_compilation/test15191.d
+++ b/test/fail_compilation/test15191.d
@@ -56,7 +56,7 @@ int* addrOfRefGlobal()
 }
 
 // Slice:
-ref int*[1] identityArr(ref return scope int*[1] x)
+ref int*[1] identityArr(return ref scope int*[1] x)
 {
 	return x;
 }

--- a/test/fail_compilation/test17422.d
+++ b/test/fail_compilation/test17422.d
@@ -7,7 +7,7 @@ fail_compilation/test17422.d(23): Error: scope variable `p` may not be returned
 */
 struct RC
 {
-    Object get() return scope @trusted
+    Object get() return @trusted
     {
         return cast(Object) &store[0];
     }

--- a/test/fail_compilation/test20881.d
+++ b/test/fail_compilation/test20881.d
@@ -1,0 +1,30 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test20881.d(27): Error: address of variable `s` assigned to `global` with longer lifetime
+fail_compilation/test20881.d(28): Error: address of variable `s` assigned to `global` with longer lifetime
+fail_compilation/test20881.d(29): Error: address of variable `s` assigned to `global` with longer lifetime
+---
+*/
+@safe:
+
+// https://issues.dlang.org/show_bug.cgi?id=20881
+
+struct S
+{
+    int* ptr;
+
+    auto borrowA() return /*scope inferred*/ { return ptr; }
+    int* borrowB() return { return ptr; }
+    int* borrowC() scope return { return ptr; }
+}
+
+void main()
+{
+    static int* global;
+    S s;
+    global = s.borrowA;
+    global = s.borrowB;
+    global = s.borrowC;
+}

--- a/test/fail_compilation/test21912.d
+++ b/test/fail_compilation/test21912.d
@@ -32,12 +32,12 @@ Dg escapeAssign(int i, return scope Dg dg)
     return dg;
 }
 
-ref Dg identityR(ref return scope Dg dg)
+ref Dg identityR(return ref scope Dg dg)
 {
     return dg;
 }
 
-ref Dg escapeAssignRef(int i, ref return scope Dg dg)
+ref Dg escapeAssignRef(int i, return ref scope Dg dg)
 {
     dg = () => i;
     return dg;


### PR DESCRIPTION
I'm working on the same issue as Walter: https://github.com/dlang/dmd/pull/13691

It's not finished, Phobos doesn't compile because sometimes methods such as `std.typecons.Tuple.opBinary!"~"` are inferred `return ref` when they should be `return scope`, which I'm still debugging. I'm already opening this to show @WalterBright the parts of the code I think need to be changed to properly fix [issue 22790](https://issues.dlang.org/show_bug.cgi?id=22790).