### PR TITLE
fix Issue 23011 - importC: asm label to set symbol name doesn't work …

### DIFF
--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -136,7 +136,7 @@ Symbol *toSymbol(Dsymbol s)
             const(char)[] id = vd.ident.toString();
             if (vd.isDataseg())
             {
-                if (!(vd.linkage == LINK.c && vd.isCsymbol() && vd.storage_class & STC.extern_))
+                if (!(vd.linkage == LINK.c && vd.isCsymbol() && vd.storage_class & STC.extern_) || vd.mangleOverride)
                 {
                     mangleToBuffer(vd, &buf);
                     id = buf.peekChars()[0..buf.length]; // symbol_calloc needs zero termination
@@ -334,7 +334,7 @@ Symbol *toSymbol(Dsymbol s)
 
         override void visit(FuncDeclaration fd)
         {
-            const(char)* id = (fd.linkage == LINK.c && fd.isCsymbol())
+            const(char)* id = (fd.linkage == LINK.c && fd.isCsymbol() && !fd.mangleOverride)
                         ? fd.ident.toChars()
                         : mangleExact(fd);
 

--- a/test/runnable/test23011.c
+++ b/test/runnable/test23011.c
@@ -1,0 +1,14 @@
+/* DISABLED: win32 win32mscoff win64
+ */
+
+/* https://issues.dlang.org/show_bug.cgi?id=23011
+ */
+
+extern char **myenviron asm("environ");
+int myprintf(char *, ...) asm("printf");
+int main()
+{
+    void *p = &myenviron;
+    myprintf("%p\n", p);
+    return 0;
+}


### PR DESCRIPTION
…with externs

Applied patch https://issues.dlang.org/attachment.cgi?id=1845&action=diff

Disabled it for Windows because of different name mangling there.