### PR TITLE
Show left expression in *no property* error when `searchUFCS` fails

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -440,7 +440,7 @@ private Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
     }
 
     if (!s)
-        return ue.e1.type.getProperty(sc, loc, ident, 0);
+        return ue.e1.type.getProperty(sc, loc, ident, 0, ue.e1);
 
     FuncDeclaration f = s.isFuncDeclaration();
     if (f)

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -2096,10 +2096,12 @@ extern (C++) Type merge(Type type)
  *  loc = the location where the property is encountered
  *  ident = the identifier of the property
  *  flag = if flag & 1, don't report "not a property" error and just return NULL.
+ *  src = expression for type `t` or null.
  * Returns:
  *      expression representing the property, or null if not a property and (flag & 1)
  */
-Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier ident, int flag)
+Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier ident, int flag,
+    Expression src = null)
 {
     Expression visitType(Type mt)
     {
@@ -2176,7 +2178,10 @@ Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier iden
                         error(loc, "no property `%s` for type `%s`, perhaps `import %.*s;` is needed?", ident.toChars(), mt.toChars(), cast(int)n.length, n.ptr);
                 else
                 {
-                    error(loc, "no property `%s` for type `%s`", ident.toChars(), mt.toPrettyChars(true));
+                    if (src)
+                        error(loc, "no property `%s` for `%s` of type `%s`", ident.toChars(), src.toChars(), mt.toPrettyChars(true));
+                    else
+                        error(loc, "no property `%s` for type `%s`", ident.toChars(), mt.toPrettyChars(true));
                     if (auto dsym = mt.toDsymbol(scope_))
                         if (auto sym = dsym.isAggregateDeclaration())
                         {

--- a/compiler/test/fail_compilation/diag10169.d
+++ b/compiler/test/fail_compilation/diag10169.d
@@ -2,7 +2,7 @@
 EXTRA_FILES: imports/a10169.d
 TEST_OUTPUT:
 ---
-fail_compilation/diag10169.d(12): Error: no property `x` for type `imports.a10169.B`
+fail_compilation/diag10169.d(12): Error: no property `x` for `B(0)` of type `imports.a10169.B`
 ---
 */
 import imports.a10169;

--- a/compiler/test/fail_compilation/diag10783.d
+++ b/compiler/test/fail_compilation/diag10783.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10783.d(14): Error: no property `type` for type `diag10783.Event`
+fail_compilation/diag10783.d(14): Error: no property `type` for `event` of type `diag10783.Event`
 fail_compilation/diag10783.d(14): Error: undefined identifier `En`
 ---
 */

--- a/compiler/test/fail_compilation/diag14145.d
+++ b/compiler/test/fail_compilation/diag14145.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag14145.d(15): Error: no property `i` for type `diag14145.main.Capture!(i)`
+fail_compilation/diag14145.d(15): Error: no property `i` for `_` of type `diag14145.main.Capture!(i)`
 fail_compilation/diag14145.d(15):        potentially malformed `opDispatch`. Use an explicit instantiation to get a better error message
 fail_compilation/diag14145.d(34): Error: expression `*this.ptr` of type `shared(int)` is not implicitly convertible to return type `ref int`
 fail_compilation/diag14145.d(16): Error: template instance `diag14145.main.Capture!(i).Capture.opDispatch!"i"` error instantiating

--- a/compiler/test/fail_compilation/diag15713.d
+++ b/compiler/test/fail_compilation/diag15713.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag15713.d(19): Error: no property `widthSign` for type `diag15713.WrData.Data`
+fail_compilation/diag15713.d(19): Error: no property `widthSign` for `this` of type `diag15713.WrData.Data`
 fail_compilation/diag15713.d(39): Error: template instance `diag15713.conwritefImpl!("parse-int", "width", "\n", Data(null))` error instantiating
 fail_compilation/diag15713.d(44):        instantiated from here: `conwritefImpl!("main", "\n", Data(null))`
 fail_compilation/diag15713.d(49):        instantiated from here: `fdwritef!()`

--- a/compiler/test/fail_compilation/diag8894.d
+++ b/compiler/test/fail_compilation/diag8894.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8894.d(16): Error: no property `x` for type `diag8894.Foo`
-fail_compilation/diag8894.d(17): Error: no property `y` for type `diag8894.Foo`
-fail_compilation/diag8894.d(18): Error: no property `x` for type `diag8894.Foo`
-fail_compilation/diag8894.d(19): Error: no property `x` for type `diag8894.Foo`
+fail_compilation/diag8894.d(16): Error: no property `x` for `f` of type `diag8894.Foo`
+fail_compilation/diag8894.d(17): Error: no property `y` for `f` of type `diag8894.Foo`
+fail_compilation/diag8894.d(18): Error: no property `x` for `f` of type `diag8894.Foo`
+fail_compilation/diag8894.d(19): Error: no property `x` for `f` of type `diag8894.Foo`
 ---
 */
 

--- a/compiler/test/fail_compilation/dip22a.d
+++ b/compiler/test/fail_compilation/dip22a.d
@@ -2,11 +2,11 @@
 EXTRA_FILES: imports/dip22a.d
 TEST_OUTPUT:
 ---
-fail_compilation/dip22a.d(16): Error: no property `bar` for type `imports.dip22a.Klass`
-fail_compilation/dip22a.d(17): Error: no property `bar` for type `imports.dip22a.Struct`
+fail_compilation/dip22a.d(16): Error: no property `bar` for `new Klass` of type `imports.dip22a.Klass`
+fail_compilation/dip22a.d(17): Error: no property `bar` for `Struct()` of type `imports.dip22a.Struct`
 fail_compilation/dip22a.d(18): Error: undefined identifier `bar` in module `imports.dip22a`
-fail_compilation/dip22a.d(19): Error: no property `bar` for type `void`
-fail_compilation/dip22a.d(20): Error: no property `bar` for type `int`
+fail_compilation/dip22a.d(19): Error: no property `bar` for `Template!int` of type `void`
+fail_compilation/dip22a.d(20): Error: no property `bar` for `12` of type `int`
 ---
 */
 import imports.dip22a;

--- a/compiler/test/fail_compilation/fail121.d
+++ b/compiler/test/fail_compilation/fail121.d
@@ -3,8 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail121.d(23): Error: no property `typeinfo` for type `fail121.myobject`
-fail_compilation/fail121.d(23): Error: no property `typeinfo` for type `int`
+fail_compilation/fail121.d(23): Error: no property `typeinfo` for `list[1]` of type `fail121.myobject`
+fail_compilation/fail121.d(23): Error: no property `typeinfo` for `i` of type `int`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail18892.d
+++ b/compiler/test/fail_compilation/fail18892.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18892.d(20): Error: no property `foo` for type `fail18892.MT`
-fail_compilation/fail18892.d(21): Error: no property `foo` for type `fail18892.MT`
+fail_compilation/fail18892.d(20): Error: no property `foo` for `a` of type `fail18892.MT`
+fail_compilation/fail18892.d(21): Error: no property `foo` for `MT` of type `fail18892.MT`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail18970.d
+++ b/compiler/test/fail_compilation/fail18970.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18970.d(24): Error: no property `y` for type `fail18970.S`
+fail_compilation/fail18970.d(24): Error: no property `y` for `S()` of type `fail18970.S`
 fail_compilation/fail18970.d(24):        potentially malformed `opDispatch`. Use an explicit instantiation to get a better error message
-fail_compilation/fail18970.d(31): Error: no property `yyy` for type `fail18970.S2`
+fail_compilation/fail18970.d(31): Error: no property `yyy` for `this` of type `fail18970.S2`
 fail_compilation/fail18970.d(31):        potentially malformed `opDispatch`. Use an explicit instantiation to get a better error message
 ---
 */

--- a/compiler/test/fail_compilation/fail18979.d
+++ b/compiler/test/fail_compilation/fail18979.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18979.d(13): Error: no property `__ctor` for type `imports.imp18979.Foo`
+fail_compilation/fail18979.d(13): Error: no property `__ctor` for `Foo()` of type `imports.imp18979.Foo`
 ----
 */
 

--- a/compiler/test/fail_compilation/fail19103.d
+++ b/compiler/test/fail_compilation/fail19103.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail19103.d(12): Error: no property `puts` for type `fail19103.C`
-fail_compilation/fail19103.d(14): Error: no property `puts` for type `fail19103.S1`
+fail_compilation/fail19103.d(12): Error: no property `puts` for `new C` of type `fail19103.C`
+fail_compilation/fail19103.d(14): Error: no property `puts` for `s1` of type `fail19103.S1`
 fail_compilation/fail19103.d(16): Error: no property `puts` for type `S2`, did you mean `core.stdc.stdio.puts`?
 ---
 */

--- a/compiler/test/fail_compilation/fail19687.d
+++ b/compiler/test/fail_compilation/fail19687.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail19687.d(17): Error: no property `nonexisting` for type `string`
+fail_compilation/fail19687.d(17): Error: no property `nonexisting` for `""` of type `string`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail19913.d
+++ b/compiler/test/fail_compilation/fail19913.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail19913.d(11): Error: no property `b` for type `int`
+fail_compilation/fail19913.d(11): Error: no property `b` for `a` of type `int`
 fail_compilation/fail19913.d(11): Error: mixin `fail19913.S.b!()` is not defined
 ---
 */

--- a/compiler/test/fail_compilation/fail23109.d
+++ b/compiler/test/fail_compilation/fail23109.d
@@ -4,8 +4,8 @@ EXTRA_FILES: imports/test23109a.d imports/test23109b.d imports/test23109c.d
 EXTRA_SOURCES: extra-files/test23109/object.d
 TEST_OUTPUT:
 ---
-Error: no property `getHash` for type `object.TypeInfo_Const`
-Error: no property `getHash` for type `object.TypeInfo_Const`
+Error: no property `getHash` for `typeid(const(Ensure[]))` of type `object.TypeInfo_Const`
+Error: no property `getHash` for `typeid(const(Ensure[1]))` of type `object.TypeInfo_Const`
 fail_compilation/imports/test23109a.d(10): Error: template instance `imports.test23109a.Array!(Ensure)` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/faildottypeinfo.d
+++ b/compiler/test/fail_compilation/faildottypeinfo.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/faildottypeinfo.d(11): Error: no property `typeinfo` for type `int`
+fail_compilation/faildottypeinfo.d(11): Error: no property `typeinfo` for `0` of type `int`
 fail_compilation/faildottypeinfo.d(12): Error: no property `typeinfo` for type `object.Object`
 ---
 */

--- a/compiler/test/fail_compilation/failoffset.d
+++ b/compiler/test/fail_compilation/failoffset.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/failoffset.d(12): Error: no property `offset` for type `int`
+fail_compilation/failoffset.d(12): Error: no property `offset` for `b` of type `int`
 fail_compilation/failoffset.d(12):        while evaluating: `static assert(b.offset == 4)`
 ---
 */

--- a/compiler/test/fail_compilation/ice10938.d
+++ b/compiler/test/fail_compilation/ice10938.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10938.d(13): Error: no property `opts` for type `ice10938.C`
+fail_compilation/ice10938.d(13): Error: no property `opts` for `this` of type `ice10938.C`
 fail_compilation/ice10938.d(13):        potentially malformed `opDispatch`. Use an explicit instantiation to get a better error message
 ---
 */

--- a/compiler/test/fail_compilation/ice12174.d
+++ b/compiler/test/fail_compilation/ice12174.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12174.d(12): Error: no property `sum` for type `int[]`
+fail_compilation/ice12174.d(12): Error: no property `sum` for `[1, 2, 3]` of type `int[]`
 fail_compilation/ice12174.d(20): Error: CTFE failed because of previous errors in `this`
 fail_compilation/ice12174.d(13):        called from here: `filter([1, 2, 3])`
 ---

--- a/compiler/test/fail_compilation/ice18469.d
+++ b/compiler/test/fail_compilation/ice18469.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice18469.d(10): Error: no property `opCall` for type `void`
+fail_compilation/ice18469.d(10): Error: no property `opCall` for `this.~this()` of type `void`
 ---
 */
 class Bar

--- a/compiler/test/fail_compilation/ice19755.d
+++ b/compiler/test/fail_compilation/ice19755.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/ice19755.d(11): Error: no property `x` for type `ice19755.Thunk!int*`
+fail_compilation/ice19755.d(11): Error: no property `x` for `self` of type `ice19755.Thunk!int*`
 fail_compilation/ice19755.d(16): Error: template instance `ice19755.Thunk!int` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/mixinprop.d
+++ b/compiler/test/fail_compilation/mixinprop.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/mixinprop.d(11): Error: no property `x` for `mixin Foo!() F;
+fail_compilation/mixinprop.d(12): Error: no property `x` for `mixin Foo!() F;
 ` of type `void`
 ---
 */

--- a/compiler/test/fail_compilation/mixinprop.d
+++ b/compiler/test/fail_compilation/mixinprop.d
@@ -1,0 +1,13 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/mixinprop.d(11): Error: no property `x` for `mixin Foo!() F;
+` of type `void`
+---
+*/
+mixin template Foo() { }
+
+void main()
+{
+    mixin Foo F;
+    F.x;
+}

--- a/compiler/test/fail_compilation/objc_tupleof.d
+++ b/compiler/test/fail_compilation/objc_tupleof.d
@@ -1,7 +1,7 @@
 // EXTRA_OBJC_SOURCES:
 /* TEST_OUTPUT:
 ---
-fail_compilation/objc_tupleof.d(16): Error: no property `tupleof` for type `objc_tupleof.Foo`
+fail_compilation/objc_tupleof.d(16): Error: no property `tupleof` for `foo` of type `objc_tupleof.Foo`
 fail_compilation/objc_tupleof.d(16):        `tupleof` is not available for members of Objective-C classes. Please use the Objective-C runtime instead
 ---
 */

--- a/compiler/test/fail_compilation/objc_tupleof.d
+++ b/compiler/test/fail_compilation/objc_tupleof.d
@@ -1,7 +1,7 @@
 // EXTRA_OBJC_SOURCES:
 /* TEST_OUTPUT:
 ---
-fail_compilation/objc_tupleof.d(16): Error: no property `tupleof` for `foo` of type `objc_tupleof.Foo`
+fail_compilation/objc_tupleof.d(16): Error: no property `tupleof` for type `objc_tupleof.Foo`
 fail_compilation/objc_tupleof.d(16):        `tupleof` is not available for members of Objective-C classes. Please use the Objective-C runtime instead
 ---
 */

--- a/compiler/test/fail_compilation/test15785.d
+++ b/compiler/test/fail_compilation/test15785.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test15785.d(16): Error: no property `foo` for type `imports.test15785.Base`
+fail_compilation/test15785.d(16): Error: no property `foo` for `super` of type `imports.test15785.Base`
 fail_compilation/test15785.d(17): Error: undefined identifier `bar`
 ---
 */

--- a/compiler/test/fail_compilation/test15897.d
+++ b/compiler/test/fail_compilation/test15897.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test15897.d(19): Error: no property `create` for type `imports.test15897.Cat`
+fail_compilation/test15897.d(19): Error: no property `create` for `cat` of type `imports.test15897.Cat`
 ---
 */
 module test15897;

--- a/compiler/test/fail_compilation/test16188.d
+++ b/compiler/test/fail_compilation/test16188.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -preview=bitfields
  * TEST_OUTPUT:
 ---
-fail_compilation/test16188.d(101): Error: no property `name` for type `test16188.Where`
+fail_compilation/test16188.d(101): Error: no property `name` for `Where()` of type `test16188.Where`
 fail_compilation/test16188.d(101):        potentially malformed `opDispatch`. Use an explicit instantiation to get a better error message
 ---
  */

--- a/compiler/test/fail_compilation/test17380spec.d
+++ b/compiler/test/fail_compilation/test17380spec.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 (spec:1) fail_compilation/test17380spec.d(14): Error: cannot resolve identifier `ThisTypeDoesNotExistAndCrashesTheCompiler`
-(spec:1) fail_compilation/test17380spec.d(14): Error: no property `ThisTypeDoesNotExistAndCrashesTheCompiler` for type `test17380spec.Uint128`
+(spec:1) fail_compilation/test17380spec.d(14): Error: no property `ThisTypeDoesNotExistAndCrashesTheCompiler` for `this.opCast()` of type `test17380spec.Uint128`
 fail_compilation/test17380spec.d(14): Error: undefined identifier `ThisTypeDoesNotExistAndCrashesTheCompiler`
 ---
  */


### PR DESCRIPTION
It's sometimes hard to tell which part of an expression the error refers to, so this prints the relevant expression too. This also helps find the part quicker.
It's also confusing when the type is `void` for anyone not aware of all the kinds of expressions which have type void.