### PR TITLE
fix Issue 23151 - ICE: core.exception.AssertError@src/dmd/aggregate.d(678): Assertion failure

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -5197,7 +5197,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                             cldec.baseClass.toChars(),
                             cldec.baseClass.toParentLocal().toChars());
                     }
-                    cldec.enclosing = null;
                 }
                 if (cldec.vthis2)
                 {

--- a/compiler/test/fail_compilation/fail23151.d
+++ b/compiler/test/fail_compilation/fail23151.d
@@ -1,0 +1,41 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23151.d(30): Error: class `fail23151.makeDerivedObj.Derived` is nested within `makeDerivedObj`, but super class `Base` is nested within `makeBaseObj`
+---
+*/
+interface I
+{
+    void intfunc(int x);
+}
+
+auto makeBaseObj()
+{
+    int realPrivateX;
+    class Base : I
+    {
+        private int modulePrivateX;
+        int publicX;
+        override void intfunc(int x)
+        {
+            realPrivateX++; // expected OK
+        }
+    }
+    return new Base;
+}
+
+auto makeDerivedObj()
+{
+    int realPrivateY;
+    class Derived : typeof(makeBaseObj())
+    {
+        private int modulePrivateY;
+        int publicY;
+        override void intfunc(int x)
+        {
+            realPrivateX++; // expected NG
+            modulePrivateX++;
+        }
+    }
+    return new Derived;
+}


### PR DESCRIPTION
If an error occurred validating a nested class, don't unnest it, it is enough that the `error` count has been incremented, which sets `cldec.errors` to flag the symbol as failed. Otherwise a subsequent call to `makeNested()` will throw an assert because `cldec.vthis` is still set.

Only affects debug builds, which have asserts compiled in.