### PR TITLE
Clarify code around 32 bits OMF compression of symbols

### DIFF
--- a/compiler/src/dmd/backend/compress.d
+++ b/compiler/src/dmd/backend/compress.d
@@ -1,8 +1,8 @@
 /**
- * Identifier comperssion
+ * Identifier compression for 32 bits OMF builds
  *
- * Compiler implementation of the
- * $(LINK2 https://www.dlang.org, D programming language).
+ * On 32 bits OMF builds, we have a limit of 128 characters for identifiers.
+ * When this limit is reached, this code is called to attempt to compress the identifier.
  *
  * Copyright:   Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)

--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -2720,7 +2720,12 @@ unittest
 }
 
 /*
+ * Expand an OMF, DMD-generated compressed identifier into its full form
  *
+ * This function only has a visible effect for OMF binaries (Win32),
+ * as compression is otherwise not used.
+ *
+ * See_Also: `compiler/src/dmd/backend/compress.d`
  */
 string decodeDmdString( const(char)[] ln, ref size_t p ) nothrow pure @safe
 {

--- a/druntime/src/core/sys/windows/stacktrace.d
+++ b/druntime/src/core/sys/windows/stacktrace.d
@@ -288,7 +288,8 @@ private:
         auto res = formatStackFrame(pc);
         res ~= " in ";
         const(char)[] tempSymName = symName[0 .. strlen(symName)];
-        //Deal with dmd mangling of long names
+        // Deal with dmd mangling of long names for OMF 32 bits builds
+        // Note that `target.d` only defines `CRuntime_DigitalMars` for OMF builds
         version (CRuntime_DigitalMars)
         {
             size_t decodeIndex = 0;


### PR DESCRIPTION
~Thanks to the new mangling scheme, it shouldn't be needed anymore.~

```
While looking at the stack-trace code, I came accross 'decodeDmdString',
which seemed like it was no longer needed. After a comment from Rainers,
it turned out to still be required for OMF builds, so this adds comments
in all places where this appears for the next reader, as well as make
the decodeDmdString function package so that it doesn't show up in documentation.
```