### PR TITLE
fix(nogc): associative array indexing may only cause GC allocation on assignment

### DIFF
--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -162,16 +162,16 @@ public:
     override void visit(IndexExp e)
     {
         Type t1b = e.e1.type.toBasetype();
-        if (t1b.ty == Taarray)
+        if (e.modifiable && t1b.ty == Taarray)
         {
             if (f.setGC())
             {
-                e.error("indexing an associative array in `@nogc` %s `%s` may cause a GC allocation",
+                e.error("assigning an associative array element in `@nogc` %s `%s` may cause a GC allocation",
                     f.kind(), f.toPrettyChars());
                 err = true;
                 return;
             }
-            f.printGCUsage(e.loc, "indexing an associative array may cause a GC allocation");
+            f.printGCUsage(e.loc, "assigning an associative array element may cause a GC allocation");
         }
     }
 

--- a/compiler/test/compilable/nogc.d
+++ b/compiler/test/compilable/nogc.d
@@ -40,7 +40,8 @@ void foo_compiles() {}
     static assert(!__traits(compiles, delete p));
 
     int[int] aa;
-    static assert(!__traits(compiles, aa[0]));
+    static assert( __traits(compiles, aa[0]));
+    static assert(!__traits(compiles, (aa[0] = 10)));
 
     int[] a;
     static assert(!__traits(compiles, a.length = 1));

--- a/compiler/test/compilable/vgc2.d
+++ b/compiler/test/compilable/vgc2.d
@@ -93,8 +93,7 @@ void testAssocArray()
 /*
 TEST_OUTPUT:
 ---
-compilable/vgc2.d(102): vgc: indexing an associative array may cause a GC allocation
-compilable/vgc2.d(103): vgc: indexing an associative array may cause a GC allocation
+compilable/vgc2.d(101): vgc: assigning an associative array element may cause a GC allocation
 ---
 */
 void testIndex(int[int] aa)

--- a/compiler/test/fail_compilation/nogc2.d
+++ b/compiler/test/fail_compilation/nogc2.d
@@ -92,8 +92,7 @@ fail_compilation/nogc2.d(87): Error: associative array literal in `@nogc` functi
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc2.d(101): Error: indexing an associative array in `@nogc` function `nogc2.testIndex` may cause a GC allocation
-fail_compilation/nogc2.d(102): Error: indexing an associative array in `@nogc` function `nogc2.testIndex` may cause a GC allocation
+fail_compilation/nogc2.d(100): Error: assigning an associative array element in `@nogc` function `nogc2.testIndex` may cause a GC allocation
 ---
 */
 @nogc void testIndex(int[int] aa)


### PR DESCRIPTION
Fix issue 13060.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Spec PR: https://github.com/dlang/dlang.org/pull/3444