### PR TITLE
Fix 22868 - Let __traits(parameters) see past opApply delegates

### DIFF
--- a/changelog/TraitsParametersRevised.dd
+++ b/changelog/TraitsParametersRevised.dd
@@ -1,0 +1,33 @@
+Special case for `__traits(parameters)` in foreach loops was removed
+
+Previously, when used inside a `foreach` using an overloaded `opApply`, the trait
+would yield the parameters to the delegate and not the function the foreach appears within.
+
+This behaviour is unintuitive, especially when the type of the `foreach` aggregate
+depends on a template parameter. Hence `__traits(parameters)` was changed to consistently
+return the parameters of the lexically enclosing function.
+
+---
+class Tree {
+    int opApply(int delegate(size_t, Tree) dg) {
+        if (dg(0, this)) return 1;
+        return 0;
+    }
+}
+void useOpApply(Tree top, int x)
+{
+    foreach(idx; 0..5)
+    {
+        static assert(is(typeof(__traits(parameters)) == AliasSeq!(Tree, int)));
+    }
+
+    foreach(idx, elem; top)
+    {
+        // Previously:
+        // static assert(is(typeof(__traits(parameters)) == AliasSeq!(size_t, Tree)));
+
+        // Now:
+        static assert(is(typeof(__traits(parameters)) == AliasSeq!(Tree, int)));
+    }
+}
+---

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -708,6 +708,31 @@ struct Scope
         return null;
     }
 
+    /********************************************
+     * Find the lexically enclosing function (if any).
+     *
+     * This function skips through generated FuncDeclarations,
+     * e.g. rewritten foreach bodies.
+     *
+     * Returns: the function or null
+     */
+    inout(FuncDeclaration) getEnclosingFunction() inout
+    {
+        if (!this.func)
+            return null;
+
+        auto fd = cast(FuncDeclaration) this.func;
+
+        // Look through foreach bodies rewritten as delegates
+        while (fd.fes)
+        {
+            assert(fd.fes.func);
+            fd = fd.fes.func;
+        }
+
+        return cast(inout(FuncDeclaration)) fd;
+    }
+
     /*******************************************
      * For TemplateDeclarations, we need to remember the Scope
      * where it was declared. So mark the Scope as not

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -2104,13 +2104,14 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             return ErrorExp.get();
         }
 
-        if (sc.func is null)
+        auto fd = sc.getEnclosingFunction();
+        if (!fd)
         {
             e.error("`__traits(parameters)` may only be used inside a function");
             return ErrorExp.get();
         }
-        assert(sc.func && sc.parent.isFuncDeclaration());
-        auto tf = sc.parent.isFuncDeclaration.type.isTypeFunction();
+
+        auto tf = fd.type.isTypeFunction();
         assert(tf);
         auto exps = new Expressions(0);
         int addParameterDG(size_t idx, Parameter x)

--- a/test/compilable/fix22291.d
+++ b/test/compilable/fix22291.d
@@ -20,6 +20,33 @@ int echoPlusOne(int x)
     return x;
 }
 static assert(echoPlusOne(1) == 2);
+
+void nesting(double d, int i)
+{
+    alias EXP = AliasSeq!(d, i);
+
+    if (d)
+    {
+        static assert(__traits(isSame, __traits(parameters), EXP));
+
+        while (d)
+        {
+            static assert(__traits(isSame, __traits(parameters), EXP));
+            switch (i)
+            {
+                static assert(__traits(isSame, __traits(parameters), EXP));
+                case 1:
+                    static assert(__traits(isSame, __traits(parameters), EXP));
+                    break;
+
+                default:
+                    static assert(__traits(isSame, __traits(parameters), EXP));
+                    break;
+            }
+        }
+    }
+}
+
 class Tree {
     int opApply(int delegate(size_t, Tree) dg) {
         if (dg(0, this)) return 1;
@@ -34,7 +61,22 @@ void useOpApply(Tree top, int x)
     }
     foreach(idx, elem; top)
     {
-        static assert(is(typeof(__traits(parameters)) == AliasSeq!(size_t, Tree)));
+        static assert(is(typeof(__traits(parameters)) == AliasSeq!(Tree, int)));
+    }
+
+    foreach(idx, elem; top)
+    {
+        foreach (idx2, elem2; elem)
+            static assert(is(typeof(__traits(parameters)) == AliasSeq!(Tree, int)));
+    }
+
+    foreach(idx, elem; top)
+    {
+        static void foo(char[] text)
+        {
+            foreach (const char c; text)
+                static assert(is(typeof(__traits(parameters)) == AliasSeq!(char[])));
+        }
     }
 }
 class Test
@@ -132,3 +174,70 @@ T testTemplate(T)(scope T input)
 
 static assert(testTemplate!long(420) == 0);
 
+void qualifiers(immutable int a, const bool b)
+{
+    static assert(is(typeof(__traits(parameters)) == AliasSeq!(immutable int, const bool)));
+}
+
+int makeAggregate(int a, bool b)
+{
+    struct S
+    {
+        typeof(__traits(parameters)) members;
+    }
+
+    S s = S(__traits(parameters));
+    assert(s.members[0] == a);
+    assert(s.members[1] == b);
+    return 1;
+}
+
+static assert(makeAggregate(5, true));
+
+int makeAlias(int a, bool b)
+{
+    alias Params = __traits(parameters);
+    version (Fixed) {
+    assert(Params[0] == 3);
+    assert(Params[1] == true);
+    }
+    return 1;
+}
+
+static assert(makeAlias(3, true));
+
+
+mixin template nestedCheckParameters(int unique)
+{
+    alias NestedNames = __traits(parameters);
+    version (Fixed)
+    alias Types = typeof(Names);
+}
+
+mixin template checkParameters(int unique)
+{
+    mixin nestedCheckParameters!unique;
+
+    alias Names = __traits(parameters);
+    version (Fixed)
+    alias Types = typeof(Names);
+}
+
+int makeAggregateMixin(immutable int a, const bool b)
+{
+    mixin checkParameters!0;
+
+    struct S
+    {
+        mixin checkParameters!1;
+        version (Fixed)
+        typeof(Names) members;
+    }
+
+    version (Fixed) {
+    S s = S(Names);
+    assert(s.members[0] == a);
+    assert(s.members[1] == b);
+    }
+    return 1;
+}


### PR DESCRIPTION
Ensure that `__traits(parameters)` consistently returns the parameters
of the enclosing function and instead of the parameters of the
`opApply` delegate (leaking an implementation detail).

Also added a bunch of tests - the parts hidden by `version (Fixed)`
fail due to another bug.