### PR TITLE
fix Issue 23002 - importC: struct or union field with same name as ty…

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2399,15 +2399,13 @@ final class CParser(AST) : Parser!AST
                 if (idx.length > 2 && idx[0] == '_' && idx[1] == '_')  // leading double underscore
                     importBuiltins = true;  // probably one of those compiler extensions
                 t = null;
-                if (scw & SCW.xtypedef)
-                {
-                    /* Punch through to what the typedef is, to support things like:
-                     *  typedef T* T;
-                     */
-                    auto pt = lookupTypedef(previd);
-                    if (pt && *pt)      // if previd is a known typedef
-                        t = *pt;
-                }
+
+                /* Punch through to what the typedef is, to support things like:
+                 *  typedef T* T;
+                 */
+                auto pt = lookupTypedef(previd);
+                if (pt && *pt)      // if previd is a known typedef
+                    t = *pt;
 
                 if (!t)
                     t = new AST.TypeIdentifier(loc, previd);

--- a/test/compilable/test23002.c
+++ b/test/compilable/test23002.c
@@ -1,0 +1,7 @@
+/* https://issues.dlang.org/show_bug.cgi?id=23002
+ */
+
+typedef int x;
+struct S { x x; };
+struct T { x *x; };
+union U { x x; };

--- a/test/fail_compilation/alignas2.c
+++ b/test/fail_compilation/alignas2.c
@@ -5,7 +5,7 @@ fail_compilation/alignas2.c(103): Error: no alignment-specifier for function dec
 fail_compilation/alignas2.c(107): Error: no alignment-specifier for `register` storage class
 fail_compilation/alignas2.c(110): Error: no alignment-specifier for parameters
 fail_compilation/alignas2.c(115): Error: no alignment-specifier for parameters
-fail_compilation/alignas2.c(116): Error: no declaration for identifier `x`
+fail_compilation/alignas2.c(116): Error: storage class and type are not allowed in identifier-list
 fail_compilation/alignas2.c(121): Error: no alignment-specifier for bit field declaration
 fail_compilation/alignas2.c(122): Error: no alignment-specifier for bit field declaration
 ---


### PR DESCRIPTION
…pe gives circular reference error

The fix is do the same thing for other declarations as was done for typedefs.