### PR TITLE
Disable fail-fast for nightly builds

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -30,6 +30,8 @@ jobs:
     needs:
       - build-all-releases
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
     steps:
       #################################################################

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -29,5 +29,5 @@ jobs:
         git config --global color.diff.whitespace "red reverse"
 
         git config --global diff.wsErrorHighlight "all"
-    - uses: actions/setup-python@v3.0.0
+    - uses: actions/setup-python@v4.0.0
     - uses: pre-commit/action@v2.0.3


### PR DESCRIPTION
So that one job failing doesn't break all nightlies.