### PR TITLE
dmd.target: Remove stackAlign from C++ headers

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8137,7 +8137,6 @@ public:
     bool isCalleeDestroyingArgs(TypeFunction* tf);
     bool libraryObjectMonitors(FuncDeclaration* fd, Statement* fbody);
     bool supportsLinkerDirective() const;
-    uint32_t stackAlign();
     Target() :
         os((OS)1u),
         osMajor(0u),

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -1141,7 +1141,7 @@ extern (C++) struct Target
      * Returns:
      *  alignment of the stack
      */
-    extern (C++) uint stackAlign()
+    extern (D) uint stackAlign()
     {
         return isXmmSupported() ? 16 : (is64bit ? 8 : 4);
     }

--- a/compiler/src/dmd/target.h
+++ b/compiler/src/dmd/target.h
@@ -208,7 +208,6 @@ public:
     bool isCalleeDestroyingArgs(TypeFunction* tf);
     bool libraryObjectMonitors(FuncDeclaration *fd, Statement *fbody);
     bool supportsLinkerDirective() const;
-    unsigned stackAlign();
     void addPredefinedGlobalIdentifiers() const;
 };
 


### PR DESCRIPTION
This is not needed to be implemented by either GDC nor LDC.