### PR TITLE
Refactor ASTBase Module isRoot() method

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -1364,7 +1364,7 @@ struct ASTBase
             this(Loc.initial, filename.toDString, ident, doDocComment, doHdrGen);
         }
 
-        bool isRoot() { return false; }
+        bool isRoot() { return true; }
 
         override void accept(Visitor v)
         {


### PR DESCRIPTION
When using dmd as a library, specifically ASTBase for parsing, you are able to parse one module at a time, module that is specified by the user. Hence, a module by default shall be **root module**.