### PR TITLE
TypeFunction.callMatch: Extract code to match typesafe variadic argument

### DIFF
--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4745,10 +4745,7 @@ extern (C++) final class TypeFunction : TypeNext
                     if (argStruct && argStruct == prmStruct && argStruct.hasCopyCtor)
                     {
                         if (!isCopyConstructorCallable(argStruct, arg, tprm, sc, pMessage))
-                        {
-                            m = MATCH.nomatch;
                             return MATCH.nomatch;
-                        }
                         m = MATCH.exact;
                     }
                     else

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4857,8 +4857,6 @@ extern (C++) final class TypeFunction : TypeNext
             }
             else if (p.defaultArg)
                 continue;
-            else // try typesafe variadics
-                goto L1;
 
             /* prefer matching the element type rather than the array
              * type when more arguments are present with T[]...

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4710,13 +4710,9 @@ extern (C++) final class TypeFunction : TypeNext
             MATCH m;
 
             assert(p);
-            if (u >= nargs)
-            {
-                if (p.defaultArg)
-                    continue;
-                // try typesafe variadics
-                goto L1;
-            }
+
+            // One or more arguments remain
+            if (u < nargs)
             {
                 Expression arg = args[u];
                 assert(arg);
@@ -4859,6 +4855,10 @@ extern (C++) final class TypeFunction : TypeNext
                     }
                 }
             }
+            else if (p.defaultArg)
+                continue;
+            else // try typesafe variadics
+                goto L1;
 
             /* prefer matching the element type rather than the array
              * type when more arguments are present with T[]...


### PR DESCRIPTION
That one wasn't fun but it should make the code much clearer.