### PR TITLE
Fix Issue 21975 - is expression ignores implicit conversion of struct via alias this when pattern matching

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -4295,8 +4295,13 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 if (ti && ti.toAlias() == t.sym)
                 {
                     auto tx = new TypeInstance(Loc.initial, ti);
-                    result = deduceType(tx, sc, tparam, parameters, dedtypes, wm);
-                    return;
+                    auto m = deduceType(tx, sc, tparam, parameters, dedtypes, wm);
+                    // if we have a no match we still need to check alias this
+                    if (m != MATCH.nomatch)
+                    {
+                        result = m;
+                        return;
+                    }
                 }
 
                 /* Match things like:

--- a/test/compilable/test21975.d
+++ b/test/compilable/test21975.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=21975
+
+struct Outer(T)
+{
+    Inner!T inner;
+    alias inner this;
+}
+
+struct Inner(T)
+{
+    T t;
+}
+
+static assert(is(Outer!int : Inner!int)); // ok
+static assert(is(Outer!int : Inner!T, T)); // needs to compile


### PR DESCRIPTION
The issue was that when the template types are deduced, implicit conversions were not taken into account. This worked for classes because it would not return immediately upon a no match [1]. I made use of the same check to fix this.

[1] https://github.com/dlang/dmd/blob/master/src/dmd/dtemplate.d#L4436