### PR TITLE
Fix issue 18472: betterC cannot use format at compile time.

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -97,7 +97,11 @@ public Expression ctfeInterpret(Expression e)
 
     auto rgnpos = ctfeGlobals.region.savePos();
 
+    ctfeGlobals.active = true;
+
     Expression result = interpret(e, null);
+
+    ctfeGlobals.active = false;
 
     // Report an error if the expression contained a `ThrowException` and
     // hence generated an uncaught exception
@@ -206,6 +210,9 @@ void incArrayAllocs()
     ++ctfeGlobals.numArrayAllocs;
 }
 
+bool isInterpreting() {
+    return ctfeGlobals.active;
+}
 /* ================================================ Implementation ======================================= */
 
 private:
@@ -227,6 +234,7 @@ struct CtfeGlobals
     int maxCallDepth = 0;     // highest number of recursive calls
     int numArrayAllocs = 0;   // Number of allocated arrays
     int numAssignments = 0;   // total number of assignments executed
+    bool active = false;      // whether we are interpreting a ctfe function
 }
 
 __gshared CtfeGlobals ctfeGlobals;

--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -59,6 +59,7 @@ enum SCOPE
     compile       = 0x0100,   /// inside __traits(compile)
     ignoresymbolvisibility    = 0x0200,   /// ignore symbol visibility
                                           /// https://issues.dlang.org/show_bug.cgi?id=15907
+    ctfeonly      = 0x0400,
     Cfile         = 0x0800,   /// C semantics apply
     free          = 0x8000,   /// is on free list
 
@@ -68,7 +69,7 @@ enum SCOPE
 /// Flags that are carried along with a scope push()
 private enum PersistentFlags =
     SCOPE.contract | SCOPE.debug_ | SCOPE.ctfe | SCOPE.compile | SCOPE.constraint |
-    SCOPE.noaccesscheck | SCOPE.ignoresymbolvisibility |
+    SCOPE.noaccesscheck | SCOPE.ignoresymbolvisibility | SCOPE.ctfeonly |
     SCOPE.Cfile;
 
 extern (C++) struct Scope
@@ -90,6 +91,7 @@ extern (C++) struct Scope
     ForeachStatement fes;           /// if nested function for ForeachStatement, this is it
     Scope* callsc;                  /// used for __FUNCTION__, __PRETTY_FUNCTION__ and __MODULE__
     Dsymbol inunion;                /// != null if processing members of a union
+    bool skipretnogc;
     bool nofree;                    /// true if shouldn't free it
     bool inLoop;                    /// true if inside a loop (where constructor calls aren't allowed)
     int intypeof;                   /// in typeof(exp)

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -6084,7 +6084,13 @@ private
 elem *getTypeInfo(Expression e, Type t, IRState* irs)
 {
     assert(t.ty != Terror);
-    genTypeInfo(e, e.loc, t, null);
+    Scope* sc;
+    if (irs && irs.ctfeOnly > 0)
+    {
+        sc = new Scope;
+        sc.flags |= SCOPE.ctfeonly;
+    }
+    genTypeInfo(e, e.loc, t, sc);
     elem* result = el_ptr(toSymbol(t.vtinfo));
     return result;
 }

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -219,7 +219,7 @@ public:
 Expression checkGC(Scope* sc, Expression e)
 {
     FuncDeclaration f = sc.func;
-    if (e && e.op != EXP.error && f && sc.intypeof != 1 && !(sc.flags & SCOPE.ctfe) &&
+    if (e && e.op != EXP.error && f && sc.intypeof != 1 && !(sc.flags & SCOPE.ctfe) && !(sc.flags & SCOPE.ctfeonly) &&
            (f.type.ty == Tfunction &&
             (cast(TypeFunction)f.type).isnogc || f.nogcInprocess || global.params.vgc) &&
            !(sc.flags & SCOPE.debug_))

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -761,6 +761,18 @@ private extern (C++) class S2irVisitor : Visitor
         //printf("ExpStatement.toIR(), exp: %p %s\n", s.exp, s.exp ? s.exp.toChars() : "");
         if (s.exp)
         {
+            if (stmtstate.prev)
+            {
+                if (auto ae = s.exp.isAssertExp())
+                {
+                    if (!stmtstate.prev.ctfeOnly && ae.e1 && ae.e1.isVarExp() && ae.e1.isVarExp().var
+                        && ae.e1.isVarExp().var.ident == Id.ctfe)
+                    {
+                        irs.ctfeOnly++;
+                        stmtstate.prev.ctfeOnly = true;
+                    }
+                }
+            }
             if (s.exp.hasCode &&
                 !(isAssertFalse(s.exp))) // `assert(0)` not meant to be covered
                 incUsage(irs, s.loc);
@@ -1536,6 +1548,8 @@ private extern (C++) class S2irVisitor : Visitor
     {
         scope v = new S2irVisitor(irs, stmtstate);
         s.accept(v);
+        if (irs && stmtstate && irs.ctfeOnly > 0 && stmtstate.ctfeOnly)
+            irs.ctfeOnly--;
     }
 }
 
@@ -1556,6 +1570,8 @@ void Statement_toIR(Statement s, IRState *irs)
     StmtState stmtstate;
     scope v = new S2irVisitor(irs, &stmtstate);
     s.accept(v);
+    if (irs && irs.ctfeOnly > 0 && stmtstate.ctfeOnly)
+        irs.ctfeOnly--;
 }
 
 /***************************************************

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -342,6 +342,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             if (funcdecl.ident != Id.require && funcdecl.ident != Id.ensure)
                 sc2.flags = sc.flags & ~SCOPE.contract;
             sc2.flags &= ~SCOPE.compile;
+            sc2.flags &= ~SCOPE.ctfeonly;
             sc2.tf = null;
             sc2.os = null;
             sc2.inLoop = false;
@@ -930,7 +931,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
                                 checkReturnEscape(sc2, exp, false);
                         }
 
-                        exp = checkGC(sc2, exp);
+                        if (!sc2.func.skipretnogc)
+                            exp = checkGC(sc2, exp);
 
                         if (funcdecl.vresult)
                         {

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -204,6 +204,21 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
 
         s.exp = s.exp.expressionSemantic(sc);
         s.exp = resolveProperties(sc, s.exp);
+
+        if (sc)
+        {
+            if (auto ae = s.exp.isAssertExp())
+            {
+                if (ae.e1 && ae.e1.isVarExp() && ae.e1.isVarExp().var
+                    && ae.e1.isVarExp().var.ident == Id.ctfe)
+                {
+                    //printf("ExpStatement::semantic() ctfeonly %s\n", s.exp.toChars());
+                    sc.flags |= SCOPE.ctfeonly;
+                    sc.func.skipretnogc = true;
+                }
+            }
+        }
+
         s.exp = s.exp.addDtorHook(sc);
         if (checkNonAssignmentArrayOp(s.exp))
             s.exp = ErrorExp.get();

--- a/compiler/src/dmd/stmtstate.d
+++ b/compiler/src/dmd/stmtstate.d
@@ -35,6 +35,8 @@ struct StmtState(block)
     block* finallyBlock;
     block* tryBlock;
 
+    bool ctfeOnly;
+
     this(StmtState* prev, Statement statement)
     {
         this.prev = prev;

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -87,6 +87,7 @@ struct IRState
     const Target* target;           // target
     bool mayThrow;                  // the expression being evaluated may throw
     bool Cfile;                     // use C semantics
+    int ctfeOnly;                   // the expression will not generate TypeInfo if >0
 
     this(Module m, FuncDeclaration fd, Array!(elem*)* varsInScope, Dsymbols* deferToObj, Label*[void*]* labels,
         const Param* params, const Target* target)
@@ -102,6 +103,7 @@ struct IRState
             && ClassDeclaration.throwable
             && !(fd && fd.hasNoEH);
         this.Cfile = m.filetype == FileType.c;
+        this.ctfeOnly = 0;
     }
 
     FuncDeclaration getFunc()

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -715,7 +715,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
         override void visit(TypeInfoDeclaration tid)
         {
-            if (isSpeculativeType(tid.tinfo))
+            import dmd.globals : global;
+            if (isSpeculativeType(tid.tinfo) || global.params.betterC)
             {
                 //printf("-speculative '%s'\n", tid.toPrettyChars());
                 return;

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -16,6 +16,7 @@ import dmd.declaration;
 import dmd.dmodule;
 import dmd.dscope;
 import dmd.dclass;
+import dmd.dinterpret;
 import dmd.dstruct;
 import dmd.errors;
 import dmd.expression;
@@ -41,7 +42,7 @@ extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope
     // Even when compiling without `useTypeInfo` (e.g. -betterC) we should
     // still be able to evaluate `TypeInfo` at compile-time, just not at runtime.
     // https://issues.dlang.org/show_bug.cgi?id=18472
-    if (!sc || !(sc.flags & SCOPE.ctfe))
+    if (!sc || (!(sc.flags & (SCOPE.ctfe | SCOPE.ctfeonly)) && !isInterpreting()))
     {
         if (!global.params.useTypeInfo)
         {
@@ -81,13 +82,13 @@ extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope
         // druntime
         if (!isUnqualifiedClassInfo && !builtinTypeInfo(t))
         {
-            if (sc) // if in semantic() pass
+            if (sc && sc._module) // if in semantic() pass
             {
                 // Find module that will go all the way to an object file
                 Module m = sc._module.importedFrom;
                 m.members.push(t.vtinfo);
             }
-            else // if in obj generation pass
+            else if (!sc) // if in obj generation pass
             {
                 toObjFile(t.vtinfo, global.params.multiobj);
             }

--- a/compiler/test/compilable/b18472.d
+++ b/compiler/test/compilable/b18472.d
@@ -1,0 +1,52 @@
+/* REQUIRED_ARGS: -betterC
+*/
+
+/*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=18472
+@nogc nothrow pure:
+immutable(Char)[] format(Char, Args...)(in Char[] fmt, Args args)
+{
+
+    if (__ctfe)
+    {
+        assert(__ctfe);
+        auto data2 = new char[5];
+        auto data = new Data2;
+        {
+            auto data3 = new Data2;
+        }
+        data2 = cast(char[]) "test2";
+        return data2;
+    }
+    else
+    {
+        return "test";
+    }
+}
+
+extern(C) void main()
+{
+    static assert(getData() == "test");
+    static assert("%s %s".format("test", "test") == "test2", "Not working");
+    assert("%s %s".format("test", "test") == "test", "%s %s".format("test", "test"));
+    assert(getData() == "test2", getData());
+}
+
+string getData() {
+    if (__ctfe)
+    {
+        assert(__ctfe);
+        auto data2 = new ubyte[5];
+        auto data = new Data2;
+        return "test";
+    }
+    else
+    {
+        return "test2";
+    }
+}
+
+private struct Data2
+{
+    size_t capacity;
+}

--- a/compiler/test/fail_compilation/b18472.d
+++ b/compiler/test/fail_compilation/b18472.d
@@ -1,0 +1,24 @@
+// REQUIRED_ARGS: -betterC
+/*
+TEST_OUTPUT:
+---
+fail_compilation/b18472.d(14): Error: cannot use `new` in `@nogc` function `b18472.getFun.gcAlloc2`
+---
+*/
+@nogc:
+
+auto getFun() {
+    if (__ctfe)
+    {
+        assert(__ctfe);
+        static ubyte[] gcAlloc2() @nogc {return new ubyte[10];}
+        return &gcAlloc2;
+    }
+    return null;
+}
+
+immutable fun = getFun();
+
+extern(C) void main() {
+    fun();
+}


### PR DESCRIPTION
For various reasons, `isInputRange!string` is now `false` even during CTFE because a `string` in betterC doesn't have the requirements to be considered a range. The `Appender` and `format` will not work, much like a lot of the standard library.

However, CTFE is mainly based on being able to allocate a `new T` during the `interpret` phase, which means we need to include `TypeInfo` in the code but avoid the external references during linking. These changes open up the opportunity to do it in a `if (__ctfe)` statement, so that the same function can be used during runtime in `betterC` without a `TypeInfo` or `GC allocation` error.

I'm currently working on adding `diet-ng` to the @skoppe/spasm library using my own memory allocation libraries that will fall back to `new T` or `new T[]` when necessary, and currently CTFE is nearly impossible due to the allocations being blocked.