### PR TITLE
FileManager.files should index [] not FileBuffer

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -664,7 +664,7 @@ extern (C++) final class Module : Package
         //printf("Module::read('%s') file '%s'\n", toChars(), srcfile.toChars());
         if (auto result = global.fileManager.lookup(srcfile))
         {
-            this.src = result.data;
+            this.src = result;
             if (global.params.emitMakeDeps)
                 global.params.makeDeps.push(srcfile.toChars());
             return true;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6032,7 +6032,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             auto fileName = FileName(name.toDString);
             if (auto fmResult = global.fileManager.lookup(fileName))
             {
-                se = new StringExp(e.loc, fmResult.data);
+                se = new StringExp(e.loc, fmResult);
             }
             else
             {
@@ -6047,9 +6047,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     // take ownership of buffer (probably leaking)
                     auto data = readResult.extractSlice();
                     se = new StringExp(e.loc, data);
-
-                    FileBuffer* fileBuffer = new FileBuffer(data);
-                    global.fileManager.add(fileName, fileBuffer);
+                    global.fileManager.add(fileName, data);
                 }
             }
         }

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -398,9 +398,9 @@ Tuple!(Module, "module_", Diagnostics, "diagnostics") parseModule(AST = ASTCodeg
     {
         import dmd.root.filename : FileName;
 
-        auto fb = new FileBuffer(cast(ubyte[]) code.dup ~ '\0');
+        auto fb = cast(ubyte[]) code.dup ~ '\0';
         global.fileManager.add(FileName(fileName), fb);
-        m.src = fb.data;
+        m.src = fb;
     }
 
     m = m.parseModule!AST();


### PR DESCRIPTION
FileBuffer is an rmem-managed buffer. But putting them into the string table makes them **un**-managed buffers that last the lifetime of the program. Fixed to store slices instead.