### PR TITLE
Add DDoc comments to AST nodes

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -83,7 +83,7 @@ void emplaceExp(T : UnionExp)(T* p, Expression e)
     memcpy(p, cast(void*)e, e.size);
 }
 
-// Return value for `checkModifiable`
+/// Return value for `checkModifiable`
 enum Modifiable
 {
     /// Not modifiable
@@ -1766,6 +1766,7 @@ extern (C++) abstract class Expression : ASTNode
 }
 
 /***********************************************************
+ * A compile-time known integer value
  */
 extern (C++) final class IntegerExp : Expression
 {
@@ -1982,6 +1983,7 @@ extern (C++) final class IntegerExp : Expression
 
 /***********************************************************
  * Use this expression for error recovery.
+ *
  * It should behave as a 'sink' to prevent further cascaded error messages.
  */
 extern (C++) final class ErrorExp : Expression
@@ -2026,6 +2028,8 @@ extern (C++) final class ErrorExp : Expression
 /***********************************************************
  * An uninitialized value,
  * generated from void initializers.
+ *
+ * https://dlang.org/spec/declaration.html#void_init
  */
 extern (C++) final class VoidInitExp : Expression
 {
@@ -2052,6 +2056,7 @@ extern (C++) final class VoidInitExp : Expression
 
 
 /***********************************************************
+ * A compile-time known floating point number
  */
 extern (C++) final class RealExp : Expression
 {
@@ -2127,6 +2132,7 @@ extern (C++) final class RealExp : Expression
 }
 
 /***********************************************************
+ * A compile-time complex number (deprecated)
  */
 extern (C++) final class ComplexExp : Expression
 {
@@ -2202,6 +2208,12 @@ extern (C++) final class ComplexExp : Expression
 }
 
 /***********************************************************
+ * An identifier in the context of an expression (as opposed to a declaration)
+ *
+ * ---
+ * int x; // VarDeclaration with Identifier
+ * x++; // PostExp with IdentifierExp
+ * ---
  */
 extern (C++) class IdentifierExp : Expression
 {
@@ -2235,6 +2247,9 @@ extern (C++) class IdentifierExp : Expression
 }
 
 /***********************************************************
+ * The dollar operator used when indexing or slicing an array. E.g `a[$]`, `a[1 .. $]` etc.
+ *
+ * https://dlang.org/spec/arrays.html#array-length
  */
 extern (C++) final class DollarExp : IdentifierExp
 {
@@ -2353,6 +2368,8 @@ extern (C++) final class SuperExp : ThisExp
 }
 
 /***********************************************************
+ * A compile-time known `null` value
+ *
  * https://dlang.org/spec/expression.html#null
  */
 extern (C++) final class NullExp : Expression
@@ -2791,6 +2808,12 @@ extern (C++) final class StringExp : Expression
 }
 
 /***********************************************************
+ * A sequence of expressions
+ *
+ * ---
+ * alias AliasSeq(T...) = T;
+ * alias Tup = AliasSeq!(3, int, "abc");
+ * ---
  */
 extern (C++) final class TupleExp : Expression
 {
@@ -4127,6 +4150,9 @@ extern (C++) final class TraitsExp : Expression
 }
 
 /***********************************************************
+ * Generates a halt instruction
+ *
+ * `assert(0)` gets rewritten to this with `CHECKACTION.halt`
  */
 extern (C++) final class HaltExp : Expression
 {
@@ -4185,6 +4211,9 @@ extern (C++) final class IsExp : Expression
 }
 
 /***********************************************************
+ * Base class for unary operators
+ *
+ * https://dlang.org/spec/expression.html#unary-expression
  */
 extern (C++) abstract class UnaExp : Expression
 {
@@ -4255,6 +4284,7 @@ alias fp_t = UnionExp function(const ref Loc loc, Type, Expression, Expression);
 alias fp2_t = bool function(const ref Loc loc, EXP, Expression, Expression);
 
 /***********************************************************
+ * Base class for binary operators
  */
 extern (C++) abstract class BinExp : Expression
 {
@@ -4550,6 +4580,7 @@ extern (C++) abstract class BinExp : Expression
 }
 
 /***********************************************************
+ * Binary operator assignment, `+=` `-=` `*=` etc.
  */
 extern (C++) class BinAssignExp : BinExp
 {
@@ -4582,6 +4613,8 @@ extern (C++) class BinAssignExp : BinExp
 }
 
 /***********************************************************
+ * A string mixin, `mixin("x")`
+ *
  * https://dlang.org/spec/expression.html#mixin_expressions
  */
 extern (C++) final class MixinExp : Expression
@@ -4628,6 +4661,11 @@ extern (C++) final class MixinExp : Expression
 }
 
 /***********************************************************
+ * An import expression, `import("file.txt")`
+ *
+ * Not to be confused with module imports, `import std.stdio`, which is an `ImportStatement`
+ *
+ * https://dlang.org/spec/expression.html#import_expressions
  */
 extern (C++) final class ImportExp : UnaExp
 {
@@ -4643,6 +4681,8 @@ extern (C++) final class ImportExp : UnaExp
 }
 
 /***********************************************************
+ * An assert expression, `assert(x == y)`
+ *
  * https://dlang.org/spec/expression.html#assert_expressions
  */
 extern (C++) final class AssertExp : UnaExp
@@ -5153,6 +5193,7 @@ FuncDeclaration isFuncAddress(Expression e, bool* hasOverloads = null)
 }
 
 /***********************************************************
+ * The 'address of' operator, `&p`
  */
 extern (C++) final class AddrExp : UnaExp
 {
@@ -5174,6 +5215,7 @@ extern (C++) final class AddrExp : UnaExp
 }
 
 /***********************************************************
+ * The pointer dereference operator, `*p`
  */
 extern (C++) final class PtrExp : UnaExp
 {
@@ -5226,6 +5268,7 @@ extern (C++) final class PtrExp : UnaExp
 }
 
 /***********************************************************
+ * The negation operator, `-x`
  */
 extern (C++) final class NegExp : UnaExp
 {
@@ -5241,6 +5284,7 @@ extern (C++) final class NegExp : UnaExp
 }
 
 /***********************************************************
+ * The unary add operator, `+x`
  */
 extern (C++) final class UAddExp : UnaExp
 {
@@ -5256,6 +5300,7 @@ extern (C++) final class UAddExp : UnaExp
 }
 
 /***********************************************************
+ * The bitwise complement operator, `~x`
  */
 extern (C++) final class ComExp : UnaExp
 {
@@ -5271,6 +5316,7 @@ extern (C++) final class ComExp : UnaExp
 }
 
 /***********************************************************
+ * The logical not operator, `!x`
  */
 extern (C++) final class NotExp : UnaExp
 {
@@ -5286,6 +5332,9 @@ extern (C++) final class NotExp : UnaExp
 }
 
 /***********************************************************
+ * The delete operator, `delete x` (deprecated)
+ *
+ * https://dlang.org/spec/expression.html#delete_expressions
  */
 extern (C++) final class DeleteExp : UnaExp
 {
@@ -5304,7 +5353,11 @@ extern (C++) final class DeleteExp : UnaExp
 }
 
 /***********************************************************
- * Possible to cast to one type while painting to another type
+ * The type cast operator, `cast(T) x`
+ *
+ * It's possible to cast to one type while painting to another type
+ *
+ * https://dlang.org/spec/expression.html#cast_expressions
  */
 extern (C++) final class CastExp : UnaExp
 {
@@ -5500,6 +5553,7 @@ extern (C++) final class SliceExp : UnaExp
 }
 
 /***********************************************************
+ * The `.length` property of an array
  */
 extern (C++) final class ArrayLengthExp : UnaExp
 {
@@ -5684,6 +5738,11 @@ extern (C++) final class IntervalExp : Expression
     }
 }
 
+/***********************************************************
+ * The `dg.ptr` property, pointing to the delegate's 'context'
+ *
+ * c.f.`DelegateFuncptrExp` for the delegate's function pointer `dg.funcptr`
+ */
 extern (C++) final class DelegatePtrExp : UnaExp
 {
     extern (D) this(const ref Loc loc, Expression e1)
@@ -5719,6 +5778,9 @@ extern (C++) final class DelegatePtrExp : UnaExp
 }
 
 /***********************************************************
+ * The `dg.funcptr` property, pointing to the delegate's function
+ *
+ * c.f.`DelegatePtrExp` for the delegate's function pointer `dg.ptr`
  */
 extern (C++) final class DelegateFuncptrExp : UnaExp
 {
@@ -5835,7 +5897,7 @@ extern (C++) final class IndexExp : BinExp
 }
 
 /***********************************************************
- * For both i++ and i--
+ * The postfix increment/decrement operator, `i++` / `i--`
  */
 extern (C++) final class PostExp : BinExp
 {
@@ -5852,7 +5914,7 @@ extern (C++) final class PostExp : BinExp
 }
 
 /***********************************************************
- * For both ++i and --i
+ * The prefix increment/decrement operator, `++i` / `--i`
  */
 extern (C++) final class PreExp : UnaExp
 {
@@ -5876,6 +5938,9 @@ enum MemorySet
 }
 
 /***********************************************************
+ * The assignment / initialization operator, `=`
+ *
+ * Note: operator assignment `op=` has a different base class, `BinAssignExp`
  */
 extern (C++) class AssignExp : BinExp
 {
@@ -5953,6 +6018,7 @@ extern (C++) final class ConstructExp : AssignExp
 }
 
 /***********************************************************
+ * A bit-for-bit copy from `e2` to `e1`
  */
 extern (C++) final class BlitExp : AssignExp
 {
@@ -5981,6 +6047,7 @@ extern (C++) final class BlitExp : AssignExp
 }
 
 /***********************************************************
+ * `x += y`
  */
 extern (C++) final class AddAssignExp : BinAssignExp
 {
@@ -5996,6 +6063,7 @@ extern (C++) final class AddAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * `x -= y`
  */
 extern (C++) final class MinAssignExp : BinAssignExp
 {
@@ -6011,6 +6079,7 @@ extern (C++) final class MinAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * `x *= y`
  */
 extern (C++) final class MulAssignExp : BinAssignExp
 {
@@ -6026,6 +6095,7 @@ extern (C++) final class MulAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * `x /= y`
  */
 extern (C++) final class DivAssignExp : BinAssignExp
 {
@@ -6041,6 +6111,7 @@ extern (C++) final class DivAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * `x %= y`
  */
 extern (C++) final class ModAssignExp : BinAssignExp
 {
@@ -6056,6 +6127,7 @@ extern (C++) final class ModAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * `x &= y`
  */
 extern (C++) final class AndAssignExp : BinAssignExp
 {
@@ -6071,6 +6143,7 @@ extern (C++) final class AndAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * `x |= y`
  */
 extern (C++) final class OrAssignExp : BinAssignExp
 {
@@ -6086,6 +6159,7 @@ extern (C++) final class OrAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * `x ^= y`
  */
 extern (C++) final class XorAssignExp : BinAssignExp
 {
@@ -6101,6 +6175,7 @@ extern (C++) final class XorAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * `x ^^= y`
  */
 extern (C++) final class PowAssignExp : BinAssignExp
 {
@@ -6116,6 +6191,7 @@ extern (C++) final class PowAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * `x <<= y`
  */
 extern (C++) final class ShlAssignExp : BinAssignExp
 {
@@ -6131,6 +6207,7 @@ extern (C++) final class ShlAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * `x >>= y`
  */
 extern (C++) final class ShrAssignExp : BinAssignExp
 {
@@ -6146,6 +6223,7 @@ extern (C++) final class ShrAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * `x >>>= y`
  */
 extern (C++) final class UshrAssignExp : BinAssignExp
 {
@@ -6161,7 +6239,9 @@ extern (C++) final class UshrAssignExp : BinAssignExp
 }
 
 /***********************************************************
- * The ~= operator. It can have one of the following operators:
+ * The `~=` operator.
+ *
+ * It can have one of the following operators:
  *
  * EXP.concatenateAssign      - appending T[] to T[]
  * EXP.concatenateElemAssign  - appending T to T[]
@@ -6188,7 +6268,9 @@ extern (C++) class CatAssignExp : BinAssignExp
     }
 }
 
-///
+/***********************************************************
+ * The `~=` operator when appending a single element
+ */
 extern (C++) final class CatElemAssignExp : CatAssignExp
 {
     extern (D) this(const ref Loc loc, Type type, Expression e1, Expression e2)
@@ -6203,7 +6285,9 @@ extern (C++) final class CatElemAssignExp : CatAssignExp
     }
 }
 
-///
+/***********************************************************
+ * The `~=` operator when appending a single `dchar`
+ */
 extern (C++) final class CatDcharAssignExp : CatAssignExp
 {
     extern (D) this(const ref Loc loc, Type type, Expression e1, Expression e2)
@@ -6219,6 +6303,8 @@ extern (C++) final class CatDcharAssignExp : CatAssignExp
 }
 
 /***********************************************************
+ * The addition operator, `x + y`
+ *
  * https://dlang.org/spec/expression.html#add_expressions
  */
 extern (C++) final class AddExp : BinExp
@@ -6235,6 +6321,9 @@ extern (C++) final class AddExp : BinExp
 }
 
 /***********************************************************
+ * The minus operator, `x - y`
+ *
+ * https://dlang.org/spec/expression.html#add_expressions
  */
 extern (C++) final class MinExp : BinExp
 {
@@ -6250,6 +6339,8 @@ extern (C++) final class MinExp : BinExp
 }
 
 /***********************************************************
+ * The concatenation operator, `x ~ y`
+ *
  * https://dlang.org/spec/expression.html#cat_expressions
  */
 extern (C++) final class CatExp : BinExp
@@ -6273,6 +6364,8 @@ extern (C++) final class CatExp : BinExp
 }
 
 /***********************************************************
+ * The multiplication operator, `x * y`
+ *
  * https://dlang.org/spec/expression.html#mul_expressions
  */
 extern (C++) final class MulExp : BinExp
@@ -6289,6 +6382,8 @@ extern (C++) final class MulExp : BinExp
 }
 
 /***********************************************************
+ * The division operator, `x / y`
+ *
  * https://dlang.org/spec/expression.html#mul_expressions
  */
 extern (C++) final class DivExp : BinExp
@@ -6305,6 +6400,8 @@ extern (C++) final class DivExp : BinExp
 }
 
 /***********************************************************
+ * The modulo operator, `x % y`
+ *
  * https://dlang.org/spec/expression.html#mul_expressions
  */
 extern (C++) final class ModExp : BinExp
@@ -6321,6 +6418,8 @@ extern (C++) final class ModExp : BinExp
 }
 
 /***********************************************************
+ * The 'power' operator, `x ^^ y`
+ *
  * https://dlang.org/spec/expression.html#pow_expressions
  */
 extern (C++) final class PowExp : BinExp
@@ -6337,6 +6436,9 @@ extern (C++) final class PowExp : BinExp
 }
 
 /***********************************************************
+ * The 'shift left' operator, `x << y`
+ *
+ * https://dlang.org/spec/expression.html#shift_expressions
  */
 extern (C++) final class ShlExp : BinExp
 {
@@ -6352,6 +6454,9 @@ extern (C++) final class ShlExp : BinExp
 }
 
 /***********************************************************
+ * The 'shift right' operator, `x >> y`
+ *
+ * https://dlang.org/spec/expression.html#shift_expressions
  */
 extern (C++) final class ShrExp : BinExp
 {
@@ -6367,6 +6472,9 @@ extern (C++) final class ShrExp : BinExp
 }
 
 /***********************************************************
+ * The 'unsigned shift right' operator, `x >>> y`
+ *
+ * https://dlang.org/spec/expression.html#shift_expressions
  */
 extern (C++) final class UshrExp : BinExp
 {
@@ -6382,6 +6490,9 @@ extern (C++) final class UshrExp : BinExp
 }
 
 /***********************************************************
+ * The bitwise 'and' operator, `x & y`
+ *
+ * https://dlang.org/spec/expression.html#and_expressions
  */
 extern (C++) final class AndExp : BinExp
 {
@@ -6397,6 +6508,9 @@ extern (C++) final class AndExp : BinExp
 }
 
 /***********************************************************
+ * The bitwise 'or' operator, `x | y`
+ *
+ * https://dlang.org/spec/expression.html#or_expressions
  */
 extern (C++) final class OrExp : BinExp
 {
@@ -6412,6 +6526,9 @@ extern (C++) final class OrExp : BinExp
 }
 
 /***********************************************************
+ * The bitwise 'xor' operator, `x ^ y`
+ *
+ * https://dlang.org/spec/expression.html#xor_expressions
  */
 extern (C++) final class XorExp : BinExp
 {
@@ -6427,6 +6544,8 @@ extern (C++) final class XorExp : BinExp
 }
 
 /***********************************************************
+ * The logical 'and' / 'or' operator, `X && Y` / `X || Y`
+ *
  * https://dlang.org/spec/expression.html#andand_expressions
  * https://dlang.org/spec/expression.html#oror_expressions
  */
@@ -6445,6 +6564,8 @@ extern (C++) final class LogicalExp : BinExp
 }
 
 /***********************************************************
+ * A comparison operator, `<` `<=` `>` `>=`
+ *
  * `op` is one of:
  *      EXP.lessThan, EXP.lessOrEqual, EXP.greaterThan, EXP.greaterOrEqual
  *
@@ -6465,6 +6586,11 @@ extern (C++) final class CmpExp : BinExp
 }
 
 /***********************************************************
+ * The `in` operator, `"a" in ["a": 1]`
+ *
+ * Note: `x !in y` is rewritten to `!(x in y)` in the parser
+ *
+ * https://dlang.org/spec/expression.html#in_expressions
  */
 extern (C++) final class InExp : BinExp
 {
@@ -6480,6 +6606,8 @@ extern (C++) final class InExp : BinExp
 }
 
 /***********************************************************
+ * Associative array removal, `aa.remove(arg)`
+ *
  * This deletes the key e1 from the associative array e2
  */
 extern (C++) final class RemoveExp : BinExp
@@ -6539,7 +6667,7 @@ extern (C++) final class IdentityExp : BinExp
 }
 
 /***********************************************************
- * `econd ? e1 : e2`
+ * The ternary operator, `econd ? e1 : e2`
  *
  * https://dlang.org/spec/expression.html#conditional_expressions
  */
@@ -6672,6 +6800,18 @@ bool isDefaultInitOp(EXP op) pure nothrow @safe @nogc
 }
 
 /***********************************************************
+ * A special keyword when used as a function's default argument
+ *
+ * When possible, special keywords are resolved in the parser, but when
+ * appearing as a default argument, they result in an expression deriving
+ * from this base class that is resolved for each function call.
+ *
+ * ---
+ * const x = __LINE__; // resolved in the parser
+ * void foo(string file = __FILE__, int line = __LINE__); // DefaultInitExp
+ * ---
+ *
+ * https://dlang.org/spec/expression.html#specialkeywords
  */
 extern (C++) class DefaultInitExp : Expression
 {
@@ -6687,6 +6827,7 @@ extern (C++) class DefaultInitExp : Expression
 }
 
 /***********************************************************
+ * The `__FILE__` token as a default argument
  */
 extern (C++) final class FileInitExp : DefaultInitExp
 {
@@ -6717,6 +6858,7 @@ extern (C++) final class FileInitExp : DefaultInitExp
 }
 
 /***********************************************************
+ * The `__LINE__` token as a default argument
  */
 extern (C++) final class LineInitExp : DefaultInitExp
 {
@@ -6739,6 +6881,7 @@ extern (C++) final class LineInitExp : DefaultInitExp
 }
 
 /***********************************************************
+ * The `__MODULE__` token as a default argument
  */
 extern (C++) final class ModuleInitExp : DefaultInitExp
 {
@@ -6763,6 +6906,7 @@ extern (C++) final class ModuleInitExp : DefaultInitExp
 }
 
 /***********************************************************
+ * The `__FUNCTION__` token as a default argument
  */
 extern (C++) final class FuncInitExp : DefaultInitExp
 {
@@ -6793,6 +6937,7 @@ extern (C++) final class FuncInitExp : DefaultInitExp
 }
 
 /***********************************************************
+ * The `__PRETTY_FUNCTION__` token as a default argument
  */
 extern (C++) final class PrettyFuncInitExp : DefaultInitExp
 {


### PR DESCRIPTION
Improves the DDoc coverage in expression.d. Sometimes I see an AST node such as `PtrExp` and it's not clear what operator it refers to, so I think comments like these make dmd more approachable for contributors who aren't intimately familiar with the internal AST.