### PR TITLE
Fix Issue 23498 - OpenBSD: Fix core.sys.posix.sys.wait

### DIFF
--- a/druntime/src/core/sys/posix/sys/wait.d
+++ b/druntime/src/core/sys/posix/sys/wait.d
@@ -387,9 +387,15 @@ else version (NetBSD)
 else version (OpenBSD)
 {
     enum WCONTINUED     = 8;
-    // OpenBSD does not define the following:
-    //enum WSTOPPED
-    //enum WNOWAIT
+    enum WSTOPPED       = WUNTRACED;
+    enum WNOWAIT        = 16;
+
+    enum idtype_t
+    {
+        P_ALL,
+        P_PID,
+        P_PGID
+    }
 }
 else version (DragonFlyBSD)
 {


### PR DESCRIPTION
Set defines for WSTOPPED and WNOWAIT accord to OpenBSD's sys/wait.h
Add the idtype_t enum, also from OpenBSD's sys/wait.h