### PR TITLE
dmd.target: Remove Target.parameterSize

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7724,7 +7724,6 @@ public:
     LINK systemLinkage();
     TypeTuple* toArgTypes(Type* t);
     bool isReturnOnStack(TypeFunction* tf, bool needsThis);
-    uint64_t parameterSize(const Loc& loc, Type* t);
     bool preferPassByRef(Type* t);
 private:
     enum class TargetInfoKeys

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -896,35 +896,6 @@ extern (C++) struct Target
         }
     }
 
-    /***
-     * Determine the size a value of type `t` will be when it
-     * is passed on the function parameter stack.
-     * Params:
-     *  loc = location to use for error messages
-     *  t = type of parameter
-     * Returns:
-     *  size used on parameter stack
-     */
-    extern (C++) ulong parameterSize(const ref Loc loc, Type t)
-    {
-        if (!is64bit &&
-            (os & (Target.OS.FreeBSD | Target.OS.OpenBSD | Target.OS.OSX)))
-        {
-            /* These platforms use clang, which regards a struct
-             * with size 0 as being of size 0 on the parameter stack,
-             * even while sizeof(struct) is 1.
-             * It's an ABI incompatibility with gcc.
-             */
-            if (auto ts = t.isTypeStruct())
-            {
-                if (ts.sym.hasNoFields)
-                    return 0;
-            }
-        }
-        const sz = t.size(loc);
-        return is64bit ? (sz + 7) & ~7 : (sz + 3) & ~3;
-    }
-
     /**
      * Decides whether an `in` parameter of the specified POD type is to be
      * passed by reference or by value. To be used with `-preview=in` only!

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -203,7 +203,6 @@ public:
     LINK systemLinkage();
     TypeTuple *toArgTypes(Type *t);
     bool isReturnOnStack(TypeFunction *tf, bool needsThis);
-    d_uns64 parameterSize(const Loc& loc, Type *t);
     bool preferPassByRef(Type *t);
     Expression *getTargetInfo(const char* name, const Loc& loc);
     bool isCalleeDestroyingArgs(TypeFunction* tf);


### PR DESCRIPTION
This was introduced by #7963, but was never used anywhere, and still remains unused to this day.