### PR TITLE
fix Issue 23387 - ImportC: identical structs defined in two C files l…

### DIFF
--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -657,7 +657,24 @@ Symbol *toInitializer(AggregateDeclaration ad)
         else
         {
             auto stag = fake_classsym(Id.ClassInfo);
-            auto s = toSymbolX(ad, "__init", SC.extern_, stag.Stype, "Z");
+
+            Symbol* s;
+
+            Module m = ad.getModule();
+            if (m.filetype == FileType.c)
+            {
+                /* For ImportC structs, the module names are stripped from the mangled name.
+                 * This leads to name collisions. Add the module name back in.
+                 */
+                import dmd.common.outbuffer : OutBuffer;
+                OutBuffer buf;
+                buf.writestring("__init");
+                buf.writestring(m.toChars());
+                s = toSymbolX(ad, buf.peekChars(), SC.extern_, stag.Stype, "Z");
+            }
+            else
+                s = toSymbolX(ad, "__init", SC.extern_, stag.Stype, "Z");
+
             s.Sfl = FLextern;
             s.Sflags |= SFLnodebug;
             if (sd)

--- a/compiler/test/runnable/imports/freer.i
+++ b/compiler/test/runnable/imports/freer.i
@@ -1,0 +1,5 @@
+typedef struct Foo *FooRef;
+struct Foo {
+    int x;
+};
+void free_foo(FooRef foo) { }

--- a/compiler/test/runnable/imports/maker.i
+++ b/compiler/test/runnable/imports/maker.i
@@ -1,0 +1,5 @@
+typedef struct Foo *FooRef;
+struct Foo {
+    int x;
+};
+FooRef make_foo(void) { return 0; }

--- a/compiler/test/runnable/test23387.d
+++ b/compiler/test/runnable/test23387.d
@@ -1,0 +1,30 @@
+/* COMPILE_SEPARATELY:
+ * EXTRA_SOURCES: imports/maker.i imports/freer.i
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=23387
+
+/+ maker.i
+typedef struct Foo *FooRef;
+struct Foo {
+    int x;
+};
+FooRef make_foo(void);
++/
+import imports.maker;
+
+
+/+ freer.i
+typedef struct Foo *FooRef;
+struct Foo {
+    int x;
+};
+void free_foo(FooRef foo);
++/
+import imports.freer;
+
+int main(){
+    FooRef f = make_foo();
+    free_foo(f);
+    return 0;
+}

--- a/compiler/test/tools/d_do_test.d
+++ b/compiler/test/tools/d_do_test.d
@@ -1712,7 +1712,7 @@ int tryMain(string[] args)
             {
                 foreach (filename; testArgs.sources ~ (autoCompileImports ? null : testArgs.compiledImports))
                 {
-                    string newo = output_dir ~ envData.sep ~ replace(filename.baseName(), ".d", envData.obj);
+                    string newo = output_dir ~ envData.sep ~ filename.baseName().setExtension(envData.obj);
                     toCleanup ~= newo;
 
                     command = format("%s -conf= -m%s -I%s %s %s -od%s -c %s %s", envData.dmd, envData.model, input_dir,


### PR DESCRIPTION
…ead to duplicate .init symbol on macOS

Note that the test should should compile them separately:
```
dmd imports/maker.i -c
dmd imports/freer.i -c
dmd test23387.d -c
dmd test23387.o freer.o maker.o
```
But I don't see a way to do that with the test runner.