### PR TITLE
Fix Issue 19978 - D sometimes just crashes on exit with daemon threads

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -1788,7 +1788,7 @@ private extern (D) bool suspend( Thread t ) nothrow @nogc
  * Throws:
  *  ThreadError if the suspend operation fails for a running thread.
  */
-extern (C) void thread_suspendAll() nothrow
+extern (C) void thread_suspendAll(bool willNeverResume = false) nothrow
 {
     // NOTE: We've got an odd chicken & egg problem here, because while the GC
     //       is required to call thread_init before calling any other thread
@@ -1812,6 +1812,11 @@ extern (C) void thread_suspendAll() nothrow
     }
 
     Thread.slock.lock_nothrow();
+    scope(exit)
+    {
+        if (willNeverResume)
+            Thread.slock.unlock_nothrow();
+    }
     {
         if ( ++suspendDepth > 1 )
             return;

--- a/druntime/src/rt/dmain2.d
+++ b/druntime/src/rt/dmain2.d
@@ -72,6 +72,7 @@ extern (C) void rt_moduleTlsCtor();
 extern (C) void rt_moduleDtor();
 extern (C) void rt_moduleTlsDtor();
 extern (C) void thread_joinAll();
+extern (C) void thread_suspendAll(bool willNeverResume = false) nothrow;
 extern (C) UnitTestResult runModuleUnitTests();
 extern (C) void _d_initMonoTime() @nogc nothrow;
 
@@ -156,6 +157,7 @@ extern (C) int rt_term()
     {
         rt_moduleTlsDtor();
         thread_joinAll();
+        thread_suspendAll(true); // for daemonThreads
         rt_moduleDtor();
         gc_term();
         thread_term();


### PR DESCRIPTION
Disclaimer: This PR is probably not the best solution and might suffer from some issues, however, I don't have any better ideas.

The problem seems to stem from the fact that daemon threads are not joined or stopped before memory is teared apart by the runtime. This leads to memory issues when the said daemon threads access memory that was freed. To fix this, I am suspending all threads before the cleanup process begins. Unfortunately, the only function that I've found to do that is suspendAll - which indiscriminately stops all threads and also acquires a lock on the global ThreadBase lock. This is problematic when the locks are freed because, typically, the lock is released when resumeAll is called. To fix this, I added an optional parameter to suspendAll (willNeverResume) so that the caller can stop the lock acquisition if the threads are suspended before terminating the process. I know that this is not ideal, but I am all ears for suggestions of better approaches; after all, I can't really find my way around druntime.

Note: This works on my machine but how do I test this in the testing framework?