### PR TITLE
Fix issue 22914 - outdated supplemental error "perhaps remove scope"

### DIFF
--- a/test/fail_compilation/dip25.d
+++ b/test/fail_compilation/dip25.d
@@ -3,8 +3,8 @@ REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
 fail_compilation/dip25.d(17): Deprecation: returning `this.buffer[]` escapes a reference to parameter `this`
-fail_compilation/dip25.d(17):        perhaps annotate the function with `return`
-fail_compilation/dip25.d(22): Error: returning `identity(x)` escapes a reference to local variable `x`
+fail_compilation/dip25.d(15):        perhaps annotate the function with `return`
+fail_compilation/dip25.d(22): Error: returning `identity(x)` escapes a reference to parameter `x`
 fail_compilation/dip25.d(23): Deprecation: returning `identity(x)` escapes a reference to parameter `x`
 fail_compilation/dip25.d(23):        perhaps annotate the parameter with `return`
 ---

--- a/test/fail_compilation/fail13902.d
+++ b/test/fail_compilation/fail13902.d
@@ -54,14 +54,14 @@ int* testEscape1()
 TEST_OUTPUT:
 ---
 fail_compilation/fail13902.d(88): Error: Using the result of a comma expression is not allowed
-fail_compilation/fail13902.d(75): Error: returning `& x` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(76): Error: returning `&s1.v` escapes a reference to local variable `s1`
-fail_compilation/fail13902.d(81): Error: returning `& sa1` escapes a reference to local variable `sa1`
-fail_compilation/fail13902.d(82): Error: returning `&sa2[0][0]` escapes a reference to local variable `sa2`
-fail_compilation/fail13902.d(83): Error: returning `& x` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(84): Error: returning `(& x+4)` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(85): Error: returning `& x + cast(long)x * 4L` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(88): Error: returning `& y` escapes a reference to local variable `y`
+fail_compilation/fail13902.d(75): Error: returning `& x` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(76): Error: returning `&s1.v` escapes a reference to parameter `s1`
+fail_compilation/fail13902.d(81): Error: returning `& sa1` escapes a reference to parameter `sa1`
+fail_compilation/fail13902.d(82): Error: returning `&sa2[0][0]` escapes a reference to parameter `sa2`
+fail_compilation/fail13902.d(83): Error: returning `& x` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(84): Error: returning `(& x+4)` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(85): Error: returning `& x + cast(long)x * 4L` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(88): Error: returning `& y` escapes a reference to parameter `y`
 ---
 */
 int* testEscape2(
@@ -134,9 +134,9 @@ int* testEscape3(
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(150): Error: returning `cast(int[])sa1` escapes a reference to local variable `sa1`
-fail_compilation/fail13902.d(151): Error: returning `cast(int[])sa1` escapes a reference to local variable `sa1`
-fail_compilation/fail13902.d(152): Error: returning `sa1[]` escapes a reference to local variable `sa1`
+fail_compilation/fail13902.d(150): Error: returning `cast(int[])sa1` escapes a reference to parameter `sa1`
+fail_compilation/fail13902.d(151): Error: returning `cast(int[])sa1` escapes a reference to parameter `sa1`
+fail_compilation/fail13902.d(152): Error: returning `sa1[]` escapes a reference to parameter `sa1`
 fail_compilation/fail13902.d(155): Error: returning `cast(int[])sa2` escapes a reference to local variable `sa2`
 fail_compilation/fail13902.d(156): Error: returning `cast(int[])sa2` escapes a reference to local variable `sa2`
 fail_compilation/fail13902.d(157): Error: returning `sa2[]` escapes a reference to local variable `sa2`
@@ -223,14 +223,14 @@ ref int testEscapeRef1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(240): Error: returning `x` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(241): Error: returning `s1.v` escapes a reference to local variable `s1`
-fail_compilation/fail13902.d(245): Error: returning `sa1[0]` escapes a reference to local variable `sa1`
-fail_compilation/fail13902.d(246): Error: returning `sa2[0][0]` escapes a reference to local variable `sa2`
-fail_compilation/fail13902.d(247): Error: returning `x = 1` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(248): Error: returning `x += 1` escapes a reference to local variable `x`
-fail_compilation/fail13902.d(249): Error: returning `s1.v = 1` escapes a reference to local variable `s1`
-fail_compilation/fail13902.d(250): Error: returning `s1.v += 1` escapes a reference to local variable `s1`
+fail_compilation/fail13902.d(240): Error: returning `x` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(241): Error: returning `s1.v` escapes a reference to parameter `s1`
+fail_compilation/fail13902.d(245): Error: returning `sa1[0]` escapes a reference to parameter `sa1`
+fail_compilation/fail13902.d(246): Error: returning `sa2[0][0]` escapes a reference to parameter `sa2`
+fail_compilation/fail13902.d(247): Error: returning `x = 1` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(248): Error: returning `x += 1` escapes a reference to parameter `x`
+fail_compilation/fail13902.d(249): Error: returning `s1.v = 1` escapes a reference to parameter `s1`
+fail_compilation/fail13902.d(250): Error: returning `s1.v += 1` escapes a reference to parameter `s1`
 ---
 */
 ref int testEscapeRef2(
@@ -324,8 +324,8 @@ int[] testSlice2() { int[3] sa; int n; return sa[n..2][1..2]; }
 TEST_OUTPUT:
 ---
 fail_compilation/fail13902.d(324): Error: returning `vda[0]` escapes a reference to parameter `vda`
-fail_compilation/fail13902.d(324):        perhaps annotate the parameter with `return`
 ---
+
 */
 ref int testDynamicArrayVariadic1(int[] vda...) { return vda[0]; }
 @safe int[]   testDynamicArrayVariadic2(int[] vda...) { return vda[]; }
@@ -334,7 +334,7 @@ int[3]  testDynamicArrayVariadic3(int[] vda...) { return vda[0..3]; }   // no er
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(335): Error: returning `vsa[0]` escapes a reference to local variable `vsa`
+fail_compilation/fail13902.d(335): Error: returning `vsa[0]` escapes a reference to parameter `vsa`
 fail_compilation/fail13902.d(336): Error: returning `vsa[]` escapes a reference to variadic parameter `vsa`
 ---
 */

--- a/test/fail_compilation/fail20084.d
+++ b/test/fail_compilation/fail20084.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail20084.d(109): Error: returning `v.front()` escapes a reference to local variable `v`
+fail_compilation/fail20084.d(109): Error: returning `v.front()` escapes a reference to parameter `v`
 ---
 */
 

--- a/test/fail_compilation/fail20448.d
+++ b/test/fail_compilation/fail20448.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20448.d(16): Error: returning `p.x` escapes a reference to local variable `p`
+fail_compilation/fail20448.d(16): Error: returning `p.x` escapes a reference to parameter `p`
 fail_compilation/fail20448.d(22): Error: template instance `fail20448.member!"x"` error instantiating
 ---
 */

--- a/test/fail_compilation/fail21868b.d
+++ b/test/fail_compilation/fail21868b.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail21868b.d(19): Error: returning `&s.x` escapes a reference to parameter `s`
-fail_compilation/fail21868b.d(19):        perhaps remove `scope` parameter annotation so `return` applies to `ref`
+fail_compilation/fail21868b.d(17):        perhaps change the `return scope` into `scope return`
 ---
 */
 

--- a/test/fail_compilation/fix18575.d
+++ b/test/fail_compilation/fix18575.d
@@ -1,10 +1,10 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fix18575.d(27): Error: returning `s.foo()` escapes a reference to local variable `s`
-fail_compilation/fix18575.d(31): Error: returning `s.foo()` escapes a reference to local variable `s`
-fail_compilation/fix18575.d(35): Error: returning `s.abc()` escapes a reference to local variable `s`
-fail_compilation/fix18575.d(39): Error: returning `s.ghi(t)` escapes a reference to local variable `t`
+fail_compilation/fix18575.d(27): Error: returning `s.foo()` escapes a reference to parameter `s`
+fail_compilation/fix18575.d(31): Error: returning `s.foo()` escapes a reference to parameter `s`
+fail_compilation/fix18575.d(35): Error: returning `s.abc()` escapes a reference to parameter `s`
+fail_compilation/fix18575.d(39): Error: returning `s.ghi(t)` escapes a reference to parameter `t`
 ---
 */
 

--- a/test/fail_compilation/shared.d
+++ b/test/fail_compilation/shared.d
@@ -91,7 +91,6 @@ fail_compilation/shared.d(2194): Error: direct access to shared `(new shared(K2)
 fail_compilation/shared.d(2202): Error: direct access to shared `c` is not allowed, see `core.atomic`
 fail_compilation/shared.d(2206): Error: function `shared.test_inference_2` function returns `shared` but cannot be inferred `ref`
 fail_compilation/shared.d(2208): Error: returning `c` escapes a reference to parameter `c`
-fail_compilation/shared.d(2208):        perhaps annotate the parameter with `return`
 fail_compilation/shared.d(2214): Error: function `shared.test_inference_3` function returns `shared` but cannot be inferred `ref`
 fail_compilation/shared.d(2216):        return value `getSharedObject()` is not an lvalue
 fail_compilation/shared.d(2222): Error: direct access to shared `a` is not allowed, see `core.atomic`
@@ -100,6 +99,7 @@ fail_compilation/shared.d(2222):        cannot implicitly convert `a` of type `s
 fail_compilation/shared.d(2222): Error: cannot implicitly convert expression `a` of type `shared(const(Object))` to `object.Object`
 ---
  */
+
 #line 2100
 // Derived from https://issues.dlang.org/show_bug.cgi?id=20908
 ref shared(int) test20908()

--- a/test/fail_compilation/test16589.d
+++ b/test/fail_compilation/test16589.d
@@ -3,15 +3,15 @@ REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test16589.d(26): Error: returning `&this.data` escapes a reference to parameter `this`
-fail_compilation/test16589.d(26):        perhaps annotate the function with `return`
+fail_compilation/test16589.d(24):        perhaps annotate the function with `return`
 fail_compilation/test16589.d(31): Error: returning `&this` escapes a reference to parameter `this`
-fail_compilation/test16589.d(31):        perhaps annotate the function with `return`
+fail_compilation/test16589.d(29):        perhaps annotate the function with `return`
 fail_compilation/test16589.d(37): Error: returning `&s.data` escapes a reference to parameter `s`
-fail_compilation/test16589.d(37):        perhaps annotate the parameter with `return`
+fail_compilation/test16589.d(35):        perhaps annotate the parameter with `return`
 fail_compilation/test16589.d(42): Error: returning `&s` escapes a reference to parameter `s`
-fail_compilation/test16589.d(42):        perhaps annotate the parameter with `return`
-fail_compilation/test16589.d(47): Error: returning `&s.data` escapes a reference to local variable `s`
-fail_compilation/test16589.d(52): Error: returning `& s` escapes a reference to local variable `s`
+fail_compilation/test16589.d(40):        perhaps annotate the parameter with `return`
+fail_compilation/test16589.d(47): Error: returning `&s.data` escapes a reference to parameter `s`
+fail_compilation/test16589.d(52): Error: returning `& s` escapes a reference to parameter `s`
 ---
 */
 

--- a/test/fail_compilation/test17450.d
+++ b/test/fail_compilation/test17450.d
@@ -3,9 +3,9 @@ REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test17450.d(17): Error: returning `&s.bar` escapes a reference to parameter `s`
-fail_compilation/test17450.d(17):        perhaps annotate the parameter with `return`
+fail_compilation/test17450.d(16):        perhaps annotate the parameter with `return`
 fail_compilation/test17450.d(20): Error: returning `&this.bar` escapes a reference to parameter `this`
-fail_compilation/test17450.d(20):        perhaps annotate the function with `return`
+fail_compilation/test17450.d(19):        perhaps annotate the function with `return`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=17450

--- a/test/fail_compilation/test22541.d
+++ b/test/fail_compilation/test22541.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/test22541.d(104): Error: returning `i` escapes a reference to parameter `i`
-fail_compilation/test22541.d(104):        perhaps annotate the parameter with `return`
+fail_compilation/test22541.d(102):        perhaps annotate the parameter with `return`
 ---
  */
 

--- a/test/fail_compilation/test22910.d
+++ b/test/fail_compilation/test22910.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/test22910.d(17): Error: returning `&this.val` escapes a reference to parameter `this`
-fail_compilation/test22910.d(17):        perhaps remove `scope` parameter annotation so `return` applies to `ref`
+fail_compilation/test22910.d(15):        perhaps change the `return scope` into `scope return`
 ---
 */
 @safe:


### PR DESCRIPTION
Don't suggest to remove scope anymore. Also, when suggesting to annotate a parameter, give the error the location of said parameter instead of the return statement.
