### PR TITLE
Fix Issue 23170 - Array literal passed to map in lambda, then returne…

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2048,7 +2048,8 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                 if (global.params.useDIP1000 == FeatureState.enabled)
                     err |= checkParamArgumentEscape(sc, fd, p, arg, false, false);
             }
-            else if (!(pStc & STC.return_))
+            else if (!(pStc & STC.return_) &&
+                ((global.params.useDIP1000 == FeatureState.enabled) || !(p.storageClass & STC.scopeinferred)))
             {
                 /* Argument value cannot escape from the called function.
                  */

--- a/test/fail_compilation/test23170.d
+++ b/test/fail_compilation/test23170.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test23170.d(10): Error: array literal in `@nogc` delegate `test23170.__lambda5` may cause a GC allocation
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=23170
+
+@nogc:
+enum lambda = () => badAlias([1, 2, 3]);
+alias badAlias = (int[] array) => id(array);
+int[] id(int[] array) { return array; }


### PR DESCRIPTION
…d from nested function, is memory corrupted

This issue is already fixed in master by https://github.com/dlang/dmd/pull/14089, but @ibuclaw suggested backporting it to stable. Specifically, this part: https://github.com/dlang/dmd/blob/15d8805b40edff7f8fdaa7d103316f4a85f1cf8c/src/dmd/expressionsem.d#L2050-L2054

