### PR TITLE
Fix Issue 23178 - Unknown error using alias to `__traits` evaluated as expression

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3018,6 +3018,7 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
         {
             pt = mt.obj.isType();
             ps = mt.obj.isDsymbol();
+            pe = mt.obj.isExpression();
             return;
         }
 
@@ -3085,7 +3086,10 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
             case EXP.overloadSet:
                 mt.obj = e.isOverExp().type;
                 break;
+            case EXP.error:
+                break;
             default:
+                mt.obj = e;
                 break;
             }
         }
@@ -3093,14 +3097,19 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
         if (mt.obj)
         {
             if (auto t = mt.obj.isType())
-                returnType(t.addMod(mt.mod));
+            {
+                t = t.addMod(mt.mod);
+                mt.obj = t;
+                returnType(t);
+            }
             else if (auto s = mt.obj.isDsymbol())
                 returnSymbol(s);
-            else
-                assert(0);
+            else if (auto e = mt.obj.isExpression())
+                returnExp(e);
         }
         else
         {
+            assert(global.errors);
             mt.obj = Type.terror;
             return returnError();
         }

--- a/test/fail_compilation/traits.d
+++ b/test/fail_compilation/traits.d
@@ -116,3 +116,21 @@ pragma(msg, __traits(hasCopyConstructor));
 pragma(msg, __traits(hasCopyConstructor, S()));
 pragma(msg, __traits(hasPostblit));
 pragma(msg, __traits(hasPostblit, S()));
+
+/********************************************
+https://issues.dlang.org/show_bug.cgi?id=23178
+
+TEST_OUTPUT:
+---
+fail_compilation/traits.d(701): Error: alias `traits.a` cannot alias an expression `true`
+fail_compilation/traits.d(702): Error: alias `traits.b` cannot alias an expression `false`
+fail_compilation/traits.d(703): Error: alias `traits.c` cannot alias an expression `"Object"`
+fail_compilation/traits.d(704):        while evaluating `pragma(msg, a)`
+---
+*/
+#line 700
+
+alias a = __traits(compiles, 1);
+alias b = __traits(isIntegral, 1.1);
+alias c = __traits(identifier, Object);
+pragma(msg, a, b, c);


### PR DESCRIPTION
Return the expression in `TypeTraits.resolve` to bring up the error.