### PR TITLE
fix Issue 22881 - ICE Index of array outside of bounds at CTFE

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1348,14 +1348,6 @@ UnionExp Slice(Type type, Expression e1, Expression lwr, Expression upr)
         }
     }
 
-    static bool sliceBoundsCheck(uinteger_t lwr, uinteger_t upr, uinteger_t newlwr, uinteger_t newupr) pure
-    {
-        assert(lwr <= upr);
-        return !(newlwr <= newupr &&
-                 lwr <= newlwr &&
-                 newupr <= upr);
-    }
-
     if (e1.op == EXP.string_ && lwr.op == EXP.int64 && upr.op == EXP.int64)
     {
         StringExp es1 = cast(StringExp)e1;
@@ -1393,6 +1385,16 @@ UnionExp Slice(Type type, Expression e1, Expression lwr, Expression upr)
     else
         cantExp(ue);
     return ue;
+}
+
+/* Check whether slice `[newlwr .. newupr]` is in the range `[lwr .. upr]`
+ */
+bool sliceBoundsCheck(uinteger_t lwr, uinteger_t upr, uinteger_t newlwr, uinteger_t newupr) pure
+{
+    assert(lwr <= upr);
+    return !(newlwr <= newupr &&
+             lwr <= newlwr &&
+             newupr <= upr);
 }
 
 /* Set a slice of char/integer array literal 'existingAE' from a string 'newval'.

--- a/test/fail_compilation/fail22881.d
+++ b/test/fail_compilation/fail22881.d
@@ -1,0 +1,60 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fail22881.d(101): Error: pointer slice `[0..6]` exceeds allocated memory block `[0..5]`
+fail_compilation/fail22881.d(102): Error: pointer slice `[0..6]` exceeds allocated memory block `[0..5]`
+fail_compilation/fail22881.d(110): Error: pointer slice `[3..5]` exceeds allocated memory block `[0..4]`
+fail_compilation/fail22881.d(113):        called from here: `ptr22881()`
+fail_compilation/fail22881.d(113):        while evaluating: `static assert(ptr22881())`
+fail_compilation/fail22881.d(203): Error: slice `[0..2]` is out of bounds
+fail_compilation/fail22881.d(207):        called from here: `null22881()`
+fail_compilation/fail22881.d(207):        while evaluating: `static assert(null22881())`
+fail_compilation/fail22881.d(305): Error: slice `[2..4]` exceeds array bounds `[0..3]`
+fail_compilation/fail22881.d(308):        called from here: `slice22881()`
+fail_compilation/fail22881.d(308):        while evaluating: `static assert(slice22881())`
+fail_compilation/fail22881.d(401): Error: slice `[0..1]` exceeds array bounds `[0..0]`
+fail_compilation/fail22881.d(403): Error: slice `[0..1]` exceeds array bounds `[0..0]`
+---
+*/
+#line 100
+// SliceExp: e1.type.ty == pointer
+static pstr22881 = "hello".ptr[0 .. 6];
+static parr22881 = ['h','e','l','l','o'].ptr[0 .. 6];
+
+bool ptr22881()
+{
+    char *p1 = new char[4].ptr;
+    p1[0 .. 4] = "str\0";
+    char *s1 = p1[1 .. 3].ptr;
+    char *s2 = s1[1 .. 3].ptr;  // = p1[2 .. 4] 
+    char *s3 = s2[1 .. 3].ptr;  // = p1[3 .. 5]
+    return true;
+}
+static assert(ptr22881());
+
+
+#line 200
+// SliceExp: e1.op == null
+bool null22881()
+{
+    string[][1] nullexp;
+    nullexp[0][0 .. 2] = "st";
+    return true;
+}
+static assert(null22881());
+
+#line 300
+// SliceExp: e1.op == slice
+bool slice22881()
+{
+    char[] str = "abcd".dup;
+    char[] slice = str[1 .. 4];
+    slice[2 .. 4] = "ab";
+    return true;
+}
+static assert(slice22881());
+
+#line 400
+// SliceExp: e1.op == arrayLiteral
+static arr22881 = [][0 .. 1];
+// SliceExp: e1.op == string_
+static str22881 = ""[0 .. 1];


### PR DESCRIPTION
#8261 replaced all errors in `dmd.constfold` with `sliceBoundsCheck()`, deduplicating all slice bound checking in the process.  However, `dmd.dinterpret` was still checking bounds in its own way, and as it turns out, there is mismatch between them when it came to verifying pointer slices during CTFE.

This makes `sliceBoundsCheck` public, and adapts all `dmd.dinterpret` slice bounds checking so both modules use the same logic, fixing issue 22881.

When verifying each check, it was noted that the bounds checking in `interpretAssignToSlice()` is redundant, as the `visit(SliceExp)` visitor does the same checks, and catches the error first.

The added test `slice22881()` unearthed a thinko in the diagnostic message, originally it would error the somewhat confusing: `slice [2..4] exceeds array bounds [1..4]`