### PR TITLE
Make FileManager a class and move it to global

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -662,7 +662,7 @@ extern (C++) final class Module : Package
             return true; // already read
 
         //printf("Module::read('%s') file '%s'\n", toChars(), srcfile.toChars());
-        if (auto result = FileManager.fileManager.lookup(srcfile))
+        if (auto result = global.fileManager.lookup(srcfile))
         {
             this.src = result.data;
             if (global.params.emitMakeDeps)

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -387,12 +387,11 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
         !loc.filename.strstr(".d-mixin-") &&
         !global.params.mixinOut)
     {
-        import dmd.file_manager : FileManager;
         import dmd.root.filename : FileName;
         const fileName = FileName(loc.filename.toDString);
-        if (auto file = FileManager.fileManager.lookup(fileName))
+        if (auto file = global.fileManager.lookup(fileName))
         {
-            const(char)[][] lines = FileManager.fileManager.getLines(fileName);
+            const(char)[][] lines = global.fileManager.getLines(fileName);
             if (loc.linnum - 1 < lines.length)
             {
                 auto line = lines[loc.linnum - 1];

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6042,7 +6042,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         {
             auto fileName = FileName(name.toDString);
-            if (auto fmResult = FileManager.fileManager.lookup(fileName))
+            if (auto fmResult = global.fileManager.lookup(fileName))
             {
                 se = new StringExp(e.loc, fmResult.data);
             }
@@ -6062,7 +6062,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                     FileBuffer* fileBuffer = FileBuffer.create();
                     fileBuffer.data = data;
-                    FileManager.fileManager.add(fileName, fileBuffer);
+                    global.fileManager.add(fileName, fileBuffer);
                 }
             }
         }

--- a/src/dmd/file_manager.d
+++ b/src/dmd/file_manager.d
@@ -20,10 +20,15 @@ import dmd.identifier;
 enum package_d  = "package." ~ mars_ext;
 enum package_di = "package." ~ hdr_ext;
 
-struct FileManager
+final class FileManager
 {
     private StringTable!(FileBuffer*) files;
-    private __gshared bool initialized = false;
+
+    ///
+    public this () nothrow
+    {
+        this.files._init();
+    }
 
 nothrow:
     /********************************************
@@ -143,9 +148,6 @@ nothrow:
      */
     const(FileBuffer)* lookup(FileName filename)
     {
-        if (!initialized)
-            FileManager._init();
-
         const name = filename.toString;
         if (auto val = files.lookup(name))
             return val.value;
@@ -182,9 +184,6 @@ nothrow:
      */
     const(char)[][] getLines(FileName file)
     {
-        if (!initialized)
-            FileManager._init();
-
         const(char)[][] lines;
         if (const buffer = lookup(file))
         {
@@ -241,28 +240,8 @@ nothrow:
      */
     FileBuffer* add(FileName filename, FileBuffer* filebuffer)
     {
-        if (!initialized)
-            FileManager._init();
-
         auto val = files.insert(filename.toString, filebuffer);
         return val == null ? null : val.value;
-    }
-
-    __gshared fileManager = FileManager();
-
-    // Initialize the global FileManager singleton
-    private void _init()
-    {
-        if (!initialized)
-        {
-            fileManager.initialize();
-            initialized = true;
-        }
-    }
-
-    void initialize()
-    {
-        files._init();
     }
 }
 

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -396,11 +396,10 @@ Tuple!(Module, "module_", Diagnostics, "diagnostics") parseModule(AST = ASTCodeg
         m.read(Loc.initial);
     else
     {
-        import dmd.file_manager : FileManager;
         import dmd.root.filename : FileName;
 
         auto fb = new FileBuffer(cast(ubyte[]) code.dup ~ '\0');
-        FileManager.fileManager.add(FileName(fileName), fb);
+        global.fileManager.add(FileName(fileName), fb);
         m.src = fb.data;
     }
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -42,6 +42,7 @@ class Identifier;
 class CPPNamespaceDeclaration;
 struct Symbol;
 struct OutBuffer;
+class FileManager;
 struct Scope;
 class DeprecatedDeclaration;
 class UserAttributeDeclaration;
@@ -852,6 +853,7 @@ struct Global final
     Array<Identifier* >* debugids;
     bool hasMainFunction;
     uint32_t varSequenceNumber;
+    FileManager* fileManager;
     enum : int32_t { recursionLimit = 500 };
 
     uint32_t startGagging();
@@ -877,10 +879,11 @@ struct Global final
         versionids(),
         debugids(),
         hasMainFunction(),
-        varSequenceNumber(1u)
+        varSequenceNumber(1u),
+        fileManager()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr) :
         inifilename(inifilename),
         copyright(copyright),
         written(written),
@@ -897,7 +900,8 @@ struct Global final
         versionids(versionids),
         debugids(debugids),
         hasMainFunction(hasMainFunction),
-        varSequenceNumber(varSequenceNumber)
+        varSequenceNumber(varSequenceNumber),
+        fileManager(fileManager)
         {}
 };
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -15,6 +15,7 @@ import core.stdc.stdint;
 import dmd.root.array;
 import dmd.root.filename;
 import dmd.common.outbuffer;
+import dmd.file_manager;
 import dmd.identifier;
 
 /// Defines a setting for how compiler warnings and deprecations are handled
@@ -329,6 +330,9 @@ extern (C++) struct Global
     bool hasMainFunction; /// Whether a main function has already been compiled in (for -main switch)
     uint varSequenceNumber = 1; /// Relative lifetime of `VarDeclaration` within a function, used for `scope` checks
 
+    /// Cache files read from disk
+    FileManager fileManager;
+
     enum recursionLimit = 500; /// number of recursive template expansions before abort
 
   nothrow:
@@ -383,6 +387,7 @@ extern (C++) struct Global
 
     extern (C++) void _init()
     {
+        this.fileManager = new FileManager();
         version (MARS)
         {
             vendor = "Digital Mars D";

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -19,6 +19,8 @@
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;
 
+class FileManager;
+
 typedef unsigned char Diagnostic;
 enum
 {
@@ -291,6 +293,8 @@ struct Global
 
     bool hasMainFunction;
     unsigned varSequenceNumber;
+
+    FileManager* fileManager;
 
     /* Start gagging. Return the current number of gagged errors
      */

--- a/test/unit/deinitialization.d
+++ b/test/unit/deinitialization.d
@@ -7,7 +7,7 @@ unittest
 {
     import dmd.globals : global;
 
-    static void assertStructsEqual(T)(const ref T a, const ref T b) @nogc pure nothrow
+    static void assertStructsEqual(T)(const ref T a, const ref T b)
     if (is(T == struct))
     {
         foreach (i, _; typeof(a.tupleof))


### PR DESCRIPTION
```
We do not want FileManager to be accidentally copied / new instances to be made,
so it obviously does not have value semantic, but reference semantic.
We also should store it in globals, along with other globals,
and using a class makes it easier as we can just forward-declare it.
```

@ibuclaw : I didn't forget you this time ;)