### PR TITLE
Rewrite CInitializer semantic()

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3279,6 +3279,7 @@ public:
     uint32_t dim;
     Type* type;
     bool sem;
+    bool isCarray;
     bool isAssociativeArray() const;
     void accept(Visitor* v) override;
 };

--- a/compiler/src/dmd/init.d
+++ b/compiler/src/dmd/init.d
@@ -167,6 +167,7 @@ extern (C++) final class ArrayInitializer : Initializer
     uint dim;               // length of array being initialized
     Type type;              // type that array will be used to initialize
     bool sem;               // true if semantic() is run
+    bool isCarray;          // C array semantics
 
     extern (D) this(const ref Loc loc)
     {

--- a/compiler/src/dmd/init.h
+++ b/compiler/src/dmd/init.h
@@ -78,6 +78,7 @@ public:
     unsigned dim;       // length of array being initialized
     Type *type;         // type that array will be used to initialize
     bool sem;           // true if semantic() is run
+    bool isCarray;      // C array semantics
 
     bool isAssociativeArray() const;
     Expression *toAssocArrayLiteral();

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -225,7 +225,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
                 assert(sc);
                 auto tm = vd.type.addMod(t.mod);
                 auto iz = i.value[j].initializerSemantic(sc, tm, needInterpret);
-                auto ex = iz.initializerToExpression();
+                auto ex = iz.initializerToExpression(null, (sc.flags & SCOPE.Cfile) != 0);
                 if (ex.op == EXP.error)
                 {
                     errors = true;
@@ -272,7 +272,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
         uint length;
         const(uint) amax = 0x80000000;
         bool errors = false;
-        //printf("ArrayInitializer::semantic(%s)\n", t.toChars());
+        //printf("ArrayInitializer::semantic(%s), ai: %s %p\n", t.toChars(), i.toChars(), i);
         if (i.sem) // if semantic() already run
         {
             return i;
@@ -374,11 +374,22 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
         }
         if (auto tsa = t.isTypeSArray())
         {
-            uinteger_t edim = tsa.dim.toInteger();
-            if (i.dim > edim && !(tsa.isIncomplete() && (sc.flags & SCOPE.Cfile)))
+            if (sc.flags & SCOPE.Cfile && tsa.isIncomplete())
             {
-                error(i.loc, "array initializer has %u elements, but array length is %llu", i.dim, edim);
-                return err();
+                // Change to array of known length
+                auto tn = tsa.next.toBasetype();
+                tsa = new TypeSArray(tn, new IntegerExp(Loc.initial, i.dim, Type.tsize_t));
+                tx = tsa;      // rewrite caller's type
+                i.type = tsa;  // remember for later passes
+            }
+            else
+            {
+                uinteger_t edim = tsa.dim.toInteger();
+                if (i.dim > edim)
+                {
+                    error(i.loc, "array initializer has %u elements, but array length is %llu", i.dim, edim);
+                    return err();
+                }
             }
         }
         if (errors)
@@ -394,6 +405,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
             error(i.loc, "array dimension %llu exceeds max of %llu", ulong(i.dim), ulong(amax / sz));
             return err();
         }
+        //printf("returns ai: %s\n", i.toChars());
         return i;
     }
 
@@ -661,295 +673,306 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
 
     Initializer visitC(CInitializer ci)
     {
-        if (ci.sem) // if semantic() already run
-            return ci;
         //printf("CInitializer::semantic() (%s) %s\n", t.toChars(), ci.toChars());
-        ci.sem = true;
+        /* Rewrite CInitializer into ExpInitializer, ArrayInitializer, or StructInitializer
+         */
         t = t.toBasetype();
-        ci.type = t;    // later passes will need this
-
-        auto dil = ci.initializerList[];
-        size_t i = 0;   // index into dil[]
-        const uint amax = 0x8000_0000;
-        bool errors;
 
         /* If `{ expression }` return the expression initializer
          */
         ExpInitializer isBraceExpression()
         {
+            auto dil = ci.initializerList[];
             return (dil.length == 1 && !dil[0].designatorList)
                     ? dil[0].initializer.isExpInitializer()
                     : null;
         }
 
-        /* Convert struct initializer into ExpInitializer
+        /********************************
          */
-        Initializer structs(TypeStruct ts)
+        bool overlaps(VarDeclaration field, VarDeclaration[] fields, StructInitializer si)
         {
-            //printf("structs %s\n", ts.toChars());
-            StructDeclaration sd = ts.sym;
-            sd.size(ci.loc);
-            if (sd.sizeok != Sizeok.done)
+            foreach (fld; fields)
             {
-                errors = true;
-                return err();
-            }
-            const nfields = sd.nonHiddenFields();
-            auto elements = new Expressions(nfields);
-            auto elems = (*elements)[];
-            foreach (ref elem; elems)
-                elem = null;
-
-          FieldLoop:
-            for (size_t fieldi = 0; fieldi < nfields; ++fieldi)
-            {
-                if (i == dil.length)
-                    break;
-
-                auto di = dil[i];
-                if (di.designatorList)
+                if (field.isOverlappedWith(fld))
                 {
-                    error(ci.loc, "C designator-list not supported yet");
-                    errors = true;
-                    break;
-                }
-
-                VarDeclaration vd = sd.fields[fieldi];
-
-                // Check for overlapping initializations (can happen with unions)
-                foreach (k, v2; sd.fields[0 .. nfields])
-                {
-                    if (vd.isOverlappedWith(v2) && elems[k])
+                    // look for initializer corresponding with fld
+                    foreach (i, ident; si.field[])
                     {
-                        continue FieldLoop;     // skip it
+                        if (ident == fld.ident && si.value[i])
+                            return true;   // already an initializer for `field`
                     }
                 }
-
-                ++i;
-
-                // Convert initializer to Expression `ex`
-                assert(sc);
-                auto tm = vd.type.addMod(ts.mod);
-                auto iz = di.initializer.initializerSemantic(sc, tm, needInterpret);
-                auto ex = iz.initializerToExpression(null, true);
-                if (ex.op == EXP.error)
-                {
-                    errors = true;
-                    continue;
-                }
-
-                elems[fieldi] = ex;
             }
-            if (errors)
-                return err();
-
-            // Make a StructLiteralExp out of elements[]
-            Type tx = ts;
-            auto sle = new StructLiteralExp(ci.loc, sd, elements, tx);
-            if (!sd.fill(ci.loc, *elements, false))
-                return err();
-            sle.type = tx;
-            auto ie = new ExpInitializer(ci.loc, sle);
-            return ie.initializerSemantic(sc, tx, needInterpret);
+            return false;
         }
 
         if (auto ts = t.isTypeStruct())
         {
-            auto ei = structs(ts);
-            if (errors)
+            auto si = new StructInitializer(ci.loc);
+            StructDeclaration sd = ts.sym;
+            sd.size(ci.loc);            // run semantic() on sd to get fields
+            if (sd.sizeok != Sizeok.done)
+            {
                 return err();
-            if (i < dil.length)
-            {
-                error(ci.loc, "%d extra initializer(s) for `struct %s`", cast(int)(dil.length - i), ts.toChars());
-                return err();
             }
-            return ei;
-        }
+            const nfields = sd.fields.length;
 
-        auto tsa = t.isTypeSArray();
-        if (!tsa)
-        {
-            /* Not an array. See if it is `{ exp }` which can be
-             * converted to an ExpInitializer
-             */
-            if (ExpInitializer ei = isBraceExpression())
+            size_t fieldi = 0;
+
+            foreach (di; ci.initializerList[])
             {
-                return ei.initializerSemantic(sc, t, needInterpret);
-            }
-
-            error(ci.loc, "C non-array initializer (%s) %s not supported yet", t.toChars(), ci.toChars());
-            return err();
-        }
-
-        /* If it's an array of integral being initialized by `{ string }`
-         * replace with `string`
-         */
-        auto tn = t.nextOf();
-        if (tn.isintegral())
-        {
-            if (ExpInitializer ei = isBraceExpression())
-            {
-                if (ei.exp.isStringExp())
-                    return ei.initializerSemantic(sc, t, needInterpret);
-            }
-        }
-
-        /* Support recursion to handle un-braced array initializers
-         * Params:
-         *    t = element type
-         *    dim = max number of elements
-         *    simple = true if array of simple elements
-         * Returns:
-         *    # of elements in array
-         */
-        size_t array(Type t, size_t dim, ref bool simple)
-        {
-            //printf(" type %s i %d dim %d dil.length = %d\n", t.toChars(), cast(int)i, cast(int)dim, cast(int)dil.length);
-            auto tn = t.nextOf().toBasetype();
-            auto tnsa = tn.isTypeSArray();
-            if (tnsa && tnsa.isIncomplete())
-            {
-                // C11 6.2.5-20 "element type shall be complete whenever the array type is specified"
-                error(ci.loc, "incomplete element type `%s` not allowed", tnsa.toChars());
-                errors = true;
-                return 1;
-            }
-            if (i == dil.length)
-                return 0;
-            size_t n;
-            const nelems = tnsa ? cast(size_t)tnsa.dim.toInteger() : 0;
-
-            /* Run initializerSemantic on a single element.
-             */
-            Initializer elem(Initializer ie)
-            {
-                ++i;
-                auto tnx = tn; // in case initializerSemantic tries to change it
-                ie = ie.initializerSemantic(sc, tnx, needInterpret);
-                if (ie.isErrorInitializer())
-                    errors = true;
-                assert(tnx == tn); // sub-types should not be modified
-                return ie;
-            }
-
-            foreach (j; 0 .. dim)
-            {
-                auto di = dil[i];
-                if (di.designatorList)
-                {
-                    error(ci.loc, "C designator-list not supported yet");
-                    errors = true;
+                if (fieldi == nfields)
                     break;
-                }
-                if (tnsa && di.initializer.isExpInitializer())
+                auto dlist = di.designatorList;
+                if (dlist)
                 {
-                    // no braces enclosing array initializer, so recurse
-                    array(tnsa, nelems, simple);
-                }
-                else if (auto tns = tn.isTypeStruct())
-                {
-                    if (auto ei = di.initializer.isExpInitializer())
+                    const length = (*dlist).length;
+                    if (length == 0 || !(*dlist)[0].ident)
                     {
-                        // no braces enclosing struct initializer
+                        error(ci.loc, "`.identifier` expected for C struct field initializer `%s`", ci.toChars());
+                        return err();
+                    }
+                    if (length > 1)
+                    {
+                        error(ci.loc, "only 1 designator currently allowed for C struct field initializer `%s`", ci.toChars());
+                        return err();
+                    }
+                    auto id = (*dlist)[0].ident;
+                    foreach (k, f; sd.fields[])         // linear search for now
+                    {
+                        if (f.ident == id)
+                        {
+                            fieldi = k;
+                            si.addInit(id, di.initializer);
+                            ++fieldi;
+                            continue;
+                        }
+                    }
+                }
+                else
+                {
+                    VarDeclaration field;
+                    while (1)   // skip field if it overlaps with previously seen fields
+                    {
+                        field = sd.fields[fieldi];
+                        ++fieldi;
+                        if (!overlaps(field, sd.fields[], si))
+                            break;
+                        if (fieldi == nfields)
+                            break;
+                    }
+                    si.addInit(field.ident, di.initializer);
+                }
+            }
+            return initializerSemantic(si, sc, t, needInterpret);
+        }
+        else if (auto ta = t.isTypeSArray())
+        {
+            /* If { } are omitted from substructs, use recursion to reconstruct where
+             * brackets go
+             * Params:
+             *  ts = substruct to initialize
+             *  index = index into ci.initializer, updated
+             * Returns: struct initializer for this substruct
+             */
+            Initializer subStruct(TypeStruct ts, ref size_t index)
+            {
+                //printf("subStruct(ts: %s, index %d)\n", ts.toChars(), cast(int)index);
 
+                auto si = new StructInitializer(ci.loc);
+                StructDeclaration sd = ts.sym;
+                sd.size(ci.loc);
+                if (sd.sizeok != Sizeok.done)
+                {
+                    index = ci.initializerList.length;
+                    return err();
+                }
+                const nfields = sd.nonHiddenFields();
+
+                foreach (n; 0 .. nfields)
+                {
+                    if (index >= ci.initializerList.length)
+                        break;          // ran out of initializers
+                    auto di = ci.initializerList[index];
+                    if (di.designatorList && n != 0)
+                        break;          // back to top level
+                    else
+                    {
+                        si.addInit(null, di.initializer);
+                        ++index;
+                    }
+                }
+                //printf("subStruct() returns ai: %s, index: %d\n", si.toChars(), cast(int)index);
+                return si;
+            }
+
+            /* If { } are omitted from subarrays, use recursion to reconstruct where
+             * brackets go
+             * Params:
+             *  tsa = subarray to initialize
+             *  index = index into ci.initializer, updated
+             * Returns: array initializer for this subarray
+             */
+            Initializer subArray(TypeSArray tsa, ref size_t index)
+            {
+                //printf("array(tsa: %s, index %d)\n", tsa.toChars(), cast(int)index);
+                if (tsa.isIncomplete())
+                {
+                    // C11 6.2.5-20 "element type shall be complete whenever the array type is specified"
+                    assert(0); // should have been detected by parser
+                }
+
+                auto tnsa = tsa.nextOf().toBasetype().isTypeSArray();
+
+                auto ai = new ArrayInitializer(ci.loc);
+                ai.isCarray = true;
+
+                foreach (n; 0 .. cast(size_t)tsa.dim.toInteger())
+                {
+                    if (index >= ci.initializerList.length)
+                        break;          // ran out of initializers
+                    auto di = ci.initializerList[index];
+                    if (di.designatorList)
+                        break;          // back to top level
+                    else if (tnsa && di.initializer.isExpInitializer())
+                    {
+                        ExpInitializer ei = di.initializer.isExpInitializer();
+                        if (ei.exp.isStringExp() && tnsa.nextOf().isintegral())
+                        {
+                            ai.addInit(null, ei);
+                            ++index;
+                        }
+                        else
+                            ai.addInit(null, subArray(tnsa, index));
+                    }
+                    else
+                    {
+                        ai.addInit(null, di.initializer);
+                        ++index;
+                    }
+                }
+                //printf("array() returns ai: %s, index: %d\n", ai.toChars(), cast(int)index);
+                return ai;
+            }
+
+            auto tn = t.nextOf().toBasetype();  // element type of array
+
+            /* If it's an array of integral being initialized by `{ string }`
+             * replace with `string`
+             */
+            if (tn.isintegral())
+            {
+                if (ExpInitializer ei = isBraceExpression())
+                {
+                    if (ei.exp.isStringExp())
+                        return ei.initializerSemantic(sc, t, needInterpret);
+                }
+            }
+
+            auto tnsa = tn.isTypeSArray();      // array of array
+            auto tns = tn.isTypeStruct();       // array of struct
+
+            auto ai = new ArrayInitializer(ci.loc);
+            ai.isCarray = true;
+            for (size_t index = 0; index < ci.initializerList.length; )
+            {
+                auto di = ci.initializerList[index];
+                if (auto dlist = di.designatorList)
+                {
+                    const length = (*dlist).length;
+                    if (length == 0 || !(*dlist)[0].exp)
+                    {
+                        error(ci.loc, "`[ constant-expression ]` expected for C array element initializer `%s`", ci.toChars());
+                        return err();
+                    }
+                    if (length > 1)
+                    {
+                        error(ci.loc, "only 1 designator currently allowed for C array element initializer `%s`", ci.toChars());
+                        return err();
+                    }
+                    //printf("tn: %s, di.initializer: %s\n", tn.toChars(), di.initializer.toChars());
+                    auto ix = di.initializer;
+                    if (tnsa && ix.isExpInitializer())
+                    {
+                        // Wrap initializer in [ ]
+                        auto ain = new ArrayInitializer(ci.loc);
+                        ain.addInit(null, di.initializer);
+                        ix = ain;
+                        ai.addInit((*dlist)[0].exp, initializerSemantic(ix, sc, tn, needInterpret));
+                        ++index;
+                    }
+                    else if (tns && ix.isExpInitializer())
+                    {
                         /* Disambiguate between an exp representing the entire
                          * struct, and an exp representing the first field of the struct
-                        */
+                         */
                         if (needInterpret)
                             sc = sc.startCTFE();
+                        ExpInitializer ei = ix.isExpInitializer();
                         ei.exp = ei.exp.expressionSemantic(sc);
                         ei.exp = resolveProperties(sc, ei.exp);
                         if (needInterpret)
                             sc = sc.endCTFE();
-                        if (ei.exp.implicitConvTo(tn))
-                            di.initializer = elem(di.initializer); // the whole struct
-                        else
+                        if (ei.exp.implicitConvTo(tn))      // initializer represents the entire struct
                         {
-                            simple = false;
-                            dil[n].initializer = structs(tns); // the first field
+                            ai.addInit((*dlist)[0].exp, initializerSemantic(ix, sc, tn, needInterpret));
+                            ++index;
                         }
+                        else                                // field initializers for struct
+                            ai.addInit((*dlist)[0].exp, subStruct(tns, index)); // the first field
                     }
                     else
-                        dil[n].initializer = elem(di.initializer);
+                    {
+                        ai.addInit((*dlist)[0].exp, initializerSemantic(ix, sc, tn, needInterpret));
+                        ++index;
+                    }
+                }
+                else if (tnsa && di.initializer.isExpInitializer())
+                {
+                    ExpInitializer ei = di.initializer.isExpInitializer();
+                    if (ei.exp.isStringExp() && tnsa.nextOf().isintegral())
+                    {
+                        ai.addInit(null, ei);
+                        ++index;
+                    }
+                    else
+                        ai.addInit(null, subArray(tnsa, index));
+                }
+                else if (tns && di.initializer.isExpInitializer())
+                {
+                    /* Disambiguate between an exp representing the entire
+                     * struct, and an exp representing the first field of the struct
+                     */
+                    if (needInterpret)
+                        sc = sc.startCTFE();
+                    ExpInitializer ei = di.initializer.isExpInitializer();
+                    ei.exp = ei.exp.expressionSemantic(sc);
+                    ei.exp = resolveProperties(sc, ei.exp);
+                    if (needInterpret)
+                        sc = sc.endCTFE();
+                    if (ei.exp.implicitConvTo(tn))      // initializer represents the entire struct
+                    {
+                        ai.addInit(null, initializerSemantic(di.initializer, sc, tn, needInterpret));
+                        ++index;
+                    }
+                    else                                // field initializers for struct
+                        ai.addInit(null, subStruct(tns, index)); // the first field
                 }
                 else
                 {
-                    di.initializer = elem(di.initializer);
+                    ai.addInit(null, initializerSemantic(di.initializer, sc, tn, needInterpret));
+                    ++index;
                 }
-                ++n;
-                if (i == dil.length)
-                    break;
             }
-            //printf(" n: %d i: %d\n", cast(int)n, cast(int)i);
-            return n;
+            return initializerSemantic(ai, sc, tx, needInterpret);
         }
-
-        size_t dim = tsa.isIncomplete() ? dil.length : cast(size_t)tsa.dim.toInteger();
-        bool simple = true;
-        auto newdim = array(t, dim, simple);
-
-        if (errors)
-            return err();
-
-        if (tsa.isIncomplete()) // array of unknown length
+        else if (ExpInitializer ei = isBraceExpression())
+            return visitExp(ei);
+        else
         {
-            // Change to array of known length
-            tsa = new TypeSArray(tn, new IntegerExp(Loc.initial, newdim, Type.tsize_t));
-            tx = tsa;       // rewrite caller's type
-            ci.type = tsa;  // remember for later passes
+            assert(0);
         }
-        const uinteger_t edim = tsa.dim.toInteger();
-        if (i < dil.length)
-        {
-            error(ci.loc, "%d extra initializer(s) for static array length of %d", cast(int)(dil.length - i), cast(int)edim);
-            return err();
-        }
-
-        const sz = tn.size(); // element size
-        if (sz == SIZE_INVALID)
-            return err();
-        bool overflow;
-        const max = mulu(edim, sz, overflow);
-        if (overflow || max >= amax)
-        {
-            error(ci.loc, "array dimension %llu exceeds max of %llu", ulong(edim), ulong(amax / sz));
-            return err();
-        }
-
-        /* If an array of simple elements, replace with an ArrayInitializer
-         */
-        auto tnb = tn.toBasetype();
-        if (!tnb.isTypeSArray() && (!tnb.isTypeStruct() || simple))
-        {
-            auto ai = new ArrayInitializer(ci.loc);
-            ai.dim = cast(uint) dil.length;
-            ai.index.setDim(dil.length);
-            ai.value.setDim(dil.length);
-            foreach (const j; 0 .. dil.length)
-            {
-                ai.index[j] = null;
-                ai.value[j] = dil[j].initializer;
-            }
-            auto ty = tx;
-            return ai.initializerSemantic(sc, ty, needInterpret);
-        }
-
-        if (newdim < ci.initializerList.length && tnb.isTypeStruct())
-        {
-            // https://issues.dlang.org/show_bug.cgi?id=22375
-            // initializerList can be bigger than the number of actual elements
-            // to initialize for array of structs because it is not required
-            // for values to have proper bracing.
-            // i.e: These are all valid initializers for `struct{int a,b;}[3]`:
-            //      {1,2,3,4}, {{1,2},3,4}, {1,2,{3,4}}, {{1,2},{3,4}}
-            // In all examples above, the new length of the initializer list
-            // has been shortened from four elements to two. This is important,
-            // because `dil` is written back to directly, making the lowered
-            // initializer `{{1,2},{3,4}}` and not `{{1,2},{3,4},3,4}`.
-            ci.initializerList.length = newdim;
-        }
-
-        return ci;
     }
 
     final switch (init.kind)

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -112,7 +112,7 @@ extern (C++) void Initializer_toDt(Initializer init, ref DtBuilder dtb, bool isC
             assert(length < ai.dim);
             auto dtb = DtBuilder(0);
             Initializer_toDt(ai.value[i], dtb, isCfile);
-            if (dts[length])
+            if (dts[length] && !ai.isCarray)
                 error(ai.loc, "duplicate initializations for index `%d`", length);
             dts[length] = dtb.finish();
             length++;
@@ -202,52 +202,9 @@ extern (C++) void Initializer_toDt(Initializer init, ref DtBuilder dtb, bool isC
 
     void visitC(CInitializer ci)
     {
-        //printf("CInitializer.toDt() (%s) %s\n", ci.type.toChars(), ci.toChars());
-
-        /* append all initializers to dtb
+        /* Should have been rewritten to Exp/Struct/ArrayInitializer by semantic()
          */
-        auto dil = ci.initializerList[];
-        size_t i = 0;
-
-        /* Support recursion to handle un-braced array initializers
-         * Params:
-         *    t = element type
-         *    dim = number of elements
-         */
-        void array(Type t, size_t dim)
-        {
-            //printf(" type %s i %d dim %d dil.length = %d\n", t.toChars(), cast(int)i, cast(int)dim, cast(int)dil.length);
-            auto tn = t.nextOf().toBasetype();
-            auto tnsa = tn.isTypeSArray();
-            const nelems = tnsa ? cast(size_t)tnsa.dim.toInteger() : 0;
-
-            foreach (j; 0 .. dim)
-            {
-                if (i == dil.length)
-                {
-                    if (j < dim)
-                    {   // Not enough initializers, fill in with 0
-                        const size = cast(uint)tn.size();
-                        dtb.nzeros(cast(uint)(size * (dim - j)));
-                    }
-                    break;
-                }
-                auto di = dil[i];
-                assert(!di.designatorList);
-                if (tnsa && di.initializer.isExpInitializer())
-                {
-                    // no braces enclosing array initializer, so recurse
-                    array(tnsa, nelems);
-                }
-                else
-                {
-                    ++i;
-                    Initializer_toDt(di.initializer, dtb, isCfile);
-                }
-            }
-        }
-
-        array(ci.type, cast(size_t)ci.type.isTypeSArray().dim.toInteger());
+        assert(0);
     }
 
     final switch (init.kind)

--- a/compiler/test/fail_compilation/init1.c
+++ b/compiler/test/fail_compilation/init1.c
@@ -1,0 +1,27 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/init1.c(100): Error: array initializer has 4 elements, but array length is 3
+fail_compilation/init1.c(103): Error: `.identifier` expected for C struct field initializer `{[0]=3}`
+fail_compilation/init1.c(104): Error: only 1 designator currently allowed for C struct field initializer `{.a[0]=3}`
+fail_compilation/init1.c(106): Error: `[ constant-expression ]` expected for C array element initializer `{.a=3}`
+fail_compilation/init1.c(107): Error: only 1 designator currently allowed for C array element initializer `{[0][1]=3}`
+fail_compilation/init1.c(110): Error: overlapping initialization for field `a` and `b`
+fail_compilation/init1.c(113): Error: struct `init1.S6` unknown size
+---
+ */
+
+#line 100
+int a1[3] = { 1,2,3,4 };
+
+typedef struct S1 { int a; } S1;
+S1 s1 = { [0] = 3 };
+S1 s2 = { .a[0] = 3 };
+
+int a3[2] = { .a = 3 };
+int a4[2] = { [0][1] = 3 };
+
+union U { int a, b; };
+union U u = { 1, 2 };
+
+struct S6;
+struct S6 a6[2] = { 1, 2 };

--- a/compiler/test/runnable/initializer.c
+++ b/compiler/test/runnable/initializer.c
@@ -1,0 +1,410 @@
+/* Test initializers */
+
+int printf(const char *s, ...);
+void exit(int);
+
+void assert(int b, int line)
+{
+    if (!b)
+    {
+        printf("failed test %d\n", line);
+        exit(1);
+    }
+}
+
+/*******************************************/
+
+void test1()
+{
+    static int a1[] = { 1, 2, [0] = 3 };
+
+    assert(a1[0] == 3, __LINE__);
+    assert(a1[1] == 2, __LINE__);
+    assert(sizeof(a1) == 8, __LINE__);
+}
+
+/*******************************************/
+
+int a2[2][3] = { 1,2,[1]={3} };
+
+void test2()
+{
+    assert(a2[0][0] == 1, __LINE__);
+    assert(a2[0][1] == 2, __LINE__);
+    assert(a2[0][2] == 0, __LINE__);
+    assert(a2[1][0] == 3, __LINE__);
+    assert(a2[1][1] == 0, __LINE__);
+    assert(a2[1][2] == 0, __LINE__);
+}
+
+/*******************************************/
+
+int a3[2][3] = { 1,2,3,[1]=4 };
+
+void test3()
+{
+    assert(a3[0][0] == 1, __LINE__);
+    assert(a3[0][1] == 2, __LINE__);
+    assert(a3[0][2] == 3, __LINE__);
+    assert(a3[1][0] == 4, __LINE__);
+    assert(a3[1][1] == 0, __LINE__);
+    assert(a3[1][2] == 0, __LINE__);
+}
+
+/*******************************************/
+
+typedef struct S { int a, b; } S;
+S a4[2] = { 3, 4, 5, 6 };
+
+void test4()
+{
+    assert(a4[0].a == 3, __LINE__);
+    assert(a4[0].b == 4, __LINE__);
+    assert(a4[1].a == 5, __LINE__);
+    assert(a4[1].b == 6, __LINE__);
+}
+
+/*******************************************/
+
+int y5[4][3] = {
+    {1,3,5},
+    {2,4,6},
+    {3,5,7},
+};
+
+void test5()
+{
+    assert(y5[0][0] == 1, __LINE__);
+    assert(y5[0][1] == 3, __LINE__);
+    assert(y5[0][2] == 5, __LINE__);
+    assert(y5[1][0] == 2, __LINE__);
+    assert(y5[1][1] == 4, __LINE__);
+    assert(y5[1][2] == 6, __LINE__);
+    assert(y5[2][0] == 3, __LINE__);
+    assert(y5[2][1] == 5, __LINE__);
+    assert(y5[2][2] == 7, __LINE__);
+    assert(y5[3][0] == 0, __LINE__);
+    assert(y5[3][1] == 0, __LINE__);
+    assert(y5[3][2] == 0, __LINE__);
+}
+
+/*******************************************/
+
+int y6[4][3] = {
+    1,3,5,
+    2,4,6,
+    3,5,7
+};
+
+void test6()
+{
+    assert(y6[0][0] == 1, __LINE__);
+    assert(y6[0][1] == 3, __LINE__);
+    assert(y6[0][2] == 5, __LINE__);
+    assert(y6[1][0] == 2, __LINE__);
+    assert(y6[1][1] == 4, __LINE__);
+    assert(y6[1][2] == 6, __LINE__);
+    assert(y6[2][0] == 3, __LINE__);
+    assert(y6[2][1] == 5, __LINE__);
+    assert(y6[2][2] == 7, __LINE__);
+    assert(y6[3][0] == 0, __LINE__);
+    assert(y6[3][1] == 0, __LINE__);
+    assert(y6[3][2] == 0, __LINE__);
+}
+
+/*******************************************/
+
+int y7[4][3] = {
+    {1},{2},{3},{4}
+};
+
+void test7()
+{
+    assert(y7[0][0] == 1, __LINE__);
+    assert(y7[0][1] == 0, __LINE__);
+    assert(y7[0][2] == 0, __LINE__);
+    assert(y7[1][0] == 2, __LINE__);
+    assert(y7[1][1] == 0, __LINE__);
+    assert(y7[1][2] == 0, __LINE__);
+    assert(y7[2][0] == 3, __LINE__);
+    assert(y7[2][1] == 0, __LINE__);
+    assert(y7[2][2] == 0, __LINE__);
+    assert(y7[3][0] == 4, __LINE__);
+    assert(y7[3][1] == 0, __LINE__);
+    assert(y7[3][2] == 0, __LINE__);
+}
+
+/*******************************************/
+
+int q8[4][3][2] = {
+    {1},
+    {2,3},
+    {4,5,6}
+};
+
+void test8()
+{
+    assert(q8[0][0][0] == 1, __LINE__);
+    assert(q8[0][0][1] == 0, __LINE__);
+    assert(q8[0][1][0] == 0, __LINE__);
+    assert(q8[0][1][1] == 0, __LINE__);
+    assert(q8[0][2][0] == 0, __LINE__);
+    assert(q8[0][2][1] == 0, __LINE__);
+
+    assert(q8[1][0][0] == 2, __LINE__);
+    assert(q8[1][0][1] == 3, __LINE__);
+    assert(q8[1][1][0] == 0, __LINE__);
+    assert(q8[1][1][1] == 0, __LINE__);
+    assert(q8[1][2][0] == 0, __LINE__);
+    assert(q8[1][2][1] == 0, __LINE__);
+
+    assert(q8[2][0][0] == 4, __LINE__);
+    assert(q8[2][0][1] == 5, __LINE__);
+    assert(q8[2][1][0] == 6, __LINE__);
+    assert(q8[2][1][1] == 0, __LINE__);
+    assert(q8[2][2][0] == 0, __LINE__);
+    assert(q8[2][2][1] == 0, __LINE__);
+
+    assert(q8[3][0][0] == 0, __LINE__);
+    assert(q8[3][0][1] == 0, __LINE__);
+    assert(q8[3][1][0] == 0, __LINE__);
+    assert(q8[3][1][1] == 0, __LINE__);
+    assert(q8[3][2][0] == 0, __LINE__);
+    assert(q8[3][2][1] == 0, __LINE__);
+}
+
+/*******************************************/
+
+int q9[4][3][2] = {
+    1, 0, 0, 0, 0, 0,
+    2, 3, 0, 0, 0, 0,
+    4, 5, 6
+};
+
+void test9()
+{
+    assert(q9[0][0][0] == 1, __LINE__);
+    assert(q9[0][0][1] == 0, __LINE__);
+    assert(q9[0][1][0] == 0, __LINE__);
+    assert(q9[0][1][1] == 0, __LINE__);
+    assert(q9[0][2][0] == 0, __LINE__);
+    assert(q9[0][2][1] == 0, __LINE__);
+
+    assert(q9[1][0][0] == 2, __LINE__);
+    assert(q9[1][0][1] == 3, __LINE__);
+    assert(q9[1][1][0] == 0, __LINE__);
+    assert(q9[1][1][1] == 0, __LINE__);
+    assert(q9[1][2][0] == 0, __LINE__);
+    assert(q9[1][2][1] == 0, __LINE__);
+
+    assert(q9[2][0][0] == 4, __LINE__);
+    assert(q9[2][0][1] == 5, __LINE__);
+    assert(q9[2][1][0] == 6, __LINE__);
+    assert(q9[2][1][1] == 0, __LINE__);
+    assert(q9[2][2][0] == 0, __LINE__);
+    assert(q9[2][2][1] == 0, __LINE__);
+
+    assert(q9[3][0][0] == 0, __LINE__);
+    assert(q9[3][0][1] == 0, __LINE__);
+    assert(q9[3][1][0] == 0, __LINE__);
+    assert(q9[3][1][1] == 0, __LINE__);
+    assert(q9[3][2][0] == 0, __LINE__);
+    assert(q9[3][2][1] == 0, __LINE__);
+}
+
+/*******************************************/
+
+int q10[4][3][2] = {
+    {
+      { 1 },
+    },
+    {
+      { 2, 3 },
+    },
+    {
+      { 4, 5 },
+      { 6 },
+    }
+};
+
+void test10()
+{
+    assert(q10[0][0][0] == 1, __LINE__);
+    assert(q10[0][0][1] == 0, __LINE__);
+    assert(q10[0][1][0] == 0, __LINE__);
+    assert(q10[0][1][1] == 0, __LINE__);
+    assert(q10[0][2][0] == 0, __LINE__);
+    assert(q10[0][2][1] == 0, __LINE__);
+
+    assert(q10[1][0][0] == 2, __LINE__);
+    assert(q10[1][0][1] == 3, __LINE__);
+    assert(q10[1][1][0] == 0, __LINE__);
+    assert(q10[1][1][1] == 0, __LINE__);
+    assert(q10[1][2][0] == 0, __LINE__);
+    assert(q10[1][2][1] == 0, __LINE__);
+
+    assert(q10[2][0][0] == 4, __LINE__);
+    assert(q10[2][0][1] == 5, __LINE__);
+    assert(q10[2][1][0] == 6, __LINE__);
+    assert(q10[2][1][1] == 0, __LINE__);
+    assert(q10[2][2][0] == 0, __LINE__);
+    assert(q10[2][2][1] == 0, __LINE__);
+
+    assert(q10[3][0][0] == 0, __LINE__);
+    assert(q10[3][0][1] == 0, __LINE__);
+    assert(q10[3][1][0] == 0, __LINE__);
+    assert(q10[3][1][1] == 0, __LINE__);
+    assert(q10[3][2][0] == 0, __LINE__);
+    assert(q10[3][2][1] == 0, __LINE__);
+}
+
+/*******************************************/
+
+typedef int A[];
+A a = { 1, 2 }, b = { 3, 4, 5 };
+_Static_assert(sizeof(a) == 8, "1");
+_Static_assert(sizeof(b) == 12, "2");
+
+/*******************************************/
+
+int a11[10] = {
+    1,2,3, [6] = 4,5,6
+};
+
+void test11()
+{
+    assert(a11[0] == 1, __LINE__);
+    assert(a11[1] == 2, __LINE__);
+    assert(a11[2] == 3, __LINE__);
+    assert(a11[3] == 0, __LINE__);
+    assert(a11[4] == 0, __LINE__);
+    assert(a11[5] == 0, __LINE__);
+    assert(a11[6] == 4, __LINE__);
+    assert(a11[7] == 5, __LINE__);
+    assert(a11[8] == 6, __LINE__);
+    assert(a11[9] == 0, __LINE__);
+}
+
+/*******************************************/
+
+char s12[] = "hello";
+
+void test12()
+{
+    assert(sizeof(s12) == 6, __LINE__);
+    assert(s12[4] == 'o', __LINE__);
+    assert(s12[5] == 0, __LINE__);
+}
+
+/*******************************************/
+
+char s13[6] = "hello";
+
+void test13()
+{
+    assert(sizeof(s13) == 6, __LINE__);
+    assert(s13[4] == 'o', __LINE__);
+    assert(s13[5] == 0, __LINE__);
+}
+
+/*******************************************/
+
+char s14[5] = "hello";
+
+void test14()
+{
+    assert(sizeof(s14) == 5, __LINE__);
+    assert(s14[4] == 'o', __LINE__);
+}
+
+/*******************************************/
+
+char s15[5] = { "hello" };
+
+void test15()
+{
+    assert(sizeof(s15) == 5, __LINE__);
+    assert(s15[4] == 'o', __LINE__);
+}
+
+/*******************************************/
+
+char s16[2][6] = { "hello", "world" };
+
+void test16()
+{
+    assert(sizeof(s16) == 12, __LINE__);
+    assert(s16[1][2] == 'r', __LINE__);
+}
+
+/*******************************************/
+
+char s17[2][6] = { {"hello"}, {"world"} };
+
+void test17()
+{
+    assert(sizeof(s17) == 12, __LINE__);
+    assert(s17[1][2] == 'r', __LINE__);
+}
+
+/*******************************************/
+
+char s18[2][1][6] = { "hello", "world" };
+
+void test18()
+{
+    assert(sizeof(s18) == 12, __LINE__);
+    assert(s18[1][0][2] == 'r', __LINE__);
+}
+
+/*******************************************/
+
+struct S19 { int a, b; };
+
+struct S19 a19[1] = { 1 };
+
+void test19()
+{
+    assert(a19[0].a == 1, __LINE__);
+    assert(a19[0].b == 0, __LINE__);
+}
+
+/*******************************************/
+
+struct S20 { int a, b; };
+
+struct S20 a20[1] = { 1, [0] = 2 };
+
+void test20()
+{
+    assert(a20[0].a == 2, __LINE__);
+    assert(a20[0].b == 0, __LINE__);
+}
+
+/*******************************************/
+
+int main()
+{
+    test1();
+    test2();
+    test3();
+    test4();
+    test5();
+    test6();
+    test7();
+    test8();
+    test9();
+    test10();
+    test11();
+    test12();
+    test13();
+    test14();
+    test15();
+    test16();
+    test17();
+    test18();
+    test19();
+    test20();
+
+    return 0;
+}

--- a/compiler/test/runnable/test22994.c
+++ b/compiler/test/runnable/test22994.c
@@ -35,16 +35,16 @@ int main()
     printf("%d\n", (int)((char[2]){0})[1]);
     printf("%lf\n", ((double[2]){0})[1]);
 
-    assert(cs1[0]== 0, 1);
-    assert(ds1[0]== 0, 2);
-    assert(cs[1]== 0, 3);
-    assert(ds[1]== 0, 4);
-    assert(css.cs[1]== 0, 5);
-    assert(dss.ds[1]== 0, 6);
-    assert(csu.cs[1]== 0, 7);
-    assert(dsu.ds[1]== 0, 8);
-    assert(((char[2]){0})[1]== 0, 9);
-    assert(((double[2]){0})[1]== 0, 10);
+    assert(cs1[0]== 0, __LINE__);
+    assert(ds1[0]== 0, __LINE__);
+    assert(cs[1]== 0, __LINE__);
+    assert(ds[1]== 0, __LINE__);
+    assert(css.cs[1]== 0, __LINE__);
+    assert(dss.ds[1]== 0, __LINE__);
+    assert(csu.cs[1]== 0, __LINE__);
+    assert(dsu.ds[1]== 0, __LINE__);
+    assert(((char[2]){0})[1]== 0, __LINE__);
+    assert(((double[2]){0})[1]== 0, __LINE__);
 
     return 0;
 }


### PR DESCRIPTION
The old one superficially worked well enough to get things moving, but was not a correct implementation. This one is a rewrite that takes a different tact - it rewrites the CInitializer in terms of StructInitializer and ArrayInitializer. This has the bonus of eliminating all the code for CInitializer in todt.d.

This is a work in progress, which is why the removed code is just disabled instead of removed.

There are several outstanding initializer bugs in bugzilla that I intend to fix once this is working.

P.S. I have no idea how this got attached to @ibuclaw 's PR.