### PR TITLE
Fix Issue 13732 - non-member templates can use "template this"

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1596,6 +1596,13 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         nextToken();
                         tp_spectype = parseType();
                     }
+                    else
+                    {
+                        // default to `const typeof(this)` to detect use outside a type
+                        // or an explicit type passed that isn't compatible
+                        tp_spectype = new AST.TypeTypeof(loc, new AST.ThisExp(loc));
+                        tp_spectype.addSTC(STC.const_);
+                    }
                     if (token.value == TOK.assign) // = Type
                     {
                         nextToken();

--- a/compiler/test/fail_compilation/templatethis.d
+++ b/compiler/test/fail_compilation/templatethis.d
@@ -1,0 +1,50 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/templatethis.d(18): Error: `this` is not in a class or struct scope
+fail_compilation/templatethis.d(18): Error: `this` is only defined in non-static member functions, not `templatethis`
+fail_compilation/templatethis.d(22): Error: `this` is not in a class or struct scope
+fail_compilation/templatethis.d(22): Error: `this` is only defined in non-static member functions, not `templatethis`
+fail_compilation/templatethis.d(26): Error: `this` is not in a class or struct scope
+fail_compilation/templatethis.d(26): Error: `this` is only defined in non-static member functions, not `templatethis`
+fail_compilation/templatethis.d(28): Error: `this` is not in a class or struct scope
+fail_compilation/templatethis.d(28): Error: `this` is only defined in non-static member functions, not `templatethis`
+fail_compilation/templatethis.d(34): Error: `this` is not in a class or struct scope
+fail_compilation/templatethis.d(34): Error: `this` is only defined in non-static member functions, not `t2!()`
+fail_compilation/templatethis.d(37): Error: mixin `templatethis.t2!()` error instantiating
+---
+*/
+
+template t(this T)
+{
+}
+
+struct S(this T)
+{
+}
+
+enum e(this T) = 1;
+
+void f(this T)()
+{
+}
+
+mixin template t2()
+{
+	int i(this T) = 1;
+}
+
+mixin t2;
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/templatethis.d(50): Error: template instance `f!int` does not match template declaration `f(this T : C)()`
+---
+*/
+class C
+{
+	static void f(this T)() {}
+}
+
+alias a = C.f!int;


### PR DESCRIPTION
Error if a TemplateThisParameter is declared where `typeof(this)` would be an error.
Error if a TemplateThisParameter is passed a type that doesn't implicitly convert to `const typeof(this)`.

Note: This is done with a dummy specialization, which triggers the semantic error messages even for a template mixin and may be more efficient than doing the check in dtemplate.d.

Explicitly overriding the specialization is supported for now, but even then `this T` should implicitly convert to `const typeof(this)`.
