### PR TITLE
fix Issue 23034 - importC: head-const struct confused with multiple f…

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2306,7 +2306,8 @@ extern (C++) Type merge(Type type)
         case Tident:
         case Tinstance:
         case Tmixin:
-            return type;
+        case Ttag:
+            return type;        // don't merge placeholder types
 
         case Tsarray:
             // prevents generating the mangle if the array dim is not yet known

--- a/test/compilable/imports/test23034b.c
+++ b/test/compilable/imports/test23034b.c
@@ -1,0 +1,8 @@
+struct S2 {
+	int field2;
+};
+void fn()
+{
+	struct S2 *const s;
+	int x = s->field2; // here
+}

--- a/test/compilable/test23034.c
+++ b/test/compilable/test23034.c
@@ -1,0 +1,6 @@
+// EXTRA_SOURCES: imports/test23034b.c
+
+struct S1 {
+        int field1;
+};
+struct S1 *const unused;


### PR DESCRIPTION
…iles on command line

I for sure thought this was memory corruption, and so went looking in all the wrong places. But it's not. It's still an ugly ugly bug, and am happy to have it fixed.