### PR TITLE
Translate `_d_newclass` to a template

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -1083,10 +1083,7 @@ elem* toElem(Expression e, IRState *irs)
                 assert(!(global.params.ehnogc && ne.thrownew),
                     "This should have been rewritten to `_d_newThrowable` in the semantic phase.");
 
-                Symbol *csym = toSymbol(cd);
-                const rtl = RTLSYM.NEWCLASS;
-                ex = el_bin(OPcall,TYnptr,el_var(getRtlsym(rtl)),el_ptr(csym));
-                toTraceGC(irs, ex, ne.loc);
+                ex = toElem(ne.lowering, irs);
                 ectype = null;
 
                 if (cd.isNested())

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -1544,7 +1544,8 @@ extern (C++) abstract class Expression : ASTNode
                 // Lowered non-@nogc'd hooks will print their own error message inside of nogc.d (NOGCVisitor.visit(CallExp e)),
                 // so don't print anything to avoid double error messages.
                 if (!(f.ident == Id._d_HookTraceImpl || f.ident == Id._d_arraysetlengthT
-                    || f.ident == Id._d_arrayappendT || f.ident == Id._d_arrayappendcTX))
+                    || f.ident == Id._d_arrayappendT || f.ident == Id._d_arrayappendcTX
+                    || f.ident == Id._d_newclassT))
                     error("`@nogc` %s `%s` cannot call non-@nogc %s `%s`",
                         sc.func.kind(), sc.func.toPrettyChars(), f.kind(), f.toPrettyChars());
 
@@ -3649,6 +3650,8 @@ extern (C++) final class NewExp : Expression
     CtorDeclaration member;     // constructor function
     bool onstack;               // allocate on stack
     bool thrownew;              // this NewExp is the expression of a ThrowStatement
+
+    Expression lowering;        // lowered druntime hook: `_d_newclass`
 
     extern (D) this(const ref Loc loc, Expression thisexp, Type newtype, Expressions* arguments)
     {

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -539,6 +539,8 @@ public:
     bool onstack;               // allocate on stack
     bool thrownew;              // this NewExp is the expression of a ThrowStatement
 
+    Expression lowering;        // lowered druntime hook: `_d_newclass`
+
     static NewExp *create(const Loc &loc, Expression *thisexp, Type *newtype, Expressions *arguments);
     NewExp *syntaxCopy() override;
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7183,6 +7183,7 @@ public:
     CtorDeclaration* member;
     bool onstack;
     bool thrownew;
+    Expression* lowering;
     static NewExp* create(const Loc& loc, Expression* thisexp, Type* newtype, Array<Expression* >* arguments);
     NewExp* syntaxCopy() override;
     void accept(Visitor* v) override;
@@ -8573,6 +8574,8 @@ struct Id final
     static Identifier* criticalexit;
     static Identifier* _d_delThrowable;
     static Identifier* _d_newThrowable;
+    static Identifier* _d_newclassT;
+    static Identifier* _d_newclassTTrace;
     static Identifier* _d_assert_fail;
     static Identifier* dup;
     static Identifier* _aaApply;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -313,6 +313,8 @@ immutable Msgtable[] msgtable =
     { "__ArrayDtor" },
     { "_d_delThrowable" },
     { "_d_newThrowable" },
+    { "_d_newclassT" },
+    { "_d_newclassTTrace" },
     { "_d_assert_fail" },
     { "dup" },
     { "_aaApply" },

--- a/compiler/test/compilable/test23431_minimal.d
+++ b/compiler/test/compilable/test23431_minimal.d
@@ -13,6 +13,13 @@ class Exception : Throwable
 
 class Error { }
 
+// Needed to lower `new Exception("ice")` to it.
+T _d_newclassT(T)()
+if (is(T == class))
+{
+    return null;
+}
+
 void test23431()
 {
     int a;

--- a/compiler/test/compilable/test23433.d
+++ b/compiler/test/compilable/test23433.d
@@ -4,6 +4,13 @@ module object;
 class Throwable { }
 class Exception : Throwable { this(immutable(char)[]) { } }
 
+// Needed to lower `new Exception("ice")` to it.
+T _d_newclassT(T)()
+if (is(T == class))
+{
+    return null;
+}
+
 void test23433()
 {
     try

--- a/compiler/test/fail_compilation/fail308.d
+++ b/compiler/test/fail_compilation/fail308.d
@@ -16,6 +16,6 @@ class MinHeap(NodeType)
     unittest
     {
         struct TestType {}
-        MinHeap!(TestType) foo = new MinHeap!(TestType)();
+        MinHeap!(TestType) foo;
     }
 }

--- a/compiler/test/fail_compilation/ice23569.d
+++ b/compiler/test/fail_compilation/ice23569.d
@@ -2,10 +2,16 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice23569.d(18): Error: cannot compare classes for equality because `object.Object` was not declared
+fail_compilation/ice23569.d(24): Error: cannot compare classes for equality because `object.Object` was not declared
 ---
 */
 module object;
+
+T _d_newclassT(T)()
+if (is(T == class))
+{
+    return null;
+}
 
 @safe unittest1()
 {

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -2709,3 +2709,108 @@ T _d_newThrowable(T)() @trusted
     assert(exc.refcount() == 1);
     assert(e.refcount() == 1);
 }
+
+/**
+ * Create a new class instance.
+ * Allocates memory and sets fields to their initial value, but does not call a
+ * constructor.
+ * ---
+ * new C() // _d_newclass!(C)()
+ * ---
+ * Returns: newly created object
+ */
+T _d_newclassT(T)() @trusted
+if (is(T == class))
+{
+    import core.internal.traits : hasIndirections;
+    import core.exception : onOutOfMemoryError;
+    import core.memory : GC, pureMalloc;
+
+    alias BlkAttr = GC.BlkAttr;
+
+    auto init = __traits(initSymbol, T);
+    void* p;
+
+    static if (__traits(getLinkage, T) == "Windows")
+    {
+        p = pureMalloc(init.length);
+        if (!p)
+            onOutOfMemoryError();
+    }
+    else
+    {
+        BlkAttr attr = BlkAttr.NONE;
+
+        /* `extern(C++)`` classes don't have a classinfo pointer in their vtable,
+         * so the GC can't finalize them.
+         */
+        static if (__traits(hasMember, T, "__dtor") && __traits(getLinkage, T) != "C++")
+            attr |= BlkAttr.FINALIZE;
+        static if (!hasIndirections!T)
+            attr |= BlkAttr.NO_SCAN;
+
+        p = GC.malloc(init.length, attr, typeid(T));
+        debug(PRINTF) printf(" p = %p\n", p);
+    }
+
+    debug(PRINTF)
+    {
+        printf("p = %p\n", p);
+        printf("init.ptr = %p, len = %llu\n", init.ptr, cast(ulong)init.length);
+        printf("vptr = %p\n", *cast(void**) init);
+        printf("vtbl[0] = %p\n", (*cast(void***) init)[0]);
+        printf("vtbl[1] = %p\n", (*cast(void***) init)[1]);
+        printf("init[0] = %x\n", (cast(uint*) init)[0]);
+        printf("init[1] = %x\n", (cast(uint*) init)[1]);
+        printf("init[2] = %x\n", (cast(uint*) init)[2]);
+        printf("init[3] = %x\n", (cast(uint*) init)[3]);
+        printf("init[4] = %x\n", (cast(uint*) init)[4]);
+    }
+
+    // initialize it
+    p[0 .. init.length] = init[];
+
+    debug(PRINTF) printf("initialization done\n");
+    return cast(T) p;
+}
+
+// Test allocation
+@safe unittest
+{
+    class C { }
+    C c = _d_newclassT!C();
+
+    assert(c !is null);
+}
+
+// Test initializers
+@safe unittest
+{
+    {
+        class C { int x, y; }
+        C c = _d_newclassT!C();
+
+        assert(c.x == 0);
+        assert(c.y == 0);
+    }
+    {
+        class C { int x = 2, y = 3; }
+        C c = _d_newclassT!C();
+
+        assert(c.x == 2);
+        assert(c.y == 3);
+    }
+}
+
+T _d_newclassTTrace(T)(string file, int line, string funcname) @trusted
+{
+    version (D_TypeInfo)
+    {
+        import core.internal.array.utils: TraceHook, gcStatsPure, accumulatePure;
+        mixin(TraceHook!(T.stringof, "_d_newclassT"));
+
+        return _d_newclassT!T();
+    }
+    else
+        assert(0, "Cannot create new class if compiling without support for runtime type information!");
+}

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -4648,6 +4648,8 @@ public import core.internal.switch_: __switch_error;
 
 public import core.lifetime : _d_delstructImpl;
 public import core.lifetime : _d_newThrowable;
+public import core.lifetime : _d_newclassT;
+public import core.lifetime : _d_newclassTTrace;
 
 public @trusted @nogc nothrow pure extern (C) void _d_delThrowable(scope Throwable);
 

--- a/druntime/src/rt/tracegc.d
+++ b/druntime/src/rt/tracegc.d
@@ -17,7 +17,6 @@ module rt.tracegc;
 
 // version = tracegc;
 
-extern (C) Object _d_newclass(const ClassInfo ci);
 extern (C) void[] _d_newarrayT(const TypeInfo ti, size_t length);
 extern (C) void[] _d_newarrayU(const scope TypeInfo ti, size_t length);
 extern (C) void[] _d_newarrayiT(const TypeInfo ti, size_t length);

--- a/druntime/test/profile/myprofilegc.log.freebsd.32.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.32.exp
@@ -6,6 +6,7 @@ bytes allocated, allocations, type, function, file:line
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
              32	              1	void[] profilegc.main src/profilegc.d:55
+             16	              1	C D main src/profilegc.d:12
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45
@@ -15,5 +16,5 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:14
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
-             16	              1	profilegc.main.C D main src/profilegc.d:12
+             16	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2752
              16	              1	wchar[] D main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.freebsd.64.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.64.exp
@@ -5,7 +5,8 @@ bytes allocated, allocations, type, function, file:line
              64	              1	double[] profilegc.main src/profilegc.d:56
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
-             32	              1	profilegc.main.C D main src/profilegc.d:12
+             32	              1	C D main src/profilegc.d:12
+             32	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2752
              32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36

--- a/druntime/test/profile/myprofilegc.log.linux.32.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.32.exp
@@ -6,6 +6,7 @@ bytes allocated, allocations, type, function, file:line
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
              32	              1	void[] profilegc.main src/profilegc.d:55
+             16	              1	C D main src/profilegc.d:12
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45
@@ -15,5 +16,5 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:14
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
-             16	              1	profilegc.main.C D main src/profilegc.d:12
+             16	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2752
              16	              1	wchar[] D main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.linux.64.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.64.exp
@@ -5,7 +5,8 @@ bytes allocated, allocations, type, function, file:line
              64	              1	double[] profilegc.main src/profilegc.d:56
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
-             32	              1	profilegc.main.C D main src/profilegc.d:12
+             32	              1	C D main src/profilegc.d:12
+             32	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2752
              32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36

--- a/druntime/test/profile/myprofilegc.log.osx.32.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.32.exp
@@ -6,6 +6,7 @@ bytes allocated, allocations, type, function, file:line
              64	              1	int[] D main src/profilegc.d:41
              64	              1	double[] profilegc.main src/profilegc.d:56
              32	              1	void[] profilegc.main src/profilegc.d:55
+             16	              1	C D main src/profilegc.d:12
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45
@@ -15,5 +16,5 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:14
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
-             16	              1	profilegc.main.C D main src/profilegc.d:12
+             16	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2752
              16	              1	wchar[] D main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.osx.64.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.64.exp
@@ -5,7 +5,8 @@ bytes allocated, allocations, type, function, file:line
              64	              1	double[] profilegc.main src/profilegc.d:56
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
-             32	              1	profilegc.main.C D main src/profilegc.d:12
+             32	              1	C D main src/profilegc.d:12
+             32	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2752
              32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36


### PR DESCRIPTION
This PR makes the following changes:
- Add template `_d_newclassT` to `druntime.src.core.lifetime.d`
- Replace lowering of `new C()` to `_d_newclassT!C()`
- Add `lowering` member to `NewExp`. This field stores the above lowering to be used by e2ir.d
- Keep the old `_d_newclass` hook because it's used by `TypeInfo_Class.create()`
- Add dummy `_d_newclassT` hook to tests that redefine the `object` module
- Remove `new MinHeap!(TestType)()` from `fail308.d`. Otherwise the errror was changed and printed the local path to druntime
- Account for the `GC.malloc()` called by the template hook in the `-profile=gc` tests