### PR TITLE
druntime: Use X86_Any in some uClibc bindings

### DIFF
--- a/druntime/src/core/stdc/math.d
+++ b/druntime/src/core/stdc/math.d
@@ -106,14 +106,7 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_UClibc)
 {
-    version (X86)
-    {
-        ///
-        enum int FP_ILOGB0        = int.min;
-        ///
-        enum int FP_ILOGBNAN      = int.min;
-    }
-    else version (X86_64)
+    version (X86_Any)
     {
         ///
         enum int FP_ILOGB0        = int.min;

--- a/druntime/src/core/sys/posix/dlfcn.d
+++ b/druntime/src/core/sys/posix/dlfcn.d
@@ -377,7 +377,7 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_UClibc)
 {
-    version (X86_64)
+    version (X86_Any)
     {
         enum RTLD_LAZY              = 0x0001;
         enum RTLD_NOW               = 0x0002;


### PR DESCRIPTION
When looking at the uClibc bindings, just a couple of things that stood out w.r.t missing or duplicated X86 bindings.