### PR TITLE
Refactor unittest in chkformat.d

### DIFF
--- a/compiler/src/dmd/chkformat.d
+++ b/compiler/src/dmd/chkformat.d
@@ -1079,386 +1079,210 @@ Format parseGenericFormatSpecifier(scope const char[] format,
     return specifier; // success
 }
 
-unittest
+@("parseGenericFormatSpecifier") unittest
 {
-    /* parseGenericFormatSpecifier
-     */
-
     char genSpecifier;
     size_t idx;
 
-    assert(parseGenericFormatSpecifier("hhd", idx, genSpecifier) == Format.hhd);
-    assert(genSpecifier == 'd');
+    void testG(string fmtStr, Format expectedFormat, char expectedGenSpecifier)
+    {
+        idx = 0;
+        assert(parseGenericFormatSpecifier(fmtStr, idx, genSpecifier) == expectedFormat);
+        assert(genSpecifier == expectedGenSpecifier);
+    }
 
-    idx = 0;
-    assert(parseGenericFormatSpecifier("hn", idx, genSpecifier) == Format.hn);
-    assert(genSpecifier == 'n');
-
-    idx = 0;
-    assert(parseGenericFormatSpecifier("ji", idx, genSpecifier) == Format.jd);
-    assert(genSpecifier == 'i');
-
-    idx = 0;
-    assert(parseGenericFormatSpecifier("lu", idx, genSpecifier) == Format.lu);
-    assert(genSpecifier == 'u');
+    testG("hhd", Format.hhd, 'd');
+    testG("hn", Format.hn, 'n');
+    testG("ji", Format.jd, 'i');
+    testG("lu", Format.lu, 'u');
 
     idx = 0;
     assert(parseGenericFormatSpecifier("k", idx, genSpecifier) == Format.error);
+}
 
-    /* parsePrintfFormatSpecifier
-     */
+@("parsePrintfFormatSpecifier") unittest
+{
+    bool useGNUExts = false;
 
-     bool widthStar;
-     bool precisionStar;
+    size_t idx = 0;
+    bool widthStar;
+    bool precisionStar;
 
-     // one for each Format
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%d", idx, widthStar, precisionStar) == Format.d);
-     assert(idx == 2);
-     assert(!widthStar && !precisionStar);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%ld", idx, widthStar, precisionStar) == Format.ld);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%lld", idx, widthStar, precisionStar) == Format.lld);
-     assert(idx == 4);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%jd", idx, widthStar, precisionStar) == Format.jd);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%zd", idx, widthStar, precisionStar) == Format.zd);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%td", idx, widthStar, precisionStar) == Format.td);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%g", idx, widthStar, precisionStar) == Format.g);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%Lg", idx, widthStar, precisionStar) == Format.Lg);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%p", idx, widthStar, precisionStar) == Format.p);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%n", idx, widthStar, precisionStar) == Format.n);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%ln", idx, widthStar, precisionStar) == Format.ln);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%lln", idx, widthStar, precisionStar) == Format.lln);
-     assert(idx == 4);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%hn", idx, widthStar, precisionStar) == Format.hn);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%hhn", idx, widthStar, precisionStar) == Format.hhn);
-     assert(idx == 4);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%jn", idx, widthStar, precisionStar) == Format.jn);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%zn", idx, widthStar, precisionStar) == Format.zn);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%tn", idx, widthStar, precisionStar) == Format.tn);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%c", idx, widthStar, precisionStar) == Format.c);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%lc", idx, widthStar, precisionStar) == Format.lc);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%s", idx, widthStar, precisionStar) == Format.s);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%ls", idx, widthStar, precisionStar) == Format.ls);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%%", idx, widthStar, precisionStar) == Format.percent);
-     assert(idx == 2);
-
-     // Synonyms
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%i", idx, widthStar, precisionStar) == Format.d);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%u", idx, widthStar, precisionStar) == Format.u);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%o", idx, widthStar, precisionStar) == Format.u);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%x", idx, widthStar, precisionStar) == Format.u);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%X", idx, widthStar, precisionStar) == Format.u);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%f", idx, widthStar, precisionStar) == Format.g);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%F", idx, widthStar, precisionStar) == Format.g);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%G", idx, widthStar, precisionStar) == Format.g);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%a", idx, widthStar, precisionStar) == Format.g);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%La", idx, widthStar, precisionStar) == Format.Lg);
-     assert(idx == 3);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%A", idx, widthStar, precisionStar) == Format.g);
-     assert(idx == 2);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%lg", idx, widthStar, precisionStar) == Format.lg);
-     assert(idx == 3);
-
-     // width, precision
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%*d", idx, widthStar, precisionStar) == Format.d);
-     assert(idx == 3);
-     assert(widthStar && !precisionStar);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%.*d", idx, widthStar, precisionStar) == Format.d);
-     assert(idx == 4);
-     assert(!widthStar && precisionStar);
-
-     idx = 0;
-     assert(parsePrintfFormatSpecifier("%*.*d", idx, widthStar, precisionStar) == Format.d);
-     assert(idx == 5);
-     assert(widthStar && precisionStar);
-
-     // Too short formats
-     {
-         foreach (s; ["%", "%-", "%+", "% ", "%#", "%0", "%*", "%1", "%19", "%.", "%.*", "%.1", "%.12",
-                      "%j", "%z", "%t", "%l", "%h", "%ll", "%hh"])
-         {
-             idx = 0;
-             assert(parsePrintfFormatSpecifier(s, idx, widthStar, precisionStar) == Format.error);
-             assert(idx == s.length);
-         }
-     }
-
-     // Undefined format combinations
-     {
-         foreach (s; ["%#d", "%llg", "%jg", "%zg", "%tg", "%hg", "%hhg",
-                      "%#c", "%0c", "%jc", "%zc", "%tc", "%Lc", "%hc", "%hhc", "%llc",
-                      "%#s", "%0s", "%js", "%zs", "%ts", "%Ls", "%hs", "%hhs", "%lls",
-                      "%jp", "%zp", "%tp", "%Lp", "%hp", "%lp", "%hhp", "%llp",
-                      "%-n", "%+n", "% n", "%#n", "%0n", "%*n", "%1n", "%19n", "%.n", "%.*n", "%.1n", "%.12n", "%Ln", "%K"])
-         {
-             idx = 0;
-             assert(parsePrintfFormatSpecifier(s, idx, widthStar, precisionStar) == Format.error);
-             assert(idx == s.length);
-         }
-     }
-
-    /* parseScanfFormatSpecifier
-     */
-
-    bool asterisk;
+    void testP(string fmtStr, Format expectedFormat, size_t expectedIdx)
+    {
+        idx = 0;
+        assert(parsePrintfFormatSpecifier(fmtStr, idx, widthStar, precisionStar, useGNUExts) == expectedFormat);
+        assert(idx == expectedIdx);
+    }
 
     // one for each Format
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%d", idx, asterisk) == Format.d);
-    assert(idx == 2);
-    assert(!asterisk);
+    testP("%d", Format.d, 2);
+    assert(!widthStar && !precisionStar);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%hhd", idx, asterisk) == Format.hhd);
-    assert(idx == 4);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%hd", idx, asterisk) == Format.hd);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%ld", idx, asterisk) == Format.ld);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%lld", idx, asterisk) == Format.lld);
-    assert(idx == 4);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%jd", idx, asterisk) == Format.jd);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%zd", idx, asterisk) == Format.zd);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%td", idx, asterisk,) == Format.td);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%u", idx, asterisk) == Format.u);
-    assert(idx == 2);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%hhu", idx, asterisk,) == Format.hhu);
-    assert(idx == 4);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%hu", idx, asterisk) == Format.hu);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%lu", idx, asterisk) == Format.lu);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%llu", idx, asterisk) == Format.llu);
-    assert(idx == 4);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%ju", idx, asterisk) == Format.ju);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%g", idx, asterisk) == Format.g);
-    assert(idx == 2);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%lg", idx, asterisk) == Format.lg);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%Lg", idx, asterisk) == Format.Lg);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%p", idx, asterisk) == Format.p);
-    assert(idx == 2);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%s", idx, asterisk) == Format.s);
-    assert(idx == 2);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%ls", idx, asterisk,) == Format.ls);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%%", idx, asterisk) == Format.percent);
-    assert(idx == 2);
+    testP("%ld", Format.ld, 3);
+    testP("%lld", Format.lld, 4);
+    testP("%jd", Format.jd, 3);
+    testP("%zd", Format.zd, 3);
+    testP("%td", Format.td, 3);
+    testP("%g", Format.g, 2);
+    testP("%Lg", Format.Lg, 3);
+    testP("%p", Format.p, 2);
+    testP("%n", Format.n, 2);
+    testP("%ln", Format.ln, 3);
+    testP("%lln", Format.lln, 4);
+    testP("%hn", Format.hn, 3);
+    testP("%hhn", Format.hhn, 4);
+    testP("%jn", Format.jn, 3);
+    testP("%zn", Format.zn, 3);
+    testP("%tn", Format.tn, 3);
+    testP("%c", Format.c, 2);
+    testP("%lc", Format.lc, 3);
+    testP("%s", Format.s, 2);
+    testP("%ls", Format.ls, 3);
+    testP("%%", Format.percent, 2);
 
     // Synonyms
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%i", idx, asterisk) == Format.d);
-    assert(idx == 2);
+    testP("%i", Format.d, 2);
+    testP("%u", Format.u, 2);
+    testP("%o", Format.u, 2);
+    testP("%x", Format.u, 2);
+    testP("%X", Format.u, 2);
+    testP("%f", Format.g, 2);
+    testP("%F", Format.g, 2);
+    testP("%G", Format.g, 2);
+    testP("%a", Format.g, 2);
+    testP("%La", Format.Lg, 3);
+    testP("%A", Format.g, 2);
+    testP("%lg", Format.lg, 3);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%n", idx, asterisk) == Format.n);
-    assert(idx == 2);
+    // width, precision
+    testP("%*d", Format.d, 3);
+    assert(widthStar && !precisionStar);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%o", idx, asterisk) == Format.u);
-    assert(idx == 2);
+    testP("%.*d", Format.d, 4);
+    assert(!widthStar && precisionStar);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%x", idx, asterisk) == Format.u);
-    assert(idx == 2);
+    testP("%*.*d", Format.d, 5);
+    assert(widthStar && precisionStar);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%f", idx, asterisk) == Format.g);
-    assert(idx == 2);
+    // Too short formats
+    foreach (s; ["%", "%-", "%+", "% ", "%#", "%0", "%*", "%1", "%19", "%.", "%.*", "%.1", "%.12",
+                    "%j", "%z", "%t", "%l", "%h", "%ll", "%hh"])
+    {
+        testP(s, Format.error, s.length);
+    }
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%e", idx, asterisk) == Format.g);
-    assert(idx == 2);
+    // Undefined format combinations
+    foreach (s; ["%#d", "%llg", "%jg", "%zg", "%tg", "%hg", "%hhg",
+                    "%#c", "%0c", "%jc", "%zc", "%tc", "%Lc", "%hc", "%hhc", "%llc",
+                    "%#s", "%0s", "%js", "%zs", "%ts", "%Ls", "%hs", "%hhs", "%lls",
+                    "%jp", "%zp", "%tp", "%Lp", "%hp", "%lp", "%hhp", "%llp",
+                    "%-n", "%+n", "% n", "%#n", "%0n", "%*n", "%1n", "%19n", "%.n", "%.*n", "%.1n", "%.12n", "%Ln", "%K"])
+    {
+        testP(s, Format.error, s.length);
+    }
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%a", idx, asterisk) == Format.g);
-    assert(idx == 2);
+    testP("%C", Format.lc, 2);
+    testP("%S", Format.ls, 2);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%c", idx, asterisk) == Format.c);
-    assert(idx == 2);
+    // GNU extensions: explicitly toggle ISO/GNU flag.
+    foreach (s; ["%jm", "%zm", "%tm", "%Lm", "%hm", "%hhm", "%lm", "%llm",
+                    "%#m", "%+m", "%-m", "% m", "%0m"])
+    {
+        useGNUExts = false;
+        testP(s, Format.error, s.length);
+        useGNUExts = true;
+        testP(s, Format.error, s.length);
+    }
+
+    foreach (s; ["%m", "%md", "%mz", "%mc", "%mm", "%msyz", "%ml", "%mlz", "%mlc", "%mlm"])
+    {
+        // valid cases, all parsed as `%m`
+        // GNU printf()
+        useGNUExts = true;
+        testP(s, Format.GNU_m, 2);
+
+        // ISO printf()
+        useGNUExts = false;
+        testP(s, Format.error, 2);
+    }
+}
+
+@("parseScanfFormatSpecifier") unittest
+{
+    size_t idx;
+    bool asterisk;
+
+    void testS(string fmtStr, Format expectedFormat, size_t expectedIdx)
+    {
+        idx = 0;
+        assert(parseScanfFormatSpecifier(fmtStr, idx, asterisk) == expectedFormat);
+        assert(idx == expectedIdx);
+    }
+
+    // one for each Format
+    testS("%d", Format.d, 2);
+    testS("%hhd", Format.hhd, 4);
+    testS("%hd", Format.hd, 3);
+    testS("%ld", Format.ld, 3);
+    testS("%lld", Format.lld, 4);
+    testS("%jd", Format.jd, 3);
+    testS("%zd", Format.zd, 3);
+    testS("%td", Format.td, 3);
+    testS("%u", Format.u, 2);
+    testS("%hhu", Format.hhu, 4);
+    testS("%hu", Format.hu, 3);
+    testS("%lu", Format.lu, 3);
+    testS("%llu", Format.llu, 4);
+    testS("%ju", Format.ju, 3);
+    testS("%g", Format.g, 2);
+    testS("%lg", Format.lg, 3);
+    testS("%Lg", Format.Lg, 3);
+    testS("%p", Format.p, 2);
+    testS("%s", Format.s, 2);
+    testS("%ls", Format.ls, 3);
+    testS("%%", Format.percent, 2);
+
+    // Synonyms
+    testS("%i", Format.d, 2);
+    testS("%n", Format.n, 2);
+
+    testS("%o", Format.u, 2);
+    testS("%x", Format.u, 2);
+    testS("%f", Format.g, 2);
+    testS("%e", Format.g, 2);
+    testS("%a", Format.g, 2);
+    testS("%c", Format.c, 2);
 
     // asterisk
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%*d", idx, asterisk) == Format.d);
-    assert(idx == 3);
+    testS("%*d", Format.d, 3);
     assert(asterisk);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%9ld", idx, asterisk) == Format.ld);
-    assert(idx == 4);
+    testS("%9ld", Format.ld, 4);
     assert(!asterisk);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%*25984hhd", idx, asterisk) == Format.hhd);
-    assert(idx == 10);
+    testS("%*25984hhd", Format.hhd, 10);
     assert(asterisk);
 
     // scansets
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%[a-zA-Z]", idx, asterisk) == Format.s);
-    assert(idx == 9);
+    testS("%[a-zA-Z]", Format.s, 9);
     assert(!asterisk);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%*25l[a-z]", idx, asterisk) == Format.ls);
-    assert(idx == 10);
+    testS("%*25l[a-z]", Format.ls, 10);
     assert(asterisk);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%[]]", idx, asterisk) == Format.s);
-    assert(idx == 4);
+    testS("%[]]", Format.s, 4);
     assert(!asterisk);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%[^]]", idx, asterisk) == Format.s);
-    assert(idx == 5);
+    testS("%[^]]", Format.s, 5);
     assert(!asterisk);
 
     // Too short formats
     foreach (s; ["%", "% ", "%#", "%0", "%*", "%1", "%19",
                  "%j", "%z", "%t", "%l", "%h", "%ll", "%hh", "%K"])
     {
-        idx = 0;
-        assert(parseScanfFormatSpecifier(s, idx, asterisk) == Format.error);
-        assert(idx == s.length);
+
+        testS(s, Format.error, s.length);
     }
 
 
@@ -1468,18 +1292,16 @@ unittest
                  "%jp", "%zp", "%tp", "%Lp", "%hp", "%lp", "%hhp", "%llp",
                  "%-", "%+", "%#", "%0", "%.", "%Ln"])
     {
-        idx = 0;
-        assert(parseScanfFormatSpecifier(s, idx, asterisk) == Format.error);
-        assert(idx == s.length);
+
+        testS(s, Format.error, s.length);
 
     }
 
     // Invalid scansets
     foreach (s; ["%[]", "%[^", "%[^]", "%[s", "%[0-9lld", "%[", "%l[^]"])
     {
-        idx = 0;
-        assert(parseScanfFormatSpecifier(s, idx, asterisk) == Format.error);
-        assert(idx == s.length);
+
+        testS(s, Format.error, s.length);
     }
 
     // Posix extensions
@@ -1488,95 +1310,19 @@ unittest
                  "%LC", "%lC", "%llC", "%jC", "%tC", "%hC", "%hhC", "%zC",
                  "%LS", "%lS", "%llS", "%jS", "%tS", "%hS", "%hhS", "%zS"])
     {
-        idx = 0;
-        assert(parseScanfFormatSpecifier(s, idx, asterisk) == Format.error);
-        assert(idx == s.length);
+
+        testS(s, Format.error, s.length);
     }
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%mc", idx, asterisk) == Format.POSIX_ms);
-    assert(idx == 3);
+    testS("%mc", Format.POSIX_ms, 3);
+    testS("%ms", Format.POSIX_ms, 3);
+    testS("%m[0-9]", Format.POSIX_ms, 7);
+    testS("%mlc", Format.POSIX_mls, 4);
+    testS("%mls", Format.POSIX_mls, 4);
+    testS("%ml[^0-9]", Format.POSIX_mls, 9);
+    testS("%mC", Format.POSIX_mls, 3);
+    testS("%mS", Format.POSIX_mls, 3);
 
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%ms", idx, asterisk) == Format.POSIX_ms);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%m[0-9]", idx, asterisk) == Format.POSIX_ms);
-    assert(idx == 7);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%mlc", idx, asterisk) == Format.POSIX_mls);
-    assert(idx == 4);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%mls", idx, asterisk) == Format.POSIX_mls);
-    assert(idx == 4);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%ml[^0-9]", idx, asterisk) == Format.POSIX_mls);
-    assert(idx == 9);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%mC", idx, asterisk) == Format.POSIX_mls);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%mS", idx, asterisk) == Format.POSIX_mls);
-    assert(idx == 3);
-
-    idx = 0;
-    assert(parsePrintfFormatSpecifier("%C", idx, widthStar, precisionStar) == Format.lc);
-    assert(idx == 2);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%C", idx, asterisk) == Format.lc);
-    assert(idx == 2);
-
-    idx = 0;
-    assert(parsePrintfFormatSpecifier("%S", idx, widthStar, precisionStar) == Format.ls);
-    assert(idx == 2);
-
-    idx = 0;
-    assert(parseScanfFormatSpecifier("%S", idx, asterisk) == Format.ls);
-    assert(idx == 2);
-
-    // GNU extensions: explicitly toggle ISO/GNU flag.
-    // ISO printf()
-    bool useGNUExts = false;
-    {
-        foreach (s; ["%jm", "%zm", "%tm", "%Lm", "%hm", "%hhm", "%lm", "%llm",
-                     "%#m", "%+m", "%-m", "% m", "%0m"])
-        {
-            idx = 0;
-            assert(parsePrintfFormatSpecifier(s, idx, widthStar, precisionStar, useGNUExts) == Format.error);
-            assert(idx == s.length);
-        }
-        foreach (s; ["%m", "%md", "%mz", "%mc", "%mm", "%msyz", "%ml", "%mlz", "%mlc", "%mlm"])
-        {
-            idx = 0;
-            assert(parsePrintfFormatSpecifier(s, idx, widthStar, precisionStar, useGNUExts) == Format.error);
-            assert(idx == 2);
-        }
-    }
-
-    // GNU printf()
-    useGNUExts = true;
-    {
-        foreach (s; ["%jm", "%zm", "%tm", "%Lm", "%hm", "%hhm", "%lm", "%llm",
-                     "%#m", "%+m", "%-m", "% m", "%0m"])
-        {
-            idx = 0;
-            assert(parsePrintfFormatSpecifier(s, idx, widthStar, precisionStar, useGNUExts) == Format.error);
-            assert(idx == s.length);
-        }
-
-        // valid cases, all parsed as `%m`
-        foreach (s; ["%m", "%md", "%mz", "%mc", "%mm", "%msyz", "%ml", "%mlz", "%mlc", "%mlm"])
-        {
-            idx = 0;
-            assert(parsePrintfFormatSpecifier(s, idx, widthStar, precisionStar, useGNUExts) == Format.GNU_m);
-            assert(idx == 2);
-        }
-    }
+    testS("%C", Format.lc, 2);
+    testS("%S", Format.ls, 2);
 }


### PR DESCRIPTION
I noticed the indentation was off in unittests of chkformat.d (using 5 spaces), then I noticed a large amount of code duplication obfuscating the actual test cases. Here I'm using nested functions to replace this pattern:

```D
     idx = 0;
     assert(parsePrintfFormatSpecifier("%d", idx, widthStar, precisionStar) == Format.d);
     assert(idx == 2);
```

With this:

```D
    testP("%d", Format.d, 2);
```

I group tests for `parseGenericFormatSpecifier`, `parsePrintfFormatSpecifier` and `parseScanfFormatSpecifier` into their own `unittest` blocks.