### PR TITLE
Fix Issue 11463 - DDoc html to show the normal escaped ASCII chars

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1836,25 +1836,12 @@ public:
                     t = te.sym.memtype;
                     goto L1;
                 }
-            case Twchar:
-                // BUG: need to cast(wchar)
-            case Tdchar:
-                // BUG: need to cast(dchar)
-                if (cast(uinteger_t)v > 0xFF)
-                {
-                    buf.printf("'\\U%08llx'", cast(long)v);
-                    break;
-                }
-                goto case;
             case Tchar:
+            case Twchar:
+            case Tdchar:
                 {
-                    size_t o = buf.length;
-                    if (v == '\'')
-                        buf.writestring("'\\''");
-                    else if (isprint(cast(int)v) && v != '\\')
-                        buf.printf("'%c'", cast(int)v);
-                    else
-                        buf.printf("'\\x%02x'", cast(int)v);
+                    const o = buf.length;
+                    writeSingleCharLiteral(*buf, cast(dchar) v);
                     if (hgs.ddoc)
                         escapeDdocString(buf, o);
                     break;

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -947,20 +947,19 @@ nothrow:
             sprintf(&buffer[0], "%d", cast(int)intvalue);
             break;
         case TOK.uns32Literal:
-        case TOK.wcharLiteral:
-        case TOK.dcharLiteral:
         case TOK.wchar_tLiteral:
             sprintf(&buffer[0], "%uU", cast(uint)unsvalue);
             break;
+        case TOK.wcharLiteral:
+        case TOK.dcharLiteral:
         case TOK.charLiteral:
-        {
-            const v = cast(int)intvalue;
-            if (v >= ' ' && v <= '~')
-                sprintf(&buffer[0], "'%c'", v);
-            else
-                sprintf(&buffer[0], "'\\x%02x'", v);
+            {
+                OutBuffer buf;
+                buf.writeSingleCharLiteral(cast(dchar) intvalue);
+                buf.writeByte('\0');
+                p = buf.extractSlice().ptr;
+            }
             break;
-        }
         case TOK.int64Literal:
             sprintf(&buffer[0], "%lldL", cast(long)intvalue);
             break;
@@ -1092,7 +1091,7 @@ void writeCharLiteral(ref OutBuffer buf, dchar c)
             buf.writeByte('\\');
             goto default;
         default:
-            if (c <= 0x7F)
+            if (c <= 0xFF)
             {
                 if (isprint(c))
                     buf.writeByte(c);
@@ -1115,4 +1114,41 @@ unittest
         writeCharLiteral(buf, d);
     }
     assert(buf.extractSlice() == `a\n\r\t\b\f\0\x11\u7233\U00017233`);
+}
+
+/**
+ * Write a single-quoted character literal
+ *
+ * Useful for printing '' char literals in e.g. error messages, ddoc, or the `.stringof` property
+ *
+ * Params:
+ *   buf = buffer to append character in
+ *   c = code point to write
+ */
+nothrow
+void writeSingleCharLiteral(ref OutBuffer buf, dchar c)
+{
+    buf.writeByte('\'');
+    if (c == '\'')
+        buf.writeByte('\\');
+
+    if (c == '"')
+        buf.writeByte('"');
+    else
+        writeCharLiteral(buf, c);
+
+    buf.writeByte('\'');
+}
+
+unittest
+{
+    OutBuffer buf;
+    writeSingleCharLiteral(buf, '\'');
+    assert(buf.extractSlice() == `'\''`);
+    buf.reset();
+    writeSingleCharLiteral(buf, '"');
+    assert(buf.extractSlice() == `'"'`);
+    buf.reset();
+    writeSingleCharLiteral(buf, '\n');
+    assert(buf.extractSlice() == `'\n'`);
 }

--- a/test/compilable/ddoc1.d
+++ b/test/compilable/ddoc1.d
@@ -47,7 +47,7 @@ wchar YY;	/// ditto
  *	argulid = the argument
  *	u = the other argument
  */
-int foo(char c, int argulid, char u);
+int foo(char c, int argulid, char u = '\'', wchar v = '\u7233', dchar y = '\U00017233');
 
 int barr() { return 3; } /// doc for barr()
 

--- a/test/compilable/extra-files/ddoc1.html
+++ b/test/compilable/extra-files/ddoc1.html
@@ -752,7 +752,7 @@
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="foo"></span>int <code class="code">foo</code>(char <code class="code">c</code>, int <code class="code">argulid</code>, char <code class="code">u</code>);
+            <span class="ddoc_anchor" id="foo"></span>int <code class="code">foo</code>(char <code class="code">c</code>, int <code class="code">argulid</code>, char <code class="code">u</code> = '\'', wchar <code class="code">v</code> = '\u7233', dchar <code class="code">y</code> = '\U00017233');
 
           </code>
         </p>

--- a/test/compilable/extra-files/vcg-ast.d.cg
+++ b/test/compilable/extra-files/vcg-ast.d.cg
@@ -140,7 +140,7 @@ values!(__c_wchar_t)
 	pure nothrow @safe __c_wchar_t[] values()
 	{
 		__c_wchar_t[] values = null;
-		values ~= cast(__c_wchar_t)'\U0000ffff';
+		values ~= cast(__c_wchar_t)'\uffff';
 		return values;
 	}
 

--- a/test/fail_compilation/lexer1.d
+++ b/test/fail_compilation/lexer1.d
@@ -11,8 +11,8 @@ fail_compilation/lexer1.d(35): Error: declaration expected, not `0.1i`
 fail_compilation/lexer1.d(36): Error: declaration expected, not `0.1fi`
 fail_compilation/lexer1.d(37): Error: declaration expected, not `0.1Li`
 fail_compilation/lexer1.d(38): Error: declaration expected, not `' '`
-fail_compilation/lexer1.d(39): Error: declaration expected, not `55295U`
-fail_compilation/lexer1.d(40): Error: declaration expected, not `65536U`
+fail_compilation/lexer1.d(39): Error: declaration expected, not `'\ud7ff'`
+fail_compilation/lexer1.d(40): Error: declaration expected, not `'\U00010000'`
 fail_compilation/lexer1.d(41): Error: declaration expected, not `"ab\\c\"\u1234a\U00011100a\0ab"d`
 fail_compilation/lexer1.d(43): Error: declaration expected, not `module`
 fail_compilation/lexer1.d(45): Error: escape hex sequence has 1 hex digits instead of 2


### PR DESCRIPTION
Unify printing of `'x'` character literals and leverage the `writeCharLiteral` from https://github.com/dlang/dmd/pull/13662.