### PR TITLE
dmd.dtoh: Don't emit bogus alignment comments in headers

### DIFF
--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -860,7 +860,7 @@ public:
             origType = vd.originalType;
         scope(exit) origType = null;
 
-        if (!vd.alignment.isDefault())
+        if (!vd.alignment.isDefault() && !vd.alignment.isUnknown())
         {
             buf.printf("// Ignoring var %s alignment %d", vd.toChars(), vd.alignment.get());
             buf.writenl();

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -402,14 +402,10 @@ typedef uint64_t size_t;
 template <typename T>
 struct Array final
 {
-    // Ignoring var length alignment 0
     size_t length;
-    // Ignoring var data alignment 0
     _d_dynamicArray< T > data;
-    // Ignoring var SMALLARRAYCAP alignment 0
     enum : int32_t { SMALLARRAYCAP = 1 };
 
-    // Ignoring var smallarray alignment 0
     T smallarray[SMALLARRAYCAP];
     Array(size_t dim);
     ~Array();
@@ -1442,9 +1438,7 @@ enum class MATCH
 template <typename T>
 struct Optional final
 {
-    // Ignoring var value alignment 0
     T value;
-    // Ignoring var present alignment 0
     bool present;
     Optional(T value);
     static Optional<T > create(T val);
@@ -1729,7 +1723,6 @@ struct File final
 template <typename K, typename V>
 struct AssocArray final
 {
-    // Ignoring var aa alignment 0
     AA* aa;
     AssocArray()
     {
@@ -5179,15 +5172,10 @@ struct StringEntry final
 template <typename T>
 struct StringTable final
 {
-    // Ignoring var table alignment 0
     _d_dynamicArray< StringEntry > table;
-    // Ignoring var pools alignment 0
     _d_dynamicArray< uint8_t* > pools;
-    // Ignoring var nfill alignment 0
     size_t nfill;
-    // Ignoring var count alignment 0
     size_t count;
-    // Ignoring var countTrigger alignment 0
     size_t countTrigger;
     ~StringTable();
     StringTable()
@@ -7766,27 +7754,16 @@ struct Target final
     template <typename T>
     struct FPTypeProperties final
     {
-        // Ignoring var max alignment 0
         real_t max;
-        // Ignoring var min_normal alignment 0
         real_t min_normal;
-        // Ignoring var nan alignment 0
         real_t nan;
-        // Ignoring var infinity alignment 0
         real_t infinity;
-        // Ignoring var epsilon alignment 0
         real_t epsilon;
-        // Ignoring var dig alignment 0
         d_int64 dig;
-        // Ignoring var mant_dig alignment 0
         d_int64 mant_dig;
-        // Ignoring var max_exp alignment 0
         d_int64 max_exp;
-        // Ignoring var min_exp alignment 0
         d_int64 min_exp;
-        // Ignoring var max_10_exp alignment 0
         d_int64 max_10_exp;
-        // Ignoring var min_10_exp alignment 0
         d_int64 min_10_exp;
         FPTypeProperties()
         {

--- a/test/compilable/dtoh_AliasDeclaration.d
+++ b/test/compilable/dtoh_AliasDeclaration.d
@@ -125,7 +125,6 @@ typedef /* noreturn */ char Impossible[0];
 template <typename T>
 struct Array final
 {
-    // Ignoring var length alignment 0
     uint32_t length;
     Array()
     {

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -73,14 +73,10 @@ struct ActualBuffer final
 template <typename T>
 struct A final
 {
-    // Ignoring var x alignment 0
     T x;
-    // Ignoring var Enum alignment 0
     enum : int32_t { Enum = 42 };
 
-    // Ignoring var GsharedNum alignment 0
     static int32_t GsharedNum;
-    // Ignoring var MemNum alignment 0
     const int32_t MemNum;
     void foo();
     A()
@@ -91,8 +87,6 @@ struct A final
 template <typename T>
 struct NotInstantiated final
 {
-    // Ignoring var noInit alignment 0
-    // Ignoring var missingSem alignment 0
     NotInstantiated()
     {
     }
@@ -113,7 +107,6 @@ struct B final
 template <typename T>
 struct Foo final
 {
-    // Ignoring var val alignment 0
     T val;
     Foo()
     {
@@ -123,7 +116,6 @@ struct Foo final
 template <typename T>
 struct Bar final
 {
-    // Ignoring var v alignment 0
     Foo<T > v;
     Bar()
     {
@@ -141,9 +133,7 @@ struct Array final
     void get() const;
     template <typename T>
     bool opCast() const;
-    // Ignoring var i alignment 0
     typename T::Member i;
-    // Ignoring var j alignment 0
     typename Outer::Member::Nested j;
     void visit(typename T::Member::Nested i);
     Array()
@@ -159,7 +149,6 @@ extern A<A<int32_t > > aaint;
 template <typename T>
 class Parent
 {
-    // Ignoring var parentMember alignment 0
 public:
     T parentMember;
     void parentFinal();
@@ -169,7 +158,6 @@ public:
 template <typename T>
 class Child final : public Parent<T >
 {
-    // Ignoring var childMember alignment 0
 public:
     T childMember;
     void parentVirtual();
@@ -207,14 +195,10 @@ extern HasMixinsTemplate<bool > hmti;
 template <typename T>
 struct NotAA final
 {
-    // Ignoring var length alignment 0
     enum : int32_t { length = 12 };
 
-    // Ignoring var buffer alignment 0
     T buffer[length];
-    // Ignoring var otherBuffer alignment 0
     T otherBuffer[SomeOtherLength];
-    // Ignoring var calcBuffer alignment 0
     T calcBuffer[foo(1)];
     NotAA()
     {
@@ -224,9 +208,7 @@ struct NotAA final
 template <typename Buffer>
 struct BufferTmpl final
 {
-    // Ignoring var buffer alignment 0
     Buffer buffer;
-    // Ignoring var buffer2 alignment 0
     Buffer buffer2;
     BufferTmpl()
     {

--- a/test/compilable/dtoh_forwarding.d
+++ b/test/compilable/dtoh_forwarding.d
@@ -86,7 +86,6 @@ struct ExternDStructRequired final
 template <typename T>
 struct ExternDTemplStruct final
 {
-    // Ignoring var member alignment 0
     T member;
     ExternDTemplStruct()
     {
@@ -129,7 +128,6 @@ extern TemplClass<int32_t >* templClass;
 template <typename T>
 class TemplClass
 {
-    // Ignoring var member alignment 0
 public:
     T member;
 };
@@ -139,7 +137,6 @@ extern TemplStruct<int32_t >* templStruct;
 template <typename T>
 class TemplStruct
 {
-    // Ignoring var member alignment 0
 public:
     T member;
 };

--- a/test/compilable/dtoh_ignored.d
+++ b/test/compilable/dtoh_ignored.d
@@ -62,11 +62,9 @@ private:
 template <typename T>
 struct WithImaginaryTemplate final
 {
-    // Ignoring var member alignment 0
     float member;
     // Ignored function onReturn because its return type cannot be mapped to C++
     // Ignored function onParam because one of its parameters has type `ifloat` which cannot be mapped to C++
-    // Ignoring var onVariable alignment 0
     // Ignored variable onVariable because its type cannot be mapped to C++
     WithImaginaryTemplate()
     {

--- a/test/compilable/dtoh_invalid_identifiers.d
+++ b/test/compilable/dtoh_invalid_identifiers.d
@@ -58,7 +58,6 @@ namespace const_cast
 template <typename register_>
 struct S final
 {
-    // Ignoring var x alignment 0
     register_ x;
     S()
     {
@@ -104,7 +103,6 @@ extern void user(Alias<Base* >* i);
 template <typename typename_>
 struct InvalidNames final
 {
-    // Ignoring var register alignment 0
     typename_ register_;
     void foo(typename_ and_);
     InvalidNames()

--- a/test/compilable/dtoh_names.d
+++ b/test/compilable/dtoh_names.d
@@ -63,13 +63,9 @@ struct Outer final
         template <typename U>
         struct InnerTmpl final
         {
-            // Ignoring var innerTmplOuterPtr alignment 0
             static Outer* innerTmplOuterPtr;
-            // Ignoring var innerTmplPtr alignment 0
             static Middle* innerTmplPtr;
-            // Ignoring var innerTmplInnerPtr alignment 0
             static Inner* innerTmplInnerPtr;
-            // Ignoring var innerTmplInnerTmplPtr alignment 0
             static InnerTmpl* innerTmplInnerTmplPtr;
             InnerTmpl()
             {
@@ -84,15 +80,11 @@ struct Outer final
     template <typename T>
     struct MiddleTmpl final
     {
-        // Ignoring var middleTmplPtr alignment 0
         static MiddleTmpl<T >* middleTmplPtr;
-        // Ignoring var middleTmplInnerTmplPtr alignment 0
         static MiddleTmpl<T >* middleTmplInnerTmplPtr;
         struct Inner final
         {
-            // Ignoring var ptr alignment 0
             static Inner* ptr;
-            // Ignoring var ptr2 alignment 0
             static MiddleTmpl<T >* ptr2;
             Inner()
             {
@@ -102,13 +94,9 @@ struct Outer final
         template <typename U>
         struct InnerTmpl final
         {
-            // Ignoring var innerTmplPtr alignment 0
             static InnerTmpl* innerTmplPtr;
-            // Ignoring var innerTmplPtrDiff alignment 0
             static InnerTmpl<char >* innerTmplPtrDiff;
-            // Ignoring var middleTmplInnerTmplPtr alignment 0
             static MiddleTmpl<T >* middleTmplInnerTmplPtr;
-            // Ignoring var a alignment 0
             static T a;
             static U bar();
             InnerTmpl()

--- a/test/compilable/dtoh_required_symbols.d
+++ b/test/compilable/dtoh_required_symbols.d
@@ -65,9 +65,7 @@ enum class ExternDEnum
 template <>
 struct ExternDStructTemplate final
 {
-    // Ignoring var i alignment 0
     int32_t i;
-    // Ignoring var d alignment 0
     double d;
     ExternDStructTemplate()
     {


### PR DESCRIPTION
These only seem to crop up in template fields.