### PR TITLE
fix 23355: invalid template parameter loses error location in some cases (T[UndefinedIdentifier] has no error loc)

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -3841,10 +3841,20 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         tp = (*parameters)[i];
                     else
                     {
+                        Loc loc;
+                        // The "type" (it hasn't been resolved yet) of the function parameter
+                        // does not have a location but the parameter it is related to does,
+                        // so we use that for the resolution (better error message).
+                        if (inferStart < parameters.dim)
+                        {
+                            TemplateParameter loctp = (*parameters)[inferStart];
+                            loc = loctp.loc;
+                        }
+
                         Expression e;
                         Type tx;
                         Dsymbol s;
-                        taa.index.resolve(Loc.initial, sc, e, tx, s);
+                        taa.index.resolve(loc, sc, e, tx, s);
                         edim = s ? getValue(s) : getValue(e);
                     }
                 }

--- a/compiler/test/fail_compilation/diag23355.d
+++ b/compiler/test/fail_compilation/diag23355.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag23355.d(1): Error: undefined identifier `n`
+fail_compilation/diag23355.d(4): Error: none of the overloads of template `diag23355.ffi1` are callable using argument types `!()(int[4])`
+fail_compilation/diag23355.d(1):        Candidate is: `ffi1(T)(T[n] s)`
+fail_compilation/diag23355.d(2): Error: undefined identifier `n`
+fail_compilation/diag23355.d(4): Error: none of the overloads of template `diag23355.ffi2` are callable using argument types `!()(int[4])`
+fail_compilation/diag23355.d(2):        Candidate is: `ffi2()(T[n] s)`
+---
+*/
+#line 1
+void ffi1(T)(T[n] s) { }
+void ffi2()(T[n] s) { }
+
+void main() { int[4] x; ffi1(x); ffi2(x); }


### PR DESCRIPTION
Types (e.g. TypeAArray) don't have a location attached to them, so instead of trying to use that we instead use the error location from the general template parameters.

@maxhaton 

The error message came from here: https://github.com/dlang/dmd/blob/58a63ffcedaada9b7501aea60d02a28b12c8770a/compiler/src/dmd/typesem.d#L175
which was called from the here changed file.