### PR TITLE
support integer simd equality comparison

### DIFF
--- a/compiler/src/dmd/backend/cgxmm.d
+++ b/compiler/src/dmd/backend/cgxmm.d
@@ -187,7 +187,7 @@ void orthxmm(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     /* We should take advantage of mem addressing modes for OP XMM,MEM
      * but we do not at the moment.
      */
-    if (OTrel(e.Eoper))
+    if (OTrel(e.Eoper) && !tyvector(tybasic(e.Ety)))
     {
         cdb.gen2(op,modregxrmx(3,rreg-XMM0,reg-XMM0));
         checkSetVex(cdb.last(), e1.Ety);
@@ -1057,6 +1057,8 @@ private opcode_t xmmoperator(tym_t tym, OPER oper)
         case OPnue:
             switch (tym)
             {
+                case TYlong4:   op = PCMPEQD;  break;
+
                 case TYfloat:
                 case TYifloat:  op = UCOMISS;  break;
                 case TYdouble:

--- a/compiler/src/dmd/backend/cod4.d
+++ b/compiler/src/dmd/backend/cod4.d
@@ -2556,6 +2556,9 @@ void cdcmp(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         return;
     }
 
+    if (tyvector(tybasic(e1.Ety)))
+        return orthxmm(cdb,e,pretregs);
+
     uint jop = jmpopcode(e);        // must be computed before
                                         // leaves are free'd
     uint reverse = 0;

--- a/compiler/src/dmd/backend/gother.d
+++ b/compiler/src/dmd/backend/gother.d
@@ -358,7 +358,7 @@ private void conpropwalk(elem *n,vec_t IN)
             case OPne:
             case OPeqeq:
                 // Collect compare elems and their rd's in the rellist list
-                if (tyintegral(n.EV.E1.Ety))
+                if (tyintegral(n.EV.E1.Ety) && !tyvector(n.Ety))
                 {   //printf("appending to eqeqlist\n"); elem_print(n);
                     auto pdata = eqeqlist.push();
                     pdata.emplace(n,thisblock);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12081,6 +12081,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
+        if (t1.isTypeVector())
+            exp.type = t1;
+
         result = exp;
     }
 

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -583,8 +583,12 @@ extern (C++) struct Target
             }
             break;
 
-        case EXP.lessThan, EXP.greaterThan, EXP.lessOrEqual, EXP.greaterOrEqual, EXP.equal, EXP.notEqual, EXP.identity, EXP.notIdentity:
+        case EXP.lessThan, EXP.greaterThan, EXP.lessOrEqual, EXP.greaterOrEqual, EXP.notEqual, EXP.identity, EXP.notIdentity:
             supported = false;
+            break;
+
+        case EXP.equal:
+            supported = true;
             break;
 
         case EXP.leftShift, EXP.leftShiftAssign, EXP.rightShift, EXP.rightShiftAssign, EXP.unsignedRightShift, EXP.unsignedRightShiftAssign:

--- a/compiler/test/fail_compilation/fail10905.d
+++ b/compiler/test/fail_compilation/fail10905.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -m64
 TEST_OUTPUT:
 ---
-fail_compilation/fail10905.d(20): Error: incompatible types for `(this.x) == (cast(const(__vector(long[2])))cast(__vector(long[2]))1L)`: both operands are of type `const(__vector(long[2]))`
+fail_compilation/fail10905.d(20): Error: incompatible types for `(this.x) != (cast(const(__vector(long[2])))cast(__vector(long[2]))1L)`: both operands are of type `const(__vector(long[2]))`
 ---
 */
 
@@ -17,6 +17,6 @@ struct Bar
 
     bool spam() const
     {
-        return x == Foo.y;
+        return x != Foo.y;
     }
 }

--- a/compiler/test/runnable/testxmm.d
+++ b/compiler/test/runnable/testxmm.d
@@ -129,7 +129,7 @@ void test1()
     static assert(!__traits(compiles, v1 ^^ v2));
     static assert(!__traits(compiles, v1 is v2));
     static assert(!__traits(compiles, v1 !is v2));
-    static assert(!__traits(compiles, v1 == v2));
+    static assert( __traits(compiles, v1 == v2));
     static assert(!__traits(compiles, v1 != v2));
     static assert(!__traits(compiles, v1 < v2));
     static assert(!__traits(compiles, v1 > v2));
@@ -189,7 +189,7 @@ void test2()
     static assert(!__traits(compiles, v1 ^^ v2));
     static assert(!__traits(compiles, v1 is v2));
     static assert(!__traits(compiles, v1 !is v2));
-    static assert(!__traits(compiles, v1 == v2));
+    static assert( __traits(compiles, v1 == v2));
     static assert(!__traits(compiles, v1 != v2));
     static assert(!__traits(compiles, v1 < v2));
     static assert(!__traits(compiles, v1 > v2));
@@ -249,7 +249,7 @@ void test2b()
     static assert(!__traits(compiles, v1 ^^ v2));
     static assert(!__traits(compiles, v1 is v2));
     static assert(!__traits(compiles, v1 !is v2));
-    static assert(!__traits(compiles, v1 == v2));
+    static assert( __traits(compiles, v1 == v2));
     static assert(!__traits(compiles, v1 != v2));
     static assert(!__traits(compiles, v1 < v2));
     static assert(!__traits(compiles, v1 > v2));
@@ -309,7 +309,7 @@ void test2c()
     static assert(!__traits(compiles, v1 ^^ v2));
     static assert(!__traits(compiles, v1 is v2));
     static assert(!__traits(compiles, v1 !is v2));
-    static assert(!__traits(compiles, v1 == v2));
+    static assert( __traits(compiles, v1 == v2));
     static assert(!__traits(compiles, v1 != v2));
     static assert(!__traits(compiles, v1 < v2));
     static assert(!__traits(compiles, v1 > v2));
@@ -370,7 +370,7 @@ void test2d()
     static assert(!__traits(compiles, v1 ^^ v2));
     static assert(!__traits(compiles, v1 is v2));
     static assert(!__traits(compiles, v1 !is v2));
-    static assert(!__traits(compiles, v1 == v2));
+    static assert( __traits(compiles, v1 == v2));
     static assert(!__traits(compiles, v1 != v2));
     static assert(!__traits(compiles, v1 < v2));
     static assert(!__traits(compiles, v1 > v2));
@@ -433,7 +433,7 @@ void test2e()
     static assert(!__traits(compiles, v1 ^^ v2));
     static assert(!__traits(compiles, v1 is v2));
     static assert(!__traits(compiles, v1 !is v2));
-    static assert(!__traits(compiles, v1 == v2));
+    static assert( __traits(compiles, v1 == v2));
     static assert(!__traits(compiles, v1 != v2));
     static assert(!__traits(compiles, v1 < v2));
     static assert(!__traits(compiles, v1 > v2));
@@ -499,7 +499,7 @@ void test2f()
     static assert(!__traits(compiles, v1 ^^ v2));
     static assert(!__traits(compiles, v1 is v2));
     static assert(!__traits(compiles, v1 !is v2));
-    static assert(!__traits(compiles, v1 == v2));
+    static assert( __traits(compiles, v1 == v2));
     static assert(!__traits(compiles, v1 != v2));
     static assert(!__traits(compiles, v1 < v2));
     static assert(!__traits(compiles, v1 > v2));
@@ -562,7 +562,7 @@ void test2g()
     static assert(!__traits(compiles, v1 ^^ v2));
     static assert(!__traits(compiles, v1 is v2));
     static assert(!__traits(compiles, v1 !is v2));
-    static assert(!__traits(compiles, v1 == v2));
+    static assert( __traits(compiles, v1 == v2));
     static assert(!__traits(compiles, v1 != v2));
     static assert(!__traits(compiles, v1 < v2));
     static assert(!__traits(compiles, v1 > v2));
@@ -622,7 +622,7 @@ void test2h()
     static assert(!__traits(compiles, v1 ^^ v2));
     static assert(!__traits(compiles, v1 is v2));
     static assert(!__traits(compiles, v1 !is v2));
-    static assert(!__traits(compiles, v1 == v2));
+    static assert( __traits(compiles, v1 == v2));
     static assert(!__traits(compiles, v1 != v2));
     static assert(!__traits(compiles, v1 < v2));
     static assert(!__traits(compiles, v1 > v2));
@@ -682,7 +682,7 @@ void test2i()
     static assert(!__traits(compiles, v1 ^^ v2));
     static assert(!__traits(compiles, v1 is v2));
     static assert(!__traits(compiles, v1 !is v2));
-    static assert(!__traits(compiles, v1 == v2));
+    static assert( __traits(compiles, v1 == v2));
     static assert(!__traits(compiles, v1 != v2));
     static assert(!__traits(compiles, v1 < v2));
     static assert(!__traits(compiles, v1 > v2));
@@ -742,7 +742,7 @@ void test2j()
     static assert(!__traits(compiles, v1 ^^ v2));
     static assert(!__traits(compiles, v1 is v2));
     static assert(!__traits(compiles, v1 !is v2));
-    static assert(!__traits(compiles, v1 == v2));
+    static assert( __traits(compiles, v1 == v2));
     static assert(!__traits(compiles, v1 != v2));
     static assert(!__traits(compiles, v1 < v2));
     static assert(!__traits(compiles, v1 > v2));

--- a/compiler/test/runnable/testxmm2.d
+++ b/compiler/test/runnable/testxmm2.d
@@ -44,9 +44,30 @@ int4 cmpss_repro(float4 a)
 
 /*****************************************/
 
+void testeq()
+{
+    static int4 testeq(int4 x, int4 y)
+    {
+        return x == y;
+    }
+
+    int4 x = [1,2,3,4];
+    int4 y = [4,3,2,1];
+    int4 t = [-1, -1, -1, -1];
+    int4 f = [0,0,0,0];
+    int4 z = testeq(x, x);
+    assert(x[] == x[]);
+    assert(z[] == t[]);
+    z = testeq(x, y);
+    assert(z[] == f[]);
+}
+
+/*****************************************/
+
 int main()
 {
     test21474();
+    testeq();
 
     return 0;
 }


### PR DESCRIPTION
Using == with simd vectors is not supported. But it should be. This is the first step, making it work with `int4` vectors.