### PR TITLE
dmd.dsymbol: Remove forward field from ForwardingScopeDsymbol

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -1274,14 +1274,14 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
  * declarations.
  */
 
-extern(C++) final class ForwardingAttribDeclaration: AttribDeclaration
+extern(C++) final class ForwardingAttribDeclaration : AttribDeclaration
 {
     ForwardingScopeDsymbol sym = null;
 
     this(Dsymbols* decl)
     {
         super(decl);
-        sym = new ForwardingScopeDsymbol(null);
+        sym = new ForwardingScopeDsymbol();
         sym.symtab = new DsymbolTable();
     }
 
@@ -1298,7 +1298,8 @@ extern(C++) final class ForwardingAttribDeclaration: AttribDeclaration
      */
     override void addMember(Scope* sc, ScopeDsymbol sds)
     {
-        parent = sym.parent = sym.forward = sds;
+        sym.parent = sds;
+        sym.forward = sds;
         return super.addMember(sc, sym);
     }
 

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -1299,7 +1299,6 @@ extern(C++) final class ForwardingAttribDeclaration : AttribDeclaration
     override void addMember(Scope* sc, ScopeDsymbol sds)
     {
         sym.parent = sds;
-        sym.forward = sds;
         return super.addMember(sc, sym);
     }
 

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -2184,19 +2184,13 @@ extern (C++) final class OverloadSet : Dsymbol
  */
 extern (C++) final class ForwardingScopeDsymbol : ScopeDsymbol
 {
-    /*************************
-     * Symbol to forward insertions to.
-     * Can be `null` before being lazily initialized.
-     */
-    ScopeDsymbol forward;
     extern (D) this() nothrow
     {
-        super(null);
+        super();
     }
 
     override Dsymbol symtabInsert(Dsymbol s) nothrow
     {
-        assert(forward);
         if (auto d = s.isDeclaration())
         {
             if (d.storage_class & STC.local)
@@ -2211,6 +2205,8 @@ extern (C++) final class ForwardingScopeDsymbol : ScopeDsymbol
                 return super.symtabInsert(s); // insert locally
             }
         }
+        auto forward = parent.isScopeDsymbol();
+        assert(forward);
         if (!forward.symtab)
         {
             forward.symtab = new DsymbolTable();
@@ -2227,7 +2223,6 @@ extern (C++) final class ForwardingScopeDsymbol : ScopeDsymbol
      */
     override Dsymbol symtabLookup(Dsymbol s, Identifier id) nothrow
     {
-        assert(forward);
         // correctly diagnose clashing foreach loop variables.
         if (auto d = s.isDeclaration())
         {
@@ -2242,6 +2237,8 @@ extern (C++) final class ForwardingScopeDsymbol : ScopeDsymbol
         }
         // Declarations within `static foreach` do not clash with
         // `static foreach` loop variables.
+        auto forward = parent.isScopeDsymbol();
+        assert(forward);
         if (!forward.symtab)
         {
             forward.symtab = new DsymbolTable();
@@ -2251,6 +2248,8 @@ extern (C++) final class ForwardingScopeDsymbol : ScopeDsymbol
 
     override void importScope(Dsymbol s, Visibility visibility)
     {
+        auto forward = parent.isScopeDsymbol();
+        assert(forward);
         forward.importScope(s, visibility);
     }
 

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -2189,10 +2189,9 @@ extern (C++) final class ForwardingScopeDsymbol : ScopeDsymbol
      * Can be `null` before being lazily initialized.
      */
     ScopeDsymbol forward;
-    extern (D) this(ScopeDsymbol forward) nothrow
+    extern (D) this() nothrow
     {
         super(null);
-        this.forward = forward;
     }
 
     override Dsymbol symtabInsert(Dsymbol s) nothrow

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -391,8 +391,6 @@ public:
 class ForwardingScopeDsymbol final : public ScopeDsymbol
 {
 public:
-    ScopeDsymbol *forward;
-
     Dsymbol *symtabInsert(Dsymbol *s) override;
     Dsymbol *symtabLookup(Dsymbol *s, Identifier *id) override;
     void importScope(Dsymbol *s, Visibility visibility) override;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6316,7 +6316,6 @@ public:
 class ForwardingScopeDsymbol final : public ScopeDsymbol
 {
 public:
-    ScopeDsymbol* forward;
     Dsymbol* symtabInsert(Dsymbol* s) override;
     Dsymbol* symtabLookup(Dsymbol* s, Identifier* id) override;
     void importScope(Dsymbol* s, Visibility visibility) override;

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -761,7 +761,7 @@ extern (C++) final class ForwardingStatement : Statement
 
     extern (D) this(const ref Loc loc, Statement statement)
     {
-        auto sym = new ForwardingScopeDsymbol(null);
+        auto sym = new ForwardingScopeDsymbol();
         sym.symtab = new DsymbolTable();
         this(loc, sym, statement);
     }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -502,10 +502,10 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
     override void visit(ForwardingStatement ss)
     {
         assert(ss.sym);
-        for (Scope* csc = sc; !ss.sym.forward; csc = csc.enclosing)
+        for (Scope* csc = sc; !ss.sym.parent; csc = csc.enclosing)
         {
             assert(csc);
-            ss.sym.forward = csc.scopesym;
+            ss.sym.parent = csc.scopesym;
         }
         sc = sc.push(ss.sym);
         sc.sbreak = ss;


### PR DESCRIPTION
Noticed that `ForwardingScopeDsymbol` is only ever new'd with `null`.  Then on closer inspection, saw that `sym.forward == sym.parent`.

Prefer just using `sym.parent` directly, as it makes it a little clearer that the "forwarded" symbols are just everything that gets flattened out into the enclosing scope, whereas loop variables remain contained within the `ForwardingScopeDsymbol` scope.