### PR TITLE
fix Issue 23758 - [REG 2.103] Segfault accessing NewExp::argprefix from C++

### DIFF
--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -532,6 +532,7 @@ public:
     Expression *thisexp;        // if !NULL, 'this' for class being allocated
     Type *newtype;
     Expressions *arguments;     // Array of Expression's
+    Identifiers *names;         // Array of names corresponding to expressions
 
     Expression *argprefix;      // expression to be evaluated just before arguments[]
 


### PR DESCRIPTION
DMD layout became out of sync with GDC and LDC, which would cause a segfault in the latter compilers during compilation of `new` expressions.