### PR TITLE
Translate `_d_newitem{U,T,iT}` to a template

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -1195,12 +1195,11 @@ elem* toElem(Expression e, IRState *irs)
             elem *ezprefix = null;
             elem *ez = null;
 
-            // call _d_newitemT(ti)
-            e = getTypeInfo(ne, ne.newtype, irs);
-
-            const rtl = t.isZeroInit(Loc.initial) ? RTLSYM.NEWITEMT : RTLSYM.NEWITEMIT;
-            ex = el_bin(OPcall,TYnptr,el_var(getRtlsym(rtl)),e);
-            toTraceGC(irs, ex, ne.loc);
+            // Call _d_newitemT()
+            if (auto lowering = ne.lowering)
+                ex = toElem(ne.lowering, irs);
+            else
+                assert(0, "This case should have been rewritten to `_d_newitemT` in the semantic phase");
 
             ectype = null;
 
@@ -1296,12 +1295,8 @@ elem* toElem(Expression e, IRState *irs)
         {
             elem *ezprefix = ne.argprefix ? toElem(ne.argprefix, irs) : null;
 
-            // call _d_newitemT(ti)
-            e = getTypeInfo(ne, ne.newtype, irs);
-
-            const rtl = tp.next.isZeroInit(Loc.initial) ? RTLSYM.NEWITEMT : RTLSYM.NEWITEMIT;
-            e = el_bin(OPcall,TYnptr,el_var(getRtlsym(rtl)),e);
-            toTraceGC(irs, e, ne.loc);
+            // call _d_newitemT()
+            e = toElem(ne.lowering, irs);
 
             if (ne.arguments && ne.arguments.length == 1)
             {

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -1530,6 +1530,11 @@ extern (C++) abstract class Expression : ASTNode
             return false;
         if (sc.flags & (SCOPE.ctfe | SCOPE.debug_))
             return false;
+        /* The original expression (`new S(...)`) will be verified instead. This
+         * is to keep errors related to the original code and not the lowering.
+         */
+        if (f.ident == Id._d_newitemT)
+            return false;
 
         if (!f.isNogc())
         {
@@ -3672,7 +3677,7 @@ extern (C++) final class NewExp : Expression
     bool onstack;               // allocate on stack
     bool thrownew;              // this NewExp is the expression of a ThrowStatement
 
-    Expression lowering;        // lowered druntime hook: `_d_newclass`
+    Expression lowering;        // lowered druntime hook: `_d_new{class,itemT}`
 
     /// Puts the `arguments` and `names` into an `ArgumentList` for easily passing them around.
     /// The fields are still separate for backwards compatibility

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8723,6 +8723,8 @@ struct Id final
     static Identifier* _d_newThrowable;
     static Identifier* _d_newclassT;
     static Identifier* _d_newclassTTrace;
+    static Identifier* _d_newitemT;
+    static Identifier* _d_newitemTTrace;
     static Identifier* _d_assert_fail;
     static Identifier* dup;
     static Identifier* _aaApply;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -315,6 +315,8 @@ immutable Msgtable[] msgtable =
     { "_d_newThrowable" },
     { "_d_newclassT" },
     { "_d_newclassTTrace" },
+    { "_d_newitemT" },
+    { "_d_newitemTTrace" },
     { "_d_assert_fail" },
     { "dup" },
     { "_aaApply" },

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -2777,6 +2777,70 @@ if (is(T == class))
     return cast(T) p;
 }
 
+/**
+ * TraceGC wrapper around $(REF _d_newclassT, core,lifetime).
+ */
+T _d_newclassTTrace(T)(string file, int line, string funcname) @trusted
+{
+    version (D_TypeInfo)
+    {
+        import core.internal.array.utils : TraceHook, gcStatsPure, accumulatePure;
+        mixin(TraceHook!(T.stringof, "_d_newclassT"));
+
+        return _d_newclassT!T();
+    }
+    else
+        assert(0, "Cannot create new class if compiling without support for runtime type information!");
+}
+
+/**
+ * Allocate an initialized non-array item.
+ *
+ * This is an optimization to avoid things needed for arrays like the __arrayPad(size).
+ * Used to allocate struct instances on the heap.
+ *
+ * ---
+ * struct Sz {int x = 0;}
+ * struct Si {int x = 3;}
+ *
+ * void main()
+ * {
+ *     new Sz(); // uses zero-initialization
+ *     new Si(); // uses Si.init
+ * }
+ * ---
+ *
+ * Returns:
+ *     newly allocated item
+ */
+T* _d_newitemT(T)() @trusted
+{
+    import core.internal.lifetime : emplaceInitializer;
+    import core.internal.traits : hasElaborateDestructor, hasIndirections;
+    import core.memory : GC;
+
+    auto flags = !hasIndirections!T ? GC.BlkAttr.NO_SCAN : GC.BlkAttr.NONE;
+    immutable tiSize = hasElaborateDestructor!T ? size_t.sizeof : 0;
+    immutable itemSize = T.sizeof;
+    immutable totalSize = itemSize + tiSize;
+    if (tiSize)
+        flags |= GC.BlkAttr.STRUCTFINAL | GC.BlkAttr.FINALIZE;
+
+    auto blkInfo = GC.qalloc(totalSize, flags, null);
+    auto p = blkInfo.base;
+
+    if (tiSize)
+    {
+        // The GC might not have cleared the padding area in the block.
+        *cast(TypeInfo*) (p + (itemSize & ~(size_t.sizeof - 1))) = null;
+        *cast(TypeInfo*) (p + blkInfo.size - tiSize) = cast() typeid(T);
+    }
+
+    emplaceInitializer(*(cast(T*) p));
+
+    return cast(T*) p;
+}
+
 // Test allocation
 @safe unittest
 {
@@ -2805,15 +2869,134 @@ if (is(T == class))
     }
 }
 
-T _d_newclassTTrace(T)(string file, int line, string funcname) @trusted
+// Test allocation
+@safe unittest
 {
-    version (D_TypeInfo)
-    {
-        import core.internal.array.utils: TraceHook, gcStatsPure, accumulatePure;
-        mixin(TraceHook!(T.stringof, "_d_newclassT"));
+    struct S { }
+    S* s = _d_newitemT!S();
 
-        return _d_newclassT!T();
+    assert(s !is null);
+}
+
+// Test initializers
+@safe unittest
+{
+    {
+        // zero-initialization
+        struct S { int x, y; }
+        S* s = _d_newitemT!S();
+
+        assert(s.x == 0);
+        assert(s.y == 0);
     }
-    else
-        assert(0, "Cannot create new class if compiling without support for runtime type information!");
+    {
+        // S.init
+        struct S { int x = 2, y = 3; }
+        S* s = _d_newitemT!S();
+
+        assert(s.x == 2);
+        assert(s.y == 3);
+    }
+}
+
+// Test GC attributes
+version (CoreUnittest)
+{
+    struct S1
+    {
+        int x = 5;
+    }
+    struct S2
+    {
+        int x;
+        this(int x) { this.x = x; }
+    }
+    struct S3
+    {
+        int[4] x;
+        this(int x) { this.x[] = x; }
+    }
+    struct S4
+    {
+        int *x;
+    }
+
+}
+@system unittest
+{
+    import core.memory : GC;
+
+    auto s1 = new S1;
+    assert(s1.x == 5);
+    assert(GC.getAttr(s1) == GC.BlkAttr.NO_SCAN);
+
+    auto s2 = new S2(3);
+    assert(s2.x == 3);
+    assert(GC.getAttr(s2) == GC.BlkAttr.NO_SCAN);
+
+    auto s3 = new S3(1);
+    assert(s3.x == [1, 1, 1, 1]);
+    assert(GC.getAttr(s3) == GC.BlkAttr.NO_SCAN);
+    debug(SENTINEL) {} else
+        assert(GC.sizeOf(s3) == 16);
+
+    auto s4 = new S4;
+    assert(s4.x == null);
+    assert(GC.getAttr(s4) == 0);
+}
+
+// Test struct finalizers exception handling
+debug(SENTINEL) {} else
+@system unittest
+{
+    import core.memory : GC;
+
+    bool test(E)()
+    {
+        import core.exception;
+        static struct S1
+        {
+            E exc;
+            ~this() { throw exc; }
+        }
+
+        bool caught = false;
+        S1* s = new S1(new E("test onFinalizeError"));
+        try
+        {
+            GC.runFinalizers((cast(char*)(typeid(S1).xdtor))[0 .. 1]);
+        }
+        catch (FinalizeError err)
+        {
+            caught = true;
+        }
+        catch (E)
+        {
+        }
+        GC.free(s);
+        return caught;
+    }
+
+    assert(test!Exception);
+    import core.exception : InvalidMemoryOperationError;
+    assert(!test!InvalidMemoryOperationError);
+}
+
+version (D_ProfileGC)
+{
+    /**
+    * TraceGC wrapper around $(REF _d_newitemT, core,lifetime).
+    */
+    T* _d_newitemTTrace(T)(string file, int line, string funcname) @trusted
+    {
+        version (D_TypeInfo)
+        {
+            import core.internal.array.utils : TraceHook, gcStatsPure, accumulatePure;
+            mixin(TraceHook!(T.stringof, "_d_newitemT"));
+
+            return _d_newitemT!T();
+        }
+        else
+            assert(0, "Cannot create new `struct` if compiling without support for runtime type information!");
+    }
 }

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -4532,6 +4532,7 @@ version (D_ProfileGC)
 {
     public import core.internal.array.appending : _d_arrayappendTTrace;
     public import core.internal.array.concatenation : _d_arraycatnTXTrace;
+    public import core.lifetime : _d_newitemTTrace;
 }
 public import core.internal.array.appending : _d_arrayappendcTXImpl;
 public import core.internal.array.comparison : __cmp;
@@ -4560,6 +4561,7 @@ public import core.lifetime : _d_delstructImpl;
 public import core.lifetime : _d_newThrowable;
 public import core.lifetime : _d_newclassT;
 public import core.lifetime : _d_newclassTTrace;
+public import core.lifetime : _d_newitemT;
 
 public @trusted @nogc nothrow pure extern (C) void _d_delThrowable(scope Throwable);
 

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -1148,25 +1148,8 @@ extern (C) void[] _d_newarraymiTX(const TypeInfo ti, size_t[] dims) @weak
 }
 
 /**
-Allocate an uninitialized non-array item.
-
-This is an optimization to avoid things needed for arrays like the __arrayPad(size).
-
-- `_d_newitemU` leaves the item uninitialized
-- `_d_newitemT` zero initializes the item
-- `_d_newitemiT` uses a non-zero initializer from `TypeInfo`
-
-Used to allocate struct instances on the heap.
----
-struct Sz {int x = 0;}
-struct Si {int x = 3;}
-
-void main()
-{
-    new Sz(); // _d_newitemT(typeid(Sz))
-    new Si(); // _d_newitemiT(typeid(Si))
-}
----
+Non-template version of $(REF _d_newitemT, core,lifetime) that does not perform
+initialization. Needed for $(REF allocEntry, rt,aaA).
 
 Params:
     _ti = `TypeInfo` of item to allocate
@@ -1193,26 +1176,6 @@ extern (C) void* _d_newitemU(scope const TypeInfo _ti) pure nothrow @weak
         *cast(TypeInfo*)(p + blkInf.size - tiSize) = cast() ti;
     }
 
-    return p;
-}
-
-/// ditto
-extern (C) void* _d_newitemT(const TypeInfo _ti) pure nothrow @weak
-{
-    import core.stdc.string;
-    auto p = _d_newitemU(_ti);
-    memset(p, 0, _ti.tsize);
-    return p;
-}
-
-/// Same as above, for item with non-zero initializer.
-extern (C) void* _d_newitemiT(const TypeInfo _ti) pure nothrow @weak
-{
-    import core.stdc.string;
-    auto p = _d_newitemU(_ti);
-    auto init = _ti.initializer();
-    assert(init.length <= _ti.tsize);
-    memcpy(p, init.ptr, init.length);
     return p;
 }
 
@@ -2361,52 +2324,6 @@ unittest
     testPostBlit!(const(S))();
 }
 
-// cannot define structs inside unit test block, or they become nested structs.
-version (CoreUnittest)
-{
-    struct S1
-    {
-        int x = 5;
-    }
-    struct S2
-    {
-        int x;
-        this(int x) {this.x = x;}
-    }
-    struct S3
-    {
-        int[4] x;
-        this(int x)
-        {this.x[] = x;}
-    }
-    struct S4
-    {
-        int *x;
-    }
-
-}
-
-unittest
-{
-    auto s1 = new S1;
-    assert(s1.x == 5);
-    assert(GC.getAttr(s1) == BlkAttr.NO_SCAN);
-
-    auto s2 = new S2(3);
-    assert(s2.x == 3);
-    assert(GC.getAttr(s2) == BlkAttr.NO_SCAN);
-
-    auto s3 = new S3(1);
-    assert(s3.x == [1,1,1,1]);
-    assert(GC.getAttr(s3) == BlkAttr.NO_SCAN);
-    debug(SENTINEL) {} else
-        assert(GC.sizeOf(s3) == 16);
-
-    auto s4 = new S4;
-    assert(s4.x == null);
-    assert(GC.getAttr(s4) == 0);
-}
-
 unittest
 {
     // Bugzilla 3454 - Inconsistent flag setting in GC.realloc()
@@ -2723,41 +2640,6 @@ unittest
         {
         }
         GC.free(cast(void*)c);
-        return caught;
-    }
-
-    assert( test!Exception);
-    import core.exception : InvalidMemoryOperationError;
-    assert(!test!InvalidMemoryOperationError);
-}
-
-// test struct finalizers exception handling
-debug(SENTINEL) {} else
-unittest
-{
-    bool test(E)()
-    {
-        import core.exception;
-        static struct S1
-        {
-            E exc;
-            ~this() { throw exc; }
-        }
-
-        bool caught = false;
-        S1* s = new S1(new E("test onFinalizeError"));
-        try
-        {
-            GC.runFinalizers((cast(char*)(typeid(S1).xdtor))[0..1]);
-        }
-        catch (FinalizeError err)
-        {
-            caught = true;
-        }
-        catch (E)
-        {
-        }
-        GC.free(s);
         return caught;
     }
 

--- a/druntime/src/rt/tracegc.d
+++ b/druntime/src/rt/tracegc.d
@@ -22,8 +22,6 @@ extern (C) void[] _d_newarrayU(const scope TypeInfo ti, size_t length);
 extern (C) void[] _d_newarrayiT(const TypeInfo ti, size_t length);
 extern (C) void[] _d_newarraymTX(const TypeInfo ti, size_t[] dims);
 extern (C) void[] _d_newarraymiTX(const TypeInfo ti, size_t[] dims);
-extern (C) void* _d_newitemT(const TypeInfo ti);
-extern (C) void* _d_newitemiT(const TypeInfo ti);
 extern (C) void _d_callfinalizer(void* p);
 extern (C) void _d_callinterfacefinalizer(void *p);
 extern (C) void _d_delclass(Object* p);

--- a/druntime/test/profile/bothgc.log.exp
+++ b/druntime/test/profile/bothgc.log.exp
@@ -1,2 +1,3 @@
 bytes allocated, allocations, type, function, file:line
-          16000	           1000	both.Num both.foo src/both.d:15
+          16000	           1000	Num both.foo src/both.d:15
+          16000	           1000	void[] core.lifetime._d_newitemT!(Num)._d_newitemT ../../src/core/lifetime.d:2829

--- a/druntime/test/profile/bothnew.def.exp
+++ b/druntime/test/profile/bothnew.def.exp
@@ -3,3 +3,6 @@ FUNCTIONS
 	_Dmain
 	_D4both3fooFkZPSQo3Num
 	_D4both3Num6__ctorMFNckZSQxQu
+	_D4core8internal8lifetime__T18emplaceInitializerTS4both3NumZQBgFNaNbNiNeMKQzZv
+	_D4core8lifetime__T11_d_newitemTTS4both3NumZQzFNaNbNeZPQw
+	_D4core8lifetime__T16_d_newitemTTraceTS4both3NumZQBeFNaNbNeAyaiQeZPQBd

--- a/druntime/test/profile/myprofilegc.log.freebsd.32.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.32.exp
@@ -17,4 +17,6 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
              16	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2755
+             16	              1	void[] core.lifetime._d_newitemT!float._d_newitemT ../../src/core/lifetime.d:2829
+             16	              1	void[] core.lifetime._d_newitemT!int._d_newitemT ../../src/core/lifetime.d:2829
              16	              1	wchar[] D main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.freebsd.64.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.64.exp
@@ -17,4 +17,6 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:14
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
+             16	              1	void[] core.lifetime._d_newitemT!float._d_newitemT ../../src/core/lifetime.d:2829
+             16	              1	void[] core.lifetime._d_newitemT!int._d_newitemT ../../src/core/lifetime.d:2829
              16	              1	wchar[] D main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.linux.32.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.32.exp
@@ -17,4 +17,6 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
              16	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2755
+             16	              1	void[] core.lifetime._d_newitemT!float._d_newitemT ../../src/core/lifetime.d:2829
+             16	              1	void[] core.lifetime._d_newitemT!int._d_newitemT ../../src/core/lifetime.d:2829
              16	              1	wchar[] D main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.linux.64.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.64.exp
@@ -17,4 +17,6 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:14
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
+             16	              1	void[] core.lifetime._d_newitemT!float._d_newitemT ../../src/core/lifetime.d:2829
+             16	              1	void[] core.lifetime._d_newitemT!int._d_newitemT ../../src/core/lifetime.d:2829
              16	              1	wchar[] D main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.osx.32.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.32.exp
@@ -17,4 +17,6 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
              16	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2755
+             16	              1	void[] core.lifetime._d_newitemT!float._d_newitemT ../../src/core/lifetime.d:2829
+             16	              1	void[] core.lifetime._d_newitemT!int._d_newitemT ../../src/core/lifetime.d:2829
              16	              1	wchar[] D main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.osx.64.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.64.exp
@@ -17,4 +17,6 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:14
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
+             16	              1	void[] core.lifetime._d_newitemT!float._d_newitemT ../../src/core/lifetime.d:2829
+             16	              1	void[] core.lifetime._d_newitemT!int._d_newitemT ../../src/core/lifetime.d:2829
              16	              1	wchar[] D main src/profilegc.d:35


### PR DESCRIPTION
This contributes to https://github.com/dlang/projects/issues/25 and makes the following changes:
- Replace `_d_newitem{U,T,iT}` with a template `_d_newitemT` that allocates memory for the new `struct` and performs the required initialisation
- Move lowering call to `_d_newitemT` from e2ir.d to expressionsem.d
- Add `lowering` field to `NewExp` that contains the lowered call and use it in e2ir.d
- Remove `_d_newitem{,i}T` from rt.lifetime.d