### PR TITLE
Fix issue 23142 - Scope should not apply to unittests

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3276,13 +3276,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if ((funcdecl.storage_class & STC.auto_) && !f.isref && !funcdecl.inferRetType)
             funcdecl.error("storage class `auto` has no effect if return type is not inferred");
 
-        /* Functions can only be 'scope' if they have a 'this'
-         */
-        if (f.isScopeQual && !funcdecl.isNested() && !ad)
-        {
-            funcdecl.error("functions cannot be `scope`");
-        }
-
         if (f.isreturn && !funcdecl.needThis() && !funcdecl.isNested())
         {
             /* Non-static nested functions have a hidden 'this' pointer to which

--- a/test/compilable/test23142.d
+++ b/test/compilable/test23142.d
@@ -1,0 +1,19 @@
+// https://issues.dlang.org/show_bug.cgi?id=23142
+
+struct Foo
+{
+    int x;
+
+scope:
+    void func()
+    {
+    }
+
+    unittest
+    {
+    }
+
+    static void func2()
+    {
+    }
+}


### PR DESCRIPTION
Ignore `scope` when it doesn't apply instead of raising an error, similar to other attributes.