### PR TITLE
add Extra to Dsymbol

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -244,8 +244,6 @@ extern (C++) class Dsymbol : ASTNode
     Dsymbol parent;
     /// C++ namespace this symbol belongs to
     CPPNamespaceDeclaration cppnamespace;
-    Symbol* csym;           // symbol for code generator
-    Symbol* isym;           // import version of csym
     const(char)* comment;   // documentation comment for this Dsymbol
     const Loc loc;          // where defined
     Scope* _scope;          // !=null means context to use for semantic()
@@ -260,6 +258,44 @@ extern (C++) class Dsymbol : ASTNode
     // !=null means there's a ddoc unittest associated with this symbol
     // (only use this with ddoc)
     UnitTestDeclaration ddocUnittest;
+
+    /* Rarely used fields, allocate separately to save memory
+     */
+    struct Extra
+    {
+        Symbol* csym;           // symbol for code generator
+        Symbol* isym;           // import version of csym
+    }
+    Extra* extra;
+
+    final @safe nothrow
+    {
+        /* Accessors of Extra fields, allocate on demand
+         */
+        Symbol* csym() { return extra ? extra.csym : null; };
+        Symbol* isym() { return extra ? extra.isym : null; };
+
+        void csym(Symbol* val)
+        {
+            if (extra)
+                extra.csym = val;
+            else if (val)
+            {
+                extra = new Extra();
+                extra.csym = val;
+            }
+        }
+        void isym(Symbol* val)
+        {
+            if (extra)
+                extra.isym = val;
+            else if (val)
+            {
+                extra = new Extra();
+                extra.isym = val;
+            }
+        }
+    }
 
     final extern (D) this()
     {

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -174,8 +174,6 @@ public:
     Dsymbol *parent;
     /// C++ namespace this symbol belongs to
     CPPNamespaceDeclaration *namespace_;
-    Symbol *csym;               // symbol for code generator
-    Symbol *isym;               // import version of csym
     const utf8_t *comment;      // documentation comment for this Dsymbol
     Loc loc;                    // where defined
     Scope *_scope;               // !=NULL means context to use for semantic()
@@ -186,6 +184,12 @@ public:
     DeprecatedDeclaration *depdecl; // customized deprecation message
     UserAttributeDeclaration *userAttribDecl;   // user defined attributes
     UnitTestDeclaration *ddocUnittest; // !=NULL means there's a ddoc unittest associated with this symbol (only use this with ddoc)
+
+    struct Extra
+    {
+        Symbol* csym;           // symbol for code generator
+        Symbol* isym;           // import version of csym
+    } *extra;
 
     static Dsymbol *create(Identifier *);
     const char *toChars() const;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -40,12 +40,12 @@ struct _d_dynamicArray final
 class Visitor;
 class Identifier;
 class CPPNamespaceDeclaration;
-struct Symbol;
 struct OutBuffer;
 struct Scope;
 class DeprecatedDeclaration;
 class UserAttributeDeclaration;
 class UnitTestDeclaration;
+struct Symbol;
 class Module;
 class TemplateInstance;
 class ScopeDsymbol;
@@ -979,8 +979,6 @@ public:
     Identifier* ident;
     Dsymbol* parent;
     CPPNamespaceDeclaration* cppnamespace;
-    Symbol* csym;
-    Symbol* isym;
     const char* comment;
     const Loc loc;
     Scope* _scope;
@@ -991,6 +989,26 @@ public:
     DeprecatedDeclaration* depdecl;
     UserAttributeDeclaration* userAttribDecl;
     UnitTestDeclaration* ddocUnittest;
+    struct Extra final
+    {
+        Symbol* csym;
+        Symbol* isym;
+        Extra() :
+            csym(),
+            isym()
+        {
+        }
+        Extra(Symbol* csym, Symbol* isym = nullptr) :
+            csym(csym),
+            isym(isym)
+            {}
+    };
+
+    Extra* extra;
+    Symbol* csym();
+    Symbol* isym();
+    void csym(Symbol* val);
+    void isym(Symbol* val);
     static Dsymbol* create(Identifier* ident);
     const char* toChars() const;
     virtual const char* toPrettyCharsHelper();

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -663,6 +663,11 @@ public:
 
                 auto vto = new VarDeclaration(vd.loc, vd.type, vd.ident, vd._init);
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
+                if (vd.extra)
+                {
+                    vto.extra = new Dsymbol.Extra();
+                    *vto.extra = *vd.extra;
+                }
                 vto.parent = ids.parent;
                 vto.csym = null;
                 vto.isym = null;
@@ -799,6 +804,11 @@ public:
                 auto vd = e.lengthVar;
                 auto vto = new VarDeclaration(vd.loc, vd.type, vd.ident, vd._init);
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
+                if (vd.extra)
+                {
+                    vto.extra = new Dsymbol.Extra();
+                    *vto.extra = *vd.extra;
+                }
                 vto.parent = ids.parent;
                 vto.csym = null;
                 vto.isym = null;
@@ -828,6 +838,11 @@ public:
                 auto vd = e.lengthVar;
                 auto vto = new VarDeclaration(vd.loc, vd.type, vd.ident, vd._init);
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
+                if (vd.extra)
+                {
+                    vto.extra = new Dsymbol.Extra();
+                    *vto.extra = *vd.extra;
+                }
                 vto.parent = ids.parent;
                 vto.csym = null;
                 vto.isym = null;


### PR DESCRIPTION
Most of the fields in Dsymbol are never used, they're just `null`. However, an enormous number of Dsymbol's are generated, so this consumes gobs of memory. This PR pulls out two fields, and puts them in Extra which is allocated separately.

If this goes well, we can transfer many more to Extra.