### PR TITLE
Fix Issue 23225 - OpenBSD: cpp invocation cannot find files

### DIFF
--- a/src/dmd/cpreprocess.d
+++ b/src/dmd/cpreprocess.d
@@ -123,6 +123,18 @@ private const(char)[] cppCommand()
         {
             return "sppn.exe";
         }
+        // Perhaps we are cross-compiling.
+        return "cpp";
     }
-    return "cpp";
+    else version (OpenBSD)
+    {
+        // On OpenBSD, we need to use the actual binary /usr/libexec/cpp
+        // rather than the shell script wrapper /usr/bin/cpp ...
+        // Turns out the shell script doesn't really understand -o
+        return "/usr/libexec/cpp";
+    }
+    else
+    {
+        return "cpp";
+    }
 }


### PR DESCRIPTION
A bug in the shell script that lives in /usr/bin/cpp eats the -o
flag in the CPP invocation, which breaks ImportC. This workaround
is to use /usr/libexec/cpp instead, which is the actual CPP binary.