### PR TITLE
fix location issue for VisibilityDeclaration

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -888,6 +888,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                             error("redundant visibility attribute `%s`", AST.visibilityToChars(prot));
                     }
                     pAttrs.visibility.kind = prot;
+                    const attrloc = token.loc;
 
                     nextToken();
 
@@ -908,7 +909,6 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         }
                     }
 
-                    const attrloc = token.loc;
                     a = parseBlock(pLastDecl, pAttrs);
                     if (pAttrs.visibility.kind != AST.Visibility.Kind.undefined)
                     {

--- a/compiler/test/unit/parser/visibilitydeclaration_location.d
+++ b/compiler/test/unit/parser/visibilitydeclaration_location.d
@@ -1,0 +1,93 @@
+module parser.visibilitydeclaration_location;
+
+import dmd.frontend : parseModule;
+import support : afterEach, beforeEach;
+import dmd.attrib : VisibilityDeclaration;
+import dmd.globals : Loc;
+import dmd.visitor : SemanticTimeTransitiveVisitor;
+
+@beforeEach
+void initializeFrontend()
+{
+    import dmd.frontend : initDMD;
+
+    initDMD();
+}
+
+@afterEach
+void deinitializeFrontend()
+{
+    import dmd.frontend : deinitializeDMD;
+    deinitializeDMD();
+}
+
+extern (C++) class Visitor : SemanticTimeTransitiveVisitor
+{
+    alias visit = typeof(super).visit;
+    Loc l;
+
+    override void visit(VisibilityDeclaration vd)
+    {
+        l = vd.loc;
+    }
+}
+
+immutable struct Test
+{
+    /*
+     * The description of the unit test.
+     *
+     * This will go into the UDA attached to the `unittest` block.
+     */
+    string description_;
+
+    /*
+     * The code to parse.
+     *
+     */
+    string code_;
+
+    string code()
+    {
+        return code_;
+    }
+
+    string description()
+    {
+        return description_;
+    }
+}
+
+enum tests = [
+    Test("`public` symbol and curly braces on the next line", q{class C
+    {
+    public
+    {
+        void foo() {}
+    }
+    }}),
+    Test("`public` symbol and colon on the same line", q{class C
+    {
+    public:
+        void foo() {}
+    }}),
+    Test("`public` symbol and function declaration on the same line", q{class C
+    {
+    public void foo() {}
+    }}),
+];
+
+static foreach (test; tests)
+{
+    @(test.description)
+    unittest
+    {
+        auto t = parseModule("test.d", "first_token " ~ test.code);
+
+        scope visitor = new Visitor;
+        t.module_.accept(visitor);
+
+        assert(visitor.l.linnum == 3);
+        assert(visitor.l.charnum == 5);
+    }
+}


### PR DESCRIPTION
The issue is that right now the location for VisibilityDeclaration is the location of the next token after the access specifier. Example
private
{
   ....
  
And let's say private is on line 1. The location of the VisibilityDeclaration will store 2 as the line number (the line number of '{' ), which is not correct