### PR TITLE
fix Issue 20811 - Regression as of 2.066.0 - CTFE static variable retained across calls

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -1849,10 +1849,27 @@ public:
         {
             printf("%s StringExp::interpret() %s\n", e.loc.toChars(), e.toChars());
         }
-        /* Attempts to modify string literals are prevented
-         * in BinExp::interpretAssignCommon.
-         */
-        result = e;
+        if (e.ownedByCtfe >= OwnedBy.ctfe) // We've already interpreted the string
+        {
+            result = e;
+            return;
+        }
+
+        if (e.type.ty != Tsarray ||
+            (cast(TypeNext)e.type).next.mod & (MODFlags.const_ | MODFlags.immutable_))
+        {
+            // If it's immutable, we don't need to dup it. Attempts to modify
+            // string literals are prevented in BinExp::interpretAssignCommon.
+            result = e;
+        }
+        else
+        {
+            // https://issues.dlang.org/show_bug.cgi?id=20811
+            // Create a copy of mutable string literals, so that any change in
+            // value via an index or slice will not survive CTFE.
+            *pue = copyLiteral(e);
+            result = pue.exp();
+        }
     }
 
     override void visit(FuncExp e)

--- a/compiler/test/runnable/test20811.d
+++ b/compiler/test/runnable/test20811.d
@@ -1,0 +1,34 @@
+// https://issues.dlang.org/show_bug.cgi?id=20811
+
+// OK: Mutable array literals are copied before CTFE takes ownership.
+string issue20811a()
+{
+    char[1] counter = ['0'];
+    counter[$-1]++;
+    return counter.dup;
+}
+
+static assert(issue20811a() == "1");
+static assert(issue20811a() == "1");
+static assert(issue20811a() == "1");
+static assert(issue20811a() == "1");
+
+// Issue 20811: String literals were assumed to be read-only, so weren't copied.
+string issue20811b()
+{
+    char[1] counter = "0";
+    counter[$-1]++;
+    return counter.dup;
+}
+
+static assert(issue20811b() == "1");
+static assert(issue20811b() == "1");
+static assert(issue20811b() == "1");
+static assert(issue20811b() == "1");
+
+void main()
+{
+    // Ensure CTFE did not overwrite the original AST.
+    assert(issue20811a() == "1");
+    assert(issue20811b() == "1");
+}


### PR DESCRIPTION
There was the assumption that `StringExp`'s don't need to be copied as any attempts at modifying them result in a compile-time error, however a StringExp can be assigned to a mutable static array (`"abc"` just becomes sugar syntax for `['a','b','c']`). Later, it is then assumed that it _has_ in-fact been copied, as both `interpretAssignToSlice` and `assignToLvalue` use `setCodeUnit()` to write to the underlying string value directly.

This direct assignment to AST node during CTFE without copy survives long after CTFE has finished, so a wrong/corrupt value ends up being emitted during code generation.