### PR TITLE
Fix Issue 22987 - Make traits getLocation have an option to return an…

### DIFF
--- a/changelog/getLocationAbsolutePath.dd
+++ b/changelog/getLocationAbsolutePath.dd
@@ -1,0 +1,7 @@
+The trait `getLocation` has been modified to accept a parameter to ask for an absolute path.
+
+Let `symbol` be a symbol known to the compiler, and *file* be the file in which it's declared:
+
+`__traits(getLocation, symbol)[0]` is the relative path to *file* to as it has always been.
+
+`__traits(getLocation, symbol, true)[0]` is now the absolute path to *file*.

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -316,3 +316,18 @@ extern(C++, `inst`)
 mixin GetNamespaceTestTemplatedMixin!() GNTT;
 
 static assert (__traits(getCppNamespaces, GNTT.foo) == Seq!(`inst`,/*`decl`,*/ `f`));
+
+struct I22987
+{
+  int x;
+}
+
+enum I22987Res = __traits(getLocation, I22987, true);
+enum filePath = I22987Res[0];
+static assert(I22987Res[1] == 318);
+static assert(I22987Res[2] == 1);
+//Make sure the path is absolute
+version(Windows)
+    static assert(filePath[1..3] == ":\\");
+else
+    static assert(filePath[0] == '/');

--- a/test/fail_compilation/trait_loc_err.d
+++ b/test/fail_compilation/trait_loc_err.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/trait_loc_err.d(13): Error: can only get the location of a symbol, not `trait_loc_err`
-fail_compilation/trait_loc_err.d(14): Error: can only get the location of a symbol, not `stdc`
+fail_compilation/trait_loc_err.d(15): Error: can only get the location of a symbol, not `trait_loc_err`
+fail_compilation/trait_loc_err.d(16): Error: can only get the location of a symbol, not `stdc`
+fail_compilation/trait_loc_err.d(17): Error: `getLocation` accepts at most 2 parameters, not 3
+fail_compilation/trait_loc_err.d(18): Error: The second parameter of `getOverloads` must have type `bool`, not `string`
 ---
 */
 module trait_loc_err;
@@ -12,4 +14,10 @@ void main()
 {
     __traits(getLocation, __traits(parent, main));
     __traits(getLocation, __traits(parent, core.stdc.stdio));
+    __traits(getLocation, Type, true, 234);
+    __traits(getLocation, Type, "Invalid");
+}
+struct Type
+{
+
 }


### PR DESCRIPTION
… absolute path

The feature is required for an application of metaprogramming within Symmetry.

A flag is added rather than changing the default in case it breaks something.