### PR TITLE
Fix issue 23514 - Incorrect compilation when adding a 64-bit constant to a link-time address

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -514,7 +514,7 @@ elem* toElem(Expression e, IRState *irs)
     {
         elem *e;
         Type tb = (se.op == EXP.symbolOffset) ? se.var.type.toBasetype() : se.type.toBasetype();
-        int offset = (se.op == EXP.symbolOffset) ? cast(int)(cast(SymOffExp)se).offset : 0;
+        long offset = (se.op == EXP.symbolOffset) ? cast(long)(cast(SymOffExp)se).offset : 0;
         VarDeclaration v = se.var.isVarDeclaration();
 
         //printf("[%s] SymbolExp.toElem('%s') %p, %s\n", se.loc.toChars(), se.toChars(), se, se.type.toChars());

--- a/compiler/test/runnable/test23514.d
+++ b/compiler/test/runnable/test23514.d
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=23514
+
+enum offset = 0xFFFF_FFFF_0000_0000UL;
+
+void main()
+{
+    assert((cast(ulong)&main) != (cast(ulong)&main + offset));
+}

--- a/compiler/test/runnable/test23514.d
+++ b/compiler/test/runnable/test23514.d
@@ -5,5 +5,6 @@ enum offset = 0xFFFF_FFFF_0000_0000UL;
 
 void main()
 {
-    assert((cast(ulong)&main) != (cast(ulong)&main + offset));
+    size_t voffset = offset;
+    assert((cast(size_t)&main + voffset) == (cast(size_t)&main + offset));
 }

--- a/compiler/test/runnable/test23514.d
+++ b/compiler/test/runnable/test23514.d
@@ -1,4 +1,5 @@
-// REQUIRED_ARGS: -O
+// REQUIRED_ARGS: -m64 -O
+// DISABLED: win32 linux32 freebsd32 osx32 netbsd32 dragonflybsd32
 // https://issues.dlang.org/show_bug.cgi?id=23514
 
 enum ulong offset = 0xFFFF_FFFF_0000_0000UL;

--- a/compiler/test/runnable/test23514.d
+++ b/compiler/test/runnable/test23514.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -O
 // https://issues.dlang.org/show_bug.cgi?id=23514
 
 enum offset = 0xFFFF_FFFF_0000_0000UL;

--- a/compiler/test/runnable/test23514.d
+++ b/compiler/test/runnable/test23514.d
@@ -1,5 +1,4 @@
-// REQUIRED_ARGS: -m64 -O
-// DISABLED: win32 linux32 freebsd32 osx32 netbsd32 dragonflybsd32
+// REQUIRED_ARGS: -O
 // https://issues.dlang.org/show_bug.cgi?id=23514
 
 enum ulong offset = 0xFFFF_FFFF_0000_0000UL;

--- a/compiler/test/runnable/test23514.d
+++ b/compiler/test/runnable/test23514.d
@@ -1,5 +1,8 @@
-// REQUIRED_ARGS: -O
+// DISABLED: win64
 // https://issues.dlang.org/show_bug.cgi?id=23514
+
+// Note: this test is disabled on Win64 because of an issue with the Windows
+// MS-COFF backend causing it to fail.
 
 enum ulong offset = 0xFFFF_FFFF_0000_0000UL;
 

--- a/compiler/test/runnable/test23514.d
+++ b/compiler/test/runnable/test23514.d
@@ -1,10 +1,10 @@
 // REQUIRED_ARGS: -O
 // https://issues.dlang.org/show_bug.cgi?id=23514
 
-enum offset = 0xFFFF_FFFF_0000_0000UL;
+enum ulong offset = 0xFFFF_FFFF_0000_0000UL;
 
 void main()
 {
-    size_t voffset = offset;
-    assert((cast(size_t)&main + voffset) == (cast(size_t)&main + offset));
+    ulong voffset = offset;
+    assert((cast(ulong)&main + voffset) == (cast(ulong)&main + offset));
 }


### PR DESCRIPTION
The current cast to int causes a loss of precision since `SymOffExp.offset` is a `dinteger_t` (aka `ulong`), which can result in incorrect compilation. See the bugzilla issue for an example. I also previously reported the issue to LDC: https://github.com/ldc-developers/ldc/issues/4264, so I think this fix should close that issue too once it gets into the DMD frontend used in LDC.

Bugzilla issue: https://issues.dlang.org/show_bug.cgi?id=23514.

Thanks!