### PR TITLE
fix Issue 23109 - ICE: AssertError@src/dmd/dclass.d(449): Assertion failure

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6626,6 +6626,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             exp.type = exp.type.addMod(t1.mod);
 
+            // https://issues.dlang.org/show_bug.cgi?id=23109
+            // Run semantic on the DotVarExp type
+            if (auto handle = exp.type.isClassHandle())
+            {
+                if (handle.semanticRun < PASS.semanticdone && !handle.isBaseInfoComplete())
+                    handle.dsymbolSemantic(null);
+            }
+
             Dsymbol vparent = exp.var.toParent();
             AggregateDeclaration ad = vparent ? vparent.isAggregateDeclaration() : null;
             if (Expression e1x = getRightThis(exp.loc, sc, ad, exp.e1, exp.var, 1))

--- a/test/fail_compilation/extra-files/test23109/object.d
+++ b/test/fail_compilation/extra-files/test23109/object.d
@@ -1,0 +1,17 @@
+module object;
+
+alias size_t = typeof(int.sizeof);
+class Object {}
+auto opEquals(Object ) { return true; }
+class TypeInfo {}
+class TypeInfo_Const {}
+bool _xopEquals() { return true; }
+
+bool __equals(T1, T2)(T1[] lhs, T2[] rhs)
+{
+    static at(R)(R[] r, size_t i) { return r.ptr[i]; }
+    foreach (u; 0 .. lhs.length)
+        if (at(lhs, u) != at(rhs, u))
+            return false;
+    return true;
+}

--- a/test/fail_compilation/fail23109.d
+++ b/test/fail_compilation/fail23109.d
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=23109
+/*
+EXTRA_FILES: imports/test23109a.d imports/test23109b.d imports/test23109c.d
+EXTRA_SOURCES: extra-files/test23109/object.d
+TEST_OUTPUT:
+---
+Error: no property `getHash` for type `object.TypeInfo_Const`
+Error: no property `getHash` for type `object.TypeInfo_Const`
+fail_compilation/imports/test23109a.d(10): Error: template instance `imports.test23109a.Array!(Ensure)` error instantiating
+---
+*/
+import imports.test23109a;

--- a/test/fail_compilation/imports/test23109a.d
+++ b/test/fail_compilation/imports/test23109a.d
@@ -1,0 +1,10 @@
+module imports.test23109a;
+import imports.test23109c;
+import imports.test23109b;
+struct Array(T)
+{
+    T[] data;
+    enum SMALLARRAYCAP = 1;
+    T[SMALLARRAYCAP] smallarray;
+}
+alias Ensures = Array!Ensure;

--- a/test/fail_compilation/imports/test23109b.d
+++ b/test/fail_compilation/imports/test23109b.d
@@ -1,0 +1,10 @@
+module imports.test23109b;
+import imports.test23109a;
+import imports.test23109c;
+struct Ensure
+{
+    Statement ensure;
+    Ensures* arraySyntaxCopy()
+    {
+    }
+}

--- a/test/fail_compilation/imports/test23109c.d
+++ b/test/fail_compilation/imports/test23109c.d
@@ -1,0 +1,3 @@
+module imports.test23109c;
+import imports.test23109b;
+class Statement {}


### PR DESCRIPTION
Yet more ClassDeclaration semantic that was originally lazily evaluated in `isBaseOf`. This time the ICE only affects bad code.