### PR TITLE
Fix Issue 23463 - Don't count skipped function overloads when limiting overloads shown

### DIFF
--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3354,8 +3354,7 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
     enum int DisplayLimit = 5;
     const(char)* constraintsTip;
     // determine if the first candidate was printed
-    int displayed;
-    bool printed = false;
+    int printed;
 
     bool matchSymbol(Dsymbol s, bool print, bool single_candidate = false)
     {
@@ -3377,7 +3376,6 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
                     single_candidate ? "Candidate is: `%s%s`" : "Candidates are: `%s%s`",
                     fd.toPrettyChars(),
                 parametersTypeToChars(tf.parameterList));
-            printed = true;
         }
         else if (auto td = s.isTemplateDeclaration())
         {
@@ -3397,7 +3395,6 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
                         printed ? "                `%s`\n%s" :
                         single_candidate ? "Candidate is: `%s`\n%s" : "Candidates are: `%s`\n%s",
                         tmsg, cmsg);
-                printed = true;
             }
             else
             {
@@ -3405,7 +3402,6 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
                         printed ? "                `%s`" :
                         single_candidate ? "Candidate is: `%s`" : "Candidates are: `%s`",
                         tmsg);
-                printed = true;
             }
         }
         return true;
@@ -3419,10 +3415,10 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
     });
     int skipped = 0;
     overloadApply(declaration, (s) {
-        if (global.params.verbose || displayed < DisplayLimit)
+        if (global.params.verbose || printed < DisplayLimit)
         {
             if (matchSymbol(s, true, count == 1))
-                displayed++;
+                printed++;
         }
         else
         {
@@ -3437,7 +3433,7 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
         .errorSupplemental(loc, "... (%d more, -v to show) ...", skipped);
 
     // Nothing was displayed, all overloads are either disabled or deprecated
-    if (!displayed)
+    if (!printed)
         .errorSupplemental(loc, "All possible candidates are marked as `deprecated` or `@disable`");
     // should be only in verbose mode
     if (constraintsTip)

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3352,40 +3352,25 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
 {
     // max num of overloads to print (-v overrides this).
     enum int DisplayLimit = 5;
-    int displayed;
     const(char)* constraintsTip;
-
     // determine if the first candidate was printed
+    int displayed;
     bool printed = false;
-    int count;
-    overloadApply(declaration, (Dsymbol s)
-    {
-        if (auto fd = s.isFuncDeclaration())
-        {
-            if (fd.errors || fd.type.ty == Terror)
-                return 0;
-            if (fd.storage_class & STC.disable || (fd.isDeprecated() && !showDeprecated))
-                return 0;
-        }
-        count++;
-        return count > 1; // early exit
-    });
-    const single_candidate = count == 1;
-    overloadApply(declaration, (Dsymbol s)
-    {
-        Dsymbol nextOverload;
 
+    bool matchSymbol(Dsymbol s, bool print, bool single_candidate = false)
+    {
         if (auto fd = s.isFuncDeclaration())
         {
             // Don't print overloads which have errors.
             // Not that if the whole overload set has errors, we'll never reach
             // this point so there's no risk of printing no candidate
             if (fd.errors || fd.type.ty == Terror)
-                return 0;
+                return false;
             // Don't print disabled functions, or `deprecated` outside of deprecated scope
             if (fd.storage_class & STC.disable || (fd.isDeprecated() && !showDeprecated))
-                return 0;
-
+                return false;
+            if (!print)
+                return true;
             auto tf = cast(TypeFunction) fd.type;
             .errorSupplemental(fd.loc,
                     printed ? "                `%s%s`" :
@@ -3393,12 +3378,13 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
                     fd.toPrettyChars(),
                 parametersTypeToChars(tf.parameterList));
             printed = true;
-            nextOverload = fd.overnext;
         }
         else if (auto td = s.isTemplateDeclaration())
         {
             import dmd.staticcond;
 
+            if (!print)
+                return true;
             const tmsg = td.toCharsNoConstraints();
             const cmsg = td.getConstraintEvalError(constraintsTip);
 
@@ -3421,21 +3407,34 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
                         tmsg);
                 printed = true;
             }
-            nextOverload = td.overnext;
         }
-
-        if (global.params.verbose || ++displayed < DisplayLimit)
-            return 0;
-
-        // Too many overloads to sensibly display.
-        // Just show count of remaining overloads.
-        int num = 0;
-        overloadApply(nextOverload, (s) { ++num; return 0; });
-
-        if (num > 0)
-            .errorSupplemental(loc, "... (%d more, -v to show) ...", num);
-        return 1;   // stop iterating
+        return true;
+    }
+    // determine if there's > 1 candidate
+    int count = 0;
+    overloadApply(declaration, (s) {
+        if (matchSymbol(s, false))
+            count++;
+        return count > 1;
     });
+    int skipped = 0;
+    overloadApply(declaration, (s) {
+        if (global.params.verbose || displayed < DisplayLimit)
+        {
+            if (matchSymbol(s, true, count == 1))
+                displayed++;
+        }
+        else
+        {
+            // Too many overloads to sensibly display.
+            // Just show count of remaining overloads.
+            if (matchSymbol(s, false))
+                skipped++;
+        }
+        return 0;
+    });
+    if (skipped > 0)
+        .errorSupplemental(loc, "... (%d more, -v to show) ...", skipped);
 
     // Nothing was displayed, all overloads are either disabled or deprecated
     if (!displayed)

--- a/compiler/test/fail_compilation/diag8101.d
+++ b/compiler/test/fail_compilation/diag8101.d
@@ -62,3 +62,6 @@ void main()
     t_1();
     t_2();
 }
+
+// ignored
+deprecated void f_2(char);

--- a/compiler/test/fail_compilation/fail15616b.d
+++ b/compiler/test/fail_compilation/fail15616b.d
@@ -22,7 +22,6 @@ fail_compilation/fail15616b.d(26):                        `foo(T)(T a)`
   `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
 `  > is(T == char)
 `  `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
-fail_compilation/fail15616b.d(44):        All possible candidates are marked as `deprecated` or `@disable`
   Tip: not satisfied constraints are marked with `>`
 ---
 */


### PR DESCRIPTION
This also fixes spurious *all candidates marked `deprecated`/`@disable`* in verbose mode.