### PR TITLE
emit runtime assert error for gcc inline asm

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -3195,15 +3195,26 @@ final class CParser(AST) : Parser!AST
             nextToken();
 
         check(TOK.leftParenthesis);
+        if (token.value != TOK.string_)
+            error("string literal expected for Assembler Template, not `%s`", token.toChars());
         Token* toklist = null;
         Token** ptoklist = &toklist;
         //Identifier label = null;
         auto statements = new AST.Statements();
+
+        int parens;
         while (1)
         {
             switch (token.value)
             {
+                case TOK.leftParenthesis:
+                    ++parens;
+                    goto default;
+
                 case TOK.rightParenthesis:
+                    --parens;
+                    if (parens >= 0)
+                        goto default;
                     break;
 
                 case TOK.semicolon:

--- a/compiler/src/dmd/iasm.d
+++ b/compiler/src/dmd/iasm.d
@@ -13,9 +13,15 @@
 
 module dmd.iasm;
 
+import core.stdc.stdio;
+
 import dmd.dscope;
+import dmd.expression;
 import dmd.func;
+import dmd.mtype;
+import dmd.tokens;
 import dmd.statement;
+import dmd.statementsem;
 
 version (MARS)
 {
@@ -43,6 +49,19 @@ extern(C++) Statement asmSemantic(AsmStatement s, Scope *sc)
 
     version (MARS)
     {
+        /* If it starts with a string literal, it's gcc inline asm
+         */
+        if (s.tokens.value == TOK.string_)
+        {
+            /* Replace the asm statement with an assert(0, msg) that trips at runtime.
+             */
+            const loc = s.loc;
+            auto e = new IntegerExp(loc, 0, Type.tint32);
+            auto msg = new StringExp(loc, "Gnu Asm not supported - compile this function with gcc or clang");
+            auto ae = new AssertExp(loc, e, msg);
+            auto se = new ExpStatement(loc, ae);
+            return statementSemantic(se, sc);
+        }
         auto ias = new InlineAsmStatement(s.loc, s.tokens);
         return inlineAsmSemantic(ias, sc);
     }

--- a/compiler/test/compilable/testcstuff2.c
+++ b/compiler/test/compilable/testcstuff2.c
@@ -713,3 +713,20 @@ enum E2 {
     m1,
     m2 = m1
 };
+
+/************************************************************/
+
+// https://issues.dlang.org/show_bug.cgi?id=23725
+
+#define	__fldcw(addr)	asm volatile("fldcw %0" : : "m" (*(addr)))
+
+static __inline void
+__fnldcw(unsigned short _cw, unsigned short _newcw)
+{
+    __fldcw(&_newcw);
+}
+
+void test23725()
+{
+    __fnldcw(1, 2);
+}

--- a/compiler/test/fail_compilation/gccasm1.c
+++ b/compiler/test/fail_compilation/gccasm1.c
@@ -1,0 +1,18 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/gccasm1.c(12): Error: string literal expected for Assembler Template, not `%`
+---
+ */
+
+#define	__fldcw(addr)	asm volatile(%0 : : "m" (*(addr)))
+
+static __inline void
+__fnldcw(unsigned short _cw, unsigned short _newcw)
+{
+        __fldcw(&_newcw);
+}
+
+void main()
+{
+    __fnldcw(1, 2);
+}


### PR DESCRIPTION
This incorporates https://github.com/dlang/dmd/pull/15007

The difficulty is gnu asm statements appear with regularity in the various gnu system headers. ImportC doesn't recognize them and gives an incomprehensible error message when it sees them.

This PR recognizes gnu asm statements, and replaces them with an assert that reports:
```
core.exception.AssertError@test.c(8): Gnu Asm not supported - compile this function with gcc or clang
```
giving a file & line where the gnu asm was, and suggesting corrective action. It's a runtime assert, so is not a problem for the user unless the code is actually executed.

It also corrects a problem where nested parentheses were not supported in inline asm statements.