### PR TITLE
Fix 22961 - Don't reject valid K&R main's in C files

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2749,8 +2749,10 @@ extern (C++) class FuncDeclaration : Declaration
             else
                 argerr = nparams != 0;
 
-            if (tf.parameterList.varargs)
-                argerr |= nparams != 0; // Allow implicitly variadic main() in C files
+            // Disallow variadic main() - except for K&R declarations in C files.
+            // E.g. int main(), int main(argc, argv) int argc, char** argc { ... }
+            if (tf.parameterList.varargs && (!this.isCsymbol() || (!tf.parameterList.hasIdentifierList && nparams)))
+                argerr |= true;
 
             if (argerr)
             {

--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -675,3 +675,12 @@ void test22841()
     int v22841;
     { unsigned v22841; }
 }
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22961
+int main(argc, argv)
+        int argc;
+        char **argv;
+{
+        return 0;
+}

--- a/test/fail_compilation/malformed_cmain.c
+++ b/test/fail_compilation/malformed_cmain.c
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/malformed_cmain.c(13): Error: function `malformed_cmain.main` parameters must match one of the following signatures
+fail_compilation/malformed_cmain.c(13):        `main()`
+fail_compilation/malformed_cmain.c(13):        `main(int argc, char** argv)`
+fail_compilation/malformed_cmain.c(13):        `main(int argc, char** argv, char** environ)` [POSIX extension]
+---
+
+*/
+
+int main(int argc, char** argv, ...)
+{
+    return 0;
+}


### PR DESCRIPTION
K&R functions are implicitly variadic and hence triggered the error
if the declaration actually specified parameters (even if when their
types are correct).

This patch changes the check s.t. it allows implicitly variadic K&R
functions in C files but still reports an error for explicit `...`.

---

Targeting `master` because the regression wasn't merged to stable yet