### PR TITLE
Add method called from codegen to C++ interface

### DIFF
--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -684,6 +684,7 @@ public:
     const char *kind() const override;
     bool isUnique();
     bool needsClosure();
+    bool checkClosure();
     bool hasNestedFrameRefs();
     ParameterList getParameterList();
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2950,6 +2950,7 @@ public:
     const char* kind() const override;
     bool isUnique() const;
     bool needsClosure();
+    bool checkClosure();
     bool hasNestedFrameRefs();
     static bool needsFensure(FuncDeclaration* fd);
     void buildEnsureRequire();

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -2179,7 +2179,7 @@ extern (C++) class FuncDeclaration : Declaration
      * Returns:
      *      true if any errors occur.
      */
-    extern (D) final bool checkClosure()
+    extern (C++) final bool checkClosure()
     {
         //printf("checkClosure() %s\n", toChars());
         if (!needsClosure())


### PR DESCRIPTION
#14183 introduced an API regression.  This should really be done from the front-end semantic (possibly a post-semantic3 pass), but until then, expose it so that both gdc and ldc can apply the same workaround.