### PR TITLE
Add test for scope inference with `_d_arrayassign_l`

### DIFF
--- a/compiler/test/compilable/scope_infer_array_assign.d
+++ b/compiler/test/compilable/scope_infer_array_assign.d
@@ -1,0 +1,28 @@
+// REQUIRED_ARGS: -preview=dip1000
+
+// Test that scope inference works even with non POD array assignment
+// This is tricky because it gets lowered to something like:
+// (S[] __assigntmp0 = e[]) , _d_arrayassign_l(this.e[], __assigntmp0) , this.e[];
+
+@safe:
+
+struct File
+{
+    void* f;
+    ~this() scope { }
+}
+
+struct Vector
+{
+    File[] e;
+
+    auto assign(File[] e)
+    {
+        this.e[] = e[]; // slice copy
+    }
+}
+
+void test(scope File[] arr, Vector v)
+{
+    v.assign(arr);
+}


### PR DESCRIPTION
The first version of https://github.com/dlang/dmd/pull/14368 introduced a regression only caught by the automem project on buildkite. I reduced it to this test case, which I think is worth including in the test suite to make it easier to catch future regressions.