### PR TITLE
[stable] druntime: Only define GC-trace templates when compiling with `-profile=gc`

### DIFF
--- a/druntime/src/core/internal/array/appending.d
+++ b/druntime/src/core/internal/array/appending.d
@@ -17,8 +17,6 @@ private enum isCopyingNothrow(T) = __traits(compiles, (ref T rhs) nothrow { T lh
 /// Implementation of `_d_arrayappendcTX` and `_d_arrayappendcTXTrace`
 template _d_arrayappendcTXImpl(Tarr : T[], T)
 {
-    import core.internal.array.utils : _d_HookTraceImpl;
-
     private enum errorMessage = "Cannot append to array if compiling without support for runtime type information!";
 
     /**
@@ -51,11 +49,13 @@ template _d_arrayappendcTXImpl(Tarr : T[], T)
             return px;
         }
         else
-            assert(0, "Cannot append arrays if compiling without support for runtime type information!");
+            assert(0, errorMessage);
     }
 
     version (D_ProfileGC)
     {
+        import core.internal.array.utils : _d_HookTraceImpl;
+
         /**
          * TraceGC wrapper around $(REF _d_arrayappendcTX, rt,array,appending,_d_arrayappendcTXImpl).
          * Bugs:

--- a/druntime/src/core/internal/array/capacity.d
+++ b/druntime/src/core/internal/array/capacity.d
@@ -22,8 +22,6 @@ private extern (C) void[] _d_arraysetlengthiT(const TypeInfo ti, size_t newlengt
 /// Implementation of `_d_arraysetlengthT` and `_d_arraysetlengthTTrace`
 template _d_arraysetlengthTImpl(Tarr : T[], T)
 {
-    import core.internal.array.utils : _d_HookTraceImpl;
-
     private enum errorMessage = "Cannot resize arrays if compiling without support for runtime type information!";
 
     /**
@@ -56,6 +54,8 @@ template _d_arraysetlengthTImpl(Tarr : T[], T)
 
     version (D_ProfileGC)
     {
+        import core.internal.array.utils : _d_HookTraceImpl;
+
         /**
          * TraceGC wrapper around $(REF _d_arraysetlengthT, core,internal,array,core.internal.array.capacity).
          * Bugs:

--- a/druntime/src/core/internal/array/capacity.d
+++ b/druntime/src/core/internal/array/capacity.d
@@ -54,14 +54,17 @@ template _d_arraysetlengthTImpl(Tarr : T[], T)
             assert(0, errorMessage);
     }
 
-    /**
-    * TraceGC wrapper around $(REF _d_arraysetlengthT, core,internal,array,core.internal.array.capacity).
-    * Bugs:
-    *  This function template was ported from a much older runtime hook that bypassed safety,
-    *  purity, and throwabilty checks. To prevent breaking existing code, this function template
-    *  is temporarily declared `@trusted pure nothrow` until the implementation can be brought up to modern D expectations.
-    */
-    alias _d_arraysetlengthTTrace = _d_HookTraceImpl!(Tarr, _d_arraysetlengthT, errorMessage);
+    version (D_ProfileGC)
+    {
+        /**
+         * TraceGC wrapper around $(REF _d_arraysetlengthT, core,internal,array,core.internal.array.capacity).
+         * Bugs:
+         *  This function template was ported from a much older runtime hook that bypassed safety,
+         *  purity, and throwabilty checks. To prevent breaking existing code, this function template
+         *  is temporarily declared `@trusted pure nothrow` until the implementation can be brought up to modern D expectations.
+         */
+        alias _d_arraysetlengthTTrace = _d_HookTraceImpl!(Tarr, _d_arraysetlengthT, errorMessage);
+    }
 }
 
 @safe unittest

--- a/druntime/src/core/internal/array/concatenation.d
+++ b/druntime/src/core/internal/array/concatenation.d
@@ -14,8 +14,6 @@ private extern (C) void[] _d_arraycatnTX(const TypeInfo ti, scope byte[][] arrs)
 /// Implementation of `_d_arraycatnTX` and `_d_arraycatnTXTrace`
 template _d_arraycatnTXImpl(Tarr : ResultArrT[], ResultArrT : T[], T)
 {
-    import core.internal.array.utils : _d_HookTraceImpl;
-
     private enum errorMessage = "Cannot concatenate arrays if compiling without support for runtime type information!";
 
     /**
@@ -45,14 +43,19 @@ template _d_arraycatnTXImpl(Tarr : ResultArrT[], ResultArrT : T[], T)
             assert(0, errorMessage);
     }
 
-    /**
-    * TraceGC wrapper around $(REF _d_arraycatnTX, core,internal,array,concat).
-    * Bugs:
-    *  This function template was ported from a much older runtime hook that bypassed safety,
-    *  purity, and throwabilty checks. To prevent breaking existing code, this function template
-    *  is temporarily declared `@trusted pure nothrow` until the implementation can be brought up to modern D expectations.
-    */
-    alias _d_arraycatnTXTrace = _d_HookTraceImpl!(ResultArrT, _d_arraycatnTX, errorMessage);
+    version (D_ProfileGC)
+    {
+        import core.internal.array.utils : _d_HookTraceImpl;
+
+        /**
+         * TraceGC wrapper around $(REF _d_arraycatnTX, core,internal,array,concat).
+         * Bugs:
+         *  This function template was ported from a much older runtime hook that bypassed safety,
+         *  purity, and throwabilty checks. To prevent breaking existing code, this function template
+         *  is temporarily declared `@trusted pure nothrow` until the implementation can be brought up to modern D expectations.
+         */
+        alias _d_arraycatnTXTrace = _d_HookTraceImpl!(ResultArrT, _d_arraycatnTX, errorMessage);
+    }
 }
 
 @safe unittest

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -2385,21 +2385,24 @@ template _d_delstructImpl(T)
         }
     }
 
-    import core.internal.array.utils : _d_HookTraceImpl;
+    version (D_ProfileGC)
+    {
+        import core.internal.array.utils : _d_HookTraceImpl;
 
-    private enum errorMessage = "Cannot delete struct if compiling without support for runtime type information!";
+        private enum errorMessage = "Cannot delete struct if compiling without support for runtime type information!";
 
-    /**
-     * TraceGC wrapper around $(REF _d_delstruct, core,lifetime,_d_delstructImpl).
-     *
-     * Bugs:
-     *   This function template was ported from a much older runtime hook that
-     *   bypassed safety, purity, and throwabilty checks. To prevent breaking
-     *   existing code, this function template is temporarily declared
-     *   `@trusted` until the implementation can be brought up to modern D
-     *   expectations.
-     */
-    alias _d_delstructTrace = _d_HookTraceImpl!(T, _d_delstruct, errorMessage);
+        /**
+         * TraceGC wrapper around $(REF _d_delstruct, core,lifetime,_d_delstructImpl).
+         *
+         * Bugs:
+         *   This function template was ported from a much older runtime hook that
+         *   bypassed safety, purity, and throwabilty checks. To prevent breaking
+         *   existing code, this function template is temporarily declared
+         *   `@trusted` until the implementation can be brought up to modern D
+         *   expectations.
+         */
+        alias _d_delstructTrace = _d_HookTraceImpl!(T, _d_delstruct, errorMessage);
+    }
 }
 
 @system pure nothrow unittest


### PR DESCRIPTION
Analogous to #14912, and covered by `druntime/test/profile/src/profilegc.d` too.