### PR TITLE
chore(treewide): make dyncast() checks with a switch-case

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -4217,23 +4217,25 @@ struct ASTBase
             for (size_t i = 0; i < idents.dim; i++)
             {
                 RootObject id = t.idents[i];
-                if (id.dyncast() == DYNCAST.dsymbol)
+                switch (id.dyncast()) with (DYNCAST)
                 {
+                case dsymbol:
                     TemplateInstance ti = cast(TemplateInstance)id;
                     ti = ti.syntaxCopy(null);
                     id = ti;
-                }
-                else if (id.dyncast() == DYNCAST.expression)
-                {
+                    break;
+                case expression:
                     Expression e = cast(Expression)id;
                     e = e.syntaxCopy();
                     id = e;
-                }
-                else if (id.dyncast() == DYNCAST.type)
-                {
+                    break;
+                case type:
                     Type tx = cast(Type)id;
                     tx = tx.syntaxCopy();
                     id = tx;
+                    break;
+                default:
+                    break;
                 }
                 idents[i] = id;
             }
@@ -5115,21 +5117,24 @@ struct ASTBase
                     Expression e = new DsymbolExp(loc, s);
                     this.exps.push(e);
                 }
-                else if (o.dyncast() == DYNCAST.expression)
-                {
-                    auto e = (cast(Expression)o).copy();
-                    e.loc = loc;    // Bugzilla 15669
-                    this.exps.push(e);
-                }
-                else if (o.dyncast() == DYNCAST.type)
-                {
-                    Type t = cast(Type)o;
-                    Expression e = new TypeExp(loc, t);
-                    this.exps.push(e);
-                }
                 else
                 {
-                    error("%s is not an expression", o.toChars());
+                    switch (o.dyncast()) with (DYNCAST)
+                    {
+                    case expression:
+                        auto e = (cast(Expression)o).copy();
+                        e.loc = loc;    // Bugzilla 15669
+                        this.exps.push(e);
+                        break;
+                    case type:
+                        Type t = cast(Type)o;
+                        Expression e = new TypeExp(loc, t);
+                        this.exps.push(e);
+                        break;
+                    default:
+                        error("%s is not an expression", o.toChars());
+                        break;
+                    }
                 }
             }
         }

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1978,8 +1978,9 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
         }
 
         const DYNCAST kind = arrayContent.dyncast();
-        if (kind == DYNCAST.dsymbol)
+        switch (kind) with (DYNCAST)
         {
+        case dsymbol:
             TupleDeclaration td = cast(TupleDeclaration) arrayContent;
             /* $ gives the number of elements in the tuple
              */
@@ -1989,10 +1990,10 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
             v.storage_class |= STC.temp | STC.static_ | STC.const_;
             v.dsymbolSemantic(sc);
             return v;
-        }
-        if (kind == DYNCAST.type)
-        {
+        case type:
             return dollarFromTypeTuple(loc, cast(TypeTuple) arrayContent, sc);
+        default:
+            break;
         }
         Expression exp = cast(Expression) arrayContent;
         if (auto ie = exp.isIndexExp())

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6543,8 +6543,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 RootObject o = (*tup.objects)[i];
                 Expression e;
                 Declaration var;
-                if (o.dyncast() == DYNCAST.expression)
+                switch (o.dyncast()) with (DYNCAST)
                 {
+                case expression:
                     e = cast(Expression)o;
                     if (auto se = e.isDsymbolExp())
                         var = se.s.isDeclaration();
@@ -6553,9 +6554,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             // Exempt functions for backwards compatibility reasons.
                             // See: https://issues.dlang.org/show_bug.cgi?id=20470#c1
                             var = ve.var;
-                }
-                else if (o.dyncast() == DYNCAST.dsymbol)
-                {
+                    break;
+                case dsymbol:
                     Dsymbol s = cast(Dsymbol) o;
                     Declaration d = s.isDeclaration();
                     if (!d || d.isFuncDeclaration())
@@ -6564,13 +6564,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         e = new DsymbolExp(exp.loc, s);
                     else
                         var = d;
-                }
-                else if (o.dyncast() == DYNCAST.type)
-                {
+                    break;
+                case type:
                     e = new TypeExp(exp.loc, cast(Type)o);
-                }
-                else
-                {
+                    break;
+                default:
                     exp.error("`%s` is not an expression", o.toChars());
                     return setError();
                 }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3835,26 +3835,24 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
     {
         foreach (id; t.idents)
         {
-            if (id.dyncast() == DYNCAST.dsymbol)
+            switch (id.dyncast()) with (DYNCAST)
             {
+            case dsymbol:
                 buf.writeByte('.');
                 TemplateInstance ti = cast(TemplateInstance)id;
                 ti.dsymbolToBuffer(buf, hgs);
-            }
-            else if (id.dyncast() == DYNCAST.expression)
-            {
+                break;
+            case expression:
                 buf.writeByte('[');
                 (cast(Expression)id).expressionToBuffer(buf, hgs);
                 buf.writeByte(']');
-            }
-            else if (id.dyncast() == DYNCAST.type)
-            {
+                break;
+            case type:
                 buf.writeByte('[');
                 typeToBufferx(cast(Type)id, buf, hgs);
                 buf.writeByte(']');
-            }
-            else
-            {
+                break;
+            default:
                 buf.writeByte('.');
                 buf.writestring(id.toString());
             }

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -2214,13 +2214,12 @@ private void asm_merge_opnds(ref OPND o1, ref OPND o2)
         else
         {
             RootObject o = (*tup.objects)[index];
-            if (o.dyncast() == DYNCAST.dsymbol)
+            switch (o.dyncast()) with (DYNCAST)
             {
+            case dsymbol:
                 o1.s = cast(Dsymbol)o;
                 return;
-            }
-            else if (o.dyncast() == DYNCAST.expression)
-            {
+            case expression:
                 Expression e = cast(Expression)o;
                 if (auto ve = e.isVarExp())
                 {
@@ -2232,6 +2231,9 @@ private void asm_merge_opnds(ref OPND o1, ref OPND o2)
                     o1.s = fe.fd;
                     return;
                 }
+                break;
+            default:
+                break;
             }
             asmerr("invalid asm operand `%s`", o1.s.toChars());
         }

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -423,12 +423,20 @@ package mixin template ParseVisitMethods(AST)
         //printf("Visiting TypeQualified\n");
         foreach (id; t.idents)
         {
-            if (id.dyncast() == DYNCAST.dsymbol)
+            switch(id.dyncast()) with(DYNCAST)
+            {
+            case dsymbol:
                 (cast(AST.TemplateInstance)id).accept(this);
-            else if (id.dyncast() == DYNCAST.expression)
+                break;
+            case expression:
                 (cast(AST.Expression)id).accept(this);
-            else if (id.dyncast() == DYNCAST.type)
+                break;
+            case type:
                 (cast(AST.Type)id).accept(this);
+                break;
+            default:
+                break;
+            }
         }
     }
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -239,9 +239,10 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
     for (size_t i = 0; i < mt.idents.dim; i++)
     {
         RootObject id = mt.idents[i];
-        if (id.dyncast() == DYNCAST.expression ||
-            id.dyncast() == DYNCAST.type)
+        switch (id.dyncast()) with (DYNCAST)
         {
+        case expression:
+        case type:
             Type tx;
             Expression ex;
             Dsymbol sx;
@@ -259,6 +260,8 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
             ex = ex.expressionSemantic(sc);
             resolveExp(ex, pt, pe, ps);
             return;
+        default:
+            break;
         }
 
         Type t = s.getType(); // type symbol, type alias, or type tuple?
@@ -2799,21 +2802,20 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
                 }
 
                 RootObject o = (*tup.objects)[cast(size_t)d];
-                if (o.dyncast() == DYNCAST.dsymbol)
+                switch (o.dyncast()) with (DYNCAST)
                 {
+                case dsymbol:
                     return returnSymbol(cast(Dsymbol)o);
-                }
-                if (o.dyncast() == DYNCAST.expression)
-                {
+                case expression:
                     Expression e = cast(Expression)o;
                     if (e.op == EXP.dSymbol)
                         return returnSymbol(e.isDsymbolExp().s);
                     else
                         return returnExp(e);
-                }
-                if (o.dyncast() == DYNCAST.type)
-                {
+                case type:
                     return returnType((cast(Type)o).addMod(mt.mod));
+                default:
+                    break;
                 }
 
                 /* Create a new TupleDeclaration which


### PR DESCRIPTION
Using switch case can generate jump tables more easily as it doesn't have any
particular order of evaluation.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Somehow related to https://github.com/dlang/dmd/pull/14155 . Read comments there for context.