### PR TITLE
changelog: Check filenames match expected format in pre_commit pipeline.

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -31,3 +31,19 @@ jobs:
         git config --global diff.wsErrorHighlight "all"
     - uses: actions/setup-python@v3.0.0
     - uses: pre-commit/action@v2.0.3
+    - name: Check changelog entries
+      run: |
+        check_prefix="$(find changelog -type f -name '*\.dd' -a ! -name 'dmd\.*' -a ! -name 'druntime\.*')"
+        if [ ! -z "${check_prefix}" ]; then
+          echo 'All changelog entries must begin with either `dmd.` or `druntime.`'
+          echo 'Found:'
+          echo "${check_prefix}"
+          exit 1
+        fi
+        check_ext="$(find changelog -type f ! -name 'README\.md' -a ! -name '*\.dd')"
+        if [ ! -z "${check_ext}" ]; then
+          echo 'All changelog entries must end with `.dd`'
+          echo 'Found:'
+          echo "${check_ext}"
+          exit 1
+        fi

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,9 +4,10 @@ merged into stable prior to a new release.
 How to add a new changelog entry to the pending changelog?
 ==========================================================
 
-Create a new file in the `changelog` folder. It should end with `.dd` and look
-similar to a git commit message. The first line represents the title of the change.
-After an empty line follows the long description:
+Create a new file in the `changelog` folder. It should begin with either `dmd.`
+or `druntime.` and end with `.dd`. The contents of the entry should look
+similar to a git commit message. The first line represents the title of the
+change.  After an empty line follows the long description:
 
 ```
 My fancy title of the new feature


### PR DESCRIPTION
The tools/changed.d script only accepts files beginning with `dmd.` or `druntime.`, and ending with `.dd`.