### PR TITLE
chore(druntime/posix): annotate posix_memalign as pure and scope

### DIFF
--- a/druntime/src/core/sys/posix/stdlib.d
+++ b/druntime/src/core/sys/posix/stdlib.d
@@ -95,44 +95,44 @@ int posix_memalign(void**, size_t, size_t);
 
 version (CRuntime_Glibc)
 {
-    int posix_memalign(void**, size_t, size_t);
+    int posix_memalign(scope void**, size_t, size_t) pure;
 }
 else version (FreeBSD)
 {
-    int posix_memalign(void**, size_t, size_t);
+    int posix_memalign(scope void**, size_t, size_t) pure;
 }
 else version (NetBSD)
 {
-    int posix_memalign(void**, size_t, size_t);
+    int posix_memalign(scope void**, size_t, size_t) pure;
 }
 else version (OpenBSD)
 {
-    int posix_memalign(void**, size_t, size_t);
+    int posix_memalign(scope void**, size_t, size_t) pure;
 }
 else version (DragonFlyBSD)
 {
-    int posix_memalign(void**, size_t, size_t);
+    int posix_memalign(scope void**, size_t, size_t) pure;
 }
 else version (Solaris)
 {
-    int posix_memalign(void**, size_t, size_t);
+    int posix_memalign(scope void**, size_t, size_t) pure;
 }
 else version (Darwin)
 {
-    int posix_memalign(void**, size_t, size_t);
+    int posix_memalign(scope void**, size_t, size_t) pure;
 }
 else version (CRuntime_Bionic)
 {
     // Added since Lollipop
-    int posix_memalign(void**, size_t, size_t);
+    int posix_memalign(scope void**, size_t, size_t) pure;
 }
 else version (CRuntime_Musl)
 {
-    int posix_memalign(void**, size_t, size_t);
+    int posix_memalign(scope void**, size_t, size_t) pure;
 }
 else version (CRuntime_UClibc)
 {
-    int posix_memalign(void**, size_t, size_t);
+    int posix_memalign(scope void**, size_t, size_t) pure;
 }
 
 //


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

As per the documentation of `pure_memalign`, it doesn't produce any side effects like writing to `errno` variable on error, therefore, it should be marked as `pure`. Required to make `AlignedMallocator` `pure`. See https://github.com/dlang/phobos/pull/8576.

Reference to documentation: https://man7.org/linux/man-pages/man3/posix_memalign.3.html