### PR TITLE
Fix 23167 - inaccurate diagnostic for internal tuple bound violation

### DIFF
--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -2208,7 +2208,7 @@ private void asm_merge_opnds(ref OPND o1, ref OPND o2)
         size_t index = cast(int)o2.disp;
         if (index >= tup.objects.dim)
         {
-            asmerr("tuple index %llu exceeds length %llu",
+            asmerr("tuple index `%llu` out of bounds `[0 .. %llu]`",
                     cast(ulong) index, cast(ulong) tup.objects.dim);
         }
         else

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -119,7 +119,7 @@ private void resolveTupleIndex(const ref Loc loc, Scope* sc, Dsymbol s, out Expr
     const(uinteger_t) d = eindex.toUInteger();
     if (d >= tup.objects.dim)
     {
-        .error(loc, "tuple index `%llu` exceeds length %llu", d, cast(ulong)tup.objects.dim);
+        .error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", d, cast(ulong)tup.objects.dim);
         pt = Type.terror;
         return;
     }
@@ -554,7 +554,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             uinteger_t d = mtype.dim.toUInteger();
             if (d >= tup.objects.dim)
             {
-                .error(loc, "tuple index %llu exceeds %llu", cast(ulong)d, cast(ulong)tup.objects.dim);
+                .error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", cast(ulong)d, cast(ulong)tup.objects.dim);
                 return error();
             }
 
@@ -649,7 +649,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                 uinteger_t d = mtype.dim.toUInteger();
                 if (d >= tt.arguments.dim)
                 {
-                    .error(loc, "tuple index %llu exceeds %llu", cast(ulong)d, cast(ulong)tt.arguments.dim);
+                    .error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", cast(ulong)d, cast(ulong)tt.arguments.dim);
                     return error();
                 }
                 Type telem = (*tt.arguments)[cast(size_t)d].type;
@@ -2591,7 +2591,7 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
                 const d = mt.dim.toUInteger();
                 if (d >= tup.objects.dim)
                 {
-                    error(loc, "tuple index `%llu` exceeds length %llu", d, cast(ulong) tup.objects.dim);
+                    error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", d, cast(ulong) tup.objects.dim);
                     return returnError();
                 }
 

--- a/test/fail_compilation/ice12574.d
+++ b/test/fail_compilation/ice12574.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12574.d(40): Error: tuple index `2` exceeds length 2
+fail_compilation/ice12574.d(40): Error: tuple index `2` out of bounds `[0 .. 2]`
 fail_compilation/ice12574.d(53): Error: template instance `ice12574.reduce!("a", "a").reduce!(Tuple!(int, int, int))` error instantiating
 ---
 */

--- a/test/fail_compilation/typeerrors.d
+++ b/test/fail_compilation/typeerrors.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/typeerrors.d(32): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
-fail_compilation/typeerrors.d(37): Error: tuple index 4 exceeds 4
+fail_compilation/typeerrors.d(37): Error: tuple index `4` out of bounds `[0 .. 4]`
 fail_compilation/typeerrors.d(39): Error: variable `x` cannot be read at compile time
 fail_compilation/typeerrors.d(40): Error: cannot have array of `void()`
 fail_compilation/typeerrors.d(41): Error: cannot have array of scope `typeerrors.C`


### PR DESCRIPTION
Instead of the suggested "index `%d` is over or equal to the element count `%d`", I opted to use the same message as array out of bounds errors instead.