### PR TITLE
[DO NOT MERGE] Fix Issue 23179 - Unicode in symbol names in DLLs breaks MSVC linker

### DIFF
--- a/test/dshell/dll.d
+++ b/test/dshell/dll.d
@@ -22,7 +22,7 @@ int main()
         enum mainExtra = `-fPIC -L-L$OUTPUT_BASE -L$DLL`;
     }
 
-    run(`$DMD -m$MODEL -shared -od=$OUTPUT_BASE -of=$DLL $SRC/mydll.d ` ~ dllExtra);
+    run(`$DMD -m$MODEL -shared -od=$OUTPUT_BASE -of=$DLL $SRC/mydll.d $SRC/testmodule.d ` ~ dllExtra);
 
     run(`$DMD -m$MODEL -I$SRC -od=$OUTPUT_BASE -of=$EXE_NAME $SRC/testdll.d ` ~ mainExtra);
 

--- a/test/dshell/extra-files/dll/testmodule.d
+++ b/test/dshell/extra-files/dll/testmodule.d
@@ -1,0 +1,16 @@
+module run.unicode_06_哪里;
+
+int 哪里(int ö){
+        return ö+2;
+}
+
+version(Windows) {
+    static assert(() {
+        foreach(char c; 哪里.mangleof) {
+            if (c == '哪' || c == '里')
+                return false;
+        }
+
+        return true;
+    }(), "Function mangling on Windows must not contain Unicode characters. Got: " ~ 哪里.mangleof);
+}


### PR DESCRIPTION
This is my attempt at fixing 23179, as it seems Microsoft does not intend for symbols to contain anything but ANSI.

So this introduces hex encoding for Unicode identifiers.