### PR TITLE
Fix issue 22848: DWARF .debug_line section should be always generated

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -1682,11 +1682,6 @@ static if (1)
 
         rewrite32(debug_line.buf, 0, cast(uint) debug_line.buf.length() - 4);
 
-        // Bugzilla 3502, workaround OSX's ld64-77 bug.
-        // Don't emit the the debug_line section if nothing has been written to the line table.
-        if (*cast(uint*) &debug_line.buf.buf[lineHeaderLengthOffset] + 10 == debug_line.buf.length())
-            debug_line.buf.reset();
-
         /* ================================================= */
 
         debug_abbrev.buf.writeByte(0);


### PR DESCRIPTION
The current DWARF generator doesn't generate .debug_line section if there is no
entries in the line table, although, to conform with DWARF standard and, in
order to readers read it correctly, this section need to be present, even
though, empty.

This change reverts d72827c39c273162966d90e64daa414c42e325c0, an old bug on OSX
ld64-77.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Testing will be introduced in https://github.com/dlang/dmd/pull/13754 .

CC @jacob-carlborg 