### PR TITLE
Fix Issue 22801 - [master] Can't return address of return ref parameter from constructor

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -440,22 +440,33 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, Exp
  *      sc = used to determine current function and module
  *      firstArg = `ref` argument through which `arg` may be assigned
  *      arg = initializer for parameter
+ *      param = parameter declaration corresponding to `arg`
  *      gag = do not print error messages
  * Returns:
  *      `true` if assignment to `firstArg` would cause an error
  */
-bool checkParamArgumentReturn(Scope* sc, Expression firstArg, Expression arg, bool gag)
+bool checkParamArgumentReturn(Scope* sc, Expression firstArg, Expression arg, Parameter param, bool gag)
 {
     enum log = false;
     if (log) printf("checkParamArgumentReturn(firstArg: %s arg: %s)\n",
         firstArg.toChars(), arg.toChars());
     //printf("type = %s, %d\n", arg.type.toChars(), arg.type.hasPointers());
 
-    if (!arg.type.hasPointers())
+    if (!(param.storageClass & STC.return_))
         return false;
 
+    if (!arg.type.hasPointers() && !param.isReference())
+        return false;
+
+    // `byRef` needed for `assign(ref int* x, ref int i) {x = &i};`
+    // Note: taking address of scope pointer is not allowed
+    // `assign(ref int** x, return ref scope int* i) {x = &i};`
+    // Thus no return ref/return scope ambiguity here
+    const byRef = param.isReference() && !(param.storageClass & STC.scope_)
+        && !(param.storageClass & STC.returnScope); // fixme: it's possible to infer returnScope without scope with vaIsFirstRef
+
     scope e = new AssignExp(arg.loc, firstArg, arg);
-    return checkAssignEscape(sc, e, gag);
+    return checkAssignEscape(sc, e, gag, byRef);
 }
 
 /*****************************************************
@@ -496,23 +507,13 @@ bool checkConstructorEscape(Scope* sc, CallExp ce, bool gag)
     foreach (const i; 0 .. n)
     {
         Expression arg = (*ce.arguments)[i];
-        if (!arg.type.hasPointers())
-            continue;
-
         //printf("\targ[%d]: %s\n", i, arg.toChars());
 
         if (i - j < nparams && i >= j)
         {
             Parameter p = tf.parameterList[i - j];
-
-            if (p.storageClass & STC.return_)
-            {
-                /* Fake `dve.e1 = arg;` and look for scope violations
-                 */
-                scope e = new AssignExp(arg.loc, dve.e1, arg);
-                if (checkAssignEscape(sc, e, gag))
-                    return true;
-            }
+            if (checkParamArgumentReturn(sc, dve.e1, arg, p, gag))
+                return true;
         }
     }
 
@@ -529,13 +530,14 @@ bool checkConstructorEscape(Scope* sc, CallExp ce, bool gag)
  *      sc = used to determine current function and module
  *      e = `AssignExp` or `CatAssignExp` to check for any pointers to the stack
  *      gag = do not print error messages
+ *      byRef = set to `true` if `e1` of `e` gets assigned a reference to `e2`
  * Returns:
  *      `true` if pointers to the stack can escape via assignment
  */
-bool checkAssignEscape(Scope* sc, Expression e, bool gag)
+bool checkAssignEscape(Scope* sc, Expression e, bool gag, bool byRef)
 {
     enum log = false;
-    if (log) printf("checkAssignEscape(e: %s)\n", e.toChars());
+    if (log) printf("checkAssignEscape(e: %s, byRef: %d)\n", e.toChars(), byRef);
     if (e.op != EXP.assign && e.op != EXP.blit && e.op != EXP.construct &&
         e.op != EXP.concatenateAssign && e.op != EXP.concatenateElemAssign && e.op != EXP.concatenateDcharAssign)
         return false;
@@ -561,7 +563,10 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
 
     EscapeByResults er;
 
-    escapeByValue(e2, &er);
+    if (byRef)
+        escapeByRef(e2, &er);
+    else
+        escapeByValue(e2, &er);
 
     if (!er.byref.dim && !er.byvalue.dim && !er.byfunc.dim && !er.byexp.dim)
         return false;
@@ -791,6 +796,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
 
         // If va's lifetime encloses v's, then error
         if (va &&
+            !(vaIsFirstRef && (v.storage_class & STC.return_)) &&
             (va.enclosesLifetimeOf(v) || (va.isReference() && !(va.storage_class & STC.temp)) || va.isDataseg()) &&
             fd.setUnsafe())
         {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2033,7 +2033,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                  * Check arg to see if it matters.
                  */
                 if (global.params.useDIP1000 == FeatureState.enabled)
-                    err |= checkParamArgumentReturn(sc, firstArg, arg, false);
+                    err |= checkParamArgumentReturn(sc, firstArg, arg, p, false);
             }
             else if (tf.parameterEscapes(tthis, p))
             {
@@ -9848,7 +9848,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          * `reorderSettingAAElem` creates a tree of comma expressions, however,
          * `checkAssignExp` expects only AssignExps.
          */
-        checkAssignEscape(sc, Expression.extractLast(res, tmp), false);
+        checkAssignEscape(sc, Expression.extractLast(res, tmp), false, false);
 
         if (auto ae = res.isConstructExp())
         {
@@ -10168,7 +10168,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         auto res = exp.reorderSettingAAElem(sc);
         if ((exp.op == EXP.concatenateElemAssign || exp.op == EXP.concatenateDcharAssign) &&
             global.params.useDIP1000 == FeatureState.enabled)
-            checkAssignEscape(sc, res, false);
+            checkAssignEscape(sc, res, false, false);
         result = res;
     }
 

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2754,7 +2754,7 @@ bool stcToBuffer(OutBuffer* buf, StorageClass stc)
     }
     if (stc & STC.returninferred)
     {
-        //buf.writestring("return-inferred ");
+        //buf.writestring((stc & STC.returnScope) ? "return-scope-inferred " : "return-ref-inferred ");
         stc &= ~(STC.return_ | STC.returninferred);
     }
 

--- a/test/compilable/test19097.d
+++ b/test/compilable/test19097.d
@@ -21,3 +21,25 @@ void foo(scope int* pf)
     betty(rf, pf);
     boop(rf, pf);
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=22801
+struct Wrapper
+{
+    int* ptr;
+
+    this(return ref int var) @safe
+    {
+        this.ptr = &var;
+    }
+}
+
+void main() @safe
+{
+    int i;
+    auto w = Wrapper(i);
+}
+
+void assign(ref scope int* x, return ref int y) @safe
+{
+    x = &y;
+}

--- a/test/fail_compilation/test19097.d
+++ b/test/fail_compilation/test19097.d
@@ -1,11 +1,18 @@
 /* REQUIRED_ARGS: -preview=dip1000
  * TEST_OUTPUT:
 ---
-fail_compilation/test19097.d(37): Error: scope variable `s` may not be returned
-fail_compilation/test19097.d(66): Error: scope variable `z` assigned to `refPtr` with longer lifetime
-fail_compilation/test19097.d(97): Error: scope variable `s` may not be returned
+fail_compilation/test19097.d(44): Error: scope variable `s` may not be returned
+fail_compilation/test19097.d(48): Error: scope variable `s1` may not be returned
+fail_compilation/test19097.d(77): Error: scope variable `z` assigned to `refPtr` with longer lifetime
+fail_compilation/test19097.d(108): Error: scope variable `s4` may not be returned
+fail_compilation/test19097.d(126): Error: scope variable `s5c` may not be returned
+fail_compilation/test19097.d(130): Error: scope variable `s5m` may not be returned
+fail_compilation/test19097.d(147): Error: scope variable `s6c` may not be returned
+fail_compilation/test19097.d(151): Error: scope variable `s6m` may not be returned
 ---
  */
+
+// Test extended return-scope / return-ref semantics, e.g. assigning to `this` or the first parameter
 
 // https://issues.dlang.org/show_bug.cgi?id=19097
 
@@ -35,6 +42,10 @@ S thorin()
     int i;
     S s = S(&i); // should infer scope for s
     return s;    // so this should error
+
+    S s1;
+    s1.mem(&i);
+    return s1;
 }
 
 /************************/
@@ -93,6 +104,49 @@ struct S4
 int* escape2()
 {
     int x;
-    auto s = S4(0, &x);
-    return s.p;
+    auto s4 = S4(0, &x);
+    return s4.p;
+}
+
+/************************/
+// https://issues.dlang.org/show_bug.cgi?id=22801
+struct S5
+{
+    int* a;
+    this(return ref int b) { a = &b; }
+
+    int* c;
+    void mem(return ref int d) scope { c = &d; }
+}
+
+S5 frerin()
+{
+    int i;
+    S5 s5c = S5(i); // should infer scope for s
+    return s5c;    // so this should error
+
+    S5 s5m;
+    s5m.mem(i);
+    return s5m;
+}
+
+
+struct S6
+{
+    int** a;
+    this(return ref int* b) { a = &b; }
+
+    int** c;
+    void mem(return ref int* d) scope { c = &d; }
+}
+
+S6 dis()
+{
+    int* i = null;
+    S6 s6c = S6(i); // should infer scope for s
+    return s6c;    // so this should error
+
+    S6 s6m;
+    s6m.mem(i);
+    return s6m;
 }


### PR DESCRIPTION
Same as https://github.com/dlang/dmd/pull/13699, but targeting master. It seems like this depends on the return-ref-scope ambiguity fixes that aren't in stable yet.