### PR TITLE
[stable] Extend LTO build with LDC to druntime modules too

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1381,7 +1381,7 @@ void processEnvironment()
                 stderr.writeln(`DMD does not support LTO! Ignoring ENABLE_LTO flag...`);
                 break;
             case "ldc":
-                dflags ~= "-flto=full";
+                dflags ~= ["-flto=full", "-defaultlib=druntime-ldc-lto"];
                 break;
             case "gdc":
                 dflags ~= "-flto";


### PR DESCRIPTION
Most LDC builds should have the LTO libs available. The official LDC packages themselves use them too, so I'd think this is low-risk.