### PR TITLE
Remove support for small octals

### DIFF
--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -2177,11 +2177,11 @@ class Lexer
             }
             break;
         }
-        if (base == 8 && n >= 8)
+        if (base == 8)
         {
             if (err)
                 // can't translate invalid octal value, just show a generic message
-                error("octal literals larger than 7 are no longer supported");
+                error("octal literals are no longer supported");
             else
                 error("octal literals `0%llo%.*s` are no longer supported, use `std.conv.octal!\"%llo%.*s\"` instead",
                     n, cast(int)(p - psuffix), psuffix, n, cast(int)(p - psuffix), psuffix);

--- a/compiler/test/fail_compilation/fix19059.d
+++ b/compiler/test/fail_compilation/fix19059.d
@@ -2,18 +2,19 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fix19059.d(16): Error: octal digit expected, not `8`
-fail_compilation/fix19059.d(16): Error: octal literals larger than 7 are no longer supported
+fail_compilation/fix19059.d(16): Error: octal literals are no longer supported
 fail_compilation/fix19059.d(17): Error: octal digit expected, not `9`
-fail_compilation/fix19059.d(17): Error: octal literals larger than 7 are no longer supported
+fail_compilation/fix19059.d(17): Error: octal literals are no longer supported
 fail_compilation/fix19059.d(18): Error: octal literals `010` are no longer supported, use `std.conv.octal!"10"` instead
+fail_compilation/fix19059.d(19): Error: octal literals `00` are no longer supported, use `std.conv.octal!"0"` instead
 ---
  */
 
 // https://issues.dlang.org/show_bug.cgi?id=19059
-
 void foo()
 {
     auto a = 08;
     auto b = 09;
     auto c = 010;
+    auto d = 00;
 }

--- a/compiler/test/fail_compilation/lexer4.d
+++ b/compiler/test/fail_compilation/lexer4.d
@@ -6,7 +6,7 @@ fail_compilation/lexer4.d(24): Error: unterminated character constant
 fail_compilation/lexer4.d(25): Error: unterminated character constant
 fail_compilation/lexer4.d(26): Error: binary digit expected, not `2`
 fail_compilation/lexer4.d(27): Error: octal digit expected, not `8`
-fail_compilation/lexer4.d(27): Error: octal literals larger than 7 are no longer supported
+fail_compilation/lexer4.d(27): Error: octal literals are no longer supported
 fail_compilation/lexer4.d(28): Error: decimal digit expected, not `a`
 fail_compilation/lexer4.d(29): Error: unrecognized token
 fail_compilation/lexer4.d(30): Error: exponent required for hex float


### PR DESCRIPTION
Implementation for https://github.com/dlang/DIPs/pull/235 to identify breakage on buildkite. If the DIP goes through it will start as a deprecation first. 

Revival of https://github.com/dlang/dmd/pull/8490