### PR TITLE
ImportC: disable blocks extension when preprocessing on OSX

### DIFF
--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1277,6 +1277,7 @@ public int runPreprocessor(const(char)[] cpp, const(char)[] filename, const(char
 
         if (target.os == Target.OS.OSX)
         {
+            argv.push("-fno-blocks");       // disable clang blocks extension
             argv.push("-E");                // run preprocessor only for clang
             argv.push("-include");          // OSX cpp has switch order dependencies
             argv.push(importc_h);


### PR DESCRIPTION
Some C standard libary headers on macOS have versions of C standard
library functions like qsort that take a clang block instead of a
function pointer. ImportC does not implement (or parse) the block
extension, so tell clang to disable them when preprocessing C source.