### PR TITLE
CI: Use host dmd to compile dshell tests

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -53,7 +53,7 @@ enum TestTools
     unitTestRunner = TestTool("unit_test_runner", [toolsDir.buildPath("paths")]),
     testRunner = TestTool("d_do_test", ["-I" ~ toolsDir, "-i", "-version=NoMain"]),
     jsonSanitizer = TestTool("sanitize_json"),
-    dshellPrebuilt = TestTool("dshell_prebuilt", null, Yes.linksWithTests),
+    dshellPrebuilt = TestTool("dshell", null, Yes.linksWithTests),
 }
 
 immutable struct TestTool
@@ -264,18 +264,14 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
     shared uint failCount = 0;
     foreach (tool; tools.parallel(1))
     {
+        const string sourceFile = toolsDir.buildPath(tool ~ ".d");
+
         string targetBin;
-        string sourceFile;
         if (tool.linksWithTests)
-        {
             targetBin = resultsDir.buildPath(tool).objName;
-            sourceFile = toolsDir.buildPath(tool, tool ~ ".d");
-        }
         else
-        {
             targetBin = resultsDir.buildPath(tool).exeName;
-            sourceFile = toolsDir.buildPath(tool ~ ".d");
-        }
+
         if (targetBin.timeLastModified.ifThrown(SysTime.init) >= sourceFile.timeLastModified)
             log("%s is already up-to-date", tool);
         else
@@ -304,7 +300,7 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
                 command = [
                     hostDMD,
                     "-m"~model,
-                    "-of"~targetBin,
+                    "-of="~targetBin,
                     sourceFile
                 ] ~ getPicFlags(env) ~ tool.extraArgs;
             }

--- a/test/run.d
+++ b/test/run.d
@@ -50,10 +50,10 @@ enum toolsDir = testPath("tools");
 
 enum TestTools
 {
-    unitTestRunner = TestTool("unit_test_runner", [toolsDir.buildPath("paths")]),
-    testRunner = TestTool("d_do_test", ["-I" ~ toolsDir, "-i", "-version=NoMain"]),
-    jsonSanitizer = TestTool("sanitize_json"),
-    dshellPrebuilt = TestTool("dshell", null, Yes.linksWithTests),
+    unitTestRunner = TestTool("tools/unit_test_runner", [toolsDir.buildPath("paths")]),
+    testRunner = TestTool("tools/d_do_test", ["-g", "-I" ~ toolsDir, "-i", "-version=NoMain"]),
+    jsonSanitizer = TestTool("tools/sanitize_json"),
+    dshellPrebuilt = TestTool("tools/dshell", [ "-c" ], buildPath("tools", "dshell".objName)),
 }
 
 immutable struct TestTool
@@ -64,8 +64,8 @@ immutable struct TestTool
     /// Extra arguments that should be supplied to the compiler when compiling the tool.
     string[] extraArgs;
 
-    /// Indicates the tool is a binary that links with tests
-    Flag!"linksWithTests" linksWithTests;
+    /// Output path
+    string binary;
 
     alias name this;
 }
@@ -124,7 +124,7 @@ Options:
 
     // allow overwrites from the environment
     hostDMD = environment.get("HOST_DMD", "dmd");
-    unitTestRunnerCommand = resultsDir.buildPath("unit_test_runner").exeName;
+    unitTestRunnerCommand = resultsDir.buildPath("tools", "unit_test_runner").exeName;
 
     // bootstrap all needed environment variables
     const env = getEnvironment();
@@ -149,6 +149,7 @@ Options:
     }
 
     ensureToolsExists(env, EnumMembers!TestTools);
+    ensureToolsExists(env, listDshellScripts());
 
     if (args == ["tools"])
         return 0;
@@ -264,11 +265,11 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
     shared uint failCount = 0;
     foreach (tool; tools.parallel(1))
     {
-        const string sourceFile = toolsDir.buildPath(tool ~ ".d");
+        const string sourceFile = scriptDir.buildPath(tool ~ ".d");
 
         string targetBin;
-        if (tool.linksWithTests)
-            targetBin = resultsDir.buildPath(tool).objName;
+        if (tool.binary)
+            targetBin = resultsDir.buildPath(tool.binary);
         else
             targetBin = resultsDir.buildPath(tool).exeName;
 
@@ -276,38 +277,19 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
             log("%s is already up-to-date", tool);
         else
         {
-            string[] command;
-            bool overrideEnv;
-            if (tool.linksWithTests)
-            {
-                // This will compile the dshell library thus needs the actual
-                // DMD compiler under test
-                command = [
-                    env["DMD"],
-                    "-conf=",
-                    "-m"~env["MODEL"],
-                    "-of" ~ targetBin,
-                    "-c",
-                    sourceFile
-                ] ~ getPicFlags(env);
-                overrideEnv = true;
-            }
-            else
-            {
-                string model = env["MODEL"];
-                if (model == "32omf") model = "32";
+            string model = env["MODEL"];
+            if (model == "32omf") model = "32";
 
-                command = [
+            string[] command = [
                     hostDMD,
                     "-m"~model,
                     "-of="~targetBin,
                     sourceFile
                 ] ~ getPicFlags(env) ~ tool.extraArgs;
-            }
 
             writefln("Executing: %-(%s %)", command);
             stdout.flush();
-            if (spawnProcess(command, overrideEnv ? env : null).wait)
+            if (spawnProcess(command, null, Config.none, scriptDir).wait)
             {
                 stderr.writefln("failed to build '%s'", targetBin);
                 atomicOp!"+="(failCount, 1);
@@ -316,6 +298,26 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
     }
     if (failCount > 0)
         quitSilently(1); // error already printed
+}
+
+TestTool[] listDshellScripts()
+{
+    TestTool[] list;
+    immutable string[] args = [
+        "-I" ~ toolsDir,
+        buildPath(resultsDir, TestTools.dshellPrebuilt.binary)
+    ];
+    const dshellDir = buildPath(scriptDir, "dshell");
+    enum runner = "run".exeName;
+
+    foreach (const entry; dirEntries(dshellDir, "*.d", SpanMode.shallow))
+    {
+        const name = entry.name[scriptDir.length + 1 .. $ - 2];
+        const binary = buildPath(name, runner);
+        list ~= TestTool(name, args, binary);
+    }
+
+    return list;
 }
 
 /// A single target to execute.

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -2112,7 +2112,7 @@ string printTestFailure(string testLogName, scope ref File outfile, string extra
 
     writeln("==============================");
     writefln("Test '%s' failed. The logged output:", testLogName);
-    const output = readText(output_file_temp);
+    const output = cast(string) read(output_file_temp);
     write(output);
     if (!output.endsWith("\n"))
           writeln();

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -2049,10 +2049,7 @@ int runDShellTest(string input_dir, string test_name, const ref EnvData envData,
         const runTest = [testScriptExe];
         outfile.writeln("\n[RUN_TEST] ", escapeShellCommand(runTest));
         outfile.flush();
-        string[string] env = [
-            "TEST_NAME": test_name,
-        ];
-        auto runTestProc = std.process.spawnProcess(runTest, stdin, outfile, outfile, env, keepFilesOpen);
+        auto runTestProc = std.process.spawnProcess(runTest, stdin, outfile, outfile, null, keepFilesOpen);
         // auto runTestProc = std.process.spawnProcess(runTest, stdin, outfile, outfile, env, keepFilesOpen, dmdTestDir);
         const exitCode = wait(runTestProc);
 

--- a/test/tools/dshell.d
+++ b/test/tools/dshell.d
@@ -1,7 +1,7 @@
 /**
 A small library to help write D shell-like test scripts.
 */
-module dshell_prebuilt;
+module dshell;
 
 public import core.stdc.stdlib : exit;
 
@@ -17,6 +17,11 @@ public import std.file;
 public import std.regex;
 public import std.stdio;
 public import std.process;
+
+shared static this()
+{
+    dshellPrebuiltInit("dshell", environment["TEST_NAME"]);
+}
 
 /**
 Emulates bash environment variables. Variables set here will be availble for BASH-like expansion.

--- a/test/tools/dshell.d
+++ b/test/tools/dshell.d
@@ -89,7 +89,7 @@ void dshellPrebuiltInit(string testDir, string testName)
     // reference to the resulting test_dir folder, e.g .test_results/runnable
     Vars.set("RESULTS_TEST_DIR", buildPath(RESULTS_DIR, TEST_DIR));
     // reference to the resulting files without a suffix, e.g. test_results/runnable/test123import test);
-    Vars.set("OUTPUT_BASE", buildPath(RESULTS_TEST_DIR, TEST_NAME));
+    Vars.set("OUTPUT_BASE", buildPath(RESULTS_TEST_DIR, TEST_NAME, "work"));
     // reference to the extra files directory
     Vars.set("EXTRA_FILES", buildPath(TEST_DIR, "extra-files"));
     // reference to the imports directory

--- a/test/tools/dshell_prebuilt.d
+++ b/test/tools/dshell_prebuilt.d
@@ -1,7 +1,7 @@
 /**
 A small library to help write D shell-like test scripts.
 */
-module dshell;
+module dshell_prebuilt;
 
 public import core.stdc.stdlib : exit;
 
@@ -17,11 +17,6 @@ public import std.file;
 public import std.regex;
 public import std.stdio;
 public import std.process;
-
-shared static this()
-{
-    dshellPrebuiltInit("dshell", environment["TEST_NAME"]);
-}
 
 /**
 Emulates bash environment variables. Variables set here will be availble for BASH-like expansion.


### PR DESCRIPTION
This ensures that a bug / breakage in the tested compiler doesn't prevent
the actual test execution (because `run.d` aborts when the test tools
fail to build).

The only drawback is that this limits the tests to the bootstrap
compiler version.