### PR TITLE
gitignore: Only match dmd in top-level directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ dmd.iml
 untracked_files/
 
 # Just in case
-dmd
+/dmd


### PR DESCRIPTION
`dmd` on its own also matches the directory `/compiler/src/dmd`, so you get git ignore warnings for all sources within.