### PR TITLE
remove the SC Enum aliases

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Removed all SC Enum aliases, which touched a ton of backend/glue files
+98a842927e4905fc2ecc0e93ffd64b5da3ebbcf2

--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -1456,7 +1456,7 @@ bool Symbol_Sisdead(const ref Symbol s, bool anyInlineAsm);
 int Symbol_needThis(const ref Symbol s);
 bool Symbol_isAffected(const ref Symbol s);
 
-bool isclassmember(const Symbol* s) { return s.Sscope && s.Sscope.Sclass == SCstruct; }
+bool isclassmember(const Symbol* s) { return s.Sscope && s.Sscope.Sclass == SC.struct_; }
 
 // Class, struct or union
 

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -974,51 +974,7 @@ enum SC : ubyte
     adl,            /// list of ADL symbols for overloading
 }
 
-enum SCunde = SC.unde;
-enum SCauto = SC.auto_;
-enum SCstatic = SC.static_;
-enum SCthread = SC.thread;
-enum SCextern = SC.extern_;
-enum SCregister = SC.register;
-enum SCpseudo = SC.pseudo;
-enum SCglobal = SC.global;
-enum SCcomdat = SC.comdat;
-enum SCparameter = SC.parameter;
-enum SCregpar = SC.regpar;
-enum SCfastpar = SC.fastpar;
-enum SCshadowreg = SC.shadowreg;
-enum SCtypedef = SC.typedef_;
-enum SCexplicit = SC.explicit;
-enum SCmutable = SC.mutable;
-enum SClabel = SC.label;
-enum SCstruct = SC.struct_;
-enum SCenum = SC.enum_;
-enum SCfield = SC.field;
-enum SCconst = SC.const_;
-enum SCmember = SC.member;
-enum SCanon = SC.anon;
-enum SCinline = SC.inline;
-enum SCsinline = SC.sinline;
-enum SCeinline = SC.einline;
-enum SCoverload = SC.overload;
-enum SCfriend = SC.friend;
-enum SCvirtual = SC.virtual;
-enum SClocstat = SC.locstat;
-enum SCtemplate = SC.template_;
-enum SCfunctempl = SC.functempl;
-enum SCftexpspec = SC.ftexpspec;
-enum SClinkage = SC.linkage;
-enum SCpublic = SC.public_;
-enum SCcomdef = SC.comdef;
-enum SCbprel = SC.bprel;
-enum SCnamespace = SC.namespace;
-enum SCalias = SC.alias_;
-enum SCfuncalias = SC.funcalias;
-enum SCmemalias = SC.memalias;
-enum SCstack = SC.stack;
-enum SCadl = SC.adl;
-
 enum SCMAX = SC.max + 1;
 
-int ClassInline(int c) { return c == SCinline || c == SCsinline || c == SCeinline; }
+int ClassInline(int c) { return c == SC.inline || c == SC.sinline || c == SC.einline; }
 int SymInline(Symbol* s) { return ClassInline(s.Sclass); }

--- a/compiler/src/dmd/backend/cgcod.d
+++ b/compiler/src/dmd/backend/cgcod.d
@@ -280,12 +280,12 @@ tryagain:
             s.Sflags &= ~SFLread;
             switch (s.Sclass)
             {
-                case SCfastpar:
-                case SCshadowreg:
+                case SC.fastpar:
+                case SC.shadowreg:
                     regcon.params |= s.Spregm();
-                    goto case SCparameter;
+                    goto case SC.parameter;
 
-                case SCparameter:
+                case SC.parameter:
                     if (s.Sfl == FLreg)
                         noparams |= s.Sregm;
                     break;
@@ -366,9 +366,9 @@ tryagain:
 
         switch (s.Sclass)
         {
-            case SCregister:
-            case SCauto:
-            case SCfastpar:
+            case SC.register:
+            case SC.auto_:
+            case SC.fastpar:
                 if (s.Sfl == FLreg)
                     break;
 
@@ -1124,8 +1124,8 @@ else
          */
         if (config.flags & CFGtrace &&
             (!(config.flags4 & CFG4allcomdat) ||
-             funcsym_p.Sclass == SCcomdat ||
-             funcsym_p.Sclass == SCglobal ||
+             funcsym_p.Sclass == SC.comdat ||
+             funcsym_p.Sclass == SC.global ||
              (config.flags2 & CFG2comdat && SymInline(funcsym_p))
             )
            )
@@ -1295,12 +1295,12 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
          */
         switch (s.Sclass)
         {
-            case SCfastpar:
+            case SC.fastpar:
                 if (!(funcsym_p.Sfunc.Fflags3 & Ffakeeh))
                     goto Ldefault;   // don't need consistent stack frame
                 break;
 
-            case SCparameter:
+            case SC.parameter:
                 if (type_zeroSize(s.Stype, tybasic(funcsym_p.Stype.Tty)))
                 {
                     Para.offset = _align(REGSIZE,Para.offset); // align on word stack boundary
@@ -1309,7 +1309,7 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
                 }
                 break;          // allocate even if it's dead
 
-            case SCshadowreg:
+            case SC.shadowreg:
                 break;          // allocate even if it's dead
 
             default:
@@ -1332,7 +1332,7 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
 
         switch (s.Sclass)
         {
-            case SCfastpar:
+            case SC.fastpar:
                 /* Get these
                  * right next to the stack frame pointer, EBP.
                  * Needed so we can call nested contract functions
@@ -1355,8 +1355,8 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
                     Fast.alignment = alignsize;
                 break;
 
-            case SCregister:
-            case SCauto:
+            case SC.register:
+            case SC.auto_:
                 if (s.Sfl == FLreg)        // if allocated in register
                     break;
 
@@ -1374,15 +1374,15 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
                     Auto.alignment = alignsize;
                 break;
 
-            case SCstack:
+            case SC.stack:
                 EEStack.offset = _align(sz,EEStack.offset);
                 s.Soffset = EEStack.offset;
                 //printf("EEStack.offset =  x%lx\n",cast(long)s.Soffset);
                 EEStack.offset += sz;
                 break;
 
-            case SCshadowreg:
-            case SCparameter:
+            case SC.shadowreg:
+            case SC.parameter:
                 if (config.exe == EX_WIN64)
                 {
                     assert((Para.offset & 7) == 0);
@@ -1405,9 +1405,9 @@ void stackoffsets(ref symtab_t symtab, bool estimate)
                             : type_size(s.Stype);
                 break;
 
-            case SCpseudo:
-            case SCstatic:
-            case SCbprel:
+            case SC.pseudo:
+            case SC.static_:
+            case SC.bprel:
                 break;
             default:
                 symbol_print(s);
@@ -1549,7 +1549,7 @@ private void blcodgen(block *bl)
                 if (vec_testbit(dfoidx,s.Srange))
                 {
                     regcon.mvar |= s.Sregm;
-                    if (s.Sclass == SCfastpar || s.Sclass == SCshadowreg)
+                    if (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg)
                         regcon.mpvar |= s.Sregm;
                 }
             }
@@ -1566,7 +1566,7 @@ private void blcodgen(block *bl)
                         regcon.cse.mval &= ~s.Sregm;
                         regcon.immed.mval &= ~s.Sregm;
                         regcon.params &= ~s.Sregm;
-                        if (s.Sclass == SCfastpar || s.Sclass == SCshadowreg)
+                        if (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg)
                             regcon.mpvar |= s.Sregm;
                     }
                 }
@@ -1945,7 +1945,7 @@ int isregvar(elem *e,regm_t *pregm,reg_t *preg)
         switch (s.Sfl)
         {
             case FLreg:
-                if (s.Sclass == SCparameter)
+                if (s.Sclass == SC.parameter)
                 {   refparam = true;
                     reflocal = true;
                 }

--- a/compiler/src/dmd/backend/cgcs.d
+++ b/compiler/src/dmd/backend/cgcs.d
@@ -617,29 +617,29 @@ void touchlvalue(ref CGCS cgcs, const elem* e)
     }
     switch (e.EV.Vsym.Sclass)
     {
-        case SCregpar:
-        case SCregister:
-        case SCpseudo:
+        case SC.regpar:
+        case SC.register:
+        case SC.pseudo:
             break;
 
-        case SCauto:
-        case SCparameter:
-        case SCfastpar:
-        case SCshadowreg:
-        case SCbprel:
+        case SC.auto_:
+        case SC.parameter:
+        case SC.fastpar:
+        case SC.shadowreg:
+        case SC.bprel:
             if (e.EV.Vsym.Sflags & SFLunambig)
                 break;
-            goto case SCstatic;
+            goto case SC.static_;
 
-        case SCstatic:
-        case SCextern:
-        case SCglobal:
-        case SClocstat:
-        case SCcomdat:
-        case SCinline:
-        case SCsinline:
-        case SCeinline:
-        case SCcomdef:
+        case SC.static_:
+        case SC.extern_:
+        case SC.global:
+        case SC.locstat:
+        case SC.comdat:
+        case SC.inline:
+        case SC.sinline:
+        case SC.einline:
+        case SC.comdef:
             touchstar(cgcs);
             break;
 

--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -1329,7 +1329,7 @@ private elem * elmin(elem *e, goal_t goal)
         {
             Symbol *s = symbol_calloc(LARGECODE ? "_aFahdiff".ptr : "_aNahdiff".ptr);
             s.Stype = tsclib;
-            s.Sclass = SCextern;
+            s.Sclass = SC.extern_;
             s.Sfl = FLfunc;
             s.Ssymnum = 0;
             s.Sregsaved = mBX|mCX|mSI|mDI|mBP|mES;
@@ -5315,7 +5315,7 @@ private elem * elshr(elem *e, goal_t goal)
         {
             Symbol *s = e1.EV.Vsym;
 
-            if (s.Sclass != SCfastpar && s.Sclass != SCshadowreg)
+            if (s.Sclass != SC.fastpar && s.Sclass != SC.shadowreg)
             {
                 e1.EV.Voffset += SHORTSIZE; // address high word in long
                 if (I32)
@@ -5527,7 +5527,7 @@ private elem * elvalist(elem *e, goal_t goal)
         {
             Symbol *s = globsym[si];
 
-            if (s.Sclass == SCparameter || s.Sclass == SCregpar)
+            if (s.Sclass == SC.parameter || s.Sclass == SC.regpar)
                 lastNamed = s;
             if (s.Sident[0] == '_' && strcmp(s.Sident.ptr, "_arguments_typeinfo") == 0)
                 arguments_typeinfo = s;
@@ -5564,7 +5564,7 @@ if (config.exe & EX_windos)
     {
         Symbol *s = globsym[si];
 
-        if (s.Sclass == SCfastpar || s.Sclass == SCshadowreg)
+        if (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg)
             lastNamed = s;
     }
 

--- a/compiler/src/dmd/backend/cgen.d
+++ b/compiler/src/dmd/backend/cgen.d
@@ -440,7 +440,7 @@ static if (TARGET_SEGMENTED)
 
     if (f.sym.Sxtrnnum == 0)
     {
-        if (f.sym.Sclass == SCstatic)
+        if (f.sym.Sclass == SC.static_)
         {
 version (SCPP)
 {
@@ -466,14 +466,14 @@ else // MARS
         else if (f.sym.Sflags & SFLwasstatic)
         {
             // Put it in BSS
-            f.sym.Sclass = SCstatic;
+            f.sym.Sclass = SC.static_;
             f.sym.Sfl = FLunde;
             f.sym.Sdt = dt_get_nzeros(cast(uint)type_size(f.sym.Stype));
             outdata(f.sym);
         }
-        else if (f.sym.Sclass != SCsinline)
+        else if (f.sym.Sclass != SC.sinline)
         {
-            f.sym.Sclass = SCextern;   /* make it external             */
+            f.sym.Sclass = SC.extern_;   /* make it external             */
             objmod.external(f.sym);
             if (f.sym.Sflags & SFLweak)
                 objmod.wkext(f.sym, null);

--- a/compiler/src/dmd/backend/cgobj.d
+++ b/compiler/src/dmd/backend/cgobj.d
@@ -2069,7 +2069,7 @@ static int generate_comdat(Symbol *s, bool is_readonly_comdat)
 
     // Put out LNAME for name of Symbol
     lnamesize = OmfObj_mangle(s,lnames.ptr);
-    objrecord((s.Sclass == SCstatic ? LLNAMES : LNAMES),lnames.ptr,cast(uint)lnamesize);
+    objrecord((s.Sclass == SC.static_ ? LLNAMES : LNAMES),lnames.ptr,cast(uint)lnamesize);
 
     // Put out CEXTDEF for name of Symbol
     outextdata();
@@ -2090,7 +2090,7 @@ static int generate_comdat(Symbol *s, bool is_readonly_comdat)
     lr.pubnamidx = obj.lnameidx - 1;
     if (isfunc)
     {   lr.pubbase = SegData[cseg].segidx;
-        if (s.Sclass == SCcomdat || s.Sclass == SCinline)
+        if (s.Sclass == SC.comdat || s.Sclass == SC.inline)
             lr.alloctyp = 0x10 | 0x00; // pick any instance | explicit allocation
         if (is_readonly_comdat)
         {
@@ -2137,7 +2137,7 @@ else
         }
         lr.alloctyp = atyp;
     }
-    if (s.Sclass == SCstatic)
+    if (s.Sclass == SC.static_)
         lr.flags |= 0x04;      // local bit (make it an "LCOMDAT")
     s.Soffset = 0;
     s.Sseg = pseg.SDseg;
@@ -2373,7 +2373,7 @@ else
     elem_debug(e);
     if ((e.Eoper == OPvar || e.Eoper == OPrelconst) &&
         (s = e.EV.Vsym).ty() & mTYimport &&
-        (s.Sclass == SCextern || s.Sclass == SCinline)
+        (s.Sclass == SC.extern_ || s.Sclass == SC.inline)
        )
     {
         char* name;
@@ -2407,7 +2407,7 @@ else
         if (!simp)
         {   type *t;
 
-            simp = scope_define(p,SCTglobal,SCextern);
+            simp = scope_define(p,SCTglobal,SC.extern_);
             simp.Ssequence = 0;
             simp.Sfl = FLextern;
             simp.Simport = s;
@@ -2988,35 +2988,35 @@ private void obj_modend()
 
         switch (s.Sclass)
         {
-            case SCcomdat:
+            case SC.comdat:
             case_SCcomdat:
-            case SCextern:
-            case SCcomdef:
+            case SC.extern_:
+            case SC.comdef:
                 if (s.Sxtrnnum)                // identifier is defined somewhere else
                     external = s.Sxtrnnum;
                 else
                 {
                  Ladd:
-                    s.Sclass = SCextern;
+                    s.Sclass = SC.extern_;
                     external = objmod.external(s);
                     outextdata();
                 }
                 break;
-            case SCinline:
+            case SC.inline:
                 if (config.flags2 & CFG2comdat)
                     goto case_SCcomdat; // treat as initialized common block
                 goto case;
 
-            case SCsinline:
-            case SCstatic:
-            case SCglobal:
+            case SC.sinline:
+            case SC.static_:
+            case SC.global:
                 if (s.Sseg == UNKNOWN)
                     goto Ladd;
                 if (seg_is_comdat(SegData[s.Sseg].segidx))   // if in comdat
                     goto case_SCcomdat;
                 goto case;
 
-            case SClocstat:
+            case SC.locstat:
                 external = 0;           // identifier is static or global
                                             // and we know its offset
                 offset += s.Soffset;
@@ -3681,10 +3681,10 @@ static if (0)
 
     switch (s.Sclass)
     {
-        case SCcomdat:
+        case SC.comdat:
         case_SCcomdat:
-        case SCextern:
-        case SCcomdef:
+        case SC.extern_:
+        case SC.comdef:
             if (s.Sxtrnnum)            // identifier is defined somewhere else
             {
                 external = s.Sxtrnnum;
@@ -3707,21 +3707,21 @@ static if (0)
                 return numbytes;
             }
             break;
-        case SCinline:
+        case SC.inline:
             if (config.flags2 & CFG2comdat)
                 goto case_SCcomdat;     // treat as initialized common block
             goto case;
 
-        case SCsinline:
-        case SCstatic:
-        case SCglobal:
+        case SC.sinline:
+        case SC.static_:
+        case SC.global:
             if (s.Sseg == UNKNOWN)
                 goto Ladd;
             if (seg_is_comdat(SegData[s.Sseg].segidx))
                 goto case_SCcomdat;
             goto case;
 
-        case SClocstat:
+        case SC.locstat:
             external = 0;               // identifier is static or global
                                         // and we know its offset
             if (flags & CFoff)
@@ -3887,7 +3887,7 @@ void OmfObj_far16thunk(Symbol *s)
     targ_size_t L2offset;
     int idx;
 
-    s.Sclass = SCstatic;
+    s.Sclass = SC.static_;
     s.Sseg = cseg;             // identifier is defined in code segment
     s.Soffset = Offset(cseg);
 

--- a/compiler/src/dmd/backend/cgreg.d
+++ b/compiler/src/dmd/backend/cgreg.d
@@ -125,7 +125,7 @@ void cgreg_init()
 
         switch (s.Sclass)
         {
-            case SCparameter:
+            case SC.parameter:
                 // Do not put parameters in registers if they are not used
                 // more than twice (otherwise we have a net loss).
                 if (s.Sweight <= 2 && !tyxmmreg(s.ty()))
@@ -300,7 +300,7 @@ static if (1) // causes assert failure in std.range(4488) from std.parallelism's
 {
       // (it works now - but keep an eye on it for the moment)
     // If s is passed in a register to the function, favor that register
-    if ((s.Sclass == SCfastpar || s.Sclass == SCshadowreg) && s.Spreg == reg)
+    if ((s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg) && s.Spreg == reg)
         ++benefit;
 }
 
@@ -575,7 +575,7 @@ void cgreg_spillreg_prolog(block *b,Symbol *s,ref CodeBuilder cdbstore,ref CodeB
     // If it's startblock, and it's a spilled parameter, we
     // need to load it
     if (live && s.Sflags & SFLspill && bi == 0 &&
-        (s.Sclass == SCparameter || s.Sclass == SCfastpar || s.Sclass == SCshadowreg))
+        (s.Sclass == SC.parameter || s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg))
     {
         return load();
     }
@@ -684,24 +684,24 @@ private void cgreg_map(Symbol *s, reg_t regmsw, reg_t reglsw)
         {
             switch (s.Sclass)
             {
-                case SCauto:
-                case SCregister:
+                case SC.auto_:
+                case SC.register:
                     s.Sfl = FLauto;
                     break;
-                case SCfastpar:
+                case SC.fastpar:
                     s.Sfl = FLfast;
                     break;
-                case SCbprel:
+                case SC.bprel:
                     s.Sfl = FLbprel;
                     break;
-                case SCshadowreg:
-                case SCparameter:
+                case SC.shadowreg:
+                case SC.parameter:
                     s.Sfl = FLpara;
                     break;
-                case SCpseudo:
+                case SC.pseudo:
                     s.Sfl = FLpseudo;
                     break;
-                case SCstack:
+                case SC.stack:
                     s.Sfl = FLstack;
                     break;
                 default:
@@ -812,24 +812,24 @@ int cgreg_assign(Symbol *retsym)
             {
                 switch (s.Sclass)
                 {
-                    case SCauto:
-                    case SCregister:
+                    case SC.auto_:
+                    case SC.register:
                         s.Sfl = FLauto;
                         break;
-                    case SCfastpar:
+                    case SC.fastpar:
                         s.Sfl = FLfast;
                         break;
-                    case SCbprel:
+                    case SC.bprel:
                         s.Sfl = FLbprel;
                         break;
-                    case SCshadowreg:
-                    case SCparameter:
+                    case SC.shadowreg:
+                    case SC.parameter:
                         s.Sfl = FLpara;
                         break;
-                    case SCpseudo:
+                    case SC.pseudo:
                         s.Sfl = FLpseudo;
                         break;
-                    case SCstack:
+                    case SC.stack:
                         s.Sfl = FLstack;
                         break;
                     default:
@@ -853,7 +853,7 @@ int cgreg_assign(Symbol *retsym)
     regm_t regparams = 0;
     for (size_t si = 0; si < globsym.length; si++)
     {   Symbol *s = globsym[si];
-        if (s.Sclass == SCfastpar || s.Sclass == SCshadowreg)
+        if (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg)
             regparams |= s.Spregm();
     }
 
@@ -942,7 +942,7 @@ static if (0 && TARGET_LINUX)
              */
             if (variadicPrologRegs & (1 << reg))
             {
-                if (s.Sclass == SCparameter || s.Sclass == SCfastpar)
+                if (s.Sclass == SC.parameter || s.Sclass == SC.fastpar)
                     continue;
                 /* Win64 doesn't use the Posix variadic scheme, so we can skip SCshadowreg
                  */
@@ -950,7 +950,7 @@ static if (0 && TARGET_LINUX)
 
             /* Don't assign register parameter to another register parameter
              */
-            if ((s.Sclass == SCfastpar || s.Sclass == SCshadowreg) &&
+            if ((s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg) &&
                 (1 << reg) & regparams &&
                 reg != s.Spreg)
                 continue;
@@ -981,7 +981,7 @@ static if (0 && TARGET_LINUX)
                             goto Ltried;                // tried and failed to assign MSW
                         if (regmsw == reg)              // can't assign msw and lsw to same reg
                             continue;
-                        if ((s.Sclass == SCfastpar || s.Sclass == SCshadowreg) &&
+                        if ((s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg) &&
                             (1 << regmsw) & regparams &&
                             regmsw != s.Spreg2)
                             continue;

--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -82,7 +82,7 @@ __gshared const   byte[8] regtorm   =   [ -1,-1,-1, 7,-1, 6, 4, 5 ];
 bool regParamInPreg(Symbol* s)
 {
     //printf("regPAramInPreg %s\n", s.Sident.ptr);
-    return (s.Sclass == SCfastpar || s.Sclass == SCshadowreg) &&
+    return (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg) &&
         (!(config.flags4 & CFG4optimized) || !(s.Sflags & GTregcand));
 }
 
@@ -972,7 +972,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                 {
                     if (s.Sfl == FLtlsdata || s.ty() & mTYthread)
                     {
-                        if (s.Sclass == SCglobal || s.Sclass == SCstatic || s.Sclass == SClocstat)
+                        if (s.Sclass == SC.global || s.Sclass == SC.static_ || s.Sclass == SC.locstat)
                             return false;
                     }
                     return true;
@@ -1384,7 +1384,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
             goto L2;
 
         case FLpara:
-            if (s.Sclass == SCshadowreg)
+            if (s.Sclass == SC.shadowreg)
                 goto case FLfast;
         Lpara:
             refparam = true;
@@ -1454,7 +1454,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                         regcon.params &= ~pregm;
                 }
             }
-            if (s.Sclass == SCshadowreg)
+            if (s.Sclass == SC.shadowreg)
                 goto Lpara;
             goto case FLbprel;
 
@@ -1524,8 +1524,8 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                     cgreg_unregister(s.Sregm);
 
                 if (
-                    s.Sclass == SCregpar ||
-                    s.Sclass == SCparameter)
+                    s.Sclass == SC.regpar ||
+                    s.Sclass == SC.parameter)
                 {   refparam = true;
                     reflocal = true;        // kludge to set up prolog
                 }
@@ -1570,7 +1570,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                 else if (I64)
                 {
                     if (config.flags3 & CFG3pie &&
-                        (s.Sclass == SCglobal || s.Sclass == SCstatic || s.Sclass == SClocstat))
+                        (s.Sclass == SC.global || s.Sclass == SC.static_ || s.Sclass == SC.locstat))
                     {
                         pcs.Iflags |= CFfs;
                         pcs.Irm = modregrm(0, 0, 4);
@@ -2110,7 +2110,7 @@ Symbol* symboly(const(char)* name, regm_t desregs)
 {
     Symbol *s = symbol_calloc(name);
     s.Stype = tsclib;
-    s.Sclass = SCextern;
+    s.Sclass = SC.extern_;
     s.Sfl = FLfunc;
     s.Ssymnum = 0;
     s.Sregsaved = ~desregs & (mBP | mES | ALLREGS);
@@ -4824,7 +4824,8 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
                     (fl = s.Sfl) != FLfardata &&
                     /* not a function that CS might not be the segment of       */
                     (!((fl == FLfunc || s.ty() & mTYcs) &&
-                      (s.Sclass == SCcomdat || s.Sclass == SCextern || s.Sclass == SCinline || config.wflags & WFthunk)) ||
+                      (s.Sclass == SC.comdat || s.Sclass == SC.extern_ ||
+                       s.Sclass == SC.inline || config.wflags & WFthunk)) ||
                      (fl == FLfunc && config.exe == EX_DOSX)
                     )
                    )

--- a/compiler/src/dmd/backend/cod2.d
+++ b/compiler/src/dmd/backend/cod2.d
@@ -92,8 +92,8 @@ bool movOnly(const elem *e)
     {
         const s = e.EV.Vsym;
         // Fixups for these can only be done with a MOV
-        if (s.Sclass == SCglobal || s.Sclass == SCextern ||
-            s.Sclass == SCcomdat || s.Sclass == SCcomdef)
+        if (s.Sclass == SC.global || s.Sclass == SC.extern_ ||
+            s.Sclass == SC.comdat || s.Sclass == SC.comdef)
             return true;
     }
     return false;
@@ -4678,9 +4678,9 @@ void cdrelconst(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         sclass = s.Sclass;
         const ety = tybasic(s.ty());
         if ((tyfarfunc(ety) || ety == TYifunc) &&
-            (sclass == SCextern || ClassInline(sclass) || config.wflags & WFthunk)
+            (sclass == SC.extern_ || ClassInline(sclass) || config.wflags & WFthunk)
             || s.Sfl == FLfardata
-            || (s.ty() & mTYcs && s.Sseg != cseg && (LARGECODE || s.Sclass == SCcomdat))
+            || (s.ty() & mTYcs && s.Sseg != cseg && (LARGECODE || s.Sclass == SC.comdat))
            )
         {   // MOV mreg,seg of symbol
             cdb.gencs(0xB8 + mreg,0,FLextern,s);
@@ -4794,7 +4794,7 @@ void getoffset(ref CodeBuilder cdb,elem *e,reg_t reg)
             css.IEV1.Vuns = 0;
             cdb.gen(&css);               // MOV reg,GS:[00000000]
 
-            if (e.EV.Vsym.Sclass == SCstatic || e.EV.Vsym.Sclass == SClocstat)
+            if (e.EV.Vsym.Sclass == SC.static_ || e.EV.Vsym.Sclass == SC.locstat)
             {   // ADD reg, offset s
                 cs.Irex = rex;
                 cs.Iop = 0x81;

--- a/compiler/src/dmd/backend/cod4.d
+++ b/compiler/src/dmd/backend/cod4.d
@@ -461,7 +461,7 @@ void cdeq(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                )
             {
                 Symbol *s = e11.EV.E1.EV.Vsym;
-                if (s.Sclass == SCfastpar || s.Sclass == SCshadowreg)
+                if (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg)
                 {
                     regcon.params &= ~s.Spregm();
                 }
@@ -733,7 +733,7 @@ void cdeq(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
        )
     {
         Symbol *s = e11.EV.E1.EV.Vsym;
-        if (s.Sclass == SCfastpar || s.Sclass == SCshadowreg)
+        if (s.Sclass == SC.fastpar || s.Sclass == SC.shadowreg)
         {
             regcon.params &= ~s.Spregm();
         }

--- a/compiler/src/dmd/backend/cv8.d
+++ b/compiler/src/dmd/backend/cv8.d
@@ -63,15 +63,15 @@ private bool symbol_iscomdat4(Symbol* s)
 {
     version (MARS)
     {
-        return s.Sclass == SCcomdat ||
-            config.flags2 & CFG2comdat && s.Sclass == SCinline ||
-            config.flags4 & CFG4allcomdat && s.Sclass == SCglobal;
+        return s.Sclass == SC.comdat ||
+            config.flags2 & CFG2comdat && s.Sclass == SC.inline ||
+            config.flags4 & CFG4allcomdat && s.Sclass == SC.global;
     }
     else
     {
-        return s.Sclass == SCcomdat ||
-            config.flags2 & CFG2comdat && s.Sclass == SCinline ||
-            config.flags4 & CFG4allcomdat && (s.Sclass == SCglobal || s.Sclass == SCstatic);
+        return s.Sclass == SC.comdat ||
+            config.flags2 & CFG2comdat && s.Sclass == SC.inline ||
+            config.flags4 & CFG4allcomdat && (s.Sclass == SC.global || s.Sclass == SC.static_);
     }
 }
 
@@ -442,7 +442,7 @@ void cv8_func_term(Symbol *sfunc)
     auto buf = currentfuncdata.f1buf;
     buf.reserve(cast(uint)(2 + 2 + 4 * 7 + 6 + 1 + len + 1));
     buf.write16n(cast(int)(2 + 4 * 7 + 6 + 1 + len + 1));
-    buf.write16n(sfunc.Sclass == SCstatic ? S_LPROC_V3 : S_GPROC_V3);
+    buf.write16n(sfunc.Sclass == SC.static_ ? S_LPROC_V3 : S_GPROC_V3);
     buf.write32(0);            // parent
     buf.write32(0);            // pend
     buf.write32(0);            // pnext
@@ -719,9 +719,9 @@ void cv8_outsym(Symbol *s)
     uint base;
     switch (s.Sclass)
     {
-        case SCparameter:
-        case SCregpar:
-        case SCshadowreg:
+        case SC.parameter:
+        case SC.regpar:
+        case SC.shadowreg:
             if (s.Sfl == FLreg)
             {
                 s.Sfl = FLpara;
@@ -732,7 +732,7 @@ void cv8_outsym(Symbol *s)
             base = cast(uint)(Para.size - BPoff);    // cancel out add of BPoff
             goto L1;
 
-        case SCauto:
+        case SC.auto_:
             if (s.Sfl == FLreg)
                 goto case_register;
         case_auto:
@@ -765,23 +765,23 @@ else
 }
             break;
 
-        case SCbprel:
+        case SC.bprel:
             base = -BPoff;
             goto L1;
 
-        case SCfastpar:
+        case SC.fastpar:
             if (s.Sfl != FLreg)
             {   base = cast(uint)Fast.size;
                 goto L1;
             }
             goto L2;
 
-        case SCregister:
+        case SC.register:
             if (s.Sfl != FLreg)
                 goto case_auto;
             goto case;
 
-        case SCpseudo:
+        case SC.pseudo:
         case_register:
         L2:
             buf.reserve(cast(uint)(2 + 2 + 4 + 2 + len + 1));
@@ -793,17 +793,17 @@ else
             buf.writeByte(0);
             break;
 
-        case SCextern:
+        case SC.extern_:
             break;
 
-        case SCstatic:
-        case SClocstat:
+        case SC.static_:
+        case SC.locstat:
             sr = S_LDATA_V3;
             goto Ldata;
 
-        case SCglobal:
-        case SCcomdat:
-        case SCcomdef:
+        case SC.global:
+        case SC.comdat:
+        case SC.comdef:
             sr = S_GDATA_V3;
         Ldata:
             /*

--- a/compiler/src/dmd/backend/dcgcv.d
+++ b/compiler/src/dmd/backend/dcgcv.d
@@ -194,7 +194,7 @@ int cv_namestring(ubyte *p, const(char)* name, int length = -1)
 private int cv_regnum(Symbol *s)
 {
     uint reg = s.Sreglsw;
-    if (s.Sclass == SCpseudo)
+    if (s.Sclass == SC.pseudo)
     {
 version (SCPP)
         reg = pseudoreg[reg];
@@ -813,7 +813,7 @@ private int cv4_methodlist(Symbol *sf,int *pcount)
     mlen = 2;
     for (s = sf; s; s = s.Sfunc.Foversym)
     {
-        if (s.Sclass == SCtypedef || s.Sclass == SCfunctempl)
+        if (s.Sclass == SC.typedef_ || s.Sclass == SC.functempl)
             continue;
         if (s.Sfunc.Fflags & Fnodebug)
             continue;
@@ -833,7 +833,7 @@ private int cv4_methodlist(Symbol *sf,int *pcount)
     p += 2;
     for (s = sf; s; s = s.Sfunc.Foversym)
     {
-        if (s.Sclass == SCtypedef || s.Sclass == SCfunctempl)
+        if (s.Sclass == SC.typedef_ || s.Sclass == SC.functempl)
             continue;
         if (s.Sfunc.Fflags & Fnodebug)
             continue;
@@ -1041,7 +1041,7 @@ version (SCPP)
     len += cv_namestring(d.data.ptr + len,id);
     switch (s.Sclass)
     {
-        case SCstruct:
+        case SC.struct_:
             leaf = LF_STRUCTURE;
             if (st.Sflags & STRunion)
             {   leaf = LF_UNION;
@@ -1203,7 +1203,7 @@ version (SCPP)
     {   Symbol *sf = list_symbol(sl);
 
         symbol_debug(sf);
-        if (sf.Sclass == SCfunctempl)
+        if (sf.Sclass == SC.functempl)
             continue;
         nfields++;
         fnamelen += ((config.fulltypes == CV4) ? 4 : 6) +
@@ -1220,8 +1220,8 @@ version (SCPP)
         const(char)* sfid = sf.Sident.ptr;
         switch (sf.Sclass)
         {
-            case SCmember:
-            case SCfield:
+            case SC.member:
+            case SC.field:
                 if (CPP && sf == s.Sstruct.Svptr)
                     fnamelen += ((config.fulltypes == CV4) ? 4 : 8);
                 else
@@ -1233,7 +1233,7 @@ version (SCPP)
 
 version (SCPP)
 {
-            case SCstruct:
+            case SC.struct_:
                 if (sf.Sstruct.Sflags & STRanonymous)
                     continue;
                 if (sf.Sstruct.Sflags & STRnotagname)
@@ -1241,25 +1241,25 @@ version (SCPP)
                 property |= 0x10;       // class contains nested classes
                 goto Lnest2;
 
-            case SCenum:
+            case SC.enum_:
                 if (sf.Senum.SEflags & SENnotagname)
                     sfid = cpp_name_none.ptr;
                 goto Lnest2;
 
-            case SCtypedef:
+            case SC.typedef_:
             Lnest2:
                 fnamelen += ((config.fulltypes == CV4) ? 4 : 8) +
                             cv_stringbytes(sfid);
                 break;
 
-            case SCextern:
-            case SCcomdef:
-            case SCglobal:
-            case SCstatic:
-            case SCinline:
-            case SCsinline:
-            case SCeinline:
-            case SCcomdat:
+            case SC.extern_:
+            case SC.comdef:
+            case SC.global:
+            case SC.static_:
+            case SC.inline:
+            case SC.sinline:
+            case SC.einline:
+            case SC.comdat:
                 if (tyfunc(sf.ty()))
                 {   Symbol *so;
                     int nfuncs;
@@ -1267,8 +1267,8 @@ version (SCPP)
                     nfuncs = 0;
                     for (so = sf; so; so = so.Sfunc.Foversym)
                     {
-                        if (so.Sclass == SCtypedef ||
-                            so.Sclass == SCfunctempl ||
+                        if (so.Sclass == SC.typedef_ ||
+                            so.Sclass == SC.functempl ||
                             so.Sfunc.Fflags & Fnodebug)       // if compiler generated
                             continue;                   // skip it
                         nfuncs++;
@@ -1423,7 +1423,7 @@ version (SCPP)
     {   Symbol *sf = list_symbol(sl);
 
         symbol_debug(sf);
-        if (sf.Sclass == SCfunctempl)
+        if (sf.Sclass == SC.functempl)
             continue;
         typidx = cv4_symtypidx(sf);
         TOWORD(p,LF_FRIENDFCN);
@@ -1447,7 +1447,7 @@ version (SCPP)
         const(char)* sfid = sf.Sident.ptr;
         switch (sf.Sclass)
         {
-            case SCfield:
+            case SC.field:
             {   debtyp_t *db;
 
                 if (config.fulltypes == CV4)
@@ -1468,7 +1468,7 @@ version (SCPP)
                 goto L3;
             }
 
-            case SCmember:
+            case SC.member:
                 typidx = cv4_symtypidx(sf);
             L3:
 version (SCPP)
@@ -1516,19 +1516,19 @@ else
 
 version (SCPP)
 {
-            case SCstruct:
+            case SC.struct_:
                 if (sf.Sstruct.Sflags & STRanonymous)
                     continue;
                 if (sf.Sstruct.Sflags & STRnotagname)
                     sfid = cpp_name_none.ptr;
                 goto Lnest;
 
-            case SCenum:
+            case SC.enum_:
                 if (sf.Senum.SEflags & SENnotagname)
                     sfid = cpp_name_none.ptr;
                 goto Lnest;
 
-            case SCtypedef:
+            case SC.typedef_:
             Lnest:
                 TOWORD(p,LF_NESTTYPE);
                 typidx = cv4_symtypidx(sf);
@@ -1544,14 +1544,14 @@ version (SCPP)
                 p += cv_namestring(p,sfid);
                 break;
 
-            case SCextern:
-            case SCcomdef:
-            case SCglobal:
-            case SCstatic:
-            case SCinline:
-            case SCsinline:
-            case SCeinline:
-            case SCcomdat:
+            case SC.extern_:
+            case SC.comdef:
+            case SC.global:
+            case SC.static_:
+            case SC.inline:
+            case SC.sinline:
+            case SC.einline:
+            case SC.comdat:
                 if (tyfunc(sf.ty()))
                 {   int count2;
 
@@ -2472,7 +2472,7 @@ version (MARS)
     t = s.Stype;
     type_debug(t);
     tym = tybasic(t.Tty);
-    if (tyfunc(tym) && s.Sclass != SCtypedef)
+    if (tyfunc(tym) && s.Sclass != SC.typedef_)
     {   int framedatum,targetdatum,fd;
         char idfree;
         idx_t typidx;
@@ -2510,7 +2510,7 @@ else
         memset(debsym,0,length + len);
 
         // Symbol type
-        u = (s.Sclass == SCstatic) ? S_LPROC16 : S_GPROC16;
+        u = (s.Sclass == SC.static_) ? S_LPROC16 : S_GPROC16;
         if (I32)
             u += S_GPROC32 - S_GPROC16;
         TOWORD(debsym + 2,u);
@@ -2588,8 +2588,8 @@ else
         assert(debsym);
         switch (s.Sclass)
         {
-            case SCparameter:
-            case SCregpar:
+            case SC.parameter:
+            case SC.regpar:
                 if (s.Sfl == FLreg)
                 {
                     s.Sfl = FLpara;
@@ -2600,7 +2600,7 @@ else
                 base = Para.size - BPoff;    // cancel out add of BPoff
                 goto L1;
 
-            case SCauto:
+            case SC.auto_:
                 if (s.Sfl == FLreg)
                     goto case_register;
             case_auto:
@@ -2622,23 +2622,23 @@ else
                 TOWORD(debsym,length - 2);
                 break;
 
-            case SCbprel:
+            case SC.bprel:
                 base = -BPoff;
                 goto L1;
 
-            case SCfastpar:
+            case SC.fastpar:
                 if (s.Sfl != FLreg)
                 {   base = Fast.size;
                     goto L1;
                 }
                 goto case_register;
 
-            case SCregister:
+            case SC.register:
                 if (s.Sfl != FLreg)
                     goto case_auto;
                 goto case_register;
 
-            case SCpseudo:
+            case SC.pseudo:
             case_register:
                 TOWORD(debsym + 2,S_REGISTER);
                 reg = cv_regnum(s);
@@ -2649,21 +2649,21 @@ else
                 TOWORD(debsym,length - 2);
                 break;
 
-            case SCextern:
-            case SCcomdef:
+            case SC.extern_:
+            case SC.comdef:
                 // Common blocks have a non-zero Sxtrnnum and an UNKNOWN seg
                 if (!(s.Sxtrnnum && s.Sseg == UNKNOWN)) // if it's not really a common block
                 {
                         goto Lret;
                 }
                 goto case;
-            case SCglobal:
-            case SCcomdat:
+            case SC.global:
+            case SC.comdat:
                 u = S_GDATA16;
                 goto L2;
 
-            case SCstatic:
-            case SClocstat:
+            case SC.static_:
+            case SC.locstat:
                 u = S_LDATA16;
             L2:
                 if (I32)
@@ -2690,7 +2690,7 @@ else
                 TOWORD(debsym,length - 2);
                 assert(length <= 40 + len);
 
-                if (s.Sseg == UNKNOWN || s.Sclass == SCcomdat) // if common block
+                if (s.Sseg == UNKNOWN || s.Sclass == SC.comdat) // if common block
                 {
                     if (config.exe & EX_flat)
                     {
@@ -2729,17 +2729,17 @@ else
 
 static if (1)
 {
-            case SCtypedef:
+            case SC.typedef_:
                 s.Stypidx = typidx;
                 reset_symbuf.write((&s)[0 .. 1]);
                 goto L4;
 
-            case SCstruct:
+            case SC.struct_:
                 if (s.Sstruct.Sflags & STRnotagname)
                     goto Lret;
                 goto L4;
 
-            case SCenum:
+            case SC.enum_:
 version (SCPP)
 {
                 if (CPP && s.Senum.SEflags & SENnotagname)
@@ -2755,7 +2755,7 @@ version (SCPP)
                 list_subtract(&cgcv.list,s);
                 break;
 
-            case SCconst:
+            case SC.const_:
                 // The only constants are enum members
                 value = cast(uint)el_tolongt(s.Svalue);
                 TOWORD(debsym + 2,S_CONST);

--- a/compiler/src/dmd/backend/drtlsym.d
+++ b/compiler/src/dmd/backend/drtlsym.d
@@ -230,7 +230,7 @@ private void symbolz(Symbol** ps, int fl, regm_t regsaved, const(char)* name, SY
     Symbol *s = symbol_calloc(name);
     s.Stype = t;
     s.Ssymnum = SYMIDX.max;
-    s.Sclass = SCextern;
+    s.Sclass = SC.extern_;
     s.Sfl = cast(char)fl;
     s.Sregsaved = regsaved;
     s.Sflags = flags;

--- a/compiler/src/dmd/backend/dt.d
+++ b/compiler/src/dmd/backend/dt.d
@@ -448,7 +448,7 @@ nothrow:
         type *t = type_alloc(TYint);
         t.Tcount++;
         Symbol *s = symbol_calloc("internal");
-        s.Sclass = SCstatic;
+        s.Sclass = SC.static_;
         s.Sfl = FLextern;
         s.Sflags |= SFLnodebug;
         s.Stype = t;

--- a/compiler/src/dmd/backend/dtype.d
+++ b/compiler/src/dmd/backend/dtype.d
@@ -512,7 +512,7 @@ type *type_allocmemptr(Classsym *stag,type *tn)
 {   type *t;
 
     symbol_debug(stag);
-    assert(stag.Sclass == SCstruct || tybasic(stag.Stype.Tty) == TYident);
+    assert(stag.Sclass == SC.struct_ || tybasic(stag.Stype.Tty) == TYident);
     t = type_allocn(TYmemptr,tn);
     t.Ttag = stag;
     //printf("type_allocmemptr() = %p\n", t);
@@ -632,7 +632,7 @@ type *type_function(tym_t tyf, type*[] ptypes, bool variadic, type *tret)
 type *type_enum(const(char)* name, type *tbase)
 {
     Symbol *s = symbol_calloc(name);
-    s.Sclass = SCenum;
+    s.Sclass = SC.enum_;
     s.Senum = cast(enum_t *) MEM_PH_CALLOC(enum_t.sizeof);
     s.Senum.SEflags |= SENforward;        // forward reference
 
@@ -671,7 +671,7 @@ type *type_struct_class(const(char)* name, uint alignsize, uint structsize,
         }
     }
     Symbol *s = symbol_calloc(name);
-    s.Sclass = SCstruct;
+    s.Sclass = SC.struct_;
     s.Sstruct = struct_calloc();
     s.Sstruct.Salignsize = alignsize;
     s.Sstruct.Sstructalign = cast(ubyte)alignsize;
@@ -1693,7 +1693,7 @@ Symbol *param_search(const(char)* name, param_t **pp)
         if (!s)
         {
             s = symbol_calloc(p.Pident);
-            s.Sclass = SCparameter;
+            s.Sclass = SC.parameter;
             s.Stype = p.Ptype;
             s.Stype.Tcount++;
             p.Psym = s;

--- a/compiler/src/dmd/backend/dvarstats.d
+++ b/compiler/src/dmd/backend/dvarstats.d
@@ -208,7 +208,7 @@ private symtab_t* calcLexicalScope(return ref symtab_t symtab) return
     for (argcnt = 0; argcnt < symtab.length; argcnt++)
     {
         Symbol* sa = symtab[argcnt];
-        if (sa.Sclass != SCparameter && sa.Sclass != SCregpar && sa.Sclass != SCfastpar && sa.Sclass != SCshadowreg)
+        if (sa.Sclass != SC.parameter && sa.Sclass != SC.regpar && sa.Sclass != SC.fastpar && sa.Sclass != SC.shadowreg)
             break;
         sortedSymtab[argcnt] = sa;
     }
@@ -286,10 +286,10 @@ public void writeSymbolTable(ref symtab_t symtab,
     {
         Symbol *sa = (*symtab2)[si];
         if (endarg == false &&
-            sa.Sclass != SCparameter &&
-            sa.Sclass != SCfastpar &&
-            sa.Sclass != SCregpar &&
-            sa.Sclass != SCshadowreg)
+            sa.Sclass != SC.parameter &&
+            sa.Sclass != SC.fastpar &&
+            sa.Sclass != SC.regpar &&
+            sa.Sclass != SC.shadowreg)
         {
             if(fnEndArgs)
                 (*fnEndArgs)();

--- a/compiler/src/dmd/backend/ee.d
+++ b/compiler/src/dmd/backend/ee.d
@@ -52,7 +52,7 @@ void eecontext_convs(SYMIDX marksi)
 {
     symtab_t *ps;
 
-    // Change all generated SCauto's to SCstack's
+    // Change all generated SC.auto's to SC.stack's
     version (SCPP)
     {
         ps = &globsym;
@@ -72,9 +72,9 @@ void eecontext_convs(SYMIDX marksi)
         auto s = (*ps)[u];
         switch (s.Sclass)
         {
-            case SCauto:
-            case SCregister:
-                s.Sclass = SCstack;
+            case SC.auto_:
+            case SC.register:
+                s.Sclass = SC.stack;
                 s.Sfl = FLstack;
                 break;
             default:
@@ -119,7 +119,7 @@ void eecontext_parse()
         if (eecontext.EEtypedef && config.fulltypes)
         {   Symbol *s;
 
-            s = symbol_name(eecontext.EEtypedef,SCtypedef,t);
+            s = symbol_name(eecontext.EEtypedef,SC.typedef_,t);
             cv_outsym(s);
             symbol_free(s);
         }

--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -561,7 +561,7 @@ elem * el_alloctmp(tym_t ty)
         assert(!PARSER);
 
     Symbol *s;
-    s = symbol_generate(SCauto,type_fake(ty));
+    s = symbol_generate(SC.auto_,type_fake(ty));
     symbol_add(s);
     s.Sfl = FLauto;
     s.Sflags = SFLfree | SFLunambig | GTregcand;
@@ -1630,7 +1630,7 @@ elem *el_convstring(elem *e)
         (tyfv(e.Ety) && config.flags3 & CFG3strcod))
     {
         assert(config.objfmt == OBJ_OMF);         // option not done yet for others
-        s = symbol_generate(SCstatic, type_fake(mTYcs | e.Ety));
+        s = symbol_generate(SC.static_, type_fake(mTYcs | e.Ety));
         s.Sfl = FLcsdata;
         s.Soffset = Offset(cseg);
         s.Sseg = cseg;
@@ -1915,10 +1915,10 @@ elem *el_ctor_dtor(elem *ec, elem *ed, elem **pedtor)
          * Use volatile to prevent optimizer from messing them up, since optimizer doesn't know about
          * landing pads (the landing pad will be on the OPddtor's EV.ed.Eleft)
          */
-        Symbol *sflag = symbol_name("__flag", SCauto, type_fake(mTYvolatile | TYbool));
-        Symbol *sreg = symbol_name("__EAX", SCpseudo, type_fake(mTYvolatile | TYnptr));
+        Symbol *sflag = symbol_name("__flag", SC.auto_, type_fake(mTYvolatile | TYbool));
+        Symbol *sreg = symbol_name("__EAX", SC.pseudo, type_fake(mTYvolatile | TYnptr));
         sreg.Sreglsw = 0;          // EAX, RAX, whatevs
-        Symbol *seo = symbol_name("__exception_object", SCauto, tspvoid);
+        Symbol *seo = symbol_name("__exception_object", SC.auto_, tspvoid);
 
         symbol_add(sflag);
         symbol_add(sreg);

--- a/compiler/src/dmd/backend/gloop.d
+++ b/compiler/src/dmd/backend/gloop.d
@@ -1556,8 +1556,8 @@ Lnextlis:
                 // first block of the function. Unfortunately, the rd vector
                 // does not take this into account. Therefore, we assume the
                 // worst and reject assignments to function parameters.
-                if (v.Sclass == SCparameter || v.Sclass == SCregpar ||
-                    v.Sclass == SCfastpar || v.Sclass == SCshadowreg)
+                if (v.Sclass == SC.parameter || v.Sclass == SC.regpar ||
+                    v.Sclass == SC.fastpar || v.Sclass == SC.shadowreg)
                         goto L3;
 
                 if (el_sideeffect(n.EV.E2)) goto L3;              // case 5

--- a/compiler/src/dmd/backend/gother.d
+++ b/compiler/src/dmd/backend/gother.d
@@ -1836,7 +1836,7 @@ void deadvar()
             char *p;
             Symbol *s = globsym[i];
 
-            if (s.Sflags & SFLdead && s.Sclass != SCparameter && s.Sclass != SCregpar)
+            if (s.Sflags & SFLdead && s.Sclass != SC.parameter && s.Sclass != SC.regpar)
                 s.Sflags &= ~GTregcand;    // do not put dead variables in registers
             debug
             {

--- a/compiler/src/dmd/backend/gsroa.d
+++ b/compiler/src/dmd/backend/gsroa.d
@@ -394,11 +394,11 @@ if (enable) // disable while we test the inliner
 
         switch (s.Sclass)
         {
-            case SCfastpar:
-            case SCregister:
-            case SCauto:
-            case SCshadowreg:
-            case SCparameter:
+            case SC.fastpar:
+            case SC.register:
+            case SC.auto_:
+            case SC.shadowreg:
+            case SC.parameter:
                 anySlice = true;
                 sia[si].canSlice = true;
                 sia[si].accessSlice = false;
@@ -411,10 +411,10 @@ if (enable) // disable while we test the inliner
                 }
                 break;
 
-            case SCstack:
-            case SCpseudo:
-            case SCstatic:
-            case SCbprel:
+            case SC.stack:
+            case SC.pseudo:
+            case SC.static_:
+            case SC.bprel:
                 if (log) printf(" can't because Sclass\n");
                 sia[si].canSlice = false;
                 break;
@@ -469,7 +469,7 @@ if (enable) // disable while we test the inliner
                 snew.Sclass = sold.Sclass;
                 snew.Sfl = sold.Sfl;
                 snew.Sflags = sold.Sflags;
-                if (snew.Sclass == SCfastpar || snew.Sclass == SCshadowreg)
+                if (snew.Sclass == SC.fastpar || snew.Sclass == SC.shadowreg)
                 {
                     snew.Spreg = sold.Spreg2;
                     snew.Spreg2 = NOREG;

--- a/compiler/src/dmd/backend/inliner.d
+++ b/compiler/src/dmd/backend/inliner.d
@@ -170,7 +170,7 @@ bool canInlineExpression(elem* e)
                 /* Statics cannot be accessed from a different object file,
                  * so the reference will fail.
                  */
-                if (e.EV.Vsym.Sclass == SClocstat || e.EV.Vsym.Sclass == SCstatic)
+                if (e.EV.Vsym.Sclass == SC.locstat || e.EV.Vsym.Sclass == SC.static_)
                 {
                     if (log) printf("not inlining due to %s\n", e.EV.Vsym.Sident.ptr);
                     return false;
@@ -260,7 +260,7 @@ elem* scanExpressionForInlines(elem *e)
             (op == OPvar || op == OPrelconst))
         {
             Symbol* s = e.EV.Vsym;
-            if (s.Sclass == SCauto &&
+            if (s.Sclass == SC.auto_ &&
                 s.Ssymnum == SYMIDX.max)
             {   //dbg_printf("Deferred allocation of %p\n",s);
                 symbol_add(s);
@@ -367,17 +367,17 @@ private elem* inlineCall(elem *e,Symbol *sfunc)
         auto sc = s.Sclass;
         switch (sc)
         {
-            case SCparameter:
-            case SCfastpar:
-            case SCshadowreg:
-                sc = SCauto;
+            case SC.parameter:
+            case SC.fastpar:
+            case SC.shadowreg:
+                sc = SC.auto_;
                 goto L1;
-            case SCregpar:
-                sc = SCregister;
+            case SC.regpar:
+                sc = SC.register;
                 goto L1;
-            case SCregister:
-            case SCauto:
-            case SCpseudo:
+            case SC.register:
+            case SC.auto_:
+            case SC.pseudo:
             L1:
             {
                 //printf("  new symbol %s\n", s.Sident.ptr);
@@ -387,7 +387,7 @@ private elem* inlineCall(elem *e,Symbol *sfunc)
                 snew.Sflags |= SFLfree;
                 snew.Srange = null;
                 s.Sflags |= SFLreplace;
-                if (sc == SCpseudo)
+                if (sc == SC.pseudo)
                 {
                     snew.Sfl = FLpseudo;
                     snew.Sreglsw = s.Sreglsw;
@@ -395,8 +395,8 @@ private elem* inlineCall(elem *e,Symbol *sfunc)
                 s.Ssymnum = symbol_add(snew);
                 break;
             }
-            case SCglobal:
-            case SCstatic:
+            case SC.global:
+            case SC.static_:
                 break;
             default:
                 //fprintf(stderr, "Sclass = %d\n", sc);
@@ -504,7 +504,7 @@ private elem* initializeParamsWithArgs(elem* eargs, SYMIDX sistart, SYMIDX siend
                 Symbol* s = globsym[si];
                 ++si;
                 // SCregpar was turned into SCregister, SCparameter to SCauto
-                if (s.Sclass == SCregister || s.Sclass == SCauto)
+                if (s.Sclass == SC.register || s.Sclass == SC.auto_)
                     return s;
             }
         }

--- a/compiler/src/dmd/backend/newman.d
+++ b/compiler/src/dmd/backend/newman.d
@@ -739,7 +739,7 @@ debug
                         e = e.EV.Vsym.Svalue;
                         goto L2;
                     }
-                    else if (e.EV.Vsym.Sclass == SCconst /*&&
+                    else if (e.EV.Vsym.Sclass == SC.const_ /*&&
                              pstate.STintemplate*/)
                     {
                         CHAR('V');              // pretend to be a class name
@@ -1546,10 +1546,10 @@ version (SCPPorMARS)
         }
         else
         {
-            if (s.Sclass == SCstatic ||
+            if (s.Sclass == SC.static_ ||
                 (s.Sscope &&
-                 s.Sscope.Sclass != SCstruct &&
-                 s.Sscope.Sclass != SCnamespace))
+                 s.Sscope.Sclass != SC.struct_ &&
+                 s.Sscope.Sclass != SC.namespace))
             {
                 CHAR('4');
                 cpp_local_static_data_type(s);
@@ -1563,7 +1563,7 @@ version (SCPPorMARS)
 }
 else
 {
-        if (s.Sclass == SCstatic)
+        if (s.Sclass == SC.static_)
         {
             CHAR('4');
             cpp_local_static_data_type(s);
@@ -1591,11 +1591,11 @@ private void cpp_scope(Symbol *s)
         symbol_debug(s);
         switch (s.Sclass)
         {
-            case SCnamespace:
+            case SC.namespace:
                 cpp_zname(s.Sident.ptr);
                 break;
 
-            case SCstruct:
+            case SC.struct_:
                 cpp_zname(symbol_ident(s));
                 break;
 
@@ -1776,7 +1776,7 @@ else
     CHAR('@');
     *mangle.np = 0;                     // 0-terminate mangle.buf[]
     assert(strlen(mangle.buf.ptr) <= BUFIDMAX);
-    s = scope_define(mangle.buf.ptr,SCTglobal | SCTnspace | SCTlocal,SCunde);
+    s = scope_define(mangle.buf.ptr,SCTglobal | SCTnspace | SCTlocal,SC.unde);
     s.Stype = t;
     t.Tcount++;
     return s;

--- a/compiler/src/dmd/backend/nteh.d
+++ b/compiler/src/dmd/backend/nteh.d
@@ -110,7 +110,7 @@ private Symbol *nteh_scopetable()
     if (!s_table)
     {
         t = type_alloc(TYint);
-        s = symbol_generate(SCstatic,t);
+        s = symbol_generate(SC.static_,t);
         s.Sseg = UNKNOWN;
         symbol_keep(s);
         s_table = s;
@@ -213,7 +213,7 @@ version (MARS)
 {
     if (!(bx.funcsym.Sfunc.Fflags3 & Fnteh)) // if haven't already done it
     {   bx.funcsym.Sfunc.Fflags3 |= Fnteh;
-        s = symbol_name(s_name_context,SCbprel,tstypes[TYint]);
+        s = symbol_name(s_name_context,SC.bprel,tstypes[TYint]);
         s.Soffset = -5 * 4;            // -6 * 4 for C __try, __except, __finally
         s.Sflags |= SFLfree | SFLnodebug;
         type_setty(&s.Stype,mTYvolatile | TYint);
@@ -229,13 +229,13 @@ else
             s_context = scope_search(s_name_context_tag, CPP ? SCTglobal : SCTglobaltag);
         symbol_debug(s_context);
 
-        s = symbol_name(s_name_context,SCbprel,s_context.Stype);
+        s = symbol_name(s_name_context,SC.bprel,s_context.Stype);
         s.Soffset = -6 * 4;            // -5 * 4 for C++
         s.Sflags |= SFLfree;
         symbol_add(s);
         type_setty(&s.Stype,mTYvolatile | TYstruct);
 
-        s = symbol_name(s_name_ecode,SCauto,type_alloc(mTYvolatile | TYint));
+        s = symbol_name(s_name_ecode,SC.auto_,type_alloc(mTYvolatile | TYint));
         s.Sflags |= SFLfree;
         symbol_add(s);
     }
@@ -847,7 +847,7 @@ void nteh_monitor_prolog(ref CodeBuilder cdb, Symbol *shandle)
 
     assert(config.exe == EX_WIN32);    // BUG: figure out how to implement for other EX's
 
-    if (shandle.Sclass == SCfastpar)
+    if (shandle.Sclass == SC.fastpar)
     {   assert(shandle.Spreg != DX);
         assert(shandle.Spreg2 == NOREG);
         cdbx.gen1(0x50 + shandle.Spreg);   // PUSH shandle

--- a/compiler/src/dmd/backend/pdata.d
+++ b/compiler/src/dmd/backend/pdata.d
@@ -41,15 +41,15 @@ private bool symbol_iscomdat3(Symbol* s)
 {
     version (MARS)
     {
-        return s.Sclass == SCcomdat ||
-            config.flags2 & CFG2comdat && s.Sclass == SCinline ||
-            config.flags4 & CFG4allcomdat && s.Sclass == SCglobal;
+        return s.Sclass == SC.comdat ||
+            config.flags2 & CFG2comdat && s.Sclass == SC.inline ||
+            config.flags4 & CFG4allcomdat && s.Sclass == SC.global;
     }
     else
     {
-        return s.Sclass == SCcomdat ||
-            config.flags2 & CFG2comdat && s.Sclass == SCinline ||
-            config.flags4 & CFG4allcomdat && (s.Sclass == SCglobal || s.Sclass == SCstatic);
+        return s.Sclass == SC.comdat ||
+            config.flags2 & CFG2comdat && s.Sclass == SC.inline ||
+            config.flags4 & CFG4allcomdat && (s.Sclass == SC.global || s.Sclass == SC.static_);
     }
 }
 
@@ -78,7 +78,7 @@ public void win64_pdata(Symbol *sf)
     memcpy(pdata_name, "$pdata$".ptr, 7);
     memcpy(pdata_name + 7, sf.Sident.ptr, sflen + 1);      // include terminating 0
 
-    Symbol *spdata = symbol_name(pdata_name,SCstatic,tstypes[TYint]);
+    Symbol *spdata = symbol_name(pdata_name,SC.static_,tstypes[TYint]);
     symbol_keep(spdata);
     symbol_debug(spdata);
 
@@ -122,7 +122,7 @@ private Symbol *win64_unwind(Symbol *sf)
     memcpy(unwind_name, "$unwind$".ptr, 8);
     memcpy(unwind_name + 8, sf.Sident.ptr, sflen + 1);     // include terminating 0
 
-    Symbol *sunwind = symbol_name(unwind_name,SCstatic,tstypes[TYint]);
+    Symbol *sunwind = symbol_name(unwind_name,SC.static_,tstypes[TYint]);
     symbol_keep(sunwind);
     symbol_debug(sunwind);
 

--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -188,7 +188,7 @@ targ_size_t size(tym_t ty)
 
 Symbol *symboldata(targ_size_t offset,tym_t ty)
 {
-    Symbol *s = symbol_generate(SClocstat, type_fake(ty));
+    Symbol *s = symbol_generate(SC.locstat, type_fake(ty));
     s.Sfl = FLdata;
     s.Soffset = offset;
     s.Stype.Tmangle = mTYman_sys; // writes symbol unmodified in Obj::mangle

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -267,7 +267,7 @@ Symbol *toStringSymbol(const(char)* str, size_t len, size_t sz)
             }
 
             si = symbol_calloc(buf.peekChars(), cast(uint)buf.length);
-            si.Sclass = SCcomdat;
+            si.Sclass = SC.comdat;
             si.Stype = type_static_array(cast(uint)(len * sz), tstypes[TYchar]);
             si.Stype.Tcount++;
             type_setmangle(&si.Stype, mTYman_c);
@@ -576,7 +576,7 @@ elem* toElem(Expression e, IRState *irs)
         if (nrvo)
             s = fd.shidden;
 
-        if (s.Sclass == SCauto || s.Sclass == SCparameter || s.Sclass == SCshadowreg)
+        if (s.Sclass == SC.auto_ || s.Sclass == SC.parameter || s.Sclass == SC.shadowreg)
         {
             if (fd && fd != irs.getFunc())
             {
@@ -672,7 +672,7 @@ elem* toElem(Expression e, IRState *irs)
             goto L1;
         }
 
-        if (s.Sclass == SCauto && s.Ssymnum == SYMIDX.max)
+        if (s.Sclass == SC.auto_ && s.Ssymnum == SYMIDX.max)
         {
             //printf("\tadding symbol %s\n", s.Sident);
             symbol_add(s);

--- a/compiler/src/dmd/eh.d
+++ b/compiler/src/dmd/eh.d
@@ -58,7 +58,7 @@ Symbol *except_gentables()
         __gshared int tmpnum;
         sprintf(name.ptr,"_HandlerTable%d",tmpnum++);
 
-        Symbol *s = symbol_name(name.ptr,SCstatic,tstypes[TYint]);
+        Symbol *s = symbol_name(name.ptr,SC.static_,tstypes[TYint]);
         symbol_keep(s);
         //symbol_debug(s);
 

--- a/compiler/src/dmd/objc_glue.d
+++ b/compiler/src/dmd/objc_glue.d
@@ -534,7 +534,7 @@ static:
      */
     Symbol* getGlobal(const(char)[] name, type* t = type_fake(TYnptr))
     {
-        return symbolName(name, SCglobal, t);
+        return symbolName(name, SC.global, t);
     }
 
     /**
@@ -548,7 +548,7 @@ static:
      */
     Symbol* getStatic(const(char)[] name, type* t = type_fake(TYnptr))
     {
-        return symbolName(name, SCstatic, t);
+        return symbolName(name, SC.static_, t);
     }
 
     Symbol* getCString(const(char)[] str, const(char)[] symbolName, Segments.Id segment)
@@ -617,7 +617,7 @@ static:
         dtb.dword(0); // version
         dtb.dword(64); // flags
 
-        imageInfo = symbol_name("L_OBJC_IMAGE_INFO", SCstatic, type_allocn(TYarray, tstypes[TYchar]));
+        imageInfo = symbol_name("L_OBJC_IMAGE_INFO", SC.static_, type_allocn(TYarray, tstypes[TYchar]));
         imageInfo.Sdt = dtb.finish();
         imageInfo.Sseg = Segments[Segments.Id.imageinfo];
         outdata(imageInfo);
@@ -638,7 +638,7 @@ static:
         foreach (c; categories)
             dtb.xoff(getClassName(c), 0);
 
-        Symbol* symbol = symbol_name("L_OBJC_LABEL_CLASS_$", SCstatic, type_allocn(TYarray, tstypes[TYchar]));
+        Symbol* symbol = symbol_name("L_OBJC_LABEL_CLASS_$", SC.static_, type_allocn(TYarray, tstypes[TYchar]));
         symbol.Sdt = dtb.finish();
         symbol.Sseg = Segments[Segments.Id.classlist];
         outdata(symbol);
@@ -718,7 +718,7 @@ static:
             __gshared size_t selectorCount = 0;
             char[42] nameString;
             sprintf(nameString.ptr, "L_OBJC_SELECTOR_REFERENCES_%llu", cast(ulong) selectorCount);
-            auto symbol = symbol_name(nameString.ptr, SCstatic, type_fake(TYnptr));
+            auto symbol = symbol_name(nameString.ptr, SC.static_, type_fake(TYnptr));
 
             symbol.Sdt = dtb.finish();
             symbol.Sseg = seg;
@@ -1309,7 +1309,7 @@ struct ProtocolDeclaration
 
             auto symbol = Symbols.getGlobal(symbolName, type);
             symbol.Sseg = Segments[Segments.Id.protolist];
-            symbol.Sclass = SCcomdat;
+            symbol.Sclass = SC.comdat;
             symbol.Sflags |= SFLhidden;
             symbol.Salignment = 3;
 
@@ -1324,7 +1324,7 @@ struct ProtocolDeclaration
 
         auto symbol = Symbols.getGlobal(symbolName, type);
         symbol.Sseg = Segments[Segments.Id.data];
-        symbol.Sclass = SCcomdat;
+        symbol.Sclass = SC.comdat;
         symbol.Sflags |= SFLhidden;
         symbol.Salignment = 3;
 

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -969,15 +969,15 @@ private extern (C++) class S2irVisitor : Visitor
              *          HALT
              */
             // volatile so optimizer won't delete it
-            Symbol *seax = symbol_name("__EAX", SCpseudo, type_fake(mTYvolatile | TYnptr));
+            Symbol *seax = symbol_name("__EAX", SC.pseudo, type_fake(mTYvolatile | TYnptr));
             seax.Sreglsw = 0;          // EAX, RAX, whatevs
             symbol_add(seax);
-            Symbol *sedx = symbol_name("__EDX", SCpseudo, type_fake(mTYvolatile | TYint));
+            Symbol *sedx = symbol_name("__EDX", SC.pseudo, type_fake(mTYvolatile | TYint));
             sedx.Sreglsw = 2;          // EDX, RDX, whatevs
             symbol_add(sedx);
-            Symbol *shandler = symbol_name("__handler", SCauto, tstypes[TYint]);
+            Symbol *shandler = symbol_name("__handler", SC.auto_, tstypes[TYint]);
             symbol_add(shandler);
-            Symbol *seo = symbol_name("__exception_object", SCauto, tspvoid);
+            Symbol *seo = symbol_name("__exception_object", SC.auto_, tspvoid);
             symbol_add(seo);
 
             elem *e1 = el_bin(OPeq, TYvoid, el_var(shandler), el_var(sedx)); // __handler = __RDX
@@ -1253,7 +1253,7 @@ private extern (C++) class S2irVisitor : Visitor
 
             /* Declare flag variable
              */
-            Symbol *sflag = symbol_name("__flag", SCauto, tstypes[TYint]);
+            Symbol *sflag = symbol_name("__flag", SC.auto_, tstypes[TYint]);
             symbol_add(sflag);
             finallyblock.flag = sflag;
             finallyblock.b_ret = retblock;
@@ -1264,10 +1264,10 @@ private extern (C++) class S2irVisitor : Visitor
              *  _flag = 0;
              */
             // Make it volatile so optimizer won't delete it
-            Symbol *sreg = symbol_name("__EAX", SCpseudo, type_fake(mTYvolatile | TYnptr));
+            Symbol *sreg = symbol_name("__EAX", SC.pseudo, type_fake(mTYvolatile | TYnptr));
             sreg.Sreglsw = 0;          // EAX, RAX, whatevs
             symbol_add(sreg);
-            Symbol *seo = symbol_name("__exception_object", SCauto, tspvoid);
+            Symbol *seo = symbol_name("__exception_object", SC.auto_, tspvoid);
             symbol_add(seo);
             assert(!landingPad.Belem);
             elem *e = el_bin(OPeq, TYvoid, el_var(seo), el_var(sreg));
@@ -1337,7 +1337,7 @@ private extern (C++) class S2irVisitor : Visitor
 
             /* Declare flag variable
              */
-            Symbol *sflag = symbol_name("__flag", SCauto, tstypes[TYint]);
+            Symbol *sflag = symbol_name("__flag", SC.auto_, tstypes[TYint]);
             symbol_add(sflag);
             finallyblock.flag = sflag;
             finallyblock.b_ret = retblock;
@@ -1471,7 +1471,7 @@ private extern (C++) class S2irVisitor : Visitor
                 case FLdsymbol:
                 case FLfunc:
                     sym = toSymbol(cast(Dsymbol)c.IEV1.Vdsym);
-                    if (sym.Sclass == SCauto && sym.Ssymnum == SYMIDX.max)
+                    if (sym.Sclass == SC.auto_ && sym.Ssymnum == SYMIDX.max)
                         symbol_add(sym);
                     c.IEV1.Vsym = sym;
                     c.IFL1 = sym.Sfl ? sym.Sfl : FLauto;
@@ -1499,7 +1499,7 @@ private extern (C++) class S2irVisitor : Visitor
                 {
                     Declaration d = cast(Declaration)c.IEV2.Vdsym;
                     sym = toSymbol(cast(Dsymbol)d);
-                    if (sym.Sclass == SCauto && sym.Ssymnum == SYMIDX.max)
+                    if (sym.Sclass == SC.auto_ && sym.Ssymnum == SYMIDX.max)
                         symbol_add(sym);
                     c.IEV2.Vsym = sym;
                     c.IFL2 = sym.Sfl ? sym.Sfl : FLauto;

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -235,14 +235,14 @@ Symbol *toSymbol(Dsymbol s)
                         message(vd.loc, "`%s` is thread local", vd.toChars());
                     }
                 }
-                s.Sclass = SCextern;
+                s.Sclass = SC.extern_;
                 s.Sfl = FLextern;
 
                 /* Make C static variables SCstatic
                  */
                 if (vd.storage_class & STC.static_ && vd.isCsymbol())
                 {
-                    s.Sclass = SCstatic;
+                    s.Sclass = SC.static_;
                     s.Sfl = FLdata;
                 }
 
@@ -255,7 +255,7 @@ Symbol *toSymbol(Dsymbol s)
             }
             else
             {
-                s.Sclass = SCauto;
+                s.Sclass = SC.auto_;
                 s.Sfl = FLauto;
 
                 if (vd.nestedrefs.dim)
@@ -343,8 +343,8 @@ Symbol *toSymbol(Dsymbol s)
             /* Make C static functions SCstatic
              */
             s.Sclass = (fd.storage_class & STC.static_ && fd.isCsymbol())
-                ? SCstatic
-                : SCglobal;
+                ? SC.static_
+                : SC.global;
 
             symbol_func(s);
             func_t *f = s.Sfunc;
@@ -449,7 +449,7 @@ Symbol *toSymbol(Dsymbol s)
 
         override void visit(ClassDeclaration cd)
         {
-            auto s = toSymbolX(cd, "__Class", SCextern, getClassInfoCType(), "Z");
+            auto s = toSymbolX(cd, "__Class", SC.extern_, getClassInfoCType(), "Z");
             s.Sfl = FLextern;
             s.Sflags |= SFLnodebug;
             result = s;
@@ -461,7 +461,7 @@ Symbol *toSymbol(Dsymbol s)
 
         override void visit(InterfaceDeclaration id)
         {
-            auto s = toSymbolX(id, "__Interface", SCextern, getClassInfoCType(), "Z");
+            auto s = toSymbolX(id, "__Interface", SC.extern_, getClassInfoCType(), "Z");
             s.Sfl = FLextern;
             s.Sflags |= SFLnodebug;
             result = s;
@@ -473,7 +473,7 @@ Symbol *toSymbol(Dsymbol s)
 
         override void visit(Module m)
         {
-            auto s = toSymbolX(m, "__ModuleInfo", SCextern, getClassInfoCType(), "Z");
+            auto s = toSymbolX(m, "__ModuleInfo", SC.extern_, getClassInfoCType(), "Z");
             s.Sfl = FLextern;
             s.Sflags |= SFLnodebug;
             result = s;
@@ -523,7 +523,7 @@ Symbol *toImport(Symbol *sym, Loc loc)
     t.Tcount++;
     auto s = symbol_calloc(id, idlen);
     s.Stype = t;
-    s.Sclass = SCextern;
+    s.Sclass = SC.extern_;
     s.Sfl = FLextern;
     return s;
 }
@@ -562,7 +562,7 @@ Symbol *toThunkSymbol(FuncDeclaration fd, int offset)
     char[6 + tmpnum.sizeof * 3 + 1] name = void;
 
     sprintf(name.ptr,"_THUNK%d",tmpnum++);
-    auto sthunk = symbol_name(name.ptr,SCstatic,fd.csym.Stype);
+    auto sthunk = symbol_name(name.ptr,SC.static_,fd.csym.Stype);
     sthunk.Sflags |= SFLnodebug | SFLartifical;
     sthunk.Sflags |= SFLimplem;
     outthunk(sthunk, fd.csym, 0, TYnptr, -offset, -1, 0);
@@ -601,7 +601,7 @@ Symbol *toVtblSymbol(ClassDeclaration cd, bool genCsymbol = true)
 
         auto t = type_allocn(TYnptr | mTYconst, tstypes[TYvoid]);
         t.Tmangle = mTYman_d;
-        auto s = toSymbolX(cd, "__vtbl", SCextern, t, "Z");
+        auto s = toSymbolX(cd, "__vtbl", SC.extern_, t, "Z");
         s.Sflags |= SFLnodebug;
         s.Sfl = FLextern;
 
@@ -650,7 +650,7 @@ Symbol *toInitializer(AggregateDeclaration ad)
         else
         {
             auto stag = fake_classsym(Id.ClassInfo);
-            auto s = toSymbolX(ad, "__init", SCextern, stag.Stype, "Z");
+            auto s = toSymbolX(ad, "__init", SC.extern_, stag.Stype, "Z");
             s.Sfl = FLextern;
             s.Sflags |= SFLnodebug;
             if (sd)
@@ -667,7 +667,7 @@ Symbol *toInitializer(EnumDeclaration ed)
     {
         auto stag = fake_classsym(Id.ClassInfo);
         assert(ed.ident);
-        auto s = toSymbolX(ed, "__init", SCextern, stag.Stype, "Z");
+        auto s = toSymbolX(ed, "__init", SC.extern_, stag.Stype, "Z");
         s.Sfl = FLextern;
         s.Sflags |= SFLnodebug;
         ed.sinit = s;
@@ -708,7 +708,7 @@ Symbol *aaGetSymbol(TypeAArray taa, const(char)* func, int flags)
     // Create new Symbol
 
     auto s = symbol_calloc(id, idlen);
-    s.Sclass = SCextern;
+    s.Sclass = SC.extern_;
     s.Ssymnum = SYMIDX.max;
     symbol_func(s);
 
@@ -732,7 +732,7 @@ Symbol* toSymbol(StructLiteralExp sle)
     auto t = type_alloc(TYint);
     t.Tcount++;
     auto s = symbol_calloc("internal", 8);
-    s.Sclass = SCstatic;
+    s.Sclass = SC.static_;
     s.Sfl = FLextern;
     s.Sflags |= SFLnodebug;
     s.Stype = t;
@@ -752,7 +752,7 @@ Symbol* toSymbol(ClassReferenceExp cre)
     auto t = type_alloc(TYint);
     t.Tcount++;
     auto s = symbol_calloc("internal", 8);
-    s.Sclass = SCstatic;
+    s.Sclass = SC.static_;
     s.Sfl = FLextern;
     s.Sflags |= SFLnodebug;
     s.Stype = t;
@@ -784,7 +784,7 @@ Symbol* toSymbolCpp(ClassDeclaration cd)
         __gshared Symbol *scpp;
         if (!scpp)
             scpp = fake_classsym(Id.cpp_type_info_ptr);
-        Symbol *s = toSymbolX(cd, "_cpp_type_info_ptr", SCcomdat, scpp.Stype, "");
+        Symbol *s = toSymbolX(cd, "_cpp_type_info_ptr", SC.comdat, scpp.Stype, "");
         s.Sfl = FLdata;
         s.Sflags |= SFLnodebug;
         auto dtb = DtBuilder(0);
@@ -807,7 +807,7 @@ Symbol *toSymbolCppTypeInfo(ClassDeclaration cd)
 {
     const id = target.cpp.typeInfoMangle(cd);
     auto s = symbol_calloc(id, cast(uint)strlen(id));
-    s.Sclass = SCextern;
+    s.Sclass = SC.extern_;
     s.Sfl = FLextern;          // C++ code will provide the definition
     s.Sflags |= SFLnodebug;
     auto t = type_fake(TYnptr);

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -656,7 +656,7 @@ elem *resolveLengthVar(VarDeclaration lengthVar, elem **pe, Type t1)
 
         L3:
             slength = toSymbol(lengthVar);
-            if (slength.Sclass == SCauto && slength.Ssymnum == SYMIDX.max)
+            if (slength.Sclass == SC.auto_ && slength.Ssymnum == SYMIDX.max)
                 symbol_add(slength);
 
             einit = el_bin(OPeq, TYsize_t, el_var(slength), elength);
@@ -823,7 +823,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
         symbol_struct_addField(Closstru.Ttag, "__chain", chaintype, 0);
 
         Symbol *sclosure;
-        sclosure = symbol_name("__closptr", SCauto, type_pointer(Closstru));
+        sclosure = symbol_name("__closptr", SC.auto_, type_pointer(Closstru));
         sclosure.Sflags |= SFLtrue | SFLfree;
         symbol_add(sclosure);
         irs.sclosure = sclosure;
@@ -985,7 +985,7 @@ void buildCapture(FuncDeclaration fd)
         }
 
         // generate pseudo symbol to put into functions' Sscope
-        Symbol *scapture = symbol_name("__captureptr", SCalias, type_pointer(capturestru));
+        Symbol *scapture = symbol_name("__captureptr", SC.alias_, type_pointer(capturestru));
         scapture.Sflags |= SFLtrue | SFLfree;
         //symbol_add(scapture);
         fd.csym.Sscope = scapture;

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -94,7 +94,7 @@ void genModuleInfo(Module m)
 
     //////////////////////////////////////////////
 
-    m.csym.Sclass = SCglobal;
+    m.csym.Sclass = SC.global;
     m.csym.Sfl = FLdata;
 
     auto dtb = DtBuilder(0);
@@ -341,7 +341,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
             assert(cd.semanticRun >= PASS.semantic3done);     // semantic() should have been run to completion
 
-            SC scclass = SCcomdat;
+            SC scclass = SC.comdat;
 
             // Put out the members
             /* There might be static ctors in the members, and they cannot
@@ -512,10 +512,10 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
                 // Generate static initializer
                 auto sinit = toInitializer(sd);
-                if (sinit.Sclass == SCextern)
+                if (sinit.Sclass == SC.extern_)
                 {
                     if (sinit == bzeroSymbol) assert(0);
-                    sinit.Sclass = sd.isInstantiated() ? SCcomdat : SCglobal;
+                    sinit.Sclass = sd.isInstantiated() ? SC.comdat : SC.global;
                     sinit.Sfl = FLdata;
                     auto dtb = DtBuilder(0);
                     StructDeclaration_toDt(sd, dtb);
@@ -529,7 +529,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                     if (config.objfmt != OBJ_MACH &&
                         dtallzeros(sinit.Sdt))
                     {
-                        sinit.Sclass = SCglobal;
+                        sinit.Sclass = SC.global;
                         dt2common(&sinit.Sdt);
                     }
                     else
@@ -593,12 +593,12 @@ void toObjFile(Dsymbol ds, bool multiobj)
             uint sz = cast(uint)sz64;
 
             Dsymbol parent = vd.toParent();
-            s.Sclass = SCglobal;
+            s.Sclass = SC.global;
 
             /* Make C static functions SCstatic
              */
             if (vd.storage_class & STC.static_ && vd.isCsymbol())
-                s.Sclass = SCstatic;
+                s.Sclass = SC.static_;
 
             do
             {
@@ -608,7 +608,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                  */
                 if (parent.isTemplateInstance() && !parent.isTemplateMixin())
                 {
-                    s.Sclass = SCcomdat;
+                    s.Sclass = SC.comdat;
                     break;
                 }
                 parent = parent.parent;
@@ -649,16 +649,16 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
             // See if we can convert a comdat to a comdef,
             // which saves on exe file space.
-            if (s.Sclass == SCcomdat &&
+            if (s.Sclass == SC.comdat &&
                 s.Sdt &&
                 dtallzeros(s.Sdt) &&
                 !vd.isThreadlocal())
             {
-                s.Sclass = SCglobal;
+                s.Sclass = SC.global;
                 dt2common(&s.Sdt);
             }
 
-            if (s.Sclass & SCglobal && s.Stype.Tty & mTYconst)
+            if (s.Sclass & SC.global && s.Stype.Tty & mTYconst)
                 out_readonly(s);
 
             outdata(s);
@@ -697,9 +697,9 @@ void toObjFile(Dsymbol ds, bool multiobj)
             }
             else
             {
-                SC scclass = SCglobal;
+                SC scclass = SC.global;
                 if (ed.isInstantiated())
-                    scclass = SCcomdat;
+                    scclass = SC.comdat;
 
                 // Generate static initializer
                 toInitializer(ed);
@@ -729,7 +729,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             }
 
             Symbol *s = toSymbol(tid);
-            s.Sclass = SCcomdat;
+            s.Sclass = SC.comdat;
             s.Sfl = FLdata;
 
             auto dtb = DtBuilder(0);
@@ -738,10 +738,10 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
             // See if we can convert a comdat to a comdef,
             // which saves on exe file space.
-            if (s.Sclass == SCcomdat &&
+            if (s.Sclass == SC.comdat &&
                 dtallzeros(s.Sdt))
             {
-                s.Sclass = SCglobal;
+                s.Sclass = SC.global;
                 dt2common(&s.Sdt);
             }
 
@@ -948,7 +948,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             outdata(tlvInit);
 
             if (target.is64bit)
-                tlvInit.Sclass = SCextern;
+                tlvInit.Sclass = SC.extern_;
 
             Symbol* tlvBootstrap = objmod.tlv_bootstrap();
             dtb.xoff(tlvBootstrap, 0, TYnptr);
@@ -980,7 +980,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             type_setty(&t, t.Tty | mTYthreadData);
             type_setmangle(&t, mangle(vd));
 
-            Symbol *tlvInit = symbol_name(tlvInitName, SCstatic, t);
+            Symbol *tlvInit = symbol_name(tlvInitName, SC.static_, t);
             tlvInit.Sdt = null;
             tlvInit.Salignment = type_alignsize(s.Stype);
             if (vd._linkage == LINK.cpp)
@@ -1197,7 +1197,7 @@ private size_t emitVtbl(ref DtBuilder dtb, BaseClass *b, ref FuncDeclarations bv
 private void genClassInfoForClass(ClassDeclaration cd, Symbol* sinit)
 {
     // Put out the ClassInfo, which will be the __ClassZ symbol in the object file
-    SC scclass = SCcomdat;
+    SC scclass = SC.comdat;
     cd.csym.Sclass = scclass;
     cd.csym.Sfl = FLdata;
 
@@ -1438,7 +1438,7 @@ Louter:
  */
 private void genClassInfoForInterface(InterfaceDeclaration id)
 {
-    SC scclass = SCcomdat;
+    SC scclass = SC.comdat;
 
     // Put out the ClassInfo
     id.csym.Sclass = scclass;


### PR DESCRIPTION
Follow up to #14399
I removed the first ~5 of the enum aliases here and the diff was big enough that I figured I'd spread it across a couple of PRs.  I also replaced entire switch/case blocks using the ones I removed, and other easily visible nearby uses of SCxxx enums.