### PR TITLE
replace addLocalClass() with ScopeDsymbol._foreach

### DIFF
--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -304,7 +304,6 @@ public:
     virtual int vtblOffset() const;
     const char *kind() const override;
 
-    void addLocalClass(ClassDeclarations *) override final;
     void addObjcSymbols(ClassDeclarations *classes, ClassDeclarations *categories) override final;
 
     // Back end

--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -197,11 +197,6 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     /****************************************
      */
-    override final void addLocalClass(ClassDeclarations* aclasses)
-    {
-        include(null).foreachDsymbol( s => s.addLocalClass(aclasses) );
-    }
-
     override final void addObjcSymbols(ClassDeclarations* classes, ClassDeclarations* categories)
     {
         objc.addSymbols(this, classes, categories);

--- a/compiler/src/dmd/attrib.h
+++ b/compiler/src/dmd/attrib.h
@@ -36,7 +36,6 @@ public:
     bool hasPointers() override final;
     bool hasStaticCtorOrDtor() override final;
     void checkCtorConstInit() override final;
-    void addLocalClass(ClassDeclarations *) override final;
     AttribDeclaration *isAttribDeclaration() override { return this; }
 
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -963,12 +963,6 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
     /****************************************
      */
-    override final void addLocalClass(ClassDeclarations* aclasses)
-    {
-        if (classKind != ClassKind.objc)
-            aclasses.push(this);
-    }
-
     override final void addObjcSymbols(ClassDeclarations* classes, ClassDeclarations* categories)
     {
         .objc.addSymbols(this, classes, categories);

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1377,6 +1377,37 @@ extern (C++) struct ModuleDeclaration
     }
 }
 
+/****************************************
+ * Create array of the local classes in the Module, suitable
+ * for inclusion in ModuleInfo
+ * Params:
+ *      mod = the Module
+ *	aclasses = array to fill in
+ * Returns: array of local classes
+ */
+extern (C++) void getLocalClasses(Module mod, ref ClassDeclarations aclasses)
+{
+    //printf("members.length = %d\n", mod.members.length);
+    int pushAddClassDg(size_t n, Dsymbol sm)
+    {
+        if (!sm)
+            return 0;
+
+        if (auto cd = sm.isClassDeclaration())
+        {
+            // compatibility with previous algorithm
+            if (cd.parent && cd.parent.isTemplateMixin())
+                return 0;
+
+            if (cd.classKind != ClassKind.objc)
+                aclasses.push(cd);
+        }
+        return 0;
+    }
+
+    ScopeDsymbol._foreach(null, mod.members, &pushAddClassDg);
+}
+
 /**
  * Process the content of a source file
  *

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -1239,10 +1239,6 @@ extern (C++) class Dsymbol : ASTNode
         return false;
     }
 
-    void addLocalClass(ClassDeclarations*)
-    {
-    }
-
     void addObjcSymbols(ClassDeclarations* classes, ClassDeclarations* categories)
     {
     }

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -258,7 +258,6 @@ public:
     virtual void setFieldOffset(AggregateDeclaration *ad, FieldState& fieldState, bool isunion);
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();
-    virtual void addLocalClass(ClassDeclarations *) { }
     virtual void addObjcSymbols(ClassDeclarations *, ClassDeclarations *) { }
     virtual void checkCtorConstInit() { }
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -508,7 +508,6 @@ public:
     virtual void setFieldOffset(AggregateDeclaration* ad, FieldState& fieldState, bool isunion);
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();
-    virtual void addLocalClass(Array<ClassDeclaration* >* _param_0);
     virtual void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories);
     virtual void checkCtorConstInit();
     virtual void addComment(const char* comment);
@@ -5388,7 +5387,6 @@ public:
     bool hasPointers() final override;
     bool hasStaticCtorOrDtor() final override;
     void checkCtorConstInit() final override;
-    void addLocalClass(Array<ClassDeclaration* >* aclasses) final override;
     void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories) final override;
     AttribDeclaration* isAttribDeclaration() override;
     void accept(Visitor* v) override;
@@ -5787,7 +5785,6 @@ public:
     bool isAbstract();
     virtual int32_t vtblOffset() const;
     const char* kind() const override;
-    void addLocalClass(Array<ClassDeclaration* >* aclasses) final override;
     void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories) final override;
     Dsymbol* vtblsym;
     Dsymbol* vtblSymbol();
@@ -6355,6 +6352,8 @@ struct ModuleDeclaration final
     {
     }
 };
+
+extern void getLocalClasses(Module* mod, Array<ClassDeclaration* >& aclasses);
 
 extern void gendocfile(Module* m);
 

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -170,3 +170,5 @@ struct ModuleDeclaration
 
     const char *toChars() const;
 };
+
+extern void getLocalClasses(Module* mod, Array<ClassDeclaration* >& aclasses);

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -99,16 +99,9 @@ void genModuleInfo(Module m)
     m.csym.Sfl = FLdata;
 
     auto dtb = DtBuilder(0);
+
     ClassDeclarations aclasses;
-
-    //printf("members.length = %d\n", members.length);
-    foreach (i; 0 .. m.members.length)
-    {
-        Dsymbol member = (*m.members)[i];
-
-        //printf("\tmember '%s'\n", member.toChars());
-        member.addLocalClass(&aclasses);
-    }
+    getLocalClasses(m, aclasses);
 
     // importedModules[]
     size_t aimports_dim = m.aimports.length;

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1179,11 +1179,7 @@ public:
                 s->accept(this);
             }
             ClassDeclarations aclasses;
-            for (size_t i = 0; i < d->members->length; i++)
-            {
-                Dsymbol *member = (*d->members)[i];
-                member->addLocalClass(&aclasses);
-            }
+            getLocalClasses(d, aclasses);
             for (size_t i = 0; i < d->aimports.length; i++)
             {
                 Module *mi = d->aimports[i];


### PR DESCRIPTION
`addLocalClass()` predates `ScopeDsymbol._foreach`, which is a more generic solution.