### PR TITLE
dmd.dmodule: Use ThreeState for Module.selfimports and rootimports fields

### DIFF
--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -41,13 +41,6 @@ enum class Baseok : uint8_t
     semanticdone  // all base classes semantic done
 };
 
-enum class ThreeState : uint8_t
-{
-    none,         // value not yet computed
-    no,           // value is false
-    yes,          // value is true
-};
-
 FuncDeclaration *search_toString(StructDeclaration *sd);
 
 enum class ClassKind : uint8_t

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -359,7 +359,8 @@ extern (C++) final class Module : Package
     Package pkg;                // if isPackageFile is true, the Package that contains this package.d
     Strings contentImportedFiles; // array of files whose content was imported
     int needmoduleinfo;
-    int selfimports;            // 0: don't know, 1: does not, 2: does
+    private ThreeState selfimports;
+    private ThreeState rootimports;
     Dsymbol[void*] tagSymTab;   /// ImportC: tag symbols that conflict with other symbols used as the index
 
     private OutBuffer defines;  // collect all the #define lines here
@@ -371,18 +372,16 @@ extern (C++) final class Module : Package
     bool selfImports()
     {
         //printf("Module::selfImports() %s\n", toChars());
-        if (selfimports == 0)
+        if (selfimports == ThreeState.none)
         {
             foreach (Module m; amodules)
                 m.insearch = 0;
-            selfimports = imports(this) + 1;
+            selfimports = imports(this) ? ThreeState.yes : ThreeState.no;
             foreach (Module m; amodules)
                 m.insearch = 0;
         }
-        return selfimports == 2;
+        return selfimports == ThreeState.yes;
     }
-
-    int rootimports;            // 0: don't know, 1: does not, 2: does
 
     /*************************************
      * Return true if module imports root module.
@@ -390,23 +389,23 @@ extern (C++) final class Module : Package
     bool rootImports()
     {
         //printf("Module::rootImports() %s\n", toChars());
-        if (rootimports == 0)
+        if (rootimports == ThreeState.none)
         {
             foreach (Module m; amodules)
                 m.insearch = 0;
-            rootimports = 1;
+            rootimports = ThreeState.no;
             foreach (Module m; amodules)
             {
                 if (m.isRoot() && imports(m))
                 {
-                    rootimports = 2;
+                    rootimports = ThreeState.yes;
                     break;
                 }
             }
             foreach (Module m; amodules)
                 m.insearch = 0;
         }
-        return rootimports == 2;
+        return rootimports == ThreeState.yes;
     }
 
     int insearch;

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -87,6 +87,13 @@ struct Ungag
     ~Ungag() { global.gag = oldgag; }
 };
 
+enum class ThreeState : uint8_t
+{
+    none,         // value not yet computed
+    no,           // value is false
+    yes,          // value is true
+};
+
 void dsymbolSemantic(Dsymbol *dsym, Scope *sc);
 void semantic2(Dsymbol *dsym, Scope *sc);
 void semantic3(Dsymbol *dsym, Scope* sc);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6258,13 +6258,15 @@ public:
     Package* pkg;
     Array<const char* > contentImportedFiles;
     int32_t needmoduleinfo;
-    int32_t selfimports;
+private:
+    ThreeState selfimports;
+    ThreeState rootimports;
+public:
     void* tagSymTab;
 private:
     OutBuffer defines;
 public:
     bool selfImports();
-    int32_t rootimports;
     bool rootImports();
     int32_t insearch;
     Identifier* searchCacheIdent;

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -79,12 +79,12 @@ public:
     Package *pkg;       // if isPackageFile is true, the Package that contains this package.d
     Strings contentImportedFiles;  // array of files whose content was imported
     int needmoduleinfo;
-    int selfimports;            // 0: don't know, 1: does not, 2: does
+    ThreeState selfimports;
+    ThreeState rootimports;
     void* tagSymTab;            // ImportC: tag symbols that conflict with other symbols used as the index
     OutBuffer defines;          // collect all the #define lines here
     bool selfImports();         // returns true if module imports itself
 
-    int rootimports;            // 0: don't know, 1: does not, 2: does
     bool rootImports();         // returns true if module imports root module
 
     int insearch;


### PR DESCRIPTION
Their values are only ever 0, 1, or 2.

Moved the C++ definition of ThreeState to a common included header between aggregate and module.

(I notice that quite a bit of Module can be made private, and it's a not very well packed class either).