### PR TITLE
Fix 23295 - explain why scope inference failed

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -271,6 +271,40 @@ bool checkAssocArrayLiteralEscape(Scope *sc, AssocArrayLiteralExp ae, bool gag)
     return errors;
 }
 
+/**
+ * A `scope` variable was assigned to non-scope parameter `v`.
+ * If applicable, print why the parameter was not inferred `scope`.
+ *
+ * Params:
+ *    printFunc = error/deprecation print function to use
+ *    v = parameter that was not inferred
+ *    recursionLimit = recursion limit for printing the reason
+ */
+void printScopeFailure(E)(E printFunc, VarDeclaration v, int recursionLimit)
+{
+    recursionLimit--;
+    if (recursionLimit < 0 || !v)
+        return;
+
+    if (RootObject* o = v.sequenceNumber in scopeInferFailure)
+    {
+        switch ((*o).dyncast())
+        {
+            case DYNCAST.expression:
+                Expression e = cast(Expression) *o;
+                printFunc(e.loc, "which is not `scope` because of `%s`", e.toChars());
+                break;
+            case DYNCAST.dsymbol:
+                VarDeclaration v1 = cast(VarDeclaration) *o;
+                printFunc(v1.loc, "which is assigned to non-scope parameter `%s`", v1.toChars());
+                printScopeFailure(printFunc, v1, recursionLimit);
+                break;
+            default:
+                assert(0);
+        }
+    }
+}
+
 /****************************************
  * Function parameter `par` is being initialized to `arg`,
  * and `par` may escape.
@@ -280,6 +314,7 @@ bool checkAssocArrayLiteralEscape(Scope *sc, AssocArrayLiteralExp ae, bool gag)
  *      sc = used to determine current function and module
  *      fdc = function being called, `null` if called indirectly
  *      par = function parameter (`this` if null)
+ *      vPar = `VarDeclaration` corresponding to `par`
  *      parStc = storage classes of function parameter (may have added `scope` from `pure`)
  *      arg = initializer for param
  *      assertmsg = true if the parameter is the msg argument to assert(bool, msg).
@@ -287,7 +322,7 @@ bool checkAssocArrayLiteralEscape(Scope *sc, AssocArrayLiteralExp ae, bool gag)
  * Returns:
  *      `true` if pointers to the stack can escape via assignment
  */
-bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, STC parStc, Expression arg, bool assertmsg, bool gag)
+bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, VarDeclaration vPar, STC parStc, Expression arg, bool assertmsg, bool gag)
 {
     enum log = false;
     if (log) printf("checkParamArgumentEscape(arg: %s par: %s)\n",
@@ -329,11 +364,17 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, STC
         {
             result |= sc.setUnsafeDIP1000(gag, arg.loc,
                 desc ~ " `%s` assigned to non-scope parameter `%s` calling `%s`", v, par, fdc);
+
+            if (result)
+                printScopeFailure(previewSupplementalFunc(sc.isDeprecated(), global.params.useDIP1000), vPar, 10);
         }
         else
         {
             result |= sc.setUnsafeDIP1000(gag, arg.loc,
                 desc ~ " `%s` assigned to non-scope parameter `this` calling `%s`", v, fdc);
+
+            if (result)
+                printScopeFailure(previewSupplementalFunc(sc.isDeprecated(), global.params.useDIP1000), fdc.vthis, 10);
         }
     }
 
@@ -345,7 +386,7 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, STC
 
         Dsymbol p = v.toParent2();
 
-        notMaybeScope(v);
+        notMaybeScope(v, vPar);
 
         if (v.isScope())
         {
@@ -366,7 +407,8 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, STC
              */
             if (log) printf("no infer for %s in %s loc %s, fdc %s, %d\n",
                 v.toChars(), sc.func.ident.toChars(), sc.func.loc.toChars(), fdc.ident.toChars(),  __LINE__);
-            doNotInferScope(v);
+
+            doNotInferScope(v, vPar);
         }
     }
 
@@ -378,7 +420,7 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, STC
 
         Dsymbol p = v.toParent2();
 
-        notMaybeScope(v);
+        notMaybeScope(v, arg);
         if (checkScopeVarAddr(v, arg, sc, gag))
         {
             result = true;
@@ -405,7 +447,7 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, STC
 
             Dsymbol p = v.toParent2();
 
-            notMaybeScope(v);
+            notMaybeScope(v, arg);
 
             if ((v.isReference() || v.isScope()) && p == sc.func)
             {
@@ -681,7 +723,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag, bool byRef)
         }
 
         if (!(va && va.isScope()) || vaIsRef)
-            notMaybeScope(v);
+            notMaybeScope(v, e);
 
         if (v.isScope())
         {
@@ -768,7 +810,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag, bool byRef)
              * It may escape via that assignment, therefore, v can never be 'scope'.
              */
             //printf("no infer for %s in %s, %d\n", v.toChars(), fd.ident.toChars(), __LINE__);
-            doNotInferScope(v);
+            doNotInferScope(v, e);
         }
     }
 
@@ -821,7 +863,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag, bool byRef)
         }
 
         if (!(va && va.isScope()))
-            notMaybeScope(v);
+            notMaybeScope(v, e);
 
         if (p != sc.func)
             continue;
@@ -864,7 +906,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag, bool byRef)
             Dsymbol p = v.toParent2();
 
             if (!(va && va.isScope()))
-                notMaybeScope(v);
+                notMaybeScope(v, e);
 
             if (!(v.isReference() || v.isScope()) || p != fd)
                 continue;
@@ -972,8 +1014,7 @@ bool checkThrowEscape(Scope* sc, Expression e, bool gag)
         }
         else
         {
-            //printf("no infer for %s in %s, %d\n", v.toChars(), sc.func.ident.toChars(), __LINE__);
-            notMaybeScope(v);
+            notMaybeScope(v, new ThrowExp(e.loc, e));
         }
     }
     return result;
@@ -1045,7 +1086,7 @@ bool checkNewEscape(Scope* sc, Expression e, bool gag)
         else
         {
             //printf("no infer for %s in %s, %d\n", v.toChars(), sc.func.ident.toChars(), __LINE__);
-            notMaybeScope(v);
+            notMaybeScope(v, e);
         }
     }
 
@@ -1275,7 +1316,7 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
         else
         {
             //printf("no infer for %s in %s, %d\n", v.toChars(), sc.func.ident.toChars(), __LINE__);
-            doNotInferScope(v);
+            doNotInferScope(v, e);
         }
     }
 
@@ -1339,7 +1380,7 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
         if (!refs)
         {
             if (sc.func.vthis == v)
-                notMaybeScope(v);
+                notMaybeScope(v, e);
 
             if (checkScopeVarAddr(v, e, sc, gag))
             {
@@ -2234,26 +2275,29 @@ public void findAllOuterAccessedVariables(FuncDeclaration fd, VarDeclarations* v
     }
 }
 
+// Maps `sequenceNumber` of a `VarDeclaration` to an object that contains the
+// reason it failed to infer `scope`
+// https://issues.dlang.org/show_bug.cgi?id=23295
+private __gshared RootObject[int] scopeInferFailure;
+
 /***********************************
  * Turn off `maybeScope` for variable `v`.
  *
  * This exists in order to find where `maybeScope` is getting turned off.
  * Params:
  *      v = variable
+ *      o = reason for it being turned off:
+ *          - `Expression` such as `throw e` or `&e`
+ *          - `VarDeclaration` of a non-scope parameter it was assigned to
+ *          - `null` for no reason
  */
-version (none)
+private void notMaybeScope(VarDeclaration v, RootObject o)
 {
-    private void notMaybeScope(string file = __FILE__, int line = __LINE__)(VarDeclaration v)
-    {
-        printf("%.*s(%d): notMaybeScope('%s')\n", cast(int)file.length, file.ptr, line, v.toChars());
-        v.maybeScope = false;
-    }
-}
-else
-{
-    private void notMaybeScope(VarDeclaration v)
+    if (v.maybeScope)
     {
         v.maybeScope = false;
+        if (o && v.isParameter())
+            scopeInferFailure[v.sequenceNumber] = o;
     }
 }
 
@@ -2266,11 +2310,12 @@ else
  *
  * Params:
  *      v = variable
+ *      o = reason for it being turned off
  */
-private void doNotInferScope(VarDeclaration v)
+private void doNotInferScope(VarDeclaration v, RootObject o)
 {
     if (!v.isParameter)
-        v.maybeScope = false;
+        notMaybeScope(v, o);
 }
 
 /***********************************
@@ -2336,7 +2381,7 @@ void finishScopeParamInference(FuncDeclaration funcdecl, ref TypeFunction f)
             if (v.maybeScope)
             {
                 //printf("Inferring scope for %s\n", v.toChars());
-                notMaybeScope(v);
+                notMaybeScope(v, null);
                 v.storage_class |= STC.scope_ | STC.scopeinferred;
                 p.storageClass |= STC.scope_ | STC.scopeinferred;
             }
@@ -2345,7 +2390,7 @@ void finishScopeParamInference(FuncDeclaration funcdecl, ref TypeFunction f)
 
     if (funcdecl.vthis && funcdecl.vthis.maybeScope)
     {
-        notMaybeScope(funcdecl.vthis);
+        notMaybeScope(funcdecl.vthis, null);
         funcdecl.vthis.storage_class |= STC.scope_ | STC.scopeinferred;
         f.isScopeQual = true;
         f.isscopeinferred = true;
@@ -2395,7 +2440,7 @@ private void eliminateMaybeScopes(VarDeclaration[] array)
                         if (v.maybeScope)
                         {
                             // v cannot be scope since it is assigned to a non-scope va
-                            notMaybeScope(v);
+                            notMaybeScope(v, va);
                             if (!v.isReference())
                                 v.storage_class &= ~(STC.return_ | STC.returninferred);
                             changes = true;
@@ -2597,7 +2642,7 @@ private bool checkScopeVarAddr(VarDeclaration v, Expression e, Scope* sc, bool g
 
     if (!v.isScope())
     {
-        notMaybeScope(v);
+        notMaybeScope(v, e);
         return false;
     }
 

--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -117,6 +117,7 @@ void initDMD(
 
     import dmd.cond : VersionCondition;
     import dmd.dmodule : Module;
+    import dmd.escape : EscapeState;
     import dmd.expression : Expression;
     import dmd.globals : CHECKENABLE, global;
     import dmd.id : Id;
@@ -150,6 +151,7 @@ void initDMD(
     Module._init();
     Expression._init();
     Objc._init();
+    EscapeState.reset();
 
     addDefaultVersionIdentifiers(global.params, target);
 
@@ -170,6 +172,7 @@ void deinitializeDMD()
 {
     import dmd.dmodule : Module;
     import dmd.dsymbol : Dsymbol;
+    import dmd.escape : EscapeState;
     import dmd.expression : Expression;
     import dmd.globals : global;
     import dmd.id : Id;
@@ -189,6 +192,7 @@ void deinitializeDMD()
     Expression.deinitialize();
     Objc.deinitialize();
     Dsymbol.deinitialize();
+    EscapeState.reset();
 }
 
 /**

--- a/compiler/test/fail_compilation/diag23295.d
+++ b/compiler/test/fail_compilation/diag23295.d
@@ -1,0 +1,40 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/diag23295.d(21): Error: scope variable `x` assigned to non-scope parameter `y` calling `foo`
+fail_compilation/diag23295.d(32):        which is assigned to non-scope parameter `z`
+fail_compilation/diag23295.d(34):        which is not `scope` because of `f = & z`
+fail_compilation/diag23295.d(24): Error: scope variable `ex` assigned to non-scope parameter `e` calling `thro`
+fail_compilation/diag23295.d(39):        which is not `scope` because of `throw e`
+---
+*/
+
+// explain why scope inference failed
+// https://issues.dlang.org/show_bug.cgi?id=23295
+
+@safe:
+
+void main()
+{
+    scope int* x;
+    foo(x, null);
+
+    scope Exception ex;
+    thro(ex);
+}
+
+auto foo(int* y, int** w)
+{
+    fooImpl(y, null);
+}
+
+auto fooImpl(int* z, int** w)
+{
+    auto f = &z;
+}
+
+auto thro(Exception e)
+{
+    throw e;
+}

--- a/compiler/test/fail_compilation/retscope6.d
+++ b/compiler/test/fail_compilation/retscope6.d
@@ -78,6 +78,7 @@ void foo() @safe
 fail_compilation/retscope6.d(8016): Error: address of variable `i` assigned to `p` with longer lifetime
 fail_compilation/retscope6.d(8031): Error: reference to local variable `i` assigned to non-scope parameter `p` calling `betty`
 fail_compilation/retscope6.d(8031): Error: reference to local variable `j` assigned to non-scope parameter `q` calling `betty`
+fail_compilation/retscope6.d(8021):        which is assigned to non-scope parameter `p`
 fail_compilation/retscope6.d(8048): Error: reference to local variable `j` assigned to non-scope parameter `q` calling `archie`
 ---
 */
@@ -255,6 +256,7 @@ void escape_throw_20150() @safe
 /* TEST_OUTPUT:
 ---
 fail_compilation/retscope6.d(14019): Error: scope variable `scopePtr` assigned to non-scope parameter `x` calling `noInfer23021`
+fail_compilation/retscope6.d(14009):        which is not `scope` because of `*escapeHole = cast(const(int)*)x`
 fail_compilation/retscope6.d(14022): Error: scope variable `scopePtr` may not be returned
 ---
 */

--- a/compiler/test/fail_compilation/test17423.d
+++ b/compiler/test/fail_compilation/test17423.d
@@ -1,7 +1,8 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test17423.d(26): Error: reference to local `this` assigned to non-scope parameter `dlg` calling `opApply`
+fail_compilation/test17423.d(27): Error: reference to local `this` assigned to non-scope parameter `dlg` calling `opApply`
+fail_compilation/test17423.d(16):        which is not `scope` because of `this.myDlg = dlg`
 ---
 */
 

--- a/compiler/test/fail_compilation/test20245.d
+++ b/compiler/test/fail_compilation/test20245.d
@@ -2,15 +2,16 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test20245.d(20): Error: reference to local variable `x` assigned to non-scope parameter `ptr` calling `escape`
-fail_compilation/test20245.d(21): Error: copying `&x` into allocated memory escapes a reference to parameter `x`
-fail_compilation/test20245.d(22): Error: scope variable `a` may not be returned
-fail_compilation/test20245.d(26): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
-fail_compilation/test20245.d(32): Error: reference to local variable `x` assigned to non-scope parameter `ptr` calling `escape`
-fail_compilation/test20245.d(33): Error: copying `&x` into allocated memory escapes a reference to parameter `x`
-fail_compilation/test20245.d(49): Error: reference to local variable `price` assigned to non-scope `this.minPrice`
-fail_compilation/test20245.d(68): Error: reference to local variable `this` assigned to non-scope parameter `msg` calling `this`
-fail_compilation/test20245.d(88): Error: reference to local variable `this` assigned to non-scope parameter `content` calling `listUp`
+fail_compilation/test20245.d(21): Error: reference to local variable `x` assigned to non-scope parameter `ptr` calling `escape`
+fail_compilation/test20245.d(22): Error: copying `&x` into allocated memory escapes a reference to parameter `x`
+fail_compilation/test20245.d(23): Error: scope variable `a` may not be returned
+fail_compilation/test20245.d(27): Error: cannot take address of `scope` variable `x` since `scope` applies to first indirection only
+fail_compilation/test20245.d(33): Error: reference to local variable `x` assigned to non-scope parameter `ptr` calling `escape`
+fail_compilation/test20245.d(34): Error: copying `&x` into allocated memory escapes a reference to parameter `x`
+fail_compilation/test20245.d(50): Error: reference to local variable `price` assigned to non-scope `this.minPrice`
+fail_compilation/test20245.d(69): Error: reference to local variable `this` assigned to non-scope parameter `msg` calling `this`
+fail_compilation/test20245.d(89): Error: reference to local variable `this` assigned to non-scope parameter `content` calling `listUp`
+fail_compilation/test20245.d(82):        which is not `scope` because of `charPtr = content`
 ---
 */
 

--- a/compiler/test/fail_compilation/test23073.d
+++ b/compiler/test/fail_compilation/test23073.d
@@ -2,7 +2,8 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/test23073.d(27): Error: scope variable `c` assigned to non-scope parameter `c` calling `assignNext`
+fail_compilation/test23073.d(28): Error: scope variable `c` assigned to non-scope parameter `c` calling `assignNext`
+fail_compilation/test23073.d(22):        which is not `scope` because of `c.next = c`
 ---
 */
 


### PR DESCRIPTION
Following up https://github.com/dlang/dmd/pull/14368

I'm using an associative array instead of an extra field to `VarDeclaration` to reduce memory. It is annoying that there's no easy way to find the corresponding `VarDeclaration` of a `Parameter`, so I'll pass it into `checkParamArgumentEscape`.

So far it only works for direct `@safe` errors, and not for a stored `AttributeViolation` (https://github.com/dlang/dmd/pull/13957), which is a future improvement.. 