### PR TITLE
Fix Issue 23105 - `__trait(getMember)` and `mixin()` of the same code as a string behave differently

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -63,7 +63,6 @@ enum SCOPE
     free          = 0x8000,   /// is on free list
 
     fullinst      = 0x10000,  /// fully instantiate templates
-    alias_        = 0x20000,  /// inside alias declaration.
 
     // The following are mutually exclusive
     printf        = 0x4_0000, /// printf-style function

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -6423,13 +6423,8 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
     ds.visibility = sc.visibility;
     ds.userAttribDecl = sc.userAttribDecl;
 
-    // TypeTraits needs to know if it's located in an AliasDeclaration
-    const oldflags = sc.flags;
-    sc.flags |= SCOPE.alias_;
-
     void normalRet()
     {
-        sc.flags = oldflags;
         ds.inuse = 0;
         ds.semanticRun = PASS.semanticdone;
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3765,7 +3765,7 @@ class TypeTraits final : public Type
 public:
     Loc loc;
     TraitsExp* exp;
-    Dsymbol* sym;
+    RootObject* obj;
     const char* kind() const;
     TypeTraits* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5221,8 +5221,8 @@ extern (C++) final class TypeTraits : Type
     Loc loc;
     /// The expression to resolve as type or symbol.
     TraitsExp exp;
-    /// After `typeSemantic` the symbol when `exp` doesn't represent a type.
-    Dsymbol sym;
+    /// Cached type/symbol after semantic analysis.
+    RootObject obj;
 
     final extern (D) this(const ref Loc loc, TraitsExp exp)
     {

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -670,8 +670,8 @@ class TypeTraits : public Type
     Loc loc;
     /// The expression to resolve as type or symbol.
     TraitsExp *exp;
-    /// The symbol when exp doesn't represent a type.
-    Dsymbol *sym;
+    /// Cached type/symbol after semantic analysis.
+    RootObject *obj;
 
     const char *kind();
     TypeTraits *syntaxCopy();

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1788,111 +1788,18 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
     Type visitTraits(TypeTraits mtype)
     {
-        if (mtype.ty == Terror)
-            return mtype;
+        Expression e;
+        Type t;
+        Dsymbol s;
+        mtype.resolve(loc, sc, e, t, s);
 
-        const inAlias = (sc.flags & SCOPE.alias_) != 0;
-        if (mtype.exp.ident != Id.allMembers &&
-            mtype.exp.ident != Id.derivedMembers &&
-            mtype.exp.ident != Id.getMember &&
-            mtype.exp.ident != Id.parent &&
-            mtype.exp.ident != Id.parameters &&
-            mtype.exp.ident != Id.child &&
-            mtype.exp.ident != Id.toType &&
-            mtype.exp.ident != Id.getOverloads &&
-            mtype.exp.ident != Id.getVirtualFunctions &&
-            mtype.exp.ident != Id.getVirtualMethods &&
-            mtype.exp.ident != Id.getAttributes &&
-            mtype.exp.ident != Id.getUnitTests &&
-            mtype.exp.ident != Id.getAliasThis)
-        {
-            static immutable (const(char)*)[2] ctxt = ["as type", "in alias"];
-            .error(mtype.loc, "trait `%s` is either invalid or not supported %s",
-                 mtype.exp.ident.toChars, ctxt[inAlias]);
-            mtype.ty = Terror;
-            return mtype;
-        }
-
-        import dmd.traits : semanticTraits;
-        Type result;
-
-        if (Expression e = semanticTraits(mtype.exp, sc))
-        {
-            switch (e.op)
-            {
-            case EXP.dotVariable:
-                mtype.sym = e.isDotVarExp().var;
-                break;
-            case EXP.variable:
-                mtype.sym = e.isVarExp().var;
-                break;
-            case EXP.function_:
-                auto fe = e.isFuncExp();
-                mtype.sym = fe.td ? fe.td : fe.fd;
-                break;
-            case EXP.dotTemplateDeclaration:
-                mtype.sym = e.isDotTemplateExp().td;
-                break;
-            case EXP.dSymbol:
-                mtype.sym = e.isDsymbolExp().s;
-                break;
-            case EXP.template_:
-                mtype.sym = e.isTemplateExp().td;
-                break;
-            case EXP.scope_:
-                mtype.sym = e.isScopeExp().sds;
-                break;
-            case EXP.tuple:
-                TupleExp te = e.isTupleExp();
-                Objects* elems = new Objects(te.exps.dim);
-                foreach (i; 0 .. elems.dim)
-                {
-                    auto src = (*te.exps)[i];
-                    switch (src.op)
-                    {
-                    case EXP.type:
-                        (*elems)[i] = src.isTypeExp().type;
-                        break;
-                    case EXP.dotType:
-                        (*elems)[i] = src.isDotTypeExp().sym.isType();
-                        break;
-                    case EXP.overloadSet:
-                        (*elems)[i] = src.isOverExp().type;
-                        break;
-                    default:
-                        if (auto sym = isDsymbol(src))
-                            (*elems)[i] = sym;
-                        else
-                            (*elems)[i] = src;
-                    }
-                }
-                TupleDeclaration td = new TupleDeclaration(e.loc, Identifier.generateId("__aliastup"), elems);
-                mtype.sym = td;
-                break;
-            case EXP.dotType:
-                result = e.isDotTypeExp().sym.isType();
-                break;
-            case EXP.type:
-                result = e.isTypeExp().type;
-                break;
-            case EXP.overloadSet:
-                result = e.isOverExp().type;
-                break;
-            default:
-                break;
-            }
-        }
-
-        if (result)
-            result = result.addMod(mtype.mod);
-        if (!inAlias && !result)
+        if (!t)
         {
             if (!global.errors)
                 .error(mtype.loc, "`%s` does not give a valid type", mtype.toChars);
             return error();
         }
-
-        return result;
+        return t;
     }
 
     Type visitReturn(TypeReturn mtype)
@@ -3327,12 +3234,94 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
         mt.obj = pe ? pe : (pt ? pt : ps);
     }
 
-    void visitTraits(TypeTraits tt)
+    void visitTraits(TypeTraits mt)
     {
-        if (Type t = typeSemantic(tt, loc, sc))
-            returnType(t);
-        else if (tt.sym)
-            returnSymbol(tt.sym);
+        // if already resolved just return the cached object.
+        if (mt.obj)
+        {
+            pt = mt.obj.isType();
+            ps = mt.obj.isDsymbol();
+            return;
+        }
+
+        import dmd.traits : semanticTraits;
+
+        if (Expression e = semanticTraits(mt.exp, sc))
+        {
+            switch (e.op)
+            {
+            case EXP.dotVariable:
+                mt.obj = e.isDotVarExp().var;
+                break;
+            case EXP.variable:
+                mt.obj = e.isVarExp().var;
+                break;
+            case EXP.function_:
+                auto fe = e.isFuncExp();
+                mt.obj = fe.td ? fe.td : fe.fd;
+                break;
+            case EXP.dotTemplateDeclaration:
+                mt.obj = e.isDotTemplateExp().td;
+                break;
+            case EXP.dSymbol:
+                mt.obj = e.isDsymbolExp().s;
+                break;
+            case EXP.template_:
+                mt.obj = e.isTemplateExp().td;
+                break;
+            case EXP.scope_:
+                mt.obj = e.isScopeExp().sds;
+                break;
+            case EXP.tuple:
+                TupleExp te = e.isTupleExp();
+                Objects* elems = new Objects(te.exps.dim);
+                foreach (i; 0 .. elems.dim)
+                {
+                    auto src = (*te.exps)[i];
+                    switch (src.op)
+                    {
+                    case EXP.type:
+                        (*elems)[i] = src.isTypeExp().type;
+                        break;
+                    case EXP.dotType:
+                        (*elems)[i] = src.isDotTypeExp().sym.isType();
+                        break;
+                    case EXP.overloadSet:
+                        (*elems)[i] = src.isOverExp().type;
+                        break;
+                    default:
+                        if (auto sym = isDsymbol(src))
+                            (*elems)[i] = sym;
+                        else
+                            (*elems)[i] = src;
+                    }
+                }
+                TupleDeclaration td = new TupleDeclaration(e.loc, Identifier.generateId("__aliastup"), elems);
+                mt.obj = td;
+                break;
+            case EXP.dotType:
+                mt.obj = e.isDotTypeExp().sym.isType();
+                break;
+            case EXP.type:
+                mt.obj = e.isTypeExp().type;
+                break;
+            case EXP.overloadSet:
+                mt.obj = e.isOverExp().type;
+                break;
+            default:
+                break;
+            }
+        }
+
+        if (mt.obj)
+        {
+            if (auto t = mt.obj.isType())
+                returnType(t.addMod(mt.mod));
+            else if (auto s = mt.obj.isDsymbol())
+                returnSymbol(s);
+            else
+                assert(0);
+        }
         else
             return returnError();
     }

--- a/test/compilable/test23105.d
+++ b/test/compilable/test23105.d
@@ -1,0 +1,6 @@
+// https://issues.dlang.org/show_bug.cgi?id=23105
+
+module test23105;
+
+static assert(is(mixin(`__traits(getMember, test23105, "object")`) == module));
+static assert(is(__traits(getMember, test23105, "object") == module)); // Fixed

--- a/test/fail_compilation/e7804_1.d
+++ b/test/fail_compilation/e7804_1.d
@@ -1,11 +1,18 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/e7804_1.d(10): Error: trait `farfelu` is either invalid or not supported as type
-fail_compilation/e7804_1.d(11): Error: trait `farfelu` is either invalid or not supported in alias
+fail_compilation/e7804_1.d(14): Error: undefined identifier `Aggr`
+fail_compilation/e7804_1.d(15): Error: unrecognized trait `farfelu`
+fail_compilation/e7804_1.d(17): Error: undefined identifier `Aggr`
+fail_compilation/e7804_1.d(18): Error: unrecognized trait `farfelu`
 ---
 */
 module e7804_1;
 
+struct S {}
+
 __traits(farfelu, Aggr, "member") a;
+__traits(farfelu, S, "member") a2;
+
 alias foo = __traits(farfelu, Aggr, "member");
+alias foo2 = __traits(farfelu, S, "member");


### PR DESCRIPTION
The fix is to remove the `SCOPE.alias_` dependency when resolving
TypeTraits on certain conditions, it's not necessary, the trait
resolves to type or symbol naturally.

Changes:
- Remove `SCOPE.alias_` as it is no longer used.
- Remove a huge `if` with an early error from `TypeTraits` typeSemantic.
- Cache not only symbols but also types in TypeTraits
(TypeTraits.sym -> TypeTraits.obj).
- Move `TypeTraits.typeSemantic` logic to `TypeTraits.resolve` since
`typeSemantic` should only care about giving a type and `resolve`
about maybe something else (like TypeMixin logic).