### PR TITLE
dtoh: Use `fields` instead of `members` to generate default constructors

### DIFF
--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1263,41 +1263,38 @@ public:
             size_t varCount;
             bool first = true;
             buf.level++;
-            foreach (m; *sd.members)
+            foreach (vd; sd.fields)
             {
-                if (auto vd = m.isVarDeclaration())
+                if (!memberField(vd) || vd.overlapped)
+                    continue;
+                varCount++;
+
+                if (!vd._init && !vd.type.isTypeBasic() && !vd.type.isTypePointer && !vd.type.isTypeStruct &&
+                    !vd.type.isTypeClass && !vd.type.isTypeDArray && !vd.type.isTypeSArray)
                 {
-                    if (!memberField(vd))
-                        continue;
-                    varCount++;
-
-                    if (!vd._init && !vd.type.isTypeBasic() && !vd.type.isTypePointer && !vd.type.isTypeStruct &&
-                        !vd.type.isTypeClass && !vd.type.isTypeDArray && !vd.type.isTypeSArray)
-                    {
-                        continue;
-                    }
-                    if (vd._init && vd._init.isVoidInitializer())
-                        continue;
-
-                    if (first)
-                    {
-                        buf.writestringln(" :");
-                        first = false;
-                    }
-                    else
-                    {
-                        buf.writestringln(",");
-                    }
-                    writeIdentifier(vd, true);
-                    buf.writeByte('(');
-
-                    if (vd._init)
-                    {
-                        auto e = AST.initializerToExpression(vd._init);
-                        printExpressionFor(vd.type, e, true);
-                    }
-                    buf.printf(")");
+                    continue;
                 }
+                if (vd._init && vd._init.isVoidInitializer())
+                    continue;
+
+                if (first)
+                {
+                    buf.writestringln(" :");
+                    first = false;
+                }
+                else
+                {
+                    buf.writestringln(",");
+                }
+                writeIdentifier(vd, true);
+                buf.writeByte('(');
+
+                if (vd._init)
+                {
+                    auto e = AST.initializerToExpression(vd._init);
+                    printExpressionFor(vd.type, e, true);
+                }
+                buf.printf(")");
             }
             buf.level--;
             buf.writenl();
@@ -1308,49 +1305,43 @@ public:
             {
                 buf.printf("%s(", sd.ident.toChars());
                 first = true;
-                foreach (m; *sd.members)
+                foreach (vd; sd.fields)
                 {
-                    if (auto vd = m.isVarDeclaration())
+                    if (!memberField(vd) || vd.overlapped)
+                        continue;
+                    if (!first)
+                        buf.writestring(", ");
+                    assert(vd.type);
+                    assert(vd.ident);
+                    typeToBuffer(vd.type, vd, true);
+                    // Don't print default value for first parameter to not clash
+                    // with the default ctor defined above
+                    if (!first)
                     {
-                        if (!memberField(vd))
-                            continue;
-                        if (!first)
-                            buf.writestring(", ");
-                        assert(vd.type);
-                        assert(vd.ident);
-                        typeToBuffer(vd.type, vd, true);
-                        // Don't print default value for first parameter to not clash
-                        // with the default ctor defined above
-                        if (!first)
-                        {
-                            buf.writestring(" = ");
-                            printExpressionFor(vd.type, findDefaultInitializer(vd));
-                        }
-                        first = false;
+                        buf.writestring(" = ");
+                        printExpressionFor(vd.type, findDefaultInitializer(vd));
                     }
+                    first = false;
                 }
                 buf.writestring(") :");
                 buf.level++;
                 buf.writenl();
 
                 first = true;
-                foreach (m; *sd.members)
+                foreach (vd; sd.fields)
                 {
-                    if (auto vd = m.isVarDeclaration())
-                    {
-                        if (!memberField(vd))
-                            continue;
+                    if (!memberField(vd) || vd.overlapped)
+                        continue;
 
-                        if (first)
-                            first = false;
-                        else
-                            buf.writestringln(",");
+                    if (first)
+                        first = false;
+                    else
+                        buf.writestringln(",");
 
-                        writeIdentifier(vd, true);
-                        buf.writeByte('(');
-                        writeIdentifier(vd, true);
-                        buf.writeByte(')');
-                    }
+                    writeIdentifier(vd, true);
+                    buf.writeByte('(');
+                    writeIdentifier(vd, true);
+                    buf.writeByte(')');
                 }
                 buf.writenl();
                 buf.writestringln("{}");

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -804,7 +804,8 @@ public:
     static const char* canonicalName(const char* name);
     static void free(const char* str);
     const char* toChars() const;
-    FileName()
+    FileName() :
+        str()
     {
     }
 };
@@ -856,10 +857,11 @@ struct Global final
         debugids(),
         hasMainFunction(),
         varSequenceNumber(1u),
-        fileManager()
+        fileManager(),
+        preprocess()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, FileName(*preprocess)(FileName , const Loc& , Array<const char* >& cppswitches, bool& , OutBuffer* defines) = nullptr) :
         inifilename(inifilename),
         copyright(copyright),
         written(written),
@@ -877,7 +879,8 @@ struct Global final
         debugids(debugids),
         hasMainFunction(hasMainFunction),
         varSequenceNumber(varSequenceNumber),
-        fileManager(fileManager)
+        fileManager(fileManager),
+        preprocess(preprocess)
         {}
 };
 
@@ -1095,9 +1098,15 @@ private:
     size_t len;
     uint64_t* ptr;
 public:
-    BitArray()
+    BitArray() :
+        len(),
+        ptr()
     {
     }
+    BitArray(uint64_t len, uint64_t* ptr = nullptr) :
+        len(len),
+        ptr(ptr)
+        {}
 };
 
 class ScopeDsymbol : public Dsymbol
@@ -1177,9 +1186,15 @@ public:
     uint32_t get() const;
     bool isPack() const;
     void setPack(bool pack);
-    structalign_t()
+    structalign_t() :
+        value(0u),
+        pack()
     {
     }
+    structalign_t(uint16_t value, bool pack = false) :
+        value(value),
+        pack(pack)
+        {}
 };
 
 enum class PINLINE : uint8_t
@@ -1678,6 +1693,10 @@ public:
     char* peekChars();
     char* extractChars();
     OutBuffer() :
+        data(),
+        offset(),
+        notlinehead(),
+        fileMapping(),
         doindent(),
         spaces(),
         level()
@@ -6114,6 +6133,9 @@ public:
     MacroTable()
     {
     }
+    MacroTable(void* mactab) :
+        mactab(mactab)
+        {}
 };
 
 extern const char* mangleExact(FuncDeclaration* fd);
@@ -6673,7 +6695,8 @@ private:
     // Ignoring var u alignment 8
     __AnonStruct__u u;
 public:
-    UnionExp()
+    UnionExp() :
+        u()
     {
     }
 };
@@ -7875,10 +7898,12 @@ public:
         omfobj(false),
         FloatProperties(),
         DoubleProperties(),
-        RealProperties()
+        RealProperties(),
+        tvalist(),
+        params()
     {
     }
-    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(), TargetCPP cpp = TargetCPP(), TargetObjC objc = TargetObjC(), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11u, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool omfobj = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >()) :
+    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(), TargetCPP cpp = TargetCPP(), TargetObjC objc = TargetObjC(), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11u, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool omfobj = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(), Type* tvalist = nullptr, const Param* params = nullptr) :
         os(os),
         osMajor(osMajor),
         ptrsize(ptrsize),
@@ -7901,7 +7926,9 @@ public:
         omfobj(omfobj),
         FloatProperties(FloatProperties),
         DoubleProperties(DoubleProperties),
-        RealProperties(RealProperties)
+        RealProperties(RealProperties),
+        tvalist(tvalist),
+        params(params)
         {}
 };
 

--- a/test/compilable/dtoh_AnonDeclaration.d
+++ b/test/compilable/dtoh_AnonDeclaration.d
@@ -61,9 +61,21 @@ struct S final
         int32_t innerPrivate;
         int32_t innerBar;
     };
-    S()
+    S() :
+        y(),
+        z(),
+        outerPrivate(),
+        innerPrivate(),
+        innerBar()
     {
     }
+    S(int32_t y, double z = NAN, int32_t outerPrivate = 0, int32_t innerPrivate = 0, int32_t innerBar = 0) :
+        y(y),
+        z(z),
+        outerPrivate(outerPrivate),
+        innerPrivate(innerPrivate),
+        innerBar(innerBar)
+        {}
 };
 
 extern void foo();

--- a/test/compilable/dtoh_StructDeclaration.d
+++ b/test/compilable/dtoh_StructDeclaration.d
@@ -173,12 +173,16 @@ struct A final
 
     A() :
         a(),
-        s()
+        s(),
+        x(),
+        y()
     {
     }
-    A(int32_t a, S s = S()) :
+    A(int32_t a, S s = S(), int32_t x = 0, int32_t y = 0) :
         a(a),
-        s(s)
+        s(s),
+        x(x),
+        y(y)
         {}
 };
 
@@ -196,11 +200,13 @@ private:
     char smallarray[1$?:32=u|64=LLU$];
 public:
     Array() :
-        length()
+        length(),
+        data()
     {
     }
-    Array(uint32_t length) :
-        length(length)
+    Array(uint32_t length, _d_dynamicArray< char > data = {}) :
+        length(length),
+        data(data)
         {}
 };
 

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -219,9 +219,13 @@ struct ImportedBuffer final
 {
     typedef ActualBuffer Buffer;
     ActualBuffer buffer2;
-    ImportedBuffer()
+    ImportedBuffer() :
+        buffer2()
     {
     }
+    ImportedBuffer(ActualBuffer buffer2) :
+        buffer2(buffer2)
+        {}
 };
 ---
 */

--- a/test/compilable/dtoh_mangling.d
+++ b/test/compilable/dtoh_mangling.d
@@ -64,9 +64,15 @@ struct HasMangleMember final
     int32_t someAttrC;
     int32_t someAttrCpp;
     void hasDefaultVar(int32_t i = someAttrC);
-    HasMangleMember()
+    HasMangleMember() :
+        someAttrC(),
+        someAttrCpp()
     {
     }
+    HasMangleMember(int32_t someAttrC, int32_t someAttrCpp = 0) :
+        someAttrC(someAttrC),
+        someAttrCpp(someAttrCpp)
+        {}
 };
 
 extern "C" void hasDefaultVar(int32_t i = someVarC);

--- a/test/compilable/dtoh_protection.d
+++ b/test/compilable/dtoh_protection.d
@@ -50,9 +50,21 @@ protected:
 private:
     int32_t e;
 public:
-    S1()
+    S1() :
+        a(),
+        b(),
+        c(),
+        d(),
+        e()
     {
     }
+    S1(int32_t a, int32_t b = 0, int32_t c = 0, int32_t d = 0, int32_t e = 0) :
+        a(a),
+        b(b),
+        c(c),
+        d(d),
+        e(e)
+        {}
 };
 
 class S2 final
@@ -102,10 +114,12 @@ public:
     public:
         int32_t publicInner;
         PublicInnerStruct() :
+            privateInner(),
             publicInner()
         {
         }
-        PublicInnerStruct(int32_t publicInner) :
+        PublicInnerStruct(int32_t privateInner, int32_t publicInner = 0) :
+            privateInner(privateInner),
             publicInner(publicInner)
             {}
     };
@@ -118,10 +132,12 @@ private:
     public:
         int32_t publicInner;
         PrivateInnerClass() :
+            privateInner(),
             publicInner()
         {
         }
-        PrivateInnerClass(int32_t publicInner) :
+        PrivateInnerClass(int32_t privateInner, int32_t publicInner = 0) :
+            privateInner(privateInner),
             publicInner(publicInner)
             {}
     };
@@ -142,9 +158,13 @@ private:
 
 public:
     typedef PrivateInnerEnum PublicAlias;
-    Outer()
+    Outer() :
+        privateOuter()
     {
     }
+    Outer(int32_t privateOuter) :
+        privateOuter(privateOuter)
+        {}
 };
 ---
 */


### PR DESCRIPTION
It's more reliable this way, for example:
```d
extern (C++) struct S
{
    int a;
    public int b;
}
```
it was generating:
```cpp
struct S final
{
    int32_t a;
    int32_t b;
    S() :
        a()  // Note: variable 'b' was omitted because it's inside a VisibilityDeclaration.
    {
    }
    S(int32_t a) :
        a(a)
        {}
};
```
Now 'b' is added correctly.
The same with anonymous struct fields.
Union fields are omitted for now though (not sure how to handle that case).