### PR TITLE
C++: Add final to virtual methods and class types

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -200,7 +200,7 @@ public:
     bool hasRegularCtor(bool checkDisabled = false);
 };
 
-class UnionDeclaration : public StructDeclaration
+class UnionDeclaration final : public StructDeclaration
 {
 public:
     UnionDeclaration *syntaxCopy(Dsymbol *s) override;
@@ -314,7 +314,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class InterfaceDeclaration : public ClassDeclaration
+class InterfaceDeclaration final : public ClassDeclaration
 {
 public:
     InterfaceDeclaration *syntaxCopy(Dsymbol *s) override;

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -120,20 +120,20 @@ public:
     Sizeok sizeok;              // set when structsize contains valid data
 
     virtual Scope *newScope(Scope *sc);
-    void setScope(Scope *sc) override;
+    void setScope(Scope *sc) override final;
     size_t nonHiddenFields();
     bool determineSize(const Loc &loc);
     virtual void finalizeSize() = 0;
-    uinteger_t size(const Loc &loc) override;
+    uinteger_t size(const Loc &loc) override final;
     bool fill(const Loc &loc, Expressions *elements, bool ctorinit);
-    Type *getType() override;
-    bool isDeprecated() const override; // is aggregate deprecated?
+    Type *getType() override final;
+    bool isDeprecated() const override final; // is aggregate deprecated?
     void setDeprecated();
     bool isNested() const;
-    bool isExport() const override;
+    bool isExport() const override final;
     Dsymbol *searchCtor();
 
-    Visibility visible() override;
+    Visibility visible() override final;
 
     // 'this' type
     Type *handleType() { return type; }
@@ -143,7 +143,7 @@ public:
     // Back end
     void *sinit;
 
-    AggregateDeclaration *isAggregateDeclaration() override { return this; }
+    AggregateDeclaration *isAggregateDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -187,12 +187,12 @@ public:
 
     static StructDeclaration *create(const Loc &loc, Identifier *id, bool inObject);
     StructDeclaration *syntaxCopy(Dsymbol *s) override;
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override final;
     const char *kind() const override;
-    void finalizeSize() override;
+    void finalizeSize() override final;
     bool isPOD();
 
-    StructDeclaration *isStructDeclaration() override { return this; }
+    StructDeclaration *isStructDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 
     unsigned numArgTypes() const;
@@ -289,7 +289,7 @@ public:
     virtual bool isBaseOf(ClassDeclaration *cd, int *poffset);
 
     bool isBaseInfoComplete();
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override final;
     ClassDeclaration *searchBase(Identifier *ident);
     void finalizeSize() override;
     bool hasMonitor();
@@ -303,14 +303,14 @@ public:
     virtual int vtblOffset() const;
     const char *kind() const override;
 
-    void addLocalClass(ClassDeclarations *) override;
-    void addObjcSymbols(ClassDeclarations *classes, ClassDeclarations *categories) override;
+    void addLocalClass(ClassDeclarations *) override final;
+    void addObjcSymbols(ClassDeclarations *classes, ClassDeclarations *categories) override final;
 
     // Back end
     Dsymbol *vtblsym;
     Dsymbol *vtblSymbol();
 
-    ClassDeclaration *isClassDeclaration() override { return (ClassDeclaration *)this; }
+    ClassDeclaration *isClassDeclaration() override final { return (ClassDeclaration *)this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/src/dmd/aliasthis.h
+++ b/src/dmd/aliasthis.h
@@ -15,7 +15,7 @@
 
 /**************************************************************/
 
-class AliasThis : public Dsymbol
+class AliasThis final : public Dsymbol
 {
 public:
    // alias Identifier this;

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -33,11 +33,11 @@ public:
     const char *kind() const override;
     bool oneMember(Dsymbol **ps, Identifier *ident) override;
     void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion) override;
-    bool hasPointers() override;
-    bool hasStaticCtorOrDtor() override;
-    void checkCtorConstInit() override;
-    void addLocalClass(ClassDeclarations *) override;
-    AttribDeclaration *isAttribDeclaration() override { return this; }
+    bool hasPointers() override final;
+    bool hasStaticCtorOrDtor() override final;
+    void checkCtorConstInit() override final;
+    void addLocalClass(ClassDeclarations *) override final;
+    AttribDeclaration *isAttribDeclaration() override final { return this; }
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -49,7 +49,7 @@ public:
 
     StorageClassDeclaration *syntaxCopy(Dsymbol *s) override;
     Scope *newScope(Scope *sc) override;
-    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    bool oneMember(Dsymbol **ps, Identifier *ident) override final;
     void addMember(Scope *sc, ScopeDsymbol *sds) override;
     StorageClassDeclaration *isStorageClassDeclaration() override { return this; }
 
@@ -166,9 +166,9 @@ public:
     Dsymbols *elsedecl; // array of Dsymbol's for else block
 
     ConditionalDeclaration *syntaxCopy(Dsymbol *s) override;
-    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    bool oneMember(Dsymbol **ps, Identifier *ident) override final;
     Dsymbols *include(Scope *sc) override;
-    void addComment(const utf8_t *comment) override;
+    void addComment(const utf8_t *comment) override final;
     void setScope(Scope *sc) override;
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -56,7 +56,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DeprecatedDeclaration : public StorageClassDeclaration
+class DeprecatedDeclaration final : public StorageClassDeclaration
 {
 public:
     Expression *msg;
@@ -68,7 +68,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class LinkDeclaration : public AttribDeclaration
+class LinkDeclaration final : public AttribDeclaration
 {
 public:
     LINK linkage;
@@ -80,7 +80,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CPPMangleDeclaration : public AttribDeclaration
+class CPPMangleDeclaration final : public AttribDeclaration
 {
 public:
     CPPMANGLE cppmangle;
@@ -92,7 +92,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CPPNamespaceDeclaration : public AttribDeclaration
+class CPPNamespaceDeclaration final : public AttribDeclaration
 {
 public:
     Expression *exp;
@@ -103,7 +103,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class VisibilityDeclaration : public AttribDeclaration
+class VisibilityDeclaration final : public AttribDeclaration
 {
 public:
     Visibility visibility;
@@ -118,7 +118,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class AlignDeclaration : public AttribDeclaration
+class AlignDeclaration final : public AttribDeclaration
 {
 public:
     Expressions *alignExps;
@@ -130,7 +130,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class AnonDeclaration : public AttribDeclaration
+class AnonDeclaration final : public AttribDeclaration
 {
 public:
     bool isunion;
@@ -147,7 +147,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class PragmaDeclaration : public AttribDeclaration
+class PragmaDeclaration final : public AttribDeclaration
 {
 public:
     Expressions *args;          // array of Expression's
@@ -173,7 +173,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class StaticIfDeclaration : public ConditionalDeclaration
+class StaticIfDeclaration final : public ConditionalDeclaration
 {
 public:
     ScopeDsymbol *scopesym;
@@ -189,7 +189,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class StaticForeachDeclaration : public AttribDeclaration
+class StaticForeachDeclaration final : public AttribDeclaration
 {
 public:
     StaticForeach *sfe;
@@ -209,7 +209,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ForwardingAttribDeclaration : public AttribDeclaration
+class ForwardingAttribDeclaration final : public AttribDeclaration
 {
 public:
     ForwardingScopeDsymbol *sym;
@@ -222,7 +222,7 @@ public:
 
 // Mixin declarations
 
-class CompileDeclaration : public AttribDeclaration
+class CompileDeclaration final : public AttribDeclaration
 {
 public:
     Expressions *exps;
@@ -241,7 +241,7 @@ public:
  * User defined attributes look like:
  *      @(args, ...)
  */
-class UserAttributeDeclaration : public AttribDeclaration
+class UserAttributeDeclaration final : public AttribDeclaration
 {
 public:
     Expressions *atts;

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -35,7 +35,7 @@ public:
     Loc loc;
     Include inc;
 
-    DYNCAST dyncast() const override { return DYNCAST_CONDITION; }
+    DYNCAST dyncast() const override final { return DYNCAST_CONDITION; }
 
     virtual Condition *syntaxCopy() = 0;
     virtual int include(Scope *sc) = 0;
@@ -64,7 +64,7 @@ public:
     Identifier *ident;
     Module *mod;
 
-    DVCondition *syntaxCopy() override;
+    DVCondition *syntaxCopy() override final;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -44,7 +44,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class StaticForeach
+class StaticForeach final : public RootObject
 {
 public:
     Loc loc;
@@ -68,7 +68,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DebugCondition : public DVCondition
+class DebugCondition final : public DVCondition
 {
 public:
     static void addGlobalIdent(const char *ident);
@@ -78,7 +78,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class VersionCondition : public DVCondition
+class VersionCondition final : public DVCondition
 {
 public:
     static void addGlobalIdent(const char *ident);
@@ -89,7 +89,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class StaticIfCondition : public Condition
+class StaticIfCondition final : public Condition
 {
 public:
     Expression *exp;

--- a/src/dmd/ctfe.h
+++ b/src/dmd/ctfe.h
@@ -17,7 +17,7 @@
   A reference to a class, or an interface. We need this when we
   point to a base class (we must record what the type is).
  */
-class ClassReferenceExp : public Expression
+class ClassReferenceExp final : public Expression
 {
 public:
     StructLiteralExp *value;
@@ -32,7 +32,7 @@ public:
 /**
   An uninitialized value
  */
-class VoidInitExp : public Expression
+class VoidInitExp final : public Expression
 {
 public:
     VarDeclaration *var;
@@ -45,7 +45,7 @@ public:
   Fake class which holds the thrown exception.
   Used for implementing exception handling.
 */
-class ThrownExceptionExp : public Expression
+class ThrownExceptionExp final : public Expression
 {
 public:
     ClassReferenceExp *thrown; // the thing being tossed
@@ -57,7 +57,7 @@ public:
 
 // This type is only used by the interpreter.
 
-class CTFEExp : public Expression
+class CTFEExp final : public Expression
 {
 public:
     const char *toChars() const override;

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -162,7 +162,7 @@ public:
 
 /**************************************************************/
 
-class TupleDeclaration : public Declaration
+class TupleDeclaration final : public Declaration
 {
 public:
     Objects *objects;
@@ -182,7 +182,7 @@ public:
 
 /**************************************************************/
 
-class AliasDeclaration : public Declaration
+class AliasDeclaration final : public Declaration
 {
 public:
     Dsymbol *aliassym;
@@ -204,7 +204,7 @@ public:
 
 /**************************************************************/
 
-class OverDeclaration : public Declaration
+class OverDeclaration final : public Declaration
 {
 public:
     Dsymbol *overnext;          // next in overload list
@@ -312,7 +312,7 @@ public:
 
 // This is a shell around a back end symbol
 
-class SymbolDeclaration : public Declaration
+class SymbolDeclaration final : public Declaration
 {
 public:
     AggregateDeclaration *dsym;
@@ -335,7 +335,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoStructDeclaration : public TypeInfoDeclaration
+class TypeInfoStructDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoStructDeclaration *create(Type *tinfo);
@@ -343,7 +343,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoClassDeclaration : public TypeInfoDeclaration
+class TypeInfoClassDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoClassDeclaration *create(Type *tinfo);
@@ -351,7 +351,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoInterfaceDeclaration : public TypeInfoDeclaration
+class TypeInfoInterfaceDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoInterfaceDeclaration *create(Type *tinfo);
@@ -359,7 +359,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoPointerDeclaration : public TypeInfoDeclaration
+class TypeInfoPointerDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoPointerDeclaration *create(Type *tinfo);
@@ -367,7 +367,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoArrayDeclaration : public TypeInfoDeclaration
+class TypeInfoArrayDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoArrayDeclaration *create(Type *tinfo);
@@ -375,7 +375,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoStaticArrayDeclaration : public TypeInfoDeclaration
+class TypeInfoStaticArrayDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoStaticArrayDeclaration *create(Type *tinfo);
@@ -383,7 +383,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoAssociativeArrayDeclaration : public TypeInfoDeclaration
+class TypeInfoAssociativeArrayDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoAssociativeArrayDeclaration *create(Type *tinfo);
@@ -391,7 +391,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoEnumDeclaration : public TypeInfoDeclaration
+class TypeInfoEnumDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoEnumDeclaration *create(Type *tinfo);
@@ -399,7 +399,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoFunctionDeclaration : public TypeInfoDeclaration
+class TypeInfoFunctionDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoFunctionDeclaration *create(Type *tinfo);
@@ -407,7 +407,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoDelegateDeclaration : public TypeInfoDeclaration
+class TypeInfoDelegateDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoDelegateDeclaration *create(Type *tinfo);
@@ -415,7 +415,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoTupleDeclaration : public TypeInfoDeclaration
+class TypeInfoTupleDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoTupleDeclaration *create(Type *tinfo);
@@ -423,7 +423,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoConstDeclaration : public TypeInfoDeclaration
+class TypeInfoConstDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoConstDeclaration *create(Type *tinfo);
@@ -431,7 +431,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoInvariantDeclaration : public TypeInfoDeclaration
+class TypeInfoInvariantDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoInvariantDeclaration *create(Type *tinfo);
@@ -439,7 +439,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoSharedDeclaration : public TypeInfoDeclaration
+class TypeInfoSharedDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoSharedDeclaration *create(Type *tinfo);
@@ -447,7 +447,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoWildDeclaration : public TypeInfoDeclaration
+class TypeInfoWildDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoWildDeclaration *create(Type *tinfo);
@@ -455,7 +455,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeInfoVectorDeclaration : public TypeInfoDeclaration
+class TypeInfoVectorDeclaration final : public TypeInfoDeclaration
 {
 public:
     static TypeInfoVectorDeclaration *create(Type *tinfo);
@@ -465,7 +465,7 @@ public:
 
 /**************************************************************/
 
-class ThisDeclaration : public VarDeclaration
+class ThisDeclaration final : public VarDeclaration
 {
 public:
     ThisDeclaration *syntaxCopy(Dsymbol *) override;
@@ -700,7 +700,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class FuncAliasDeclaration : public FuncDeclaration
+class FuncAliasDeclaration final : public FuncDeclaration
 {
 public:
     FuncDeclaration *funcalias;
@@ -713,7 +713,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class FuncLiteralDeclaration : public FuncDeclaration
+class FuncLiteralDeclaration final : public FuncDeclaration
 {
 public:
     TOK tok;                       // TOKfunction or TOKdelegate
@@ -737,7 +737,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CtorDeclaration : public FuncDeclaration
+class CtorDeclaration final : public FuncDeclaration
 {
 public:
     bool isCpCtor;
@@ -752,7 +752,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class PostBlitDeclaration : public FuncDeclaration
+class PostBlitDeclaration final : public FuncDeclaration
 {
 public:
     PostBlitDeclaration *syntaxCopy(Dsymbol *) override;
@@ -765,7 +765,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DtorDeclaration : public FuncDeclaration
+class DtorDeclaration final : public FuncDeclaration
 {
 public:
     DtorDeclaration *syntaxCopy(Dsymbol *) override;
@@ -794,7 +794,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class SharedStaticCtorDeclaration : public StaticCtorDeclaration
+class SharedStaticCtorDeclaration final : public StaticCtorDeclaration
 {
 public:
     SharedStaticCtorDeclaration *syntaxCopy(Dsymbol *) override;
@@ -819,7 +819,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class SharedStaticDtorDeclaration : public StaticDtorDeclaration
+class SharedStaticDtorDeclaration final : public StaticDtorDeclaration
 {
 public:
     SharedStaticDtorDeclaration *syntaxCopy(Dsymbol *) override;
@@ -828,7 +828,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class InvariantDeclaration : public FuncDeclaration
+class InvariantDeclaration final : public FuncDeclaration
 {
 public:
     InvariantDeclaration *syntaxCopy(Dsymbol *) override;
@@ -840,7 +840,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class UnitTestDeclaration : public FuncDeclaration
+class UnitTestDeclaration final : public FuncDeclaration
 {
 public:
     char *codedoc; /** For documented unittest. */
@@ -858,7 +858,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class NewDeclaration : public FuncDeclaration
+class NewDeclaration final : public FuncDeclaration
 {
 public:
     NewDeclaration *syntaxCopy(Dsymbol *) override;

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -123,9 +123,9 @@ public:
     DString mangleOverride;     // overridden symbol with pragma(mangle, "...")
 
     const char *kind() const override;
-    uinteger_t size(const Loc &loc) override;
+    uinteger_t size(const Loc &loc) override final;
 
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override final;
 
     bool isStatic() const { return (storage_class & STCstatic) != 0; }
     LINK resolvedLinkage() const; // returns the linkage, resolving the target-specific `System` one
@@ -142,7 +142,7 @@ public:
     bool isScope() const        { return (storage_class & STCscope) != 0; }
     bool isSynchronized() const { return (storage_class & STCsynchronized) != 0; }
     bool isParameter() const    { return (storage_class & STCparameter) != 0; }
-    bool isDeprecated() const override { return (storage_class & STCdeprecated) != 0; }
+    bool isDeprecated() const override final { return (storage_class & STCdeprecated) != 0; }
     bool isOverride() const     { return (storage_class & STCoverride) != 0; }
     bool isResult() const       { return (storage_class & STCresult) != 0; }
     bool isField() const        { return (storage_class & STCfield) != 0; }
@@ -154,9 +154,9 @@ public:
 
     bool isFuture() const { return (storage_class & STCfuture) != 0; }
 
-    Visibility visible() override;
+    Visibility visible() override final;
 
-    Declaration *isDeclaration() override { return this; }
+    Declaration *isDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -272,24 +272,24 @@ public:
     bool isArgDtorVar(bool v);
     static VarDeclaration *create(const Loc &loc, Type *t, Identifier *id, Initializer *init, StorageClass storage_class = STCundefined);
     VarDeclaration *syntaxCopy(Dsymbol *) override;
-    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion) override;
+    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion) override final;
     const char *kind() const override;
-    AggregateDeclaration *isThis() override;
-    bool needThis() override;
-    bool isExport() const override;
-    bool isImportedSymbol() const override;
+    AggregateDeclaration *isThis() override final;
+    bool needThis() override final;
+    bool isExport() const override final;
+    bool isImportedSymbol() const override final;
     bool isCtorinit() const;
-    bool isDataseg() override;
-    bool isThreadlocal() override;
+    bool isDataseg() override final;
+    bool isThreadlocal() override final;
     bool isCTFE();
     bool isOverlappedWith(VarDeclaration *v);
-    bool hasPointers() override;
+    bool hasPointers() override final;
     bool canTakeAddressOf();
     bool needsScopeDtor();
-    void checkCtorConstInit() override;
-    Dsymbol *toAlias() override;
+    void checkCtorConstInit() override final;
+    Dsymbol *toAlias() override final;
     // Eliminate need for dynamic_cast
-    VarDeclaration *isVarDeclaration() override { return (VarDeclaration *)this; }
+    VarDeclaration *isVarDeclaration() override final { return (VarDeclaration *)this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -304,7 +304,7 @@ public:
     unsigned bitOffset;
 
     BitFieldDeclaration *syntaxCopy(Dsymbol *) override;
-    BitFieldDeclaration *isBitFieldDeclaration() override { return this; }
+    BitFieldDeclaration *isBitFieldDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -328,10 +328,10 @@ public:
     Type *tinfo;
 
     static TypeInfoDeclaration *create(Type *tinfo);
-    TypeInfoDeclaration *syntaxCopy(Dsymbol *) override;
-    const char *toChars() const override;
+    TypeInfoDeclaration *syntaxCopy(Dsymbol *) override final;
+    const char *toChars() const override final;
 
-    TypeInfoDeclaration *isTypeInfoDeclaration() override { return this; }
+    TypeInfoDeclaration *isTypeInfoDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -628,7 +628,7 @@ public:
     FuncDeclaration *syntaxCopy(Dsymbol *) override;
     bool functionSemantic();
     bool functionSemantic3();
-    bool equals(const RootObject *o) const override;
+    bool equals(const RootObject *o) const override final;
 
     int overrides(FuncDeclaration *fd);
     int findVtblIndex(Dsymbols *vtbl, int dim);
@@ -645,11 +645,11 @@ public:
     bool isCMain() const;
     bool isWinMain() const;
     bool isDllMain() const;
-    bool isExport() const override;
-    bool isImportedSymbol() const override;
-    bool isCodeseg() const override;
-    bool isOverloadable() const override;
-    bool isAbstract() override;
+    bool isExport() const override final;
+    bool isImportedSymbol() const override final;
+    bool isCodeseg() const override final;
+    bool isOverloadable() const override final;
+    bool isAbstract() override final;
     PURE isPure();
     PURE isPureBypassingInference();
     bool isSafe();
@@ -677,7 +677,7 @@ public:
 
     virtual bool isNested() const;
     AggregateDeclaration *isThis() override;
-    bool needThis() override;
+    bool needThis() override final;
     bool isVirtualMethod();
     virtual bool isVirtual() const;
     bool isFinalFunc() const;
@@ -694,7 +694,7 @@ public:
 
     bool checkNRVO();
 
-    FuncDeclaration *isFuncDeclaration() override { return this; }
+    FuncDeclaration *isFuncDeclaration() override final { return this; }
 
     virtual FuncDeclaration *toAliasFunc() { return this; }
     void accept(Visitor *v) override { v->visit(this); }
@@ -784,13 +784,13 @@ class StaticCtorDeclaration : public FuncDeclaration
 {
 public:
     StaticCtorDeclaration *syntaxCopy(Dsymbol *) override;
-    AggregateDeclaration *isThis() override;
-    bool isVirtual() const override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
-    bool hasStaticCtorOrDtor() override;
+    AggregateDeclaration *isThis() override final;
+    bool isVirtual() const override final;
+    bool addPreInvariant() override final;
+    bool addPostInvariant() override final;
+    bool hasStaticCtorOrDtor() override final;
 
-    StaticCtorDeclaration *isStaticCtorDeclaration() override { return this; }
+    StaticCtorDeclaration *isStaticCtorDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -809,13 +809,13 @@ public:
     VarDeclaration *vgate;      // 'gate' variable
 
     StaticDtorDeclaration *syntaxCopy(Dsymbol *) override;
-    AggregateDeclaration *isThis() override;
-    bool isVirtual() const override;
-    bool hasStaticCtorOrDtor() override;
-    bool addPreInvariant() override;
-    bool addPostInvariant() override;
+    AggregateDeclaration *isThis() override final;
+    bool isVirtual() const override final;
+    bool hasStaticCtorOrDtor() override final;
+    bool addPreInvariant() override final;
+    bool addPostInvariant() override final;
 
-    StaticDtorDeclaration *isStaticDtorDeclaration() override { return this; }
+    StaticDtorDeclaration *isStaticDtorDeclaration() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -347,7 +347,7 @@ public:
 
 // With statement scope
 
-class WithScopeSymbol : public ScopeDsymbol
+class WithScopeSymbol final : public ScopeDsymbol
 {
 public:
     WithStatement *withstate;
@@ -360,7 +360,7 @@ public:
 
 // Array Index/Slice scope
 
-class ArrayScopeSymbol : public ScopeDsymbol
+class ArrayScopeSymbol final : public ScopeDsymbol
 {
 private:
     RootObject *arrayContent;
@@ -375,7 +375,7 @@ public:
 
 // Overload Sets
 
-class OverloadSet : public Dsymbol
+class OverloadSet final : public Dsymbol
 {
 public:
     Dsymbols a;         // array of Dsymbols
@@ -388,7 +388,7 @@ public:
 
 // Forwarding ScopeDsymbol
 
-class ForwardingScopeDsymbol : public ScopeDsymbol
+class ForwardingScopeDsymbol final : public ScopeDsymbol
 {
 public:
     ScopeDsymbol *forward;
@@ -401,7 +401,7 @@ public:
     ForwardingScopeDsymbol *isForwardingScopeDsymbol() override { return this; }
 };
 
-class ExpressionDsymbol : public Dsymbol
+class ExpressionDsymbol final : public Dsymbol
 {
 public:
     Expression *exp;
@@ -411,7 +411,7 @@ public:
 
 // Table of Dsymbol's
 
-class DsymbolTable : public RootObject
+class DsymbolTable final : public RootObject
 {
 public:
     AA *tab;

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -211,7 +211,7 @@ public:
     Ungag ungagSpeculative();
 
     // kludge for template.isSymbol()
-    DYNCAST dyncast() const override { return DYNCAST_DSYMBOL; }
+    DYNCAST dyncast() const override final { return DYNCAST_DSYMBOL; }
 
     virtual Identifier *getIdent();
     virtual const char *toPrettyChars(bool QualifyTypes = false);
@@ -333,7 +333,7 @@ public:
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
     virtual void importScope(Dsymbol *s, Visibility visibility);
     virtual bool isPackageAccessible(Package *p, Visibility visibility, int flags = 0);
-    bool isforwardRef() override;
+    bool isforwardRef() override final;
     static void multiplyDefined(const Loc &loc, Dsymbol *s1, Dsymbol *s2);
     const char *kind() const override;
     FuncDeclaration *findGetMembers();
@@ -341,7 +341,7 @@ public:
     virtual Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
     bool hasStaticCtorOrDtor() override;
 
-    ScopeDsymbol *isScopeDsymbol() override { return this; }
+    ScopeDsymbol *isScopeDsymbol() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/src/dmd/enum.h
+++ b/src/dmd/enum.h
@@ -17,7 +17,7 @@ class Identifier;
 class Type;
 class Expression;
 
-class EnumDeclaration : public ScopeDsymbol
+class EnumDeclaration final : public ScopeDsymbol
 {
 public:
     /* The separate, and distinct, cases are:
@@ -60,7 +60,7 @@ public:
 };
 
 
-class EnumMember : public VarDeclaration
+class EnumMember final : public VarDeclaration
 {
 public:
     /* Can take the following forms:

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -90,7 +90,7 @@ public:
     virtual Expression *syntaxCopy();
 
     // kludge for template.isExpression()
-    DYNCAST dyncast() const override { return DYNCAST_EXPRESSION; }
+    DYNCAST dyncast() const override final { return DYNCAST_EXPRESSION; }
 
     const char *toChars() const override;
     void error(const char *format, ...) const;
@@ -313,8 +313,8 @@ public:
     Identifier *ident;
 
     static IdentifierExp *create(const Loc &loc, Identifier *ident);
-    bool isLvalue() override;
-    Expression *toLvalue(Scope *sc, Expression *e) override;
+    bool isLvalue() override final;
+    Expression *toLvalue(Scope *sc, Expression *e) override final;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -343,8 +343,8 @@ public:
 
     ThisExp *syntaxCopy() override;
     Optional<bool> toBool() override;
-    bool isLvalue() override;
-    Expression *toLvalue(Scope *sc, Expression *e) override;
+    bool isLvalue() override final;
+    Expression *toLvalue(Scope *sc, Expression *e) override final;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -690,7 +690,7 @@ public:
 
     UnaExp *syntaxCopy() override;
     Expression *incompatibleTypes();
-    Expression *resolveLoc(const Loc &loc, Scope *sc) override;
+    Expression *resolveLoc(const Loc &loc, Scope *sc) override final;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -715,9 +715,9 @@ public:
 class BinAssignExp : public BinExp
 {
 public:
-    bool isLvalue() override;
-    Expression *toLvalue(Scope *sc, Expression *ex) override;
-    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
+    bool isLvalue() override final;
+    Expression *toLvalue(Scope *sc, Expression *ex) override final;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override final;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -1056,8 +1056,8 @@ class AssignExp : public BinExp
 public:
     MemorySet memset;
 
-    bool isLvalue() override;
-    Expression *toLvalue(Scope *sc, Expression *ex) override;
+    bool isLvalue() override final;
+    Expression *toLvalue(Scope *sc, Expression *ex) override final;
 
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -243,7 +243,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class IntegerExp : public Expression
+class IntegerExp final : public Expression
 {
 public:
     dinteger_t value;
@@ -264,7 +264,7 @@ public:
     static IntegerExp literal();
 };
 
-class ErrorExp : public Expression
+class ErrorExp final : public Expression
 {
 public:
     Expression *toLvalue(Scope *sc, Expression *e) override;
@@ -273,7 +273,7 @@ public:
     static ErrorExp *errorexp; // handy shared value
 };
 
-class RealExp : public Expression
+class RealExp final : public Expression
 {
 public:
     real_t value;
@@ -290,7 +290,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ComplexExp : public Expression
+class ComplexExp final : public Expression
 {
 public:
     complex_t value;
@@ -318,13 +318,13 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DollarExp : public IdentifierExp
+class DollarExp final : public IdentifierExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DsymbolExp : public Expression
+class DsymbolExp final : public Expression
 {
 public:
     Dsymbol *s;
@@ -349,13 +349,13 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class SuperExp : public ThisExp
+class SuperExp final : public ThisExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class NullExp : public Expression
+class NullExp final : public Expression
 {
 public:
     bool equals(const RootObject *o) const override;
@@ -364,7 +364,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class StringExp : public Expression
+class StringExp final : public Expression
 {
 public:
     void *string;       // char, wchar, or dchar data
@@ -393,7 +393,7 @@ public:
 
 // Tuple
 
-class TupleExp : public Expression
+class TupleExp final : public Expression
 {
 public:
     Expression *e0;     // side-effect part
@@ -413,7 +413,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ArrayLiteralExp : public Expression
+class ArrayLiteralExp final : public Expression
 {
 public:
     Expression *basis;
@@ -432,7 +432,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class AssocArrayLiteralExp : public Expression
+class AssocArrayLiteralExp final : public Expression
 {
 public:
     Expressions *keys;
@@ -446,7 +446,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class StructLiteralExp : public Expression
+class StructLiteralExp final : public Expression
 {
 public:
     StructDeclaration *sd;      // which aggregate this is for
@@ -487,7 +487,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeExp : public Expression
+class TypeExp final : public Expression
 {
 public:
     TypeExp *syntaxCopy() override;
@@ -496,7 +496,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ScopeExp : public Expression
+class ScopeExp final : public Expression
 {
 public:
     ScopeDsymbol *sds;
@@ -507,7 +507,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TemplateExp : public Expression
+class TemplateExp final : public Expression
 {
 public:
     TemplateDeclaration *td;
@@ -520,7 +520,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class NewExp : public Expression
+class NewExp final : public Expression
 {
 public:
     /* newtype(arguments)
@@ -541,7 +541,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class NewAnonClassExp : public Expression
+class NewAnonClassExp final : public Expression
 {
 public:
     /* class baseclasses { } (arguments)
@@ -566,7 +566,7 @@ public:
 
 // Offset from symbol
 
-class SymOffExp : public SymbolExp
+class SymOffExp final : public SymbolExp
 {
 public:
     dinteger_t offset;
@@ -578,7 +578,7 @@ public:
 
 // Variable
 
-class VarExp : public SymbolExp
+class VarExp final : public SymbolExp
 {
 public:
     bool delegateWasExtracted;
@@ -593,7 +593,7 @@ public:
 
 // Overload Set
 
-class OverExp : public Expression
+class OverExp final : public Expression
 {
 public:
     OverloadSet *vars;
@@ -605,7 +605,7 @@ public:
 
 // Function/Delegate literal
 
-class FuncExp : public Expression
+class FuncExp final : public Expression
 {
 public:
     FuncLiteralDeclaration *fd;
@@ -626,7 +626,7 @@ public:
 // D grammar allows declarations only as statements. However in AST representation
 // it can be part of any expression. This is used, for example, during internal
 // syntax re-writes to inject hidden symbols.
-class DeclarationExp : public Expression
+class DeclarationExp final : public Expression
 {
 public:
     Dsymbol *declaration;
@@ -638,7 +638,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeidExp : public Expression
+class TypeidExp final : public Expression
 {
 public:
     RootObject *obj;
@@ -647,7 +647,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TraitsExp : public Expression
+class TraitsExp final : public Expression
 {
 public:
     Identifier *ident;
@@ -657,13 +657,13 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class HaltExp : public Expression
+class HaltExp final : public Expression
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class IsExp : public Expression
+class IsExp final : public Expression
 {
 public:
     /* is(targ id tok tspec)
@@ -723,19 +723,19 @@ public:
 
 /****************************************************************/
 
-class MixinExp : public UnaExp
+class MixinExp final : public UnaExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ImportExp : public UnaExp
+class ImportExp final : public UnaExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class AssertExp : public UnaExp
+class AssertExp final : public UnaExp
 {
 public:
     Expression *msg;
@@ -745,7 +745,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ThrowExp : public UnaExp
+class ThrowExp final : public UnaExp
 {
 public:
     ThrowExp *syntaxCopy() override;
@@ -753,7 +753,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DotIdExp : public UnaExp
+class DotIdExp final : public UnaExp
 {
 public:
     Identifier *ident;
@@ -765,7 +765,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DotTemplateExp : public UnaExp
+class DotTemplateExp final : public UnaExp
 {
 public:
     TemplateDeclaration *td;
@@ -775,7 +775,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DotVarExp : public UnaExp
+class DotVarExp final : public UnaExp
 {
 public:
     Declaration *var;
@@ -787,7 +787,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DotTemplateInstanceExp : public UnaExp
+class DotTemplateInstanceExp final : public UnaExp
 {
 public:
     TemplateInstance *ti;
@@ -799,7 +799,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DelegateExp : public UnaExp
+class DelegateExp final : public UnaExp
 {
 public:
     FuncDeclaration *func;
@@ -810,7 +810,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DotTypeExp : public UnaExp
+class DotTypeExp final : public UnaExp
 {
 public:
     Dsymbol *sym;               // symbol that represents a type
@@ -818,7 +818,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CallExp : public UnaExp
+class CallExp final : public UnaExp
 {
 public:
     Expressions *arguments;     // function arguments
@@ -841,13 +841,13 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class AddrExp : public UnaExp
+class AddrExp final : public UnaExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class PtrExp : public UnaExp
+class PtrExp final : public UnaExp
 {
 public:
     bool isLvalue() override;
@@ -857,38 +857,38 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class NegExp : public UnaExp
+class NegExp final : public UnaExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class UAddExp : public UnaExp
+class UAddExp final : public UnaExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ComExp : public UnaExp
+class ComExp final : public UnaExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class NotExp : public UnaExp
+class NotExp final : public UnaExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DeleteExp : public UnaExp
+class DeleteExp final : public UnaExp
 {
 public:
     bool isRAII;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CastExp : public UnaExp
+class CastExp final : public UnaExp
 {
 public:
     // Possible to cast to one type while painting to another type
@@ -902,7 +902,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class VectorExp : public UnaExp
+class VectorExp final : public UnaExp
 {
 public:
     TypeVector *to;             // the target vector type before semantic()
@@ -915,7 +915,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class VectorArrayExp : public UnaExp
+class VectorArrayExp final : public UnaExp
 {
 public:
     bool isLvalue() override;
@@ -923,7 +923,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class SliceExp : public UnaExp
+class SliceExp final : public UnaExp
 {
 public:
     Expression *upr;            // NULL if implicit 0
@@ -942,13 +942,13 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ArrayLengthExp : public UnaExp
+class ArrayLengthExp final : public UnaExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class IntervalExp : public Expression
+class IntervalExp final : public Expression
 {
 public:
     Expression *lwr;
@@ -958,7 +958,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DelegatePtrExp : public UnaExp
+class DelegatePtrExp final : public UnaExp
 {
 public:
     bool isLvalue() override;
@@ -967,7 +967,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DelegateFuncptrExp : public UnaExp
+class DelegateFuncptrExp final : public UnaExp
 {
 public:
     bool isLvalue() override;
@@ -978,7 +978,7 @@ public:
 
 // e1[a0,a1,a2,a3,...]
 
-class ArrayExp : public UnaExp
+class ArrayExp final : public UnaExp
 {
 public:
     Expressions *arguments;             // Array of Expression's
@@ -994,13 +994,13 @@ public:
 
 /****************************************************************/
 
-class DotExp : public BinExp
+class DotExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CommaExp : public BinExp
+class CommaExp final : public BinExp
 {
 public:
     bool isGenerated;
@@ -1013,7 +1013,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class IndexExp : public BinExp
+class IndexExp final : public BinExp
 {
 public:
     VarDeclaration *lengthVar;
@@ -1030,7 +1030,7 @@ public:
 
 /* For both i++ and i--
  */
-class PostExp : public BinExp
+class PostExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
@@ -1038,7 +1038,7 @@ public:
 
 /* For both ++i and --i
  */
-class PreExp : public UnaExp
+class PreExp final : public UnaExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
@@ -1062,85 +1062,85 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ConstructExp : public AssignExp
+class ConstructExp final : public AssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class BlitExp : public AssignExp
+class BlitExp final : public AssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class AddAssignExp : public BinAssignExp
+class AddAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class MinAssignExp : public BinAssignExp
+class MinAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class MulAssignExp : public BinAssignExp
+class MulAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DivAssignExp : public BinAssignExp
+class DivAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ModAssignExp : public BinAssignExp
+class ModAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class AndAssignExp : public BinAssignExp
+class AndAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class OrAssignExp : public BinAssignExp
+class OrAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class XorAssignExp : public BinAssignExp
+class XorAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class PowAssignExp : public BinAssignExp
+class PowAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ShlAssignExp : public BinAssignExp
+class ShlAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ShrAssignExp : public BinAssignExp
+class ShrAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class UshrAssignExp : public BinAssignExp
+class UshrAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
@@ -1152,115 +1152,115 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CatElemAssignExp : public CatAssignExp
+class CatElemAssignExp final : public CatAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CatDcharAssignExp : public CatAssignExp
+class CatDcharAssignExp final : public CatAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class AddExp : public BinExp
+class AddExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class MinExp : public BinExp
+class MinExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CatExp : public BinExp
+class CatExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class MulExp : public BinExp
+class MulExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DivExp : public BinExp
+class DivExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ModExp : public BinExp
+class ModExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class PowExp : public BinExp
+class PowExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ShlExp : public BinExp
+class ShlExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ShrExp : public BinExp
+class ShrExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class UshrExp : public BinExp
+class UshrExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class AndExp : public BinExp
+class AndExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class OrExp : public BinExp
+class OrExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class XorExp : public BinExp
+class XorExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class LogicalExp : public BinExp
+class LogicalExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CmpExp : public BinExp
+class CmpExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class InExp : public BinExp
+class InExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class RemoveExp : public BinExp
+class RemoveExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
@@ -1268,7 +1268,7 @@ public:
 
 // == and !=
 
-class EqualExp : public BinExp
+class EqualExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
@@ -1276,7 +1276,7 @@ public:
 
 // is and !is
 
-class IdentityExp : public BinExp
+class IdentityExp final : public BinExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
@@ -1284,7 +1284,7 @@ public:
 
 /****************************************************************/
 
-class CondExp : public BinExp
+class CondExp final : public BinExp
 {
 public:
     Expression *econd;
@@ -1298,7 +1298,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class GenericExp : Expression
+class GenericExp final : Expression
 {
     Expression *cntlExp;
     Types *types;
@@ -1317,35 +1317,35 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class FileInitExp : public DefaultInitExp
+class FileInitExp final : public DefaultInitExp
 {
 public:
     Expression *resolveLoc(const Loc &loc, Scope *sc) override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class LineInitExp : public DefaultInitExp
+class LineInitExp final : public DefaultInitExp
 {
 public:
     Expression *resolveLoc(const Loc &loc, Scope *sc) override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ModuleInitExp : public DefaultInitExp
+class ModuleInitExp final : public DefaultInitExp
 {
 public:
     Expression *resolveLoc(const Loc &loc, Scope *sc) override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class FuncInitExp : public DefaultInitExp
+class FuncInitExp final : public DefaultInitExp
 {
 public:
     Expression *resolveLoc(const Loc &loc, Scope *sc) override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class PrettyFuncInitExp : public DefaultInitExp
+class PrettyFuncInitExp final : public DefaultInitExp
 {
 public:
     Expression *resolveLoc(const Loc &loc, Scope *sc) override;
@@ -1410,7 +1410,7 @@ private:
 
 /****************************************************************/
 
-class ObjcClassReferenceExp : public Expression
+class ObjcClassReferenceExp final : public Expression
 {
 public:
     ClassDeclaration* classDeclaration;

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -13,7 +13,7 @@
 #include "root/dcompat.h"
 #include "root/object.h"
 
-class Identifier : public RootObject
+class Identifier final : public RootObject
 {
 private:
     int value;

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -22,7 +22,6 @@ private:
 
 public:
     static Identifier* create(const char *string);
-    bool equals(const RootObject *o) const override;
     const char *toChars() const override;
     int getValue() const;
     bool isAnonymous() const;

--- a/src/dmd/import.h
+++ b/src/dmd/import.h
@@ -17,7 +17,7 @@ struct Scope;
 class Module;
 class Package;
 
-class Import : public Dsymbol
+class Import final : public Dsymbol
 {
 public:
     /* static import aliasId = pkg1.pkg2.id : alias1 = name1, alias2 = name2;

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -35,7 +35,7 @@ public:
 
     DYNCAST dyncast() const override { return DYNCAST_INITIALIZER; }
 
-    const char *toChars() const override;
+    const char *toChars() const override final;
 
     ErrorInitializer   *isErrorInitializer();
     VoidInitializer    *isVoidInitializer();

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -47,7 +47,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class VoidInitializer : public Initializer
+class VoidInitializer final : public Initializer
 {
 public:
     Type *type;         // type that this will initialize to
@@ -55,13 +55,13 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ErrorInitializer : public Initializer
+class ErrorInitializer final : public Initializer
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class StructInitializer : public Initializer
+class StructInitializer final : public Initializer
 {
 public:
     Identifiers field;  // of Identifier *'s
@@ -70,7 +70,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ArrayInitializer : public Initializer
+class ArrayInitializer final : public Initializer
 {
 public:
     Expressions index;  // indices
@@ -85,7 +85,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ExpInitializer : public Initializer
+class ExpInitializer final : public Initializer
 {
 public:
     bool expandTuples;
@@ -106,7 +106,7 @@ struct DesigInit
     Initializer *initializer;
 };
 
-class CInitializer : public Initializer
+class CInitializer final : public Initializer
 {
 public:
     DesigInits initializerList;

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -39,7 +39,7 @@ public:
 
     bool equals(const RootObject *o) const override;
 
-    Package *isPackage() override { return this; }
+    Package *isPackage() override final { return this; }
 
     bool isAncestorPackageOf(const Package * const pkg) const;
 

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -49,7 +49,7 @@ public:
     Module *isPackageMod();
 };
 
-class Module : public Package
+class Module final : public Package
 {
 public:
     static Module *rootModule;

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -224,7 +224,7 @@ public:
     bool equals(const RootObject *o) const override;
     bool equivalent(Type *t);
     // kludge for template.isType()
-    DYNCAST dyncast() const override { return DYNCAST_TYPE; }
+    DYNCAST dyncast() const override final { return DYNCAST_TYPE; }
     size_t getUniqueID() const;
     Covariant covariant(Type *t, StorageClass *pstc = NULL);
     const char *toChars() const override;
@@ -368,20 +368,20 @@ class TypeNext : public Type
 public:
     Type *next;
 
-    void checkDeprecated(const Loc &loc, Scope *sc) override;
-    int hasWild() const override;
-    Type *nextOf() override;
-    Type *makeConst() override;
-    Type *makeImmutable() override;
-    Type *makeShared() override;
-    Type *makeSharedConst() override;
-    Type *makeWild() override;
-    Type *makeWildConst() override;
-    Type *makeSharedWild() override;
-    Type *makeSharedWildConst() override;
-    Type *makeMutable() override;
+    void checkDeprecated(const Loc &loc, Scope *sc) override final;
+    int hasWild() const override final;
+    Type *nextOf() override final;
+    Type *makeConst() override final;
+    Type *makeImmutable() override final;
+    Type *makeShared() override final;
+    Type *makeSharedConst() override final;
+    Type *makeWild() override final;
+    Type *makeWildConst() override final;
+    Type *makeSharedWild() override final;
+    Type *makeSharedWildConst() override final;
+    Type *makeMutable() override final;
     MATCH constConv(Type *to) override;
-    unsigned char deduceWild(Type *t, bool isRef) override;
+    unsigned char deduceWild(Type *t, bool isRef) override final;
     void transitive();
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -352,7 +352,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeError : public Type
+class TypeError final : public Type
 {
 public:
     const char *kind() override;
@@ -386,7 +386,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeBasic : public Type
+class TypeBasic final : public Type
 {
 public:
     const char *dstring;
@@ -411,7 +411,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeVector : public Type
+class TypeVector final : public Type
 {
 public:
     Type *basetype;
@@ -441,7 +441,7 @@ public:
 };
 
 // Static array, one with a fixed dimension
-class TypeSArray : public TypeArray
+class TypeSArray final : public TypeArray
 {
 public:
     Expression *dim;
@@ -467,7 +467,7 @@ public:
 };
 
 // Dynamic array, no dimension
-class TypeDArray : public TypeArray
+class TypeDArray final : public TypeArray
 {
 public:
     const char *kind() override;
@@ -483,7 +483,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeAArray : public TypeArray
+class TypeAArray final : public TypeArray
 {
 public:
     Type *index;                // key type
@@ -502,7 +502,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypePointer : public TypeNext
+class TypePointer final : public TypeNext
 {
 public:
     static TypePointer *create(Type *t);
@@ -518,7 +518,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeReference : public TypeNext
+class TypeReference final : public TypeNext
 {
 public:
     const char *kind() override;
@@ -556,7 +556,7 @@ enum class PURE : unsigned char
     const_ = 3,     // parameters are values or const
 };
 
-class Parameter : public ASTNode
+class Parameter final : public ASTNode
 {
 public:
     StorageClass storageClass;
@@ -590,7 +590,7 @@ struct ParameterList
     Parameter *operator[](size_t i) { return Parameter::getNth(parameters, i); }
 };
 
-class TypeFunction : public TypeNext
+class TypeFunction final : public TypeNext
 {
 public:
     // .next is the return type
@@ -646,7 +646,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeDelegate : public TypeNext
+class TypeDelegate final : public TypeNext
 {
 public:
     // .next is a TypeFunction
@@ -665,7 +665,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeTraits : public Type
+class TypeTraits final : public Type
 {
     Loc loc;
     /// The expression to resolve as type or symbol.
@@ -680,7 +680,7 @@ class TypeTraits : public Type
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeMixin : public Type
+class TypeMixin final : public Type
 {
     Loc loc;
     Expressions *exps;
@@ -709,7 +709,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeIdentifier : public TypeQualified
+class TypeIdentifier final : public TypeQualified
 {
 public:
     Identifier *ident;
@@ -724,7 +724,7 @@ public:
 
 /* Similar to TypeIdentifier, but with a TemplateInstance as the root
  */
-class TypeInstance : public TypeQualified
+class TypeInstance final : public TypeQualified
 {
 public:
     TemplateInstance *tempinst;
@@ -735,7 +735,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeTypeof : public TypeQualified
+class TypeTypeof final : public TypeQualified
 {
 public:
     Expression *exp;
@@ -748,7 +748,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeReturn : public TypeQualified
+class TypeReturn final : public TypeQualified
 {
 public:
     const char *kind() override;
@@ -769,7 +769,7 @@ enum AliasThisRec
     RECtracingDT = 0x8  // mark in progress of deduceType
 };
 
-class TypeStruct : public Type
+class TypeStruct final : public Type
 {
 public:
     StructDeclaration *sym;
@@ -801,7 +801,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeEnum : public Type
+class TypeEnum final : public Type
 {
 public:
     EnumDeclaration *sym;
@@ -836,7 +836,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeClass : public Type
+class TypeClass final : public Type
 {
 public:
     ClassDeclaration *sym;
@@ -861,7 +861,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeTuple : public Type
+class TypeTuple final : public Type
 {
 public:
     // 'logically immutable' cached global - don't modify (neither pointer nor pointee)!
@@ -879,7 +879,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeSlice : public TypeNext
+class TypeSlice final : public TypeNext
 {
 public:
     Expression *lwr;
@@ -890,7 +890,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TypeNull : public Type
+class TypeNull final : public Type
 {
 public:
     const char *kind() override;

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -306,7 +306,7 @@ public:
     virtual ClassDeclaration *isClassHandle();
     virtual structalign_t alignment();
     virtual Expression *defaultInitLiteral(const Loc &loc);
-    virtual bool isZeroInit(const Loc &loc = Loc());                // if initializer is 0
+    virtual bool isZeroInit(const Loc &loc = Loc()); // if initializer is 0
     Identifier *getTypeInfoIdent();
     virtual int hasWild() const;
     virtual bool hasPointers();
@@ -897,6 +897,7 @@ public:
 
     TypeNull *syntaxCopy() override;
     MATCH implicitConvTo(Type *to) override;
+    bool hasPointers() override;
     bool isBoolean() override;
 
     uinteger_t size(const Loc &loc) override;

--- a/src/dmd/nspace.h
+++ b/src/dmd/nspace.h
@@ -16,7 +16,7 @@
  * Implies extern(C++).
  */
 
-class Nspace : public ScopeDsymbol
+class Nspace final : public ScopeDsymbol
 {
   public:
     Expression *identExp;

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -167,7 +167,7 @@ public:
 /** Any Statement that fails semantic() or has a component that is an ErrorExp or
  * a TypeError should return an ErrorStatement from semantic().
  */
-class ErrorStatement : public Statement
+class ErrorStatement final : public Statement
 {
 public:
     ErrorStatement *syntaxCopy() override;
@@ -175,7 +175,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class PeelStatement : public Statement
+class PeelStatement final : public Statement
 {
 public:
     Statement *s;
@@ -194,7 +194,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DtorExpStatement : public ExpStatement
+class DtorExpStatement final : public ExpStatement
 {
 public:
     /* Wraps an expression that is the destruction of 'var'
@@ -206,7 +206,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CompileStatement : public Statement
+class CompileStatement final : public Statement
 {
 public:
     Expressions *exps;
@@ -228,7 +228,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CompoundDeclarationStatement : public CompoundStatement
+class CompoundDeclarationStatement final : public CompoundStatement
 {
 public:
     CompoundDeclarationStatement *syntaxCopy() override;
@@ -238,7 +238,7 @@ public:
 /* The purpose of this is so that continue will go to the next
  * of the statements, and break will go to the end of the statements.
  */
-class UnrolledLoopStatement : public Statement
+class UnrolledLoopStatement final : public Statement
 {
 public:
     Statements *statements;
@@ -250,7 +250,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ScopeStatement : public Statement
+class ScopeStatement final : public Statement
 {
 public:
     Statement *statement;
@@ -264,7 +264,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ForwardingStatement : public Statement
+class ForwardingStatement final : public Statement
 {
 public:
     ForwardingScopeDsymbol *sym;
@@ -274,7 +274,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class WhileStatement : public Statement
+class WhileStatement final : public Statement
 {
 public:
     Parameter *param;
@@ -289,7 +289,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DoStatement : public Statement
+class DoStatement final : public Statement
 {
 public:
     Statement *_body;
@@ -303,7 +303,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ForStatement : public Statement
+class ForStatement final : public Statement
 {
 public:
     Statement *_init;
@@ -325,7 +325,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ForeachStatement : public Statement
+class ForeachStatement final : public Statement
 {
 public:
     TOK op;                     // TOKforeach or TOKforeach_reverse
@@ -349,7 +349,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ForeachRangeStatement : public Statement
+class ForeachRangeStatement final : public Statement
 {
 public:
     TOK op;                     // TOKforeach or TOKforeach_reverse
@@ -368,7 +368,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class IfStatement : public Statement
+class IfStatement final : public Statement
 {
 public:
     Parameter *prm;
@@ -383,7 +383,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ConditionalStatement : public Statement
+class ConditionalStatement final : public Statement
 {
 public:
     Condition *condition;
@@ -395,7 +395,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class StaticForeachStatement : public Statement
+class StaticForeachStatement final : public Statement
 {
 public:
     StaticForeach *sfe;
@@ -405,7 +405,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class PragmaStatement : public Statement
+class PragmaStatement final : public Statement
 {
 public:
     Identifier *ident;
@@ -417,7 +417,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class StaticAssertStatement : public Statement
+class StaticAssertStatement final : public Statement
 {
 public:
     StaticAssert *sa;
@@ -427,7 +427,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class SwitchStatement : public Statement
+class SwitchStatement final : public Statement
 {
 public:
     Expression *condition;
@@ -449,7 +449,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CaseStatement : public Statement
+class CaseStatement final : public Statement
 {
 public:
     Expression *exp;
@@ -465,7 +465,7 @@ public:
 };
 
 
-class CaseRangeStatement : public Statement
+class CaseRangeStatement final : public Statement
 {
 public:
     Expression *first;
@@ -477,7 +477,7 @@ public:
 };
 
 
-class DefaultStatement : public Statement
+class DefaultStatement final : public Statement
 {
 public:
     Statement *statement;
@@ -488,7 +488,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class GotoDefaultStatement : public Statement
+class GotoDefaultStatement final : public Statement
 {
 public:
     SwitchStatement *sw;
@@ -498,7 +498,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class GotoCaseStatement : public Statement
+class GotoCaseStatement final : public Statement
 {
 public:
     Expression *exp;            // NULL, or which case to goto
@@ -509,7 +509,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class SwitchErrorStatement : public Statement
+class SwitchErrorStatement final : public Statement
 {
 public:
     Expression *exp;
@@ -517,7 +517,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ReturnStatement : public Statement
+class ReturnStatement final : public Statement
 {
 public:
     Expression *exp;
@@ -529,7 +529,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class BreakStatement : public Statement
+class BreakStatement final : public Statement
 {
 public:
     Identifier *ident;
@@ -539,7 +539,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ContinueStatement : public Statement
+class ContinueStatement final : public Statement
 {
 public:
     Identifier *ident;
@@ -549,7 +549,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class SynchronizedStatement : public Statement
+class SynchronizedStatement final : public Statement
 {
 public:
     Expression *exp;
@@ -562,7 +562,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class WithStatement : public Statement
+class WithStatement final : public Statement
 {
 public:
     Expression *exp;
@@ -575,7 +575,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TryCatchStatement : public Statement
+class TryCatchStatement final : public Statement
 {
 public:
     Statement *_body;
@@ -589,7 +589,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class Catch : public RootObject
+class Catch final : public RootObject
 {
 public:
     Loc loc;
@@ -608,7 +608,7 @@ public:
     Catch *syntaxCopy();
 };
 
-class TryFinallyStatement : public Statement
+class TryFinallyStatement final : public Statement
 {
 public:
     Statement *_body;
@@ -625,7 +625,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ScopeGuardStatement : public Statement
+class ScopeGuardStatement final : public Statement
 {
 public:
     TOK tok;
@@ -636,7 +636,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ThrowStatement : public Statement
+class ThrowStatement final : public Statement
 {
 public:
     Expression *exp;
@@ -649,7 +649,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class DebugStatement : public Statement
+class DebugStatement final : public Statement
 {
 public:
     Statement *statement;
@@ -658,7 +658,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class GotoStatement : public Statement
+class GotoStatement final : public Statement
 {
 public:
     Identifier *ident;
@@ -673,7 +673,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class LabelStatement : public Statement
+class LabelStatement final : public Statement
 {
 public:
     Identifier *ident;
@@ -691,7 +691,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class LabelDsymbol : public Dsymbol
+class LabelDsymbol final : public Dsymbol
 {
 public:
     LabelStatement *statement;
@@ -715,7 +715,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class InlineAsmStatement : public AsmStatement
+class InlineAsmStatement final : public AsmStatement
 {
 public:
     code *asmcode;
@@ -729,7 +729,7 @@ public:
 };
 
 // A GCC asm statement - assembler instructions with D expression operands
-class GccAsmStatement : public AsmStatement
+class GccAsmStatement final : public AsmStatement
 {
 public:
     StorageClass stc;           // attributes of the asm {} block
@@ -747,7 +747,7 @@ public:
 };
 
 // a complete asm {} block
-class CompoundAsmStatement : public CompoundStatement
+class CompoundAsmStatement final : public CompoundStatement
 {
 public:
     StorageClass stc; // postfix attributes like nothrow/pure/@trusted
@@ -757,7 +757,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class ImportStatement : public Statement
+class ImportStatement final : public Statement
 {
 public:
     Dsymbols *imports;          // Array of Import's

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -109,11 +109,11 @@ public:
     Loc loc;
     STMT stmt;
 
-    DYNCAST dyncast() const override { return DYNCAST_STATEMENT; }
+    DYNCAST dyncast() const override final { return DYNCAST_STATEMENT; }
 
     virtual Statement *syntaxCopy();
 
-    const char *toChars() const override;
+    const char *toChars() const override final;
 
     void error(const char *format, ...);
     void warning(const char *format, ...);
@@ -222,8 +222,8 @@ public:
 
     static CompoundStatement *create(const Loc &loc, Statement *s1, Statement *s2);
     CompoundStatement *syntaxCopy() override;
-    ReturnStatement *endsWithReturnStatement() override;
-    Statement *last() override;
+    ReturnStatement *endsWithReturnStatement() override final;
+    Statement *last() override final;
 
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -151,14 +151,14 @@ public:
     Type *specType;     // type parameter: if !=NULL, this is the type specialization
     Type *defaultType;
 
-    TemplateTypeParameter *isTemplateTypeParameter() override;
+    TemplateTypeParameter *isTemplateTypeParameter() override final;
     TemplateTypeParameter *syntaxCopy() override;
-    bool declareParameter(Scope *sc) override;
-    void print(RootObject *oarg, RootObject *oded) override;
-    RootObject *specialization() override;
-    RootObject *defaultArg(const Loc &instLoc, Scope *sc) override;
-    bool hasDefaultArg() override;
-    RootObject *dummyArg() override;
+    bool declareParameter(Scope *sc) override final;
+    void print(RootObject *oarg, RootObject *oded) override final;
+    RootObject *specialization() override final;
+    RootObject *defaultArg(const Loc &instLoc, Scope *sc) override final;
+    bool hasDefaultArg() override final;
+    RootObject *dummyArg() override final;
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -278,18 +278,18 @@ public:
     unsigned char inuse;                 // for recursive expansion detection
 
     TemplateInstance *syntaxCopy(Dsymbol *) override;
-    Dsymbol *toAlias() override;         // resolve real symbol
+    Dsymbol *toAlias() override final;   // resolve real symbol
     const char *kind() const override;
     bool oneMember(Dsymbol **ps, Identifier *ident) override;
     const char *toChars() const override;
-    const char* toPrettyCharsHelper() override;
-    Identifier *getIdent() override;
+    const char* toPrettyCharsHelper() override final;
+    Identifier *getIdent() override final;
     hash_t toHash();
 
     bool isDiscardable();
     bool needsCodegen();
 
-    TemplateInstance *isTemplateInstance() override { return this; }
+    TemplateInstance *isTemplateInstance() override final { return this; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -28,7 +28,7 @@ class Expression;
 class FuncDeclaration;
 class Parameter;
 
-class Tuple : public RootObject
+class Tuple final : public RootObject
 {
 public:
     Objects objects;
@@ -46,7 +46,7 @@ struct TemplatePrevious
     Objects *dedargs;
 };
 
-class TemplateDeclaration : public ScopeDsymbol
+class TemplateDeclaration final : public ScopeDsymbol
 {
 public:
     TemplateParameters *parameters;     // array of TemplateParameter's
@@ -165,7 +165,7 @@ public:
 /* Syntax:
  *  this ident : specType = defaultType
  */
-class TemplateThisParameter : public TemplateTypeParameter
+class TemplateThisParameter final : public TemplateTypeParameter
 {
 public:
     TemplateThisParameter *isTemplateThisParameter() override;
@@ -176,7 +176,7 @@ public:
 /* Syntax:
  *  valType ident : specValue = defaultValue
  */
-class TemplateValueParameter : public TemplateParameter
+class TemplateValueParameter final : public TemplateParameter
 {
 public:
     Type *valType;
@@ -197,7 +197,7 @@ public:
 /* Syntax:
  *  specType ident : specAlias = defaultAlias
  */
-class TemplateAliasParameter : public TemplateParameter
+class TemplateAliasParameter final : public TemplateParameter
 {
 public:
     Type *specType;
@@ -218,7 +218,7 @@ public:
 /* Syntax:
  *  ident ...
  */
-class TemplateTupleParameter : public TemplateParameter
+class TemplateTupleParameter final : public TemplateParameter
 {
 public:
     TemplateTupleParameter *isTemplateTupleParameter() override;
@@ -293,7 +293,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class TemplateMixin : public TemplateInstance
+class TemplateMixin final : public TemplateInstance
 {
 public:
     TypeQualified *tqual;

--- a/src/dmd/version.h
+++ b/src/dmd/version.h
@@ -12,7 +12,7 @@
 
 #include "dsymbol.h"
 
-class DebugSymbol : public Dsymbol
+class DebugSymbol final : public Dsymbol
 {
 public:
     unsigned level;
@@ -26,7 +26,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class VersionSymbol : public Dsymbol
+class VersionSymbol final : public Dsymbol
 {
 public:
     unsigned level;


### PR DESCRIPTION
With C++11 we can add `final` and `override` to the decls of virtual funcs in derived classes, which documents to both human and automated readers of the code that a decl is intended to override a virtual func in a base class, and can help catch mistakes where we intended to override a virtual func, but messed up the prototypes between the D sources and C++ headers.

Leaving as a draft, as I expect this to find many, many more issues with the C++ interface that will only be caught when compiling this against GDC and LDC directly.  Especially where D is more lax by allowing a `override foo() const` method to override a mutable `override foo();` method (C++ treats both as separate methods).  See `hasPointers()` as one example caught by the test suite, though a quick spot check and I can see a few more.

FYI @kinke 