### PR TITLE
Fix 22954 - dtoh: Ignore member functions with C linkage

### DIFF
--- a/changelog/dtoh-improvements.dd
+++ b/changelog/dtoh-improvements.dd
@@ -12,6 +12,8 @@ experimental C++ header generator:
 - Emits destructors not easily accessible from C++ (e.g. `extern(D)`) as private
   members, preventing the creation of instances that would not be destroyed
   on the C++ side.
+- No longer generates `extern(C)` functions in aggregates that are emitted
+  with D mangling.
 
 Note: The header generator is still considered experimental, so please submit
       any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -727,7 +727,7 @@ public:
 
         // Note that tf might be null for templated (member) functions
         auto tf = cast(AST.TypeFunction)fd.type;
-        if ((tf && tf.linkage != LINK.c && tf.linkage != LINK.cpp) || (!tf && fd.isPostBlitDeclaration()))
+        if ((tf && (tf.linkage != LINK.c || adparent) && tf.linkage != LINK.cpp) || (!tf && fd.isPostBlitDeclaration()))
         {
             ignored("function %s because of linkage", fd.toPrettyChars());
             return checkFunctionNeedsPlaceholder(fd);

--- a/test/compilable/dtoh_AnonDeclaration.d
+++ b/test/compilable/dtoh_AnonDeclaration.d
@@ -50,7 +50,6 @@ struct S final
     {
         int32_t y;
         double z;
-        extern "C" void foo();
         void bar();
     };
     struct

--- a/test/compilable/dtoh_ClassDeclaration.d
+++ b/test/compilable/dtoh_ClassDeclaration.d
@@ -82,7 +82,9 @@ public:
     int32_t a;
     C* c;
     virtual void foo();
-    extern "C" virtual void bar();
+private:
+    virtual void __vtable_slot_0();
+public:
     virtual void baz(int32_t x = 42);
     struct
     {
@@ -146,8 +148,8 @@ public:
 
 class Parent
 {
-    virtual void __vtable_slot_0();
     virtual void __vtable_slot_1();
+    virtual void __vtable_slot_2();
 public:
     virtual void foo();
 };

--- a/test/compilable/dtoh_StructDeclaration.d
+++ b/test/compilable/dtoh_StructDeclaration.d
@@ -84,7 +84,6 @@ struct S3 final
     int32_t a;
     int32_t b;
     int64_t c;
-    extern "C" S3(int32_t a);
     S3() :
         a(42),
         b(),
@@ -146,7 +145,6 @@ struct A final
 {
     int32_t a;
     S s;
-    extern "C" void bar();
     void baz(int32_t x = 42);
     struct
     {

--- a/test/compilable/dtoh_mangling.d
+++ b/test/compilable/dtoh_mangling.d
@@ -43,7 +43,7 @@ extern "C" int32_t freeC();
 // Ignored function dtoh_mangling.bar because C++ doesn't support explicit mangling
 struct Data final
 {
-    extern "C" static int32_t memberC();
+    // Ignored function dtoh_mangling.Data.foo because of linkage
     // Ignored function dtoh_mangling.Data.bar because C++ doesn't support explicit mangling
     Data()
     {
@@ -84,7 +84,6 @@ extern (C++) void bar() {}
 pragma(mangle, "Aggregate")
 struct Data
 {
-    // FIXME: extern(C) member functions should be ignored
     pragma(mangle, "memberC")
     static int foo() { return 0; }
 

--- a/test/dshell/extra-files/cpp_header_gen/app.cpp
+++ b/test/dshell/extra-files/cpp_header_gen/app.cpp
@@ -70,5 +70,7 @@ int main()
         // RequiresDummy dummy;
         acceptDummy(nullptr);
     }
+
+    assert(fromMixin(2, 4) == 8);
     return 0;
 }

--- a/test/dshell/extra-files/cpp_header_gen/library.d
+++ b/test/dshell/extra-files/cpp_header_gen/library.d
@@ -170,3 +170,13 @@ ref RequiresDummy acceptDummy(RequiresDummy* dummy)
 {
     return *dummy;
 }
+
+mixin template CreateModuleMembers()
+{
+    int fromMixin(int a, int b)
+    {
+        return a * b;
+    }
+}
+
+mixin CreateModuleMembers!();


### PR DESCRIPTION
Those functions receive D mangling and hence aren't easily callable via
the header file. Note that C++ does the same for members in an
`extern "C"` aggregate (=> mangle as C++ symbol).
`
