### PR TITLE
Revise newly unresolved Declaration.linkage

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -867,7 +867,7 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
 
     // Build the field destructor (`ad.fieldDtor`), if needed.
     // If the user dtor is an extern(C++) prototype, then we expect it performs a full-destruction and skip building.
-    const bool dtorIsCppPrototype = ad.userDtors.dim && ad.userDtors[0].linkage == LINK.cpp && !ad.userDtors[0].fbody;
+    const bool dtorIsCppPrototype = ad.userDtors.dim && ad.userDtors[0]._linkage == LINK.cpp && !ad.userDtors[0].fbody;
     if (!dtorIsCppPrototype)
     {
         Expression e = null;
@@ -1019,7 +1019,7 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
 
     // Set/build `ad.dtor`.
     // On Windows, the dtor in the vtable is a shim with different signature.
-    ad.dtor = (ad.aggrDtor && ad.aggrDtor.linkage == LINK.cpp && !target.cpp.twoDtorInVtable)
+    ad.dtor = (ad.aggrDtor && ad.aggrDtor._linkage == LINK.cpp && !target.cpp.twoDtorInVtable)
         ? buildWindowsCppDtor(ad, ad.aggrDtor, sc)
         : ad.aggrDtor;
 

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -984,7 +984,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
             auto var = new VarDeclaration(loc, vtype, Identifier.idPool("__vtbl"), null, STC.immutable_ | STC.static_);
             var.addMember(null, this);
             var.isdataseg = 1;
-            var.linkage = LINK.d;
+            var._linkage = LINK.d;
             var.semanticRun = PASS.semanticdone; // no more semantic wanted
             vtblsym = var;
         }

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -221,7 +221,7 @@ extern (C++) abstract class Declaration : Dsymbol
     Type originalType;  // before semantic analysis
     StorageClass storage_class = STC.undefined_;
     Visibility visibility;
-    LINK linkage = LINK.default_;
+    LINK _linkage = LINK.default_; // may be `LINK.system`; use `resolvedLinkage()` to resolve it
     short inuse;          // used to detect cycles
 
     ubyte adFlags;         // control re-assignment of AliasDeclaration (put here for packing reasons)
@@ -418,6 +418,12 @@ extern (C++) abstract class Declaration : Dsymbol
     final bool isStatic() const pure nothrow @nogc @safe
     {
         return (storage_class & STC.static_) != 0;
+    }
+
+    /// Returns the linkage, resolving the target-specific `System` one.
+    final LINK resolvedLinkage() const
+    {
+        return _linkage == LINK.system ? target.systemLinkage() : _linkage;
     }
 
     bool isDelete()
@@ -1919,7 +1925,7 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
         this.tinfo = tinfo;
         storage_class = STC.static_ | STC.gshared;
         visibility = Visibility(Visibility.Kind.public_);
-        linkage = LINK.c;
+        _linkage = LINK.c;
         alignment.set(target.ptrsize);
     }
 

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -115,7 +115,7 @@ public:
     Type *originalType;         // before semantic analysis
     StorageClass storage_class;
     Visibility visibility;
-    LINK linkage;
+    LINK _linkage;              // may be `LINK::system`; use `resolvedLinkage()` to resolve it
     short inuse;                // used to detect cycles
     uint8_t adFlags;
     Symbol* isym;               // import version of csym
@@ -127,6 +127,7 @@ public:
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
 
     bool isStatic() const { return (storage_class & STCstatic) != 0; }
+    LINK resolvedLinkage() const; // returns the linkage, resolving the target-specific `System` one
     virtual bool isDelete();
     virtual bool isDataseg();
     virtual bool isThreadlocal();

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -1337,17 +1337,17 @@ extern (D) const(char)[] externallyMangledIdentifier(Declaration d)
 {
     assert(!d.mangleOverride, "mangle overrides should have been handled earlier");
 
+    const linkage = d.resolvedLinkage();
     const par = d.toParent(); //toParent() skips over mixin templates
-    if (!par || par.isModule() || d.linkage == LINK.cpp ||
-        (d.linkage == LINK.c && d.isCsymbol() &&
+    if (!par || par.isModule() || linkage == LINK.cpp ||
+        (linkage == LINK.c && d.isCsymbol() &&
          (d.isFuncDeclaration() ||
           (d.isVarDeclaration() && d.isDataseg() && d.storage_class & STC.extern_))))
     {
-        if (d.linkage != LINK.d && d.localNum)
+        if (linkage != LINK.d && d.localNum)
             d.error("the same declaration cannot be in multiple scopes with non-D linkage");
 
-        const l = d.linkage == LINK.system ? target.systemLinkage() : d.linkage;
-        final switch (l)
+        final switch (linkage)
         {
             case LINK.d:
                 break;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -376,7 +376,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         // https://issues.dlang.org/show_bug.cgi?id=19482
         if ((dsym.storage_class & (STC.foreach_ | STC.local)) == (STC.foreach_ | STC.local))
         {
-            dsym.linkage = LINK.d;
+            dsym._linkage = LINK.d;
             dsym.visibility = Visibility(Visibility.Kind.public_);
             dsym.overlapped = false; // unset because it is modified early on this function
             dsym.userAttribDecl = null; // unset because it is set by Dsymbol.setScope()
@@ -389,7 +389,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym.storage_class |= (sc.stc & ~(STC.synchronized_ | STC.override_ | STC.abstract_ | STC.final_));
             dsym.userAttribDecl = sc.userAttribDecl;
             dsym.cppnamespace = sc.namespace;
-            dsym.linkage = sc.linkage;
+            dsym._linkage = sc.linkage;
             dsym.visibility = sc.visibility;
             dsym.alignment = sc.alignment();
         }
@@ -1191,7 +1191,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(TypeInfoDeclaration dsym)
     {
-        assert(dsym.linkage == LINK.c);
+        assert(dsym._linkage == LINK.c);
     }
 
     override void visit(BitFieldDeclaration dsym)
@@ -2174,7 +2174,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
                 em.semanticRun = PASS.semantic;
                 em.type = Type.tint32;
-                em.linkage = LINK.c;
+                em._linkage = LINK.c;
                 em.storage_class |= STC.manifest;
                 if (em.value)
                 {
@@ -2264,7 +2264,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         em.semanticRun = PASS.semantic;
 
         em.visibility = em.ed.isAnonymous() ? em.ed.visibility : Visibility(Visibility.Kind.public_);
-        em.linkage = LINK.d;
+        em._linkage = LINK.d;
         em.storage_class |= STC.manifest;
 
         // https://issues.dlang.org/show_bug.cgi?id=9701
@@ -3024,7 +3024,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (sc.flags & SCOPE.compile)
             funcdecl.flags |= FUNCFLAG.compileTimeOnly; // don't emit code for this function
 
-        funcdecl.linkage = sc.linkage;
+        funcdecl._linkage = sc.linkage;
         if (auto fld = funcdecl.isFuncLiteralDeclaration())
         {
             if (fld.treq)
@@ -3037,7 +3037,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     fld.tok = TOK.function_;
                 else
                     assert(0);
-                funcdecl.linkage = treq.nextOf().toTypeFunction().linkage;
+                funcdecl._linkage = treq.nextOf().toTypeFunction().linkage;
             }
         }
 
@@ -3048,7 +3048,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         // check pragma(crt_constructor)
         if (funcdecl.flags & (FUNCFLAG.CRTCtor | FUNCFLAG.CRTDtor))
         {
-            if (funcdecl.linkage != LINK.c)
+            if (funcdecl._linkage != LINK.c)
             {
                 funcdecl.error("must be `extern(C)` for `pragma(%s)`",
                     (funcdecl.flags & FUNCFLAG.CRTCtor) ? "crt_constructor".ptr : "crt_destructor".ptr);
@@ -3057,7 +3057,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         funcdecl.visibility = sc.visibility;
         funcdecl.userAttribDecl = sc.userAttribDecl;
-        UserAttributeDeclaration.checkGNUABITag(funcdecl, funcdecl.linkage);
+        UserAttributeDeclaration.checkGNUABITag(funcdecl, funcdecl._linkage);
         checkMustUseReserved(funcdecl);
 
         if (!funcdecl.originalType)
@@ -3193,7 +3193,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 tf.isScopeQual = false;
             }
 
-            sc.linkage = funcdecl.linkage;
+            sc.linkage = funcdecl._linkage;
 
             if (!tf.isNaked() && !(funcdecl.isThis() || funcdecl.isNested()))
             {

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -2777,7 +2777,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
             fd.storage_class == m.lastf.storage_class &&
             fd.parent == m.lastf.parent &&
             fd.visibility == m.lastf.visibility &&
-            fd.linkage == m.lastf.linkage)
+            fd._linkage == m.lastf._linkage)
         {
             if (fd.fbody && !m.lastf.fbody)
                 goto LfIsBetter;

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -3306,7 +3306,7 @@ elem* toElem(Expression e, IRState *irs)
                 // multiple times within the same function, eg in a loop
                 // see issue 3822
                 if (fd && fd.ident == Id.__alloca &&
-                    !fd.fbody && fd.linkage == LINK.c &&
+                    !fd.fbody && fd._linkage == LINK.c &&
                     arguments && arguments.dim == 1)
                 {   Expression arg = (*arguments)[0];
                     arg = arg.optimize(WANTvalue);
@@ -5688,7 +5688,7 @@ elem *callfunc(const ref Loc loc,
             e.Eflags |= EFLAGS_variadic;
     }
 
-    const isCPPCtor = fd && fd.linkage == LINK.cpp && fd.isCtorDeclaration();
+    const isCPPCtor = fd && fd._linkage == LINK.cpp && fd.isCtorDeclaration();
     if (isCPPCtor && irs.target.isPOSIX)
     {
         // CPP constructor returns void on Posix

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5695,7 +5695,7 @@ public:
     Type* originalType;
     StorageClass storage_class;
     Visibility visibility;
-    LINK linkage;
+    LINK _linkage;
     int16_t inuse;
     uint8_t adFlags;
     enum : int32_t { wasRead = 1 };
@@ -5708,6 +5708,7 @@ public:
     uinteger_t size(const Loc& loc);
     Dsymbol* search(const Loc& loc, Identifier* ident, int32_t flags = 8);
     bool isStatic() const;
+    LINK resolvedLinkage() const;
     virtual bool isDelete();
     virtual bool isDataseg();
     virtual bool isThreadlocal();

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1207,12 +1207,12 @@ extern (C++) class FuncDeclaration : Declaration
 
     final bool isMain() const
     {
-        return ident == Id.main && linkage != LINK.c && !isMember() && !isNested();
+        return ident == Id.main && resolvedLinkage() != LINK.c && !isMember() && !isNested();
     }
 
     final bool isCMain() const
     {
-        return ident == Id.main && linkage == LINK.c && !isMember() && !isNested();
+        return ident == Id.main && resolvedLinkage() == LINK.c && !isMember() && !isNested();
     }
 
     final bool isWinMain() const
@@ -1220,24 +1220,24 @@ extern (C++) class FuncDeclaration : Declaration
         //printf("FuncDeclaration::isWinMain() %s\n", toChars());
         version (none)
         {
-            bool x = ident == Id.WinMain && linkage != LINK.c && !isMember();
+            bool x = ident == Id.WinMain && resolvedLinkage() != LINK.c && !isMember();
             printf("%s\n", x ? "yes" : "no");
             return x;
         }
         else
         {
-            return ident == Id.WinMain && linkage != LINK.c && !isMember();
+            return ident == Id.WinMain && resolvedLinkage() != LINK.c && !isMember();
         }
     }
 
     final bool isDllMain() const
     {
-        return ident == Id.DllMain && linkage != LINK.c && !isMember();
+        return ident == Id.DllMain && resolvedLinkage() != LINK.c && !isMember();
     }
 
     final bool isRtInit() const
     {
-        return ident == Id.rt_init && linkage == LINK.c && !isMember() && !isNested();
+        return ident == Id.rt_init && resolvedLinkage() == LINK.c && !isMember() && !isNested();
     }
 
     override final bool isExport() const
@@ -1776,7 +1776,7 @@ extern (C++) class FuncDeclaration : Declaration
         auto f = toAliasFunc();
         //printf("\ttoParent2() = '%s'\n", f.toParent2().toChars());
         return ((f.storage_class & STC.static_) == 0) &&
-                (f.linkage == LINK.d) &&
+                (f._linkage == LINK.d) &&
                 (f.toParent2().isFuncDeclaration() !is null ||
                  f.toParent2() !is f.toParentLocal());
     }
@@ -2663,7 +2663,7 @@ extern (C++) class FuncDeclaration : Declaration
             tf = new TypeFunction(ParameterList(fparams), treturn, LINK.c, stc);
             fd = new FuncDeclaration(Loc.initial, Loc.initial, id, STC.static_, tf);
             fd.visibility = Visibility(Visibility.Kind.public_);
-            fd.linkage = LINK.c;
+            fd._linkage = LINK.c;
 
             st.insert(fd);
         }
@@ -2723,6 +2723,7 @@ extern (C++) class FuncDeclaration : Declaration
         const nparams = tf.parameterList.length;
         bool argerr;
 
+        const linkage = resolvedLinkage();
         if (linkage == LINK.d)
         {
             if (nparams == 1)

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -772,8 +772,9 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         {
             // functions without D or C++ name mangling mixed in at global scope
             // shouldn't have multiple definitions
-            if (p.isTemplateMixin() && (fd.linkage == LINK.c || fd.linkage == LINK.windows ||
-                fd.linkage == LINK.objc))
+            const linkage = fd.resolvedLinkage();
+            if (p.isTemplateMixin() && (linkage == LINK.c || linkage == LINK.windows ||
+                linkage == LINK.objc))
             {
                 const q = p.toParent();
                 if (q && q.isModule())
@@ -959,7 +960,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         pi++;
     }
 
-    if (target.isPOSIX && fd.linkage != LINK.d && shidden && sthis)
+    if (target.isPOSIX && fd._linkage != LINK.d && shidden && sthis)
     {
         /* swap shidden and sthis
          */

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -1898,7 +1898,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
             auto tmp = Identifier.generateId("__retvar");
             vret = new VarDeclaration(fd.loc, eret.type, tmp, ei);
             vret.storage_class |= STC.temp | STC.ref_;
-            vret.linkage = LINK.d;
+            vret._linkage = LINK.d;
             vret.parent = parent;
 
             ei.exp = new ConstructExp(fd.loc, vret, eret);
@@ -1923,7 +1923,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
             vret = new VarDeclaration(fd.loc, fd.nrvo_var.type, tmp, new VoidInitializer(fd.loc));
             assert(!tf.isref);
             vret.storage_class = STC.temp | STC.rvalue;
-            vret.linkage = tf.linkage;
+            vret._linkage = tf.linkage;
             vret.parent = parent;
 
             auto de = new DeclarationExp(fd.loc, vret);
@@ -1981,7 +1981,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
                 vthis.storage_class = STC.ref_;
             else
                 vthis.storage_class = STC.in_;
-            vthis.linkage = LINK.d;
+            vthis._linkage = LINK.d;
             vthis.parent = parent;
 
             ei.exp = new ConstructExp(fd.loc, vthis, ethis);
@@ -2009,7 +2009,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
             auto ei = new ExpInitializer(vfrom.loc, arg);
             auto vto = new VarDeclaration(vfrom.loc, vfrom.type, vfrom.ident, ei);
             vto.storage_class |= vfrom.storage_class & (STC.temp | STC.IOR | STC.lazy_ | STC.nodtor);
-            vto.linkage = vfrom.linkage;
+            vto._linkage = vfrom._linkage;
             vto.parent = parent;
             //printf("vto = '%s', vto.storage_class = x%x\n", vto.toChars(), vto.storage_class);
             //printf("vto.parent = '%s'\n", parent.toChars());
@@ -2144,7 +2144,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
             auto tmp = Identifier.generateId("__inlineretval");
             auto vd = new VarDeclaration(callLoc, tf.next, tmp, ei);
             vd.storage_class = STC.temp | (tf.isref ? STC.ref_ : STC.rvalue);
-            vd.linkage = tf.linkage;
+            vd._linkage = tf.linkage;
             vd.parent = parent;
 
             ei.exp = new ConstructExp(callLoc, vd, e);

--- a/src/dmd/inlinecost.d
+++ b/src/dmd/inlinecost.d
@@ -503,7 +503,7 @@ public:
         // can't handle that at present.
         if (e.e1.op == EXP.dotVariable && (cast(DotVarExp)e.e1).e1.op == EXP.super_)
             cost = COST_MAX;
-        else if (e.f && e.f.ident == Id.__alloca && e.f.linkage == LINK.c && !allowAlloca)
+        else if (e.f && e.f.ident == Id.__alloca && e.f._linkage == LINK.c && !allowAlloca)
             cost = COST_MAX; // inlining alloca may cause stack overflows
         else
             cost++;

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -446,7 +446,7 @@ public:
             return;
         jsonProperties(cast(Dsymbol)d);
         propertyStorageClass("storageClass", d.storage_class);
-        property("linkage", d.linkage);
+        property("linkage", d._linkage);
         property("type", "deco", d.type);
         // Emit originalType if it differs from type
         if (d.type != d.originalType && d.originalType)

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -578,7 +578,7 @@ extern(C++) private final class Supported : Objc
 
     override void checkLinkage(FuncDeclaration fd)
     {
-        if (fd.linkage != LINK.objc && fd.objc.selector)
+        if (fd._linkage != LINK.objc && fd.objc.selector)
             fd.error("must have Objective-C linkage to attach a selector");
     }
 
@@ -640,11 +640,11 @@ extern(C++) private final class Supported : Objc
         if (!fd.objc.isOptional)
             return;
 
-        if (fd.linkage != LINK.objc)
+        if (fd._linkage != LINK.objc)
         {
             fd.error("only functions with Objective-C linkage can be declared as optional");
 
-            const linkage = linkageToString(fd.linkage);
+            const linkage = linkageToString(fd._linkage);
 
             errorSupplemental(fd.loc, "function is declared with %.*s linkage",
                 cast(uint) linkage.length, linkage.ptr);

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -238,7 +238,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
             return;
         }
 
-        UserAttributeDeclaration.checkGNUABITag(vd, vd.linkage);
+        UserAttributeDeclaration.checkGNUABITag(vd, vd._linkage);
 
         if (vd._init && !vd.toParent().isFuncDeclaration())
         {
@@ -379,6 +379,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
             alias f1 = fd;
             auto tf1 = cast(TypeFunction) f1.type;
             auto parent1 = f1.toParent2();
+            const linkage1 = f1.resolvedLinkage();
 
             overloadApply(f1, (Dsymbol s)
             {
@@ -391,7 +392,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
                     return 0;
 
                 // Functions with different manglings can never conflict
-                if (f1.linkage != f2.linkage)
+                if (linkage1 != f2.resolvedLinkage())
                     return 0;
 
                 // Functions with different names never conflict
@@ -428,12 +429,12 @@ private extern(C++) final class Semantic2Visitor : Visitor
                 // @@@DEPRECATED_2.104@@@
                 // Deprecated in 2020-08, make this an error in 2.104
                 if (parent1.isModule() &&
-                    f1.linkage != LINK.d && f1.linkage != LINK.cpp &&
+                    linkage1 != LINK.d && linkage1 != LINK.cpp &&
                     (!sameAttr || !sameParams)
                 )
                 {
                     f2.deprecation("cannot overload `extern(%s)` function at %s",
-                            linkageToChars(f1.linkage),
+                            linkageToChars(f1._linkage),
                             f1.loc.toChars());
                     return 0;
                 }
@@ -443,7 +444,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
                     return 0;
 
                 // Different attributes don't conflict in extern(D)
-                if (!sameAttr && f1.linkage == LINK.d)
+                if (!sameAttr && linkage1 == LINK.d)
                     return 0;
 
                 error(f2.loc, "%s `%s%s` conflicts with previous declaration at %s",
@@ -460,7 +461,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
             return;
         TypeFunction f = cast(TypeFunction) fd.type;
 
-        UserAttributeDeclaration.checkGNUABITag(fd, fd.linkage);
+        UserAttributeDeclaration.checkGNUABITag(fd, fd._linkage);
         //semantic for parameters' UDAs
         foreach (i, param; f.parameterList)
         {
@@ -643,7 +644,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
                     {
                         //printf("            found\n");
                         // Check that calling conventions match
-                        if (fd.linkage != ifd.linkage)
+                        if (fd._linkage != ifd._linkage)
                             fd.error("linkage doesn't match interface function");
 
                         // Check that it is current

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1353,7 +1353,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             if (funcdecl.isCtorDeclaration()) // https://issues.dlang.org/show_bug.cgi?id=#15665
                 f.isctor = true;
             sc.stc = 0;
-            sc.linkage = funcdecl.linkage; // https://issues.dlang.org/show_bug.cgi?id=8496
+            sc.linkage = funcdecl._linkage; // https://issues.dlang.org/show_bug.cgi?id=8496
             funcdecl.type = f.typeSemantic(funcdecl.loc, sc);
             sc = sc.pop();
         }

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -276,8 +276,7 @@ Symbol *toSymbol(Dsymbol s)
             }
 
             mangle_t m = 0;
-            const linkage = vd.linkage == LINK.system ? target.systemLinkage() : vd.linkage;
-            final switch (linkage)
+            final switch (vd.resolvedLinkage())
             {
                 case LINK.windows:
                     m = target.is64bit ? mTYman_c : mTYman_std;
@@ -300,7 +299,7 @@ Symbol *toSymbol(Dsymbol s)
                 case LINK.default_:
                 case LINK.system:
                     printf("linkage = %d, vd = %s %s @ [%s]\n",
-                        vd.linkage, vd.kind(), vd.toChars(), vd.loc.toChars());
+                        vd._linkage, vd.kind(), vd.toChars(), vd.loc.toChars());
                     assert(0);
             }
 
@@ -370,8 +369,7 @@ Symbol *toSymbol(Dsymbol s)
             }
             else
             {
-                const l = fd.linkage == LINK.system ? target.systemLinkage() : fd.linkage;
-                final switch (l)
+                final switch (fd.resolvedLinkage())
                 {
                     case LINK.windows:
                         t.Tmangle = target.is64bit ? mTYman_c : mTYman_std;
@@ -404,7 +402,7 @@ Symbol *toSymbol(Dsymbol s)
                         break;
                     case LINK.default_:
                     case LINK.system:
-                        printf("linkage = %d\n", fd.linkage);
+                        printf("linkage = %d\n", fd._linkage);
                         assert(0);
                 }
             }

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -971,7 +971,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             Symbol *tlvInit = symbol_name(tlvInitName, SCstatic, t);
             tlvInit.Sdt = null;
             tlvInit.Salignment = type_alignsize(s.Stype);
-            if (vd.linkage == LINK.cpp)
+            if (vd._linkage == LINK.cpp)
                 tlvInit.Sflags |= SFLpublic;
 
             return tlvInit;
@@ -988,8 +988,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
          */
         static mangle_t mangle(const VarDeclaration vd)
         {
-            const linkage = vd.linkage == LINK.system ? target.systemLinkage() : vd.linkage;
-            final switch (linkage)
+            final switch (vd.resolvedLinkage())
             {
                 case LINK.windows:
                     return target.is64bit ? mTYman_c : mTYman_std;
@@ -1006,7 +1005,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
                 case LINK.default_:
                 case LINK.system:
-                    printf("linkage = %d\n", vd.linkage);
+                    printf("linkage = %d\n", vd._linkage);
                     assert(0);
             }
         }

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1381,7 +1381,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 e.error("argument to `__traits(getFunctionVariadicStyle, %s)` is not a function", o.toChars());
                 return ErrorExp.get();
             }
-            link = fd.linkage;
+            link = fd._linkage;
             varargs = fd.getParameterList().varargs;
         }
         string style;
@@ -1515,7 +1515,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
         if (tf)
         {
-            link = fd ? fd.toAliasFunc().linkage : tf.linkage;
+            link = fd ? fd.toAliasFunc()._linkage : tf.linkage;
         }
         else
         {
@@ -1529,7 +1529,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             }
 
             if (d !is null)
-                link = d.linkage;
+                link = d._linkage;
             else
             {
                 // Resolves forward references


### PR DESCRIPTION
Since #13942, `Declaration.linkage` may be unresolved `LINK.system`. Rename the field and add a little resolve helper, requiring all usage sites to be adapted and checked for unwanted side effects.