### PR TITLE
Remove dprogress state variable for semantic1

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -325,7 +325,6 @@ extern (C++) final class Module : Package
     extern (C++) __gshared Dsymbols deferred;    // deferred Dsymbol's needing semantic() run on them
     extern (C++) __gshared Dsymbols deferred2;   // deferred Dsymbol's needing semantic2() run on them
     extern (C++) __gshared Dsymbols deferred3;   // deferred Dsymbol's needing semantic3() run on them
-    extern (C++) __gshared uint dprogress;       // progress resolving the deferred list
 
     static void _init()
     {
@@ -1323,19 +1322,15 @@ extern (C++) final class Module : Package
      */
     static void runDeferredSemantic()
     {
-        if (dprogress == 0)
-            return;
-
         __gshared int nested;
         if (nested)
             return;
-        //if (deferred.dim) printf("+Module::runDeferredSemantic(), len = %d\n", deferred.dim);
+        //if (deferred.dim) printf("+Module::runDeferredSemantic(), len = %ld\n", deferred.dim);
         nested++;
 
         size_t len;
         do
         {
-            dprogress = 0;
             len = deferred.dim;
             if (!len)
                 break;
@@ -1361,13 +1356,13 @@ extern (C++) final class Module : Package
                 s.dsymbolSemantic(null);
                 //printf("deferred: %s, parent = %s\n", s.toChars(), s.parent.toChars());
             }
-            //printf("\tdeferred.dim = %d, len = %d, dprogress = %d\n", deferred.dim, len, dprogress);
+            //printf("\tdeferred.dim = %ld, len = %ld\n", deferred.dim, len);
             if (todoalloc)
                 free(todoalloc);
         }
-        while (deferred.dim < len || dprogress); // while making progress
+        while (deferred.dim != len); // while making progress
         nested--;
-        //printf("-Module::runDeferredSemantic(), len = %d\n", deferred.dim);
+        //printf("-Module::runDeferredSemantic(), len = %ld\n", deferred.dim);
     }
 
     static void runDeferredSemantic2()

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1300,19 +1300,22 @@ extern (C++) final class Module : Package
     extern (D) static void addDeferredSemantic(Dsymbol s)
     {
         //printf("Module::addDeferredSemantic('%s')\n", s.toChars());
-        deferred.push(s);
+        if (!deferred.contains(s))
+            deferred.push(s);
     }
 
     extern (D) static void addDeferredSemantic2(Dsymbol s)
     {
         //printf("Module::addDeferredSemantic2('%s')\n", s.toChars());
-        deferred2.push(s);
+        if (!deferred2.contains(s))
+            deferred2.push(s);
     }
 
     extern (D) static void addDeferredSemantic3(Dsymbol s)
     {
         //printf("Module::addDeferredSemantic3('%s')\n", s.toChars());
-        deferred3.push(s);
+        if (!deferred.contains(s))
+            deferred3.push(s);
     }
 
     /******************************************

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2034,8 +2034,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             ed.semanticRun = PASS.semanticdone;
             return;
         }
-        uint dprogress_save = Module.dprogress;
-
         Scope* scx = null;
         if (ed._scope)
         {
@@ -2093,7 +2091,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 {
                     // memtype is forward referenced, so try again later
                     deferDsymbolSemantic(ed, scx);
-                    Module.dprogress = dprogress_save;
                     //printf("\tdeferring %s\n", toChars());
                     ed.semanticRun = PASS.initial;
                     return;
@@ -2133,8 +2130,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (!(sc.flags & SCOPE.Cfile))  // C enum remains incomplete until members are done
             ed.semanticRun = PASS.semanticdone;
-
-        Module.dprogress++;
 
         // @@@DEPRECATED_2.110@@@ https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
         // Deprecated in 2.100
@@ -3945,7 +3940,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (funcdecl.canInferAttributes(sc))
             funcdecl.initInferAttributes();
 
-        Module.dprogress++;
         funcdecl.semanticRun = PASS.semanticdone;
 
         /* Save scope for possible later use (if we need the
@@ -4669,7 +4663,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         sd.inv = buildInv(sd, sc2);
 
-        Module.dprogress++;
         sd.semanticRun = PASS.semanticdone;
         //printf("-StructDeclaration::semantic(this=%p, '%s')\n", sd, sd.toChars());
 
@@ -5329,7 +5322,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         cldec.inv = buildInv(cldec, sc2);
 
-        Module.dprogress++;
         cldec.semanticRun = PASS.semanticdone;
         //printf("-ClassDeclaration.dsymbolSemantic(%s), type = %p\n", toChars(), type);
 
@@ -5676,7 +5668,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         idec.members.foreachDsymbol( s => s.dsymbolSemantic(sc2) );
 
-        Module.dprogress++;
         idec.semanticRun = PASS.semanticdone;
         //printf("-InterfaceDeclaration.dsymbolSemantic(%s), type = %p\n", toChars(), type);
 

--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -430,7 +430,6 @@ void fullSemantic(Module m)
     m.importAll(null);
 
     m.dsymbolSemantic(null);
-    Module.dprogress = 1;
     Module.runDeferredSemantic();
 
     m.semantic2(null);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6176,7 +6176,6 @@ public:
     static Array<Dsymbol* > deferred;
     static Array<Dsymbol* > deferred2;
     static Array<Dsymbol* > deferred3;
-    static uint32_t dprogress;
     static void _init();
     static void deinitialize();
     static AggregateDeclaration* moduleinfo;

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -441,7 +441,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     }
     //if (global.errors)
     //    fatal();
-    Module.dprogress = 1;
     Module.runDeferredSemantic();
     if (Module.deferred.dim)
     {

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -58,7 +58,6 @@ public:
     static Dsymbols deferred;   // deferred Dsymbol's needing semantic() run on them
     static Dsymbols deferred2;  // deferred Dsymbol's needing semantic2() run on them
     static Dsymbols deferred3;  // deferred Dsymbol's needing semantic3() run on them
-    static unsigned dprogress;  // progress resolving the deferred list
 
     static void _init();
 

--- a/compiler/test/dub_package/retrieveScope.d
+++ b/compiler/test/dub_package/retrieveScope.d
@@ -93,8 +93,6 @@ int main()
 
     // semantic
     m.dsymbolSemantic(null);
-
-    Module.dprogress = 1;
     Module.runDeferredSemantic();
 
     m.semantic2(null);


### PR DESCRIPTION
In the code that we are testing via CI, the checking of `dprogress` [appears](https://github.com/dlang/dmd/pull/14345) to be redundant.  So we shouldn't be hitting any pathological slowdown in the semantic1 phase by removing it, and checking progress using another condition.