### PR TITLE
fix Issue 22610 - ImportC: 3 extra initializer(s) for struct __tag21

### DIFF
--- a/compiler/test/runnable/initializer.c
+++ b/compiler/test/runnable/initializer.c
@@ -622,6 +622,21 @@ void test39()
 
 /*********************************/
 
+void test22610()
+{
+    struct S
+    {
+        unsigned char c[4];
+    };
+    static struct S c = { 255,255,255,255 };
+    assert(c.c[0] == 255, __LINE__);
+    assert(c.c[1] == 255, __LINE__);
+    assert(c.c[2] == 255, __LINE__);
+    assert(c.c[3] == 255, __LINE__);
+}
+
+/*********************************/
+
 void test40()
 {
     char s[6] = { "s" }; if (s[0] != 's')                     { assert(0, __LINE__); }
@@ -697,6 +712,7 @@ int main()
     test38a();
     test38b();
     test39();
+    test22610();
     test40();
     test41();
     test42();


### PR DESCRIPTION
Already fixed, adding test case.