### PR TITLE
Fix 20674, 23208, 23300 - improve `scope` inference

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -485,12 +485,12 @@ extern (C++) abstract class Declaration : Dsymbol
         return (storage_class & STC.auto_) != 0;
     }
 
-    final bool isScope() const pure nothrow @nogc @safe
+    bool isScope()
     {
         return (storage_class & STC.scope_) != 0;
     }
 
-    final bool isReturn() const pure nothrow @nogc @safe
+    bool isReturn()
     {
         return (storage_class & STC.return_) != 0;
     }
@@ -1117,7 +1117,7 @@ extern (C++) class VarDeclaration : Declaration
     VarDeclaration lastVar;         // Linked list of variables for goto-skips-init detection
     Expression edtor;               // if !=null, does the destruction of the variable
     IntRange* range;                // if !=null, the variable is known to be within the range
-    VarDeclarations* maybes;        // maybeScope variables that are assigned to this maybeScope variable
+    VarDeclaration lifetimeParent; // the declaration with represents the lifetime of this variable, null = its own root
 
     uint endlinnum;                 // line number of end of scope that this var lives in
     uint offset;
@@ -1434,6 +1434,18 @@ extern (C++) class VarDeclaration : Declaration
 
         return   bitoffset < vbitoffset + vbitsize &&
                 vbitoffset <  bitoffset + tbitsize;
+    }
+
+    override final bool isScope()
+    {
+        import dmd.escape : findLifetimeRoot;
+        return !!(this.findLifetimeRoot().storage_class & STC.scope_);
+    }
+
+    override final bool isReturn()
+    {
+        import dmd.escape : findLifetimeRoot;
+        return (this.findLifetimeRoot().storage_class & STC.return_) != 0;
     }
 
     override final bool hasPointers()

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -233,7 +233,7 @@ public:
     VarDeclaration *lastVar;    // Linked list of variables for goto-skips-init detection
     Expression *edtor;          // if !=NULL, does the destruction of the variable
     IntRange *range;            // if !NULL, the variable is known to be within the range
-    VarDeclarations *maybes;    // STCmaybescope variables that are assigned to this STCmaybescope variable
+    VarDeclaration* lifetimeParent;
 
     unsigned endlinnum;         // line number of end of scope that this var lives in
     unsigned offset;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6030,7 +6030,7 @@ public:
     VarDeclaration* lastVar;
     Expression* edtor;
     IntRange* range;
-    Array<VarDeclaration* >* maybes;
+    VarDeclaration* lifetimeParent;
     uint32_t endlinnum;
     uint32_t offset;
     uint32_t sequenceNumber;

--- a/compiler/test/compilable/test20674.d
+++ b/compiler/test/compilable/test20674.d
@@ -1,0 +1,18 @@
+// REQUIRED_ARGS: -preview=dip1000
+// Issue 20674 - [DIP1000] inference of `scope` is easily confused
+// https://issues.dlang.org/show_bug.cgi?id=20674
+
+int* f()(int* p)
+{
+    static int g;
+    g = 0; // do not infer pure
+
+    auto p2 = p;
+    return new int;
+}
+
+int* g() @safe
+{
+    int x;
+    return f(&x);
+}

--- a/compiler/test/fail_compilation/retscope.d
+++ b/compiler/test/fail_compilation/retscope.d
@@ -201,14 +201,14 @@ void* escapeDg1(scope void* d) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(212): Error: scope variable `p` assigned to non-scope `e.e`
+fail_compilation/retscope.d(213): Error: scope variable `dg` may not be returned
 ---
 */
 struct Escaper3 { void* e; }
 
 void* escape3 (scope void* p) @safe {
     Escaper3 e;
-    scope dg = () { return e.e; };
+    scope dg = () return scope { return e.e; }; // Remove return scope when https://issues.dlang.org/show_bug.cgi?id=22977 is fixed
     e.e = p;
     return dg();
 }

--- a/compiler/test/fail_compilation/retscope6.d
+++ b/compiler/test/fail_compilation/retscope6.d
@@ -78,8 +78,9 @@ void foo() @safe
 fail_compilation/retscope6.d(8016): Error: address of variable `i` assigned to `p` with longer lifetime
 fail_compilation/retscope6.d(8031): Error: reference to local variable `i` assigned to non-scope parameter `p` calling `betty`
 fail_compilation/retscope6.d(8031): Error: reference to local variable `j` assigned to non-scope parameter `q` calling `betty`
-fail_compilation/retscope6.d(8021):        which is assigned to non-scope parameter `p`
+fail_compilation/retscope6.d(8023):        which is not `scope` because of `p = q`
 fail_compilation/retscope6.d(8048): Error: reference to local variable `j` assigned to non-scope parameter `q` calling `archie`
+fail_compilation/retscope6.d(8038):        which is not `scope` because of `p = q`
 ---
 */
 
@@ -109,8 +110,8 @@ void testfrankly()
 
 void betty()(int* p, int* q)
 {
-     p = q;
-     escape(p);
+    p = q;
+    escape(p);
 }
 
 void testbetty()
@@ -124,9 +125,9 @@ void testbetty()
 
 void archie()(int* p, int* q, int* r)
 {
-     p = q;
-     r = p;
-     escape(q);
+    p = q;
+    r = p;
+    escape(q);
 }
 
 void testarchie()

--- a/compiler/test/fail_compilation/retscope7.d
+++ b/compiler/test/fail_compilation/retscope7.d
@@ -1,0 +1,23 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/retscope7.d(22): Error: scope variable `y` may not be returned
+---
+*/
+
+@safe:
+int* f()
+{
+	int local;
+
+	int* x;
+	int* y;
+
+	foreach(i; 0..2)
+	{
+		y = x;
+		x = &local;
+	}
+	return y;
+}

--- a/compiler/test/fail_compilation/test23208.d
+++ b/compiler/test/fail_compilation/test23208.d
@@ -1,0 +1,33 @@
+/*
+REQUIRED_ARGS:-preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test23208.d(31): Error: returning `rsfailA(& i, null)` escapes a reference to local variable `i`
+fail_compilation/test23208.d(32): Error: returning `rsfailB(& i, null)` escapes a reference to local variable `i`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=23208
+// Issue 23208 - [dip1000] missing return scope inference after parameter assignment
+
+@safe:
+
+int* rsfailA()(scope int* pA, int* rA)
+{
+    rA = pA;
+    return rA; // should infer return scope on p
+}
+
+int* rsfailB()(int* pB, int* rB)
+{
+    rB = pB;
+    return rB; // should infer return scope on p
+}
+
+
+int* escape()
+{
+    int i;
+    return rsfailA(&i, null); // error
+    return rsfailB(&i, null); // error
+}

--- a/compiler/test/fail_compilation/test23294.d
+++ b/compiler/test/fail_compilation/test23294.d
@@ -1,0 +1,25 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+
+TEST_OUTPUT:
+---
+fail_compilation/test23294.d(24): Error: scope variable `z` assigned to non-scope parameter `y` calling `f`
+fail_compilation/test23294.d(18):        which is not `scope` because of `x = y`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=23294
+// Issue 23294 - [dip1000] parameter to parameter assignment leads to incorrect scope inference
+
+@safe:
+
+auto f(int* x, int* y)
+{
+    x = y;
+    static int global; global++; // make sure it's not inferring scope from pure
+}
+
+void g(scope int* z)
+{
+    f(z, z); // passes
+}


### PR DESCRIPTION
Remove the complex and broken `eliminateMaybeScopes` system for parameters, and use a simpler scheme for both parameters and local variables. When you assign `va = v`, then add a link from `va` to `v` and when `va` becomes `return scope` or `notMaybeScope`, then do the same for `v`.

It's not complete yet, I still need to go the other way and test more thoroughly, but I'm already opening a PR to get feedback from the test suite, and so that I can link to this central PR when making smaller PRs.