### PR TITLE
Fix Issue 23635 - Nonsensical "`case` must be a `string` or an integr…

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2485,7 +2485,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                 cs.exp = se;
             else if (!cs.exp.isIntegerExp() && !cs.exp.isErrorExp())
             {
-                cs.error("`case` must be a `string` or an integral constant, not `%s`", cs.exp.toChars());
+                cs.error("`case` expression must be a compile-time `string` or an integral constant, not `%s`", cs.exp.toChars());
                 errors = true;
             }
 

--- a/compiler/test/fail_compilation/diag9358.d
+++ b/compiler/test/fail_compilation/diag9358.d
@@ -1,9 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9358.d(12): Error: `x` must be of integral or string type, it is a `double`
-fail_compilation/diag9358.d(14): Error: `case` must be a `string` or an integral constant, not `1.1`
-fail_compilation/diag9358.d(15): Error: `case` must be a `string` or an integral constant, not `2.1`
+fail_compilation/diag9358.d(13): Error: `x` must be of integral or string type, it is a `double`
+fail_compilation/diag9358.d(15): Error: `case` expression must be a compile-time `string` or an integral constant, not `1.1`
+fail_compilation/diag9358.d(16): Error: `case` expression must be a compile-time `string` or an integral constant, not `2.1`
+fail_compilation/diag9358.d(26): Error: `case` expression must be a compile-time `string` or an integral constant, not `z`
 ---
 */
 void main()
@@ -13,6 +14,16 @@ void main()
     {
         case 1.1: break;
         case 2.1: break;
+        default:
+    }
+}
+
+void f(immutable string y)
+{
+    auto z = y[0..2];
+    switch (y)
+    {
+        case z: break;
         default:
     }
 }

--- a/compiler/test/fail_compilation/test_switch_error.d
+++ b/compiler/test/fail_compilation/test_switch_error.d
@@ -104,7 +104,7 @@ void test5(int i)
 TEST_OUTPUT:
 ---
 fail_compilation/test_switch_error.d(513): Error: undefined identifier `undefinedFunc`
-fail_compilation/test_switch_error.d(517): Error: `case` must be a `string` or an integral constant, not `Strukt(1)`
+fail_compilation/test_switch_error.d(517): Error: `case` expression must be a compile-time `string` or an integral constant, not `Strukt(1)`
 fail_compilation/test_switch_error.d(518): Error: `case` variables have to be `const` or `immutable`
 fail_compilation/test_switch_error.d(518): Error: `case` variables not allowed in `final switch` statements
 fail_compilation/test_switch_error.d(519): Error: `case` variables not allowed in `final switch` statements
@@ -144,8 +144,8 @@ void errorsWithErrors(int param, immutable int constant)
 TEST_OUTPUT:
 ---
 fail_compilation/test_switch_error.d(622): Error: undefined identifier `undefinedFunc`
-fail_compilation/test_switch_error.d(624): Error: `case` must be a `string` or an integral constant, not `SubtypeOfInt(2)`
-fail_compilation/test_switch_error.d(625): Error: `case` must be a `string` or an integral constant, not `SubtypeOfIntMethod()`
+fail_compilation/test_switch_error.d(624): Error: `case` expression must be a compile-time `string` or an integral constant, not `SubtypeOfInt(2)`
+fail_compilation/test_switch_error.d(625): Error: `case` expression must be a compile-time `string` or an integral constant, not `SubtypeOfIntMethod()`
 ---
 ++/
 #line 600


### PR DESCRIPTION
…al constant, not `x`"