### PR TITLE
fix Issue 22807 - ImportC: Array index is out of bounds for old-style…

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1230,7 +1230,7 @@ UnionExp ArrayLength(Type type, Expression e1)
 
 /* Also return EXP.cantExpression if this fails
  */
-UnionExp Index(Type type, Expression e1, Expression e2)
+UnionExp Index(Type type, Expression e1, Expression e2, bool indexIsInBounds)
 {
     UnionExp ue = void;
     Loc loc = e1.loc;
@@ -1255,8 +1255,9 @@ UnionExp Index(Type type, Expression e1, Expression e2)
         TypeSArray tsa = cast(TypeSArray)e1.type.toBasetype();
         uinteger_t length = tsa.dim.toInteger();
         uinteger_t i = e2.toInteger();
-        if (i >= length)
+        if (i >= length && (e1.op == EXP.arrayLiteral || !indexIsInBounds))
         {
+            // C code only checks bounds if an ArrayLiteralExp
             e1.error("array index %llu is out of bounds `%s[0 .. %llu]`", i, e1.toChars(), length);
             emplaceExp!(ErrorExp)(&ue);
         }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5831,6 +5831,13 @@ extern (C++) final class IndexExp : BinExp
         //printf("IndexExp::IndexExp('%s')\n", toChars());
     }
 
+    extern (D) this(const ref Loc loc, Expression e1, Expression e2, bool indexIsInBounds)
+    {
+        super(loc, EXP.index, __traits(classInstanceSize, IndexExp), e1, e2);
+        this.indexIsInBounds = indexIsInBounds;
+        //printf("IndexExp::IndexExp('%s')\n", toChars());
+    }
+
     override IndexExp syntaxCopy()
     {
         auto ie = new IndexExp(loc, e1.syntaxCopy(), e2.syntaxCopy());

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8446,7 +8446,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (length)
                 {
                     auto bounds = IntRange(SignExtendedNumber(0), SignExtendedNumber(length - 1));
-                    exp.indexIsInBounds = bounds.contains(getIntRange(exp.e2));
+                    // OR it in, because it might already be set for C array indexing
+                    exp.indexIsInBounds |= bounds.contains(getIntRange(exp.e2));
                 }
             }
         }

--- a/src/dmd/importc.d
+++ b/src/dmd/importc.d
@@ -159,7 +159,8 @@ Expression carraySemantic(ArrayExp ae, Scope* sc)
     if (t1.isTypeDArray() || t1.isTypeSArray())
     {
         e2 = e2.expressionSemantic(sc).arrayFuncConv(sc);
-        return new IndexExp(ae.loc, e1, e2).expressionSemantic(sc);
+        // C doesn't do array bounds checking, so `true` turns it off
+        return new IndexExp(ae.loc, e1, e2, true).expressionSemantic(sc);
     }
 
     e1 = e1.arrayFuncConv(sc);   // e1 might still be a function call
@@ -167,7 +168,7 @@ Expression carraySemantic(ArrayExp ae, Scope* sc)
     auto t2 = e2.type.toBasetype();
     if (t2.isTypeDArray() || t2.isTypeSArray())
     {
-        return new IndexExp(ae.loc, e2, e1).expressionSemantic(sc); // swap operands
+        return new IndexExp(ae.loc, e2, e1, true).expressionSemantic(sc); // swap operands
     }
 
     e2 = e2.arrayFuncConv(sc);

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -1065,7 +1065,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
         // Don't optimize to an array literal element directly in case an lvalue is requested
         if (keepLvalue && ex.op == EXP.arrayLiteral)
             return;
-        ret = Index(e.type, ex, e.e2).copy();
+        ret = Index(e.type, ex, e.e2, e.indexIsInBounds).copy();
         if (CTFEExp.isCantExp(ret) || (!ret.isErrorExp() && keepLvalue && !ret.isLvalue()))
             ret = e;
     }

--- a/test/compilable/test22807.c
+++ b/test/compilable/test22807.c
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=22807
+
+
+struct OldFashionedHeader {
+    int n; // number of entries in buff
+    char buff[1];
+};
+
+
+int peek(OldFashionedHeader *head){
+    if(head->n < 2)
+        return 0;
+    return head->buff[1]; // do not give array bounds error
+}


### PR DESCRIPTION
… flexible arrays

C code relies on indexing beyond the end of the array. But just blanket allowing this means CTFE won't work with arrays. So we just suppress the error only if an array literal is *not* being indexed.