### PR TITLE
dmd.mtype: Change return type of size() to uinteger_t

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -234,7 +234,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
     abstract void finalizeSize();
 
-    override final d_uns64 size(const ref Loc loc)
+    override final uinteger_t size(const ref Loc loc)
     {
         //printf("+AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
         bool ok = determineSize(loc);

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -124,7 +124,7 @@ public:
     size_t nonHiddenFields();
     bool determineSize(const Loc &loc);
     virtual void finalizeSize() = 0;
-    d_uns64 size(const Loc &loc);
+    uinteger_t size(const Loc &loc);
     bool fill(const Loc &loc, Expressions *elements, bool ctorinit);
     Type *getType();
     bool isDeprecated() const;         // is aggregate deprecated?

--- a/src/dmd/argtypes_x86.d
+++ b/src/dmd/argtypes_x86.d
@@ -325,7 +325,7 @@ extern (C++) TypeTuple toArgTypes_x86(Type t)
          *      nfields = number of fields in the aggregate (dimension for static arrays)
          *      getFieldInfo = get information about the nth field in the aggregate
          */
-        extern (D) void aggregate(d_uns64 sz, size_t nfields, Type delegate(size_t, out uint, out uint) getFieldInfo)
+        extern (D) void aggregate(uinteger_t sz, size_t nfields, Type delegate(size_t, out uint, out uint) getFieldInfo)
         {
             if (nfields == 0)
                 return memory();

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1894,7 +1894,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
         if (e.committed && tb.ty == Tsarray && typeb.ty == Tarray)
         {
             se = e.copy().isStringExp();
-            d_uns64 szx = tb.nextOf().size();
+            uinteger_t szx = tb.nextOf().size();
             assert(szx <= 255);
             se.sz = cast(ubyte)szx;
             se.len = cast(size_t)tb.isTypeSArray().dim.toInteger();
@@ -2059,7 +2059,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                 }
 
                 {
-                    d_uns64 szx = tb.nextOf().size();
+                    uinteger_t szx = tb.nextOf().size();
                     assert(szx <= 255);
                     se.setData(buffer.extractSlice().ptr, newlen, cast(ubyte)szx);
                 }
@@ -2742,7 +2742,7 @@ Expression scaleFactor(BinExp be, Scope* sc)
         // Replace (ptr + int) with (ptr + (int * stride))
         Type t = Type.tptrdiff_t;
 
-        d_uns64 stride = t1b.nextOf().size(be.loc);
+        uinteger_t stride = t1b.nextOf().size(be.loc);
         if (!t.equals(t2b))
             be.e2 = be.e2.castTo(sc, t);
         eoff = be.e2;
@@ -2757,7 +2757,7 @@ Expression scaleFactor(BinExp be, Scope* sc)
         Type t = Type.tptrdiff_t;
         Expression e;
 
-        d_uns64 stride = t2b.nextOf().size(be.loc);
+        uinteger_t stride = t2b.nextOf().size(be.loc);
         if (!t.equals(t1b))
             e = be.e1.castTo(sc, t);
         else

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -250,7 +250,7 @@ extern (C++) abstract class Declaration : Dsymbol
         return "declaration";
     }
 
-    override final d_uns64 size(const ref Loc loc)
+    override final uinteger_t size(const ref Loc loc)
     {
         assert(type);
         const sz = type.size();

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -123,7 +123,7 @@ public:
     DString mangleOverride;     // overridden symbol with pragma(mangle, "...")
 
     const char *kind() const;
-    d_uns64 size(const Loc &loc);
+    uinteger_t size(const Loc &loc);
 
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
 

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -1886,7 +1886,7 @@ public:
         {
             // Check for unsupported type painting operations
             Type elemtype = (cast(TypeArray)val.type).next;
-            d_uns64 elemsize = elemtype.size();
+            const elemsize = elemtype.size();
 
             // It's OK to cast from fixed length to fixed length array, eg &int[n] to int[d]*.
             if (val.type.ty == Tsarray && pointee.ty == Tsarray && elemsize == pointee.nextOf().size())
@@ -3038,7 +3038,7 @@ public:
         if (e.op == EXP.rightShift || e.op == EXP.leftShift || e.op == EXP.unsignedRightShift)
         {
             const sinteger_t i2 = e2.toInteger();
-            const d_uns64 sz = e1.type.size() * 8;
+            const uinteger_t sz = e1.type.size() * 8;
             if (i2 < 0 || i2 >= sz)
             {
                 e.error("shift by %lld is outside the range 0..%llu", i2, cast(ulong)sz - 1);

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -972,7 +972,7 @@ extern (C++) class Dsymbol : ASTNode
      * Returns:
      *  SIZE_INVALID when the size cannot be determined
      */
-    d_uns64 size(const ref Loc loc)
+    uinteger_t size(const ref Loc loc)
     {
         error("Dsymbol `%s` has no size", toChars());
         return SIZE_INVALID;

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -223,7 +223,7 @@ public:
     virtual void importAll(Scope *sc);
     virtual Dsymbol *search(const Loc &loc, Identifier *ident, int flags = IgnoreNone);
     virtual bool overloadInsert(Dsymbol *s);
-    virtual d_uns64 size(const Loc &loc);
+    virtual uinteger_t size(const Loc &loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration *isThis();     // is a 'this' required to access the member
     virtual bool isExport() const;              // is Dsymbol exported?

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -891,7 +891,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym.error("manifest constants must have initializers");
 
         bool isBlit = false;
-        d_uns64 sz;
+        uinteger_t sz;
         if (sc.flags & SCOPE.Cfile && !dsym._init)
         {
             addDefaultCInitializer(dsym);

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1898,7 +1898,7 @@ extern (C++) class ToElemVisitor : Visitor
                 elem* eptr1, eptr2; // Pointer to data, to pass to memcmp
                 elem* elen1, elen2; // Length, for comparison
                 elem* esiz1, esiz2; // Data size, to pass to memcmp
-                d_uns64 sz = telement.size(); // Size of one element
+                const sz = telement.size(); // Size of one element
 
                 if (t1.ty == Tarray)
                 {

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -943,7 +943,7 @@ struct Ungag final
     }
 };
 
-typedef uint64_t d_uns64;
+typedef uint64_t uinteger_t;
 
 struct Visibility final
 {
@@ -1017,7 +1017,7 @@ public:
     virtual void importAll(Scope* sc);
     virtual Dsymbol* search(const Loc& loc, Identifier* ident, int32_t flags = 0);
     virtual bool overloadInsert(Dsymbol* s);
-    virtual d_uns64 size(const Loc& loc);
+    virtual uinteger_t size(const Loc& loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration* isThis();
     virtual bool isExport() const;
@@ -1411,8 +1411,6 @@ enum class EXP : uint8_t
 };
 
 typedef uint64_t dinteger_t;
-
-typedef uint64_t uinteger_t;
 
 struct complex_t final
 {
@@ -1869,8 +1867,8 @@ public:
     char* toPrettyChars(bool QualifyTypes = false);
     static void _init();
     static void deinitialize();
-    d_uns64 size();
-    virtual d_uns64 size(const Loc& loc);
+    uinteger_t size();
+    virtual uinteger_t size(const Loc& loc);
     virtual uint32_t alignsize();
     Type* trySemantic(const Loc& loc, Scope* sc);
     Type* merge2();
@@ -3360,7 +3358,7 @@ public:
     static TypeAArray* create(Type* t, Type* index);
     const char* kind() const;
     TypeAArray* syntaxCopy();
-    d_uns64 size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc) /* const */;
     bool isZeroInit(const Loc& loc) /* const */;
     bool isBoolean() /* const */;
     bool hasPointers() /* const */;
@@ -3376,7 +3374,7 @@ public:
     uint32_t flags;
     const char* kind() const;
     TypeBasic* syntaxCopy();
-    d_uns64 size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc) /* const */;
     uint32_t alignsize();
     bool isintegral();
     bool isfloating() /* const */;
@@ -3408,7 +3406,7 @@ public:
     AliasThisRec att;
     CPPMANGLE cppmangle;
     const char* kind() const;
-    d_uns64 size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc) /* const */;
     TypeClass* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
     ClassDeclaration* isClassHandle();
@@ -3429,7 +3427,7 @@ class TypeDArray final : public TypeArray
 public:
     const char* kind() const;
     TypeDArray* syntaxCopy();
-    d_uns64 size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc) /* const */;
     uint32_t alignsize() /* const */;
     bool isString();
     bool isZeroInit(const Loc& loc) /* const */;
@@ -3446,7 +3444,7 @@ public:
     const char* kind() const;
     TypeDelegate* syntaxCopy();
     Type* addStorageClass(StorageClass stc);
-    d_uns64 size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc) /* const */;
     uint32_t alignsize() /* const */;
     MATCH implicitConvTo(Type* to);
     bool isZeroInit(const Loc& loc) /* const */;
@@ -3461,7 +3459,7 @@ public:
     EnumDeclaration* sym;
     const char* kind() const;
     TypeEnum* syntaxCopy();
-    d_uns64 size(const Loc& loc);
+    uinteger_t size(const Loc& loc);
     Type* memType(const Loc& loc = Loc::initial);
     uint32_t alignsize();
     Dsymbol* toDsymbol(Scope* sc);
@@ -3493,7 +3491,7 @@ class TypeError final : public Type
 public:
     const char* kind() const;
     TypeError* syntaxCopy();
-    d_uns64 size(const Loc& loc);
+    uinteger_t size(const Loc& loc);
     Expression* defaultInitLiteral(const Loc& loc);
     void accept(Visitor* v);
 };
@@ -3591,7 +3589,7 @@ public:
     void addIdent(Identifier* ident);
     void addInst(TemplateInstance* inst);
     void addIndex(RootObject* e);
-    d_uns64 size(const Loc& loc);
+    uinteger_t size(const Loc& loc);
     void accept(Visitor* v);
 };
 
@@ -3637,7 +3635,7 @@ public:
     MATCH implicitConvTo(Type* to);
     MATCH constConv(Type* to);
     bool isBoolean() /* const */;
-    d_uns64 size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc) /* const */;
     uint32_t alignsize();
     void accept(Visitor* v);
 };
@@ -3650,7 +3648,7 @@ public:
     MATCH implicitConvTo(Type* to);
     bool hasPointers();
     bool isBoolean() /* const */;
-    d_uns64 size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc) /* const */;
     void accept(Visitor* v);
 };
 
@@ -3660,7 +3658,7 @@ public:
     static TypePointer* create(Type* t);
     const char* kind() const;
     TypePointer* syntaxCopy();
-    d_uns64 size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc) /* const */;
     MATCH implicitConvTo(Type* to);
     MATCH constConv(Type* to);
     bool isscalar() /* const */;
@@ -3674,7 +3672,7 @@ class TypeReference final : public TypeNext
 public:
     const char* kind() const;
     TypeReference* syntaxCopy();
-    d_uns64 size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc) /* const */;
     bool isZeroInit(const Loc& loc) /* const */;
     void accept(Visitor* v);
 };
@@ -3695,7 +3693,7 @@ public:
     const char* kind() const;
     TypeSArray* syntaxCopy();
     bool isIncomplete();
-    d_uns64 size(const Loc& loc);
+    uinteger_t size(const Loc& loc);
     uint32_t alignsize();
     bool isString();
     bool isZeroInit(const Loc& loc);
@@ -3729,7 +3727,7 @@ public:
     bool inuse;
     static TypeStruct* create(StructDeclaration* sym);
     const char* kind() const;
-    d_uns64 size(const Loc& loc);
+    uinteger_t size(const Loc& loc);
     uint32_t alignsize();
     TypeStruct* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
@@ -3775,7 +3773,7 @@ public:
     TypeTraits* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
     void accept(Visitor* v);
-    d_uns64 size(const Loc& loc);
+    uinteger_t size(const Loc& loc);
 };
 
 class TypeTuple final : public Type
@@ -3802,7 +3800,7 @@ public:
     const char* kind() const;
     TypeTypeof* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
-    d_uns64 size(const Loc& loc);
+    uinteger_t size(const Loc& loc);
     void accept(Visitor* v);
 };
 
@@ -3813,7 +3811,7 @@ public:
     static TypeVector* create(Type* basetype);
     const char* kind() const;
     TypeVector* syntaxCopy();
-    d_uns64 size(const Loc& loc);
+    uinteger_t size(const Loc& loc);
     uint32_t alignsize();
     bool isintegral();
     bool isfloating();
@@ -5159,7 +5157,7 @@ public:
     size_t nonHiddenFields();
     bool determineSize(const Loc& loc);
     virtual void finalizeSize() = 0;
-    d_uns64 size(const Loc& loc);
+    uinteger_t size(const Loc& loc);
     bool fill(const Loc& loc, Array<Expression* >* elements, bool ctorinit);
     Type* getType();
     bool isDeprecated() const;
@@ -5648,7 +5646,7 @@ public:
     Symbol* isym;
     _d_dynamicArray< const char > mangleOverride;
     const char* kind() const;
-    d_uns64 size(const Loc& loc);
+    uinteger_t size(const Loc& loc);
     Dsymbol* search(const Loc& loc, Identifier* ident, int32_t flags = 8);
     bool isStatic() const;
     virtual bool isDelete();

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -55,7 +55,7 @@ import dmd.visitor;
 enum LOGDOTEXP = 0;         // log ::dotExp()
 enum LOGDEFAULTINIT = 0;    // log ::defaultInit()
 
-enum SIZE_INVALID = (~cast(d_uns64)0);   // error return from size() functions
+enum SIZE_INVALID = (~cast(uinteger_t)0);   // error return from size() functions
 
 
 /***************************
@@ -887,12 +887,12 @@ extern (C++) abstract class Type : ASTNode
         stringtable = stringtable.init;
     }
 
-    final d_uns64 size()
+    final uinteger_t size()
     {
         return size(Loc.initial);
     }
 
-    d_uns64 size(const ref Loc loc)
+    uinteger_t size(const ref Loc loc)
     {
         error(loc, "no size for type `%s`", toChars());
         return SIZE_INVALID;
@@ -2770,7 +2770,7 @@ extern (C++) final class TypeError : Type
         return this;
     }
 
-    override d_uns64 size(const ref Loc loc)
+    override uinteger_t size(const ref Loc loc)
     {
         return SIZE_INVALID;
     }
@@ -3237,7 +3237,7 @@ extern (C++) final class TypeBasic : Type
         return this;
     }
 
-    override d_uns64 size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc) const
     {
         uint size;
         //printf("TypeBasic::size()\n");
@@ -3411,8 +3411,8 @@ extern (C++) final class TypeBasic : Type
             // If converting from integral to integral
             if (tob.flags & TFlags.integral)
             {
-                d_uns64 sz = size(Loc.initial);
-                d_uns64 tosz = tob.size(Loc.initial);
+                const sz = size(Loc.initial);
+                const tosz = tob.size(Loc.initial);
 
                 /* Can't convert to smaller size
                  */
@@ -3512,7 +3512,7 @@ extern (C++) final class TypeVector : Type
         return new TypeVector(basetype.syntaxCopy());
     }
 
-    override d_uns64 size(const ref Loc loc)
+    override uinteger_t size(const ref Loc loc)
     {
         return basetype.size();
     }
@@ -3661,7 +3661,7 @@ extern (C++) final class TypeSArray : TypeArray
         return dim.isIntegerExp() && dim.isIntegerExp().getInteger() == 0;
     }
 
-    override d_uns64 size(const ref Loc loc)
+    override uinteger_t size(const ref Loc loc)
     {
         //printf("TypeSArray::size()\n");
         const n = numberOfElems(loc);
@@ -3860,7 +3860,7 @@ extern (C++) final class TypeDArray : TypeArray
         return result;
     }
 
-    override d_uns64 size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc) const
     {
         //printf("TypeDArray::size()\n");
         return target.ptrsize * 2;
@@ -3964,7 +3964,7 @@ extern (C++) final class TypeAArray : TypeArray
         return result;
     }
 
-    override d_uns64 size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc) const
     {
         return target.ptrsize;
     }
@@ -4056,7 +4056,7 @@ extern (C++) final class TypePointer : TypeNext
         return result;
     }
 
-    override d_uns64 size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc) const
     {
         return target.ptrsize;
     }
@@ -4159,7 +4159,7 @@ extern (C++) final class TypeReference : TypeNext
         return result;
     }
 
-    override d_uns64 size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc) const
     {
         return target.ptrsize;
     }
@@ -5330,7 +5330,7 @@ extern (C++) final class TypeDelegate : TypeNext
         return t;
     }
 
-    override d_uns64 size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc) const
     {
         return target.ptrsize * 2;
     }
@@ -5437,7 +5437,7 @@ extern (C++) final class TypeTraits : Type
         v.visit(this);
     }
 
-    override d_uns64 size(const ref Loc loc)
+    override uinteger_t size(const ref Loc loc)
     {
         return SIZE_INVALID;
     }
@@ -5564,7 +5564,7 @@ extern (C++) abstract class TypeQualified : Type
         idents.push(e);
     }
 
-    override d_uns64 size(const ref Loc loc)
+    override uinteger_t size(const ref Loc loc)
     {
         error(this.loc, "size of type `%s` is not known", toChars());
         return SIZE_INVALID;
@@ -5719,7 +5719,7 @@ extern (C++) final class TypeTypeof : TypeQualified
         return s;
     }
 
-    override d_uns64 size(const ref Loc loc)
+    override uinteger_t size(const ref Loc loc)
     {
         if (exp.type)
             return exp.type.size(loc);
@@ -5794,7 +5794,7 @@ extern (C++) final class TypeStruct : Type
         return "struct";
     }
 
-    override d_uns64 size(const ref Loc loc)
+    override uinteger_t size(const ref Loc loc)
     {
         return sym.size(loc);
     }
@@ -6150,7 +6150,7 @@ extern (C++) final class TypeEnum : Type
         return this;
     }
 
-    override d_uns64 size(const ref Loc loc)
+    override uinteger_t size(const ref Loc loc)
     {
         return sym.getMemtype(loc).size(loc);
     }
@@ -6317,7 +6317,7 @@ extern (C++) final class TypeClass : Type
         return "class";
     }
 
-    override d_uns64 size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc) const
     {
         return target.ptrsize;
     }
@@ -6720,7 +6720,7 @@ extern (C++) final class TypeNull : Type
         return true;
     }
 
-    override d_uns64 size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc) const
     {
         return tvoidptr.size(loc);
     }
@@ -6779,7 +6779,7 @@ extern (C++) final class TypeNoreturn : Type
         return true;  // bottom type can be implicitly converted to any other type
     }
 
-    override d_uns64 size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc) const
     {
         return 0;
     }

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -100,7 +100,7 @@ enum class TY : uint8_t
     TMAX
 };
 
-#define SIZE_INVALID (~(d_uns64)0)   // error return from size() functions
+#define SIZE_INVALID (~(uinteger_t)0)   // error return from size() functions
 
 
 /**
@@ -230,8 +230,8 @@ public:
     char *toPrettyChars(bool QualifyTypes = false);
     static void _init();
 
-    d_uns64 size();
-    virtual d_uns64 size(const Loc &loc);
+    uinteger_t size();
+    virtual uinteger_t size(const Loc &loc);
     virtual unsigned alignsize();
     Type *trySemantic(const Loc &loc, Scope *sc);
     Type *merge2();
@@ -357,7 +357,7 @@ public:
     const char *kind();
     TypeError *syntaxCopy();
 
-    d_uns64 size(const Loc &loc);
+    uinteger_t size(const Loc &loc);
     Expression *defaultInitLiteral(const Loc &loc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -393,7 +393,7 @@ public:
 
     const char *kind();
     TypeBasic *syntaxCopy();
-    d_uns64 size(const Loc &loc) /*const*/;
+    uinteger_t size(const Loc &loc) /*const*/;
     unsigned alignsize();
     bool isintegral();
     bool isfloating() /*const*/;
@@ -418,7 +418,7 @@ public:
     static TypeVector *create(Type *basetype);
     const char *kind();
     TypeVector *syntaxCopy();
-    d_uns64 size(const Loc &loc);
+    uinteger_t size(const Loc &loc);
     unsigned alignsize();
     bool isintegral();
     bool isfloating();
@@ -448,7 +448,7 @@ public:
     const char *kind();
     TypeSArray *syntaxCopy();
     bool isIncomplete();
-    d_uns64 size(const Loc &loc);
+    uinteger_t size(const Loc &loc);
     unsigned alignsize();
     bool isString();
     bool isZeroInit(const Loc &loc);
@@ -471,7 +471,7 @@ class TypeDArray : public TypeArray
 public:
     const char *kind();
     TypeDArray *syntaxCopy();
-    d_uns64 size(const Loc &loc) /*const*/;
+    uinteger_t size(const Loc &loc) /*const*/;
     unsigned alignsize() /*const*/;
     bool isString();
     bool isZeroInit(const Loc &loc) /*const*/;
@@ -491,7 +491,7 @@ public:
     static TypeAArray *create(Type *t, Type *index);
     const char *kind();
     TypeAArray *syntaxCopy();
-    d_uns64 size(const Loc &loc);
+    uinteger_t size(const Loc &loc);
     bool isZeroInit(const Loc &loc) /*const*/;
     bool isBoolean() /*const*/;
     bool hasPointers() /*const*/;
@@ -507,7 +507,7 @@ public:
     static TypePointer *create(Type *t);
     const char *kind();
     TypePointer *syntaxCopy();
-    d_uns64 size(const Loc &loc) /*const*/;
+    uinteger_t size(const Loc &loc) /*const*/;
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
     bool isscalar() /*const*/;
@@ -522,7 +522,7 @@ class TypeReference : public TypeNext
 public:
     const char *kind();
     TypeReference *syntaxCopy();
-    d_uns64 size(const Loc &loc) /*const*/;
+    uinteger_t size(const Loc &loc) /*const*/;
     bool isZeroInit(const Loc &loc) /*const*/;
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -655,7 +655,7 @@ public:
     const char *kind();
     TypeDelegate *syntaxCopy();
     Type *addStorageClass(StorageClass stc);
-    d_uns64 size(const Loc &loc) /*const*/;
+    uinteger_t size(const Loc &loc) /*const*/;
     unsigned alignsize() /*const*/;
     MATCH implicitConvTo(Type *to);
     bool isZeroInit(const Loc &loc) /*const*/;
@@ -675,7 +675,7 @@ class TypeTraits : public Type
 
     const char *kind();
     TypeTraits *syntaxCopy();
-    d_uns64 size(const Loc &loc);
+    uinteger_t size(const Loc &loc);
     Dsymbol *toDsymbol(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -704,7 +704,7 @@ public:
     void addIdent(Identifier *ident);
     void addInst(TemplateInstance *inst);
     void addIndex(RootObject *expr);
-    d_uns64 size(const Loc &loc);
+    uinteger_t size(const Loc &loc);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -744,7 +744,7 @@ public:
     const char *kind();
     TypeTypeof *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
-    d_uns64 size(const Loc &loc);
+    uinteger_t size(const Loc &loc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -778,7 +778,7 @@ public:
 
     static TypeStruct *create(StructDeclaration *sym);
     const char *kind();
-    d_uns64 size(const Loc &loc);
+    uinteger_t size(const Loc &loc);
     unsigned alignsize();
     TypeStruct *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
@@ -808,7 +808,7 @@ public:
 
     const char *kind();
     TypeEnum *syntaxCopy();
-    d_uns64 size(const Loc &loc);
+    uinteger_t size(const Loc &loc);
     unsigned alignsize();
     Type *memType(const Loc &loc = Loc());
     Dsymbol *toDsymbol(Scope *sc);
@@ -844,7 +844,7 @@ public:
     CPPMANGLE cppmangle;
 
     const char *kind();
-    d_uns64 size(const Loc &loc) /*const*/;
+    uinteger_t size(const Loc &loc) /*const*/;
     TypeClass *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
     ClassDeclaration *isClassHandle();
@@ -899,7 +899,7 @@ public:
     MATCH implicitConvTo(Type *to);
     bool isBoolean() /*const*/;
 
-    d_uns64 size(const Loc &loc) /*const*/;
+    uinteger_t size(const Loc &loc) /*const*/;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -911,7 +911,7 @@ public:
     MATCH implicitConvTo(Type* to);
     MATCH constConv(Type* to);
     bool isBoolean() /* const */;
-    d_uns64 size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc) /* const */;
     unsigned alignsize();
 
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -809,7 +809,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             if (e.e2.isConst() == 1)
             {
                 sinteger_t i2 = e.e2.toInteger();
-                d_uns64 sz = e.e1.type.size(e.e1.loc);
+                uinteger_t sz = e.e1.type.size(e.e1.loc);
                 assert(sz != SIZE_INVALID);
                 sz *= 8;
                 if (i2 < 0 || i2 >= sz)
@@ -895,7 +895,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
         if (e.e2.isConst() == 1)
         {
             sinteger_t i2 = e.e2.toInteger();
-            d_uns64 sz = e.e1.type.size(e.e1.loc);
+            uinteger_t sz = e.e1.type.size(e.e1.loc);
             assert(sz != SIZE_INVALID);
             sz *= 8;
             if (i2 < 0 || i2 >= sz)

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -570,7 +570,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 return;
 
             Symbol *s = toSymbol(vd);
-            d_uns64 sz64 = vd.type.size(vd.loc);
+            const sz64 = vd.type.size(vd.loc);
             if (sz64 == SIZE_INVALID)
             {
                 vd.error("size overflow");


### PR DESCRIPTION
Both `d_uns64` and `uinteger_t` are equivalent, but the latter maps directly to D `ulong` rather than `uint64_t`, which could be any 64-bit C type.