### PR TITLE
Implement `private(this)` visibility attribute

### DIFF
--- a/changelog/private-this.dd
+++ b/changelog/private-this.dd
@@ -1,0 +1,24 @@
+Add experimental `private(this)` visibility attribute
+
+The `private` visibility attribute only limits access to the current module.
+While `class` encapsulation [can be ensured using package modules](https://dlang.org/blog/2018/11/06/lost-in-translation-encapsulation),
+some users dislike having to put classes into individual files to accomplish this.
+
+With the `-preview=privateThis` switch, member variables can now be marked invisible outside of the
+`class`, `struct` or `union` it's declared in.
+Note that this feature it not accepted as part of the D language yet.
+
+---
+class C
+{
+    private int x;
+    private(this) int y;
+}
+
+void main()
+{
+    auto c = new C();
+    c.x++; // allowed
+    c.y++; // not allowed
+}
+---

--- a/changelog/private-this.dd
+++ b/changelog/private-this.dd
@@ -6,7 +6,7 @@ some users dislike having to put classes into individual files to accomplish thi
 
 With the `-preview=privateThis` switch, member variables can now be marked invisible outside of the
 `class`, `struct` or `union` it's declared in.
-Note that this feature it not accepted as part of the D language yet.
+Note that this feature has not been accepted into the D language yet.
 
 ---
 class C

--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -239,31 +239,26 @@ bool checkAccess(Scope* sc, Package p)
  * Check whether symbols `s` is visible in `mod`.
  *
  * Params:
- *  mod = lookup origin
+ *  origin = lookup origin
  *  s = symbol to check for visibility
  * Returns: true if s is visible in mod
  */
-bool symbolIsVisible(Module mod, Dsymbol s)
+bool symbolIsVisible(Dsymbol origin, Dsymbol s)
 {
+    Module mod = origin.getAccessModule();
+
     // should sort overloads by ascending visibility instead of iterating here
     s = mostVisibleOverload(s);
     final switch (s.visible().kind)
     {
     case Visibility.Kind.undefined: return true;
     case Visibility.Kind.none: return false; // no access
+    case Visibility.Kind.privateThis: return origin == s.isMember2();
     case Visibility.Kind.private_: return s.getAccessModule() == mod;
     case Visibility.Kind.package_: return s.getAccessModule() == mod || hasPackageAccess(mod, s);
     case Visibility.Kind.protected_: return s.getAccessModule() == mod;
     case Visibility.Kind.public_, Visibility.Kind.export_: return true;
     }
-}
-
-/**
- * Same as above, but determines the lookup module from symbols `origin`.
- */
-bool symbolIsVisible(Dsymbol origin, Dsymbol s)
-{
-    return symbolIsVisible(origin.getAccessModule(), s);
 }
 
 /**
@@ -296,6 +291,7 @@ bool checkSymbolAccess(Scope *sc, Dsymbol s)
     {
     case Visibility.Kind.undefined: return true;
     case Visibility.Kind.none: return false; // no access
+    case Visibility.Kind.privateThis: return sc.getStructClassScope() == s.isMember2();
     case Visibility.Kind.private_: return sc._module == s.getAccessModule();
     case Visibility.Kind.package_: return sc._module == s.getAccessModule() || hasPackageAccess(sc._module, s);
     case Visibility.Kind.protected_: return hasProtectedAccess(sc, s);

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6527,6 +6527,7 @@ struct ASTBase
         {
             undefined,
             none,
+            privateThis,
             private_,
             package_,
             protected_,
@@ -6580,6 +6581,8 @@ struct ASTBase
             return null;
         case Visibility.Kind.none:
             return "none";
+        case Visibility.Kind.privateThis:
+            return "private(this)";
         case Visibility.Kind.private_:
             return "private";
         case Visibility.Kind.package_:

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -641,6 +641,11 @@ extern (C++) final class VisibilityDeclaration : AttribDeclaration
             visibility.pkg = tmp ? tmp.isPackage() : null;
             pkg_identifiers = null;
         }
+
+        if (visibility.kind == Visibility.Kind.privateThis && sds.isModule())
+        {
+            error("cannot be used in global scope");
+        }
         if (visibility.kind == Visibility.Kind.package_ && visibility.pkg && sc._module)
         {
             Module m = sc._module;

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -868,6 +868,8 @@ dmd -cov -unittest myprog.d
             "allow use of => for methods and top-level functions in addition to lambdas"),
         Feature("fixImmutableConv", "fixImmutableConv",
             "disallow unsound immutable conversions that were formerly incorrectly permitted"),
+        Feature("privateThis", "privateThis",
+            "add `private(this)` visibility attribute, private to the class/struct/union instead of module"),
     ];
 }
 

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -525,6 +525,7 @@ extern(D):
     {
         switch (d.visibility.kind)
         {
+            case Visibility.Kind.privateThis:
             case Visibility.Kind.private_:
                 buf.writeByte(privProtDef[0]);
                 break;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -130,6 +130,7 @@ struct Visibility
     {
         undefined,
         none,           // no access
+        privateThis,    // only within aggregate
         private_,
         package_,
         protected_,

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -507,6 +507,7 @@ struct Param final
     bool useExceptions;
     bool noSharedAccess;
     bool previewIn;
+    bool privateThis;
     bool shortenedMethods;
     bool betterC;
     bool addMain;
@@ -607,6 +608,7 @@ struct Param final
         useExceptions(true),
         noSharedAccess(),
         previewIn(),
+        privateThis(),
         shortenedMethods(),
         betterC(),
         addMain(),
@@ -673,7 +675,7 @@ struct Param final
         mapfile()
     {
     }
-    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool verbose = false, bool vcg_ast = false, bool showColumns = false, bool vtls = false, bool vtemplates = false, bool vtemplatesListInstances = false, bool vgc = false, bool vfield = false, bool vcomplex = true, bool vin = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, FeatureState useDIP25 = (FeatureState)-1, FeatureState useDIP1000 = (FeatureState)-1, bool fixImmutableConv = false, bool useDIP1021 = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, bool color = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = false, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool noSharedAccess = false, bool previewIn = false, bool shortenedMethods = false, bool betterC = false, bool addMain = false, bool allInst = false, bool fix16997 = true, bool fixAliasThis = false, bool inclusiveInContracts = false, bool ehnogc = false, FeatureState dtorFields = (FeatureState)-1, bool fieldwise = false, bool bitfields = false, FeatureState rvalueRefParam = (FeatureState)-1, CppStdRevision cplusplus = (CppStdRevision)201103u, bool showGaggedErrors = false, bool printErrorContext = false, bool manual = false, bool usage = false, bool mcpuUsage = false, bool transitionUsage = false, bool checkUsage = false, bool checkActionUsage = false, bool revertUsage = false, bool previewUsage = false, bool externStdUsage = false, bool hcUsage = false, bool logo = false, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, uint32_t errorLimit = 20u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* >* imppath = nullptr, Array<const char* >* fileImppath = nullptr, _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, Array<const char* >* debugids = nullptr, uint32_t versionlevel = 0u, Array<const char* >* versionids = nullptr, MessageStyle messageStyle = (MessageStyle)0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
+    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool verbose = false, bool vcg_ast = false, bool showColumns = false, bool vtls = false, bool vtemplates = false, bool vtemplatesListInstances = false, bool vgc = false, bool vfield = false, bool vcomplex = true, bool vin = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, FeatureState useDIP25 = (FeatureState)-1, FeatureState useDIP1000 = (FeatureState)-1, bool fixImmutableConv = false, bool useDIP1021 = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, bool color = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = false, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool noSharedAccess = false, bool previewIn = false, bool privateThis = false, bool shortenedMethods = false, bool betterC = false, bool addMain = false, bool allInst = false, bool fix16997 = true, bool fixAliasThis = false, bool inclusiveInContracts = false, bool ehnogc = false, FeatureState dtorFields = (FeatureState)-1, bool fieldwise = false, bool bitfields = false, FeatureState rvalueRefParam = (FeatureState)-1, CppStdRevision cplusplus = (CppStdRevision)201103u, bool showGaggedErrors = false, bool printErrorContext = false, bool manual = false, bool usage = false, bool mcpuUsage = false, bool transitionUsage = false, bool checkUsage = false, bool checkActionUsage = false, bool revertUsage = false, bool previewUsage = false, bool externStdUsage = false, bool hcUsage = false, bool logo = false, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, uint32_t errorLimit = 20u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* >* imppath = nullptr, Array<const char* >* fileImppath = nullptr, _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, Array<const char* >* debugids = nullptr, uint32_t versionlevel = 0u, Array<const char* >* versionids = nullptr, MessageStyle messageStyle = (MessageStyle)0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
         obj(obj),
         multiobj(multiobj),
         trace(trace),
@@ -708,6 +710,7 @@ struct Param final
         useExceptions(useExceptions),
         noSharedAccess(noSharedAccess),
         previewIn(previewIn),
+        privateThis(privateThis),
         shortenedMethods(shortenedMethods),
         betterC(betterC),
         addMain(addMain),
@@ -930,11 +933,12 @@ struct Visibility final
     {
         undefined = 0u,
         none = 1u,
-        private_ = 2u,
-        package_ = 3u,
-        protected_ = 4u,
-        public_ = 5u,
-        export_ = 6u,
+        privateThis = 2u,
+        private_ = 3u,
+        package_ = 4u,
+        protected_ = 5u,
+        public_ = 6u,
+        export_ = 7u,
     };
 
     Kind kind;

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -133,6 +133,7 @@ extern (C++) struct Param
     bool useExceptions = true;   // support exception handling
     bool noSharedAccess;         // read/write access to shared memory objects
     bool previewIn;         // `in` means `[ref] scope const`, accepts rvalues
+    bool privateThis;       // add `private(this)`, limiting access to this class/struct/union
     bool shortenedMethods; // allow => in normal function declarations
     bool betterC;           // be a "better C" compiler; no dependency on D runtime
     bool addMain;           // add a default main() function

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -133,6 +133,7 @@ struct Param
     bool useExceptions; // support exception handling
     bool noSharedAccess; // read/write access to shared memory objects
     bool previewIn;     // `in` means `scope const`, perhaps `ref`, accepts rvalues
+    bool privateThis;   // add `private(this)`, limiting access to this class/struct/union
     bool shortenedMethods; // allow => in normal function declarations
     bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3015,6 +3015,8 @@ extern (D) string visibilityToString(Visibility.Kind kind) nothrow pure
         return null;
     case Visibility.Kind.none:
         return "none";
+    case Visibility.Kind.privateThis:
+        return "private(this)";
     case Visibility.Kind.private_:
         return "private";
     case Visibility.Kind.package_:

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -860,7 +860,22 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 }
 
             case TOK.private_:
-                prot = AST.Visibility.Kind.private_;
+                if (peekNext() == TOK.leftParenthesis && peekNext2() == TOK.this_)
+                {
+                    if (!global.params.privateThis)
+                    {
+                        error("use `-preview=privateThis` to enable usage of `private(this)`");
+                    }
+                    nextToken();
+                    nextToken();
+                    nextToken();
+                    check(TOK.rightParenthesis);
+                    prot = AST.Visibility.Kind.privateThis;
+                }
+                else
+                {
+                    prot = AST.Visibility.Kind.private_;
+                }
                 goto Lprot;
 
             case TOK.package_:
@@ -889,7 +904,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     }
                     pAttrs.visibility.kind = prot;
 
-                    nextToken();
+                    if (pAttrs.visibility.kind != AST.Visibility.Kind.privateThis)
+                        nextToken();
 
                     // optional qualified package identifier to bind
                     // visibility to

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -69,6 +69,7 @@ uint visibilityToCVAttr(Visibility.Kind vis) pure nothrow @safe @nogc
 
     final switch (vis)
     {
+        case Visibility.Kind.privateThis:
         case Visibility.Kind.private_:       attribute = 1;  break;
         case Visibility.Kind.package_:       attribute = 2;  break;
         case Visibility.Kind.protected_:     attribute = 2;  break;

--- a/test/compilable/previewhelp.d
+++ b/test/compilable/previewhelp.d
@@ -18,5 +18,6 @@ Upcoming language changes listed by -preview=name:
   =inclusiveincontracts 'in' contracts of overridden methods must be a superset of parent contract
   =shortenedMethods allow use of => for methods and top-level functions in addition to lambdas
   =fixImmutableConv disallow unsound immutable conversions that were formerly incorrectly permitted
+  =privateThis      add `private(this)` visibility attribute, private to the class/struct/union instead of module
 ----
 */

--- a/test/fail_compilation/prot_privatethis.d
+++ b/test/fail_compilation/prot_privatethis.d
@@ -1,0 +1,63 @@
+/*
+REQUIRED_ARGS: -preview=privateThis
+TEST_OUTPUT:
+---
+fail_compilation/prot_privatethis.d(35): Error: no property `secret` for type `prot_privatethis.C.Nested`
+fail_compilation/prot_privatethis.d(56): Error: no property `secret` for type `prot_privatethis.C`
+fail_compilation/prot_privatethis.d(57): Error: no property `internalFunc` for type `prot_privatethis.C`
+fail_compilation/prot_privatethis.d(58): Error: no property `mixedInSecret` for type `prot_privatethis.C`
+fail_compilation/prot_privatethis.d(61): Error: no property `secret` for type `prot_privatethis.U`
+---
+*/
+
+mixin template MT()
+{
+    private(this) string mixedInSecret;
+    void accessSecret() { secret++; }
+}
+
+class C
+{
+    private(this) int secret;
+    mixin MT!();
+
+    struct Nested
+    {
+        private(this) int secret;
+        void setSecret(int secret) { this.secret = secret; }
+    }
+
+    Nested nested;
+
+    this(int secret)
+    {
+        this.secret = secret;
+        nested.secret = 3; // no access
+        nested.setSecret(3); // access
+        mixedInSecret = "s"; // access
+        internalFunc(); // access
+        accessSecret(); // access
+    }
+
+    private(this) void internalFunc() { }
+}
+
+static assert(__traits(getVisibility, C.secret) == "private(this)");
+
+union U
+{
+    private(this) int secret;
+    private int butNotReally;
+}
+
+void main()
+{
+    C c = new C(2);
+    assert(c.secret == 2); // no access
+    c.internalFunc(); // no access
+    c.mixedInSecret = ""; // no access
+
+    U u;
+    u.secret = 3; // no access
+    u.butNotReally = 4; // access
+}

--- a/test/fail_compilation/prot_privatethis_global.d
+++ b/test/fail_compilation/prot_privatethis_global.d
@@ -1,0 +1,18 @@
+/*
+REQUIRED_ARGS: -preview=privateThis
+TEST_OUTPUT:
+---
+fail_compilation/prot_privatethis_global.d(11): Error: visibility attribute `private(this)` cannot be used in global scope
+fail_compilation/prot_privatethis_global.d(13): Error: visibility attribute `private(this)` cannot be used in global scope
+fail_compilation/prot_privatethis_global.d(16): Error: visibility attribute `private(this)` cannot be used in global scope
+---
+*/
+
+private(this) int x;
+
+private(this): int y;
+
+private(this)
+{
+    int z;
+}

--- a/test/fail_compilation/prot_privatethis_preview.d
+++ b/test/fail_compilation/prot_privatethis_preview.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/prot_privatethis_preview.d(10): Error: use `-preview=privateThis` to enable usage of `private(this)`
+---
+*/
+
+class C
+{
+    private(this) int x;
+}


### PR DESCRIPTION
Based on recent discussions in the newsgroup about `private` to the class instead of module:

[`restricted` member variables](https://forum.dlang.org/post/ccqkjqeueuapanfrbdxj@forum.dlang.org)
[Adding a new design constraint to D](https://forum.dlang.org/post/sldtyzrqpsqgobsgcmpy@forum.dlang.org)

The `private(this)` syntax is inspired by Scala's `private[this]` and D's `package(name)`. 
It's only enabled under the `-preview=privateThis` switch since it's not part of the language yet.