### PR TITLE
Fix Issue 23549, 22587 - Lower certain noreturn expressions to a comm…

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12217,10 +12217,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (t1.ty == Tnoreturn)
         {
             exp.type = t2;
+            exp.e1 = specialNoreturnCast(exp.e1, exp.type);
         }
         else if (t2.ty == Tnoreturn)
         {
             exp.type = t1;
+            exp.e2 = specialNoreturnCast(exp.e2, exp.type);
         }
         // If either operand is void the result is void, we have to cast both
         // the expression to void so that we explicitly discard the expression

--- a/compiler/test/compilable/noreturn1.d
+++ b/compiler/test/compilable/noreturn1.d
@@ -150,3 +150,14 @@ void noreturnImplicit()
         auto y = (throw new Exception("wow")) + value;
     }
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=23549
+int foo(int g = assert(0)) {
+    return g;
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=22587
+int front(int param)
+{
+    return param ? 1 : assert(0);
+}


### PR DESCRIPTION
…a expression rather than a cast.

This avoids a backend segfault.

GDC already does this lowering so it may have to be made optional via a frontend parameter.