### PR TITLE
Follow up "- betterC with CTFE and gc"

### DIFF
--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -600,7 +600,6 @@ public:
     // set if someone took the address of this function
     int tookAddressOf;
     bool requiresClosure;               // this function needs a closure
-    bool skipCodegen;                   // do not generate code for this function
 
     // local variables in this function which are referenced by nested functions
     VarDeclarations closureVars;
@@ -637,6 +636,8 @@ public:
     bool hasCatches(bool v);
     bool isCompileTimeOnly() const;
     bool isCompileTimeOnly(bool v);
+    bool skipCodegen() const;
+    bool skipCodegen(bool v);
     bool printf() const;
     bool printf(bool v);
     bool scanf() const;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2472,7 +2472,6 @@ public:
     BUILTIN builtin;
     int32_t tookAddressOf;
     bool requiresClosure;
-    bool skipCodegen;
     Array<VarDeclaration* > closureVars;
     Array<VarDeclaration* > outerVars;
     Array<FuncDeclaration* > siblingCallers;
@@ -2496,6 +2495,8 @@ public:
     bool hasCatches(bool v);
     bool isCompileTimeOnly() const;
     bool isCompileTimeOnly(bool v);
+    bool skipCodegen() const;
+    bool skipCodegen(bool v);
     bool printf() const;
     bool printf(bool v);
     bool scanf() const;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -203,6 +203,8 @@ private struct FUNCFLAG
     bool inferScope;         /// infer 'scope' for parameters
     bool hasCatches;         /// function has try-catch statements
     bool isCompileTimeOnly;  /// is a compile time only function; no code will be generated for it
+    bool skipCodegen;        /// do not generate code for this function.
+                             // FIXME: redundant with `isCompileTimeOnly`, see https://github.com/dlang/dmd/pull/14791#discussion_r1065066099
     bool printf;             /// is a printf-like function
     bool scanf;              /// is a scanf-like function
     bool noreturn;           /// the function does not return
@@ -329,7 +331,6 @@ extern (C++) class FuncDeclaration : Declaration
     int tookAddressOf;
 
     bool requiresClosure;               // this function needs a closure
-    bool skipCodegen;                   // do not generate code for this function
 
     /** local variables in this function which are referenced by nested functions
      * (They'll get put into the "closure" for this function.)


### PR DESCRIPTION
Reduce code duplication, as suggested in my review: https://github.com/dlang/dmd/pull/14791#discussion_r1064449966

Put `skipCodegen` next to `isCompileTimeOnly` and put a comment about the redundancy.