### PR TITLE
test/compilable/test17434a.d: Add missing EXTRA_FILES directive

### DIFF
--- a/test/compilable/test17434a.d
+++ b/test/compilable/test17434a.d
@@ -1,3 +1,4 @@
+// EXTRA_FILES: imports/imp17434a.d imports/imp17434b.d
 module test17434a;
 
 private import imports.imp17434a;


### PR DESCRIPTION
Used by gdc's dejagnu testing framework.