### PR TITLE
Group attributes in Dsymbol to reduce memory usage

### DIFF
--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -167,25 +167,31 @@ struct FieldState
     bool inFlight;
 };
 
+struct DsymbolAttributes;
+
 class Dsymbol : public ASTNode
 {
 public:
     Identifier *ident;
     Dsymbol *parent;
-    /// C++ namespace this symbol belongs to
-    CPPNamespaceDeclaration *namespace_;
     Symbol *csym;               // symbol for code generator
     Loc loc;                    // where defined
     Scope *_scope;               // !=NULL means context to use for semantic()
     const utf8_t *prettystring;
+private:
+    DsymbolAttributes* atts;
+public:
     bool errors;                // this symbol failed to pass semantic()
     PASS semanticRun;
     unsigned short localNum;        // perturb mangled name to avoid collisions with those in FuncDeclaration.localsymtab
-    DeprecatedDeclaration *depdecl; // customized deprecation message
-    UserAttributeDeclaration *userAttribDecl;   // user defined attributes
-
     static Dsymbol *create(Identifier *);
     const char *toChars() const override;
+    DeprecatedDeclaration* depdecl();
+    CPPNamespaceDeclaration* cppnamespace();
+    UserAttributeDeclaration* userAttribDecl();
+    DeprecatedDeclaration* depdecl(DeprecatedDeclaration* dd);
+    CPPNamespaceDeclaration* cppnamespace(CPPNamespaceDeclaration* ns);
+    UserAttributeDeclaration* userAttribDecl(UserAttributeDeclaration* uad);
     virtual const char *toPrettyCharsHelper(); // helper to print fully qualified (template) arguments
     Loc getLoc();
     const char *locToChars();

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -39,13 +39,14 @@ struct _d_dynamicArray final
 
 class Visitor;
 class Identifier;
-class CPPNamespaceDeclaration;
 struct Symbol;
 struct OutBuffer;
 class FileManager;
 struct FileName;
 struct Scope;
+struct DsymbolAttributes;
 class DeprecatedDeclaration;
+class CPPNamespaceDeclaration;
 class UserAttributeDeclaration;
 class Module;
 class TemplateInstance;
@@ -954,18 +955,24 @@ class Dsymbol : public ASTNode
 public:
     Identifier* ident;
     Dsymbol* parent;
-    CPPNamespaceDeclaration* cppnamespace;
     Symbol* csym;
     const Loc loc;
     Scope* _scope;
     const char* prettystring;
+private:
+    DsymbolAttributes* atts;
+public:
     bool errors;
     PASS semanticRun;
     uint16_t localNum;
-    DeprecatedDeclaration* depdecl;
-    UserAttributeDeclaration* userAttribDecl;
     static Dsymbol* create(Identifier* ident);
     const char* toChars() const override;
+    DeprecatedDeclaration* depdecl();
+    CPPNamespaceDeclaration* cppnamespace();
+    UserAttributeDeclaration* userAttribDecl();
+    DeprecatedDeclaration* depdecl(DeprecatedDeclaration* dd);
+    CPPNamespaceDeclaration* cppnamespace(CPPNamespaceDeclaration* ns);
+    UserAttributeDeclaration* userAttribDecl(UserAttributeDeclaration* uad);
     virtual const char* toPrettyCharsHelper();
     const Loc getLoc();
     const char* locToChars();

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -686,9 +686,9 @@ public:
     }
     void visitUserAttributes(Dsymbol *sym)
     {
-        if (!sym->userAttribDecl)
+        if (!sym->userAttribDecl())
             return;
-        Expressions *attrs = sym->userAttribDecl->getAttributes();
+        Expressions *attrs = sym->userAttribDecl()->getAttributes();
         if (attrs)
         {
             expandTuples(attrs);


### PR DESCRIPTION
Reduces class instance size of `Dsymbol` from 96 to 76, and reduces peak memory usage of compiling Phobos by 16MB (1%).

Previous work: https://github.com/dlang/dmd/pull/13762