### PR TITLE
backend: move iasm_regs from iasmdmd.d

### DIFF
--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -661,10 +661,20 @@ void cdd_u64(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void cdd_u32(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void loadPair87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 
-/* iasm.c */
-//void iasm_term();
-regm_t iasm_regs(block *bp);
+/**********************************
+ * Get registers used by a given block
+ * Params: bp = asm block
+ * Returns: mask of registers used by block bp.
+ */
+@system
+regm_t iasm_regs(block *bp)
+{
+    debug (debuga)
+        printf("Block iasm regs = 0x%X\n", bp.usIasmregs);
 
+    refparam |= bp.bIasmrefparam;
+    return bp.usIasmregs;
+}
 
 /**********************************
  * Set value in regimmed for reg.

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -260,22 +260,6 @@ AFTER_EMIT:
     return asmstate.errors ? new ErrorStatement() : s;
 }
 
-/**********************************
- * Called from back end.
- * Params: bp = asm block
- * Returns: mask of registers used by block bp.
- */
-extern (C++) public regm_t iasm_regs(block *bp)
-{
-    debug (debuga)
-        printf("Block iasm regs = 0x%X\n", bp.usIasmregs);
-
-    refparam |= bp.bIasmrefparam;
-    return bp.usIasmregs;
-}
-
-
-
 private:
 
 enum ADDFWAIT = false;


### PR DESCRIPTION
Since this function only uses and is only used in backend code, let's move to
the right place.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Related to #13820. Starting to separate glue/backend code from semantic in the inline assembler.