### PR TITLE
recognize if(not __ctfe)

### DIFF
--- a/compiler/test/fail_compilation/ctfeblock.d
+++ b/compiler/test/fail_compilation/ctfeblock.d
@@ -42,4 +42,3 @@ L1:
         int* p = new int;
     }
 }
-

--- a/compiler/test/fail_compilation/ctfeblock.d
+++ b/compiler/test/fail_compilation/ctfeblock.d
@@ -19,7 +19,7 @@ struct T { }
     {
 L1:
         new T();
-	a = 3;
+        a = 3;
     }
     goto L1;
 }
@@ -31,3 +31,15 @@ L1:
         new T();
     }
 }
+
+@nogc void test3()
+{
+    if (!__ctfe)
+    {
+    }
+    else
+    {
+        int* p = new int;
+    }
+}
+


### PR DESCRIPTION
I noticed that druntime and Phobos had many uses of `if (!__ctfe)` and realized that could be trivially supported by swapping the "arms" of the `if`.