### PR TITLE
Issue 23226 - allow access to non-shared `this`

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -13172,7 +13172,10 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
             if (sc.func && sc.func.isSynchronized())
                 return false;
 
-            return sharedError(e);
+            if (!allowRef && e.type.isShared())
+                return sharedError(e);
+
+            return false;
         }
 
         bool visitDotVar(DotVarExp e)

--- a/compiler/test/fail_compilation/shared.d
+++ b/compiler/test/fail_compilation/shared.d
@@ -225,3 +225,14 @@ auto ref Object test_inference_4(const return shared ref Object a)
 {
     return a;
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=23226
+// Allow accessing non-shared `this`
+struct BitRange
+{
+    int bits;
+    void f()
+    {
+        this.bits++;
+    }
+}


### PR DESCRIPTION
Treat `ThisExp` like `VarExp`. 

Not closing the issue because druntime still does not compile.