### PR TITLE
feat(test): Add DWARF_VERIFY flag on DWARF tests

### DIFF
--- a/ci/cirrusci.sh
+++ b/ci/cirrusci.sh
@@ -32,7 +32,7 @@ elif [ "$OS_NAME" == "darwin" ]; then
   brew update-reset
   brew install gnupg libarchive xz llvm
 elif [ "$OS_NAME" == "freebsd" ]; then
-  packages="git gmake devel/llvm"
+  packages="git gmake devel/llvm12"
   if [ "$HOST_DMD" == "dmd-2.079.0" ] ; then
     packages="$packages lang/gcc9"
   fi
@@ -40,4 +40,5 @@ elif [ "$OS_NAME" == "freebsd" ]; then
   # replace default make by GNU make
   rm /usr/bin/make
   ln -s /usr/local/bin/gmake /usr/bin/make
+  ln -s /usr/local/bin/llvm-dwarfdump12 /usr/bin/llvm-dwarfdump
 fi

--- a/ci/cirrusci.sh
+++ b/ci/cirrusci.sh
@@ -16,7 +16,7 @@ if [ -z ${HOST_DMD+x} ] ; then echo "Variable 'HOST_DMD' needs to be set."; exit
 
 if [ "$OS_NAME" == "linux" ]; then
   export DEBIAN_FRONTEND=noninteractive
-  packages="git-core make g++ gdb gnupg curl libcurl4 tzdata zip unzip xz-utils"
+  packages="git-core make g++ gdb gnupg curl libcurl4 tzdata zip unzip xz-utils llvm"
   if [ "$MODEL" == "32" ]; then
     dpkg --add-architecture i386
     packages="$packages g++-multilib libcurl4:i386"
@@ -30,9 +30,9 @@ if [ "$OS_NAME" == "linux" ]; then
 elif [ "$OS_NAME" == "darwin" ]; then
   # required for dlang install.sh
   brew update-reset
-  brew install gnupg libarchive xz
+  brew install gnupg libarchive xz llvm
 elif [ "$OS_NAME" == "freebsd" ]; then
-  packages="git gmake"
+  packages="git gmake devel/llvm"
   if [ "$HOST_DMD" == "dmd-2.079.0" ] ; then
     packages="$packages lang/gcc9"
   fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -33,6 +33,10 @@ if [ "$OS_NAME" == "linux" ]; then
     NM="nm --print-size"
 else
     NM=nm
+
+  if [ "$OS_NAME" == "darwin" ]; then
+    export PATH="/usr/local/opt/llvm/bin:$PATH"
+  fi
 fi
 
 # clone a repo

--- a/test/dshell/dwarf.d
+++ b/test/dshell/dwarf.d
@@ -36,7 +36,6 @@ int main()
     if (sysObjdump.status)
         return DISABLED;
 
-
     double objdumpVersion;
     try
     {
@@ -97,6 +96,12 @@ int main()
         run("objdump -W " ~ exe, objdump_file);
         objdump_file.close();
 
+        auto llvmDwarfdump = executeShell("llvm-dwarfdump --version");
+        try {
+            if (!llvmDwarfdump.status && requirements["DWARF_VERIFY"].to!bool)
+                run("llvm-dwarfdump --verify " ~ exe);
+        } catch (ConvException e) { }
+
         // Objdump excepted results
         string excepted_results_file = extra_dwarf_dir ~ "excepted_results"
             ~ slash ~ filename ~ ".txt";
@@ -137,6 +142,7 @@ string[string] getRequirements(string dfile)
     // Initialize to an empty string to prevent RangeViolation exceptions.
     foreach (req; ["EXTRA_ARGS", "MIN_OBJDUMP_VERSION"])
         result[req] = "";
+    result["DWARF_VERIFY"] = "true";
 
     bool begin;
 

--- a/test/dshell/extra-files/dwarf/fix21160.d
+++ b/test/dshell/extra-files/dwarf/fix21160.d
@@ -1,5 +1,8 @@
 /*
 EXTRA_ARGS: -gdwarf=4
+
+// Issue https://issues.dlang.org/show_bug.cgi?id=22855
+DWARF_VERIFY: false
 */
 
 void main() {}

--- a/test/dshell/extra-files/dwarf/fix22426.d
+++ b/test/dshell/extra-files/dwarf/fix22426.d
@@ -1,5 +1,8 @@
 /*
 EXTRA_ARGS: -gdwarf=5 -main
+
+// Issue https://issues.dlang.org/show_bug.cgi?id=22855
+DWARF_VERIFY: false
 */
 
 noreturn noret()

--- a/test/dshell/extra-files/dwarf/fix22471.d
+++ b/test/dshell/extra-files/dwarf/fix22471.d
@@ -1,4 +1,7 @@
 /*
 EXTRA_ARGS: -g -defaultlib= -main -c
+
+// Issue https://issues.dlang.org/show_bug.cgi?id=22856
+DWARF_VERIFY: false
 */
 

--- a/test/dshell/extra-files/dwarf/fix22508.d
+++ b/test/dshell/extra-files/dwarf/fix22508.d
@@ -1,5 +1,8 @@
 /*
 EXTRA_ARGS: -g -defaultlib= -main -c
+
+// Issue https://issues.dlang.org/show_bug.cgi?id=22856
+DWARF_VERIFY: false
 */
 
 int[string] istr_a;

--- a/test/dshell/extra-files/dwarf/immutable.d
+++ b/test/dshell/extra-files/dwarf/immutable.d
@@ -1,6 +1,9 @@
 /*
 EXTRA_ARGS: -gdwarf=5
 MIN_OBJDUMP_VERSION: 2.30
+
+// Issue https://issues.dlang.org/show_bug.cgi?id=22855
+DWARF_VERIFY: false
 */
 
 void main()

--- a/test/dshell/extra-files/dwarf/immutableVoid.d
+++ b/test/dshell/extra-files/dwarf/immutableVoid.d
@@ -1,6 +1,9 @@
 /*
 EXTRA_ARGS: -gdwarf=5
 MIN_OBJDUMP_VERSION: 2.30
+
+// Issue https://issues.dlang.org/show_bug.cgi?id=22855
+DWARF_VERIFY: false
 */
 
 void main()

--- a/test/dshell/extra-files/dwarf/testVersion.d
+++ b/test/dshell/extra-files/dwarf/testVersion.d
@@ -1,5 +1,8 @@
 /*
 EXTRA_ARGS: -gdwarf=5
+
+// Issue https://issues.dlang.org/show_bug.cgi?id=22855
+DWARF_VERIFY: false
 */
 
 void main() {}


### PR DESCRIPTION
The other tests are disabled because of inconsistency with DWARF4/5 and `.debug_aranges` section.