### PR TITLE
Fix Issue 22919 - -checkaction=context gives "assigned to `__assertOp…

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -692,9 +692,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
 
             // If va's lifetime encloses v's, then error
             if (va && !va.isDataseg() &&
-                (va.enclosesLifetimeOf(v) && !(v.storage_class & STC.temp) ||
-                 vaIsRef ||
-                 va.isReference() && !(v.storage_class & (STC.parameter | STC.temp))) &&
+                ((va.enclosesLifetimeOf(v) && !(v.storage_class & STC.temp)) || vaIsRef) &&
                 fd.setUnsafe())
             {
                 if (!gag)

--- a/test/compilable/test22919.d
+++ b/test/compilable/test22919.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -checkaction=context -preview=dip1000
+
+// Issue 22919 - [dip1000] -checkaction=context gives "assigned to `__assertOp2` with longer lifetime" (
+// https://issues.dlang.org/show_bug.cgi?id=22919
+
+@safe:
+struct S
+{
+    int* p;
+    ref S get() scope return {return this;}
+}
+
+void main()
+{
+    scope S arr = S();
+    assert(arr == arr.get());
+}


### PR DESCRIPTION
…2` with longer lifetime"

The problem is that the `__assertOp2` is a temporary with the `ref` storage class, which is assumed to have longer lifetime than any local. One fix is to add an exception for a `va` with `STC.temp`, but the whole thing starts to look rather redundant when there's also `vaIsRef`, so let's see if we can remove it.