### PR TITLE
fix Issue 23235 - [DIP1000] typesafe variadic parameters should autom…

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1272,6 +1272,16 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                     errors = true;
                 }
 
+                const bool isTypesafeVariadic = i + 1 == dim &&
+                                                tf.parameterList.varargs == VarArg.typesafe &&
+                                                (t.isTypeDArray() || t.isTypeClass());
+                if (isTypesafeVariadic)
+                {
+                    /* typesafe variadic arguments are constructed on the stack, so must be `scope`
+                     */
+                    fparam.storageClass |= STC.scope_ | STC.scopeinferred;
+                }
+
                 if (fparam.storageClass & STC.return_)
                 {
                     if (fparam.isReference())
@@ -1300,8 +1310,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                         }
                     }
 
-                    if (i + 1 == dim && tf.parameterList.varargs == VarArg.typesafe &&
-                        (t.isTypeDArray() || t.isTypeClass()))
+                    if (isTypesafeVariadic)
                     {
                         /* This is because they can be constructed on the stack
                          * https://dlang.org/spec/function.html#typesafe_variadic_functions

--- a/compiler/test/compilable/test23235.d
+++ b/compiler/test/compilable/test23235.d
@@ -1,0 +1,20 @@
+/* https://issues.dlang.org/show_bug.cgi?id=23235
+ */
+
+@safe:
+
+void awkk(string[] ppp...)
+{
+}
+
+void bark(string[] foo...) {
+    awkk(foo);
+}
+
+void cack(string[] bar...) {
+    bark(bar);
+}
+
+void test() {
+    cack("abc", "def");
+}


### PR DESCRIPTION
…atically be scope

So set them to `scope` in the sematic pass.