### PR TITLE
fix Issue 23548 - [REG 2.098] C sources files have precedent over D modules in imports

### DIFF
--- a/compiler/src/dmd/file_manager.d
+++ b/compiler/src/dmd/file_manager.d
@@ -51,8 +51,8 @@ nothrow:
     static const(char)[] lookForSourceFile(const char[] filename, const char*[] path)
     {
         //printf("lookForSourceFile(`%.*s`)\n", cast(int)filename.length, filename.ptr);
-        /* Search along path[] for .di file, then .d file, then .i file, then .c file.
-        */
+        /* Search along path[] for .di file, then .d file.
+         */
         const sdi = FileName.forceExt(filename, hdr_ext);
         if (FileName.exists(sdi) == 1)
             return sdi;
@@ -65,16 +65,6 @@ nothrow:
         if (FileName.exists(sd) == 1)
             return sd;
         scope(exit) FileName.free(sd.ptr);
-
-        const si = FileName.forceExt(filename, i_ext);
-        if (FileName.exists(si) == 1)
-            return si;
-        scope(exit) FileName.free(si.ptr);
-
-        const sc = FileName.forceExt(filename, c_ext);
-        if (FileName.exists(sc) == 1)
-            return sc;
-        scope(exit) FileName.free(sc.ptr);
 
         if (FileName.exists(filename) == 2)
         {
@@ -112,18 +102,6 @@ nothrow:
             }
             FileName.free(n.ptr);
 
-            n = FileName.combine(p, si);
-            if (FileName.exists(n) == 1) {
-                return n;
-            }
-            FileName.free(n.ptr);
-
-            n = FileName.combine(p, sc);
-            if (FileName.exists(n) == 1) {
-                return n;
-            }
-            FileName.free(n.ptr);
-
             const b = FileName.removeExt(filename);
             n = FileName.combine(p, b);
             FileName.free(b.ptr);
@@ -138,6 +116,34 @@ nothrow:
                     return n2;
                 }
                 FileName.free(n2.ptr);
+            }
+            FileName.free(n.ptr);
+        }
+
+        /* ImportC: No D modules found, now search along path[] for .i file, then .c file.
+         */
+        const si = FileName.forceExt(filename, i_ext);
+        if (FileName.exists(si) == 1)
+            return si;
+        scope(exit) FileName.free(si.ptr);
+
+        const sc = FileName.forceExt(filename, c_ext);
+        if (FileName.exists(sc) == 1)
+            return sc;
+        scope(exit) FileName.free(sc.ptr);
+        foreach (entry; path)
+        {
+            const p = entry.toDString();
+
+            const(char)[] n = FileName.combine(p, si);
+            if (FileName.exists(n) == 1) {
+                return n;
+            }
+            FileName.free(n.ptr);
+
+            n = FileName.combine(p, sc);
+            if (FileName.exists(n) == 1) {
+                return n;
             }
             FileName.free(n.ptr);
         }

--- a/compiler/test/compilable/extra-files/issue23548/imports/imp23548.d
+++ b/compiler/test/compilable/extra-files/issue23548/imports/imp23548.d
@@ -1,0 +1,1 @@
+enum issue23548 = true;

--- a/compiler/test/compilable/imports/imp23548.c
+++ b/compiler/test/compilable/imports/imp23548.c
@@ -1,0 +1,1 @@
+#define issue23548 false

--- a/compiler/test/compilable/test23548.d
+++ b/compiler/test/compilable/test23548.d
@@ -1,0 +1,5 @@
+// https://issues.dlang.org/show_bug.cgi?id=23548
+// REQUIRED_ARGS: -Icompilable/extra-files/issue23548
+// EXTRA_FILES: extra-files/issue23548/imports/imp23548.d imports/imp23548.c
+import imports.imp23548;
+static assert(issue23548 == true);


### PR DESCRIPTION
C sources should not be imported if there exists a D module in an include path that also matches.

Test doesn't exactly match that in the regression issue, as in the bug report, the C source file gets picked up by the implicit `-I.`

This would allow fixing issue 23479 without causing the regression in issue 23547.