### PR TITLE
Add Zephyr version identifier

### DIFF
--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -741,6 +741,7 @@ extern (C++) final class VersionCondition : DVCondition
             case "Windows":
             case "X86":
             case "X86_64":
+            case "Zephyr":
                 return true;
 
             default:

--- a/compiler/test/fail_compilation/reserved_version.d
+++ b/compiler/test/fail_compilation/reserved_version.d
@@ -34,90 +34,91 @@ fail_compilation/reserved_version.d(133): Error: version identifier `PlayStation
 fail_compilation/reserved_version.d(134): Error: version identifier `PlayStation4` is reserved and cannot be set
 fail_compilation/reserved_version.d(135): Error: version identifier `Cygwin` is reserved and cannot be set
 fail_compilation/reserved_version.d(136): Error: version identifier `MinGW` is reserved and cannot be set
-fail_compilation/reserved_version.d(137): Error: version identifier `FreeStanding` is reserved and cannot be set
-fail_compilation/reserved_version.d(138): Error: version identifier `X86` is reserved and cannot be set
-fail_compilation/reserved_version.d(139): Error: version identifier `X86_64` is reserved and cannot be set
-fail_compilation/reserved_version.d(140): Error: version identifier `ARM` is reserved and cannot be set
-fail_compilation/reserved_version.d(141): Error: version identifier `ARM_Thumb` is reserved and cannot be set
-fail_compilation/reserved_version.d(142): Error: version identifier `ARM_SoftFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(143): Error: version identifier `ARM_SoftFP` is reserved and cannot be set
-fail_compilation/reserved_version.d(144): Error: version identifier `ARM_HardFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(145): Error: version identifier `AArch64` is reserved and cannot be set
-fail_compilation/reserved_version.d(146): Error: version identifier `Epiphany` is reserved and cannot be set
-fail_compilation/reserved_version.d(147): Error: version identifier `PPC` is reserved and cannot be set
-fail_compilation/reserved_version.d(148): Error: version identifier `PPC_SoftFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(149): Error: version identifier `PPC_HardFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(150): Error: version identifier `PPC64` is reserved and cannot be set
-fail_compilation/reserved_version.d(151): Error: version identifier `IA64` is reserved and cannot be set
-fail_compilation/reserved_version.d(152): Error: version identifier `MIPS32` is reserved and cannot be set
-fail_compilation/reserved_version.d(153): Error: version identifier `MIPS64` is reserved and cannot be set
-fail_compilation/reserved_version.d(154): Error: version identifier `MIPS_O32` is reserved and cannot be set
-fail_compilation/reserved_version.d(155): Error: version identifier `MIPS_N32` is reserved and cannot be set
-fail_compilation/reserved_version.d(156): Error: version identifier `MIPS_O64` is reserved and cannot be set
-fail_compilation/reserved_version.d(157): Error: version identifier `MIPS_N64` is reserved and cannot be set
-fail_compilation/reserved_version.d(158): Error: version identifier `MIPS_EABI` is reserved and cannot be set
-fail_compilation/reserved_version.d(159): Error: version identifier `MIPS_SoftFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(160): Error: version identifier `MIPS_HardFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(161): Error: version identifier `NVPTX` is reserved and cannot be set
-fail_compilation/reserved_version.d(162): Error: version identifier `NVPTX64` is reserved and cannot be set
-fail_compilation/reserved_version.d(163): Error: version identifier `RISCV32` is reserved and cannot be set
-fail_compilation/reserved_version.d(164): Error: version identifier `RISCV64` is reserved and cannot be set
-fail_compilation/reserved_version.d(165): Error: version identifier `SPARC` is reserved and cannot be set
-fail_compilation/reserved_version.d(166): Error: version identifier `SPARC_V8Plus` is reserved and cannot be set
-fail_compilation/reserved_version.d(167): Error: version identifier `SPARC_SoftFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(168): Error: version identifier `SPARC_HardFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(169): Error: version identifier `SPARC64` is reserved and cannot be set
-fail_compilation/reserved_version.d(170): Error: version identifier `S390` is reserved and cannot be set
-fail_compilation/reserved_version.d(171): Error: version identifier `S390X` is reserved and cannot be set
-fail_compilation/reserved_version.d(172): Error: version identifier `SystemZ` is reserved and cannot be set
-fail_compilation/reserved_version.d(173): Error: version identifier `HPPA` is reserved and cannot be set
-fail_compilation/reserved_version.d(174): Error: version identifier `HPPA64` is reserved and cannot be set
-fail_compilation/reserved_version.d(175): Error: version identifier `SH` is reserved and cannot be set
-fail_compilation/reserved_version.d(176): Error: version identifier `Alpha` is reserved and cannot be set
-fail_compilation/reserved_version.d(177): Error: version identifier `Alpha_SoftFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(178): Error: version identifier `Alpha_HardFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(179): Error: version identifier `LittleEndian` is reserved and cannot be set
-fail_compilation/reserved_version.d(180): Error: version identifier `BigEndian` is reserved and cannot be set
-fail_compilation/reserved_version.d(181): Error: version identifier `ELFv1` is reserved and cannot be set
-fail_compilation/reserved_version.d(182): Error: version identifier `ELFv2` is reserved and cannot be set
-fail_compilation/reserved_version.d(183): Error: version identifier `CRuntime_Bionic` is reserved and cannot be set
-fail_compilation/reserved_version.d(184): Error: version identifier `CRuntime_DigitalMars` is reserved and cannot be set
-fail_compilation/reserved_version.d(185): Error: version identifier `CRuntime_Glibc` is reserved and cannot be set
-fail_compilation/reserved_version.d(186): Error: version identifier `CRuntime_Microsoft` is reserved and cannot be set
-fail_compilation/reserved_version.d(187): Error: version identifier `CRuntime_Musl` is reserved and cannot be set
-fail_compilation/reserved_version.d(188): Error: version identifier `CRuntime_Newlib` is reserved and cannot be set
-fail_compilation/reserved_version.d(189): Error: version identifier `CRuntime_UClibc` is reserved and cannot be set
-fail_compilation/reserved_version.d(190): Error: version identifier `CRuntime_WASI` is reserved and cannot be set
-fail_compilation/reserved_version.d(191): Error: version identifier `D_Coverage` is reserved and cannot be set
-fail_compilation/reserved_version.d(192): Error: version identifier `D_Ddoc` is reserved and cannot be set
-fail_compilation/reserved_version.d(193): Error: version identifier `D_InlineAsm_X86` is reserved and cannot be set
-fail_compilation/reserved_version.d(194): Error: version identifier `D_InlineAsm_X86_64` is reserved and cannot be set
-fail_compilation/reserved_version.d(195): Error: version identifier `D_LP64` is reserved and cannot be set
-fail_compilation/reserved_version.d(196): Error: version identifier `D_X32` is reserved and cannot be set
-fail_compilation/reserved_version.d(197): Error: version identifier `D_HardFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(198): Error: version identifier `D_SoftFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(199): Error: version identifier `D_PIC` is reserved and cannot be set
-fail_compilation/reserved_version.d(200): Error: version identifier `D_SIMD` is reserved and cannot be set
-fail_compilation/reserved_version.d(201): Error: version identifier `D_Version2` is reserved and cannot be set
-fail_compilation/reserved_version.d(202): Error: version identifier `D_NoBoundsChecks` is reserved and cannot be set
-fail_compilation/reserved_version.d(205): Error: version identifier `all` is reserved and cannot be set
-fail_compilation/reserved_version.d(206): Error: version identifier `none` is reserved and cannot be set
-fail_compilation/reserved_version.d(207): Error: version identifier `AsmJS` is reserved and cannot be set
-fail_compilation/reserved_version.d(208): Error: version identifier `Emscripten` is reserved and cannot be set
-fail_compilation/reserved_version.d(209): Error: version identifier `WebAssembly` is reserved and cannot be set
-fail_compilation/reserved_version.d(210): Error: version identifier `WASI` is reserved and cannot be set
-fail_compilation/reserved_version.d(211): Error: version identifier `CppRuntime_Clang` is reserved and cannot be set
-fail_compilation/reserved_version.d(212): Error: version identifier `CppRuntime_DigitalMars` is reserved and cannot be set
-fail_compilation/reserved_version.d(213): Error: version identifier `CppRuntime_Gcc` is reserved and cannot be set
-fail_compilation/reserved_version.d(214): Error: version identifier `CppRuntime_Microsoft` is reserved and cannot be set
-fail_compilation/reserved_version.d(215): Error: version identifier `CppRuntime_Sun` is reserved and cannot be set
-fail_compilation/reserved_version.d(216): Error: version identifier `D_PIE` is reserved and cannot be set
-fail_compilation/reserved_version.d(217): Error: version identifier `AVR` is reserved and cannot be set
-fail_compilation/reserved_version.d(218): Error: version identifier `D_PreConditions` is reserved and cannot be set
-fail_compilation/reserved_version.d(219): Error: version identifier `D_PostConditions` is reserved and cannot be set
-fail_compilation/reserved_version.d(220): Error: version identifier `D_ProfileGC` is reserved and cannot be set
-fail_compilation/reserved_version.d(221): Error: version identifier `D_Invariants` is reserved and cannot be set
-fail_compilation/reserved_version.d(222): Error: version identifier `D_Optimized` is reserved and cannot be set
+fail_compilation/reserved_version.d(137): Error: version identifier `Zephyr` is reserved and cannot be set
+fail_compilation/reserved_version.d(138): Error: version identifier `FreeStanding` is reserved and cannot be set
+fail_compilation/reserved_version.d(139): Error: version identifier `X86` is reserved and cannot be set
+fail_compilation/reserved_version.d(140): Error: version identifier `X86_64` is reserved and cannot be set
+fail_compilation/reserved_version.d(141): Error: version identifier `ARM` is reserved and cannot be set
+fail_compilation/reserved_version.d(142): Error: version identifier `ARM_Thumb` is reserved and cannot be set
+fail_compilation/reserved_version.d(143): Error: version identifier `ARM_SoftFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(144): Error: version identifier `ARM_SoftFP` is reserved and cannot be set
+fail_compilation/reserved_version.d(145): Error: version identifier `ARM_HardFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(146): Error: version identifier `AArch64` is reserved and cannot be set
+fail_compilation/reserved_version.d(147): Error: version identifier `Epiphany` is reserved and cannot be set
+fail_compilation/reserved_version.d(148): Error: version identifier `PPC` is reserved and cannot be set
+fail_compilation/reserved_version.d(149): Error: version identifier `PPC_SoftFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(150): Error: version identifier `PPC_HardFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(151): Error: version identifier `PPC64` is reserved and cannot be set
+fail_compilation/reserved_version.d(152): Error: version identifier `IA64` is reserved and cannot be set
+fail_compilation/reserved_version.d(153): Error: version identifier `MIPS32` is reserved and cannot be set
+fail_compilation/reserved_version.d(154): Error: version identifier `MIPS64` is reserved and cannot be set
+fail_compilation/reserved_version.d(155): Error: version identifier `MIPS_O32` is reserved and cannot be set
+fail_compilation/reserved_version.d(156): Error: version identifier `MIPS_N32` is reserved and cannot be set
+fail_compilation/reserved_version.d(157): Error: version identifier `MIPS_O64` is reserved and cannot be set
+fail_compilation/reserved_version.d(158): Error: version identifier `MIPS_N64` is reserved and cannot be set
+fail_compilation/reserved_version.d(159): Error: version identifier `MIPS_EABI` is reserved and cannot be set
+fail_compilation/reserved_version.d(160): Error: version identifier `MIPS_SoftFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(161): Error: version identifier `MIPS_HardFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(162): Error: version identifier `NVPTX` is reserved and cannot be set
+fail_compilation/reserved_version.d(163): Error: version identifier `NVPTX64` is reserved and cannot be set
+fail_compilation/reserved_version.d(164): Error: version identifier `RISCV32` is reserved and cannot be set
+fail_compilation/reserved_version.d(165): Error: version identifier `RISCV64` is reserved and cannot be set
+fail_compilation/reserved_version.d(166): Error: version identifier `SPARC` is reserved and cannot be set
+fail_compilation/reserved_version.d(167): Error: version identifier `SPARC_V8Plus` is reserved and cannot be set
+fail_compilation/reserved_version.d(168): Error: version identifier `SPARC_SoftFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(169): Error: version identifier `SPARC_HardFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(170): Error: version identifier `SPARC64` is reserved and cannot be set
+fail_compilation/reserved_version.d(171): Error: version identifier `S390` is reserved and cannot be set
+fail_compilation/reserved_version.d(172): Error: version identifier `S390X` is reserved and cannot be set
+fail_compilation/reserved_version.d(173): Error: version identifier `SystemZ` is reserved and cannot be set
+fail_compilation/reserved_version.d(174): Error: version identifier `HPPA` is reserved and cannot be set
+fail_compilation/reserved_version.d(175): Error: version identifier `HPPA64` is reserved and cannot be set
+fail_compilation/reserved_version.d(176): Error: version identifier `SH` is reserved and cannot be set
+fail_compilation/reserved_version.d(177): Error: version identifier `Alpha` is reserved and cannot be set
+fail_compilation/reserved_version.d(178): Error: version identifier `Alpha_SoftFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(179): Error: version identifier `Alpha_HardFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(180): Error: version identifier `LittleEndian` is reserved and cannot be set
+fail_compilation/reserved_version.d(181): Error: version identifier `BigEndian` is reserved and cannot be set
+fail_compilation/reserved_version.d(182): Error: version identifier `ELFv1` is reserved and cannot be set
+fail_compilation/reserved_version.d(183): Error: version identifier `ELFv2` is reserved and cannot be set
+fail_compilation/reserved_version.d(184): Error: version identifier `CRuntime_Bionic` is reserved and cannot be set
+fail_compilation/reserved_version.d(185): Error: version identifier `CRuntime_DigitalMars` is reserved and cannot be set
+fail_compilation/reserved_version.d(186): Error: version identifier `CRuntime_Glibc` is reserved and cannot be set
+fail_compilation/reserved_version.d(187): Error: version identifier `CRuntime_Microsoft` is reserved and cannot be set
+fail_compilation/reserved_version.d(188): Error: version identifier `CRuntime_Musl` is reserved and cannot be set
+fail_compilation/reserved_version.d(189): Error: version identifier `CRuntime_Newlib` is reserved and cannot be set
+fail_compilation/reserved_version.d(190): Error: version identifier `CRuntime_UClibc` is reserved and cannot be set
+fail_compilation/reserved_version.d(191): Error: version identifier `CRuntime_WASI` is reserved and cannot be set
+fail_compilation/reserved_version.d(192): Error: version identifier `D_Coverage` is reserved and cannot be set
+fail_compilation/reserved_version.d(193): Error: version identifier `D_Ddoc` is reserved and cannot be set
+fail_compilation/reserved_version.d(194): Error: version identifier `D_InlineAsm_X86` is reserved and cannot be set
+fail_compilation/reserved_version.d(195): Error: version identifier `D_InlineAsm_X86_64` is reserved and cannot be set
+fail_compilation/reserved_version.d(196): Error: version identifier `D_LP64` is reserved and cannot be set
+fail_compilation/reserved_version.d(197): Error: version identifier `D_X32` is reserved and cannot be set
+fail_compilation/reserved_version.d(198): Error: version identifier `D_HardFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(199): Error: version identifier `D_SoftFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(200): Error: version identifier `D_PIC` is reserved and cannot be set
+fail_compilation/reserved_version.d(201): Error: version identifier `D_SIMD` is reserved and cannot be set
+fail_compilation/reserved_version.d(202): Error: version identifier `D_Version2` is reserved and cannot be set
+fail_compilation/reserved_version.d(203): Error: version identifier `D_NoBoundsChecks` is reserved and cannot be set
+fail_compilation/reserved_version.d(206): Error: version identifier `all` is reserved and cannot be set
+fail_compilation/reserved_version.d(207): Error: version identifier `none` is reserved and cannot be set
+fail_compilation/reserved_version.d(208): Error: version identifier `AsmJS` is reserved and cannot be set
+fail_compilation/reserved_version.d(209): Error: version identifier `Emscripten` is reserved and cannot be set
+fail_compilation/reserved_version.d(210): Error: version identifier `WebAssembly` is reserved and cannot be set
+fail_compilation/reserved_version.d(211): Error: version identifier `WASI` is reserved and cannot be set
+fail_compilation/reserved_version.d(212): Error: version identifier `CppRuntime_Clang` is reserved and cannot be set
+fail_compilation/reserved_version.d(213): Error: version identifier `CppRuntime_DigitalMars` is reserved and cannot be set
+fail_compilation/reserved_version.d(214): Error: version identifier `CppRuntime_Gcc` is reserved and cannot be set
+fail_compilation/reserved_version.d(215): Error: version identifier `CppRuntime_Microsoft` is reserved and cannot be set
+fail_compilation/reserved_version.d(216): Error: version identifier `CppRuntime_Sun` is reserved and cannot be set
+fail_compilation/reserved_version.d(217): Error: version identifier `D_PIE` is reserved and cannot be set
+fail_compilation/reserved_version.d(218): Error: version identifier `AVR` is reserved and cannot be set
+fail_compilation/reserved_version.d(219): Error: version identifier `D_PreConditions` is reserved and cannot be set
+fail_compilation/reserved_version.d(220): Error: version identifier `D_PostConditions` is reserved and cannot be set
+fail_compilation/reserved_version.d(221): Error: version identifier `D_ProfileGC` is reserved and cannot be set
+fail_compilation/reserved_version.d(222): Error: version identifier `D_Invariants` is reserved and cannot be set
+fail_compilation/reserved_version.d(223): Error: version identifier `D_Optimized` is reserved and cannot be set
 ---
 */
 
@@ -156,6 +157,7 @@ version = PlayStation;
 version = PlayStation4;
 version = Cygwin;
 version = MinGW;
+version = Zephyr;
 version = FreeStanding;
 version = X86;
 version = X86_64;
@@ -269,6 +271,7 @@ debug = Hurd;
 debug = Android;
 debug = Cygwin;
 debug = MinGW;
+debug = Zephyr;
 debug = FreeStanding;
 debug = X86;
 debug = X86_64;

--- a/compiler/test/fail_compilation/reserved_version_switch.d
+++ b/compiler/test/fail_compilation/reserved_version_switch.d
@@ -25,6 +25,7 @@
 // REQUIRED_ARGS: -version=Android
 // REQUIRED_ARGS: -version=Cygwin
 // REQUIRED_ARGS: -version=MinGW
+// REQUIRED_ARGS: -version=Zephyr
 // REQUIRED_ARGS: -version=FreeStanding
 // REQUIRED_ARGS: -version=X86
 // REQUIRED_ARGS: -version=X86_64
@@ -133,6 +134,7 @@
 // REQUIRED_ARGS: -debug=Android
 // REQUIRED_ARGS: -debug=Cygwin
 // REQUIRED_ARGS: -debug=MinGW
+// REQUIRED_ARGS: -debug=Zephyr
 // REQUIRED_ARGS: -debug=FreeStanding
 // REQUIRED_ARGS: -debug=X86
 // REQUIRED_ARGS: -debug=X86_64
@@ -241,6 +243,7 @@ Error: version identifier `Hurd` is reserved and cannot be set
 Error: version identifier `Android` is reserved and cannot be set
 Error: version identifier `Cygwin` is reserved and cannot be set
 Error: version identifier `MinGW` is reserved and cannot be set
+Error: version identifier `Zephyr` is reserved and cannot be set
 Error: version identifier `FreeStanding` is reserved and cannot be set
 Error: version identifier `X86` is reserved and cannot be set
 Error: version identifier `X86_64` is reserved and cannot be set


### PR DESCRIPTION
Added Zephyr version identifier to support ZephyrOS

* Zephyr project: https://www.zephyrproject.org/

I'll open a corresponding dlang.org PR later