### PR TITLE
Add reusable bitfields utility

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1563,7 +1563,7 @@ auto sourceFiles()
             rootobject.d stringtable.d utf.d
         "),
         common: fileArray(env["COMMON"], "
-            file.d int128.d outbuffer.d string.d
+            bitfields.d file.d int128.d outbuffer.d string.d
         "),
         commonHeaders: fileArray(env["COMMON"], "
             outbuffer.h

--- a/src/dmd/common/README.md
+++ b/src/dmd/common/README.md
@@ -2,6 +2,7 @@
 
 | File                                                                               | Purpose                                                         |
 |------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| [bitfields.d](https://github.com/dlang/dmd/blob/master/src/dmd/common/bitfields.d) | Pack multiple boolean fields into bit fields                    |
 | [file.d](https://github.com/dlang/dmd/blob/master/src/dmd/common/file.d)           | Functions and objects dedicated to file I/O and management      |
 | [outbuffer.d](https://github.com/dlang/dmd/blob/master/src/dmd/common/outbuffer.d) | An expandable buffer in which you can write text or binary data |
 | [string.d](https://github.com/dlang/dmd/blob/master/src/dmd/common/string.d)       | Common string functions including filename manipulation         |

--- a/src/dmd/common/bitfields.d
+++ b/src/dmd/common/bitfields.d
@@ -1,0 +1,70 @@
+/**
+ * A library bitfields utility
+ *
+ * Copyright: Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved
+ * Authors:   Dennis Korpel
+ * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/bitfields.d, common/bitfields.d)
+ * Documentation: https://dlang.org/phobos/dmd_common_bitfields.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/common/bitfields.d
+ */
+module dmd.common.bitfields;
+
+/**
+ * Generate code for bit fields inside a struct/class body
+ * Params:
+ *   S = type of a struct with only boolean fields, which should become bit fields
+ *   T = type of bit fields variable, must have enough bits to store all booleans
+ * Returns: D code with a bit fields variable and getter / setter functions
+ */
+extern (D) string generateBitFields(S, T)()
+if (__traits(isUnsigned, T))
+{
+    string result = "extern (C++) pure nothrow @nogc @safe final {";
+    enum structName = __traits(identifier, S);
+
+    foreach (size_t i, mem; __traits(allMembers, S))
+    {
+        static assert(is(typeof(__traits(getMember, S, mem)) == bool));
+        static assert(i < T.sizeof * 8, "too many fields for bit field storage of type `"~T.stringof~"`");
+        enum mask = "(1 << "~i.stringof~")";
+        result ~= "
+        /// set or get the corresponding "~structName~" member
+        bool "~mem~"() const { return !!(bitFields & "~mask~"); }
+        /// ditto
+        bool "~mem~"(bool v)
+        {
+            v ? (bitFields |= "~mask~") : (bitFields &= ~"~mask~");
+            return v;
+        }";
+    }
+    return result ~ "}\n private "~T.stringof~" bitFields;\n";
+}
+
+///
+unittest
+{
+    static struct B
+    {
+        bool x;
+        bool y;
+        bool z;
+    }
+
+    static struct S
+    {
+        mixin(generateBitFields!(B, ubyte));
+    }
+
+    S s;
+    assert(!s.x);
+    s.x = true;
+    assert(s.x);
+    s.x = false;
+    assert(!s.x);
+
+    s.y = true;
+    assert(s.y);
+    assert(!s.x);
+    assert(!s.z);
+}

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1083,28 +1083,11 @@ extern (C++) class VarDeclaration : Declaration
         bool isArgDtorVar;      /// temporary created to handle scope destruction of a function argument
     }
 
-    private ushort bitFields;       // stores multiple booleans for BitFields
+    import dmd.common.bitfields : generateBitFields;
+    mixin(generateBitFields!(BitFields, ushort));
+
     byte canassign;                 // it can be assigned to
     ubyte isdataseg;                // private data for isDataseg 0 unset, 1 true, 2 false
-
-    // Generate getter and setter functions for `bitFields`
-    extern (D) mixin(() {
-        string result = "extern (C++) pure nothrow @nogc @safe final {";
-        foreach (size_t i, mem; __traits(allMembers, BitFields))
-        {
-            result ~= "
-            /// set or get the corresponding BitFields member
-            bool "~mem~"() const { return !!(bitFields & (1 << "~i.stringof~")); }
-            /// ditto
-            bool "~mem~"(bool v)
-            {
-                v ? (bitFields |= (1 << "~i.stringof~")) : (bitFields &= ~(1 << "~i.stringof~"));
-                return v;
-            }";
-        }
-        return result ~ "}";
-    }());
-
 
     final extern (D) this(const ref Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.undefined_)
     in

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3528,28 +3528,90 @@ class TypeFunction final : public TypeNext
 public:
     ParameterList parameterList;
 private:
-    enum class FunctionFlag : uint32_t
+    struct BitFields final
     {
-        none = 0u,
-        isnothrow = 1u,
-        isnogc = 2u,
-        isproperty = 4u,
-        isref = 8u,
-        isreturn = 16u,
-        isScopeQual = 32u,
-        isreturninferred = 64u,
-        isscopeinferred = 128u,
-        islive = 256u,
-        incomplete = 512u,
-        isInOutParam = 1024u,
-        isInOutQual = 2048u,
-        isctor = 4096u,
-        isreturnscope = 8192u,
+        bool isnothrow;
+        bool isnogc;
+        bool isproperty;
+        bool isref;
+        bool isreturn;
+        bool isScopeQual;
+        bool isreturninferred;
+        bool isscopeinferred;
+        bool islive;
+        bool incomplete;
+        bool isInOutParam;
+        bool isInOutQual;
+        bool isctor;
+        bool isreturnscope;
+        BitFields() :
+            isnothrow(),
+            isnogc(),
+            isproperty(),
+            isref(),
+            isreturn(),
+            isScopeQual(),
+            isreturninferred(),
+            isscopeinferred(),
+            islive(),
+            incomplete(),
+            isInOutParam(),
+            isInOutQual(),
+            isctor(),
+            isreturnscope()
+        {
+        }
+        BitFields(bool isnothrow, bool isnogc = false, bool isproperty = false, bool isref = false, bool isreturn = false, bool isScopeQual = false, bool isreturninferred = false, bool isscopeinferred = false, bool islive = false, bool incomplete = false, bool isInOutParam = false, bool isInOutQual = false, bool isctor = false, bool isreturnscope = false) :
+            isnothrow(isnothrow),
+            isnogc(isnogc),
+            isproperty(isproperty),
+            isref(isref),
+            isreturn(isreturn),
+            isScopeQual(isScopeQual),
+            isreturninferred(isreturninferred),
+            isscopeinferred(isscopeinferred),
+            islive(islive),
+            incomplete(incomplete),
+            isInOutParam(isInOutParam),
+            isInOutQual(isInOutQual),
+            isctor(isctor),
+            isreturnscope(isreturnscope)
+            {}
     };
 
 public:
+    bool isnothrow() const;
+    bool isnothrow(bool v);
+    bool isnogc() const;
+    bool isnogc(bool v);
+    bool isproperty() const;
+    bool isproperty(bool v);
+    bool isref() const;
+    bool isref(bool v);
+    bool isreturn() const;
+    bool isreturn(bool v);
+    bool isScopeQual() const;
+    bool isScopeQual(bool v);
+    bool isreturninferred() const;
+    bool isreturninferred(bool v);
+    bool isscopeinferred() const;
+    bool isscopeinferred(bool v);
+    bool islive() const;
+    bool islive(bool v);
+    bool incomplete() const;
+    bool incomplete(bool v);
+    bool isInOutParam() const;
+    bool isInOutParam(bool v);
+    bool isInOutQual() const;
+    bool isInOutQual(bool v);
+    bool isctor() const;
+    bool isctor(bool v);
+    bool isreturnscope() const;
+    bool isreturnscope(bool v);
+private:
+    uint16_t bitFields;
+public:
     LINK linkage;
-    FunctionFlag funcFlags;
     TRUST trust;
     PURE purity;
     int8_t inuse;
@@ -3565,36 +3627,6 @@ public:
     Type* addStorageClass(StorageClass stc);
     Type* substWildTo(uint32_t _param_0);
     MATCH constConv(Type* to);
-    bool none() const;
-    void none(bool v);
-    bool isnothrow() const;
-    void isnothrow(bool v);
-    bool isnogc() const;
-    void isnogc(bool v);
-    bool isproperty() const;
-    void isproperty(bool v);
-    bool isref() const;
-    void isref(bool v);
-    bool isreturn() const;
-    void isreturn(bool v);
-    bool isScopeQual() const;
-    void isScopeQual(bool v);
-    bool isreturninferred() const;
-    void isreturninferred(bool v);
-    bool isscopeinferred() const;
-    void isscopeinferred(bool v);
-    bool islive() const;
-    void islive(bool v);
-    bool incomplete() const;
-    void incomplete(bool v);
-    bool isInOutParam() const;
-    void isInOutParam(bool v);
-    bool isInOutQual() const;
-    void isInOutQual(bool v);
-    bool isctor() const;
-    void isctor(bool v);
-    bool isreturnscope() const;
-    void isreturnscope(bool v);
     bool iswild() const;
     bool attributesEqual(const TypeFunction* const other) const;
     void accept(Visitor* v);
@@ -5762,11 +5794,6 @@ public:
     enum : uint32_t { AdrOnStackNone = 4294967295u };
 
     uint32_t ctfeAdrOnStack;
-private:
-    uint16_t bitFields;
-public:
-    int8_t canassign;
-    uint8_t isdataseg;
     bool isargptr() const;
     bool isargptr(bool v);
     bool ctorinit() const;
@@ -5789,6 +5816,11 @@ public:
     bool doNotInferReturn(bool v);
     bool isArgDtorVar() const;
     bool isArgDtorVar(bool v);
+private:
+    uint16_t bitFields;
+public:
+    int8_t canassign;
+    uint8_t isdataseg;
     static VarDeclaration* create(const Loc& loc, Type* type, Identifier* ident, Initializer* _init, StorageClass storage_class = static_cast<StorageClass>(STC::undefined_));
     VarDeclaration* syntaxCopy(Dsymbol* s);
     void setFieldOffset(AggregateDeclaration* ad, FieldState& fieldState, bool isunion);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4200,27 +4200,28 @@ extern (C++) final class TypeFunction : TypeNext
 
     // These flags can be accessed like `bool` properties,
     // getters and setters are generated for them
-    private enum FunctionFlag : uint
+    private extern (D) static struct BitFields
     {
-        none            = 0,
-        isnothrow       = 0x0001, // nothrow
-        isnogc          = 0x0002, // is @nogc
-        isproperty      = 0x0004, // can be called without parentheses
-        isref           = 0x0008, // returns a reference
-        isreturn        = 0x0010, // 'this' is returned by ref
-        isScopeQual     = 0x0020, // 'this' is scope
-        isreturninferred= 0x0040, // 'this' is return from inference
-        isscopeinferred = 0x0080, // 'this' is scope from inference
-        islive          = 0x0100, // is @live
-        incomplete      = 0x0200, // return type or default arguments removed
-        isInOutParam    = 0x0400, // inout on the parameters
-        isInOutQual     = 0x0800, // inout on the qualifier
-        isctor          = 0x1000, // the function is a constructor
-        isreturnscope   = 0x2000, // `this` is returned by value
+        bool isnothrow;        /// nothrow
+        bool isnogc;           /// is @nogc
+        bool isproperty;       /// can be called without parentheses
+        bool isref;            /// returns a reference
+        bool isreturn;         /// 'this' is returned by ref
+        bool isScopeQual;      /// 'this' is scope
+        bool isreturninferred; /// 'this' is return from inference
+        bool isscopeinferred;  /// 'this' is scope from inference
+        bool islive;           /// is @live
+        bool incomplete;       /// return type or default arguments removed
+        bool isInOutParam;     /// inout on the parameters
+        bool isInOutQual;      /// inout on the qualifier
+        bool isctor;           /// the function is a constructor
+        bool isreturnscope;    /// `this` is returned by value
     }
 
+    import dmd.common.bitfields : generateBitFields;
+    mixin(generateBitFields!(BitFields, ushort));
+
     LINK linkage;               // calling convention
-    FunctionFlag funcFlags;
     TRUST trust;                // level of trust
     PURE purity = PURE.impure;
     byte inuse;
@@ -5086,41 +5087,21 @@ extern (C++) final class TypeFunction : TypeNext
         return false;
     }
 
-    // Generate getter / setter functions for `FunctionFlag` members so they can be
-    // treated like regular `bool` fields, instead of requiring bit twiddling to read/write
-    extern (D) mixin(() {
-        string result = "extern(C++) pure nothrow @safe @nogc {";
-        foreach (string mem; __traits(allMembers, FunctionFlag))
-        {
-            result ~= "
-            /// set or get if the function has the FunctionFlag attribute of the same name
-            bool "~mem~"() const { return (funcFlags & FunctionFlag."~mem~") != 0; }
-            /// ditto
-            void "~mem~"(bool v)
-            {
-                if (v) funcFlags |= FunctionFlag."~mem~";
-                else funcFlags &= ~FunctionFlag."~mem~";
-            }";
-        }
-        return result ~ "}\n";
-    }());
 
     /// Returns: `true` the function is `isInOutQual` or `isInOutParam` ,`false` otherwise.
     bool iswild() const pure nothrow @safe @nogc
     {
-        return (funcFlags & (FunctionFlag.isInOutParam | FunctionFlag.isInOutQual)) != 0;
+        return isInOutParam || isInOutQual;
     }
 
     /// Returns: whether `this` function type has the same attributes (`@safe`,...) as `other`
     bool attributesEqual(const scope TypeFunction other) const pure nothrow @safe @nogc
     {
-        enum attributes = FunctionFlag.isnothrow
-                        | FunctionFlag.isnogc
-                        | FunctionFlag.islive;
-
         return this.trust == other.trust &&
                 this.purity == other.purity &&
-                (this.funcFlags & attributes) == (other.funcFlags & attributes);
+                this.isnothrow == other.isnothrow &&
+                this.isnogc == other.isnogc &&
+                this.islive == other.islive;
     }
 
     override void accept(Visitor v)

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -595,8 +595,8 @@ public:
     // .next is the return type
 
     ParameterList parameterList; // function parameters
+    uint16_t bitFields;
     LINK linkage;                // calling convention
-    unsigned funcFlags;
     TRUST trust;                 // level of trust
     PURE purity;                 // PURExxxx
     char inuse;


### PR DESCRIPTION
Following up https://github.com/dlang/dmd/pull/13874
Replace the `FunctionFlag` `enum` by a `struct`, and factor out the getter/setter generation code from mtype.d and declaration.d into a new module.