### PR TITLE
add test case for scoping error with opApply

### DIFF
--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1549,7 +1549,8 @@ bool inferForeachAggregate(Scope* sc, bool isForeach, ref Expression feaggr, out
  * Params:
  *      fes = the foreach statement
  *      sc = context
- *      sapply = null or opApply or delegate
+ *      sapply = null or opApply or delegate, overload resolution has not been done.
+ *               Do overload resolution on sapply.
  * Returns:
  *      false for errors
  */
@@ -1585,8 +1586,7 @@ bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbol sapply)
          */
         if (FuncDeclaration fd = sapply.isFuncDeclaration())
         {
-            auto fdapply = findBestOpApplyMatch(ethis, fd, fes.parameters);
-            if (fdapply)
+            if (auto fdapply = findBestOpApplyMatch(ethis, fd, fes.parameters))
             {
                 // Fill in any missing types on foreach parameters[]
                 matchParamsToOpApply(fdapply.type.isTypeFunction(), fes.parameters, true);
@@ -1595,7 +1595,7 @@ bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbol sapply)
             }
             return false;
         }
-        return sapply !is null;
+        return true;   // shouldn't this be false?
     }
 
     Parameter p = (*fes.parameters)[0];

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -866,7 +866,6 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                             assert(t.ty == Tdelegate);
                             tfld = cast(TypeFunction)t.nextOf();
                         }
-                        //printf("tfld = %s\n", tfld.toChars());
                     }
                 }
             }

--- a/test/fail_compilation/opapplyscope.d
+++ b/test/fail_compilation/opapplyscope.d
@@ -1,0 +1,27 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/opapplyscope.d(113): Error: function `opapplyscope.S.opApply(scope int delegate(scope int* ptr) @safe dg)` is not callable using argument types `(int delegate(int* x) nothrow @nogc @safe)`
+fail_compilation/opapplyscope.d(113):        cannot pass argument `__foreachbody3` of type `int delegate(int* x) nothrow @nogc @safe` to parameter `scope int delegate(scope int* ptr) @safe dg`
+---
+ */
+
+#line 100
+
+struct S
+{
+    int opApply(scope int delegate (scope int* ptr) @safe dg) @safe
+    {
+        return 0;
+    }
+}
+
+void test() @safe
+{
+    static int* global;
+    S s;
+    foreach (/*scope*/ int* x; s)
+    {
+        global = x;
+    }
+}
+


### PR DESCRIPTION
This adds an important test case.

Changed the return expression to what it always is as sapply is never null. Whether it should be false or not is an issue for another day.