### PR TITLE
Fix 22916 - copy of ref return still treated as scope variable

### DIFF
--- a/compiler/test/compilable/test22916.d
+++ b/compiler/test/compilable/test22916.d
@@ -1,0 +1,42 @@
+// REQUIRED_ARGS: -preview=dip1000
+
+// https://issues.dlang.org/show_bug.cgi?id=22916
+// Issue 22916 - [dip1000] copy of ref return still treated as scope variable (edit)
+
+@safe:
+struct Arr
+{
+    int** ptr;
+    ref int* index() return scope { return *ptr; }
+    void assign(int* p) scope { *ptr = p; }
+}
+
+void main0()
+{
+    scope Arr a;
+    a.assign(a.index());
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=23682
+ref char* front_p(ref return scope char** p) { return *p; }
+ref char* front_r(    return scope char** p) { return *p; }
+
+char* g;
+
+void test23862()
+{
+    scope char** _errors;
+    g = front_p(_errors);   // should pass
+    g = front_r(_errors);   // should pass
+}
+
+// Test case reduced from druntime
+ref int* monitor(return scope Object h) pure nothrow @nogc @trusted
+{
+    return *cast(int**)&h.__monitor;
+}
+
+int* getMonitor(Object h) pure @nogc
+{
+    return monitor(h); // should pass
+}

--- a/compiler/test/fail_compilation/retscope6.d
+++ b/compiler/test/fail_compilation/retscope6.d
@@ -293,31 +293,3 @@ ref int escape23021() @safe
 }
 
 /******************************/
-
-// https://issues.dlang.org/show_bug.cgi?id=23682
-
-alias VErr = char*;
-
-@safe ref char* front_p(return scope char** p) { return *p; }
-
-char* g;
-
-@safe void test23862()
-{
-    char* _errors;
-    g = front_p(&_errors);   // should pass
-}
-
-/*******************************************/
-
-ref int* monitor(return scope Object h) pure nothrow @nogc
-{
-    return *cast(int**)&h.__monitor;
-}
-
-int* getMonitor(Object h) pure @nogc
-{
-    return monitor(h); // should pass
-}
-
-/*******************************************/


### PR DESCRIPTION
Alternative to https://github.com/dlang/dmd/pull/14869

This needs a bit more testing, I think this does not account for compound call expressions yet, but opening already for discussion and checking the test suite. @WalterBright 