### PR TITLE
Fix Issue 7432 - DMD allows variables to be declared as pure

### DIFF
--- a/changelog/deprecate-var-attributes.dd
+++ b/changelog/deprecate-var-attributes.dd
@@ -1,0 +1,33 @@
+Deprecate explicitly annotating variables with irrelevant attributes
+
+Certain attributes never apply to variables, and applying them directly raises an error:
+
+---
+synchronized int v1; // error
+override     int v2; // error
+abstract     int v3; // error
+final        int v4; // error
+---
+
+However, some attributes that never apply to variables do not raise an error:
+
+---
+@nogc     int w1;
+@property int w2;
+nothrow   int w3;
+pure      int w4;
+@live     int w5;
+---
+(Note that safety attributes are not included in this list because of [DIP1035: `@system` variables](dlang.org/dips/1035))
+
+Starting with this release, using these as variable annotations raises a deprecation warning. It will become an error in 2.111.
+
+When the attribute applies to a larger scope, it is never raises an error or deprecation:
+
+---
+pure { int x; } // fine
+
+@property:
+
+int y; // fine
+---

--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -132,6 +132,13 @@ enum STC : ulong  // transfer changes to declaration.h
                          STC.TYPECTOR | STC.final_ | STC.tls | STC.gshared | STC.ref_ | STC.return_ | STC.property |
                          STC.nothrow_ | STC.pure_ | STC.safe | STC.trusted | STC.system), /// for a FuncDeclaration
 
+    /* These cause an error when applied directly to a variable instead of function
+     */
+    varError = STC.synchronized_ | STC.override_ | STC.abstract_ | STC.final_,
+
+    /* These should also cause an error, but deprecation for now to avoid breaking code
+     */
+    varDeprecation = STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.live,
 }
 
 alias StorageClass = ulong;

--- a/compiler/src/dmd/backend/cgcod.d
+++ b/compiler/src/dmd/backend/cgcod.d
@@ -2833,7 +2833,7 @@ void callcdxxx(ref CodeBuilder cdb, elem *e, regm_t *pretregs, OPER op)
 }
 
 // jump table
-private extern (C++) __gshared nothrow void function (ref CodeBuilder,elem *,regm_t *)[OPMAX] cdxxx =
+private extern (C++) __gshared void function (ref CodeBuilder,elem *,regm_t *)[OPMAX] cdxxx =
 [
     OPunde:    &cderr,
     OPadd:     &cdorth,

--- a/compiler/test/fail_compilation/failattr.d
+++ b/compiler/test/fail_compilation/failattr.d
@@ -3,12 +3,18 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/failattr.d(16): Error: variable `failattr.C2901.v1` cannot be `synchronized`
-fail_compilation/failattr.d(17): Error: variable `failattr.C2901.v2` cannot be `override`
-fail_compilation/failattr.d(18): Error: variable `failattr.C2901.v3` cannot be `abstract`
-fail_compilation/failattr.d(19): Error: variable `failattr.C2901.v4` cannot be `final`, perhaps you meant `const`?
-fail_compilation/failattr.d(31): Error: variable `failattr.C2901.v13` cannot be `final abstract synchronized override`
-fail_compilation/failattr.d(33): Error: variable `failattr.C2901.v14` cannot be `final`, perhaps you meant `const`?
+fail_compilation/failattr.d(22): Error: variable `failattr.C2901.v1` cannot be `synchronized`
+fail_compilation/failattr.d(23): Error: variable `failattr.C2901.v2` cannot be `override`
+fail_compilation/failattr.d(24): Error: variable `failattr.C2901.v3` cannot be `abstract`
+fail_compilation/failattr.d(25): Error: variable `failattr.C2901.v4` cannot be `final`, perhaps you meant `const`?
+fail_compilation/failattr.d(37): Error: variable `failattr.C2901.v13` cannot be `final abstract synchronized override`
+fail_compilation/failattr.d(39): Error: variable `failattr.C2901.v14` cannot be `final`, perhaps you meant `const`?
+fail_compilation/failattr.d(43): Deprecation: variable `failattr.e1` cannot be `@nogc`
+fail_compilation/failattr.d(44): Deprecation: variable `failattr.e2` cannot be `@property`
+fail_compilation/failattr.d(45): Deprecation: variable `failattr.e3` cannot be `nothrow`
+fail_compilation/failattr.d(46): Deprecation: variable `failattr.e4` cannot be `pure`
+fail_compilation/failattr.d(47): Deprecation: variable `failattr.e5` cannot be `@live`
+fail_compilation/failattr.d(62): Error: variable `failattr.c6` cannot be `final @nogc`
 ---
 */
 class C2901
@@ -32,3 +38,29 @@ class C2901
 
     static final int v14;           // error, even if static is applied at the same time
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=7432
+@nogc           int e1;         // deprecation
+@property       int e2;         // deprecation
+nothrow         int e3;         // deprecation
+pure            int e4;         // deprecation
+@live           int e5;         // deprecation
+
+@nogc          { int s1; }      // no error
+@property      { int s2; }      // no error
+nothrow        { int s3; }      // no error
+pure           { int s4; }      // no error
+@live          { int s5; }      // no error
+
+@nogc:         int c1;          // no error
+@property:     int c2;          // no error
+nothrow:       int c3;          // no error
+pure:          int c4;          // no error
+@live:         int c5;          // no error
+
+// deprecation + error => error
+@nogc final int c6;             // error
+
+// this should still be allowed
+nothrow void function() x = null;
+@nogc void function()[1] x = [null];


### PR DESCRIPTION
Includes other function-only attributes as well, such as `@nogc` `@property` `nothrow` and `@live`.