### PR TITLE
dmd.dtemplate: Declare printTemplateStats as extern(C++)

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -8346,7 +8346,7 @@ struct TemplateStats
     }
 }
 
-void printTemplateStats()
+extern (C++) void printTemplateStats()
 {
     static struct TemplateDeclarationStats
     {

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6576,6 +6576,8 @@ public:
     void accept(Visitor* v);
 };
 
+extern void printTemplateStats();
+
 extern void genCppHdrFiles(Array<Module* >& ms);
 
 class DebugSymbol final : public Dsymbol

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -314,3 +314,4 @@ Tuple *isTuple(RootObject *o);
 Parameter *isParameter(RootObject *o);
 TemplateParameter *isTemplateParameter(RootObject *o);
 bool isError(const RootObject *const o);
+void printTemplateStats();


### PR DESCRIPTION
Make the function (and `vtemplates`/`vtemplatesListInstances` parameters) useful for gdc and ldc.  @kinke.