### PR TITLE
Fix 22858 - Don't skip alignment of zero-sized fields

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -547,7 +547,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         if (overflow) assert(0);
 
         // Skip no-op for noreturn without custom aligment
-        if (memsize != 0 || !alignment.isDefault())
+        if (memalignsize != 0 || !alignment.isDefault())
             alignmember(alignment, memalignsize, &ofs);
 
         uint memoffset = ofs;

--- a/test/compilable/noreturn3.d
+++ b/test/compilable/noreturn3.d
@@ -229,3 +229,19 @@ struct EmptyStruct2
 
 static assert(EmptyStruct2.sizeof == 1);
 static assert(EmptyStruct2.noRet.offsetof == 0);
+
+// https://issues.dlang.org/show_bug.cgi?id=22858
+// Shouldn't mess with the alignment of other zero-sized types.
+
+struct S22858
+{
+    int a;
+    void*[0] arr;
+    char c;
+    noreturn[0] arr2;
+    char c2;
+}
+
+static assert (S22858.arr.offsetof % size_t.sizeof == 0);
+static assert (S22858.arr2.offsetof == S22858.c.offsetof + 1);
+static assert (S22858.arr2.offsetof == S22858.c2.offsetof);


### PR DESCRIPTION
The exception for `noreturn` should've checked for `T.alignof == 0`
instead of `T.sizeof == 0` which also applies to zero-sized arrays.