### PR TITLE
Enable `-preview=in` by default in the standard library 

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -934,6 +934,8 @@ extern (C++) final class Module : Package
          * Ignore prevsc.
          */
         Scope* sc = Scope.createGlobal(this); // create root scope
+        if (global.params.previewIn || this.isStandardLibrary())
+            sc.flags |= SCOPE.previewIn;
 
         if (md && md.msg)
             md.msg = semanticString(sc, md.msg, "deprecation message");
@@ -1233,6 +1235,22 @@ extern (C++) final class Module : Package
     bool isCoreModule(Identifier ident) nothrow
     {
         return this.ident == ident && parent && parent.ident == Id.core && !parent.parent;
+    }
+
+    /// Returns: `true` if this module is in the standard library (druntime or Phobos)
+    final bool isStandardLibrary () const scope @trusted nothrow @nogc
+    {
+        if (this.parent is null)
+            return this.ident == Id.object;
+        const(Dsymbol)* rootPkg = &this.parent;
+        while (rootPkg.parent !is null)
+            rootPkg = &rootPkg.parent;
+
+        if (rootPkg.ident == Id.core)
+            return true;
+        if (rootPkg.ident == Id.etc)
+            return true;
+        return rootPkg.ident == Id.std;
     }
 
     // Back end

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1229,8 +1229,7 @@ extern (C++) final class Module : Package
         return this.importedFrom == this;
     }
 
-    // true if the module source file is directly
-    // listed in command line.
+    /// Returns: Whether this module is in the `core` package and has name `ident`
     bool isCoreModule(Identifier ident) nothrow
     {
         return this.ident == ident && parent && parent.ident == Id.core && !parent.parent;

--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -65,13 +65,17 @@ enum SCOPE
 
     fullinst      = 0x10000,  /// fully instantiate templates
     ctfeBlock     = 0x20000,  /// inside a `if (__ctfe)` block
+
+    /// `-preview=in` changes the ABI, thus it is scope-specific to allow
+    /// enabling it by default on druntime / Phobos, which we distribute compiled
+    previewIn     = 0x10_0000,
 }
 
 /// Flags that are carried along with a scope push()
 private enum PersistentFlags =
     SCOPE.contract | SCOPE.debug_ | SCOPE.ctfe | SCOPE.compile | SCOPE.constraint |
     SCOPE.noaccesscheck | SCOPE.ignoresymbolvisibility |
-    SCOPE.Cfile | SCOPE.ctfeBlock;
+    SCOPE.Cfile | SCOPE.ctfeBlock | SCOPE.previewIn;
 
 extern (C++) struct Scope
 {

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -774,7 +774,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         // At this point we can add `scope` to the STC instead of `in`,
         // because we are never going to use this variable's STC for user messages
-        if (dsym.storage_class & STC.in_ && global.params.previewIn)
+        if (dsym.storage_class & STC.in_)
             dsym.storage_class |= STC.scope_;
 
         if (dsym.storage_class & STC.scope_)

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -3268,6 +3268,7 @@ private void parameterToBuffer(Parameter p, OutBuffer* buf, HdrGenState* hgs)
     if (p.storageClass & STC.in_)
     {
         buf.writestring("in ");
+        // Note: This is not correct for standard library modules
         if (global.params.previewIn && p.storageClass & STC.ref_)
             stc &= ~STC.ref_;
     }

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -7381,7 +7381,7 @@ private extern(D) MATCH argumentMatchParameter (TypeFunction tf, Parameter p,
                     ta = tn.sarrayOf(dim);
                 }
             }
-            else if ((p.storageClass & STC.in_) && global.params.previewIn)
+            else if ((p.storageClass & STC.in_) && (sc.flags & SCOPE.previewIn))
             {
                 // Allow converting a literal to an `in` which is `ref`
                 if (arg.op == EXP.arrayLiteral && tp.ty == Tsarray)

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4415,7 +4415,7 @@ extern (C++) final class TypeFunction : TypeNext
         auto stc = p.storageClass;
 
         // When the preview switch is enable, `in` parameters are `scope`
-        if (stc & STC.in_ && global.params.previewIn)
+        if (stc & STC.in_)
             return stc | STC.scope_;
 
         if (stc & (STC.scope_ | STC.return_ | STC.lazy_) || purity == PURE.impure)
@@ -6884,28 +6884,23 @@ extern (C++) final class Parameter : ASTNode
      * Params:
      *  returnByRef = true if the function returns by ref
      *  p = Parameter to compare with
-     *  previewIn = Whether `-preview=in` is being used, and thus if
-     *              `in` means `scope [ref]`.
      *
      * Returns:
      *  true = `this` can be used in place of `p`
      *  false = nope
      */
-    bool isCovariant(bool returnByRef, const Parameter p, bool previewIn = global.params.previewIn)
+    bool isCovariant(bool returnByRef, const Parameter p)
         const pure nothrow @nogc @safe
     {
         ulong thisSTC = this.storageClass;
         ulong otherSTC = p.storageClass;
 
-        if (previewIn)
-        {
-            if (thisSTC & STC.in_)
-                thisSTC |= STC.scope_;
-            if (otherSTC & STC.in_)
-                otherSTC |= STC.scope_;
-        }
+        if (thisSTC & STC.in_)
+            thisSTC |= STC.scope_;
+        if (otherSTC & STC.in_)
+            otherSTC |= STC.scope_;
 
-        const mask = STC.ref_ | STC.out_ | STC.lazy_ | (previewIn ? STC.in_ : 0);
+        const mask = STC.ref_ | STC.out_ | STC.lazy_ | STC.in_;
         if ((thisSTC & mask) != (otherSTC & mask))
             return false;
         return isCovariantScope(returnByRef, thisSTC, otherSTC);

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1084,7 +1084,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
             // default arg must be an lvalue
             if (isRefOrOut && !isAuto &&
-                !(global.params.previewIn && (fparam.storageClass & STC.in_)) &&
+                !((sc.flags & SCOPE.previewIn) && (fparam.storageClass & STC.in_)) &&
                 global.params.rvalueRefParam != FeatureState.enabled)
                 e = e.toLvalue(sc, e);
 
@@ -1185,7 +1185,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
                 // -preview=in: Always add `ref` when used with `extern(C++)` functions
                 // Done here to allow passing opaque types with `in`
-                if (global.params.previewIn && (fparam.storageClass & (STC.in_ | STC.ref_)) == STC.in_)
+                if ((sc.flags & SCOPE.previewIn) && (fparam.storageClass & (STC.in_ | STC.ref_)) == STC.in_)
                 {
                     switch (tf.linkage)
                     {
@@ -1214,7 +1214,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                     if (tb2.ty == Tstruct && !tb2.isTypeStruct().sym.members ||
                         tb2.ty == Tenum   && !tb2.isTypeEnum().sym.memtype)
                     {
-                        if (global.params.previewIn && (fparam.storageClass & STC.in_))
+                        if ((sc.flags & SCOPE.previewIn) && (fparam.storageClass & STC.in_))
                         {
                             .error(loc, "cannot infer `ref` for `in` parameter `%s` of opaque type `%s`",
                                    fparam.toChars(), fparam.type.toChars());
@@ -1318,7 +1318,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                 fparam.storageClass &= ~(STC.TYPECTOR);
 
                 // -preview=in: add `ref` storage class to suited `in` params
-                if (global.params.previewIn && (fparam.storageClass & (STC.in_ | STC.ref_)) == STC.in_)
+                if ((sc.flags & SCOPE.previewIn) && (fparam.storageClass & (STC.in_ | STC.ref_)) == STC.in_)
                 {
                     auto ts = t.baseElemOf().isTypeStruct();
                     const isPOD = !ts || ts.sym.isPOD();


### PR DESCRIPTION
This builds on the idea I mentioned in the past, of having `pragma(preview, "feature")` in modules.
However, I was never really found of the idea, as it risked balkanizing the language. Walter shared similar concerns.
So the approach this takes is to allow compiler devs to implement a feature similar to `pragma(preview)` without exposing it to the user.

While doing so, I originally had to fight to make it work for the `scope`ness, because those changes are much more invasive. Separating the two concerns reduces the patch to almost nothing, so I think that's a clear win.

Let's see what the CI has to say.

```
Because the standard library (Phobos / druntime) are distributed compiled,
we have a recurent problem with build flags: User-supplied build flags,
such as `-version`, `-{debug,release}`, or `-preview` have no effect on
the generated code, but may affect semantic analysis.

This was particularly problematic when DIP1000 was implemented,
as it originally changed the mangling, leading to years where the switch
was unusable. This new approach attempts to circumvent the problem
by having scope-specific flags which will allow turning on a feature
in the standard library independently of what user code does.

Currently, this has no effect: When `-preview=in` was implemented,
all places where it could turn into `ref` were stripped, to prevent
the issue from creeping early adopters. However, in the short term,
it could be used in concert with `-checkaction=context`,
allowing to reduce template instantiation and bloat.
```