### PR TITLE
Don't use 'Candidate is' when there is more than one alias function overload

### DIFF
--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3357,10 +3357,16 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
 
     // determine if the first candidate was printed
     bool printed = false;
-
     int count;
     overloadApply(declaration, (Dsymbol s)
     {
+        if (auto fd = s.isFuncDeclaration())
+        {
+            if (fd.errors || fd.type.ty == Terror)
+                return 0;
+            if (fd.storage_class & STC.disable || (fd.isDeprecated() && !showDeprecated))
+                return 0;
+        }
         count++;
         return count > 1; // early exit
     });

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3358,6 +3358,13 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
     // determine if the first candidate was printed
     bool printed = false;
 
+    int count;
+    overloadApply(declaration, (Dsymbol s)
+    {
+        count++;
+        return count > 1; // early exit
+    });
+    const single_candidate = count == 1;
     overloadApply(declaration, (Dsymbol s)
     {
         Dsymbol nextOverload;
@@ -3373,7 +3380,6 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
             if (fd.storage_class & STC.disable || (fd.isDeprecated() && !showDeprecated))
                 return 0;
 
-            const single_candidate = fd.overnext is null;
             auto tf = cast(TypeFunction) fd.type;
             .errorSupplemental(fd.loc,
                     printed ? "                `%s%s`" :
@@ -3389,8 +3395,6 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
 
             const tmsg = td.toCharsNoConstraints();
             const cmsg = td.getConstraintEvalError(constraintsTip);
-
-            const single_candidate = td.overnext is null;
 
             // add blank space if there are multiple candidates
             // the length of the blank space is `strlen("Candidates are: ")`

--- a/compiler/test/fail_compilation/diag14818.d
+++ b/compiler/test/fail_compilation/diag14818.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag14818.d(40): Error: none of the overloads of `func` are callable using argument types `(string)`
-fail_compilation/diag14818.d(18):        Candidate is: `diag14818.foo(int _param_0)`
+fail_compilation/diag14818.d(18):        Candidates are: `diag14818.foo(int _param_0)`
 fail_compilation/diag14818.d(19):                        `diag14818.bar(double _param_0)`
 fail_compilation/diag14818.d(41): Error: template instance `diag14818.X!string` does not match any template declaration
 fail_compilation/diag14818.d(41):        Candidates are:

--- a/compiler/test/fail_compilation/ice13459.d
+++ b/compiler/test/fail_compilation/ice13459.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/ice13459.d(12): Error: undefined identifier `B`
 fail_compilation/ice13459.d(18): Error: none of the overloads of `opSlice` are callable using argument types `(int, int)`
-fail_compilation/ice13459.d(11):        Candidates are: `ice13459.A.opSlice()`
+fail_compilation/ice13459.d(11):        Candidate is: `ice13459.A.opSlice()`
 ---
 */
 struct A


### PR DESCRIPTION
~Depends on #14617 for now.~