### PR TITLE
Fix Issue 23284 - better floating point error messages.

### DIFF
--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -2582,9 +2582,7 @@ class Lexer
         {
             /* C11 6.4.4.2 doesn't actually care if it is not representable if it is not hex
              */
-            const char* suffix = [TOK.float32Literal: "f".ptr,
-                                TOK.float64Literal: "".ptr,
-                                TOK.float80Literal: "L".ptr][result];
+            const char* suffix = result == TOK.float32Literal ? "f" : result == TOK.float80Literal ? "L" : "";
             const char* type = [TOK.float32Literal: "`float`".ptr,
                                 TOK.float64Literal: "`double`".ptr,
                                 TOK.float80Literal: "`real` for the current target".ptr][result];

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -2582,8 +2582,15 @@ class Lexer
         {
             /* C11 6.4.4.2 doesn't actually care if it is not representable if it is not hex
              */
-            const char* suffix = (result == TOK.float32Literal || result == TOK.imaginary32Literal) ? "f" : "";
-            error(scanloc, "number `%s%s` is not representable", sbufptr, suffix);
+            const char* suffix = [TOK.float32Literal: "f".ptr,
+                                TOK.float64Literal: "".ptr,
+                                TOK.float80Literal: "L".ptr][result];
+            const char* type = [TOK.float32Literal: "`float`".ptr,
+                                TOK.float64Literal: "`double`".ptr,
+                                TOK.float80Literal: "`real` for the current target".ptr][result];
+            error(scanloc, "number `%s%s` is not representable as a %s", sbufptr, suffix, type);
+            const char* extra = result == TOK.float64Literal ? "`real` literals can be written using the `L` suffix. " : "";
+            errorSupplemental(scanloc, "%shttps://dlang.org/spec/lex.html#floatliteral", extra);
         }
         debug
         {

--- a/compiler/test/fail_compilation/lexer5.d
+++ b/compiler/test/fail_compilation/lexer5.d
@@ -1,9 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/lexer5.d(9): Error: number `1e-100f` is not representable as a `float`
-fail_compilation/lexer5.d(9):        https://dlang.org/spec/lex.html#floatliteral
+fail_compilation/lexer5.d(11): Error: number `1e-100f` is not representable as a `float`
+fail_compilation/lexer5.d(11):        https://dlang.org/spec/lex.html#floatliteral
+fail_compilation/lexer5.d(12): Error: number `1e-10024` is not representable as a `double`
+fail_compilation/lexer5.d(12):        `real` literals can be written using the `L` suffix. https://dlang.org/spec/lex.html#floatliteral
 ---
 */
 
 static float f = 1e-100f;
+static float f2 = 1e-10024;

--- a/compiler/test/fail_compilation/lexer5.d
+++ b/compiler/test/fail_compilation/lexer5.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/lexer5.d(8): Error: number `1e-100f` is not representable
+fail_compilation/lexer5.d(9): Error: number `1e-100f` is not representable as a `float`
+fail_compilation/lexer5.d(9):        https://dlang.org/spec/lex.html#floatliteral
 ---
 */
 


### PR DESCRIPTION
There was also a bug here in that real literals did not get a suffix attached.