### PR TITLE
druntime: avoid using compiler tricks of unspecified .mangleof

### DIFF
--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -202,8 +202,8 @@ unittest
 // make it more difficult to call the function again, manually.
 private void initialize();
 pragma(crt_constructor)
-pragma(mangle, `_D` ~ initialize.mangleof)
-private extern (C) void initialize() @system
+pragma(mangle, initialize.mangleof)
+private extern (C) void _initialize() @system
 {
     version (Posix)
     {


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

This is unspecified behaviour of `.mangleof` and we might want to forbid the usage of this. This behaviour happens when multiple overloads of the same function exists.