### PR TITLE
Print deprecations for calling functions that would be `@system` with dip1000

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -614,9 +614,7 @@ public:
 
     FuncDeclarations *inlinedNestedCallees;
 
-private:
     AttributeViolation* safetyViolation;
-public:
 
     unsigned flags;                     // FUNCFLAGxxxxx
 

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -2513,6 +2513,11 @@ private bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, con
                     loc, msg, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : ""
                 );
         }
+        else if (!sc.func.safetyViolation)
+        {
+            import dmd.func : AttributeViolation;
+            sc.func.safetyViolation = new AttributeViolation(loc, msg, arg0, arg1);
+        }
         return false;
     }
 }

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -278,7 +278,6 @@ class GotoCaseStatement;
 class GotoStatement;
 class ReturnStatement;
 class ScopeStatement;
-struct AttributeViolation;
 struct ObjcSelector;
 class PeelStatement;
 class CompoundStatement;
@@ -2726,6 +2725,27 @@ enum : int32_t { stageSearchPointers = 2 };
 
 enum : int32_t { stageToCBuffer = 32 };
 
+struct AttributeViolation final
+{
+    Loc loc;
+    const char* fmtStr;
+    RootObject* arg0;
+    RootObject* arg1;
+    AttributeViolation() :
+        loc(Loc(nullptr, 0u, 0u)),
+        fmtStr(nullptr),
+        arg0(nullptr),
+        arg1(nullptr)
+    {
+    }
+    AttributeViolation(Loc loc, const char* fmtStr = nullptr, RootObject* arg0 = nullptr, RootObject* arg1 = nullptr) :
+        loc(loc),
+        fmtStr(fmtStr),
+        arg0(arg0),
+        arg1(arg1)
+        {}
+};
+
 enum class ILS : uint8_t
 {
     uninitialized = 0u,
@@ -2831,9 +2851,7 @@ public:
     Array<VarDeclaration* > outerVars;
     Array<FuncDeclaration* > siblingCallers;
     Array<FuncDeclaration* >* inlinedNestedCallees;
-private:
     AttributeViolation* safetyViolation;
-public:
     uint32_t flags;
     ObjcFuncDeclaration objc;
     static FuncDeclaration* create(const Loc& loc, const Loc& endloc, Identifier* id, StorageClass storage_class, Type* type, bool noreturn = false);
@@ -4838,6 +4856,7 @@ struct ASTCodegen final
     using emplaceExp = ::emplaceExp;
     using fp2_t = ::fp2_t;
     using fp_t = ::fp_t;
+    using AttributeViolation = ::AttributeViolation;
     using BUILTIN = ::BUILTIN;
     using CtorDeclaration = ::CtorDeclaration;
     using DtorDeclaration = ::DtorDeclaration;

--- a/test/fail_compilation/dip1000_deprecation.d
+++ b/test/fail_compilation/dip1000_deprecation.d
@@ -2,11 +2,42 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/dip1000_deprecation.d(23): Deprecation: escaping reference to stack allocated value returned by `S(null)`
-fail_compilation/dip1000_deprecation.d(24): Deprecation: escaping reference to stack allocated value returned by `createS()`
-fail_compilation/dip1000_deprecation.d(27): Deprecation: returning `s.incorrectReturnRef()` escapes a reference to local variable `s`
+fail_compilation/dip1000_deprecation.d(20): Deprecation: `@safe` function `main` calling `inferred`
+fail_compilation/dip1000_deprecation.d(28):        which would be `@system` because of:
+fail_compilation/dip1000_deprecation.d(28):        scope variable `x0` may not be returned
+fail_compilation/dip1000_deprecation.d(22): Deprecation: `@safe` function `main` calling `inferredC`
+fail_compilation/dip1000_deprecation.d(39):        which calls `dip1000_deprecation.inferred`
+fail_compilation/dip1000_deprecation.d(28):        which would be `@system` because of:
+fail_compilation/dip1000_deprecation.d(28):        scope variable `x0` may not be returned
+fail_compilation/dip1000_deprecation.d(54): Deprecation: escaping reference to stack allocated value returned by `S(null)`
+fail_compilation/dip1000_deprecation.d(55): Deprecation: escaping reference to stack allocated value returned by `createS()`
+fail_compilation/dip1000_deprecation.d(58): Deprecation: returning `s.incorrectReturnRef()` escapes a reference to local variable `s`
 ---
 */
+
+void main() @safe
+{
+    inferred();
+    inferredB(); // no deprecation, trusted
+    inferredC(); // nested deprecation
+}
+
+auto inferred()
+{
+    scope int* x0;
+    return x0;
+}
+
+auto inferredB() @trusted
+{
+    scope int* x1;
+    return x1;
+}
+
+auto inferredC()
+{
+    return inferred(); // no deprecation, inferredC is not explicit `@safe`
+}
 
 @safe:
 


### PR DESCRIPTION
dip1000 errors are only filed in `@safe` functions. For the transition of making dip1000 the default, such errors are printed as deprecations in functions explicitly marked `@safe`. But what about template / `auto` functions? Currently, the error is ignored and the function remains `@safe`, but once dip1000 is truly on by default, it would become `@system`.

This PR stores the ignored error as a `safetyViolation` even when the function ends up `@safe`. When such a function is called in a function that has to be `@safe`, a deprecation is printed.