### PR TITLE
Use setUnsafeDIP1000 in escape.d more consistently

### DIFF
--- a/test/fail_compilation/retscope2.d
+++ b/test/fail_compilation/retscope2.d
@@ -156,7 +156,7 @@ fail_compilation/retscope2.d(804): Error: scope variable `e` may not be thrown
 
 #line 800
 
-void foo800()
+void foo800() @safe
 {
     scope Exception e;
     throw e;

--- a/test/fail_compilation/test13536.d
+++ b/test/fail_compilation/test13536.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/test13536.d(23): Error: field `U.sysDg` cannot access pointers in `@safe` code that overlap other fields
-fail_compilation/test13536.d(23): Error: address of variable `s` assigned to `u` with longer lifetime
+fail_compilation/test13536.d(23): Deprecation: address of variable `s` assigned to `u` with longer lifetime
 fail_compilation/test13536.d(24): Error: field `U.safeDg` cannot access pointers in `@safe` code that overlap other fields
 ---
 */

--- a/test/fail_compilation/test16365.d
+++ b/test/fail_compilation/test16365.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/test16365.d(21): Error: `this` reference necessary to take address of member `f1` in `@safe` function `main`
 fail_compilation/test16365.d(23): Error: cannot implicitly convert expression `&f2` of type `void delegate() pure nothrow @nogc @safe` to `void function() @safe`
-fail_compilation/test16365.d(27): Error: address of variable `s` assigned to `dg` with longer lifetime
+fail_compilation/test16365.d(27): Deprecation: address of variable `s` assigned to `dg` with longer lifetime
 fail_compilation/test16365.d(28): Error: `dg.funcptr` cannot be used in `@safe` code
 ---
 */

--- a/test/fail_compilation/test22145.d
+++ b/test/fail_compilation/test22145.d
@@ -1,4 +1,5 @@
 /* TEST_OUTPUT:
+REQUIRED_ARGS: -preview=dip1000
 ---
 fail_compilation/test22145.d(115): Error: scope variable `x` assigned to non-scope `global`
 ---


### PR DESCRIPTION
For the dip1000 by default transition, `if (global.params.useDIP1000 == FeatureState.enabled)` needs to be eliminated. Currently many such checks in expressionsem.d prevent calling checkXXXescape functions in escape.d. However, removing these checks in expressionsem.d now will result in breakage, since  escape.d often uses `setUnsafe()` instead of `setUnsafeDIP1000`. This PR makes escape.d use `setUnsafeDIP1000` more consistently.