### PR TITLE
Fix issue 22862: Remove error when overloading two D functions with the same parameters. (Change)

### DIFF
--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -419,14 +419,14 @@ private extern(C++) final class Semantic2Visitor : Visitor
                     return 0;
 
                 const sameAttr = tf1.attributesEqual(tf2);
-                const sameParams = tf1.parameterList == tf2.parameterList;
+                const sameParamsReturn = tf1.parameterList == tf2.parameterList && tf1.next == tf2.next;
 
                 // Allow the hack to declare overloads with different parameters/STC's
                 // @@@DEPRECATED_2.104@@@
                 // Deprecated in 2020-08, make this an error in 2.104
                 if (parent1.isModule() &&
                     f1.linkage != LINK.d && f1.linkage != LINK.cpp &&
-                    (!sameAttr || !sameParams)
+                    (!sameAttr || !sameParamsReturn)
                 )
                 {
                     f2.deprecation("cannot overload `extern(%s)` function at %s",
@@ -435,8 +435,8 @@ private extern(C++) final class Semantic2Visitor : Visitor
                     return 0;
                 }
 
-                // Different parameters don't conflict in extern(C++/D)
-                if (!sameParams)
+                // Different parameters/return type don't conflict in extern(C++/D)
+                if (!sameParamsReturn)
                     return 0;
 
                 // Different attributes don't conflict in extern(D)
@@ -450,6 +450,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
                         f1.loc.toChars());
                 f2.type = Type.terror;
                 f2.errors = true;
+
                 return 0;
             });
         }

--- a/test/fail_compilation/fail2789.d
+++ b/test/fail_compilation/fail2789.d
@@ -1,40 +1,8 @@
 /*
-https://issues.dlang.org/show_bug.cgi?id=18385
-
 TEST_OUTPUT:
 ---
-fail_compilation/fail2789.d(15): Error: function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(10)
----
-*/
-#line 7
-
-class A2789
-{
-    int m()
-    {
-        return 1;
-    }
-
-    float m()       // conflict
-    {
-        return 2.0;
-    }
-
-    float m() const // doen't conflict
-    {
-        return 3.0;
-    }
-
-    static void m() // no conflict
-    {
-    }
-}
-
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail2789.d(49): Error: function `fail2789.f4()` conflicts with previous declaration at fail_compilation/fail2789.d(48)
-fail_compilation/fail2789.d(55): Error: function `fail2789.f6()` conflicts with previous declaration at fail_compilation/fail2789.d(54)
+fail_compilation/fail2789.d(20): Error: function `fail2789.f4()` conflicts with previous declaration at fail_compilation/fail2789.d(19)
+fail_compilation/fail2789.d(26): Error: function `fail2789.f6()` conflicts with previous declaration at fail_compilation/fail2789.d(25)
 ---
 */
 
@@ -60,9 +28,9 @@ auto f6() { return ""; }    // string(), conflict
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2789.d(67): Error: function `fail2789.f_ExternC1()` conflicts with previous declaration at fail_compilation/fail2789.d(66)
-fail_compilation/fail2789.d(70): Deprecation: function `fail2789.f_ExternC2` cannot overload `extern(C)` function at fail_compilation/fail2789.d(69)
-fail_compilation/fail2789.d(73): Deprecation: function `fail2789.f_ExternC3` cannot overload `extern(C)` function at fail_compilation/fail2789.d(72)
+fail_compilation/fail2789.d(38): Error: function `fail2789.f_ExternC1()` conflicts with previous declaration at fail_compilation/fail2789.d(37)
+fail_compilation/fail2789.d(41): Deprecation: function `fail2789.f_ExternC2` cannot overload `extern(C)` function at fail_compilation/fail2789.d(40)
+fail_compilation/fail2789.d(44): Deprecation: function `fail2789.f_ExternC3` cannot overload `extern(C)` function at fail_compilation/fail2789.d(43)
 ---
 */
 
@@ -93,7 +61,7 @@ extern (C) void f_ExternC6(int sig) @nogc {}    // no error
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2789.d(103): Error: function `fail2789.mul14147(const(int[]) left, const(int[]) right)` conflicts with previous declaration at fail_compilation/fail2789.d(99)
+fail_compilation/fail2789.d(74): Error: function `fail2789.mul14147(const(int[]) left, const(int[]) right)` conflicts with previous declaration at fail_compilation/fail2789.d(70)
 ---
 */
 struct S14147(alias func)

--- a/test/runnable/test22862.d
+++ b/test/runnable/test22862.d
@@ -1,0 +1,11 @@
+module test22862;
+
+int fun() { return 1; }
+string fun() { return "hello"; }
+
+void main() {
+    // fun can only be called by selecting a specific overload
+    static assert(!__traits(compiles, fun()));
+    assert(__traits(getOverloads, test22862, "fun")[0]() == 1);
+    assert(__traits(getOverloads, test22862, "fun")[1]() == "hello");
+}


### PR DESCRIPTION
As far as I can tell, this error is not required by the spec.

Attempts to actually call such an overloaded function directly will still fail with an ambiguity error.

However, this change will make it possible to select an overload to call based on inspecting the return type directly. This will remove the issue I have in `serialized` where syntax errors in decode functions cannot be easily detected, because it will allow me to use an overload set of normal functions (even if the parameter, for instance, `JSONValue` appears multiple times) rather than specialized templates.

edit: Changed error to still trigger if two functions have the same parameters and return type. (Ie. same mangling.)