### PR TITLE
fix Issue 23097 - [REG 2.100] ArrayIndexError@src/dmd/mtype.d(4767): index [$-1] is out of bounds for array of length 0

### DIFF
--- a/test/compilable/test23097.d
+++ b/test/compilable/test23097.d
@@ -1,0 +1,33 @@
+/* https://issues.dlang.org/show_bug.cgi?id=23097
+REQUIRED_ARGS: -verrors=spec
+TEST_OUTPUT:
+---
+(spec:2) compilable/test23097.d(14): Error: `inout` constructor `test23097.S23097.this` creates const object, not mutable
+(spec:2) compilable/test23097.d(14): Error: `inout` constructor `test23097.S23097.this` creates const object, not mutable
+(spec:1) compilable/test23097.d(14): Error: generated function `test23097.S23097.opAssign(S23097 p)` is not callable using argument types `(const(S23097))`
+(spec:2) compilable/test23097.d(14): Error: `inout` constructor `test23097.S23097.this` creates const object, not mutable
+(spec:1) compilable/test23097.d(14):        `struct S23097` does not define a copy constructor for `const(S23097)` to `S23097` copies
+---
+*/
+void emplaceRef(UT, Args)(UT chunk, Args args)
+{
+    static if (__traits(compiles, chunk = args))
+        chunk = args;
+}
+
+struct CpCtor23097(T)
+{
+    T* payload;
+    this(ref inout typeof(this)) { }
+    ref opAssign(typeof(this)) { }
+}
+
+struct S23097
+{
+    CpCtor23097!int payload;
+}
+
+void test23097(S23097 lhs, const S23097 rhs)
+{
+    emplaceRef(lhs, rhs);
+}

--- a/test/fail_compilation/ice23097.d
+++ b/test/fail_compilation/ice23097.d
@@ -1,0 +1,28 @@
+/* https://issues.dlang.org/show_bug.cgi?id=23097
+TEST_OUTPUT:
+---
+fail_compilation/ice23097.d(12): Error: undefined identifier `ICE`
+fail_compilation/ice23097.d(27): Error: template instance `ice23097.ice23097!(S23097)` error instantiating
+fail_compilation/ice23097.d(27): Error: function `ice23097.ice23097!(S23097).ice23097(S23097 _param_0)` is not callable using argument types `(S23097)`
+fail_compilation/ice23097.d(27):        generating a copy constructor for `struct S23097` failed, therefore instances of it are uncopyable
+---
+*/
+auto ice23097(I)(I)
+{
+    ICE;
+}
+
+struct Cpctor23097
+{
+    this(ref typeof(this)) { }
+}
+
+struct S23097
+{
+    Cpctor23097 cpctor;
+}
+
+auto fail23097(S23097 s)
+{
+    s.ice23097;
+}


### PR DESCRIPTION
Poking around, this ICE was only hit with generated copy constructor functions, of which there are two kinds - those that failed to be generated (annotated with `@disable`), and those that don't match the required arguments (such as const -> mutable objects).

This uses a new supplemental error for the first case, otherwise falls back on the original generic error.