### PR TITLE
fix Issue 23087 - getLinkage trait regression for overloads with v2.100.0-rc.1

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1515,7 +1515,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
         if (tf)
         {
-            link = fd ? fd.linkage : tf.linkage;
+            link = fd ? fd.toAliasFunc().linkage : tf.linkage;
         }
         else
         {

--- a/test/compilable/test23087.d
+++ b/test/compilable/test23087.d
@@ -1,0 +1,9 @@
+// https://issues.dlang.org/show_bug.cgi?id=23087
+struct S
+{
+    this(bool) {}
+    this(bool, int) {}
+}
+
+static foreach (ctor; __traits(getOverloads, S, "__ctor"))
+    static assert(__traits(getLinkage, ctor) == "D");


### PR DESCRIPTION
Since #13942, function linkages are not resolved early, and the use of `getOverloads` as per this test creates a new [FuncAliasDeclaration](https://github.com/dlang/dmd/blob/stable/src/dmd/traits.d#L1176) for the `__ctor` overload, which leaves the linkage unset.  Running `functionSemantic` on the alias doesn't set the linkage either, because [_scope is null](https://github.com/dlang/dmd/blob/081d61e157f0064dc93c757d61cd998d3cb5288f/src/dmd/func.d#L403-L407) for function aliases as well.

There's two ways to possibly go about this:
1. Copy/propagate the linkage from `FuncDeclaration` to `FuncAliasDeclaration` immediately after new'ing it.
2. Get the underlying `FuncDeclaration` from this alias at the point of reading the linkage.

This patch does the latter (2).