### PR TITLE
Use `buildScopeRef` in escapeByX

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1707,9 +1707,10 @@ void escapeByValue(Expression e, EscapeByResults* er, bool live = false)
                     {
                         Parameter p = tf.parameterList[i - j];
                         const stc = tf.parameterStorageClass(null, p);
-                        if ((stc & (STC.scope_)) && (stc & STC.return_))
+                        ScopeRef psr = buildScopeRef(stc);
+                        if (psr == ScopeRef.ReturnScope || psr == ScopeRef.Ref_ReturnScope)
                             arg.accept(this);
-                        else if ((stc & (STC.ref_)) && (stc & STC.return_))
+                        else if (psr == ScopeRef.ReturnRef || psr == ScopeRef.ReturnRef_Scope)
                         {
                             if (tf.isref)
                             {
@@ -1967,9 +1968,10 @@ void escapeByRef(Expression e, EscapeByResults* er, bool live = false)
                         {
                             Parameter p = tf.parameterList[i - j];
                             const stc = tf.parameterStorageClass(null, p);
-                            if ((stc & (STC.out_ | STC.ref_)) && (stc & STC.return_))
+                            ScopeRef psr = buildScopeRef(stc);
+                            if (psr == ScopeRef.ReturnRef || psr == ScopeRef.ReturnRef_Scope)
                                 arg.accept(this);
-                            else if ((stc & STC.scope_) && (stc & STC.return_))
+                            else if (psr == ScopeRef.ReturnScope || psr == ScopeRef.Ref_ReturnScope)
                             {
                                 if (auto de = arg.isDelegateExp())
                                 {


### PR DESCRIPTION
When returning a parameter, the compiler uses `buildScopeRef` to determine whether it has the right `return ref` / `return scope` (introduced by https://github.com/dlang/dmd/pull/12909)
When analyzing whether arguments of a function call escape, the old way of inspecting individual `return` `scope` `ref` attributes is still used. This PR makes `escapeByValue` and `escapeByRef` use the new function as well.

This is split off from https://github.com/dlang/dmd/pull/13693