### PR TITLE
fix Issue 22652 - importC: Braceless initializer of nested struct is …

### DIFF
--- a/compiler/test/runnable/initializer.c
+++ b/compiler/test/runnable/initializer.c
@@ -701,6 +701,28 @@ void test23230()
 }
 
 /*********************************/
+// https://issues.dlang.org/show_bug.cgi?id=22652
+
+void test22652()
+{
+    struct S1 {
+        int x, y;
+    };
+
+    struct S2 {
+        struct S1 s;
+    };
+
+    struct S2 c = {1};
+    struct S2 d = {1, 2};
+
+    assert(c.s.x == 1, __LINE__);
+    assert(c.s.y == 0, __LINE__);
+    assert(d.s.x == 1, __LINE__);
+    assert(d.s.y == 2, __LINE__);
+}
+
+/*********************************/
 
 void test42()
 {
@@ -765,6 +787,7 @@ int main()
     test40();
     test41();
     test23230();
+    test22652();
     test42();
     test43();
 


### PR DESCRIPTION
…rejected

Had to move subStruct() and subArray() so they wouldn't be forward referenced. They weren't altered. The meat of the change starts at line 854, which adds the disambiguate test to decide whether to call subStruct() or not.

This concludes the current set of ImportC initializer bugs in bugzilla. There are still a couple issues not covered by bug reports yet.