### PR TITLE
Fix Issue 22039 - ICE on infinite recursion in default parameter

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1726,7 +1726,6 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
     const size_t nparams = tf.parameterList.length;
     const olderrors = global.errors;
     bool err = false;
-    *prettype = Type.terror;
     Expression eprefix = null;
     *peprefix = null;
 
@@ -1796,6 +1795,8 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                     return errorArgs();
                 }
                 arg = p.defaultArg;
+                if (!arg.type)
+                    arg = arg.expressionSemantic(sc);
                 arg = inlineCopy(arg, sc);
                 // __FILE__, __LINE__, __MODULE__, __FUNCTION__, and __PRETTY_FUNCTION__
                 arg = arg.resolveLoc(loc, sc);

--- a/compiler/test/fail_compilation/fail22039.d
+++ b/compiler/test/fail_compilation/fail22039.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=22039
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail22039.d(11): Error: recursive evaluation of `func()`
+fail_compilation/fail22039.d(14): Error: recursive evaluation of `gun(func2())`
+---
+*/
+
+int func(int x = func()) { return x; }
+
+int gun() { return 2; }
+int func2(int x = gun(func2())) { return x; }


### PR DESCRIPTION
When `functionParameters` is called, a pointer to the type of the call expression is passed so that the type is set. This is done because inout needs to be matched to one of the mutable, const, immutable qualifiers. As a measure of precaution, the first thing `functionParameters` does is to set that pointer to point to a TypeError. I guess this is done to catch any error that falls between the cracks, however, the downside is that you might end up with errors in your AST for which you have not outputted an error message.

This mechanism interferes with how default arguments are processed in the provided bug report:

```d
int func(int x = func()) { return x; }
```

When the type of function `func` is analyzed, it needs to check that the type of the default arg matches the type of the parameter. As a consequence it performs semantic analysis on the function call of `func`. Then it ends up calling `functionParameters` with the type of function `func` (`int(int x = func())`) and a pointer to the type of the call expression. The catch is that this pointer points to a part of the type of `func`, therefore, when the pointer is set to TypeError the type of `func` is automatically updated to contain an error that is unaccounted for. This messes up the analysis of the default arg inside `functionParameters` and leads to the error being caught somewhere down the road where the compiler has no idea where it comes from, hence the ICE.

To fix this, I am deleting the line that bluntly sets the call type to error and if a default argument is missing its type information I'm just performing semantic on it on the spot. This seems to fix the issue and correctly output the recursive evaluation error.

Anyway, I find that `functionParameteres` is a complex beast doing all kinds of stuff. In my opinion, the way `inout` is handled here and how it uglifies the code is another justification for deprecating `inout`.

Although this is a regression, I'm not targeting stable since it's possible that some erroneous cases that would have been caught by the older mechanism slip through. Let's see what the tester says. 