### PR TITLE
rename static assert field in astbase

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -453,21 +453,21 @@ struct ASTBase
     extern (C++) final class StaticAssert : Dsymbol
     {
         Expression exp;
-        Expressions* msg;
+        Expressions* msgs;
 
         extern (D) this(const ref Loc loc, Expression exp, Expression msg)
         {
             super(loc, Id.empty);
             this.exp = exp;
-            this.msg = new Expressions(1);
-            (*this.msg)[0] = msg;
+            this.msgs = new Expressions(1);
+            (*this.msgs)[0] = msg;
         }
 
-        extern (D) this(const ref Loc loc, Expression exp, Expressions* msg)
+        extern (D) this(const ref Loc loc, Expression exp, Expressions* msgs)
         {
             super(loc, Id.empty);
             this.exp = exp;
-            this.msg = msg;
+            this.msgs = msgs;
         }
 
         override void accept(Visitor v)


### PR DESCRIPTION
This is needed in order to be coherent with https://github.com/dlang/dmd/blob/master/compiler/src/dmd/staticassert.d#L29.

I don't know when the naming was changed but currently, ASTBase cannot be used with transitive visitor: https://github.com/dlang/dmd/blob/master/compiler/src/dmd/transitivevisitor.d#L489