### PR TITLE
[stable] druntime: Fix InvalidMemoryOperation error on Windows when throwing exceptions from finalizers

### DIFF
--- a/druntime/test/allocations/win64.mak
+++ b/druntime/test/allocations/win64.mak
@@ -1,0 +1,12 @@
+# built from the druntime top-level folder
+# to be overwritten by caller
+DMD=dmd
+MODEL=64
+DRUNTIMELIB=druntime64.lib
+
+test: alloc_from_assert
+
+alloc_from_assert:
+	$(DMD) -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\allocations\src\$@.d
+	$@.exe
+	del $@.*

--- a/druntime/win32.mak
+++ b/druntime/win32.mak
@@ -128,6 +128,9 @@ unittest.obj: $(SRCS) win32.mak
 test_aa:
 	$(DMD) -m32omf -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\aa\src\test_aa.d
 
+test_allocations:
+	"$(MAKE)" -f test\allocations\win64.mak "DMD=$(DMD)" MODEL=32omf "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+
 test_cpuid:
 	"$(MAKE)" -f test\cpuid\win64.mak "DMD=$(DMD)" MODEL=32omf "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
@@ -146,7 +149,7 @@ custom_gc:
 test_shared:
 	$(MAKE) -f test\shared\win64.mak "DMD=$(DMD)" MODEL=32omf "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
-test_all: test_aa test_cpuid test_exceptions test_hash test_gc custom_gc test_shared
+test_all: test_aa test_allocations test_cpuid test_exceptions test_hash test_gc custom_gc test_shared
 
 ################### zip/install/clean ##########################
 

--- a/druntime/win64.mak
+++ b/druntime/win64.mak
@@ -85,6 +85,9 @@ test_uuid:
 test_aa:
 	"$(DMD)" -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\aa\src\test_aa.d
 
+test_allocations:
+	"$(MAKE)" -f test\allocations\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) DRUNTIMELIB=$(DRUNTIME) test
+
 test_betterc:
 	"$(MAKE)" -f test\betterc\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) DRUNTIMELIB=$(DRUNTIME) test
 
@@ -113,7 +116,7 @@ custom_gc:
 test_shared:
 	$(MAKE) -f test\shared\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) DRUNTIMELIB=$(DRUNTIME) test
 
-test_common: test_shared test_aa test_cpuid test_exceptions test_hash test_gc custom_gc
+test_common: test_shared test_aa test_allocations test_cpuid test_exceptions test_hash test_gc custom_gc
 
 test_mingw: test_common test_betterc_mingw
 


### PR DESCRIPTION
A v2.102 regression, which newly enabled `StackTrace` constructions from within GC finalizers. The construction is `@nogc`, but apparently depends on the `typeid(StackTrace)` monitor having been allocated already, i.e., a previous `StackTrace` construction.

So pre-allocate a dedicated `Mutex` in the module constructor to make the `StackTrace` construction really `@nogc`. `druntime/test/allocations/src/alloc_from_assert.d` then passes on Windows again (not tested by DMD, but by LDC).

While at it, also prevent `InvalidMemoryOperation` errors when trying to print exceptions within finalizers - by not resolving anything (=> empty printed trace), as resolving currently heavily depends on the GC.