### PR TITLE
dmd.mtype: Expose Type.covariant to C++ interface

### DIFF
--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -1747,6 +1747,14 @@ enum class TY : uint8_t
     TMAX = 48u,
 };
 
+enum class Covariant
+{
+    distinct = 0,
+    yes = 1,
+    no = 2,
+    fwdref = 3,
+};
+
 class Type : public ASTNode
 {
 public:
@@ -1855,6 +1863,7 @@ public:
     bool equivalent(Type* t);
     DYNCAST dyncast() const final override;
     size_t getUniqueID() const;
+    Covariant covariant(Type* t, uint64_t* pstc = nullptr, bool cppCovariant = false);
     const char* toChars() const final override;
     char* toPrettyChars(bool QualifyTypes = false);
     static void _init();
@@ -3297,14 +3306,6 @@ public:
 extern Initializer* initializerSemantic(Initializer* init, Scope* sc, Type*& tx, NeedInterpret needInterpret);
 
 extern Expression* initializerToExpression(Initializer* init, Type* itype = nullptr, const bool isCfile = false);
-
-enum class Covariant
-{
-    distinct = 0,
-    yes = 1,
-    no = 2,
-    fwdref = 3,
-};
 
 enum class DotExpFlag
 {

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -529,7 +529,6 @@ extern (C++) abstract class Type : ASTNode
      * Returns:
      *     An enum value of either `Covariant.yes` or a reason it's not covariant.
      */
-    extern (D)
     final Covariant covariant(Type t, StorageClass* pstc = null, bool cppCovariant = false)
     {
         version (none)

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -128,6 +128,14 @@ enum VarArgValues
 };
 typedef unsigned char VarArg;
 
+enum class Covariant
+{
+    distinct = 0, /// types are distinct
+    yes = 1,      /// types are covariant
+    no = 2,       /// arguments match as far as overloading goes, but types are not covariant
+    fwdref = 3,   /// cannot determine covariance because of forward references
+};
+
 class Type : public ASTNode
 {
 public:
@@ -218,6 +226,7 @@ public:
     // kludge for template.isType()
     DYNCAST dyncast() const override final { return DYNCAST_TYPE; }
     size_t getUniqueID() const;
+    Covariant covariant(Type *, StorageClass * = NULL, bool = false);
     const char *toChars() const override;
     char *toPrettyChars(bool QualifyTypes = false);
     static void _init();


### PR DESCRIPTION
I found a need for it when implementing `-Wbuiltin-declaration-mismatch`, part of support for allowing C library built-ins to be recognized from any module (not just core.stdc) in gdc.

For example:
```
pure float tanf(float x);
int puts(scope const char*);
```
Are not `Type::equivalent` to the built-in prototypes that know nothing about D attributes.
```
float tanf(float x);
int puts(const(char)*);
```
But they are `Type::covariant`.