### PR TITLE
Fix 19623 - HERE string identifier cannot start with Unicode letter

### DIFF
--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -1475,6 +1475,7 @@ class Lexer
         stringbuffer.setsize(0);
         while (1)
         {
+            const s = p;
             dchar c = *p++;
             //printf("c = '%c'\n", c);
             switch (c)
@@ -1534,7 +1535,7 @@ class Lexer
                 {
                     // Start of identifier; must be a heredoc
                     Token tok;
-                    p--;
+                    p = s;
                     scan(&tok); // read in heredoc identifier
                     if (tok.value != TOK.identifier)
                     {
@@ -1582,7 +1583,7 @@ class Lexer
                 {
                     Token tok;
                     auto psave = p;
-                    p--;
+                    p = s;
                     scan(&tok); // read in possible heredoc identifier
                     //printf("endid = '%s'\n", tok.ident.toChars());
                     if (tok.value == TOK.identifier && tok.ident is hereid)

--- a/compiler/test/runnable/lexer.d
+++ b/compiler/test/runnable/lexer.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-runnable/lexer.d(81): Deprecation: `version( <integer> )` is deprecated, use version identifiers instead
-runnable/lexer.d(82): Deprecation: `debug( <integer> )` is deprecated, use debug identifiers instead
+runnable/lexer.d(86): Deprecation: `version( <integer> )` is deprecated, use version identifiers instead
+runnable/lexer.d(87): Deprecation: `debug( <integer> )` is deprecated, use debug identifiers instead
 ---
 */
 
@@ -36,6 +36,11 @@ HERE";
     //writefln("'%s'", s);
     assert(s == "foo\n");
 
+    // https://issues.dlang.org/show_bug.cgi?id=19623
+    s = q"übel
+foo
+übel";
+    assert(s == "foo\n");
 
     s = q{ foo(xxx) };
     assert(s ==" foo(xxx) ");


### PR DESCRIPTION
`p--` assumes the last decoded char was a single code unit, so in case of a Unicode letter, the identifier is scanned starting in the middle of a code point.