### PR TITLE
Fix issue 22234 - traits(getLinkage) returns wrong value for extern(System) functions

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6628,8 +6628,9 @@ struct ASTBase
         final switch (linkage)
         {
         case LINK.default_:
-        case LINK.system:
             return null;
+        case LINK.system:
+            return "System";
         case LINK.d:
             return "D";
         case LINK.c:

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -44,7 +44,6 @@ import dmd.mtype;
 import dmd.objc; // for objc.addSymbols
 import dmd.common.outbuffer;
 import dmd.root.array; // for each
-import dmd.target; // for target.systemLinkage
 import dmd.tokens;
 import dmd.visitor;
 

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -399,7 +399,7 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
     {
         super(loc, null, decl);
         //printf("LinkDeclaration(linkage = %d, decl = %p)\n", linkage, decl);
-        this.linkage = (linkage == LINK.system) ? target.systemLinkage() : linkage;
+        this.linkage = linkage;
     }
 
     static LinkDeclaration create(const ref Loc loc, LINK p, Dsymbols* decl)

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1214,10 +1214,11 @@ extern(D):
                 break;
             case LINK.d:
             case LINK.default_:
-            case LINK.system:
             case LINK.objc:
                 tmp.visit(cast(Type)type);
                 break;
+            case LINK.system:
+                assert(0);
             }
         }
         tmp.flags &= ~IS_NOT_TOP_TYPE;

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -340,7 +340,6 @@ public:
         final switch (t.linkage)
         {
         case LINK.default_:
-        case LINK.system:
         case LINK.d:
             mc = 'F';
             break;
@@ -356,6 +355,8 @@ public:
         case LINK.objc:
             mc = 'Y';
             break;
+        case LINK.system:
+            assert(0);
         }
         buf.writeByte(mc);
 
@@ -1340,7 +1341,9 @@ extern (D) const(char)[] externallyMangledIdentifier(Declaration d)
     {
         if (d.linkage != LINK.d && d.localNum)
             d.error("the same declaration cannot be in multiple scopes with non-D linkage");
-        final switch (d.linkage)
+
+        const l = d.linkage == LINK.system ? target.systemLinkage() : d.linkage;
+        final switch (l)
         {
             case LINK.d:
                 break;
@@ -1354,9 +1357,10 @@ extern (D) const(char)[] externallyMangledIdentifier(Declaration d)
                 return p.toDString();
             }
             case LINK.default_:
-            case LINK.system:
                 d.error("forward declaration");
                 return d.ident.toString();
+            case LINK.system:
+                assert(0);
         }
     }
     return null;

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -319,10 +319,7 @@ public:
             // Should not be printed
             //property(name, "d");
             break;
-        case LINK.system:
-            // Should not be printed
-            //property(name, "system");
-            break;
+        case LINK.system:   return property(name, "system");
         case LINK.c:        return property(name, "c");
         case LINK.cpp:      return property(name, "cpp");
         case LINK.windows:  return property(name, "windows");

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -372,7 +372,8 @@ Symbol *toSymbol(Dsymbol s)
             }
             else
             {
-                final switch (fd.linkage)
+                const l = fd.linkage == LINK.system ? target.systemLinkage() : fd.linkage;
+                final switch (l)
                 {
                     case LINK.windows:
                         t.Tmangle = target.is64bit ? mTYman_c : mTYman_std;

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1514,7 +1514,9 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         TypeFunction tf = toTypeFunction(o, fd);
 
         if (tf)
-            link = tf.linkage;
+        {
+            link = fd ? fd.linkage : tf.linkage;
+        }
         else
         {
             auto s = getDsymbol(o);

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1220,6 +1220,9 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             tf.islive = true;
 
         tf.linkage = sc.linkage;
+        if (tf.linkage == LINK.system)
+            tf.linkage = target.systemLinkage();
+
         version (none)
         {
             /* If the parent is @safe, then this function defaults to safe

--- a/test/compilable/extra-files/json.json
+++ b/test/compilable/extra-files/json.json
@@ -1083,6 +1083,15 @@
                 "protection": "public"
             },
             {
+                "char": 20,
+                "deco": "VALUE_REMOVED_FOR_TEST",
+                "kind": "variable",
+                "line": 191,
+                "linkage": "system",
+                "name": "vlinkageSystem",
+                "protection": "public"
+            },
+            {
                 "char": 12,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
@@ -1135,6 +1144,16 @@
                 "line": 197,
                 "linkage": "objc",
                 "name": "flinkageObjc",
+                "protection": "public"
+            },
+            {
+                "char": 20,
+                "deco": "VALUE_REMOVED_FOR_TEST",
+                "kind": "function",
+                "line": 198,
+                "linkage": "system",
+                "name": "flinkageSystem",
+                "originalType": "extern (System) int()",
                 "protection": "public"
             },
             {

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -203,14 +203,14 @@ extern(C) int vlinakgeC;
 extern(C++) __gshared int vlinkageCpp;
 extern(Windows) int vlinkageWindows;
 extern(Objective-C) int vlinkageObjc;
-
+extern(System) int vlinkageSystem;
 extern int flinkageDefault();
 extern(D) int flinkageD();
 extern(C) int linakgeC();
 extern(C++) int flinkageCpp();
 extern(Windows) int flinkageWindows();
 extern(Objective-C) int flinkageObjc();
-
+extern(System) int flinkageSystem();
 mixin template test18211(int n)
 {
     static foreach (i; 0 .. n>10 ? 10 : n)

--- a/test/compilable/test17419.d
+++ b/test/compilable/test17419.d
@@ -17,10 +17,7 @@ static assert(__traits(getLinkage, food) == "D");
 static assert(__traits(getLinkage, foocpp) == "C++");
 static assert(__traits(getLinkage, foow) == "Windows");
 static assert(__traits(getLinkage, fooobjc) == "Objective-C");
-version (Windows)
-    static assert(__traits(getLinkage, foos) == "Windows");
-else
-    static assert(__traits(getLinkage, foos) == "C");
+static assert(__traits(getLinkage, foos) == "System");
 
 extern (C) int global;
 static assert(__traits(getLinkage, global) == "C");


### PR DESCRIPTION
Instead of resolving `LINK.system` in the constructor of `LinkDeclaration`, defer resolving `LINK.system` until either type semantic, or the point where an actual ABI is needed. See also the previous discussion in: https://github.com/dlang/dlang.org/pull/3185