### PR TITLE
move .isym from Dsymbol to Declaration

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -29,6 +29,7 @@ import dmd.errors;
 import dmd.expression;
 import dmd.func;
 import dmd.globals;
+import dmd.gluelayer;
 import dmd.id;
 import dmd.identifier;
 import dmd.init;
@@ -226,6 +227,8 @@ extern (C++) abstract class Declaration : Dsymbol
     ubyte adFlags;         // control re-assignment of AliasDeclaration (put here for packing reasons)
       enum wasRead    = 1; // set if AliasDeclaration was read
       enum ignoreRead = 2; // ignore any reads of AliasDeclaration
+
+    Symbol* isym;           // import version of csym
 
     // overridden symbol with pragma(mangle, "...")
     const(char)[] mangleOverride;

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -119,6 +119,7 @@ public:
     LINK linkage;
     short inuse;                // used to detect cycles
     uint8_t adFlags;
+    Symbol* isym;               // import version of csym
     DString mangleOverride;     // overridden symbol with pragma(mangle, "...")
 
     const char *kind() const;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -245,7 +245,6 @@ extern (C++) class Dsymbol : ASTNode
     /// C++ namespace this symbol belongs to
     CPPNamespaceDeclaration cppnamespace;
     Symbol* csym;           // symbol for code generator
-    Symbol* isym;           // import version of csym
     const(char)* comment;   // documentation comment for this Dsymbol
     const Loc loc;          // where defined
     Scope* _scope;          // !=null means context to use for semantic()

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -175,7 +175,6 @@ public:
     /// C++ namespace this symbol belongs to
     CPPNamespaceDeclaration *namespace_;
     Symbol *csym;               // symbol for code generator
-    Symbol *isym;               // import version of csym
     const utf8_t *comment;      // documentation comment for this Dsymbol
     Loc loc;                    // where defined
     Scope *_scope;               // !=NULL means context to use for semantic()

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -980,7 +980,6 @@ public:
     Dsymbol* parent;
     CPPNamespaceDeclaration* cppnamespace;
     Symbol* csym;
-    Symbol* isym;
     const char* comment;
     const Loc loc;
     Scope* _scope;
@@ -5716,6 +5715,7 @@ public:
 
     enum : int32_t { ignoreRead = 2 };
 
+    Symbol* isym;
     _d_dynamicArray< const char > mangleOverride;
     const char* kind() const;
     d_uns64 size(const Loc& loc);

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -502,7 +502,7 @@ Symbol *toImport(Symbol *sym, Loc loc)
  * Generate import symbol from symbol.
  */
 
-Symbol *toImport(Dsymbol ds)
+Symbol *toImport(Declaration ds)
 {
     if (!ds.isym)
     {


### PR DESCRIPTION
An alternative to https://github.com/dlang/dmd/pull/13762 which moves a field from the base class to the derived class.