### PR TITLE
add errorsink.d, an abstract interface to error messages

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1576,7 +1576,7 @@ auto sourceFiles()
             statement.h staticassert.h target.h template.h tokens.h version.h visitor.h
         "),
         lexer: fileArray(env["D"], "
-            console.d entity.d errors.d file_manager.d globals.d id.d identifier.d lexer.d location.d tokens.d
+            console.d entity.d errors.d errorsink.d file_manager.d globals.d id.d identifier.d lexer.d location.d tokens.d
         ") ~ fileArray(env["ROOT"], "
             array.d bitarray.d ctfloat.d file.d filename.d hash.d port.d region.d rmem.d
             rootobject.d stringtable.d utf.d

--- a/compiler/src/dmd/README.md
+++ b/compiler/src/dmd/README.md
@@ -38,7 +38,8 @@ Note that these groups have no strict meaning, the category assignments are a bi
 | [dinifile.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dinifile.d)   | Parse settings from .ini file (`sc.ini` / `dmd.conf`)                 |
 | [vsoptions.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/vsoptions.d) | Detect the Microsoft Visual Studio toolchain for linking              |
 | [frontend.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/frontend.d)   | An interface for using DMD as a library                               |
-| [errors.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/errors.d)       | Error reporting functionality                                         |
+| [errors.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/errors.d)       | Error reporting implementation                                        |
+| [errorsink.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/errorsink.d) | Error reporting interface                                             |
 | [target.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/target.d)       | Manage target-specific parameters for cross-compiling (for LDC/GDC)   |
 | [compiler.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/compiler.d)   | Describe a back-end compiler and implements compiler-specific actions |
 

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -29,6 +29,7 @@ import dmd.dscope;
 import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.errors;
+import dmd.errorsink;
 import dmd.expression;
 import dmd.expressionsem;
 import dmd.file_manager;
@@ -766,7 +767,7 @@ extern (C++) final class Module : Package
         {
             filetype = FileType.c;
 
-            scope p = new CParser!AST(this, buf, cast(bool) docfile, target.c, &defines);
+            scope p = new CParser!AST(this, buf, cast(bool) docfile, global.errorSink, target.c, &defines);
             p.nextToken();
             checkCompiledImport();
             members = p.parseModule();
@@ -775,7 +776,7 @@ extern (C++) final class Module : Package
         }
         else
         {
-            scope p = new Parser!AST(this, buf, cast(bool) docfile);
+            scope p = new Parser!AST(this, buf, cast(bool) docfile, global.errorSink);
             p.nextToken();
             p.parseModuleDeclaration();
             md = p.md;
@@ -1382,7 +1383,7 @@ extern (C++) struct ModuleDeclaration
  * for inclusion in ModuleInfo
  * Params:
  *      mod = the Module
- *	aclasses = array to fill in
+ *      aclasses = array to fill in
  * Returns: array of local classes
  */
 extern (C++) void getLocalClasses(Module mod, ref ClassDeclarations aclasses)

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -5183,6 +5183,7 @@ private void highlightCode2(Scope* sc, Dsymbols* a, ref OutBuffer buf, size_t of
     uint errorsave = global.startGagging();
 
     scope Lexer lex = new Lexer(null, cast(char*)buf[].ptr, 0, buf.length - 1, 0, 1,
+        global.errorSink,
         global.vendor, global.versionNumber());
     OutBuffer res;
     const(char)* lastp = cast(char*)buf[].ptr;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1917,7 +1917,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         const len = buf.length;
         buf.writeByte(0);
         const str = buf.extractSlice()[0 .. len];
-        scope p = new Parser!ASTCodegen(cd.loc, sc._module, str, false);
+        scope p = new Parser!ASTCodegen(cd.loc, sc._module, str, false, global.errorSink);
         p.nextToken();
 
         auto d = p.parseDeclDefs(0);

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -7561,7 +7561,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 //printf("\t staticIfDg on '%s %s' in '%s'\n",  s.kind(), s.toChars(), this.toChars());
                 if (!s.isStaticIfDeclaration())
                 {
-		    //s.dsymbolSemantic(sc2);
+                    //s.dsymbolSemantic(sc2);
                     done = true;
                     return;
                 }

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -15,6 +15,7 @@ import core.stdc.stdarg;
 import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
+import dmd.errorsink;
 import dmd.globals;
 import dmd.location;
 import dmd.common.outbuffer;
@@ -23,6 +24,57 @@ import dmd.root.string;
 import dmd.console;
 
 nothrow:
+
+/***************************
+ * Error message sink for D compiler.
+ */
+class ErrorSinkCompiler : ErrorSink
+{
+  nothrow:
+  extern (C++):
+  override:
+
+    void error(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        verror(loc, format, ap);
+        va_end(ap);
+    }
+
+    void errorSupplemental(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        verrorSupplemental(loc, format, ap);
+        va_end(ap);
+    }
+
+    void warning(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vwarning(loc, format, ap);
+        va_end(ap);
+    }
+
+    void deprecation(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vdeprecation(loc, format, ap);
+        va_end(ap);
+    }
+
+    void deprecationSupplemental(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vdeprecationSupplemental(loc, format, ap);
+        va_end(ap);
+    }
+}
+
 
 /**
  * Color highlighting to classify messages
@@ -768,7 +820,7 @@ private void colorHighlightCode(ref OutBuffer buf)
     ++nested;
 
     auto gaggedErrorsSave = global.startGagging();
-    scope Lexer lex = new Lexer(null, cast(char*)buf[].ptr, 0, buf.length - 1, 0, 1, global.vendor, global.versionNumber());
+    scope Lexer lex = new Lexer(null, cast(char*)buf[].ptr, 0, buf.length - 1, 0, 1, global.errorSink, global.vendor, global.versionNumber());
     OutBuffer res;
     const(char)* lastp = cast(char*)buf[].ptr;
     //printf("colorHighlightCode('%.*s')\n", cast(int)(buf.length - 1), buf[].ptr);

--- a/compiler/src/dmd/errorsink.d
+++ b/compiler/src/dmd/errorsink.d
@@ -1,0 +1,121 @@
+/**
+ * Provides an abstraction for what to do with error messages.
+ *
+ * Copyright:   Copyright (C) 2023 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/errorsink.d, _errorsink.d)
+ * Documentation:  https://dlang.org/phobos/dmd_errorsink.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/errorsink.d
+ */
+
+module dmd.errorsink;
+
+import dmd.location;
+
+/***************************************
+ * Where error/warning/deprecation messages go.
+ */
+abstract class ErrorSink
+{
+  nothrow:
+  extern (C++):
+
+    void error(const ref Loc loc, const(char)* format, ...);
+
+    void errorSupplemental(const ref Loc loc, const(char)* format, ...);
+
+    void warning(const ref Loc loc, const(char)* format, ...);
+
+    void deprecation(const ref Loc loc, const(char)* format, ...);
+
+    void deprecationSupplemental(const ref Loc loc, const(char)* format, ...);
+}
+
+/*****************************************
+ * Just ignores the messages.
+ */
+class ErrorSinkNull : ErrorSink
+{
+  nothrow:
+  extern (C++):
+  override:
+
+    void error(const ref Loc loc, const(char)* format, ...) { }
+
+    void errorSupplemental(const ref Loc loc, const(char)* format, ...) { }
+
+    void warning(const ref Loc loc, const(char)* format, ...) { }
+
+    void deprecation(const ref Loc loc, const(char)* format, ...) { }
+
+    void deprecationSupplemental(const ref Loc loc, const(char)* format, ...) { }
+}
+
+/*****************************************
+ * Simplest implementation, just sends messages to stderr.
+ */
+class ErrorSinkStderr : ErrorSink
+{
+    import core.stdc.stdio;
+    import core.stdc.stdarg;
+
+  nothrow:
+  extern (C++):
+  override:
+
+    void error(const ref Loc loc, const(char)* format, ...)
+    {
+        fputs("Error: ", stderr);
+        const p = loc.toChars();
+        if (*p)
+        {
+            fprintf(stderr, "%s: ", p);
+            //mem.xfree(cast(void*)p); // loc should provide the free()
+        }
+
+        va_list ap;
+        va_start(ap, format);
+        vfprintf(stderr, format, ap);
+        fputc('\n', stderr);
+        va_end(ap);
+    }
+
+    void errorSupplemental(const ref Loc loc, const(char)* format, ...) { }
+
+    void warning(const ref Loc loc, const(char)* format, ...)
+    {
+        fputs("Warning: ", stderr);
+        const p = loc.toChars();
+        if (*p)
+        {
+            fprintf(stderr, "%s: ", p);
+            //mem.xfree(cast(void*)p); // loc should provide the free()
+        }
+
+        va_list ap;
+        va_start(ap, format);
+        vfprintf(stderr, format, ap);
+        fputc('\n', stderr);
+        va_end(ap);
+    }
+
+    void deprecation(const ref Loc loc, const(char)* format, ...)
+    {
+        fputs("Deprecation: ", stderr);
+        const p = loc.toChars();
+        if (*p)
+        {
+            fprintf(stderr, "%s: ", p);
+            //mem.xfree(cast(void*)p); // loc should provide the free()
+        }
+
+        va_list ap;
+        va_start(ap, format);
+        vfprintf(stderr, format, ap);
+        fputc('\n', stderr);
+        va_end(ap);
+    }
+
+    void deprecationSupplemental(const ref Loc loc, const(char)* format, ...) { }
+}

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6101,7 +6101,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         uint errors = global.errors;
         const len = buf.length;
         const str = buf.extractChars()[0 .. len];
-        scope p = new Parser!ASTCodegen(exp.loc, sc._module, str, false);
+        scope p = new Parser!ASTCodegen(exp.loc, sc._module, str, false, global.errorSink);
         p.nextToken();
         //printf("p.loc.linnum = %d\n", p.loc.linnum);
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -307,6 +307,7 @@ class ArrayInitializer;
 class ExpInitializer;
 class CInitializer;
 class FileManager;
+class ErrorSink;
 class ErrorStatement;
 class ExpStatement;
 class ConditionalStatement;
@@ -3382,6 +3383,7 @@ struct Global final
     FileManager* fileManager;
     enum : int32_t { recursionLimit = 500 };
 
+    ErrorSink* errorSink;
     FileName(*preprocess)(FileName , const Loc& , bool& , OutBuffer* );
     uint32_t startGagging();
     bool endGagging(uint32_t oldGagged);
@@ -3408,10 +3410,11 @@ struct Global final
         hasMainFunction(),
         varSequenceNumber(1u),
         fileManager(),
+        errorSink(),
         preprocess()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2023 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, FileName(*preprocess)(FileName , const Loc& , bool& , OutBuffer* ) = nullptr) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2023 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, _d_dynamicArray< const char > vendor = {}, Param params = Param(), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, ErrorSink* errorSink = nullptr, FileName(*preprocess)(FileName , const Loc& , bool& , OutBuffer* ) = nullptr) :
         inifilename(inifilename),
         copyright(copyright),
         written(written),
@@ -3430,6 +3433,7 @@ struct Global final
         hasMainFunction(hasMainFunction),
         varSequenceNumber(varSequenceNumber),
         fileManager(fileManager),
+        errorSink(errorSink),
         preprocess(preprocess)
         {}
 };

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -15,6 +15,8 @@ import core.stdc.stdint;
 import dmd.root.array;
 import dmd.root.filename;
 import dmd.common.outbuffer;
+import dmd.errorsink;
+import dmd.errors;
 import dmd.file_manager;
 import dmd.identifier;
 import dmd.location;
@@ -292,6 +294,8 @@ extern (C++) struct Global
 
     enum recursionLimit = 500; /// number of recursive template expansions before abort
 
+    ErrorSink errorSink;       /// where the error messages go
+
     extern (C++) FileName function(FileName, ref const Loc, out bool, OutBuffer*) preprocess;
 
   nothrow:
@@ -346,6 +350,8 @@ extern (C++) struct Global
 
     extern (C++) void _init()
     {
+        global.errorSink = new ErrorSinkCompiler;
+
         this.fileManager = new FileManager();
         version (MARS)
         {

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -19,6 +19,7 @@
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;
 
+class ErrorSink;
 class FileManager;
 struct Loc;
 
@@ -278,6 +279,7 @@ struct Global
     unsigned varSequenceNumber;
 
     FileManager* fileManager;
+    ErrorSink* errorSink;       // where the error messages go
 
     FileName (*preprocess)(FileName, const Loc&, bool&, OutBuffer&);
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -39,6 +39,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.dtemplate;
 import dmd.errors;
+import dmd.errorsink;
 import dmd.escape;
 import dmd.expression;
 import dmd.expressionsem;
@@ -4732,7 +4733,7 @@ private Statements* flatten(Statement statement, Scope* sc)
             const len = buf.length;
             buf.writeByte(0);
             const str = buf.extractSlice()[0 .. len];
-            scope p = new Parser!ASTCodegen(cs.loc, sc._module, str, false);
+            scope p = new Parser!ASTCodegen(cs.loc, sc._module, str, false, global.errorSink);
             p.nextToken();
 
             auto a = new Statements();

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -35,6 +35,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.dtemplate;
 import dmd.errors;
+import dmd.errorsink;
 import dmd.expression;
 import dmd.expressionsem;
 import dmd.func;
@@ -4917,7 +4918,7 @@ RootObject compileTypeMixin(TypeMixin tm, Loc loc, Scope* sc)
     const len = buf.length;
     buf.writeByte(0);
     const str = buf.extractSlice()[0 .. len];
-    scope p = new Parser!ASTCodegen(loc, sc._module, str, false);
+    scope p = new Parser!ASTCodegen(loc, sc._module, str, false, global.errorSink);
     p.nextToken();
     //printf("p.loc.linnum = %d\n", p.loc.linnum);
 

--- a/compiler/test/unit/frontend.d
+++ b/compiler/test/unit/frontend.d
@@ -56,7 +56,7 @@ unittest
     initDMD();
     defaultImportPaths.each!addImport;
 
-    auto t = parseModule!AST("test.d", q{
+    auto t = parseModule!AST("frontendcustomASTfamily.d", q{
         interface Foo {}
     });
 
@@ -174,7 +174,7 @@ unittest
     initDMD();
     defaultImportPaths.each!addImport;
 
-    auto t = parseModule("test.d", q{
+    auto t = parseModule("frontendcontractchecking.d", q{
         int foo(int a)
         in(a == 3)
         out(result; result == 0)
@@ -219,7 +219,7 @@ unittest
     initDMD(null, null, ["Foo"]);
     defaultImportPaths.each!addImport;
 
-    auto t = parseModule("test.d", q{
+    auto t = parseModule("frontendversionidentifiers.d", q{
         version (Foo)
             enum a = 1;
         else
@@ -263,7 +263,7 @@ unittest
     initDMD(&diagnosticHandler);
     defaultImportPaths.each!addImport;
 
-    parseModule("test.d", q{
+    parseModule("frontendcustomdiagnostichandling.d", q{
         void foo(){
             auto temp == 7.8;
             foreach(i; 0..5){
@@ -287,7 +287,7 @@ unittest
     defaultImportPaths.each!addImport;
     addStringImport(__FILE_FULL_PATH__.dirName.buildPath("support", "data"));
 
-    auto t = parseModule("test.d", q{
+    auto t = parseModule("frontendaddStringImport.d", q{
         enum a = import("foo.txt");
     });
 
@@ -310,7 +310,7 @@ unittest
     initDMD();
     defaultImportPaths.each!addImport;
 
-    auto t = parseModule("test.d", q{
+    auto t = parseModule("frontendfloatingpoint.d", q{
         static assert((2.0i).re == 0);
     });
 
@@ -333,7 +333,7 @@ unittest
     initDMD();
     defaultImportPaths.each!addImport;
 
-    auto t = parseModule("test.d", q{
+    auto t = parseModule("frontendinlineassembly.d", q{
         void foo()
         {
             asm
@@ -380,7 +380,7 @@ unittest
     initDMD(&diagnosticHandler);
     defaultImportPaths.each!addImport;
 
-    auto t = parseModule("test.dd", q{Ddoc});
+    auto t = parseModule("frontendddoc.dd", q{Ddoc});
 
     assert(!t.diagnostics.hasErrors);
     assert(!t.diagnostics.hasWarnings);

--- a/compiler/test/unit/lexer/diagnostic_reporter.d
+++ b/compiler/test/unit/lexer/diagnostic_reporter.d
@@ -6,6 +6,7 @@ import core.stdc.stdarg;
 
 import dmd.globals : global, DiagnosticReporting;
 import dmd.location;
+import dmd.errors;
 
 import support : afterEach, NoopDiagnosticReporter;
 
@@ -61,7 +62,9 @@ private void lexUntilEndOfFile(string code)
     import dmd.lexer : Lexer;
     import dmd.tokens : TOK;
 
-    scope lexer = new Lexer("test", code.ptr, 0, code.length, 0, 0);
+    if (!global.errorSink)
+	global.errorSink = new ErrorSinkCompiler;
+    scope lexer = new Lexer("test", code.ptr, 0, code.length, 0, 0, global.errorSink);
     lexer.nextToken;
 
     while (lexer.nextToken != TOK.endOfFile) {}

--- a/compiler/test/unit/lexer/lexer_dmdlib.d
+++ b/compiler/test/unit/lexer/lexer_dmdlib.d
@@ -2,6 +2,7 @@ module lexer.lexer_dmdlib;
 
 import dmd.lexer : Lexer;
 import dmd.tokens : TOK;
+import dmd.errorsink;
 
 unittest
 {
@@ -16,7 +17,7 @@ unittest
         TOK.rightCurly,
     ];
 
-    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, false, false);
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, false, false, new ErrorSinkStderr);
     TOK[] result;
 
     while (lexer.nextToken != TOK.endOfFile)
@@ -39,7 +40,7 @@ unittest
         TOK.comment,
     ];
 
-    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true, false);
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true, false, new ErrorSinkStderr);
     TOK[] result;
 
     while (lexer.nextToken != TOK.endOfFile)
@@ -65,7 +66,7 @@ unittest
         TOK.comment,
     ];
 
-    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true, true);
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true, true, new ErrorSinkStderr);
     TOK[] result;
 
     while (lexer.nextToken != TOK.endOfFile)
@@ -92,7 +93,7 @@ unittest
         TOK.whitespace,
     ];
 
-    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true, true);
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true, true, new ErrorSinkStderr);
     TOK[] result;
 
     while (lexer.nextToken != TOK.endOfFile)
@@ -136,7 +137,7 @@ unittest
         TOK.whitespace,
     ];
 
-    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true, true);
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true, true, new ErrorSinkStderr);
     TOK[] result;
 
     while (lexer.nextToken != TOK.endOfFile)
@@ -171,7 +172,7 @@ unittest
         TOK.whitespace,
     ];
 
-    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true, true);
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true, true, new ErrorSinkStderr);
     TOK[] result;
 
     while (lexer.nextToken != TOK.endOfFile)
@@ -193,7 +194,7 @@ unittest
         TOK.rightCurly,
     ];
 
-    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, false);
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, false, new ErrorSinkStderr);
     lexer.nextToken;
 
     TOK[] result;
@@ -214,7 +215,7 @@ unittest
         TOK.comment,
     ];
 
-    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true);
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, true, new ErrorSinkStderr);
     lexer.nextToken;
 
     TOK[] result;
@@ -240,7 +241,7 @@ unittest
         TOK.reserved,
     ];
 
-    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, false);
+    Lexer lexer = new Lexer(null, code.ptr, 0, code.length, false, false, new ErrorSinkStderr);
 
     TOK[] result;
 
@@ -265,6 +266,7 @@ unittest
     import dmd.location;
     import dmd.common.outbuffer;
     import dmd.console : Color;
+    import dmd.errors;
 
     const(char)[][2][] diagnosticMessages;
     nothrow bool diagnosticHandler(const ref Loc loc, Color headerColor, const(char)* header,
@@ -288,7 +290,7 @@ unittest
     foreach (codeNum, code; codes)
     {
         auto fileName = text("file", codeNum, '\0');
-        Lexer lexer = new Lexer(fileName.ptr, code.ptr, 0, code.length, false, false);
+        Lexer lexer = new Lexer(fileName.ptr, code.ptr, 0, code.length, false, false, new ErrorSinkCompiler);
         // Generate the errors
         foreach(unused; lexer){}
     }

--- a/compiler/test/unit/lexer/location_offset.d
+++ b/compiler/test/unit/lexer/location_offset.d
@@ -2,6 +2,7 @@ module lexer.location_offset;
 
 import dmd.lexer : Lexer;
 import dmd.tokens : TOK;
+import dmd.errorsink;
 
 import support : afterEach;
 
@@ -16,7 +17,7 @@ unittest
 {
     enum code = "token";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
 
@@ -28,7 +29,7 @@ unittest
 {
     enum code = "ignored_token token";
 
-    scope lexer = new Lexer("test.d", code.ptr, 13, code.length - 14, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 13, code.length - 14, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
 
@@ -40,7 +41,7 @@ unittest
 {
     enum code = "token1 token2 3";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
     lexer.nextToken;
@@ -54,7 +55,7 @@ unittest
 {
     enum code = "token";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
     lexer.nextToken;
@@ -67,7 +68,7 @@ unittest
 {
     enum code = "/* comment */";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, true);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, true, new ErrorSinkStderr);
 
     lexer.nextToken;
 
@@ -80,7 +81,7 @@ unittest
 {
     enum code = "// comment";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, true);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, true, new ErrorSinkStderr);
 
     lexer.nextToken;
 
@@ -93,7 +94,7 @@ unittest
 {
     enum code = "/+ comment +/";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, true);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, true, new ErrorSinkStderr);
 
     lexer.nextToken;
 
@@ -106,7 +107,7 @@ unittest
 {
     enum code = "/* comment */ token";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
 
@@ -118,7 +119,7 @@ unittest
 {
     enum code = "// comment\ntoken";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
 
@@ -130,7 +131,7 @@ unittest
 {
     enum code = "/+ comment +/ token";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
 
@@ -142,7 +143,7 @@ unittest
 {
     enum code = "line\ntoken";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
     lexer.nextToken;
@@ -155,7 +156,7 @@ unittest
 {
     enum code = "line\r\ntoken";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
     lexer.nextToken;
@@ -168,7 +169,7 @@ unittest
 {
     enum code = "line\rtoken";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
     lexer.nextToken;
@@ -181,7 +182,7 @@ unittest
 {
     enum code = "'🍺'";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
 
@@ -193,7 +194,7 @@ unittest
 {
     enum code = `"🍺🍺"`;
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
 
@@ -205,7 +206,7 @@ unittest
 {
     enum code = "'🍺' token";
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
     lexer.nextToken;
@@ -218,7 +219,7 @@ unittest
 {
     enum code = `"🍺🍺" token`;
 
-    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0);
+    scope lexer = new Lexer("test.d", code.ptr, 0, code.length, 0, 0, new ErrorSinkStderr);
 
     lexer.nextToken;
     lexer.nextToken;
@@ -557,7 +558,7 @@ static foreach (tok; __traits(allMembers, TOK))
         {
             const newCode = "first_token " ~ tests[tok].code;
 
-            scope lexer = new Lexer("test.d", newCode.ptr, 0, newCode.length, 0, 0);
+            scope lexer = new Lexer("test.d", newCode.ptr, 0, newCode.length, 0, 0, new ErrorSinkStderr);
 
             lexer.nextToken;
             lexer.nextToken;


### PR DESCRIPTION
I've made considerable progress into making the lexer standalone, and the lexer/parser standalone. The problem is its reliance on globals.d and errors.d, which pull in a bunch of other stuff not relevant to lexing/parsing. The code in errors.d is of rather stupefying complexity, which is completely irrelevant to the lexer/parser. This complexity also makes it difficult to create a standalone lexer/parser.

Enter the abstract interface for error messages, ErrorSink, in errorsink.d. It's only got the functions in it that the lexer/parser actually need. The lexer/parser should not need to know anything about color formatting, highlighting, gagging, or where the messages are sent to.

The constructors for the lexer/parser are passed an instance of ErrorSink.

This isn't perfect, there's still an ugly wart in it that relies on getenv. I'll tackle that problem after this one is incorporated.

Sorry about the high line count, although nearly all of it is just changing the call to `error()`. The substantive changes are pretty small.

The more we can reduce all these "everybody imports everybody else" the more tractable the code base will be.