### PR TITLE
fix Issue 21008 - dmd segfaults because of __traits(getMember, ...) a…

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3551,6 +3551,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             default:
                 {
+                    if (vi >= cd.vtbl.length)
+                    {
+                        /* the derived class cd doesn't have its vtbl[] allocated yet.
+                         * https://issues.dlang.org/show_bug.cgi?id=21008
+                         */
+                        funcdecl.error("circular reference to class `%s`", cd.toChars());
+                        funcdecl.errors = true;
+                        return;
+                    }
                     FuncDeclaration fdv = cd.baseClass.vtbl[vi].isFuncDeclaration();
                     FuncDeclaration fdc = cd.vtbl[vi].isFuncDeclaration();
                     // This function is covariant with fdv

--- a/test/fail_compilation/test21008.d
+++ b/test/fail_compilation/test21008.d
@@ -1,0 +1,41 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test21008.d(110): Error: function `test21008.C.after` circular reference to class `C`
+fail_compilation/test21008.d(117): Error: need `this` for `toString` of type `string()`
+fail_compilation/test21008.d(117): Error: need `this` for `toHash` of type `nothrow @trusted $?:32=uint|64=ulong$()`
+fail_compilation/test21008.d(117): Error: function `object.Object.opCmp(Object o)` is not callable using argument types `()`
+fail_compilation/test21008.d(117):        missing argument for parameter #1: `Object o`
+fail_compilation/test21008.d(117): Error: function `object.Object.opEquals(Object o)` is not callable using argument types `()`
+fail_compilation/test21008.d(117):        missing argument for parameter #1: `Object o`
+fail_compilation/test21008.d(117): Error: `Monitor` has no effect
+fail_compilation/test21008.d(117): Error: function `object.Object.factory(string classname)` is not callable using argument types `()`
+fail_compilation/test21008.d(117):        missing argument for parameter #1: `string classname`
+fail_compilation/test21008.d(105):        called from here: `handleMiddlewareAnnotation()`
+fail_compilation/test21008.d(108): Error: class `test21008.C` no size because of forward reference
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=21008
+
+#line 100
+
+class Base
+{
+    bool after();
+
+    mixin(handleMiddlewareAnnotation);
+}
+
+class C : Base
+{
+    override bool after();
+}
+
+string handleMiddlewareAnnotation()
+{
+    foreach (member; __traits(allMembers, C))
+    {
+        __traits(getMember, C, member);
+    }
+}


### PR DESCRIPTION
…nd virtual function overriding

An old bug, so doesn't need to go into stable.