### PR TITLE
druntime: Fix build for MIPS64 UClibc

### DIFF
--- a/druntime/src/core/stdc/fenv.d
+++ b/druntime/src/core/stdc/fenv.d
@@ -483,7 +483,7 @@ else version (CRuntime_UClibc)
 
         alias fexcept_t = ushort;
     }
-    else version (MIPS32)
+    else version (MIPS_Any)
     {
         struct fenv_t
         {

--- a/druntime/src/core/stdc/math.d
+++ b/druntime/src/core/stdc/math.d
@@ -120,7 +120,7 @@ else version (CRuntime_UClibc)
         ///
         enum int FP_ILOGBNAN      = int.min;
     }
-    else version (MIPS32)
+    else version (MIPS_Any)
     {
         ///
         enum int FP_ILOGB0        = -int.max;

--- a/druntime/src/core/sys/posix/dlfcn.d
+++ b/druntime/src/core/sys/posix/dlfcn.d
@@ -387,7 +387,7 @@ else version (CRuntime_UClibc)
         enum RTLD_LOCAL             = 0;
         enum RTLD_NODELETE          = 0x01000;
     }
-    else version (MIPS32)
+    else version (MIPS_Any)
     {
         enum RTLD_LAZY              = 0x0001;
         enum RTLD_NOW               = 0x0002;

--- a/druntime/src/core/sys/posix/setjmp.d
+++ b/druntime/src/core/sys/posix/setjmp.d
@@ -370,6 +370,22 @@ else version (CRuntime_UClibc)
                 double[6] __fpregs;
         }
     }
+    else version (MIPS64)
+    {
+        struct __jmp_buf
+        {
+            long __pc;
+            long __sp;
+            long[8] __regs;
+            long __fp;
+            long __gp;
+            int __fpc_csr;
+            version (MIPS_N64)
+                double[8] __fpregs;
+            else
+                double[6] __fpregs;
+        }
+    }
     else
         static assert(0, "unimplemented");
 

--- a/druntime/src/core/sys/posix/sys/types.d
+++ b/druntime/src/core/sys/posix/sys/types.d
@@ -1140,6 +1140,18 @@ else version (CRuntime_UClibc)
         enum __SIZEOF_PTHREAD_BARRIER_T     = 20;
         enum __SIZEOF_PTHREAD_BARRIERATTR_T = 4;
      }
+     else version (MIPS64)
+     {
+        enum __SIZEOF_PTHREAD_ATTR_T        = 56;
+        enum __SIZEOF_PTHREAD_MUTEX_T       = 40;
+        enum __SIZEOF_PTHREAD_MUTEXATTR_T   = 4;
+        enum __SIZEOF_PTHREAD_COND_T        = 48;
+        enum __SIZEOF_PTHREAD_CONDATTR_T    = 4;
+        enum __SIZEOF_PTHREAD_RWLOCK_T      = 56;
+        enum __SIZEOF_PTHREAD_RWLOCKATTR_T  = 8;
+        enum __SIZEOF_PTHREAD_BARRIER_T     = 32;
+        enum __SIZEOF_PTHREAD_BARRIERATTR_T = 4;
+     }
      else version (ARM)
      {
         enum __SIZEOF_PTHREAD_ATTR_T = 36;


### PR DESCRIPTION
From comment here https://github.com/compiler-explorer/compiler-explorer/issues/3973#issuecomment-1250074395, and tested using the given crosstools-ng scripts.