### PR TITLE
Fix C syntax in printf log statements

### DIFF
--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -955,7 +955,7 @@ else
         }
     }
 
-    //printf("Fast.size = x%x, Auto.size = x%x\n", (int)Fast.size, (int)Auto.size);
+    //printf("Fast.size = x%x, Auto.size = x%x\n", cast(int)Fast.size, cast(int)Auto.size);
 
     cgstate.funcarg.alignment = STACKALIGN;
     /* If the function doesn't need the extra alignment, don't do it.
@@ -1349,7 +1349,7 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
                 Fast.offset = _align(sz,Fast.offset);
                 s.Soffset = Fast.offset;
                 Fast.offset += sz;
-                //printf("fastpar '%s' sz = %d, fast offset =  x%x, %p\n",s.Sident,(int)sz,(int)s.Soffset, s);
+                //printf("fastpar '%s' sz = %d, fast offset =  x%x, %p\n", s.Sident, cast(int) sz, cast(int) s.Soffset, s);
 
                 if (alignsize > Fast.alignment)
                     Fast.alignment = alignsize;
@@ -1368,7 +1368,7 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
                 Auto.offset = _align(sz,Auto.offset);
                 s.Soffset = Auto.offset;
                 Auto.offset += sz;
-                //printf("auto    '%s' sz = %d, auto offset =  x%lx\n",s.Sident,sz,(long)s.Soffset);
+                //printf("auto    '%s' sz = %d, auto offset =  x%lx\n", s.Sident,sz, cast(long) s.Soffset);
 
                 if (alignsize > Auto.alignment)
                     Auto.alignment = alignsize;
@@ -1377,7 +1377,7 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
             case SCstack:
                 EEStack.offset = _align(sz,EEStack.offset);
                 s.Soffset = EEStack.offset;
-                //printf("EEStack.offset =  x%lx\n",(long)s.Soffset);
+                //printf("EEStack.offset =  x%lx\n",cast(long)s.Soffset);
                 EEStack.offset += sz;
                 break;
 
@@ -1399,7 +1399,7 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
                          (tyaggregate(s.ty()) || tyvector(s.ty())))))
                     Para.offset = (Para.offset + (alignsize - 1)) & ~(alignsize - 1);
                 s.Soffset = Para.offset;
-                //printf("%s param offset =  x%lx, alignsize = %d\n",s.Sident,(long)s.Soffset, (int)alignsize);
+                //printf("%s param offset =  x%lx, alignsize = %d\n", s.Sident, cast(long) s.Soffset, cast(int) alignsize);
                 Para.offset += (s.Sflags & SFLdouble)
                             ? type_size(tstypes[TYdouble])   // float passed as double
                             : type_size(s.Stype);
@@ -1460,7 +1460,7 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
             }
             Auto.offset = _align(sz,Auto.offset);
             s.Soffset = Auto.offset;
-            //printf("auto    '%s' sz = %d, auto offset =  x%lx\n",s.Sident,sz,(long)s.Soffset);
+            //printf("auto    '%s' sz = %d, auto offset =  x%lx\n", s.Sident, sz, cast(long) s.Soffset);
             Auto.offset += sz;
             if (s.Srange && !(s.Sflags & SFLspill))
                 vec_setbit(si,tbl);

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -2939,7 +2939,7 @@ private bool optim_loglog(elem **pe)
             any = false;
     }
 
-    //printf("n = %d, count = %d, min = %d, max = %d\n", (int)n, last - first + 1, (int)emin, (int)emax);
+    //printf("n = %d, count = %d, min = %d, max = %d\n", cast(int)n, last - first + 1, cast(int)emin, cast(int)emax);
     if (any && last - first > 2 && emax - emin < REGSIZE * 8)
     {
         /**
@@ -3517,14 +3517,14 @@ elem * elstruct(elem *e, goal_t goal)
 
     if (!e.ET)
         return e;
-    //printf("\tnumbytes = %d\n", (int)type_size(e.ET));
+    //printf("\tnumbytes = %d\n", cast(int)type_size(e.ET));
 
     type *t = e.ET;
     tym_t tym = ~0;
     tym_t ty = tybasic(t.Tty);
 
     uint sz = (e.Eoper == OPstrpar && type_zeroSize(t, global_tyf)) ? 0 : cast(uint)type_size(t);
-    //printf("\tsz = %d\n", (int)sz);
+    //printf("\tsz = %d\n", cast(int)sz);
 
     type *targ1 = null;
     type *targ2 = null;

--- a/src/dmd/backend/cgen.d
+++ b/src/dmd/backend/cgen.d
@@ -331,7 +331,7 @@ bool reghasvalue(regm_t regm,targ_size_t value,reg_t *preg)
 
 void regwithvalue(ref CodeBuilder cdb,regm_t regm,targ_size_t value,reg_t *preg,regm_t flags)
 {
-    //printf("regwithvalue(value = %lld)\n", (long long)value);
+    //printf("regwithvalue(value = %lld)\n", cast(long)value);
     reg_t reg;
     if (!preg)
         preg = &reg;

--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -1013,7 +1013,7 @@ else
         ln.reset();
 
     L1:
-        //printf("offset = x%x, line = %d\n", (int)offset, linnum);
+        //printf("offset = x%x, line = %d\n", cast(int)offset, linnum);
         ln.data.write16(linnum);
         if (_tysize[TYint] == 2)
             ln.data.write16(cast(int)offset);

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3464,7 +3464,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
 
         if (numpara > cgstate.funcarg.size)
         {   // New high water mark
-            //printf("increasing size from %d to %d\n", (int)cgstate.funcarg.size, (int)numpara);
+            //printf("increasing size from %d to %d\n", cast(int)cgstate.funcarg.size, cast(int)numpara);
             cgstate.funcarg.size = numpara;
         }
         usefuncarg = true;
@@ -3763,7 +3763,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
         keepmsk |= mAX;
     }
 
-    //printf("funcargtos2 = %d\n", (int)funcargtos);
+    //printf("funcargtos2 = %d\n", cast(int)funcargtos);
     assert(!usefuncarg || (funcargtos == 0 && cgstate.funcargtos == 0));
     cgstate.stackclean--;
 
@@ -4243,7 +4243,7 @@ private void movParams(ref CodeBuilder cdb, elem* e, uint stackalign, uint funca
     targ_size_t sz = _align(stackalign, szb);       // size after alignment
     assert((sz & (stackalign - 1)) == 0);         // ensure that alignment worked
     assert((sz & (REGSIZE - 1)) == 0);
-    //printf("szb = %d sz = %d\n", (int)szb, (int)sz);
+    //printf("szb = %d sz = %d\n", cast(int)szb, cast(int)sz);
 
     code cs;
     cs.Iflags = 0;

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -4675,7 +4675,7 @@ static if (0)
 @trusted
 targ_size_t cod3_spoff()
 {
-    //printf("spoff = x%x, localsize = x%x\n", (int)spoff, (int)localsize);
+    //printf("spoff = x%x, localsize = x%x\n", cast(int)spoff, cast(int)localsize);
     return spoff + localsize;
 }
 
@@ -5182,7 +5182,7 @@ void cod3_adjSymOffsets()
                 break;
 
             case SCfastpar:
-//printf("\tfastpar %s %p Soffset %x Fast.size %x BPoff %x\n", s.Sident, s, (int)s.Soffset, (int)Fast.size, (int)BPoff);
+//printf("\tfastpar %s %p Soffset %x Fast.size %x BPoff %x\n", s.Sident, s, cast(int)s.Soffset, cast(int)Fast.size, cast(int)BPoff);
                 s.Soffset += Fast.size + BPoff;
                 break;
 
@@ -5191,7 +5191,7 @@ void cod3_adjSymOffsets()
                 if (s.Sfl == FLfast)
                     s.Soffset += Fast.size + BPoff;
                 else
-//printf("s = '%s', Soffset = x%x, Auto.size = x%x, BPoff = x%x EBPtoESP = x%x\n", s.Sident, (int)s.Soffset, (int)Auto.size, (int)BPoff, (int)EBPtoESP);
+//printf("s = '%s', Soffset = x%x, Auto.size = x%x, BPoff = x%x EBPtoESP = x%x\n", s.Sident, cast(int)s.Soffset, cast(int)Auto.size, cast(int)BPoff, cast(int)EBPtoESP);
 //              if (!(funcsym_p.Sfunc.Fflags3 & Fnested))
                     s.Soffset += Auto.size + BPoff;
                 break;
@@ -5265,7 +5265,7 @@ void assignaddrc(code *c)
         {
             if (c.Iop == (ESCAPE | ESCadjesp))
             {
-                //printf("adjusting EBPtoESP (%d) by %ld\n",EBPtoESP,(long)c.IEV1.Vint);
+                //printf("adjusting EBPtoESP (%d) by %ld\n",EBPtoESP,cast(long)c.IEV1.Vint);
                 EBPtoESP += c.IEV1.Vint;
                 c.Iop = NOP;
             }
@@ -6968,7 +6968,7 @@ else
 }
 }
                     case ESCadjesp:
-                        //printf("adjust ESP %ld\n", (long)c.IEV1.Vint);
+                        //printf("adjust ESP %ld\n", cast(long)c.IEV1.Vint);
                         break;
 
                     default:

--- a/src/dmd/backend/cv8.d
+++ b/src/dmd/backend/cv8.d
@@ -531,7 +531,7 @@ void cv8_linnum(Srcpos srcpos, uint offset)
         const sfilename = srcpos.Sfilename;
     else
         const sfilename = srcpos_name(srcpos);
-    //printf("cv8_linnum(file = %s, line = %d, offset = x%x)\n", sfilename, (int)srcpos.Slinnum, (uint)offset);
+    //printf("cv8_linnum(file = %s, line = %d, offset = x%x)\n", sfilename, cast(int)srcpos.Slinnum, cast(uint)offset);
 
     if (!sfilename)
         return;
@@ -640,7 +640,7 @@ L1:
     uint u = 0;
     while (u + 8 <= length)
     {
-        //printf("\t%x\n", *(uint *)(p + u));
+        //printf("\t%x\n", *cast(uint *)(p + u));
         if (off == *cast(uint *)(p + u))
         {
             //printf("\tfound %x\n", u);

--- a/src/dmd/backend/dwarfeh.d
+++ b/src/dmd/backend/dwarfeh.d
@@ -205,7 +205,7 @@ static if (0)
             assert(n == 0);
         }
     }
-    //printf("deh.dim = %d\n", (int)deh.dim);
+    //printf("deh.dim = %d\n", cast(int)deh.dim);
 
 static if (1)
 {

--- a/src/dmd/backend/gother.d
+++ b/src/dmd/backend/gother.d
@@ -379,7 +379,7 @@ private void conpropwalk(elem *n,vec_t IN)
     /* propagate a constant.                                */
     if (op == OPvar && sytab[n.EV.Vsym.Sclass] & SCRD)
     {
-        //printf("const prop: %s\n", n.EV.Vsym.Sident);
+        //printf("const prop: %s\n", n.EV.Vsym.Sident.ptr);
         Barray!(elem*) rdl;
         listrds(IN,n,null,&rdl);
 

--- a/src/dmd/backend/machobj.d
+++ b/src/dmd/backend/machobj.d
@@ -604,7 +604,7 @@ int32_t *patchAddr64(int seg, targ_size_t offset)
 @trusted
 void patch(seg_data *pseg, targ_size_t offset, int seg, targ_size_t value)
 {
-    //printf("patch(offset = x%04x, seg = %d, value = x%llx)\n", (uint)offset, seg, value);
+    //printf("patch(offset = x%04x, seg = %d, value = x%llx)\n", cast(uint)offset, seg, value);
     if (I64)
     {
         int32_t *p = cast(int32_t *)(fobjbuf.buf + SecHdrTab64[pseg.SDshtidx].offset + offset);
@@ -1107,7 +1107,7 @@ version (SCPP)
                                 int32_t *p = patchAddr64(seg, r.offset);
                                 // Absolute address; add in addr of start of targ seg
 //printf("*p = x%x, .addr = x%x, Soffset = x%x\n", *p, cast(int)SecHdrTab64[SegData[s.Sseg].SDshtidx].addr, cast(int)s.Soffset);
-//printf("pseg = x%x, r.offset = x%x\n", (int)SecHdrTab64[pseg.SDshtidx].addr, cast(int)r.offset);
+//printf("pseg = x%x, r.offset = x%x\n", cast(int)SecHdrTab64[pseg.SDshtidx].addr, cast(int)r.offset);
                                 *p += SecHdrTab64[SegData[s.Sseg].SDshtidx].addr;
                                 *p += s.Soffset;
                                 *p -= SecHdrTab64[pseg.SDshtidx].addr + r.offset + 4;
@@ -2742,7 +2742,7 @@ static if (0)
                 indirectsymbuf2.write((&s)[0 .. 1]);
 
              L2:
-                //printf("MachObj_reftoident: seg = %d, offset = x%x, s = %s, val = x%x, pointersSeg = %d\n", seg, (int)offset, s.Sident.ptr, (int)val, pointersSeg);
+                //printf("MachObj_reftoident: seg = %d, offset = x%x, s = %s, val = x%x, pointersSeg = %d\n", seg, cast(int)offset, s.Sident.ptr, cast(int)val, pointersSeg);
                 if (flags & CFindirect)
                 {
                     Relocation rel = void;
@@ -2934,7 +2934,7 @@ void MachObj_write_pointerRef(Symbol* s, uint off)
  */
 int mach_dwarf_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val)
 {
-    //printf("dwarf_reftoident(seg=%d offset=x%x s=%s val=x%x\n", seg, (int)offset, s.Sident.ptr, (int)val);
+    //printf("dwarf_reftoident(seg=%d offset=x%x s=%s val=x%x\n", seg, cast(int)offset, s.Sident.ptr, cast(int)val);
     MachObj_reftoident(seg, offset, s, val + 4, I64 ? CFoff : CFindirect);
     return 4;
 }

--- a/src/dmd/backend/mscoffobj.d
+++ b/src/dmd/backend/mscoffobj.d
@@ -1835,7 +1835,7 @@ segidx_t MsCoffObj_data_start(Symbol *sdata, targ_size_t datasize, segidx_t seg)
 {
     targ_size_t alignbytes;
 
-    //printf("MsCoffObj_data_start(%s,size %d,seg %d)\n",sdata.Sident.ptr,(int)datasize,seg);
+    //printf("MsCoffObj_data_start(%s,size %d,seg %d)\n",sdata.Sident.ptr,cast(int)datasize,seg);
     //symbol_print(sdata);
 
     assert(sdata.Sseg);
@@ -1929,7 +1929,7 @@ void MsCoffObj_pubdef(segidx_t seg, Symbol *s, targ_size_t offset)
             symbuf.write((&s)[0 .. 1]);
             break;
     }
-    //printf("%p\n", *(void**)symbuf.buf);
+    //printf("%p\n", *cast(void**)symbuf.buf);
     s.Sxtrnnum = 1;
 }
 
@@ -2430,7 +2430,7 @@ int elf_align(int size, int foffset)
     if (size <= 1)
         return foffset;
     int offset = (foffset + size - 1) & ~(size - 1);
-    //printf("offset = x%lx, foffset = x%lx, size = x%lx\n", offset, foffset, (int)size);
+    //printf("offset = x%lx, foffset = x%lx, size = x%lx\n", offset, foffset, cast(int)size);
     if (offset > foffset)
         fobjbuf.writezeros(offset - foffset);
     return offset;

--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -334,7 +334,7 @@ Symbol * symbol_calloc(const(char)* id)
 Symbol * symbol_calloc(const(char)* id, uint len)
 {   Symbol *s;
 
-    //printf("sizeof(symbol)=%d, sizeof(s.Sident)=%d, len=%d\n",sizeof(symbol),sizeof(s.Sident),(int)len);
+    //printf("sizeof(symbol)=%d, sizeof(s.Sident)=%d, len=%d\n", symbol.sizeof, s.Sident.sizeof, cast(int)len);
     s = cast(Symbol *) mem_fmalloc(Symbol.sizeof - s.Sident.length + len + 1 + 5);
     memset(s,0,Symbol.sizeof - s.Sident.length);
 version (SCPP_HTOD)

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -137,7 +137,7 @@ public:
 
     void reserve(size_t nentries) pure nothrow
     {
-        //printf("Array::reserve: length = %d, data.length = %d, nentries = %d\n", (int)length, (int)data.length, (int)nentries);
+        //printf("Array::reserve: length = %d, data.length = %d, nentries = %d\n", cast(int)length, cast(int)data.length, cast(int)nentries);
 
         // Cold path
         void enlarge(size_t nentries)


### PR DESCRIPTION
Lots of old C-style casts in the backend. Doesn't fix the various format string type mismatches.