### PR TITLE
[trivial] Use errorSupplemental to list conflicting symbols

### DIFF
--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -1755,9 +1755,9 @@ public:
         }
         if (loc.isValid())
         {
-            .error(loc, "%s `%s` at %s conflicts with %s `%s` at %s",
-                s1.kind(), s1.toPrettyChars(), s1.locToChars(),
-                s2.kind(), s2.toPrettyChars(), s2.locToChars());
+            .error(loc, "`%s` matches conflicting symbols:", s1.ident.toChars());
+            errorSupplemental(s1.loc, "%s `%s`", s1.kind(), s1.toPrettyChars());
+            errorSupplemental(s2.loc, "%s `%s`", s2.kind(), s2.toPrettyChars());
 
             static if (0)
             {

--- a/compiler/test/fail_compilation/fail12.d
+++ b/compiler/test/fail_compilation/fail12.d
@@ -1,7 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12.d(17): Error: function `fail12.main.Foo!(y).abc` at fail_compilation/fail12.d(9) conflicts with function `fail12.main.Foo!(y).abc` at fail_compilation/fail12.d(9)
+fail_compilation/fail12.d(19): Error: `abc` matches conflicting symbols:
+fail_compilation/fail12.d(11):        function `fail12.main.Foo!(y).abc`
+fail_compilation/fail12.d(11):        function `fail12.main.Foo!(y).abc`
 ---
 */
 template Foo(alias b)

--- a/compiler/test/fail_compilation/fail1900.d
+++ b/compiler/test/fail_compilation/fail1900.d
@@ -30,7 +30,9 @@ void test1900a()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail1900.d(42): Error: template `imports.fail1900b.Bar(short n)` at fail_compilation/imports/fail1900b.d(2) conflicts with template `imports.fail1900a.Bar(int n)` at fail_compilation/imports/fail1900a.d(2)
+fail_compilation/fail1900.d(44): Error: `Bar` matches conflicting symbols:
+fail_compilation/imports/fail1900b.d(2):        template `imports.fail1900b.Bar(short n)`
+fail_compilation/imports/fail1900a.d(2):        template `imports.fail1900a.Bar(int n)`
 ---
 */
 
@@ -45,7 +47,9 @@ void test1900b()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail1900.d(66): Error: template `fail1900.Mix2b!().Baz(int x)` at fail_compilation/fail1900.d(58) conflicts with template `fail1900.Mix2a!().Baz(byte x)` at fail_compilation/fail1900.d(54)
+fail_compilation/fail1900.d(70): Error: `Baz` matches conflicting symbols:
+fail_compilation/fail1900.d(62):        template `fail1900.Mix2b!().Baz(int x)`
+fail_compilation/fail1900.d(58):        template `fail1900.Mix2a!().Baz(byte x)`
 ---
 */
 


### PR DESCRIPTION
This is much easier to read.