### PR TITLE
ImportC - First go at implementing mixinC (In this iteration it has t…

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4618,16 +4618,17 @@ extern (C++) class BinAssignExp : BinExp
 extern (C++) final class MixinExp : Expression
 {
     Expressions* exps;
-
-    extern (D) this(const ref Loc loc, Expressions* exps)
+    const FileType language;
+    extern (D) this(const ref Loc loc, Expressions* exps, const FileType lang)
     {
         super(loc, EXP.mixin_, __traits(classInstanceSize, MixinExp));
         this.exps = exps;
+        this.language = lang;
     }
 
     override MixinExp syntaxCopy()
     {
-        return new MixinExp(loc, arraySyntaxCopy(exps));
+        return new MixinExp(loc, arraySyntaxCopy(exps), this.language);
     }
 
     override bool equals(const RootObject o) const

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5927,23 +5927,49 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (expressionsToString(buf, sc, exp.exps))
             return null;
 
-        uint errors = global.errors;
+        const errors = global.errors;
         const len = buf.length;
         const str = buf.extractChars()[0 .. len];
-        scope p = new Parser!ASTCodegen(exp.loc, sc._module, str, false);
-        p.nextToken();
-        //printf("p.loc.linnum = %d\n", p.loc.linnum);
 
-        Expression e = p.parseExpression();
-        if (global.errors != errors)
-            return null;
-
-        if (p.token.value != TOK.endOfFile)
+        switch (exp.language)
+        with(FileType)
         {
-            exp.error("incomplete mixin expression `%s`", str.ptr);
-            return null;
+            case d:
+                scope p = new Parser!ASTCodegen(exp.loc, sc._module, str, false);
+                p.nextToken();
+                //printf("p.loc.linnum = %d\n", p.loc.linnum);
+
+                Expression e = p.parseExpression();
+                if (global.errors != errors)
+                    return null;
+
+                if (p.token.value != TOK.endOfFile)
+                {
+                    exp.error("incomplete mixin expression `%s`", str.ptr);
+                    return null;
+                }
+                return e.expressionSemantic(sc);
+            case c:
+                import dmd.cparse : CParser;
+                scope p = new CParser!ASTCodegen(sc._module, str, false, target.c);
+                p.nextToken();
+
+                Expression e = p.cparseExpression();
+                if (global.errors != errors)
+                    return null;
+
+                if (p.token.value != TOK.endOfFile)
+                {
+                    exp.error("incomplete mixin[C] expression `%s`", str.ptr);
+                    return null;
+                }
+                Scope* cScope = sc.push();
+                if (exp.language == FileType.c)
+                    cScope.flags |= SCOPE.Cfile;
+                return e.expressionSemantic(cScope);
+            default:
+                assert(0, "Invalid FileType");
         }
-        return e;
     }
 
     override void visit(MixinExp exp)
@@ -5959,7 +5985,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         auto e = compileIt(exp);
         if (!e)
             return setError();
-        result = e.expressionSemantic(sc);
+        result = e;
     }
 
     override void visit(ImportExp e)

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -8331,10 +8331,28 @@ LagainStc:
             {
                 // https://dlang.org/spec/expression.html#mixin_expressions
                 nextToken();
-                if (token.value != TOK.leftParenthesis)
+                if (token.value != TOK.leftParenthesis && token.value != TOK.leftBracket)
                     error("found `%s` when expecting `%s` following `mixin`", token.toChars(), Token.toChars(TOK.leftParenthesis));
+                FileType mixinLanguage = FileType.d;
+                // look for mixin[C](args)
+                if (token.value == TOK.leftBracket)
+                {
+                    check(TOK.leftBracket);
+                    Identifier language = token.ident;
+                    if (language == Id.D)
+                    {
+                        mixinLanguage = FileType.d;
+                    } else if (language == Id.C)
+                    {
+                        mixinLanguage = FileType.c;
+                    } else {
+                        error("Invalid mixin language");
+                    }
+                    check(TOK.identifier);
+                    check(TOK.rightBracket);
+                }
                 auto exps = parseArguments();
-                e = new AST.MixinExp(loc, exps);
+                e = new AST.MixinExp(loc, exps, mixinLanguage);
                 break;
             }
         case TOK.import_:

--- a/test/compilable/mixinc.d
+++ b/test/compilable/mixinc.d
@@ -1,0 +1,16 @@
+struct Ty
+{
+  int x;
+}
+void main()
+{
+  float f = 420.0;
+  Ty* ptr = new Ty;
+  ptr.x = 299792458;
+  int xx;
+  long yx;
+  static assert(!__traits(compiles, xx = yx));
+  int res = mixin[C]("xx = yx");
+  int x = mixin[C]("(int) f");
+  auto g = mixin[C]("sizeof(struct Ty)");
+}


### PR DESCRIPTION
…he syntax

mixin[C], bikeshed away) - Currently just for expressions.

We don't capture macros yet so this isn't particularly useful just yet (we do have
a small macro engine for ddoc so maybe we don't need to reimplement the preprocessor), but
it's important to know the semantic analysis is actually possible (it seems like it is?)