### PR TITLE
Do not strip STC.in_ on parameter matching

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -3901,7 +3901,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     // https://issues.dlang.org/show_bug.cgi?id=2579
                     // Apply function parameter storage classes to parameter types
                     fparam.type = fparam.type.addStorageClass(fparam.storageClass);
-                    fparam.storageClass &= ~(STC.TYPECTOR | STC.in_);
+                    fparam.storageClass &= ~STC.TYPECTOR;
 
                     // https://issues.dlang.org/show_bug.cgi?id=15243
                     // Resolve parameter type if it's not related with template parameters


### PR DESCRIPTION
```
That behavior was introduced when `in` was equivalent to `const`, which is no longer the case and will cause issues when `in` enforces `scope`.
```

This is a simple fix, which is extracted from https://github.com/dlang/dmd/pull/14569
One of the test in the test-suite fails when `in` is given its `scope` meaning, and looking at the code it's obvious why.