### PR TITLE
[REG master] dmd.func: Add setters for isNRVO and isGenerated

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -642,8 +642,10 @@ public:
     bool isNogc();
     bool isNogcBypassingInference();
     bool isNRVO() const;
+    void isNRVO(bool v);
     bool isNaked() const;
     bool isGenerated() const;
+    void isGenerated(bool v);
     bool isIntroducing() const;
     bool hasSemantic3Errors() const;
     bool hasNoEH() const;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2879,8 +2879,10 @@ public:
     bool isNogc();
     bool isNogcBypassingInference();
     bool isNRVO() const;
+    void isNRVO(bool v);
     bool isNaked() const;
     bool isGenerated() const;
+    void isGenerated(bool v);
     bool isIntroducing() const;
     bool hasSemantic3Errors() const;
     bool hasNoEH() const;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1463,6 +1463,12 @@ extern (C++) class FuncDeclaration : Declaration
         return !!(this.flags & FUNCFLAG.NRVO);
     }
 
+    final void isNRVO(bool v) pure nothrow @safe @nogc
+    {
+        if (v) this.flags |= FUNCFLAG.NRVO;
+        else this.flags &= ~FUNCFLAG.NRVO;
+    }
+
     final bool isNaked() const scope @safe pure nothrow @nogc
     {
         return !!(this.flags & FUNCFLAG.naked);
@@ -1471,6 +1477,12 @@ extern (C++) class FuncDeclaration : Declaration
     final bool isGenerated() const scope @safe pure nothrow @nogc
     {
         return !!(this.flags & FUNCFLAG.generated);
+    }
+
+    final void isGenerated(bool v) pure nothrow @safe @nogc
+    {
+        if (v) this.flags |= FUNCFLAG.generated;
+        else this.flags &= ~FUNCFLAG.generated;
     }
 
     final bool isIntroducing() const scope @safe pure nothrow @nogc

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -749,7 +749,7 @@ void setClosureVarOffset(FuncDeclaration fd)
          */
         if (fd.isNRVO() && fd.nrvo_var == v)
         {
-            fd.flags &= ~FUNCFLAG.NRVO;
+            fd.isNRVO = false;
         }
     }
 }


### PR DESCRIPTION
Fixes more build regressions caused by removing bool fields.