### PR TITLE
Fix Issue 23597 - .di files not compatible with -i

### DIFF
--- a/compiler/src/dmd/compiler.d
+++ b/compiler/src/dmd/compiler.d
@@ -142,7 +142,7 @@ extern (C++) struct Compiler
      */
     extern(C++) static bool onImport(Module m)
     {
-        if (includeImports)
+        if (includeImports && m.filetype == FileType.d)
         {
             if (includeImportedModuleCheck(ModuleComponentRange(
                 m.md ? m.md.packages : [], m.ident, m.isPackageFile)))

--- a/compiler/test/compilable/imports/test23597.di
+++ b/compiler/test/compilable/imports/test23597.di
@@ -1,0 +1,3 @@
+module imports.test23597;
+
+void fun()() {}

--- a/compiler/test/compilable/issue23597.d
+++ b/compiler/test/compilable/issue23597.d
@@ -1,0 +1,7 @@
+/**
+PERMUTE_ARGS: -i
+LINK:
+**/
+import imports.test23597;
+
+void main() { fun(); }


### PR DESCRIPTION
Makes `.di` files more useful for e.g. [Deimos projects](https://github.com/D-Programming-Deimos/ncurses/pull/45).