### PR TITLE
fix(dsymbolsem): override methods should have semantic logic on attributes

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3592,6 +3592,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         break;
                     }
 
+                    auto vtf = getFunctionType(fdv);
+                    if (vtf.trust > TRUST.system && f.trust == TRUST.system)
+                        funcdecl.error("cannot override `@safe` method `%s` with a `@system` attribute",
+                                       fdv.toPrettyChars);
+
                     if (fdc.toParent() == parent)
                     {
                         //printf("vi = %d,\tthis = %p %s %s @ [%s]\n\tfdc  = %p %s %s @ [%s]\n\tfdv  = %p %s %s @ [%s]\n",

--- a/test/fail_compilation/fix23138.d
+++ b/test/fail_compilation/fix23138.d
@@ -1,0 +1,16 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fix23138.d(14): Error: function `fix23138.C2.foo` cannot override `@safe` method `fix23138.C1.foo` with a `@system` attribute
+---
+ */
+
+class C1 {
+    void foo() @safe
+    {}
+}
+
+class C2 : C1
+{
+    override void foo() @system
+    {}
+}


### PR DESCRIPTION
Fix issue 23138.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>