### PR TITLE
Attempt to use longdouble_soft everywhere I can see.

### DIFF
--- a/compiler/src/dmd/backend/bcomplex.d
+++ b/compiler/src/dmd/backend/bcomplex.d
@@ -13,8 +13,7 @@ module dmd.backend.bcomplex;
 
 public import dmd.root.longdouble : targ_ldouble = longdouble;
 import core.stdc.math : fabs, fabsl, sqrt;
-version(CRuntime_Microsoft)
-    private import dmd.root.longdouble : fabsl, sqrt; // needed if longdouble is longdouble_soft
+private import dmd.root.longdouble : fabsl, sqrt; // needed if longdouble is longdouble_soft
 
 extern (C++):
 @nogc:

--- a/compiler/src/dmd/backend/cg87.d
+++ b/compiler/src/dmd/backend/cg87.d
@@ -660,10 +660,11 @@ ubyte loadconst(elem *e, int im)
     immutable double[7] dval =
         [0.0,1.0,PI,LOG2T,LOG2E,LOG2,LN2];
 
-    static if (real.sizeof < 10)
+    static if (true)
     {
         import dmd.root.longdouble;
-        immutable targ_ldouble[7] ldval =
+        // Static is to allow WorseD (betterC) compilation on 2.079.0
+        static immutable targ_ldouble[7] ldval =
         [ld_zero,ld_one,ld_pi,ld_log2t,ld_log2e,ld_log2,ld_ln2];
     }
     else

--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -1787,15 +1787,7 @@ void shrinkLongDoubleConstantIfPossible(elem *e)
         auto v = e.EV.Vldouble;
         double vDouble;
 
-        version (CRuntime_Microsoft)
-        {
-            static if (is(typeof(v) == real))
-                *(&vDouble) = v;
-            else
-                *(&vDouble) = cast(double)v;
-        }
-        else
-            *(&vDouble) = v;
+        *(&vDouble) = cast(double) v;
 
         if (v == vDouble)       // This will fail if compiler does NaN incorrectly!
         {
@@ -3105,17 +3097,21 @@ case_tym:
 
         case TYldouble:
         {
-            version (CRuntime_Microsoft)
+            version (all)
             {
+                import dmd.root.ctfloat;
+                /*
+                    We are now using longdouble_soft/CTFloat everywhere.
+                */
                 char[3 + 3 * (targ_ldouble).sizeof + 1] buffer = void;
                 static if (is(typeof(e.EV.Vldouble) == real))
-                    ld_sprint(buffer.ptr, 'g', longdouble_soft(e.EV.Vldouble));
+                    CTFloat.sprint(buffer.ptr, 'g', longdouble_soft(e.EV.Vldouble));
                 else
-                    ld_sprint(buffer.ptr, 'g', longdouble_soft(cast(real)e.EV.Vldouble));
+                    CTFloat.sprint(buffer.ptr, 'g', longdouble_soft(cast(real)e.EV.Vldouble));
                 printf("%s ", buffer.ptr);
             }
-            else
-                printf("%Lg ", e.EV.Vldouble);
+            // else
+                // printf("%Lg ", e.EV.Vldouble);
             break;
         }
 

--- a/compiler/src/dmd/backend/evalu8.d
+++ b/compiler/src/dmd/backend/evalu8.d
@@ -37,7 +37,7 @@ import dmd.backend.global;
 import dmd.backend.el;
 import dmd.backend.ty;
 import dmd.backend.type;
-
+import dmd.root.ctfloat;
 import dmd.common.int128;
 
 version (SCPP)
@@ -128,7 +128,8 @@ version (SCPP)
                 case TYdouble_alias:
                 case TYildouble:
                 case TYldouble:
-                {   targ_ldouble ld = el_toldoubled(e);
+                {
+                    targ_ldouble ld = el_toldoubled(e);
 
                     if (isnan(ld))
                         b = 1;

--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -155,9 +155,6 @@ void initDMD(
 
     addDefaultVersionIdentifiers(global.params, target);
 
-    version (CRuntime_Microsoft)
-        initFPU();
-
     CTFloat.initialize();
 }
 

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -287,11 +287,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     Objc._init();
 
     reconcileLinkRunLib(params, files.length, target.obj_ext);
-    version(CRuntime_Microsoft)
-    {
-        import dmd.root.longdouble;
-        initFPU();
-    }
+
     import dmd.root.ctfloat : CTFloat;
     CTFloat.initialize();
 

--- a/compiler/src/dmd/root/longdouble.d
+++ b/compiler/src/dmd/root/longdouble.d
@@ -11,19 +11,11 @@
 
 module dmd.root.longdouble;
 
-version (CRuntime_Microsoft)
-{
-    static if (real.sizeof > 8)
-        alias longdouble = real;
-    else
-        alias longdouble = longdouble_soft;
-}
-else
-    alias longdouble = real;
+alias longdouble = longdouble_soft;
 
 // longdouble_soft needed when building the backend with
 // Visual C or the frontend with LDC on Windows
-version (CRuntime_Microsoft):
+
 extern (C++):
 nothrow:
 @nogc:
@@ -67,11 +59,10 @@ bool initFPU()
             pop     EAX;
         }
     }
-
     return true;
 }
 
-version(unittest) version(CRuntime_Microsoft)
+version(unittest)
 extern(D) shared static this()
 {
     initFPU(); // otherwise not guaranteed to be run before pure unittest below
@@ -229,14 +220,20 @@ else version(D_InlineAsm_X86_64)
     private:
     string fld_arg(string arg)()
     {
-        return "asm nothrow @nogc pure @trusted { mov RAX, " ~ arg ~ "; fld real ptr [RAX]; }";
+        return "asm nothrow @nogc pure @trusted { lea RAX, " ~ arg ~ "; fld real ptr [RAX]; }";
     }
     string fstp_arg(string arg)()
     {
+        return "asm nothrow @nogc pure @trusted { lea RAX, " ~ arg ~ "; fstp real ptr [RAX]; }";
+    }
+    string fld_parg(string arg)()
+    {
+        return "asm nothrow @nogc pure @trusted { mov RAX, " ~ arg ~ "; fld real ptr [RAX]; }";
+    }
+    string fstp_parg(string arg)()
+    {
         return "asm nothrow @nogc pure @trusted { mov RAX, " ~ arg ~ "; fstp real ptr [RAX]; }";
     }
-    alias fld_parg = fld_arg;
-    alias fstp_parg = fstp_arg;
 }
 else version(D_InlineAsm_X86)
 {


### PR DESCRIPTION
This does not yet mean that we are truly emulating things yet but this makes it much easier to emulate things when the code to do so is ready.

The fstp fld mixins were wrong for 64 bit linux (at least) and have been changed. Now we see what the test-suite says