### PR TITLE
ImportC: Check a few more cases of register variables having their address taken

### DIFF
--- a/src/dmd/importc.d
+++ b/src/dmd/importc.d
@@ -79,26 +79,16 @@ Expression arrayFuncConv(Expression e, Scope* sc)
         return e;
 
     auto t = e.type.toBasetype();
-    auto e1x = e;
-    while (e1x.op == EXP.dotVariable)
-        e1x = e1x.isDotVarExp().e1;
-    if (auto ve = e1x.isVarExp())
-    {
-        // C11 6.3.2.1 casting a variable from array to pointer takes its address,
-        // which is forbidden in C.
-        if ((t.ty == Tarray || t.ty == Tsarray) && ve.var.storage_class & STC.register)
-        {
-            e.error("cannot take address of register variable `%s`", ve.toChars());
-            return ErrorExp.get();
-        }
-    }
-
     if (auto ta = t.isTypeDArray())
     {
+        if (!checkAddressable(e, sc))
+            return ErrorExp.get();
         e = e.castTo(sc, ta.next.pointerTo());
     }
     else if (auto ts = t.isTypeSArray())
     {
+        if (!checkAddressable(e, sc))
+            return ErrorExp.get();
         e = e.castTo(sc, ts.next.pointerTo());
     }
     else if (t.isTypeFunction())
@@ -163,16 +153,6 @@ Expression carraySemantic(ArrayExp ae, Scope* sc)
 
     auto e1 = ae.e1.expressionSemantic(sc);
 
-    if (auto ve = e1.isVarExp())
-    {
-        // C11 6.3.2.1: Forbids the address of any part of an object declared
-        // register from being computed.
-        if (ve.var.storage_class & STC.register)
-        {
-            ae.error("cannot index through register variable `%s`", ve.toChars());
-            return ErrorExp.get();
-        }
-    }
     assert(ae.arguments.length == 1);
     Expression e2 = (*ae.arguments)[0];
 

--- a/test/compilable/testcstuff1.c
+++ b/test/compilable/testcstuff1.c
@@ -494,6 +494,22 @@ int testregister(register int x)
   return y + sizeof z;
 }
 
+int testregisterptr()
+{
+    register struct
+    {
+        int i;
+        int a[1];
+    } *regptr1;
+    int a = regptr1->i;
+    int *b = &regptr1->i;
+    int *c = regptr1->a;
+    int d = regptr1->a[0];
+
+    register int *regptr2;
+    return regptr2[0];
+}
+
 /********************************/
 
 int printf(const char*, ...);

--- a/test/fail_compilation/failcstuff2.c
+++ b/test/fail_compilation/failcstuff2.c
@@ -27,9 +27,14 @@ fail_compilation/failcstuff2.c(358): Error: cannot take address of register vari
 fail_compilation/failcstuff2.c(359): Error: cannot index through register variable `reg3`
 fail_compilation/failcstuff2.c(360): Error: cannot take address of register variable `reg3`
 fail_compilation/failcstuff2.c(361): Error: cannot take address of register variable `reg3`
-fail_compilation/failcstuff2.c(371): Error: cannot take address of register variable `reg4`
-fail_compilation/failcstuff2.c(372): Error: cannot take address of register variable `reg4`
+fail_compilation/failcstuff2.c(362): Error: cannot index through register variable `reg3`
 fail_compilation/failcstuff2.c(373): Error: cannot take address of register variable `reg4`
+fail_compilation/failcstuff2.c(374): Error: cannot take address of register variable `reg4`
+fail_compilation/failcstuff2.c(375): Error: cannot take address of register variable `reg4`
+fail_compilation/failcstuff2.c(376): Error: cannot take address of bit-field `b`
+fail_compilation/failcstuff2.c(377): Error: cannot index through register variable `reg4`
+fail_compilation/failcstuff2.c(378): Error: cannot index through register variable `reg4`
+fail_compilation/failcstuff2.c(381): Error: cannot take address of register variable `reg5`
 ---
 */
 
@@ -132,19 +137,27 @@ void testRegister(register int reg1)
 
     register int reg3[1];
     int *ptr3 = (int *)reg3;
-    int idx1 = reg3[0];
-    int idx2 = *reg3;
-    int idx3 = reg3 + 0;
+    int idx3a = reg3[0];
+    int idx3b = *reg3;
+    int idx3c = reg3 + 0;
+    int idx3d = 0[reg3];
 
     register struct
     {
         struct
         {
             int i;
+            int b : 4;
             int a[1];
         } inner;
     } reg4;
     int *ptr4a = &(reg4.inner.i);
     int *ptr4b = reg4.inner.a;
     int *ptr4c = (int*)reg4.inner.a;
+    int *ptr4d = &(reg4.inner.b);
+    int idx4a = reg4.inner.a[0];
+    int idx4b = 0[reg4.inner.a];
+
+    register int *reg5;
+    int **ptr5 = &reg5;
 }

--- a/test/runnable/test22070_2.c
+++ b/test/runnable/test22070_2.c
@@ -29,6 +29,14 @@ short test3(void)
 
 _Static_assert(test3() == 2, "");
 
+char test4(void)
+{
+   register char(*bar)[4] = &"456";
+   return 1[*bar];
+}
+
+_Static_assert(test4() == '5', "in");
+
 int main()
 {
     if ((*var)[2] != '3')
@@ -40,6 +48,8 @@ int main()
     if (test2() != '5')
         return 1;
     if (test3() != 2)
+        return 1;
+    if (test4() != '5')
         return 1;
     return 0;
 }


### PR DESCRIPTION
It is OK to dereference and index register pointers, just not register arrays.  Reverse array subscripting (`1[arr]`) was not properly handled either.