### PR TITLE
replace Visitor for Statement_toIR() with mixin

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -320,6 +320,13 @@ class ForwardingStatement;
 class ContinueStatement;
 class ThrowStatement;
 class SwitchErrorStatement;
+class CompoundAsmStatement;
+class PragmaStatement;
+class StaticAssertStatement;
+class AsmStatement;
+class InlineAsmStatement;
+class GccAsmStatement;
+class ImportStatement;
 struct Token;
 struct code;
 class Object;
@@ -4115,6 +4122,7 @@ public:
     void accept(Visitor* v) override;
     virtual ReturnStatement* endsWithReturnStatement();
     ErrorStatement* isErrorStatement();
+    PeelStatement* isPeelStatement();
     ScopeStatement* isScopeStatement();
     ExpStatement* isExpStatement();
     CompoundStatement* isCompoundStatement();
@@ -4148,6 +4156,15 @@ public:
     UnrolledLoopStatement* isUnrolledLoopStatement();
     ForeachRangeStatement* isForeachRangeStatement();
     CompoundDeclarationStatement* isCompoundDeclarationStatement();
+    CompoundAsmStatement* isCompoundAsmStatement();
+    PragmaStatement* isPragmaStatement();
+    StaticAssertStatement* isStaticAssertStatement();
+    CaseRangeStatement* isCaseRangeStatement();
+    SynchronizedStatement* isSynchronizedStatement();
+    AsmStatement* isAsmStatement();
+    InlineAsmStatement* isInlineAsmStatement();
+    GccAsmStatement* isGccAsmStatement();
+    ImportStatement* isImportStatement();
 };
 
 class AsmStatement : public Statement
@@ -5099,6 +5116,7 @@ struct ASTCodegen final
     using TryCatchStatement = ::TryCatchStatement;
     using TryFinallyStatement = ::TryFinallyStatement;
     using UnrolledLoopStatement = ::UnrolledLoopStatement;
+    using VisitStatement = ::VisitStatement;
     using WhileStatement = ::WhileStatement;
     using WithStatement = ::WithStatement;
     using StaticAssert = ::StaticAssert;


### PR DESCRIPTION
First use of mixin instead of Visitor for Statements.