### PR TITLE
dmd.root.file: Comment out debug messages in File.read

### DIFF
--- a/src/dmd/root/file.d
+++ b/src/dmd/root/file.d
@@ -97,13 +97,13 @@ nothrow:
             int fd = name.toCStringThen!(slice => open(slice.ptr, O_RDONLY));
             if (fd == -1)
             {
-                //printf("\topen error, errno = %d\n",errno);
+                //perror("\topen error");
                 return result;
             }
             //printf("\tfile opened\n");
             if (fstat(fd, &buf))
             {
-                perror("\tfstat error");
+                //perror("\tfstat error");
                 close(fd);
                 return result;
             }
@@ -112,12 +112,12 @@ nothrow:
             numread = .read(fd, buffer, size);
             if (numread != size)
             {
-                perror("\tread error");
+                //perror("\tread error");
                 goto err2;
             }
             if (close(fd) == -1)
             {
-                perror("\tclose error");
+                //perror("\tclose error");
                 goto err;
             }
             // Always store a wchar ^Z past end of buffer so scanner has a


### PR DESCRIPTION
These aren't part of the usual compiler diagnostics.  Though it might be a good idea to store `errno` in `ReadResult` to propagate the underlying cause of read errors as a future enhancement.