### PR TITLE
fix Issue 23143 - ImportC: forward enum declarations need to be suppo…

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1675,7 +1675,7 @@ final class CParser(AST) : Parser!AST
             auto stags = applySpecifier(stag, specifier);
             symbols.push(stags);
 
-            if (tt.tok == TOK.enum_)
+            if (0 && tt.tok == TOK.enum_)    // C11 proscribes enums with no members, but we allow it
             {
                 if (!tt.members)
                     error(tt.loc, "`enum %s` has no members", stag.toChars());

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2023,7 +2023,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     override void visit(EnumDeclaration ed)
     {
         //printf("EnumDeclaration::semantic(sd = %p, '%s') %s\n", sc.scopesym, sc.scopesym.toChars(), ed.toChars());
-        //printf("EnumDeclaration::semantic() %p %s\n", this, ed.toChars());
+        //printf("EnumDeclaration::semantic() %p %s\n", ed, ed.toChars());
         if (ed.semanticRun >= PASS.semanticdone)
             return; // semantic() already completed
         if (ed.semanticRun == PASS.semantic)
@@ -5716,6 +5716,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
  */
 void addEnumMembers(EnumDeclaration ed, Scope* sc, ScopeDsymbol sds)
 {
+    //printf("addEnumMembers(ed: %p)\n", ed);
     if (ed.added)
         return;
     ed.added = true;
@@ -5739,6 +5740,7 @@ void addEnumMembers(EnumDeclaration ed, Scope* sc, ScopeDsymbol sds)
             em.ed = ed;
             if (isCEnum)
             {
+                //printf("adding EnumMember %s to %p\n", em.toChars(), ed);
                 em.addMember(sc, ed);   // add em to ed's symbol table
                 em.addMember(sc, sds);  // add em to symbol table that ed is in
                 em.parent = ed; // restore it after previous addMember() changed it

--- a/compiler/test/compilable/testcstuff2.c
+++ b/compiler/test/compilable/testcstuff2.c
@@ -697,3 +697,19 @@ int i;
 _Static_assert( sizeof (s).x == sizeof(int), "" );
 _Static_assert( sizeof (fn)() == sizeof(int), "" );
 _Static_assert( sizeof (i)++ == sizeof(int), "" );
+
+// https://issues.dlang.org/show_bug.cgi?id=23143
+
+enum E1;
+
+enum E1 {
+    m3,
+    m4 = m3
+};
+
+typedef enum E2 T1;
+
+enum E2 {
+    m1,
+    m2 = m1
+};

--- a/compiler/test/fail_compilation/failcstuff1.c
+++ b/compiler/test/fail_compilation/failcstuff1.c
@@ -25,7 +25,6 @@ fail_compilation/failcstuff1.c(260): Error: identifier or `(` expected
 fail_compilation/failcstuff1.c(301): Error: illegal type combination
 fail_compilation/failcstuff1.c(352): Error: found `2` when expecting `:`
 fail_compilation/failcstuff1.c(352): Error: found `:` instead of statement
-fail_compilation/failcstuff1.c(400): Error: `enum ENUM` has no members
 fail_compilation/failcstuff1.c(450): Error: static array parameters are not supported
 fail_compilation/failcstuff1.c(450): Error: static or type qualifier used in non-outermost array type derivation
 fail_compilation/failcstuff1.c(451): Error: static or type qualifier used in non-outermost array type derivation


### PR DESCRIPTION
…rted

Most of the machinery was already in place, thanks to struct and union tags. Only problem was EnumMembers had a back reference to the EnumDeclaration that had to be adjusted.