### PR TITLE
add class ErrorStatement in ASTBase

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -2463,6 +2463,20 @@ struct ASTBase
         }
     }
 
+    extern (C++) final class ErrorStatement : Statement
+    {
+        extern (D) this()
+        {
+            super(Loc.initial, STMT.Error);
+            assert(global.gaggedErrors || global.errors);
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
     extern (C++) final class CompoundDeclarationStatement : CompoundStatement
     {
         final extern (D) this(const ref Loc loc, Statements* statements)


### PR DESCRIPTION
This is needed because it is currently used in parse.d, hence making the parser incompatible with ASTBase.