### PR TITLE
dmd.expression: Emplace initializer on preallocated pointer instead of temporary

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -72,10 +72,15 @@ import dmd.typesem;
 import dmd.visitor;
 
 enum LOGSEMANTIC = false;
+
 void emplaceExp(T : Expression, Args...)(void* p, Args args)
 {
-    scope tmp = new T(args);
-    memcpy(p, cast(void*)tmp, __traits(classInstanceSize, T));
+    static if (__VERSION__ < 2099)
+        const init = typeid(T).initializer;
+    else
+        const init = __traits(initSymbol, T);
+    p[0 .. __traits(classInstanceSize, T)] = init[];
+    (cast(T)p).__ctor(args);
 }
 
 void emplaceExp(T : UnionExp)(T* p, Expression e)


### PR DESCRIPTION
The original C++ code did i.e: `new(&ue) StringExp(loc, string)` which is subtly different from what the converted D emplaceExp is doing.

By creating a new temporary and escaping its data with memcpy(), you can under some conditions corrupt the stack. So instead do what we used to do and initialize and call the constructor on the pointer directly.

Fixes segfault seen on mips64el-linux.