### PR TITLE
Fix Issue 23010 - mixed in aliaseqs used as type don't initialize

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -647,7 +647,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 else
                     ti = dsym._init ? dsym._init.syntaxCopy() : null;
 
-                StorageClass storage_class = STC.temp | STC.local | dsym.storage_class;
+                StorageClass storage_class = STC.temp | dsym.storage_class;
                 if ((dsym.storage_class & STC.parameter) && (arg.storageClass & STC.parameter))
                     storage_class |= arg.storageClass;
                 auto v = new VarDeclaration(dsym.loc, arg.type, id, ti, storage_class);
@@ -655,14 +655,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 v.overlapped = dsym.overlapped;
 
                 v.dsymbolSemantic(sc);
-
-                if (sc.scopesym)
-                {
-                    //printf("adding %s to %s\n", v.toChars(), sc.scopesym.toChars());
-                    if (sc.scopesym.members)
-                        // Note this prevents using foreach() over members, because the limits can change
-                        sc.scopesym.members.push(v);
-                }
 
                 Expression e = new DsymbolExp(dsym.loc, v);
                 (*exps)[i] = e;
@@ -6854,7 +6846,12 @@ bool determineFields(AggregateDeclaration ad)
             return 1;
 
         if (v.aliassym)
-            return 0;   // If this variable was really a tuple, skip it.
+        {
+            // If this variable was really a tuple, process each element.
+            if (auto tup = v.aliassym.isTupleDeclaration())
+                return tup.foreachVar(tv => tv.apply(&func, ad));
+            return 0;
+        }
 
         if (v.storage_class & (STC.static_ | STC.extern_ | STC.tls | STC.gshared | STC.manifest | STC.ctfe | STC.templateparameter))
             return 0;

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -873,7 +873,11 @@ public:
         // Tuple field are expanded into multiple VarDeclarations
         // (we'll visit them later)
         if (vd.type && vd.type.isTypeTuple())
+        {
+            assert(vd.aliassym);
+            vd.toAlias().accept(this);
             return;
+        }
 
         if (vd.originalType && vd.type == AST.Type.tsize_t)
             origType = vd.originalType;
@@ -1652,6 +1656,13 @@ public:
         }
 
         assert(false, "This node type should be handled in the EnumDeclaration");
+    }
+
+    override void visit(AST.TupleDeclaration tup)
+    {
+        debug (Debug_DtoH) mixin(traceVisit!tup);
+
+        tup.foreachVar((s) { s.accept(this); });
     }
 
     /**

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -677,6 +677,11 @@ private extern(C++) final class Semantic2Visitor : Visitor
     {
         visit(cast(AggregateDeclaration) cd);
     }
+
+    override void visit(TupleDeclaration td)
+    {
+        td.foreachVar((s) { s.accept(this); });
+    }
 }
 
 /**

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -566,7 +566,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
             if (vd.aliassym)
             {
-                visitNoMultiObj(vd.toAlias());
+                vd.toAlias().accept(this);
                 return;
             }
 
@@ -871,6 +871,11 @@ void toObjFile(Dsymbol ds, bool multiobj)
                     ns.members.foreachDsymbol( (s) { s.accept(this); } );
                 }
             }
+        }
+
+        override void visit(TupleDeclaration tup)
+        {
+            tup.foreachVar((s) { s.accept(this); });
         }
 
     private:

--- a/test/runnable/test23010.d
+++ b/test/runnable/test23010.d
@@ -1,0 +1,43 @@
+// https://issues.dlang.org/show_bug.cgi?id=23010
+
+alias AliasSeq(T...) = T;
+
+mixin template faz() {
+    alias T = AliasSeq!(int);
+    T bar = 12345;
+
+    void write1() {
+        assert(bar[0] == 12345);
+    }
+
+    AliasSeq!(string, float) foo = AliasSeq!("qwerty", 1.25f);
+
+    void write2() {
+        assert(foo == AliasSeq!("qwerty", 1.25f));
+        foo = AliasSeq!("asdfg", 2.5f); // this even crashed before
+        assert(foo == AliasSeq!("asdfg", 2.5f));
+    }
+}
+
+void main() {
+    mixin faz!();
+    write1;
+    write2;
+    fun;
+}
+
+// Testing static symbol generation ('toobj.d' changes)
+
+static AliasSeq!(int, string) tup;
+
+void fun()
+{
+    auto v = tup;
+
+    struct S(T...) {
+        static T b;
+    }
+
+    alias T = S!(int, float);
+    auto p = T.b;
+}


### PR DESCRIPTION
`TupleDeclaration` elements were inserted to the `members` array of
current `ScopeDsymbol` but `TemplateMixin` declarations are already
expanded in statement level and this confused DMD backend.
After adding some code to insert tuple elements to `AggregateDeclaration.fields`
and for parsing tuples in `toObjFile`, the code in question can be removed.
No more hidden symbols (like `__tuple_field_0`) inside any `members` field.