### PR TITLE
dmd.globals: Remove unused d_intN and d_unsN types

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -4551,30 +4551,30 @@ struct ASTBase
                 break;
 
             case Tint8:
-                value = cast(d_int8)value;
+                value = cast(byte)value;
                 break;
 
             case Tchar:
             case Tuns8:
-                value = cast(d_uns8)value;
+                value = cast(ubyte)value;
                 break;
 
             case Tint16:
-                value = cast(d_int16)value;
+                value = cast(short)value;
                 break;
 
             case Twchar:
             case Tuns16:
-                value = cast(d_uns16)value;
+                value = cast(ushort)value;
                 break;
 
             case Tint32:
-                value = cast(d_int32)value;
+                value = cast(int)value;
                 break;
 
             case Tdchar:
             case Tuns32:
-                value = cast(d_uns32)value;
+                value = cast(uint)value;
                 break;
 
             case Tint64:

--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -60,7 +60,7 @@ extern (C++) struct Compiler
     {
         union U
         {
-            d_int32 int32value;
+            int int32value;
             d_int64 int64value;
             float float32value;
             double float64value;
@@ -73,7 +73,7 @@ extern (C++) struct Compiler
         {
         case Tint32:
         case Tuns32:
-            u.int32value = cast(d_int32) e.toInteger();
+            u.int32value = cast(int) e.toInteger();
             break;
         case Tint64:
         case Tuns64:

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -619,25 +619,25 @@ UnionExp Shr(const ref Loc loc, Type type, Expression e1, Expression e2)
     switch (e1.type.toBasetype().ty)
     {
     case Tint8:
-        value = cast(d_int8)value >> count;
+        value = cast(byte)value >> count;
         break;
     case Tuns8:
     case Tchar:
-        value = cast(d_uns8)value >> count;
+        value = cast(ubyte)value >> count;
         break;
     case Tint16:
-        value = cast(d_int16)value >> count;
+        value = cast(short)value >> count;
         break;
     case Tuns16:
     case Twchar:
-        value = cast(d_uns16)value >> count;
+        value = cast(ushort)value >> count;
         break;
     case Tint32:
-        value = cast(d_int32)value >> count;
+        value = cast(int)value >> count;
         break;
     case Tuns32:
     case Tdchar:
-        value = cast(d_uns32)value >> count;
+        value = cast(uint)value >> count;
         break;
     case Tint64:
         value = cast(d_int64)value >> count;
@@ -1106,25 +1106,25 @@ UnionExp Cast(const ref Loc loc, Type type, Type to, Expression e1)
             switch (typeb.ty)
             {
             case Tint8:
-                result = cast(d_int8)cast(sinteger_t)r;
+                result = cast(byte)cast(sinteger_t)r;
                 break;
             case Tchar:
             case Tuns8:
-                result = cast(d_uns8)cast(dinteger_t)r;
+                result = cast(ubyte)cast(dinteger_t)r;
                 break;
             case Tint16:
-                result = cast(d_int16)cast(sinteger_t)r;
+                result = cast(short)cast(sinteger_t)r;
                 break;
             case Twchar:
             case Tuns16:
-                result = cast(d_uns16)cast(dinteger_t)r;
+                result = cast(ushort)cast(dinteger_t)r;
                 break;
             case Tint32:
-                result = cast(d_int32)r;
+                result = cast(int)r;
                 break;
             case Tdchar:
             case Tuns32:
-                result = cast(d_uns32)r;
+                result = cast(uint)r;
                 break;
             case Tint64:
                 result = cast(d_int64)r;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1797,7 +1797,7 @@ extern (C++) final class IntegerExp : Expression
     {
         super(Loc.initial, EXP.int64, __traits(classInstanceSize, IntegerExp));
         this.type = Type.tint32;
-        this.value = cast(d_int32)value;
+        this.value = cast(int)value;
     }
 
     static IntegerExp create(const ref Loc loc, dinteger_t value, Type type)
@@ -1895,30 +1895,30 @@ extern (C++) final class IntegerExp : Expression
             break;
 
         case Tint8:
-            result = cast(d_int8)value;
+            result = cast(byte)value;
             break;
 
         case Tchar:
         case Tuns8:
-            result = cast(d_uns8)value;
+            result = cast(ubyte)value;
             break;
 
         case Tint16:
-            result = cast(d_int16)value;
+            result = cast(short)value;
             break;
 
         case Twchar:
         case Tuns16:
-            result = cast(d_uns16)value;
+            result = cast(ushort)value;
             break;
 
         case Tint32:
-            result = cast(d_int32)value;
+            result = cast(int)value;
             break;
 
         case Tdchar:
         case Tuns32:
-            result = cast(d_uns32)value;
+            result = cast(uint)value;
             break;
 
         case Tint64:

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -486,12 +486,6 @@ alias dinteger_t = ulong;
 alias sinteger_t = long;
 alias uinteger_t = ulong;
 
-alias d_int8 = int8_t;
-alias d_uns8 = uint8_t;
-alias d_int16 = int16_t;
-alias d_uns16 = uint16_t;
-alias d_int32 = int32_t;
-alias d_uns32 = uint32_t;
 alias d_int64 = int64_t;
 alias d_uns64 = uint64_t;
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -346,12 +346,6 @@ typedef long long sinteger_t;
 typedef unsigned long long uinteger_t;
 #endif
 
-typedef int8_t                  d_int8;
-typedef uint8_t                 d_uns8;
-typedef int16_t                 d_int16;
-typedef uint16_t                d_uns16;
-typedef int32_t                 d_int32;
-typedef uint32_t                d_uns32;
 typedef int64_t                 d_int64;
 typedef uint64_t                d_uns64;
 

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -3571,10 +3571,10 @@ code *asm_db_parse(OP *pop)
         switch (asmstate.tokValue)
         {
             case TOK.int32Literal:
-                dt.ul = cast(d_int32)asmstate.tok.intvalue;
+                dt.ul = cast(int)asmstate.tok.intvalue;
                 goto L1;
             case TOK.uns32Literal:
-                dt.ul = cast(d_uns32)asmstate.tok.unsvalue;
+                dt.ul = cast(uint)asmstate.tok.unsvalue;
                 goto L1;
             case TOK.int64Literal:
                 dt.ul = asmstate.tok.intvalue;
@@ -3709,11 +3709,11 @@ int asm_getnum()
     switch (asmstate.tokValue)
     {
         case TOK.int32Literal:
-            v = cast(d_int32)asmstate.tok.intvalue;
+            v = cast(int)asmstate.tok.intvalue;
             break;
 
         case TOK.uns32Literal:
-            v = cast(d_uns32)asmstate.tok.unsvalue;
+            v = cast(uint)asmstate.tok.unsvalue;
             break;
 
         case TOK.identifier:
@@ -4476,12 +4476,12 @@ void asm_primary_exp(out OPND o1)
             break;
 
         case TOK.int32Literal:
-            o1.disp = cast(d_int32)asmstate.tok.intvalue;
+            o1.disp = cast(int)asmstate.tok.intvalue;
             asm_token();
             break;
 
         case TOK.uns32Literal:
-            o1.disp = cast(d_uns32)asmstate.tok.unsvalue;
+            o1.disp = cast(uint)asmstate.tok.unsvalue;
             asm_token();
             break;
 

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -942,17 +942,17 @@ nothrow:
         switch (value)
         {
         case TOK.int32Literal:
-            sprintf(&buffer[0], "%d", cast(d_int32)intvalue);
+            sprintf(&buffer[0], "%d", cast(int)intvalue);
             break;
         case TOK.uns32Literal:
         case TOK.wcharLiteral:
         case TOK.dcharLiteral:
         case TOK.wchar_tLiteral:
-            sprintf(&buffer[0], "%uU", cast(d_uns32)unsvalue);
+            sprintf(&buffer[0], "%uU", cast(uint)unsvalue);
             break;
         case TOK.charLiteral:
         {
-            const v = cast(d_int32)intvalue;
+            const v = cast(int)intvalue;
             if (v >= ' ' && v <= '~')
                 sprintf(&buffer[0], "'%c'", v);
             else


### PR DESCRIPTION
This also fixes [#22898](https://issues.dlang.org/show_bug.cgi?id=22898), but only by acknowledging that we can't trust `core.stdc.stdint`.