### PR TITLE
Fix issue 23177 - ModuleInfo is not exported on Windows

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -361,6 +361,7 @@ extern (C++) final class Module : Package
     int needmoduleinfo;
     int selfimports;            // 0: don't know, 1: does not, 2: does
     Dsymbol[void*] tagSymTab;   /// ImportC: tag symbols that conflict with other symbols used as the index
+    Symbol* isym;               /// Import version of csym used for DllImport on Windows
 
     private OutBuffer defines;  // collect all the #define lines here
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6219,6 +6219,7 @@ public:
     int32_t needmoduleinfo;
     int32_t selfimports;
     void* tagSymTab;
+    Symbol* isym;
 private:
     OutBuffer defines;
 public:

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -90,7 +90,7 @@ void genModuleInfo(Module m)
         ObjectNotFound(Id.ModuleInfo);
     }
 
-    Symbol *msym = toSymbol(m);
+    toSymbol(m);
 
     //////////////////////////////////////////////
 

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -243,7 +243,7 @@ void genModuleInfo(Module m)
     out_readonly(m.csym);
     outdata(m.csym);
 
-    if (!m.isym)
+    if (target.os == Target.OS.Windows && !m.isym)
     {
         m.isym = m.csym.toImport(m.loc);
         out_readonly(m.isym);

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -243,7 +243,7 @@ void genModuleInfo(Module m)
     out_readonly(m.csym);
     outdata(m.csym);
 
-    if (!mod.isym)
+    if (!m.isym)
     {
         m.isym = m.csym.toImport(m.loc);
         out_readonly(m.isym);

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -210,12 +210,15 @@ void genModuleInfo(Module m)
 
                 s = mod.isym;
             }
+            else
+            {
+                /* Weak references don't pull objects in from the library,
+                 * they resolve to 0 if not pulled in by something else.
+                 * Don't pull in a module just because it was imported.
+                 */
+                s.Sflags |= SFLweak;
+            }
 
-            /* Weak references don't pull objects in from the library,
-             * they resolve to 0 if not pulled in by something else.
-             * Don't pull in a module just because it was imported.
-             */
-            s.Sflags |= SFLweak;
             dtb.xoff(s, 0, TYnptr);
         }
     }

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -188,6 +188,29 @@ void genModuleInfo(Module m)
 
             Symbol *s = toSymbol(mod);
 
+            if (target.os == Target.OS.Windows)
+            {
+                // For Windows we need to perform DllImport for symbols
+                //  accessed outside of the DLL.
+                // This also applies to the ModuleInfo importedModules member
+                //  which is very much required if you don't want segfaults.
+                // While it would seem like a good idea to do the work of
+                //  getting the DllImport symbol when we emit the ModuleInfo of
+                //  a dependency, it would be particularly bad and would result
+                //  in cyclic compilation cycles that would not be desirable to detect.
+
+                if (!mod.isym)
+                {
+                    mod.isym = s.toImport(mod.loc);
+
+                    // do we need to do this?
+                    out_readonly(mod.isym);
+                    outdata(mod.isym);
+                }
+
+                s = mod.isym;
+            }
+
             /* Weak references don't pull objects in from the library,
              * they resolve to 0 if not pulled in by something else.
              * Don't pull in a module just because it was imported.

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -210,15 +210,12 @@ void genModuleInfo(Module m)
 
                 s = mod.isym;
             }
-            else
-            {
-                /* Weak references don't pull objects in from the library,
-                 * they resolve to 0 if not pulled in by something else.
-                 * Don't pull in a module just because it was imported.
-                 */
-                s.Sflags |= SFLweak;
-            }
 
+            /* Weak references don't pull objects in from the library,
+             * they resolve to 0 if not pulled in by something else.
+             * Don't pull in a module just because it was imported.
+             */
+            s.Sflags |= SFLweak;
             dtb.xoff(s, 0, TYnptr);
         }
     }
@@ -246,12 +243,14 @@ void genModuleInfo(Module m)
     out_readonly(m.csym);
     outdata(m.csym);
 
-    /+if (target.os == Target.OS.Windows && !m.isym)
+    if (target.os == Target.OS.Windows && !m.isym)
     {
         m.isym = m.csym.toImport(m.loc);
+        m.isym.Sflags |= SFLweak;
+
         out_readonly(m.isym);
         outdata(m.isym);
-    }+/
+    }
 
     //////////////////////////////////////////////
 

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -243,9 +243,17 @@ void genModuleInfo(Module m)
     out_readonly(m.csym);
     outdata(m.csym);
 
+    if (!mod.isym)
+    {
+        m.isym = m.csym.toImport(m.loc);
+        out_readonly(m.isym);
+        outdata(m.isym);
+    }
+
     //////////////////////////////////////////////
 
-    objmod.moduleinfo(msym);
+    objmod.moduleinfo(m.csym);
+    objmod.export_symbol(m.csym, 0);
 }
 
 /*****************************************

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -246,12 +246,12 @@ void genModuleInfo(Module m)
     out_readonly(m.csym);
     outdata(m.csym);
 
-    if (target.os == Target.OS.Windows && !m.isym)
+    /+if (target.os == Target.OS.Windows && !m.isym)
     {
         m.isym = m.csym.toImport(m.loc);
         out_readonly(m.isym);
         outdata(m.isym);
-    }
+    }+/
 
     //////////////////////////////////////////////
 

--- a/compiler/test/tools/d_do_test.d
+++ b/compiler/test/tools/d_do_test.d
@@ -1732,6 +1732,7 @@ int tryMain(string[] args)
                 }
             }
 
+            /// This should be similar in nature as ``dshell_prebuilt.d`` ``filterCompilerOutput`` function.
             void prepare(ref string compile_output)
             {
                 if (compile_output.empty)
@@ -1739,6 +1740,15 @@ int tryMain(string[] args)
 
                 compile_output = compile_output.unifyNewLine();
                 compile_output = std.regex.replaceAll(compile_output, regex(`^DMD v2\.[0-9]+.*\n? DEBUG$`, "m"), "");
+
+                if (envData.os == "windows" && envData.model != "32omf")
+                {
+                    // For MSVC linker, when it generates a binary file with an export table (with the import generation) it will add a message
+                    // this message is both linker specific and platform specific, which we do not want our tests checked against.
+                    // so we'll remove it prior to doing anything with the output.
+                    compile_output = std.regex.replaceAll(compile_output, std.regex.regex(r"\s*Creating library [\S\\/]+ and object [\S\\/]+\r?\n?", "s"), "");
+                }
+
                 compile_output = std.string.strip(compile_output);
                 // replace test_result path with fixed ones
                 compile_output = compile_output.replace(result_path, resultsDirReplacement);

--- a/compiler/test/tools/dshell_prebuilt/dshell_prebuilt.d
+++ b/compiler/test/tools/dshell_prebuilt/dshell_prebuilt.d
@@ -336,5 +336,14 @@ string filterCompilerOutput(string output)
 {
     output = std.string.replace(output, "\r", "");
     output = std.regex.replaceAll(output, regex(`^DMD v2\.[0-9]+.*\n? DEBUG\n`, "m"), "");
+
+    version(Windows)
+    {
+        // For MSVC linker, when it generates a binary file with an export table (with the import generation) it will add a message
+        // this message is both linker specific and platform specific, which we do not want our tests checked against.
+        // so we'll remove it prior to doing anything with the output.
+        output = std.regex.replaceAll(output, std.regex.regex(r"\s*Creating library [\S\\/]+ and object [\S\\/]+\r?\n?", "s"), "");
+    }
+
     return output;
 }

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -2417,7 +2417,7 @@ const:
      * Returns:
      *  array of pointers to the ModuleInfo's of modules imported by this one
      */
-    @property immutable(ModuleInfo*)[] importedModules() return nothrow pure
+    @property immutable(ModuleInfo*)[] importedModules() return nothrow pure @nogc
     {
         if (flags & MIimportedModules)
         {
@@ -2426,7 +2426,9 @@ const:
 
             version(ModuleInfoNeedDereference)
             {
-                auto dereferenced = new ModuleInfo*[](embeddedImportedModules.length);
+                //auto dereferenced = new ModuleInfo*[](embeddedImportedModules.length);
+                import core.stdc.stdlib;
+                auto dereferenced = (cast(ModuleInfo**)malloc(ModuleInfo.sizeof * embeddedImportedModules.length))[0 .. embeddedImportedModules.length];
                 foreach(offset, mod; cast(ModuleInfo**[])embeddedImportedModules)
                 {
                     if (mod !is null)

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -2431,7 +2431,7 @@ const:
                     if (mod !is null)
                         dereferenced[offset] = *mod;
                 }
-                return cast(typeof(return))dreferenced;
+                return cast(typeof(return))dereferenced;
             }
             else
             {

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -2231,6 +2231,7 @@ class TypeInfo_Inout : TypeInfo_Const
 //  which will run after the system linker does its own patching.
 // For dmd the solution that is being used here is to
 //  dereference on the fly and allocate a new array as needed.
+// You will need to update rt.minfo if you change this.
 version(Windows)
 {
     version(DigitalMars)

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -2427,8 +2427,8 @@ const:
             version(ModuleInfoNeedDereference)
             {
                 //auto dereferenced = new ModuleInfo*[](embeddedImportedModules.length);
-                import core.stdc.stdlib;
-                auto dereferenced = (cast(ModuleInfo**)malloc(ModuleInfo.sizeof * embeddedImportedModules.length))[0 .. embeddedImportedModules.length];
+                import core.memory : pureMalloc;
+                auto dereferenced = (cast(ModuleInfo**)pureMalloc(ModuleInfo.sizeof * embeddedImportedModules.length))[0 .. embeddedImportedModules.length];
                 foreach(offset, mod; cast(ModuleInfo**[])embeddedImportedModules)
                 {
                     if (mod !is null)

--- a/druntime/src/rt/minfo.d
+++ b/druntime/src/rt/minfo.d
@@ -720,7 +720,7 @@ unittest
             version(ModuleInfoNeedDereference)
             {
                 imports = imports.dup;
-                ModuleInfo**[] into = (cast(ModuleInfo***)&pad[nfuncs + 1])[0 .. imports.length];
+                auto into = (cast(immutable(ModuleInfo)***)&pad[nfuncs + 1])[0 .. imports.length];
                 foreach(offset; 0 .. imports.length)
                     into[offset] = &imports[offset];
             }


### PR DESCRIPTION
This doesn't include any tests, right now I want to know if this breaks anything existing.

If it doesn't, I'll re-add them.

Assuming this works, the patching can be done a different way in the future allowing ``ModuleInfo.importedModules`` to be ``@nogc`` and in doing so simplifying it back to how it was.