### PR TITLE
refactor: Replace toParentXXX.isAggregateDeclaration with isMemberXXX

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1506,7 +1506,7 @@ extern (C++) class VarDeclaration : Declaration
         uint oldgag = global.gag;
         if (global.gag)
         {
-            Dsymbol sym = toParent().isAggregateDeclaration();
+            Dsymbol sym = isMember();
             if (sym && !sym.isSpeculative())
                 global.gag = 0;
         }

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2834,7 +2834,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
          */
         //if (!sc.func && Module.deferred.dim > deferred_dim) {}
 
-        AggregateDeclaration ad = tm.toParent().isAggregateDeclaration();
+        AggregateDeclaration ad = tm.isMember();
         if (sc.func && !ad)
         {
             tm.semantic2(sc2);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3261,7 +3261,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // to fix https://issues.dlang.org/show_bug.cgi?id=9490
             VarExp ve = e.isVarExp();
             if (ve && ve.var && exp.parens && !ve.var.isStatic() && !(sc.stc & STC.static_) &&
-                sc.func && sc.func.needThis && ve.var.toParent2().isAggregateDeclaration())
+                sc.func && sc.func.needThis && ve.var.isMember2())
             {
                 // printf("apply fix for issue 9490: add `this.` to `%s`...\n", e.toChars());
                 e = new DotVarExp(exp.loc, new ThisExp(exp.loc), ve.var, false);
@@ -4677,7 +4677,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             if (exp.f.needThis())
             {
-                AggregateDeclaration ad = exp.f.toParentLocal().isAggregateDeclaration();
+                AggregateDeclaration ad = exp.f.isMemberLocal();
                 ue.e1 = getRightThis(exp.loc, sc, ad, ue.e1, exp.f);
                 if (ue.e1.op == EXP.error)
                 {
@@ -6688,7 +6688,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         e.type = e.type.typeSemantic(e.loc, sc);
 
         FuncDeclaration f = e.func.toAliasFunc();
-        AggregateDeclaration ad = f.toParentLocal().isAggregateDeclaration();
+        AggregateDeclaration ad = f.isMemberLocal();
         if (f.needThis())
             e.e1 = getRightThis(e.loc, sc, ad, e.e1, f);
         if (e.e1.op == EXP.error)

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -53,7 +53,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
     {
         if (sc.intypeof || !sc.func || !sc.func.isSafeBypassingInference())
             return false;
-        auto ad = v.toParent2().isAggregateDeclaration();
+        auto ad = v.isMember2();
         if (!ad)
             return false;
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3391,7 +3391,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 v.dsymbolSemantic(null);
                 if (v.isField())
                 {
-                    auto ad = v.toParent().isAggregateDeclaration();
+                    auto ad = v.isMember();
                     objc.checkOffsetof(e, ad);
                     ad.size(e.loc);
                     if (ad.sizeok != Sizeok.done)


### PR DESCRIPTION
The `isMemberXXX` functions do the exact same operation.