### PR TITLE
fix Issue 22367 - Modules compiled with -betterC never generate a Mod…

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5851,8 +5851,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             dedtypes.zero();
 
             MATCH m = deduceType(e.targ, sc, e.tspec, e.parameters, &dedtypes, null, 0, e.tok == TOK.equal);
-            //printf("targ: %s\n", targ.toChars());
-            //printf("tspec: %s\n", tspec.toChars());
+            //printf("targ: %s\n", e.targ.toChars());
+            //printf("tspec: %s\n", e.tspec.toChars());
             if (m == MATCH.nomatch || (m != MATCH.exact && e.tok == TOK.equal))
             {
                 return no();

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -2672,7 +2672,6 @@ private void reconcileCommands(ref Param params, ref Target target)
         if (params.checkAction != CHECKACTION.halt)
             params.checkAction = CHECKACTION.C;
 
-        params.useModuleInfo = false;
         params.useTypeInfo = false;
         params.useExceptions = false;
     }

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -101,12 +101,15 @@ void genModuleInfo(Module m)
     ClassDeclarations aclasses;
 
     //printf("members.length = %d\n", members.length);
-    foreach (i; 0 .. m.members.length)
+    if (!global.params.betterC) // betterC cannot deal with TypeInfo
     {
-        Dsymbol member = (*m.members)[i];
+        foreach (i; 0 .. m.members.length)
+        {
+            Dsymbol member = (*m.members)[i];
 
-        //printf("\tmember '%s'\n", member.toChars());
-        member.addLocalClass(&aclasses);
+            //printf("\tmember '%s'\n", member.toChars());
+            member.addLocalClass(&aclasses);
+        }
     }
 
     // importedModules[]


### PR DESCRIPTION
…uleInfo

This fixes modules compiled with -betterC to generate a ModuleInfo if and only if one or more of the following conditions happen:

1. it imports a module that generates ModuleInfo
2. it has a static constructor
3. it has a static destructor
4. it has a unit test declaration

The local classes section in ModuleInfo is omitted and is not supported by betterC.

If a betterC executable is built, of course those static constructors, static destructors, and unit tests will not be run. This is because betterC relies only on the C standard library, which does not consult ModuleInfo.

The test case is:
```
module mylib1;
static this() { }
```
```
module mylib2;
import mylib1;
```
```
module myexe;
import mylib1;
```
```
dmd -betterC -c -of=mylib.obj mylib1.d mylib2.d
dmd -I. myexe.d mylib1.obj -main
```
but I do not know how to get the test runner to do that.
