### PR TITLE
Trivial: Remove some superfluous Array.setDim calls

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -967,8 +967,7 @@ struct ASTBase
             Objects* a = null;
             if (objs)
             {
-                a = new Objects();
-                a.setDim(objs.dim);
+                a = new Objects(objs.dim);
                 for (size_t i = 0; i < objs.dim; i++)
                     (*a)[i] = objectSyntaxCopy((*objs)[i]);
             }
@@ -1750,8 +1749,7 @@ struct ASTBase
             Parameters* params = null;
             if (parameters)
             {
-                params = new Parameters();
-                params.setDim(parameters.dim);
+                params = new Parameters(parameters.dim);
                 for (size_t i = 0; i < params.dim; i++)
                     (*params)[i] = (*parameters)[i].syntaxCopy();
             }
@@ -3618,10 +3616,9 @@ struct ASTBase
         extern (D) this(Expressions* exps)
         {
             super(Ttuple);
-            auto arguments = new Parameters();
+            auto arguments = new Parameters(exps ? exps.dim : 0);
             if (exps)
             {
-                arguments.setDim(exps.dim);
                 for (size_t i = 0; i < exps.dim; i++)
                 {
                     Expression e = (*exps)[i];
@@ -5389,20 +5386,16 @@ struct ASTBase
         extern (D) this(const ref Loc loc, Expression e, Expression earg1)
         {
             super(loc, EXP.call, __traits(classInstanceSize, CallExp), e);
-            auto arguments = new Expressions();
+            auto arguments = new Expressions(earg1 ? 1 : 0);
             if (earg1)
-            {
-                arguments.setDim(1);
                 (*arguments)[0] = earg1;
-            }
             this.arguments = arguments;
         }
 
         extern (D) this(const ref Loc loc, Expression e, Expression earg1, Expression earg2)
         {
             super(loc, EXP.call, __traits(classInstanceSize, CallExp), e);
-            auto arguments = new Expressions();
-            arguments.setDim(2);
+            auto arguments = new Expressions(2);
             (*arguments)[0] = earg1;
             (*arguments)[1] = earg2;
             this.arguments = arguments;

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -105,8 +105,7 @@ FuncDeclaration hasIdentityOpAssign(AggregateDeclaration ad, Scope* sc)
         scope er = new NullExp(ad.loc, ad.type);    // dummy rvalue
         scope el = new IdentifierExp(ad.loc, Id.p); // dummy lvalue
         el.type = ad.type;
-        Expressions a;
-        a.setDim(1);
+        auto a = Expressions(1);
         const errors = global.startGagging(); // Do not report errors, even if the template opAssign fbody makes it.
         sc = sc.push();
         sc.tinst = null;
@@ -465,8 +464,7 @@ private FuncDeclaration hasIdentityOpEquals(AggregateDeclaration ad, Scope* sc)
          */
         scope er = new NullExp(ad.loc, null); // dummy rvalue
         scope el = new IdentifierExp(ad.loc, Id.p); // dummy lvalue
-        Expressions a;
-        a.setDim(1);
+        auto a = Expressions(1);
 
         bool hasIt(Type tthis)
         {

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -2603,7 +2603,6 @@ final class CParser(AST) : Parser!AST
     {
         //printf("cparseDeclarator(%d, %p)\n", declarator, t);
         AST.Types constTypes; // all the Types that will need `const` applied to them
-        constTypes.setDim(0);
 
         AST.Type parseDecl(AST.Type t)
         {

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -1327,7 +1327,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         Loc instLoc = ti.loc;
         Objects* tiargs = ti.tiargs;
-        auto dedargs = new Objects();
+        auto dedargs = new Objects(parameters.dim);
         Objects* dedtypes = &ti.tdtypes; // for T:T*, the dedargs is the T*, dedtypes is the T
 
         version (none)
@@ -1346,7 +1346,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         assert(_scope);
 
-        dedargs.setDim(parameters.dim);
         dedargs.zero();
 
         dedtypes.setDim(parameters.dim);

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -6355,10 +6355,9 @@ extern (C++) final class TypeTuple : Type
     extern (D) this(Expressions* exps)
     {
         super(Ttuple);
-        auto arguments = new Parameters();
+        auto arguments = new Parameters(exps ? exps.dim : 0);
         if (exps)
         {
-            arguments.setDim(exps.dim);
             for (size_t i = 0; i < exps.dim; i++)
             {
                 Expression e = (*exps)[i];

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -97,8 +97,7 @@ extern (C++) void Initializer_toDt(Initializer init, ref DtBuilder dtb, bool isC
         Type tn = tb.nextOf().toBasetype();
 
         //printf("\tdim = %d\n", ai.dim);
-        Dts dts;
-        dts.setDim(ai.dim);
+        Dts dts = Dts(ai.dim);
         dts.zero();
 
         uint size = cast(uint)tn.size();


### PR DESCRIPTION
Use the constructor instead.