### PR TITLE
add scope to constructors

### DIFF
--- a/compiler/src/dmd/apply.d
+++ b/compiler/src/dmd/apply.d
@@ -75,7 +75,7 @@ private extern (C++) final class PostorderExpressionVisitor : StoppableVisitor
 public:
     StoppableVisitor v;
 
-    extern (D) this(StoppableVisitor v)
+    extern (D) this(StoppableVisitor v) scope
     {
         this.v = v;
     }

--- a/compiler/src/dmd/argtypes_sysv_x64.d
+++ b/compiler/src/dmd/argtypes_sysv_x64.d
@@ -156,7 +156,7 @@ extern (C++) final class ToClassesVisitor : Visitor
     int numEightbytes;
     Class[4] result = Class.noClass;
 
-    this(size_t size)
+    this(size_t size) scope
     {
         assert(size > 0);
         this.size = size;

--- a/compiler/src/dmd/arrayop.d
+++ b/compiler/src/dmd/arrayop.d
@@ -194,7 +194,7 @@ private Expressions* buildArrayOp(Scope* sc, Expression e, Objects* tiargs)
         Expressions* args;
 
     public:
-        extern (D) this(Scope* sc, Objects* tiargs)
+        extern (D) this(Scope* sc, Objects* tiargs) scope
         {
             this.sc = sc;
             this.tiargs = tiargs;

--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -71,7 +71,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         bool mustNotThrow;
         int result;
 
-        extern (D) this(FuncDeclaration func, bool mustNotThrow)
+        extern (D) this(FuncDeclaration func, bool mustNotThrow) scope
         {
             this.func = func;
             this.mustNotThrow = mustNotThrow;

--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -63,7 +63,7 @@ extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, bool mustN
         CT result;
 
     public:
-        extern (D) this(FuncDeclaration func, bool mustNotThrow)
+        extern (D) this(FuncDeclaration func, bool mustNotThrow) scope
         {
             this.func = func;
             this.mustNotThrow = mustNotThrow;

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -69,7 +69,7 @@ final class CParser(AST) : Parser!AST
     OutBuffer* defines;
 
     extern (D) this(TARGET)(AST.Module _module, const(char)[] input, bool doDocComment,
-                            const ref TARGET target, OutBuffer* defines)
+                            const ref TARGET target, OutBuffer* defines) scope
     {
         super(_module, input, doDocComment);
 

--- a/compiler/src/dmd/cppmangle.d
+++ b/compiler/src/dmd/cppmangle.d
@@ -173,7 +173,7 @@ private final class CppMangleVisitor : Visitor
      *   buf = `OutBuffer` to write the mangling to
      *   loc = `Loc` of the symbol being mangled
      */
-    this(OutBuffer* buf, Loc loc)
+    this(OutBuffer* buf, Loc loc) scope
     {
         this.buf = buf;
         this.loc = loc;

--- a/compiler/src/dmd/cppmanglewin.d
+++ b/compiler/src/dmd/cppmanglewin.d
@@ -122,7 +122,7 @@ private final class VisualCPPMangler : Visitor
     int flags;
     OutBuffer buf;
 
-    extern (D) this(VisualCPPMangler rvl)
+    extern (D) this(VisualCPPMangler rvl) scope
     {
         flags |= (rvl.flags & IS_DMC);
         saved_idents[] = rvl.saved_idents[];
@@ -131,7 +131,7 @@ private final class VisualCPPMangler : Visitor
     }
 
 public:
-    extern (D) this(bool isdmc, Loc loc)
+    extern (D) this(bool isdmc, Loc loc) scope
     {
         if (isdmc)
         {

--- a/compiler/src/dmd/delegatize.d
+++ b/compiler/src/dmd/delegatize.d
@@ -109,7 +109,7 @@ private void lambdaSetParent(Expression e, FuncDeclaration fd)
         }
 
     public:
-        extern (D) this(FuncDeclaration fd)
+        extern (D) this(FuncDeclaration fd) scope
         {
             this.fd = fd;
         }
@@ -205,7 +205,7 @@ bool lambdaCheckForNestedRef(Expression e, Scope* sc)
         Scope* sc;
         bool result;
 
-        extern (D) this(Scope* sc)
+        extern (D) this(Scope* sc) scope
         {
             this.sc = sc;
         }

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -747,7 +747,7 @@ public:
     Expression result;
     UnionExp* pue;              // storage for `result`
 
-    extern (D) this(UnionExp* pue, InterState* istate, CTFEGoal goal)
+    extern (D) this(UnionExp* pue, InterState* istate, CTFEGoal goal) scope
     {
         this.pue = pue;
         this.istate = istate;

--- a/compiler/src/dmd/dmangle.d
+++ b/compiler/src/dmd/dmangle.d
@@ -240,7 +240,7 @@ public:
     OutBuffer* buf;
     Backref backref;
 
-    extern (D) this(OutBuffer* buf, Type rootType = null)
+    extern (D) this(OutBuffer* buf, Type rootType = null) scope
     {
         this.buf = buf;
         this.backref = Backref(rootType);

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -951,7 +951,7 @@ private void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
         OutBuffer* buf;
         Scope* sc;
 
-        extern (D) this(ref OutBuffer buf, Scope* sc)
+        extern (D) this(ref OutBuffer buf, Scope* sc) scope
         {
             this.buf = &buf;
             this.sc = sc;
@@ -1235,7 +1235,7 @@ private void toDocBuffer(Dsymbol s, ref OutBuffer buf, Scope* sc)
         OutBuffer* buf;
         Scope* sc;
 
-        extern (D) this(ref OutBuffer buf, Scope* sc)
+        extern (D) this(ref OutBuffer buf, Scope* sc) scope
         {
             this.buf = &buf;
             this.sc = sc;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -271,7 +271,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     alias visit = Visitor.visit;
 
     Scope* sc;
-    this(Scope* sc)
+    this(Scope* sc) scope
     {
         this.sc = sc;
     }
@@ -6017,7 +6017,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
                 alias visit = Visitor.visit;
                 TemplateInstance inst;
 
-                extern (D) this(TemplateInstance inst)
+                extern (D) this(TemplateInstance inst) scope
                 {
                     this.inst = inst;
                 }

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -5897,7 +5897,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         }
     }
 
-    extern (D) this(const ref Loc loc, Identifier ident, Objects* tiargs)
+    extern (D) this(const ref Loc loc, Identifier ident, Objects* tiargs) scope
     {
         super(loc, null);
         static if (LOG)
@@ -5912,7 +5912,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
      * This constructor is only called when we figured out which function
      * template to instantiate.
      */
-    extern (D) this(const ref Loc loc, TemplateDeclaration td, Objects* tiargs)
+    extern (D) this(const ref Loc loc, TemplateDeclaration td, Objects* tiargs) scope
     {
         super(loc, null);
         static if (LOG)

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -293,7 +293,7 @@ public:
     Context context;
     alias context this;
 
-    this(OutBuffer* fwdbuf, OutBuffer* donebuf, OutBuffer* buf)
+    this(OutBuffer* fwdbuf, OutBuffer* donebuf, OutBuffer* buf) scope
     {
         this.fwdbuf = fwdbuf;
         this.donebuf = donebuf;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -734,7 +734,7 @@ extern (C++) abstract class Expression : ASTNode
     Type type;      // !=null means that semantic() has been run
     Loc loc;        // file location
 
-    extern (D) this(const ref Loc loc, EXP op, int size)
+    extern (D) this(const ref Loc loc, EXP op, int size) scope
     {
         //printf("Expression::Expression(op = %d) this = %p\n", op, this);
         this.loc = loc;
@@ -2336,7 +2336,7 @@ extern (C++) class IdentifierExp : Expression
 {
     Identifier ident;
 
-    extern (D) this(const ref Loc loc, Identifier ident)
+    extern (D) this(const ref Loc loc, Identifier ident) scope
     {
         super(loc, EXP.identifier, __traits(classInstanceSize, IdentifierExp));
         this.ident = ident;
@@ -2491,7 +2491,7 @@ extern (C++) final class SuperExp : ThisExp
  */
 extern (C++) final class NullExp : Expression
 {
-    extern (D) this(const ref Loc loc, Type type = null)
+    extern (D) this(const ref Loc loc, Type type = null) scope
     {
         super(loc, EXP.null_, __traits(classInstanceSize, NullExp));
         this.type = type;
@@ -2550,7 +2550,7 @@ extern (C++) final class StringExp : Expression
     char postfix = NoPostfix;   // 'c', 'w', 'd'
     OwnedBy ownedByCtfe = OwnedBy.code;
 
-    extern (D) this(const ref Loc loc, const(void)[] string)
+    extern (D) this(const ref Loc loc, const(void)[] string) scope
     {
         super(loc, EXP.string_, __traits(classInstanceSize, StringExp));
         this.string = cast(char*)string.ptr; // note that this.string should be const
@@ -2558,7 +2558,7 @@ extern (C++) final class StringExp : Expression
         this.sz = 1;                    // work around LDC bug #1286
     }
 
-    extern (D) this(const ref Loc loc, const(void)[] string, size_t len, ubyte sz, char postfix = NoPostfix)
+    extern (D) this(const ref Loc loc, const(void)[] string, size_t len, ubyte sz, char postfix = NoPostfix) scope
     {
         super(loc, EXP.string_, __traits(classInstanceSize, StringExp));
         this.string = cast(char*)string.ptr; // note that this.string should be const
@@ -4294,7 +4294,7 @@ extern (C++) final class IsExp : Expression
     TOK tok;            // ':' or '=='
     TOK tok2;           // 'struct', 'union', etc.
 
-    extern (D) this(const ref Loc loc, Type targ, Identifier id, TOK tok, Type tspec, TOK tok2, TemplateParameters* parameters)
+    extern (D) this(const ref Loc loc, Type targ, Identifier id, TOK tok, Type tspec, TOK tok2, TemplateParameters* parameters) scope
     {
         super(loc, EXP.is_, __traits(classInstanceSize, IsExp));
         this.targ = targ;
@@ -4334,7 +4334,7 @@ extern (C++) abstract class UnaExp : Expression
     Expression e1;
     Type att1;      // Save alias this type to detect recursion
 
-    extern (D) this(const ref Loc loc, EXP op, int size, Expression e1)
+    extern (D) this(const ref Loc loc, EXP op, int size, Expression e1) scope
     {
         super(loc, op, size);
         this.e1 = e1;
@@ -4407,7 +4407,7 @@ extern (C++) abstract class BinExp : Expression
     Type att1;      // Save alias this type to detect recursion
     Type att2;      // Save alias this type to detect recursion
 
-    extern (D) this(const ref Loc loc, EXP op, int size, Expression e1, Expression e2)
+    extern (D) this(const ref Loc loc, EXP op, int size, Expression e1, Expression e2) scope
     {
         super(loc, op, size);
         this.e1 = e1;
@@ -4698,7 +4698,7 @@ extern (C++) abstract class BinExp : Expression
  */
 extern (C++) class BinAssignExp : BinExp
 {
-    extern (D) this(const ref Loc loc, EXP op, int size, Expression e1, Expression e2)
+    extern (D) this(const ref Loc loc, EXP op, int size, Expression e1, Expression e2) scope
     {
         super(loc, op, size, e1, e2);
     }
@@ -5404,7 +5404,7 @@ extern (C++) final class NegExp : UnaExp
  */
 extern (C++) final class UAddExp : UnaExp
 {
-    extern (D) this(const ref Loc loc, Expression e)
+    extern (D) this(const ref Loc loc, Expression e) scope
     {
         super(loc, EXP.uadd, __traits(classInstanceSize, UAddExp), e);
     }
@@ -6466,7 +6466,7 @@ extern (C++) final class MinExp : BinExp
  */
 extern (C++) final class CatExp : BinExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2)
+    extern (D) this(const ref Loc loc, Expression e1, Expression e2) scope
     {
         super(loc, EXP.concatenate, __traits(classInstanceSize, CatExp), e1, e2);
     }
@@ -6796,7 +6796,7 @@ extern (C++) final class CondExp : BinExp
 {
     Expression econd;
 
-    extern (D) this(const ref Loc loc, Expression econd, Expression e1, Expression e2)
+    extern (D) this(const ref Loc loc, Expression econd, Expression e1, Expression e2) scope
     {
         super(loc, EXP.question, __traits(classInstanceSize, CondExp), e1, e2);
         this.econd = econd;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -2550,7 +2550,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     Scope* sc;
     Expression result;
 
-    this(Scope* sc)
+    this(Scope* sc) scope
     {
         this.sc = sc;
     }

--- a/compiler/src/dmd/foreachvar.d
+++ b/compiler/src/dmd/foreachvar.d
@@ -56,7 +56,7 @@ void foreachVar(Expression e, void delegate(VarDeclaration) dgVar)
         alias visit = typeof(super).visit;
         extern (D) void delegate(VarDeclaration) dgVar;
 
-        extern (D) this(void delegate(VarDeclaration) dgVar)
+        extern (D) this(void delegate(VarDeclaration) dgVar) scope
         {
             this.dgVar = dgVar;
         }

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -145,7 +145,7 @@ public:
     OutBuffer* buf;
     HdrGenState* hgs;
 
-    extern (D) this(OutBuffer* buf, HdrGenState* hgs)
+    extern (D) this(OutBuffer* buf, HdrGenState* hgs) scope
     {
         this.buf = buf;
         this.hgs = hgs;
@@ -806,7 +806,7 @@ public:
     OutBuffer* buf;
     HdrGenState* hgs;
 
-    extern (D) this(OutBuffer* buf, HdrGenState* hgs)
+    extern (D) this(OutBuffer* buf, HdrGenState* hgs) scope
     {
         this.buf = buf;
         this.hgs = hgs;
@@ -2762,7 +2762,7 @@ public:
     OutBuffer* buf;
     HdrGenState* hgs;
 
-    extern (D) this(OutBuffer* buf, HdrGenState* hgs)
+    extern (D) this(OutBuffer* buf, HdrGenState* hgs) scope
     {
         this.buf = buf;
         this.hgs = hgs;
@@ -2843,7 +2843,7 @@ public:
     OutBuffer* buf;
     HdrGenState* hgs;
 
-    extern (D) this(OutBuffer* buf, HdrGenState* hgs)
+    extern (D) this(OutBuffer* buf, HdrGenState* hgs) scope
     {
         this.buf = buf;
         this.hgs = hgs;

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -142,7 +142,7 @@ private final class InlineDoState
     // inline result
     bool foundReturn;
 
-    this(Dsymbol parent, FuncDeclaration fd)
+    this(Dsymbol parent, FuncDeclaration fd) scope
     {
         this.parent = parent;
         this.fd = fd;
@@ -167,7 +167,7 @@ public:
 
     enum asStatements = is(Result == Statement);
 
-    extern (D) this(InlineDoState ids)
+    extern (D) this(InlineDoState ids) scope
     {
         this.ids = ids;
     }
@@ -943,7 +943,7 @@ public:
     Expression eresult;
     bool again;
 
-    extern (D) this()
+    extern (D) this() scope
     {
     }
 
@@ -2298,7 +2298,7 @@ private bool expNeedsDtor(Expression exp)
         Expression exp;
 
     public:
-        extern (D) this(Expression exp)
+        extern (D) this(Expression exp) scope
         {
             this.exp = exp;
         }

--- a/compiler/src/dmd/inlinecost.d
+++ b/compiler/src/dmd/inlinecost.d
@@ -156,11 +156,11 @@ public:
     FuncDeclaration fd;
     int cost;           // zero start for subsequent AST
 
-    extern (D) this()
+    extern (D) this() scope
     {
     }
 
-    extern (D) this(bool hasthis, bool hdrscan, bool allowAlloca, FuncDeclaration fd)
+    extern (D) this(bool hasthis, bool hdrscan, bool allowAlloca, FuncDeclaration fd) scope
     {
         this.hasthis = hasthis;
         this.hdrscan = hdrscan;
@@ -168,7 +168,7 @@ public:
         this.fd = fd;
     }
 
-    extern (D) this(InlineCostVisitor icv)
+    extern (D) this(InlineCostVisitor icv) scope
     {
         nested = icv.nested;
         hasthis = icv.hasthis;

--- a/compiler/src/dmd/json.d
+++ b/compiler/src/dmd/json.d
@@ -54,7 +54,7 @@ public:
     int indentLevel;
     const(char)[] filename;
 
-    extern (D) this(OutBuffer* buf)
+    extern (D) this(OutBuffer* buf) scope
     {
         this.buf = buf;
     }

--- a/compiler/src/dmd/lambdacomp.d
+++ b/compiler/src/dmd/lambdacomp.d
@@ -120,7 +120,7 @@ public:
     OutBuffer buf;
     alias visit = SemanticTimeTransitiveVisitor.visit;
 
-    this(Scope* sc)
+    this(Scope* sc) scope
     {
         this.sc = sc;
     }

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -108,7 +108,7 @@ class Lexer
      */
     this(const(char)* filename, const(char)* base, size_t begoffset,
         size_t endoffset, bool doDocComment, bool commentToken,
-        const(char)[] vendor = "DLF", uint versionNumber = 1) pure
+        const(char)[] vendor = "DLF", uint versionNumber = 1) pure scope
     {
         scanloc = Loc(filename, 1, 1);
         // debug printf("Lexer::Lexer(%p)\n", base);
@@ -172,7 +172,7 @@ class Lexer
     /******************
      * Used for unittests for a mock Lexer
      */
-    this() { }
+    this() scope { }
 
     /**************************************
      * Reset lexer to lex #define's

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -456,7 +456,7 @@ extern (C++) abstract class Type : ASTNode
             return sizeTy;
         }();
 
-    final extern (D) this(TY ty)
+    final extern (D) this(TY ty) scope
     {
         this.ty = ty;
     }
@@ -3120,7 +3120,7 @@ extern (C++) final class TypeBasic : Type
     const(char)* dstring;
     uint flags;
 
-    extern (D) this(TY ty)
+    extern (D) this(TY ty) scope
     {
         super(ty);
         const(char)* d;

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -37,7 +37,7 @@ public:
     bool checkOnly;     // don't print errors
     bool err;
 
-    extern (D) this(FuncDeclaration f)
+    extern (D) this(FuncDeclaration f) scope
     {
         this.f = f;
     }

--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -115,7 +115,7 @@ struct ObNode
     PtrVarState[] input;  /// variable states on entry to exp
     PtrVarState[] output; /// variable states on exit to exp
 
-    this(ObNode* tryBlock)
+    this(ObNode* tryBlock) scope
     {
         this.tryBlock = tryBlock;
     }
@@ -1353,7 +1353,7 @@ void genKill(ref ObState obstate, ObNode* ob)
 
             extern (D) this(void delegate(ObNode*, VarDeclaration, Expression, bool) dgWriteVar,
                             void delegate(const ref Loc loc, ObNode* ob, VarDeclaration v, bool mutable) dgReadVar,
-                            ObNode* ob, ref ObState obstate)
+                            ObNode* ob, ref ObState obstate) scope
             {
                 this.dgWriteVar = dgWriteVar;
                 this.dgReadVar  = dgReadVar;
@@ -2058,7 +2058,7 @@ void checkObErrors(ref ObState obstate)
 
             extern (D) this(void delegate(const ref Loc loc, ObNode* ob, VarDeclaration v, bool mutable, PtrVarState[]) dgReadVar,
                             void delegate(ObNode*, PtrVarState[], VarDeclaration, Expression) dgWriteVar,
-                            PtrVarState[] cpvs, ObNode* ob, ref ObState obstate)
+                            PtrVarState[] cpvs, ObNode* ob, ref ObState obstate) scope
             {
                 this.dgReadVar  = dgReadVar;
                 this.dgWriteVar = dgWriteVar;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -51,7 +51,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Input:
      *      loc     location in source file of mixin
      */
-    extern (D) this(const ref Loc loc, AST.Module _module, const(char)[] input, bool doDocComment)
+    extern (D) this(const ref Loc loc, AST.Module _module, const(char)[] input, bool doDocComment) scope
     {
         super(_module ? _module.srcfile.toChars() : null, input.ptr, 0, input.length, doDocComment, false,
                 global.vendor, global.versionNumber());
@@ -75,7 +75,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         //nextToken();              // start up the scanner
     }
 
-    extern (D) this(AST.Module _module, const(char)[] input, bool doDocComment)
+    extern (D) this(AST.Module _module, const(char)[] input, bool doDocComment) scope
     {
         super(_module ? _module.srcfile.toChars() : null, input.ptr, 0, input.length, doDocComment, false,
               global.vendor, global.versionNumber());

--- a/compiler/src/dmd/printast.d
+++ b/compiler/src/dmd/printast.d
@@ -39,7 +39,7 @@ extern (C++) final class PrintASTVisitor : Visitor
 
     int indent;
 
-    extern (D) this(int indent)
+    extern (D) this(int indent) scope
     {
         this.indent = indent;
     }

--- a/compiler/src/dmd/root/aav.d
+++ b/compiler/src/dmd/root/aav.d
@@ -149,7 +149,7 @@ private struct AARange(K,V)
     size_t bIndex;
     aaA* current;
 
-    this(AA* aa) pure nothrow @nogc
+    this(AA* aa) pure nothrow @nogc scope
     {
         if (aa)
         {

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -41,7 +41,7 @@ public:
      * Params:
      *  dim = initial length of array
      */
-    this(size_t dim) pure nothrow
+    this(size_t dim) pure nothrow scope
     {
         reserve(dim);
         this.length = dim;

--- a/compiler/src/dmd/root/rootobject.d
+++ b/compiler/src/dmd/root/rootobject.d
@@ -38,7 +38,7 @@ enum DYNCAST : int
 
 extern (C++) class RootObject
 {
-    this() nothrow pure @nogc @safe
+    this() nothrow pure @nogc @safe scope
     {
     }
 

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -146,7 +146,7 @@ private extern (C++) class S2irVisitor : Visitor
     IRState* irs;
     StmtState* stmtstate;
 
-    this(IRState *irs, StmtState* stmtstate)
+    this(IRState *irs, StmtState* stmtstate) scope
     {
         this.irs = irs;
         this.stmtstate = stmtstate;

--- a/compiler/src/dmd/sapply.d
+++ b/compiler/src/dmd/sapply.d
@@ -37,7 +37,7 @@ private extern (C++) final class PostorderStatementVisitor : StoppableVisitor
 public:
     StoppableVisitor v;
 
-    extern (D) this(StoppableVisitor v)
+    extern (D) this(StoppableVisitor v) scope
     {
         this.v = v;
     }

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -83,7 +83,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
 {
     alias visit = Visitor.visit;
     Scope* sc;
-    this(Scope* sc)
+    this(Scope* sc) scope
     {
         this.sc = sc;
     }

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -88,7 +88,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
     alias visit = Visitor.visit;
 
     Scope* sc;
-    this(Scope* sc)
+    this(Scope* sc) scope
     {
         this.sc = sc;
     }
@@ -1599,7 +1599,7 @@ private struct FuncDeclSem3
 
     // Scope of analysis
     Scope* sc;
-    this(FuncDeclaration fd,Scope* s)
+    this(FuncDeclaration fd,Scope* s) scope
     {
         funcdecl = fd;
         sc = s;

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -37,7 +37,7 @@ extern (C++) bool isTrivialExp(Expression e)
     {
         alias visit = typeof(super).visit;
     public:
-        extern (D) this()
+        extern (D) this() scope
         {
         }
 
@@ -75,7 +75,7 @@ extern (C++) bool hasSideEffect(Expression e, bool assumeImpureCalls = false)
     {
         alias visit = typeof(super).visit;
     public:
-        extern (D) this()
+        extern (D) this() scope
         {
         }
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -160,7 +160,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
     Statement result;
     Scope* sc;
 
-    this(Scope* sc)
+    this(Scope* sc) scope
     {
         this.sc = sc;
     }

--- a/compiler/src/dmd/templateparamsem.d
+++ b/compiler/src/dmd/templateparamsem.d
@@ -50,7 +50,7 @@ private extern (C++) final class TemplateParameterSemanticVisitor : Visitor
     TemplateParameters* parameters;
     bool result;
 
-    this(Scope* sc, TemplateParameters* parameters)
+    this(Scope* sc, TemplateParameters* parameters) scope
     {
         this.sc = sc;
         this.parameters = parameters;

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -110,7 +110,7 @@ Symbol *toSymbol(Dsymbol s)
 
         Symbol *result;
 
-        this()
+        this() scope
         {
             result = null;
         }

--- a/compiler/src/dmd/tocvdebug.d
+++ b/compiler/src/dmd/tocvdebug.d
@@ -360,7 +360,7 @@ struct CvFieldList
 
     const bool canSplitList;
 
-    this(uint fields, uint len)
+    this(uint fields, uint len) scope
     {
         canSplitList = config.fulltypes == CV8; // optlink bails out with LF_INDEX
         fieldIndexLen = canSplitList ? (config.fulltypes == CV8 ? 2 + 2 + 4 : 2 + 2) : 0;

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -1156,7 +1156,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         }
     }
 
-    this(ref DtBuilder dtb)
+    this(ref DtBuilder dtb) scope
     {
         this.dtb = &dtb;
     }

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -284,7 +284,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
     public:
         bool multiobj;
 
-        this(bool multiobj)
+        this(bool multiobj) scope
         {
             this.multiobj = multiobj;
         }

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -122,7 +122,7 @@ ulong getTypePointerBitmap(Loc loc, Type t, Array!(ulong)* data)
     {
         alias visit = Visitor.visit;
     public:
-        extern (D) this(Array!(ulong)* _data, ulong _sz_size_t)
+        extern (D) this(Array!(ulong)* _data, ulong _sz_size_t) scope
         {
             this.data = _data;
             this.sz_size_t = _sz_size_t;

--- a/compiler/src/dmd/visitor.d
+++ b/compiler/src/dmd/visitor.d
@@ -248,7 +248,7 @@ extern (C++) class StoppableVisitor : Visitor
 public:
     bool stop;
 
-    final extern (D) this()
+    final extern (D) this() scope
     {
     }
 }


### PR DESCRIPTION
This is so that https://github.com/dlang/dmd/pull/14175 is less likely to run out of memory due to `scope` allocating on the heap rather than the stack.

It's only about half the job, I'll do the rest later once we see how this goes.