### PR TITLE
Improve `@safe` annotations in outbuffer.d

### DIFF
--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -173,7 +173,7 @@ struct Relocation
  * Returns offset into the specified string table.
  */
 
-IDXSTR MsCoffObj_addstr(OutBuffer *strtab, const(char)* str)
+IDXSTR MsCoffObj_addstr(OutBuffer *strtab, const(char)* str) @system
 {
     //printf("MsCoffObj_addstr(strtab = %p str = '%s')\n",strtab,str);
     IDXSTR idx = cast(IDXSTR)strtab.length();        // remember starting offset

--- a/compiler/src/dmd/common/outbuffer.d
+++ b/compiler/src/dmd/common/outbuffer.d
@@ -109,12 +109,12 @@ struct OutBuffer
     }
 
     /// For porting with ease from dmd.backend.outbuf.Outbuffer
-    ubyte* buf() nothrow {
+    ubyte* buf() nothrow @system {
         return data.ptr;
     }
 
     /// For porting with ease from dmd.backend.outbuf.Outbuffer
-    ubyte** bufptr() nothrow {
+    ubyte** bufptr() nothrow @system {
         static struct Array { size_t length; ubyte* ptr; }
         auto a = cast(Array*) &data;
         assert(a.length == data.length && a.ptr == data.ptr);
@@ -156,7 +156,7 @@ struct OutBuffer
     Params:
     nbytes = the number of additional bytes to reserve
     */
-    extern (C++) void reserve(size_t nbytes) pure nothrow
+    extern (C++) void reserve(size_t nbytes) pure nothrow @trusted
     {
         //debug (stomp) printf("OutBuffer::reserve: size = %lld, offset = %lld, nbytes = %lld\n", data.length, offset, nbytes);
         const minSize = offset + nbytes;
@@ -210,7 +210,7 @@ struct OutBuffer
         offset = 0;
     }
 
-    private void indent() pure nothrow
+    private void indent() pure nothrow @safe
     {
         if (level)
         {
@@ -223,19 +223,19 @@ struct OutBuffer
     }
 
     // Write an array to the buffer, no reserve check
-    @trusted nothrow
+    @system nothrow
     void writen(const void *b, size_t len)
     {
         memcpy(data.ptr + offset, b, len);
         offset += len;
     }
 
-    extern (C++) void write(const(void)* data, size_t nbytes) pure nothrow
+    extern (C++) void write(const(void)* data, size_t nbytes) pure nothrow @system
     {
         write(data[0 .. nbytes]);
     }
 
-    void write(const(void)[] buf) pure nothrow
+    void write(scope const(void)[] buf) pure nothrow @trusted
     {
         if (doindent && !notlinehead)
             indent();
@@ -282,7 +282,7 @@ struct OutBuffer
     }
 
     /// NOT zero-terminated
-    extern (C++) void writestring(const(char)* s) pure nothrow
+    extern (C++) void writestring(const(char)* s) pure nothrow @system
     {
         if (!s)
             return;
@@ -291,19 +291,19 @@ struct OutBuffer
     }
 
     /// ditto
-    void writestring(const(char)[] s) pure nothrow
+    void writestring(scope const(char)[] s) pure nothrow @safe
     {
         write(s);
     }
 
     /// ditto
-    void writestring(string s) pure nothrow
+    void writestring(scope string s) pure nothrow @safe
     {
         write(s);
     }
 
     /// NOT zero-terminated, followed by newline
-    void writestringln(const(char)[] s) pure nothrow
+    void writestringln(const(char)[] s) pure nothrow @safe
     {
         writestring(s);
         writenl();
@@ -311,25 +311,25 @@ struct OutBuffer
 
     /** Write string to buffer, ensure it is zero terminated
      */
-    void writeStringz(const(char)* s) pure nothrow @trusted
+    void writeStringz(const(char)* s) pure nothrow @system
     {
         write(s[0 .. strlen(s)+1]);
     }
 
     /// ditto
-    void writeStringz(const(char)[] s) pure nothrow
+    void writeStringz(const(char)[] s) pure nothrow @safe
     {
         write(s);
         writeByte(0);
     }
 
     /// ditto
-    void writeStringz(string s) pure nothrow
+    void writeStringz(string s) pure nothrow @safe
     {
         writeStringz(cast(const(char)[])(s));
     }
 
-    extern (C++) void prependstring(const(char)* string) pure nothrow
+    extern (C++) void prependstring(const(char)* string) pure nothrow @system
     {
         size_t len = strlen(string);
         reserve(len);
@@ -339,7 +339,7 @@ struct OutBuffer
     }
 
     /// write newline
-    extern (C++) void writenl() pure nothrow
+    extern (C++) void writenl() pure nothrow @safe
     {
         version (Windows)
         {
@@ -385,7 +385,7 @@ struct OutBuffer
         this.data[offset++] = cast(ubyte) b;
     }
 
-    extern (C++) void writeByte(uint b) pure nothrow
+    extern (C++) void writeByte(uint b) pure nothrow @safe
     {
         if (doindent && !notlinehead && b != '\n')
             indent();
@@ -394,7 +394,7 @@ struct OutBuffer
         offset++;
     }
 
-    extern (C++) void writeUTF8(uint b) pure nothrow
+    extern (C++) void writeUTF8(uint b) pure nothrow @safe
     {
         reserve(6);
         if (b <= 0x7F)
@@ -427,7 +427,7 @@ struct OutBuffer
             assert(0);
     }
 
-    extern (C++) void prependbyte(uint b) pure nothrow
+    extern (C++) void prependbyte(uint b) pure nothrow @trusted
     {
         reserve(1);
         memmove(data.ptr + 1, data.ptr, offset);
@@ -435,7 +435,7 @@ struct OutBuffer
         offset++;
     }
 
-    extern (C++) void writewchar(uint w) pure nothrow
+    extern (C++) void writewchar(uint w) pure nothrow @safe
     {
         version (Windows)
         {
@@ -447,7 +447,7 @@ struct OutBuffer
         }
     }
 
-    extern (C++) void writeword(uint w) pure nothrow
+    extern (C++) void writeword(uint w) pure nothrow @trusted
     {
         version (Windows)
         {
@@ -465,7 +465,7 @@ struct OutBuffer
         offset += 2;
     }
 
-    extern (C++) void writeUTF16(uint w) pure nothrow
+    extern (C++) void writeUTF16(uint w) pure nothrow @trusted
     {
         reserve(4);
         if (w <= 0xFFFF)
@@ -483,7 +483,7 @@ struct OutBuffer
             assert(0);
     }
 
-    extern (C++) void write4(uint w) pure nothrow
+    extern (C++) void write4(uint w) pure nothrow @trusted
     {
         version (Windows)
         {
@@ -500,7 +500,7 @@ struct OutBuffer
         offset += 4;
     }
 
-    extern (C++) void write(const OutBuffer* buf) pure nothrow
+    extern (C++) void write(const OutBuffer* buf) pure nothrow @trusted
     {
         if (buf)
         {
@@ -510,7 +510,7 @@ struct OutBuffer
         }
     }
 
-    extern (C++) void fill0(size_t nbytes) pure nothrow
+    extern (C++) void fill0(size_t nbytes) pure nothrow @trusted
     {
         reserve(nbytes);
         memset(data.ptr + offset, 0, nbytes);
@@ -531,7 +531,7 @@ struct OutBuffer
         return cast(char[])data[offset - nbytes .. offset];
     }
 
-    extern (C++) void vprintf(const(char)* format, va_list args) nothrow
+    extern (C++) void vprintf(const(char)* format, va_list args) nothrow @system
     {
         int count;
         if (doindent && !notlinehead)
@@ -567,7 +567,7 @@ struct OutBuffer
 
     static if (__VERSION__ < 2092)
     {
-        extern (C++) void printf(const(char)* format, ...) nothrow
+        extern (C++) void printf(const(char)* format, ...) nothrow @system
         {
             va_list ap;
             va_start(ap, format);
@@ -577,7 +577,7 @@ struct OutBuffer
     }
     else
     {
-        pragma(printf) extern (C++) void printf(const(char)* format, ...) nothrow
+        pragma(printf) extern (C++) void printf(const(char)* format, ...) nothrow @system
         {
             va_list ap;
             va_start(ap, format);
@@ -591,13 +591,13 @@ struct OutBuffer
      * Params:
      *  u = integral value to append
      */
-    extern (C++) void print(ulong u) pure nothrow
+    extern (C++) void print(ulong u) pure nothrow @safe
     {
         UnsignedStringBuf buf = void;
         writestring(unsignedToTempString(u, buf));
     }
 
-    extern (C++) void bracket(char left, char right) pure nothrow
+    extern (C++) void bracket(char left, char right) pure nothrow @trusted
     {
         reserve(2);
         memmove(data.ptr + 1, data.ptr, offset);
@@ -610,7 +610,7 @@ struct OutBuffer
      * Insert left at i, and right at j.
      * Return index just past right.
      */
-    extern (C++) size_t bracket(size_t i, const(char)* left, size_t j, const(char)* right) pure nothrow
+    extern (C++) size_t bracket(size_t i, const(char)* left, size_t j, const(char)* right) pure nothrow @system
     {
         size_t leftlen = strlen(left);
         size_t rightlen = strlen(right);
@@ -620,7 +620,7 @@ struct OutBuffer
         return j + leftlen + rightlen;
     }
 
-    extern (C++) void spread(size_t offset, size_t nbytes) pure nothrow
+    extern (C++) void spread(size_t offset, size_t nbytes) pure nothrow @system
     {
         reserve(nbytes);
         memmove(data.ptr + offset + nbytes, data.ptr + offset, this.offset - offset);
@@ -630,19 +630,19 @@ struct OutBuffer
     /****************************************
      * Returns: offset + nbytes
      */
-    extern (C++) size_t insert(size_t offset, const(void)* p, size_t nbytes) pure nothrow
+    extern (C++) size_t insert(size_t offset, const(void)* p, size_t nbytes) pure nothrow @system
     {
         spread(offset, nbytes);
         memmove(data.ptr + offset, p, nbytes);
         return offset + nbytes;
     }
 
-    size_t insert(size_t offset, const(char)[] s) pure nothrow
+    size_t insert(size_t offset, const(char)[] s) pure nothrow @system
     {
         return insert(offset, s.ptr, s.length);
     }
 
-    extern (C++) void remove(size_t offset, size_t nbytes) pure nothrow @nogc
+    extern (C++) void remove(size_t offset, size_t nbytes) pure nothrow @nogc @system
     {
         memmove(data.ptr + offset, data.ptr + offset + nbytes, this.offset - (offset + nbytes));
         this.offset -= nbytes;
@@ -716,7 +716,7 @@ struct OutBuffer
         return extractData();
     }
 
-    void writesLEB128(int value) pure nothrow
+    void writesLEB128(int value) pure nothrow @safe
     {
         while (1)
         {
@@ -733,7 +733,7 @@ struct OutBuffer
         }
     }
 
-    void writeuLEB128(uint value) pure nothrow
+    void writeuLEB128(uint value) pure nothrow @safe
     {
         do
         {
@@ -758,7 +758,7 @@ struct OutBuffer
 
     Returns: `true` iff the operation succeeded.
     */
-    extern(D) bool moveToFile(const char* filename)
+    extern(D) bool moveToFile(const char* filename) @system
     {
         bool result = true;
         const bool identical = this[] == FileMapping!(const ubyte)(filename)[];
@@ -799,7 +799,7 @@ private:
 
 alias UnsignedStringBuf = char[20];
 
-char[] unsignedToTempString(ulong value, char[] buf, uint radix = 10) @safe pure nothrow @nogc
+char[] unsignedToTempString(ulong value, return scope char[] buf, uint radix = 10) @safe pure nothrow @nogc
 {
     size_t i = buf.length;
     do


### PR DESCRIPTION
Mark functions with a safe interface `@safe` or `@trusted`.
Mark functions with an unsafe interface `@system`.