### PR TITLE
Fix 22993 - Suggest string overload of std.conv.octal

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -2139,7 +2139,7 @@ class Lexer
                 // can't translate invalid octal value, just show a generic message
                 error("octal literals larger than 7 are no longer supported");
             else
-                error("octal literals `0%llo%.*s` are no longer supported, use `std.conv.octal!%llo%.*s` instead",
+                error("octal literals `0%llo%.*s` are no longer supported, use `std.conv.octal!\"%llo%.*s\"` instead",
                     n, cast(int)(p - psuffix), psuffix, n, cast(int)(p - psuffix), psuffix);
         }
         TOK result;

--- a/test/fail_compilation/fail2656.d
+++ b/test/fail_compilation/fail2656.d
@@ -1,20 +1,20 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2656.d(21): Error: octal literals `0123` are no longer supported, use `std.conv.octal!123` instead
-fail_compilation/fail2656.d(22): Error: octal literals `01000000000000000000000` are no longer supported, use `std.conv.octal!1000000000000000000000` instead
-fail_compilation/fail2656.d(23): Error: octal literals `0100000L` are no longer supported, use `std.conv.octal!100000L` instead
-fail_compilation/fail2656.d(24): Error: octal literals `01777777777777777777777u` are no longer supported, use `std.conv.octal!1777777777777777777777u` instead
-fail_compilation/fail2656.d(25): Error: octal literals `017777777777uL` are no longer supported, use `std.conv.octal!17777777777uL` instead
-fail_compilation/fail2656.d(26): Error: octal literals `0177777` are no longer supported, use `std.conv.octal!177777` instead
-fail_compilation/fail2656.d(27): Error: octal literals `020000000000L` are no longer supported, use `std.conv.octal!20000000000L` instead
-fail_compilation/fail2656.d(28): Error: octal literals `0200000u` are no longer supported, use `std.conv.octal!200000u` instead
-fail_compilation/fail2656.d(29): Error: octal literals `037777777777uL` are no longer supported, use `std.conv.octal!37777777777uL` instead
-fail_compilation/fail2656.d(30): Error: octal literals `040000000000` are no longer supported, use `std.conv.octal!40000000000` instead
-fail_compilation/fail2656.d(31): Error: octal literals `0777777777777777777777L` are no longer supported, use `std.conv.octal!777777777777777777777L` instead
-fail_compilation/fail2656.d(32): Error: octal literals `077777u` are no longer supported, use `std.conv.octal!77777u` instead
-fail_compilation/fail2656.d(33): Error: octal literals `077777uL` are no longer supported, use `std.conv.octal!77777uL` instead
-fail_compilation/fail2656.d(34): Error: octal literals `077777uL` are no longer supported, use `std.conv.octal!77777uL` instead
+fail_compilation/fail2656.d(21): Error: octal literals `0123` are no longer supported, use `std.conv.octal!"123"` instead
+fail_compilation/fail2656.d(22): Error: octal literals `01000000000000000000000` are no longer supported, use `std.conv.octal!"1000000000000000000000"` instead
+fail_compilation/fail2656.d(23): Error: octal literals `0100000L` are no longer supported, use `std.conv.octal!"100000L"` instead
+fail_compilation/fail2656.d(24): Error: octal literals `01777777777777777777777u` are no longer supported, use `std.conv.octal!"1777777777777777777777u"` instead
+fail_compilation/fail2656.d(25): Error: octal literals `017777777777uL` are no longer supported, use `std.conv.octal!"17777777777uL"` instead
+fail_compilation/fail2656.d(26): Error: octal literals `0177777` are no longer supported, use `std.conv.octal!"177777"` instead
+fail_compilation/fail2656.d(27): Error: octal literals `020000000000L` are no longer supported, use `std.conv.octal!"20000000000L"` instead
+fail_compilation/fail2656.d(28): Error: octal literals `0200000u` are no longer supported, use `std.conv.octal!"200000u"` instead
+fail_compilation/fail2656.d(29): Error: octal literals `037777777777uL` are no longer supported, use `std.conv.octal!"37777777777uL"` instead
+fail_compilation/fail2656.d(30): Error: octal literals `040000000000` are no longer supported, use `std.conv.octal!"40000000000"` instead
+fail_compilation/fail2656.d(31): Error: octal literals `0777777777777777777777L` are no longer supported, use `std.conv.octal!"777777777777777777777L"` instead
+fail_compilation/fail2656.d(32): Error: octal literals `077777u` are no longer supported, use `std.conv.octal!"77777u"` instead
+fail_compilation/fail2656.d(33): Error: octal literals `077777uL` are no longer supported, use `std.conv.octal!"77777uL"` instead
+fail_compilation/fail2656.d(34): Error: octal literals `077777uL` are no longer supported, use `std.conv.octal!"77777uL"` instead
 ---
 */
 

--- a/test/fail_compilation/fix19059.d
+++ b/test/fail_compilation/fix19059.d
@@ -5,7 +5,7 @@ fail_compilation/fix19059.d(16): Error: octal digit expected, not `8`
 fail_compilation/fix19059.d(16): Error: octal literals larger than 7 are no longer supported
 fail_compilation/fix19059.d(17): Error: octal digit expected, not `9`
 fail_compilation/fix19059.d(17): Error: octal literals larger than 7 are no longer supported
-fail_compilation/fix19059.d(18): Error: octal literals `010` are no longer supported, use `std.conv.octal!10` instead
+fail_compilation/fix19059.d(18): Error: octal literals `010` are no longer supported, use `std.conv.octal!"10"` instead
 ---
  */
 


### PR DESCRIPTION
The previously suggested integer overload has two drawbacks. The literal
parsed as base 10 and hence can overflow for larger values that are only
valid in base 8. It also requires additional CTFE because it converts
the value to string.

So add quotes to the literal in the error message to suggest the string
overload.
