### PR TITLE
Fix 23676 - Static foreach hangs compilation for some time

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2542,6 +2542,10 @@ public:
     bool isCrtCtor(bool v);
     bool isCrtDtor() const;
     bool isCrtDtor(bool v);
+    bool hasEscapingSiblings() const;
+    bool hasEscapingSiblings(bool v);
+    bool computedEscapingSiblings() const;
+    bool computedEscapingSiblings(bool v);
 private:
     uint32_t bitFields;
 public:

--- a/compiler/test/compilable/test23676.d
+++ b/compiler/test/compilable/test23676.d
@@ -1,0 +1,16 @@
+// Issue 23676 - Static foreach hangs compilation for some time
+// https://issues.dlang.org/show_bug.cgi?id=23676
+
+void f()
+{
+    int i;
+    void g(int I)()
+    {
+        static foreach(j; 0..11)
+        {
+            i++;
+            g!j();
+        }
+    }
+    g!0;
+}


### PR DESCRIPTION
Not sure exactly how the algorithm works yet, but it makes exponentially many redundant calls, so try caching the result.