### PR TITLE
Refactor FUNCFLAG into bitfields

### DIFF
--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -300,7 +300,7 @@ FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
     auto tf = new TypeFunction(ParameterList(fparams), sd.handleType(), LINK.d, stc | STC.ref_);
     auto fop = new FuncDeclaration(declLoc, Loc.initial, Id.assign, stc, tf);
     fop.storage_class |= STC.inference;
-    fop.flags  |= FUNCFLAG.generated;
+    fop.isGenerated = true;
     Expression e;
     if (stc & STC.disable)
     {
@@ -581,7 +581,7 @@ FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
     tf = tf.addSTC(STC.const_).toTypeFunction();
     Identifier id = Id.xopEquals;
     auto fop = new FuncDeclaration(declLoc, Loc.initial, id, 0, tf);
-    fop.flags |= FUNCFLAG.generated;
+    fop.isGenerated = true;
     fop.parent = sd;
     Expression e1 = new IdentifierExp(loc, Id.This);
     Expression e2 = new IdentifierExp(loc, Id.p);
@@ -705,7 +705,7 @@ FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
     tf = tf.addSTC(STC.const_).toTypeFunction();
     Identifier id = Id.xopCmp;
     auto fop = new FuncDeclaration(declLoc, Loc.initial, id, 0, tf);
-    fop.flags |= FUNCFLAG.generated;
+    fop.isGenerated = true;
     fop.parent = sd;
     Expression e1 = new IdentifierExp(loc, Id.This);
     Expression e2 = new IdentifierExp(loc, Id.p);
@@ -823,7 +823,7 @@ FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
     auto tf = new TypeFunction(ParameterList(parameters), Type.thash_t, LINK.d, STC.nothrow_ | STC.trusted);
     Identifier id = Id.xtoHash;
     auto fop = new FuncDeclaration(declLoc, Loc.initial, id, STC.static_, tf);
-    fop.flags |= FUNCFLAG.generated;
+    fop.isGenerated = true;
 
     /* Do memberwise hashing.
      *
@@ -961,7 +961,7 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
         {
             //printf("Building __fieldDtor(), %s\n", e.toChars());
             auto dd = new DtorDeclaration(declLoc, Loc.initial, stc, Id.__fieldDtor);
-            dd.flags |= FUNCFLAG.generated;
+            dd.isGenerated = true;
             dd.storage_class |= STC.inference;
             dd.fbody = new ExpStatement(loc, e);
             ad.members.push(dd);
@@ -1017,7 +1017,7 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
             e = Expression.combine(e, ce);
         }
         auto dd = new DtorDeclaration(declLoc, Loc.initial, stc, Id.__aggrDtor);
-        dd.flags |= FUNCFLAG.generated;
+        dd.isGenerated = true;
         dd.storage_class |= STC.inference;
         dd.fbody = new ExpStatement(loc, e);
         ad.members.push(dd);
@@ -1088,7 +1088,7 @@ private DtorDeclaration buildWindowsCppDtor(AggregateDeclaration ad, DtorDeclara
     stmts.push(new ExpStatement(loc, call));
     stmts.push(new ReturnStatement(loc, new CastExp(loc, new ThisExp(loc), Type.tvoidptr)));
     func.fbody = new CompoundStatement(loc, stmts);
-    func.flags |= FUNCFLAG.generated;
+    func.isGenerated = true;
 
     auto sc2 = sc.push();
     sc2.stc &= ~STC.static_; // not a static destructor
@@ -1140,7 +1140,7 @@ private DtorDeclaration buildExternDDtor(AggregateDeclaration ad, Scope* sc)
     auto call = new CallExp(dtor.loc, dtor, null);
     call.directcall = true;                   // non-virtual call Class.__dtor();
     func.fbody = new ExpStatement(dtor.loc, call);
-    func.flags |= FUNCFLAG.generated;
+    func.isGenerated = true;
     func.storage_class |= STC.inference;
 
     auto sc2 = sc.push();
@@ -1416,7 +1416,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         //printf("Building __fieldPostBlit()\n");
         checkShared();
         auto dd = new PostBlitDeclaration(declLoc, Loc.initial, stc, Id.__fieldPostblit);
-        dd.flags |= FUNCFLAG.generated;
+        dd.isGenerated = true;
         dd.storage_class |= STC.inference | STC.scope_;
         dd.fbody = (stc & STC.disable) ? null : new CompoundStatement(loc, postblitCalls);
         sd.postblits.shift(dd);
@@ -1454,7 +1454,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
 
         checkShared();
         auto dd = new PostBlitDeclaration(declLoc, Loc.initial, stc, Id.__aggrPostblit);
-        dd.flags |= FUNCFLAG.generated;
+        dd.isGenerated = true;
         dd.storage_class |= STC.inference;
         dd.fbody = new ExpStatement(loc, e);
         sd.members.push(dd);
@@ -1517,7 +1517,7 @@ private CtorDeclaration generateCopyCtorDeclaration(StructDeclaration sd, const 
     auto ccd = new CtorDeclaration(sd.loc, Loc.initial, STC.ref_, tf, true);
     ccd.storage_class |= funcStc;
     ccd.storage_class |= STC.inference;
-    ccd.flags |= FUNCFLAG.generated;
+    ccd.isGenerated = true;
     return ccd;
 }
 

--- a/compiler/src/dmd/common/bitfields.d
+++ b/compiler/src/dmd/common/bitfields.d
@@ -23,6 +23,7 @@ if (__traits(isUnsigned, T))
     string result = "extern (C++) pure nothrow @nogc @safe final {";
     enum structName = __traits(identifier, S);
 
+    string initialValue = "";
     foreach (size_t i, mem; __traits(allMembers, S))
     {
         static assert(is(typeof(__traits(getMember, S, mem)) == bool));
@@ -37,8 +38,10 @@ if (__traits(isUnsigned, T))
             v ? (bitFields |= "~mask~") : (bitFields &= ~"~mask~");
             return v;
         }";
+
+        initialValue = (__traits(getMember, S.init, mem) ? "1" : "0") ~ initialValue;
     }
-    return result ~ "}\n private "~T.stringof~" bitFields;\n";
+    return result ~ "}\n private "~T.stringof~" bitFields = 0b" ~ initialValue ~ ";\n";
 }
 
 ///
@@ -48,7 +51,7 @@ unittest
     {
         bool x;
         bool y;
-        bool z;
+        bool z = 1;
     }
 
     static struct S
@@ -66,5 +69,5 @@ unittest
     s.y = true;
     assert(s.y);
     assert(!s.x);
-    assert(!s.z);
+    assert(s.z);
 }

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1649,7 +1649,7 @@ extern (C++) class VarDeclaration : Declaration
         // Add this VarDeclaration to fdv.closureVars[] if not already there
         if (!sc.intypeof && !(sc.flags & SCOPE.compile) &&
             // https://issues.dlang.org/show_bug.cgi?id=17605
-            (fdv.flags & FUNCFLAG.compileTimeOnly || !(fdthis.flags & FUNCFLAG.compileTimeOnly))
+            (fdv.isCompileTimeOnly || !fdthis.isCompileTimeOnly)
            )
         {
             if (!fdv.closureVars.contains(this))

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -616,7 +616,54 @@ public:
 
     AttributeViolation* safetyViolation;
 
-    unsigned flags;                     // FUNCFLAGxxxxx
+    // Formerly FUNCFLAGS
+    uint32_t flags;
+    bool purityInprocess() const;
+    bool purityInprocess(bool v);
+    bool safetyInprocess() const;
+    bool safetyInprocess(bool v);
+    bool nothrowInprocess() const;
+    bool nothrowInprocess(bool v);
+    bool nogcInprocess() const;
+    bool nogcInprocess(bool v);
+    bool returnInprocess() const;
+    bool returnInprocess(bool v);
+    bool inlineScanned() const;
+    bool inlineScanned(bool v);
+    bool inferScope() const;
+    bool inferScope(bool v);
+    bool hasCatches() const;
+    bool hasCatches(bool v);
+    bool isCompileTimeOnly() const;
+    bool isCompileTimeOnly(bool v);
+    bool printf() const;
+    bool printf(bool v);
+    bool scanf() const;
+    bool scanf(bool v);
+    bool noreturn() const;
+    bool noreturn(bool v);
+    bool isNRVO() const;
+    bool isNRVO(bool v);
+    bool isNaked() const;
+    bool isNaked(bool v);
+    bool isGenerated() const;
+    bool isGenerated(bool v);
+    bool isIntroducing() const;
+    bool isIntroducing(bool v);
+    bool hasSemantic3Errors() const;
+    bool hasSemantic3Errors(bool v);
+    bool hasNoEH() const;
+    bool hasNoEH(bool v);
+    bool inferRetType() const;
+    bool inferRetType(bool v);
+    bool hasDualContext() const;
+    bool hasDualContext(bool v);
+    bool hasAlwaysInlines() const;
+    bool hasAlwaysInlines(bool v);
+    bool isCrtCtor() const;
+    bool isCrtCtor(bool v);
+    bool isCrtDtor() const;
+    bool isCrtDtor(bool v);
 
     // Data for a function declaration that is needed for the Objective-C
     // integration.
@@ -656,22 +703,6 @@ public:
 
     bool isNogc();
     bool isNogcBypassingInference();
-    bool isNRVO() const;
-    void isNRVO(bool v);
-    bool isNaked() const;
-    void isNaked(bool v);
-    bool isGenerated() const;
-    void isGenerated(bool v);
-    bool isIntroducing() const;
-    bool hasSemantic3Errors() const;
-    bool hasNoEH() const;
-    bool inferRetType() const;
-    bool hasDualContext() const;
-    bool hasAlwaysInlines() const;
-    bool isCrtCtor() const;
-    void isCrtCtor(bool v);
-    bool isCrtDtor() const;
-    void isCrtDtor(bool v);
 
     virtual bool isNested() const;
     AggregateDeclaration *isThis() override;

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -1173,7 +1173,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
                 fd = new FuncDeclaration(fd.loc, fd.endloc, fd.ident, fd.storage_class, tf);
                 fd.parent = ti;
-                fd.flags |= FUNCFLAG.inferRetType;
+                fd.inferRetType = true;
 
                 // Shouldn't run semantic on default arguments and return type.
                 foreach (ref param; *tf.parameterList.parameters)

--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -1346,7 +1346,7 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
                 continue;
             }
             FuncDeclaration fd = p.isFuncDeclaration();
-            if (fd && sc.func.flags & FUNCFLAG.returnInprocess)
+            if (fd && sc.func.returnInprocess)
             {
                 /* Code like:
                  *   int x;
@@ -1458,7 +1458,7 @@ private bool inferReturn(FuncDeclaration fd, VarDeclaration v, bool returnScope)
     if (!v.isParameter() || v.isTypesafeVariadicArray || (returnScope && v.doNotInferReturn))
         return false;
 
-    if (!(fd.flags & FUNCFLAG.returnInprocess))
+    if (!fd.returnInprocess)
         return false;
 
     if (returnScope && !(v.isScope() || v.maybeScope))
@@ -2301,9 +2301,9 @@ private void doNotInferScope(VarDeclaration v, RootObject o)
 void finishScopeParamInference(FuncDeclaration funcdecl, ref TypeFunction f)
 {
 
-    if (funcdecl.flags & FUNCFLAG.returnInprocess)
+    if (funcdecl.returnInprocess)
     {
-        funcdecl.flags &= ~FUNCFLAG.returnInprocess;
+        funcdecl.returnInprocess = false;
         if (funcdecl.storage_class & STC.return_)
         {
             if (funcdecl.type == f)
@@ -2315,9 +2315,9 @@ void finishScopeParamInference(FuncDeclaration funcdecl, ref TypeFunction f)
         }
     }
 
-    if (!(funcdecl.flags & FUNCFLAG.inferScope))
+    if (!funcdecl.inferScope)
         return;
-    funcdecl.flags &= ~FUNCFLAG.inferScope;
+    funcdecl.inferScope = false;
 
     // Eliminate maybescope's
     {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1745,7 +1745,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
         if (sc._module)
             sc._module.hasAlwaysInlines = true;
         if (sc.func)
-            sc.func.flags |= FUNCFLAG.hasAlwaysInline;
+            sc.func.hasAlwaysInlines = true;
     }
 
     const isCtorCall = fd && fd.needThis() && fd.isCtorDeclaration();
@@ -2231,14 +2231,14 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
     /* If calling C scanf(), printf(), or any variants, check the format string against the arguments
      */
     const isVa_list = tf.parameterList.varargs == VarArg.none;
-    if (fd && fd.flags & FUNCFLAG.printf)
+    if (fd && fd.printf)
     {
         if (auto se = (*arguments)[nparams - 1 - isVa_list].isStringExp())
         {
             checkPrintfFormat(se.loc, se.peekString(), (*arguments)[nparams .. nargs], isVa_list);
         }
     }
-    else if (fd && fd.flags & FUNCFLAG.scanf)
+    else if (fd && fd.scanf)
     {
         if (auto se = (*arguments)[nparams - 1 - isVa_list].isStringExp())
         {
@@ -12533,8 +12533,7 @@ Expression semanticX(DotIdExp exp, Scope* sc)
                 if (f.checkForwardRef(loc))
                     return ErrorExp.get();
 
-                if (f.flags & (FUNCFLAG.purityInprocess | FUNCFLAG.safetyInprocess |
-                               FUNCFLAG.nothrowInprocess | FUNCFLAG.nogcInprocess))
+                if (f.purityInprocess || f.safetyInprocess || f.nothrowInprocess || f.nogcInprocess)
                 {
                     f.error(loc, "cannot retrieve its `.mangleof` while inferring attributes");
                     return ErrorExp.get();

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2884,7 +2884,55 @@ public:
     Array<FuncDeclaration* > siblingCallers;
     Array<FuncDeclaration* >* inlinedNestedCallees;
     AttributeViolation* safetyViolation;
-    uint32_t flags;
+    bool purityInprocess() const;
+    bool purityInprocess(bool v);
+    bool safetyInprocess() const;
+    bool safetyInprocess(bool v);
+    bool nothrowInprocess() const;
+    bool nothrowInprocess(bool v);
+    bool nogcInprocess() const;
+    bool nogcInprocess(bool v);
+    bool returnInprocess() const;
+    bool returnInprocess(bool v);
+    bool inlineScanned() const;
+    bool inlineScanned(bool v);
+    bool inferScope() const;
+    bool inferScope(bool v);
+    bool hasCatches() const;
+    bool hasCatches(bool v);
+    bool isCompileTimeOnly() const;
+    bool isCompileTimeOnly(bool v);
+    bool printf() const;
+    bool printf(bool v);
+    bool scanf() const;
+    bool scanf(bool v);
+    bool noreturn() const;
+    bool noreturn(bool v);
+    bool isNRVO() const;
+    bool isNRVO(bool v);
+    bool isNaked() const;
+    bool isNaked(bool v);
+    bool isGenerated() const;
+    bool isGenerated(bool v);
+    bool isIntroducing() const;
+    bool isIntroducing(bool v);
+    bool hasSemantic3Errors() const;
+    bool hasSemantic3Errors(bool v);
+    bool hasNoEH() const;
+    bool hasNoEH(bool v);
+    bool inferRetType() const;
+    bool inferRetType(bool v);
+    bool hasDualContext() const;
+    bool hasDualContext(bool v);
+    bool hasAlwaysInlines() const;
+    bool hasAlwaysInlines(bool v);
+    bool isCrtCtor() const;
+    bool isCrtCtor(bool v);
+    bool isCrtDtor() const;
+    bool isCrtDtor(bool v);
+private:
+    uint32_t bitFields;
+public:
     ObjcFuncDeclaration objc;
     static FuncDeclaration* create(const Loc& loc, const Loc& endloc, Identifier* id, StorageClass storage_class, Type* type, bool noreturn = false);
     FuncDeclaration* syntaxCopy(Dsymbol* s) override;
@@ -2923,22 +2971,6 @@ public:
     bool isTrusted();
     bool isNogc();
     bool isNogcBypassingInference();
-    bool isNRVO() const;
-    void isNRVO(bool v);
-    bool isNaked() const;
-    void isNaked(bool v);
-    bool isGenerated() const;
-    void isGenerated(bool v);
-    bool isIntroducing() const;
-    bool hasSemantic3Errors() const;
-    bool hasNoEH() const;
-    bool inferRetType() const;
-    bool hasDualContext() const;
-    bool hasAlwaysInlines() const;
-    bool isCrtCtor() const;
-    void isCrtCtor(bool v);
-    bool isCrtDtor() const;
-    void isCrtDtor(bool v);
     virtual bool isNested() const;
     AggregateDeclaration* isThis() override;
     bool needThis() final override;
@@ -2989,33 +3021,6 @@ public:
     bool overloadInsert(Dsymbol* s) override;
     DtorDeclaration* isDtorDeclaration() override;
     void accept(Visitor* v) override;
-};
-
-enum class FUNCFLAG : uint32_t
-{
-    purityInprocess = 1u,
-    safetyInprocess = 2u,
-    nothrowInprocess = 4u,
-    nogcInprocess = 8u,
-    returnInprocess = 16u,
-    inlineScanned = 32u,
-    inferScope = 64u,
-    hasCatches = 128u,
-    compileTimeOnly = 256u,
-    printf = 512u,
-    scanf = 1024u,
-    noreturn = 2048u,
-    NRVO = 4096u,
-    naked = 8192u,
-    generated = 16384u,
-    introducing = 32768u,
-    semantic3Errors = 65536u,
-    noEH = 131072u,
-    inferRetType = 262144u,
-    dualContext = 524288u,
-    hasAlwaysInline = 1048576u,
-    CRTCtor = 2097152u,
-    CRTDtor = 4194304u,
 };
 
 class FuncAliasDeclaration final : public FuncDeclaration
@@ -4888,7 +4893,6 @@ struct ASTCodegen final
     using CtorDeclaration = ::CtorDeclaration;
     using DtorDeclaration = ::DtorDeclaration;
     using Ensure = ::Ensure;
-    using FUNCFLAG = ::FUNCFLAG;
     using FuncAliasDeclaration = ::FuncAliasDeclaration;
     using FuncDeclaration = ::FuncDeclaration;
     using FuncLiteralDeclaration = ::FuncLiteralDeclaration;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -182,7 +182,7 @@ public:
             catches.push(ctch);
 
             Statement s2 = new TryCatchStatement(Loc.initial, s._body, catches);
-            fd.flags &= ~FUNCFLAG.noEH;
+            fd.hasNoEH = false;
             replaceCurrent(s2);
             s2.accept(this);
         }
@@ -191,31 +191,31 @@ public:
     }
 }
 
-enum FUNCFLAG : uint
+private struct FUNCFLAG
 {
-    purityInprocess  = 1,      /// working on determining purity
-    safetyInprocess  = 2,      /// working on determining safety
-    nothrowInprocess = 4,      /// working on determining nothrow
-    nogcInprocess    = 8,      /// working on determining @nogc
-    returnInprocess  = 0x10,   /// working on inferring 'return' for parameters
-    inlineScanned    = 0x20,   /// function has been scanned for inline possibilities
-    inferScope       = 0x40,   /// infer 'scope' for parameters
-    hasCatches       = 0x80,   /// function has try-catch statements
-    compileTimeOnly  = 0x100,  /// is a compile time only function; no code will be generated for it
-    printf           = 0x200,  /// is a printf-like function
-    scanf            = 0x400,  /// is a scanf-like function
-    noreturn         = 0x800,  /// the function does not return
-    NRVO             = 0x1000, /// Support for named return value optimization
-    naked            = 0x2000, /// The function is 'naked' (see inline ASM)
-    generated        = 0x4000, /// The function is compiler generated (e.g. `opCmp`)
-    introducing      = 0x8000, /// If this function introduces the overload set
-    semantic3Errors  = 0x10000, /// If errors in semantic3 this function's frame ptr
-    noEH             = 0x20000, /// No exception unwinding is needed
-    inferRetType     = 0x40000, /// Return type is to be inferred
-    dualContext      = 0x80000, /// has a dual-context 'this' parameter
-    hasAlwaysInline  = 0x100000, /// Contains references to functions that must be inlined
-    CRTCtor          = 0x200000, /// Has attribute pragma(crt_constructor)
-    CRTDtor          = 0x400000, /// Has attribute pragma(crt_destructor)
+    bool purityInprocess;    /// working on determining purity
+    bool safetyInprocess;    /// working on determining safety
+    bool nothrowInprocess;   /// working on determining nothrow
+    bool nogcInprocess;      /// working on determining @nogc
+    bool returnInprocess;    /// working on inferring 'return' for parameters
+    bool inlineScanned;      /// function has been scanned for inline possibilities
+    bool inferScope;         /// infer 'scope' for parameters
+    bool hasCatches;         /// function has try-catch statements
+    bool isCompileTimeOnly;  /// is a compile time only function; no code will be generated for it
+    bool printf;             /// is a printf-like function
+    bool scanf;              /// is a scanf-like function
+    bool noreturn;           /// the function does not return
+    bool isNRVO = true;      /// Support for named return value optimization
+    bool isNaked;            /// The function is 'naked' (see inline ASM)
+    bool isGenerated;        /// The function is compiler generated (e.g. `opCmp`)
+    bool isIntroducing;      /// If this function introduces the overload set
+    bool hasSemantic3Errors; /// If errors in semantic3 this function's frame ptr
+    bool hasNoEH;            /// No exception unwinding is needed
+    bool inferRetType;       /// Return type is to be inferred
+    bool hasDualContext;     /// has a dual-context 'this' parameter
+    bool hasAlwaysInlines;   /// Contains references to functions that must be inlined
+    bool isCrtCtor;          /// Has attribute pragma(crt_constructor)
+    bool isCrtDtor;          /// Has attribute pragma(crt_destructor)
 }
 
 /***********************************************************
@@ -348,9 +348,9 @@ extern (C++) class FuncDeclaration : Declaration
     /// better diagnostics
     AttributeViolation* safetyViolation;
 
-    /// Function flags: A collection of boolean packed for memory efficiency
-    /// See the `FUNCFLAG` enum
-    uint flags = FUNCFLAG.NRVO;
+    /// See the `FUNCFLAG` struct
+    import dmd.common.bitfields;
+    mixin(generateBitFields!(FUNCFLAG, uint));
 
     /**
      * Data for a function declaration that is needed for the Objective-C
@@ -373,13 +373,13 @@ extern (C++) class FuncDeclaration : Declaration
         }
         this.endloc = endloc;
         if (noreturn)
-            this.flags |= FUNCFLAG.noreturn;
+            this.noreturn = true;
 
         /* The type given for "infer the return type" is a TypeFunction with
          * NULL for the return type.
          */
         if (type && type.nextOf() is null)
-            this.flags |= FUNCFLAG.inferRetType;
+            this.inferRetType = true;
     }
 
     static FuncDeclaration create(const ref Loc loc, const ref Loc endloc, Identifier id, StorageClass storage_class, Type type, bool noreturn = false)
@@ -391,7 +391,7 @@ extern (C++) class FuncDeclaration : Declaration
     {
         //printf("FuncDeclaration::syntaxCopy('%s')\n", toChars());
         FuncDeclaration f = s ? cast(FuncDeclaration)s
-                              : new FuncDeclaration(loc, endloc, ident, storage_class, type.syntaxCopy(), (flags & FUNCFLAG.noreturn) != 0);
+                              : new FuncDeclaration(loc, endloc, ident, storage_class, type.syntaxCopy(), this.noreturn != 0);
         f.frequires = frequires ? Statement.arraySyntaxCopy(frequires) : null;
         f.fensures = fensures ? Ensure.arraySyntaxCopy(fensures) : null;
         f.fbody = fbody ? fbody.syntaxCopy() : null;
@@ -522,7 +522,7 @@ extern (C++) class FuncDeclaration : Declaration
     {
         const bool dualCtx = (toParent2() != toParentLocal());
         if (dualCtx)
-            this.flags |= FUNCFLAG.dualContext;
+            this.hasDualContext = true;
         auto ad = isThis();
         if (!dualCtx && !ad && !isNested())
         {
@@ -1376,29 +1376,29 @@ extern (C++) class FuncDeclaration : Declaration
         //printf("initInferAttributes() for %s (%s)\n", toPrettyChars(), ident.toChars());
         TypeFunction tf = type.toTypeFunction();
         if (tf.purity == PURE.impure) // purity not specified
-            flags |= FUNCFLAG.purityInprocess;
+            purityInprocess = true;
 
         if (tf.trust == TRUST.default_)
-            flags |= FUNCFLAG.safetyInprocess;
+            safetyInprocess = true;
 
         if (!tf.isnothrow)
-            flags |= FUNCFLAG.nothrowInprocess;
+            nothrowInprocess = true;
 
         if (!tf.isnogc)
-            flags |= FUNCFLAG.nogcInprocess;
+            nogcInprocess = true;
 
         if (!isVirtual() || this.isIntroducing())
-            flags |= FUNCFLAG.returnInprocess;
+            returnInprocess = true;
 
         // Initialize for inferring STC.scope_
-        flags |= FUNCFLAG.inferScope;
+        inferScope = true;
     }
 
     final PURE isPure()
     {
         //printf("FuncDeclaration::isPure() '%s'\n", toChars());
         TypeFunction tf = type.toTypeFunction();
-        if (flags & FUNCFLAG.purityInprocess)
+        if (purityInprocess)
             setImpure();
         if (tf.purity == PURE.fwdref)
             tf.purityLevel();
@@ -1424,7 +1424,7 @@ extern (C++) class FuncDeclaration : Declaration
 
     final PURE isPureBypassingInference()
     {
-        if (flags & FUNCFLAG.purityInprocess)
+        if (purityInprocess)
             return PURE.fwdref;
         else
             return isPure();
@@ -1437,9 +1437,9 @@ extern (C++) class FuncDeclaration : Declaration
      */
     extern (D) final bool setImpure()
     {
-        if (flags & FUNCFLAG.purityInprocess)
+        if (purityInprocess)
         {
-            flags &= ~FUNCFLAG.purityInprocess;
+            purityInprocess = false;
             if (fes)
                 fes.func.setImpure();
         }
@@ -1448,21 +1448,32 @@ extern (C++) class FuncDeclaration : Declaration
         return false;
     }
 
+    extern (D) final uint flags()
+    {
+        return bitFields;
+    }
+
+    extern (D) final uint flags(uint f)
+    {
+        bitFields = f;
+        return bitFields;
+    }
+
     final bool isSafe()
     {
-        if (flags & FUNCFLAG.safetyInprocess)
+        if (safetyInprocess)
             setUnsafe();
         return type.toTypeFunction().trust == TRUST.safe;
     }
 
     final bool isSafeBypassingInference()
     {
-        return !(flags & FUNCFLAG.safetyInprocess) && isSafe();
+        return !(safetyInprocess) && isSafe();
     }
 
     final bool isTrusted()
     {
-        if (flags & FUNCFLAG.safetyInprocess)
+        if (safetyInprocess)
             setUnsafe();
         return type.toTypeFunction().trust == TRUST.trusted;
     }
@@ -1483,9 +1494,9 @@ extern (C++) class FuncDeclaration : Declaration
         bool gag = false, Loc loc = Loc.init, const(char)* fmt = null,
         RootObject arg0 = null, RootObject arg1 = null, RootObject arg2 = null)
     {
-        if (flags & FUNCFLAG.safetyInprocess)
+        if (safetyInprocess)
         {
-            flags &= ~FUNCFLAG.safetyInprocess;
+            safetyInprocess = false;
             type.toTypeFunction().trust = TRUST.system;
             if (fmt || arg0)
                 safetyViolation = new AttributeViolation(loc, fmt, arg0, arg1, arg2);
@@ -1518,99 +1529,14 @@ extern (C++) class FuncDeclaration : Declaration
     final bool isNogc()
     {
         //printf("isNogc() %s, inprocess: %d\n", toChars(), !!(flags & FUNCFLAG.nogcInprocess));
-        if (flags & FUNCFLAG.nogcInprocess)
+        if (nogcInprocess)
             setGC();
         return type.toTypeFunction().isnogc;
     }
 
     final bool isNogcBypassingInference()
     {
-        return !(flags & FUNCFLAG.nogcInprocess) && isNogc();
-    }
-
-    final bool isNRVO() const scope @safe pure nothrow @nogc
-    {
-        return !!(this.flags & FUNCFLAG.NRVO);
-    }
-
-    final void isNRVO(bool v) pure nothrow @safe @nogc
-    {
-        if (v) this.flags |= FUNCFLAG.NRVO;
-        else this.flags &= ~FUNCFLAG.NRVO;
-    }
-
-    final bool isNaked() const scope @safe pure nothrow @nogc
-    {
-        return !!(this.flags & FUNCFLAG.naked);
-    }
-
-    final void isNaked(bool v) @safe pure nothrow @nogc
-    {
-        if (v) this.flags |= FUNCFLAG.naked;
-        else this.flags &= ~FUNCFLAG.naked;
-    }
-
-    final bool isGenerated() const scope @safe pure nothrow @nogc
-    {
-        return !!(this.flags & FUNCFLAG.generated);
-    }
-
-    final void isGenerated(bool v) pure nothrow @safe @nogc
-    {
-        if (v) this.flags |= FUNCFLAG.generated;
-        else this.flags &= ~FUNCFLAG.generated;
-    }
-
-    final bool isIntroducing() const scope @safe pure nothrow @nogc
-    {
-        return !!(this.flags & FUNCFLAG.introducing);
-    }
-
-    final bool hasSemantic3Errors() const scope @safe pure nothrow @nogc
-    {
-        return !!(this.flags & FUNCFLAG.semantic3Errors);
-    }
-
-    final bool hasNoEH() const scope @safe pure nothrow @nogc
-    {
-        return !!(this.flags & FUNCFLAG.noEH);
-    }
-
-    final bool inferRetType() const scope @safe pure nothrow @nogc
-    {
-        return !!(this.flags & FUNCFLAG.inferRetType);
-    }
-
-    final bool hasDualContext() const scope @safe pure nothrow @nogc
-    {
-        return !!(this.flags & FUNCFLAG.dualContext);
-    }
-
-    final bool hasAlwaysInlines() const scope @safe pure nothrow @nogc
-    {
-        return !!(this.flags & FUNCFLAG.hasAlwaysInline);
-    }
-
-    final bool isCrtCtor() const scope @safe pure nothrow @nogc
-    {
-        return !!(this.flags & FUNCFLAG.CRTCtor);
-    }
-
-    final void isCrtCtor(bool v) @safe pure nothrow @nogc
-    {
-        if (v) this.flags |= FUNCFLAG.CRTCtor;
-        else this.flags &= ~FUNCFLAG.CRTCtor;
-    }
-
-    final bool isCrtDtor() const scope @safe pure nothrow @nogc
-    {
-        return !!(this.flags & FUNCFLAG.CRTDtor);
-    }
-
-    final void isCrtDtor(bool v) @safe pure nothrow @nogc
-    {
-        if (v) this.flags |= FUNCFLAG.CRTDtor;
-        else this.flags &= ~FUNCFLAG.CRTDtor;
+        return !nogcInprocess && isNogc();
     }
 
     /**************************************
@@ -1622,15 +1548,15 @@ extern (C++) class FuncDeclaration : Declaration
     extern (D) final bool setGC()
     {
         //printf("setGC() %s\n", toChars());
-        if (flags & FUNCFLAG.nogcInprocess && semanticRun < PASS.semantic3 && _scope)
+        if (nogcInprocess && semanticRun < PASS.semantic3 && _scope)
         {
             this.semantic2(_scope);
             this.semantic3(_scope);
         }
 
-        if (flags & FUNCFLAG.nogcInprocess)
+        if (nogcInprocess)
         {
-            flags &= ~FUNCFLAG.nogcInprocess;
+            nogcInprocess = false;
             type.toTypeFunction().isnogc = false;
             if (fes)
                 fes.func.setGC();
@@ -3789,7 +3715,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
         this.fes = fes;
         // Always infer scope for function literals
         // See https://issues.dlang.org/show_bug.cgi?id=20362
-        this.flags |= FUNCFLAG.inferScope;
+        this.inferScope = true;
         //printf("FuncLiteralDeclaration() id = '%s', type = '%s'\n", this.ident.toChars(), type.toChars());
     }
 

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -691,7 +691,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         return;
 
     if (multiobj && !fd.isStaticDtorDeclaration() && !fd.isStaticCtorDeclaration()
-        && !(fd.flags & (FUNCFLAG.CRTCtor | FUNCFLAG.CRTDtor)))
+        && !(fd.isCrtCtor || fd.isCrtDtor))
     {
         obj_append(fd);
         return;
@@ -880,7 +880,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         // Register return style cannot make nrvo.
         // Auto functions keep the NRVO flag up to here,
         // so we should eliminate it before entering backend.
-        fd.flags &= ~FUNCFLAG.NRVO;
+        fd.isNRVO = false;
     }
 
     if (fd.vthis)
@@ -1193,10 +1193,10 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     if (fd.isExport())
         objmod.export_symbol(s, cast(uint)Para.offset);
 
-    if (fd.flags & FUNCFLAG.CRTCtor)
+    if (fd.isCrtCtor)
         objmod.setModuleCtorDtor(s, true);
 
-    if (fd.flags & FUNCFLAG.CRTDtor)
+    if (fd.isCrtDtor)
     {
         //See TargetC.initialize
         if(target.c.crtDestructorsSupported)

--- a/compiler/src/dmd/iasmdmd.d
+++ b/compiler/src/dmd/iasmdmd.d
@@ -124,10 +124,8 @@ version (none) // don't use bReturnax anymore, and will fail anyway if we use re
     switch (asmstate.tokValue)
     {
         case cast(TOK)ASMTK.naked:
-            import dmd.func : FUNCFLAG;
-
             s.naked = true;
-            sc.func.flags |= FUNCFLAG.naked;
+            sc.func.isNaked = true;
             asm_token();
             break;
 
@@ -2346,8 +2344,7 @@ void asm_merge_symbol(ref OPND o1, Dsymbol s)
               * We could leave it on unless fd.nrvo_var==v,
               * but fd.nrvo_var isn't set yet
               */
-            import dmd.func : FUNCFLAG;
-            fd.flags &= ~FUNCFLAG.NRVO;
+            fd.isNRVO = false;
         }
 
         if (v.isParameter())

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -1542,8 +1542,7 @@ public:
         }
         if (!(global.params.useInline || fd.hasAlwaysInlines))
             return;
-        if (fd.isUnitTestDeclaration() && !global.params.useUnitTests ||
-            fd.flags & FUNCFLAG.inlineScanned)
+        if (fd.isUnitTestDeclaration() && !global.params.useUnitTests || fd.inlineScanned)
             return;
         if (fd.fbody && !fd.isNaked())
         {
@@ -1554,7 +1553,7 @@ public:
             {
                 again = false;
                 fd.inlineNest++;
-                fd.flags |= FUNCFLAG.inlineScanned;
+                fd.inlineScanned = true;
                 inlineScan(fd.fbody);
                 fd.inlineNest--;
             }

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -221,7 +221,7 @@ Expression checkGC(Scope* sc, Expression e)
     FuncDeclaration f = sc.func;
     if (e && e.op != EXP.error && f && sc.intypeof != 1 && !(sc.flags & SCOPE.ctfe) &&
            (f.type.ty == Tfunction &&
-            (cast(TypeFunction)f.type).isnogc || (f.flags & FUNCFLAG.nogcInprocess) || global.params.vgc) &&
+            (cast(TypeFunction)f.type).isnogc || f.nogcInprocess || global.params.vgc) &&
            !(sc.flags & SCOPE.debug_))
     {
         scope NOGCVisitor gcv = new NOGCVisitor(f);

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -282,7 +282,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     // Disable generated opAssign, because some members forbid identity assignment.
                     funcdecl.storage_class |= STC.disable;
                     funcdecl.fbody = null;   // remove fbody which contains the error
-                    funcdecl.flags &= ~FUNCFLAG.semantic3Errors;
+                    funcdecl.hasSemantic3Errors = false;
                 }
                 return;
             }
@@ -292,7 +292,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
         if (funcdecl.semanticRun >= PASS.semantic3)
             return;
         funcdecl.semanticRun = PASS.semantic3;
-        funcdecl.flags &= ~FUNCFLAG.semantic3Errors;
+        funcdecl.hasSemantic3Errors = false;
 
         if (!funcdecl.type || funcdecl.type.ty != Tfunction)
             return;
@@ -650,7 +650,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 // handle NRVO
                 if (!target.isReturnOnStack(f, funcdecl.needThis()) || !funcdecl.checkNRVO())
-                    funcdecl.flags &= ~FUNCFLAG.NRVO;
+                    funcdecl.isNRVO = false;
 
                 if (funcdecl.fbody.isErrorStatement())
                 {
@@ -753,15 +753,15 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 if (f.isnothrow && blockexit & BE.throw_)
                     error(funcdecl.loc, "%s `%s` may throw but is marked as `nothrow`", funcdecl.kind(), funcdecl.toPrettyChars());
 
-                if (!(blockexit & (BE.throw_ | BE.halt) || funcdecl.flags & FUNCFLAG.hasCatches))
+                if (!(blockexit & (BE.throw_ | BE.halt) || funcdecl.hasCatches))
                 {
                     /* Don't generate unwind tables for this function
                      * https://issues.dlang.org/show_bug.cgi?id=17997
                      */
-                    funcdecl.flags |= FUNCFLAG.noEH;
+                    funcdecl.hasNoEH = true;
                 }
 
-                if (funcdecl.flags & FUNCFLAG.nothrowInprocess)
+                if (funcdecl.nothrowInprocess)
                 {
                     if (funcdecl.type == f)
                         f = cast(TypeFunction)f.copy();
@@ -976,7 +976,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             /* Do the semantic analysis on the [in] preconditions and
              * [out] postconditions.
              */
-            immutable bool isnothrow = f.isnothrow && !(funcdecl.flags & FUNCFLAG.nothrowInprocess);
+            immutable bool isnothrow = f.isnothrow && !funcdecl.nothrowInprocess;
             if (freq)
             {
                 /* frequire is composed of the [in] contracts
@@ -1001,11 +1001,11 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         // Deprecated in 2.101, can be made an error in 2.111
                         deprecation(funcdecl.loc, "`%s`: `in` contract may throw but function is marked as `nothrow`",
                             funcdecl.toPrettyChars());
-                    else if (funcdecl.flags & FUNCFLAG.nothrowInprocess)
+                    else if (funcdecl.nothrowInprocess)
                         f.isnothrow = false;
                 }
 
-                funcdecl.flags &= ~FUNCFLAG.noEH;
+                funcdecl.hasNoEH = false;
 
                 sc2 = sc2.pop();
 
@@ -1048,11 +1048,11 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         // Deprecated in 2.101, can be made an error in 2.111
                         deprecation(funcdecl.loc, "`%s`: `out` contract may throw but function is marked as `nothrow`",
                             funcdecl.toPrettyChars());
-                    else if (funcdecl.flags & FUNCFLAG.nothrowInprocess)
+                    else if (funcdecl.nothrowInprocess)
                         f.isnothrow = false;
                 }
 
-                funcdecl.flags &= ~FUNCFLAG.noEH;
+                funcdecl.hasNoEH = false;
 
                 sc2 = sc2.pop();
 
@@ -1180,10 +1180,10 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             const blockexit = s.blockExit(funcdecl, isnothrow);
                             if (blockexit & BE.throw_)
                             {
-                                funcdecl.flags &= ~FUNCFLAG.noEH;
+                                funcdecl.hasNoEH = false;
                                 if (isnothrow)
                                     error(funcdecl.loc, "%s `%s` may throw but is marked as `nothrow`", funcdecl.kind(), funcdecl.toPrettyChars());
-                                else if (funcdecl.flags & FUNCFLAG.nothrowInprocess)
+                                else if (funcdecl.nothrowInprocess)
                                     f.isnothrow = false;
                             }
 
@@ -1195,7 +1195,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     }
                 }
                 // from this point on all possible 'throwers' are checked
-                funcdecl.flags &= ~FUNCFLAG.nothrowInprocess;
+                funcdecl.nothrowInprocess = false;
 
                 if (funcdecl.isSynchronized())
                 {
@@ -1274,25 +1274,25 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
         /* If function survived being marked as impure, then it is pure
          */
-        if (funcdecl.flags & FUNCFLAG.purityInprocess)
+        if (funcdecl.purityInprocess)
         {
-            funcdecl.flags &= ~FUNCFLAG.purityInprocess;
+            funcdecl.purityInprocess = false;
             if (funcdecl.type == f)
                 f = cast(TypeFunction)f.copy();
             f.purity = PURE.fwdref;
         }
 
-        if (funcdecl.flags & FUNCFLAG.safetyInprocess)
+        if (funcdecl.safetyInprocess)
         {
-            funcdecl.flags &= ~FUNCFLAG.safetyInprocess;
+            funcdecl.safetyInprocess = false;
             if (funcdecl.type == f)
                 f = cast(TypeFunction)f.copy();
             f.trust = TRUST.safe;
         }
 
-        if (funcdecl.flags & FUNCFLAG.nogcInprocess)
+        if (funcdecl.nogcInprocess)
         {
-            funcdecl.flags &= ~FUNCFLAG.nogcInprocess;
+            funcdecl.nogcInprocess = false;
             if (funcdecl.type == f)
                 f = cast(TypeFunction)f.copy();
             f.isnogc = true;
@@ -1395,9 +1395,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
          */
         funcdecl.semanticRun = PASS.semantic3done;
         if ((global.errors != oldErrors) || (funcdecl.fbody && funcdecl.fbody.isErrorStatement()))
-            funcdecl.flags |= FUNCFLAG.semantic3Errors;
+            funcdecl.hasSemantic3Errors = true;
         else
-            funcdecl.flags &= ~FUNCFLAG.semantic3Errors;
+            funcdecl.hasSemantic3Errors = false;
         if (funcdecl.type.ty == Terror)
             funcdecl.errors = true;
         //printf("-FuncDeclaration::semantic3('%s.%s', sc = %p, loc = %s)\n", funcdecl.parent.toChars(), funcdecl.toChars(), sc, funcdecl.loc.toChars());

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3562,7 +3562,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
 
         if (sc.func)
         {
-            sc.func.flags |= FUNCFLAG.hasCatches;
+            sc.func.hasCatches = true;
             if (flags == (FLAGcpp | FLAGd))
             {
                 tcs.error("cannot mix catching D and C++ exceptions in the same try-catch");

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -371,7 +371,7 @@ Symbol *toSymbol(Dsymbol s)
                     f.Fflags |= Finline;    // inline this function if possible
             }
 
-            if (fd.type.toBasetype().isTypeFunction().nextOf().isTypeNoreturn() || fd.flags & FUNCFLAG.noreturn)
+            if (fd.type.toBasetype().isTypeFunction().nextOf().isTypeNoreturn() || fd.noreturn)
                 s.Sflags |= SFLexit;    // the function never returns
 
             f.Fstartline = toSrcpos(fd.loc);


### PR DESCRIPTION
Because of the initial value `uint flags = FUNCFLAG.NRVO;`, the first commit adds initializer support to the bitfields generator.