### PR TITLE
Fix Issue 23114 - Make noreturn conversions work

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2954,6 +2954,9 @@ Lagain:
 
         t1 = Type.basic[ty1];
         t2 = Type.basic[ty2];
+
+        if (!(t1 && t2))
+            return null;
         e1 = e1.castTo(sc, t1);
         e2 = e2.castTo(sc, t2);
         return Lret(Type.basic[ty]);

--- a/src/dmd/impcnvtab.d
+++ b/src/dmd/impcnvtab.d
@@ -64,6 +64,57 @@ enum ImpCnvTab impCnvTab = generateImpCnvTab();
 
 ImpCnvTab generateImpCnvTab()
 {
+    TY[TMAX] typeTYs =
+    [
+        Tarray,
+        Tsarray,
+        Taarray,
+        Tpointer,
+        Treference,
+        Tfunction,
+        Tident,
+        Tclass,
+        Tstruct,
+        Tenum,
+        Tdelegate,
+        Tnone,
+        Tvoid,
+        Tint8,
+        Tuns8,
+        Tint16,
+        Tuns16,
+        Tint32,
+        Tuns32,
+        Tint64,
+        Tuns64,
+        Tfloat32,
+        Tfloat64,
+        Tfloat80,
+        Timaginary32,
+        Timaginary64,
+        Timaginary80,
+        Tcomplex32,
+        Tcomplex64,
+        Tcomplex80,
+        Tbool,
+        Tchar,
+        Twchar,
+        Tdchar,
+        Terror,
+        Tinstance,
+        Ttypeof,
+        Ttuple,
+        Tslice,
+        Treturn,
+        Tnull,
+        Tvector,
+        Tint128,
+        Tuns128,
+        Ttraits,
+        Tmixin,
+        Tnoreturn,
+        Ttag,
+    ];
     ImpCnvTab impCnvTab;
 
     // Set conversion tables
@@ -374,6 +425,10 @@ ImpCnvTab generateImpCnvTab()
     /* ======================= */
 
     X(Tcomplex80,Tcomplex80,  Tcomplex80,Tcomplex80, Tcomplex80);
+
+    // "No type is implicitly convertible to noreturn, but noreturn is implicitly convertible to every other type"
+    foreach(convertToTy; typeTYs)
+        X(Tnoreturn, convertToTy, convertToTy, convertToTy, convertToTy);
 
     return impCnvTab;
 }

--- a/test/compilable/noreturn1.d
+++ b/test/compilable/noreturn1.d
@@ -122,3 +122,31 @@ noreturn testdg(noreturn delegate() dg)
 {
     dg();
 }
+
+noreturn func()
+{
+    while(1)
+    {
+    }
+}
+alias AliasSeq(T...) = T;
+alias Types = AliasSeq!(bool, byte, ubyte, short, ushort, int, uint,
+                        long, ulong, char, wchar, dchar, float, double,
+                        real);
+void noreturnImplicit()
+{
+    /*
+        Testing both ways because, although the underlying table
+        is symmetrical the code that calls into it may be buggy.
+    */
+    {
+        int x = 2 + func();
+        int y = func() + 2;
+    }
+    foreach(T; Types)
+    {
+        T value;
+        auto x = value + throw new Exception("Hello");
+        auto y = (throw new Exception("wow")) + value;
+    }
+}


### PR DESCRIPTION
I will probably refactor the rest of the implicit conversion table because it's pretty murky.

The `TY` enum could also use a lot of rework because it's currently completely confused (e.g. Some of them are types, some of them are sets of types, some of them aren't really types at all)