### PR TITLE
Fix Issue 21844: makedeps contain non-existing files

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -675,24 +675,28 @@ extern (C++) final class Module : Package
 
         //printf("Module::read('%s') file '%s'\n", toChars(), srcfile.toChars());
 
-        if (global.params.emitMakeDeps)
-        {
-            global.params.makeDeps.push(srcfile.toChars());
-        }
 
+
+        bool success;
         if (auto readResult = FileManager.fileManager.lookup(srcfile))
         {
             srcBuffer = readResult;
-            return true;
+            success = true;
         }
-
-        auto readResult = File.read(srcfile.toChars());
-        if (loadSourceBuffer(loc, readResult))
+        else
         {
-            FileManager.fileManager.add(srcfile, srcBuffer);
-            return true;
+            auto readResult = File.read(srcfile.toChars());
+            if (loadSourceBuffer(loc, readResult))
+            {
+                FileManager.fileManager.add(srcfile, srcBuffer);
+                success = true;
+            }
         }
-        return false;
+        if (success && global.params.emitMakeDeps)
+        {
+            global.params.makeDeps.push(srcfile.toChars());
+        }
+        return success;
     }
 
     /// syntactic parse

--- a/test/compilable/makedeps_exe.d
+++ b/test/compilable/makedeps_exe.d
@@ -9,6 +9,7 @@ $r:.*makedeps_exe_$0$?:windows=.exe$: \
   $p:makedeps_exe.d$ \
   $p:makedeps_a.d$ \
   $p:makedeps-import.txt$ \
+  $p:makedeps-import-codemixin.txt$ \
 ---
 **/
 module makedeps_exe;
@@ -19,6 +20,13 @@ import imports.makedeps_a;
 // Test import expression
 enum text = import("makedeps-import.txt");
 static assert(text == "Imported text");
+
+/*******************************/
+// https://issues.dlang.org/show_bug.cgi?id=21844
+enum bool failingModuleImport = __traits(compiles, ((){ import does.not.exist; })());
+enum bool failingFileImport = __traits(compiles, ((){ return import("does.not.exists.txt");})());
+enum bool workingFileImport = __traits(compiles, ((){ return import("makedeps-import-codemixin.txt");})());
+static assert (workingFileImport);
 
 void main()
 {


### PR DESCRIPTION
There is no reasonable way to track non-existing files (since they could be anywhere where -J, -I points to) and by not tracking them at least the builds won't be always out of date. 