### PR TITLE
Fix issue 22920: Improve errors when missing import paths

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -601,10 +601,21 @@ extern (C++) final class Module : Package
     {
         if (FileName.equals(srcfile.toString(), "object.d"))
         {
-            .error(loc, "cannot find source code for runtime library file 'object.d'");
-            errorSupplemental(loc, "dmd might not be correctly installed. Run 'dmd -man' for installation instructions.");
-            const dmdConfFile = global.inifilename.length ? FileName.canonicalName(global.inifilename) : "not found";
-            errorSupplemental(loc, "config file: %.*s", cast(int)dmdConfFile.length, dmdConfFile.ptr);
+            error("cannot find source code for runtime library file `object.d`.");
+            /* errorSupplemental("DMD might not be correctly installed. Run 'dmd -man' for installation instructions."); */
+            if (global.inifilename.length)
+            {
+                const dmdConfFile = FileName.canonicalName(global.inifilename);
+                errorSupplemental(loc, "Perhaps add an include path using `-I` or into the config file (`%.*s`)",
+                        cast(int)dmdConfFile.length,
+                        dmdConfFile.ptr);
+            }
+            else
+            {
+                errorSupplemental(loc, "There is no config file. Perhaps add one or add an include path using `-I`.");
+            }
+            if (global.path)
+                errorSupplemental(loc, "Currently, the compiler search on the following include paths:");
         }
         else if (FileName.ext(this.arg) || !loc.isValid())
         {
@@ -621,28 +632,34 @@ extern (C++) final class Module : Package
                 .error(loc, "importing package '%s' requires a 'package.d' file which cannot be found in '%s'", toChars(), srcfile.toChars());
             else
             {
-                .error(loc, "unable to read module `%s`", toChars());
+                error("unable to read module `%s`", toChars());
                 const pkgfile = FileName.combine(FileName.removeExt(srcfile.toString()), package_d);
-                .errorSupplemental(loc, "Expected '%s' or '%s' in one of the following import paths:",
+                .errorSupplemental(loc,
+                    global.path
+                        ? "Expected '%s' or '%s' in one of the following import paths:"
+                        : "Expected '%s' or '%s' in the import paths.",
                     srcfile.toChars(), pkgfile.ptr);
             }
         }
-        if (!global.gag)
-        {
-            /* Print path
-             */
-            if (global.path)
-            {
-                foreach (i, p; *global.path)
-                    fprintf(stderr, "import path[%llu] = %s\n", cast(ulong)i, p);
-            }
-            else
-            {
-                fprintf(stderr, "Specify path to file '%s' with -I switch\n", srcfile.toChars());
-            }
 
-            removeHdrFilesAndFail(global.params, Module.amodules);
+        /* Print path
+         */
+        if (global.path)
+        {
+            foreach (idx, path; *global.path)
+            {
+                const attr = FileName.exists(path);
+                const(char)* err = attr == 2 ? "" :
+                    (attr == 1 ? " (not a directory)" : " (path not found)");
+                .errorSupplemental(loc, "[%llu]: `%s`%s", cast(ulong)idx, path, err);
+            }
         }
+        else
+        {
+            .errorSupplemental(loc, "Specify the import path for file `%s` with -I switch.", srcfile.toChars());
+        }
+        if (!global.gag)
+            removeHdrFilesAndFail(global.params, Module.amodules);
     }
 
     /**

--- a/test/fail_compilation/diag10327.d
+++ b/test/fail_compilation/diag10327.d
@@ -3,9 +3,9 @@ TEST_OUTPUT:
 ---
 fail_compilation/diag10327.d(12): Error: unable to read module `test10327`
 fail_compilation/diag10327.d(12):        Expected 'imports/test10327.d' or 'imports/test10327/package.d' in one of the following import paths:
-import path[0] = fail_compilation
-import path[1] = $p:druntime/import$
-import path[2] = $p:phobos$
+fail_compilation/diag10327.d(12):        [0]: `fail_compilation`
+fail_compilation/diag10327.d(12):        [1]: `$p:druntime/import$`
+fail_compilation/diag10327.d(12):        [2]: `$p:phobos$`
 ---
 */
 

--- a/test/fail_compilation/diag22920.d
+++ b/test/fail_compilation/diag22920.d
@@ -1,0 +1,15 @@
+/*
+REQUIRED_ARGS: -Ifail_compilation/diag22920.d -Ithis/folder/doesnt/exist
+TEST_OUTPUT:
+----
+fail_compilation/diag22920.d(15): Error: unable to read module `foo`
+fail_compilation/diag22920.d(15):        Expected 'foo.d' or 'foo/package.d' in one of the following import paths:
+fail_compilation/diag22920.d(15):        [0]: `fail_compilation`
+fail_compilation/diag22920.d(15):        [1]: `fail_compilation/diag22920.d` (not a directory)
+fail_compilation/diag22920.d(15):        [2]: `this/folder/doesnt/exist` (path not found)
+fail_compilation/diag22920.d(15):        [3]: `$p:druntime/import$`
+fail_compilation/diag22920.d(15):        [4]: `$p:phobos$`
+----
+*/
+
+import foo;

--- a/test/fail_compilation/fail21091a.d
+++ b/test/fail_compilation/fail21091a.d
@@ -5,9 +5,9 @@ TEST_OUTPUT:
 ----
 fail_compilation/fail21091a.d(16): Error: unable to read module `Ternary`
 fail_compilation/fail21091a.d(16):        Expected 'Ternary.d' or 'Ternary/package.d' in one of the following import paths:
-import path[0] = fail_compilation
-import path[1] = $p:druntime/import$
-import path[2] = $p:phobos$
+fail_compilation/fail21091a.d(16):        [0]: `fail_compilation`
+fail_compilation/fail21091a.d(16):        [1]: `$p:druntime/import$`
+fail_compilation/fail21091a.d(16):        [2]: `$p:phobos$`
 ----
 */
 

--- a/test/fail_compilation/fail21091b.d
+++ b/test/fail_compilation/fail21091b.d
@@ -5,9 +5,9 @@ TEST_OUTPUT:
 ----
 fail_compilation/fail21091b.d(16): Error: unable to read module `Tid`
 fail_compilation/fail21091b.d(16):        Expected 'Tid.d' or 'Tid/package.d' in one of the following import paths:
-import path[0] = fail_compilation
-import path[1] = $p:druntime/import$
-import path[2] = $p:phobos$
+fail_compilation/fail21091b.d(16):        [0]: `fail_compilation`
+fail_compilation/fail21091b.d(16):        [1]: `$p:druntime/import$`
+fail_compilation/fail21091b.d(16):        [2]: `$p:phobos$`
 ----
 */
 

--- a/test/fail_compilation/ice7782.d
+++ b/test/fail_compilation/ice7782.d
@@ -4,9 +4,9 @@ TEST_OUTPUT:
 ----
 fail_compilation/ice7782.d(14): Error: unable to read module `ice7782math`
 fail_compilation/ice7782.d(14):        Expected 'imports/ice7782range/imports/ice7782math.d' or 'imports/ice7782range/imports/ice7782math/package.d' in one of the following import paths:
-import path[0] = fail_compilation
-import path[1] = $p:druntime/import$
-import path[2] = $p:phobos$
+fail_compilation/ice7782.d(14):        [0]: `fail_compilation`
+fail_compilation/ice7782.d(14):        [1]: `$p:druntime/import$`
+fail_compilation/ice7782.d(14):        [2]: `$p:phobos$`
 ----
 */
 

--- a/test/fail_compilation/no_object.d
+++ b/test/fail_compilation/no_object.d
@@ -2,10 +2,11 @@
 DFLAGS:
 TEST_OUTPUT:
 ---
-Error: cannot find source code for runtime library file 'object.d'
-       dmd might not be correctly installed. Run 'dmd -man' for installation instructions.
-       config file: not found
-import path[0] = fail_compilation
+Error: cannot find source code for runtime library file `object.d`.
+       DMD might not be correctly installed. Run 'dmd -man' for installation instructions.
+       There is no config file. Perhaps add one or add an include path using `-I`.
+       Currently, the compiler search on the following include paths:
+       [0]: `fail_compilation`
 ---
 */
 

--- a/test/fail_compilation/test22361.d
+++ b/test/fail_compilation/test22361.d
@@ -3,9 +3,9 @@ TEST_OUTPUT:
 ---
 fail_compilation/test22361.d(11): Error: unable to read module `this_module_does_not_exist`
 fail_compilation/test22361.d(11):        Expected 'this_module_does_not_exist.d' or 'this_module_does_not_exist/package.d' in one of the following import paths:
-import path[0] = fail_compilation
-import path[1] = $p:druntime/import$
-import path[2] = $p:phobos$
+fail_compilation/test22361.d(11):        [0]: `fail_compilation`
+fail_compilation/test22361.d(11):        [1]: `$p:druntime/import$`
+fail_compilation/test22361.d(11):        [2]: `$p:phobos$`
 ---
 */
 import this_module_does_not_exist;


### PR DESCRIPTION
    This patch introduces errorSupplemental() to the import paths error to display
    extra information about them. These error messages are out of sync with `-J`
    flag, which have similar purposes. This patch make `-I` behave similarly to
    `-J` flag in terms of errors, improving consistency among other error messages
    and add some alignment to the main error.
    
    It also improves the message for missing `object.d` file and give better hints
    about configured import paths.
    
    This change is particularly crucial for DMD as a library, since error
    interfaces writes to a diagnostic handler rather than directly to `stderr`.
    
    Signed-off-by: Luís Ferreira <contact@lsferreira.net>