### PR TITLE
Deprecate invalid `#` tokens in `q{}` strings

### DIFF
--- a/changelog/dmd.deprecate-pound-in-token-string.dd
+++ b/changelog/dmd.deprecate-pound-in-token-string.dd
@@ -1,0 +1,12 @@
+Deprecate invalid special token sequences inside token strings
+
+A token string is specified to contain valid D tokens, but the compiler formerly allowed `#identifier` tokens in them.
+
+---
+enum s = q{
+#endif x
+}
+
+---
+
+This will now issue a deprecation warning. It will become an error in dmd 2.113.

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -2664,14 +2664,19 @@ class Lexer
         eSink.error(loc, format, args);
     }
 
-    final void deprecation(const(char)* format)
+    void deprecation(T...)(const ref Loc loc, const(char)* format, T args)
     {
-        eSink.deprecation(token.loc, format);
+        eSink.deprecation(loc, format, args);
     }
 
-    final void deprecationSupplemental(const(char)* format)
+    void deprecation(T...)(const(char)* format, T args)
     {
-        eSink.deprecationSupplemental(token.loc, format);
+        eSink.deprecation(token.loc, format, args);
+    }
+
+    void deprecationSupplemental(T...)(const(char)* format, T args)
+    {
+        eSink.deprecationSupplemental(token.loc, format, args);
     }
 
     /***************************************
@@ -2692,15 +2697,24 @@ class Lexer
                 poundLine(n, false);
                 return true;
             }
-            else if (!inTokenStringConstant)
+            else
             {
                 const locx = loc();
-                eSink.warning(locx, "C preprocessor directive `#%s` is not supported", n.ident.toChars());
+                // @@@DEPRECATED_2.103@@@
+                // Turn into an error in 2.113
+                if (inTokenStringConstant)
+                    deprecation(locx, "token string requires valid D tokens, not `#%s`", n.ident.toChars());
+                else
+                    error(locx, "C preprocessor directive `#%s` is not supported", n.ident.toChars());
             }
         }
-        else if (n.value == TOK.if_ && !inTokenStringConstant)
+        else if (n.value == TOK.if_)
         {
-            error("C preprocessor directive `#if` is not supported, use `version` or `static if`");
+            const locx = loc();
+            if (inTokenStringConstant)
+                error(locx, "token string requires valid D tokens, not `#if`");
+            else
+                error(locx, "C preprocessor directive `#if` is not supported, use `version` or `static if`");
         }
         return false;
     }

--- a/compiler/test/fail_compilation/cerrors.d
+++ b/compiler/test/fail_compilation/cerrors.d
@@ -1,10 +1,12 @@
 /* REQUIRED_ARGS: -wi
 TEST_OUTPUT:
 ---
-fail_compilation/cerrors.d(11): Error: C preprocessor directive `#if` is not supported, use `version` or `static if`
-fail_compilation/cerrors.d(11): Error: declaration expected, not `#`
-fail_compilation/cerrors.d(15): Warning: C preprocessor directive `#endif` is not supported
-fail_compilation/cerrors.d(15): Error: declaration expected, not `#`
+fail_compilation/cerrors.d(13): Error: C preprocessor directive `#if` is not supported, use `version` or `static if`
+fail_compilation/cerrors.d(13): Error: declaration expected, not `#`
+fail_compilation/cerrors.d(17): Error: C preprocessor directive `#endif` is not supported
+fail_compilation/cerrors.d(17): Error: declaration expected, not `#`
+fail_compilation/cerrors.d(21): Error: token string requires valid D tokens, not `#if`
+fail_compilation/cerrors.d(22): Deprecation: token string requires valid D tokens, not `#include`
 ---
 */
 

--- a/compiler/test/unit/lexer/diagnostic_reporter.d
+++ b/compiler/test/unit/lexer/diagnostic_reporter.d
@@ -36,27 +36,6 @@ unittest
     assert(reporter.errorCount == 1);
 }
 
-@("warnings: C preprocessor directive")
-unittest
-{
-    static final class WarningCountingDiagnosticReporter : NoopDiagnosticReporter
-    {
-        int warningCount;
-
-        override bool warning(const ref Loc, const(char)*, va_list, const(char)*, const(char)*)
-        {
-            warningCount++;
-            return true;
-        }
-    }
-
-    global.params.warnings = DiagnosticReporting.inform;
-    scope reporter = new WarningCountingDiagnosticReporter;
-    lexUntilEndOfFile(`#foo`);
-
-    assert(reporter.warningCount == 1);
-}
-
 private void lexUntilEndOfFile(string code)
 {
     import dmd.lexer : Lexer;


### PR DESCRIPTION
See https://github.com/dlang/dmd/pull/15001#issuecomment-1474828212

Turn `#endif` and other `# identifier` into an error instead of warning (just like `#if`), and deprecate it inside token strings `q{#include}`