### PR TITLE
unhack gc crt_constructor hack

### DIFF
--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -110,13 +110,23 @@ alias GC gc_t;
 /* ============================ GC =============================== */
 
 // register GC in C constructor (_STI_)
-extern(C) pragma(crt_constructor) void _d_register_conservative_gc()
+private pragma(crt_constructor) void gc_conservative_ctor()
+{
+    _d_register_conservative_gc();
+}
+
+extern(C) void _d_register_conservative_gc()
 {
     import core.gc.registry;
     registerGCFactory("conservative", &initialize);
 }
 
-extern(C) pragma(crt_constructor) void _d_register_precise_gc()
+private pragma(crt_constructor) void gc_precise_ctor()
+{
+    _d_register_precise_gc();
+}
+
+extern(C) void _d_register_precise_gc()
 {
     import core.gc.registry;
     registerGCFactory("precise", &initialize_precise);

--- a/druntime/src/core/internal/gc/impl/manual/gc.d
+++ b/druntime/src/core/internal/gc/impl/manual/gc.d
@@ -29,7 +29,12 @@ static import core.memory;
 extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow @nogc; /* dmd @@@BUG11461@@@ */
 
 // register GC in C constructor (_STI_)
-extern(C) pragma(crt_constructor) void _d_register_manual_gc()
+private pragma(crt_constructor) void gc_manual_ctor()
+{
+    _d_register_manual_gc();
+}
+
+extern(C) void _d_register_manual_gc()
 {
     import core.gc.registry;
     registerGCFactory("manual", &initialize);


### PR DESCRIPTION
The gc constructor relies on forcing C style mangling of the `pragma(crt_constructor)`, which is wholly unnecessary. This fixes that.