### PR TITLE
ci: Bump macOS parallelism to 8 processes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -91,6 +91,7 @@ macos13_task:
     OS_NAME: darwin
     # override Cirrus default OS (`darwin`)
     OS: osx
+    N: 8
     matrix:
       - TASK_NAME_SUFFIX: DMD (latest)
       - TASK_NAME_SUFFIX: DMD (coverage)
@@ -105,6 +106,7 @@ macos12_task:
     OS_NAME: darwin
     # override Cirrus default OS (`darwin`)
     OS: osx
+    N: 8
     # de-facto bootstrap version on OSX
     # See: https://github.com/dlang/dmd/pull/13890
     HOST_DMD: dmd-2.099.1


### PR DESCRIPTION
Old Intel-based runners (12 threads, 24G memory) took around:
```
Build: 1m40s
Test DMD: 3m45s
Test Druntime: 20s
Test Phobos: 1m45s
```

New M1-based runners (4 threads, 8G memory) take around:
```
Build: 1m30s
Test DMD: 14m15s
Test Druntime: 40s
Test Phobos: 3m00s
```

If M1 is as great as people say it is, these cores should be able to handle doubling the load.  Let's see how pipeline times are affected...

With N=8
```
Build: 1m30s
Test DMD: 14m20s
Test Druntime: 40s
Test Phobos: 3m50s
```