### PR TITLE
Add a `lowering` field for AssignExp to store potential lowerings

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -4848,25 +4848,6 @@ public:
                     result = CTFEExp.voidexp;
                 return;
             }
-            else if (fd.ident == Id._d_arraysetlengthT)
-            {
-                // In expressionsem.d `ea.length = eb;` got lowered to `_d_arraysetlengthT(ea, eb);`.
-                // The following code will rewrite it back to `ea.length = eb` and then interpret that expression.
-                assert(e.arguments.length == 2);
-
-                Expression ea = (*e.arguments)[0];
-                Expression eb = (*e.arguments)[1];
-
-                auto ale = ctfeEmplaceExp!ArrayLengthExp(e.loc, ea);
-                ale.type = Type.tsize_t;
-                AssignExp ae = ctfeEmplaceExp!AssignExp(e.loc, ale, eb);
-                ae.type = ea.type;
-
-                // if (global.params.verbose)
-                //     message("interpret  %s =>\n          %s", e.toChars(), ae.toChars());
-                result = interpretRegion(ae, istate);
-                return;
-            }
             else if (isArrayConstructionOrAssign(fd.ident))
             {
                 // In expressionsem.d, the following lowerings were performed:

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -2241,10 +2241,7 @@ elem* toElem(Expression e, IRState *irs)
         // Look for array.length = n
         if (auto ale = ae.e1.isArrayLengthExp())
         {
-            if (!ae.lowering)
-                assert(0, "This case should have been rewritten to `_d_arraysetlengthT` in the semantic phase");
-
-            return setResult(toElem(ae.lowering, irs));
+            assert(0, "This case should have been rewritten to `_d_arraysetlengthT` in the semantic phase");
         }
 
         // Look for array[]=n
@@ -2776,6 +2773,11 @@ elem* toElem(Expression e, IRState *irs)
             return setResult2(e);
         }
         assert(0);
+    }
+
+    elem* visitLoweredAssign(LoweredAssignExp e)
+    {
+        return toElem(e.lowering, irs);
     }
 
     /***************************************
@@ -4167,6 +4169,7 @@ elem* toElem(Expression e, IRState *irs)
         case EXP.assign:        return visitAssign(e.isAssignExp());
         case EXP.construct:     return visitAssign(e.isConstructExp());
         case EXP.blit:          return visitAssign(e.isBlitExp());
+        case EXP.loweredAssignExp: return visitLoweredAssign(e.isLoweredAssignExp());
         case EXP.addAssign:     return visitAddAssign(e.isAddAssignExp());
         case EXP.minAssign:     return visitMinAssign(e.isMinAssignExp());
         case EXP.concatenateDcharAssign: return visitCatAssign(e.isCatDcharAssignExp());

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -2241,7 +2241,10 @@ elem* toElem(Expression e, IRState *irs)
         // Look for array.length = n
         if (auto ale = ae.e1.isArrayLengthExp())
         {
-            assert(0, "This case should have been rewritten to `_d_arraysetlengthT` in the semantic phase");
+            if (!ae.lowering)
+                assert(0, "This case should have been rewritten to `_d_arraysetlengthT` in the semantic phase");
+
+            return setResult(toElem(ae.lowering, irs));
         }
 
         // Look for array[]=n

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -6123,6 +6123,7 @@ enum MemorySet
 extern (C++) class AssignExp : BinExp
 {
     MemorySet memset;
+    Expression lowering;
 
     /************************************************************/
     /* op can be EXP.assign, EXP.construct, or EXP.blit */

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -38,6 +38,7 @@ class TemplateDeclaration;
 class ClassDeclaration;
 class OverloadSet;
 class StringExp;
+class LoweredAssignExp;
 struct UnionExp;
 #ifdef IN_GCC
 typedef union tree_node Symbol;
@@ -240,6 +241,7 @@ public:
     UnaExp* isUnaExp();
     BinExp* isBinExp();
     BinAssignExp* isBinAssignExp();
+    LoweredAssignExp* isLoweredAssignExp();
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -1069,7 +1071,6 @@ class AssignExp : public BinExp
 {
 public:
     MemorySet memset;
-    Expression *lowering;
 
     bool isLvalue() override final;
     Expression *toLvalue(Scope *sc, Expression *ex) override final;
@@ -1080,6 +1081,15 @@ public:
 class ConstructExp final : public AssignExp
 {
 public:
+    void accept(Visitor *v) override { v->visit(this); }
+};
+
+class LoweredAssignExp final : public AssignExp
+{
+public:
+    Expression *lowering;
+
+    const char *toChars() const override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -1069,6 +1069,7 @@ class AssignExp : public BinExp
 {
 public:
     MemorySet memset;
+    Expression *lowering;
 
     bool isLvalue() override final;
     Expression *toLvalue(Scope *sc, Expression *ex) override final;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9829,10 +9829,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             arguments.push(exp.e2);
 
             Expression ce = new CallExp(ale.loc, id, arguments);
-            auto res = ce.expressionSemantic(sc);
+            exp.lowering = ce.expressionSemantic(sc);
             // if (global.params.verbose)
             //     message("lowered   %s =>\n          %s", exp.toChars(), res.toChars());
-            return setResult(res);
+            exp.type = Type.tsize_t;
+            return setResult(exp);
         }
         else if (auto se = exp.e1.isSliceExp())
         {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9828,12 +9828,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             arguments.push(ale.e1);
             arguments.push(exp.e2);
 
-            Expression ce = new CallExp(ale.loc, id, arguments);
-            exp.lowering = ce.expressionSemantic(sc);
+            Expression ce = new CallExp(ale.loc, id, arguments).expressionSemantic(sc);
+            auto res = new LoweredAssignExp(exp, ce);
             // if (global.params.verbose)
             //     message("lowered   %s =>\n          %s", exp.toChars(), res.toChars());
-            exp.type = Type.tsize_t;
-            return setResult(exp);
+            res.type = Type.tsize_t;
+            return setResult(res);
         }
         else if (auto se = exp.e1.isSliceExp())
         {
@@ -13940,6 +13940,7 @@ Expression toBoolean(Expression exp, Scope* sc)
         case EXP.assign:
         case EXP.construct:
         case EXP.blit:
+        case EXP.loweredAssignExp:
             if (sc.flags & SCOPE.Cfile)
                 return exp;
             // Things like:

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -181,6 +181,7 @@ class IndexExp;
 class PostExp;
 class PreExp;
 class AssignExp;
+class LoweredAssignExp;
 class ConstructExp;
 class BlitExp;
 class AddAssignExp;
@@ -924,6 +925,7 @@ enum class EXP : uint8_t
     compoundLiteral = 123u,
     _Generic = 124u,
     interval = 125u,
+    loweredAssignExp = 126u,
 };
 
 typedef uint64_t dinteger_t;
@@ -1069,6 +1071,7 @@ public:
     PostExp* isPostExp();
     PreExp* isPreExp();
     AssignExp* isAssignExp();
+    LoweredAssignExp* isLoweredAssignExp();
     ConstructExp* isConstructExp();
     BlitExp* isBlitExp();
     AddAssignExp* isAddAssignExp();
@@ -4937,6 +4940,7 @@ struct ASTCodegen final
     using IsExp = ::IsExp;
     using LineInitExp = ::LineInitExp;
     using LogicalExp = ::LogicalExp;
+    using LoweredAssignExp = ::LoweredAssignExp;
     using MemorySet = ::MemorySet;
     using MinAssignExp = ::MinAssignExp;
     using MinExp = ::MinExp;
@@ -5199,6 +5203,7 @@ public:
     virtual void visit(ClassReferenceExp* e);
     virtual void visit(VoidInitExp* e);
     virtual void visit(ThrownExceptionExp* e);
+    virtual void visit(LoweredAssignExp* e);
 };
 
 class StoppableVisitor : public Visitor
@@ -7715,10 +7720,17 @@ class AssignExp : public BinExp
 {
 public:
     MemorySet memset;
-    Expression* lowering;
     AssignExp(const Loc& loc, EXP tok, Expression* e1, Expression* e2);
     bool isLvalue() final override;
     Expression* toLvalue(Scope* sc, Expression* ex) final override;
+    void accept(Visitor* v) override;
+};
+
+class LoweredAssignExp final : public AssignExp
+{
+public:
+    Expression* lowering;
+    const char* toChars() const override;
     void accept(Visitor* v) override;
 };
 
@@ -8403,6 +8415,7 @@ public:
     void visit(DotExp* e) override;
     void visit(IndexExp* e) override;
     void visit(RemoveExp* e) override;
+    void visit(LoweredAssignExp* e) override;
 };
 
 extern _d_real creall(complex_t x);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7715,6 +7715,7 @@ class AssignExp : public BinExp
 {
 public:
     MemorySet memset;
+    Expression* lowering;
     AssignExp(const Loc& loc, EXP tok, Expression* e1, Expression* e2);
     bool isLvalue() final override;
     Expression* toLvalue(Scope* sc, Expression* ex) final override;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2310,6 +2310,15 @@ private void expressionPrettyPrint(Expression e, OutBuffer* buf, HdrGenState* hg
 
     void visitBin(BinExp e)
     {
+        if (auto ae = e.isAssignExp())
+        {
+            if (ae.lowering && global.params.vcg_ast)
+            {
+                expressionToBuffer(ae.lowering, buf, hgs);
+                return;
+            }
+        }
+
         expToBuffer(e.e1, precedence[e.op], buf, hgs);
         buf.writeByte(' ');
         buf.writestring(EXPtoString(e.op));

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2308,17 +2308,18 @@ private void expressionPrettyPrint(Expression e, OutBuffer* buf, HdrGenState* hg
         expToBuffer(e.e1, precedence[e.op], buf, hgs);
     }
 
-    void visitBin(BinExp e)
+    void visitLoweredAssignExp(LoweredAssignExp e)
     {
-        if (auto ae = e.isAssignExp())
+        if (global.params.vcg_ast)
         {
-            if (ae.lowering && global.params.vcg_ast)
-            {
-                expressionToBuffer(ae.lowering, buf, hgs);
-                return;
-            }
+            expressionToBuffer(e.lowering, buf, hgs);
+            return;
         }
 
+        visit(cast(BinExp)e);
+    }
+    void visitBin(BinExp e)
+    {
         expToBuffer(e.e1, precedence[e.op], buf, hgs);
         buf.writeByte(' ');
         buf.writestring(EXPtoString(e.op));
@@ -2690,6 +2691,7 @@ private void expressionPrettyPrint(Expression e, OutBuffer* buf, HdrGenState* hg
         case EXP.remove:        return visitRemove(e.isRemoveExp());
         case EXP.question:      return visitCond(e.isCondExp());
         case EXP.classReference:        return visitClassReference(e.isClassReferenceExp());
+        case EXP.loweredAssignExp:      return visitLoweredAssignExp(e.isLoweredAssignExp());
     }
 }
 
@@ -4218,6 +4220,7 @@ string EXPtoString(EXP op)
         EXP.declaration : "declaration",
 
         EXP.interval : "interval",
+        EXP.loweredAssignExp : "="
     ];
     const p = strings[op];
     if (!p)

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -765,12 +765,12 @@ public:
 
         override void visit(AssignExp e)
         {
-            if (e.lowering)
-            {
-                result = doInlineAs!Expression(e.lowering, ids);
-                return;
-            }
             visit(cast(BinExp)e);
+        }
+
+        override void visit(LoweredAssignExp e)
+        {
+            result = doInlineAs!Expression(e.lowering, ids);
         }
 
         override void visit(EqualExp e)
@@ -1249,11 +1249,6 @@ public:
 
     override void visit(AssignExp e)
     {
-        if (e.lowering)
-        {
-            inlineScan(e.lowering);
-            return;
-        }
         // Look for NRVO, as inlining NRVO function returns require special handling
         if (e.op == EXP.construct && e.e2.op == EXP.call)
         {
@@ -1288,6 +1283,11 @@ public:
         }
     L1:
         visit(cast(BinExp)e);
+    }
+
+    override void visit(LoweredAssignExp e)
+    {
+        inlineScan(e.lowering);
     }
 
     override void visit(CallExp e)

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -765,13 +765,12 @@ public:
 
         override void visit(AssignExp e)
         {
-            visit(cast(BinExp)e);
-
-            if (auto ale = e.e1.isArrayLengthExp())
+            if (e.lowering)
             {
-                Type tn = ale.e1.type.toBasetype().nextOf();
-                semanticTypeInfo(null, tn);
+                result = doInlineAs!Expression(e.lowering, ids);
+                return;
             }
+            visit(cast(BinExp)e);
         }
 
         override void visit(EqualExp e)
@@ -1250,6 +1249,11 @@ public:
 
     override void visit(AssignExp e)
     {
+        if (e.lowering)
+        {
+            inlineScan(e.lowering);
+            return;
+        }
         // Look for NRVO, as inlining NRVO function returns require special handling
         if (e.op == EXP.construct && e.e2.op == EXP.call)
         {

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -185,6 +185,7 @@ private bool lambdaHasSideEffect(Expression e, bool assumeImpureCalls = false)
     case EXP.delete_:
     case EXP.new_:
     case EXP.newAnonymousClass:
+    case EXP.loweredAssignExp:
         return true;
     case EXP.call:
         {

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -419,6 +419,8 @@ enum EXP : ubyte
     compoundLiteral, // ( type-name ) { initializer-list }
     _Generic,
     interval,
+
+    loweredAssignExp,
 }
 
 enum FirstCKeyword = TOK.inline;

--- a/compiler/src/dmd/visitor.d
+++ b/compiler/src/dmd/visitor.d
@@ -89,6 +89,7 @@ public:
     void visit(ASTCodegen.ClassReferenceExp e) { visit(cast(ASTCodegen.Expression)e); }
     void visit(ASTCodegen.VoidInitExp e) { visit(cast(ASTCodegen.Expression)e); }
     void visit(ASTCodegen.ThrownExceptionExp e) { visit(cast(ASTCodegen.Expression)e); }
+    void visit(ASTCodegen.LoweredAssignExp e) { visit(cast(ASTCodegen.AssignExp)e); }
 }
 
 /**
@@ -239,6 +240,12 @@ extern (C++) class SemanticTimeTransitiveVisitor : SemanticTimePermissiveVisitor
     {
         e.e1.accept(this);
         e.e2.accept(this);
+    }
+
+    override void visit(ASTCodegen.LoweredAssignExp e)
+    {
+        e.lowering.accept(this);
+        visit(cast(AssignExp)e);
     }
 }
 

--- a/compiler/test/fail_compilation/fail23773.d
+++ b/compiler/test/fail_compilation/fail23773.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=23773
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23773.d(14): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+---
+*/
+
+void main()
+{
+    int i;
+    int[] arr;
+    assert(arr.length = i);
+}


### PR DESCRIPTION
This PR does the  following:

- ~add a field, `lowering` to `AssignExp` to store the potential lowerings that are done in the frontend.~
- ~use `lowering` to lower array length expressions.~
- add a new AST node `LoweredAssignExp` that inherits from AssignExp and adds a `lowering` field.
- use the new AST node to handle lowerings to array length expressions.
- delete the code in dinterpret that recreates the initial assign expression.
- update `inline.d` to inline the call to the lowering, not the AssignExp since that avoids extra copies.
- update `hdrgen.d` so that if the switch `-vcg-ast` is used we will print the call to the hook not the initial AssignExp. For code that does not use `-vcg-ast` the AssignExp is printed.
- update C++ headers
- fix Issue 23773

cc @WalterBright as this is in line with your work of not generating the hook if in ctfe blocks
cc @teodutu - this needs to be done for all previously implemented templated hooks.