### PR TITLE
Fix 22977 - can escape scope pointer returned by nested function

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -158,7 +158,7 @@ bool checkMutableArguments(Scope* sc, FuncDeclaration fd, TypeFunction tf,
 
         void onRef(VarDeclaration v, bool transition) { eb.byref.push(v); }
         void onValue(VarDeclaration v) { eb.byvalue.push(v); }
-        void onFunc(FuncDeclaration fd) {}
+        void onFunc(FuncDeclaration fd, bool called) {}
         void onExp(Expression e, bool transition) {}
 
         scope EscapeByResults er = EscapeByResults(&onRef, &onValue, &onFunc, &onExp);
@@ -417,7 +417,7 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Identifier parId, 
         }
     }
 
-    void onFunc(FuncDeclaration fd)
+    void onFunc(FuncDeclaration fd, bool called)
     {
         //printf("fd = %s, %d\n", fd.toChars(), fd.tookAddressOf);
         if (parStc & STC.scope_)
@@ -862,7 +862,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag, bool byRef)
         result |= sc.setUnsafeDIP1000(gag, ae.loc, "reference to local variable `%s` assigned to non-scope `%s`", v, e1);
     }
 
-    void onFunc(FuncDeclaration func)
+    void onFunc(FuncDeclaration func, bool called)
     {
         if (log) printf("byfunc: %s, %d\n", func.toChars(), func.tookAddressOf);
         VarDeclarations vars;
@@ -992,7 +992,7 @@ bool checkThrowEscape(Scope* sc, Expression e, bool gag)
             notMaybeScope(v, new ThrowExp(e.loc, e));
         }
     }
-    void onFunc(FuncDeclaration fd) {}
+    void onFunc(FuncDeclaration fd, bool called) {}
     void onExp(Expression exp, bool retRefTransition) {}
 
     scope EscapeByResults er = EscapeByResults(&onRef, &onValue, &onFunc, &onExp);
@@ -1124,7 +1124,7 @@ bool checkNewEscape(Scope* sc, Expression e, bool gag)
         }
     }
 
-    void onFunc(FuncDeclaration fd) {}
+    void onFunc(FuncDeclaration fd, bool called) {}
 
     void onExp(Expression ee, bool retRefTransition)
     {
@@ -1236,15 +1236,20 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
                  *        return s;     // s is inferred as 'scope' but incorrectly tested in foo()
                  *    return null; }
                  */
-                !(!refs && p.parent == sc.func && pfunc.fes) &&
+                !(!refs && p.parent == sc.func && pfunc.fes)
+               )
+            {
                 /*
                  *  auto p(scope string s) {
                  *      string scfunc() { return s; }
                  *  }
                  */
-                !(!refs && sc.func.isFuncDeclaration().getLevel(pfunc, sc.intypeof) > 0)
-               )
-            {
+                if (sc.func.isFuncDeclaration().getLevel(pfunc, sc.intypeof) > 0 &&
+                    inferReturn(sc.func, sc.func.vthis, /*returnScope*/ !refs))
+                {
+                    return;
+                }
+
                 if (v.isParameter() && !v.isReturn())
                 {
                     // https://issues.dlang.org/show_bug.cgi?id=23191
@@ -1411,7 +1416,11 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
         }
     }
 
-    void onFunc(FuncDeclaration fd) {}
+    void onFunc(FuncDeclaration fd, bool called)
+    {
+        if (called && fd.isNested())
+            result |= sc.setUnsafeDIP1000(gag, e.loc, "escaping local variable through nested function `%s`", fd);
+    }
 
     void onExp(Expression ee, bool retRefTransition)
     {
@@ -1603,13 +1612,13 @@ void escapeByValue(Expression e, ref scope EscapeByResults er, bool retRefTransi
             escapeByValue(e.e1, er, retRefTransition);
         else
             escapeByRef(e.e1, er, retRefTransition);
-        er.byFunc(e.func);
+        er.byFunc(e.func, false);
     }
 
     void visitFunc(FuncExp e)
     {
         if (e.fd.tok == TOK.delegate_)
-            er.byFunc(e.fd);
+            er.byFunc(e.fd, false);
     }
 
     void visitTuple(TupleExp e)
@@ -1860,7 +1869,12 @@ void escapeByValue(Expression e, ref scope EscapeByResults er, bool retRefTransi
             if (fd && fd.isNested())
             {
                 if (tf.isreturn && tf.isScopeQual)
-                    er.byExp(e, false);
+                {
+                    if (tf.isreturnscope)
+                        er.byFunc(fd, true);
+                    else
+                        er.byExp(e, false);
+                }
             }
         }
 
@@ -1881,7 +1895,12 @@ void escapeByValue(Expression e, ref scope EscapeByResults er, bool retRefTransi
             if (fd && fd.isNested())
             {
                 if (tf.isreturn && tf.isScopeQual)
-                    er.byExp(e, false);
+                {
+                    if (tf.isreturnscope)
+                        er.byFunc(fd, true);
+                    else
+                        er.byExp(e, false);
+                }
             }
         }
     }
@@ -2195,7 +2214,10 @@ struct EscapeByResults
     /// called on variables with values containing pointers
     void delegate(VarDeclaration) byValue;
     /// called on nested functions that are turned into delegates
-    void delegate(FuncDeclaration) byFunc;
+    /// When `called` is true, it means the delegate escapes variables
+    /// from the closure through a call to it, while `false` means the
+    /// delegate itself escapes.
+    void delegate(FuncDeclaration, bool called) byFunc;
     /// called when expression temporaries are being returned by ref / address
     void delegate(Expression, bool retRefTransition) byExp;
 

--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -1996,7 +1996,7 @@ void escapeLive(Expression e, scope void delegate(VarDeclaration) onVar)
     scope EscapeByResults er = EscapeByResults(
         (VarDeclaration v, bool) => onVar(v),
         onVar,
-        (FuncDeclaration f) {},
+        (FuncDeclaration f, bool) {},
         (Expression e, bool) {},
         true,
     );

--- a/compiler/test/fail_compilation/test22977.d
+++ b/compiler/test/fail_compilation/test22977.d
@@ -1,0 +1,56 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test22977.d(16): Error: escaping local variable through nested function `scfunc`
+fail_compilation/test22977.d(22): Error: escaping reference to stack allocated value returned by `scfunc2()`
+---
+*/
+
+// Issue 22977 - [dip1000] can escape scope pointer returned by nested function
+// https://issues.dlang.org/show_bug.cgi?id=22977
+
+auto p0(scope string s) @safe
+{
+    string scfunc() { return s; }
+    return scfunc();
+}
+
+auto p1(scope string s) @safe
+{
+    ref string scfunc2() { return s; }
+    return scfunc2();
+}
+
+// Reduced from Mir
+struct Tuple(T...)
+{
+    T expand;
+}
+
+auto autoExpandAndForward(alias value)()
+{
+    return value.expand[0];
+}
+
+struct MapIterator
+{
+    int* p;
+    int* foo() scope
+    {
+        auto t = Tuple!(int*)(p);
+        return autoExpandAndForward!t;
+    }
+}
+
+// Reduced from Phobos
+float partial(alias fun)()
+{
+    return fun();
+}
+
+auto partialFunction() @safe
+{
+    int function() f = () => 0;
+    return &partial!(f);
+}


### PR DESCRIPTION
Blocked by:
* [x] https://github.com/dlang/phobos/pull/8481
* [x] https://github.com/atilaneves/automem/pull/69
* [ ] https://github.com/libmir/mir-algorithm/pull/464