### PR TITLE
Fix Issue 23530 - casting immutable away allowed in safe

### DIFF
--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -130,6 +130,13 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
  */
 bool isSafeCast(Expression e, Type tfrom, Type tto)
 {
+    if (tto.equivalent(tfrom) &&
+        ((tto.isMutable() && tfrom.isImmutable()) ||
+         (tto.isImmutable() && tfrom.isMutable()) ||
+         (tto.isShared() && !tfrom.isShared())    ||
+         (!tto.isShared() && tfrom.isShared())))
+        return false;
+
     // Implicit conversions are always safe
     if (tfrom.implicitConvTo(tto))
         return true;


### PR DESCRIPTION
Up until this point, the `isSafeCast` function checked if the casted type is implicitly convertible to the cast type. Although that if fine if we are passing an `immutable int` to an `int` parameter, casting an `immutable int` to a `int` should not be allowed since in dip1000 code you can take the address of the result.

I tried to fix this by adding the cases specified [in the spec](https://dlang.org/spec/function.html#safe-functions) (curios that there is no mention of `const` to mutable conversions) however that leads to tons of failings in phobos. It seems that there are a lot of instances where immutability is cast away in generic code - which used to be safe prior to this PR but it stops being with it.

Any ideas on how to proceed here?