### PR TITLE
fix Issue 22977 - [dip1000] can escape scope pointer returned by nest…

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -1270,6 +1270,22 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
             continue;
         }
 
+        if (p != sc.func &&     // v is in the scope of an enclosing function
+            p.isFuncDeclaration() &&
+            v.isScope() &&
+            !sc.func.vthis.doNotInferReturn &&
+            sc.func.flags & FUNCFLAG.returnInprocess)
+        {
+            if (auto tf = sc.func.type.isTypeFunction())
+            {
+                sc.func.storage_class |= STC.return_ | STC.returninferred | STC.returnScope;
+                tf.isreturnscope = true;
+                tf.isreturn = true;
+                tf.isreturninferred = true;
+            }
+            continue;
+        }
+
         if (v.isScope())
         {
             /* If `return scope` applies to v.

--- a/compiler/test/fail_compilation/test22977.d
+++ b/compiler/test/fail_compilation/test22977.d
@@ -1,0 +1,19 @@
+/* REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test22977.d(107): Error: reference to stack allocated value returned by `fn()` assigned to non-scope `gPtr`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22977
+
+#line 100
+
+int* gPtr;
+
+void test() @safe
+{
+    scope int* sPtr;
+    int* fn() { return sPtr; }
+    gPtr = fn();
+}


### PR DESCRIPTION
…ed function

See also @dkorpel 's fix https://github.com/dlang/dmd/pull/14236