### PR TITLE
follow-up Issue 23626 - invert trustSystemEqualsDefault initializer to true

### DIFF
--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4828,7 +4828,7 @@ extern (C++) final class TypeFunction : TypeNext
     override MATCH constConv(Type to)
     {
         // Attributes need to match exactly, otherwise it's an implicit conversion
-        if (this.ty != to.ty || !this.attributesEqual(cast(TypeFunction) to, true))
+        if (this.ty != to.ty || !this.attributesEqual(cast(TypeFunction) to))
             return MATCH.nomatch;
 
         return super.constConv(to);
@@ -4871,7 +4871,7 @@ extern (C++) final class TypeFunction : TypeNext
     }
 
     /// Returns: whether `this` function type has the same attributes (`@safe`,...) as `other`
-    extern (D) bool attributesEqual(const scope TypeFunction other, bool trustSystemEqualsDefault = false) const pure nothrow @safe @nogc
+    extern (D) bool attributesEqual(const scope TypeFunction other, bool trustSystemEqualsDefault = true) const pure nothrow @safe @nogc
     {
         // @@@DEPRECATED_2.112@@@
         // See semantic2.d Semantic2Visitor.visit(FuncDeclaration):

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1746,7 +1746,10 @@ private FuncDeclaration findBestOpApplyMatch(Expression ethis, FuncDeclaration f
 
             // Found another overload with different attributes?
             // e.g. @system vs. @safe opApply
-            bool ambig = tf.attributesEqual(bestTf);
+            // @@@DEPRECATED_2.112@@@
+            // See semantic2.d Semantic2Visitor.visit(FuncDeclaration):
+            // Remove `false` after deprecation period is over.
+            bool ambig = tf.attributesEqual(bestTf, false);
 
             // opApplies with identical attributes could still accept
             // different function bodies as delegate

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -439,7 +439,11 @@ private extern(C++) final class Semantic2Visitor : Visitor
                 if (tf1.mod != tf2.mod || ((f1.storage_class ^ f2.storage_class) & STC.static_))
                     return 0;
 
-                const sameAttr = tf1.attributesEqual(tf2);
+                // @@@DEPRECATED_2.112@@@
+                // This test doesn't catch identical functions that differ only
+                // in explicit/implicit `@system` - a deprecation has now been
+                // added below, remove `false` after deprecation period is over.
+                const sameAttr = tf1.attributesEqual(tf2, false);
                 const sameParams = tf1.parameterList == tf2.parameterList;
 
                 // Allow the hack to declare overloads with different parameters/STC's
@@ -467,7 +471,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
                     // Same as 2.104 deprecation, but also catching explicit/implicit `@system`
                     // At the end of deprecation period, fix Type.attributesEqual and remove
                     // this condition, as well as the error for extern(C) functions above.
-                    if (sameAttr != tf1.attributesEqual(tf2, true))
+                    if (sameAttr != tf1.attributesEqual(tf2))
                     {
                         f2.deprecation("cannot overload `extern(%s)` function at %s",
                                 linkageToChars(f1._linkage),


### PR DESCRIPTION
This is the desired behaviour for any future users of this function.