### PR TITLE
Fix 23022 - typesafe variadic parameter should not infer return

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -1196,7 +1196,8 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
             v.isParameter() &&
             !v.doNotInferReturn &&
             sc.func.flags & FUNCFLAG.returnInprocess &&
-            p == sc.func)
+            p == sc.func &&
+            !v.isTypesafeVariadicParameter)
         {
             inferReturn(sc.func, v, /*returnScope:*/ true); // infer addition of 'return'
             continue;

--- a/compiler/test/fail_compilation/test23022.d
+++ b/compiler/test/fail_compilation/test23022.d
@@ -1,0 +1,15 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test23022.d(14): Error: scope parameter `p` may not be returned
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=23022
+// Typesafe variadic parameter should not infer return
+
+auto ir(string[] p...)
+{
+    return p;
+}


### PR DESCRIPTION
Branched off https://github.com/dlang/dmd/pull/14326 because it uses the new signature of `isTypesafeVariadicParameter`