### PR TITLE
A WAG at selective imports.

### DIFF
--- a/compiler/src/dmd/access.d
+++ b/compiler/src/dmd/access.d
@@ -16,16 +16,12 @@ module dmd.access;
 import dmd.aggregate;
 import dmd.astenums;
 import dmd.dclass;
-import dmd.declaration;
 import dmd.dmodule;
 import dmd.dscope;
 import dmd.dstruct;
 import dmd.dsymbol;
-import dmd.errors;
 import dmd.expression;
-import dmd.func;
 import dmd.globals;
-import dmd.mtype;
 import dmd.tokens;
 
 private enum LOG = false;


### PR DESCRIPTION
This is an attempt at finding the selective imports in
dmd/compiler.

There were issues with the "automatic" finding of
selective imports with the files below.  Several
of the errors result in recursive template errors, so
these files are not touched and is a short list for
digging deeper into issues caused by selective
imports in them.

./src/dmd/frontend.d
./src/dmd/toir.d
./src/dmd/func.d
./src/dmd/statement.d
./src/dmd/compiler.d
./src/dmd/aggregate.d
./src/dmd/mtype.d
./src/dmd/arraytypes.d
./src/dmd/dsymbol.d
./src/dmd/tocsym.d
./src/dmd/dtemplate.d
./src/dmd/root/stringtable.d
./src/dmd/root/array.d
./src/dmd/statementsem.d
./src/dmd/tokens.d
./src/dmd/scanmscoff.d
./src/dmd/backend/cgreg.d
./src/dmd/backend/cgxmm.d
./src/dmd/backend/gflow.d
./src/dmd/backend/dtype.d
./src/dmd/backend/elfobj.d
./src/dmd/backend/dwarfdbginf.d
./src/dmd/backend/gdag.d
./src/dmd/backend/gother.d
./src/dmd/backend/machobj.d
./src/dmd/arrayop.d
./src/dmd/declaration.d
./src/dmd/expression.d
./src/dmd/attrib.d
./src/dmd/entity.d