### PR TITLE
Fix Issues 23130, 19528 : Inline asm was too liberal about operand si…

### DIFF
--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -1206,7 +1206,7 @@ opflag_t asm_determine_operand_flags(ref OPND popnd)
     else
     {
         auto ptype = (ds && ds.storage_class & (STC.out_ | STC.ref_)) ? popnd.ptype.pointerTo() : popnd.ptype;
-        sz = asm_type_size(ptype, popnd.bPtr);
+        sz = asm_type_size(ptype);
     }
 
     if (popnd.bRIP)
@@ -3443,11 +3443,11 @@ void asm_token_trans(Token *tok)
 /*******************************
  */
 
-OpndSize asm_type_size(Type ptype, bool bPtr)
+OpndSize asm_type_size(Type ptype)
 {
     OpndSize u;
 
-    //if (ptype) printf("asm_type_size('%s') = %d\n", ptype.toChars(), (int)ptype.size());
+    //if (ptype) printf("asm_type_size('%s') = %d\n", ptype.toChars(), cast(int)ptype.size());
     u = OpndSize._anysize;
     if (ptype && ptype.ty != Tfunction /*&& ptype.isscalar()*/)
     {
@@ -3459,8 +3459,8 @@ OpndSize asm_type_size(Type ptype, bool bPtr)
             case 4:     u = OpndSize._32;        break;
             case 6:     u = OpndSize._48;        break;
 
-            case 8:     if (target.is64bit || bPtr)
-                            u = OpndSize._64;
+            case 8:
+                        u = OpndSize._64;
                         break;
 
             case 16:    u = OpndSize._128;       break;

--- a/test/fail_compilation/failasm.d
+++ b/test/fail_compilation/failasm.d
@@ -21,3 +21,21 @@ uint func()
         inc long ptr [EAX];
     }
 }
+
+#line 200
+
+/* TEST_OUTPUT:
+---
+fail_compilation/failasm.d(213): Error: bad type/size of operands `mov`
+---
+*/
+
+void foo()
+{
+    long i = void;
+    static assert(long.sizeof == 8);
+    asm
+    {
+        mov i, EAX;
+    }
+}

--- a/test/fail_compilation/iasm1.d
+++ b/test/fail_compilation/iasm1.d
@@ -142,3 +142,21 @@ void test6()
     }
     L1:;
 }
+
+#line 700
+
+/* TEST_OUTPUT:
+---
+fail_compilation/iasm1.d(713): Error: bad type/size of operands `mov`
+---
+*/
+
+void foo()
+{
+    long i = void;
+    static assert(long.sizeof == 8);
+    asm
+    {
+        mov i, EAX;
+    }
+}


### PR DESCRIPTION
…zes.

A 8-byte type was only considered 8 bytes in 64 bit code, for some reason.
This led to inconsistent compilation of extended asm.

I tried to add an error message suggesting the use of an instruction like movsx
but this code is spaghetti.