### PR TITLE
dmd.parse: Highlight 'alias' in a couple more diagnostic errors

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -4862,7 +4862,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     if (udas !is null)
                     {
                         if (storage_class != 0)
-                            error("cannot put a storage-class in an alias declaration.");
+                            error("cannot put a storage-class in an `alias` declaration.");
                         // parseAttributes shouldn't have set these variables
                         assert(link == linkage && !setAlignment && ealign is null);
                         auto tpl_ = cast(AST.TemplateDeclaration) s;
@@ -4887,7 +4887,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     parseAttributes();
                     // type
                     if (udas)
-                        error("user-defined attributes not allowed for alias declarations");
+                        error("user-defined attributes not allowed for `alias` declarations");
 
                     auto t = parseType();
 

--- a/test/fail_compilation/udaparams.d
+++ b/test/fail_compilation/udaparams.d
@@ -12,8 +12,8 @@ fail_compilation/udaparams.d(40): Error: `@safe` attribute for function paramete
 fail_compilation/udaparams.d(43): Error: `@system` attribute for function parameter is not supported
 fail_compilation/udaparams.d(44): Error: `@trusted` attribute for function parameter is not supported
 fail_compilation/udaparams.d(45): Error: `@nogc` attribute for function parameter is not supported
-fail_compilation/udaparams.d(51): Error: cannot put a storage-class in an alias declaration.
-fail_compilation/udaparams.d(52): Error: cannot put a storage-class in an alias declaration.
+fail_compilation/udaparams.d(51): Error: cannot put a storage-class in an `alias` declaration.
+fail_compilation/udaparams.d(52): Error: cannot put a storage-class in an `alias` declaration.
 fail_compilation/udaparams.d(53): Error: semicolon expected to close `alias` declaration
 fail_compilation/udaparams.d(53): Error: declaration expected, not `=>`
 fail_compilation/udaparams.d(54): Error: semicolon expected to close `alias` declaration

--- a/test/fail_compilation/udatypes.d
+++ b/test/fail_compilation/udatypes.d
@@ -1,0 +1,8 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/udatypes.d(8): Error: user-defined attributes not allowed for `alias` declarations
+---
+*/
+
+alias c_typedef = extern(C) @(1) void* function(size_t);


### PR DESCRIPTION
Spotted a couple more places where this was missing.