### PR TITLE
Fix Issue 22864 - [REG 2.067] Throwing in array literal leads to destructor being called on unconstructed data

### DIFF
--- a/test/runnable/test22864.d
+++ b/test/runnable/test22864.d
@@ -1,0 +1,40 @@
+// https://issues.dlang.org/show_bug.cgi?id=22864
+
+import core.stdc.stdlib;
+
+public S* deserializeFull ()
+{
+    return &[ getS() ][0];
+}
+
+S getS () { throw new Exception("socket error"); }
+
+struct S
+{
+    ~this ()
+    {
+        abort();
+    }
+
+    ubyte hash;
+}
+
+void foo ()
+{
+    try
+    {
+        auto v = deserializeFull();
+        assert(0, "Exception not thrown?");
+    }
+    catch (Exception exc)
+    {
+        assert(exc.msg == "socket error");
+    }
+}
+
+void main ()
+{
+    foo();
+    import core.memory;
+    GC.collect(); // Abort triggered from here
+}


### PR DESCRIPTION
The gluelayer first inserts a call to _d_arrayliteral (which allocates the array with the gc) and then executes the array initializers. If any of the initialzers throw, then the gc wants to destruct the allocated memory and calls any potential destructors. Since the initializers have thrown, destructors will be called on uninitialized memory.

This patch first allocates a stack array where the intializers are emplaced and after that it calls the gc to allocate memory. Finally, it emplaces the stack array in the dynamic one via memcpy.

I guess that this could be optimized by checking whether we are in a nothrow context. In that situation, the old, faster code, may be used.

I am not targeting stable because this has the potential to unknowingly break stuff. cc @WalterBright as this is my first gluelayer contribution.

cc @kinke as ldc seems to suffer from the same issue.