### PR TITLE
Remove redundant doNotInferScope in escape.d

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -417,16 +417,6 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, Var
                 unsafeAssign!"variadic variable"(v);
             }
         }
-        else
-        {
-            /* v is not 'scope', and is assigned to a parameter that may escape.
-             * Therefore, v can never be 'scope'.
-             */
-            if (log) printf("no infer for %s in %s loc %s, fdc %s, %d\n",
-                v.toChars(), sc.func.ident.toChars(), sc.func.loc.toChars(), fdc.ident.toChars(),  __LINE__);
-
-            doNotInferScope(v, vPar);
-        }
     }
 
     foreach (VarDeclaration v; er.byref)


### PR DESCRIPTION
There's a `notMaybeScope(v, vPar);` above it.