### PR TITLE
fix Issue 23688 - FTBFS: error: cannot convert 'Expression' to 'Expression*'

### DIFF
--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -539,7 +539,7 @@ public:
     bool onstack;               // allocate on stack
     bool thrownew;              // this NewExp is the expression of a ThrowStatement
 
-    Expression lowering;        // lowered druntime hook: `_d_newclass`
+    Expression *lowering;       // lowered druntime hook: `_d_newclass`
 
     static NewExp *create(const Loc &loc, Expression *thisexp, Type *newtype, Expressions *arguments);
     NewExp *syntaxCopy() override;


### PR DESCRIPTION
This wasn't checked during review in #14837.