### PR TITLE
recognize Gnu Asm statements

### DIFF
--- a/compiler/test/compilable/testcstuff2.c
+++ b/compiler/test/compilable/testcstuff2.c
@@ -713,3 +713,12 @@ enum E2 {
     m1,
     m2 = m1
 };
+
+/**********************************************/
+
+#define	__fldcw(addr)	asm volatile inline goto ("fldcw %0" : : "m" (*(addr)))
+
+static __inline void __fnldcw(unsigned short _cw, unsigned short _newcw)
+{
+    __fldcw(&_newcw);
+}

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -100,6 +100,7 @@
 #endif
 
 #if __FreeBSD__
+#define __volatile volatile
 #endif
 
 #if _MSC_VER


### PR DESCRIPTION
The difficulty is gnu asm statements appear with regularity in the various gnu system headers. ImportC doesn't recognize them and gives an incomprehensible error message when it sees them.

This PR recognizes gnu asm statements, and replaces them with an assert that reports:
```
core.exception.AssertError@test.c(8): Gnu Asm not supported - compile this function with gcc or clang
```
giving a file & line where the gnu asm was, and suggesting corrective action. It's a runtime assert, so is not a problem for the user unless the code is actually executed.