### PR TITLE
fix Issue 23433 - [REG 2.081][ICE] Segmentation fault in dmd.blockexit.checkThrow at at src/dmd/blockexit.d:557

### DIFF
--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -554,7 +554,7 @@ BE checkThrow(ref const Loc loc, Expression exp, const bool mustNotThrow)
     ClassDeclaration cd = t.isClassHandle();
     assert(cd);
 
-    if (cd == ClassDeclaration.errorException || ClassDeclaration.errorException.isBaseOf(cd, null))
+    if (cd.isErrorException())
     {
         return BE.errthrow;
     }

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -991,6 +991,11 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         return vtblsym;
     }
 
+    extern (D) final bool isErrorException()
+    {
+        return errorException && (this == errorException || errorException.isBaseOf(this, null));
+    }
+
     override final inout(ClassDeclaration) isClassDeclaration() inout @nogc nothrow pure @safe
     {
         return this;

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -1521,11 +1521,6 @@ public:
         result = e;
     }
 
-    static bool isAnErrorException(ClassDeclaration cd)
-    {
-        return cd == ClassDeclaration.errorException || ClassDeclaration.errorException.isBaseOf(cd, null);
-    }
-
     static ThrownExceptionExp chainExceptions(ThrownExceptionExp oldest, ThrownExceptionExp newest)
     {
         debug (LOG)
@@ -1537,7 +1532,7 @@ public:
         const next = 4;                         // index of Throwable.next
         assert((*boss.value.elements)[next].type.ty == Tclass); // Throwable.next
         ClassReferenceExp collateral = newest.thrown;
-        if (isAnErrorException(collateral.originalClass()) && !isAnErrorException(boss.originalClass()))
+        if (collateral.originalClass().isErrorException() && !boss.originalClass().isErrorException())
         {
             /* Find the index of the Error.bypassException field
              */

--- a/compiler/test/compilable/test23433.d
+++ b/compiler/test/compilable/test23433.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=23433
+module object;
+
+class Throwable { }
+class Exception : Throwable { this(immutable(char)[]) { } }
+
+void test23433()
+{
+    try
+    {
+        throw new Exception("ice");
+    }
+    finally
+    {
+    }
+}


### PR DESCRIPTION
There was no null checking for `ClassDeclaration::errorException`, resulting in a segfault from dereferencing it.  There's a convenience function in dinterpret.d for checking whether a given class declaration is derived from `Error`, move that to dclass.d and reuse it in all places that check `ClassDeclaration::errorException`.