### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   # Build and package a new release for all supported platforms
   build-all-releases:
+    permissions:
+      contents: none
     name: Build nightly from master
     if: github.repository == 'dlang/dmd'
     uses: dlang/installer/.github/workflows/build_release_template.yml@master

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -44,6 +44,9 @@ on:
       # Use this branch name in your fork to test changes
       - github-actions
 
+permissions:
+  contents: read
+
 jobs:
   main:
     name: Run


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
