### PR TITLE
Fix Issue 22626 - Can't use synchronized member functions with -nosharedaccess

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -12966,8 +12966,19 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
 
         bool visitVar(VarExp e)
         {
-            if (!allowRef && e.var.type.isShared())
+            // https://issues.dlang.org/show_bug.cgi?id=22626
+            // Synchronized functions don't need to use core.atomic
+            // when accessing `this`.
+            if (sc.func && sc.func.isSynchronized())
+            {
+                if (e.var.isThisDeclaration())
+                    return false;
+                else
+                    return sharedError(e);
+            }
+            else if (!allowRef && e.var.type.isShared())
                 return sharedError(e);
+
             return false;
         }
 
@@ -12987,15 +12998,22 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
             return check(e.e1, false);
         }
 
+        bool visitThis(ThisExp e)
+        {
+            if (sc.func && sc.func.isSynchronized())
+                return false;
+
+            return sharedError(e);
+        }
+
         bool visitDotVar(DotVarExp e)
         {
+            //printf("dotvarexp = %s\n", e.toChars());
             auto fd = e.var.isFuncDeclaration();
             const sharedFunc = fd && fd.type.isShared;
-
-            if (!allowRef && e.type.isShared() && !sharedFunc)
-                return sharedError(e);
-
             // Allow using `DotVarExp` within value types
+            if (!allowRef && e.type.isShared() && !sharedFunc && !(sc.func && sc.func.isSynchronized()))
+                return sharedError(e);
             if (e.e1.type.isTypeSArray() || e.e1.type.isTypeStruct())
                 return check(e.e1, allowRef);
 
@@ -13044,6 +13062,7 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
             case EXP.star:        return visitPtr(e.isPtrExp());
             case EXP.dotVariable: return visitDotVar(e.isDotVarExp());
             case EXP.index:       return visitIndex(e.isIndexExp());
+            case EXP.this_:       return visitThis(e.isThisExp());
         }
     }
 

--- a/test/compilable/test22626.d
+++ b/test/compilable/test22626.d
@@ -1,0 +1,23 @@
+// https://issues.dlang.org/show_bug.cgi?id=22626
+// REQUIRED_ARGS: -preview=nosharedaccess
+
+shared int k;
+
+class Oops
+{
+    shared int a;
+    shared int* pa;
+    synchronized void oops()
+    {
+        // this should compile since the function is synchronized
+        // and `a` is accessed through `this`.
+        a = 2;
+
+        // this shouldn't compile because synchronized guards
+        // only accesses to the first level of dereferencing
+        static assert (!__traits(compiles, *pa = 2));
+
+        // this shouldn't compile `k` is a field of class `Oops`
+        static assert (!__traits(compiles, k = 2));
+    }
+}


### PR DESCRIPTION
Shared variables should be accessible from synchronized functions without any further locking, provided they are accessed through the `this` reference.

cc @atilaneves 