### PR TITLE
fix Issue 22854 - [REG  2.099-rc.1] static foreach byCodepoint segfault

### DIFF
--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -218,12 +218,12 @@ extern (C++) final class StaticForeach : RootObject
     {
         if (aggrfe)
         {
-            return new ForeachStatement(loc, aggrfe.op, parameters, aggrfe.aggr.syntaxCopy(), s, loc);
+            return new ForeachStatement(loc, aggrfe.op, parameters, aggrfe.aggr, s, loc);
         }
         else
         {
             assert(rangefe && parameters.dim == 1);
-            return new ForeachRangeStatement(loc, rangefe.op, (*parameters)[0], rangefe.lwr.syntaxCopy(), rangefe.upr.syntaxCopy(), s, loc);
+            return new ForeachRangeStatement(loc, rangefe.op, (*parameters)[0], rangefe.lwr, rangefe.upr, s, loc);
         }
     }
 

--- a/compiler/test/compilable/issue22854.d
+++ b/compiler/test/compilable/issue22854.d
@@ -1,0 +1,20 @@
+// https://issues.dlang.org/show_bug.cgi?id=22854
+void test22854()
+{
+    static foreach (ch; SomeContainer().range) { }
+}
+
+struct SomeContainer
+{
+    SomeRange range() { return SomeRange(); }
+    TypeWithDestructor data;
+}
+
+struct TypeWithDestructor { ~this() { } }
+
+struct SomeRange
+{
+    int front() { return 0; }
+    bool empty() { return true; }
+    void popFront() { }
+}

--- a/compiler/test/runnable/issue22854.d
+++ b/compiler/test/runnable/issue22854.d
@@ -1,0 +1,27 @@
+// https://issues.dlang.org/show_bug.cgi?id=22854
+void main()
+{
+    uint loops = 0;
+    static foreach (i; 0 .. 50)
+    {
+        static foreach (ch; SomeContainer().range)
+            loops++;
+    }
+    assert(loops == 50 * 50);
+}
+
+struct SomeContainer
+{
+    SomeRange range() { return SomeRange(); }
+    TypeWithDestructor data;
+}
+
+struct TypeWithDestructor { ~this() { } }
+
+struct SomeRange
+{
+    int count = 50;
+    int front() { return count; }
+    bool empty() { return count <= 0; }
+    void popFront() { count--; }
+}


### PR DESCRIPTION
The `aggr` expression gets lowered to a comma exp by semantic, to handle the temporary needed for constructing `TypeWithDestructor()`.

However, `static foreach`'s needless use of `syntaxCopy()` creates a _new_ var declaration that has no referencing declaration expression to construct it.

This would throw off gdc and ldc backends that have strict tree checking if it ever reached codegen, but rather CTFE trips on this condition instead:
```
// If the comma returns a temporary variable, it needs to be an lvalue
// (this is particularly important for struct constructors)
if (e.e1.op == EXP.declaration &&
    e.e2.op == EXP.variable &&
    e.e1.isDeclarationExp().declaration == e.e2.isVarExp().var &&  // <-- this is false
    e.e2.isVarExp().var.storage_class & STC.ctfe)
```
This prevents the temporary from being pushed to the CTFE variable stack, which in turn triggers the assert.

I can't see a reason why `static foreach` would use `syntaxCopy` in `createForeach`. Removing it fixes the corrupt AST, saving a little more memory in the process.