### PR TITLE
Fix issue 22865 - __traits(compiles) affects inferrence of attributes

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2768,16 +2768,14 @@ Expression scaleFactor(BinExp be, Scope* sc)
     else
         assert(0);
 
-    if (sc.func && !sc.intypeof)
+
+    eoff = eoff.optimize(WANTvalue);
+    if (eoff.op == EXP.int64 && eoff.toInteger() == 0)
     {
-        eoff = eoff.optimize(WANTvalue);
-        if (eoff.op == EXP.int64 && eoff.toInteger() == 0)
-        {
-        }
-        else if (sc.func.setUnsafe(false, be.loc, "pointer arithmetic not allowed in @safe functions"))
-        {
-            return ErrorExp.get();
-        }
+    }
+    else if (sc.setUnsafe(false, be.loc, "pointer arithmetic not allowed in @safe functions"))
+    {
+        return ErrorExp.get();
     }
 
     return be;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -468,12 +468,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         dsym.type.checkComplexTransition(dsym.loc, sc);
 
         // Calculate type size + safety checks
-        if (sc.func && !sc.intypeof)
+        if (dsym.storage_class & STC.gshared && !dsym.isMember())
         {
-            if (dsym.storage_class & STC.gshared && !dsym.isMember())
-            {
-                sc.func.setUnsafe(false, dsym.loc, "__gshared not allowed in safe functions; use shared");
-            }
+            sc.setUnsafe(false, dsym.loc, "__gshared not allowed in safe functions; use shared");
         }
 
         Dsymbol parent = dsym.toParent();
@@ -857,23 +854,23 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
 
         // Calculate type size + safety checks
-        if (sc.func && !sc.intypeof)
+        if (1)
         {
             if (dsym._init && dsym._init.isVoidInitializer() &&
                 (dsym.type.hasPointers() || dsym.type.hasInvariant())) // also computes type size
             {
                 if (dsym.type.hasPointers())
-                    sc.func.setUnsafe(false, dsym.loc,
+                    sc.setUnsafe(false, dsym.loc,
                         "`void` initializers for pointers not allowed in safe functions");
                 else
-                    sc.func.setUnsafe(false, dsym.loc,
+                    sc.setUnsafe(false, dsym.loc,
                         "`void` initializers for structs with invariants are not allowed in safe functions");
             }
             else if (!dsym._init &&
                      !(dsym.storage_class & (STC.static_ | STC.extern_ | STC.gshared | STC.manifest | STC.field | STC.parameter)) &&
                      dsym.type.hasVoidInitPointers())
             {
-                sc.func.setUnsafe(false, dsym.loc, "`void` initializers for pointers not allowed in safe functions");
+                sc.setUnsafe(false, dsym.loc, "`void` initializers for pointers not allowed in safe functions");
             }
         }
 

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -165,7 +165,7 @@ bool checkMutableArguments(Scope* sc, FuncDeclaration fd, TypeFunction tf,
         if (!(eb.isMutable || eb2.isMutable))
             return;
 
-        if (!(global.params.useDIP1000 == FeatureState.enabled && sc.func.setUnsafe()))
+        if (!(global.params.useDIP1000 == FeatureState.enabled && sc.setUnsafe()))
             return;
 
         if (!gag)
@@ -2502,7 +2502,7 @@ private bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, con
     }
     else if (fs == FeatureState.enabled)
     {
-        return sc.func.setUnsafe(gag, loc, msg, arg0, arg1);
+        return sc.setUnsafe(gag, loc, msg, arg0, arg1);
     }
     else
     {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1370,7 +1370,7 @@ extern (C++) abstract class Expression : ASTNode
          */
         if (v.storage_class & STC.gshared)
         {
-            if (sc.func.setUnsafe(false, this.loc,
+            if (sc.setUnsafe(false, this.loc,
                 "`@safe` function `%s` cannot access `__gshared` data `%s`", sc.func, v))
             {
                 err = true;
@@ -5761,7 +5761,7 @@ extern (C++) final class DelegatePtrExp : UnaExp
 
     override Expression modifiableLvalue(Scope* sc, Expression e)
     {
-        if (sc.func.setUnsafe(false, this.loc, "cannot modify delegate pointer in `@safe` code `%s`", this))
+        if (sc.setUnsafe(false, this.loc, "cannot modify delegate pointer in `@safe` code `%s`", this))
         {
             return ErrorExp.get();
         }
@@ -5799,7 +5799,7 @@ extern (C++) final class DelegateFuncptrExp : UnaExp
 
     override Expression modifiableLvalue(Scope* sc, Expression e)
     {
-        if (sc.func.setUnsafe(false, this.loc, "cannot modify delegate function pointer in `@safe` code `%s`", this))
+        if (sc.setUnsafe(false, this.loc, "cannot modify delegate function pointer in `@safe` code `%s`", this))
         {
             return ErrorExp.get();
         }

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -197,10 +197,9 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
                 if (vd.type.hasPointers)
                 {
                     if ((!t.alignment.isDefault() && t.alignment.get() < target.ptrsize ||
-                         (vd.offset & (target.ptrsize - 1))) &&
-                        sc.func)
+                         (vd.offset & (target.ptrsize - 1))))
                     {
-                        if (sc.func.setUnsafe(false, i.value[j].loc,
+                        if (sc.setUnsafe(false, i.value[j].loc,
                             "field `%s.%s` cannot assign to misaligned pointers in `@safe` code", sd, vd))
                         {
                             errors = true;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4760,7 +4760,7 @@ extern (C++) final class TypeFunction : TypeNext
                                         char[] s;
                                         if (!f.isPure && sc.func.setImpure())
                                             s ~= "pure ";
-                                        if (!f.isSafe() && !f.isTrusted() && sc.func.setUnsafe())
+                                        if (!f.isSafe() && !f.isTrusted() && sc.setUnsafe())
                                             s ~= "@safe ";
                                         if (!f.isNogc && sc.func.setGC())
                                             s ~= "nogc ";

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3928,7 +3928,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
             cas.error("`asm` statement is assumed to use the GC - mark it with `@nogc` if it does not");
         if (!(cas.stc & (STC.trusted | STC.safe)))
         {
-            sc.func.setUnsafe(false, cas.loc, "`asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not");
+            sc.setUnsafe(false, cas.loc, "`asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not");
         }
 
         sc.pop();
@@ -4033,9 +4033,9 @@ void catchSemantic(Catch c, Scope* sc)
             error(c.loc, "catching C++ class objects not supported for this target");
             c.errors = true;
         }
-        if (sc.func && !sc.intypeof && !c.internalCatch)
+        if (!c.internalCatch)
         {
-            if (sc.func.setUnsafe(false, c.loc, "cannot catch C++ class objects in `@safe` code"))
+            if (sc.setUnsafe(false, c.loc, "cannot catch C++ class objects in `@safe` code"))
                 c.errors = true;
         }
     }
@@ -4044,9 +4044,9 @@ void catchSemantic(Catch c, Scope* sc)
         error(c.loc, "can only catch class objects derived from `Throwable`, not `%s`", c.type.toChars());
         c.errors = true;
     }
-    else if (sc.func && !sc.intypeof && !c.internalCatch && ClassDeclaration.exception &&
+    else if (!c.internalCatch && ClassDeclaration.exception &&
             cd != ClassDeclaration.exception && !ClassDeclaration.exception.isBaseOf(cd, null) &&
-            sc.func.setUnsafe(false, c.loc,
+            sc.setUnsafe(false, c.loc,
                 "can only catch class objects derived from `Exception` in `@safe` code, not `%s`", c.type))
     {
         c.errors = true;

--- a/test/compilable/test22865.d
+++ b/test/compilable/test22865.d
@@ -1,0 +1,35 @@
+// https://issues.dlang.org/show_bug.cgi?id=22865
+
+// Test that safety errors inside speculative scopes don't affect attribute inference
+
+void main() @safe
+{
+    foo();
+}
+
+__gshared int g;
+
+auto foo()
+{
+    alias x0 = typeof(g++);
+    alias x1 = typeof(cast(int*) 0);
+
+    auto x2 = __traits(compiles, g++);
+    enum x3 = __traits(compiles, (cast(int*) 0));
+
+    debug
+    {
+        g++;
+        const x4 = cast(int*) 0;
+        asm { }
+    }
+}
+
+// Test that safety violations still occur if the function is inside the __traits(compiles)
+
+static assert(!__traits(compiles, {
+    void f() @safe
+    {
+        g++;
+    }
+}));


### PR DESCRIPTION
DMD is full of variations of:
```D
if (sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe(...))
```
Sometimes `intypeof` is included, sometimes not. Sometimes `SCOPE.debug_` is included, sometimes not.
This fix refactors them to into a single `sc.setUnsafe(...)`, which calls `setUnsafe` on `sc.func`. This `Scope*` version of `setUnsafe` then does all the checks consistently, including the new `sc.flags & SCOPE.compile` check for `__traits(compiles)`.