### PR TITLE
Fix 23764 - Message printed twice: Usage of in on parameter

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -777,6 +777,7 @@ extern (C++) final class Module : Package
         else
         {
             scope p = new Parser!AST(this, buf, cast(bool) docfile, global.errorSink, &global.compileEnv);
+            p.transitionIn = global.params.vin;
             p.nextToken();
             p.parseModuleDeclaration();
             md = p.md;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1937,6 +1937,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         buf.writeByte(0);
         const str = buf.extractSlice()[0 .. len];
         scope p = new Parser!ASTCodegen(cd.loc, sc._module, str, false, global.errorSink, &global.compileEnv);
+        p.transitionIn = global.params.vin;
         p.nextToken();
 
         auto d = p.parseDeclDefs(0);

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -73,6 +73,14 @@ class ErrorSinkCompiler : ErrorSink
         vdeprecationSupplemental(loc, format, ap);
         va_end(ap);
     }
+
+    void message(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vmessage(loc, format, ap);
+        va_end(ap);
+    }
 }
 
 

--- a/compiler/src/dmd/errorsink.d
+++ b/compiler/src/dmd/errorsink.d
@@ -27,6 +27,8 @@ abstract class ErrorSink
 
     void warning(const ref Loc loc, const(char)* format, ...);
 
+    void message(const ref Loc loc, const(char)* format, ...);
+
     void deprecation(const ref Loc loc, const(char)* format, ...);
 
     void deprecationSupplemental(const ref Loc loc, const(char)* format, ...);
@@ -46,6 +48,8 @@ class ErrorSinkNull : ErrorSink
     void errorSupplemental(const ref Loc loc, const(char)* format, ...) { }
 
     void warning(const ref Loc loc, const(char)* format, ...) { }
+
+    void message(const ref Loc loc, const(char)* format, ...) { }
 
     void deprecation(const ref Loc loc, const(char)* format, ...) { }
 
@@ -103,6 +107,22 @@ class ErrorSinkStderr : ErrorSink
     void deprecation(const ref Loc loc, const(char)* format, ...)
     {
         fputs("Deprecation: ", stderr);
+        const p = loc.toChars();
+        if (*p)
+        {
+            fprintf(stderr, "%s: ", p);
+            //mem.xfree(cast(void*)p); // loc should provide the free()
+        }
+
+        va_list ap;
+        va_start(ap, format);
+        vfprintf(stderr, format, ap);
+        fputc('\n', stderr);
+        va_end(ap);
+    }
+
+    void message(const ref Loc loc, const(char)* format, ...)
+    {
         const p = loc.toChars();
         if (*p)
         {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6107,6 +6107,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         const len = buf.length;
         const str = buf.extractChars()[0 .. len];
         scope p = new Parser!ASTCodegen(exp.loc, sc._module, str, false, global.errorSink, &global.compileEnv);
+        p.transitionIn = global.params.vin;
         p.nextToken();
         //printf("p.loc.linnum = %d\n", p.loc.linnum);
 

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -49,6 +49,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         Loc lookingForElse; // location of lonely if looking for an else
     }
 
+    bool transitionIn = false; /// `-transition=in` is active, `in` parameters are listed
+
     /*********************
      * Use this constructor for string mixins.
      * Input:
@@ -2857,6 +2859,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         // Don't call nextToken again.
                     }
                 case TOK.in_:
+                    if (transitionIn)
+                        eSink.message(scanloc, "Usage of 'in' on parameter");
                     stc = STC.in_;
                     goto L2;
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -4756,6 +4756,7 @@ private Statements* flatten(Statement statement, Scope* sc)
             buf.writeByte(0);
             const str = buf.extractSlice()[0 .. len];
             scope p = new Parser!ASTCodegen(cs.loc, sc._module, str, false, global.errorSink, &global.compileEnv);
+            p.transitionIn = global.params.vin;
             p.nextToken();
 
             auto a = new Statements();

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1119,9 +1119,6 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
                 fparam.type = fparam.type.addStorageClass(fparam.storageClass);
 
-                if (global.params.vin && fparam.storageClass & STC.in_)
-                    message(loc, "Usage of 'in' on parameter");
-
                 if (fparam.storageClass & (STC.auto_ | STC.alias_ | STC.static_))
                 {
                     if (!fparam.type)
@@ -4934,6 +4931,7 @@ RootObject compileTypeMixin(TypeMixin tm, Loc loc, Scope* sc)
     buf.writeByte(0);
     const str = buf.extractSlice()[0 .. len];
     scope p = new Parser!ASTCodegen(loc, sc._module, str, false, global.errorSink, &global.compileEnv);
+    p.transitionIn = global.params.vin;
     p.nextToken();
     //printf("p.loc.linnum = %d\n", p.loc.linnum);
 

--- a/compiler/test/compilable/transition_in.d
+++ b/compiler/test/compilable/transition_in.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 ---
 compilable/transition_in.d(3): Usage of 'in' on parameter
 compilable/transition_in.d(3): Usage of 'in' on parameter
-compilable/transition_in.d(13): Usage of 'in' on parameter
+compilable/transition_in.d(8): Usage of 'in' on parameter
 compilable/transition_in.d(13): Usage of 'in' on parameter
 ---
 */


### PR DESCRIPTION
Restore the behavior of `-transition=in` after https://github.com/dlang/dmd/pull/14957 by adding `message` to `ErrorSink` and passing `global.params.vin` 'through the front door'.  No imports are added.