### PR TITLE
fix Issue 22809 - ImportC: druntime.s definition of __builtin_offseto…

### DIFF
--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -469,10 +469,11 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
              * Params:
              *      e = the DotVarExp or VarExp
              *      var = set to the VarExp at the end, or null if doesn't end in VarExp
+             *      eint = set to the IntegerExp at the end, or null if doesn't end in IntegerExp
              *      offset = accumulation of all the .var offsets encountered
              * Returns: true on error
              */
-            static bool getVarAndOffset(Expression e, ref VarDeclaration var, ref uint offset)
+            static bool getVarAndOffset(Expression e, out VarDeclaration var, out IntegerExp eint, ref uint offset)
             {
                 if (e.type.size() == SIZE_INVALID)  // trigger computation of v.offset
                     return true;
@@ -483,7 +484,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
                     if (!v || !v.isField() || v.isBitFieldDeclaration())
                         return false;
 
-                    if (getVarAndOffset(dve.e1, var, offset))
+                    if (getVarAndOffset(dve.e1, var, eint, offset))
                         return true;
                     offset += v.offset;
                 }
@@ -497,12 +498,20 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
                         var = ve.var.isVarDeclaration();
                     }
                 }
+                else if (auto ep = e.isPtrExp())
+                {
+                    if (auto ei = ep.e1.isIntegerExp())
+                    {
+                        eint = ei;
+                    }
+                }
                 return false;
             }
 
             uint offset;
             VarDeclaration var;
-            if (getVarAndOffset(e.e1, var, offset))
+            IntegerExp eint;
+            if (getVarAndOffset(e.e1, var, eint, offset))
             {
                 ret = ErrorExp.get();
                 return;
@@ -511,6 +520,11 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             {
                 ret = new SymOffExp(e.loc, var, offset, false);
                 ret.type = e.type;
+                return;
+            }
+            if (eint)
+            {
+                ret = new IntegerExp(e.loc, eint.toInteger() + offset, e.type);
                 return;
             }
         }
@@ -828,6 +842,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
 
     void visitMin(MinExp e)
     {
+        //printf("MinExp::optimize(%s)\n", e.toChars());
         if (binOptimize(e, result))
             return;
         if (e.e1.isConst() && e.e2.isConst())

--- a/test/compilable/test22809.c
+++ b/test/compilable/test22809.c
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=22809
+
+typedef unsigned long size_t;
+
+// #define __builtin_offsetof(t,i) ((size_t)((char *)&((t *)0)->i - (char *)0))
+
+struct Foo {
+    int x, y;
+};
+
+//int y = __builtin_offsetof(struct Foo, y);
+//_Static_assert(__builtin_offsetof(struct Foo, y)==4, "");
+
+int y = ((size_t)((char *)&((struct Foo *)1)->x - (char *)1));
+_Static_assert(((size_t)((char *)&((struct Foo *)0)->y - (char *)0))==4, "");
+


### PR DESCRIPTION
…f leads to dereference of invalid pointer

Fixed it by adjusting optimize.d to coalesce the &* sequences, because no actual dereferencing of the pointers is done, and before dinterpret.d complains about dereferencing 0.