### PR TITLE
Windows: Double dmd.exe stack limit to 16 MB

### DIFF
--- a/changelog/dmd.windows_stack_limit.dd
+++ b/changelog/dmd.windows_stack_limit.dd
@@ -1,0 +1,6 @@
+Windows: Double DMD stack limit to 16 MB
+
+The compilation of some projects require more stack space than previously available.
+Now DMD has the same limit as LDC, which
+$(LINK2 https://github.com/ldc-developers/ldc/pull/3921, increased its stack limit)
+in its 1.29.0 release.

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -472,7 +472,7 @@ alias dmdExe = makeRuleWithArgs!((MethodInitializer!BuildRule builder, BuildRule
 
     string[] platformArgs;
     version (Windows)
-        platformArgs = ["-L/STACK:8388608"];
+        platformArgs = ["-L/STACK:16777216"];
 
     auto lexer = lexer(targetSuffix, depFlags);
     auto backend = backend(targetSuffix, depFlags);


### PR DESCRIPTION
DMD fails on some projects where LDC does not. LDC increased its stack space to 16 MB in ldc-developers/ldc#3921.