### PR TITLE
dmd.backend: Define top-level function literals as extern(D)

### DIFF
--- a/src/dmd/backend/cg.d
+++ b/src/dmd/backend/cg.d
@@ -54,7 +54,8 @@ int STACKALIGN = 2;             // varies for each function
 
 
 /// Is fl data?
-bool[FLMAX] datafl =
+bool[FLMAX] datafl = datafl_init;
+extern (D) private enum datafl_init =
 () {
     bool[FLMAX] datafl;
     foreach (fl; [ FLdata,FLudata,FLreg,FLpseudo,FLauto,FLfast,FLpara,FLextern,
@@ -70,7 +71,8 @@ bool[FLMAX] datafl =
 
 
 /// Is fl on the stack?
-bool[FLMAX] stackfl =
+bool[FLMAX] stackfl = stackfl_init;
+extern (D) private enum stackfl_init =
 () {
     bool[FLMAX] stackfl;
     foreach (fl; [ FLauto,FLfast,FLpara,FLcs,FLfltreg,FLallocatmp,FLbprel,FLstack,FLregsave,
@@ -84,7 +86,8 @@ bool[FLMAX] stackfl =
 } ();
 
 /// What segment register is associated with it?
-ubyte[FLMAX] segfl =
+ubyte[FLMAX] segfl = segfl_init;
+extern (D) private enum segfl_init =
 () {
     ubyte[FLMAX] segfl;
 
@@ -146,7 +149,8 @@ ubyte[FLMAX] segfl =
 } ();
 
 /// Is fl in the symbol table?
-bool[FLMAX] flinsymtab =
+bool[FLMAX] flinsymtab = flinsymtab_init;
+extern (D) private enum flinsymtab_init =
 () {
     bool[FLMAX] flinsymtab;
     foreach (fl; [ FLdata,FLudata,FLreg,FLpseudo,FLauto,FLfast,FLpara,FLextern,FLfunc,

--- a/src/dmd/backend/var.d
+++ b/src/dmd/backend/var.d
@@ -265,7 +265,8 @@ type *chartype;                 /* default 'char' type                  */
 
 Obj objmod = null;
 
-__gshared uint[256] tytab =
+__gshared uint[256] tytab = tytab_init;
+extern (D) private enum tytab_init =
 () {
     uint[256] tab;
     foreach (i; TXptr)        { tab[i] |= TYFLptr; }
@@ -467,7 +468,8 @@ extern (C) __gshared const(char)*[TYMAX] tystring =
 } ();
 
 /// Map to unsigned version of type
-__gshared tym_t[256] tytouns =
+__gshared tym_t[256] tytouns = tytouns_init;
+extern (D) private enum tytouns_init =
 () {
     tym_t[256] tab;
     foreach (ty; 0 .. TYMAX)
@@ -510,8 +512,8 @@ __gshared tym_t[256] tytouns =
 } ();
 
 /// Map to relaxed version of type
-__gshared ubyte[TYMAX] _tyrelax =
-() {
+__gshared ubyte[TYMAX] _tyrelax = _tyrelax_init;
+extern(D) private enum _tyrelax_init = (){
     ubyte[TYMAX] tab;
     foreach (ty; 0 .. TYMAX)
     {
@@ -546,7 +548,8 @@ __gshared ubyte[TYMAX] _tyrelax =
 } ();
 
 /// Map to equivalent version of type
-__gshared ubyte[TYMAX] tyequiv =
+__gshared ubyte[TYMAX] tyequiv = tyequiv_init;
+extern (D) private enum tyequiv_init =
 () {
     ubyte[TYMAX] tab;
     foreach (ty; 0 .. TYMAX)


### PR DESCRIPTION
Otherwise they'll be marked as `extern(C++)`, which doesn't support returning static arrays.

Alternatively, @WalterBright can't we remove `extern (C++):` from the entire backend now?

See also: #14125.