### PR TITLE
Deprecate 'scope' as a type constraint on struct and enum declarations

### DIFF
--- a/changelog/dep_scope_type.dd
+++ b/changelog/dep_scope_type.dd
@@ -1,4 +1,4 @@
-`scope` as a type constraint on class declarations is deprecated.
+`scope` as a type constraint on class, struct, and enum declarations is deprecated.
 
 `scope` as a type constraint on class declarations was meant to force users
 of a class to `scope` allocate it, which resulted in the class being placed
@@ -6,8 +6,13 @@ on the stack rather than GC-allocated. While it has been scheduled for
 deprecation for quite some time, the compiler will emit a deprecation warning
 on usage starting from this release.
 
+`scope` as a type constraint on struct or enum declarations has never had any
+effect, and has been deprecated as well.
+
 ---
 scope class C { }  // Deprecation: `scope` as a type constraint is deprecated. Use `scope` at the usage site.
+scope struct S { } // Ditto
+scope enum E { }   // Ditto
 ---
 
 Using `scope` to stack-allocate `class` is still suported,

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2140,6 +2140,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         Module.dprogress++;
 
+        // @@@DEPRECATED_2.110@@@ https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+        // Deprecated in 2.100
+        // Make an error in 2.110
+        if (sc.stc & STC.scope_)
+            deprecation(ed.loc, "`scope` as a type constraint is deprecated.  Use `scope` at the usage site.");
+
         Scope* sce;
         if (ed.isAnonymous())
             sce = sc;
@@ -4634,6 +4640,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             sd.deferred.semantic2(sc);
             sd.deferred.semantic3(sc);
         }
+
+        // @@@DEPRECATED_2.110@@@ https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+        // Deprecated in 2.100
+        // Make an error in 2.110
+        if (sd.storage_class & STC.scope_)
+            deprecation(sd.loc, "`scope` as a type constraint is deprecated.  Use `scope` at the usage site.");
     }
 
     void interfaceSemantic(ClassDeclaration cd)

--- a/test/fail_compilation/scope_type.d
+++ b/test/fail_compilation/scope_type.d
@@ -2,12 +2,15 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/scope_type.d(11): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
-fail_compilation/scope_type.d(12): Error: `scope` as a type constraint is obsolete.  Use `scope` at the usage site.
+fail_compilation/scope_type.d(13): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/scope_type.d(14): Error: `scope` as a type constraint is obsolete.  Use `scope` at the usage site.
+fail_compilation/scope_type.d(15): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/scope_type.d(16): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
 ---
 */
 
 
 scope class C { }
 scope interface I { }
-//scope struct S { }
+scope struct S { }
+scope enum E { e }


### PR DESCRIPTION
Follows #13669 and #13764.

Ping @Geod24 