### PR TITLE
fix Issue 23439 - [REG 2.098] Error: CTFE internal error: literal 'assert(false, "Accessed expression of type noreturn")'

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -2867,6 +2867,12 @@ public:
                         else
                             m = v.getConstInitializer(true);
                     }
+                    else if (v.type.isTypeNoreturn())
+                    {
+                        // Noreturn field with default initializer
+                        (*elems)[fieldsSoFar + i] = null;
+                        continue;
+                    }
                     else
                         m = v.type.defaultInitLiteral(e.loc);
                     if (exceptionOrCant(m))

--- a/compiler/test/compilable/test23439.d
+++ b/compiler/test/compilable/test23439.d
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=23439
+// PERMUTE_ARGS: -lowmem
+class C23439
+{
+    noreturn f23439;
+}
+
+__gshared ice23439 = new C23439();

--- a/compiler/test/fail_compilation/fail23439.d
+++ b/compiler/test/fail_compilation/fail23439.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=23439
+// PERMUTE_ARGS: -lowmem
+/* TEST_OUTPUT:
+---
+fail_compilation/fail23439.d(13): Error: variable `fail23439.ice23439` is a thread-local class and cannot have a static initializer. Use `static this()` to initialize instead.
+---
+*/
+class C23439
+{
+    noreturn f23439;
+}
+
+static ice23439 = new C23439();


### PR DESCRIPTION
As per #13142 which ignores `noreturn` fields with default initializers in the codegen, also ignore them in CTFE.