### PR TITLE
Fix Issue 23481 - [inf loop] usertype enums opOpAssign cause an compile time infinite loop

### DIFF
--- a/compiler/src/dmd/aliasthis.d
+++ b/compiler/src/dmd/aliasthis.d
@@ -94,7 +94,7 @@ Expression resolveAliasThis(Scope* sc, Expression e, bool gag = false, bool find
             Type tthis = (e.op == EXP.type ? e.type : null);
             const flags = DotExpFlag.noAliasThis | (gag ? DotExpFlag.gag : 0);
             uint olderrors = gag ? global.startGagging() : 0;
-            e = dotExp(e.type, sc, e, ad.aliasthis.ident, flags);
+            e = dotExp(ad.type, sc, e, ad.aliasthis.ident, flags);
             if (!e || findOnly)
                 return gag && global.endGagging(olderrors) ? null : e;
 

--- a/compiler/test/compilable/test23481.d
+++ b/compiler/test/compilable/test23481.d
@@ -1,0 +1,28 @@
+// https://issues.dlang.org/show_bug.cgi?id=23481
+
+struct flagenum(I = ubyte)
+{
+	I i = 1;
+    alias i this;
+
+	auto opBinary(string s)(int j) {
+		return typeof(this)(cast(I)(i*2));
+	}
+	auto opEquals(I a) {
+		return false;
+	}
+}
+
+enum alphakey
+{
+    a = flagenum!int(), b, c, d, e, f, g, h, i, j, k, l,
+    m, n, o, p, q, r, s, t, u, v, w, x, y, z
+}
+
+flagenum!int alpha;
+
+void main()
+{
+	alpha &= alphakey.a;
+    alpha = alpha & alphakey.a; // also crashed in another way
+}


### PR DESCRIPTION
Make sure `alias this` lookup is done on the aggregate. It was bugged in the case of `enum` values.