### PR TITLE
check return value of allocator

### DIFF
--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -513,7 +513,7 @@ private void genObjFile(Module m, bool multiobj)
 
         outdata(m.cov);
 
-        m.covb = cast(uint *)calloc((m.numlines + 32) / 32, (*m.covb).sizeof);
+        m.covb = cast(uint *)Mem.check(calloc((m.numlines + 32) / 32, (*m.covb).sizeof));
     }
 
     for (int i = 0; i < m.members.dim; i++)
@@ -1222,8 +1222,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
                 platform it, if needed.
             */
             __gshared uint nthDestructor = 0;
-            char* buf = cast(char*) calloc(50, 1);
-            assert(buf);
+            char* buf = cast(char*) Mem.check(calloc(50, 1));
             const ret = snprintf(buf, 100, "_dmd_crt_destructor_thunk.%u", nthDestructor++);
             assert(ret >= 0 && ret < 100, "snprintf either failed or overran buffer");
             //Function symbol


### PR DESCRIPTION
One is unchecked (how embarrassing) and the other is checked with assert, which is unreliable if compiled with asserts disabled.