### PR TITLE
More robust invariant check, fix stack trace reentrancy

### DIFF
--- a/druntime/src/rt/invariant.d
+++ b/druntime/src/rt/invariant.d
@@ -13,6 +13,7 @@
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
 
+extern (C) void onAssertErrorMsg( string file, size_t line, string msg ) nothrow;
 
 /**
  *
@@ -22,8 +23,14 @@ void _d_invariant(Object o)
 
     //printf("__d_invariant(%p)\n", o);
 
-    // BUG: needs to be filename/line of caller, not library routine
-    assert(o !is null); // just do null check, not invariant check
+
+    // check for null object or null vtable (as opposed to just segfaulting)
+    // Do this regardless of whether asserts are enabled or not. Since this is
+    // in druntime, it likely is compiled without asserts enabled, and clearly
+    // the user is OK with extra checks if they are using invariants.
+    if (o is null || *cast(void**)o is null)
+        // BUG: needs to be filename/line of caller, not library routine
+        onAssertErrorMsg(__FILE__, __LINE__, "object is null or has null vtbl");
 
     c = typeid(o);
     do

--- a/druntime/test/exceptions/Makefile
+++ b/druntime/test/exceptions/Makefile
@@ -25,7 +25,7 @@ ifeq ($(OS)-$(BUILD),osx-debug)
 endif
 
 ifeq ($(BUILD),debug)
-	TESTS+=assert_fail
+	TESTS+=assert_fail invariant_on_invalid_object
 endif
 
 DIFF:=diff
@@ -79,6 +79,7 @@ $(ROOT)/rt_trap_exceptions.done: STDERR_EXP="object.Exception@src/rt_trap_except
 $(ROOT)/rt_trap_exceptions.done: STDERR_EXP2="src/rt_trap_exceptions.d:8 main"
 $(ROOT)/assert_fail.done: STDERR_EXP="success."
 $(ROOT)/cpp_demangle.done: STDERR_EXP="thrower(int)"
+$(ROOT)/invariant_on_invalid_object.done: STDERR_EXP="object is null or has null vtbl"
 
 $(ROOT)/message_with_null.done: STDERR_EXP=" world"
 

--- a/druntime/test/exceptions/src/invariant_on_invalid_object.d
+++ b/druntime/test/exceptions/src/invariant_on_invalid_object.d
@@ -1,0 +1,6 @@
+void main()
+{
+    auto o = new Object;
+    destroy(o);
+    assert(o);
+}


### PR DESCRIPTION
Attempt to solve some of the bizarre situations we can get into when allocating a stack trace actually throws.

Also fix an issue where an object invariant will segfault if called on a destroyed object. e.g.:

```d
    Object o = new Object;
    destroy(o);
    assert(o); // would segfault, with this change it will now throw an assert error
```

Please pay close attention to the notes and way this is written. I tried to think of all cases, but possibly I missed some! This is a very tricky piece of code to write, because we are writing the framework upon which D exceptions are built, in D, which can end up using exceptions!

ping @ibuclaw would appreciate a review.