### PR TITLE
importc.h: #define both `__inline` AND `__inline__` to `inline`

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -27,6 +27,8 @@
 #define __signed__ signed
 #define __asm__ asm
 #define __asm asm
+#define __inline__ inline
+#define __inline inline
 
 /********************
  * Clang nullability extension used by macOS headers.
@@ -56,7 +58,6 @@
 #define __far
 #define __near
 #define __handle
-#define __inline        /* ImportC does its own notion of inlining */
 #define __pascal
 
 /****************************


### PR DESCRIPTION
`__inline__` was causing compilation errors on headers that tried using it assuming it was supported. Since ImportC's parser supports `inline`, it makes more sense to alias both to that instead of ignoring it like before.