### PR TITLE
Fix Issue 19649 - Misleading error for duplicate constraints

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -2420,7 +2420,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         tf = tf.addSTC(stc);
 
         auto f = new AST.CtorDeclaration(loc, Loc.initial, stc, tf);
-        AST.Dsymbol s = parseContracts(f);
+        AST.Dsymbol s = parseContracts(f, !!tpl);
         if (udas)
         {
             auto a = new AST.Dsymbols();
@@ -4571,7 +4571,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     pAttrs.storageClass = STC.undefined_;
                 if (tpl)
                     constraint = parseConstraint();
-                AST.Dsymbol s = parseContracts(f);
+                AST.Dsymbol s = parseContracts(f, !!tpl);
                 auto tplIdent = s.ident;
 
                 if (link != linkage)
@@ -5157,7 +5157,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     /*****************************************
      * Parse contracts following function declaration.
      */
-    private AST.FuncDeclaration parseContracts(AST.FuncDeclaration f)
+    private AST.FuncDeclaration parseContracts(AST.FuncDeclaration f, bool isTemplateFunction = false)
     {
         LINK linksave = linkage;
 
@@ -5329,7 +5329,12 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 else if (t == TOK.at)
                     error("attributes cannot be placed after a template constraint");
                 else if (t == TOK.if_)
-                    error("cannot use function constraints for non-template functions. Use `static if` instead");
+                {
+                    if (isTemplateFunction)
+                        error("template constraint must follow parameter lists and attributes");
+                    else
+                        error("cannot use function constraints for non-template functions. Use `static if` instead");
+                }
                 else
                     error("semicolon expected following function declaration");
             }

--- a/compiler/test/fail_compilation/fnconstraint.d
+++ b/compiler/test/fail_compilation/fnconstraint.d
@@ -1,0 +1,25 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fnconstraint.d(13): Error: template constraint must follow parameter lists and attributes
+fail_compilation/fnconstraint.d(13): Error: declaration expected, not `if`
+fail_compilation/fnconstraint.d(22): Error: template constraint must follow parameter lists and attributes
+fail_compilation/fnconstraint.d(22): Error: declaration expected, not `if`
+fail_compilation/fnconstraint.d(26): Error: `}` expected following members in `struct` declaration at fail_compilation/fnconstraint.d(18)
+---
+*/
+void foo()()
+in(true)
+if (true)
+{}
+
+alias f = foo!();
+
+struct S
+{
+    this()()
+    if (true)
+    if (true) {}
+}
+
+S s;


### PR DESCRIPTION
Error also helps when constraint follows contract (which is not allowed by the grammar).
Also applies to template constructors.