### PR TITLE
Fix Issue 21416 - betterC mode program with C++ interface fails to link

### DIFF
--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -573,11 +573,11 @@ Classsym *fake_classsym(Identifier id)
  * needed directly (like for rtti comparisons), make it directly accessible.
  */
 
-Symbol *toVtblSymbol(ClassDeclaration cd)
+Symbol *toVtblSymbol(ClassDeclaration cd, bool genCsymbol = true)
 {
     if (!cd.vtblsym || !cd.vtblsym.csym)
     {
-        if (!cd.csym)
+        if (!cd.csym && genCsymbol)
             toSymbol(cd);
 
         auto t = type_allocn(TYnptr | mTYconst, tstypes[TYvoid]);

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -789,6 +789,9 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
     uint offset;
     if (cd)
     {
+        const bool gentypeinfo = global.params.useTypeInfo && Type.dtypeinfo;
+        const bool genclassinfo = gentypeinfo || !(cd.isCPPclass || cd.isCOMclass);
+
         if (ClassDeclaration cdb = cd.baseClass)
         {
             // Insert { base class }
@@ -801,7 +804,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
         else if (InterfaceDeclaration id = cd.isInterfaceDeclaration())
         {
             offset = (**ppb).offset;
-            if (id.vtblInterfaces.dim == 0)
+            if (id.vtblInterfaces.dim == 0 && genclassinfo)
             {
                 BaseClass* b = **ppb;
                 //printf("  Interface %s, b = %p\n", id.toChars(), b);
@@ -833,7 +836,10 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
         }
 
         // Interface vptr initializations
-        toSymbol(cd);                                         // define csym
+        if (genclassinfo)
+        {
+            toSymbol(cd);                                         // define csym
+        }
 
         BaseClass** pb;
         if (!ppb)

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -369,7 +369,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             // Generate C symbols
             if (genclassinfo)
                 toSymbol(cd);                           // __ClassZ symbol
-            toVtblSymbol(cd);                           // __vtblZ symbol
+            toVtblSymbol(cd, genclassinfo);             // __vtblZ symbol
             Symbol *sinit = toInitializer(cd);          // __initZ symbol
 
             //////////////////////////////////////////////
@@ -459,13 +459,18 @@ void toObjFile(Dsymbol ds, bool multiobj)
             if (id.classKind == ClassKind.objc)
                 return;
 
+            const bool gentypeinfo = global.params.useTypeInfo && Type.dtypeinfo;
+            const bool genclassinfo = gentypeinfo || !(id.isCPPclass || id.isCOMclass);
+
+
             // Generate C symbols
-            toSymbol(id);
+            if (genclassinfo)
+                toSymbol(id);
 
             //////////////////////////////////////////////
 
             // Put out the TypeInfo
-            if (global.params.useTypeInfo && Type.dtypeinfo)
+            if (gentypeinfo)
             {
                 genTypeInfo(id.loc, id.type, null);
                 id.type.vtinfo.accept(this);
@@ -473,7 +478,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
             //////////////////////////////////////////////
 
-            genClassInfoForInterface(id);
+            if (genclassinfo)
+                genClassInfoForInterface(id);
         }
 
         override void visit(StructDeclaration sd)

--- a/test/runnable/test21416.d
+++ b/test/runnable/test21416.d
@@ -1,0 +1,9 @@
+// https://issues.dlang.org/show_bug.cgi?id=21416
+
+// REQUIRED_ARGS: -betterC
+
+extern(C) void main() {}
+
+extern(C++) interface IEntry {}
+
+extern(C++) class MyEntryInfo : IEntry {}


### PR DESCRIPTION
Naive attempt at fixing the issue. It seems that `toSymbol` is called whenever the actual druntime symbol is emitted for classes. I tried excluding such calls whenever `useTypeInfo` is false and C++ classes are used. 