### PR TITLE
fix Issue 23490 - [REG 2.101] Class vtable being overwritten by class semantic ran out of order

### DIFF
--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -468,7 +468,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     {
         //printf("%s.ClassDeclaration.search('%s', flags=x%x)\n", toChars(), ident.toChars(), flags);
         //if (_scope) printf("%s baseok = %d\n", toChars(), baseok);
-        if (_scope && baseok < Baseok.done)
+        if (_scope && baseok < Baseok.semanticdone)
         {
             if (!inuse)
             {

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -5153,6 +5153,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 }
 
                 // Copy vtbl[] from base class
+                assert(cldec.vtbl.dim == 0);
                 cldec.vtbl.setDim(cldec.baseClass.vtbl.dim);
                 memcpy(cldec.vtbl.tdata(), cldec.baseClass.vtbl.tdata(), (void*).sizeof * cldec.vtbl.dim);
 

--- a/compiler/test/compilable/imports/test23490frop.d
+++ b/compiler/test/compilable/imports/test23490frop.d
@@ -1,0 +1,7 @@
+module imports.test23490frop;
+import imports.test23490pop;
+class Mu23490 : Pop23490 { }
+class Frop23490 : Pop23490 {
+  // final       // does not fail if declared final
+  void frolick() {}
+}

--- a/compiler/test/compilable/imports/test23490pop.d
+++ b/compiler/test/compilable/imports/test23490pop.d
@@ -1,0 +1,7 @@
+module imports.test23490pop;
+import imports.test23490frop;
+import imports.test23490zoo : Zoo23490;
+class Pop23490 {
+  void frop(Frop23490) { }
+  void zoo(Zoo23490) { }
+}

--- a/compiler/test/compilable/imports/test23490zoo.d
+++ b/compiler/test/compilable/imports/test23490zoo.d
@@ -1,0 +1,17 @@
+module imports.test23490zoo;
+import imports.test23490pop;
+import imports.test23490frop;
+class Foo23490() : Pop23490 {
+  override void frop(Frop23490 f) {
+    f.frolick;
+  }
+}
+class Baz23490 {
+  Foo23490!() foo;
+  Frop23490 frop;
+}
+class Bar23490 {
+  static instance() { return new Baz23490; }
+  auto ss = __traits(getAttributes, instance.frop);
+}
+class Zoo23490 { }

--- a/compiler/test/compilable/test23490.d
+++ b/compiler/test/compilable/test23490.d
@@ -1,0 +1,3 @@
+// https://issues.dlang.org/show_bug.cgi?id=23490
+// EXTRA_FILES: imports/test23490frop.d imports/test23490pop.d imports/test23490zoo.d
+import imports.test23490pop;


### PR DESCRIPTION
All base classes should finish semantic before owned members are added to the vtable.  Fixed regression by ensuring this is done, and added an ICE test to ensure that the `memcpy()` of vtbl doesn't overwrite any existing entries.