### PR TITLE
Fix Issue 23466 - -verrors=context should not repeat same context for supplemental m…

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -381,6 +381,8 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
     fputc('\n', stderr);
 
     if (global.params.printErrorContext &&
+        // ignore supplemental
+        strchr(header, ':') &&
         // ignore invalid files
         loc != Loc.initial &&
         // ignore mixins for now
@@ -475,6 +477,7 @@ private void _verrorSupplemental(const ref Loc loc, const(char)* format, va_list
     }
     else
         color = Classification.error;
+
     verrorPrint(loc, color, "       ", format, ap);
 }
 

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -380,9 +380,10 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
         fputs(tmp.peekChars(), stderr);
     fputc('\n', stderr);
 
+    static Loc old_loc;
     if (global.params.printErrorContext &&
-        // ignore supplemental
-        strchr(header, ':') &&
+        // ignore supplemental messages with same loc
+        (loc != old_loc || strchr(header, ':')) &&
         // ignore invalid files
         loc != Loc.initial &&
         // ignore mixins for now
@@ -418,6 +419,7 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
             }
         }
     }
+    old_loc = loc;
     fflush(stderr);     // ensure it gets written out in case of compiler aborts
 }
 

--- a/compiler/test/fail_compilation/fail_pretty_errors.d
+++ b/compiler/test/fail_compilation/fail_pretty_errors.d
@@ -5,17 +5,17 @@ TEST_OUTPUT:
 fail_compilation/fail_pretty_errors.d(24): Error: undefined identifier `a`
     a = 1;
     ^
-fail_compilation/fail_pretty_errors.d-mixin-25(29): Error: undefined identifier `b`
+fail_compilation/fail_pretty_errors.d-mixin-29(29): Error: undefined identifier `b`
 fail_compilation/fail_pretty_errors.d(34): Error: cannot implicitly convert expression `5` of type `int` to `string`
     string x = 5;
                ^
 fail_compilation/fail_pretty_errors.d(39): Error: mixin `fail_pretty_errors.testMixin2.mixinTemplate!()` error instantiating
     mixin mixinTemplate;
     ^
-fail_compilation/fail_pretty_errors.d(44): Error: invalid array operation `"" + ""` (possible missing [])
+fail_compilation/fail_pretty_errors.d(45): Error: invalid array operation `"" + ""` (possible missing [])
     auto x = ""+"";
              ^
-fail_compilation/fail_pretty_errors.d(44):        did you mean to concatenate (`"" ~ ""`) instead ?
+fail_compilation/fail_pretty_errors.d(45):        did you mean to concatenate (`"" ~ ""`) instead ?
 ---
 */
 
@@ -41,5 +41,6 @@ void testMixin2()
 
 void f()
 {
-    auto x = ""+""; // check supplemental error doesn't show context
+    // check supplemental error doesn't show context
+    auto x = ""+"";
 }

--- a/compiler/test/fail_compilation/fail_pretty_errors.d
+++ b/compiler/test/fail_compilation/fail_pretty_errors.d
@@ -2,16 +2,20 @@
 REQUIRED_ARGS: -verrors=context
 TEST_OUTPUT:
 ---
-fail_compilation/fail_pretty_errors.d(20): Error: undefined identifier `a`
+fail_compilation/fail_pretty_errors.d(24): Error: undefined identifier `a`
     a = 1;
     ^
-fail_compilation/fail_pretty_errors.d-mixin-25(25): Error: undefined identifier `b`
-fail_compilation/fail_pretty_errors.d(30): Error: cannot implicitly convert expression `5` of type `int` to `string`
+fail_compilation/fail_pretty_errors.d-mixin-25(29): Error: undefined identifier `b`
+fail_compilation/fail_pretty_errors.d(34): Error: cannot implicitly convert expression `5` of type `int` to `string`
     string x = 5;
                ^
-fail_compilation/fail_pretty_errors.d(35): Error: mixin `fail_pretty_errors.testMixin2.mixinTemplate!()` error instantiating
+fail_compilation/fail_pretty_errors.d(39): Error: mixin `fail_pretty_errors.testMixin2.mixinTemplate!()` error instantiating
     mixin mixinTemplate;
     ^
+fail_compilation/fail_pretty_errors.d(44): Error: invalid array operation `"" + ""` (possible missing [])
+    auto x = ""+"";
+             ^
+fail_compilation/fail_pretty_errors.d(44):        did you mean to concatenate (`"" ~ ""`) instead ?
 ---
 */
 
@@ -33,4 +37,9 @@ mixin template mixinTemplate()
 void testMixin2()
 {
     mixin mixinTemplate;
+}
+
+void f()
+{
+    auto x = ""+""; // check supplemental error doesn't show context
 }


### PR DESCRIPTION
…essages

At least when the `loc` has not changed since the last message.