### PR TITLE
Fix issue 22845: DWARF .debug_line section is not standard compliant

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -1118,7 +1118,7 @@ static if (1)
                         1,      // DW_LNS_fixed_advance_pc
                         0,      // DW_LNS_set_prologue_end
                         0,      // DW_LNS_set_epilogue_begin
-                        0,      // DW_LNS_set_isa
+                        1,      // DW_LNS_set_isa
                     ];
                     static if (hversion >= 5)
                     {


### PR DESCRIPTION
According to DWARF standard, DW_LNS_set_isa standard opcode takes one operand,
the generator is reporting 0, wrongly.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>