### PR TITLE
Fix missing overloads in call candidate list

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4712,9 +4712,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 .error(loc, "no overload matches for `%s`", exp.toChars());
                 errorSupplemental(loc, "Candidates are:");
-                foreach (ds; os.a)
+                foreach (s; os.a)
                 {
-                    .errorSupplemental(ds.loc, "%s", ds.toChars());
+                    overloadApply(s, (ds){
+                        if (auto fd = ds.isFuncDeclaration())
+                            .errorSupplemental(ds.loc, "%s%s", fd.toChars(),
+                                fd.type.toTypeFunction().parameterList.parametersTypeToChars());
+                        else
+                            .errorSupplemental(ds.loc, "%s", ds.toChars());
+                        return 0;
+                    });
                 }
             }
             else if (f.errors)

--- a/compiler/test/fail_compilation/fail320.d
+++ b/compiler/test/fail_compilation/fail320.d
@@ -2,10 +2,12 @@
 EXTRA_FILES: imports/fail320a.d imports/fail320b.d
 TEST_OUTPUT:
 ---
-fail_compilation/fail320.d(14): Error: no overload matches for `foo("")`
-fail_compilation/fail320.d(14):        Candidates are:
-fail_compilation/imports/fail320b.d(1):        foo(T)()
-fail_compilation/imports/fail320a.d(1):        foo
+fail_compilation/fail320.d(16): Error: no overload matches for `foo("")`
+fail_compilation/fail320.d(16):        Candidates are:
+fail_compilation/imports/fail320b.d(1):        foo(T)(string)
+fail_compilation/imports/fail320b.d(2):        foo(alias a)()
+fail_compilation/imports/fail320a.d(1):        foo(int)
+fail_compilation/imports/fail320a.d(2):        foo(bool)
 ---
 */
 

--- a/compiler/test/fail_compilation/imports/fail320a.d
+++ b/compiler/test/fail_compilation/imports/fail320a.d
@@ -1,1 +1,2 @@
 void foo(int) { }
+void foo(bool) { }

--- a/compiler/test/fail_compilation/imports/fail320b.d
+++ b/compiler/test/fail_compilation/imports/fail320b.d
@@ -1,1 +1,2 @@
-void foo(T)(){}
+void foo(T)(string){}
+void foo(alias a)(){}


### PR DESCRIPTION
Also fix missing non-template function parameters.

Part of Issue 21338 - Confusing error message for template overload resolution failure.