### PR TITLE
added function isStorageClassDeclaration to ASTBase

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -191,6 +191,11 @@ struct ASTBase
             return null;
         }
 
+        inout(StorageClassDeclaration) isStorageClassDeclaration() inout
+        {
+            return null;
+        }
+
         inout(FuncLiteralDeclaration) isFuncLiteralDeclaration() inout
         {
             return null;
@@ -1258,6 +1263,11 @@ struct ASTBase
         override void accept(Visitor v)
         {
             v.visit(this);
+        }
+
+        override final inout(StorageClassDeclaration) isStorageClassDeclaration() inout
+        {
+            return this;
         }
     }
 

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1246,6 +1246,11 @@ struct ASTBase
         {
             v.visit(this);
         }
+
+        override final inout(StorageClassDeclaration) isStorageClassDeclaration() inout
+        {
+            return this;
+        }
     }
 
     extern (C++) class ConditionalDeclaration : AttribDeclaration
@@ -1263,11 +1268,6 @@ struct ASTBase
         override void accept(Visitor v)
         {
             v.visit(this);
-        }
-
-        override final inout(StorageClassDeclaration) isStorageClassDeclaration() inout
-        {
-            return this;
         }
     }
 


### PR DESCRIPTION
When using the class AST.StorageClassDeclaration, it would be useful to have a method that checks if a symbol is actually a StorageClassDeclaration, as most other classes do.