### PR TITLE
fix Issue 23001 - [REG 2.063] missing unreachable code warning with switch inside switch

### DIFF
--- a/compiler/src/dmd/sapply.d
+++ b/compiler/src/dmd/sapply.d
@@ -21,10 +21,18 @@ bool walkPostorder(Statement s, StoppableVisitor v)
     return v.stop;
 }
 
+bool walkPreorder(Statement s, StoppableVisitor v)
+{
+    scope PreorderStatementVisitor pv = new PreorderStatementVisitor(v);
+    s.accept(pv);
+    return v.stop;
+}
+
 /**************************************
  * A Statement tree walker that will visit each Statement s in the tree,
- * in depth-first evaluation order, and call fp(s,param) on it.
- * fp() signals whether the walking continues with its return value:
+ * in depth-first evaluation order using post-order traversal, and call
+ * fp(s,param) on it. fp() signals whether the walking continues with its
+ * return value:
  * Returns:
  *      0       continue
  *      1       done
@@ -175,5 +183,166 @@ public:
     override void visit(LabelStatement s)
     {
         doCond(s.statement) || applyTo(s);
+    }
+}
+
+/**************************************
+ * A Statement tree walker that will visit each Statement s in the tree,
+ * in depth-first evaluation order using pre-order traversal, and call
+ * fp(s,param) on it. fp() signals whether the walking continues with its
+ * return value:
+ * Returns:
+ *      0       continue
+ *      1       done
+ * It's a bit slower than using virtual functions, but more encapsulated and less brittle.
+ * Creating an iterator for this would be much more complex.
+ */
+private extern (C++) final class PreorderStatementVisitor : StoppableVisitor
+{
+    alias visit = typeof(super).visit;
+public:
+    StoppableVisitor v;
+
+    extern (D) this(StoppableVisitor v)
+    {
+        this.v = v;
+    }
+
+    bool doCond(Statement s)
+    {
+        if (!stop && s)
+            s.accept(this);
+        return stop;
+    }
+
+    bool applyTo(Statement s)
+    {
+        s.accept(v);
+        stop = v.stop;
+        return stop;
+    }
+
+    override void visit(Statement s)
+    {
+        applyTo(s);
+    }
+
+    override void visit(PeelStatement s)
+    {
+        applyTo(s) || doCond(s.s);
+    }
+
+    override void visit(CompoundStatement s)
+    {
+        if (applyTo(s))
+            return;
+        for (size_t i = 0; i < s.statements.length; i++)
+            if (doCond((*s.statements)[i]))
+                return;
+    }
+
+    override void visit(UnrolledLoopStatement s)
+    {
+        if (applyTo(s))
+            return;
+        for (size_t i = 0; i < s.statements.length; i++)
+            if (doCond((*s.statements)[i]))
+                return;
+    }
+
+    override void visit(ScopeStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
+    }
+
+    override void visit(WhileStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(DoStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(ForStatement s)
+    {
+        applyTo(s) || doCond(s._init) || doCond(s._body);
+    }
+
+    override void visit(ForeachStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(ForeachRangeStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(IfStatement s)
+    {
+        applyTo(s) || doCond(s.ifbody) || doCond(s.elsebody);
+    }
+
+    override void visit(PragmaStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(SwitchStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(CaseStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
+    }
+
+    override void visit(DefaultStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
+    }
+
+    override void visit(SynchronizedStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(WithStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(TryCatchStatement s)
+    {
+        if (applyTo(s))
+            return;
+        if (doCond(s._body))
+            return;
+        for (size_t i = 0; i < s.catches.length; i++)
+            if (doCond((*s.catches)[i].handler))
+                return;
+    }
+
+    override void visit(TryFinallyStatement s)
+    {
+        applyTo(s) || doCond(s._body) || doCond(s.finalbody);
+    }
+
+    override void visit(ScopeGuardStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
+    }
+
+    override void visit(DebugStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
+    }
+
+    override void visit(LabelStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
     }
 }

--- a/compiler/test/fail_compilation/fail23001.d
+++ b/compiler/test/fail_compilation/fail23001.d
@@ -1,0 +1,148 @@
+// REQUIRED_ARGS: -w
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23001.d(20): Warning: statement is not reachable
+fail_compilation/fail23001.d(35): Warning: statement is not reachable
+fail_compilation/fail23001.d(50): Warning: statement is not reachable
+fail_compilation/fail23001.d(110): Warning: statement is not reachable
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
+---
+*/
+
+void test23001a()
+{
+    switch (0)
+    {
+        default:
+            break;
+        switch (1)  // Unreachable
+        {
+            default:
+                break;
+        }
+    }
+}
+
+void test23001b()
+{
+    switch (0)
+    {
+        default:
+            break;
+        { }         // Ignored
+        switch (1)  // Unreachable
+        {
+            default:
+                break;
+        }
+    }
+}
+
+void test23001c()
+{
+    switch (0)
+    {
+        default:
+            break;
+        import object;  // Ignored
+        switch (1)      // Unreachable
+        {
+            default:
+                break;
+        }
+    }
+}
+
+void test23001d()
+{
+    switch (0)
+    {
+        default:
+            break;
+        label:
+            switch (1)  // May be reachable
+            {
+                default:
+                    break;
+            }
+    }
+}
+
+void test23001e()
+{
+    switch (0)
+    {
+        default:
+            break;
+        case 1:
+            switch (1)  // May be reachable
+            {
+                default:
+                    break;
+            }
+    }
+}
+
+void test23001f()
+{
+    switch (0)
+    {
+        case 0:
+            break;
+        default:
+            switch (1)  // May be reachable
+            {
+                default:
+                    break;
+            }
+    }
+}
+
+void test23001g()
+{
+    switch (0)
+    {
+        default:
+            break;
+        asm {}      // Ignored
+        switch (1)  // Unreachable
+        {
+            default:
+                break;
+        }
+    }
+}
+
+void test23001h()
+{
+    version (DigitalMars)
+    {
+        switch (0)
+        {
+            default:
+                break;
+            asm {nop;}
+            switch (1)  // May be reachable
+            {
+                default:
+                    break;
+            }
+        }
+    }
+}
+
+void test23001i()
+{
+    switch (0)
+    {
+        switch (1)  // ??? May be reachable
+        {
+            default:
+                break;
+        }
+        default:
+            break;
+    }
+}


### PR DESCRIPTION
Implements a `walkPreorder` visitor function, and uses it for the implementation of `comesFrom`, so that nodes are processed from top-to-bottom.  This is preferred when looking for code that is reachable, for example:
```
return;
{
    int unreachable = 1;  // this is unreachable in the scope statement, but doesn't trigger a warning
                          // because...
Ljmp:                     // ... this label can "come from" anywhere.
    int reachable = 0;    // so this may be reachable.
}
```
The presence of the label shouldn't mean the entire block should be considered reachable.

However... the `comeFrom()` function appears to be used in two different ways.
1.
https://github.com/dlang/dmd/blob/6b2c13a9eb0f8497d0e97586cb172bad23d54f0c/compiler/src/dmd/blockexit.d#L161-L166
2.
https://github.com/dlang/dmd/blob/6b2c13a9eb0f8497d0e97586cb172bad23d54f0c/compiler/src/dmd/statementsem.d#L3601-L3608

In the second example, Postorder walking is actually preferred, because we don't want the entire catch block to be removed _because_ the entrypoint is unreachable.

So this is left as an experiment for now. I'm not convinced by how `comeFrom` works, though I am more unconvinced about these unreachable warnings being in the front-end in the first place.