### PR TITLE
remove memory corruption bug from cparse.d

### DIFF
--- a/test/compilable/extra-files/testcdefines.i.cg
+++ b/test/compilable/extra-files/testcdefines.i.cg
@@ -1,0 +1,2 @@
+=== compilable/testcdefines.i.cg
+extern (C) enum int _ATFILE_SOURCE = 1;

--- a/test/compilable/testcdefines.i
+++ b/test/compilable/testcdefines.i
@@ -1,0 +1,5 @@
+// REQUIRED_ARGS: -vcg-ast -o-
+// OUTPUT_FILES: compilable/testcdefines.i.cg
+// TEST_OUTPUT_FILE: extra-files/testcdefines.i.cg
+#undef _ATFILE_SOURCE
+#define _ATFILE_SOURCE 1


### PR DESCRIPTION
I'm embarrassed to discover I created a memory corruption bug in cparse.d. The `defines` buffer would get reallocated while it was reading from a slice into the same buffer. It's rather difficult to reproduce, I encountered it from mysterious behavior compiling the phobos gzip library.