### PR TITLE
Merge bool fields of VarDeclaration into bit fields

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1063,22 +1063,24 @@ extern (C++) class VarDeclaration : Declaration
     // `bool` fields that are compacted into bit fields in a string mixin
     private extern (D) static struct BitFields
     {
-        bool isargptr;                  // if parameter that _argptr points to
-        bool ctorinit;                  // it has been initialized in a ctor
-        bool iscatchvar;                // this is the exception object variable in catch() clause
-        bool isowner;                   // this is an Owner, despite it being `scope`
-        bool setInCtorOnly;             // field can only be set in a constructor, as it is const or immutable
+        bool isargptr;          /// if parameter that _argptr points to
+        bool ctorinit;          /// it has been initialized in a ctor
+        bool iscatchvar;        /// this is the exception object variable in catch() clause
+        bool isowner;           /// this is an Owner, despite it being `scope`
+        bool setInCtorOnly;     /// field can only be set in a constructor, as it is const or immutable
 
-        // Both these mean the var is not rebindable once assigned,
-        // and the destructor gets run when it goes out of scope
-        bool onstack;                   // it is a class that was allocated on the stack
+        /// It is a class that was allocated on the stack
+        ///
+        /// This means the var is not rebindable once assigned,
+        /// and the destructor gets run when it goes out of scope
+        bool onstack;
 
-        bool overlapped;                // if it is a field and has overlapping
-        bool overlapUnsafe;             // if it is an overlapping field and the overlaps are unsafe
-        bool doNotInferScope;           // do not infer 'scope' for this variable
-        bool doNotInferReturn;          // do not infer 'return' for this variable
+        bool overlapped;        /// if it is a field and has overlapping
+        bool overlapUnsafe;     /// if it is an overlapping field and the overlaps are unsafe
+        bool doNotInferScope;   /// do not infer 'scope' for this variable
+        bool doNotInferReturn;  /// do not infer 'return' for this variable
 
-        bool isArgDtorVar;              // temporary created to handle scope destruction of a function argument
+        bool isArgDtorVar;      /// temporary created to handle scope destruction of a function argument
     }
 
     private ushort bitFields;       // stores multiple booleans for BitFields

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -241,22 +241,33 @@ public:
     // When interpreting, these point to the value (NULL if value not determinable)
     // The index of this variable on the CTFE stack, ~0u if not allocated
     unsigned ctfeAdrOnStack;
-
-    bool isargptr;              // if parameter that _argptr points to
-    bool ctorinit;              // it has been initialized in a ctor
-    bool iscatchvar;            // this is the exception object variable in catch() clause
-    bool isowner;               // this is an Owner, despite it being `scope`
-    bool setInCtorOnly;         // field can only be set in a constructor, as it is const or immutable
-    bool onstack;               // it is a class that was allocated on the stack
-    char canassign;             // it can be assigned to
-    bool overlapped;            // if it is a field and has overlapping
-    bool overlapUnsafe;         // if it is an overlapping field and the overlaps are unsafe
-    bool doNotInferScope;       // do not infer 'scope' for this variable
-    bool doNotInferReturn;      // do not infer 'return' for this variable
-    unsigned char isdataseg;    // private data for isDataseg
-    bool isArgDtorVar;          // temporary created to handle scope destruction of a function argument
-
+private:
+    uint16_t bitFields;
 public:
+    int8_t canassign; // // it can be assigned to
+    uint8_t isdataseg; // private data for isDataseg
+    bool isargptr() const; // if parameter that _argptr points to
+    bool isargptr(bool v);
+    bool ctorinit() const; // it has been initialized in a ctor
+    bool ctorinit(bool v);
+    bool iscatchvar() const; // this is the exception object variable in catch() clause
+    bool iscatchvar(bool v);
+    bool isowner() const; // this is an Owner, despite it being `scope`
+    bool isowner(bool v);
+    bool setInCtorOnly() const; // field can only be set in a constructor, as it is const or immutable
+    bool setInCtorOnly(bool v);
+    bool onstack() const; // it is a class that was allocated on the stack
+    bool onstack(bool v);
+    bool overlapped() const; // if it is a field and has overlapping
+    bool overlapped(bool v);
+    bool overlapUnsafe() const; // if it is an overlapping field and the overlaps are unsafe
+    bool overlapUnsafe(bool v);
+    bool doNotInferScope() const; // do not infer 'scope' for this variable
+    bool doNotInferScope(bool v);
+    bool doNotInferReturn() const; // do not infer 'return' for this variable
+    bool doNotInferReturn(bool v);
+    bool isArgDtorVar() const; // temporary created to handle scope destruction of a function argument
+    bool isArgDtorVar(bool v);
     static VarDeclaration *create(const Loc &loc, Type *t, Identifier *id, Initializer *init, StorageClass storage_class = STCundefined);
     VarDeclaration *syntaxCopy(Dsymbol *);
     void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5762,19 +5762,33 @@ public:
     enum : uint32_t { AdrOnStackNone = 4294967295u };
 
     uint32_t ctfeAdrOnStack;
-    bool isargptr;
-    bool ctorinit;
-    bool iscatchvar;
-    bool isowner;
-    bool setInCtorOnly;
-    bool onstack;
+private:
+    uint16_t bitFields;
+public:
     int8_t canassign;
-    bool overlapped;
-    bool overlapUnsafe;
-    bool doNotInferScope;
-    bool doNotInferReturn;
     uint8_t isdataseg;
-    bool isArgDtorVar;
+    bool isargptr() const;
+    bool isargptr(bool v);
+    bool ctorinit() const;
+    bool ctorinit(bool v);
+    bool iscatchvar() const;
+    bool iscatchvar(bool v);
+    bool isowner() const;
+    bool isowner(bool v);
+    bool setInCtorOnly() const;
+    bool setInCtorOnly(bool v);
+    bool onstack() const;
+    bool onstack(bool v);
+    bool overlapped() const;
+    bool overlapped(bool v);
+    bool overlapUnsafe() const;
+    bool overlapUnsafe(bool v);
+    bool doNotInferScope() const;
+    bool doNotInferScope(bool v);
+    bool doNotInferReturn() const;
+    bool doNotInferReturn(bool v);
+    bool isArgDtorVar() const;
+    bool isArgDtorVar(bool v);
     static VarDeclaration* create(const Loc& loc, Type* type, Identifier* ident, Initializer* _init, StorageClass storage_class = static_cast<StorageClass>(STC::undefined_));
     VarDeclaration* syntaxCopy(Dsymbol* s);
     void setFieldOffset(AggregateDeclaration* ad, FieldState& fieldState, bool isunion);


### PR DESCRIPTION
Similar to https://github.com/dlang/dmd/pull/13871

Reduces the size of `VarDeclaration` from 281 to 272 bytes.

Instead of using an `enum` with flags, this puts the `bool` fields into a `private static struct` that is used to generate getter/setter functions to the new `ushort bitFields` field.

Since C++ does not have UFCS, this may break downstream compilers if they access the fields @ibuclaw @kinke 