### PR TITLE
Avoid `init` members in backend

### DIFF
--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -440,7 +440,6 @@ struct Blockx
     int next_index;             // value for next scope index
     uint flags;                 // value to OR into Bflags
     block* tryblock;            // current enclosing try block
-    elem* init;                 // static initializer
     ClassDeclaration_ classdec;
     Declaration_ member;        // member we're compiling for
     Module_ _module;            // module we're in

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -183,7 +183,7 @@ void codgen(Symbol *sfunc)
     cod3_initregs();
     allregs = ALLREGS;
     pass = PASSinitial;
-    Alloca.init();
+    Alloca.initialize();
     anyiasm = 0;
 
     if (config.ehmethod == EHmethod.EH_DWARF)
@@ -216,7 +216,7 @@ tryagain:
     retsym = null;
 
     cgstate.stackclean = 1;
-    cgstate.funcarg.init();
+    cgstate.funcarg.initialize();
     cgstate.funcargtos = ~0;
     cgstate.accessedTLS = false;
     STACKALIGN = TARGET_STACKALIGN;
@@ -1266,10 +1266,10 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
 {
     //printf("stackoffsets() %s\n", funcsym_p.Sident.ptr);
 
-    Para.init();        // parameter offset
-    Fast.init();        // SCfastpar offset
-    Auto.init();        // automatic & register offset
-    EEStack.init();     // for SCstack's
+    Para.initialize();        // parameter offset
+    Fast.initialize();        // SCfastpar offset
+    Auto.initialize();        // automatic & register offset
+    EEStack.initialize();     // for SCstack's
 
     // Set if doing optimization of auto layout
     bool doAutoOpt = estimate && config.flags4 & CFG4optimized;

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -139,7 +139,7 @@ struct LocalSection
     int alignment;              // alignment size
 
   nothrow:
-    void init()                 // initialize
+    void initialize()
     {   offset = 0;
         size = 0;
         alignment = 0;

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -636,7 +636,7 @@ int ElfObj_string_literal_segment(uint sz)
 /******************************
  * Perform initialization that applies to all .o output files.
  *      Called before any other obj_xxx routines
- *      Called by Obj.init()
+ *      Called by Obj.initialize()
  * Params:
  *      objbuf = where to write the object file data
  *      filename = source file name

--- a/src/dmd/backend/obj.d
+++ b/src/dmd/backend/obj.d
@@ -191,7 +191,7 @@ else
       {
         nothrow:
 
-        Obj init(OutBuffer* objbuf, const(char)* filename, const(char)* csegname)
+        Obj initialize(OutBuffer* objbuf, const(char)* filename, const(char)* csegname)
         {
             mixin(genRetVal("init(objbuf, filename, csegname)"));
         }

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -351,7 +351,7 @@ private void obj_start(ref OutBuffer objbuf, const(char)* srcfile)
     }
     else
     {
-        objmod = Obj.init(&objbuf, srcfile, null);
+        objmod = Obj.initialize(&objbuf, srcfile, null);
     }
 
     el_reset();


### PR DESCRIPTION
Don't have member functions named `init`, because they conflict with the built-in `.init` property of types.
For https://github.com/dlang/dmd/pull/12512