### PR TITLE
Reduce the number of calls to the filesystem to see if a module file exists

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -499,7 +499,7 @@ extern (C++) final class Module : Package
 
     extern (D) static const(char)[] find(const(char)[] filename)
     {
-        return FileManager.lookForSourceFile(filename, global.path ? (*global.path)[] : null);
+        return global.fileManager.lookForSourceFile(filename, global.path ? (*global.path)[] : null);
     }
 
     extern (C++) static Module load(const ref Loc loc, Identifiers* packages, Identifier ident)

--- a/compiler/src/dmd/file_manager.d
+++ b/compiler/src/dmd/file_manager.d
@@ -12,7 +12,7 @@ module dmd.file_manager;
 
 import dmd.root.stringtable : StringTable;
 import dmd.root.file : File, Buffer;
-import dmd.root.filename : FileName;
+import dmd.root.filename : FileName, isDirSeparator;
 import dmd.root.string : toDString;
 import dmd.globals;
 import dmd.identifier;
@@ -26,14 +26,86 @@ bool isPackageFileName(scope FileName fileName) nothrow
     return FileName.equals(fileName.name, package_d) || FileName.equals(fileName.name, package_di);
 }
 
+// A path stack that allows one to go up and down the path using directory
+// separators. `cur` is the current path, `up` goes up one path, `down` goes
+// down one path. if `up` or `down` return false, there are no further paths.
+private struct PathStack
+{
+    private const(char)[] path;
+    private size_t pos;
+
+    @safe @nogc nothrow pure:
+
+    this(const(char)[] p)
+    {
+        path = p;
+        pos = p.length;
+    }
+
+    const(char)[] cur()
+    {
+        return path[0 .. pos];
+    }
+
+    bool up()
+    {
+        if (pos == 0)
+            return false;
+        while (--pos != 0)
+            if (isDirSeparator(path[pos]))
+                return true;
+        return false;
+    }
+
+    bool down()
+    {
+        if (pos == path.length)
+            return false;
+        while (++pos != path.length)
+            if (isDirSeparator(path[pos]))
+                return true;
+        return false;
+    }
+}
+
 final class FileManager
 {
     private StringTable!(const(ubyte)[]) files;
+    private StringTable!(bool) packageStatus;
+
+    // check if the package path of the given path exists. The input path is
+    // expected to contain the full path to the module, so the parent
+    // directories of that path are checked.
+    private bool packageExists(const(char)[] p) nothrow
+    {
+        // step 1, look for the closest parent path that is cached
+        bool exists = true;
+        auto st = PathStack(p);
+        while (st.up) {
+            if (auto cached = packageStatus.lookup(st.cur)) {
+                exists = cached.value;
+                break;
+            }
+        }
+        // found a parent that is cached (or reached the end of the stack).
+        // step 2, traverse back up the stack storing either false if the
+        // parent doesn't exist, or the result of the `exists` call if it does.
+        while (st.down) {
+            if (!exists)
+                packageStatus.insert(st.cur, false);
+            else
+                exists = packageStatus.insert(st.cur, FileName.exists(st.cur) == 2).value;
+        }
+
+        // at this point, exists should be the answer.
+        return exists;
+    }
 
     ///
     public this () nothrow
     {
         this.files._init();
+        this.packageStatus._init();
     }
 
 nothrow:
@@ -48,13 +120,15 @@ nothrow:
     *      the found file name or
     *      `null` if it is not different from filename.
     */
-    static const(char)[] lookForSourceFile(const char[] filename, const char*[] path)
+    const(char)[] lookForSourceFile(const char[] filename, const char*[] path)
     {
         //printf("lookForSourceFile(`%.*s`)\n", cast(int)filename.length, filename.ptr);
         /* Search along path[] for .di file, then .d file, then .i file, then .c file.
         */
+        // see if we should check for the module locally.
+        bool checkLocal = packageExists(filename);
         const sdi = FileName.forceExt(filename, hdr_ext);
-        if (FileName.exists(sdi) == 1)
+        if (checkLocal && FileName.exists(sdi) == 1)
             return sdi;
         scope(exit) FileName.free(sdi.ptr);
 
@@ -62,36 +136,43 @@ nothrow:
         // Special file name representing `stdin`, always assume its presence
         if (sd == "__stdin.d")
             return sd;
-        if (FileName.exists(sd) == 1)
+        if (checkLocal && FileName.exists(sd) == 1)
             return sd;
         scope(exit) FileName.free(sd.ptr);
 
         const si = FileName.forceExt(filename, i_ext);
-        if (FileName.exists(si) == 1)
+        if (checkLocal && FileName.exists(si) == 1)
             return si;
         scope(exit) FileName.free(si.ptr);
 
         const sc = FileName.forceExt(filename, c_ext);
-        if (FileName.exists(sc) == 1)
+        if (checkLocal && FileName.exists(sc) == 1)
             return sc;
         scope(exit) FileName.free(sc.ptr);
 
-        if (FileName.exists(filename) == 2)
+        if (checkLocal)
         {
-            /* The filename exists and it's a directory.
-            * Therefore, the result should be: filename/package.d
-            * iff filename/package.d is a file
-            */
-            const ni = FileName.combine(filename, package_di);
-            if (FileName.exists(ni) == 1)
-                return ni;
-            FileName.free(ni.ptr);
+            auto cached = packageStatus.lookup(filename);
+            if (!cached)
+                cached = packageStatus.insert(filename, FileName.exists(filename) == 2);
+            if (cached.value)
+            {
+                /* The filename exists and it's a directory.
+                 * Therefore, the result should be: filename/package.d
+                 * iff filename/package.d is a file
+                 */
+                const ni = FileName.combine(filename, package_di);
+                if (FileName.exists(ni) == 1)
+                    return ni;
+                FileName.free(ni.ptr);
 
-            const n = FileName.combine(filename, package_d);
-            if (FileName.exists(n) == 1)
-                return n;
-            FileName.free(n.ptr);
+                const n = FileName.combine(filename, package_d);
+                if (FileName.exists(n) == 1)
+                    return n;
+                FileName.free(n.ptr);
+            }
         }
+
         if (FileName.absolute(filename))
             return null;
         if (!path.length)
@@ -101,6 +182,11 @@ nothrow:
             const p = entry.toDString();
 
             const(char)[] n = FileName.combine(p, sdi);
+
+            if (!packageExists(n)) {
+                FileName.free(n.ptr);
+                continue; // no need to check for anything else.
+            }
             if (FileName.exists(n) == 1) {
                 return n;
             }
@@ -127,7 +213,16 @@ nothrow:
             const b = FileName.removeExt(filename);
             n = FileName.combine(p, b);
             FileName.free(b.ptr);
-            if (FileName.exists(n) == 2)
+
+            scope(exit) FileName.free(n.ptr);
+
+            // also cache this if we are looking for package.d[i]
+            auto cached = packageStatus.lookup(n);
+            if (!cached) {
+                cached = packageStatus.insert(n, FileName.exists(n) == 2);
+            }
+
+            if (cached.value)
             {
                 const n2i = FileName.combine(n, package_di);
                 if (FileName.exists(n2i) == 1)
@@ -139,7 +234,6 @@ nothrow:
                 }
                 FileName.free(n2.ptr);
             }
-            FileName.free(n.ptr);
         }
         return null;
     }

--- a/compiler/src/dmd/root/filename.d
+++ b/compiler/src/dmd/root/filename.d
@@ -55,7 +55,7 @@ alias Strings = Array!(const(char)*);
 
 
 // Check whether character is a directory separator
-private bool isDirSeparator(char c) pure nothrow @nogc @safe
+bool isDirSeparator(char c) pure nothrow @nogc @safe
 {
     version (Windows)
     {


### PR DESCRIPTION
In a work project, this reduces the number of `stat` calls from 127_416 to 9_909.

This works by short-circuiting the stat calls if the parent directory is known not to exist.

With current dmd and this project, due to the `-I` parameters for each dependency (of which there are many), importing one module from phobos would result in 335 stat calls.