### PR TITLE
[WIP] fix issue 4071 and others: shared runtime DLL for Windows

### DIFF
--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -164,6 +164,9 @@ if [ "$MODEL" != "32omf" ] ; then
     # run some tests for shared druntime
     # the test_runner links against libdruntime-ut.dll and runs all unittests
     #  no matter what module name is passed in
+
+    # no separate output for static or shared builds, so clean directories to force rebuild
+    rm -rf test/shared/generated
     # running additional tests needs druntime_shared.dll on the path
     export PATH="$PATH:$PWD/generated/windows/release/$MODEL"
     "$GNU_MAKE" -j$N unittest MODEL=$MODEL SHARED=1 DMD="$DMD_BIN_PATH" CC="$CC" \

--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -169,7 +169,7 @@ if [ "$MODEL" != "32omf" ] ; then
     rm -rf test/shared/generated
     # running additional tests needs druntime_shared.dll on the path
     export PATH="$PATH:$PWD/generated/windows/release/$MODEL"
-    "$GNU_MAKE" -j$N unittest MODEL=$MODEL SHARED=1 DMD="$DMD_BIN_PATH" CC="$CC" \
+    "$GNU_MAKE" -j$N unittest MODEL=$MODEL BUILD=release SHARED=1 DMD="$DMD_BIN_PATH" CC="$CC" \
         UT_MODULES=../generated/windows/release/$MODEL/unittest/object ADDITIONAL_TESTS=test/shared
 fi
 

--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -160,6 +160,16 @@ fi
 cd "$DMD_DIR/druntime"
 "$GNU_MAKE" -j$N MODEL=$MODEL DMD="$DMD_BIN_PATH" CC="$CC" unittest
 
+if [ "$MODEL" != "32omf" ] ; then
+    # run some tests for shared druntime
+    # the test_runner links against libdruntime-ut.dll and runs all unittests
+    #  no matter what module name is passed in
+    # running additional tests needs druntime_shared.dll on the path
+    export PATH="$PATH:$PWD/generated/windows/release/$MODEL"
+    "$GNU_MAKE" -j$N unittest MODEL=$MODEL SHARED=1 DMD="$DMD_BIN_PATH" CC="$CC" \
+        UT_MODULES=../generated/windows/release/$MODEL/unittest/object ADDITIONAL_TESTS=test/shared
+fi
+
 ################################################################################
 # Build and run Phobos unittests
 ################################################################################

--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -168,7 +168,7 @@ if [ "$MODEL" != "32omf" ] ; then
     # no separate output for static or shared builds, so clean directories to force rebuild
     rm -rf test/shared/generated
     # running additional tests needs druntime_shared.dll on the path
-    export PATH="$PATH:$PWD/generated/windows/release/$MODEL"
+    export PATH="$PATH:$DMD_DIR/generated/windows/release/$MODEL"
     "$GNU_MAKE" -j$N unittest MODEL=$MODEL BUILD=release SHARED=1 DMD="$DMD_BIN_PATH" CC="$CC" \
         UT_MODULES=../generated/windows/release/$MODEL/unittest/object ADDITIONAL_TESTS=test/shared
 fi

--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -77,8 +77,8 @@ extern (C) void out_config_init(
         ubyte dwarf,
         string _version,
         exefmt_t exefmt,
-        bool generatedMain      // a main entrypoint is generated
-        )
+        bool generatedMain,     // a main entrypoint is generated
+        bool dataimports)
 {
     //printf("out_config_init()\n");
 
@@ -139,6 +139,8 @@ extern (C) void out_config_init(
             cfg.objfmt = mscoff ? OBJ_MSCOFF : OBJ_OMF;
             if (mscoff)
                 cfg.flags |= CFGnoebp;    // test suite fails without this
+            if (dataimports)
+                cfg.flags2 |= CFG2noreadonly;
         }
 
         if (exe)

--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -54,6 +54,8 @@ nothrow:
     _version      = Compiler version
     exefmt        = Executable file format
     generatedMain = a main entrypoint is generated
+    dataimports   = do not place data symbols into read-only segment,
+                    it might be necessary to resolve relocations at runtime
  */
 public
 @trusted

--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -141,10 +141,10 @@ extern (C) void out_config_init(
             cfg.objfmt = mscoff ? OBJ_MSCOFF : OBJ_OMF;
             if (mscoff)
                 cfg.flags |= CFGnoebp;    // test suite fails without this
-            if (dataimports)
-                cfg.flags2 |= CFG2noreadonly;
         }
 
+        if (dataimports)
+            cfg.flags2 |= CFG2noreadonly;
         if (exe)
             cfg.wflags |= WFexe;         // EXE file only optimizations
         cfg.flags4 |= CFG4underscore;

--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -1060,6 +1060,7 @@ enum
     SFLpmask        = 0x60,        // mask for the visibility bits
 
     SFLvtbl         = 0x2000,      // VEC_VTBL_LIST: Symbol is a vtable or vbtable
+    SFLimported     = 0x200000,    // symbol is in another DSO (D only, SFLdyninit unused)
 
     // OPTIMIZER and CODGEN
     GTregcand       = 0x100,       // if Symbol is a register candidate
@@ -1100,6 +1101,7 @@ struct Symbol
 
     Symbol* Sl, Sr;             // left, right child
     Symbol* Snext;              // next in threaded list
+    Symbol* Sisym;              // import version of this symbol
     dt_t* Sdt;                  // variables: initializer
     int Salignment;             // variables: alignment, 0 or -1 means default alignment
 

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -485,6 +485,7 @@ enum
     CFG2stomp       = 0x8000,  // enable stack stomping code
     CFG2gms         = 0x10000, // optimize debug symbols for microsoft debuggers
     CFG2genmain     = 0x20000, // main entrypoint is generated
+    CFG2noreadonly  = 0x40000, // do not generate read-only symbols, dllimport might have to patch them
 }
 
 alias config_flags3_t = uint;

--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -499,6 +499,8 @@ void outcommon(Symbol *s,targ_size_t n)
 @trusted
 void out_readonly(Symbol *s)
 {
+    if (config.flags2 & CFG2noreadonly)
+        return;
     if (config.objfmt == OBJ_ELF || config.objfmt == OBJ_MACH)
     {
         /* Cannot have pointers in CDATA when compiling PIC code, because

--- a/compiler/src/dmd/backend/elpicpie.d
+++ b/compiler/src/dmd/backend/elpicpie.d
@@ -286,6 +286,11 @@ elem * el_ptr(Symbol *s)
 
     elem *e;
 
+    if (config.exe & EX_windos)
+    {
+        if (s.Sisym)
+            s = s.Sisym; // if imported, prefer the __imp_... symbol
+    }
     if (config.exe & EX_posix)
     {
         if (config.flags3 & CFG3pic &&

--- a/compiler/src/dmd/backend/elpicpie.d
+++ b/compiler/src/dmd/backend/elpicpie.d
@@ -309,6 +309,13 @@ elem * el_ptr(Symbol *s)
         e = el_una(OPaddr, typtr, e);
         e = doptelem(e, GOALvalue | GOALflags);
     }
+    if (config.exe & EX_windos)
+    {
+        if (s.Sflags & SFLimported)
+        {
+            e = el_una(OPind, s.Stype.Tty, e);
+        }
+    }
     return e;
 }
 

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -2501,7 +2501,6 @@ extern (D) private void objflush_pointerRefs()
  *      seg  = segment of the reference
  *      soff = offset of the reference in the segment
  *      imp  = symbol referenced in the import table
- *      ioff = offset to add to pointer from import table
  */
 @trusted
 void write_importTableRef(segidx_t seg, targ_size_t soff, Symbol* imp)

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -91,6 +91,7 @@ IMAGE_SECTION_HEADER* ScnhdrTab() { return cast(IMAGE_SECTION_HEADER *)ScnhdrBuf
     extern (D) int pointersSeg;      // segment index for __pointers
 
     OutBuffer *ptrref_buf;           // buffer for pointer references
+    OutBuffer *impref_buf;           // buffer for import table references
 
     int floatused;
 
@@ -603,6 +604,7 @@ void MsCoffObj_term(const(char)* objfilename)
 
     objflush_pointerRefs();
     outfixlist();           // backpatches
+    objflush_importTableRefs();
 
     if (configv.addlinenumbers)
     {
@@ -2076,6 +2078,12 @@ static if (0)
 void MsCoffObj_addrel(segidx_t seg, targ_size_t offset, Symbol *targsym,
         uint targseg, int rtype, int val)
 {
+    if (targsym && targsym.Sflags & SFLimported && !SegData[seg].isCode())
+    {
+        assert(rtype == RELaddr && val == 0);
+        write_importTableRef(seg, offset, targsym);
+        return;
+    }
     //printf("addrel()\n");
     if (!targsym)
     {   // Generate one
@@ -2231,7 +2239,11 @@ static if (0)
     }
     else
     {
-        if (I64 || I32)
+        if ((s.Sisym || (s.Sflags & SFLimported)) && !SegData[seg].isCode())
+        {
+            write_importTableRef(seg, offset, s.Sisym ? s.Sisym : s);
+        }
+        else if (I64 || I32)
         {
             //if (s.Sclass != SCcomdat)
                 //val += s.Soffset;
@@ -2481,4 +2493,108 @@ extern (D) private void objflush_pointerRefs()
         objflush_pointerRef(s, soff);
     }
     ptrref_buf.reset();
+}
+
+/*****************************************
+ * write a reference to the import table into the object file
+ * Params:
+ *      seg  = segment of the reference
+ *      soff = offset of the reference in the segment
+ *      imp  = symbol referenced in the import table
+ *      ioff = offset to add to pointer from import table
+ */
+@trusted
+void write_importTableRef(segidx_t seg, targ_size_t soff, Symbol* imp)
+{
+    if (!imp.Sxtrnnum)
+        MsCoffObj_external(imp);
+
+    if (!impref_buf)
+    {
+        impref_buf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
+        if (!impref_buf)
+            err_nomem();
+    }
+
+    // defer writing pointer references until the symbols are written out
+    impref_buf.write32(seg);
+    impref_buf.write32(cast(uint)soff);
+    impref_buf.write((&imp)[0 .. 1]);
+}
+
+/*****************************************
+ * flush all pointer references saved by write_importTableRef
+ * to the object file as a crt_constructor function
+ */
+@trusted
+extern (D) private void objflush_importTableRefs()
+{
+    if (!impref_buf)
+        return;
+
+    auto align_ = I64 ? 16 : 4;
+    auto seg = MsCoffObj_getsegment(".text", IMAGE_SCN_CNT_CODE |
+                                    IMAGE_SCN_LNK_COMDAT |
+                                    (I64 ? IMAGE_SCN_ALIGN_16BYTES : IMAGE_SCN_ALIGN_4BYTES) |
+                                    IMAGE_SCN_MEM_EXECUTE |
+                                    IMAGE_SCN_MEM_READ);
+
+    targ_size_t offset = SegData[seg].SDoffset;
+    OutBuffer* buf = SegData[seg].SDbuf;
+    buf.setsize(cast(uint)offset);
+
+    ubyte *p = impref_buf.buf;
+    ubyte *end = impref_buf.buf + impref_buf.length();
+    while (p < end)
+    {
+        int sseg = *cast(int*)p;
+        p += sseg.sizeof;
+        uint soff = *cast(uint*)p;
+        p += soff.sizeof;
+        Symbol* imp = *cast(Symbol**)p;
+        p += imp.sizeof;
+
+        if (I64)
+        {
+            buf.writeByte(0x48); // opcode for mov RAX,[addr]
+            buf.writeByte(0x8b);
+            buf.writeByte(0x05);
+        }
+        else
+            buf.writeByte(0xA1);
+        SegData[seg].SDoffset = offset = buf.length;
+        MsCoffObj_addrel(seg, offset, imp, 0, RELaddr32, 0);
+        buf.write32(0);
+
+        if (I64)
+        {
+            buf.writeByte(0x48); // opcode for add [addr],RAX
+            buf.writeByte(0x01);
+            buf.writeByte(0x05);
+        }
+        else
+        {
+            buf.writeByte(0x01);
+            buf.writeByte(0x05);
+        }
+
+        SegData[seg].SDoffset = offset = buf.length;
+        MsCoffObj_addrel(seg, offset, null, sseg, RELaddr32, 0);
+        //buf.setsize(cast(uint)offset);
+        buf.write32(soff);
+    }
+    buf.writeByte(0xc3); // ret
+    SegData[seg].SDoffset = buf.length();
+
+    // use an early .CRT$XC group so C init code can access relocated pointers, too
+    const int align2 = I64 ? IMAGE_SCN_ALIGN_8BYTES : IMAGE_SCN_ALIGN_4BYTES;
+    const int attr = IMAGE_SCN_CNT_INITIALIZED_DATA | align2 | IMAGE_SCN_MEM_READ;
+    const int cseg = MsCoffObj_getsegment(".CRT$XCB", attr);
+
+    MsCoffObj_addrel(cseg, SegData[cseg].SDoffset, null, seg, RELaddr, 0);
+    OutBuffer* cbuf = SegData[cseg].SDbuf;
+    cbuf.fill0(I64 ? 8 : 4);
+    SegData[cseg].SDoffset = cbuf.length();
+
+    impref_buf.reset();
 }

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -340,9 +340,9 @@ dmd -cov -unittest myprog.d
             "Windows only: select symbols to dllimport (none/defaultLibsOnly/all)",
             `Which global variables to dllimport implicitly if not defined in a root module
             $(UL
-                $(LI $(I none): None
-                $(LI $(I defaultLibsOnly): Only druntime/Phobos symbols
-                $(LI $(I all): All
+                $(LI $(I none): None)
+                $(LI $(I defaultLibsOnly): Only druntime/Phobos symbols)
+                $(LI $(I all): All)
             )`,
         ),
         Option("extern-std=<standard>",

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -336,6 +336,15 @@ dmd -cov -unittest myprog.d
             With $(I filename), write module dependencies as text to $(I filename)
             (only imports).`,
         ),
+        Option("dllimport=<value>",
+            "Windows only: select symbols to dllimport (none/defaultLibsOnly/all)",
+            `Which extern(D) global variables to dllimport implicitly if not defined in a root module
+            $(UL
+                $(LI $(I none): None (default with -link-defaultlib-shared=false)
+                $(LI $(I defaultLibsOnly): Only druntime/Phobos symbols (default with -link-defaultlib-shared and -fvisibility=hidden)
+                $(LI $(I all): All (default with -link-defaultlib-shared and -fvisibility=public)
+            )`,
+        ),
         Option("extern-std=<standard>",
             "set C++ name mangling compatibility with <standard>",
             "Standards supported are:

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -812,6 +812,14 @@ dmd -cov -unittest myprog.d
         Option("vgc",
             "list all gc allocations including hidden ones"
         ),
+        Option("visibility=<value>",
+            "default visibility of symbols (default/hidden/public)",
+            "$(UL
+               $(LI $(I default): Hidden for Windows targets without -shared, otherwise public)
+               $(LI $(I hidden):  Only export symbols marked with 'export')
+               $(LI $(I public):  Export all symbols)
+            )",
+        ),
         Option("vtls",
             "list all variables going into thread local storage"
         ),

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -338,11 +338,11 @@ dmd -cov -unittest myprog.d
         ),
         Option("dllimport=<value>",
             "Windows only: select symbols to dllimport (none/defaultLibsOnly/all)",
-            `Which extern(D) global variables to dllimport implicitly if not defined in a root module
+            `Which global variables to dllimport implicitly if not defined in a root module
             $(UL
-                $(LI $(I none): None (default with -link-defaultlib-shared=false)
-                $(LI $(I defaultLibsOnly): Only druntime/Phobos symbols (default with -link-defaultlib-shared and -fvisibility=hidden)
-                $(LI $(I all): All (default with -link-defaultlib-shared and -fvisibility=public)
+                $(LI $(I none): None
+                $(LI $(I defaultLibsOnly): Only druntime/Phobos symbols
+                $(LI $(I all): All
             )`,
         ),
         Option("extern-std=<standard>",

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -246,8 +246,6 @@ extern (C++) abstract class Declaration : Dsymbol
       enum nounderscore = 4; // don't prepend _ to mangled name
       enum hidden       = 8; // don't print this in .di files
 
-    Symbol* isym;           // import version of csym
-
     // overridden symbol with pragma(mangle, "...")
     const(char)[] mangleOverride;
 

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -118,7 +118,6 @@ public:
     LINK _linkage;              // may be `LINK::system`; use `resolvedLinkage()` to resolve it
     short inuse;                // used to detect cycles
     uint8_t adFlags;
-    Symbol* isym;               // import version of csym
     DString mangleOverride;     // overridden symbol with pragma(mangle, "...")
 
     const char *kind() const override;

--- a/compiler/src/dmd/dmdparams.d
+++ b/compiler/src/dmd/dmdparams.d
@@ -21,6 +21,14 @@ enum PIC : ubyte
     pie,                /// Position Independent Executable
 }
 
+/// export visibility
+enum ExpVis : ubyte
+{
+    default_,           /// hidden for Windows targets without -shared, otherwise public
+    hidden,             /// only export symbols marked with 'export'
+    public_,            /// export all symbols
+}
+
 struct DMDparams
 {
     bool alwaysframe;       // always emit standard stack frame
@@ -38,6 +46,7 @@ struct DMDparams
     bool ibt;               // generate indirect branch tracking
     PIC pic = PIC.fixed;    // generate fixed, pic or pie code
     bool stackstomp;        // add stack stomping code
+    ExpVis exportVisibility = ExpVis.hidden; // which symbols to "dllexport"
 
     bool symdebug;          // insert debug symbolic information
     bool symdebugref;       // insert debug information for all referenced types, too

--- a/compiler/src/dmd/dmdparams.d
+++ b/compiler/src/dmd/dmdparams.d
@@ -29,6 +29,14 @@ enum ExpVis : ubyte
     public_,            /// export all symbols
 }
 
+/// symbol dllimport
+enum SymImport : ubyte
+{
+    none,               /// no symbols
+    defaultLibsOnly,    /// only druntime/phobos symbols
+    all,                /// all non-root symbols
+}
+
 struct DMDparams
 {
     bool alwaysframe;       // always emit standard stack frame
@@ -47,6 +55,7 @@ struct DMDparams
     PIC pic = PIC.fixed;    // generate fixed, pic or pie code
     bool stackstomp;        // add stack stomping code
     ExpVis exportVisibility = ExpVis.hidden; // which symbols to "dllexport"
+    SymImport symImport;    // which symbols to "dllimport"
 
     bool symdebug;          // insert debug symbolic information
     bool symdebugref;       // insert debug information for all referenced types, too

--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -87,7 +87,8 @@ void backend_init()
         driverParams.dwarf,
         global.versionString(),
         exfmt,
-        params.addMain
+        params.addMain,
+        driverParams.symImport != SymImport.none
     );
 
     out_config_debug(

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -501,7 +501,7 @@ private __gshared StringTable!(Symbol*) *stringTab;
  */
 bool isDllImported(Dsymbol var)
 {
-    if (target.os & Target.OS.Posix)
+    if (!(target.os & Target.OS.Windows))
         return false;
     if (var.isImportedSymbol())
         return true;

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -514,8 +514,12 @@ bool isDllImported(Dsymbol var)
     if (var.isFuncDeclaration())
         return false; // can always jump through import table
     if (auto tid = var.isTypeInfoDeclaration())
+    {
         if (builtinTypeInfo(tid.tinfo))
             return true;
+        else if (auto ad = isAggregate(tid.type))
+            var = ad;
+    }
     if (driverParams.symImport == SymImport.defaultLibsOnly)
     {
         auto m = var.getModule();

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -493,14 +493,16 @@ void clearStringTab()
 private __gshared StringTable!(Symbol*) *stringTab;
 
 /*********************************************
-* Figure out whether a data symbol should be dllimported
-* Params:
-*      var = declaration of the symbol
-* Returns:
-*      true if symbol should be imported from a DLL
-*/
+ * Figure out whether a data symbol should be dllimported
+ * Params:
+ *      var = declaration of the symbol
+ * Returns:
+ *      true if symbol should be imported from a DLL
+ */
 bool isDllImported(Dsymbol var)
 {
+    if (target.os & Target.OS.Posix)
+        return false;
     if (var.isImportedSymbol())
         return true;
     if (driverParams.symImport == SymImport.none)
@@ -523,6 +525,14 @@ bool isDllImported(Dsymbol var)
     return false;
 }
 
+/*********************************************
+ * Generate a backend symbol for a frontend symbol
+ * Params:
+ *      s = frontend symbol
+ * Returns:
+ *      the backend symbol or the associated symbol in the
+ *      import table if it is expected to be imported from a DLL
+ */
 Symbol* toExtSymbol(Dsymbol s)
 {
     if (isDllImported(s))
@@ -4627,8 +4637,7 @@ elem *toElemCast(CastExp ce, elem *e, bool isLvalue, ref IRState irs)
             const rtl = cdfrom.isInterfaceDeclaration()
                         ? RTLSYM.INTERFACE_CAST
                         : RTLSYM.DYNAMIC_CAST;
-            Symbol* csym = toExtSymbol(cdto);
-            elem *ep = el_param(el_ptr(csym), e);
+            elem *ep = el_param(el_ptr(toExtSymbol(cdto)), e);
             e = el_bin(OPcall, TYnptr, el_var(getRtlsym(rtl)), ep);
         }
         return Lret(ce, e);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6739,7 +6739,6 @@ public:
 
     enum : int32_t { hidden = 8 };
 
-    Symbol* isym;
     _d_dynamicArray< const char > mangleOverride;
     const char* kind() const override;
     uinteger_t size(const Loc& loc) final override;

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -1266,7 +1266,7 @@ public void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     // Restore symbol table
     cstate.CSpsymtab = symtabsave;
 
-    if (fd.isExport())
+    if (fd.isExport() || driverParams.exportVisibility == ExpVis.public_)
         objmod.export_symbol(s, cast(uint)Para.offset);
 
     if (fd.isCrtCtor)

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -669,7 +669,6 @@ public:
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
                 vto.csym = null;
-                vto.isym = null;
 
                 ids.from.push(vd);
                 ids.to.push(vto);
@@ -845,7 +844,6 @@ public:
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
                 vto.csym = null;
-                vto.isym = null;
 
                 ids.from.push(vd);
                 ids.to.push(vto);
@@ -874,7 +872,6 @@ public:
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
                 vto.csym = null;
-                vto.isym = null;
 
                 ids.from.push(vd);
                 ids.to.push(vto);

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -789,6 +789,25 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         }
         else if (arg == "-shared")
             driverParams.dll = true;
+        else if (startsWith(p + 1, "visibility="))
+        {
+            const(char)[] vis = arg["-visibility=".length .. $];
+
+            switch (vis)
+            {
+                case "default":
+                    driverParams.exportVisibility = ExpVis.default_;
+                    break;
+                case "hidden":
+                    driverParams.exportVisibility = ExpVis.hidden;
+                    break;
+                case "public":
+                    driverParams.exportVisibility = ExpVis.public_;
+                    break;
+                default:
+                    error("unknown visibility '%.*s', must be 'dwfault', 'hidden' or 'public'", cast(int) vis.length, vis.ptr);
+            }
+        }
         else if (arg == "-fIBT")
         {
             driverParams.ibt = true;

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -805,7 +805,26 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                     driverParams.exportVisibility = ExpVis.public_;
                     break;
                 default:
-                    error("unknown visibility '%.*s', must be 'dwfault', 'hidden' or 'public'", cast(int) vis.length, vis.ptr);
+                    error("unknown visibility '%.*s', must be 'default', 'hidden' or 'public'", cast(int) vis.length, vis.ptr);
+            }
+        }
+        else if (startsWith(p + 1, "dllimport="))
+        {
+            const(char)[] imp = arg["-dllimport=".length .. $];
+
+            switch (imp)
+            {
+                case "none":
+                    driverParams.symImport = SymImport.none;
+                    break;
+                case "defaultLibsOnly":
+                    driverParams.symImport = SymImport.defaultLibsOnly;
+                    break;
+                case "all":
+                    driverParams.symImport = SymImport.all;
+                    break;
+                default:
+                    error("unknown dllimport '%.*s', must be 'none', 'defaultLibsOnly' or 'all'", cast(int) imp.length, imp.ptr);
             }
         }
         else if (arg == "-fIBT")

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -561,15 +561,15 @@ private Symbol *createImport(Symbol *sym, Loc loc)
     int idlen;
     if (target.os & Target.OS.Posix)
     {
-        error(loc, "could not generate import symbol for this platform");
+        error(loc, "could not generate import symbol `%s` for this platform", n);
         fatal();
     }
-    if (target.os & Target.OS.Windows && sym.Stype.Tty & mTYthread)
+    else if (target.os & Target.OS.Windows && sym.Stype.Tty & mTYthread)
     {
         error(loc, "cannot generate import symbol for thread local symbol `%s`", n);
         fatal();
     }
-    if (sym.Stype.Tmangle == mTYman_std && tyfunc(sym.Stype.Tty))
+    else if (sym.Stype.Tmangle == mTYman_std && tyfunc(sym.Stype.Tty))
     {
         if (target.os == Target.OS.Windows && target.isX86_64)
             idlen = snprintf(id, allocLen, "__imp_%s",n);

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -735,6 +735,8 @@ Symbol *toInitializer(AggregateDeclaration ad)
             s.Sflags |= SFLnodebug;
             if (sd)
                 s.Salignment = sd.alignment.isDefault() ? -1 : sd.alignment.get();
+            if (isDllImported(ad))
+                s.Sisym = createImport(s, ad.loc);
             ad.sinit = s;
         }
     }
@@ -750,6 +752,8 @@ Symbol *toInitializer(EnumDeclaration ed)
         auto s = toSymbolX(ed, "__init", SC.extern_, stag.Stype, "Z");
         s.Sfl = FLextern;
         s.Sflags |= SFLnodebug;
+        if (isDllImported(ed))
+            s.Sisym = createImport(s, ed.loc);
         ed.sinit = s;
     }
     return ed.sinit;

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -214,6 +214,8 @@ void genModuleInfo(Module m)
     //////////////////////////////////////////////
 
     objmod.moduleinfo(msym);
+    if (driverParams.exportVisibility == ExpVis.public_)
+        objmod.export_symbol(msym, 0);
 }
 
 /*****************************************
@@ -392,6 +394,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 sinit.Sdt = dtb.finish();
                 out_readonly(sinit);
                 outdata(sinit);
+                if (cd.isExport() || driverParams.exportVisibility == ExpVis.public_)
+                    objmod.export_symbol(sinit, 0);
             }
 
             //////////////////////////////////////////////
@@ -439,7 +443,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             out_readonly(cd.vtblsym.csym);
             outdata(cd.vtblsym.csym);
             if (cd.isExport() || driverParams.exportVisibility == ExpVis.public_)
-                objmod.export_symbol(cd.vtblsym.csym,0);
+                objmod.export_symbol(cd.vtblsym.csym, 0);
         }
 
         override void visit(InterfaceDeclaration id)
@@ -544,6 +548,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
                     else
                         out_readonly(sinit);    // put in read-only segment
                     outdata(sinit);
+                    if (sd.isExport() || driverParams.exportVisibility == ExpVis.public_)
+                        objmod.export_symbol(sinit, 0);
                 }
 
                 // Put out the members

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -438,7 +438,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             cd.vtblsym.csym.Sfl = FLdata;
             out_readonly(cd.vtblsym.csym);
             outdata(cd.vtblsym.csym);
-            if (cd.isExport())
+            if (cd.isExport() || driverParams.exportVisibility == ExpVis.public_)
                 objmod.export_symbol(cd.vtblsym.csym,0);
         }
 
@@ -673,7 +673,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             outdata(s);
             if (vd.type.isMutable() || !vd._init)
                 write_pointers(vd.type, s, 0);
-            if (vd.isExport())
+            if (vd.isExport() || driverParams.exportVisibility == ExpVis.public_)
                 objmod.export_symbol(s, 0);
         }
 
@@ -755,7 +755,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             }
 
             outdata(s);
-            if (tid.isExport())
+            if (tid.isExport() || driverParams.exportVisibility == ExpVis.public_)
                 objmod.export_symbol(s, 0);
         }
 
@@ -1443,7 +1443,7 @@ Louter:
     cd.csym.Sdt = dtb.finish();
     // ClassInfo cannot be const data, because we use the monitor on it
     outdata(cd.csym);
-    if (cd.isExport())
+    if (cd.isExport() || driverParams.exportVisibility == ExpVis.public_)
         objmod.export_symbol(cd.csym, 0);
 }
 
@@ -1598,6 +1598,6 @@ private void genClassInfoForInterface(InterfaceDeclaration id)
     id.csym.Sdt = dtb.finish();
     out_readonly(id.csym);
     outdata(id.csym);
-    if (id.isExport())
+    if (id.isExport() || driverParams.exportVisibility == ExpVis.public_)
         objmod.export_symbol(id.csym, 0);
 }

--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -483,7 +483,7 @@ $(UT_DRUNTIME): $(OBJS) $(SRCS) $(DMD)
 	$(DMD) $(UDFLAGS) -shared $(UTFLAGS) -of$@ $(SRCS) $(OBJS) $(LINKDL) -defaultlib= $(if $(findstring $(OS),windows),user32.lib -L/IMPLIB:$(UT_DRUNTIMELIB),) $(SOLIBS)
 
 $(ROOT)/unittest/test_runner$(DOTEXE): $(UT_DRUNTIME) src/test_runner.d $(DMD)
-	$(DMD) $(UDFLAGS) -of$@ src/test_runner.d -L$(UT_DRUNTIMELIB) -defaultlib= $(if $(findstring $(OS),windows),user32.lib,-L-lpthread -L-lm)
+	$(DMD) $(UDFLAGS) -of$@ src/test_runner.d -L$(UT_DRUNTIMELIB) -defaultlib= $(if $(findstring $(OS),windows),-dllimport=defaultLibsOnly user32.lib,-L-lpthread -L-lm)
 
 endif
 

--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -110,6 +110,9 @@ else
 	DFLAGS:=$(UDFLAGS) -inline # unittests don't compile with -inline
 endif
 
+SHAREDFLAGS:=$(if $(findstring $(OS),windows),-visibility=public -mscrtlib=msvcrt,-fPIC)
+SOLIBS:=$(if $(findstring $(OS),windows),msvcrt.lib legacy_stdio_definitions.lib,-L-lpthread -L-lm)
+
 UTFLAGS:=-version=CoreUnittest -unittest -checkaction=context
 
 # Set PHOBOS_DFLAGS (for linking against Phobos)
@@ -125,7 +128,8 @@ ROOT_OF_THEM_ALL = ../generated
 ROOT = $(ROOT_OF_THEM_ALL)/$(OS)/$(BUILD)/$(MODEL)
 OBJDIR=obj/$(OS)/$(BUILD)/$(MODEL)
 DRUNTIME=$(ROOT)/$(if $(findstring $(OS),windows),,lib)druntime$(DOTLIB)
-DRUNTIMESO=$(ROOT)/$(if $(findstring $(OS),windows),,lib)druntime$(DOTDLL)
+DRUNTIMESO_BASE=$(ROOT)/$(if $(findstring $(OS),windows),druntime_shared,libdruntime)
+DRUNTIMESO=$(DRUNTIMESO_BASE)$(DOTDLL)
 DRUNTIMESOOBJ=$(DRUNTIMESO)$(DOTOBJ)
 DRUNTIMESOLIB=$(DRUNTIMESO)$(DOTLIB)
 
@@ -401,11 +405,12 @@ $(ROOT)/valgrind$(DOTOBJ) : src/etc/valgrind/valgrind.c src/etc/valgrind/valgrin
 
 ######################## Create a shared library ##############################
 
-$(DRUNTIMESO) $(DRUNTIMESOLIB) dll: DFLAGS+=-version=Shared $(if $(findstring $(OS),windows),,-fPIC)
+$(DRUNTIMESO) $(DRUNTIMESOLIB) dll: DFLAGS+=-version=Shared $(SHAREDFLAGS)
 dll: $(DRUNTIMESOLIB)
+dll_so: $(DRUNTIMESO)
 
 $(DRUNTIMESO): $(OBJS) $(SRCS) $(DMD)
-	$(DMD) -shared -debuglib= -defaultlib= -of$(DRUNTIMESO) $(DFLAGS) $(SRCS) $(OBJS) $(LINKDL) -L-lpthread -L-lm
+	$(DMD) -shared -debuglib= -defaultlib= -of$(DRUNTIMESO) $(DFLAGS) $(SRCS) $(OBJS) $(LINKDL) $(SOLIBS)
 
 $(DRUNTIMESOLIB): $(OBJS) $(SRCS) $(DMD)
 	$(DMD) -c $(if $(findstring $(OS),windows),,-fPIC) -of$(DRUNTIMESOOBJ) $(DFLAGS) $(SRCS)
@@ -471,13 +476,14 @@ $(ROOT)/unittest/test_runner$(DOTEXE): $(OBJS) $(SRCS) src/test_runner.d $(DMD)
 else
 
 UT_DRUNTIME:=$(ROOT)/unittest/libdruntime-ut$(DOTDLL)
+UT_DRUNTIMELIB:=$(ROOT)/unittest/libdruntime-ut$(if $(findstring $(OS),windows),$(DOTLIB),$(DOTDLL))
 
-$(UT_DRUNTIME): UDFLAGS+=-version=Shared $(if $(findstring $(OS),windows),,-fPIC)
+$(UT_DRUNTIME): UDFLAGS+=-version=Shared $(SHAREDFLAGS)
 $(UT_DRUNTIME): $(OBJS) $(SRCS) $(DMD)
-	$(DMD) $(UDFLAGS) -shared $(UTFLAGS) -of$@ $(SRCS) $(OBJS) $(LINKDL) -defaultlib= $(if $(findstring $(OS),windows),user32.lib,-L-lpthread -L-lm)
+	$(DMD) $(UDFLAGS) -shared $(UTFLAGS) -of$@ $(SRCS) $(OBJS) $(LINKDL) -defaultlib= $(if $(findstring $(OS),windows),user32.lib -L/IMPLIB:$(UT_DRUNTIMELIB),) $(SOLIBS)
 
 $(ROOT)/unittest/test_runner$(DOTEXE): $(UT_DRUNTIME) src/test_runner.d $(DMD)
-	$(DMD) $(UDFLAGS) -of$@ src/test_runner.d -L$(UT_DRUNTIME) -defaultlib= $(if $(findstring $(OS),windows),user32.lib,-L-lpthread -L-lm)
+	$(DMD) $(UDFLAGS) -of$@ src/test_runner.d -L$(UT_DRUNTIMELIB) -defaultlib= $(if $(findstring $(OS),windows),user32.lib,-L-lpthread -L-lm)
 
 endif
 

--- a/druntime/src/rt/msvc.d
+++ b/druntime/src/rt/msvc.d
@@ -201,6 +201,8 @@ int  _msvc_fileno(_iobuf* stream)
 }
 
 
+// MSVCRT.lib only provides _strdup
+mixin declareAlternateName!("strdup", "_strdup");
 
 /**
  * 32-bit x86 MS VC runtimes lack most single-precision math functions.

--- a/druntime/src/rt/sections.d
+++ b/druntime/src/rt/sections.d
@@ -80,7 +80,10 @@ static assert(is(typeof(&initTLSRanges) RT == return) &&
               is(typeof(&finiTLSRanges) == void function(RT) nothrow @nogc) &&
               is(typeof(&scanTLSRanges) == void function(RT, scope void delegate(void*, void*) nothrow) nothrow));
 
-version (Shared)
+version (Windows)
+{
+}
+else version (Shared)
 {
     static assert(is(typeof(&pinLoadedLibraries) == void* function() nothrow @nogc));
     static assert(is(typeof(&unpinLoadedLibraries) == void function(void*) nothrow @nogc));

--- a/druntime/test/common.mak
+++ b/druntime/test/common.mak
@@ -27,7 +27,7 @@ ifeq (osx64,$(OS)$(MODEL))
 endif
 DFLAGS:=$(MODEL_FLAG) $(PIC) -w -I../../src -I../../import -I$(SRC) -defaultlib= -preview=dip1000 $(if $(findstring $(OS),windows),,-L-lpthread -L-lm $(LINKDL))
 # LINK_SHARED may be set by importing makefile
-DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIMESO),-L$(DRUNTIME))
+DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIMESO) $(if $(findstring $(OS),windows),-dllimport=defaultLibsOnly),-L$(DRUNTIME))
 ifeq ($(BUILD),debug)
     DFLAGS+=-g -debug
     CFLAGS:=$(CFLAGS_BASE) $(if $(findstring $(OS),windows),/Zi,-g)

--- a/druntime/test/common.mak
+++ b/druntime/test/common.mak
@@ -26,7 +26,7 @@ CFLAGS_BASE:=$(if $(findstring $(OS),windows),/Wall,$(MODEL_FLAG) $(PIC) -Wall)
 ifeq (osx64,$(OS)$(MODEL))
     CFLAGS_BASE+=--target=x86_64-darwin-apple  # ARM cpu is not supported by dmd
 endif
-DFLAGS:=$(MODEL_FLAG) $(PIC) -w -I../../src -I../../import -I$(SRC) -defaultlib= -preview=dip1000 $(if $(findstring $(OS),windows),,-L-lpthread -L-lm $(LINKDL))
+DFLAGS:=$(MODEL_FLAG) $(PIC) -w -I../../src -I../../import -I$(SRC) -preview=dip1000 $(if $(findstring $(OS),windows),,-defaultlib= -L-lpthread -L-lm $(LINKDL))
 # LINK_SHARED may be set by importing makefile
 DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIME_IMPLIB) $(if $(findstring $(OS),windows),-dllimport=defaultLibsOnly),-L$(DRUNTIME))
 ifeq ($(BUILD),debug)

--- a/druntime/test/common.mak
+++ b/druntime/test/common.mak
@@ -26,7 +26,7 @@ CFLAGS_BASE:=$(if $(findstring $(OS),windows),/Wall,$(MODEL_FLAG) $(PIC) -Wall)
 ifeq (osx64,$(OS)$(MODEL))
     CFLAGS_BASE+=--target=x86_64-darwin-apple  # ARM cpu is not supported by dmd
 endif
-DFLAGS:=$(MODEL_FLAG) $(PIC) -w -I../../src -I../../import -I$(SRC) -preview=dip1000 $(if $(findstring $(OS),windows),,-defaultlib= -L-lpthread -L-lm $(LINKDL))
+DFLAGS:=$(MODEL_FLAG) $(PIC) -w -I../../src -I../../import -I$(SRC) -defaultlib= -preview=dip1000 $(if $(findstring $(OS),windows),,-L-lpthread -L-lm $(LINKDL))
 # LINK_SHARED may be set by importing makefile
 DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIME_IMPLIB) $(if $(findstring $(OS),windows),-dllimport=defaultLibsOnly),-L$(DRUNTIME))
 ifeq ($(BUILD),debug)

--- a/druntime/test/common.mak
+++ b/druntime/test/common.mak
@@ -19,6 +19,7 @@ LDL:=$(subst -L,,$(LINKDL)) # -ldl
 SRC:=src
 GENERATED:=./generated
 ROOT:=$(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
+DRUNTIME_IMPLIB:=$(subst .dll,.lib,$(DRUNTIMESO))
 
 MODEL_FLAG:=$(if $(findstring $(MODEL),default),,-m$(MODEL))
 CFLAGS_BASE:=$(if $(findstring $(OS),windows),/Wall,$(MODEL_FLAG) $(PIC) -Wall)
@@ -27,7 +28,7 @@ ifeq (osx64,$(OS)$(MODEL))
 endif
 DFLAGS:=$(MODEL_FLAG) $(PIC) -w -I../../src -I../../import -I$(SRC) -defaultlib= -preview=dip1000 $(if $(findstring $(OS),windows),,-L-lpthread -L-lm $(LINKDL))
 # LINK_SHARED may be set by importing makefile
-DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIMESO) $(if $(findstring $(OS),windows),-dllimport=defaultLibsOnly),-L$(DRUNTIME))
+DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIME_IMPLIB) $(if $(findstring $(OS),windows),-dllimport=defaultLibsOnly),-L$(DRUNTIME))
 ifeq ($(BUILD),debug)
     DFLAGS+=-g -debug
     CFLAGS:=$(CFLAGS_BASE) $(if $(findstring $(OS),windows),/Zi,-g)

--- a/druntime/test/shared/Makefile
+++ b/druntime/test/shared/Makefile
@@ -8,6 +8,9 @@ include ../common.mak # affected by LINK_SHARED!
 ifeq (windows,$(OS))
 
 TESTS:=loadlibwin dllrefcount dllgc dynamiccast
+ifeq ($(SHARED),1)
+DFLAGS+=-version=SharedRuntime
+endif
 
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 

--- a/druntime/test/shared/Makefile
+++ b/druntime/test/shared/Makefile
@@ -1,5 +1,5 @@
 # druntime DLL not supported on Windows yet
-LINK_SHARED:=$(if $(findstring $(OS),windows),,1)
+LINK_SHARED:=$(if $(findstring $(OS),windows),$(SHARED),1)
 
 include ../common.mak # affected by LINK_SHARED!
 

--- a/druntime/test/shared/src/dynamiccast.d
+++ b/druntime/test/shared/src/dynamiccast.d
@@ -72,7 +72,8 @@ else
         return null;
     }
 
-    version (DigitalMars) version (Win64) version = DMD_Win64;
+    version (DigitalMars) version (Win64) version = NoExceptions;
+    version (SharedRuntime) version (DigitalMars) version (Win32) version = NoExceptions;
 
     void main(string[] args)
     {
@@ -101,7 +102,7 @@ else
         auto o = getFunc!(Object function(Object))("foo")(c);
         assert(cast(C) o);
 
-        version (DMD_Win64)
+        version (NoExceptions)
         {
             // FIXME: apparent crash & needs more work, see https://github.com/dlang/druntime/pull/2874
             fclose(fopen("dynamiccast_endbar", "w"));


### PR DESCRIPTION
This is work in progress.

Basic idea is copied from LDC: 
- root modules dllexport all symbols
- symbols from non-root modules are dllimported.
- code accessing symbols in another DLL use an indirection through the import table
- data initialized with addresses in another DLL are patched by an "early" CRT constructor

Runtime support for properly attaching to the GC still missing.