### PR TITLE
do not emit switch templates in CTFE

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2334,7 +2334,8 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
         }
 
 
-        if (!ss.condition.type.isString())
+        if (!ss.condition.type.isString() ||
+            sc.flags & (SCOPE.ctfe | SCOPE.compile | SCOPE.ctfeBlock))
         {
             sc.pop();
             result = ss;


### PR DESCRIPTION
Because of Bloaty-McBloatFace of unnecessary templates