### PR TITLE
ImportC: Check for overflow in enumeration values

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2218,9 +2218,21 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 }
                 else
                 {
+                    // C11 6.7.2.2-3 add 1 to value of previous enumeration constant
+                    bool first = (em == (*em.ed.members)[0]);
+                    if (!first)
+                    {
+                        import core.checkedint : adds;
+                        bool overflow;
+                        nextValue = adds(nextValue, 1, overflow);
+                        if (overflow)
+                        {
+                            em.error("initialization with `%d+1` causes overflow for type `int`", nextValue - 1);
+                            return errorReturn(em);
+                        }
+                    }
                     em.value = new IntegerExp(em.loc, nextValue, Type.tint32);
                 }
-                ++nextValue; // C11 6.7.2.2-3 add 1 to value of previous enumeration constant
                 em.semanticRun = PASS.semanticdone;
             }
 

--- a/test/fail_compilation/failcstuff6.c
+++ b/test/fail_compilation/failcstuff6.c
@@ -1,0 +1,17 @@
+// check dsymbolSemantic analysis of C files
+/* TEST_OUTPUT:
+---
+fail_compilation/failcstuff6.c(56): Error: enum member `failcstuff6.test_overflow.boom` initialization with `2147483647+1` causes overflow for type `int`
+---
+*/
+
+/***************************************************/
+#line 50
+
+enum test_overflow
+{
+    three = 2147483645,
+    two,
+    one,
+    boom,
+};


### PR DESCRIPTION
The Cfile semantic was silently allowing it to overflow.