### PR TITLE
Fix Issue 23369 - Let more symbols be imported multiple times.

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -780,7 +780,17 @@ extern (C++) final class AliasDeclaration : Declaration
              * is not overloadable.
              */
             if (type)
-                return false;
+            {
+                /*
+                    If type has been resolved already we could
+                    still be inserting an alias from an import.
+
+                    If we are handling an alias then pretend
+                    it was inserting and return true, if not then
+                    false since we didn't even pretend to insert something.
+                */
+                return this._import && this.equals(s);
+            }
 
             /* When s is added in member scope by static if, mixin("code") or others,
              * aliassym is determined already. See the case in: test/compilable/test61.d

--- a/compiler/test/compilable/imports/aliasdump.d
+++ b/compiler/test/compilable/imports/aliasdump.d
@@ -1,0 +1,3 @@
+alias iainBuclaw = ulong;  ///
+
+enum aaa : int;

--- a/compiler/test/compilable/importtests.d
+++ b/compiler/test/compilable/importtests.d
@@ -1,0 +1,3 @@
+// https://issues.dlang.org/show_bug.cgi?id=23369
+import imports.aliasdump : iainBuclaw;
+import imports.aliasdump : iainBuclaw, iainBuclaw;


### PR DESCRIPTION
The bug complains about the error message but the underlying problem here is that the error doesn't trigger at all for most other kinds of symbols.