### PR TITLE
dmd.root.filename: Add FileName::create helper

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -786,6 +786,7 @@ struct FileName final
 private:
     _d_dynamicArray< const char > str;
 public:
+    static FileName create(const char* name);
     static bool equals(const char* name1, const char* name2);
     static bool absolute(const char* name);
     static const char* toAbsolute(const char* name, const char* base = nullptr);

--- a/compiler/src/dmd/root/filename.d
+++ b/compiler/src/dmd/root/filename.d
@@ -85,6 +85,12 @@ nothrow:
         this.str = str.xarraydup;
     }
 
+    ///
+    extern (C++) static FileName create(const(char)* name) pure
+    {
+        return FileName(name.toDString);
+    }
+
     /// Compare two name according to the platform's rules (case sensitive or not)
     extern (C++) static bool equals(const(char)* name1, const(char)* name2) pure @nogc
     {

--- a/compiler/src/dmd/root/filename.h
+++ b/compiler/src/dmd/root/filename.h
@@ -19,6 +19,7 @@ struct FileName
 private:
     DString str;
 public:
+    static FileName create(const char *name);
     static bool equals(const char *name1, const char *name2);
     static bool absolute(const char *name);
     static const char *toAbsolute(const char *name, const char *base = NULL);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -566,6 +566,26 @@ void test_optional()
     assert(opt.hasValue(true));
 }
 
+void test_filename()
+{
+    const char *fname = "/a/nice/long/path/to/somefile.d";
+
+    const char *basename = FileName::name(fname);
+    assert(strcmp(basename, "somefile.d") == 0);
+
+    const char *name = FileName::removeExt(basename);
+    assert(strcmp(name, "somefile") == 0);
+
+    const char *jsonname = FileName::defaultExt(name, json_ext.ptr);
+    assert(strcmp(jsonname, "somefile.json") == 0);
+
+    FileName file = FileName::create("somefile.d");
+    assert(FileName::equals(basename, file.toChars()));
+
+    FileName::free(name);
+    FileName::free(jsonname);
+}
+
 /**********************************/
 
 class MiniGlueVisitor : public Visitor
@@ -1706,6 +1726,7 @@ int main(int argc, char **argv)
     test_cppmangle();
     test_module();
     test_optional();
+    test_filename();
 
     frontend_term();
 


### PR DESCRIPTION
The `preprocess` callback expects a `FileName` to be returned, but the encapsulated string is `private`.  Add a `::create` factory function that can be used from C++ to create new FileNames.