### PR TITLE
cirrus: Only run bootstrap pipeline on 11.x

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,3 @@
-# Test
 common_steps_template: &COMMON_STEPS_TEMPLATE
   install_prerequisites_script: ./ci/cirrusci.sh
   install_host_compiler_script: ./ci/run.sh install_host_compiler
@@ -102,24 +101,7 @@ macos12_task:
         << : *COVERAGE_ENVIRONMENT_TEMPLATE
   << : *COMMON_STEPS_TEMPLATE
 macos11_task:
-  name: macOS 11.x x64, $TASK_NAME_SUFFIX
-  osx_instance:
-    image: big-sur-xcode
-  timeout_in: 60m
-  environment:
-    OS_NAME: darwin
-    # override Cirrus default OS (`darwin`)
-    OS: osx
-    # 12 CPU cores and 24 GB of memory are available
-    N: 12
-    matrix:
-      - TASK_NAME_SUFFIX: DMD (latest)
-      - TASK_NAME_SUFFIX: DMD (coverage)
-        << : *COVERAGE_ENVIRONMENT_TEMPLATE
-  << : *COMMON_STEPS_TEMPLATE
-
-macos10_task:
-  name: macOS 10.15 x64, DMD (bootstrap)
+  name: macOS 11.x x64, DMD (bootstrap)
   osx_instance:
     image: big-sur-xcode
   timeout_in: 60m

--- a/ci/README.md
+++ b/ci/README.md
@@ -167,9 +167,7 @@ These should be taken seriously, since untested code is likely to introduce bugs
 - Ubuntu 18.04 x86, DMD (bootstrap)
 - Ubuntu 18.04 x86, DMD (coverage)
 - Ubuntu 18.04 x86, DMD (latest)
-- macOS 10.15 x64, DMD (bootstrap)
-- macOS 11.x x64, DMD (coverage)
-- macOS 11.x x64, DMD (latest)
+- macOS 11.x x64, DMD (bootstrap)
 - macOS 12.x x64, DMD (coverage)
 - macOS 12.x x64, DMD (latest)
 


### PR DESCRIPTION
It turns out that the 10.15 bootstrap pipeline was using the 11.x image all along...