### PR TITLE
fix Issue 18026 - Stack overflow in dmd/dtemplate.d:6248, TemplateInstance::needsCodegen()

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -6303,10 +6303,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 else if (!minst && tnext.minst)
                 {
                     minst = tnext.minst; // cache result from non-speculative sibling
-                    return false;
+                    // continue searching
                 }
-                else if (needsCodegen != ThreeState.none)
-                    break;
             }
 
             // Elide codegen because there's no instantiation from any root modules.
@@ -6373,10 +6371,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     else if (!minst)
                     {
                         minst = tnext.minst; // cache result from non-speculative sibling
-                        return true;
+                        // continue searching
                     }
-                    else if (needsCodegen != ThreeState.none)
-                        break;
                 }
             }
 

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -6305,6 +6305,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     minst = tnext.minst; // cache result from non-speculative sibling
                     // continue searching
                 }
+                else if (needsCodegen != ThreeState.none)
+                    break;
             }
 
             // Elide codegen because there's no instantiation from any root modules.
@@ -6373,6 +6375,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                         minst = tnext.minst; // cache result from non-speculative sibling
                         // continue searching
                     }
+                    else if (needsCodegen != ThreeState.none)
+                        break;
                 }
             }
 

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -6261,6 +6261,9 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             return false;
         }
 
+        // This should only be called on the primary instantiation.
+        assert(this is inst || inst is null);
+
         if (global.params.allInst)
         {
             // Do codegen if there is an instantiation from a root module, to maximize link-ability.
@@ -6271,6 +6274,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     return ThreeState.yes;
 
                 // Do codegen if the ancestor needs it.
+                if (tinst && tinst.inst && tinst !is tinst.inst)
+                    tinst = tinst.inst;
                 if (tinst && tinst.needsCodegen())
                 {
                     tithis.minst = tinst.minst; // cache result
@@ -6333,6 +6338,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 // 2. elide codegen if the ancestor doesn't need it (non-root instantiation of ancestor incl. subtree)
                 if (tinst)
                 {
+                    if (tinst.inst && tinst !is tinst.inst)
+                        tinst = tinst.inst;
                     const needsCodegen = tinst.needsCodegen(); // sets tinst.minst
                     if (tinst.minst) // not speculative
                     {

--- a/compiler/test/compilable/test18026.d
+++ b/compiler/test/compilable/test18026.d
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=18026
+bool f(T)(T x)
+{
+    return false;
+}
+
+static foreach(i; 0..60000)
+{
+    static if(f(i))
+    {
+    }
+}


### PR DESCRIPTION
:warning: Please think about this change very carefully (i.e: more than 15 minutes) as it touches a pretty critical routine. :warning: 

This is best reviewed with whitespace changes hidden. https://github.com/dlang/dmd/pull/14787/files?w=1


**Problem**: `needsCodegen` calls itself recursively, this results in a stack overflow when checking an instance that has a sufficient number of siblings, or is lexically nested deep enough in other template instances, or a quadratic combination of both.

**To solve**: I have isolated the _meat_ of the needsCodegen algorithm (there are two; (1) for `-allinst`, (2) for the default emission strategy).  Then, the recursive call for instance siblings has been replaced with a `for` loop.

How was the "meat" determined?

1. The first check is done on the "main" template instance (stored in the `tempdecl.instances` AA), which is the same for every sibling.  No need to check this repeatedly, so we leave this block alone and save some processing time as well.
https://github.com/dlang/dmd/blob/fc695ff8ebd7171c18bfda3b5241be3ca4808c05/compiler/src/dmd/dtemplate.d#L6258-L6262

2. The `tnext` branch in both the default and allinst emission strategies are there for **caching** the result of `needsCodegen` only.  They can be part of the `for` loop body, no need to include them in the nested function.
https://github.com/dlang/dmd/blob/fc695ff8ebd7171c18bfda3b5241be3ca4808c05/compiler/src/dmd/dtemplate.d#L6282-L6296
https://github.com/dlang/dmd/blob/fc695ff8ebd7171c18bfda3b5241be3ca4808c05/compiler/src/dmd/dtemplate.d#L6339-L6356

3. Everything **between** (1) and (2) then is the part of the algorithm used to detect whether codegen is required.  These have been moved into static nested functions named `needsCodegenAllInst` (returns `false` if no condition hit).
https://github.com/dlang/dmd/blob/fc695ff8ebd7171c18bfda3b5241be3ca4808c05/compiler/src/dmd/dtemplate.d#L6268-L6279
and `needsCodegenRootOnly` (returns `true` if no condition hit).
https://github.com/dlang/dmd/blob/fc695ff8ebd7171c18bfda3b5241be3ca4808c05/compiler/src/dmd/dtemplate.d#L6322-L6336

4. There is a case to handle in `needsCodegenRootOnly` for when the `needsCodegen` variable is `true` - meaning "do codegen if the ancestor needs it".  For this, the `tnext` of the instance is set to `null` so that no siblings (or further siblings) are checked.

---

There is still recursive checking done for parents (`tinst`) of the template instance, so the possibility for a stack overflow is still present if we are handling a deeply nested instance (as in, 100,000+ levels of lexical nestedness).  I'm willing to leave that risk in until someone presents a reasonable example which triggers that.

Are there any cases that I might have missed here? Do we need to check `tnext.errors` on every sibling too?