### PR TITLE
fix Issue 22793 - importC: __import conflicts when importing multiple…

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -811,7 +811,7 @@ extern (C++) class Dsymbol : ASTNode
             Dsymbol s2 = sds.symtabLookup(this,ident);
 
             // If using C tag/prototype/forward declaration rules
-            if (sc.flags & SCOPE.Cfile)
+            if (sc.flags & SCOPE.Cfile && !this.isImport())
             {
                 if (handleTagSymbols(*sc, this, s2, sds))
                     return;

--- a/test/compilable/test22793.c
+++ b/test/compilable/test22793.c
@@ -1,0 +1,4 @@
+// https://issues.dlang.org/show_bug.cgi?id=22793
+
+__import core.stdc.stdio;
+__import core.stdc.stdlib;


### PR DESCRIPTION
… modules with same package

Treat import symbols as D symbols, not C symbols.