### PR TITLE
Move dip1000 checkAddrVar functionality to escape.d

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1695,14 +1695,6 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             {
                 // T[n] sa;
                 // cast(U[])sa; // ==> cast(U[])sa[];
-                if (global.params.useDIP1000 == FeatureState.enabled)
-                {
-                    if (auto v = expToVariable(e))
-                    {
-                        if (e.type.hasPointers() && !checkAddressVar(sc, e, v))
-                            goto Lfail;
-                    }
-                }
                 const fsize = t1b.nextOf().size();
                 const tsize = tob.nextOf().size();
                 if (fsize == SIZE_INVALID || tsize == SIZE_INVALID)

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -2478,10 +2478,17 @@ private bool setUnsafeDIP1000(Scope* sc, bool gag, Loc loc, const(char)* msg, Ro
  */
 private bool checkScopeVarAddr(VarDeclaration v, Expression e, Scope* sc, bool gag)
 {
-    if (!e.type)
+    if (v.storage_class & STC.temp)
         return false;
 
-    if ((v.storage_class & STC.temp) || !v.isScope())
+    if (!v.isScope())
+    {
+        v.storage_class &= ~STC.maybescope;
+        v.doNotInferScope = true;
+        return false;
+    }
+
+    if (!e.type)
         return false;
 
     // When the type after dereferencing has no pointers, it's okay.


### PR DESCRIPTION
checkAddrVar does two things:
- without dip1000, prevent taking the address with `&` of local variables in `@safe` code
- with dip1000, check transitive scope errors, and prevent aliased pointers to be inferred `scope`

`expToVariable` is exactly what `escapeByRef` does already, so essentially part of escape.d is re-implemented in expressionsem.d, which hinders the dip1000 by default transition. Hence, this PR moves the dip1000 part of `checkAddrVar` to `checkScopeVarAddr`.