### PR TITLE
Refactor: Patch up the invariant identifier based on the number of invariants in the aggregate.

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4407,7 +4407,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
              invd.semanticRun < PASS.semantic &&
              !ad.isUnionDeclaration()           // users are on their own with union fields
            )
+        {
+            invd.fixupInvariantIdent(ad.invs.length);
             ad.invs.push(invd);
+        }
         if (!invd.type)
             invd.type = new TypeFunction(ParameterList(), Type.tvoid, LINK.d, invd.storage_class);
 

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3022,6 +3022,7 @@ public:
     bool addPostInvariant();
     InvariantDeclaration* isInvariantDeclaration();
     void accept(Visitor* v);
+    void fixupInvariantIdent(size_t offset);
 };
 
 class NewDeclaration final : public FuncDeclaration

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -4150,7 +4150,8 @@ extern (C++) final class InvariantDeclaration : FuncDeclaration
 {
     extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, Identifier id, Statement fbody)
     {
-        super(loc, endloc, id ? id : Identifier.generateIdWithLoc("__invariant", loc), stc, null);
+        // Make a unique invariant for now; we'll fix it up as we add it to the aggregate invariant list.
+        super(loc, endloc, id ? id : Identifier.generateId("__invariant"), stc, null);
         this.fbody = fbody;
     }
 
@@ -4185,6 +4186,15 @@ extern (C++) final class InvariantDeclaration : FuncDeclaration
     override void accept(Visitor v)
     {
         v.visit(this);
+    }
+
+    void fixupInvariantIdent(size_t offset)
+    {
+        OutBuffer idBuf;
+        idBuf.writestring("__invariant");
+        idBuf.print(offset);
+
+        ident = Identifier.idPool(idBuf[]);
     }
 }
 

--- a/test/compilable/extra-files/vcg-ast.d.cg
+++ b/test/compilable/extra-files/vcg-ast.d.cg
@@ -83,7 +83,7 @@ class C : Object
 	}
 	invariant
 	{
-		this.__invariant_L41_C5() , this.__invariant_L42_C5();
+		this.__invariant0() , this.__invariant1();
 	}
 }
 enum __c_wchar_t : dchar;

--- a/test/fail_compilation/fail4421.d
+++ b/test/fail_compilation/fail4421.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail4421.d(16): Error: function `fail4421.U1.__postblit` destructors, postblits and invariants are not allowed in union `U1`
 fail_compilation/fail4421.d(17): Error: destructor `fail4421.U1.~this` destructors, postblits and invariants are not allowed in union `U1`
-fail_compilation/fail4421.d(18): Error: function `fail4421.U1.__invariant_L18_C5` destructors, postblits and invariants are not allowed in union `U1`
+fail_compilation/fail4421.d(18): Error: function `fail4421.U1.__invariant1` destructors, postblits and invariants are not allowed in union `U1`
 ---
 
 

--- a/test/fail_compilation/fail7848.d
+++ b/test/fail_compilation/fail7848.d
@@ -9,12 +9,12 @@ fail_compilation/fail7848.d(21):        `fail7848.func` is declared here
 fail_compilation/fail7848.d(27): Error: `@nogc` function `fail7848.C.__unittest_L25_C30` cannot call non-@nogc function `fail7848.func`
 fail_compilation/fail7848.d(27): Error: function `fail7848.func` is not `nothrow`
 fail_compilation/fail7848.d(25): Error: function `fail7848.C.__unittest_L25_C30` may throw but is marked as `nothrow`
-fail_compilation/fail7848.d(32): Error: `pure` function `fail7848.C.__invariant_L30_C30` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(32): Error: `@safe` function `fail7848.C.__invariant_L30_C30` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(32): Error: `pure` function `fail7848.C.__invariant0` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(32): Error: `@safe` function `fail7848.C.__invariant0` cannot call `@system` function `fail7848.func`
 fail_compilation/fail7848.d(21):        `fail7848.func` is declared here
-fail_compilation/fail7848.d(32): Error: `@nogc` function `fail7848.C.__invariant_L30_C30` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(32): Error: `@nogc` function `fail7848.C.__invariant0` cannot call non-@nogc function `fail7848.func`
 fail_compilation/fail7848.d(32): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(30): Error: function `fail7848.C.__invariant_L30_C30` may throw but is marked as `nothrow`
+fail_compilation/fail7848.d(30): Error: function `fail7848.C.__invariant0` may throw but is marked as `nothrow`
 ---
 */
 

--- a/test/fail_compilation/test20626.d
+++ b/test/fail_compilation/test20626.d
@@ -19,4 +19,4 @@ struct S
     invariant {}
 }
 
-pragma(msg, typeof(S.init.__invariant_L6_C5));
+pragma(msg, typeof(S.init.__invariant1));


### PR DESCRIPTION
Follow-up to https://github.com/dlang/dmd/pull/14176

Instead of using any global-counter-based identifier for invariants, like `Identifier.generateId` or `Identifier.generateIdWithLoc`, just patch up the invariant identifier based on the number of invariants in the aggregate.

Relying on any sort of global counter leads to linker errors with static libraries. Even the current approach, which fixed #23148 and #21723, is not reliable. This commit instead fixes up the identifier of the invariant symbol based on the index of the invariant in the struct or class itself, thus removing any reliance on a global counter.

This is technically a bugfix for *yet another* "use of global counters leads to different invariant identifiers between static library and final link" bug like #23148 and #21723, but the project where the bug occurred takes about a minute and half my ram to build, so dustmiting it is truly impractical. So instead, I'm submitting this PR on the basis that doing it this way is simply better.