### PR TITLE
Fix Issue 23456 - OpenBSD: Add waitid support

### DIFF
--- a/druntime/src/core/sys/posix/sys/wait.d
+++ b/druntime/src/core/sys/posix/sys/wait.d
@@ -452,6 +452,7 @@ else version (NetBSD)
 }
 else version (OpenBSD)
 {
+    int waitid(idtype_t, id_t, siginfo_t*, int);
 }
 else version (DragonFlyBSD)
 {


### PR DESCRIPTION
As stated, we support waitid(2) now.
https://marc.info/?l=openbsd-cvs&m=166671373628366&w=2