### PR TITLE
fix Issue 23251 - Deprecation: format specifier "%[a-z]" is invalid

### DIFF
--- a/compiler/test/compilable/test21177.d
+++ b/compiler/test/compilable/test21177.d
@@ -5,7 +5,6 @@ TEST_OUTPUT:
 ---
 compilable/test21177.d(103): Deprecation: more format specifiers than 0 arguments
 compilable/test21177.d(111): Deprecation: more format specifiers than 0 arguments
-compilable/test21177.d(115): Deprecation: format specifier `"%m["` is invalid
 compilable/test21177.d(150): Deprecation: more format specifiers than 0 arguments
 compilable/test21177.d(151): Deprecation: more format specifiers than 0 arguments
 compilable/test21177.d(152): Deprecation: more format specifiers than 0 arguments


### PR DESCRIPTION
`%[` is its own format specifier, it doesn't require anything else to follow it.

Also implements `%l[..]` and `%m[..]` as the only other two valid modifiers of scan sets.