### PR TITLE
fix Issue 22351 - extern(C++) function contravariant in D, but not C++

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -3486,7 +3486,7 @@ struct ASTBase
             merge();
         }
 
-        override bool isscalar() const
+        override bool isscalar()
         {
             return (flags & (TFlags.integral | TFlags.floating)) != 0;
         }

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -801,24 +801,10 @@ public:
         if (adparent && fd.isDisabled && global.params.cplusplus < CppStdRevision.cpp11)
             writeProtection(AST.Visibility.Kind.private_);
         funcToBuffer(tf, fd);
-        // FIXME: How to determine if fd is const without tf?
-        if (adparent && tf && (tf.isConst() || tf.isImmutable()))
-        {
-            bool fdOverridesAreConst = true;
-            foreach (fdv; fd.foverrides)
-            {
-                auto tfv = cast(AST.TypeFunction)fdv.type;
-                if (!tfv.isConst() && !tfv.isImmutable())
-                {
-                    fdOverridesAreConst = false;
-                    break;
-                }
-            }
-
-            buf.writestring(fdOverridesAreConst ? " const" : " /* const */");
-        }
         if (adparent)
         {
+            if (tf && (tf.isConst() || tf.isImmutable()))
+                buf.writestring(" const");
             if (global.params.cplusplus >= CppStdRevision.cpp11)
             {
                 if (fd.vtblIndex != -1 && !(adparent.storage_class & AST.STC.final_) && fd.isFinalFunc())

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1745,14 +1745,6 @@ enum class TY : uint8_t
     TMAX = 48u,
 };
 
-enum class Covariant
-{
-    distinct = 0,
-    yes = 1,
-    no = 2,
-    fwdref = 3,
-};
-
 class Type : public ASTNode
 {
 public:
@@ -1861,7 +1853,6 @@ public:
     bool equivalent(Type* t);
     DYNCAST dyncast() const final override;
     size_t getUniqueID() const;
-    Covariant covariant(Type* t, uint64_t* pstc = nullptr, bool cppCovariant = false);
     const char* toChars() const final override;
     char* toPrettyChars(bool QualifyTypes = false);
     static void _init();
@@ -3285,6 +3276,14 @@ public:
 extern Initializer* initializerSemantic(Initializer* init, Scope* sc, Type*& tx, NeedInterpret needInterpret);
 
 extern Expression* initializerToExpression(Initializer* init, Type* itype = nullptr, const bool isCfile = false);
+
+enum class Covariant
+{
+    distinct = 0,
+    yes = 1,
+    no = 2,
+    fwdref = 3,
+};
 
 enum class DotExpFlag
 {

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1861,7 +1861,7 @@ public:
     bool equivalent(Type* t);
     DYNCAST dyncast() const final override;
     size_t getUniqueID() const;
-    Covariant covariant(Type* t, uint64_t* pstc = nullptr);
+    Covariant covariant(Type* t, uint64_t* pstc = nullptr, bool cppCovariant = false);
     const char* toChars() const final override;
     char* toPrettyChars(bool QualifyTypes = false);
     static void _init();

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -529,6 +529,7 @@ extern (C++) abstract class Type : ASTNode
      * Returns:
      *     An enum value of either `Covariant.yes` or a reason it's not covariant.
      */
+    extern (D)
     final Covariant covariant(Type t, StorageClass* pstc = null, bool cppCovariant = false)
     {
         version (none)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -525,10 +525,11 @@ extern (C++) abstract class Type : ASTNode
      * Params:
      *      t = type 'this' is covariant with
      *      pstc = if not null, store STCxxxx which would make it covariant
+     *      cppCovariant = true if extern(C++) function types should follow C++ covariant rules
      * Returns:
      *     An enum value of either `Covariant.yes` or a reason it's not covariant.
      */
-    final Covariant covariant(Type t, StorageClass* pstc = null)
+    final Covariant covariant(Type t, StorageClass* pstc = null, bool cppCovariant = false)
     {
         version (none)
         {
@@ -563,11 +564,11 @@ extern (C++) abstract class Type : ASTNode
             foreach (i, fparam1; t1.parameterList)
             {
                 Parameter fparam2 = t2.parameterList[i];
+                Type tp1 = fparam1.type;
+                Type tp2 = fparam2.type;
 
-                if (!fparam1.type.equals(fparam2.type))
+                if (!tp1.equals(tp2))
                 {
-                    Type tp1 = fparam1.type;
-                    Type tp2 = fparam2.type;
                     if (tp1.ty == tp2.ty)
                     {
                         if (auto tc1 = tp1.isTypeClass())
@@ -600,6 +601,16 @@ extern (C++) abstract class Type : ASTNode
                 }
             Lcov:
                 notcovariant |= !fparam1.isCovariant(t1.isref, fparam2);
+
+                /* https://issues.dlang.org/show_bug.cgi?id=23135
+                 * extern(C++) mutable parameters are not covariant with const.
+                 */
+                if (t1.linkage == LINK.cpp && cppCovariant)
+                {
+                    notcovariant |= tp1.isNaked() != tp2.isNaked();
+                    if (auto tpn1 = tp1.nextOf())
+                        notcovariant |= tpn1.isNaked() != tp2.nextOf().isNaked();
+                }
             }
         }
         else if (t1.parameterList.parameters != t2.parameterList.parameters)
@@ -699,6 +710,12 @@ extern (C++) abstract class Type : ASTNode
 
         // We can subtract 'return ref' from 'this', but cannot add it
         else if (t1.isreturn && !t2.isreturn)
+            goto Lnotcovariant;
+
+        /* https://issues.dlang.org/show_bug.cgi?id=23135
+         * extern(C++) mutable member functions are not covariant with const.
+         */
+        if (t1.linkage == LINK.cpp && cppCovariant && t1.isNaked() != t2.isNaked())
             goto Lnotcovariant;
 
         /* Can convert mutable to const

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -119,14 +119,6 @@ enum MODFlags
 };
 typedef unsigned char MOD;
 
-enum class Covariant
-{
-    distinct = 0,
-    yes = 1,
-    no = 2,
-    fwdref = 3,
-};
-
 enum VarArgValues
 {
     VARARGnone     = 0,  /// fixed number of arguments
@@ -226,7 +218,6 @@ public:
     // kludge for template.isType()
     DYNCAST dyncast() const override final { return DYNCAST_TYPE; }
     size_t getUniqueID() const;
-    Covariant covariant(Type *t, StorageClass *pstc = NULL);
     const char *toChars() const override;
     char *toPrettyChars(bool QualifyTypes = false);
     static void _init();

--- a/test/compilable/dtoh_ClassDeclaration.d
+++ b/test/compilable/dtoh_ClassDeclaration.d
@@ -157,7 +157,7 @@ public:
 class Child final : public Parent
 {
 public:
-    void foo() /* const */ override;
+    void foo() override;
 };
 
 class VisitorBase
@@ -303,7 +303,7 @@ class Parent
 final class Child : Parent
 {
     extern(D) override void over() {}
-    override void foo() const {}
+    override void foo() {}
 }
 
 class VisitorBase

--- a/test/fail_compilation/fail22351.d
+++ b/test/fail_compilation/fail22351.d
@@ -1,0 +1,20 @@
+/* https://issues.dlang.org/show_bug.cgi?id=22351
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/fail22351.d(18): Deprecation: overriding `extern(C++)` function `fail22351.C22351.func(int*)` with `const` qualified function `fail22351.Fail22351.func(const(int*))` is deprecated
+fail_compilation/fail22351.d(18):        Either remove `override`, or adjust the `const` qualifiers of the overriding function parameters
+fail_compilation/fail22351.d(19): Error: function `extern (C++) void fail22351.Fail22351.func(const(int*)**)` does not override any function, did you mean to override `extern (C++) void fail22351.C22351.func(int*)`?
+---
+*/
+extern(C++) class C22351
+{
+    void func(int*) { }
+    void func(int***) { }
+}
+
+extern(C++) final class Fail22351 : C22351
+{
+    override void func(const int*) { }
+    override void func(const(int*)**) { }
+}

--- a/test/fail_compilation/fail23135.d
+++ b/test/fail_compilation/fail23135.d
@@ -1,0 +1,17 @@
+/* https://issues.dlang.org/show_bug.cgi?id=23135
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/fail23135.d(16): Deprecation: overriding `extern(C++)` function `fail23135.C23135.func()` with `const` qualified function `fail23135.Fail23135.func() const` is deprecated
+fail_compilation/fail23135.d(16):        Either remove `override`, or adjust the `const` qualifiers of the overriding function type
+---
+*/
+extern(C++) class C23135
+{
+    void func() { }
+}
+
+extern(C++) final class Fail23135 : C23135
+{
+    override void func() const { }
+}

--- a/test/runnable_cxx/extra-files/test22351.cpp
+++ b/test/runnable_cxx/extra-files/test22351.cpp
@@ -1,0 +1,46 @@
+#include <assert.h>
+
+class A22351
+{
+public:
+    virtual int f();
+    virtual int g(int *);
+    virtual int h();
+    virtual int h() const;
+};
+
+class B22351 : public A22351
+{
+public:
+    virtual int f() const;
+    virtual int g(const int *);
+    int h() const override;
+};
+
+B22351 *createB();
+
+int main()
+{
+    // mutable A calls functions in A vtable
+    A22351 *a = createB();
+    assert(a->f() == 1);
+    assert(a->g(0) == 3);
+    assert(a->h() == 5);
+
+    // cast to B calls functions in B vtable
+    B22351 *b = (B22351 *)a;
+    assert(b->f() == 2);
+    assert(b->g(0) == 4);
+    assert(b->h() == 6);
+
+    // cast to const calls B override function
+    const A22351 *ca = a;
+    assert(ca->h() == 6);
+
+    // const B calls functions in B vtable
+    const B22351 *cb = createB();
+    assert(cb->f() == 2);
+    assert(cb->h() == 6);
+
+    return 0;
+}

--- a/test/runnable_cxx/extra-files/test23135.cpp
+++ b/test/runnable_cxx/extra-files/test23135.cpp
@@ -1,0 +1,52 @@
+class Mutable
+{
+public:
+    virtual ~Mutable();
+    virtual void func();
+};
+
+Mutable::~Mutable()
+{
+}
+
+class DeriveMutable final : public Mutable
+{
+public:
+    virtual ~DeriveMutable();
+    void func() override;
+};
+
+DeriveMutable::~DeriveMutable()
+{
+}
+
+class Const
+{
+public:
+    virtual ~Const();
+    virtual void func() const;
+};
+
+Const::~Const()
+{
+}
+
+class DeriveConst final : public Const
+{
+public:
+    virtual ~DeriveConst();
+    void func() const override;
+};
+
+DeriveConst::~DeriveConst()
+{
+}
+
+void test23135()
+{
+    DeriveMutable mut;
+    mut.func();
+
+    DeriveConst cst;
+    cst.func();
+}

--- a/test/runnable_cxx/test22351.d
+++ b/test/runnable_cxx/test22351.d
@@ -1,0 +1,55 @@
+// https://issues.dlang.org/show_bug.cgi?id=22351
+// EXTRA_CPP_SOURCES: test22351.cpp
+// REQUIRED_ARGS: -de -extern-std=c++11
+// CXXFLAGS: -std=c++11
+// DISABLED: win32
+
+extern(C++) class A22351
+{
+    int f()
+    {
+        return 1;
+    }
+
+    int g(int*)
+    {
+        return 3;
+    }
+
+    int h()
+    {
+        return 5;
+    }
+
+    int h() const
+    {
+        return 7;
+    }
+}
+
+extern(C++) class B22351 : A22351
+{
+    alias f = A22351.f;
+    alias g = A22351.g;
+    alias h = A22351.h;
+
+    int f() const
+    {
+        return 2;
+    }
+
+    int g(const(int)*)
+    {
+        return 4;
+    }
+
+    override int h() const
+    {
+        return 6;
+    }
+}
+
+extern(C++) B22351 createB()
+{
+    return new B22351;
+}

--- a/test/runnable_cxx/test23135.d
+++ b/test/runnable_cxx/test23135.d
@@ -1,0 +1,38 @@
+// https://issues.dlang.org/show_bug.cgi?id=23135
+// EXTRA_CPP_SOURCES: test23135.cpp
+// REQUIRED_ARGS: -extern-std=c++11
+// CXXFLAGS: -std=c++11
+// DISABLED: win32
+
+void main()
+{
+    test23135();
+}
+
+extern(C++):
+
+void test23135();
+
+class Mutable
+{
+    ~this();
+    void func() { }
+}
+
+final class DeriveMutable : Mutable
+{
+    ~this();
+    override void func() { }
+}
+
+class Const
+{
+    ~this();
+    void func() const { }
+}
+
+final class DeriveConst : Const
+{
+    ~this();
+    override void func() const { }
+}


### PR DESCRIPTION
Also fixes Issue 23135 - Covariance rules for C++ member functions mismatch D.

The special casing of mutable->const overrides in dtoh has been removed as with this change to the covariance rules for `extern(C++)`, such a mismatch should never occur anymore.