### PR TITLE
Deprecate 'in ref' to prepare for -preview=in

### DIFF
--- a/changelog/dmd.in-ref.dd
+++ b/changelog/dmd.in-ref.dd
@@ -1,0 +1,8 @@
+`in ref` on parameters has been deprecated in favor of `-preview=in`
+
+Using `in ref` (or `ref in`) on function parameters will now yield a deprecation.
+Users are encouraged to remove the `ref` and compile with `-preview=in`,
+which will infer whether the parameter should be passed by reference or value.
+Users wanting a specific ABI are encouraged to use `scope const ref` instead.
+Note that this also applies to `auto ref in`, which is equivalent to `in` with `-preview=in`,
+but the latter doesn't require the function to be templated.

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1221,8 +1221,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             return orig | added;
         }
 
-        const Redundant = (STC.const_ | STC.scope_ |
-                           (global.params.previewIn ? STC.ref_ : 0));
+        const Redundant = (STC.const_ | STC.scope_ | STC.ref_);
         orig |= added;
 
         if ((orig & STC.in_) && (added & Redundant))
@@ -1234,6 +1233,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 error("attribute `%s` is redundant with previously-applied `in`",
                       (orig & STC.scope_) ? "scope".ptr : "ref".ptr);
             }
+            else if (added & STC.ref_)
+                deprecation("using `in ref` is deprecated, use `-preview=in` and `in` instead");
             else
                 error("attribute `scope` cannot be applied with `in`, use `-preview=in` instead");
             return orig;
@@ -1250,6 +1251,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 error(token.loc, "attribute `in` cannot be added after `%s`: remove `%s`",
                       stc_str, stc_str);
             }
+            else if (orig & STC.ref_)
+                deprecation("using `ref in` is deprecated, use `-preview=in` and `in` instead");
             else
                 error("attribute `in` cannot be added after `scope`: remove `scope` and use `-preview=in`");
             return orig;

--- a/compiler/test/compilable/interpret3.d
+++ b/compiler/test/compilable/interpret3.d
@@ -7208,7 +7208,7 @@ struct S13630(T)
 {
     T[3] arr;
 
-    this(A...)(auto ref in A args)
+    this(A...)(const auto ref A args)
     {
         auto p = arr.ptr;
 
@@ -7238,7 +7238,7 @@ struct Matrix13827(T, uint N)
         T[N] flat;
     }
 
-    this(A...)(auto ref in A args)
+    this(A...)(const auto ref A args)
     {
         uint k;
 

--- a/compiler/test/compilable/warn3882.d
+++ b/compiler/test/compilable/warn3882.d
@@ -64,7 +64,7 @@ void test12909()
 
 const struct Foo13899
 {
-    int opApply(immutable int delegate(in ref int) pure nothrow dg) pure nothrow
+    int opApply(immutable int delegate(const ref int) pure nothrow dg) pure nothrow
     {
         return 1;
     }

--- a/compiler/test/fail_compilation/deprecatedinref.d
+++ b/compiler/test/fail_compilation/deprecatedinref.d
@@ -1,0 +1,10 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/deprecatedinref.d(9): Deprecation: using `in ref` is deprecated, use `-preview=in` and `in` instead
+fail_compilation/deprecatedinref.d(10): Deprecation: using `ref in` is deprecated, use `-preview=in` and `in` instead
+---
+*/
+void foo(in ref int);
+void foor(ref in int);

--- a/compiler/test/fail_compilation/ice11626.d
+++ b/compiler/test/fail_compilation/ice11626.d
@@ -5,4 +5,4 @@ fail_compilation/ice11626.d(8): Error: undefined identifier `Bar`
 ---
 */
 
-void foo(in ref Bar) {}
+void foo(const ref Bar) {}

--- a/compiler/test/runnable/imports/link11069z.d
+++ b/compiler/test/runnable/imports/link11069z.d
@@ -1,7 +1,7 @@
 module imports.link11069z;
 struct Matrix(T, uint _M)
 {
-    int opCmp()(auto ref in Matrix b) const
+    int opCmp()(const auto ref Matrix b) const
     {
         return 0;
     }

--- a/compiler/test/runnable/test42.d
+++ b/compiler/test/runnable/test42.d
@@ -2105,7 +2105,7 @@ void test12725()
 
 struct Matrix12728(T, uint m, uint n = m, ubyte f = 0)
 {
-    void foo(uint r)(auto ref in Matrix12728!(T, n, r) b)
+    void foo(uint r)(const auto ref Matrix12728!(T, n, r) b)
     {
     }
 }

--- a/compiler/test/runnable/xtest46.d
+++ b/compiler/test/runnable/xtest46.d
@@ -6170,14 +6170,6 @@ static assert(!__traits(compiles, foo8220(typeof(0)))); // fail
 
 /***************************************************/
 
-void func8105(in ref int x) { }
-
-void test8105()
-{
-}
-
-/***************************************************/
-
 template ParameterTypeTuple159(alias foo)
 {
     static if (is(typeof(foo) P == __parameters))
@@ -8300,7 +8292,6 @@ int main()
     test12503();
     test8004();
     test8064();
-    test8105();
     test159();
     test12824();
     test8283();


### PR DESCRIPTION
This should nudge people into using '-preview=in' and clear up the remaining projects which are incompatible with it.