### PR TITLE
Fix `-v` output of test3004

### DIFF
--- a/test/compilable/test3004.d
+++ b/test/compilable/test3004.d
@@ -1,15 +1,13 @@
 // https://issues.dlang.org/show_bug.cgi?id=3004
 /*
 REQUIRED_ARGS: -ignore -v
-TRANSFORM_OUTPUT: remove_lines("^(predefs|binary|version|config|DFLAG|parse|import|semantic|entry|library|function  object|\s*$)")
+TRANSFORM_OUTPUT: remove_lines("^(predefs|binary|version|config|DFLAG|parse|import|semantic|entry|library|function  object|function  core|\s*$)")
 TEST_OUTPUT:
 ---
 pragma    GNU_attribute (__error)
 pragma    GNU_attribute (__error)
 code      test3004
 function  test3004.test
-function  core.internal.array.appending._d_arrayappendcTXImpl!(char[], char)._d_arrayappendcTX
-function  core.internal.array.utils._d_HookTraceImpl!(char[], _d_arrayappendcTX, "Cannot append to array if compiling without support for runtime type information!")._d_HookTraceImpl
 ---
 */
 


### PR DESCRIPTION
Blocks https://github.com/dlang/druntime/pull/3866, which adds an import to `core.internal.array.duplication` to the `-v` output.
The now removed `core.internal.array.appending` line was added in https://github.com/dlang/dmd/pull/13495 and not relevant to the test either.


