### PR TITLE
Fix Issue 23661 - Using typeid from template inside __traits(compiles, ...) causes linker error

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -6024,6 +6024,12 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
                     else
                         visit(cast(Dsymbol)cd);
                 }
+                override void visit(FuncDeclaration fd)
+                {
+                    if (fd.skipCodegen)
+                        fd.skipCodegen = false;
+                    visit(cast(Dsymbol)fd);
+                }
             }
             scope v = new InstMemberWalker(tempinst.inst);
             tempinst.inst.accept(v);
@@ -6183,6 +6189,8 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     sc2.tinst = tempinst;
     sc2.minst = tempinst.minst;
     sc2.stc &= ~STC.deprecated_;
+    if (sc.flags & SCOPE.compile)
+        sc2.flags |= SCOPE.compile;
     tempinst.tryExpandMembers(sc2);
 
     tempinst.semanticRun = PASS.semanticdone;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5551,7 +5551,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // https://issues.dlang.org/show_bug.cgi?id=23650
             // We generate object code for typeinfo, required
             // by typeid, only if in non-speculative context
-            if (sc.flags & SCOPE.compile)
+            if (sc.flags & SCOPE.compile || (sc.func && sc.func.skipCodegen))
             {
                 genObjCode = false;
             }

--- a/compiler/test/runnable/test23650.d
+++ b/compiler/test/runnable/test23650.d
@@ -1,8 +1,7 @@
-// https://issues.dlang.org/show_bug.cgi?id=23650
-
 __gshared int x;
 
-void main()
+// https://issues.dlang.org/show_bug.cgi?id=23650
+void test23650()
 {
 
     static assert(__traits(compiles,
@@ -10,4 +9,25 @@ void main()
         struct S { int *p = &x; }
         auto t = typeid(S);
     }));
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=23661
+void foo(T)()
+{
+    auto x = typeid(T);
+}
+
+void test23661()
+{
+    static assert(__traits(compiles,
+    {
+        struct S { int *p = &x; }
+        foo!S();
+    }));
+}
+
+void main()
+{
+    test23650();
+    test23661();
 }


### PR DESCRIPTION
```d
_gshared int x;

void foo(T)()
{
    auto x = typeid(T);
}

void main()
{
    static assert(__traits(compiles,
    {
        struct S { int *p = &x; }
        foo!S();
    }));
}
```

When instantiating a template from a traits(compiles) block the template instance does not store this information. Although in the gluelayer the template instance is discarded (object code is not generated for it) because the `TemplateInstance.needsCodegen` has all the information it needs regarding tinst and minst (which are used to deduce whether we are in speculative context or not), this information is not available during semantic analysis. Therefore, typeid's inside speculative contexts are still going to generate code for Typeinfo (see the associated bug report).

To fix this, I am propagating the SCOPE.COMPILE flag to the scope of the members of the template instance. This has the effect of considering function declarations inside the template instance (such as `foo!S`) as being exempt from code generation (`funcdecl.skipCodegen` is set to true). This enables TypeidExp semantic to deduce that it is in a speculative context and avoid generating code for TypeInfo.

However, if a second instantiation of the template declaration with the same template parameters occurs (foo!S outside of the traits(compiles) block), the instance that was generated inside the traits(compiles) block may be used, but we need to generate code for it.