### PR TITLE
Template Parser with Lexer argument

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -30,7 +30,7 @@ import dmd.tokens;
 
 /***********************************************************
  */
-class Parser(AST) : Lexer
+class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 {
     AST.ModuleDeclaration* md;
 


### PR DESCRIPTION
Before this PR, the parser was simply inheriting the lexer which made it impossible to use it with a different lexer than the dmd one.

Previous rejected attempts:

- Adding a lexer field to the parser and prefixing all uses of lexer methods with `lexer.`: https://github.com/dlang/dmd/pull/9475
- Adding a lexer field and using alias this: https://github.com/dlang/dmd/pull/9899

This PR templates the parser with a lexer type that is inherited. This allows to select the lexer by passing it as a template parameter. 

Advantages:
- simple, easy to understand one-liner
- offers maximum flexibility

Disadvantages:
- Still uses inheritance