### PR TITLE
Fix Issue 23650 - Using typeid with struct defined in __traits(compiles, ...) causes linker error

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5519,8 +5519,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             // Handle this in the glue layer
             e = new TypeidExp(exp.loc, ta);
-            e.type = getTypeInfoType(exp.loc, ta, sc);
 
+            bool genObjCode = true;
+
+            // https://issues.dlang.org/show_bug.cgi?id=23650
+            // We generate object code for typeinfo, required
+            // by typeid, only if in non-speculative context
+            if (sc.flags & SCOPE.compile)
+            {
+                genObjCode = false;
+            }
+
+            e.type = getTypeInfoType(exp.loc, ta, sc, genObjCode);
             semanticTypeInfo(sc, ta);
 
             if (ea)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8156,9 +8156,9 @@ extern Target target;
 
 extern bool tpsemantic(TemplateParameter* tp, Scope* sc, Array<TemplateParameter* >* parameters);
 
-extern void genTypeInfo(Expression* e, const Loc& loc, Type* torig, Scope* sc);
+extern void genTypeInfo(Expression* e, const Loc& loc, Type* torig, Scope* sc, bool genObjCode = true);
 
-extern Type* getTypeInfoType(const Loc& loc, Type* t, Scope* sc);
+extern Type* getTypeInfoType(const Loc& loc, Type* t, Scope* sc, bool genObjCode = true);
 
 extern bool builtinTypeInfo(Type* t);
 

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -34,8 +34,9 @@ import core.stdc.stdio;
  *      loc   = the location for reporting line numbers in errors
  *      torig = the type to generate the `TypeInfo` object for
  *      sc    = the scope
+ *      genObjCode = if true, object code will be generated for the obtained TypeInfo
  */
-extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc)
+extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc, bool genObjCode = true)
 {
     // printf("genTypeInfo() %s\n", torig.toChars());
 
@@ -80,7 +81,7 @@ extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope
 
         // generate a COMDAT for other TypeInfos not available as builtins in
         // druntime
-        if (!isUnqualifiedClassInfo && !builtinTypeInfo(t))
+        if (!isUnqualifiedClassInfo && !builtinTypeInfo(t) && genObjCode)
         {
             if (sc) // if in semantic() pass
             {
@@ -105,13 +106,14 @@ extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope
  *      loc = the location for reporting line nunbers in errors
  *      t   = the type to get the type of the `TypeInfo` object for
  *      sc  = the scope
+ *      genObjCode = if true, object code will be generated for the obtained TypeInfo
  * Returns:
  *      The type of the `TypeInfo` object associated with `t`
  */
-extern (C++) Type getTypeInfoType(const ref Loc loc, Type t, Scope* sc)
+extern (C++) Type getTypeInfoType(const ref Loc loc, Type t, Scope* sc, bool genObjCode = true)
 {
     assert(t.ty != Terror);
-    genTypeInfo(null, loc, t, sc);
+    genTypeInfo(null, loc, t, sc, genObjCode);
     return t.vtinfo.type;
 }
 

--- a/compiler/test/runnable/test23650.d
+++ b/compiler/test/runnable/test23650.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=23650
+
+__gshared int x;
+
+void main()
+{
+
+    static assert(__traits(compiles,
+    {
+        struct S { int *p = &x; }
+        auto t = typeid(S);
+    }));
+}


### PR DESCRIPTION
Currently blocking: https://github.com/dlang/dmd/pull/14664

If a typeid is encountered in a speculative context it should not generate any Typeinfo.
The actual typeinfo ast node is generated so that assignments such as `Typeinfo a = typeid(b)`
still work.