### PR TITLE
Update downloads.dlang.org links to use https

### DIFF
--- a/.azure-pipelines/lib.sh
+++ b/.azure-pipelines/lib.sh
@@ -34,9 +34,9 @@ download() {
 
 install_host_dmd() {
     if [ ! -f dmd2/README.TXT ]; then
-        download "http://downloads.dlang.org/releases/2.x/${HOST_DMD_VERSION}/dmd.${HOST_DMD_VERSION}.windows.7z" dmd2.7z
+        download "https://downloads.dlang.org/releases/2.x/${HOST_DMD_VERSION}/dmd.${HOST_DMD_VERSION}.windows.7z" dmd2.7z
         7z x dmd2.7z > /dev/null
-        download "http://downloads.dlang.org/other/libcurl-7.65.3-2-WinSSL-zlib-x86-x64.zip" libcurl.zip
+        download "https://downloads.dlang.org/other/libcurl-7.65.3-2-WinSSL-zlib-x86-x64.zip" libcurl.zip
         7z -y x libcurl.zip > /dev/null
     fi
     export PATH="$PWD/dmd2/windows/bin/:$PATH"
@@ -50,7 +50,7 @@ install_host_dmd() {
 
 install_host_dmc() {
     if [ ! -f dm/README.TXT ]; then
-        download "http://downloads.dlang.org/other/dm857c.zip" dmc.zip
+        download "https://downloads.dlang.org/other/dm857c.zip" dmc.zip
         7z x dmc.zip > /dev/null
         download "http://ftp.digitalmars.com/sppn.zip" sppn.zip
         7z x -odm/bin sppn.zip > /dev/null
@@ -67,7 +67,7 @@ install_grep() {
     mkdir -p "$tools_dir"
     cd "$tools_dir"
     if [ ! -f grep.exe ]; then
-        download "http://downloads.dlang.org/other/grep-3.1.zip" "grep-3.1.zip"
+        download "https://downloads.dlang.org/other/grep-3.1.zip" "grep-3.1.zip"
         unzip "grep-3.1.zip" # contains grep.exe
     fi
     export PATH="${tools_dir}:$PATH"

--- a/.azure-pipelines/windows-msbuild.bat
+++ b/.azure-pipelines/windows-msbuild.bat
@@ -64,7 +64,7 @@ cd "%DMD_DIR%"
 if not "%C_RUNTIME%" == "mingw" goto not_mingw
     rem install recent LLD and mingw libraries to built dmd
     if exist "%DMD_DIR%\generated\Windows\%CONFIGURATION%\%PLATFORM%\lld-link.exe" goto lld_exists
-    powershell -command "& { iwr http://downloads.dlang.org/other/lld-link-9.0.0-seh.zip -OutFile lld.zip }" || exit /B 11
+    powershell -command "& { iwr https://downloads.dlang.org/other/lld-link-9.0.0-seh.zip -OutFile lld.zip }" || exit /B 11
     7z x lld.zip -o%DMD_DIR%\generated\Windows\%CONFIGURATION%\%PLATFORM% || exit /B 12
     :lld_exists
 

--- a/.azure-pipelines/windows-visual-studio.sh
+++ b/.azure-pipelines/windows-visual-studio.sh
@@ -45,7 +45,7 @@ visuald() {
 ################################################################################
 
 dm_make() {
-    download "http://downloads.dlang.org/other/dm857c.zip" dmc.zip
+    download "https://downloads.dlang.org/other/dm857c.zip" dmc.zip
     unzip dmc.zip > /dev/null
     export DMC="$PWD/dm/bin/dmc.exe"
     export DM_MAKE="$PWD/dm/bin/make.exe"

--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -15,7 +15,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 install_grep
 
 if [ "$HOST_DMD_VERSION" == "LATEST" ]; then
-    download "http://downloads.dlang.org/releases/LATEST" LATEST
+    download "https://downloads.dlang.org/releases/LATEST" LATEST
     HOST_DMD_VERSION="$(cat LATEST)"
 fi
 echo "D_VERSION: $HOST_DMD_VERSION"

--- a/compiler/src/bootstrap.sh
+++ b/compiler/src/bootstrap.sh
@@ -50,8 +50,8 @@ else
     # dmd.2.095.0.osx.zip or dmd.2.095.0.linux.tar.xz
     HOST_DMD_BASENAME=dmd.${HOST_DMD_VER}.${OS}
 fi
-# http://downloads.dlang.org/releases/2.x/2.095.0/dmd.2.095.0.linux.tar.xz
-HOST_DMD_URL=http://downloads.dlang.org/releases/2.x/${HOST_DMD_VER}/${HOST_DMD_BASENAME}
+# https://downloads.dlang.org/releases/2.x/2.095.0/dmd.2.095.0.linux.tar.xz
+HOST_DMD_URL=https://downloads.dlang.org/releases/2.x/${HOST_DMD_VER}/${HOST_DMD_BASENAME}
 HOST_RDMD="${HOST_DMD_ROOT}/dmd2/${OS}/${MODEL_PATH}/rdmd"
 HOST_DMD="${HOST_DMD_ROOT}/dmd2/${OS}/${MODEL_PATH}/dmd" # required by build.d
 

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1292,7 +1292,7 @@ void parseEnvironment()
         writefln("Using Bootstrap compiler: %s", hostDMDVer);
         auto hostDMDRoot = env["G"].buildPath("host_dmd-"~hostDMDVer);
         auto hostDMDBase = hostDMDVer~"."~(os == "freebsd" ? os~"-"~model : os);
-        auto hostDMDURL = "http://downloads.dlang.org/releases/2.x/"~hostDMDVer~"/dmd."~hostDMDBase;
+        auto hostDMDURL = "https://downloads.dlang.org/releases/2.x/"~hostDMDVer~"/dmd."~hostDMDBase;
         env["HOST_DMD"] = hostDMDRoot.buildPath("dmd2", os, os == "osx" ? "bin" : "bin"~model, "dmd");
         env["HOST_DMD_PATH"] = env["HOST_DMD"];
         // TODO: use dmd.conf from the host too (in case there's a global or user-level dmd.conf)

--- a/druntime/win64.mak
+++ b/druntime/win64.mak
@@ -21,7 +21,7 @@ DOCDIR=doc
 IMPDIR=import
 
 # Make program to use. Designed to be run with make.exe which can be obtained from
-# http://downloads.dlang.org/other/dm857c.zip
+# https://downloads.dlang.org/other/dm857c.zip
 MAKE=make
 
 HOST_DMD=dmd


### PR DESCRIPTION
This is now possible now the site now has a new front for its bucket.