### PR TITLE
fix Issue 22973 - importC: sizeof with array and pointer access gives…

### DIFF
--- a/compiler/test/compilable/test22973.i
+++ b/compiler/test/compilable/test22973.i
@@ -1,0 +1,4 @@
+// https://issues.dlang.org/show_bug.cgi?id=22973
+
+int *ps[1];
+_Static_assert(sizeof(ps[0][0]) == sizeof(int), "");


### PR DESCRIPTION
… array type has incomplete element type

Already works, just adding the test case.