### PR TITLE
[dmd/arrayop] Remove BuildArrayOpVisitor

### DIFF
--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -227,10 +227,12 @@ private void buildArrayOp(Scope* sc, Expression e, Objects* tiargs, Expressions*
                 tiargs.push(new StringExp(Loc.initial, EXPtoString(e.op)).expressionSemantic(sc));
             }
         }
-        if (auto be = e.isBinExp())
-            visitBin(be);
+        if (e.isSliceExp() || e.isCastExp())
+            visit(e);
         else if (auto ue = e.isUnaExp())
             visitUna(ue);
+        else if (auto be = e.isBinExp())
+            visitBin(be);
         else
             visit(e);
     }


### PR DESCRIPTION
In the spirit of b374b4ed84897e55f4d6b833ffa8aa6bbf7d53b4.

As there are only 3 distinct `visit` overloads, I've used an `if` chain instead of `switch e.op`. Otherwise I'd have to list all the matching EXP members for each of BinExp and UnaExp - not sure if there's an easy way to do that.