### PR TITLE
Fix issue 23021 - infer `return scope` from `pure nothrow`

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2028,7 +2028,9 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
             //printf("type: %s\n", arg.type.toChars());
             //printf("param: %s\n", p.toChars());
 
-            if (firstArg && p.storageClass & STC.return_)
+            const pStc = tf.parameterStorageClass(tthis, p);
+
+            if (firstArg && (pStc & STC.return_))
             {
                 /* Argument value can be assigned to firstArg.
                  * Check arg to see if it matters.
@@ -2036,7 +2038,9 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                 if (global.params.useDIP1000 == FeatureState.enabled)
                     err |= checkParamArgumentReturn(sc, firstArg, arg, p, false);
             }
-            else if (tf.parameterEscapes(tthis, p))
+            // Allow 'lazy' to imply 'scope' - lazy parameters can be passed along
+            // as lazy parameters to the next function, but that isn't escaping.
+            else if (!(pStc & (STC.scope_ | STC.lazy_)))
             {
                 /* Argument value can escape from the called function.
                  * Check arg to see if it matters.
@@ -2044,7 +2048,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                 if (global.params.useDIP1000 == FeatureState.enabled)
                     err |= checkParamArgumentEscape(sc, fd, p, arg, false, false);
             }
-            else if (!(p.storageClass & STC.return_))
+            else if (!(pStc & STC.return_))
             {
                 /* Argument value cannot escape from the called function.
                  */

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3623,7 +3623,6 @@ public:
     void purityLevel();
     bool hasLazyParameters();
     bool isDstyleVariadic() const;
-    bool parameterEscapes(Type* tthis, Parameter* p);
     StorageClass parameterStorageClass(Type* tthis, Parameter* p);
     Type* addStorageClass(StorageClass stc);
     Type* substWildTo(uint32_t _param_0);

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -608,7 +608,6 @@ public:
     void purityLevel();
     bool hasLazyParameters();
     bool isDstyleVariadic() const;
-    bool parameterEscapes(Parameter *p);
     StorageClass parameterStorageClass(Parameter *p);
     Type *addStorageClass(StorageClass stc);
 

--- a/test/fail_compilation/retscope6.d
+++ b/test/fail_compilation/retscope6.d
@@ -201,8 +201,8 @@ void hmac(scope ubyte[] secret)
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(12011): Error: reference to local variable `x` assigned to non-scope parameter `r` calling retscope6.escape_m_20150
-fail_compilation/retscope6.d(12022): Error: reference to local variable `x` assigned to non-scope parameter `r` calling retscope6.escape_c_20150
+fail_compilation/retscope6.d(12011): Error: returning `escape_m_20150(& x)` escapes a reference to local variable `x`
+fail_compilation/retscope6.d(12022): Error: returning `escape_c_20150(& x)` escapes a reference to local variable `x`
 ---
 */
 
@@ -210,23 +210,23 @@ fail_compilation/retscope6.d(12022): Error: reference to local variable `x` assi
 
 // https://issues.dlang.org/show_bug.cgi?id=20150
 
-int* escape_m_20150(int* r) @safe pure
+int* escape_m_20150(int* r) @safe pure nothrow
 {
     return r;
 }
 
-int* f_m_20150() @safe
+int* f_m_20150() @safe nothrow
 {
     int x = 42;
     return escape_m_20150(&x);
 }
 
-const(int)* escape_c_20150(const int* r) @safe pure
+const(int)* escape_c_20150(const int* r) @safe pure nothrow
 {
     return r;
 }
 
-const(int)* f_c_20150() @safe
+const(int)* f_c_20150() @safe nothrow
 {
     int x = 42;
     return escape_c_20150(&x);
@@ -250,4 +250,40 @@ void escape_throw_20150() @safe
 {
     immutable(char)[4] str;
     f_throw(str[]);
+}
+
+/* TEST_OUTPUT:
+---
+fail_compilation/retscope6.d(14019): Error: scope variable `scopePtr` assigned to non-scope parameter `x` calling retscope6.noInfer23021
+fail_compilation/retscope6.d(14022): Error: scope variable `scopePtr` may not be returned
+---
+*/
+
+#line 14000
+// https://issues.dlang.org/show_bug.cgi?id=23021
+
+ref int infer23021(ref int* x) @safe pure nothrow
+{
+    return *x;
+}
+
+ref int noInfer23021(ref int* x, const(int)** escapeHole = null) @safe pure nothrow
+{
+    *escapeHole = x;
+    return *x;
+}
+
+ref int escape23021() @safe
+{
+    scope int* scopePtr;
+    int* nonScopePtr = null;
+
+    // don't infer scope
+    cast(void) noInfer23021(scopePtr); // error
+
+    // ensure we infer return scope
+    return infer23021(scopePtr); // error
+
+    // ensure we do not infer return ref
+    return infer23021(nonScopePtr); // no error
 }

--- a/test/runnable/testscope.d
+++ b/test/runnable/testscope.d
@@ -242,22 +242,6 @@ void test7435() {
 
 /********************************************/
 
-char[] dup12()(char[] a) // although inferred pure, don't infer a is 'return'
-{
-    char[] res;
-    foreach (ref e; a)
-    {}
-    return res;
-}
-
-char[] foo12()
-{
-    char[10] buf;
-    return dup12(buf);
-}
-
-/********************************************/
-
 void test7049() @safe
 {
     int count = 0;


### PR DESCRIPTION
Since we have `STC.returnScope` now, the "spurious error messages escaping references" should be gone.