### PR TITLE
Remove FUNCFLAG.compileTimeOnly 

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1658,8 +1658,7 @@ extern (C++) class VarDeclaration : Declaration
         // Add this VarDeclaration to fdv.closureVars[] if not already there
         if (!sc.intypeof && !(sc.flags & SCOPE.compile) &&
             // https://issues.dlang.org/show_bug.cgi?id=17605
-            (fdv.isCompileTimeOnly || !fdthis.isCompileTimeOnly)
-           )
+            (fdv.skipCodegen || !fdthis.skipCodegen))
         {
             if (!fdv.closureVars.contains(this))
                 fdv.closureVars.push(this);

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -636,8 +636,6 @@ public:
     bool inferScope(bool v);
     bool hasCatches() const;
     bool hasCatches(bool v);
-    bool isCompileTimeOnly() const;
-    bool isCompileTimeOnly(bool v);
     bool skipCodegen() const;
     bool skipCodegen(bool v);
     bool printf() const;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -3059,7 +3059,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         //printf("function storage_class = x%llx, sc.stc = x%llx, %x\n", storage_class, sc.stc, Declaration.isFinal());
 
         if (sc.flags & SCOPE.compile)
-            funcdecl.isCompileTimeOnly = true; // don't emit code for this function
+            funcdecl.skipCodegen = true;
 
         funcdecl._linkage = sc.linkage;
         if (auto fld = funcdecl.isFuncLiteralDeclaration())

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2494,8 +2494,6 @@ public:
     bool inferScope(bool v);
     bool hasCatches() const;
     bool hasCatches(bool v);
-    bool isCompileTimeOnly() const;
-    bool isCompileTimeOnly(bool v);
     bool skipCodegen() const;
     bool skipCodegen(bool v);
     bool printf() const;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -202,9 +202,7 @@ private struct FUNCFLAG
     bool inlineScanned;      /// function has been scanned for inline possibilities
     bool inferScope;         /// infer 'scope' for parameters
     bool hasCatches;         /// function has try-catch statements
-    bool isCompileTimeOnly;  /// is a compile time only function; no code will be generated for it
     bool skipCodegen;        /// do not generate code for this function.
-                             // FIXME: redundant with `isCompileTimeOnly`, see https://github.com/dlang/dmd/pull/14791#discussion_r1065066099
     bool printf;             /// is a printf-like function
     bool scanf;              /// is a scanf-like function
     bool noreturn;           /// the function does not return


### PR DESCRIPTION
Because it is redundant with FUNCFLAG.skipCodegen and used instead of SCOPE.compile.

As detailed in https://github.com/dlang/dmd/pull/14846 , the addition of compileTimeOnly [was a hack](https://github.com/dlang/dmd/pull/7897) to mask [another hack](https://github.com/dlang/dmd/pull/3625/files#diff-02babf7ea0f50cfaa87332ce316d492b684016b8ed9761fd79cb4fc9afeab54cR1294).

https://github.com/dlang/dmd/pull/14846 untied the original hack so we can now tidy up the mess.