### PR TITLE
Simplify `Module.read` and its interaction with `FileManager`

### DIFF
--- a/src/dmd/file_manager.d
+++ b/src/dmd/file_manager.d
@@ -26,27 +26,6 @@ extern(C++) struct FileManager
     private __gshared bool initialized = false;
 
 nothrow:
-    extern(D) private FileBuffer* readToFileBuffer(const(char)[] filename)
-    {
-        if (!initialized)
-            FileManager._init();
-
-        auto readResult = File.read(filename);
-        if (!readResult.success)
-            return null;
-
-        FileBuffer* fb;
-        if (auto val = files.lookup(filename))
-            fb = val.value;
-
-        if (!fb)
-            fb = FileBuffer.create();
-
-        fb.data = readResult.extractSlice();
-
-        return files.insert(filename, fb) == null ? null : fb;
-    }
-
     /********************************************
     * Look for the source file if it's different from filename.
     * Look for .di, .d, directory, and along global.path.
@@ -178,7 +157,22 @@ nothrow:
         const name = filename.toString;
         auto res = FileName.exists(name);
         if (res == 1)
-            return readToFileBuffer(name);
+        {
+            auto readResult = File.read(name);
+            if (!readResult.success)
+                return null;
+
+            FileBuffer* fb;
+            if (auto val = files.lookup(name))
+                fb = val.value;
+
+            if (!fb)
+                fb = FileBuffer.create();
+
+            fb.data = readResult.extractSlice();
+
+            return files.insert(name, fb) == null ? null : fb;
+        }
 
         return null;
     }

--- a/src/dmd/file_manager.d
+++ b/src/dmd/file_manager.d
@@ -32,24 +32,19 @@ nothrow:
             FileManager._init();
 
         auto readResult = File.read(filename);
-        if (readResult.success)
-        {
-            FileBuffer* fb;
-            if (auto val = files.lookup(filename))
-                fb = val.value;
-
-            if (!fb)
-                fb = FileBuffer.create();
-
-            fb.data = readResult.extractSlice();
-
-            return files.insert(filename, fb) == null ? null : fb;
-        }
-        else
-        {
+        if (!readResult.success)
             return null;
-        }
 
+        FileBuffer* fb;
+        if (auto val = files.lookup(filename))
+            fb = val.value;
+
+        if (!fb)
+            fb = FileBuffer.create();
+
+        fb.data = readResult.extractSlice();
+
+        return files.insert(filename, fb) == null ? null : fb;
     }
 
     /********************************************

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -396,17 +396,12 @@ Tuple!(Module, "module_", Diagnostics, "diagnostics") parseModule(AST = ASTCodeg
         m.read(Loc.initial);
     else
     {
-        File.ReadResult readResult = {
-            success: true,
-            buffer: FileBuffer(cast(ubyte[]) code.dup ~ '\0')
-        };
+        import dmd.file_manager : FileManager;
+        import dmd.root.filename : FileName;
 
-        if (m.loadSourceBuffer(Loc.initial, readResult))
-        {
-            import dmd.file_manager : FileManager;
-            import dmd.root.filename : FileName;
-            FileManager.fileManager.add(FileName(fileName), m.srcBuffer);
-        }
+        auto fb = new FileBuffer(cast(ubyte[]) code.dup ~ '\0');
+        FileManager.fileManager.add(FileName(fileName), fb);
+        m.srcBuffer = fb;
     }
 
     m = m.parseModule!AST();
@@ -678,4 +673,3 @@ nothrow:
         return false;
     }
 }
-

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1688,45 +1688,6 @@ enum class FileType : uint8_t
     c = 3u,
 };
 
-struct FileBuffer final
-{
-    _d_dynamicArray< uint8_t > data;
-    static FileBuffer* create();
-    FileBuffer() :
-        data()
-    {
-    }
-    FileBuffer(_d_dynamicArray< uint8_t > data) :
-        data(data)
-        {}
-};
-
-struct File final
-{
-    struct ReadResult final
-    {
-        bool success;
-        FileBuffer buffer;
-        ReadResult() :
-            success(),
-            buffer()
-        {
-        }
-        ReadResult(bool success, FileBuffer buffer = FileBuffer()) :
-            success(success),
-            buffer(buffer)
-            {}
-    };
-
-    static ReadResult read(const char* name);
-    static bool write(const char* name, const void* data, size_t size);
-    static void remove(const char* name);
-    static bool update(const char* name, const void* data, size_t size);
-    File()
-    {
-    }
-};
-
 template <typename K, typename V>
 struct AssocArray final
 {
@@ -6163,7 +6124,6 @@ public:
     static Module* create(const char* filename, Identifier* ident, int32_t doDocComment, int32_t doHdrGen);
     static Module* load(const Loc& loc, Array<Identifier* >* packages, Identifier* ident);
     const char* kind() const;
-    bool loadSourceBuffer(const Loc& loc, File::ReadResult& readResult);
     bool read(const Loc& loc);
     Module* parse();
     void importAll(Scope* prevsc);

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -36,6 +36,8 @@ version (Windows)
     import core.sys.windows.windef;
     import core.sys.windows.winnls;
 
+    import dmd.common.string : extendedPathThen;
+
     extern (Windows) DWORD GetFullPathNameW(LPCWSTR, DWORD, LPWSTR, LPWSTR*) nothrow @nogc;
     extern (Windows) void SetLastError(DWORD) nothrow @nogc;
     extern (C) char* getcwd(char* buffer, size_t maxlen) nothrow;
@@ -855,7 +857,7 @@ nothrow:
         }
         else version (Windows)
         {
-            return name.toWStringzThen!((wname)
+            return name.extendedPathThen!((wname)
             {
                 const dw = GetFileAttributesW(&wname[0]);
                 if (dw == -1)
@@ -1124,7 +1126,6 @@ version(Windows)
      */
     private int _mkdir(const(char)[] path) nothrow
     {
-        import dmd.common.string : extendedPathThen;
         const createRet = path.extendedPathThen!(
             p => CreateDirectoryW(&p[0], null /*securityAttributes*/));
         // different conventions for CreateDirectory and mkdir


### PR DESCRIPTION
```
Since the FileManager will read a file if it exists on the filesystem,
the else clause of Module.read was only ever called if File.read would fail.
As a result, the code can be simplified, and loadSourceBuffer can be renamed
to match its true purpose (printing a decent error message on missing file).
```