### PR TITLE
Fix Issue 23172 - [REG2.100] Wrong cast inserted for ternary operator and non-int enums

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1107,9 +1107,14 @@ MATCH implicitConvTo(Expression e, Type t)
 
     MATCH visitCond(CondExp e)
     {
-        auto result = visit(e);
-        if (result != MATCH.nomatch)
-            return result;
+        e.econd = e.econd.optimize(WANTvalue);
+        const opt = e.econd.toBool();
+        if (opt.isPresent())
+        {
+            auto result = visit(e);
+            if (result != MATCH.nomatch)
+                return result;
+        }
 
         MATCH m1 = e.e1.implicitConvTo(t);
         MATCH m2 = e.e2.implicitConvTo(t);

--- a/test/compilable/test23172.d
+++ b/test/compilable/test23172.d
@@ -1,0 +1,33 @@
+// https://issues.dlang.org/show_bug.cgi?id=23172
+
+enum E : ubyte { // `ubyte` is needed to trigger the bug
+    A,
+    B,
+}
+
+struct S {
+    E e;
+}
+
+void compiles(bool b, S s) {
+    E e = b ? E.A : s.e;
+}
+
+void errors(bool b, const ref S s) {
+    E e = b ? E.A : s.e;
+}
+
+// from https://issues.dlang.org/show_bug.cgi?id=23188
+
+enum Status : byte
+{
+    A, B, C
+}
+
+Status foo()
+{
+    Status t = Status.A;
+    const Status s = t;
+
+    return (s == Status.A) ? Status.B : s;  // <-- here
+}


### PR DESCRIPTION
A revision of patch #13961.
Go to the generic visitor, which optimizes the whole ternary exp, only if it can const-fold the condition so that only the used branch is optimized.

Note: The regression just exposed a bug caused by the combination of two existing bugs in the compiler:
1. A questionable integer promotion that also affects `enum`, (more info: #9893 #9943)
```d
enum E : ubyte { a }
auto v = 1 ? E.a : const(E)(E.a);  // 'v' type is 'int'
pragma(msg, typeof(1 ? E.a : const(E)(E.a)));
```
Prints `int`, so the common base type of `E` and `const(E)` is `int`, and the final expression is
`1 ? cast(int)E.a : cast(int)const(E)(E.a)`

Yet the following works because 2:
```d
E e = 1 ? E.a : const(E)(E.a);
```
2. An explicit cast to `E` is inserted to the ternary expression that now becomes
```d
1 ? cast(E)cast(int)E.a : cast(E)cast(int)const(E)(E.a)
```
this cast prevents the error about implicit conversion from `int` to `E`.
The origin is in `implicitConvTo.visitCast()`, here [dcast.d#L1137-L1138](https://github.com/dlang/dmd/blob/32c99d0b58684f1e5549dda710bf2f3d86b86cc8/src/dmd/dcast.d#L1137-L1138):
```d
if (t.isintegral() && e.e1.type.isintegral() && e.e1.implicitConvTo(t) != MATCH.nomatch)
            result = MATCH.convert;
```
 probably the `if` should start with `!t.isTypeEnum() &&`.

In conclusion, another can of worms...