### PR TITLE
fix Issue 23725 - ImportC fails to parse __asm __volatile on FreeBSD …

### DIFF
--- a/compiler/test/compilable/testcstuff2.c
+++ b/compiler/test/compilable/testcstuff2.c
@@ -713,3 +713,13 @@ enum E2 {
     m1,
     m2 = m1
 };
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=23725
+
+#if __FreeBSD__
+void test23725()
+{
+    __asm __volatile("fldcw %0" : : "m" (*(addr)))
+}
+#endif

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -100,6 +100,7 @@
 #endif
 
 #if __FreeBSD__
+#define __volatile
 #endif
 
 #if _MSC_VER


### PR DESCRIPTION
…stdatomic.h and fenv.h