### PR TITLE
C++: Add override to overriding virtual functions

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -120,20 +120,20 @@ public:
     Sizeok sizeok;              // set when structsize contains valid data
 
     virtual Scope *newScope(Scope *sc);
-    void setScope(Scope *sc);
+    void setScope(Scope *sc) override;
     size_t nonHiddenFields();
     bool determineSize(const Loc &loc);
     virtual void finalizeSize() = 0;
-    uinteger_t size(const Loc &loc);
+    uinteger_t size(const Loc &loc) override;
     bool fill(const Loc &loc, Expressions *elements, bool ctorinit);
-    Type *getType();
-    bool isDeprecated() const;         // is aggregate deprecated?
+    Type *getType() override;
+    bool isDeprecated() const override; // is aggregate deprecated?
     void setDeprecated();
     bool isNested() const;
-    bool isExport() const;
+    bool isExport() const override;
     Dsymbol *searchCtor();
 
-    Visibility visible();
+    Visibility visible() override;
 
     // 'this' type
     Type *handleType() { return type; }
@@ -143,8 +143,8 @@ public:
     // Back end
     void *sinit;
 
-    AggregateDeclaration *isAggregateDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    AggregateDeclaration *isAggregateDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 struct StructFlags
@@ -186,14 +186,14 @@ public:
     TypeTuple *argTypes;
 
     static StructDeclaration *create(const Loc &loc, Identifier *id, bool inObject);
-    StructDeclaration *syntaxCopy(Dsymbol *s);
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
-    const char *kind() const;
-    void finalizeSize();
+    StructDeclaration *syntaxCopy(Dsymbol *s) override;
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
+    const char *kind() const override;
+    void finalizeSize() override;
     bool isPOD();
 
-    StructDeclaration *isStructDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    StructDeclaration *isStructDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 
     unsigned numArgTypes() const;
     Type *argType(unsigned index);
@@ -203,11 +203,11 @@ public:
 class UnionDeclaration : public StructDeclaration
 {
 public:
-    UnionDeclaration *syntaxCopy(Dsymbol *s);
-    const char *kind() const;
+    UnionDeclaration *syntaxCopy(Dsymbol *s) override;
+    const char *kind() const override;
 
-    UnionDeclaration *isUnionDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    UnionDeclaration *isUnionDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 struct BaseClass
@@ -279,9 +279,9 @@ public:
     Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
     static ClassDeclaration *create(const Loc &loc, Identifier *id, BaseClasses *baseclasses, Dsymbols *members, bool inObject);
-    const char *toPrettyChars(bool QualifyTypes = false);
-    ClassDeclaration *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
+    const char *toPrettyChars(bool QualifyTypes = false) override;
+    ClassDeclaration *syntaxCopy(Dsymbol *s) override;
+    Scope *newScope(Scope *sc) override;
     bool isBaseOf2(ClassDeclaration *cd);
 
     #define OFFSET_RUNTIME 0x76543210
@@ -289,9 +289,9 @@ public:
     virtual bool isBaseOf(ClassDeclaration *cd, int *poffset);
 
     bool isBaseInfoComplete();
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
     ClassDeclaration *searchBase(Identifier *ident);
-    void finalizeSize();
+    void finalizeSize() override;
     bool hasMonitor();
     bool isFuncHidden(FuncDeclaration *fd);
     FuncDeclaration *findFunc(Identifier *ident, TypeFunction *tf);
@@ -301,30 +301,30 @@ public:
     virtual bool isCPPinterface() const;
     bool isAbstract();
     virtual int vtblOffset() const;
-    const char *kind() const;
+    const char *kind() const override;
 
-    void addLocalClass(ClassDeclarations *);
-    void addObjcSymbols(ClassDeclarations *classes, ClassDeclarations *categories);
+    void addLocalClass(ClassDeclarations *) override;
+    void addObjcSymbols(ClassDeclarations *classes, ClassDeclarations *categories) override;
 
     // Back end
     Dsymbol *vtblsym;
     Dsymbol *vtblSymbol();
 
-    ClassDeclaration *isClassDeclaration() { return (ClassDeclaration *)this; }
-    void accept(Visitor *v) { v->visit(this); }
+    ClassDeclaration *isClassDeclaration() override { return (ClassDeclaration *)this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class InterfaceDeclaration : public ClassDeclaration
 {
 public:
-    InterfaceDeclaration *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
-    bool isBaseOf(ClassDeclaration *cd, int *poffset);
-    const char *kind() const;
-    int vtblOffset() const;
-    bool isCPPinterface() const;
-    bool isCOMinterface() const;
+    InterfaceDeclaration *syntaxCopy(Dsymbol *s) override;
+    Scope *newScope(Scope *sc) override;
+    bool isBaseOf(ClassDeclaration *cd, int *poffset) override;
+    const char *kind() const override;
+    int vtblOffset() const override;
+    bool isCPPinterface() const override;
+    bool isCOMinterface() const override;
 
-    InterfaceDeclaration *isInterfaceDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    InterfaceDeclaration *isInterfaceDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/aliasthis.h
+++ b/src/dmd/aliasthis.h
@@ -23,9 +23,9 @@ public:
     Dsymbol    *sym;
     bool       isDeprecated_;
 
-    AliasThis *syntaxCopy(Dsymbol *);
-    const char *kind() const;
+    AliasThis *syntaxCopy(Dsymbol *) override;
+    const char *kind() const override;
     AliasThis *isAliasThis() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
-    bool isDeprecated() const { return this->isDeprecated_; }
+    void accept(Visitor *v) override { v->visit(this); }
+    bool isDeprecated() const override { return this->isDeprecated_; }
 };

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -26,20 +26,20 @@ public:
 
     virtual Dsymbols *include(Scope *sc);
     virtual Scope *newScope(Scope *sc);
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    void setScope(Scope *sc);
-    void importAll(Scope *sc);
-    void addComment(const utf8_t *comment);
-    const char *kind() const;
-    bool oneMember(Dsymbol **ps, Identifier *ident);
-    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
-    bool hasPointers();
-    bool hasStaticCtorOrDtor();
-    void checkCtorConstInit();
-    void addLocalClass(ClassDeclarations *);
-    AttribDeclaration *isAttribDeclaration() { return this; }
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    void setScope(Scope *sc) override;
+    void importAll(Scope *sc) override;
+    void addComment(const utf8_t *comment) override;
+    const char *kind() const override;
+    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion) override;
+    bool hasPointers() override;
+    bool hasStaticCtorOrDtor() override;
+    void checkCtorConstInit() override;
+    void addLocalClass(ClassDeclarations *) override;
+    AttribDeclaration *isAttribDeclaration() override { return this; }
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StorageClassDeclaration : public AttribDeclaration
@@ -47,13 +47,13 @@ class StorageClassDeclaration : public AttribDeclaration
 public:
     StorageClass stc;
 
-    StorageClassDeclaration *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
-    bool oneMember(Dsymbol **ps, Identifier *ident);
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    StorageClassDeclaration *isStorageClassDeclaration() { return this; }
+    StorageClassDeclaration *syntaxCopy(Dsymbol *s) override;
+    Scope *newScope(Scope *sc) override;
+    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    StorageClassDeclaration *isStorageClassDeclaration() override { return this; }
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DeprecatedDeclaration : public StorageClassDeclaration
@@ -62,10 +62,10 @@ public:
     Expression *msg;
     const char *msgstr;
 
-    DeprecatedDeclaration *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
-    void setScope(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    DeprecatedDeclaration *syntaxCopy(Dsymbol *s) override;
+    Scope *newScope(Scope *sc) override;
+    void setScope(Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class LinkDeclaration : public AttribDeclaration
@@ -74,10 +74,10 @@ public:
     LINK linkage;
 
     static LinkDeclaration *create(const Loc &loc, LINK p, Dsymbols *decl);
-    LinkDeclaration *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
-    const char *toChars() const;
-    void accept(Visitor *v) { v->visit(this); }
+    LinkDeclaration *syntaxCopy(Dsymbol *s) override;
+    Scope *newScope(Scope *sc) override;
+    const char *toChars() const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CPPMangleDeclaration : public AttribDeclaration
@@ -85,11 +85,11 @@ class CPPMangleDeclaration : public AttribDeclaration
 public:
     CPPMANGLE cppmangle;
 
-    CPPMangleDeclaration *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
-    void setScope(Scope *sc);
-    const char *toChars() const;
-    void accept(Visitor *v) { v->visit(this); }
+    CPPMangleDeclaration *syntaxCopy(Dsymbol *s) override;
+    Scope *newScope(Scope *sc) override;
+    void setScope(Scope *sc) override;
+    const char *toChars() const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CPPNamespaceDeclaration : public AttribDeclaration
@@ -97,10 +97,10 @@ class CPPNamespaceDeclaration : public AttribDeclaration
 public:
     Expression *exp;
 
-    CPPNamespaceDeclaration *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
-    const char *toChars() const;
-    void accept(Visitor *v) { v->visit(this); }
+    CPPNamespaceDeclaration *syntaxCopy(Dsymbol *s) override;
+    Scope *newScope(Scope *sc) override;
+    const char *toChars() const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class VisibilityDeclaration : public AttribDeclaration
@@ -109,13 +109,13 @@ public:
     Visibility visibility;
     DArray<Identifier*> pkg_identifiers;
 
-    VisibilityDeclaration *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    const char *kind() const;
-    const char *toPrettyChars(bool unused);
-    VisibilityDeclaration *isVisibilityDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    VisibilityDeclaration *syntaxCopy(Dsymbol *s) override;
+    Scope *newScope(Scope *sc) override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    const char *kind() const override;
+    const char *toPrettyChars(bool unused) override;
+    VisibilityDeclaration *isVisibilityDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class AlignDeclaration : public AttribDeclaration
@@ -125,9 +125,9 @@ public:
     structalign_t salign;
 
     AlignDeclaration(const Loc &loc, Expression *ealign, Dsymbols *decl);
-    AlignDeclaration *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    AlignDeclaration *syntaxCopy(Dsymbol *s) override;
+    Scope *newScope(Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class AnonDeclaration : public AttribDeclaration
@@ -139,12 +139,12 @@ public:
     unsigned anonstructsize;    // size of anonymous struct
     unsigned anonalignsize;     // size of anonymous struct for alignment purposes
 
-    AnonDeclaration *syntaxCopy(Dsymbol *s);
-    void setScope(Scope *sc);
-    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
-    const char *kind() const;
-    AnonDeclaration *isAnonDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    AnonDeclaration *syntaxCopy(Dsymbol *s) override;
+    void setScope(Scope *sc) override;
+    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion) override;
+    const char *kind() const override;
+    AnonDeclaration *isAnonDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class PragmaDeclaration : public AttribDeclaration
@@ -152,11 +152,11 @@ class PragmaDeclaration : public AttribDeclaration
 public:
     Expressions *args;          // array of Expression's
 
-    PragmaDeclaration *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
+    PragmaDeclaration *syntaxCopy(Dsymbol *s) override;
+    Scope *newScope(Scope *sc) override;
     PINLINE evalPragmaInline(Scope* sc);
-    const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    const char *kind() const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ConditionalDeclaration : public AttribDeclaration
@@ -165,12 +165,12 @@ public:
     Condition *condition;
     Dsymbols *elsedecl; // array of Dsymbol's for else block
 
-    ConditionalDeclaration *syntaxCopy(Dsymbol *s);
-    bool oneMember(Dsymbol **ps, Identifier *ident);
-    Dsymbols *include(Scope *sc);
-    void addComment(const utf8_t *comment);
-    void setScope(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    ConditionalDeclaration *syntaxCopy(Dsymbol *s) override;
+    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    Dsymbols *include(Scope *sc) override;
+    void addComment(const utf8_t *comment) override;
+    void setScope(Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StaticIfDeclaration : public ConditionalDeclaration
@@ -180,13 +180,13 @@ public:
     bool addisdone;
     bool onStack;
 
-    StaticIfDeclaration *syntaxCopy(Dsymbol *s);
-    Dsymbols *include(Scope *sc);
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    void setScope(Scope *sc);
-    void importAll(Scope *sc);
-    const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    StaticIfDeclaration *syntaxCopy(Dsymbol *s) override;
+    Dsymbols *include(Scope *sc) override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    void setScope(Scope *sc) override;
+    void importAll(Scope *sc) override;
+    const char *kind() const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StaticForeachDeclaration : public AttribDeclaration
@@ -198,15 +198,15 @@ public:
     bool cached;
     Dsymbols *cache;
 
-    StaticForeachDeclaration *syntaxCopy(Dsymbol *s);
-    bool oneMember(Dsymbol **ps, Identifier *ident);
-    Dsymbols *include(Scope *sc);
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    void addComment(const utf8_t *comment);
-    void setScope(Scope *sc);
-    void importAll(Scope *sc);
-    const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    StaticForeachDeclaration *syntaxCopy(Dsymbol *s) override;
+    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    Dsymbols *include(Scope *sc) override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    void addComment(const utf8_t *comment) override;
+    void setScope(Scope *sc) override;
+    void importAll(Scope *sc) override;
+    const char *kind() const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ForwardingAttribDeclaration : public AttribDeclaration
@@ -214,10 +214,10 @@ class ForwardingAttribDeclaration : public AttribDeclaration
 public:
     ForwardingScopeDsymbol *sym;
 
-    Scope *newScope(Scope *sc);
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    ForwardingAttribDeclaration *isForwardingAttribDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    Scope *newScope(Scope *sc) override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    ForwardingAttribDeclaration *isForwardingAttribDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Mixin declarations
@@ -230,11 +230,11 @@ public:
     ScopeDsymbol *scopesym;
     bool compiled;
 
-    CompileDeclaration *syntaxCopy(Dsymbol *s);
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    void setScope(Scope *sc);
-    const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    CompileDeclaration *syntaxCopy(Dsymbol *s) override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    void setScope(Scope *sc) override;
+    const char *kind() const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /**
@@ -246,10 +246,10 @@ class UserAttributeDeclaration : public AttribDeclaration
 public:
     Expressions *atts;
 
-    UserAttributeDeclaration *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
-    void setScope(Scope *sc);
+    UserAttributeDeclaration *syntaxCopy(Dsymbol *s) override;
+    Scope *newScope(Scope *sc) override;
+    void setScope(Scope *sc) override;
     Expressions *getAttributes();
-    const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    const char *kind() const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -35,13 +35,13 @@ public:
     Loc loc;
     Include inc;
 
-    DYNCAST dyncast() const { return DYNCAST_CONDITION; }
+    DYNCAST dyncast() const override { return DYNCAST_CONDITION; }
 
     virtual Condition *syntaxCopy() = 0;
     virtual int include(Scope *sc) = 0;
     virtual DebugCondition *isDebugCondition() { return NULL; }
     virtual VersionCondition *isVersionCondition() { return NULL; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StaticForeach
@@ -64,8 +64,8 @@ public:
     Identifier *ident;
     Module *mod;
 
-    DVCondition *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    DVCondition *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DebugCondition : public DVCondition
@@ -73,9 +73,9 @@ class DebugCondition : public DVCondition
 public:
     static void addGlobalIdent(const char *ident);
 
-    int include(Scope *sc);
-    DebugCondition *isDebugCondition() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    int include(Scope *sc) override;
+    DebugCondition *isDebugCondition() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class VersionCondition : public DVCondition
@@ -84,9 +84,9 @@ public:
     static void addGlobalIdent(const char *ident);
     static void addPredefinedGlobalIdent(const char *ident);
 
-    int include(Scope *sc);
-    VersionCondition *isVersionCondition() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    int include(Scope *sc) override;
+    VersionCondition *isVersionCondition() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StaticIfCondition : public Condition
@@ -94,7 +94,7 @@ class StaticIfCondition : public Condition
 public:
     Expression *exp;
 
-    StaticIfCondition *syntaxCopy();
-    int include(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    StaticIfCondition *syntaxCopy() override;
+    int include(Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/ctfe.h
+++ b/src/dmd/ctfe.h
@@ -26,7 +26,7 @@ public:
     /// Return index of the field, or -1 if not found
     /// Same as getFieldIndex, but checks for a direct match with the VarDeclaration
     int findFieldIndexByName(VarDeclaration *v);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /**
@@ -37,8 +37,8 @@ class VoidInitExp : public Expression
 public:
     VarDeclaration *var;
 
-    const char *toChars() const;
-    void accept(Visitor *v) { v->visit(this); }
+    const char *toChars() const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /**
@@ -49,8 +49,8 @@ class ThrownExceptionExp : public Expression
 {
 public:
     ClassReferenceExp *thrown; // the thing being tossed
-    const char *toChars() const;
-    void accept(Visitor *v) { v->visit(this); }
+    const char *toChars() const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /****************************************************************/
@@ -60,5 +60,5 @@ public:
 class CTFEExp : public Expression
 {
 public:
-    const char *toChars() const;
+    const char *toChars() const override;
 };

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -122,10 +122,10 @@ public:
     Symbol* isym;               // import version of csym
     DString mangleOverride;     // overridden symbol with pragma(mangle, "...")
 
-    const char *kind() const;
-    uinteger_t size(const Loc &loc);
+    const char *kind() const override;
+    uinteger_t size(const Loc &loc) override;
 
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
 
     bool isStatic() const { return (storage_class & STCstatic) != 0; }
     LINK resolvedLinkage() const; // returns the linkage, resolving the target-specific `System` one
@@ -142,7 +142,7 @@ public:
     bool isScope() const        { return (storage_class & STCscope) != 0; }
     bool isSynchronized() const { return (storage_class & STCsynchronized) != 0; }
     bool isParameter() const    { return (storage_class & STCparameter) != 0; }
-    bool isDeprecated() const   { return (storage_class & STCdeprecated) != 0; }
+    bool isDeprecated() const override { return (storage_class & STCdeprecated) != 0; }
     bool isOverride() const     { return (storage_class & STCoverride) != 0; }
     bool isResult() const       { return (storage_class & STCresult) != 0; }
     bool isField() const        { return (storage_class & STCfield) != 0; }
@@ -154,10 +154,10 @@ public:
 
     bool isFuture() const { return (storage_class & STCfuture) != 0; }
 
-    Visibility visible();
+    Visibility visible() override;
 
-    Declaration *isDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    Declaration *isDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /**************************************************************/
@@ -170,14 +170,14 @@ public:
 
     TypeTuple *tupletype;       // !=NULL if this is a type tuple
 
-    TupleDeclaration *syntaxCopy(Dsymbol *);
-    const char *kind() const;
-    Type *getType();
-    Dsymbol *toAlias2();
-    bool needThis();
+    TupleDeclaration *syntaxCopy(Dsymbol *) override;
+    const char *kind() const override;
+    Type *getType() override;
+    Dsymbol *toAlias2() override;
+    bool needThis() override;
 
-    TupleDeclaration *isTupleDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    TupleDeclaration *isTupleDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /**************************************************************/
@@ -190,16 +190,16 @@ public:
     Dsymbol *_import;           // !=NULL if unresolved internal alias for selective import
 
     static AliasDeclaration *create(const Loc &loc, Identifier *id, Type *type);
-    AliasDeclaration *syntaxCopy(Dsymbol *);
-    bool overloadInsert(Dsymbol *s);
-    const char *kind() const;
-    Type *getType();
-    Dsymbol *toAlias();
-    Dsymbol *toAlias2();
-    bool isOverloadable() const;
+    AliasDeclaration *syntaxCopy(Dsymbol *) override;
+    bool overloadInsert(Dsymbol *s) override;
+    const char *kind() const override;
+    Type *getType() override;
+    Dsymbol *toAlias() override;
+    Dsymbol *toAlias2() override;
+    bool isOverloadable() const override;
 
-    AliasDeclaration *isAliasDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    AliasDeclaration *isAliasDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /**************************************************************/
@@ -210,16 +210,16 @@ public:
     Dsymbol *overnext;          // next in overload list
     Dsymbol *aliassym;
 
-    const char *kind() const;
-    bool equals(const RootObject *o) const;
-    bool overloadInsert(Dsymbol *s);
+    const char *kind() const override;
+    bool equals(const RootObject *o) const override;
+    bool overloadInsert(Dsymbol *s) override;
 
-    Dsymbol *toAlias();
+    Dsymbol *toAlias() override;
     Dsymbol *isUnique();
-    bool isOverloadable() const;
+    bool isOverloadable() const override;
 
-    OverDeclaration *isOverDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    OverDeclaration *isOverDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /**************************************************************/
@@ -271,26 +271,26 @@ public:
     bool isArgDtorVar() const; // temporary created to handle scope destruction of a function argument
     bool isArgDtorVar(bool v);
     static VarDeclaration *create(const Loc &loc, Type *t, Identifier *id, Initializer *init, StorageClass storage_class = STCundefined);
-    VarDeclaration *syntaxCopy(Dsymbol *);
-    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
-    const char *kind() const;
-    AggregateDeclaration *isThis();
-    bool needThis();
-    bool isExport() const;
-    bool isImportedSymbol() const;
+    VarDeclaration *syntaxCopy(Dsymbol *) override;
+    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion) override;
+    const char *kind() const override;
+    AggregateDeclaration *isThis() override;
+    bool needThis() override;
+    bool isExport() const override;
+    bool isImportedSymbol() const override;
     bool isCtorinit() const;
-    bool isDataseg();
-    bool isThreadlocal();
+    bool isDataseg() override;
+    bool isThreadlocal() override;
     bool isCTFE();
     bool isOverlappedWith(VarDeclaration *v);
-    bool hasPointers();
+    bool hasPointers() override;
     bool canTakeAddressOf();
     bool needsScopeDtor();
-    void checkCtorConstInit();
-    Dsymbol *toAlias();
+    void checkCtorConstInit() override;
+    Dsymbol *toAlias() override;
     // Eliminate need for dynamic_cast
-    VarDeclaration *isVarDeclaration() { return (VarDeclaration *)this; }
-    void accept(Visitor *v) { v->visit(this); }
+    VarDeclaration *isVarDeclaration() override { return (VarDeclaration *)this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /**************************************************************/
@@ -303,9 +303,9 @@ public:
     unsigned fieldWidth;
     unsigned bitOffset;
 
-    BitFieldDeclaration *syntaxCopy(Dsymbol*);
-    BitFieldDeclaration *isBitFieldDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    BitFieldDeclaration *syntaxCopy(Dsymbol *) override;
+    BitFieldDeclaration *isBitFieldDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /**************************************************************/
@@ -318,8 +318,8 @@ public:
     AggregateDeclaration *dsym;
 
     // Eliminate need for dynamic_cast
-    SymbolDeclaration *isSymbolDeclaration() { return (SymbolDeclaration *)this; }
-    void accept(Visitor *v) { v->visit(this); }
+    SymbolDeclaration *isSymbolDeclaration() override { return (SymbolDeclaration *)this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoDeclaration : public VarDeclaration
@@ -328,11 +328,11 @@ public:
     Type *tinfo;
 
     static TypeInfoDeclaration *create(Type *tinfo);
-    TypeInfoDeclaration *syntaxCopy(Dsymbol *);
-    const char *toChars() const;
+    TypeInfoDeclaration *syntaxCopy(Dsymbol *) override;
+    const char *toChars() const override;
 
-    TypeInfoDeclaration *isTypeInfoDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    TypeInfoDeclaration *isTypeInfoDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoStructDeclaration : public TypeInfoDeclaration
@@ -340,7 +340,7 @@ class TypeInfoStructDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoStructDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoClassDeclaration : public TypeInfoDeclaration
@@ -348,7 +348,7 @@ class TypeInfoClassDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoClassDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoInterfaceDeclaration : public TypeInfoDeclaration
@@ -356,7 +356,7 @@ class TypeInfoInterfaceDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoInterfaceDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoPointerDeclaration : public TypeInfoDeclaration
@@ -364,7 +364,7 @@ class TypeInfoPointerDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoPointerDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoArrayDeclaration : public TypeInfoDeclaration
@@ -372,7 +372,7 @@ class TypeInfoArrayDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoArrayDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoStaticArrayDeclaration : public TypeInfoDeclaration
@@ -380,7 +380,7 @@ class TypeInfoStaticArrayDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoStaticArrayDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoAssociativeArrayDeclaration : public TypeInfoDeclaration
@@ -388,7 +388,7 @@ class TypeInfoAssociativeArrayDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoAssociativeArrayDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoEnumDeclaration : public TypeInfoDeclaration
@@ -396,7 +396,7 @@ class TypeInfoEnumDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoEnumDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoFunctionDeclaration : public TypeInfoDeclaration
@@ -404,7 +404,7 @@ class TypeInfoFunctionDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoFunctionDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoDelegateDeclaration : public TypeInfoDeclaration
@@ -412,7 +412,7 @@ class TypeInfoDelegateDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoDelegateDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoTupleDeclaration : public TypeInfoDeclaration
@@ -420,7 +420,7 @@ class TypeInfoTupleDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoTupleDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoConstDeclaration : public TypeInfoDeclaration
@@ -428,7 +428,7 @@ class TypeInfoConstDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoConstDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoInvariantDeclaration : public TypeInfoDeclaration
@@ -436,7 +436,7 @@ class TypeInfoInvariantDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoInvariantDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoSharedDeclaration : public TypeInfoDeclaration
@@ -444,7 +444,7 @@ class TypeInfoSharedDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoSharedDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoWildDeclaration : public TypeInfoDeclaration
@@ -452,7 +452,7 @@ class TypeInfoWildDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoWildDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeInfoVectorDeclaration : public TypeInfoDeclaration
@@ -460,7 +460,7 @@ class TypeInfoVectorDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoVectorDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /**************************************************************/
@@ -468,9 +468,9 @@ public:
 class ThisDeclaration : public VarDeclaration
 {
 public:
-    ThisDeclaration *syntaxCopy(Dsymbol *);
-    ThisDeclaration *isThisDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    ThisDeclaration *syntaxCopy(Dsymbol *) override;
+    ThisDeclaration *isThisDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 enum class ILS : unsigned char
@@ -625,31 +625,31 @@ public:
     ObjcFuncDeclaration objc;
 
     static FuncDeclaration *create(const Loc &loc, const Loc &endloc, Identifier *id, StorageClass storage_class, Type *type, bool noreturn = false);
-    FuncDeclaration *syntaxCopy(Dsymbol *);
+    FuncDeclaration *syntaxCopy(Dsymbol *) override;
     bool functionSemantic();
     bool functionSemantic3();
-    bool equals(const RootObject *o) const;
+    bool equals(const RootObject *o) const override;
 
     int overrides(FuncDeclaration *fd);
     int findVtblIndex(Dsymbols *vtbl, int dim);
     BaseClass *overrideInterface();
-    bool overloadInsert(Dsymbol *s);
+    bool overloadInsert(Dsymbol *s) override;
     bool inUnittest();
     MATCH leastAsSpecialized(FuncDeclaration *g);
     LabelDsymbol *searchLabel(Identifier *ident, const Loc &loc);
     int getLevel(FuncDeclaration *fd, int intypeof); // lexical nesting level difference
     int getLevelAndCheck(const Loc &loc, Scope *sc, FuncDeclaration *fd);
-    const char *toPrettyChars(bool QualifyTypes = false);
+    const char *toPrettyChars(bool QualifyTypes = false) override;
     const char *toFullSignature();  // for diagnostics, e.g. 'int foo(int x, int y) pure'
     bool isMain() const;
     bool isCMain() const;
     bool isWinMain() const;
     bool isDllMain() const;
-    bool isExport() const;
-    bool isImportedSymbol() const;
-    bool isCodeseg() const;
-    bool isOverloadable() const;
-    bool isAbstract();
+    bool isExport() const override;
+    bool isImportedSymbol() const override;
+    bool isCodeseg() const override;
+    bool isOverloadable() const override;
+    bool isAbstract() override;
     PURE isPure();
     PURE isPureBypassingInference();
     bool isSafe();
@@ -676,14 +676,14 @@ public:
     void isCrtDtor(bool v);
 
     virtual bool isNested() const;
-    AggregateDeclaration *isThis();
-    bool needThis();
+    AggregateDeclaration *isThis() override;
+    bool needThis() override;
     bool isVirtualMethod();
     virtual bool isVirtual() const;
     bool isFinalFunc() const;
     virtual bool addPreInvariant();
     virtual bool addPostInvariant();
-    const char *kind() const;
+    const char *kind() const override;
     bool isUnique();
     bool needsClosure();
     bool hasNestedFrameRefs();
@@ -694,10 +694,10 @@ public:
 
     bool checkNRVO();
 
-    FuncDeclaration *isFuncDeclaration() { return this; }
+    FuncDeclaration *isFuncDeclaration() override { return this; }
 
     virtual FuncDeclaration *toAliasFunc() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class FuncAliasDeclaration : public FuncDeclaration
@@ -706,11 +706,11 @@ public:
     FuncDeclaration *funcalias;
     bool hasOverloads;
 
-    FuncAliasDeclaration *isFuncAliasDeclaration() { return this; }
-    const char *kind() const;
+    FuncAliasDeclaration *isFuncAliasDeclaration() override { return this; }
+    const char *kind() const override;
 
-    FuncDeclaration *toAliasFunc();
-    void accept(Visitor *v) { v->visit(this); }
+    FuncDeclaration *toAliasFunc() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class FuncLiteralDeclaration : public FuncDeclaration
@@ -722,85 +722,85 @@ public:
     // backend
     bool deferToObj;
 
-    FuncLiteralDeclaration *syntaxCopy(Dsymbol *);
-    bool isNested() const;
-    AggregateDeclaration *isThis();
-    bool isVirtual() const;
-    bool addPreInvariant();
-    bool addPostInvariant();
+    FuncLiteralDeclaration *syntaxCopy(Dsymbol *) override;
+    bool isNested() const override;
+    AggregateDeclaration *isThis() override;
+    bool isVirtual() const override;
+    bool addPreInvariant() override;
+    bool addPostInvariant() override;
 
     void modifyReturns(Scope *sc, Type *tret);
 
-    FuncLiteralDeclaration *isFuncLiteralDeclaration() { return this; }
-    const char *kind() const;
-    const char *toPrettyChars(bool QualifyTypes = false);
-    void accept(Visitor *v) { v->visit(this); }
+    FuncLiteralDeclaration *isFuncLiteralDeclaration() override { return this; }
+    const char *kind() const override;
+    const char *toPrettyChars(bool QualifyTypes = false) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CtorDeclaration : public FuncDeclaration
 {
 public:
     bool isCpCtor;
-    CtorDeclaration *syntaxCopy(Dsymbol *);
-    const char *kind() const;
-    const char *toChars() const;
-    bool isVirtual() const;
-    bool addPreInvariant();
-    bool addPostInvariant();
+    CtorDeclaration *syntaxCopy(Dsymbol *) override;
+    const char *kind() const override;
+    const char *toChars() const override;
+    bool isVirtual() const override;
+    bool addPreInvariant() override;
+    bool addPostInvariant() override;
 
-    CtorDeclaration *isCtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    CtorDeclaration *isCtorDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class PostBlitDeclaration : public FuncDeclaration
 {
 public:
-    PostBlitDeclaration *syntaxCopy(Dsymbol *);
-    bool isVirtual() const;
-    bool addPreInvariant();
-    bool addPostInvariant();
-    bool overloadInsert(Dsymbol *s);
+    PostBlitDeclaration *syntaxCopy(Dsymbol *) override;
+    bool isVirtual() const override;
+    bool addPreInvariant() override;
+    bool addPostInvariant() override;
+    bool overloadInsert(Dsymbol *s) override;
 
-    PostBlitDeclaration *isPostBlitDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    PostBlitDeclaration *isPostBlitDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DtorDeclaration : public FuncDeclaration
 {
 public:
-    DtorDeclaration *syntaxCopy(Dsymbol *);
-    const char *kind() const;
-    const char *toChars() const;
-    bool isVirtual() const;
-    bool addPreInvariant();
-    bool addPostInvariant();
-    bool overloadInsert(Dsymbol *s);
+    DtorDeclaration *syntaxCopy(Dsymbol *) override;
+    const char *kind() const override;
+    const char *toChars() const override;
+    bool isVirtual() const override;
+    bool addPreInvariant() override;
+    bool addPostInvariant() override;
+    bool overloadInsert(Dsymbol *s) override;
 
-    DtorDeclaration *isDtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    DtorDeclaration *isDtorDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StaticCtorDeclaration : public FuncDeclaration
 {
 public:
-    StaticCtorDeclaration *syntaxCopy(Dsymbol *);
-    AggregateDeclaration *isThis();
-    bool isVirtual() const;
-    bool addPreInvariant();
-    bool addPostInvariant();
-    bool hasStaticCtorOrDtor();
+    StaticCtorDeclaration *syntaxCopy(Dsymbol *) override;
+    AggregateDeclaration *isThis() override;
+    bool isVirtual() const override;
+    bool addPreInvariant() override;
+    bool addPostInvariant() override;
+    bool hasStaticCtorOrDtor() override;
 
-    StaticCtorDeclaration *isStaticCtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    StaticCtorDeclaration *isStaticCtorDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class SharedStaticCtorDeclaration : public StaticCtorDeclaration
 {
 public:
-    SharedStaticCtorDeclaration *syntaxCopy(Dsymbol *);
+    SharedStaticCtorDeclaration *syntaxCopy(Dsymbol *) override;
 
-    SharedStaticCtorDeclaration *isSharedStaticCtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    SharedStaticCtorDeclaration *isSharedStaticCtorDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StaticDtorDeclaration : public FuncDeclaration
@@ -808,36 +808,36 @@ class StaticDtorDeclaration : public FuncDeclaration
 public:
     VarDeclaration *vgate;      // 'gate' variable
 
-    StaticDtorDeclaration *syntaxCopy(Dsymbol *);
-    AggregateDeclaration *isThis();
-    bool isVirtual() const;
-    bool hasStaticCtorOrDtor();
-    bool addPreInvariant();
-    bool addPostInvariant();
+    StaticDtorDeclaration *syntaxCopy(Dsymbol *) override;
+    AggregateDeclaration *isThis() override;
+    bool isVirtual() const override;
+    bool hasStaticCtorOrDtor() override;
+    bool addPreInvariant() override;
+    bool addPostInvariant() override;
 
-    StaticDtorDeclaration *isStaticDtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    StaticDtorDeclaration *isStaticDtorDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class SharedStaticDtorDeclaration : public StaticDtorDeclaration
 {
 public:
-    SharedStaticDtorDeclaration *syntaxCopy(Dsymbol *);
+    SharedStaticDtorDeclaration *syntaxCopy(Dsymbol *) override;
 
-    SharedStaticDtorDeclaration *isSharedStaticDtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    SharedStaticDtorDeclaration *isSharedStaticDtorDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class InvariantDeclaration : public FuncDeclaration
 {
 public:
-    InvariantDeclaration *syntaxCopy(Dsymbol *);
-    bool isVirtual() const;
-    bool addPreInvariant();
-    bool addPostInvariant();
+    InvariantDeclaration *syntaxCopy(Dsymbol *) override;
+    bool isVirtual() const override;
+    bool addPreInvariant() override;
+    bool addPostInvariant() override;
 
-    InvariantDeclaration *isInvariantDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    InvariantDeclaration *isInvariantDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class UnitTestDeclaration : public FuncDeclaration
@@ -848,25 +848,25 @@ public:
     // toObjFile() these nested functions after this one
     FuncDeclarations deferredNested;
 
-    UnitTestDeclaration *syntaxCopy(Dsymbol *);
-    AggregateDeclaration *isThis();
-    bool isVirtual() const;
-    bool addPreInvariant();
-    bool addPostInvariant();
+    UnitTestDeclaration *syntaxCopy(Dsymbol *) override;
+    AggregateDeclaration *isThis() override;
+    bool isVirtual() const override;
+    bool addPreInvariant() override;
+    bool addPostInvariant() override;
 
-    UnitTestDeclaration *isUnitTestDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    UnitTestDeclaration *isUnitTestDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class NewDeclaration : public FuncDeclaration
 {
 public:
-    NewDeclaration *syntaxCopy(Dsymbol *);
-    const char *kind() const;
-    bool isVirtual() const;
-    bool addPreInvariant();
-    bool addPostInvariant();
+    NewDeclaration *syntaxCopy(Dsymbol *) override;
+    const char *kind() const override;
+    bool isVirtual() const override;
+    bool addPreInvariant() override;
+    bool addPostInvariant() override;
 
-    NewDeclaration *isNewDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    NewDeclaration *isNewDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -185,11 +185,11 @@ public:
     UserAttributeDeclaration *userAttribDecl;   // user defined attributes
 
     static Dsymbol *create(Identifier *);
-    const char *toChars() const;
+    const char *toChars() const override;
     virtual const char *toPrettyCharsHelper(); // helper to print fully qualified (template) arguments
     Loc getLoc();
     const char *locToChars();
-    bool equals(const RootObject *o) const;
+    bool equals(const RootObject *o) const override;
     bool isAnonymous() const;
     void error(const Loc &loc, const char *format, ...);
     void error(const char *format, ...);
@@ -211,7 +211,7 @@ public:
     Ungag ungagSpeculative();
 
     // kludge for template.isSymbol()
-    DYNCAST dyncast() const { return DYNCAST_DSYMBOL; }
+    DYNCAST dyncast() const override { return DYNCAST_DSYMBOL; }
 
     virtual Identifier *getIdent();
     virtual const char *toPrettyChars(bool QualifyTypes = false);
@@ -310,7 +310,7 @@ public:
     virtual OverloadSet *isOverloadSet() { return NULL; }
     virtual CompileDeclaration *isCompileDeclaration() { return NULL; }
     virtual StaticAssert *isStaticAssert() { return NULL; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Dsymbol that generates a scope
@@ -329,20 +329,20 @@ private:
     BitArray accessiblePackages, privateAccessiblePackages;
 
 public:
-    ScopeDsymbol *syntaxCopy(Dsymbol *s);
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
+    ScopeDsymbol *syntaxCopy(Dsymbol *s) override;
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
     virtual void importScope(Dsymbol *s, Visibility visibility);
     virtual bool isPackageAccessible(Package *p, Visibility visibility, int flags = 0);
-    bool isforwardRef();
+    bool isforwardRef() override;
     static void multiplyDefined(const Loc &loc, Dsymbol *s1, Dsymbol *s2);
-    const char *kind() const;
+    const char *kind() const override;
     FuncDeclaration *findGetMembers();
     virtual Dsymbol *symtabInsert(Dsymbol *s);
     virtual Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
-    bool hasStaticCtorOrDtor();
+    bool hasStaticCtorOrDtor() override;
 
-    ScopeDsymbol *isScopeDsymbol() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    ScopeDsymbol *isScopeDsymbol() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // With statement scope
@@ -352,10 +352,10 @@ class WithScopeSymbol : public ScopeDsymbol
 public:
     WithStatement *withstate;
 
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
 
-    WithScopeSymbol *isWithScopeSymbol() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    WithScopeSymbol *isWithScopeSymbol() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Array Index/Slice scope
@@ -367,10 +367,10 @@ private:
 public:
     Scope *sc;
 
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = IgnoreNone);
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = IgnoreNone) override;
 
-    ArrayScopeSymbol *isArrayScopeSymbol() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    ArrayScopeSymbol *isArrayScopeSymbol() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Overload Sets
@@ -381,9 +381,9 @@ public:
     Dsymbols a;         // array of Dsymbols
 
     void push(Dsymbol *s);
-    OverloadSet *isOverloadSet() { return this; }
-    const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    OverloadSet *isOverloadSet() override { return this; }
+    const char *kind() const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Forwarding ScopeDsymbol
@@ -393,12 +393,12 @@ class ForwardingScopeDsymbol : public ScopeDsymbol
 public:
     ScopeDsymbol *forward;
 
-    Dsymbol *symtabInsert(Dsymbol *s);
-    Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
-    void importScope(Dsymbol *s, Visibility visibility);
-    const char *kind() const;
+    Dsymbol *symtabInsert(Dsymbol *s) override;
+    Dsymbol *symtabLookup(Dsymbol *s, Identifier *id) override;
+    void importScope(Dsymbol *s, Visibility visibility) override;
+    const char *kind() const override;
 
-    ForwardingScopeDsymbol *isForwardingScopeDsymbol() { return this; }
+    ForwardingScopeDsymbol *isForwardingScopeDsymbol() override { return this; }
 };
 
 class ExpressionDsymbol : public Dsymbol
@@ -406,7 +406,7 @@ class ExpressionDsymbol : public Dsymbol
 public:
     Expression *exp;
 
-    ExpressionDsymbol *isExpressionDsymbol() { return this; }
+    ExpressionDsymbol *isExpressionDsymbol() override { return this; }
 };
 
 // Table of Dsymbol's

--- a/src/dmd/enum.h
+++ b/src/dmd/enum.h
@@ -40,23 +40,23 @@ public:
     bool added;
     int inuse;
 
-    EnumDeclaration *syntaxCopy(Dsymbol *s);
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    void setScope(Scope *sc);
-    bool oneMember(Dsymbol **ps, Identifier *ident);
-    Type *getType();
-    const char *kind() const;
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
-    bool isDeprecated() const;                // is Dsymbol deprecated?
-    Visibility visible();
+    EnumDeclaration *syntaxCopy(Dsymbol *s) override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    void setScope(Scope *sc) override;
+    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    Type *getType() override;
+    const char *kind() const override;
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
+    bool isDeprecated() const override;       // is Dsymbol deprecated?
+    Visibility visible() override;
     bool isSpecial() const;
     Expression *getDefaultValue(const Loc &loc);
     Type *getMemtype(const Loc &loc);
 
-    EnumDeclaration *isEnumDeclaration() { return this; }
+    EnumDeclaration *isEnumDeclaration() override { return this; }
 
     Symbol *sinit;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 
@@ -78,9 +78,9 @@ public:
 
     EnumDeclaration *ed;
 
-    EnumMember *syntaxCopy(Dsymbol *s);
-    const char *kind() const;
+    EnumMember *syntaxCopy(Dsymbol *s) override;
+    const char *kind() const override;
 
-    EnumMember *isEnumMember() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    EnumMember *isEnumMember() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -90,9 +90,9 @@ public:
     virtual Expression *syntaxCopy();
 
     // kludge for template.isExpression()
-    DYNCAST dyncast() const { return DYNCAST_EXPRESSION; }
+    DYNCAST dyncast() const override { return DYNCAST_EXPRESSION; }
 
-    const char *toChars() const;
+    const char *toChars() const override;
     void error(const char *format, ...) const;
     void warning(const char *format, ...) const;
     void deprecation(const char *format, ...) const;
@@ -240,7 +240,7 @@ public:
     BinExp* isBinExp();
     BinAssignExp* isBinAssignExp();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class IntegerExp : public Expression
@@ -250,14 +250,14 @@ public:
 
     static IntegerExp *create(const Loc &loc, dinteger_t value, Type *type);
     static void emplace(UnionExp *pue, const Loc &loc, dinteger_t value, Type *type);
-    bool equals(const RootObject *o) const;
-    dinteger_t toInteger();
-    real_t toReal();
-    real_t toImaginary();
-    complex_t toComplex();
-    Optional<bool> toBool();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    bool equals(const RootObject *o) const override;
+    dinteger_t toInteger() override;
+    real_t toReal() override;
+    real_t toImaginary() override;
+    complex_t toComplex() override;
+    Optional<bool> toBool() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    void accept(Visitor *v) override { v->visit(this); }
     dinteger_t getInteger() { return value; }
     void setInteger(dinteger_t value);
     template<int v>
@@ -267,8 +267,8 @@ public:
 class ErrorExp : public Expression
 {
 public:
-    Expression *toLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    void accept(Visitor *v) override { v->visit(this); }
 
     static ErrorExp *errorexp; // handy shared value
 };
@@ -280,14 +280,14 @@ public:
 
     static RealExp *create(const Loc &loc, real_t value, Type *type);
     static void emplace(UnionExp *pue, const Loc &loc, real_t value, Type *type);
-    bool equals(const RootObject *o) const;
-    dinteger_t toInteger();
-    uinteger_t toUInteger();
-    real_t toReal();
-    real_t toImaginary();
-    complex_t toComplex();
-    Optional<bool> toBool();
-    void accept(Visitor *v) { v->visit(this); }
+    bool equals(const RootObject *o) const override;
+    dinteger_t toInteger() override;
+    uinteger_t toUInteger() override;
+    real_t toReal() override;
+    real_t toImaginary() override;
+    complex_t toComplex() override;
+    Optional<bool> toBool() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ComplexExp : public Expression
@@ -297,14 +297,14 @@ public:
 
     static ComplexExp *create(const Loc &loc, complex_t value, Type *type);
     static void emplace(UnionExp *pue, const Loc &loc, complex_t value, Type *type);
-    bool equals(const RootObject *o) const;
-    dinteger_t toInteger();
-    uinteger_t toUInteger();
-    real_t toReal();
-    real_t toImaginary();
-    complex_t toComplex();
-    Optional<bool> toBool();
-    void accept(Visitor *v) { v->visit(this); }
+    bool equals(const RootObject *o) const override;
+    dinteger_t toInteger() override;
+    uinteger_t toUInteger() override;
+    real_t toReal() override;
+    real_t toImaginary() override;
+    complex_t toComplex() override;
+    Optional<bool> toBool() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class IdentifierExp : public Expression
@@ -313,15 +313,15 @@ public:
     Identifier *ident;
 
     static IdentifierExp *create(const Loc &loc, Identifier *ident);
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DollarExp : public IdentifierExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DsymbolExp : public Expression
@@ -330,10 +330,10 @@ public:
     Dsymbol *s;
     bool hasOverloads;
 
-    DsymbolExp *syntaxCopy();
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    DsymbolExp *syntaxCopy() override;
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ThisExp : public Expression
@@ -341,27 +341,27 @@ class ThisExp : public Expression
 public:
     VarDeclaration *var;
 
-    ThisExp *syntaxCopy();
-    Optional<bool> toBool();
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
+    ThisExp *syntaxCopy() override;
+    Optional<bool> toBool() override;
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class SuperExp : public ThisExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class NullExp : public Expression
 {
 public:
-    bool equals(const RootObject *o) const;
-    Optional<bool> toBool();
-    StringExp *toStringExp();
-    void accept(Visitor *v) { v->visit(this); }
+    bool equals(const RootObject *o) const override;
+    Optional<bool> toBool() override;
+    StringExp *toStringExp() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StringExp : public Expression
@@ -377,16 +377,16 @@ public:
     static StringExp *create(const Loc &loc, const char *s);
     static StringExp *create(const Loc &loc, const void *s, d_size_t len);
     static void emplace(UnionExp *pue, const Loc &loc, const char *s);
-    bool equals(const RootObject *o) const;
+    bool equals(const RootObject *o) const override;
     char32_t getCodeUnit(d_size_t i) const;
     void setCodeUnit(d_size_t i, char32_t c);
-    StringExp *toStringExp();
+    StringExp *toStringExp() override;
     StringExp *toUTF8(Scope *sc);
-    Optional<bool> toBool();
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    Optional<bool> toBool() override;
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
+    void accept(Visitor *v) override { v->visit(this); }
     size_t numberOfCodeUnits(int tynto = 0) const;
     void writeTo(void* dest, bool zero, int tyto = 0) const;
 };
@@ -407,10 +407,10 @@ public:
     Expressions *exps;
 
     static TupleExp *create(const Loc &loc, Expressions *exps);
-    TupleExp *syntaxCopy();
-    bool equals(const RootObject *o) const;
+    TupleExp *syntaxCopy() override;
+    bool equals(const RootObject *o) const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ArrayLiteralExp : public Expression
@@ -422,14 +422,14 @@ public:
 
     static ArrayLiteralExp *create(const Loc &loc, Expressions *elements);
     static void emplace(UnionExp *pue, const Loc &loc, Expressions *elements);
-    ArrayLiteralExp *syntaxCopy();
-    bool equals(const RootObject *o) const;
+    ArrayLiteralExp *syntaxCopy() override;
+    bool equals(const RootObject *o) const override;
     Expression *getElement(d_size_t i); // use opIndex instead
     Expression *opIndex(d_size_t i);
-    Optional<bool> toBool();
-    StringExp *toStringExp();
+    Optional<bool> toBool() override;
+    StringExp *toStringExp() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class AssocArrayLiteralExp : public Expression
@@ -439,11 +439,11 @@ public:
     Expressions *values;
     OwnedBy ownedByCtfe;
 
-    bool equals(const RootObject *o) const;
-    AssocArrayLiteralExp *syntaxCopy();
-    Optional<bool> toBool();
+    bool equals(const RootObject *o) const override;
+    AssocArrayLiteralExp *syntaxCopy() override;
+    Optional<bool> toBool() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StructLiteralExp : public Expression
@@ -477,23 +477,23 @@ public:
     OwnedBy ownedByCtfe;
 
     static StructLiteralExp *create(const Loc &loc, StructDeclaration *sd, void *elements, Type *stype = NULL);
-    bool equals(const RootObject *o) const;
-    StructLiteralExp *syntaxCopy();
+    bool equals(const RootObject *o) const override;
+    StructLiteralExp *syntaxCopy() override;
     Expression *getField(Type *type, unsigned offset);
     int getFieldIndex(Type *type, unsigned offset);
-    Expression *addDtorHook(Scope *sc);
-    Expression *toLvalue(Scope *sc, Expression *e);
+    Expression *addDtorHook(Scope *sc) override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeExp : public Expression
 {
 public:
-    TypeExp *syntaxCopy();
-    bool checkType();
-    bool checkValue();
-    void accept(Visitor *v) { v->visit(this); }
+    TypeExp *syntaxCopy() override;
+    bool checkType() override;
+    bool checkValue() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ScopeExp : public Expression
@@ -501,10 +501,10 @@ class ScopeExp : public Expression
 public:
     ScopeDsymbol *sds;
 
-    ScopeExp *syntaxCopy();
-    bool checkType();
-    bool checkValue();
-    void accept(Visitor *v) { v->visit(this); }
+    ScopeExp *syntaxCopy() override;
+    bool checkType() override;
+    bool checkValue() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TemplateExp : public Expression
@@ -513,11 +513,11 @@ public:
     TemplateDeclaration *td;
     FuncDeclaration *fd;
 
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    bool checkType();
-    bool checkValue();
-    void accept(Visitor *v) { v->visit(this); }
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    bool checkType() override;
+    bool checkValue() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class NewExp : public Expression
@@ -536,9 +536,9 @@ public:
     bool thrownew;              // this NewExp is the expression of a ThrowStatement
 
     static NewExp *create(const Loc &loc, Expression *thisexp, Type *newtype, Expressions *arguments);
-    NewExp *syntaxCopy();
+    NewExp *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class NewAnonClassExp : public Expression
@@ -550,8 +550,8 @@ public:
     ClassDeclaration *cd;       // class being instantiated
     Expressions *arguments;     // Array of Expression's to call class constructor
 
-    NewAnonClassExp *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    NewAnonClassExp *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class SymbolExp : public Expression
@@ -561,7 +561,7 @@ public:
     Dsymbol *originalScope;
     bool hasOverloads;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Offset from symbol
@@ -571,9 +571,9 @@ class SymOffExp : public SymbolExp
 public:
     dinteger_t offset;
 
-    Optional<bool> toBool();
+    Optional<bool> toBool() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Variable
@@ -583,12 +583,12 @@ class VarExp : public SymbolExp
 public:
     bool delegateWasExtracted;
     static VarExp *create(const Loc &loc, Declaration *var, bool hasOverloads = true);
-    bool equals(const RootObject *o) const;
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
+    bool equals(const RootObject *o) const override;
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Overload Set
@@ -598,9 +598,9 @@ class OverExp : public Expression
 public:
     OverloadSet *vars;
 
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Function/Delegate literal
@@ -612,13 +612,13 @@ public:
     TemplateDeclaration *td;
     TOK tok;
 
-    bool equals(const RootObject *o) const;
-    FuncExp *syntaxCopy();
-    const char *toChars() const;
-    bool checkType();
-    bool checkValue();
+    bool equals(const RootObject *o) const override;
+    FuncExp *syntaxCopy() override;
+    const char *toChars() const override;
+    bool checkType() override;
+    bool checkValue() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Declaration of a symbol
@@ -631,11 +631,11 @@ class DeclarationExp : public Expression
 public:
     Dsymbol *declaration;
 
-    DeclarationExp *syntaxCopy();
+    DeclarationExp *syntaxCopy() override;
 
-    bool hasCode();
+    bool hasCode() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeidExp : public Expression
@@ -643,8 +643,8 @@ class TypeidExp : public Expression
 public:
     RootObject *obj;
 
-    TypeidExp *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    TypeidExp *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TraitsExp : public Expression
@@ -653,14 +653,14 @@ public:
     Identifier *ident;
     Objects *args;
 
-    TraitsExp *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    TraitsExp *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class HaltExp : public Expression
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class IsExp : public Expression
@@ -676,8 +676,8 @@ public:
     TOK tok;       // ':' or '=='
     TOK tok2;      // 'struct', 'union', etc.
 
-    IsExp *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    IsExp *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /****************************************************************/
@@ -688,11 +688,11 @@ public:
     Expression *e1;
     Type *att1; // Save alias this type to detect recursion
 
-    UnaExp *syntaxCopy();
+    UnaExp *syntaxCopy() override;
     Expression *incompatibleTypes();
-    Expression *resolveLoc(const Loc &loc, Scope *sc);
+    Expression *resolveLoc(const Loc &loc, Scope *sc) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class BinExp : public Expression
@@ -704,21 +704,21 @@ public:
     Type *att1; // Save alias this type to detect recursion
     Type *att2; // Save alias this type to detect recursion
 
-    BinExp *syntaxCopy();
+    BinExp *syntaxCopy() override;
     Expression *incompatibleTypes();
 
     Expression *reorderSettingAAElem(Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class BinAssignExp : public BinExp
 {
 public:
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *ex);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *ex) override;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /****************************************************************/
@@ -726,13 +726,13 @@ public:
 class MixinExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ImportExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class AssertExp : public UnaExp
@@ -740,17 +740,17 @@ class AssertExp : public UnaExp
 public:
     Expression *msg;
 
-    AssertExp *syntaxCopy();
+    AssertExp *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ThrowExp : public UnaExp
 {
 public:
-    ThrowExp *syntaxCopy();
+    ThrowExp *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DotIdExp : public UnaExp
@@ -762,7 +762,7 @@ public:
     bool arrow;         // ImportC: if -> instead of .
 
     static DotIdExp *create(const Loc &loc, Expression *e, Identifier *ident);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DotTemplateExp : public UnaExp
@@ -770,9 +770,9 @@ class DotTemplateExp : public UnaExp
 public:
     TemplateDeclaration *td;
 
-    bool checkType();
-    bool checkValue();
-    void accept(Visitor *v) { v->visit(this); }
+    bool checkType() override;
+    bool checkValue() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DotVarExp : public UnaExp
@@ -781,10 +781,10 @@ public:
     Declaration *var;
     bool hasOverloads;
 
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DotTemplateInstanceExp : public UnaExp
@@ -792,11 +792,11 @@ class DotTemplateInstanceExp : public UnaExp
 public:
     TemplateInstance *ti;
 
-    DotTemplateInstanceExp *syntaxCopy();
+    DotTemplateInstanceExp *syntaxCopy() override;
     bool findTempDecl(Scope *sc);
-    bool checkType();
-    bool checkValue();
-    void accept(Visitor *v) { v->visit(this); }
+    bool checkType() override;
+    bool checkValue() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DelegateExp : public UnaExp
@@ -807,7 +807,7 @@ public:
     VarDeclaration *vthis2;  // container for multi-context
 
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DotTypeExp : public UnaExp
@@ -815,7 +815,7 @@ class DotTypeExp : public UnaExp
 public:
     Dsymbol *sym;               // symbol that represents a type
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CallExp : public UnaExp
@@ -833,59 +833,59 @@ public:
     static CallExp *create(const Loc &loc, Expression *e, Expression *earg1);
     static CallExp *create(const Loc &loc, FuncDeclaration *fd, Expression *earg1);
 
-    CallExp *syntaxCopy();
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *addDtorHook(Scope *sc);
+    CallExp *syntaxCopy() override;
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    Expression *addDtorHook(Scope *sc) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class AddrExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class PtrExp : public UnaExp
 {
 public:
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class NegExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class UAddExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ComExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class NotExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DeleteExp : public UnaExp
 {
 public:
     bool isRAII;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CastExp : public UnaExp
@@ -895,11 +895,11 @@ public:
     Type *to;                   // type to cast to
     unsigned char mod;          // MODxxxxx
 
-    CastExp *syntaxCopy();
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
+    CastExp *syntaxCopy() override;
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class VectorExp : public UnaExp
@@ -911,16 +911,16 @@ public:
 
     static VectorExp *create(const Loc &loc, Expression *e, Type *t);
     static void emplace(UnionExp *pue, const Loc &loc, Expression *e, Type *t);
-    VectorExp *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    VectorExp *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class VectorArrayExp : public UnaExp
 {
 public:
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class SliceExp : public UnaExp
@@ -933,19 +933,19 @@ public:
     bool lowerIsLessThanUpper;  // true if lwr <= upr
     bool arrayop;               // an array operation, rather than a slice
 
-    SliceExp *syntaxCopy();
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
-    Optional<bool> toBool();
+    SliceExp *syntaxCopy() override;
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
+    Optional<bool> toBool() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ArrayLengthExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class IntervalExp : public Expression
@@ -954,26 +954,26 @@ public:
     Expression *lwr;
     Expression *upr;
 
-    IntervalExp *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    IntervalExp *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DelegatePtrExp : public UnaExp
 {
 public:
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DelegateFuncptrExp : public UnaExp
 {
 public:
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // e1[a0,a1,a2,a3,...]
@@ -985,11 +985,11 @@ public:
     size_t currentDimension;            // for opDollar
     VarDeclaration *lengthVar;
 
-    ArrayExp *syntaxCopy();
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
+    ArrayExp *syntaxCopy() override;
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /****************************************************************/
@@ -997,7 +997,7 @@ public:
 class DotExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CommaExp : public BinExp
@@ -1005,12 +1005,12 @@ class CommaExp : public BinExp
 public:
     bool isGenerated;
     bool allowCommaExp;
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
-    Optional<bool> toBool();
-    Expression *addDtorHook(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
+    Optional<bool> toBool() override;
+    Expression *addDtorHook(Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class IndexExp : public BinExp
@@ -1020,12 +1020,12 @@ public:
     bool modifiable;
     bool indexIsInBounds;       // true if 0 <= e2 && e2 <= e1.length - 1
 
-    IndexExp *syntaxCopy();
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
+    IndexExp *syntaxCopy() override;
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /* For both i++ and i--
@@ -1033,7 +1033,7 @@ public:
 class PostExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /* For both ++i and --i
@@ -1041,7 +1041,7 @@ public:
 class PreExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 enum class MemorySet
@@ -1056,100 +1056,100 @@ class AssignExp : public BinExp
 public:
     MemorySet memset;
 
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *ex);
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *ex) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ConstructExp : public AssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class BlitExp : public AssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class AddAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class MinAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class MulAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DivAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ModAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class AndAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class OrAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class XorAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class PowAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ShlAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ShrAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class UshrAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CatAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CatElemAssignExp : public CatAssignExp
@@ -1167,103 +1167,103 @@ public:
 class AddExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class MinExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CatExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class MulExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DivExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ModExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class PowExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ShlExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ShrExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class UshrExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class AndExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class OrExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class XorExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class LogicalExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CmpExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class InExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class RemoveExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // == and !=
@@ -1271,7 +1271,7 @@ public:
 class EqualExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // is and !is
@@ -1279,7 +1279,7 @@ public:
 class IdentityExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /****************************************************************/
@@ -1289,13 +1289,13 @@ class CondExp : public BinExp
 public:
     Expression *econd;
 
-    CondExp *syntaxCopy();
-    bool isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
+    CondExp *syntaxCopy() override;
+    bool isLvalue() override;
+    Expression *toLvalue(Scope *sc, Expression *e) override;
+    Expression *modifiableLvalue(Scope *sc, Expression *e) override;
     void hookDtors(Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class GenericExp : Expression
@@ -1304,9 +1304,9 @@ class GenericExp : Expression
     Types *types;
     Expressions *exps;
 
-    GenericExp *syntaxCopy();
+    GenericExp *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /****************************************************************/
@@ -1314,42 +1314,42 @@ class GenericExp : Expression
 class DefaultInitExp : public Expression
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class FileInitExp : public DefaultInitExp
 {
 public:
-    Expression *resolveLoc(const Loc &loc, Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    Expression *resolveLoc(const Loc &loc, Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class LineInitExp : public DefaultInitExp
 {
 public:
-    Expression *resolveLoc(const Loc &loc, Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    Expression *resolveLoc(const Loc &loc, Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ModuleInitExp : public DefaultInitExp
 {
 public:
-    Expression *resolveLoc(const Loc &loc, Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    Expression *resolveLoc(const Loc &loc, Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class FuncInitExp : public DefaultInitExp
 {
 public:
-    Expression *resolveLoc(const Loc &loc, Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    Expression *resolveLoc(const Loc &loc, Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class PrettyFuncInitExp : public DefaultInitExp
 {
 public:
-    Expression *resolveLoc(const Loc &loc, Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    Expression *resolveLoc(const Loc &loc, Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /****************************************************************/
@@ -1415,5 +1415,5 @@ class ObjcClassReferenceExp : public Expression
 public:
     ClassDeclaration* classDeclaration;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -22,12 +22,12 @@ private:
 
 public:
     static Identifier* create(const char *string);
-    bool equals(const RootObject *o) const;
-    const char *toChars() const;
+    bool equals(const RootObject *o) const override;
+    const char *toChars() const override;
     int getValue() const;
     bool isAnonymous() const;
     const char *toHChars2() const;
-    DYNCAST dyncast() const;
+    DYNCAST dyncast() const override;
 
     static Identifier *generateId(const char *prefix, size_t length, size_t suffix);
     static Identifier *idPool(const char *s, unsigned len);

--- a/src/dmd/import.h
+++ b/src/dmd/import.h
@@ -38,17 +38,17 @@ public:
 
     AliasDeclarations aliasdecls; // corresponding AliasDeclarations for alias=name pairs
 
-    const char *kind() const;
-    Visibility visible();
-    Import *syntaxCopy(Dsymbol *s);    // copy only syntax trees
+    const char *kind() const override;
+    Visibility visible() override;
+    Import *syntaxCopy(Dsymbol *s) override; // copy only syntax trees
     void load(Scope *sc);
-    void importAll(Scope *sc);
-    Dsymbol *toAlias();
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    void setScope(Scope* sc);
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
-    bool overloadInsert(Dsymbol *s);
+    void importAll(Scope *sc) override;
+    Dsymbol *toAlias() override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    void setScope(Scope* sc) override;
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
+    bool overloadInsert(Dsymbol *s) override;
 
-    Import *isImport() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    Import *isImport() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -33,9 +33,9 @@ public:
     Loc loc;
     unsigned char kind;
 
-    DYNCAST dyncast() const { return DYNCAST_INITIALIZER; }
+    DYNCAST dyncast() const override { return DYNCAST_INITIALIZER; }
 
-    const char *toChars() const;
+    const char *toChars() const override;
 
     ErrorInitializer   *isErrorInitializer();
     VoidInitializer    *isVoidInitializer();
@@ -44,7 +44,7 @@ public:
     ExpInitializer     *isExpInitializer();
     CInitializer       *isCInitializer();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class VoidInitializer : public Initializer
@@ -52,13 +52,13 @@ class VoidInitializer : public Initializer
 public:
     Type *type;         // type that this will initialize to
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ErrorInitializer : public Initializer
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StructInitializer : public Initializer
@@ -67,7 +67,7 @@ public:
     Identifiers field;  // of Identifier *'s
     Initializers value; // parallel array of Initializer *'s
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ArrayInitializer : public Initializer
@@ -82,7 +82,7 @@ public:
     bool isAssociativeArray() const;
     Expression *toAssocArrayLiteral();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ExpInitializer : public Initializer
@@ -91,7 +91,7 @@ public:
     bool expandTuples;
     Expression *exp;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 struct Designator
@@ -113,7 +113,7 @@ public:
     Type *type;         // type that array will be used to initialize
     bool sem;           // true if semantic() is run
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 Expression *initializerToExpression(Initializer *init, Type *t = NULL, const bool isCfile = false);

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -35,16 +35,16 @@ public:
     unsigned tag;       // auto incremented tag, used to mask package tree in scopes
     Module *mod;        // != NULL if isPkgMod == PKGmodule
 
-    const char *kind() const;
+    const char *kind() const override;
 
-    bool equals(const RootObject *o) const;
+    bool equals(const RootObject *o) const override;
 
-    Package *isPackage() { return this; }
+    Package *isPackage() override { return this; }
 
     bool isAncestorPackageOf(const Package * const pkg) const;
 
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
-    void accept(Visitor *v) { v->visit(this); }
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
+    void accept(Visitor *v) override { v->visit(this); }
 
     Module *isPackageMod();
 };
@@ -120,14 +120,14 @@ public:
 
     static Module *load(const Loc &loc, Identifiers *packages, Identifier *ident);
 
-    const char *kind() const;
+    const char *kind() const override;
     bool read(const Loc &loc); // read file, returns 'true' if succeed, 'false' otherwise.
     Module *parse();    // syntactic parse
-    void importAll(Scope *sc);
+    void importAll(Scope *sc) override;
     int needModuleInfo();
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
-    bool isPackageAccessible(Package *p, Visibility visibility, int flags = 0);
-    Dsymbol *symtabInsert(Dsymbol *s);
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
+    bool isPackageAccessible(Package *p, Visibility visibility, int flags = 0) override;
+    Dsymbol *symtabInsert(Dsymbol *s) override;
     void deleteObjFile();
     static void runDeferredSemantic();
     static void runDeferredSemantic2();
@@ -156,8 +156,8 @@ public:
 
     void *ctfe_cov;             // stores coverage information from ctfe
 
-    Module *isModule() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    Module *isModule() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -221,13 +221,13 @@ public:
     virtual const char *kind();
     Type *copy() const;
     virtual Type *syntaxCopy();
-    bool equals(const RootObject *o) const;
+    bool equals(const RootObject *o) const override;
     bool equivalent(Type *t);
     // kludge for template.isType()
-    DYNCAST dyncast() const { return DYNCAST_TYPE; }
+    DYNCAST dyncast() const override { return DYNCAST_TYPE; }
     size_t getUniqueID() const;
     Covariant covariant(Type *t, StorageClass *pstc = NULL);
-    const char *toChars() const;
+    const char *toChars() const override;
     char *toPrettyChars(bool QualifyTypes = false);
     static void _init();
 
@@ -349,18 +349,18 @@ public:
     TypeNoreturn *isTypeNoreturn();
     TypeTag *isTypeTag();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeError : public Type
 {
 public:
-    const char *kind();
-    TypeError *syntaxCopy();
+    const char *kind() override;
+    TypeError *syntaxCopy() override;
 
-    uinteger_t size(const Loc &loc);
-    Expression *defaultInitLiteral(const Loc &loc);
-    void accept(Visitor *v) { v->visit(this); }
+    uinteger_t size(const Loc &loc) override;
+    Expression *defaultInitLiteral(const Loc &loc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeNext : public Type
@@ -368,22 +368,22 @@ class TypeNext : public Type
 public:
     Type *next;
 
-    void checkDeprecated(const Loc &loc, Scope *sc);
-    int hasWild() const;
-    Type *nextOf();
-    Type *makeConst();
-    Type *makeImmutable();
-    Type *makeShared();
-    Type *makeSharedConst();
-    Type *makeWild();
-    Type *makeWildConst();
-    Type *makeSharedWild();
-    Type *makeSharedWildConst();
-    Type *makeMutable();
-    MATCH constConv(Type *to);
-    unsigned char deduceWild(Type *t, bool isRef);
+    void checkDeprecated(const Loc &loc, Scope *sc) override;
+    int hasWild() const override;
+    Type *nextOf() override;
+    Type *makeConst() override;
+    Type *makeImmutable() override;
+    Type *makeShared() override;
+    Type *makeSharedConst() override;
+    Type *makeWild() override;
+    Type *makeWildConst() override;
+    Type *makeSharedWild() override;
+    Type *makeSharedWildConst() override;
+    Type *makeMutable() override;
+    MATCH constConv(Type *to) override;
+    unsigned char deduceWild(Type *t, bool isRef) override;
     void transitive();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeBasic : public Type
@@ -392,23 +392,23 @@ public:
     const char *dstring;
     unsigned flags;
 
-    const char *kind();
-    TypeBasic *syntaxCopy();
-    uinteger_t size(const Loc &loc) /*const*/;
-    unsigned alignsize();
-    bool isintegral();
-    bool isfloating() /*const*/;
-    bool isreal() /*const*/;
-    bool isimaginary() /*const*/;
-    bool iscomplex() /*const*/;
-    bool isscalar() /*const*/;
-    bool isunsigned() /*const*/;
-    MATCH implicitConvTo(Type *to);
-    bool isZeroInit(const Loc &loc) /*const*/;
+    const char *kind() override;
+    TypeBasic *syntaxCopy() override;
+    uinteger_t size(const Loc &loc) override;
+    unsigned alignsize() override;
+    bool isintegral() override;
+    bool isfloating() override;
+    bool isreal() override;
+    bool isimaginary() override;
+    bool iscomplex() override;
+    bool isscalar() override;
+    bool isunsigned() override;
+    MATCH implicitConvTo(Type *to) override;
+    bool isZeroInit(const Loc &loc) override;
 
     // For eliminating dynamic_cast
-    TypeBasic *isTypeBasic();
-    void accept(Visitor *v) { v->visit(this); }
+    TypeBasic *isTypeBasic() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeVector : public Type
@@ -417,27 +417,27 @@ public:
     Type *basetype;
 
     static TypeVector *create(Type *basetype);
-    const char *kind();
-    TypeVector *syntaxCopy();
-    uinteger_t size(const Loc &loc);
-    unsigned alignsize();
-    bool isintegral();
-    bool isfloating();
-    bool isscalar();
-    bool isunsigned();
-    bool isBoolean() /*const*/;
-    MATCH implicitConvTo(Type *to);
-    Expression *defaultInitLiteral(const Loc &loc);
+    const char *kind() override;
+    TypeVector *syntaxCopy() override;
+    uinteger_t size(const Loc &loc) override;
+    unsigned alignsize() override;
+    bool isintegral() override;
+    bool isfloating() override;
+    bool isscalar() override;
+    bool isunsigned() override;
+    bool isBoolean() override;
+    MATCH implicitConvTo(Type *to) override;
+    Expression *defaultInitLiteral(const Loc &loc) override;
     TypeBasic *elementType();
-    bool isZeroInit(const Loc &loc);
+    bool isZeroInit(const Loc &loc) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeArray : public TypeNext
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Static array, one with a fixed dimension
@@ -446,41 +446,41 @@ class TypeSArray : public TypeArray
 public:
     Expression *dim;
 
-    const char *kind();
-    TypeSArray *syntaxCopy();
+    const char *kind() override;
+    TypeSArray *syntaxCopy() override;
     bool isIncomplete();
-    uinteger_t size(const Loc &loc);
-    unsigned alignsize();
-    bool isString();
-    bool isZeroInit(const Loc &loc);
-    structalign_t alignment();
-    MATCH constConv(Type *to);
-    MATCH implicitConvTo(Type *to);
-    Expression *defaultInitLiteral(const Loc &loc);
-    bool hasPointers();
-    bool hasInvariant();
-    bool needsDestruction();
-    bool needsCopyOrPostblit();
-    bool needsNested();
+    uinteger_t size(const Loc &loc) override;
+    unsigned alignsize() override;
+    bool isString() override;
+    bool isZeroInit(const Loc &loc) override;
+    structalign_t alignment() override;
+    MATCH constConv(Type *to) override;
+    MATCH implicitConvTo(Type *to) override;
+    Expression *defaultInitLiteral(const Loc &loc) override;
+    bool hasPointers() override;
+    bool hasInvariant() override;
+    bool needsDestruction() override;
+    bool needsCopyOrPostblit() override;
+    bool needsNested() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Dynamic array, no dimension
 class TypeDArray : public TypeArray
 {
 public:
-    const char *kind();
-    TypeDArray *syntaxCopy();
-    uinteger_t size(const Loc &loc) /*const*/;
-    unsigned alignsize() /*const*/;
-    bool isString();
-    bool isZeroInit(const Loc &loc) /*const*/;
-    bool isBoolean() /*const*/;
-    MATCH implicitConvTo(Type *to);
-    bool hasPointers() /*const*/;
+    const char *kind() override;
+    TypeDArray *syntaxCopy() override;
+    uinteger_t size(const Loc &loc) override;
+    unsigned alignsize() override;
+    bool isString() override;
+    bool isZeroInit(const Loc &loc) override;
+    bool isBoolean() override;
+    MATCH implicitConvTo(Type *to) override;
+    bool hasPointers() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeAArray : public TypeArray
@@ -490,42 +490,42 @@ public:
     Loc loc;
 
     static TypeAArray *create(Type *t, Type *index);
-    const char *kind();
-    TypeAArray *syntaxCopy();
-    uinteger_t size(const Loc &loc);
-    bool isZeroInit(const Loc &loc) /*const*/;
-    bool isBoolean() /*const*/;
-    bool hasPointers() /*const*/;
-    MATCH implicitConvTo(Type *to);
-    MATCH constConv(Type *to);
+    const char *kind() override;
+    TypeAArray *syntaxCopy() override;
+    uinteger_t size(const Loc &loc) override;
+    bool isZeroInit(const Loc &loc) override;
+    bool isBoolean() override;
+    bool hasPointers() override;
+    MATCH implicitConvTo(Type *to) override;
+    MATCH constConv(Type *to) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypePointer : public TypeNext
 {
 public:
     static TypePointer *create(Type *t);
-    const char *kind();
-    TypePointer *syntaxCopy();
-    uinteger_t size(const Loc &loc) /*const*/;
-    MATCH implicitConvTo(Type *to);
-    MATCH constConv(Type *to);
-    bool isscalar() /*const*/;
-    bool isZeroInit(const Loc &loc) /*const*/;
-    bool hasPointers() /*const*/;
+    const char *kind() override;
+    TypePointer *syntaxCopy() override;
+    uinteger_t size(const Loc &loc) override;
+    MATCH implicitConvTo(Type *to) override;
+    MATCH constConv(Type *to) override;
+    bool isscalar() override;
+    bool isZeroInit(const Loc &loc) override;
+    bool hasPointers() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeReference : public TypeNext
 {
 public:
-    const char *kind();
-    TypeReference *syntaxCopy();
-    uinteger_t size(const Loc &loc) /*const*/;
-    bool isZeroInit(const Loc &loc) /*const*/;
-    void accept(Visitor *v) { v->visit(this); }
+    const char *kind() override;
+    TypeReference *syntaxCopy() override;
+    uinteger_t size(const Loc &loc) override;
+    bool isZeroInit(const Loc &loc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 enum RET
@@ -570,12 +570,12 @@ public:
     Parameter *syntaxCopy();
     Type *isLazyArray();
     // kludge for template.isType()
-    DYNCAST dyncast() const { return DYNCAST_PARAMETER; }
-    void accept(Visitor *v) { v->visit(this); }
+    DYNCAST dyncast() const override { return DYNCAST_PARAMETER; }
+    void accept(Visitor *v) override { v->visit(this); }
 
     static size_t dim(Parameters *parameters);
     static Parameter *getNth(Parameters *parameters, d_size_t nth);
-    const char *toChars() const;
+    const char *toChars() const override;
     bool isCovariant(bool returnByRef, const Parameter *p, bool previewIn) const;
 };
 
@@ -604,16 +604,16 @@ public:
     Expressions *fargs;          // function arguments
 
     static TypeFunction *create(Parameters *parameters, Type *treturn, VarArg varargs, LINK linkage, StorageClass stc = 0);
-    const char *kind();
-    TypeFunction *syntaxCopy();
+    const char *kind() override;
+    TypeFunction *syntaxCopy() override;
     void purityLevel();
     bool hasLazyParameters();
     bool isDstyleVariadic() const;
     StorageClass parameterStorageClass(Parameter *p);
-    Type *addStorageClass(StorageClass stc);
+    Type *addStorageClass(StorageClass stc) override;
 
-    Type *substWildTo(unsigned mod);
-    MATCH constConv(Type *to);
+    Type *substWildTo(unsigned mod) override;
+    MATCH constConv(Type *to) override;
 
     bool isnothrow() const;
     void isnothrow(bool v);
@@ -643,7 +643,7 @@ public:
     void isInOutQual(bool v);
     bool iswild() const;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeDelegate : public TypeNext
@@ -652,17 +652,17 @@ public:
     // .next is a TypeFunction
 
     static TypeDelegate *create(TypeFunction *t);
-    const char *kind();
-    TypeDelegate *syntaxCopy();
-    Type *addStorageClass(StorageClass stc);
-    uinteger_t size(const Loc &loc) /*const*/;
-    unsigned alignsize() /*const*/;
-    MATCH implicitConvTo(Type *to);
-    bool isZeroInit(const Loc &loc) /*const*/;
-    bool isBoolean() /*const*/;
-    bool hasPointers() /*const*/;
+    const char *kind() override;
+    TypeDelegate *syntaxCopy() override;
+    Type *addStorageClass(StorageClass stc) override;
+    uinteger_t size(const Loc &loc) override;
+    unsigned alignsize() override;
+    MATCH implicitConvTo(Type *to) override;
+    bool isZeroInit(const Loc &loc) override;
+    bool isBoolean() override;
+    bool hasPointers() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeTraits : public Type
@@ -673,11 +673,11 @@ class TypeTraits : public Type
     /// Cached type/symbol after semantic analysis.
     RootObject *obj;
 
-    const char *kind();
-    TypeTraits *syntaxCopy();
-    uinteger_t size(const Loc &loc);
-    Dsymbol *toDsymbol(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    const char *kind() override;
+    TypeTraits *syntaxCopy() override;
+    uinteger_t size(const Loc &loc) override;
+    Dsymbol *toDsymbol(Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeMixin : public Type
@@ -686,10 +686,10 @@ class TypeMixin : public Type
     Expressions *exps;
     RootObject *obj;
 
-    const char *kind();
-    TypeMixin *syntaxCopy();
-    Dsymbol *toDsymbol(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    const char *kind() override;
+    TypeMixin *syntaxCopy() override;
+    Dsymbol *toDsymbol(Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeQualified : public Type
@@ -704,9 +704,9 @@ public:
     void addIdent(Identifier *ident);
     void addInst(TemplateInstance *inst);
     void addIndex(RootObject *expr);
-    uinteger_t size(const Loc &loc);
+    uinteger_t size(const Loc &loc) override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeIdentifier : public TypeQualified
@@ -716,10 +716,10 @@ public:
     Dsymbol *originalSymbol; // The symbol representing this identifier, before alias resolution
 
     static TypeIdentifier *create(const Loc &loc, Identifier *ident);
-    const char *kind();
-    TypeIdentifier *syntaxCopy();
-    Dsymbol *toDsymbol(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    const char *kind() override;
+    TypeIdentifier *syntaxCopy() override;
+    Dsymbol *toDsymbol(Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /* Similar to TypeIdentifier, but with a TemplateInstance as the root
@@ -729,10 +729,10 @@ class TypeInstance : public TypeQualified
 public:
     TemplateInstance *tempinst;
 
-    const char *kind();
-    TypeInstance *syntaxCopy();
-    Dsymbol *toDsymbol(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    const char *kind() override;
+    TypeInstance *syntaxCopy() override;
+    Dsymbol *toDsymbol(Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeTypeof : public TypeQualified
@@ -741,20 +741,20 @@ public:
     Expression *exp;
     int inuse;
 
-    const char *kind();
-    TypeTypeof *syntaxCopy();
-    Dsymbol *toDsymbol(Scope *sc);
-    uinteger_t size(const Loc &loc);
-    void accept(Visitor *v) { v->visit(this); }
+    const char *kind() override;
+    TypeTypeof *syntaxCopy() override;
+    Dsymbol *toDsymbol(Scope *sc) override;
+    uinteger_t size(const Loc &loc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeReturn : public TypeQualified
 {
 public:
-    const char *kind();
-    TypeReturn *syntaxCopy();
-    Dsymbol *toDsymbol(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    const char *kind() override;
+    TypeReturn *syntaxCopy() override;
+    Dsymbol *toDsymbol(Scope *sc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Whether alias this dependency is recursive or not.
@@ -777,28 +777,28 @@ public:
     bool inuse;
 
     static TypeStruct *create(StructDeclaration *sym);
-    const char *kind();
-    uinteger_t size(const Loc &loc);
-    unsigned alignsize();
-    TypeStruct *syntaxCopy();
-    Dsymbol *toDsymbol(Scope *sc);
-    structalign_t alignment();
-    Expression *defaultInitLiteral(const Loc &loc);
-    bool isZeroInit(const Loc &loc);
-    bool isAssignable();
-    bool isBoolean() /*const*/;
-    bool needsDestruction() /*const*/;
-    bool needsCopyOrPostblit();
-    bool needsNested();
-    bool hasPointers();
-    bool hasVoidInitPointers();
-    bool hasInvariant();
-    MATCH implicitConvTo(Type *to);
-    MATCH constConv(Type *to);
-    unsigned char deduceWild(Type *t, bool isRef);
-    Type *toHeadMutable();
+    const char *kind() override;
+    uinteger_t size(const Loc &loc) override;
+    unsigned alignsize() override;
+    TypeStruct *syntaxCopy() override;
+    Dsymbol *toDsymbol(Scope *sc) override;
+    structalign_t alignment() override;
+    Expression *defaultInitLiteral(const Loc &loc) override;
+    bool isZeroInit(const Loc &loc) override;
+    bool isAssignable() override;
+    bool isBoolean() override;
+    bool needsDestruction() override;
+    bool needsCopyOrPostblit() override;
+    bool needsNested() override;
+    bool hasPointers() override;
+    bool hasVoidInitPointers() override;
+    bool hasInvariant() override;
+    MATCH implicitConvTo(Type *to) override;
+    MATCH constConv(Type *to) override;
+    unsigned char deduceWild(Type *t, bool isRef) override;
+    Type *toHeadMutable() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeEnum : public Type
@@ -806,34 +806,34 @@ class TypeEnum : public Type
 public:
     EnumDeclaration *sym;
 
-    const char *kind();
-    TypeEnum *syntaxCopy();
-    uinteger_t size(const Loc &loc);
-    unsigned alignsize();
+    const char *kind() override;
+    TypeEnum *syntaxCopy() override;
+    uinteger_t size(const Loc &loc) override;
+    unsigned alignsize() override;
     Type *memType(const Loc &loc = Loc());
-    Dsymbol *toDsymbol(Scope *sc);
-    bool isintegral();
-    bool isfloating();
-    bool isreal();
-    bool isimaginary();
-    bool iscomplex();
-    bool isscalar();
-    bool isunsigned();
-    bool isBoolean();
-    bool isString();
-    bool isAssignable();
-    bool needsDestruction();
-    bool needsCopyOrPostblit();
-    bool needsNested();
-    MATCH implicitConvTo(Type *to);
-    MATCH constConv(Type *to);
-    bool isZeroInit(const Loc &loc);
-    bool hasPointers();
-    bool hasVoidInitPointers();
-    bool hasInvariant();
-    Type *nextOf();
+    Dsymbol *toDsymbol(Scope *sc) override;
+    bool isintegral() override;
+    bool isfloating() override;
+    bool isreal() override;
+    bool isimaginary() override;
+    bool iscomplex() override;
+    bool isscalar() override;
+    bool isunsigned() override;
+    bool isBoolean() override;
+    bool isString() override;
+    bool isAssignable() override;
+    bool needsDestruction() override;
+    bool needsCopyOrPostblit() override;
+    bool needsNested() override;
+    MATCH implicitConvTo(Type *to) override;
+    MATCH constConv(Type *to) override;
+    bool isZeroInit(const Loc &loc) override;
+    bool hasPointers() override;
+    bool hasVoidInitPointers() override;
+    bool hasInvariant() override;
+    Type *nextOf() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeClass : public Type
@@ -843,22 +843,22 @@ public:
     AliasThisRec att;
     CPPMANGLE cppmangle;
 
-    const char *kind();
-    uinteger_t size(const Loc &loc) /*const*/;
-    TypeClass *syntaxCopy();
-    Dsymbol *toDsymbol(Scope *sc);
-    ClassDeclaration *isClassHandle();
-    bool isBaseOf(Type *t, int *poffset);
-    MATCH implicitConvTo(Type *to);
-    MATCH constConv(Type *to);
-    unsigned char deduceWild(Type *t, bool isRef);
-    Type *toHeadMutable();
-    bool isZeroInit(const Loc &loc) /*const*/;
-    bool isscope() /*const*/;
-    bool isBoolean() /*const*/;
-    bool hasPointers() /*const*/;
+    const char *kind() override;
+    uinteger_t size(const Loc &loc) override;
+    TypeClass *syntaxCopy() override;
+    Dsymbol *toDsymbol(Scope *sc) override;
+    ClassDeclaration *isClassHandle() override;
+    bool isBaseOf(Type *t, int *poffset) override;
+    MATCH implicitConvTo(Type *to) override;
+    MATCH constConv(Type *to) override;
+    unsigned char deduceWild(Type *t, bool isRef) override;
+    Type *toHeadMutable() override;
+    bool isZeroInit(const Loc &loc) override;
+    bool isscope() override;
+    bool isBoolean() override;
+    bool hasPointers() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeTuple : public Type
@@ -873,10 +873,10 @@ public:
     static TypeTuple *create();
     static TypeTuple *create(Type *t1);
     static TypeTuple *create(Type *t1, Type *t2);
-    const char *kind();
-    TypeTuple *syntaxCopy();
-    bool equals(const RootObject *o) const;
-    void accept(Visitor *v) { v->visit(this); }
+    const char *kind() override;
+    TypeTuple *syntaxCopy() override;
+    bool equals(const RootObject *o) const override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeSlice : public TypeNext
@@ -885,44 +885,44 @@ public:
     Expression *lwr;
     Expression *upr;
 
-    const char *kind();
-    TypeSlice *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    const char *kind() override;
+    TypeSlice *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeNull : public Type
 {
 public:
-    const char *kind();
+    const char *kind() override;
 
-    TypeNull *syntaxCopy();
-    MATCH implicitConvTo(Type *to);
-    bool isBoolean() /*const*/;
+    TypeNull *syntaxCopy() override;
+    MATCH implicitConvTo(Type *to) override;
+    bool isBoolean() override;
 
-    uinteger_t size(const Loc &loc) /*const*/;
-    void accept(Visitor *v) { v->visit(this); }
+    uinteger_t size(const Loc &loc) override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeNoreturn final : public Type
 {
 public:
-    const char *kind();
-    TypeNoreturn *syntaxCopy();
-    MATCH implicitConvTo(Type* to);
-    MATCH constConv(Type* to);
-    bool isBoolean() /* const */;
-    uinteger_t size(const Loc& loc) /* const */;
-    unsigned alignsize();
+    const char *kind() override;
+    TypeNoreturn *syntaxCopy() override;
+    MATCH implicitConvTo(Type* to) override;
+    MATCH constConv(Type* to) override;
+    bool isBoolean() override;
+    uinteger_t size(const Loc& loc) override;
+    unsigned alignsize() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TypeTag final : public Type
 {
 public:
-    TypeTag *syntaxCopy();
+    TypeTag *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /**************************************************************/

--- a/src/dmd/nspace.h
+++ b/src/dmd/nspace.h
@@ -20,13 +20,13 @@ class Nspace : public ScopeDsymbol
 {
   public:
     Expression *identExp;
-    Nspace *syntaxCopy(Dsymbol *s);
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    void setScope(Scope *sc);
-    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
-    bool hasPointers();
-    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
-    const char *kind() const;
-    Nspace *isNspace() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    Nspace *syntaxCopy(Dsymbol *s) override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    void setScope(Scope *sc) override;
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
+    bool hasPointers() override;
+    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion) override;
+    const char *kind() const override;
+    Nspace *isNspace() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -109,11 +109,11 @@ public:
     Loc loc;
     STMT stmt;
 
-    DYNCAST dyncast() const { return DYNCAST_STATEMENT; }
+    DYNCAST dyncast() const override { return DYNCAST_STATEMENT; }
 
     virtual Statement *syntaxCopy();
 
-    const char *toChars() const;
+    const char *toChars() const override;
 
     void error(const char *format, ...);
     void warning(const char *format, ...);
@@ -161,7 +161,7 @@ public:
     ForeachRangeStatement *isForeachRangeStatement() { return stmt == STMTforeachRange ? (ForeachRangeStatement*)this : NULL; }
     CompoundDeclarationStatement *isCompoundDeclarationStatement() { return stmt == STMTcompoundDeclaration ? (CompoundDeclarationStatement*)this : NULL; }
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /** Any Statement that fails semantic() or has a component that is an ErrorExp or
@@ -170,9 +170,9 @@ public:
 class ErrorStatement : public Statement
 {
 public:
-    ErrorStatement *syntaxCopy();
+    ErrorStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class PeelStatement : public Statement
@@ -180,7 +180,7 @@ class PeelStatement : public Statement
 public:
     Statement *s;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ExpStatement : public Statement
@@ -189,9 +189,9 @@ public:
     Expression *exp;
 
     static ExpStatement *create(const Loc &loc, Expression *exp);
-    ExpStatement *syntaxCopy();
+    ExpStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DtorExpStatement : public ExpStatement
@@ -202,8 +202,8 @@ public:
 
     VarDeclaration *var;
 
-    DtorExpStatement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    DtorExpStatement *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CompileStatement : public Statement
@@ -211,8 +211,8 @@ class CompileStatement : public Statement
 public:
     Expressions *exps;
 
-    CompileStatement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    CompileStatement *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CompoundStatement : public Statement
@@ -221,18 +221,18 @@ public:
     Statements *statements;
 
     static CompoundStatement *create(const Loc &loc, Statement *s1, Statement *s2);
-    CompoundStatement *syntaxCopy();
-    ReturnStatement *endsWithReturnStatement();
-    Statement *last();
+    CompoundStatement *syntaxCopy() override;
+    ReturnStatement *endsWithReturnStatement() override;
+    Statement *last() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CompoundDeclarationStatement : public CompoundStatement
 {
 public:
-    CompoundDeclarationStatement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    CompoundDeclarationStatement *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /* The purpose of this is so that continue will go to the next
@@ -243,11 +243,11 @@ class UnrolledLoopStatement : public Statement
 public:
     Statements *statements;
 
-    UnrolledLoopStatement *syntaxCopy();
-    bool hasBreak() const;
-    bool hasContinue() const;
+    UnrolledLoopStatement *syntaxCopy() override;
+    bool hasBreak() const override;
+    bool hasContinue() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ScopeStatement : public Statement
@@ -256,12 +256,12 @@ public:
     Statement *statement;
     Loc endloc;                 // location of closing curly bracket
 
-    ScopeStatement *syntaxCopy();
-    ReturnStatement *endsWithReturnStatement();
-    bool hasBreak() const;
-    bool hasContinue() const;
+    ScopeStatement *syntaxCopy() override;
+    ReturnStatement *endsWithReturnStatement() override;
+    bool hasBreak() const override;
+    bool hasContinue() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ForwardingStatement : public Statement
@@ -270,8 +270,8 @@ public:
     ForwardingScopeDsymbol *sym;
     Statement *statement;
 
-    ForwardingStatement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    ForwardingStatement *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class WhileStatement : public Statement
@@ -282,11 +282,11 @@ public:
     Statement *_body;
     Loc endloc;                 // location of closing curly bracket
 
-    WhileStatement *syntaxCopy();
-    bool hasBreak() const;
-    bool hasContinue() const;
+    WhileStatement *syntaxCopy() override;
+    bool hasBreak() const override;
+    bool hasContinue() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DoStatement : public Statement
@@ -296,11 +296,11 @@ public:
     Expression *condition;
     Loc endloc;                 // location of ';' after while
 
-    DoStatement *syntaxCopy();
-    bool hasBreak() const;
-    bool hasContinue() const;
+    DoStatement *syntaxCopy() override;
+    bool hasBreak() const override;
+    bool hasContinue() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ForStatement : public Statement
@@ -317,12 +317,12 @@ public:
     // treat that label as referring to this loop.
     Statement *relatedLabeled;
 
-    ForStatement *syntaxCopy();
-    Statement *getRelatedLabeled() { return relatedLabeled ? relatedLabeled : this; }
-    bool hasBreak() const;
-    bool hasContinue() const;
+    ForStatement *syntaxCopy() override;
+    Statement *getRelatedLabeled() override { return relatedLabeled ? relatedLabeled : this; }
+    bool hasBreak() const override;
+    bool hasContinue() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ForeachStatement : public Statement
@@ -342,11 +342,11 @@ public:
     Statements *cases;          // put breaks, continues, gotos and returns here
     ScopeStatements *gotos;     // forward referenced goto's go here
 
-    ForeachStatement *syntaxCopy();
-    bool hasBreak() const;
-    bool hasContinue() const;
+    ForeachStatement *syntaxCopy() override;
+    bool hasBreak() const override;
+    bool hasContinue() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ForeachRangeStatement : public Statement
@@ -361,11 +361,11 @@ public:
 
     VarDeclaration *key;
 
-    ForeachRangeStatement *syntaxCopy();
-    bool hasBreak() const;
-    bool hasContinue() const;
+    ForeachRangeStatement *syntaxCopy() override;
+    bool hasBreak() const override;
+    bool hasContinue() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class IfStatement : public Statement
@@ -378,9 +378,9 @@ public:
     VarDeclaration *match;      // for MatchExpression results
     Loc endloc;                 // location of closing curly bracket
 
-    IfStatement *syntaxCopy();
+    IfStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ConditionalStatement : public Statement
@@ -390,9 +390,9 @@ public:
     Statement *ifbody;
     Statement *elsebody;
 
-    ConditionalStatement *syntaxCopy();
+    ConditionalStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StaticForeachStatement : public Statement
@@ -400,9 +400,9 @@ class StaticForeachStatement : public Statement
 public:
     StaticForeach *sfe;
 
-    StaticForeachStatement *syntaxCopy();
+    StaticForeachStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class PragmaStatement : public Statement
@@ -412,9 +412,9 @@ public:
     Expressions *args;          // array of Expression's
     Statement *_body;
 
-    PragmaStatement *syntaxCopy();
+    PragmaStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class StaticAssertStatement : public Statement
@@ -422,9 +422,9 @@ class StaticAssertStatement : public Statement
 public:
     StaticAssert *sa;
 
-    StaticAssertStatement *syntaxCopy();
+    StaticAssertStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class SwitchStatement : public Statement
@@ -443,10 +443,10 @@ public:
     int hasVars;                // !=0 if has variable case values
     VarDeclaration *lastVar;
 
-    SwitchStatement *syntaxCopy();
-    bool hasBreak() const;
+    SwitchStatement *syntaxCopy() override;
+    bool hasBreak() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class CaseStatement : public Statement
@@ -459,9 +459,9 @@ public:
     VarDeclaration *lastVar;
     void* extra;            // for use by Statement_toIR()
 
-    CaseStatement *syntaxCopy();
+    CaseStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 
@@ -472,8 +472,8 @@ public:
     Expression *last;
     Statement *statement;
 
-    CaseRangeStatement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    CaseRangeStatement *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 
@@ -483,9 +483,9 @@ public:
     Statement *statement;
     VarDeclaration *lastVar;
 
-    DefaultStatement *syntaxCopy();
+    DefaultStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class GotoDefaultStatement : public Statement
@@ -493,9 +493,9 @@ class GotoDefaultStatement : public Statement
 public:
     SwitchStatement *sw;
 
-    GotoDefaultStatement *syntaxCopy();
+    GotoDefaultStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class GotoCaseStatement : public Statement
@@ -504,9 +504,9 @@ public:
     Expression *exp;            // NULL, or which case to goto
     CaseStatement *cs;          // case statement it resolves to
 
-    GotoCaseStatement *syntaxCopy();
+    GotoCaseStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class SwitchErrorStatement : public Statement
@@ -514,7 +514,7 @@ class SwitchErrorStatement : public Statement
 public:
     Expression *exp;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ReturnStatement : public Statement
@@ -523,10 +523,10 @@ public:
     Expression *exp;
     size_t caseDim;
 
-    ReturnStatement *syntaxCopy();
+    ReturnStatement *syntaxCopy() override;
 
-    ReturnStatement *endsWithReturnStatement() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    ReturnStatement *endsWithReturnStatement() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class BreakStatement : public Statement
@@ -534,9 +534,9 @@ class BreakStatement : public Statement
 public:
     Identifier *ident;
 
-    BreakStatement *syntaxCopy();
+    BreakStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ContinueStatement : public Statement
@@ -544,9 +544,9 @@ class ContinueStatement : public Statement
 public:
     Identifier *ident;
 
-    ContinueStatement *syntaxCopy();
+    ContinueStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class SynchronizedStatement : public Statement
@@ -555,11 +555,11 @@ public:
     Expression *exp;
     Statement *_body;
 
-    SynchronizedStatement *syntaxCopy();
-    bool hasBreak() const;
-    bool hasContinue() const;
+    SynchronizedStatement *syntaxCopy() override;
+    bool hasBreak() const override;
+    bool hasContinue() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class WithStatement : public Statement
@@ -570,9 +570,9 @@ public:
     VarDeclaration *wthis;
     Loc endloc;
 
-    WithStatement *syntaxCopy();
+    WithStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TryCatchStatement : public Statement
@@ -583,10 +583,10 @@ public:
 
     Statement *tryBody;   /// set to enclosing TryCatchStatement or TryFinallyStatement if in _body portion
 
-    TryCatchStatement *syntaxCopy();
-    bool hasBreak() const;
+    TryCatchStatement *syntaxCopy() override;
+    bool hasBreak() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class Catch : public RootObject
@@ -618,11 +618,11 @@ public:
     bool bodyFallsThru;   // true if _body falls through to finally
 
     static TryFinallyStatement *create(const Loc &loc, Statement *body, Statement *finalbody);
-    TryFinallyStatement *syntaxCopy();
-    bool hasBreak() const;
-    bool hasContinue() const;
+    TryFinallyStatement *syntaxCopy() override;
+    bool hasBreak() const override;
+    bool hasContinue() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ScopeGuardStatement : public Statement
@@ -631,9 +631,9 @@ public:
     TOK tok;
     Statement *statement;
 
-    ScopeGuardStatement *syntaxCopy();
+    ScopeGuardStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ThrowStatement : public Statement
@@ -644,9 +644,9 @@ public:
     // wasn't present in source code
     bool internalThrow;
 
-    ThrowStatement *syntaxCopy();
+    ThrowStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class DebugStatement : public Statement
@@ -654,8 +654,8 @@ class DebugStatement : public Statement
 public:
     Statement *statement;
 
-    DebugStatement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    DebugStatement *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class GotoStatement : public Statement
@@ -668,9 +668,9 @@ public:
     ScopeGuardStatement *os;
     VarDeclaration *lastVar;
 
-    GotoStatement *syntaxCopy();
+    GotoStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class LabelStatement : public Statement
@@ -686,9 +686,9 @@ public:
     void* extra;                // used by Statement_toIR()
     bool breaks;                // someone did a 'break ident'
 
-    LabelStatement *syntaxCopy();
+    LabelStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class LabelDsymbol : public Dsymbol
@@ -700,8 +700,8 @@ public:
     bool iasm;              // set if used by inline assembler
 
     static LabelDsymbol *create(Identifier *ident);
-    LabelDsymbol *isLabel();
-    void accept(Visitor *v) { v->visit(this); }
+    LabelDsymbol *isLabel() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 Statement* asmSemantic(AsmStatement *s, Scope *sc);
@@ -711,8 +711,8 @@ class AsmStatement : public Statement
 public:
     Token *tokens;
 
-    AsmStatement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    AsmStatement *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class InlineAsmStatement : public AsmStatement
@@ -724,8 +724,8 @@ public:
     bool refparam;              // true if function parameter is referenced
     bool naked;                 // true if function is to be naked
 
-    InlineAsmStatement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    InlineAsmStatement *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // A GCC asm statement - assembler instructions with D expression operands
@@ -742,8 +742,8 @@ public:
     Identifiers *labels;        // list of goto labels
     GotoStatements *gotos;      // of the goto labels, the equivalent statements they represent
 
-    GccAsmStatement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    GccAsmStatement *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // a complete asm {} block
@@ -752,9 +752,9 @@ class CompoundAsmStatement : public CompoundStatement
 public:
     StorageClass stc; // postfix attributes like nothrow/pure/@trusted
 
-    CompoundAsmStatement *syntaxCopy();
+    CompoundAsmStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class ImportStatement : public Statement
@@ -762,7 +762,7 @@ class ImportStatement : public Statement
 public:
     Dsymbols *imports;          // Array of Import's
 
-    ImportStatement *syntaxCopy();
+    ImportStatement *syntaxCopy() override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/staticassert.h
+++ b/src/dmd/staticassert.h
@@ -20,10 +20,10 @@ public:
     Expression *exp;
     Expression *msg;
 
-    StaticAssert *syntaxCopy(Dsymbol *s);
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    bool oneMember(Dsymbol **ps, Identifier *ident);
-    const char *kind() const;
-    StaticAssert *isStaticAssert() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    StaticAssert *syntaxCopy(Dsymbol *s) override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    const char *kind() const override;
+    StaticAssert *isStaticAssert() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -34,9 +34,9 @@ public:
     Objects objects;
 
     // kludge for template.isType()
-    DYNCAST dyncast() const { return DYNCAST_TUPLE; }
+    DYNCAST dyncast() const override { return DYNCAST_TUPLE; }
 
-    const char *toChars() const { return objects.toChars(); }
+    const char *toChars() const override { return objects.toChars(); }
 };
 
 struct TemplatePrevious
@@ -74,24 +74,24 @@ public:
 
     TemplatePrevious *previous;         // threaded list of previous instantiation attempts on stack
 
-    TemplateDeclaration *syntaxCopy(Dsymbol *);
-    bool overloadInsert(Dsymbol *s);
-    bool hasStaticCtorOrDtor();
-    const char *kind() const;
-    const char *toChars() const;
+    TemplateDeclaration *syntaxCopy(Dsymbol *) override;
+    bool overloadInsert(Dsymbol *s) override;
+    bool hasStaticCtorOrDtor() override;
+    const char *kind() const override;
+    const char *toChars() const override;
 
-    Visibility visible();
+    Visibility visible() override;
 
     MATCH leastAsSpecialized(Scope *sc, TemplateDeclaration *td2, Expressions *fargs);
     RootObject *declareParameter(Scope *sc, TemplateParameter *tp, RootObject *o);
 
-    TemplateDeclaration *isTemplateDeclaration() { return this; }
+    TemplateDeclaration *isTemplateDeclaration() override { return this; }
 
     TemplateTupleParameter *isVariadic();
-    bool isDeprecated() const;
-    bool isOverloadable() const;
+    bool isDeprecated() const override;
+    bool isOverloadable() const override;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /* For type-parameter:
@@ -134,12 +134,12 @@ public:
     virtual RootObject *defaultArg(const Loc &instLoc, Scope *sc) = 0;
     virtual bool hasDefaultArg() = 0;
 
-    DYNCAST dyncast() const { return DYNCAST_TEMPLATEPARAMETER; }
+    DYNCAST dyncast() const override { return DYNCAST_TEMPLATEPARAMETER; }
 
     /* Create dummy argument based on parameter.
      */
     virtual RootObject *dummyArg() = 0;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /* Syntax:
@@ -151,15 +151,15 @@ public:
     Type *specType;     // type parameter: if !=NULL, this is the type specialization
     Type *defaultType;
 
-    TemplateTypeParameter *isTemplateTypeParameter();
-    TemplateTypeParameter *syntaxCopy();
-    bool declareParameter(Scope *sc);
-    void print(RootObject *oarg, RootObject *oded);
-    RootObject *specialization();
-    RootObject *defaultArg(const Loc &instLoc, Scope *sc);
-    bool hasDefaultArg();
-    RootObject *dummyArg();
-    void accept(Visitor *v) { v->visit(this); }
+    TemplateTypeParameter *isTemplateTypeParameter() override;
+    TemplateTypeParameter *syntaxCopy() override;
+    bool declareParameter(Scope *sc) override;
+    void print(RootObject *oarg, RootObject *oded) override;
+    RootObject *specialization() override;
+    RootObject *defaultArg(const Loc &instLoc, Scope *sc) override;
+    bool hasDefaultArg() override;
+    RootObject *dummyArg() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /* Syntax:
@@ -168,9 +168,9 @@ public:
 class TemplateThisParameter : public TemplateTypeParameter
 {
 public:
-    TemplateThisParameter *isTemplateThisParameter();
-    TemplateThisParameter *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    TemplateThisParameter *isTemplateThisParameter() override;
+    TemplateThisParameter *syntaxCopy() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /* Syntax:
@@ -183,15 +183,15 @@ public:
     Expression *specValue;
     Expression *defaultValue;
 
-    TemplateValueParameter *isTemplateValueParameter();
-    TemplateValueParameter *syntaxCopy();
-    bool declareParameter(Scope *sc);
-    void print(RootObject *oarg, RootObject *oded);
-    RootObject *specialization();
-    RootObject *defaultArg(const Loc &instLoc, Scope *sc);
-    bool hasDefaultArg();
-    RootObject *dummyArg();
-    void accept(Visitor *v) { v->visit(this); }
+    TemplateValueParameter *isTemplateValueParameter() override;
+    TemplateValueParameter *syntaxCopy() override;
+    bool declareParameter(Scope *sc) override;
+    void print(RootObject *oarg, RootObject *oded) override;
+    RootObject *specialization() override;
+    RootObject *defaultArg(const Loc &instLoc, Scope *sc) override;
+    bool hasDefaultArg() override;
+    RootObject *dummyArg() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /* Syntax:
@@ -204,15 +204,15 @@ public:
     RootObject *specAlias;
     RootObject *defaultAlias;
 
-    TemplateAliasParameter *isTemplateAliasParameter();
-    TemplateAliasParameter *syntaxCopy();
-    bool declareParameter(Scope *sc);
-    void print(RootObject *oarg, RootObject *oded);
-    RootObject *specialization();
-    RootObject *defaultArg(const Loc &instLoc, Scope *sc);
-    bool hasDefaultArg();
-    RootObject *dummyArg();
-    void accept(Visitor *v) { v->visit(this); }
+    TemplateAliasParameter *isTemplateAliasParameter() override;
+    TemplateAliasParameter *syntaxCopy() override;
+    bool declareParameter(Scope *sc) override;
+    void print(RootObject *oarg, RootObject *oded) override;
+    RootObject *specialization() override;
+    RootObject *defaultArg(const Loc &instLoc, Scope *sc) override;
+    bool hasDefaultArg() override;
+    RootObject *dummyArg() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /* Syntax:
@@ -221,15 +221,15 @@ public:
 class TemplateTupleParameter : public TemplateParameter
 {
 public:
-    TemplateTupleParameter *isTemplateTupleParameter();
-    TemplateTupleParameter *syntaxCopy();
-    bool declareParameter(Scope *sc);
-    void print(RootObject *oarg, RootObject *oded);
-    RootObject *specialization();
-    RootObject *defaultArg(const Loc &instLoc, Scope *sc);
-    bool hasDefaultArg();
-    RootObject *dummyArg();
-    void accept(Visitor *v) { v->visit(this); }
+    TemplateTupleParameter *isTemplateTupleParameter() override;
+    TemplateTupleParameter *syntaxCopy() override;
+    bool declareParameter(Scope *sc) override;
+    void print(RootObject *oarg, RootObject *oded) override;
+    RootObject *specialization() override;
+    RootObject *defaultArg(const Loc &instLoc, Scope *sc) override;
+    bool hasDefaultArg() override;
+    RootObject *dummyArg() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 /* Given:
@@ -277,20 +277,20 @@ private:
 public:
     unsigned char inuse;                 // for recursive expansion detection
 
-    TemplateInstance *syntaxCopy(Dsymbol *);
-    Dsymbol *toAlias();                 // resolve real symbol
-    const char *kind() const;
-    bool oneMember(Dsymbol **ps, Identifier *ident);
-    const char *toChars() const;
-    const char* toPrettyCharsHelper();
-    Identifier *getIdent();
+    TemplateInstance *syntaxCopy(Dsymbol *) override;
+    Dsymbol *toAlias() override;         // resolve real symbol
+    const char *kind() const override;
+    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    const char *toChars() const override;
+    const char* toPrettyCharsHelper() override;
+    Identifier *getIdent() override;
     hash_t toHash();
 
     bool isDiscardable();
     bool needsCodegen();
 
-    TemplateInstance *isTemplateInstance() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    TemplateInstance *isTemplateInstance() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class TemplateMixin : public TemplateInstance
@@ -298,15 +298,15 @@ class TemplateMixin : public TemplateInstance
 public:
     TypeQualified *tqual;
 
-    TemplateMixin *syntaxCopy(Dsymbol *s);
-    const char *kind() const;
-    bool oneMember(Dsymbol **ps, Identifier *ident);
-    bool hasPointers();
-    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
-    const char *toChars() const;
+    TemplateMixin *syntaxCopy(Dsymbol *s) override;
+    const char *kind() const override;
+    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    bool hasPointers() override;
+    void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion) override;
+    const char *toChars() const override;
 
-    TemplateMixin *isTemplateMixin() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    TemplateMixin *isTemplateMixin() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 Expression *isExpression(RootObject *o);

--- a/src/dmd/version.h
+++ b/src/dmd/version.h
@@ -17,13 +17,13 @@ class DebugSymbol : public Dsymbol
 public:
     unsigned level;
 
-    DebugSymbol *syntaxCopy(Dsymbol *);
+    DebugSymbol *syntaxCopy(Dsymbol *) override;
 
-    const char *toChars() const;
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    const char *kind() const;
-    DebugSymbol *isDebugSymbol();
-    void accept(Visitor *v) { v->visit(this); }
+    const char *toChars() const override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    const char *kind() const override;
+    DebugSymbol *isDebugSymbol() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 class VersionSymbol : public Dsymbol
@@ -31,11 +31,11 @@ class VersionSymbol : public Dsymbol
 public:
     unsigned level;
 
-    VersionSymbol *syntaxCopy(Dsymbol *);
+    VersionSymbol *syntaxCopy(Dsymbol *) override;
 
-    const char *toChars() const;
-    void addMember(Scope *sc, ScopeDsymbol *sds);
-    const char *kind() const;
-    VersionSymbol *isVersionSymbol();
-    void accept(Visitor *v) { v->visit(this); }
+    const char *toChars() const override;
+    void addMember(Scope *sc, ScopeDsymbol *sds) override;
+    const char *kind() const override;
+    VersionSymbol *isVersionSymbol() override;
+    void accept(Visitor *v) override { v->visit(this); }
 };

--- a/src/tests/cxxfrontend.cc
+++ b/src/tests/cxxfrontend.cc
@@ -143,52 +143,52 @@ class TestVisitor : public Visitor
     {
     }
 
-    void visit(Expression *)
+    void visit(Expression *) override
     {
         expr = true;
     }
 
-    void visit(IdentifierExp *)
+    void visit(IdentifierExp *) override
     {
         idexpr = true;
     }
 
-    void visit(Package *)
+    void visit(Package *) override
     {
         package = true;
     }
 
-    void visit(Statement *)
+    void visit(Statement *) override
     {
         stmt = true;
     }
 
-    void visit(AttribDeclaration *)
+    void visit(AttribDeclaration *) override
     {
         attrib = true;
     }
 
-    void visit(Declaration *)
+    void visit(Declaration *) override
     {
         decl = true;
     }
 
-    void visit(AggregateDeclaration *)
+    void visit(AggregateDeclaration *) override
     {
         aggr = true;
     }
 
-    void visit(TypeNext *)
+    void visit(TypeNext *) override
     {
         type = true;
     }
 
-    void visit(TypeInfoDeclaration *)
+    void visit(TypeInfoDeclaration *) override
     {
         typeinfo = true;
     }
 
-    void visit(FuncDeclaration *)
+    void visit(FuncDeclaration *) override
     {
         function = true;
     }
@@ -572,11 +572,11 @@ public:
     {
     }
 
-    void visit(Type *) { assert(0); }
-    void visit(TypeError *t) { (void)t->ctype; }
-    void visit(TypeNull *t) { (void)t->ctype; }
-    void visit(TypeNoreturn *t) { (void)t->ctype; }
-    void visit(TypeBasic *t)
+    void visit(Type *) override { assert(0); }
+    void visit(TypeError *t) override { (void)t->ctype; }
+    void visit(TypeNull *t) override { (void)t->ctype; }
+    void visit(TypeNoreturn *t) override { (void)t->ctype; }
+    void visit(TypeBasic *t) override
     {
         switch (t->ty)
         {
@@ -610,19 +610,19 @@ public:
         }
         (void)t->toChars();
     }
-    void visit(TypePointer *t)
+    void visit(TypePointer *t) override
     {
         t->next->accept(this);
         (void)t->ctype;
     }
-    void visit(TypeDArray *t)
+    void visit(TypeDArray *t) override
     {
         t->next->accept(this);
         Type::tsize_t->accept(this);
         (void)t->ctype;
         (void)t->toChars();
     }
-    void visit(TypeSArray *t)
+    void visit(TypeSArray *t) override
     {
         if (t->dim->isConst() && t->dim->type->isintegral())
         {
@@ -633,7 +633,7 @@ public:
         else
             assert(0);
     }
-    void visit(TypeVector *t)
+    void visit(TypeVector *t) override
     {
         (void)t->basetype->isTypeSArray()->dim->toUInteger();
         t->elementType()->accept(this);
@@ -642,12 +642,12 @@ public:
         (void)t->ctype;
         (void)t->toChars();
     }
-    void visit(TypeAArray *t)
+    void visit(TypeAArray *t) override
     {
         (void)t->ctype;
         (void)t->toChars();
     }
-    void visit(TypeFunction *t)
+    void visit(TypeFunction *t) override
     {
         if (t->isDstyleVariadic())
             Type::typeinfotypelist->type->accept(this);
@@ -677,7 +677,7 @@ public:
             assert(0);
         }
     }
-    void visit(TypeDelegate *t)
+    void visit(TypeDelegate *t) override
     {
         t->next->accept(this);
         Type::tvoidptr->accept(this);
@@ -715,7 +715,7 @@ public:
             }
         }
     }
-    void visit(TypeEnum *t)
+    void visit(TypeEnum *t) override
     {
         if (t->sym->memtype)
             t->sym->memtype->accept(this);
@@ -747,7 +747,7 @@ public:
         }
         visitUserAttributes(t->sym);
     }
-    void visit(TypeStruct *t)
+    void visit(TypeStruct *t) override
     {
         t->sym->accept(this);
         (void)t->sym->isUnionDeclaration();
@@ -797,7 +797,7 @@ public:
         }
         visitUserAttributes(t->sym);
     }
-    void visit(TypeClass *t)
+    void visit(TypeClass *t) override
     {
         t->sym->accept(this);
         (void)t->ctype;
@@ -868,9 +868,9 @@ public:
         }
         visitUserAttributes(t->sym);
     }
-    void visit(Statement *) { assert(0); }
-    void visit(ScopeGuardStatement *) { }
-    void visit(IfStatement *s)
+    void visit(Statement *) override { assert(0); }
+    void visit(ScopeGuardStatement *) override { }
+    void visit(IfStatement *s) override
     {
         s->condition->accept(this);
         s->condition->type->accept(this);
@@ -879,9 +879,9 @@ public:
         if (s->elsebody)
             s->elsebody->accept(this);
     }
-    void visit(PragmaStatement *) { }
-    void visit(WhileStatement *) { assert(0); }
-    void visit(DoStatement *s)
+    void visit(PragmaStatement *) override { }
+    void visit(WhileStatement *) override { assert(0); }
+    void visit(DoStatement *s) override
     {
         s->getRelatedLabeled()->accept(this);
         if (s->_body)
@@ -889,7 +889,7 @@ public:
         s->condition->accept(this);
         s->condition->type->accept(this);
     }
-    void visit(ForStatement *s)
+    void visit(ForStatement *s) override
     {
         s->getRelatedLabeled()->accept(this);
         if (s->_init)
@@ -904,9 +904,9 @@ public:
         if (s->increment)
             s->increment->accept(this);
     }
-    void visit(ForeachStatement *) { assert(0); }
-    void visit(ForeachRangeStatement *) { assert(0); }
-    void visit(BreakStatement *s)
+    void visit(ForeachStatement *) override { assert(0); }
+    void visit(ForeachRangeStatement *) override { assert(0); }
+    void visit(BreakStatement *s) override
     {
         if (s->ident)
         {
@@ -915,7 +915,7 @@ public:
             label->statement->getRelatedLabeled()->accept(this);
         }
     }
-    void visit(ContinueStatement *s)
+    void visit(ContinueStatement *s) override
     {
         if (s->ident)
         {
@@ -924,13 +924,13 @@ public:
             label->statement->accept(this);
         }
     }
-    void visit(GotoStatement *s)
+    void visit(GotoStatement *s) override
     {
         assert(s->label->statement != NULL);
         assert(s->tf == s->label->statement->tf);
         (void)s->label->ident;
     }
-    void visit(LabelStatement *s)
+    void visit(LabelStatement *s) override
     {
         LabelDsymbol *sym;
         if (func->returnLabel && func->returnLabel->ident == s->ident)
@@ -943,7 +943,7 @@ public:
         else if (s->statement)
             s->statement->accept(this);
     }
-    void visit(SwitchStatement *s)
+    void visit(SwitchStatement *s) override
     {
         s->getRelatedLabeled()->accept(this);
         s->condition->accept(this);
@@ -963,7 +963,7 @@ public:
         if (s->_body)
             s->_body->accept(this);
     }
-    void visit(CaseStatement *s)
+    void visit(CaseStatement *s) override
     {
         s->getRelatedLabeled()->accept(this);
         if (s->exp->type->isscalar())
@@ -973,25 +973,25 @@ public:
         if (s->statement)
             s->statement->accept(this);
     }
-    void visit(DefaultStatement *s)
+    void visit(DefaultStatement *s) override
     {
         s->getRelatedLabeled()->accept(this);
         if (s->statement)
             s->statement->accept(this);
     }
-    void visit(GotoDefaultStatement *s)
+    void visit(GotoDefaultStatement *s) override
     {
         s->sw->sdefault->accept(this);
     }
-    void visit(GotoCaseStatement *s)
+    void visit(GotoCaseStatement *s) override
     {
         s->cs->accept(this);
     }
-    void visit(SwitchErrorStatement *s)
+    void visit(SwitchErrorStatement *s) override
     {
         s->exp->accept(this);
     }
-    void visit(ReturnStatement *s)
+    void visit(ReturnStatement *s) override
     {
         if (s->exp == NULL || s->exp->type->toBasetype()->ty == TY::Tvoid)
             return;
@@ -1038,12 +1038,12 @@ public:
         else
             s->exp->accept(this);
     }
-    void visit(ExpStatement *s)
+    void visit(ExpStatement *s) override
     {
         if (s->exp)
             s->exp->accept(this);
     }
-    void visit(CompoundStatement *s)
+    void visit(CompoundStatement *s) override
     {
         if (s->statements == NULL)
             return;
@@ -1054,7 +1054,7 @@ public:
                 statement->accept(this);
         }
     }
-    void visit(UnrolledLoopStatement *s)
+    void visit(UnrolledLoopStatement *s) override
     {
         if (s->statements == NULL)
             return;
@@ -1066,13 +1066,13 @@ public:
                 statement->accept(this);
         }
     }
-    void visit(ScopeStatement *s)
+    void visit(ScopeStatement *s) override
     {
         if (s->statement == NULL)
             return;
         s->statement->accept(this);
     }
-    void visit(WithStatement *s)
+    void visit(WithStatement *s) override
     {
         if (s->wthis)
         {
@@ -1082,12 +1082,12 @@ public:
         if (s->_body)
             s->_body->accept(this);
     }
-    void visit(ThrowStatement *s)
+    void visit(ThrowStatement *s) override
     {
         s->exp->type->toBasetype()->isClassHandle()->accept(this);
         s->exp->accept(this);
     }
-    void visit(TryCatchStatement *s)
+    void visit(TryCatchStatement *s) override
     {
         if (s->_body)
             s->_body->accept(this);
@@ -1105,22 +1105,22 @@ public:
             }
         }
     }
-    void visit(TryFinallyStatement *s)
+    void visit(TryFinallyStatement *s) override
     {
         if (s->_body)
             s->_body->accept(this);
         if (s->finalbody)
             s->finalbody->accept(this);
     }
-    void visit(SynchronizedStatement *)
+    void visit(SynchronizedStatement *) override
     {
         assert(0);
     }
-    void visit(AsmStatement *)
+    void visit(AsmStatement *) override
     {
         assert(0);
     }
-    void visit(GccAsmStatement *s)
+    void visit(GccAsmStatement *s) override
     {
         s->insn->accept(this);
         if (s->args)
@@ -1149,7 +1149,7 @@ public:
             }
         }
     }
-    void visit(ImportStatement *s)
+    void visit(ImportStatement *s) override
     {
         if (s->imports == NULL)
             return;
@@ -1160,8 +1160,8 @@ public:
                 dsym->accept(this);
         }
     }
-    void visit(Dsymbol *) { assert(0); }
-    void visit(Module *d)
+    void visit(Dsymbol *) override { assert(0); }
+    void visit(Module *d) override
     {
         if (d->semanticRun >= PASS::obj)
             return;
@@ -1195,7 +1195,7 @@ public:
         }
         d->semanticRun = PASS::obj;
     }
-    void visit(Import *d)
+    void visit(Import *d) override
     {
         if (d->semanticRun >= PASS::obj)
             return;
@@ -1213,7 +1213,7 @@ public:
             d->mod->accept(this);
         d->semanticRun = PASS::obj;
     }
-    void visit(TupleDeclaration *d)
+    void visit(TupleDeclaration *d) override
     {
         for (size_t i = 0; i < d->objects->length; i++)
         {
@@ -1226,7 +1226,7 @@ public:
             }
         }
     }
-    void visit(AttribDeclaration *d)
+    void visit(AttribDeclaration *d) override
     {
         Dsymbols *ds = d->include(NULL);
         if (!ds)
@@ -1234,23 +1234,23 @@ public:
         for (size_t i = 0; i < ds->length; i++)
             (*ds)[i]->accept(this);
     }
-    void visit(PragmaDeclaration *d)
+    void visit(PragmaDeclaration *d) override
     {
         visit((AttribDeclaration *)d);
     }
-    void visit(ConditionalDeclaration *d)
+    void visit(ConditionalDeclaration *d) override
     {
         (void)d->condition->isVersionCondition();
         visit((AttribDeclaration *)d);
     }
-    void visit(Nspace *d)
+    void visit(Nspace *d) override
     {
         if (isError(d) || !d->members)
             return;
         for (size_t i = 0; i < d->members->length; i++)
             (*d->members)[i]->accept(this);
     }
-    void visit(TemplateDeclaration *d)
+    void visit(TemplateDeclaration *d) override
     {
         if (!func || !func->isAuto())
             return;
@@ -1265,7 +1265,7 @@ public:
         if (ti && ti->tempdecl == d)
             ti->accept(this);
     }
-    void visit(TemplateInstance *d)
+    void visit(TemplateInstance *d) override
     {
         if (isError(d) || !d->members)
             return;
@@ -1274,14 +1274,14 @@ public:
         for (size_t i = 0; i < d->members->length; i++)
             (*d->members)[i]->accept(this);
     }
-    void visit(TemplateMixin *d)
+    void visit(TemplateMixin *d) override
     {
         if (isError(d) || !d->members)
             return;
         for (size_t i = 0; i < d->members->length; i++)
             (*d->members)[i]->accept(this);
     }
-    void visit(StructDeclaration *d)
+    void visit(StructDeclaration *d) override
     {
         if (d->semanticRun >= PASS::obj)
             return;
@@ -1306,7 +1306,7 @@ public:
             d->xhash->accept(this);
         d->semanticRun = PASS::obj;
     }
-    void visit(ClassDeclaration *d)
+    void visit(ClassDeclaration *d) override
     {
         if (d->semanticRun >= PASS::obj)
             return;
@@ -1403,7 +1403,7 @@ public:
         d->type->accept(this);
         d->semanticRun = PASS::obj;
     }
-    void visit(InterfaceDeclaration *d)
+    void visit(InterfaceDeclaration *d) override
     {
         if (d->semanticRun >= PASS::obj)
             return;
@@ -1417,7 +1417,7 @@ public:
         d->type->accept(this);
         d->semanticRun = PASS::obj;
     }
-    void visit(EnumDeclaration *d)
+    void visit(EnumDeclaration *d) override
     {
         if (d->semanticRun >= PASS::obj)
             return;
@@ -1523,7 +1523,7 @@ public:
             (void)decl->csym;
         visitUserAttributes(decl);
     }
-    void visit(VarDeclaration *d)
+    void visit(VarDeclaration *d) override
     {
         if (d->semanticRun >= PASS::obj)
             return;
@@ -1581,14 +1581,14 @@ public:
         d->type->accept(this);
         d->semanticRun = PASS::obj;
     }
-    void visit(TypeInfoDeclaration *d)
+    void visit(TypeInfoDeclaration *d) override
     {
         if (d->semanticRun >= PASS::obj)
             return;
         visitDeclaration(d);
         d->semanticRun = PASS::obj;
     }
-    void visit(FuncDeclaration *d)
+    void visit(FuncDeclaration *d) override
     {
         if (d->semanticRun >= PASS::obj)
             return;


### PR DESCRIPTION
With C++11 we can add `override` to the decls of virtual funcs in derived classes, which documents to both human and automated readers of the code that a decl is intended to override a virtual func in a base class, and can help catch mistakes where we intended to override a virtual func, but messed up the prototypes between the D sources and C++ headers.