### PR TITLE
pass preprocessor flags to preprocessor

### DIFF
--- a/src/dmd/cpreprocess.d
+++ b/src/dmd/cpreprocess.d
@@ -37,12 +37,13 @@ import dmd.root.string;
  * Params:
  *      csrcfile = C file to be preprocessed, with .c or .h extension
  *      importc_h = filename of importc.h
+ *      cppswitches = array of switches to pass to C preprocessor
  *      ifile = set to true if an output file was written
  * Result:
  *      filename of output
  */
 extern (C++)
-FileName preprocess(FileName csrcfile, const char* importc_h, out bool ifile)
+FileName preprocess(FileName csrcfile, const char* importc_h, ref Array!(const(char)*) cppswitches, out bool ifile)
 {
     //printf("preprocess %s\n", csrcfile.toChars());
     version (Posix)
@@ -52,7 +53,7 @@ FileName preprocess(FileName csrcfile, const char* importc_h, out bool ifile)
         assert(ext);
         const ifilename = FileName.addExt(name[0 .. name.length - (ext.length + 1)], i_ext);
         const command = cppCommand();
-        auto status = runPreprocessor(command, csrcfile.toString(), importc_h, ifilename);
+        auto status = runPreprocessor(command, csrcfile.toString(), importc_h, cppswitches, ifilename);
         if (status)
         {
             error(Loc.initial, "C preprocess command %.*s failed for file %s, exit status %d\n",
@@ -74,7 +75,7 @@ FileName preprocess(FileName csrcfile, const char* importc_h, out bool ifile)
         assert(ext);
         const ifilename = FileName.addExt(name[0 .. name.length - (ext.length + 1)], i_ext);
         const command = cppCommand();
-        auto status = runPreprocessor(command, csrcfile.toString(), importc_h, ifilename);
+        auto status = runPreprocessor(command, csrcfile.toString(), importc_h, cppswitches, ifilename);
         if (status)
         {
             error(Loc.initial, "C preprocess command %.*s failed for file %s, exit status %d\n",

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -703,7 +703,7 @@ extern (C++) final class Module : Package
                 error("cannot find \"importc.h\" along import path");
                 fatal();
             }
-            filename = global.preprocess(srcfile, importc_h, ifile);  // run C preprocessor
+            filename = global.preprocess(srcfile, importc_h, global.params.cppswitches, ifile);  // run C preprocessor
         }
 
         if (auto result = global.fileManager.lookup(filename))

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -827,7 +827,7 @@ struct Global final
     FileManager* fileManager;
     enum : int32_t { recursionLimit = 500 };
 
-    FileName(*preprocess)(FileName , const char* importc_h, bool& );
+    FileName(*preprocess)(FileName , const char* importc_h, Array<const char* >& cppswitches, bool& );
     uint32_t startGagging();
     bool endGagging(uint32_t oldGagged);
     void increaseErrorCount();
@@ -5512,7 +5512,7 @@ extern const char* toCppMangleDMC(Dsymbol* s);
 
 extern const char* cppTypeInfoMangleDMC(Dsymbol* s);
 
-extern FileName preprocess(FileName csrcfile, const char* const importc_h, bool& ifile);
+extern FileName preprocess(FileName csrcfile, const char* const importc_h, Array<const char* >& cppswitches, bool& ifile);
 
 class ClassReferenceExp final : public Expression
 {

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -298,7 +298,7 @@ extern (C++) struct Global
 
     enum recursionLimit = 500; /// number of recursive template expansions before abort
 
-    extern (C++) FileName function(FileName, const(char)* importc_h, out bool) preprocess;
+    extern (C++) FileName function(FileName, const(char)* importc_h, ref Array!(const(char)*) cppswitches, out bool) preprocess;
 
   nothrow:
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -270,7 +270,7 @@ struct Global
 
     FileManager* fileManager;
 
-    FileName (*preprocess)(FileName, const char*, bool&);
+    FileName (*preprocess)(FileName, const char*, Array<const char *>& cppswitches, bool&);
 
     /* Start gagging. Return the current number of gagged errors
      */

--- a/test/compilable/cppflags.c
+++ b/test/compilable/cppflags.c
@@ -1,0 +1,4 @@
+/* REQUIRED_ARGS: -P=-DABC=3
+ */
+
+_Static_assert(ABC == 3, "1");


### PR DESCRIPTION
This completes what was started in https://github.com/dlang/dmd/pull/14126

I.e. the flags are passed through to `cpp`. I also changed the `-v` effect to show the actual preprocessor command line.