### PR TITLE
Add a missing test for typesafe variadic

### DIFF
--- a/compiler/test/compilable/vararg.d
+++ b/compiler/test/compilable/vararg.d
@@ -1,0 +1,20 @@
+void main ()
+{
+    variance([1.0, 2, 3]);
+}
+
+alias meanType(T) = T;
+
+template variance(bool stable = true)
+{
+    void variance(Range)(Range r, bool isPopulation = false)
+    {
+        .variance!(double, stable)(r, isPopulation);
+    }
+}
+
+template variance(F, bool stable = true)
+{
+    void variance(Range)(Range r, bool isPopulation = false) {}
+    void variance(scope const F[] ar...) {}
+}


### PR DESCRIPTION
```
While refactoring typesafe variadics, I noticed one 'if'
statement was not covered (but was by Buildkite),
so adding it to the testsuite.
The code in question is in compiler/src/dmd/mtype.d,
L4863 - L4867 ('prefer matching the element type rather than the array').
```