### PR TITLE
Fix 22915 - Print the type of invalid foreach aggregates

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -728,12 +728,12 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
         Dsymbol sapply = null;                  // the inferred opApply() or front() function
         if (!inferForeachAggregate(sc, fs.op == TOK.foreach_, fs.aggr, sapply))
         {
-            const(char)* msg = "";
-            if (fs.aggr.type && isAggregate(fs.aggr.type))
-            {
-                msg = ", define `opApply()`, range primitives, or use `.tupleof`";
-            }
-            fs.error("invalid `foreach` aggregate `%s`%s", oaggr.toChars(), msg);
+            assert(oaggr.type);
+
+            fs.error("invalid `foreach` aggregate `%s` of type `%s`", oaggr.toChars(), oaggr.type.toPrettyChars());
+            if (isAggregate(fs.aggr.type))
+                fs.loc.errorSupplemental("maybe define `opApply()`, range primitives, or use `.tupleof`");
+
             return setError();
         }
 

--- a/test/fail_compilation/fail118.d
+++ b/test/fail_compilation/fail118.d
@@ -1,8 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail118.d(26): Error: invalid `foreach` aggregate `Iter`, define `opApply()`, range primitives, or use `.tupleof`
-fail_compilation/fail118.d(27): Error: invalid `foreach` aggregate `Iter`, define `opApply()`, range primitives, or use `.tupleof`
+fail_compilation/fail118.d(43): Error: invalid `foreach` aggregate `Iter` of type `Iter`
+fail_compilation/fail118.d(43):        maybe define `opApply()`, range primitives, or use `.tupleof`
+fail_compilation/fail118.d(44): Error: invalid `foreach` aggregate `Iter` of type `Iter`
+fail_compilation/fail118.d(44):        maybe define `opApply()`, range primitives, or use `.tupleof`
+fail_compilation/fail118.d(47): Error: invalid `foreach` aggregate `s` of type `S*`
+fail_compilation/fail118.d(49): Error: undefined identifier `unknown`
+fail_compilation/fail118.d(37): Error: undefined identifier `doesNotExist`
+fail_compilation/fail118.d(51): Error: template instance `fail118.error!()` error instantiating
+fail_compilation/fail118.d(51): Error: invalid `foreach` aggregate `error()` of type `void`
 ---
 */
 
@@ -20,9 +27,26 @@ class Foo
     mixin opHackedApply!() oldIterMix;
 }
 
+struct S
+{
+    int opApply(scope int delegate(const int) dg);
+}
+
+auto error()()
+{
+    doesNotExist();
+}
+
 void main()
 {
     Foo f = new Foo;
     foreach (int i; f.oldIterMix.Iter) {}
     foreach (    i; f.oldIterMix.Iter) {}
+
+    S* s;
+    foreach (const i; s) {}
+
+    foreach(const i; unknown) {}
+
+    foreach (const i; error()) {}
 }

--- a/test/fail_compilation/fail249.d
+++ b/test/fail_compilation/fail249.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail249.d(16): Error: invalid `foreach` aggregate `bar()`
+fail_compilation/fail249.d(16): Error: invalid `foreach` aggregate `bar()` of type `void`
 ---
 */
 

--- a/test/fail_compilation/fail261.d
+++ b/test/fail_compilation/fail261.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail261.d(18): Error: invalid `foreach` aggregate `range`, define `opApply()`, range primitives, or use `.tupleof`
+fail_compilation/fail261.d(19): Error: invalid `foreach` aggregate `range` of type `MyRange`
+fail_compilation/fail261.d(19):        maybe define `opApply()`, range primitives, or use `.tupleof`
 ---
 */
 

--- a/test/fail_compilation/fail92.d
+++ b/test/fail_compilation/fail92.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail92.d(15): Error: invalid `foreach` aggregate `t`
+fail_compilation/fail92.d(15): Error: invalid `foreach` aggregate `t` of type `typeof(null)`
 fail_compilation/fail92.d(23): Error: template instance `fail92.crash!(typeof(null))` error instantiating
 ---
 */

--- a/test/fail_compilation/ice9254a.d
+++ b/test/fail_compilation/ice9254a.d
@@ -6,7 +6,7 @@ fail_compilation/ice9254a.d(15): Error: Using the result of a comma expression i
 fail_compilation/ice9254a.d(15): Error: Using the result of a comma expression is not allowed
 fail_compilation/ice9254a.d(15): Error: Using the result of a comma expression is not allowed
 fail_compilation/ice9254a.d(15): Error: Using the result of a comma expression is not allowed
-fail_compilation/ice9254a.d(15): Error: invalid `foreach` aggregate `false`
+fail_compilation/ice9254a.d(15): Error: invalid `foreach` aggregate `false` of type `bool`
 ---
 */
 

--- a/test/fail_compilation/ice9254b.d
+++ b/test/fail_compilation/ice9254b.d
@@ -6,7 +6,7 @@ fail_compilation/ice9254b.d(17): Error: Using the result of a comma expression i
 fail_compilation/ice9254b.d(17): Error: Using the result of a comma expression is not allowed
 fail_compilation/ice9254b.d(17): Error: Using the result of a comma expression is not allowed
 fail_compilation/ice9254b.d(17): Error: Using the result of a comma expression is not allowed
-fail_compilation/ice9254b.d(17): Error: invalid `foreach` aggregate `false`
+fail_compilation/ice9254b.d(17): Error: invalid `foreach` aggregate `false` of type `bool`
 ---
 */
 

--- a/test/fail_compilation/ice9254c.d
+++ b/test/fail_compilation/ice9254c.d
@@ -6,7 +6,7 @@ fail_compilation/ice9254c.d(15): Error: Using the result of a comma expression i
 fail_compilation/ice9254c.d(15): Error: Using the result of a comma expression is not allowed
 fail_compilation/ice9254c.d(15): Error: Using the result of a comma expression is not allowed
 fail_compilation/ice9254c.d(15): Error: Using the result of a comma expression is not allowed
-fail_compilation/ice9254c.d(15): Error: invalid `foreach` aggregate `false`
+fail_compilation/ice9254c.d(15): Error: invalid `foreach` aggregate `false` of type `bool`
 ---
 */
 

--- a/test/fail_compilation/test21927.d
+++ b/test/fail_compilation/test21927.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test21927.d(17): Error: invalid `foreach` aggregate `this.T2(Args2...)`
-fail_compilation/test21927.d(18): Error: invalid `foreach` aggregate `this.T2!()`
+fail_compilation/test21927.d(17): Error: invalid `foreach` aggregate `this.T2(Args2...)` of type `void`
+fail_compilation/test21927.d(18): Error: invalid `foreach` aggregate `this.T2!()` of type `void`
 ---
 */
 

--- a/test/fail_compilation/test21939.d
+++ b/test/fail_compilation/test21939.d
@@ -2,7 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test21939.d(9): Error: invalid `foreach` aggregate `Object`, define `opApply()`, range primitives, or use `.tupleof`
+fail_compilation/test21939.d(10): Error: invalid `foreach` aggregate `Object` of type `Object`
+fail_compilation/test21939.d(10):        maybe define `opApply()`, range primitives, or use `.tupleof`
 ---
 */
 


### PR DESCRIPTION
Mentioning the type alongside the expressions is helpful when the
error isn't obvious, e.g. when the code didn't derefence a pointer.
