### PR TITLE
better HtmlNamedEntity()

### DIFF
--- a/compiler/src/dmd/entity.d
+++ b/compiler/src/dmd/entity.d
@@ -17,18 +17,27 @@ import core.stdc.ctype;
 
 nothrow:
 
-public int HtmlNamedEntity(const(char)* p, size_t length)
+/**********************************
+ * See if `name` is an HTML Named Entity
+ * Params:
+ *      name = name of the entity
+ * Returns:
+ *      code point corresponding to the named entity
+ *      ~0 for not recognized as a named entity
+ */
+public uint HtmlNamedEntity(scope const char[] name) pure @nogc @safe
 {
-    int tableIndex = tolower(*p) - 'a';
-    if (tableIndex >= 0 && tableIndex < 26)
+    const firstC = tolower(name[0]);
+    if (firstC >= 'a' && firstC <= 'z')
     {
-        foreach (entity; namesTable[tableIndex])
+        // Linear search (use hash table instead?)
+        foreach (entity; namesTable[firstC - 'a'])
         {
-            if (entity.name == p[0 .. length])
+            if (entity.name == name)
                 return entity.value;
         }
     }
-    return -1;
+    return ~0;
 }
 
 private:

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -1326,7 +1326,7 @@ class Lexer
                 switch (*p)
                 {
                 case ';':
-                    c = HtmlNamedEntity(idstart, p - idstart);
+                    c = HtmlNamedEntity(idstart[0 .. p - idstart]);
                     if (c == ~0)
                     {
                         error(loc, "unnamed character entity &%.*s;", cast(int)(p - idstart), idstart);


### PR DESCRIPTION
1. ddoc function
2. add qualifiers
3. switch to string type instead of pointers
4. consistent use of error return value (-1 in one place, ~0 in another)
5. consistently use uint
6. use const when possible