### PR TITLE
Revert "fix Issue 22790 - ref-return-scope is always ref-return, scope, unless return-scope appear in that order "

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -575,7 +575,18 @@ extern (C++) class FuncDeclaration : Declaration
             if (tf.isScopeQual)
                 vthis.storage_class |= STC.scope_;
 
-            inferReturnScope(tf.isref, vthis.storage_class);
+            /* Add STC.returnScope like typesem.d does for TypeFunction parameters,
+             * at least it should be the same. At the moment, we'll just
+             * do existing practice. But we should examine how TypeFunction does
+             * it, for consistency.
+             */
+            if (global.params.useDIP1000 != FeatureState.enabled &&
+                !tf.isref && isRefReturnScope(vthis.storage_class))
+            {
+                /* if `ref return scope`, evaluate to `ref` `return scope`
+                 */
+                vthis.storage_class |= STC.returnScope;
+            }
         }
         if (flags & FUNCFLAG.inferScope && !(vthis.storage_class & STC.scope_))
             vthis.storage_class |= STC.maybescope;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -7361,29 +7361,6 @@ bool isCopyable(Type t)
     return true;
 }
 
-/*******************************************
- * Decide if ref-return-scope should be `ref` `return scope`.
- * Params:
- *    returnByRef = if function returns by ref
- *    stc = storage class to possibly adjust by addition of STC.returnScope
- */
-void inferReturnScope(bool returnByRef, ref StorageClass stc)
-{
-    /* The old way was a determination based on whether the return
-     * value was by ref or not. The new way is `return scope` is set
-     * only if the `return` is immediately followed by `scope`, which
-     * is done by the parser.
-     * Keep the old way to not break pre-dip1000 code.
-     */
-    if (global.params.useDIP1000 != FeatureState.enabled &&
-        !returnByRef && isRefReturnScope(stc))
-    {
-        /* if `ref return scope`, evaluate to `ref` `return scope`
-         */
-        stc |= STC.returnScope;
-    }
-}
-
 /***************************************
  * Computes how a parameter may be returned.
  * Shrinking the representation is necessary because StorageClass is so wide

--- a/test/compilable/scope.d
+++ b/test/compilable/scope.d
@@ -142,7 +142,7 @@ int f1_20682(return scope ref D d) @safe
     return d.pos;
 }
 
-ref int f2_20682(return ref scope D d) @safe
+ref int f2_20682(return scope ref D d) @safe
 {
     return d.pos;
 }

--- a/test/fail_compilation/test21912.d
+++ b/test/fail_compilation/test21912.d
@@ -32,12 +32,12 @@ Dg escapeAssign(int i, return scope Dg dg)
     return dg;
 }
 
-ref Dg identityR(ref scope return Dg dg)
+ref Dg identityR(ref return scope Dg dg)
 {
     return dg;
 }
 
-ref Dg escapeAssignRef(int i, ref scope return Dg dg)
+ref Dg escapeAssignRef(int i, ref return scope Dg dg)
 {
     dg = () => i;
     return dg;


### PR DESCRIPTION
Reverts dlang/dmd#13691. The PR broke the test suite and some outstanding review by @dkorpel wasn't resolved