### PR TITLE
fix Issue 23214 - ImportC: typedef with unsigned types does not compile

### DIFF
--- a/test/compilable/test23214.c
+++ b/test/compilable/test23214.c
@@ -1,0 +1,3 @@
+// https://issues.dlang.org/show_bug.cgi?id=23214
+
+typedef unsigned __int64 uintptr_t;


### PR DESCRIPTION
This works for me, so I just added the test case.