### PR TITLE
Fix issue 23100 - empty array literal passed to scope param not 'fals…

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2058,10 +2058,10 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
 
                 ArrayLiteralExp ale;
                 if (p.type.toBasetype().ty == Tarray &&
-                    (ale = a.isArrayLiteralExp()) !is null)
+                    (ale = a.isArrayLiteralExp()) !is null && ale.elements && ale.elements.length > 0)
                 {
                     // allocate the array literal as temporary static array on the stack
-                    ale.type = ale.type.nextOf().sarrayOf(ale.elements ? ale.elements.length : 0);
+                    ale.type = ale.type.nextOf().sarrayOf(ale.elements.length);
                     auto tmp = copyToTemp(0, "__arrayliteral_on_stack", ale);
                     auto declareTmp = new DeclarationExp(ale.loc, tmp);
                     auto castToSlice = new CastExp(ale.loc, new VarExp(ale.loc, tmp),

--- a/test/runnable/test20734.d
+++ b/test/runnable/test20734.d
@@ -16,6 +16,7 @@ extern(C) int main() nothrow @nogc @safe
 {
     takeScopeSlice([ S(1), S(2) ]); // @nogc => no GC allocation
     (() @trusted { assert(numDtor == 2); })(); // stack-allocated array literal properly destructed
+    assert23100([]);
     return 0;
 }
 
@@ -25,4 +26,10 @@ void f23098(scope inout(int)[] d) @safe {}
 void test23098() @safe
 {
     f23098([10, 20]);
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=23100
+void assert23100(scope int[] d) @safe nothrow @nogc
+{
+    assert(!d);
 }


### PR DESCRIPTION
…ey' anymore

Uncovered by https://github.com/nomad-software/dunit/blob/7aabca699cbfe32581754b19a2b93d1b4178ebdc/source/dunit/toolkit.d#L474 on buildkite of https://github.com/dlang/dmd/pull/14089