### PR TITLE
Fix 22934 - Emit context pointer as `outer` instead of `this`

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -1,0 +1,11 @@
+Improvements for the C++ header generation
+
+The following features/bugfixes/improvements were implemented for the
+experimental C++ header generator:
+
+- The implicitly generated context pointer for nested aggregates is now
+  emitted as `outer` instead of `this`
+
+
+Note: The header generator is still considered experimental, so please submit
+      any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1655,7 +1655,16 @@ public:
             scope(exit) printf("[typeToBuffer(AST.Type, AST.Dsymbol) exit] %s sym %s\n", t.toChars(), s.toChars());
         }
 
-        this.ident = s.ident;
+        // The context pointer (represented as `ThisDeclaration`) is named
+        // `this` but accessible via `outer`
+        if (auto td = s.isThisDeclaration())
+        {
+            import dmd.id;
+            this.ident = Id.outer;
+        }
+        else
+            this.ident = s.ident;
+
         auto type = origType !is null ? origType : t;
         AST.Dsymbol customLength;
 
@@ -1702,7 +1711,12 @@ public:
         if (this.ident)
         {
             buf.writeByte(' ');
-            writeIdentifier(s, canFixup);
+            // Custom identifier doesn't need further checks
+            if (this.ident !is s.ident)
+                buf.writestring(this.ident.toString());
+            else
+                writeIdentifier(s, canFixup);
+
         }
         this.ident = null;
 

--- a/test/compilable/dtoh_ClassDeclaration.d
+++ b/test/compilable/dtoh_ClassDeclaration.d
@@ -116,7 +116,7 @@ public:
     {
     public:
         int32_t x;
-        A* this;
+        A* outer;
     };
 
     typedef Inner I;


### PR DESCRIPTION
Because the latter is obviosly not a valid identifier.
