### PR TITLE
Fix 23412 - void init member detection does not account for static arrays

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -878,7 +878,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
 
         // Calculate type size + safety checks
-        if (1)
+        if (sc && sc.func)
         {
             if (dsym._init && dsym._init.isVoidInitializer())
             {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3816,6 +3816,7 @@ public:
     Expression* defaultInitLiteral(const Loc& loc) override;
     bool hasPointers() override;
     bool hasSystemFields() override;
+    bool hasVoidInitPointers() override;
     bool hasInvariant() override;
     bool needsDestruction() override;
     bool needsCopyOrPostblit() override;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -3836,6 +3836,11 @@ extern (C++) final class TypeSArray : TypeArray
         return next.hasSystemFields();
     }
 
+    override bool hasVoidInitPointers()
+    {
+        return next.hasVoidInitPointers();
+    }
+
     override bool hasInvariant()
     {
         return next.hasInvariant();

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -460,6 +460,7 @@ public:
     Expression *defaultInitLiteral(const Loc &loc) override;
     bool hasPointers() override;
     bool hasSystemFields() override;
+    bool hasVoidInitPointers() override;
     bool hasInvariant() override;
     bool needsDestruction() override;
     bool needsCopyOrPostblit() override;

--- a/compiler/test/fail_compilation/test14496.d
+++ b/compiler/test/fail_compilation/test14496.d
@@ -6,10 +6,10 @@ fail_compilation/test14496.d(24): Error: `void` initializers for pointers not al
 fail_compilation/test14496.d(28): Error: `void` initializers for pointers not allowed in safe functions
 fail_compilation/test14496.d(48): Error: `void` initializers for pointers not allowed in safe functions
 fail_compilation/test14496.d(49): Error: `void` initializers for pointers not allowed in safe functions
+fail_compilation/test14496.d(50): Error: `void` initializers for pointers not allowed in safe functions
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=14496
-
 @safe void foo()
 {
     struct Foo {
@@ -47,4 +47,5 @@ struct Baz {
 @safe void sinister() {
     Bar bar;
     Baz baz;
+    Bar[2] bars; // https://issues.dlang.org/show_bug.cgi?id=23412
 }


### PR DESCRIPTION
I noticed TypeSArray didn't override `hasVoidInitPointers` while working on https://github.com/dlang/dmd/pull/14558

