### PR TITLE
change symbol_calloc() to use slices

### DIFF
--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -1327,7 +1327,7 @@ private elem * elmin(elem *e, goal_t goal)
         __gshared Symbol *hdiff;
         if (!hdiff)
         {
-            Symbol *s = symbol_calloc(LARGECODE ? "_aFahdiff".ptr : "_aNahdiff".ptr);
+            Symbol *s = symbol_calloc(LARGECODE ? "_aFahdiff" : "_aNahdiff");
             s.Stype = tsclib;
             s.Sclass = SC.extern_;
             s.Sfl = FLfunc;

--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -2105,7 +2105,7 @@ __gshared int clib_inited = false;          // true if initialized
 @trusted
 Symbol* symboly(const(char)* name, regm_t desregs)
 {
-    Symbol *s = symbol_calloc(name);
+    Symbol *s = symbol_calloc(name[0 .. strlen(name)]);
     s.Stype = tsclib;
     s.Sclass = SC.extern_;
     s.Sfl = FLfunc;

--- a/compiler/src/dmd/backend/drtlsym.d
+++ b/compiler/src/dmd/backend/drtlsym.d
@@ -227,7 +227,7 @@ Symbol *getRtlsym(RTLSYM i)
  */
 private void symbolz(Symbol** ps, int fl, regm_t regsaved, const(char)* name, SYMFLGS flags, type *t)
 {
-    Symbol *s = symbol_calloc(name);
+    Symbol *s = symbol_calloc(name[0 .. strlen(name)]);
     s.Stype = t;
     s.Ssymnum = SYMIDX.max;
     s.Sclass = SC.extern_;

--- a/compiler/src/dmd/backend/dtype.d
+++ b/compiler/src/dmd/backend/dtype.d
@@ -635,7 +635,7 @@ type *type_function(tym_t tyf, type*[] ptypes, bool variadic, type *tret)
 @trusted
 type *type_enum(const(char)* name, type *tbase)
 {
-    Symbol *s = symbol_calloc(name);
+    Symbol *s = symbol_calloc(name[0 .. strlen(name)]);
     s.Sclass = SC.enum_;
     s.Senum = cast(enum_t *) MEM_PH_CALLOC(enum_t.sizeof);
     s.Senum.SEflags |= SENforward;        // forward reference
@@ -674,7 +674,7 @@ type *type_struct_class(const(char)* name, uint alignsize, uint structsize,
             type_print(arg2type);
         }
     }
-    Symbol *s = symbol_calloc(name);
+    Symbol *s = symbol_calloc(name[0 .. strlen(name)]);
     s.Sclass = SC.struct_;
     s.Sstruct = struct_calloc();
     s.Sstruct.Salignsize = alignsize;
@@ -1696,7 +1696,7 @@ Symbol *param_search(const(char)* name, param_t **pp)
         s = p.Psym;
         if (!s)
         {
-            s = symbol_calloc(p.Pident);
+            s = symbol_calloc(p.Pident[0 .. strlen(p.Pident)]);
             s.Sclass = SC.parameter;
             s.Stype = p.Ptype;
             s.Stype.Tcount++;

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -323,11 +323,8 @@ void symbol_keep(Symbol *s) { }
 void symbol_print(const Symbol* s);
 void symbol_term();
 const(char)* symbol_ident(const Symbol *s);
-Symbol *symbol_calloc(const(char)* id);
-Symbol *symbol_calloc(const(char)* id, uint len);
-
-extern (C)
-Symbol *symbol_name(const(char)[] name, SC sclass, type *t);
+extern (C) Symbol *symbol_calloc(const(char)[] id);
+extern (C) Symbol *symbol_name(const(char)[] name, SC sclass, type *t);
 Symbol *symbol_generate(SC sclass, type *t);
 Symbol *symbol_genauto(type *t);
 Symbol *symbol_genauto(elem *e);

--- a/compiler/src/dmd/backend/gsroa.d
+++ b/compiler/src/dmd/backend/gsroa.d
@@ -459,12 +459,13 @@ if (enable) // disable while we test the inliner
 
                 const idlen = 2 + strlen(sold.Sident.ptr) + 2;
                 char *id = cast(char *)malloc(idlen + 1);
-                assert(id);
+                if (!id)
+                    err_nomem();
                 const len = sprintf(id, "__%s_%d", sold.Sident.ptr, SLICESIZE);
                 assert(len == idlen);
                 if (log) printf("retyping slice symbol %s %s\n", sold.Sident.ptr, tym_str(sia[si].ty[0]));
                 if (log) printf("creating slice symbol %s %s\n", id, tym_str(sia[si].ty[1]));
-                Symbol *snew = symbol_calloc(id, cast(uint)idlen);
+                Symbol *snew = symbol_calloc(id[0 .. idlen]);
                 free(id);
                 snew.Sclass = sold.Sclass;
                 snew.Sfl = sold.Sfl;

--- a/compiler/src/dmd/backend/symbol.d
+++ b/compiler/src/dmd/backend/symbol.d
@@ -331,17 +331,11 @@ version (SCPP_HTOD)
  */
 
 @trusted
-Symbol * symbol_calloc(const(char)* id)
+extern (C)
+Symbol * symbol_calloc(const(char)[] id)
 {
-    return symbol_calloc(id, cast(uint)strlen(id));
-}
-
-@trusted
-Symbol * symbol_calloc(const(char)* id, uint len)
-{   Symbol *s;
-
-    //printf("sizeof(symbol)=%d, sizeof(s.Sident)=%d, len=%d\n", symbol.sizeof, s.Sident.sizeof, cast(int)len);
-    s = cast(Symbol *) mem_fmalloc(Symbol.sizeof - s.Sident.length + len + 1 + 5);
+    //printf("sizeof(symbol)=%d, sizeof(s.Sident)=%d, len=%d\n", symbol.sizeof, s.Sident.sizeof, cast(int)id.length);
+    Symbol* s = cast(Symbol *) mem_fmalloc(Symbol.sizeof - Symbol.Sident.length + id.length + 1 + 5);
     memset(s,0,Symbol.sizeof - s.Sident.length);
 version (SCPP_HTOD)
 {
@@ -349,14 +343,12 @@ version (SCPP_HTOD)
     pstate.STsequence += 1;
     //if (s.Ssequence == 0x21) *cast(char*)0=0;
 }
-debug
-{
-    if (debugy)
-        printf("symbol_calloc('%s') = %p\n",id,s);
-    s.id = Symbol.IDsymbol;
-}
-    memcpy(s.Sident.ptr,id,len + 1);
+    memcpy(s.Sident.ptr,id.ptr,id.length);
+    s.Sident.ptr[id.length] = 0;
     s.Ssymnum = SYMIDX.max;
+    if (debugy)
+        printf("symbol_calloc('%s') = %p\n",s.Sident.ptr,s);
+    debug s.id = Symbol.IDsymbol;
     return s;
 }
 
@@ -374,7 +366,7 @@ extern (C)
 Symbol * symbol_name(const(char)[] name, SC sclass, type *t)
 {
     type_debug(t);
-    Symbol *s = symbol_calloc(name.ptr, cast(uint)name.length);
+    Symbol *s = symbol_calloc(name);
     s.Sclass = sclass;
     s.Stype = t;
     s.Stype.Tcount++;
@@ -579,7 +571,7 @@ version (SCPP_HTOD)
 {
 Symbol * defsy(const(char)* p,Symbol **parent)
 {
-   Symbol *s = symbol_calloc(p);
+   Symbol *s = symbol_calloc(p[0 .. strlen(p)]);
    symbol_addtotree(parent,s);
    return s;
 }
@@ -1255,7 +1247,7 @@ Symbol * symbol_copy(Symbol *s)
 
     symbol_debug(s);
     /*printf("symbol_copy(%s)\n",s.Sident.ptr);*/
-    scopy = symbol_calloc(s.Sident.ptr);
+    scopy = symbol_calloc(s.Sident.ptr[0 .. strlen(s.Sident.ptr)]);
     memcpy(scopy,s,Symbol.sizeof - s.Sident.sizeof);
     scopy.Sl = scopy.Sr = scopy.Snext = null;
     scopy.Ssymnum = SYMIDX.max;

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -266,7 +266,7 @@ Symbol *toStringSymbol(const(char)* str, size_t len, size_t sz)
                 }
             }
 
-            si = symbol_calloc(buf.peekChars(), cast(uint)buf.length);
+            si = symbol_calloc(buf[]);
             si.Sclass = SC.comdat;
             si.Stype = type_static_array(cast(uint)(len * sz), tstypes[TYchar]);
             si.Stype.Tcount++;

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -1226,7 +1226,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             const ret = snprintf(buf, 100, "_dmd_crt_destructor_thunk.%u", nthDestructor++);
             assert(ret >= 0 && ret < 100, "snprintf either failed or overran buffer");
             //Function symbol
-            auto newConstructor = symbol_calloc(buf);
+            auto newConstructor = symbol_calloc(buf[0 .. strlen(buf)]);
             //Build type
             newConstructor.Stype = type_function(TYnfunc, [], false, type_alloc(TYvoid));
             //Tell it it's supposed to be a C function. Does it do anything? Not sure.

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -137,7 +137,7 @@ Symbol *toSymbol(Dsymbol s)
             if (vd.isDataseg())
             {
                 mangleToBuffer(vd, &buf);
-                id = buf.peekChars()[0..buf.length]; // symbol_calloc needs zero termination
+                id = buf[];
             }
             else
             {
@@ -147,12 +147,12 @@ Symbol *toSymbol(Dsymbol s)
                     {
                         buf.writestring("__nrvo_");
                         buf.writestring(id);
-                        id = buf.peekChars()[0..buf.length]; // symbol_calloc needs zero termination
+                        id = buf[];
                         isNRVO = true;
                     }
                 }
             }
-            Symbol *s = symbol_calloc(id.ptr, cast(uint)id.length);
+            Symbol *s = symbol_calloc(id);
             s.Salignment = vd.alignment.isDefault() ? -1 : vd.alignment.get();
             if (vd.storage_class & STC.temp)
                 s.Sflags |= SFLartifical;
@@ -338,7 +338,7 @@ Symbol *toSymbol(Dsymbol s)
             //printf("FuncDeclaration.toSymbol(%s %s)\n", fd.kind(), fd.toChars());
             //printf("\tid = '%s'\n", id);
             //printf("\ttype = %s\n", fd.type.toChars());
-            auto s = symbol_calloc(id, cast(uint)strlen(id));
+            auto s = symbol_calloc(id[0 .. strlen(id)]);
 
             s.prettyIdent = fd.toPrettyChars(true);
 
@@ -526,7 +526,7 @@ Symbol *toImport(Symbol *sym, Loc loc)
     t.Tnext.Tcount++;
     t.Tmangle = mTYman_c;
     t.Tcount++;
-    auto s = symbol_calloc(id, idlen);
+    auto s = symbol_calloc(id[0 .. idlen]);
     s.Stype = t;
     s.Sclass = SC.extern_;
     s.Sfl = FLextern;
@@ -712,7 +712,7 @@ Symbol *aaGetSymbol(TypeAArray taa, const(char)* func, int flags)
 
     // Create new Symbol
 
-    auto s = symbol_calloc(id, idlen);
+    auto s = symbol_calloc(id[0 .. idlen]);
     s.Sclass = SC.extern_;
     s.Ssymnum = SYMIDX.max;
     symbol_func(s);
@@ -736,7 +736,7 @@ Symbol* toSymbol(StructLiteralExp sle)
         return sle.sym;
     auto t = type_alloc(TYint);
     t.Tcount++;
-    auto s = symbol_calloc("internal", 8);
+    auto s = symbol_calloc("internal");
     s.Sclass = SC.static_;
     s.Sfl = FLextern;
     s.Sflags |= SFLnodebug;
@@ -756,7 +756,7 @@ Symbol* toSymbol(ClassReferenceExp cre)
         return cre.value.origin.sym;
     auto t = type_alloc(TYint);
     t.Tcount++;
-    auto s = symbol_calloc("internal", 8);
+    auto s = symbol_calloc("internal");
     s.Sclass = SC.static_;
     s.Sfl = FLextern;
     s.Sflags |= SFLnodebug;
@@ -811,7 +811,7 @@ Symbol* toSymbolCpp(ClassDeclaration cd)
 Symbol *toSymbolCppTypeInfo(ClassDeclaration cd)
 {
     const id = target.cpp.typeInfoMangle(cd);
-    auto s = symbol_calloc(id, cast(uint)strlen(id));
+    auto s = symbol_calloc(id[0 .. strlen(id)]);
     s.Sclass = SC.extern_;
     s.Sfl = FLextern;          // C++ code will provide the definition
     s.Sflags |= SFLnodebug;


### PR DESCRIPTION
Also winds up eliminating casts, and the awkward problem of a slice still needing 0 termination.

The strlen's are pushed upward in the call stack, where they can be hopefully also be replaced by slices.