### PR TITLE
Do parameterStorageClass also without dip1000 switch

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2064,7 +2064,8 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                     ale.type = ale.type.nextOf().sarrayOf(ale.elements ? ale.elements.length : 0);
                     auto tmp = copyToTemp(0, "__arrayliteral_on_stack", ale);
                     auto declareTmp = new DeclarationExp(ale.loc, tmp);
-                    auto castToSlice = new CastExp(ale.loc, new VarExp(ale.loc, tmp), p.type);
+                    auto castToSlice = new CastExp(ale.loc, new VarExp(ale.loc, tmp),
+                        p.type.substWildTo(MODFlags.mutable));
                     arg = CommaExp.combine(declareTmp, castToSlice);
                     arg = arg.expressionSemantic(sc);
                 }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4375,8 +4375,6 @@ extern (C++) final class TypeFunction : TypeNext
     {
         //printf("parameterStorageClass(p: %s)\n", p.toChars());
         auto stc = p.storageClass;
-        if (global.params.useDIP1000 != FeatureState.enabled)
-            return stc;
 
         // When the preview switch is enable, `in` parameters are `scope`
         if (stc & STC.in_ && global.params.previewIn)
@@ -4441,7 +4439,12 @@ extern (C++) final class TypeFunction : TypeNext
         // Check escaping through return value
         Type tret = nextOf().toBasetype();
         if (isref || tret.hasPointers())
+        {
+            if (global.params.useDIP1000 != FeatureState.enabled)
+                return stc;
+
             return stc | STC.scope_ | STC.return_ | STC.returnScope;
+        }
         else
             return stc | STC.scope_;
     }


### PR DESCRIPTION
Making `-preview=dip1000` the default involves eliminating semantic differences between the switch being on and off. 
`scope` inference from pure is something that happens with dip1000, and if you don't do it without dip1000, there will be false deprecation warnings about assigning `scope` pointers to non-scope parameters that aren't actually errors with dip1000.

`return scope` inference is a bit trickier, since that may suddenly make the returned pointer `scope` and not all lifetime errors are disabled in `@system` code, so leave that off for now.