### PR TITLE
Move timespec back to core.sys.posix.time

### DIFF
--- a/druntime/src/core/sys/posix/signal.d
+++ b/druntime/src/core/sys/posix/signal.d
@@ -14,7 +14,7 @@ module core.sys.posix.signal;
 import core.sys.posix.config;
 public import core.stdc.signal;
 public import core.sys.posix.sys.types; // for pid_t
-//public import core.sys.posix.time;      // for timespec, now defined here
+public import core.sys.posix.time; // for timespec
 
 version (OSX)
     version = Darwin;
@@ -2798,83 +2798,6 @@ else version (CRuntime_UClibc)
     int siginterrupt(int, int);
     int sigpause(int);
     int sigrelse(int);
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
-
-//
-// Timer (TMR)
-//
-/*
-NOTE: This should actually be defined in core.sys.posix.time.
-      It is defined here instead to break a circular import.
-
-struct timespec
-{
-    time_t  tv_sec;
-    int     tv_nsec;
-}
-*/
-
-version (linux)
-{
-    struct timespec
-    {
-        time_t  tv_sec;
-        c_long  tv_nsec;
-    }
-}
-else version (Darwin)
-{
-    struct timespec
-    {
-        time_t  tv_sec;
-        c_long  tv_nsec;
-    }
-}
-else version (FreeBSD)
-{
-    struct timespec
-    {
-        time_t  tv_sec;
-        c_long  tv_nsec;
-    }
-}
-else version (NetBSD)
-{
-    struct timespec
-    {
-        time_t  tv_sec;
-        c_long  tv_nsec;
-    }
-}
-else version (OpenBSD)
-{
-    struct timespec
-    {
-        time_t  tv_sec;
-        c_long  tv_nsec;
-    }
-}
-else version (DragonFlyBSD)
-{
-    struct timespec
-    {
-        time_t  tv_sec;
-        c_long  tv_nsec;
-    }
-}
-else version (Solaris)
-{
-    struct timespec
-    {
-        time_t tv_sec;
-        c_long tv_nsec;
-    }
-
-    alias timespec timestruc_t;
 }
 else
 {

--- a/druntime/src/core/sys/posix/time.d
+++ b/druntime/src/core/sys/posix/time.d
@@ -167,9 +167,6 @@ else
 CLOCK_PROCESS_CPUTIME_ID (TMR|CPT)
 CLOCK_THREAD_CPUTIME_ID (TMR|TCT)
 
-NOTE: timespec must be defined in core.sys.posix.signal to break
-      a circular import.
-
 struct timespec
 {
     time_t  tv_sec;
@@ -198,6 +195,69 @@ int timer_gettime(timer_t, itimerspec*);
 int timer_getoverrun(timer_t);
 int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
 */
+
+version (linux)
+{
+    struct timespec
+    {
+        time_t  tv_sec;
+        c_long  tv_nsec;
+    }
+}
+else version (Darwin)
+{
+    struct timespec
+    {
+        time_t  tv_sec;
+        c_long  tv_nsec;
+    }
+}
+else version (FreeBSD)
+{
+    struct timespec
+    {
+        time_t  tv_sec;
+        c_long  tv_nsec;
+    }
+}
+else version (NetBSD)
+{
+    struct timespec
+    {
+        time_t  tv_sec;
+        c_long  tv_nsec;
+    }
+}
+else version (OpenBSD)
+{
+    struct timespec
+    {
+        time_t  tv_sec;
+        c_long  tv_nsec;
+    }
+}
+else version (DragonFlyBSD)
+{
+    struct timespec
+    {
+        time_t  tv_sec;
+        c_long  tv_nsec;
+    }
+}
+else version (Solaris)
+{
+    struct timespec
+    {
+        time_t tv_sec;
+        c_long tv_nsec;
+    }
+
+    alias timespec timestruc_t;
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}
 
 version (CRuntime_Glibc)
 {


### PR DESCRIPTION
I doubt this comment still holds true given there's been a lot of fixes in import logic since 2008, but we'll see what breaks.