### PR TITLE
fix Issue 23338 - braceless subarray initalizers for struct fields fails

### DIFF
--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -852,9 +852,21 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
                             break;
                     }
                     auto tn = field.type.toBasetype();
+                    auto tnsa = tn.isTypeSArray();
                     auto tns = tn.isTypeStruct();
                     auto ix = di.initializer;
-                    if (tns && ix.isExpInitializer())
+                    if (tnsa && ix.isExpInitializer())
+                    {
+                        ExpInitializer ei = ix.isExpInitializer();
+                        if (ei.exp.isStringExp() && tnsa.nextOf().isintegral())
+                        {
+                            si.addInit(field.ident, ei);
+                            ++index;
+                        }
+                        else
+                            si.addInit(field.ident, subArray(tnsa, index));
+                    }
+                    else if (tns && ix.isExpInitializer())
                     {
                         /* Disambiguate between an exp representing the entire
                          * struct, and an exp representing the first field of the struct

--- a/compiler/test/runnable/initializer.c
+++ b/compiler/test/runnable/initializer.c
@@ -760,6 +760,26 @@ void test44()
 }
 
 /*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=23338
+
+struct S45 {
+    char a, b[2];
+};
+
+struct S45 s45 = { 1, 2, 3 };
+struct S45 t45 = { 'a', "bc" };
+
+void test45()
+{
+    assert(s45.a    == 1, __LINE__);
+    assert(s45.b[0] == 2, __LINE__);
+    assert(s45.b[1] == 3, __LINE__);
+    assert(t45.a    == 'a', __LINE__);
+    assert(t45.b[0] == 'b', __LINE__);
+    assert(t45.b[1] == 'c', __LINE__);
+}
+
+/*******************************************/
 
 int main()
 {
@@ -805,6 +825,7 @@ int main()
     test42();
     test43();
     test44();
+    test45();
 
     return 0;
 }


### PR DESCRIPTION
Analogous to the other initialization code.