### PR TITLE
remove legacy int64_t and uint64_t

### DIFF
--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -247,8 +247,6 @@ enum EXIT_BREAK = 255;     // aborted compile with ^C
  * Target machine data types as they appear on the host.
  */
 
-import core.stdc.stdint : int64_t, uint64_t;
-
 alias targ_char = byte;
 alias targ_uchar = ubyte;
 alias targ_schar = byte;
@@ -256,8 +254,8 @@ alias targ_short = short;
 alias targ_ushort= ushort;
 alias targ_long = int;
 alias targ_ulong = uint;
-alias targ_llong = int64_t;
-alias targ_ullong = uint64_t;
+alias targ_llong = long;
+alias targ_ullong = ulong;
 alias targ_float = float;
 alias targ_double = double;
 public import dmd.root.longdouble : targ_ldouble = longdouble;
@@ -292,8 +290,8 @@ enum REGMASK = 0xFFFF;
 // targ_llong is also used to store host pointers, so it should have at least their size
 
 // 64 bit support
-alias targ_ptrdiff_t = int64_t;   // ptrdiff_t for target machine
-alias targ_size_t = uint64_t;     // size_t for the target machine
+alias targ_ptrdiff_t = long;   // ptrdiff_t for target machine
+alias targ_size_t    = ulong;  // size_t for the target machine
 
 /* Enable/disable various features
    (Some features may no longer work the old way when compiled out,

--- a/compiler/src/dmd/backend/divcoeff.d
+++ b/compiler/src/dmd/backend/divcoeff.d
@@ -18,8 +18,7 @@ extern (C++):
 nothrow:
 @safe:
 
-import core.stdc.stdint : uint64_t;
-alias ullong = uint64_t;
+alias ullong = ulong;
 
 /* unsigned 128 bit math
  */

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -135,7 +135,7 @@ void util_progress();
 void util_set16();
 void util_set32(exefmt_t);
 void util_set64(exefmt_t);
-int ispow2(uint64_t);
+int ispow2(ulong);
 
 version (Posix)
 {

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -1026,7 +1026,7 @@ version (SCPP)
                             ++nreloc;
 
                             // patch with fdesym.Soffset - offset
-                            int64_t *p = cast(int64_t *)patchAddr64(seg, r.offset);
+                            long *p = cast(long *)patchAddr64(seg, r.offset);
                             *p += r.funcsym.Soffset - r.offset;
                             continue;
                         }
@@ -1274,7 +1274,7 @@ version (SCPP)
                     if (I64)
                     {
                         int32_t *p64 = patchAddr64(seg, r.offset);
-                        //int64_t before = *p64;
+                        //long before = *p64;
                         if (rel.r_pcrel)
                             // Relative address
                             patch(pseg, r.offset, r.targseg, 0);

--- a/compiler/src/dmd/backend/util2.d
+++ b/compiler/src/dmd/backend/util2.d
@@ -18,7 +18,6 @@ module dmd.backend.util2;
 import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
-import core.stdc.stdint : uint64_t;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
@@ -269,7 +268,7 @@ int binary(const(char)* p, size_t len, const(char)** table, int high)
  * If c is a power of 2, return that power else -1.
  */
 
-int ispow2(uint64_t c)
+int ispow2(ulong c)
 {       int i;
 
         if (c == 0 || (c & (c - 1)))


### PR DESCRIPTION
This is a legacy of the code being originally written in C++. Not necessary with D.