### PR TITLE
dmd.mtype: Remove const from extern(C++) methods that override mutable virtual

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3380,10 +3380,10 @@ public:
     static TypeAArray* create(Type* t, Type* index);
     const char* kind() const;
     TypeAArray* syntaxCopy();
-    uinteger_t size(const Loc& loc) /* const */;
-    bool isZeroInit(const Loc& loc) /* const */;
-    bool isBoolean() /* const */;
-    bool hasPointers() /* const */;
+    uinteger_t size(const Loc& loc);
+    bool isZeroInit(const Loc& loc);
+    bool isBoolean();
+    bool hasPointers();
     MATCH implicitConvTo(Type* to);
     MATCH constConv(Type* to);
     void accept(Visitor* v);
@@ -3396,17 +3396,17 @@ public:
     uint32_t flags;
     const char* kind() const;
     TypeBasic* syntaxCopy();
-    uinteger_t size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc);
     uint32_t alignsize();
     bool isintegral();
-    bool isfloating() /* const */;
-    bool isreal() /* const */;
-    bool isimaginary() /* const */;
-    bool iscomplex() /* const */;
-    bool isscalar() /* const */;
-    bool isunsigned() /* const */;
+    bool isfloating();
+    bool isreal();
+    bool isimaginary();
+    bool iscomplex();
+    bool isscalar();
+    bool isunsigned();
     MATCH implicitConvTo(Type* to);
-    bool isZeroInit(const Loc& loc) /* const */;
+    bool isZeroInit(const Loc& loc);
     TypeBasic* isTypeBasic();
     void accept(Visitor* v);
 };
@@ -3428,7 +3428,7 @@ public:
     AliasThisRec att;
     CPPMANGLE cppmangle;
     const char* kind() const;
-    uinteger_t size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc);
     TypeClass* syntaxCopy();
     Dsymbol* toDsymbol(Scope* sc);
     ClassDeclaration* isClassHandle();
@@ -3437,10 +3437,10 @@ public:
     MATCH constConv(Type* to);
     uint8_t deduceWild(Type* t, bool isRef);
     Type* toHeadMutable();
-    bool isZeroInit(const Loc& loc) /* const */;
-    bool isscope() /* const */;
-    bool isBoolean() /* const */;
-    bool hasPointers() /* const */;
+    bool isZeroInit(const Loc& loc);
+    bool isscope();
+    bool isBoolean();
+    bool hasPointers();
     void accept(Visitor* v);
 };
 
@@ -3449,13 +3449,13 @@ class TypeDArray final : public TypeArray
 public:
     const char* kind() const;
     TypeDArray* syntaxCopy();
-    uinteger_t size(const Loc& loc) /* const */;
-    uint32_t alignsize() /* const */;
+    uinteger_t size(const Loc& loc);
+    uint32_t alignsize();
     bool isString();
-    bool isZeroInit(const Loc& loc) /* const */;
-    bool isBoolean() /* const */;
+    bool isZeroInit(const Loc& loc);
+    bool isBoolean();
     MATCH implicitConvTo(Type* to);
-    bool hasPointers() /* const */;
+    bool hasPointers();
     void accept(Visitor* v);
 };
 
@@ -3466,12 +3466,12 @@ public:
     const char* kind() const;
     TypeDelegate* syntaxCopy();
     Type* addStorageClass(StorageClass stc);
-    uinteger_t size(const Loc& loc) /* const */;
-    uint32_t alignsize() /* const */;
+    uinteger_t size(const Loc& loc);
+    uint32_t alignsize();
     MATCH implicitConvTo(Type* to);
-    bool isZeroInit(const Loc& loc) /* const */;
-    bool isBoolean() /* const */;
-    bool hasPointers() /* const */;
+    bool isZeroInit(const Loc& loc);
+    bool isBoolean();
+    bool hasPointers();
     void accept(Visitor* v);
 };
 
@@ -3689,8 +3689,8 @@ public:
     TypeNoreturn* syntaxCopy();
     MATCH implicitConvTo(Type* to);
     MATCH constConv(Type* to);
-    bool isBoolean() /* const */;
-    uinteger_t size(const Loc& loc) /* const */;
+    bool isBoolean();
+    uinteger_t size(const Loc& loc);
     uint32_t alignsize();
     void accept(Visitor* v);
 };
@@ -3702,8 +3702,8 @@ public:
     TypeNull* syntaxCopy();
     MATCH implicitConvTo(Type* to);
     bool hasPointers();
-    bool isBoolean() /* const */;
-    uinteger_t size(const Loc& loc) /* const */;
+    bool isBoolean();
+    uinteger_t size(const Loc& loc);
     void accept(Visitor* v);
 };
 
@@ -3713,12 +3713,12 @@ public:
     static TypePointer* create(Type* t);
     const char* kind() const;
     TypePointer* syntaxCopy();
-    uinteger_t size(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc);
     MATCH implicitConvTo(Type* to);
     MATCH constConv(Type* to);
-    bool isscalar() /* const */;
-    bool isZeroInit(const Loc& loc) /* const */;
-    bool hasPointers() /* const */;
+    bool isscalar();
+    bool isZeroInit(const Loc& loc);
+    bool hasPointers();
     void accept(Visitor* v);
 };
 
@@ -3727,8 +3727,8 @@ class TypeReference final : public TypeNext
 public:
     const char* kind() const;
     TypeReference* syntaxCopy();
-    uinteger_t size(const Loc& loc) /* const */;
-    bool isZeroInit(const Loc& loc) /* const */;
+    uinteger_t size(const Loc& loc);
+    bool isZeroInit(const Loc& loc);
     void accept(Visitor* v);
 };
 
@@ -3790,8 +3790,8 @@ public:
     Expression* defaultInitLiteral(const Loc& loc);
     bool isZeroInit(const Loc& loc);
     bool isAssignable();
-    bool isBoolean() /* const */;
-    bool needsDestruction() /* const */;
+    bool isBoolean();
+    bool needsDestruction();
     bool needsCopyOrPostblit();
     bool needsNested();
     bool hasPointers();
@@ -3872,7 +3872,7 @@ public:
     bool isfloating();
     bool isscalar();
     bool isunsigned();
-    bool isBoolean() /* const */;
+    bool isBoolean();
     MATCH implicitConvTo(Type* to);
     Expression* defaultInitLiteral(const Loc& loc);
     TypeBasic* elementType();

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -3237,7 +3237,7 @@ extern (C++) final class TypeBasic : Type
         return this;
     }
 
-    override uinteger_t size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc)
     {
         uint size;
         //printf("TypeBasic::size()\n");
@@ -3325,32 +3325,32 @@ extern (C++) final class TypeBasic : Type
         return (flags & TFlags.integral) != 0;
     }
 
-    override bool isfloating() const
+    override bool isfloating()
     {
         return (flags & TFlags.floating) != 0;
     }
 
-    override bool isreal() const
+    override bool isreal()
     {
         return (flags & TFlags.real_) != 0;
     }
 
-    override bool isimaginary() const
+    override bool isimaginary()
     {
         return (flags & TFlags.imaginary) != 0;
     }
 
-    override bool iscomplex() const
+    override bool iscomplex()
     {
         return (flags & TFlags.complex) != 0;
     }
 
-    override bool isscalar() const
+    override bool isscalar()
     {
         return (flags & (TFlags.integral | TFlags.floating)) != 0;
     }
 
-    override bool isunsigned() const
+    override bool isunsigned()
     {
         return (flags & TFlags.unsigned) != 0;
     }
@@ -3447,7 +3447,7 @@ extern (C++) final class TypeBasic : Type
         return MATCH.convert;
     }
 
-    override bool isZeroInit(const ref Loc loc) const
+    override bool isZeroInit(const ref Loc loc)
     {
         switch (ty)
         {
@@ -3543,7 +3543,7 @@ extern (C++) final class TypeVector : Type
         return basetype.nextOf().isunsigned();
     }
 
-    override bool isBoolean() const
+    override bool isBoolean()
     {
         return false;
     }
@@ -3860,13 +3860,13 @@ extern (C++) final class TypeDArray : TypeArray
         return result;
     }
 
-    override uinteger_t size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc)
     {
         //printf("TypeDArray::size()\n");
         return target.ptrsize * 2;
     }
 
-    override uint alignsize() const
+    override uint alignsize()
     {
         // A DArray consists of two ptr-sized values, so align it on pointer size
         // boundary
@@ -3879,12 +3879,12 @@ extern (C++) final class TypeDArray : TypeArray
         return nty.isSomeChar;
     }
 
-    override bool isZeroInit(const ref Loc loc) const
+    override bool isZeroInit(const ref Loc loc)
     {
         return true;
     }
 
-    override bool isBoolean() const
+    override bool isBoolean()
     {
         return true;
     }
@@ -3918,7 +3918,7 @@ extern (C++) final class TypeDArray : TypeArray
         return Type.implicitConvTo(to);
     }
 
-    override bool hasPointers() const
+    override bool hasPointers()
     {
         return true;
     }
@@ -3964,22 +3964,22 @@ extern (C++) final class TypeAArray : TypeArray
         return result;
     }
 
-    override uinteger_t size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc)
     {
         return target.ptrsize;
     }
 
-    override bool isZeroInit(const ref Loc loc) const
+    override bool isZeroInit(const ref Loc loc)
     {
         return true;
     }
 
-    override bool isBoolean() const
+    override bool isBoolean()
     {
         return true;
     }
 
-    override bool hasPointers() const
+    override bool hasPointers()
     {
         return true;
     }
@@ -4056,7 +4056,7 @@ extern (C++) final class TypePointer : TypeNext
         return result;
     }
 
-    override uinteger_t size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc)
     {
         return target.ptrsize;
     }
@@ -4112,17 +4112,17 @@ extern (C++) final class TypePointer : TypeNext
         return TypeNext.constConv(to);
     }
 
-    override bool isscalar() const
+    override bool isscalar()
     {
         return true;
     }
 
-    override bool isZeroInit(const ref Loc loc) const
+    override bool isZeroInit(const ref Loc loc)
     {
         return true;
     }
 
-    override bool hasPointers() const
+    override bool hasPointers()
     {
         return true;
     }
@@ -4159,12 +4159,12 @@ extern (C++) final class TypeReference : TypeNext
         return result;
     }
 
-    override uinteger_t size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc)
     {
         return target.ptrsize;
     }
 
-    override bool isZeroInit(const ref Loc loc) const
+    override bool isZeroInit(const ref Loc loc)
     {
         return true;
     }
@@ -5156,12 +5156,12 @@ extern (C++) final class TypeDelegate : TypeNext
         return t;
     }
 
-    override uinteger_t size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc)
     {
         return target.ptrsize * 2;
     }
 
-    override uint alignsize() const
+    override uint alignsize()
     {
         return target.ptrsize;
     }
@@ -5189,17 +5189,17 @@ extern (C++) final class TypeDelegate : TypeNext
         return MATCH.nomatch;
     }
 
-    override bool isZeroInit(const ref Loc loc) const
+    override bool isZeroInit(const ref Loc loc)
     {
         return true;
     }
 
-    override bool isBoolean() const
+    override bool isBoolean()
     {
         return true;
     }
 
-    override bool hasPointers() const
+    override bool hasPointers()
     {
         return true;
     }
@@ -5748,12 +5748,12 @@ extern (C++) final class TypeStruct : Type
         return assignable;
     }
 
-    override bool isBoolean() const
+    override bool isBoolean()
     {
         return false;
     }
 
-    override bool needsDestruction() const
+    override bool needsDestruction()
     {
         return sym.dtor !is null;
     }
@@ -5985,6 +5985,7 @@ extern (C++) final class TypeEnum : Type
     {
         return sym.getMemtype(loc);
     }
+
     override uint alignsize()
     {
         Type t = memType();
@@ -6143,7 +6144,7 @@ extern (C++) final class TypeClass : Type
         return "class";
     }
 
-    override uinteger_t size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc)
     {
         return target.ptrsize;
     }
@@ -6268,22 +6269,22 @@ extern (C++) final class TypeClass : Type
         return this;
     }
 
-    override bool isZeroInit(const ref Loc loc) const
+    override bool isZeroInit(const ref Loc loc)
     {
         return true;
     }
 
-    override bool isscope() const
+    override bool isscope()
     {
         return sym.stack;
     }
 
-    override bool isBoolean() const
+    override bool isBoolean()
     {
         return true;
     }
 
-    override bool hasPointers() const
+    override bool hasPointers()
     {
         return true;
     }
@@ -6538,12 +6539,12 @@ extern (C++) final class TypeNull : Type
         return true;
     }
 
-    override bool isBoolean() const
+    override bool isBoolean()
     {
         return true;
     }
 
-    override uinteger_t size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc)
     {
         return tvoidptr.size(loc);
     }
@@ -6597,12 +6598,12 @@ extern (C++) final class TypeNoreturn : Type
         return this.implicitConvTo(to);
     }
 
-    override bool isBoolean() const
+    override bool isBoolean()
     {
         return true;  // bottom type can be implicitly converted to any other type
     }
 
-    override uinteger_t size(const ref Loc loc) const
+    override uinteger_t size(const ref Loc loc)
     {
         return 0;
     }


### PR DESCRIPTION
Workaround https://issues.dlang.org/show_bug.cgi?id=23135

C++ treats mutable and const member functions as distinct, unlike D where mutable->const is considered covariant.