### PR TITLE
run.d: Split ensureToolsExists & remove duplication

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -164,7 +164,7 @@ check_clean_git()
 check_run_individual()
 {
     local build_path=generated/linux/$BUILD/$MODEL
-    "${build_path}/dmd" -I./test -i -run ./test/run.d test/runnable/template2962.d ./test/compilable/test14275.d
+    "${build_path}/dmd" -I./test -i -run ./test/run.d "BUILD=$BUILD" "MODEL=$MODEL" test/runnable/template2962.d ./test/compilable/test14275.d
 }
 
 # Checks the D build.d script

--- a/test/run.d
+++ b/test/run.d
@@ -140,6 +140,7 @@ Options:
     }
 
     verifyCompilerExists(env);
+    prepareOutputDirectory(env);
 
     if (runUnitTests)
     {
@@ -221,13 +222,12 @@ void verifyCompilerExists(const string[string] env)
     }
 }
 
-/**
-Builds the binary of the tools required by the testsuite.
-Does nothing if the tools already exist and are newer than their source.
-*/
-void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
+/// Creates the necessary directories and files for the test runner(s)
+void prepareOutputDirectory(const string[string] env)
 {
-    resultsDir.mkdirRecurse;
+    // ensure output directories exist
+    foreach (dir; testDirs)
+        resultsDir.buildPath(dir).mkdirRecurse;
 
     version (Windows)
     {{
@@ -253,7 +253,14 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
             wrapper.write(`[ -z "${`, key, `+x}" ] && export `, key, `='`, value, "' ;\n");
         }
     }}
+}
 
+/**
+Builds the binaries of the tools required by the testsuite.
+Does nothing if the tools already exist and are newer than their source.
+*/
+void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
+{
     shared uint failCount = 0;
     foreach (tool; tools.parallel(1))
     {
@@ -313,10 +320,6 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
     }
     if (failCount > 0)
         quitSilently(1); // error already printed
-
-    // ensure output directories exist
-    foreach (dir; testDirs)
-        resultsDir.buildPath(dir).mkdirRecurse;
 }
 
 /// A single target to execute.

--- a/test/run.d
+++ b/test/run.d
@@ -139,19 +139,18 @@ Options:
         stdout.flush();
     }
 
+    verifyCompilerExists(env);
+
     if (runUnitTests)
     {
-        verifyCompilerExists(env);
         ensureToolsExists(env, TestTools.unitTestRunner);
         return spawnProcess(unitTestRunnerCommand ~ args, env, Config.none, scriptDir).wait();
     }
 
+    ensureToolsExists(env, EnumMembers!TestTools);
+
     if (args == ["tools"])
-    {
-        verifyCompilerExists(env);
-        ensureToolsExists(env, EnumMembers!TestTools);
         return 0;
-    }
 
     // default target
     if (!args.length)
@@ -185,10 +184,7 @@ Options:
 
     if (targets.length > 0)
     {
-        verifyCompilerExists(env);
-
         string[] failedTargets;
-        ensureToolsExists(env, EnumMembers!TestTools);
         foreach (target; parallel(targets, 1))
         {
             log("run: %-(%s %)", target.args);


### PR DESCRIPTION
The method currently implements two things - the initialiation of `$RESULTS_DIR` and the compilation of the `TestTool`s. These tasks belong into individual methods s.t. the latter can be reused (see #13981).

Also moved the common calls out of the individual branches for normal tests, unittests and pure tool build. Less code duplication.
