### PR TITLE
For posix targets make a symlink to the latest generated dmd (./gener…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ dmd.iml
 
 # Deliberately ignored files
 untracked_files/
+
+# Just in case
+dmd

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -459,7 +459,19 @@ alias directoryRule = makeRuleWithArgs!((MethodInitializer!BuildRule builder, Bu
    .msg("mkdirRecurse '%s'".format(dir))
    .commandFunction(() => mkdirRecurse(dir))
 );
+alias dmdSymlink = makeRule!((builder, rule) => builder
+    .commandFunction((){
+        import std.process;
+        version(Windows)
+        {
 
+        }
+        else
+        {
+            spawnProcess(["ln", "-sf", env["DMD_PATH"], "./dmd"]);
+        }
+    })
+);
 /**
 BuildRule for the DMD executable.
 


### PR DESCRIPTION
…ated/...) in the top level dir.

The idea is to have faster iteration times.

A "dmd" entry has been added to the .gitignore