### PR TITLE
dmd.func: Return false in checkNRVO for all variables with nested refs

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2799,6 +2799,8 @@ extern (C++) class FuncDeclaration : Declaration
                     // parameters and closure variables cannot be NRVOed.
                     if (v.isDataseg() || v.isParameter() || v.toParent2() != this)
                         return false;
+                    if (v.nestedrefs.length && needsClosure())
+                        return false;
                     // The variable type needs to be equivalent to the return type.
                     if (!v.type.equivalent(tf.next))
                         return false;

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -747,10 +747,7 @@ void setClosureVarOffset(FuncDeclaration fd)
         /* Can't do nrvo if the variable is put in a closure, since
          * what the shidden points to may no longer exist.
          */
-        if (fd.isNRVO() && fd.nrvo_var == v)
-        {
-            fd.isNRVO = false;
-        }
+        assert(!fd.isNRVO() || fd.nrvo_var != v);
     }
 }
 

--- a/test/runnable/nrvo.d
+++ b/test/runnable/nrvo.d
@@ -1,0 +1,30 @@
+/***************************************************/
+
+struct S1
+{
+    int x;
+    ~this() {}
+}
+
+__gshared S1* s1ptr;
+
+S1 test1a()
+{
+    auto result = S1(123);
+    (() @trusted { result.x++; s1ptr = &result; })();
+    return result;
+}
+
+void test1()
+{
+    auto r = test1a();
+    assert(r.x == 124);
+    assert(&r == s1ptr);
+}
+
+/***************************************************/
+
+void main()
+{
+    test1();
+}


### PR DESCRIPTION
Whether it ends up in a closure, or stack frame.  The address of such variables cannot share the same address as the return slot/hidden pointer.

This removes the need to override isNRVO after semantic has finished.