### PR TITLE
ImportC: add __check(assign-expression) extension

### DIFF
--- a/changelog/dmd.check.dd
+++ b/changelog/dmd.check.dd
@@ -1,0 +1,14 @@
+Add __check(assign-expression) to ImportC
+
+C code normally relies on `#include <assert.h>` to add support for assert's. D has them builtin to the
+language, which is much more convenient and does not rely on a preprocessor. This extension adds
+
+---
+__check(assign-expression)
+---
+
+as an expression to ImportC. The compiler switch -checkaction=C gives it the same behavior
+as C's assert macro. If the compiler switch -release is thrown, the `__check`'s are ignored.
+The `__check` expressions are handy for writing C programs that are free of reliance on `#include`.
+
+`__assert` is not used due to conflicts with some C .h files.

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -268,6 +268,7 @@ final class CParser(AST) : Parser!AST
         case TOK.minusMinus:
         case TOK.sizeof_:
         case TOK._Generic:
+        case TOK._assert:
         Lexp:
             auto exp = cparseExpression();
             if (token.value == TOK.identifier && exp.op == EXP.identifier)
@@ -780,6 +781,14 @@ final class CParser(AST) : Parser!AST
 
         case TOK._Generic:
             e = cparseGenericSelection();
+            break;
+
+        case TOK._assert:  // __check(assign-exp) extension
+            nextToken();
+            check(TOK.leftParenthesis, "`__check`");
+            e = parseAssignExp();
+            check(TOK.rightParenthesis);
+            e = new AST.AssertExp(loc, e, null);
             break;
 
         default:

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1814,13 +1814,14 @@ enum class TOK : uint8_t
     _Noreturn = 212u,
     _Static_assert = 213u,
     _Thread_local = 214u,
-    _import = 215u,
-    __cdecl_ = 216u,
-    __declspec_ = 217u,
-    __stdcall_ = 218u,
-    __pragma_ = 219u,
-    __int128_ = 220u,
-    __attribute___ = 221u,
+    _assert = 215u,
+    _import = 216u,
+    __cdecl_ = 217u,
+    __declspec_ = 218u,
+    __stdcall_ = 219u,
+    __pragma_ = 220u,
+    __int128_ = 221u,
+    __attribute___ = 222u,
 };
 
 enum class MemorySet

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -269,6 +269,7 @@ enum TOK : ubyte
     _Thread_local,
 
     // C only extended keywords
+    _assert,
     _import,
     __cdecl,
     __declspec,
@@ -580,6 +581,7 @@ private immutable TOK[] keywords =
     TOK._Thread_local,
 
     // C only extended keywords
+    TOK._assert,
     TOK._import,
     TOK.__cdecl,
     TOK.__declspec,
@@ -615,7 +617,8 @@ static immutable TOK[TOK.max + 1] Ckeywords =
                        union_, unsigned, void_, volatile, while_, asm_, typeof_,
                        _Alignas, _Alignof, _Atomic, _Bool, _Complex, _Generic, _Imaginary, _Noreturn,
                        _Static_assert, _Thread_local,
-                       _import, __cdecl, __declspec, __stdcall, __pragma, __int128, __attribute__ ];
+                       _import, __cdecl, __declspec, __stdcall, __pragma, __int128, __attribute__,
+                       _assert ];
 
         foreach (kw; Ckwds)
             tab[kw] = cast(TOK) kw;
@@ -881,6 +884,7 @@ extern (C++) struct Token
         TOK._Thread_local  : "_Thread_local",
 
         // C only extended keywords
+        TOK._assert       : "__check",
         TOK._import       : "__import",
         TOK.__cdecl        : "__cdecl",
         TOK.__declspec     : "__declspec",

--- a/compiler/src/dmd/tokens.h
+++ b/compiler/src/dmd/tokens.h
@@ -278,6 +278,7 @@ enum class TOK : unsigned char
     _Thread_local_,
 
     // C only extended keywords
+    _assert,
     _import,
     cdecl_,
     declspec,

--- a/compiler/test/unit/lexer/location_offset.d
+++ b/compiler/test/unit/lexer/location_offset.d
@@ -536,6 +536,7 @@ enum ignoreTokens
     _Static_assert,
     _Thread_local,
 
+    _assert,
     _import,
     __cdecl,
     __declspec,

--- a/test/runnable/testcheck.c
+++ b/test/runnable/testcheck.c
@@ -1,0 +1,7 @@
+
+int main()
+{
+    int i = 3;
+    __check(i == 3);
+    return 0;
+}


### PR DESCRIPTION
Trying to use `assert` in ImportC without the preprocessor gets tiresome, so I added __assert as an extension.