### PR TITLE
[NFC] Group all `-preview=/-revert=` options in `global.params`

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -361,13 +361,6 @@ enum class DiagnosticReporting : uint8_t
     off = 2u,
 };
 
-enum class FeatureState : int8_t
-{
-    default_ = -1,
-    disabled = 0,
-    enabled = 1,
-};
-
 enum class CppStdRevision : uint32_t
 {
     cpp98 = 199711u,
@@ -375,6 +368,13 @@ enum class CppStdRevision : uint32_t
     cpp14 = 201402u,
     cpp17 = 201703u,
     cpp20 = 202002u,
+};
+
+enum class FeatureState : int8_t
+{
+    default_ = -1,
+    disabled = 0,
+    enabled = 1,
 };
 
 enum class CHECKENABLE : uint8_t
@@ -490,10 +490,6 @@ struct Param final
     DiagnosticReporting useDeprecated;
     bool useUnitTests;
     bool useInline;
-    FeatureState useDIP25;
-    FeatureState useDIP1000;
-    bool fixImmutableConv;
-    bool useDIP1021;
     bool release;
     bool preservePaths;
     DiagnosticReporting warnings;
@@ -505,20 +501,10 @@ struct Param final
     bool useModuleInfo;
     bool useTypeInfo;
     bool useExceptions;
-    bool noSharedAccess;
-    bool previewIn;
-    bool shortenedMethods;
     bool betterC;
     bool addMain;
     bool allInst;
-    bool fix16997;
-    bool fixAliasThis;
-    bool inclusiveInContracts;
-    bool ehnogc;
-    FeatureState dtorFields;
-    bool fieldwise;
     bool bitfields;
-    FeatureState rvalueRefParam;
     CppStdRevision cplusplus;
     bool showGaggedErrors;
     bool printErrorContext;
@@ -533,6 +519,20 @@ struct Param final
     bool externStdUsage;
     bool hcUsage;
     bool logo;
+    FeatureState useDIP25;
+    FeatureState useDIP1000;
+    bool ehnogc;
+    bool useDIP1021;
+    bool fieldwise;
+    bool fixAliasThis;
+    FeatureState rvalueRefParam;
+    bool noSharedAccess;
+    bool previewIn;
+    bool inclusiveInContracts;
+    bool shortenedMethods;
+    bool fixImmutableConv;
+    bool fix16997;
+    FeatureState dtorFields;
     CHECKENABLE useInvariants;
     CHECKENABLE useIn;
     CHECKENABLE useOut;
@@ -592,8 +592,6 @@ struct Param final
         useDeprecated((DiagnosticReporting)1u),
         useUnitTests(),
         useInline(false),
-        fixImmutableConv(),
-        useDIP1021(),
         release(),
         preservePaths(),
         warnings((DiagnosticReporting)2u),
@@ -605,17 +603,9 @@ struct Param final
         useModuleInfo(true),
         useTypeInfo(true),
         useExceptions(true),
-        noSharedAccess(),
-        previewIn(),
-        shortenedMethods(),
         betterC(),
         addMain(),
         allInst(),
-        fix16997(true),
-        fixAliasThis(),
-        inclusiveInContracts(),
-        ehnogc(),
-        fieldwise(),
         bitfields(),
         cplusplus((CppStdRevision)201103u),
         showGaggedErrors(),
@@ -631,6 +621,16 @@ struct Param final
         externStdUsage(),
         hcUsage(),
         logo(),
+        ehnogc(),
+        useDIP1021(),
+        fieldwise(),
+        fixAliasThis(),
+        noSharedAccess(),
+        previewIn(),
+        inclusiveInContracts(),
+        shortenedMethods(),
+        fixImmutableConv(),
+        fix16997(true),
         useInvariants((CHECKENABLE)0u),
         useIn((CHECKENABLE)0u),
         useOut((CHECKENABLE)0u),
@@ -673,7 +673,7 @@ struct Param final
         mapfile()
     {
     }
-    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool verbose = false, bool vcg_ast = false, bool showColumns = false, bool vtls = false, bool vtemplates = false, bool vtemplatesListInstances = false, bool vgc = false, bool vfield = false, bool vcomplex = true, bool vin = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, FeatureState useDIP25 = (FeatureState)-1, FeatureState useDIP1000 = (FeatureState)-1, bool fixImmutableConv = false, bool useDIP1021 = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, bool color = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = false, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool noSharedAccess = false, bool previewIn = false, bool shortenedMethods = false, bool betterC = false, bool addMain = false, bool allInst = false, bool fix16997 = true, bool fixAliasThis = false, bool inclusiveInContracts = false, bool ehnogc = false, FeatureState dtorFields = (FeatureState)-1, bool fieldwise = false, bool bitfields = false, FeatureState rvalueRefParam = (FeatureState)-1, CppStdRevision cplusplus = (CppStdRevision)201103u, bool showGaggedErrors = false, bool printErrorContext = false, bool manual = false, bool usage = false, bool mcpuUsage = false, bool transitionUsage = false, bool checkUsage = false, bool checkActionUsage = false, bool revertUsage = false, bool previewUsage = false, bool externStdUsage = false, bool hcUsage = false, bool logo = false, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, uint32_t errorLimit = 20u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* >* imppath = nullptr, Array<const char* >* fileImppath = nullptr, _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, Array<const char* >* debugids = nullptr, uint32_t versionlevel = 0u, Array<const char* >* versionids = nullptr, MessageStyle messageStyle = (MessageStyle)0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
+    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool verbose = false, bool vcg_ast = false, bool showColumns = false, bool vtls = false, bool vtemplates = false, bool vtemplatesListInstances = false, bool vgc = false, bool vfield = false, bool vcomplex = true, bool vin = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, bool color = false, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = false, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, bool showGaggedErrors = false, bool printErrorContext = false, bool manual = false, bool usage = false, bool mcpuUsage = false, bool transitionUsage = false, bool checkUsage = false, bool checkActionUsage = false, bool revertUsage = false, bool previewUsage = false, bool externStdUsage = false, bool hcUsage = false, bool logo = false, FeatureState useDIP25 = (FeatureState)-1, FeatureState useDIP1000 = (FeatureState)-1, bool ehnogc = false, bool useDIP1021 = false, bool fieldwise = false, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)-1, bool noSharedAccess = false, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = false, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)-1, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, uint32_t errorLimit = 20u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* >* imppath = nullptr, Array<const char* >* fileImppath = nullptr, _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, Array<const char* >* debugids = nullptr, uint32_t versionlevel = 0u, Array<const char* >* versionids = nullptr, MessageStyle messageStyle = (MessageStyle)0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
         obj(obj),
         multiobj(multiobj),
         trace(trace),
@@ -691,10 +691,6 @@ struct Param final
         useDeprecated(useDeprecated),
         useUnitTests(useUnitTests),
         useInline(useInline),
-        useDIP25(useDIP25),
-        useDIP1000(useDIP1000),
-        fixImmutableConv(fixImmutableConv),
-        useDIP1021(useDIP1021),
         release(release),
         preservePaths(preservePaths),
         warnings(warnings),
@@ -706,20 +702,10 @@ struct Param final
         useModuleInfo(useModuleInfo),
         useTypeInfo(useTypeInfo),
         useExceptions(useExceptions),
-        noSharedAccess(noSharedAccess),
-        previewIn(previewIn),
-        shortenedMethods(shortenedMethods),
         betterC(betterC),
         addMain(addMain),
         allInst(allInst),
-        fix16997(fix16997),
-        fixAliasThis(fixAliasThis),
-        inclusiveInContracts(inclusiveInContracts),
-        ehnogc(ehnogc),
-        dtorFields(dtorFields),
-        fieldwise(fieldwise),
         bitfields(bitfields),
-        rvalueRefParam(rvalueRefParam),
         cplusplus(cplusplus),
         showGaggedErrors(showGaggedErrors),
         printErrorContext(printErrorContext),
@@ -734,6 +720,20 @@ struct Param final
         externStdUsage(externStdUsage),
         hcUsage(hcUsage),
         logo(logo),
+        useDIP25(useDIP25),
+        useDIP1000(useDIP1000),
+        ehnogc(ehnogc),
+        useDIP1021(useDIP1021),
+        fieldwise(fieldwise),
+        fixAliasThis(fixAliasThis),
+        rvalueRefParam(rvalueRefParam),
+        noSharedAccess(noSharedAccess),
+        previewIn(previewIn),
+        inclusiveInContracts(inclusiveInContracts),
+        shortenedMethods(shortenedMethods),
+        fixImmutableConv(fixImmutableConv),
+        fix16997(fix16997),
+        dtorFields(dtorFields),
         useInvariants(useInvariants),
         useIn(useIn),
         useOut(useOut),

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -116,10 +116,6 @@ extern (C++) struct Param
     DiagnosticReporting useDeprecated = DiagnosticReporting.inform;  // how use of deprecated features are handled
     bool useUnitTests;          // generate unittest code
     bool useInline = false;     // inline expand functions
-    FeatureState useDIP25;  // implement https://wiki.dlang.org/DIP25
-    FeatureState useDIP1000; // implement https://dlang.org/spec/memory-safe-d.html#scope-return-params
-    bool fixImmutableConv;  // error on unsound immutable conversion - https://github.com/dlang/dmd/pull/14070
-    bool useDIP1021;        // implement https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1021.md
     bool release;           // build release version
     bool preservePaths;     // true means don't strip path from source file
     DiagnosticReporting warnings = DiagnosticReporting.off;  // how compiler warnings are handled
@@ -131,31 +127,10 @@ extern (C++) struct Param
     bool useModuleInfo = true;   // generate runtime module information
     bool useTypeInfo = true;     // generate runtime type information
     bool useExceptions = true;   // support exception handling
-    bool noSharedAccess;         // read/write access to shared memory objects
-    bool previewIn;         // `in` means `[ref] scope const`, accepts rvalues
-    bool shortenedMethods; // allow => in normal function declarations
     bool betterC;           // be a "better C" compiler; no dependency on D runtime
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations
-    bool fix16997 = true;   // fix integral promotions for unary + - ~ operators
-                            // https://issues.dlang.org/show_bug.cgi?id=16997
-    bool fixAliasThis;      // if the current scope has an alias this, check it before searching upper scopes
-    bool inclusiveInContracts;   // 'in' contracts of overridden methods must be a superset of parent contract
-    /** The --transition=safe switch should only be used to show code with
-     * silent semantics changes related to @safe improvements.  It should not be
-     * used to hide a feature that will have to go through deprecate-then-error
-     * before becoming default.
-     */
-    bool ehnogc;            // use @nogc exception handling
-    FeatureState dtorFields; // destruct fields of partially constructed objects
-                            // https://issues.dlang.org/show_bug.cgi?id=14246
-    bool fieldwise;         // do struct equality testing field-wise rather than by memcmp()
     bool bitfields;         // support C style bit fields
-    FeatureState rvalueRefParam; // allow rvalues to be arguments to ref parameters
-                                 // https://dconf.org/2019/talks/alexandrescu.html
-                                 // https://gist.github.com/andralex/e5405a5d773f07f73196c05f8339435a
-                                 // https://digitalmars.com/d/archives/digitalmars/D/Binding_rvalues_to_ref_parameters_redux_325087.html
-                                 // Implementation: https://github.com/dlang/dmd/pull/9817
 
     CppStdRevision cplusplus = CppStdRevision.cpp11;    // version of C++ standard to support
 
@@ -172,6 +147,28 @@ extern (C++) struct Param
     bool externStdUsage;    // print help on -extern-std switch
     bool hcUsage;           // print help on -HC switch
     bool logo;              // print compiler logo
+
+    // Options for `-preview=/-revert=`
+    FeatureState useDIP25;       // implement https://wiki.dlang.org/DIP25
+    FeatureState useDIP1000;     // implement https://dlang.org/spec/memory-safe-d.html#scope-return-params
+    bool ehnogc;                 // use @nogc exception handling
+    bool useDIP1021;             // implement https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1021.md
+    bool fieldwise;              // do struct equality testing field-wise rather than by memcmp()
+    bool fixAliasThis;           // if the current scope has an alias this, check it before searching upper scopes
+    FeatureState rvalueRefParam; // allow rvalues to be arguments to ref parameters
+                                 // https://dconf.org/2019/talks/alexandrescu.html
+                                 // https://gist.github.com/andralex/e5405a5d773f07f73196c05f8339435a
+                                 // https://digitalmars.com/d/archives/digitalmars/D/Binding_rvalues_to_ref_parameters_redux_325087.html
+                                 // Implementation: https://github.com/dlang/dmd/pull/9817
+    bool noSharedAccess;         // read/write access to shared memory objects
+    bool previewIn;              // `in` means `[ref] scope const`, accepts rvalues
+    bool inclusiveInContracts;   // 'in' contracts of overridden methods must be a superset of parent contract
+    bool shortenedMethods;       // allow => in normal function declarations
+    bool fixImmutableConv;       // error on unsound immutable conversion - https://github.com/dlang/dmd/pull/14070
+    bool fix16997 = true;        // fix integral promotions for unary + - ~ operators
+                                 // https://issues.dlang.org/show_bug.cgi?id=16997
+    FeatureState dtorFields;     // destruct fields of partially constructed objects
+                                 // https://issues.dlang.org/show_bug.cgi?id=14246
 
     CHECKENABLE useInvariants  = CHECKENABLE._default;  // generate class invariant checks
     CHECKENABLE useIn          = CHECKENABLE._default;  // generate precondition checks

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -116,10 +116,6 @@ struct Param
     Diagnostic useDeprecated;
     bool useUnitTests;  // generate unittest code
     bool useInline;     // inline expand functions
-    FeatureState useDIP25;      // implement https://wiki.dlang.org/DIP25
-    FeatureState useDIP1000; // implement https://dlang.org/spec/memory-safe-d.html#scope-return-params
-    bool fixImmutableConv;
-    bool useDIP1021;    // implement https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1021.md
     bool release;       // build release version
     bool preservePaths; // true means don't strip path from source file
     Diagnostic warnings;
@@ -131,22 +127,10 @@ struct Param
     bool useModuleInfo; // generate runtime module information
     bool useTypeInfo;   // generate runtime type information
     bool useExceptions; // support exception handling
-    bool noSharedAccess; // read/write access to shared memory objects
-    bool previewIn;     // `in` means `scope const`, perhaps `ref`, accepts rvalues
-    bool shortenedMethods; // allow => in normal function declarations
     bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations
-    bool fix16997;      // fix integral promotions for unary + - ~ operators
-                        // https://issues.dlang.org/show_bug.cgi?id=16997
-    bool fixAliasThis;  // if the current scope has an alias this, check it before searching upper scopes
-    bool inclusiveInContracts;   // 'in' contracts of overridden methods must be a superset of parent contract
-    bool ehnogc;        // use @nogc exception handling
-    FeatureState dtorFields;  // destruct fields of partially constructed objects
-                              // https://issues.dlang.org/show_bug.cgi?id=14246
-    bool fieldwise;         // do struct equality testing field-wise rather than by memcmp()
     bool bitfields;         // support C style bit fields
-    FeatureState rvalueRefParam;    // allow rvalues to be arguments to ref parameters
     CppStdRevision cplusplus;  // version of C++ name mangling to support
     bool showGaggedErrors;  // print gagged errors anyway
     bool printErrorContext;  // print errors with the error context (the error line in the source file)
@@ -162,6 +146,27 @@ struct Param
     bool hcUsage;           // print help on -HC switch
     bool logo;              // print logo;
 
+    // Options for `-preview=/-revert=`
+    FeatureState useDIP25;       // implement https://wiki.dlang.org/DIP25
+    FeatureState useDIP1000;     // implement https://dlang.org/spec/memory-safe-d.html#scope-return-params
+    bool ehnogc;                 // use @nogc exception handling
+    bool useDIP1021;             // implement https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1021.md
+    bool fieldwise;              // do struct equality testing field-wise rather than by memcmp()
+    bool fixAliasThis;           // if the current scope has an alias this, check it before searching upper scopes
+    FeatureState rvalueRefParam; // allow rvalues to be arguments to ref parameters
+                                 // https://dconf.org/2019/talks/alexandrescu.html
+                                 // https://gist.github.com/andralex/e5405a5d773f07f73196c05f8339435a
+                                 // https://digitalmars.com/d/archives/digitalmars/D/Binding_rvalues_to_ref_parameters_redux_325087.html
+                                 // Implementation: https://github.com/dlang/dmd/pull/9817
+    bool noSharedAccess;         // read/write access to shared memory objects
+    bool previewIn;              // `in` means `[ref] scope const`, accepts rvalues
+    bool inclusiveInContracts;   // 'in' contracts of overridden methods must be a superset of parent contract
+    bool shortenedMethods;       // allow => in normal function declarations
+    bool fixImmutableConv;       // error on unsound immutable conversion - https://github.com/dlang/dmd/pull/14070
+    bool fix16997;               // fix integral promotions for unary + - ~ operators
+                                 // https://issues.dlang.org/show_bug.cgi?id=16997
+    FeatureState dtorFields;     // destruct fields of partially constructed objects
+                                     // https://issues.dlang.org/show_bug.cgi?id=14246
     CHECKENABLE useInvariants;     // generate class invariant checks
     CHECKENABLE useIn;             // generate precondition checks
     CHECKENABLE useOut;            // generate postcondition checks


### PR DESCRIPTION
If we want to have preview switches be per module/package/whatever we will need to do something with them, so let's start by grouping them all together.