### PR TITLE
fix Issue 23089 - Linkage-related ICE regression in v2.100.0-rc.1

### DIFF
--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -276,7 +276,8 @@ Symbol *toSymbol(Dsymbol s)
             }
 
             mangle_t m = 0;
-            final switch (vd.linkage)
+            const linkage = vd.linkage == LINK.system ? target.systemLinkage() : vd.linkage;
+            final switch (linkage)
             {
                 case LINK.windows:
                     m = target.is64bit ? mTYman_c : mTYman_std;

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -985,7 +985,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
          */
         static mangle_t mangle(const VarDeclaration vd)
         {
-            final switch (vd.linkage)
+            const linkage = vd.linkage == LINK.system ? target.systemLinkage() : vd.linkage;
+            final switch (linkage)
             {
                 case LINK.windows:
                     return target.is64bit ? mTYman_c : mTYman_std;

--- a/test/compilable/test23089.d
+++ b/test/compilable/test23089.d
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=23089
+extern(System) int i23089;
+
+extern(System):
+
+alias F23089 = void function(int);
+F23089 f23089;


### PR DESCRIPTION
Exactly the same change to tocsym.d as in #13942, but applied to VarDeclaration symbols.