### PR TITLE
Fix Issue 23447 - wrong expression in error message when template ins…

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -7082,7 +7082,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             }
             else
             {
-                .error(loc, "%s `%s.%s` does not match any template declaration", tempdecl.kind(), tempdecl.parent.toPrettyChars(), tempdecl.ident.toChars());
+                .error(loc, "%s `%s` does not match any template declaration", kind(), toPrettyChars());
                 if (tdecl)
                     .errorSupplemental(loc, "Candidates are:");
                 for (; tdecl; tdecl = tdecl.overnext)

--- a/compiler/test/fail_compilation/diag14818.d
+++ b/compiler/test/fail_compilation/diag14818.d
@@ -4,8 +4,8 @@ TEST_OUTPUT:
 fail_compilation/diag14818.d(34): Error: none of the overloads of `func` are callable using argument types `(string)`
 fail_compilation/diag14818.d(12):        Candidate is: `diag14818.foo(int _param_0)`
 fail_compilation/diag14818.d(13):                        `diag14818.bar(double _param_0)`
-fail_compilation/diag14818.d(35): Error: overload alias `diag14818.X` does not match any template declaration
-fail_compilation/diag14818.d(36): Error: overloadset `diag14818.M` does not match any template declaration
+fail_compilation/diag14818.d(35): Error: template instance `diag14818.X!string` does not match any template declaration
+fail_compilation/diag14818.d(36): Error: template instance `diag14818.Y!string` does not match any template declaration
 ---
 */
 

--- a/compiler/test/fail_compilation/templateoverload.d
+++ b/compiler/test/fail_compilation/templateoverload.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/templateoverload.d(17): Error: template `templateoverload.T` does not match any template declaration
+fail_compilation/templateoverload.d(17): Error: template instance `T!1` does not match any template declaration
 fail_compilation/templateoverload.d(17):        Candidates are:
 fail_compilation/templateoverload.d(14):        T(X)
 fail_compilation/templateoverload.d(15):        T()
-fail_compilation/templateoverload.d(22): Error: template `templateoverload.V` does not match any template declaration
+fail_compilation/templateoverload.d(22): Error: template instance `V!int` does not match any template declaration
 fail_compilation/templateoverload.d(22):        Candidates are:
 fail_compilation/templateoverload.d(19):        V(int i)
 fail_compilation/templateoverload.d(20):        V(T, alias a)


### PR DESCRIPTION
…tance doesn't match any overload

The error should show the template instance expression, not just the template name.