### PR TITLE
dmd.globals: Remove unused d_uns64 alias

### DIFF
--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -486,8 +486,6 @@ alias dinteger_t = ulong;
 alias sinteger_t = long;
 alias uinteger_t = ulong;
 
-alias d_uns64 = uint64_t;
-
 version (DMDLIB)
 {
     version = LocOffset;

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -346,8 +346,6 @@ typedef long long sinteger_t;
 typedef unsigned long long uinteger_t;
 #endif
 
-typedef uint64_t                d_uns64;
-
 // file location
 struct Loc
 {


### PR DESCRIPTION
It's now completely gone from the dmd front-end.