### PR TITLE
chore(treewide): make dyncast() overrides use the default attributes

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5352,7 +5352,7 @@ extern (C++) class TemplateParameter : ASTNode
         return this.ident.toChars();
     }
 
-    override DYNCAST dyncast() const pure @nogc nothrow @safe
+    override DYNCAST dyncast() const
     {
         return DYNCAST.templateparameter;
     }

--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -44,7 +44,7 @@ extern (C++) class Initializer : ASTNode
     Loc loc;
     InitKind kind;
 
-    override DYNCAST dyncast() const nothrow pure
+    override DYNCAST dyncast() const
     {
         return DYNCAST.initializer;
     }


### PR DESCRIPTION
This can lead to missleading attribute "downcast" and is inconsistent
with the other overrided functions. Those attributes are ignored when
they don't have priviledge, which is part of a compiler bug.

This patch remove the duplicated applied attributes.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

We should either explicitly add all attributes to all overrides or none, not only on some.