### PR TITLE
fix Issue 19575 - core.cpuid not usable without a runtime

### DIFF
--- a/druntime/src/core/cpuid.d
+++ b/druntime/src/core/cpuid.d
@@ -1080,7 +1080,7 @@ void cpuidSparc()
 }
 */
 
-shared static this()
+pragma(crt_constructor) void cpuid_initialization()
 {
     auto cf = getCpuFeatures();
 


### PR DESCRIPTION
Using a C runtime constructor means that anybody importing core.cpuid need not generate a ModuleInfo.

Blocked by https://github.com/dlang/dmd/pull/14669