### PR TITLE
add isXExpression() method for most expression types in ASTBase

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -12,6 +12,7 @@ module dmd.astbase;
 
 import dmd.astenums;
 import dmd.parsetimevisitor;
+import dmd.tokens : EXP;
 
 /** The ASTBase  family defines a family of AST nodes appropriate for parsing with
   * no semantic information. It defines all the AST nodes that the parser needs
@@ -4538,16 +4539,126 @@ struct ASTBase
             return DYNCAST.expression;
         }
 
+        final pure inout nothrow @nogc @safe
+        {
+            inout(IntegerExp)   isIntegerExp() { return op == EXP.int64 ? cast(typeof(return))this : null; }
+            inout(ErrorExp)     isErrorExp() { return op == EXP.error ? cast(typeof(return))this : null; }
+            inout(RealExp)      isRealExp() { return op == EXP.float64 ? cast(typeof(return))this : null; }
+            inout(IdentifierExp) isIdentifierExp() { return op == EXP.identifier ? cast(typeof(return))this : null; }
+            inout(DollarExp)    isDollarExp() { return op == EXP.dollar ? cast(typeof(return))this : null; }
+            inout(DsymbolExp)   isDsymbolExp() { return op == EXP.dSymbol ? cast(typeof(return))this : null; }
+            inout(ThisExp)      isThisExp() { return op == EXP.this_ ? cast(typeof(return))this : null; }
+            inout(SuperExp)     isSuperExp() { return op == EXP.super_ ? cast(typeof(return))this : null; }
+            inout(NullExp)      isNullExp() { return op == EXP.null_ ? cast(typeof(return))this : null; }
+            inout(StringExp)    isStringExp() { return op == EXP.string_ ? cast(typeof(return))this : null; }
+            inout(TupleExp)     isTupleExp() { return op == EXP.tuple ? cast(typeof(return))this : null; }
+            inout(ArrayLiteralExp) isArrayLiteralExp() { return op == EXP.arrayLiteral ? cast(typeof(return))this : null; }
+            inout(AssocArrayLiteralExp) isAssocArrayLiteralExp() { return op == EXP.assocArrayLiteral ? cast(typeof(return))this : null; }
+            inout(TypeExp)      isTypeExp() { return op == EXP.type ? cast(typeof(return))this : null; }
+            inout(ScopeExp)     isScopeExp() { return op == EXP.scope_ ? cast(typeof(return))this : null; }
+            inout(TemplateExp)  isTemplateExp() { return op == EXP.template_ ? cast(typeof(return))this : null; }
+            inout(NewExp) isNewExp() { return op == EXP.new_ ? cast(typeof(return))this : null; }
+            inout(NewAnonClassExp) isNewAnonClassExp() { return op == EXP.newAnonymousClass ? cast(typeof(return))this : null; }
+            inout(VarExp)       isVarExp() { return op == EXP.variable ? cast(typeof(return))this : null; }
+            inout(FuncExp)      isFuncExp() { return op == EXP.function_ ? cast(typeof(return))this : null; }
+            inout(DeclarationExp) isDeclarationExp() { return op == EXP.declaration ? cast(typeof(return))this : null; }
+            inout(TypeidExp)    isTypeidExp() { return op == EXP.typeid_ ? cast(typeof(return))this : null; }
+            inout(TraitsExp)    isTraitsExp() { return op == EXP.traits ? cast(typeof(return))this : null; }
+            inout(IsExp)        isExp() { return op == EXP.is_ ? cast(typeof(return))this : null; }
+            inout(MixinExp)     isMixinExp() { return op == EXP.mixin_ ? cast(typeof(return))this : null; }
+            inout(ImportExp)    isImportExp() { return op == EXP.import_ ? cast(typeof(return))this : null; }
+            inout(AssertExp)    isAssertExp() { return op == EXP.assert_ ? cast(typeof(return))this : null; }
+            inout(ThrowExp)     isThrowExp() { return op == EXP.throw_ ? cast(typeof(return))this : null; }
+            inout(DotIdExp)     isDotIdExp() { return op == EXP.dotIdentifier ? cast(typeof(return))this : null; }
+            inout(DotTemplateInstanceExp) isDotTemplateInstanceExp() { return op == EXP.dotTemplateInstance ? cast(typeof(return))this : null; }
+            inout(CallExp)      isCallExp() { return op == EXP.call ? cast(typeof(return))this : null; }
+            inout(AddrExp)      isAddrExp() { return op == EXP.address ? cast(typeof(return))this : null; }
+            inout(PtrExp)       isPtrExp() { return op == EXP.star ? cast(typeof(return))this : null; }
+            inout(NegExp)       isNegExp() { return op == EXP.negate ? cast(typeof(return))this : null; }
+            inout(UAddExp)      isUAddExp() { return op == EXP.uadd ? cast(typeof(return))this : null; }
+            inout(ComExp)       isComExp() { return op == EXP.tilde ? cast(typeof(return))this : null; }
+            inout(NotExp)       isNotExp() { return op == EXP.not ? cast(typeof(return))this : null; }
+            inout(DeleteExp)    isDeleteExp() { return op == EXP.delete_ ? cast(typeof(return))this : null; }
+            inout(CastExp)      isCastExp() { return op == EXP.cast_ ? cast(typeof(return))this : null; }
+            inout(ArrayExp)     isArrayExp() { return op == EXP.array ? cast(typeof(return))this : null; }
+            inout(CommaExp)     isCommaExp() { return op == EXP.comma ? cast(typeof(return))this : null; }
+            inout(IntervalExp)  isIntervalExp() { return op == EXP.interval ? cast(typeof(return))this : null; }
+            inout(PostExp)      isPostExp()  { return (op == EXP.plusPlus || op == EXP.minusMinus) ? cast(typeof(return))this : null; }
+            inout(PreExp)       isPreExp()   { return (op == EXP.prePlusPlus || op == EXP.preMinusMinus) ? cast(typeof(return))this : null; }
+            inout(AssignExp)    isAssignExp()    { return op == EXP.assign ? cast(typeof(return))this : null; }
+            inout(AddAssignExp) isAddAssignExp() { return op == EXP.addAssign ? cast(typeof(return))this : null; }
+            inout(MinAssignExp) isMinAssignExp() { return op == EXP.minAssign ? cast(typeof(return))this : null; }
+            inout(MulAssignExp) isMulAssignExp() { return op == EXP.mulAssign ? cast(typeof(return))this : null; }
+
+            inout(DivAssignExp) isDivAssignExp() { return op == EXP.divAssign ? cast(typeof(return))this : null; }
+            inout(ModAssignExp) isModAssignExp() { return op == EXP.modAssign ? cast(typeof(return))this : null; }
+            inout(AndAssignExp) isAndAssignExp() { return op == EXP.andAssign ? cast(typeof(return))this : null; }
+            inout(OrAssignExp)  isOrAssignExp()  { return op == EXP.orAssign ? cast(typeof(return))this : null; }
+            inout(XorAssignExp) isXorAssignExp() { return op == EXP.xorAssign ? cast(typeof(return))this : null; }
+            inout(PowAssignExp) isPowAssignExp() { return op == EXP.powAssign ? cast(typeof(return))this : null; }
+
+            inout(ShlAssignExp)  isShlAssignExp()  { return op == EXP.leftShiftAssign ? cast(typeof(return))this : null; }
+            inout(ShrAssignExp)  isShrAssignExp()  { return op == EXP.rightShiftAssign ? cast(typeof(return))this : null; }
+            inout(UshrAssignExp) isUshrAssignExp() { return op == EXP.unsignedRightShiftAssign ? cast(typeof(return))this : null; }
+
+            inout(CatAssignExp) isCatAssignExp() { return op == EXP.concatenateAssign
+                                                    ? cast(typeof(return))this
+                                                    : null; }
+
+            inout(CatElemAssignExp) isCatElemAssignExp() { return op == EXP.concatenateElemAssign
+                                                    ? cast(typeof(return))this
+                                                    : null; }
+
+            inout(CatDcharAssignExp) isCatDcharAssignExp() { return op == EXP.concatenateDcharAssign
+                                                    ? cast(typeof(return))this
+                                                    : null; }
+
+            inout(AddExp)      isAddExp() { return op == EXP.add ? cast(typeof(return))this : null; }
+            inout(MinExp)      isMinExp() { return op == EXP.min ? cast(typeof(return))this : null; }
+            inout(CatExp)      isCatExp() { return op == EXP.concatenate ? cast(typeof(return))this : null; }
+            inout(MulExp)      isMulExp() { return op == EXP.mul ? cast(typeof(return))this : null; }
+            inout(DivExp)      isDivExp() { return op == EXP.div ? cast(typeof(return))this : null; }
+            inout(ModExp)      isModExp() { return op == EXP.mod ? cast(typeof(return))this : null; }
+            inout(PowExp)      isPowExp() { return op == EXP.pow ? cast(typeof(return))this : null; }
+            inout(ShlExp)      isShlExp() { return op == EXP.leftShift ? cast(typeof(return))this : null; }
+            inout(ShrExp)      isShrExp() { return op == EXP.rightShift ? cast(typeof(return))this : null; }
+            inout(UshrExp)     isUshrExp() { return op == EXP.unsignedRightShift ? cast(typeof(return))this : null; }
+            inout(AndExp)      isAndExp() { return op == EXP.and ? cast(typeof(return))this : null; }
+            inout(OrExp)       isOrExp() { return op == EXP.or ? cast(typeof(return))this : null; }
+            inout(XorExp)      isXorExp() { return op == EXP.xor ? cast(typeof(return))this : null; }
+            inout(LogicalExp)  isLogicalExp() { return (op == EXP.andAnd || op == EXP.orOr) ? cast(typeof(return))this : null; }
+            inout(InExp)       isInExp() { return op == EXP.in_ ? cast(typeof(return))this : null; }
+            inout(EqualExp)    isEqualExp() { return (op == EXP.equal || op == EXP.notEqual) ? cast(typeof(return))this : null; }
+            inout(IdentityExp) isIdentityExp() { return (op == EXP.identity || op == EXP.notIdentity) ? cast(typeof(return))this : null; }
+            inout(CondExp)     isCondExp() { return op == EXP.question ? cast(typeof(return))this : null; }
+            inout(GenericExp)  isGenericExp() { return op == EXP._Generic ? cast(typeof(return))this : null; }
+            inout(FileInitExp)       isFileInitExp() { return (op == EXP.file || op == EXP.fileFullPath) ? cast(typeof(return))this : null; }
+            inout(LineInitExp)       isLineInitExp() { return op == EXP.line ? cast(typeof(return))this : null; }
+            inout(ModuleInitExp)     isModuleInitExp() { return op == EXP.moduleString ? cast(typeof(return))this : null; }
+            inout(FuncInitExp)       isFuncInitExp() { return op == EXP.functionString ? cast(typeof(return))this : null; }
+            inout(PrettyFuncInitExp) isPrettyFuncInitExp() { return op == EXP.prettyFunction ? cast(typeof(return))this : null; }
+            inout(AssignExp)         isConstructExp() { return op == EXP.construct ? cast(typeof(return))this : null; }
+            inout(AssignExp)         isBlitExp()      { return op == EXP.blit ? cast(typeof(return))this : null; }
+
+            inout(UnaExp) isUnaExp() pure inout nothrow @nogc
+            {
+                return exptab[op] & EXPFLAGS.unary ? cast(typeof(return))this : null;
+            }
+
+            inout(BinExp) isBinExp() pure inout nothrow @nogc
+            {
+                return exptab[op] & EXPFLAGS.binary ? cast(typeof(return))this : null;
+            }
+
+            inout(BinAssignExp) isBinAssignExp() pure inout nothrow @nogc
+            {
+                return exptab[op] & EXPFLAGS.binaryAssign ? cast(typeof(return))this : null;
+            }
+        }
+
         override void accept(Visitor v)
         {
             v.visit(this);
-        }
-
-        extern (C++) final pure inout nothrow @nogc @safe
-        {
-            inout(DeclarationExp) isDeclarationExp() { return op == EXP.declaration ? cast(typeof(return))this : null; }
-            inout(AssignExp) isConstructExp() { return op == EXP.construct ? cast(typeof(return))this : null; }
-            inout(AssignExp) isBlitExp()      { return op == EXP.blit ? cast(typeof(return))this : null; }
         }
     }
 
@@ -6766,3 +6877,50 @@ struct ASTBase
         extern (C++) __gshared bool isLP64;
     }
 }
+
+private immutable ubyte[EXP.max + 1] exptab =
+() {
+    ubyte[EXP.max + 1] tab;
+    with (EXPFLAGS)
+    {
+        foreach (i; Eunary)  { tab[i] |= unary;  }
+        foreach (i; Ebinary) { tab[i] |= unary | binary; }
+        foreach (i; EbinaryAssign) { tab[i] |= unary | binary | binaryAssign; }
+    }
+    return tab;
+} ();
+
+private enum EXPFLAGS : ubyte
+{
+    unary = 1,
+    binary = 2,
+    binaryAssign = 4,
+}
+
+private enum Eunary =
+    [
+        EXP.import_, EXP.assert_, EXP.throw_, EXP.dotIdentifier, EXP.dotTemplateDeclaration,
+        EXP.dotVariable, EXP.dotTemplateInstance, EXP.delegate_, EXP.dotType, EXP.call,
+        EXP.address, EXP.star, EXP.negate, EXP.uadd, EXP.tilde, EXP.not, EXP.delete_, EXP.cast_,
+        EXP.vector, EXP.vectorArray, EXP.slice, EXP.arrayLength, EXP.array, EXP.delegatePointer,
+        EXP.delegateFunctionPointer, EXP.preMinusMinus, EXP.prePlusPlus,
+    ];
+
+private enum Ebinary =
+    [
+        EXP.dot, EXP.comma, EXP.index, EXP.minusMinus, EXP.plusPlus, EXP.assign,
+        EXP.add, EXP.min, EXP.concatenate, EXP.mul, EXP.div, EXP.mod, EXP.pow, EXP.leftShift,
+        EXP.rightShift, EXP.unsignedRightShift, EXP.and, EXP.or, EXP.xor, EXP.andAnd, EXP.orOr,
+        EXP.lessThan, EXP.lessOrEqual, EXP.greaterThan, EXP.greaterOrEqual,
+        EXP.in_, EXP.remove, EXP.equal, EXP.notEqual, EXP.identity, EXP.notIdentity,
+        EXP.question,
+        EXP.construct, EXP.blit,
+    ];
+
+private enum EbinaryAssign =
+    [
+        EXP.addAssign, EXP.minAssign, EXP.mulAssign, EXP.divAssign, EXP.modAssign,
+        EXP.andAssign, EXP.orAssign, EXP.xorAssign, EXP.powAssign,
+        EXP.leftShiftAssign, EXP.rightShiftAssign, EXP.unsignedRightShiftAssign,
+        EXP.concatenateAssign, EXP.concatenateElemAssign, EXP.concatenateDcharAssign,
+    ];

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -6897,7 +6897,7 @@ private enum EXPFLAGS : ubyte
     binaryAssign = 4,
 }
 
-private enum Eunary =
+private static immutable Eunary =
     [
         EXP.import_, EXP.assert_, EXP.throw_, EXP.dotIdentifier, EXP.dotTemplateDeclaration,
         EXP.dotVariable, EXP.dotTemplateInstance, EXP.delegate_, EXP.dotType, EXP.call,
@@ -6906,7 +6906,7 @@ private enum Eunary =
         EXP.delegateFunctionPointer, EXP.preMinusMinus, EXP.prePlusPlus,
     ];
 
-private enum Ebinary =
+private static immutable Ebinary =
     [
         EXP.dot, EXP.comma, EXP.index, EXP.minusMinus, EXP.plusPlus, EXP.assign,
         EXP.add, EXP.min, EXP.concatenate, EXP.mul, EXP.div, EXP.mod, EXP.pow, EXP.leftShift,
@@ -6917,7 +6917,7 @@ private enum Ebinary =
         EXP.construct, EXP.blit,
     ];
 
-private enum EbinaryAssign =
+private static immutable EbinaryAssign =
     [
         EXP.addAssign, EXP.minAssign, EXP.mulAssign, EXP.divAssign, EXP.modAssign,
         EXP.andAssign, EXP.orAssign, EXP.xorAssign, EXP.powAssign,


### PR DESCRIPTION
As in expression.d, ASTBase classes that extend Expression would benefit from a more elegant way to check if an expression in an AST is of a particular type.