### PR TITLE
module: use a FileType instead of three seperate bools

### DIFF
--- a/src/dmd/astenums.d
+++ b/src/dmd/astenums.d
@@ -430,3 +430,12 @@ enum PINLINE : ubyte
     never,    /// never inline
     always,   /// always inline
 }
+
+/// Source file type
+enum FileType : ubyte
+{
+    d,    /// normal D source file
+    dhdr, /// D header file (.di)
+    ddoc, /// Ddoc documentation file (.dd)
+    c,    /// C source file
+}

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -146,7 +146,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                             else if (sd && (!sd.statement.hasCode() || sd.statement.isCaseStatement() || sd.statement.isErrorStatement()))
                             {
                             }
-                            else if (!func.getModule().isCFile)
+                            else if (func.getModule().filetype != FileType.c)
                             {
                                 const(char)* gototype = s.isCaseStatement() ? "case" : "default";
                                 s.error("switch case fallthrough - use 'goto %s;' if intended", gototype);

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -425,7 +425,7 @@ extern(C++) void gendocfile(Module m)
         dc.copyright.nooutput = 1;
         m.macrotable.define("COPYRIGHT", dc.copyright.body_);
     }
-    if (m.isDocFile)
+    if (m.filetype == FileType.ddoc)
     {
         const ploc = m.md ? &m.md.loc : &m.loc;
         const loc = Loc(ploc.filename ? ploc.filename : srcfilename.ptr,
@@ -4991,7 +4991,7 @@ private void highlightText(Scope* sc, Dsymbols* a, Loc loc, ref OutBuffer buf, s
 
         default:
             leadingBlank = false;
-            if (sc._module.isDocFile || inCode)
+            if (sc._module.filetype == FileType.ddoc || inCode)
                 break;
             const start = cast(char*)buf[].ptr + i;
             if (isIdStart(start))

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -174,7 +174,7 @@ struct Scope
             m = m.parent;
         m.addMember(null, sc.scopesym);
         m.parent = null; // got changed by addMember()
-        if (_module.isCFile)
+        if (_module.filetype == FileType.c)
             sc.flags |= SCOPE.Cfile;
         // Create the module scope underneath the global scope
         sc = sc.push(_module);

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -469,10 +469,7 @@ extern (C++) class Dsymbol : ASTNode
      final bool isCsymbol()
      {
         if (Module m = getModule())
-        {
-            if (m.isCFile)
-                return true;
-        }
+            return m.filetype == FileType.c;
         return false;
     }
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1686,6 +1686,14 @@ public:
     }
 };
 
+enum class FileType : uint8_t
+{
+    d = 0u,
+    dhdr = 1u,
+    ddoc = 2u,
+    c = 3u,
+};
+
 struct FileBuffer final
 {
     _d_dynamicArray< uint8_t > data;
@@ -6133,9 +6141,7 @@ public:
     FileBuffer* srcBuffer;
     uint32_t errors;
     uint32_t numlines;
-    bool isHdrFile;
-    bool isCFile;
-    bool isDocFile;
+    FileType filetype;
     bool hasAlwaysInlines;
     bool isPackageFile;
     Package* pkg;

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -415,4 +415,12 @@ enum class PINLINE : uint8_t
     always        // always inline
 };
 
+enum class FileType : uint8_t
+{
+    d,    /// normal D source file
+    dhdr, /// D header file (.di)
+    ddoc, /// Ddoc documentation file (.dd)
+    c,    /// C source file
+};
+
 typedef uinteger_t StorageClass;

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -108,7 +108,7 @@ void generateCodeAndWrite(Module[] modules, const(char)*[] libmodules,
         Module firstm;    // first module we generate code for
         foreach (m; modules)
         {
-            if (m.isHdrFile)
+            if (m.filetype == FileType.dhdr)
                 continue;
             if (!firstm)
             {
@@ -129,7 +129,7 @@ void generateCodeAndWrite(Module[] modules, const(char)*[] libmodules,
         OutBuffer objbuf;
         foreach (m; modules)
         {
-            if (m.isHdrFile)
+            if (m.filetype == FileType.dhdr)
                 continue;
             if (verbose)
                 message("code      %s", m.toChars());
@@ -620,7 +620,7 @@ private void genObjFile(Module m, bool multiobj)
      *  explicitly disabled through compiler switches such as `-betterC`.
      *  Don't generate ModuleInfo for C files.
      */
-    if (global.params.useModuleInfo && Module.moduleinfo && !m.isCFile /*|| needModuleInfo()*/)
+    if (global.params.useModuleInfo && Module.moduleinfo && m.filetype != FileType.c/*|| needModuleInfo()*/)
         genModuleInfo(m);
 
     objmod.termfile();

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -24,6 +24,7 @@ import core.stdc.string;
 
 import dmd.arraytypes;
 import dmd.astcodegen;
+import dmd.astenums;
 import dmd.builtin;
 import dmd.cond;
 import dmd.console;
@@ -367,7 +368,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
 //            m.deleteObjFile();
 
         m.parse();
-        if (m.isHdrFile)
+        if (m.filetype == FileType.dhdr)
         {
             // Remove m's object file from list of object files
             for (size_t j = 0; j < params.objfiles.length; j++)
@@ -381,7 +382,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
             if (params.objfiles.length == 0)
                 params.link = false;
         }
-        if (m.isDocFile)
+        if (m.filetype == FileType.ddoc)
         {
             anydocfiles = true;
             gendocfile(m);
@@ -419,7 +420,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
          */
         foreach (m; modules)
         {
-            if (m.isHdrFile)
+            if (m.filetype == FileType.dhdr)
                 continue;
             if (params.verbose)
                 message("import    %s", m.toChars());

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -74,9 +74,7 @@ public:
     FileBuffer *srcBuffer; // set during load(), free'd in parse()
     unsigned errors;    // if any errors in file
     unsigned numlines;  // number of lines in source file
-    bool isHdrFile;     // if it is a header (.di) file
-    bool isCFile;       // if it is a C (.c) file
-    bool isDocFile;     // if it is a documentation input file, not D source
+    FileType filetype;  // source file type
     bool hasAlwaysInlines; // contains references to functions that must be inlined
     bool isPackageFile; // if it is a package.d
     Package *pkg;       // if isPackageFile is true, the Package that contains this package.d

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -100,7 +100,7 @@ struct IRState
         mayThrow = global.params.useExceptions
             && ClassDeclaration.throwable
             && !(fd && fd.eh_none);
-        this.Cfile = m.isCFile;
+        this.Cfile = m.filetype == FileType.c;
     }
 
     FuncDeclaration getFunc()
@@ -114,7 +114,7 @@ struct IRState
      */
     bool arrayBoundsCheck()
     {
-        if (m.isCFile)
+        if (m.filetype == FileType.c)
             return false;
         bool result;
         final switch (global.params.useArrayBounds)


### PR DESCRIPTION
This patch uses an enum to represent either a Ddoc, D header file or C file.
Since there is no way to have two at the same time, lets save some space on the
AST.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>