### PR TITLE
core.int128 alignment is adjusted

### DIFF
--- a/druntime/src/core/int128.d
+++ b/druntime/src/core/int128.d
@@ -18,8 +18,23 @@ alias I = long;
 alias U = ulong;
 enum Ubits = uint(U.sizeof * 8);
 
-version (X86_64) private enum Cent_alignment = 16;
-else             private enum Cent_alignment = (size_t.sizeof * 2);
+version (DigitalMars)
+{
+    /* The alignment should follow target.stackAlign(),
+     * which is `isXmmSupported() ? 16 : (is64bit ? 8 : 4)
+     */
+    version (D_SIMD)
+        private enum Cent_alignment = 16;
+    else version (X86_64)
+        private enum Cent_alignment = 8;
+    else
+        private enum Cent_alignment = 4;
+}
+else
+{
+    version (X86_64) private enum Cent_alignment = 16;
+    else             private enum Cent_alignment = (size_t.sizeof * 2);
+}
 
 align(Cent_alignment) struct Cent
 {


### PR DESCRIPTION
As alignment is now implemented per https://github.com/dlang/dmd/pull/14764 the code generated trying to align everything to 16 bytes when the stack is aligned to less is just terrible. I see no reason for alignment to be more than the stack alignment, so this changes the alignment of Cent to match the stack.