### PR TITLE
fix Issue 23651 - Order dependency in semantic analysis of template members

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -338,12 +338,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         assert(dsym.semanticRun <= PASS.semantic);
 
-        if (dsym._scope)
-        {
-            sc = dsym._scope;
-            dsym._scope = null;
-        }
-
         if (!sc)
             return;
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -338,6 +338,17 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         assert(dsym.semanticRun <= PASS.semantic);
 
+        if (dsym._scope)
+        {
+            sc = dsym._scope;
+            dsym._scope = null;
+        }
+
+        if (!sc)
+            return;
+
+        dsym.semanticRun = PASS.semantic;
+
         dsym.storage_class |= sc.stc & STC.deprecated_;
         dsym.visibility = sc.visibility;
         dsym.userAttribDecl = sc.userAttribDecl;

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -6591,7 +6591,17 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         }
 
         TemplateInstance ti = s.parent ? s.parent.isTemplateInstance() : null;
-        if (ti && (ti.name == s.ident || ti.toAlias().ident == s.ident) && ti.tempdecl)
+
+        /* This avoids the VarDeclaration.toAlias() which runs semantic() too soon
+         */
+        static bool matchId(TemplateInstance ti, Identifier id)
+        {
+            if (ti.aliasdecl && ti.aliasdecl.isVarDeclaration())
+                return ti.aliasdecl.isVarDeclaration().ident == id;
+            return ti.toAlias().ident == id;
+        }
+
+        if (ti && (ti.name == s.ident || matchId(ti, s.ident)) && ti.tempdecl)
         {
             /* This is so that one can refer to the enclosing
              * template, even if it has the same name as a member

--- a/compiler/test/compilable/test23651.d
+++ b/compiler/test/compilable/test23651.d
@@ -1,0 +1,34 @@
+// https://issues.dlang.org/show_bug.cgi?id=23651
+
+template isCallable(alias callable)
+{
+    static if (is(typeof(&callable!())))
+        enum bool isCallable = isCallable!(typeof(&callable!()));
+    else
+        enum bool isCallable = true;
+}
+
+string foo();
+
+template FunctionTypeOf(alias func)
+if (isCallable!func)
+{
+    alias FunctionTypeOf = typeof(foo);
+}
+
+template ReturnType(alias func)
+{
+    static if (is(FunctionTypeOf!func R == return))
+        alias ReturnType = R;
+}
+
+template isAttrRange()
+{
+    alias NameType  = ReturnType!((string r) => r);
+    //pragma(msg, "isAttrRange ", NameType, " ", string);
+    static assert(is(NameType == string));
+
+    enum isAttrRange = is(NameType == string);
+}
+
+static assert(isAttrRange!());


### PR DESCRIPTION
AliasDeclarations should behave like other declarations w.r.t. being able to be lazily semantically evaluated.