### PR TITLE
Improve error when assigning scope variable to AA

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9890,14 +9890,17 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         exp.type = exp.e1.type;
         assert(exp.type);
+        auto assignElem = exp.e2;
         auto res = exp.op == EXP.assign ? exp.reorderSettingAAElem(sc) : exp;
-        Expression tmp;
         /* https://issues.dlang.org/show_bug.cgi?id=22366
          *
          * `reorderSettingAAElem` creates a tree of comma expressions, however,
          * `checkAssignExp` expects only AssignExps.
          */
-        checkAssignEscape(sc, Expression.extractLast(res, tmp), false, false);
+        if (res == exp) // no `AA[k] = v` rewrite was performed
+            checkAssignEscape(sc, res, false, false);
+        else
+            checkNewEscape(sc, assignElem, false); // assigning to AA puts it on heap
 
         if (auto ae = res.isConstructExp())
         {

--- a/compiler/test/fail_compilation/fail22366.d
+++ b/compiler/test/fail_compilation/fail22366.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22366.d(13): Error: scope variable `__aaval2` assigned to non-scope `aa[0]`
+fail_compilation/fail22366.d(13): Error: scope variable `x` may not be copied into allocated memory
 ---
 */
 


### PR DESCRIPTION
Extracted from https://github.com/dlang/dmd/pull/14492

I stumbled on this because the assignment error wasn't happening anymore. The original error "`__aaval2` assigned to non-scope `aa[0]`" relies on the fact that `aa[0]` may not be inferred `scope`, but that's not really the problem. The problem is that `aa[0]` dereferences a pointer so `scope` doesn't apply to the element anymore.