### PR TITLE
fix Issue 23672 - importC: Infinite recursion: Error: found 'End of File' when expecting ','

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -2991,11 +2991,11 @@ final class CParser(AST) : Parser!AST
             auto param = new AST.Parameter(specifiersToSTC(LVL.parameter, specifier),
                                            t, id, null, null);
             parameters.push(param);
-            if (token.value == TOK.rightParenthesis)
+            if (token.value == TOK.rightParenthesis || token.value == TOK.endOfFile)
                 break;
             check(TOK.comma);
         }
-        nextToken();
+        check(TOK.rightParenthesis);
         return finish();
     }
 

--- a/compiler/test/fail_compilation/test23672.i
+++ b/compiler/test/fail_compilation/test23672.i
@@ -1,0 +1,8 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test23672.i(9): Error: found `End of File` when expecting `)`
+fail_compilation/test23672.i(9): Error: `=`, `;` or `,` expected to end declaration instead of `End of File`
+---
+*/
+extern int feof (FILE *__strea


### PR DESCRIPTION
There was no escape hatch in the `while(1)` loop.