### PR TITLE
fix Issue 23217 - ImportC: extra initializer(s) error for array of st…

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -3701,6 +3701,7 @@ struct ASTBase
         Dsymbols* members;
 
         Type resolved;
+        MOD mod;
 
         extern (D) this(const ref Loc loc, TOK tok, Identifier id, Dsymbols* members)
         {
@@ -3710,6 +3711,7 @@ struct ASTBase
             this.tok = tok;
             this.id = id;
             this.members = members;
+            this.mod = 0;
         }
 
         override TypeTag syntaxCopy()

--- a/src/dmd/cparse.d
+++ b/src/dmd/cparse.d
@@ -4812,6 +4812,8 @@ final class CParser(AST) : Parser!AST
         // type function itself.
         if (auto tf = t.isTypeFunction())
             tf.next = tf.next.addSTC(STC.const_);
+        else if (auto tt = t.isTypeTag())
+            tt.mod |= MODFlags.const_;
         else
             t = t.addSTC(STC.const_);
         return t;

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -3858,6 +3858,7 @@ public:
     Type* base;
     Array<Dsymbol* >* members;
     Type* resolved;
+    uint8_t mod;
     const char* kind() const override;
     TypeTag* syntaxCopy() override;
     void accept(Visitor* v) override;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3916,6 +3916,8 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
 
     void visitTag(TypeTag t)
     {
+        if (t.mod & MODFlags.const_)
+            buf.writestring("const ");
         buf.writestring(Token.toChars(t.tok));
         buf.writeByte(' ');
         if (t.id)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6655,16 +6655,18 @@ extern (C++) final class TypeTag : Type
     Type resolved;          /// type after semantic() in case there are more others
                             /// pointing to this instance, which can happen with
                             ///   struct S { int a; } s1, *s2;
+    MOD mod;                /// modifiers to apply after type is resolved (only MODFlags.const_ at the moment)
 
     extern (D) this(const ref Loc loc, TOK tok, Identifier id, Type base, Dsymbols* members)
     {
-        //printf("TypeTag %p\n", this);
+        //printf("TypeTag ctor %s %p\n", id ? id.toChars() : "null".ptr, this);
         super(Ttag);
         this.loc = loc;
         this.tok = tok;
         this.id = id;
         this.base = base;
         this.members = members;
+        this.mod = 0;
     }
 
     override const(char)* kind() const
@@ -6674,6 +6676,7 @@ extern (C++) final class TypeTag : Type
 
     override TypeTag syntaxCopy()
     {
+        //printf("TypeTag syntaxCopy()\n");
         // No semantic analysis done, no need to copy
         return this;
     }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1778,8 +1778,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         {
             /* struct S s, *p;
              */
-            //printf("already resolved\n");
-            return mtype.resolved;
+            return mtype.resolved.addSTC(mtype.mod);
         }
 
         /* Find the current scope by skipping tag scopes.
@@ -1850,7 +1849,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         {
             mtype.id = Identifier.generateId("__tag"[]);
             declareTag();
-            return mtype.resolved;
+            return mtype.resolved.addSTC(mtype.mod);
         }
 
         /* look for pre-existing declaration
@@ -1863,7 +1862,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             if (mtype.tok == TOK.enum_ && !mtype.members)
                 .error(mtype.loc, "`enum %s` is incomplete without members", mtype.id.toChars()); // C11 6.7.2.3-3
             declareTag();
-            return mtype.resolved;
+            return mtype.resolved.addSTC(mtype.mod);
         }
 
         /* A redeclaration only happens if both declarations are in
@@ -1963,7 +1962,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                 declareTag();
             }
         }
-        return mtype.resolved;
+        return mtype.resolved.addSTC(mtype.mod);
     }
 
     switch (type.ty)

--- a/test/compilable/test23217.c
+++ b/test/compilable/test23217.c
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=23217
+
+typedef struct {
+ int a,b,c;
+} code;
+
+const code array[2] = { {96,7,0}, {0,8,80} };
+const code distfix[2] = { {22,5,193},{64,5,0} };


### PR DESCRIPTION
…ructs

The fix was to delay applying `const` to the `TypeTag` until after it gets resolved.