### PR TITLE
Parse UDAs like template arguments

### DIFF
--- a/changelog/dmd.uda-template-args.dd
+++ b/changelog/dmd.uda-template-args.dd
@@ -1,0 +1,27 @@
+User Defined Attributes now parse Template Arguments
+
+It was already allowed to put types in UDAs, but the parser would reject basic types written directly, requiring the use of an alias.
+
+---
+alias Tint = int;
+
+@Tint void f();
+---
+
+Also, simple literals that can appear in template instantiations without brackets (example: `foo!"arg"`) require parentheses when used as an attribute:
+---
+@("my test") unittest
+{
+
+}
+---
+
+Now, arguments that can appear after a template instantiation `foo!` can also appear after an `@` attribute.
+---
+@int void f();
+
+@"my test" unittest
+{
+
+}
+---

--- a/compiler/test/compilable/user_defined_attributes.d
+++ b/compiler/test/compilable/user_defined_attributes.d
@@ -1,0 +1,22 @@
+
+enum Test;
+
+@true @null @byte int x;
+@(int) int y;
+@"test" @`test2` @30 @'a' @__LINE__ void f();
+
+@Test void h();
+
+static assert(   __traits(getAttributes, x)[0] == true);
+static assert(   __traits(getAttributes, x)[1] == null);
+static assert(is(__traits(getAttributes, x)[2] == byte));
+
+static assert(is(__traits(getAttributes, y)[0] == int));
+
+static assert(   __traits(getAttributes, f)[0] == "test");
+static assert(   __traits(getAttributes, f)[1] == "test2");
+static assert(   __traits(getAttributes, f)[2] == 30);
+static assert(   __traits(getAttributes, f)[3] == 'a');
+static assert(   __traits(getAttributes, f)[4] == 6);
+
+static assert(is(__traits(getAttributes, h)[0] == enum));

--- a/compiler/test/fail_compilation/named_arguments_parse.d
+++ b/compiler/test/fail_compilation/named_arguments_parse.d
@@ -1,13 +1,13 @@
 /**
 TEST_OUTPUT:
 ---
-fail_compilation/named_arguments_parse.d(10): Error: named arguments not allowed here
 fail_compilation/named_arguments_parse.d(13): Error: named arguments not allowed here
 fail_compilation/named_arguments_parse.d(14): Error: named arguments not allowed here
 ---
 */
 
-@(attribute: 3)
+
+// @(attribute: 3) Currently gives an ugly parse error, will be better when named template arguments are implemented
 void main()
 {
 	mixin(thecode: "{}");


### PR DESCRIPTION
With this PR, whatever comes after `myTemplate!` may also follow `@`, based on these observations:

- Types are already allowed as UDAs by the specification and implementation, except the parser doesn't allow you to put basic types (`int`, `float`) in there directly, requiring you to use an `alias` instead.
- The requirement for brackets around UDAs often confuses me: I can do `@f` and `@f()` and `@f("s")` but not `@"s"`?
- Forcing brackets around string literals is not ergonomic, see the [unittest "name" {}](https://forum.dlang.org/post/kdrhqwkoyybvgsbamumh@forum.dlang.org) thread on the forum.

