### PR TITLE
Fix Issue 22988 - no short-circuiting when constant folding ternary operator

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1107,6 +1107,10 @@ MATCH implicitConvTo(Expression e, Type t)
 
     MATCH visitCond(CondExp e)
     {
+        auto result = visit(e);
+        if (result != MATCH.nomatch)
+            return result;
+
         MATCH m1 = e.e1.implicitConvTo(t);
         MATCH m2 = e.e2.implicitConvTo(t);
         //printf("CondExp: m1 %d m2 %d\n", m1, m2);

--- a/test/compilable/test22988.d
+++ b/test/compilable/test22988.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=22988
+
+enum a1 = 0;
+enum b1 = a1 ? 1 << a1 - 1 : 0;
+
+enum l = 0;
+enum int[l] a2 = [];
+enum b2 = l ? a2[l - 1] : 0;
+
+enum a3 = 0 ? 1 << -1 : 0;
+
+enum int[0] a4 = [];
+enum b4 = 0 ? a4[0] : 0;
+
+enum b5 = false ? (1 << -1) : 0;


### PR DESCRIPTION
When calling `implicitConvTo` with `CondExp` go through the generic visit function first (it checks for optimized expression).