### PR TITLE
Limit 'address of `ref`' errors to safe code

### DIFF
--- a/test/fail_compilation/dip25.d
+++ b/test/fail_compilation/dip25.d
@@ -12,15 +12,15 @@ fail_compilation/dip25.d(23):        perhaps annotate the parameter with `return
 struct Data
 {
     char[256] buffer;
-    @property const(char)[] filename() const pure nothrow
+    @property const(char)[] filename() const pure nothrow @safe
     {
         return buffer[];
     }
 }
 
-ref int identity(return ref int x) { return x; }
+ref int identity(return ref int x) @safe { return x; }
 ref int fun(return int x) { return identity(x); }
-ref int fun2(ref int x) { return identity(x); }
+ref int fun2(ref int x) @safe { return identity(x); }
 
 void main()
 {

--- a/test/fail_compilation/fail21868b.d
+++ b/test/fail_compilation/fail21868b.d
@@ -14,7 +14,7 @@ struct S
     int* y;
 }
 
-int* test(ref return scope S s)
+int* test(ref return scope S s) @safe
 {
     return &s.x;
 }

--- a/test/fail_compilation/test18484.d
+++ b/test/fail_compilation/test18484.d
@@ -10,11 +10,11 @@ fail_compilation/test18484.d(24): Error: escaping reference to stack allocated v
 
 struct S
 {
-    int* bar() return;
+    int* bar() @safe return;
     int i;
 }
 
-int* test1()
+int* test1() @safe
 {
     auto x = S(); return x.bar();  // error
 }


### PR DESCRIPTION
Returning the address of a ref variable is rejected even in `@system` code, even though it is allowed as soon as there is an intermediate assignment: https://github.com/dlang/dmd/pull/13993#issuecomment-1100646152

This inconsistency makes that adding `return scope`, which should strictly improve safety compared to a parameter without any scope annotations, can break `@system` code. This blocks https://github.com/dlang/dmd/pull/14100