### PR TITLE
fail_compilation/fail22881.d: Remove trailing whitespace

### DIFF
--- a/test/fail_compilation/fail22881.d
+++ b/test/fail_compilation/fail22881.d
@@ -25,7 +25,7 @@ bool ptr22881()
     char *p1 = new char[4].ptr;
     p1[0 .. 4] = "str\0";
     char *s1 = p1[1 .. 3].ptr;
-    char *s2 = s1[1 .. 3].ptr;  // = p1[2 .. 4] 
+    char *s2 = s1[1 .. 3].ptr;  // = p1[2 .. 4]
     char *s3 = s2[1 .. 3].ptr;  // = p1[3 .. 5]
     return true;
 }


### PR DESCRIPTION
As of `pre-commit/action@v2.0.3`, an error/hard fail is done if any trailing whitespace is found.
```
 [INFO] This may take a few minutes...
trim trailing whitespace.................................................Failed
- hook id: trailing-whitespace
- exit code: 1
- files were modified by this hook

Fixing test/fail_compilation/fail22881.d

check for merge conflicts................................................Passed
check for added large files..............................................Passed
detect private key.......................................................Passed
don't commit to branch..................................................Skipped
Validate GitHub Workflows................................................Passed
pre-commit hook(s) made changes.
If you are seeing this message in CI, reproduce locally with: `pre-commit run --all-files`.
To run `pre-commit` as part of git workflow, use `pre-commit install`.
All changes made by hooks:
diff --git a/test/fail_compilation/fail22881.d b/test/fail_compilation/fail22881.d
index fc8d53c..31195f6 100644
--- a/test/fail_compilation/fail22881.d
+++ b/test/fail_compilation/fail22881.d
@@ -25,7 +25,7 @@ bool ptr22881()
     char *p1 = new char[4].ptr;
     p1[0 .. 4] = "str\0";
     char *s1 = p1[1 .. 3].ptr;
-    char *s2 = s1[1 .. 3].ptr;  // = p1[2 .. 4] 
+    char *s2 = s1[1 .. 3].ptr;  // = p1[2 .. 4]
     char *s3 = s2[1 .. 3].ptr;  // = p1[3 .. 5]
     return true;
 }
Error: The process '/opt/hostedtoolcache/Python/3.10.2/x64/bin/pre-commit' failed with exit code 1
```