### PR TITLE
Fix issue 22882 - Floating-point literals with leading zeroes incorrectly throw octal errors

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -1976,6 +1976,11 @@ class Lexer
             case '.':
                 if (p[1] == '.')
                     goto Ldone; // if ".."
+                if (base == 8)
+                {
+                    base = 10; // the number is not an octal after all
+                    errorDigit = 0;
+                }
                 if (base <= 10 && n > 0 && (isalpha(p[1]) || p[1] == '_' || p[1] & 0x80))
                 {
                     if (Ccompile && base == 10 &&


### PR DESCRIPTION
Fixes issue [#22882](https://issues.dlang.org/show_bug.cgi?id=22882).

Floating-point literals with leading zeroes incorrectly throw an octal digit error, as follows:

`writeln(07.0);` // 7
`writeln(08.0);` // Error: octal digit expected, not `8`
`writeln(010.9);` // 10.9
`writeln(018.9);` // Error: octal digit expected, not `8`
`writeln(00077777.0);` // 77777
`writeln(00077778.0);` // Error: octal digit expected, not `8`


The error is in lexer.d; errorDigit is set in number() in the initial switch statement, but when a '.' is subsequently handled later in the function, the error state is never unset.

The fix checks for `base == 8` within the `'.'` case of the appropriate switch, and if true, unsets `errorDigit` and sets `base` to `10`, as we are now working with a decimal float literal.