### PR TITLE
Move `enclosesLifetimeOf` and `addMaybe` to escape.d

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1642,38 +1642,6 @@ extern (C++) class VarDeclaration : Declaration
     {
         v.visit(this);
     }
-
-    /**********************************
-     * Determine if `this` has a lifetime that lasts past
-     * the destruction of `v`
-     * Params:
-     *  v = variable to test against
-     * Returns:
-     *  true if it does
-     */
-    final bool enclosesLifetimeOf(VarDeclaration v) const pure
-    {
-        assert(this.sequenceNumber != this.sequenceNumber.init);
-        assert(v.sequenceNumber != v.sequenceNumber.init);
-        return (this.sequenceNumber < v.sequenceNumber);
-    }
-
-    /***************************************
-     * Add variable to maybes[].
-     * When a maybescope variable `v` is assigned to a maybescope variable `this`,
-     * we cannot determine if `this` is actually scope until the semantic
-     * analysis for the function is completed. Thus, we save the data
-     * until then.
-     * Params:
-     *  v = an STC.maybescope variable that was assigned to `this`
-     */
-    final void addMaybe(VarDeclaration v)
-    {
-        //printf("add %s to %s's list of dependencies\n", v.toChars(), toChars());
-        if (!maybes)
-            maybes = new VarDeclarations();
-        maybes.push(v);
-    }
 }
 
 /*******************************************************

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -273,7 +273,6 @@ public:
     bool hasPointers();
     bool canTakeAddressOf();
     bool needsScopeDtor();
-    bool enclosesLifetimeOf(VarDeclaration *v) const;
     void checkCtorConstInit();
     Dsymbol *toAlias();
     // Eliminate need for dynamic_cast

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -2294,3 +2294,37 @@ bool isReferenceToMutable(Parameter p, Type t)
     }
     return isReferenceToMutable(p.type);
 }
+
+/**********************************
+* Determine if `va` has a lifetime that lasts past
+* the destruction of `v`
+* Params:
+*     va = variable assigned to
+*     v = variable being assigned
+* Returns:
+*     true if it does
+*/
+private bool enclosesLifetimeOf(const VarDeclaration va, const VarDeclaration v) pure
+{
+    assert(va.sequenceNumber != va.sequenceNumber.init);
+    assert(v.sequenceNumber != v.sequenceNumber.init);
+    return va.sequenceNumber < v.sequenceNumber;
+}
+
+/***************************************
+ * Add variable `v` to maybes[]
+ *
+ * When a maybescope variable `v` is assigned to a maybescope variable `va`,
+ * we cannot determine if `this` is actually scope until the semantic
+ * analysis for the function is completed. Thus, we save the data
+ * until then.
+ * Params:
+ *     v = an `STC.maybescope` variable that was assigned to `this`
+ */
+private void addMaybe(VarDeclaration va, VarDeclaration v)
+{
+    //printf("add %s to %s's list of dependencies\n", v.toChars(), toChars());
+    if (!va.maybes)
+        va.maybes = new VarDeclarations();
+    va.maybes.push(v);
+}

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5792,8 +5792,6 @@ public:
     Dsymbol* toAlias();
     VarDeclaration* isVarDeclaration();
     void accept(Visitor* v);
-    bool enclosesLifetimeOf(VarDeclaration* v) const;
-    void addMaybe(VarDeclaration* v);
 };
 
 class BitFieldDeclaration : public VarDeclaration


### PR DESCRIPTION
I don't think they make sense as member functions in declaration.d. They're only used in escape.d, so move them there and make them private.