### PR TITLE
Add test case for scope tuple expansion

### DIFF
--- a/compiler/test/compilable/scope_tuple_expansion.d
+++ b/compiler/test/compilable/scope_tuple_expansion.d
@@ -1,0 +1,21 @@
+// REQUIRED_ARGS: -preview=dip1000
+
+// Reduced from `std.systime`.
+// Tuple expansion can trip up scope checking with errors like:
+// Error: scope variable `__tup4` assigned to `found` with longer lifetime
+
+struct Tuple(T...)
+{
+    T t;
+    alias t this;
+}
+
+Tuple!(int*, int) find(return scope int* x) @safe
+{
+    assert(0);
+}
+
+void fromISOExtString(scope int* str) @safe
+{
+    int* found = str.find()[0];
+}


### PR DESCRIPTION
There's a check in escape.d `!(v.storage_class & STC.temp)` that is needed for tuple expansion currently. I want to change that at some point, but regressions should be caught by the test suite, not a Phobos unittest.