### PR TITLE
github workflows: Bump OSX image version to 11

### DIFF
--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -346,6 +346,11 @@ jobs:
         echo "HOST_DMD=${{ env.DC }}" >> $GITHUB_ENV
         echo "${{ github.workspace }}/tools/dm/bin/" >> $GITHUB_PATH
 
+    # Debug OSX with tmate
+    - name: '[OSX] Run tmate'
+      uses: P3TERX/ssh2actions@main
+      if: matrix.os == 'macos-11'
+
     ########################################
     #    Building DMD, druntime, Phobos    #
     ########################################

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -56,9 +56,9 @@ jobs:
       # very few PRs actually benefit from this.
       fail-fast: false
       matrix:
-        # OSX 10.15, Ubuntu 18.04 in order to support older LLVM / GCC
+        # OSX 11, Ubuntu 18.04 in order to support older LLVM / GCC
         # Ubuntu 20.04 in order to support newer LLVM / GCC
-        os: [ macOS-10.15, ubuntu-18.04, ubuntu-20.04, windows-2019 ]
+        os: [ macos-11, ubuntu-18.04, ubuntu-20.04, windows-2019 ]
 
         target: [
           # Versions of clang earlier than 8 are not available on 18.04
@@ -99,17 +99,17 @@ jobs:
           - { os: ubuntu-20.04, target: g++-6 }
           - { os: ubuntu-20.04, target: g++-5 }
           # OSX only supports clang
-          - { os: macOS-10.15, target: g++-11 }
-          - { os: macOS-10.15, target: g++-10 }
-          - { os: macOS-10.15, target: g++-9 }
-          - { os: macOS-10.15, target: g++-8 }
-          - { os: macOS-10.15, target: g++-7 }
-          - { os: macOS-10.15, target: g++-6 }
-          - { os: macOS-10.15, target: g++-5 }
-          - { os: macOS-10.15, target: msvc-2019 }
-          - { os: macOS-10.15, target: msvc-2017 }
-          - { os: macOS-10.15, target: msvc-2015 }
-          - { os: macOS-10.15, target: msvc-2013 }
+          - { os: macos-11, target: g++-11 }
+          - { os: macos-11, target: g++-10 }
+          - { os: macos-11, target: g++-9 }
+          - { os: macos-11, target: g++-8 }
+          - { os: macos-11, target: g++-7 }
+          - { os: macos-11, target: g++-6 }
+          - { os: macos-11, target: g++-5 }
+          - { os: macos-11, target: msvc-2019 }
+          - { os: macos-11, target: msvc-2017 }
+          - { os: macos-11, target: msvc-2015 }
+          - { os: macos-11, target: msvc-2013 }
           # We don't test g++ on Windows as DMD only mangles for MSVC
           - { os: windows-2019, target: g++-11 }
           - { os: windows-2019, target: g++-10 }
@@ -157,13 +157,13 @@ jobs:
           # Platform boilerplate
           - { os: ubuntu-18.04, arch: x86_64-linux-gnu-ubuntu-18.04 }
           - { os: ubuntu-20.04, arch: x86_64-linux-gnu-ubuntu-20.04 }
-          - { os: macOS-10.15,  arch: x86_64-apple-darwin }
+          - { os: macos-11,  arch: x86_64-apple-darwin }
           # Clang 9.0.0 have a different arch for OSX
-          - { os: macOS-10.15, target: clang-9.0.0, arch: x86_64-darwin-apple }
+          - { os: macos-11, target: clang-9.0.0, arch: x86_64-darwin-apple }
           # Those targets will generate artifacts that can be used by other testers
           - { storeArtifacts: false }
           - { os: ubuntu-18.04, target: g++-9,       storeArtifacts: true }
-          - { os: macOS-10.15,  target: clang-9.0.0, storeArtifacts: true }
+          - { os: macos-11,  target: clang-9.0.0, storeArtifacts: true }
           #- { os: windows-2019, target: msvc-2019,   storeArtifacts: true }
 
     # We're using the latest available images at the time of this commit.
@@ -236,7 +236,7 @@ jobs:
         # On OSX, the system header are installed via `xcode-select` and not distributed with clang
         # Since some part of the testsuite rely on CC being only a binary (not a command),
         # and config files where only introduced from 6.0.0, use a wrapper script.
-        if [ "${{ matrix.os }}" == "macOS-10.15" ]; then
+        if [ "${{ matrix.os }}" == "macos-11" ]; then
           # Note: heredoc shouldn't be indented
           cat << 'EOF' > ${TMP_CC}-wrapper
         #!/bin/bash
@@ -258,7 +258,7 @@ jobs:
       if: matrix.compiler == 'clang' && runner.os != 'Windows'
       run: |
         TMP_CC='${{ github.workspace }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}/bin/clang'
-        if [ "${{ matrix.os }}" == "macOS-10.15" ]; then
+        if [ "${{ matrix.os }}" == "macos-11" ]; then
           echo "CC=${TMP_CC}-wrapper" >> $GITHUB_ENV
           echo "CXX=${TMP_CC}++-wrapper" >> $GITHUB_ENV
         else

--- a/ci/README.md
+++ b/ci/README.md
@@ -113,12 +113,12 @@ The auto tester tests DMD on various Posix platforms.
 **Config**: [azure-pipelines.yml](https://github.com/dlang/dmd/blob/master/.github/workflows/runnable_cxx.yml)
 
 **Checks**:
-- C++ interop tests / Run (macOS-10.15, clang-13.0.0)
-- C++ interop tests / Run (macOS-10.15, clang-12.0.0)
-- C++ interop tests / Run (macOS-10.15, clang-11.0.0)
-- C++ interop tests / Run (macOS-10.15, clang-10.0.0)
-- C++ interop tests / Run (macOS-10.15, clang-9.0.0)
-- C++ interop tests / Run (macOS-10.15, clang-8.0.0)
+- C++ interop tests / Run (macos-11, clang-13.0.0)
+- C++ interop tests / Run (macos-11, clang-12.0.0)
+- C++ interop tests / Run (macos-11, clang-11.0.0)
+- C++ interop tests / Run (macos-11, clang-10.0.0)
+- C++ interop tests / Run (macos-11, clang-9.0.0)
+- C++ interop tests / Run (macos-11, clang-8.0.0)
 - C++ interop tests / Run (ubuntu-18.04, clang-10.0.0)
 - C++ interop tests / Run (ubuntu-18.04, clang-9.0.0)
 - C++ interop tests / Run (ubuntu-18.04, clang-8.0.0)

--- a/druntime/.github/workflows/cxx.yml
+++ b/druntime/.github/workflows/cxx.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       # Matches the matrix in DMD to support the same platforms
       matrix:
-        os: [ macOS-10.15, ubuntu-18.04, windows-2019 ]
+        os: [ macos-11, ubuntu-18.04, windows-2019 ]
         target: [
           clang-9.0.0, clang-8.0.0,
           g++-9, g++-8, g++-7, g++-6, g++-5,
@@ -42,14 +42,14 @@ jobs:
           - { os: ubuntu-18.04, target: msvc-2017 }
           - { os: ubuntu-18.04, target: msvc-2015 }
           # OSX only supports clang
-          - { os: macOS-10.15, target: g++-9 }
-          - { os: macOS-10.15, target: g++-8 }
-          - { os: macOS-10.15, target: g++-7 }
-          - { os: macOS-10.15, target: g++-6 }
-          - { os: macOS-10.15, target: g++-5 }
-          - { os: macOS-10.15, target: msvc-2019 }
-          - { os: macOS-10.15, target: msvc-2017 }
-          - { os: macOS-10.15, target: msvc-2015 }
+          - { os: macos-11, target: g++-9 }
+          - { os: macos-11, target: g++-8 }
+          - { os: macos-11, target: g++-7 }
+          - { os: macos-11, target: g++-6 }
+          - { os: macos-11, target: g++-5 }
+          - { os: macos-11, target: msvc-2019 }
+          - { os: macos-11, target: msvc-2017 }
+          - { os: macos-11, target: msvc-2015 }
           # We don't test g++ on Windows as DMD only mangles for MSVC
           - { os: windows-2019, target: g++-9 }
           - { os: windows-2019, target: g++-8 }
@@ -80,9 +80,9 @@ jobs:
           - { target: g++-5, compiler: g++, cxx-version: 5.5.0 }
           # Platform boilerplate
           - { os: ubuntu-18.04, arch: x86_64-linux-gnu-ubuntu-18.04 }
-          - { os: macOS-10.15,  arch: x86_64-apple-darwin }
+          - { os: macos-11,  arch: x86_64-apple-darwin }
           # Clang 9.0.0 have a different arch for OSX
-          - { os: macOS-10.15, target: clang-9.0.0, arch: x86_64-darwin-apple }
+          - { os: macos-11, target: clang-9.0.0, arch: x86_64-darwin-apple }
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -146,7 +146,7 @@ jobs:
         # On OSX, the system header are installed via `xcode-select` and not distributed with clang
         # Since some part of the testsuite rely on CC being only a binary (not a command),
         # and config files where only introduced from 6.0.0, use a wrapper script.
-        if [ "${{ matrix.os }}" == "macOS-10.15" ]; then
+        if [ "${{ matrix.os }}" == "macos-11" ]; then
           # Note: heredoc shouldn't be indented
           cat <<EOF > ${TMP_CC}-wrapper
         #!/bin/bash


### PR DESCRIPTION
I'm aware of another PR doing this - this is just a vanilla switchover without manipulating library switches - Cirrus-ci darwin images work just fine without the extra changes.