### PR TITLE
Fix 23763: Correctly handle struct constants with 0 initializer

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -2117,6 +2117,16 @@ public:
                     return CTFEExp.cantexp;
                 assert(e.type);
 
+                // There's a terrible hack in `dmd.dsymbolsem` that special case
+                // a struct with all zeros to an `ExpInitializer(BlitExp(IntegerExp(0)))`
+                // There's matching code for it in e2ir (toElem's visitAssignExp),
+                // so we need the same hack here.
+                // This does not trigger for global as they get a normal initializer.
+                if (auto ts = e.type.isTypeStruct())
+                    if (auto ae = e.isBlitExp())
+                        if (ae.e2.op == EXP.int64)
+                            e = ts.defaultInitLiteral(loc);
+
                 if (e.op == EXP.construct || e.op == EXP.blit)
                 {
                     AssignExp ae = cast(AssignExp)e;

--- a/compiler/test/compilable/test17351.d
+++ b/compiler/test/compilable/test17351.d
@@ -1,3 +1,4 @@
+// PERMUTE_ARGS: -preview=in
 bool fun(S)(ref S[3] a) { assert(a == [42, 84, 169]); return true; }
 bool fun2(S)(ref S a) { return true; }
 void main()
@@ -14,4 +15,12 @@ void test2()
 {
     static immutable int[2] P = [ 0, 1 ];
     static assert(f2(P) == 1);
+    immutable BigInt a, b;
+    static assert(glob1.twice == b.twice);
+    static assert(a.twice == b.twice);
 }
+
+struct BigInt { int[64] big; }
+BigInt twice (in BigInt v) @safe pure nothrow @nogc { return v; }
+
+immutable BigInt glob1 = BigInt.init;


### PR DESCRIPTION
At the moment, in dsymbolsem.d:1026, there is the following comment:
```
/* If a struct is all zeros, as a special case
 * set its initializer to the integer 0.
 * In AssignExp::toElem(), we check for this and issue
 * a memset() to initialize the struct.
 * Must do same check in interpreter.
 */
```
Turns out, the 'Must do same check in interpreter.' part was missing.

https://github.com/dlang/dmd/blob/bae9399370ba80066c187502a6b922669b27f533/compiler/src/dmd/dsymbolsem.d#L1023-L1036

https://github.com/dlang/dmd/blob/bae9399370ba80066c187502a6b922669b27f533/compiler/src/dmd/e2ir.d#L2579-L2601