### PR TITLE
Infer @system variables from initializer

### DIFF
--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -78,6 +78,7 @@ struct Scope
     Module _module;                 /// Root module
     ScopeDsymbol scopesym;          /// current symbol
     FuncDeclaration func;           /// function we are in
+    VarDeclaration varDecl;         /// variable we are in during semantic2
     Dsymbol parent;                 /// parent to use
     LabelStatement slabel;          /// enclosing labelled statement
     SwitchStatement sw;             /// enclosing switch statement

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7646,14 +7646,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // Check for unsafe casts
         if (!isSafeCast(ex, t1b, tob))
         {
-            // This is an ad-hoc fix for https://issues.dlang.org/show_bug.cgi?id=19646
-            // Should be replaced by a more general @system variables implementation
-            if (!sc.func && sc.stc & STC.safe)
-            {
-                exp.error("cast from `%s` to `%s` not allowed in safe code", exp.e1.type.toChars(), exp.to.toChars());
-                return setError();
-            }
-
             if (sc.setUnsafe(false, exp.loc, "cast from `%s` to `%s` not allowed in safe code", exp.e1.type, exp.to))
             {
                 return setError();

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -230,6 +230,8 @@ private extern(C++) final class Semantic2Visitor : Visitor
             return;
 
         //printf("VarDeclaration::semantic2('%s')\n", toChars());
+        sc.varDecl = vd;
+        scope(exit) sc.varDecl = null;
 
         if (vd.aliassym)        // if it's a tuple
         {

--- a/compiler/test/fail_compilation/test19646.d
+++ b/compiler/test/fail_compilation/test19646.d
@@ -1,11 +1,17 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/test19646.d(11): Error: cast from `const(int)*` to `int*` not allowed in safe code
+fail_compilation/test19646.d(17): Error: `@safe` variable `z` cannot be initialized by calling `@system` function `f`
 ---
 https://issues.dlang.org/show_bug.cgi?id=19646
  */
 
 @safe:
-
 const x = 42;
 int* y = cast(int*)&x;
+
+@system:
+
+@system int* f() { return cast(int*) 0xDEADBEEF; };
+
+@safe int* z = f();


### PR DESCRIPTION
Improve the bug fix for [Issue 19646](https://issues.dlang.org/show_bug.cgi?id=19646) - Initialization of globals not checked for `@safe`. 

Also helps the implementation of system variables.