### PR TITLE
ci: remove intermediate scripts introduced on PR #13652

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-source ci/run.sh

--- a/cirrusci.sh
+++ b/cirrusci.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-source ci/cirrusci.sh


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

As suggested by the following comment https://github.com/dlang/dmd/pull/13652#issuecomment-1041828105, this can now be removed since https://github.com/dlang/phobos/pull/8391 and https://github.com/dlang/druntime/pull/3751 got merged.

CC @MoonlightSentinel .