### PR TITLE
Use more slices in transitivevisitors

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7961,7 +7961,6 @@ public:
     void visit(ForeachRangeStatement* s) override;
     void visit(IfStatement* s) override;
     void visit(ConditionalStatement* s) override;
-    virtual void visitArgs(Array<Expression* >* expressions, Expression* basis = nullptr);
     void visit(PragmaStatement* s) override;
     void visit(StaticAssertStatement* s) override;
     void visit(SwitchStatement* s) override;
@@ -7981,7 +7980,6 @@ public:
     virtual void visit(Catch* c);
     virtual void visitType(Type* t);
     virtual void visitFunctionType(TypeFunction* t, TemplateDeclaration* td);
-    virtual void visitParameters(Array<Parameter* >* parameters);
     void visit(TypeVector* t) override;
     void visit(TypeSArray* t) override;
     void visit(TypeDArray* t) override;

--- a/compiler/src/dmd/transitivevisitor.d
+++ b/compiler/src/dmd/transitivevisitor.d
@@ -28,6 +28,7 @@ extern(C++) class ParseTimeTransitiveVisitor(AST) : PermissiveVisitor!AST
  */
 package mixin template ParseVisitMethods(AST)
 {
+    import dmd.root.array;
 
 //   Statement Nodes
 //===========================================================
@@ -46,7 +47,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.CompileStatement s)
     {
         //printf("Visiting CompileStatement\n");
-        visitArgs(s.exps);
+        visitArgs(s.exps.peekSlice());
     }
 
     override void visit(AST.CompoundStatement s)
@@ -181,11 +182,9 @@ package mixin template ParseVisitMethods(AST)
             s.elsebody.accept(this);
     }
 
-    void visitArgs(AST.Expressions* expressions, AST.Expression basis = null)
+    private extern(D) void visitArgs(AST.Expression[] expressions, AST.Expression basis = null)
     {
-        if (!expressions || !expressions.dim)
-            return;
-        foreach (el; *expressions)
+        foreach (el; expressions)
         {
             if (!el)
                 el = basis;
@@ -197,8 +196,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.PragmaStatement s)
     {
         //printf("Visiting PragmaStatement\n");
-        if (s.args && s.args.dim)
-            visitArgs(s.args);
+        visitArgs(s.args.peekSlice());
         if (s._body)
             s._body.accept(this);
     }
@@ -346,19 +344,14 @@ package mixin template ParseVisitMethods(AST)
             foreach (p; *td.origParameters)
                 p.accept(this);
         }
-        visitParameters(t.parameterList.parameters);
+        visitParameters(t.parameterList.parameters.peekSlice());
     }
 
-    void visitParameters(AST.Parameters* parameters)
+    private extern(D) final void visitParameters(AST.Parameter[] parameters)
     {
-        if (parameters)
+        foreach (i; 0 .. parameters.length)
         {
-            size_t dim = AST.Parameter.dim(parameters);
-            foreach(i; 0..dim)
-            {
-                AST.Parameter fparam = AST.Parameter.getNth(parameters, i);
-                fparam.accept(this);
-            }
+            parameters[i].accept(this);
         }
     }
 
@@ -469,7 +462,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.TypeTuple t)
     {
         //printf("Visiting TypeTuple\n");
-        visitParameters(t.arguments);
+        visitParameters(t.arguments.peekSlice());
     }
 
     override void visit(AST.TypeSlice t)
@@ -487,7 +480,7 @@ package mixin template ParseVisitMethods(AST)
 
     override void visit(AST.TypeMixin t)
     {
-        visitArgs(t.exps);
+        visitArgs(t.exps.peekSlice());
     }
 
 //      Miscellaneous
@@ -571,8 +564,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.PragmaDeclaration d)
     {
         //printf("Visiting PragmaDeclaration\n");
-        if (d.args && d.args.dim)
-            visitArgs(d.args);
+        visitArgs(d.args.peekSlice());
         visitAttribDeclaration(cast(AST.AttribDeclaration)d);
     }
 
@@ -580,24 +572,22 @@ package mixin template ParseVisitMethods(AST)
     {
         //printf("Visiting ConditionalDeclaration\n");
         d.condition.accept(this);
-        if (d.decl)
-            foreach (de; *d.decl)
-                de.accept(this);
-        if (d.elsedecl)
-            foreach (de; *d.elsedecl)
-                de.accept(this);
+        foreach (de; d.decl.peekSlice())
+            de.accept(this);
+        foreach (de; d.elsedecl.peekSlice())
+            de.accept(this);
     }
 
     override void visit(AST.CompileDeclaration d)
     {
         //printf("Visiting compileDeclaration\n");
-        visitArgs(d.exps);
+        visitArgs(d.exps.peekSlice());
     }
 
     override void visit(AST.UserAttributeDeclaration d)
     {
         //printf("Visiting UserAttributeDeclaration\n");
-        visitArgs(d.atts);
+        visitArgs(d.atts.peekSlice());
         visitAttribDeclaration(cast(AST.AttribDeclaration)d);
     }
 
@@ -840,7 +830,7 @@ package mixin template ParseVisitMethods(AST)
         auto tf = f.type.isTypeFunction();
         if (!f.inferRetType && tf.next)
             visitType(tf.next);
-        visitParameters(tf.parameterList.parameters);
+        visitParameters(tf.parameterList.parameters.peekSlice());
         AST.CompoundStatement cs = f.fbody.isCompoundStatement();
         AST.Statement s = !cs ? f.fbody : null;
         AST.ReturnStatement rs = s ? s.isReturnStatement() : null;
@@ -946,7 +936,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.ArrayLiteralExp e)
     {
         //printf("Visiting ArrayLiteralExp\n");
-        visitArgs(e.elements, e.basis);
+        visitArgs(e.elements.peekSlice(), e.basis);
     }
 
     override void visit(AST.AssocArrayLiteralExp e)
@@ -978,8 +968,7 @@ package mixin template ParseVisitMethods(AST)
         if (e.thisexp)
             e.thisexp.accept(this);
         visitType(e.newtype);
-        if (e.arguments && e.arguments.dim)
-            visitArgs(e.arguments);
+        visitArgs(e.arguments.peekSlice());
     }
 
     override void visit(AST.NewAnonClassExp e)
@@ -987,8 +976,7 @@ package mixin template ParseVisitMethods(AST)
         //printf("Visiting NewAnonClassExp\n");
         if (e.thisexp)
             e.thisexp.accept(this);
-        if (e.arguments && e.arguments.dim)
-            visitArgs(e.arguments);
+        visitArgs(e.arguments.peekSlice());
         if (e.cd)
             e.cd.accept(this);
     }
@@ -998,7 +986,7 @@ package mixin template ParseVisitMethods(AST)
         //printf("Visiting TupleExp\n");
         if (e.e0)
             e.e0.accept(this);
-        visitArgs(e.exps);
+        visitArgs(e.exps.peekSlice());
     }
 
     override void visit(AST.FuncExp e)
@@ -1056,7 +1044,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.MixinExp e)
     {
         //printf("Visiting MixinExp\n");
-        visitArgs(e.exps);
+        visitArgs(e.exps.peekSlice());
     }
 
     override void visit(AST.ImportExp e)
@@ -1090,7 +1078,7 @@ package mixin template ParseVisitMethods(AST)
     {
         //printf("Visiting CallExp\n");
         e.e1.accept(this);
-        visitArgs(e.arguments);
+        visitArgs(e.arguments.peekSlice());
     }
 
     override void visit(AST.PtrExp e)
@@ -1124,7 +1112,7 @@ package mixin template ParseVisitMethods(AST)
     {
         //printf("Visiting ArrayExp\n");
         e.e1.accept(this);
-        visitArgs(e.arguments);
+        visitArgs(e.arguments.peekSlice());
     }
 
     override void visit(AST.PostExp e)


### PR DESCRIPTION
Because null checks are so 2010s.