### PR TITLE
CTFloat.parse - use out parameter

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8642,7 +8642,7 @@ struct CTFloat final
     static bool isNaN(_d_real r);
     static bool isSNaN(_d_real r);
     static bool isInfinity(_d_real r);
-    static _d_real parse(const char* literal, bool* isOutOfRange = nullptr);
+    static _d_real parse(const char* literal, bool& isOutOfRange);
     static int32_t sprint(char* str, char fmt, _d_real x);
     static _d_real zero;
     static _d_real one;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2661,7 +2661,9 @@ void floatToBuffer(Type type, const real_t value, OutBuffer* buf, const bool all
     assert(strlen(buffer.ptr) < BUFFER_LEN);
     if (allowHex)
     {
-        real_t r = CTFloat.parse(buffer.ptr);
+        bool isOutOfRange;
+        real_t r = CTFloat.parse(buffer.ptr, isOutOfRange);
+        //assert(!isOutOfRange); // test/compilable/test22725.c asserts here
         if (r != value) // if exact duplication
             CTFloat.sprint(buffer.ptr, 'a', value);
     }

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -2531,7 +2531,7 @@ class Lexer
         auto sbufptr = cast(const(char)*)stringbuffer[].ptr;
         TOK result;
         bool isOutOfRange = false;
-        t.floatvalue = (isWellformedString ? CTFloat.parse(sbufptr, &isOutOfRange) : CTFloat.zero);
+        t.floatvalue = (isWellformedString ? CTFloat.parse(sbufptr, isOutOfRange) : CTFloat.zero);
         switch (*p)
         {
         case 'F':

--- a/compiler/src/dmd/root/ctfloat.d
+++ b/compiler/src/dmd/root/ctfloat.d
@@ -168,7 +168,7 @@ extern (C++) struct CTFloat
     }
 
     @system
-    static real_t parse(const(char)* literal, bool* isOutOfRange = null)
+    static real_t parse(const(char)* literal, out bool isOutOfRange)
     {
         errno = 0;
         version(CRuntime_DigitalMars)
@@ -183,8 +183,7 @@ extern (C++) struct CTFloat
         else
             auto r = strtold(literal, null);
         version(CRuntime_DigitalMars) __locale_decpoint = save;
-        if (isOutOfRange)
-            *isOutOfRange = (errno == ERANGE);
+        isOutOfRange = (errno == ERANGE);
         return r;
     }
 

--- a/compiler/src/dmd/root/ctfloat.h
+++ b/compiler/src/dmd/root/ctfloat.h
@@ -50,7 +50,7 @@ struct CTFloat
     static bool isSNaN(real_t r);
     static bool isInfinity(real_t r);
 
-    static real_t parse(const char *literal, bool *isOutOfRange = NULL);
+    static real_t parse(const char *literal, bool& isOutOfRange);
     static int sprint(char *str, char fmt, real_t x);
 
     static size_t hash(real_t a);


### PR DESCRIPTION
Using pointers instead of `out` is the old C way. Also get rid of the default value, which impedes understanding the usage of the function. Also added an assert that the round-trip conversions didn't fall off a bridge in the process.