### PR TITLE
fix Issue 23567 - pragma(printf) messes up with the vtable of extern(C++) classes

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1584,6 +1584,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (pd.ident == Id.printf || pd.ident == Id.scanf)
                 {
                     s.setPragmaPrintf(pd.ident == Id.printf);
+                    s.dsymbolSemantic(sc2);
                     continue;
                 }
 

--- a/compiler/test/compilable/issue23567.d
+++ b/compiler/test/compilable/issue23567.d
@@ -1,0 +1,9 @@
+// https://issues.dlang.org/show_bug.cgi?id=23567
+extern(C++) abstract class CCvar
+{
+public:
+    pragma(printf) void func1(const(char)* pFormat, ...);
+    pragma(printf) void func2(const(char)* pFormat, ...);
+}
+
+static assert(__traits(getVirtualIndex, CCvar.func2) == 1);


### PR DESCRIPTION
 #14503 only set the function flags for all symbols underneath the pragma(printf) attribute, and removed the running of semantic, causing the vtblIndex field to not be updated in time for when static conditions are evaluated.