### PR TITLE
fix Issue 23535 - extend pragma(crt_constructor) with semantics that …

### DIFF
--- a/compiler/src/dmd/dmangle.d
+++ b/compiler/src/dmd/dmangle.d
@@ -636,6 +636,7 @@ public:
 
     void mangleFunc(FuncDeclaration fd, bool inParent)
     {
+        //printf("mangleFunc(%s, %d)\n", fd.toChars(), inParent);
         //printf("deco = '%s'\n", fd.type.deco ? fd.type.deco : "null");
         //printf("fd.type = %s\n", fd.type.toChars());
         if (fd.needThis() || fd.isNested())
@@ -1416,6 +1417,7 @@ void realToMangleBuffer(ref OutBuffer buf, real_t value)
 private
 extern (D) const(char)[] externallyMangledIdentifier(Declaration d)
 {
+    //printf("externallyMangledIdentifier(%s)\n", d.toChars());
     assert(!d.mangleOverride, "mangle overrides should have been handled earlier");
 
     const linkage = d.resolvedLinkage();
@@ -1433,6 +1435,10 @@ extern (D) const(char)[] externallyMangledIdentifier(Declaration d)
             case LINK.d:
                 break;
             case LINK.c:
+                auto fd = d.isFuncDeclaration();
+                if (fd && (fd.isCrtCtor || fd.isCrtDtor))
+                    return null;        // pragma(crt_constructor) has D mangling with C ABI
+                goto case;
             case LINK.windows:
             case LINK.objc:
                 return d.ident.toString();

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -3386,6 +3386,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         funcdecl._linkage = sc.linkage;
         if (sc.flags & SCOPE.Cfile && funcdecl.isFuncLiteralDeclaration())
             funcdecl._linkage = LINK.d; // so they are uniquely mangled
+        else
+            funcdecl._linkage = (funcdecl.isCrtCtor || funcdecl.isCrtDtor) ? LINK.c : sc.linkage;
 
         if (auto fld = funcdecl.isFuncLiteralDeclaration())
         {
@@ -3521,6 +3523,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 else if (tf.trust == TRUST.trusted)
                     sc.stc |= STC.trusted;
             }
+
+            if (funcdecl.isCrtCtor)
+                tf.trust = TRUST.system;
 
             if (funcdecl.isCtorDeclaration())
             {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15526,7 +15526,7 @@ Modifiable checkModifiable(Expression exp, Scope* sc, ModifyFlags flag = ModifyF
         case EXP.variable:
             auto varExp = cast(VarExp)exp;
 
-            //printf("VarExp::checkModifiable %s", varExp.toChars());
+            //printf("VarExp::checkModifiable %s, flag: %d", varExp.toChars(), flag);
             assert(varExp.type);
             return varExp.var.checkModify(varExp.loc, sc, null, flag);
 

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -336,8 +336,6 @@ Symbol *toSymbol(Dsymbol s)
 
         override void visit(FuncDeclaration fd)
         {
-            const(char)* id = mangleExact(fd);
-
             //printf("FuncDeclaration.toSymbol(%s %s)\n", fd.kind(), fd.toChars());
 
             /* MS-LINK cannot handle multiple COMDATs with the same name.
@@ -372,6 +370,7 @@ Symbol *toSymbol(Dsymbol s)
                 }
             }
 
+            const(char)* id = mangleExact(fd);
             //printf("\tid = '%s'\n", id);
             //printf("\ttype = %s\n", fd.type.toChars());
             auto s = symbol_calloc(id[0 .. strlen(id)]);

--- a/compiler/test/fail_compilation/test17868b.d
+++ b/compiler/test/fail_compilation/test17868b.d
@@ -3,9 +3,9 @@ TEST_OUTPUT:
 ----
 fail_compilation/test17868b.d(9): Error: pragma `crt_constructor` can only apply to a single declaration
 fail_compilation/test17868b.d(14): Error: function `test17868b.bar` must return `void` for `pragma(crt_constructor)`
-fail_compilation/test17868b.d(18): Error: function `test17868b.baz` must be `extern(C)` for `pragma(crt_constructor)` when taking parameters
 ----
  */
+
 pragma(crt_constructor):
 void foo()
 {

--- a/compiler/test/runnable/test23535.d
+++ b/compiler/test/runnable/test23535.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=23535
+
+import core.stdc.stdio;
+
+immutable int x;
+
+pragma(crt_constructor) void initty() { x = 1; }
+
+pragma(crt_destructor) void dtorty() { }
+
+int main()
+{
+    assert(x == 1);
+    printf("x = %d\n", x);
+    return 0;
+}


### PR DESCRIPTION
…static constructors have

1. allow crt_constructors to modify immutable variables
2. make crt_constructors @system because of (1)
3. make crt_constructors and crt_destructors use C linkage, because the C runtime expects that