### PR TITLE
Use -fmain rather than -main when compiling dmd-unittest executable w…

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -659,7 +659,7 @@ alias runTests = makeRule!((testBuilder, testRule)
 
 /// BuildRule to run the DMD unittest executable.
 alias runDmdUnittest = makeRule!((builder, rule) {
-auto dmdUnittestExe = dmdExe("-unittest", ["-version=NoMain", "-unittest", "-main"], ["-unittest"]);
+auto dmdUnittestExe = dmdExe("-unittest", ["-version=NoMain", "-unittest", env["HOST_DMD_KIND"] == "gdc" ? "-fmain" : "-main"], ["-unittest"]);
     builder
         .name("unittest")
         .description("Run the dmd unittests")


### PR DESCRIPTION
…ith gdmd (gcc)