### PR TITLE
rename VarDeclaration.aliassym to aliasTuple

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1111,7 +1111,7 @@ extern (C++) class VarDeclaration : Declaration
 {
     Initializer _init;
     FuncDeclarations nestedrefs;    // referenced by these lexically nested functions
-    Dsymbol aliassym;               // if redone as alias to another symbol
+    TupleDeclaration aliasTuple;    // when `this` is really a tuple of declarations
     VarDeclaration lastVar;         // Linked list of variables for goto-skips-init detection
     Expression edtor;               // if !=null, does the destruction of the variable
     IntRange* range;                // if !=null, the variable is known to be within the range
@@ -1200,12 +1200,10 @@ extern (C++) class VarDeclaration : Declaration
     {
         //printf("VarDeclaration::setFieldOffset(ad = %s) %s\n", ad.toChars(), toChars());
 
-        if (aliassym)
+        if (aliasTuple)
         {
             // If this variable was really a tuple, set the offsets for the tuple fields
-            TupleDeclaration v2 = aliassym.isTupleDeclaration();
-            assert(v2);
-            v2.foreachVar((s) { s.setFieldOffset(ad, fieldState, isunion); });
+            aliasTuple.foreachVar((s) { s.setFieldOffset(ad, fieldState, isunion); });
             return;
         }
 
@@ -1698,8 +1696,8 @@ extern (C++) class VarDeclaration : Declaration
         if ((!type || !type.deco) && _scope)
             dsymbolSemantic(this, _scope);
 
-        assert(this != aliassym);
-        Dsymbol s = aliassym ? aliassym.toAlias() : this;
+        assert(this != aliasTuple);
+        Dsymbol s = aliasTuple ? aliasTuple.toAlias() : this;
         return s;
     }
 

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -229,7 +229,7 @@ class VarDeclaration : public Declaration
 public:
     Initializer *_init;
     FuncDeclarations nestedrefs; // referenced by these lexically nested functions
-    Dsymbol *aliassym;          // if redone as alias to another symbol
+    TupleDeclaration *aliasTuple;  // if `this` is really a tuple of declarations
     VarDeclaration *lastVar;    // Linked list of variables for goto-skips-init detection
     Expression *edtor;          // if !=NULL, does the destruction of the variable
     IntRange *range;            // if !NULL, the variable is known to be within the range

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -694,7 +694,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             auto v2 = new TupleDeclaration(dsym.loc, dsym.ident, exps);
             v2.parent = dsym.parent;
             v2.isexp = true;
-            dsym.aliassym = v2;
+            dsym.aliasTuple = v2;
             dsym.semanticRun = PASS.semanticdone;
             return;
         }
@@ -7027,12 +7027,10 @@ bool determineFields(AggregateDeclaration ad)
         if (ad.sizeok != Sizeok.none)
             return 1;
 
-        if (v.aliassym)
+        if (v.aliasTuple)
         {
             // If this variable was really a tuple, process each element.
-            if (auto tup = v.aliassym.isTupleDeclaration())
-                return tup.foreachVar(tv => tv.apply(&func, ad));
-            return 0;
+            return v.aliasTuple.foreachVar(tv => tv.apply(&func, ad));
         }
 
         if (v.storage_class & (STC.static_ | STC.extern_ | STC.tls | STC.gshared | STC.manifest | STC.ctfe | STC.templateparameter))

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -875,7 +875,7 @@ public:
         // (we'll visit them later)
         if (vd.type && vd.type.isTypeTuple())
         {
-            assert(vd.aliassym);
+            assert(vd.aliasTuple);
             vd.toAlias().accept(this);
             return;
         }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5912,7 +5912,7 @@ class VarDeclaration : public Declaration
 public:
     Initializer* _init;
     Array<FuncDeclaration* > nestedrefs;
-    Dsymbol* aliassym;
+    TupleDeclaration* aliasTuple;
     VarDeclaration* lastVar;
     Expression* edtor;
     IntRange* range;

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -248,9 +248,9 @@ private extern(C++) final class Semantic2Visitor : Visitor
         sc.varDecl = vd;
         scope(exit) sc.varDecl = null;
 
-        if (vd.aliassym)        // if it's a tuple
+        if (vd.aliasTuple)        // if it's a tuple
         {
-            vd.aliassym.accept(this);
+            vd.aliasTuple.accept(this);
             vd.semanticRun = PASS.semantic2done;
             return;
         }

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -565,7 +565,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 return;
             }
 
-            if (vd.aliassym)
+            if (vd.aliasTuple)
             {
                 vd.toAlias().accept(this);
                 return;

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -771,7 +771,7 @@ public:
                 if (VarDeclaration *var = sym->isVarDeclaration())
                 {
                     (void)var->csym;
-                    (void)var->aliassym;
+                    (void)var->aliasTuple;
                     (void)var->isField();
                     (void)var->ident->toChars();
                     continue;
@@ -833,7 +833,7 @@ public:
                 if (VarDeclaration *var = sym->isVarDeclaration())
                 {
                     (void)var->csym;
-                    (void)var->aliassym;
+                    (void)var->aliasTuple;
                     (void)var->isField();
                     (void)var->ident->toChars();
                     continue;
@@ -1545,7 +1545,7 @@ public:
             }
             return;
         }
-        if (d->aliassym)
+        if (d->aliasTuple)
         {
             d->toAlias()->accept(this);
             return;


### PR DESCRIPTION
I ran into this and was misled by the name. So changed it (and its type) to what it really represents.