### PR TITLE
fix(dub): Make config.d executable to incremental compilation

### DIFF
--- a/config.d
+++ b/config.d
@@ -1,7 +1,8 @@
+#!/usr/bin/env dub
 /+
 dub.sdl:
     name "config"
-    targetPath "generated/dub"
+    targetPath "generated/dub-gen"
 +/
 /**
 Generates the compiler version, the version printed with `dmd --version`.


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Before:
```
Running pre-generate commands for dmd:lexer...
parsePackageRecipe dub.sdl
Performing "debug" build using /usr/bin/dmd for x86_64.
config ~master: building configuration "application"...
Linking...
Running generated/dub/config /home/luis/Workspace/Programming/Repos/temp/dmdlint/dmd/generated/dub /home/luis/Workspace/Programming/Repos/temp/dmdlint/dmd/VERSION /etc
Performing "debug" build using /usr/bin/dmd for x86_64.
dmd:root ~master: target for configuration "library" is up to date.
dmd:lexer ~master: building configuration "library"...
dmd:parser ~master: building configuration "library"...
dmd:frontend ~master: building configuration "library"...
```

After:
```
Running pre-generate commands for dmd:lexer...
Performing "debug" build using /usr/bin/dmd for x86_64.
dmd:root ~master: target for configuration "library" is up to date.
dmd:lexer ~master: target for configuration "library" is up to date.
dmd:parser ~master: target for configuration "library" is up to date.
dmd:frontend ~master: target for configuration "library" is up to date.
```