### PR TITLE
Improve error for using in operator on arrays

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -11694,6 +11694,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         case Terror:
             return setError();
 
+        case Tarray, Tsarray:
+            result = exp.incompatibleTypes();
+            exp.errorSupplemental("`in` is only allowed on associative arrays");
+            const(char)* slice = (t2b.ty == Tsarray) ? "[]" : "";
+            exp.errorSupplemental("perhaps use `std.algorithm.find(%s, %s%s)` instead",
+                exp.e1.toChars(), exp.e2.toChars(), slice);
+            return;
+
         default:
             result = exp.incompatibleTypes();
             return;

--- a/test/fail_compilation/diag_in_array.d
+++ b/test/fail_compilation/diag_in_array.d
@@ -1,0 +1,20 @@
+/**
+TEST_OUTPUT:
+---
+fail_compilation/diag_in_array.d(17): Error: incompatible types for `(3) in (a)`: `int` and `int[4]`
+fail_compilation/diag_in_array.d(17):        `in` is only allowed on associative arrays
+fail_compilation/diag_in_array.d(17):        perhaps use `std.algorithm.find(3, a[])` instead
+fail_compilation/diag_in_array.d(19): Error: incompatible types for `("s") in (b)`: `string` and `string[]`
+fail_compilation/diag_in_array.d(19):        `in` is only allowed on associative arrays
+fail_compilation/diag_in_array.d(19):        perhaps use `std.algorithm.find("s", b)` instead
+---
+*/
+
+void main()
+{
+    int[4] a;
+    string[] b;
+    if (3 in a)
+        return;
+    auto c = "s" in b;
+}


### PR DESCRIPTION
There have been multiple discussions on the news group about defining the `in` operator for regular arrays instead of associative arrays. While that's still up in the air, in any case we can improve the error message for now.