### PR TITLE
Add third error message parameter to `AttributeViolation`

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -328,12 +328,12 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, STC
         else if (par)
         {
             result |= sc.setUnsafeDIP1000(gag, arg.loc,
-                desc ~ " `%s` assigned to non-scope parameter `%s`", v, par);
+                desc ~ " `%s` assigned to non-scope parameter `%s` calling `%s`", v, par, fdc);
         }
         else
         {
             result |= sc.setUnsafeDIP1000(gag, arg.loc,
-                desc ~ " `%s` assigned to non-scope parameter `this`", v);
+                desc ~ " `%s` assigned to non-scope parameter `this` calling `%s`", v, fdc);
         }
     }
 
@@ -2492,9 +2492,11 @@ private void addMaybe(VarDeclaration va, VarDeclaration v)
  *   fmt = printf-style format string
  *   arg0  = (optional) argument for first %s format specifier
  *   arg1  = (optional) argument for second %s format specifier
+ *   arg2  = (optional) argument for third %s format specifier
  * Returns: whether an actual safe error (not deprecation) occured
  */
-private bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, const(char)* msg, RootObject arg0 = null, RootObject arg1 = null)
+private bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, const(char)* msg,
+    RootObject arg0 = null, RootObject arg1 = null, RootObject arg2 = null)
 {
     if (fs == FeatureState.disabled)
     {
@@ -2502,7 +2504,7 @@ private bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, con
     }
     else if (fs == FeatureState.enabled)
     {
-        return sc.setUnsafe(gag, loc, msg, arg0, arg1);
+        return sc.setUnsafe(gag, loc, msg, arg0, arg1, arg2);
     }
     else
     {
@@ -2510,22 +2512,23 @@ private bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, con
         {
             if (!gag)
                 previewErrorFunc(sc.isDeprecated(), fs)(
-                    loc, msg, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : ""
+                    loc, msg, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : ""
                 );
         }
         else if (!sc.func.safetyViolation)
         {
             import dmd.func : AttributeViolation;
-            sc.func.safetyViolation = new AttributeViolation(loc, msg, arg0, arg1);
+            sc.func.safetyViolation = new AttributeViolation(loc, msg, arg0, arg1, arg2);
         }
         return false;
     }
 }
 
 // `setUnsafePreview` partially evaluated for dip1000
-private bool setUnsafeDIP1000(Scope* sc, bool gag, Loc loc, const(char)* msg, RootObject arg0 = null, RootObject arg1 = null)
+private bool setUnsafeDIP1000(Scope* sc, bool gag, Loc loc, const(char)* msg,
+    RootObject arg0 = null, RootObject arg1 = null, RootObject arg2 = null)
 {
-    return setUnsafePreview(sc, global.params.useDIP1000, gag, loc, msg, arg0, arg1);
+    return setUnsafePreview(sc, global.params.useDIP1000, gag, loc, msg, arg0, arg1, arg2);
 }
 
 /***************************************

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1438,7 +1438,7 @@ extern (C++) abstract class Expression : ASTNode
             else if (!sc.func.safetyViolation)
             {
                 import dmd.func : AttributeViolation;
-                sc.func.safetyViolation = new AttributeViolation(this.loc, null, f, null);
+                sc.func.safetyViolation = new AttributeViolation(this.loc, null, f, null, null);
             }
         }
         return false;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2731,18 +2731,21 @@ struct AttributeViolation final
     const char* fmtStr;
     RootObject* arg0;
     RootObject* arg1;
+    RootObject* arg2;
     AttributeViolation() :
         loc(Loc(nullptr, 0u, 0u)),
         fmtStr(nullptr),
         arg0(nullptr),
-        arg1(nullptr)
+        arg1(nullptr),
+        arg2(nullptr)
     {
     }
-    AttributeViolation(Loc loc, const char* fmtStr = nullptr, RootObject* arg0 = nullptr, RootObject* arg1 = nullptr) :
+    AttributeViolation(Loc loc, const char* fmtStr = nullptr, RootObject* arg0 = nullptr, RootObject* arg1 = nullptr, RootObject* arg2 = nullptr) :
         loc(loc),
         fmtStr(fmtStr),
         arg0(arg0),
-        arg1(arg1)
+        arg1(arg1),
+        arg2(arg2)
         {}
 };
 

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -85,7 +85,7 @@ struct HTTP
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(96): Error: reference to local variable `sa` assigned to non-scope parameter `a`
+fail_compilation/retscope.d(96): Error: reference to local variable `sa` assigned to non-scope parameter `a` calling `bar8`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=8838
@@ -403,7 +403,7 @@ class Foo13
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1205): Error: scope variable `f14` assigned to non-scope parameter `this`
+fail_compilation/retscope.d(1205): Error: scope variable `f14` assigned to non-scope parameter `this` calling `foo`
 ---
 */
 
@@ -454,7 +454,7 @@ fail_compilation/retscope.d(1311): Error: scope variable `u2` assigned to `ek` w
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1405): Error: reference to local variable `buf` assigned to non-scope parameter `__anonymous_param`
+fail_compilation/retscope.d(1405): Error: reference to local variable `buf` assigned to non-scope parameter `__anonymous_param` calling `myprintf`
 ---
 */
 

--- a/test/fail_compilation/retscope2.d
+++ b/test/fail_compilation/retscope2.d
@@ -86,8 +86,8 @@ fail_compilation/retscope2.d(504): Error: scope variable `c` may not be returned
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(604): Error: scope variable `_param_0` assigned to non-scope parameter `__anonymous_param`
-fail_compilation/retscope2.d(604): Error: scope variable `_param_1` assigned to non-scope parameter `__anonymous_param`
+fail_compilation/retscope2.d(604): Error: scope variable `_param_0` assigned to non-scope parameter `__anonymous_param` calling `foo600`
+fail_compilation/retscope2.d(604): Error: scope variable `_param_1` assigned to non-scope parameter `__anonymous_param` calling `foo600`
 fail_compilation/retscope2.d(614): Error: template instance `retscope2.test600!(int*, int*)` error instantiating
 ---
 */

--- a/test/fail_compilation/retscope6.d
+++ b/test/fail_compilation/retscope6.d
@@ -76,9 +76,9 @@ void foo() @safe
 /* TEST_OUTPUT:
 ---
 fail_compilation/retscope6.d(8016): Error: address of variable `i` assigned to `p` with longer lifetime
-fail_compilation/retscope6.d(8031): Error: reference to local variable `i` assigned to non-scope parameter `p`
-fail_compilation/retscope6.d(8031): Error: reference to local variable `j` assigned to non-scope parameter `q`
-fail_compilation/retscope6.d(8048): Error: reference to local variable `j` assigned to non-scope parameter `q`
+fail_compilation/retscope6.d(8031): Error: reference to local variable `i` assigned to non-scope parameter `p` calling `betty`
+fail_compilation/retscope6.d(8031): Error: reference to local variable `j` assigned to non-scope parameter `q` calling `betty`
+fail_compilation/retscope6.d(8048): Error: reference to local variable `j` assigned to non-scope parameter `q` calling `archie`
 ---
 */
 
@@ -172,7 +172,7 @@ T9 testfred()
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(10003): Error: scope variable `values` assigned to non-scope parameter `values`
+fail_compilation/retscope6.d(10003): Error: scope variable `values` assigned to non-scope parameter `values` calling `escape`
 ---
 */
 
@@ -234,7 +234,7 @@ const(int)* f_c_20150() @safe nothrow
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(13010): Error: reference to local variable `str` assigned to non-scope parameter `x`
+fail_compilation/retscope6.d(13010): Error: reference to local variable `str` assigned to non-scope parameter `x` calling `f_throw`
 ---
 */
 
@@ -254,7 +254,7 @@ void escape_throw_20150() @safe
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(14019): Error: scope variable `scopePtr` assigned to non-scope parameter `x`
+fail_compilation/retscope6.d(14019): Error: scope variable `scopePtr` assigned to non-scope parameter `x` calling `noInfer23021`
 fail_compilation/retscope6.d(14022): Error: scope variable `scopePtr` may not be returned
 ---
 */

--- a/test/fail_compilation/test17423.d
+++ b/test/fail_compilation/test17423.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test17423.d(26): Error: reference to local `this` assigned to non-scope parameter `dlg`
+fail_compilation/test17423.d(26): Error: reference to local `this` assigned to non-scope parameter `dlg` calling `opApply`
 ---
 */
 

--- a/test/fail_compilation/test20245.d
+++ b/test/fail_compilation/test20245.d
@@ -2,15 +2,15 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test20245.d(20): Error: reference to local variable `x` assigned to non-scope parameter `ptr`
+fail_compilation/test20245.d(20): Error: reference to local variable `x` assigned to non-scope parameter `ptr` calling `escape`
 fail_compilation/test20245.d(21): Error: copying `&x` into allocated memory escapes a reference to parameter `x`
 fail_compilation/test20245.d(22): Error: scope variable `a` may not be returned
 fail_compilation/test20245.d(26): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
-fail_compilation/test20245.d(32): Error: reference to local variable `x` assigned to non-scope parameter `ptr`
+fail_compilation/test20245.d(32): Error: reference to local variable `x` assigned to non-scope parameter `ptr` calling `escape`
 fail_compilation/test20245.d(33): Error: copying `&x` into allocated memory escapes a reference to parameter `x`
 fail_compilation/test20245.d(49): Error: reference to local variable `price` assigned to non-scope `this.minPrice`
-fail_compilation/test20245.d(68): Error: reference to local variable `this` assigned to non-scope parameter `msg`
-fail_compilation/test20245.d(88): Error: reference to local variable `this` assigned to non-scope parameter `content`
+fail_compilation/test20245.d(68): Error: reference to local variable `this` assigned to non-scope parameter `msg` calling `this`
+fail_compilation/test20245.d(88): Error: reference to local variable `this` assigned to non-scope parameter `content` calling `listUp`
 ---
 */
 


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/14087 removed the "calling functionName" part from the error message when assigning a `scope` variable to a non-scope parameter, because `AttributeViolation` only supported 2 arguments. This PR adds a third parameter so the error is more informative again.