### PR TITLE
fix Issue 23711 - compilable/testcstuff1.c:63:1: error: invalid use o…

### DIFF
--- a/compiler/test/compilable/testcstuff1.c
+++ b/compiler/test/compilable/testcstuff1.c
@@ -60,7 +60,7 @@ _Static_assert(sizeof(float) == 4, "ok");
 _Static_assert(sizeof(double) == 8, "ok");
 //_Static_assert(sizeof(long double) == 8 || sizeof(long double) == 10 || sizeof(long double) == 16, "ok");
 
-_Static_assert(sizeof(const restrict volatile char volatile restrict const) == 1, "ok");
+_Static_assert(sizeof(const volatile char volatile const) == 1, "ok");
 
 _Static_assert(sizeof(int*) == 8 || 4 == sizeof(char*), "ok");
 
@@ -257,7 +257,7 @@ void test2()
     int;
     int (*xi);
     int (*fp)(void);
-    int (* const volatile restrict fp2)(void);
+    int (* const volatile fp2)(void);
     void* pv;
     char c, d;
     short sh;
@@ -275,7 +275,7 @@ void test2()
     register int reg;
     const int ci;
     volatile int vi;
-    restrict int ri;
+    int* restrict ri;
 
 //    _Atomic(int) ai;
 //    _Alignas(c) ac;


### PR DESCRIPTION
…f restrict

Since ImportC does not assign any semantic meaning to `restrict` for now, I just removed the tests that were invalid usage of `restrict`.