### PR TITLE
Deprecate version/debug integers

### DIFF
--- a/changelog/deprecate_version_int.dd
+++ b/changelog/deprecate_version_int.dd
@@ -1,0 +1,22 @@
+Using integers for `version` or `debug` conditions has been deprecated
+
+The problem is that it only provides a single number namespace without any meaning.
+It's better to use version identifiers describing the feature they enable.
+See also [this thread on the forum](https://forum.dlang.org/post/chtcuqdjzddlesdhablo@forum.dlang.org).
+
+---
+// now deprecated:
+version = 3;
+version (2) { }
+
+debug = 4;
+debug (5) { }
+
+// use identifiers instead:
+version = HasX;
+
+version (HasX)
+    void x() { /* ... */ }
+else
+    void x() {}
+---

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -2370,6 +2370,10 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                 {
                     if (!params.debuglevel.parseDigits(p.toDString()[7 .. $]))
                         goto Lerror;
+
+                    // @@@DEPRECATED_2.111@@@
+                    // Deprecated in 2.101, remove in 2.111
+                    deprecation(Loc.initial, "`-debug=number` is deprecated, use debug identifiers instead");
                 }
                 else if (Identifier.isValidIdentifier(p + 7))
                 {
@@ -2396,9 +2400,14 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                 {
                     if (!params.versionlevel.parseDigits(p.toDString()[9 .. $]))
                         goto Lerror;
+
+                    // @@@DEPRECATED_2.111@@@
+                    // Deprecated in 2.101, remove in 2.111
+                    deprecation(Loc.initial, "`-version=number` is deprecated, use version identifiers instead");
                 }
                 else if (Identifier.isValidIdentifier(p + 9))
                 {
+
                     if (!params.versionids)
                         params.versionids = new Array!(const(char)*);
                     params.versionids.push(p + 9);

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -2186,7 +2186,13 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         if (token.value == TOK.identifier)
             s = new AST.DebugSymbol(token.loc, token.ident);
         else if (token.value == TOK.int32Literal || token.value == TOK.int64Literal)
+        {
+            // @@@DEPRECATED_2.111@@@
+            // Deprecated in 2.101, remove in 2.111
+            deprecation("`debug = <integer>` is deprecated, use debug identifiers instead");
+
             s = new AST.DebugSymbol(token.loc, cast(uint)token.unsvalue);
+        }
         else
         {
             error("identifier or integer expected, not `%s`", token.toChars());
@@ -2215,7 +2221,13 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (token.value == TOK.identifier)
                 id = token.ident;
             else if (token.value == TOK.int32Literal || token.value == TOK.int64Literal)
+            {
+                // @@@DEPRECATED_2.111@@@
+                // Deprecated in 2.101, remove in 2.111
+                deprecation("`debug( <integer> )` is deprecated, use debug identifiers instead");
+
                 level = cast(uint)token.unsvalue;
+            }
             else
                 error("identifier or integer expected inside `debug(...)`, not `%s`", token.toChars());
             loc = token.loc;
@@ -2235,7 +2247,12 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         if (token.value == TOK.identifier)
             s = new AST.VersionSymbol(token.loc, token.ident);
         else if (token.value == TOK.int32Literal || token.value == TOK.int64Literal)
+        {
+            // @@@DEPRECATED_2.111@@@
+            // Deprecated in 2.101, remove in 2.111
+            deprecation("`version = <integer>` is deprecated, use version identifiers instead");
             s = new AST.VersionSymbol(token.loc, cast(uint)token.unsvalue);
+        }
         else
         {
             error("identifier or integer expected, not `%s`", token.toChars());
@@ -2269,7 +2286,13 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (token.value == TOK.identifier)
                 id = token.ident;
             else if (token.value == TOK.int32Literal || token.value == TOK.int64Literal)
+            {
+                // @@@DEPRECATED_2.111@@@
+                // Deprecated in 2.101, remove in 2.111
+                deprecation("`version( <integer> )` is deprecated, use version identifiers instead");
+
                 level = cast(uint)token.unsvalue;
+            }
             else if (token.value == TOK.unittest_)
                 id = Identifier.idPool(Token.toString(TOK.unittest_));
             else if (token.value == TOK.assert_)

--- a/compiler/test/compilable/cppmangle3.d
+++ b/compiler/test/compilable/cppmangle3.d
@@ -45,16 +45,12 @@ alias Alias(T) = T;
 static assert(is(Alias!(__traits(parent, Foo.bar)) == Foo));
 
 extern(C++, "std"):
-debug = 456;
 debug = def;
-version = 456;
 version = def;
 
 extern(C++, "std")
 {
-    debug = 456;
     debug = def;
-    version = 456;
     version = def;
 }
 

--- a/compiler/test/fail_compilation/diag11198.d
+++ b/compiler/test/fail_compilation/diag11198.d
@@ -1,12 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag11198.d(15): Error: version `blah` declaration must be at module level
-fail_compilation/diag11198.d(16): Error: debug `blah` declaration must be at module level
-fail_compilation/diag11198.d(17): Error: version `1` level declaration must be at module level
-fail_compilation/diag11198.d(18): Error: debug `2` level declaration must be at module level
-fail_compilation/diag11198.d(19): Error: identifier or integer expected, not `""`
-fail_compilation/diag11198.d(20): Error: identifier or integer expected, not `""`
+fail_compilation/diag11198.d(17): Error: version `blah` declaration must be at module level
+fail_compilation/diag11198.d(18): Error: debug `blah` declaration must be at module level
+fail_compilation/diag11198.d(19): Deprecation: `version = <integer>` is deprecated, use version identifiers instead
+fail_compilation/diag11198.d(19): Error: version `1` level declaration must be at module level
+fail_compilation/diag11198.d(20): Deprecation: `debug = <integer>` is deprecated, use debug identifiers instead
+fail_compilation/diag11198.d(20): Error: debug `2` level declaration must be at module level
+fail_compilation/diag11198.d(21): Error: identifier or integer expected, not `""`
+fail_compilation/diag11198.d(22): Error: identifier or integer expected, not `""`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail58.d
+++ b/compiler/test/fail_compilation/fail58.d
@@ -7,7 +7,7 @@ fail_compilation/fail58.d(30): Error: function `fail58.SomeFunc(dchar[] pText, o
 fail_compilation/fail58.d(30):        cannot pass argument `""` of type `string` to parameter `dchar[] pText`
 ---
 */
-debug(1) import std.stdio;
+debug import std.stdio;
 const int anything = -1000; // Line #2
 dchar[] SomeFunc( dchar[] pText, out int pStopPosn)
 {
@@ -15,7 +15,7 @@ dchar[] SomeFunc( dchar[] pText, out int pStopPosn)
         pStopPosn = 0;
     else
         pStopPosn = -1;
-    debug(1) writefln("DEBUG: using '%s' we get %d", pText, pStopPosn);
+    debug writefln("DEBUG: using '%s' we get %d", pText, pStopPosn);
     return pText.dup;
 }
 
@@ -24,12 +24,12 @@ int main(char[][] pArgs)
     int sp;
 
     SomeFunc("123", sp);
-    debug(1) writefln("DEBUG: got %d", sp);
+    debug writefln("DEBUG: got %d", sp);
     assert(sp == -1);
 
     SomeFunc("", sp);
 //    if (sp != 0){} // Line #22
-    debug(1) writefln("DEBUG: got %d", sp);
+    debug writefln("DEBUG: got %d", sp);
     assert(sp == -1);
     return 0;
 }

--- a/compiler/test/fail_compilation/test13786.d
+++ b/compiler/test/fail_compilation/test13786.d
@@ -1,11 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test13786.d(14): Error: debug `123` level declaration must be at module level
-fail_compilation/test13786.d(15): Error: debug `abc` declaration must be at module level
-fail_compilation/test13786.d(16): Error: version `123` level declaration must be at module level
-fail_compilation/test13786.d(17): Error: version `abc` declaration must be at module level
-fail_compilation/test13786.d(20): Error: template instance `test13786.T!()` error instantiating
+fail_compilation/test13786.d(16): Deprecation: `debug = <integer>` is deprecated, use debug identifiers instead
+fail_compilation/test13786.d(18): Deprecation: `version = <integer>` is deprecated, use version identifiers instead
+fail_compilation/test13786.d(16): Error: debug `123` level declaration must be at module level
+fail_compilation/test13786.d(17): Error: debug `abc` declaration must be at module level
+fail_compilation/test13786.d(18): Error: version `123` level declaration must be at module level
+fail_compilation/test13786.d(19): Error: version `abc` declaration must be at module level
+fail_compilation/test13786.d(22): Error: template instance `test13786.T!()` error instantiating
 ---
 */
 

--- a/compiler/test/runnable/lexer.d
+++ b/compiler/test/runnable/lexer.d
@@ -1,5 +1,11 @@
 // REQUIRED_ARGS:
-
+/*
+TEST_OUTPUT:
+---
+runnable/lexer.d(81): Deprecation: `version( <integer> )` is deprecated, use version identifiers instead
+runnable/lexer.d(82): Deprecation: `debug( <integer> )` is deprecated, use debug identifiers instead
+---
+*/
 
 /*********************************************************/
 

--- a/compiler/test/runnable/test11.d
+++ b/compiler/test/runnable/test11.d
@@ -1193,41 +1193,6 @@ void test63()
      printf("%.*s\n", cast(int)s.length, s.ptr);
 }
 
-
-/**************************************/
-
-debug = 3;
-
-void test64()
-{
-    debug(5)
-    {
-        assert(0);
-    }
-    debug(3)
-    {
-        int x = 3;
-    }
-    assert(x == 3);
-}
-
-/**************************************/
-
-version = 3;
-
-void test65()
-{
-    version(5)
-    {
-        assert(0);
-    }
-    version(3)
-    {
-        int x = 3;
-    }
-    assert(x == 3);
-}
-
 /**************************************/
 // https://issues.dlang.org/show_bug.cgi?id=8809
 
@@ -1381,8 +1346,6 @@ int main(string[] argv)
     test61();
     test62();
     test63();
-    test64();
-    test65();
     test8809();
     test9734();
 

--- a/compiler/test/runnable/test19.d
+++ b/compiler/test/runnable/test19.d
@@ -59,22 +59,7 @@ void test2()
 void test3()
 {
     debug printf("debug\n");
-    debug(1) printf("debug(1)\n");
-    debug(2) printf("debug(2)\n");
-    debug(3) printf("debug(3)\n");
     debug(bar) printf("debug(bar)\n");
-    debug(10) assert(0);
-
-    debug(1)
-    {
-        int d1 = 3;
-
-        printf("debug(1) { }\n");
-    }
-    debug(2)
-    {
-        printf("debug(2): d1 = %d\n", d1);
-    }
 }
 
 /* ================================ */

--- a/compiler/test/runnable/test2.d
+++ b/compiler/test/runnable/test2.d
@@ -2,8 +2,7 @@
 REQUIRED_ARGS: -unittest
 PERMUTE_ARGS:
 ARG_SETS: -debug
-ARG_SETS: -debug=1
-ARG_SETS: -debug=2 -debug=bar
+ARG_SETS: -debug=bar
 */
 
 import object;
@@ -64,21 +63,7 @@ void test2()
 void test3()
 {
     debug printf("debug\n");
-    debug(1) printf("debug(1)\n");
-    debug(2) printf("debug(2)\n");
-    debug(3) printf("debug(3)\n");
     debug(bar) printf("debug(bar)\n");
-    debug(10) assert(0);
-
-    debug(1)
-    {	int d1 = 3;
-
-	printf("debug(1) { }\n");
-    }
-    debug(2)
-    {
-	printf("debug(2): d1 = %d\n", d1);
-    }
 }
 
 /* ================================ */

--- a/compiler/test/runnable/version.d
+++ b/compiler/test/runnable/version.d
@@ -1,9 +1,8 @@
 /*
 PERMUTE_ARGS:
-REQUIRED_ARGS: -version=3 -version=foo
+REQUIRED_ARGS: -version=foo
 RUN_OUTPUT:
 ---
-i = 2
 i = 2
 ---
 */
@@ -15,20 +14,6 @@ extern(C) int printf(const char*, ...);
 void test1()
 {
     int i = 3;
-
-    version(2)
-    {
-        i = 2;
-    }
-    else
-    {
-        i = 0;
-    }
-    printf("i = %d\n", i);
-    assert(i == 2);
-
-    i = 3;
-
     version(foo)
     {
         i = 2;
@@ -47,10 +32,6 @@ version(foo)
 {
     version = bar;
 }
-else
-{
-    version = 4;
-}
 
 void test2()
 {
@@ -59,8 +40,6 @@ void test2()
     }
     else
         assert(0);
-
-    version(4) assert(0);
 }
 
 /*******************************************/

--- a/compiler/test/unit/parser/dvcondition_location.d
+++ b/compiler/test/unit/parser/dvcondition_location.d
@@ -47,34 +47,10 @@ unittest
     assert(visitor.l.charnum == 9);
 }
 
-@("version(integer)")
-unittest
-{
-    auto t = parseModule("test.d", "version(1)");
-
-    scope visitor = new Visitor;
-    t.module_.accept(visitor);
-
-    assert(visitor.l.linnum == 1);
-    assert(visitor.l.charnum == 9);
-}
-
 @("debug(identifier)")
 unittest
 {
     auto t = parseModule("test.d", "debug(a)");
-
-    scope visitor = new Visitor;
-    t.module_.accept(visitor);
-
-    assert(visitor.l.linnum == 1);
-    assert(visitor.l.charnum == 7);
-}
-
-@("debug(integer)")
-unittest
-{
-    auto t = parseModule("test.d", "debug(1)");
 
     scope visitor = new Visitor;
     t.module_.accept(visitor);


### PR DESCRIPTION
As @WalterBright said:

> Yes, the [version/debug] numbers are a failed idea of mine. I'd endorse deprecating them.

https://forum.dlang.org/post/tbair7$2ltc$1@digitalmars.com

Also consistent with vision to deprecate useless features: https://github.com/dlang/vision-document#simplification