### PR TITLE
fix alias location issue

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4341,6 +4341,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         /* Declarations that start with `alias`
          */
         bool isAliasDeclaration = false;
+        auto aliasLoc = token.loc;
         if (token.value == TOK.alias_)
         {
             if (auto a = parseAliasDeclarations(comment))
@@ -4517,7 +4518,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     else
                         error("alias cannot have initializer");
                 }
-                v = new AST.AliasDeclaration(loc, ident, t);
+                v = new AST.AliasDeclaration(aliasLoc, ident, t);
 
                 v.storage_class = storage_class;
                 if (pAttrs)

--- a/compiler/test/compilable/extra-files/json.json
+++ b/compiler/test/compilable/extra-files/json.json
@@ -184,7 +184,7 @@
                 "protection": "public"
             },
             {
-                "char": 11,
+                "char": 1,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "alias",
                 "line": 18,

--- a/compiler/test/unit/parser/aliasdeclaration_location.d
+++ b/compiler/test/unit/parser/aliasdeclaration_location.d
@@ -1,0 +1,115 @@
+module parser.aliasdeclaration_location;
+
+import dmd.frontend : parseModule;
+import support : afterEach, beforeEach;
+import dmd.declaration : AliasDeclaration;
+import dmd.globals : Loc;
+import dmd.visitor : SemanticTimeTransitiveVisitor;
+
+@beforeEach
+void initializeFrontend()
+{
+    import dmd.frontend : initDMD;
+
+    initDMD();
+}
+
+@afterEach
+void deinitializeFrontend()
+{
+    import dmd.frontend : deinitializeDMD;
+    deinitializeDMD();
+}
+
+extern (C++) class Visitor : SemanticTimeTransitiveVisitor
+{
+    alias visit = typeof(super).visit;
+    Loc l;
+
+    override void visit(AliasDeclaration ad)
+    {
+        l = ad.loc;
+    }
+}
+
+immutable struct Test
+{
+    /*
+     * The description of the unit test.
+     *
+     * This will go into the UDA attached to the `unittest` block.
+     */
+    string description_;
+
+    /*
+     * The code to parse.
+     *
+     */
+    string code_;
+
+    /*
+     * Test index.
+     *
+     */
+    int index_;
+
+    string code()
+    {
+        return code_;
+    }
+
+    string description()
+    {
+        return description_;
+    }
+
+    int index()
+    {
+        return index_;
+    }
+}
+
+enum tests = [
+    Test("alias type identifier", q{
+    alias int a;}, 1),
+    Test("alias identifier = type", q{
+    import foo.bar;
+    alias a = int;
+    }, 2),
+    Test("alias identifier = type in local scope", q{
+struct MyType {
+    string foo;
+    alias a = Alias!(123);
+}
+    }, 3),
+];
+
+static foreach (test; tests)
+{
+    @(test.description)
+    unittest
+    {
+        auto t = parseModule("test.d", "first_token " ~ test.code);
+
+        scope visitor = new Visitor;
+        t.module_.accept(visitor);
+
+        static if (test.index == 1)
+        {
+            assert(visitor.l.linnum == 2);
+            assert(visitor.l.charnum  == 5);
+        }
+
+        static if (test.index == 2)
+        {
+            assert(visitor.l.linnum == 3);
+            assert(visitor.l.charnum  == 5);
+        }
+
+        static if (test.index == 3)
+        {
+            assert(visitor.l.linnum == 4);
+            assert(visitor.l.charnum  == 5);
+        }
+    }
+}


### PR DESCRIPTION
This fix is meant only for the syntax `alias type identifier`. Currently when the AliasDeclaration is created, it is created with the location of the identifier, not the `alias` keyword (as I think it's expected, that's what happens for the other syntax `alias identifier = type`).

Is the current implementation the desired behavior?