### PR TITLE
dmd: Deprecate 'in' parameters on non-extern(D,C++) functions

### DIFF
--- a/changelog/dmd.in-externd.dd
+++ b/changelog/dmd.in-externd.dd
@@ -1,0 +1,7 @@
+Using `in` parameters with non `extern(D)`/`extern(C++)` functions is deprecated
+
+In preparation for enabling `-preview=in` by default,
+using `in` parameters on function that have neither D nor C++ linkage is deprecated.
+Users can replace instances of `in` with either `const` or `scope const`.
+Refer to [v2.101.0 changelog's](https://dlang.org/changelog/2.101.0.html#dmd.previewInLink)
+for a full rationale.

--- a/compiler/test/compilable/warn3882.d
+++ b/compiler/test/compilable/warn3882.d
@@ -12,7 +12,7 @@ void test3882()
 /******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=12619
 
-extern (C) @system nothrow pure void* memcpy(void* s1, in void* s2, size_t n);
+extern (C) @system nothrow pure void* memcpy(void* s1, const void* s2, size_t n);
 // -> weakly pure
 
 void test12619() pure

--- a/compiler/test/fail_compilation/deprecations_preview_in.d
+++ b/compiler/test/fail_compilation/deprecations_preview_in.d
@@ -1,0 +1,11 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/deprecations_preview_in.d(1): Deprecation: using `in` parameters with `extern(C)` functions is deprecated
+fail_compilation/deprecations_preview_in.d(1):        parameter `__anonymous_param` declared as `in` here
+---
+*/
+
+#line 1
+extern(C) void fun1(in char*);

--- a/compiler/test/runnable/debug_info.d
+++ b/compiler/test/runnable/debug_info.d
@@ -27,8 +27,8 @@ else
 extern (C)
 {
     MachHeader* _dyld_get_image_header(uint image_index);
-    const(section)* getsectbynamefromheader(in mach_header* mhp, in char* segname, in char* sectname);
-    const(section_64)* getsectbynamefromheader_64(in mach_header_64* mhp, in char* segname, in char* sectname);
+    const(section)* getsectbynamefromheader(scope const mach_header* mhp, scope const char* segname, scope const char* sectname);
+    const(section_64)* getsectbynamefromheader_64(scope const mach_header_64* mhp, scope const char* segname, scope const char* sectname);
 }
 
 const(Section)* getSectByNameFromHeader(MachHeader* mhp, in char* segname, in char* sectname)

--- a/compiler/test/runnable/imports/link13415a.d
+++ b/compiler/test/runnable/imports/link13415a.d
@@ -7,7 +7,7 @@ struct S(alias func)
     }
 }
 
-extern(C) int printf(in char*, ...);
+extern(C) int printf(const char*, ...);
 
 void f(int i = 77)
 {

--- a/compiler/test/runnable/objc_call.d
+++ b/compiler/test/runnable/objc_call.d
@@ -12,12 +12,12 @@ extern class Class
 extern (Objective-C)
 extern class NSObject
 {
-    NSObject initWithUTF8String(in char* str) @selector("initWithUTF8String:");
+    NSObject initWithUTF8String(scope const char* str) @selector("initWithUTF8String:");
     void release() @selector("release");
 }
 
 extern (C) void NSLog(NSObject, ...);
-extern (C) Class objc_lookUpClass(in char* name);
+extern (C) Class objc_lookUpClass(scope const char* name);
 
 void main()
 {

--- a/compiler/test/runnable/objc_objc_msgSend.d
+++ b/compiler/test/runnable/objc_objc_msgSend.d
@@ -3,7 +3,7 @@
 
 import core.attribute : selector;
 
-extern (C) Class objc_lookUpClass(in char* name);
+extern (C) Class objc_lookUpClass(scope const char* name);
 
 struct Struct
 {

--- a/compiler/test/runnable/objc_protocol_sections.d
+++ b/compiler/test/runnable/objc_protocol_sections.d
@@ -31,8 +31,8 @@ struct objc_method_description
     }
 }
 
-SEL sel_registerName(in char* str);
-Protocol* objc_getProtocol(in char* name);
+SEL sel_registerName(scope const char* str);
+Protocol* objc_getProtocol(scope const char* name);
 objc_method_description protocol_getMethodDescription(
     Protocol* proto, SEL aSel, bool isRequiredMethod, bool isInstanceMethod
 );


### PR DESCRIPTION
This error was introduced in `-preview=in` in v2.101.0. In order to make `-preview=in` the default, we add a deprecation even if `-preview=in` is not used.