### PR TITLE
Revert "Fix Issue 23177 - ModuleInfo is not exported on Windows"

### DIFF
--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -222,7 +222,6 @@ void genModuleInfo(Module m)
     //////////////////////////////////////////////
 
     objmod.moduleinfo(msym);
-    objmod.export_symbol(m.csym, 0);
 }
 
 /*****************************************

--- a/test/dshell/dll.d
+++ b/test/dshell/dll.d
@@ -22,7 +22,7 @@ int main()
         enum mainExtra = `-fPIC -L-L$OUTPUT_BASE -L$DLL`;
     }
 
-    run(`$DMD -m$MODEL -shared -od=$OUTPUT_BASE -of=$DLL $SRC/mydll.d $SRC/issue23177.d ` ~ dllExtra);
+    run(`$DMD -m$MODEL -shared -od=$OUTPUT_BASE -of=$DLL $SRC/mydll.d ` ~ dllExtra);
 
     run(`$DMD -m$MODEL -I$SRC -od=$OUTPUT_BASE -of=$EXE_NAME $SRC/testdll.d ` ~ mainExtra);
 

--- a/test/dshell/extra-files/dll/issue23177.d
+++ b/test/dshell/extra-files/dll/issue23177.d
@@ -1,7 +1,0 @@
-module issue23177;
-// This module existing should trigger ModuleInfo to be referenced.
-// Therefore if the fix for issue23177 works, this won't cause a linker error.
-
-shared static this() {
-    assert(1);
-}

--- a/test/dshell/extra-files/dll/mydll.d
+++ b/test/dshell/extra-files/dll/mydll.d
@@ -1,5 +1,4 @@
 module mydll;
-import issue23177;
 
 export:
 

--- a/test/dshell/extra-files/dll/testdll.d
+++ b/test/dshell/extra-files/dll/testdll.d
@@ -1,5 +1,4 @@
 import mydll;
-import issue23177;
 
 void test1()
 {

--- a/test/dshell/test9377.d
+++ b/test/dshell/test9377.d
@@ -1,8 +1,8 @@
 import dshell;
 void main()
 {
-    Vars.set("libname", "$OUTPUT_BASE/a_b$LIBEXT");
+    Vars.set("libname", "$OUTPUT_BASE/a$LIBEXT");
 
     run("$DMD -m$MODEL -I$EXTRA_FILES -of$libname -c $EXTRA_FILES/mul9377a.d $EXTRA_FILES/mul9377b.d -lib");
-    run("$DMD -m$MODEL -I$EXTRA_FILES -of$OUTPUT_BASE/a_b_full$EXE $EXTRA_FILES/multi9377.d $libname");
+    run("$DMD -m$MODEL -I$EXTRA_FILES -of$OUTPUT_BASE/a$EXE $EXTRA_FILES/multi9377.d $libname");
 }

--- a/test/runnable/gdb15729.sh
+++ b/test/runnable/gdb15729.sh
@@ -7,12 +7,8 @@ echo RESULT=
 p s.val
 "
 
-
-libname=${OUTPUT_BASE}_dep${LIBEXT}
-
-
-$DMD -g -m${MODEL} -I${EXTRA_FILES} -of${libname} -lib ${EXTRA_FILES}${SEP}lib15729.d
-$DMD -g -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}gdb15729.d ${libname}
+$DMD -g -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${LIBEXT} -lib ${EXTRA_FILES}${SEP}lib15729.d
+$DMD -g -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}gdb15729.d ${OUTPUT_BASE}${LIBEXT}
 
 if [ $OS == "linux" ]; then
     echo "${GDB_SCRIPT}" > ${OUTPUT_BASE}.gdb

--- a/test/runnable/link14198a.sh
+++ b/test/runnable/link14198a.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-libname=${OUTPUT_BASE}_dep${LIBEXT}
+libname=${OUTPUT_BASE}${LIBEXT}
 
 
 # build library

--- a/test/runnable/link14834.sh
+++ b/test/runnable/link14834.sh
@@ -3,7 +3,7 @@
 
 dir=${RESULTS_DIR}${SEP}runnable
 
-libname=${OUTPUT_BASE}_dep${LIBEXT}
+libname=${OUTPUT_BASE}${LIBEXT}
 exename=${OUTPUT_BASE}${EXE}
 
 $DMD -m${MODEL} -I${EXTRA_FILES} -lib           -of${libname} ${EXTRA_FILES}${SEP}link14834a.d

--- a/test/runnable/link846.sh
+++ b/test/runnable/link846.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-libname=${OUTPUT_BASE}_dep${LIBEXT}
+libname=${OUTPUT_BASE}${LIBEXT}
 
 # build library with -release
 $DMD -m${MODEL} -I${EXTRA_FILES} -of${libname} -release -boundscheck=off -lib ${EXTRA_FILES}${SEP}lib846.d

--- a/test/runnable/test10386.sh
+++ b/test/runnable/test10386.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-libname=${OUTPUT_BASE}_dep${LIBEXT}
+libname=${OUTPUT_BASE}${LIBEXT}
 
 
 $DMD -m${MODEL} -Irunnable -I${EXTRA_FILES} -of${libname} -c ${EXTRA_FILES}${SEP}lib10386${SEP}foo${SEP}bar.d ${EXTRA_FILES}${SEP}lib10386${SEP}foo${SEP}package.d -lib

--- a/test/runnable/test13666.sh
+++ b/test/runnable/test13666.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-libname=${OUTPUT_BASE}_dep${LIBEXT}
+libname=${OUTPUT_BASE}${LIBEXT}
 
 
 $DMD -m${MODEL} -I${EXTRA_FILES} -of${libname} -lib ${EXTRA_FILES}${SEP}lib13666.d

--- a/test/runnable/test13742.sh
+++ b/test/runnable/test13742.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 
 
-libname=${OUTPUT_BASE}_dep${LIBEXT}
-
-
-$DMD -m${MODEL} -I${EXTRA_FILES} -lib -cov -of${libname} ${EXTRA_FILES}${SEP}lib13742a.d ${EXTRA_FILES}${SEP}lib13742b.d
-$DMD -m${MODEL} -I${EXTRA_FILES} -cov -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}test13742.d ${libname}
+$DMD -m${MODEL} -I${EXTRA_FILES} -lib -cov -of${OUTPUT_BASE}${LIBEXT} ${EXTRA_FILES}${SEP}lib13742a.d ${EXTRA_FILES}${SEP}lib13742b.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -cov -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}test13742.d ${OUTPUT_BASE}${LIBEXT}
 
 ${OUTPUT_BASE}${EXE} --DRT-covopt=dstpath:${RESULTS_TEST_DIR}
 

--- a/test/runnable/test18456.sh
+++ b/test/runnable/test18456.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
-
-libname=${OUTPUT_BASE}_dep${LIBEXT}
-
-
 # source file order is important
-$DMD -m${MODEL} -I${EXTRA_FILES} -of${libname} -lib ${EXTRA_FILES}/lib18456b.d ${EXTRA_FILES}/lib18456.d
-$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}/test18456.d ${libname}
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${LIBEXT} -lib ${EXTRA_FILES}/lib18456b.d ${EXTRA_FILES}/lib18456.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}/test18456.d ${OUTPUT_BASE}${LIBEXT}
 ${OUTPUT_BASE}${EXE}
 
 rm_retry ${OUTPUT_BASE}{${LIBEXT},${EXE}}

--- a/test/runnable/test21723.sh
+++ b/test/runnable/test21723.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-
-libname=${OUTPUT_BASE}_dep${LIBEXT}
-
-
-$DMD -m${MODEL} -I${EXTRA_FILES} -of${libname} -lib ${EXTRA_FILES}/lib21723a.d ${EXTRA_FILES}/lib21723b.d
-$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} -inline ${EXTRA_FILES}/test21723.d ${libname}
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${LIBEXT} -lib ${EXTRA_FILES}/lib21723a.d ${EXTRA_FILES}/lib21723b.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} -inline ${EXTRA_FILES}/test21723.d ${OUTPUT_BASE}${LIBEXT}
 
 rm_retry ${OUTPUT_BASE}{${LIBEXT},${EXE}}

--- a/test/runnable/test23148.sh
+++ b/test/runnable/test23148.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-
-libname=${OUTPUT_BASE}_dep${LIBEXT}
-
-
-$DMD -m${MODEL} -I${EXTRA_FILES} -of${libname} -lib ${EXTRA_FILES}/lib23148.d
-$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}/test23148.d ${libname}
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${LIBEXT} -lib ${EXTRA_FILES}/lib23148.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}/test23148.d ${OUTPUT_BASE}${LIBEXT}
 
 rm_retry ${OUTPUT_BASE}{${LIBEXT},${EXE}}

--- a/test/runnable/testmodule.d
+++ b/test/runnable/testmodule.d
@@ -1,10 +1,5 @@
 // PERMUTE_ARGS:
 
-// MS linker apparently doesn't (properly?) support Unicode in
-//      `/INCLUDE:symbol` linker directives.
-//      This has been upstreamed from LDC.
-// DISABLED: win
-
 // $HeadURL$
 // $Date$
 // $Author$

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -1730,22 +1730,13 @@ int tryMain(string[] args)
                 }
             }
 
-            /// This should be similar in nature as ``dshell_prebuilt.d`` ``filterCompilerOutput`` function.
             void prepare(ref string compile_output)
             {
                 if (compile_output.empty)
                     return;
 
                 compile_output = compile_output.unifyNewLine();
-                compile_output = std.regex.replaceAll(compile_output, std.regex.regex(`^DMD v2\.[0-9]+.*\n? DEBUG$`, "m"), "");
-
-                if(envData.os == "windows" && envData.model != "32omf") {
-                    // For MSVC linker, when it generates a binary file with an export table (with the import generation) it will add a message
-                    // this message is both linker specific and platform specific, which we do not want our tests checked against.
-                    // so we'll remove it prior to doing anything with the output.
-                    compile_output = std.regex.replaceAll(compile_output, std.regex.regex(r"\s*Creating library [\S\\/]+ and object [\S\\/]+\r?\n?", "s"), "");
-                }
-
+                compile_output = std.regex.replaceAll(compile_output, regex(`^DMD v2\.[0-9]+.*\n? DEBUG$`, "m"), "");
                 compile_output = std.string.strip(compile_output);
                 // replace test_result path with fixed ones
                 compile_output = compile_output.replace(result_path, resultsDirReplacement);

--- a/test/tools/dshell_prebuilt/dshell_prebuilt.d
+++ b/test/tools/dshell_prebuilt/dshell_prebuilt.d
@@ -326,20 +326,10 @@ private GrepResult grepLines(T)(T lineRange, string finalPattern)
 
 /**
 remove \r and the compiler debug header from the given string.
-
-This should be the same code that is used in ``d_do_test.d`` inside the inline function ``tryMain`` ``testCombination`` ``prepare``.
 */
 string filterCompilerOutput(string output)
 {
     output = std.string.replace(output, "\r", "");
-    output = std.regex.replaceAll(output, std.regex.regex(`^DMD v2\.[0-9]+.*\n? DEBUG\n`, "m"), "");
-
-    version(Windows) {
-        // For MSVC linker, when it generates a binary file with an export table (with the import generation) it will add a message
-        // this message is both linker specific and platform specific, which we do not want our tests checked against.
-        // so we'll remove it prior to doing anything with the output.
-        output = std.regex.replaceAll(output, std.regex.regex(r"\s*Creating library [\S\\/]+ and object [\S\\/]+\r?\n?", "s"), "");
-    }
-
+    output = std.regex.replaceAll(output, regex(`^DMD v2\.[0-9]+.*\n? DEBUG\n`, "m"), "");
     return output;
 }


### PR DESCRIPTION
Reverts dlang/dmd#14200.

With that change, not only will people see an extra MS linker line for every single linked D binary, but more importantly, linking a `foo.exe` leads to a potentially existing `foo.lib` to be overwritten by the import lib for that executable. So that can break builds and should have never landed in `stable`.

At the very least, the export should be explicitly enabled (after all, no existing and currently working code needs the exports). As DMD doesn't have an `-fvisibility=public` option yet (that's when LDC exports them), I'd say exporting with `-shared` only is an option for now. Then as good as all previous test adaptions can be gotten rid of again (e.g., the `_dep` filename changes) .