### PR TITLE
OpenBSD needs -o in its cpp invocation

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1287,7 +1287,7 @@ public int runPreprocessor(const(char)[] cpp, const(char)[] filename, const(char
             argv.push("-include");
             argv.push(importc_h);
         }
-        if (target.os == Target.OS.FreeBSD)
+        if (target.os == Target.OS.FreeBSD || target.os == Target.OS.OpenBSD)
             argv.push("-o");                // specify output file
         argv.push(output.xarraydup.ptr);    // and the output
         argv.push(null);                    // argv[] always ends with a null


### PR DESCRIPTION
Like FreeBSD, OpenBSD uses clang for its cpp utility. As such, it needs the `-o` flag added too.
No bug report in the bug tracker, since this is below trivial.