### PR TITLE
use PXOR to zero an XMM register

### DIFF
--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -5391,6 +5391,16 @@ void loaddata(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
         if (sz == 8)
             value = cast(targ_size_t)e.EV.Vullong;
 
+        if (tyvector(tym) && forregs & XMMREGS)
+        {
+            assert(!flags);
+            reg_t xreg;
+            allocreg(cdb, &forregs, &xreg, tym);     // allocate registers
+            movxmmconst(cdb, xreg, sz, value, flags);
+            fixresult(cdb, e, forregs, pretregs);
+            return;
+        }
+
         if (sz == REGSIZE && reghasvalue(forregs, value, &reg))
             forregs = mask(reg);
 

--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -617,6 +617,8 @@ void cod5_noprol();
 
 /* cgxmm.c */
 bool isXMMstore(opcode_t op);
+@trusted
+void movxmmconst(ref CodeBuilder cdb, reg_t xreg, uint sz, targ_size_t value, regm_t flags);
 void orthxmm(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void xmmeq(ref CodeBuilder cdb, elem *e, opcode_t op, elem *e1, elem *e2, regm_t *pretregs);
 void xmmcnvt(ref CodeBuilder cdb,elem *e,regm_t *pretregs);

--- a/compiler/src/dmd/backend/code_x86.d
+++ b/compiler/src/dmd/backend/code_x86.d
@@ -580,3 +580,4 @@ void getlvalue_msw(code *);
 void getlvalue_lsw(code *);
 void getlvalue(ref CodeBuilder cdb, code *pcs, elem *e, regm_t keepmsk);
 void loadea(ref CodeBuilder cdb, elem *e, code *cs, uint op, uint reg, targ_size_t offset, regm_t keepmsk, regm_t desmsk);
+bool loadxmmconst(elem* e);

--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -1576,11 +1576,8 @@ elem *el_convxmm(elem *e)
     ubyte[eve.sizeof] buffer = void;
 
     // Do not convert if the constants can be loaded with the special XMM instructions
-static if (0)
-{
-    if (loadconst(e))
+    if (loadxmmconst(e))
         return e;
-}
 
     go.changes++;
     tym_t ty = e.Ety;


### PR DESCRIPTION
This uses PXOR to zero an XMM register, rather than loading a 0 from a memory location. The PXOR is much faster.