### PR TITLE
dmd.cpreprocess: Move searching of importc.h header to the preprocess handler itself

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -677,33 +677,7 @@ extern (C++) final class Module : Package
             FileName.equalsExt(srcfile.toString(), c_ext) &&
             FileName.exists(srcfile.toString()))
         {
-            /* Look for "importc.h" by searching along import path.
-             * It should be in the same place as "object.d"
-             */
-            const(char)* importc_h;
-
-            foreach (entry; (global.path ? (*global.path)[] : null))
-            {
-                auto f = FileName.combine(entry, "importc.h");
-                if (FileName.exists(f) == 1)
-                {
-                     importc_h = f;
-                     break;
-                }
-                FileName.free(f);
-            }
-
-            if (importc_h)
-            {
-                if (global.params.verbose)
-                    message("include   %s", importc_h);
-            }
-            else
-            {
-                error("cannot find \"importc.h\" along import path");
-                fatal();
-            }
-            filename = global.preprocess(srcfile, importc_h, global.params.cppswitches, ifile);  // run C preprocessor
+            filename = global.preprocess(srcfile, loc, global.params.cppswitches, ifile);  // run C preprocessor
         }
 
         if (auto result = global.fileManager.lookup(filename))

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -827,7 +827,7 @@ struct Global final
     FileManager* fileManager;
     enum : int32_t { recursionLimit = 500 };
 
-    FileName(*preprocess)(FileName , const char* importc_h, Array<const char* >& cppswitches, bool& );
+    FileName(*preprocess)(FileName , const Loc& , Array<const char* >& cppswitches, bool& );
     uint32_t startGagging();
     bool endGagging(uint32_t oldGagged);
     void increaseErrorCount();
@@ -5512,7 +5512,7 @@ extern const char* toCppMangleDMC(Dsymbol* s);
 
 extern const char* cppTypeInfoMangleDMC(Dsymbol* s);
 
-extern FileName preprocess(FileName csrcfile, const char* const importc_h, Array<const char* >& cppswitches, bool& ifile);
+extern FileName preprocess(FileName csrcfile, const Loc& loc, Array<const char* >& cppswitches, bool& ifile);
 
 class ClassReferenceExp final : public Expression
 {

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -298,7 +298,7 @@ extern (C++) struct Global
 
     enum recursionLimit = 500; /// number of recursive template expansions before abort
 
-    extern (C++) FileName function(FileName, const(char)* importc_h, ref Array!(const(char)*) cppswitches, out bool) preprocess;
+    extern (C++) FileName function(FileName, ref const Loc, ref Array!(const(char)*) cppswitches, out bool) preprocess;
 
   nothrow:
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -20,6 +20,7 @@
 template <typename TYPE> struct Array;
 
 class FileManager;
+struct Loc;
 
 typedef unsigned char Diagnostic;
 enum
@@ -270,7 +271,7 @@ struct Global
 
     FileManager* fileManager;
 
-    FileName (*preprocess)(FileName, const char*, Array<const char *>& cppswitches, bool&);
+    FileName (*preprocess)(FileName, const Loc&, Array<const char *>& cppswitches, bool&);
 
     /* Start gagging. Return the current number of gagged errors
      */


### PR DESCRIPTION
1. This hard dependency interferes with implementers of preprocess() that interact with cpp as a library interface and have zero need for loading a header file (i.e: `cpp_define("__IMPORTC__=1");`).
2. The cpreprocess module has access to dmd.globals, there's no reason why it shouldn't reach for this information itself.

There's also `cppswitches` which can and should be read from `global.params.cppswitches` directly instead of passing it as an argument over the callback interface - cppswitches are also redundant when invoking cpp via a library interface - but that can be dealt with in another PR.