### PR TITLE
Add a visitor method for CtorDeclaration in transitivevisitor.d

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8034,6 +8034,7 @@ public:
     void visit(FuncLiteralDeclaration* f) override;
     void visit(PostBlitDeclaration* d) override;
     void visit(DtorDeclaration* d) override;
+    void visit(CtorDeclaration* d) override;
     void visit(StaticCtorDeclaration* d) override;
     void visit(StaticDtorDeclaration* d) override;
     void visit(InvariantDeclaration* d) override;

--- a/compiler/src/dmd/transitivevisitor.d
+++ b/compiler/src/dmd/transitivevisitor.d
@@ -862,6 +862,12 @@ package mixin template ParseVisitMethods(AST)
         visitFuncBody(d);
     }
 
+    override void visit(AST.CtorDeclaration d)
+    {
+        //printf("Visiting CtorDeclaration\n");
+        visitFuncBody(d);
+    }
+
     override void visit(AST.StaticCtorDeclaration d)
     {
         //printf("Visiting StaticCtorDeclaration\n");


### PR DESCRIPTION
The class ParseTimeTransitiveVisitor currently does not implement the visit function for AST.CtorDeclaration and this functionality might be necessary when traversing an ast.