### PR TITLE
fix Issue 19467 - Support EV_SET on OSX

### DIFF
--- a/druntime/src/core/sys/darwin/sys/event.d
+++ b/druntime/src/core/sys/darwin/sys/event.d
@@ -46,12 +46,12 @@ enum : short
     EVFILT_EXCEPT   = -15,
 }
 
-extern(D) void EV_SET(kevent_t* kevp, typeof(kevent_t.tupleof) args)
+extern(D) void EV_SET()(kevent_t* kevp, typeof(kevent_t.tupleof) args)
 {
     *kevp = kevent_t(args);
 }
 
-extern(D) void EV_SET64(kevent64_s* kevp, typeof(kevent64_s.tupleof) args)
+extern(D) void EV_SET64()(kevent64_s* kevp, typeof(kevent64_s.tupleof) args)
 {
     *kevp = kevent64_s(args);
 }


### PR DESCRIPTION
The solution is to make such druntime function templates so they work with -betterC.