### PR TITLE
Fix issue 21673, 21676, 23009 - don't put SIMD variables in registers

### DIFF
--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -1604,6 +1604,19 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                 debug if (debugr) printf("'%s' not reg cand due to offset or size\n", s.Sident.ptr);
                 s.Sflags &= ~GTregcand;
             }
+            else if (tyvector(s.Stype.Tty))
+            {
+                // https://issues.dlang.org/show_bug.cgi?id=21673
+                // https://issues.dlang.org/show_bug.cgi?id=21676
+                // https://issues.dlang.org/show_bug.cgi?id=23009
+                // Currently, when assigning to element [0] of a double2 and -O puts it in
+                // a register, this gets generated:
+                // movsd   XMM0,[RDI]
+                // This clears the rest of XMM0, setting element [1] to 0.
+                // Until this is fixed, keep vector variables on the stack
+                debug if (debugr) printf("'%s' not reg cand due to vector type\n", s.Sident.ptr);
+                s.Sflags &= ~GTregcand;
+            }
 
             if (config.fpxmmregs && tyfloating(s.ty()) && !tyfloating(ty))
             {


### PR DESCRIPTION
This function:
```D
double2 _mm_loadl_pd(double2 a, const(double)* mem_addr)
{
    a[0] = *mem_addr;
    return a;
}
```
Generates this with `-O`:
```
    movsd XMM0,[RDI]
    movapd XMM0,XMM0
```

The [movsd documentation](https://www.felixcloutier.com/x86/movsd)  says:

> When the source operand is a memory location and destination operand is an XMM registers, the quadword at bits 127:64 of the destination operand is cleared to all 0s

So this unintentionally sets `a[1] = 0`, causing the issue. I was wondering what instruction DMD would generate when assigning to `a[1]`, but it turns out as soon as `e.EV.Voffset > 0` it gives up putting the variable in a register and falls back on putting it on the stack, so this patch does the same for any variable with a vector type.
