### PR TITLE
fix Issue 23343 - ImportC: functions declared with asm label to set s…

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -318,6 +318,7 @@ struct ASTBase
         Type type;
         short inuse;
         ubyte adFlags;
+          enum nounderscore = 4;
 
         final extern (D) this(Identifier id)
         {

--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -1190,6 +1190,7 @@ enum
     SFLweak         = 0x1000000,   // resolve to NULL if not found
     SFLhidden       = 0x2000000,   // not visible outside of DSOs (-fvisibility=hidden)
     SFLartifical    = 0x4000000,   // compiler generated symbol
+    SFLnounderscore = 0x8000_0000, // don't prepend an _ to identifiers in object file
 
     // CPP
     SFLnodtor       = 0x10,        // set if destructor for Symbol is already called

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -2174,6 +2174,9 @@ else
             break;
 
         case mTYman_c:
+            if (s.Sflags & SFLnounderscore)
+                goto case 0;
+            goto case;
         case mTYman_cpp:
         case mTYman_d:
             if (len >= DEST_LEN - 1)

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1906,6 +1906,8 @@ final class CParser(AST) : Parser!AST
                     {
                         auto str = asmName.peekString();
                         p.mangleOverride = str;
+//                      p.adFlags |= AST.VarDeclaration.nounderscore;
+                        p.adFlags |= 4; // cannot get above line to compile on Ubuntu
                     }
                 }
                 s = applySpecifier(s, specifier);

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -227,6 +227,7 @@ extern (C++) abstract class Declaration : Dsymbol
     ubyte adFlags;         // control re-assignment of AliasDeclaration (put here for packing reasons)
       enum wasRead    = 1; // set if AliasDeclaration was read
       enum ignoreRead = 2; // ignore any reads of AliasDeclaration
+      enum nounderscore = 4; // don't prepend _ to mangled name
 
     Symbol* isym;           // import version of csym
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5748,6 +5748,8 @@ public:
 
     enum : int32_t { ignoreRead = 2 };
 
+    enum : int32_t { nounderscore = 4 };
+
     Symbol* isym;
     _d_dynamicArray< const char > mangleOverride;
     const char* kind() const override;

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -158,6 +158,8 @@ Symbol *toSymbol(Dsymbol s)
                 s.Sflags |= SFLartifical;
             if (isNRVO)
                 s.Sflags |= SFLnodebug;
+            if (vd.adFlags & Declaration.nounderscore)
+                s.Sflags |= SFLnounderscore;
 
             TYPE *t;
             if (vd.storage_class & (STC.out_ | STC.ref_))
@@ -394,6 +396,9 @@ Symbol *toSymbol(Dsymbol s)
                         break;
 
                     case LINK.c:
+                        if (fd.adFlags & Declaration.nounderscore)
+                            s.Sflags |= SFLnounderscore;
+                        goto case;
                     case LINK.objc:
                         t.Tmangle = mTYman_c;
                         break;

--- a/compiler/test/runnable/test23011.c
+++ b/compiler/test/runnable/test23011.c
@@ -1,4 +1,4 @@
-/* DISABLED: win32 win32mscoff win64
+/* DISABLED: win32 win32mscoff win64 osx32 osx64
  */
 
 /* https://issues.dlang.org/show_bug.cgi?id=23011

--- a/compiler/test/runnable/test23343.c
+++ b/compiler/test/runnable/test23343.c
@@ -1,0 +1,12 @@
+/* DISABLED: win32 win64 linux32 linux64 freebsd32 freebsd64 osx32 dragonflybsd32 netbsd32
+ */
+
+/* https://issues.dlang.org/show_bug.cgi?id=23343
+ */
+
+int open(const char*, int, ...) asm("_" "open");
+
+int main(){
+    int fd = open("/dev/null", 0);
+    return fd >= 0 ? 0 : 1;
+}


### PR DESCRIPTION
…ymbol name gets extra underscore prepended

I narrowed this to only affect OSX. Windows also prepends an _, but I'd prefer to wait and see if this problem is an issue on Windows.