### PR TITLE
Refactor address-taking code and use it to give a better error message

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2138,7 +2138,8 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             }
             if (f)
             {
-                f.tookAddressOf++;
+                // f.tookAddressOf++;
+                f.takeAddressOf(e, sc);
                 auto se = new SymOffExp(e.loc, f, 0, false);
                 auto se2 = se.expressionSemantic(sc);
                 // Let SymOffExp::castTo() do the heavy lifting
@@ -2416,7 +2417,8 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                     result = new SymOffExp(e.loc, f, 0, false);
                     result.type = t;
                 }
-                f.tookAddressOf++;
+                f.takeAddressOf(e, sc);
+                // f.tookAddressOf++;
                 return result;
             }
         }
@@ -2446,7 +2448,8 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
         if (tb.equals(typeb) && !e.hasOverloads)
         {
             int offset;
-            e.func.tookAddressOf++;
+            // e.func.tookAddressOf++;
+            e.func.takeAddressOf(e, sc);
             if (e.func.tintro && e.func.tintro.nextOf().isBaseOf(e.func.type.nextOf(), &offset) && offset)
                 e.error("%s", msg.ptr);
             auto result = e.copy();
@@ -2466,7 +2469,8 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                     if (f.tintro && f.tintro.nextOf().isBaseOf(f.type.nextOf(), &offset) && offset)
                         e.error("%s", msg.ptr);
                     if (f != e.func)    // if address not already marked as taken
-                        f.tookAddressOf++;
+                        f.takeAddressOf(e, sc);
+                        // f.tookAddressOf++;
                     auto result = new DelegateExp(e.loc, e.e1, f, false, e.vthis2);
                     result.type = t;
                     return result;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1052,7 +1052,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                             // or a delegate that doesn't escape a reference to the function
                             FuncDeclaration f = fe.fd;
                             if (f.tookAddressOf)
-                                f.tookAddressOf--;
+                                f.clearAddressTakens();
+                                // f.tookAddressOf--;
                         }
                     }
                 }

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -843,8 +843,8 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag, bool byRef)
          * closure to be allocated.
          */
         if (va && va.isScope() && !(va.storage_class & STC.return_) && func.tookAddressOf)
-            --func.tookAddressOf;
-
+            // --func.tookAddressOf;
+            func.clearAddressTakens();
         foreach (v; vars)
         {
             //printf("v = %s\n", v.toChars());

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2080,7 +2080,8 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                     /* Function literals can only appear once, so if this
                      * appearance was scoped, there cannot be any others.
                      */
-                    fe.fd.tookAddressOf = 0;
+                    // fe.fd.tookAddressOf = 0;
+                    fe.fd.clearAddressTakens();
                 }
                 else if (auto de = a.isDelegateExp())
                 {
@@ -2093,7 +2094,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                         if (auto f = ve.var.isFuncDeclaration())
                         {
                             if (f.tookAddressOf)
-                                --f.tookAddressOf;
+                                f.clearAddressTakens(); //--f.tookAddressOf;
                             //printf("--tookAddressOf = %d\n", f.tookAddressOf);
                         }
                     }
@@ -4134,7 +4135,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.fd.vthis = null;
             }
         }
-        exp.fd.tookAddressOf++;
+        exp.fd.takeAddressOf(exp, sc); // exp.fd.tookAddressOf++;
 
     Ldone:
         sc = sc.pop();
@@ -5153,7 +5154,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // Handle the case of a direct lambda call
         if (exp.f && exp.f.isFuncLiteralDeclaration() && sc.func && !sc.intypeof)
         {
-            exp.f.tookAddressOf = 0;
+            exp.f.clearAddressTakens(); // exp.f.tookAddressOf = 0;
         }
 
         result = Expression.combine(argprefix, exp);
@@ -7011,7 +7012,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 f = f.toAliasFunc(); // FIXME, should see overloads
                                      // https://issues.dlang.org/show_bug.cgi?id=1983
                 if (!dve.hasOverloads)
-                    f.tookAddressOf++;
+                    f.takeAddressOf(exp, sc); // f.tookAddressOf++;
 
                 Expression e;
                 if (f.needThis())
@@ -7054,7 +7055,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (!sc.isFromSpeculativeSemanticContext() && (!ve.hasOverloads || (f.isNested() && !f.needThis())))
                 {
                     // TODO: Refactor to use a proper interface that can keep track of causes.
-                    f.tookAddressOf++;
+                    f.takeAddressOf(exp, sc); // f.tookAddressOf++;
                 }
 
                 if (f.isNested() && !f.needThis())

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -347,9 +347,7 @@ extern (C++) class FuncDeclaration : Declaration
     ///
     void clearAddressTakens()
     {
-        // Seems to cause memory corruption.
-        // destroy(*addressTakens);
-        addressTakens = null;
+        addressTakens.setDim(0);
         // As above
         tookAddressOf = 0;
     }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1386,7 +1386,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
         else
         {
             if (global.params.useDIP1000 == FeatureState.enabled)
-                ++(cast(FuncExp)flde).fd.tookAddressOf;  // allocate a closure unless the opApply() uses 'scope'
+                (cast(FuncExp)flde).fd.takeAddressOf(flde, sc2);  // allocate a closure unless the opApply() uses 'scope'
         }
         assert(tab.ty == Tstruct || tab.ty == Tclass);
         assert(sapply);
@@ -1670,7 +1670,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
         fld.fbody = fs._body;
         Expression flde = new FuncExp(fs.loc, fld);
         flde = flde.expressionSemantic(sc);
-        fld.tookAddressOf = 0;
+        fld.clearAddressTakens();
         if (flde.op == EXP.error)
             return null;
         return cast(FuncExp)flde;


### PR DESCRIPTION
Sketch towards structuring the escape code. Strange functions lying in ponds manipulating integers is no basis for a system of compilation.

much to clean up but enough to be looked at.