### PR TITLE
ImportC: Implement semantic support for register variables

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2972,7 +2972,8 @@ final class CParser(AST) : Parser!AST
                 cparseGnuAttributes(specifier);
             if (specifier.mod & MOD.xconst)
                 t = toConst(t);
-            auto param = new AST.Parameter(STC.parameter, t, id, null, null);
+            auto param = new AST.Parameter(specifiersToSTC(LVL.parameter, specifier),
+                                           t, id, null, null);
             parameters.push(param);
             if (token.value == TOK.rightParenthesis)
                 break;
@@ -4638,6 +4639,15 @@ final class CParser(AST) : Parser!AST
                     stc = AST.STC.extern_ | AST.STC.gshared;
                 else if (specifier.scw & SCW.xstatic)
                     stc = AST.STC.gshared;
+                else if (specifier.scw & SCW.xregister)
+                    stc = AST.STC.register;
+            }
+            else if (level == LVL.parameter)
+            {
+                if (specifier.scw & SCW.xregister)
+                    stc = AST.STC.register | AST.STC.parameter;
+                else
+                    stc = AST.STC.parameter;
             }
             else if (level == LVL.member)
             {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6963,6 +6963,22 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.error("cannot take address of `%s`", exp.e1.toChars());
             return setError();
         }
+        if (sc.flags & SCOPE.Cfile)
+        {
+            auto e1x = exp.e1;
+            while (e1x.op == EXP.dotVariable)
+                e1x = e1x.isDotVarExp().e1;
+            if (auto ve = e1x.isVarExp())
+            {
+                // C11 6.5.3.2 A variable that has its address taken cannot be
+                // stored in a register.
+                if (ve.var.storage_class & STC.register)
+                {
+                    exp.error("cannot take address of register variable `%s`", ve.toChars());
+                    return setError();
+                }
+            }
+        }
         if (auto dve = exp.e1.isDotVarExp())
         {
             /* https://issues.dlang.org/show_bug.cgi?id=22749

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -483,7 +483,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if ((funcdecl.flags & FUNCFLAG.inferScope) && !(fparam.storageClass & STC.scope_))
                         stc |= STC.maybescope;
 
-                    stc |= fparam.storageClass & (STC.IOR | STC.return_ | STC.scope_ | STC.lazy_ | STC.final_ | STC.TYPECTOR | STC.nodtor | STC.returnScope);
+                    stc |= fparam.storageClass & (STC.IOR | STC.return_ | STC.scope_ | STC.lazy_ | STC.final_ | STC.TYPECTOR | STC.nodtor | STC.returnScope | STC.register);
                     v.storage_class = stc;
                     v.dsymbolSemantic(sc2);
                     if (!sc2.insert(v))

--- a/test/compilable/testcstuff1.c
+++ b/test/compilable/testcstuff1.c
@@ -486,6 +486,16 @@ void testoverflow()
 
 /********************************/
 
+int testregister(register int x)
+{
+  register int y = x * 2;
+  register int z[] = {x, y};
+
+  return y + sizeof z;
+}
+
+/********************************/
+
 int printf(const char*, ...);
 
 int main()

--- a/test/fail_compilation/failcstuff1.c
+++ b/test/fail_compilation/failcstuff1.c
@@ -63,6 +63,7 @@ fail_compilation/failcstuff1.c(663): Error: multiple storage classes in declarat
 fail_compilation/failcstuff1.c(664): Error: multiple storage classes in declaration specifiers
 fail_compilation/failcstuff1.c(666): Error: `inline` and `_Noreturn` function specifiers not allowed for `_Thread_local`
 fail_compilation/failcstuff1.c(667): Error: `inline` and `_Noreturn` function specifiers not allowed for `_Thread_local`
+fail_compilation/failcstuff1.c(700): Error: `auto` and `register` storage class not allowed for global
 ---
 */
 
@@ -212,3 +213,7 @@ void testDeclSpec()
     typedef _Noreturn int ax;
     inline _Noreturn int az;
 }
+
+/****************************************************/
+#line 700
+register char *stack_pointer;

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -21,6 +21,15 @@ fail_compilation/failcstuff2.c(154): Error: `cast(long)var` is not an lvalue and
 fail_compilation/failcstuff2.c(308): Error: cannot modify `const` expression `(*s).p`
 fail_compilation/failcstuff2.c(354): Error: variable `arr` cannot be read at compile time
 fail_compilation/failcstuff2.c(360): Error: variable `str` cannot be read at compile time
+fail_compilation/failcstuff2.c(352): Error: cannot take address of register variable `reg1`
+fail_compilation/failcstuff2.c(355): Error: cannot take address of register variable `reg2`
+fail_compilation/failcstuff2.c(358): Error: cannot take address of register variable `reg3`
+fail_compilation/failcstuff2.c(359): Error: cannot index through register variable `reg3`
+fail_compilation/failcstuff2.c(360): Error: cannot take address of register variable `reg3`
+fail_compilation/failcstuff2.c(361): Error: cannot take address of register variable `reg3`
+fail_compilation/failcstuff2.c(371): Error: cannot take address of register variable `reg4`
+fail_compilation/failcstuff2.c(372): Error: cannot take address of register variable `reg4`
+fail_compilation/failcstuff2.c(373): Error: cannot take address of register variable `reg4`
 ---
 */
 
@@ -110,4 +119,32 @@ void test22413b()
 {
     const char *str = "hello";
     char msg[] = str;
+}
+
+/***************************************************/
+#line 350
+void testRegister(register int reg1)
+{
+    int *ptr1 = &reg1;
+
+    register int reg2;
+    int *ptr2 = &reg2;
+
+    register int reg3[1];
+    int *ptr3 = (int *)reg3;
+    int idx1 = reg3[0];
+    int idx2 = *reg3;
+    int idx3 = reg3 + 0;
+
+    register struct
+    {
+        struct
+        {
+            int i;
+            int a[1];
+        } inner;
+    } reg4;
+    int *ptr4a = &(reg4.inner.i);
+    int *ptr4b = reg4.inner.a;
+    int *ptr4c = (int*)reg4.inner.a;
 }


### PR DESCRIPTION
The main difference between register variables and regular variables is that register variables cannot be forced into memory, either by taking its address, casting to lvalue pointer, or subscripting an array.