### PR TITLE
Fix Issue 3332 - Mixin a constructor with a construct already present fails

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -751,7 +751,8 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         {
             if (!(s.isCtorDeclaration() ||
                   s.isTemplateDeclaration() ||
-                  s.isOverloadSet()))
+                  s.isOverloadSet() ||
+                  s.isAliasDeclaration))
             {
                 s.error("is not a constructor; identifiers starting with `__` are reserved for the implementation");
                 errors = true;

--- a/compiler/test/compilable/test3332.d
+++ b/compiler/test/compilable/test3332.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=3332
+
+template C ()
+{
+    this (int i)
+    {
+    }
+}
+
+class A
+{
+    mixin C f;
+    this ()
+    {
+    }
+    alias __ctor = f.__ctor;
+}
+
+void main ()
+{
+    auto a = new A(3);
+}


### PR DESCRIPTION
Previously, you were not allowed to add a constructor to an overload set because `__ctor` is specifically forbidden to be used for defining a symbol. However, this makes it impossible to add constructors defined in mixin templates to a constructor overload set. I see no harm in allowing this.