### PR TITLE
fix Issue 23727 - ImportC support imaginary real numbers

### DIFF
--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -2563,6 +2563,14 @@ class Lexer
         TOK result;
         bool isOutOfRange = false;
         t.floatvalue = (isWellformedString ? CTFloat.parse(sbufptr, isOutOfRange) : CTFloat.zero);
+
+        bool imaginary = false;
+        if (*p == 'i' && Ccompile)
+        {
+            ++p;
+            imaginary = true;
+        }
+
         switch (*p)
         {
         case 'F':
@@ -2588,11 +2596,17 @@ class Lexer
             result = TOK.float80Literal;
             break;
         }
+
         if ((*p == 'i' || *p == 'I') && !Ccompile)
         {
             if (*p == 'I')
                 error("use 'i' suffix instead of 'I'");
             p++;
+            imaginary = true;
+        }
+
+        if (imaginary)
+        {
             switch (result)
             {
             case TOK.float32Literal:

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2645,6 +2645,8 @@ extern (C++) abstract class Type : ASTNode
 
         if (t.isimaginary() || t.iscomplex())
         {
+            if (sc.flags & SCOPE.Cfile)
+                return true;            // complex/imaginary not deprecated in C code
             Type rt;
             switch (t.ty)
             {

--- a/compiler/test/compilable/testcomplex.i
+++ b/compiler/test/compilable/testcomplex.i
@@ -1,0 +1,22 @@
+
+/* GCC header complex.h requires supporting `i` suffix extension
+ */
+
+_Complex float testf()
+{
+    _Complex float x = 1.0if;
+    return x;
+}
+
+_Complex double testd()
+{
+    _Complex double x = 1.0i;
+    return x;
+}
+
+_Complex long double testld()
+{
+    _Complex long double x = 1.0iL;
+    return x;
+}
+

--- a/compiler/test/compilable/testcomplex.i
+++ b/compiler/test/compilable/testcomplex.i
@@ -19,4 +19,3 @@ _Complex long double testld()
     _Complex long double x = 1.0iL;
     return x;
 }
-


### PR DESCRIPTION
Since D already supports complex numbers, ImportC just has to support the syntax, and skip the deprecation warnings.

This is blocking compiling <complex.h>