### PR TITLE
[stable] Fix runnable_cxx/test22898.d on macOS-arm64

### DIFF
--- a/compiler/test/runnable_cxx/test22898.d
+++ b/compiler/test/runnable_cxx/test22898.d
@@ -4,14 +4,26 @@ import core.stdc.config;
 
 extern(C++):
 
-version (AArch64) version = UnsignedChar;
-version (ARM)     version = UnsignedChar;
-version (RISCV32) version = UnsignedChar;
-version (RISCV64) version = UnsignedChar;
-version (PPC)     version = UnsignedChar;
-version (PPC64)   version = UnsignedChar;
-version (S390)    version = UnsignedChar;
-version (SystemZ) version = UnsignedChar;
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
+version (Darwin) { /* signed on ARM too */ } else
+{
+    version (AArch64) version = UnsignedChar;
+    version (ARM)     version = UnsignedChar;
+    version (RISCV32) version = UnsignedChar;
+    version (RISCV64) version = UnsignedChar;
+    version (PPC)     version = UnsignedChar;
+    version (PPC64)   version = UnsignedChar;
+    version (S390)    version = UnsignedChar;
+    version (SystemZ) version = UnsignedChar;
+}
 
 version (UnsignedChar)
     enum __c_char : ubyte;


### PR DESCRIPTION
Apple diverges wrt. `char` signedness: https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Handle-data-types-and-data-alignment-properly