### PR TITLE
Fixup PR13857: Add new getter functions to declaration.h

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -642,6 +642,15 @@ public:
 
     bool isNogc();
     bool isNogcBypassingInference();
+    bool isNRVO() const;
+    bool isNaked() const;
+    bool isGenerated() const;
+    bool isIntroducing() const;
+    bool hasSemantic3Errors() const;
+    bool hasNoEH() const;
+    bool inferRetType() const;
+    bool hasDualContext() const;
+    bool hasAlwaysInlines() const;
 
     virtual bool isNested() const;
     AggregateDeclaration *isThis();


### PR DESCRIPTION
Those were forgotten in the PR (frontend.h was updated).
However, FUNCFLAG is not present in the C++ header.