### PR TITLE
ci/cirrusci.sh: Remove brew update-reset from cirrusci script

### DIFF
--- a/ci/cirrusci.sh
+++ b/ci/cirrusci.sh
@@ -29,7 +29,6 @@ if [ "$OS_NAME" == "linux" ]; then
   apt-get install -yq $packages
 elif [ "$OS_NAME" == "darwin" ]; then
   # required for dlang install.sh
-  brew update-reset
   brew install gnupg libarchive xz llvm
 elif [ "$OS_NAME" == "freebsd" ]; then
   packages="git gmake devel/llvm12"


### PR DESCRIPTION
This step adds anywhere between 6-8 minutes to each OSX pipeline total times.  Lets find out what remains broken from the fallout of bintray shutting down its shop.