### PR TITLE
[object] Fix wrong anchor link for array dup

### DIFF
--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -6,7 +6,7 @@
  * $(TR $(TD Arrays) $(TD
  *     $(MYREF assumeSafeAppend)
  *     $(MYREF capacity)
- *     $(A #.dup.2, dup)
+ *     $(A #.dup.2, $(TT dup))
  *     $(MYREF idup)
  *     $(MYREF reserve)
  * ))

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -6,7 +6,7 @@
  * $(TR $(TD Arrays) $(TD
  *     $(MYREF assumeSafeAppend)
  *     $(MYREF capacity)
- *     $(A dup, .dup.2)
+ *     $(A #.dup.2, dup)
  *     $(MYREF idup)
  *     $(MYREF reserve)
  * ))


### PR DESCRIPTION
See category links at:
https://dlang.org/phobos-prerelease/object.html

After #14341.