### PR TITLE
Fix 23019 - Use proper format spec when reporting file errors

### DIFF
--- a/src/dmd/utils.d
+++ b/src/dmd/utils.d
@@ -83,7 +83,7 @@ extern (D) void writeFile(Loc loc, const(char)[] filename, const void[] data)
     ensurePathToNameExists(Loc.initial, filename);
     if (!File.update(filename, data))
     {
-        error(loc, "Error writing file '%*.s'", cast(int) filename.length, filename.ptr);
+        error(loc, "Error writing file '%.*s'", cast(int) filename.length, filename.ptr);
         fatal();
     }
 }

--- a/test/fail_compilation/write_error.d
+++ b/test/fail_compilation/write_error.d
@@ -1,0 +1,11 @@
+/++
+https://issues.dlang.org/show_bug.cgi?id=23019
+
+ARG_SETS: -of=fail_compilation
+TEST_OUTPUT:
+---
+Error: Error writing file 'fail_compilation'
+---
+++/
+
+void main() {}


### PR DESCRIPTION
The code used `*.` instead of `.*`.
