### PR TITLE
chore(docs): fix link in changelog

### DIFF
--- a/changelog/mustUse.dd
+++ b/changelog/mustUse.dd
@@ -6,4 +6,4 @@ be used to implement alternative error-handling mechanisms for code that cannot
 use exceptions, including `@nogc` and BetterC code.
 
 For more information, see
-$(LINK https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1038.md, DIP 1038).
+$(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1038.md, DIP 1038).


### PR DESCRIPTION
This link as-is is broken at https://dlang.org/changelog/2.100.0.html#mustUse leading to "https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1038.md,%20DIP%201038".

I may be incorrect on the best approach to fix it, but I am hoping this is right.
This change to LINK2 is based on the README.md in this folder, as well as sibling files like deprecation_delete.dd.