### PR TITLE
Fix 22951 - Emit non-extern (C++) destructors as private members

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -9,6 +9,9 @@ experimental C++ header generator:
   functions / variables. The mangling is used as the identifier of `extern(C)`
   declarations because C doesn't mangle declaration names. `extern(C++)`
   declarations are ignored because there's no portable alternative for C++.
+- Emits destructors not easily accessible from C++ (e.g. `extern(D)`) as private
+  members, preventing the creation of instances that would not be destroyed
+  on the C++ side.
 
 Note: The header generator is still considered experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1115,6 +1115,7 @@ struct BitArray final
     enum : uint64_t { BitsPerChunk = 64LLU };
 
 private:
+    ~BitArray();
     size_t len;
     uint64_t* ptr;
 public:

--- a/test/compilable/dtoh_StructDeclaration.d
+++ b/test/compilable/dtoh_StructDeclaration.d
@@ -45,6 +45,9 @@ struct S final
     int32_t b;
     int64_t c;
     _d_dynamicArray< int32_t > arr;
+private:
+    ~S();
+public:
     S() :
         a(),
         b(),
@@ -232,6 +235,7 @@ extern (C++) struct S
     int b;
     long c;
     int[] arr;
+    extern(D) ~this() {}
 }
 
 extern (C++) struct S2

--- a/test/dshell/extra-files/cpp_header_gen/app.cpp
+++ b/test/dshell/extra-files/cpp_header_gen/app.cpp
@@ -65,5 +65,10 @@ int main()
     invalidNames.register_ = Pass::inline_;
     invalidNames.foo(Pass::inline_);
 
+    {
+        // Disallowed, would skip the dtor
+        // RequiresDummy dummy;
+        acceptDummy(nullptr);
+    }
     return 0;
 }

--- a/test/dshell/extra-files/cpp_header_gen/library.d
+++ b/test/dshell/extra-files/cpp_header_gen/library.d
@@ -159,3 +159,14 @@ struct InvalidNames(typename)
 }
 
 void useInvalid(InvalidNames!Pass) {}
+
+struct RequiresDummy
+{
+    extern(D):
+    ~this() {}
+}
+
+ref RequiresDummy acceptDummy(RequiresDummy* dummy)
+{
+    return *dummy;
+}


### PR DESCRIPTION
Destructors not marked as `extern (C++)` aren't accessible from C++
due to the D name mangling. The header generator used to skip `extern(D)`
destructors, allowing C++ code that violated RAII guarantees.

Declaring the constructors as `private` members ensures that any
instance that would need to be destroyed on the C++ side causes a
compiler error (rather than a linker error due to missmatched mangling).

Renamed the helper function `checkVirtualFunction` because it now also
handles other types of functions.
