### PR TITLE
Fix Issue 23261 - druntime core.std.attribute.Tagged1_2 constructor i…

### DIFF
--- a/druntime/src/core/attribute.d
+++ b/druntime/src/core/attribute.d
@@ -236,9 +236,9 @@ version (UdaGNUAbiTag) struct gnuAbiTag
 {
     string[] tags;
 
-    this(string[] tags...)
+    this(string[] tags...) @safe pure nothrow
     {
-        this.tags = tags;
+        this.tags = tags.dup;
     }
 }
 


### PR DESCRIPTION
…s unsafe