### PR TITLE
Fix 23386 - Segfault on enum member UDA inside template

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3168,9 +3168,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
                 if (udas)
                 {
-                    auto s = new AST.Dsymbols();
-                    s.push(em);
-                    auto uad = new AST.UserAttributeDeclaration(udas, s);
+                    auto uad = new AST.UserAttributeDeclaration(udas, new AST.Dsymbols());
                     em.userAttribDecl = uad;
                 }
 

--- a/compiler/test/compilable/test23386.d
+++ b/compiler/test/compilable/test23386.d
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=23386
+// Segfault on enum member UDA inside template
+
+template E()
+{
+    enum E : byte
+    {
+        @(1) none,
+    }
+}
+
+alias T = E!();


### PR DESCRIPTION
`EnumMember.syntaxCopy` calls `UserAttributeDeclaration.syntaxCopy` which will copy the `AttribDeclaration.decl` array, including the original `EnumMember`, resulting in endless recursion.

`Parameter.syntaxCopy` doesn't have this problem because the parser doesn't add the `Parameter` to the uda's `decl` list, and before https://github.com/dlang/dmd/pull/11527 neither did the parser add an `EnumMember` to the uda's `decl`. This PR restores the old behavior since it seems to be unrelated to the fix, though it's still not ideal that `syntaxCopy` doesn't protect against cycles in the AST.

Targeting master assuming stable is still closed (@ibuclaw)