### PR TITLE
fix Issue 3254 - [module] Module member visibility depends on declaration order

### DIFF
--- a/compiler/test/fail_compilation/fail3254.d
+++ b/compiler/test/fail_compilation/fail3254.d
@@ -1,0 +1,14 @@
+/*
+EXTRA_FILES: imports/imp3254.d
+TEST_OUTPUT:
+---
+fail_compilation/fail3254.d(13): Error: function `imports.imp3254.test3254(float)` is not accessible from function `D main`
+---
+*/
+import imports.imp3254;
+
+void main()
+{
+    test3254();     // OK, public
+    test3254(0.0);
+}

--- a/compiler/test/fail_compilation/imports/imp3254.d
+++ b/compiler/test/fail_compilation/imports/imp3254.d
@@ -1,0 +1,11 @@
+module imports.imp3254;
+
+string test3254()
+{
+    return "public function";
+}
+
+private string test3254(float)
+{
+    return "private function";
+}


### PR DESCRIPTION
The order that semantic goes in to determine an overload is visible from the scope of another is:
- `dmd.access.symbolIsVisible` - picks the most visible symbol, errors if non are visible.
- `dmd.dtemplate.functionResolve` - picks the overload that matches (overload might not be visible, but accepted anyway).
- `dmd.access.checkAccess` - checks that access is permitted.

The current `checkAccess` routine only applies to class/struct members.  This adds a new version that does the general access check from one module to another.

There are two alternative ways to approach this I can think of:
1. Prune private symbols from the list of overloads checked by `functionResolve`.
2. Give `functionResolve` the context from which symbols are being resolved from, so it can do both argument matching and access checks at the same time.

However I'm a little wary of making any changes to `functionResolve`, as it would affect _everything_ template and overload related, and may make it brittle to work with - introducing many subtle and hidden changes to the way code is expanded at compile-time.

First seeing what the testsuite says, but making this a deprecation would be the preferred choice.  I originally made `checkAccess(AggregateDeclaration)` private, and the compiler successfully built, but then errors occurred when I removed it - I hit the same bug as what this is fixing!