### PR TITLE
[changelog] Improve static array .tupleof entry

### DIFF
--- a/changelog/static_array_tupleof.dd
+++ b/changelog/static_array_tupleof.dd
@@ -1,19 +1,17 @@
 Added `.tupleof` property for static arrays
 
-The `.tupleof` property may now be used with instances of static arrays, yielding an $(DDSUBLINK spec/template, variadic-templates, expression sequence) of all the array's elements.
+The `.tupleof` property may now be used with instances of static arrays, yielding an $(DDSUBLINK spec/template, homogeneous_sequences, lvalue sequence) of each element in the array.
 
-Note that this is only for static array *values*, it remains an error when used upon a type so as to not break older code lacking suitable checks. As a workaround use `typeof((T[N]).init.tupleof)`.
+Note that this is only for static array *instances*. It remains an error when used on a type, to avoid breaking older code lacking suitable checks. As a workaround, use `typeof((T[N]).init.tupleof)`.
 
 ---
-void foo(int x, int y) { /* ... */ }
-void bar(int[2] xs)
-{
-    foo(xs.tupleof);
-}
+void foo(int, int, int) { /* ... */ }
 
-ubyte[] encoded = iota!int(10)
-    .map!(x => only(nativeToBigEndian(x).tupleof))
-    .joiner
-    .array
-;
+int[3] ia;
+foo(ia.tupleof); // same as `foo(8, 8, 8);`
+
+float[3] fa = [1.1, 2.2, 3.3];
+//ia = fa; // error
+ia.tupleof = fa.tupleof;
+assert(ia == [1, 2, 3]);
 ---

--- a/changelog/static_array_tupleof.dd
+++ b/changelog/static_array_tupleof.dd
@@ -7,11 +7,11 @@ Note that this is only for static array *instances*. It remains an error when us
 ---
 void foo(int, int, int) { /* ... */ }
 
-int[3] ia;
-foo(ia.tupleof); // same as `foo(8, 8, 8);`
+int[3] ia = [1, 2, 3];
+foo(ia.tupleof); // same as `foo(1, 2, 3);`
 
-float[3] fa = [1.1, 2.2, 3.3];
-//ia = fa; // error
-ia.tupleof = fa.tupleof;
-assert(ia == [1, 2, 3]);
+float[3] fa;
+//fa = ia; // error
+fa.tupleof = ia.tupleof;
+assert(fa == [1F, 2F, 3F]);
 ---


### PR DESCRIPTION
Tweak description & link to more relevant subheading.
Remove example involving nativeToBigEndian (a bit obscure, not clear what the return type is).
Add example showing tupleof assignment.

This mirrors the spec update: https://github.com/dlang/dlang.org/pull/3271