### PR TITLE
Amend prior fix for issue 22877

### DIFF
--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -573,7 +573,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
         }
         else if (sc.flags & SCOPE.Cfile && i.exp.isStringExp() &&
             tta && (tta.next.ty == Tint8 || tta.next.ty == Tuns8) &&
-            ti.ty == Tpointer && ti.nextOf().ty == Tchar)
+            ti.ty == Tsarray && ti.nextOf().ty == Tchar)
         {
             /* unsigned char bbb[1] = "";
              *   signed char ccc[1] = "";

--- a/test/compilable/test22877.c
+++ b/test/compilable/test22877.c
@@ -3,5 +3,12 @@
 int array[3];
 _Static_assert(sizeof(array) == 3 * sizeof(int), "array");
 
-_Static_assert(sizeof("a") == 2, "string");
-_Static_assert((sizeof(L"ab") == 3 * 2) || (sizeof(L"ab") == 3 * 4), "wstring");
+_Static_assert(sizeof("ab") == 3, "string");
+_Static_assert((sizeof(L"ab") == 3 * sizeof(short)) ||
+               (sizeof(L"ab") == 3 * sizeof(int)), "wstring");
+_Static_assert(sizeof(u8"ab") == 3, "UTF-8 string");
+_Static_assert(sizeof(u"ab") == 3 * sizeof(short), "UTF-16 string");
+_Static_assert(sizeof(U"ab") == 3 * sizeof(int), "UTF-32 string");
+
+_Static_assert(sizeof(&"ab") == sizeof(void*), "pointer");
+_Static_assert(sizeof(*&"ab") == 3, "pointer deref");


### PR DESCRIPTION
Aligns ImportC's treatment of string literals with C11 by typing them as static arrays (also fixing [an issue with typeof](https://github.com/dlang/dmd/pull/14000#issuecomment-1101805029).)
Also fixes `typeof(&"")` returning string length instead of pointer size.