### PR TITLE
dshell_prebuilt: Replace auto return with actual type

### DIFF
--- a/test/tools/dshell_prebuilt/dshell_prebuilt.d
+++ b/test/tools/dshell_prebuilt/dshell_prebuilt.d
@@ -156,7 +156,7 @@ void mkdirFor(string filename)
 Run the given command. The `tryRun` variants return the exit code, whereas the `run` variants
 will assert on a non-zero exit code.
 */
-auto tryRun(scope const(char[])[] args, File stdout = std.stdio.stdout,
+int tryRun(scope const(char[])[] args, File stdout = std.stdio.stdout,
             File stderr = std.stdio.stderr, string[string] env = null)
 {
     std.stdio.stdout.write("[RUN]");
@@ -182,7 +182,7 @@ auto tryRun(scope const(char[])[] args, File stdout = std.stdio.stdout,
 }
 
 /// ditto
-auto tryRun(string cmd, File stdout = std.stdio.stdout,
+int tryRun(string cmd, File stdout = std.stdio.stdout,
             File stderr = std.stdio.stderr, string[string] env = null)
 {
     return tryRun(parseCommand(cmd), stdout, stderr, env);


### PR DESCRIPTION
Makes separate compilation for dshell tests more effective because the
body doesn't need to be analyzed to infer the return type
