### PR TITLE
dmd.parse: Improve error message for declaring version or debug condition in a function

### DIFF
--- a/test/fail_compilation/diag11198.d
+++ b/test/fail_compilation/diag11198.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag11198.d(11): Error: version conditions can only be declared at module scope
-fail_compilation/diag11198.d(12): Error: debug conditions can only be declared at module scope
+fail_compilation/diag11198.d(11): Error: version `blah` declaration must be at module level
+fail_compilation/diag11198.d(12): Error: debug `blah` declaration must be at module level
 ---
 */
 

--- a/test/fail_compilation/diag11198.d
+++ b/test/fail_compilation/diag11198.d
@@ -1,8 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag11198.d(11): Error: version `blah` declaration must be at module level
-fail_compilation/diag11198.d(12): Error: debug `blah` declaration must be at module level
+fail_compilation/diag11198.d(15): Error: version `blah` declaration must be at module level
+fail_compilation/diag11198.d(16): Error: debug `blah` declaration must be at module level
+fail_compilation/diag11198.d(17): Error: version `1` level declaration must be at module level
+fail_compilation/diag11198.d(18): Error: debug `2` level declaration must be at module level
+fail_compilation/diag11198.d(19): Error: identifier or integer expected, not `""`
+fail_compilation/diag11198.d(20): Error: identifier or integer expected, not `""`
 ---
 */
 
@@ -10,4 +14,8 @@ void main()
 {
     version = blah;
     debug = blah;
+    version = 1;
+    debug = 2;
+    version = "";
+    debug = "";
 }


### PR DESCRIPTION
This matches the same diagnostic that happens at semantic time for [other kinds of invalid declarations](https://github.com/dlang/dmd/blob/b374b4ed84897e55f4d6b833ffa8aa6bbf7d53b4/src/dmd/dversion.d#L79).