### PR TITLE
dmd.func: Add FuncDeclaration.isCrtCtor and isCrtDtor getters

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -651,6 +651,8 @@ public:
     bool inferRetType() const;
     bool hasDualContext() const;
     bool hasAlwaysInlines() const;
+    bool isCrtCtor() const;
+    bool isCrtDtor() const;
 
     virtual bool isNested() const;
     AggregateDeclaration *isThis();

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2883,6 +2883,8 @@ public:
     bool inferRetType() const;
     bool hasDualContext() const;
     bool hasAlwaysInlines() const;
+    bool isCrtCtor() const;
+    bool isCrtDtor() const;
     virtual bool isNested() const;
     AggregateDeclaration* isThis();
     bool needThis();

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -214,8 +214,8 @@ enum FUNCFLAG : uint
     inferRetType     = 0x40000, /// Return type is to be inferred
     dualContext      = 0x80000, /// has a dual-context 'this' parameter
     hasAlwaysInline  = 0x100000, /// Contains references to functions that must be inlined
-    CRTCtor          = 0x200000, /// Has attribute pragma(crt_constructor) (set in glue)
-    CRTDtor          = 0x400000, /// Has attribpute pragma(crt_destructor) (set in glue)
+    CRTCtor          = 0x200000, /// Has attribute pragma(crt_constructor)
+    CRTDtor          = 0x400000, /// Has attribute pragma(crt_destructor)
 }
 
 /***********************************************************
@@ -1512,6 +1512,16 @@ extern (C++) class FuncDeclaration : Declaration
     final bool hasAlwaysInlines() const scope @safe pure nothrow @nogc
     {
         return !!(this.flags & FUNCFLAG.hasAlwaysInline);
+    }
+
+    final bool isCrtCtor() const scope @safe pure nothrow @nogc
+    {
+        return !!(this.flags & FUNCFLAG.CRTCtor);
+    }
+
+    final bool isCrtDtor() const scope @safe pure nothrow @nogc
+    {
+        return !!(this.flags & FUNCFLAG.CRTDtor);
     }
 
     /**************************************


### PR DESCRIPTION
These are needed for gdc and ldc to query whether a function was marked pragma(crt_constructor/destructor).