### PR TITLE
Add test for calling a function type

### DIFF
--- a/compiler/test/fail_compilation/call_function_type.d
+++ b/compiler/test/fail_compilation/call_function_type.d
@@ -1,0 +1,20 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/call_function_type.d(18): Error: expected 1 function arguments, not 0
+fail_compilation/call_function_type.d(19): Error: cannot call `int(int)(3)` at compile time
+---
+*/
+
+// This is a rare case where `dmd.expressionsem.functionParameters` catches a missing argument error,
+// which is usually caught earlier by `TypeFunction.callMatch`, and had no test coverage yet.
+// This was found while implementing named arguments and reduced from `vibe.internal.meta.traits`.
+
+int f(int);
+
+void m()
+{
+	alias FT = typeof(f);
+	enum X0 = FT();
+	enum X1 = FT(3);
+}


### PR DESCRIPTION
This is a rare case where `dmd.expressionsem.functionParameters` catches a missing argument error, which is usually caught earlier by `TypeFunction.callMatch`, and had no test coverage yet. This was found while implementing named arguments and reduced from `vibe.internal.meta.traits`.