### PR TITLE
Simplify 'maybeScope' from 2 variables to 1

### DIFF
--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -68,7 +68,6 @@ enum STC : ulong  // transfer changes to declaration.h
     ref_                = 0x4_0000,   /// `ref`
     scope_              = 0x8_0000,   /// `scope`
 
-    maybescope          = 0x10_0000,   /// parameter might be `scope`
     scopeinferred       = 0x20_0000,   /// `scope` has been inferred and should not be part of mangling, `scope_` must also be set
     return_             = 0x40_0000,   /// 'return ref' or 'return scope' for function parameters
     returnScope         = 0x80_0000,   /// if `ref return scope` then resolve to `ref` and `return scope`

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1090,7 +1090,7 @@ extern (C++) class VarDeclaration : Declaration
     VarDeclaration lastVar;         // Linked list of variables for goto-skips-init detection
     Expression edtor;               // if !=null, does the destruction of the variable
     IntRange* range;                // if !=null, the variable is known to be within the range
-    VarDeclarations* maybes;        // STC.maybescope variables that are assigned to this STC.maybescope variable
+    VarDeclarations* maybes;        // maybeScope variables that are assigned to this maybeScope variable
 
     uint endlinnum;                 // line number of end of scope that this var lives in
     uint offset;
@@ -1119,7 +1119,7 @@ extern (C++) class VarDeclaration : Declaration
 
         bool overlapped;        /// if it is a field and has overlapping
         bool overlapUnsafe;     /// if it is an overlapping field and the overlaps are unsafe
-        bool doNotInferScope;   /// do not infer 'scope' for this variable
+        bool maybeScope;        /// allow inferring 'scope' for this variable
         bool doNotInferReturn;  /// do not infer 'return' for this variable
 
         bool isArgDtorVar;      /// temporary created to handle scope destruction of a function argument

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -59,7 +59,6 @@ struct AttributeViolation;
     #define STCref                0x40000ULL    /// `ref`
     #define STCscope              0x80000ULL    /// `scope`
 
-    #define STCmaybescope         0x100000ULL    /// parameter might be `scope`
     #define STCscopeinferred      0x200000ULL    /// `scope` has been inferred and should not be part of mangling, `scope` must also be set
     #define STCreturn             0x400000ULL    /// 'return ref' or 'return scope' for function parameters
     #define STCreturnScope        0x800000ULL    /// if `ref return scope` then resolve to `ref` and `return scope`
@@ -264,8 +263,8 @@ public:
     bool overlapped(bool v);
     bool overlapUnsafe() const; // if it is an overlapping field and the overlaps are unsafe
     bool overlapUnsafe(bool v);
-    bool doNotInferScope() const; // do not infer 'scope' for this variable
-    bool doNotInferScope(bool v);
+    bool maybeScope() const; // allow inferring 'scope' for this variable
+    bool maybeScope(bool v);
     bool doNotInferReturn() const; // do not infer 'return' for this variable
     bool doNotInferReturn(bool v);
     bool isArgDtorVar() const; // temporary created to handle scope destruction of a function argument

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -359,6 +359,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym.overlapped = true;
 
         dsym.sequenceNumber = global.varSequenceNumber++;
+        if (!dsym.isScope())
+            dsym.maybeScope = true;
 
         Scope* scx = null;
         if (dsym._scope)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -10043,8 +10043,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // `__assigntmp` will be destroyed together with the array `ae.e1`.
             // When `ae.e2` is a variadic arg array, it is also `scope`, so
             // `__assigntmp` may also be scope.
-            auto vd = copyToTemp(STC.rvalue | STC.nodtor | STC.maybescope,
-                "__assigntmp", ae.e2);
+            auto vd = copyToTemp(STC.rvalue | STC.nodtor | STC.scope_, "__assigntmp", ae.e2);
             eValue2 = new DeclarationExp(vd.loc, vd).expressionSemantic(sc);
             value2 = new VarExp(vd.loc, vd).expressionSemantic(sc);
         }
@@ -13265,8 +13264,7 @@ bool checkAddressVar(Scope* sc, Expression exp, VarDeclaration v)
     }
     if (sc.func && !sc.intypeof && !v.isDataseg())
     {
-        v.storage_class &= ~STC.maybescope;
-        v.doNotInferScope = true;
+        v.maybeScope = false;
         if (global.params.useDIP1000 != FeatureState.enabled &&
             !(v.storage_class & STC.temp) &&
             sc.setUnsafe(false, exp.loc, "cannot take address of local `%s` in `@safe` function `%s`", v, sc.func))

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4592,7 +4592,6 @@ enum class STC : uint64_t
     templateparameter = 131072LLU,
     ref_ = 262144LLU,
     scope_ = 524288LLU,
-    maybescope = 1048576LLU,
     scopeinferred = 2097152LLU,
     return_ = 4194304LLU,
     returnScope = 8388608LLU,
@@ -5865,8 +5864,8 @@ public:
     bool overlapped(bool v);
     bool overlapUnsafe() const;
     bool overlapUnsafe(bool v);
-    bool doNotInferScope() const;
-    bool doNotInferScope(bool v);
+    bool maybeScope() const;
+    bool maybeScope(bool v);
     bool doNotInferReturn() const;
     bool doNotInferReturn(bool v);
     bool isArgDtorVar() const;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -568,8 +568,6 @@ extern (C++) class FuncDeclaration : Declaration
             if (tf.isreturnscope)
                 vthis.storage_class |= STC.returnScope;
         }
-        if (flags & FUNCFLAG.inferScope && !(vthis.storage_class & STC.scope_))
-            vthis.storage_class |= STC.maybescope;
 
         vthis.dsymbolSemantic(sc);
         if (!sc.insert(vthis))

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -472,9 +472,6 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         stc |= STC.variadic;
                     }
 
-                    if ((funcdecl.flags & FUNCFLAG.inferScope) && !(fparam.storageClass & STC.scope_))
-                        stc |= STC.maybescope;
-
                     stc |= fparam.storageClass & (STC.IOR | STC.return_ | STC.scope_ | STC.lazy_ | STC.final_ | STC.TYPECTOR | STC.nodtor | STC.returnScope | STC.register);
                     v.storage_class = stc;
                     v.dsymbolSemantic(sc2);


### PR DESCRIPTION
Currently, there's both `STC.maybeScope` for parameter scope inference and `VarDeclaration.doNotInferScope` for variables in general. This leads to complexity and inconsistencies making it harder to solve DMD's issues with scope inference, such as:
- It infers scope when it shouldn't ([Issue 23208](https://issues.dlang.org/show_bug.cgi?id=23208), [Issue 23294](https://issues.dlang.org/show_bug.cgi?id=23294))
- It fails to infer scope when it should ([Issue 20674](https://issues.dlang.org/show_bug.cgi?id=20674))
- When inference fails, it doesn't tell you why ([Issue 23295](https://issues.dlang.org/show_bug.cgi?id=23295))

This change should make it easier to start working on those issues.