### PR TITLE
Fix issue 22828: dcast: use an implicit cast instead of explicit

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2740,11 +2740,15 @@ Expression scaleFactor(BinExp be, Scope* sc)
     {
         // Need to adjust operator by the stride
         // Replace (ptr + int) with (ptr + (int * stride))
-        Type t = Type.tptrdiff_t;
+        Type t = Type.tsize_t;
 
         d_uns64 stride = t1b.nextOf().size(be.loc);
         if (!t.equals(t2b))
-            be.e2 = be.e2.castTo(sc, t);
+        {
+            be.e2 = be.e2.implicitCastTo(sc, t);
+            if (be.e2.type == Type.terror)
+                return ErrorExp.get();
+        }
         eoff = be.e2;
         be.e2 = new MulExp(be.loc, be.e2, new IntegerExp(Loc.initial, stride, t));
         be.e2.type = t;
@@ -2754,12 +2758,16 @@ Expression scaleFactor(BinExp be, Scope* sc)
     {
         // Need to adjust operator by the stride
         // Replace (int + ptr) with (ptr + (int * stride))
-        Type t = Type.tptrdiff_t;
+        Type t = Type.tsize_t;
         Expression e;
 
         d_uns64 stride = t2b.nextOf().size(be.loc);
         if (!t.equals(t1b))
-            e = be.e1.castTo(sc, t);
+        {
+            e = be.e1.implicitCastTo(sc, t);
+            if (e.type == Type.terror)
+                return ErrorExp.get();
+        }
         else
             e = be.e1;
         eoff = e;

--- a/test/fail_compilation/fail13902.d
+++ b/test/fail_compilation/fail13902.d
@@ -15,7 +15,7 @@ fail_compilation/fail13902.d(38): Error: returning `& sa1` escapes a reference t
 fail_compilation/fail13902.d(39): Error: returning `&sa2[0][0]` escapes a reference to local variable `sa2`
 fail_compilation/fail13902.d(40): Error: returning `& x` escapes a reference to local variable `x`
 fail_compilation/fail13902.d(41): Error: returning `(& x+4)` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(42): Error: returning `& x + cast(long)x * 4L` escapes a reference to local variable `x`
+fail_compilation/fail13902.d(42): Error: returning `& x + cast(ulong)x * 4LU` escapes a reference to local variable `x`
 fail_compilation/fail13902.d(45): Error: returning `& y` escapes a reference to local variable `y`
 ---
 */
@@ -60,7 +60,7 @@ fail_compilation/fail13902.d(81): Error: returning `& sa1` escapes a reference t
 fail_compilation/fail13902.d(82): Error: returning `&sa2[0][0]` escapes a reference to local variable `sa2`
 fail_compilation/fail13902.d(83): Error: returning `& x` escapes a reference to local variable `x`
 fail_compilation/fail13902.d(84): Error: returning `(& x+4)` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(85): Error: returning `& x + cast(long)x * 4L` escapes a reference to local variable `x`
+fail_compilation/fail13902.d(85): Error: returning `& x + cast(ulong)x * 4LU` escapes a reference to local variable `x`
 fail_compilation/fail13902.d(88): Error: returning `& y` escapes a reference to local variable `y`
 ---
 */

--- a/test/fail_compilation/fix22828.d
+++ b/test/fail_compilation/fix22828.d
@@ -1,0 +1,21 @@
+/*
+REQUIRED_ARGS: -m32
+TEST_OUTPUT:
+---
+fail_compilation/fix22828.d(104): Error: cannot implicitly convert expression `len` of type `ulong` to `uint`
+fail_compilation/fix22828.d(105): Error: cannot implicitly convert expression `len` of type `ulong` to `uint`
+fail_compilation/fix22828.d(106): Error: cannot implicitly convert expression `len` of type `ulong` to `uint`
+---
+ */
+
+#line 100
+
+int main() {
+    int i;
+    ulong len;
+    *(&i + len) = 0;
+    *(len + &i) = 0;
+    (&i)[len] = 0;
+
+    return 0;
+}


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

I made this critical, but I don't know the definition of critical/major, so please clarify and change accordingly, if necessary. For context, this behaviour is being used on the backend code, and can trigger a silent buffer overflow, since the compiler explicit cast this wrongly. One example is on the object file generation, you can see that this triggers an error when using IndexExp but not with AddExp.