### PR TITLE
Deduplicate `pragma(startAddress)` semantic

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1686,22 +1686,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         else if (pd.ident == Id.startaddress)
         {
-            if (!pd.args || pd.args.dim != 1)
-                pd.error("function name expected for start address");
-            else
-            {
-                /* https://issues.dlang.org/show_bug.cgi?id=11980
-                 * resolveProperties and ctfeInterpret call are not necessary.
-                 */
-                Expression e = (*pd.args)[0];
-                sc = sc.startCTFE();
-                e = e.expressionSemantic(sc);
-                sc = sc.endCTFE();
-                (*pd.args)[0] = e;
-                Dsymbol sa = getDsymbol(e);
-                if (!sa || !sa.isFuncDeclaration())
-                    pd.error("function name expected for start address, not `%s`", e.toChars());
-            }
+            pragmaStartAddressSemantic(pd.loc, sc, pd.args);
             return noDeclarations();
         }
         else if (pd.ident == Id.Pinline)

--- a/compiler/test/compilable/test11980.d
+++ b/compiler/test/compilable/test11980.d
@@ -1,2 +1,5 @@
-void start() {}
+void start()
+{
+	pragma(startaddress, start);
+}
 pragma(startaddress, start);


### PR DESCRIPTION
The duplication lead to [Issue 11980](https://issues.dlang.org/show_bug.cgi?id=11980) being fixed in one place (pragma declarations) but not the other (pragma statements).