### PR TITLE
dmd.aggregate: Define importAll override for AggregateDeclaration

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -188,6 +188,23 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             ScopeDsymbol.setScope(sc);
     }
 
+    override void importAll(Scope* sc)
+    {
+        if (!members || !members.length)
+            return;
+
+        if (!symtab)
+        {
+            symtab = new DsymbolTable();
+            members.foreachDsymbol( s => s.addMember(sc, this) );
+            // Set scope so if there are forward references, we still might be able to
+            // resolve individual members like enums.
+            auto sc2 = newScope(sc);
+            members.foreachDsymbol( s => s.setScope(sc2) );
+            sc2.pop();
+        }
+    }
+
     /***************************************
      * Returns:
      *      The total number of fields minus the number of hidden fields.

--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -114,6 +114,7 @@ public:
 
     virtual Scope *newScope(Scope *sc);
     void setScope(Scope *sc) override final;
+    void importAll(Scope *sc) override;
     size_t nonHiddenFields();
     bool determineSize(const Loc &loc);
     virtual void finalizeSize() = 0;

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -469,7 +469,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     {
         //printf("%s.ClassDeclaration.search('%s', flags=x%x)\n", toChars(), ident.toChars(), flags);
         //if (_scope) printf("%s baseok = %d\n", toChars(), baseok);
-        if (_scope && baseok < Baseok.semanticdone)
+        if (_scope && !symtab)
         {
             if (!inuse)
             {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5326,6 +5326,7 @@ public:
     Sizeok sizeok;
     virtual Scope* newScope(Scope* sc);
     void setScope(Scope* sc) final override;
+    void importAll(Scope* sc) override;
     size_t nonHiddenFields();
     bool determineSize(const Loc& loc);
     virtual void finalizeSize() = 0;

--- a/compiler/test/compilable/extra-files/test23595png.d
+++ b/compiler/test/compilable/extra-files/test23595png.d
@@ -1,0 +1,6 @@
+module test23595png;
+
+struct GC
+{
+    import imports.test23595types;
+}

--- a/compiler/test/compilable/imports/test23595types.d
+++ b/compiler/test/compilable/imports/test23595types.d
@@ -1,0 +1,11 @@
+module imports.test23595types;
+
+enum __WORDSIZE = 64;
+
+static if (__WORDSIZE)
+    enum __SIZEOF_PTHREAD_MUTEX_T = 1;
+
+union pthread_mutex_t
+{
+    byte[__SIZEOF_PTHREAD_MUTEX_T] __size;
+}

--- a/compiler/test/compilable/test10616.d
+++ b/compiler/test/compilable/test10616.d
@@ -1,0 +1,20 @@
+// https://issues.dlang.org/show_bug.cgi?id=10616
+class A
+{
+    void foo() {}
+}
+class B(T) : T
+{
+    static if (is(B : A))
+        override void foo() {}
+}
+alias BA = B!A;
+
+////
+
+class C : C.D
+{
+    static class D
+    {
+    }
+}

--- a/compiler/test/compilable/test20913.d
+++ b/compiler/test/compilable/test20913.d
@@ -1,0 +1,41 @@
+// https://issues.dlang.org/show_bug.cgi?id=20913
+template anySatisfy(alias F, Ts...)
+{
+    static foreach (T; Ts)
+        static if (F!T)
+        enum anySatisfy ;
+    enum anySatisfy = false;
+}
+
+template hasIndirections(T)
+{
+    static if (is(T == struct) )
+        enum hasIndirections = anySatisfy!(.hasIndirections, typeof(T.tupleof));
+    else static if (is(E))
+        enum hasIndirections ;
+    else static if (isFunctionPointer!T)
+        enum hasIndirections ;
+    else
+        enum hasIndirections = isDelegate!T ;
+}
+
+template isFunctionPointer(T)
+{
+    enum isFunctionPointer = false;
+}
+
+template isDelegate(T)
+{
+    static if (is(typeof(T[])))
+        enum isDelegate;
+    enum isDelegate = is(W);
+}
+
+struct Array(T)
+{
+    static if (hasIndirections!T) {}
+}
+
+struct Foo { Array!Bar _barA; }
+struct Bar { Frop _frop; }
+class Frop { Array!Foo _foos; }

--- a/compiler/test/compilable/test22981.d
+++ b/compiler/test/compilable/test22981.d
@@ -1,0 +1,71 @@
+// https://issues.dlang.org/show_bug.cgi?id=22981
+mixin ("enum E1 {", S1.attr, "}");
+
+struct S1
+{
+    E1 e;
+    enum attr = "a";
+}
+
+////
+
+template E2()
+{
+    mixin ("enum E2 {", S2.attr, "}");
+}
+
+struct S2
+{
+    E2!() e;
+    enum attr = "a";
+}
+
+////
+
+template E3_()
+{
+	mixin ("enum E3_ {", S3.attr, "}");
+}
+
+alias E3 = E3_!();
+
+struct S3
+{
+    E3 e;
+    enum attr = "a";
+}
+
+////
+
+template E4_()
+{
+	mixin ("enum E4_ {", S4.attr, "}");
+}
+
+struct S4
+{
+    alias E4 = E4_!();
+    E4 e;
+    enum attr = "a";
+}
+
+////
+
+mixin ("enum E5 {", __traits(getAttributes, S5)[0], "}");
+
+@("a")
+struct S5
+{
+    E5 e;
+}
+
+////
+
+mixin ("enum E6 {", __traits(getAttributes, S6)[0], "}");
+
+@(S6.a)
+struct S6
+{
+    E6 e;
+    enum a = "dfgdf";
+}

--- a/compiler/test/compilable/test23595.d
+++ b/compiler/test/compilable/test23595.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=23595
+// EXTRA_SOURCES: extra-files/test23595png.d
+// EXTRA_FILES: imports/test23595types.d
+
+struct AudioOutputThread
+{
+    alias Sample = AudioPcmOutThreadImplementation.Sample;
+}
+
+import imports.test23595types;
+
+class AudioPcmOutThreadImplementation
+{
+    void[pthread_mutex_t.sizeof] _slock;
+    struct Sample { }
+}

--- a/compiler/test/compilable/test23598.d
+++ b/compiler/test/compilable/test23598.d
@@ -1,0 +1,31 @@
+alias aliases(a...) = a;
+
+template sort(alias f, a...)
+{
+    static if (a.length > 0) // (1)
+    {
+        alias x = f!(a[1]);
+        alias sort = a;
+    }
+    else
+        alias sort = a;
+}
+
+alias SortedItems = sort!(isDependencyOf, Top, String); // (2)
+//pragma (msg, "1: ", SortedItems);
+
+enum isDependencyOf(Item) = Item.DirectDependencies.length == 0;
+
+struct Top
+{
+    alias DirectDependencies = aliases!();
+}
+
+struct String
+{
+    alias DirectDependencies = aliases!();
+    
+    //pragma(msg, "2: ", SortedItems);
+    enum l = SortedItems.length; // (3)
+    static assert(is(typeof(SortedItems.length) == size_t)); // (4)
+}

--- a/compiler/test/fail_compilation/ice10616.d
+++ b/compiler/test/fail_compilation/ice10616.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10616.d(8): Error: class `ice10616.A` is forward referenced when looking for `B`
+fail_compilation/ice10616.d(8): Error: undefined identifier `B`
 ---
 */
 
-class A : A.B
+class A : B
 {
     interface B {}
 }

--- a/compiler/test/fail_compilation/ice14642.d
+++ b/compiler/test/fail_compilation/ice14642.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14642.d(47): Error: undefined identifier `errorValue`
-fail_compilation/ice14642.d(23): Error: template instance `ice14642.X.NA!()` error instantiating
+fail_compilation/ice14642.d(29): Error: no property `func` for `p` of type `ice14642.Y*`
+fail_compilation/ice14642.d(24): Error: template instance `ice14642.X.NA!()` error instantiating
+fail_compilation/ice14642.d(48): Error: undefined identifier `errorValue`
 ---
 */
 


### PR DESCRIPTION
```
The laziness of adding aggregate members to the symbol table is a source
of the dozens of forward reference bugs in D. This change makes it so
that known members are added in before running semantic to give them the
best possible chance of being resolved without needing to trigger a
cascading effect of `semantic > resolve > semantic > resolve > ...`
which can wrongly trip up the "forward reference to ..." detection if
declarations appear in the source file in the wrong order.

I would have preferred to add importAll to a lot more AST nodes, but
there is a lot of unpicking to be done in various semantic visitor
passes in order to properly support early symbol resolving, and maybe
places use `!symtab` to determine whether semantic should be ran, to
which modifying has the potential for breaking downstream code if not
handled right, despite fixing half a dozen or more. In some cases there
are simply too many knots to untangle, but this seems like a good start
and is relatively small.
```