### PR TITLE
dmd.globals: Replace d_int64 with long

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -4578,7 +4578,7 @@ struct ASTBase
                 break;
 
             case Tint64:
-                value = cast(d_int64)value;
+                value = cast(long)value;
                 break;
 
             case Tuns64:

--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -61,7 +61,7 @@ extern (C++) struct Compiler
         union U
         {
             int int32value;
-            d_int64 int64value;
+            long int64value;
             float float32value;
             double float64value;
         }
@@ -77,7 +77,7 @@ extern (C++) struct Compiler
             break;
         case Tint64:
         case Tuns64:
-            u.int64value = cast(d_int64) e.toInteger();
+            u.int64value = cast(long) e.toInteger();
             break;
         case Tfloat32:
             u.float32value = cast(float) e.toReal();

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -640,7 +640,7 @@ UnionExp Shr(const ref Loc loc, Type type, Expression e1, Expression e2)
         value = cast(uint)value >> count;
         break;
     case Tint64:
-        value = cast(d_int64)value >> count;
+        value = cast(long)value >> count;
         break;
     case Tuns64:
         value = cast(ulong)value >> count;
@@ -1127,7 +1127,7 @@ UnionExp Cast(const ref Loc loc, Type type, Type to, Expression e1)
                 result = cast(uint)r;
                 break;
             case Tint64:
-                result = cast(d_int64)r;
+                result = cast(long)r;
                 break;
             case Tuns64:
                 result = cast(ulong)r;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1839,7 +1839,7 @@ extern (C++) final class IntegerExp : Expression
         value = val;
         return (ty == Tuns64)
             ? real_t(cast(ulong)val)
-            : real_t(cast(d_int64)val);
+            : real_t(cast(long)val);
     }
 
     override real_t toImaginary()
@@ -1922,7 +1922,7 @@ extern (C++) final class IntegerExp : Expression
             break;
 
         case Tint64:
-            result = cast(d_int64)value;
+            result = cast(long)value;
             break;
 
         case Tuns64:

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -10336,7 +10336,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 // Need to divide the result by the stride
                 // Replace (ptr - ptr) with (ptr - ptr) / stride
-                d_int64 stride;
+                long stride;
 
                 // make sure pointer types are compatible
                 if (Expression ex = typeCombine(exp, sc))
@@ -10351,7 +10351,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     e = new IntegerExp(exp.loc, 0, Type.tptrdiff_t);
                 }
-                else if (stride == cast(d_int64)SIZE_INVALID)
+                else if (stride == cast(long)SIZE_INVALID)
                     e = ErrorExp.get();
                 else
                 {

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7695,12 +7695,12 @@ struct Target final
         real_t nan;
         real_t infinity;
         real_t epsilon;
-        d_int64 dig;
-        d_int64 mant_dig;
-        d_int64 max_exp;
-        d_int64 min_exp;
-        d_int64 max_10_exp;
-        d_int64 min_10_exp;
+        int64_t dig;
+        int64_t mant_dig;
+        int64_t max_exp;
+        int64_t min_exp;
+        int64_t max_10_exp;
+        int64_t min_10_exp;
         FPTypeProperties()
         {
         }

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -486,7 +486,6 @@ alias dinteger_t = ulong;
 alias sinteger_t = long;
 alias uinteger_t = ulong;
 
-alias d_int64 = int64_t;
 alias d_uns64 = uint64_t;
 
 version (DMDLIB)

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -346,7 +346,6 @@ typedef long long sinteger_t;
 typedef unsigned long long uinteger_t;
 #endif
 
-typedef int64_t                 d_int64;
 typedef uint64_t                d_uns64;
 
 // file location

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -80,7 +80,7 @@ extern (C++) struct Target
     import dmd.dscope : Scope;
     import dmd.expression : Expression;
     import dmd.func : FuncDeclaration;
-    import dmd.globals : Loc, d_int64;
+    import dmd.globals : Loc;
     import dmd.astenums : LINK, TY;
     import dmd.mtype : Type, TypeFunction, TypeTuple;
     import dmd.root.ctfloat : real_t;
@@ -152,18 +152,18 @@ extern (C++) struct Target
      */
     extern (C++) struct FPTypeProperties(T)
     {
-        real_t max;                         /// largest representable value that's not infinity
-        real_t min_normal;                  /// smallest representable normalized value that's not 0
-        real_t nan;                         /// NaN value
-        real_t infinity;                    /// infinity value
-        real_t epsilon;                     /// smallest increment to the value 1
+        real_t max;         /// largest representable value that's not infinity
+        real_t min_normal;  /// smallest representable normalized value that's not 0
+        real_t nan;         /// NaN value
+        real_t infinity;    /// infinity value
+        real_t epsilon;     /// smallest increment to the value 1
 
-        d_int64 dig;                        /// number of decimal digits of precision
-        d_int64 mant_dig;                   /// number of bits in mantissa
-        d_int64 max_exp;                    /// maximum int value such that 2$(SUPERSCRIPT `max_exp-1`) is representable
-        d_int64 min_exp;                    /// minimum int value such that 2$(SUPERSCRIPT `min_exp-1`) is representable as a normalized value
-        d_int64 max_10_exp;                 /// maximum int value such that 10$(SUPERSCRIPT `max_10_exp` is representable)
-        d_int64 min_10_exp;                 /// minimum int value such that 10$(SUPERSCRIPT `min_10_exp`) is representable as a normalized value
+        long dig;           /// number of decimal digits of precision
+        long mant_dig;      /// number of bits in mantissa
+        long max_exp;       /// maximum int value such that 2$(SUPERSCRIPT `max_exp-1`) is representable
+        long min_exp;       /// minimum int value such that 2$(SUPERSCRIPT `min_exp-1`) is representable as a normalized value
+        long max_10_exp;    /// maximum int value such that 10$(SUPERSCRIPT `max_10_exp` is representable)
+        long min_10_exp;    /// minimum int value such that 10$(SUPERSCRIPT `min_10_exp`) is representable as a normalized value
 
         extern (D) void initialize()
         {

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -175,12 +175,12 @@ struct Target
         real_t infinity;
         real_t epsilon;
 
-        d_int64 dig;
-        d_int64 mant_dig;
-        d_int64 max_exp;
-        d_int64 min_exp;
-        d_int64 max_10_exp;
-        d_int64 min_10_exp;
+        int64_t dig;
+        int64_t mant_dig;
+        int64_t max_exp;
+        int64_t min_exp;
+        int64_t max_10_exp;
+        int64_t min_10_exp;
     };
 
     FPTypeProperties<float> FloatProperties;


### PR DESCRIPTION
Same as #13835, but for `d_int64`.  The only place this is used other than casting is for member fields, which are trivially replaceable with `int64_t`.