### PR TITLE
dmd.expression: Add missing CatElemAssignExp and CatDcharAssignExp definitions and visitor methods

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6055,11 +6055,44 @@ struct ASTBase
         }
     }
 
-    extern (C++) final class CatAssignExp : BinAssignExp
+    extern (C++) class CatAssignExp : BinAssignExp
     {
         extern (D) this(const ref Loc loc, Expression e1, Expression e2)
         {
             super(loc, EXP.concatenateAssign, __traits(classInstanceSize, CatAssignExp), e1, e2);
+        }
+
+        extern (D) this(const ref Loc loc, EXP tok, Expression e1, Expression e2)
+        {
+            super(loc, tok, __traits(classInstanceSize, CatAssignExp), e1, e2);
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) final class CatElemAssignExp : CatAssignExp
+    {
+        extern (D) this(const ref Loc loc, Type type, Expression e1, Expression e2)
+        {
+            super(loc, EXP.concatenateElemAssign, e1, e2);
+            this.type = type;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) final class CatDcharAssignExp : CatAssignExp
+    {
+        extern (D) this(const ref Loc loc, Type type, Expression e1, Expression e2)
+        {
+            super(loc, EXP.concatenateDcharAssign, e1, e2);
+            this.type = type;
         }
 
         override void accept(Visitor v)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -206,6 +206,8 @@ public:
     ShrAssignExp* isShrAssignExp();
     UshrAssignExp* isUshrAssignExp();
     CatAssignExp* isCatAssignExp();
+    CatElemAssignExp* isCatElemAssignExp();
+    CatDcharAssignExp* isCatDcharAssignExp();
     AddExp* isAddExp();
     MinExp* isMinExp();
     CatExp* isCatExp();
@@ -1148,6 +1150,18 @@ class CatAssignExp : public BinAssignExp
 {
 public:
     void accept(Visitor *v) { v->visit(this); }
+};
+
+class CatElemAssignExp : public CatAssignExp
+{
+public:
+    void accept(Visitor *v) override { v->visit(this); }
+};
+
+class CatDcharAssignExp : public CatAssignExp
+{
+public:
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class AddExp : public BinExp

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2434,6 +2434,8 @@ public:
     virtual void visit(typename AST::ShrAssignExp e);
     virtual void visit(typename AST::UshrAssignExp e);
     virtual void visit(typename AST::CatAssignExp e);
+    virtual void visit(typename AST::CatElemAssignExp e);
+    virtual void visit(typename AST::CatDcharAssignExp e);
     virtual void visit(typename AST::TemplateAliasParameter tp);
     virtual void visit(typename AST::TemplateTypeParameter tp);
     virtual void visit(typename AST::TemplateTupleParameter tp);

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -272,6 +272,10 @@ public:
     void visit(AST.UshrAssignExp e) { visit(cast(AST.BinAssignExp)e); }
     void visit(AST.CatAssignExp e) { visit(cast(AST.BinAssignExp)e); }
 
+    // CatAssignExp
+    void visit(AST.CatElemAssignExp e) { visit(cast(AST.CatAssignExp)e); }
+    void visit(AST.CatDcharAssignExp e) { visit(cast(AST.CatAssignExp)e); }
+
     //===============================================================================
     // TemplateParameter
     void visit(AST.TemplateAliasParameter tp) { visit(cast(AST.TemplateParameter)tp); }

--- a/src/dmd/strictvisitor.d
+++ b/src/dmd/strictvisitor.d
@@ -215,6 +215,8 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.ShrAssignExp) { assert(0); }
     override void visit(AST.UshrAssignExp) { assert(0); }
     override void visit(AST.CatAssignExp) { assert(0); }
+    override void visit(AST.CatElemAssignExp) { assert(0); }
+    override void visit(AST.CatDcharAssignExp) { assert(0); }
     override void visit(AST.GenericExp) { assert(0); }
     override void visit(AST.TemplateParameter) { assert(0); }
     override void visit(AST.TemplateAliasParameter) { assert(0); }

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -265,6 +265,8 @@ class ShlAssignExp;
 class ShrAssignExp;
 class UshrAssignExp;
 class CatAssignExp;
+class CatElemAssignExp;
+class CatDcharAssignExp;
 class AddExp;
 class MinExp;
 class CatExp;
@@ -563,6 +565,10 @@ public:
     virtual void visit(ShrAssignExp *e) { visit((BinAssignExp *)e); }
     virtual void visit(UshrAssignExp *e) { visit((BinAssignExp *)e); }
     virtual void visit(CatAssignExp *e) { visit((BinAssignExp *)e); }
+
+    // CatAssignExp
+    virtual void visit(CatElemAssignExp *e) { visit((CatAssignExp *)e); }
+    virtual void visit(CatDcharAssignExp *e) { visit((CatAssignExp *)e); }
 
     // TemplateParameter
     virtual void visit(TemplateAliasParameter *tp) { visit((TemplateParameter *)tp); }


### PR DESCRIPTION
This was added in #9690, but neither C++ headers were updated, nor were the AST nodes hooked into Visitor, despite having `accept()` methods.