### PR TITLE
fix Issue 23044 - importC: comma expression with function call parsed…

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -213,16 +213,12 @@ final class CParser(AST) : Parser!AST
                     goto Lexp;
 
                 case TOK.leftParenthesis:
-                {
-                    /* If tokens look like a function call, assume it is one,
-                     * As any type-name won't be resolved until semantic, this
-                     * could be rewritten later.
-                     */
-                    auto tk = &token;
-                    if (isFunctionCall(tk))
-                        goto Lexp;
-                    goto default;
-                }
+                    if (auto pt = lookupTypedef(token.ident))
+                    {
+                        if (*pt)
+                            goto Ldeclaration;
+                    }
+                    goto Lexp;  // function call
 
                 default:
                 {

--- a/test/compilable/test23044.c
+++ b/test/compilable/test23044.c
@@ -1,0 +1,9 @@
+/* https://issues.dlang.org/show_bug.cgi?id=23044
+ */
+
+void other(int x){}
+void fn()
+{
+	int x;
+	other(x), x = 1;
+}

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -18,14 +18,9 @@ fail_compilation/failcstuff2.c(126): Error: `makeS22067().field` is not an lvalu
 fail_compilation/failcstuff2.c(127): Error: `makeS22067().field` is not an lvalue and cannot be modified
 fail_compilation/failcstuff2.c(153): Error: `cast(short)var` is not an lvalue and cannot be modified
 fail_compilation/failcstuff2.c(154): Error: `cast(long)var` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(254): Error: identifier or `(` expected before `)`
-fail_compilation/failcstuff2.c(255): Error: identifier or `(` expected
 fail_compilation/failcstuff2.c(308): Error: cannot modify `const` expression `(*s).p`
 fail_compilation/failcstuff2.c(354): Error: variable `arr` cannot be read at compile time
 fail_compilation/failcstuff2.c(360): Error: variable `str` cannot be read at compile time
-fail_compilation/failcstuff2.c(404): Error: undefined identifier `p1`
-fail_compilation/failcstuff2.c(404): Error: undefined identifier `p2`
-fail_compilation/failcstuff2.c(458): Error: cannot take address of bit-field `field`
 ---
 */
 
@@ -88,17 +83,6 @@ void test22068()
 }
 
 /***************************************************/
-// https://issues.dlang.org/show_bug.cgi?id=22102
-#line 250
-typedef int int22102;
-
-void test22102()
-{
-    int22102();
-    int22102(0);
-}
-
-/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=22405
 #line 300
 struct S22405
@@ -126,28 +110,4 @@ void test22413b()
 {
     const char *str = "hello";
     char msg[] = str;
-}
-
-/***************************************************/
-// https://issues.dlang.org/show_bug.cgi?id=22584
-#line 400
-long test22584(long p1, long p2);
-
-long test22584(long, long)
-{
-    return p1 + p2;
-}
-
-/***************************************************/
-// https://issues.dlang.org/show_bug.cgi?id=22749
-#line 450
-struct S22749
-{
-    int field : 1;
-};
-
-void test22749(void)
-{
-    struct S22749 s;
-    void *ptr = &s.field;
 }

--- a/test/fail_compilation/failcstuff5.c
+++ b/test/fail_compilation/failcstuff5.c
@@ -1,0 +1,32 @@
+// check semantic analysis of C files
+/* TEST_OUTPUT:
+---
+fail_compilation/failcstuff5.c(404): Error: undefined identifier `p1`
+fail_compilation/failcstuff5.c(404): Error: undefined identifier `p2`
+fail_compilation/failcstuff5.c(458): Error: cannot take address of bit-field `field`
+---
+*/
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22584
+#line 400
+long test22584(long p1, long p2);
+
+long test22584(long, long)
+{
+    return p1 + p2;
+}
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22749
+#line 450
+struct S22749
+{
+    int field : 1;
+};
+
+void test22749(void)
+{
+    struct S22749 s;
+    void *ptr = &s.field;
+}

--- a/test/fail_compilation/test22102.c
+++ b/test/fail_compilation/test22102.c
@@ -1,0 +1,18 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test22102.c(254): Error: identifier or `(` expected
+fail_compilation/test22102.c(254): Error: found `;` when expecting `)`
+fail_compilation/test22102.c(255): Error: `=`, `;` or `,` expected to end declaration instead of `int22102`
+---
+*/
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22102
+
+#line 250
+typedef int int22102;
+
+void test22102()
+{
+    int22102();
+    int22102(0);
+}


### PR DESCRIPTION
… as declaration

My attempt to parse C without a symbol table is a complete failure.