### PR TITLE
Add a `FunctionFlag` for `return scope`

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3567,6 +3567,7 @@ private:
         inoutParam = 1024u,
         inoutQual = 2048u,
         isctor = 4096u,
+        isreturnscope = 8192u,
     };
 
 public:
@@ -3597,6 +3598,8 @@ public:
     void isref(bool v);
     bool isreturn() const;
     void isreturn(bool v);
+    bool isreturnscope() const;
+    void isreturnscope(bool v);
     bool isScopeQual() const;
     void isScopeQual(bool v);
     bool isreturninferred() const;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4214,6 +4214,7 @@ extern (C++) final class TypeFunction : TypeNext
         inoutParam      = 0x0400, // inout on the parameters
         inoutQual       = 0x0800, // inout on the qualifier
         isctor          = 0x1000, // the function is a constructor
+        isreturnscope   = 0x2000, // `this` is returned by value
     }
 
     LINK linkage;               // calling convention
@@ -4247,6 +4248,8 @@ extern (C++) final class TypeFunction : TypeNext
             this.isref = true;
         if (stc & STC.return_)
             this.isreturn = true;
+        if (stc & STC.returnScope)
+            this.isreturnscope = true;
         if (stc & STC.returninferred)
             this.isreturninferred = true;
         if (stc & STC.scope_)
@@ -4285,6 +4288,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isproperty = isproperty;
         t.isref = isref;
         t.isreturn = isreturn;
+        t.isreturnscope = isreturnscope;
         t.isScopeQual = isScopeQual;
         t.isreturninferred = isreturninferred;
         t.isscopeinferred = isscopeinferred;
@@ -4507,6 +4511,7 @@ extern (C++) final class TypeFunction : TypeNext
             tf.isproperty = t.isproperty;
             tf.isref = t.isref;
             tf.isreturn = t.isreturn;
+            tf.isreturnscope = t.isreturnscope;
             tf.isScopeQual = t.isScopeQual;
             tf.isreturninferred = t.isreturninferred;
             tf.isscopeinferred = t.isscopeinferred;
@@ -4573,6 +4578,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isproperty = isproperty;
         t.isref = isref;
         t.isreturn = isreturn;
+        t.isreturnscope = isreturnscope;
         t.isScopeQual = isScopeQual;
         t.isreturninferred = isreturninferred;
         t.isscopeinferred = isscopeinferred;
@@ -5134,6 +5140,18 @@ extern (C++) final class TypeFunction : TypeNext
     {
         if (v) funcFlags |= FunctionFlag.isreturn;
         else funcFlags &= ~FunctionFlag.isreturn;
+    }
+
+    /// set or get if the function has the `returnscope` attribute
+    bool isreturnscope() const pure nothrow @safe @nogc
+    {
+        return (funcFlags & FunctionFlag.isreturnscope) != 0;
+    }
+    /// ditto
+    void isreturnscope(bool v) pure nothrow @safe @nogc
+    {
+        if (v) funcFlags |= FunctionFlag.isreturnscope;
+        else funcFlags &= ~FunctionFlag.isreturnscope;
     }
 
     /// set or get if the function has the `scope` attribute

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -625,6 +625,8 @@ public:
     void isref(bool v);
     bool isreturn() const;
     void isreturn(bool v);
+    bool isreturnscope() const;
+    void isreturnscope(bool v);
     bool isScopeQual() const;
     void isScopeQual(bool v);
     bool isreturninferred() const;

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1192,6 +1192,8 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             tf.isref = true;
         if (sc.stc & STC.return_)
             tf.isreturn = true;
+        if (sc.stc & STC.returnScope)
+            tf.isreturnscope = true;
         if (sc.stc & STC.returninferred)
             tf.isreturninferred = true;
         if (sc.stc & STC.scope_)


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/13357 would set `STC.returnScope_` for member functions with `return scope` annotations in that order. However, this information isn't accessible yet since it is not propagated to the flags in `TypeFunction`. This PR fixes that.

This is split off from https://github.com/dlang/dmd/pull/13693 because Walter prefers small incremental pull requests.