### PR TITLE
Fix 18973, 9161 - TypeInfo generation does not account for `@disable`

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -1121,6 +1121,10 @@ private DtorDeclaration buildExternDDtor(AggregateDeclaration ad, Scope* sc)
     if (!dtor)
         return null;
 
+    // Don't try to call `@disable`d dtors
+    if (dtor.storage_class & STC.disable)
+        return null;
+
     // Generate shim only when ABI incompatible on target platform
     if (ad.classKind != ClassKind.cpp || !target.cpp.wrapDtorInExternD)
         return dtor;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -867,6 +867,8 @@ extern (C++) class FuncDeclaration : Declaration
             auto f = s.isFuncDeclaration();
             if (!f)
                 return 0;
+            if (f.storage_class & STC.disable)
+                return 0;
             if (t.equals(f.type))
             {
                 fd = f;

--- a/test/runnable/test18973.d
+++ b/test/runnable/test18973.d
@@ -1,0 +1,11 @@
+struct X {
+    @disable size_t toHash() const;
+    @disable string toString() const;
+    @disable bool opEquals(const ref X) const;
+    @disable int opCmp(const ref X) const;
+}
+
+void main ()
+{
+    // This is a runnable test as we are testing a linker error
+}

--- a/test/runnable/test18973.d
+++ b/test/runnable/test18973.d
@@ -1,3 +1,6 @@
+// This is a runnable test as we are testing a linker error
+
+// https://issues.dlang.org/show_bug.cgi?id=18973
 struct X {
     @disable size_t toHash() const;
     @disable string toString() const;
@@ -5,7 +8,18 @@ struct X {
     @disable int opCmp(const ref X) const;
 }
 
-void main ()
+// https://issues.dlang.org/show_bug.cgi?id=9161
+public struct dummy
 {
-    // This is a runnable test as we are testing a linker error
+    static auto opCall(C)(in C[] name)
+    {
+        return name;
+    }
+
+    @disable ~this(); //comment this out to avoid error
+}
+
+void main()
+{
+    assert(dummy("ABCDE") == "ABCDE");
 }


### PR DESCRIPTION
```
This changes `overloadExactMatch` as all 14 usages of it are to find
functions that can later be called.
```