### PR TITLE
Fix dip1000 deprecations inside dmd

### DIFF
--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -1258,7 +1258,7 @@ struct Symbol
     int Salignment;             // variables: alignment, 0 or -1 means default alignment
 
     int Salignsize()            // variables: return alignment
-    { return Symbol_Salignsize(&this); }
+    { return Symbol_Salignsize(this); }
 
     type* Stype;                // type of Symbol
     tym_t ty() const { return Stype.Tty; }
@@ -1447,10 +1447,10 @@ struct Symbol
     char[1] Sident;
 
     int needThis()              // !=0 if symbol needs a 'this' pointer
-    { return Symbol_needThis(&this); }
+    { return Symbol_needThis(this); }
 
     bool Sisdead(bool anyiasm)  // if variable is not referenced
-    { return Symbol_Sisdead(&this, anyiasm); }
+    { return Symbol_Sisdead(this, anyiasm); }
 }
 
 void symbol_debug(const Symbol* s)
@@ -1458,9 +1458,9 @@ void symbol_debug(const Symbol* s)
     debug assert(s.id == s.IDsymbol);
 }
 
-int Symbol_Salignsize(Symbol* s);
-bool Symbol_Sisdead(const Symbol* s, bool anyInlineAsm);
-int Symbol_needThis(const Symbol* s);
+int Symbol_Salignsize(ref Symbol s);
+bool Symbol_Sisdead(const ref Symbol s, bool anyInlineAsm);
+int Symbol_needThis(const ref Symbol s);
 bool Symbol_isAffected(const ref Symbol s);
 
 bool isclassmember(const Symbol* s) { return s.Sscope && s.Sscope.Sclass == SCstruct; }
@@ -1588,11 +1588,11 @@ nothrow:
     { param_t_print_list(&this); }
 }
 
-void param_t_print(const param_t* p);
-void param_t_print_list(param_t* p);
-uint param_t_length(param_t* p);
-param_t *param_t_createTal(param_t* p, param_t *ptali);
-param_t *param_t_search(param_t* p, char *id);
+void param_t_print(const scope param_t* p);
+void param_t_print_list(scope param_t* p);
+uint param_t_length(scope param_t* p);
+param_t* param_t_createTal(scope param_t* p, param_t *ptali);
+param_t* param_t_search(scope param_t* p, char *id);
 int param_t_searchn(param_t* p, char *id);
 
 

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -361,7 +361,7 @@ tryagain:
     {
         Symbol *s = globsym[i];
 
-        if (Symbol_Sisdead(s, anyiasm))
+        if (Symbol_Sisdead(*s, anyiasm))
             continue;
 
         switch (s.Sclass)
@@ -1230,8 +1230,8 @@ extern (C) int
     /* Largest align size goes furthest away from frame pointer,
      * so they get allocated first.
      */
-    uint alignsize1 = Symbol_Salignsize(s1);
-    uint alignsize2 = Symbol_Salignsize(s2);
+    uint alignsize1 = Symbol_Salignsize(*s1);
+    uint alignsize2 = Symbol_Salignsize(*s2);
     if (alignsize1 < alignsize2)
         return 1;
     else if (alignsize1 > alignsize2)
@@ -1314,7 +1314,7 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
 
             default:
             Ldefault:
-                if (Symbol_Sisdead(s, anyiasm))
+                if (Symbol_Sisdead(*s, anyiasm))
                     continue;       // don't allocate space
                 break;
         }
@@ -1323,7 +1323,7 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
         if (sz == 0)
             sz++;               // can't handle 0 length structs
 
-        uint alignsize = Symbol_Salignsize(s);
+        uint alignsize = Symbol_Salignsize(*s);
         if (alignsize > STACKALIGN)
             alignsize = STACKALIGN;         // no point if the stack is less aligned
 
@@ -1429,7 +1429,7 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
             if (sz == 0)
                 sz++;               // can't handle 0 length structs
 
-            uint alignsize = Symbol_Salignsize(s);
+            uint alignsize = Symbol_Salignsize(*s);
             if (alignsize > STACKALIGN)
                 alignsize = STACKALIGN;         // no point if the stack is less aligned
 

--- a/src/dmd/backend/cgxmm.d
+++ b/src/dmd/backend/cgxmm.d
@@ -1689,7 +1689,7 @@ bool xmmIsAligned(elem *e)
     {
         Symbol *s = e.EV.Vsym;
         const alignsz = tyalignsize(e.Ety);
-        if (Symbol_Salignsize(s) < alignsz ||
+        if (Symbol_Salignsize(*s) < alignsz ||
             e.EV.Voffset & (alignsz - 1) ||
             alignsz > STACKALIGN
            )

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -4150,7 +4150,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc, out regm_
             }
         }
 
-        if (Symbol_Sisdead(s, anyiasm))
+        if (Symbol_Sisdead(*s, anyiasm))
         {
             // Ignore it, as it is never referenced
             continue;
@@ -5411,7 +5411,7 @@ void assignaddrc(code *c)
             case FLauto:
                 soff = Auto.size;
             L1:
-                if (Symbol_Sisdead(s, anyiasm))
+                if (Symbol_Sisdead(*s, anyiasm))
                 {
                     c.Iop = NOP;               // remove references to it
                     continue;
@@ -8171,7 +8171,7 @@ void WRcodlst(code *c)
 }
 
 @trusted
-extern (C) void code_print(code* c)
+extern (C) void code_print(scope code* c)
 {
     ubyte ins;
     ubyte rexb;

--- a/src/dmd/backend/code_x86.d
+++ b/src/dmd/backend/code_x86.d
@@ -402,7 +402,7 @@ struct code
     }
 }
 
-extern (C) void code_print(code*);
+extern (C) void code_print(scope code*);
 
 /*******************
  * Some instructions.

--- a/src/dmd/backend/dtype.d
+++ b/src/dmd/backend/dtype.d
@@ -1344,7 +1344,7 @@ printf("Pident=%p,Ptype=%p,Pelem=%p,Pnext=%p ",p.Pident,p.Ptype,p.Pelem,p.Pnext)
  */
 
 @trusted
-void param_t_print(const param_t* p)
+void param_t_print(const scope param_t* p)
 {
     printf("Pident=%p,Ptype=%p,Pelem=%p,Psym=%p,Pnext=%p\n",p.Pident,p.Ptype,p.Pelem,p.Psym,p.Pnext);
     if (p.Pident)
@@ -1369,7 +1369,7 @@ void param_t_print(const param_t* p)
     }
 }
 
-void param_t_print_list(param_t* p)
+void param_t_print_list(scope param_t* p)
 {
     for (; p; p = p.Pnext)
         p.print();
@@ -1577,7 +1577,7 @@ void param_free(param_t **pparamlst)
  * Compute number of parameters
  */
 
-uint param_t_length(param_t* p)
+uint param_t_length(scope param_t* p)
 {
     uint nparams = 0;
 
@@ -1594,7 +1594,7 @@ uint param_t_length(param_t* p)
  */
 
 @trusted
-param_t *param_t_createTal(param_t* p, param_t *ptali)
+param_t* param_t_createTal(scope param_t* p, param_t *ptali)
 {
 version (SCPP_HTOD)
 {
@@ -1647,7 +1647,7 @@ version (SCPP_HTOD)
  */
 
 @trusted
-param_t *param_t_search(param_t* p, char *id)
+param_t* param_t_search(scope param_t* p, char *id)
 {
     for (; p; p = p.Pnext)
     {

--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -176,7 +176,7 @@ void symbol_keep(Symbol *s)
  * Return alignment of symbol.
  */
 @trusted
-int Symbol_Salignsize(Symbol* s)
+int Symbol_Salignsize(ref Symbol s)
 {
     if (s.Salignment > 0)
         return s.Salignment;
@@ -204,7 +204,7 @@ int Symbol_Salignsize(Symbol* s)
  */
 
 @trusted
-bool Symbol_Sisdead(const Symbol* s, bool anyInlineAsm)
+bool Symbol_Sisdead(const ref Symbol s, bool anyInlineAsm)
 {
     version (MARS)
         enum vol = false;
@@ -231,11 +231,11 @@ bool Symbol_Sisdead(const Symbol* s, bool anyInlineAsm)
  */
 
 @trusted
-int Symbol_needThis(const Symbol* s)
+int Symbol_needThis(const ref Symbol s)
 {
     //printf("needThis() '%s'\n", Sident.ptr);
 
-    debug assert(isclassmember(s));
+    debug assert(isclassmember(&s));
 
     if (s.Sclass == SCmember || s.Sclass == SCfield)
         return 1;

--- a/src/dmd/common/bitfields.d
+++ b/src/dmd/common/bitfields.d
@@ -30,7 +30,7 @@ if (__traits(isUnsigned, T))
         enum mask = "(1 << "~i.stringof~")";
         result ~= "
         /// set or get the corresponding "~structName~" member
-        bool "~mem~"() const { return !!(bitFields & "~mask~"); }
+        bool "~mem~"() const scope { return !!(bitFields & "~mask~"); }
         /// ditto
         bool "~mem~"(bool v)
         {


### PR DESCRIPTION
Needed for making dip1000 the default, since dmd cannot compile with deprecations. https://github.com/dlang/dmd/pull/14089 gives these errors currently:

```
src/dmd/mtype.d(5090): Deprecation: scope variable `other` assigned to non-scope parameter `this`
src/dmd/mtype.d(5091): Deprecation: scope variable `other` assigned to non-scope parameter `this`
src/dmd/mtype.d(5092): Deprecation: scope variable `other` assigned to non-scope parameter `this`
src/dmd/backend/cc.d(1261): Deprecation: reference to local variable `this` assigned to non-scope parameter `s`
src/dmd/backend/cc.d(1450): Deprecation: reference to local variable `this` assigned to non-scope parameter `s`
src/dmd/backend/cc.d(1453): Deprecation: reference to local variable `this` assigned to non-scope parameter `s`
src/dmd/backend/cc.d(1574): Deprecation: reference to local variable `this` assigned to non-scope parameter `p`
src/dmd/backend/cc.d(1577): Deprecation: reference to local variable `this` assigned to non-scope parameter `p`
src/dmd/backend/cc.d(1582): Deprecation: reference to local variable `this` assigned to non-scope parameter `p`
src/dmd/backend/cc.d(1585): Deprecation: reference to local variable `this` assigned to non-scope parameter `p`
src/dmd/backend/cc.d(1588): Deprecation: reference to local variable `this` assigned to non-scope parameter `p`
src/dmd/backend/code_x86.d(401): Deprecation: reference to local variable `this` assigned to non-scope parameter `__anonymous_param`
```

This PR fixes them:
- add `scope` to bitfield getters (mtype.d)
- change `Symbol*` to `ref Symbol`
- change `param_t*` to `scope param_t*`