### PR TITLE
Fix issue 22999 - no switch fallthrough error with multi-valued case

### DIFF
--- a/changelog/switch-fallthrough.dd
+++ b/changelog/switch-fallthrough.dd
@@ -7,15 +7,16 @@ However, the compiler would not issue an error when using multiple values in a s
 ---
 void main()
 {
-	int i = 0;
-	switch (10) {
-		case 10, 11:
-			i = 4;
-			// accidental falltrough allowed
-		default:
-			i = 8;
-	}
-	assert(i == 4); // fails
+    int i = 0;
+    switch (10)
+    {
+        case 10, 11:
+            i = 4;
+            // accidental falltrough allowed
+        default:
+            i = 8;
+    }
+    assert(i == 4); // fails
 }
 ---
 

--- a/changelog/switch-fallthrough.dd
+++ b/changelog/switch-fallthrough.dd
@@ -1,0 +1,23 @@
+A missed case of switch case fallthrough has been deprecated
+
+Forgetting a `break;` statement in a switch case has been turned from a deprecation
+$(LINK2 $(ROOT_DIR)/changelog/2.099.0.html#switch_fallthrough_error, into an error in DMD 2.099.0).
+However, the compiler would not issue an error when using multiple values in a single case statement:
+
+---
+void main()
+{
+	int i = 0;
+	switch (10) {
+		case 10, 11:
+			i = 4;
+			// accidental falltrough allowed
+		default:
+			i = 8;
+	}
+	assert(i == 4); // fails
+}
+---
+
+This bug has been fixed, but to avoid breaking code, this specific case now issues a deprecation warning.
+Starting from DMD 2.110, it will produce an error just like other cases of switch case fallthrough.

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -139,16 +139,21 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                             // Allow if last case/default was empty
                             CaseStatement sc = slast.isCaseStatement();
                             DefaultStatement sd = slast.isDefaultStatement();
-                            if (sc && (!sc.statement.hasCode() || sc.statement.isErrorStatement()))
-                            {
-                            }
-                            else if (sd && (!sd.statement.hasCode() || sd.statement.isErrorStatement()))
+                            auto sl = (sc ? sc.statement : (sd ? sd.statement : null));
+
+                            if (sl && (!sl.hasCode() || sl.isErrorStatement()))
                             {
                             }
                             else if (func.getModule().filetype != FileType.c)
                             {
                                 const(char)* gototype = s.isCaseStatement() ? "case" : "default";
-                                s.error("switch case fallthrough - use 'goto %s;' if intended", gototype);
+                                // @@@DEPRECATED_2.110@@@ https://issues.dlang.org/show_bug.cgi?id=22999
+                                // Deprecated in 2.100
+                                // Make an error in 2.110
+                                if (sl && sl.isCaseStatement())
+                                    s.deprecation("switch case fallthrough - use 'goto %s;' if intended", gototype);
+                                else
+                                    s.error("switch case fallthrough - use 'goto %s;' if intended", gototype);
                             }
                         }
                     }

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -139,10 +139,10 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                             // Allow if last case/default was empty
                             CaseStatement sc = slast.isCaseStatement();
                             DefaultStatement sd = slast.isDefaultStatement();
-                            if (sc && (!sc.statement.hasCode() || sc.statement.isCaseStatement() || sc.statement.isErrorStatement()))
+                            if (sc && (!sc.statement.hasCode() || sc.statement.isErrorStatement()))
                             {
                             }
-                            else if (sd && (!sd.statement.hasCode() || sd.statement.isCaseStatement() || sd.statement.isErrorStatement()))
+                            else if (sd && (!sd.statement.hasCode() || sd.statement.isErrorStatement()))
                             {
                             }
                             else if (func.getModule().filetype != FileType.c)

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -315,6 +315,14 @@ extern (C++) abstract class Statement : ASTNode
             override void visit(ImportStatement s)
             {
             }
+
+            override void visit(CaseStatement s)
+            {
+            }
+
+            override void visit(DefaultStatement s)
+            {
+            }
         }
 
         scope HasCode hc = new HasCode();

--- a/test/fail_compilation/test22999.d
+++ b/test/fail_compilation/test22999.d
@@ -1,0 +1,26 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test22999.d(17): Error: switch case fallthrough - use 'goto default;' if intended
+fail_compilation/test22999.d(24): Error: switch case fallthrough - use 'goto case;' if intended
+---
+*/
+
+// no switch fallthrough error with multi-valued case
+// https://issues.dlang.org/show_bug.cgi?id=22999
+void main()
+{
+    int i;
+    switch (0)
+    {
+        case 0, 1: i = 20;
+        default: assert(0);
+    }
+
+    switch (0)
+    {
+        default:
+        case 0, 1: i = 20;
+        case 2, 3: i = 30;
+    }
+}

--- a/test/fail_compilation/test22999.d
+++ b/test/fail_compilation/test22999.d
@@ -1,8 +1,9 @@
 /*
+REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/test22999.d(17): Error: switch case fallthrough - use 'goto default;' if intended
-fail_compilation/test22999.d(24): Error: switch case fallthrough - use 'goto case;' if intended
+fail_compilation/test22999.d(18): Deprecation: switch case fallthrough - use 'goto default;' if intended
+fail_compilation/test22999.d(25): Deprecation: switch case fallthrough - use 'goto case;' if intended
 ---
 */
 


### PR DESCRIPTION
Revert the incorrect fix of https://github.com/dlang/dmd/pull/1673 and fix `hasCode()` instead to account for `CaseStatement` and `DefaultStatement`.