### PR TITLE
Fix issue 23068 - BetterC does not respect -checkaction=halt

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -2665,7 +2665,9 @@ private void reconcileCommands(ref Param params, ref Target target)
 
     if (params.betterC)
     {
-        params.checkAction = CHECKACTION.C;
+        if (params.checkAction != CHECKACTION.halt)
+            params.checkAction = CHECKACTION.C;
+
         params.useModuleInfo = false;
         params.useTypeInfo = false;
         params.useExceptions = false;

--- a/test/compilable/test23068.d
+++ b/test/compilable/test23068.d
@@ -1,0 +1,19 @@
+/*
+DISABLED: osx
+REQUIRED_ARGS: -vasm -betterC -checkaction=halt
+TEST_OUTPUT:
+---
+main:
+0000:   0F 0B                    ud2
+0002:   31 C0                    xor       EAX,EAX
+0004:   C3                       ret
+---
+*/
+
+// Issue 23068 - [betterC] BetterC does not respect -checkaction=halt
+// https://issues.dlang.org/show_bug.cgi?id=23068
+
+extern(C) void main()
+{
+    assert(0);
+}


### PR DESCRIPTION
The test is a bit dubious, since it assumes this exact x86 code to be emitted, but there are no tests for -checkaction=halt yet so I'm improvising here.