### PR TITLE
fix Issue 23539 - [REG master] Scope C++ definition out of sync with D

### DIFF
--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -71,7 +71,7 @@ private enum PersistentFlags =
     SCOPE.noaccesscheck | SCOPE.ignoresymbolvisibility |
     SCOPE.Cfile;
 
-struct Scope
+extern (C++) struct Scope
 {
     Scope* enclosing;               /// enclosing Scope
 
@@ -178,7 +178,7 @@ struct Scope
         return sc;
     }
 
-    extern (C++) Scope* copy()
+    extern (D) Scope* copy()
     {
         Scope* sc = Scope.alloc();
         *sc = this;
@@ -189,7 +189,7 @@ struct Scope
         return sc;
     }
 
-    extern (C++) Scope* push()
+    extern (D) Scope* push()
     {
         Scope* s = copy();
         //printf("Scope::push(this = %p) new = %p\n", this, s);
@@ -215,7 +215,7 @@ struct Scope
         return s;
     }
 
-    extern (C++) Scope* push(ScopeDsymbol ss)
+    extern (D) Scope* push(ScopeDsymbol ss)
     {
         //printf("Scope::push(%s)\n", ss.toChars());
         Scope* s = push();
@@ -223,7 +223,7 @@ struct Scope
         return s;
     }
 
-    extern (C++) Scope* pop()
+    extern (D) Scope* pop()
     {
         //printf("Scope::pop() %p nofree = %d\n", this, nofree);
         if (enclosing)
@@ -253,7 +253,7 @@ struct Scope
         pop();
     }
 
-    extern (C++) Scope* startCTFE()
+    extern (D) Scope* startCTFE()
     {
         Scope* sc = this.push();
         sc.flags = this.flags | SCOPE.ctfe;
@@ -280,7 +280,7 @@ struct Scope
         return sc;
     }
 
-    extern (C++) Scope* endCTFE()
+    extern (D) Scope* endCTFE()
     {
         assert(flags & SCOPE.ctfe);
         return pop();
@@ -664,7 +664,7 @@ struct Scope
     /********************************************
      * Search enclosing scopes for ScopeDsymbol.
      */
-    ScopeDsymbol getScopesym()
+    extern (D) ScopeDsymbol getScopesym()
     {
         for (Scope* sc = &this; sc; sc = sc.enclosing)
         {
@@ -677,7 +677,7 @@ struct Scope
     /********************************************
      * Search enclosing scopes for ClassDeclaration.
      */
-    extern (C++) ClassDeclaration getClassScope()
+    extern (D) ClassDeclaration getClassScope()
     {
         for (Scope* sc = &this; sc; sc = sc.enclosing)
         {
@@ -692,7 +692,7 @@ struct Scope
     /********************************************
      * Search enclosing scopes for ClassDeclaration or StructDeclaration.
      */
-    extern (C++) AggregateDeclaration getStructClassScope()
+    extern (D) AggregateDeclaration getStructClassScope()
     {
         for (Scope* sc = &this; sc; sc = sc.enclosing)
         {
@@ -714,7 +714,7 @@ struct Scope
      *
      * Returns: the function or null
      */
-    inout(FuncDeclaration) getEnclosingFunction() inout
+    extern (D) inout(FuncDeclaration) getEnclosingFunction() inout
     {
         if (!this.func)
             return null;
@@ -753,7 +753,7 @@ struct Scope
     }
     /******************************
      */
-    structalign_t alignment()
+    extern (D) structalign_t alignment()
     {
         if (aligndecl)
         {
@@ -773,7 +773,7 @@ struct Scope
     *
     * Returns: `true` if this or any parent scope is deprecated, `false` otherwise`
     */
-    extern(C++) bool isDeprecated()
+    extern (D) bool isDeprecated()
     {
         for (const(Dsymbol)* sp = &(this.parent); *sp; sp = &(sp.parent))
         {
@@ -803,7 +803,7 @@ struct Scope
      *
      * Returns: `true` if this `Scope` is known to be from one of these speculative contexts
      */
-    extern(C++) bool isFromSpeculativeSemanticContext() scope
+    extern (D) bool isFromSpeculativeSemanticContext() scope
     {
         return this.intypeof || this.flags & SCOPE.compile;
     }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -236,6 +236,12 @@ struct ModuleDeclaration;
 template <typename Datum>
 struct FileMapping;
 struct Escape;
+class LabelStatement;
+class SwitchStatement;
+class Statement;
+class TryFinallyStatement;
+class ScopeGuardStatement;
+struct DocComment;
 class WithStatement;
 struct AA;
 class Tuple;
@@ -274,7 +280,6 @@ class TypeQualified;
 class CaseStatement;
 class Catch;
 struct Designator;
-class Statement;
 class GotoCaseStatement;
 class GotoStatement;
 class ReturnStatement;
@@ -288,14 +293,11 @@ class WhileStatement;
 class DoStatement;
 class ForStatement;
 class IfStatement;
-class SwitchStatement;
 class CaseRangeStatement;
 class DefaultStatement;
 class SynchronizedStatement;
 class TryCatchStatement;
-class TryFinallyStatement;
 class DebugStatement;
-class LabelStatement;
 class ErrorInitializer;
 class VoidInitializer;
 class StructInitializer;
@@ -313,7 +315,6 @@ class CompileStatement;
 class ForwardingStatement;
 class ContinueStatement;
 class ThrowStatement;
-class ScopeGuardStatement;
 class SwitchErrorStatement;
 struct Token;
 struct code;
@@ -1703,6 +1704,45 @@ public:
         level()
     {
     }
+};
+
+enum class CSX : uint16_t
+{
+    none = 0u,
+    this_ctor = 1u,
+    super_ctor = 2u,
+    label = 4u,
+    return_ = 8u,
+    any_ctor = 16u,
+    halt = 32u,
+};
+
+struct FieldInit final
+{
+    CSX csx;
+    Loc loc;
+    FieldInit() :
+        loc()
+    {
+    }
+    FieldInit(CSX csx, Loc loc = Loc()) :
+        csx(csx),
+        loc(loc)
+        {}
+};
+
+struct CtorFlow final
+{
+    CSX callSuper;
+    _d_dynamicArray< FieldInit > fieldinit;
+    CtorFlow() :
+        fieldinit()
+    {
+    }
+    CtorFlow(CSX callSuper, _d_dynamicArray< FieldInit > fieldinit = {}) :
+        callSuper(callSuper),
+        fieldinit(fieldinit)
+        {}
 };
 
 template <typename K, typename V>
@@ -6296,6 +6336,129 @@ struct ModuleDeclaration final
 };
 
 extern void gendocfile(Module* m);
+
+struct Scope final
+{
+    Scope* enclosing;
+    Module* _module;
+    ScopeDsymbol* scopesym;
+    FuncDeclaration* func;
+    VarDeclaration* varDecl;
+    Dsymbol* parent;
+    LabelStatement* slabel;
+    SwitchStatement* sw;
+    Statement* tryBody;
+    TryFinallyStatement* tf;
+    ScopeGuardStatement* os;
+    Statement* sbreak;
+    Statement* scontinue;
+    ForeachStatement* fes;
+    Scope* callsc;
+    Dsymbol* inunion;
+    bool nofree;
+    bool inLoop;
+    int32_t intypeof;
+    VarDeclaration* lastVar;
+    Module* minst;
+    TemplateInstance* tinst;
+    CtorFlow ctorflow;
+    AlignDeclaration* aligndecl;
+    CPPNamespaceDeclaration* namespace_;
+    LINK linkage;
+    CPPMANGLE cppmangle;
+    PragmaDeclaration* inlining;
+    Visibility visibility;
+    int32_t explicitVisibility;
+    StorageClass stc;
+    DeprecatedDeclaration* depdecl;
+    uint32_t flags;
+    UserAttributeDeclaration* userAttribDecl;
+    DocComment* lastdc;
+    void* anchorCounts;
+    Identifier* prevAnchor;
+    AliasDeclaration* aliasAsg;
+    Dsymbol* search(const Loc& loc, Identifier* ident, Dsymbol** pscopesym, int32_t flags = 0);
+    Scope() :
+        enclosing(),
+        _module(),
+        scopesym(),
+        func(),
+        varDecl(),
+        parent(),
+        slabel(),
+        sw(),
+        tryBody(),
+        tf(),
+        os(),
+        sbreak(),
+        scontinue(),
+        fes(),
+        callsc(),
+        inunion(),
+        nofree(),
+        inLoop(),
+        intypeof(),
+        lastVar(),
+        minst(),
+        tinst(),
+        ctorflow(),
+        aligndecl(),
+        namespace_(),
+        linkage((LINK)1u),
+        cppmangle((CPPMANGLE)0u),
+        inlining(),
+        visibility(Visibility((Visibility::Kind)5u, nullptr)),
+        explicitVisibility(),
+        stc(),
+        depdecl(),
+        flags(),
+        userAttribDecl(),
+        lastdc(),
+        prevAnchor(),
+        aliasAsg()
+    {
+    }
+    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* sw = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tf = nullptr, ScopeGuardStatement* os = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, bool nofree = false, bool inLoop = false, int32_t intypeof = 0, VarDeclaration* lastVar = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), int32_t explicitVisibility = 0, uint64_t stc = 0LLU, DeprecatedDeclaration* depdecl = nullptr, uint32_t flags = 0u, UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr) :
+        enclosing(enclosing),
+        _module(_module),
+        scopesym(scopesym),
+        func(func),
+        varDecl(varDecl),
+        parent(parent),
+        slabel(slabel),
+        sw(sw),
+        tryBody(tryBody),
+        tf(tf),
+        os(os),
+        sbreak(sbreak),
+        scontinue(scontinue),
+        fes(fes),
+        callsc(callsc),
+        inunion(inunion),
+        nofree(nofree),
+        inLoop(inLoop),
+        intypeof(intypeof),
+        lastVar(lastVar),
+        minst(minst),
+        tinst(tinst),
+        ctorflow(ctorflow),
+        aligndecl(aligndecl),
+        namespace_(namespace_),
+        linkage(linkage),
+        cppmangle(cppmangle),
+        inlining(inlining),
+        visibility(visibility),
+        explicitVisibility(explicitVisibility),
+        stc(stc),
+        depdecl(depdecl),
+        flags(flags),
+        userAttribDecl(userAttribDecl),
+        lastdc(lastdc),
+        anchorCounts(anchorCounts),
+        prevAnchor(prevAnchor),
+        aliasAsg(aliasAsg)
+        {}
+};
 
 extern FuncDeclaration* search_toString(StructDeclaration* sd);
 

--- a/compiler/src/dmd/scope.h
+++ b/compiler/src/dmd/scope.h
@@ -74,6 +74,7 @@ struct Scope
     Module *_module;            // Root module
     ScopeDsymbol *scopesym;     // current symbol
     FuncDeclaration *func;      // function we are in
+    VarDeclaration  *varDecl;   // variable we are in during semantic2
     Dsymbol *parent;            // parent to use
     LabelStatement *slabel;     // enclosing labelled statement
     SwitchStatement *sw;        // enclosing switch statement

--- a/compiler/src/dmd/scope.h
+++ b/compiler/src/dmd/scope.h
@@ -28,43 +28,38 @@ class CPPNamespaceDeclaration;
 
 #include "dsymbol.h"
 
-enum
+enum class CSX : uint16_t
 {
-    CSXthis_ctor  = 1,      // called this()
-    CSXsuper_ctor = 2,      // called super()
-    CSXthis       = 4,      // referenced this
-    CSXsuper      = 8,      // referenced super
-    CSXlabel      = 0x10,   // seen a label
-    CSXreturn     = 0x20,   // seen a return statement
-    CSXany_ctor   = 0x40,   // either this() or super() was called
-    CSXhalt       = 0x80,   // assert(0)
+    none       = 0,
+    this_ctor  = 1,      // called this()
+    super_ctor = 2,      // called super()
+    label      = 4,      // seen a label
+    return_    = 8,      // seen a return statement
+    any_ctor   = 0x10,   // either this() or super() was called
+    halt       = 0x20,   // assert(0)
 };
 
-enum
+enum class SCOPE
 {
     // Flags that would not be inherited beyond scope nesting
-    SCOPEctor          = 0x0001,  // constructor type
-    SCOPEcondition     = 0x0004,  // inside static if/assert condition
-    SCOPEdebug         = 0x0008,  // inside debug conditional
+    ctor          = 0x0001,  // constructor type
+    noaccesscheck = 0x0002,  // don't do access checks
+    condition     = 0x0004,  // inside static if/assert condition
+    debug_        = 0x0008,  // inside debug conditional
 
     // Flags that would be inherited beyond scope nesting
-    SCOPEnoaccesscheck = 0x0002,  // don't do access checks
-    SCOPEconstraint    = 0x0010,  // inside template constraint
-    SCOPEinvariant     = 0x0020,  // inside invariant code
-    SCOPErequire       = 0x0040,  // inside in contract code
-    SCOPEensure        = 0x0060,  // inside out contract code
-    SCOPEcontract      = 0x0060,  // [mask] we're inside contract code
-    SCOPEctfe          = 0x0080,  // inside a ctfe-only expression
-    SCOPEcompile       = 0x0100,  // inside __traits(compile)
-    SCOPEignoresymbolvisibility = 0x0200,  // ignore symbol visibility (Bugzilla 15907)
+    constraint    = 0x0010,  // inside template constraint
+    invariant_    = 0x0020,  // inside invariant code
+    require       = 0x0040,  // inside in contract code
+    ensure        = 0x0060,  // inside out contract code
+    contract      = 0x0060,  // [mask] we're inside contract code
+    ctfe          = 0x0080,  // inside a ctfe-only expression
+    compile       = 0x0100,  // inside __traits(compile)
+    ignoresymbolvisibility = 0x0200,  // ignore symbol visibility (Bugzilla 15907)
 
-    SCOPEfree          = 0x8000,  // is on free list
-    SCOPEfullinst      = 0x10000, // fully instantiate templates
-    SCOPEalias         = 0x20000, // inside alias declaration
-
-    // The following are mutually exclusive
-    SCOPEprintf        = 0x40000, // printf-style function
-    SCOPEscanf         = 0x80000, // scanf-style function
+    Cfile         = 0x0800,  // C semantics apply
+    free          = 0x8000,  // is on free list
+    fullinst      = 0x10000, // fully instantiate templates
 };
 
 struct Scope
@@ -99,8 +94,8 @@ struct Scope
     Module *minst;              // root module where the instantiated templates should belong to
     TemplateInstance *tinst;    // enclosing template instance
 
-    unsigned char callSuper;    // primitive flow analysis for constructors
-    unsigned char *fieldinit;
+    CSX callSuper;              // primitive flow analysis for constructors
+    CSX *fieldinit;
     size_t fieldinit_dim;
 
     AlignDeclaration *aligndecl;    // alignment for struct members
@@ -129,24 +124,6 @@ struct Scope
 
     AliasDeclaration *aliasAsg; // if set, then aliasAsg is being assigned a new value,
                                 // do not set wasRead for it
-    Scope();
-
-    Scope *copy();
-
-    Scope *push();
-    Scope *push(ScopeDsymbol *ss);
-    Scope *pop();
-
-    Scope *startCTFE();
-    Scope *endCTFE();
 
     Dsymbol *search(const Loc &loc, Identifier *ident, Dsymbol **pscopesym, int flags = IgnoreNone);
-
-    ClassDeclaration *getClassScope();
-    AggregateDeclaration *getStructClassScope();
-
-    structalign_t alignment();
-
-    bool isDeprecated() const;
-    bool isFromSpeculativeSemanticContext() const;
 };


### PR DESCRIPTION
And synchronize headers with the D sources. Flip over the enums to `enum class` and remove long gone members.

GDC only requires `Scope` for `->_module`, `->flags`, and `SCOPE::ctfe`.
LDC only requires `Scope` for `->func`, `->_module`, and `->search(...)`.