### PR TITLE
add constraint in template constructor

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -930,6 +930,7 @@ struct ASTBase
             this.parameters = parameters;
             this.origParameters = parameters;
             this.members = decldefs;
+            this.constraint = constraint;
             this.literal = literal;
             this.ismixin = ismixin;
             this.isstatic = true;


### PR DESCRIPTION
This was most likely omitted. Or is there a particular reason it was missing?