### PR TITLE
remove potential overflow from binary search

### DIFF
--- a/compiler/src/dmd/backend/dvarstats.d
+++ b/compiler/src/dmd/backend/dvarstats.d
@@ -374,12 +374,12 @@ private targ_size_t getLineOffset(int linnum)
 // return the first record index in the lineOffsets array with linnum >= line
 private int findLineIndex(uint line)
 {
-    int low = 0;
-    int high = cast(int)lineOffsets.length;
+    uint low = 0;
+    uint high = cast(uint)lineOffsets.length;
     while (low < high)
     {
-        int mid = (low + high) >> 1;
-        int ln = lineOffsets[mid].linnum;
+        uint mid = low + ((high - low) >> 1);
+        uint ln = lineOffsets[mid].linnum;
         if (line < ln)
             high = mid;
         else if (line > ln)

--- a/compiler/src/dmd/backend/ptrntab.d
+++ b/compiler/src/dmd/backend/ptrntab.d
@@ -5833,14 +5833,14 @@ extern (C++) OP *asm_op_lookup(const(char)* s)
 @trusted
 private int binary(const(char)* p, const OP[] table)
 {
-    int low = 0;
+    uint low = 0;
     char cp = *p;
-    int high = cast(int)(table.length) - 1;
+    uint high = cast(uint)(table.length) - 1;
     p++;
 
     while (low <= high)
     {
-        const mid = (low + high) >> 1;
+        const mid = low + ((high - low) >> 1);
         int cond = table[mid].str[0] - cp;
         if (cond == 0)
             cond = strcmp(table[mid].str.ptr + 1,p);

--- a/compiler/src/dmd/backend/util2.d
+++ b/compiler/src/dmd/backend/util2.d
@@ -217,7 +217,7 @@ else
 
     while (low <= high)
     {
-        int mid = (low + high) >> 1;
+        int mid = low + ((high - low) >> 1);
         int cond = table[mid][0] - cp;
         if (cond == 0)
             cond = strcmp(table[mid] + 1,p);
@@ -245,7 +245,7 @@ int binary(const(char)* p, size_t len, const(char)** table, int high)
 
     while (low <= high)
     {
-        int mid = (low + high) >> 1;
+        int mid = low + ((high - low) >> 1);
         int cond = table[mid][0] - cp;
 
         if (cond == 0)

--- a/compiler/src/dmd/root/utf.d
+++ b/compiler/src/dmd/root/utf.d
@@ -288,7 +288,7 @@ bool isUniAlpha(dchar c)
     // Binary search
     while (low <= high)
     {
-        size_t mid = (low + high) >> 1;
+        const size_t mid = low + ((high - low) >> 1);
         if (c < ALPHA_TABLE[mid][0])
             high = mid - 1;
         else if (ALPHA_TABLE[mid][1] < c)


### PR DESCRIPTION
It would be very hard to trigger these, but it's just good practice to not have code that might overflow.

Idea is from https://github.com/viperproject/prusti-dev