### PR TITLE
chore(pre-commit): bump hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.2.0
   hooks:
   - id: trailing-whitespace
     exclude: >
@@ -20,6 +20,6 @@ repos:
   - id: no-commit-to-branch
     args: [--branch, master]
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.14.1
+  rev: 0.14.2
   hooks:
     - id: check-github-workflows


### PR DESCRIPTION
Updated versions:
- pre-commit/pre-commit-hooks: v4.1.0 -> v4.2.0
- sirosen/check-jsonschema: 0.14.1 -> 0.14.2

Signed-off-by: Luís Ferreira <contact@lsferreira.net>