### PR TITLE
`core.demangle`: Remove return value of `put`

### DIFF
--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -253,23 +253,22 @@ pure @safe:
             put(", ");
     }
 
-    char[] put(char c) return scope
+    void put(char c) return scope
     {
         char[1] val = c;
-        return put(val[]);
+        put(val[]);
     }
 
-    char[] put( scope const(char)[] val ) return scope
+    void put(scope const(char)[] val) return scope
     {
         pragma(inline, false); // tame dmd inliner
 
-        if ( val.length )
-        {
-            if ( !contains( dst[0 .. len], val ) )
-                return append( val );
-            return shift( val );
-        }
-        return null;
+        if (!val.length) return;
+
+        if (!contains(dst[0 .. len], val))
+            append(val);
+        else
+            shift(val);
     }
 
 

--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -82,7 +82,7 @@ pure @safe:
 
     static class ParseException : Exception
     {
-        @safe pure nothrow this( string msg )
+        this(string msg) @safe pure nothrow
         {
             super( msg );
         }
@@ -91,7 +91,7 @@ pure @safe:
 
     static class OverflowException : Exception
     {
-        @safe pure nothrow this( string msg )
+        this(string msg) @safe pure nothrow
         {
             super( msg );
         }


### PR DESCRIPTION
It's not used. Also a small cosmetic change while I'm at it.