### PR TITLE
Add supplemental scope info to mixin T; errors - Fix issue 7372 - Error provides too little information to diagnose the problem (error: undefined identifier)

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -167,11 +167,18 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
         sc = sc.push(tmix.argsym);
         sc = sc.push(tmix);
+
+        uint olderrors = global.errors;
+
         for (size_t i = 0; i < tmix.members.dim; i++)
         {
             Dsymbol s = (*tmix.members)[i];
             s.semantic3(sc);
         }
+
+        if (global.errors != olderrors)
+            errorSupplemental(tmix.loc, "parent scope from here: `mixin %s`", tmix.toChars());
+
         sc = sc.pop();
         sc.pop();
     }

--- a/compiler/test/fail_compilation/diag13528.d
+++ b/compiler/test/fail_compilation/diag13528.d
@@ -1,10 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag13528.d(13): Error: value of `this` is not known at compile time
-fail_compilation/diag13528.d(13):        while evaluating `pragma(msg, __traits(getMember, A, "foo"))`
+fail_compilation/diag13528.d(6): Error: value of `this` is not known at compile time
+fail_compilation/diag13528.d(6):        while evaluating `pragma(msg, __traits(getMember, A, "foo"))`
+fail_compilation/diag13528.d(12):        parent scope from here: `mixin MyTemplate!()`
 ---
 */
+#line 1
 
 mixin template MyTemplate()
 {

--- a/compiler/test/fail_compilation/fail7372.d
+++ b/compiler/test/fail_compilation/fail7372.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/imports/fail7372.d(7): Error: undefined identifier `X`
+fail_compilation/fail7372.d(4):        parent scope from here: `mixin Issue7372!()`
+---
+*/
+#line 1
+import imports.fail7372;
+interface I {}
+class C : I {
+    mixin Issue7372!();
+}

--- a/compiler/test/fail_compilation/imports/fail7372.d
+++ b/compiler/test/fail_compilation/imports/fail7372.d
@@ -1,0 +1,9 @@
+module imports.fail7372;
+import imports.imp1;
+mixin template Issue7372()
+{
+    public void f()
+    {
+        int foo = X;
+    }
+}


### PR DESCRIPTION
Mixin templates are often defined inside libraries and may require the definition of certain symbols alongside them (for example a text templating library mapping struct fields to HTML text blocks could attempt to simply access member variables) - Fixing compilation errors where such identifiers are not found would then usually not require code changes inside the library, but rather in the user code, where the mixin is written.

So this PR adds a supplemental `` parent scope from here: `...` `` message, which may be used from IDEs to show errors on the mixin line or just for the user to read it in the command line and see where in the user code the error originates from.

The "instantiated from here" code in regular template instantiations above this function also uses gagging, but it doesn't seem like it was needed here. Otherwise the code was pretty much copied from that function.