### PR TITLE
Cache TypeStruct hasXXX methods

### DIFF
--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -174,7 +174,7 @@ public:
     structalign_t alignment;    // alignment applied outside of the struct
     ThreeState ispod;           // if struct is POD
 private:
-    uint8_t bitFields;
+    uint16_t bitFields;
 public:
     static StructDeclaration *create(const Loc &loc, Identifier *id, bool inObject);
     StructDeclaration *syntaxCopy(Dsymbol *s) override;

--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -216,6 +216,10 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         bool hasIdentityEquals;     // true if has identity opEquals
         bool hasNoFields;           // has no fields
         bool hasCopyCtor;           // copy constructor
+        bool hasPointerField;       // members with indirections
+        bool hasVoidInitPointers;   // void-initialized unsafe fields
+        bool hasFieldWithInvariant; // invariants
+        bool computedTypeProperties;// the above 3 fields are computed
         // Even if struct is defined as non-root symbol, some built-in operations
         // (e.g. TypeidExp, NewExp, ArrayLiteralExp, etc) request its TypeInfo.
         // For those, today TypeInfo_Struct is generated in COMDAT.
@@ -223,7 +227,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     }
 
     import dmd.common.bitfields : generateBitFields;
-    mixin(generateBitFields!(BitFields, ubyte));
+    mixin(generateBitFields!(BitFields, ushort));
 
     extern (D) this(const ref Loc loc, Identifier id, bool inObject)
     {
@@ -391,7 +395,30 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             }
         }
 
+
         argTypes = target.toArgTypes(type);
+    }
+
+    /// Compute cached type properties for `TypeStruct`
+    extern(D) final void determineTypeProperties()
+    {
+        if (computedTypeProperties)
+            return;
+        foreach (vd; fields)
+        {
+            if (vd.storage_class & STC.ref_ || vd.hasPointers())
+                hasPointerField = true;
+
+            if (vd._init && vd._init.isVoidInitializer() && vd.type.hasPointers())
+                hasVoidInitPointers = true;
+
+            if (!vd._init && vd.type.hasVoidInitPointers())
+                hasVoidInitPointers = true;
+
+            if (vd.type.hasInvariant())
+                hasFieldWithInvariant = true;
+        }
+        computedTypeProperties = true;
     }
 
     /***************************************

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6307,10 +6307,18 @@ public:
     bool hasNoFields(bool v);
     bool hasCopyCtor() const;
     bool hasCopyCtor(bool v);
+    bool hasPointerField() const;
+    bool hasPointerField(bool v);
+    bool hasVoidInitPointers() const;
+    bool hasVoidInitPointers(bool v);
+    bool hasFieldWithInvariant() const;
+    bool hasFieldWithInvariant(bool v);
+    bool computedTypeProperties() const;
+    bool computedTypeProperties(bool v);
     bool requestTypeInfo() const;
     bool requestTypeInfo(bool v);
 private:
-    uint8_t bitFields;
+    uint16_t bitFields;
 public:
     static StructDeclaration* create(const Loc& loc, Identifier* id, bool inObject);
     StructDeclaration* syntaxCopy(Dsymbol* s) override;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -5532,52 +5532,25 @@ extern (C++) final class TypeStruct : Type
 
     override bool hasPointers()
     {
-        // Probably should cache this information in sym rather than recompute
-        StructDeclaration s = sym;
-
         if (sym.members && !sym.determineFields() && sym.type != Type.terror)
             error(sym.loc, "no size because of forward references");
 
-        foreach (VarDeclaration v; s.fields)
-        {
-            if (v.storage_class & STC.ref_ || v.hasPointers())
-                return true;
-        }
-        return false;
+        sym.determineTypeProperties();
+        return sym.hasPointerField;
     }
 
     override bool hasVoidInitPointers()
     {
-        // Probably should cache this information in sym rather than recompute
-        StructDeclaration s = sym;
-
         sym.size(Loc.initial); // give error for forward references
-        foreach (VarDeclaration v; s.fields)
-        {
-            if (v._init && v._init.isVoidInitializer() && v.type.hasPointers())
-                return true;
-            if (!v._init && v.type.hasVoidInitPointers())
-                return true;
-        }
-        return false;
+        sym.determineTypeProperties();
+        return sym.hasVoidInitPointers;
     }
 
     override bool hasInvariant()
     {
-        // Probably should cache this information in sym rather than recompute
-        StructDeclaration s = sym;
-
         sym.size(Loc.initial); // give error for forward references
-
-        if (s.hasInvariant())
-            return true;
-
-        foreach (VarDeclaration v; s.fields)
-        {
-            if (v.type.hasInvariant())
-                return true;
-        }
-        return false;
+        sym.determineTypeProperties();
+        return sym.hasInvariant() || sym.hasFieldWithInvariant;
     }
 
     extern (D) MATCH implicitConvToWithoutAliasThis(Type to)


### PR DESCRIPTION
Like the comment says: 
```
// Probably should cache this information in sym rather than recompute
```

`hasPointers` gets called a lot in escape.d. Also, for DIP 1035, structs need to keep track of `@system` variables being present, which this makes easier as well.