### PR TITLE
extricate location.d into its own file

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1597,7 +1597,7 @@ auto sourceFiles()
             statement.h staticassert.h target.h template.h tokens.h version.h visitor.h
         "),
         lexer: fileArray(env["D"], "
-            console.d entity.d errors.d file_manager.d globals.d id.d identifier.d lexer.d tokens.d
+            console.d entity.d errors.d file_manager.d globals.d id.d identifier.d lexer.d location.d tokens.d
         ") ~ fileArray(env["ROOT"], "
             array.d bitarray.d ctfloat.d file.d filename.d hash.d port.d region.d rmem.d
             rootobject.d stringtable.d utf.d

--- a/compiler/src/dmd/README.md
+++ b/compiler/src/dmd/README.md
@@ -47,6 +47,7 @@ Note that these groups have no strict meaning, the category assignments are a bi
 | File                                                                  | Purpose                                                              |
 |-----------------------------------------------------------------------|----------------------------------------------------------------------|
 | [lexer.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/lexer.d)   | Convert source code into tokens for the D and ImportC parsers        |
+| [location.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/location.d)| Encapsulate file/line/column info for error messages, etc.        |
 | [entity.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/entity.d) | Define "\\&Entity;" escape sequence for strings / character literals |
 | [tokens.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/tokens.d) | Define lexical tokens.                                               |
 | [parse.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/parse.d)   | D parser, converting tokens into an Abstract Syntax Tree (AST)       |

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -17,6 +17,7 @@ import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.file_manager;
 import dmd.identifier;
+public import dmd.location;
 
 /// Defines a setting for how compiler warnings and deprecations are handled
 enum DiagnosticReporting : ubyte
@@ -445,126 +446,6 @@ alias dinteger_t = ulong;
 // Signed and unsigned variants
 alias sinteger_t = long;
 alias uinteger_t = ulong;
-
-version (DMDLIB)
-{
-    version = LocOffset;
-}
-
-/**
-A source code location
-
-Used for error messages, `__FILE__` and `__LINE__` tokens, `__traits(getLocation, XXX)`,
-debug info etc.
-*/
-struct Loc
-{
-    /// zero-terminated filename string, either absolute or relative to cwd
-    const(char)* filename;
-    uint linnum; /// line number, starting from 1
-    uint charnum; /// utf8 code unit index relative to start of line, starting from 1
-    version (LocOffset)
-        uint fileOffset; /// utf8 code unit index relative to start of file, starting from 0
-
-    static immutable Loc initial; /// use for default initialization of const ref Loc's
-
-nothrow:
-    extern (D) this(const(char)* filename, uint linnum, uint charnum) pure
-    {
-        this.linnum = linnum;
-        this.charnum = charnum;
-        this.filename = filename;
-    }
-
-    extern (C++) const(char)* toChars(
-        bool showColumns = global.params.showColumns,
-        ubyte messageStyle = global.params.messageStyle) const pure nothrow
-    {
-        OutBuffer buf;
-        if (filename)
-        {
-            buf.writestring(filename);
-        }
-        if (linnum)
-        {
-            final switch (messageStyle)
-            {
-                case MessageStyle.digitalmars:
-                    buf.writeByte('(');
-                    buf.print(linnum);
-                    if (showColumns && charnum)
-                    {
-                        buf.writeByte(',');
-                        buf.print(charnum);
-                    }
-                    buf.writeByte(')');
-                    break;
-                case MessageStyle.gnu: // https://www.gnu.org/prep/standards/html_node/Errors.html
-                    buf.writeByte(':');
-                    buf.print(linnum);
-                    if (showColumns && charnum)
-                    {
-                        buf.writeByte(':');
-                        buf.print(charnum);
-                    }
-                    break;
-            }
-        }
-        return buf.extractChars();
-    }
-
-    /**
-     * Checks for equivalence by comparing the filename contents (not the pointer) and character location.
-     *
-     * Note:
-     *  - Uses case-insensitive comparison on Windows
-     *  - Ignores `charnum` if `global.params.showColumns` is false.
-     */
-    extern (C++) bool equals(ref const(Loc) loc) const
-    {
-        return (!global.params.showColumns || charnum == loc.charnum) &&
-               linnum == loc.linnum &&
-               FileName.equals(filename, loc.filename);
-    }
-
-    /**
-     * `opEquals()` / `toHash()` for AA key usage
-     *
-     * Compare filename contents (case-sensitively on Windows too), not
-     * the pointer - a static foreach loop repeatedly mixing in a mixin
-     * may lead to multiple equivalent filenames (`foo.d-mixin-<line>`),
-     * e.g., for test/runnable/test18880.d.
-     */
-    extern (D) bool opEquals(ref const(Loc) loc) const @trusted pure nothrow @nogc
-    {
-        import core.stdc.string : strcmp;
-
-        return charnum == loc.charnum &&
-               linnum == loc.linnum &&
-               (filename == loc.filename ||
-                (filename && loc.filename && strcmp(filename, loc.filename) == 0));
-    }
-
-    /// ditto
-    extern (D) size_t toHash() const @trusted pure nothrow
-    {
-        import dmd.root.string : toDString;
-
-        auto hash = hashOf(linnum);
-        hash = hashOf(charnum, hash);
-        hash = hashOf(filename.toDString, hash);
-        return hash;
-    }
-
-    /******************
-     * Returns:
-     *   true if Loc has been set to other than the default initialization
-     */
-    bool isValid() const pure
-    {
-        return filename !is null;
-    }
-}
 
 /// Collection of global state
 extern (C++) __gshared Global global;

--- a/compiler/src/dmd/location.d
+++ b/compiler/src/dmd/location.d
@@ -1,0 +1,136 @@
+/**
+ * Encapsulates file/line/column locations.
+ *
+ * Copyright:   Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/location.d, _location.d)
+ * Documentation:  https://dlang.org/phobos/dmd_location.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/location.d
+ */
+
+module dmd.location;
+
+import dmd.common.outbuffer;
+import dmd.root.filename;
+import dmd.globals;
+
+version (DMDLIB)
+{
+    version = LocOffset;
+}
+
+/**
+A source code location
+
+Used for error messages, `__FILE__` and `__LINE__` tokens, `__traits(getLocation, XXX)`,
+debug info etc.
+*/
+struct Loc
+{
+    /// zero-terminated filename string, either absolute or relative to cwd
+    const(char)* filename;
+    uint linnum; /// line number, starting from 1
+    uint charnum; /// utf8 code unit index relative to start of line, starting from 1
+    version (LocOffset)
+        uint fileOffset; /// utf8 code unit index relative to start of file, starting from 0
+
+    static immutable Loc initial; /// use for default initialization of const ref Loc's
+
+nothrow:
+    extern (D) this(const(char)* filename, uint linnum, uint charnum) pure
+    {
+        this.linnum = linnum;
+        this.charnum = charnum;
+        this.filename = filename;
+    }
+
+    extern (C++) const(char)* toChars(
+        bool showColumns = global.params.showColumns,
+        ubyte messageStyle = global.params.messageStyle) const pure nothrow
+    {
+        OutBuffer buf;
+        if (filename)
+        {
+            buf.writestring(filename);
+        }
+        if (linnum)
+        {
+            final switch (messageStyle)
+            {
+                case MessageStyle.digitalmars:
+                    buf.writeByte('(');
+                    buf.print(linnum);
+                    if (showColumns && charnum)
+                    {
+                        buf.writeByte(',');
+                        buf.print(charnum);
+                    }
+                    buf.writeByte(')');
+                    break;
+                case MessageStyle.gnu: // https://www.gnu.org/prep/standards/html_node/Errors.html
+                    buf.writeByte(':');
+                    buf.print(linnum);
+                    if (showColumns && charnum)
+                    {
+                        buf.writeByte(':');
+                        buf.print(charnum);
+                    }
+                    break;
+            }
+        }
+        return buf.extractChars();
+    }
+
+    /**
+     * Checks for equivalence by comparing the filename contents (not the pointer) and character location.
+     *
+     * Note:
+     *  - Uses case-insensitive comparison on Windows
+     *  - Ignores `charnum` if `global.params.showColumns` is false.
+     */
+    extern (C++) bool equals(ref const(Loc) loc) const
+    {
+        return (!global.params.showColumns || charnum == loc.charnum) &&
+               linnum == loc.linnum &&
+               FileName.equals(filename, loc.filename);
+    }
+
+    /**
+     * `opEquals()` / `toHash()` for AA key usage
+     *
+     * Compare filename contents (case-sensitively on Windows too), not
+     * the pointer - a static foreach loop repeatedly mixing in a mixin
+     * may lead to multiple equivalent filenames (`foo.d-mixin-<line>`),
+     * e.g., for test/runnable/test18880.d.
+     */
+    extern (D) bool opEquals(ref const(Loc) loc) const @trusted pure nothrow @nogc
+    {
+        import core.stdc.string : strcmp;
+
+        return charnum == loc.charnum &&
+               linnum == loc.linnum &&
+               (filename == loc.filename ||
+                (filename && loc.filename && strcmp(filename, loc.filename) == 0));
+    }
+
+    /// ditto
+    extern (D) size_t toHash() const @trusted pure nothrow
+    {
+        import dmd.root.string : toDString;
+
+        auto hash = hashOf(linnum);
+        hash = hashOf(charnum, hash);
+        hash = hashOf(filename.toDString, hash);
+        return hash;
+    }
+
+    /******************
+     * Returns:
+     *   true if Loc has been set to other than the default initialization
+     */
+    bool isValid() const pure
+    {
+        return filename !is null;
+    }
+}

--- a/compiler/test/unit/frontend.d
+++ b/compiler/test/unit/frontend.d
@@ -28,8 +28,8 @@ unittest
         extern (C++) static final class InterfaceDeclaration : ClassDeclaration
         {
             import dmd.arraytypes : BaseClasses;
-            import dmd.globals : Loc;
             import dmd.identifier : Identifier;
+            import dmd.location;
 
             bool created = false;
 
@@ -109,8 +109,8 @@ unittest
     import dmd.frontend;
 
     import dmd.common.outbuffer;
-    import dmd.globals : Loc;
     import dmd.console : Color;
+    import dmd.location;
     import core.stdc.stdarg : va_list;
 
     string[] diagnosticMessages;
@@ -245,9 +245,9 @@ unittest
     import core.stdc.stdarg : va_list;
 
     import dmd.frontend;
-    import dmd.globals : Loc;
     import dmd.common.outbuffer;
     import dmd.console : Color;
+    import dmd.location;
 
     string[] diagnosticMessages;
 
@@ -361,9 +361,10 @@ unittest
     import core.stdc.stdarg : va_list;
 
     import dmd.frontend;
-    import dmd.globals : Loc, global;
+    import dmd.globals : global;
     import dmd.common.outbuffer;
     import dmd.console : Color;
+    import dmd.location;
 
     string[] diagnosticMessages;
 

--- a/compiler/test/unit/interfaces/check_implementations_20861.d
+++ b/compiler/test/unit/interfaces/check_implementations_20861.d
@@ -12,7 +12,7 @@
  */
 module interfaces.check_implementations_20861;
 
-import dmd.globals : Loc;
+import dmd.location;
 
 import support : afterEach, beforeEach, compiles, stripDelimited, Diagnostic;
 

--- a/compiler/test/unit/lexer/diagnostic_reporter.d
+++ b/compiler/test/unit/lexer/diagnostic_reporter.d
@@ -4,7 +4,8 @@ module lexer.diagnostic_reporter;
 
 import core.stdc.stdarg;
 
-import dmd.globals : Loc, global, DiagnosticReporting;
+import dmd.globals : global, DiagnosticReporting;
+import dmd.location;
 
 import support : afterEach, NoopDiagnosticReporter;
 

--- a/compiler/test/unit/lexer/lexer_dmdlib.d
+++ b/compiler/test/unit/lexer/lexer_dmdlib.d
@@ -262,7 +262,7 @@ unittest
     import core.stdc.stdarg : va_list;
 
     import dmd.frontend;
-    import dmd.globals : Loc;
+    import dmd.location;
     import dmd.common.outbuffer;
     import dmd.console : Color;
 

--- a/compiler/test/unit/objc/protocols/diagnostic_messages.d
+++ b/compiler/test/unit/objc/protocols/diagnostic_messages.d
@@ -5,7 +5,7 @@ module objc.protocols.diagnostic_messages;
 
 version (D_ObjectiveC):
 
-import dmd.globals : Loc;
+import dmd.location;
 
 import support : afterEach, beforeEach, compiles, stripDelimited, Diagnostic;
 

--- a/compiler/test/unit/objc/protocols/optional_methods.d
+++ b/compiler/test/unit/objc/protocols/optional_methods.d
@@ -5,7 +5,7 @@ module objc.protocols.optional_methods;
 
 version (D_ObjectiveC):
 
-import dmd.globals : Loc;
+import dmd.location;
 
 import support : afterEach, beforeEach, compiles, stripDelimited, Diagnostic;
 

--- a/compiler/test/unit/parser/aliasdeclaration_location.d
+++ b/compiler/test/unit/parser/aliasdeclaration_location.d
@@ -3,7 +3,7 @@ module parser.aliasdeclaration_location;
 import dmd.frontend : parseModule;
 import support : afterEach, beforeEach;
 import dmd.declaration : AliasDeclaration;
-import dmd.globals : Loc;
+import dmd.location;
 import dmd.visitor : SemanticTimeTransitiveVisitor;
 
 @beforeEach

--- a/compiler/test/unit/parser/conditionalcompilation_location.d
+++ b/compiler/test/unit/parser/conditionalcompilation_location.d
@@ -3,7 +3,7 @@ module parser.conditionalcompilation_location;
 import dmd.frontend : parseModule;
 import support : afterEach, beforeEach;
 import dmd.attrib : ConditionalDeclaration, StaticIfDeclaration, StaticForeachDeclaration;
-import dmd.globals : Loc;
+import dmd.location;
 import dmd.visitor : SemanticTimeTransitiveVisitor;
 
 @beforeEach

--- a/compiler/test/unit/parser/diagnostic_reporter.d
+++ b/compiler/test/unit/parser/diagnostic_reporter.d
@@ -5,7 +5,8 @@ module parser.diagnostic_reporter;
 import core.stdc.stdarg;
 
 import dmd.frontend : parseModule;
-import dmd.globals : Loc, global, DiagnosticReporting;
+import dmd.globals : global, DiagnosticReporting;
+import dmd.location;
 
 import support : afterEach, beforeEach, NoopDiagnosticReporter;
 

--- a/compiler/test/unit/parser/dvcondition_location.d
+++ b/compiler/test/unit/parser/dvcondition_location.d
@@ -3,7 +3,7 @@ module parser.dvcondition_location;
 import dmd.frontend : parseModule;
 import support : afterEach, beforeEach;
 import dmd.cond : VersionCondition, DebugCondition;
-import dmd.globals : Loc;
+import dmd.location;
 import dmd.visitor : SemanticTimeTransitiveVisitor;
 
 @beforeEach initializeFrontend()

--- a/compiler/test/unit/parser/linkage_location.d
+++ b/compiler/test/unit/parser/linkage_location.d
@@ -3,7 +3,7 @@ module parser.linkage_location;
 import dmd.frontend : parseModule;
 import support : afterEach, beforeEach;
 import dmd.attrib : CPPMangleDeclaration, CPPNamespaceDeclaration, LinkDeclaration;
-import dmd.globals : Loc;
+import dmd.location;
 import dmd.visitor : SemanticTimeTransitiveVisitor;
 
 @beforeEach initializeFrontend()

--- a/compiler/test/unit/parser/visibilitydeclaration_location.d
+++ b/compiler/test/unit/parser/visibilitydeclaration_location.d
@@ -3,7 +3,7 @@ module parser.visibilitydeclaration_location;
 import dmd.frontend : parseModule;
 import support : afterEach, beforeEach;
 import dmd.attrib : VisibilityDeclaration;
-import dmd.globals : Loc;
+import dmd.location;
 import dmd.visitor : SemanticTimeTransitiveVisitor;
 
 @beforeEach

--- a/compiler/test/unit/support.d
+++ b/compiler/test/unit/support.d
@@ -6,7 +6,7 @@ import core.stdc.stdarg : va_list;
 
 import dmd.console : Color;
 import dmd.frontend : DiagnosticReporter;
-import dmd.globals : Loc;
+import dmd.location;
 
 /// UDA used to indicate a function should be run before each test.
 enum beforeEach;
@@ -110,7 +110,7 @@ CompilationResult compiles(string code, string filename = "test.d")
 class NoopDiagnosticReporter : DiagnosticReporter
 {
     import core.stdc.stdarg : va_list;
-    import dmd.globals : Loc;
+    import dmd.location;
 
     override int errorCount() { return 0; }
     override int warningCount() { return 0; }

--- a/dub.sdl
+++ b/dub.sdl
@@ -29,6 +29,7 @@ subPackage {
     "compiler/src/dmd/id.d" \
     "compiler/src/dmd/identifier.d" \
     "compiler/src/dmd/lexer.d" \
+    "compiler/src/dmd/location.d" \
     "compiler/src/dmd/tokens.d" \
     "compiler/src/dmd/utils.d"
 


### PR DESCRIPTION
Pulling out `struct Loc`. This will help in disentangling modules that need Loc but nothing else from globals.d.

Cut&paste job for easy review and first stab at this.