### PR TITLE
ci: Update Ubuntu images to 22.04

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,6 +58,9 @@ linux_task:
     image: ubuntu:22.04
     cpu: 4
     memory: 8G
+    # Workaround GDB bug on 22.04 by requesting a privileged container
+    # See https://github.com/cirruslabs/cirrus-ci-docs/issues/1136
+    kvm: true
   timeout_in: 60m
   environment:
     matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,9 +53,9 @@ coverage_environment_template: &COVERAGE_ENVIRONMENT_TEMPLATE
 
 # Linux
 linux_task:
-  name: Ubuntu 18.04 $TASK_NAME_SUFFIX
+  name: Ubuntu 20.04 $TASK_NAME_SUFFIX
   container:
-    image: ubuntu:18.04
+    image: ubuntu:20.04
     cpu: 4
     memory: 8G
   timeout_in: 60m

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,9 +53,9 @@ coverage_environment_template: &COVERAGE_ENVIRONMENT_TEMPLATE
 
 # Linux
 linux_task:
-  name: Ubuntu 20.04 $TASK_NAME_SUFFIX
+  name: Ubuntu 22.04 $TASK_NAME_SUFFIX
   container:
-    image: ubuntu:20.04
+    image: ubuntu:22.04
     cpu: 4
     memory: 8G
   timeout_in: 60m

--- a/ci/README.md
+++ b/ci/README.md
@@ -113,20 +113,12 @@ The auto tester tests DMD on various Posix platforms.
 **Config**: [azure-pipelines.yml](https://github.com/dlang/dmd/blob/master/.github/workflows/runnable_cxx.yml)
 
 **Checks**:
-- C++ interop tests / Run (macOS-10.15, clang-13.0.0)
-- C++ interop tests / Run (macOS-10.15, clang-12.0.0)
-- C++ interop tests / Run (macOS-10.15, clang-11.0.0)
-- C++ interop tests / Run (macOS-10.15, clang-10.0.0)
-- C++ interop tests / Run (macOS-10.15, clang-9.0.0)
-- C++ interop tests / Run (macOS-10.15, clang-8.0.0)
-- C++ interop tests / Run (ubuntu-18.04, clang-10.0.0)
-- C++ interop tests / Run (ubuntu-18.04, clang-9.0.0)
-- C++ interop tests / Run (ubuntu-18.04, clang-8.0.0)
-- C++ interop tests / Run (ubuntu-18.04, g++-9)
-- C++ interop tests / Run (ubuntu-18.04, g++-8)
-- C++ interop tests / Run (ubuntu-18.04, g++-7)
-- C++ interop tests / Run (ubuntu-18.04, g++-6)
-- C++ interop tests / Run (ubuntu-18.04, g++-5)
+- C++ interop tests / Run (macOS-11, clang-13.0.0)
+- C++ interop tests / Run (macOS-11, clang-12.0.0)
+- C++ interop tests / Run (macOS-11, clang-11.0.0)
+- C++ interop tests / Run (macOS-11, clang-10.0.0)
+- C++ interop tests / Run (macOS-11, clang-9.0.0)
+- C++ interop tests / Run (macOS-11, clang-8.0.0)
 - C++ interop tests / Run (ubuntu-20.04, clang-13.0.0)
 - C++ interop tests / Run (ubuntu-20.04, clang-12.0.0)
 - C++ interop tests / Run (ubuntu-20.04, clang-11.0.0)
@@ -157,19 +149,19 @@ These should be taken seriously, since untested code is likely to introduce bugs
 **Config**: [.cirrus.yml](https://github.com/dlang/dmd/blob/master/.cirrus.yml)
 
 **Checks**:
-- FreeBSD 11.4 x64, DMD (bootstrap)
-- FreeBSD 12.2 x64, DMD (coverage)
-- FreeBSD 12.2 x64, DMD (latest)
-- Ubuntu 18.04 x64, DMD (bootstrap)
-- Ubuntu 18.04 x64, DMD (latest)
-- Ubuntu 18.04 x64, GDC
-- Ubuntu 18.04 x64, LDC
-- Ubuntu 18.04 x86, DMD (bootstrap)
-- Ubuntu 18.04 x86, DMD (coverage)
-- Ubuntu 18.04 x86, DMD (latest)
-- macOS 11.x x64, DMD (bootstrap)
-- macOS 12.x x64, DMD (coverage)
-- macOS 12.x x64, DMD (latest)
+- FreeBSD 12.3 x64, DMD (bootstrap)
+- FreeBSD 13.0 x64, DMD (coverage)
+- FreeBSD 13.0 x64, DMD (latest)
+- Ubuntu 20.04 x64, DMD (bootstrap)
+- Ubuntu 20.04 x64, DMD (latest)
+- Ubuntu 20.04 x64, GDC
+- Ubuntu 20.04 x64, LDC
+- Ubuntu 20.04 x86, DMD (bootstrap)
+- Ubuntu 20.04 x86, DMD (coverage)
+- Ubuntu 20.04 x86, DMD (latest)
+- macOS 12.x x64 (M1), DMD (bootstrap)
+- macOS 13.x x64 (M1), DMD (coverage)
+- macOS 13.x x64 (M1), DMD (latest)
 
 Cirrus tests DMD on Posix platforms.
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -152,13 +152,13 @@ These should be taken seriously, since untested code is likely to introduce bugs
 - FreeBSD 12.3 x64, DMD (bootstrap)
 - FreeBSD 13.0 x64, DMD (coverage)
 - FreeBSD 13.0 x64, DMD (latest)
-- Ubuntu 20.04 x64, DMD (bootstrap)
-- Ubuntu 20.04 x64, DMD (latest)
-- Ubuntu 20.04 x64, GDC
-- Ubuntu 20.04 x64, LDC
-- Ubuntu 20.04 x86, DMD (bootstrap)
-- Ubuntu 20.04 x86, DMD (coverage)
-- Ubuntu 20.04 x86, DMD (latest)
+- Ubuntu 22.04 x64, DMD (bootstrap)
+- Ubuntu 22.04 x64, DMD (latest)
+- Ubuntu 22.04 x64, GDC
+- Ubuntu 22.04 x64, LDC
+- Ubuntu 22.04 x86, DMD (bootstrap)
+- Ubuntu 22.04 x86, DMD (coverage)
+- Ubuntu 22.04 x86, DMD (latest)
 - macOS 12.x x64 (M1), DMD (bootstrap)
 - macOS 13.x x64 (M1), DMD (coverage)
 - macOS 13.x x64 (M1), DMD (latest)

--- a/compiler/test/runnable_cxx/cppa.d
+++ b/compiler/test/runnable_cxx/cppa.d
@@ -444,57 +444,10 @@ void test13161()
 
 /****************************************/
 
-version (linux)
-{
-    static if (__traits(getTargetInfo, "cppStd") < 201703)
-    {
-        // See note on std::allocator below.
-        extern(C++, __gnu_cxx)
-        {
-            struct new_allocator(T)
-            {
-                alias size_type = size_t;
-                static if (is(T : char))
-                    void deallocate(T*, size_type) { }
-                else
-                    void deallocate(T*, size_type);
-            }
-        }
-    }
-}
-
 extern (C++, std)
 {
-    version (linux)
-    {
-        static if (__traits(getTargetInfo, "cppStd") >= 201703)
-        {
-            // std::allocator no longer derives from __gnu_cxx::new_allocator,
-            // it derives from std::__new_allocator instead.
-            struct __new_allocator(T)
-            {
-                alias size_type = size_t;
-                static if (is(T : char))
-                    void deallocate(T*, size_type) { }
-                else
-                    void deallocate(T*, size_type);
-            }
-        }
-    }
-
     extern (C++, class) struct allocator(T)
     {
-        version (linux)
-        {
-            alias size_type = size_t;
-            void deallocate(T* p, size_type sz)
-            {
-                static if (__traits(getTargetInfo, "cppStd") >= 201703)
-                    (cast(std.__new_allocator!T*)&this).deallocate(p, sz);
-                else
-                    (cast(__gnu_cxx.new_allocator!T*)&this).deallocate(p, sz);
-            }
-        }
     }
 
     class vector(T, A = allocator!T)
@@ -586,11 +539,6 @@ void test14()
 
 version (linux)
 {
-    void test14a(std.allocator!int * pa)
-    {
-    pa.deallocate(null, 0);
-    }
-
     void gun(std.vector!int pa)
     {
     int x = 42;

--- a/compiler/test/runnable_cxx/cppa.d
+++ b/compiler/test/runnable_cxx/cppa.d
@@ -5,8 +5,6 @@
 // CXXFLAGS(linux freebsd osx netbsd dragonflybsd): -std=c++11
 // druntime isn't linked, this prevents missing symbols '_d_arraybounds_slicep':
 // REQUIRED_ARGS: -checkaction=C
-// Filter a spurious warning on Semaphore:
-// TRANSFORM_OUTPUT: remove_lines("warning: relocation refers to discarded section")
 
 // N.B MSVC doesn't have a C++11 switch, but it defaults to the latest fully-supported standard
 
@@ -1063,83 +1061,99 @@ void test15576()
 /****************************************/
 // https://issues.dlang.org/show_bug.cgi?id=15579
 
-extern (C++)
+version (DigitalMars)
 {
-    class Base
+    version (linux)
     {
-        //~this() {}
-        void based() { }
-        ubyte x = 4;
+        // Test removed for DMD/linux-only.
+        // https://issues.dlang.org/show_bug.cgi?id=23660
     }
-
-    interface Interface
-    {
-        int MethodCPP();
-        int MethodD();
-    }
-
-    class Derived : Base, Interface
-    {
-        short y = 5;
-        int MethodCPP();
-        int MethodD() {
-            printf("Derived.MethodD(): this = %p, x = %d, y = %d\n", this, x, y);
-            Derived p = this;
-            //p = cast(Derived)(cast(void*)p - 16);
-            assert(p.x == 4 || p.x == 7);
-            assert(p.y == 5 || p.y == 8);
-            return 3;
-        }
-        int Method() { return 6; }
-    }
-
-    Derived cppfoo(Derived);
-    Interface cppfooi(Interface);
+    else
+        version = TEST15579;
 }
+else
+    version = TEST15579;
 
-void test15579()
+version (TEST15579)
 {
-    Derived d = new Derived();
-    printf("d = %p\n", d);
-    assert(d.x == 4);
-    assert(d.y == 5);
-    assert((cast(Interface)d).MethodCPP() == 30);
-    assert((cast(Interface)d).MethodD() == 3);
-    assert(d.MethodCPP() == 30);
-    assert(d.MethodD() == 3);
-    assert(d.Method() == 6);
-
-    d = cppfoo(d);
-    assert(d.x == 7);
-    assert(d.y == 8);
-
-    printf("d2 = %p\n", d);
-
-    /* Casting to an interface involves thunks in the vtbl[].
-     * g++ puts the thunks for MethodD in the same COMDAT as MethodD.
-     * But D doesn't, so when the linker "picks one" of the D generated MethodD
-     * or the g++ generated MethodD, it may wind up with a messed up thunk,
-     * resulting in a seg fault. The solution is to not expect objects of the same
-     * type to be constructed on both sides of the D/C++ divide if the same member
-     * function (in this case, MethodD) is also defined on both sides.
-     */
-    version (Windows)
+    extern (C++)
     {
+        class Base
+        {
+            //~this() {}
+            void based() { }
+            ubyte x = 4;
+        }
+
+        interface Interface
+        {
+            int MethodCPP();
+            int MethodD();
+        }
+
+        class Derived : Base, Interface
+        {
+            short y = 5;
+            int MethodCPP();
+            int MethodD() {
+                printf("Derived.MethodD(): this = %p, x = %d, y = %d\n", this, x, y);
+                Derived p = this;
+                //p = cast(Derived)(cast(void*)p - 16);
+                assert(p.x == 4 || p.x == 7);
+                assert(p.y == 5 || p.y == 8);
+                return 3;
+            }
+            int Method() { return 6; }
+        }
+
+        Derived cppfoo(Derived);
+        Interface cppfooi(Interface);
+    }
+
+    void test15579()
+    {
+        Derived d = new Derived();
+        printf("d = %p\n", d);
+        assert(d.x == 4);
+        assert(d.y == 5);
+        assert((cast(Interface)d).MethodCPP() == 30);
         assert((cast(Interface)d).MethodD() == 3);
-    }
-    assert((cast(Interface)d).MethodCPP() == 30);
+        assert(d.MethodCPP() == 30);
+        assert(d.MethodD() == 3);
+        assert(d.Method() == 6);
 
-    assert(d.Method() == 6);
+        d = cppfoo(d);
+        assert(d.x == 7);
+        assert(d.y == 8);
 
-    printf("d = %p, i = %p\n", d, cast(Interface)d);
-    version (Windows)
-    {
-        Interface i = cppfooi(d);
-        printf("i2: %p\n", i);
-        assert(i.MethodD() == 3);
-        assert(i.MethodCPP() == 30);
+        printf("d2 = %p\n", d);
+
+        /* Casting to an interface involves thunks in the vtbl[].
+         * g++ puts the thunks for MethodD in the same COMDAT as MethodD.
+         * But D doesn't, so when the linker "picks one" of the D generated MethodD
+         * or the g++ generated MethodD, it may wind up with a messed up thunk,
+         * resulting in a seg fault. The solution is to not expect objects of the same
+         * type to be constructed on both sides of the D/C++ divide if the same member
+         * function (in this case, MethodD) is also defined on both sides.
+         */
+        version (Windows)
+        {
+            assert((cast(Interface)d).MethodD() == 3);
+        }
+        assert((cast(Interface)d).MethodCPP() == 30);
+
+        assert(d.Method() == 6);
+
+        printf("d = %p, i = %p\n", d, cast(Interface)d);
+        version (Windows)
+        {
+            Interface i = cppfooi(d);
+            printf("i2: %p\n", i);
+            assert(i.MethodD() == 3);
+            assert(i.MethodCPP() == 30);
+        }
+        printf("test15579() done\n");
     }
-    printf("test15579() done\n");
 }
 
 /****************************************/
@@ -1647,7 +1661,7 @@ void main()
     testeh2();
     testeh3();
     test15576();
-    test15579();
+    version (TEST15579) test15579();
     test15610();
     test15455();
     test15372();

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -77,9 +77,6 @@
 #undef __has_extension
 #define __has_extension(x) 0
 
-#undef __has_builtin
-#define __has_builtin(x) 0
-
 /*************************************
  * OS-specific macros
  */

--- a/druntime/test/exceptions/Makefile
+++ b/druntime/test/exceptions/Makefile
@@ -110,7 +110,7 @@ $(ROOT)/rt_trap_exceptions_drt_gdb.done: $(ROOT)/rt_trap_exceptions_drt
 	$(QUIET)$(TIMELIMIT) $(GDB) -n -ex 'set confirm off' -ex run -ex 'bt full' -ex q --args $< --DRT-trapExceptions=0 \
 		> $(ROOT)/rt_trap_exceptions_drt_gdb.output 2>&1 || true
 	cat $(ROOT)/rt_trap_exceptions_drt_gdb.output
-	grep "D main (args=...) at .*rt_trap_exceptions_drt.d:9" > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
+	grep "\(D main\|_Dmain\) (args=...) at .*rt_trap_exceptions_drt.d:9" > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
 	grep 'myLocal' > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
 	! grep "No stack." > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
 	@touch $@


### PR DESCRIPTION
Test using a more recent OS and system compiler.

Older systems won't catch problems that people on newer systems will run into.
i.e: https://issues.dlang.org/show_bug.cgi?id=23631

**Removed tests**:
- Removed test in #3895 because GCC-12 has dropped the `__gnu_cxx` namespace, there is no backwards compatibility. 
- Disabled test in #5361 for DMD/Linux because of issue 23660.

**Reverted changes**:
- Reverted change to cppa.d in #10877 because warning is not spurious, it's a DMD bug, which now hits a hard linker error.
- Reverted #14801 because of issue 23631.