### PR TITLE
Fix issue 11051 - Unmatched case in a final switch should throw in both release and non-release mode

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2256,7 +2256,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
         }
 
         if (!sc.sw.sdefault &&
-            (!ss.isFinal || needswitcherror || global.params.useAssert == CHECKENABLE.on))
+            (!ss.isFinal || needswitcherror || global.params.useAssert == CHECKENABLE.on || sc.func.isSafe))
         {
             ss.hasNoDefault = 1;
 

--- a/compiler/test/runnable/extra-files/test11051.d
+++ b/compiler/test/runnable/extra-files/test11051.d
@@ -1,0 +1,30 @@
+module test11051;
+
+version (Safe)
+{
+    void main() @safe
+    {
+        enum E { A, B }
+        E e = cast(E)-1;
+
+        final switch (e)
+        {
+            case E.A: break;
+            case E.B: break;
+        }
+    }
+}
+else
+{
+    void main()
+    {
+        enum E { A, B }
+        E e = cast(E)-1;
+
+        final switch (e)
+        {
+            case E.A: break;
+            case E.B: break;
+        }
+    }
+}

--- a/compiler/test/runnable/test_safe_final_switch.sh
+++ b/compiler/test/runnable/test_safe_final_switch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# tests various @safe behavior for final switches in
+# -release and non-release builds
+
+src_file=runnable/extra-files/test11051.d
+
+die()
+{
+    echo "test_safe_final_switch.sh error: test #$1 failed"
+    exit 1
+}
+
+$DMD -run ${src_file} 2> /dev/null
+
+die()
+{
+    exit 1
+}
+
+# returns 1 (failure)
+$DMD -run ${src_file} 2> /dev/null && die 1
+
+# returns 0 (success)
+$DMD -release -run ${src_file} 2> /dev/null || die 2
+
+# returns 1 (failure)
+$DMD -version=Safe -run ${src_file} 2> /dev/null && die 3
+
+# returns 1 (failure)
+$DMD -release -version=Safe -run ${src_file} 2> /dev/null && die 4
+
+exit 0

--- a/compiler/test/runnable/test_safe_final_switch.sh
+++ b/compiler/test/runnable/test_safe_final_switch.sh
@@ -21,8 +21,8 @@ die()
 # returns 1 (failure)
 $DMD -run ${src_file} 2> /dev/null && die 1
 
-# returns 0 (success)
-$DMD -release -run ${src_file} 2> /dev/null || die 2
+# returns 1 (failure)
+$DMD -release -run ${src_file} 2> /dev/null && die 2
 
 # returns 1 (failure)
 $DMD -version=Safe -run ${src_file} 2> /dev/null && die 3

--- a/compiler/test/runnable/test_safe_final_switch.sh
+++ b/compiler/test/runnable/test_safe_final_switch.sh
@@ -13,11 +13,6 @@ die()
 
 $DMD -run ${src_file} 2> /dev/null
 
-die()
-{
-    exit 1
-}
-
 # returns 1 (failure)
 $DMD -run ${src_file} 2> /dev/null && die 1
 

--- a/compiler/test/runnable/test_safe_final_switch.sh
+++ b/compiler/test/runnable/test_safe_final_switch.sh
@@ -11,6 +11,9 @@ die()
     exit 1
 }
 
+# some tests cause a core dump rather than throwing an Error
+ulimit -c 0
+
 # returns 1 (failure)
 $DMD -run ${src_file} 2> /dev/null && die 1
 

--- a/compiler/test/runnable/test_safe_final_switch.sh
+++ b/compiler/test/runnable/test_safe_final_switch.sh
@@ -11,8 +11,6 @@ die()
     exit 1
 }
 
-$DMD -run ${src_file} 2> /dev/null
-
 # returns 1 (failure)
 $DMD -run ${src_file} 2> /dev/null && die 1
 


### PR DESCRIPTION
Reboot of #6095 ~~so far just fixing merge failure~~.

Keep a HALT instruction in a final switch statement if the function is @safe and -release mode is enabled.