### PR TITLE
fix Issue 21432 - [CTFE] Cannot declare enum array in function scope

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -2352,6 +2352,7 @@ public:
                 if (ExpInitializer ie = v._init.isExpInitializer())
                 {
                     result = interpretRegion(ie.exp, istate, goal);
+                    return;
                 }
                 else if (v._init.isVoidInitializer())
                 {
@@ -2359,12 +2360,16 @@ public:
                     // There is no AssignExp for void initializers,
                     // so set it here.
                     setValue(v, result);
+                    return;
                 }
-                else
+                else if (v._init.isArrayInitializer())
                 {
-                    e.error("declaration `%s` is not yet implemented in CTFE", e.toChars());
-                    result = CTFEExp.cantexp;
+                    result = v._init.initializerToExpression(v.type);
+                    if (result !is null)
+                        return;
                 }
+                e.error("declaration `%s` is not yet implemented in CTFE", e.toChars());
+                result = CTFEExp.cantexp;
             }
             else if (v.type.size() == 0)
             {

--- a/compiler/test/compilable/test21432.d
+++ b/compiler/test/compilable/test21432.d
@@ -1,0 +1,25 @@
+// https://issues.dlang.org/show_bug.cgi?id=21432
+auto issue21432()
+{
+    enum int[] a = [];
+    return a;
+}
+
+enum test21432a = issue21432;
+
+///////////////////////
+
+double issue21432b(double r)
+{
+    enum double[4] poly = [
+        0x1.ffffffffffdbdp-2,
+        0x1.555555555543cp-3,
+        0x1.55555cf172b91p-5,
+        0x1.1111167a4d017p-7,
+    ];
+
+    immutable r2 = r * r;
+    return r + r2 * (poly[0] + r * poly[1]) + r2 * r2 * (poly[2] + r * poly[3]);
+}
+
+enum test21432b = issue21432b(-0x1p-1);


### PR DESCRIPTION
Noticed when writing some coefficients as `enum double[]`, and turns out there's a bug report for it.  This fixes that by allowing ArrayInitializer to be used at CTFE.