### PR TITLE
use template mixin for visiting Initializers

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5018,6 +5018,7 @@ struct ASTCodegen final
     using Initializer = ::Initializer;
     using NeedInterpret = ::NeedInterpret;
     using StructInitializer = ::StructInitializer;
+    using VisitInitializer = ::VisitInitializer;
     using VoidInitializer = ::VoidInitializer;
     using Covariant = ::Covariant;
     using DotExpFlag = ::DotExpFlag;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -3814,15 +3814,8 @@ private void initializerToBuffer(Initializer inx, OutBuffer* buf, HdrGenState* h
         buf.writeByte('}');
     }
 
-    final switch (inx.kind)
-    {
-        case InitKind.error:   return visitError (inx.isErrorInitializer ());
-        case InitKind.void_:   return visitVoid  (inx.isVoidInitializer  ());
-        case InitKind.struct_: return visitStruct(inx.isStructInitializer());
-        case InitKind.array:   return visitArray (inx.isArrayInitializer ());
-        case InitKind.exp:     return visitExp   (inx.isExpInitializer   ());
-        case InitKind.C_:      return visitC     (inx.isCInitializer     ());
-    }
+    mixin VisitInitializer!void visit;
+    visit.VisitInitializer(inx);
 }
 
 

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -958,15 +958,9 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
         }
     }
 
-    final switch (init.kind)
-    {
-        case InitKind.void_:   return visitVoid  (init.isVoidInitializer());
-        case InitKind.error:   return visitError (init.isErrorInitializer());
-        case InitKind.struct_: return visitStruct(init.isStructInitializer());
-        case InitKind.array:   return visitArray (init.isArrayInitializer());
-        case InitKind.exp:     return visitExp   (init.isExpInitializer());
-        case InitKind.C_:      return visitC     (init.isCInitializer());
-    }
+    mixin VisitInitializer!Initializer visit;
+    auto result = visit.VisitInitializer(init);
+    return (result !is null) ? result : new ErrorInitializer();
 }
 
 /***********************
@@ -1120,15 +1114,9 @@ Initializer inferType(Initializer init, Scope* sc)
         return new ErrorInitializer();
     }
 
-    final switch (init.kind)
-    {
-        case InitKind.void_:   return visitVoid  (init.isVoidInitializer());
-        case InitKind.error:   return visitError (init.isErrorInitializer());
-        case InitKind.struct_: return visitStruct(init.isStructInitializer());
-        case InitKind.array:   return visitArray (init.isArrayInitializer());
-        case InitKind.exp:     return visitExp   (init.isExpInitializer());
-        case InitKind.C_:      return visitC     (init.isCInitializer());
-    }
+    mixin VisitInitializer!Initializer visit;
+    auto result = visit.VisitInitializer(init);
+    return (result !is null) ? result : new ErrorInitializer();
 }
 
 /***********************
@@ -1333,15 +1321,8 @@ extern (C++) Expression initializerToExpression(Initializer init, Type itype = n
         return null;
     }
 
-    final switch (init.kind)
-    {
-        case InitKind.void_:   return visitVoid  (init.isVoidInitializer());
-        case InitKind.error:   return visitError (init.isErrorInitializer());
-        case InitKind.struct_: return visitStruct(init.isStructInitializer());
-        case InitKind.array:   return visitArray (init.isArrayInitializer());
-        case InitKind.exp:     return visitExp   (init.isExpInitializer());
-        case InitKind.C_:      return visitC     (init.isCInitializer());
-    }
+    mixin VisitInitializer!Expression visit;
+    return visit.VisitInitializer(init);
 }
 
 

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -208,15 +208,8 @@ extern (C++) void Initializer_toDt(Initializer init, ref DtBuilder dtb, bool isC
         assert(0);
     }
 
-    final switch (init.kind)
-    {
-        case InitKind.void_:   return visitVoid  (cast(  VoidInitializer)init);
-        case InitKind.error:   return visitError (cast( ErrorInitializer)init);
-        case InitKind.struct_: return visitStruct(cast(StructInitializer)init);
-        case InitKind.array:   return visitArray (cast( ArrayInitializer)init);
-        case InitKind.exp:     return visitExp   (cast(   ExpInitializer)init);
-        case InitKind.C_:      return visitC     (cast(     CInitializer)init);
-    }
+    mixin VisitInitializer!void visit;
+    visit.VisitInitializer(init);
 }
 
 /* ================================================================ */


### PR DESCRIPTION
While the Visitor class works, I've never been very happy with it:
1. it's inherently slow, using virtual double dispatch. Virtual dispatch stops compiler optimizations dead. It's cache unfriendly. Since the source does a lot of this, it's a problem.
2. it can't be const or pure. This has been worked around with unsafe casts, but is a hack
3. I've always thought the class thing looked awkward.

I've replaced many of them with a switch statement and nested functions. But that has a problem, too. If there are only a handful of node types, one still has to replicate all the recursion logic for all the node types. That's why conversion to switch/nested has remained incomplete. It is tedious and error-prone to repeatedly re-invent the switch statement.

I finally realized the Visitor pattern can be implemented with a mixin template. Yay for an underused/underappreciated feature of D! Along with string mixins for boilerplate.

I picked the simplest use case in the compiler as the opening salvo in this conversion. The mixin template will be reused for each Visitor function instead of the switch.