### PR TITLE
fix Issue 23224 - ImportC: memory model switch is not passed to C pre…

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1269,6 +1269,9 @@ public int runPreprocessor(const(char)[] cpp, const(char)[] filename, const(char
                 argv.push(p);
         }
 
+        // Set memory model
+        argv.push(target.is64bit ? "-m64" : "-m32");
+
         // merge #define's with output
         argv.push("-dD");       // https://gcc.gnu.org/onlinedocs/cpp/Invocation.html#index-dD
 


### PR DESCRIPTION
…processor

For `cpp` builds.

For `sppn.exe`, it's 32 bit only so not necessary.

For `cl /P` the executable determines 32 or 64 bit, not a command line option.

Needed for https://github.com/dlang/phobos/pull/8484