### PR TITLE
dmd.expressionsem: Call copy() on default argument from CallExp semantic

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1754,8 +1754,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                         goto L2;
                     return errorArgs();
                 }
-                arg = p.defaultArg;
-                arg = inlineCopy(arg, sc);
+                arg = p.defaultArg.copy();
                 // __FILE__, __LINE__, __MODULE__, __FUNCTION__, and __PRETTY_FUNCTION__
                 arg = arg.resolveLoc(loc, sc);
                 arguments.push(arg);

--- a/test/compilable/test2437.d
+++ b/test/compilable/test2437.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=2437
+
+struct S2437
+{
+    int	m;
+
+    this(int a)
+    {
+        m = a;
+    }
+}
+
+class C2437
+{
+    void fun(S2437 a = S2437(44)) { }
+}
+
+void main()
+{
+    C2437 a = new C2437();
+    a.fun();
+}

--- a/test/compilable/test2935.d
+++ b/test/compilable/test2935.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=2935
+
+struct S2935
+{
+   int z;
+   this(int a) { z = a; }
+}
+
+void test2935(S2935 a = S2935(1)) { }
+
+void main()
+{
+    test2935();
+}


### PR DESCRIPTION
With this, the only entrypoint into the front-end inliner would be `dmd.mars`.

As of #3885, `CallExp` semantic no longer does early lowering of struct literal constructors into a `DeclarationExp`, which triggered the backend ICE in bugzilla 2935 - if there is any lowering required, that is appropriately dealt with by `functionParameters()` _after_ a copy of `defaultArg` has been made.

So it is now safe to do a plain copy, instead of implicitly calling the front-end inliner to perform a deep copy of the node.

[As noted in the original bugzilla issue](https://issues.dlang.org/show_bug.cgi?id=2935#c8), a visitor/walker would also suffice to do a deep copy of any nested DeclarationExp's, but I don't see that as necessary anymore as that possibility looks to be no longer reachable.

CC: @WalterBright - because you were the one who cried "Danger, Will Robinson!"

This partiallly reverts commit b5ea872c6c5373e7b96f7ac343d8b34783483398.