### PR TITLE
Issue 17374 - Begin improving inferred attribute error message for safety

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -28,6 +28,7 @@ struct Ensure
 class FuncDeclaration;
 class StructDeclaration;
 struct IntRange;
+struct AttributeViolation;
 
 //enum STC : ulong from astenums.d:
 
@@ -611,6 +612,10 @@ public:
     FuncDeclarations siblingCallers;
 
     FuncDeclarations *inlinedNestedCallees;
+
+private:
+    AttributeViolation* safetyViolation;
+public:
 
     unsigned flags;                     // FUNCFLAGxxxxx
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1411,7 +1411,7 @@ extern (C++) abstract class Expression : ASTNode
 
         if (!f.isSafe() && !f.isTrusted())
         {
-            if (sc.flags & SCOPE.compile ? sc.func.isSafeBypassingInference() : sc.func.setUnsafe())
+            if (sc.flags & SCOPE.compile ? sc.func.isSafeBypassingInference() : sc.func.setUnsafeCall(f))
             {
                 if (!loc.isValid()) // e.g. implicitly generated dtor
                     loc = sc.func.loc;
@@ -1420,6 +1420,7 @@ extern (C++) abstract class Expression : ASTNode
                 error("`@safe` %s `%s` cannot call `@system` %s `%s`",
                     sc.func.kind(), sc.func.toPrettyChars(), f.kind(),
                     prettyChars);
+                f.errorSupplementalInferredSafety(/*max depth*/ 10);
                 .errorSupplemental(f.loc, "`%s` is declared here", prettyChars);
 
                 checkOverridenDtor(sc, f, dd => dd.type.toTypeFunction().trust > TRUST.system, "@system");

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -276,6 +276,7 @@ class GotoCaseStatement;
 class GotoStatement;
 class ReturnStatement;
 class ScopeStatement;
+struct AttributeViolation;
 struct ObjcSelector;
 class PeelStatement;
 class CompoundStatement;
@@ -2784,6 +2785,9 @@ public:
     Array<VarDeclaration* > outerVars;
     Array<FuncDeclaration* > siblingCallers;
     Array<FuncDeclaration* >* inlinedNestedCallees;
+private:
+    AttributeViolation* safetyViolation;
+public:
     uint32_t flags;
     ObjcFuncDeclaration objc;
     static FuncDeclaration* create(const Loc& loc, const Loc& endloc, Identifier* id, StorageClass storage_class, Type* type, bool noreturn = false);

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3927,8 +3927,10 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
             cas.error("`asm` statement is assumed to be impure - mark it with `pure` if it is not");
         if (!(cas.stc & STC.nogc) && sc.func.setGC())
             cas.error("`asm` statement is assumed to use the GC - mark it with `@nogc` if it does not");
-        if (!(cas.stc & (STC.trusted | STC.safe)) && sc.func.setUnsafe())
-            cas.error("`asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not");
+        if (!(cas.stc & (STC.trusted | STC.safe)))
+        {
+            sc.func.setUnsafe(false, cas.loc, "`asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not");
+        }
 
         sc.pop();
         result = cas;

--- a/test/fail_compilation/attributediagnostic.d
+++ b/test/fail_compilation/attributediagnostic.d
@@ -1,0 +1,23 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/attributediagnostic.d(16): Error: `@safe` function `attributediagnostic.layer2` cannot call `@system` function `attributediagnostic.layer1`
+fail_compilation/attributediagnostic.d(18):        which calls `attributediagnostic.layer0`
+fail_compilation/attributediagnostic.d(20):        which calls `attributediagnostic.system`
+fail_compilation/attributediagnostic.d(22):        which was inferred `@system` because of:
+fail_compilation/attributediagnostic.d(22):        `asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not
+fail_compilation/attributediagnostic.d(17):        `attributediagnostic.layer1` is declared here
+---
+*/
+
+// Issue 17374 - Improve inferred attribute error message
+// https://issues.dlang.org/show_bug.cgi?id=17374
+
+auto layer2() @safe { layer1(); }
+auto layer1() { layer0(); }
+auto layer0() { system(); }
+
+auto system()
+{
+	asm {}
+}

--- a/test/fail_compilation/dtor_attributes.d
+++ b/test/fail_compilation/dtor_attributes.d
@@ -8,6 +8,8 @@ fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is impu
 fail_compilation/dtor_attributes.d(111):         - HasDtor member
 fail_compilation/dtor_attributes.d(103):           impure `HasDtor.~this` is declared here
 fail_compilation/dtor_attributes.d(118): Error: `@safe` function `dtor_attributes.test1` cannot call `@system` destructor `dtor_attributes.Strict.~this`
+fail_compilation/dtor_attributes.d(113):        which calls `dtor_attributes.Strict.~this`
+fail_compilation/dtor_attributes.d(103):        which calls `dtor_attributes.HasDtor.~this`
 fail_compilation/dtor_attributes.d(113):        `dtor_attributes.Strict.~this` is declared here
 fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is @system because of the following field's destructors:
 fail_compilation/dtor_attributes.d(111):         - HasDtor member

--- a/test/fail_compilation/dtorfields_attributes.d
+++ b/test/fail_compilation/dtorfields_attributes.d
@@ -9,6 +9,7 @@ fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` i
 fail_compilation/dtorfields_attributes.d(115):         - HasDtor member
 fail_compilation/dtorfields_attributes.d(103):           impure `HasDtor.~this` is declared here
 fail_compilation/dtorfields_attributes.d(117): Error: `@safe` constructor `dtorfields_attributes.Strict.this` cannot call `@system` destructor `dtorfields_attributes.Strict.~this`
+fail_compilation/dtorfields_attributes.d(103):        which calls `dtorfields_attributes.HasDtor.~this`
 fail_compilation/dtorfields_attributes.d(119):        `dtorfields_attributes.Strict.~this` is declared here
 fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` is @system because of the following field's destructors:
 fail_compilation/dtorfields_attributes.d(115):         - HasDtor member


### PR DESCRIPTION
Partial fix for [Issue 17374](https://issues.dlang.org/show_bug.cgi?id=17374). @MoonlightSentinel started https://github.com/dlang/dmd/pull/12383 which is blocked and stalled unfortunately, so here's my attempt at a simpler, more incremental approach.

Example of the new supplemental error:
```
fail_compilation/attributediagnostic.d(16): Error: `@safe` function `attributediagnostic.layer2` cannot call `@system` function `attributediagnostic.layer1`
fail_compilation/attributediagnostic.d(18):        which calls `attributediagnostic.layer0`
fail_compilation/attributediagnostic.d(20):        which calls `attributediagnostic.system`
fail_compilation/attributediagnostic.d(22):        which was inferred `@system` because of:
fail_compilation/attributediagnostic.d(22):        `asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not
fail_compilation/attributediagnostic.d(17):        `attributediagnostic.layer1` is declared here
```

The idea is to let each `FunctionDeclaration` store a pointer to a `SafetyViolation` struct, which represents either:
- a direct safety violation (like pointer arithmetic, or inline asm)
- a call to another `@system` function, which recursively might have its own `SafetyViolation`

To register the errors, the following pattern:
```D
if (func.setUnsafe()) 
{
    if (!gag)
        exp.error("expression %s is unsafe!", exp.toChars());
    return ErrorExp();
}
```
Is replaced by this:
```D
if (func.setUnsafe(gag, exp.loc, "expression %s is unsafe!", exp)) 
{
    return ErrorExp();
}
```
Where up to two `RootObject` args are allowed, which looks like it covers the current set of errors.

There are roughly 50 calls to `setUnsafe()`, and this PR starts by only changing one of them (the one for `asm` blocks).
If this approach is approved, follow up steps are:

- update the remaining `setUnsafe()` calls with error messages / parameters
- remove the default parameters of `setUnsafe`
- based on feedback, perhaps improve the error message
- give `setImpure` and `setGc` a similar treatment