### PR TITLE
fix Issue 22841 - importC: Error: variable 'var' is shadowing variable 'var'

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5279,6 +5279,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     // The mangling change only works for D mangling
                 }
 
+                if (!(sc.flags & SCOPE.Cfile))
                 {
                     /* https://issues.dlang.org/show_bug.cgi?id=21272
                      * If we are in a foreach body we need to extract the

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -667,3 +667,11 @@ struct S22401
 const int c22401[1] = {0};
 const struct S22401 d22401 = {c22401};
 
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22841
+
+void test22841()
+{
+    int v22841;
+    { unsigned v22841; }
+}


### PR DESCRIPTION
Shadowing code is already in its own little code block, only run it when compiling D code.