### PR TITLE
Issue 22827 - Deprecate 128-bit cent and ucent types

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -666,9 +666,13 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
     Type visitType(Type t)
     {
+        // @@@DEPRECATED_2.110@@@
+        // Use of `cent` and `ucent` has always been an error.
+        // Starting from 2.100, recommend core.int128 as a replace for the
+        // lack of compiler support.
         if (t.ty == Tint128 || t.ty == Tuns128)
         {
-            .error(loc, "`cent` and `ucent` types not implemented");
+            .error(loc, "`cent` and `ucent` types are obsolete, use `core.int128.Cent` instead");
             return error();
         }
 

--- a/test/fail_compilation/fail22827.d
+++ b/test/fail_compilation/fail22827.d
@@ -1,0 +1,9 @@
+// https://issues.dlang.org/show_bug.cgi?id=22827
+/* TEST_OUTPUT:
+---
+fail_compilation/fail22827.d(8): Error: `cent` and `ucent` types are obsolete, use `core.int128.Cent` instead
+fail_compilation/fail22827.d(9): Error: `cent` and `ucent` types are obsolete, use `core.int128.Cent` instead
+---
+*/
+cent i22827;
+ucent j22827;


### PR DESCRIPTION
Pave the way for making an exit for these types in the compiler.

After removal both can be moved to be aliases in the object module.

Actually issuing a deprecation message in the parser would break everyone, and keeping the error in the semantic makes it consistent with the deprecation->error path for complex numbers.