### PR TITLE
[stable] Re-enable selecting default FreeBSD target version via -version=TARGET_FREEBSD<NN> at DMD build time

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -76,7 +76,7 @@ rebuild() {
     cp $build_path/dmd _${build_path}/host_dmd
     cp $build_path/dmd.conf _${build_path}
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd clean
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd ENABLE_RELEASE=${ENABLE_RELEASE:-1} ENABLE_WARNINGS=1 all
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd DFLAGS="$CI_DFLAGS" ENABLE_RELEASE=${ENABLE_RELEASE:-1} ENABLE_WARNINGS=1 all
 
     # compare binaries to test reproducible build
     if [ $compare -eq 1 ]; then

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -7809,7 +7809,7 @@ public:
     bool supportsLinkerDirective() const;
     Target() :
         os((OS)1u),
-        osMajor(),
+        osMajor(0u),
         ptrsize(),
         realsize(),
         realpad(),

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1256,6 +1256,7 @@ void addPredefinedGlobalIdentifiers(const ref Target tgt)
                     case 10: predef("FreeBSD_10");  break;
                     case 11: predef("FreeBSD_11"); break;
                     case 12: predef("FreeBSD_12"); break;
+                    case 13: predef("FreeBSD_13"); break;
                     default: predef("FreeBSD_11"); break;
                 }
                 break;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -65,6 +65,26 @@ Target.OS defaultTargetOS()
     else
         static assert(0, "unknown TARGET");
 }
+
+ubyte defaultTargetOSMajor()
+{
+    version (FreeBSD)
+    {
+        version (TARGET_FREEBSD10)
+            return 10;
+        else version (TARGET_FREEBSD11)
+            return 11;
+        else version (TARGET_FREEBSD12)
+            return 12;
+        else version (TARGET_FREEBSD13)
+            return 13;
+        else
+            return 0;
+    }
+    else
+        return 0;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /**
  * Describes a back-end target. At present it is incomplete, but in the future
@@ -116,7 +136,7 @@ extern (C++) struct Target
     }
 
     OS os = defaultTargetOS();
-    ubyte osMajor;
+    ubyte osMajor = defaultTargetOSMajor();
 
     // D ABI
     ubyte ptrsize;            /// size of a pointer in bytes


### PR DESCRIPTION
As this functionality was apparently lost, making the FreeBSD 12.x CI jobs actually target FreeBSD 11.