### PR TITLE
Implement .tupleof for static array values

### DIFF
--- a/changelog/static_array_tupleof.dd
+++ b/changelog/static_array_tupleof.dd
@@ -1,0 +1,19 @@
+Added `.tupleof` property for static arrays
+
+The `.tupleof` property may now be used with instances of static arrays, yielding an $(DDSUBLINK spec/template, variadic-templates, expression sequence) of all the array's elements.
+
+Note that this is only for static array *values*, it remains an error when used upon a type so as to not break older code lacking suitable checks. As a workaround use `typeof((T[N]).init.tupleof)`.
+
+---
+void foo(int x, int y) { /* ... */ }
+void bar(int[2] xs)
+{
+    foo(xs.tupleof);
+}
+
+ubyte[] encoded = iota!int(10)
+    .map!(x => only(nativeToBigEndian(x).tupleof))
+    .joiner
+    .array
+;
+---

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3625,6 +3625,23 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             }
             e = e.castTo(sc, e.type.nextOf().pointerTo());
         }
+        else if (ident == Id._tupleof)
+        {
+            if (e.isTypeExp())
+            {
+                e.error("`.tupleof` cannot be used on type `%s`", mt.toChars);
+                return ErrorExp.get();
+            }
+            else
+            {
+                const length = cast(size_t)mt.dim.toUInteger();
+                auto exps = new Expressions();
+                exps.reserve(length);
+                foreach (i; 0 .. length)
+                    exps.push(new IndexExp(e.loc, e, new IntegerExp(e.loc, i, Type.tsize_t)));
+                e = new TupleExp(e.loc, exps);
+            }
+        }
         else
         {
             e = visitArray(mt);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -7808,3 +7808,101 @@ int test9937()
 }
 
 static assert(test9937());
+
+/************************************************/
+// static array .tupleof
+
+struct SArrayTupleEquiv(T)
+{
+    T f1;
+    T f2;
+}
+
+// basic .tupleof invariants
+bool testSArrayTupleA()
+{
+    int[2] xs;
+    assert(xs.tupleof == TypeTuple!(0, 0));
+    assert(xs.tupleof == (cast(int[2])[0, 0]).tupleof);
+
+    xs.tupleof = TypeTuple!(1, 2);
+    assert(xs.tupleof == TypeTuple!(1, 2));
+
+    auto ys = SArrayTupleEquiv!int(1, 2);
+    assert(xs.tupleof == ys.tupleof);
+
+    return true;
+}
+static assert(testSArrayTupleA());
+
+// tuples with side effects
+bool testSArrayTupleB()
+{
+    // Counter records lifetime events in copies/dtors, as a cheap way to check that .tupleof for
+    // static arrays exhibit all the same side effects as an equivalent struct's .tupleof
+    int[int] copies;
+    int[int] dtors;
+    struct Counter
+    {
+        int id = -1;
+
+        this(this)
+        {
+            copies[id] = copies.get(id, 0) + 1;
+        }
+
+        ~this()
+        {
+            dtors[id] = dtors.get(id, 0) + 1;
+        }
+    }
+
+    void consume(Counter, Counter) {}
+    Counter[2] produce(int id1, int id2)
+    {
+        return [Counter(id1), Counter(id2)];
+    }
+
+    // first sample expected behavior from struct .tupleof
+    // braces create a subscope, shortening lifetimes
+    {
+        auto a = SArrayTupleEquiv!Counter(Counter(0), Counter(1));
+
+        typeof(a) b;
+        b.tupleof = a.tupleof;
+
+        Counter x, y;
+        TypeTuple!(x, y) = a.tupleof;
+
+        a.tupleof[0] = Counter(2);
+        a.tupleof[1] = Counter(3);
+        consume(a.tupleof);
+
+        a.tupleof = produce(4, 5).tupleof;
+    }
+    int[int][2] expected = [copies.dup, dtors.dup];
+    copies = null; // .clear is not CTFE friendly
+    dtors = null;
+
+    // the real test -- sample behavior of array .tupleof
+    {
+        Counter[2] a = [Counter(0), Counter(1)];
+
+        typeof(a) b;
+        b.tupleof = a.tupleof;
+
+        Counter x, y;
+        TypeTuple!(x, y) = a.tupleof;
+
+        a.tupleof[0] = Counter(2);
+        a.tupleof[1] = Counter(3);
+        consume(a.tupleof);
+
+        a.tupleof = produce(4, 5).tupleof;
+    }
+    assert(expected[0] == copies);
+    assert(expected[1] == dtors);
+
+    return true;
+}
+static assert(testSArrayTupleB());


### PR DESCRIPTION
Something I (and others, apparently) have wanted for quite a while, in a myriad of situations.

A specific example of its utility, reduced from the real code that finally motivated my writing this patch:
```d
ubyte[] encoded = iota!int(10)
    .map!(x => only(nativeToBigEndian(x).tupleof))
    .joiner
    .array
;
```

---

Does this need a bugzilla issue?
Are there any cases I haven't thought of in the implementation/tests? (I'd be surprised if not)