### PR TITLE
test: Fix cdcmp output to match binutils 2.39

### DIFF
--- a/compiler/test/compilable/extra-files/cdcmp.out
+++ b/compiler/test/compilable/extra-files/cdcmp.out
@@ -4,7 +4,7 @@ Disassembly of section .text._D5cdcmp8test_ltzFhZb:
 
 0000000000000000 <_D5cdcmp8test_ltzFhZb>:
    0:	31 c0                	xor    eax,eax
-   2:	c3                   	ret    
+   2:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_lezFhZb:
@@ -12,7 +12,7 @@ Disassembly of section .text._D5cdcmp8test_lezFhZb:
 0000000000000000 <_D5cdcmp8test_lezFhZb>:
    0:	40 84 ff             	test   dil,dil
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_eqzFhZb:
@@ -20,7 +20,7 @@ Disassembly of section .text._D5cdcmp8test_eqzFhZb:
 0000000000000000 <_D5cdcmp8test_eqzFhZb>:
    0:	40 84 ff             	test   dil,dil
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_nezFhZb:
@@ -28,14 +28,14 @@ Disassembly of section .text._D5cdcmp8test_nezFhZb:
 0000000000000000 <_D5cdcmp8test_nezFhZb>:
    0:	40 84 ff             	test   dil,dil
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gezFhZb:
 
 0000000000000000 <_D5cdcmp8test_gezFhZb>:
    0:	b8 01 00 00 00       	mov    eax,0x1
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gtzFhZb:
@@ -43,7 +43,7 @@ Disassembly of section .text._D5cdcmp8test_gtzFhZb:
 0000000000000000 <_D5cdcmp8test_gtzFhZb>:
    0:	40 84 ff             	test   dil,dil
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_ltzFgZb:
@@ -51,7 +51,7 @@ Disassembly of section .text._D5cdcmp8test_ltzFgZb:
 0000000000000000 <_D5cdcmp8test_ltzFgZb>:
    0:	40 84 ff             	test   dil,dil
    3:	0f 98 c0             	sets   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_lezFgZb:
@@ -59,7 +59,7 @@ Disassembly of section .text._D5cdcmp8test_lezFgZb:
 0000000000000000 <_D5cdcmp8test_lezFgZb>:
    0:	40 84 ff             	test   dil,dil
    3:	0f 9e c0             	setle  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_eqzFgZb:
@@ -67,7 +67,7 @@ Disassembly of section .text._D5cdcmp8test_eqzFgZb:
 0000000000000000 <_D5cdcmp8test_eqzFgZb>:
    0:	40 84 ff             	test   dil,dil
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_nezFgZb:
@@ -75,7 +75,7 @@ Disassembly of section .text._D5cdcmp8test_nezFgZb:
 0000000000000000 <_D5cdcmp8test_nezFgZb>:
    0:	40 84 ff             	test   dil,dil
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gezFgZb:
@@ -83,7 +83,7 @@ Disassembly of section .text._D5cdcmp8test_gezFgZb:
 0000000000000000 <_D5cdcmp8test_gezFgZb>:
    0:	40 84 ff             	test   dil,dil
    3:	0f 99 c0             	setns  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gtzFgZb:
@@ -91,14 +91,14 @@ Disassembly of section .text._D5cdcmp8test_gtzFgZb:
 0000000000000000 <_D5cdcmp8test_gtzFgZb>:
    0:	40 84 ff             	test   dil,dil
    3:	0f 9f c0             	setg   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_ltzFtZb:
 
 0000000000000000 <_D5cdcmp8test_ltzFtZb>:
    0:	31 c0                	xor    eax,eax
-   2:	c3                   	ret    
+   2:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_lezFtZb:
@@ -106,7 +106,7 @@ Disassembly of section .text._D5cdcmp8test_lezFtZb:
 0000000000000000 <_D5cdcmp8test_lezFtZb>:
    0:	66 85 ff             	test   di,di
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_eqzFtZb:
@@ -114,7 +114,7 @@ Disassembly of section .text._D5cdcmp8test_eqzFtZb:
 0000000000000000 <_D5cdcmp8test_eqzFtZb>:
    0:	66 85 ff             	test   di,di
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_nezFtZb:
@@ -122,14 +122,14 @@ Disassembly of section .text._D5cdcmp8test_nezFtZb:
 0000000000000000 <_D5cdcmp8test_nezFtZb>:
    0:	66 85 ff             	test   di,di
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gezFtZb:
 
 0000000000000000 <_D5cdcmp8test_gezFtZb>:
    0:	b8 01 00 00 00       	mov    eax,0x1
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gtzFtZb:
@@ -137,7 +137,7 @@ Disassembly of section .text._D5cdcmp8test_gtzFtZb:
 0000000000000000 <_D5cdcmp8test_gtzFtZb>:
    0:	66 85 ff             	test   di,di
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_ltzFsZb:
@@ -145,7 +145,7 @@ Disassembly of section .text._D5cdcmp8test_ltzFsZb:
 0000000000000000 <_D5cdcmp8test_ltzFsZb>:
    0:	66 85 ff             	test   di,di
    3:	0f 98 c0             	sets   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_lezFsZb:
@@ -153,7 +153,7 @@ Disassembly of section .text._D5cdcmp8test_lezFsZb:
 0000000000000000 <_D5cdcmp8test_lezFsZb>:
    0:	66 85 ff             	test   di,di
    3:	0f 9e c0             	setle  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_eqzFsZb:
@@ -161,7 +161,7 @@ Disassembly of section .text._D5cdcmp8test_eqzFsZb:
 0000000000000000 <_D5cdcmp8test_eqzFsZb>:
    0:	66 85 ff             	test   di,di
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_nezFsZb:
@@ -169,7 +169,7 @@ Disassembly of section .text._D5cdcmp8test_nezFsZb:
 0000000000000000 <_D5cdcmp8test_nezFsZb>:
    0:	66 85 ff             	test   di,di
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gezFsZb:
@@ -177,7 +177,7 @@ Disassembly of section .text._D5cdcmp8test_gezFsZb:
 0000000000000000 <_D5cdcmp8test_gezFsZb>:
    0:	66 85 ff             	test   di,di
    3:	0f 99 c0             	setns  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gtzFsZb:
@@ -185,14 +185,14 @@ Disassembly of section .text._D5cdcmp8test_gtzFsZb:
 0000000000000000 <_D5cdcmp8test_gtzFsZb>:
    0:	66 85 ff             	test   di,di
    3:	0f 9f c0             	setg   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_ltzFkZb:
 
 0000000000000000 <_D5cdcmp8test_ltzFkZb>:
    0:	31 c0                	xor    eax,eax
-   2:	c3                   	ret    
+   2:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_lezFkZb:
@@ -200,7 +200,7 @@ Disassembly of section .text._D5cdcmp8test_lezFkZb:
 0000000000000000 <_D5cdcmp8test_lezFkZb>:
    0:	85 ff                	test   edi,edi
    2:	0f 94 c0             	sete   al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_eqzFkZb:
@@ -208,7 +208,7 @@ Disassembly of section .text._D5cdcmp8test_eqzFkZb:
 0000000000000000 <_D5cdcmp8test_eqzFkZb>:
    0:	85 ff                	test   edi,edi
    2:	0f 94 c0             	sete   al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_nezFkZb:
@@ -216,14 +216,14 @@ Disassembly of section .text._D5cdcmp8test_nezFkZb:
 0000000000000000 <_D5cdcmp8test_nezFkZb>:
    0:	85 ff                	test   edi,edi
    2:	0f 95 c0             	setne  al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gezFkZb:
 
 0000000000000000 <_D5cdcmp8test_gezFkZb>:
    0:	b8 01 00 00 00       	mov    eax,0x1
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gtzFkZb:
@@ -231,7 +231,7 @@ Disassembly of section .text._D5cdcmp8test_gtzFkZb:
 0000000000000000 <_D5cdcmp8test_gtzFkZb>:
    0:	85 ff                	test   edi,edi
    2:	0f 95 c0             	setne  al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_ltzFiZb:
@@ -239,7 +239,7 @@ Disassembly of section .text._D5cdcmp8test_ltzFiZb:
 0000000000000000 <_D5cdcmp8test_ltzFiZb>:
    0:	8b c7                	mov    eax,edi
    2:	c1 e8 1f             	shr    eax,0x1f
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_lezFiZb:
@@ -249,14 +249,14 @@ Disassembly of section .text._D5cdcmp8test_lezFiZb:
    2:	83 c0 ff             	add    eax,0xffffffff
    5:	83 d0 00             	adc    eax,0x0
    8:	c1 e8 1f             	shr    eax,0x1f
-   b:	c3                   	ret    
+   b:	c3                   	ret
 
 Disassembly of section .text._D5cdcmp8test_eqzFiZb:
 
 0000000000000000 <_D5cdcmp8test_eqzFiZb>:
    0:	85 ff                	test   edi,edi
    2:	0f 94 c0             	sete   al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_nezFiZb:
@@ -264,7 +264,7 @@ Disassembly of section .text._D5cdcmp8test_nezFiZb:
 0000000000000000 <_D5cdcmp8test_nezFiZb>:
    0:	85 ff                	test   edi,edi
    2:	0f 95 c0             	setne  al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gezFiZb:
@@ -274,7 +274,7 @@ Disassembly of section .text._D5cdcmp8test_gezFiZb:
    2:	01 c0                	add    eax,eax
    4:	19 c0                	sbb    eax,eax
    6:	ff c0                	inc    eax
-   8:	c3                   	ret    
+   8:	c3                   	ret
    9:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -285,14 +285,14 @@ Disassembly of section .text._D5cdcmp8test_gtzFiZb:
    2:	f7 d8                	neg    eax
    4:	83 d8 00             	sbb    eax,0x0
    7:	c1 e8 1f             	shr    eax,0x1f
-   a:	c3                   	ret    
+   a:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_ltzFmZb:
 
 0000000000000000 <_D5cdcmp8test_ltzFmZb>:
    0:	31 c0                	xor    eax,eax
-   2:	c3                   	ret    
+   2:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_lezFmZb:
@@ -300,7 +300,7 @@ Disassembly of section .text._D5cdcmp8test_lezFmZb:
 0000000000000000 <_D5cdcmp8test_lezFmZb>:
    0:	48 85 ff             	test   rdi,rdi
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_eqzFmZb:
@@ -308,7 +308,7 @@ Disassembly of section .text._D5cdcmp8test_eqzFmZb:
 0000000000000000 <_D5cdcmp8test_eqzFmZb>:
    0:	48 85 ff             	test   rdi,rdi
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_nezFmZb:
@@ -316,14 +316,14 @@ Disassembly of section .text._D5cdcmp8test_nezFmZb:
 0000000000000000 <_D5cdcmp8test_nezFmZb>:
    0:	48 85 ff             	test   rdi,rdi
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gezFmZb:
 
 0000000000000000 <_D5cdcmp8test_gezFmZb>:
    0:	b8 01 00 00 00       	mov    eax,0x1
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gtzFmZb:
@@ -331,7 +331,7 @@ Disassembly of section .text._D5cdcmp8test_gtzFmZb:
 0000000000000000 <_D5cdcmp8test_gtzFmZb>:
    0:	48 85 ff             	test   rdi,rdi
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_ltzFlZb:
@@ -339,7 +339,7 @@ Disassembly of section .text._D5cdcmp8test_ltzFlZb:
 0000000000000000 <_D5cdcmp8test_ltzFlZb>:
    0:	48 8b c7             	mov    rax,rdi
    3:	48 c1 e8 3f          	shr    rax,0x3f
-   7:	c3                   	ret    
+   7:	c3                   	ret
 
 Disassembly of section .text._D5cdcmp8test_lezFlZb:
 
@@ -348,14 +348,14 @@ Disassembly of section .text._D5cdcmp8test_lezFlZb:
    3:	48 83 c0 ff          	add    rax,0xffffffffffffffff
    7:	48 83 d0 00          	adc    rax,0x0
    b:	48 c1 e8 3f          	shr    rax,0x3f
-   f:	c3                   	ret    
+   f:	c3                   	ret
 
 Disassembly of section .text._D5cdcmp8test_eqzFlZb:
 
 0000000000000000 <_D5cdcmp8test_eqzFlZb>:
    0:	48 85 ff             	test   rdi,rdi
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_nezFlZb:
@@ -363,7 +363,7 @@ Disassembly of section .text._D5cdcmp8test_nezFlZb:
 0000000000000000 <_D5cdcmp8test_nezFlZb>:
    0:	48 85 ff             	test   rdi,rdi
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp8test_gezFlZb:
@@ -373,7 +373,7 @@ Disassembly of section .text._D5cdcmp8test_gezFlZb:
    3:	48 01 c0             	add    rax,rax
    6:	48 19 c0             	sbb    rax,rax
    9:	48 ff c0             	inc    rax
-   c:	c3                   	ret    
+   c:	c3                   	ret
    d:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -384,7 +384,7 @@ Disassembly of section .text._D5cdcmp8test_gtzFlZb:
    3:	48 f7 d8             	neg    rax
    6:	48 83 d8 00          	sbb    rax,0x0
    a:	48 c1 e8 3f          	shr    rax,0x3f
-   e:	c3                   	ret    
+   e:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_ltFhhZb:
@@ -392,7 +392,7 @@ Disassembly of section .text._D5cdcmp7test_ltFhhZb:
 0000000000000000 <_D5cdcmp7test_ltFhhZb>:
    0:	40 38 fe             	cmp    sil,dil
    3:	0f 92 c0             	setb   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_leFhhZb:
@@ -400,7 +400,7 @@ Disassembly of section .text._D5cdcmp7test_leFhhZb:
 0000000000000000 <_D5cdcmp7test_leFhhZb>:
    0:	40 3a fe             	cmp    dil,sil
    3:	0f 93 c0             	setae  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_eqFhhZb:
@@ -408,7 +408,7 @@ Disassembly of section .text._D5cdcmp7test_eqFhhZb:
 0000000000000000 <_D5cdcmp7test_eqFhhZb>:
    0:	40 38 fe             	cmp    sil,dil
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_neFhhZb:
@@ -416,7 +416,7 @@ Disassembly of section .text._D5cdcmp7test_neFhhZb:
 0000000000000000 <_D5cdcmp7test_neFhhZb>:
    0:	40 38 fe             	cmp    sil,dil
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_geFhhZb:
@@ -424,7 +424,7 @@ Disassembly of section .text._D5cdcmp7test_geFhhZb:
 0000000000000000 <_D5cdcmp7test_geFhhZb>:
    0:	40 38 fe             	cmp    sil,dil
    3:	0f 93 c0             	setae  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_gtFhhZb:
@@ -432,7 +432,7 @@ Disassembly of section .text._D5cdcmp7test_gtFhhZb:
 0000000000000000 <_D5cdcmp7test_gtFhhZb>:
    0:	40 3a fe             	cmp    dil,sil
    3:	0f 92 c0             	setb   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_ltFggZb:
@@ -440,7 +440,7 @@ Disassembly of section .text._D5cdcmp7test_ltFggZb:
 0000000000000000 <_D5cdcmp7test_ltFggZb>:
    0:	40 38 fe             	cmp    sil,dil
    3:	0f 9c c0             	setl   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_leFggZb:
@@ -448,7 +448,7 @@ Disassembly of section .text._D5cdcmp7test_leFggZb:
 0000000000000000 <_D5cdcmp7test_leFggZb>:
    0:	40 38 fe             	cmp    sil,dil
    3:	0f 9e c0             	setle  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_eqFggZb:
@@ -456,7 +456,7 @@ Disassembly of section .text._D5cdcmp7test_eqFggZb:
 0000000000000000 <_D5cdcmp7test_eqFggZb>:
    0:	40 38 fe             	cmp    sil,dil
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_neFggZb:
@@ -464,7 +464,7 @@ Disassembly of section .text._D5cdcmp7test_neFggZb:
 0000000000000000 <_D5cdcmp7test_neFggZb>:
    0:	40 38 fe             	cmp    sil,dil
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_geFggZb:
@@ -472,7 +472,7 @@ Disassembly of section .text._D5cdcmp7test_geFggZb:
 0000000000000000 <_D5cdcmp7test_geFggZb>:
    0:	40 38 fe             	cmp    sil,dil
    3:	0f 9d c0             	setge  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_gtFggZb:
@@ -480,7 +480,7 @@ Disassembly of section .text._D5cdcmp7test_gtFggZb:
 0000000000000000 <_D5cdcmp7test_gtFggZb>:
    0:	40 38 fe             	cmp    sil,dil
    3:	0f 9f c0             	setg   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_ltFttZb:
@@ -488,7 +488,7 @@ Disassembly of section .text._D5cdcmp7test_ltFttZb:
 0000000000000000 <_D5cdcmp7test_ltFttZb>:
    0:	66 39 fe             	cmp    si,di
    3:	0f 92 c0             	setb   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_leFttZb:
@@ -496,7 +496,7 @@ Disassembly of section .text._D5cdcmp7test_leFttZb:
 0000000000000000 <_D5cdcmp7test_leFttZb>:
    0:	66 3b fe             	cmp    di,si
    3:	0f 93 c0             	setae  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_eqFttZb:
@@ -504,7 +504,7 @@ Disassembly of section .text._D5cdcmp7test_eqFttZb:
 0000000000000000 <_D5cdcmp7test_eqFttZb>:
    0:	66 39 fe             	cmp    si,di
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_neFttZb:
@@ -512,7 +512,7 @@ Disassembly of section .text._D5cdcmp7test_neFttZb:
 0000000000000000 <_D5cdcmp7test_neFttZb>:
    0:	66 39 fe             	cmp    si,di
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_geFttZb:
@@ -520,7 +520,7 @@ Disassembly of section .text._D5cdcmp7test_geFttZb:
 0000000000000000 <_D5cdcmp7test_geFttZb>:
    0:	66 39 fe             	cmp    si,di
    3:	0f 93 c0             	setae  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_gtFttZb:
@@ -528,7 +528,7 @@ Disassembly of section .text._D5cdcmp7test_gtFttZb:
 0000000000000000 <_D5cdcmp7test_gtFttZb>:
    0:	66 3b fe             	cmp    di,si
    3:	0f 92 c0             	setb   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_ltFssZb:
@@ -536,7 +536,7 @@ Disassembly of section .text._D5cdcmp7test_ltFssZb:
 0000000000000000 <_D5cdcmp7test_ltFssZb>:
    0:	66 39 fe             	cmp    si,di
    3:	0f 9c c0             	setl   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_leFssZb:
@@ -544,7 +544,7 @@ Disassembly of section .text._D5cdcmp7test_leFssZb:
 0000000000000000 <_D5cdcmp7test_leFssZb>:
    0:	66 39 fe             	cmp    si,di
    3:	0f 9e c0             	setle  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_eqFssZb:
@@ -552,7 +552,7 @@ Disassembly of section .text._D5cdcmp7test_eqFssZb:
 0000000000000000 <_D5cdcmp7test_eqFssZb>:
    0:	66 39 fe             	cmp    si,di
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_neFssZb:
@@ -560,7 +560,7 @@ Disassembly of section .text._D5cdcmp7test_neFssZb:
 0000000000000000 <_D5cdcmp7test_neFssZb>:
    0:	66 39 fe             	cmp    si,di
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_geFssZb:
@@ -568,7 +568,7 @@ Disassembly of section .text._D5cdcmp7test_geFssZb:
 0000000000000000 <_D5cdcmp7test_geFssZb>:
    0:	66 39 fe             	cmp    si,di
    3:	0f 9d c0             	setge  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_gtFssZb:
@@ -576,7 +576,7 @@ Disassembly of section .text._D5cdcmp7test_gtFssZb:
 0000000000000000 <_D5cdcmp7test_gtFssZb>:
    0:	66 39 fe             	cmp    si,di
    3:	0f 9f c0             	setg   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_ltFkkZb:
@@ -584,7 +584,7 @@ Disassembly of section .text._D5cdcmp7test_ltFkkZb:
 0000000000000000 <_D5cdcmp7test_ltFkkZb>:
    0:	39 fe                	cmp    esi,edi
    2:	0f 92 c0             	setb   al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_leFkkZb:
@@ -592,7 +592,7 @@ Disassembly of section .text._D5cdcmp7test_leFkkZb:
 0000000000000000 <_D5cdcmp7test_leFkkZb>:
    0:	3b fe                	cmp    edi,esi
    2:	0f 93 c0             	setae  al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_eqFkkZb:
@@ -600,7 +600,7 @@ Disassembly of section .text._D5cdcmp7test_eqFkkZb:
 0000000000000000 <_D5cdcmp7test_eqFkkZb>:
    0:	39 fe                	cmp    esi,edi
    2:	0f 94 c0             	sete   al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_neFkkZb:
@@ -608,7 +608,7 @@ Disassembly of section .text._D5cdcmp7test_neFkkZb:
 0000000000000000 <_D5cdcmp7test_neFkkZb>:
    0:	39 fe                	cmp    esi,edi
    2:	0f 95 c0             	setne  al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_geFkkZb:
@@ -616,7 +616,7 @@ Disassembly of section .text._D5cdcmp7test_geFkkZb:
 0000000000000000 <_D5cdcmp7test_geFkkZb>:
    0:	39 fe                	cmp    esi,edi
    2:	0f 93 c0             	setae  al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_gtFkkZb:
@@ -624,7 +624,7 @@ Disassembly of section .text._D5cdcmp7test_gtFkkZb:
 0000000000000000 <_D5cdcmp7test_gtFkkZb>:
    0:	3b fe                	cmp    edi,esi
    2:	0f 92 c0             	setb   al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_ltFiiZb:
@@ -632,7 +632,7 @@ Disassembly of section .text._D5cdcmp7test_ltFiiZb:
 0000000000000000 <_D5cdcmp7test_ltFiiZb>:
    0:	39 fe                	cmp    esi,edi
    2:	0f 9c c0             	setl   al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_leFiiZb:
@@ -640,7 +640,7 @@ Disassembly of section .text._D5cdcmp7test_leFiiZb:
 0000000000000000 <_D5cdcmp7test_leFiiZb>:
    0:	39 fe                	cmp    esi,edi
    2:	0f 9e c0             	setle  al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_eqFiiZb:
@@ -648,7 +648,7 @@ Disassembly of section .text._D5cdcmp7test_eqFiiZb:
 0000000000000000 <_D5cdcmp7test_eqFiiZb>:
    0:	39 fe                	cmp    esi,edi
    2:	0f 94 c0             	sete   al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_neFiiZb:
@@ -656,7 +656,7 @@ Disassembly of section .text._D5cdcmp7test_neFiiZb:
 0000000000000000 <_D5cdcmp7test_neFiiZb>:
    0:	39 fe                	cmp    esi,edi
    2:	0f 95 c0             	setne  al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_geFiiZb:
@@ -664,7 +664,7 @@ Disassembly of section .text._D5cdcmp7test_geFiiZb:
 0000000000000000 <_D5cdcmp7test_geFiiZb>:
    0:	39 fe                	cmp    esi,edi
    2:	0f 9d c0             	setge  al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_gtFiiZb:
@@ -672,7 +672,7 @@ Disassembly of section .text._D5cdcmp7test_gtFiiZb:
 0000000000000000 <_D5cdcmp7test_gtFiiZb>:
    0:	39 fe                	cmp    esi,edi
    2:	0f 9f c0             	setg   al
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_ltFmmZb:
@@ -680,7 +680,7 @@ Disassembly of section .text._D5cdcmp7test_ltFmmZb:
 0000000000000000 <_D5cdcmp7test_ltFmmZb>:
    0:	48 39 fe             	cmp    rsi,rdi
    3:	0f 92 c0             	setb   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_leFmmZb:
@@ -688,7 +688,7 @@ Disassembly of section .text._D5cdcmp7test_leFmmZb:
 0000000000000000 <_D5cdcmp7test_leFmmZb>:
    0:	48 3b fe             	cmp    rdi,rsi
    3:	0f 93 c0             	setae  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_eqFmmZb:
@@ -696,7 +696,7 @@ Disassembly of section .text._D5cdcmp7test_eqFmmZb:
 0000000000000000 <_D5cdcmp7test_eqFmmZb>:
    0:	48 39 fe             	cmp    rsi,rdi
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_neFmmZb:
@@ -704,7 +704,7 @@ Disassembly of section .text._D5cdcmp7test_neFmmZb:
 0000000000000000 <_D5cdcmp7test_neFmmZb>:
    0:	48 39 fe             	cmp    rsi,rdi
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_geFmmZb:
@@ -712,7 +712,7 @@ Disassembly of section .text._D5cdcmp7test_geFmmZb:
 0000000000000000 <_D5cdcmp7test_geFmmZb>:
    0:	48 39 fe             	cmp    rsi,rdi
    3:	0f 93 c0             	setae  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_gtFmmZb:
@@ -720,7 +720,7 @@ Disassembly of section .text._D5cdcmp7test_gtFmmZb:
 0000000000000000 <_D5cdcmp7test_gtFmmZb>:
    0:	48 3b fe             	cmp    rdi,rsi
    3:	0f 92 c0             	setb   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_ltFllZb:
@@ -728,7 +728,7 @@ Disassembly of section .text._D5cdcmp7test_ltFllZb:
 0000000000000000 <_D5cdcmp7test_ltFllZb>:
    0:	48 39 fe             	cmp    rsi,rdi
    3:	0f 9c c0             	setl   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_leFllZb:
@@ -736,7 +736,7 @@ Disassembly of section .text._D5cdcmp7test_leFllZb:
 0000000000000000 <_D5cdcmp7test_leFllZb>:
    0:	48 39 fe             	cmp    rsi,rdi
    3:	0f 9e c0             	setle  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_eqFllZb:
@@ -744,7 +744,7 @@ Disassembly of section .text._D5cdcmp7test_eqFllZb:
 0000000000000000 <_D5cdcmp7test_eqFllZb>:
    0:	48 39 fe             	cmp    rsi,rdi
    3:	0f 94 c0             	sete   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_neFllZb:
@@ -752,7 +752,7 @@ Disassembly of section .text._D5cdcmp7test_neFllZb:
 0000000000000000 <_D5cdcmp7test_neFllZb>:
    0:	48 39 fe             	cmp    rsi,rdi
    3:	0f 95 c0             	setne  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_geFllZb:
@@ -760,7 +760,7 @@ Disassembly of section .text._D5cdcmp7test_geFllZb:
 0000000000000000 <_D5cdcmp7test_geFllZb>:
    0:	48 39 fe             	cmp    rsi,rdi
    3:	0f 9d c0             	setge  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_gtFllZb:
@@ -768,7 +768,7 @@ Disassembly of section .text._D5cdcmp7test_gtFllZb:
 0000000000000000 <_D5cdcmp7test_gtFllZb>:
    0:	48 39 fe             	cmp    rsi,rdi
    3:	0f 9f c0             	setg   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_ltFffZb:
@@ -776,7 +776,7 @@ Disassembly of section .text._D5cdcmp7test_ltFffZb:
 0000000000000000 <_D5cdcmp7test_ltFffZb>:
    0:	0f 2e c1             	ucomiss xmm0,xmm1
    3:	0f 97 c0             	seta   al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_leFffZb:
@@ -784,7 +784,7 @@ Disassembly of section .text._D5cdcmp7test_leFffZb:
 0000000000000000 <_D5cdcmp7test_leFffZb>:
    0:	0f 2e c1             	ucomiss xmm0,xmm1
    3:	0f 93 c0             	setae  al
-   6:	c3                   	ret    
+   6:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_eqFffZb:
@@ -795,7 +795,7 @@ Disassembly of section .text._D5cdcmp7test_eqFffZb:
    8:	7a 02                	jp     c <_D5cdcmp7test_eqFffZb+0xc>
    a:	74 02                	je     e <_D5cdcmp7test_eqFffZb+0xe>
    c:	31 c0                	xor    eax,eax
-   e:	c3                   	ret    
+   e:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_neFffZb:
@@ -806,7 +806,7 @@ Disassembly of section .text._D5cdcmp7test_neFffZb:
    8:	75 04                	jne    e <_D5cdcmp7test_neFffZb+0xe>
    a:	7a 02                	jp     e <_D5cdcmp7test_neFffZb+0xe>
    c:	31 c0                	xor    eax,eax
-   e:	c3                   	ret    
+   e:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_geFffZb:
@@ -817,7 +817,7 @@ Disassembly of section .text._D5cdcmp7test_geFffZb:
    8:	7a 02                	jp     c <_D5cdcmp7test_geFffZb+0xc>
    a:	76 02                	jbe    e <_D5cdcmp7test_geFffZb+0xe>
    c:	31 c0                	xor    eax,eax
-   e:	c3                   	ret    
+   e:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_gtFffZb:
@@ -828,7 +828,7 @@ Disassembly of section .text._D5cdcmp7test_gtFffZb:
    8:	7a 02                	jp     c <_D5cdcmp7test_gtFffZb+0xc>
    a:	72 02                	jb     e <_D5cdcmp7test_gtFffZb+0xe>
    c:	31 c0                	xor    eax,eax
-   e:	c3                   	ret    
+   e:	c3                   	ret
 	...
 
 Disassembly of section .text._D5cdcmp7test_ltFddZb:
@@ -836,14 +836,14 @@ Disassembly of section .text._D5cdcmp7test_ltFddZb:
 0000000000000000 <_D5cdcmp7test_ltFddZb>:
    0:	66 0f 2e c1          	ucomisd xmm0,xmm1
    4:	0f 97 c0             	seta   al
-   7:	c3                   	ret    
+   7:	c3                   	ret
 
 Disassembly of section .text._D5cdcmp7test_leFddZb:
 
 0000000000000000 <_D5cdcmp7test_leFddZb>:
    0:	66 0f 2e c1          	ucomisd xmm0,xmm1
    4:	0f 93 c0             	setae  al
-   7:	c3                   	ret    
+   7:	c3                   	ret
 
 Disassembly of section .text._D5cdcmp7test_eqFddZb:
 
@@ -853,7 +853,7 @@ Disassembly of section .text._D5cdcmp7test_eqFddZb:
    9:	7a 02                	jp     d <_D5cdcmp7test_eqFddZb+0xd>
    b:	74 02                	je     f <_D5cdcmp7test_eqFddZb+0xf>
    d:	31 c0                	xor    eax,eax
-   f:	c3                   	ret    
+   f:	c3                   	ret
 
 Disassembly of section .text._D5cdcmp7test_neFddZb:
 
@@ -863,7 +863,7 @@ Disassembly of section .text._D5cdcmp7test_neFddZb:
    9:	75 04                	jne    f <_D5cdcmp7test_neFddZb+0xf>
    b:	7a 02                	jp     f <_D5cdcmp7test_neFddZb+0xf>
    d:	31 c0                	xor    eax,eax
-   f:	c3                   	ret    
+   f:	c3                   	ret
 
 Disassembly of section .text._D5cdcmp7test_geFddZb:
 
@@ -873,7 +873,7 @@ Disassembly of section .text._D5cdcmp7test_geFddZb:
    9:	7a 02                	jp     d <_D5cdcmp7test_geFddZb+0xd>
    b:	76 02                	jbe    f <_D5cdcmp7test_geFddZb+0xf>
    d:	31 c0                	xor    eax,eax
-   f:	c3                   	ret    
+   f:	c3                   	ret
 
 Disassembly of section .text._D5cdcmp7test_gtFddZb:
 
@@ -883,7 +883,7 @@ Disassembly of section .text._D5cdcmp7test_gtFddZb:
    9:	7a 02                	jp     d <_D5cdcmp7test_gtFddZb+0xd>
    b:	72 02                	jb     f <_D5cdcmp7test_gtFddZb+0xf>
    d:	31 c0                	xor    eax,eax
-   f:	c3                   	ret    
+   f:	c3                   	ret
 
 Disassembly of section .text.d_dso_init:
 
@@ -899,5 +899,5 @@ Disassembly of section .text.d_dso_init:
   1c:	6a 01                	push   0x1
   1e:	48 8b fc             	mov    rdi,rsp
   21:	e8 00 00 00 00       	call   26 <.text.d_dso_init+0x26>
-  26:	c9                   	leave  
-  27:	c3                   	ret    
+  26:	c9                   	leave
+  27:	c3                   	ret

--- a/compiler/test/compilable/extra-files/objdump-postscript.sh
+++ b/compiler/test/compilable/extra-files/objdump-postscript.sh
@@ -10,7 +10,7 @@ objdump --disassemble --disassembler-options=intel-mnemonic "${obj_file}" > "${o
 
 echo SANITIZING Objdump...
 < "${obj_file}.dump" \
-    tail -n+3 > "${obj_file}.dump.sanitized"
+    tail -n+3 | sed 's/[ \t]\s*$//' > "${obj_file}.dump.sanitized"
 
 diff -up --strip-trailing-cr "${expect_file}" "${obj_file}.dump.sanitized"
 


### PR DESCRIPTION
Test started failing, seems to be related to binutils version.