### PR TITLE
build.d: Don't queue further tasks on failure

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -2117,10 +2117,13 @@ abstract final class Scheduler
 
             /// Stores whether the current build is stopping because some step failed
             static shared bool aborting;
+            if (atomicLoad(aborting))
+                return; // Abort but let other jobs finish
+
             scope (failure) atomicStore(aborting, true);
 
-            // Build the current rule unless another one failed
-            if (!atomicLoad(aborting) && target.run(depUpdated))
+            // Build the current rule
+            if (target.run(depUpdated))
             {
                 // Propagate that this rule's targets were (re)built
                 foreach (parent; requiredBy)


### PR DESCRIPTION
Immediatly abort the execution and don't update + potentially queue the dependant tasks (which would skip the actual execution anyways).

CC @maxhaton Probably doesn't fix your build issue if dmd hangs but might help debugging.