### PR TITLE
ImportC: Fix member value fits integer check

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -49,6 +49,7 @@ import dmd.identifier;
 import dmd.importc;
 import dmd.init;
 import dmd.initsem;
+import dmd.intrange;
 import dmd.hdrgen;
 import dmd.mtype;
 import dmd.mustuse;
@@ -2177,6 +2178,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             assert(ed.memtype);
             int nextValue = 0;        // C11 6.7.2.2-3 first member value defaults to 0
 
+            // C11 6.7.2.2-2 value must be representable as an int.
+            // The sizemask represents all values that int will fit into,
+            // from 0..uint.max.  We want to cover int.min..uint.max.
+            const mask = Type.tint32.sizemask();
+            IntRange ir = IntRange(SignExtendedNumber(~(mask >> 1), true),
+                                   SignExtendedNumber(mask));
+
             void emSemantic(EnumMember em, ref int nextValue)
             {
                 static void errorReturn(EnumMember em)
@@ -2206,15 +2214,14 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         em.error("enum member must be an integral constant expression, not `%s` of type `%s`", e.toChars(), e.type.toChars());
                         return errorReturn(em);
                     }
-                    const sinteger_t v = ie.toInteger();
-                    if (v < int.min || v > uint.max)
+                    if (!ir.contains(getIntRange(ie)))
                     {
                         // C11 6.7.2.2-2
                         em.error("enum member value `%s` does not fit in an `int`", e.toChars());
                         return errorReturn(em);
                     }
-                    em.value = new IntegerExp(em.loc, cast(int)v, Type.tint32);
-                    nextValue = cast(int)v;
+                    nextValue = cast(int)ie.toInteger();
+                    em.value = new IntegerExp(em.loc, nextValue, Type.tint32);
                 }
                 else
                 {

--- a/test/fail_compilation/failcstuff6.c
+++ b/test/fail_compilation/failcstuff6.c
@@ -2,6 +2,11 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/failcstuff6.c(56): Error: enum member `failcstuff6.test_overflow.boom` initialization with `2147483647+1` causes overflow for type `int`
+fail_compilation/failcstuff6.c(105): Error: enum member `failcstuff6.test_enum_fits.firstMinError` enum member value `-2147483649L` does not fit in an `int`
+fail_compilation/failcstuff6.c(106): Error: enum member `failcstuff6.test_enum_fits.firstMaxError` enum member value `4294967296L` does not fit in an `int`
+fail_compilation/failcstuff6.c(107): Error: enum member `failcstuff6.test_enum_fits.lastMaxError` enum member value `18446744071562067967LU` does not fit in an `int`
+fail_compilation/failcstuff6.c(108): Error: enum member `failcstuff6.test_enum_fits.firstBlindSpot` enum member value `18446744071562067968LU` does not fit in an `int`
+fail_compilation/failcstuff6.c(109): Error: enum member `failcstuff6.test_enum_fits.lastBlindSpot` enum member value `18446744073709551615LU` does not fit in an `int`
 ---
 */
 
@@ -14,4 +19,19 @@ enum test_overflow
     two,
     one,
     boom,
+};
+
+
+/***************************************************/
+#line 100
+
+enum test_enum_fits
+{
+    intMinFits     = -2147483648,
+    intMaxFits     = 4294967295,
+    firstMinError  = -2147483649,
+    firstMaxError  = 4294967296,
+    lastMaxError   = 0xffffffff7fffffff,
+    firstBlindSpot = 0xffffffff80000000,
+    lastBlindSpot  = 0xffffffffffffffff,
 };


### PR DESCRIPTION
Because it was relying on `ulong`->`long` conversion, there is a blind spot starting from `cast(long)0xffffffff80000000` which wraps around back to the range of `int.min .. -1`, which doesn't trigger the condition to raise an error.

Extra bug found by CI: having an enum member value set to `-2147483648` triggers the "cannot fit" error on 32-bit.

Let's use `IntRange`. I trust that to be more correct than this overflowed integer comparison.