### PR TITLE
Don't require extern(C) for CRT con/destructors

### DIFF
--- a/changelog/crt_constructor_signature.dd
+++ b/changelog/crt_constructor_signature.dd
@@ -1,0 +1,4 @@
+Relaxed `pragma(crt_constructor)` / `pragma(crt_destructor)` linkage check
+
+`extern(C)` isn't a requirement for CRT con/destructors anymore when
+using the default `void ()` signature.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3054,16 +3054,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (auto pragmadecl = sc.inlining)
             funcdecl.inlining = pragmadecl.evalPragmaInline(sc);
 
-        // check pragma(crt_constructor)
-        if (funcdecl.flags & (FUNCFLAG.CRTCtor | FUNCFLAG.CRTDtor))
-        {
-            if (funcdecl.linkage != LINK.c)
-            {
-                funcdecl.error("must be `extern(C)` for `pragma(%s)`",
-                    (funcdecl.flags & FUNCFLAG.CRTCtor) ? "crt_constructor".ptr : "crt_destructor".ptr);
-            }
-        }
-
         funcdecl.visibility = sc.visibility;
         funcdecl.userAttribDecl = sc.userAttribDecl;
         UserAttributeDeclaration.checkGNUABITag(funcdecl, funcdecl.linkage);
@@ -3250,6 +3240,16 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             tfo.trust = f.trust;
 
             funcdecl.storage_class &= ~(STC.TYPECTOR | STC.FUNCATTR);
+        }
+
+        // check pragma(crt_constructor) signature
+        if (funcdecl.flags & (FUNCFLAG.CRTCtor | FUNCFLAG.CRTDtor))
+        {
+            const idStr = (funcdecl.flags & FUNCFLAG.CRTCtor) ? "crt_constructor" : "crt_destructor";
+            if (f.nextOf().ty != Tvoid)
+                funcdecl.error("must return `void` for `pragma(%s)`", idStr.ptr);
+            if (funcdecl.linkage != LINK.c && f.parameterList.length != 0)
+                funcdecl.error("must be `extern(C)` for `pragma(%s)` when taking parameters", idStr.ptr);
         }
 
         if (funcdecl.overnext && funcdecl.isCsymbol())

--- a/test/fail_compilation/test17868b.d
+++ b/test/fail_compilation/test17868b.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ----
 fail_compilation/test17868b.d(9): Error: pragma `crt_constructor` can only apply to a single declaration
-fail_compilation/test17868b.d(10): Error: function `test17868b.foo` must be `extern(C)` for `pragma(crt_constructor)`
-fail_compilation/test17868b.d(14): Error: function `test17868b.bar` must be `extern(C)` for `pragma(crt_constructor)`
+fail_compilation/test17868b.d(14): Error: function `test17868b.bar` must return `void` for `pragma(crt_constructor)`
+fail_compilation/test17868b.d(18): Error: function `test17868b.baz` must be `extern(C)` for `pragma(crt_constructor)` when taking parameters
 ----
  */
 pragma(crt_constructor):
@@ -11,6 +11,14 @@ void foo()
 {
 }
 
-void bar()
+extern(C) int bar()
+{
+}
+
+void baz(int argc, char** argv)
+{
+}
+
+extern(C) void bazC(int, char**)
 {
 }

--- a/test/runnable/extra-files/lib18456.d
+++ b/test/runnable/extra-files/lib18456.d
@@ -2,7 +2,7 @@
 __gshared int initVar;
 
 pragma(crt_constructor)
-extern(C) void mir_cpuid_crt_init()
+void mir_cpuid_crt_init()
 {
     initVar = 42;
 }

--- a/test/runnable/test17868b.d
+++ b/test/runnable/test17868b.d
@@ -12,8 +12,6 @@ fini
 
 import core.stdc.stdio;
 
-extern(C):
-
 pragma(crt_constructor)
 pragma(crt_destructor)
 void ctor_dtor_1()
@@ -45,7 +43,7 @@ template fini()
 
 alias instantiate = fini!();
 
-int main()
+extern(C) int main()
 {
     puts("main");
     return 0;


### PR DESCRIPTION
The default signature is `void ()`, which e.g. works with C++ and D linkages just fine too. IIRC, an MSVCRT constructor is called with the `main()` arguments, so only require `extern(C)` for signatures with parameters - and newly check that all functions return `void`.

`extern(D)` CRT con/destructors are nice because they don't pollute the global C namespace and prevent symbol conflicts at link-time.