### PR TITLE
Rename CompileStatement to MixinStatement

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -1928,7 +1928,7 @@ struct ASTBase
 
         final extern (D) this(const ref Loc loc, Expressions* exps)
         {
-            super(loc, STMT.Compile);
+            super(loc, STMT.Mixin);
             this.exps = exps;
         }
 

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -1922,7 +1922,7 @@ struct ASTBase
         }
     }
 
-    extern (C++) final class CompileStatement : Statement
+    extern (C++) final class MixinStatement : Statement
     {
         Expressions* exps;
 

--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -339,7 +339,7 @@ enum STMT : ubyte
     Error,
     Peel,
     Exp, DtorExp,
-    Compile,
+    Mixin,
     Compound, CompoundDeclaration, CompoundAsm,
     UnrolledLoop,
     Scope,

--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -115,7 +115,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             }
         }
 
-        override void visit(CompileStatement s)
+        override void visit(MixinStatement s)
         {
             assert(global.errors);
             result = BE.fallthru;

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -840,7 +840,7 @@ FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
         "    else " ~
         "        h = h * 33 + typeid(T).getHash(cast(const void*)&p.tupleof[i]);" ~
         "return h;";
-    fop.fbody = new CompileStatement(loc, new StringExp(loc, code));
+    fop.fbody = new MixinStatement(loc, new StringExp(loc, code));
     Scope* sc2 = sc.push();
     sc2.stc = 0;
     sc2.linkage = LINK.d;

--- a/compiler/src/dmd/foreachvar.d
+++ b/compiler/src/dmd/foreachvar.d
@@ -299,7 +299,7 @@ void foreachExpAndVar(Statement s,
             case STMT.Conditional:
             case STMT.While:
             case STMT.Forwarding:
-            case STMT.Compile:
+            case STMT.Mixin:
             case STMT.Peel:
             case STMT.Synchronized:
                 assert(0);              // should have been rewritten

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4203,14 +4203,6 @@ public:
     Catch* syntaxCopy();
 };
 
-class MixinStatement final : public Statement
-{
-public:
-    Array<Expression* >* exps;
-    MixinStatement* syntaxCopy() override;
-    void accept(Visitor* v) override;
-};
-
 class CompoundStatement : public Statement
 {
 public:
@@ -4474,6 +4466,14 @@ public:
     bool breaks;
     bool inCtfeBlock;
     LabelStatement* syntaxCopy() override;
+    void accept(Visitor* v) override;
+};
+
+class MixinStatement final : public Statement
+{
+public:
+    Array<Expression* >* exps;
+    MixinStatement* syntaxCopy() override;
     void accept(Visitor* v) override;
 };
 
@@ -5060,7 +5060,6 @@ struct ASTCodegen final
     using CaseRangeStatement = ::CaseRangeStatement;
     using CaseStatement = ::CaseStatement;
     using Catch = ::Catch;
-    using MixinStatement = ::MixinStatement;
     using CompoundAsmStatement = ::CompoundAsmStatement;
     using CompoundDeclarationStatement = ::CompoundDeclarationStatement;
     using CompoundStatement = ::CompoundStatement;
@@ -5085,6 +5084,7 @@ struct ASTCodegen final
     using InlineAsmStatement = ::InlineAsmStatement;
     using LabelDsymbol = ::LabelDsymbol;
     using LabelStatement = ::LabelStatement;
+    using MixinStatement = ::MixinStatement;
     using PeelStatement = ::PeelStatement;
     using PragmaStatement = ::PragmaStatement;
     using ReturnStatement = ::ReturnStatement;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -315,7 +315,7 @@ class StaticForeachStatement;
 class GotoDefaultStatement;
 class BreakStatement;
 class DtorExpStatement;
-class CompileStatement;
+class MixinStatement;
 class ForwardingStatement;
 class ContinueStatement;
 class ThrowStatement;
@@ -1916,7 +1916,7 @@ public:
     virtual void visit(typename AST::ReturnStatement s);
     virtual void visit(typename AST::LabelStatement s);
     virtual void visit(typename AST::StaticAssertStatement s);
-    virtual void visit(typename AST::CompileStatement s);
+    virtual void visit(typename AST::MixinStatement s);
     virtual void visit(typename AST::WhileStatement s);
     virtual void visit(typename AST::ForStatement s);
     virtual void visit(typename AST::DoStatement s);
@@ -4132,7 +4132,7 @@ public:
     GotoCaseStatement* isGotoCaseStatement();
     BreakStatement* isBreakStatement();
     DtorExpStatement* isDtorExpStatement();
-    CompileStatement* isCompileStatement();
+    MixinStatement* isCompileStatement();
     ForwardingStatement* isForwardingStatement();
     DoStatement* isDoStatement();
     WhileStatement* isWhileStatement();
@@ -4203,11 +4203,11 @@ public:
     Catch* syntaxCopy();
 };
 
-class CompileStatement final : public Statement
+class MixinStatement final : public Statement
 {
 public:
     Array<Expression* >* exps;
-    CompileStatement* syntaxCopy() override;
+    MixinStatement* syntaxCopy() override;
     void accept(Visitor* v) override;
 };
 
@@ -5060,7 +5060,7 @@ struct ASTCodegen final
     using CaseRangeStatement = ::CaseRangeStatement;
     using CaseStatement = ::CaseStatement;
     using Catch = ::Catch;
-    using CompileStatement = ::CompileStatement;
+    using MixinStatement = ::MixinStatement;
     using CompoundAsmStatement = ::CompoundAsmStatement;
     using CompoundDeclarationStatement = ::CompoundDeclarationStatement;
     using CompoundStatement = ::CompoundStatement;
@@ -8210,7 +8210,7 @@ class SemanticTimeTransitiveVisitor : public SemanticTimePermissiveVisitor
 public:
     using SemanticTimePermissiveVisitor::visit;
     void visit(ExpStatement* s) override;
-    void visit(CompileStatement* s) override;
+    void visit(MixinStatement* s) override;
     void visit(CompoundStatement* s) override;
     virtual void visitVarDecl(VarDeclaration* v);
     void visit(CompoundDeclarationStatement* s) override;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4132,7 +4132,7 @@ public:
     GotoCaseStatement* isGotoCaseStatement();
     BreakStatement* isBreakStatement();
     DtorExpStatement* isDtorExpStatement();
-    MixinStatement* isCompileStatement();
+    MixinStatement* isMixinStatement();
     ForwardingStatement* isForwardingStatement();
     DoStatement* isDoStatement();
     WhileStatement* isWhileStatement();

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4053,7 +4053,7 @@ enum class STMT : uint8_t
     Peel = 1u,
     Exp = 2u,
     DtorExp = 3u,
-    Compile = 4u,
+    Mixin = 4u,
     Compound = 5u,
     CompoundDeclaration = 6u,
     CompoundAsm = 7u,

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -180,7 +180,7 @@ public:
             buf.writenl();
     }
 
-    override void visit(CompileStatement s)
+    override void visit(MixinStatement s)
     {
         buf.writestring("mixin(");
         argsToBuffer(s.exps, buf, hgs, null);

--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -844,7 +844,7 @@ void toObNodes(ref ObNodes obnodes, Statement s)
             case STMT.Conditional:
             case STMT.While:
             case STMT.Forwarding:
-            case STMT.Compile:
+            case STMT.Mixin:
             case STMT.Peel:
             case STMT.Synchronized:
                 debug printf("s: %s\n", s.toChars());

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -5959,7 +5959,7 @@ LagainStc:
                     if (e.op == EXP.mixin_)
                     {
                         AST.MixinExp cpe = cast(AST.MixinExp)e;
-                        s = new AST.CompileStatement(loc, cpe.exps);
+                        s = new AST.MixinStatement(loc, cpe.exps);
                     }
                     else
                     {

--- a/compiler/src/dmd/parsetimevisitor.d
+++ b/compiler/src/dmd/parsetimevisitor.d
@@ -99,7 +99,7 @@ public:
     void visit(AST.ReturnStatement s) { visit(cast(AST.Statement)s); }
     void visit(AST.LabelStatement s) { visit(cast(AST.Statement)s); }
     void visit(AST.StaticAssertStatement s) { visit(cast(AST.Statement)s); }
-    void visit(AST.CompileStatement s) { visit(cast(AST.Statement)s); }
+    void visit(AST.MixinStatement s) { visit(cast(AST.Statement)s); }
     void visit(AST.WhileStatement s) { visit(cast(AST.Statement)s); }
     void visit(AST.ForStatement s) { visit(cast(AST.Statement)s); }
     void visit(AST.DoStatement s) { visit(cast(AST.Statement)s); }

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -388,7 +388,7 @@ extern (C++) abstract class Statement : ASTNode
     inout(GotoCaseStatement)    isGotoCaseStatement()    { return stmt == STMT.GotoCase    ? cast(typeof(return))this : null; }
     inout(BreakStatement)       isBreakStatement()       { return stmt == STMT.Break       ? cast(typeof(return))this : null; }
     inout(DtorExpStatement)     isDtorExpStatement()     { return stmt == STMT.DtorExp     ? cast(typeof(return))this : null; }
-    inout(MixinStatement)       isCompileStatement()     { return stmt == STMT.Compile     ? cast(typeof(return))this : null; }
+    inout(MixinStatement)       isMixinStatement()       { return stmt == STMT.Compile     ? cast(typeof(return))this : null; }
     inout(ForwardingStatement)  isForwardingStatement()  { return stmt == STMT.Forwarding  ? cast(typeof(return))this : null; }
     inout(DoStatement)          isDoStatement()          { return stmt == STMT.Do          ? cast(typeof(return))this : null; }
     inout(WhileStatement)       isWhileStatement()       { return stmt == STMT.While       ? cast(typeof(return))this : null; }

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -388,7 +388,7 @@ extern (C++) abstract class Statement : ASTNode
     inout(GotoCaseStatement)    isGotoCaseStatement()    { return stmt == STMT.GotoCase    ? cast(typeof(return))this : null; }
     inout(BreakStatement)       isBreakStatement()       { return stmt == STMT.Break       ? cast(typeof(return))this : null; }
     inout(DtorExpStatement)     isDtorExpStatement()     { return stmt == STMT.DtorExp     ? cast(typeof(return))this : null; }
-    inout(MixinStatement)       isMixinStatement()       { return stmt == STMT.Compile     ? cast(typeof(return))this : null; }
+    inout(MixinStatement)       isMixinStatement()       { return stmt == STMT.Mixin       ? cast(typeof(return))this : null; }
     inout(ForwardingStatement)  isForwardingStatement()  { return stmt == STMT.Forwarding  ? cast(typeof(return))this : null; }
     inout(DoStatement)          isDoStatement()          { return stmt == STMT.Do          ? cast(typeof(return))this : null; }
     inout(WhileStatement)       isWhileStatement()       { return stmt == STMT.While       ? cast(typeof(return))this : null; }
@@ -532,7 +532,7 @@ extern (C++) final class MixinStatement : Statement
 
     extern (D) this(const ref Loc loc, Expressions* exps)
     {
-        super(loc, STMT.Compile);
+        super(loc, STMT.Mixin);
         this.exps = exps;
     }
 

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -388,7 +388,7 @@ extern (C++) abstract class Statement : ASTNode
     inout(GotoCaseStatement)    isGotoCaseStatement()    { return stmt == STMT.GotoCase    ? cast(typeof(return))this : null; }
     inout(BreakStatement)       isBreakStatement()       { return stmt == STMT.Break       ? cast(typeof(return))this : null; }
     inout(DtorExpStatement)     isDtorExpStatement()     { return stmt == STMT.DtorExp     ? cast(typeof(return))this : null; }
-    inout(CompileStatement)     isCompileStatement()     { return stmt == STMT.Compile     ? cast(typeof(return))this : null; }
+    inout(MixinStatement)       isCompileStatement()     { return stmt == STMT.Compile     ? cast(typeof(return))this : null; }
     inout(ForwardingStatement)  isForwardingStatement()  { return stmt == STMT.Forwarding  ? cast(typeof(return))this : null; }
     inout(DoStatement)          isDoStatement()          { return stmt == STMT.Do          ? cast(typeof(return))this : null; }
     inout(WhileStatement)       isWhileStatement()       { return stmt == STMT.While       ? cast(typeof(return))this : null; }
@@ -518,7 +518,8 @@ extern (C++) final class DtorExpStatement : ExpStatement
 /***********************************************************
  * https://dlang.org/spec/statement.html#mixin-statement
  */
-extern (C++) final class CompileStatement : Statement
+// Note: was called CompileStatement
+extern (C++) final class MixinStatement : Statement
 {
     Expressions* exps;
 
@@ -535,9 +536,9 @@ extern (C++) final class CompileStatement : Statement
         this.exps = exps;
     }
 
-    override CompileStatement syntaxCopy()
+    override MixinStatement syntaxCopy()
     {
-        return new CompileStatement(loc, Expression.arraySyntaxCopy(exps));
+        return new MixinStatement(loc, Expression.arraySyntaxCopy(exps));
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -143,7 +143,7 @@ public:
     GotoCaseStatement    *isGotoCaseStatement()    { return stmt == STMTgotoCase    ? (GotoCaseStatement*)this    : NULL; }
     BreakStatement       *isBreakStatement()       { return stmt == STMTbreak       ? (BreakStatement*)this       : NULL; }
     DtorExpStatement     *isDtorExpStatement()     { return stmt == STMTdtorExp     ? (DtorExpStatement*)this     : NULL; }
-    MixinStatement       *isCompileStatement()     { return stmt == STMTcompile     ? (MixinStatement*)this       : NULL; }
+    MixinStatement       *isMixinStatement()       { return stmt == STMTcompile     ? (MixinStatement*)this       : NULL; }
     ForwardingStatement  *isForwardingStatement()  { return stmt == STMTforwarding  ? (ForwardingStatement*)this  : NULL; }
     DoStatement          *isDoStatement()          { return stmt == STMTdo          ? (DoStatement*)this          : NULL; }
     ForStatement         *isForStatement()         { return stmt == STMTfor         ? (ForStatement*)this         : NULL; }

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -143,7 +143,7 @@ public:
     GotoCaseStatement    *isGotoCaseStatement()    { return stmt == STMTgotoCase    ? (GotoCaseStatement*)this    : NULL; }
     BreakStatement       *isBreakStatement()       { return stmt == STMTbreak       ? (BreakStatement*)this       : NULL; }
     DtorExpStatement     *isDtorExpStatement()     { return stmt == STMTdtorExp     ? (DtorExpStatement*)this     : NULL; }
-    CompileStatement     *isCompileStatement()     { return stmt == STMTcompile     ? (CompileStatement*)this     : NULL; }
+    MixinStatement       *isCompileStatement()     { return stmt == STMTcompile     ? (MixinStatement*)this       : NULL; }
     ForwardingStatement  *isForwardingStatement()  { return stmt == STMTforwarding  ? (ForwardingStatement*)this  : NULL; }
     DoStatement          *isDoStatement()          { return stmt == STMTdo          ? (DoStatement*)this          : NULL; }
     ForStatement         *isForStatement()         { return stmt == STMTfor         ? (ForStatement*)this         : NULL; }
@@ -206,12 +206,12 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class CompileStatement final : public Statement
+class MixinStatement final : public Statement
 {
 public:
     Expressions *exps;
 
-    CompileStatement *syntaxCopy() override;
+    MixinStatement *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -65,7 +65,7 @@ enum
     STMTerror,
     STMTpeel,
     STMTexp, STMTdtorExp,
-    STMTcompile,
+    STMTmixin,
     STMTcompound, STMTcompoundDeclaration, STMTcompoundAsm,
     STMTunrolledLoop,
     STMTscope,
@@ -143,7 +143,7 @@ public:
     GotoCaseStatement    *isGotoCaseStatement()    { return stmt == STMTgotoCase    ? (GotoCaseStatement*)this    : NULL; }
     BreakStatement       *isBreakStatement()       { return stmt == STMTbreak       ? (BreakStatement*)this       : NULL; }
     DtorExpStatement     *isDtorExpStatement()     { return stmt == STMTdtorExp     ? (DtorExpStatement*)this     : NULL; }
-    MixinStatement       *isMixinStatement()       { return stmt == STMTcompile     ? (MixinStatement*)this       : NULL; }
+    MixinStatement       *isMixinStatement()       { return stmt == STMTmixin       ? (MixinStatement*)this       : NULL; }
     ForwardingStatement  *isForwardingStatement()  { return stmt == STMTforwarding  ? (ForwardingStatement*)this  : NULL; }
     DoStatement          *isDoStatement()          { return stmt == STMTdo          ? (DoStatement*)this          : NULL; }
     ForStatement         *isForStatement()         { return stmt == STMTfor         ? (ForStatement*)this         : NULL; }

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -4734,7 +4734,7 @@ private Statements* flatten(Statement statement, Scope* sc)
             return a;
 
         case STMT.Compile:
-            auto cs = statement.isCompileStatement();
+            auto cs = statement.isMixinStatement();
 
 
             OutBuffer buf;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -226,12 +226,12 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
         result = s;
     }
 
-    override void visit(CompileStatement cs)
+    override void visit(MixinStatement cs)
     {
         /* https://dlang.org/spec/statement.html#mixin-statement
          */
 
-        //printf("CompileStatement::semantic() %s\n", exp.toChars());
+        //printf("MixinStatement::semantic() %s\n", exp.toChars());
         Statements* a = cs.flatten(sc);
         if (!a)
             return;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -4733,7 +4733,7 @@ private Statements* flatten(Statement statement, Scope* sc)
             (*a)[0] = ls;
             return a;
 
-        case STMT.Compile:
+        case STMT.Mixin:
             auto cs = statement.isMixinStatement();
 
 

--- a/compiler/src/dmd/strictvisitor.d
+++ b/compiler/src/dmd/strictvisitor.d
@@ -71,7 +71,7 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.ReturnStatement) { assert(0); }
     override void visit(AST.LabelStatement) { assert(0); }
     override void visit(AST.StaticAssertStatement) { assert(0); }
-    override void visit(AST.CompileStatement) { assert(0); }
+    override void visit(AST.MixinStatement) { assert(0); }
     override void visit(AST.WhileStatement) { assert(0); }
     override void visit(AST.ForStatement) { assert(0); }
     override void visit(AST.DoStatement) { assert(0); }

--- a/compiler/src/dmd/transitivevisitor.d
+++ b/compiler/src/dmd/transitivevisitor.d
@@ -44,9 +44,9 @@ package mixin template ParseVisitMethods(AST)
         }
     }
 
-    override void visit(AST.CompileStatement s)
+    override void visit(AST.MixinStatement s)
     {
-        //printf("Visiting CompileStatement\n");
+        //printf("Visiting MixinStatement\n");
         visitArgs(s.exps.peekSlice());
     }
 

--- a/compiler/src/dmd/visitor.h
+++ b/compiler/src/dmd/visitor.h
@@ -16,7 +16,7 @@ class ErrorStatement;
 class PeelStatement;
 class ExpStatement;
 class DtorExpStatement;
-class CompileStatement;
+class MixinStatement;
 class CompoundStatement;
 class CompoundDeclarationStatement;
 class UnrolledLoopStatement;
@@ -395,7 +395,7 @@ public:
     virtual void visit(ReturnStatement *s) { visit((Statement *)s); }
     virtual void visit(LabelStatement *s) { visit((Statement *)s); }
     virtual void visit(StaticAssertStatement *s) { visit((Statement *)s); }
-    virtual void visit(CompileStatement *s) { visit((Statement *)s); }
+    virtual void visit(MixinStatement *s) { visit((Statement *)s); }
     virtual void visit(WhileStatement *s) { visit((Statement *)s); }
     virtual void visit(ForStatement *s) { visit((Statement *)s); }
     virtual void visit(DoStatement *s) { visit((Statement *)s); }


### PR DESCRIPTION
We already have MixinExp and CompileStatement is not specific enough.

(This was mentioned in @dkorpel's video: https://www.youtube.com/watch?v=hYLvw18obMA)

After this, need to do CompileDeclaration.