### PR TITLE
Fix Issue 23241 - Consider types with no symbol (e.g. int) to have no…

### DIFF
--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1268,6 +1268,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto o = (*e.args)[0];
         auto po = isParameter(o);
         auto s = getDsymbolWithoutExpCtx(o);
+        auto typeOfArg = isType(o);
         UserAttributeDeclaration udad = null;
         if (po)
         {
@@ -1281,6 +1282,10 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             }
             //printf("getAttributes %s, attrs = %p, scope = %p\n", s.toChars(), s.userAttribDecl, s._scope);
             udad = s.userAttribDecl;
+        }
+        else if (typeOfArg)
+        {
+            // If there is a type but no symbol, do nothing rather than errorring.
         }
         else
         {

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1285,7 +1285,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         else if (typeOfArg)
         {
-            // If there is a type but no symbol, do nothing rather than errorring.
+            // If there is a type but no symbol, do nothing rather than erroring.
         }
         else
         {

--- a/compiler/test/compilable/uda.d
+++ b/compiler/test/compilable/uda.d
@@ -6,3 +6,9 @@ struct foo { }
 @foo bar () { }
 
 /************************************************/
+
+// https://issues.dlang.org/show_bug.cgi?id=23241
+
+alias feynman = int;
+enum get = __traits(getAttributes, feynman);
+static assert(get.length == 0);


### PR DESCRIPTION
… attributes

not completely convinced about this