### PR TITLE
add location for storage class declaration

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -1282,6 +1282,13 @@ struct ASTBase
             this.stc = stc;
         }
 
+        final extern (D) this(const ref Loc loc, StorageClass stc, Dsymbols* decl)
+        {
+            super(decl);
+            this.loc = loc;
+            this.stc = stc;
+        }
+
         override void accept(Visitor v)
         {
             v.visit(this);

--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -62,6 +62,12 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         this.decl = decl;
     }
 
+    extern (D) this(const ref Loc loc, Dsymbols* decl)
+    {
+        super(loc, null);
+        this.decl = decl;
+    }
+
     extern (D) this(const ref Loc loc, Identifier ident, Dsymbols* decl)
     {
         super(loc, ident);
@@ -225,6 +231,12 @@ extern (C++) class StorageClassDeclaration : AttribDeclaration
     extern (D) this(StorageClass stc, Dsymbols* decl)
     {
         super(decl);
+        this.stc = stc;
+    }
+
+    extern (D) this(const ref Loc loc, StorageClass stc, Dsymbols* decl)
+    {
+        super(loc, decl);
         this.stc = stc;
     }
 

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -335,6 +335,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             linkage = linksave;
 
             Loc startloc;
+            Loc scdLoc;
 
             switch (token.value)
             {
@@ -696,6 +697,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 }
             Lstc:
                 pAttrs.storageClass = appendStorageClass(pAttrs.storageClass, stc);
+                scdLoc = token.loc;
                 nextToken();
 
             Lautodecl:
@@ -748,7 +750,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 auto stc2 = getStorageClass!AST(pAttrs);
                 if (stc2 != STC.undefined_)
                 {
-                    s = new AST.StorageClassDeclaration(stc2, a);
+                    s = new AST.StorageClassDeclaration(scdLoc, stc2, a);
                 }
                 if (pAttrs.udas)
                 {


### PR DESCRIPTION
Currently there is no possibility of setting the location for a `StorageClassDeclaration`. This pr creates a way for `StorageClassDeclarations` to be instantiated with a location