### PR TITLE
fix Issue 20101 - BetterC: Template instantiation in CTFE only contex…

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -6247,6 +6247,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
      */
     final bool needsCodegen()
     {
+        //printf("needsCodegen() %s\n", toChars());
+
         // minst is finalized after the 1st invocation.
         // tnext and tinst are only needed for the 1st invocation and
         // cleared for further invocations.

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -6296,7 +6296,7 @@ Lagain:
     if (r == RTLSYM.MEMSET8 ||
         r == RTLSYM.MEMSET16 ||
         r == RTLSYM.MEMSET32 ||
-	r == RTLSYM.MEMSET64)
+        r == RTLSYM.MEMSET64)
     {
         elem *e = el_param(edim, evalue);
         return el_bin(OPmemset,TYnptr,eptr,e);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -105,6 +105,8 @@ bool expressionsToString(ref OutBuffer buf, Scope* sc, Expressions* exps)
         if (!ex)
             continue;
         auto sc2 = sc.startCTFE();
+        sc2.tinst = null;
+        sc2.minst = null;       // prevents emission of any instantiated templates to object file
         auto e2 = ex.expressionSemantic(sc2);
         auto e3 = resolveProperties(sc2, e2);
         sc2.endCTFE();

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -281,7 +281,7 @@ void write_instance_pointers(Type type, Symbol *s, uint offset)
 
 void toObjFile(Dsymbol ds, bool multiobj)
 {
-    //printf("toObjFile(%s)\n", ds.toChars());
+    //printf("toObjFile(%s %s)\n", ds.kind(), ds.toChars());
 
     bool isCfile = ds.isCsymbol();
 

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1676,7 +1676,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             uint errors = global.startGagging();
             Scope* sc2 = sc.push();
             sc2.tinst = null;
-            sc2.minst = null;
+            sc2.minst = null;   // this is why code for these are not emitted to object file
             sc2.flags = (sc.flags & ~(SCOPE.ctfe | SCOPE.condition)) | SCOPE.compile | SCOPE.fullinst;
 
             bool err = false;

--- a/compiler/test/compilable/test20201.d
+++ b/compiler/test/compilable/test20201.d
@@ -1,0 +1,16 @@
+/* REQUIRED_ARGS: -betterC
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=20101
+
+public string ctfeHelper()(string a)
+{
+    return "int " ~ a ~ " = 42;";
+}
+
+extern(C) int main()
+{
+    int b = __traits(compiles, ctfeHelper("a"));
+    mixin(ctfeHelper("a"));
+    return !(a + b);
+}


### PR DESCRIPTION
…t should skip codegen

The code that determines what is "compile only" or not is a mess. Took me a while to figure out what knob to turn.