### PR TITLE
partial Issue 16098 - align(N) not respected for stack variables if N…

### DIFF
--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -703,14 +703,17 @@ TYPE* getParentClosureType(Symbol* sthis, FuncDeclaration fd)
  * Also turns off nrvo for closure variables.
  * Params:
  *      fd = function
+ * Returns:
+ *      overall alignment of the closure
  */
-void setClosureVarOffset(FuncDeclaration fd)
+uint setClosureVarOffset(FuncDeclaration fd)
 {
     // Nothing to do
     if (!fd.needsClosure())
-        return;
+        return 0;
 
     uint offset = target.ptrsize;      // leave room for previous sthis
+    uint aggAlignment = offset;        // overall alignment for the closure
 
     foreach (v; fd.closureVars)
     {
@@ -748,11 +751,16 @@ void setClosureVarOffset(FuncDeclaration fd)
 
         offset += memsize;
 
+        uint actualAlignment = xalign.isDefault() ? memalignsize : xalign.get();
+        if (aggAlignment < actualAlignment)
+            aggAlignment = actualAlignment;     // take the largest
+
         /* Can't do nrvo if the variable is put in a closure, since
          * what the shidden points to may no longer exist.
          */
         assert(!fd.isNRVO() || fd.nrvo_var != v);
     }
+    return aggAlignment;
 }
 
 /*************************************
@@ -790,7 +798,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
             fd.checkClosure();   // give decent diagnostic
         }
 
-        setClosureVarOffset(fd);
+        auto aggAlignment = setClosureVarOffset(fd);
 
         // Generate closure on the heap
         // BUG: doesn't capture variadic arguments passed to this function
@@ -872,7 +880,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
         else
             lastsize = vlast.type.size();
         bool overflow;
-        const structsize = addu(vlast.offset, lastsize, overflow);
+        auto structsize = addu(vlast.offset, lastsize, overflow);
         assert(!overflow && structsize <= uint.max);
         //printf("structsize = %d\n", cast(uint)structsize);
 
@@ -882,10 +890,22 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
         if (driverParams.symdebug)
             toDebugClosure(Closstru.Ttag);
 
+        // Add extra size so we can align it
+        if (aggAlignment > 16)  // gc aligns on 16 bytes
+            structsize += aggAlignment - 16;
+
         // Allocate memory for the closure
         elem *e = el_long(TYsize_t, structsize);
         e = el_bin(OPcall, TYnptr, el_var(getRtlsym(RTLSYM.ALLOCMEMORY)), e);
         toTraceGC(irs, e, fd.loc);
+
+        // Align it
+        if (aggAlignment > 16)
+        {
+            // e + (aggAlignment - 1) & ~(aggAlignment - 1)
+            e = el_bin(OPadd, TYsize_t, e, el_long(TYsize_t, aggAlignment - 1));
+            e = el_bin(OPand, TYsize_t, e, el_long(TYsize_t, ~(aggAlignment - 1L)));
+        }
 
         // Assign block of memory to sclosure
         //    sclosure = allocmemory(sz);

--- a/compiler/test/runnable/test16098.d
+++ b/compiler/test/runnable/test16098.d
@@ -1,0 +1,14 @@
+
+// https://issues.dlang.org/show_bug.cgi?id=16098
+
+void main() {
+    byte a;
+    align(128) byte b;
+    assert((cast(size_t) &b) % 128 == 0);
+
+    byte foo() { return b; }
+    dg = &foo;
+    assert(dg() == false);
+}
+
+__gshared byte delegate() dg;


### PR DESCRIPTION
… > platform stack alignment

This is a partial fix for https://issues.dlang.org/show_bug.cgi?id=16098 in that it only fixes it for variables that go into a dynamic closure. It works by aligning the closure to the max of its members.

It's a preview of how I intend to fix the case of the variables not placed in closures, by placing them in a special aligned section allocated on the stack.

Splitting it into two PRs makes for easier review.