### PR TITLE
Fix Issue 23088 - This bug is a symptom of a bad error message.

### DIFF
--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -250,6 +250,9 @@ bool discardValue(Expression e)
             }
             break; // complain
         }
+    // Assumption that error => no side effect
+    case EXP.error:
+        return true;
     case EXP.variable:
         {
             VarDeclaration v = (cast(VarExp)e).var.isVarDeclaration();
@@ -362,19 +365,16 @@ bool discardValue(Expression e)
         BinExp tmp = e.isBinExp();
         assert(tmp);
 
-        e.error("`%s` may not be discarded, since it is likely a mistake", e.toChars());
+        e.error("the result of the equality expression `%s` is discarded", e.toChars());
         bool seenSideEffect = false;
         foreach(expr; [tmp.e1, tmp.e2])
         {
             if (hasSideEffect(expr)) {
-                expr.errorSupplemental("Note that `%s` may have a side effect", expr.toChars());
+                expr.errorSupplemental("note that `%s` may have a side effect", expr.toChars());
                 seenSideEffect |= true;
             }
         }
         return !seenSideEffect;
-    // Assumption that error => no side effect
-    case EXP.error:
-        return true;
     default:
         break;
     }

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -203,10 +203,9 @@ private bool lambdaHasSideEffect(Expression e, bool assumeImpureCalls = false)
                 Type t = ce.e1.type.toBasetype();
                 if (t.ty == Tdelegate)
                     t = (cast(TypeDelegate)t).next;
-                if (t.ty == Tfunction && (ce.f ? callSideEffectLevel(ce.f) : callSideEffectLevel(ce.e1.type)) > 0)
-                {
-                }
-                else
+
+                const level = t.ty == Tfunction && (ce.f ? callSideEffectLevel(ce.f) : callSideEffectLevel(ce.e1.type));
+                if (level == 0) // 0 means the function has a side effect
                     return true;
             }
             break;
@@ -251,8 +250,6 @@ bool discardValue(Expression e)
             }
             break; // complain
         }
-    case EXP.error:
-        return false;
     case EXP.variable:
         {
             VarDeclaration v = (cast(VarExp)e).var.isVarDeclaration();
@@ -356,6 +353,28 @@ bool discardValue(Expression e)
         if (!hasSideEffect(e))
             break;
         return false;
+    case EXP.identity, EXP.notIdentity:
+    case EXP.equal, EXP.notEqual:
+        /*
+            `[side effect] == 0`
+            Technically has a side effect but is clearly wrong;
+        */
+        BinExp tmp = e.isBinExp();
+        assert(tmp);
+
+        e.error("`%s` may not be discarded, since it is likely a mistake", e.toChars());
+        bool seenSideEffect = false;
+        foreach(expr; [tmp.e1, tmp.e2])
+        {
+            if (hasSideEffect(expr)) {
+                expr.errorSupplemental("Note that `%s` may have a side effect", expr.toChars());
+                seenSideEffect |= true;
+            }
+        }
+        return !seenSideEffect;
+    // Assumption that error => no side effect
+    case EXP.error:
+        return true;
     default:
         break;
     }

--- a/test/fail_compilation/fail12390.d
+++ b/test/fail_compilation/fail12390.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12390.d(14): Error: `fun().i == 4` has no effect
+fail_compilation/fail12390.d(15): Error: `fun().i == 4` may not be discarded, since it is likely a mistake
+fail_compilation/fail12390.d(15):        Note that `fun().i` may have a side effect
 ---
 */
 

--- a/test/fail_compilation/fail12390.d
+++ b/test/fail_compilation/fail12390.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12390.d(15): Error: `fun().i == 4` may not be discarded, since it is likely a mistake
-fail_compilation/fail12390.d(15):        Note that `fun().i` may have a side effect
+fail_compilation/fail12390.d(15): Error: the result of the equality expression `fun().i == 4` is discarded
+fail_compilation/fail12390.d(15):        note that `fun().i` may have a side effect
 ---
 */
 


### PR DESCRIPTION
The expression (or rather it's context is still worthy of being illegal).

This type of error message is probably worthy of having a link to a website where more context can be given as to why the expression suggests a misunderstanding.