### PR TITLE
Fix Issue 23306 - @disable new() ought not disable scope A = new A

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -984,7 +984,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 // possibilities.
                 if (fd && !(dsym.storage_class & (STC.manifest | STC.static_ | STC.gshared | STC.extern_)) && !dsym._init.isVoidInitializer())
                 {
-                    //printf("fd = '%s', var = '%s'\n", fd.toChars(), toChars());
+                    //printf("fd = '%s', var = '%s'\n", fd.toChars(), dsym.toChars());
                     if (!ei)
                     {
                         ArrayInitializer ai = dsym._init.isArrayInitializer();
@@ -1015,24 +1015,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         dsym._init = dsym._init.initializerSemantic(sc, dsym.type, INITinterpret);
                     }
 
-                    Expression exp = ei.exp;
-                    Expression e1 = new VarExp(dsym.loc, dsym);
-                    if (isBlit)
-                        exp = new BlitExp(dsym.loc, e1, exp);
-                    else
-                        exp = new ConstructExp(dsym.loc, e1, exp);
-                    dsym.canassign++;
-                    exp = exp.expressionSemantic(sc);
-                    dsym.canassign--;
-                    exp = exp.optimize(WANTvalue);
-                    if (exp.op == EXP.error)
-                    {
-                        dsym._init = new ErrorInitializer();
-                        ei = null;
-                    }
-                    else
-                        ei.exp = exp;
-
                     if (ei && dsym.isScope())
                     {
                         Expression ex = ei.exp.lastComma();
@@ -1055,6 +1037,24 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                                 f.tookAddressOf--;
                         }
                     }
+
+                    Expression exp = ei.exp;
+                    Expression e1 = new VarExp(dsym.loc, dsym);
+                    if (isBlit)
+                        exp = new BlitExp(dsym.loc, e1, exp);
+                    else
+                        exp = new ConstructExp(dsym.loc, e1, exp);
+                    dsym.canassign++;
+                    exp = exp.expressionSemantic(sc);
+                    dsym.canassign--;
+                    exp = exp.optimize(WANTvalue);
+                    if (exp.op == EXP.error)
+                    {
+                        dsym._init = new ErrorInitializer();
+                        ei = null;
+                    }
+                    else
+                        ei.exp = exp;
                 }
                 else
                 {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3669,7 +3669,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
 
-            if (cd.disableNew)
+            if (cd.disableNew && !exp.onstack)
             {
                 exp.error("cannot allocate `class %s` with `new` because it is annotated with `@disable new()`",
                           originalNewtype.toChars());

--- a/compiler/test/compilable/test23306.d
+++ b/compiler/test/compilable/test23306.d
@@ -1,0 +1,7 @@
+class A {
+        @disable new();
+}
+
+void main() {
+        scope A a = new A();
+}


### PR DESCRIPTION
I only added this check for class declarations because, although allowed by the compiler, scope struct declarations that are allocated with `new` seem nonsensical.