### PR TITLE
dmd.dmodule: Expose FileManager.lookForSourceFile to C++

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -308,7 +308,7 @@ extern (C++) class Package : ScopeDsymbol
             packages ~= s.ident;
         reverse(packages);
 
-        if (FileManager.lookForSourceFile(getFilename(packages, ident), global.path ? (*global.path)[] : null))
+        if (Module.find(getFilename(packages, ident)))
             Module.load(Loc.initial, packages, this.ident);
         else
             isPkgMod = PKG.package_;
@@ -492,6 +492,16 @@ extern (C++) final class Module : Package
         return new Module(Loc.initial, filename, ident, doDocComment, doHdrGen);
     }
 
+    static const(char)* find(const(char)* filename)
+    {
+        return find(filename.toDString).ptr;
+    }
+
+    extern (D) static const(char)[] find(const(char)[] filename)
+    {
+        return FileManager.lookForSourceFile(filename, global.path ? (*global.path)[] : null);
+    }
+
     extern (C++) static Module load(const ref Loc loc, Identifiers* packages, Identifier ident)
     {
         return load(loc, packages ? (*packages)[] : null, ident);
@@ -506,7 +516,7 @@ extern (C++) final class Module : Package
         //  foo\bar\baz
         const(char)[] filename = getFilename(packages, ident);
         // Look for the source file
-        if (const result = FileManager.lookForSourceFile(filename, global.path ? (*global.path)[] : null))
+        if (const result = find(filename))
             filename = result; // leaks
 
         auto m = new Module(loc, filename, ident, 0, 0);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6221,6 +6221,7 @@ public:
     size_t nameoffset;
     size_t namelen;
     static Module* create(const char* filename, Identifier* ident, int32_t doDocComment, int32_t doHdrGen);
+    static const char* find(const char* filename);
     static Module* load(const Loc& loc, Array<Identifier* >* packages, Identifier* ident);
     const char* kind() const override;
     bool read(const Loc& loc);

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -116,7 +116,7 @@ public:
     size_t namelen;             // length of module name in characters
 
     static Module* create(const char *arg, Identifier *ident, int doDocComment, int doHdrGen);
-
+    static const char *find(const char *filename);
     static Module *load(const Loc &loc, Identifiers *packages, Identifier *ident);
 
     const char *kind() const override;

--- a/compiler/test/unit/compilable/searching.d
+++ b/compiler/test/unit/compilable/searching.d
@@ -135,14 +135,14 @@ void doTest(const string code, const string symbol, const string member = "membe
 
     auto mod = cast() res.module_;
 
-    auto td = mod.find!TemplateDeclaration(symbol);
+    auto td = find!TemplateDeclaration(mod, symbol);
 
     // Search doesn't work on uninstantiated templates
     assert(td.members);
     assert(td.members.length == 1);
     auto cl = (*td.members)[0];
 
-    cl.find!VarDeclaration(member, true);
+    find!VarDeclaration(cl, member, true);
 }
 
 /**


### PR DESCRIPTION
Allows implementing compiler glue layers to check whether a given module exists before proceeding with compilation steps proper (i.e: object.d).