### PR TITLE
fix Issue 18062 - ddoc: Generated .html files should retain the package hierarchy 

### DIFF
--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -281,6 +281,9 @@ dmd -cov -unittest myprog.d
         Option("Df<filename>",
             "write documentation file to filename"
         ),
+        Option("Dfs=[flat|name|path]",
+            "set documentation file structure: module names (default) or fully qualified module names separated by underscores or use package hierarchy"
+        ),
         Option("d",
             "silently allow deprecated features and symbols",
             `Silently allow $(DDLINK deprecate,deprecate,deprecated features) and use of symbols with

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -281,8 +281,8 @@ dmd -cov -unittest myprog.d
         Option("Df<filename>",
             "write documentation file to filename"
         ),
-        Option("Dfs=[flat|name|path]",
-            "set documentation file structure: module names (default) or fully qualified module names separated by underscores or use package hierarchy"
+        Option("Dfs=[flat|name[:<sep>]|path]",
+            "set documentation file structure: module names (default) or fully qualified module names separated by sep (default: -) or use package hierarchy"
         ),
         Option("d",
             "silently allow deprecated features and symbols",

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -594,9 +594,48 @@ extern (C++) final class Module : Package
         return FileName(docfilename);
     }
 
-    extern (D) void setDocfile()
+    extern (D) void setDocfile(const(char)[] fullname = "")
     {
-        docfile = setOutfilename(global.params.ddoc.name, global.params.ddoc.dir, arg, doc_ext);
+        const(char)[] modpath = global.params.ddoc.dir;
+        if (fullname.length > 0 && global.params.docStructure == DDocStructure.qualifiedPaths)
+        {
+            size_t prevDot = 0;
+            foreach (i, ch; fullname)
+            {
+                if (ch == '.')
+                {
+                    modpath = FileName.combine(modpath, fullname[prevDot .. i]);
+                    prevDot = i + 1;
+                }
+            }
+            if (arg.length > 8 && arg[0 .. 9] == "package.")
+            {
+                modpath = FileName.combine(modpath, fullname[prevDot .. $]);
+            }
+        }
+        const(char)[] modname;
+        if (fullname.length > 0 && global.params.docStructure == DDocStructure.qualifiedNames)
+        {
+            OutBuffer buf;
+            buf.reserve(fullname.length);
+            foreach (ch; fullname)
+            {
+                switch (ch)
+                {
+                case '.':
+                    buf.writeByte('_');
+                    break;
+                default:
+                    buf.writeByte(ch);
+                    break;
+                }
+            }
+            modname = buf.extractChars().toDString;
+        }
+        else
+            modname = arg;
+
+        docfile = setOutfilename(global.params.ddoc.name, modpath, modname, doc_ext);
     }
 
     /**

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -623,7 +623,7 @@ extern (C++) final class Module : Package
                 switch (ch)
                 {
                 case '.':
-                    buf.writeByte('_');
+                    buf.writestring(global.params.docSeparator);
                     break;
                 default:
                     buf.writeByte(ch);

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -404,6 +404,7 @@ extern(C++) void gendocfile(Module m)
     sc.lastdc = dc;
     // Generate predefined macros
     // Set the title to be the name of the module
+    m.setDocfile(m.toPrettyChars(true).toDString);
     {
         const p = m.toPrettyChars().toDString;
         m.macrotable.define("TITLE", p);

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -72,7 +72,7 @@ enum CppStdRevision : uint
 enum DDocStructure : ubyte
 {
     flat,           /// `module a.b.c;` => c.html
-    qualifiedNames, /// `module a.b.c;` => a_b_c.html
+    qualifiedNames, /// `module a.b.c;` => a-b-c.html
     qualifiedPaths, /// `module a.b.c;` => a/b/c.html
 }
 
@@ -133,6 +133,7 @@ extern (C++) struct Param
     bool allInst;           // generate code for all template instantiations
     bool bitfields;         // support C style bit fields
     DDocStructure docStructure = DDocStructure.flat; // where to put/how to name doc files based on their module names
+    const(char)[] docSeparator = "-";                // what character to separate documentation file module names with
 
     CppStdRevision cplusplus = CppStdRevision.cpp11;    // version of C++ standard to support
 

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -69,6 +69,13 @@ enum CppStdRevision : uint
     cpp20 = 2020_02,
 }
 
+enum DDocStructure : ubyte
+{
+    flat,           /// `module a.b.c;` => c.html
+    qualifiedNames, /// `module a.b.c;` => a_b_c.html
+    qualifiedPaths, /// `module a.b.c;` => a/b/c.html
+}
+
 /// Trivalent boolean to represent the state of a `revert`able change
 enum FeatureState : byte
 {
@@ -125,6 +132,7 @@ extern (C++) struct Param
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations
     bool bitfields;         // support C style bit fields
+    DDocStructure docStructure = DDocStructure.flat; // where to put/how to name doc files based on their module names
 
     CppStdRevision cplusplus = CppStdRevision.cpp11;    // version of C++ standard to support
 

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -130,7 +130,8 @@ struct Param
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations
     bool bitfields;         // support C style bit fields
-    unsigned char docStructure; // where to put/how to name doc files based on their module names
+    unsigned char docStructure;       // where to put/how to name doc files based on their module names
+    Array<const char *> docSeparator; // what character to separate documentation file module names with
 
     CppStdRevision cplusplus;  // version of C++ name mangling to support
 

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -130,7 +130,10 @@ struct Param
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations
     bool bitfields;         // support C style bit fields
+    unsigned char docStructure; // where to put/how to name doc files based on their module names
+
     CppStdRevision cplusplus;  // version of C++ name mangling to support
+
     bool showGaggedErrors;  // print gagged errors anyway
     bool printErrorContext;  // print errors with the error context (the error line in the source file)
     bool manual;            // open browser on compiler manual

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1855,6 +1855,25 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             params.showColumns = true;
         else if (arg == "-vgc") // https://dlang.org/dmd.html#switch-vgc
             params.vgc = true;
+        else if (startsWith(p + 1, "Dfs="))
+        {
+            const(char)[] struc = arg["Dfs=".length + 1 .. $];
+
+            switch (struc)
+            {
+            case "flat":
+                params.docStructure = DDocStructure.flat;
+                break;
+            case "name":
+                params.docStructure = DDocStructure.qualifiedNames;
+                break;
+            case "path":
+                params.docStructure = DDocStructure.qualifiedPaths;
+                break;
+            default:
+                error("unknown documentation file structure '%.*s', must be 'flat', 'name' or 'path'", cast(int) struc.length, struc.ptr);
+            }
+        }
         else if (startsWith(p + 1, "verrors")) // https://dlang.org/dmd.html#switch-verrors
         {
             if (p[8] != '=')

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1871,7 +1871,15 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                 params.docStructure = DDocStructure.qualifiedPaths;
                 break;
             default:
-                error("unknown documentation file structure '%.*s', must be 'flat', 'name' or 'path'", cast(int) struc.length, struc.ptr);
+                if (struc.length >= 6 && struc[0 .. 5] == "name:")
+                {
+                    params.docStructure = DDocStructure.qualifiedNames;
+                    params.docSeparator = struc[5 .. $];
+                }
+                else
+                {
+                    error("unknown documentation file structure '%.*s', must be 'flat', 'name', 'name:<sep>' or 'path'", cast(int) struc.length, struc.ptr);
+                }
             }
         }
         else if (startsWith(p + 1, "verrors")) // https://dlang.org/dmd.html#switch-verrors


### PR DESCRIPTION
Added a command-line option `-Dfs=` for generating documentation files with different file structures. The default behaviour is the same as before for the sake of backwards compatibility.