### PR TITLE
fix Issue 23589 - [REG2.095] Purity check special case gives circular reference error

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -1291,12 +1291,16 @@ extern (C++) abstract class Expression : ASTNode
             return false; // ...or manifest constants
 
         // accessing empty structs is pure
+        // https://issues.dlang.org/show_bug.cgi?id=18694
+        // https://issues.dlang.org/show_bug.cgi?id=21464
+        // https://issues.dlang.org/show_bug.cgi?id=23589
         if (v.type.ty == Tstruct)
         {
             StructDeclaration sd = (cast(TypeStruct)v.type).sym;
             if (sd.members) // not opaque
             {
-                sd.determineSize(v.loc);
+                if (sd.semanticRun >= PASS.semanticdone)
+                    sd.determineSize(v.loc);
                 if (sd.hasNoFields)
                     return false;
             }

--- a/compiler/test/compilable/test23589.d
+++ b/compiler/test/compilable/test23589.d
@@ -1,0 +1,30 @@
+// https://issues.dlang.org/show_bug.cgi?id=23589
+struct TemplStr(string Description_) {}
+
+template A() {
+    bool member;
+    alias THIS = typeof(this);
+    static THIS staticInstance;
+    static asSize()
+    {
+        return staticInstance.member;
+    }
+}
+
+template B() {
+    enum cols = columns();
+
+    enum cols_two = cols;
+    TemplStr!(cols_two) tstr;
+}
+
+struct S
+{
+  mixin A;
+  mixin B;
+
+  static string columns() {
+    auto dummy = &asSize;
+    return "as";
+  }
+}


### PR DESCRIPTION
I feel like this is another case of running semantic-related things in the wrong place - or not having a clear separation between resolving types/sizes, and doing validation checks.

This looks wrong, but it keeps both the introducing, and regression tests happy.  @kinke ?