### PR TITLE
add -dD to cpp command

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1201,6 +1201,9 @@ public int runPreprocessor(const(char)[] cpp, const(char)[] filename, const(char
                 argv.push(p);
         }
 
+        // merge #define's with output
+        argv.push("-dD");       // https://gcc.gnu.org/onlinedocs/cpp/Invocation.html#index-dD
+
         if (target.os == Target.OS.OSX)
         {
             argv.push("-include");          // OSX cpp has switch order dependencies

--- a/test/compilable/testdefines.c
+++ b/test/compilable/testdefines.c
@@ -1,2 +1,3 @@
+// DISABLED: win32 win64 win32mscoff
 #define GHI 3
 _Static_assert(GHI == 3, "1");


### PR DESCRIPTION
So that the #define's are merged in with the preprocessed `.i` file.