### PR TITLE
Fix issue 22910 - `return scope` struct member functions allow returning `this` by ref

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -561,19 +561,8 @@ extern (C++) class FuncDeclaration : Declaration
                 vthis.storage_class |= STC.return_;
             if (tf.isScopeQual)
                 vthis.storage_class |= STC.scope_;
-
-            /* Add STC.returnScope like typesem.d does for TypeFunction parameters,
-             * at least it should be the same. At the moment, we'll just
-             * do existing practice. But we should examine how TypeFunction does
-             * it, for consistency.
-             */
-            if (global.params.useDIP1000 != FeatureState.enabled &&
-                !tf.isref && isRefReturnScope(vthis.storage_class))
-            {
-                /* if `ref return scope`, evaluate to `ref` `return scope`
-                 */
+            if (tf.isreturnscope)
                 vthis.storage_class |= STC.returnScope;
-            }
         }
         if (flags & FUNCFLAG.inferScope && !(vthis.storage_class & STC.scope_))
             vthis.storage_class |= STC.maybescope;

--- a/test/compilable/extra-files/header1.d
+++ b/test/compilable/extra-files/header1.d
@@ -577,7 +577,8 @@ struct SafeS
 
     ref SafeS foo3() return scope
     {
-        return this;
+        static SafeS s;
+        return s;
     }
 
     int* p;

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -659,7 +659,8 @@ struct SafeS
 		}
 		ref scope SafeS foo3() return
 		{
-			return this;
+			static SafeS s;
+			return s;
 		}
 		int* p;
 	}

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -191,7 +191,7 @@ struct SafeS
 
     ref SafeS foo3() return scope
     {
-        return this;
+        static SafeS s; return s;
     }
 
 	int* p;

--- a/test/fail_compilation/test22910.d
+++ b/test/fail_compilation/test22910.d
@@ -1,0 +1,19 @@
+/* REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test22910.d(17): Error: returning `&this.val` escapes a reference to parameter `this`
+fail_compilation/test22910.d(17):        perhaps remove `scope` parameter annotation so `return` applies to `ref`
+---
+*/
+@safe:
+
+struct S
+{
+    int  val;
+    int* ptr;
+
+    int* retScope() return scope
+    {
+        return &this.val;
+    }
+}


### PR DESCRIPTION
Following up https://github.com/dlang/dmd/pull/13693
Blocked by: https://github.com/dlang/druntime/pull/3782 https://github.com/dlang/phobos/pull/8416
The supplemental error is not right, but that's a separate issue.
