### PR TITLE
Move issue 23112 check to front-end semantic

### DIFF
--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -777,19 +777,8 @@ void setClosureVarOffset(FuncDeclaration fd)
 void buildClosure(FuncDeclaration fd, IRState *irs)
 {
     //printf("buildClosure(fd = %s)\n", fd.toChars());
-    const oldValue = fd.requiresClosure;
     if (fd.needsClosure())
     {
-        /* nrvo is incompatible with closure
-         */
-        if (oldValue != fd.requiresClosure && (fd.nrvo_var || irs.params.betterC))
-        {
-            /* https://issues.dlang.org/show_bug.cgi?id=23112
-             * This can shift due to templates being expanded that access alias symbols.
-             */
-            fd.checkClosure();   // give decent diagnostic
-        }
-
         setClosureVarOffset(fd);
 
         // Generate closure on the heap

--- a/compiler/test/fail_compilation/test23112.d
+++ b/compiler/test/fail_compilation/test23112.d
@@ -3,6 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/test23112.d(106): Error: function `test23112.bar` is `@nogc` yet allocates closure for `bar()` with the GC
 fail_compilation/test23112.d(108):        `test23112.bar.f` closes over variable `a` at fail_compilation/test23112.d(106)
+fail_compilation/test23112.d(117): Error: template instance `test23112.bar.Forward!(f).Forward.call!()` error instantiating
 ---
 */
 


### PR DESCRIPTION
This code should fail even when just checking syntax (`-o-`), not at the codegen stage.