### PR TITLE
Fix 23781: Segmentation fault on taking the address of a ref return at CTFE

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -2036,7 +2036,7 @@ public:
         }
         auto er = interpret(e.e1, istate, CTFEGoal.LValue);
         if (auto ve = er.isVarExp())
-            if (ve.var == istate.fd.vthis)
+            if (istate && ve.var == istate.fd.vthis)
                 er = interpret(er, istate);
 
         if (exceptionOrCant(er))

--- a/compiler/test/fail_compilation/ice23781.d
+++ b/compiler/test/fail_compilation/ice23781.d
@@ -1,0 +1,10 @@
+/**
+TEST_OUTPUT:
+---
+fail_compilation/ice23781.d(10): Error: variable `b` cannot be read at compile time
+---
+**/
+struct Bar { int i; }
+ref const(Bar) func1 (const return ref Bar b) { return b; }
+immutable E1 = Bar();
+enum E2 = &E1.func1();


### PR DESCRIPTION
We don't handle `CommaExp` well in CTFE and that's one of the consequences.