### PR TITLE
Fix Issue 21956 - ice on foreach over an AA of noreturn

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -8900,6 +8900,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if ((t1.ty != Tstruct && t1.ty != Tclass && e2x.checkValue()) ||
                 e2x.checkSharedAccess(sc))
                 return setError();
+
+            if (e2x.type.isTypeNoreturn() && !e2x.isAssertExp() && !e2x.isThrowExp() && !e2x.isCallExp())
+            {
+                auto msg = new StringExp(e2x.loc, "Accessed expression of type `noreturn`");
+                msg.type = Type.tstring;
+                e2x = new AssertExp(e2x.loc, IntegerExp.literal!0, msg);
+                e2x.type = Type.tnoreturn;
+                return setResult(e2x);
+            }
             exp.e2 = e2x;
         }
 

--- a/test/compilable/test21956.d
+++ b/test/compilable/test21956.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=21956
+
+noreturn[noreturn] nrnr;
+
+void gun()
+{
+    foreach (a; nrnr){}
+}
+
+int main()
+{
+    noreturn[] empty;
+    int val;
+    foreach(el; empty) val++;
+    return val;
+}


### PR DESCRIPTION
The backend does not know how to treat assignments where the rhs is a noreturn expression. And that is probably fine since such expressions should be replaced with `assert(0)`.

For each statements over `noreturn` arrays, the compiler ends up generating `el = __r[idx]`, therefore trying to assign a noreturn expression. With this patch, the mentioned assignment is replaced with `assert(0)`.

I'm targeting master because this is the first step to unblock https://github.com/dlang/phobos/pull/8283