### PR TITLE
Fix 23531 - scope variable can be assigned as AA key

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -8473,6 +8473,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
 
                 semanticTypeInfo(sc, taa);
+                checkNewEscape(sc, exp.e2, false);
 
                 exp.type = taa.next;
                 break;
@@ -10365,9 +10366,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
 
         exp.type = exp.e1.type;
+        auto assignElem = exp.e2;
         auto res = exp.reorderSettingAAElem(sc);
-        if (exp.op == EXP.concatenateElemAssign || exp.op == EXP.concatenateDcharAssign)
+        if (res != exp) // `AA[k] = v` rewrite was performed
+            checkNewEscape(sc, assignElem, false);
+        else if (exp.op == EXP.concatenateElemAssign || exp.op == EXP.concatenateDcharAssign)
             checkAssignEscape(sc, res, false, false);
+
         result = res;
 
         if ((exp.op == EXP.concatenateAssign || exp.op == EXP.concatenateElemAssign) &&

--- a/compiler/test/fail_compilation/fail22366.d
+++ b/compiler/test/fail_compilation/fail22366.d
@@ -1,15 +1,33 @@
-// REQUIRED_ARGS: -dip1000
-
 /*
+REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail22366.d(13): Error: scope variable `x` may not be copied into allocated memory
+fail_compilation/fail22366.d(22): Error: scope variable `s` may not be copied into allocated memory
+fail_compilation/fail22366.d(25): Error: scope variable `s` may not be copied into allocated memory
+fail_compilation/fail22366.d(26): Error: scope variable `s` may not be copied into allocated memory
+fail_compilation/fail22366.d(27): Error: scope variable `s` may not be copied into allocated memory
+fail_compilation/fail22366.d(28): Error: scope variable `s` may not be copied into allocated memory
+fail_compilation/fail22366.d(31): Error: scope variable `s` may not be copied into allocated memory
+fail_compilation/fail22366.d(32): Error: scope variable `s` may not be copied into allocated memory
 ---
 */
 
-int* fun(scope int* x) @safe
+// Test escaping scope variables through AA keys / values
+// https://issues.dlang.org/show_bug.cgi?id=22366
+// https://issues.dlang.org/show_bug.cgi?id=23531
+
+void fun(scope string s) @safe
 {
-    int*[int] aa;
-    aa[0] = x; // should give an error
-    return aa[0];
+    int[string] aa;
+    aa[s] ^^= 3;
+
+    string[string] saa;
+    saa[""] = s;
+    saa[""] ~= s;
+    saa[s] = "";
+    saa[s] ~= "";
+
+    string[string][string] snaa;
+    snaa[s][""] = "";
+    snaa[""][s] = "";
 }

--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -2218,7 +2218,7 @@ char[] reencodeMangled(return scope const(char)[] mangled) nothrow pure @safe
             }
         }
 
-        bool parseLName(scope ref Remangle d) scope
+        bool parseLName(scope ref Remangle d) scope @trusted
         {
             flushPosition(d);
 
@@ -2269,7 +2269,7 @@ char[] reencodeMangled(return scope const(char)[] mangled) nothrow pure @safe
                 }
                 else
                 {
-                    idpos[id] = refpos;
+                    idpos[id] = refpos; //! scope variable id used as AA key, makes this function @trusted
                     result ~= d.buf[refpos .. d.pos];
                 }
             }


### PR DESCRIPTION
Indexing without assignment should maybe remain allowed with scope variables. 

The druntime breakage is really annoying, the `demangle.d` module is always fragile when it comes to dip1000 fixes.