### PR TITLE
Fix `rt_trap_exceptions_drt_gdb` in the presence of optimisations

### DIFF
--- a/druntime/test/exceptions/Makefile
+++ b/druntime/test/exceptions/Makefile
@@ -110,7 +110,7 @@ $(ROOT)/rt_trap_exceptions_drt_gdb.done: $(ROOT)/rt_trap_exceptions_drt
 	$(QUIET)$(TIMELIMIT) $(GDB) -n -ex 'set confirm off' -ex run -ex 'bt full' -ex q --args $< --DRT-trapExceptions=0 \
 		> $(ROOT)/rt_trap_exceptions_drt_gdb.output 2>&1 || true
 	cat $(ROOT)/rt_trap_exceptions_drt_gdb.output
-	grep "in D main (args=...) at .*rt_trap_exceptions_drt.d:9" > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
+	grep "D main (args=...) at .*rt_trap_exceptions_drt.d:9" > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
 	grep 'myLocal' > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
 	! grep "No stack." > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
 	@touch $@


### PR DESCRIPTION
The test checks the stack frame of `_Dmain` is in the backtrace, however if unused locals are optimised out and`test` is inlined into `main` 
```d
void test()
{
    int innerLocal = 20;
    throw new Exception("foo");
}
void main(string[] args)
{
    string myLocal = "bar";
    test();
}
```
then the point at which the untapped exception is thrown is at the start of D main - not somewhere in the middle of it - and so GDB prints 
```
...
#4 D main (args=...)
```
rather than 
```
...
#4 0xSOMEADDRESS in D main (args=...)
```