### PR TITLE
ImportC: adds defines for non-standard extensions seen in macOS headers.

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -26,6 +26,14 @@
  */
 #define __signed__ signed
 #define __asm__ asm
+#define __asm asm
+
+/********************
+ * Clang nullability extension used by macOS headers.
+ */
+#define _Nonnull
+#define _Nullable
+#define _Null_unspecified
 
 /********************
  * This is a Microsoft C function calling convention not supported by ImportC,


### PR DESCRIPTION
This includes attributes for nullability:
  https://clang.llvm.org/docs/AttributeReference.html#nullability-attributes
  - _Nonnull
  - _Nullable
  - _Null_unspecified

It is safe to define these to nothing.

Additionally, macOS headers use the non-standard __asm an alias for asm.