### PR TITLE
fix Issue 23574 - ICE: AssertError@src/dmd/optimize.d(866): Assertion failure

### DIFF
--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -862,7 +862,8 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
                 return returnE_e1();    // can always convert a class to Object
             // Need to determine correct offset before optimizing away the cast.
             // https://issues.dlang.org/show_bug.cgi?id=16980
-            cdfrom.size(e.loc);
+            if (cdfrom.size(e.loc) == SIZE_INVALID)
+                return error();
             assert(cdfrom.sizeok == Sizeok.done);
             assert(cdto.sizeok == Sizeok.done || !cdto.isBaseOf(cdfrom, null));
             int offset;

--- a/compiler/test/fail_compilation/fail23574.d
+++ b/compiler/test/fail_compilation/fail23574.d
@@ -1,0 +1,41 @@
+// https://issues.dlang.org/show_bug.cgi?id=23574
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23574.d(26): Error: function `object._xopEquals` has no `return` statement, but is expected to return a value of type `bool`
+Error: undefined identifier `size_t` in module `object`
+fail_compilation/fail23574.d(34): Error: template instance `object.S17915!(MyClass)` error instantiating
+fail_compilation/fail23574.d(30): Error: function `object.SDL_GetKeyName` has no `return` statement, but is expected to return a value of type `const(char)`
+---
+*/
+module object;
+
+class Object
+{
+}
+
+bool opEquals(LHS, RHS)(LHS lhs, RHS)
+{
+    opEquals(cast()lhs);
+}
+
+class TypeInfo
+{
+}
+
+bool _xopEquals()
+{
+}
+
+const(char)SDL_GetKeyName()
+{
+    class MyClass
+    {
+        S17915!MyClass m_member;
+    }
+}
+
+struct S17915(T)
+{
+    T owner;
+}


### PR DESCRIPTION
The ICE is triggered after a call to `cdfrom.size()` failed.  Usually an error would be printed, but in this case, that error was gagged.  Check the return type and propagate the error if we were to encounter this in optimize.d