### PR TITLE
Fix Issue 7337 - subclasses without invariants don't check baseclass …

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1877,7 +1877,7 @@ extern (C++) class FuncDeclaration : Declaration
     {
         auto ad = isThis();
         ClassDeclaration cd = ad ? ad.isClassDeclaration() : null;
-        return (ad && !(cd && cd.isCPPclass()) && ad.inv && global.params.useInvariants == CHECKENABLE.on && (visibility.kind == Visibility.Kind.protected_ || visibility.kind == Visibility.Kind.public_ || visibility.kind == Visibility.Kind.export_) && !this.isNaked());
+        return (ad && !(cd && cd.isCPPclass()) && global.params.useInvariants == CHECKENABLE.on && (visibility.kind == Visibility.Kind.protected_ || visibility.kind == Visibility.Kind.public_ || visibility.kind == Visibility.Kind.export_) && !this.isNaked());
     }
 
     override const(char)* kind() const

--- a/test/runnable/testinvariant.d
+++ b/test/runnable/testinvariant.d
@@ -176,6 +176,45 @@ void test13147()
     s.test();
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=7337
+void test7337()
+{
+    class A
+    {
+        static uint invariantStatus;
+
+        public void foo()
+        in
+        {
+            assert(invariantStatus == 0);
+        }
+        out
+        {
+            assert(invariantStatus == 2);
+        }
+        do
+        {
+            assert(invariantStatus == 1);
+        }
+
+        invariant()
+        {
+            invariantStatus++;
+        }
+    }
+
+    class B : A
+    {
+        override public void foo() {}
+    }
+
+    A a = new A();
+    a.foo();
+    A.invariantStatus = 0;
+
+    B b = new B();
+    b.foo();
+}
 
 /***************************************************/
 
@@ -183,6 +222,7 @@ void main()
 {
     testinvariant();
     test6453();
+    test7337();
     test13113();
     test13147();
 }


### PR DESCRIPTION
…invariant after method