### PR TITLE
fix Issue 23462 - dmd: src/dmd/backend/cod2.d:2158: Assertion cast(in…

### DIFF
--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -4336,6 +4336,9 @@ private elem * elcmp(elem *e, goal_t goal)
 
     //printf("elcmp(%p)\n",e); elem_print(e);
 
+    if (tyvector(e1.Ety))       // vectors don't give boolean result
+        return e;
+
     if (OPTIMIZER)
     {
         auto op = e.Eoper;

--- a/compiler/test/runnable/testxmm2.d
+++ b/compiler/test/runnable/testxmm2.d
@@ -203,6 +203,20 @@ void test3() { }
 }
 
 /*****************************************/
+// https://issues.dlang.org/show_bug.cgi?id=23462
+
+int4 notMask(int4 a) { return a == 0; }
+
+void test23462()
+{
+    int4 x = [1,2,3,4];
+    x = notMask(x);
+    assert(x.array == [0,0,0,0]);
+    x = notMask(x);
+    assert(x.array == [~0,~0,~0,~0]);
+}
+
+/*****************************************/
 
 void testunscmp()
 {
@@ -262,6 +276,7 @@ int main()
     testz4();
     test2();
     test3();
+    test23462();
     testunscmp();
     testflt();
     testdbl();


### PR DESCRIPTION
…t)tysize((*e).Ety) <= REGSIZE() failed