### PR TITLE
dsymbol: make imported scopes and visibility properties public via accessors

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1641,6 +1641,32 @@ public:
         }
     }
 
+
+    /*****************************************
+     * Returns: the symbols whose members have been imported, i.e. imported modules
+     * and template mixins.
+     *
+     * See_Also: importScope
+     */
+    extern (D) final Dsymbols* getImportedScopes() nothrow @nogc @safe pure
+    {
+        return importedScopes;
+    }
+
+    /*****************************************
+     * Returns: the array of visibilities associated with each imported scope. The
+     * length of the array matches the imported scopes array.
+     *
+     * See_Also: getImportedScopes
+     */
+    extern (D) final Visibility.Kind[] getImportVisibilities() nothrow @nogc @safe pure
+    {
+        if (!importedScopes)
+            return null;
+
+        return (() @trusted => visibilities[0 .. importedScopes.dim])();
+    }
+
     extern (D) final void addAccessiblePackage(Package p, Visibility visibility) nothrow
     {
         auto pary = visibility.kind == Visibility.Kind.private_ ? &privateAccessiblePackages : &accessiblePackages;

--- a/test/unit/semantic/imports.d
+++ b/test/unit/semantic/imports.d
@@ -1,0 +1,53 @@
+module semantic.imports;
+
+import std.algorithm;
+import std.typecons;
+
+import dmd.frontend;
+import dmd.dsymbol;
+import dmd.astcodegen;
+import dmd.common.outbuffer;
+
+import support;
+
+@("semantics - imported modules")
+unittest
+{
+    initDMD();
+    defaultImportPaths.each!addImport;
+
+    auto t = parseModule!ASTCodegen("test.d", q{
+        public import std.stdio;
+	import std.file;
+    });
+
+    assert(!t.diagnostics.hasErrors);
+    assert(!t.diagnostics.hasWarnings);
+
+    Tuple!(string, Visibility.Kind)[] imports;
+
+    import std.stdio;
+    t.module_.fullSemantic();
+
+    auto vsym = t.module_.getImportVisibilities();
+
+    foreach(i, sym; *t.module_.getImportedScopes())
+    {
+        if (auto im = sym.isModule())
+        {
+            if (im.md)
+            {
+                auto buf = im.md.toString();
+                imports ~= tuple(buf.idup, vsym[i]);
+
+                import core.stdc.stdlib : free;
+                free(cast(void*)buf.ptr);
+            }
+        }
+    }
+    writeln(imports);
+    assert(imports.any!(a => a == tuple("object", Visibility.Kind.private_))); // implicitly imported
+    assert(imports.any!(a => a == tuple("std.stdio", Visibility.Kind.public_)));
+    assert(imports.any!(a => a == tuple("std.file", Visibility.Kind.private_)));
+    assert(!imports.any!`a[0] == "std.algorithm"`); // not imported
+}


### PR DESCRIPTION
This is useful to crawl ScopeDsymbol's when using libdmd to create rules for
unused public imports.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Is there any strong reason to make this private?