### PR TITLE
ImportC better error message for __int128

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -286,6 +286,7 @@ final class CParser(AST) : Parser!AST
         case TOK.int16:
         case TOK.int32:
         case TOK.int64:
+        case TOK.__int128:
         case TOK.float32:
         case TOK.float64:
         case TOK.signed:
@@ -2183,6 +2184,7 @@ final class CParser(AST) : Parser!AST
             ximaginary = 0x8000,
             xcomplex   = 0x10000,
             x_Atomic   = 0x20000,
+            xint128    = 0x40000,
         }
 
         AST.Type t;
@@ -2227,6 +2229,7 @@ final class CParser(AST) : Parser!AST
                 case TOK.int16:      tkwx = TKW.xshort;     break;
                 case TOK.int32:      tkwx = TKW.xint;       break;
                 case TOK.int64:      tkwx = TKW.xlong;      break;
+                case TOK.__int128:   tkwx = TKW.xint128;    break;
                 case TOK.float32:    tkwx = TKW.xfloat;     break;
                 case TOK.float64:    tkwx = TKW.xdouble;    break;
                 case TOK.void_:      tkwx = TKW.xvoid;      break;
@@ -2504,6 +2507,11 @@ final class CParser(AST) : Parser!AST
 
             case TKW.xunsigned | TKW.xllong | TKW.xint:
             case TKW.xunsigned | TKW.xllong:     t = unsignedTypeForSize(long_longsize); break;
+
+            case TKW.xint128:
+            case TKW.xsigned | TKW.xint128:     t = integerTypeForSize(16); break;
+
+            case TKW.xunsigned | TKW.xint128:   t = unsignedTypeForSize(16); break;
 
             case TKW.xvoid:                     t = AST.Type.tvoid; break;
             case TKW.xbool:                     t = boolsize == 1 ? AST.Type.tbool : integerTypeForSize(boolsize); break;
@@ -3270,6 +3278,7 @@ final class CParser(AST) : Parser!AST
             case TOK._Complex:
             case TOK._Thread_local:
             case TOK.int32:
+            case TOK.__int128:
             case TOK.char_:
             case TOK.float32:
             case TOK.float64:
@@ -3940,6 +3949,7 @@ final class CParser(AST) : Parser!AST
                 case TOK.int16:
                 case TOK.int32:
                 case TOK.int64:
+                case TOK.__int128:
                 case TOK.float32:
                 case TOK.float64:
                 case TOK.signed:
@@ -4304,6 +4314,7 @@ final class CParser(AST) : Parser!AST
                 case TOK.int16:
                 case TOK.int32:
                 case TOK.int64:
+                case TOK.__int128:
                 case TOK.float32:
                 case TOK.float64:
                 case TOK.void_:
@@ -4702,6 +4713,11 @@ final class CParser(AST) : Parser!AST
             return AST.Type.tint32;
         if (size <= 8)
             return AST.Type.tint64;
+        if (size == 16)
+        {
+            error("__int128 not supported");
+            return AST.Type.terror;
+        }
         error("unsupported integer type");
         return AST.Type.terror;
     }
@@ -4723,6 +4739,11 @@ final class CParser(AST) : Parser!AST
             return AST.Type.tuns32;
         if (size <= 8)
             return AST.Type.tuns64;
+        if (size == 16)
+        {
+            error("unsigned __int128 not supported");
+            return AST.Type.terror;
+        }
         error("unsupported integer type");
         return AST.Type.terror;
     }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1816,7 +1816,8 @@ enum class TOK : uint8_t
     __declspec_ = 217u,
     __stdcall_ = 218u,
     __pragma_ = 219u,
-    __attribute___ = 220u,
+    __int128_ = 220u,
+    __attribute___ = 221u,
 };
 
 enum class MemorySet

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -274,6 +274,7 @@ enum TOK : ubyte
     __declspec,
     __stdcall,
     __pragma,
+    __int128,
     __attribute__,
 }
 
@@ -584,6 +585,7 @@ private immutable TOK[] keywords =
     TOK.__declspec,
     TOK.__stdcall,
     TOK.__pragma,
+    TOK.__int128,
     TOK.__attribute__,
 ];
 
@@ -612,7 +614,8 @@ static immutable TOK[TOK.max + 1] Ckeywords =
                        restrict, return_, int16, signed, sizeof_, static_, struct_, switch_, typedef_,
                        union_, unsigned, void_, volatile, while_, asm_, typeof_,
                        _Alignas, _Alignof, _Atomic, _Bool, _Complex, _Generic, _Imaginary, _Noreturn,
-                       _Static_assert, _Thread_local, _import, __cdecl, __declspec, __stdcall, __pragma, __attribute__ ];
+                       _Static_assert, _Thread_local,
+                       _import, __cdecl, __declspec, __stdcall, __pragma, __int128, __attribute__ ];
 
         foreach (kw; Ckwds)
             tab[kw] = cast(TOK) kw;
@@ -883,6 +886,7 @@ extern (C++) struct Token
         TOK.__declspec     : "__declspec",
         TOK.__stdcall      : "__stdcall",
         TOK.__pragma       : "__pragma",
+        TOK.__int128       : "__int128",
         TOK.__attribute__  : "__attribute__",
     ];
 

--- a/compiler/src/dmd/tokens.h
+++ b/compiler/src/dmd/tokens.h
@@ -283,6 +283,7 @@ enum class TOK : unsigned char
     declspec,
     stdcall,
     pragma,
+    int128_,
     attribute__,
 
     MAX,

--- a/compiler/test/fail_compilation/test128.i
+++ b/compiler/test/fail_compilation/test128.i
@@ -1,0 +1,15 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test128.i(12): Error: unsigned __int128 not supported
+fail_compilation/test128.i(12): Error: __int128 not supported
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=23614
+
+unsigned long long _mulx_u64(unsigned long long __X, unsigned long long __Y, unsigned long long *__P)
+{
+    unsigned __int128 __res = (__int128) __X * __Y;
+    *__P = (unsigned long long) (__res >> 64);
+    return (unsigned long long) __res;
+}

--- a/compiler/test/unit/lexer/location_offset.d
+++ b/compiler/test/unit/lexer/location_offset.d
@@ -541,6 +541,7 @@ enum ignoreTokens
     __declspec,
     __stdcall,
     __pragma,
+    __int128,
     __attribute__,
 
     max_,


### PR DESCRIPTION
This is a partial step towards fixing https://issues.dlang.org/show_bug.cgi?id=23614 by recognizing __int128 as a type and giving a better error message for it.

Not sure how to implement it fully.