### PR TITLE
Move bool fields of EnumDeclaration into bit fields

### DIFF
--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -54,9 +54,17 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
     Expression maxval;
     Expression minval;
     Expression defaultval;  // default initializer
-    bool isdeprecated;
-    bool added;
-    int inuse;
+
+    // `bool` fields that are compacted into bit fields in a string mixin
+    private extern (D) static struct BitFields
+    {
+        bool isdeprecated;
+        bool added;
+        bool inuse;
+    }
+
+    import dmd.common.bitfields : generateBitFields;
+    mixin(generateBitFields!(BitFields, ubyte));
 
     extern (D) this(const ref Loc loc, Identifier ident, Type memtype)
     {

--- a/src/dmd/enum.h
+++ b/src/dmd/enum.h
@@ -35,10 +35,15 @@ public:
     Expression *maxval;
     Expression *minval;
     Expression *defaultval;     // default initializer
-
-    bool isdeprecated;
-    bool added;
-    int inuse;
+private:
+    uint8_t bitFields;
+public:
+    bool isdeprecated() const;
+    bool isdeprecated(bool v);
+    bool added() const;
+    bool added(bool v);
+    bool inuse() const;
+    bool inuse(bool v);
 
     EnumDeclaration *syntaxCopy(Dsymbol *s) override;
     void addMember(Scope *sc, ScopeDsymbol *sds) override;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -6033,9 +6033,15 @@ public:
     Expression* maxval;
     Expression* minval;
     Expression* defaultval;
-    bool isdeprecated;
-    bool added;
-    int32_t inuse;
+    bool isdeprecated() const;
+    bool isdeprecated(bool v);
+    bool added() const;
+    bool added(bool v);
+    bool inuse() const;
+    bool inuse(bool v);
+private:
+    uint8_t bitFields;
+public:
     EnumDeclaration* syntaxCopy(Dsymbol* s) override;
     void addMember(Scope* sc, ScopeDsymbol* sds) override;
     void setScope(Scope* sc) override;

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -4891,9 +4891,9 @@ Expression getMaxMinValue(EnumDeclaration ed, const ref Loc loc, Identifier id)
              */
             Expression e = em.value;
             Expression ec = new CmpExp(id == Id.max ? EXP.greaterThan : EXP.lessThan, em.loc, e, *pval);
-            ed.inuse++;
+            ed.inuse = true;
             ec = ec.expressionSemantic(em._scope);
-            ed.inuse--;
+            ed.inuse = false;
             ec = ec.ctfeInterpret();
             if (ec.op == EXP.error)
             {


### PR DESCRIPTION
The `inuse` field is only used from `getMaxMinValue` in a boolean way, so that shaves off an extra 4 bytes there too.

On 64-bit, this doesn't reduce the overall size (there's still 8-byte alignment), but it does chip away the size at 32-bit compilers.