### PR TITLE
Deprecate adding functions with different access specifiers in the same overload set

### DIFF
--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -395,6 +395,16 @@ private extern(C++) final class Semantic2Visitor : Visitor
                 if (linkage1 != f2.resolvedLinkage())
                     return 0;
 
+                if (f1.visibility.kind != f2.visibility.kind)
+                {
+                    deprecation(f1.loc, "overload set `%s` cannot contain functions with different access specifiers", f1.toChars());
+                    deprecationSupplemental(f1.loc, "function `%s` has access specifier `%s`", f1.toPrettyChars(), visibilityToChars(f1.visibility.kind));
+                    deprecationSupplemental(f2.loc, "function `%s` has access specifier `%s`", f2.toPrettyChars(), visibilityToChars(f2.visibility.kind));
+                    auto fd_tmp = f1.visibility.kind < f2.visibility.kind ? f1 : f2;
+                    deprecationSupplemental(fd_tmp.loc, "renaming `%s` will fix this", fd_tmp.toPrettyChars());
+                    return 0;
+                }
+
                 // Functions with different names never conflict
                 // (they can form overloads sets introduced by an alias)
                 if (f1.ident != f2.ident)


### PR DESCRIPTION
Backlog:

While trying to fix: https://issues.dlang.org/show_bug.cgi?id=3254 I have stumbled upon the fact that it is hard/impossible to fix it as long as public aliases to private symbols are allowed. I presented this issue to @WalterBright and @acehreli and they both suggested that having private symbols in the same overload set with public symbols does not make any sense. So here is the  PR.

Currently this PR is pretty blunt: if the overloads have different access specifiers, the deprecation is issued. Also, it does not currently test for template declarations. That can be added in a future PR if we decide to go on with this.

Let's see the amount of breakage that this causes.