### PR TITLE
Deprecate `Array.dim`

### DIFF
--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -352,7 +352,9 @@ public:
     }
 
     alias opDollar = length;
-    alias dim = length;
+
+    deprecated("use `.length` instead")
+    extern(D) size_t dim() const @nogc nothrow pure @safe { return length; }
 }
 
 unittest


### PR DESCRIPTION
After https://github.com/dlang/dmd/pull/14613, there's no access to `Array.dim` in dmd anymore. I'm deprecating it instead of removing it in case dmd as a library users access `.dim`. 

It seems deprecated aliases don't trigger deprecation warnings, so convert it to a function.