### PR TITLE
Fix issue 22635 - opCast prevent calling destructor for const this

### DIFF
--- a/src/dmd/astenums.d
+++ b/src/dmd/astenums.d
@@ -28,6 +28,7 @@ enum Baseok : ubyte
 
 enum MODFlags : int
 {
+    none         = 0,    // default (mutable)
     const_       = 1,    // type is const
     immutable_   = 4,    // type is immutable
     shared_      = 2,    // type is shared

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -912,8 +912,8 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
                 ex = new DotVarExp(loc, ex, v);
 
                 // This is a hack so we can call destructors on const/immutable objects.
-                // Do it as a type 'paint'.
-                ex = new CastExp(loc, ex, v.type.mutableOf());
+                // Do it as a type 'paint', `cast()`
+                ex = new CastExp(loc, ex, MODFlags.none);
                 if (stc & STC.safe)
                     stc = (stc & ~STC.safe) | STC.trusted;
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -4513,6 +4513,7 @@ extern Type* typeSemantic(Type* type, const Loc& loc, Scope* sc);
 
 enum class MODFlags
 {
+    none = 0,
     const_ = 1,
     immutable_ = 4,
     shared_ = 2,

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -109,6 +109,7 @@ enum class TY : uint8_t
  */
 enum MODFlags
 {
+    MODnone      = 0, // default (mutable)
     MODconst     = 1, // type is const
     MODimmutable = 4, // type is immutable
     MODshared    = 2, // type is shared

--- a/test/compilable/test22635.d
+++ b/test/compilable/test22635.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=22635
+// opCast prevent calling destructor for const this
+
+struct Foo
+{
+    bool opCast(T : bool)() const { assert(0); }
+    ~this() {}
+}
+
+struct Bar
+{
+    const Foo foo;
+}


### PR DESCRIPTION
Rewrite it as `cast() const(T)(...)` instead of `cast(T) const(T)(...)` so it doesn't look for operator overloading in expression semantic.