### PR TITLE
Assert that dprogress == 0 when deferred length unchanged

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1361,6 +1361,9 @@ extern (C++) final class Module : Package
             //printf("\tdeferred.dim = %d, len = %d, dprogress = %d\n", deferred.dim, len, dprogress);
             if (todoalloc)
                 free(todoalloc);
+            if (deferred.dim == len)
+                if (dprogress != 0)
+                    assert(0);
         }
         while (deferred.dim < len || dprogress); // while making progress
         nested--;


### PR DESCRIPTION
This checks whether dprogress is possibly a redundant heuristic for deferred semantic1 processing (and whether we can get away with just `while (deferred.dim != len)`.