### PR TITLE
Give checkNewEscape errors in safe code only

### DIFF
--- a/test/fail_compilation/test18282.d
+++ b/test/fail_compilation/test18282.d
@@ -60,7 +60,7 @@ TEST_OUTPUT:
 fail_compilation/test18282.d(1007): Error: copying `& foo` into allocated memory escapes a reference to local variable `foo`
 fail_compilation/test18282.d(1008): Error: copying `& foo` into allocated memory escapes a reference to local variable `foo`
 fail_compilation/test18282.d(1009): Error: copying `& foo` into allocated memory escapes a reference to local variable `foo`
-fail_compilation/test18282.d(1016): Error: copying `&this` into allocated memory escapes a reference to parameter variable `this`
+fail_compilation/test18282.d(1016): Error: copying `&this` into allocated memory escapes a reference to parameter `this`
 ---
 */
 

--- a/test/fail_compilation/test20245.d
+++ b/test/fail_compilation/test20245.d
@@ -3,11 +3,11 @@ REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test20245.d(20): Error: reference to local variable `x` assigned to non-scope parameter `ptr`
-fail_compilation/test20245.d(21): Error: copying `&x` into allocated memory escapes a reference to parameter variable `x`
+fail_compilation/test20245.d(21): Error: copying `&x` into allocated memory escapes a reference to parameter `x`
 fail_compilation/test20245.d(22): Error: scope variable `a` may not be returned
 fail_compilation/test20245.d(26): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
 fail_compilation/test20245.d(32): Error: reference to local variable `x` assigned to non-scope parameter `ptr`
-fail_compilation/test20245.d(33): Error: copying `&x` into allocated memory escapes a reference to parameter variable `x`
+fail_compilation/test20245.d(33): Error: copying `&x` into allocated memory escapes a reference to parameter `x`
 fail_compilation/test20245.d(49): Error: reference to local variable `price` assigned to non-scope `this.minPrice`
 fail_compilation/test20245.d(68): Error: reference to local variable `this` assigned to non-scope parameter `msg`
 fail_compilation/test20245.d(88): Error: reference to local variable `this` assigned to non-scope parameter `content`


### PR DESCRIPTION
Previous work: https://github.com/dlang/dmd/pull/14088
