### PR TITLE
Fix Issue 23406 - [seg fault] enums can cause compile time seg faults with assignments using alias this

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -8932,7 +8932,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.e1 = e1x;
             assert(exp.e1.type);
         }
-        Type t1 = exp.e1.type.toBasetype();
+        Type t1 = exp.e1.type.isTypeEnum() ? exp.e1.type : exp.e1.type.toBasetype();
 
         /* Run this.e2 semantic.
          * Different from other binary expressions, the analysis of e2

--- a/compiler/test/fail_compilation/fail23406.d
+++ b/compiler/test/fail_compilation/fail23406.d
@@ -1,0 +1,40 @@
+// https://issues.dlang.org/show_bug.cgi?id=23406
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23406.d(39): Error: cannot implicitly convert expression `0` of type `int` to `alphakey`
+---
+*/
+
+struct flagenum
+{
+    int i = 1;
+    alias i this;
+
+    auto opBinary(string s)(int j)
+    {
+        assert(j == 1);
+        return typeof(this)(i*2);
+    }
+
+    auto opEquals(int a)
+    {
+        return false;
+    }
+}
+
+enum alphakey
+{
+    a = flagenum(),
+    b,c,d,e,f,g,h,i,
+    k,l,m,n,o,p,q,r,
+    s,t,u,v,w,x,y,z
+}
+
+alphakey alpha;
+
+void main()
+{
+    alpha = 0;
+}


### PR DESCRIPTION
```d
struct flagenum
{
    int i = 1;
    alias i this;

    auto opBinary(string s)(int j)
    {
        assert(j == 1); 
        return typeof(this)(i*2);
    }

    auto opEquals(int a)
    {
        return false;
    }
}

enum alphakey
{
    a = flagenum(),
    b,c,d,e,f,g,h,i,
    k,l,m,n,o,p,q,r,
    s,t,u,v,w,x,y,z
}

alphakey alpha;

void main()
{
    alpha = 0;
}
```

The problem here is that when the compiler sees `alpha = 0` it thinks that the type of alpha is `flagenum` and therefore tries to rewrite to `alpha.i = 0` which obviously makes no sense. The patch makes it so that when an enum type is the `lhs` of an assign expression, do not the peel off the enum type. `alpha` should be seen as being of type `alphakey` not `flagenum`.

Prior to this patch, if `i` was not a member of `alphakey` then the code would have compiled, but that does not make any sense. Firstly, because the spec explicitly states that "EnumBaseType types cannot be implicitly cast to an enum type" [1]. Secondly, because we cannot use the methods of the enum base type when using the enum.

[1] https://dlang.org/spec/enum.html - point 5