### PR TITLE
replace assert on alloc failure with err_nomem()

### DIFF
--- a/compiler/src/dmd/backend/dcgcv.d
+++ b/compiler/src/dmd/backend/dcgcv.d
@@ -464,7 +464,8 @@ void cv_init()
     else
     {
         reset_symbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(reset_symbuf);
+        if (!reset_symbuf)
+            err_nomem();
         reset_symbuf.reserve(10 * (Symbol*).sizeof);
     }
 

--- a/compiler/src/dmd/backend/dwarfdbginf.d
+++ b/compiler/src/dmd/backend/dwarfdbginf.d
@@ -2639,7 +2639,8 @@ static if (1)
                 if (!functypebuf)
                 {
                     functypebuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-                    assert(functypebuf);
+                    if (!functypebuf)
+                        err_nomem();
                 }
                 uint functypebufidx = cast(uint)functypebuf.length();
                 functypebuf.write(tmpbuf.buf, cast(uint)tmpbuf.length());

--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -417,7 +417,8 @@ private IDXSYM elf_addsym(IDXSTR nam, targ_size_t val, uint sz,
         if (!shndx_data)
         {
             shndx_data = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-            assert(shndx_data);
+            if (!shndx_data)
+                err_nomem();
             shndx_data.reserve(50 * (Elf64_Word).sizeof);
         }
         // fill with zeros up to symbol_idx
@@ -667,7 +668,8 @@ Obj ElfObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
     else
     {
         symtab_strings = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(symtab_strings);
+        if (!symtab_strings)
+            err_nomem();
         symtab_strings.reserve(2048);
         symtab_strings.writeByte(0);
     }
@@ -704,7 +706,8 @@ Obj ElfObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
         else
         {
             section_names = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-            assert(section_names);
+            if (!section_names)
+                err_nomem();
             section_names.reserve(1024);
             section_names.writen(section_names_init64.ptr, section_names_init64.sizeof);
         }
@@ -746,7 +749,8 @@ Obj ElfObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
         else
         {
             section_names = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-            assert(section_names);
+            if (!section_names)
+                err_nomem();
             section_names.reserve(100*1024);
             section_names.writen(section_names_init.ptr, section_names_init.sizeof);
         }
@@ -1539,7 +1543,8 @@ void ElfObj_compiler()
 {
     //dbg_printf("ElfObj_compiler\n");
     comment_data = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-    assert(comment_data);
+    if (!comment_data)
+        err_nomem();
 
     enum maxVersionLength = 40;  // hope enough to store `git describe --dirty`
     enum compilerHeader = "\0Digital Mars C/C++ ";
@@ -1896,7 +1901,8 @@ private segidx_t elf_addsegment2(IDXSEC shtidx, IDXSYM symidx, IDXSEC relidx)
     {   if (SecHdrTab[shtidx].sh_type != SHT_NOBITS)
         {
             pseg.SDbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-            assert(pseg.SDbuf);
+            if (!pseg.SDbuf)
+                err_nomem();
             pseg.SDbuf.reserve(1024);
         }
     }
@@ -2674,7 +2680,8 @@ void ElfObj_addrel(int seg, targ_size_t offset, uint type,
     if (segdata.SDrel == null)
     {
         segdata.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(segdata.SDrel);
+        if (!segdata.SDrel)
+            err_nomem();
     }
 
     if (segdata.SDrel.length() == 0)

--- a/compiler/src/dmd/backend/gflow.d
+++ b/compiler/src/dmd/backend/gflow.d
@@ -53,10 +53,22 @@ char symbol_isintab(const Symbol* s) { return sytab[s.Sclass] & SCSS; }
 void util_free(void* p) { if (p) free(p); }
 
 @trusted
-void *util_calloc(uint n, uint size) { void* p = calloc(n, size); assert(!(n * size) || p); return p; }
+void *util_calloc(uint n, uint size)
+{
+    void* p = calloc(n, size);
+    if (n * size && !p)
+        err_nomem();
+    return p;
+}
 
 @trusted
-void *util_realloc(void* p, size_t n, size_t size) { void* q = realloc(p, n * size); assert(!(n * size) || q); return q; }
+void *util_realloc(void* p, size_t n, size_t size)
+{
+    void* q = realloc(p, n * size);
+    if (n * size && !q)
+        err_nomem();
+    return q;
+}
 
 extern (C++):
 

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -467,7 +467,8 @@ Obj MachObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname
     else
     {
         symtab_strings = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(symtab_strings);
+        if (!symtab_strings)
+            err_nomem();
         symtab_strings.reserve(2048);
         symtab_strings.writeByte(0);
     }
@@ -475,7 +476,8 @@ Obj MachObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname
     if (!local_symbuf)
     {
         local_symbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(local_symbuf);
+        if (!local_symbuf)
+            err_nomem();
         local_symbuf.reserve((Symbol *).sizeof * SYM_TAB_INIT);
     }
     local_symbuf.reset();
@@ -488,7 +490,8 @@ Obj MachObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname
     else
     {
         public_symbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(public_symbuf);
+        if (!public_symbuf)
+            err_nomem();
         public_symbuf.reserve((Symbol *).sizeof * SYM_TAB_INIT);
     }
 
@@ -500,14 +503,16 @@ Obj MachObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname
     else
     {
         extern_symbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(extern_symbuf);
+        if (!extern_symbuf)
+            err_nomem();
         extern_symbuf.reserve((Symbol *).sizeof * SYM_TAB_INIT);
     }
 
     if (!comdef_symbuf)
     {
         comdef_symbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(comdef_symbuf);
+        if (!comdef_symbuf)
+            err_nomem();
         comdef_symbuf.reserve((Symbol *).sizeof * SYM_TAB_INIT);
     }
     comdef_symbuf.reset();
@@ -531,7 +536,8 @@ Obj MachObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname
     else
     {
         SECbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(SECbuf);
+        if (!SECbuf)
+            err_nomem();
         SECbuf.reserve(cast(uint)(SEC_TAB_INIT * struct_section_size));
         // Ignore the first section - section numbers start at 1
         SECbuf.writezeros(cast(uint)struct_section_size);
@@ -1900,7 +1906,8 @@ int MachObj_getsegment(const(char)* sectname, const(char)* segname,
         if (flags != S_ZEROFILL && flags != S_THREAD_LOCAL_ZEROFILL)
         {
             pseg.SDbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-            assert(pseg.SDbuf);
+            if (!pseg.SDbuf)
+                err_nomem();
             pseg.SDbuf.reserve(4096);
         }
     }
@@ -2528,7 +2535,8 @@ void MachObj_addrel(int seg, targ_size_t offset, Symbol *targsym,
     if (!pseg.SDrel)
     {
         pseg.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(pseg.SDrel);
+        if (!pseg.SDrel)
+            err_nomem();
     }
     pseg.SDrel.write(&rel, rel.sizeof);
 }
@@ -2676,7 +2684,8 @@ static if (0)
                 if (!indirectsymbuf1)
                 {
                     indirectsymbuf1 = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-                    assert(indirectsymbuf1);
+                    if (!indirectsymbuf1)
+                        err_nomem();
                 }
                 else
                 {   // Look through indirectsym to see if it is already there
@@ -2722,7 +2731,8 @@ static if (0)
                 if (!indirectsymbuf2)
                 {
                     indirectsymbuf2 = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-                    assert(indirectsymbuf2);
+                    if (!indirectsymbuf2)
+                        err_nomem();
                 }
                 else
                 {   // Look through indirectsym to see if it is already there
@@ -2759,7 +2769,8 @@ static if (0)
                     if (!pseg2.SDrel)
                     {
                         pseg2.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-                        assert(pseg2.SDrel);
+                        if (!pseg2.SDrel)
+                            err_nomem();
                     }
                     pseg2.SDrel.write(&rel, rel.sizeof);
                 }
@@ -2866,6 +2877,8 @@ static if (0)
     type *t = type_fake(TYint);
     t.Tmangle = mTYman_c;
     char *p = cast(char *)malloc(5 + strlen(scc.Sident.ptr) + 1);
+    if (!p)
+        err_nomem();
     strcpy(p, "SUPER");
     strcpy(p + 5, scc.Sident.ptr);
     Symbol *s_minfo_beg = symbol_name(p, SC.global, t);
@@ -2992,7 +3005,8 @@ int dwarf_eh_frame_fixup(int dfseg, targ_size_t offset, Symbol *s, targ_size_t v
     if (!pseg.SDrel)
     {
         pseg.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(pseg.SDrel);
+        if (!pseg.SDrel)
+            err_nomem();
     }
     pseg.SDrel.write(&rel, rel.sizeof);
 

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -280,7 +280,8 @@ Obj MsCoffObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegna
     if (!string_table)
     {
         string_table = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(string_table);
+        if (!string_table)
+            err_nomem();
         string_table.reserve(2048);
     }
     string_table.reset();
@@ -297,14 +298,16 @@ Obj MsCoffObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegna
     else
     {
         symbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(symbuf);
+        if (!symbuf)
+            err_nomem();
         symbuf.reserve((Symbol *).sizeof * SYM_TAB_INIT);
     }
 
     if (!syment_buf)
     {
         syment_buf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(syment_buf);
+        if (!syment_buf)
+            err_nomem();
         syment_buf.reserve(SymbolTable32.sizeof * SYM_TAB_INIT);
     }
     syment_buf.reset();
@@ -316,7 +319,8 @@ Obj MsCoffObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegna
     if (!ScnhdrBuf)
     {
         ScnhdrBuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(ScnhdrBuf);
+        if (!ScnhdrBuf)
+            err_nomem();
         ScnhdrBuf.reserve(SCNHDR_TAB_INITSIZE * (IMAGE_SECTION_HEADER).sizeof);
     }
     ScnhdrBuf.reset();
@@ -1462,7 +1466,8 @@ segidx_t MsCoffObj_getsegment2(IDXSEC shtidx)
         else
         {
             b1 = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-            assert(b1);
+            if (!b1)
+                err_nomem();
             b1.reserve(4096);
         }
         if (b2)
@@ -1478,7 +1483,8 @@ segidx_t MsCoffObj_getsegment2(IDXSEC shtidx)
 
         {
             pseg.SDbuf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-            assert(pseg.SDbuf);
+            if (!pseg.SDbuf)
+                err_nomem();
             pseg.SDbuf.reserve(4096);
         }
     }
@@ -2161,7 +2167,8 @@ void MsCoffObj_addrel(segidx_t seg, targ_size_t offset, Symbol *targsym,
     if (!pseg.SDrel)
     {
         pseg.SDrel = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(pseg.SDrel);
+        if (!pseg.SDrel)
+            err_nomem();
     }
     pseg.SDrel.write((&rel)[0 .. 1]);
 }
@@ -2342,7 +2349,8 @@ static if (0)
                 if (!indirectsymbuf2)
                 {
                     indirectsymbuf2 = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-                    assert(indirectsymbuf2);
+                    if (!indirectsymbuf2)
+                        err_nomem();
                 }
                 else
                 {   // Look through indirectsym to see if it is already there
@@ -2497,7 +2505,8 @@ void MsCoffObj_write_pointerRef(Symbol* s, uint soff)
     if (!ptrref_buf)
     {
         ptrref_buf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
-        assert(ptrref_buf);
+        if (!ptrref_buf)
+            err_nomem();
     }
 
     // defer writing pointer references until the symbols are written out

--- a/compiler/src/dmd/backend/symbol.d
+++ b/compiler/src/dmd/backend/symbol.d
@@ -88,7 +88,13 @@ else
 void struct_free(struct_t *st) { }
 
 @trusted
-func_t* func_calloc() { return cast(func_t *) calloc(1, func_t.sizeof); }
+func_t* func_calloc()
+{
+    func_t* f = cast(func_t *) calloc(1, func_t.sizeof);
+    if (!f)
+        err_nomem();
+    return f;
+}
 
 @trusted
 void func_free(func_t* f) { free(f); }


### PR DESCRIPTION
The trouble with using asserts for this is:

1. out of memory errors do happen
2. assert gives an unfriendly assert failure message
3. assert can be turned off with compiler switches

This doesn't address all of them, but is a good start.