### PR TITLE
Fix 22031 - Allow modification of constants in `crt_constructor`'s

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -92,7 +92,7 @@ bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
             fd = s.isFuncDeclaration();
         if (fd &&
             ((fd.isCtorDeclaration() && var.isField()) ||
-             (fd.isStaticCtorDeclaration() && !var.isField())) &&
+             ((fd.isStaticCtorDeclaration() || fd.isCrtConstructor()) && !var.isField())) &&
             fd.toParentDecl() == var.toParent2() &&
             (!e1 || e1.op == EXP.this_))
         {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5182,9 +5182,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = result.expressionSemantic(sc);
         }
 
-        if (exp.f && exp.f.isCrtConstructor())
+        if (exp.f && exp.f.isCrtConstructor() && sc.func.setUnsafe())
         {
-            exp.error("functions marked as `crt_constructor` may not be called at runtime");
+            exp.error("cannot call `crt_constructor` function `%s` in `@safe` code", exp.f.toChars());
             return setError();
         }
 
@@ -7116,9 +7116,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (auto ve = exp.e1.isVarExp())
         {
             auto fd = ve.var.isFuncDeclaration();
-            if (fd && fd.isCrtConstructor())
+            if (fd && fd.isCrtConstructor() && sc.func.setUnsafe())
             {
-                exp.error("cannot take address of function `%s` marked as `crt_constructor`", fd.toChars());
+                exp.error("cannot take address of `crt_constructor` function `%s` in `@safe` code", fd.toChars());
                 return setError();
             }
         }

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2689,6 +2689,12 @@ extern (C++) class FuncDeclaration : Declaration
         return this;
     }
 
+    /// Returns: true if this is a function annotated with `pragma(crt_constructor)`
+    extern (D) final bool isCrtConstructor() const pure nothrow @nogc @safe
+    {
+        return this.isCrtCtorDtor == 1;
+    }
+
     inout(FuncDeclaration) toAliasFunc() inout
     {
         return this;

--- a/test/compilable/crt_ctor.d
+++ b/test/compilable/crt_ctor.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=22031
+
+immutable int example;
+
+shared static this()
+{
+    example = 1;
+}
+
+pragma(crt_constructor)
+extern (C)
+void initialize()
+{
+    example = 1;
+}

--- a/test/compilable/issue9884.d
+++ b/test/compilable/issue9884.d
@@ -22,4 +22,14 @@ struct Foo
     }
 }
 
+__gshared const(int)[] data2;
+
+pragma(crt_constructor)
+extern(C) void initialize()
+{
+    data2 = new int[10];
+    foreach (ref x; data2) x = 1;
+    data2[] = 1;
+}
+
 void main() {}

--- a/test/fail_compilation/crt_ctor.d
+++ b/test/fail_compilation/crt_ctor.d
@@ -1,0 +1,40 @@
+/+
+https://issues.dlang.org/show_bug.cgi?id=22031
+
+TEST_OUTPUT:
+---
+fail_compilation/crt_ctor.d(17): Error: cannot modify `immutable` expression `example`
+fail_compilation/crt_ctor.d(31): Error: cannot modify `immutable` expression `example`
+fail_compilation/crt_ctor.d(37): Error: functions marked as `crt_constructor` may not be called at runtime
+fail_compilation/crt_ctor.d(38): Error: cannot take address of function `initialize` marked as `crt_constructor`
+---
++/
+
+immutable int example;
+
+shared static ~this()
+{
+    example = 2;
+}
+
+extern (C)
+{
+    pragma(crt_constructor)
+    void initialize()
+    {
+        example = 1;
+    }
+
+    pragma(crt_destructor)
+    void destruct()
+    {
+        example = 2;
+    }
+}
+
+void main()
+{
+    initialize();
+    auto addr = &initialize;
+    addr();
+}

--- a/test/fail_compilation/crt_ctor.d
+++ b/test/fail_compilation/crt_ctor.d
@@ -3,10 +3,14 @@ https://issues.dlang.org/show_bug.cgi?id=22031
 
 TEST_OUTPUT:
 ---
-fail_compilation/crt_ctor.d(17): Error: cannot modify `immutable` expression `example`
-fail_compilation/crt_ctor.d(31): Error: cannot modify `immutable` expression `example`
-fail_compilation/crt_ctor.d(37): Error: functions marked as `crt_constructor` may not be called at runtime
-fail_compilation/crt_ctor.d(38): Error: cannot take address of function `initialize` marked as `crt_constructor`
+fail_compilation/crt_ctor.d(21): Error: cannot modify `immutable` expression `example`
+fail_compilation/crt_ctor.d(35): Error: cannot modify `immutable` expression `example`
+fail_compilation/crt_ctor.d(41): Error: cannot call `crt_constructor` function `initialize` in `@safe` code
+fail_compilation/crt_ctor.d(42): Error: cannot take address of `crt_constructor` function `initialize` in `@safe` code
+fail_compilation/crt_ctor.d(44): Error: `@safe` function `D main` cannot call `@system` function `crt_ctor.inferCall!().inferCall`
+fail_compilation/crt_ctor.d(48):        `crt_ctor.inferCall!().inferCall` is declared here
+fail_compilation/crt_ctor.d(45): Error: `@safe` function `D main` cannot call `@system` function `crt_ctor.inferAddress!().inferAddress`
+fail_compilation/crt_ctor.d(53):        `crt_ctor.inferAddress!().inferAddress` is declared here
 ---
 +/
 
@@ -20,7 +24,7 @@ shared static ~this()
 extern (C)
 {
     pragma(crt_constructor)
-    void initialize()
+    void initialize() @safe
     {
         example = 1;
     }
@@ -32,9 +36,21 @@ extern (C)
     }
 }
 
-void main()
+void main() @safe
 {
     initialize();
     auto addr = &initialize;
     addr();
+    inferCall();
+    inferAddress();
+}
+
+void inferCall()()
+{
+    initialize();
+}
+
+void inferAddress()()
+{
+    auto addr = &initialize;
 }


### PR DESCRIPTION
Allow functions marked as `pragma(crt_constructor)` to modify `const` /
`immutable` variables, which is currently restricted to module ctors.
This enables the use of lazily initialized global constants for
applications without druntime.

Such function may not be called at runtime because they might violate
the guarantees of `const` / `immutable`. Hence it is now an error to
call / take the address of a function marked as `pragma(crt_constructor)`.