### PR TITLE
fix Issue 23569 - [REG 2.081][ICE] Segmentation fault in in AggregateDeclaration::getType() (this=0x0) at src/dmd/aggregate.d:594

### DIFF
--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -931,6 +931,12 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                     /* Rewrite as:
                      *      .object.opEquals(e1, e2)
                      */
+                    if (!ClassDeclaration.object)
+                    {
+                        e.error("cannot compare classes for equality because `object.Object` was not declared");
+                        return null;
+                    }
+
                     Expression e1x = e.e1;
                     Expression e2x = e.e2;
 

--- a/compiler/test/fail_compilation/ice23569.d
+++ b/compiler/test/fail_compilation/ice23569.d
@@ -1,0 +1,19 @@
+// https://issues.dlang.org/show_bug.cgi?id=23569
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice23569.d(18): Error: cannot compare classes for equality because `object.Object` was not declared
+---
+*/
+module object;
+
+@safe unittest1()
+{
+    class F
+    {
+        this(int )
+        {
+        }
+    }
+    auto ice23569 = new F(0) == new F(0);
+}


### PR DESCRIPTION
This is a minimal/corrupt object.d bug.  Issue a generic error that `class Object` has no definition, and so cannot be used to generate a call to `opEquals()`.

There is no strong reason for this error, and maybe in future we could remove it error for the benefit of `-betterC` code.