### PR TITLE
colorHighlightCode: use ErrorSinkNull instead of gagging

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -819,8 +819,11 @@ private void colorHighlightCode(ref OutBuffer buf)
     }
     ++nested;
 
-    auto gaggedErrorsSave = global.startGagging();
-    scope Lexer lex = new Lexer(null, cast(char*)buf[].ptr, 0, buf.length - 1, 0, 1, global.errorSink, global.vendor, global.versionNumber());
+    __gshared ErrorSinkNull errorSinkNull;
+    if (!errorSinkNull)
+        errorSinkNull = new ErrorSinkNull;
+
+    scope Lexer lex = new Lexer(null, cast(char*)buf[].ptr, 0, buf.length - 1, 0, 1, errorSinkNull, global.vendor, global.versionNumber());
     OutBuffer res;
     const(char)* lastp = cast(char*)buf[].ptr;
     //printf("colorHighlightCode('%.*s')\n", cast(int)(buf.length - 1), buf[].ptr);
@@ -871,7 +874,6 @@ private void colorHighlightCode(ref OutBuffer buf)
     //printf("res = '%.*s'\n", cast(int)buf.length, buf[].ptr);
     buf.setsize(0);
     buf.write(&res);
-    global.endGagging(gaggedErrorsSave);
     --nested;
 }
 


### PR DESCRIPTION
The gagging thing has always been a hack, and the less of it the better.