### PR TITLE
C preprocessor: cl.exe needs to be run from the path appropriate for …

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1038,7 +1038,7 @@ public int runProgram()
  * Returns:
  *    exit status.
  */
-public int runPreprocessor(string cpp, const(char)[] filename, const(char)[] output)
+public int runPreprocessor(const(char)[] cpp, const(char)[] filename, const(char)[] output)
 {
     //printf("runPreprocessor() cpp: %.*s filename: %.*s\n", cast(int)cpp.length, cpp.ptr, cast(int)filename.length, filename.ptr);
     if (global.params.verbose)

--- a/src/dmd/vsoptions.d
+++ b/src/dmd/vsoptions.d
@@ -186,6 +186,26 @@ extern(C++) struct VSOptions
         return "link.exe";
     }
 
+    /**
+    * retrieve path to the Microsoft compiler executable
+    * Params:
+    *   x64 = target architecture (x86 if false)
+    * Returns:
+    *   absolute path to cl.exe, just "cl.exe" if not found
+    */
+    const(char)* compilerPath(bool x64)
+    {
+        const(char)* addpath;
+        if (auto p = getVCBinDir(x64, addpath))
+        {
+            OutBuffer cmdbuf;
+            cmdbuf.writestring(p);
+            cmdbuf.writestring(r"\cl.exe");
+            return cmdbuf.extractChars();
+        }
+        return "cl.exe";
+    }
+
 private:
     /**
      * detect WindowsSdkDir and WindowsSDKVersion from environment or registry


### PR DESCRIPTION
…the target architecture

allow overriding the cpp command line with environment variable CPPCMD

As a followup on https://github.com/dlang/dmd/pull/14059 and a possible prerequisite for https://github.com/dlang/dmd/pull/14090