### PR TITLE
add unsigned vector compare

### DIFF
--- a/compiler/src/dmd/backend/cgxmm.d
+++ b/compiler/src/dmd/backend/cgxmm.d
@@ -1098,6 +1098,7 @@ private opcode_t xmmoperator(tym_t tym, OPER oper)
         case OPnue:
             switch (tym)
             {
+                case TYulong4:
                 case TYlong4:   op = (oper == OPeqeq) ? PCMPEQD : PCMPGTD;  break;
 
                 case TYfloat:

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -1854,6 +1854,26 @@ elem* toElem(Expression e, IRState *irs)
             }
 
             tym_t tym = totym(ce.type);
+
+            if (t1.isunsigned() || t2.isunsigned())
+            {
+                /* only signed compare is available. Bias
+                 * unsigned values by subtracting int.min
+                 */
+                elem* ec1 = el_calloc();
+                ec1.Eoper = OPconst;
+                ec1.Ety = totym(t1);
+                ec1.EV.Vlong4[0] = int.min;
+                ec1.EV.Vlong4[1] = int.min;
+                ec1.EV.Vlong4[2] = int.min;
+                ec1.EV.Vlong4[3] = int.min;
+                e1 = el_bin(OPmin, ec1.Ety, e1, ec1);
+
+                elem* ec2 = el_calloc();
+                el_copy(ec2, ec1);
+                e2 = el_bin(OPmin, ec2.Ety, e2, ec2);
+            }
+
             e = el_bin(OPgt, tym, e1, e2);
 
             if (comp)

--- a/compiler/test/runnable/testxmm2.d
+++ b/compiler/test/runnable/testxmm2.d
@@ -140,6 +140,16 @@ void test3() { }
 
 /*****************************************/
 
+void testunscmp()
+{
+    uint4 x = [uint.max,1, 0, uint.max];
+    uint4 y = [0,1,1,6];
+    uint4 z = x > y;
+    assert(z.array == [-1,0,0,-1]);
+}
+
+/*****************************************/
+
 int main()
 {
     test21474();
@@ -149,6 +159,7 @@ int main()
     testz4();
     test2();
     test3();
+    testunscmp();
 
     return 0;
 }


### PR DESCRIPTION
The SIMD instructions only offer signed compare. To do unsigned compares, the values have to be biased by subtracting `int.min`.