### PR TITLE
C++: Use d_size_t instead of size_t for 32-bit Darwin support

### DIFF
--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -373,11 +373,11 @@ public:
     OwnedBy ownedByCtfe;
 
     static StringExp *create(const Loc &loc, const char *s);
-    static StringExp *create(const Loc &loc, const void *s, size_t len);
+    static StringExp *create(const Loc &loc, const void *s, d_size_t len);
     static void emplace(UnionExp *pue, const Loc &loc, const char *s);
     bool equals(const RootObject *o) const;
-    char32_t getCodeUnit(size_t i) const;
-    void setCodeUnit(size_t i, char32_t c);
+    char32_t getCodeUnit(d_size_t i) const;
+    void setCodeUnit(d_size_t i, char32_t c);
     StringExp *toStringExp();
     StringExp *toUTF8(Scope *sc);
     Optional<bool> toBool();

--- a/src/dmd/root/port.h
+++ b/src/dmd/root/port.h
@@ -13,12 +13,13 @@
 // The idea is to minimize #ifdef's in the app code.
 
 #include "dsystem.h"
+#include "dcompat.h"
 
 typedef unsigned char utf8_t;
 
 struct Port
 {
-    static int memicmp(const char *s1, const char *s2, size_t n);
+    static int memicmp(const char *s1, const char *s2, d_size_t n);
     static char *strupr(char *s);
 
     static bool isFloat32LiteralOutOfRange(const char *s);
@@ -30,5 +31,5 @@ struct Port
     static unsigned readlongBE(const void *buffer);
     static unsigned readwordLE(const void *buffer);
     static unsigned readwordBE(const void *buffer);
-    static void valcpy(void *dst, uint64_t val, size_t size);
+    static void valcpy(void *dst, uint64_t val, d_size_t size);
 };


### PR DESCRIPTION
Darwin defines `size_t` as `long unsigned int`, which doesn't match [cppmangle](https://github.com/dlang/dmd/blob/1b6f9efb374c445bac401a69aac127eda91846af/src/dmd/cppmangle.d#L1760-L1765)'s logic when compiling for i686-apple-darwin14 (macOS 10.10).