### PR TITLE
Revert dip1000 deprecations for 2.100

### DIFF
--- a/changelog/dip1000_deprecation_warnings.dd
+++ b/changelog/dip1000_deprecation_warnings.dd
@@ -1,6 +1,0 @@
-Print warning messages unless -revert=dip1000 is used
-
-As an incentive to transition to -preview=dip1000 by default, now the
-compiler prints what would have been error messages if the flag had
-been on as deprecation messages.  This new behaviour can be disabled
-with -revert=dip1000.

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -2360,5 +2360,5 @@ private bool setUnsafeDIP1000(FuncDeclaration f)
 {
     return global.params.useDIP1000 == FeatureState.enabled
         ? f.setUnsafe()
-        : f.isSafeBypassingInference();
+        : false; // reverted for 2.100, retry in 2.101
 }

--- a/test/fail_compilation/fail_scope.d
+++ b/test/fail_compilation/fail_scope.d
@@ -2,13 +2,6 @@
 REQUIRED_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/fail_scope.d(29): Deprecation: scope variable `da` may not be returned
-fail_compilation/fail_scope.d(31): Deprecation: scope variable `o` may not be returned
-fail_compilation/fail_scope.d(32): Deprecation: scope variable `dg` may not be returned
-fail_compilation/fail_scope.d(34): Deprecation: scope variable `da` may not be returned
-fail_compilation/fail_scope.d(36): Deprecation: scope variable `o` may not be returned
-fail_compilation/fail_scope.d(37): Deprecation: scope variable `dg` may not be returned
-fail_compilation/fail_scope.d(39): Deprecation: scope variable `p` may not be returned
 fail_compilation/fail_scope.d(44): Error: returning `cast(char[])string` escapes a reference to local variable `string`
 fail_compilation/fail_scope.d(62): Error: returning `s.bar()` escapes a reference to local variable `s`
 fail_compilation/fail_scope.d(73): Error: `fail_scope.foo8` called with argument types `(int)` matches both:
@@ -22,19 +15,26 @@ fail_compilation/fail_scope.d(107): Deprecation: escaping reference to outer loc
 fail_compilation/fail_scope.d(126): Error: returning `s.bar()` escapes a reference to local variable `s`
 fail_compilation/fail_scope.d(136): Error: returning `foo16226(i)` escapes a reference to local variable `i`
 ---
+//fail_compilation/fail_scope.d(30): Error: scope variable `da` may not be returned
+//fail_compilation/fail_scope.d(32): Error: scope variable `o` may not be returned
+//fail_compilation/fail_scope.d(33): Error: scope variable `dg` may not be returned
+//fail_compilation/fail_scope.d(35): Error: scope variable `da` may not be returned
+//fail_compilation/fail_scope.d(37): Error: scope variable `o` may not be returned
+//fail_compilation/fail_scope.d(38): Error: scope variable `dg` may not be returned
+//fail_compilation/fail_scope.d(40): Error: scope variable `p` may not be returned
 */
 
 alias int delegate() dg_t;
 
-int[]  checkEscapeScope1(scope int[]  da) @safe { return da; }
-int[3] checkEscapeScope2(scope int[3] sa) @safe { return sa; }
-Object checkEscapeScope3(scope Object o)  @safe { return o;  }
-dg_t   checkEscapeScope4(scope dg_t   dg) @safe { return dg; }
+int[]  checkEscapeScope1(scope int[]  da) { return da; }
+int[3] checkEscapeScope2(scope int[3] sa) { return sa; }
+Object checkEscapeScope3(scope Object o)  { return o;  }
+dg_t   checkEscapeScope4(scope dg_t   dg) { return dg; }
 
-int[]  checkEscapeScope1() @safe { scope int[]  da = [];           return da; }
-int[3] checkEscapeScope2() @safe { scope int[3] sa = [1,2,3];      return sa; }
-Object checkEscapeScope3() @safe { scope Object  o = new Object;   return o;  }   // same with fail7294.d
-dg_t   checkEscapeScope4() @safe { scope dg_t   dg = () => 1;      return dg; }
+int[]  checkEscapeScope1() { scope int[]  da = [];           return da; }
+int[3] checkEscapeScope2() { scope int[3] sa = [1,2,3];      return sa; }
+Object checkEscapeScope3() { scope Object  o = new Object;   return o;  }   // same with fail7294.d
+dg_t   checkEscapeScope4() { scope dg_t   dg = () => 1;      return dg; }
 
 int* test(scope int* p) @safe { return p; }
 


### PR DESCRIPTION
Disable deprecation warnings introduced by https://github.com/dlang/dmd/pull/12578. Doesn't completely remove the supporting code, so re-enabling should be easy.

The release for 2.100 came faster than expected, and lots of things aren't ready yet: Documentation is still being written, better safety error messages (https://github.com/dlang/dmd/pull/13957) haven't landed, many deprecation warnings for would-be dip1000 errors are missing, and deprecation warnings it does give may be false positives since inference of `scope` / `return` is currently broken without `-preview=dip1000`.

@WalterBright @atilaneves I propose to move this change to 2.101, because I'm afraid rushing the transition is only giving confusion to users.