### PR TITLE
.cirrus.yml: Add test_dub_package_script instruction

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,6 +35,7 @@ common_steps_template: &COMMON_STEPS_TEMPLATE
       ./ci/run.sh test_dmd
     fi
 
+  test_dub_package_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci/run.sh test_dub_package
   test_druntime_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci/run.sh test_druntime
   test_phobos_script: \[ "${DMD_TEST_COVERAGE:-0}" == "1" \] || ./ci/run.sh test_phobos
 

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -2800,7 +2800,6 @@ Params:
 Returns:
   A D module
 */
-private
 Module createModule(const(char)* file, ref Strings libmodules, const ref Target target)
 {
     const(char)[] name;

--- a/test/dub_package/retrieveScope.d
+++ b/test/dub_package/retrieveScope.d
@@ -30,6 +30,7 @@ import dmd.dsymbolsem;
 import dmd.semantic2;
 import dmd.semantic3;
 import dmd.statement;
+import dmd.target;
 import dmd.visitor;
 import dmd.dscope;
 import dmd.denum;
@@ -79,7 +80,7 @@ int main()
 
     Strings libmodules;
     Module m = createModule((dirName(__FILE_FULL_PATH__) ~ "/testfiles/correct.d").ptr,
-                                libmodules);
+                                libmodules, target);
     m.importedFrom = m; // m.isRoot() == true
 
     m.read(Loc.initial);


### PR DESCRIPTION
This stopped being tested when the [semaphoreci.sh](https://github.com/dlang/dmd/blob/fe4ade5b7c3d88120d92f52dcc48a166df7bd38b/semaphoreci.sh#L43) script [was removed](https://github.com/dlang/dmd/blob/fe4ade5b7c3d88120d92f52dcc48a166df7bd38b/ci.sh#L90-L95) in a [previous PR](https://github.com/dlang/dmd/pull/13474).