### PR TITLE
WIP: Move last occurrence of symbols when occurring in rhs of VarExpr or if passed to a function declaration [skip ci]

### DIFF
--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -1223,6 +1223,8 @@ FuncDeclaration buildInv(AggregateDeclaration ad, Scope* sc)
  */
 FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
 {
+    if (sd.toString() == "SYZ")
+        asm { int 3; }
     //printf("buildPostBlit() %s\n", sd.toChars());
     if (sd.isUnionDeclaration())
         return null;

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1414,9 +1414,11 @@ extern (C++) class VarDeclaration : Declaration
     /******************************************
      * Return true if variable needs to call the destructor.
      */
-    final bool needsScopeDtor()
+    extern(D) final bool needsScopeDtor(string file = __FILE__, uint line = __LINE__)
     {
         //printf("VarDeclaration::needsScopeDtor() %s\n", toChars());
+        if (type.toString == "SYZ")
+            printf("%.*s:%d: called needsScopeDtor\n", cast(int)file.length, file.ptr, line);
         return edtor && !(storage_class & STC.nodtor);
     }
 

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1091,6 +1091,7 @@ extern (C++) class VarDeclaration : Declaration
     Expression edtor;               // if !=null, does the destruction of the variable
     IntRange* range;                // if !=null, the variable is known to be within the range
     VarDeclarations* maybes;        // maybeScope variables that are assigned to this maybeScope variable
+    VarExp lastVarExp;              // last reference of `this`
 
     uint endlinnum;                 // line number of end of scope that this var lives in
     uint offset;
@@ -1101,6 +1102,8 @@ extern (C++) class VarDeclaration : Declaration
     // The index of this variable on the CTFE stack, AdrOnStackNone if not allocated
     enum AdrOnStackNone = ~0u;
     uint ctfeAdrOnStack;
+
+    bool lastVarExpCanBeMoved; // TODO: true if `lastVarExp` can (and should be) moved
 
     // `bool` fields that are compacted into bit fields in a string mixin
     private extern (D) static struct BitFields

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -431,6 +431,7 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
  */
 extern (C++) void verror(const ref Loc loc, const(char)* format, va_list ap, const(char)* p1 = null, const(char)* p2 = null, const(char)* header = "Error: ")
 {
+    asm nothrow pure @nogc { int 3; }
     global.errors++;
     if (!global.gag)
     {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -2519,12 +2519,24 @@ private Module loadStdMath()
     return impStdMath.mod;
 }
 
-private void setLastVarExpFlag(Expression e)
+private void setLastVarExpFlag(Scope* sc, Expression e)
 {
     if (VarExp ve = e.isVarExp)
     {
         if (auto vd = ve.var.isVarDeclaration)
-            vd.lastVarExpCanBeMoved = true;
+        {
+            if (sc.func)
+            {
+                if (auto parameters = sc.func.parameters)
+                {
+                    foreach (p; *parameters)
+                    {
+                        if (p == vd)
+                            vd.lastVarExpCanBeMoved = true;
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -4177,7 +4189,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             for (size_t k = 0; k < arguments.dim; k++)
             {
                 Expression checkarg = (*arguments)[k];
-                setLastVarExpFlag(checkarg);
+                setLastVarExpFlag(sc, checkarg);
                 if (checkarg.op == EXP.error)
                     return checkarg;
             }
@@ -9082,7 +9094,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             auto e1x = exp.e1;
             auto e2x = exp.e2;
             auto sd = (cast(TypeStruct)t1).sym;
-            setLastVarExpFlag(e2x);
+            setLastVarExpFlag(sc, e2x);
 
             if (exp.op == EXP.construct)
             {

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1129,7 +1129,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     // check if callee destroys arguments
                     const bool paramsNeedDtor = target.isCalleeDestroyingArgs(f);
 
-                    foreach (v; *funcdecl.parameters)
+                    foreach (VarDeclaration v; *funcdecl.parameters)
                     {
                         if (v.isReference() || (v.storage_class & STC.lazy_))
                             continue;

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1133,6 +1133,19 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     {
                         if (v.isReference() || (v.storage_class & STC.lazy_))
                             continue;
+                        if (v.lastVarExpCanBeMoved)
+                        {
+                            if (VarExp ve = v.lastVarExp)
+                            {
+                                // message(ve.loc, "From: %s", ve.toChars());
+                                if (auto vtmp = ve.var.isVarDeclaration())
+                                {
+                                    // TODO: verify that opPostMove is called
+                                    vtmp.storage_class |= STC.nodtor;
+                                    continue; // TODO: only needed for clarity, maybe remove
+                                }
+                            }
+                        }
                         if (v.needsScopeDtor())
                         {
                             v.storage_class |= STC.nodtor;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2809,7 +2809,17 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
         assert(tf.ty == Tfunction);
 
         if (rs.exp)             // TODO: check if this happens on nested functions
-            rs.exp = valueNoDtor(rs.exp);
+        {
+            if (auto ve = rs.exp.isVarExp)
+            {
+                if (auto vd = ve.var.isVarDeclaration)
+                {
+                    vd.lastVarExp = ve;
+                    vd.lastVarExpCanBeMoved = true;
+                    asm { int 3; }
+                }
+            }
+        }
 
         if (rs.exp && rs.exp.op == EXP.variable && (cast(VarExp)rs.exp).var == fd.vresult)
         {
@@ -4205,6 +4215,7 @@ Statement scopeCode(Statement statement, Scope* sc, out Statement sentry, out St
             {
                 if (v.needsScopeDtor())
                 {
+                    asm { int 3; }
                     sfinally = new DtorExpStatement(es.loc, v.edtor, v);
                     v.storage_class |= STC.nodtor; // don't add in dtor again
                 }

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2808,6 +2808,9 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
             TypeFunction tf = cast(TypeFunction)fd.type;
         assert(tf.ty == Tfunction);
 
+        if (rs.exp)             // TODO: check if this happens on nested functions
+            rs.exp = valueNoDtor(rs.exp);
+
         if (rs.exp && rs.exp.op == EXP.variable && (cast(VarExp)rs.exp).var == fd.vresult)
         {
             // return vresult;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2808,19 +2808,6 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
             TypeFunction tf = cast(TypeFunction)fd.type;
         assert(tf.ty == Tfunction);
 
-        if (rs.exp)             // TODO: check if this happens on nested functions
-        {
-            if (auto ve = rs.exp.isVarExp)
-            {
-                if (auto vd = ve.var.isVarDeclaration)
-                {
-                    vd.lastVarExp = ve;
-                    vd.lastVarExpCanBeMoved = true;
-                    asm { int 3; }
-                }
-            }
-        }
-
         if (rs.exp && rs.exp.op == EXP.variable && (cast(VarExp)rs.exp).var == fd.vresult)
         {
             // return vresult;
@@ -2903,6 +2890,18 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                 rs.exp = inferType(rs.exp, fld.treq.nextOf().nextOf());
 
             rs.exp = rs.exp.expressionSemantic(sc);
+            {
+                // TODO: check if this happens on nested functions
+                if (auto ve = rs.exp.isVarExp)
+                {
+                    if (auto vd = ve.var.isVarDeclaration)
+                    {
+                        vd.lastVarExp = ve;
+                        vd.lastVarExpCanBeMoved = true;
+                    }
+                }
+            }
+
             rs.exp = rs.exp.arrayFuncConv(sc);
             // If we're returning by ref, allow the expression to be `shared`
             const returnSharedRef = (tf.isref && (fd.inferRetType || tret.isShared()));

--- a/movetest.d
+++ b/movetest.d
@@ -1,5 +1,6 @@
 struct S {
     int x;
+    this(int x) @safe pure nothrow @nogc { this.x = x; }
     ~this() @safe pure nothrow @nogc {}
 }
 

--- a/movetest.d
+++ b/movetest.d
@@ -20,7 +20,7 @@ SYZ moveOnReturn1(SYZ s) {
 void moveOnAssign1a(SYZ s) {
     SYZ t = s;                    // `s` is moved
 }
-void moveOnAssign1b(SYZ s) {
+SYZ moveOnAssign1b(SYZ s) {
     SYZ t = s;                    // `s` is moved
     return t;                     // `t` is moved
 }

--- a/movetest.d
+++ b/movetest.d
@@ -1,38 +1,40 @@
+@safe pure nothrow @nogc:
+
 struct S {
     int x;
     this(int x) @safe pure nothrow @nogc { this.x = x; }
     ~this() @safe pure nothrow @nogc {}
 }
 
-void moveOnAssign1(S s) @safe pure nothrow @nogc {
+void moveOnAssign1(S s) {
     S t = s;                    // `s` is moved
 }
-void moveOnAssign2(S s) @safe pure nothrow @nogc {
+void moveOnAssign2(S s) {
     S t = s;                    // `s` is moved
     S u = t;                    // TODO: `t` should move here
 }
 
-void moveOnCall1(S s) @safe pure nothrow @nogc {
+void moveOnCall1(S s) {
     static f(S s) {}
     f(s);                       // TODO: `s` should move here
 }
 
 struct S2 { @disable this(this); }
 version(none)
-void moveOnDisabledPostblit(S2 s) @safe pure nothrow @nogc {
+void moveOnDisabledPostblit(S2 s) {
     S2 t = s;                   // TODO: should not error and `s` is moved
 }
 
-void moveOff(S s) @safe pure nothrow @nogc {
+void moveOff(S s) {
     S t = s;                    // `s` is not moved here because
     s.x = 42;                   // `s` is referenced in another type of Expression here
 }
 
-S moveOnReturn1(S s) @safe pure nothrow @nogc {
+S moveOnReturn1(S s) {
     return s;                   // TODO: should move
 }
 
-S moveOnReturn2(S s) @safe pure nothrow @nogc {
+S moveOnReturn2(S s) {
     S t = s;
     return t;                   // TODO: should move
 }

--- a/movetest.d
+++ b/movetest.d
@@ -2,6 +2,7 @@ struct S {
     int x;
     this(int x) @safe pure nothrow @nogc { this.x = x; }
     ~this() @safe pure nothrow @nogc {}
+    // TODO: enable when Errors are avoided @disable this(this);
 }
 
 void moveOnAssign1(S s) @safe pure nothrow @nogc {

--- a/movetest.d
+++ b/movetest.d
@@ -26,3 +26,12 @@ void moveOff(S s) @safe pure nothrow @nogc {
     S t = s;                    // `s` is not moved here because
     s.x = 42;                   // `s` is referenced in another type of Expression here
 }
+
+S moveOnReturn1(S s) @safe pure nothrow @nogc {
+    return s;                   // TODO: should move
+}
+
+S moveOnReturn2(S s) @safe pure nothrow @nogc {
+    S t = s;
+    return t;                   // TODO: should move
+}

--- a/movetest.d
+++ b/movetest.d
@@ -1,0 +1,25 @@
+struct S
+{
+    int x;
+    ~this() @safe pure nothrow @nogc
+    {
+        // import std.stdio;
+        // debug writeln(__FUNCTION__);
+    }
+}
+
+void moveOnAssign1(S s) @safe pure nothrow @nogc
+{
+    S t = s; // s is moved here and t i
+}
+
+void moveOnAssign2(S s) @safe pure nothrow @nogc
+{
+    S t = s; // s is moved here and t i
+}
+
+void moveOff(S s) @safe pure nothrow @nogc
+{
+    S t = s; // is not moved here because
+    s.x = 42; // it's reference here
+}

--- a/movetest.d
+++ b/movetest.d
@@ -5,13 +5,21 @@ struct SYZ {
     // TODO: enable when Errors are avoided @disable this(this);
 }
 
+SYZ moveOnReturn1(SYZ s) @safe pure nothrow @nogc {
+    return s;                   // TODO: should move
+}
+// SYZ moveOnReturn2(SYZ s) @safe pure nothrow @nogc {
+//     SYZ t = s;
+//     return t;                   // TODO: should move
+// }
+
 // void moveOnAssign0() @safe pure nothrow @nogc {
 //     SYZ s;
 //     SYZ t = s;                    // TODO: `s` should move here
 // }
-// void moveOnAssign1(SYZ s) @safe pure nothrow @nogc {
-//     SYZ t = s;                    // `s` is moved
-// }
+void moveOnAssign1(SYZ s) @safe pure nothrow @nogc {
+    SYZ t = s;                    // `s` is moved
+}
 // void moveOnAssign2(SYZ s) @safe pure nothrow @nogc {
 //     SYZ t = s;                    // `s` is moved
 //     SYZ u = t;                    // TODO: `t` should move here
@@ -31,13 +39,4 @@ struct SYZ {
 // void moveOff(SYZ s) @safe pure nothrow @nogc {
 //     SYZ t = s;                    // `s` is not moved here because
 //     s.x = 42;                   // `s` is referenced in another type of Expression here
-// }
-
-SYZ moveOnReturn1(SYZ s) @safe pure nothrow @nogc {
-    return s;                   // TODO: should move
-}
-
-// SYZ moveOnReturn2(SYZ s) @safe pure nothrow @nogc {
-//     SYZ t = s;
-//     return t;                   // TODO: should move
 // }

--- a/movetest.d
+++ b/movetest.d
@@ -1,43 +1,43 @@
-struct S {
+struct SYZ {
     int x;
     this(int x) @safe pure nothrow @nogc { this.x = x; }
     ~this() @safe pure nothrow @nogc {}
     // TODO: enable when Errors are avoided @disable this(this);
 }
 
-void moveOnAssign0() @safe pure nothrow @nogc {
-    S s;
-    S t = s;                    // TODO: `s` should move here
+// void moveOnAssign0() @safe pure nothrow @nogc {
+//     SYZ s;
+//     SYZ t = s;                    // TODO: `s` should move here
+// }
+void moveOnAssign1(SYZ s) @safe pure nothrow @nogc {
+    SYZ t = s;                    // `s` is moved
 }
-void moveOnAssign1(S s) @safe pure nothrow @nogc {
-    S t = s;                    // `s` is moved
-}
-void moveOnAssign2(S s) @safe pure nothrow @nogc {
-    S t = s;                    // `s` is moved
-    S u = t;                    // TODO: `t` should move here
-}
+// void moveOnAssign2(SYZ s) @safe pure nothrow @nogc {
+//     SYZ t = s;                    // `s` is moved
+//     SYZ u = t;                    // TODO: `t` should move here
+// }
 
-void moveOnCall1(S s) @safe pure nothrow @nogc {
-    static f(S s) {}
-    f(s);                       // TODO: `s` should move here
-}
+// void moveOnCall1(SYZ s) @safe pure nothrow @nogc {
+//     static f(SYZ s) {}
+//     f(s);                       // TODO: `s` should move here
+// }
 
-struct S2 { @disable this(this); }
-version(none)
-void moveOnDisabledPostblit(S2 s) @safe pure nothrow @nogc {
-    S2 t = s;                   // TODO: should not error and `s` is moved
-}
+// struct S2 { @disable this(this); }
+// version(none)
+// void moveOnDisabledPostblit(S2 s) @safe pure nothrow @nogc {
+//     S2 t = s;                   // TODO: should not error and `s` is moved
+// }
 
-void moveOff(S s) @safe pure nothrow @nogc {
-    S t = s;                    // `s` is not moved here because
-    s.x = 42;                   // `s` is referenced in another type of Expression here
-}
+// void moveOff(SYZ s) @safe pure nothrow @nogc {
+//     SYZ t = s;                    // `s` is not moved here because
+//     s.x = 42;                   // `s` is referenced in another type of Expression here
+// }
 
-S moveOnReturn1(S s) @safe pure nothrow @nogc {
-    return s;                   // TODO: should move
-}
+// SYZ moveOnReturn1(SYZ s) @safe pure nothrow @nogc {
+//     return s;                   // TODO: should move
+// }
 
-S moveOnReturn2(S s) @safe pure nothrow @nogc {
-    S t = s;
-    return t;                   // TODO: should move
-}
+// SYZ moveOnReturn2(SYZ s) @safe pure nothrow @nogc {
+//     SYZ t = s;
+//     return t;                   // TODO: should move
+// }

--- a/movetest.d
+++ b/movetest.d
@@ -1,42 +1,42 @@
 struct SYZ {
     int x;
-    this(int x) @safe pure nothrow @nogc { this.x = x; }
-    ~this() @safe pure nothrow @nogc {}
-    // TODO: enable when Errors are avoided @disable this(this);
+    this(int x) { this.x = x; }
+    ~this() {}
+    // @disable this(this);
 }
 
-SYZ moveOnReturn1(SYZ s) @safe pure nothrow @nogc {
+SYZ moveOnReturn1(SYZ s) {
     return s;                   // TODO: should move
 }
-// SYZ moveOnReturn2(SYZ s) @safe pure nothrow @nogc {
+// SYZ moveOnReturn2(SYZ s) {
 //     SYZ t = s;
 //     return t;                   // TODO: should move
 // }
 
-// void moveOnAssign0() @safe pure nothrow @nogc {
+// void moveOnAssign0() {
 //     SYZ s;
 //     SYZ t = s;                    // TODO: `s` should move here
 // }
-void moveOnAssign1(SYZ s) @safe pure nothrow @nogc {
+void moveOnAssign1(SYZ s) {
     SYZ t = s;                    // `s` is moved
 }
-// void moveOnAssign2(SYZ s) @safe pure nothrow @nogc {
+// void moveOnAssign2(SYZ s) {
 //     SYZ t = s;                    // `s` is moved
 //     SYZ u = t;                    // TODO: `t` should move here
 // }
 
-// void moveOnCall1(SYZ s) @safe pure nothrow @nogc {
+// void moveOnCall1(SYZ s) {
 //     static f(SYZ s) {}
 //     f(s);                       // TODO: `s` should move here
 // }
 
 // struct S2 { @disable this(this); }
 // version(none)
-// void moveOnDisabledPostblit(S2 s) @safe pure nothrow @nogc {
+// void moveOnDisabledPostblit(S2 s) {
 //     S2 t = s;                   // TODO: should not error and `s` is moved
 // }
 
-// void moveOff(SYZ s) @safe pure nothrow @nogc {
+// void moveOff(SYZ s) {
 //     SYZ t = s;                    // `s` is not moved here because
 //     s.x = 42;                   // `s` is referenced in another type of Expression here
 // }

--- a/movetest.d
+++ b/movetest.d
@@ -8,12 +8,12 @@ void moveOnAssign1(S s) @safe pure nothrow @nogc {
 }
 void moveOnAssign2(S s) @safe pure nothrow @nogc {
     S t = s;                    // `s` is moved
-    S u = t;                    // TODO: t should move here
+    S u = t;                    // TODO: `t` should move here
 }
 
 void moveOnCall1(S s) @safe pure nothrow @nogc {
     static f(S s) {}
-    f(s);                       // `s` is moved
+    f(s);                       // TODO: `s` should move here
 }
 
 struct S2 { @disable this(this); }

--- a/movetest.d
+++ b/movetest.d
@@ -5,6 +5,10 @@ struct S {
     // TODO: enable when Errors are avoided @disable this(this);
 }
 
+void moveOnAssign0() @safe pure nothrow @nogc {
+    S s;
+    S t = s;                    // TODO: `s` should move here
+}
 void moveOnAssign1(S s) @safe pure nothrow @nogc {
     S t = s;                    // `s` is moved
 }

--- a/movetest.d
+++ b/movetest.d
@@ -4,19 +4,25 @@ struct S {
 }
 
 void moveOnAssign1(S s) @safe pure nothrow @nogc {
-    S t = s;                    // s is moved
+    S t = s;                    // `s` is moved
 }
 void moveOnAssign2(S s) @safe pure nothrow @nogc {
-    S t = s;                    // s is moved
+    S t = s;                    // `s` is moved
     S u = t;                    // TODO: t should move here
 }
 
+void moveOnCall1(S s) @safe pure nothrow @nogc {
+    static f(S s) {}
+    f(s);                       // `s` is moved
+}
+
 struct S2 { @disable this(this); }
+version(none)
 void moveOnDisabledPostblit(S2 s) @safe pure nothrow @nogc {
-    S2 t = s;                   // TODO: should not error and s is moved
+    S2 t = s;                   // TODO: should not error and `s` is moved
 }
 
 void moveOff(S s) @safe pure nothrow @nogc {
-    S t = s; // is not moved here because
-    s.x = 42; // it's referenced here
+    S t = s;                    // `s` is not moved here because
+    s.x = 42;                   // `s` is referenced in another type of Expression here
 }

--- a/movetest.d
+++ b/movetest.d
@@ -2,7 +2,7 @@ struct SYZ {
     int x;
     this(int x) { this.x = x; }
     ~this() {}
-    @disable this(this);
+    // @disable this(this);
 }
 
 SYZ moveOnReturn1(SYZ s) {

--- a/movetest.d
+++ b/movetest.d
@@ -10,12 +10,13 @@ struct S
 
 void moveOnAssign1(S s) @safe pure nothrow @nogc
 {
-    S t = s; // s is moved here and t i
+    S t = s;                    // s is moved
 }
 
 void moveOnAssign2(S s) @safe pure nothrow @nogc
 {
-    S t = s; // s is moved here and t i
+    S t = s;                    // s is moved
+    S u = t;                    // TODO: t should move here
 }
 
 void moveOff(S s) @safe pure nothrow @nogc

--- a/movetest.d
+++ b/movetest.d
@@ -2,7 +2,7 @@ struct SYZ {
     int x;
     this(int x) { this.x = x; }
     ~this() {}
-    // @disable this(this);
+    @disable this(this);
 }
 
 SYZ moveOnReturn1(SYZ s) {
@@ -17,8 +17,12 @@ SYZ moveOnReturn1(SYZ s) {
 //     SYZ s;
 //     SYZ t = s;                    // TODO: `s` should move here
 // }
-void moveOnAssign1(SYZ s) {
+void moveOnAssign1a(SYZ s) {
     SYZ t = s;                    // `s` is moved
+}
+void moveOnAssign1b(SYZ s) {
+    SYZ t = s;                    // `s` is moved
+    return t;                     // `t` is moved
 }
 // void moveOnAssign2(SYZ s) {
 //     SYZ t = s;                    // `s` is moved

--- a/movetest.d
+++ b/movetest.d
@@ -1,40 +1,38 @@
-@safe pure nothrow @nogc:
-
 struct S {
     int x;
     this(int x) @safe pure nothrow @nogc { this.x = x; }
     ~this() @safe pure nothrow @nogc {}
 }
 
-void moveOnAssign1(S s) {
+void moveOnAssign1(S s) @safe pure nothrow @nogc {
     S t = s;                    // `s` is moved
 }
-void moveOnAssign2(S s) {
+void moveOnAssign2(S s) @safe pure nothrow @nogc {
     S t = s;                    // `s` is moved
     S u = t;                    // TODO: `t` should move here
 }
 
-void moveOnCall1(S s) {
+void moveOnCall1(S s) @safe pure nothrow @nogc {
     static f(S s) {}
     f(s);                       // TODO: `s` should move here
 }
 
 struct S2 { @disable this(this); }
 version(none)
-void moveOnDisabledPostblit(S2 s) {
+void moveOnDisabledPostblit(S2 s) @safe pure nothrow @nogc {
     S2 t = s;                   // TODO: should not error and `s` is moved
 }
 
-void moveOff(S s) {
+void moveOff(S s) @safe pure nothrow @nogc {
     S t = s;                    // `s` is not moved here because
     s.x = 42;                   // `s` is referenced in another type of Expression here
 }
 
-S moveOnReturn1(S s) {
+S moveOnReturn1(S s) @safe pure nothrow @nogc {
     return s;                   // TODO: should move
 }
 
-S moveOnReturn2(S s) {
+S moveOnReturn2(S s) @safe pure nothrow @nogc {
     S t = s;
     return t;                   // TODO: should move
 }

--- a/movetest.d
+++ b/movetest.d
@@ -1,26 +1,22 @@
-struct S
-{
+struct S {
     int x;
-    ~this() @safe pure nothrow @nogc
-    {
-        // import std.stdio;
-        // debug writeln(__FUNCTION__);
-    }
+    ~this() @safe pure nothrow @nogc {}
 }
 
-void moveOnAssign1(S s) @safe pure nothrow @nogc
-{
+void moveOnAssign1(S s) @safe pure nothrow @nogc {
     S t = s;                    // s is moved
 }
-
-void moveOnAssign2(S s) @safe pure nothrow @nogc
-{
+void moveOnAssign2(S s) @safe pure nothrow @nogc {
     S t = s;                    // s is moved
     S u = t;                    // TODO: t should move here
 }
 
-void moveOff(S s) @safe pure nothrow @nogc
-{
+struct S2 { @disable this(this); }
+void moveOnDisabledPostblit(S2 s) @safe pure nothrow @nogc {
+    S2 t = s;                   // TODO: should not error and s is moved
+}
+
+void moveOff(S s) @safe pure nothrow @nogc {
     S t = s; // is not moved here because
     s.x = 42; // it's reference here
 }

--- a/movetest.d
+++ b/movetest.d
@@ -9,9 +9,9 @@ struct SYZ {
 //     SYZ s;
 //     SYZ t = s;                    // TODO: `s` should move here
 // }
-void moveOnAssign1(SYZ s) @safe pure nothrow @nogc {
-    SYZ t = s;                    // `s` is moved
-}
+// void moveOnAssign1(SYZ s) @safe pure nothrow @nogc {
+//     SYZ t = s;                    // `s` is moved
+// }
 // void moveOnAssign2(SYZ s) @safe pure nothrow @nogc {
 //     SYZ t = s;                    // `s` is moved
 //     SYZ u = t;                    // TODO: `t` should move here
@@ -33,9 +33,9 @@ void moveOnAssign1(SYZ s) @safe pure nothrow @nogc {
 //     s.x = 42;                   // `s` is referenced in another type of Expression here
 // }
 
-// SYZ moveOnReturn1(SYZ s) @safe pure nothrow @nogc {
-//     return s;                   // TODO: should move
-// }
+SYZ moveOnReturn1(SYZ s) @safe pure nothrow @nogc {
+    return s;                   // TODO: should move
+}
 
 // SYZ moveOnReturn2(SYZ s) @safe pure nothrow @nogc {
 //     SYZ t = s;

--- a/movetest.d
+++ b/movetest.d
@@ -18,5 +18,5 @@ void moveOnDisabledPostblit(S2 s) @safe pure nothrow @nogc {
 
 void moveOff(S s) @safe pure nothrow @nogc {
     S t = s; // is not moved here because
-    s.x = 42; // it's reference here
+    s.x = 42; // it's referenced here
 }


### PR DESCRIPTION
This enable automatic move of last occurrence of an l-value struct instance in a VarExp when occurring 

1. as a right-hand-side `VarExp` of an `AssignExp`
2. as a value-passed `Parameter`
3. as the single `VarExpr` of a `ReturnStatement`
4. ...

It took me and @UplinkCoder about 2-3 hours online to accomplish this. Superb cooperation.

Hopefully this will make https://github.com/dlang/phobos/pull/8537 unnecessary.

C++23 is going in that direction aswell - see https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2266r3.html.

TODOs:

- [ ] Discuss if it's ok to add `VarExp lastVarExp` and `bool lastVarExpCanBeMoved` to VarDeclaration or if should go with a much smaller number of cases that can be handled typically
  1. `return VarExp`
  2. ... = VarExp; being the last statement in the scope of `VarExp`
- [ ] Check for move in `return VarExp` _after the corresponding `VarDeclaration` has been resolved. Use `asm { int 3; }` where VarDeclaration is resolved and continue in gdb.
- [ ] Handle `ReturnStatement` case as well. If scope of `ReturnStatement` matches that of `VariableDeclaration` of `VarExp` move is unconditional. Cases to handle are:
  - [ ] `return X` where `X` is `VarExp`
  - [ ] `return f(Xs...)` for all `X` in `Xs` being a `VarExpr`
  - [ ] `return P ? X : Y`
  All these cases are easiest handled with an extra state in visitor keeping track of current `ReturnStatement` (if any).
- [ ] Should move structs with disabled copy constructor (`moveOnDisabledPostblit` in added test file `movetest.d` should pass)
- [ ] Test that copy constructors are correctly avoided aswell in assignments
- [ ] Test that structs with `@disable this(this)` are allowed in the three cases outline above
- [ ] Handle if-statements and other branching structures.
- [ ] Limit moves to when scope of `VarDeclaration` equals scope of `VarExp`.
- [ ] Check if `opPostMove` needs to be taken into consideration here
- [ ] Regenerate C++ headers
- [ ] Update tests now that compiler optimizes avoid away more copy constructor and destructor calls and potentially inserts calls to `opPostMove`.
- [ ] Adjust TODO comments added
- [ ] Discuss if an alternatie solution avoiding extra state in `VarDeclaration` in favor of extra state in `SemanticTimeVisitor` is preferred.
- [ ] Close https://github.com/dlang/phobos/pull/8537 as doesn't need fix
- [ ] Add warning diagnostics about unnecessary calls to `core.lifetime.move`
- [ ] Remove all other calls to `move()` and `std.forward` that are no longer neccessary.

Current simple test

```sh
make -f posix.mak; generated/linux/release/64/dmd -vcg-ast -c ~/movetest.d
```

where `movetest.d` is

```d
struct S
{
    int x;
    ~this() @safe pure nothrow @nogc
    {
        import std.stdio;
        debug writeln(__FUNCTION__);
    }
}

void moveOn(S s) @safe pure nothrow @nogc
{
    S t = s; // s is moved here and t i
}

void moveOff(S s) @safe pure nothrow @nogc
{
    S t = s; // is not moved here because
    s.x = 42; // it's reference here
}
```

correctly outputs

```d
import object;
struct S
{
	int x;
	~this()
	{
	}
	alias __xdtor = ~this()
	{
	}
	;
	pure nothrow @nogc ref @trusted S opAssign(S p) return
	{
		(S __swap2 = void;) , __swap2 = this , (this = p , __swap2.~this());
		return this;
	}
}
pure nothrow @nogc @safe void moveOn(S s)
{
	S t = s;
	t.~this();
}
pure nothrow @nogc @safe void moveOff(S s)
{
	S t = s;
	s.x = 42;
	t.~this();
	s.~this();
}
RTInfo!(S)
{
	enum immutable(void)* RTInfo = null;

}
NoPointersBitmapPayload!1LU
{
	enum ulong[1] NoPointersBitmapPayload = [0LU];

}
```

FYI, @maxhaton @atilaneves @andralex @WalterBright.