### PR TITLE
Add named argument parsing support

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -6141,6 +6141,19 @@ struct ASTBase
         }
     }
 
+    extern (C++) class NamedArgExp : Expression
+    {
+        Identifier ident;
+        RootObject arg;
+
+        extern (D) this(const ref Loc loc, Identifier ident, RootObject arg)
+        {
+            super(loc, EXP.namedArg, __traits(classInstanceSize, NamedArgExp));
+            this.ident = ident;
+            this.arg = arg;
+        }
+    }
+
     extern (C++) final class GenericExp : Expression
     {
         Expression cntlExp;

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -1756,6 +1756,12 @@ public:
         result = CTFEExp.cantexp;
     }
 
+    override void visit(NamedArgExp e)
+    {
+        e.error("cannot use named argument `%s` in `mixin` or `pragma`", e.toChars());
+        result = CTFEExp.cantexp;
+    }
+
     override void visit(TypeExp e)
     {
         debug (LOG)

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -6590,6 +6590,15 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             Expression ea = isExpression(o);
             Dsymbol sa = isDsymbol(o);
 
+            if (ea)
+            {
+                if (auto na = ea.isNamedArgExp())
+                {
+                    ea.error("named arguments (`%s`) are not supported yet", na.toChars());
+                    continue;
+                }
+            }
+
             //printf("1: (*tiargs)[%d] = %p, s=%p, v=%p, ea=%p, ta=%p\n", j, o, isDsymbol(o), isTuple(o), ea, ta);
             if (ta)
             {

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -1761,6 +1761,7 @@ extern (C++) abstract class Expression : ASTNode
         inout(ObjcClassReferenceExp) isObjcClassReferenceExp() { return op == EXP.objcClassReference ? cast(typeof(return))this : null; }
         inout(ClassReferenceExp) isClassReferenceExp() { return op == EXP.classReference ? cast(typeof(return))this : null; }
         inout(ThrownExceptionExp) isThrownExceptionExp() { return op == EXP.thrownException ? cast(typeof(return))this : null; }
+        inout(NamedArgExp) isNamedArgExp() { return op == EXP.namedArg ? cast(typeof(return))this : null; }
 
         inout(UnaExp) isUnaExp() pure inout nothrow @nogc
         {
@@ -6988,6 +6989,31 @@ extern (C++) final class PrettyFuncInitExp : DefaultInitExp
         e = e.expressionSemantic(sc);
         e.type = Type.tstring;
         return e;
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+/***********************************************************
+ * Named argument in an argument list
+ *
+ * Examples: `f(x: 3)`, `g!(T: int)`
+ */
+extern (C++) class NamedArgExp : Expression
+{
+    /// Name of parameter to assign argument to
+    Identifier ident;
+    /// (template) argument to assign
+    RootObject arg;
+
+    extern (D) this(const ref Loc loc, Identifier ident, RootObject arg)
+    {
+        super(loc, EXP.namedArg, __traits(classInstanceSize, NamedArgExp));
+        this.ident = ident;
+        this.arg = arg;
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -236,6 +236,7 @@ public:
     PrettyFuncInitExp* isPrettyFuncInitExp();
     ClassReferenceExp* isClassReferenceExp();
     ThrownExceptionExp* isThrownExceptionExp();
+    NamedArgExp* isNamedArgExp();
     UnaExp* isUnaExp();
     BinExp* isBinExp();
     BinAssignExp* isBinAssignExp();
@@ -1350,6 +1351,14 @@ class PrettyFuncInitExp final : public DefaultInitExp
 public:
     Expression *resolveLoc(const Loc &loc, Scope *sc) override;
     void accept(Visitor *v) override { v->visit(this); }
+};
+
+class NamedArgExp : public Expression
+{
+public:
+    Identifier* ident;
+    RootObject* arg;
+    void accept(Visitor* v) override;
 };
 
 /****************************************************************/

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1636,6 +1636,12 @@ private bool preFunctionParameters(Scope* sc, Expressions* exps, const bool repo
         for (size_t i = 0; i < exps.dim; i++)
         {
             Expression arg = (*exps)[i];
+            if (arg.isNamedArgExp())
+            {
+                arg.error("named arguments (`%s`) are not supported yet", arg.toChars());
+                err = true;
+                continue;
+            }
             arg = resolveProperties(sc, arg);
             arg = arg.arrayFuncConv(sc);
             if (arg.op == EXP.type)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -224,6 +224,7 @@ class PrettyFuncInitExp;
 class ObjcClassReferenceExp;
 class ClassReferenceExp;
 class ThrownExceptionExp;
+class NamedArgExp;
 class UnaExp;
 class BinExp;
 class BinAssignExp;
@@ -1397,6 +1398,7 @@ enum class EXP : uint8_t
     compoundLiteral = 132u,
     _Generic = 133u,
     interval = 134u,
+    namedArg = 135u,
 };
 
 typedef uint64_t dinteger_t;
@@ -1587,6 +1589,7 @@ public:
     ObjcClassReferenceExp* isObjcClassReferenceExp();
     ClassReferenceExp* isClassReferenceExp();
     ThrownExceptionExp* isThrownExceptionExp();
+    NamedArgExp* isNamedArgExp();
     UnaExp* isUnaExp();
     BinExp* isBinExp();
     BinAssignExp* isBinAssignExp();
@@ -2467,6 +2470,7 @@ public:
     virtual void visit(typename AST::ArrayInitializer i);
     virtual void visit(typename AST::VoidInitializer i);
     virtual void visit(typename AST::CInitializer i);
+    virtual void visit(typename AST::NamedArgExp e);
 };
 
 struct MangleOverride final
@@ -4847,6 +4851,7 @@ struct ASTCodegen final
     using ModuleInitExp = ::ModuleInitExp;
     using MulAssignExp = ::MulAssignExp;
     using MulExp = ::MulExp;
+    using NamedArgExp = ::NamedArgExp;
     using NegExp = ::NegExp;
     using NewAnonClassExp = ::NewAnonClassExp;
     using NewExp = ::NewExp;
@@ -7717,6 +7722,14 @@ public:
     void accept(Visitor* v) override;
 };
 
+class NamedArgExp : public Expression
+{
+public:
+    Identifier* ident;
+    RootObject* arg;
+    void accept(Visitor* v) override;
+};
+
 class ObjcClassReferenceExp final : public Expression
 {
 public:
@@ -8104,6 +8117,7 @@ public:
     void visit(TemplateThisParameter* tp) override;
     void visit(TemplateAliasParameter* tp) override;
     void visit(TemplateValueParameter* tp) override;
+    void visit(NamedArgExp* e) override;
     void visit(StaticIfCondition* c) override;
     void visit(Parameter* p) override;
     void visit(Module* m) override;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2586,6 +2586,13 @@ private void expressionPrettyPrint(Expression e, OutBuffer* buf, HdrGenState* hg
         buf.writestring(e.value.toChars());
     }
 
+    void visitNamedArg(NamedArgExp e)
+    {
+        buf.writestring(e.ident.toChars());
+        buf.writestring(": ");
+        buf.writestring(e.arg.toChars());
+    }
+
     switch (e.op)
     {
         default:
@@ -2659,6 +2666,7 @@ private void expressionPrettyPrint(Expression e, OutBuffer* buf, HdrGenState* hg
         case EXP.remove:        return visitRemove(e.isRemoveExp());
         case EXP.question:      return visitCond(e.isCondExp());
         case EXP.classReference:        return visitClassReference(e.isClassReferenceExp());
+        case EXP.namedArg:      return visitNamedArg(e.isNamedArgExp());
     }
 }
 

--- a/compiler/src/dmd/parsetimevisitor.d
+++ b/compiler/src/dmd/parsetimevisitor.d
@@ -299,4 +299,6 @@ public:
     void visit(AST.ArrayInitializer i) { visit(cast(AST.Initializer)i); }
     void visit(AST.VoidInitializer i) { visit(cast(AST.Initializer)i); }
     void visit(AST.CInitializer i) { visit(cast(AST.CInitializer)i); }
+
+    void visit(AST.NamedArgExp e) { visit(cast(AST.Expression)e); }
 }

--- a/compiler/src/dmd/strictvisitor.d
+++ b/compiler/src/dmd/strictvisitor.d
@@ -235,4 +235,5 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.ArrayInitializer) { assert(0); }
     override void visit(AST.VoidInitializer) { assert(0); }
     override void visit(AST.CInitializer) { assert(0); }
+    override void visit(AST.NamedArgExp) { assert(0); }
 }

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -426,6 +426,7 @@ enum EXP : ubyte
     compoundLiteral, // ( type-name ) { initializer-list }
     _Generic,
     interval,
+    namedArg,
 }
 
 enum FirstCKeyword = TOK.inline;

--- a/compiler/src/dmd/tokens.h
+++ b/compiler/src/dmd/tokens.h
@@ -436,6 +436,7 @@ enum class EXP : unsigned char
     compoundLiteral, // ( type-name ) { initializer-list }
     _Generic_,
     interval,
+    namedArg,
 
     MAX
 };

--- a/compiler/src/dmd/transitivevisitor.d
+++ b/compiler/src/dmd/transitivevisitor.d
@@ -1204,6 +1204,21 @@ package mixin template ParseVisitMethods(AST)
             tp.defaultValue.accept(this);
     }
 
+    override void visit(AST.NamedArgExp e)
+    {
+        switch(e.arg.dyncast())
+        {
+            case DYNCAST.expression:
+                (cast(AST.Expression)e.arg).accept(this);
+                break;
+            case DYNCAST.type:
+                (cast(AST.Type)e.arg).accept(this);
+                break;
+            default:
+                break;
+        }
+    }
+
 //===========================================================
 
     override void visit(AST.StaticIfCondition c)

--- a/compiler/src/dmd/visitor.h
+++ b/compiler/src/dmd/visitor.h
@@ -293,6 +293,7 @@ class LineInitExp;
 class ModuleInitExp;
 class FuncInitExp;
 class PrettyFuncInitExp;
+class NamedArgExp;
 class ClassReferenceExp;
 class VoidInitExp;
 class ThrownExceptionExp;
@@ -590,6 +591,8 @@ public:
     virtual void visit(ArrayInitializer *i) { visit((Initializer *)i); }
     virtual void visit(VoidInitializer *i) { visit((Initializer *)i); }
     virtual void visit(CInitializer *i) { visit((Initializer *)i); }
+
+    virtual void visit(NamedArgExp *e) { visit((Expression *)e); }
 };
 
 class Visitor : public ParseTimeVisitor

--- a/compiler/test/fail_compilation/named_arguments.d
+++ b/compiler/test/fail_compilation/named_arguments.d
@@ -1,0 +1,26 @@
+/**
+TEST_OUTPUT:
+---
+fail_compilation/named_arguments.d(21): Error: named arguments (`mx: 10`) are not supported yet
+fail_compilation/named_arguments.d(22): Error: named arguments (`x: 20`) are not supported yet
+fail_compilation/named_arguments.d(22): Error: named arguments (`y: 30`) are not supported yet
+fail_compilation/named_arguments.d(23): Error: named arguments (`T: int`) are not supported yet
+fail_compilation/named_arguments.d(23): Error: template instance `tt!(T: int)` does not match template declaration `tt(T)`
+fail_compilation/named_arguments.d(24): Error: cannot use named argument `thecode: "{}"` in `mixin` or `pragma`
+fail_compilation/named_arguments.d(25): Error: cannot use named argument `themsg: "hello"` in `mixin` or `pragma`
+fail_compilation/named_arguments.d(25):        while evaluating `pragma(msg, themsg: "hello")`
+---
+*/
+
+void f(int x, int y);
+struct S { int mx; }
+alias tt(T) = T;
+
+void main()
+{
+	auto s = new S(mx: 10);
+	f(x: 20, y: 30,);
+	tt!(T: int);
+	mixin(thecode: "{}");
+	pragma(msg, themsg: "hello");
+}


### PR DESCRIPTION
Start implementing https://www.dlang.org/dips/1030

Does not do the hard part yet, but it's a start. Named (template) arguments are parsed to a `NamedArgExp`, which result in a "not implemented" error during semantic analysis.