### PR TITLE
ImportC: run cpp on Posix .c files

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1525,7 +1525,7 @@ auto sourceFiles()
         frontend: fileArray(env["D"], "
             access.d aggregate.d aliasthis.d apply.d argtypes_x86.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d
             arraytypes.d astenums.d ast_node.d astcodegen.d asttypename.d attrib.d blockexit.d builtin.d canthrow.d chkformat.d
-            cli.d clone.d compiler.d cond.d constfold.d cppmangle.d cppmanglewin.d ctfeexpr.d
+            cli.d clone.d compiler.d cond.d constfold.d cppmangle.d cppmanglewin.d cpreprocess.d ctfeexpr.d
             ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d dimport.d
             dinterpret.d dmacro.d dmangle.d dmodule.d doc.d dscope.d dstruct.d dsymbol.d dsymbolsem.d
             dtemplate.d dtoh.d dversion.d escape.d expression.d expressionsem.d func.d hdrgen.d impcnvtab.d

--- a/src/dmd/README.md
+++ b/src/dmd/README.md
@@ -164,20 +164,21 @@ Note that these groups have no strict meaning, the category assignments are a bi
 
 **Other**
 
-| File                                                                          | Purpose                                                                                     |
-|-------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| [aliasthis.d](https://github.com/dlang/dmd/blob/master/src/dmd/aliasthis.d)   | Resolve implicit conversions for `alias X this`                                             |
-| [traits.d](https://github.com/dlang/dmd/blob/master/src/dmd/traits.d)         | `__traits()`                                                                                |
-| [lambdacomp.d](https://github.com/dlang/dmd/blob/master/src/dmd/lambdacomp.d) | `__traits(isSame, x => y, z => w)`                                                          |
-| [cond.d](https://github.com/dlang/dmd/blob/master/src/dmd/cond.d)             | Evaluate `static if`, `version` `debug `                                                    |
-| [staticcond.d](https://github.com/dlang/dmd/blob/master/src/dmd/staticcond.d) | Lazily evaluate static conditions for `static if`, `static assert` and template constraints |
-| [delegatize.d](https://github.com/dlang/dmd/blob/master/src/dmd/delegatize.d) | Converts expression to delegates for `lazy` parameters                                      |
-| [eh.d](https://github.com/dlang/dmd/blob/master/src/dmd/eh.d)                 | Generate tables for exception handling                                                      |
-| [nspace.d](https://github.com/dlang/dmd/blob/master/src/dmd/nspace.d)         | Namespace for `extern (C++, Module)`                                                        |
-| [intrange.d](https://github.com/dlang/dmd/blob/master/src/dmd/intrange.d)     | [Value range propagation](https://digitalmars.com/articles/b62.html)                        |
-| [dimport.d](https://github.com/dlang/dmd/blob/master/src/dmd/dimport.d)       | Renamed imports (`import aliasSymbol = pkg1.pkg2.symbol`)                                   |
-| [arrayop.d](https://github.com/dlang/dmd/blob/master/src/dmd/arrayop.d)       | Array operations (`a[] = b[] + c[]`)                                                        |
-| [typinf.d](https://github.com/dlang/dmd/blob/master/src/dmd/typinf.d)         | Generate typeinfo for `typeid()` (as well as internals)                                     |
+| File                                                                           | Purpose                                                                                     |
+|--------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| [aliasthis.d](https://github.com/dlang/dmd/blob/master/src/dmd/aliasthis.d)    | Resolve implicit conversions for `alias X this`                                             |
+| [traits.d](https://github.com/dlang/dmd/blob/master/src/dmd/traits.d)          | `__traits()`                                                                                |
+| [lambdacomp.d](https://github.com/dlang/dmd/blob/master/src/dmd/lambdacomp.d)  | `__traits(isSame, x => y, z => w)`                                                          |
+| [cond.d](https://github.com/dlang/dmd/blob/master/src/dmd/cond.d)              | Evaluate `static if`, `version` `debug `                                                    |
+| [staticcond.d](https://github.com/dlang/dmd/blob/master/src/dmd/staticcond.d)  | Lazily evaluate static conditions for `static if`, `static assert` and template constraints |
+| [delegatize.d](https://github.com/dlang/dmd/blob/master/src/dmd/delegatize.d)  | Converts expression to delegates for `lazy` parameters                                      |
+| [eh.d](https://github.com/dlang/dmd/blob/master/src/dmd/eh.d)                  | Generate tables for exception handling                                                      |
+| [nspace.d](https://github.com/dlang/dmd/blob/master/src/dmd/nspace.d)          | Namespace for `extern (C++, Module)`                                                        |
+| [intrange.d](https://github.com/dlang/dmd/blob/master/src/dmd/intrange.d)      | [Value range propagation](https://digitalmars.com/articles/b62.html)                        |
+| [dimport.d](https://github.com/dlang/dmd/blob/master/src/dmd/dimport.d)        | Renamed imports (`import aliasSymbol = pkg1.pkg2.symbol`)                                   |
+| [arrayop.d](https://github.com/dlang/dmd/blob/master/src/dmd/arrayop.d)        | Array operations (`a[] = b[] + c[]`)                                                        |
+| [cpreprocess.d](https://github.com/dlang/dmd/blob/master/src/dmd/cpreprocess.d)| Run the C preprocessor on C source files                                                   |
+| [typinf.d](https://github.com/dlang/dmd/blob/master/src/dmd/typinf.d)          | Generate typeinfo for `typeid()` (as well as internals)                                     |
 
 | File                                                                        | Purpose                                                                            |
 |-----------------------------------------------------------------------------|------------------------------------------------------------------------------------|

--- a/src/dmd/cpreprocess.d
+++ b/src/dmd/cpreprocess.d
@@ -1,0 +1,72 @@
+/**
+ * Run the C preprocessor on a C source file.
+ *
+ * Specification: C11
+ *
+ * Copyright:   Copyright (C) 2022 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/cpreprocess.d, _cpreprocess.d)
+ * Documentation:  https://dlang.org/phobos/dmd_cpreprocess.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/cpreprocess.d
+ */
+
+module dmd.cpreprocess;
+
+import core.stdc.stdio;
+import core.stdc.string;
+
+import dmd.astenums;
+import dmd.globals;
+import dmd.link;
+import dmd.errors;
+
+import dmd.common.outbuffer;
+
+import dmd.root.array;
+import dmd.root.filename;
+import dmd.root.rmem;
+import dmd.root.rootobject;
+import dmd.root.string;
+
+/***************************************
+ * Preprocess C file.
+ * Params:
+ *      csrcfile = C file to be preprocessed, with .c or .h extension
+ * Result:
+ *      filename of output
+ */
+extern (C++)
+FileName preprocess(FileName csrcfile)
+{
+    //printf("preprocess %s\n", csrcfile.toChars());
+    version (Posix)
+    {
+        const name = FileName.name(csrcfile.toString());
+        const ext = FileName.ext(name);
+        assert(ext);
+        const ifilename = FileName.addExt(name[0 .. name.length - (ext.length + 1)], i_ext);
+        auto status = runPreprocessor("cpp", csrcfile.toString(), ifilename);
+        if (status)
+        {
+            error(Loc.initial, "C preprocess failed for file %s, exit status %d\n", csrcfile.toChars(), status);
+            fatal();
+        }
+        return FileName(ifilename);
+    }
+    else version (Windows)
+    {
+        /* This actually works, but fails the test suite because:
+           1. For Microsoft's preprocessor, it insists on printing the filename it's preprocessing,
+              which causes all the fail_compilation tests to fail. Yes, even with /nologo.
+              cl.exe does not appear to have a "quiet" mode.
+           2. For Win32 with Digital Mars, the tests all fail because sppn.exe, the DMC preprocessor,
+              is not on the path. Even if it was, it would still fail because the DMC headers are not
+              there. To get the headers and sppn.exe, dmc will need to be installed on the test machines:
+              http://ftp.digitalmars.com/Digital_Mars_C++/Patch/dm857c.zip
+         */
+        return csrcfile;
+    }
+    else
+        return csrcfile;        // no-op
+}

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -662,7 +662,26 @@ extern (C++) final class Module : Package
             return true; // already read
 
         //printf("Module::read('%s') file '%s'\n", toChars(), srcfile.toChars());
-        if (auto result = global.fileManager.lookup(srcfile))
+
+        /* Preprocess the file if it's a C file
+         */
+        FileName filename = srcfile;
+        bool ifile = false;             // did we generate a .i file
+        scope (exit)
+        {
+            if (ifile)
+                File.remove(filename.toChars());        // remove generated file
+        }
+
+        if (global.preprocess &&
+            FileName.equalsExt(srcfile.toString(), c_ext) &&
+            FileName.exists(srcfile.toString()))
+        {
+            filename = global.preprocess(srcfile);  // run C preprocessor
+            ifile = true;
+        }
+
+        if (auto result = global.fileManager.lookup(filename))
         {
             this.src = result;
             if (global.params.emitMakeDeps)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -43,6 +43,7 @@ class CPPNamespaceDeclaration;
 struct Symbol;
 struct OutBuffer;
 class FileManager;
+struct FileName;
 struct Scope;
 class DeprecatedDeclaration;
 class UserAttributeDeclaration;
@@ -834,6 +835,37 @@ struct Param final
         {}
 };
 
+struct FileName final
+{
+private:
+    _d_dynamicArray< const char > str;
+public:
+    static bool equals(const char* name1, const char* name2);
+    static bool absolute(const char* name);
+    static const char* toAbsolute(const char* name, const char* base = nullptr);
+    static const char* ext(const char* str);
+    const char* ext() const;
+    static const char* removeExt(const char* str);
+    static const char* name(const char* str);
+    const char* name() const;
+    static const char* path(const char* str);
+    static const char* combine(const char* path, const char* name);
+    static Array<const char* >* splitPath(const char* path);
+    static const char* defaultExt(const char* name, const char* ext);
+    static const char* forceExt(const char* name, const char* ext);
+    static bool equalsExt(const char* name, const char* ext);
+    bool equalsExt(const char* ext) const;
+    static const char* searchPath(Array<const char* >* path, const char* name, bool cwd);
+    static int32_t exists(const char* name);
+    static bool ensurePathExists(const char* path);
+    static const char* canonicalName(const char* name);
+    static void free(const char* str);
+    const char* toChars() const;
+    FileName()
+    {
+    }
+};
+
 struct Global final
 {
     _d_dynamicArray< const char > inifilename;
@@ -856,6 +888,7 @@ struct Global final
     FileManager* fileManager;
     enum : int32_t { recursionLimit = 500 };
 
+    FileName(*preprocess)(FileName );
     uint32_t startGagging();
     bool endGagging(uint32_t oldGagged);
     void increaseErrorCount();
@@ -1647,37 +1680,6 @@ enum class PKG
     unknown = 0,
     module_ = 1,
     package_ = 2,
-};
-
-struct FileName final
-{
-private:
-    _d_dynamicArray< const char > str;
-public:
-    static bool equals(const char* name1, const char* name2);
-    static bool absolute(const char* name);
-    static const char* toAbsolute(const char* name, const char* base = nullptr);
-    static const char* ext(const char* str);
-    const char* ext() const;
-    static const char* removeExt(const char* str);
-    static const char* name(const char* str);
-    const char* name() const;
-    static const char* path(const char* str);
-    static const char* combine(const char* path, const char* name);
-    static Array<const char* >* splitPath(const char* path);
-    static const char* defaultExt(const char* name, const char* ext);
-    static const char* forceExt(const char* name, const char* ext);
-    static bool equalsExt(const char* name, const char* ext);
-    bool equalsExt(const char* ext) const;
-    static const char* searchPath(Array<const char* >* path, const char* name, bool cwd);
-    static int32_t exists(const char* name);
-    static bool ensurePathExists(const char* path);
-    static const char* canonicalName(const char* name);
-    static void free(const char* str);
-    const char* toChars() const;
-    FileName()
-    {
-    }
 };
 
 enum class FileType : uint8_t
@@ -5531,6 +5533,8 @@ extern const char* cppTypeInfoMangleMSVC(Dsymbol* s);
 extern const char* toCppMangleDMC(Dsymbol* s);
 
 extern const char* cppTypeInfoMangleDMC(Dsymbol* s);
+
+extern FileName preprocess(FileName csrcfile);
 
 class ClassReferenceExp final : public Expression
 {

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -335,6 +335,8 @@ extern (C++) struct Global
 
     enum recursionLimit = 500; /// number of recursive template expansions before abort
 
+    extern (C++) FileName function(FileName) preprocess;
+
   nothrow:
 
     /**

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -296,6 +296,8 @@ struct Global
 
     FileManager* fileManager;
 
+    FileName (*preprocess)(FileName);
+
     /* Start gagging. Return the current number of gagged errors
      */
     unsigned startGagging();

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -29,6 +29,7 @@ import dmd.builtin;
 import dmd.cond;
 import dmd.console;
 import dmd.compiler;
+import dmd.cpreprocess;
 import dmd.dmdparams;
 import dmd.dinifile;
 import dmd.dinterpret;
@@ -728,6 +729,9 @@ bool parseCommandlineAndConfig(size_t argc, const(char)** argv, ref Param params
     if (target.is64bit != is64bit)
         error(Loc.initial, "the architecture must not be changed in the %s section of %.*s",
               envsection.ptr, cast(int)global.inifilename.length, global.inifilename.ptr);
+
+    version (Posix)
+        global.preprocess = &preprocess;
     return false;
 }
 /// Emit the makefile dependencies for the -makedeps switch

--- a/test/compilable/testcstuff1.c
+++ b/test/compilable/testcstuff1.c
@@ -493,18 +493,3 @@ int main()
 {
     printf("hello world\n");
 }
-
-#line 1000
-%:line 1010
-
-# 1020 "cstuff1.c" 1 2 3 4
-# 1030
-struct S21944
-{
-    int var;
-#1040 "cstuff1.c" 3 4
-};
-
-/********************************/
-
-#line 1050 "cstuff1.c" extra tokens ignored (should warn?)

--- a/test/compilable/testcstuff3.i
+++ b/test/compilable/testcstuff3.i
@@ -1,0 +1,19 @@
+
+/* cpp doesn't like this, so don't run preprocessor on this file
+ */
+
+/********************************/
+
+#line 1050 "cstuff3.c" extra tokens ignored (should warn?)
+
+
+#line 1000
+%:line 1010
+
+# 1020 "cstuff3.c" 1 2 3 4
+# 1030
+struct S21944
+{
+    int var;
+#1040 "cstuff3.c" 3 4
+};

--- a/test/fail_compilation/failcstuff1.c
+++ b/test/fail_compilation/failcstuff1.c
@@ -46,7 +46,6 @@ fail_compilation/failcstuff1.c(504): Error: found `;` when expecting `)`
 fail_compilation/failcstuff1.c(505): Error: `=`, `;` or `,` expected to end declaration instead of `int`
 fail_compilation/failcstuff1.c(551): Error: missing comma or semicolon after declaration of `pluto`, found `p` instead
 fail_compilation/failcstuff1.c(601): Error: `=`, `;` or `,` expected to end declaration instead of `'s'`
-fail_compilation/failcstuff1.c(605): Error: invalid flag for line marker directive
 ---
 */
 
@@ -159,7 +158,3 @@ int * pluto p;
 #line 600
 
 char c22909 = u8's';
-
-/****************************************************/
-
-#650 "fail_compilation/failcstuff1.c" invalid

--- a/test/fail_compilation/failcstuff4.i
+++ b/test/fail_compilation/failcstuff4.i
@@ -1,0 +1,9 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/failcstuff4.i(605): Error: invalid flag for line marker directive
+---
+*/
+
+/****************************************************/
+#line 605
+#650 "fail_compilation/failcstuff4.c" invalid

--- a/test/fail_compilation/test22899.c
+++ b/test/fail_compilation/test22899.c
@@ -3,7 +3,6 @@
 fail_compilation/test22899.c(105): Error: expression expected, not `)`
 fail_compilation/test22899.c(105): Error: found `;` when expecting `)`
 fail_compilation/test22899.c(106): Error: found `}` when expecting `;` following statement
-fail_compilation/test22899.c(107): Error: found `End of File` when expecting `}` following compound statement
 ---
 */
 
@@ -16,4 +15,4 @@ void fn()
 {
     int x;
     x = sizeof( (mytype_t) );
-}
+}}

--- a/test/runnable/test22428.c
+++ b/test/runnable/test22428.c
@@ -14,7 +14,7 @@ void assert(int b, int line)
 
 /*********************************************/
 
-static void dummy() { } // so staticFunc() isn't at offset 0
+static void dummy() { } /* so staticFunc() is not at offset 0 */
 
 static int staticFunc(int i) { return i * 2; }
 


### PR DESCRIPTION
It's way past time for dmd to start running the C preprocessor. This kicks that baby bird out of the nest so it can learn to fly.

I like incrementalism, so this PR does as little as possible:

1. it only works on .c files
2. if you don't want to run the preprocessor on Posix, name the file with a .i extension
3. it runs `cpp` on the default path
4. no parameters can be passed to `cpp`
5. doesn't automatically `#include <importc.h>`
6. error messages are minimal
7. most of the code is copypasta from `runProgram()` in `link.d`

Hence review should be easy.

Based on Max's prior work https://github.com/maxhaton/dmd/commit/e132151a02c6b7434544207321cd084145c780b5 greatly simplified.