### PR TITLE
dmd.lexer: Give more informative errors for #line directive

### DIFF
--- a/test/compilable/testcstuff1.c
+++ b/test/compilable/testcstuff1.c
@@ -504,3 +504,7 @@ struct S21944
     int var;
 #1040 "cstuff1.c" 3 4
 };
+
+/********************************/
+
+#line 1050 "cstuff1.c" extra tokens ignored (should warn?)

--- a/test/fail_compilation/fail22825a.d
+++ b/test/fail_compilation/fail22825a.d
@@ -1,7 +1,7 @@
 // https://issues.dlang.org/show_bug.cgi?id=22825
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail22825a.d(8): Error: #line integer ["filespec"]\n expected
+fail_compilation/fail22825a.d(10): Error: positive integer argument expected following `#line`
 fail_compilation/fail22825a.d(11): Error: declaration expected, not `42`
 ---
 */

--- a/test/fail_compilation/fail359.d
+++ b/test/fail_compilation/fail359.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail359.d(7): Error: #line integer ["filespec"]\n expected
+fail_compilation/fail359.d(7): Error: invalid filename for `#line` directive
 ---
 */
 #line 5 _BOOM

--- a/test/fail_compilation/fail7524a.d
+++ b/test/fail_compilation/fail7524a.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -o-
 TEST_OUTPUT:
 ----
-fail_compilation/fail7524a.d(9): Error: #line integer ["filespec"]\n expected
+fail_compilation/fail7524a.d(9): Error: invalid filename for `#line` directive
 ----
 */
 

--- a/test/fail_compilation/fail7524b.d
+++ b/test/fail_compilation/fail7524b.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7524b.d(9): Error: #line integer ["filespec"]\n expected
+fail_compilation/fail7524b.d(9): Error: invalid filename for `#line` directive
 ---
 */
 

--- a/test/fail_compilation/failcstuff1.c
+++ b/test/fail_compilation/failcstuff1.c
@@ -46,6 +46,7 @@ fail_compilation/failcstuff1.c(504): Error: found `;` when expecting `)`
 fail_compilation/failcstuff1.c(505): Error: `=`, `;` or `,` expected to end declaration instead of `int`
 fail_compilation/failcstuff1.c(551): Error: missing comma or semicolon after declaration of `pluto`, found `p` instead
 fail_compilation/failcstuff1.c(601): Error: `=`, `;` or `,` expected to end declaration instead of `'s'`
+fail_compilation/failcstuff1.c(605): Error: invalid flag for line marker directive
 ---
 */
 
@@ -158,3 +159,7 @@ int * pluto p;
 #line 600
 
 char c22909 = u8's';
+
+/****************************************************/
+
+#650 "fail_compilation/failcstuff1.c" invalid

--- a/test/fail_compilation/issue22826.d
+++ b/test/fail_compilation/issue22826.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/issue22826.d(6): Error: #line integer ["filespec"]\n expected
+fail_compilation/issue22826.d(6): Error: found `3` when expecting new line following `#line` directive
 ---
 */
 #line 12 "issue22826.d" 3

--- a/test/fail_compilation/lexer4.d
+++ b/test/fail_compilation/lexer4.d
@@ -13,8 +13,8 @@ fail_compilation/lexer4.d(30): Error: exponent required for hex float
 fail_compilation/lexer4.d(31): Error: lower case integer suffix 'l' is not allowed. Please use 'L' instead
 fail_compilation/lexer4.d(32): Error: use 'i' suffix instead of 'I'
 fail_compilation/lexer4.d(34): Error: line number `1234567891234567879` out of range
-fail_compilation/lexer4.d(36): Error: #line integer ["filespec"]\n expected
-fail_compilation/lexer4.d(19): Error: #line integer ["filespec"]\n expected
+fail_compilation/lexer4.d(36): Error: positive integer argument expected following `#line`
+fail_compilation/lexer4.d(19): Error: found `"file"` when expecting new line following `#line` directive
 ---
 */
 


### PR DESCRIPTION
The current errors are too generic, and don't point towards what might be the syntax error.