### PR TITLE
fix(druntime): only initialize mono timers once

### DIFF
--- a/druntime/src/rt/dmain2.d
+++ b/druntime/src/rt/dmain2.d
@@ -101,6 +101,11 @@ alias void delegate(Throwable) ExceptionHandler;
  */
 shared size_t _initCount;
 
+/****
+ * Boolean flag set to true while the runtime is first initialized.
+ */
+package __gshared bool _isRuntimeFirstInitialized;
+
 /**********************************************
  * Initialize druntime.
  * If a C program wishes to call D code, and there's no D main(), then it
@@ -124,9 +129,15 @@ extern (C) int rt_init()
     try
     {
         initSections();
-        // this initializes mono time before anything else to allow usage
-        // in other druntime systems.
-        _d_initMonoTime();
+
+        if (!_isRuntimeFirstInitialized)
+        {
+            // this initializes mono time before anything else to allow usage
+            // in other druntime systems.
+            _d_initMonoTime();
+            _isRuntimeFirstInitialized = true;
+        }
+
         thread_init();
         // TODO: fixme - calls GC.addRange -> Initializes GC
         initStaticDataGC();


### PR DESCRIPTION
This issue affects the usage of `Runtime.initialize()` and `Runtime.terminate()` on a `crt_constructor`, which, if done more than once, hangs.

CC @JohanEngelen this might be useful to cherry-pick to the Weka runtime, since we rely on these routines for DPDK initialization to use traces, AFAIK. I faced this when adding some new initialization code. For future, we won't need full runtime initialization for the new tracing system, tho (theoretically, none).