### PR TITLE
Put error messages inside setUnsafe()

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2782,9 +2782,8 @@ Expression scaleFactor(BinExp be, Scope* sc)
         if (eoff.op == EXP.int64 && eoff.toInteger() == 0)
         {
         }
-        else if (sc.func.setUnsafe())
+        else if (sc.func.setUnsafe(false, be.loc, "pointer arithmetic not allowed in @safe functions"))
         {
-            be.error("pointer arithmetic not allowed in @safe functions");
             return ErrorExp.get();
         }
     }

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -472,8 +472,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (dsym.storage_class & STC.gshared && !dsym.isMember())
             {
-                if (sc.func.setUnsafe())
-                    dsym.error("__gshared not allowed in safe functions; use shared");
+                sc.func.setUnsafe(false, dsym.loc, "__gshared not allowed in safe functions; use shared");
             }
         }
 
@@ -863,20 +862,18 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (dsym._init && dsym._init.isVoidInitializer() &&
                 (dsym.type.hasPointers() || dsym.type.hasInvariant())) // also computes type size
             {
-                if (sc.func.setUnsafe())
-                {
-                    if (dsym.type.hasPointers())
-                        dsym.error("`void` initializers for pointers not allowed in safe functions");
-                    else
-                        dsym.error("`void` initializers for structs with invariants are not allowed in safe functions");
-                }
+                if (dsym.type.hasPointers())
+                    sc.func.setUnsafe(false, dsym.loc,
+                        "`void` initializers for pointers not allowed in safe functions");
+                else
+                    sc.func.setUnsafe(false, dsym.loc,
+                        "`void` initializers for structs with invariants are not allowed in safe functions");
             }
             else if (!dsym._init &&
                      !(dsym.storage_class & (STC.static_ | STC.extern_ | STC.gshared | STC.manifest | STC.field | STC.parameter)) &&
                      dsym.type.hasVoidInitPointers())
             {
-                if (sc.func.setUnsafe())
-                    dsym.error("`void` initializers for pointers not allowed in safe functions");
+                sc.func.setUnsafe(false, dsym.loc, "`void` initializers for pointers not allowed in safe functions");
             }
         }
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5761,9 +5761,8 @@ extern (C++) final class DelegatePtrExp : UnaExp
 
     override Expression modifiableLvalue(Scope* sc, Expression e)
     {
-        if (sc.func.setUnsafe())
+        if (sc.func.setUnsafe(false, this.loc, "cannot modify delegate pointer in `@safe` code `%s`", this))
         {
-            error("cannot modify delegate pointer in `@safe` code `%s`", toChars());
             return ErrorExp.get();
         }
         return Expression.modifiableLvalue(sc, e);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6897,19 +6897,19 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                          * because it might end up being a pointer to undefined
                          * memory.
                          */
-                        if (sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
+                        if (sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_))
                         {
-                            exp.error("cannot take address of lazy parameter `%s` in `@safe` function `%s`",
-                                     ve.toChars(), sc.func.toChars());
-                            setError();
+                            if (sc.func.setUnsafe(false, exp.loc,
+                                "cannot take address of lazy parameter `%s` in `@safe` function `%s`", ve, sc.func))
+                            {
+                                setError();
+                                return;
+                            }
                         }
-                        else
-                        {
-                            VarExp ve2 = callExp.e1.isVarExp();
-                            ve2.delegateWasExtracted = true;
-                            ve2.var.storage_class |= STC.scope_;
-                            result = ve2;
-                        }
+                        VarExp ve2 = callExp.e1.isVarExp();
+                        ve2.delegateWasExtracted = true;
+                        ve2.var.storage_class |= STC.scope_;
+                        result = ve2;
                         return;
                     }
                 }
@@ -7845,10 +7845,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 return setError();
             }
-            if (sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
+            if (sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_))
             {
-                exp.error("pointer slicing not allowed in safe functions");
-                return setError();
+                if (sc.func.setUnsafe(false, exp.loc, "pointer slicing not allowed in safe functions"))
+                    return setError();
             }
         }
         else if (t1b.ty == Tarray)

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -198,14 +198,16 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
                 {
                     if ((!t.alignment.isDefault() && t.alignment.get() < target.ptrsize ||
                          (vd.offset & (target.ptrsize - 1))) &&
-                        sc.func && sc.func.setUnsafe())
+                        sc.func)
                     {
-                        error(i.value[j].loc, "field `%s.%s` cannot assign to misaligned pointers in `@safe` code",
-                            sd.toChars(), vd.toChars());
-                        errors = true;
-                        elems[fieldi] = ErrorExp.get(); // for better diagnostics on multiple errors
-                        ++fieldi;
-                        continue;
+                        if (sc.func.setUnsafe(false, i.value[j].loc,
+                            "field `%s.%s` cannot assign to misaligned pointers in `@safe` code", sd, vd))
+                        {
+                            errors = true;
+                            elems[fieldi] = ErrorExp.get(); // for better diagnostics on multiple errors
+                            ++fieldi;
+                            continue;
+                        }
                     }
                 }
 

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -64,23 +64,22 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
         const hasPointers = v.type.hasPointers();
         if (hasPointers)
         {
-            if (v.overlapped && sc.func.setUnsafe())
+            if (v.overlapped)
             {
-                if (printmsg)
-                    e.error("field `%s.%s` cannot access pointers in `@safe` code that overlap other fields",
-                        ad.toChars(), v.toChars());
-                return true;
+                if (sc.func.setUnsafe(!printmsg, e.loc,
+                    "field `%s.%s` cannot access pointers in `@safe` code that overlap other fields", ad, v))
+                    return true;
             }
         }
 
         if (v.type.hasInvariant())
         {
-            if (v.overlapped && sc.func.setUnsafe())
+            if (v.overlapped)
             {
-                if (printmsg)
-                    e.error("field `%s.%s` cannot access structs with invariants in `@safe` code that overlap other fields",
-                        ad.toChars(), v.toChars());
-                return true;
+                if (sc.func.setUnsafe(!printmsg, e.loc,
+                    "field `%s.%s` cannot access structs with invariants in `@safe` code that overlap other fields",
+                    ad, v))
+                    return true;
             }
         }
 
@@ -90,22 +89,22 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
         if (hasPointers && v.type.toBasetype().ty != Tstruct)
         {
             if ((!ad.type.alignment.isDefault() && ad.type.alignment.get() < target.ptrsize ||
-                 (v.offset & (target.ptrsize - 1))) &&
-                sc.func.setUnsafe())
+                 (v.offset & (target.ptrsize - 1))))
             {
-                if (printmsg)
-                    e.error("field `%s.%s` cannot modify misaligned pointers in `@safe` code",
-                        ad.toChars(), v.toChars());
-                return true;
+                if (sc.func.setUnsafe(!printmsg, e.loc,
+                    "field `%s.%s` cannot modify misaligned pointers in `@safe` code", ad, v))
+                    return true;
             }
         }
 
-        if (v.overlapUnsafe && sc.func.setUnsafe())
+        if (v.overlapUnsafe)
         {
-             if (printmsg)
-                 e.error("field `%s.%s` cannot modify fields in `@safe` code that overlap fields with other storage classes",
-                    ad.toChars(), v.toChars());
-             return true;
+            if (sc.func.setUnsafe(!printmsg, e.loc,
+                "field `%s.%s` cannot modify fields in `@safe` code that overlap fields with other storage classes",
+                ad, v))
+            {
+                return true;
+            }
         }
     }
     return false;
@@ -215,14 +214,12 @@ bool checkUnsafeDotExp(Scope* sc, Expression e, Identifier id, int flag)
     if (!(flag & DotExpFlag.noDeref) && // this use is attempting a dereference
         sc.func &&                      // inside a function
         !sc.intypeof &&                 // allow unsafe code in typeof expressions
-        !(sc.flags & SCOPE.debug_) &&   // allow unsafe code in debug statements
-        sc.func.setUnsafe())            // infer this function to be unsafe
+        !(sc.flags & SCOPE.debug_))     // allow unsafe code in debug statements
     {
         if (id == Id.ptr)
-            e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
+            return sc.func.setUnsafe(false, e.loc, "`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e, e);
         else
-            e.error("`%s.%s` cannot be used in `@safe` code", e.toChars(), id.toChars());
-        return true;
+            return sc.func.setUnsafe(false, e.loc, "`%s.%s` cannot be used in `@safe` code", e, id);
     }
     return false;
 }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -4034,10 +4034,10 @@ void catchSemantic(Catch c, Scope* sc)
             error(c.loc, "catching C++ class objects not supported for this target");
             c.errors = true;
         }
-        if (sc.func && !sc.intypeof && !c.internalCatch && sc.func.setUnsafe())
+        if (sc.func && !sc.intypeof && !c.internalCatch)
         {
-            error(c.loc, "cannot catch C++ class objects in `@safe` code");
-            c.errors = true;
+            if (sc.func.setUnsafe(false, c.loc, "cannot catch C++ class objects in `@safe` code"))
+                c.errors = true;
         }
     }
     else if (cd != ClassDeclaration.throwable && !ClassDeclaration.throwable.isBaseOf(cd, null))
@@ -4046,10 +4046,10 @@ void catchSemantic(Catch c, Scope* sc)
         c.errors = true;
     }
     else if (sc.func && !sc.intypeof && !c.internalCatch && ClassDeclaration.exception &&
-             cd != ClassDeclaration.exception && !ClassDeclaration.exception.isBaseOf(cd, null) &&
-             sc.func.setUnsafe())
+            cd != ClassDeclaration.exception && !ClassDeclaration.exception.isBaseOf(cd, null) &&
+            sc.func.setUnsafe(false, c.loc,
+                "can only catch class objects derived from `Exception` in `@safe` code, not `%s`", c.type))
     {
-        error(c.loc, "can only catch class objects derived from `Exception` in `@safe` code, not `%s`", c.type.toChars());
         c.errors = true;
     }
     else if (global.params.ehnogc)

--- a/test/fail_compilation/test14496.d
+++ b/test/fail_compilation/test14496.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test14496.d(21): Error: variable `test14496.foo.f` `void` initializers for pointers not allowed in safe functions
-fail_compilation/test14496.d(24): Error: variable `test14496.foo.Bar.foo` `void` initializers for pointers not allowed in safe functions
-fail_compilation/test14496.d(28): Error: variable `test14496.foo.Baz.x` `void` initializers for pointers not allowed in safe functions
-fail_compilation/test14496.d(48): Error: variable `test14496.sinister.bar` `void` initializers for pointers not allowed in safe functions
-fail_compilation/test14496.d(49): Error: variable `test14496.sinister.baz` `void` initializers for pointers not allowed in safe functions
+fail_compilation/test14496.d(21): Error: `void` initializers for pointers not allowed in safe functions
+fail_compilation/test14496.d(24): Error: `void` initializers for pointers not allowed in safe functions
+fail_compilation/test14496.d(28): Error: `void` initializers for pointers not allowed in safe functions
+fail_compilation/test14496.d(48): Error: `void` initializers for pointers not allowed in safe functions
+fail_compilation/test14496.d(49): Error: `void` initializers for pointers not allowed in safe functions
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=14496

--- a/test/fail_compilation/test21665.d
+++ b/test/fail_compilation/test21665.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test21665.d(18): Error: variable `test21665.test1.s` `void` initializers for structs with invariants are not allowed in safe functions
+fail_compilation/test21665.d(18): Error: `void` initializers for structs with invariants are not allowed in safe functions
 fail_compilation/test21665.d(30): Error: field `U.s` cannot access structs with invariants in `@safe` code that overlap other fields
 ---
 */


### PR DESCRIPTION
Continuation of https://github.com/dlang/dmd/pull/13957

Put error messages inside `setUnsafe()` so they are also printed when calling a function that's inferred `@system` because of the error. This covers the easy ones, some of them require a string argument, and the ones in escape.d will get some special treatment because of the dip1000 by default transition.