### PR TITLE
fix Issue 22878 - importC: glibc fallback for HUGE_VAL gives 'not rep…

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -2495,8 +2495,10 @@ class Lexer
             }
         }
         const isLong = (result == TOK.float80Literal || result == TOK.imaginary80Literal);
-        if (isOutOfRange && !isLong)
+        if (isOutOfRange && !isLong && (!Ccompile || hex))
         {
+            /* C11 6.4.4.2 doesn't actually care if it is not representable if it is not hex
+             */
             const char* suffix = (result == TOK.float32Literal || result == TOK.imaginary32Literal) ? "f" : "";
             error(scanloc, "number `%s%s` is not representable", sbufptr, suffix);
         }

--- a/test/compilable/test22878.c
+++ b/test/compilable/test22878.c
@@ -1,0 +1,3 @@
+// https://issues.dlang.org/show_bug.cgi?id=22878
+
+_Static_assert(1e10000 + 1e10000 == 1e10000, "1");


### PR DESCRIPTION
…resentable'

C should just return infinity, which is tested in the static assert.

gcc and clang give warnings for this, but ImportC doesn't do warnings.