### PR TITLE
fix problem with .nounderscore on Ubuntu

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1906,8 +1906,7 @@ final class CParser(AST) : Parser!AST
                     {
                         auto str = asmName.peekString();
                         p.mangleOverride = str;
-//                      p.adFlags |= AST.VarDeclaration.nounderscore;
-                        p.adFlags |= 4; // cannot get above line to compile on Ubuntu
+                        p.adFlags |= AST.VarDeclaration.nounderscore;
                     }
                 }
                 s = applySpecifier(s, specifier);


### PR DESCRIPTION
This line wasn't compiling on the tester's Ubuntu, though it worked fine on my Ubuntu, on PR https://github.com/dlang/dmd/pull/14485

To move https://github.com/dlang/dmd/pull/14485 along, I replaced it with a literal. To find the problem, I put back the original line of code.