### PR TITLE
Optimize AliasAssign tuple building

### DIFF
--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -166,9 +166,9 @@ class TupleDeclaration final : public Declaration
 {
 public:
     Objects *objects;
-    bool isexp;                 // true: expression tuple
-
     TypeTuple *tupletype;       // !=NULL if this is a type tuple
+    bool isexp;                 // true: expression tuple
+    bool building;              // it's growing in AliasAssign semantic
 
     TupleDeclaration *syntaxCopy(Dsymbol *) override;
     const char *kind() const override;

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -6564,10 +6564,12 @@ extern (C++) class TemplateInstance : ScopeDsymbol
      *      tiargs  array of template arguments
      *      flags   1: replace const variables with their initializers
      *              2: don't devolve Parameter to Type
+     *      atd     tuple being optimized. If found, it's not expanded here
+     *              but in AliasAssign semantic.
      * Returns:
      *      false if one or more arguments have errors.
      */
-    extern (D) static bool semanticTiargs(const ref Loc loc, Scope* sc, Objects* tiargs, int flags)
+    extern (D) static bool semanticTiargs(const ref Loc loc, Scope* sc, Objects* tiargs, int flags, TupleDeclaration atd = null)
     {
         // Run semantic on each argument, place results in tiargs[]
         //printf("+TemplateInstance.semanticTiargs()\n");
@@ -6767,6 +6769,11 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 TupleDeclaration d = sa.toAlias().isTupleDeclaration();
                 if (d)
                 {
+                    if (d is atd)
+                    {
+                        (*tiargs)[j] = d;
+                        continue;
+                    }
                     // Expand tuple
                     tiargs.remove(j);
                     tiargs.insert(j, d.objects);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5787,8 +5787,9 @@ class TupleDeclaration final : public Declaration
 {
 public:
     Array<RootObject* >* objects;
-    bool isexp;
     TypeTuple* tupletype;
+    bool isexp;
+    bool building;
     TupleDeclaration* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
     Type* getType() override;

--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -222,6 +222,16 @@ public:
         }
     }
 
+    extern (D) void insert(size_t index, T[] a) pure nothrow
+    {
+        size_t d = a.length;
+        reserve(d);
+        if (length != index)
+            memmove(data.ptr + index + d, data.ptr + index, (length - index) * T.sizeof);
+        memcpy(data.ptr + index, a.ptr, d * T.sizeof);
+        length += d;
+    }
+
     void insert(size_t index, T ptr) pure nothrow
     {
         reserve(1);
@@ -414,6 +424,14 @@ unittest
     arrayA.zero();
     foreach(e; arrayA)
         assert(e == 0);
+
+    arrayA.setDim(0);
+    arrayA.pushSlice([5, 6]);
+    arrayA.insert(1, [1, 2]);
+    assert(arrayA[] == [5, 1, 2, 6]);
+    arrayA.insert(0, [7, 8]);
+    arrayA.insert(arrayA.length, [0, 9]);
+    assert(arrayA[] == [7, 8, 5, 1, 2, 6, 0, 9]);
 }
 
 /**

--- a/compiler/test/compilable/aliasassign.d
+++ b/compiler/test/compilable/aliasassign.d
@@ -3,18 +3,18 @@ template AliasSeq(T...) { alias AliasSeq = T; }
 template Unqual(T)
 {
     static if (is(T U == const U))
-	alias Unqual = U;
+        alias Unqual = U;
     else static if (is(T U == immutable U))
-	alias Unqual = U;
+        alias Unqual = U;
     else
-	alias Unqual = T;
+        alias Unqual = T;
 }
 
 template staticMap(alias F, T...)
 {
     alias A = AliasSeq!();
     static foreach (t; T)
-	A = AliasSeq!(A, F!t); // what's tested
+        A = AliasSeq!(A, F!t); // what's tested
     alias staticMap = A;
 }
 
@@ -28,7 +28,7 @@ template reverse(T...)
 {
     alias A = AliasSeq!();
     static foreach (t; T)
-	A = AliasSeq!(t, A); // what's tested
+        A = AliasSeq!(t, A); // what's tested
     alias reverse = A;
 }
 
@@ -38,3 +38,98 @@ alias TK2 = reverse!(int, const uint, X2);
 static assert(TK2[0] == 3);
 static assert(is(TK2[1] == const(uint)));
 static assert(is(TK2[2] == int));
+
+/**************************************************/
+
+template Tp(Args...)
+{
+    alias Tp = AliasSeq!(int, 1, "asd", Args);
+    static foreach (arg; Args)
+    {
+        Tp = AliasSeq!(4, Tp, "zxc", arg, Tp, 5, 4, int, Tp[0..2]);
+    }
+}
+
+void fun(){}
+
+alias a1 = Tp!(char[], fun, x => x);
+static assert(
+        __traits(isSame, a1, AliasSeq!(4, 4, 4, int, 1, "asd", char[], fun,
+                x => x, "zxc", char[], int, 1, "asd", char[], fun, x => x,
+                5, 4, int, int, 1, "zxc", fun, 4, int, 1, "asd", char[],
+                fun, x => x, "zxc", char[], int, 1, "asd", char[], fun,
+                x => x, 5, 4, int, int, 1, 5, 4, int, 4, int, "zxc", x => x,
+                4, 4, int, 1, "asd", char[], fun, x => x, "zxc", char[],
+                int, 1, "asd", char[], fun, x => x, 5, 4, int, int, 1,
+                "zxc", fun, 4, int, 1, "asd", char[], fun, x => x, "zxc",
+                char[], int, 1, "asd", char[], fun, x => x, 5, 4, int, int,
+                1, 5, 4, int, 4, int, 5, 4, int, 4, 4)));
+
+template Tp2(Args...)
+{
+    alias Tp2 = () => 1;
+    static foreach (i; 0..Args.length)
+        Tp2 = AliasSeq!(Tp2, Args[i]);
+}
+
+const x = 8;
+static assert(
+        __traits(isSame, Tp2!(2, float, x), AliasSeq!(() => 1, 2, float, x)));
+
+
+enum F(int i) = i * i;
+
+template staticMap2(alias fun, args...)
+{
+    alias staticMap2 = AliasSeq!();
+    static foreach (i; 0 .. args.length)
+        staticMap2 = AliasSeq!(fun!(args[i]), staticMap2, fun!(args[i]));
+}
+
+enum a2 = staticMap2!(F, 0, 1, 2, 3, 4);
+
+struct Cmp(T...){}
+// isSame sucks
+static assert(is(Cmp!a2 == Cmp!(16, 9, 4, 1, 0, 0, 1, 4, 9, 16)));
+
+template Tp3()
+{
+    alias aa1 = int;
+    static foreach (t; AliasSeq!(float, char[]))
+        aa1 = AliasSeq!(aa1, t);
+    static assert(is(aa1 == AliasSeq!(int, float, char[])));
+
+    alias aa2 = AliasSeq!int;
+    static foreach (t; AliasSeq!(float, char[]))
+        aa2 = AliasSeq!(aa2, t);
+    static assert(is(aa2 == AliasSeq!(int, float, char[])));
+
+    alias aa3 = AliasSeq!int;
+    aa3 = AliasSeq!(float, char);
+    static assert(is(aa3 == AliasSeq!(float, char)));
+}
+alias a3 = Tp3!();
+
+template Tp4() // Uses slow path because overload
+{
+    alias AliasSeq(T...) = T;
+    alias AliasSeq(alias f, T...) = T;
+
+    alias aa4 = int;
+    aa4 = AliasSeq!(aa4, float);
+    static assert(is(aa4 == AliasSeq!(int, float)));
+
+}
+alias a4 = Tp4!();
+
+template Tp5() // same tp overloaded, still uses fast path
+{
+    alias AliasSeq2(T...) = T;
+    alias AliasSeq = AliasSeq2;
+    alias AliasSeq = AliasSeq2;
+
+    alias aa5 = int;
+    aa5 = AliasSeq!(aa5, float);
+    static assert(is(aa5 == AliasSeq!(int, float)));
+}
+alias a5 = Tp5!();

--- a/compiler/test/fail_compilation/aliasassign2.d
+++ b/compiler/test/fail_compilation/aliasassign2.d
@@ -1,0 +1,33 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/aliasassign2.d(16): Error: `alias aa1 = aa1;` cannot alias itself, use a qualified name to create an overload set
+fail_compilation/aliasassign2.d(19): Error: template instance `aliasassign2.Tp1!()` error instantiating
+fail_compilation/aliasassign2.d(24): Error: undefined identifier `unknown`
+fail_compilation/aliasassign2.d(26): Error: template instance `aliasassign2.Tp2!()` error instantiating
+fail_compilation/aliasassign2.d(31): Error: template instance `AliasSeqX!(aa3, 1)` template `AliasSeqX` is not defined, did you mean AliasSeq(T...)?
+fail_compilation/aliasassign2.d(33): Error: template instance `aliasassign2.Tp3!()` error instantiating
+---
+*/
+
+alias AliasSeq(T...) = T;
+
+template Tp1()
+{
+    alias aa1 = aa1;
+    aa1 = AliasSeq!(aa1, float);
+}
+alias a1 = Tp1!();
+
+template Tp2()
+{
+    alias aa2 = AliasSeq!();
+    aa2 = AliasSeq!(aa2, unknown);
+}
+alias a2 = Tp2!();
+
+template Tp3()
+{
+    alias aa3 = AliasSeq!();
+    aa3 = AliasSeqX!(aa3, 1);
+}
+alias a3 = Tp3!();


### PR DESCRIPTION
Try to remove some quadratic behavior by expanding `AliasSeq` elements only in the target `AliasDeclaration`.

A synthetic test:
```d
alias AliasSeq(T...) = T;
template Count(size_t l)
{
    alias Count = AliasSeq!();
    static foreach (i; 0 .. l)
        Count = AliasSeq!(Count, i);
}
alias c = Count!10000;
static assert(c.length == 10000);
static assert(c[0..5]   == AliasSeq!(0,1,2,3,4));
static assert(c[$-5..$] == AliasSeq!(9995,9996,9997,9998,9999));
```
Compilation time, memory usage. (just using `/usr/bin/time -v dmd -o- test.d`)
before: 6.66 sec.  815MB
after:    0.07 sec.  45MB