### PR TITLE
Fix Issue 22969 - Can't mixin name of manifest constant on right-hand side of alias declaration

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -957,14 +957,7 @@ extern (C++) class Dsymbol : ASTNode
                 TemplateInstance ti = st.isTemplateInstance();
                 sm = s.search(loc, ti.name);
                 if (!sm)
-                {
-                    sm = s.search_correct(ti.name);
-                    if (sm)
-                        .error(loc, "template identifier `%s` is not a member of %s `%s`, did you mean %s `%s`?", ti.name.toChars(), s.kind(), s.toPrettyChars(), sm.kind(), sm.toChars());
-                    else
-                        .error(loc, "template identifier `%s` is not a member of %s `%s`", ti.name.toChars(), s.kind(), s.toPrettyChars());
                     return null;
-                }
                 sm = sm.toAlias();
                 TemplateDeclaration td = sm.isTemplateDeclaration();
                 if (!td)

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1733,69 +1733,33 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             bool err = false;
 
             auto t = isType(o);
-            while (t)
+            auto ex = isExpression(o);
+            if (t)
             {
-                if (auto tm = t.isTypeMixin())
+                Dsymbol s;
+                t.resolve(e.loc, sc2, ex, t, s);
+                if (t)
                 {
-                    /* The mixin string could be a type or an expression.
-                     * Have to try compiling it to see.
-                     */
-                    OutBuffer buf;
-                    if (expressionsToString(buf, sc, tm.exps))
-                    {
+                    t.typeSemantic(e.loc, sc2);
+                    if (t.ty == Terror)
                         err = true;
-                        break;
-                    }
-                    const olderrors = global.errors;
-                    const len = buf.length;
-                    buf.writeByte(0);
-                    const str = buf.extractSlice()[0 .. len];
-                    scope p = new Parser!ASTCodegen(e.loc, sc._module, str, false);
-                    p.nextToken();
-                    //printf("p.loc.linnum = %d\n", p.loc.linnum);
-
-                    o = p.parseTypeOrAssignExp(TOK.endOfFile);
-                    if (olderrors != global.errors || p.token.value != TOK.endOfFile)
-                    {
-                        err = true;
-                        break;
-                    }
-                    t = o.isType();
                 }
-                else
-                    break;
+                else if (s && s.errors)
+                    err = true;
             }
-
-            if (!err)
+            if (ex)
             {
-                auto ex = t ? t.typeToExpression() : isExpression(o);
-                if (!ex && t)
+                ex = ex.expressionSemantic(sc2);
+                ex = resolvePropertiesOnly(sc2, ex);
+                ex = ex.optimize(WANTvalue);
+                if (sc2.func && sc2.func.type.ty == Tfunction)
                 {
-                    Dsymbol s;
-                    t.resolve(e.loc, sc2, ex, t, s);
-                    if (t)
-                    {
-                        t.typeSemantic(e.loc, sc2);
-                        if (t.ty == Terror)
-                            err = true;
-                    }
-                    else if (s && s.errors)
-                        err = true;
+                    const tf = cast(TypeFunction)sc2.func.type;
+                    err |= tf.isnothrow && canThrow(ex, sc2.func, false);
                 }
-                if (ex)
-                {
-                    ex = ex.expressionSemantic(sc2);
-                    ex = resolvePropertiesOnly(sc2, ex);
-                    ex = ex.optimize(WANTvalue);
-                    if (sc2.func && sc2.func.type.ty == Tfunction)
-                    {
-                        const tf = cast(TypeFunction)sc2.func.type;
-                        err |= tf.isnothrow && canThrow(ex, sc2.func, false);
-                    }
-                    ex = checkGC(sc2, ex);
-                    if (ex.op == EXP.error)
-                        err = true;
-                }
+                ex = checkGC(sc2, ex);
+                if (ex.op == EXP.error)
+                    err = true;
             }
 
             // Carefully detach the scope from the parent and throw it away as

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2288,10 +2288,7 @@ RootObject compileTypeMixin(TypeMixin tm, Loc loc, Scope* sc)
         return null;
     }
 
-    Type t = o.isType();
-    Expression e = t ? t.typeToExpression() : o.isExpression();
-
-    return (!e && t) ? t : e;
+    return o;
 }
 
 

--- a/test/compilable/mixintype2.d
+++ b/test/compilable/mixintype2.d
@@ -115,3 +115,9 @@ void test_statements_22356()
     mixin("int") y22356, z22356;
     static assert(is(typeof(y22356) == int) && is(typeof(z22356) == int));
 }
+
+/**************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22969
+
+enum e = 0;
+alias a = mixin("e");

--- a/test/fail_compilation/diag14235.d
+++ b/test/fail_compilation/diag14235.d
@@ -2,8 +2,8 @@
 EXTRA_FILES: imports/a14235.d
 TEST_OUTPUT:
 ---
-fail_compilation/diag14235.d(12): Error: template identifier `Undefined` is not a member of module `imports.a14235`
-fail_compilation/diag14235.d(13): Error: template identifier `Something` is not a member of module `imports.a14235`, did you mean struct `SomeThing(T...)`?
+fail_compilation/diag14235.d(12): Error: undefined identifier `Undefined` in module `imports.a14235`
+fail_compilation/diag14235.d(13): Error: undefined identifier `Something` in module `imports.a14235`, did you mean struct `SomeThing(T...)`?
 fail_compilation/diag14235.d(14): Error: `imports.a14235.SomeClass` is not a template, it is a class
 ---
 */


### PR DESCRIPTION
Remove an unnecessary `typeToExpression` conversion call that forced `mixin` to
be resolved via expression semantic (expanding enum constants when it shouldn't).
This was a change I wanted to make some time ago but an early error somewhere
in the type semantic prevented me (fixed here).
Also a duplicated code in `traits.d` to handle mixins is removed (it was a copy
of `typesem.d:compileTypeMixin` function).

Regression caused by #10629