### PR TITLE
Fix Issue 23399 - OpenBSD: Teach druntime about new mimmutable(2) syscall

### DIFF
--- a/druntime/src/core/sys/openbsd/sys/mman.d
+++ b/druntime/src/core/sys/openbsd/sys/mman.d
@@ -47,5 +47,6 @@ static if (__BSD_VISIBLE)
 
     int madvise(void *, size_t, int);
     int minherit(void *, size_t, int);
+    int mimmutable(void *, size_t);
     void* mquery(void *, size_t, int, int, int, off_t);
 }


### PR DESCRIPTION
Teach druntime about the new OpenBSD mimmutable syscall.
https://github.com/openbsd/src/commit/8c7187e8f9910ee01579e69c0d0a30f2bd8a8769