### PR TITLE
fix Issue 23568: Set the result type of vector comparisons to an integer vector type

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11803,8 +11803,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (t1.isTypeVector())
-            exp.type = t1;
+        if (auto tv = t1.isTypeVector())
+            exp.type = tv.toBooleanVector();
 
         result = exp;
         return;
@@ -12085,8 +12085,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (t1.isTypeVector())
-            exp.type = t1;
+        if (auto tv = t1.isTypeVector())
+            exp.type = tv.toBooleanVector();
 
         result = exp;
     }

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -7384,3 +7384,51 @@ private extern(D) MATCH matchTypeSafeVarArgs(TypeFunction tf, Parameter p,
         return MATCH.nomatch;
     }
 }
+
+/**
+ * Creates an appropriate vector type for `tv` that will hold one boolean
+ * result for each element of the vector type. The result of vector comparisons
+ * is a single or doubleword mask of all 1s (comparison true) or all 0s
+ * (comparison false). This SIMD mask type does not have an equivalent D type,
+ * however its closest equivalent would be an integer vector of the same unit
+ * size and length.
+ *
+ * Params:
+ *   tv = The `TypeVector` to build a vector from.
+ * Returns:
+ *   A vector type suitable for the result of a vector comparison operation.
+ */
+TypeVector toBooleanVector(TypeVector tv)
+{
+    Type telem = tv.elementType();
+    switch (telem.ty)
+    {
+        case Tvoid:
+        case Tint8:
+        case Tuns8:
+        case Tint16:
+        case Tuns16:
+        case Tint32:
+        case Tuns32:
+        case Tint64:
+        case Tuns64:
+            // No need to build an equivalent mask type.
+            return tv;
+
+        case Tfloat32:
+            telem = Type.tuns32;
+            break;
+
+        case Tfloat64:
+            telem = Type.tuns64;
+            break;
+
+        default:
+            assert(0);
+    }
+
+    TypeSArray tsa = tv.basetype.isTypeSArray();
+    assert(tsa !is null);
+
+    return new TypeVector(new TypeSArray(telem, tsa.dim));
+}

--- a/compiler/test/runnable/testxmm2.d
+++ b/compiler/test/runnable/testxmm2.d
@@ -247,10 +247,10 @@ void testunscmp()
 
 /*****************************************/
 
-float4 testlt(float4 x, float4 y) { return x < y; }
-float4 testgt(float4 x, float4 y) { return x > y; }
-float4 testge(float4 x, float4 y) { return x >= y; }
-float4 testle(float4 x, float4 y) { return x <= y; }
+uint4 testlt(float4 x, float4 y) { return x < y; }
+uint4 testgt(float4 x, float4 y) { return x > y; }
+uint4 testge(float4 x, float4 y) { return x >= y; }
+uint4 testle(float4 x, float4 y) { return x <= y; }
 
 void testflt()
 {
@@ -264,10 +264,10 @@ void testflt()
     assert((cast(int4)x).array == [-1,-1,0,0]);
 }
 
-double2 testlt(double2 x, double2 y) { return x < y; }
-double2 testgt(double2 x, double2 y) { return x > y; }
-double2 testge(double2 x, double2 y) { return x >= y; }
-double2 testle(double2 x, double2 y) { return x <= y; }
+ulong2 testlt(double2 x, double2 y) { return x < y; }
+ulong2 testgt(double2 x, double2 y) { return x > y; }
+ulong2 testge(double2 x, double2 y) { return x >= y; }
+ulong2 testle(double2 x, double2 y) { return x <= y; }
 
 void testdbl()
 {


### PR DESCRIPTION
The result of vector comparisons is a single or doubleword mask of all 1s (comparison true) or all 0s (comparison false). This SIMD mask type does not have an equivalent D type, however its closest equivalent would be an integer vector of the same unit size and length.

Rationale: Currently the result of vector float comparison and equality operations is either NaNs or 0s, which requires an explicit cast to a vector int in order to use it for checking the result post operation.

For example, GDC's ternary (`? :`) vector intrinsic `blendvector` can work with the following:
```
blendvector(a, b, a < b);
```
However if the condition is a vector float type...
```
blendvector(f, g, cast(__vector[uint[4])(f < g));
```
This removes the need for such boilerplate.