### PR TITLE
C++: Add missing dyncast overrides

### DIFF
--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -35,6 +35,8 @@ public:
     Loc loc;
     Include inc;
 
+    DYNCAST dyncast() const { return DYNCAST_CONDITION; }
+
     virtual Condition *syntaxCopy() = 0;
     virtual int include(Scope *sc) = 0;
     virtual DebugCondition *isDebugCondition() { return NULL; }

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -33,6 +33,8 @@ public:
     Loc loc;
     unsigned char kind;
 
+    DYNCAST dyncast() const { return DYNCAST_INITIALIZER; }
+
     const char *toChars() const;
 
     ErrorInitializer   *isErrorInitializer();

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -109,6 +109,8 @@ public:
     Loc loc;
     STMT stmt;
 
+    DYNCAST dyncast() const { return DYNCAST_STATEMENT; }
+
     virtual Statement *syntaxCopy();
 
     const char *toChars() const;

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -134,6 +134,8 @@ public:
     virtual RootObject *defaultArg(const Loc &instLoc, Scope *sc) = 0;
     virtual bool hasDefaultArg() = 0;
 
+    DYNCAST dyncast() const { return DYNCAST_TEMPLATEPARAMETER; }
+
     /* Create dummy argument based on parameter.
      */
     virtual RootObject *dummyArg() = 0;


### PR DESCRIPTION
Enums were added in #14155, but not the virtual methods that use them.