### PR TITLE
Issue 22898 - [REG master] Solaris: byte.min value is 128

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1908,6 +1908,8 @@ extern(C++):
             return writeBasicType(t, 0, 'l');
         else if (id == Id.__c_ulong)
             return writeBasicType(t, 0, 'm');
+        else if (id == Id.__c_char)
+            return writeBasicType(t, 0, 'c');
         else if (id == Id.__c_wchar_t)
             return writeBasicType(t, 0, 'w');
         else if (id == Id.__c_longlong)

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -443,6 +443,8 @@ public:
             c = "_J"; // VC++ long long
         else if (id == Id.__c_ulonglong)
             c = "_K"; // VC++ unsigned long long
+        else if (id == Id.__c_char)
+            c = "D";  // VC++ char
         else if (id == Id.__c_wchar_t)
         {
             c = (flags & IS_DMC) ? "_Y" : "_W";

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1934,6 +1934,8 @@ public:
                 buf.writestring("unsigned long long");
             else if (ed.ident == DMDType.c_long_double)
                 buf.writestring("long double");
+            else if (ed.ident == DMDType.c_char)
+                buf.writestring("char");
             else if (ed.ident == DMDType.c_wchar_t)
                 buf.writestring("wchar_t");
             else if (ed.ident == DMDType.c_complex_float)
@@ -2983,6 +2985,7 @@ struct DMDType
     __gshared Identifier c_longlong;
     __gshared Identifier c_ulonglong;
     __gshared Identifier c_long_double;
+    __gshared Identifier c_char;
     __gshared Identifier c_wchar_t;
     __gshared Identifier c_complex_float;
     __gshared Identifier c_complex_double;
@@ -2996,6 +2999,7 @@ struct DMDType
         c_ulonglong     = Identifier.idPool("__c_ulonglong");
         c_long_double   = Identifier.idPool("__c_long_double");
         c_wchar_t       = Identifier.idPool("__c_wchar_t");
+        c_char          = Identifier.idPool("__c_char");
         c_complex_float  = Identifier.idPool("__c_complex_float");
         c_complex_double = Identifier.idPool("__c_complex_double");
         c_complex_real = Identifier.idPool("__c_complex_real");

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -123,6 +123,7 @@ immutable Msgtable[] msgtable =
     { "__c_longlong" },
     { "__c_ulonglong" },
     { "__c_long_double" },
+    { "__c_char" },
     { "__c_wchar_t" },
     { "__c_complex_float" },
     { "__c_complex_double" },

--- a/test/runnable_cxx/extra-files/test22898.cpp
+++ b/test/runnable_cxx/extra-files/test22898.cpp
@@ -1,0 +1,7 @@
+int testCppCMangle (unsigned long long val, char ch)
+{
+    int vch = (char)val;
+    if (vch != ch)
+        return 0;
+    return vch;
+}

--- a/test/runnable_cxx/test22898.d
+++ b/test/runnable_cxx/test22898.d
@@ -1,0 +1,28 @@
+// EXTRA_CPP_SOURCES: test22898.cpp
+
+import core.stdc.config;
+
+extern(C++):
+
+version (AArch64) version = UnsignedChar;
+version (ARM)     version = UnsignedChar;
+version (RISCV32) version = UnsignedChar;
+version (RISCV64) version = UnsignedChar;
+version (PPC)     version = UnsignedChar;
+version (PPC64)   version = UnsignedChar;
+version (S390)    version = UnsignedChar;
+version (SystemZ) version = UnsignedChar;
+
+version (UnsignedChar)
+    enum __c_char : ubyte;
+else
+    enum __c_char : byte;
+
+int testCppCMangle (cpp_ulonglong, __c_char);
+
+void main()
+{
+    auto val = cast(cpp_ulonglong)18446744073709551488UL;
+    auto ch = cast(__c_char)val;
+    assert(testCppCMangle(val, ch) == cast(int)ch);
+}


### PR DESCRIPTION
C `char` can either be signed or unsigned, depending on platform (or in some cases, compiler flags).