### PR TITLE
redo #pragma pack(pop)

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5178,18 +5178,26 @@ final class CParser(AST) : Parser!AST
                     packalign = (*this.packs)[len - 1];
                 return closingParen();
             }
-            while (n.value == TOK.comma)
+            while (n.value == TOK.comma)        // #pragma pack ( pop ,
             {
                 scan(&n);
                 if (n.value == TOK.identifier)
                 {
+                    /* pragma pack(pop, identifier
+                     * Pop until identifier is found, pop that one too, and set
+                     * alignment to the new top of the stack.
+                     * If identifier is not found, do nothing.
+                     */
                     for ( ; len; --len)
                     {
                         if ((*this.records)[len - 1] == n.ident)
                         {
-                            packalign = (*this.packs)[len - 1];
                             this.records.setDim(len - 1);
                             this.packs.setDim(len - 1);
+                            if (len > 1)
+                                packalign = (*this.packs)[len - 2];
+                            else
+                                packalign.setDefault(); // stack empty, use default
                             break;
                         }
                     }
@@ -5198,14 +5206,18 @@ final class CParser(AST) : Parser!AST
                 else if (n.value == TOK.int32Literal)
                 {
                     setPackAlign(n);
-                    this.records.push(null);
-                    this.packs.push(packalign);
+                    scan(&n);
+                }
+                else
+                {
+                    error(loc, "identifier or alignment value expected following `#pragma pack(pop,` not `%s`", n.toChars());
                     scan(&n);
                 }
             }
             return closingParen();
         }
         /* # pragma pack ( integer )
+         * Sets alignment to integer
          */
         if (n.value == TOK.int32Literal)
         {
@@ -5214,6 +5226,7 @@ final class CParser(AST) : Parser!AST
             return closingParen();
         }
         /* # pragma pack ( )
+         * Sets alignment to default
          */
         if (n.value == TOK.rightParenthesis)
         {

--- a/compiler/test/compilable/pragmapack.c
+++ b/compiler/test/compilable/pragmapack.c
@@ -1,6 +1,36 @@
+/* REQUIRED_ARGS: -wi
+TEST_OUTPUT:
+---
+compilable/pragmapack.c(101): Warning: current pack attribute is default
+compilable/pragmapack.c(104): Warning: current pack attribute is 2
+compilable/pragmapack.c(112): Warning: current pack attribute is default
+compilable/pragmapack.c(117): Warning: current pack attribute is 8
+compilable/pragmapack.c(123): Warning: current pack attribute is default
+compilable/pragmapack.c(128): Warning: current pack attribute is 8
+compilable/pragmapack.c(135): Warning: current pack attribute is default
+compilable/pragmapack.c(140): Warning: current pack attribute is default
+compilable/pragmapack.c(143): Warning: current pack attribute is 2
+compilable/pragmapack.c(145): Warning: current pack attribute is 2
+compilable/pragmapack.c(147): Warning: current pack attribute is 2
+compilable/pragmapack.c(149): Warning: current pack attribute is 2
+compilable/pragmapack.c(151): Warning: current pack attribute is 2
+compilable/pragmapack.c(153): Warning: current pack attribute is 2
+compilable/pragmapack.c(155): Warning: current pack attribute is 2
+compilable/pragmapack.c(157): Warning: current pack attribute is 8
+compilable/pragmapack.c(159): Warning: current pack attribute is 2
+compilable/pragmapack.c(161): Warning: current pack attribute is 2
+compilable/pragmapack.c(163): Warning: current pack attribute is default
+---
+*/
+
 // Test #pragma pack
 
+#line 100
+
+#pragma pack(show)
+
 #pragma pack(2)
+#pragma pack(show)
 struct S
 {
     int i;
@@ -8,25 +38,30 @@ struct S
     double k;
 };
 #pragma pack()
+#pragma pack(show)
 
 _Static_assert(sizeof(struct S) == 4 + 2 + 8, "1");
 
 #pragma pack(push, 8)
+#pragma pack(show)
 struct S2
 {
     char a, b;
 };
 #pragma pack(pop)
+#pragma pack(show)
 
 _Static_assert(sizeof(struct S2) == 1 + 1, "2");
 
 #pragma pack(push, 8)
+#pragma pack(show)
 struct S3
 {
     unsigned short u;
     char a;
 };
 #pragma pack(pop)
+#pragma pack(show)
 
 _Static_assert(sizeof(struct S3) == 4, "3");
 
@@ -34,12 +69,26 @@ _Static_assert(sizeof(struct S3) == 4, "3");
 #pragma pack(show)
 #pragma pack(2)
 #pragma pack(push)
+#pragma pack(show)
 #pragma pack(push,2)
+#pragma pack(show)
 #pragma pack(push,abc)
+#pragma pack(show)
 #pragma pack(push,abc,2)
+#pragma pack(show)
 #pragma pack(pop)
+#pragma pack(show)
 #pragma pack(pop,a)
+#pragma pack(show)
 #pragma pack(pop,2)
+#pragma pack(show)
 #pragma pack(pop,a,b,4,8,c)
+#pragma pack(show)
+#pragma pack(pop);
+#pragma pack(show)
+#pragma pack(pop);
+#pragma pack(show)
+#pragma pack(pop);
+#pragma pack(show)
 
 int x;

--- a/compiler/test/fail_compilation/pragma2.c
+++ b/compiler/test/fail_compilation/pragma2.c
@@ -1,17 +1,21 @@
 /* REQUIRED_ARGS: -w
 TEST_OUTPUT:
 ---
-fail_compilation/pragma2.c(11): Warning: current pack attribute is default
-fail_compilation/pragma2.c(12): Error: left parenthesis expected to follow `#pragma pack`
-fail_compilation/pragma2.c(13): Error: right parenthesis expected to close `#pragma pack(`
-fail_compilation/pragma2.c(14): Error: unrecognized `#pragma pack(&)`
+fail_compilation/pragma2.c(101): Warning: current pack attribute is default
+fail_compilation/pragma2.c(102): Error: left parenthesis expected to follow `#pragma pack`
+fail_compilation/pragma2.c(103): Error: right parenthesis expected to close `#pragma pack(`
+fail_compilation/pragma2.c(104): Error: unrecognized `#pragma pack(&)`
+fail_compilation/pragma2.c(106): Error: identifier or alignment value expected following `#pragma pack(pop,` not `"foo"`
 ---
 */
+
+#line 100
 
 #pragma pack(show)
 #pragma pack
 #pragma pack(pop,a,b,4,8,c
 #pragma pack(&)
 #pragma pack() ;a
+#pragma pack (pop, "foo");
 
 int x;


### PR DESCRIPTION
Comparing the implementation with the Microsoft documentation on `#pragma pack(pop)` showed some errors. Added a more rigor to the test case.