### PR TITLE
runnable/issue22854.d: Reduce code expansion to speed up testsuite

### DIFF
--- a/compiler/test/runnable/issue22854.d
+++ b/compiler/test/runnable/issue22854.d
@@ -2,12 +2,12 @@
 void main()
 {
     uint loops = 0;
-    static foreach (i; 0 .. 50)
+    static foreach (i; 0 .. 5)
     {
         static foreach (ch; SomeContainer().range)
             loops++;
     }
-    assert(loops == 50 * 50);
+    assert(loops == 5 * 5);
 }
 
 struct SomeContainer
@@ -20,7 +20,7 @@ struct TypeWithDestructor { ~this() { } }
 
 struct SomeRange
 {
-    int count = 50;
+    int count = 5;
     int front() { return count; }
     bool empty() { return count <= 0; }
     void popFront() { count--; }


### PR DESCRIPTION
Because the dmd backend optimizer is really, really, really slow (https://issues.dlang.org/show_bug.cgi?id=7157).