### PR TITLE
Fix issue 23079 - be more lenient when taking address of `ref` return

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -280,13 +280,14 @@ bool checkAssocArrayLiteralEscape(Scope *sc, AssocArrayLiteralExp ae, bool gag)
  *      sc = used to determine current function and module
  *      fdc = function being called, `null` if called indirectly
  *      par = function parameter (`this` if null)
+ *      parStc = storage classes of function parameter (may have added `scope` from `pure`)
  *      arg = initializer for param
  *      assertmsg = true if the parameter is the msg argument to assert(bool, msg).
  *      gag = do not print error messages
  * Returns:
  *      `true` if pointers to the stack can escape via assignment
  */
-bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, Expression arg, bool assertmsg, bool gag)
+bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, STC parStc, Expression arg, bool assertmsg, bool gag)
 {
     enum log = false;
     if (log) printf("checkParamArgumentEscape(arg: %s par: %s)\n",
@@ -301,16 +302,19 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, Exp
 
     escapeByValue(arg, &er);
 
+    if (parStc & STC.scope_)
+    {
+        // These errors only apply to non-scope parameters
+        // When the paraneter is `scope`, only `checkTransitiveScope` on `er.byref` is needed
+        er.byfunc.setDim(0);
+        er.byvalue.setDim(0);
+        er.byexp.setDim(0);
+    }
+
     if (!er.byref.dim && !er.byvalue.dim && !er.byfunc.dim && !er.byexp.dim)
         return false;
 
     bool result = false;
-
-    ScopeRef psr;
-    if (par && fdc && fdc.type.isTypeFunction())
-        psr = buildScopeRef(par.storageClass);
-    else
-        psr = ScopeRef.None;
 
     /* 'v' is assigned unsafely to 'par'
      */
@@ -375,16 +379,14 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, Exp
         Dsymbol p = v.toParent2();
 
         notMaybeScope(v);
-
-        if (p == sc.func)
+        if (checkTransitiveScope(v, arg, sc, gag))
         {
-            if (psr == ScopeRef.Scope ||
-                psr == ScopeRef.RefScope ||
-                psr == ScopeRef.ReturnRef_Scope)
-            {
-                continue;
-            }
+            result = true;
+            continue;
+        }
 
+        if (p == sc.func && !(parStc & STC.scope_))
+        {
             unsafeAssign!"reference to local variable"(v);
             continue;
         }
@@ -764,6 +766,12 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag, bool byRef)
         if (log) printf("byref: %s\n", v.toChars());
         if (v.isDataseg())
             continue;
+
+        if (checkTransitiveScope(v, ae, sc, gag))
+        {
+            result = true;
+            continue;
+        }
 
         if (va && va.isScope() && !v.isReference())
         {
@@ -1290,8 +1298,17 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
         Dsymbol p = v.toParent2();
 
         // https://issues.dlang.org/show_bug.cgi?id=19965
-        if (!refs && sc.func.vthis == v)
-            notMaybeScope(v);
+        if (!refs)
+        {
+            if (sc.func.vthis == v)
+                notMaybeScope(v);
+
+            if (checkTransitiveScope(v, e, sc, gag))
+            {
+                result = true;
+                continue;
+            }
+        }
 
         if (!v.isReference())
         {
@@ -2443,4 +2460,39 @@ private bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, con
 private bool setUnsafeDIP1000(Scope* sc, bool gag, Loc loc, const(char)* msg, RootObject arg0 = null, RootObject arg1 = null)
 {
     return setUnsafePreview(sc, global.params.useDIP1000, gag, loc, msg, arg0, arg1);
+}
+
+/***************************************
+ * Check that taking the address of `v` is `@safe` because of transitive scope.
+ *
+ * It's not possible to take the address of a scope variable, because `scope` only applies
+ * to the top level indirection.
+ *
+ * Params:
+ *     v = variable that a reference is created
+ *     e = expression that takes the referene
+ *     sc = used to obtain function / deprecated status
+ *     gag = don't print errors
+ * Returns:
+ *     true if taking the address of `v` is problematic because of the lack of transitive `scope`
+ */
+private bool checkTransitiveScope(VarDeclaration v, Expression e, Scope* sc, bool gag)
+{
+    if (!(v.storage_class & STC.temp) && v.isScope())
+    {
+        if (!e.type)
+            return false;
+
+        Type t = e.type.baseElemOf();
+        if (t.ty == Tarray || t.ty == Tpointer)
+        {
+            if (!t.nextOf().toBasetype().hasPointers())
+                return false;
+        }
+
+        // take address of `scope` variable not allowed, requires transitive scope
+        return sc.setUnsafeDIP1000(gag, e.loc,
+            "cannot take address of `scope` variable `%s` since `scope` applies to first indirection only", v);
+    }
+    return false;
 }

--- a/test/fail_compilation/fail20691.d
+++ b/test/fail_compilation/fail20691.d
@@ -1,12 +1,9 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail20691.d(106): Error: cannot take address of `scope` local `sa` in `@safe` function `bar`
-fail_compilation/fail20691.d(106): Error: cannot cast expression `sa` of type `char[][2]` to `char[][]`
-fail_compilation/fail20691.d(107): Error: cannot take address of `scope` local `sa` in `@safe` function `bar`
-fail_compilation/fail20691.d(107): Error: cannot cast expression `sa` of type `char[][2]` to `char[][]`
-fail_compilation/fail20691.d(108): Error: cannot take address of `scope` local `sa` in `@safe` function `bar`
-fail_compilation/fail20691.d(108): Error: cannot cast expression `sa` of type `char[][2]` to `char[][]`
+fail_compilation/fail20691.d(106): Error: cannot take address of `scope` variable `sa` since `scope` applies to first indirection only
+fail_compilation/fail20691.d(107): Error: cannot take address of `scope` variable `sa` since `scope` applies to first indirection only
+fail_compilation/fail20691.d(108): Error: cannot take address of `scope` variable `sa` since `scope` applies to first indirection only
 ---
 */
 

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -254,7 +254,7 @@ void escape4() @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(266): Error: cannot take address of `scope` local `p` in `@safe` function `escape5`
+fail_compilation/retscope.d(266): Error: cannot take address of `scope` variable `p` since `scope` applies to first indirection only
 ---
 */
 
@@ -331,7 +331,7 @@ int* bar10( scope int** ptr ) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(342): Error: cannot take address of `scope` local `aa` in `@safe` function `escape11`
+fail_compilation/retscope.d(342): Error: cannot take address of `scope` variable `aa` since `scope` applies to first indirection only
 ---
 */
 

--- a/test/fail_compilation/test15191.d
+++ b/test/fail_compilation/test15191.d
@@ -1,12 +1,11 @@
 /* TEST_OUTPUT:
 REQUIRED_ARGS: -preview=dip1000
 ---
-fail_compilation/test15191.d(35): Error: returning `&identity(x)` escapes a reference to local variable `x`
-fail_compilation/test15191.d(41): Error: returning `&identityPtr(x)` escapes a reference to local variable `x`
-fail_compilation/test15191.d(47): Error: cannot take address of `ref return` of `identityPtr()` in `@safe` function `addrOfRefTransitive`
-fail_compilation/test15191.d(47):        return type `int*` has pointers that may be `scope`
-fail_compilation/test15191.d(68): Error: cannot slice static array of `ref return` of `identityArr()` in `@safe` function `sliceOfRefEscape`
-fail_compilation/test15191.d(68):        return type `int*[1]` has pointers that may be `scope`
+fail_compilation/test15191.d(34): Error: returning `&identity(x)` escapes a reference to local variable `x`
+fail_compilation/test15191.d(40): Error: returning `&identityPtr(x)` escapes a reference to local variable `x`
+fail_compilation/test15191.d(46): Error: returning `&identityPtr(x)` escapes a reference to local variable `x`
+fail_compilation/test15191.d(67): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
+fail_compilation/test15191.d(68): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
 ---
 */
 
@@ -61,10 +60,23 @@ ref int*[1] identityArr(return ref scope int*[1] x)
 	return x;
 }
 
-int* sliceOfRefEscape()
+int*[] sliceOfRefEscape()
 {
 	int stackVar = 0xFF;
 	scope int*[1] x = [&stackVar];
 	int*[] y = identityArr(x)[];
-	return y[0];
+	return identityArr(x)[];
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=23079
+int** p;
+
+ref int* get() @safe
+{
+    return *p;
+}
+
+int** g1() @safe
+{
+    return &get();
 }

--- a/test/fail_compilation/test15191.d
+++ b/test/fail_compilation/test15191.d
@@ -5,7 +5,7 @@ fail_compilation/test15191.d(34): Error: returning `&identity(x)` escapes a refe
 fail_compilation/test15191.d(40): Error: returning `&identityPtr(x)` escapes a reference to local variable `x`
 fail_compilation/test15191.d(46): Error: returning `&identityPtr(x)` escapes a reference to local variable `x`
 fail_compilation/test15191.d(67): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
-fail_compilation/test15191.d(68): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
+fail_compilation/test15191.d(69): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
 ---
 */
 
@@ -64,8 +64,9 @@ int*[] sliceOfRefEscape()
 {
 	int stackVar = 0xFF;
 	scope int*[1] x = [&stackVar];
-	int*[] y = identityArr(x)[];
-	return identityArr(x)[];
+	auto y = identityArr(x)[]; // check transitive scope in assignment
+	cast(void) y;
+	return identityArr(x)[]; // check transitive scope in return statement
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=23079

--- a/test/fail_compilation/test20245.d
+++ b/test/fail_compilation/test20245.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 fail_compilation/test20245.d(20): Error: reference to local variable `x` assigned to non-scope parameter `ptr`
 fail_compilation/test20245.d(21): Error: copying `&x` into allocated memory escapes a reference to parameter variable `x`
 fail_compilation/test20245.d(22): Error: scope variable `a` may not be returned
-fail_compilation/test20245.d(26): Error: cannot take address of `scope` parameter `x` in `@safe` function `foo`
+fail_compilation/test20245.d(26): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
 fail_compilation/test20245.d(32): Error: reference to local variable `x` assigned to non-scope parameter `ptr`
 fail_compilation/test20245.d(33): Error: copying `&x` into allocated memory escapes a reference to parameter variable `x`
 fail_compilation/test20245.d(49): Error: reference to local variable `price` assigned to non-scope `this.minPrice`

--- a/test/fail_compilation/test20569.d
+++ b/test/fail_compilation/test20569.d
@@ -1,8 +1,8 @@
 /* REQUIRED_ARGS: -preview=dip1000
    TEST_OUTPUT:
 ---
-fail_compilation/test20569.d(19): Error: cannot take address of `scope` local `s1` in `@safe` function `main`
-fail_compilation/test20569.d(23): Error: cannot take address of `scope` local `s2` in `@safe` function `main`
+fail_compilation/test20569.d(19): Error: cannot take address of `scope` variable `s1` since `scope` applies to first indirection only
+fail_compilation/test20569.d(23): Error: cannot take address of `scope` variable `s2` since `scope` applies to first indirection only
 ---
  */
 


### PR DESCRIPTION
Instead of disallowing slicing or taking the address of `scope` variables in expressionsem, do it in escape.d when the variable is actually escaping through `escapeByRef`. This way, dmd actually looks through function calls to see if a scope variable is actually being returned.

Unfortunately, escape.d is full of code duplication, so the logic has to be put in 3 separate places now: `=` assignment, return statements, and function parameter assignment. Also, `escapeByRef` reduces a struct member `s.x` to the variable `s`, meaning that at that point you don't know whether you're returning a pointer member or non-pointer member:

```D
struct S 
{
    int val;
    int* ptr;
}

void f(scope S s) 
{
    auto x = &s.val; // escape by ref `s`, allowed
    auto y = &s.ptr; // escape by ref `s`, disallowed
}
```
To solve this I add a function `pointerDepth` to see if after one layer of `scope` in the destination type, there are still indirections, in which case the lack of transitive `scope` should generate an error.

This PR is a bit big and messy, still to do:

- deduplicate the error logic from paramEscape / assignEscape / returnEscape
- split off the addition of `pointerDepth()` to a separate PR
- deduplicate `hasPointers()` and `pointerDepth()`. since `hasPointers` is equivalent to `pointerDepth > 0`

**Update**: logic is deduplicated, pointerDepth has been replaced by something simpler.