### PR TITLE
Fix issue 20853 - static array ptr cannot be used in safe code but it…

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3619,8 +3619,10 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 e.error("`%s` is not an expression", e.toChars());
                 return ErrorExp.get();
             }
-            else if (checkUnsafeDotExp(sc, e, ident, flag))
+            else if (mt.dim.toUInteger() < 1 && checkUnsafeDotExp(sc, e, ident, flag))
             {
+                // .ptr on static array is @safe unless size is 0
+                // https://issues.dlang.org/show_bug.cgi?id=20853
                 return ErrorExp.get();
             }
             e = e.castTo(sc, e.type.nextOf().pointerTo());

--- a/test/fail_compilation/test11176.d
+++ b/test/fail_compilation/test11176.d
@@ -12,6 +12,10 @@ fail_compilation/test11176.d(16): Error: `b.ptr` cannot be used in `@safe` code,
     return *b.ptr;
 }
 
-@safe ubyte oops(ubyte[3] b) {
+@safe ubyte oops(ubyte[0] b) {
+    return *b.ptr;
+}
+
+@safe ubyte cool(ubyte[1] b) {
     return *b.ptr;
 }


### PR DESCRIPTION
… should be allowed

The suggestion in the error message "use `&b[0]` instead" is non very useful on 0-size static arrays, that could still be improved.