### PR TITLE
Fix Issue 16213 - CTFE internal error with static array $ as template argument

### DIFF
--- a/compiler/test/compilable/test16213.d
+++ b/compiler/test/compilable/test16213.d
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=16213
+
+enum Id(size_t i) = i;
+void main()
+{
+    int[5] y;
+    y[ Id!($) - 1 ] = 3;
+}


### PR DESCRIPTION
Declare dollar (variable for $) as being a manifest constant for when using for static arrays. This enables the use of $ at ctfe.