### PR TITLE
[dsymbolsem] Fix error punctuation (part 3)

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -856,7 +856,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 {
                 }
                 else
-                    dsym.error("default construction is disabled for type `%s`", dsym.type.toChars());
+                    dsym.error("- default construction is disabled for type `%s`", dsym.type.toChars());
             }
         }
 
@@ -911,7 +911,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (dsym._init)
         { } // remember we had an explicit initializer
         else if (dsym.storage_class & STC.manifest)
-            dsym.error("manifest constants must have initializers");
+            dsym.error("- manifest constants must have initializers");
 
         // Don't allow non-extern, non-__gshared variables to be interfaced with C++
         if (dsym._linkage == LINK.cpp && !(dsym.storage_class & (STC.ctfe | STC.extern_ | STC.gshared)) && dsym.isDataseg())
@@ -939,7 +939,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             //printf("Providing default initializer for '%s'\n", dsym.toChars());
             if (sz == SIZE_INVALID && dsym.type.ty != Terror)
-                dsym.error("size of type `%s` is invalid", dsym.type.toChars());
+                dsym.error("- size of type `%s` is invalid", dsym.type.toChars());
 
             Type tv = dsym.type;
             while (tv.ty == Tsarray)    // Don't skip Tenum

--- a/compiler/test/fail_compilation/diag10099.d
+++ b/compiler/test/fail_compilation/diag10099.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10099.d(15): Error: variable `diag10099.main.s` default construction is disabled for type `S`
+fail_compilation/diag10099.d(15): Error: variable `diag10099.main.s` - default construction is disabled for type `S`
 ---
 */
 

--- a/compiler/test/fail_compilation/enum9921.d
+++ b/compiler/test/fail_compilation/enum9921.d
@@ -3,9 +3,11 @@ TEST_OUTPUT:
 ---
 fail_compilation/enum9921.d(9): Error: enum `enum9921.X` base type must not be `void`
 fail_compilation/enum9921.d(11): Error: enum `enum9921.Z` base type must not be `void`
+fail_compilation/enum9921.d(13): Error: variable `enum9921.x` - manifest constants must have initializers
 ---
 */
-
 enum X : void;
 
 enum Z : void { Y };
+
+enum int x;

--- a/compiler/test/fail_compilation/fail10102.d
+++ b/compiler/test/fail_compilation/fail10102.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10102.d(48): Error: variable `fail10102.main.m` default construction is disabled for type `NotNull!(int*)`
-fail_compilation/fail10102.d(49): Error: variable `fail10102.main.a` default construction is disabled for type `NotNull!(int*)[3]`
+fail_compilation/fail10102.d(48): Error: variable `fail10102.main.m` - default construction is disabled for type `NotNull!(int*)`
+fail_compilation/fail10102.d(49): Error: variable `fail10102.main.a` - default construction is disabled for type `NotNull!(int*)[3]`
 fail_compilation/fail10102.d(50): Error: default construction is disabled for type `NotNull!(int*)`
 fail_compilation/fail10102.d(51): Error: field `S.m` must be initialized because it has no default constructor
 ---

--- a/compiler/test/fail_compilation/test17451.d
+++ b/compiler/test/fail_compilation/test17451.d
@@ -2,7 +2,7 @@
 ---
 fail_compilation/test17451.d(22): Error: undefined identifier `allocator`
 fail_compilation/test17451.d(23): Error: `false` has no effect
-fail_compilation/test17451.d(30): Error: variable `test17451.HashMap!(ThreadSlot).HashMap.__lambda2.v` size of type `ThreadSlot` is invalid
+fail_compilation/test17451.d(30): Error: variable `test17451.HashMap!(ThreadSlot).HashMap.__lambda2.v` - size of type `ThreadSlot` is invalid
 fail_compilation/test17451.d(44): Error: template instance `test17451.HashMap!(ThreadSlot)` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/test20719.d
+++ b/compiler/test/fail_compilation/test20719.d
@@ -1,7 +1,7 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/test20719.d(13): Error: struct `test20719.SumType` no size because of forward reference
-fail_compilation/test20719.d(32): Error: variable `test20719.isCopyable!(SumType).__lambda2.foo` size of type `SumType` is invalid
+fail_compilation/test20719.d(32): Error: variable `test20719.isCopyable!(SumType).__lambda2.foo` - size of type `SumType` is invalid
 fail_compilation/test20719.d(18): Error: template instance `test20719.isCopyable!(SumType)` error instantiating
 ---
 */


### PR DESCRIPTION
Also add test for "manifest constants must have initializers" error.