### PR TITLE
Issue 23759 - [REG 2.103][FTBFS] Undefined symbols for architecture i386: "__ZN7CTFloat6sprintEPcjc10longdouble"

### DIFF
--- a/compiler/src/dmd/root/ctfloat.h
+++ b/compiler/src/dmd/root/ctfloat.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "dcompat.h"
 #include "longdouble.h"
 
 // Type used by the front-end for compile-time reals
@@ -51,7 +52,7 @@ struct CTFloat
     static bool isInfinity(real_t r);
 
     static real_t parse(const char *literal, bool& isOutOfRange);
-    static int sprint(char *str, size_t size, char fmt, real_t x);
+    static int sprint(char *str, d_size_t size, char fmt, real_t x);
 
     static size_t hash(real_t a);
 


### PR DESCRIPTION
`size_t` is a troublesome type for D compatibility.  Fix headers to use `d_size_t` instead for all parameters.