### PR TITLE
Use Array.length instead of Array.dim

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
 # .git-blame-ignore-revs
 # Removed all SC Enum aliases, which touched a ton of backend/glue files
 98a842927e4905fc2ecc0e93ffd64b5da3ebbcf2
+
+# Rename Array.dim access to Array.length
+0331e76234deff5bfdb0c42f5bb42f4bb7c97b30

--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -193,7 +193,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     final size_t nonHiddenFields()
     {
-        return fields.dim - isNested() - (vthis2 !is null);
+        return fields.length - isNested() - (vthis2 !is null);
     }
 
     /***************************************
@@ -274,7 +274,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     {
         //printf("AggregateDeclaration::checkOverlappedFields() %s\n", toChars());
         assert(sizeok == Sizeok.done);
-        size_t nfields = fields.dim;
+        size_t nfields = fields.length;
         if (isNested())
         {
             auto cd = isClassDeclaration();
@@ -362,7 +362,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         const nfields = nonHiddenFields();
         bool errors = false;
 
-        size_t dim = elements.dim;
+        size_t dim = elements.length;
         elements.setDim(nfields);
         foreach (size_t i; dim .. nfields)
             elements[i] = null;
@@ -774,7 +774,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                 }
             }
 
-            for (size_t i = 0; i < members.dim; i++)
+            for (size_t i = 0; i < members.length; i++)
             {
                 auto sm = (*members)[i];
                 sm.apply(&SearchCtor.fp, null);

--- a/compiler/src/dmd/argtypes_sysv_x64.d
+++ b/compiler/src/dmd/argtypes_sysv_x64.d
@@ -314,7 +314,7 @@ extern (C++) final class ToClassesVisitor : Visitor
             return field.type;
         }
 
-        classifyFields(baseOffset, t.sym.fields.dim, &getNthField);
+        classifyFields(baseOffset, t.sym.fields.length, &getNthField);
     }
 
     void classifyStaticArrayElements(uint baseOffset, TypeSArray t)

--- a/compiler/src/dmd/argtypes_x86.d
+++ b/compiler/src/dmd/argtypes_x86.d
@@ -275,7 +275,7 @@ extern (C++) TypeTuple toArgTypes_x86(Type t)
             /*****
              * Get the nth element of this array.
              * Params:
-             *   n = element number, from 0..dim
+             *   n = element number, from 0..length
              *   offset = set to offset of the element from the start of the array
              *   alignsize = set to the aligned size of the element
              * Returns:
@@ -315,7 +315,7 @@ extern (C++) TypeTuple toArgTypes_x86(Type t)
                 return field.type;
             }
 
-            aggregate(t.size(Loc.initial), t.sym.fields.dim, &getNthField);
+            aggregate(t.size(Loc.initial), t.sym.fields.length, &getNthField);
         }
 
         /*******************
@@ -364,7 +364,7 @@ extern (C++) TypeTuple toArgTypes_x86(Type t)
                 uint falignsize;
                 Type ftype = getFieldInfo(0, foffset, falignsize);
                 TypeTuple tup = toArgTypes_x86(ftype);
-                if (tup && tup.arguments.dim == 1)
+                if (tup && tup.arguments.length == 1)
                 {
                     Type ft1 = (*tup.arguments)[0].type;
                     if (ft1.ty == Tfloat32 || ft1.ty == Tfloat64)

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -108,7 +108,7 @@ struct ASTBase
         extern (D) static bool oneMembers(ref Dsymbols members, Dsymbol* ps, Identifier ident)
         {
             Dsymbol s = null;
-            for (size_t i = 0; i < members.dim; i++)
+            for (size_t i = 0; i < members.length; i++)
             {
                 Dsymbol sx = members[i];
                 bool x = sx.oneMember(ps, ident);
@@ -979,8 +979,8 @@ struct ASTBase
             Objects* a = null;
             if (objs)
             {
-                a = new Objects(objs.dim);
-                for (size_t i = 0; i < objs.dim; i++)
+                a = new Objects(objs.length);
+                for (size_t i = 0; i < objs.length; i++)
                     (*a)[i] = objectSyntaxCopy((*objs)[i]);
             }
             return a;
@@ -1081,9 +1081,9 @@ struct ASTBase
         extern (D) static Expressions* concat(Expressions* udas1, Expressions* udas2)
         {
             Expressions* udas;
-            if (!udas1 || udas1.dim == 0)
+            if (!udas1 || udas1.length == 0)
                 udas = udas2;
-            else if (!udas2 || udas2.dim == 0)
+            else if (!udas2 || udas2.length == 0)
                 udas = udas1;
             else
             {
@@ -1465,7 +1465,7 @@ struct ASTBase
 
             this.members = members;
 
-            //printf("ClassDeclaration(%s), dim = %d\n", id.toChars(), this.baseclasses.dim);
+            //printf("ClassDeclaration(%s), dim = %d\n", id.toChars(), this.baseclasses.length);
 
             // For forward references
             type = new TypeClass(this);
@@ -1649,7 +1649,7 @@ struct ASTBase
         extern (D) this(const ref Loc loc, Identifier ident, TypeQualified tqual, Objects *tiargs)
         {
             super(loc,
-                  tqual.idents.dim ? cast(Identifier)tqual.idents[tqual.idents.dim - 1] : (cast(TypeIdentifier)tqual).ident,
+                  tqual.idents.length ? cast(Identifier)tqual.idents[tqual.idents.length - 1] : (cast(TypeIdentifier)tqual).ident,
                   tiargs ? tiargs : new Objects());
             this.ident = ident;
             this.tqual = tqual;
@@ -1734,7 +1734,7 @@ struct ASTBase
 
             size_t n = pn ? *pn : 0; // take over index
             int result = 0;
-            foreach (i; 0 .. parameters.dim)
+            foreach (i; 0 .. parameters.length)
             {
                 Parameter p = (*parameters)[i];
                 Type t = p.type.toBasetype();
@@ -1771,8 +1771,8 @@ struct ASTBase
             Parameters* params = null;
             if (parameters)
             {
-                params = new Parameters(parameters.dim);
-                for (size_t i = 0; i < params.dim; i++)
+                params = new Parameters(parameters.length);
+                for (size_t i = 0; i < params.length; i++)
                     (*params)[i] = (*parameters)[i].syntaxCopy();
             }
             return params;
@@ -3652,10 +3652,10 @@ struct ASTBase
         extern (D) this(Expressions* exps)
         {
             super(Ttuple);
-            auto arguments = new Parameters(exps ? exps.dim : 0);
+            auto arguments = new Parameters(exps ? exps.length : 0);
             if (exps)
             {
-                for (size_t i = 0; i < exps.dim; i++)
+                for (size_t i = 0; i < exps.length; i++)
                 {
                     Expression e = (*exps)[i];
                     if (e.type.ty == Ttuple)
@@ -4258,8 +4258,8 @@ struct ASTBase
 
         final void syntaxCopyHelper(TypeQualified t)
         {
-            idents.setDim(t.idents.dim);
-            for (size_t i = 0; i < idents.dim; i++)
+            idents.setDim(t.idents.length);
+            for (size_t i = 0; i < idents.length; i++)
             {
                 RootObject id = t.idents[i];
                 switch (id.dyncast()) with (DYNCAST)
@@ -4288,7 +4288,7 @@ struct ASTBase
 
         final Expression toExpressionHelper(Expression e, size_t i = 0)
         {
-            for (; i < idents.dim; i++)
+            for (; i < idents.length; i++)
             {
                 RootObject id = idents[i];
 
@@ -4371,7 +4371,7 @@ struct ASTBase
                 Expressions* a = null;
                 if (exps)
                 {
-                    a = new Expressions(exps.dim);
+                    a = new Expressions(exps.length);
                     foreach (i, e; *exps)
                     {
                         (*a)[i] = e ? e.syntaxCopy() : null;
@@ -4984,7 +4984,7 @@ struct ASTBase
         extern (D) this(const ref Loc loc, Expressions* keys, Expressions* values)
         {
             super(loc, EXP.assocArrayLiteral, __traits(classInstanceSize, AssocArrayLiteralExp));
-            assert(keys.dim == values.dim);
+            assert(keys.length == values.length);
             this.keys = keys;
             this.values = values;
         }
@@ -5040,7 +5040,7 @@ struct ASTBase
             if (td)
             {
                 assert(td.literal);
-                assert(td.members && td.members.dim == 1);
+                assert(td.members && td.members.length == 1);
                 fd = (*td.members)[0].isFuncLiteralDeclaration();
             }
             tok = fd.tok; // save original kind of function/delegate/(infer)
@@ -5263,8 +5263,8 @@ struct ASTBase
             super(loc, EXP.tuple, __traits(classInstanceSize, TupleExp));
             this.exps = new Expressions();
 
-            this.exps.reserve(tup.objects.dim);
-            for (size_t i = 0; i < tup.objects.dim; i++)
+            this.exps.reserve(tup.objects.length);
+            for (size_t i = 0; i < tup.objects.length; i++)
             {
                 RootObject o = (*tup.objects)[i];
                 if (Dsymbol s = getDsymbol(o))

--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -781,7 +781,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
              * so in order to place that member we need to compute the member's
              * size and alignment.
              */
-            size_t fieldstart = ad.fields.dim;
+            size_t fieldstart = ad.fields.length;
 
             /* Hackishly hijack ad's structsize and alignsize fields
              * for use in our fake anon aggregate member.
@@ -804,7 +804,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
              * added in ad.fields, just update *poffset for the subsequent
              * field offset calculation.
              */
-            if (fieldstart == ad.fields.dim)
+            if (fieldstart == ad.fields.length)
             {
                 ad.structsize = savestructsize;
                 ad.alignsize = savealignsize;
@@ -838,7 +838,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
 
             // Add to the anon fields the base offset of this anonymous aggregate
             //printf("anon fields, anonoffset = %d\n", anonoffset);
-            foreach (const i; fieldstart .. ad.fields.dim)
+            foreach (const i; fieldstart .. ad.fields.length)
             {
                 VarDeclaration v = ad.fields[i];
                 //printf("\t[%d] %s %d\n", i, v.toChars(), v.offset);
@@ -1349,7 +1349,7 @@ extern (C++) final class UserAttributeDeclaration : AttribDeclaration
     override Scope* newScope(Scope* sc)
     {
         Scope* sc2 = sc;
-        if (atts && atts.dim)
+        if (atts && atts.length)
         {
             // create new one for changes
             sc2 = sc.copy();
@@ -1369,9 +1369,9 @@ extern (C++) final class UserAttributeDeclaration : AttribDeclaration
     extern (D) static Expressions* concat(Expressions* udas1, Expressions* udas2)
     {
         Expressions* udas;
-        if (!udas1 || udas1.dim == 0)
+        if (!udas1 || udas1.length == 0)
             udas = udas2;
-        else if (!udas2 || udas2.dim == 0)
+        else if (!udas2 || udas2.length == 0)
             udas = udas1;
         else
         {
@@ -1395,7 +1395,7 @@ extern (C++) final class UserAttributeDeclaration : AttribDeclaration
         auto exps = new Expressions();
         if (userAttribDecl && userAttribDecl !is this)
             exps.push(new TupleExp(Loc.initial, userAttribDecl.getAttributes()));
-        if (atts && atts.dim)
+        if (atts && atts.length)
             exps.push(new TupleExp(Loc.initial, atts));
         return exps;
     }

--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -122,7 +122,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
 
         override void visit(CompoundStatement cs)
         {
-            //printf("CompoundStatement.blockExit(%p) %d result = x%X\n", cs, cs.statements.dim, result);
+            //printf("CompoundStatement.blockExit(%p) %d result = x%X\n", cs, cs.statements.length, result);
             result = BE.fallthru;
             Statement slast = null;
             foreach (s; *cs.statements)

--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -102,7 +102,7 @@ extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, bool mustN
             if (global.errors && !ce.e1.type)
                 return; // error recovery
 
-            if (ce.f && ce.arguments.dim > 0)
+            if (ce.f && ce.arguments.length > 0)
             {
                 Type tb = (*ce.arguments)[0].type.toBasetype();
                 auto tbNext = tb.nextOf();

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -870,17 +870,17 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
         return;                    // unions don't have destructors
 
     StorageClass stc = STC.safe | STC.nothrow_ | STC.pure_ | STC.nogc;
-    Loc declLoc = ad.userDtors.dim ? ad.userDtors[0].loc : ad.loc;
+    Loc declLoc = ad.userDtors.length ? ad.userDtors[0].loc : ad.loc;
     Loc loc; // internal code should have no loc to prevent coverage
     FuncDeclaration xdtor_fwd = null;
 
     // Build the field destructor (`ad.fieldDtor`), if needed.
     // If the user dtor is an extern(C++) prototype, then we expect it performs a full-destruction and skip building.
-    const bool dtorIsCppPrototype = ad.userDtors.dim && ad.userDtors[0]._linkage == LINK.cpp && !ad.userDtors[0].fbody;
+    const bool dtorIsCppPrototype = ad.userDtors.length && ad.userDtors[0]._linkage == LINK.cpp && !ad.userDtors[0].fbody;
     if (!dtorIsCppPrototype)
     {
         Expression e = null;
-        for (size_t i = 0; i < ad.fields.dim; i++)
+        for (size_t i = 0; i < ad.fields.length; i++)
         {
             auto v = ad.fields[i];
             if (v.storage_class & STC.ref_)
@@ -985,7 +985,7 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
     }
 
     // Set/build `ad.aggrDtor`
-    switch (dtors.dim)
+    switch (dtors.length)
     {
     case 0:
         break;
@@ -1168,7 +1168,7 @@ private DtorDeclaration buildExternDDtor(AggregateDeclaration ad, Scope* sc)
  */
 FuncDeclaration buildInv(AggregateDeclaration ad, Scope* sc)
 {
-    switch (ad.invs.dim)
+    switch (ad.invs.length)
     {
     case 0:
         return null;
@@ -1225,11 +1225,11 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
     if (sd.isUnionDeclaration())
         return null;
 
-    const hasUserDefinedPosblit = sd.postblits.dim && !sd.postblits[0].isDisabled ? true : false;
+    const hasUserDefinedPosblit = sd.postblits.length && !sd.postblits[0].isDisabled ? true : false;
 
     // by default, the storage class of the created postblit
     StorageClass stc = STC.safe | STC.nothrow_ | STC.pure_ | STC.nogc;
-    Loc declLoc = sd.postblits.dim ? sd.postblits[0].loc : sd.loc;
+    Loc declLoc = sd.postblits.length ? sd.postblits[0].loc : sd.loc;
     Loc loc; // internal code should have no loc to prevent coverage
 
     // if any of the postblits are disabled, then the generated postblit
@@ -1240,7 +1240,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
     VarDeclaration[] fieldsToDestroy;
     auto postblitCalls = new Statements();
     // iterate through all the struct fields that are not disabled
-    for (size_t i = 0; i < sd.fields.dim && !(stc & STC.disable); i++)
+    for (size_t i = 0; i < sd.fields.length && !(stc & STC.disable); i++)
     {
         auto structField = sd.fields[i];
         if (structField.storage_class & STC.ref_)
@@ -1411,7 +1411,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
     }
 
     // Build our own "postblit" which executes a, but only if needed.
-    if (postblitCalls.dim || (stc & STC.disable))
+    if (postblitCalls.length || (stc & STC.disable))
     {
         //printf("Building __fieldPostBlit()\n");
         checkShared();
@@ -1426,7 +1426,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
 
     // create __xpostblit, which is the generated postblit
     FuncDeclaration xpostblit = null;
-    switch (sd.postblits.dim)
+    switch (sd.postblits.length)
     {
     case 0:
         break;

--- a/compiler/src/dmd/compiler.d
+++ b/compiler/src/dmd/compiler.d
@@ -213,7 +213,7 @@ do
 {
     createMatchNodes();
     size_t nodeIndex = 0;
-    while (nodeIndex < matchNodes.dim)
+    while (nodeIndex < matchNodes.length)
     {
         //printf("matcher ");printMatcher(nodeIndex);printf("\n");
         auto info = matchNodes[nodeIndex++];
@@ -236,7 +236,7 @@ do
         }
         nodeIndex += info.depth;
     }
-    assert(nodeIndex == matchNodes.dim, "code bug");
+    assert(nodeIndex == matchNodes.length, "code bug");
     return includeByDefault;
 }
 
@@ -291,7 +291,7 @@ private void createMatchNodes()
     static size_t findSortedIndexToAddForDepth(size_t depth)
     {
         size_t index = 0;
-        while (index < matchNodes.dim)
+        while (index < matchNodes.length)
         {
             auto info = matchNodes[index];
             if (depth > info.depth)
@@ -301,7 +301,7 @@ private void createMatchNodes()
         return index;
     }
 
-    if (matchNodes.dim == 0)
+    if (matchNodes.length == 0)
     {
         foreach (modulePattern; includeModulePatterns)
         {

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -222,7 +222,7 @@ extern (C++) final class StaticForeach : RootObject
         }
         else
         {
-            assert(rangefe && parameters.dim == 1);
+            assert(rangefe && parameters.length == 1);
             return new ForeachRangeStatement(loc, rangefe.op, (*parameters)[0], rangefe.lwr.syntaxCopy(), rangefe.upr.syntaxCopy(), s, loc);
         }
     }
@@ -306,7 +306,7 @@ extern (C++) final class StaticForeach : RootObject
 
     private void lowerNonArrayAggregate(Scope* sc)
     {
-        auto nvars = aggrfe ? aggrfe.parameters.dim : 1;
+        auto nvars = aggrfe ? aggrfe.parameters.length : 1;
         auto aloc = aggrfe ? aggrfe.aggr.loc : rangefe.lwr.loc;
         // We need three sets of foreach loop variables because the
         // lowering contains three foreach loops.
@@ -332,7 +332,7 @@ extern (C++) final class StaticForeach : RootObject
         {
             foreach (i; 0 .. 2)
             {
-                auto e = new Expressions(pparams[0].dim);
+                auto e = new Expressions(pparams[0].length);
                 foreach (j, ref elem; *e)
                 {
                     auto p = (*pparams[i])[j];

--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -644,7 +644,7 @@ UnionExp Equal(EXP op, const ref Loc loc, Type type, Expression e1, Expression e
         }
         else if (ArrayLiteralExp es2 = e2.isArrayLiteralExp())
         {
-            cmp = !es2.elements || (0 == es2.elements.dim);
+            cmp = !es2.elements || (0 == es2.elements.length);
         }
         else
         {
@@ -660,7 +660,7 @@ UnionExp Equal(EXP op, const ref Loc loc, Type type, Expression e1, Expression e
         }
         else if (ArrayLiteralExp es1 = e1.isArrayLiteralExp())
         {
-            cmp = !es1.elements || (0 == es1.elements.dim);
+            cmp = !es1.elements || (0 == es1.elements.length);
         }
         else
         {
@@ -689,15 +689,15 @@ UnionExp Equal(EXP op, const ref Loc loc, Type type, Expression e1, Expression e
     {
         ArrayLiteralExp es1 = e1.isArrayLiteralExp();
         ArrayLiteralExp es2 = e2.isArrayLiteralExp();
-        if ((!es1.elements || !es1.elements.dim) && (!es2.elements || !es2.elements.dim))
+        if ((!es1.elements || !es1.elements.length) && (!es2.elements || !es2.elements.length))
             cmp = 1; // both arrays are empty
         else if (!es1.elements || !es2.elements)
             cmp = 0;
-        else if (es1.elements.dim != es2.elements.dim)
+        else if (es1.elements.length != es2.elements.length)
             cmp = 0;
         else
         {
-            for (size_t i = 0; i < es1.elements.dim; i++)
+            for (size_t i = 0; i < es1.elements.length; i++)
             {
                 auto ee1 = es1[i];
                 auto ee2 = es2[i];
@@ -724,7 +724,7 @@ UnionExp Equal(EXP op, const ref Loc loc, Type type, Expression e1, Expression e
         StringExp es1 = e1.isStringExp();
         ArrayLiteralExp es2 = e2.isArrayLiteralExp();
         size_t dim1 = es1.len;
-        size_t dim2 = es2.elements ? es2.elements.dim : 0;
+        size_t dim2 = es2.elements ? es2.elements.length : 0;
         if (dim1 != dim2)
             cmp = 0;
         else
@@ -751,16 +751,16 @@ UnionExp Equal(EXP op, const ref Loc loc, Type type, Expression e1, Expression e
         StructLiteralExp es2 = e2.isStructLiteralExp();
         if (es1.sd != es2.sd)
             cmp = 0;
-        else if ((!es1.elements || !es1.elements.dim) && (!es2.elements || !es2.elements.dim))
+        else if ((!es1.elements || !es1.elements.length) && (!es2.elements || !es2.elements.length))
             cmp = 1; // both arrays are empty
         else if (!es1.elements || !es2.elements)
             cmp = 0;
-        else if (es1.elements.dim != es2.elements.dim)
+        else if (es1.elements.length != es2.elements.length)
             cmp = 0;
         else
         {
             cmp = 1;
-            for (size_t i = 0; i < es1.elements.dim; i++)
+            for (size_t i = 0; i < es1.elements.length; i++)
             {
                 Expression ee1 = (*es1.elements)[i];
                 Expression ee2 = (*es2.elements)[i];
@@ -1074,7 +1074,7 @@ UnionExp Cast(const ref Loc loc, Type type, Type to, Expression e1)
         StructDeclaration sd = tb.toDsymbol(null).isStructDeclaration();
         assert(sd);
         auto elements = new Expressions();
-        for (size_t i = 0; i < sd.fields.dim; i++)
+        for (size_t i = 0; i < sd.fields.length; i++)
         {
             VarDeclaration v = sd.fields[i];
             UnionExp zero;
@@ -1110,12 +1110,12 @@ UnionExp ArrayLength(Type type, Expression e1)
     }
     else if (ArrayLiteralExp ale = e1.isArrayLiteralExp())
     {
-        size_t dim = ale.elements ? ale.elements.dim : 0;
+        size_t dim = ale.elements ? ale.elements.length : 0;
         emplaceExp!(IntegerExp)(&ue, loc, dim, type);
     }
     else if (AssocArrayLiteralExp ale = e1.isAssocArrayLiteralExp)
     {
-        size_t dim = ale.keys.dim;
+        size_t dim = ale.keys.length;
         emplaceExp!(IntegerExp)(&ue, loc, dim, type);
     }
     else if (e1.type.toBasetype().ty == Tsarray)
@@ -1183,9 +1183,9 @@ UnionExp Index(Type type, Expression e1, Expression e2, bool indexIsInBounds)
         uinteger_t i = e2.toInteger();
         if (ArrayLiteralExp ale = e1.isArrayLiteralExp())
         {
-            if (i >= ale.elements.dim)
+            if (i >= ale.elements.length)
             {
-                e1.error("array index %llu is out of bounds `%s[0 .. %llu]`", i, e1.toChars(), cast(ulong) ale.elements.dim);
+                e1.error("array index %llu is out of bounds `%s[0 .. %llu]`", i, e1.toChars(), cast(ulong) ale.elements.length);
                 emplaceExp!(ErrorExp)(&ue);
             }
             else
@@ -1206,7 +1206,7 @@ UnionExp Index(Type type, Expression e1, Expression e2, bool indexIsInBounds)
     {
         /* Search the keys backwards, in case there are duplicate keys
          */
-        for (size_t i = ae.keys.dim; i;)
+        for (size_t i = ae.keys.length; i;)
         {
             i--;
             Expression ekey = (*ae.keys)[i];
@@ -1274,7 +1274,7 @@ UnionExp Slice(Type type, Expression e1, Expression lwr, Expression upr)
         ArrayLiteralExp es1 = e1.isArrayLiteralExp();
         const uinteger_t ilwr = lwr.toInteger();
         const uinteger_t iupr = upr.toInteger();
-        if (sliceBoundsCheck(0, es1.elements.dim, ilwr, iupr))
+        if (sliceBoundsCheck(0, es1.elements.length, ilwr, iupr))
             cantExp(ue);
         else
         {
@@ -1318,7 +1318,7 @@ void sliceAssignArrayLiteralFromString(ArrayLiteralExp existingAE, const StringE
 void sliceAssignStringFromArrayLiteral(StringExp existingSE, ArrayLiteralExp newae, size_t firstIndex)
 {
     assert(existingSE.ownedByCtfe != OwnedBy.code);
-    foreach (j; 0 .. newae.elements.dim)
+    foreach (j; 0 .. newae.elements.length)
     {
         existingSE.setCodeUnit(firstIndex + j, cast(dchar)newae[j].toInteger());
     }
@@ -1383,9 +1383,9 @@ private Expressions* copyElements(Expression e1, Expression e2 = null)
     {
         if (!ale.elements)
             return;
-        auto d = elems.dim;
+        auto d = elems.length;
         elems.append(ale.elements);
-        foreach (ref el; (*elems)[d .. elems.dim])
+        foreach (ref el; (*elems)[d .. elems.length])
         {
             if (!el)
                 el = ale.basis;
@@ -1524,15 +1524,15 @@ UnionExp Cat(const ref Loc loc, Type type, Expression e1, Expression e2)
         // [chars] ~ string --> [chars]
         StringExp es = e2.isStringExp();
         ArrayLiteralExp ea = e1.isArrayLiteralExp();
-        size_t len = es.len + ea.elements.dim;
+        size_t len = es.len + ea.elements.length;
         auto elems = new Expressions(len);
-        for (size_t i = 0; i < ea.elements.dim; ++i)
+        for (size_t i = 0; i < ea.elements.length; ++i)
         {
             (*elems)[i] = ea[i];
         }
         emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, elems);
         ArrayLiteralExp dest = ue.exp().isArrayLiteralExp();
-        sliceAssignArrayLiteralFromString(dest, es, ea.elements.dim);
+        sliceAssignArrayLiteralFromString(dest, es, ea.elements.length);
         assert(ue.exp().type);
         return ue;
     }
@@ -1541,9 +1541,9 @@ UnionExp Cat(const ref Loc loc, Type type, Expression e1, Expression e2)
         // string ~ [chars] --> [chars]
         StringExp es = e1.isStringExp();
         ArrayLiteralExp ea = e2.isArrayLiteralExp();
-        size_t len = es.len + ea.elements.dim;
+        size_t len = es.len + ea.elements.length;
         auto elems = new Expressions(len);
-        for (size_t i = 0; i < ea.elements.dim; ++i)
+        for (size_t i = 0; i < ea.elements.length; ++i)
         {
             (*elems)[es.len + i] = ea[i];
         }
@@ -1609,7 +1609,7 @@ UnionExp Cat(const ref Loc loc, Type type, Expression e1, Expression e2)
         e = ue.exp();
         if (type.toBasetype().ty == Tsarray)
         {
-            e.type = t1.nextOf().sarrayOf(elems.dim);
+            e.type = t1.nextOf().sarrayOf(elems.length);
         }
         else
             e.type = type;
@@ -1633,7 +1633,7 @@ UnionExp Cat(const ref Loc loc, Type type, Expression e1, Expression e2)
         e = ue.exp();
         if (type.toBasetype().ty == Tsarray)
         {
-            e.type = t1.nextOf().sarrayOf(elems.dim);
+            e.type = t1.nextOf().sarrayOf(elems.length);
         }
         else
             e.type = type;
@@ -1651,7 +1651,7 @@ UnionExp Cat(const ref Loc loc, Type type, Expression e1, Expression e2)
         e = ue.exp();
         if (type.toBasetype().ty == Tsarray)
         {
-            e.type = e2.type.sarrayOf(elems.dim);
+            e.type = e2.type.sarrayOf(elems.length);
         }
         else
             e.type = type;
@@ -1667,7 +1667,7 @@ UnionExp Cat(const ref Loc loc, Type type, Expression e1, Expression e2)
         e = ue.exp();
         if (type.toBasetype().ty == Tsarray)
         {
-            e.type = e1.type.sarrayOf(elems.dim);
+            e.type = e1.type.sarrayOf(elems.length);
         }
         else
             e.type = type;

--- a/compiler/src/dmd/cppmangle.d
+++ b/compiler/src/dmd/cppmangle.d
@@ -534,10 +534,10 @@ private final class CppMangleVisitor : Visitor
     {
         /* <template-args> ::= I <template-arg>+ E
          */
-        if (!ti || ti.tiargs.dim <= firstArg)   // could happen if std::basic_string is not a template
+        if (!ti || ti.tiargs.length <= firstArg)   // could happen if std::basic_string is not a template
             return false;
         buf.writeByte('I');
-        foreach (i; firstArg .. ti.tiargs.dim)
+        foreach (i; firstArg .. ti.tiargs.length)
         {
             TemplateDeclaration td = ti.tempdecl.isTemplateDeclaration();
             assert(td);
@@ -556,7 +556,7 @@ private final class CppMangleVisitor : Visitor
                 buf.writeByte('J');     // argument pack
 
                 // mangle the rest of the arguments as types
-                foreach (j; i .. (*ti.tiargs).dim)
+                foreach (j; i .. (*ti.tiargs).length)
                 {
                     Type t = isType((*ti.tiargs)[j]);
                     assert(t);
@@ -760,7 +760,7 @@ private final class CppMangleVisitor : Visitor
             return false;
         Dsymbol q = getQualifier(ti);
         const bool inStd = isStd(q) || isStd(this.getTiNamespace(ti));
-        return inStd && ti.tiargs.dim == 1 && isChar((*ti.tiargs)[0]);
+        return inStd && ti.tiargs.length == 1 && isChar((*ti.tiargs)[0]);
     }
 
     /***
@@ -771,7 +771,7 @@ private final class CppMangleVisitor : Visitor
      */
     bool char_std_char_traits_char(TemplateInstance ti, string st)
     {
-        if (ti.tiargs.dim == 2 &&
+        if (ti.tiargs.length == 2 &&
             isChar((*ti.tiargs)[0]) &&
             isChar_traits_char((*ti.tiargs)[1]))
         {
@@ -851,7 +851,7 @@ private final class CppMangleVisitor : Visitor
         if (ti.name == Id.basic_string)
         {
             // ::std::basic_string<char, ::std::char_traits<char>, ::std::allocator<char>>
-            if (ti.tiargs.dim == 3 &&
+            if (ti.tiargs.length == 3 &&
                 isChar((*ti.tiargs)[0]) &&
                 isChar_traits_char((*ti.tiargs)[1]) &&
                 isAllocator_char((*ti.tiargs)[2]))
@@ -933,7 +933,7 @@ private final class CppMangleVisitor : Visitor
         else if (s.ident == Id.basic_string)
         {
             // ::std::basic_string<char, ::std::char_traits<char>, ::std::allocator<char>>
-            if (ti.tiargs.dim == 3 &&
+            if (ti.tiargs.length == 3 &&
                 isChar((*ti.tiargs)[0]) &&
                 isChar_traits_char((*ti.tiargs)[1]) &&
                 isAllocator_char((*ti.tiargs)[2]))
@@ -1224,7 +1224,7 @@ private final class CppMangleVisitor : Visitor
         case CppOperator.OpAssign:
             TemplateDeclaration td = ti.tempdecl.isTemplateDeclaration();
             assert(td);
-            assert(ti.tiargs.dim >= 1);
+            assert(ti.tiargs.length >= 1);
             TemplateParameter tp = (*td.parameters)[0];
             TemplateValueParameter tv = tp.isTemplateValueParameter();
             if (!tv || !tv.valType.isString())
@@ -2005,14 +2005,14 @@ extern(C++):
                 this.context.res = (*analyzed_ti.tiargs)[idx];
                 o.visitObject(this);
             }
-            if (analyzed_ti.tiargs.dim > t.tiargs.dim)
+            if (analyzed_ti.tiargs.length > t.tiargs.length)
             {
                 // If the resolved AST has more args than the parse one,
                 // we have default arguments
                 auto oparams = (cast(TemplateDeclaration)analyzed_ti.tempdecl).origParameters;
-                foreach (idx, arg; (*oparams)[t.tiargs.dim .. $])
+                foreach (idx, arg; (*oparams)[t.tiargs.length .. $])
                 {
-                    this.context.res = (*analyzed_ti.tiargs)[idx + t.tiargs.dim];
+                    this.context.res = (*analyzed_ti.tiargs)[idx + t.tiargs.length];
 
                     if (auto ttp = arg.isTemplateTypeParameter())
                         ttp.defaultType.accept(this);

--- a/compiler/src/dmd/cppmanglewin.d
+++ b/compiler/src/dmd/cppmanglewin.d
@@ -695,7 +695,7 @@ extern(D):
         case CppOperator.OpAssign:
             TemplateDeclaration td = ti.tempdecl.isTemplateDeclaration();
             assert(td);
-            assert(ti.tiargs.dim >= 1);
+            assert(ti.tiargs.length >= 1);
             TemplateParameter tp = (*td.parameters)[0];
             TemplateValueParameter tv = tp.isTemplateValueParameter();
             if (!tv || !tv.valType.isString())
@@ -749,7 +749,7 @@ extern(D):
             }
         }
         continue_template:
-        if (ti.tiargs.dim == 1)
+        if (ti.tiargs.length == 1)
         {
             buf.writestring(symName);
             return true;
@@ -973,7 +973,7 @@ extern(D):
             is_dmc_template = true;
         }
         bool is_var_arg = false;
-        for (size_t i = firstTemplateArg; i < actualti.tiargs.dim; i++)
+        for (size_t i = firstTemplateArg; i < actualti.tiargs.length; i++)
         {
             RootObject o = (*actualti.tiargs)[i];
             TemplateParameter tp = null;
@@ -1250,7 +1250,7 @@ extern(D):
             rettype.accept(tmp);
             tmp.flags &= ~MANGLE_RETURN_TYPE;
         }
-        if (!type.parameterList.parameters || !type.parameterList.parameters.dim)
+        if (!type.parameterList.parameters || !type.parameterList.parameters.length)
         {
             if (type.parameterList.varargs == VarArg.variadic)
                 tmp.buf.writeByte('Z');

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -192,7 +192,7 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
             {
                 Type tb = t.toBasetype();
                 Type tx = (tb.ty == Tsarray)
-                    ? tb.nextOf().sarrayOf(ale.elements ? ale.elements.dim : 0)
+                    ? tb.nextOf().sarrayOf(ale.elements ? ale.elements.length : 0)
                     : tb.nextOf().arrayOf();
                 se.e1 = ale.implicitCastTo(sc, tx);
             }
@@ -333,7 +333,7 @@ MATCH implicitConvTo(Expression e, Type t)
     {
         const size_t nparams = tf.parameterList.length;
         const size_t j = tf.isDstyleVariadic(); // if TypeInfoArray was prepended
-        foreach (const i; j .. args.dim)
+        foreach (const i; j .. args.length)
         {
             Expression earg = (*args)[i];
             Type targ = earg.type.toBasetype();
@@ -749,12 +749,12 @@ MATCH implicitConvTo(Expression e, Type t)
 
             if (auto tsa = tb.isTypeSArray())
             {
-                if (e.elements.dim != tsa.dim.toInteger())
+                if (e.elements.length != tsa.dim.toInteger())
                     result = MATCH.nomatch;
             }
 
             Type telement = tb.nextOf();
-            if (!e.elements.dim)
+            if (!e.elements.length)
             {
                 if (typen.ty != Tvoid)
                     result = typen.implicitConvTo(telement);
@@ -767,7 +767,7 @@ MATCH implicitConvTo(Expression e, Type t)
                     if (m < result)
                         result = m;
                 }
-                for (size_t i = 0; i < e.elements.dim; i++)
+                for (size_t i = 0; i < e.elements.length; i++)
                 {
                     Expression el = (*e.elements)[i];
                     if (result == MATCH.nomatch)
@@ -792,7 +792,7 @@ MATCH implicitConvTo(Expression e, Type t)
             TypeVector tv = tb.isTypeVector();
             TypeSArray tbase = tv.basetype.isTypeSArray();
             assert(tbase);
-            const edim = e.elements.dim;
+            const edim = e.elements.length;
             const tbasedim = tbase.dim.toInteger();
             if (edim > tbasedim)
             {
@@ -1233,7 +1233,7 @@ MATCH implicitConvTo(Expression e, Type t)
          */
         if (!e.member && e.arguments)
         {
-            for (size_t i = 0; i < e.arguments.dim; ++i)
+            for (size_t i = 0; i < e.arguments.length; ++i)
             {
                 Expression earg = (*e.arguments)[i];
                 if (!earg) // https://issues.dlang.org/show_bug.cgi?id=14853
@@ -1284,7 +1284,7 @@ MATCH implicitConvTo(Expression e, Type t)
                 {
                     extern (C++) static bool convertible(Expression e, ClassDeclaration cd, MOD mod)
                     {
-                        for (size_t i = 0; i < cd.fields.dim; i++)
+                        for (size_t i = 0; i < cd.fields.length; i++)
                         {
                             VarDeclaration v = cd.fields[i];
                             Initializer _init = v._init;
@@ -2101,7 +2101,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
         {
             OverExp eo = e.e1.isOverExp();
             FuncDeclaration f = null;
-            for (size_t i = 0; i < eo.vars.a.dim; i++)
+            for (size_t i = 0; i < eo.vars.a.length; i++)
             {
                 auto s = eo.vars.a[i];
                 auto f2 = s.isFuncDeclaration();
@@ -2177,7 +2177,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
         TupleExp te = e.copy().isTupleExp();
         te.e0 = e.e0 ? e.e0.copy() : null;
         te.exps = e.exps.copy();
-        for (size_t i = 0; i < te.exps.dim; i++)
+        for (size_t i = 0; i < te.exps.length; i++)
         {
             Expression ex = (*te.exps)[i];
             ex = ex.castTo(sc, totuple ? (*totuple.arguments)[i].type : t);
@@ -2239,7 +2239,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             {
                 if (auto tsa = tb.isTypeSArray())
                 {
-                    if (e.elements.dim != tsa.dim.toInteger())
+                    if (e.elements.length != tsa.dim.toInteger())
                         goto L1;
                 }
 
@@ -2247,7 +2247,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
                 if (e.basis)
                     ae.basis = e.basis.castTo(sc, tb.nextOf());
                 ae.elements = e.elements.copy();
-                for (size_t i = 0; i < e.elements.dim; i++)
+                for (size_t i = 0; i < e.elements.length; i++)
                 {
                     Expression ex = (*e.elements)[i];
                     if (!ex)
@@ -2274,7 +2274,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             TypeVector tv = tb.isTypeVector();
             TypeSArray tbase = tv.basetype.isTypeSArray();
             assert(tbase.ty == Tsarray);
-            const edim = e.elements.dim;
+            const edim = e.elements.length;
             const tbasedim = tbase.dim.toInteger();
             if (edim > tbasedim)
                 goto L1;
@@ -2322,8 +2322,8 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             AssocArrayLiteralExp ae = e.copy().isAssocArrayLiteralExp();
             ae.keys = e.keys.copy();
             ae.values = e.values.copy();
-            assert(e.keys.dim == e.values.dim);
-            for (size_t i = 0; i < e.keys.dim; i++)
+            assert(e.keys.length == e.values.length);
+            for (size_t i = 0; i < e.keys.length; i++)
             {
                 Expression ex = (*e.values)[i];
                 ex = ex.castTo(sc, tb.nextOf());
@@ -2637,7 +2637,7 @@ Expression inferType(Expression e, Type t, int flag = 0)
             Type tn = tb.nextOf();
             if (ale.basis)
                 ale.basis = inferType(ale.basis, tn, flag);
-            for (size_t i = 0; i < ale.elements.dim; i++)
+            for (size_t i = 0; i < ale.elements.length; i++)
             {
                 if (Expression e = (*ale.elements)[i])
                 {
@@ -2656,7 +2656,7 @@ Expression inferType(Expression e, Type t, int flag = 0)
         {
             Type ti = taa.index;
             Type tv = taa.nextOf();
-            for (size_t i = 0; i < aale.keys.dim; i++)
+            for (size_t i = 0; i < aale.keys.length; i++)
             {
                 if (Expression e = (*aale.keys)[i])
                 {
@@ -2664,7 +2664,7 @@ Expression inferType(Expression e, Type t, int flag = 0)
                     (*aale.keys)[i] = e;
                 }
             }
-            for (size_t i = 0; i < aale.values.dim; i++)
+            for (size_t i = 0; i < aale.values.length; i++)
             {
                 if (Expression e = (*aale.values)[i])
                 {
@@ -2772,7 +2772,7 @@ Expression scaleFactor(BinExp be, Scope* sc)
  */
 private bool isVoidArrayLiteral(Expression e, Type other)
 {
-    while (e.op == EXP.arrayLiteral && e.type.ty == Tarray && (e.isArrayLiteralExp().elements.dim == 1))
+    while (e.op == EXP.arrayLiteral && e.type.ty == Tarray && (e.isArrayLiteralExp().elements.length == 1))
     {
         auto ale = e.isArrayLiteralExp();
         e = ale[0];
@@ -2784,7 +2784,7 @@ private bool isVoidArrayLiteral(Expression e, Type other)
     if (other.ty != Tsarray && other.ty != Tarray)
         return false;
     Type t = e.type;
-    return (e.op == EXP.arrayLiteral && t.ty == Tarray && t.nextOf().ty == Tvoid && e.isArrayLiteralExp().elements.dim == 0);
+    return (e.op == EXP.arrayLiteral && t.ty == Tarray && t.nextOf().ty == Tvoid && e.isArrayLiteralExp().elements.length == 0);
 }
 
 /**

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -74,10 +74,10 @@ extern (C++) struct BaseClass
 
         //printf("BaseClass.fillVtbl(this='%s', cd='%s')\n", sym.toChars(), cd.toChars());
         if (vtbl)
-            vtbl.setDim(sym.vtbl.dim);
+            vtbl.setDim(sym.vtbl.length);
 
         // first entry is ClassInfo reference
-        for (size_t j = sym.vtblOffset(); j < sym.vtbl.dim; j++)
+        for (size_t j = sym.vtblOffset(); j < sym.vtbl.length; j++)
         {
             FuncDeclaration ifd = sym.vtbl[j].isFuncDeclaration();
 
@@ -113,7 +113,7 @@ extern (C++) struct BaseClass
             BaseClass* b = &baseInterfaces[i];
             BaseClass* b2 = sym.interfaces[i];
 
-            assert(b2.vtbl.dim == 0); // should not be filled yet
+            assert(b2.vtbl.length == 0); // should not be filled yet
             memcpy(b, b2, BaseClass.sizeof);
 
             if (i) // single inheritance is i==0
@@ -217,7 +217,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
         this.members = members;
 
-        //printf("ClassDeclaration(%s), dim = %d\n", ident.toChars(), this.baseclasses.dim);
+        //printf("ClassDeclaration(%s), dim = %d\n", ident.toChars(), this.baseclasses.length);
 
         // For forward references
         type = new TypeClass(this);
@@ -390,8 +390,8 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
         cd.storage_class |= storage_class;
 
-        cd.baseclasses.setDim(this.baseclasses.dim);
-        for (size_t i = 0; i < cd.baseclasses.dim; i++)
+        cd.baseclasses.setDim(this.baseclasses.length);
+        for (size_t i = 0; i < cd.baseclasses.length; i++)
         {
             BaseClass* b = (*this.baseclasses)[i];
             auto b2 = new BaseClass(b.type.syntaxCopy());
@@ -424,7 +424,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         if (!cd)
             return false;
         //printf("ClassDeclaration.isBaseOf2(this = '%s', cd = '%s')\n", toChars(), cd.toChars());
-        for (size_t i = 0; i < cd.baseclasses.dim; i++)
+        for (size_t i = 0; i < cd.baseclasses.length; i++)
         {
             BaseClass* b = (*cd.baseclasses)[i];
             if (b.sym == this || isBaseOf2(b.sym))
@@ -610,7 +610,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
                 if (!b.sym.alignsize)
                     b.sym.alignsize = target.ptrsize;
                 alignmember(structalign_t(cast(ushort)b.sym.alignsize), b.sym.alignsize, &offset);
-                assert(bi < vtblInterfaces.dim);
+                assert(bi < vtblInterfaces.length);
 
                 BaseClass* bv = (*vtblInterfaces)[bi];
                 if (b.sym.interfaces.length == 0)
@@ -879,7 +879,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
             return 0;
         }
 
-        for (size_t i = 0; i < members.dim; i++)
+        for (size_t i = 0; i < members.length; i++)
         {
             auto s = (*members)[i];
             if (s.apply(&func))
@@ -917,7 +917,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
                 return 0;
             }
 
-            for (size_t i = 0; i < members.dim; i++)
+            for (size_t i = 0; i < members.length; i++)
             {
                 auto s = (*members)[i];
                 s.apply(&virtualSemantic);
@@ -926,7 +926,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
         /* Finally, check the vtbl[]
          */
-        foreach (i; 1 .. vtbl.dim)
+        foreach (i; 1 .. vtbl.length)
         {
             auto fd = vtbl[i].isFuncDeclaration();
             //if (fd) printf("\tvtbl[%d] = [%s] %s\n", i, fd.loc.toChars(), fd.toPrettyChars());
@@ -980,7 +980,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     {
         if (!vtblsym)
         {
-            auto vtype = Type.tvoidptr.immutableOf().sarrayOf(vtbl.dim);
+            auto vtype = Type.tvoidptr.immutableOf().sarrayOf(vtbl.length);
             auto var = new VarDeclaration(loc, vtype, Identifier.idPool("__vtbl"), null, STC.immutable_ | STC.static_);
             var.addMember(null, this);
             var.isdataseg = 1;

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -66,7 +66,7 @@ bool checkFrameAccess(Loc loc, Scope* sc, AggregateDeclaration ad, size_t iStart
     }
 
     bool result = false;
-    for (size_t i = iStart; i < ad.fields.dim; i++)
+    for (size_t i = iStart; i < ad.fields.length; i++)
     {
         VarDeclaration vd = ad.fields[i];
         Type tb = vd.type.baseElemOf();
@@ -297,7 +297,7 @@ extern (C++) abstract class Declaration : Dsymbol
                 {
                     auto sd = p.isStructDeclaration();
                     assert(sd);
-                    for (size_t i = 0; i < sd.fields.dim; i++)
+                    for (size_t i = 0; i < sd.fields.length; i++)
                     {
                         auto structField = sd.fields[i];
                         if (structField.overlapped)
@@ -606,7 +606,7 @@ extern (C++) final class TupleDeclaration : Declaration
         {
             /* It's only a type tuple if all the Object's are types
              */
-            for (size_t i = 0; i < objects.dim; i++)
+            for (size_t i = 0; i < objects.length; i++)
             {
                 RootObject o = (*objects)[i];
                 if (o.dyncast() != DYNCAST.type)
@@ -619,10 +619,10 @@ extern (C++) final class TupleDeclaration : Declaration
             /* We know it's a type tuple, so build the TypeTuple
              */
             Types* types = cast(Types*)objects;
-            auto args = new Parameters(objects.dim);
+            auto args = new Parameters(objects.length);
             OutBuffer buf;
             int hasdeco = 1;
-            for (size_t i = 0; i < types.dim; i++)
+            for (size_t i = 0; i < types.length; i++)
             {
                 Type t = (*types)[i];
                 //printf("type = %s\n", t.toChars());
@@ -653,7 +653,7 @@ extern (C++) final class TupleDeclaration : Declaration
     override Dsymbol toAlias2()
     {
         //printf("TupleDeclaration::toAlias2() '%s' objects = %s\n", toChars(), objects.toChars());
-        for (size_t i = 0; i < objects.dim; i++)
+        for (size_t i = 0; i < objects.length; i++)
         {
             RootObject o = (*objects)[i];
             if (Dsymbol s = isDsymbol(o))
@@ -1219,7 +1219,7 @@ extern (C++) class VarDeclaration : Declaration
             fieldState.offset = ad.structsize; // https://issues.dlang.org/show_bug.cgi?id=13613
             return;
         }
-        for (size_t i = 0; i < ad.fields.dim; i++)
+        for (size_t i = 0; i < ad.fields.length; i++)
         {
             if (ad.fields[i] == this)
             {

--- a/compiler/src/dmd/delegatize.d
+++ b/compiler/src/dmd/delegatize.d
@@ -96,7 +96,7 @@ private void lambdaSetParent(Expression e, FuncDeclaration fd)
             if (!vd || !pfd)
                 return;
             // move to fd's closure when applicable
-            foreach (i; 0 .. pfd.closureVars.dim)
+            foreach (i; 0 .. pfd.closureVars.length)
             {
                 if (vd == pfd.closureVars[i])
                 {

--- a/compiler/src/dmd/denum.d
+++ b/compiler/src/dmd/denum.d
@@ -88,7 +88,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         version (none)
         {
             printf("EnumDeclaration::addMember() %s\n", toChars());
-            for (size_t i = 0; i < members.dim; i++)
+            for (size_t i = 0; i < members.length; i++)
             {
                 EnumMember em = (*members)[i].isEnumMember();
                 printf("    member %s\n", em.toChars());
@@ -191,7 +191,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             return handleErrors();
         }
 
-        foreach (const i; 0 .. members.dim)
+        foreach (const i; 0 .. members.length)
         {
             EnumMember em = (*members)[i].isEnumMember();
             if (em)

--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -114,7 +114,7 @@ extern (C++) final class Import : Dsymbol
         assert(!s);
         auto si = new Import(loc, packages, id, aliasId, isstatic);
         si.comment = comment;
-        for (size_t i = 0; i < names.dim; i++)
+        for (size_t i = 0; i < names.length; i++)
         {
             si.addAlias(names[i], aliases[i]);
         }
@@ -241,11 +241,11 @@ extern (C++) final class Import : Dsymbol
         mod.checkImportDeprecation(loc, sc);
         if (sc.explicitVisibility)
             visibility = sc.visibility;
-        if (!isstatic && !aliasId && !names.dim)
+        if (!isstatic && !aliasId && !names.length)
             sc.scopesym.importScope(mod, visibility);
         // Enable access to pkgs/mod as soon as posible, because compiler
         // can traverse them before the import gets semantic (Issue: 21501)
-        if (!aliasId && !names.dim)
+        if (!aliasId && !names.length)
             addPackageAccess(sc.scopesym);
     }
 
@@ -296,14 +296,14 @@ extern (C++) final class Import : Dsymbol
     override void addMember(Scope* sc, ScopeDsymbol sd)
     {
         //printf("Import.addMember(this=%s, sd=%s, sc=%p)\n", toChars(), sd.toChars(), sc);
-        if (names.dim == 0)
+        if (names.length == 0)
             return Dsymbol.addMember(sc, sd);
         if (aliasId)
             Dsymbol.addMember(sc, sd);
         /* Instead of adding the import to sd's symbol table,
          * add each of the alias=name pairs
          */
-        for (size_t i = 0; i < names.dim; i++)
+        for (size_t i = 0; i < names.length; i++)
         {
             Identifier name = names[i];
             Identifier _alias = aliases[i];
@@ -320,7 +320,7 @@ extern (C++) final class Import : Dsymbol
     override void setScope(Scope* sc)
     {
         Dsymbol.setScope(sc);
-        if (aliasdecls.dim)
+        if (aliasdecls.length)
         {
             if (!mod)
                 importAll(sc);

--- a/compiler/src/dmd/dinifile.d
+++ b/compiler/src/dmd/dinifile.d
@@ -286,7 +286,7 @@ void parseConfFile(ref StringTable!(char*) environment, const(char)[] filename, 
              */
             for (size_t j = 0; 1; ++j)
             {
-                if (j == sections.dim)
+                if (j == sections.length)
                 {
                     // Didn't find it
                     envsection = false;

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -282,7 +282,7 @@ private:
 public:
     extern (C++) size_t stackPointer()
     {
-        return values.dim;
+        return values.length;
     }
 
     // The current value of 'this', or NULL if none
@@ -308,12 +308,12 @@ public:
 
     extern (C++) void endFrame()
     {
-        size_t oldframe = cast(size_t)frames[frames.dim - 1];
-        localThis = savedThis[savedThis.dim - 1];
+        size_t oldframe = cast(size_t)frames[frames.length - 1];
+        localThis = savedThis[savedThis.length - 1];
         popAll(framepointer);
         framepointer = oldframe;
-        frames.setDim(frames.dim - 1);
-        savedThis.setDim(savedThis.dim - 1);
+        frames.setDim(frames.length - 1);
+        savedThis.setDim(savedThis.length - 1);
     }
 
     extern (C++) bool isInCurrentFrame(VarDeclaration v)
@@ -328,7 +328,7 @@ public:
         //printf("getValue() %s\n", v.toChars());
         if ((v.isDataseg() || v.storage_class & STC.manifest) && !v.isCTFE())
         {
-            assert(v.ctfeAdrOnStack < globalValues.dim);
+            assert(v.ctfeAdrOnStack < globalValues.length);
             return globalValues[v.ctfeAdrOnStack];
         }
         assert(v.ctfeAdrOnStack < stackPointer());
@@ -354,7 +354,7 @@ public:
             return;
         }
         savedId.push(cast(void*)cast(size_t)v.ctfeAdrOnStack);
-        v.ctfeAdrOnStack = cast(uint)values.dim;
+        v.ctfeAdrOnStack = cast(uint)values.length;
         vars.push(v);
         values.push(null);
     }
@@ -365,7 +365,7 @@ public:
         assert(!v.isReference());
         const oldid = v.ctfeAdrOnStack;
         v.ctfeAdrOnStack = cast(uint)cast(size_t)savedId[oldid];
-        if (v.ctfeAdrOnStack == values.dim - 1)
+        if (v.ctfeAdrOnStack == values.length - 1)
         {
             values.pop();
             vars.pop();
@@ -377,8 +377,8 @@ public:
     {
         if (stackPointer() > maxStackPointer)
             maxStackPointer = stackPointer();
-        assert(values.dim >= stackpointer);
-        for (size_t i = stackpointer; i < values.dim; ++i)
+        assert(values.length >= stackpointer);
+        for (size_t i = stackpointer; i < values.length; ++i)
         {
             VarDeclaration v = vars[i];
             v.ctfeAdrOnStack = cast(uint)cast(size_t)savedId[i];
@@ -391,7 +391,7 @@ public:
     extern (C++) void saveGlobalConstant(VarDeclaration v, Expression e)
     {
         assert(v._init && (v.isConst() || v.isImmutable() || v.storage_class & STC.manifest) && !v.isCTFE());
-        v.ctfeAdrOnStack = cast(uint)globalValues.dim;
+        v.ctfeAdrOnStack = cast(uint)globalValues.length;
         globalValues.push(copyRegionExp(e));
     }
 }
@@ -444,7 +444,7 @@ private Expression interpretFunction(UnionExp* pue, FuncDeclaration fd, InterSta
 
     auto tf = fd.type.toBasetype().isTypeFunction();
     if (tf.parameterList.varargs != VarArg.none && arguments &&
-        ((fd.parameters && arguments.dim != fd.parameters.dim) || (!fd.parameters && arguments.dim)))
+        ((fd.parameters && arguments.length != fd.parameters.length) || (!fd.parameters && arguments.length)))
     {
         fd.error("C-style variadic functions are not yet implemented in CTFE");
         return CTFEExp.cantexp;
@@ -467,8 +467,8 @@ private Expression interpretFunction(UnionExp* pue, FuncDeclaration fd, InterSta
 
     // Place to hold all the arguments to the function while
     // we are evaluating them.
-    size_t dim = arguments ? arguments.dim : 0;
-    assert((fd.parameters ? fd.parameters.dim : 0) == dim);
+    size_t dim = arguments ? arguments.length : 0;
+    assert((fd.parameters ? fd.parameters.length : 0) == dim);
 
     /* Evaluate all the arguments to the function,
      * store the results in eargs[]
@@ -827,7 +827,7 @@ public:
         if (istate.start == s)
             istate.start = null;
 
-        const dim = s.statements ? s.statements.dim : 0;
+        const dim = s.statements ? s.statements.length : 0;
         foreach (i; 0 .. dim)
         {
             Statement sx = (*s.statements)[i];
@@ -850,7 +850,7 @@ public:
         if (istate.start == s)
             istate.start = null;
 
-        const dim = s.statements ? s.statements.dim : 0;
+        const dim = s.statements ? s.statements.length : 0;
         foreach (i; 0 .. dim)
         {
             Statement sx = (*s.statements)[i];
@@ -1034,7 +1034,7 @@ public:
             result = interpret(pue, s.exp, istate, CTFEGoal.LValue);
             return;
         }
-        if (tf.next && tf.next.ty == Tdelegate && istate.fd.closureVars.dim > 0)
+        if (tf.next && tf.next.ty == Tdelegate && istate.fd.closureVars.length > 0)
         {
             // To support this, we need to copy all the closure vars
             // into the delegate literal.
@@ -2291,7 +2291,7 @@ public:
         while (s.isAttribDeclaration())
         {
             auto ad = cast(AttribDeclaration)s;
-            assert(ad.decl && ad.decl.dim == 1); // Currently, only one allowed when parsing
+            assert(ad.decl && ad.decl.length == 1); // Currently, only one allowed when parsing
             s = (*ad.decl)[0];
         }
         if (VarDeclaration v = s.isVarDeclaration())
@@ -2500,7 +2500,7 @@ public:
             return;
 
         auto expsx = e.elements;
-        size_t dim = expsx ? expsx.dim : 0;
+        size_t dim = expsx ? expsx.length : 0;
         for (size_t i = 0; i < dim; i++)
         {
             Expression exp = (*expsx)[i];
@@ -2539,7 +2539,7 @@ public:
         {
             // todo: all tuple expansions should go in semantic phase.
             expandTuples(expsx);
-            if (expsx.dim != dim)
+            if (expsx.length != dim)
             {
                 e.error("CTFE internal error: invalid array literal");
                 result = CTFEExp.cantexp;
@@ -2602,7 +2602,7 @@ public:
             expandTuples(keysx);
         if (valuesx !is e.values)
             expandTuples(valuesx);
-        if (keysx.dim != valuesx.dim)
+        if (keysx.length != valuesx.length)
         {
             e.error("CTFE internal error: invalid AA");
             result = CTFEExp.cantexp;
@@ -2611,10 +2611,10 @@ public:
 
         /* Remove duplicate keys
          */
-        for (size_t i = 1; i < keysx.dim; i++)
+        for (size_t i = 1; i < keysx.length; i++)
         {
             auto ekey = (*keysx)[i - 1];
-            for (size_t j = i; j < keysx.dim; j++)
+            for (size_t j = i; j < keysx.length; j++)
             {
                 auto ekey2 = (*keysx)[j];
                 if (!ctfeEqual(e.loc, EXP.equal, ekey, ekey2))
@@ -2660,14 +2660,14 @@ public:
             return;
         }
 
-        size_t dim = e.elements ? e.elements.dim : 0;
+        size_t dim = e.elements ? e.elements.length : 0;
         auto expsx = e.elements;
 
-        if (dim != e.sd.fields.dim)
+        if (dim != e.sd.fields.length)
         {
             // guaranteed by AggregateDeclaration.fill and TypeStruct.defaultInitLiteral
-            const nvthis = e.sd.fields.dim - e.sd.nonHiddenFields();
-            assert(e.sd.fields.dim - dim == nvthis);
+            const nvthis = e.sd.fields.length - e.sd.nonHiddenFields();
+            assert(e.sd.fields.length - dim == nvthis);
 
             /* If a nested struct has no initialized hidden pointer,
              * set it to null to match the runtime behaviour.
@@ -2683,7 +2683,7 @@ public:
                 ++dim;
             }
         }
-        assert(dim == e.sd.fields.dim);
+        assert(dim == e.sd.fields.length);
 
         foreach (i; 0 .. dim)
         {
@@ -2723,7 +2723,7 @@ public:
         if (expsx !is e.elements)
         {
             expandTuples(expsx);
-            if (expsx.dim != e.sd.fields.dim)
+            if (expsx.length != e.sd.fields.length)
             {
                 e.error("CTFE internal error: invalid struct literal");
                 result = CTFEExp.cantexp;
@@ -2752,7 +2752,7 @@ public:
             return lenExpr;
         size_t len = cast(size_t)lenExpr.toInteger();
         Type elemType = (cast(TypeArray)newtype).next;
-        if (elemType.ty == Tarray && argnum < arguments.dim - 1)
+        if (elemType.ty == Tarray && argnum < arguments.length - 1)
         {
             Expression elem = recursivelyCreateArrayLiteral(pue, loc, elemType, istate, arguments, argnum + 1);
             if (exceptionOrCantInterpret(elem))
@@ -2766,7 +2766,7 @@ public:
             ae.ownedByCtfe = OwnedBy.ctfe;
             return ae;
         }
-        assert(argnum == arguments.dim - 1);
+        assert(argnum == arguments.length - 1);
         if (elemType.ty.isSomeChar)
         {
             const ch = cast(dchar)elemType.defaultInitLiteral(loc).toInteger();
@@ -2813,10 +2813,10 @@ public:
             {
                 StructDeclaration sd = ts.sym;
                 auto exps = new Expressions();
-                exps.reserve(sd.fields.dim);
+                exps.reserve(sd.fields.length);
                 if (e.arguments)
                 {
-                    exps.setDim(e.arguments.dim);
+                    exps.setDim(e.arguments.length);
                     foreach (i, ex; *e.arguments)
                     {
                         ex = interpretRegion(ex, istate);
@@ -2845,12 +2845,12 @@ public:
             ClassDeclaration cd = tc.sym;
             size_t totalFieldCount = 0;
             for (ClassDeclaration c = cd; c; c = c.baseClass)
-                totalFieldCount += c.fields.dim;
+                totalFieldCount += c.fields.length;
             auto elems = new Expressions(totalFieldCount);
             size_t fieldsSoFar = totalFieldCount;
             for (ClassDeclaration c = cd; c; c = c.baseClass)
             {
-                fieldsSoFar -= c.fields.dim;
+                fieldsSoFar -= c.fields.length;
                 foreach (i, v; c.fields)
                 {
                     if (v.inuse)
@@ -2922,7 +2922,7 @@ public:
         if (e.newtype.toBasetype().isscalar())
         {
             Expression newval;
-            if (e.arguments && e.arguments.dim)
+            if (e.arguments && e.arguments.length)
                 newval = (*e.arguments)[0];
             else
                 newval = e.newtype.defaultInitLiteral(e.loc);
@@ -3845,7 +3845,7 @@ public:
                 e.error("CTFE internal error: cannot find field `%s` in `%s`", v.toChars(), ex.toChars());
                 return CTFEExp.cantexp;
             }
-            assert(0 <= fieldi && fieldi < sle.elements.dim);
+            assert(0 <= fieldi && fieldi < sle.elements.length);
 
             // If it's a union, set all other members of this union to void
             stompOverlappedFields(sle, v);
@@ -3953,7 +3953,7 @@ public:
 
             Expressions* oldelems = oldval.isArrayLiteralExp().elements;
             Expressions* newelems = newval.isArrayLiteralExp().elements;
-            assert(oldelems.dim == newelems.dim);
+            assert(oldelems.length == newelems.length);
 
             Type elemtype = oldval.type.nextOf();
             foreach (i, ref oldelem; *oldelems)
@@ -4044,7 +4044,7 @@ public:
             if (auto ale = e1.isArrayLiteralExp())
             {
                 lowerbound = 0;
-                upperbound = ale.elements.dim;
+                upperbound = ale.elements.length;
             }
             else if (auto se = e1.isStringExp())
             {
@@ -4282,7 +4282,7 @@ public:
 
                 extern (C++) Expression assignTo(ArrayLiteralExp ae)
                 {
-                    return assignTo(ae, 0, ae.elements.dim);
+                    return assignTo(ae, 0, ae.elements.length);
                 }
 
                 extern (C++) Expression assignTo(ArrayLiteralExp ae, size_t lwr, size_t upr)
@@ -4781,7 +4781,7 @@ public:
 
             if (fd.ident == Id.__ArrayPostblit || fd.ident == Id.__ArrayDtor)
             {
-                assert(e.arguments.dim == 1);
+                assert(e.arguments.length == 1);
                 Expression ea = (*e.arguments)[0];
                 // printf("1 ea = %s %s\n", ea.type.toChars(), ea.toChars());
                 if (auto se = ea.isSliceExp())
@@ -4817,7 +4817,7 @@ public:
             {
                 // In expressionsem.d `ea.length = eb;` got lowered to `_d_arraysetlengthT(ea, eb);`.
                 // The following code will rewrite it back to `ea.length = eb` and then interpret that expression.
-                assert(e.arguments.dim == 2);
+                assert(e.arguments.length == 2);
 
                 Expression ea = (*e.arguments)[0];
                 Expression eb = (*e.arguments)[1];
@@ -4841,9 +4841,9 @@ public:
                 // then interpret that expression.
 
                 if (fd.ident == Id._d_arrayctor)
-                    assert(e.arguments.dim == 3);
+                    assert(e.arguments.length == 3);
                 else
-                    assert(e.arguments.dim == 2);
+                    assert(e.arguments.length == 2);
 
                 Expression ea = (*e.arguments)[0];
                 if (ea.isCastExp)
@@ -4872,13 +4872,13 @@ public:
 
                 if (fd.ident == Id._d_arrayappendT)
                 {
-                    assert(e.arguments.dim == 2);
+                    assert(e.arguments.length == 2);
                     lhs = (*e.arguments)[0];
                     rhs = (*e.arguments)[1];
                 }
                 else
                 {
-                    assert(e.arguments.dim == 5);
+                    assert(e.arguments.length == 5);
                     lhs = (*e.arguments)[3];
                     rhs = (*e.arguments)[4];
                 }
@@ -5039,7 +5039,7 @@ public:
             // `_d_arrayappendcTX(arr, elem), arr[arr.length - 1] = elem, elem;`.
             // The following code will rewrite it back to `arr ~= elem`
             // and then interpret that expression.
-            assert(ce.arguments.dim == 2);
+            assert(ce.arguments.length == 2);
 
             auto arr = (*ce.arguments)[0];
             auto elem = e.e2.isConstructExp().e2;
@@ -5994,7 +5994,7 @@ public:
                     {
                         ArrayLiteralExp ale = ie.e1.isArrayLiteralExp();
                         const indx = cast(size_t)ie.e2.toInteger();
-                        if (indx < ale.elements.dim)
+                        if (indx < ale.elements.length)
                         {
                             if (Expression xx = (*ale.elements)[indx])
                             {
@@ -6458,8 +6458,8 @@ public:
                 (*valuesx)[j - removed] = evalue;
             }
         }
-        valuesx.dim = valuesx.dim - removed;
-        keysx.dim = keysx.dim - removed;
+        valuesx.length = valuesx.length - removed;
+        keysx.length = keysx.length - removed;
         result = IntegerExp.createBool(removed != 0);
     }
 
@@ -6973,7 +6973,7 @@ private Expression interpret_length(UnionExp* pue, InterState* istate, Expressio
         return earg;
     dinteger_t len = 0;
     if (auto aae = earg.isAssocArrayLiteralExp())
-        len = aae.keys.dim;
+        len = aae.keys.length;
     else
         assert(earg.op == EXP.null_);
     emplaceExp!(IntegerExp)(pue, earg.loc, len, Type.tsize_t);
@@ -7044,7 +7044,7 @@ private Expression interpret_dup(UnionExp* pue, InterState* istate, Expression e
     if (earg.op != EXP.assocArrayLiteral && earg.type.toBasetype().ty != Taarray)
         return null;
     auto aae = copyLiteral(earg).copy().isAssocArrayLiteralExp();
-    for (size_t i = 0; i < aae.keys.dim; i++)
+    for (size_t i = 0; i < aae.keys.length; i++)
     {
         if (Expression e = evaluatePostblit(istate, (*aae.keys)[i]))
             return e;
@@ -7080,7 +7080,7 @@ private Expression interpret_aaApply(UnionExp* pue, InterState* istate, Expressi
 
     assert(fd && fd.fbody);
     assert(fd.parameters);
-    size_t numParams = fd.parameters.dim;
+    size_t numParams = fd.parameters.length;
     assert(numParams == 1 || numParams == 2);
 
     Parameter fparam = fd.type.isTypeFunction().parameterList[numParams - 1];
@@ -7089,11 +7089,11 @@ private Expression interpret_aaApply(UnionExp* pue, InterState* istate, Expressi
     Expressions args = Expressions(numParams);
 
     AssocArrayLiteralExp ae = aa.isAssocArrayLiteralExp();
-    if (!ae.keys || ae.keys.dim == 0)
+    if (!ae.keys || ae.keys.length == 0)
         return ctfeEmplaceExp!IntegerExp(deleg.loc, 0, Type.tsize_t);
     Expression eresult;
 
-    for (size_t i = 0; i < ae.keys.dim; ++i)
+    for (size_t i = 0; i < ae.keys.length; ++i)
     {
         Expression ekey = (*ae.keys)[i];
         Expression evalue = (*ae.values)[i];
@@ -7141,7 +7141,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
 
     assert(fd && fd.fbody);
     assert(fd.parameters);
-    size_t numParams = fd.parameters.dim;
+    size_t numParams = fd.parameters.length;
     assert(numParams == 1 || numParams == 2);
     Type charType = (*fd.parameters)[numParams - 1].type;
     Type indexType = numParams == 2 ? (*fd.parameters)[0].type : Type.tsize_t;
@@ -7384,7 +7384,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
 private Expression evaluateIfBuiltin(UnionExp* pue, InterState* istate, const ref Loc loc, FuncDeclaration fd, Expressions* arguments, Expression pthis)
 {
     Expression e = null;
-    size_t nargs = arguments ? arguments.dim : 0;
+    size_t nargs = arguments ? arguments.length : 0;
     if (!pthis)
     {
         if (isBuiltin(fd) != BUILTIN.unimp)
@@ -7448,7 +7448,7 @@ private Expression evaluateIfBuiltin(UnionExp* pue, InterState* istate, const re
             // At present, the constructors just copy their arguments into the struct.
             // But we might need some magic if stack tracing gets added to druntime.
             StructLiteralExp se = pthis.isClassReferenceExp().value;
-            assert(arguments.dim <= se.elements.dim);
+            assert(arguments.length <= se.elements.length);
             foreach (i, arg; *arguments)
             {
                 auto elem = interpret(arg, istate);
@@ -7610,7 +7610,7 @@ private void removeHookTraceImpl(ref CallExp ce, ref FuncDeclaration fd)
 
     // Remove the first three trace parameters
     auto arguments = new Expressions();
-    arguments.reserve(ce.arguments.dim - 3);
+    arguments.reserve(ce.arguments.length - 3);
     arguments.pushSlice((*ce.arguments)[3 .. $]);
 
     ce = ctfeEmplaceExp!CallExp(ce.loc, ctfeEmplaceExp!VarExp(ce.loc, fd, false), arguments);

--- a/compiler/src/dmd/dmangle.d
+++ b/compiler/src/dmd/dmangle.d
@@ -721,8 +721,8 @@ public:
         mangleIdentifier(tempdecl.ident, tempdecl);
 
         auto args = ti.tiargs;
-        size_t nparams = tempdecl.parameters.dim - (tempdecl.isVariadic() ? 1 : 0);
-        for (size_t i = 0; i < args.dim; i++)
+        size_t nparams = tempdecl.parameters.length - (tempdecl.isVariadic() ? 1 : 0);
+        for (size_t i = 0; i < args.length; i++)
         {
             auto o = (*args)[i];
             Type ta = isType(o);
@@ -814,7 +814,7 @@ public:
             }
             else if (va)
             {
-                assert(i + 1 == args.dim); // must be last one
+                assert(i + 1 == args.length); // must be last one
                 args = &va.objects;
                 i = -cast(size_t)1;
             }
@@ -960,7 +960,7 @@ public:
 
     override void visit(ArrayLiteralExp e)
     {
-        const dim = e.elements ? e.elements.dim : 0;
+        const dim = e.elements ? e.elements.length : 0;
         buf.writeByte('A');
         buf.print(dim);
         foreach (i; 0 .. dim)
@@ -971,7 +971,7 @@ public:
 
     override void visit(AssocArrayLiteralExp e)
     {
-        const dim = e.keys.dim;
+        const dim = e.keys.length;
         buf.writeByte('A');
         buf.print(dim);
         foreach (i; 0 .. dim)
@@ -983,7 +983,7 @@ public:
 
     override void visit(StructLiteralExp e)
     {
-        const dim = e.elements ? e.elements.dim : 0;
+        const dim = e.elements ? e.elements.length : 0;
         buf.writeByte('S');
         buf.print(dim);
         foreach (i; 0 .. dim)

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -62,7 +62,7 @@ void semantic3OnDependencies(Module m)
 
     m.semantic3(null);
 
-    foreach (i; 1 .. m.aimports.dim)
+    foreach (i; 1 .. m.aimports.length)
         semantic3OnDependencies(m.aimports[i]);
 }
 
@@ -132,7 +132,7 @@ private const(char)[] getFilename(Identifier[] packages, Identifier ident) nothr
     {
         const p = pid.toString();
         buf.writestring(p);
-        if (modAliases.dim)
+        if (modAliases.length)
             checkModFileAlias(p);
         version (Windows)
             enum FileSeparator = '\\';
@@ -141,7 +141,7 @@ private const(char)[] getFilename(Identifier[] packages, Identifier ident) nothr
         buf.writeByte(FileSeparator);
     }
     buf.writestring(filename);
-    if (modAliases.dim)
+    if (modAliases.length)
         checkModFileAlias(filename);
     buf.writeByte(0);
     filename = buf.extractSlice()[0 .. $ - 1];
@@ -942,7 +942,7 @@ extern (C++) final class Module : Package
         //    classinst == classinst -> .object.opEquals(classinst, classinst)
         // would fail inside object.d.
         if (filetype != FileType.c &&
-            (members.dim == 0 ||
+            (members.length == 0 ||
              (*members)[0].ident != Id.object ||
              (*members)[0].isImport() is null))
         {
@@ -953,7 +953,7 @@ extern (C++) final class Module : Package
         {
             // Add all symbols into module's symbol table
             symtab = new DsymbolTable();
-            for (size_t i = 0; i < members.dim; i++)
+            for (size_t i = 0; i < members.length; i++)
             {
                 Dsymbol s = (*members)[i];
                 s.addMember(sc, sc.scopesym);
@@ -966,12 +966,12 @@ extern (C++) final class Module : Package
          * before any semantic() on any of them.
          */
         setScope(sc); // remember module scope for semantic
-        for (size_t i = 0; i < members.dim; i++)
+        for (size_t i = 0; i < members.length; i++)
         {
             Dsymbol s = (*members)[i];
             s.setScope(sc);
         }
-        for (size_t i = 0; i < members.dim; i++)
+        for (size_t i = 0; i < members.length; i++)
         {
             Dsymbol s = (*members)[i];
             s.importAll(sc);
@@ -1115,13 +1115,13 @@ extern (C++) final class Module : Package
         __gshared int nested;
         if (nested)
             return;
-        //if (deferred.dim) printf("+Module::runDeferredSemantic(), len = %ld\n", deferred.dim);
+        //if (deferred.length) printf("+Module::runDeferredSemantic(), len = %ld\n", deferred.length);
         nested++;
 
         size_t len;
         do
         {
-            len = deferred.dim;
+            len = deferred.length;
             if (!len)
                 break;
 
@@ -1146,13 +1146,13 @@ extern (C++) final class Module : Package
                 s.dsymbolSemantic(null);
                 //printf("deferred: %s, parent = %s\n", s.toChars(), s.parent.toChars());
             }
-            //printf("\tdeferred.dim = %ld, len = %ld\n", deferred.dim, len);
+            //printf("\tdeferred.length = %ld, len = %ld\n", deferred.length, len);
             if (todoalloc)
                 free(todoalloc);
         }
-        while (deferred.dim != len); // while making progress
+        while (deferred.length != len); // while making progress
         nested--;
-        //printf("-Module::runDeferredSemantic(), len = %ld\n", deferred.dim);
+        //printf("-Module::runDeferredSemantic(), len = %ld\n", deferred.length);
     }
 
     static void runDeferredSemantic2()
@@ -1160,7 +1160,7 @@ extern (C++) final class Module : Package
         Module.runDeferredSemantic();
 
         Dsymbols* a = &Module.deferred2;
-        for (size_t i = 0; i < a.dim; i++)
+        for (size_t i = 0; i < a.length; i++)
         {
             Dsymbol s = (*a)[i];
             //printf("[%d] %s semantic2a\n", i, s.toPrettyChars());
@@ -1177,7 +1177,7 @@ extern (C++) final class Module : Package
         Module.runDeferredSemantic2();
 
         Dsymbols* a = &Module.deferred3;
-        for (size_t i = 0; i < a.dim; i++)
+        for (size_t i = 0; i < a.length; i++)
         {
             Dsymbol s = (*a)[i];
             //printf("[%d] %s semantic3a\n", i, s.toPrettyChars());

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -106,7 +106,7 @@ private class Section
 
     void write(Loc loc, DocComment* dc, Scope* sc, Dsymbols* a, OutBuffer* buf)
     {
-        assert(a.dim);
+        assert(a.length);
         if (name.length)
         {
             static immutable table =
@@ -161,7 +161,7 @@ private final class ParamSection : Section
 {
     override void write(Loc loc, DocComment* dc, Scope* sc, Dsymbols* a, OutBuffer* buf)
     {
-        assert(a.dim);
+        assert(a.length);
         Dsymbol s = (*a)[0]; // test
         const(char)* p = body_.ptr;
         size_t len = body_.length;
@@ -295,10 +295,10 @@ private final class ParamSection : Section
             goto L1;
         // write out last one
         buf.writestring(")");
-        TypeFunction tf = a.dim == 1 ? isTypeFunction(s) : null;
+        TypeFunction tf = a.length == 1 ? isTypeFunction(s) : null;
         if (tf)
         {
-            size_t pcount = (tf.parameterList.parameters ? tf.parameterList.parameters.dim : 0) +
+            size_t pcount = (tf.parameterList.parameters ? tf.parameterList.parameters.length : 0) +
                             cast(int)(tf.parameterList.varargs == VarArg.variadic);
             if (pcount != paramcount)
             {
@@ -386,7 +386,7 @@ extern(C++) void gendocfile(Module m)
         if (p)
             global.params.ddoc.files.shift(p);
         // Override with the ddoc macro files from the command line
-        for (size_t i = 0; i < global.params.ddoc.files.dim; i++)
+        for (size_t i = 0; i < global.params.ddoc.files.length; i++)
         {
             auto buffer = readFile(m.loc, global.params.ddoc.files[i]);
             // BUG: convert file contents to UTF-8 before use
@@ -757,9 +757,9 @@ private void emitAnchor(ref OutBuffer buf, Dsymbol s, Scope* sc, bool forHeader 
     if (auto imp = s.isImport())
     {
         // For example: `public import core.stdc.string : memcpy, memcmp;`
-        if (imp.aliases.dim > 0)
+        if (imp.aliases.length > 0)
         {
-            for(int i = 0; i < imp.aliases.dim; i++)
+            for(int i = 0; i < imp.aliases.length; i++)
             {
                 // Need to distinguish between
                 // `public import core.stdc.string : memcpy, memcmp;` and
@@ -866,7 +866,7 @@ private void expandTemplateMixinComments(TemplateMixin tm, ref OutBuffer buf, Sc
     TemplateDeclaration td = (tm && tm.tempdecl) ? tm.tempdecl.isTemplateDeclaration() : null;
     if (td && td.members)
     {
-        for (size_t i = 0; i < td.members.dim; i++)
+        for (size_t i = 0; i < td.members.length; i++)
         {
             Dsymbol sm = (*td.members)[i];
             TemplateMixin tmc = sm.isTemplateMixin();
@@ -898,7 +898,7 @@ private void emitMemberComments(ScopeDsymbol sds, ref OutBuffer buf, Scope* sc)
     buf.writestring(m);
     size_t offset2 = buf.length; // to see if we write anything
     sc = sc.push(sds);
-    for (size_t i = 0; i < sds.members.dim; i++)
+    for (size_t i = 0; i < sds.members.length; i++)
     {
         Dsymbol s = (*sds.members)[i];
         //printf("\ts = '%s'\n", s.toChars());
@@ -998,7 +998,7 @@ private void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
             // Put previous doc comment if exists
             if (DocComment* dc = sc.lastdc)
             {
-                assert(dc.a.dim > 0, "Expects at least one declaration for a" ~
+                assert(dc.a.length > 0, "Expects at least one declaration for a" ~
                     "documentation comment");
 
                 auto symbol = dc.a[0];
@@ -1010,7 +1010,7 @@ private void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
 
                 // Put the declaration signatures as the document 'title'
                 buf.writestring(ddoc_decl_s);
-                for (size_t i = 0; i < dc.a.dim; i++)
+                for (size_t i = 0; i < dc.a.length; i++)
                 {
                     Dsymbol sx = dc.a[i];
                     // the added linebreaks in here make looking at multiple
@@ -1138,7 +1138,7 @@ private void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
                 return;
             if (ed.isAnonymous() && ed.members)
             {
-                for (size_t i = 0; i < ed.members.dim; i++)
+                for (size_t i = 0; i < ed.members.length; i++)
                 {
                     Dsymbol s = (*ed.members)[i];
                     emitComment(s, *buf, sc);
@@ -1176,7 +1176,7 @@ private void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
             Dsymbols* d = ad.include(null);
             if (d)
             {
-                for (size_t i = 0; i < d.dim; i++)
+                for (size_t i = 0; i < d.length; i++)
                 {
                     Dsymbol s = (*d)[i];
                     //printf("AttribDeclaration::emitComment %s\n", s.toChars());
@@ -1210,7 +1210,7 @@ private void emitComment(Dsymbol s, ref OutBuffer buf, Scope* sc)
              * a template, then include(null) will fail.
              */
             Dsymbols* d = cd.decl ? cd.decl : cd.elsedecl;
-            for (size_t i = 0; i < d.dim; i++)
+            for (size_t i = 0; i < d.length; i++)
             {
                 Dsymbol s = (*d)[i];
                 emitComment(s, *buf, sc);
@@ -1324,9 +1324,9 @@ private void toDocBuffer(Dsymbol s, ref OutBuffer buf, Scope* sc)
             if (d.isVarDeclaration() && td)
             {
                 buf.writeByte('(');
-                if (td.origParameters && td.origParameters.dim)
+                if (td.origParameters && td.origParameters.length)
                 {
-                    for (size_t i = 0; i < td.origParameters.dim; i++)
+                    for (size_t i = 0; i < td.origParameters.length; i++)
                     {
                         if (i)
                             buf.writestring(", ");
@@ -1484,7 +1484,7 @@ private void toDocBuffer(Dsymbol s, ref OutBuffer buf, Scope* sc)
                 buf.printf("%s %s", cd.kind(), cd.toChars());
             }
             int any = 0;
-            for (size_t i = 0; i < cd.baseclasses.dim; i++)
+            for (size_t i = 0; i < cd.baseclasses.length; i++)
             {
                 BaseClass* bc = (*cd.baseclasses)[i];
                 if (bc.sym && bc.sym.ident == Id.Object)
@@ -1557,7 +1557,7 @@ struct DocComment
         if (!comment)
             return dc;
         dc.parseSections(comment);
-        for (size_t i = 0; i < dc.sections.dim; i++)
+        for (size_t i = 0; i < dc.sections.length; i++)
         {
             Section sec = dc.sections[i];
             if (iequals("copyright", sec.name))
@@ -1873,7 +1873,7 @@ struct DocComment
 
     void writeSections(Scope* sc, Dsymbols* a, OutBuffer* buf)
     {
-        assert(a.dim);
+        assert(a.length);
         //printf("DocComment::writeSections()\n");
         Loc loc = (*a)[0].loc;
         if (Module m = (*a)[0].isModule())
@@ -1884,7 +1884,7 @@ struct DocComment
         size_t offset1 = buf.length;
         buf.writestring("$(DDOC_SECTIONS ");
         size_t offset2 = buf.length;
-        for (size_t i = 0; i < sections.dim; i++)
+        for (size_t i = 0; i < sections.length; i++)
         {
             Section sec = sections[i];
             if (sec.nooutput)
@@ -1902,7 +1902,7 @@ struct DocComment
             else
                 sec.write(loc, &this, sc, a, buf);
         }
-        for (size_t i = 0; i < a.dim; i++)
+        for (size_t i = 0; i < a.length; i++)
         {
             Dsymbol s = (*a)[i];
             if (Dsymbol td = getEponymousParent(s))
@@ -2719,7 +2719,7 @@ private Parameter isEponymousFunctionParameter(Dsymbols *a, const(char)[] p) @sa
  */
 private TemplateParameter isTemplateParameter(Dsymbols* a, const(char)* p, size_t len)
 {
-    for (size_t i = 0; i < a.dim; i++)
+    for (size_t i = 0; i < a.length; i++)
     {
         TemplateDeclaration td = (*a)[i].isTemplateDeclaration();
         // Check for the parent, if the current symbol is not a template declaration.
@@ -5004,10 +5004,10 @@ private void highlightText(Scope* sc, Dsymbols* a, Loc loc, ref OutBuffer buf, s
 private void highlightCode(Scope* sc, Dsymbol s, ref OutBuffer buf, size_t offset)
 {
     auto imp = s.isImport();
-    if (imp && imp.aliases.dim > 0)
+    if (imp && imp.aliases.length > 0)
     {
         // For example: `public import core.stdc.string : memcpy, memcmp;`
-        for(int i = 0; i < imp.aliases.dim; i++)
+        for(int i = 0; i < imp.aliases.length; i++)
         {
             // Need to distinguish between
             // `public import core.stdc.string : memcpy, memcmp;` and
@@ -5089,7 +5089,7 @@ private void highlightCode(Scope* sc, Dsymbols* a, ref OutBuffer buf, size_t off
             size_t previ = i;
 
             // hunt for template declarations:
-            foreach (symi; 0 .. a.dim)
+            foreach (symi; 0 .. a.length)
             {
                 FuncDeclaration fd = (*a)[symi].isFuncDeclaration();
 
@@ -5102,14 +5102,14 @@ private void highlightCode(Scope* sc, Dsymbols* a, ref OutBuffer buf, size_t off
 
                 // build the template parameters
                 Array!(size_t) paramLens;
-                paramLens.reserve(td.parameters.dim);
+                paramLens.reserve(td.parameters.length);
 
                 OutBuffer parametersBuf;
                 HdrGenState hgs;
 
                 parametersBuf.writeByte('(');
 
-                foreach (parami; 0 .. td.parameters.dim)
+                foreach (parami; 0 .. td.parameters.length)
                 {
                     TemplateParameter tp = (*td.parameters)[parami];
 

--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -292,14 +292,14 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         }
         sizeok = Sizeok.inProcess;
 
-        //printf("+StructDeclaration::finalizeSize() %s, fields.dim = %d, sizeok = %d\n", toChars(), fields.dim, sizeok);
+        //printf("+StructDeclaration::finalizeSize() %s, fields.length = %d, sizeok = %d\n", toChars(), fields.length, sizeok);
 
         fields.setDim(0);   // workaround
 
         // Set the offsets of the fields and determine the size of the struct
         FieldState fieldState;
         bool isunion = isUnionDeclaration() !is null;
-        for (size_t i = 0; i < members.dim; i++)
+        for (size_t i = 0; i < members.length; i++)
         {
             Dsymbol s = (*members)[i];
             s.setFieldOffset(this, fieldState, isunion);
@@ -353,7 +353,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
 
         sizeok = Sizeok.done;
 
-        //printf("-StructDeclaration::finalizeSize() %s, fields.dim = %d, structsize = %d\n", toChars(), fields.dim, structsize);
+        //printf("-StructDeclaration::finalizeSize() %s, fields.length = %d, structsize = %d\n", toChars(), fields.length, structsize);
 
         if (errors)
             return;
@@ -454,7 +454,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         }
 
         // Recursively check all fields are POD.
-        for (size_t i = 0; i < fields.dim; i++)
+        for (size_t i = 0; i < fields.length; i++)
         {
             VarDeclaration v = fields[i];
             if (v.storage_class & STC.ref_)
@@ -491,7 +491,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
 
     final uint numArgTypes() const
     {
-        return argTypes && argTypes.arguments ? cast(uint) argTypes.arguments.dim : 0;
+        return argTypes && argTypes.arguments ? cast(uint) argTypes.arguments.length : 0;
     }
 
     final Type argType(uint index)
@@ -570,7 +570,7 @@ private bool _isZeroInit(Expression exp)
         case EXP.structLiteral:
         {
             auto sle = cast(StructLiteralExp) exp;
-            foreach (i; 0 .. sle.sd.fields.dim)
+            foreach (i; 0 .. sle.sd.fields.length)
             {
                 auto field = sle.sd.fields[i];
                 if (field.type.size(field.loc))
@@ -588,7 +588,7 @@ private bool _isZeroInit(Expression exp)
         {
             auto ale = cast(ArrayLiteralExp)exp;
 
-            const dim = ale.elements ? ale.elements.dim : 0;
+            const dim = ale.elements ? ale.elements.length : 0;
 
             if (ale.type.toBasetype().ty == Tarray) // if initializing a dynamic array
                 return dim == 0;

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -73,7 +73,7 @@ int foreachDsymbol(Dsymbols* symbols, scope int delegate(Dsymbol) dg)
     {
         /* Do not use foreach, as the size of the array may expand during iteration
          */
-        for (size_t i = 0; i < symbols.dim; ++i)
+        for (size_t i = 0; i < symbols.length; ++i)
         {
             Dsymbol s = (*symbols)[i];
             const result = dg(s);
@@ -99,7 +99,7 @@ void foreachDsymbol(Dsymbols* symbols, scope void delegate(Dsymbol) dg)
     {
         /* Do not use foreach, as the size of the array may expand during iteration
          */
-        for (size_t i = 0; i < symbols.dim; ++i)
+        for (size_t i = 0; i < symbols.length; ++i)
         {
             Dsymbol s = (*symbols)[i];
             dg(s);
@@ -739,7 +739,7 @@ extern (C++) class Dsymbol : ASTNode
         if (a)
         {
             b = a.copy();
-            for (size_t i = 0; i < b.dim; i++)
+            for (size_t i = 0; i < b.length; i++)
             {
                 (*b)[i] = (*b)[i].syntaxCopy(null);
             }
@@ -1164,7 +1164,7 @@ extern (C++) class Dsymbol : ASTNode
      */
     extern (D) static bool oneMembers(Dsymbols* members, Dsymbol* ps, Identifier ident)
     {
-        //printf("Dsymbol::oneMembers() %d\n", members ? members.dim : 0);
+        //printf("Dsymbol::oneMembers() %d\n", members ? members.length : 0);
         Dsymbol s = null;
         if (!members)
         {
@@ -1172,7 +1172,7 @@ extern (C++) class Dsymbol : ASTNode
             return true;
         }
 
-        for (size_t i = 0; i < members.dim; i++)
+        for (size_t i = 0; i < members.length; i++)
         {
             Dsymbol sx = (*members)[i];
             bool x = sx.oneMember(ps, ident);
@@ -1489,7 +1489,7 @@ public:
         Dsymbol s = null;
         OverloadSet a = null;
         // Look in imported modules
-        for (size_t i = 0; i < importedScopes.dim; i++)
+        for (size_t i = 0; i < importedScopes.length; i++)
         {
             // If private import, don't search it
             if ((flags & IgnorePrivateImports) && visibilities[i] == Visibility.Kind.private_)
@@ -1628,14 +1628,14 @@ public:
         if (OverloadSet os2 = s.isOverloadSet())
         {
             // Merge the cross-module overload set 'os2' into 'os'
-            if (os.a.dim == 0)
+            if (os.a.length == 0)
             {
-                os.a.setDim(os2.a.dim);
-                memcpy(os.a.tdata(), os2.a.tdata(), (os.a[0]).sizeof * os2.a.dim);
+                os.a.setDim(os2.a.length);
+                memcpy(os.a.tdata(), os2.a.tdata(), (os.a[0]).sizeof * os2.a.length);
             }
             else
             {
-                for (size_t i = 0; i < os2.a.dim; i++)
+                for (size_t i = 0; i < os2.a.length; i++)
                 {
                     os = mergeOverloadSet(ident, os, os2.a[i]);
                 }
@@ -1646,7 +1646,7 @@ public:
             assert(s.isOverloadable());
             /* Don't add to os[] if s is alias of previous sym
              */
-            for (size_t j = 0; j < os.a.dim; j++)
+            for (size_t j = 0; j < os.a.length; j++)
             {
                 Dsymbol s2 = os.a[j];
                 if (s.toAlias() == s2.toAlias())
@@ -1674,7 +1674,7 @@ public:
                 importedScopes = new Dsymbols();
             else
             {
-                for (size_t i = 0; i < importedScopes.dim; i++)
+                for (size_t i = 0; i < importedScopes.length; i++)
                 {
                     Dsymbol ss = (*importedScopes)[i];
                     if (ss == s) // if already imported
@@ -1686,8 +1686,8 @@ public:
                 }
             }
             importedScopes.push(s);
-            visibilities = cast(Visibility.Kind*)mem.xrealloc(visibilities, importedScopes.dim * (visibilities[0]).sizeof);
-            visibilities[importedScopes.dim - 1] = visibility.kind;
+            visibilities = cast(Visibility.Kind*)mem.xrealloc(visibilities, importedScopes.length * (visibilities[0]).sizeof);
+            visibilities[importedScopes.length - 1] = visibility.kind;
         }
     }
 
@@ -1714,7 +1714,7 @@ public:
         if (!importedScopes)
             return null;
 
-        return (() @trusted => visibilities[0 .. importedScopes.dim])();
+        return (() @trusted => visibilities[0 .. importedScopes.length])();
     }
 
     extern (D) final void addAccessiblePackage(Package p, Visibility visibility) nothrow
@@ -1854,7 +1854,7 @@ public:
     {
         if (members)
         {
-            for (size_t i = 0; i < members.dim; i++)
+            for (size_t i = 0; i < members.length; i++)
             {
                 Dsymbol member = (*members)[i];
                 if (member.hasStaticCtorOrDtor())
@@ -1883,7 +1883,7 @@ public:
             return 0;
         size_t n = pn ? *pn : 0; // take over index
         int result = 0;
-        foreach (size_t i; 0 .. members.dim)
+        foreach (size_t i; 0 .. members.length)
         {
             Dsymbol s = (*members)[i];
             if (AttribDeclaration a = s.isAttribDeclaration())
@@ -2020,7 +2020,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
             /* $ gives the number of type entries in the type tuple
              */
             auto v = new VarDeclaration(loc, Type.tsize_t, Id.dollar, null);
-            Expression e = new IntegerExp(Loc.initial, tt.arguments.dim, Type.tsize_t);
+            Expression e = new IntegerExp(Loc.initial, tt.arguments.length, Type.tsize_t);
             v._init = new ExpInitializer(Loc.initial, e);
             v.storage_class |= STC.temp | STC.static_ | STC.const_;
             v.dsymbolSemantic(sc);
@@ -2035,7 +2035,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
             /* $ gives the number of elements in the tuple
              */
             auto v = new VarDeclaration(loc, Type.tsize_t, Id.dollar, null);
-            Expression e = new IntegerExp(Loc.initial, td.objects.dim, Type.tsize_t);
+            Expression e = new IntegerExp(Loc.initial, td.objects.length, Type.tsize_t);
             v._init = new ExpInitializer(Loc.initial, e);
             v.storage_class |= STC.temp | STC.static_ | STC.const_;
             v.dsymbolSemantic(sc);
@@ -2098,7 +2098,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
                 /* It is for an expression tuple, so the
                  * length will be a const.
                  */
-                Expression e = new IntegerExp(Loc.initial, tupexp.exps.dim, Type.tsize_t);
+                Expression e = new IntegerExp(Loc.initial, tupexp.exps.length, Type.tsize_t);
                 v = new VarDeclaration(loc, Type.tsize_t, Id.dollar, new ExpInitializer(Loc.initial, e));
                 v.storage_class |= STC.temp | STC.static_ | STC.const_;
             }
@@ -2142,7 +2142,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
                      * Note that it's impossible to have both template & function opDollar,
                      * because both take no arguments.
                      */
-                    if (exp.op == EXP.array && (cast(ArrayExp)exp).arguments.dim != 1)
+                    if (exp.op == EXP.array && (cast(ArrayExp)exp).arguments.length != 1)
                     {
                         exp.error("`%s` only defines opDollar for one dimension", ad.toChars());
                         return null;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -559,19 +559,19 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 auto iexps = new Expressions();
                 iexps.push(ie);
                 auto exps = new Expressions();
-                for (size_t pos = 0; pos < iexps.dim; pos++)
+                for (size_t pos = 0; pos < iexps.length; pos++)
                 {
                 Lexpand1:
                     Expression e = (*iexps)[pos];
                     Parameter arg = Parameter.getNth(tt.arguments, pos);
                     arg.type = arg.type.typeSemantic(dsym.loc, sc);
-                    //printf("[%d] iexps.dim = %d, ", pos, iexps.dim);
+                    //printf("[%d] iexps.length = %d, ", pos, iexps.length);
                     //printf("e = (%s %s, %s), ", Token.tochars[e.op], e.toChars(), e.type.toChars());
                     //printf("arg = (%s, %s)\n", arg.toChars(), arg.type.toChars());
 
                     if (e != ie)
                     {
-                        if (iexps.dim > nelems)
+                        if (iexps.length > nelems)
                             goto Lnomatch;
                         if (e.type.implicitConvTo(arg.type))
                             continue;
@@ -579,7 +579,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
                     if (auto te = e.isTupleExp())
                     {
-                        if (iexps.dim - 1 + te.exps.dim > nelems)
+                        if (iexps.length - 1 + te.exps.length > nelems)
                             goto Lnomatch;
 
                         iexps.remove(pos);
@@ -598,17 +598,17 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         (*exps)[0] = ve;
                         expandAliasThisTuples(exps, 0);
 
-                        for (size_t u = 0; u < exps.dim; u++)
+                        for (size_t u = 0; u < exps.length; u++)
                         {
                         Lexpand2:
                             Expression ee = (*exps)[u];
                             arg = Parameter.getNth(tt.arguments, pos + u);
                             arg.type = arg.type.typeSemantic(dsym.loc, sc);
-                            //printf("[%d+%d] exps.dim = %d, ", pos, u, exps.dim);
+                            //printf("[%d+%d] exps.length = %d, ", pos, u, exps.length);
                             //printf("ee = (%s %s, %s), ", Token.tochars[ee.op], ee.toChars(), ee.type.toChars());
                             //printf("arg = (%s, %s)\n", arg.toChars(), arg.type.toChars());
 
-                            size_t iexps_dim = iexps.dim - 1 + exps.dim;
+                            size_t iexps_dim = iexps.length - 1 + exps.length;
                             if (iexps_dim > nelems)
                                 goto Lnomatch;
                             if (ee.type.implicitConvTo(arg.type))
@@ -630,7 +630,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         }
                     }
                 }
-                if (iexps.dim < nelems)
+                if (iexps.length < nelems)
                     goto Lnomatch;
 
                 ie = new TupleExp(dsym._init.loc, iexps);
@@ -640,7 +640,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (ie && ie.op == EXP.tuple)
             {
                 auto te = ie.isTupleExp();
-                size_t tedim = te.exps.dim;
+                size_t tedim = te.exps.length;
                 if (tedim != nelems)
                 {
                     error(dsym.loc, "tuple of %d elements cannot be assigned to tuple of %d elements", cast(int)tedim, cast(int)nelems);
@@ -1334,7 +1334,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (sc.explicitVisibility)
                 imp.visibility = sc.visibility;
 
-            if (!imp.aliasId && !imp.names.dim) // neither a selective nor a renamed import
+            if (!imp.aliasId && !imp.names.length) // neither a selective nor a renamed import
             {
                 ScopeDsymbol scopesym = sc.getScopesym();
 
@@ -1360,7 +1360,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             sc = sc.push(imp.mod);
             sc.visibility = imp.visibility;
-            for (size_t i = 0; i < imp.aliasdecls.dim; i++)
+            for (size_t i = 0; i < imp.aliasdecls.length; i++)
             {
                 AliasDeclaration ad = imp.aliasdecls[i];
                 //printf("\tImport %s alias %s = %s, scope = %p\n", toPrettyChars(), aliases[i].toChars(), names[i].toChars(), ad._scope);
@@ -1472,7 +1472,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             Scope* sc2 = ad.newScope(sc);
             bool errors;
-            for (size_t i = 0; i < d.dim; i++)
+            for (size_t i = 0; i < d.length; i++)
             {
                 Dsymbol s = (*d)[i];
                 s.dsymbolSemantic(sc2);
@@ -1510,7 +1510,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         sc.stc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.gshared);
         sc.inunion = scd.isunion ? scd : null;
         sc.flags = 0;
-        for (size_t i = 0; i < scd.decl.dim; i++)
+        for (size_t i = 0; i < scd.decl.length; i++)
         {
             Dsymbol s = (*scd.decl)[i];
             if (auto var = s.isVarDeclaration)
@@ -1628,7 +1628,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     if (agg)
                     {
                         ad.pMangleOverride.agg = agg;
-                        if (pd.args.dim == 2)
+                        if (pd.args.length == 2)
                         {
                             setString((*pd.args)[1]);
                         }
@@ -1669,7 +1669,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (pd.ident == Id.linkerDirective)
             {
-                if (!pd.args || pd.args.dim != 1)
+                if (!pd.args || pd.args.length != 1)
                     pd.error("one string argument expected for pragma(linkerDirective)");
                 else
                 {
@@ -1695,7 +1695,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         else if (pd.ident == Id.lib)
         {
-            if (!pd.args || pd.args.dim != 1)
+            if (!pd.args || pd.args.length != 1)
                 pd.error("string expected for library name");
             else
             {
@@ -1738,9 +1738,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (!pd.args)
                 pd.args = new Expressions();
-            if (pd.args.dim == 0 || pd.args.dim > 2)
+            if (pd.args.length == 0 || pd.args.length > 2)
             {
-                pd.error(pd.args.dim == 0 ? "string expected for mangled name"
+                pd.error(pd.args.length == 0 ? "string expected for mangled name"
                                           : "expected 1 or 2 arguments");
                 pd.args.setDim(1);
                 (*pd.args)[0] = ErrorExp.get(); // error recovery
@@ -1749,7 +1749,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         else if (pd.ident == Id.crt_constructor || pd.ident == Id.crt_destructor)
         {
-            if (pd.args && pd.args.dim != 0)
+            if (pd.args && pd.args.length != 0)
                 pd.error("takes no argument");
             else
             {
@@ -1763,7 +1763,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         auto decls = ad.include(null);
                         if (decls)
                         {
-                            for (size_t i = 0; i < decls.dim; ++i)
+                            for (size_t i = 0; i < decls.length; ++i)
                                 nestedCount += recurse((*decls)[i], isCtor);
                         }
                         return nestedCount;
@@ -1789,7 +1789,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         else if (pd.ident == Id.printf || pd.ident == Id.scanf)
         {
-            if (pd.args && pd.args.dim != 0)
+            if (pd.args && pd.args.length != 0)
                 pd.error("takes no argument");
             return declarations();
         }
@@ -1809,7 +1809,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (pd.args)
         {
             const errors_save = global.startGagging();
-            for (size_t i = 0; i < pd.args.dim; i++)
+            for (size_t i = 0; i < pd.args.length; i++)
             {
                 Expression e = (*pd.args)[i];
                 sc = sc.startCTFE();
@@ -1823,7 +1823,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     buf.writeByte(',');
                 buf.writestring(e.toChars());
             }
-            if (pd.args.dim)
+            if (pd.args.length)
                 buf.writeByte(')');
             global.endGagging(errors_save);
         }
@@ -1881,7 +1881,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (cd._scope && cd.decl)
             {
-                for (size_t i = 0; i < cd.decl.dim; i++)
+                for (size_t i = 0; i < cd.decl.length; i++)
                 {
                     Dsymbol s = (*cd.decl)[i];
                     s.setScope(cd._scope);
@@ -1920,11 +1920,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             expandTuples(te.exps);
             CPPNamespaceDeclaration current = ns.cppnamespace;
-            for (size_t d = 0; d < te.exps.dim; ++d)
+            for (size_t d = 0; d < te.exps.length; ++d)
             {
                 auto exp = (*te.exps)[d];
                 auto prev = d ? current : ns.cppnamespace;
-                current = (d + 1) != te.exps.dim
+                current = (d + 1) != te.exps.length
                     ? new CPPNamespaceDeclaration(ns.loc, exp, null)
                     : ns;
                 current.exp = exp;
@@ -2123,7 +2123,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         }
 
-        if (ed.members.dim == 0)
+        if (ed.members.length == 0)
         {
             ed.error("enum `%s` must have at least one member", ed.toChars());
             ed.errors = true;
@@ -2567,15 +2567,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (global.params.ddoc.doOutput)
         {
-            tempdecl.origParameters = new TemplateParameters(tempdecl.parameters.dim);
-            for (size_t i = 0; i < tempdecl.parameters.dim; i++)
+            tempdecl.origParameters = new TemplateParameters(tempdecl.parameters.length);
+            for (size_t i = 0; i < tempdecl.parameters.length; i++)
             {
                 TemplateParameter tp = (*tempdecl.parameters)[i];
                 (*tempdecl.origParameters)[i] = tp.syntaxCopy();
             }
         }
 
-        for (size_t i = 0; i < tempdecl.parameters.dim; i++)
+        for (size_t i = 0; i < tempdecl.parameters.length; i++)
         {
             TemplateParameter tp = (*tempdecl.parameters)[i];
             if (!tp.declareParameter(paramscope))
@@ -2587,7 +2587,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 tempdecl.errors = true;
             }
-            if (i + 1 != tempdecl.parameters.dim && tp.isTemplateTupleParameter())
+            if (i + 1 != tempdecl.parameters.length && tp.isTemplateTupleParameter())
             {
                 tempdecl.error("template tuple parameter must be last one");
                 tempdecl.errors = true;
@@ -2597,12 +2597,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         /* Calculate TemplateParameter.dependent
          */
         TemplateParameters tparams = TemplateParameters(1);
-        for (size_t i = 0; i < tempdecl.parameters.dim; i++)
+        for (size_t i = 0; i < tempdecl.parameters.length; i++)
         {
             TemplateParameter tp = (*tempdecl.parameters)[i];
             tparams[0] = tp;
 
-            for (size_t j = 0; j < tempdecl.parameters.dim; j++)
+            for (size_t j = 0; j < tempdecl.parameters.length; j++)
             {
                 // Skip cases like: X(T : T)
                 if (i == j)
@@ -2743,10 +2743,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             /* Different argument list lengths happen with variadic args
              */
-            if (tm.tiargs.dim != tmix.tiargs.dim)
+            if (tm.tiargs.length != tmix.tiargs.length)
                 continue;
 
-            for (size_t i = 0; i < tm.tiargs.dim; i++)
+            for (size_t i = 0; i < tm.tiargs.length; i++)
             {
                 RootObject o = (*tm.tiargs)[i];
                 Type ta = isType(o);
@@ -2826,7 +2826,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             printf("\tdo semantic() on template instance members '%s'\n", tm.toChars());
         }
         Scope* sc2 = argscope.push(tm);
-        //size_t deferred_dim = Module.deferred.dim;
+        //size_t deferred_dim = Module.deferred.length;
 
         __gshared int nest;
         //printf("%d\n", nest);
@@ -2849,7 +2849,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
          * Because the members would already call Module.addDeferredSemantic() for themselves.
          * See Struct, Class, Interface, and EnumDeclaration.dsymbolSemantic().
          */
-        //if (!sc.func && Module.deferred.dim > deferred_dim) {}
+        //if (!sc.func && Module.deferred.length > deferred_dim) {}
 
         AggregateDeclaration ad = tm.isMember();
         if (sc.func && !ad)
@@ -3345,7 +3345,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 if (!funcdecl.isStatic() || funcdecl.type.nextOf().ty != Tvoid)
                     funcdecl.error("static constructors / destructors must be `static void`");
-                if (f.arguments && f.arguments.dim)
+                if (f.arguments && f.arguments.length)
                     funcdecl.error("static constructors / destructors must have empty parameter list");
                 // BUG: check for invalid storage classes
             }
@@ -3452,13 +3452,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 goto Ldone;
 
             bool may_override = false;
-            for (size_t i = 0; i < cd.baseclasses.dim; i++)
+            for (size_t i = 0; i < cd.baseclasses.length; i++)
             {
                 BaseClass* b = (*cd.baseclasses)[i];
                 ClassDeclaration cbd = b.type.toBasetype().isClassHandle();
                 if (!cbd)
                     continue;
-                for (size_t j = 0; j < cbd.vtbl.dim; j++)
+                for (size_t j = 0; j < cbd.vtbl.length; j++)
                 {
                     FuncDeclaration f2 = cbd.vtbl[j].isFuncDeclaration();
                     if (!f2 || f2.ident != funcdecl.ident)
@@ -3482,7 +3482,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             /* Find index of existing function in base class's vtbl[] to override
              * (the index will be the same as in cd's current vtbl[])
              */
-            int vi = cd.baseClass ? funcdecl.findVtblIndex(&cd.baseClass.vtbl, cast(int)cd.baseClass.vtbl.dim) : -1;
+            int vi = cd.baseClass ? funcdecl.findVtblIndex(&cd.baseClass.vtbl, cast(int)cd.baseClass.vtbl.length) : -1;
 
             bool doesoverride = false;
             switch (vi)
@@ -3514,7 +3514,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                    with offsets to each of the virtual bases.
                  */
                 if (target.cpp.splitVBasetable && cd.classKind == ClassKind.cpp &&
-                    cd.baseClass && cd.baseClass.vtbl.dim)
+                    cd.baseClass && cd.baseClass.vtbl.length)
                 {
                     /* if overriding an interface function, then this is not
                      * introducing and don't put it in the class vtbl[]
@@ -3545,7 +3545,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                          * Search for first function of overload group, and insert
                          * funcdecl into vtbl[] immediately before it.
                          */
-                        funcdecl.vtblIndex = cast(int)cd.vtbl.dim;
+                        funcdecl.vtblIndex = cast(int)cd.vtbl.length;
                         bool found;
                         foreach (const i, s; cd.vtbl)
                         {
@@ -3575,7 +3575,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     else
                     {
                         // Append to end of vtbl[]
-                        vi = cast(int)cd.vtbl.dim;
+                        vi = cast(int)cd.vtbl.length;
                         cd.vtbl.push(funcdecl);
                         funcdecl.vtblIndex = vi;
                     }
@@ -3673,7 +3673,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                              * will be updated at the end of the enclosing `if` block
                              * to point to the current (non-mixined) function.
                              */
-                            auto vitmp = cast(int)cd.vtbl.dim;
+                            auto vitmp = cast(int)cd.vtbl.length;
                             cd.vtbl.push(fdc);
                             fdc.vtblIndex = vitmp;
                         }
@@ -3684,7 +3684,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                              * vtbl, but keep the previous (non-mixined) function as
                              * the overriding one.
                              */
-                            auto vitmp = cast(int)cd.vtbl.dim;
+                            auto vitmp = cast(int)cd.vtbl.length;
                             cd.vtbl.push(funcdecl);
                             funcdecl.vtblIndex = vitmp;
                             break;
@@ -3744,7 +3744,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 foreach (b; bcd.interfaces)
                 {
-                    vi = funcdecl.findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
+                    vi = funcdecl.findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.length);
                     switch (vi)
                     {
                     case -1:
@@ -3812,7 +3812,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 BaseClass* bc = null;
                 Dsymbol s = null;
-                for (size_t i = 0; i < cd.baseclasses.dim; i++)
+                for (size_t i = 0; i < cd.baseclasses.length; i++)
                 {
                     bc = (*cd.baseclasses)[i];
                     s = bc.sym.search_correct(funcdecl.ident);
@@ -4208,7 +4208,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     else if (!dd.isFinal())
                     {
                         // reserve the dtor slot for the destructor (which we'll create later)
-                        cldec.cppDtorVtblIndex = cast(int)cldec.vtbl.dim;
+                        cldec.cppDtorVtblIndex = cast(int)cldec.vtbl.length;
                         cldec.vtbl.push(dd);
                         if (target.cpp.twoDtorInVtable)
                             cldec.vtbl.push(dd); // deleting destructor uses a second slot
@@ -4866,7 +4866,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             cldec.baseok = Baseok.start;
 
             // Expand any tuples in baseclasses[]
-            for (size_t i = 0; i < cldec.baseclasses.dim;)
+            for (size_t i = 0; i < cldec.baseclasses.length;)
             {
                 auto b = (*cldec.baseclasses)[i];
                 b.type = resolveBase(b.type.typeSemantic(cldec.loc, sc));
@@ -4896,7 +4896,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
 
             // See if there's a base class as first in baseclasses[]
-            if (cldec.baseclasses.dim)
+            if (cldec.baseclasses.length)
             {
                 BaseClass* b = (*cldec.baseclasses)[0];
                 Type tb = b.type.toBasetype();
@@ -4956,7 +4956,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             int multiClassError = cldec.baseClass is null ? 0 : 1;
 
             BCLoop:
-            for (size_t i = (cldec.baseClass ? 1 : 0); i < cldec.baseclasses.dim;)
+            for (size_t i = (cldec.baseClass ? 1 : 0); i < cldec.baseclasses.length;)
             {
                 BaseClass* b = (*cldec.baseclasses)[i];
                 Type tb = b.type.toBasetype();
@@ -4979,7 +4979,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                                           " Use multiple interface inheritance and/or composition.", cldec.toPrettyChars());
                                 multiClassError += 1;
 
-                                if (tc.sym.fields.dim)
+                                if (tc.sym.fields.length)
                                     errorSupplemental(cldec.loc,"`%s` has fields, consider making it a member of `%s`",
                                                       b.type.toChars(), cldec.type.toChars());
                                 else
@@ -5088,7 +5088,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 cldec.storage_class |= cldec.baseClass.storage_class & STC.TYPECTOR;
             }
 
-            cldec.interfaces = cldec.baseclasses.tdata()[(cldec.baseClass ? 1 : 0) .. cldec.baseclasses.dim];
+            cldec.interfaces = cldec.baseclasses.tdata()[(cldec.baseClass ? 1 : 0) .. cldec.baseclasses.length];
             foreach (b; cldec.interfaces)
             {
                 // If this is an interface, and it derives from a COM interface,
@@ -5134,7 +5134,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             sc2.pop();
         }
 
-        for (size_t i = 0; i < cldec.baseclasses.dim; i++)
+        for (size_t i = 0; i < cldec.baseclasses.length; i++)
         {
             BaseClass* b = (*cldec.baseclasses)[i];
             Type tb = b.type.toBasetype();
@@ -5157,14 +5157,14 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             // initialize vtbl
             if (cldec.baseClass)
             {
-                if (cldec.classKind == ClassKind.cpp && cldec.baseClass.vtbl.dim == 0)
+                if (cldec.classKind == ClassKind.cpp && cldec.baseClass.vtbl.length == 0)
                 {
                     cldec.error("C++ base class `%s` needs at least one virtual function", cldec.baseClass.toChars());
                 }
 
                 // Copy vtbl[] from base class
-                cldec.vtbl.setDim(cldec.baseClass.vtbl.dim);
-                memcpy(cldec.vtbl.tdata(), cldec.baseClass.vtbl.tdata(), (void*).sizeof * cldec.vtbl.dim);
+                cldec.vtbl.setDim(cldec.baseClass.vtbl.length);
+                memcpy(cldec.vtbl.tdata(), cldec.baseClass.vtbl.tdata(), (void*).sizeof * cldec.vtbl.length);
 
                 cldec.vthis = cldec.baseClass.vthis;
                 cldec.vthis2 = cldec.baseClass.vthis2;
@@ -5238,7 +5238,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         cldec.members.foreachDsymbol( s => s.importAll(sc2) );
 
-        // Note that members.dim can grow due to tuple expansion during semantic()
+        // Note that members.length can grow due to tuple expansion during semantic()
         cldec.members.foreachDsymbol( s => s.dsymbolSemantic(sc2) );
 
         if (!cldec.determineFields())
@@ -5504,7 +5504,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             idec.baseok = Baseok.start;
 
             // Expand any tuples in baseclasses[]
-            for (size_t i = 0; i < idec.baseclasses.dim;)
+            for (size_t i = 0; i < idec.baseclasses.length;)
             {
                 auto b = (*idec.baseclasses)[i];
                 b.type = resolveBase(b.type.typeSemantic(idec.loc, sc));
@@ -5533,7 +5533,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 goto Lancestorsdone;
             }
 
-            if (!idec.baseclasses.dim && sc.linkage == LINK.cpp)
+            if (!idec.baseclasses.length && sc.linkage == LINK.cpp)
                 idec.classKind = ClassKind.cpp;
             idec.cppnamespace = sc.namespace;
             UserAttributeDeclaration.checkGNUABITag(idec, sc.linkage);
@@ -5544,7 +5544,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             // Check for errors, handle forward references
             BCLoop:
-            for (size_t i = 0; i < idec.baseclasses.dim;)
+            for (size_t i = 0; i < idec.baseclasses.length;)
             {
                 BaseClass* b = (*idec.baseclasses)[i];
                 Type tb = b.type.toBasetype();
@@ -5604,7 +5604,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
             idec.baseok = Baseok.done;
 
-            idec.interfaces = idec.baseclasses.tdata()[0 .. idec.baseclasses.dim];
+            idec.interfaces = idec.baseclasses.tdata()[0 .. idec.baseclasses.length];
             foreach (b; idec.interfaces)
             {
                 // If this is an interface, and it derives from a COM interface,
@@ -5627,7 +5627,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!idec.symtab)
             idec.symtab = new DsymbolTable();
 
-        for (size_t i = 0; i < idec.baseclasses.dim; i++)
+        for (size_t i = 0; i < idec.baseclasses.length; i++)
         {
             BaseClass* b = (*idec.baseclasses)[i];
             Type tb = b.type.toBasetype();
@@ -5663,7 +5663,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 // Copy vtbl[] from base class
                 if (b.sym.vtblOffset())
                 {
-                    size_t d = b.sym.vtbl.dim;
+                    size_t d = b.sym.vtbl.length;
                     if (d > 1)
                     {
                         idec.vtbl.pushSlice(b.sym.vtbl[1 .. d]);
@@ -6056,13 +6056,13 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     // Store the place we added it to in target_symbol_list(_idx) so we can
     // remove it later if we encounter an error.
     Dsymbols* target_symbol_list = tempinst.appendToModuleMember();
-    size_t target_symbol_list_idx = target_symbol_list ? target_symbol_list.dim - 1 : 0;
+    size_t target_symbol_list_idx = target_symbol_list ? target_symbol_list.length - 1 : 0;
 
     // Copy the syntax trees from the TemplateDeclaration
     tempinst.members = Dsymbol.arraySyntaxCopy(tempdecl.members);
 
     // resolve TemplateThisParameter
-    for (size_t i = 0; i < tempdecl.parameters.dim; i++)
+    for (size_t i = 0; i < tempdecl.parameters.length; i++)
     {
         if ((*tempdecl.parameters)[i].isTemplateThisParameter() is null)
             continue;
@@ -6127,8 +6127,8 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
      * member has the same name as the template instance.
      * If so, this template instance becomes an alias for that member.
      */
-    //printf("members.dim = %d\n", tempinst.members.dim);
-    if (tempinst.members.dim)
+    //printf("members.length = %d\n", tempinst.members.length);
+    if (tempinst.members.length)
     {
         Dsymbol s;
         if (Dsymbol.oneMembers(tempinst.members, &s, tempdecl.ident) && s)
@@ -6173,7 +6173,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     /* ConditionalDeclaration may introduce eponymous declaration,
      * so we should find it once again after semantic.
      */
-    if (tempinst.members.dim)
+    if (tempinst.members.length)
     {
         Dsymbol s;
         if (Dsymbol.oneMembers(tempinst.members, &s, tempdecl.ident) && s)
@@ -6196,7 +6196,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
      */
     {
         bool found_deferred_ad = false;
-        for (size_t i = 0; i < Module.deferred.dim; i++)
+        for (size_t i = 0; i < Module.deferred.length; i++)
         {
             Dsymbol sd = Module.deferred[i];
             AggregateDeclaration ad = sd.isAggregateDeclaration();
@@ -6212,7 +6212,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
                 }
             }
         }
-        if (found_deferred_ad || Module.deferred.dim)
+        if (found_deferred_ad || Module.deferred.length)
             goto Laftersemantic;
     }
 
@@ -6246,7 +6246,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
         //printf("Run semantic3 on %s\n", toChars());
         tempinst.trySemantic3(sc2);
 
-        for (size_t i = 0; i < deferred.dim; i++)
+        for (size_t i = 0; i < deferred.length; i++)
         {
             //printf("+ run deferred semantic3 on %s\n", deferred[i].toChars());
             deferred[i].semantic3(null);
@@ -6289,7 +6289,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
                 {
                     if (!td.literal)
                         continue;
-                    assert(td.members && td.members.dim == 1);
+                    assert(td.members && td.members.length == 1);
                     s = (*td.members)[0];
                 }
                 if (auto fld = s.isFuncLiteralDeclaration())
@@ -6323,7 +6323,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
             //printf("deferred semantic3 of %p %s, ti = %s, ti.deferred = %p\n", this, toChars(), ti.toChars());
             for (size_t i = 0;; i++)
             {
-                if (i == ti.deferred.dim)
+                if (i == ti.deferred.length)
                 {
                     ti.deferred.push(tempinst);
                     break;
@@ -6554,7 +6554,7 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
         // Selective imports are allowed to alias to the same name `import mod : sym=sym`.
         if (!ds._import)
         {
-            if (tident.ident is ds.ident && !tident.idents.dim)
+            if (tident.ident is ds.ident && !tident.idents.length)
             {
                 error(ds.loc, "`alias %s = %s;` cannot alias itself, use a qualified name to create an overload set",
                     ds.ident.toChars(), tident.ident.toChars());
@@ -6959,7 +6959,7 @@ private TupleDeclaration aliasAssignInPlace(Scope* sc, TemplateInstance tempinst
 private TemplateInstance isAliasSeq(Scope* sc, TypeInstance ti)
 {
     auto tovers = ti.tempinst.tempdecl.isOverloadSet();
-    foreach (size_t oi; 0 .. tovers ? tovers.a.dim : 1)
+    foreach (size_t oi; 0 .. tovers ? tovers.a.length : 1)
     {
         Dsymbol dstart = tovers ? tovers.a[oi] : ti.tempinst.tempdecl;
         int r = overloadApply(dstart, (Dsymbol s)
@@ -6995,7 +6995,7 @@ bool determineFields(AggregateDeclaration ad)
     if (ad.sizeok != Sizeok.none)
         return true;
 
-    //printf("determineFields() %s, fields.dim = %d\n", toChars(), fields.dim);
+    //printf("determineFields() %s, fields.length = %d\n", toChars(), fields.length);
     // determineFields can be called recursively from one of the fields's v.semantic
     ad.fields.setDim(0);
 
@@ -7047,7 +7047,7 @@ bool determineFields(AggregateDeclaration ad)
 
     if (ad.members)
     {
-        for (size_t i = 0; i < ad.members.dim; i++)
+        for (size_t i = 0; i < ad.members.length; i++)
         {
             auto s = (*ad.members)[i];
             if (s.apply(&func, ad))
@@ -7124,12 +7124,12 @@ private CallExp doAtomicOp (string op, Identifier var, Expression arg)
  */
 PINLINE evalPragmaInline(Loc loc, Scope* sc, Expressions* args)
 {
-    if (!args || args.dim == 0)
+    if (!args || args.length == 0)
         return PINLINE.default_;
 
-    if (args && args.dim > 1)
+    if (args && args.length > 1)
     {
-        .error(loc, "one boolean expression expected for `pragma(inline)`, not %llu", cast(ulong) args.dim);
+        .error(loc, "one boolean expression expected for `pragma(inline)`, not %llu", cast(ulong) args.length);
         args.setDim(1);
         (*args)[0] = ErrorExp.get();
     }

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -362,9 +362,9 @@ private bool arrayObjectMatch(Objects* oa1, Objects* oa2)
 {
     if (oa1 == oa2)
         return true;
-    if (oa1.dim != oa2.dim)
+    if (oa1.length != oa2.length)
         return false;
-    immutable oa1dim = oa1.dim;
+    immutable oa1dim = oa1.length;
     auto oa1d = (*oa1)[].ptr;
     auto oa2d = (*oa2)[].ptr;
     foreach (j; 0 .. oa1dim)
@@ -454,7 +454,7 @@ private size_t expressionHash(Expression e)
     {
         auto ae = e.isArrayLiteralExp();
         size_t hash;
-        foreach (i; 0 .. ae.elements.dim)
+        foreach (i; 0 .. ae.elements.length)
             hash = mixHash(hash, expressionHash(ae[i]));
         return hash;
     }
@@ -463,7 +463,7 @@ private size_t expressionHash(Expression e)
     {
         auto ae = e.isAssocArrayLiteralExp();
         size_t hash;
-        foreach (i; 0 .. ae.keys.dim)
+        foreach (i; 0 .. ae.keys.length)
             // reduction needs associative op as keys are unsorted (use XOR)
             hash ^= mixHash(expressionHash((*ae.keys)[i]), expressionHash((*ae.values)[i]));
         return hash;
@@ -586,7 +586,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         version (none)
         {
             if (parameters)
-                for (int i = 0; i < parameters.dim; i++)
+                for (int i = 0; i < parameters.length; i++)
                 {
                     TemplateParameter tp = (*parameters)[i];
                     //printf("\tparameter[%d] = %p\n", i, tp);
@@ -660,7 +660,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         TemplateParameters* p = null;
         if (parameters)
         {
-            p = new TemplateParameters(parameters.dim);
+            p = new TemplateParameters(parameters.length);
             foreach (i, ref param; *p)
                 param = (*parameters)[i].syntaxCopy();
         }
@@ -1059,9 +1059,9 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         }
         version (none)
         {
-            printf("dedtypes.dim = %d, parameters.dim = %d\n", dedtypes.dim, parameters.dim);
-            if (ti.tiargs.dim)
-                printf("ti.tiargs.dim = %d, [0] = %p\n", ti.tiargs.dim, (*ti.tiargs)[0]);
+            printf("dedtypes.length = %d, parameters.length = %d\n", dedtypes.length, parameters.length);
+            if (ti.tiargs.length)
+                printf("ti.tiargs.length = %d, [0] = %p\n", ti.tiargs.length, (*ti.tiargs)[0]);
         }
         MATCH nomatch()
         {
@@ -1072,18 +1072,18 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             return MATCH.nomatch;
         }
         MATCH m;
-        size_t dedtypes_dim = dedtypes.dim;
+        size_t dedtypes_dim = dedtypes.length;
 
         dedtypes.zero();
 
         if (errors)
             return MATCH.nomatch;
 
-        size_t parameters_dim = parameters.dim;
+        size_t parameters_dim = parameters.length;
         int variadic = isVariadic() !is null;
 
         // If more arguments than parameters, no match
-        if (ti.tiargs.dim > parameters_dim && !variadic)
+        if (ti.tiargs.length > parameters_dim && !variadic)
         {
             static if (LOGM)
             {
@@ -1093,7 +1093,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         }
 
         assert(dedtypes_dim == parameters_dim);
-        assert(dedtypes_dim >= ti.tiargs.dim || variadic);
+        assert(dedtypes_dim >= ti.tiargs.length || variadic);
 
         assert(_scope);
 
@@ -1152,7 +1152,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             {
                 if (!dedtype)
                 {
-                    assert(i < ti.tiargs.dim);
+                    assert(i < ti.tiargs.length);
                     dedtype = cast(Type)(*ti.tiargs)[i];
                 }
             }
@@ -1210,7 +1210,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     TemplateParameter tp = (*parameters)[i];
                     RootObject oarg;
                     printf(" [%d]", i);
-                    if (i < ti.tiargs.dim)
+                    if (i < ti.tiargs.length)
                         oarg = (*ti.tiargs)[i];
                     else
                         oarg = null;
@@ -1257,7 +1257,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         // Set type arguments to dummy template instance to be types
         // generated from the parameters to this template declaration
         auto tiargs = new Objects();
-        tiargs.reserve(parameters.dim);
+        tiargs.reserve(parameters.length);
         foreach (tp; *parameters)
         {
             if (tp.dependent)
@@ -1271,7 +1271,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         scope TemplateInstance ti = new TemplateInstance(Loc.initial, ident, tiargs); // create dummy template instance
 
         // Temporary Array to hold deduced types
-        Objects dedtypes = Objects(td2.parameters.dim);
+        Objects dedtypes = Objects(td2.parameters.length);
 
         // Attempt a type deduction
         MATCH m = td2.matchWithInstance(sc, ti, &dedtypes, fargs, 1);
@@ -1327,13 +1327,13 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         Loc instLoc = ti.loc;
         Objects* tiargs = ti.tiargs;
-        auto dedargs = new Objects(parameters.dim);
+        auto dedargs = new Objects(parameters.length);
         Objects* dedtypes = &ti.tdtypes; // for T:T*, the dedargs is the T*, dedtypes is the T
 
         version (none)
         {
             printf("\nTemplateDeclaration.deduceFunctionTemplateMatch() %s\n", toChars());
-            for (size_t i = 0; i < (fargs ? fargs.dim : 0); i++)
+            for (size_t i = 0; i < (fargs ? fargs.length : 0); i++)
             {
                 Expression e = (*fargs)[i];
                 printf("\tfarg[%d] is %s, type is %s\n", i, e.toChars(), e.type.toChars());
@@ -1348,7 +1348,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         dedargs.zero();
 
-        dedtypes.setDim(parameters.dim);
+        dedtypes.setDim(parameters.length);
         dedtypes.zero();
 
         if (errors || fd.errors)
@@ -1381,7 +1381,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         version (none)
         {
-            for (size_t i = 0; i < dedargs.dim; i++)
+            for (size_t i = 0; i < dedargs.length; i++)
             {
                 printf("\tdedarg[%d] = ", i);
                 RootObject oarg = (*dedargs)[i];
@@ -1395,8 +1395,8 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         if (tiargs)
         {
             // Set initial template arguments
-            ntargs = tiargs.dim;
-            size_t n = parameters.dim;
+            ntargs = tiargs.length;
+            size_t n = parameters.length;
             if (tp)
                 n--;
             if (ntargs > n)
@@ -1408,10 +1408,10 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                  * now form the tuple argument.
                  */
                 auto t = new Tuple(ntargs - n);
-                assert(parameters.dim);
-                (*dedargs)[parameters.dim - 1] = t;
+                assert(parameters.length);
+                (*dedargs)[parameters.length - 1] = t;
 
-                for (size_t i = 0; i < t.objects.dim; i++)
+                for (size_t i = 0; i < t.objects.length; i++)
                 {
                     t.objects[i] = (*tiargs)[n + i];
                 }
@@ -1425,7 +1425,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
             for (size_t i = 0; i < n; i++)
             {
-                assert(i < parameters.dim);
+                assert(i < parameters.length);
                 Declaration sparam = null;
                 MATCH m = (*parameters)[i].matchArg(instLoc, paramscope, dedargs, i, parameters, dedtypes, &sparam);
                 //printf("\tdeduceType m = %d\n", m);
@@ -1438,17 +1438,17 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                 if (!paramscope.insert(sparam))
                     return nomatch();
             }
-            if (n < parameters.dim && !declaredTuple)
+            if (n < parameters.length && !declaredTuple)
             {
                 inferStart = n;
             }
             else
-                inferStart = parameters.dim;
+                inferStart = parameters.length;
             //printf("tiargs matchTiargs = %d\n", matchTiargs);
         }
         version (none)
         {
-            for (size_t i = 0; i < dedargs.dim; i++)
+            for (size_t i = 0; i < dedargs.length; i++)
             {
                 printf("\tdedarg[%d] = ", i);
                 RootObject oarg = (*dedargs)[i];
@@ -1460,7 +1460,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         fparameters = fd.getParameterList();
         nfparams = fparameters.length; // number of function parameters
-        nfargs = fargs ? fargs.dim : 0; // number of function arguments
+        nfargs = fargs ? fargs.length : 0; // number of function arguments
 
         /* Check for match of function arguments with variadic template
          * parameter, such as:
@@ -1479,7 +1479,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                 {
                     auto t = new Tuple();
                     //printf("t = %p\n", t);
-                    (*dedargs)[parameters.dim - 1] = t;
+                    (*dedargs)[parameters.length - 1] = t;
                     declareParameter(paramscope, tp, t);
                     declaredTuple = t;
                 }
@@ -1497,7 +1497,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     if (fparam.type.ty != Tident)
                         continue;
                     TypeIdentifier tid = cast(TypeIdentifier)fparam.type;
-                    if (!tp.ident.equals(tid.ident) || tid.idents.dim)
+                    if (!tp.ident.equals(tid.ident) || tid.idents.length)
                         continue;
 
                     if (fparameters.varargs != VarArg.none) // variadic function doesn't
@@ -1570,7 +1570,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         // Loop through the function parameters
         {
-            //printf("%s\n\tnfargs = %d, nfparams = %d, tuple_dim = %d\n", toChars(), nfargs, nfparams, declaredTuple ? declaredTuple.objects.dim : 0);
+            //printf("%s\n\tnfargs = %d, nfparams = %d, tuple_dim = %d\n", toChars(), nfargs, nfparams, declaredTuple ? declaredTuple.objects.length : 0);
             //printf("\ttp = %p, fptupindex = %d, found = %d, declaredTuple = %s\n", tp, fptupindex, fptupindex != IDX_NOTFOUND, declaredTuple ? declaredTuple.toChars() : NULL);
             size_t argi = 0;
             size_t nfargs2 = nfargs; // nfargs + supplied defaultArgs
@@ -1596,7 +1596,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                          * now form the tuple argument.
                          */
                         declaredTuple = new Tuple();
-                        (*dedargs)[parameters.dim - 1] = declaredTuple;
+                        (*dedargs)[parameters.length - 1] = declaredTuple;
 
                         /* Count function parameters with no defaults following a tuple parameter.
                          * void foo(U, T...)(int y, T, U, double, int bar = 0) {}  // rem == 2 (U, double)
@@ -1609,10 +1609,10 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                             {
                                break;
                             }
-                            if (!reliesOnTemplateParameters(p.type, (*parameters)[inferStart .. parameters.dim]))
+                            if (!reliesOnTemplateParameters(p.type, (*parameters)[inferStart .. parameters.length]))
                             {
                                 Type pt = p.type.syntaxCopy().typeSemantic(fd.loc, paramscope);
-                                rem += pt.ty == Ttuple ? (cast(TypeTuple)pt).arguments.dim : 1;
+                                rem += pt.ty == Ttuple ? (cast(TypeTuple)pt).arguments.length : 1;
                             }
                             else
                             {
@@ -1623,7 +1623,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         if (nfargs2 - argi < rem)
                             return nomatch();
                         declaredTuple.objects.setDim(nfargs2 - argi - rem);
-                        for (size_t i = 0; i < declaredTuple.objects.dim; i++)
+                        for (size_t i = 0; i < declaredTuple.objects.length; i++)
                         {
                             farg = (*fargs)[argi + i];
 
@@ -1665,20 +1665,20 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         // https://issues.dlang.org/show_bug.cgi?id=6810
                         // If declared tuple is not a type tuple,
                         // it cannot be function parameter types.
-                        for (size_t i = 0; i < declaredTuple.objects.dim; i++)
+                        for (size_t i = 0; i < declaredTuple.objects.length; i++)
                         {
                             if (!isType(declaredTuple.objects[i]))
                                 return nomatch();
                         }
                     }
                     assert(declaredTuple);
-                    argi += declaredTuple.objects.dim;
+                    argi += declaredTuple.objects.length;
                     continue;
                 }
 
                 // If parameter type doesn't depend on inferred template parameters,
                 // semantic it to get actual type.
-                if (!reliesOnTemplateParameters(prmtype, (*parameters)[inferStart .. parameters.dim]))
+                if (!reliesOnTemplateParameters(prmtype, (*parameters)[inferStart .. parameters.length]))
                 {
                     // should copy prmtype to avoid affecting semantic result
                     prmtype = prmtype.syntaxCopy().typeSemantic(fd.loc, paramscope);
@@ -1686,7 +1686,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     if (prmtype.ty == Ttuple)
                     {
                         TypeTuple tt = cast(TypeTuple)prmtype;
-                        size_t tt_dim = tt.arguments.dim;
+                        size_t tt_dim = tt.arguments.length;
                         for (size_t j = 0; j < tt_dim; j++, ++argi)
                         {
                             Parameter p = (*tt.arguments)[j];
@@ -1748,7 +1748,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                                 dedtype = xt.tded; // 'unbox'
                             }
                         }
-                        for (size_t i = ntargs; i < dedargs.dim; i++)
+                        for (size_t i = ntargs; i < dedargs.length; i++)
                         {
                             TemplateParameter tparam = (*parameters)[i];
 
@@ -1850,7 +1850,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         /* Allow expressions that have CT-known boundaries and type [] to match with [dim]
                          */
                         Type taai;
-                        if (argtype.ty == Tarray && (prmtype.ty == Tsarray || prmtype.ty == Taarray && (taai = (cast(TypeAArray)prmtype).index).ty == Tident && (cast(TypeIdentifier)taai).idents.dim == 0))
+                        if (argtype.ty == Tarray && (prmtype.ty == Tsarray || prmtype.ty == Taarray && (taai = (cast(TypeAArray)prmtype).index).ty == Tident && (cast(TypeIdentifier)taai).idents.length == 0))
                         {
                             if (farg.op == EXP.string_)
                             {
@@ -1860,7 +1860,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                             else if (farg.op == EXP.arrayLiteral)
                             {
                                 ArrayLiteralExp ae = cast(ArrayLiteralExp)farg;
-                                argtype = ae.type.nextOf().sarrayOf(ae.elements.dim);
+                                argtype = ae.type.nextOf().sarrayOf(ae.elements.length);
                             }
                             else if (farg.op == EXP.slice)
                             {
@@ -1872,7 +1872,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
                         oarg = argtype;
                     }
-                    else if ((fparam.storageClass & STC.out_) == 0 && (argtype.ty == Tarray || argtype.ty == Tpointer) && templateParameterLookup(prmtype, parameters) != IDX_NOTFOUND && (cast(TypeIdentifier)prmtype).idents.dim == 0)
+                    else if ((fparam.storageClass & STC.out_) == 0 && (argtype.ty == Tarray || argtype.ty == Tpointer) && templateParameterLookup(prmtype, parameters) != IDX_NOTFOUND && (cast(TypeIdentifier)prmtype).idents.length == 0)
                     {
                         /* The farg passing to the prmtype always make a copy. Therefore,
                          * we can shrink the set of the deduced type arguments for prmtype
@@ -2124,7 +2124,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                 dedtype = at.merge2();
             }
         }
-        for (size_t i = ntargs; i < dedargs.dim; i++)
+        for (size_t i = ntargs; i < dedargs.length; i++)
         {
             TemplateParameter tparam = (*parameters)[i];
             //printf("tparam[%d] = %s\n", i, tparam.ident.toChars());
@@ -2176,7 +2176,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     // we're one or more arguments short (i.e. no tuple argument)
                     if (tparam == tp &&
                         fptupindex == IDX_NOTFOUND &&
-                        ntargs <= dedargs.dim - 1)
+                        ntargs <= dedargs.length - 1)
                     {
                         // make tuple argument an empty tuple
                         oded = new Tuple();
@@ -2215,7 +2215,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
          * As same as the code for 7469 in findBestMatch,
          * expand a Tuple in dedargs to normalize template arguments.
          */
-        if (auto d = dedargs.dim)
+        if (auto d = dedargs.length)
         {
             if (auto va = isTuple((*dedargs)[d - 1]))
             {
@@ -2253,7 +2253,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         version (none)
         {
-            for (size_t i = 0; i < dedargs.dim; i++)
+            for (size_t i = 0; i < dedargs.length; i++)
             {
                 RootObject o = (*dedargs)[i];
                 printf("\tdedargs[%d] = %d, %s\n", i, o.dyncast(), o.toChars());
@@ -2515,7 +2515,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
      */
     TemplateTupleParameter isVariadic()
     {
-        size_t dim = parameters.dim;
+        size_t dim = parameters.length;
         if (dim == 0)
             return null;
         return (*parameters)[dim - 1].isTemplateTupleParameter();
@@ -2612,14 +2612,14 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
         printf("    tiargs:\n");
         if (tiargs)
         {
-            for (size_t i = 0; i < tiargs.dim; i++)
+            for (size_t i = 0; i < tiargs.length; i++)
             {
                 RootObject arg = (*tiargs)[i];
                 printf("\t%s\n", arg.toChars());
             }
         }
         printf("    fargs:\n");
-        for (size_t i = 0; i < (fargs ? fargs.dim : 0); i++)
+        for (size_t i = 0; i < (fargs ? fargs.length : 0); i++)
         {
             Expression arg = (*fargs)[i];
             printf("\t%s %s\n", arg.type.toChars(), arg.toChars());
@@ -2645,7 +2645,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
         if (fd == m.lastf)
             return 0;
         // explicitly specified tiargs never match to non template function
-        if (tiargs && tiargs.dim > 0)
+        if (tiargs && tiargs.length > 0)
             return 0;
 
         // constructors need a valid scope in order to detect semantic errors
@@ -2847,7 +2847,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
             if (!tiargs)
                 tiargs = new Objects();
             auto ti = new TemplateInstance(loc, td, tiargs);
-            Objects dedtypes = Objects(td.parameters.dim);
+            Objects dedtypes = Objects(td.parameters.length);
             assert(td.semanticRun != PASS.initial);
             MATCH mta = td.matchWithInstance(sc, ti, &dedtypes, fargs, 0);
             //printf("matchWithInstance = %d\n", mta);
@@ -3154,7 +3154,7 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
  */
 private size_t templateIdentifierLookup(Identifier id, TemplateParameters* parameters)
 {
-    for (size_t i = 0; i < parameters.dim; i++)
+    for (size_t i = 0; i < parameters.length; i++)
     {
         TemplateParameter tp = (*parameters)[i];
         if (tp.ident.equals(id))
@@ -3536,7 +3536,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     /* Need a loc to go with the semantic routine.
                      */
                     Loc loc;
-                    if (parameters.dim)
+                    if (parameters.length)
                     {
                         TemplateParameter tp = (*parameters)[0];
                         loc = tp.loc;
@@ -3554,11 +3554,11 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 TemplateParameter tp = (*parameters)[i];
 
                 TypeIdentifier tident = cast(TypeIdentifier)tparam;
-                if (tident.idents.dim > 0)
+                if (tident.idents.length > 0)
                 {
                     //printf("matching %s to %s\n", tparam.toChars(), t.toChars());
                     Dsymbol s = t.toDsymbol(sc);
-                    for (size_t j = tident.idents.dim; j-- > 0;)
+                    for (size_t j = tident.idents.length; j-- > 0;)
                     {
                         RootObject id = tident.idents[j];
                         if (id.dyncast() == DYNCAST.identifier)
@@ -3707,7 +3707,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 /* Need a loc to go with the semantic routine.
                  */
                 Loc loc;
-                if (parameters.dim)
+                if (parameters.length)
                 {
                     TemplateParameter tp = (*parameters)[0];
                     loc = tp.loc;
@@ -3845,7 +3845,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         // The "type" (it hasn't been resolved yet) of the function parameter
                         // does not have a location but the parameter it is related to does,
                         // so we use that for the resolution (better error message).
-                        if (inferStart < parameters.dim)
+                        if (inferStart < parameters.length)
                         {
                             TemplateParameter loctp = (*parameters)[inferStart];
                             loc = loctp.loc;
@@ -3905,7 +3905,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
                     // https://issues.dlang.org/show_bug.cgi?id=15243
                     // Resolve parameter type if it's not related with template parameters
-                    if (!reliesOnTemplateParameters(fparam.type, (*parameters)[inferStart .. parameters.dim]))
+                    if (!reliesOnTemplateParameters(fparam.type, (*parameters)[inferStart .. parameters.length]))
                     {
                         auto tx = fparam.type.typeSemantic(Loc.initial, sc);
                         if (tx.ty == Terror)
@@ -3933,7 +3933,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     if (fparam.type.ty != Tident)
                         goto L1;
                     TypeIdentifier tid = cast(TypeIdentifier)fparam.type;
-                    if (tid.idents.dim)
+                    if (tid.idents.length)
                         goto L1;
 
                     /* Look through parameters to find tuple matching tid.ident
@@ -3941,7 +3941,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     size_t tupi = 0;
                     for (; 1; tupi++)
                     {
-                        if (tupi == parameters.dim)
+                        if (tupi == parameters.length)
                             goto L1;
                         TemplateParameter tx = (*parameters)[tupi];
                         TemplateTupleParameter tup = tx.isTemplateTupleParameter();
@@ -3961,7 +3961,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     {
                         // Existing deduced argument must be a tuple, and must match
                         Tuple tup = isTuple(o);
-                        if (!tup || tup.objects.dim != tuple_dim)
+                        if (!tup || tup.objects.length != tuple_dim)
                         {
                             result = MATCH.nomatch;
                             return;
@@ -4023,7 +4023,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             if (tparam && tparam.ty == Tident)
             {
                 TypeIdentifier tp = cast(TypeIdentifier)tparam;
-                for (size_t i = 0; i < t.idents.dim; i++)
+                for (size_t i = 0; i < t.idents.length; i++)
                 {
                     RootObject id1 = t.idents[i];
                     RootObject id2 = tp.idents[i];
@@ -4112,19 +4112,19 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 {
                     //printf("\ttest: tempinst.tiargs[%d]\n", i);
                     RootObject o1 = null;
-                    if (i < t.tempinst.tiargs.dim)
+                    if (i < t.tempinst.tiargs.length)
                         o1 = (*t.tempinst.tiargs)[i];
-                    else if (i < t.tempinst.tdtypes.dim && i < tp.tempinst.tiargs.dim)
+                    else if (i < t.tempinst.tdtypes.length && i < tp.tempinst.tiargs.length)
                     {
                         // Pick up default arg
                         o1 = t.tempinst.tdtypes[i];
                     }
-                    else if (i >= tp.tempinst.tiargs.dim)
+                    else if (i >= tp.tempinst.tiargs.length)
                         break;
 
-                    if (i >= tp.tempinst.tiargs.dim)
+                    if (i >= tp.tempinst.tiargs.length)
                     {
-                        size_t dim = tempdecl.parameters.dim - (tempdecl.isVariadic() ? 1 : 0);
+                        size_t dim = tempdecl.parameters.length - (tempdecl.isVariadic() ? 1 : 0);
                         while (i < dim && ((*tempdecl.parameters)[i].dependent || (*tempdecl.parameters)[i].hasDefaultArg()))
                         {
                             i++;
@@ -4137,9 +4137,9 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     RootObject o2 = (*tp.tempinst.tiargs)[i];
                     Type t2 = isType(o2);
 
-                    size_t j = (t2 && t2.ty == Tident && i == tp.tempinst.tiargs.dim - 1)
+                    size_t j = (t2 && t2.ty == Tident && i == tp.tempinst.tiargs.length - 1)
                         ? templateParameterLookup(t2, parameters) : IDX_NOTFOUND;
-                    if (j != IDX_NOTFOUND && j == parameters.dim - 1 &&
+                    if (j != IDX_NOTFOUND && j == parameters.length - 1 &&
                         (*parameters)[j].isTemplateTupleParameter())
                     {
                         /* Given:
@@ -4151,12 +4151,12 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
                         /* Create tuple from remaining args
                          */
-                        size_t vtdim = (tempdecl.isVariadic() ? t.tempinst.tiargs.dim : t.tempinst.tdtypes.dim) - i;
+                        size_t vtdim = (tempdecl.isVariadic() ? t.tempinst.tiargs.length : t.tempinst.tdtypes.length) - i;
                         auto vt = new Tuple(vtdim);
                         for (size_t k = 0; k < vtdim; k++)
                         {
                             RootObject o;
-                            if (k < t.tempinst.tiargs.dim)
+                            if (k < t.tempinst.tiargs.length)
                                 o = (*t.tempinst.tiargs)[i + k];
                             else // Pick up default arg
                                 o = t.tempinst.tdtypes[i + k];
@@ -4315,9 +4315,9 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                  *  S!(T).foo
                  */
                 TypeInstance tpi = cast(TypeInstance)tparam;
-                if (tpi.idents.dim)
+                if (tpi.idents.length)
                 {
-                    RootObject id = tpi.idents[tpi.idents.dim - 1];
+                    RootObject id = tpi.idents[tpi.idents.length - 1];
                     if (id.dyncast() == DYNCAST.identifier && t.sym.ident.equals(cast(Identifier)id))
                     {
                         Type tparent = t.sym.parent.getType();
@@ -4325,9 +4325,9 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         {
                             /* Slice off the .foo in S!(T).foo
                              */
-                            tpi.idents.dim--;
+                            tpi.idents.length--;
                             result = deduceType(tparent, sc, tpi, parameters, dedtypes, wm);
-                            tpi.idents.dim++;
+                            tpi.idents.length++;
                             return;
                         }
                     }
@@ -4398,8 +4398,8 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             if (parti)
             {
                 // Make a temporary copy of dedtypes so we don't destroy it
-                auto tmpdedtypes = new Objects(dedtypes.dim);
-                memcpy(tmpdedtypes.tdata(), dedtypes.tdata(), dedtypes.dim * (void*).sizeof);
+                auto tmpdedtypes = new Objects(dedtypes.length);
+                memcpy(tmpdedtypes.tdata(), dedtypes.tdata(), dedtypes.length * (void*).sizeof);
 
                 auto t = new TypeInstance(Loc.initial, parti);
                 MATCH m = deduceType(t, sc, tparam, parameters, tmpdedtypes);
@@ -4407,9 +4407,9 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 {
                     // If this is the first ever match, it becomes our best estimate
                     if (numBaseClassMatches == 0)
-                        memcpy(best.tdata(), tmpdedtypes.tdata(), tmpdedtypes.dim * (void*).sizeof);
+                        memcpy(best.tdata(), tmpdedtypes.tdata(), tmpdedtypes.length * (void*).sizeof);
                     else
-                        for (size_t k = 0; k < tmpdedtypes.dim; ++k)
+                        for (size_t k = 0; k < tmpdedtypes.length; ++k)
                         {
                             // If we've found more than one possible type for a parameter,
                             // mark it as unknown.
@@ -4456,9 +4456,9 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                  *  S!(T).foo
                  */
                 TypeInstance tpi = cast(TypeInstance)tparam;
-                if (tpi.idents.dim)
+                if (tpi.idents.length)
                 {
-                    RootObject id = tpi.idents[tpi.idents.dim - 1];
+                    RootObject id = tpi.idents[tpi.idents.length - 1];
                     if (id.dyncast() == DYNCAST.identifier && t.sym.ident.equals(cast(Identifier)id))
                     {
                         Type tparent = t.sym.parent.getType();
@@ -4466,9 +4466,9 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         {
                             /* Slice off the .foo in S!(T).foo
                              */
-                            tpi.idents.dim--;
+                            tpi.idents.length--;
                             result = deduceType(tparent, sc, tpi, parameters, dedtypes, wm);
-                            tpi.idents.dim++;
+                            tpi.idents.length++;
                             return;
                         }
                     }
@@ -4487,10 +4487,10 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 int numBaseClassMatches = 0; // Have we found an interface match?
 
                 // Our best guess at dedtypes
-                auto best = new Objects(dedtypes.dim);
+                auto best = new Objects(dedtypes.length);
 
                 ClassDeclaration s = t.sym;
-                while (s && s.baseclasses.dim > 0)
+                while (s && s.baseclasses.length > 0)
                 {
                     // Test the base class
                     deduceBaseClassParameters(*(*s.baseclasses)[0], sc, tparam, parameters, dedtypes, best, numBaseClassMatches);
@@ -4510,7 +4510,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 }
 
                 // If we got at least one match, copy the known types into dedtypes
-                memcpy(dedtypes.tdata(), best.tdata(), best.dim * (void*).sizeof);
+                memcpy(dedtypes.tdata(), best.tdata(), best.length * (void*).sizeof);
                 result = MATCH.convert;
                 return;
             }
@@ -4536,7 +4536,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         {
             //printf("Expression.deduceType(e = %s)\n", e.toChars());
             size_t i = templateParameterLookup(tparam, parameters);
-            if (i == IDX_NOTFOUND || (cast(TypeIdentifier)tparam).idents.dim > 0)
+            if (i == IDX_NOTFOUND || (cast(TypeIdentifier)tparam).idents.length > 0)
             {
                 if (e == emptyArrayElement && tparam.ty == Tarray)
                 {
@@ -4721,7 +4721,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         override void visit(StringExp e)
         {
             Type taai;
-            if (e.type.ty == Tarray && (tparam.ty == Tsarray || tparam.ty == Taarray && (taai = (cast(TypeAArray)tparam).index).ty == Tident && (cast(TypeIdentifier)taai).idents.dim == 0))
+            if (e.type.ty == Tarray && (tparam.ty == Tsarray || tparam.ty == Taarray && (taai = (cast(TypeAArray)tparam).index).ty == Tident && (cast(TypeIdentifier)taai).idents.length == 0))
             {
                 // Consider compile-time known boundaries
                 e.type.nextOf().sarrayOf(e.len).accept(this);
@@ -4733,19 +4733,19 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         override void visit(ArrayLiteralExp e)
         {
             // https://issues.dlang.org/show_bug.cgi?id=20092
-            if (e.elements && e.elements.dim && e.type.toBasetype().nextOf().ty == Tvoid)
+            if (e.elements && e.elements.length && e.type.toBasetype().nextOf().ty == Tvoid)
             {
                 result = deduceEmptyArrayElement();
                 return;
             }
-            if ((!e.elements || !e.elements.dim) && e.type.toBasetype().nextOf().ty == Tvoid && tparam.ty == Tarray)
+            if ((!e.elements || !e.elements.length) && e.type.toBasetype().nextOf().ty == Tvoid && tparam.ty == Tarray)
             {
                 // tparam:T[] <- e:[] (void[])
                 result = deduceEmptyArrayElement();
                 return;
             }
 
-            if (tparam.ty == Tarray && e.elements && e.elements.dim)
+            if (tparam.ty == Tarray && e.elements && e.elements.length)
             {
                 Type tn = (cast(TypeDArray)tparam).next;
                 result = MATCH.exact;
@@ -4769,10 +4769,10 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             }
 
             Type taai;
-            if (e.type.ty == Tarray && (tparam.ty == Tsarray || tparam.ty == Taarray && (taai = (cast(TypeAArray)tparam).index).ty == Tident && (cast(TypeIdentifier)taai).idents.dim == 0))
+            if (e.type.ty == Tarray && (tparam.ty == Tsarray || tparam.ty == Taarray && (taai = (cast(TypeAArray)tparam).index).ty == Tident && (cast(TypeIdentifier)taai).idents.length == 0))
             {
                 // Consider compile-time known boundaries
-                e.type.nextOf().sarrayOf(e.elements.dim).accept(this);
+                e.type.nextOf().sarrayOf(e.elements.length).accept(this);
                 return;
             }
             visit(cast(Expression)e);
@@ -4780,7 +4780,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
         override void visit(AssocArrayLiteralExp e)
         {
-            if (tparam.ty == Taarray && e.keys && e.keys.dim)
+            if (tparam.ty == Taarray && e.keys && e.keys.length)
             {
                 TypeAArray taa = cast(TypeAArray)tparam;
                 result = MATCH.exact;
@@ -4825,7 +4825,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     return;
 
                 auto tiargs = new Objects();
-                tiargs.reserve(e.td.parameters.dim);
+                tiargs.reserve(e.td.parameters.length);
 
                 foreach (tp; *e.td.parameters)
                 {
@@ -4841,7 +4841,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     if (!pto)
                         break;
                     Type t = pto.type.syntaxCopy(); // https://issues.dlang.org/show_bug.cgi?id=11774
-                    if (reliesOnTemplateParameters(t, (*parameters)[inferStart .. parameters.dim]))
+                    if (reliesOnTemplateParameters(t, (*parameters)[inferStart .. parameters.length]))
                         return;
                     t = t.typeSemantic(e.loc, sc);
                     if (t.ty == Terror)
@@ -4885,7 +4885,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         override void visit(SliceExp e)
         {
             Type taai;
-            if (e.type.ty == Tarray && (tparam.ty == Tsarray || tparam.ty == Taarray && (taai = (cast(TypeAArray)tparam).index).ty == Tident && (cast(TypeIdentifier)taai).idents.dim == 0))
+            if (e.type.ty == Tarray && (tparam.ty == Tsarray || tparam.ty == Taarray && (taai = (cast(TypeAArray)tparam).index).ty == Tident && (cast(TypeIdentifier)taai).idents.length == 0))
             {
                 // Consider compile-time known boundaries
                 if (Type tsa = toStaticArrayType(e))
@@ -4928,7 +4928,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
  */
 bool reliesOnTident(Type t, TemplateParameters* tparams, size_t iStart = 0)
 {
-    return reliesOnTemplateParameters(t, (*tparams)[0 .. tparams.dim]);
+    return reliesOnTemplateParameters(t, (*tparams)[0 .. tparams.length]);
 }
 
 /***********************************************************
@@ -5739,7 +5739,7 @@ extern (C++) final class TemplateTupleParameter : TemplateParameter
         Tuple v = isTuple(oded);
         assert(v);
 
-        //printf("|%d| ", v.objects.dim);
+        //printf("|%d| ", v.objects.length);
         foreach (i, o; v.objects)
         {
             if (i)
@@ -5901,7 +5901,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         Objects* a = null;
         if (objs)
         {
-            a = new Objects(objs.dim);
+            a = new Objects(objs.length);
             foreach (i, o; *objs)
                 (*a)[i] = objectSyntaxCopy(o);
         }
@@ -6094,7 +6094,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     final bool equalsx(TemplateInstance ti)
     {
         //printf("this = %p, ti = %p\n", this, ti);
-        assert(tdtypes.dim == ti.tdtypes.dim);
+        assert(tdtypes.length == ti.tdtypes.length);
 
         // Nesting must match
         if (enclosing != ti.enclosing)
@@ -6121,7 +6121,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     Parameter fparam = fparameters[j];
                     if (fparam.storageClass & STC.autoref)       // if "auto ref"
                     {
-                        Expression farg = fargs && j < fargs.dim ? (*fargs)[j] : fparam.defaultArg;
+                        Expression farg = fargs && j < fargs.length ? (*fargs)[j] : fparam.defaultArg;
                         if (!farg)
                             goto Lnotequals;
                         if (farg.isLvalue())
@@ -6423,7 +6423,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
         // Look for forward references
         auto tovers = tempdecl.isOverloadSet();
-        foreach (size_t oi; 0 .. tovers ? tovers.a.dim : 1)
+        foreach (size_t oi; 0 .. tovers ? tovers.a.length : 1)
         {
             Dsymbol dstart = tovers ? tovers.a[oi] : tempdecl;
             int r = overloadApply(dstart, (Dsymbol s)
@@ -6583,7 +6583,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         if (!tiargs)
             return true;
         bool err = false;
-        for (size_t j = 0; j < tiargs.dim; j++)
+        for (size_t j = 0; j < tiargs.length; j++)
         {
             RootObject o = (*tiargs)[j];
             Type ta = isType(o);
@@ -6612,7 +6612,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 {
                     // Expand tuple
                     TypeTuple tt = cast(TypeTuple)ta;
-                    size_t dim = tt.arguments.dim;
+                    size_t dim = tt.arguments.length;
                     tiargs.remove(j);
                     if (dim)
                     {
@@ -6688,7 +6688,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 {
                     // Expand tuple
                     TupleExp te = cast(TupleExp)ea;
-                    size_t dim = te.exps.dim;
+                    size_t dim = te.exps.length;
                     tiargs.remove(j);
                     if (dim)
                     {
@@ -6820,7 +6820,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         version (none)
         {
             printf("-TemplateInstance.semanticTiargs()\n");
-            for (size_t j = 0; j < tiargs.dim; j++)
+            for (size_t j = 0; j < tiargs.length; j++)
             {
                 RootObject o = (*tiargs)[j];
                 Type ta = isType(o);
@@ -6875,7 +6875,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             assert(tempdecl);
             assert(tempdecl._scope);
             // Deduce tdtypes
-            tdtypes.setDim(tempdecl.parameters.dim);
+            tdtypes.setDim(tempdecl.parameters.length);
             if (!tempdecl.matchWithInstance(sc, this, &tdtypes, fargs, 2))
             {
                 error("incompatible arguments for template instantiation");
@@ -6898,7 +6898,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
          * name, look for the best match.
          */
         auto tovers = tempdecl.isOverloadSet();
-        foreach (size_t oi; 0 .. tovers ? tovers.a.dim : 1)
+        foreach (size_t oi; 0 .. tovers ? tovers.a.length : 1)
         {
             TemplateDeclaration td_best;
             TemplateDeclaration td_ambig;
@@ -6921,13 +6921,13 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 //printf("td = %s\n", td.toPrettyChars());
                 // If more arguments than parameters,
                 // then this is no match.
-                if (td.parameters.dim < tiargs.dim)
+                if (td.parameters.length < tiargs.length)
                 {
                     if (!td.isVariadic())
                         return 0;
                 }
 
-                dedtypes.setDim(td.parameters.dim);
+                dedtypes.setDim(td.parameters.length);
                 dedtypes.zero();
                 assert(td.semanticRun != PASS.initial);
 
@@ -6960,8 +6960,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 td_ambig = null;
                 td_best = td;
                 m_best = m;
-                tdtypes.setDim(dedtypes.dim);
-                memcpy(tdtypes.tdata(), dedtypes.tdata(), tdtypes.dim * (void*).sizeof);
+                tdtypes.setDim(dedtypes.length);
+                memcpy(tdtypes.tdata(), dedtypes.tdata(), tdtypes.length * (void*).sizeof);
                 return 0;
             });
 
@@ -7000,12 +7000,12 @@ extern (C++) class TemplateInstance : ScopeDsymbol
              *    S!num s;             // S!1 is instantiated, not S!num
              *  }
              */
-            size_t dim = td_last.parameters.dim - (td_last.isVariadic() ? 1 : 0);
+            size_t dim = td_last.parameters.length - (td_last.isVariadic() ? 1 : 0);
             for (size_t i = 0; i < dim; i++)
             {
-                if (tiargs.dim <= i)
+                if (tiargs.length <= i)
                     tiargs.push(tdtypes[i]);
-                assert(i < tiargs.dim);
+                assert(i < tiargs.length);
 
                 auto tvp = (*td_last.parameters)[i].isTemplateValueParameter();
                 if (!tvp)
@@ -7015,7 +7015,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
                 (*tiargs)[i] = tdtypes[i];
             }
-            if (td_last.isVariadic() && tiargs.dim == dim && tdtypes[dim])
+            if (td_last.isVariadic() && tiargs.length == dim && tdtypes[dim])
             {
                 Tuple va = isTuple(tdtypes[dim]);
                 assert(va);
@@ -7051,7 +7051,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 {
                     error("%s `%s`", msg, tmsg);
 
-                    if (tdecl.parameters.dim == tiargs.dim)
+                    if (tdecl.parameters.length == tiargs.length)
                     {
                         // https://issues.dlang.org/show_bug.cgi?id=7352
                         // print additional information, e.g. `foo` is not a type
@@ -7123,7 +7123,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         size_t count = 0;
 
         auto tovers = tempdecl.isOverloadSet();
-        foreach (size_t oi; 0 .. tovers ? tovers.a.dim : 1)
+        foreach (size_t oi; 0 .. tovers ? tovers.a.length : 1)
         {
             Dsymbol dstart = tovers ? tovers.a[oi] : tempdecl;
             int r = overloadApply(dstart, (Dsymbol s)
@@ -7146,7 +7146,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 {
                     if (!td2.onemember || !td2.onemember.isFuncDeclaration())
                         return 0;
-                    if (tiargs.dim >= td.parameters.dim - (td.isVariadic() ? 1 : 0))
+                    if (tiargs.length >= td.parameters.length - (td.isVariadic() ? 1 : 0))
                         return 0;
                     return 1;
                 }
@@ -7163,18 +7163,18 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 /* Determine if the instance arguments, tiargs, are all that is necessary
                  * to instantiate the template.
                  */
-                //printf("tp = %p, td.parameters.dim = %d, tiargs.dim = %d\n", tp, td.parameters.dim, tiargs.dim);
+                //printf("tp = %p, td.parameters.length = %d, tiargs.length = %d\n", tp, td.parameters.length, tiargs.length);
                 auto tf = cast(TypeFunction)fd.type;
                 if (tf.parameterList.length)
                 {
                     auto tp = td.isVariadic();
-                    if (tp && td.parameters.dim > 1)
+                    if (tp && td.parameters.length > 1)
                         return 1;
 
-                    if (!tp && tiargs.dim < td.parameters.dim)
+                    if (!tp && tiargs.length < td.parameters.length)
                     {
                         // Can remain tiargs be filled by default arguments?
-                        foreach (size_t i; tiargs.dim .. td.parameters.dim)
+                        foreach (size_t i; tiargs.length .. td.parameters.length)
                         {
                             if (!(*td.parameters)[i].hasDefaultArg())
                                 return 1;
@@ -7194,7 +7194,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     /* Calculate the need for overload resolution.
                      * When only one template can match with tiargs, inference is not necessary.
                      */
-                    dedtypes.setDim(td.parameters.dim);
+                    dedtypes.setDim(td.parameters.length);
                     dedtypes.zero();
                     if (td.semanticRun == PASS.initial)
                     {
@@ -7661,7 +7661,7 @@ extern (C++) final class TemplateMixin : TemplateInstance
     extern (D) this(const ref Loc loc, Identifier ident, TypeQualified tqual, Objects* tiargs)
     {
         super(loc,
-              tqual.idents.dim ? cast(Identifier)tqual.idents[tqual.idents.dim - 1] : (cast(TypeIdentifier)tqual).ident,
+              tqual.idents.length ? cast(Identifier)tqual.idents[tqual.idents.length - 1] : (cast(TypeIdentifier)tqual).ident,
               tiargs ? tiargs : new Objects());
         //printf("TemplateMixin(ident = '%s')\n", ident ? ident.toChars() : "");
         this.ident = ident;
@@ -7753,7 +7753,7 @@ extern (C++) final class TemplateMixin : TemplateInstance
 
         // Look for forward references
         auto tovers = tempdecl.isOverloadSet();
-        foreach (size_t oi; 0 .. tovers ? tovers.a.dim : 1)
+        foreach (size_t oi; 0 .. tovers ? tovers.a.length : 1)
         {
             Dsymbol dstart = tovers ? tovers.a[oi] : tempdecl;
             int r = overloadApply(dstart, (Dsymbol s)
@@ -7873,7 +7873,7 @@ MATCH matchArg(TemplateParameter tp, Loc instLoc, Scope* sc, Objects* tiargs, si
     {
         RootObject oarg;
 
-        if (i < tiargs.dim)
+        if (i < tiargs.length)
             oarg = (*tiargs)[i];
         else
         {
@@ -7881,7 +7881,7 @@ MATCH matchArg(TemplateParameter tp, Loc instLoc, Scope* sc, Objects* tiargs, si
             oarg = tp.defaultArg(instLoc, sc);
             if (!oarg)
             {
-                assert(i < dedtypes.dim);
+                assert(i < dedtypes.length);
                 // It might have already been deduced
                 oarg = (*dedtypes)[i];
                 if (!oarg)
@@ -7896,7 +7896,7 @@ MATCH matchArg(TemplateParameter tp, Loc instLoc, Scope* sc, Objects* tiargs, si
         /* The rest of the actual arguments (tiargs[]) form the match
          * for the variadic parameter.
          */
-        assert(i + 1 == dedtypes.dim); // must be the last one
+        assert(i + 1 == dedtypes.length); // must be the last one
         Tuple ovar;
 
         if (Tuple u = isTuple((*dedtypes)[i]))
@@ -7904,16 +7904,16 @@ MATCH matchArg(TemplateParameter tp, Loc instLoc, Scope* sc, Objects* tiargs, si
             // It has already been deduced
             ovar = u;
         }
-        else if (i + 1 == tiargs.dim && isTuple((*tiargs)[i]))
+        else if (i + 1 == tiargs.length && isTuple((*tiargs)[i]))
             ovar = isTuple((*tiargs)[i]);
         else
         {
             ovar = new Tuple();
             //printf("ovar = %p\n", ovar);
-            if (i < tiargs.dim)
+            if (i < tiargs.length)
             {
-                //printf("i = %d, tiargs.dim = %d\n", i, tiargs.dim);
-                ovar.objects.setDim(tiargs.dim - i);
+                //printf("i = %d, tiargs.length = %d\n", i, tiargs.length);
+                ovar.objects.setDim(tiargs.length - i);
                 foreach (j, ref obj; ovar.objects)
                     obj = (*tiargs)[i + j];
             }

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -1945,7 +1945,7 @@ public:
         }
         if (tf.parameterList.varargs)
         {
-            if (tf.parameterList.parameters.dim && tf.parameterList.varargs == 1)
+            if (tf.parameterList.parameters.length && tf.parameterList.varargs == 1)
                 buf.writestring(", ");
             buf.writestring("...");
         }
@@ -2280,7 +2280,7 @@ public:
         }
         if (tf.parameterList.varargs)
         {
-            if (tf.parameterList.parameters.dim && tf.parameterList.varargs == 1)
+            if (tf.parameterList.parameters.length && tf.parameterList.varargs == 1)
                 buf.writestring(", ");
             buf.writestring("...");
         }

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -402,9 +402,9 @@ elem *toElemDtor(Expression e, IRState *irs)
     if (irs.mayThrow && !canThrow(e, irs.getFunc(), false))
         irs.mayThrow = false;
 
-    const starti = irs.varsInScope.dim;
+    const starti = irs.varsInScope.length;
     elem* er = toElem(e, irs);
-    const endi = irs.varsInScope.dim;
+    const endi = irs.varsInScope.length;
 
     irs.mayThrow = mayThrowSave;
 
@@ -1233,8 +1233,8 @@ elem* toElem(Expression e, IRState *irs)
         {
             elem *ezprefix = ne.argprefix ? toElem(ne.argprefix, irs) : null;
 
-            assert(ne.arguments && ne.arguments.dim >= 1);
-            if (ne.arguments.dim == 1)
+            assert(ne.arguments && ne.arguments.length >= 1);
+            if (ne.arguments.length == 1)
             {
                 // Single dimension array allocations
                 Expression arg = (*ne.arguments)[0]; // gives array length
@@ -1249,7 +1249,7 @@ elem* toElem(Expression e, IRState *irs)
             else
             {
                 // Multidimensional array allocations
-                foreach (i; 0 .. ne.arguments.dim)
+                foreach (i; 0 .. ne.arguments.length)
                 {
                     assert(t.ty == Tarray);
                     t = t.nextOf();
@@ -1260,7 +1260,7 @@ elem* toElem(Expression e, IRState *irs)
                 Symbol *sdata = null;
                 elem *earray = ExpressionsToStaticArray(irs, ne.loc, ne.arguments, &sdata);
 
-                e = el_pair(TYdarray, el_long(TYsize_t, ne.arguments.dim), el_ptr(sdata));
+                e = el_pair(TYdarray, el_long(TYsize_t, ne.arguments.length), el_ptr(sdata));
                 if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
                     e = addressElem(e, Type.tsize_t.arrayOf());
                 e = el_param(e, getTypeInfo(ne, ne.type, irs));
@@ -1283,7 +1283,7 @@ elem* toElem(Expression e, IRState *irs)
             e = el_bin(OPcall,TYnptr,el_var(getRtlsym(rtl)),e);
             toTraceGC(irs, e, ne.loc);
 
-            if (ne.arguments && ne.arguments.dim == 1)
+            if (ne.arguments && ne.arguments.length == 1)
             {
                 /* ezprefix, ts=_d_newitemT(ti), *ts=arguments[0], ts
                  */
@@ -1731,7 +1731,7 @@ elem* toElem(Expression e, IRState *irs)
             Symbol *sdata;
             elem *earr = ElemsToStaticArray(ce.loc, ce.type, &elems, &sdata);
 
-            elem *ep = el_pair(TYdarray, el_long(TYsize_t, elems.dim), el_ptr(sdata));
+            elem *ep = el_pair(TYdarray, el_long(TYsize_t, elems.length), el_ptr(sdata));
             if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
                 ep = addressElem(ep, Type.tvoid.arrayOf());
             ep = el_param(ep, getTypeInfo(ce, ta, irs));
@@ -2110,7 +2110,7 @@ elem* toElem(Expression e, IRState *irs)
 
         const canSkipCompare = isTrivialExp(ie.e1) && isTrivialExp(ie.e2);
         elem *e;
-        if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.fields.dim == 0 && canSkipCompare)
+        if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.fields.length == 0 && canSkipCompare)
         {
             // we can skip the compare if the structs are empty
             e = el_long(TYbool, ie.op == EXP.identity);
@@ -2682,7 +2682,7 @@ elem* toElem(Expression e, IRState *irs)
             {
                 ArrayLiteralExp ale = cast(ArrayLiteralExp)ae.e2;
                 elem* e;
-                if (ale.elements.dim == 0)
+                if (ale.elements.length == 0)
                 {
                     e = e1;
                 }
@@ -3321,7 +3321,7 @@ elem* toElem(Expression e, IRState *irs)
             if (dctor)
             {
             }
-            else if (ce.arguments && ce.arguments.dim && ec.Eoper != OPvar)
+            else if (ce.arguments && ce.arguments.length && ec.Eoper != OPvar)
             {
                 if (ec.Eoper == OPind && el_sideeffect(ec.EV.E1))
                 {
@@ -3356,7 +3356,7 @@ elem* toElem(Expression e, IRState *irs)
                 // see issue 3822
                 if (fd && fd.ident == Id.__alloca &&
                     !fd.fbody && fd._linkage == LINK.c &&
-                    arguments && arguments.dim == 1)
+                    arguments && arguments.length == 1)
                 {   Expression arg = (*arguments)[0];
                     arg = arg.optimize(WANTvalue);
                     if (arg.isConst() && arg.type.isintegral())
@@ -3383,7 +3383,7 @@ elem* toElem(Expression e, IRState *irs)
         else
         {
             ec = toElem(ce.e1, irs);
-            if (ce.arguments && ce.arguments.dim)
+            if (ce.arguments && ce.arguments.length)
             {
                 /* The idea is to enforce expressions being evaluated left to right,
                  * even though call trees are evaluated parameters first.
@@ -3975,7 +3975,7 @@ elem* toElem(Expression e, IRState *irs)
 
     elem* visitArrayLiteral(ArrayLiteralExp ale)
     {
-        size_t dim = ale.elements ? ale.elements.dim : 0;
+        size_t dim = ale.elements ? ale.elements.length : 0;
 
         //printf("ArrayLiteralExp.toElem() %s, type = %s\n", ale.toChars(), ale.type.toChars());
         Type tb = ale.type.toBasetype();
@@ -4044,7 +4044,7 @@ elem* toElem(Expression e, IRState *irs)
 
         Type t = aale.type.toBasetype().mutableOf();
 
-        size_t dim = aale.keys.dim;
+        size_t dim = aale.keys.length;
         if (dim)
         {
             // call _d_assocarrayliteralTX(TypeInfo_AssociativeArray ti, void[] keys, void[] values)
@@ -4305,7 +4305,7 @@ elem *Dsymbol_toElem(Dsymbol s, IRState* irs)
 elem *ElemsToStaticArray(const ref Loc loc, Type telem, Elems *elems, Symbol **psym)
 {
     // Create a static array of type telem[dim]
-    const dim = elems.dim;
+    const dim = elems.length;
     assert(dim);
 
     Type tsarray = telem.sarrayOf(dim);
@@ -4337,7 +4337,7 @@ elem *ElemsToStaticArray(const ref Loc loc, Type telem, Elems *elems, Symbol **p
 elem *ExpressionsToStaticArray(IRState* irs, const ref Loc loc, Expressions *exps, Symbol **psym, size_t offset = 0, Expression basis = null)
 {
     // Create a static array of type telem[dim]
-    const dim = exps.dim;
+    const dim = exps.length;
     assert(dim);
 
     Type telem = ((*exps)[0] ? (*exps)[0] : basis).type;
@@ -4362,7 +4362,7 @@ elem *ExpressionsToStaticArray(IRState* irs, const ref Loc loc, Expressions *exp
             el.type.toBasetype().ty == Tsarray)
         {
             ArrayLiteralExp ale = cast(ArrayLiteralExp)el;
-            if (ale.elements && ale.elements.dim)
+            if (ale.elements && ale.elements.length)
             {
                 elem *ex = ExpressionsToStaticArray(irs,
                     ale.loc, ale.elements, &stmp, cast(uint)(offset + i * szelem), ale.basis);
@@ -5365,7 +5365,7 @@ elem *callfunc(const ref Loc loc,
         // Discard unreachable argument evaluation + function call
         return ec;
     }
-    if (arguments && arguments.dim)
+    if (arguments && arguments.length)
     {
         if (op == OPvector)
         {
@@ -5376,7 +5376,7 @@ elem *callfunc(const ref Loc loc,
 
         /* Convert arguments[] to elems[] in left-to-right order
          */
-        const n = arguments.dim;
+        const n = arguments.length;
         debug
             elem*[2] elems_array = void;
         else
@@ -6417,8 +6417,8 @@ elem *toElemStructLit(StructLiteralExp sle, IRState *irs, EXP op, Symbol *sym, b
      *  U u3 = U(1, 2);     // error
      *  U u4 = {x:1, y:2};  // error
      */
-    size_t dim = sle.elements ? sle.elements.dim : 0;
-    assert(dim <= sle.sd.fields.dim);
+    size_t dim = sle.elements ? sle.elements.length : 0;
+    assert(dim <= sle.sd.fields.length);
 
     if (fillHoles)
     {
@@ -6429,7 +6429,7 @@ elem *toElemStructLit(StructLiteralExp sle, IRState *irs, EXP op, Symbol *sym, b
         const size_t structsize = sle.sd.structsize;
         size_t offset = 0;
         //printf("-- %s - fillHoles, structsize = %d\n", sle.toChars(), structsize);
-        for (size_t i = 0; i < sle.sd.fields.dim && offset < structsize; )
+        for (size_t i = 0; i < sle.sd.fields.length && offset < structsize; )
         {
             VarDeclaration v = sle.sd.fields[i];
 
@@ -6461,7 +6461,7 @@ elem *toElemStructLit(StructLiteralExp sle, IRState *irs, EXP op, Symbol *sym, b
              *  }
              *  S s = {f2:x, f3:y};     // filled holes: 2..8 and 12..16
              */
-            size_t vend = sle.sd.fields.dim;
+            size_t vend = sle.sd.fields.length;
             size_t holeEnd = structsize;
             size_t offset2 = structsize;
             foreach (j; i + 1 .. vend)
@@ -6568,10 +6568,10 @@ elem *toElemStructLit(StructLiteralExp sle, IRState *irs, EXP op, Symbol *sym, b
         }
     }
 
-    if (sle.sd.isNested() && dim != sle.sd.fields.dim)
+    if (sle.sd.isNested() && dim != sle.sd.fields.length)
     {
         // Initialize the hidden 'this' pointer
-        assert(sle.sd.fields.dim);
+        assert(sle.sd.fields.length);
 
         elem* e1, e2;
         if (tybasic(stmp.Stype.Tty) == TYnptr)

--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -361,7 +361,7 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, Var
         er.byexp.setDim(0);
     }
 
-    if (!er.byref.dim && !er.byvalue.dim && !er.byfunc.dim && !er.byexp.dim)
+    if (!er.byref.length && !er.byvalue.length && !er.byfunc.length && !er.byexp.length)
         return false;
 
     bool result = false;
@@ -537,7 +537,7 @@ bool checkConstructorEscape(Scope* sc, CallExp ce, bool gag)
     if (!tthis.hasPointers())
         return false;
 
-    if (!ce.arguments && ce.arguments.dim)
+    if (!ce.arguments && ce.arguments.length)
         return false;
 
     DotVarExp dve = ce.e1.isDotVarExp();
@@ -545,7 +545,7 @@ bool checkConstructorEscape(Scope* sc, CallExp ce, bool gag)
     TypeFunction tf = ctor.type.isTypeFunction();
 
     const nparams = tf.parameterList.length;
-    const n = ce.arguments.dim;
+    const n = ce.arguments.length;
 
     // j=1 if _arguments[] is first argument
     const j = tf.isDstyleVariadic();
@@ -625,7 +625,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag, bool byRef)
     else
         escapeByValue(e2, &er);
 
-    if (!er.byref.dim && !er.byvalue.dim && !er.byfunc.dim && !er.byexp.dim)
+    if (!er.byref.length && !er.byvalue.length && !er.byfunc.length && !er.byexp.length)
         return false;
 
     VarDeclaration va = expToVariable(e1);
@@ -959,7 +959,7 @@ bool checkThrowEscape(Scope* sc, Expression e, bool gag)
 
     escapeByValue(e, &er);
 
-    if (!er.byref.dim && !er.byvalue.dim && !er.byexp.dim)
+    if (!er.byref.length && !er.byvalue.length && !er.byexp.length)
         return false;
 
     bool result = false;
@@ -1007,7 +1007,7 @@ bool checkNewEscape(Scope* sc, Expression e, bool gag)
 
     escapeByValue(e, &er);
 
-    if (!er.byref.dim && !er.byvalue.dim && !er.byexp.dim)
+    if (!er.byref.length && !er.byvalue.length && !er.byexp.length)
         return false;
 
     bool result = false;
@@ -1187,7 +1187,7 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
     else
         escapeByValue(e, &er);
 
-    if (!er.byref.dim && !er.byvalue.dim && !er.byexp.dim)
+    if (!er.byref.length && !er.byvalue.length && !er.byexp.length)
         return false;
 
     bool result = false;
@@ -1739,13 +1739,13 @@ void escapeByValue(Expression e, EscapeByResults* er, bool live = false, bool re
         if (!e.type.hasPointers())
             return;
 
-        if (e.arguments && e.arguments.dim)
+        if (e.arguments && e.arguments.length)
         {
             /* j=1 if _arguments[] is first argument,
              * skip it because it is not passed by ref
              */
             int j = tf.isDstyleVariadic();
-            for (size_t i = j; i < e.arguments.dim; ++i)
+            for (size_t i = j; i < e.arguments.length; ++i)
             {
                 Expression arg = (*e.arguments)[i];
                 size_t nparams = tf.parameterList.length;
@@ -2048,13 +2048,13 @@ void escapeByRef(Expression e, EscapeByResults* er, bool live = false, bool retR
             return;
         if (tf.isref)
         {
-            if (e.arguments && e.arguments.dim)
+            if (e.arguments && e.arguments.length)
             {
                 /* j=1 if _arguments[] is first argument,
                  * skip it because it is not passed by ref
                  */
                 int j = tf.isDstyleVariadic();
-                for (size_t i = j; i < e.arguments.dim; ++i)
+                for (size_t i = j; i < e.arguments.length; ++i)
                 {
                     Expression arg = (*e.arguments)[i];
                     size_t nparams = tf.parameterList.length;
@@ -2323,7 +2323,7 @@ void finishScopeParamInference(FuncDeclaration funcdecl, ref TypeFunction f)
     {
         // Create and fill array[] with maybe candidates from the `this` and the parameters
         VarDeclaration[10] tmp = void;
-        size_t dim = (funcdecl.vthis !is null) + (funcdecl.parameters ? funcdecl.parameters.dim : 0);
+        size_t dim = (funcdecl.vthis !is null) + (funcdecl.parameters ? funcdecl.parameters.length : 0);
 
         import dmd.common.string : SmallBuffer;
         auto sb = SmallBuffer!VarDeclaration(dim, tmp[]);
@@ -2345,7 +2345,7 @@ void finishScopeParamInference(FuncDeclaration funcdecl, ref TypeFunction f)
     // Infer STC.scope_
     if (funcdecl.parameters && !funcdecl.errors)
     {
-        assert(f.parameterList.length == funcdecl.parameters.dim);
+        assert(f.parameterList.length == funcdecl.parameters.length);
         foreach (u, p; f.parameterList)
         {
             auto v = (*funcdecl.parameters)[u];

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -260,7 +260,7 @@ extern (C++) void expandTuples(Expressions* exps)
     if (exps is null)
         return;
 
-    for (size_t i = 0; i < exps.dim; i++)
+    for (size_t i = 0; i < exps.length; i++)
     {
         Expression arg = (*exps)[i];
         if (!arg)
@@ -271,10 +271,10 @@ extern (C++) void expandTuples(Expressions* exps)
         {
             if (auto tt = e.type.toBasetype().isTypeTuple())
             {
-                if (!tt.arguments || tt.arguments.dim == 0)
+                if (!tt.arguments || tt.arguments.length == 0)
                 {
                     exps.remove(i);
-                    if (i == exps.dim)
+                    if (i == exps.length)
                         return;
                 }
                 else // Expand a TypeTuple
@@ -296,7 +296,7 @@ extern (C++) void expandTuples(Expressions* exps)
             TupleExp te = cast(TupleExp)arg;
             exps.remove(i); // remove arg
             exps.insert(i, te.exps); // replace with tuple contents
-            if (i == exps.dim)
+            if (i == exps.length)
                 return; // empty tuple, no more arguments
             (*exps)[i] = Expression.combine(te.e0, (*exps)[i]);
             arg = (*exps)[i];
@@ -339,10 +339,10 @@ TupleDeclaration isAliasThisTuple(Expression e)
 
 int expandAliasThisTuples(Expressions* exps, size_t starti = 0)
 {
-    if (!exps || exps.dim == 0)
+    if (!exps || exps.length == 0)
         return -1;
 
-    for (size_t u = starti; u < exps.dim; u++)
+    for (size_t u = starti; u < exps.length; u++)
     {
         Expression exp = (*exps)[u];
         if (TupleDeclaration td = exp.isAliasThisTuple)
@@ -924,7 +924,7 @@ extern (C++) abstract class Expression : ASTNode
         Expressions* a = null;
         if (exps)
         {
-            a = new Expressions(exps.dim);
+            a = new Expressions(exps.length);
             foreach (i, e; *exps)
             {
                 (*a)[i] = e ? e.syntaxCopy() : null;
@@ -1214,7 +1214,7 @@ extern (C++) abstract class Expression : ASTNode
         auto ad = cast(AggregateDeclaration) f.toParent2();
         assert(ad);
 
-        if (ad.userDtors.dim)
+        if (ad.userDtors.length)
         {
             if (!check(ad.userDtors[0])) // doesn't match check (e.g. is impure as well)
                 return;
@@ -2885,7 +2885,7 @@ extern (C++) final class TupleExp : Expression
         super(loc, EXP.tuple, __traits(classInstanceSize, TupleExp));
         this.exps = new Expressions();
 
-        this.exps.reserve(tup.objects.dim);
+        this.exps.reserve(tup.objects.length);
         foreach (o; *tup.objects)
         {
             if (Dsymbol s = getDsymbol(o))
@@ -2931,7 +2931,7 @@ extern (C++) final class TupleExp : Expression
         if (auto e = o.isExpression())
             if (auto te = e.isTupleExp())
             {
-                if (exps.dim != te.exps.dim)
+                if (exps.length != te.exps.length)
                     return false;
                 if (e0 && !e0.equals(te.e0) || !e0 && te.e0)
                     return false;
@@ -3020,9 +3020,9 @@ extern (C++) final class ArrayLiteralExp : Expression
             return false;
         if (auto ae = e.isArrayLiteralExp())
         {
-            if (elements.dim != ae.elements.dim)
+            if (elements.length != ae.elements.length)
                 return false;
-            if (elements.dim == 0 && !type.equals(ae.type))
+            if (elements.length == 0 && !type.equals(ae.type))
             {
                 return false;
             }
@@ -3054,14 +3054,14 @@ extern (C++) final class ArrayLiteralExp : Expression
 
     override Optional!bool toBool()
     {
-        size_t dim = elements ? elements.dim : 0;
+        size_t dim = elements ? elements.length : 0;
         return typeof(return)(dim != 0);
     }
 
     override StringExp toStringExp()
     {
         TY telem = type.nextOf().toBasetype().ty;
-        if (telem.isSomeChar || (telem == Tvoid && (!elements || elements.dim == 0)))
+        if (telem.isSomeChar || (telem == Tvoid && (!elements || elements.length == 0)))
         {
             ubyte sz = 1;
             if (telem == Twchar)
@@ -3072,7 +3072,7 @@ extern (C++) final class ArrayLiteralExp : Expression
             OutBuffer buf;
             if (elements)
             {
-                foreach (i; 0 .. elements.dim)
+                foreach (i; 0 .. elements.length)
                 {
                     auto ch = this[i];
                     if (ch.op != EXP.int64)
@@ -3132,7 +3132,7 @@ extern (C++) final class AssocArrayLiteralExp : Expression
     extern (D) this(const ref Loc loc, Expressions* keys, Expressions* values)
     {
         super(loc, EXP.assocArrayLiteral, __traits(classInstanceSize, AssocArrayLiteralExp));
-        assert(keys.dim == values.dim);
+        assert(keys.length == values.length);
         this.keys = keys;
         this.values = values;
     }
@@ -3146,7 +3146,7 @@ extern (C++) final class AssocArrayLiteralExp : Expression
             return false;
         if (auto ae = e.isAssocArrayLiteralExp())
         {
-            if (keys.dim != ae.keys.dim)
+            if (keys.length != ae.keys.length)
                 return false;
             size_t count = 0;
             foreach (i, key; *keys)
@@ -3161,7 +3161,7 @@ extern (C++) final class AssocArrayLiteralExp : Expression
                     }
                 }
             }
-            return count == keys.dim;
+            return count == keys.length;
         }
         return false;
     }
@@ -3173,7 +3173,7 @@ extern (C++) final class AssocArrayLiteralExp : Expression
 
     override Optional!bool toBool()
     {
-        size_t dim = keys.dim;
+        size_t dim = keys.length;
         return typeof(return)(dim != 0);
     }
 
@@ -3250,7 +3250,7 @@ extern (C++) final class StructLiteralExp : Expression
         {
             if (!type.equals(se.type))
                 return false;
-            if (elements.dim != se.elements.dim)
+            if (elements.length != se.elements.length)
                 return false;
             foreach (i, e1; *elements)
             {
@@ -3287,7 +3287,7 @@ extern (C++) final class StructLiteralExp : Expression
             if (i >= sd.nonHiddenFields())
                 return null;
 
-            assert(i < elements.dim);
+            assert(i < elements.length);
             e = (*elements)[i];
             if (e)
             {
@@ -3328,7 +3328,7 @@ extern (C++) final class StructLiteralExp : Expression
     {
         /* Find which field offset is by looking at the field offsets
          */
-        if (elements.dim)
+        if (elements.length)
         {
             const sz = type.size();
             if (sz == SIZE_INVALID)
@@ -3815,7 +3815,7 @@ extern (C++) final class FuncExp : Expression
         if (td)
         {
             assert(td.literal);
-            assert(td.members && td.members.dim == 1);
+            assert(td.members && td.members.length == 1);
             fd = (*td.members)[0].isFuncLiteralDeclaration();
         }
         tok = fd.tok; // save original kind of function/delegate/(infer)
@@ -3946,7 +3946,7 @@ extern (C++) final class FuncExp : Expression
                 return cannotInfer(this, to, flag);
 
             auto tiargs = new Objects();
-            tiargs.reserve(td.parameters.dim);
+            tiargs.reserve(td.parameters.length);
 
             foreach (tp; *td.parameters)
             {
@@ -4229,7 +4229,7 @@ extern (C++) final class IsExp : Expression
         TemplateParameters* p = null;
         if (parameters)
         {
-            p = new TemplateParameters(parameters.dim);
+            p = new TemplateParameters(parameters.length);
             foreach (i, el; *parameters)
                 (*p)[i] = el.syntaxCopy();
         }
@@ -4673,7 +4673,7 @@ extern (C++) final class MixinExp : Expression
             return false;
         if (auto ce = e.isMixinExp())
         {
-            if (exps.dim != ce.exps.dim)
+            if (exps.length != ce.exps.length)
                 return false;
             foreach (i, e1; *exps)
             {
@@ -4864,7 +4864,7 @@ extern (C++) final class DotVarExp : UnaExp
             if (VarDeclaration vd = var.isVarDeclaration())
             {
                 auto ad = vd.isMember2();
-                if (ad && ad.fields.dim == sc.ctorflow.fieldinit.length)
+                if (ad && ad.fields.length == sc.ctorflow.fieldinit.length)
                 {
                     foreach (i, f; ad.fields)
                     {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -220,7 +220,7 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
         if (e.op == EXP.interval && !(slice && slice.isTemplateDeclaration()))
         {
         Lfallback:
-            if (ae.arguments.dim == 1)
+            if (ae.arguments.length == 1)
                 return null;
             ae.error("multi-dimensional slicing requires template `opSlice`");
             return ErrorExp.get();
@@ -534,7 +534,7 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
                 /* Transform:
                  *  aa.remove(arg) into delete aa[arg]
                  */
-                if (!ce.arguments || ce.arguments.dim != 1)
+                if (!ce.arguments || ce.arguments.length != 1)
                 {
                     ce.error("expected key as argument to `aa.remove()`");
                     return ErrorExp.get();
@@ -1189,7 +1189,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
             Expressions a;
             a.push(e2);
 
-            for (size_t i = 0; i < os.a.dim; i++)
+            for (size_t i = 0; i < os.a.length; i++)
             {
                 if (FuncDeclaration f = resolveFuncCall(loc, sc, os.a[i], tiargs, tthis, &a, FuncResolveFlag.quiet))
                 {
@@ -1206,7 +1206,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
             }
         }
         {
-            for (size_t i = 0; i < os.a.dim; i++)
+            for (size_t i = 0; i < os.a.length; i++)
             {
                 if (FuncDeclaration f = resolveFuncCall(loc, sc, os.a[i], tiargs, tthis, null, FuncResolveFlag.quiet))
                 {
@@ -1439,7 +1439,7 @@ private Type arrayExpressionToCommonType(Scope* sc, ref Expressions exps)
     Expression e0 = null;
     bool foundType;
 
-    for (size_t i = 0; i < exps.dim; i++)
+    for (size_t i = 0; i < exps.length; i++)
     {
         Expression e = exps[i];
         if (!e)
@@ -1506,7 +1506,7 @@ private Type arrayExpressionToCommonType(Scope* sc, ref Expressions exps)
     if (t0.ty == Terror)
         return null;
 
-    for (size_t i = 0; i < exps.dim; i++)
+    for (size_t i = 0; i < exps.length; i++)
     {
         Expression e = exps[i];
         if (!e)
@@ -1633,7 +1633,7 @@ private bool preFunctionParameters(Scope* sc, Expressions* exps, const bool repo
     {
         expandTuples(exps);
 
-        for (size_t i = 0; i < exps.dim; i++)
+        for (size_t i = 0; i < exps.length; i++)
         {
             Expression arg = (*exps)[i];
             arg = resolveProperties(sc, arg);
@@ -1721,7 +1721,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
     //printf("functionParameters() %s\n", fd ? fd.toChars() : "");
     assert(arguments);
     assert(fd || tf.next);
-    size_t nargs = arguments ? arguments.dim : 0;
+    size_t nargs = arguments ? arguments.length : 0;
     const size_t nparams = tf.parameterList.length;
     const olderrors = global.errors;
     bool err = false;
@@ -1843,7 +1843,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                         Type tret = p.isLazyArray();
 
                         auto elements = new Expressions(nargs - i);
-                        foreach (u; 0 .. elements.dim)
+                        foreach (u; 0 .. elements.length)
                         {
                             Expression a = (*arguments)[i + u];
                             if (tret && a.implicitConvTo(tret))
@@ -2451,10 +2451,10 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
     // If D linkage and variadic, add _arguments[] as first argument
     if (tf.isDstyleVariadic())
     {
-        assert(arguments.dim >= nparams);
+        assert(arguments.length >= nparams);
 
-        auto args = new Parameters(arguments.dim - nparams);
-        for (size_t i = 0; i < arguments.dim - nparams; i++)
+        auto args = new Parameters(arguments.length - nparams);
+        for (size_t i = 0; i < arguments.length - nparams; i++)
         {
             auto arg = new Parameter(STC.in_, (*arguments)[nparams + i].type, null, null, null);
             (*args)[i] = arg;
@@ -3109,7 +3109,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         // Run semantic() on each argument
         bool err = false;
-        for (size_t i = 0; i < exp.exps.dim; i++)
+        for (size_t i = 0; i < exp.exps.length; i++)
         {
             Expression e = (*exp.exps)[i];
             e = e.expressionSemantic(sc);
@@ -3169,7 +3169,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         /* Disallow array literals of type void being used.
          */
-        if (e.elements.dim > 0 && t0.ty == Tvoid)
+        if (e.elements.length > 0 && t0.ty == Tvoid)
         {
             e.error("`%s` of type `%s` has no value", e.toChars(), e.type.toChars());
             return setError();
@@ -3201,10 +3201,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         expandTuples(e.keys);
         expandTuples(e.values);
-        if (e.keys.dim != e.values.dim)
+        if (e.keys.length != e.values.length)
         {
             e.error("number of keys is %llu, must match number of values %llu",
-                        cast(ulong) e.keys.dim, cast(ulong) e.values.dim);
+                        cast(ulong) e.keys.length, cast(ulong) e.values.length);
             return setError();
         }
 
@@ -3263,7 +3263,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
         }
 
-        if (checkFrameAccess(e.loc, sc, e.sd, e.elements.dim))
+        if (checkFrameAccess(e.loc, sc, e.sd, e.elements.length))
             return setError();
 
         e.type = e.stype ? e.stype : e.sd.type;
@@ -3579,7 +3579,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
         }
 
-        const size_t nargs = exp.arguments ? exp.arguments.dim : 0;
+        const size_t nargs = exp.arguments ? exp.arguments.length : 0;
         Expression newprefix = null;
 
         if (auto tc = tb.isTypeClass())
@@ -3605,7 +3605,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (cd.isAbstract())
             {
                 exp.error("cannot create instance of abstract class `%s`", cd.toChars());
-                for (size_t i = 0; i < cd.vtbl.dim; i++)
+                for (size_t i = 0; i < cd.vtbl.length; i++)
                 {
                     FuncDeclaration fd = cd.vtbl[i].isFuncDeclaration();
                     if (fd && fd.isAbstract())
@@ -3836,7 +3836,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.member = f.isCtorDeclaration();
                 assert(exp.member);
 
-                if (checkFrameAccess(exp.loc, sc, sd, sd.fields.dim))
+                if (checkFrameAccess(exp.loc, sc, sd, sd.fields.length))
                     return setError();
             }
             else
@@ -3850,7 +3850,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (!sd.fill(exp.loc, *exp.arguments, false))
                     return setError();
 
-                if (checkFrameAccess(exp.loc, sc, sd, exp.arguments ? exp.arguments.dim : 0))
+                if (checkFrameAccess(exp.loc, sc, sd, exp.arguments ? exp.arguments.length : 0))
                     return setError();
 
                 /* Since a `new` allocation may escape, check each of the arguments for escaping
@@ -4113,7 +4113,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         //printf("td = %p, treq = %p\n", td, fd.treq);
         if (exp.td)
         {
-            assert(exp.td.parameters && exp.td.parameters.dim);
+            assert(exp.td.parameters && exp.td.parameters.length);
             exp.td.dsymbolSemantic(sc);
             exp.type = Type.tvoid; // temporary type
 
@@ -4199,9 +4199,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
      */
     Expression callExpSemantic(FuncExp exp, Scope* sc, Expressions* arguments)
     {
-        if ((!exp.type || exp.type == Type.tvoid) && exp.td && arguments && arguments.dim)
+        if ((!exp.type || exp.type == Type.tvoid) && exp.td && arguments && arguments.length)
         {
-            for (size_t k = 0; k < arguments.dim; k++)
+            for (size_t k = 0; k < arguments.length; k++)
             {
                 Expression checkarg = (*arguments)[k];
                 if (checkarg.op == EXP.error)
@@ -4210,21 +4210,21 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             exp.genIdent(sc);
 
-            assert(exp.td.parameters && exp.td.parameters.dim);
+            assert(exp.td.parameters && exp.td.parameters.length);
             exp.td.dsymbolSemantic(sc);
 
             TypeFunction tfl = cast(TypeFunction)exp.fd.type;
             size_t dim = tfl.parameterList.length;
-            if (arguments.dim < dim)
+            if (arguments.length < dim)
             {
                 // Default arguments are always typed, so they don't need inference.
-                Parameter p = tfl.parameterList[arguments.dim];
+                Parameter p = tfl.parameterList[arguments.length];
                 if (p.defaultArg)
-                    dim = arguments.dim;
+                    dim = arguments.length;
             }
 
-            if ((tfl.parameterList.varargs == VarArg.none && arguments.dim > dim) ||
-                arguments.dim < dim)
+            if ((tfl.parameterList.varargs == VarArg.none && arguments.length > dim) ||
+                arguments.length < dim)
             {
                 OutBuffer buf;
                 foreach (idx, ref arg; *arguments)
@@ -4233,15 +4233,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                           exp.fd.toChars(), parametersTypeToChars(tfl.parameterList),
                           buf.peekChars());
                 exp.errorSupplemental("too %s arguments, expected `%d`, got `%d`",
-                                      arguments.dim < dim ? "few".ptr : "many".ptr,
-                                      cast(int)dim, cast(int)arguments.dim);
+                                      arguments.length < dim ? "few".ptr : "many".ptr,
+                                      cast(int)dim, cast(int)arguments.length);
                 return ErrorExp.get();
             }
 
             auto tiargs = new Objects();
-            tiargs.reserve(exp.td.parameters.dim);
+            tiargs.reserve(exp.td.parameters.length);
 
-            for (size_t i = 0; i < exp.td.parameters.dim; i++)
+            for (size_t i = 0; i < exp.td.parameters.length; i++)
             {
                 TemplateParameter tp = (*exp.td.parameters)[i];
                 assert(dim <= tfl.parameterList.length);
@@ -4571,7 +4571,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // First look for constructor
                 if (exp.e1.op == EXP.type && sd.ctor)
                 {
-                    if (!sd.noDefaultCtor && !(exp.arguments && exp.arguments.dim))
+                    if (!sd.noDefaultCtor && !(exp.arguments && exp.arguments.length))
                         goto Lx;
 
                     /* https://issues.dlang.org/show_bug.cgi?id=20695
@@ -4587,7 +4587,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     auto sle = new StructLiteralExp(exp.loc, sd, null, exp.e1.type);
                     if (!sd.fill(exp.loc, *sle.elements, true))
                         return setError();
-                    if (checkFrameAccess(exp.loc, sc, sd, sle.elements.dim))
+                    if (checkFrameAccess(exp.loc, sc, sd, sle.elements.length))
                         return setError();
 
                     // https://issues.dlang.org/show_bug.cgi?id=14556
@@ -4664,11 +4664,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     t1 = exp.e1.type;
                 }
 
-                if (!exp.arguments || exp.arguments.dim == 0)
+                if (!exp.arguments || exp.arguments.length == 0)
                 {
                     e = t1.defaultInitLiteral(exp.loc);
                 }
-                else if (exp.arguments.dim == 1)
+                else if (exp.arguments.length == 1)
                 {
                     e = (*exp.arguments)[0];
                     if (!e.type.isTypeNoreturn())
@@ -4765,7 +4765,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 auto ad2 = b.sym;
                 ue.e1 = ue.e1.castTo(sc, ad2.type.addMod(ue.e1.type.mod));
                 ue.e1 = ue.e1.expressionSemantic(sc);
-                auto vi = exp.f.findVtblIndex(&ad2.vtbl, cast(int)ad2.vtbl.dim);
+                auto vi = exp.f.findVtblIndex(&ad2.vtbl, cast(int)ad2.vtbl.length);
                 assert(vi >= 0);
                 exp.f = ad2.vtbl[vi].isFuncDeclaration();
                 assert(exp.f);
@@ -5297,7 +5297,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             AttribDeclaration ad = s.isAttribDeclaration();
             if (ad)
             {
-                if (ad.decl && ad.decl.dim == 1)
+                if (ad.decl && ad.decl.length == 1)
                 {
                     s = (*ad.decl)[0];
                     continue;
@@ -5697,10 +5697,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     ClassDeclaration cd = (cast(TypeClass)e.targ).sym;
                     auto args = new Parameters();
-                    args.reserve(cd.baseclasses.dim);
+                    args.reserve(cd.baseclasses.length);
                     if (cd.semanticRun < PASS.semanticdone)
                         cd.dsymbolSemantic(null);
-                    for (size_t i = 0; i < cd.baseclasses.dim; i++)
+                    for (size_t i = 0; i < cd.baseclasses.length; i++)
                     {
                         BaseClass* b = (*cd.baseclasses)[i];
                         args.push(new Parameter(STC.in_, b.type, null, null, null));
@@ -5789,7 +5789,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return yes();
             return no();
         }
-        else if (e.tspec && !e.id && !(e.parameters && e.parameters.dim))
+        else if (e.tspec && !e.id && !(e.parameters && e.parameters.length))
         {
             /* Evaluate to true if targ matches tspec
              * is(targ == tspec)
@@ -5847,7 +5847,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Identifier tid = e.id ? e.id : Identifier.generateId("__isexp_id");
             e.parameters.insert(0, new TemplateTypeParameter(e.loc, tid, null, null));
 
-            Objects dedtypes = Objects(e.parameters.dim);
+            Objects dedtypes = Objects(e.parameters.length);
             dedtypes.zero();
 
             MATCH m = deduceType(e.targ, sc, e.tspec, e.parameters, &dedtypes, null, 0, e.tok == TOK.equal);
@@ -5867,7 +5867,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 /* Declare trailing parameters
                  */
-                for (size_t i = 1; i < e.parameters.dim; i++)
+                for (size_t i = 1; i < e.parameters.length; i++)
                 {
                     TemplateParameter tp = (*e.parameters)[i];
                     Declaration s = null;
@@ -6632,8 +6632,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Expression ev = sc.func ? extractSideEffect(sc, "__tup", e0, exp.e1) : exp.e1;
 
             auto exps = new Expressions();
-            exps.reserve(tup.objects.dim);
-            for (size_t i = 0; i < tup.objects.dim; i++)
+            exps.reserve(tup.objects.length);
+            for (size_t i = 0; i < tup.objects.length; i++)
             {
                 RootObject o = (*tup.objects)[i];
                 Expression e;
@@ -7574,7 +7574,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
             TupleExp te = exp.e1.isTupleExp();
-            if (te.exps.dim == 1)
+            if (te.exps.length == 1)
                 exp.e1 = (*te.exps)[0];
         }
 
@@ -8006,7 +8006,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 te = cast(TupleExp)exp.e1;
                 tup = null;
-                length = te.exps.dim;
+                length = te.exps.length;
             }
             else if (exp.e1.op == EXP.type) // slicing a type tuple
             {
@@ -8409,7 +8409,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.e2.op == EXP.tuple)
         {
             TupleExp te = cast(TupleExp)exp.e2;
-            if (te.exps && te.exps.dim == 1)
+            if (te.exps && te.exps.length == 1)
                 exp.e2 = Expression.combine(te.e0, (*te.exps)[0]); // bug 4444 fix
         }
         if (sc != scx)
@@ -8493,7 +8493,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     te = cast(TupleExp)exp.e1;
                     tup = null;
-                    length = te.exps.dim;
+                    length = te.exps.length;
                 }
                 else if (exp.e1.op == EXP.type)
                 {
@@ -8716,7 +8716,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             auto sle = new StructLiteralExp(loc, sd, null, t);
             if (!sd.fill(loc, *sle.elements, true))
                 return ErrorExp.get();
-            if (checkFrameAccess(loc, sc, sd, sle.elements.dim))
+            if (checkFrameAccess(loc, sc, sd, sle.elements.length))
                 return ErrorExp.get();
 
             sle.type = t;
@@ -8775,11 +8775,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Expression ae1old = ae.e1;
 
             const(bool) maybeSlice =
-                (ae.arguments.dim == 0 ||
-                 ae.arguments.dim == 1 && (*ae.arguments)[0].op == EXP.interval);
+                (ae.arguments.length == 0 ||
+                 ae.arguments.length == 1 && (*ae.arguments)[0].op == EXP.interval);
 
             IntervalExp ie = null;
-            if (maybeSlice && ae.arguments.dim)
+            if (maybeSlice && ae.arguments.length)
             {
                 assert((*ae.arguments)[0].op == EXP.interval);
                 ie = cast(IntervalExp)(*ae.arguments)[0];
@@ -8989,11 +8989,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 TupleExp tup1 = cast(TupleExp)exp.e1;
                 TupleExp tup2 = cast(TupleExp)e2x;
-                size_t dim = tup1.exps.dim;
+                size_t dim = tup1.exps.length;
                 Expression e = null;
-                if (dim != tup2.exps.dim)
+                if (dim != tup2.exps.length)
                 {
-                    exp.error("mismatched tuple lengths, %d and %d", cast(int)dim, cast(int)tup2.exps.dim);
+                    exp.error("mismatched tuple lengths, %d and %d", cast(int)dim, cast(int)tup2.exps.length);
                     return setError();
                 }
                 if (dim == 0)
@@ -9032,13 +9032,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 auto iexps = new Expressions();
                 iexps.push(ev);
-                for (size_t u = 0; u < iexps.dim; u++)
+                for (size_t u = 0; u < iexps.length; u++)
                 {
                 Lexpand:
                     Expression e = (*iexps)[u];
 
                     Parameter arg = Parameter.getNth(tt.arguments, u);
-                    //printf("[%d] iexps.dim = %d, ", u, iexps.dim);
+                    //printf("[%d] iexps.length = %d, ", u, iexps.length);
                     //printf("e = (%s %s, %s), ", Token.toChars[e.op], e.toChars(), e.type.toChars());
                     //printf("arg = (%s, %s)\n", arg.toChars(), arg.type.toChars());
 
@@ -9047,7 +9047,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         // expand initializer to tuple
                         if (expandAliasThisTuples(iexps, u) != -1)
                         {
-                            if (iexps.dim <= u)
+                            if (iexps.length <= u)
                                 break;
                             goto Lexpand;
                         }
@@ -9533,7 +9533,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     uinteger_t dim2 = dim1;
                     if (auto ale = e2x.isArrayLiteralExp())
                     {
-                        dim2 = ale.elements ? ale.elements.dim : 0;
+                        dim2 = ale.elements ? ale.elements.length : 0;
                     }
                     else if (auto se = e2x.isSliceExp())
                     {
@@ -9758,7 +9758,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             TypeSArray tsa1 = cast(TypeSArray)toStaticArrayType(se1);
             TypeSArray tsa2 = null;
             if (auto ale = e2x.isArrayLiteralExp())
-                tsa2 = cast(TypeSArray)t2.nextOf().sarrayOf(ale.elements.dim);
+                tsa2 = cast(TypeSArray)t2.nextOf().sarrayOf(ale.elements.length);
             else if (auto se = e2x.isSliceExp())
                 tsa2 = cast(TypeSArray)toStaticArrayType(se);
             else
@@ -11923,7 +11923,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 static struct Result { bool ttEmpty; bool te; }
                 auto tt = e.op == EXP.type ? e.isTypeExp().type.isTypeTuple() : null;
-                return Result(tt && (!tt.arguments || !tt.arguments.dim), e.isTupleExp() !is null);
+                return Result(tt && (!tt.arguments || !tt.arguments.length), e.isTupleExp() !is null);
             }
             auto tups1 = extractTypeTupAndExpTup(exp.e1);
             auto tups2 = extractTypeTupAndExpTup(exp.e2);
@@ -12605,7 +12605,7 @@ Expression semanticX(DotIdExp exp, Scope* sc)
         {
             /* 'distribute' the .offsetof to each of the tuple elements.
              */
-            auto exps = new Expressions(te.exps.dim);
+            auto exps = new Expressions(te.exps.length);
             foreach (i, e; (*te.exps)[])
             {
                 (*exps)[i] = new DotIdExp(e.loc, e, Id.offsetof);
@@ -12618,7 +12618,7 @@ Expression semanticX(DotIdExp exp, Scope* sc)
         if (exp.ident == Id.length)
         {
             // Don't evaluate te.e0 in runtime
-            return new IntegerExp(exp.loc, te.exps.dim, Type.tsize_t);
+            return new IntegerExp(exp.loc, te.exps.length, Type.tsize_t);
         }
     }
 
@@ -13570,7 +13570,7 @@ private bool fit(StructDeclaration sd, const ref Loc loc, Scope* sc, Expressions
 
     const nfields = sd.nonHiddenFields();
     size_t offset = 0;
-    for (size_t i = 0; i < elements.dim; i++)
+    for (size_t i = 0; i < elements.length; i++)
     {
         Expression e = (*elements)[i];
         if (!e)
@@ -13579,7 +13579,7 @@ private bool fit(StructDeclaration sd, const ref Loc loc, Scope* sc, Expressions
         e = resolveProperties(sc, e);
         if (i >= nfields)
         {
-            if (i < sd.fields.dim && e.op == EXP.null_)
+            if (i < sd.fields.length && e.op == EXP.null_)
             {
                 // CTFE sometimes creates null as hidden pointer; we'll allow this.
                 continue;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -640,7 +640,7 @@ extern (C++) class FuncDeclaration : Declaration
     }
 
     /*************************************************
-     * Find index of function in vtbl[0..dim] that
+     * Find index of function in vtbl[0..length] that
      * this function overrides.
      * Prefer an exact match to a covariant one.
      * Params:
@@ -777,7 +777,7 @@ extern (C++) class FuncDeclaration : Declaration
         {
             foreach (b; cd.interfaces)
             {
-                auto v = findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
+                auto v = findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.length);
                 if (v >= 0)
                     return b;
             }
@@ -1810,7 +1810,7 @@ extern (C++) class FuncDeclaration : Declaration
         if (!isVirtual())
             return false;
         // If it's a final method, and does not override anything, then it is not virtual
-        if (isFinalFunc() && foverrides.dim == 0)
+        if (isFinalFunc() && foverrides.length == 0)
         {
             return false;
         }
@@ -1967,7 +1967,7 @@ extern (C++) class FuncDeclaration : Declaration
                 if (fdthis != this)
                 {
                     bool found = false;
-                    for (size_t i = 0; i < siblingCallers.dim; ++i)
+                    for (size_t i = 0; i < siblingCallers.length; ++i)
                     {
                         if (siblingCallers[i] == fdthis)
                             found = true;
@@ -2033,12 +2033,12 @@ extern (C++) class FuncDeclaration : Declaration
         if (requiresClosure)
             goto Lyes;
 
-        for (size_t i = 0; i < closureVars.dim; i++)
+        for (size_t i = 0; i < closureVars.length; i++)
         {
             VarDeclaration v = closureVars[i];
             //printf("\tv = %s\n", v.toChars());
 
-            for (size_t j = 0; j < v.nestedrefs.dim; j++)
+            for (size_t j = 0; j < v.nestedrefs.length; j++)
             {
                 FuncDeclaration f = v.nestedrefs[j];
                 assert(f != this);
@@ -2167,7 +2167,7 @@ extern (C++) class FuncDeclaration : Declaration
      */
     final bool hasNestedFrameRefs()
     {
-        if (closureVars.dim)
+        if (closureVars.length)
             return true;
 
         /* If a virtual function has contracts, assume its variables are referenced
@@ -2181,9 +2181,9 @@ extern (C++) class FuncDeclaration : Declaration
         if (fdrequire || fdensure)
             return true;
 
-        if (foverrides.dim && isVirtualMethod())
+        if (foverrides.length && isVirtualMethod())
         {
-            for (size_t i = 0; i < foverrides.dim; i++)
+            for (size_t i = 0; i < foverrides.length; i++)
             {
                 FuncDeclaration fdv = foverrides[i];
                 if (fdv.hasNestedFrameRefs())
@@ -2406,7 +2406,7 @@ extern (C++) class FuncDeclaration : Declaration
              * becomes:
              *   in { { statements1... } { statements2... } ... }
              */
-            assert(frequires.dim);
+            assert(frequires.length);
             auto loc = (*frequires)[0].loc;
             auto s = new Statements;
             foreach (r; *frequires)
@@ -2425,7 +2425,7 @@ extern (C++) class FuncDeclaration : Declaration
              *   out(__result) { { ref id1 = __result; { statements1... } }
              *                   { ref id2 = __result; { statements2... } } ... }
              */
-            assert(fensures.dim);
+            assert(fensures.length);
             auto loc = (*fensures)[0].ensure.loc;
             auto s = new Statements;
             foreach (r; *fensures)
@@ -3133,7 +3133,7 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
             printf("\tthis: %s\n", tthis.toChars());
         if (fargs)
         {
-            for (size_t i = 0; i < fargs.dim; i++)
+            for (size_t i = 0; i < fargs.length; i++)
             {
                 Expression arg = (*fargs)[i];
                 assert(arg.type);
@@ -3570,7 +3570,7 @@ private void markAsNeedingClosure(Dsymbol f, FuncDeclaration outerFunc)
     for (Dsymbol sx = f; sx && sx != outerFunc; sx = sx.toParentP(outerFunc))
     {
         FuncDeclaration fy = sx.isFuncDeclaration();
-        if (fy && fy.closureVars.dim)
+        if (fy && fy.closureVars.length)
         {
             /* fy needs a closure if it has closureVars[],
              * because the frame pointer in the closure will be accessed.
@@ -3608,7 +3608,7 @@ private bool checkEscapingSiblings(FuncDeclaration f, FuncDeclaration outerFunc,
 
     //printf("checkEscapingSiblings(f = %s, outerfunc = %s)\n", f.toChars(), outerFunc.toChars());
     bool bAnyClosures = false;
-    for (size_t i = 0; i < f.siblingCallers.dim; ++i)
+    for (size_t i = 0; i < f.siblingCallers.length; ++i)
     {
         FuncDeclaration g = f.siblingCallers[i];
         if (g.isThis() || g.tookAddressOf)

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -261,7 +261,7 @@ private void obj_write_deferred(ref OutBuffer objbuf, Library library, ref Dsymb
         //printf("writing '%s'\n", fname);
         obj_end(objbuf, library, fname);
     }
-    glue.obj_symbols_towrite.dim = 0;
+    glue.obj_symbols_towrite.length = 0;
 }
 
 
@@ -516,7 +516,7 @@ private void genObjFile(Module m, bool multiobj)
         m.covb = cast(uint *)Mem.check(calloc((m.numlines + 32) / 32, (*m.covb).sizeof));
     }
 
-    for (int i = 0; i < m.members.dim; i++)
+    for (int i = 0; i < m.members.length; i++)
     {
         auto member = (*m.members)[i];
         //printf("toObjFile %s %s\n", member.kind(), member.toChars());
@@ -583,8 +583,8 @@ private void genObjFile(Module m, bool multiobj)
     }
 
     // If coverage / static constructor / destructor / unittest calls
-    if (glue.eictor || glue.sctors.dim || glue.ectorgates.dim || glue.sdtors.dim ||
-        glue.ssharedctors.dim || glue.esharedctorgates.dim || glue.sshareddtors.dim || glue.stests.dim)
+    if (glue.eictor || glue.sctors.length || glue.ectorgates.length || glue.sdtors.length ||
+        glue.ssharedctors.length || glue.esharedctorgates.length || glue.sshareddtors.length || glue.stests.length)
     {
         if (glue.eictor)
         {
@@ -870,7 +870,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         }
         shidden = symbol_name(name, SC.parameter, thidden);
         shidden.Sflags |= SFLtrue | SFLfree;
-        if (fd.isNRVO() && fd.nrvo_var && fd.nrvo_var.nestedrefs.dim)
+        if (fd.isNRVO() && fd.nrvo_var && fd.nrvo_var.nestedrefs.length)
             type_setcv(&shidden.Stype, shidden.Stype.Tty | mTYvolatile);
         irs.shidden = shidden;
         fd.shidden = shidden;
@@ -896,7 +896,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     // Estimate number of parameters, pi
     size_t pi = (fd.v_arguments !is null);
     if (fd.parameters)
-        pi += fd.parameters.dim;
+        pi += fd.parameters.length;
     if (fd.objc.selector)
         pi++; // Extra argument for Objective-C selector
     // Create a temporary buffer, params[], to hold function parameters
@@ -922,7 +922,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             assert(!v.csym);
             params[pi + i] = toSymbol(v);
         }
-        pi += fd.parameters.dim;
+        pi += fd.parameters.length;
     }
 
     if (reverse)

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -484,7 +484,7 @@ public:
     {
         buf.writestring("pragma (");
         buf.writestring(s.ident.toString());
-        if (s.args && s.args.dim)
+        if (s.args && s.args.length)
         {
             buf.writestring(", ");
             argsToBuffer(s.args, buf, hgs);
@@ -883,7 +883,7 @@ public:
             buf.printf("%s.", pid.toChars());
         }
         buf.writestring(imp.id.toString());
-        if (imp.names.dim)
+        if (imp.names.length)
         {
             buf.writestring(" : ");
             foreach (const i, const name; imp.names)
@@ -922,13 +922,13 @@ public:
             buf.writenl();
             return;
         }
-        if (d.decl.dim == 0 || (hgs.hdrgen && d.decl.dim == 1 && (*d.decl)[0].isUnitTestDeclaration()))
+        if (d.decl.length == 0 || (hgs.hdrgen && d.decl.length == 1 && (*d.decl)[0].isUnitTestDeclaration()))
         {
             // hack for bugzilla 8081
             if (hasSTC) buf.writeByte(' ');
             buf.writestring("{}");
         }
-        else if (d.decl.dim == 1)
+        else if (d.decl.length == 1)
         {
             if (hasSTC) buf.writeByte(' ');
             (*d.decl)[0].accept(this);
@@ -993,9 +993,9 @@ public:
     {
         visibilityToBuffer(buf, d.visibility);
         AttribDeclaration ad = cast(AttribDeclaration)d;
-        if (ad.decl.dim <= 1)
+        if (ad.decl.length <= 1)
             buf.writeByte(' ');
-        if (ad.decl.dim == 1 && (*ad.decl)[0].isVisibilityDeclaration)
+        if (ad.decl.length == 1 && (*ad.decl)[0].isVisibilityDeclaration)
             visit(cast(AttribDeclaration)(*ad.decl)[0]);
         else
             visit(cast(AttribDeclaration)d);
@@ -1011,7 +1011,7 @@ public:
                     buf.writeByte(' ');
                 buf.printf("align (%s)", exp.toChars());
             }
-            if (d.decl && d.decl.dim < 2)
+            if (d.decl && d.decl.length < 2)
                 buf.writeByte(' ');
         }
         else
@@ -1041,7 +1041,7 @@ public:
     {
         buf.writestring("pragma (");
         buf.writestring(d.ident.toString());
-        if (d.args && d.args.dim)
+        if (d.args && d.args.length)
         {
             buf.writestring(", ");
             argsToBuffer(d.args, buf, hgs);
@@ -1210,7 +1210,7 @@ public:
 
     bool visitEponymousMember(TemplateDeclaration d)
     {
-        if (!d.members || d.members.dim != 1)
+        if (!d.members || d.members.length != 1)
             return false;
         Dsymbol onemember = (*d.members)[0];
         if (onemember.ident != d.ident)
@@ -1286,7 +1286,7 @@ public:
 
     void visitTemplateParameters(TemplateParameters* parameters)
     {
-        if (!parameters || !parameters.dim)
+        if (!parameters || !parameters.length)
             return;
         foreach (i, p; *parameters)
         {
@@ -1437,7 +1437,7 @@ public:
 
     void visitBaseClasses(ClassDeclaration d)
     {
-        if (!d || !d.baseclasses.dim)
+        if (!d || !d.baseclasses.length)
             return;
         if (!d.isAnonymous())
             buf.writestring(" : ");
@@ -1722,7 +1722,7 @@ public:
         Statement s1;
         if (f.semanticRun >= PASS.semantic3done && cs)
         {
-            s1 = (*cs.statements)[cs.statements.dim - 1];
+            s1 = (*cs.statements)[cs.statements.length - 1];
         }
         else
             s1 = !cs ? f.fbody : null;
@@ -2130,7 +2130,7 @@ private void expressionPrettyPrint(Expression e, OutBuffer* buf, HdrGenState* hg
         }
         buf.writestring("new ");
         typeToBuffer(e.newtype, null, buf, hgs);
-        if (e.arguments && e.arguments.dim)
+        if (e.arguments && e.arguments.length)
         {
             buf.writeByte('(');
             argsToBuffer(e.arguments, buf, hgs);
@@ -2147,7 +2147,7 @@ private void expressionPrettyPrint(Expression e, OutBuffer* buf, HdrGenState* hg
         }
         buf.writestring("new");
         buf.writestring(" class ");
-        if (e.arguments && e.arguments.dim)
+        if (e.arguments && e.arguments.length)
         {
             buf.writeByte('(');
             argsToBuffer(e.arguments, buf, hgs);
@@ -2271,7 +2271,7 @@ private void expressionPrettyPrint(Expression e, OutBuffer* buf, HdrGenState* hg
                 buf.writestring(" == ");
             typeToBuffer(e.tspec, null, buf, hgs);
         }
-        if (e.parameters && e.parameters.dim)
+        if (e.parameters && e.parameters.length)
         {
             buf.writestring(", ");
             scope v = new DsymbolPrettyPrintVisitor(buf, hgs);
@@ -3100,7 +3100,7 @@ void toCBuffer(const Expression e, OutBuffer* buf, HdrGenState* hgs)
  */
 void argExpTypesToCBuffer(OutBuffer* buf, Expressions* arguments)
 {
-    if (!arguments || !arguments.dim)
+    if (!arguments || !arguments.length)
         return;
     HdrGenState hgs;
     foreach (i, arg; *arguments)
@@ -3119,7 +3119,7 @@ void toCBuffer(const TemplateParameter tp, OutBuffer* buf, HdrGenState* hgs)
 
 void arrayObjectsToBuffer(OutBuffer* buf, Objects* objects)
 {
-    if (!objects || !objects.dim)
+    if (!objects || !objects.length)
         return;
     HdrGenState hgs;
     foreach (i, o; *objects)
@@ -3160,7 +3160,7 @@ const(char)* parameterToChars(Parameter parameter, TypeFunction tf, bool fullQua
 
     parameterToBuffer(parameter, &buf, &hgs);
 
-    if (tf.parameterList.varargs == VarArg.typesafe && parameter == tf.parameterList[tf.parameterList.parameters.dim - 1])
+    if (tf.parameterList.varargs == VarArg.typesafe && parameter == tf.parameterList[tf.parameterList.parameters.length - 1])
     {
         buf.writestring("...");
     }
@@ -3219,7 +3219,7 @@ private void parameterToBuffer(Parameter p, OutBuffer* buf, HdrGenState* hgs)
     {
         buf.writeByte('@');
 
-        bool isAnonymous = p.userAttribDecl.atts.dim > 0 && !(*p.userAttribDecl.atts)[0].isCallExp();
+        bool isAnonymous = p.userAttribDecl.atts.length > 0 && !(*p.userAttribDecl.atts)[0].isCallExp();
         if (isAnonymous)
             buf.writeByte('(');
 
@@ -3281,7 +3281,7 @@ private void parameterToBuffer(Parameter p, OutBuffer* buf, HdrGenState* hgs)
  */
 private void argsToBuffer(Expressions* expressions, OutBuffer* buf, HdrGenState* hgs, Expression basis = null)
 {
-    if (!expressions || !expressions.dim)
+    if (!expressions || !expressions.length)
         return;
     version (all)
     {
@@ -3298,11 +3298,11 @@ private void argsToBuffer(Expressions* expressions, OutBuffer* buf, HdrGenState*
     else
     {
         // Sparse style formatting, for debug use only
-        //      [0..dim: basis, 1: e1, 5: e5]
+        //      [0..length: basis, 1: e1, 5: e5]
         if (basis)
         {
             buf.writestring("0..");
-            buf.print(expressions.dim);
+            buf.print(expressions.length);
             buf.writestring(": ");
             expToBuffer(basis, PREC.assign, buf, hgs);
         }
@@ -3483,12 +3483,12 @@ private void tiargsToBuffer(TemplateInstance ti, OutBuffer* buf, HdrGenState* hg
         buf.writestring("()");
         return;
     }
-    if (ti.tiargs.dim == 1)
+    if (ti.tiargs.length == 1)
     {
         RootObject oarg = (*ti.tiargs)[0];
         if (Type t = isType(oarg))
         {
-            if (t.equals(Type.tstring) || t.equals(Type.twstring) || t.equals(Type.tdstring) || t.mod == 0 && (t.isTypeBasic() || t.ty == Tident && (cast(TypeIdentifier)t).idents.dim == 0))
+            if (t.equals(Type.tstring) || t.equals(Type.twstring) || t.equals(Type.tdstring) || t.mod == 0 && (t.isTypeBasic() || t.ty == Tident && (cast(TypeIdentifier)t).idents.length == 0))
             {
                 buf.writestring(t.toChars());
                 return;

--- a/compiler/src/dmd/iasmdmd.d
+++ b/compiler/src/dmd/iasmdmd.d
@@ -2204,10 +2204,10 @@ private void asm_merge_opnds(ref OPND o1, ref OPND o2)
     {
         TupleDeclaration tup = o1.s.isTupleDeclaration();
         size_t index = cast(int)o2.disp;
-        if (index >= tup.objects.dim)
+        if (index >= tup.objects.length)
         {
             asmerr("tuple index `%llu` out of bounds `[0 .. %llu]`",
-                    cast(ulong) index, cast(ulong) tup.objects.dim);
+                    cast(ulong) index, cast(ulong) tup.objects.length);
         }
         else
         {

--- a/compiler/src/dmd/iasmgcc.d
+++ b/compiler/src/dmd/iasmgcc.d
@@ -332,7 +332,7 @@ extern (C++) public Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
     // Analyse all input and output operands.
     if (s.args)
     {
-        foreach (i; 0 .. s.args.dim)
+        foreach (i; 0 .. s.args.length)
         {
             Expression e = (*s.args)[i];
             e = e.expressionSemantic(sc);
@@ -353,7 +353,7 @@ extern (C++) public Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
     // Analyse all clobbers.
     if (s.clobbers)
     {
-        foreach (i; 0 .. s.clobbers.dim)
+        foreach (i; 0 .. s.clobbers.length)
         {
             Expression e = (*s.clobbers)[i];
             e = e.expressionSemantic(sc);
@@ -365,7 +365,7 @@ extern (C++) public Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
     // Analyse all goto labels.
     if (s.labels)
     {
-        foreach (i; 0 .. s.labels.dim)
+        foreach (i; 0 .. s.labels.length)
         {
             Identifier ident = (*s.labels)[i];
             GotoStatement gs = new GotoStatement(s.loc, ident);

--- a/compiler/src/dmd/init.d
+++ b/compiler/src/dmd/init.d
@@ -271,10 +271,10 @@ Initializer syntaxCopy(Initializer inx)
     static Initializer copyStruct(StructInitializer vi)
     {
         auto si = new StructInitializer(vi.loc);
-        assert(vi.field.dim == vi.value.dim);
-        si.field.setDim(vi.field.dim);
-        si.value.setDim(vi.value.dim);
-        foreach (const i; 0 .. vi.field.dim)
+        assert(vi.field.length == vi.value.length);
+        si.field.setDim(vi.field.length);
+        si.value.setDim(vi.value.length);
+        foreach (const i; 0 .. vi.field.length)
         {
             si.field[i] = vi.field[i];
             si.value[i] = vi.value[i].syntaxCopy();
@@ -285,10 +285,10 @@ Initializer syntaxCopy(Initializer inx)
     static Initializer copyArray(ArrayInitializer vi)
     {
         auto ai = new ArrayInitializer(vi.loc);
-        assert(vi.index.dim == vi.value.dim);
-        ai.index.setDim(vi.index.dim);
-        ai.value.setDim(vi.value.dim);
-        foreach (const i; 0 .. vi.value.dim)
+        assert(vi.index.length == vi.value.length);
+        ai.index.setDim(vi.index.length);
+        ai.value.setDim(vi.value.length);
+        foreach (const i; 0 .. vi.value.length)
         {
             ai.index[i] = vi.index[i] ? vi.index[i].syntaxCopy() : null;
             ai.value[i] = vi.value[i].syntaxCopy();

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -55,7 +55,7 @@ Expression toAssocArrayLiteral(ArrayInitializer ai)
     Expression e;
     //printf("ArrayInitializer::toAssocArrayInitializer()\n");
     //static int i; if (++i == 2) assert(0);
-    const dim = ai.value.dim;
+    const dim = ai.value.length;
     auto keys = new Expressions(dim);
     auto values = new Expressions(dim);
     for (size_t i = 0; i < dim; i++)
@@ -249,7 +249,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
             auto ie = new ExpInitializer(i.loc, sle);
             return ie.initializerSemantic(sc, t, needInterpret);
         }
-        else if ((t.ty == Tdelegate || t.isPtrToFunction()) && i.value.dim == 0)
+        else if ((t.ty == Tdelegate || t.isPtrToFunction()) && i.value.length == 0)
         {
             const tok = (t.ty == Tdelegate) ? TOK.delegate_ : TOK.function_;
             /* Rewrite as empty delegate literal { }
@@ -315,7 +315,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
         }
         i.type = t;
         length = 0;
-        for (size_t j = 0; j < i.index.dim; j++)
+        for (size_t j = 0; j < i.index.length; j++)
         {
             Expression idx = i.index[j];
             if (idx)
@@ -350,7 +350,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
                 TupleExp te = ei.exp.isTupleExp();
                 i.index.remove(j);
                 i.value.remove(j);
-                for (size_t k = 0; k < te.exps.dim; ++k)
+                for (size_t k = 0; k < te.exps.length; ++k)
                 {
                     Expression e = (*te.exps)[k];
                     i.index.insert(j + k, cast(Expression)null);
@@ -475,7 +475,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
         {
             return i; // Failed, suppress duplicate error messages
         }
-        if (i.exp.type.isTypeTuple() && i.exp.type.isTypeTuple().arguments.dim == 0)
+        if (i.exp.type.isTypeTuple() && i.exp.type.isTypeTuple().arguments.length == 0)
         {
             Type et = i.exp.type;
             i.exp = new TupleExp(i.exp.loc, new Expressions());
@@ -638,7 +638,7 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
                 uinteger_t dim2 = dim1;
                 if (auto ale = i.exp.isArrayLiteralExp())
                 {
-                    dim2 = ale.elements ? ale.elements.dim : 0;
+                    dim2 = ale.elements ? ale.elements.length : 0;
                 }
                 else if (auto se = i.exp.isSliceExp())
                 {
@@ -1094,9 +1094,9 @@ Initializer inferType(Initializer init, Scope* sc)
         Expressions* values;
         if (init.isAssociativeArray())
         {
-            keys = new Expressions(init.value.dim);
-            values = new Expressions(init.value.dim);
-            for (size_t i = 0; i < init.value.dim; i++)
+            keys = new Expressions(init.value.length);
+            values = new Expressions(init.value.length);
+            for (size_t i = 0; i < init.value.length; i++)
             {
                 Expression e = init.index[i];
                 if (!e)
@@ -1119,9 +1119,9 @@ Initializer inferType(Initializer init, Scope* sc)
         }
         else
         {
-            auto elements = new Expressions(init.value.dim);
+            auto elements = new Expressions(init.value.length);
             elements.zero();
-            for (size_t i = 0; i < init.value.dim; i++)
+            for (size_t i = 0; i < init.value.length; i++)
             {
                 assert(!init.index[i]); // already asserted by isAssociativeArray()
                 Initializer iz = init.value[i];
@@ -1300,9 +1300,9 @@ extern (C++) Expression initializerToExpression(Initializer init, Type itype = n
         {
             /* Calculate the length of the array literal
              */
-            edim = cast(uint)init.value.dim;
+            edim = cast(uint)init.value.length;
             size_t j = 0;
-            foreach (i; 0 .. init.value.dim)
+            foreach (i; 0 .. init.value.length)
             {
                 if (auto e = init.index[i])
                 {
@@ -1325,7 +1325,7 @@ extern (C++) Expression initializerToExpression(Initializer init, Type itype = n
         auto elements = new Expressions(edim);
         elements.zero();
         size_t j = 0;
-        foreach (i; 0 .. init.value.dim)
+        foreach (i; 0 .. init.value.length)
         {
             if (auto e = init.index[i])
                 j = cast(size_t)e.toInteger();

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -63,7 +63,7 @@ public void inlineScanModule(Module m)
 
     //printf("Module = %p\n", m.sc.scopesym);
 
-    foreach (i; 0 .. m.members.dim)
+    foreach (i; 0 .. m.members.length)
     {
         Dsymbol s = (*m.members)[i];
         //if (global.params.verbose)
@@ -197,11 +197,11 @@ public:
 
     override void visit(CompoundStatement s)
     {
-        //printf("CompoundStatement.doInlineAs!%s() %d\n", Result.stringof.ptr, s.statements.dim);
+        //printf("CompoundStatement.doInlineAs!%s() %d\n", Result.stringof.ptr, s.statements.length);
         static if (asStatements)
         {
             auto as = new Statements();
-            as.reserve(s.statements.dim);
+            as.reserve(s.statements.length);
         }
 
         foreach (i, sx; *s.statements)
@@ -225,7 +225,7 @@ public:
                     ifs.ifbody &&
                     ifs.ifbody.endsWithReturnStatement() &&
                     !ifs.elsebody &&
-                    i + 1 < s.statements.dim &&
+                    i + 1 < s.statements.length &&
                     (s3 = (*s.statements)[i + 1]) !is null &&
                     s3.endsWithReturnStatement()
                    )
@@ -266,11 +266,11 @@ public:
 
     override void visit(UnrolledLoopStatement s)
     {
-        //printf("UnrolledLoopStatement.doInlineAs!%s() %d\n", Result.stringof.ptr, s.statements.dim);
+        //printf("UnrolledLoopStatement.doInlineAs!%s() %d\n", Result.stringof.ptr, s.statements.length);
         static if (asStatements)
         {
             auto as = new Statements();
-            as.reserve(s.statements.dim);
+            as.reserve(s.statements.length);
         }
 
         foreach (sx; *s.statements)
@@ -293,7 +293,7 @@ public:
 
     override void visit(ScopeStatement s)
     {
-        //printf("ScopeStatement.doInlineAs!%s() %d\n", Result.stringof.ptr, s.statement.dim);
+        //printf("ScopeStatement.doInlineAs!%s() %d\n", Result.stringof.ptr, s.statement.length);
         auto r = doInlineAs!Result(s.statement, ids);
         static if (asStatements)
             result = new ScopeStatement(s.loc, r, s.endloc);
@@ -422,9 +422,9 @@ public:
             if (!a)
                 return null;
 
-            auto newa = new Expressions(a.dim);
+            auto newa = new Expressions(a.length);
 
-            foreach (i; 0 .. a.dim)
+            foreach (i; 0 .. a.length)
             {
                 (*newa)[i] = doInlineAs!Expression((*a)[i], ids);
             }
@@ -440,7 +440,7 @@ public:
         override void visit(SymOffExp e)
         {
             //printf("SymOffExp.doInlineAs!%s(%s)\n", Result.stringof.ptr, e.toChars());
-            foreach (i; 0 .. ids.from.dim)
+            foreach (i; 0 .. ids.from.length)
             {
                 if (e.var != ids.from[i])
                     continue;
@@ -455,7 +455,7 @@ public:
         override void visit(VarExp e)
         {
             //printf("VarExp.doInlineAs!%s(%s)\n", Result.stringof.ptr, e.toChars());
-            foreach (i; 0 .. ids.from.dim)
+            foreach (i; 0 .. ids.from.length)
             {
                 if (e.var != ids.from[i])
                     continue;
@@ -493,7 +493,7 @@ public:
              *      auto x = *(t.vthis.vthis + i.voffset) + *(t.vthis + g.voffset)
              */
             auto v = e.var.isVarDeclaration();
-            if (v && v.nestedrefs.dim && ids.vthis)
+            if (v && v.nestedrefs.length && ids.vthis)
             {
                 Dsymbol s = ids.fd;
                 auto fdv = v.toParent().isFuncDeclaration();
@@ -571,7 +571,7 @@ public:
                 //printf("\t==> result = %s, type = %s\n", result.toChars(), result.type.toChars());
                 return;
             }
-            else if (v && v.nestedrefs.dim)
+            else if (v && v.nestedrefs.length)
             {
                 auto ve = e.copy().isVarExp();
                 ve.originalScope = ids.fd;
@@ -634,7 +634,7 @@ public:
                     if (auto tup = vd.toAlias().isTupleDeclaration())
                     {
                         tup.foreachVar((s) { s; });
-                        result = st.objects.dim;
+                        result = st.objects.length;
                         return;
                     }
                 }
@@ -643,7 +643,7 @@ public:
 
                 if (ids.fd && vd == ids.fd.nrvo_var)
                 {
-                    foreach (i; 0 .. ids.from.dim)
+                    foreach (i; 0 .. ids.from.length)
                     {
                         if (vd != ids.from[i])
                             continue;
@@ -1020,7 +1020,7 @@ public:
 
     override void visit(CompoundStatement s)
     {
-        foreach (i; 0 .. s.statements.dim)
+        foreach (i; 0 .. s.statements.length)
         {
             inlineScan((*s.statements)[i]);
         }
@@ -1028,7 +1028,7 @@ public:
 
     override void visit(UnrolledLoopStatement s)
     {
-        foreach (i; 0 .. s.statements.dim)
+        foreach (i; 0 .. s.statements.length)
         {
             inlineScan((*s.statements)[i]);
         }
@@ -1089,7 +1089,7 @@ public:
         s.sdefault = cast(DefaultStatement)sdefault;
         if (s.cases)
         {
-            foreach (i; 0 .. s.cases.dim)
+            foreach (i; 0 .. s.cases.length)
             {
                 Statement scase = (*s.cases)[i];
                 inlineScan(scase);
@@ -1180,7 +1180,7 @@ public:
     {
         if (arguments)
         {
-            foreach (i; 0 .. arguments.dim)
+            foreach (i; 0 .. arguments.length)
             {
                 inlineScan((*arguments)[i]);
             }
@@ -1568,7 +1568,7 @@ public:
         Dsymbols* decls = d.include(null);
         if (decls)
         {
-            foreach (i; 0 .. decls.dim)
+            foreach (i; 0 .. decls.length)
             {
                 Dsymbol s = (*decls)[i];
                 //printf("AttribDeclaration.inlineScan %s\n", s.toChars());
@@ -1582,7 +1582,7 @@ public:
         //printf("AggregateDeclaration.inlineScan(%s)\n", toChars());
         if (ad.members)
         {
-            foreach (i; 0 .. ad.members.dim)
+            foreach (i; 0 .. ad.members.length)
             {
                 Dsymbol s = (*ad.members)[i];
                 //printf("inline scan aggregate symbol '%s'\n", s.toChars());
@@ -1599,7 +1599,7 @@ public:
         }
         if (!ti.errors && ti.members)
         {
-            foreach (i; 0 .. ti.members.dim)
+            foreach (i; 0 .. ti.members.length)
             {
                 Dsymbol s = (*ti.members)[i];
                 s.accept(this);
@@ -2005,10 +2005,10 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
 
     // Set up parameters
     Expression eparams;
-    if (arguments && arguments.dim)
+    if (arguments && arguments.length)
     {
-        assert(fd.parameters.dim == arguments.dim);
-        foreach (i; 0 .. arguments.dim)
+        assert(fd.parameters.length == arguments.length);
+        foreach (i; 0 .. arguments.length)
         {
             auto vfrom = (*fd.parameters)[i];
             auto arg = (*arguments)[i];

--- a/compiler/src/dmd/inlinecost.d
+++ b/compiler/src/dmd/inlinecost.d
@@ -106,7 +106,7 @@ AggregateDeclaration isInlinableNestedAggregate(DeclarationExp e)
     if (e.declaration.isAnonymous() && e.declaration.isAttribDeclaration)
     {
         AttribDeclaration ad = e.declaration.isAttribDeclaration;
-        if (ad.decl.dim == 1)
+        if (ad.decl.length == 1)
         {
             if ((result = (*ad.decl)[0].isAggregateDeclaration) !is null)
             {
@@ -193,7 +193,7 @@ public:
     override void visit(CompoundStatement s)
     {
         scope InlineCostVisitor icv = new InlineCostVisitor(this);
-        foreach (i; 0 .. s.statements.dim)
+        foreach (i; 0 .. s.statements.length)
         {
             if (Statement s2 = (*s.statements)[i])
             {
@@ -208,7 +208,7 @@ public:
                     ifs.ifbody &&
                     ifs.ifbody.endsWithReturnStatement() &&
                     !ifs.elsebody &&
-                    i + 1 < s.statements.dim &&
+                    i + 1 < s.statements.length &&
                     (s3 = (*s.statements)[i + 1]) !is null &&
                     s3.endsWithReturnStatement()
                    )

--- a/compiler/src/dmd/json.d
+++ b/compiler/src/dmd/json.d
@@ -386,13 +386,13 @@ public:
 
     extern(D) void property(const char[] name, Parameters* parameters)
     {
-        if (parameters is null || parameters.dim == 0)
+        if (parameters is null || parameters.length == 0)
             return;
         propertyStart(name);
         arrayStart();
         if (parameters)
         {
-            for (size_t i = 0; i < parameters.dim; i++)
+            for (size_t i = 0; i < parameters.length; i++)
             {
                 Parameter p = (*parameters)[i];
                 objectStart();
@@ -491,7 +491,7 @@ public:
         property("comment", s.comment.toDString);
         propertyStart("members");
         arrayStart();
-        for (size_t i = 0; i < s.members.dim; i++)
+        for (size_t i = 0; i < s.members.length; i++)
         {
             (*s.members)[i].accept(this);
         }
@@ -522,7 +522,7 @@ public:
             property("alias", s.aliasId.toString());
         bool hasRenamed = false;
         bool hasSelective = false;
-        for (size_t i = 0; i < s.aliases.dim; i++)
+        for (size_t i = 0; i < s.aliases.length; i++)
         {
             // avoid empty "renamed" and "selective" sections
             if (hasRenamed && hasSelective)
@@ -537,7 +537,7 @@ public:
             // import foo : alias1 = target1;
             propertyStart("renamed");
             objectStart();
-            for (size_t i = 0; i < s.aliases.dim; i++)
+            for (size_t i = 0; i < s.aliases.length; i++)
             {
                 const name = s.names[i];
                 const _alias = s.aliases[i];
@@ -566,7 +566,7 @@ public:
         Dsymbols* ds = d.include(null);
         if (ds)
         {
-            for (size_t i = 0; i < ds.dim; i++)
+            for (size_t i = 0; i < ds.length; i++)
             {
                 Dsymbol s = (*ds)[i];
                 s.accept(this);
@@ -582,7 +582,7 @@ public:
             return; // Don't visit the if/else bodies again below
         }
         Dsymbols* ds = d.decl ? d.decl : d.elsedecl;
-        for (size_t i = 0; i < ds.dim; i++)
+        for (size_t i = 0; i < ds.length; i++)
         {
             Dsymbol s = (*ds)[i];
             s.accept(this);
@@ -631,7 +631,7 @@ public:
         {
             propertyStart("members");
             arrayStart();
-            for (size_t i = 0; i < d.members.dim; i++)
+            for (size_t i = 0; i < d.members.length; i++)
             {
                 Dsymbol s = (*d.members)[i];
                 s.accept(this);
@@ -649,11 +649,11 @@ public:
         if (tf && tf.ty == Tfunction)
             property("parameters", tf.parameterList.parameters);
         property("endline", "endchar", d.endloc);
-        if (d.foverrides.dim)
+        if (d.foverrides.length)
         {
             propertyStart("overrides");
             arrayStart();
-            for (size_t i = 0; i < d.foverrides.dim; i++)
+            for (size_t i = 0; i < d.foverrides.length; i++)
             {
                 FuncDeclaration fd = d.foverrides[i];
                 item(fd.toPrettyChars().toDString);
@@ -681,7 +681,7 @@ public:
         jsonProperties(d);
         propertyStart("parameters");
         arrayStart();
-        for (size_t i = 0; i < d.parameters.dim; i++)
+        for (size_t i = 0; i < d.parameters.length; i++)
         {
             TemplateParameter s = (*d.parameters)[i];
             objectStart();
@@ -732,7 +732,7 @@ public:
         }
         propertyStart("members");
         arrayStart();
-        for (size_t i = 0; i < d.members.dim; i++)
+        for (size_t i = 0; i < d.members.length; i++)
         {
             Dsymbol s = (*d.members)[i];
             s.accept(this);
@@ -747,7 +747,7 @@ public:
         {
             if (d.members)
             {
-                for (size_t i = 0; i < d.members.dim; i++)
+                for (size_t i = 0; i < d.members.length; i++)
                 {
                     Dsymbol s = (*d.members)[i];
                     s.accept(this);
@@ -762,7 +762,7 @@ public:
         {
             propertyStart("members");
             arrayStart();
-            for (size_t i = 0; i < d.members.dim; i++)
+            for (size_t i = 0; i < d.members.length; i++)
             {
                 Dsymbol s = (*d.members)[i];
                 s.accept(this);
@@ -963,7 +963,7 @@ public:
             requiredProperty("name", m.md ? m.md.toString() : null);
             requiredProperty("file", m.srcfile.toString());
             propertyBool("isRoot", m.isRoot());
-            if(m.contentImportedFiles.dim > 0)
+            if(m.contentImportedFiles.length > 0)
             {
                 propertyStart("contentImports");
                 arrayStart();

--- a/compiler/src/dmd/lambdacomp.d
+++ b/compiler/src/dmd/lambdacomp.d
@@ -452,7 +452,7 @@ public:
         if (ty)
         {
             writeMangledName(ty.sym);
-            auto dim = e.elements.dim;
+            auto dim = e.elements.length;
             foreach (i; 0..dim)
             {
                 auto elem = (*e.elements)[i];

--- a/compiler/src/dmd/libelf.d
+++ b/compiler/src/dmd/libelf.d
@@ -125,7 +125,7 @@ final class LibElf : Library
             uint symtab_size = 0;
             char* filenametab = null;
             uint filenametab_size = 0;
-            uint mstart = cast(uint)objmodules.dim;
+            uint mstart = cast(uint)objmodules.length;
             while (offset < buflen)
             {
                 if (offset + ElfLibHeader.sizeof >= buflen)
@@ -235,7 +235,7 @@ final class LibElf : Library
                 //printf("symtab[%d] moff = %x  %x, name = %s\n", i, moff, moff + ElfLibHeader.sizeof, name.ptr);
                 for (uint m = mstart; 1; m++)
                 {
-                    if (m == objmodules.dim)
+                    if (m == objmodules.length)
                         return corrupt(__LINE__);  // didn't find it
                     ElfObjModule* om = objmodules[m];
                     //printf("\t%x\n", cast(char *)om.base - cast(char *)buf);
@@ -436,7 +436,7 @@ private:
         ElfOmToHeader(&h, &om);
         libbuf.write((&h)[0 .. 1]);
         char[4] buf;
-        Port.writelongBE(cast(uint)objsymbols.dim, buf.ptr);
+        Port.writelongBE(cast(uint)objsymbols.length, buf.ptr);
         libbuf.write(buf[0 .. 4]);
         foreach (os; objsymbols)
         {

--- a/compiler/src/dmd/libmach.d
+++ b/compiler/src/dmd/libmach.d
@@ -125,7 +125,7 @@ final class LibMach : Library
             uint offset = 8;
             char* symtab = null;
             uint symtab_size = 0;
-            uint mstart = cast(uint)objmodules.dim;
+            uint mstart = cast(uint)objmodules.length;
             while (offset < buflen)
             {
                 if (offset + MachLibHeader.sizeof >= buflen)
@@ -192,7 +192,7 @@ final class LibMach : Library
                 //printf("symtab[%d] moff = x%x  x%x, name = %s\n", i, moff, moff + MachLibHeader.sizeof, name);
                 for (uint m = mstart; 1; m++)
                 {
-                    if (m == objmodules.dim)
+                    if (m == objmodules.length)
                         return corrupt(__LINE__);       // didn't find it
                     MachObjModule* om = objmodules[m];
                     //printf("\tom offset = x%x\n", cast(char *)om.base - cast(char *)buf);
@@ -339,7 +339,7 @@ private:
         }
         __gshared char* pad = [0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A];
         /************* Scan Object Modules for Symbols ******************/
-        for (size_t i = 0; i < objmodules.dim; i++)
+        for (size_t i = 0; i < objmodules.length; i++)
         {
             MachObjModule* om = objmodules[i];
             if (om.scan)
@@ -349,7 +349,7 @@ private:
         }
         /************* Determine module offsets ******************/
         uint moffset = 8 + MachLibHeader.sizeof + 4 + 4;
-        for (size_t i = 0; i < objsymbols.dim; i++)
+        for (size_t i = 0; i < objsymbols.length; i++)
         {
             MachObjSymbol* os = objsymbols[i];
             moffset += 8 + os.name.length + 1;
@@ -362,7 +362,7 @@ private:
         {
             printf("\tmoffset = x%x\n", moffset);
         }
-        for (size_t i = 0; i < objmodules.dim; i++)
+        for (size_t i = 0; i < objmodules.length; i++)
         {
             MachObjModule* om = objmodules[i];
             moffset += moffset & 1;
@@ -410,10 +410,10 @@ private:
         memset(h.file_size.ptr + len, ' ', 10 - len);
         libbuf.write((&h)[0 .. 1]);
         char[4] buf;
-        Port.writelongLE(cast(uint)(objsymbols.dim * 8), buf.ptr);
+        Port.writelongLE(cast(uint)(objsymbols.length * 8), buf.ptr);
         libbuf.write(buf[0 .. 4]);
         int stringoff = 0;
-        for (size_t i = 0; i < objsymbols.dim; i++)
+        for (size_t i = 0; i < objsymbols.length; i++)
         {
             MachObjSymbol* os = objsymbols[i];
             Port.writelongLE(stringoff, buf.ptr);
@@ -424,7 +424,7 @@ private:
         }
         Port.writelongLE(stringoff, buf.ptr);
         libbuf.write(buf[0 .. 4]);
-        for (size_t i = 0; i < objsymbols.dim; i++)
+        for (size_t i = 0; i < objsymbols.length; i++)
         {
             MachObjSymbol* os = objsymbols[i];
             libbuf.writestring(os.name);
@@ -441,7 +441,7 @@ private:
         assert(libbuf.length == hoffset);
         /* Write out each of the object modules
          */
-        for (size_t i = 0; i < objmodules.dim; i++)
+        for (size_t i = 0; i < objmodules.length; i++)
         {
             MachObjModule* om2 = objmodules[i];
             if (libbuf.length & 1)

--- a/compiler/src/dmd/libmscoff.d
+++ b/compiler/src/dmd/libmscoff.d
@@ -140,7 +140,7 @@ final class LibMSCoff : Library
             char* longnames = null;
             size_t longnames_length = 0;
             size_t offset = 8;
-            size_t mstart = objmodules.dim;
+            size_t mstart = objmodules.length;
             while (1)
             {
                 offset = (offset + 1) & ~1; // round to even boundary
@@ -292,7 +292,7 @@ final class LibMSCoff : Library
                 uint moff = member_file_offsets[memi];
                 for (size_t m = mstart; 1; m++)
                 {
-                    if (m == objmodules.dim)
+                    if (m == objmodules.length)
                         return corrupt(__LINE__);       // didn't find it
                     MSCoffObjModule* om = objmodules[m];
                     //printf("\tom offset = x%x\n", cast(char *)om.base - cast(char *)buf);
@@ -418,7 +418,7 @@ private:
         }
         assert(MSCoffLibHeader.sizeof == 60);
         /************* Scan Object Modules for Symbols ******************/
-        for (size_t i = 0; i < objmodules.dim; i++)
+        for (size_t i = 0; i < objmodules.length; i++)
         {
             MSCoffObjModule* om = objmodules[i];
             if (om.scan)
@@ -430,7 +430,7 @@ private:
         /* The longnames section is where we store long file names.
          */
         uint noffset = 0;
-        for (size_t i = 0; i < objmodules.dim; i++)
+        for (size_t i = 0; i < objmodules.length; i++)
         {
             MSCoffObjModule* om = objmodules[i];
             size_t len = om.name.length;
@@ -448,7 +448,7 @@ private:
         }
         /************* Determine string table length ******************/
         size_t slength = 0;
-        for (size_t i = 0; i < objsymbols.dim; i++)
+        for (size_t i = 0; i < objsymbols.length; i++)
         {
             MSCoffObjSymbol* os = objsymbols[i];
             slength += os.name.length + 1;
@@ -456,10 +456,10 @@ private:
         /************* Offset of first module ***********************/
         size_t moffset = 8; // signature
         size_t firstLinkerMemberOffset = moffset;
-        moffset += MSCoffLibHeader.sizeof + 4 + objsymbols.dim * 4 + slength; // 1st Linker Member
+        moffset += MSCoffLibHeader.sizeof + 4 + objsymbols.length * 4 + slength; // 1st Linker Member
         moffset += moffset & 1;
         size_t secondLinkerMemberOffset = moffset;
-        moffset += MSCoffLibHeader.sizeof + 4 + objmodules.dim * 4 + 4 + objsymbols.dim * 2 + slength;
+        moffset += MSCoffLibHeader.sizeof + 4 + objmodules.length * 4 + 4 + objsymbols.length * 2 + slength;
         moffset += moffset & 1;
         size_t LongnamesMemberOffset = moffset;
         moffset += MSCoffLibHeader.sizeof + noffset; // Longnames Member size
@@ -468,7 +468,7 @@ private:
             printf("\tmoffset = x%x\n", moffset);
         }
         /************* Offset of each module *************************/
-        for (size_t i = 0; i < objmodules.dim; i++)
+        for (size_t i = 0; i < objmodules.length; i++)
         {
             MSCoffObjModule* om = objmodules[i];
             moffset += moffset & 1;
@@ -484,7 +484,7 @@ private:
         MSCoffObjModule om;
         om.name_offset = -1;
         om.base = null;
-        om.length = cast(uint)(4 + objsymbols.dim * 4 + slength);
+        om.length = cast(uint)(4 + objsymbols.length * 4 + slength);
         om.offset = 8;
         om.name = "";
         time_t file_time = 0;
@@ -499,12 +499,12 @@ private:
         MSCoffOmToHeader(&h, &om);
         libbuf.write((&h)[0 .. 1]);
         char[4] buf;
-        Port.writelongBE(cast(uint)objsymbols.dim, buf.ptr);
+        Port.writelongBE(cast(uint)objsymbols.length, buf.ptr);
         libbuf.write(buf[0 .. 4]);
         // Sort objsymbols[] in module offset order
         objsymbols.sort!(MSCoffObjSymbol.offset_pred);
         uint lastoffset;
-        for (size_t i = 0; i < objsymbols.dim; i++)
+        for (size_t i = 0; i < objsymbols.length; i++)
         {
             MSCoffObjSymbol* os = objsymbols[i];
             //printf("objsymbols[%d] = '%s', offset = %u\n", cast(int) i, os.name.ptr, os.om.offset);
@@ -517,7 +517,7 @@ private:
             Port.writelongBE(lastoffset, buf.ptr);
             libbuf.write(buf[0 .. 4]);
         }
-        for (size_t i = 0; i < objsymbols.dim; i++)
+        for (size_t i = 0; i < objsymbols.length; i++)
         {
             MSCoffObjSymbol* os = objsymbols[i];
             libbuf.writestring(os.name);
@@ -527,29 +527,29 @@ private:
         if (libbuf.length & 1)
             libbuf.writeByte('\n');
         assert(libbuf.length == secondLinkerMemberOffset);
-        om.length = cast(uint)(4 + objmodules.dim * 4 + 4 + objsymbols.dim * 2 + slength);
+        om.length = cast(uint)(4 + objmodules.length * 4 + 4 + objsymbols.length * 2 + slength);
         MSCoffOmToHeader(&h, &om);
         libbuf.write((&h)[0 .. 1]);
-        Port.writelongLE(cast(uint)objmodules.dim, buf.ptr);
+        Port.writelongLE(cast(uint)objmodules.length, buf.ptr);
         libbuf.write(buf[0 .. 4]);
-        for (size_t i = 0; i < objmodules.dim; i++)
+        for (size_t i = 0; i < objmodules.length; i++)
         {
             MSCoffObjModule* om2 = objmodules[i];
             om2.index = cast(ushort)i;
             Port.writelongLE(om2.offset, buf.ptr);
             libbuf.write(buf[0 .. 4]);
         }
-        Port.writelongLE(cast(uint)objsymbols.dim, buf.ptr);
+        Port.writelongLE(cast(uint)objsymbols.length, buf.ptr);
         libbuf.write(buf[0 .. 4]);
         // Sort objsymbols[] in lexical order
         objsymbols.sort!(MSCoffObjSymbol.name_pred);
-        for (size_t i = 0; i < objsymbols.dim; i++)
+        for (size_t i = 0; i < objsymbols.length; i++)
         {
             MSCoffObjSymbol* os = objsymbols[i];
             Port.writelongLE(os.om.index + 1, buf.ptr);
             libbuf.write(buf[0 .. 2]);
         }
-        for (size_t i = 0; i < objsymbols.dim; i++)
+        for (size_t i = 0; i < objsymbols.length; i++)
         {
             MSCoffObjSymbol* os = objsymbols[i];
             libbuf.writestring(os.name);
@@ -570,7 +570,7 @@ private:
         h.trailer[0] = '`';
         h.trailer[1] = '\n';
         libbuf.write((&h)[0 .. 1]);
-        for (size_t i = 0; i < objmodules.dim; i++)
+        for (size_t i = 0; i < objmodules.length; i++)
         {
             MSCoffObjModule* om2 = objmodules[i];
             if (om2.name_offset >= 0)
@@ -581,7 +581,7 @@ private:
         }
         /* Write out each of the object modules
          */
-        for (size_t i = 0; i < objmodules.dim; i++)
+        for (size_t i = 0; i < objmodules.length; i++)
         {
             MSCoffObjModule* om2 = objmodules[i];
             if (libbuf.length & 1)

--- a/compiler/src/dmd/libomf.d
+++ b/compiler/src/dmd/libomf.d
@@ -246,7 +246,7 @@ private:
                 len += 2; // Digital Mars long name extension
             symSize += (len + 4 + 1) & ~1;
         }
-        bucksForHash = cast(ushort)((objsymbols.dim + objmodules.dim + HASHMOD - 3) / (HASHMOD - 2));
+        bucksForHash = cast(ushort)((objsymbols.length + objmodules.length + HASHMOD - 3) / (HASHMOD - 2));
         bucksForSize = cast(ushort)((symSize + BUCKETSIZE - padding - padding - 1) / (BUCKETSIZE - padding));
         ndicpages = (bucksForHash > bucksForSize) ? bucksForHash : bucksForSize;
         //printf("ndicpages = %u\n",ndicpages);

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -776,7 +776,7 @@ public int runLINK()
         {
             // Print it
             OutBuffer buf;
-            for (size_t i = 0; i < argv.dim; i++)
+            for (size_t i = 0; i < argv.length; i++)
             {
                 buf.writestring(argv[i]);
                 buf.writeByte(' ');
@@ -956,7 +956,7 @@ public int runProgram()
     {
         OutBuffer buf;
         buf.writestring(global.params.exefile);
-        for (size_t i = 0; i < global.params.runargs.dim; ++i)
+        for (size_t i = 0; i < global.params.runargs.length; ++i)
         {
             buf.writeByte(' ');
             buf.writestring(global.params.runargs[i]);
@@ -966,7 +966,7 @@ public int runProgram()
     // Build argv[]
     Strings argv;
     argv.push(global.params.exefile.xarraydup.ptr);
-    for (size_t i = 0; i < global.params.runargs.dim; ++i)
+    for (size_t i = 0; i < global.params.runargs.length; ++i)
     {
         const(char)* a = global.params.runargs[i];
         version (Windows)

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -255,7 +255,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     {
         fatal();
     }
-    if (files.dim == 0)
+    if (files.length == 0)
     {
         if (params.jsonFieldFlags)
         {
@@ -286,7 +286,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     Expression._init();
     Objc._init();
 
-    reconcileLinkRunLib(params, files.dim, target.obj_ext);
+    reconcileLinkRunLib(params, files.length, target.obj_ext);
     version(CRuntime_Microsoft)
     {
         import dmd.root.longdouble;
@@ -303,7 +303,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         stdout.printPredefinedVersions();
         stdout.printGlobalConfigs();
     }
-    //printf("%d source files\n", cast(int) files.dim);
+    //printf("%d source files\n", cast(int) files.length);
 
     // Build import search path
 
@@ -345,7 +345,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
 
     // Parse files
     bool anydocfiles = false;
-    size_t filecount = modules.dim;
+    size_t filecount = modules.length;
     for (size_t filei = 0, modi = 0; filei < filecount; filei++, modi++)
     {
         Module m = modules[modi];
@@ -393,7 +393,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         }
     }
 
-    if (anydocfiles && modules.dim && (driverParams.oneobj || params.objname))
+    if (anydocfiles && modules.length && (driverParams.oneobj || params.objname))
     {
         error(Loc.initial, "conflicting Ddoc and obj generation options");
         fatal();
@@ -442,9 +442,9 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     //if (global.errors)
     //    fatal();
     Module.runDeferredSemantic();
-    if (Module.deferred.dim)
+    if (Module.deferred.length)
     {
-        for (size_t i = 0; i < Module.deferred.dim; i++)
+        for (size_t i = 0; i < Module.deferred.length; i++)
         {
             Dsymbol sd = Module.deferred[i];
             sd.error("unable to resolve forward reference in definition");
@@ -472,9 +472,9 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     }
     if (includeImports)
     {
-        // Note: DO NOT USE foreach here because Module.amodules.dim can
+        // Note: DO NOT USE foreach here because Module.amodules.length can
         //       change on each iteration of the loop
-        for (size_t i = 0; i < compiledImports.dim; i++)
+        for (size_t i = 0; i < compiledImports.length; i++)
         {
             auto m = compiledImports[i];
             assert(m.isRoot);
@@ -510,7 +510,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     // So deps file generation should be moved after the inlining stage.
     if (OutBuffer* ob = params.moduleDeps.buffer)
     {
-        foreach (i; 1 .. modules[0].aimports.dim)
+        foreach (i; 1 .. modules[0].aimports.length)
             semantic3OnDependencies(modules[0].aimports[i]);
         Module.runDeferredSemantic3();
 
@@ -652,8 +652,8 @@ bool parseCommandlineAndConfig(size_t argc, const(char)** argv, ref Param params
     }
     if (const(char)* missingFile = responseExpand(arguments)) // expand response files
         error(Loc.initial, "cannot open response file '%s'", missingFile);
-    //for (size_t i = 0; i < arguments.dim; ++i) printf("arguments[%d] = '%s'\n", i, arguments[i]);
-    files.reserve(arguments.dim - 1);
+    //for (size_t i = 0; i < arguments.length; ++i) printf("arguments[%d] = '%s'\n", i, arguments[i]);
+    files.reserve(arguments.length - 1);
     // Set default values
     params.argv0 = arguments[0].toDString;
 
@@ -1539,12 +1539,12 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
 
     version (none)
     {
-        for (size_t i = 0; i < arguments.dim; i++)
+        for (size_t i = 0; i < arguments.length; i++)
         {
             printf("arguments[%d] = '%s'\n", i, arguments[i]);
         }
     }
-    for (size_t i = 1; i < arguments.dim; i++)
+    for (size_t i = 1; i < arguments.length; i++)
     {
         const(char)* p = arguments[i];
         const(char)[] arg = p.toDString();
@@ -2911,7 +2911,7 @@ private
 Modules createModules(ref Strings files, ref Strings libmodules, const ref Target target)
 {
     Modules modules;
-    modules.reserve(files.dim);
+    modules.reserve(files.length);
     bool firstmodule = true;
     foreach(file; files)
     {

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4556,7 +4556,7 @@ extern (C++) final class TypeFunction : TypeNext
         Parameters* params = parameterList.parameters;
         if (mod & MODFlags.wild)
             params = parameterList.parameters.copy();
-        for (size_t i = 0; i < params.dim; i++)
+        for (size_t i = 0; i < params.length; i++)
         {
             Parameter p = (*params)[i];
             Type t = p.type.substWildTo(m);
@@ -5108,8 +5108,8 @@ extern (C++) abstract class TypeQualified : Type
     final void syntaxCopyHelper(TypeQualified t)
     {
         //printf("TypeQualified::syntaxCopyHelper(%s) %s\n", t.toChars(), toChars());
-        idents.setDim(t.idents.dim);
-        for (size_t i = 0; i < idents.dim; i++)
+        idents.setDim(t.idents.length);
+        for (size_t i = 0; i < idents.length; i++)
         {
             RootObject id = t.idents[i];
             with (DYNCAST) final switch (id.dyncast())
@@ -5251,7 +5251,7 @@ extern (C++) final class TypeInstance : TypeQualified
 
     override TypeInstance syntaxCopy()
     {
-        //printf("TypeInstance::syntaxCopy() %s, %d\n", toChars(), idents.dim);
+        //printf("TypeInstance::syntaxCopy() %s, %d\n", toChars(), idents.length);
         auto t = new TypeInstance(loc, tempinst.syntaxCopy(null));
         t.syntaxCopyHelper(this);
         t.mod = mod;
@@ -5432,7 +5432,7 @@ extern (C++) final class TypeStruct : Type
 
         auto structelems = new Expressions(sym.nonHiddenFields());
         uint offset = 0;
-        foreach (j; 0 .. structelems.dim)
+        foreach (j; 0 .. structelems.length)
         {
             VarDeclaration vd = sym.fields[j];
             Expression e;
@@ -5487,7 +5487,7 @@ extern (C++) final class TypeStruct : Type
         /* If any of the fields are const or immutable,
          * then one cannot assign this struct.
          */
-        for (size_t i = 0; i < sym.fields.dim; i++)
+        for (size_t i = 0; i < sym.fields.length; i++)
         {
             VarDeclaration v = sym.fields[i];
             //printf("%s [%d] v = (%s) %s, v.offset = %d, v.parent = %s\n", sym.toChars(), i, v.kind(), v.toChars(), v.offset, v.parent.kind());
@@ -5541,7 +5541,7 @@ extern (C++) final class TypeStruct : Type
         if (sym.isNested())
             return true;
 
-        for (size_t i = 0; i < sym.fields.dim; i++)
+        for (size_t i = 0; i < sym.fields.length; i++)
         {
             VarDeclaration v = sym.fields[i];
             if (!v.isDataseg() && v.type.needsNested())
@@ -5599,7 +5599,7 @@ extern (C++) final class TypeStruct : Type
                      * allow the conversion.
                      */
                     uint offset = ~0; // dead-store to prevent spurious warning
-                    for (size_t i = 0; i < sym.fields.dim; i++)
+                    for (size_t i = 0; i < sym.fields.length; i++)
                     {
                         VarDeclaration v = sym.fields[i];
                         if (i == 0)
@@ -6072,7 +6072,7 @@ extern (C++) final class TypeTuple : Type
         {
             if (arguments)
             {
-                for (size_t i = 0; i < arguments.dim; i++)
+                for (size_t i = 0; i < arguments.length; i++)
                 {
                     Parameter arg = (*arguments)[i];
                     assert(arg && arg.type);
@@ -6088,10 +6088,10 @@ extern (C++) final class TypeTuple : Type
     extern (D) this(Expressions* exps)
     {
         super(Ttuple);
-        auto arguments = new Parameters(exps ? exps.dim : 0);
+        auto arguments = new Parameters(exps ? exps.length : 0);
         if (exps)
         {
-            for (size_t i = 0; i < exps.dim; i++)
+            for (size_t i = 0; i < exps.length; i++)
             {
                 Expression e = (*exps)[i];
                 if (e.type.ty == Ttuple)
@@ -6169,9 +6169,9 @@ extern (C++) final class TypeTuple : Type
             return true;
         if (auto tt = t.isTypeTuple())
         {
-            if (arguments.dim == tt.arguments.dim)
+            if (arguments.length == tt.arguments.length)
             {
-                for (size_t i = 0; i < tt.arguments.dim; i++)
+                for (size_t i = 0; i < tt.arguments.length; i++)
                 {
                     const Parameter arg1 = (*arguments)[i];
                     Parameter arg2 = (*tt.arguments)[i];
@@ -6190,10 +6190,10 @@ extern (C++) final class TypeTuple : Type
             return MATCH.exact;
         if (auto tt = to.isTypeTuple())
         {
-            if (arguments.dim == tt.arguments.dim)
+            if (arguments.length == tt.arguments.length)
             {
                 MATCH m = MATCH.exact;
-                for (size_t i = 0; i < tt.arguments.dim; i++)
+                for (size_t i = 0; i < tt.arguments.length; i++)
                 {
                     Parameter arg1 = (*arguments)[i];
                     Parameter arg2 = (*tt.arguments)[i];
@@ -6595,8 +6595,8 @@ extern (C++) final class Parameter : ASTNode
         Parameters* params = null;
         if (parameters)
         {
-            params = new Parameters(parameters.dim);
-            for (size_t i = 0; i < params.dim; i++)
+            params = new Parameters(parameters.length);
+            for (size_t i = 0; i < params.length; i++)
                 (*params)[i] = (*parameters)[i].syntaxCopy();
         }
         return params;

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -99,7 +99,7 @@ public:
 
     override void visit(ArrayLiteralExp e)
     {
-        if (e.type.ty != Tarray || !e.elements || !e.elements.dim || e.onstack)
+        if (e.type.ty != Tarray || !e.elements || !e.elements.length || e.onstack)
             return;
         if (f.setGC())
         {
@@ -113,7 +113,7 @@ public:
 
     override void visit(AssocArrayLiteralExp e)
     {
-        if (!e.keys.dim)
+        if (!e.keys.length)
             return;
         if (f.setGC())
         {

--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -565,7 +565,7 @@ void toObNodes(ref ObNodes obnodes, Statement s)
              */
             mystate.defaultBlock = s.sdefault ? newNode() : mystate.breakBlock;
 
-            const numcases = s.cases ? s.cases.dim : 0;
+            const numcases = s.cases ? s.cases.length : 0;
 
             /* allocate a block for each case
              */

--- a/compiler/src/dmd/objc.d
+++ b/compiler/src/dmd/objc.d
@@ -555,7 +555,7 @@ extern(C++) private final class Supported : Objc
                 return 1;
             }
 
-            assert(literal.elements.dim == 1);
+            assert(literal.elements.length == 1);
             auto se = (*literal.elements)[0].toStringExp();
             assert(se);
 
@@ -570,7 +570,7 @@ extern(C++) private final class Supported : Objc
         if (!fd.objc.selector)
             return;
         TypeFunction tf = cast(TypeFunction)fd.type;
-        if (fd.objc.selector.paramCount != tf.parameterList.parameters.dim)
+        if (fd.objc.selector.paramCount != tf.parameterList.parameters.length)
             fd.error("number of colons in Objective-C selector must match number of parameters");
         if (fd.parent && fd.parent.isTemplateInstance())
             fd.error("template cannot have an Objective-C selector attached");

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -286,9 +286,9 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                 ae.e1 = ae.e1.expressionSemantic(sc);
                 ae.e1 = resolveProperties(sc, ae.e1);
                 Expression ae1old = ae.e1;
-                const(bool) maybeSlice = (ae.arguments.dim == 0 || ae.arguments.dim == 1 && (*ae.arguments)[0].op == EXP.interval);
+                const(bool) maybeSlice = (ae.arguments.length == 0 || ae.arguments.length == 1 && (*ae.arguments)[0].op == EXP.interval);
                 IntervalExp ie = null;
-                if (maybeSlice && ae.arguments.dim)
+                if (maybeSlice && ae.arguments.length)
                 {
                     ie = (*ae.arguments)[0].isIntervalExp();
                 }
@@ -425,9 +425,9 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
             ae.e1 = ae.e1.expressionSemantic(sc);
             ae.e1 = resolveProperties(sc, ae.e1);
             Expression ae1old = ae.e1;
-            const(bool) maybeSlice = (ae.arguments.dim == 0 || ae.arguments.dim == 1 && (*ae.arguments)[0].op == EXP.interval);
+            const(bool) maybeSlice = (ae.arguments.length == 0 || ae.arguments.length == 1 && (*ae.arguments)[0].op == EXP.interval);
             IntervalExp ie = null;
-            if (maybeSlice && ae.arguments.dim)
+            if (maybeSlice && ae.arguments.length)
             {
                 ie = (*ae.arguments)[0].isIntervalExp();
             }
@@ -457,7 +457,7 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                             return result;
                         }
                         // Convert to IndexExp
-                        if (ae.arguments.dim == 1)
+                        if (ae.arguments.length == 1)
                         {
                             result = new IndexExp(ae.loc, ae.e1, (*ae.arguments)[0]);
                             result = result.expressionSemantic(sc);
@@ -849,7 +849,7 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                      * the mentioned member, then alias this may be
                      * used since the object will be fully initialised.
                      * If the struct is nested, the context pointer is considered
-                     * one of the members, hence the `ad1.fields.dim == 2 && ad1.vthis`
+                     * one of the members, hence the `ad1.fields.length == 2 && ad1.vthis`
                      * condition.
                      */
                     if (result.op != EXP.assign)
@@ -864,7 +864,7 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                     {
                         // i.e: Rewrote `e1 = e2` -> `e1.some.var = e2`
                         // Ensure that `var` is the only field member in `ad`
-                        if (ad.fields.dim == 1 || (ad.fields.dim == 2 && ad.vthis))
+                        if (ad.fields.length == 1 || (ad.fields.length == 2 && ad.vthis))
                         {
                             if (dve.var == ad.aliasthis.sym)
                                 return result;
@@ -1043,11 +1043,11 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
             {
                 auto tup1 = e.e1.isTupleExp();
                 auto tup2 = e.e2.isTupleExp();
-                size_t dim = tup1.exps.dim;
-                if (dim != tup2.exps.dim)
+                size_t dim = tup1.exps.length;
+                if (dim != tup2.exps.length)
                 {
                     e.error("mismatched tuple lengths, `%d` and `%d`",
-                        cast(int)dim, cast(int)tup2.exps.dim);
+                        cast(int)dim, cast(int)tup2.exps.length);
                     return ErrorExp.get();
                 }
 
@@ -1101,9 +1101,9 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                 ae.e1 = ae.e1.expressionSemantic(sc);
                 ae.e1 = resolveProperties(sc, ae.e1);
                 Expression ae1old = ae.e1;
-                const(bool) maybeSlice = (ae.arguments.dim == 0 || ae.arguments.dim == 1 && (*ae.arguments)[0].op == EXP.interval);
+                const(bool) maybeSlice = (ae.arguments.length == 0 || ae.arguments.length == 1 && (*ae.arguments)[0].op == EXP.interval);
                 IntervalExp ie = null;
-                if (maybeSlice && ae.arguments.dim)
+                if (maybeSlice && ae.arguments.length)
                 {
                     ie = (*ae.arguments)[0].isIntervalExp();
                 }
@@ -1553,7 +1553,7 @@ bool inferForeachAggregate(Scope* sc, bool isForeach, ref Expression feaggr, out
  */
 bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbol sapply)
 {
-    if (!fes.parameters || !fes.parameters.dim)
+    if (!fes.parameters || !fes.parameters.length)
         return false;
     if (sapply) // prefer opApply
     {
@@ -1604,7 +1604,7 @@ bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbol sapply)
     case Tarray:
     case Tsarray:
     case Ttuple:
-        if (fes.parameters.dim == 2)
+        if (fes.parameters.length == 2)
         {
             if (!p.type)
             {
@@ -1623,7 +1623,7 @@ bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbol sapply)
     case Taarray:
         {
             TypeAArray taa = tab.isTypeAArray();
-            if (fes.parameters.dim == 2)
+            if (fes.parameters.length == 2)
             {
                 if (!p.type)
                 {
@@ -1647,7 +1647,7 @@ bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbol sapply)
     {
         AggregateDeclaration ad = (tab.ty == Tclass) ? tab.isTypeClass().sym
                                                      : tab.isTypeStruct().sym;
-        if (fes.parameters.dim == 1)
+        if (fes.parameters.length == 1)
         {
             if (!p.type)
             {
@@ -1811,7 +1811,7 @@ private bool matchParamsToOpApply(TypeFunction tf, Parameters* parameters, bool 
      * Fill in missing types in parameters.
      */
     const nparams = tdg.parameterList.length;
-    if (nparams == 0 || nparams != parameters.dim || tdg.parameterList.varargs != VarArg.none)
+    if (nparams == 0 || nparams != parameters.length || tdg.parameterList.varargs != VarArg.none)
         return nomatch; // parameter mismatch
 
     foreach (u, p; *parameters)

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -225,7 +225,7 @@ package void setLengthVarIfKnown(VarDeclaration lengthVar, Expression arr)
     if (auto se = arr.isStringExp())
         len = se.len;
     else if (auto ale = arr.isArrayLiteralExp())
-        len = ale.elements.dim;
+        len = ale.elements.length;
     else
     {
         auto tsa = arr.type.toBasetype().isTypeSArray();
@@ -358,7 +358,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
 
     void visitAssocArrayLiteral(AssocArrayLiteralExp e)
     {
-        assert(e.keys.dim == e.values.dim);
+        assert(e.keys.length == e.values.length);
         foreach (i, ref ekey; (*e.keys)[])
         {
             expOptimize(ekey, result & WANTexpand);

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -425,8 +425,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             case TOK.traits:
             Ldeclaration:
                 a = parseDeclarations(false, pAttrs, pAttrs.comment);
-                if (a && a.dim)
-                    *pLastDecl = (*a)[a.dim - 1];
+                if (a && a.length)
+                    *pLastDecl = (*a)[a.length - 1];
                 break;
 
             case TOK.this_:
@@ -698,8 +698,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 if (token.value == TOK.identifier && hasOptionalParensThen(peek(&token), TOK.assign))
                 {
                     a = parseAutoDeclarations(getStorageClass!AST(pAttrs), pAttrs.comment);
-                    if (a && a.dim)
-                        *pLastDecl = (*a)[a.dim - 1];
+                    if (a && a.length)
+                        *pLastDecl = (*a)[a.length - 1];
                     if (pAttrs.udas)
                     {
                         s = new AST.UserAttributeDeclaration(pAttrs.udas, a);
@@ -725,8 +725,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         deprecation("usage of the `body` keyword is deprecated. Use `do` instead.");
 
                     a = parseDeclarations(true, pAttrs, pAttrs.comment);
-                    if (a && a.dim)
-                        *pLastDecl = (*a)[a.dim - 1];
+                    if (a && a.length)
+                        *pLastDecl = (*a)[a.length - 1];
                     if (pAttrs.udas)
                     {
                         s = new AST.UserAttributeDeclaration(pAttrs.udas, a);
@@ -817,8 +817,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     if (res.idents)
                     {
                         assert(res.link == LINK.cpp);
-                        assert(res.idents.dim);
-                        for (size_t i = res.idents.dim; i;)
+                        assert(res.idents.length);
+                        for (size_t i = res.idents.length; i;)
                         {
                             Identifier id = (*res.idents)[--i];
                             if (s)
@@ -833,8 +833,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     else if (res.identExps)
                     {
                         assert(res.link == LINK.cpp);
-                        assert(res.identExps.dim);
-                        for (size_t i = res.identExps.dim; i;)
+                        assert(res.identExps.length);
+                        for (size_t i = res.identExps.length; i;)
                         {
                             AST.Expression exp = (*res.identExps)[--i];
                             if (s)
@@ -1059,7 +1059,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 decldefs.push(s);
                 addComment(s, pAttrs.comment);
             }
-            else if (a && a.dim)
+            else if (a && a.length)
             {
                 decldefs.append(a);
             }
@@ -3786,10 +3786,10 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                                 break;
                             }
                         }
-                        assert(dimStack.dim > 0);
+                        assert(dimStack.length > 0);
                         // We're good. Replay indices in the reverse order.
                         tid = cast(AST.TypeQualified)t;
-                        while (dimStack.dim)
+                        while (dimStack.length)
                         {
                             tid.addIndex(dimStack.pop());
                         }
@@ -4882,7 +4882,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         // parseAttributes shouldn't have set these variables
                         assert(link == linkage && !setAlignment && ealign is null);
                         auto tpl_ = cast(AST.TemplateDeclaration) s;
-                        if (tpl_ is null || tpl_.members.dim != 1)
+                        if (tpl_ is null || tpl_.members.length != 1)
                         {
                             error("user-defined attributes are not allowed on `alias` declarations");
                         }
@@ -4890,7 +4890,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         {
                             auto fd = cast(AST.FuncLiteralDeclaration) (*tpl_.members)[0];
                             auto tf = cast(AST.TypeFunction) fd.type;
-                            assert(tf.parameterList.parameters.dim > 0);
+                            assert(tf.parameterList.parameters.length > 0);
                             auto as = new AST.Dsymbols();
                             (*tf.parameterList.parameters)[0].userAttribDecl = new AST.UserAttributeDeclaration(udas, as);
                         }
@@ -5514,7 +5514,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         nextToken();
 
         AST.Expression aggr = parseExpression();
-        if (token.value == TOK.slice && parameters.dim == 1)
+        if (token.value == TOK.slice && parameters.length == 1)
         {
             AST.Parameter p = (*parameters)[0];
             nextToken();
@@ -5898,11 +5898,11 @@ LagainStc:
         Ldeclaration:
             {
                 AST.Dsymbols* a = parseDeclarations(false, null, null);
-                if (a.dim > 1)
+                if (a.length > 1)
                 {
                     auto as = new AST.Statements();
-                    as.reserve(a.dim);
-                    foreach (i; 0 .. a.dim)
+                    as.reserve(a.length);
+                    foreach (i; 0 .. a.length)
                     {
                         AST.Dsymbol d = (*a)[i];
                         s = new AST.ExpStatement(loc, d);
@@ -5910,7 +5910,7 @@ LagainStc:
                     }
                     s = new AST.CompoundDeclarationStatement(loc, as);
                 }
-                else if (a.dim == 1)
+                else if (a.length == 1)
                 {
                     AST.Dsymbol d = (*a)[0];
                     s = new AST.ExpStatement(loc, d);
@@ -6284,7 +6284,7 @@ LagainStc:
                  */
                 if (token.value == TOK.slice)
                 {
-                    if (cases.dim > 1)
+                    if (cases.length > 1)
                         error("only one `case` allowed for start of case range");
                     nextToken();
                     check(TOK.case_);
@@ -6323,7 +6323,7 @@ LagainStc:
                 else
                 {
                     // Keep cases in order by building the case statements backwards
-                    for (size_t i = cases.dim; i; i--)
+                    for (size_t i = cases.length; i; i--)
                     {
                         exp = cases[i - 1];
                         s = new AST.CaseStatement(loc, exp, s);
@@ -8478,7 +8478,7 @@ LagainStc:
                 while (token.value != TOK.rightBracket && token.value != TOK.endOfFile)
                 {
                     e = parseAssignExp();
-                    if (token.value == TOK.colon && (keys || values.dim == 0))
+                    if (token.value == TOK.colon && (keys || values.length == 0))
                     {
                         nextToken();
                         if (!keys)

--- a/compiler/src/dmd/root/response.d
+++ b/compiler/src/dmd/root/response.d
@@ -56,7 +56,7 @@ const(char)* responseExpandFrom(alias lookup)(ref Strings args) nothrow
     bool recurse = false;
 
     // i is updated by insertArgumentsFromResponse, so no foreach
-    for (size_t i = 0; i < args.dim;)
+    for (size_t i = 0; i < args.length;)
     {
         cp = args[i];
         if (cp[0] != '@')

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -217,7 +217,7 @@ private extern (C++) class S2irVisitor : Visitor
         //printf("PragmaStatement.toIR()\n");
         if (s.ident == Id.startaddress)
         {
-            assert(s.args && s.args.dim == 1);
+            assert(s.args && s.args.length == 1);
             Expression e = (*s.args)[0];
             Dsymbol sa = getDsymbol(e);
             FuncDeclaration f = sa.isFuncDeclaration();
@@ -454,7 +454,7 @@ private extern (C++) class S2irVisitor : Visitor
          */
         mystate.defaultBlock = s.sdefault ? block_calloc(blx) : mystate.breakBlock;
 
-        const numcases = s.cases ? s.cases.dim : 0;
+        const numcases = s.cases ? s.cases.length : 0;
 
         /* allocate a block for each case
          */
@@ -1007,7 +1007,7 @@ private extern (C++) class S2irVisitor : Visitor
             bswitch.Belem = el_combine(el_combine(e1, e2),
                                         el_combine(e3, el_var(shandler)));
 
-            const numcases = s.catches.dim;
+            const numcases = s.catches.length;
             bswitch.Bswitch = cast(targ_llong *) Mem.check(.malloc((targ_llong).sizeof * (numcases + 1)));
             bswitch.Bswitch[0] = numcases;
             bswitch.appendSucc(defaultblock);

--- a/compiler/src/dmd/sapply.d
+++ b/compiler/src/dmd/sapply.d
@@ -68,7 +68,7 @@ public:
 
     override void visit(CompoundStatement s)
     {
-        for (size_t i = 0; i < s.statements.dim; i++)
+        for (size_t i = 0; i < s.statements.length; i++)
             if (doCond((*s.statements)[i]))
                 return;
         applyTo(s);
@@ -76,7 +76,7 @@ public:
 
     override void visit(UnrolledLoopStatement s)
     {
-        for (size_t i = 0; i < s.statements.dim; i++)
+        for (size_t i = 0; i < s.statements.length; i++)
             if (doCond((*s.statements)[i]))
                 return;
         applyTo(s);
@@ -151,7 +151,7 @@ public:
     {
         if (doCond(s._body))
             return;
-        for (size_t i = 0; i < s.catches.dim; i++)
+        for (size_t i = 0; i < s.catches.length; i++)
             if (doCond((*s.catches)[i].handler))
                 return;
         applyTo(s);

--- a/compiler/src/dmd/scanomf.d
+++ b/compiler/src/dmd/scanomf.d
@@ -42,7 +42,7 @@ void scanOmfObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol,
     char[LIBIDMAX + 1] name;
     Strings names;
     scope(exit)
-        for (size_t u = 1; u < names.dim; u++)
+        for (size_t u = 1; u < names.length; u++)
             free(cast(void*)names[u]);
     names.push(null); // don't use index 0
     easyomf = 0; // assume not EASY-OMF
@@ -105,7 +105,7 @@ void scanOmfObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol,
                     parseIdx(&p); // base segment
                 }
                 uint idx = parseIdx(&p); // public name index
-                if (idx == 0 || idx >= names.dim)
+                if (idx == 0 || idx >= names.length)
                 {
                     //debug(printf("[s] name idx=%d, uCntNames=%d\n", idx, uCntNames));
                     error(loc, "corrupt COMDAT");

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -163,7 +163,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
         if (needGagging)
             oldGaggedErrors = global.startGagging();
 
-        for (size_t i = 0; i < tempinst.members.dim; i++)
+        for (size_t i = 0; i < tempinst.members.length; i++)
         {
             Dsymbol s = (*tempinst.members)[i];
             static if (LOG)
@@ -211,7 +211,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
         sc = sc.push(tmix);
         sc.tinst = tmix;
         sc.minst = tmix.minst;
-        for (size_t i = 0; i < tmix.members.dim; i++)
+        for (size_t i = 0; i < tmix.members.length; i++)
         {
             Dsymbol s = (*tmix.members)[i];
             static if (LOG)
@@ -335,7 +335,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
         if (mod.members)
         {
             // Pass 2 semantic routines: do initializers and function bodies
-            for (size_t i = 0; i < mod.members.dim; i++)
+            for (size_t i = 0; i < mod.members.length; i++)
             {
                 Dsymbol s = (*mod.members)[i];
                 s.semantic2(sc);
@@ -522,7 +522,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
             return;
 
         Scope* sc2 = ad.newScope(sc);
-        for (size_t i = 0; i < d.dim; i++)
+        for (size_t i = 0; i < d.length; i++)
         {
             Dsymbol s = (*d)[i];
             s.semantic2(sc2);
@@ -561,7 +561,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
     override void visit(UserAttributeDeclaration uad)
     {
-        if (!uad.decl || !uad.atts || !uad.atts.dim || !uad._scope)
+        if (!uad.decl || !uad.atts || !uad.atts.length || !uad._scope)
             return visit(cast(AttribDeclaration)uad);
 
         Expression* lastTag;
@@ -611,7 +611,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
         ad.determineSize(ad.loc);
 
-        for (size_t i = 0; i < ad.members.dim; i++)
+        for (size_t i = 0; i < ad.members.length; i++)
         {
             Dsymbol s = (*ad.members)[i];
             //printf("\t[%d] %s\n", i, s.toChars());

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -127,7 +127,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
         if (needGagging)
             oldGaggedErrors = global.startGagging();
 
-        for (size_t i = 0; i < tempinst.members.dim; i++)
+        for (size_t i = 0; i < tempinst.members.length; i++)
         {
             Dsymbol s = (*tempinst.members)[i];
             s.semantic3(sc);
@@ -170,7 +170,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
         uint olderrors = global.errors;
 
-        for (size_t i = 0; i < tmix.members.dim; i++)
+        for (size_t i = 0; i < tmix.members.length; i++)
         {
             Dsymbol s = (*tmix.members)[i];
             s.semantic3(sc);
@@ -197,7 +197,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
         if (mod.members)
         {
             // Pass 3 semantic routines: do initializers and function bodies
-            for (size_t i = 0; i < mod.members.dim; i++)
+            for (size_t i = 0; i < mod.members.length; i++)
             {
                 Dsymbol s = (*mod.members)[i];
                 //printf("Module %s: %s.semantic3()\n", toChars(), s.toChars());
@@ -586,7 +586,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                  */
                 if (ad2 && funcdecl.isCtorDeclaration())
                 {
-                    sc2.ctorflow.allocFieldinit(ad2.fields.dim);
+                    sc2.ctorflow.allocFieldinit(ad2.fields.length);
                     foreach (v; ad2.fields)
                     {
                         v.ctorinit = 0;
@@ -624,7 +624,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 if (funcdecl.returns && !funcdecl.fbody.isErrorStatement())
                 {
-                    for (size_t i = 0; i < funcdecl.returns.dim;)
+                    for (size_t i = 0; i < funcdecl.returns.length;)
                     {
                         Expression exp = (*funcdecl.returns)[i].exp;
                         if (exp.op == EXP.variable && (cast(VarExp)exp).var == funcdecl.vresult)
@@ -661,7 +661,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                      * ctor consts were initialized.
                      */
                     ScopeDsymbol pd = funcdecl.toParent().isScopeDsymbol();
-                    for (size_t i = 0; i < pd.members.dim; i++)
+                    for (size_t i = 0; i < pd.members.length; i++)
                     {
                         Dsymbol s = (*pd.members)[i];
                         s.checkCtorConstInit();
@@ -829,7 +829,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     /* Cannot move this loop into NrvoWalker, because
                      * returns[i] may be in the nested delegate for foreach-body.
                      */
-                    for (size_t i = 0; i < funcdecl.returns.dim; i++)
+                    for (size_t i = 0; i < funcdecl.returns.length; i++)
                     {
                         ReturnStatement rs = (*funcdecl.returns)[i];
                         Expression exp = rs.exp;
@@ -1068,7 +1068,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 // Merge in initialization of 'out' parameters
                 if (funcdecl.parameters)
                 {
-                    for (size_t i = 0; i < funcdecl.parameters.dim; i++)
+                    for (size_t i = 0; i < funcdecl.parameters.length; i++)
                     {
                         VarDeclaration v = (*funcdecl.parameters)[i];
                         if (v.storage_class & STC.out_)
@@ -1253,7 +1253,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             // Fix up forward-referenced gotos
             if (funcdecl.gotos && !funcdecl.isCsymbol())
             {
-                for (size_t i = 0; i < funcdecl.gotos.dim; ++i)
+                for (size_t i = 0; i < funcdecl.gotos.length; ++i)
                 {
                     (*funcdecl.gotos)[i].checkLabel();
                 }
@@ -1526,7 +1526,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             return;
 
         Scope* sc2 = ad.newScope(sc);
-        for (size_t i = 0; i < d.dim; i++)
+        for (size_t i = 0; i < d.length; i++)
         {
             Dsymbol s = (*d)[i];
             s.semantic3(sc2);
@@ -1551,7 +1551,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
         auto sc2 = ad.newScope(sc);
 
-        for (size_t i = 0; i < ad.members.dim; i++)
+        for (size_t i = 0; i < ad.members.length; i++)
         {
             Dsymbol s = (*ad.members)[i];
             s.semantic3(sc2);
@@ -1612,7 +1612,7 @@ private struct FuncDeclSem3
     {
         if (funcdecl.frequires)
         {
-            for (size_t i = 0; i < funcdecl.foverrides.dim; i++)
+            for (size_t i = 0; i < funcdecl.foverrides.length; i++)
             {
                 FuncDeclaration fdv = funcdecl.foverrides[i];
                 if (fdv.fbody && !fdv.frequires)

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -610,7 +610,7 @@ extern (C++) class CompoundStatement : Statement
     override final inout(Statement) last() inout nothrow pure
     {
         Statement s = null;
-        for (size_t i = statements.dim; i; --i)
+        for (size_t i = statements.length; i; --i)
         {
             s = cast(Statement)(*statements)[i - 1];
             if (s)
@@ -640,7 +640,7 @@ extern (C++) final class CompoundDeclarationStatement : CompoundStatement
 
     override CompoundDeclarationStatement syntaxCopy()
     {
-        auto a = new Statements(statements.dim);
+        auto a = new Statements(statements.length);
         foreach (i, s; *statements)
         {
             (*a)[i] = s ? s.syntaxCopy() : null;
@@ -670,7 +670,7 @@ extern (C++) final class UnrolledLoopStatement : Statement
 
     override UnrolledLoopStatement syntaxCopy()
     {
-        auto a = new Statements(statements.dim);
+        auto a = new Statements(statements.length);
         foreach (i, s; *statements)
         {
             (*a)[i] = s ? s.syntaxCopy() : null;
@@ -1571,7 +1571,7 @@ extern (C++) final class TryCatchStatement : Statement
 
     override TryCatchStatement syntaxCopy()
     {
-        auto a = new Catches(catches.dim);
+        auto a = new Catches(catches.length);
         foreach (i, c; *catches)
         {
             (*a)[i] = c.syntaxCopy();
@@ -2019,7 +2019,7 @@ extern (C++) final class CompoundAsmStatement : CompoundStatement
 
     override CompoundAsmStatement syntaxCopy()
     {
-        auto a = new Statements(statements.dim);
+        auto a = new Statements(statements.length);
         foreach (i, s; *statements)
         {
             (*a)[i] = s ? s.syntaxCopy() : null;
@@ -2048,7 +2048,7 @@ extern (C++) final class ImportStatement : Statement
 
     override ImportStatement syntaxCopy()
     {
-        auto m = new Dsymbols(imports.dim);
+        auto m = new Dsymbols(imports.length);
         foreach (i, s; *imports)
         {
             (*m)[i] = s.syntaxCopy(null);

--- a/compiler/src/dmd/statement_rewrite_walker.d
+++ b/compiler/src/dmd/statement_rewrite_walker.d
@@ -48,9 +48,9 @@ public:
 
     override void visit(CompoundStatement s)
     {
-        if (s.statements && s.statements.dim)
+        if (s.statements && s.statements.length)
         {
-            for (size_t i = 0; i < s.statements.dim; i++)
+            for (size_t i = 0; i < s.statements.length; i++)
             {
                 if ((*s.statements)[i])
                     visitStmt((*s.statements)[i]);
@@ -65,9 +65,9 @@ public:
 
     override void visit(UnrolledLoopStatement s)
     {
-        if (s.statements && s.statements.dim)
+        if (s.statements && s.statements.length)
         {
-            for (size_t i = 0; i < s.statements.dim; i++)
+            for (size_t i = 0; i < s.statements.length; i++)
             {
                 if ((*s.statements)[i])
                     visitStmt((*s.statements)[i]);
@@ -161,9 +161,9 @@ public:
     {
         if (s._body)
             visitStmt(s._body);
-        if (s.catches && s.catches.dim)
+        if (s.catches && s.catches.length)
         {
-            for (size_t i = 0; i < s.catches.dim; i++)
+            for (size_t i = 0; i < s.catches.length; i++)
             {
                 Catch c = (*s.catches)[i];
                 if (c && c.handler)

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -249,7 +249,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
             }
         }
 
-        for (size_t i = 0; i < cs.statements.dim;)
+        for (size_t i = 0; i < cs.statements.length;)
         {
             Statement s = (*cs.statements)[i];
             if (!s)
@@ -312,7 +312,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                     return true;
                 }
 
-                if (!sfinally && isEmpty((*cs.statements)[i + 1 .. cs.statements.dim]))
+                if (!sfinally && isEmpty((*cs.statements)[i + 1 .. cs.statements.length]))
                 {
                 }
                 else
@@ -358,7 +358,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
             }
             else if (sfinally)
             {
-                if (0 && i + 1 == cs.statements.dim)
+                if (0 && i + 1 == cs.statements.length)
                 {
                     cs.statements.push(sfinally);
                 }
@@ -693,7 +693,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
         }
 
         const loc = fs.loc;
-        const dim = fs.parameters.dim;
+        const dim = fs.parameters.length;
 
         fs.func = sc.func;
         if (fs.func.fes)
@@ -791,7 +791,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                 }
             }
 
-            //printf("dim = %d, parameters.dim = %d\n", dim, parameters.dim);
+            //printf("dim = %d, parameters.length = %d\n", dim, parameters.length);
             if (foundMismatch && dim != foreachParamCount)
             {
                 const(char)* plural = foreachParamCount > 1 ? "s" : "";
@@ -877,7 +877,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                     tfld = cast(TypeFunction)tab.nextOf();
                 Lget:
                     //printf("tfld = %s\n", tfld.toChars());
-                    if (tfld.parameterList.parameters.dim == 1)
+                    if (tfld.parameterList.parameters.length == 1)
                     {
                         Parameter p = tfld.parameterList[0];
                         if (p.type && p.type.ty == Tdelegate)
@@ -902,7 +902,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                 {
                     // 'Promote' it to this scope, and replace with a return
                     fs.cases.push(gs);
-                    ss.statement = new ReturnStatement(Loc.initial, new IntegerExp(fs.cases.dim + 1));
+                    ss.statement = new ReturnStatement(Loc.initial, new IntegerExp(fs.cases.length + 1));
                 }
             }
 
@@ -1075,7 +1075,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                 if (fs.aggr.op == EXP.arrayLiteral && !valueIsRef)
                 {
                     auto ale = cast(ArrayLiteralExp)fs.aggr;
-                    size_t edim = ale.elements ? ale.elements.dim : 0;
+                    size_t edim = ale.elements ? ale.elements.length : 0;
                     auto telem = (*fs.parameters)[dim - 1].type;
 
                     // https://issues.dlang.org/show_bug.cgi?id=12936
@@ -1323,17 +1323,17 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                     auto exps = new Expressions();
                     exps.push(ve);
                     int pos = 0;
-                    while (exps.dim < dim)
+                    while (exps.length < dim)
                     {
                         pos = expandAliasThisTuples(exps, pos);
                         if (pos == -1)
                             break;
                     }
-                    if (exps.dim != dim)
+                    if (exps.length != dim)
                     {
-                        const(char)* plural = exps.dim > 1 ? "s" : "";
+                        const(char)* plural = exps.length > 1 ? "s" : "";
                         fs.error("cannot infer argument types, expected %llu argument%s, not %llu",
-                            cast(ulong) exps.dim, plural, cast(ulong) dim);
+                            cast(ulong) exps.length, plural, cast(ulong) dim);
                         return retError();
                     }
 
@@ -1453,7 +1453,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                                                    Scope* sc2, Type tn, Type tnv, TY tabty)
     {
         Expression ec;
-        const dim = fs.parameters.dim;
+        const dim = fs.parameters.length;
         const loc = fs.loc;
         /* Call:
          *      _aApply(aggr, flde)
@@ -1519,7 +1519,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
     private static extern(D) Expression applyAssocArray(ForeachStatement fs, Expression flde, TypeAArray taa)
     {
         Expression ec;
-        const dim = fs.parameters.dim;
+        const dim = fs.parameters.length;
         // Check types
         Parameter p = (*fs.parameters)[0];
         bool isRef = (p.storageClass & STC.ref_) != 0;
@@ -1593,7 +1593,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
 
     private static extern(D) Statement loopReturn(Expression e, Statements* cases, const ref Loc loc)
     {
-        if (!cases.dim)
+        if (!cases.length)
         {
             // Easy case, a clean exit from the loop
             e = new CastExp(loc, e, Type.tvoid); // https://issues.dlang.org/show_bug.cgi?id=13899
@@ -2024,7 +2024,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
             }
             else
             {
-                if (!ps.args || ps.args.dim != 1)
+                if (!ps.args || ps.args.length != 1)
                 {
                     ps.error("`string` expected for library name");
                     return setError();
@@ -2338,7 +2338,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
 
         size_t numcases = 0;
         if (ss.cases)
-            numcases = ss.cases.dim;
+            numcases = ss.cases.length;
 
         for (size_t i = 0; i < numcases; i++)
         {
@@ -2501,7 +2501,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
             sw.cases.push(cs);
 
             // Resolve any goto case's with no exp to this case statement
-            for (size_t i = 0; i < sw.gotoCases.dim;)
+            for (size_t i = 0; i < sw.gotoCases.length;)
             {
                 GotoCaseStatement gcs = sw.gotoCases[i];
                 if (!gcs.exp)
@@ -2735,7 +2735,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
             {
                 assert(rs.caseDim == 0);
                 sc.fes.cases.push(rs);
-                result = new ReturnStatement(Loc.initial, new IntegerExp(sc.fes.cases.dim + 1));
+                result = new ReturnStatement(Loc.initial, new IntegerExp(sc.fes.cases.length + 1));
                 return;
             }
             if (fd.returnLabel)
@@ -3053,8 +3053,8 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                 sc.fes.cases.push(s);
 
                 // Immediately rewrite "this" return statement as:
-                //  return cases.dim+1;
-                rs.exp = new IntegerExp(sc.fes.cases.dim + 1);
+                //  return cases.length+1;
+                rs.exp = new IntegerExp(sc.fes.cases.length + 1);
                 if (e0)
                 {
                     result = new CompoundStatement(rs.loc, new ExpStatement(rs.loc, e0), rs);
@@ -3078,7 +3078,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                 //  return exp;
                 // to:
                 //  vresult = exp; retrun caseDim;
-                rs.caseDim = sc.fes.cases.dim + 1;
+                rs.caseDim = sc.fes.cases.length + 1;
             }
         }
         if (rs.exp)
@@ -3136,7 +3136,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                          * and 1 is break.
                          */
                         sc.fes.cases.push(bs);
-                        result = new ReturnStatement(Loc.initial, new IntegerExp(sc.fes.cases.dim + 1));
+                        result = new ReturnStatement(Loc.initial, new IntegerExp(sc.fes.cases.length + 1));
                         return;
                     }
                     break; // can't break to it
@@ -3224,7 +3224,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                          * and 1 is break.
                          */
                         sc.fes.cases.push(cs);
-                        result = new ReturnStatement(Loc.initial, new IntegerExp(sc.fes.cases.dim + 1));
+                        result = new ReturnStatement(Loc.initial, new IntegerExp(sc.fes.cases.length + 1));
                         return;
                     }
                     break; // can't continue to it
@@ -3589,7 +3589,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
          */
         if (!(tcs._body.blockExit(sc.func, false) & BE.throw_) && ClassDeclaration.exception)
         {
-            foreach_reverse (i; 0 .. tcs.catches.dim)
+            foreach_reverse (i; 0 .. tcs.catches.length)
             {
                 Catch c = (*tcs.catches)[i];
 
@@ -3604,7 +3604,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
             }
         }
 
-        if (tcs.catches.dim == 0)
+        if (tcs.catches.length == 0)
         {
             result = tcs._body.hasCode() ? tcs._body : null;
             return;
@@ -3909,10 +3909,10 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
         /* https://dlang.org/spec/module.html#ImportDeclaration
          */
 
-        foreach (i; 0 .. imps.imports.dim)
+        foreach (i; 0 .. imps.imports.length)
         {
             Import s = (*imps.imports)[i].isImport();
-            assert(!s.aliasdecls.dim);
+            assert(!s.aliasdecls.length);
             foreach (j, name; s.names)
             {
                 Identifier _alias = s.aliases[j];
@@ -4217,7 +4217,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
     }
 
     auto loc = fs.loc;
-    size_t dim = fs.parameters.dim;
+    size_t dim = fs.parameters.length;
     const bool skipCheck = isStatic && needExpansion;
     if (!skipCheck && (dim < 1 || dim > 2))
     {
@@ -4251,7 +4251,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
     if (fs.aggr.op == EXP.tuple) // expression tuple
     {
         te = cast(TupleExp)fs.aggr;
-        n = te.exps.dim;
+        n = te.exps.length;
     }
     else if (fs.aggr.op == EXP.type) // type tuple
     {
@@ -4632,7 +4632,7 @@ private Statements* flatten(Statement statement, Scope* sc)
             {
                 return a;
             }
-            auto b = new Statements(a.dim);
+            auto b = new Statements(a.length);
             foreach (i, s; *a)
             {
                 (*b)[i] = s ? new ForwardingStatement(s.loc, fs.sym, s) : null;
@@ -4702,7 +4702,7 @@ private Statements* flatten(Statement statement, Scope* sc)
             if (!a)
                 return null;
 
-            if (!a.dim)
+            if (!a.length)
             {
                 a.push(new ExpStatement(ls.loc, cast(Expression)null));
             }
@@ -4892,7 +4892,7 @@ bool pragmaMsgSemantic(Loc loc, Scope* sc, Expressions* args)
  */
 bool pragmaStartAddressSemantic(Loc loc, Scope* sc, Expressions* args)
 {
-    if (!args || args.dim != 1)
+    if (!args || args.length != 1)
     {
         .error(loc, "function name expected for start address");
         return false;

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -793,7 +793,7 @@ extern (C++) struct Target
                     return true;
                 if (!sd.isPOD() || sz > 8)
                     return true;
-                if (sd.fields.dim == 0)
+                if (sd.fields.length == 0)
                     return true;
             }
             if (sz <= 16 && !(sz & (sz - 1)))
@@ -815,7 +815,7 @@ extern (C++) struct Target
             if (!tt)
                 return false; // void
             else
-                return !tt.arguments.dim;
+                return !tt.arguments.length;
         }
 
     Lagain:

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -260,7 +260,7 @@ Symbol *toSymbol(Dsymbol s)
                 s.Sclass = SC.auto_;
                 s.Sfl = FLauto;
 
-                if (vd.nestedrefs.dim)
+                if (vd.nestedrefs.length)
                 {
                     /* Symbol is accessed by a nested function. Make sure
                      * it is not put in a register, and that the optimizer

--- a/compiler/src/dmd/tocvdebug.d
+++ b/compiler/src/dmd/tocvdebug.d
@@ -155,7 +155,7 @@ uint cv4_Denum(EnumDeclaration e)
     CvFieldList mc = CvFieldList(0, 0);
     if (!property)
     {
-        for (size_t i = 0; i < e.members.dim; i++)
+        for (size_t i = 0; i < e.members.length; i++)
         {
             EnumMember sf = (*e.members)[i].isEnumMember();
             if (!sf)
@@ -212,7 +212,7 @@ uint cv4_Denum(EnumDeclaration e)
         mc.alloc();
 
         // And fill it in
-        for (size_t i = 0; i < e.members.dim; i++)
+        for (size_t i = 0; i < e.members.length; i++)
         {
             EnumMember sf = (*e.members)[i].isEnumMember();
             if (!sf)
@@ -557,7 +557,7 @@ void toDebug(StructDeclaration sd)
 
     // Compute the number of fields and the length of the fieldlist record
     CvFieldList mc = CvFieldList(0, 0);
-    for (size_t i = 0; i < sd.members.dim; i++)
+    for (size_t i = 0; i < sd.members.length; i++)
     {
         Dsymbol s = (*sd.members)[i];
         s.apply(&cv_mem_count, &mc);
@@ -568,7 +568,7 @@ void toDebug(StructDeclaration sd)
     mc.alloc();
     if (nfields)
     {
-        for (size_t i = 0; i < sd.members.dim; i++)
+        for (size_t i = 0; i < sd.members.length; i++)
         {
             Dsymbol s = (*sd.members)[i];
             s.apply(&cv_mem_p, &mc);
@@ -647,7 +647,7 @@ void toDebug(ClassDeclaration cd)
     idx_t vshapeidx = 0;
     if (1)
     {
-        const size_t dim = cd.vtbl.dim;              // number of virtual functions
+        const size_t dim = cd.vtbl.length;              // number of virtual functions
         if (dim)
         {   // 4 bits per descriptor
             debtyp_t *vshape = debtyp_alloc(cast(uint)(4 + (dim + 1) / 2));
@@ -656,7 +656,7 @@ void toDebug(ClassDeclaration cd)
 
             size_t n = 0;
             ubyte descriptor = 0;
-            for (size_t i = 0; i < cd.vtbl.dim; i++)
+            for (size_t i = 0; i < cd.vtbl.length; i++)
             {
                 //if (intsize == 4)
                     descriptor |= 5;
@@ -715,7 +715,7 @@ void toDebug(ClassDeclaration cd)
     if (addInBaseClasses)
     {
         // Add in base classes
-        for (size_t i = 0; i < cd.baseclasses.dim; i++)
+        for (size_t i = 0; i < cd.baseclasses.length; i++)
         {
             const bc = (*cd.baseclasses)[i];
             const uint elementlen = 4 + cgcv.sz_idx + cv4_numericbytes(bc.offset);
@@ -723,7 +723,7 @@ void toDebug(ClassDeclaration cd)
         }
     }
 
-    for (size_t i = 0; i < cd.members.dim; i++)
+    for (size_t i = 0; i < cd.members.length; i++)
     {
         Dsymbol s = (*cd.members)[i];
         s.apply(&cv_mem_count, &mc);
@@ -743,7 +743,7 @@ void toDebug(ClassDeclaration cd)
             ubyte* p = base;
 
             // Add in base classes
-            for (size_t i = 0; i < cd.baseclasses.dim; i++)
+            for (size_t i = 0; i < cd.baseclasses.length; i++)
             {
                 BaseClass *bc = (*cd.baseclasses)[i];
                 const idx_t typidx2 = cv4_typidx(Type_toCtype(bc.sym.type).Tnext);

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -458,7 +458,7 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
         //printf("ArrayLiteralExp.toDt() '%s', type = %s\n", e.toChars(), e.type.toChars());
 
         auto dtbarray = DtBuilder(0);
-        foreach (i; 0 .. e.elements.dim)
+        foreach (i; 0 .. e.elements.length)
         {
             Expression_toDt(e[i], dtbarray);
         }
@@ -471,7 +471,7 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
                 break;
 
             case Tarray:
-                dtb.size(e.elements.dim);
+                dtb.size(e.elements.length);
                 goto case Tpointer;
 
             case Tpointer:
@@ -501,7 +501,7 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
     void visitStructLiteral(StructLiteralExp sle)
     {
         //printf("StructLiteralExp.toDt() %s, ctfe = %d\n", sle.toChars(), sle.ownedByCtfe);
-        assert(sle.sd.nonHiddenFields() <= sle.elements.dim);
+        assert(sle.sd.nonHiddenFields() <= sle.elements.length);
         membersToDt(sle.sd, dtb, sle.elements, 0, null, null);
     }
 
@@ -763,14 +763,14 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
             // Insert { base class }
             size_t index = 0;
             for (ClassDeclaration c = cdb.baseClass; c; c = c.baseClass)
-                index += c.fields.dim;
+                index += c.fields.length;
             membersToDt(cdb, dtb, elements, index, concreteType, null);
             offset = cdb.structsize;
         }
         else if (InterfaceDeclaration id = cd.isInterfaceDeclaration())
         {
             offset = (**ppb).offset;
-            if (id.vtblInterfaces.dim == 0 && genclassinfo)
+            if (id.vtblInterfaces.length == 0 && genclassinfo)
             {
                 BaseClass* b = **ppb;
                 //printf("  Interface %s, b = %p\n", id.toChars(), b);
@@ -829,8 +829,8 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
     // `offset` now is where the fields start
 
     assert(!elements ||
-           firstFieldIndex <= elements.dim &&
-           firstFieldIndex + ad.fields.dim <= elements.dim);
+           firstFieldIndex <= elements.length &&
+           firstFieldIndex + ad.fields.length <= elements.length);
 
     uint bitByteOffset = 0;     // byte offset of bit field
     uint bitOffset = 0;         // starting bit number
@@ -1095,7 +1095,7 @@ private void toDtElem(TypeSArray tsa, ref DtBuilder dtb, Expression e, bool isCt
             if (auto se = e.isStringExp())
                 len /= se.numberOfCodeUnits();
             else if (auto ae = e.isArrayLiteralExp())
-                len /= ae.elements.dim;
+                len /= ae.elements.length;
         }
 
         auto dtb2 = DtBuilder(0);
@@ -1127,7 +1127,7 @@ extern (C++) void ClassReferenceExp_toInstanceDt(ClassReferenceExp ce, ref DtBui
     // Put in the rest
     size_t firstFieldIndex = 0;
     for (ClassDeclaration c = cd.baseClass; c; c = c.baseClass)
-        firstFieldIndex += c.fields.dim;
+        firstFieldIndex += c.fields.length;
     membersToDt(cd, dtb, ce.value.elements, firstFieldIndex, cd, null);
 }
 
@@ -1606,7 +1606,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tu = d.tinfo.isTypeTuple();
 
-        const dim = tu.arguments.dim;
+        const dim = tu.arguments.length;
         dtb.size(dim);                       // elements.length
 
         auto dtbargs = DtBuilder(0);

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -227,7 +227,7 @@ elem *getEthis(const ref Loc loc, IRState *irs, Dsymbol fd, Dsymbol fdp = null, 
         FuncDeclaration fdthis = thisfd;
         for (size_t i = 0; ; )
         {
-            if (i == fdthis.foverrides.dim)
+            if (i == fdthis.foverrides.length)
             {
                 if (i == 0)
                     break;
@@ -828,7 +828,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
         symbol_add(sclosure);
         irs.sclosure = sclosure;
 
-        assert(fd.closureVars.dim);
+        assert(fd.closureVars.length);
         assert(fd.closureVars[0].offset >= target.ptrsize);
         foreach (v; fd.closureVars)
         {
@@ -863,7 +863,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
         }
 
         // Calculate the size of the closure
-        VarDeclaration  vlast = fd.closureVars[fd.closureVars.dim - 1];
+        VarDeclaration  vlast = fd.closureVars[fd.closureVars.length - 1];
         typeof(Type.size()) lastsize;
         if (vlast.storage_class & STC.lazy_)
             lastsize = target.ptrsize * 2;
@@ -959,7 +959,7 @@ void buildCapture(FuncDeclaration fd)
     if (target.objectFormat() != Target.ObjectFormat.coff)  // toDebugClosure only implemented for CodeView,
         return;                 //  but optlink crashes for negative field offsets
 
-    if (fd.closureVars.dim && !fd.needsClosure)
+    if (fd.closureVars.length && !fd.needsClosure)
     {
         /* Generate type name for struct with captured variables */
         const char *name1 = "CAPTURE.";

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -100,8 +100,8 @@ void genModuleInfo(Module m)
     auto dtb = DtBuilder(0);
     ClassDeclarations aclasses;
 
-    //printf("members.dim = %d\n", members.dim);
-    foreach (i; 0 .. m.members.dim)
+    //printf("members.length = %d\n", members.length);
+    foreach (i; 0 .. m.members.length)
     {
         Dsymbol member = (*m.members)[i];
 
@@ -110,8 +110,8 @@ void genModuleInfo(Module m)
     }
 
     // importedModules[]
-    size_t aimports_dim = m.aimports.dim;
-    for (size_t i = 0; i < m.aimports.dim; i++)
+    size_t aimports_dim = m.aimports.length;
+    for (size_t i = 0; i < m.aimports.length; i++)
     {
         Module mod = m.aimports[i];
         if (!mod.needmoduleinfo)
@@ -155,7 +155,7 @@ void genModuleInfo(Module m)
         flags |= MIunitTest;
     if (aimports_dim)
         flags |= MIimportedModules;
-    if (aclasses.dim)
+    if (aclasses.length)
         flags |= MIlocalClasses;
     flags |= MIname;
 
@@ -179,7 +179,7 @@ void genModuleInfo(Module m)
     if (flags & MIimportedModules)
     {
         dtb.size(aimports_dim);
-        foreach (i; 0 .. m.aimports.dim)
+        foreach (i; 0 .. m.aimports.length)
         {
             Module mod = m.aimports[i];
 
@@ -198,8 +198,8 @@ void genModuleInfo(Module m)
     }
     if (flags & MIlocalClasses)
     {
-        dtb.size(aclasses.dim);
-        foreach (i; 0 .. aclasses.dim)
+        dtb.size(aclasses.length);
+        foreach (i; 0 .. aclasses.length)
         {
             ClassDeclaration cd = aclasses[i];
             dtb.xoff(toSymbol(cd), 0, TYnptr);
@@ -263,7 +263,7 @@ void write_instance_pointers(Type type, Symbol *s, uint offset)
     const bytes_size_t = cast(size_t)Type.tsize_t.size(Loc.initial);
     const bits_size_t = bytes_size_t * 8;
     auto words = cast(size_t)(sz / bytes_size_t);
-    for (size_t i = 0; i < data.dim; i++)
+    for (size_t i = 0; i < data.length; i++)
     {
         size_t bits = words < bits_size_t ? words : bits_size_t;
         for (size_t b = 0; b < bits; b++)
@@ -404,7 +404,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             auto dtbv = DtBuilder(0);
             if (cd.vtblOffset())
                 dtbv.xoff(cd.csym, 0, TYnptr);           // first entry is ClassInfo reference
-            foreach (i; cd.vtblOffset() .. cd.vtbl.dim)
+            foreach (i; cd.vtblOffset() .. cd.vtbl.length)
             {
                 FuncDeclaration fd = cd.vtbl[i].isFuncDeclaration();
 
@@ -756,7 +756,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
             if (d)
             {
-                for (size_t i = 0; i < d.dim; i++)
+                for (size_t i = 0; i < d.length; i++)
                 {
                     Dsymbol s = (*d)[i];
                     s.accept(this);
@@ -768,7 +768,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
         {
             if (pd.ident == Id.lib)
             {
-                assert(pd.args && pd.args.dim == 1);
+                assert(pd.args && pd.args.length == 1);
 
                 Expression e = (*pd.args)[0];
 
@@ -793,7 +793,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             }
             else if (pd.ident == Id.startaddress)
             {
-                assert(pd.args && pd.args.dim == 1);
+                assert(pd.args && pd.args.length == 1);
                 Expression e = (*pd.args)[0];
                 Dsymbol sa = getDsymbol(e);
                 FuncDeclaration f = sa.isFuncDeclaration();
@@ -803,7 +803,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             }
             else if (pd.ident == Id.linkerDirective)
             {
-                assert(pd.args && pd.args.dim == 1);
+                assert(pd.args && pd.args.length == 1);
 
                 Expression e = (*pd.args)[0];
 
@@ -1039,7 +1039,7 @@ private bool finishVtbl(ClassDeclaration cd)
 {
     bool hasError = false;
 
-    foreach (i; cd.vtblOffset() .. cd.vtbl.dim)
+    foreach (i; cd.vtblOffset() .. cd.vtbl.length)
     {
         FuncDeclaration fd = cd.vtbl[i].isFuncDeclaration();
 
@@ -1066,7 +1066,7 @@ private bool finishVtbl(ClassDeclaration cd)
          * If fd overlaps with any function in the vtbl[], then
          * issue 'hidden' error.
          */
-        foreach (j; 1 .. cd.vtbl.dim)
+        foreach (j; 1 .. cd.vtbl.length)
         {
             if (j == i)
                 continue;
@@ -1104,15 +1104,15 @@ uint baseVtblOffset(ClassDeclaration cd, BaseClass *bc)
 {
     //printf("ClassDeclaration.baseVtblOffset('%s', bc = %p)\n", cd.toChars(), bc);
     uint csymoffset = target.classinfosize;    // must be ClassInfo.size
-    csymoffset += cd.vtblInterfaces.dim * (4 * target.ptrsize);
+    csymoffset += cd.vtblInterfaces.length * (4 * target.ptrsize);
 
-    for (size_t i = 0; i < cd.vtblInterfaces.dim; i++)
+    for (size_t i = 0; i < cd.vtblInterfaces.length; i++)
     {
         BaseClass *b = (*cd.vtblInterfaces)[i];
 
         if (b == bc)
             return csymoffset;
-        csymoffset += b.sym.vtbl.dim * target.ptrsize;
+        csymoffset += b.sym.vtbl.length * target.ptrsize;
     }
 
     // Put out the overriding interface vtbl[]s.
@@ -1122,7 +1122,7 @@ uint baseVtblOffset(ClassDeclaration cd, BaseClass *bc)
 
     for (cd2 = cd.baseClass; cd2; cd2 = cd2.baseClass)
     {
-        foreach (k; 0 .. cd2.vtblInterfaces.dim)
+        foreach (k; 0 .. cd2.vtblInterfaces.length)
         {
             BaseClass *bs = (*cd2.vtblInterfaces)[k];
             if (bs.fillVtbl(cd, null, 0))
@@ -1132,7 +1132,7 @@ uint baseVtblOffset(ClassDeclaration cd, BaseClass *bc)
                     //printf("\tcsymoffset = x%x\n", csymoffset);
                     return csymoffset;
                 }
-                csymoffset += bs.sym.vtbl.dim * target.ptrsize;
+                csymoffset += bs.sym.vtbl.length * target.ptrsize;
             }
         }
     }
@@ -1156,8 +1156,8 @@ private size_t emitVtbl(ref DtBuilder dtb, BaseClass *b, ref FuncDeclarations bv
     //printf("\toverriding vtbl[] for %s\n", b.sym.toChars());
     ClassDeclaration id = b.sym;
 
-    const id_vtbl_dim = id.vtbl.dim;
-    assert(id_vtbl_dim <= bvtbl.dim);
+    const id_vtbl_dim = id.vtbl.length;
+    assert(id_vtbl_dim <= bvtbl.length);
 
     size_t jstart = 0;
     if (id.vtblOffset())
@@ -1263,15 +1263,15 @@ private void genClassInfoForClass(ClassDeclaration cd, Symbol* sinit)
     dt_t *pdtname = dtb.xoffpatch(cd.csym, 0, TYnptr);
 
     // vtbl[]
-    dtb.size(cd.vtbl.dim);
-    if (cd.vtbl.dim)
+    dtb.size(cd.vtbl.length);
+    if (cd.vtbl.length)
         dtb.xoff(cd.vtblsym.csym, 0, TYnptr);
     else
         dtb.size(0);
 
     // interfaces[]
-    dtb.size(cd.vtblInterfaces.dim);
-    if (cd.vtblInterfaces.dim)
+    dtb.size(cd.vtblInterfaces.length);
+    if (cd.vtblInterfaces.length)
         dtb.xoff(cd.csym, offset, TYnptr);      // (*)
     else
         dtb.size(0);
@@ -1319,7 +1319,7 @@ Louter:
     {
         if (pc.members)
         {
-            for (size_t i = 0; i < pc.members.dim; i++)
+            for (size_t i = 0; i < pc.members.length; i++)
             {
                 Dsymbol sm = (*pc.members)[i];
                 //printf("sm = %s %s\n", sm.kind(), sm.toChars());
@@ -1361,8 +1361,8 @@ Louter:
     // Put out (*vtblInterfaces)[]. Must immediately follow csym, because
     // of the fixup (*)
 
-    offset += cd.vtblInterfaces.dim * (4 * target.ptrsize);
-    for (size_t i = 0; i < cd.vtblInterfaces.dim; i++)
+    offset += cd.vtblInterfaces.length * (4 * target.ptrsize);
+    for (size_t i = 0; i < cd.vtblInterfaces.length; i++)
     {
         BaseClass *b = (*cd.vtblInterfaces)[i];
         ClassDeclaration id = b.sym;
@@ -1383,7 +1383,7 @@ Louter:
         dtb.xoff(toSymbol(id), 0, TYnptr);
 
         // vtbl[]
-        dtb.size(id.vtbl.dim);
+        dtb.size(id.vtbl.length);
         dtb.xoff(cd.csym, offset, TYnptr);
 
         // offset
@@ -1392,8 +1392,8 @@ Louter:
 
     // Put out the (*vtblInterfaces)[].vtbl[]
     // This must be mirrored with ClassDeclaration.baseVtblOffset()
-    //printf("putting out %d interface vtbl[]s for '%s'\n", vtblInterfaces.dim, toChars());
-    foreach (i; 0 .. cd.vtblInterfaces.dim)
+    //printf("putting out %d interface vtbl[]s for '%s'\n", vtblInterfaces.length, toChars());
+    foreach (i; 0 .. cd.vtblInterfaces.length)
     {
         BaseClass *b = (*cd.vtblInterfaces)[i];
         offset += emitVtbl(dtb, b, b.vtbl, cd, i);
@@ -1404,7 +1404,7 @@ Louter:
     //printf("putting out overriding interface vtbl[]s for '%s' at offset x%x\n", toChars(), offset);
     for (ClassDeclaration pc = cd.baseClass; pc; pc = pc.baseClass)
     {
-        foreach (i; 0 .. pc.vtblInterfaces.dim)
+        foreach (i; 0 .. pc.vtblInterfaces.length)
         {
             BaseClass *b = (*pc.vtblInterfaces)[i];
             FuncDeclarations bvtbl;
@@ -1494,8 +1494,8 @@ private void genClassInfoForInterface(InterfaceDeclaration id)
 
     // interfaces[]
     uint offset = target.classinfosize;
-    dtb.size(id.vtblInterfaces.dim);
-    if (id.vtblInterfaces.dim)
+    dtb.size(id.vtblInterfaces.length);
+    if (id.vtblInterfaces.length)
     {
         if (Type.typeinfoclass)
         {
@@ -1553,8 +1553,8 @@ private void genClassInfoForInterface(InterfaceDeclaration id)
     // Put out (*vtblInterfaces)[]. Must immediately follow csym, because
     // of the fixup (*)
 
-    offset += id.vtblInterfaces.dim * (4 * target.ptrsize);
-    for (size_t i = 0; i < id.vtblInterfaces.dim; i++)
+    offset += id.vtblInterfaces.length * (4 * target.ptrsize);
+    for (size_t i = 0; i < id.vtblInterfaces.length; i++)
     {
         BaseClass *b = (*id.vtblInterfaces)[i];
         ClassDeclaration base = b.sym;

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -394,7 +394,7 @@ ulong getTypePointerBitmap(Loc loc, Type t, Array!(ulong)* data)
  */
 private Expression pointerBitmap(TraitsExp e)
 {
-    if (!e.args || e.args.dim != 1)
+    if (!e.args || e.args.length != 1)
     {
         error(e.loc, "a single type expected for trait pointerBitmap");
         return ErrorExp.get();
@@ -412,12 +412,12 @@ private Expression pointerBitmap(TraitsExp e)
     if (sz == ulong.max)
         return ErrorExp.get();
 
-    auto exps = new Expressions(data.dim + 1);
+    auto exps = new Expressions(data.length + 1);
     (*exps)[0] = new IntegerExp(e.loc, sz, Type.tsize_t);
-    foreach (size_t i; 1 .. exps.dim)
+    foreach (size_t i; 1 .. exps.length)
         (*exps)[i] = new IntegerExp(e.loc, data[cast(size_t) (i - 1)], Type.tsize_t);
 
-    auto ale = new ArrayLiteralExp(e.loc, Type.tsize_t.sarrayOf(data.dim + 1), exps);
+    auto ale = new ArrayLiteralExp(e.loc, Type.tsize_t.sarrayOf(data.length + 1), exps);
     return ale;
 }
 
@@ -446,7 +446,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         sc.stc = save;
     }
-    size_t dim = e.args ? e.args.dim : 0;
+    size_t dim = e.args ? e.args.length : 0;
 
     Expression dimError(int expected)
     {
@@ -1689,12 +1689,12 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
             void pushBaseMembersDg(ClassDeclaration cd)
             {
-                for (size_t i = 0; i < cd.baseclasses.dim; i++)
+                for (size_t i = 0; i < cd.baseclasses.length; i++)
                 {
                     auto cb = (*cd.baseclasses)[i].sym;
                     assert(cb);
                     ScopeDsymbol._foreach(null, cb.members, &pushIdentsDg);
-                    if (cb.baseclasses.dim)
+                    if (cb.baseclasses.length)
                         pushBaseMembersDg(cb);
                 }
             }
@@ -1801,9 +1801,9 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             return ErrorExp.get();
         if (!TemplateInstance.semanticTiargs(e.loc, sc, &ob2, 0))
             return ErrorExp.get();
-        if (ob1.dim != ob2.dim)
+        if (ob1.length != ob2.length)
             return False();
-        foreach (immutable i; 0 .. ob1.dim)
+        foreach (immutable i; 0 .. ob1.length)
             if (!ob1[i].isSame(ob2[i], sc))
                 return False();
         return True();
@@ -2041,7 +2041,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 if (prependNamespaces(outer, pp.cppnamespace)) return ErrorExp.get();
 
                 size_t i = 0;
-                while(i < outer.dim && ((*inner)[i]) == (*outer)[i])
+                while(i < outer.length && ((*inner)[i]) == (*outer)[i])
                     i++;
 
                 foreach_reverse (ns; (*inner)[][i .. $])
@@ -2124,7 +2124,7 @@ private bool isSame(RootObject o1, RootObject o2, Scope* sc)
         {
             if (auto td = t.isTemplateDeclaration())
             {
-                if (td.members && td.members.dim == 1)
+                if (td.members && td.members.length == 1)
                 {
                     if (auto fd = (*td.members)[0].isFuncLiteralDeclaration())
                         return fd;
@@ -2221,7 +2221,7 @@ private bool isSame(RootObject o1, RootObject o2, Scope* sc)
     if (!overSet2)
         return false;
 
-    if (overSet1.a.dim != overSet2.a.dim)
+    if (overSet1.a.length != overSet2.a.length)
         return false;
 
     // OverloadSets contain array of Dsymbols => O(n*n)

--- a/compiler/src/dmd/transitivevisitor.d
+++ b/compiler/src/dmd/transitivevisitor.d
@@ -617,7 +617,7 @@ package mixin template ParseVisitMethods(AST)
     void visitBaseClasses(AST.ClassDeclaration d)
     {
         //printf("Visiting ClassDeclaration\n");
-        if (!d || !d.baseclasses.dim)
+        if (!d || !d.baseclasses.length)
             return;
         foreach (b; *d.baseclasses)
             visitType(b.type);
@@ -626,7 +626,7 @@ package mixin template ParseVisitMethods(AST)
     bool visitEponymousMember(AST.TemplateDeclaration d)
     {
         //printf("Visiting EponymousMember\n");
-        if (!d.members || d.members.dim != 1)
+        if (!d.members || d.members.length != 1)
             return false;
         AST.Dsymbol onemember = (*d.members)[0];
         if (onemember.ident != d.ident)
@@ -688,7 +688,7 @@ package mixin template ParseVisitMethods(AST)
 
     void visitTemplateParameters(AST.TemplateParameters* parameters)
     {
-        if (!parameters || !parameters.dim)
+        if (!parameters || !parameters.length)
             return;
         foreach (p; *parameters)
             p.accept(this);
@@ -1042,7 +1042,7 @@ package mixin template ParseVisitMethods(AST)
         visitType(e.targ);
         if (e.tspec)
             visitType(e.tspec);
-        if (e.parameters && e.parameters.dim)
+        if (e.parameters && e.parameters.length)
             visitTemplateParameters(e.parameters);
     }
 

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -117,9 +117,9 @@ private void resolveTupleIndex(const ref Loc loc, Scope* sc, Dsymbol s, out Expr
         return;
     }
     const(uinteger_t) d = eindex.toUInteger();
-    if (d >= tup.objects.dim)
+    if (d >= tup.objects.length)
     {
-        .error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", d, cast(ulong)tup.objects.dim);
+        .error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", d, cast(ulong)tup.objects.length);
         pt = Type.terror;
         return;
     }
@@ -194,7 +194,7 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
     }
     s = s.toAlias();
     //printf("\t2: s = '%s' %p, kind = '%s'\n",s.toChars(), s, s.kind());
-    for (size_t i = 0; i < mt.idents.dim; i++)
+    for (size_t i = 0; i < mt.idents.length; i++)
     {
         RootObject id = mt.idents[i];
         switch (id.dyncast()) with (DYNCAST)
@@ -552,9 +552,9 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                 return error();
 
             uinteger_t d = mtype.dim.toUInteger();
-            if (d >= tup.objects.dim)
+            if (d >= tup.objects.length)
             {
-                .error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", cast(ulong)d, cast(ulong)tup.objects.dim);
+                .error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", cast(ulong)d, cast(ulong)tup.objects.length);
                 return error();
             }
 
@@ -647,9 +647,9 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                 assert(mtype.dim);
                 TypeTuple tt = tbn.isTypeTuple();
                 uinteger_t d = mtype.dim.toUInteger();
-                if (d >= tt.arguments.dim)
+                if (d >= tt.arguments.length)
                 {
-                    .error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", cast(ulong)d, cast(ulong)tt.arguments.dim);
+                    .error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", cast(ulong)d, cast(ulong)tt.arguments.length);
                     return error();
                 }
                 Type telem = (*tt.arguments)[cast(size_t)d].type;
@@ -875,11 +875,11 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                 fhash = search_function(ClassDeclaration.object, Id.tohash).isFuncDeclaration();
             assert(fcmp && feq && fhash);
 
-            if (feq.vtblIndex < cd.vtbl.dim && cd.vtbl[feq.vtblIndex] == feq)
+            if (feq.vtblIndex < cd.vtbl.length && cd.vtbl[feq.vtblIndex] == feq)
             {
                 version (all)
                 {
-                    if (fcmp.vtblIndex < cd.vtbl.dim && cd.vtbl[fcmp.vtblIndex] != fcmp)
+                    if (fcmp.vtblIndex < cd.vtbl.length && cd.vtbl[fcmp.vtblIndex] != fcmp)
                     {
                         const(char)* s = (mtype.index.toBasetype().ty != Tclass) ? "bottom of " : "";
                         .error(loc, "%sAA key type `%s` now requires equality rather than comparison", s, cd.toChars());
@@ -993,7 +993,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         if (mtype.parameterList.parameters)
         {
             tf.parameterList.parameters = mtype.parameterList.parameters.copy();
-            for (size_t i = 0; i < mtype.parameterList.parameters.dim; i++)
+            for (size_t i = 0; i < mtype.parameterList.parameters.length; i++)
             {
                 Parameter p = cast(Parameter)mem.xmalloc(__traits(classInstanceSize, Parameter));
                 memcpy(cast(void*)p, cast(void*)(*mtype.parameterList.parameters)[i], __traits(classInstanceSize, Parameter));
@@ -1180,13 +1180,13 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                      * the elements of TypeTuple::arguments to avoid unintended
                      * sharing of Parameter object among other functions.
                      */
-                    if (tt.arguments && tt.arguments.dim)
+                    if (tt.arguments && tt.arguments.length)
                     {
                         /* Propagate additional storage class from tuple parameters to their
                          * element-parameters.
                          * Make a copy, as original may be referenced elsewhere.
                          */
-                        size_t tdim = tt.arguments.dim;
+                        size_t tdim = tt.arguments.length;
                         auto newparams = new Parameters(tdim);
                         for (size_t j = 0; j < tdim; j++)
                         {
@@ -1437,7 +1437,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                  */
                 if (eparam.storageClass & STC.auto_)
                 {
-                    Expression farg = mtype.fargs && eidx < mtype.fargs.dim ?
+                    Expression farg = mtype.fargs && eidx < mtype.fargs.length ?
                         (*mtype.fargs)[eidx] : eparam.defaultArg;
                     if (farg && (eparam.storageClass & STC.ref_))
                     {
@@ -1756,10 +1756,10 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
         uinteger_t i1 = mtype.lwr.toUInteger();
         uinteger_t i2 = mtype.upr.toUInteger();
-        if (!(i1 <= i2 && i2 <= tt.arguments.dim))
+        if (!(i1 <= i2 && i2 <= tt.arguments.length))
         {
             .error(loc, "slice `[%llu..%llu]` is out of range of `[0..%llu]`",
-                cast(ulong)i1, cast(ulong)i2, cast(ulong)tt.arguments.dim);
+                cast(ulong)i1, cast(ulong)i2, cast(ulong)tt.arguments.length);
             return error();
         }
 
@@ -2477,7 +2477,7 @@ Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier iden
         }
         if (ident == Id.length)
         {
-            e = new IntegerExp(loc, mt.arguments.dim, Type.tsize_t);
+            e = new IntegerExp(loc, mt.arguments.length, Type.tsize_t);
         }
         else if (ident == Id._init)
         {
@@ -2614,9 +2614,9 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
                     return returnError();
 
                 const d = mt.dim.toUInteger();
-                if (d >= tup.objects.dim)
+                if (d >= tup.objects.length)
                 {
-                    error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", d, cast(ulong) tup.objects.dim);
+                    error(loc, "tuple index `%llu` out of bounds `[0 .. %llu]`", d, cast(ulong) tup.objects.length);
                     return returnError();
                 }
 
@@ -2897,7 +2897,7 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
             error(loc, "forward reference to `%s`", mt.toChars());
             goto Lerr;
         }
-        if (mt.idents.dim == 0)
+        if (mt.idents.length == 0)
         {
             returnType(t.addMod(mt.mod));
         }
@@ -2937,7 +2937,7 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
                 return returnError();
             }
         }
-        if (mt.idents.dim == 0)
+        if (mt.idents.length == 0)
         {
             return returnType(t.addMod(mt.mod));
         }
@@ -2987,13 +2987,13 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
                 mt.upr = mt.upr.ctfeInterpret();
                 const i1 = mt.lwr.toUInteger();
                 const i2 = mt.upr.toUInteger();
-                if (!(i1 <= i2 && i2 <= td.objects.dim))
+                if (!(i1 <= i2 && i2 <= td.objects.length))
                 {
-                    error(loc, "slice `[%llu..%llu]` is out of range of [0..%llu]", i1, i2, cast(ulong) td.objects.dim);
+                    error(loc, "slice `[%llu..%llu]` is out of range of [0..%llu]", i1, i2, cast(ulong) td.objects.length);
                     return returnError();
                 }
 
-                if (i1 == 0 && i2 == td.objects.dim)
+                if (i1 == 0 && i2 == td.objects.length)
                 {
                     return returnSymbol(td);
                 }
@@ -3002,7 +3002,7 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
                  * is a slice [i1..i2] out of the old one.
                  */
                 auto objects = new Objects(cast(size_t)(i2 - i1));
-                for (size_t i = 0; i < objects.dim; i++)
+                for (size_t i = 0; i < objects.length; i++)
                 {
                     (*objects)[i] = (*td.objects)[cast(size_t)i1 + i];
                 }
@@ -3096,8 +3096,8 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
                 break;
             case EXP.tuple:
                 TupleExp te = e.isTupleExp();
-                Objects* elems = new Objects(te.exps.dim);
-                foreach (i; 0 .. elems.dim)
+                Objects* elems = new Objects(te.exps.length);
+                foreach (i; 0 .. elems.length)
                 {
                     auto src = (*te.exps)[i];
                     switch (src.op)
@@ -3757,8 +3757,8 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 ev = extractSideEffect(sc, "__tup", e0, ev);
 
             auto exps = new Expressions();
-            exps.reserve(mt.sym.fields.dim);
-            for (size_t i = 0; i < mt.sym.fields.dim; i++)
+            exps.reserve(mt.sym.fields.length);
+            for (size_t i = 0; i < mt.sym.fields.length; i++)
             {
                 VarDeclaration v = mt.sym.fields[i];
                 Expression ex;
@@ -4015,8 +4015,8 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 ev = extractSideEffect(sc, "__tup", e0, ev);
 
             auto exps = new Expressions();
-            exps.reserve(mt.sym.fields.dim);
-            for (size_t i = 0; i < mt.sym.fields.dim; i++)
+            exps.reserve(mt.sym.fields.length);
+            for (size_t i = 0; i < mt.sym.fields.length; i++)
             {
                 VarDeclaration v = mt.sym.fields[i];
                 // Don't include hidden 'this' pointer
@@ -4589,8 +4589,8 @@ extern (C++) Expression defaultInit(Type mt, const ref Loc loc, const bool isCfi
         {
             printf("TypeTuple::defaultInit() '%s'\n", mt.toChars());
         }
-        auto exps = new Expressions(mt.arguments.dim);
-        for (size_t i = 0; i < mt.arguments.dim; i++)
+        auto exps = new Expressions(mt.arguments.length);
+        for (size_t i = 0; i < mt.arguments.length; i++)
         {
             Parameter p = (*mt.arguments)[i];
             assert(p.type);
@@ -4655,7 +4655,7 @@ private:
 Expression typeToExpressionHelper(TypeQualified t, Expression e, size_t i = 0)
 {
     //printf("toExpressionHelper(e = %s %s)\n", EXPtoString(e.op).ptr, e.toChars());
-    foreach (id; t.idents[i .. t.idents.dim])
+    foreach (id; t.idents[i .. t.idents.length])
     {
         //printf("\t[%d] e: '%s', id: '%s'\n", i, e.toChars(), id.toChars());
 
@@ -4770,7 +4770,7 @@ Type stripDefaultArgs(Type t)
                 if (ps)
                 {
                     // Replace params with a copy we can modify
-                    Parameters* nparams = new Parameters(parameters.dim);
+                    Parameters* nparams = new Parameters(parameters.length);
 
                     foreach (j, ref np; *nparams)
                     {
@@ -4898,7 +4898,7 @@ Expression getMaxMinValue(EnumDeclaration ed, const ref Loc loc, Identifier id)
     }
 
     bool first = true;
-    for (size_t i = 0; i < ed.members.dim; i++)
+    for (size_t i = 0; i < ed.members.length; i++)
     {
         EnumMember em = (*ed.members)[i].isEnumMember();
         if (!em)


### PR DESCRIPTION
Use `.length` to get the length of an `Array` instead of `dim`, to make the code more idiomatic D so it's easier to read, especially for new contributors.

Does not rename `TypeSArray.dim`, `Parameter.dim`, or `VectorExp.dim`.

It's a lot of churn, but the commit is added to `.git-blame-ignore-revs` so git blame shouldn't be affected.