### PR TITLE
core.runtime: use crt_constructor instead of static this

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -81,6 +81,9 @@ bool checkFrameAccess(Loc loc, Scope* sc, AggregateDeclaration ad, size_t iStart
 /***********************************************
  * Mark variable v as modified if it is inside a constructor that var
  * is a field in.
+ * Also used to allow immutable globals to be initialized inside a static constructor.
+ * Returns:
+ *    true if it's an initialization of v
  */
 bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
 {
@@ -93,7 +96,7 @@ bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
             fd = s.isFuncDeclaration();
         if (fd &&
             ((fd.isCtorDeclaration() && var.isField()) ||
-             (fd.isStaticCtorDeclaration() && !var.isField())) &&
+             ((fd.isStaticCtorDeclaration() || fd.isCrtCtor) && !var.isField())) &&
             fd.toParentDecl() == var.toParent2() &&
             (!e1 || e1.op == EXP.this_))
         {

--- a/druntime/src/core/runtime.d
+++ b/druntime/src/core/runtime.d
@@ -105,7 +105,7 @@ private
 }
 
 
-shared static this()
+pragma(crt_constructor) void runtimeInitializer()
 {
     // NOTE: Some module ctors will run before this handler is set, so it's
     //       still possible the app could exit without a stack trace.  If


### PR DESCRIPTION
so importing it from betterC code will not result in emitting a ModuleInfo