### PR TITLE
fix Issue 23626 - [REG2.096] Template deduction with auto const ref Args... and delegate

### DIFF
--- a/changelog/dmd.deprecate-duplicate-system-implementations.dd
+++ b/changelog/dmd.deprecate-duplicate-system-implementations.dd
@@ -1,0 +1,19 @@
+A missed case of conflicting `extern (D) @system` function definitions has been deprecated
+
+Having multiple definitions of functions within a module had been turned
+$(LINK2 $(ROOT_DIR)/changelog/2.095.0.html#duplicate-implementations-deprecation,
+into an error in DMD 2.095.0).
+
+However, the compiler would not issue an error when two implementations
+differed by an explicit and inferred `@system` attribute, although they have
+the same mangling.
+
+---
+void foo() {}
+void foo() @system {} // no error
+---
+
+This bug has been fixed, and DMD will now issue a deprecation if there are such
+conflicting `@system` function implementations. Starting from DMD 2.112, it
+will produce a multiple definition error just like other kinds of conflicting
+functions within a module.

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3740,7 +3740,6 @@ public:
     Type* substWildTo(uint32_t _param_0) override;
     MATCH constConv(Type* to) override;
     bool iswild() const;
-    bool attributesEqual(const TypeFunction* const other) const;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -462,7 +462,19 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
                 // Different attributes don't conflict in extern(D)
                 if (!sameAttr && linkage1 == LINK.d)
+                {
+                    // @@@DEPRECATED_2.112@@@
+                    // Same as 2.104 deprecation, but also catching explicit/implicit `@system`
+                    // At the end of deprecation period, fix Type.attributesEqual and remove
+                    // this condition, as well as the error for extern(C) functions above.
+                    if (sameAttr != tf1.attributesEqual(tf2, true))
+                    {
+                        f2.deprecation("cannot overload `extern(%s)` function at %s",
+                                linkageToChars(f1._linkage),
+                                f1.loc.toChars());
+                    }
                     return 0;
+                }
 
                 error(f2.loc, "%s `%s%s` conflicts with previous declaration at %s",
                         f2.kind(),

--- a/compiler/test/compilable/extra-files/test23626a.d
+++ b/compiler/test/compilable/extra-files/test23626a.d
@@ -1,0 +1,49 @@
+template fullyQualifiedName(T...)
+{   
+    enum fullyQualifiedName = !T[0];
+}
+
+void __trace_maybeDumpTupleToFile(Args...)(auto ref const Args args) nothrow @nogc { }
+
+int getStructInfoEx(T)() {
+   enum Ctx = fullyQualifiedName!T;
+   return 0;
+}
+
+auto as(Func)(Func) {}
+
+@nogc void foo() { }
+
+void assertOp(string OPERATION, LHS, RHS)(LHS lhs, RHS) {
+  as({
+    try {
+      try as(lhs);
+      catch(Throwable) foo();
+    } catch(Throwable) assert(false);
+  });
+}
+
+struct FixedArray(T, size_t capacity_) {
+  int a = getStructInfoEx!FixedArray;
+
+  T* some_function() {
+    assertOp !""(1, 1);
+    return null;
+  }
+  alias some_function this;
+}
+
+struct ReclamationBatch {
+
+  FixedArray !(uint,1) dummy;
+
+  @nogc nothrow void some_inout_func() inout { }
+
+  void func_2(Dlg)(Dlg dlg) {
+    __trace_maybeDumpTupleToFile(dlg);
+  }
+
+  void _reclaimBatch() {
+    func_2({ some_inout_func; });
+  }
+}

--- a/compiler/test/compilable/extra-files/test23626b.d
+++ b/compiler/test/compilable/extra-files/test23626b.d
@@ -1,0 +1,14 @@
+interface Timeline {
+}
+
+struct Policy {
+  alias OldTagCallback = void delegate() @nogc nothrow;
+  Timeline timeline;
+  OldTagCallback oldTagCB;
+}
+
+import test23626;
+
+struct Tiering {
+    StaticHashTable!(Policy) policies;
+}

--- a/compiler/test/compilable/test23626.d
+++ b/compiler/test/compilable/test23626.d
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=23626
+// EXTRA_SOURCES: extra-files/test23626a.d extra-files/test23626b.d
+module test23626;
+
+struct StaticHashTable(V)
+{
+    V v;
+}

--- a/compiler/test/fail_compilation/fail23626a.d
+++ b/compiler/test/fail_compilation/fail23626a.d
@@ -1,0 +1,16 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fail23626a.d(10): Deprecation: function `fail23626a.ambig` cannot overload `extern(D)` function at fail_compilation/fail23626a.d(9)
+fail_compilation/fail23626a.d(13): Deprecation: function `fail23626a.ambigC` cannot overload `extern(C)` function at fail_compilation/fail23626a.d(12)
+fail_compilation/fail23626a.d(16): Error: function `fail23626a.ambigCxx(int a)` conflicts with previous declaration at fail_compilation/fail23626a.d(15)
+---
+*/
+
+extern(D) int ambig(int a) { return 0; }
+extern(D) int ambig(int a) @system { return 1; }
+
+extern(C) int ambigC(int a) { return 2; }
+extern(C) int ambigC(int a) @system { return 3; }
+
+extern(C++) int ambigCxx(int a) { return 4; }
+extern(C++) int ambigCxx(int a) @system { return 5; }

--- a/compiler/test/fail_compilation/fail23626b.d
+++ b/compiler/test/fail_compilation/fail23626b.d
@@ -1,0 +1,27 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fail23626b.d(26): Error: `fail23626b.AmbigOpApply.opApply` called with argument types `(int delegate(int i) pure nothrow @nogc @system)` matches both:
+fail_compilation/fail23626b.d(12):     `fail23626b.AmbigOpApply.opApply(int delegate(int) dg)`
+and:
+fail_compilation/fail23626b.d(17):     `fail23626b.AmbigOpApply.opApply(int delegate(int) dg)`
+---
+*/
+
+struct AmbigOpApply
+{
+    int opApply(int delegate(int) dg)
+    {
+        return 0;
+    }
+
+    int opApply(int delegate(int) dg) @system
+    {
+        return 0;
+    }
+}
+
+void ambigOpApply() @system
+{
+    AmbigOpApply sa;
+    foreach (int i; sa) { }
+}


### PR DESCRIPTION
Regression introduced by #12090.

The function `attributesEqual` has a logic bug `this.trusted == other.trusted` fails when comparing an explicitly `@system` type function with an implicit one (`TRUST.default_`).  For the purpose of attribute equality, `TRUST.default_` and `TRUST.system` are really the same, as per comment.

https://github.com/dlang/dmd/blob/7eb96c8b64409a3ec6c07c3e31abf0825d353d2e/compiler/src/dmd/astenums.d#L294-L300

This `attributesEqual` function is also used for:
1. Testing whether two functions are ambiguous - explicit/implicit `@system` functions _are_ ambiguous/conflict, but for some reason dmd doesn't emit either a deprecation/error for this (gdc _always_ errors when two functions conflict), so this has been made a new deprecation.
2. Testing whether two opApply functions are ambiguous - they again are ambiguous, but a change in `attributesEqual` does not affect how dmd/opover.d works.

Because of the current in-flight deprecation period for `extern(C)` functions, I can't make the desired behaviour the default just now, and as `extern(D)` also allowed any duplicate definition of unused functions to be compilable.  Fixing the latter addressed an apparent oversight for issue 18385 fix.

@JohanEngelen are you OK using the mostly unabridged original copy of your test, or is the fully reduced version fine?