### PR TITLE
fix Issue 23586 - DMD forgets a variable was just declared

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -5720,6 +5720,8 @@ LagainStc:
                         s = null;
                     else if (token.value == TOK.leftCurly)
                         s = parseStatement(ParseStatementFlags.curly | ParseStatementFlags.scope_);
+                    else if (flags & ParseStatementFlags.curlyScope)
+                        s = parseStatement(ParseStatementFlags.semiOk | ParseStatementFlags.curlyScope);
                     else
                         s = parseStatement(ParseStatementFlags.semiOk);
                     s = new AST.LabelStatement(loc, ident, s);

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -323,6 +323,10 @@ extern (C++) abstract class Statement : ASTNode
             override void visit(DefaultStatement s)
             {
             }
+
+            override void visit(LabelStatement s)
+            {
+            }
         }
 
         scope HasCode hc = new HasCode();

--- a/compiler/test/compilable/test23586.d
+++ b/compiler/test/compilable/test23586.d
@@ -1,0 +1,34 @@
+// https://issues.dlang.org/show_bug.cgi?id=23586
+
+int test23686a(int x)
+{
+    switch(x)
+    {
+        case 0:
+            goto Bar;
+
+        Bar:
+        default:
+            auto y = 6;
+            return y;
+    }
+}
+
+int test23686b(int x)
+{
+    switch(x)
+    {
+        case 0:
+        Bar:
+        case 1:
+        case 2:
+            auto y = 7;
+            return y;
+
+        default:
+            goto Bar;
+    }
+}
+
+static assert(test23686a(0) == 6);
+static assert(test23686b(3) == 7);


### PR DESCRIPTION
The grammar/relationship of labelled statements to case statements are:
```
LabeledStatement:
    Identifier :
    Identifier : Statement

Statement:
    EmptyStatement
    NonEmptyStatement
    ScopeBlockStatement

NonEmptyStatement:
    NonEmptyStatementNoCaseNoDefault
    CaseStatement
    CaseRangeStatement
    DefaultStatement

CaseStatement:
    case ArgumentList : ScopeStatementList(opt)

ScopeStatementList:
    StatementListNoCaseNoDefault

StatementListNoCaseNoDefault:
    StatementNoCaseNoDefault
    StatementNoCaseNoDefault StatementListNoCaseNoDefault

StatementNoCaseNoDefault:
    EmptyStatement
    NonEmptyStatementNoCaseNoDefault
    ScopeBlockStatement
```

So the code:
```
Bar:
case 0:
    auto y = 7;
    return y;
```
Should result in a tree that looks like (as per the grammar rules):
```
LabeledStatement (
    Identifier(Bar) : Statement (
        CaseStatement (
            ArgumentList(0) : ScopeStatementList(
                DeclarationStatement(auto y = 7),
                ReturnStatement(y),
            )
        )
    )
)
```

However, instead it's currently being parsed as:
```
LabeledStatement (
    Identifier(Bar) : Statement (
        CaseStatement (
            ArgumentList(0) : ScopeStatementList(
                DeclarationStatement(auto y = 7)
            )
        )
    )
)
ReturnStatement(y)
```
Because both `case` and `default` case statements check whether `ParseStatementFlags.curlyScope` is in effect to determine whether to only parse one statement, or a list of statements.  This flag is removed when a labelled statement is being parsed - forward the flag on so that it will be correctly picked up.