### PR TITLE
Put error messages in setUnsafe() 2

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1370,10 +1370,9 @@ extern (C++) abstract class Expression : ASTNode
          */
         if (v.storage_class & STC.gshared)
         {
-            if (sc.func.setUnsafe())
+            if (sc.func.setUnsafe(false, this.loc,
+                "`@safe` function `%s` cannot access `__gshared` data `%s`", sc.func, v))
             {
-                error("`@safe` %s `%s` cannot access `__gshared` data `%s`",
-                    sc.func.kind(), sc.func.toChars(), v.toChars());
                 err = true;
             }
         }
@@ -5799,9 +5798,8 @@ extern (C++) final class DelegateFuncptrExp : UnaExp
 
     override Expression modifiableLvalue(Scope* sc, Expression e)
     {
-        if (sc.func.setUnsafe())
+        if (sc.func.setUnsafe(false, this.loc, "cannot modify delegate function pointer in `@safe` code `%s`", this))
         {
-            error("cannot modify delegate function pointer in `@safe` code `%s`", toChars());
             return ErrorExp.get();
         }
         return Expression.modifiableLvalue(sc, e);

--- a/test/fail_compilation/safe_gshared.d
+++ b/test/fail_compilation/safe_gshared.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/safe_gshared.d(13): Error: `@safe` function `f` cannot access `__gshared` data `x`
+fail_compilation/safe_gshared.d(14): Error: `@safe` function `f` cannot access `__gshared` data `x`
+---
+*/
+
+__gshared int x;
+
+@safe int f()
+{
+    x++;
+    return x;
+}

--- a/test/fail_compilation/safe_pointer_index.d
+++ b/test/fail_compilation/safe_pointer_index.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/safe_pointer_index.d(11): Error: `@safe` function `f` cannot index pointer `x`
+---
+*/
+
+@safe void f(int* x)
+{
+    int y = x[0]; // allowed, same as *x
+    int z = x[1];
+}


### PR DESCRIPTION
See https://github.com/dlang/dmd/pull/14065

Adds some test cases for uncovered cases.

I'm starting to notice there is no consistent way to refer to the function in these errors: sometimes it uses `func.kind()`, other times it's simply "function". Somtimes it's `func.toPrettyChars()`, other times it's `func.toChars()`. And sometimes it's just "in `@safe` code". I'm changing them a bit here to make them more consistent (and also to work around limitations of `AttributeViolation`), but a later PR could introduce a standard way for this, making the error messages shorter.