### PR TITLE
deprecate Object.factory

### DIFF
--- a/compiler/test/runnable/test34.d
+++ b/compiler/test/runnable/test34.d
@@ -1,3 +1,5 @@
+// REQUIRED_ARGS: -d
+
 module test34;
 
 import core.exception;

--- a/compiler/test/runnable/xtest46.d
+++ b/compiler/test/runnable/xtest46.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -preview=rvaluerefparam
+// REQUIRED_ARGS: -d -preview=rvaluerefparam
 //
 /* TEST_OUTPUT:
 ---

--- a/compiler/test/runnable/xtest46_gc.d
+++ b/compiler/test/runnable/xtest46_gc.d
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS: -lowmem -Jrunnable -preview=rvaluerefparam
+REQUIRED_ARGS: -d -lowmem -Jrunnable -preview=rvaluerefparam
 EXTRA_FILES: xtest46.d
 TEST_OUTPUT:
 ---

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -246,7 +246,7 @@ class Object
      * }
      * ---
      */
-    static Object factory(string classname)
+    deprecated static Object factory(string classname)
     {
         auto ci = TypeInfo_Class.find(classname);
         if (ci)
@@ -256,7 +256,7 @@ class Object
         return null;
     }
 
-    @system unittest
+    deprecated @system unittest
     {
         Object valid_obj = Object.factory("object.Object");
         Object invalid_obj = Object.factory("object.__this_class_doesnt_exist__");


### PR DESCRIPTION
For discussion, see:

1. https://issues.dlang.org/show_bug.cgi?id=16423
2. https://www.digitalmars.com/d/archives/digitalmars/D/ModuleInfo_Object.localClasses_and_Object.find_-_any_users_366643.html

The language has problems guessing which classes should go into the ModuleInfo, and people don't want more annotations for this. The pragmatic solution is for users to make the list themselves of which classes can be instantiated with a factory.