### PR TITLE
Fix Issue 23452 - Noncopyable variable can be silently passed to a function with variadic args

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1883,6 +1883,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                             else
                                 a = a.implicitCastTo(sc, tbn);
                             a = a.addDtorHook(sc);
+                            a = doCopyOrMove(sc, a);
                             (*elements)[u] = a;
                         }
                         // https://issues.dlang.org/show_bug.cgi?id=14395

--- a/compiler/test/fail_compilation/fail23452.d
+++ b/compiler/test/fail_compilation/fail23452.d
@@ -1,0 +1,25 @@
+// https://issues.dlang.org/show_bug.cgi?id=23452
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23452.d(24): Error: struct `fail23452.Foo` is not copyable because it has a disabled postblit
+fail_compilation/fail23452.d(24): Error: struct `fail23452.Foo` is not copyable because it has a disabled postblit
+---
+*/
+import std.stdio;
+
+struct Foo
+{
+    @disable this(this);
+    int x;
+}
+
+void test(Foo[] foos...) {}
+
+void main()
+{
+    Foo f1 = Foo(1);
+    Foo f2 = Foo(2);
+    test(f1, f2);
+}

--- a/compiler/test/runnable/test19393.d
+++ b/compiler/test/runnable/test19393.d
@@ -33,5 +33,5 @@ void bar()
 void main()
 {
     bar();
-    assert(result == "ABB");
+    assert(result == "AABB");
 }


### PR DESCRIPTION
It turns out that the compiler did not call the postblit/copy constructor for typesafe variadic arguments. This is silent change of code behavior.