### PR TITLE
Fix issue 23000 - final switch error has no line number with -checkaction=C

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1443,7 +1443,7 @@ extern (C++) class ToElemVisitor : Visitor
             if (irs.params.checkAction == CHECKACTION.C)
             {
                 auto econd = toElem(ae.e1, irs);
-                auto ea = callCAssert(irs, ae.e1.loc, ae.e1, ae.msg, null);
+                auto ea = callCAssert(irs, ae.loc, ae.e1, ae.msg, null);
                 auto eo = el_bin(OPoror, TYvoid, econd, ea);
                 elem_setLoc(eo, ae.loc);
                 result = eo;


### PR DESCRIPTION
The `assert(0)` for the default case of the final switch is generated in statementsem.d:
```D
s = new ExpStatement(ss.loc, new AssertExp(ss.loc, IntegerExp.literal!0));
```
Then in e2ir.d, the location of the assert expression is used, which is `IntegerExp.literal!0` in this case, which doesn't have a location set. This patch makes it use the location of the statement instead, which is actually consistent with the other `checkaction`s since a D `assert` also uses the location of the statement.

I tested this manually, but not sure how to add this to the test suite because I can't `catch` a C assert, and I'm not sure we even want a new runnable test for something trivial like this, but I'm open to suggestions.