### PR TITLE
Revert "Fix Issues 23331, 23379 - fix casts involving noreturn"

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4652,8 +4652,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 else if (exp.arguments.length == 1)
                 {
                     e = (*exp.arguments)[0];
-                    if (!e.type.isTypeNoreturn())
-                        e = e.implicitCastTo(sc, t1);
+                    e = e.implicitCastTo(sc, t1);
+                    e = new CastExp(exp.loc, e, t1);
                 }
                 else
                 {
@@ -7508,11 +7508,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (exp.e1.type.isTypeNoreturn() && (!exp.to || !exp.to.isTypeNoreturn()))
-        {
-            result = exp.e1;
-            return;
-        }
         if (exp.to && !exp.to.isTypeSArray() && !exp.to.isTypeFunction())
             exp.e1 = exp.e1.arrayFuncConv(sc);
 

--- a/compiler/test/compilable/noreturn3.d
+++ b/compiler/test/compilable/noreturn3.d
@@ -245,13 +245,3 @@ struct S22858
 static assert (S22858.arr.offsetof % size_t.sizeof == 0);
 static assert (S22858.arr2.offsetof == S22858.c.offsetof + 1);
 static assert (S22858.arr2.offsetof == S22858.c2.offsetof);
-
-// https://issues.dlang.org/show_bug.cgi?id=23331
-
-auto fun() { return double(new noreturn[](0)[0]); }
-auto gun() { return double(assert(0)); }
-auto hun() { return int(assert(0)); }
-
-// https://issues.dlang.org/show_bug.cgi?id=23379
-
-void casting_noreturn() { auto b = cast(double)(assert(0)); }

--- a/compiler/test/compilable/test23587.d
+++ b/compiler/test/compilable/test23587.d
@@ -1,0 +1,18 @@
+// https://issues.dlang.org/show_bug.cgi?id=23587
+// REQUIRED_ARGS: -w
+noreturn stuff()
+{
+    assert(false);
+}
+
+void doStuff(alias fun)()
+{
+    cast(void) fun();
+    string s = "never executed";
+    static assert(is(typeof(cast(void) fun()) == void));
+}
+
+void main()
+{
+    doStuff!stuff();
+}

--- a/compiler/test/fail_compilation/fail23591.d
+++ b/compiler/test/fail_compilation/fail23591.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=23591
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23591.d(13): Error: cannot implicitly convert expression `square(i) , null` of type `string` to `int`
+fail_compilation/fail23591.d(14): Error: cannot implicitly convert expression `assert(0) , null` of type `real function(char)` to `int`
+---
+*/
+noreturn square(int x);
+
+int example(int i)
+{
+    int x = cast(string)square(i);
+    int y = cast(real function(char))assert(0);
+    return x + y;
+}


### PR DESCRIPTION
Reverts dlang/dmd#14494

The original fix in question chose to ignore casts from `typeof(*null)` to other types.  This act of propagating means that now this complete nonsense is now compilable.
```d
noreturn square(int x);

int example(int i)
{
    int x = cast(string)square(i);
    int y = cast(real function(char))assert(0);
    return x + y;
}
```

However, the two issues that the PR attempted to solve are the result of a back-end bug, not a front-end.  Changing behaviour as it did deviated behaviour away from the D spec too.

From: https://dlang.org/spec/type.html#noreturn
> noreturn is the [bottom type](https://en.wikipedia.org/wiki/Bottom_type) **which can implicitly convert to any type, including void**. A value of type noreturn will never be produced and the compiler can optimize such code accordingly.

GDC follows the spec and compiles this code without issue at least. https://d.godbolt.org/z/bh37Y7E75

Targetting master to give time to fix the reopened critical issues in the next release.