### PR TITLE
Fix Issue 23551 - Start making nogc error messages for array literals…

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -685,6 +685,18 @@ extern (C++) abstract class Expression : ASTNode
     Type type;      // !=null means that semantic() has been run
     Loc loc;        // file location
 
+    import dmd.root.optional;
+
+    /** 
+        The idea is to try and saved where an expression was lowered from.
+        This is for better error messages.
+     */
+    Optional!ASTNode origin;
+
+    extern(D) void setOrigin(ASTNode e)
+    {
+        this.origin = typeof(origin)(e);
+    }
     extern (D) this(const ref Loc loc, EXP op, int size)
     {
         //printf("Expression::Expression(op = %d) this = %p\n", op, this);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -2621,6 +2621,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             Expression e;
 
+            scope(exit) {
+                /*
+                  If nothing else got there first, just syntax copy the identifier.
+                  Not a great default but a default it is.
+                */
+                if (e && !e.origin.isPresent())
+                    e.setOrigin(exp.syntaxCopy());
+            }
             /* See if the symbol was a member of an enclosing 'with'
              */
             WithScopeSymbol withsym = scopesym.isWithScopeSymbol();
@@ -2705,7 +2713,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 // Haven't done overload resolution yet, so pass 1
                 e = symbolToExp(s, exp.loc, sc, true);
+                e.setOrigin(s);
             }
+
             result = e;
             return;
         }
@@ -12514,6 +12524,7 @@ Expression binSemanticProp(BinExp e, Scope* sc)
 // entrypoint for semantic ExpressionSemanticVisitor
 extern (C++) Expression expressionSemantic(Expression e, Scope* sc)
 {
+
     scope v = new ExpressionSemanticVisitor(sc);
     e.accept(v);
     return v.result;

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -103,8 +103,8 @@ public:
             return;
         if (f.setGC())
         {
-            e.error("array literal in `@nogc` %s `%s` may cause a GC allocation",
-                f.kind(), f.toPrettyChars());
+            e.error("array literal `%s` in `@nogc` %s `%s` may cause a GC allocation",
+                e.toChars(), f.kind(), f.toPrettyChars());
             err = true;
             return;
         }

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -103,8 +103,23 @@ public:
             return;
         if (f.setGC())
         {
-            e.error("array literal `%s` in `@nogc` %s `%s` may cause a GC allocation",
-                e.toChars(), f.kind(), f.toPrettyChars());
+            with(e.origin) 
+            {
+                e.error("array literal `%s` in `@nogc` %s `%s` may cause a GC allocation",
+                    (isPresent ? get : e).toChars(), f.kind(), f.toPrettyChars());
+                if (isPresent)
+                {
+                    import dmd.dtemplate : isDsymbol;
+                    import dmd.dsymbol;
+                    if (auto from = get().isDsymbol())
+                    {
+                        import dmd.errors;
+                        auto tmp = from.isVarDeclaration();
+                        if (tmp && tmp.storage_class & STC.manifest)
+                            errorSupplemental(from.loc, "Consider declaring the manifest constant `%s` `static immutable` to avoid the GC", from.toChars());
+                    }
+                }
+            }
             err = true;
             return;
         }

--- a/compiler/test/fail_compilation/fail12932.d
+++ b/compiler/test/fail_compilation/fail12932.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12932.d(11): Error: array literal in `@nogc` function `fail12932.foo` may cause a GC allocation
-fail_compilation/fail12932.d(15): Error: array literal in `@nogc` function `fail12932.foo` may cause a GC allocation
+fail_compilation/fail12932.d(11): Error: array literal `[1, 2, 3]` in `@nogc` function `fail12932.foo` may cause a GC allocation
+fail_compilation/fail12932.d(15): Error: array literal `[1, 2, 3]` in `@nogc` function `fail12932.foo` may cause a GC allocation
 ---
 */
 

--- a/compiler/test/fail_compilation/fail21928.d
+++ b/compiler/test/fail_compilation/fail21928.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail21928.d(18): Error: array literal in `@nogc` function `D main` may cause a GC allocation
+fail_compilation/fail21928.d(18): Error: array literal `[2LU]` in `@nogc` function `D main` may cause a GC allocation
 ---
 */
 

--- a/compiler/test/fail_compilation/fail21928b.d
+++ b/compiler/test/fail_compilation/fail21928b.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail21928b.d(18): Error: array literal in `@nogc` function `D main` may cause a GC allocation
+fail_compilation/fail21928b.d(18): Error: array literal `[2LU]` in `@nogc` function `D main` may cause a GC allocation
 ---
 */
 

--- a/compiler/test/fail_compilation/nogc2.d
+++ b/compiler/test/fail_compilation/nogc2.d
@@ -57,8 +57,9 @@ fail_compilation/nogc2.d(50): Error: cannot use operator `~=` in `@nogc` functio
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc2.d(69): Error: array literal `[p, p, barA()]` in `@nogc` function `nogc2.testArray` may cause a GC allocation
-fail_compilation/nogc2.d(70): Error: array literal `[null, null]` in `@nogc` function `nogc2.testArray` may cause a GC allocation
+fail_compilation/nogc2.d(70): Error: array literal `[p, p, barA()]` in `@nogc` function `nogc2.testArray` may cause a GC allocation
+fail_compilation/nogc2.d(71): Error: array literal `arrLiteral` in `@nogc` function `nogc2.testArray` may cause a GC allocation
+fail_compilation/nogc2.d(67):        Consider declaring the manifest constant `arrLiteral` `static immutable` to avoid the GC
 ---
 */
 @nogc void testArray()
@@ -75,8 +76,8 @@ fail_compilation/nogc2.d(70): Error: array literal `[null, null]` in `@nogc` fun
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc2.d(86): Error: associative array literal in `@nogc` function `nogc2.testAssocArray` may cause a GC allocation
 fail_compilation/nogc2.d(87): Error: associative array literal in `@nogc` function `nogc2.testAssocArray` may cause a GC allocation
+fail_compilation/nogc2.d(88): Error: associative array literal in `@nogc` function `nogc2.testAssocArray` may cause a GC allocation
 ---
 */
 @nogc void testAssocArray()
@@ -92,7 +93,7 @@ fail_compilation/nogc2.d(87): Error: associative array literal in `@nogc` functi
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc2.d(100): Error: assigning an associative array element in `@nogc` function `nogc2.testIndex` may cause a GC allocation
+fail_compilation/nogc2.d(101): Error: assigning an associative array element in `@nogc` function `nogc2.testIndex` may cause a GC allocation
 ---
 */
 @nogc void testIndex(int[int] aa)

--- a/compiler/test/fail_compilation/nogc2.d
+++ b/compiler/test/fail_compilation/nogc2.d
@@ -57,8 +57,8 @@ fail_compilation/nogc2.d(50): Error: cannot use operator `~=` in `@nogc` functio
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc2.d(69): Error: array literal in `@nogc` function `nogc2.testArray` may cause a GC allocation
-fail_compilation/nogc2.d(70): Error: array literal in `@nogc` function `nogc2.testArray` may cause a GC allocation
+fail_compilation/nogc2.d(69): Error: array literal `[p, p, barA()]` in `@nogc` function `nogc2.testArray` may cause a GC allocation
+fail_compilation/nogc2.d(70): Error: array literal `[null, null]` in `@nogc` function `nogc2.testArray` may cause a GC allocation
 ---
 */
 @nogc void testArray()

--- a/compiler/test/fail_compilation/nogc3.d
+++ b/compiler/test/fail_compilation/nogc3.d
@@ -73,10 +73,10 @@ fail_compilation/nogc3.d(67):        `nogc3.testClosure3.bar` closes over variab
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc3.d(85): Error: array literal in `@nogc` function `nogc3.foo13702` may cause a GC allocation
-fail_compilation/nogc3.d(86): Error: array literal in `@nogc` function `nogc3.foo13702` may cause a GC allocation
-fail_compilation/nogc3.d(92): Error: array literal in `@nogc` function `nogc3.bar13702` may cause a GC allocation
-fail_compilation/nogc3.d(91): Error: array literal in `@nogc` function `nogc3.bar13702` may cause a GC allocation
+fail_compilation/nogc3.d(85): Error: array literal `[1]` in `@nogc` function `nogc3.foo13702` may cause a GC allocation
+fail_compilation/nogc3.d(86): Error: array literal `[1, 2]` in `@nogc` function `nogc3.foo13702` may cause a GC allocation
+fail_compilation/nogc3.d(92): Error: array literal `[1, 2]` in `@nogc` function `nogc3.bar13702` may cause a GC allocation
+fail_compilation/nogc3.d(91): Error: array literal `[1]` in `@nogc` function `nogc3.bar13702` may cause a GC allocation
 ---
 */
 int[] foo13702(bool b) @nogc

--- a/compiler/test/fail_compilation/test23170.d
+++ b/compiler/test/fail_compilation/test23170.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test23170.d(10): Error: array literal in `@nogc` delegate `test23170.__lambda5` may cause a GC allocation
+fail_compilation/test23170.d(10): Error: array literal `[1, 2, 3]` in `@nogc` delegate `test23170.__lambda5` may cause a GC allocation
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=23170


### PR DESCRIPTION
… more precise

This makes it more obvious what the array literal is, the greater issue is to know where it was lowered from. More on that soon.