### PR TITLE
DIP1000: Make 'in' means 'scope' regardless of '-preview=in'

### DIFF
--- a/changelog/dmd.in-means-scope.dd
+++ b/changelog/dmd.in-means-scope.dd
@@ -1,0 +1,4 @@
+`scope` behavior is now enforced on `in` parameters when DIP1000 is enabled
+
+Previosuly, `in` on parameters meant `scope` only when both `-preview=in` and `-preview=dip1000` were used.
+From this release, only `-preview=dip1000` is required to enforce `scope` behavior on `in` parameter.

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -774,7 +774,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         // At this point we can add `scope` to the STC instead of `in`,
         // because we are never going to use this variable's STC for user messages
-        if (dsym.storage_class & STC.in_ && global.params.previewIn)
+        if (dsym.storage_class & STC.in_)
             dsym.storage_class |= STC.scope_;
 
         if (dsym.storage_class & STC.scope_)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3460,7 +3460,7 @@ public:
     static size_t dim(Array<Parameter* >* parameters);
     static Parameter* getNth(Array<Parameter* >* parameters, size_t nth);
     const char* toChars() const override;
-    bool isCovariant(bool returnByRef, const Parameter* const p, bool previewIn = global.params.previewIn) const;
+    bool isCovariant(bool returnByRef, const Parameter* const p) const;
 };
 
 enum class RET

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4415,7 +4415,7 @@ extern (C++) final class TypeFunction : TypeNext
         auto stc = p.storageClass;
 
         // When the preview switch is enable, `in` parameters are `scope`
-        if (stc & STC.in_ && global.params.previewIn)
+        if (stc & STC.in_)
             return stc | STC.scope_;
 
         if (stc & (STC.scope_ | STC.return_ | STC.lazy_) || purity == PURE.impure)
@@ -6884,28 +6884,23 @@ extern (C++) final class Parameter : ASTNode
      * Params:
      *  returnByRef = true if the function returns by ref
      *  p = Parameter to compare with
-     *  previewIn = Whether `-preview=in` is being used, and thus if
-     *              `in` means `scope [ref]`.
      *
      * Returns:
      *  true = `this` can be used in place of `p`
      *  false = nope
      */
-    bool isCovariant(bool returnByRef, const Parameter p, bool previewIn = global.params.previewIn)
+    bool isCovariant(bool returnByRef, const Parameter p)
         const pure nothrow @nogc @safe
     {
         ulong thisSTC = this.storageClass;
         ulong otherSTC = p.storageClass;
 
-        if (previewIn)
-        {
-            if (thisSTC & STC.in_)
-                thisSTC |= STC.scope_;
-            if (otherSTC & STC.in_)
-                otherSTC |= STC.scope_;
-        }
+        if (thisSTC & STC.in_)
+            thisSTC |= STC.scope_;
+        if (otherSTC & STC.in_)
+            otherSTC |= STC.scope_;
 
-        const mask = STC.ref_ | STC.out_ | STC.lazy_ | (previewIn ? STC.in_ : 0);
+        const mask = STC.ref_ | STC.out_ | STC.lazy_ | STC.in_;
         if ((thisSTC & mask) != (otherSTC & mask))
             return false;
         return isCovariantScope(returnByRef, thisSTC, otherSTC);

--- a/compiler/test/compilable/testInference.d
+++ b/compiler/test/compilable/testInference.d
@@ -293,7 +293,7 @@ void test8504()
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=8751
 
-alias bool delegate(in int) pure Bar8751;
+alias bool delegate(const int) pure Bar8751;
 Bar8751 foo8751a(immutable int x) pure
 {
     return y => x > y; // OK
@@ -306,8 +306,8 @@ Bar8751 foo8751b(const int x) pure
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=8793
 
-alias bool delegate(in int) pure Dg8793;
-alias bool function(in int) pure Fp8793;
+alias bool delegate(const int) pure Dg8793;
+alias bool function(const int) pure Fp8793;
 
 Dg8793 foo8793fp1(immutable Fp8793 f) pure { return x => (*f)(x); } // OK
 Dg8793 foo8793fp2(    const Fp8793 f) pure { return x => (*f)(x); } // OK

--- a/compiler/test/compilable/testfptr.d
+++ b/compiler/test/compilable/testfptr.d
@@ -107,7 +107,7 @@ void bug3797()
     static assert(!is(typeof( purefunc = nonpurefunc )));
     static assert( is(typeof( nonpurefunc = purefunc )));
 
-    // Cannot convert parameter storage classes (except const to in and in to const)
+    // Cannot convert parameter storage classes
 
     void function(const(int)) constfunc;
     void function(in int) infunc;
@@ -115,8 +115,8 @@ void bug3797()
     void function(ref int) reffunc;
     void function(lazy int) lazyfunc;
 
-    static assert(is(typeof( infunc = constfunc )));
-    static assert(is(typeof( constfunc = infunc )));
+    static assert(!is(typeof( infunc = constfunc )));
+    static assert(!is(typeof( constfunc = infunc )));
 
     static assert(!is(typeof( infunc = outfunc )));
     static assert(!is(typeof( infunc = reffunc )));
@@ -250,7 +250,7 @@ void bug3797dg()
     static assert(!is(typeof( purefunc = nonpurefunc )));
     static assert( is(typeof( nonpurefunc = purefunc )));
 
-    // Cannot convert parameter storage classes (except const to in and in to const)
+    // Cannot convert parameter storage classes
 
     void delegate(const(int)) constfunc;
     void delegate(in int) infunc;
@@ -258,8 +258,8 @@ void bug3797dg()
     void delegate(ref int) reffunc;
     void delegate(lazy int) lazyfunc;
 
-    static assert(is(typeof( infunc = constfunc )));
-    static assert(is(typeof( constfunc = infunc )));
+    static assert(!is(typeof( infunc = constfunc )));
+    static assert(!is(typeof( constfunc = infunc )));
 
     static assert(!is(typeof( infunc = outfunc )));
     static assert(!is(typeof( infunc = reffunc )));

--- a/compiler/test/compilable/warn3882.d
+++ b/compiler/test/compilable/warn3882.d
@@ -64,7 +64,7 @@ void test12909()
 
 const struct Foo13899
 {
-    int opApply(immutable int delegate(in ref int) pure nothrow dg) pure nothrow
+    int opApply(immutable int delegate(const ref int) pure nothrow dg) pure nothrow
     {
         return 1;
     }


### PR DESCRIPTION
```
This somewhat simplifies the code, and decouple DIP1000 behavior from '-preview=in' behavior. The '-preview=in' specific behavior is now limited to the 'ref' / rvalue feature.
```

Extracted from https://github.com/dlang/dmd/pull/14557