### PR TITLE
Fix 23497: Revert #14116 as it introduced a regression

### DIFF
--- a/compiler/test/fail_compilation/dip1000_deprecation.d
+++ b/compiler/test/fail_compilation/dip1000_deprecation.d
@@ -2,16 +2,13 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/dip1000_deprecation.d(20): Deprecation: `@safe` function `main` calling `inferred`
-fail_compilation/dip1000_deprecation.d(28):        which would be `@system` because of:
-fail_compilation/dip1000_deprecation.d(28):        scope variable `x0` may not be returned
-fail_compilation/dip1000_deprecation.d(22): Deprecation: `@safe` function `main` calling `inferredC`
-fail_compilation/dip1000_deprecation.d(39):        which calls `dip1000_deprecation.inferred`
-fail_compilation/dip1000_deprecation.d(28):        which would be `@system` because of:
-fail_compilation/dip1000_deprecation.d(28):        scope variable `x0` may not be returned
-fail_compilation/dip1000_deprecation.d(54): Deprecation: escaping reference to stack allocated value returned by `S(null)`
-fail_compilation/dip1000_deprecation.d(55): Deprecation: escaping reference to stack allocated value returned by `createS()`
-fail_compilation/dip1000_deprecation.d(58): Deprecation: returning `s.incorrectReturnRef()` escapes a reference to local variable `s`
+fail_compilation/dip1000_deprecation.d(17): Deprecation: `@safe` function `main` calling `inferred`
+fail_compilation/dip1000_deprecation.d(25):        which would be `@system` because of:
+fail_compilation/dip1000_deprecation.d(25):        scope variable `x0` may not be returned
+fail_compilation/dip1000_deprecation.d(19): Deprecation: `@safe` function `main` calling `inferredC`
+fail_compilation/dip1000_deprecation.d(36):        which calls `dip1000_deprecation.inferred`
+fail_compilation/dip1000_deprecation.d(25):        which would be `@system` because of:
+fail_compilation/dip1000_deprecation.d(25):        scope variable `x0` may not be returned
 ---
 */
 

--- a/compiler/test/fail_compilation/fail_scope.d
+++ b/compiler/test/fail_compilation/fail_scope.d
@@ -16,7 +16,7 @@ fail_compilation/fail_scope.d(82): Error: returning `& string` escapes a referen
 fail_compilation/fail_scope.d(92): Error: returning `cast(int[])a` escapes a reference to local variable `a`
 fail_compilation/fail_scope.d(100): Error: returning `cast(int[])a` escapes a reference to local variable `a`
 fail_compilation/fail_scope.d(108): Deprecation: escaping reference to outer local variable `x`
-fail_compilation/fail_scope.d(127): Deprecation: returning `s.bar()` escapes a reference to local variable `s`
+fail_compilation/fail_scope.d(127): Error: returning `s.bar()` escapes a reference to local variable `s`
 fail_compilation/fail_scope.d(137): Error: returning `foo16226(i)` escapes a reference to local variable `i`
 ---
 //fail_compilation/fail_scope.d(35): Error: scope variable `da` may not be returned

--- a/compiler/test/runnable/test23497.d
+++ b/compiler/test/runnable/test23497.d
@@ -1,0 +1,21 @@
+
+class A {}
+
+A getA(T t) {
+        return t.a;
+}
+
+struct T {
+        A _a;
+
+        void k() {}
+
+        @property
+        auto a() in {
+                k();
+        } do {
+                return _a;
+        }
+}
+
+void main() {}


### PR DESCRIPTION
This is achieved by reverting 4e7c4925772fe6e098d3a0736f25cb4fae4bce0b, which introduced the regression, and adding a new test case that ensure this specific regression doesn't happen again going forward.