### PR TITLE
Provide the expression Location for TypeInfo errors on betterC

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -184,7 +184,7 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
         Type tb = result.type.toBasetype();
         if (auto ta = tb.isTypeDArray())
             if (global.params.useTypeInfo && Type.dtypeinfo)
-                semanticTypeInfo(sc, ta.next);
+                semanticTypeInfo(sc, ta.next, e.loc);
         return result;
     }
 

--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -69,7 +69,7 @@ extern (C++) FuncDeclaration search_toString(StructDeclaration sd)
  *      sc = context
  *      t = type that TypeInfo is being generated for
  */
-extern (C++) void semanticTypeInfo(Scope* sc, Type t)
+extern (C++) void semanticTypeInfo(Scope* sc, Type t, const ref Loc loc)
 {
     if (sc)
     {
@@ -84,13 +84,13 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
 
     void visitVector(TypeVector t)
     {
-        semanticTypeInfo(sc, t.basetype);
+        semanticTypeInfo(sc, t.basetype, loc);
     }
 
     void visitAArray(TypeAArray t)
     {
-        semanticTypeInfo(sc, t.index);
-        semanticTypeInfo(sc, t.next);
+        semanticTypeInfo(sc, t.index, loc);
+        semanticTypeInfo(sc, t.next, loc);
     }
 
     void visitStruct(TypeStruct t)
@@ -104,7 +104,7 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
         {
             Scope scx;
             scx._module = sd.getModule();
-            getTypeInfoType(sd.loc, t, &scx);
+            getTypeInfoType(loc, t, &scx);
             sd.requestTypeInfo = true;
         }
         else if (!sc.minst)
@@ -114,7 +114,7 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
         }
         else
         {
-            getTypeInfoType(sd.loc, t, sc);
+            getTypeInfoType(loc, t, sc);
             sd.requestTypeInfo = true;
 
             // https://issues.dlang.org/show_bug.cgi?id=15149
@@ -159,7 +159,7 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
         {
             foreach (arg; *t.arguments)
             {
-                semanticTypeInfo(sc, arg.type);
+                semanticTypeInfo(sc, arg.type, loc);
             }
         }
     }
@@ -178,7 +178,7 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
         case Tclass:
         case Tenum:     break;
 
-        default:        semanticTypeInfo(sc, tb.nextOf()); break;
+        default:        semanticTypeInfo(sc, tb.nextOf(), loc); break;
     }
 }
 

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -1561,7 +1561,7 @@ extern (C++) abstract class Expression : ASTNode
             {
                 // https://issues.dlang.org/show_bug.cgi?id=11395
                 // Require TypeInfo generation for array concatenation
-                semanticTypeInfo(sc, t);
+                semanticTypeInfo(sc, t, loc);
             }
 
             StructDeclaration sd = ts.sym;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -557,7 +557,7 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
                 if (key.checkValue() || key.checkSharedAccess(sc))
                     return ErrorExp.get();
 
-                semanticTypeInfo(sc, taa.index);
+                semanticTypeInfo(sc, taa.index, loc);
 
                 return new RemoveExp(loc, eleft, key);
             }
@@ -3175,7 +3175,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         if (global.params.useTypeInfo && Type.dtypeinfo)
-            semanticTypeInfo(sc, e.type);
+            semanticTypeInfo(sc, e.type, e.loc);
 
         result = e;
     }
@@ -3215,7 +3215,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         e.type = new TypeAArray(tvalue, tkey);
         e.type = e.type.typeSemantic(e.loc, sc);
 
-        semanticTypeInfo(sc, e.type);
+        semanticTypeInfo(sc, e.type, e.loc);
 
         if (checkAssocArrayLiteralEscape(sc, e, false))
             return setError();
@@ -3995,7 +3995,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         //printf("NewExp: '%s'\n", toChars());
         //printf("NewExp:type '%s'\n", type.toChars());
-        semanticTypeInfo(sc, exp.type);
+        semanticTypeInfo(sc, exp.type, exp.loc);
 
         if (newprefix)
         {
@@ -5593,7 +5593,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
 
             e.type = getTypeInfoType(exp.loc, ta, sc, genObjCode);
-            semanticTypeInfo(sc, ta);
+            semanticTypeInfo(sc, ta, exp.loc);
 
             if (ea)
             {
@@ -8529,7 +8529,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         return setError();
                 }
 
-                semanticTypeInfo(sc, taa);
+                semanticTypeInfo(sc, taa, exp.loc);
                 checkNewEscape(sc, exp.e2, false);
 
                 exp.type = taa.next;
@@ -11924,7 +11924,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.e1 = exp.e1.implicitCastTo(sc, ta.index);
                 }
 
-                semanticTypeInfo(sc, ta.index);
+                semanticTypeInfo(sc, ta.index, exp.loc);
 
                 // Return type is pointer to value
                 exp.type = ta.nextOf().pointerTo();
@@ -12046,7 +12046,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         // Indicates whether the comparison of the 2 specified array types
         // requires an object.__equals() lowering.
-        static bool needsDirectEq(Type t1, Type t2, Scope* sc)
+        static bool needsDirectEq(Type t1, Type t2, Scope* sc, const ref Loc loc)
         {
             Type t1n = t1.nextOf().toBasetype();
             Type t2n = t2.nextOf().toBasetype();
@@ -12065,7 +12065,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 // semanticTypeInfo() makes sure hasIdentityEquals has been computed
                 if (global.params.useTypeInfo && Type.dtypeinfo)
-                    semanticTypeInfo(sc, ts);
+                    semanticTypeInfo(sc, ts, loc);
 
                 return ts.sym.hasIdentityEquals; // has custom opEquals
             }
@@ -12082,7 +12082,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         const isArrayComparison = (t1.ty == Tarray || t1.ty == Tsarray) &&
                                   (t2.ty == Tarray || t2.ty == Tsarray);
-        const needsArrayLowering = isArrayComparison && needsDirectEq(t1, t2, sc);
+        const needsArrayLowering = isArrayComparison && needsDirectEq(t1, t2, sc, exp.loc);
 
         if (!needsArrayLowering)
         {
@@ -12165,7 +12165,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         if (exp.e1.type.toBasetype().ty == Taarray)
-            semanticTypeInfo(sc, exp.e1.type.toBasetype());
+            semanticTypeInfo(sc, exp.e1.type.toBasetype(), exp.loc);
 
 
         if (!target.isVectorOpSupported(t1, exp.op, t2))

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6518,7 +6518,7 @@ struct Scope final
 
 extern FuncDeclaration* search_toString(StructDeclaration* sd);
 
-extern void semanticTypeInfo(Scope* sc, Type* t);
+extern void semanticTypeInfo(Scope* sc, Type* t, const Loc &loc);
 
 class StructDeclaration : public AggregateDeclaration
 {

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -724,7 +724,7 @@ public:
             ne.arguments = arrayExpressionDoInline(e.arguments);
             result = ne;
 
-            semanticTypeInfo(null, e.type);
+            semanticTypeInfo(null, e.type, e.loc);
         }
 
         override void visit(UnaExp e)
@@ -765,7 +765,7 @@ public:
             if (auto ale = e.e1.isArrayLengthExp())
             {
                 Type tn = ale.e1.type.toBasetype().nextOf();
-                semanticTypeInfo(null, tn);
+                semanticTypeInfo(null, tn, e.loc);
             }
         }
 
@@ -780,11 +780,11 @@ public:
                 while (t.toBasetype().nextOf())
                     t = t.nextOf().toBasetype();
                 if (t.ty == Tstruct)
-                    semanticTypeInfo(null, t);
+                    semanticTypeInfo(null, t, e.loc);
             }
             else if (t1.ty == Taarray)
             {
-                semanticTypeInfo(null, t1);
+                semanticTypeInfo(null, t1, e.loc);
             }
         }
 
@@ -863,7 +863,7 @@ public:
             ce.elements = arrayExpressionDoInline(e.elements);
             result = ce;
 
-            semanticTypeInfo(null, e.type);
+            semanticTypeInfo(null, e.type, e.loc);
         }
 
         override void visit(AssocArrayLiteralExp e)
@@ -873,7 +873,7 @@ public:
             ce.values = arrayExpressionDoInline(e.values);
             result = ce;
 
-            semanticTypeInfo(null, e.type);
+            semanticTypeInfo(null, e.type, e.loc);
         }
 
         override void visit(StructLiteralExp e)

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -39,7 +39,7 @@ typedef union tree_node type;
 typedef struct TYPE type;
 #endif
 
-void semanticTypeInfo(Scope *sc, Type *t);
+void semanticTypeInfo(Scope *sc, Type *t, const Loc &loc);
 
 Type *typeSemantic(Type *t, const Loc &loc, Scope *sc);
 Type *merge(Type *type);


### PR DESCRIPTION
I'm currently working to port some libraries to BetterC, and I get a lot of `TypeInfo` Errors without a clue where it could come from.

E.g.
```d
void main() {
        struct Field {
                int n;
        }
        string[Field] table;

        assert(table[Field(5)] == null);
}
```
returns: 
```
test4.d(2): Error: `TypeInfo` cannot be used with -betterC
```

Which is the location of the `struct Field` declaration.

This pull request will give me the file/line of the expression that is causing the issue, which in this case is the assertion.