### PR TITLE
fix Issue 18646 - [REG 2.079.0] Recursive template expansion incorrectly reported

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6460,7 +6460,6 @@ public:
     bool isTrivialAlias;
     bool deprecated_;
     Visibility visibility;
-    int32_t inuse;
     TemplatePrevious* previous;
 private:
     Expression* lastConstraint;

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -70,7 +70,6 @@ public:
     bool isTrivialAlias;        // matches pattern `template Alias(T) { alias Alias = qualifiers(T); }`
     bool deprecated_;           // this template declaration is deprecated
     Visibility visibility;
-    int inuse;                  // for recursive expansion detection
 
     TemplatePrevious *previous;         // threaded list of previous instantiation attempts on stack
 

--- a/compiler/test/compilable/test18646.d
+++ b/compiler/test/compilable/test18646.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=18646
+class SuperClass {}
+
+class TemplatedClass(T : SuperClass) {}
+
+class A18646 : SuperClass {
+    alias T = TemplatedClass!B18646;
+}
+
+class B18646 : SuperClass {
+    alias T = TemplatedClass!C18646;
+}
+
+class C18646 : SuperClass {}

--- a/compiler/test/compilable/test19585.d
+++ b/compiler/test/compilable/test19585.d
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=19585
+struct S19585
+{
+    M2 stdin;
+}
+
+mixin template Handle(T, T invalid_value = T.init) {}
+
+struct M1 { mixin Handle!(size_t); }
+struct M2 { mixin Handle!(M1); }

--- a/compiler/test/compilable/test22813.d
+++ b/compiler/test/compilable/test22813.d
@@ -1,0 +1,9 @@
+// https://issues.dlang.org/show_bug.cgi?id=22813
+struct Template(int i) { }
+uint test22813()
+{
+    Template!(1) x;
+    return 0;
+}
+immutable constant = test22813();
+alias X = Template!constant;


### PR DESCRIPTION
The original fix for issue 14907 was a bit too broad a net, and caught many things that it thought were recursive, but in fact were not.

Detection and error have now been localized to the `TemplateValueParameter.defaultValue` member function, and added regression tests that were broken by #7702.