### PR TITLE
convert C imaginary numbers to core.stdc.config.c_complex_double

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -738,7 +738,7 @@ extern (C++) final class AliasDeclaration : Declaration
     extern (D) this(const ref Loc loc, Identifier ident, Type type)
     {
         super(loc, ident);
-        //printf("AliasDeclaration(id = '%s', type = %p)\n", id.toChars(), type);
+        //printf("AliasDeclaration(id = '%s', type = %p)\n", ident.toChars(), type);
         //printf("type = '%s'\n", type.toChars());
         this.type = type;
         assert(type);
@@ -747,7 +747,7 @@ extern (C++) final class AliasDeclaration : Declaration
     extern (D) this(const ref Loc loc, Identifier ident, Dsymbol s)
     {
         super(loc, ident);
-        //printf("AliasDeclaration(id = '%s', s = %p)\n", id.toChars(), s);
+        //printf("AliasDeclaration(id = '%s', s = %p)\n", ident.toChars(), s);
         assert(s != this);
         this.aliassym = s;
         assert(s);

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1286,6 +1286,20 @@ extern (C++) final class Module : Package
     }
 
     /****************************
+     * A Singleton that loads core.stdc.config
+     * Returns:
+     *  Module of core.atomic, null if couldn't find it
+     */
+    extern (D) static Module loadCoreStdcConfig()
+    {
+        __gshared Module core_stdc_config;
+        auto pkgids = new Identifier[2];
+        pkgids[0] = Id.core;
+        pkgids[1] = Id.stdc;
+        return loadModuleFromLibrary(core_stdc_config, pkgids, Id.config);
+    }
+
+    /****************************
      * A Singleton that loads core.atomic
      * Returns:
      *  Module of core.atomic, null if couldn't find it
@@ -1293,7 +1307,9 @@ extern (C++) final class Module : Package
     extern (D) static Module loadCoreAtomic()
     {
         __gshared Module core_atomic;
-        return loadModuleFromLibrary(core_atomic, Id.core, Id.atomic);
+        auto pkgids = new Identifier[1];
+        pkgids[0] = Id.core;
+        return loadModuleFromLibrary(core_atomic, pkgids, Id.atomic);
     }
 
     /****************************
@@ -1304,26 +1320,26 @@ extern (C++) final class Module : Package
     extern (D) static Module loadStdMath()
     {
         __gshared Module std_math;
-        return loadModuleFromLibrary(std_math, Id.std, Id.math);
+        auto pkgids = new Identifier[1];
+        pkgids[0] = Id.std;
+        return loadModuleFromLibrary(std_math, pkgids, Id.math);
     }
 
     /**********************************
      * Load a Module from the library.
      * Params:
      *  mod = cached return value of this call
-     *  pkgid = package id
+     *  pkgids = package identifiers
      *  modid = module id
      * Returns:
      *  Module loaded, null if cannot load it
      */
-    private static Module loadModuleFromLibrary(ref Module mod, Identifier pkgid, Identifier modid)
+    extern (D) private static Module loadModuleFromLibrary(ref Module mod, Identifier[] pkgids, Identifier modid)
     {
         if (mod)
             return mod;
 
-        auto ids = new Identifier[1];
-        ids[0] = pkgid;
-        auto imp = new Import(Loc.initial, ids[], modid, null, true);
+        auto imp = new Import(Loc.initial, pkgids[], modid, null, true);
         // Module.load will call fatal() if there's no module available.
         // Gag the error here, pushing the error handling to the caller.
         const errors = global.startGagging();

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1288,7 +1288,7 @@ extern (C++) final class Module : Package
     /****************************
      * A Singleton that loads core.stdc.config
      * Returns:
-     *  Module of core.atomic, null if couldn't find it
+     *  Module of core.stdc.config, null if couldn't find it
      */
     extern (D) static Module loadCoreStdcConfig()
     {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8684,6 +8684,10 @@ struct Id final
     static Identifier* va_start;
     static Identifier* std;
     static Identifier* core;
+    static Identifier* config;
+    static Identifier* c_complex_float;
+    static Identifier* c_complex_double;
+    static Identifier* c_complex_real;
     static Identifier* etc;
     static Identifier* attribute;
     static Identifier* atomic;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -370,6 +370,10 @@ immutable Msgtable[] msgtable =
     // Builtin functions
     { "std" },
     { "core" },
+    { "config" },
+    { "c_complex_float" },
+    { "c_complex_double" },
+    { "c_complex_real" },
     { "etc" },
     { "attribute" },
     { "atomic" },

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -456,6 +456,27 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         return t.merge();
     }
 
+    Type visitComplex64(TypeBasic t)
+    {
+        if (!(sc.flags & SCOPE.Cfile))
+            return visitType(t);
+
+        /* Convert to core.stdc.config.complex
+         */
+        Module mConfig = Module.loadCoreStdcConfig();
+        if (!mConfig)
+        {
+            .error(loc, "`%s` requires `core.stdc.config` for complex numbers", t.toChars());
+            return error();
+        }
+
+        Dsymbol s = mConfig.searchX(Loc.initial, sc, Id.c_complex_double, IgnorePrivateImports);
+        s = s.toAlias();
+        AliasDeclaration ad = s.isAliasDeclaration();
+        TypeStruct ts = ad.getType().toBasetype().isTypeStruct();
+        return ts.merge();
+    }
+
     Type visitVector(TypeVector mtype)
     {
         const errors = global.errors;
@@ -1943,6 +1964,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
     switch (type.ty)
     {
         default:         return visitType(type);
+        case Tcomplex64: return visitComplex64(type.isTypeBasic());
         case Tvector:    return visitVector(type.isTypeVector());
         case Tsarray:    return visitSArray(type.isTypeSArray());
         case Tarray:     return visitDArray(type.isTypeDArray());

--- a/compiler/test/compilable/testcomplex.i
+++ b/compiler/test/compilable/testcomplex.i
@@ -2,11 +2,13 @@
 /* GCC header complex.h requires supporting `i` suffix extension
  */
 
+/*
 _Complex float testf()
 {
     _Complex float x = 1.0if;
     return x;
 }
+*/
 
 _Complex double testd()
 {
@@ -14,8 +16,10 @@ _Complex double testd()
     return x;
 }
 
+/*
 _Complex long double testld()
 {
     _Complex long double x = 1.0iL;
     return x;
 }
+*/


### PR DESCRIPTION
As I mentioned https://github.com/dlang/dmd/pull/14902#issuecomment-1459796238, this converts C complex numbers to `core.stdc.config.c_complex_double`. It's a proof of concept demonstrating the viability of this approach, rather than supporting complex numbers explicitly in D.

Being proof of concept, it's incomplete, although it generates the correct code for the test case. What's needed:

1. only supports `_Complex double`
2. _Complex!double needs operator overloading
3. pretty much no error checking
4. should cache the conversions
5. should move `_Complex!T` into `core.stdc.complex`

I considered `std.complex`, but it requires too much of Phobos to be usable for this. Besides, `_Complex!T` already existed in druntime (where it should be) but it's in the wrong module.