### PR TITLE
Changelog: Tweak the release notes for scope class deprecation

### DIFF
--- a/changelog/dep_scope_class.dd
+++ b/changelog/dep_scope_class.dd
@@ -1,12 +1,23 @@
 `scope` as a type constraint on class declarations is deprecated.
 
-`scope` as a type constraint on class declarations has been scheduled for
-deprecation for quite some time. However, starting with this release, the
-compiler will emit a deprecation warning if used.
+`scope` as a type constraint on class declarations was meant to force users
+of a class to `scope` allocate it, which resulted in the class being placed
+on the stack rather than GC-allocated. While it has been scheduled for
+deprecation for quite some time, the compiler will emit a deprecation warning
+on usage starting from this release.
 
 ---
 scope class C { }  // Deprecation: `scope` as a type constraint is deprecated. Use `scope` at the usage site.
 ---
 
-Note that this does not apply to structs. Deprecation of `scope` as a type
-constraint on structs is still awaiting a decision.
+Using `scope` to stack-allocate `class` is still suported,
+only the type constraint is deprecated.
+
+---
+class C { }
+
+void main () @nogc
+{
+    scope c = new C;
+}
+---


### PR DESCRIPTION
```
A common misunderstanding is the difference between scope at the usage site
and scope on class declaration. So be extra verbose to let the user know
what is deprecated and what is not. Also remove the mention of structs,
as 'scope' on struct doesn't seem to have any effect, and many people
don't even know it is possible.
```

Follows https://github.com/dlang/dmd/pull/13669
@ibuclaw : Maybe we should just deprecate it on `struct` as well now ?