### PR TITLE
Improve inferred `pure` `@nogc` `notrhow` errors

### DIFF
--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -76,10 +76,15 @@ extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, bool mustN
             {
                 if (mustNotThrow)
                 {
-                    e.error("%s `%s` is not `nothrow`",
-                        f.kind(), f.toPrettyChars());
+                    e.error("%s `%s` is not `nothrow`", f.kind(), f.toPrettyChars());
+                    if (!f.isDtorDeclaration())
+                        errorSupplementalInferredAttr(f, 10, false, STC.nothrow_);
 
                     e.checkOverridenDtor(null, f, dd => dd.type.toTypeFunction().isnothrow, "not nothrow");
+                }
+                else if (func)
+                {
+                    func.setThrowCall(e.loc, f);
                 }
                 result |= CT.exception;
             }
@@ -205,7 +210,7 @@ extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, bool mustN
 
         override void visit(ThrowExp te)
         {
-            const res = checkThrow(te.loc, te.e1, mustNotThrow);
+            const res = checkThrow(te.loc, te.e1, mustNotThrow, func);
             assert((res & ~(CT.exception | CT.error)) == 0);
             result |= res;
         }

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -623,6 +623,9 @@ public:
     FuncDeclarations *inlinedNestedCallees;
 
     AttributeViolation* safetyViolation;
+    AttributeViolation* nogcViolation;
+    AttributeViolation* pureViolation;
+    AttributeViolation* nothrowViolation;
 
     // Formerly FUNCFLAGS
     uint32_t flags;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5139,13 +5139,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             else if (sc.func && sc.intypeof != 1 && !(sc.flags & (SCOPE.ctfe | SCOPE.debug_)))
             {
                 bool err = false;
-                if (!tf.purity && sc.func.setImpure())
+                if (!tf.purity && sc.func.setImpure(exp.loc, "`pure` %s `%s` cannot call impure `%s`", exp.e1))
                 {
                     exp.error("`pure` %s `%s` cannot call impure %s `%s`",
                         sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toChars());
                     err = true;
                 }
-                if (!tf.isnogc && sc.func.setGC())
+                if (!tf.isnogc && sc.func.setGC(exp.loc, "`@nogc` %s `%s` cannot call non-@nogc `%s`", exp.e1))
                 {
                     exp.error("`@nogc` %s `%s` cannot call non-@nogc %s `%s`",
                         sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toChars());

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2499,6 +2499,9 @@ public:
     Array<FuncDeclaration* > siblingCallers;
     Array<FuncDeclaration* >* inlinedNestedCallees;
     AttributeViolation* safetyViolation;
+    AttributeViolation* nogcViolation;
+    AttributeViolation* pureViolation;
+    AttributeViolation* nothrowViolation;
     bool purityInprocess() const;
     bool purityInprocess(bool v);
     bool safetyInprocess() const;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -356,6 +356,9 @@ extern (C++) class FuncDeclaration : Declaration
     /// In case of failed `@safe` inference, store the error that made the function `@system` for
     /// better diagnostics
     AttributeViolation* safetyViolation;
+    AttributeViolation* nogcViolation;
+    AttributeViolation* pureViolation;
+    AttributeViolation* nothrowViolation;
 
     /// See the `FUNCFLAG` struct
     import dmd.common.bitfields;
@@ -1441,17 +1444,27 @@ extern (C++) class FuncDeclaration : Declaration
     }
 
     /**************************************
-     * The function is doing something impure,
-     * so mark it as impure.
-     * If there's a purity error, return true.
+     * The function is doing something impure, so mark it as impure.
+     *
+     * Params:
+     *     loc = location of impure action
+     *     fmt = format string for error message. Must include "%s `%s`" for the function kind and name.
+     *     arg0 = (optional) argument to format string
+     *
+     * Returns: `true` if there's a purity error
      */
-    extern (D) final bool setImpure()
+    extern (D) final bool setImpure(Loc loc = Loc.init, const(char)* fmt = null, RootObject arg0 = null)
     {
         if (purityInprocess)
         {
             purityInprocess = false;
+            if (fmt)
+                pureViolation = new AttributeViolation(loc, fmt, this, arg0); // impure action
+            else if (arg0)
+                pureViolation = new AttributeViolation(loc, fmt, arg0); // call to impure function
+
             if (fes)
-                fes.func.setImpure();
+                fes.func.setImpure(loc, fmt, arg0);
         }
         else if (isPure())
             return true;
@@ -1540,7 +1553,7 @@ extern (C++) class FuncDeclaration : Declaration
     {
         //printf("isNogc() %s, inprocess: %d\n", toChars(), !!(flags & FUNCFLAG.nogcInprocess));
         if (nogcInprocess)
-            setGC();
+            setGC(loc, null);
         return type.toTypeFunction().isnogc;
     }
 
@@ -1552,10 +1565,16 @@ extern (C++) class FuncDeclaration : Declaration
     /**************************************
      * The function is doing something that may allocate with the GC,
      * so mark it as not nogc (not no-how).
+     *
+     * Params:
+     *     loc = location of impure action
+     *     fmt = format string for error message. Must include "%s `%s`" for the function kind and name.
+     *     arg0 = (optional) argument to format string
+     *
      * Returns:
      *      true if function is marked as @nogc, meaning a user error occurred
      */
-    extern (D) final bool setGC()
+    extern (D) final bool setGC(Loc loc, const(char)* fmt, RootObject arg0 = null)
     {
         //printf("setGC() %s\n", toChars());
         if (nogcInprocess && semanticRun < PASS.semantic3 && _scope)
@@ -1567,13 +1586,30 @@ extern (C++) class FuncDeclaration : Declaration
         if (nogcInprocess)
         {
             nogcInprocess = false;
+            if (fmt)
+                nogcViolation = new AttributeViolation(loc, fmt, this, arg0); // action that requires GC
+            else if (arg0)
+                nogcViolation = new AttributeViolation(loc, fmt, arg0); // call to non-@nogc function
+
             type.toTypeFunction().isnogc = false;
             if (fes)
-                fes.func.setGC();
+                fes.func.setGC(Loc.init, null, null);
         }
         else if (isNogc())
             return true;
         return false;
+    }
+
+    /**************************************
+     * The function calls non-`@nogc` function f, mark it as not nogc.
+     * Params:
+     *     f = function being called
+     * Returns:
+     *      true if function is marked as @nogc, meaning a user error occurred
+     */
+    extern (D) final bool setGCCall(FuncDeclaration f)
+    {
+        return setGC(loc, null, f);
     }
 
     extern (D) final void printGCUsage(const ref Loc loc, const(char)* warn)
@@ -2119,7 +2155,7 @@ extern (C++) class FuncDeclaration : Declaration
         if (!needsClosure())
             return false;
 
-        if (setGC())
+        if (setGC(loc, "%s `%s` is `@nogc` yet allocates closure for `%s()` with the GC", this))
         {
             error("is `@nogc` yet allocates closure for `%s()` with the GC", toChars());
             if (global.gag)     // need not report supplemental errors
@@ -4531,18 +4567,51 @@ struct AttributeViolation
 ///   fd = function to check
 ///   maxDepth = up to how many functions deep to report errors
 ///   deprecation = print deprecations instead of errors
-void errorSupplementalInferredSafety(FuncDeclaration fd, int maxDepth, bool deprecation)
+///   stc = storage class of attribute to check
+void errorSupplementalInferredAttr(FuncDeclaration fd, int maxDepth, bool deprecation, STC stc)
 {
     auto errorFunc = deprecation ? &deprecationSupplemental : &errorSupplemental;
-    if (auto s = fd.safetyViolation)
+
+    AttributeViolation* s;
+    const(char)* attr;
+    if (stc & STC.safe)
+    {
+        s = fd.safetyViolation;
+        attr = "@safe";
+    }
+    else if (stc & STC.pure_)
+    {
+        s = fd.pureViolation;
+        attr = "pure";
+    }
+    else if (stc & STC.nothrow_)
+    {
+        s = fd.nothrowViolation;
+        attr = "nothrow";
+    }
+    else if (stc & STC.nogc)
+    {
+        s = fd.nogcViolation;
+        attr = "@nogc";
+    }
+
+    if (s)
     {
         if (s.fmtStr)
         {
             errorFunc(s.loc, deprecation ?
-                "which would be `@system` because of:" :
-                "which was inferred `@system` because of:");
-            errorFunc(s.loc, s.fmtStr,
-                s.arg0 ? s.arg0.toChars() : "", s.arg1 ? s.arg1.toChars() : "", s.arg2 ? s.arg2.toChars() : "");
+                "which wouldn't be `%s` because of:" :
+                "which wasn't inferred `%s` because of:", attr);
+            if (stc == STC.nogc || stc == STC.pure_)
+            {
+                auto f = (cast(Dsymbol) s.arg0).isFuncDeclaration();
+                errorFunc(s.loc, s.fmtStr, f.kind(), f.toPrettyChars(), s.arg1 ? s.arg1.toChars() : "");
+            }
+            else
+            {
+                errorFunc(s.loc, s.fmtStr,
+                    s.arg0 ? s.arg0.toChars() : "", s.arg1 ? s.arg1.toChars() : "", s.arg2 ? s.arg2.toChars() : "");
+            }
         }
         else if (s.arg0.dyncast() == DYNCAST.dsymbol)
         {
@@ -4551,7 +4620,7 @@ void errorSupplementalInferredSafety(FuncDeclaration fd, int maxDepth, bool depr
                 if (maxDepth > 0)
                 {
                     errorFunc(s.loc, "which calls `%s`", fd2.toPrettyChars());
-                    errorSupplementalInferredSafety(fd2, maxDepth - 1, deprecation);
+                    errorSupplementalInferredAttr(fd2, maxDepth - 1, deprecation, stc);
                 }
             }
         }

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1612,6 +1612,33 @@ extern (C++) class FuncDeclaration : Declaration
         return setGC(loc, null, f);
     }
 
+    /**************************************
+     * The function is doing something that may throw an exception, register that in case nothrow is being inferred
+     *
+     * Params:
+     *     loc = location of action
+     *     fmt = format string for error message
+     *     arg0 = (optional) argument to format string
+     */
+    extern (D) final void setThrow(Loc loc, const(char)* fmt, RootObject arg0 = null)
+    {
+        if (nothrowInprocess && !nothrowViolation)
+        {
+            nothrowViolation = new AttributeViolation(loc, fmt, arg0); // action that requires GC
+        }
+    }
+
+    /**************************************
+     * The function calls non-`nothrow` function f, register that in case nothrow is being inferred
+     * Params:
+     *     loc = location of call
+     *     f = function being called
+     */
+    extern (D) final void setThrowCall(Loc loc, FuncDeclaration f)
+    {
+        return setThrow(loc, null, f);
+    }
+
     extern (D) final void printGCUsage(const ref Loc loc, const(char)* warn)
     {
         if (!global.params.vgc)

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -7252,7 +7252,7 @@ private extern(D) bool isCopyConstructorCallable (StructDeclaration argStruct,
                 s ~= "pure ";
             if (!f.isSafe() && !f.isTrusted() && sc.setUnsafe())
                 s ~= "@safe ";
-            if (!f.isNogc && sc.func.setGC())
+            if (!f.isNogc && sc.func.setGC(arg.loc, null))
                 s ~= "nogc ";
             if (s)
             {

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -83,7 +83,7 @@ public:
             err = true;
             return true;
         }
-        if (f.setGC())
+        if (f.setGC(e.loc, format))
         {
             e.error(format, f.kind(), f.toPrettyChars());
             err = true;
@@ -135,7 +135,7 @@ public:
 
     override void visit(NewExp e)
     {
-        if (e.member && !e.member.isNogc() && f.setGC())
+        if (e.member && !e.member.isNogc() && f.setGC(e.loc, null))
         {
             // @nogc-ness is already checked in NewExp::semantic
             return;
@@ -195,7 +195,7 @@ public:
             err = true;
             return;
         }
-        if (f.setGC())
+        if (f.setGC(e.loc, null))
         {
             err = true;
             return;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3912,9 +3912,9 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
         }
 
         assert(sc.func);
-        if (!(cas.stc & STC.pure_) && sc.func.setImpure())
+        if (!(cas.stc & STC.pure_) && sc.func.setImpure(cas.loc, "`asm` statement is assumed to be impure - mark it with `pure` if it is not"))
             cas.error("`asm` statement is assumed to be impure - mark it with `pure` if it is not");
-        if (!(cas.stc & STC.nogc) && sc.func.setGC())
+        if (!(cas.stc & STC.nogc) && sc.func.setGC(cas.loc, "`asm` statement in %s `%s` is assumed to use the GC - mark it with `@nogc` if it does not"))
             cas.error("`asm` statement is assumed to use the GC - mark it with `@nogc` if it does not");
         if (!(cas.stc & (STC.trusted | STC.safe)))
         {

--- a/compiler/test/fail_compilation/attributediagnostic.d
+++ b/compiler/test/fail_compilation/attributediagnostic.d
@@ -4,15 +4,15 @@ TEST_OUTPUT:
 fail_compilation/attributediagnostic.d(24): Error: `@safe` function `attributediagnostic.layer2` cannot call `@system` function `attributediagnostic.layer1`
 fail_compilation/attributediagnostic.d(26):        which calls `attributediagnostic.layer0`
 fail_compilation/attributediagnostic.d(28):        which calls `attributediagnostic.system`
-fail_compilation/attributediagnostic.d(30):        which was inferred `@system` because of:
+fail_compilation/attributediagnostic.d(30):        which wasn't inferred `@safe` because of:
 fail_compilation/attributediagnostic.d(30):        `asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not
 fail_compilation/attributediagnostic.d(25):        `attributediagnostic.layer1` is declared here
 fail_compilation/attributediagnostic.d(46): Error: `@safe` function `D main` cannot call `@system` function `attributediagnostic.system1`
-fail_compilation/attributediagnostic.d(35):        which was inferred `@system` because of:
+fail_compilation/attributediagnostic.d(35):        which wasn't inferred `@safe` because of:
 fail_compilation/attributediagnostic.d(35):        cast from `uint` to `int*` not allowed in safe code
 fail_compilation/attributediagnostic.d(33):        `attributediagnostic.system1` is declared here
 fail_compilation/attributediagnostic.d(47): Error: `@safe` function `D main` cannot call `@system` function `attributediagnostic.system2`
-fail_compilation/attributediagnostic.d(41):        which was inferred `@system` because of:
+fail_compilation/attributediagnostic.d(41):        which wasn't inferred `@safe` because of:
 fail_compilation/attributediagnostic.d(41):        `@safe` function `system2` cannot call `@system` `fsys`
 fail_compilation/attributediagnostic.d(39):        `attributediagnostic.system2` is declared here
 ---

--- a/compiler/test/fail_compilation/attributediagnostic_nogc.d
+++ b/compiler/test/fail_compilation/attributediagnostic_nogc.d
@@ -1,0 +1,45 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/attributediagnostic_nogc.d(21): Error: `@nogc` function `attributediagnostic_nogc.layer2` cannot call non-@nogc function `attributediagnostic_nogc.layer1`
+fail_compilation/attributediagnostic_nogc.d(22):        which calls `attributediagnostic_nogc.layer0`
+fail_compilation/attributediagnostic_nogc.d(23):        which calls `attributediagnostic_nogc.gc`
+fail_compilation/attributediagnostic_nogc.d(27):        which wasn't inferred `@nogc` because of:
+fail_compilation/attributediagnostic_nogc.d(27):        `asm` statement in function `attributediagnostic_nogc.gc` is assumed to use the GC - mark it with `@nogc` if it does not
+fail_compilation/attributediagnostic_nogc.d(43): Error: `@nogc` function `D main` cannot call non-@nogc function `attributediagnostic_nogc.gc1`
+fail_compilation/attributediagnostic_nogc.d(32):        which wasn't inferred `@nogc` because of:
+fail_compilation/attributediagnostic_nogc.d(32):        cannot use `new` in `@nogc` function `attributediagnostic_nogc.gc1`
+fail_compilation/attributediagnostic_nogc.d(44): Error: `@nogc` function `D main` cannot call non-@nogc function `attributediagnostic_nogc.gc2`
+fail_compilation/attributediagnostic_nogc.d(38):        which wasn't inferred `@nogc` because of:
+fail_compilation/attributediagnostic_nogc.d(38):        `@nogc` function `attributediagnostic_nogc.gc2` cannot call non-@nogc `fgc`
+---
+*/
+
+// Issue 17374 - Improve inferred attribute error message
+// https://issues.dlang.org/show_bug.cgi?id=17374
+
+auto layer2() @nogc { layer1(); }
+auto layer1() { layer0(); }
+auto layer0() { gc(); }
+
+auto gc()
+{
+    asm {}
+}
+
+auto gc1()
+{
+    int* x = new int;
+}
+
+auto fgc = function void() {new int[10];};
+auto gc2()
+{
+    fgc();
+}
+
+void main() @nogc
+{
+    gc1();
+    gc2();
+}

--- a/compiler/test/fail_compilation/attributediagnostic_nothrow.d
+++ b/compiler/test/fail_compilation/attributediagnostic_nothrow.d
@@ -1,0 +1,45 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/attributediagnostic_nothrow.d(21): Error: function `attributediagnostic_nothrow.layer1` is not `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(22):        which calls `attributediagnostic_nothrow.layer0`
+fail_compilation/attributediagnostic_nothrow.d(23):        which calls `attributediagnostic_nothrow.gc`
+fail_compilation/attributediagnostic_nothrow.d(27):        which wasn't inferred `nothrow` because of:
+fail_compilation/attributediagnostic_nothrow.d(27):        `asm` statement is assumed to throw - mark it with `nothrow` if it does not
+fail_compilation/attributediagnostic_nothrow.d(21): Error: function `attributediagnostic_nothrow.layer2` may throw but is marked as `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(43): Error: function `attributediagnostic_nothrow.gc1` is not `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(32):        which wasn't inferred `nothrow` because of:
+fail_compilation/attributediagnostic_nothrow.d(32):        `object.Exception` is thrown but not caught
+fail_compilation/attributediagnostic_nothrow.d(44): Error: function `attributediagnostic_nothrow.gc2` is not `nothrow`
+fail_compilation/attributediagnostic_nothrow.d(41): Error: function `D main` may throw but is marked as `nothrow`
+---
+*/
+
+// Issue 17374 - Improve inferred attribute error message
+// https://issues.dlang.org/show_bug.cgi?id=17374
+
+auto layer2() nothrow { layer1(); }
+auto layer1() { layer0(); }
+auto layer0() { gc(); }
+
+auto gc()
+{
+    asm {}
+}
+
+auto gc1()
+{
+    throw new Exception("msg");
+}
+
+auto fgc = function void() {throw new Exception("msg");};
+auto gc2()
+{
+    fgc();
+}
+
+void main() nothrow
+{
+    gc1();
+    gc2();
+}

--- a/compiler/test/fail_compilation/attributediagnostic_pure.d
+++ b/compiler/test/fail_compilation/attributediagnostic_pure.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/attributediagnostic_pure.d(20): Error: `pure` function `D main` cannot call impure function `attributediagnostic_pure.gc`
+fail_compilation/attributediagnostic_pure.d(15):        which wasn't inferred `pure` because of:
+fail_compilation/attributediagnostic_pure.d(15):        `asm` statement is assumed to be impure - mark it with `pure` if it is not
+---
+*/
+
+// Issue 17374 - Improve inferred attribute error message
+// https://issues.dlang.org/show_bug.cgi?id=17374
+
+auto gc()
+{
+    asm {}
+}
+
+void main() pure
+{
+    gc();
+}

--- a/compiler/test/fail_compilation/diag10319.d
+++ b/compiler/test/fail_compilation/diag10319.d
@@ -1,19 +1,21 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10319.d(31): Error: `pure` function `D main` cannot call impure function `diag10319.foo`
-fail_compilation/diag10319.d(31): Error: `@safe` function `D main` cannot call `@system` function `diag10319.foo`
-fail_compilation/diag10319.d(20):        `diag10319.foo` is declared here
-fail_compilation/diag10319.d(32): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int.bar`
-fail_compilation/diag10319.d(24):        which wasn't inferred `pure` because of:
-fail_compilation/diag10319.d(24):        `pure` function `diag10319.bar!int.bar` cannot access mutable static data `g`
-fail_compilation/diag10319.d(32): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar`
-fail_compilation/diag10319.d(25):        which wasn't inferred `@safe` because of:
-fail_compilation/diag10319.d(25):        cannot take address of local `x` in `@safe` function `bar`
-fail_compilation/diag10319.d(22):        `diag10319.bar!int.bar` is declared here
-fail_compilation/diag10319.d(31): Error: function `diag10319.foo` is not `nothrow`
-fail_compilation/diag10319.d(32): Error: function `diag10319.bar!int.bar` is not `nothrow`
-fail_compilation/diag10319.d(29): Error: function `D main` may throw but is marked as `nothrow`
+fail_compilation/diag10319.d(33): Error: `pure` function `D main` cannot call impure function `diag10319.foo`
+fail_compilation/diag10319.d(33): Error: `@safe` function `D main` cannot call `@system` function `diag10319.foo`
+fail_compilation/diag10319.d(22):        `diag10319.foo` is declared here
+fail_compilation/diag10319.d(34): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int.bar`
+fail_compilation/diag10319.d(26):        which wasn't inferred `pure` because of:
+fail_compilation/diag10319.d(26):        `pure` function `diag10319.bar!int.bar` cannot access mutable static data `g`
+fail_compilation/diag10319.d(34): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar`
+fail_compilation/diag10319.d(27):        which wasn't inferred `@safe` because of:
+fail_compilation/diag10319.d(27):        cannot take address of local `x` in `@safe` function `bar`
+fail_compilation/diag10319.d(24):        `diag10319.bar!int.bar` is declared here
+fail_compilation/diag10319.d(33): Error: function `diag10319.foo` is not `nothrow`
+fail_compilation/diag10319.d(34): Error: function `diag10319.bar!int.bar` is not `nothrow`
+fail_compilation/diag10319.d(28):        which wasn't inferred `nothrow` because of:
+fail_compilation/diag10319.d(28):        `object.Exception` is thrown but not caught
+fail_compilation/diag10319.d(31): Error: function `D main` may throw but is marked as `nothrow`
 ---
 */
 

--- a/compiler/test/fail_compilation/diag10319.d
+++ b/compiler/test/fail_compilation/diag10319.d
@@ -1,17 +1,19 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10319.d(29): Error: `pure` function `D main` cannot call impure function `diag10319.foo`
-fail_compilation/diag10319.d(29): Error: `@safe` function `D main` cannot call `@system` function `diag10319.foo`
-fail_compilation/diag10319.d(18):        `diag10319.foo` is declared here
-fail_compilation/diag10319.d(30): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int.bar`
-fail_compilation/diag10319.d(30): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar`
-fail_compilation/diag10319.d(23):        which was inferred `@system` because of:
-fail_compilation/diag10319.d(23):        cannot take address of local `x` in `@safe` function `bar`
-fail_compilation/diag10319.d(20):        `diag10319.bar!int.bar` is declared here
-fail_compilation/diag10319.d(29): Error: function `diag10319.foo` is not `nothrow`
-fail_compilation/diag10319.d(30): Error: function `diag10319.bar!int.bar` is not `nothrow`
-fail_compilation/diag10319.d(27): Error: function `D main` may throw but is marked as `nothrow`
+fail_compilation/diag10319.d(31): Error: `pure` function `D main` cannot call impure function `diag10319.foo`
+fail_compilation/diag10319.d(31): Error: `@safe` function `D main` cannot call `@system` function `diag10319.foo`
+fail_compilation/diag10319.d(20):        `diag10319.foo` is declared here
+fail_compilation/diag10319.d(32): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int.bar`
+fail_compilation/diag10319.d(24):        which wasn't inferred `pure` because of:
+fail_compilation/diag10319.d(24):        `pure` function `diag10319.bar!int.bar` cannot access mutable static data `g`
+fail_compilation/diag10319.d(32): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar`
+fail_compilation/diag10319.d(25):        which wasn't inferred `@safe` because of:
+fail_compilation/diag10319.d(25):        cannot take address of local `x` in `@safe` function `bar`
+fail_compilation/diag10319.d(22):        `diag10319.bar!int.bar` is declared here
+fail_compilation/diag10319.d(31): Error: function `diag10319.foo` is not `nothrow`
+fail_compilation/diag10319.d(32): Error: function `diag10319.bar!int.bar` is not `nothrow`
+fail_compilation/diag10319.d(29): Error: function `D main` may throw but is marked as `nothrow`
 ---
 */
 

--- a/compiler/test/fail_compilation/diag9620.d
+++ b/compiler/test/fail_compilation/diag9620.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9620.d(18): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo1`
-fail_compilation/diag9620.d(19): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo2!().foo2`
+fail_compilation/diag9620.d(20): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo1`
+fail_compilation/diag9620.d(21): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo2!().foo2`
+fail_compilation/diag9620.d(14):        which wasn't inferred `pure` because of:
+fail_compilation/diag9620.d(14):        `pure` function `diag9620.foo2!().foo2` cannot access mutable static data `x`
 ---
 */
 

--- a/compiler/test/fail_compilation/dip1000_deprecation.d
+++ b/compiler/test/fail_compilation/dip1000_deprecation.d
@@ -3,11 +3,11 @@ REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
 fail_compilation/dip1000_deprecation.d(20): Deprecation: `@safe` function `main` calling `inferred`
-fail_compilation/dip1000_deprecation.d(28):        which would be `@system` because of:
+fail_compilation/dip1000_deprecation.d(28):        which wouldn't be `@safe` because of:
 fail_compilation/dip1000_deprecation.d(28):        scope variable `x0` may not be returned
 fail_compilation/dip1000_deprecation.d(22): Deprecation: `@safe` function `main` calling `inferredC`
 fail_compilation/dip1000_deprecation.d(39):        which calls `dip1000_deprecation.inferred`
-fail_compilation/dip1000_deprecation.d(28):        which would be `@system` because of:
+fail_compilation/dip1000_deprecation.d(28):        which wouldn't be `@safe` because of:
 fail_compilation/dip1000_deprecation.d(28):        scope variable `x0` may not be returned
 fail_compilation/dip1000_deprecation.d(54): Deprecation: escaping reference to stack allocated value returned by `S(null)`
 fail_compilation/dip1000_deprecation.d(55): Deprecation: escaping reference to stack allocated value returned by `createS()`

--- a/compiler/test/fail_compilation/dtor_attributes.d
+++ b/compiler/test/fail_compilation/dtor_attributes.d
@@ -8,8 +8,6 @@ fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is impu
 fail_compilation/dtor_attributes.d(111):         - HasDtor member
 fail_compilation/dtor_attributes.d(103):           impure `HasDtor.~this` is declared here
 fail_compilation/dtor_attributes.d(118): Error: `@safe` function `dtor_attributes.test1` cannot call `@system` destructor `dtor_attributes.Strict.~this`
-fail_compilation/dtor_attributes.d(113):        which calls `dtor_attributes.Strict.~this`
-fail_compilation/dtor_attributes.d(103):        which calls `dtor_attributes.HasDtor.~this`
 fail_compilation/dtor_attributes.d(113):        `dtor_attributes.Strict.~this` is declared here
 fail_compilation/dtor_attributes.d(113):        generated `Strict.~this` is @system because of the following field's destructors:
 fail_compilation/dtor_attributes.d(111):         - HasDtor member

--- a/compiler/test/fail_compilation/dtorfields_attributes.d
+++ b/compiler/test/fail_compilation/dtorfields_attributes.d
@@ -9,7 +9,6 @@ fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` i
 fail_compilation/dtorfields_attributes.d(115):         - HasDtor member
 fail_compilation/dtorfields_attributes.d(103):           impure `HasDtor.~this` is declared here
 fail_compilation/dtorfields_attributes.d(117): Error: `@safe` constructor `dtorfields_attributes.Strict.this` cannot call `@system` destructor `dtorfields_attributes.Strict.~this`
-fail_compilation/dtorfields_attributes.d(103):        which calls `dtorfields_attributes.HasDtor.~this`
 fail_compilation/dtorfields_attributes.d(119):        `dtorfields_attributes.Strict.~this` is declared here
 fail_compilation/dtorfields_attributes.d(119):        generated `Strict.~this` is @system because of the following field's destructors:
 fail_compilation/dtorfields_attributes.d(115):         - HasDtor member

--- a/compiler/test/fail_compilation/fail10968.d
+++ b/compiler/test/fail_compilation/fail10968.d
@@ -8,10 +8,14 @@ fail_compilation/fail10968.d(44): Error: `pure` function `fail10968.bar` cannot 
 fail_compilation/fail10968.d(44): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(31):        `fail10968.SA.__postblit` is declared here
 fail_compilation/fail10968.d(44): Error: `pure` function `fail10968.bar` cannot call impure function `core.internal.array.arrayassign._d_arraysetassign!(SA[], SA)._d_arraysetassign`
+$p:druntime/import/core/internal/array/arrayassign.d$($n$):        which calls `core.lifetime.copyEmplace!(SA, SA).copyEmplace`
+$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(45): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(45): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(31):        `fail10968.SA.__postblit` is declared here
 fail_compilation/fail10968.d(45): Error: `pure` function `fail10968.bar` cannot call impure function `core.internal.array.arrayassign._d_arrayassign_l!(SA[], SA)._d_arrayassign_l`
+$p:druntime/import/core/internal/array/arrayassign.d$-mixin-$n$($n$):        which calls `core.lifetime.copyEmplace!(SA, SA).copyEmplace`
+$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(48): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(48): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(31):        `fail10968.SA.__postblit` is declared here
@@ -19,13 +23,18 @@ fail_compilation/fail10968.d(49): Error: `pure` function `fail10968.bar` cannot 
 fail_compilation/fail10968.d(49): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(31):        `fail10968.SA.__postblit` is declared here
 fail_compilation/fail10968.d(49): Error: `pure` function `fail10968.bar` cannot call impure function `core.internal.array.construction._d_arraysetctor!(SA[], SA)._d_arraysetctor`
+$p:druntime/import/core/internal/array/construction.d$($n$):        which calls `core.lifetime.copyEmplace!(SA, SA).copyEmplace`
+$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(50): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(50): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
 fail_compilation/fail10968.d(31):        `fail10968.SA.__postblit` is declared here
 fail_compilation/fail10968.d(50): Error: `pure` function `fail10968.bar` cannot call impure function `core.internal.array.construction._d_arrayctor!(SA[], SA)._d_arrayctor`
+$p:druntime/import/core/internal/array/construction.d$($n$):        which calls `core.lifetime.copyEmplace!(SA, SA).copyEmplace`
+$p:druntime/import/core/lifetime.d$($n$):        which calls `fail10968.SA.__postblit`
 ---
 */
 
+#line 29
 struct SA
 {
     this(this)

--- a/compiler/test/fail_compilation/fail11375.d
+++ b/compiler/test/fail_compilation/fail11375.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11375.d(17): Error: constructor `fail11375.D!().D.this` is not `nothrow`
-fail_compilation/fail11375.d(15): Error: function `D main` may throw but is marked as `nothrow`
+fail_compilation/fail11375.d(18): Error: constructor `fail11375.D!().D.this` is not `nothrow`
+       which calls `fail11375.B.this`
+fail_compilation/fail11375.d(16): Error: function `D main` may throw but is marked as `nothrow`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail13120.d
+++ b/compiler/test/fail_compilation/fail13120.d
@@ -17,13 +17,13 @@ void g1(char[] s) pure @nogc
 TEST_OUTPUT:
 ---
 fail_compilation/fail13120.d(35): Error: `pure` function `fail13120.h2` cannot call impure function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(30):        which calls `fail13120.f2`
 fail_compilation/fail13120.d(35): Error: `@safe` function `fail13120.h2` cannot call `@system` function `fail13120.g2!().g2`
 fail_compilation/fail13120.d(27):        `fail13120.g2!().g2` is declared here
 fail_compilation/fail13120.d(35): Error: `@nogc` function `fail13120.h2` cannot call non-@nogc function `fail13120.g2!().g2`
 ---
 */
 void f2() {}
-
 void g2()(char[] s)
 {
     foreach (dchar dc; s)

--- a/compiler/test/fail_compilation/systemvariables_deprecation.d
+++ b/compiler/test/fail_compilation/systemvariables_deprecation.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/systemvariables_deprecation.d(16): Deprecation: `@safe` function `main` calling `middle`
 fail_compilation/systemvariables_deprecation.d(21):        which calls `systemvariables_deprecation.inferred`
-fail_compilation/systemvariables_deprecation.d(27):        which would be `@system` because of:
+fail_compilation/systemvariables_deprecation.d(27):        which wouldn't be `@safe` because of:
 fail_compilation/systemvariables_deprecation.d(27):        cannot access `@system` variable `x0` in @safe code
 ---
 */

--- a/compiler/test/fail_compilation/testInference.d
+++ b/compiler/test/fail_compilation/testInference.d
@@ -138,8 +138,13 @@ immutable(void)* g10063(inout int* p) pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(154): Error: `pure` function `testInference.bar14049` cannot call impure function `testInference.foo14049!int.foo14049`
+fail_compilation/testInference.d(149):        which calls `testInference.foo14049!int.foo14049.__lambda2`
+fail_compilation/testInference.d(148):        which calls `testInference.impure14049`
+fail_compilation/testInference.d(143):        which wasn't inferred `pure` because of:
+fail_compilation/testInference.d(143):        `pure` function `testInference.impure14049` cannot access mutable static data `i`
 ---
 */
+#line 143
 auto impure14049() { static int i = 1; return i; }
 
 void foo14049(T)(T val)
@@ -170,8 +175,10 @@ int* f14160() pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(180): Error: `pure` function `testInference.test12422` cannot call impure function `testInference.test12422.bar12422!().bar12422`
+fail_compilation/testInference.d(179):        which calls `testInference.foo12422`
 ---
 */
+#line 175
 int g12422;
 void foo12422() { ++g12422; }
 void test12422() pure
@@ -184,9 +191,15 @@ void test12422() pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(198): Error: `pure` function `testInference.test13729a` cannot call impure function `testInference.test13729a.foo`
+fail_compilation/testInference.d(196):        which wasn't inferred `pure` because of:
+fail_compilation/testInference.d(196):        `pure` function `testInference.test13729a.foo` cannot access mutable static data `g13729`
 fail_compilation/testInference.d(206): Error: `pure` function `testInference.test13729b` cannot call impure function `testInference.test13729b.foo!().foo`
+fail_compilation/testInference.d(204):        which wasn't inferred `pure` because of:
+fail_compilation/testInference.d(204):        `pure` function `testInference.test13729b.foo!().foo` cannot access mutable static data `g13729`
 ---
 */
+
+#line 190
 int g13729;
 
 void test13729a() pure
@@ -229,8 +242,10 @@ void test17086_call ()
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(238): Error: `pure` function `testInference.test20047_pure_function` cannot call impure function `testInference.test20047_pure_function.bug`
+fail_compilation/testInference.d(237):        which calls `testInference.test20047_impure_function`
 ---
 */
+#line 234
 void test20047_impure_function() {}
 void test20047_pure_function() pure
 {


### PR DESCRIPTION
Expand https://github.com/dlang/dmd/pull/13957 to `@nogc` and `pure` errors

https://issues.dlang.org/show_bug.cgi?id=17374

Inspired by [Blog post on figuring out attribute inference failure](https://forum.dlang.org/post/tsttva$16an$1@digitalmars.com)