### PR TITLE
Improve static array initializer checks

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9491,9 +9491,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         if (tx)
                             dim2 = (cast(TypeSArray)tx).dim.toInteger();
                     }
-                    else if (e2x.op == EXP.null_)
+                    else if (e2x.op == EXP.null_ &&
+                        e2x.implicitConvTo(t1.nextOf()) == MATCH.nomatch)
+                       // ignore valid element type init from null
                     {
                         dim2 = 0;
+                        // allow T[].init
                         if (e2x.type.ty != Tarray)
                         {
                             // @@@DEPRECATED_2.111@@@

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9496,9 +9496,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         dim2 = 0;
                         if (e2x.type.ty != Tarray)
                         {
-                            e2x.error("cannot implicitly convert expression `%s` of type `%s` to `%s`",
+                            // @@@DEPRECATED_2.111@@@
+                            // When turning into error, uncomment the return statement
+                            e2x.deprecation("cannot implicitly convert expression `%s` of type `%s` to `%s`",
                                 e2x.toChars(), e2x.type.toChars(), t1.toChars());
-                            return setError();
+                            //return setError();
                         }
                     }
                     if (dim1 != dim2)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9491,6 +9491,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         if (tx)
                             dim2 = (cast(TypeSArray)tx).dim.toInteger();
                     }
+                    else if (e2x.op == EXP.null_)
+                    {
+                        dim2 = 0;
+                        if (e2x.type.ty != Tarray)
+                        {
+                            e2x.error("cannot implicitly convert expression `%s` of type `%s` to `%s`",
+                                e2x.toChars(), e2x.type.toChars(), t1.toChars());
+                            return setError();
+                        }
+                    }
                     if (dim1 != dim2)
                     {
                         exp.error("mismatched array lengths, %d and %d", cast(int)dim1, cast(int)dim2);

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -645,6 +645,10 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
                     if (Type tx = toStaticArrayType(se))
                         dim2 = tx.isTypeSArray().dim.toInteger();
                 }
+                else if (i.exp.op == EXP.null_ && i.exp.type.ty == Tarray)
+                {
+                    return i;
+                }
                 if (dim1 != dim2)
                 {
                     i.exp.error("mismatched array lengths, %d and %d", cast(int)dim1, cast(int)dim2);

--- a/compiler/test/fail_compilation/sarrinit.d
+++ b/compiler/test/fail_compilation/sarrinit.d
@@ -1,0 +1,8 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/sarrinit.d(8): Error: cannot implicitly convert expression `null` of type `typeof(null)` to `int[0]`
+---
+*/
+int[0] a = []; // ok
+int[0] a1 = null; // fail

--- a/compiler/test/fail_compilation/sarrrtinit.d
+++ b/compiler/test/fail_compilation/sarrrtinit.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/sarrrtinit.d(11): Error: cannot implicitly convert expression `null` of type `typeof(null)` to `int[0]`
+fail_compilation/sarrrtinit.d(11): Deprecation: cannot implicitly convert expression `null` of type `typeof(null)` to `int[0]`
 fail_compilation/sarrrtinit.d(13): Error: mismatched array lengths, 1 and 0
 ---
 */

--- a/compiler/test/fail_compilation/sarrrtinit.d
+++ b/compiler/test/fail_compilation/sarrrtinit.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/sarrrtinit.d(11): Error: cannot implicitly convert expression `null` of type `typeof(null)` to `int[0]`
+fail_compilation/sarrrtinit.d(13): Error: mismatched array lengths, 1 and 0
+---
+*/
+void f()
+{
+	int[0] a = []; // ok
+	int[0] a1 = null; // fail
+	int[0] a2 = (int[]).init; // ok
+	int[1] a3 = (int[]).init; // fail
+}

--- a/compiler/test/runnable/sarrinit.d
+++ b/compiler/test/runnable/sarrinit.d
@@ -1,0 +1,16 @@
+int[0] a2 = (int[]).init;
+int[1] a3 = (int[]).init;
+int[][2] a4 = (int[][]).init;
+
+// element initializer:
+int[][2] a5 = null;
+int[][2] a6 = (int[]).init;
+
+void f()
+{
+    assert(a2 == []);
+    assert(a3 == [0]);
+    assert(a4 == [[], []]);
+    assert(a5 == [[], []]);
+    assert(a6 == [[], []]);
+}

--- a/compiler/test/runnable/sarrinit.d
+++ b/compiler/test/runnable/sarrinit.d
@@ -6,11 +6,17 @@ int[][2] a4 = (int[][]).init;
 int[][2] a5 = null;
 int[][2] a6 = (int[]).init;
 
-void f()
+void main()
 {
     assert(a2 == []);
     assert(a3 == [0]);
     assert(a4 == [[], []]);
     assert(a5 == [[], []]);
     assert(a6 == [[], []]);
+
+    int[][2] b1 = null;
+    assert(b1 == [[], []]);
+
+    void*[2] c = null;
+    assert(c == [null, null]);
 }


### PR DESCRIPTION
~Disallow~ Deprecate null literal runtime SA initializer (except as an element initializer when element type accepts null). Rationale in bug below.
Disallow `init` as runtime SA initializer when static array length > 0. 
Allow `init` as initializer for global static array regardless of length.

Fix Issue 23381 - init as initializer of 0-sized static array