### PR TITLE
Fix Issue 20717 - Unsilenced bogus undefined identifier error from speculative collision

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -6425,10 +6425,10 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
 
     // Ungag errors when not instantiated DeclDefs scope alias
     auto ungag = Ungag(global.gag);
-    //printf("%s parent = %s, gag = %d, instantiated = %d\n", toChars(), parent, global.gag, isInstantiated());
-    if (ds.parent && global.gag && !ds.isInstantiated() && !ds.toParent2().isFuncDeclaration())
+    //printf("%s parent = %s, gag = %d, instantiated = %d\n", ds.toChars(), ds.parent.toChars(), global.gag, ds.isInstantiated() !is null);
+    if (ds.parent && global.gag && !ds.isInstantiated() && !ds.toParent2().isFuncDeclaration() && (sc.minst || sc.tinst))
     {
-        //printf("%s type = %s\n", toPrettyChars(), type.toChars());
+        //printf("%s type = %s\n", ds.toPrettyChars(), ds.type.toChars());
         global.gag = 0;
     }
 
@@ -6502,13 +6502,13 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
     }
     if (s) // it's a symbolic alias
     {
-        //printf("alias %s resolved to %s %s\n", toChars(), s.kind(), s.toChars());
+        //printf("alias %s resolved to %s %s\n", ds.toChars(), s.kind(), s.toChars());
         ds.type = null;
         ds.aliassym = s;
     }
     else    // it's a type alias
     {
-        //printf("alias %s resolved to type %s\n", toChars(), type.toChars());
+        //printf("alias %s resolved to type %s\n", ds.toChars(), ds.type.toChars());
         ds.type = ds.type.typeSemantic(ds.loc, sc);
         ds.aliassym = null;
     }

--- a/test/compilable/test20717.d
+++ b/test/compilable/test20717.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=20717
+
+/*
+TEST_OUTPUT:
+---
+false
+---
+*/
+
+pragma(msg, is(typeof({
+    struct S
+    {
+        struct Foo {}
+        struct Bar() {}
+        alias Bar = Foo;
+    }
+})));


### PR DESCRIPTION
Alias semantic ungags errors in contexts where the start point of semantic analysis is speculative, but the actual declaration is not in a speculative context. This condition was to wide so I narrowed it down so that if we are in a speculative context the errors should be gagged.