### PR TITLE
test/fail_compilation/fail22825a.d: remove trailing whitespace

### DIFF
--- a/test/fail_compilation/fail22825a.d
+++ b/test/fail_compilation/fail22825a.d
@@ -7,5 +7,5 @@ fail_compilation/fail22825a.d(11): Error: declaration expected, not `42`
 */
 #line /*
          multi-line comment
-*/ 
+*/
 42


### PR DESCRIPTION
Introduced by d682eac9b8aed372c9e1ea6b9e0d038ca391560e.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>