### PR TITLE
Fix Issues 23408 and 23403 - __FUNCTION__ does not resolve properly

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -3369,6 +3369,17 @@ extern (C++) final class StructLiteralExp : Expression
             return Expression.toLvalue(sc, e);
     }
 
+    override Expression resolveLoc(const ref Loc loc, Scope* sc)
+    {
+        for (int i = 0; i < (*elements).length; i++)
+        {
+            auto elem = (*elements)[i];
+            if (elem)
+                (*elements)[i] = elem.resolveLoc(loc, sc);
+        }
+        return this;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -4282,7 +4293,7 @@ extern (C++) abstract class UnaExp : Expression
 
     }
 
-    override final Expression resolveLoc(const ref Loc loc, Scope* sc)
+    override Expression resolveLoc(const ref Loc loc, Scope* sc)
     {
         e1 = e1.resolveLoc(loc, sc);
         return this;
@@ -5164,6 +5175,16 @@ extern (C++) final class CallExp : UnaExp
         return this;
     }
 
+    override Expression resolveLoc(ref const Loc loc, Scope* sc)
+    {
+        for (int i = 0; i < arguments.length; i++)
+        {
+            auto arg = (*arguments)[i];
+            if (arg)
+                (*arguments)[i] = arg.resolveLoc(loc, sc);
+        }
+        return this;
+    }
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1789,15 +1789,6 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                 arguments.push(arg);
                 nargs++;
             }
-            else
-            {
-                if (isDefaultInitOp(arg.op))
-                {
-                    arg = arg.resolveLoc(loc, sc);
-                    (*arguments)[i] = arg;
-                }
-            }
-
 
             if (tf.parameterList.varargs == VarArg.typesafe && i + 1 == nparams) // https://dlang.org/spec/function.html#variadic
             {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6937,6 +6937,7 @@ public:
     int32_t getFieldIndex(Type* type, uint32_t offset);
     Expression* addDtorHook(Scope* sc) override;
     Expression* toLvalue(Scope* sc, Expression* e) override;
+    Expression* resolveLoc(const Loc& loc, Scope* sc) override;
     void accept(Visitor* v) override;
 };
 
@@ -7108,7 +7109,7 @@ public:
     UnaExp* syntaxCopy() override;
     Expression* incompatibleTypes();
     void setNoderefOperand();
-    Expression* resolveLoc(const Loc& loc, Scope* sc) final override;
+    Expression* resolveLoc(const Loc& loc, Scope* sc) override;
     void accept(Visitor* v) override;
 };
 
@@ -7240,6 +7241,7 @@ public:
     bool isLvalue() override;
     Expression* toLvalue(Scope* sc, Expression* e) override;
     Expression* addDtorHook(Scope* sc) override;
+    Expression* resolveLoc(const Loc& loc, Scope* sc) override;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/test/runnable/test18916.d
+++ b/compiler/test/runnable/test18916.d
@@ -11,7 +11,7 @@ struct Line
 
 void foo(Line line1 = __LINE__, int line2 = __LINE__, int line3 = int(__LINE__))
 {
-    assert(line1 == 12);
+    assert(line1 == 21);
     assert(line2 == 21);
     assert(line3 == 12);
 }

--- a/compiler/test/runnable/testFUNCTION.d
+++ b/compiler/test/runnable/testFUNCTION.d
@@ -1,0 +1,27 @@
+// https://issues.dlang.org/show_bug.cgi?id=23403
+struct Context
+{
+    string pretty_function;
+}
+
+void test23403(Context ctx = Context(__FUNCTION__))
+{
+    assert(ctx.pretty_function == "testFUNCTION.main");
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=23408
+string foo(string arg)
+{
+    return arg;
+}
+
+void test23408(string s = foo(__FUNCTION__))
+{
+    assert(s == "testFUNCTION.main");
+}
+
+void main()
+{
+    test23403();
+    test23408();
+}


### PR DESCRIPTION
Properly resolves `__FUNCTION__` and folks by adding `resolveLoc` for `StructLiteralExp` and `CallExp`. The new `resolveLoc` overrides call `resolveLoc` on the arguments of the 2 AST constructions.

I am not targeting stable because this is blocking @teodutu from implementing the array concatenation template hook and lowering (which target master).