### PR TITLE
chore(console): make isatty extern signature private 

### DIFF
--- a/src/dmd/console.d
+++ b/src/dmd/console.d
@@ -13,13 +13,14 @@
 module dmd.console;
 
 import core.stdc.stdio;
-extern (C) int isatty(int) nothrow;
 
 version (Windows)
 {
     import core.sys.windows.winbase;
     import core.sys.windows.wincon;
     import core.sys.windows.windef;
+
+    private extern (C) int isatty(int) @trusted @nogc nothrow;
 }
 else version (Posix)
 {


### PR DESCRIPTION
    It's also annotated as a @trusted @nogc nothrow interface.
    
    Reference: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/posix-isatty?view=msvc-170
    Signed-off-by: Luís Ferreira <contact@lsferreira.net>