### PR TITLE
fix Issue 23206 - ImportC: __declspec(noreturn) does not compile

### DIFF
--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -2328,6 +2328,14 @@ final class CParser(AST) : Parser!AST
                     break;
                 }
 
+                case TOK.__declspec:
+                {
+                    /* Microsoft extension
+                     */
+                    cparseDeclspec(specifier);
+                    break;
+                }
+
                 case TOK.typeof_:
                 {
                     nextToken();
@@ -3048,9 +3056,13 @@ final class CParser(AST) : Parser!AST
      * extended-decl-modifier:
      *    dllimport
      *    dllexport
+     *    noreturn
+     * Params:
+     *  specifier = filled in with the attribute(s)
      */
-    private void cparseDeclspec()
+    private void cparseDeclspec(ref Specifier specifier)
     {
+        //printf("cparseDeclspec()\n");
         /* Check for dllexport, dllimport
          * Ignore the rest
          */
@@ -3079,6 +3091,11 @@ final class CParser(AST) : Parser!AST
                     dllexport = true;
                     nextToken();
                 }
+                else if (token.ident == Id.noreturn)
+                {
+                    specifier.noreturn = true;
+                    nextToken();
+                }
                 else
                 {
                     nextToken();
@@ -3089,8 +3106,8 @@ final class CParser(AST) : Parser!AST
             else
             {
                 error("extended-decl-modifier expected");
+                break;
             }
-            break;
         }
     }
 

--- a/test/compilable/test22724.i
+++ b/test/compilable/test22724.i
@@ -3,4 +3,8 @@
 
 __pragma(pack(push, 8))
 
-typedef unsigned int     size_t;
+typedef unsigned int size_t;
+
+// https://issues.dlang.org/show_bug.cgi?id=23206
+
+__declspec(noreturn) void abra(void);


### PR DESCRIPTION
Needed to compile `<errno.h>` in https://github.com/dlang/druntime/pull/3856