### PR TITLE
Remove unused core.demangler : parseType name argument

### DIFF
--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -801,7 +801,7 @@ pure @safe:
     TypeTuple:
         B Number Arguments
     */
-    char[] parseType( char[] name = null ) return scope
+    char[] parseType() return scope
     {
         static immutable string[23] primitives = [
             "char", // a
@@ -830,7 +830,7 @@ pure @safe:
         ];
 
         static if (__traits(hasMember, Hooks, "parseType"))
-            if (auto n = hooks.parseType(this, name))
+            if (auto n = hooks.parseType(this, null))
                 return n;
 
         debug(trace) printf( "parseType+\n" );
@@ -861,27 +861,24 @@ pure @safe:
         switch ( t )
         {
         case 'Q': // Type back reference
-            return parseBackrefType( () => parseType( name ) );
+            return parseBackrefType(() => parseType());
         case 'O': // Shared (O Type)
             popFront();
             put( "shared(" );
             parseType();
             put( ')' );
-            pad( name );
             return dst[beg .. len];
         case 'x': // Const (x Type)
             popFront();
             put( "const(" );
             parseType();
             put( ')' );
-            pad( name );
             return dst[beg .. len];
         case 'y': // Immutable (y Type)
             popFront();
             put( "immutable(" );
             parseType();
             put( ')' );
-            pad( name );
             return dst[beg .. len];
         case 'N':
             popFront();
@@ -912,7 +909,6 @@ pure @safe:
             popFront();
             parseType();
             put( "[]" );
-            pad( name );
             return dst[beg .. len];
         case 'G': // TypeStaticArray (G Number Type)
             popFront();
@@ -921,7 +917,6 @@ pure @safe:
             put( '[' );
             put( num );
             put( ']' );
-            pad( name );
             return dst[beg .. len];
         case 'H': // TypeAssocArray (H Type Type)
             popFront();
@@ -931,31 +926,28 @@ pure @safe:
             put( '[' );
             put( tx );
             put( ']' );
-            pad( name );
             return dst[beg .. len];
         case 'P': // TypePointer (P Type)
             popFront();
             parseType();
             put( '*' );
-            pad( name );
             return dst[beg .. len];
         case 'F': case 'U': case 'W': case 'V': case 'R': // TypeFunction
-            return parseTypeFunction( name );
+            return parseTypeFunction();
         case 'C': // TypeClass (C LName)
         case 'S': // TypeStruct (S LName)
         case 'E': // TypeEnum (E LName)
         case 'T': // TypeTypedef (T LName)
             popFront();
             parseQualifiedName();
-            pad( name );
             return dst[beg .. len];
         case 'D': // TypeDelegate (D TypeFunction)
             popFront();
             auto modifiers = parseModifier();
             if ( front == 'Q' )
-                parseBackrefType( () => parseTypeFunction( name, IsDelegate.yes ) );
+                parseBackrefType(() => parseTypeFunction(IsDelegate.yes));
             else
-                parseTypeFunction( name, IsDelegate.yes );
+                parseTypeFunction(IsDelegate.yes);
             if (modifiers)
             {
                 // write modifiers behind the function arguments
@@ -989,7 +981,6 @@ pure @safe:
             {
                 popFront();
                 put( primitives[cast(size_t)(t - 'a')] );
-                pad( name );
                 return dst[beg .. len];
             }
             else if (t == 'z')
@@ -1000,12 +991,10 @@ pure @safe:
                 case 'i':
                     popFront();
                     put( "cent" );
-                    pad( name );
                     return dst[beg .. len];
                 case 'k':
                     popFront();
                     put( "ucent" );
-                    pad( name );
                     return dst[beg .. len];
                 default:
                     error();
@@ -1358,7 +1347,7 @@ pure @safe:
         TypeFunction:
             CallConvention FuncAttrs Arguments ArgClose Type
     */
-    char[] parseTypeFunction( char[] name = null, IsDelegate isdg = IsDelegate.no ) return scope
+    char[] parseTypeFunction(IsDelegate isdg = IsDelegate.no) return scope
     {
         debug(trace) printf( "parseTypeFunction+\n" );
         debug(trace) scope(success) printf( "parseTypeFunction-\n" );
@@ -1383,18 +1372,8 @@ pure @safe:
         auto retbeg = len;
         parseType();
         put( ' ' );
-        // append name/delegate/function
-        if ( name.length )
-        {
-            if ( !contains( dst[0 .. len], name ) )
-                put( name );
-            else if ( shift( name ).ptr != name.ptr )
-            {
-                argbeg -= name.length;
-                retbeg -= name.length;
-            }
-        }
-        else if ( IsDelegate.yes == isdg )
+        // append delegate/function
+        if (IsDelegate.yes == isdg)
             put( "delegate" );
         else
             put( "function" );


### PR DESCRIPTION
```
The function is private, so it is fine to remove it. There were no place where the non-default value wasn't given, directly or indirectly.
```

At least that's what the unittests and the diff tell me, let's see what the CI thinks.