### PR TITLE
fix Issue 23391 - [Reg 2.098.1] Segmentation fault with static foreach + range + inout

### DIFF
--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -1249,7 +1249,14 @@ UnionExp Slice(Type type, Expression e1, Expression lwr, Expression upr)
         }
     }
 
-    if (e1.op == EXP.string_ && lwr.op == EXP.int64 && upr.op == EXP.int64)
+    if (!lwr)
+    {
+        if (e1.op == EXP.string_)
+            emplaceExp(&ue, e1);
+        else
+            cantExp(ue);
+    }
+    else if (e1.op == EXP.string_ && lwr.op == EXP.int64 && upr.op == EXP.int64)
     {
         StringExp es1 = e1.isStringExp();
         const uinteger_t ilwr = lwr.toInteger();

--- a/compiler/test/compilable/issue23391.d
+++ b/compiler/test/compilable/issue23391.d
@@ -1,0 +1,31 @@
+struct MyTuple {
+    string s;
+}
+
+inout(string) myfront(inout(string)[] a)
+{
+    return a[0];
+}
+
+MyTuple[] myarray(MyZip r)
+{
+    MyTuple[] result;
+    foreach (e; r)
+        result ~= e;
+    return result;
+}
+
+struct MyZip
+{
+    bool empty = false;
+    MyTuple front()
+    {
+        return MyTuple([""].myfront);
+    }
+    void popFront()
+    {
+        empty = true;
+    }
+}
+
+static foreach(t; MyZip().myarray) {}


### PR DESCRIPTION
#4719 sets both `lwr` and `upr` pointers to `null`. A null `lwr` pointer is handled in the code generator, but not during CTFE, correct that so both code paths are similar.