### PR TITLE
dmd.gluelayer: Add toObjFile declaration for version IN_GCC

### DIFF
--- a/compiler/src/dmd/gluelayer.d
+++ b/compiler/src/dmd/gluelayer.d
@@ -78,6 +78,7 @@ else version (IN_GCC)
     extern (C++)
     {
         Statement asmSemantic(AsmStatement s, Scope* sc);
+        void toObjFile(Dsymbol ds, bool multiobj);
     }
 
     // stubs


### PR DESCRIPTION
Since the switch to self-hosted D, have started to adopt dmd.typinf for keeping in sync with front-end specific logic for typeinfo generation/emission, which requires that this stub function be defined somewhere.