### PR TITLE
test: Disable dshell/dll.d test on OSX

### DIFF
--- a/test/dshell/dll.d
+++ b/test/dshell/dll.d
@@ -5,6 +5,10 @@ int main()
     version (Windows) if (Vars.MODEL == "32omf") // Avoid optlink
         return DISABLED;
 
+    version (DigitalMars)
+        version (OSX) // Shared libraries are not yet supported on OSX
+            return DISABLED;
+
     Vars.set(`SRC`, `$EXTRA_FILES/dll`);
     Vars.set(`EXE_NAME`, `$OUTPUT_BASE/testdll$EXE`);
     Vars.set(`DLL`, `$OUTPUT_BASE/mydll$SOEXT`);

--- a/test/dshell/dll_cxx.d
+++ b/test/dshell/dll_cxx.d
@@ -16,9 +16,6 @@ int main()
         if (Vars.MODEL == "32")
             return DISABLED;
 
-    version (OSX)
-        Vars.set(`SOEXT`, `.dylib`);
-
     Vars.set(`SRC`, `$EXTRA_FILES${SEP}dll_cxx`);
     Vars.set(`EXE_NAME`, `$OUTPUT_BASE${SEP}testdll$EXE`);
     Vars.set(`DLL`, `$OUTPUT_BASE${SEP}mydll$SOEXT`);

--- a/test/tools/dshell_prebuilt/dshell_prebuilt.d
+++ b/test/tools/dshell_prebuilt/dshell_prebuilt.d
@@ -94,6 +94,11 @@ void dshellPrebuiltInit(string testDir, string testName)
         Vars.set("LIBEXT", ".lib");
         Vars.set("SOEXT", ".dll");
     }
+    else version (OSX)
+    {
+        Vars.set("LIBEXT", ".a");
+        Vars.set(`SOEXT`, `.dylib`);
+    }
     else
     {
         Vars.set("LIBEXT", ".a");


### PR DESCRIPTION
When running the dll test, the [following](https://github.com/dlang/druntime/blob/master/src/rt/sections_osx_x86_64.d#L139) warning is written to console.

```
user@darwin20:~/src/dlang/dmd/test$ ./test_results/dshell/dll/testdll
Shared libraries are not yet supported on OSX.
```

This is correct, as when you link druntime into a shared library on OSX, all the symbols of libphobos.a are copied into the DSO/image for that library.  Then, linking an executable with both libphobos and that library means there are now two copies of all globals present at run-time.

i.e:
```
user@darwin20:~/src/dlang/dmd/test$ otool -L test_results/dshell/dll/testdll
test_results/dshell/dll/testdll:
	test_results/dshell/dll/mydll.so (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.100.5)

user@darwin20:~/src/dlang/dmd/test$ nm test_results/dshell/dll/testdll | grep __D4core6thread10threadbase10ThreadBase6_slockG96v
00000001000399e8 B __D4core6thread10threadbase10ThreadBase6_slockG96v

user@darwin20:~/src/dlang/dmd/test$ nm test_results/dshell/dll/mydll.so | grep __D4core6thread10threadbase10ThreadBase6_slockG96v
0000000000057c58 B __D4core6thread10threadbase10ThreadBase6_slockG96v
```

Unlike ELF DSOs, where at run-time these are resolved as-if the symbol is weak.  On OSX, depending on which DSO/image a referencing function is resolved/called from, you could get either version of these symbols. i.e: `Thread.initLocks()` is called from `testdll.exe`, initializing the `Thread.slock@1000399e8` handle in that image, but `thread_suspendAll` is called from `mydll.so`, which tries to use the uninitialized `Thread.slock@000057c58` and throws an Error as a result.

Until DMD sorts out symbol emission to avoid this (GDC annotates these `__gshared` variables with `@weak` IIRC), or gains proper support for shared libraries, it can only be considered a fluke that this test even passes.  Disabling it unblocks #14194.