### PR TITLE
Fix Issue 23552 - Function x does not override any function, but it actually does

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -206,7 +206,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         //printf("AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
 
         // The previous instance size finalizing had:
-        if (type.ty == Terror)
+        if (type.ty == Terror || errors)
             return false;   // failed already
         if (sizeok == Sizeok.done)
             return true;    // succeeded

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -5378,10 +5378,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             cldec.error("already exists at %s. Perhaps in another function with the same name?", cd.loc.toChars());
         }
 
-        if (global.errors != errors)
+        if (global.errors != errors || (cldec.baseClass && cldec.baseClass.errors))
         {
-            // The type is no good.
-            cldec.type = Type.terror;
+            // The type is no good, but we should keep the
+            // the type so that we have more accurate error messages
+            // See: https://issues.dlang.org/show_bug.cgi?id=23552
             cldec.errors = true;
             if (cldec.deferred)
                 cldec.deferred.errors = true;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3563,6 +3563,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (auto tc = tb.isTypeClass())
         {
             auto cd = tc.sym;
+            if (cd.errors)
+                return setError();
             cd.size(exp.loc);
             if (cd.sizeok != Sizeok.done)
                 return setError();

--- a/compiler/test/fail_compilation/test12228.d
+++ b/compiler/test/fail_compilation/test12228.d
@@ -1,10 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test12228.d(13): Error: undefined identifier `this`, did you mean `typeof(this)`?
-fail_compilation/test12228.d(18): Error: no property `x` for type `object.Object`
+fail_compilation/test12228.d(12): Error: undefined identifier `this`, did you mean `typeof(this)`?
+fail_compilation/test12228.d(18): Error: undefined identifier `super`, did you mean `typeof(super)`?
 fail_compilation/test12228.d(19): Error: undefined identifier `super`, did you mean `typeof(super)`?
-fail_compilation/test12228.d(20): Error: undefined identifier `super`, did you mean `typeof(super)`?
 ---
 */
 

--- a/compiler/test/fail_compilation/test21008.d
+++ b/compiler/test/fail_compilation/test21008.d
@@ -12,7 +12,6 @@ fail_compilation/test21008.d(117): Error: `Monitor` has no effect
 fail_compilation/test21008.d(117): Error: function `object.Object.factory(string classname)` is not callable using argument types `()`
 fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
 fail_compilation/test21008.d(105):        called from here: `handleMiddlewareAnnotation()`
-fail_compilation/test21008.d(108): Error: class `test21008.C` no size because of forward reference
 ---
 */
 

--- a/compiler/test/fail_compilation/test23552.d
+++ b/compiler/test/fail_compilation/test23552.d
@@ -1,0 +1,24 @@
+// https://issues.dlang.org/show_bug.cgi?id=23552
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test23552.d(17): Error: cannot implicitly override base class method `test23552.Base.foo` with `test23552.Derived.foo`; add `override` attribute
+---
+*/
+
+abstract class Base
+{
+    void foo();
+}
+
+class Derived : Base
+{
+    void foo() { }
+    int data() { return 0; }
+}
+
+class DerivedX : Derived
+{
+    override int data() { return 1; }
+}


### PR DESCRIPTION
This bug was happening because when  a class contains some errors, its associated type is replaced with TypeError, although there is a field `bool errors` that also keeps track of that. To pertain the information about the class I am keeping the type, but just updating the errors field. This required some tweaks in some places, but I think that this is a better alternative.