### PR TITLE
Remove toHash attribute soup related warnings.

### DIFF
--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -1485,13 +1485,6 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             dtb.xoff(toSymbol(fd), 0);
             TypeFunction tf = cast(TypeFunction)fd.type;
             assert(tf.ty == Tfunction);
-            /* I'm a little unsure this is the right way to do it. Perhaps a better
-             * way would to automatically add these attributes to any struct member
-             * function with the name "toHash".
-             * So I'm leaving this here as an experiment for the moment.
-             */
-            if (!tf.isnothrow || tf.trust == TRUST.system /*|| tf.purity == PURE.impure*/)
-                warning(fd.loc, "toHash() must be declared as extern (D) size_t toHash() const nothrow @safe, not %s", tf.toChars());
         }
         else
             dtb.size(0);


### PR DESCRIPTION
This experiment has gone wrong. It is causing an untold amount of bullshit to deal with when trying to do real work.

Navigating an ever increasing web of attribute soup does not help anyone getting any real work done. For some reason, this specific warning started firing a lot more on recent releases, too many man hours have been put into working around it and the best that was achieved is to get the lastest DMD to work at the cost of breaking things for LDC.

