### PR TITLE
fix Issue 23247 - Deprecation: argument 0.0L for format specification "%La" must be double, not real

### DIFF
--- a/compiler/test/compilable/test21177.d
+++ b/compiler/test/compilable/test21177.d
@@ -32,13 +32,13 @@ void main()
         printf("%*m");
 
         char* a, b;
-        sscanf("salut poilu", "%a %m", a, b);
+        sscanf("salut poilu", "%m %m", a, b);
         assert(!strcmp(a, b));
         free(a);
         free(b);
 
         char* t, p;
-        sscanf("Tomate Patate", "%ms %as", t, p);
+        sscanf("Tomate Patate", "%ms %m[^\n]", t, p);
         free(t);
         free(p);
 
@@ -48,11 +48,14 @@ void main()
         sscanf("152", "%a");
         sscanf("153", "%as");
 
+        #line 200
         pragma(msg, "compilable/test21177.d(200): Deprecation: more format specifiers than 0 arguments");
+
+        char* c;
         pragma(msg, "compilable/test21177.d(203): Deprecation: format specifier `\"%m\"` is invalid");
         pragma(msg, "compilable/test21177.d(204): Deprecation: format specifier `\"%m\"` is invalid");
-        pragma(msg, "compilable/test21177.d(205): Deprecation: argument `c` for format specification `\"%a\"` must be `float*`, not `char*`");
-        pragma(msg, "compilable/test21177.d(206): Deprecation: argument `c` for format specification `\"%a\"` must be `float*`, not `char*`");
+        sscanf("206", "%a", c);
+        sscanf("207", "%as", c);
     }
     else
     {
@@ -71,6 +74,5 @@ void main()
         sscanf("205", "%ms", c);
         sscanf("206", "%a", c);
         sscanf("207", "%as", c);
-
     }
 }

--- a/compiler/test/fail_compilation/chkformat.d
+++ b/compiler/test/fail_compilation/chkformat.d
@@ -169,3 +169,21 @@ void test409() { char* p; printf("%llu", p); }
 void test410() { char* p; printf("%lld", p); }
 void test411() { char* p; printf("%ju", p); }
 void test412() { char* p; printf("%jd", p); }
+
+/* https://issues.dlang.org/show_bug.cgi?id=23247
+TEST_OUTPUT:
+---
+fail_compilation/chkformat.d(501): Deprecation: argument `p` for format specification `"%a"` must be `double`, not `char*`
+fail_compilation/chkformat.d(502): Deprecation: argument `p` for format specification `"%La"` must be `real`, not `char*`
+fail_compilation/chkformat.d(503): Deprecation: argument `p` for format specification `"%a"` must be `float*`, not `char*`
+fail_compilation/chkformat.d(504): Deprecation: argument `p` for format specification `"%la"` must be `double*`, not `char*`
+fail_compilation/chkformat.d(505): Deprecation: argument `p` for format specification `"%La"` must be `real*`, not `char*`
+---
+*/
+#line 500
+
+void test501() { char* p; printf("%a", p); }
+void test502() { char* p; printf("%La", p); }
+void test503() { char* p; scanf("%a", p); }
+void test504() { char* p; scanf("%la", p); }
+void test505() { char* p; scanf("%La", p); }

--- a/druntime/src/core/stdc/stdio.d
+++ b/druntime/src/core/stdc/stdio.d
@@ -1286,6 +1286,57 @@ version (MinGW)
     ///
     alias __mingw_scanf scanf;
 }
+else version (CRuntime_Glibc)
+{
+    ///
+    pragma(printf)
+    int fprintf(FILE* stream, scope const char* format, scope const ...);
+    ///
+    pragma(scanf)
+    int __isoc99_fscanf(FILE* stream, scope const char* format, scope ...);
+    ///
+    alias fscanf = __isoc99_fscanf;
+    ///
+    pragma(printf)
+    int sprintf(scope char* s, scope const char* format, scope const ...);
+    ///
+    pragma(scanf)
+    int __isoc99_sscanf(scope const char* s, scope const char* format, scope ...);
+    ///
+    alias sscanf = __isoc99_sscanf;
+    ///
+    pragma(printf)
+    int vfprintf(FILE* stream, scope const char* format, va_list arg);
+    ///
+    pragma(scanf)
+    int __isoc99_vfscanf(FILE* stream, scope const char* format, va_list arg);
+    ///
+    alias vfscanf = __isoc99_vfscanf;
+    ///
+    pragma(printf)
+    int vsprintf(scope char* s, scope const char* format, va_list arg);
+    ///
+    pragma(scanf)
+    int __isoc99_vsscanf(scope const char* s, scope const char* format, va_list arg);
+    ///
+    alias vsscanf = __isoc99_vsscanf;
+    ///
+    pragma(printf)
+    int vprintf(scope const char* format, va_list arg);
+    ///
+    pragma(scanf)
+    int __isoc99_vscanf(scope const char* format, va_list arg);
+    ///
+    alias vscanf = __isoc99_vscanf;
+    ///
+    pragma(printf)
+    int printf(scope const char* format, scope const ...);
+    ///
+    pragma(scanf)
+    int __isoc99_scanf(scope const char* format, scope ...);
+    ///
+    alias scanf = __isoc99_scanf;
+}
 else
 {
     ///

--- a/druntime/src/core/stdc/wchar_.d
+++ b/druntime/src/core/stdc/wchar_.d
@@ -127,30 +127,72 @@ alias wchar_t wint_t;
 ///
 enum wchar_t WEOF = 0xFFFF;
 
-///
-int fwprintf(FILE* stream, const scope wchar_t* format, scope const ...);
-///
-int fwscanf(FILE* stream, const scope wchar_t* format, scope ...);
-///
-int swprintf(wchar_t* s, size_t n, const scope wchar_t* format, scope const ...);
-///
-int swscanf(const scope wchar_t* s, const scope wchar_t* format, scope ...);
-///
-int vfwprintf(FILE* stream, const scope wchar_t* format, va_list arg);
-///
-int vfwscanf(FILE* stream, const scope wchar_t* format, va_list arg);
-///
-int vswprintf(wchar_t* s, size_t n, const scope wchar_t* format, va_list arg);
-///
-int vswscanf(const scope wchar_t* s, const scope wchar_t* format, va_list arg);
-///
-int vwprintf(const scope wchar_t* format, va_list arg);
-///
-int vwscanf(const scope wchar_t* format, va_list arg);
-///
-int wprintf(const scope wchar_t* format, scope const ...);
-///
-int wscanf(const scope wchar_t* format, scope ...);
+version (CRuntime_Glibc)
+{
+    ///
+    int fwprintf(FILE* stream, const scope wchar_t* format, scope const ...);
+    ///
+    int __isoc99_fwscanf(FILE* stream, const scope wchar_t* format, scope ...);
+    ///
+    alias fwscanf = __isoc99_fwscanf;
+    ///
+    int swprintf(wchar_t* s, size_t n, const scope wchar_t* format, scope const ...);
+    ///
+    int __isoc99_swscanf(const scope wchar_t* s, const scope wchar_t* format, scope ...);
+    ///
+    alias swscanf = __isoc99_swscanf;
+    ///
+    int vfwprintf(FILE* stream, const scope wchar_t* format, va_list arg);
+    ///
+    int __isoc99_vfwscanf(FILE* stream, const scope wchar_t* format, va_list arg);
+    ///
+    alias vfwscanf = __isoc99_vfwscanf;
+    ///
+    int vswprintf(wchar_t* s, size_t n, const scope wchar_t* format, va_list arg);
+    ///
+    int __isoc99_vswscanf(const scope wchar_t* s, const scope wchar_t* format, va_list arg);
+    ///
+    alias vswscanf = __isoc99_vswscanf;
+    ///
+    int vwprintf(const scope wchar_t* format, va_list arg);
+    ///
+    int __isoc99_vwscanf(const scope wchar_t* format, va_list arg);
+    ///
+    alias vwscanf = __isoc99_vwscanf;
+    ///
+    int wprintf(const scope wchar_t* format, scope const ...);
+    ///
+    int __isoc99_wscanf(const scope wchar_t* format, scope ...);
+    ///
+    alias wscanf = __isoc99_wscanf;
+}
+else
+{
+    ///
+    int fwprintf(FILE* stream, const scope wchar_t* format, scope const ...);
+    ///
+    int fwscanf(FILE* stream, const scope wchar_t* format, scope ...);
+    ///
+    int swprintf(wchar_t* s, size_t n, const scope wchar_t* format, scope const ...);
+    ///
+    int swscanf(const scope wchar_t* s, const scope wchar_t* format, scope ...);
+    ///
+    int vfwprintf(FILE* stream, const scope wchar_t* format, va_list arg);
+    ///
+    int vfwscanf(FILE* stream, const scope wchar_t* format, va_list arg);
+    ///
+    int vswprintf(wchar_t* s, size_t n, const scope wchar_t* format, va_list arg);
+    ///
+    int vswscanf(const scope wchar_t* s, const scope wchar_t* format, va_list arg);
+    ///
+    int vwprintf(const scope wchar_t* format, va_list arg);
+    ///
+    int vwscanf(const scope wchar_t* format, va_list arg);
+    ///
+    int wprintf(const scope wchar_t* format, scope const ...);
+    ///
+    int wscanf(const scope wchar_t* format, scope ...);
+}
 
 // No unsafe pointer manipulation.
 @trusted


### PR DESCRIPTION
The default for glibc is to use the ISO C99 versions of scanf and wscanf family of functions, which reject the `%as` and `%a[flag]` formats.  Update `CRuntime_Glibc` to use those instead.

Since then we are no longer using the GNU/C89 extensions of scanf() in the druntime bindings, remove all `GNU_a` handling in the compiler, this fixes the regression in parsing "%La".