### PR TITLE
Fix Issue 15749 - Implement with expressions

### DIFF
--- a/changelog/withexpressions.dd
+++ b/changelog/withexpressions.dd
@@ -1,0 +1,37 @@
+With expressions have been added to D under the preview flag `-preview=withExpressions`.
+
+These expressions are a simple feature designed to remove the need for a few keystrokes
+in non-trival code, based on the observation that the with *statement* is very useful, but often not useable
+within certain patterns of code. Why? The atom of any piece of D code that could be, loosely, considered
+[functional](https://en.wikipedia.org/wiki/Functional_programming) is the expression and not the statement.
+
+Put simply, this new type of expression allows the programmer to use with "statements" inside an expression.
+
+For example if one has a range-based algorithm dealing with a type like
+---
+struct Polar
+{
+    double angle;
+    double length;
+}
+---
+one can, using these with expressions, transform the following
+---
+//project data onto x axis
+getData()
+    .map!(p => p.length * cos(p.angle))
+    .doSomthing();
+---
+into the following
+---
+getData()
+    .map!(p => with(p)(length * cos(angle)))
+    .doSomething();
+---
+
+Blaise Pascal once wrote:
+
+> If I had more time, I would have written a shorter letter.
+
+Unlike some purely creative disciplines, programming does not always afford a programmer the luxury of beauty —
+this feature does something to rectify that by making it possible for you to write a shorter letter.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -860,6 +860,8 @@ dmd -cov -unittest myprog.d
             "'in' contracts of overridden methods must be a superset of parent contract"),
         Feature("shortenedMethods", "shortenedMethods",
             "allow use of => for methods and top-level functions in addition to lambdas"),
+        Feature("withExpressions", "withExpressions",
+            "implement with expressions"),
         // DEPRECATED previews
         // trigger deprecation message once D repositories don't use this flag anymore
         Feature("markdown", "markdown", "enable Markdown replacements in Ddoc", false, false),

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5162,6 +5162,11 @@ extern (C++) class ToElemVisitor : Visitor
         //printf("ClassReferenceExp.toElem() %p, value=%p, %s\n", e, e.value, e.toChars());
         result = el_ptr(toSymbol(e));
     }
+
+    override void visit(WithExp exp)
+    {
+        assert(0);
+    }
 }
 
 /******************************************

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2217,7 +2217,16 @@ extern (C++) final class ComplexExp : Expression
  */
 extern (C++) class IdentifierExp : Expression
 {
-    Identifier ident;
+    ///The pseudo-sumtype probably has to stay, but the interface is the stuff of nightmares.
+    //If you're reading this, dear reviewer, I haven't made it safe yet.
+    union
+    {
+        Identifier ident;
+        ///To support with expressions
+        DotIdExp   symbolWithIdent;
+    }
+    ///Safe to access ident
+    bool hasBeenRewritten = false;
 
     extern (D) this(const ref Loc loc, Identifier ident)
     {
@@ -2245,7 +2254,6 @@ extern (C++) class IdentifierExp : Expression
         v.visit(this);
     }
 }
-
 /***********************************************************
  * The dollar operator used when indexing or slicing an array. E.g `a[$]`, `a[1 .. $]` etc.
  *
@@ -5454,7 +5462,27 @@ extern (C++) final class VectorExp : UnaExp
         v.visit(this);
     }
 }
+extern (C++) final class WithExp : UnaExp
+{
+    //Same deal as a WithStatement.
+    Expression wrt;
 
+    extern (D) this(const ref Loc loc, Expression e, Expression w)
+    {
+        super(loc, EXP.withExp, __traits(classInstanceSize, WithExp), e);
+        this.wrt = w;
+    }
+
+    override WithExp syntaxCopy()
+    {
+        return new WithExp(this.loc, this.e1.syntaxCopy, this.wrt.syntaxCopy);
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
 /***********************************************************
  * e1.array property for vectors.
  *

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2513,7 +2513,7 @@ private Module loadStdMath()
     return impStdMath.mod;
 }
 
-private extern (C++) final class ExpressionSemanticVisitor : Visitor
+private extern (C++) class ExpressionSemanticVisitor : Visitor
 {
     alias visit = Visitor.visit;
 
@@ -2587,7 +2587,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp;
             return;
         }
-
+        //This was rewritten during the semantic analysis of a with expression
+        if (exp.hasBeenRewritten)
+        {
+            result = exp.symbolWithIdent.expressionSemantic(sc);
+            return;
+        }
         Dsymbol scopesym;
         Dsymbol s = sc.search(exp.loc, exp.ident, &scopesym);
         if (s)
@@ -4029,7 +4034,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
-        //printf("td = %p, treq = %p\n", td, fd.treq);
+        //printf("td = %p, treq = %p\n", exp.td, exp.fd.treq);
         if (exp.td)
         {
             assert(exp.td.parameters && exp.td.parameters.dim);
@@ -7382,7 +7387,112 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         result = e;
     }
+    override void visit(WithExp exp)
+    {
+        static if (LOGSEMANTIC)
+        {
+            printf("WithExp::semantic('%s')\n", exp.wrt.toChars());
+        }
+        //We need to know what the with(...) contains
+        exp.wrt = exp.wrt.expressionSemantic(sc);
+        exp.wrt = resolveProperties(sc, exp.wrt);
+        exp.wrt = exp.wrt.optimize(WANTvalue);
 
+        //This unpropitiative type is to initialize any temporary we declare, see below
+        DeclarationExp var;
+
+        /*
+            Just substituting the expression into identifiers we collect below is not good enough.
+
+            If wrt is an rvalue then we need to copy it (so it's only evaluated once).
+
+            To mimic a WithStatement, if we have something with pointer type, then we need to transform it
+            from expr to *(expr)
+        */
+
+        //TypeExp's are considered non-lvalues, but can't be copied to a temporary
+        if (!(exp.wrt.isLvalue() || exp.wrt.isTypeExp()))
+        {
+            auto tempVar = copyToTemp(STC.exptemp, "__withexp_temp", exp.wrt);
+            exp.wrt = new VarExp(exp.loc, tempVar);
+            var = (new DeclarationExp(exp.wrt.loc, tempVar)).expressionSemantic(sc).isDeclarationExp();
+            exp.wrt = exp.wrt.expressionSemantic(sc);
+            //N.B. a syntax copy might be needed in here for some edge case
+        }
+        Type base = exp.wrt.type.toBasetype();
+
+        if (base.isTypePointer())
+        {
+            exp.wrt = (new PtrExp(exp.loc, exp.wrt)).expressionSemantic(sc);
+        }
+
+        extern (C++) class IdentifierWalk : StoppableVisitor
+        {
+        private:
+            Scope* sc;
+            Expression withExpSym;
+        public:
+            alias visit = typeof(super).visit;
+            this(Scope* sc, Expression e)
+            {
+                this.sc = sc;
+                this.withExpSym = e;
+            }
+            void rewrite(IdentifierExp e)
+            {
+                Identifier ident = e.ident;
+                Dsymbol lsearch(const ref Loc loc, Identifier x)
+                {
+                    Dsymbol s = null;
+                    Expression eold = null;
+                    for (Expression e = withExpSym; e && e != eold; e = resolveAliasThis(sc, e, true))
+                    {
+                        if (auto sE = e.isScopeExp())
+                        {
+                            s = sE.sds;
+                        }
+                        else if (auto tE = e.isTypeExp())
+                        {
+                            s = tE.type.toBasetype.toDsymbol(null);
+                        }
+                        else
+                        {
+                            Type t = e.type.toBasetype();
+                            s = t.toDsymbol(null);
+                        }
+                        if (s)
+                        {
+                            s = s.search(loc, ident);
+                            if (s)
+                                return s;
+                        }
+                        eold = e;
+                    }
+                    return null;
+                }
+                if (auto p = lsearch(e.loc, ident))
+                {
+                    e.symbolWithIdent = new DotIdExp(e.loc, withExpSym, ident);
+                    e.hasBeenRewritten = true;
+                }
+            }
+            override void visit(IdentifierExp exp) {
+                rewrite(exp);
+            }
+            override void visit(Expression) {}
+        }
+        scope v = new IdentifierWalk(sc, exp.wrt);
+        import dmd.apply : walkPostorder;
+        //Rewrite identifiers beneath us as set out above
+        walkPostorder(exp.e1, v);
+        //If `var` was set then we need to use a CommaExp to initialize it properly
+        auto innerSema = (var ? new CommaExp(exp.loc, var, exp.e1) : exp.e1).expressionSemantic(sc);
+
+        if (innerSema.isError)
+            return setError();
+        result = innerSema;
+        return;
+    }
     override void visit(CastExp exp)
     {
         static if (LOGSEMANTIC)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -512,6 +512,7 @@ struct Param final
     FeatureState dtorFields;
     bool fieldwise;
     bool rvalueRefParam;
+    bool withExpressions;
     CppStdRevision cplusplus;
     bool markdown;
     bool vmarkdown;
@@ -637,6 +638,7 @@ struct Param final
         ehnogc(),
         fieldwise(),
         rvalueRefParam(),
+        withExpressions(false),
         cplusplus((CppStdRevision)201103u),
         markdown(true),
         vmarkdown(),
@@ -710,7 +712,7 @@ struct Param final
         mapfile()
     {
     }
-    Param(bool obj, bool link = true, bool dll = false, bool lib = false, bool multiobj = false, bool oneobj = false, bool trace = false, bool tracegc = false, bool verbose = false, bool vcg_ast = false, bool showColumns = false, bool vtls = false, bool vtemplates = false, bool vtemplatesListInstances = false, bool vgc = false, bool vfield = false, bool vcomplex = true, bool vin = false, uint8_t symdebug = 0u, bool symdebugref = false, bool optimize = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool stackstomp = false, bool useUnitTests = false, bool useInline = false, FeatureState useDIP25 = (FeatureState)-1, FeatureState useDIP1000 = (FeatureState)-1, bool useDIP1021 = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, PIC pic = (PIC)0u, bool color = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool nofloat = false, bool ignoreUnsupportedPragmas = false, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool noSharedAccess = false, bool previewIn = false, bool shortenedMethods = false, bool betterC = false, bool addMain = false, bool allInst = false, bool fix16997 = true, bool fixAliasThis = false, bool inclusiveInContracts = false, bool ehnogc = false, FeatureState dtorFields = (FeatureState)-1, bool fieldwise = false, bool rvalueRefParam = false, CppStdRevision cplusplus = (CppStdRevision)201103u, bool markdown = true, bool vmarkdown = false, bool showGaggedErrors = false, bool printErrorContext = false, bool manual = false, bool usage = false, bool mcpuUsage = false, bool transitionUsage = false, bool checkUsage = false, bool checkActionUsage = false, bool revertUsage = false, bool previewUsage = false, bool externStdUsage = false, bool hcUsage = false, bool logo = false, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, uint32_t errorLimit = 20u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >* imppath = nullptr, Array<const char* >* fileImppath = nullptr, _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, bool doDocComments = false, _d_dynamicArray< const char > docdir = {}, _d_dynamicArray< const char > docname = {}, Array<const char* > ddocfiles = Array<const char* >(0LLU, {}, arrayliteral), bool doHdrGeneration = false, _d_dynamicArray< const char > hdrdir = {}, _d_dynamicArray< const char > hdrname = {}, bool hdrStripPlainFunctions = true, CxxHeaderMode doCxxHdrGeneration = (CxxHeaderMode)0u, _d_dynamicArray< const char > cxxhdrdir = {}, _d_dynamicArray< const char > cxxhdrname = {}, bool doJsonGeneration = false, _d_dynamicArray< const char > jsonfilename = {}, JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, OutBuffer* mixinOut = nullptr, const char* mixinFile = nullptr, int32_t mixinLines = 0, uint32_t debuglevel = 0u, Array<const char* >* debugids = nullptr, uint32_t versionlevel = 0u, Array<const char* >* versionids = nullptr, _d_dynamicArray< const char > defaultlibname = {}, _d_dynamicArray< const char > debuglibname = {}, _d_dynamicArray< const char > mscrtlib = {}, _d_dynamicArray< const char > moduleDepsFile = {}, OutBuffer* moduleDeps = nullptr, bool emitMakeDeps = false, _d_dynamicArray< const char > makeDepsFile = {}, Array<const char* > makeDeps = Array<const char* >(0LLU, {}, arrayliteral), MessageStyle messageStyle = (MessageStyle)0u, bool run = false, Array<const char* > runargs = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > objfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > linkswitches = Array<const char* >(0LLU, {}, arrayliteral), Array<bool > linkswitchIsForCC = Array<bool >(0LLU, {}, arrayliteral), Array<const char* > libfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > dllfiles = Array<const char* >(0LLU, {}, arrayliteral), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
+    Param(bool obj, bool link = true, bool dll = false, bool lib = false, bool multiobj = false, bool oneobj = false, bool trace = false, bool tracegc = false, bool verbose = false, bool vcg_ast = false, bool showColumns = false, bool vtls = false, bool vtemplates = false, bool vtemplatesListInstances = false, bool vgc = false, bool vfield = false, bool vcomplex = true, bool vin = false, uint8_t symdebug = 0u, bool symdebugref = false, bool optimize = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool stackstomp = false, bool useUnitTests = false, bool useInline = false, FeatureState useDIP25 = (FeatureState)-1, FeatureState useDIP1000 = (FeatureState)-1, bool useDIP1021 = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, PIC pic = (PIC)0u, bool color = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool nofloat = false, bool ignoreUnsupportedPragmas = false, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool noSharedAccess = false, bool previewIn = false, bool shortenedMethods = false, bool betterC = false, bool addMain = false, bool allInst = false, bool fix16997 = true, bool fixAliasThis = false, bool inclusiveInContracts = false, bool ehnogc = false, FeatureState dtorFields = (FeatureState)-1, bool fieldwise = false, bool rvalueRefParam = false, bool withExpressions = false, CppStdRevision cplusplus = (CppStdRevision)201103u, bool markdown = true, bool vmarkdown = false, bool showGaggedErrors = false, bool printErrorContext = false, bool manual = false, bool usage = false, bool mcpuUsage = false, bool transitionUsage = false, bool checkUsage = false, bool checkActionUsage = false, bool revertUsage = false, bool previewUsage = false, bool externStdUsage = false, bool hcUsage = false, bool logo = false, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, uint32_t errorLimit = 20u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >* imppath = nullptr, Array<const char* >* fileImppath = nullptr, _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, bool doDocComments = false, _d_dynamicArray< const char > docdir = {}, _d_dynamicArray< const char > docname = {}, Array<const char* > ddocfiles = Array<const char* >(0LLU, {}, arrayliteral), bool doHdrGeneration = false, _d_dynamicArray< const char > hdrdir = {}, _d_dynamicArray< const char > hdrname = {}, bool hdrStripPlainFunctions = true, CxxHeaderMode doCxxHdrGeneration = (CxxHeaderMode)0u, _d_dynamicArray< const char > cxxhdrdir = {}, _d_dynamicArray< const char > cxxhdrname = {}, bool doJsonGeneration = false, _d_dynamicArray< const char > jsonfilename = {}, JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, OutBuffer* mixinOut = nullptr, const char* mixinFile = nullptr, int32_t mixinLines = 0, uint32_t debuglevel = 0u, Array<const char* >* debugids = nullptr, uint32_t versionlevel = 0u, Array<const char* >* versionids = nullptr, _d_dynamicArray< const char > defaultlibname = {}, _d_dynamicArray< const char > debuglibname = {}, _d_dynamicArray< const char > mscrtlib = {}, _d_dynamicArray< const char > moduleDepsFile = {}, OutBuffer* moduleDeps = nullptr, bool emitMakeDeps = false, _d_dynamicArray< const char > makeDepsFile = {}, Array<const char* > makeDeps = Array<const char* >(0LLU, {}, arrayliteral), MessageStyle messageStyle = (MessageStyle)0u, bool run = false, Array<const char* > runargs = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > objfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > linkswitches = Array<const char* >(0LLU, {}, arrayliteral), Array<bool > linkswitchIsForCC = Array<bool >(0LLU, {}, arrayliteral), Array<const char* > libfiles = Array<const char* >(0LLU, {}, arrayliteral), Array<const char* > dllfiles = Array<const char* >(0LLU, {}, arrayliteral), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
         obj(obj),
         link(link),
         dll(dll),
@@ -765,6 +767,7 @@ struct Param final
         dtorFields(dtorFields),
         fieldwise(fieldwise),
         rvalueRefParam(rvalueRefParam),
+        withExpressions(withExpressions),
         cplusplus(cplusplus),
         markdown(markdown),
         vmarkdown(vmarkdown),
@@ -888,7 +891,7 @@ struct Global final
         varSequenceNumber(1u)
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, 0u, false, false, (DiagnosticReporting)1u, false, false, false, (FeatureState)-1, (FeatureState)-1, false, false, false, (DiagnosticReporting)2u, (PIC)0u, false, false, 0u, false, false, false, true, true, true, false, false, false, false, false, false, true, false, false, false, (FeatureState)-1, false, false, (CppStdRevision)201103u, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKACTION)0u, 20u, {}, Array<const char* >(0LLU, {}, arrayliteral), nullptr, nullptr, {}, {}, {}, false, {}, {}, Array<const char* >(0LLU, {}, arrayliteral), false, {}, {}, true, (CxxHeaderMode)0u, {}, {}, false, {}, (JsonFieldFlags)0u, nullptr, nullptr, 0, 0u, nullptr, 0u, nullptr, {}, {}, {}, {}, nullptr, false, {}, Array<const char* >(0LLU, {}, arrayliteral), (MessageStyle)0u, false, Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<bool >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), {}, {}, {}, {}), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, 0u, false, false, (DiagnosticReporting)1u, false, false, false, (FeatureState)-1, (FeatureState)-1, false, false, false, (DiagnosticReporting)2u, (PIC)0u, false, false, 0u, false, false, false, true, true, true, false, false, false, false, false, false, true, false, false, false, (FeatureState)-1, false, false, false, (CppStdRevision)201103u, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKENABLE)0u, (CHECKACTION)0u, 20u, {}, Array<const char* >(0LLU, {}, arrayliteral), nullptr, nullptr, {}, {}, {}, false, {}, {}, Array<const char* >(0LLU, {}, arrayliteral), false, {}, {}, true, (CxxHeaderMode)0u, {}, {}, false, {}, (JsonFieldFlags)0u, nullptr, nullptr, 0, 0u, nullptr, 0u, nullptr, {}, {}, {}, {}, nullptr, false, {}, Array<const char* >(0LLU, {}, arrayliteral), (MessageStyle)0u, false, Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<bool >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), Array<const char* >(0LLU, {}, arrayliteral), {}, {}, {}, {}), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u) :
         inifilename(inifilename),
         copyright(copyright),
         written(written),
@@ -1319,99 +1322,100 @@ enum class EXP : uint8_t
     thrownException = 39u,
     delegatePointer = 40u,
     delegateFunctionPointer = 41u,
-    lessThan = 42u,
-    greaterThan = 43u,
-    lessOrEqual = 44u,
-    greaterOrEqual = 45u,
-    equal = 46u,
-    notEqual = 47u,
-    identity = 48u,
-    notIdentity = 49u,
-    index = 50u,
-    is_ = 51u,
-    leftShift = 52u,
-    rightShift = 53u,
-    leftShiftAssign = 54u,
-    rightShiftAssign = 55u,
-    unsignedRightShift = 56u,
-    unsignedRightShiftAssign = 57u,
-    concatenate = 58u,
-    concatenateAssign = 59u,
-    concatenateElemAssign = 60u,
-    concatenateDcharAssign = 61u,
-    add = 62u,
-    min = 63u,
-    addAssign = 64u,
-    minAssign = 65u,
-    mul = 66u,
-    div = 67u,
-    mod = 68u,
-    mulAssign = 69u,
-    divAssign = 70u,
-    modAssign = 71u,
-    and_ = 72u,
-    or_ = 73u,
-    xor_ = 74u,
-    andAssign = 75u,
-    orAssign = 76u,
-    xorAssign = 77u,
-    assign = 78u,
-    not_ = 79u,
-    tilde = 80u,
-    plusPlus = 81u,
-    minusMinus = 82u,
-    construct = 83u,
-    blit = 84u,
-    dot = 85u,
-    comma = 86u,
-    question = 87u,
-    andAnd = 88u,
-    orOr = 89u,
-    prePlusPlus = 90u,
-    preMinusMinus = 91u,
-    identifier = 92u,
-    string_ = 93u,
-    this_ = 94u,
-    super_ = 95u,
-    halt = 96u,
-    tuple = 97u,
-    error = 98u,
-    void_ = 99u,
-    int64 = 100u,
-    float64 = 101u,
-    complex80 = 102u,
-    char_ = 103u,
-    import_ = 104u,
-    delegate_ = 105u,
-    function_ = 106u,
-    mixin_ = 107u,
-    in_ = 108u,
-    default_ = 109u,
-    break_ = 110u,
-    continue_ = 111u,
-    goto_ = 112u,
-    scope_ = 113u,
-    traits = 114u,
-    overloadSet = 115u,
-    line = 116u,
-    file = 117u,
-    fileFullPath = 118u,
-    moduleString = 119u,
-    functionString = 120u,
-    prettyFunction = 121u,
-    shared_ = 122u,
-    pow = 123u,
-    powAssign = 124u,
-    vector = 125u,
-    voidExpression = 126u,
-    cantExpression = 127u,
-    showCtfeContext = 128u,
-    objcClassReference = 129u,
-    vectorArray = 130u,
-    arrow = 131u,
-    compoundLiteral = 132u,
-    _Generic = 133u,
-    interval = 134u,
+    withExp = 42u,
+    lessThan = 43u,
+    greaterThan = 44u,
+    lessOrEqual = 45u,
+    greaterOrEqual = 46u,
+    equal = 47u,
+    notEqual = 48u,
+    identity = 49u,
+    notIdentity = 50u,
+    index = 51u,
+    is_ = 52u,
+    leftShift = 53u,
+    rightShift = 54u,
+    leftShiftAssign = 55u,
+    rightShiftAssign = 56u,
+    unsignedRightShift = 57u,
+    unsignedRightShiftAssign = 58u,
+    concatenate = 59u,
+    concatenateAssign = 60u,
+    concatenateElemAssign = 61u,
+    concatenateDcharAssign = 62u,
+    add = 63u,
+    min = 64u,
+    addAssign = 65u,
+    minAssign = 66u,
+    mul = 67u,
+    div = 68u,
+    mod = 69u,
+    mulAssign = 70u,
+    divAssign = 71u,
+    modAssign = 72u,
+    and_ = 73u,
+    or_ = 74u,
+    xor_ = 75u,
+    andAssign = 76u,
+    orAssign = 77u,
+    xorAssign = 78u,
+    assign = 79u,
+    not_ = 80u,
+    tilde = 81u,
+    plusPlus = 82u,
+    minusMinus = 83u,
+    construct = 84u,
+    blit = 85u,
+    dot = 86u,
+    comma = 87u,
+    question = 88u,
+    andAnd = 89u,
+    orOr = 90u,
+    prePlusPlus = 91u,
+    preMinusMinus = 92u,
+    identifier = 93u,
+    string_ = 94u,
+    this_ = 95u,
+    super_ = 96u,
+    halt = 97u,
+    tuple = 98u,
+    error = 99u,
+    void_ = 100u,
+    int64 = 101u,
+    float64 = 102u,
+    complex80 = 103u,
+    char_ = 104u,
+    import_ = 105u,
+    delegate_ = 106u,
+    function_ = 107u,
+    mixin_ = 108u,
+    in_ = 109u,
+    default_ = 110u,
+    break_ = 111u,
+    continue_ = 112u,
+    goto_ = 113u,
+    scope_ = 114u,
+    traits = 115u,
+    overloadSet = 116u,
+    line = 117u,
+    file = 118u,
+    fileFullPath = 119u,
+    moduleString = 120u,
+    functionString = 121u,
+    prettyFunction = 122u,
+    shared_ = 123u,
+    pow = 124u,
+    powAssign = 125u,
+    vector = 126u,
+    voidExpression = 127u,
+    cantExpression = 128u,
+    showCtfeContext = 129u,
+    objcClassReference = 130u,
+    vectorArray = 131u,
+    arrow = 132u,
+    compoundLiteral = 133u,
+    _Generic = 134u,
+    interval = 135u,
 };
 
 typedef uint64_t dinteger_t;
@@ -2434,6 +2438,7 @@ public:
     virtual void visit(typename AST::ImportExp e);
     virtual void visit(typename AST::DotTemplateInstanceExp e);
     virtual void visit(typename AST::ArrayExp e);
+    virtual void visit(typename AST::WithExp e);
     virtual void visit(typename AST::FuncInitExp e);
     virtual void visit(typename AST::PrettyFuncInitExp e);
     virtual void visit(typename AST::FileInitExp e);
@@ -4813,6 +4818,7 @@ struct ASTCodegen final
     using VectorArrayExp = ::VectorArrayExp;
     using VectorExp = ::VectorExp;
     using VoidInitExp = ::VoidInitExp;
+    using WithExp = ::WithExp;
     using XorAssignExp = ::XorAssignExp;
     using XorExp = ::XorExp;
     using emplaceExp = ::emplaceExp;
@@ -6706,8 +6712,13 @@ public:
 
 class IdentifierExp : public Expression
 {
+    union
+    {
+        Identifier* ident;
+        DotIdExp* symbolWithIdent;
+    };
 public:
-    Identifier* ident;
+    bool hasBeenRewritten;
     static IdentifierExp* create(const Loc& loc, Identifier* ident);
     bool isLvalue();
     Expression* toLvalue(Scope* sc, Expression* e);
@@ -7225,6 +7236,14 @@ public:
     static VectorExp* create(const Loc& loc, Expression* e, Type* t);
     static void emplace(UnionExp* pue, const Loc& loc, Expression* e, Type* type);
     VectorExp* syntaxCopy();
+    void accept(Visitor* v);
+};
+
+class WithExp final : public UnaExp
+{
+public:
+    Expression* wrt;
+    WithExp* syntaxCopy();
     void accept(Visitor* v);
 };
 
@@ -8013,6 +8032,7 @@ public:
     void visit(PostExp* e);
     void visit(CondExp* e);
     void visit(GenericExp* e);
+    void visit(WithExp* e);
     void visit(ThrowExp* e);
     void visit(TemplateTypeParameter* tp);
     void visit(TemplateThisParameter* tp);

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -166,6 +166,7 @@ extern (C++) struct Param
                             // https://gist.github.com/andralex/e5405a5d773f07f73196c05f8339435a
                             // https://digitalmars.com/d/archives/digitalmars/D/Binding_rvalues_to_ref_parameters_redux_325087.html
                             // Implementation: https://github.com/dlang/dmd/pull/9817
+    bool withExpressions = false;
 
     CppStdRevision cplusplus = CppStdRevision.cpp11;    // version of C++ standard to support
 

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2541,6 +2541,16 @@ public:
     {
         buf.writestring(e.value.toChars());
     }
+
+    override void visit(WithExp we)
+    {
+        buf.writestring("with(");
+        expToBuffer(we.wrt, precedence[we.op], buf, hgs);
+        buf.writeByte(')');
+        buf.writeByte('(');
+        expToBuffer(we.e1, precedence[we.op], buf, hgs);
+        buf.writeByte(')');
+    }
 }
 
 /**
@@ -4002,6 +4012,7 @@ string EXPtoString(EXP op)
         EXP.new_ : "new",
         EXP.newAnonymousClass : "newanonclass",
         EXP.cast_ : "cast",
+        EXP.withExp : "with",
 
         EXP.vector : "__vector",
         EXP.pow : "^^",

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -8452,7 +8452,20 @@ LagainStc:
             e = parseUnaryExp();
             e = new AST.DeleteExp(loc, e, false);
             break;
-
+        case TOK.with_:
+            {
+                if (!global.params.withExpressions)
+                    error("with expressions are not enabled — enable them with `-preview=withExpressions`");
+                //with expression - with(x) y;
+                nextToken();
+                check(TOK.leftParenthesis);
+                auto lhs = parseAssignExp();
+                check(TOK.rightParenthesis);
+                auto rhs = parseUnaryExp();
+                //First expression parameter to the constructor is y
+                e = new AST.WithExp(loc, rhs, lhs);
+                break;
+            }
         case TOK.cast_: // cast(type) expression
             {
                 nextToken();
@@ -9417,6 +9430,7 @@ immutable PREC[EXP.max + 1] precedence =
     EXP.newAnonymousClass : PREC.unary,
     EXP.cast_ : PREC.unary,
     EXP.throw_ : PREC.unary,
+    EXP.withExp: PREC.unary,
 
     EXP.vector : PREC.unary,
     EXP.pow : PREC.pow,

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -224,7 +224,7 @@ public:
     void visit(AST.ImportExp e) { visit(cast(AST.UnaExp)e); }
     void visit(AST.DotTemplateInstanceExp e) { visit(cast(AST.UnaExp)e); }
     void visit(AST.ArrayExp e) { visit(cast(AST.UnaExp)e); }
-
+    void visit(AST.WithExp e) { visit(cast(AST.UnaExp)e); }
     // DefaultInitExp
     void visit(AST.FuncInitExp e) { visit(cast(AST.DefaultInitExp)e); }
     void visit(AST.PrettyFuncInitExp e) { visit(cast(AST.DefaultInitExp)e); }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3436,7 +3436,6 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
     {
         /* https://dlang.org/spec/statement.html#with-statement
          */
-
         ScopeDsymbol sym;
         Initializer _init;
 

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -323,6 +323,7 @@ enum EXP : ubyte
     thrownException,
     delegatePointer,
     delegateFunctionPointer,
+    withExp,
 
     // Operators
     lessThan,

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -1136,7 +1136,11 @@ package mixin template ParseVisitMethods(AST)
             (*e.exps )[i].accept(this);
         }
     }
-
+    override void visit(AST.WithExp e)
+    {
+        e.wrt.accept(this);
+        e.e1.accept(this);
+    }
     override void visit(AST.ThrowExp e)
     {
         //printf("Visiting ThrowExp\n");

--- a/test/runnable/withexpression.d
+++ b/test/runnable/withexpression.d
@@ -1,0 +1,76 @@
+// https://issues.dlang.org/show_bug.cgi?id=21538
+// REQUIRED_ARGS: -preview=withExpressions
+
+//This is a runnable test so the final code generation is tested properly
+
+struct Type
+{
+    int x;
+    int y;
+}
+class Test
+{
+    int x;
+    this(int i)
+    {
+        x = i;
+    }
+}
+struct HasStatic
+{
+    static int chimpanzee = 299;
+}
+Type grab()
+{
+    return Type(45, 100);
+}
+//grab() but counts how many times it was called
+static int count = 0;
+Type countingGrab()
+{
+    ++count;
+    return grab();
+}
+void testThunk(alias fun)(const int res)
+{
+    assert(fun() == res);
+}
+int inc(const int x)
+{
+    return x + 1;
+}
+int main()
+{
+    const t = Type(4, 5);
+    const int res = with(t)(x + y);
+    assert(res == 9);
+
+    testThunk!(() => with(grab())(x + y))(145);
+
+    testThunk!(() => with(countingGrab())(x + y))(145);
+    assert(count == 1);
+
+    Type l, r;
+    with(l) with(r) y = 420;
+    assert(l.y == 0);
+    assert(r.y == 420);
+
+    const int xyz = with(new Test(420)) x;
+    assert(xyz==420);
+
+    Type viaPtr = Type(2, 3);
+    with(&viaPtr) {
+        x = 420;
+    }
+    assert((with(&viaPtr) x) == 420);
+
+    with(HasStatic)
+    {
+        chimpanzee = 420;
+    }
+    const int moo = with(HasStatic()) chimpanzee;
+    assert(moo == 420);
+
+    testThunk!(() => with(grab()) inc(x))(46);
+    return 0;
+}


### PR DESCRIPTION
I've definitely missed some things but this is enough to be reviewed (i.e. non-draft).

I haven't decided what to do with the `union` usage yet. Hypothetically one could use the same symbol table thing the WithStatements use and avoid any such thing entirely, but this seemed very ugly i.e. dmd already conflates a bunch of things behind it's back as is so making `Scope` granular on the level of expressions is a bit ridiculous in my mind.