### PR TITLE
Fix Issue 23585 - Add bp relative symbols (frame-relative, see ntreh.…

### DIFF
--- a/compiler/src/dmd/backend/inliner.d
+++ b/compiler/src/dmd/backend/inliner.d
@@ -378,6 +378,7 @@ private elem* inlineCall(elem *e,Symbol *sfunc)
             case SC.register:
             case SC.auto_:
             case SC.pseudo:
+            case SC.bprel:
             L1:
             {
                 //printf("  new symbol %s\n", s.Sident.ptr);

--- a/compiler/test/compilable/extra-files/inliner23585b.d
+++ b/compiler/test/compilable/extra-files/inliner23585b.d
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=23585
+
+void f()
+{
+    import std.file : exists;
+    exists("");
+}

--- a/compiler/test/compilable/inliner23585a.d
+++ b/compiler/test/compilable/inliner23585a.d
@@ -1,0 +1,10 @@
+// COMPILED_IMPORTS: extra-files/inliner23585b.d
+// REQUIRED_ARGS: -os=windows -m32 -inline -O
+
+// https://issues.dlang.org/show_bug.cgi?id=23585
+
+void f()
+{
+    import std.file : exists;
+    exists("");
+}


### PR DESCRIPTION
…d for apparently the only use) to local symbols during inlining.