### PR TITLE
use clang -E for preprocessing on OSX

### DIFF
--- a/src/dmd/cpreprocess.d
+++ b/src/dmd/cpreprocess.d
@@ -133,6 +133,10 @@ private const(char)[] cppCommand()
         // Turns out the shell script doesn't really understand -o
         return "/usr/libexec/cpp";
     }
+    else version (OSX)
+    {
+        return "clang";
+    }
     else
     {
         return "cpp";

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1277,9 +1277,11 @@ public int runPreprocessor(const(char)[] cpp, const(char)[] filename, const(char
 
         if (target.os == Target.OS.OSX)
         {
+            argv.push("-E");                // run preprocessor only for clang
             argv.push("-include");          // OSX cpp has switch order dependencies
             argv.push(importc_h);
             argv.push(filename.xarraydup.ptr);  // and the input
+            argv.push("-o");                // specify output file
         }
         else
         {


### PR DESCRIPTION
Running `cpp` isn't doing so well on OSX. Try `clang -E`.