### PR TITLE
fix Issue 23564 - [REG 2.099.0] SIGSEGV during compilation

### DIFF
--- a/compiler/test/fail_compilation/ice23564.d
+++ b/compiler/test/fail_compilation/ice23564.d
@@ -1,0 +1,25 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/ice23564.d(10): Error: cannot construct nested class `FreeList` because no implicit `this` reference to outer class `RBTree` is available
+---
+*/
+class BlockHeader
+{
+    this()
+    {
+        new FreeList;
+    }
+}
+
+class RBTree
+{
+    class FreeList
+    {
+    }
+
+    void _each_reverse()
+    {
+    }
+}
+
+alias FreeList = RBTree.FreeList;


### PR DESCRIPTION
#13463 removed the null pointer check that served as the exit condition in the for loop.  This re-adds a null pointer check, wrapping the new error message into a function.