### PR TITLE
fix Issue 23717 - runnable/bitfields.c:192:5: error: unknown type nam…

### DIFF
--- a/compiler/test/runnable/bitfields.c
+++ b/compiler/test/runnable/bitfields.c
@@ -189,7 +189,7 @@ struct S6
 
 int boo6()
 {
-    S s;
+    struct S6 s;
     s.a = 3;
     s.b = 1;
     s.a += 2;


### PR DESCRIPTION
…e S; use struct keyword to refer to the typ

fix typo