### PR TITLE
Fix Issue 23662: ImportC bad handling of enum arguments for a function

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1823,6 +1823,8 @@ final class CParser(AST) : Parser!AST
                 {
                     if (tt.id || tt.tok == TOK.enum_)
                     {
+                        if (!tt.id && id)
+                            tt.id = id;
                         /* `struct tag;` and `struct tag { ... };`
                          * always result in a declaration in the current scope
                          */

--- a/compiler/test/compilable/imports/imp23662.c
+++ b/compiler/test/compilable/imports/imp23662.c
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=23662
+typedef enum {A} E;
+
+E func(E v) {
+    return v;
+}
+

--- a/compiler/test/compilable/imports/imp23662.c
+++ b/compiler/test/compilable/imports/imp23662.c
@@ -4,4 +4,3 @@ typedef enum {A} E;
 E func(E v) {
     return v;
 }
-

--- a/compiler/test/compilable/test23662.d
+++ b/compiler/test/compilable/test23662.d
@@ -1,0 +1,9 @@
+// https://issues.dlang.org/show_bug.cgi?id=23662
+// EXTRA_FILES: imports/imp23662.c
+import imports.imp23662;
+
+void main(string[] args) {
+    auto r = func(A);
+    assert(r == A);
+}
+

--- a/compiler/test/compilable/test23662.d
+++ b/compiler/test/compilable/test23662.d
@@ -6,4 +6,3 @@ void main(string[] args) {
     auto r = func(A);
     assert(r == A);
 }
-


### PR DESCRIPTION
See: https://issues.dlang.org/show_bug.cgi?id=23662

### Before this PR:

In case of declaration of anonymous enums with `typedef`:

```c
typedef enum {A} E;
```

There was impossible to use them as arguments for functions, like:

```c
E func(E v) {
    return v;
}
```

When calling this function from D

```d
void main(string[] args) {
    auto r = func(A);
    assert(r == A);
}
```

Following errors were raised:

```
compilable/test23662.d(6): Error: function `imp23662.func(__tag2 v)` is not callable using argument types `(__anonymous)`
compilable/test23662.d(6):        cannot pass argument `A` of type `__anonymous` to parameter `__tag2 v`
```

### After this PR:

Anonymous enums defined via `typedef` can be used as arguments for functions.


---

PS: With this change [libgit2](https://libgit2.org/) (version `1.3.2`) seems to be usable with *importC*.

---

PS2: Not sure, if it have sense to add this change to `stable` or `master` branch...