### PR TITLE
Replace `DsymbolExp` with `VarExp` when creating `TupleDeclaration` variables

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -661,7 +661,7 @@ extern (C++) final class TupleDeclaration : Declaration
 
     /***********************************************************
      * Calls dg(Dsymbol) for each Dsymbol, which should be a VarDeclaration
-     * inside DsymbolExp (isexp == true).
+     * inside VarExp (isexp == true).
      * Params:
      *    dg = delegate to call for each Dsymbol
      */
@@ -671,14 +671,14 @@ extern (C++) final class TupleDeclaration : Declaration
         foreach (o; *objects)
         {
             if (auto e = o.isExpression())
-                if (auto se = e.isDsymbolExp())
-                    dg(se.s);
+                if (auto ve = e.isVarExp())
+                    dg(ve.var);
         }
     }
 
     /***********************************************************
      * Calls dg(Dsymbol) for each Dsymbol, which should be a VarDeclaration
-     * inside DsymbolExp (isexp == true).
+     * inside VarExp (isexp == true).
      * If dg returns !=0, stops and returns that value else returns 0.
      * Params:
      *    dg = delegate to call for each Dsymbol
@@ -691,8 +691,8 @@ extern (C++) final class TupleDeclaration : Declaration
         foreach (o; *objects)
         {
             if (auto e = o.isExpression())
-                if (auto se = e.isDsymbolExp())
-                    if(auto ret = dg(se.s))
+                if (auto ve = e.isVarExp())
+                    if(auto ret = dg(ve.var))
                         return ret;
         }
         return 0;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -664,7 +664,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         sc.scopesym.members.push(v);
                 }
 
-                Expression e = new DsymbolExp(dsym.loc, v);
+                Expression e = new VarExp(dsym.loc, v);
                 (*exps)[i] = e;
             }
             auto v2 = new TupleDeclaration(dsym.loc, dsym.ident, exps);

--- a/src/tests/cxxfrontend.cc
+++ b/src/tests/cxxfrontend.cc
@@ -1220,9 +1220,9 @@ public:
             RootObject *o = (*d->objects)[i];
             if (o->dyncast() == DYNCAST_EXPRESSION)
             {
-                DsymbolExp *de = ((Expression *) o)->isDsymbolExp();
-                if (de && de->s->isDeclaration())
-                    de->s->accept(this);
+                VarExp *ve = ((Expression *) o)->isVarExp();
+                if (ve)
+                    ve->var->accept(this);
             }
         }
     }


### PR DESCRIPTION
There was a little discrepancy between the two instances where `TupleDeclaration` variables were created.

In [dsymbolsem.d#L670](https://github.com/dlang/dmd/blob/bfea47d8eb5dd582c1642f26829bbed63d05b1ef/src/dmd/dsymbolsem.d#L670), the most common one, it was using `DsymbolExp` as element.
But in [semantic3.d#L526](https://github.com/dlang/dmd/blob/bfea47d8eb5dd582c1642f26829bbed63d05b1ef/src/dmd/semantic3.d#L526), for tuple argument expansion, `VarExp` was used.

I am not aware of any issue caused by this for the time being (for example `TupleDeclaration.needThis()` coincidentally returns false in the second case because no variable is inspected), but for the sake of consistency it's better to merge both things.
I'm going from `DsymbolExp` to `VarExp` seeing that probably the compiler already is doing that transformation when evaluating individual members of the tuple.

GDC changes @ibuclaw :
```cpp
diff --git a/gcc/d/decl.cc b/gcc/d/decl.cc
index 8676a1b58..b82e2d55c 100644
--- a/gcc/d/decl.cc
+++ b/gcc/d/decl.cc
@@ -225,9 +225,9 @@ public:
 	RootObject *o = (*d->objects)[i];
 	if (o->dyncast () == DYNCAST_EXPRESSION)
 	  {
-	    DsymbolExp *de = ((Expression *) o)->isDsymbolExp ();
-	    if (de != NULL && de->s->isDeclaration ())
-	      this->build_dsymbol (de->s);
+	    VarExp *ve = ((Expression *) o)->isVarExp ();
+	    if (ve)
+	      this->build_dsymbol (ve->var);
 	  }
       }
   }
diff --git a/gcc/d/types.cc b/gcc/d/types.cc
index b706c9156..38cc7f511 100644
--- a/gcc/d/types.cc
+++ b/gcc/d/types.cc
@@ -392,10 +392,10 @@ layout_aggregate_members (Dsymbols *members, tree context, bool inherited_p)
 		  RootObject *ro = (*td->objects)[j];
 		  gcc_assert (ro->dyncast () == DYNCAST_EXPRESSION);
 		  Expression *e = (Expression *) ro;
-		  gcc_assert (e->op == EXP::dSymbol);
-		  DsymbolExp *se = e->isDsymbolExp ();
+		  gcc_assert (e->op == EXP::variable);
+		  VarExp *ve = e->isVarExp ();
 
-		  tmembers.push (se->s);
+		  tmembers.push (ve->var);
 		}
 
 	      fields += layout_aggregate_members (&tmembers, context,
```
LDC changes @kinke :
```cpp
diff --git a/gen/declarations.cpp b/gen/declarations.cpp
index d0edae4..4c55a53 100644
--- a/gen/declarations.cpp
+++ b/gen/declarations.cpp
@@ -230,9 +230,9 @@ public:
     assert(decl->objects);
 
     for (auto o : *decl->objects) {
-      DsymbolExp *exp = static_cast<DsymbolExp *>(o);
-      assert(exp->op == EXP::dSymbol);
-      exp->s->accept(this);
+      VarExp *exp = static_cast<VarExp *>(o);
+      assert(exp->op == EXP::variable);
+      exp->var->accept(this);
     }
   }
 
diff --git a/gen/llvmhelpers.cpp b/gen/llvmhelpers.cpp
index 6e38b27..cb874fc 100644
--- a/gen/llvmhelpers.cpp
+++ b/gen/llvmhelpers.cpp
@@ -1007,8 +1007,8 @@ DValue *DtoDeclarationExp(Dsymbol *declaration) {
     assert(tupled->isexp && "Non-expression tuple decls not handled yet.");
     assert(tupled->objects);
     for (unsigned i = 0; i < tupled->objects->length; ++i) {
-      auto exp = static_cast<DsymbolExp *>((*tupled->objects)[i]);
-      DtoDeclarationExp(exp->s);
+      auto exp = static_cast<VarExp *>((*tupled->objects)[i]);
+      DtoDeclarationExp(exp->var);
     }
   } else {
     // Do nothing for template/alias/enum declarations and static
```