### PR TITLE
fix Issue 21492 - betterC: TypeInfo is generated for code guarded by …

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -6102,6 +6102,13 @@ elem *sarray_toDarray(const ref Loc loc, Type tfrom, Type tto, elem *e)
 private
 elem *getTypeInfo(Expression e, Type t, IRState* irs)
 {
+    if (irs.falseBlock)
+    {
+        /* Return null so we do not trigger the error
+         * about no TypeInfo
+         */
+        return el_long(TYnptr, 0);
+    }
     assert(t.ty != Terror);
     genTypeInfo(e, e.loc, t, null);
     elem* result = el_ptr(toSymbol(t.vtinfo));

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -86,6 +86,7 @@ struct IRState
     Label*[void*]* labels;          // table of labels used/declared in function
     const Param* params;            // command line parameters
     const Target* target;           // target
+    int falseBlock;                 // !=0 means do not generate code
     bool mayThrow;                  // the expression being evaluated may throw
     bool Cfile;                     // use C semantics
 

--- a/compiler/test/runnable/test21492.d
+++ b/compiler/test/runnable/test21492.d
@@ -1,0 +1,34 @@
+/* REQUIRED_ARGS: -betterC
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=21492
+
+int test(int i)
+{
+    switch (i)
+    {
+	case 0:
+	    break;
+	case 1:
+	    if (__ctfe)
+	    {
+		{ int[] foo = [1]; }
+	L3:
+		i += 2;
+	case 2:
+		++i;
+	    }
+	    return i;
+	default:
+	    break;
+    }
+    goto L3;
+}
+
+extern (C)
+int main()
+{
+    static assert(test(1) == 4);
+    assert(test(2) == 3);
+    return 0;
+}


### PR DESCRIPTION
…if(__ctfe)

Code protected by `if (__ctfe)` need not have any code generated for it, as illustrated by the bug report. Generating code for it anyway will trigger an error that certain things are not allowed in -betterC code, but are allowed in ctfe code.

Normally, the backend will do just fine eliminating such dead code. But the error detection occurs before the backend. To do it thoroughly in the front end requires data flow analysis. But that's awful expensive for just this problem. So this PR implements a rather primitive method which will handle the usual cases. The cases it doesn't handle (and such can be easily contrived) will still trigger the error. But such are easily rewritten into the form that is accepted, so nothing is worse off.

More cases can be worked in if the future if it becomes necessary.