### PR TITLE
Fix inconsistent `names` and `arguments` arrays

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -273,14 +273,6 @@ extern (C++) void expandTuples(Expressions* exps, Identifiers* names = null)
     {
         if (exps.length != names.length)
         {
-            // Fixme: this branch should be removed when CallExp rewrites
-            // (UFCS/operator overloading) are fixed to take named arguments into account
-            names.setDim(exps.length);
-            foreach (i; 0..exps.length)
-                (*names)[i] = null;
-        }
-        if (exps.length != names.length)
-        {
             printf("exps.length = %d, names.length = %d\n", cast(int) exps.length, cast(int) names.length);
             printf("exps = %s, names = %s\n", exps.toChars(), names.toChars());
             if (exps.length > 0)
@@ -3677,7 +3669,8 @@ extern (C++) final class NewExp : Expression
         return new NewExp(loc,
             thisexp ? thisexp.syntaxCopy() : null,
             newtype.syntaxCopy(),
-            arraySyntaxCopy(arguments));
+            arraySyntaxCopy(arguments),
+            names ? names.copy() : null);
     }
 
     override void accept(Visitor v)
@@ -5244,7 +5237,7 @@ extern (C++) final class CallExp : UnaExp
 
     override CallExp syntaxCopy()
     {
-        return new CallExp(loc, e1.syntaxCopy(), arraySyntaxCopy(arguments), names);
+        return new CallExp(loc, e1.syntaxCopy(), arraySyntaxCopy(arguments), names ? names.copy() : null);
     }
 
     override bool isLvalue()

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -9352,7 +9352,7 @@ LagainStc:
 
         nextToken();
         AST.Expressions* arguments = null;
-        AST.Identifiers* names = new AST.Identifiers();
+        AST.Identifiers* names = null;
 
         // An anonymous nested class starts with "class"
         if (token.value == TOK.class_)
@@ -9361,6 +9361,7 @@ LagainStc:
             if (token.value == TOK.leftParenthesis)
             {
                 arguments = new AST.Expressions();
+                names = new AST.Identifiers();
                 parseNamedArguments(arguments, names);
             }
 
@@ -9405,6 +9406,7 @@ LagainStc:
         else if (token.value == TOK.leftParenthesis && t.ty != Tsarray)
         {
             arguments = new AST.Expressions();
+            names = new AST.Identifiers();
             parseNamedArguments(arguments, names);
         }
 


### PR DESCRIPTION
Make sure `arguments` and `names` are kept in sync.
Following up https://github.com/dlang/dmd/pull/14776#discussion_r1072112837

The main problem was that I assumed the names array would be `const` after creation, so it didn't need to be duplicated in `syntaxCopy`. However, if one template instance shifts the names for a UFCS call, it shouldn't also shift the array in other template instances, which does happen if they share the same array pointer.