### PR TITLE
Fix issue 22967 - no `return ref` inference for extended return semantics

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -794,6 +794,15 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag, bool byRef)
 
         Dsymbol p = v.toParent2();
 
+        if (vaIsFirstRef && v.isParameter() &&
+            !(v.storage_class & STC.return_) &&
+            fd.flags & FUNCFLAG.returnInprocess &&
+            p == fd)
+        {
+            //if (log) printf("inferring 'return' for parameter %s in function %s\n", v.toChars(), fd.toChars());
+            inferReturn(fd, v, /*returnScope:*/ false);
+        }
+
         // If va's lifetime encloses v's, then error
         if (va &&
             !(vaIsFirstRef && (v.storage_class & STC.return_)) &&

--- a/test/compilable/test19097.d
+++ b/test/compilable/test19097.d
@@ -37,9 +37,27 @@ void main() @safe
 {
     int i;
     auto w = Wrapper(i);
+    auto wt = WrapperT!()(i);
 }
 
 void assign(ref scope int* x, return ref int y) @safe
 {
     x = &y;
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=22967
+// inference of `return ref` when assigned to first parameter
+struct WrapperT()
+{
+    int* ptr;
+
+    this(ref int var) @safe
+    {
+        this.ptr = &var;
+    }
+
+    static void assignInferred(ref scope int* xi, ref int yi) @safe
+    {
+        xi = &yi;
+    }
 }


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/13940 introduced proper 'extended return semantics' (returning by assigning to `this` / the first `ref` parameter) for `return ref`, but it didn't have inference yet unlike `return scope` (https://github.com/dlang/dmd/pull/9220).