### PR TITLE
change type of value parameter to movxmmconst()

### DIFF
--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -5387,26 +5387,26 @@ void loaddata(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
         forregs |= DOUBLEREGS;
     if (e.Eoper == OPconst)
     {
-        targ_size_t value = e.EV.Vint;
-        if (sz == 8)
-            value = cast(targ_size_t)e.EV.Vullong;
-
         if (tyvector(tym) && forregs & XMMREGS)
         {
             assert(!flags);
             reg_t xreg;
             allocreg(cdb, &forregs, &xreg, tym);     // allocate registers
-            movxmmconst(cdb, xreg, sz, value, flags);
+            movxmmconst(cdb, xreg, sz, &e.EV, flags);
             fixresult(cdb, e, forregs, pretregs);
             return;
         }
+
+        targ_size_t value = e.EV.Vint;
+        if (sz == 8)
+            value = cast(targ_size_t)e.EV.Vullong;
 
         if (sz == REGSIZE && reghasvalue(forregs, value, &reg))
             forregs = mask(reg);
 
         regm_t save = regcon.immed.mval;
         allocreg(cdb, &forregs, &reg, tym);        // allocate registers
-        regcon.immed.mval = save;               // KLUDGE!
+        regcon.immed.mval = save;               // allocreg could unnecessarily clear .mval
         if (sz <= REGSIZE)
         {
             if (sz == 1)

--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -618,7 +618,7 @@ void cod5_noprol();
 /* cgxmm.c */
 bool isXMMstore(opcode_t op);
 @trusted
-void movxmmconst(ref CodeBuilder cdb, reg_t xreg, uint sz, targ_size_t value, regm_t flags);
+void movxmmconst(ref CodeBuilder cdb, reg_t xreg, uint sz, eve* pvalue, regm_t flags);
 void orthxmm(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void xmmeq(ref CodeBuilder cdb, elem *e, opcode_t op, elem *e1, elem *e2, regm_t *pretregs);
 void xmmcnvt(ref CodeBuilder cdb,elem *e,regm_t *pretregs);

--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -2329,6 +2329,20 @@ L1:
                             return false;
                         break;
 
+                    case TYfloat8:
+                    case TYdouble4:
+                    case TYschar32:
+                    case TYuchar32:
+                    case TYshort16:
+                    case TYushort16:
+                    case TYlong8:
+                    case TYulong8:
+                    case TYllong4:
+                    case TYullong4:
+                        if (memcmp(&n1.EV,&n2.EV,32))   // 32 byte vector types (256 bit)
+                            return false;
+                        break;
+
                     case TYcldouble:
                         static if ((n1.EV.Vldouble).sizeof > 10)
                         {


### PR DESCRIPTION
Prepare movxmmconst() to handle any size value, not just 8 and 4. Also extend el_match() to handle larger `union eve` values.