### PR TITLE
fix Issue 11048 - Default arguments bypass most attributes check (pure, @safe, @nogc)

### DIFF
--- a/compiler/src/dmd/chkformat.d
+++ b/compiler/src/dmd/chkformat.d
@@ -526,7 +526,7 @@ private:
  *      Format
  */
 Format parseScanfFormatSpecifier(scope const char[] format, ref size_t idx,
-        out bool asterisk) nothrow pure @safe
+        out bool asterisk) nothrow @trusted
 {
     auto i = idx;
     assert(format[i] == '%');
@@ -634,7 +634,7 @@ Format parseScanfFormatSpecifier(scope const char[] format, ref size_t idx,
  *      Format
  */
 Format parsePrintfFormatSpecifier(scope const char[] format, ref size_t idx,
-        out bool widthStar, out bool precisionStar) nothrow pure @safe
+        out bool widthStar, out bool precisionStar) nothrow @trusted
 {
     auto i = idx;
     assert(format[i] == '%');

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1755,9 +1755,11 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                     return errorArgs();
                 }
                 arg = p.defaultArg;
-                arg = inlineCopy(arg, sc);
+                arg = arg.syntaxCopy();
                 // __FILE__, __LINE__, __MODULE__, __FUNCTION__, and __PRETTY_FUNCTION__
                 arg = arg.resolveLoc(loc, sc);
+                arg = arg.expressionSemantic(sc);
+                arg = resolveProperties(sc, arg);
                 arguments.push(arg);
                 nargs++;
             }

--- a/compiler/test/compilable/test2437.d
+++ b/compiler/test/compilable/test2437.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=2437
+
+struct S2437
+{
+    int	m;
+
+    this(int a)
+    {
+        m = a;
+    }
+}
+
+class C2437
+{
+    void fun(S2437 a = S2437(44)) { }
+}
+
+void main()
+{
+    C2437 a = new C2437();
+    a.fun();
+}

--- a/compiler/test/compilable/test2935.d
+++ b/compiler/test/compilable/test2935.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=2935
+
+struct S2935
+{
+   int z;
+   this(int a) { z = a; }
+}
+
+void test2935(S2935 a = S2935(1)) { }
+
+void main()
+{
+    test2935();
+}

--- a/compiler/test/fail_compilation/fail11048a.d
+++ b/compiler/test/fail_compilation/fail11048a.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=11048
+/* TEST_OUTPUT:
+---
+fail_compilation/fail11048a.d(15): Error: `pure` function `fail11048a.foo` cannot access mutable static data `x`
+fail_compilation/fail11048a.d(17): Error: `pure` function `fail11048a.foo` cannot access mutable static data `x`
+fail_compilation/fail11048a.d(17): Error: function `fail11048a.baz(int a)` is not callable using argument types `(_error_)`
+fail_compilation/fail11048a.d(17):        cannot pass argument `__error` of type `_error_` to parameter `int a`
+---
+*/
+int x = 7;
+
+void foo() pure
+{
+    // Does not detect use of mutable global and compiles when it shouldn't.
+    bar();
+    // Correctly detects the use of a mutable global and gives an error
+    baz(x);
+}
+
+void bar(int a = x) pure {}
+
+void baz(int a) pure {}

--- a/compiler/test/fail_compilation/fail13442.d
+++ b/compiler/test/fail_compilation/fail13442.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=13442
+/* TEST_OUTPUT:
+---
+fail_compilation/fail13442.d(15): Error: `@safe` function `main` cannot access `__gshared` data `var`
+---
+*/
+__gshared int var;
+
+void f(int i = var) @safe
+{
+}
+
+void main() @safe
+{
+    f();
+}

--- a/druntime/src/core/atomic.d
+++ b/druntime/src/core/atomic.d
@@ -929,8 +929,6 @@ version (CoreUnittest)
     @safe pure nothrow unittest
     {
 
-        testType!(shared int*)();
-
         static interface Inter {}
         static class KlassImpl : Inter {}
         testXCHG!(shared Inter)(new shared(KlassImpl));
@@ -1000,6 +998,8 @@ version (CoreUnittest)
 
     @betterC pure nothrow unittest
     {
+        testType!(shared int*)();
+
         static if (has128BitCAS)
         {
             struct DoubleValue


### PR DESCRIPTION
Variant on #14214 - this use of inlineCopy is exposing a hole in the `@safe` system.

Checking the testsuite first, then might fold the two together.