### PR TITLE
Fix Issue 23174 - Can't alias tuple when it's part of dot expression following a struct literal

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6612,6 +6612,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = e;
             return;
         }
+        else if (auto ad = exp.var.isAliasDeclaration())
+        {
+            if (auto t = ad.getType())
+            {
+                result = new TypeExp(exp.loc, t).expressionSemantic(sc);
+                return;
+            }
+        }
 
         exp.e1 = exp.e1.addDtorHook(sc);
 
@@ -12885,11 +12893,8 @@ Expression semanticY(DotTemplateInstanceExp exp, Scope* sc, int flag)
 
         if (Declaration v = exp.ti.toAlias().isDeclaration())
         {
-            if (v.isFuncDeclaration() || v.isVarDeclaration())
-            {
-                return new DotVarExp(exp.loc, exp.e1, v)
-                       .expressionSemantic(sc);
-            }
+            return new DotVarExp(exp.loc, exp.e1, v)
+                   .expressionSemantic(sc);
         }
         return new DotExp(exp.loc, exp.e1, new ScopeExp(exp.loc, exp.ti))
                .expressionSemantic(sc);

--- a/test/compilable/test23174.d
+++ b/test/compilable/test23174.d
@@ -1,0 +1,58 @@
+// https://issues.dlang.org/show_bug.cgi?id=23174
+
+alias AliasSeq(T...) = T;
+
+template staticMap(alias fun, args...)
+{
+    alias staticMap = AliasSeq!();
+    static foreach(arg; args)
+        staticMap = AliasSeq!(staticMap, fun!arg);
+}
+
+template Filter(alias pred, args...)
+{
+    alias Filter = AliasSeq!();
+    static foreach (arg; args)
+        static if (pred!arg)
+            Filter = AliasSeq!(Filter, arg);
+}
+
+struct Fields(T)
+{
+    private static alias toField(alias e) = Field!(__traits(identifier, e));
+    alias fields = staticMap!(toField, T.tupleof);
+
+    static alias map(alias F) = staticMap!(F, fields);
+    static alias filter(alias pred) = Filter!(pred, fields);
+}
+
+struct Field(string n)
+{
+    enum name = n;
+}
+
+struct Foo
+{
+    int a;
+}
+
+void test23174()
+{
+    Foo value;
+
+    enum toName(alias e) = e.name;
+    enum pred(alias e) = true;
+
+    alias a = Fields!(Foo).filter!(pred); // works
+    static assert(is(a == AliasSeq!(Field!"a")));
+
+    alias b = Fields!(Foo).map!(toName); // works
+    static assert(b == AliasSeq!("a"));
+
+    alias c = Fields!(Foo).init.filter!(pred); // works
+    static assert(is(c == AliasSeq!(Field!"a")));
+
+    // OK <- Error: alias `d` cannot alias an expression `Fields().tuple("a")`
+    alias d = Fields!(Foo).init.map!(toName);
+    static assert(d == AliasSeq!("a"));
+}


### PR DESCRIPTION
Go through `DotVarExp` semantic instead of `DotExp` and resolve `alias` to types there too.