### PR TITLE
Fix missing directives in testsuite

### DIFF
--- a/compiler/test/compilable/test22674.d
+++ b/compiler/test/compilable/test22674.d
@@ -1,4 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=22674
+// EXTRA_FILES: imports/cimports2a.i imports/cimports2b.i
 
 import imports.cimports2a;
 import imports.cimports2b;


### PR DESCRIPTION
Otherwise the test testsuite fails to compile on remote execution targets (running under gdc / dejagnu)