### PR TITLE
dmd.globals: Replace trivial uses of d_uns64 with ulong

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -4582,7 +4582,7 @@ struct ASTBase
                 break;
 
             case Tuns64:
-                value = cast(d_uns64)value;
+                value = cast(ulong)value;
                 break;
 
             case Tpointer:

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -643,7 +643,7 @@ UnionExp Shr(const ref Loc loc, Type type, Expression e1, Expression e2)
         value = cast(d_int64)value >> count;
         break;
     case Tuns64:
-        value = cast(d_uns64)value >> count;
+        value = cast(ulong)value >> count;
         break;
     case Terror:
         emplaceExp!(ErrorExp)(&ue);
@@ -1130,7 +1130,7 @@ UnionExp Cast(const ref Loc loc, Type type, Type to, Expression e1)
                 result = cast(d_int64)r;
                 break;
             case Tuns64:
-                result = cast(d_uns64)r;
+                result = cast(ulong)r;
                 break;
             default:
                 assert(0);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1838,7 +1838,7 @@ extern (C++) final class IntegerExp : Expression
         const val = normalize(ty, value);
         value = val;
         return (ty == Tuns64)
-            ? real_t(cast(d_uns64)val)
+            ? real_t(cast(ulong)val)
             : real_t(cast(d_int64)val);
     }
 
@@ -1926,7 +1926,7 @@ extern (C++) final class IntegerExp : Expression
             break;
 
         case Tuns64:
-            result = cast(d_uns64)value;
+            result = cast(ulong)value;
             break;
 
         case Tpointer:

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -221,7 +221,7 @@ package void setLengthVarIfKnown(VarDeclaration lengthVar, Expression arr)
         return;
     if (lengthVar._init && !lengthVar._init.isVoidInitializer())
         return; // we have previously calculated the length
-    d_uns64 len;
+    dinteger_t len;
     if (auto se = arr.isStringExp())
         len = se.len;
     else if (auto ale = arr.isArrayLiteralExp())
@@ -253,7 +253,7 @@ package void setLengthVarIfKnown(VarDeclaration lengthVar, Type type)
     auto tsa = type.toBasetype().isTypeSArray();
     if (!tsa)
         return; // we don't know the length yet
-    d_uns64 len = tsa.dim.toInteger();
+    const len = tsa.dim.toInteger();
     Expression dollar = new IntegerExp(Loc.initial, len, Type.tsize_t);
     lengthVar._init = new ExpInitializer(Loc.initial, dollar);
     lengthVar.storage_class |= STC.static_ | STC.const_;

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -254,9 +254,9 @@ void write_instance_pointers(Type type, Symbol *s, uint offset)
     if (!type.hasPointers())
         return;
 
-    Array!(d_uns64) data;
-    d_uns64 sz = getTypePointerBitmap(Loc.initial, type, &data);
-    if (sz == d_uns64.max)
+    Array!(ulong) data;
+    ulong sz = getTypePointerBitmap(Loc.initial, type, &data);
+    if (sz == ulong.max)
         return;
 
     const bytes_size_t = cast(size_t)Type.tsize_t.size(Loc.initial);

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -166,28 +166,28 @@ shared static this()
 /**
  * get an array of size_t values that indicate possible pointer words in memory
  *  if interpreted as the type given as argument
- * Returns: the size of the type in bytes, d_uns64.max on error
+ * Returns: the size of the type in bytes, ulong.max on error
  */
-d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
+ulong getTypePointerBitmap(Loc loc, Type t, Array!(ulong)* data)
 {
-    d_uns64 sz;
+    ulong sz;
     if (t.ty == Tclass && !(cast(TypeClass)t).sym.isInterfaceDeclaration())
         sz = (cast(TypeClass)t).sym.AggregateDeclaration.size(loc);
     else
         sz = t.size(loc);
     if (sz == SIZE_INVALID)
-        return d_uns64.max;
+        return ulong.max;
 
     const sz_size_t = Type.tsize_t.size(loc);
     if (sz > sz.max - sz_size_t)
     {
         error(loc, "size overflow for type `%s`", t.toChars());
-        return d_uns64.max;
+        return ulong.max;
     }
 
-    d_uns64 bitsPerWord = sz_size_t * 8;
-    d_uns64 cntptr = (sz + sz_size_t - 1) / sz_size_t;
-    d_uns64 cntdata = (cntptr + bitsPerWord - 1) / bitsPerWord;
+    ulong bitsPerWord = sz_size_t * 8;
+    ulong cntptr = (sz + sz_size_t - 1) / sz_size_t;
+    ulong cntdata = (cntptr + bitsPerWord - 1) / bitsPerWord;
 
     data.setDim(cast(size_t)cntdata);
     data.zero();
@@ -196,15 +196,15 @@ d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
     {
         alias visit = Visitor.visit;
     public:
-        extern (D) this(Array!(d_uns64)* _data, d_uns64 _sz_size_t)
+        extern (D) this(Array!(ulong)* _data, ulong _sz_size_t)
         {
             this.data = _data;
             this.sz_size_t = _sz_size_t;
         }
 
-        void setpointer(d_uns64 off)
+        void setpointer(ulong off)
         {
-            d_uns64 ptroff = off / sz_size_t;
+            ulong ptroff = off / sz_size_t;
             (*data)[cast(size_t)(ptroff / (8 * sz_size_t))] |= 1L << (ptroff % (8 * sz_size_t));
         }
 
@@ -242,12 +242,12 @@ d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
 
         override void visit(TypeSArray t)
         {
-            d_uns64 arrayoff = offset;
-            d_uns64 nextsize = t.next.size();
+            ulong arrayoff = offset;
+            ulong nextsize = t.next.size();
             if (nextsize == SIZE_INVALID)
                 error = true;
-            d_uns64 dim = t.dim.toInteger();
-            for (d_uns64 i = 0; i < dim; i++)
+            ulong dim = t.dim.toInteger();
+            for (ulong i = 0; i < dim; i++)
             {
                 offset = arrayoff + i * nextsize;
                 t.next.accept(this);
@@ -340,7 +340,7 @@ d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
 
         override void visit(TypeStruct t)
         {
-            d_uns64 structoff = offset;
+            ulong structoff = offset;
             foreach (v; t.sym.fields)
             {
                 offset = structoff + v.offset;
@@ -355,7 +355,7 @@ d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
         // a "toplevel" class is treated as an instance, while TypeClass fields are treated as references
         void visitClass(TypeClass t)
         {
-            d_uns64 classoff = offset;
+            ulong classoff = offset;
             // skip vtable-ptr and monitor
             if (t.sym.baseClass)
                 visitClass(cast(TypeClass)t.sym.baseClass.type);
@@ -367,9 +367,9 @@ d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
             offset = classoff;
         }
 
-        Array!(d_uns64)* data;
-        d_uns64 offset;
-        d_uns64 sz_size_t;
+        Array!(ulong)* data;
+        ulong offset;
+        ulong sz_size_t;
         bool error;
     }
 
@@ -378,7 +378,7 @@ d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
         pbv.visitClass(cast(TypeClass)t);
     else
         t.accept(pbv);
-    return pbv.error ? d_uns64.max : sz;
+    return pbv.error ? ulong.max : sz;
 }
 
 /**
@@ -406,9 +406,9 @@ private Expression pointerBitmap(TraitsExp e)
         return ErrorExp.get();
     }
 
-    Array!(d_uns64) data;
-    d_uns64 sz = getTypePointerBitmap(e.loc, t, &data);
-    if (sz == d_uns64.max)
+    Array!(ulong) data;
+    ulong sz = getTypePointerBitmap(e.loc, t, &data);
+    if (sz == ulong.max)
         return ErrorExp.get();
 
     auto exps = new Expressions(data.dim + 1);

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2411,7 +2411,7 @@ Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier iden
         }
         if (ident == Id.__sizeof)
         {
-            d_uns64 sz = mt.size(loc);
+            const sz = mt.size(loc);
             if (sz == SIZE_INVALID)
                 return ErrorExp.get();
             e = new IntegerExp(loc, sz, Type.tsize_t);


### PR DESCRIPTION
Same as https://github.com/dlang/dmd/pull/13835 and #13836, but for trivial uses of d_uns64 that don't affect the C++ ABI.