### PR TITLE
Propagate SCOPE.compiles for nested functions in traits(compiles) blocks

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -1441,7 +1441,7 @@ extern (C++) abstract class Expression : ASTNode
     */
     private static bool checkImpure(Scope* sc)
     {
-        return sc.func && (sc.flags & SCOPE.compile
+        return sc.func && (isRootTraitsCompilesScope(sc)
                 ? sc.func.isPureBypassingInference() >= PURE.weak
                 : sc.func.setImpure());
     }
@@ -1483,7 +1483,7 @@ extern (C++) abstract class Expression : ASTNode
 
         if (!f.isSafe() && !f.isTrusted())
         {
-            if (sc.flags & SCOPE.compile ? sc.func.isSafeBypassingInference() : sc.func.setUnsafeCall(f))
+            if (isRootTraitsCompilesScope(sc) ? sc.func.isSafeBypassingInference() : sc.func.setUnsafeCall(f))
             {
                 if (!loc.isValid()) // e.g. implicitly generated dtor
                     loc = sc.func.loc;
@@ -1536,7 +1536,7 @@ extern (C++) abstract class Expression : ASTNode
 
         if (!f.isNogc())
         {
-            if (sc.flags & SCOPE.compile ? sc.func.isNogcBypassingInference() : sc.func.setGC())
+            if (isRootTraitsCompilesScope(sc) ? sc.func.isNogcBypassingInference() : sc.func.setGC())
             {
                 if (loc.linnum == 0) // e.g. implicitly generated dtor
                     loc = sc.func.loc;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -4355,6 +4355,26 @@ extern (C++) final class NewDeclaration : FuncDeclaration
 }
 
 /**************************************
+ * When a traits(compiles) is used on a function literal call
+ * we need to take into account if the body of the function
+ * violates any attributes, however, we must not affect the
+ * attribute inference on the outer function. The attributes
+ * of the function literal still need to be inferred, therefore
+ * we need a way to check for the scope that the traits compiles
+ * introduces.
+ *
+ * Params:
+ *   sc = scope to be checked for
+ *
+ * Returns: `true` if the provided scope is the root
+ * of the traits compiles list of scopes.
+ */
+bool isRootTraitsCompilesScope(Scope* sc)
+{
+    return (sc.flags & SCOPE.compile) && !(sc.func.flags & SCOPE.compile);
+}
+
+/**************************************
  * A statement / expression in this scope is not `@safe`,
  * so mark the enclosing function as `@system`
  *
@@ -4396,7 +4416,7 @@ bool setUnsafe(Scope* sc,
     }
 
 
-    if (sc.flags & SCOPE.compile) // __traits(compiles, x)
+    if (isRootTraitsCompilesScope(sc)) // __traits(compiles, x)
     {
         if (sc.func.isSafeBypassingInference())
         {

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -342,7 +342,6 @@ private extern(C++) final class Semantic3Visitor : Visitor
             sc2.aligndecl = null;
             if (funcdecl.ident != Id.require && funcdecl.ident != Id.ensure)
                 sc2.flags = sc.flags & ~SCOPE.contract;
-            sc2.flags &= ~SCOPE.compile;
             sc2.tf = null;
             sc2.os = null;
             sc2.inLoop = false;


### PR DESCRIPTION
While trying to fix [1][2], I noticed that when a function's body is semantically analyzed the SCOPE.compiles field is always set to 0. Digging through what has caused this, I noticed that [this was done to prevent traits(compiles) blocks from affecting the inferred attributes of the outer function](https://github.com/dlang/dmd/pull/3625/files#diff-02babf7ea0f50cfaa87332ce316d492b684016b8ed9761fd79cb4fc9afeab54cR1294). However, this has the side effect that functions that are nested in the traits(compiles) lose this information. This information is necessary for [2], which currently works around this issue by using one of the 4 different ways of checking if we are in a speculative scope, but should use SCOPE.compiles after this is merged. I suspect that this will also make it easy to get rid of the useless complexity added by [3].

[1] https://issues.dlang.org/show_bug.cgi?id=23650
[2] https://github.com/dlang/dmd/pull/14844
[3] https://github.com/dlang/dmd/pull/7897