### PR TITLE
dmd.cpreprocess: Don't delete non-generated files

### DIFF
--- a/src/dmd/cpreprocess.d
+++ b/src/dmd/cpreprocess.d
@@ -33,11 +33,12 @@ import dmd.root.string;
  * Preprocess C file.
  * Params:
  *      csrcfile = C file to be preprocessed, with .c or .h extension
+ *      ifile = set to true if an output file was written
  * Result:
  *      filename of output
  */
 extern (C++)
-FileName preprocess(FileName csrcfile)
+FileName preprocess(FileName csrcfile, out bool ifile)
 {
     //printf("preprocess %s\n", csrcfile.toChars());
     version (Posix)
@@ -52,6 +53,7 @@ FileName preprocess(FileName csrcfile)
             error(Loc.initial, "C preprocess failed for file %s, exit status %d\n", csrcfile.toChars(), status);
             fatal();
         }
+        ifile = true;
         return FileName(ifilename);
     }
     else version (Windows)

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -677,8 +677,7 @@ extern (C++) final class Module : Package
             FileName.equalsExt(srcfile.toString(), c_ext) &&
             FileName.exists(srcfile.toString()))
         {
-            filename = global.preprocess(srcfile);  // run C preprocessor
-            ifile = true;
+            filename = global.preprocess(srcfile, ifile);  // run C preprocessor
         }
 
         if (auto result = global.fileManager.lookup(filename))

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -829,7 +829,7 @@ struct Global final
     FileManager* fileManager;
     enum : int32_t { recursionLimit = 500 };
 
-    FileName(*preprocess)(FileName );
+    FileName(*preprocess)(FileName , bool );
     uint32_t startGagging();
     bool endGagging(uint32_t oldGagged);
     void increaseErrorCount();
@@ -5508,7 +5508,7 @@ extern const char* toCppMangleDMC(Dsymbol* s);
 
 extern const char* cppTypeInfoMangleDMC(Dsymbol* s);
 
-extern FileName preprocess(FileName csrcfile);
+extern FileName preprocess(FileName csrcfile, bool ifile);
 
 class ClassReferenceExp final : public Expression
 {

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -300,7 +300,7 @@ extern (C++) struct Global
 
     enum recursionLimit = 500; /// number of recursive template expansions before abort
 
-    extern (C++) FileName function(FileName) preprocess;
+    extern (C++) FileName function(FileName, out bool) preprocess;
 
   nothrow:
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -270,7 +270,7 @@ struct Global
 
     FileManager* fileManager;
 
-    FileName (*preprocess)(FileName);
+    FileName (*preprocess)(FileName, bool&);
 
     /* Start gagging. Return the current number of gagged errors
      */


### PR DESCRIPTION
Moves setting of `ifile` to inside the preprocess callback, so that no-op returns don't result in deleting the original C source file.