### PR TITLE
chore(pre-commit): bump hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,6 @@ repos:
   - id: no-commit-to-branch
     args: [--branch, master]
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.14.2
+  rev: 0.15.1
   hooks:
     - id: check-github-workflows


### PR DESCRIPTION
- Updated hook https://github.com/sirosen/check-jsonschema from version
  0.14.2 to version 0.15.1.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>