### PR TITLE
Fix Issue 23302 - std.algorithm.comparison.predSwitch producing SwitchError with error message as the filename

### DIFF
--- a/druntime/src/core/exception.d
+++ b/druntime/src/core/exception.d
@@ -14,7 +14,7 @@ void __switch_errorT()(string file = __FILE__, size_t line = __LINE__) @trusted
 {
     // Consider making this a compile time check.
     version (D_Exceptions)
-        throw staticError!SwitchError(file, line, null);
+        throw staticError!SwitchError("No appropriate switch clause found", file, line, null);
     else
         assert(0, "No appropriate switch clause found");
 }
@@ -446,16 +446,16 @@ class ForkError : Error
  */
 class SwitchError : Error
 {
-    @safe pure nothrow @nogc this( string file = __FILE__, size_t line = __LINE__, Throwable next = null )
+    @safe pure nothrow @nogc this( string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null )
     {
-        super( "No appropriate switch clause found", file, line, next );
+        super( msg, file, line, next );
     }
 }
 
 unittest
 {
     {
-        auto se = new SwitchError();
+        auto se = new SwitchError("No appropriate switch clause found");
         assert(se.file == __FILE__);
         assert(se.line == __LINE__ - 2);
         assert(se.next is null);
@@ -463,7 +463,7 @@ unittest
     }
 
     {
-        auto se = new SwitchError("hello", 42, new Exception("It's an Exception!"));
+        auto se = new SwitchError("No appropriate switch clause found", "hello", 42, new Exception("It's an Exception!"));
         assert(se.file == "hello");
         assert(se.line == 42);
         assert(se.next !is null);


### PR DESCRIPTION
This theoretically modifies the user facing API, however, I would argue that `SwitchError` was designed for internal use. If anyone has used it in the wild, chances are it was wrongfully used (as we do in phobos). I don't think this requires a changelog entry, or a deprecation.