### PR TITLE
Fix Issue 23018 - sizeof unary-expression was not parsed correctly

### DIFF
--- a/test/compilable/testcstuff2.c
+++ b/test/compilable/testcstuff2.c
@@ -684,3 +684,16 @@ int main(argc, argv)
 {
         return 0;
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=23018
+
+int xs[1];
+struct { int x; } s, *sp;
+int fn(void);
+int i;
+
+ _Static_assert( sizeof (xs)[0] == sizeof(int), "" );
+ _Static_assert( sizeof (sp)->x == sizeof(int), "" );
+_Static_assert( sizeof (s).x == sizeof(int), "" );
+_Static_assert( sizeof (fn)() == sizeof(int), "" );
+_Static_assert( sizeof (i)++ == sizeof(int), "" );

--- a/test/fail_compilation/failcstuff1.c
+++ b/test/fail_compilation/failcstuff1.c
@@ -7,7 +7,9 @@ fail_compilation/failcstuff1.c(152): Error: `;` or `,` expected
 fail_compilation/failcstuff1.c(153): Error: `void` has no value
 fail_compilation/failcstuff1.c(153): Error: missing comma
 fail_compilation/failcstuff1.c(153): Error: `;` or `,` expected
-fail_compilation/failcstuff1.c(157): Error: identifier not allowed in abstract-declarator
+fail_compilation/failcstuff1.c(157): Error: expression expected, not `struct`
+fail_compilation/failcstuff1.c(157): Error: found `S22028` when expecting `)`
+fail_compilation/failcstuff1.c(157): Error: missing comma or semicolon after declaration of `test22028`, found `ident` instead
 fail_compilation/failcstuff1.c(203): Error: storage class not allowed in specifier-qualified-list
 fail_compilation/failcstuff1.c(204): Error: storage class not allowed in specifier-qualified-list
 fail_compilation/failcstuff1.c(205): Error: storage class not allowed in specifier-qualified-list


### PR DESCRIPTION
This is fixed by improving the logic for guessing if a token is part of a type or not.
Previously it did not use the typedef-table (boo!) the parser maintains, now it does.