### PR TITLE
fix Issue 23536 - crt_constructors and crt_destructors should not be …

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -3276,6 +3276,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 funcdecl.error("must return `void` for `pragma(%s)`", idStr.ptr);
             if (funcdecl._linkage != LINK.c && f.parameterList.length != 0)
                 funcdecl.error("must be `extern(C)` for `pragma(%s)` when taking parameters", idStr.ptr);
+            if (funcdecl.isThis())
+                funcdecl.error("cannot be a non-static member function for `pragma(%s)`", idStr.ptr);
         }
 
         if (funcdecl.overnext && funcdecl.isCsymbol())

--- a/compiler/test/fail_compilation/test23536.d
+++ b/compiler/test/fail_compilation/test23536.d
@@ -1,0 +1,19 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test23536.d(104): Error: function `test23536.S.nonctor` cannot be a non-static member function for `pragma(crt_constructor)`
+fail_compilation/test23536.d(106): Error: function `test23536.S.nondtor` cannot be a non-static member function for `pragma(crt_destructor)`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=23536
+
+#line 100
+
+struct S
+{
+    int x;
+    extern (C) pragma(crt_constructor)        void nonctor() { } // should not compile
+    extern (C) pragma(crt_constructor) static void stactor() { } // should compile
+    extern (C) pragma(crt_destructor)         void nondtor() { } // should not compile
+    extern (C) pragma(crt_destructor)  static void stadtor() { } // should compile
+}


### PR DESCRIPTION
…non-static member functions

Discovered this while looking into other bugs with those functions.