### PR TITLE
dshell: Don't generate intermediate source files

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -53,7 +53,7 @@ enum TestTools
     unitTestRunner = TestTool("unit_test_runner", [toolsDir.buildPath("paths")]),
     testRunner = TestTool("d_do_test", ["-I" ~ toolsDir, "-i", "-version=NoMain"]),
     jsonSanitizer = TestTool("sanitize_json"),
-    dshellPrebuilt = TestTool("dshell_prebuilt", null, Yes.linksWithTests),
+    dshellPrebuilt = TestTool("dshell", null, Yes.linksWithTests),
 }
 
 immutable struct TestTool
@@ -264,18 +264,14 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
     shared uint failCount = 0;
     foreach (tool; tools.parallel(1))
     {
+        const string sourceFile = toolsDir.buildPath(tool ~ ".d");
+
         string targetBin;
-        string sourceFile;
         if (tool.linksWithTests)
-        {
             targetBin = resultsDir.buildPath(tool).objName;
-            sourceFile = toolsDir.buildPath(tool, tool ~ ".d");
-        }
         else
-        {
             targetBin = resultsDir.buildPath(tool).exeName;
-            sourceFile = toolsDir.buildPath(tool ~ ".d");
-        }
+
         if (targetBin.timeLastModified.ifThrown(SysTime.init) >= sourceFile.timeLastModified)
             log("%s is already up-to-date", tool);
         else
@@ -304,7 +300,7 @@ void ensureToolsExists(const string[string] env, const TestTool[] tools ...)
                 command = [
                     hostDMD,
                     "-m"~model,
-                    "-of"~targetBin,
+                    "-of="~targetBin,
                     sourceFile
                 ] ~ getPicFlags(env) ~ tool.extraArgs;
             }

--- a/test/tools/dshell.d
+++ b/test/tools/dshell.d
@@ -1,7 +1,7 @@
 /**
 A small library to help write D shell-like test scripts.
 */
-module dshell_prebuilt;
+module dshell;
 
 public import core.stdc.stdlib : exit;
 
@@ -17,6 +17,11 @@ public import std.file;
 public import std.regex;
 public import std.stdio;
 public import std.process;
+
+shared static this()
+{
+    dshellPrebuiltInit("dshell", environment["TEST_NAME"]);
+}
 
 /**
 Emulates bash environment variables. Variables set here will be availble for BASH-like expansion.


### PR DESCRIPTION
Simply declare the module constructor inside of the library and pass
the test name as an environment variable. This simplifies the code
and avoids additional IO.

The `dshell_prebuilt.d` file was renamed to `dshell.d` s.t. the keep
existing tests unchanged (they use `import dshell;`).

Extracted from #13981 