### PR TITLE
fix Issue 22859 - Error: forward reference of variable 'isAssignable' for mutually recursed 'allSatisfy'

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6386,9 +6386,6 @@ extern (C++) final class TypeClass : Type
 
     override MOD deduceWild(Type t, bool isRef)
     {
-        // If sym is forward referenced:
-        if (sym.semanticRun < PASS.semanticdone && !sym.isBaseInfoComplete())
-            sym.dsymbolSemantic(null);
         ClassDeclaration cd = t.isClassHandle();
         if (cd && (sym == cd || cd.isBaseOf(sym, null)))
             return Type.deduceWild(t, isRef);

--- a/test/compilable/test22714.d
+++ b/test/compilable/test22714.d
@@ -1,2 +1,3 @@
+// EXTRA_FILES: imports/test22714a.d imports/test22714b.d
 // https://issues.dlang.org/show_bug.cgi?id=22714
 import imports.test22714a;

--- a/test/compilable/test22859.d
+++ b/test/compilable/test22859.d
@@ -1,0 +1,40 @@
+// https://issues.dlang.org/show_bug.cgi?id=22859
+private struct __InoutWorkaroundStruct {}
+@property T rvalueOf(T)(T val) { return val; }
+@property T rvalueOf(T)(inout __InoutWorkaroundStruct = __InoutWorkaroundStruct.init);
+@property ref T lvalueOf(T)(inout __InoutWorkaroundStruct = __InoutWorkaroundStruct.init);
+
+// taken from std.traits.isAssignable
+template isAssignable(Lhs, Rhs = Lhs)
+{
+    enum isAssignable = __traits(compiles, lvalueOf!Lhs = rvalueOf!Rhs) && __traits(compiles, lvalueOf!Lhs = lvalueOf!Rhs);
+}
+
+// taken from std.meta.allSatisfy
+template allSatisfy(alias F, T...)
+{
+    static foreach (Ti; T)
+    {
+        static if (!is(typeof(allSatisfy) == bool) && // not yet defined
+                   !F!(Ti))
+        {
+            enum allSatisfy = false;
+        }
+    }
+    static if (!is(typeof(allSatisfy) == bool)) // if not yet defined
+    {
+        enum allSatisfy = true;
+    }
+}
+
+struct None{}
+
+class C1
+{
+    static if(allSatisfy!(isAssignable, None, C2)) {}
+}
+
+class C2
+{
+    static if(allSatisfy!(isAssignable, None, C1, C2)) {}
+}

--- a/test/compilable/test22860.d
+++ b/test/compilable/test22860.d
@@ -1,0 +1,62 @@
+// https://issues.dlang.org/show_bug.cgi?id=22860
+class C1
+{   
+    SumType!(C1, C2) field;
+}
+
+class C2
+{
+    SumType!(SumType!(C1, C2)) field;
+}
+
+alias AliasSeq(TList...) = TList;
+
+template allSatisfy(alias F, T...)
+{
+    static foreach (Ti; T)
+    {
+        static if (!F!Ti)
+            enum allSatisfy = false;
+    }
+}
+
+struct This {}
+
+enum isAssignableTo(T) = isAssignable!T;
+enum isHashable(T) = __traits(compiles, { T.init; });
+
+struct SumType(Types...)
+{
+    alias Types = AliasSeq!(ReplaceTypeUnless!(isSumTypeInstance, This, typeof(this), TemplateArgsOf!SumType));
+
+    static foreach (T; Types)
+    {
+        static if (isAssignableTo!T)
+        {
+        }
+    }
+
+    static if (allSatisfy!(isAssignableTo, Types))
+    {
+    }
+
+    static if (allSatisfy!(isHashable, Types))
+        size_t toHash;
+}
+
+bool isSumTypeInstance;
+
+alias TemplateArgsOf(T : Base!Args, alias Base, Args...) = Args;
+enum isAssignable(Lhs, Rhs = Lhs) = isRvalueAssignable!(Lhs, Rhs) ;
+enum isRvalueAssignable(Lhs, Rhs ) = __traits(compiles, { lvalueOf!Lhs = Rhs; });
+
+struct __InoutWorkaroundStruct{}
+T lvalueOf(T)(__InoutWorkaroundStruct );
+
+template ReplaceTypeUnless(alias pred, From, To, T...)
+{
+    static if (T.length == 1)
+        alias ReplaceTypeUnless = T;
+    static if (T.length > 1)
+        alias ReplaceTypeUnless = AliasSeq!(ReplaceTypeUnless!(pred, From, To, T[1 ]));
+}

--- a/test/fail_compilation/ice10727a.d
+++ b/test/fail_compilation/ice10727a.d
@@ -4,8 +4,6 @@
 TEST_OUTPUT:
 ---
 fail_compilation/imports/foo10727a.d(34): Error: undefined identifier `Frop`
-fail_compilation/imports/foo10727a.d(26): Error: template instance `foo10727a.CirBuff!(Foo)` error instantiating
-fail_compilation/imports/foo10727a.d(31):        instantiated from here: `Bar!(Foo)`
 ---
 */
 

--- a/test/fail_compilation/ice10727b.d
+++ b/test/fail_compilation/ice10727b.d
@@ -4,8 +4,6 @@
 TEST_OUTPUT:
 ---
 fail_compilation/imports/foo10727b.d(25): Error: undefined identifier `Frop`
-fail_compilation/imports/foo10727b.d(17): Error: template instance `foo10727b.CirBuff!(Foo)` error instantiating
-fail_compilation/imports/foo10727b.d(22):        instantiated from here: `Bar!(Foo)`
 ---
 */
 


### PR DESCRIPTION
Checked the bootstrap on x86_64-linux-gnu, and the ICE in `isBaseOf` no longer occurs, so this introducing code can be removed.