### PR TITLE
Add visit method for UnionDeclaration in transitivevisitor

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8025,6 +8025,7 @@ public:
     void visit(EnumDeclaration* d) override;
     void visit(Nspace* d) override;
     void visit(StructDeclaration* d) override;
+    void visit(UnionDeclaration* d) override;
     void visit(ClassDeclaration* d) override;
     void visit(AliasDeclaration* d) override;
     void visit(AliasAssign* d) override;

--- a/compiler/src/dmd/transitivevisitor.d
+++ b/compiler/src/dmd/transitivevisitor.d
@@ -781,6 +781,15 @@ package mixin template ParseVisitMethods(AST)
             s.accept(this);
     }
 
+    override void visit(AST.UnionDeclaration d)
+    {
+        //printf("Visiting UnionDeclaration\n");
+        if (!d.members)
+            return;
+        foreach (s; *d.members)
+            s.accept(this);
+    }
+
     override void visit(AST.ClassDeclaration d)
     {
         //printf("Visiting ClassDeclaration\n");


### PR DESCRIPTION
UnionDeclaration should have it's own visit method because one might want to extend the transitive visitor class and override the visit method of StructDeclaration, but keep the default logic for UnionDeclaration. Without a visit method for UnionDeclaration, what would happen currently in this situation is that if you override the visit method for StructDeclaration you automatically override also the visit method for UnionDeclaration