### PR TITLE
Fix super.visit issue in ParseTimeTransitiveVisitor

### DIFF
--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -17,7 +17,9 @@ import core.stdc.stdio;
 extern(C++) class ParseTimeTransitiveVisitor(AST) : PermissiveVisitor!AST
 {
     alias visit = PermissiveVisitor!AST.visit;
-    mixin ParseVisitMethods!AST;
+
+    mixin ParseVisitMethods!AST __methods;
+    alias visit = __methods.visit;
 }
 
 /* This mixin implements the AST traversal logic for parse time AST nodes. The same code


### PR DESCRIPTION
This adds the same workaround to ParseTimeTransitiveVisitor,
which has already been used for SemanticTimeTransitiveVisitor
in https://github.com/dlang/dmd/pull/7635.