### PR TITLE
Use isReference instead of isRef

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -793,7 +793,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
 
         // If va's lifetime encloses v's, then error
         if (va &&
-            (va.enclosesLifetimeOf(v) || (va.isRef() && !(va.storage_class & STC.temp)) || va.isDataseg()) &&
+            (va.enclosesLifetimeOf(v) || (va.isReference() && !(va.storage_class & STC.temp)) || va.isDataseg()) &&
             fd.setUnsafe())
         {
             if (!gag)

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1288,7 +1288,7 @@ extern (C++) abstract class Expression : ASTNode
             return false; // magic variable never violates pure and safe
         if (v.isImmutable())
             return false; // always safe and pure to access immutables...
-        if (v.isConst() && !v.isRef() && (v.isDataseg() || v.isParameter()) && v.type.implicitConvTo(v.type.immutableOf()))
+        if (v.isConst() && !v.isReference() && (v.isDataseg() || v.isParameter()) && v.type.implicitConvTo(v.type.immutableOf()))
             return false; // or const global/parameter values which have no mutable indirections
         if (v.storage_class & STC.manifest)
             return false; // ...or manifest constants

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2779,7 +2779,7 @@ extern (C++) class FuncDeclaration : Declaration
             if (auto ve = rs.exp.isVarExp())
             {
                 auto v = ve.var.isVarDeclaration();
-                if (!v || v.isOut() || v.isRef())
+                if (!v || v.isReference())
                     return false;
                 else if (nrvo_var is null)
                 {

--- a/src/dmd/ob.d
+++ b/src/dmd/ob.d
@@ -1747,7 +1747,7 @@ PtrState toPtrState(VarDeclaration v)
      */
 
     auto t = v.type;
-    if (v.isRef())
+    if (v.isReference())
     {
         return t.hasMutableFields() ? PtrState.Borrowed : PtrState.Readonly;
     }
@@ -1775,7 +1775,7 @@ bool hasPointersToMutableFields(Type t)
     {
         foreach (v; ts.sym.fields)
         {
-            if (v.isRef())
+            if (v.isReference())
             {
                 if (v.type.hasMutableFields())
                     return true;


### PR DESCRIPTION
`isRef`, which checks for the `ref` storage class, should only be used for `__traits(isRef, x)`. In other cases, it's about `ref` semantics, which includes `out` parameters, so use `isReference` instead.