### PR TITLE
test: Fix cdvecfill output to match binutils 2.39

### DIFF
--- a/compiler/test/runnable/cdvecfill.sh
+++ b/compiler/test/runnable/cdvecfill.sh
@@ -10,17 +10,17 @@ obj_file=${RESULTS_TEST_DIR}/${TEST_NAME}.o
 
 if [ $OS == "linux" ] && [ $MODEL == "64" ]; then
   $DMD -betterC -c -O -m64 ${src_file} -of${obj_file}
-  objdump --disassemble --disassembler-options=intel-mnemonic ${obj_file} | tail -n+3 > ${tmp_file}
+  objdump --disassemble --disassembler-options=intel-mnemonic ${obj_file} | tail -n+3 | sed 's/[ \t]\s*$//' > ${tmp_file}
   diff ${expect_file} ${tmp_file}
   rm_retry ${obj_file} ${tmp_file}
 
   $DMD -betterC -c -O -m64 -mcpu=avx ${src_file} -of${obj_file}
-  objdump --disassemble --disassembler-options=intel-mnemonic ${obj_file} | tail -n+3 > ${tmp_file}
+  objdump --disassemble --disassembler-options=intel-mnemonic ${obj_file} | tail -n+3 | sed 's/[ \t]\s*$//' > ${tmp_file}
   diff ${expect_file_avx} ${tmp_file}
   rm_retry ${obj_file} ${tmp_file}
 
   $DMD -betterC -c -O -m64 -mcpu=avx2 ${src_file} -of${obj_file}
-  objdump --disassemble --disassembler-options=intel-mnemonic ${obj_file} | tail -n+3 > ${tmp_file}
+  objdump --disassemble --disassembler-options=intel-mnemonic ${obj_file} | tail -n+3 | sed 's/[ \t]\s*$//' > ${tmp_file}
   diff ${expect_file_avx2} ${tmp_file}
   rm_retry ${obj_file} ${tmp_file}
 fi

--- a/compiler/test/runnable/extra-files/cdvecfill.out
+++ b/compiler/test/runnable/extra-files/cdvecfill.out
@@ -7,7 +7,7 @@ Disassembly of section .text._D9cdvecfill4testFhZNhG16h:
    4:	66 0f 60 c0          	punpcklbw xmm0,xmm0
    8:	66 0f 61 c0          	punpcklwd xmm0,xmm0
    c:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-  11:	c3                   	ret    
+  11:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPhZNhG16h:
@@ -18,7 +18,7 @@ Disassembly of section .text._D9cdvecfill4testFPhZNhG16h:
    7:	66 0f 60 c0          	punpcklbw xmm0,xmm0
    b:	66 0f 61 c0          	punpcklwd xmm0,xmm0
    f:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-  14:	c3                   	ret    
+  14:	c3                   	ret
   15:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -29,7 +29,7 @@ Disassembly of section .text._D9cdvecfill4testFgZNhG16g:
    4:	66 0f 60 c0          	punpcklbw xmm0,xmm0
    8:	66 0f 61 c0          	punpcklwd xmm0,xmm0
    c:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-  11:	c3                   	ret    
+  11:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPgZNhG16g:
@@ -40,7 +40,7 @@ Disassembly of section .text._D9cdvecfill4testFPgZNhG16g:
    7:	66 0f 60 c0          	punpcklbw xmm0,xmm0
    b:	66 0f 61 c0          	punpcklwd xmm0,xmm0
    f:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-  14:	c3                   	ret    
+  14:	c3                   	ret
   15:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -50,7 +50,7 @@ Disassembly of section .text._D9cdvecfill4testFtZNhG8t:
    0:	66 0f 6e c7          	movd   xmm0,edi
    4:	66 0f 61 c0          	punpcklwd xmm0,xmm0
    8:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-   d:	c3                   	ret    
+   d:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPtZNhG8t:
@@ -60,7 +60,7 @@ Disassembly of section .text._D9cdvecfill4testFPtZNhG8t:
    3:	66 0f 6e c0          	movd   xmm0,eax
    7:	66 0f 61 c0          	punpcklwd xmm0,xmm0
    b:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-  10:	c3                   	ret    
+  10:	c3                   	ret
   11:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -70,7 +70,7 @@ Disassembly of section .text._D9cdvecfill4testFsZNhG8s:
    0:	66 0f 6e c7          	movd   xmm0,edi
    4:	66 0f 61 c0          	punpcklwd xmm0,xmm0
    8:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-   d:	c3                   	ret    
+   d:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPsZNhG8s:
@@ -80,7 +80,7 @@ Disassembly of section .text._D9cdvecfill4testFPsZNhG8s:
    3:	66 0f 6e c0          	movd   xmm0,eax
    7:	66 0f 61 c0          	punpcklwd xmm0,xmm0
    b:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-  10:	c3                   	ret    
+  10:	c3                   	ret
   11:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -89,7 +89,7 @@ Disassembly of section .text._D9cdvecfill4testFkZNhG4k:
 0000000000000000 <_D9cdvecfill4testFkZNhG4k>:
    0:	66 0f 6e c7          	movd   xmm0,edi
    4:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPkZNhG4k:
@@ -97,7 +97,7 @@ Disassembly of section .text._D9cdvecfill4testFPkZNhG4k:
 0000000000000000 <_D9cdvecfill4testFPkZNhG4k>:
    0:	66 0f 6e 07          	movd   xmm0,DWORD PTR [rdi]
    4:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFiZNhG4i:
@@ -105,7 +105,7 @@ Disassembly of section .text._D9cdvecfill4testFiZNhG4i:
 0000000000000000 <_D9cdvecfill4testFiZNhG4i>:
    0:	66 0f 6e c7          	movd   xmm0,edi
    4:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPiZNhG4i:
@@ -113,7 +113,7 @@ Disassembly of section .text._D9cdvecfill4testFPiZNhG4i:
 0000000000000000 <_D9cdvecfill4testFPiZNhG4i>:
    0:	66 0f 6e 07          	movd   xmm0,DWORD PTR [rdi]
    4:	66 0f 70 c0 00       	pshufd xmm0,xmm0,0x0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFmZNhG2m:
@@ -121,14 +121,14 @@ Disassembly of section .text._D9cdvecfill4testFmZNhG2m:
 0000000000000000 <_D9cdvecfill4testFmZNhG2m>:
    0:	66 48 0f 6e c7       	movq   xmm0,rdi
    5:	66 0f 6c c0          	punpcklqdq xmm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPmZNhG2m:
 
 0000000000000000 <_D9cdvecfill4testFPmZNhG2m>:
    0:	66 0f 6c 07          	punpcklqdq xmm0,XMMWORD PTR [rdi]
-   4:	c3                   	ret    
+   4:	c3                   	ret
    5:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -137,14 +137,14 @@ Disassembly of section .text._D9cdvecfill4testFlZNhG2l:
 0000000000000000 <_D9cdvecfill4testFlZNhG2l>:
    0:	66 48 0f 6e c7       	movq   xmm0,rdi
    5:	66 0f 6c c0          	punpcklqdq xmm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPlZNhG2l:
 
 0000000000000000 <_D9cdvecfill4testFPlZNhG2l>:
    0:	66 0f 6c 07          	punpcklqdq xmm0,XMMWORD PTR [rdi]
-   4:	c3                   	ret    
+   4:	c3                   	ret
    5:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -156,7 +156,7 @@ Disassembly of section .text._D9cdvecfill4testFfZNhG4f:
    6:	f3 0f 10 04 24       	movss  xmm0,DWORD PTR [rsp]
    b:	0f c6 c0 00          	shufps xmm0,xmm0,0x0
    f:	59                   	pop    rcx
-  10:	c3                   	ret    
+  10:	c3                   	ret
   11:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -165,7 +165,7 @@ Disassembly of section .text._D9cdvecfill4testFPfZNhG4f:
 0000000000000000 <_D9cdvecfill4testFPfZNhG4f>:
    0:	f3 0f 10 07          	movss  xmm0,DWORD PTR [rdi]
    4:	0f c6 c0 00          	shufps xmm0,xmm0,0x0
-   8:	c3                   	ret    
+   8:	c3                   	ret
    9:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -177,7 +177,7 @@ Disassembly of section .text._D9cdvecfill4testFdZNhG2d:
    6:	f2 0f 10 04 24       	movsd  xmm0,QWORD PTR [rsp]
    b:	66 0f 14 c0          	unpcklpd xmm0,xmm0
    f:	59                   	pop    rcx
-  10:	c3                   	ret    
+  10:	c3                   	ret
   11:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -186,6 +186,6 @@ Disassembly of section .text._D9cdvecfill4testFPdZNhG2d:
 0000000000000000 <_D9cdvecfill4testFPdZNhG2d>:
    0:	f2 0f 10 07          	movsd  xmm0,QWORD PTR [rdi]
    4:	66 0f 14 c0          	unpcklpd xmm0,xmm0
-   8:	c3                   	ret    
+   8:	c3                   	ret
    9:	00 00                	add    BYTE PTR [rax],al
 	...

--- a/compiler/test/runnable/extra-files/cdvecfillavx.out
+++ b/compiler/test/runnable/extra-files/cdvecfillavx.out
@@ -6,7 +6,7 @@ Disassembly of section .text._D9cdvecfill4testFhZNhG16h:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
    8:	c4 e2 79 00 c1       	vpshufb xmm0,xmm0,xmm1
-   d:	c3                   	ret    
+   d:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPhZNhG16h:
@@ -16,7 +16,7 @@ Disassembly of section .text._D9cdvecfill4testFPhZNhG16h:
    3:	c5 f9 6e c0          	vmovd  xmm0,eax
    7:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
    b:	c4 e2 79 00 c1       	vpshufb xmm0,xmm0,xmm1
-  10:	c3                   	ret    
+  10:	c3                   	ret
   11:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -26,7 +26,7 @@ Disassembly of section .text._D9cdvecfill4testFgZNhG16g:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
    8:	c4 e2 79 00 c1       	vpshufb xmm0,xmm0,xmm1
-   d:	c3                   	ret    
+   d:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPgZNhG16g:
@@ -36,7 +36,7 @@ Disassembly of section .text._D9cdvecfill4testFPgZNhG16g:
    3:	c5 f9 6e c0          	vmovd  xmm0,eax
    7:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
    b:	c4 e2 79 00 c1       	vpshufb xmm0,xmm0,xmm1
-  10:	c3                   	ret    
+  10:	c3                   	ret
   11:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -46,7 +46,7 @@ Disassembly of section .text._D9cdvecfill4testFtZNhG8t:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
    8:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
-   d:	c3                   	ret    
+   d:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPtZNhG8t:
@@ -56,7 +56,7 @@ Disassembly of section .text._D9cdvecfill4testFPtZNhG8t:
    3:	c5 f9 6e c0          	vmovd  xmm0,eax
    7:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
    b:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
-  10:	c3                   	ret    
+  10:	c3                   	ret
   11:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -66,7 +66,7 @@ Disassembly of section .text._D9cdvecfill4testFsZNhG8s:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
    8:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
-   d:	c3                   	ret    
+   d:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPsZNhG8s:
@@ -76,7 +76,7 @@ Disassembly of section .text._D9cdvecfill4testFPsZNhG8s:
    3:	c5 f9 6e c0          	vmovd  xmm0,eax
    7:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
    b:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
-  10:	c3                   	ret    
+  10:	c3                   	ret
   11:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -85,14 +85,14 @@ Disassembly of section .text._D9cdvecfill4testFkZNhG4k:
 0000000000000000 <_D9cdvecfill4testFkZNhG4k>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPkZNhG4k:
 
 0000000000000000 <_D9cdvecfill4testFPkZNhG4k>:
    0:	c4 e2 79 18 07       	vbroadcastss xmm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFiZNhG4i:
@@ -100,14 +100,14 @@ Disassembly of section .text._D9cdvecfill4testFiZNhG4i:
 0000000000000000 <_D9cdvecfill4testFiZNhG4i>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPiZNhG4i:
 
 0000000000000000 <_D9cdvecfill4testFPiZNhG4i>:
    0:	c4 e2 79 18 07       	vbroadcastss xmm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFmZNhG2m:
@@ -115,14 +115,14 @@ Disassembly of section .text._D9cdvecfill4testFmZNhG2m:
 0000000000000000 <_D9cdvecfill4testFmZNhG2m>:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c5 f9 6c c0          	vpunpcklqdq xmm0,xmm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPmZNhG2m:
 
 0000000000000000 <_D9cdvecfill4testFPmZNhG2m>:
    0:	c5 f9 6c 07          	vpunpcklqdq xmm0,xmm0,XMMWORD PTR [rdi]
-   4:	c3                   	ret    
+   4:	c3                   	ret
    5:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -131,14 +131,14 @@ Disassembly of section .text._D9cdvecfill4testFlZNhG2l:
 0000000000000000 <_D9cdvecfill4testFlZNhG2l>:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c5 f9 6c c0          	vpunpcklqdq xmm0,xmm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPlZNhG2l:
 
 0000000000000000 <_D9cdvecfill4testFPlZNhG2l>:
    0:	c5 f9 6c 07          	vpunpcklqdq xmm0,xmm0,XMMWORD PTR [rdi]
-   4:	c3                   	ret    
+   4:	c3                   	ret
    5:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -150,14 +150,14 @@ Disassembly of section .text._D9cdvecfill4testFfZNhG4f:
    6:	c5 fa 10 04 24       	vmovss xmm0,DWORD PTR [rsp]
    b:	c5 f8 c6 c0 00       	vshufps xmm0,xmm0,xmm0,0x0
   10:	59                   	pop    rcx
-  11:	c3                   	ret    
+  11:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPfZNhG4f:
 
 0000000000000000 <_D9cdvecfill4testFPfZNhG4f>:
    0:	c4 e2 79 18 07       	vbroadcastss xmm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFdZNhG2d:
@@ -168,7 +168,7 @@ Disassembly of section .text._D9cdvecfill4testFdZNhG2d:
    6:	c5 fb 10 04 24       	vmovsd xmm0,QWORD PTR [rsp]
    b:	c5 f9 14 c0          	vunpcklpd xmm0,xmm0,xmm0
    f:	59                   	pop    rcx
-  10:	c3                   	ret    
+  10:	c3                   	ret
   11:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -177,7 +177,7 @@ Disassembly of section .text._D9cdvecfill4testFPdZNhG2d:
 0000000000000000 <_D9cdvecfill4testFPdZNhG2d>:
    0:	c5 fb 10 07          	vmovsd xmm0,QWORD PTR [rdi]
    4:	c5 f9 14 c0          	vunpcklpd xmm0,xmm0,xmm0
-   8:	c3                   	ret    
+   8:	c3                   	ret
    9:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -188,7 +188,7 @@ Disassembly of section .text._D9cdvecfill5test2FhZNhG32h:
    4:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
    8:	c4 e2 79 00 c1       	vpshufb xmm0,xmm0,xmm1
    d:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-  13:	c3                   	ret    
+  13:	c3                   	ret
 
 Disassembly of section .text._D9cdvecfill5test2FPhZNhG32h:
 
@@ -198,7 +198,7 @@ Disassembly of section .text._D9cdvecfill5test2FPhZNhG32h:
    7:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
    b:	c4 e2 79 00 c1       	vpshufb xmm0,xmm0,xmm1
   10:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-  16:	c3                   	ret    
+  16:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FgZNhG32g:
@@ -208,7 +208,7 @@ Disassembly of section .text._D9cdvecfill5test2FgZNhG32g:
    4:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
    8:	c4 e2 79 00 c1       	vpshufb xmm0,xmm0,xmm1
    d:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-  13:	c3                   	ret    
+  13:	c3                   	ret
 
 Disassembly of section .text._D9cdvecfill5test2FPgZNhG32g:
 
@@ -218,7 +218,7 @@ Disassembly of section .text._D9cdvecfill5test2FPgZNhG32g:
    7:	c5 f1 ef c9          	vpxor  xmm1,xmm1,xmm1
    b:	c4 e2 79 00 c1       	vpshufb xmm0,xmm0,xmm1
   10:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-  16:	c3                   	ret    
+  16:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FtZNhG16t:
@@ -228,7 +228,7 @@ Disassembly of section .text._D9cdvecfill5test2FtZNhG16t:
    4:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
    8:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
    d:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-  13:	c3                   	ret    
+  13:	c3                   	ret
 
 Disassembly of section .text._D9cdvecfill5test2FPtZNhG16t:
 
@@ -238,7 +238,7 @@ Disassembly of section .text._D9cdvecfill5test2FPtZNhG16t:
    7:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
    b:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
   10:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-  16:	c3                   	ret    
+  16:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FsZNhG16s:
@@ -248,7 +248,7 @@ Disassembly of section .text._D9cdvecfill5test2FsZNhG16s:
    4:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
    8:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
    d:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-  13:	c3                   	ret    
+  13:	c3                   	ret
 
 Disassembly of section .text._D9cdvecfill5test2FPsZNhG16s:
 
@@ -258,7 +258,7 @@ Disassembly of section .text._D9cdvecfill5test2FPsZNhG16s:
    7:	c5 f9 61 c0          	vpunpcklwd xmm0,xmm0,xmm0
    b:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
   10:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-  16:	c3                   	ret    
+  16:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FkZNhG8k:
@@ -267,13 +267,13 @@ Disassembly of section .text._D9cdvecfill5test2FkZNhG8k:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
    9:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-   f:	c3                   	ret    
+   f:	c3                   	ret
 
 Disassembly of section .text._D9cdvecfill5test2FPkZNhG8k:
 
 0000000000000000 <_D9cdvecfill5test2FPkZNhG8k>:
    0:	c4 e2 7d 18 07       	vbroadcastss ymm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FiZNhG8i:
@@ -282,13 +282,13 @@ Disassembly of section .text._D9cdvecfill5test2FiZNhG8i:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c5 f9 70 c0 00       	vpshufd xmm0,xmm0,0x0
    9:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-   f:	c3                   	ret    
+   f:	c3                   	ret
 
 Disassembly of section .text._D9cdvecfill5test2FPiZNhG8i:
 
 0000000000000000 <_D9cdvecfill5test2FPiZNhG8i>:
    0:	c4 e2 7d 18 07       	vbroadcastss ymm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FmZNhG4m:
@@ -297,13 +297,13 @@ Disassembly of section .text._D9cdvecfill5test2FmZNhG4m:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c5 f9 6c c0          	vpunpcklqdq xmm0,xmm0,xmm0
    9:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-   f:	c3                   	ret    
+   f:	c3                   	ret
 
 Disassembly of section .text._D9cdvecfill5test2FPmZNhG4m:
 
 0000000000000000 <_D9cdvecfill5test2FPmZNhG4m>:
    0:	c4 e2 7d 19 07       	vbroadcastsd ymm0,QWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FlZNhG4l:
@@ -312,13 +312,13 @@ Disassembly of section .text._D9cdvecfill5test2FlZNhG4l:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c5 f9 6c c0          	vpunpcklqdq xmm0,xmm0,xmm0
    9:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
-   f:	c3                   	ret    
+   f:	c3                   	ret
 
 Disassembly of section .text._D9cdvecfill5test2FPlZNhG4l:
 
 0000000000000000 <_D9cdvecfill5test2FPlZNhG4l>:
    0:	c4 e2 7d 19 07       	vbroadcastsd ymm0,QWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FfZNhG8f:
@@ -330,13 +330,13 @@ Disassembly of section .text._D9cdvecfill5test2FfZNhG8f:
    b:	c5 fc c6 c0 00       	vshufps ymm0,ymm0,ymm0,0x0
   10:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
   16:	59                   	pop    rcx
-  17:	c3                   	ret    
+  17:	c3                   	ret
 
 Disassembly of section .text._D9cdvecfill5test2FPfZNhG8f:
 
 0000000000000000 <_D9cdvecfill5test2FPfZNhG8f>:
    0:	c4 e2 7d 18 07       	vbroadcastss ymm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FdZNhG4d:
@@ -348,12 +348,12 @@ Disassembly of section .text._D9cdvecfill5test2FdZNhG4d:
    b:	c5 f9 14 c0          	vunpcklpd xmm0,xmm0,xmm0
    f:	c4 e3 7d 18 c0 01    	vinsertf128 ymm0,ymm0,xmm0,0x1
   15:	59                   	pop    rcx
-  16:	c3                   	ret    
+  16:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FPdZNhG4d:
 
 0000000000000000 <_D9cdvecfill5test2FPdZNhG4d>:
    0:	c4 e2 7d 19 07       	vbroadcastsd ymm0,QWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...

--- a/compiler/test/runnable/extra-files/cdvecfillavx2.out
+++ b/compiler/test/runnable/extra-files/cdvecfillavx2.out
@@ -5,14 +5,14 @@ Disassembly of section .text._D9cdvecfill4testFhZNhG16h:
 0000000000000000 <_D9cdvecfill4testFhZNhG16h>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 79 78 c0       	vpbroadcastb xmm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPhZNhG16h:
 
 0000000000000000 <_D9cdvecfill4testFPhZNhG16h>:
    0:	c4 e2 79 78 07       	vpbroadcastb xmm0,BYTE PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFgZNhG16g:
@@ -20,14 +20,14 @@ Disassembly of section .text._D9cdvecfill4testFgZNhG16g:
 0000000000000000 <_D9cdvecfill4testFgZNhG16g>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 79 78 c0       	vpbroadcastb xmm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPgZNhG16g:
 
 0000000000000000 <_D9cdvecfill4testFPgZNhG16g>:
    0:	c4 e2 79 78 07       	vpbroadcastb xmm0,BYTE PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFtZNhG8t:
@@ -35,14 +35,14 @@ Disassembly of section .text._D9cdvecfill4testFtZNhG8t:
 0000000000000000 <_D9cdvecfill4testFtZNhG8t>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 79 79 c0       	vpbroadcastw xmm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPtZNhG8t:
 
 0000000000000000 <_D9cdvecfill4testFPtZNhG8t>:
    0:	c4 e2 79 79 07       	vpbroadcastw xmm0,WORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFsZNhG8s:
@@ -50,14 +50,14 @@ Disassembly of section .text._D9cdvecfill4testFsZNhG8s:
 0000000000000000 <_D9cdvecfill4testFsZNhG8s>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 79 79 c0       	vpbroadcastw xmm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPsZNhG8s:
 
 0000000000000000 <_D9cdvecfill4testFPsZNhG8s>:
    0:	c4 e2 79 79 07       	vpbroadcastw xmm0,WORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFkZNhG4k:
@@ -65,14 +65,14 @@ Disassembly of section .text._D9cdvecfill4testFkZNhG4k:
 0000000000000000 <_D9cdvecfill4testFkZNhG4k>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 79 58 c0       	vpbroadcastd xmm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPkZNhG4k:
 
 0000000000000000 <_D9cdvecfill4testFPkZNhG4k>:
    0:	c4 e2 79 58 07       	vpbroadcastd xmm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFiZNhG4i:
@@ -80,14 +80,14 @@ Disassembly of section .text._D9cdvecfill4testFiZNhG4i:
 0000000000000000 <_D9cdvecfill4testFiZNhG4i>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 79 58 c0       	vpbroadcastd xmm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPiZNhG4i:
 
 0000000000000000 <_D9cdvecfill4testFPiZNhG4i>:
    0:	c4 e2 79 58 07       	vpbroadcastd xmm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFmZNhG2m:
@@ -95,14 +95,14 @@ Disassembly of section .text._D9cdvecfill4testFmZNhG2m:
 0000000000000000 <_D9cdvecfill4testFmZNhG2m>:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c4 e2 79 59 c0       	vpbroadcastq xmm0,xmm0
-   a:	c3                   	ret    
+   a:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPmZNhG2m:
 
 0000000000000000 <_D9cdvecfill4testFPmZNhG2m>:
    0:	c4 e2 79 59 07       	vpbroadcastq xmm0,QWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFlZNhG2l:
@@ -110,14 +110,14 @@ Disassembly of section .text._D9cdvecfill4testFlZNhG2l:
 0000000000000000 <_D9cdvecfill4testFlZNhG2l>:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c4 e2 79 59 c0       	vpbroadcastq xmm0,xmm0
-   a:	c3                   	ret    
+   a:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPlZNhG2l:
 
 0000000000000000 <_D9cdvecfill4testFPlZNhG2l>:
    0:	c4 e2 79 59 07       	vpbroadcastq xmm0,QWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFfZNhG4f:
@@ -128,14 +128,14 @@ Disassembly of section .text._D9cdvecfill4testFfZNhG4f:
    6:	c5 fa 10 04 24       	vmovss xmm0,DWORD PTR [rsp]
    b:	c4 e2 79 18 c0       	vbroadcastss xmm0,xmm0
   10:	59                   	pop    rcx
-  11:	c3                   	ret    
+  11:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFPfZNhG4f:
 
 0000000000000000 <_D9cdvecfill4testFPfZNhG4f>:
    0:	c4 e2 79 18 07       	vbroadcastss xmm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill4testFdZNhG2d:
@@ -146,7 +146,7 @@ Disassembly of section .text._D9cdvecfill4testFdZNhG2d:
    6:	c5 fb 10 04 24       	vmovsd xmm0,QWORD PTR [rsp]
    b:	c5 f9 14 c0          	vunpcklpd xmm0,xmm0,xmm0
    f:	59                   	pop    rcx
-  10:	c3                   	ret    
+  10:	c3                   	ret
   11:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -155,7 +155,7 @@ Disassembly of section .text._D9cdvecfill4testFPdZNhG2d:
 0000000000000000 <_D9cdvecfill4testFPdZNhG2d>:
    0:	c5 fb 10 07          	vmovsd xmm0,QWORD PTR [rdi]
    4:	c5 f9 14 c0          	vunpcklpd xmm0,xmm0,xmm0
-   8:	c3                   	ret    
+   8:	c3                   	ret
    9:	00 00                	add    BYTE PTR [rax],al
 	...
 
@@ -164,14 +164,14 @@ Disassembly of section .text._D9cdvecfill5test2FhZNhG32h:
 0000000000000000 <_D9cdvecfill5test2FhZNhG32h>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 78 c0       	vpbroadcastb ymm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FPhZNhG32h:
 
 0000000000000000 <_D9cdvecfill5test2FPhZNhG32h>:
    0:	c4 e2 7d 78 07       	vpbroadcastb ymm0,BYTE PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FgZNhG32g:
@@ -179,14 +179,14 @@ Disassembly of section .text._D9cdvecfill5test2FgZNhG32g:
 0000000000000000 <_D9cdvecfill5test2FgZNhG32g>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 78 c0       	vpbroadcastb ymm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FPgZNhG32g:
 
 0000000000000000 <_D9cdvecfill5test2FPgZNhG32g>:
    0:	c4 e2 7d 78 07       	vpbroadcastb ymm0,BYTE PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FtZNhG16t:
@@ -194,14 +194,14 @@ Disassembly of section .text._D9cdvecfill5test2FtZNhG16t:
 0000000000000000 <_D9cdvecfill5test2FtZNhG16t>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 79 c0       	vpbroadcastw ymm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FPtZNhG16t:
 
 0000000000000000 <_D9cdvecfill5test2FPtZNhG16t>:
    0:	c4 e2 7d 79 07       	vpbroadcastw ymm0,WORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FsZNhG16s:
@@ -209,14 +209,14 @@ Disassembly of section .text._D9cdvecfill5test2FsZNhG16s:
 0000000000000000 <_D9cdvecfill5test2FsZNhG16s>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 79 c0       	vpbroadcastw ymm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FPsZNhG16s:
 
 0000000000000000 <_D9cdvecfill5test2FPsZNhG16s>:
    0:	c4 e2 7d 79 07       	vpbroadcastw ymm0,WORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FkZNhG8k:
@@ -224,14 +224,14 @@ Disassembly of section .text._D9cdvecfill5test2FkZNhG8k:
 0000000000000000 <_D9cdvecfill5test2FkZNhG8k>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 58 c0       	vpbroadcastd ymm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FPkZNhG8k:
 
 0000000000000000 <_D9cdvecfill5test2FPkZNhG8k>:
    0:	c4 e2 7d 58 07       	vpbroadcastd ymm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FiZNhG8i:
@@ -239,14 +239,14 @@ Disassembly of section .text._D9cdvecfill5test2FiZNhG8i:
 0000000000000000 <_D9cdvecfill5test2FiZNhG8i>:
    0:	c5 f9 6e c7          	vmovd  xmm0,edi
    4:	c4 e2 7d 58 c0       	vpbroadcastd ymm0,xmm0
-   9:	c3                   	ret    
+   9:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FPiZNhG8i:
 
 0000000000000000 <_D9cdvecfill5test2FPiZNhG8i>:
    0:	c4 e2 7d 58 07       	vpbroadcastd ymm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FmZNhG4m:
@@ -254,14 +254,14 @@ Disassembly of section .text._D9cdvecfill5test2FmZNhG4m:
 0000000000000000 <_D9cdvecfill5test2FmZNhG4m>:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c4 e2 7d 59 c0       	vpbroadcastq ymm0,xmm0
-   a:	c3                   	ret    
+   a:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FPmZNhG4m:
 
 0000000000000000 <_D9cdvecfill5test2FPmZNhG4m>:
    0:	c4 e2 7d 59 07       	vpbroadcastq ymm0,QWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FlZNhG4l:
@@ -269,14 +269,14 @@ Disassembly of section .text._D9cdvecfill5test2FlZNhG4l:
 0000000000000000 <_D9cdvecfill5test2FlZNhG4l>:
    0:	c4 e1 f9 6e c7       	vmovq  xmm0,rdi
    5:	c4 e2 7d 59 c0       	vpbroadcastq ymm0,xmm0
-   a:	c3                   	ret    
+   a:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FPlZNhG4l:
 
 0000000000000000 <_D9cdvecfill5test2FPlZNhG4l>:
    0:	c4 e2 7d 59 07       	vpbroadcastq ymm0,QWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FfZNhG8f:
@@ -287,14 +287,14 @@ Disassembly of section .text._D9cdvecfill5test2FfZNhG8f:
    6:	c5 fa 10 04 24       	vmovss xmm0,DWORD PTR [rsp]
    b:	c4 e2 7d 18 c0       	vbroadcastss ymm0,xmm0
   10:	59                   	pop    rcx
-  11:	c3                   	ret    
+  11:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FPfZNhG8f:
 
 0000000000000000 <_D9cdvecfill5test2FPfZNhG8f>:
    0:	c4 e2 7d 18 07       	vbroadcastss ymm0,DWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FdZNhG4d:
@@ -305,12 +305,12 @@ Disassembly of section .text._D9cdvecfill5test2FdZNhG4d:
    6:	c5 fb 10 04 24       	vmovsd xmm0,QWORD PTR [rsp]
    b:	c4 e2 7d 19 c0       	vbroadcastsd ymm0,xmm0
   10:	59                   	pop    rcx
-  11:	c3                   	ret    
+  11:	c3                   	ret
 	...
 
 Disassembly of section .text._D9cdvecfill5test2FPdZNhG4d:
 
 0000000000000000 <_D9cdvecfill5test2FPdZNhG4d>:
    0:	c4 e2 7d 19 07       	vbroadcastsd ymm0,QWORD PTR [rdi]
-   5:	c3                   	ret    
+   5:	c3                   	ret
 	...


### PR DESCRIPTION
Same as #14656 but for runnable/cdvecfill.sh, which I seem to have missed when running the testsuite locally.