### PR TITLE
Fix Issue 23173 - "Error: signed integer overflow" for compiler gener…

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -1890,7 +1890,17 @@ private void expressionPrettyPrint(Expression e, OutBuffer* buf, HdrGenState* hg
                 buf.printf("%uu", cast(uint)v);
                 break;
             case Tint64:
-                buf.printf("%lldL", v);
+                if (v == long.min)
+                {
+                    // https://issues.dlang.org/show_bug.cgi?id=23173
+                    // This is a special case because - is not part of the
+                    // integer literal and 9223372036854775808L overflows a long
+                    buf.writestring("cast(long)-9223372036854775808");
+                }
+                else
+                {
+                    buf.printf("%lldL", v);
+                }
                 break;
             case Tuns64:
                 buf.printf("%lluLU", v);

--- a/test/compilable/test23173.d
+++ b/test/compilable/test23173.d
@@ -1,0 +1,6 @@
+// REQUIRED_ARGS: -o-
+// https://issues.dlang.org/show_bug.cgi?id=23173
+
+mixin("long l = ", long.min, ";");
+static assert(mixin(long.min) == long.min);
+static assert(is(typeof(mixin(long.min)) == long));


### PR DESCRIPTION
…ated string of `long.min`

I don't know of a clean way to write `-9223372036854775808` typed as a `long`, so it's a bit ugly.