### PR TITLE
core.time: use crt_constructor instead of static this

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -81,6 +81,9 @@ bool checkFrameAccess(Loc loc, Scope* sc, AggregateDeclaration ad, size_t iStart
 /***********************************************
  * Mark variable v as modified if it is inside a constructor that var
  * is a field in.
+ * Also used to allow immutable globals to be initialized inside a static constructor.
+ * Returns:
+ *    true if it's an initialization of v
  */
 bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
 {
@@ -93,7 +96,7 @@ bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
             fd = s.isFuncDeclaration();
         if (fd &&
             ((fd.isCtorDeclaration() && var.isField()) ||
-             (fd.isStaticCtorDeclaration() && !var.isField())) &&
+             ((fd.isStaticCtorDeclaration() || fd.isCrtCtor) && !var.isField())) &&
             fd.toParentDecl() == var.toParent2() &&
             (!e1 || e1.op == EXP.this_))
         {

--- a/druntime/src/core/time.d
+++ b/druntime/src/core/time.d
@@ -2822,7 +2822,7 @@ struct TickDuration
     }
 
 
-    pragma(crt_constructor) void time_initializer()
+    static pragma(crt_constructor) void time_initializer()
     {
         version (Windows)
         {

--- a/druntime/src/core/time.d
+++ b/druntime/src/core/time.d
@@ -2822,7 +2822,7 @@ struct TickDuration
     }
 
 
-    @trusted shared static this()
+    pragma(crt_constructor) void time_initializer()
     {
         version (Windows)
         {


### PR DESCRIPTION
This will avoid problems with betterC code attempting to import core.time and winding up with a reference to ModuleInfo.