### PR TITLE
ci: Update cirrus macOS image to M1-based runners

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,38 +82,32 @@ linux_task:
   << : *COMMON_STEPS_TEMPLATE
 
 # Mac
-macos12_task:
-  name: macOS 12.x x64, $TASK_NAME_SUFFIX
-  osx_instance:
-    image: monterey-xcode
+macos13_task:
+  name: macOS 13.x x64 (M1), $TASK_NAME_SUFFIX
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-xcode:latest
   timeout_in: 60m
   environment:
     OS_NAME: darwin
     # override Cirrus default OS (`darwin`)
     OS: osx
-    # 12 CPU cores and 24 GB of memory are available
-    N: 12
-    # FIXME: Temporarily use LDC until a release with a fix for issue 22942 is available (probably 2.101)
-    HOST_DMD: ldc
     matrix:
       - TASK_NAME_SUFFIX: DMD (latest)
       - TASK_NAME_SUFFIX: DMD (coverage)
         << : *COVERAGE_ENVIRONMENT_TEMPLATE
   << : *COMMON_STEPS_TEMPLATE
-macos11_task:
-  name: macOS 11.x x64, DMD (bootstrap)
-  osx_instance:
-    image: big-sur-xcode
+macos12_task:
+  name: macOS 12.x x64 (M1), DMD (bootstrap)
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:latest
   timeout_in: 60m
   environment:
     OS_NAME: darwin
     # override Cirrus default OS (`darwin`)
     OS: osx
-    # 12 CPU cores and 24 GB of memory are available
-    N: 12
     # de-facto bootstrap version on OSX
-    # See: https://forum.dlang.org/post/qfsgt2$1goc$1@digitalmars.com
-    HOST_DMD: dmd-2.088.0
+    # See: https://github.com/dlang/dmd/pull/13890
+    HOST_DMD: dmd-2.099.1
   << : *COMMON_STEPS_TEMPLATE
 
 # FreeBSD

--- a/compiler/test/Makefile
+++ b/compiler/test/Makefile
@@ -142,6 +142,11 @@ ifneq ($(N),)
     EXECUTE_RUNNER:=$(EXECUTE_RUNNER) --jobs=$N
 endif
 
+# Workaround https://issues.dlang.org/show_bug.cgi?id=23517
+ifeq (osx,$(OS))
+    export MACOSX_DEPLOYMENT_TARGET=11
+endif
+
 ifeq (windows,$(OS))
 all:
 	echo "Windows builds have been disabled"

--- a/druntime/test/common.mak
+++ b/druntime/test/common.mak
@@ -18,6 +18,11 @@ ifneq (default,$(MODEL))
 	MODEL_FLAG:=-m$(MODEL)
 endif
 CFLAGS_BASE:= $(MODEL_FLAG) $(PIC) -Wall
+ifeq (osx,$(OS))
+	ifeq (64,$(MODEL))
+		CFLAGS_BASE+=--target=x86_64-darwin-apple  # ARM cpu is not supported by dmd
+	endif
+endif
 DFLAGS:=$(MODEL_FLAG) $(PIC) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= -preview=dip1000 -L-lpthread -L-lm $(LINKDL)
 # LINK_SHARED may be set by importing makefile
 DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIMESO),-L$(DRUNTIME))


### PR DESCRIPTION
Intel-based runners have been removed. :-(