### PR TITLE
fix Issue 23614 - ImportC: __int128 not supported

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -82,3 +82,7 @@
 #if linux  // Microsoft won't allow the following macro
 #define __PRETTY_FUNCTION__ __func__
 #endif
+
+#if __APPLE__
+#undef __SIZEOF_INT128__
+#endif


### PR DESCRIPTION
Fix using Jacob Carlborg's suggestion.

This blocks compiling the BearSSL package.