### PR TITLE
dmd.cpreprocess: Internalize the looking up of cppswitches

### DIFF
--- a/src/dmd/cpreprocess.d
+++ b/src/dmd/cpreprocess.d
@@ -42,14 +42,13 @@ version (Windows) version = runPreprocessor;
  * Params:
  *      csrcfile = C file to be preprocessed, with .c or .h extension
  *      loc = The source location where preprocess is requested from
- *      cppswitches = array of switches to pass to C preprocessor
  *      ifile = set to true if an output file was written
  *      defines = buffer to append any `#define` and `#undef` lines encountered to
  * Result:
  *      filename of output
  */
 extern (C++)
-FileName preprocess(FileName csrcfile, ref const Loc loc, ref Array!(const(char)*) cppswitches, out bool ifile, OutBuffer* defines)
+FileName preprocess(FileName csrcfile, ref const Loc loc, out bool ifile, OutBuffer* defines)
 {
     /* Look for "importc.h" by searching along import path.
      * It should be in the same place as "object.d"
@@ -91,7 +90,7 @@ FileName preprocess(FileName csrcfile, ref const Loc loc, ref Array!(const(char)
         assert(ext);
         const ifilename = FileName.addExt(name[0 .. name.length - (ext.length + 1)], i_ext);
         const command = cppCommand();
-        auto status = runPreprocessor(command, csrcfile.toString(), importc_h, cppswitches, ifilename, defines);
+        auto status = runPreprocessor(command, csrcfile.toString(), importc_h, global.params.cppswitches, ifilename, defines);
         if (status)
         {
             error(loc, "C preprocess command %.*s failed for file %s, exit status %d\n",

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -680,7 +680,7 @@ extern (C++) final class Module : Package
             FileName.equalsExt(srcfile.toString(), c_ext) &&
             FileName.exists(srcfile.toString()))
         {
-            filename = global.preprocess(srcfile, loc, global.params.cppswitches, ifile, &defines);  // run C preprocessor
+            filename = global.preprocess(srcfile, loc, ifile, &defines);  // run C preprocessor
         }
 
         if (auto result = global.fileManager.lookup(filename))

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -832,7 +832,7 @@ struct Global final
     FileManager* fileManager;
     enum : int32_t { recursionLimit = 500 };
 
-    FileName(*preprocess)(FileName , const Loc& , Array<const char* >& cppswitches, bool& , OutBuffer* defines);
+    FileName(*preprocess)(FileName , const Loc& , bool& , OutBuffer* );
     uint32_t startGagging();
     bool endGagging(uint32_t oldGagged);
     void increaseErrorCount();
@@ -861,7 +861,7 @@ struct Global final
         preprocess()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, FileName(*preprocess)(FileName , const Loc& , Array<const char* >& cppswitches, bool& , OutBuffer* defines) = nullptr) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, FileName(*preprocess)(FileName , const Loc& , bool& , OutBuffer* ) = nullptr) :
         inifilename(inifilename),
         copyright(copyright),
         written(written),
@@ -5613,7 +5613,7 @@ extern const char* toCppMangleDMC(Dsymbol* s);
 
 extern const char* cppTypeInfoMangleDMC(Dsymbol* s);
 
-extern FileName preprocess(FileName csrcfile, const Loc& loc, Array<const char* >& cppswitches, bool& ifile, OutBuffer* defines);
+extern FileName preprocess(FileName csrcfile, const Loc& loc, bool& ifile, OutBuffer* defines);
 
 class ClassReferenceExp final : public Expression
 {

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -299,7 +299,7 @@ extern (C++) struct Global
 
     enum recursionLimit = 500; /// number of recursive template expansions before abort
 
-    extern (C++) FileName function(FileName, ref const Loc, ref Array!(const(char)*) cppswitches, out bool, OutBuffer* defines) preprocess;
+    extern (C++) FileName function(FileName, ref const Loc, out bool, OutBuffer*) preprocess;
 
   nothrow:
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -272,7 +272,7 @@ struct Global
 
     FileManager* fileManager;
 
-    FileName (*preprocess)(FileName, const Loc&, Array<const char *>& cppswitches, bool&, OutBuffer&);
+    FileName (*preprocess)(FileName, const Loc&, bool&, OutBuffer&);
 
     /* Start gagging. Return the current number of gagged errors
      */


### PR DESCRIPTION
This array is a dmd implementation detail, and doesn't need to be part of the preprocess callback signature (i.e: gdc has cpp library linked in, so there is no fork() or command-line switches to pass).