### PR TITLE
Add __traits(getTargetInfo, "predefinedVersions")

### DIFF
--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -981,6 +981,7 @@ extern (C++) struct Target
         cppStd,
         floatAbi,
         objectFormat,
+        predefinedVersions,
     }
 
     /**
@@ -993,8 +994,10 @@ extern (C++) struct Target
      */
     extern (C++) Expression getTargetInfo(const(char)* name, const ref Loc loc)
     {
+        import dmd.arraytypes : Expressions;
         import dmd.dmdparams : driverParams;
-        import dmd.expression : IntegerExp, StringExp;
+        import dmd.expression : ArrayLiteralExp, IntegerExp, StringExp;
+        import dmd.globals : global;
         import dmd.root.string : toDString;
 
         StringExp stringExp(const(char)[] sval)
@@ -1023,6 +1026,11 @@ extern (C++) struct Target
                 return stringExp("");
             case cppStd.stringof:
                 return new IntegerExp(params.cplusplus);
+            case predefinedVersions.stringof:
+                auto elements = new Expressions();
+                foreach (const id; *global.versionids)
+                    elements.push(stringExp(id.toString()));
+                return new ArrayLiteralExp(loc, null, elements);
 
             default:
                 return null;

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -35,6 +35,15 @@ version (linux)
 
 static assert(__traits(getTargetInfo, "cppStd") == 199711);
 
+enum testPredefinedVersions = ()
+{
+    static foreach (predef; __traits(getTargetInfo, "predefinedVersions"))
+        mixin("enum __"~predef~"__ = 1;");
+    static assert(__traits(compiles, __all__));
+    static assert(__traits(compiles, __D_Version2__));
+    static assert(!__traits(compiles, __DavidLister__));
+};
+
 import imports.plainpackage.plainmodule;
 import imports.pkgmodule.plainmodule;
 


### PR DESCRIPTION
This information is already printed to console with `-v` option. As an experiment, this exposes that same information to `__traits`.