### PR TITLE
do not lower if using CTFE

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3796,8 +3796,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 result = id.expressionSemantic(sc);
                 return;
             }
-            else if (!exp.onstack && !exp.type.isscope())
+            else if (!(sc.flags & (SCOPE.ctfe | SCOPE.ctfeBlock | SCOPE.compile)) && // interpreter can handle these
+                     !exp.onstack && !exp.type.isscope()) // these won't use the GC
             {
+                /* replace `new T(arguments)` with `core.lifetime._d_newclassT!T(arguments)`
+                 * or `_d_newclassTTrace`
+                 */
                 auto hook = global.params.tracegc ? Id._d_newclassTTrace : Id._d_newclassT;
                 if (!verifyHookExist(exp.loc, *sc, hook, "new class"))
                     return setError();


### PR DESCRIPTION
This lowering causes a lot of template bloat and slowdown and is not necessary for CTFE execution. CTFE ought to be able to execute `new` directly.