### PR TITLE
Fix issue 22863 - -main doesn't work anymore when used for linking only

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -574,7 +574,12 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     }
 
     if (params.addMain && !global.hasMainFunction)
-        modules.push(moduleWithEmptyMain());
+    {
+        auto mainModule = moduleWithEmptyMain();
+        modules.push(mainModule);
+        if (!params.oneobj || modules.length == 1)
+            params.objfiles.push(mainModule.objfile.toChars());
+    }
 
     generateCodeAndWrite(modules[], libmodules[], params.libname, params.objdir,
                          params.lib, params.obj, params.oneobj, params.multiobj,

--- a/test/runnable/test22863.sh
+++ b/test/runnable/test22863.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# -main doesn't work anymore when used for linking only (without source modules)
+# https://issues.dlang.org/show_bug.cgi?id=22863
+
+set -e
+
+FOO=${OUTPUT_BASE}/foo${OBJ}
+
+$DMD -m"${MODEL}" -c ${TEST_DIR}/testmain.d -of=$FOO
+$DMD -m"${MODEL}" -main $FOO -of=${OUTPUT_BASE}/result
+rm_retry -r ${OUTPUT_BASE}


### PR DESCRIPTION
Porting https://github.com/ldc-developers/ldc/pull/3938 to DMD