### PR TITLE
gitignore: ignore vim backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.[oa]
 *.deps
 .B*
+*~
 /compiler/test/test_results
 /compiler/test/trace.def
 /compiler/test/trace.log


### PR DESCRIPTION
which have a trailing ~.