### PR TITLE
Fix issue 22849: Global buffer overflow on lexer dereferencing

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -227,7 +227,7 @@ class Lexer
                         goto LendSkipFourSpaces;
                     p++;
                 }
-                while (*(cast(uint*)p) == 0x20202020) // ' ' == 0x20
+                while (p + 4 < end && *(cast(uint*)p) == 0x20202020) // ' ' == 0x20
                     p += 4;
                 // Skip over any remaining space on the line.
                 while (*p == ' ')


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Related to https://github.com/dlang/dmd/pull/13765 .
This is already being tested, but not triggered, since the CI test suite is not being run with a sanitiser.