### PR TITLE
fix Issue 22818 - typesafe variadic function parameter of type class …

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -468,7 +468,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     {
                         stc |= STC.variadic;
                         auto vtypeb = vtype.toBasetype();
-                        if (vtypeb.ty == Tarray)
+                        if (vtypeb.ty == Tarray || vtypeb.ty == Tclass)
                         {
                             /* Since it'll be pointing into the stack for the array
                              * contents, it needs to be `scope`

--- a/test/fail_compilation/test22818.d
+++ b/test/fail_compilation/test22818.d
@@ -1,0 +1,21 @@
+/* REQUIRED_ARGS: -preview=dip1000
+ * TEST_OUTPUT:
+---
+fail_compilation/test22818.d(104): Error: scope variable `c` may not be returned
+---
+*/
+
+// issues.dlang.org/show_bug.cgi?id=22818
+
+#line 100
+
+@safe:
+ref int g(C c ...)
+{
+    return c.x;
+}
+
+class C
+{
+    int x;
+}


### PR DESCRIPTION
…should be scope

I like one line fixes.