### PR TITLE
Revert "fix Issue 17934 - [scope] scopeness entrypoint for unique/ref…

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1162,23 +1162,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         dsym.edtor = dsym.callScopeDtor(sc);
         if (dsym.edtor)
         {
-            /* If dsym is a local variable, who's type is a struct with a scope destructor,
-             * then make dsym scope, too.
-             */
-            if (global.params.useDIP1000 == FeatureState.enabled &&
-                !(dsym.storage_class & (STC.parameter | STC.temp | STC.field | STC.in_ | STC.foreach_ | STC.result | STC.manifest)) &&
-                !dsym.isDataseg() &&
-                !dsym.doNotInferScope &&
-                dsym.type.hasPointers())
-            {
-                auto tv = dsym.type.baseElemOf();
-                if (tv.ty == Tstruct &&
-                    tv.isTypeStruct().sym.dtor.storage_class & STC.scope_)
-                {
-                    dsym.storage_class |= STC.scope_;
-                }
-            }
-
             if (sc.func && dsym.storage_class & (STC.static_ | STC.gshared))
                 dsym.edtor = dsym.edtor.expressionSemantic(sc._module._scope);
             else

--- a/test/fail_compilation/retscope3.d
+++ b/test/fail_compilation/retscope3.d
@@ -53,47 +53,6 @@ void bar4()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope3.d(3027): Error: scope variable `l` assigned to `elem` with longer lifetime
----
-*/
-
-#line 3000
-
-struct List
-{
-    Elem front() @safe return scope;
-
-    ~this() @trusted scope;
-
-    @disable this(this);
-
-    void* data;
-}
-
-struct Elem
-{
-    void* data;
-}
-
-List list() @trusted
-{
-    return List();
-}
-
-void test3000() @safe
-{
-    Elem elem;
-    {
-        auto l = list(); // inferred as scope
-        elem = l.front; // escapes, b/c l isn't scoped
-    }
-}
-
-/**********************************************/
-
-/*
-TEST_OUTPUT:
----
 fail_compilation/retscope3.d(4003): Error: copying `u[]` into allocated memory escapes a reference to variadic parameter `u`
 fail_compilation/retscope3.d(4016): Error: storing reference to outer local variable `i` into allocated memory causes it to escape
 fail_compilation/retscope3.d(4025): Error: storing reference to stack allocated value returned by `makeSA()` into allocated memory causes it to escape


### PR DESCRIPTION
…-counted missing"

Revert https://github.com/dlang/dmd/pull/7284

This came to my attention in the discussion of [Issue 22680 - @safe hole with destructors](https://issues.dlang.org/show_bug.cgi?id=22680). The new behavior of making a `scope` destructor imply `scope` instances remains undocumented, incomplete (only works on named variables), and nonsensical. As Walter mentioned in https://github.com/dlang/dmd/pull/8369#issuecomment-398182558 :

> It turns out that `scope` on a destructor means it isn't leaking the data, which has nothing to do with implying the instance itself should be `scope`.

However, that PR is stuck because it also tries to implement an alternative fix to [Issue 17934](https://issues.dlang.org/show_bug.cgi?id=17934) with `scope struct`, which is now deprecated.