### PR TITLE
core.sys.posix.sys.stat: Fix duplicate definition of __mode_t on Musl

### DIFF
--- a/druntime/src/core/sys/posix/sys/stat.d
+++ b/druntime/src/core/sys/posix/sys/stat.d
@@ -1656,7 +1656,6 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    alias __mode_t = uint;
     enum {
         S_IRUSR    = 0x100, // octal 0400
         S_IWUSR    = 0x080, // octal 0200


### PR DESCRIPTION
The definition was conflicting with the other definitions within the same file.