### PR TITLE
ImportC add Win32 OMF preprocessor #define support

### DIFF
--- a/src/dmd/cpreprocess.d
+++ b/src/dmd/cpreprocess.d
@@ -44,11 +44,12 @@ version (Windows) version = runPreprocessor;
  *      loc = The source location where preprocess is requested from
  *      cppswitches = array of switches to pass to C preprocessor
  *      ifile = set to true if an output file was written
+ *      defines = buffer to append any `#define` and `#undef` lines encountered to
  * Result:
  *      filename of output
  */
 extern (C++)
-FileName preprocess(FileName csrcfile, ref const Loc loc, ref Array!(const(char)*) cppswitches, out bool ifile)
+FileName preprocess(FileName csrcfile, ref const Loc loc, ref Array!(const(char)*) cppswitches, out bool ifile, OutBuffer* defines)
 {
     /* Look for "importc.h" by searching along import path.
      * It should be in the same place as "object.d"
@@ -90,7 +91,7 @@ FileName preprocess(FileName csrcfile, ref const Loc loc, ref Array!(const(char)
         assert(ext);
         const ifilename = FileName.addExt(name[0 .. name.length - (ext.length + 1)], i_ext);
         const command = cppCommand();
-        auto status = runPreprocessor(command, csrcfile.toString(), importc_h, cppswitches, ifilename);
+        auto status = runPreprocessor(command, csrcfile.toString(), importc_h, cppswitches, ifilename, defines);
         if (status)
         {
             error(loc, "C preprocess command %.*s failed for file %s, exit status %d\n",

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -363,6 +363,9 @@ extern (C++) final class Module : Package
     int selfimports;            // 0: don't know, 1: does not, 2: does
     Dsymbol[void*] tagSymTab;   /// ImportC: tag symbols that conflict with other symbols used as the index
 
+    private OutBuffer defines;  // collect all the #define lines here
+
+
     /*************************************
      * Return true if module imports itself.
      */
@@ -677,7 +680,7 @@ extern (C++) final class Module : Package
             FileName.equalsExt(srcfile.toString(), c_ext) &&
             FileName.exists(srcfile.toString()))
         {
-            filename = global.preprocess(srcfile, loc, global.params.cppswitches, ifile);  // run C preprocessor
+            filename = global.preprocess(srcfile, loc, global.params.cppswitches, ifile, &defines);  // run C preprocessor
         }
 
         if (auto result = global.fileManager.lookup(filename))
@@ -975,7 +978,6 @@ extern (C++) final class Module : Package
         {
             filetype = FileType.c;
 
-            OutBuffer defines;
             scope p = new CParser!AST(this, buf, cast(bool) docfile, target.c, &defines);
             p.nextToken();
             checkCompiledImport();

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -298,7 +298,7 @@ extern (C++) struct Global
 
     enum recursionLimit = 500; /// number of recursive template expansions before abort
 
-    extern (C++) FileName function(FileName, ref const Loc, ref Array!(const(char)*) cppswitches, out bool) preprocess;
+    extern (C++) FileName function(FileName, ref const Loc, ref Array!(const(char)*) cppswitches, out bool, OutBuffer* defines) preprocess;
 
   nothrow:
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -271,7 +271,7 @@ struct Global
 
     FileManager* fileManager;
 
-    FileName (*preprocess)(FileName, const Loc&, Array<const char *>& cppswitches, bool&);
+    FileName (*preprocess)(FileName, const Loc&, Array<const char *>& cppswitches, bool&, OutBuffer&);
 
     /* Start gagging. Return the current number of gagged errors
      */

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -82,6 +82,7 @@ public:
     int needmoduleinfo;
     int selfimports;            // 0: don't know, 1: does not, 2: does
     void* tagSymTab;            // ImportC: tag symbols that conflict with other symbols used as the index
+    OutBuffer defines;          // collect all the #define lines here
     bool selfImports();         // returns true if module imports itself
 
     int rootimports;            // 0: don't know, 1: does not, 2: does

--- a/test/compilable/testdefines.c
+++ b/test/compilable/testdefines.c
@@ -1,3 +1,3 @@
-// DISABLED: win32 win64 win32mscoff
+// DISABLED: win64 win32mscoff
 #define GHI 3
 _Static_assert(GHI == 3, "1");


### PR DESCRIPTION
Adds `-ED` switch to `sppn.exe` to send the `#define`'s to `stdout`, where it gets captured into `defines[]` and passed to `CParser`.

Also relocates `defines` to being a global so its buffer is recycled rather than reallocated.

The only interesting thing here is the use of a state machine to decide where the `stdout` characters go.