### PR TITLE
fix Issue 23616 - ImportC: clang __has_feature and __has_extension no…

### DIFF
--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1276,6 +1276,9 @@ public int runPreprocessor(const(char)[] cpp, const(char)[] filename, const(char
         // merge #define's with output
         argv.push("-dD");       // https://gcc.gnu.org/onlinedocs/cpp/Invocation.html#index-dD
 
+        // need to redefine some macros in importc.h
+        argv.push("-Wno-builtin-macro-redefined");
+
         if (target.os == Target.OS.OSX)
         {
             argv.push("-fno-blocks");       // disable clang blocks extension

--- a/compiler/test/compilable/test23616.c
+++ b/compiler/test/compilable/test23616.c
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=23616
+
+#if __has_extension(gnu_asm)
+void _hreset(int __eax)
+{
+    __asm__ ("hreset $0" :: "a"(__eax));
+}
+#endif

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -66,6 +66,18 @@
  */
 #define __extension__  /* ignore it, as ImportC doesn't do warnings */
 
+/********************************
+ * __has_extension is a clang thing:
+ *    https://clang.llvm.org/docs/LanguageExtensions.html
+ * ImportC doesn't has those extensions.
+ */
+#undef __has_feature
+#define __has_feature(x) 0
+
+#undef __has_extension
+#define __has_extension(x) 0
+
+
 /****************************
  * Define it to do what other C compilers do.
  */


### PR DESCRIPTION
…t recognized

Rely on the C preprocessor to get rid of these. This should enable a lot more clang header compatiblity.