### PR TITLE
fix Issue 23558 - add __traits(getModuleClasses [, module name])

### DIFF
--- a/changelog/dmd.getClassInfos.dd
+++ b/changelog/dmd.getClassInfos.dd
@@ -1,0 +1,34 @@
+# add __traits(getModuleClasses [, module name])
+
+Since Object.factory() is being deprecated https://github.com/dlang/dmd/pull/14681 a convenient replacement is necessary.
+
+<pre>
+TraitsExpression:
+    __traits ( getModuleClasses [, TraitsArgument] )
+</pre>
+
+The TraitsArgument is the name of the module or a fully qualified import.
+
+If the TraitsArgument is not specified, it defaults to the current module.
+
+It returns a Tuple of strings representing the fully qualified classes defined in the specified module.
+
+For example:
+
+---
+module test;
+import std.stdio;
+class C { }
+pragma(msg, __traits(getModuleClasses));
+pragma(msg, __traits(getModuleClasses, std.stdio);
+---
+
+prints:
+
+<pre>
+tuple("test.C")
+tuple("std.stdio.Stdio.Exception")
+</pre>
+
+".classinfo" can be appended to those strings to get the classinfo for those modules.
+See https://dlang.org/spec/property.html#classinfoSince

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8708,6 +8708,7 @@ struct Id final
     static Identifier* getVisibility;
     static Identifier* parent;
     static Identifier* child;
+    static Identifier* getModuleClasses;
     static Identifier* getMember;
     static Identifier* getOverloads;
     static Identifier* getVirtualFunctions;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -462,6 +462,7 @@ immutable Msgtable[] msgtable =
     { "getVisibility" },
     { "parent" },
     { "child" },
+    { "getModuleClasses" },
     { "getMember" },
     { "getOverloads" },
     { "getVirtualFunctions" },

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -14,6 +14,7 @@
 module dmd.traits;
 
 import core.stdc.stdio;
+import core.stdc.string;
 
 import dmd.aggregate;
 import dmd.arraytypes;
@@ -743,6 +744,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto se = new StringExp(e.loc, id.toString());
         return se.expressionSemantic(sc);
     }
+
     if (e.ident == Id.fullyQualifiedName) // https://dlang.org/spec/traits.html#fullyQualifiedName
     {
         if (dim != 1)
@@ -779,6 +781,56 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         return se.expressionSemantic(sc);
 
     }
+
+    if (e.ident == Id.getModuleClasses)
+    {
+        /* https://dlang.org/spec/traits.html#getModuleClasses
+         */
+        Module m;
+        if (dim == 0)
+        {
+            m = sc._module;     // default to current module
+            if (!m)
+                return False();
+        }
+        else if (dim == 1)
+        {
+            auto o = (*e.args)[0];
+            auto s = getDsymbol(o);
+            if (s)
+            {
+                if (auto imp = s.isImport())
+                    m = imp.mod;
+                else
+                    m = s.isModule();
+            }
+            if (!m)
+            {
+                e.error("in expression `%s` `%s` must be a module", e.toChars(), o.toChars());
+                return ErrorExp.get();
+            }
+        }
+        else
+            return dimError(0);
+
+        ClassDeclarations aclasses;
+        getLocalClasses(m, aclasses);
+
+        auto exps = new Expressions(aclasses.length);
+        foreach (i, cd; aclasses)
+        {
+            const p = cd.toPrettyChars();
+            //printf("class %s\n", p);
+            const s = p[0 .. strlen(p)];
+            auto se = new StringExp(e.loc, s);
+            (*exps)[i] = se;
+        }
+
+        Expression ex = new TupleExp(e.loc, exps);
+        ex = ex.expressionSemantic(sc);
+        return ex;
+    }
+
     if (e.ident == Id.getProtection || e.ident == Id.getVisibility)
     {
         if (dim != 1)
@@ -2244,7 +2296,7 @@ private void traitNotFound(TraitsExp e)
         initialized = true;     // lazy initialization
 
         // All possible traits
-        __gshared Identifier*[59] idents =
+        __gshared Identifier*[60] idents =
         [
             &Id.isAbstractClass,
             &Id.isArithmetic,
@@ -2281,6 +2333,7 @@ private void traitNotFound(TraitsExp e)
             &Id.child,
             &Id.getLinkage,
             &Id.getMember,
+            &Id.getModuleClasses,
             &Id.getOverloads,
             &Id.getVirtualFunctions,
             &Id.getVirtualMethods,

--- a/compiler/test/compilable/test23558.d
+++ b/compiler/test/compilable/test23558.d
@@ -1,0 +1,17 @@
+/* TEST_OUTPUT:
+---
+getModuleClasses: tuple("test23558.C")
+getModuleClasses: tuple("std.stdio.StdioException")
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=23558
+
+import std.stdio;
+
+class C { }
+
+pragma(msg, "getModuleClasses: ", __traits(getModuleClasses));
+pragma(msg, "getModuleClasses: ", __traits(getModuleClasses, std.stdio));
+
+//pragma(msg, "getClassInfos: ", __traits(getModuleClasses, 3));

--- a/compiler/test/fail_compilation/test23558.d
+++ b/compiler/test/fail_compilation/test23558.d
@@ -1,0 +1,16 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test23558.d(103): Error: in expression `__traits(getModuleClasses, S)` `S` must be a module
+fail_compilation/test23558.d(105): Error: expected 0 arguments for `getModuleClasses` but had 2
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=23558
+
+#line 100
+
+struct S { }
+
+auto x = __traits(getModuleClasses, S);
+
+auto y = __traits(getModuleClasses, 1, 2);

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -246,7 +246,8 @@ class Object
      * }
      * ---
      */
-    deprecated static Object factory(string classname)
+    deprecated("use __traits(getModuleClasses) instead")
+    static Object factory(string classname)
     {
         auto ci = TypeInfo_Class.find(classname);
         if (ci)


### PR DESCRIPTION
Provide alternative to Object.factory(), see https://github.com/dlang/dmd/pull/14681