### PR TITLE
Deprecate case-variables

### DIFF
--- a/changelog/dmd.deprecate-case-variables.dd
+++ b/changelog/dmd.deprecate-case-variables.dd
@@ -1,0 +1,44 @@
+Using run-time variables as switch cases has been deprecated
+
+It's a feature that's not commonly used, and it goes against normal expectations of a switch statement.
+When using run-time variables:
+
+- Case statements can contain duplicates
+- Case statements can be mutated through mutable aliasing of a `const ref`
+- There's no fast dispatch mechanism (such as a jump table)
+
+It's also only implemented for integers, on strings it gives a weird error message ([Issue 23635](https://issues.dlang.org/show_bug.cgi?id=23635)).
+See also the discussion in [Issue 16523](https://issues.dlang.org/show_bug.cgi?id=16523).
+
+---
+void f(const int x, const int y, const int z)
+{
+    // Deprecated:
+    switch(x)
+    {
+        case y:
+            // ...
+            break;
+        case z:
+            // ...
+            break;
+        default:
+            // ...
+            break;
+    }
+
+    // Corrective action:
+    if (x == y)
+    {
+        // case y
+    }
+    else if (x == z)
+    {
+        // case z
+    }
+    else
+    {
+        // default
+    }
+}
+---

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2166,6 +2166,11 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             */
             if (e.op == EXP.variable)
             {
+                // @@@DEPRECATION 2.113
+                // Turn into an error and remove this branch,
+                // as well as other branches on `SwitchStatement.hasVars == 1`
+                cs.deprecation("run-time `case` variables are deprecated, use if-else statements instead");
+
                 VarExp ve = cast(VarExp)e;
                 VarDeclaration v = ve.var.isVarDeclaration();
                 Type t = cs.exp.type.toBasetype();

--- a/compiler/test/compilable/b17111.d
+++ b/compiler/test/compilable/b17111.d
@@ -1,3 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+compilable/b17111.d(15): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+compilable/b17111.d(16): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+---
+*/
+
 alias TestType = ubyte;
 
 void test(immutable TestType a, immutable TestType b, TestType c)

--- a/compiler/test/compilable/interpret3.d
+++ b/compiler/test/compilable/interpret3.d
@@ -2,7 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/interpret3.d(6350): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
+compilable/interpret3.d(2915): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+compilable/interpret3.d(6351): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
 ---
 */
 

--- a/compiler/test/fail_compilation/diag9358.d
+++ b/compiler/test/fail_compilation/diag9358.d
@@ -1,10 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9358.d(13): Error: `x` must be of integral or string type, it is a `double`
-fail_compilation/diag9358.d(15): Error: `case` expression must be a compile-time `string` or an integral constant, not `1.1`
-fail_compilation/diag9358.d(16): Error: `case` expression must be a compile-time `string` or an integral constant, not `2.1`
-fail_compilation/diag9358.d(26): Error: `case` expression must be a compile-time `string` or an integral constant, not `z`
+fail_compilation/diag9358.d(14): Error: `x` must be of integral or string type, it is a `double`
+fail_compilation/diag9358.d(16): Error: `case` expression must be a compile-time `string` or an integral constant, not `1.1`
+fail_compilation/diag9358.d(17): Error: `case` expression must be a compile-time `string` or an integral constant, not `2.1`
+fail_compilation/diag9358.d(27): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+fail_compilation/diag9358.d(27): Error: `case` expression must be a compile-time `string` or an integral constant, not `z`
 ---
 */
 void main()

--- a/compiler/test/fail_compilation/ice17831.d
+++ b/compiler/test/fail_compilation/ice17831.d
@@ -1,16 +1,21 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice17831.d(23): Error: `case` variables have to be `const` or `immutable`
-fail_compilation/ice17831.d(23): Error: `case` variable `i` declared at fail_compilation/ice17831.d(21) cannot be declared in `switch` body
-fail_compilation/ice17831.d(37): Error: `case` variables have to be `const` or `immutable`
-fail_compilation/ice17831.d(37): Error: `case` variable `i` declared at fail_compilation/ice17831.d(35) cannot be declared in `switch` body
-fail_compilation/ice17831.d(52): Error: `case` variables have to be `const` or `immutable`
-fail_compilation/ice17831.d(52): Error: `case` variable `i` declared at fail_compilation/ice17831.d(49) cannot be declared in `switch` body
-fail_compilation/ice17831.d(65): Error: `case` variables have to be `const` or `immutable`
-fail_compilation/ice17831.d(65): Error: `case` variable `i` declared at fail_compilation/ice17831.d(64) cannot be declared in `switch` body
-fail_compilation/ice17831.d(77): Error: `case` variables have to be `const` or `immutable`
-fail_compilation/ice17831.d(77): Error: `case` variable `i` declared at fail_compilation/ice17831.d(76) cannot be declared in `switch` body
+fail_compilation/ice17831.d(28): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+fail_compilation/ice17831.d(28): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/ice17831.d(28): Error: `case` variable `i` declared at fail_compilation/ice17831.d(26) cannot be declared in `switch` body
+fail_compilation/ice17831.d(42): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+fail_compilation/ice17831.d(42): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/ice17831.d(42): Error: `case` variable `i` declared at fail_compilation/ice17831.d(40) cannot be declared in `switch` body
+fail_compilation/ice17831.d(57): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+fail_compilation/ice17831.d(57): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/ice17831.d(57): Error: `case` variable `i` declared at fail_compilation/ice17831.d(54) cannot be declared in `switch` body
+fail_compilation/ice17831.d(70): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+fail_compilation/ice17831.d(70): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/ice17831.d(70): Error: `case` variable `i` declared at fail_compilation/ice17831.d(69) cannot be declared in `switch` body
+fail_compilation/ice17831.d(82): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+fail_compilation/ice17831.d(82): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/ice17831.d(82): Error: `case` variable `i` declared at fail_compilation/ice17831.d(81) cannot be declared in `switch` body
 ---
  */
 

--- a/compiler/test/fail_compilation/test16523.d
+++ b/compiler/test/fail_compilation/test16523.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test16523.d(12): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/test16523.d(13): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+fail_compilation/test16523.d(13): Error: `case` variables have to be `const` or `immutable`
 ---
 */
 

--- a/compiler/test/fail_compilation/test_switch_error.d
+++ b/compiler/test/fail_compilation/test_switch_error.d
@@ -78,7 +78,9 @@ void test4()
 /++
 TEST_OUTPUT:
 ---
+fail_compilation/test_switch_error.d(405): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
 fail_compilation/test_switch_error.d(405): Error: `case` variables have to be `const` or `immutable`
+fail_compilation/test_switch_error.d(412): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
 fail_compilation/test_switch_error.d(412): Error: `case` variables not allowed in `final switch` statements
 ---
 ++/
@@ -105,10 +107,13 @@ TEST_OUTPUT:
 ---
 fail_compilation/test_switch_error.d(513): Error: undefined identifier `undefinedFunc`
 fail_compilation/test_switch_error.d(517): Error: `case` expression must be a compile-time `string` or an integral constant, not `Strukt(1)`
+fail_compilation/test_switch_error.d(518): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
 fail_compilation/test_switch_error.d(518): Error: `case` variables have to be `const` or `immutable`
 fail_compilation/test_switch_error.d(518): Error: `case` variables not allowed in `final switch` statements
+fail_compilation/test_switch_error.d(519): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
 fail_compilation/test_switch_error.d(519): Error: `case` variables not allowed in `final switch` statements
 fail_compilation/test_switch_error.d(522): Error: undefined identifier `undefinedFunc2`
+fail_compilation/test_switch_error.d(524): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
 ---
 ++/
 #line 500

--- a/compiler/test/runnable/testswitch.d
+++ b/compiler/test/runnable/testswitch.d
@@ -1,4 +1,12 @@
 // PERMUTE_ARGS: -w
+/*
+TEST_OUTPUT:
+---
+runnable/testswitch.d(344): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+runnable/testswitch.d(350): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+runnable/testswitch.d(353): Deprecation: run-time `case` variables are deprecated, use if-else statements instead
+---
+*/
 
 extern(C) int printf(const char*, ...);
 


### PR DESCRIPTION
Should start as a deprecation first of course, but let's see if any buildkite use this feature first.