### PR TITLE
dmd.dmacro: Make MacroTable.mactab a hash table

### DIFF
--- a/src/dmd/dmacro.d
+++ b/src/dmd/dmacro.d
@@ -31,18 +31,12 @@ extern (C++) struct MacroTable
     extern (D) void define(const(char)[] name, const(char)[] text)
     {
         //printf("MacroTable::define('%.*s' = '%.*s')\n", cast(int)name.length, name.ptr, text.length, text.ptr);
-        Macro* table;
-        for (table = mactab; table; table = table.next)
+        if (auto table = name in mactab)
         {
-            if (table.name == name)
-            {
-                table.text = text;
-                return;
-            }
+            (*table).text = text;
+            return;
         }
-        table = new Macro(name, text);
-        table.next = mactab;
-        mactab = table;
+        mactab[name] = new Macro(name, text);
     }
 
     /*****************************************************
@@ -266,20 +260,16 @@ extern (C++) struct MacroTable
 
     extern (D) Macro* search(const(char)[] name)
     {
-        Macro* table;
         //printf("Macro::search(%.*s)\n", cast(int)name.length, name.ptr);
-        for (table = mactab; table; table = table.next)
+        if (auto table = name in mactab)
         {
-            if (table.name == name)
-            {
-                //printf("\tfound %d\n", table.textlen);
-                break;
-            }
+            //printf("\tfound %d\n", table.textlen);
+            return *table;
         }
-        return table;
+        return null;
     }
 
-    Macro* mactab;
+    private Macro*[const(char)[]] mactab;
 }
 
 /* ************************************************************************ */
@@ -288,7 +278,6 @@ private:
 
 struct Macro
 {
-    Macro* next;            // next in list
     const(char)[] name;     // macro name
     const(char)[] text;     // macro replacement text
     int inuse;              // macro is in use (don't expand)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -227,7 +227,6 @@ class TypeInfoClassDeclaration;
 class TypeFunction;
 class Initializer;
 struct IntRange;
-struct Macro;
 struct ModuleDeclaration;
 struct Escape;
 class WithStatement;
@@ -6005,7 +6004,7 @@ extern void printCtfePerformanceStats();
 struct MacroTable final
 {
 private:
-    Macro* mactab;
+    void* mactab;
 public:
     MacroTable()
     {


### PR DESCRIPTION
For O(1) lookups and saving up to 8 bytes of space per inserted Macro.