### PR TITLE
dmd.expressionsem: Remove double-space from error message

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5995,7 +5995,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         auto idxReserved = FileName.findReservedChar(namez);
         if (idxReserved != size_t.max)
         {
-            e.error("`%s` is  not a valid filename on this platform", se.toChars());
+            e.error("`%s` is not a valid filename on this platform", se.toChars());
             e.errorSupplemental("Character `'%c'` is reserved and cannot be used", namez[idxReserved]);
             return setError();
         }

--- a/test/fail_compilation/fail21227_win.d
+++ b/test/fail_compilation/fail21227_win.d
@@ -13,19 +13,19 @@ fail_compilation\fail21227_win.d(8): Error: path refers to parent (`..`) directo
 fail_compilation\fail21227_win.d(9): Error: path refers to parent (`..`) directory: `"../file.txt"`
 fail_compilation\fail21227_win.d(10): Error: path refers to parent (`..`) directory: `"path\\to\\parent\\..\\file.txt"`
 fail_compilation\fail21227_win.d(11): Error: path refers to parent (`..`) directory: `"path/to/parent/../file.txt"`
-fail_compilation\fail21227_win.d(12): Error: `"file>txt"` is  not a valid filename on this platform
+fail_compilation\fail21227_win.d(12): Error: `"file>txt"` is not a valid filename on this platform
 fail_compilation\fail21227_win.d(12):        Character `'>'` is reserved and cannot be used
-fail_compilation\fail21227_win.d(13): Error: `"file<txt"` is  not a valid filename on this platform
+fail_compilation\fail21227_win.d(13): Error: `"file<txt"` is not a valid filename on this platform
 fail_compilation\fail21227_win.d(13):        Character `'<'` is reserved and cannot be used
-fail_compilation\fail21227_win.d(14): Error: `"file:txt"` is  not a valid filename on this platform
+fail_compilation\fail21227_win.d(14): Error: `"file:txt"` is not a valid filename on this platform
 fail_compilation\fail21227_win.d(14):        Character `':'` is reserved and cannot be used
-fail_compilation\fail21227_win.d(15): Error: `"file\"txt"` is  not a valid filename on this platform
+fail_compilation\fail21227_win.d(15): Error: `"file\"txt"` is not a valid filename on this platform
 fail_compilation\fail21227_win.d(15):        Character `'"'` is reserved and cannot be used
-fail_compilation\fail21227_win.d(16): Error: `"file|txt"` is  not a valid filename on this platform
+fail_compilation\fail21227_win.d(16): Error: `"file|txt"` is not a valid filename on this platform
 fail_compilation\fail21227_win.d(16):        Character `'|'` is reserved and cannot be used
-fail_compilation\fail21227_win.d(17): Error: `"file?txt"` is  not a valid filename on this platform
+fail_compilation\fail21227_win.d(17): Error: `"file?txt"` is not a valid filename on this platform
 fail_compilation\fail21227_win.d(17):        Character `'?'` is reserved and cannot be used
-fail_compilation\fail21227_win.d(18): Error: `"file*txt"` is  not a valid filename on this platform
+fail_compilation\fail21227_win.d(18): Error: `"file*txt"` is not a valid filename on this platform
 fail_compilation\fail21227_win.d(18):        Character `'*'` is reserved and cannot be used
 fail_compilation\fail21227_win.d(19): Error: file `"do_not_exist"` cannot be found or not in a path specified with `-J`
 fail_compilation\fail21227_win.d(19):        Path(s) searched (as provided by `-J`):


### PR DESCRIPTION
Caught when reviewing some code around it.