### PR TITLE
Use `FileName.equals` when comparing `ddoc_ext`

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -2811,7 +2811,7 @@ Module createModule(const(char)* file, ref Strings libmodules, const ref Target 
             return null;
         }
     }
-    if (ext == ddoc_ext)
+    if (FileName.equals(ext, ddoc_ext))
     {
         global.params.ddoc.files.push(file);
         return null;


### PR DESCRIPTION
I don't see a reason to treat ".ddoc" as the only case-sensitive extension on Windows