### PR TITLE
dmd/declaration.h: Align header with D definition

### DIFF
--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -688,7 +688,7 @@ public:
     BaseClass *overrideInterface();
     bool overloadInsert(Dsymbol *s) override;
     bool inUnittest();
-    MATCH leastAsSpecialized(FuncDeclaration *g, Identifiers *names = nullptr);
+    MATCH leastAsSpecialized(FuncDeclaration *g, Identifiers *names);
     LabelDsymbol *searchLabel(Identifier *ident, const Loc &loc);
     int getLevel(FuncDeclaration *fd, int intypeof); // lexical nesting level difference
     int getLevelAndCheck(const Loc &loc, Scope *sc, FuncDeclaration *fd);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1356,8 +1356,8 @@ public:
                     continue;
                 if (fd2->isFuture())
                     continue;
-                if (fd->leastAsSpecialized(fd2) != MATCH::nomatch ||
-                    fd2->leastAsSpecialized(fd) != MATCH::nomatch)
+                if (fd->leastAsSpecialized(fd2, NULL) != MATCH::nomatch ||
+                    fd2->leastAsSpecialized(fd, NULL) != MATCH::nomatch)
                 {
                     return;
                 }


### PR DESCRIPTION
This got changed in #14575, make it so C++ clients call the function in the same way.