### PR TITLE
fix Issue 23108 - ICE: AssertError@src/dmd/clone.d(567): Assertion failure

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -563,9 +563,12 @@ FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
         e = new DotIdExp(sd.loc, e, Id.object);
         e = new DotIdExp(sd.loc, e, id);
         e = e.expressionSemantic(sc);
-        Dsymbol s = getDsymbol(e);
-        assert(s);
-        sd.xerreq = s.isFuncDeclaration();
+        if (!e.isErrorExp())
+        {
+            Dsymbol s = getDsymbol(e);
+            assert(s);
+            sd.xerreq = s.isFuncDeclaration();
+        }
     }
     Loc declLoc; // loc is unnecessary so __xopEquals is never called directly
     Loc loc; // loc is unnecessary so errors are gagged
@@ -684,9 +687,12 @@ FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
         e = new DotIdExp(sd.loc, e, Id.object);
         e = new DotIdExp(sd.loc, e, id);
         e = e.expressionSemantic(sc);
-        Dsymbol s = getDsymbol(e);
-        assert(s);
-        sd.xerrcmp = s.isFuncDeclaration();
+        if (!e.isErrorExp())
+        {
+            Dsymbol s = getDsymbol(e);
+            assert(s);
+            sd.xerrcmp = s.isFuncDeclaration();
+        }
     }
     Loc declLoc; // loc is unnecessary so __xopCmp is never called directly
     Loc loc; // loc is unnecessary so errors are gagged

--- a/test/fail_compilation/fail23108a.d
+++ b/test/fail_compilation/fail23108a.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=23108
+/* TEST_OUTPUT:
+---
+fail_compilation/fail23108a.d(9): Error: undefined identifier `_xopEquals` in module `object`
+---
+*/
+module object;
+
+struct Interface
+{
+    void[] vtbl;
+}
+
+class TypeInfo
+{
+}

--- a/test/fail_compilation/fail23108b.d
+++ b/test/fail_compilation/fail23108b.d
@@ -1,0 +1,18 @@
+// https://issues.dlang.org/show_bug.cgi?id=23108
+/* TEST_OUTPUT:
+---
+fail_compilation/fail23108b.d(10): Error: undefined identifier `_xopEquals` in module `object`
+fail_compilation/fail23108b.d(10): Error: undefined identifier `_xopCmp` in module `object`
+---
+*/
+module object;
+
+struct Interface
+{
+    void[] vtbl;
+    int opCmp() { return 0; }
+}
+
+class TypeInfo
+{
+}


### PR DESCRIPTION
Don't ICE if `_xopCmp` or `_xopEquals` doesn't exist, just let semantic continue and issue an error.