### PR TITLE
Fix Issue 23083 - .tupleof on static array rvalue evaluates expressio…

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3637,12 +3637,16 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             }
             else
             {
+                Expression e0;
+                Expression ev = e;
+                ev = extractSideEffect(sc, "__tup", e0, ev);
+
                 const length = cast(size_t)mt.dim.toUInteger();
                 auto exps = new Expressions();
                 exps.reserve(length);
                 foreach (i; 0 .. length)
-                    exps.push(new IndexExp(e.loc, e, new IntegerExp(e.loc, i, Type.tsize_t)));
-                e = new TupleExp(e.loc, exps);
+                    exps.push(new IndexExp(e.loc, ev, new IntegerExp(e.loc, i, Type.tsize_t)));
+                e = new TupleExp(e.loc, e0, exps);
             }
         }
         else

--- a/test/runnable/test23083.d
+++ b/test/runnable/test23083.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=23083
+int calls = 0;
+
+int[2] f()
+{
+    calls++;
+    return [123, 456];
+}
+
+void g(int a, int b) {}
+
+void main()
+{
+    g(f().tupleof);
+    assert(calls == 1);
+}


### PR DESCRIPTION
…n multiple times

---

Targeting stable because this affects a newly-introduced language feature in 2.100.