### PR TITLE
Fix 22871 - Support aliases to __traits(parameters)

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -3658,7 +3658,7 @@ class Parser(AST) : Lexer
 
         case TOK.traits:
             if (AST.TraitsExp te = cast(AST.TraitsExp) parsePrimaryExp())
-                if (te.ident && te.args)
+                if (te.ident)
                 {
                     t = new AST.TypeTraits(token.loc, te);
                     break;
@@ -9611,5 +9611,3 @@ private bool writeMixin(const(char)[] s, ref Loc loc)
 
     return true;
 }
-
-

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1800,6 +1800,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             mtype.exp.ident != Id.derivedMembers &&
             mtype.exp.ident != Id.getMember &&
             mtype.exp.ident != Id.parent &&
+            mtype.exp.ident != Id.parameters &&
             mtype.exp.ident != Id.child &&
             mtype.exp.ident != Id.toType &&
             mtype.exp.ident != Id.getOverloads &&

--- a/test/compilable/fix22291.d
+++ b/test/compilable/fix22291.d
@@ -197,10 +197,8 @@ static assert(makeAggregate(5, true));
 int makeAlias(int a, bool b)
 {
     alias Params = __traits(parameters);
-    version (Fixed) {
     assert(Params[0] == 3);
     assert(Params[1] == true);
-    }
     return 1;
 }
 
@@ -219,7 +217,6 @@ mixin template checkParameters(int unique)
     mixin nestedCheckParameters!unique;
 
     alias Names = __traits(parameters);
-    version (Fixed)
     alias Types = typeof(Names);
 }
 
@@ -230,14 +227,11 @@ int makeAggregateMixin(immutable int a, const bool b)
     struct S
     {
         mixin checkParameters!1;
-        version (Fixed)
         typeof(Names) members;
     }
 
-    version (Fixed) {
     S s = S(Names);
     assert(s.members[0] == a);
     assert(s.members[1] == b);
-    }
     return 1;
 }


### PR DESCRIPTION
The current implementation had two bugs preventing users from using
the tuple returned by `__traits(parameters)` bound to an alias:

- the parser rejected `typeof(__traits(X))`, i.e. a traits without
  parameters. Fixed by removing the check for existing arguments.
- type semantic rejected the alias as invalid and eagerly issued an
  error. Fixed by extending the list of viable traits.