### PR TITLE
dmd/common/outbuffer.h: Include root headers relative to its path

### DIFF
--- a/src/dmd/common/outbuffer.h
+++ b/src/dmd/common/outbuffer.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "root/dsystem.h"
-#include "root/dcompat.h"
-#include "root/rmem.h"
+#include "../root/dsystem.h"
+#include "../root/dcompat.h"
+#include "../root/rmem.h"
 
 class RootObject;
 


### PR DESCRIPTION
Don't assume that `-Isrc/dmd` is present when compiling C++ sources.