### PR TITLE
fix Issue 22912 - importC: syntax error for function call with cast a…

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1051,6 +1051,7 @@ final class CParser(AST) : Parser!AST
                     return cparsePostfixOperators(ce);
                 }
                 else if (t.isTypeIdentifier() &&
+                         !isTypedef(t.isTypeIdentifier().ident) &&
                          token.value == TOK.leftParenthesis &&
                          !isCastExpression(pt))
                 {

--- a/test/compilable/test22904.c
+++ b/test/compilable/test22904.c
@@ -2,3 +2,8 @@
 
 int fn1() { return 0; }
 void fn2() { long x = (long) (fn1) (); }
+
+// https://issues.dlang.org/show_bug.cgi?id=22912
+
+typedef long my_long;
+void fn3() { long x = (my_long) (fn1) (); }


### PR DESCRIPTION
…nd typedef and parentheses around name