### PR TITLE
Infer return on delegate without -dip1000

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -1423,10 +1423,7 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
                  *   auto dg = () return { return &x; }
                  * Because dg.ptr points to x, this is returning dt.ptr+offset
                  */
-                if (global.params.useDIP1000 == FeatureState.enabled)
-                {
-                    sc.func.storage_class |= STC.return_ | STC.returninferred;
-                }
+                sc.func.storage_class |= STC.return_ | STC.returninferred;
             }
         }
 


### PR DESCRIPTION
Remove one of the last `useDIP1000` branches hindering dip1000 by default.