### PR TITLE
fix Issue 22885 - ImportC: typedef declared with itself should work

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2382,7 +2382,19 @@ final class CParser(AST) : Parser!AST
                 const idx = previd.toString();
                 if (idx.length > 2 && idx[0] == '_' && idx[1] == '_')  // leading double underscore
                     importBuiltins = true;  // probably one of those compiler extensions
-                t = new AST.TypeIdentifier(loc, previd);
+                t = null;
+                if (scw & SCW.xtypedef)
+                {
+                    /* Punch through to what the typedef is, to support things like:
+                     *  typedef T* T;
+                     */
+                    auto pt = lookupTypedef(previd);
+                    if (pt && *pt)      // if previd is a known typedef
+                        t = *pt;
+                }
+
+                if (!t)
+                    t = new AST.TypeIdentifier(loc, previd);
                 break;
             }
 

--- a/test/compilable/test22885.c
+++ b/test/compilable/test22885.c
@@ -1,0 +1,9 @@
+// https://issues.dlang.org/show_bug.cgi?id=22885
+
+typedef int T;
+void test()
+{
+    typedef T* T;  // should declare a new T that is an int*
+    int i;
+    T p = &i;
+}


### PR DESCRIPTION
The idea is to resolve the typedef declaration before the new typedef enters the symbol table.