### PR TITLE
fix Issue 22816 - [REG 2.099] Parser reads files with other extensions

### DIFF
--- a/src/dmd/file_manager.d
+++ b/src/dmd/file_manager.d
@@ -185,11 +185,7 @@ nothrow:
         if (res == 1)
             return readToFileBuffer(name);
 
-        const fullName = lookForSourceFile(name, global.path ? (*global.path)[] : null);
-        if (!fullName)
-            return null;
-
-        return readToFileBuffer(fullName);
+        return null;
     }
 
     extern(C++) FileBuffer* lookup(const(char)* filename)


### PR DESCRIPTION
I can't see any rationale for this looking up filenames with different extensions.  Either `Module.read` or the driver already ensures that the filename already has an inferred extension for all file arguments from the command-line.

All other uses of `FileManager.lookup` in `dmd.error` and `dmd.expressionsem` will also either have a file extension or have been checked that it exists on disk before calling.

No idea how to test this - I guess using dshell?  It's important not to delay getting this in though, as it should _not_ hit a release.