### PR TITLE
fix Issue 23030 - importC: errors using typedef struct after first us…

### DIFF
--- a/compiler/test/compilable/test23030.c
+++ b/compiler/test/compilable/test23030.c
@@ -1,0 +1,15 @@
+
+// https://issues.dlang.org/show_bug.cgi?id=23030
+
+typedef struct {
+    int i;
+} S1;
+const S1 unused;
+S1 s;
+void fn() { int i = s.i; } // Error: need `this` for `i` of type `int`
+
+typedef struct {
+    int a,b;
+} S2;
+const S2 aaa = { 0,0 };
+S2 bbb = { 0,0 }; // Error: 1 extra initializer(s) for `struct __tag3`


### PR DESCRIPTION
…e as const

This is working in master, this just adds the test cases to ensure it stays working.