### PR TITLE
make: Put windows build files in the toplevel generated directory

### DIFF
--- a/druntime/mak/WINDOWS
+++ b/druntime/mak/WINDOWS
@@ -6,11 +6,11 @@ import: copy
 
 copydir: $(IMPDIR)
 
-copy: generated\windows\copyimports.exe
-	@~generated\windows\copyimports.exe $(COPY)
+copy: ..\generated\windows\copyimports.exe
+	@~..\generated\windows\copyimports.exe $(COPY)
 
-generated\windows\copyimports.exe: mak\copyimports.d generated\windows\host_dmd.bat
-	generated\windows\host_dmd.bat -of=$@ -m$(MODEL) mak\copyimports.d
+..\generated\windows\copyimports.exe: mak\copyimports.d ..\generated\windows\host_dmd.bat
+	..\generated\windows\host_dmd.bat -of=$@ -m$(MODEL) mak\copyimports.d
 
 # find a host dmd on the different CI systems
 # - auto-tester: 2.079 installed, but not exposed to the druntime build
@@ -19,9 +19,9 @@ generated\windows\copyimports.exe: mak\copyimports.d generated\windows\host_dmd.
 # - azure-vs: $(DMD_DIR)\dmd2\Windows\bin\dmd.exe
 ATCLIENT_DMD = ../../release-build/dmd-2.079.0/windows/bin/dmd.exe
 
-generated\windows\host_dmd.bat:
-	+if not exist generated md generated
-	+if not exist generated\windows md generated\windows
+..\generated\windows\host_dmd.bat:
+	+if not exist ..\generated md ..\generated
+	+if not exist ..\generated\windows md ..\generated\windows
 	-+if exist "$(ATCLIENT_DMD)" (echo @"$(ATCLIENT_DMD)" %* >$@)
 	-+if not "$(DMD_DIR)"  == "" ("$(DMD_DIR)\dmd2\Windows\bin\dmd.exe" --version >nul 2>&1 && echo @"$(DMD_DIR)\dmd2\Windows\bin\dmd.exe" %* >$@)
 	-+if not "$(HOST_DC)"  == "" ("$(HOST_DC)"  --version >nul 2>&1 && echo @"$(HOST_DC)" %* >$@)


### PR DESCRIPTION
The druntime one doesn't get cleaned up with `make clean`.