### PR TITLE
fix Issue 23343 - ImportC: functions declared with asm label to set s…

### DIFF
--- a/compiler/src/dmd/backend/cgobj.d
+++ b/compiler/src/dmd/backend/cgobj.d
@@ -2449,7 +2449,15 @@ size_t OmfObj_mangle(Symbol *s,char *dest)
 version (SCPP)
     name = CPP ? cpp_mangle(s) : &s.Sident[0];
 else version (MARS)
+{
     name = &s.Sident[0];
+    if (*name == '*')   // if name overrides any mangling
+    {
+        ++name;         // skip over '*'
+        len = strlen(name);
+        goto Lcase0;
+    }
+}
 else
     static assert(0);
 
@@ -2563,9 +2571,11 @@ else
             goto case;
 
         case mTYman_sys:
+        Lcase0:
             memcpy(dest + 1, name, len);        // no mangling
             dest[1 + len] = 0;
             break;
+
         default:
             symbol_print(s);
             assert(0);

--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -2158,15 +2158,22 @@ char *obj_mangle2(Symbol *s,char *dest, size_t *destlen)
     symbol_debug(s);
     assert(dest);
 
+    size_t len;
 version (SCPP)
     name = CPP ? cpp_mangle2(s) : s.Sident.ptr;
 else version (MARS)
     // C++ name mangling is handled by front end
     name = s.Sident.ptr;
+    if (*name == '*')   // if name overrides any mangling
+    {
+        ++name;         // skip over '*'
+        len = strlen(name);
+        goto Lcase0;
+    }
 else
     name = s.Sident.ptr;
 
-    size_t len = strlen(name);                 // # of bytes in name
+    len = strlen(name);                 // # of bytes in name
     //dbg_printf("len %d\n",len);
     switch (type_mangle(s.Stype))
     {
@@ -2208,6 +2215,7 @@ else
         case mTYman_d:
         case mTYman_sys:
         case 0:
+        Lcase0:
             if (len >= DEST_LEN)
                 dest = cast(char *)mem_malloc(len + 1);
             memcpy(dest,name,len+1);// copy in name and trailing 0

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -2124,6 +2124,12 @@ else version (MARS)
 {
     // C++ name mangling is handled by front end
     name = &s.Sident[0];
+    if (*name == '*')   // if name overrides any mangling
+    {
+        ++name;         // skip over '*'
+        len = strlen(name);
+        goto Lcase0;
+    }
 }
 else
 {
@@ -2161,6 +2167,7 @@ else
         }
         case mTYman_sys:
         case 0:
+        Lcase0:
             if (len >= DEST_LEN)
                 dest = cast(char *)mem_malloc(len + 1);
             memcpy(dest,name,len+1);// copy in name and trailing 0

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -1734,6 +1734,12 @@ version (SCPP)
 else version (MARS)
     // C++ name mangling is handled by front end
     name = &s.Sident[0];
+    if (*name == '*')   // if name overrides any mangling
+    {
+        ++name;         // skip over '*'
+        len = strlen(name);
+        goto Lcase0;
+    }
 else
     name = &s.Sident[0];
 
@@ -1772,6 +1778,7 @@ else
         case mTYman_sys:
         case_mTYman_c64:
         case 0:
+        Lcase0:
             if (len >= DEST_LEN)
                 dest = cast(char *)mem_malloc(len + 1);
             memcpy(dest,name,len+1);// copy in name and trailing 0

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1914,7 +1914,7 @@ final class CParser(AST) : Parser!AST
                     if (auto p = s.isDeclaration())
                     {
                         auto str = asmName.peekString();
-                        p.mangleOverride = str;
+                        p.mangleOverride = '*' ~ str;
                     }
                 }
                 symbols.push(s);

--- a/compiler/src/dmd/dmangle.d
+++ b/compiler/src/dmd/dmangle.d
@@ -692,7 +692,7 @@ public:
     override void visit(Declaration d)
     {
         //printf("Declaration.mangle(this = %p, '%s', parent = '%s', linkage = %d)\n",
-        //        d, d.toChars(), d.parent ? d.parent.toChars() : "null", d.linkage);
+        //        d, d.toChars(), d.parent ? d.parent.toChars() : "null", d._linkage);
         if (const id = externallyMangledIdentifier(d))
         {
             buf.writestring(id);
@@ -794,9 +794,11 @@ public:
     void mangleExact(FuncDeclaration fd)
     {
         assert(!fd.isFuncAliasDeclaration());
-        if (fd.mangleOverride)
+        if (auto str = fd.mangleOverride)
         {
-            buf.writestring(fd.mangleOverride);
+            auto s = (str.length > 1 && str[0] == '*')
+                ? str[1 .. $] : str;
+            buf.writestring(s);
             return;
         }
         if (fd.isMain())
@@ -814,9 +816,11 @@ public:
 
     override void visit(VarDeclaration vd)
     {
-        if (vd.mangleOverride)
+        if (auto str = vd.mangleOverride)
         {
-            buf.writestring(vd.mangleOverride);
+            auto s = (str.length > 1 && str[0] == '*')
+                ? str[1 .. $] : str;
+            buf.writestring(s);
             return;
         }
         visit(cast(Declaration)vd);

--- a/compiler/test/runnable/test23011.c
+++ b/compiler/test/runnable/test23011.c
@@ -1,4 +1,4 @@
-/* DISABLED: win32 win32mscoff win64
+/* DISABLED: linux32 linux64 freebsd32 freebsd64
  */
 
 /* https://issues.dlang.org/show_bug.cgi?id=23011

--- a/compiler/test/runnable/test23343.c
+++ b/compiler/test/runnable/test23343.c
@@ -1,0 +1,12 @@
+/* DISABLED: win32 win64 linux32 linux64 freebsd32 freebsd64 osx32 dragonflybsd32 netbsd32
+ */
+
+/* https://issues.dlang.org/show_bug.cgi?id=23343
+ */
+
+int open(const char*, int, ...) asm("_" "open");
+
+int main(){
+    int fd = open("/dev/null", 0);
+    return fd >= 0 ? 0 : 1;
+}


### PR DESCRIPTION
…ymbol name gets extra underscore prepended

Rebooted due to @ibuclaw 's suggestion in https://github.com/dlang/dmd/pull/14485