### PR TITLE
add lexer range interface under version DMDLIB

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -147,12 +147,12 @@ class Lexer
 
     version (DMDLIB)
     {
-        bool empty()
+        bool empty() const pure @property @nogc @safe
         {
             return front() == TOK.endOfFile;
         }
 
-        TOK front() const @property
+        TOK front() const pure @property @nogc @safe
         {
             return token.value;
         }

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -145,6 +145,24 @@ class Lexer
         }
     }
 
+    version (DMDLIB)
+    {
+        bool empty()
+        {
+            return front() == TOK.endOfFile;
+        }
+
+        TOK front() const @property
+        {
+            return token.value;
+        }
+
+        void popFront()
+        {
+            nextToken();
+        }
+    }
+
     /// Returns: a newly allocated `Token`.
     Token* allocateToken() pure nothrow @safe
     {

--- a/test/unit/lexer/lexer_dmdlib.d
+++ b/test/unit/lexer/lexer_dmdlib.d
@@ -1,0 +1,77 @@
+module lexer.lexer_dmdlib;
+
+import dmd.lexer : Lexer;
+import dmd.tokens : TOK;
+
+unittest
+{
+    immutable code = "void test() {} // foobar";
+
+    immutable expected = [
+        TOK.void_,
+        TOK.identifier,
+        TOK.leftParenthesis,
+        TOK.rightParenthesis,
+        TOK.leftCurly,
+        TOK.rightCurly,
+    ];
+
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, false);
+    lexer.nextToken;
+    
+    TOK[] result;
+
+    foreach(TOK t; lexer)
+    {
+        result ~= t;
+    }
+
+    assert(result == expected);
+}
+
+unittest
+{
+    immutable code = "// some comment";
+
+    immutable expected = [
+        TOK.comment,
+    ];
+
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true);
+    lexer.nextToken;
+    
+    TOK[] result;
+
+    foreach(TOK t; lexer)
+    {
+        result ~= t;
+    }
+
+    assert(result == expected);
+    assert(lexer.empty);
+    lexer.popFront;
+    assert(lexer.empty);
+    lexer.popFront;
+    assert(lexer.empty);
+}
+
+unittest
+{
+    immutable code = "";
+
+    immutable expected = [
+        TOK.reserved,
+    ];
+
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, false);
+    
+    TOK[] result;
+
+    foreach(TOK t; lexer)
+    {
+        result ~= t;
+    }
+
+    assert(result == expected);
+    assert(lexer.empty);
+}


### PR DESCRIPTION
Initially part of [this pull request](https://github.com/dlang/dmd/pull/13696).

The changes are motivated by the need to improve the versatility of the lexer and other parts of the compiler such that dmd will eventually replace 3rd party libraries like libdparse.

This change should make iterating through tokens more intuitive, for example:
```
auto lexer = new Lexer(..); // call lexer constructor
lexer.nextToken;

foreach (ref someTOK; lexer)
{
    // do something cool with someTOK..
}
```