### PR TITLE
fix Issue 22759 - ImportC: cannot modify const expression from derefe…

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -4816,7 +4816,13 @@ final class CParser(AST) : Parser!AST
         else if (auto tt = t.isTypeTag())
             tt.mod |= MODFlags.const_;
         else
-            t = t.addSTC(STC.const_);
+        {
+            /* Ignore const if the result would be const pointer to mutable
+             */
+            auto tn = t.nextOf();
+            if (!tn || tn.isConst())
+                t = t.addSTC(STC.const_);
+        }
         return t;
     }
 

--- a/compiler/test/fail_compilation/cconst1.c
+++ b/compiler/test/fail_compilation/cconst1.c
@@ -2,7 +2,6 @@
 ---
 fail_compilation/cconst1.c(104): Error: cannot modify `const` expression `i`
 fail_compilation/cconst1.c(106): Error: cannot modify `const` expression `j`
-fail_compilation/cconst1.c(108): Error: cannot modify `const` expression `p`
 ---
 */
 

--- a/compiler/test/fail_compilation/failcstuff2.c
+++ b/compiler/test/fail_compilation/failcstuff2.c
@@ -18,7 +18,6 @@ fail_compilation/failcstuff2.c(126): Error: `makeS22067().field` is not an lvalu
 fail_compilation/failcstuff2.c(127): Error: `makeS22067().field` is not an lvalue and cannot be modified
 fail_compilation/failcstuff2.c(153): Error: `cast(short)var` is not an lvalue and cannot be modified
 fail_compilation/failcstuff2.c(154): Error: `cast(long)var` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(308): Error: cannot modify `const` expression `(*s).p`
 fail_compilation/failcstuff2.c(354): Error: variable `arr` cannot be read at compile time
 fail_compilation/failcstuff2.c(360): Error: variable `str` cannot be read at compile time
 fail_compilation/failcstuff2.c(352): Error: cannot take address of register variable `reg1`

--- a/compiler/test/fail_compilation/test22759.c
+++ b/compiler/test/fail_compilation/test22759.c
@@ -1,0 +1,23 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test22759.c(108): Error: cannot modify `const` expression `*p`
+fail_compilation/test22759.c(111): Error: cannot modify `const` expression `r`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=22759
+
+#line 100
+
+void test()
+{
+    int *const q;
+    *q = 3;
+    q = 0;
+
+    const int *p;
+    *p = 3;                 // 108
+
+    const int *const r;
+    r = 0;                  // 111
+}


### PR DESCRIPTION
…rencing const pointer declared within function

This fix simply ignores `const` if the result would be a "const pointer to mutable".