### PR TITLE
common/file.d fix malloc check

### DIFF
--- a/compiler/src/dmd/common/file.d
+++ b/compiler/src/dmd/common/file.d
@@ -144,9 +144,14 @@ struct FileMapping(Datum)
         import core.stdc.string : strlen;
         import core.stdc.stdlib : malloc;
         import core.stdc.string : memcpy;
-        auto totalNameLength = filename.strlen() + 1;
-        name = cast(char*) memcpy(malloc(totalNameLength), filename, totalNameLength);
-        name || assert(0, "FileMapping: Out of memory.");
+        const totalNameLength = filename.strlen() + 1;
+        auto namex = cast(char*) malloc(totalNameLength);
+        if (!namex)
+        {
+            fprintf(stderr, "FileMapping: Out of memory.");
+            exit(1);
+        }
+        name = cast(char*) memcpy(namex, filename, totalNameLength);
     }
 
     /**


### PR DESCRIPTION
This bad out of memory check was caught by @dkorpel

https://www.digitalmars.com/d/archives/digitalmars/D/Segmentation_fault_in_DMD_-_how_to_debug_364468.html#N364546