### PR TITLE
fix Issue 22810 - [REG 2.088] FAIL: runnable/test15.d on BigEndian targets

### DIFF
--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -1425,7 +1425,7 @@ void test19758()
     int[2] array = [16, 678];
     union U { int i; bool b; }
     U u;
-    u.i = 0xDEADBEEF;
+    u.i = 0xBFBFBFBF;
     assert(array[u.b] == 678);
 }
 


### PR DESCRIPTION
Use a value that is friendly for both endians.
```
0xBF_BF_BF_BF
   ^(BE)    ^(LE)
```