### PR TITLE
[stable] cirrus.yml: Use an alternative mirror for FreeBSD 11

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -162,5 +162,7 @@ freebsd11_task:
     OS_NAME: freebsd
     HOST_DMD: dmd-2.079.0
     CI_DFLAGS: -version=TARGET_FREEBSD11
-  install_bash_script: pkg install -y bash
+  install_bash_script: |
+    sed -i '' -e 's|pkg.FreeBSD.org|mirrors.xtom.com/freebsd-pkg|' /etc/pkg/FreeBSD.conf
+    pkg install -y bash
   << : *COMMON_STEPS_TEMPLATE


### PR DESCRIPTION
The official mirror no longer has FreeBSD:11:amd64 in its archive.

See: https://pkg.freebsd.org/

This is to be considered temporary until we transition over to FreeBSD 12+13 in our CI pipelines, but no use waiting for those ports to be fixed when we have a release to go out.