### PR TITLE
Add predefined version `D_Optimized` when compiling with `-O`

### DIFF
--- a/changelog/d_optimized.dd
+++ b/changelog/d_optimized.dd
@@ -1,0 +1,5 @@
+Add predefined version `D_Optimized` when compiling with `-O`
+
+So that code can be aware of whether it's compiled with `-O`, e.g., to
+distinguish between debug and optimized release builds (not necessarily
+using `-release`).

--- a/changelog/d_optimized.dd
+++ b/changelog/d_optimized.dd
@@ -1,5 +1,5 @@
 Add predefined version `D_Optimized` when compiling with `-O`
 
-So that code can be aware of whether it's compiled with `-O`, e.g., to
-distinguish between debug and optimized release builds (not necessarily
-using `-release`).
+It allows code to distinguish whether it's being compiled with optimizations enabled (the `-O` flag was provided).
+This is orthogonal to whether `-release` mode is active - for that see the
+predefined versions `assert`, `D_NoBoundsChecks`, `D_Invariants`, etc.

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1204,6 +1204,9 @@ void addDefaultVersionIdentifiers(const ref Param params, const ref Target tgt)
 
     if (params.tracegc)
         VersionCondition.addPredefinedGlobalIdent("D_ProfileGC");
+
+    if (driverParams.optimize)
+        VersionCondition.addPredefinedGlobalIdent("D_Optimized");
 }
 
 /**

--- a/compiler/test/compilable/version_d_optimized.d
+++ b/compiler/test/compilable/version_d_optimized.d
@@ -1,0 +1,15 @@
+/+
+ARG_SETS: -version=Unoptimized
+ARG_SETS: -O
++/
+
+version (Unoptimized)
+{
+    version (D_Optimized)
+        static assert(0);
+}
+else
+{
+    version (D_Optimized) { /* expected */ } else
+        static assert(0);
+}

--- a/compiler/test/fail_compilation/reserved_version.d
+++ b/compiler/test/fail_compilation/reserved_version.d
@@ -117,6 +117,7 @@ fail_compilation/reserved_version.d(218): Error: version identifier `D_PreCondit
 fail_compilation/reserved_version.d(219): Error: version identifier `D_PostConditions` is reserved and cannot be set
 fail_compilation/reserved_version.d(220): Error: version identifier `D_ProfileGC` is reserved and cannot be set
 fail_compilation/reserved_version.d(221): Error: version identifier `D_Invariants` is reserved and cannot be set
+fail_compilation/reserved_version.d(222): Error: version identifier `D_Optimized` is reserved and cannot be set
 ---
 */
 
@@ -240,6 +241,7 @@ version = D_PreConditions;
 version = D_PostConditions;
 version = D_ProfileGC;
 version = D_Invariants;
+version = D_Optimized;
 
 // This should work though
 debug = DigitalMars;
@@ -351,3 +353,4 @@ debug = AVR;
 debug = D_PreConditions;
 debug = D_PostConditions;
 debug = D_ProfileGC;
+debug = D_Optimized;

--- a/compiler/test/fail_compilation/reserved_version_switch.d
+++ b/compiler/test/fail_compilation/reserved_version_switch.d
@@ -107,6 +107,7 @@
 // REQUIRED_ARGS: -version=D_PostConditions
 // REQUIRED_ARGS: -version=D_ProfileGC
 // REQUIRED_ARGS: -version=D_Invariants
+// REQUIRED_ARGS: -version=D_Optimized
 // REQUIRED_ARGS: -debug=DigitalMars
 // REQUIRED_ARGS: -debug=GNU
 // REQUIRED_ARGS: -debug=LDC
@@ -211,6 +212,7 @@
 // REQUIRED_ARGS: -debug=D_PostConditions
 // REQUIRED_ARGS: -debug=D_ProfileGC
 // REQUIRED_ARGS: -debug=D_Invariants
+// REQUIRED_ARGS: -debug=D_Optimized
 /*
 TEST_OUTPUT:
 ---
@@ -321,5 +323,6 @@ Error: version identifier `D_PreConditions` is reserved and cannot be set
 Error: version identifier `D_PostConditions` is reserved and cannot be set
 Error: version identifier `D_ProfileGC` is reserved and cannot be set
 Error: version identifier `D_Invariants` is reserved and cannot be set
+Error: version identifier `D_Optimized` is reserved and cannot be set
 ---
 */


### PR DESCRIPTION
So that code can be aware of whether it's compiled with `-O`, e.g., to distinguish between debug and optimized release builds (not necessarily using `-release`).

Rationale: https://dlang.slack.com/archives/C1ZDHBB2S/p1655556068067789

I'd have use for it for optimized druntime/Phobos unittests with LDC as well, where I've so far had to work around benign failures with `-O` by either preventing optimizations for unittest blocks/test helper functions (via `@optStrategy("none")`), or disabling some checks altogether.