### PR TITLE
rename mangleOverride to pMangleOverride

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -109,7 +109,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     CPPMANGLE cppmangle;
 
     /// overridden symbol with pragma(mangle, "...") if not null
-    MangleOverride* mangleOverride;
+    MangleOverride* pMangleOverride;
 
     /**
      * !=null if is nested

--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -82,7 +82,7 @@ public:
     CPPMANGLE cppmangle;
 
     // overridden symbol with pragma(mangle, "...")
-    MangleOverride *mangleOverride;
+    MangleOverride *pMangleOverride;
     /* !=NULL if is nested
      * pointing to the dsymbol that directly enclosing it.
      * 1. The function that enclosing it (nested struct and class)

--- a/compiler/src/dmd/cppmangle.d
+++ b/compiler/src/dmd/cppmangle.d
@@ -615,7 +615,7 @@ private final class CppMangleVisitor : Visitor
         if (!ti)
         {
             auto ag = s.isAggregateDeclaration();
-            const ident = (ag && ag.mangleOverride) ? ag.mangleOverride.id : s.ident;
+            const ident = (ag && ag.pMangleOverride) ? ag.pMangleOverride.id : s.ident;
             this.writeNamespace(s.cppnamespace, () {
                 this.writeIdentifier(ident);
                 this.abiTags.writeSymbol(s, this);
@@ -654,14 +654,14 @@ private final class CppMangleVisitor : Visitor
         }
 
         auto ag = ti.aliasdecl ? ti.aliasdecl.isAggregateDeclaration() : null;
-        if (ag && ag.mangleOverride)
+        if (ag && ag.pMangleOverride)
         {
             this.writeNamespace(
                 ti.toAlias().cppnamespace, () {
-                    this.writeIdentifier(ag.mangleOverride.id);
-                    if (ag.mangleOverride.agg && ag.mangleOverride.agg.isInstantiated())
+                    this.writeIdentifier(ag.pMangleOverride.id);
+                    if (ag.pMangleOverride.agg && ag.pMangleOverride.agg.isInstantiated())
                     {
-                        auto to = ag.mangleOverride.agg.isInstantiated();
+                        auto to = ag.pMangleOverride.agg.isInstantiated();
                         append(to);
                         this.abiTags.writeSymbol(to.tempdecl, this);
                         template_args(to);

--- a/compiler/src/dmd/cppmanglewin.d
+++ b/compiler/src/dmd/cppmanglewin.d
@@ -911,9 +911,9 @@ extern(D):
         {
             if (auto ag = sym.isAggregateDeclaration())
             {
-                if (ag.mangleOverride)
+                if (ag.pMangleOverride)
                 {
-                    writeName(ag.mangleOverride.id);
+                    writeName(ag.pMangleOverride.id);
                     return;
                 }
             }
@@ -932,27 +932,27 @@ extern(D):
         bool needNamespaces;
         if (auto ag = ti.aliasdecl ? ti.aliasdecl.isAggregateDeclaration() : null)
         {
-            if (ag.mangleOverride)
+            if (ag.pMangleOverride)
             {
-                if (ag.mangleOverride.agg)
+                if (ag.pMangleOverride.agg)
                 {
-                    if (auto aggti = ag.mangleOverride.agg.isInstantiated())
+                    if (auto aggti = ag.pMangleOverride.agg.isInstantiated())
                         actualti = aggti;
                     else
                     {
-                        writeName(ag.mangleOverride.id);
+                        writeName(ag.pMangleOverride.id);
                         if (sym.parent && !sym.parent.needThis())
-                            for (auto ns = ag.mangleOverride.agg.toAlias().cppnamespace; ns !is null && ns.ident !is null; ns = ns.cppnamespace)
+                            for (auto ns = ag.pMangleOverride.agg.toAlias().cppnamespace; ns !is null && ns.ident !is null; ns = ns.cppnamespace)
                                 writeName(ns.ident);
                         return;
                     }
-                    id = ag.mangleOverride.id;
+                    id = ag.pMangleOverride.id;
                     symName = id.toString();
                     needNamespaces = true;
                 }
                 else
                 {
-                    writeName(ag.mangleOverride.id);
+                    writeName(ag.pMangleOverride.id);
                     for (auto ns = ti.toAlias().cppnamespace; ns !is null && ns.ident !is null; ns = ns.cppnamespace)
                         writeName(ns.ident);
                     return;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1574,13 +1574,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         agg = tc.sym;
                     else if (auto ts = e.type.isTypeStruct())
                         agg = ts.sym;
-                    ad.mangleOverride = new MangleOverride;
+                    ad.pMangleOverride = new MangleOverride;
                     void setString(ref Expression e)
                     {
                         if (auto se = verifyMangleString(e))
                         {
                             const name = (cast(const(char)[])se.peekData()).xarraydup;
-                            ad.mangleOverride.id = Identifier.idPool(name);
+                            ad.pMangleOverride.id = Identifier.idPool(name);
                             e = se;
                         }
                         else
@@ -1588,13 +1588,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     }
                     if (agg)
                     {
-                        ad.mangleOverride.agg = agg;
+                        ad.pMangleOverride.agg = agg;
                         if (pd.args.dim == 2)
                         {
                             setString((*pd.args)[1]);
                         }
                         else
-                            ad.mangleOverride.id = agg.ident;
+                            ad.pMangleOverride.id = agg.ident;
                     }
                     else
                         setString((*pd.args)[0]);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5237,7 +5237,7 @@ public:
     Dsymbol* deferred;
     ClassKind classKind;
     CPPMANGLE cppmangle;
-    MangleOverride* mangleOverride;
+    MangleOverride* pMangleOverride;
     Dsymbol* enclosing;
     VarDeclaration* vthis;
     VarDeclaration* vthis2;


### PR DESCRIPTION
Renamed it because of confusion with a string field also named `mangleOverride`.