### PR TITLE
driver: Make DMD fail faster by calling backend_init() only when required

### DIFF
--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -617,3 +617,9 @@ nothrow:
 
 /// Collection of global state
 extern (C++) __gshared Global global;
+
+
+// FIXME: This should be removed when inline assembler codegen is decoupled
+// from frontend.
+version(DMDLIB) {}
+else extern (D) __gshared bool useInlineAsm;

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -440,8 +440,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (global.errors)
         removeHdrFilesAndFail(params, modules);
 
-    backend_init();
-
     // Do semantic analysis
     foreach (m; modules)
     {
@@ -473,6 +471,12 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     Module.runDeferredSemantic2();
     if (global.errors)
         removeHdrFilesAndFail(params, modules);
+
+    // FIXME: Backend is needed for DMD inline assembler. We should remove
+    // codegen/glue code from inline assembler to seperate it from semantic
+    // analysis.
+    if (useInlineAsm)
+      backend_init();
 
     // Do pass 3 semantic analysis
     foreach (m; modules)
@@ -576,6 +580,9 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
 
     if (params.addMain && !global.hasMainFunction)
         modules.push(moduleWithEmptyMain());
+
+    if (!useInlineAsm)
+      backend_init();
 
     generateCodeAndWrite(modules[], libmodules[], params.libname, params.objdir,
                          params.lib, params.obj, params.oneobj, params.multiobj,

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -6875,6 +6875,8 @@ LagainStc:
             break;
         }
         nextToken();
+        version(DMDLIB) {}
+        else useInlineAsm = true;
         auto s = new AST.CompoundAsmStatement(loc, statements, stc);
         return s;
     }


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>