### PR TITLE
Bump default FreeBSD version to 12.x

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,15 +135,15 @@ macos10_task:
 
 # FreeBSD
 freebsd12_task:
-  name: FreeBSD 12.2 x64, DMD ($TASK_NAME_TYPE)
+  name: FreeBSD 13.0 x64, DMD ($TASK_NAME_TYPE)
   freebsd_instance:
-    image_family: freebsd-12-2
+    image_family: freebsd-13-0
     cpu: 4
     memory: 8G
   timeout_in: 60m
   environment:
     OS_NAME: freebsd
-    CI_DFLAGS: -version=TARGET_FREEBSD12
+    CI_DFLAGS: -version=TARGET_FREEBSD13
     matrix:
       - TASK_NAME_TYPE: latest
       - TASK_NAME_TYPE: coverage
@@ -151,16 +151,16 @@ freebsd12_task:
   install_bash_script: pkg install -y bash
   << : *COMMON_STEPS_TEMPLATE
 
-freebsd11_task:
-  name: FreeBSD 11.4 x64, DMD (bootstrap)
+freebsd12_task:
+  name: FreeBSD 12.3 x64, DMD (bootstrap)
   freebsd_instance:
-    image_family: freebsd-11-4
+    image_family: freebsd-12-3
     cpu: 4
     memory: 8G
   timeout_in: 60m
   environment:
     OS_NAME: freebsd
     HOST_DMD: dmd-2.079.0
-    CI_DFLAGS: -version=TARGET_FREEBSD11
+    CI_DFLAGS: -version=TARGET_FREEBSD12
   install_bash_script: pkg install -y bash
   << : *COMMON_STEPS_TEMPLATE

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1260,7 +1260,8 @@ void addPredefinedGlobalIdentifiers(const ref Target tgt)
                     case 10: predef("FreeBSD_10");  break;
                     case 11: predef("FreeBSD_11"); break;
                     case 12: predef("FreeBSD_12"); break;
-                    default: predef("FreeBSD_11"); break;
+                    case 13: predef("FreeBSD_13"); break;
+                    default: predef("FreeBSD_12"); break;
                 }
                 break;
             }


### PR DESCRIPTION
FreeBSD 11 has been retired from the main pkg repositories (https://pkg.freebsd.org/).