### PR TITLE
fix Issue 16575 - [ICE] extern(C++) function with D specific types

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -888,6 +888,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         else if (dsym.storage_class & STC.manifest)
             dsym.error("manifest constants must have initializers");
 
+        // Don't allow non-extern, non-__gshared variables to be interfaced with C++
+        if (dsym._linkage == LINK.cpp && !(dsym.storage_class & (STC.ctfe | STC.extern_ | STC.gshared)) && dsym.isDataseg())
+        {
+            const char* p = (dsym.storage_class & STC.shared_) ? "shared" : "static";
+            dsym.error("cannot have `extern(C++)` linkage because it is `%s`", p);
+            errorSupplemental(dsym.loc, "perhaps declare it as `__gshared` instead");
+            dsym.errors = true;
+        }
+
         bool isBlit = false;
         uinteger_t sz;
         if (sc.flags & SCOPE.Cfile && !dsym._init)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1154,7 +1154,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             //printf("already done\n");
             return mtype;
         }
-        //printf("TypeFunction::semantic() this = %p\n", this);
+        //printf("TypeFunction::semantic() this = %p\n", mtype);
         //printf("TypeFunction::semantic() %s, sc.stc = %llx\n", mtype.toChars(), sc.stc);
 
         bool errors = false;

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1327,3 +1327,8 @@ extern (C++)
             static assert(funccpp.mangleof == "?funccpp@@YAHP6AXXZ@Z");
     }
 }
+
+/*****************************************/
+
+extern(C++) enum _LIBNAME = "library";
+extern(C++) enum _DEBUG = _LIBNAME.length && 'd' == _LIBNAME[$-1];

--- a/test/compilable/test20427.d
+++ b/test/compilable/test20427.d
@@ -1,0 +1,3 @@
+// https://issues.dlang.org/show_bug.cgi?id=20427
+extern(C++) void test20427(T)(T) {}
+static assert(!__traits(compiles, { test20427([1, 2]); }));

--- a/test/fail_compilation/cppvar.d
+++ b/test/fail_compilation/cppvar.d
@@ -1,0 +1,8 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/cppvar.d(10): Error: delegate `cppvar.__lambda3` cannot return type `bool[3]` because its linkage is `extern(C++)`
+---
+*/
+#line 10
+extern(C++) bool[3] funcLiteral = () { bool[3] a; return a; };

--- a/test/fail_compilation/cppvar.d
+++ b/test/fail_compilation/cppvar.d
@@ -1,8 +1,22 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/cppvar.d(10): Error: delegate `cppvar.__lambda3` cannot return type `bool[3]` because its linkage is `extern(C++)`
+fail_compilation/cppvar.d(10): Error: variable `cppvar.funcLiteral` cannot have `extern(C++)` linkage because it is `static`
+fail_compilation/cppvar.d(10):        perhaps declare it as `__gshared` instead
+fail_compilation/cppvar.d(20): Error: variable `cppvar.threadLocalVar` cannot have `extern(C++)` linkage because it is `static`
+fail_compilation/cppvar.d(20):        perhaps declare it as `__gshared` instead
+fail_compilation/cppvar.d(21): Error: variable `cppvar.staticVar` cannot have `extern(C++)` linkage because it is `static`
+fail_compilation/cppvar.d(21):        perhaps declare it as `__gshared` instead
+fail_compilation/cppvar.d(22): Error: variable `cppvar.sharedVar` cannot have `extern(C++)` linkage because it is `shared`
+fail_compilation/cppvar.d(22):        perhaps declare it as `__gshared` instead
+fail_compilation/cppvar.d(30): Error: delegate `cppvar.__lambda7` cannot return type `bool[3]` because its linkage is `extern(C++)`
 ---
 */
 #line 10
 extern(C++) bool[3] funcLiteral = () { bool[3] a; return a; };
+#line 20
+extern(C++) int threadLocalVar;
+extern(C++) static int staticVar;
+extern(C++) shared int sharedVar;
+#line 30
+extern(C++) __gshared bool[3] gfuncLiteral = () { bool[3] a; return a; };

--- a/test/fail_compilation/fail16575.d
+++ b/test/fail_compilation/fail16575.d
@@ -1,0 +1,65 @@
+// https://issues.dlang.org/show_bug.cgi?id=16575
+/*
+REQUIRED_ARGS: -m64
+TEST_OUTPUT:
+---
+fail_compilation/fail16575.d(10): Error: function `fail16575.immNull` cannot have parameter of type `immutable(typeof(null))*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(11): Error: function `fail16575.shaNull` cannot have parameter of type `shared(typeof(null))*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(20): Error: function `fail16575.immNoReturn` cannot have parameter of type `immutable(noreturn)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(21): Error: function `fail16575.shaNoReturn` cannot have parameter of type `shared(noreturn)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(30): Error: function `fail16575.immBasic` cannot have parameter of type `immutable(int)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(31): Error: function `fail16575.shaBasic` cannot have parameter of type `shared(int)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(40): Error: function `fail16575.immVector` cannot have parameter of type `immutable(__vector(long[2]))*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(41): Error: function `fail16575.shaVector` cannot have parameter of type `shared(__vector(long[2]))*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(50): Error: function `fail16575.immSArray` cannot have parameter of type `immutable(long[2])` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(50):        perhaps use a `long*` type instead
+fail_compilation/fail16575.d(51): Error: function `fail16575.shaSArray` cannot have parameter of type `shared(long[2])` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(51):        perhaps use a `long*` type instead
+fail_compilation/fail16575.d(60): Error: function `fail16575.immPointer` cannot have parameter of type `immutable(int*)` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(61): Error: function `fail16575.shaPointer` cannot have parameter of type `shared(int*)` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(71): Error: function `fail16575.immStruct` cannot have parameter of type `immutable(SPP)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(72): Error: function `fail16575.shaStruct` cannot have parameter of type `shared(SPP)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(81): Error: function `fail16575.immClass` cannot have parameter of type `immutable(CPP)` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(82): Error: function `fail16575.shaClass` cannot have parameter of type `shared(CPP)` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(91): Error: function `fail16575.immEnum` cannot have parameter of type `immutable(EPP)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(92): Error: function `fail16575.shaEnum` cannot have parameter of type `shared(EPP)*` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(100): Error: function `fail16575.typeDArray` cannot have parameter of type `int[]` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(101): Error: function `fail16575.typeAArray` cannot have parameter of type `int[int]` because its linkage is `extern(C++)`
+fail_compilation/fail16575.d(102): Error: function `fail16575.typeDelegate` cannot have parameter of type `extern (C++) int delegate()` because its linkage is `extern(C++)`
+---
+*/
+
+#line 10
+extern(C++) void immNull(immutable(typeof(null))* a) {}
+extern(C++) void shaNull(shared(typeof(null))* a) {}
+#line 20
+extern(C++) void immNoReturn(immutable(typeof(*null))* a) {}
+extern(C++) void shaNoReturn(shared(typeof(*null))* a) {}
+#line 30
+extern(C++) void immBasic(immutable(int)* a) {}
+extern(C++) void shaBasic(shared(int)* a) {}
+#line 40
+extern(C++) void immVector(immutable(__vector(long[2]))* a) {}
+extern(C++) void shaVector(shared(__vector(long[2]))* a) {}
+#line 50
+extern(C++) void immSArray(immutable(long[2]) a) {}
+extern(C++) void shaSArray(shared(long[2]) a) {}
+#line 60
+extern(C++) void immPointer(immutable(int*) a) {}
+extern(C++) void shaPointer(shared(int*) a) {}
+#line 70
+extern(C++) struct SPP {}
+extern(C++) void immStruct(immutable(SPP)* a) {}
+extern(C++) void shaStruct(shared(SPP)* a) {}
+#line 80
+extern(C++) class CPP {}
+extern(C++) void immClass(immutable CPP a) {}
+extern(C++) void shaClass(shared CPP a) {}
+#line 90
+extern(C++) enum EPP {a}
+extern(C++) void immEnum(immutable(EPP)* a) {}
+extern(C++) void shaEnum(shared(EPP)* a) {}
+# line 100
+extern(C++) void typeDArray(int[] a) {}
+extern(C++) void typeAArray(int[int] a) {}
+extern(C++) void typeDelegate(int delegate() a) {}

--- a/test/fail_compilation/fail16772.d
+++ b/test/fail_compilation/fail16772.d
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=16772
+/* TEST_OUTPUT:
+---
+fail_compilation/fail16772.d(7): Error: function `fail16772.ice16772` cannot return type `ubyte[]` because its linkage is `extern(C++)`
+---
+*/
+extern(C++) ubyte[] ice16772() { return []; }

--- a/test/fail_compilation/fail19759.d
+++ b/test/fail_compilation/fail19759.d
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=19759
+/* TEST_OUTPUT:
+---
+fail_compilation/fail19759.d(8): Error: function `fail19759.fail19759` cannot have parameter of type `float[4]` because its linkage is `extern(C++)`
+fail_compilation/fail19759.d(8):        perhaps use a `float*` type instead
+---
+*/
+extern(C++) bool fail19759(float[4] col);

--- a/test/fail_compilation/fail21206.d
+++ b/test/fail_compilation/fail21206.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=21206
+/* TEST_OUTPUT:
+---
+fail_compilation/fail21206.d(9): Error: function `fail21206.Obj.toString` cannot return type `string` because its linkage is `extern(C++)`
+---
+*/
+extern(C++) struct Obj
+{
+    string toString()
+    {
+        return "ret";
+    }
+}

--- a/test/fail_compilation/fail21314.d
+++ b/test/fail_compilation/fail21314.d
@@ -1,0 +1,11 @@
+// https://issues.dlang.org/show_bug.cgi?id=21314
+/* TEST_OUTPUT:
+---
+fail_compilation/fail21314.d(10): Error: variable `fail21314.C21314.c21314` cannot have `extern(C++)` linkage because it is `static`
+fail_compilation/fail21314.d(10):        perhaps declare it as `__gshared` instead
+---
+*/
+extern(C++) class C21314
+{
+    static C21314[] c21314;
+}

--- a/test/fail_compilation/ice22377.d
+++ b/test/fail_compilation/ice22377.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice22377.d(8): Error: internal compiler error: type `string` cannot be mapped to C++
+fail_compilation/ice22377.d(8): Error: function `ice22377.foo` cannot have parameter of type `string` because its linkage is `extern(C++)`
 ---
 */
 


### PR DESCRIPTION
Just seeing what the testsuite says for now.  May move the check up to the declaration semantic, and also add checking of non-mappable D variables too.