### PR TITLE
core.thread.osthread: Don't subtract suspend counter if thread has detached itself

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -1819,12 +1819,17 @@ extern (C) void thread_suspendAll() nothrow
         Thread.criticalRegionLock.lock_nothrow();
         scope (exit) Thread.criticalRegionLock.unlock_nothrow();
         size_t cnt;
+        bool suspendedSelf;
         Thread t = ThreadBase.sm_tbeg.toThread;
         while (t)
         {
             auto tn = t.next.toThread;
             if (suspend(t))
+            {
+                if (t is ThreadBase.getThis())
+                    suspendedSelf = true;
                 ++cnt;
+            }
             t = tn;
         }
 
@@ -1832,9 +1837,12 @@ extern (C) void thread_suspendAll() nothrow
         {}
         else version (Posix)
         {
-            // subtract own thread
+            // Subtract own thread if we called suspend() on ourselves.
+            // For example, suspendedSelf would be false if the current
+            // thread ran thread_detachThis().
             assert(cnt >= 1);
-            --cnt;
+            if (suspendedSelf)
+                --cnt;
             // wait for semaphore notifications
             for (; cnt; --cnt)
             {

--- a/druntime/test/gc/sentinel2.d
+++ b/druntime/test/gc/sentinel2.d
@@ -10,10 +10,6 @@ void main()
     // so that the pointer p will not be visible to the GC.
     auto t = new Thread({
         thread_detachThis();
-        // Keep reference to this thread object in a shared data address, because
-        // the thread-local pointer in druntime will not be visible to the GC either.
-        __gshared Thread threadobj;
-        threadobj = Thread.getThis();
 
         auto p = cast(ubyte*)GC.malloc(1);
         assert(p[-1] == 0xF4);


### PR DESCRIPTION
Fix FreeBSD failing test suite in master 2 (Electric Boogaloo)

More debugging done in #14754.