### PR TITLE
dmd.dmdparams: Rename dmdParams to driverParams

### DIFF
--- a/src/dmd/dmdparams.d
+++ b/src/dmd/dmdparams.d
@@ -280,4 +280,4 @@ void setTriple(ref Target target, const ref Triple triple)
     target.cpp.runtime = triple.cppenv;
 }
 
-shared DMDparams dmdParams = dmdParams.init;
+shared DMDparams driverParams = DMDparams.init;

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -108,31 +108,31 @@ void backend_init()
         exe,
         false, //params.trace,
         params.nofloat,
-        dmdParams.vasm,
+        driverParams.vasm,
         params.verbose,
         params.optimize,
         params.symdebug,
-        dmdParams.alwaysframe,
+        driverParams.alwaysframe,
         params.stackstomp,
         target.cpu >= CPU.avx2 ? 2 : target.cpu >= CPU.avx ? 1 : 0,
         params.pic,
         params.useModuleInfo && Module.moduleinfo,
         params.useTypeInfo && Type.dtypeinfo,
         params.useExceptions && ClassDeclaration.throwable,
-        dmdParams.dwarf,
+        driverParams.dwarf,
         global.versionString(),
         exfmt,
         params.addMain
     );
 
     out_config_debug(
-        dmdParams.debugb,
-        dmdParams.debugc,
-        dmdParams.debugf,
-        dmdParams.debugr,
+        driverParams.debugb,
+        driverParams.debugc,
+        driverParams.debugf,
+        driverParams.debugr,
         false,
-        dmdParams.debugx,
-        dmdParams.debugy
+        driverParams.debugx,
+        driverParams.debugy
     );
 }
 

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -259,7 +259,7 @@ public int runLINK()
                 cmdbuf.writestring("/MAP:");
                 writeFilename(&cmdbuf, global.params.mapfile);
             }
-            else if (dmdParams.map)
+            else if (driverParams.map)
             {
                 cmdbuf.writestring("/MAP:");
                 writeFilename(&cmdbuf, getMapFilename());
@@ -378,7 +378,7 @@ public int runLINK()
             cmdbuf.writeByte(',');
             if (global.params.mapfile)
                 writeFilename(&cmdbuf, global.params.mapfile);
-            else if (dmdParams.map)
+            else if (driverParams.map)
             {
                 writeFilename(&cmdbuf, getMapFilename());
             }
@@ -409,7 +409,7 @@ public int runLINK()
                 cmdbuf.writestring("/RC:");
                 writeFilename(&cmdbuf, global.params.resfile);
             }
-            if (dmdParams.map || global.params.mapfile)
+            if (driverParams.map || global.params.mapfile)
                 cmdbuf.writestring("/m");
             version (none)
             {
@@ -587,7 +587,7 @@ public int runLINK()
             argv.push("-Xlinker");
             argv.push("-no_compact_unwind");
         }
-        if (dmdParams.map || global.params.mapfile.length)
+        if (driverParams.map || global.params.mapfile.length)
         {
             argv.push("-Xlinker");
             version (OSX)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1770,7 +1770,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             params.pic = PIC.pie;
         }
         else if (arg == "-map") // https://dlang.org/dmd.html#switch-map
-            dmdParams.map = true;
+            driverParams.map = true;
         else if (arg == "-multiobj")
             params.multiobj = true;
         else if (startsWith(p + 1, "mixin="))
@@ -1784,7 +1784,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             params.symdebug = 1;
         else if (startsWith(p + 1, "gdwarf")) // https://dlang.org/dmd.html#switch-gdwarf
         {
-            if (dmdParams.dwarf)
+            if (driverParams.dwarf)
             {
                 error("`-gdwarf=<version>` can only be provided once");
                 break;
@@ -1794,7 +1794,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             enum len = "-gdwarf=".length;
             // Parse:
             //      -gdwarf=version
-            if (arg.length < len || !dmdParams.dwarf.parseDigits(arg[len .. $], 5) || dmdParams.dwarf < 3)
+            if (arg.length < len || !driverParams.dwarf.parseDigits(arg[len .. $], 5) || driverParams.dwarf < 3)
             {
                 error("`-gdwarf=<version>` requires a valid version [3|4|5]", p);
                 return false;
@@ -1807,7 +1807,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             params.symdebugref = true;
         }
         else if (arg == "-gs")  // https://dlang.org/dmd.html#switch-gs
-            dmdParams.alwaysframe = true;
+            driverParams.alwaysframe = true;
         else if (arg == "-gx")  // https://dlang.org/dmd.html#switch-gx
             params.stackstomp = true;
         else if (arg == "-lowmem") // https://dlang.org/dmd.html#switch-lowmem
@@ -1867,7 +1867,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         else if (arg == "-vcg-ast")
             params.vcg_ast = true;
         else if (arg == "-vasm") // https://dlang.org/dmd.html#switch-vasm
-            dmdParams.vasm = true;
+            driverParams.vasm = true;
         else if (arg == "-vtls") // https://dlang.org/dmd.html#switch-vtls
             params.vtls = true;
         else if (startsWith(p + 1, "vtemplates")) // https://dlang.org/dmd.html#switch-vtemplates
@@ -2451,11 +2451,11 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                 goto Lerror;
         }
         else if (arg == "--b")
-            dmdParams.debugb = true;
+            driverParams.debugb = true;
         else if (arg == "--c")
-            dmdParams.debugc = true;
+            driverParams.debugc = true;
         else if (arg == "--f")
-            dmdParams.debugf = true;
+            driverParams.debugf = true;
         else if (arg == "--help" ||
                  arg == "-h")
         {
@@ -2463,16 +2463,16 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             return false;
         }
         else if (arg == "--r")
-            dmdParams.debugr = true;
+            driverParams.debugr = true;
         else if (arg == "--version")
         {
             params.logo = true;
             return false;
         }
         else if (arg == "--x")
-            dmdParams.debugx = true;
+            driverParams.debugx = true;
         else if (arg == "--y")
-            dmdParams.debugy = true;
+            driverParams.debugy = true;
         else if (p[1] == 'L')                        // https://dlang.org/dmd.html#switch-L
         {
             params.linkswitches.push(p + 2 + (p[2] == '='));
@@ -2607,7 +2607,7 @@ private void reconcileCommands(ref Param params, ref Target target)
     {
         if (params.pic)
             error(Loc.initial, "`-fPIC` and `-fPIE` cannot be used when targetting windows");
-        if (dmdParams.dwarf)
+        if (driverParams.dwarf)
             error(Loc.initial, "`-gdwarf` cannot be used when targetting windows");
     }
     else if (target.os == Target.OS.DragonFlyBSD)


### PR DESCRIPTION
As per https://github.com/dlang/dmd/pull/13796#issuecomment-1064626257.  LDC wants to use this code (but GDC doesn't), so give it an agnostic name.