### PR TITLE
fix Issue 22724 - ImportC: VC extension __pragma(pack) is not impleme…

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -1619,6 +1619,12 @@ final class CParser(AST) : Parser!AST
             return;
         }
 
+        if (token.value == TOK.__pragma)
+        {
+            uupragmaDirective(scanloc);
+            return;
+        }
+
         if (token.value == TOK._import) // import declaration extension
         {
             auto a = parseImport();
@@ -4948,6 +4954,35 @@ final class CParser(AST) : Parser!AST
     }
 
     /*********************************************
+     * VC __pragma
+     * https://docs.microsoft.com/en-us/cpp/preprocessor/pragma-directives-and-the-pragma-keyword?view=msvc-170
+     * Scanner is on the `__pragma`
+     * Params:
+     *  startloc = location to use for error messages
+     */
+    private void uupragmaDirective(const ref Loc startloc)
+    {
+        const loc = startloc;
+        nextToken();
+        if (token.value != TOK.leftParenthesis)
+        {
+            error(loc, "left parenthesis expected to follow `__pragma`");
+            return;
+        }
+        nextToken();
+        if (token.value == TOK.identifier && token.ident == Id.pack)
+            pragmaPack(startloc, false);
+        else
+            error(loc, "unrecognized __pragma");
+        if (token.value != TOK.rightParenthesis)
+        {
+            error(loc, "right parenthesis expected to close `__pragma(...)`");
+            return;
+        }
+        nextToken();
+    }
+
+    /*********************************************
      * C11 6.10.6 Pragma directive
      * # pragma pp-tokens(opt) new-line
      * The C preprocessor sometimes leaves pragma directives in
@@ -4959,7 +4994,7 @@ final class CParser(AST) : Parser!AST
         Token n;
         scan(&n);
         if (n.value == TOK.identifier && n.ident == Id.pack)
-            return pragmaPack(loc);
+            return pragmaPack(loc, true);
         if (n.value != TOK.endOfLine)
             skipToNextLine();
     }
@@ -4971,10 +5006,27 @@ final class CParser(AST) : Parser!AST
      * Scanner is on the `pack`
      * Params:
      *  startloc = location to use for error messages
+     *  useScan = use scan() to retrieve next token, instead of nextToken()
      */
-    private void pragmaPack(const ref Loc startloc)
+    private void pragmaPack(const ref Loc startloc, bool useScan)
     {
         const loc = startloc;
+
+        /* Pull tokens from scan() or nextToken()
+         */
+        void scan(Token* t)
+        {
+            if (useScan)
+            {
+                Lexer.scan(t);
+            }
+            else
+            {
+                nextToken();
+                *t = token;
+            }
+        }
+
         Token n;
         scan(&n);
         if (n.value != TOK.leftParenthesis)

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -2211,7 +2211,8 @@ enum class TOK : uint8_t
     __cdecl_ = 216u,
     __declspec_ = 217u,
     __stdcall_ = 218u,
-    __attribute___ = 219u,
+    __pragma_ = 219u,
+    __attribute___ = 220u,
 };
 
 enum class MemorySet

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -273,6 +273,7 @@ enum TOK : ubyte
     __cdecl,
     __declspec,
     __stdcall,
+    __pragma,
     __attribute__,
 }
 
@@ -582,6 +583,7 @@ private immutable TOK[] keywords =
     TOK.__cdecl,
     TOK.__declspec,
     TOK.__stdcall,
+    TOK.__pragma,
     TOK.__attribute__,
 ];
 
@@ -610,7 +612,7 @@ static immutable TOK[TOK.max + 1] Ckeywords =
                        restrict, return_, int16, signed, sizeof_, static_, struct_, switch_, typedef_,
                        union_, unsigned, void_, volatile, while_, asm_, typeof_,
                        _Alignas, _Alignof, _Atomic, _Bool, _Complex, _Generic, _Imaginary, _Noreturn,
-                       _Static_assert, _Thread_local, _import, __cdecl, __declspec, __stdcall, __attribute__ ];
+                       _Static_assert, _Thread_local, _import, __cdecl, __declspec, __stdcall, __pragma, __attribute__ ];
 
         foreach (kw; Ckwds)
             tab[kw] = cast(TOK) kw;
@@ -880,6 +882,7 @@ extern (C++) struct Token
         TOK.__cdecl        : "__cdecl",
         TOK.__declspec     : "__declspec",
         TOK.__stdcall      : "__stdcall",
+        TOK.__pragma       : "__pragma",
         TOK.__attribute__  : "__attribute__",
     ];
 

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -282,6 +282,7 @@ enum class TOK : unsigned char
     cdecl_,
     declspec,
     stdcall,
+    pragma,
     attribute__,
 
     MAX,

--- a/test/compilable/test22724.i
+++ b/test/compilable/test22724.i
@@ -1,0 +1,6 @@
+// https://issues.dlang.org/show_bug.cgi?id=22724
+// https://docs.microsoft.com/en-us/cpp/preprocessor/pragma-directives-and-the-pragma-keyword?view=msvc-170
+
+__pragma(pack(push, 8))
+
+typedef unsigned int     size_t;

--- a/test/unit/lexer/location_offset.d
+++ b/test/unit/lexer/location_offset.d
@@ -540,6 +540,7 @@ enum ignoreTokens
     __cdecl,
     __declspec,
     __stdcall,
+    __pragma,
     __attribute__,
 
     max_,


### PR DESCRIPTION
…nted

Another of the endless smorgasbord of C extensions to control alignment. It's undocumented where in the grammar this construct may appear, so we just implement where it does appear in the Microsoft .h files.

This implementation does its best to share code with the implementation of `#pragma pack` in order to minimize testing.

This is necessary to compile Microsoft clib .h files.