### PR TITLE
Fix FreeBSD failing test suite in master

### DIFF
--- a/druntime/test/gc/sentinel2.d
+++ b/druntime/test/gc/sentinel2.d
@@ -10,6 +10,10 @@ void main()
     // so that the pointer p will not be visible to the GC.
     auto t = new Thread({
         thread_detachThis();
+        // Keep reference to this thread object in a shared data address, because
+        // the thread-local pointer in druntime will not be visible to the GC either.
+        __gshared Thread threadobj;
+        threadobj = Thread.getThis();
 
         auto p = cast(ubyte*)GC.malloc(1);
         assert(p[-1] == 0xF4);


### PR DESCRIPTION
Debugging done in #14753.

The test creates a thread that removes itself from the GC.  This means that all live TLS objects in druntime could (and are) collected and freed too.  Keep a reference to the one that we rely on for tracebacks.

There are only two reasons why this pipeline failure has occurred as a result of #14710 now.
1. Previously, no traceback was created when inside a finalizer (the segfault occurs within a finalizer).
2. The `_d_createTrace` function is called again post GC.collect because running finalizers failed, I can only assume that `new DefaultTraceHandler` also failed for another unrelated reason too, masking the underlying cause of this issue (and avoiding a second possibility of a segfault).

The pipelines don't always fail, so there is an added race issue too.  But why FreeBSD?  As far as I can tell every platform should be affected. Maybe because it's running in a VM, unlike the other Cirrus pipelines.

**Edit**: The GC is compiled with `version = COLLECT_PARALLEL` - so that _could be_ that is where our race condition is occurring.

Scenario 1:
- TLS is scanned and collects/finalizes `core.thread.threadbase.ThreadBase.sm_this`
- Stack is scanned and collects `p` - which throws an error because the sentinel has been invalidated.
- Segfault occurs because `DefaultTraceInfo` dereferences `sm_this`, but it has already been destroyed.

Scenario 2:
- Stack is scanned and collects `p` - which throws an error because the sentinel has been invalidated.
- TLS is scanned but no collections ran because of thrown exception
- Exception is caught by main program and exits successfully.