### PR TITLE
dmd.cparser: Move directive lexing/parsing to specialTokenSequence

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -68,8 +68,6 @@ class Lexer
     ubyte long_doublesize;      /// size of C long double, 8 or D real.sizeof
     ubyte wchar_tsize;          /// size of C wchar_t, 2 or 4
 
-    structalign_t packalign;    /// current state of #pragma pack alignment (ImportC)
-
     private
     {
         const(char)* base;      // pointer to start of buffer
@@ -89,10 +87,6 @@ class Lexer
         int lastDocLine;        // last line of previous doc comment
 
         Token* tokenFreelist;
-
-        // ImportC #pragma pack stack
-        Array!Identifier* records;      // identifers (or null)
-        Array!structalign_t* packs;     // parallel alignment values
     }
 
   nothrow:
@@ -124,7 +118,6 @@ class Lexer
         this.commentToken = commentToken;
         this.inTokenStringConstant = 0;
         this.lastDocLine = 0;
-        this.packalign.setDefault();
         //initKeywords();
         /* If first line starts with '#!', ignore the line
          */
@@ -1051,35 +1044,8 @@ class Lexer
             case '#':
                 {
                     p++;
-                    Token n;
-                    scan(&n);
-                    if (Ccompile && n.value == TOK.int32Literal)
-                    {
-                        poundLine(n, true);
+                    if (parseSpecialTokenSequence())
                         continue;
-                    }
-                    if (n.value == TOK.identifier)
-                    {
-                        if (n.ident == Id.line)
-                        {
-                            poundLine(n, false);
-                            continue;
-                        }
-                        else if (n.ident == Id.__pragma && Ccompile)
-                        {
-                            pragmaDirective(scanloc);
-                            continue;
-                        }
-                        else
-                        {
-                            const locx = loc();
-                            warning(locx, "C preprocessor directive `#%s` is not supported", n.ident.toChars());
-                        }
-                    }
-                    else if (n.value == TOK.if_)
-                    {
-                        error("C preprocessor directive `#if` is not supported, use `version` or `static if`");
-                    }
                     t.value = TOK.pound;
                     return;
                 }
@@ -2666,6 +2632,37 @@ class Lexer
         va_end(args);
     }
 
+    /***************************************
+     * Parse special token sequence:
+     * Returns:
+     *  true if the special token sequence was handled
+     * References:
+     *  https://dlang.org/spec/lex.html#special-token-sequence
+     */
+    bool parseSpecialTokenSequence()
+    {
+        Token n;
+        scan(&n);
+        if (n.value == TOK.identifier)
+        {
+            if (n.ident == Id.line)
+            {
+                poundLine(n, false);
+                return true;
+            }
+            else
+            {
+                const locx = loc();
+                warning(locx, "C preprocessor directive `#%s` is not supported", n.ident.toChars());
+            }
+        }
+        else if (n.value == TOK.if_)
+        {
+            error("C preprocessor directive `#if` is not supported, use `version` or `static if`");
+        }
+        return false;
+    }
+
     /*********************************************
      * Parse line/file preprocessor directive:
      *    #line linnum [filespec]
@@ -2680,7 +2677,7 @@ class Lexer
      * References:
      *  linemarker https://gcc.gnu.org/onlinedocs/gcc-11.1.0/cpp/Preprocessor-Output.html
      */
-    private void poundLine(ref Token tok, bool linemarker)
+    final void poundLine(ref Token tok, bool linemarker)
     {
         auto linnum = this.scanloc.linnum;
         const(char)* filespec = null;
@@ -2806,183 +2803,10 @@ class Lexer
             error(loc, "#line integer [\"filespec\"]\\n expected");
     }
 
-    /*********************************************
-     * C11 6.10.6 Pragma directive
-     * # pragma pp-tokens(opt) new-line
-     * The C preprocessor sometimes leaves pragma directives in
-     * the preprocessed output. Ignore them.
-     * Upon return, p is at start of next line.
-     */
-    private void pragmaDirective(const ref Loc loc)
-    {
-        Token n;
-        scan(&n);
-        if (n.value == TOK.identifier && n.ident == Id.pack)
-            return pragmaPack(loc);
-        skipToNextLine();
-    }
-
-    /*********
-     * ImportC
-     * # pragma pack
-     * https://gcc.gnu.org/onlinedocs/gcc-4.4.4/gcc/Structure_002dPacking-Pragmas.html
-     * https://docs.microsoft.com/en-us/cpp/preprocessor/pack
-     * Scanner is on the `pack`
-     * Params:
-     *  startloc = location to use for error messages
-     */
-    private void pragmaPack(const ref Loc startloc)
-    {
-        const loc = startloc;
-        Token n;
-        scan(&n);
-        if (n.value != TOK.leftParenthesis)
-        {
-            error(loc, "left parenthesis expected to follow `#pragma pack`");
-            skipToNextLine();
-            return;
-        }
-
-        void closingParen()
-        {
-            if (n.value != TOK.rightParenthesis)
-            {
-                error(loc, "right parenthesis expected to close `#pragma pack(`");
-            }
-            skipToNextLine();
-        }
-
-        void setPackAlign(ref const Token t)
-        {
-            const n = t.unsvalue;
-            if (n < 1 || n & (n - 1) || ushort.max < n)
-                error(loc, "pack must be an integer positive power of 2, not 0x%llx", cast(ulong)n);
-            packalign.set(cast(uint)n);
-            packalign.setPack(true);
-        }
-
-        scan(&n);
-
-        if (!records)
-        {
-            records = new Array!Identifier;
-            packs = new Array!structalign_t;
-        }
-
-        /* # pragma pack ( show )
-         */
-        if (n.value == TOK.identifier && n.ident == Id.show)
-        {
-            if (packalign.isDefault())
-                warning(startloc, "current pack attribute is default");
-            else
-                warning(startloc, "current pack attribute is %d", packalign.get());
-            scan(&n);
-            return closingParen();
-        }
-        /* # pragma pack ( push )
-         * # pragma pack ( push , identifier )
-         * # pragma pack ( push , integer )
-         * # pragma pack ( push , identifier , integer )
-         */
-        if (n.value == TOK.identifier && n.ident == Id.push)
-        {
-            scan(&n);
-            Identifier record = null;
-            if (n.value == TOK.comma)
-            {
-                scan(&n);
-                if (n.value == TOK.identifier)
-                {
-                    record = n.ident;
-                    scan(&n);
-                    if (n.value == TOK.comma)
-                    {
-                        scan(&n);
-                        if (n.value == TOK.int32Literal)
-                        {
-                            setPackAlign(n);
-                            scan(&n);
-                        }
-                        else
-                            error(loc, "alignment value expected, not `%s`", n.toChars());
-                    }
-                }
-                else if (n.value == TOK.int32Literal)
-                {
-                    setPackAlign(n);
-                    scan(&n);
-                }
-                else
-                    error(loc, "alignment value expected, not `%s`", n.toChars());
-            }
-            this.records.push(record);
-            this.packs.push(packalign);
-            return closingParen();
-        }
-        /* # pragma pack ( pop )
-         * # pragma pack ( pop PopList )
-         * PopList :
-         *    , IdentifierOrInteger
-         *    , IdentifierOrInteger PopList
-         * IdentifierOrInteger:
-         *      identifier
-         *      integer
-         */
-        if (n.value == TOK.identifier && n.ident == Id.pop)
-        {
-            scan(&n);
-            while (n.value == TOK.comma)
-            {
-                scan(&n);
-                if (n.value == TOK.identifier)
-                {
-                    for (size_t len = this.records.length; len; --len)
-                    {
-                        if ((*this.records)[len - 1] == n.ident)
-                        {
-                            packalign = (*this.packs)[len - 1];
-                            this.records.setDim(len - 1);
-                            this.packs.setDim(len - 1);
-                            break;
-                        }
-                    }
-                    scan(&n);
-                }
-                else if (n.value == TOK.int32Literal)
-                {
-                    setPackAlign(n);
-                    this.records.push(null);
-                    this.packs.push(packalign);
-                    scan(&n);
-                }
-            }
-            return closingParen();
-        }
-        /* # pragma pack ( integer )
-         */
-        if (n.value == TOK.int32Literal)
-        {
-            setPackAlign(n);
-            scan(&n);
-            return closingParen();
-        }
-        /* # pragma pack ( )
-         */
-        if (n.value == TOK.rightParenthesis)
-        {
-            packalign.setDefault();
-            return closingParen();
-        }
-
-        error(loc, "unrecognized `#pragma pack(%s)`", n.toChars());
-        skipToNextLine();
-    }
-
     /***************************************
      * Scan forward to start of next line.
      */
-    private void skipToNextLine()
+    final void skipToNextLine()
     {
         while (1)
         {


### PR DESCRIPTION
The parsing of C-specific `#line` and `#pragma` has also been moved out of dmd.lexer to dmd.cparse, a more suitable place to handle importC code.