### PR TITLE
fix Issue 22823 - dmd.root.file: File.read fails to read any file on PPC

### DIFF
--- a/src/dmd/root/file.d
+++ b/src/dmd/root/file.d
@@ -289,3 +289,35 @@ nothrow:
     }
 }
 
+private
+{
+    version (linux) version (PPC)
+    {
+        // https://issues.dlang.org/show_bug.cgi?id=22823
+        // Define our own version of stat_t, as older versions of the compiler
+        // had the st_size field at the wrong offset on PPC.
+        alias stat_t_imported = core.sys.posix.sys.stat.stat_t;
+        static if (stat_t_imported.st_size.offsetof != 48)
+        {
+            extern (C) nothrow @nogc:
+            struct stat_t
+            {
+                ulong[6] __pad1;
+                ulong st_size;
+                ulong[6] __pad2;
+            }
+            version (CRuntime_Glibc)
+            {
+                int fstat64(int, stat_t*) @trusted;
+                alias fstat = fstat64;
+                int stat64(const scope char*, stat_t*) @system;
+                alias stat = stat64;
+            }
+            else
+            {
+                int fstat(int, stat_t*) @trusted;
+                int stat(const scope char*, stat_t*) @system;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The druntime fix is dlang/druntime#3762, but older releases of the compiler can't be used to bootstrap as-is.  This provides a stub definition of `stat_t` which fixes the read routines for calling stat to get file sizes correct.

`stat_t` is also used by `dmd.lib`, and `dmd.common.file`.  But both `FileMapper` and `Library` are only used by the dmd backend.

~Note, am using `__VERSION__ < 2099` here, as gdc is making the jump from 2.076 (C++) to 2.099 (D).  For ldc, which switched to being self hosted a long while before, retroactively fixing self-hosted PPC will be more difficult.~

Edit: switched to `stat_t_imported.st_size.offsetof != 48`.  Also fixed the `stat()` and `fstat()` definitions to be friendly towards CRuntimes that aren't glibc.

FYI @kinke.