### PR TITLE
ImportC: compile Digital Mars complex.h

### DIFF
--- a/compiler/test/compilable/stdcheaders.c
+++ b/compiler/test/compilable/stdcheaders.c
@@ -4,10 +4,7 @@
 
 #include <assert.h>
 
-#ifndef __DMC__ // D:\a\1\s\tools\dm\include\complex.h(105): Deprecation: use of complex type `cdouble` is deprecated, use `std.complex.Complex!(double)` instead
 #include <complex.h>
-#endif
-
 #include <ctype.h>
 #include <errno.h>
 

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -66,6 +66,9 @@ typedef unsigned short __uint16_t;
 typedef unsigned int __uint32_t;
 typedef unsigned long long __uint64_t;
 
+/* Digital Mars C */
+#define __imaginary 1.0i
+
 /*********************
  * Obsolete detritus
  */


### PR DESCRIPTION
DMC doesn't support the `i` postfix, using `__imaginary` instead. But ImportC does support the `i` postfix, and not `__imaginary`.

Provided the blocking https://github.com/dlang/dmd/pull/14902 is merged.