### PR TITLE
dmd.apply: Implement walkPreorder helper function

### DIFF
--- a/compiler/src/dmd/sapply.d
+++ b/compiler/src/dmd/sapply.d
@@ -21,9 +21,16 @@ bool walkPostorder(Statement s, StoppableVisitor v)
     return v.stop;
 }
 
+bool walkPreorder(Statement s, StoppableVisitor v)
+{
+    scope PreorderStatementVisitor pv = new PreorderStatementVisitor(v);
+    s.accept(pv);
+    return v.stop;
+}
+
 /**************************************
- * A Statement tree walker that will visit each Statement s in the tree,
- * in depth-first evaluation order, and call fp(s,param) on it.
+ * A post-order Statement tree walker that will visit each Statement s in the
+ * tree, in depth-first evaluation order, and call fp(s,param) on it.
  * fp() signals whether the walking continues with its return value:
  * Returns:
  *      0       continue
@@ -175,5 +182,163 @@ public:
     override void visit(LabelStatement s)
     {
         doCond(s.statement) || applyTo(s);
+    }
+}
+
+/**************************************
+ * A pre-order Statement tree walker that will visit each Statement s in the
+ * tree, in depth-first evaluation order, and call fp(s,param) on it.
+ * fp() signals whether the walking continues with its return value:
+ * Returns:
+ *      0       continue
+ *      1       done
+ * It's a bit slower than using virtual functions, but more encapsulated and less brittle.
+ * Creating an iterator for this would be much more complex.
+ */
+private extern (C++) final class PreorderStatementVisitor : StoppableVisitor
+{
+    alias visit = typeof(super).visit;
+public:
+    StoppableVisitor v;
+
+    extern (D) this(StoppableVisitor v) scope
+    {
+        this.v = v;
+    }
+
+    bool doCond(Statement s)
+    {
+        if (!stop && s)
+            s.accept(this);
+        return stop;
+    }
+
+    bool applyTo(Statement s)
+    {
+        s.accept(v);
+        stop = v.stop;
+        return stop;
+    }
+
+    override void visit(Statement s)
+    {
+        applyTo(s);
+    }
+
+    override void visit(PeelStatement s)
+    {
+        applyTo(s) || doCond(s.s);
+    }
+
+    override void visit(CompoundStatement s)
+    {
+        if (applyTo(s))
+            return;
+        for (size_t i = 0; i < s.statements.length; i++)
+            if (doCond((*s.statements)[i]))
+                return;
+    }
+
+    override void visit(UnrolledLoopStatement s)
+    {
+        if (applyTo(s))
+            return;
+        for (size_t i = 0; i < s.statements.length; i++)
+            if (doCond((*s.statements)[i]))
+                return;
+    }
+
+    override void visit(ScopeStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
+    }
+
+    override void visit(WhileStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(DoStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(ForStatement s)
+    {
+        applyTo(s) || doCond(s._init) || doCond(s._body);
+    }
+
+    override void visit(ForeachStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(ForeachRangeStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(IfStatement s)
+    {
+        applyTo(s) || doCond(s.ifbody) || doCond(s.elsebody);
+    }
+
+    override void visit(PragmaStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(SwitchStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(CaseStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
+    }
+
+    override void visit(DefaultStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
+    }
+
+    override void visit(SynchronizedStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(WithStatement s)
+    {
+        applyTo(s) || doCond(s._body);
+    }
+
+    override void visit(TryCatchStatement s)
+    {
+        if (applyTo(s) || doCond(s._body))
+            return;
+        for (size_t i = 0; i < s.catches.length; i++)
+            if (doCond((*s.catches)[i].handler))
+                return;
+    }
+
+    override void visit(TryFinallyStatement s)
+    {
+        applyTo(s) || doCond(s._body) || doCond(s.finalbody);
+    }
+
+    override void visit(ScopeGuardStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
+    }
+
+    override void visit(DebugStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
+    }
+
+    override void visit(LabelStatement s)
+    {
+        applyTo(s) || doCond(s.statement);
     }
 }


### PR DESCRIPTION
Looking at putting #14830 into the front-end where it feels like it belongs (@kinke).  I'll have to see whether what I'm using this for actually makes sense, this change only breaks out the boilerplate part into its own standalone PR.

Current expression/statement apply helper implements a post-order DFS traversal of the AST.  This is fine when you want to descend and mark all children first before each connecting parent, but doesn't help when you want to traverse the AST in a more forwards direction as you'd expect the flow of user code to be executed in.

i.e: Given a stoppable visitor with `override void visit(LabelStatement) { stop = true; }` and marking every other statement/expression visited, for the following:
```
case 1:
    if (__ctfe)
    {
        {
            int[] foo = [1];
        }
L3:
        i += 2;
case 2:
        ++i;
    }
```
Traversing post-order will give you
```
case 1:
    if (__ctfe)
    {
        {                    // 2. mark
            int[] foo = [1]; // 1. mark
        }
L3:                          // 4. stop
        i += 2;              // 3. mark
case 2:
        ++i;
    }
```
Traversing pre-order will instead give you
```
case 1:                      // 1. mark
    if (__ctfe)              // 2. mark
    {                        // 3. mark
        {                    // 4. mark
            int[] foo = [1]; // 5. mark
        }
L3:                          // 6. stop
        i += 2;
case 2:
        ++i;
    }
```

---

_Wait, if you want forward walking, shouldn't you be instead using a `ParseTimeTransitiveVisitor`?_ 
Yes, maybe, well, not sure anymore the more I think about it.  At the very least, one negative aspect of `ParseTimeTransitiveVisitor` is that it by default visits _all_ connecting nodes, including types, constraints, and base class declarations.  This would waste extra time walking the trees just to get to the nodes you actually want to visit.

---

_Couldn't `PostorderStatementVisitor` and `PreorderStatementVisitor` just be folded into the same visitor, make it a template instead of 300 lines of almost (but not quite) identical code?_ 
Yes, but would it be readable having both paths mixed together, ehh... _maybe_.  We'll see how this goes first.