### PR TITLE
[Bug fix] Use the location and type of the original index offset

### DIFF
--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -586,7 +586,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
                     Expression ex = new AddrExp(ae1.loc, ae1);  // &a[i]
                     ex.type = ae1.type.pointerTo();
 
-                    Expression add = new AddExp(ae.loc, ex, new IntegerExp(ae.loc, offset, e.type));
+                    Expression add = new AddExp(ae.loc, ex, new IntegerExp(ae.e2.loc, offset, ae.e2.type));
                     add.type = e.type;
                     ret = Expression_optimize(add, result, keepLvalue);
                     return;


### PR DESCRIPTION
#14094 broke downstream compilers by introducing the lowering:
```
auto test(const(ubyte[32])[] a)
{
    return cast(const(ubyte)*)&a[1][0];
}
```
Into
```
return &a[1] + null;
```

This corrects the bad codegen to instead generate in the original example:
```
return &a[1] + 0;
```