### PR TITLE
Add named arguments to struct literals

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -251,6 +251,14 @@ bool isDotOpDispatch(Expression e)
 /****************************************
  * Expand tuples in-place.
  *
+ * Example:
+ *     When there's a call `f(10, pair: AliasSeq!(20, 30), single: 40))`, the input is:
+ *         exps =  [10, (20, 30), 40]
+ *         names = [null, "pair", "single"]);
+ *     The arrays will be modified to:
+ *         exps =  [10, 20, 30, 40]
+ *         names = [null, "pair", null, "single"]);
+ *
  * Params:
  *     exps  = array of Expressions
  *     names = optional array of names corresponding to Expressions

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -265,7 +265,8 @@ extern (C++) void expandTuples(Expressions* exps, Identifiers* names = null)
     {
         if (exps.length != names.length)
         {
-            // Fixme: this branch should be removed when bugs are fixed.
+            // Fixme: this branch should be removed when CallExp rewrites
+            // (UFCS/operator overloading) are fixed to take named arguments into account
             names.setDim(exps.length);
             foreach (i; 0..exps.length)
                 (*names)[i] = null;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -5079,16 +5079,18 @@ extern (C++) final class DotTypeExp : UnaExp
 extern (C++) final class CallExp : UnaExp
 {
     Expressions* arguments; // function arguments
+    Identifiers* names;       // named argument identifiers
     FuncDeclaration f;      // symbol to call
     bool directcall;        // true if a virtual call is devirtualized
     bool inDebugStatement;  /// true if this was in a debug statement
     bool ignoreAttributes;  /// don't enforce attributes (e.g. call @gc function in @nogc code)
     VarDeclaration vthis2;  // container for multi-context
 
-    extern (D) this(const ref Loc loc, Expression e, Expressions* exps)
+    extern (D) this(const ref Loc loc, Expression e, Expressions* exps, Identifiers* names = null)
     {
         super(loc, EXP.call, __traits(classInstanceSize, CallExp), e);
         this.arguments = exps;
+        this.names = names;
     }
 
     extern (D) this(const ref Loc loc, Expression e)
@@ -5155,7 +5157,7 @@ extern (C++) final class CallExp : UnaExp
 
     override CallExp syntaxCopy()
     {
-        return new CallExp(loc, e1.syntaxCopy(), arraySyntaxCopy(arguments));
+        return new CallExp(loc, e1.syntaxCopy(), arraySyntaxCopy(arguments), names);
     }
 
     override bool isLvalue()

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -265,7 +265,10 @@ extern (C++) void expandTuples(Expressions* exps, Identifiers* names = null)
     {
         if (exps.length != names.length)
         {
-            names.setDim(exps.length); // REMOVE ME
+            // Fixme: this branch should be removed when bugs are fixed.
+            names.setDim(exps.length);
+            foreach (i; 0..exps.length)
+                (*names)[i] = null;
         }
         if (exps.length != names.length)
         {

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -45,7 +45,7 @@ typedef union tree_node Symbol;
 struct Symbol;          // back end symbol
 #endif
 
-void expandTuples(Expressions *exps);
+void expandTuples(Expressions *exps, Identifiers *names = nullptr);
 bool isTrivialExp(Expression *e);
 bool hasSideEffect(Expression *e, bool assumeImpureCalls = false);
 

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -826,6 +826,7 @@ class CallExp final : public UnaExp
 {
 public:
     Expressions *arguments;     // function arguments
+    Identifiers *names;
     FuncDeclaration *f;         // symbol to call
     bool directcall;            // true if a virtual call is devirtualized
     bool inDebugStatement;      // true if this was in a debug statement

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4632,7 +4632,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         (size_t i, Type t) => (*exp.arguments)[i],
                         i => (*exp.arguments)[i].loc
                     );
+                    if (!resolvedArgs)
+                    {
+                        result = ErrorExp.get();
+                        return;
+                    }
                 }
+
                 Expression e = new StructLiteralExp(exp.loc, sd, resolvedArgs, exp.e1.type);
                 e = e.expressionSemantic(sc);
                 result = e;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4624,7 +4624,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 /* It's a struct literal
                  */
             Lx:
-                Expression e = new StructLiteralExp(exp.loc, sd, exp.arguments, exp.e1.type);
+                Expressions* resolvedArgs = exp.arguments;
+                if (exp.names)
+                {
+                    resolvedArgs = resolveStructLiteralNamedArgs(sd, exp.e1.type, sc, exp.loc,
+                        (*exp.names)[],
+                        (size_t i, Type t) => (*exp.arguments)[i],
+                        i => (*exp.arguments)[i].loc
+                    );
+                }
+                Expression e = new StructLiteralExp(exp.loc, sd, resolvedArgs, exp.e1.type);
                 e = e.expressionSemantic(sc);
                 result = e;
                 return;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -651,6 +651,9 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
     if (!ce.arguments)
         ce.arguments = new Expressions();
     ce.arguments.shift(eleft);
+    if (!ce.names)
+        ce.names = new Identifiers();
+    ce.names.shift(null);
 
     return null;
 }
@@ -1629,12 +1632,12 @@ private Expression rewriteOpAssign(BinExp exp)
  * Returns:
  *      true    a semantic error occurred
  */
-private bool preFunctionParameters(Scope* sc, Expressions* exps, const bool reportErrors = true)
+private bool preFunctionParameters(Scope* sc, Identifiers* names, Expressions* exps, const bool reportErrors = true)
 {
     bool err = false;
     if (exps)
     {
-        expandTuples(exps);
+        expandTuples(exps, names);
 
         for (size_t i = 0; i < exps.length; i++)
         {
@@ -3549,7 +3552,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             return setError();
         }
-        if (preFunctionParameters(sc, exp.arguments))
+        if (preFunctionParameters(sc, /*names*/ null, exp.arguments))
         {
             return setError();
         }
@@ -4287,7 +4290,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (FuncExp fe = exp.e1.isFuncExp())
         {
             if (arrayExpressionSemantic(exp.arguments.peekSlice(), sc) ||
-                preFunctionParameters(sc, exp.arguments))
+                preFunctionParameters(sc, exp.names, exp.arguments))
                 return setError();
 
             // Run e1 semantic even if arguments have any errors
@@ -4526,7 +4529,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         if (arrayExpressionSemantic(exp.arguments.peekSlice(), sc) ||
-            preFunctionParameters(sc, exp.arguments))
+            preFunctionParameters(sc, exp.names, exp.arguments))
             return setError();
 
         // Check for call operator overload

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6874,7 +6874,7 @@ public:
     void accept(Visitor* v) override;
 };
 
-extern void expandTuples(Array<Expression* >* exps);
+extern void expandTuples(Array<Expression* >* exps, Array<Identifier* >* names = nullptr);
 
 struct UnionExp final
 {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7422,6 +7422,7 @@ class CallExp final : public UnaExp
 {
 public:
     Array<Expression* >* arguments;
+    Array<Identifier* >* names;
     FuncDeclaration* f;
     bool directcall;
     bool inDebugStatement;

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1435,11 +1435,12 @@ Params:
     names = identifiers passed in argument list, `null` entries for positional arguments
     getExp = function that, given an index into `names` and destination type, returns the initializing expression
     getLoc = function that, given an index into `names`, returns a location for error messages
+
 Returns: list of expressions ordered to the struct's fields, or `null` on error
 */
-Expressions* resolveStructLiteralNamedArgs(
-    StructDeclaration sd, Type t, Scope* sc, Loc iloc, Identifier[] names,
-    scope Expression delegate(size_t i, Type fieldType) getExp, scope Loc delegate(size_t i) getLoc
+Expressions* resolveStructLiteralNamedArgs(StructDeclaration sd, Type t, Scope* sc,
+    Loc iloc, Identifier[] names, scope Expression delegate(size_t i, Type fieldType) getExp,
+    scope Loc delegate(size_t i) getLoc
 )
 {
     //expandTuples for non-identity arguments?

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1429,7 +1429,7 @@ resolve it to a list of expressions to construct a `StructLiteralExp`.
 
 Params:
     sd = struct
-    t = type of struct (potentially including qualifiers such as `const` `immutable`)
+    t = type of struct (potentially including qualifiers such as `const` or `immutable`)
     sc = scope of the expression initializing the struct
     iloc = location of expression initializing the struct
     names = identifiers passed in argument list, `null` entries for positional arguments

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1458,8 +1458,7 @@ Expressions* resolveStructLiteralNamedArgs(
         const argLoc = getLoc(j);
         if (id)
         {
-            /* Determine `fieldi` that `id` matches
-                */
+            // Determine `fieldi` that `id` matches
             Dsymbol s = sd.search(iloc, id);
             if (!s)
             {

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1524,6 +1524,11 @@ Expressions* resolveStructLiteralNamedArgs(StructDeclaration sd, Type t, Scope* 
             if (vd.isOverlappedWith(v2) && elems[k])
             {
                 error(elems[k].loc, "overlapping initialization for field `%s` and `%s`", v2.toChars(), vd.toChars());
+                enum errorMsg = "`struct` initializers that contain anonymous unions" ~
+                    " must initialize only the first member of a `union`. All subsequent" ~
+                    " non-overlapping fields are default initialized";
+                if (!sd.isUnionDeclaration())
+                    .errorSupplemental(elems[k].loc, errorMsg);
                 errors = true;
                 continue;
             }

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -1485,9 +1485,15 @@ Expressions* resolveStructLiteralNamedArgs(StructDeclaration sd, Type t, Scope* 
                     break;
             }
         }
+        if (nfields == 0)
+        {
+            error(argLoc, "initializer provided for struct `%s` with no fields", sd.toChars());
+            return null;
+        }
         if (j >= nfields)
         {
-            error(argLoc, "too many initializers for `%s`", sd.toChars());
+            error(argLoc, "too many initializers for `%s` with %d field%s", sd.toChars(),
+                cast(int) nfields, nfields != 1 ? "s".ptr : "".ptr);
             return null;
         }
 

--- a/compiler/test/compilable/named_argumens_struct.d
+++ b/compiler/test/compilable/named_argumens_struct.d
@@ -1,8 +1,8 @@
 
 struct S
 {
-	string name;
-	int x;
+    string name;
+    int x;
     int y;
 }
 
@@ -15,8 +15,8 @@ static assert(s.name == "boo");
 
 union U
 {
-	float f;
-	int i;
+    float f;
+    int i;
 }
 
 immutable U u = U(i: 2);

--- a/compiler/test/compilable/named_argumens_struct.d
+++ b/compiler/test/compilable/named_argumens_struct.d
@@ -1,0 +1,24 @@
+
+struct S
+{
+	string name;
+	int x;
+    int y;
+}
+
+
+immutable S s = S(x: 2, 3, name: "boo");
+
+static assert(s.x == 2);
+static assert(s.y == 3);
+static assert(s.name == "boo");
+
+union U
+{
+	float f;
+	int i;
+}
+
+immutable U u = U(i: 2);
+
+static assert(u.i == 2);

--- a/compiler/test/fail_compilation/diag11132.d
+++ b/compiler/test/fail_compilation/diag11132.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag11132.d(22): Error: overlapping initialization for field `a` and `b`
+fail_compilation/diag11132.d(23): Error: overlapping initialization for field `a` and `b`
+fail_compilation/diag11132.d(23):        `struct` initializers that contain anonymous unions must initialize only the first member of a `union`. All subsequent non-overlapping fields are default initialized
 ---
 */
 

--- a/compiler/test/fail_compilation/fail155.d
+++ b/compiler/test/fail_compilation/fail155.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail155.d(19): Error: overlapping initialization for field `x` and `y`
+fail_compilation/fail155.d(20): Error: overlapping initialization for field `x` and `y`
+fail_compilation/fail155.d(20):        `struct` initializers that contain anonymous unions must initialize only the first member of a `union`. All subsequent non-overlapping fields are default initialized
 ---
 */
 

--- a/compiler/test/fail_compilation/fail155.d
+++ b/compiler/test/fail_compilation/fail155.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail155.d(20): Error: overlapping initialization for `y`
-fail_compilation/fail155.d(20):        `struct` initializers that contain anonymous unions must initialize only the first member of a `union`. All subsequent non-overlapping fields are default initialized
+fail_compilation/fail155.d(19): Error: overlapping initialization for field `x` and `y`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail156.d
+++ b/compiler/test/fail_compilation/fail156.d
@@ -2,10 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail156.d(35): Error: overlapping initialization for `y`
-fail_compilation/fail156.d(35):        `struct` initializers that contain anonymous unions must initialize only the first member of a `union`. All subsequent non-overlapping fields are default initialized
-fail_compilation/fail156.d(42): Error: overlapping initialization for `y`
-fail_compilation/fail156.d(42):        `struct` initializers that contain anonymous unions must initialize only the first member of a `union`. All subsequent non-overlapping fields are default initialized
+fail_compilation/fail156.d(33): Error: overlapping initialization for field `x` and `y`
+fail_compilation/fail156.d(40): Error: overlapping initialization for field `x` and `y`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail156.d
+++ b/compiler/test/fail_compilation/fail156.d
@@ -2,8 +2,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail156.d(33): Error: overlapping initialization for field `x` and `y`
-fail_compilation/fail156.d(40): Error: overlapping initialization for field `x` and `y`
+fail_compilation/fail156.d(35): Error: overlapping initialization for field `x` and `y`
+fail_compilation/fail156.d(35):        `struct` initializers that contain anonymous unions must initialize only the first member of a `union`. All subsequent non-overlapping fields are default initialized
+fail_compilation/fail156.d(42): Error: overlapping initialization for field `x` and `y`
+fail_compilation/fail156.d(42):        `struct` initializers that contain anonymous unions must initialize only the first member of a `union`. All subsequent non-overlapping fields are default initialized
 ---
 */
 

--- a/compiler/test/fail_compilation/fail158.d
+++ b/compiler/test/fail_compilation/fail158.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail158.d(17): Error: more initializers than fields (2) of `S`
+fail_compilation/fail158.d(17): Error: too many initializers for `S`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail158.d
+++ b/compiler/test/fail_compilation/fail158.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail158.d(17): Error: too many initializers for `S`
+fail_compilation/fail158.d(17): Error: too many initializers for `S` with 2 fields
 ---
 */
 

--- a/compiler/test/fail_compilation/fail22570.d
+++ b/compiler/test/fail_compilation/fail22570.d
@@ -3,8 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22570.d(19): Error: too many initializers for `S`
-fail_compilation/fail22570.d(20): Error: too many initializers for `S`
+fail_compilation/fail22570.d(19): Error: too many initializers for `S` with 1 field
+fail_compilation/fail22570.d(20): Error: too many initializers for `S` with 1 field
 ---
 */
 

--- a/compiler/test/fail_compilation/fail22570.d
+++ b/compiler/test/fail_compilation/fail22570.d
@@ -3,8 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22570.d(19): Error: more initializers than fields (1) of `S`
-fail_compilation/fail22570.d(20): Error: more initializers than fields (1) of `S`
+fail_compilation/fail22570.d(19): Error: too many initializers for `S`
+fail_compilation/fail22570.d(20): Error: too many initializers for `S`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail299.d
+++ b/compiler/test/fail_compilation/fail299.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail299.d(14): Error: more initializers than fields (0) of `Foo`
+fail_compilation/fail299.d(14): Error: too many initializers for `Foo`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail299.d
+++ b/compiler/test/fail_compilation/fail299.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail299.d(14): Error: too many initializers for `Foo`
+fail_compilation/fail299.d(14): Error: initializer provided for struct `Foo` with no fields
 ---
 */
 

--- a/compiler/test/fail_compilation/named_arguments_parse.d
+++ b/compiler/test/fail_compilation/named_arguments_parse.d
@@ -1,0 +1,15 @@
+/**
+TEST_OUTPUT:
+---
+fail_compilation/named_arguments_parse.d(10): Error: named arguments not allowed here
+fail_compilation/named_arguments_parse.d(13): Error: named arguments not allowed here
+fail_compilation/named_arguments_parse.d(14): Error: named arguments not allowed here
+---
+*/
+
+@(attribute: 3)
+void main()
+{
+	mixin(thecode: "{}");
+	pragma(msg, themsg: "hello");
+}

--- a/compiler/test/fail_compilation/test20998.d
+++ b/compiler/test/fail_compilation/test20998.d
@@ -6,7 +6,7 @@ TEST_OUTPUT:
 fail_compilation/test20998.d(76): Error: undefined identifier `invalid`
 X x = { invalid, 2, "asd" };
         ^
-fail_compilation/test20998.d(76): Error: too many initializers for `X`
+fail_compilation/test20998.d(76): Error: too many initializers for `X` with 2 fields
 X x = { invalid, 2, "asd" };
                     ^
 fail_compilation/test20998.d(83): Error: cannot implicitly convert expression `"a"` of type `string` to `int`
@@ -15,7 +15,7 @@ X2 x2 = { ptr: null, "a", ptr: 2, 444 };
 fail_compilation/test20998.d(83): Error: duplicate initializer for field `ptr`
 X2 x2 = { ptr: null, "a", ptr: 2, 444 };
                                ^
-fail_compilation/test20998.d(83): Error: too many initializers for `X2`
+fail_compilation/test20998.d(83): Error: too many initializers for `X2` with 3 fields
 X2 x2 = { ptr: null, "a", ptr: 2, 444 };
                                   ^
 fail_compilation/test20998.d(90): Error: overlapping initialization for field `ptr` and `x`
@@ -27,7 +27,7 @@ X3 x3 = { ptr: null, "a", ptr: 2, 444 };
 fail_compilation/test20998.d(90): Error: duplicate initializer for field `ptr`
 X3 x3 = { ptr: null, "a", ptr: 2, 444 };
                                ^
-fail_compilation/test20998.d(90): Error: too many initializers for `X3`
+fail_compilation/test20998.d(90): Error: too many initializers for `X3` with 3 fields
 X3 x3 = { ptr: null, "a", ptr: 2, 444 };
                                   ^
 fail_compilation/test20998.d(98): Error: field `X4.ptr` cannot assign to misaligned pointers in `@safe` code
@@ -36,7 +36,7 @@ fail_compilation/test20998.d(98): Error: field `X4.ptr` cannot assign to misalig
 fail_compilation/test20998.d(98): Error: cannot implicitly convert expression `"a"` of type `string` to `int`
     X4 x4 = { ptr: null, "a", 444, ptr: 2, true };
                          ^
-fail_compilation/test20998.d(98): Error: too many initializers for `X4`
+fail_compilation/test20998.d(98): Error: too many initializers for `X4` with 2 fields
     X4 x4 = { ptr: null, "a", 444, ptr: 2, true };
                               ^
 fail_compilation/test20998.d(102):        called from here: `test()`
@@ -51,16 +51,16 @@ X2 a5 = { ptr: 1, ptr: 2, ptr: 444, ptr: 555 };
 fail_compilation/test20998.d(104): Error: duplicate initializer for field `ptr`
 X2 a5 = { ptr: 1, ptr: 2, ptr: 444, ptr: 555 };
                                ^
-fail_compilation/test20998.d(104): Error: too many initializers for `X2`
+fail_compilation/test20998.d(104): Error: too many initializers for `X2` with 3 fields
 X2 a5 = { ptr: 1, ptr: 2, ptr: 444, ptr: 555 };
                                          ^
-fail_compilation/test20998.d(107): Error: too many initializers for `X2`
+fail_compilation/test20998.d(107): Error: too many initializers for `X2` with 3 fields
 X2 c6 = { null, 2, true, null };
                          ^
 fail_compilation/test20998.d(116): Error: cannot implicitly convert expression `1` of type `int` to `immutable(char*)`
     immutable Struct iStruct = {1, &ch};
                                 ^
-fail_compilation/test20998.d(116): Error: too many initializers for `Struct`
+fail_compilation/test20998.d(116): Error: too many initializers for `Struct` with 1 field
     immutable Struct iStruct = {1, &ch};
                                    ^
 fail_compilation/test20998.d(120):        called from here: `test2()`


### PR DESCRIPTION
Best reviewed per commit, because the big copy-paste [Move out resolveStructLiteralNamedArgs](https://github.com/dlang/dmd/commit/0ed0a218490ed44229243cbad5a562dd4213aa54) does not give a pleasant diff.

- Add named argument parsing. This time with a separate `Array!Identifier` instead of a `NamedArgExp`, which was disliked in https://github.com/dlang/dmd/pull/14475
- Make initsem of `StructInitializer` re-usable 
- Use the logic in expsemantic of a `CallExp` on a constructor-less struct

This PR does not do function calls / constructors, that's https://github.com/dlang/dmd/pull/14575, which is stalled because checking which of two overloads is more specialized still needs to be adjusted for named parameters.

I haven't started on named template arguments.

