### PR TITLE
Fix Issue 23674 - incompatible types for array comparison: string and string

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -12042,6 +12042,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             __equals = new DotIdExp(exp.loc, __equals, Id.object);
             __equals = new DotIdExp(exp.loc, __equals, id);
 
+            /* https://issues.dlang.org/show_bug.cgi?id=23674
+             *
+             * Optimize before creating the call expression to the
+             * druntime hook as the optimizer may output errors
+             * that will get swallowed otherwise.
+             */
+            exp.e1 = exp.e1.optimize(WANTvalue);
+            exp.e2 = exp.e2.optimize(WANTvalue);
+
             auto arguments = new Expressions(2);
             (*arguments)[0] = exp.e1;
             (*arguments)[1] = exp.e2;

--- a/compiler/test/fail_compilation/test23674.d
+++ b/compiler/test/fail_compilation/test23674.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=23674
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test23674.d(14): Error: array index 2 is out of bounds `arr[0 .. 2]`
+fail_compilation/test23674.d(14): Error: array index 3 is out of bounds `arr[0 .. 2]`
+---
+*/
+
+void main()
+{
+    string[2] arr;
+    assert(arr[2] == arr[3]);
+}


### PR DESCRIPTION
This regression was introduced by https://github.com/dlang/dmd/pull/11212/ (cc @kinke ).

When the array equality expression is lowered to a druntime hook, semantic analysis on the hook is performed with gagged error messages so that the failures inside it are not outputted, but rather a generic message is printed ("incompatible types for array equality"). However, there still are some checks done during the optimization phase which get silenced (in this case, an out of bounds access for static arrays). To avoid that, I am calling the optimization routine before trying semantic lowered hook.