### PR TITLE
fix Issue 23342 - ImportC: Array compound literals use the GC

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -3868,7 +3868,8 @@ elem* toElem(Expression e, IRState *irs)
         elem *e;
         if (dim > 0)
         {
-            if (tb.ty == Tsarray)
+            if (tb.ty == Tsarray ||
+                irs.Cfile && tb.ty == Tpointer)
             {
                 Symbol *stmp = null;
                 e = ExpressionsToStaticArray(irs, ale.loc, ale.elements, &stmp, 0, ale.basis);

--- a/compiler/src/dmd/printast.d
+++ b/compiler/src/dmd/printast.d
@@ -203,6 +203,13 @@ extern (C++) final class PrintASTVisitor : Visitor
         printf(".func: %s\n", e.func ? e.func.toChars() : "");
     }
 
+    override void visit(CompoundLiteralExp e)
+    {
+        visit(cast(Expression)e);
+        printIndent(indent + 2);
+        printf(".init: %s\n", e.initializer ? e.initializer.toChars() : "");
+    }
+
     static void printIndent(int indent)
     {
         foreach (i; 0 .. indent)

--- a/compiler/test/compilable/test23342.i
+++ b/compiler/test/compilable/test23342.i
@@ -1,0 +1,9 @@
+/* REQUIRED_ARGS: -betterC
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=23342
+
+void test()
+{
+    int* p = (int[]){4};
+}


### PR DESCRIPTION
Allocate them in a temporary on the stack instead.