### PR TITLE
Issue 23473: Improvement: Implement single-argument __traits(getOverloads) form.

### DIFF
--- a/changelog/dmd.traits_getOverloads_with_symbol.dd
+++ b/changelog/dmd.traits_getOverloads_with_symbol.dd
@@ -1,0 +1,14 @@
+__traits(getOverloads) takes an overload symbol
+
+`__traits(getOverloads)` can now be invoked with
+a single parameter. This parameter must be an overload set.
+`__traits(getOverloads)` will evaluate to a tuple of the
+overloads forming the set.
+For example:
+-------
+int foo() { return 0; }
+int foo(int a) { return a + 1; }
+
+assert(__traits(getOverloads, foo)[0]() == 0);
+assert(__traits(getOverloads, foo)[1](5) == 6);
+-------

--- a/compiler/test/compilable/imports/traits_a.d
+++ b/compiler/test/compilable/imports/traits_a.d
@@ -1,0 +1,5 @@
+module imports.traits_a;
+
+void baz(int);
+
+void baz(string);

--- a/compiler/test/compilable/imports/traits_b.d
+++ b/compiler/test/compilable/imports/traits_b.d
@@ -1,0 +1,3 @@
+module imports.traits_b;
+
+void baz();

--- a/compiler/test/compilable/traits.d
+++ b/compiler/test/compilable/traits.d
@@ -76,9 +76,17 @@ int foo();
 int foo(int);
 
 static assert(__traits(getLocation, __traits(getOverloads, traits, "foo")[1])[1] == 74);
+static assert(__traits(getLocation, __traits(getOverloads, foo)[1])[1] == 74);
+
+import imports.traits_a;
+import imports.traits_b;
+
+static assert(__traits(compiles, __traits(getOverloads, baz)[0]()));
+static assert(__traits(compiles, __traits(getOverloads, baz)[1](int.init)));
+static assert(__traits(compiles, __traits(getOverloads, baz)[2](string.init)));
 
 mixin("int bar;");
-static assert(__traits(getLocation, bar)[1] == 78);
+static assert(__traits(getLocation, bar)[1] == 86);
 
 struct Outer
 {
@@ -86,8 +94,8 @@ struct Outer
 
     void method() {}
 }
-static assert(__traits(getLocation, Outer.Nested)[1] == 83);
-static assert(__traits(getLocation, Outer.method)[1] == 85);
+static assert(__traits(getLocation, Outer.Nested)[1] == 91);
+static assert(__traits(getLocation, Outer.method)[1] == 93);
 
 /******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=19902


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=23473

Rationale:

At the moment, when looking at an overload set passed via an alias parameter to a template, there is *no way* of extracting the individual functions making up the overload set. In the ordinary case, you can use a hack like `__traits(getOverloads, __traits(parent, sym), __traits(identifier, sym))`, but this fails as soon as the overload set contains alias renames or other modules. But `__traits(getOverloads)` internally looks at a symbol anyways, so we just redefine the single-argument form (currently an error) to pass that symbol directly.

Should I make a spec PR first?