### PR TITLE
Trivial: Remove redundant if clause in opover

### DIFF
--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1247,13 +1247,10 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                 args2[0] = e.e2;
                 expandTuples(&args2);
                 MatchAccumulator m;
-                if (s)
+                functionResolve(m, s, e.loc, sc, tiargs, e.e1.type, &args2);
+                if (m.lastf && (m.lastf.errors || m.lastf.hasSemantic3Errors()))
                 {
-                    functionResolve(m, s, e.loc, sc, tiargs, e.e1.type, &args2);
-                    if (m.lastf && (m.lastf.errors || m.lastf.hasSemantic3Errors()))
-                    {
-                        return ErrorExp.get();
-                    }
+                    return ErrorExp.get();
                 }
                 if (m.count > 1)
                 {


### PR DESCRIPTION
Since 's' is not set in between the first and second if,
the second one will always be true.