### PR TITLE
fix Issue 23327 - [ICE] SEGV in AssocArray!(Identifier, Dsymbol).AssocArray.opIndex(const(Identifier)) at src/dmd/root/aav.d:313

### DIFF
--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -265,11 +265,16 @@ extern (C++) final class Import : Dsymbol
             scopesym.addAccessiblePackage(p, visibility);
             foreach (id; packages[1 .. $]) // [b, c]
             {
-                p = cast(Package) p.symtab.lookup(id);
+                auto sym = p.symtab.lookup(id);
                 // https://issues.dlang.org/show_bug.cgi?id=17991
                 // An import of truly empty file/package can happen
                 // https://issues.dlang.org/show_bug.cgi?id=20151
                 // Package in the path conflicts with a module name
+                if (sym is null)
+                    break;
+                // https://issues.dlang.org/show_bug.cgi?id=23327
+                // Package conflicts with symbol of the same name
+                p = sym.isPackage();
                 if (p is null)
                     break;
                 scopesym.addAccessiblePackage(p, visibility);

--- a/compiler/test/compilable/imports/format23327.d
+++ b/compiler/test/compilable/imports/format23327.d
@@ -1,0 +1,7 @@
+module imports.format23327;
+
+import imports.format23327.write;
+
+immutable(string) format23327() { }
+
+import imports.format23327.internal.write;

--- a/compiler/test/compilable/test23327.d
+++ b/compiler/test/compilable/test23327.d
@@ -1,0 +1,3 @@
+// https://issues.dlang.org/show_bug.cgi?id=23327
+// EXTRA_FILES: imports/format23327.d imports/format23327/write.d
+import imports.format23327;


### PR DESCRIPTION
This occurs when `symtab.lookup(id)` returns another kind of symbol - the test has a `FuncDeclaration`, but we still blindly cast it to a `Package` without any verification.