### PR TITLE
fix Issue 22909 - importC: u8 strings rejected by parser

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -371,6 +371,12 @@ class Lexer
                                 'd';
                     return;
                 }
+                else if (p[1] == '8' && p[2] == '\"') // C UTF-8 string literal
+                {
+                    p += 2;
+                    escapeStringConstant(t);
+                    return;
+                }
                 goto case_ident;
 
             case 'r':

--- a/test/compilable/testcstuff1.c
+++ b/test/compilable/testcstuff1.c
@@ -180,8 +180,9 @@ _Static_assert(s5(4) == 5, "s5(4) == 5");
 void tokens()
 <%
     char c = 'c';
+    char* cs = u8"utf8-string";
     unsigned short w = L'w';
-    //unsigned short* ws = L"wstring";
+    unsigned short* ws = L"wstring";
     int LLL1[1];
     int LLL2<:1:>;
 %>

--- a/test/fail_compilation/failcstuff1.c
+++ b/test/fail_compilation/failcstuff1.c
@@ -44,6 +44,8 @@ fail_compilation/failcstuff1.c(503): Error: `=`, `;` or `,` expected to end decl
 fail_compilation/failcstuff1.c(504): Error: identifier or `(` expected
 fail_compilation/failcstuff1.c(504): Error: found `;` when expecting `)`
 fail_compilation/failcstuff1.c(505): Error: `=`, `;` or `,` expected to end declaration instead of `int`
+fail_compilation/failcstuff1.c(551): Error: missing comma or semicolon after declaration of `pluto`, found `p` instead
+fail_compilation/failcstuff1.c(601): Error: `=`, `;` or `,` expected to end declaration instead of `'s'`
 ---
 */
 
@@ -147,15 +149,12 @@ void test22102()
     int var2;
 }
 
-
 /****************************************************/
-
-/* TEST_OUTPUT:
----
-fail_compilation/failcstuff1.c(551): Error: missing comma or semicolon after declaration of `pluto`, found `p` instead
----
-*/
-
 #line 550
 
 int * pluto p;
+
+// https://issues.dlang.org/show_bug.cgi?id=22909
+#line 600
+
+char c22909 = u8's';


### PR DESCRIPTION
This is a simple extension to the [uUL] encoding prefix handling done in Lexer.scan().