### PR TITLE
Fix issue 22922 - Support empty array literal in -betterC

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -3933,7 +3933,7 @@ elem* toElem(Expression e, IRState *irs)
             e = ExpressionsToStaticArray(irs, ale.loc, ale.elements, &stmp, 0, ale.basis);
             e = el_combine(e, el_ptr(stmp));
         }
-        else if (ale.elements)
+        else if (ale.elements && dim)
         {
             /* Instead of passing the initializers on the stack, allocate the
              * array and assign the members inline.
@@ -3949,12 +3949,7 @@ elem* toElem(Expression e, IRState *irs)
             Symbol *stmp = symbol_genauto(Type_toCtype(Type.tvoid.pointerTo()));
             e = el_bin(OPeq, TYnptr, el_var(stmp), e);
 
-            /* Note: Even if dm == 0, the druntime function will be called so
-             * GC heap may be allocated. However, currently it's implemented
-             * to return null for 0 length.
-             */
-            if (dim)
-                e = el_combine(e, ExpressionsToStaticArray(irs, ale.loc, ale.elements, &stmp, 0, ale.basis));
+            e = el_combine(e, ExpressionsToStaticArray(irs, ale.loc, ale.elements, &stmp, 0, ale.basis));
 
             e = el_combine(e, el_var(stmp));
         }

--- a/test/compilable/betterCarray.d
+++ b/test/compilable/betterCarray.d
@@ -26,3 +26,10 @@ void issue19234()
     A[10] b;
     b[] = a[];
 }
+
+/**********************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22922
+void issue22922()
+{
+    int[] x = [];
+}


### PR DESCRIPTION
I don't see why a call to `_d_arrayliteralTX` needs to be made for `[]` if it just returns `null`. LDC doesn't do it.