### PR TITLE
fix Issue 23548 - [REG 2.098] C sources files have precedent over D modules in imports

### DIFF
--- a/compiler/src/dmd/file_manager.d
+++ b/compiler/src/dmd/file_manager.d
@@ -123,7 +123,7 @@ nothrow:
     const(char)[] lookForSourceFile(const char[] filename, const char*[] path)
     {
         //printf("lookForSourceFile(`%.*s`)\n", cast(int)filename.length, filename.ptr);
-        /* Search along path[] for .di file, then .d file, then .i file, then .c file.
+        /* Search along path[] for .di file, then .d file.
         */
         // see if we should check for the module locally.
         bool checkLocal = packageExists(filename);
@@ -139,16 +139,6 @@ nothrow:
         if (checkLocal && FileName.exists(sd) == 1)
             return sd;
         scope(exit) FileName.free(sd.ptr);
-
-        const si = FileName.forceExt(filename, i_ext);
-        if (checkLocal && FileName.exists(si) == 1)
-            return si;
-        scope(exit) FileName.free(si.ptr);
-
-        const sc = FileName.forceExt(filename, c_ext);
-        if (checkLocal && FileName.exists(sc) == 1)
-            return sc;
-        scope(exit) FileName.free(sc.ptr);
 
         if (checkLocal)
         {
@@ -198,18 +188,6 @@ nothrow:
             }
             FileName.free(n.ptr);
 
-            n = FileName.combine(p, si);
-            if (FileName.exists(n) == 1) {
-                return n;
-            }
-            FileName.free(n.ptr);
-
-            n = FileName.combine(p, sc);
-            if (FileName.exists(n) == 1) {
-                return n;
-            }
-            FileName.free(n.ptr);
-
             const b = FileName.removeExt(filename);
             n = FileName.combine(p, b);
             FileName.free(b.ptr);
@@ -234,6 +212,34 @@ nothrow:
                 }
                 FileName.free(n2.ptr);
             }
+        }
+
+        /* ImportC: No D modules found, now search along path[] for .i file, then .c file.
+         */
+        const si = FileName.forceExt(filename, i_ext);
+        if (FileName.exists(si) == 1)
+            return si;
+        scope(exit) FileName.free(si.ptr);
+
+        const sc = FileName.forceExt(filename, c_ext);
+        if (FileName.exists(sc) == 1)
+            return sc;
+        scope(exit) FileName.free(sc.ptr);
+        foreach (entry; path)
+        {
+            const p = entry.toDString();
+
+            const(char)[] n = FileName.combine(p, si);
+            if (FileName.exists(n) == 1) {
+                return n;
+            }
+            FileName.free(n.ptr);
+
+            n = FileName.combine(p, sc);
+            if (FileName.exists(n) == 1) {
+                return n;
+            }
+            FileName.free(n.ptr);
         }
         return null;
     }

--- a/compiler/test/compilable/extra-files/issue23548/imports/imp23548.d
+++ b/compiler/test/compilable/extra-files/issue23548/imports/imp23548.d
@@ -1,0 +1,1 @@
+enum issue23548 = true;

--- a/compiler/test/compilable/imports/imp23548.c
+++ b/compiler/test/compilable/imports/imp23548.c
@@ -1,0 +1,1 @@
+#define issue23548 false

--- a/compiler/test/compilable/test23548.d
+++ b/compiler/test/compilable/test23548.d
@@ -1,0 +1,5 @@
+// https://issues.dlang.org/show_bug.cgi?id=23548
+// REQUIRED_ARGS: -Icompilable/extra-files/issue23548
+// EXTRA_FILES: extra-files/issue23548/imports/imp23548.d imports/imp23548.c
+import imports.imp23548;
+static assert(issue23548 == true);


### PR DESCRIPTION
Restores import behaviour to pre-2.098.  ImportC is not part of the language, it's an add-on, and shouldn't hijack the importing of D modules.

Other choices include:

- Do the same as we have for `import("foo.c")`, and have a specific list of include paths only searched for `.c`, `.h`, and `.i` files.
- Change syntax to `import(C) foo;` so there can be no ambiguity in the language.
- Likewise, but use `import "foo.h"`.
- MixinC: http://dpldocs.info/experimental-docs/mixinc.html