### PR TITLE
Simplify objfmt boilerplate generation

### DIFF
--- a/compiler/src/dmd/backend/obj.d
+++ b/compiler/src/dmd/backend/obj.d
@@ -198,17 +198,17 @@ else
 
         void initfile(const(char)* filename, const(char)* csegname, const(char)* modname)
         {
-            mixin(genRetVoid("initfile(filename, csegname, modname)"));
+            mixin(genRetVal("initfile(filename, csegname, modname)"));
         }
 
         void termfile()
         {
-            mixin(genRetVoid("termfile()"));
+            mixin(genRetVal("termfile()"));
         }
 
         void term(const(char)* objfilename)
         {
-            mixin(genRetVoid("term(objfilename)"));
+            mixin(genRetVal("term(objfilename)"));
         }
 
         size_t mangle(Symbol *s,char *dest)
@@ -225,7 +225,7 @@ else
 
         void linnum(Srcpos srcpos, int seg, targ_size_t offset)
         {
-            mixin(genRetVoid("linnum(srcpos, seg, offset)"));
+            mixin(genRetVal("linnum(srcpos, seg, offset)"));
         }
 
         int codeseg(const char *name,int suffix)
@@ -241,7 +241,7 @@ else
 
         void startaddress(Symbol *s)
         {
-            mixin(genRetVoid("startaddress(s)"));
+            mixin(genRetVal("startaddress(s)"));
         }
 
         bool includelib(const(char)* name)
@@ -261,22 +261,22 @@ else
 
         void exestr(const(char)* p)
         {
-            mixin(genRetVoid("exestr(p)"));
+            mixin(genRetVal("exestr(p)"));
         }
 
         void user(const(char)* p)
         {
-            mixin(genRetVoid("user(p)"));
+            mixin(genRetVal("user(p)"));
         }
 
         void compiler()
         {
-            mixin(genRetVoid("compiler()"));
+            mixin(genRetVal("compiler()"));
         }
 
         void wkext(Symbol* s1, Symbol* s2)
         {
-            mixin(genRetVoid("wkext(s1, s2)"));
+            mixin(genRetVal("wkext(s1, s2)"));
         }
 
         void lzext(Symbol* s1, Symbol* s2)
@@ -287,7 +287,7 @@ else
 
         void _alias(const(char)* n1,const(char)* n2)
         {
-            mixin(genRetVoid("alias(n1, n2)"));
+            mixin(genRetVal("alias(n1, n2)"));
         }
 
         void theadr(const(char)* modname)
@@ -304,32 +304,32 @@ else
 
         void staticctor(Symbol *s,int dtor,int seg)
         {
-            mixin(genRetVoid("staticctor(s, dtor, seg)"));
+            mixin(genRetVal("staticctor(s, dtor, seg)"));
         }
 
         void staticdtor(Symbol *s)
         {
-            mixin(genRetVoid("staticdtor(s)"));
+            mixin(genRetVal("staticdtor(s)"));
         }
 
         void setModuleCtorDtor(Symbol *s, bool isCtor)
         {
-            mixin(genRetVoid("setModuleCtorDtor(s, isCtor)"));
+            mixin(genRetVal("setModuleCtorDtor(s, isCtor)"));
         }
 
         void ehtables(Symbol *sfunc,uint size,Symbol *ehsym)
         {
-            mixin(genRetVoid("ehtables(sfunc, size, ehsym)"));
+            mixin(genRetVal("ehtables(sfunc, size, ehsym)"));
         }
 
         void ehsections()
         {
-            mixin(genRetVoid("ehsections()"));
+            mixin(genRetVal("ehsections()"));
         }
 
         void moduleinfo(Symbol *scc)
         {
-            mixin(genRetVoid("moduleinfo(scc)"));
+            mixin(genRetVal("moduleinfo(scc)"));
         }
 
         int comdat(Symbol *s)
@@ -349,7 +349,7 @@ else
 
         void setcodeseg(int seg)
         {
-            mixin(genRetVoid("setcodeseg(seg)"));
+            mixin(genRetVal("setcodeseg(seg)"));
         }
 
         seg_data *tlsseg()
@@ -375,17 +375,17 @@ else
 
         void export_symbol(Symbol *s, uint argsize)
         {
-            mixin(genRetVoid("export_symbol(s, argsize)"));
+            mixin(genRetVal("export_symbol(s, argsize)"));
         }
 
         void pubdef(int seg, Symbol *s, targ_size_t offset)
         {
-            mixin(genRetVoid("pubdef(seg, s, offset)"));
+            mixin(genRetVal("pubdef(seg, s, offset)"));
         }
 
         void pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize)
         {
-            mixin(genRetVoid("pubdefsize(seg, s, offset, symsize)"));
+            mixin(genRetVal("pubdefsize(seg, s, offset, symsize)"));
         }
 
         int external_def(const(char)* name)
@@ -415,27 +415,27 @@ else
 
         void lidata(int seg, targ_size_t offset, targ_size_t count)
         {
-            mixin(genRetVoid("lidata(seg, offset, count)"));
+            mixin(genRetVal("lidata(seg, offset, count)"));
         }
 
         void write_zeros(seg_data *pseg, targ_size_t count)
         {
-            mixin(genRetVoid("write_zeros(pseg, count)"));
+            mixin(genRetVal("write_zeros(pseg, count)"));
         }
 
         void write_byte(seg_data *pseg, uint _byte)
         {
-            mixin(genRetVoid("write_byte(pseg, _byte)"));
+            mixin(genRetVal("write_byte(pseg, _byte)"));
         }
 
         void write_bytes(seg_data *pseg, uint nbytes, void *p)
         {
-            mixin(genRetVoid("write_bytes(pseg, nbytes, p)"));
+            mixin(genRetVal("write_bytes(pseg, nbytes, p)"));
         }
 
         void _byte(int seg, targ_size_t offset, uint _byte)
         {
-            mixin(genRetVoid("byte(seg, offset, _byte)"));
+            mixin(genRetVal("byte(seg, offset, _byte)"));
         }
 
         uint bytes(int seg, targ_size_t offset, uint nbytes, void *p)
@@ -451,7 +451,7 @@ else
 
         void reftodatseg(int seg, targ_size_t offset, targ_size_t val, uint targetdatum, int flags)
         {
-            mixin(genRetVoid("reftodatseg(seg, offset, val, targetdatum, flags)"));
+            mixin(genRetVal("reftodatseg(seg, offset, val, targetdatum, flags)"));
         }
 
         void reftofarseg(int seg, targ_size_t offset, targ_size_t val, int farseg, int flags)
@@ -462,7 +462,7 @@ else
 
         void reftocodeseg(int seg, targ_size_t offset, targ_size_t val)
         {
-            mixin(genRetVoid("reftocodeseg(seg, offset, val)"));
+            mixin(genRetVal("reftocodeseg(seg, offset, val)"));
         }
 
         int reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val, int flags)
@@ -472,12 +472,12 @@ else
 
         void far16thunk(Symbol *s)
         {
-            mixin(genRetVoid("far16thunk(s)"));
+            mixin(genRetVal("far16thunk(s)"));
         }
 
         void fltused()
         {
-            mixin(genRetVoid("fltused()"));
+            mixin(genRetVal("fltused()"));
         }
 
         int data_readonly(char *p, int len, int *pseg)
@@ -502,17 +502,17 @@ else
 
         void func_start(Symbol *sfunc)
         {
-            mixin(genRetVoid("func_start(sfunc)"));
+            mixin(genRetVal("func_start(sfunc)"));
         }
 
         void func_term(Symbol *sfunc)
         {
-            mixin(genRetVoid("func_term(sfunc)"));
+            mixin(genRetVal("func_term(sfunc)"));
         }
 
         void write_pointerRef(Symbol* s, uint off)
         {
-            mixin(genRetVoid("write_pointerRef(s, off)"));
+            mixin(genRetVal("write_pointerRef(s, off)"));
         }
 
         int jmpTableSegment(Symbol* s)
@@ -702,87 +702,41 @@ string ObjMemDecl(string pattern)
 
 /****************************************
  * Generate boilerplate for static dispatch that
- * returns a void.
- * Params:
- *      arg = string to insert where ever there's a '$'
- * Returns:
- *      mixin string with static dispatch
- */
-private extern (D)
-string genRetVoid(string arg)
-{
-    string pattern =
-    "
-        switch (config.objfmt)
-        {
-            case OBJ_ELF:       ElfObj_$; break;
-            case OBJ_MSCOFF: MsCoffObj_$; break;
-            case OBJ_OMF:       OmfObj_$; break;
-            case OBJ_MACH:     MachObj_$; break;
-            default:     assert(0);
-        }
-    ";
-    return gen(pattern, arg);
-}
-
-/****************************************
- * Generate boilerplate for static dispatch that
  * returns a value. Don't care about type of the value.
  * Params:
- *      arg = string to insert where ever there's a '$'
+ *      arg = function name to be dispatched based on `objfmt`
  * Returns:
  *      mixin string with static dispatch
  */
 private extern (D)
 string genRetVal(string arg)
 {
-    string pattern =
+    return
     "
         switch (config.objfmt)
         {
-            case OBJ_ELF:    return    ElfObj_$;
-            case OBJ_MSCOFF: return MsCoffObj_$;
-            case OBJ_OMF:    return    OmfObj_$;
-            case OBJ_MACH:   return   MachObj_$;
+            case OBJ_ELF:    return    ElfObj_"~arg~";
+            case OBJ_MSCOFF: return MsCoffObj_"~arg~";
+            case OBJ_OMF:    return    OmfObj_"~arg~";
+            case OBJ_MACH:   return   MachObj_"~arg~";
             default:     assert(0);
         }
     ";
-    return gen(pattern, arg);
 }
 
 /****************************************
- * Generate boilerplate that replaces '$' in pattern with `arg`
+ * Generate boilerplate that replaces the single '$' in `pattern` with `arg`
  * Params:
  *      pattern = pattern to scan for '$'
- *      arg = string to insert where ever '$' is found
+ *      arg = string to insert where '$' is found
  * Returns:
  *      boilerplate string
  */
 private extern (D)
 string gen(string pattern, string arg)
 {
-    size_t count;               // number of '$' in pattern
-    foreach (c; pattern)
-        count += (c == '$');
-
-    // length of result
-    const length = pattern.length - count + arg.length * count;
-
-    char[] result = new char[length];
-    size_t i;
-    foreach (c; pattern)
-    {
-        if (c == '$')
-        {
-            result[i .. i + arg.length] = arg[]; // substitution
-            i += arg.length;
-        }
-        else
-        {
-            result[i] = c;
-            ++i;
-        }
-    }
-    assert(i == length);
-    return cast(string)result;
+    foreach (i; 0 .. pattern.length)
+        if (pattern[i] == '$')
+            return pattern[0 .. i] ~ arg ~ pattern[i + 1 .. $];
+    assert(0);
 }


### PR DESCRIPTION
- Replace calls to `genRetVoid` with `genRetVal`, no need to special case `void` return
- Remove `genRetVoid` function
- No need to replace `$` in `genRetVal`, can just use regular string concatenation which should be faster at CTFE
- `gen` doesn't need to replace multiple "$" patterns anymore, so can be simplified to just replace 1