### PR TITLE
fix Issue 22680 - @safe hole with destructors

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4183,6 +4183,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dd.errors = true;
             return;
         }
+
+        if (ad.isClassDeclaration() && ad.classKind == ClassKind.d)
+        {
+            // Class destructors are implicitly `scope`
+            dd.storage_class |= STC.scope_;
+        }
+
         if (dd.ident == Id.dtor && dd.semanticRun < PASS.semantic)
             ad.userDtors.push(dd);
         if (!dd.type)

--- a/compiler/test/compilable/extra-files/json.json
+++ b/compiler/test/compilable/extra-files/json.json
@@ -337,7 +337,10 @@
                         "kind": "destructor",
                         "line": 29,
                         "name": "~this",
-                        "protection": "public"
+                        "protection": "public",
+                        "storageClass": [
+                            "scope"
+                        ]
                     },
                     {
                         "char": 12,

--- a/compiler/test/fail_compilation/test22680.d
+++ b/compiler/test/fail_compilation/test22680.d
@@ -1,0 +1,17 @@
+/* REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test22680.d(104): Error: scope variable `this` assigned to non-scope `c`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22680
+
+#line 100
+
+C c;
+class C {
+    ~this() @safe {
+	    c = this;
+    }
+}


### PR DESCRIPTION
Trying this out.

Made it only for class destructors, not struct destructors, because struct `this` is passed by ref, not by pointer.