### PR TITLE
ci(pre-commit): add pre-commit configuration

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -1,0 +1,20 @@
+name: pre_commit
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    env:
+      SKIP: no-commit-to-branch
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3.0.0
+    - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.1.0
+  hooks:
+  - id: trailing-whitespace
+    exclude: >
+      (?x)^(
+        ^test/runnable/extra-files/.*$|
+        ^test/compilable/extra-files/.*$|
+      )$
+  - id: check-merge-conflict
+  - id: check-added-large-files
+  - id: detect-private-key
+  - id: no-commit-to-branch
+    args: [--branch, master]
+- repo: https://github.com/sirosen/check-jsonschema
+  rev: 0.14.0
+  hooks:
+    - id: check-github-workflows


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

I would like to introduce pre-commit to DMD and later extend this to other @dlang projects. A lot of nits can be avoided with the introduction of this tool. People are be encouraged to run this on their `git commit` pre hooks by installing `pre-commit` using `pre-commit install`. This is, although, not a requirement for any contributor, since a CI step is added. This CI step is very fast, but introduction of https://pre-commit.ci/ is even faster. There are some problems I see introducing pre-commit.ci since it heavily relies on cached dependencies, and if a regression is introduced, there is no way to force update the cache, at this moment.