### PR TITLE
Expand fix for issue 22070 to also allow array literals as lvalues

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -6119,7 +6119,7 @@ public:
             return;
         }
 
-        if (result.isStringExp())
+        if (result.isStringExp() || result.isArrayLiteralExp())
             return;
 
         if (result.op != EXP.address)

--- a/test/fail_compilation/test22070.c
+++ b/test/fail_compilation/test22070.c
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test22070.c(10): Error: `&""` is not an lvalue and cannot be modified
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22070
+
+char(**s1)[3] = &(&"");

--- a/test/runnable/test22070_2.c
+++ b/test/runnable/test22070_2.c
@@ -3,8 +3,9 @@
 int printf(const char *, ...);
 
 char(*var)[4] = &"123";
+short(*var2)[2] = &(short[]){1, 2};
 
-char test()
+char test(void)
 {
    char(*bar)[4] = &"456";
    return (*bar)[1];
@@ -12,7 +13,7 @@ char test()
 
 _Static_assert(test() == '5', "in");
 
-char test2()
+char test2(void)
 {
    char(*bar)[4] = &"456";
    return 1[*bar];
@@ -20,13 +21,25 @@ char test2()
 
 _Static_assert(test2() == '5', "in");
 
+short test3(void)
+{
+    short(*bar)[2] = &(short[]){1, 2};
+    return (*bar)[1];
+}
+
+_Static_assert(test3() == 2, "");
+
 int main()
 {
     if ((*var)[2] != '3')
         return 1;
+    if ((*var2)[1] != 2)
+        return 1;
     if (test() != '5')
         return 1;
     if (test2() != '5')
+        return 1;
+    if (test3() != 2)
         return 1;
     return 0;
 }


### PR DESCRIPTION
Additionally checks for and restricts nested address-of expressions on string/array literals, such as `&(&"")`

This depends on #14027, test failures are expected for now.