### PR TITLE
fix Issue 23445 - Can leak scope variable through delegate context

### DIFF
--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -611,6 +611,10 @@ public:
      */
     VarDeclarations outerVars;
 
+    /** Subset of outerVars that are returned by the nested function
+     */
+    VarDeclarations outerVarsReturnedByValue;
+
     // Sibling nested functions which called this one
     FuncDeclarations siblingCallers;
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4176,6 +4176,20 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.type = exp.type.typeSemantic(exp.loc, sc);
 
             exp.fd.tok = TOK.delegate_;
+
+            /* Cannot take the address of a nested function that returns scope variables from
+             * outer scopes
+             */
+            foreach (vo; exp.fd.outerVarsReturnedByValue[])
+            {
+                if (vo.isScope && exp.fd.type.isTypeFunction().hasReturnParameters())
+                {
+//xyzzy
+                    if (setUnsafePreview(sc, global.params.useDIP1000, false, exp.loc,
+                        "cannot make delegate from `%s` because it returns `%s` from outer `%s`", exp.fd, vo, vo.toParent()))
+                        return setError();
+                }
+            }
         }
         else
         {
@@ -7130,9 +7144,24 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 ve.checkPurity(sc, v);
             }
-            FuncDeclaration f = ve.var.isFuncDeclaration();
-            if (f)
+            if (FuncDeclaration f = ve.var.isFuncDeclaration())
             {
+                /* Cannot take the address of a nested function that returns scope variables from
+                 * outer scopes
+                 */
+                foreach (vo; f.outerVarsReturnedByValue[])
+                {
+                    if (vo.isScope && f.type.isTypeFunction().hasReturnParameters())
+                    {
+//xyzzy
+                        if (setUnsafePreview(sc, global.params.useDIP1000, false, exp.loc,
+                            "cannot make delegate from `%s` because it returns `%s` from outer `%s`", f, vo, vo.toParent()))
+                            return setError();
+                    }
+                }
+
+                if (f.isNested())
+
                 /* Because nested functions cannot be overloaded,
                  * mark here that we took its address because castTo()
                  * may not be called with an exact match.

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3745,6 +3745,7 @@ public:
     TypeFunction* syntaxCopy() override;
     void purityLevel();
     bool hasLazyParameters();
+    bool hasReturnParameters();
     bool isDstyleVariadic() const;
     StorageClass parameterStorageClass(Type* tthis, Parameter* p);
     Type* addStorageClass(StorageClass stc) override;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2477,6 +2477,7 @@ public:
     bool requiresClosure;
     Array<VarDeclaration* > closureVars;
     Array<VarDeclaration* > outerVars;
+    Array<VarDeclaration* > outerVarsReturnedByValue;
     Array<FuncDeclaration* > siblingCallers;
     Array<FuncDeclaration* >* inlinedNestedCallees;
     AttributeViolation* safetyViolation;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -340,6 +340,10 @@ extern (C++) class FuncDeclaration : Declaration
      */
     VarDeclarations outerVars;
 
+    /** Subset of outerVars that are returned by the nested function
+     */
+    VarDeclarations outerVarsReturnedByValue;
+
     /// Sibling nested functions which called this one
     FuncDeclarations siblingCallers;
 

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4387,6 +4387,23 @@ extern (C++) final class TypeFunction : TypeNext
         return false;
     }
 
+    /********************************
+     * Returns: true if any of the parameters are marked `return`
+     */
+
+    bool hasReturnParameters()
+    {
+        if (isreturnscope)
+            return true;
+        foreach (i, fparam; parameterList)
+        {
+            const sr = buildScopeRef(fparam.storageClass);
+            if (buildScopeRef(sr == ScopeRef.ReturnScope || sr == ScopeRef.Ref_ReturnScope))
+                return true;
+        }
+        return false;
+    }
+
     /*******************************
      * Check for `extern (D) U func(T t, ...)` variadic function type,
      * which has `_arguments[]` added as the first argument.

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -613,6 +613,7 @@ public:
     TypeFunction *syntaxCopy() override;
     void purityLevel();
     bool hasLazyParameters();
+    bool hasReturnParameters();
     bool isDstyleVariadic() const;
     StorageClass parameterStorageClass(Parameter *p);
     Type *addStorageClass(StorageClass stc) override;

--- a/compiler/test/fail_compilation/test23438.d
+++ b/compiler/test/fail_compilation/test23438.d
@@ -1,0 +1,45 @@
+/* REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test23438.d(114): Error: scope variable `x` assigned to global variable `escaped`
+---
+*/
+
+// https://github.com/dlang/dmd/pull/14601
+
+#line 100
+
+int global;
+int* escaped;
+
+void quxfail() @safe
+{
+    int stack=1337;
+    int* foo(return scope int* x) @safe
+    {
+        int* bar(return scope int* y) @safe
+        {
+            return x;
+        }
+        auto p = &bar;
+        escaped = bar(&global); // fail
+        return x;
+    }
+    foo(&stack);
+}
+
+void quxsucceed() @safe
+{
+    int stack=1337;
+    int* foo(return scope int* x) @safe
+    {
+        int* bar(return scope int* y) @safe
+        {
+            return x;
+        }
+        auto dg = &bar; // causes closure to be GC allocated
+        escaped = dg(&global); // so this should succeed
+        return x;
+    }
+    foo(&stack);
+}

--- a/compiler/test/fail_compilation/test23445.d
+++ b/compiler/test/fail_compilation/test23445.d
@@ -1,0 +1,63 @@
+/* REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test23445.d(105): Error: cannot make delegate from `__lambda2` because it returns `p` from outer `foo1`
+fail_compilation/test23445.d(117): Error: cannot make delegate from `nested` because it returns `p` from outer `foo2`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=23445
+
+#line 100
+
+int global;
+
+int* foo1(scope int* p)@safe
+{
+    auto dg=(return scope int* q)@safe return scope{
+        return p;
+    };
+    return dg(&global);
+}
+
+int* foo2(scope int* p)@safe
+{
+    int* nested(return scope int* q)@safe return scope
+    {
+        return p;
+    }
+    auto dg = &nested;
+    return dg(&global);
+}
+
+struct S
+{
+    char* p;
+
+    char* parseType() return scope pure @safe
+    {
+	char* parseBackrefType() pure @safe
+	{
+	    char* foo() { return p; }
+            auto dg = &foo;
+	    return dg();
+	}
+	return p;
+    }
+}
+
+struct T
+{
+    char* p;
+
+    char* parseType() return scope pure @safe
+    {
+	char* parseBackrefType(scope char* delegate() pure @safe parseDg) pure @safe
+	{
+	    char* foo() { return parseType(); }
+            auto dg = &foo;
+	    return parseBackrefType( dg );
+	}
+	return p;
+    }
+}


### PR DESCRIPTION
Since this incorporates https://github.com/dlang/dmd/pull/14601, that should be pulled first and so it blocks this PR.

Since the type of a delegate loses information about what outer variables may be returned, the most pragmatic solution is to disallow creating delegates that return outer scoped variables.