### PR TITLE
Fix 22784 - pragma(printf) applies to nested functions

### DIFF
--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -894,18 +894,6 @@ extern (C++) final class PragmaDeclaration : AttribDeclaration
             // then it's evaluated on demand in function semantic
             return createNewScope(sc, sc.stc, sc.linkage, sc.cppmangle, sc.visibility, sc.explicitVisibility, sc.aligndecl, this);
         }
-        if (ident == Id.printf || ident == Id.scanf)
-        {
-            auto sc2 = sc.push();
-
-            if (ident == Id.printf)
-                // Override previous setting, never let both be set
-                sc2.flags = (sc2.flags & ~SCOPE.scanf) | SCOPE.printf;
-            else
-                sc2.flags = (sc2.flags & ~SCOPE.printf) | SCOPE.scanf;
-
-            return sc2;
-        }
         return sc;
     }
 

--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -63,17 +63,13 @@ enum SCOPE
     free          = 0x8000,   /// is on free list
 
     fullinst      = 0x10000,  /// fully instantiate templates
-
-    // The following are mutually exclusive
-    printf        = 0x4_0000, /// printf-style function
-    scanf         = 0x8_0000, /// scanf-style function
 }
 
 /// Flags that are carried along with a scope push()
 private enum PersistentFlags =
     SCOPE.contract | SCOPE.debug_ | SCOPE.ctfe | SCOPE.compile | SCOPE.constraint |
     SCOPE.noaccesscheck | SCOPE.ignoresymbolvisibility |
-    SCOPE.printf | SCOPE.scanf | SCOPE.Cfile;
+    SCOPE.Cfile;
 
 struct Scope
 {

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -98,6 +98,29 @@ private uint setMangleOverride(Dsymbol s, const(char)[] sym)
     return 0;
 }
 
+/**
+ * Apply pragma printf/scanf to FuncDeclarations under `s`,
+ * poking through attribute declarations such as `extern(C)`
+ * but not through aggregates or function bodies.
+ *
+ * Params:
+ *    s = symbol to apply
+ *    printf = `true` for printf, `false` for scanf
+ */
+private void setPragmaPrintf(Dsymbol s, bool printf)
+{
+    if (auto fd = s.isFuncDeclaration())
+    {
+        fd.flags &= ~(FUNCFLAG.printf | FUNCFLAG.scanf);
+        fd.flags |= printf ? FUNCFLAG.printf : FUNCFLAG.scanf;
+    }
+
+    if (auto ad = s.isAttribDeclaration())
+    {
+        ad.include(null).foreachDsymbol( (s) { setPragmaPrintf(s, printf); } );
+    }
+}
+
 /*************************************
  * Does semantic analysis on the public face of declarations.
  */
@@ -1558,6 +1581,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             foreach (s; (*pd.decl)[])
             {
+                if (pd.ident == Id.printf || pd.ident == Id.scanf)
+                {
+                    s.setPragmaPrintf(pd.ident == Id.printf);
+                    continue;
+                }
+
                 s.dsymbolSemantic(sc2);
                 if (pd.ident != Id.mangle)
                     continue;
@@ -3323,7 +3352,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        if (const pors = sc.flags & (SCOPE.printf | SCOPE.scanf))
+        if (funcdecl.flags & (FUNCFLAG.printf | FUNCFLAG.scanf))
         {
             /* printf/scanf-like functions must be of the form:
              *    extern (C/C++) T printf([parameters...], const(char)* format, ...);
@@ -3359,11 +3388,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 )
                )
             {
-                funcdecl.flags |= (pors == SCOPE.printf) ? FUNCFLAG.printf : FUNCFLAG.scanf;
+                // the signature is valid for printf/scanf, no error
             }
             else
             {
-                const p = (pors == SCOPE.printf ? Id.printf : Id.scanf).toChars();
+                const p = ((funcdecl.flags & FUNCFLAG.printf) ? Id.printf : Id.scanf).toChars();
                 if (f.parameterList.varargs == VarArg.variadic)
                 {
                     funcdecl.error("`pragma(%s)` functions must be `extern(C) %s %s([parameters...], const(char)*, ...)`"

--- a/compiler/test/compilable/test22784.d
+++ b/compiler/test/compilable/test22784.d
@@ -1,0 +1,10 @@
+// Issue 22784 - pragma(printf) applies to nested functions
+// https://issues.dlang.org/show_bug.cgi?id=22784
+
+import core.stdc.stdarg;
+extern(C)
+pragma(printf)
+void fn(const(char)* fmt, ...)
+{
+    void inner(){}
+}


### PR DESCRIPTION
Instead of enabling a `SCOPE` flag, apply it directly to declarations under it, similar to `pragma(mangle)`.