### PR TITLE
Strip trailing whitespace in `Outbuffer.writenl`

### DIFF
--- a/compiler/src/dmd/common/outbuffer.d
+++ b/compiler/src/dmd/common/outbuffer.d
@@ -338,9 +338,12 @@ struct OutBuffer
         offset += len;
     }
 
-    /// write newline
+    /// strip trailing tabs or spaces, write newline
     extern (C++) void writenl() pure nothrow @safe
     {
+        while (offset > 0 && (data[offset - 1] == ' ' || data[offset - 1] == '\t'))
+            offset--;
+
         version (Windows)
         {
             writeword(0x0A0D); // newline is CR,LF on Microsoft OS's
@@ -918,4 +921,19 @@ unittest
 
     buf.setsize(4);
     assert(buf.length == 4);
+}
+
+unittest
+{
+    OutBuffer buf;
+
+    buf.writenl();
+    buf.writestring("abc \t ");
+    buf.writenl(); // strips trailing whitespace
+    buf.writenl(); // doesn't strip previous newline
+
+    version(Windows)
+        assert(buf[] == "\r\nabc\r\n\r\n");
+    else
+        assert(buf[] == "\nabc\n\n");
 }

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -487,14 +487,14 @@ void test_outbuffer()
 
     buf.reserve(16);
     buf.writestring("hello");
-    buf.writeByte(' ');
+    buf.writeByte('!');
     buf.write(&buf);
     buf.writenl();
     assert(buf.length() == 13);
 
     const char *data = buf.extractChars();
     assert(buf.length() == 0);
-    assert(strcmp(data, "hello hello \n") == 0);
+    assert(strcmp(data, "hello!hello!\n") == 0);
 }
 
 void test_cppmangle()

--- a/compiler/test/compilable/extra-files/header18365.d
+++ b/compiler/test/compilable/extra-files/header18365.d
@@ -1,5 +1,5 @@
 module foo.bar.ba;
-nothrow pure @nogc @safe package(foo) 
+nothrow pure @nogc @safe package(foo)
 {
 	void foo();
 	nothrow pure @nogc @safe package(foo.bar) void foo2();

--- a/compiler/test/compilable/extra-files/imp9057.d
+++ b/compiler/test/compilable/extra-files/imp9057.d
@@ -1,5 +1,5 @@
 struct BugInt
 {
-    uint[] data = ZEROX;  
+    uint[] data = ZEROX;
 }
 enum uint [] ZEROX = [0];

--- a/compiler/test/compilable/extra-files/test23626a.d
+++ b/compiler/test/compilable/extra-files/test23626a.d
@@ -1,5 +1,5 @@
 template fullyQualifiedName(T...)
-{   
+{
     enum fullyQualifiedName = !T[0];
 }
 

--- a/compiler/test/compilable/extra-files/vcg-ast.d.cg
+++ b/compiler/test/compilable/extra-files/vcg-ast.d.cg
@@ -109,7 +109,7 @@ R!int
 }
 mixin _d_cmain!();
 {
-	extern (C) 
+	extern (C)
 	{
 		extern (C) int _d_run_main(int argc, char** argv, void* mainFunc);
 		extern (C) int _Dmain(char[][] args);

--- a/compiler/test/runnable/extra-files/test39.d
+++ b/compiler/test/runnable/extra-files/test39.d
@@ -7,4 +7,4 @@ void main()
 {
         auto t = new Test!(char);
         t.show ("hello");
-} 
+}


### PR DESCRIPTION
Ensure DMD doesn't generate text with trailing whitespace. It's annoying when I edit `compiler/test/compilable/extra-files/vcg-ast.d.cg` because my editor strips whitespace, but the test output requires the trailing whitespaces.