### PR TITLE
Fix 22831 - Check signature of extern(C) main functions

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3916,8 +3916,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        if (funcdecl.isMain())
-            funcdecl.checkDmain();       // Check main() parameters and return type
+        funcdecl.checkMain();       // Check main() parameters and return type
 
         /* Purity and safety can be inferred for some functions by examining
          * the function body.

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2710,7 +2710,7 @@ extern (C++) class FuncDeclaration : Declaration
             }
 
             if (tf.parameterList.varargs || nparams >= 2 || argerr)
-                error("parameters must be `main()` or `main(string[] args)`");
+                error("parameter list must be empty or accept one parameter of type `string[]`");
         }
 
         else if (linkage == LINK.c)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -619,8 +619,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         f.next = Type.tvoid;
                     if (f.checkRetType(funcdecl.loc))
                         funcdecl.fbody = new ErrorStatement();
-                    else if (funcdecl.isMain())
-                        funcdecl.checkDmain();       // Check main() parameters and return type
+                    else
+                        funcdecl.checkMain(); // Check main() parameters and return type
                 }
 
                 if (f.next !is null)

--- a/test/compilable/betterCarray.d
+++ b/test/compilable/betterCarray.d
@@ -4,7 +4,8 @@
 
 import core.stdc.stdio;
 
-extern (C) int main(char** argv, int argc) {
+extern (C) int main()
+{
     printf("hello world\n");
     int[3] a;
     foo(a[], 3);

--- a/test/compilable/betterCswitch.d
+++ b/test/compilable/betterCswitch.d
@@ -1,6 +1,7 @@
 import core.stdc.stdio;
 
-extern (C) int main(char** argv, int argc) {
+extern (C) int main()
+{
     printf("hello world\n");
     foo(3);
     return 0;

--- a/test/compilable/cmain.d
+++ b/test/compilable/cmain.d
@@ -1,0 +1,26 @@
+/+
+ARG_SETS: -version=A
+ARG_SETS: -version=B
+ARG_SETS: -version=C
+ARG_SETS: -version=D
+ARG_SETS: -version=E
++/
+
+extern(C):
+
+version (A) int main() { return 0; }
+
+else version (B) int main(const int, const(char*)*) { return 0; }
+
+else version (C) void main(const int, const char**, const char**) {}
+
+else:
+
+enum Length : int;
+enum Char : char;
+enum CharPtr : char*;
+enum CharPtrPtr : char**;
+
+version (D) void main(const Length, const Char**) {}
+
+else version (E) void main(const Length, const CharPtr*, const CharPtrPtr) {}

--- a/test/compilable/noreturn_main.d
+++ b/test/compilable/noreturn_main.d
@@ -4,6 +4,7 @@ Allow main to return noreturn.
 
 ARG_SETS: -version=Use_D_Main
 ARG_SETS: -version=Use_C_Main
+ARG_SETS: -version=Use_Extended_C_Main
 ARG_SETS(windows64): -version=Use_Win_Main
 ARG_SETS(windows64): -version=Use_Dll_Main -shared
 
@@ -20,7 +21,14 @@ noreturn main()
 }
 
 version (Use_C_Main)
-extern(C) noreturn main(int* argc, const char** argv)
+extern(C) noreturn main(int argc, const char** argv)
+{
+	// puts("Hello, World!");
+	assert(false);
+}
+
+version (Use_Extended_C_Main)
+extern(C) noreturn main(int argc, const char** argv, const char** env)
 {
 	// puts("Hello, World!");
 	assert(false);

--- a/test/fail_compilation/fail131.d
+++ b/test/fail_compilation/fail131.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail131.d(8): Error: function `D main` parameters must be `main()` or `main(string[] args)`
+fail_compilation/fail131.d(8): Error: function `D main` parameter list must be empty or accept one parameter of type `string[]`
 ---
 */
 

--- a/test/fail_compilation/malformed_cmain.d
+++ b/test/fail_compilation/malformed_cmain.d
@@ -1,0 +1,33 @@
+/+
+TEST_OUTPUT:
+---
+fail_compilation/malformed_cmain.d($n$): Error: function `malformed_cmain.main` parameters must match one of the following signatures
+fail_compilation/malformed_cmain.d($n$):        `main()`
+fail_compilation/malformed_cmain.d($n$):        `main(int argc, char** argv)`
+fail_compilation/malformed_cmain.d($n$):        `main(int argc, char** argv, char** environ)` [POSIX extension]
+---
+
+ARG_SETS: -version=A
+ARG_SETS: -version=B
+ARG_SETS: -version=C
+ARG_SETS: -version=D
+ARG_SETS: -version=E
+ARG_SETS: -version=F
+ARG_SETS: -version=G
++/
+
+extern(C):
+
+version (A) int main(char) { return 0; }
+
+else version (B) int main(int, char) { return 0; }
+
+else version (C) int main(int, char**, bool) { return 0; }
+
+else version (D) int main(int, char**...) { return 0; }
+
+else version (E) int main(int...) { return 0; }
+
+else version (F) int main(lazy int, char**) { return 0; }
+
+else version (G) int main(int, ref char**) { return 0; }


### PR DESCRIPTION
Enforce that the `main` function uses (most likely) valid arguments / return types. The spec / C standard denotes the following signatures:

```d
int main() { ... }
int main(int, char**) { ... }
```

The implemented checks are more lenient to accomodate for common deviations from the standard. See the DDOC comment of `checkMain()` for a list of accepted extensions. Exotic platforms that expect a different signature can circumvent the checks using  `pragma(mangle, "main")`.

See e.g. https://stackoverflow.com/questions/2108192/what-are-the-valid-signatures-for-cs-main-function

CC @pbackus 