### PR TITLE
dmd: Remove capitilization of internal compiler error diagnostics

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1181,7 +1181,7 @@ UnionExp Cast(const ref Loc loc, Type type, Type to, Expression e1)
     {
         if (type != Type.terror)
         {
-            // have to change to Internal Compiler Error
+            // have to change to internal compiler error
             // all invalid casts should be handled already in Expression::castTo().
             error(loc, "cannot cast `%s` to `%s`", e1.type.toChars(), type.toChars());
         }

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -471,7 +471,7 @@ private final class CppMangleVisitor : Visitor
             }
             else
             {
-                ti.error("Internal Compiler Error: C++ `%s` template value parameter is not supported", tv.valType.toChars());
+                ti.error("internal compiler error: C++ `%s` template value parameter is not supported", tv.valType.toChars());
                 fatal();
             }
         }
@@ -506,13 +506,13 @@ private final class CppMangleVisitor : Visitor
             }
             else
             {
-                ti.error("Internal Compiler Error: C++ `%s` template alias parameter is not supported", o.toChars());
+                ti.error("internal compiler error: C++ `%s` template alias parameter is not supported", o.toChars());
                 fatal();
             }
         }
         else if (tp.isTemplateThisParameter())
         {
-            ti.error("Internal Compiler Error: C++ `%s` template this parameter is not supported", o.toChars());
+            ti.error("internal compiler error: C++ `%s` template this parameter is not supported", o.toChars());
             fatal();
         }
         else
@@ -995,7 +995,7 @@ private final class CppMangleVisitor : Visitor
         // fake mangling for fields to fix https://issues.dlang.org/show_bug.cgi?id=16525
         if (!(d.storage_class & (STC.extern_ | STC.field | STC.gshared)))
         {
-            d.error("Internal Compiler Error: C++ static non-`__gshared` non-`extern` variables not supported");
+            d.error("internal compiler error: C++ static non-`__gshared` non-`extern` variables not supported");
             fatal();
         }
         Dsymbol p = d.toParent();
@@ -1330,7 +1330,7 @@ private final class CppMangleVisitor : Visitor
             if (t.ty == Tsarray)
             {
                 // Static arrays in D are passed by value; no counterpart in C++
-                .error(loc, "Internal Compiler Error: unable to pass static array `%s` to extern(C++) function, use pointer instead",
+                .error(loc, "internal compiler error: unable to pass static array `%s` to extern(C++) function, use pointer instead",
                     t.toChars());
                 fatal();
             }
@@ -1369,7 +1369,7 @@ private final class CppMangleVisitor : Visitor
             p = "`shared` ";
         else
             p = "";
-        .error(loc, "Internal Compiler Error: %stype `%s` cannot be mapped to C++\n", p, t.toChars());
+        .error(loc, "internal compiler error: %stype `%s` cannot be mapped to C++\n", p, t.toChars());
         fatal(); //Fatal, because this error should be handled in frontend
     }
 

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -78,7 +78,7 @@ private extern (D) bool checkImmutableShared(Type type, Loc loc)
 {
     if (type.isImmutable() || type.isShared())
     {
-        error(loc, "Internal Compiler Error: `shared` or `immutable` types cannot be mapped to C++ (%s)", type.toChars());
+        error(loc, "internal compiler error: `shared` or `immutable` types cannot be mapped to C++ (%s)", type.toChars());
         fatal();
         return true;
     }
@@ -146,7 +146,7 @@ public:
         if (checkImmutableShared(type, loc))
             return;
 
-        error(loc, "Internal Compiler Error: type `%s` cannot be mapped to C++\n", type.toChars());
+        error(loc, "internal compiler error: type `%s` cannot be mapped to C++\n", type.toChars());
         fatal(); //Fatal, because this error should be handled in frontend
     }
 
@@ -588,7 +588,7 @@ extern(D):
         // fake mangling for fields to fix https://issues.dlang.org/show_bug.cgi?id=16525
         if (!(d.storage_class & (STC.extern_ | STC.field | STC.gshared)))
         {
-            d.error("Internal Compiler Error: C++ static non-__gshared non-extern variables not supported");
+            d.error("internal compiler error: C++ static non-__gshared non-extern variables not supported");
             fatal();
         }
         buf.writeByte('?');
@@ -770,7 +770,7 @@ extern(D):
     {
         if (!tv.valType.isintegral())
         {
-            sym.error("Internal Compiler Error: C++ %s template value parameter is not supported", tv.valType.toChars());
+            sym.error("internal compiler error: C++ %s template value parameter is not supported", tv.valType.toChars());
             fatal();
             return;
         }
@@ -849,7 +849,7 @@ extern(D):
                 }
                 else
                 {
-                    sym.error("Internal Compiler Error: C++ templates support only integral value, type parameters, alias templates and alias function parameters");
+                    sym.error("internal compiler error: C++ templates support only integral value, type parameters, alias templates and alias function parameters");
                     fatal();
                 }
             }
@@ -857,7 +857,7 @@ extern(D):
         }
         else
         {
-            sym.error("Internal Compiler Error: `%s` is unsupported parameter for C++ template", o.toChars());
+            sym.error("internal compiler error: `%s` is unsupported parameter for C++ template", o.toChars());
             fatal();
         }
     }
@@ -1007,7 +1007,7 @@ extern(D):
             }
             else
             {
-                sym.error("Internal Compiler Error: C++ templates support only integral value, type parameters, alias templates and alias function parameters");
+                sym.error("internal compiler error: C++ templates support only integral value, type parameters, alias templates and alias function parameters");
                 fatal();
             }
         }
@@ -1275,7 +1275,7 @@ extern(D):
                     t = cpptype;
                 if (t.ty == Tsarray)
                 {
-                    error(loc, "Internal Compiler Error: unable to pass static array to `extern(C++)` function.");
+                    error(loc, "internal compiler error: unable to pass static array to `extern(C++)` function.");
                     errorSupplemental(loc, "Use pointer instead.");
                     assert(0);
                 }

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -6340,7 +6340,7 @@ public:
         result = (*se.elements)[i];
         if (!result)
         {
-            e.error("Internal Compiler Error: null field `%s`", v.toChars());
+            e.error("internal compiler error: null field `%s`", v.toChars());
             result = CTFEExp.cantexp;
             return;
         }

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1305,7 +1305,7 @@ elem* toElem(Expression e, IRState *irs)
         }
         else
         {
-            ne.error("Internal Compiler Error: cannot new type `%s`\n", t.toChars());
+            ne.error("internal compiler error: cannot new type `%s`\n", t.toChars());
             assert(0);
         }
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2473,7 +2473,7 @@ Package resolveIsPackage(Dsymbol sym)
     {
         if (imp.pkg is null)
         {
-            .error(sym.loc, "Internal Compiler Error: unable to process forward-referenced import `%s`",
+            .error(sym.loc, "internal compiler error: unable to process forward-referenced import `%s`",
                     imp.toChars());
             assert(0);
         }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -4831,7 +4831,7 @@ private Statement toStatement(Dsymbol s)
     }
     else
     {
-        .error(Loc.initial, "Internal Compiler Error: cannot mixin %s `%s`\n", s.kind(), s.toChars());
+        .error(Loc.initial, "internal compiler error: cannot mixin %s `%s`\n", s.kind(), s.toChars());
         result = new ErrorStatement();
     }
 

--- a/test/fail_compilation/ice22377.d
+++ b/test/fail_compilation/ice22377.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice22377.d(8): Error: Internal Compiler Error: type `string` cannot be mapped to C++
+fail_compilation/ice22377.d(8): Error: internal compiler error: type `string` cannot be mapped to C++
 ---
 */
 


### PR DESCRIPTION
Same as #14103, but applied only on ICE diagnostics.  Separated as may be contentious bike shedding (it may well be better to introduce a new function just for internal errors, or switch them over to assert).