### PR TITLE
fix Issue 23181 - [REG 2.099] AssertError@src/dmd/e2ir.d(6094): Trying reference _d_arraysetctor

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -6124,7 +6124,10 @@ Lagain:
                     /* Need to do postblit/destructor.
                      *   void *_d_arraysetassign(void *p, void *value, int dim, TypeInfo ti);
                      */
-                    assert(op != EXP.construct, "Trying reference _d_arraysetctor, this should not happen!");
+                    if (op == EXP.construct)
+                    {
+                        assert(0, "Trying reference _d_arraysetctor, this should not happen!");
+                    }
                     r = RTLSYM.ARRAYSETASSIGN;
                     evalue = el_una(OPaddr, TYnptr, evalue);
                     // This is a hack so we can call postblits on const/immutable objects.

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -9927,9 +9927,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 ae.e2.type.nextOf &&
                 ae.e1.type.nextOf.mutableOf.equals(ae.e2.type.nextOf.mutableOf);
 
+            /* Unlike isArrayCtor above, lower all Rvalues. If the RHS is a literal,
+             * then we do want to make a temporary for it and call its destructor.
+             */
             const isArraySetCtor =
                 (ae.e1.isSliceExp || ae.e1.type.ty == Tsarray) &&
-                ae.e2.isLvalue &&
                 (ae.e2.type.ty == Tstruct || ae.e2.type.ty == Tsarray) &&
                 ae.e1.type.nextOf &&
                 ae.e1.type.nextOf.equivalent(ae.e2.type);

--- a/test/fail_compilation/fail23181.d
+++ b/test/fail_compilation/fail23181.d
@@ -1,0 +1,16 @@
+/* https://issues.dlang.org/show_bug.cgi?id=23181
+TEST_OUTPUT:
+---
+$p:druntime/import/core/lifetime.d$($n$): Error: struct `fail23181.fail23181.NoPostblit` is not copyable because it has a disabled postblit
+$p:druntime/import/core/internal/array/construction.d$($n$): Error: template instance `core.lifetime.copyEmplace!(NoPostblit, NoPostblit)` error instantiating
+fail_compilation/fail23181.d(15):        instantiated from here: `_d_arraysetctor!(NoPostblit[], NoPostblit)`
+---
+*/
+void fail23181()
+{
+    struct NoPostblit
+    {
+        @disable this(this);
+    }
+    NoPostblit[4] noblit23181 = NoPostblit();
+}

--- a/test/runnable/test23181.d
+++ b/test/runnable/test23181.d
@@ -1,0 +1,27 @@
+// https://issues.dlang.org/show_bug.cgi?id=23181
+void main()
+{
+    int count;
+    struct HasDtor
+    {
+        ~this() { ++count; }
+    }
+
+    // array[] = elem()
+    // -> creates temporary to construct array and calls destructor.
+    {
+        count = 0;
+        HasDtor[4] dtor1 = HasDtor();
+        assert(count == 1);
+    }
+    assert(count == 5);
+
+    // array[] = array[elem()]
+    // -> constructs array using direct emplacement.
+    {
+        count = 0;
+        HasDtor[2] dtor2 = [HasDtor(), HasDtor()];
+        assert(count == 0);
+    }
+    assert(count == 2);
+}


### PR DESCRIPTION
The old behavior of 2.098 was partially incorrect, in the given test, the destructor was called only 4 times (once for each element) as the temporary created to construct an array would not be destructed after use.

After changing this over to template lowering, the old call to `_d_arraysetctor` was removed, so now it forwards to `_d_arraysetassign` which results in the destructor being called 8 times (the first four on the uninitialized array!).

This fixes that the destructor is called the correct number of times (five), plus fixes the ICE that was triggered in debug builds.