### PR TITLE
Improve layout of Expression classes

### DIFF
--- a/compiler/src/dmd/apply.d
+++ b/compiler/src/dmd/apply.d
@@ -170,7 +170,7 @@ public:
     {
         if (e.stageflags & stageApply)
             return;
-        int old = e.stageflags;
+        const old = e.stageflags;
         e.stageflags |= stageApply;
         doCond(e.elements.peekSlice()) || applyTo(e);
         e.stageflags = old;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -2539,6 +2539,8 @@ extern (C++) final class NullExp : Expression
  */
 extern (C++) final class StringExp : Expression
 {
+    char postfix = NoPostfix;   // 'c', 'w', 'd'
+    OwnedBy ownedByCtfe = OwnedBy.code;
     private union
     {
         char* string;   // if sz == 1
@@ -2559,8 +2561,6 @@ extern (C++) final class StringExp : Expression
     bool committed;
 
     enum char NoPostfix = 0;
-    char postfix = NoPostfix;   // 'c', 'w', 'd'
-    OwnedBy ownedByCtfe = OwnedBy.code;
 
     extern (D) this(const ref Loc loc, const(void)[] string) scope
     {

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -5662,9 +5662,15 @@ extern (C++) final class SliceExp : UnaExp
     Expression lwr;             // null if implicit [length - 1]
 
     VarDeclaration lengthVar;
-    bool upperIsInBounds;       // true if upr <= e1.length
-    bool lowerIsLessThanUpper;  // true if lwr <= upr
-    bool arrayop;               // an array operation, rather than a slice
+
+    private extern(D) static struct BitFields
+    {
+        bool upperIsInBounds;       // true if upr <= e1.length
+        bool lowerIsLessThanUpper;  // true if lwr <= upr
+        bool arrayop;               // an array operation, rather than a slice
+    }
+    import dmd.common.bitfields : generateBitFields;
+    mixin(generateBitFields!(BitFields, ubyte));
 
     /************************************************************/
     extern (D) this(const ref Loc loc, Expression e1, IntervalExp ie)

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -3217,10 +3217,10 @@ extern (C++) final class ArrayLiteralExp : Expression
  */
 extern (C++) final class AssocArrayLiteralExp : Expression
 {
+    OwnedBy ownedByCtfe = OwnedBy.code;
+
     Expressions* keys;
     Expressions* values;
-
-    OwnedBy ownedByCtfe = OwnedBy.code;
 
     extern (D) this(const ref Loc loc, Expressions* keys, Expressions* values)
     {

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -3308,7 +3308,7 @@ extern (C++) final class StructLiteralExp : Expression
      * 'inlinecopy' uses similar 'stageflags' and from multiple evaluation 'doInline'
      * (with infinite recursion) of this expression.
      */
-    int stageflags;
+    ubyte stageflags;
 
     bool useStaticInit;     /// if this is true, use the StructDeclaration's init symbol
     bool isOriginal = false; /// used when moving instances to indicate `this is this.origin`

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -720,10 +720,10 @@ enum WANTexpand = 1;    // expand const/immutable variables if possible
  */
 extern (C++) abstract class Expression : ASTNode
 {
-    const EXP op;   // to minimize use of dynamic_cast
-    bool parens;    // if this is a parenthesized expression
     Type type;      // !=null means that semantic() has been run
     Loc loc;        // file location
+    const EXP op;   // to minimize use of dynamic_cast
+    bool parens;    // if this is a parenthesized expression
 
     extern (D) this(const ref Loc loc, EXP op) scope
     {

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -3051,6 +3051,9 @@ extern (C++) final class TupleExp : Expression
  */
 extern (C++) final class ArrayLiteralExp : Expression
 {
+    OwnedBy ownedByCtfe = OwnedBy.code;
+    bool onstack = false;
+
     /** If !is null, elements[] can be sparse and basis is used for the
      * "default" element value. In other words, non-null elements[i] overrides
      * this 'basis' value.
@@ -3058,8 +3061,6 @@ extern (C++) final class ArrayLiteralExp : Expression
     Expression basis;
 
     Expressions* elements;
-    OwnedBy ownedByCtfe = OwnedBy.code;
-    bool onstack = false;
 
     extern (D) this(const ref Loc loc, Type type, Expressions* elements)
     {

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -370,12 +370,12 @@ public:
 class StringExp final : public Expression
 {
 public:
+    utf8_t postfix;      // 'c', 'w', 'd'
+    OwnedBy ownedByCtfe;
     void *string;       // char, wchar, or dchar data
     size_t len;         // number of chars, wchars, or dchars
     unsigned char sz;   // 1: char, 2: wchar, 4: dchar
     bool committed;     // if type is committed
-    utf8_t postfix;      // 'c', 'w', 'd'
-    OwnedBy ownedByCtfe;
 
     static StringExp *create(const Loc &loc, const char *s);
     static StringExp *create(const Loc &loc, const void *s, d_size_t len);

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -474,7 +474,7 @@ public:
      * 'inlinecopy' uses similar 'stageflags' and from multiple evaluation 'doInline'
      * (with infinite recursion) of this expression.
      */
-    int stageflags;
+    uint8_t stageflags;
 
     d_bool useStaticInit;         // if this is true, use the StructDeclaration's init symbol
     d_bool isOriginal;            // used when moving instances to indicate `this is this.origin`

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -937,9 +937,15 @@ public:
     Expression *upr;            // NULL if implicit 0
     Expression *lwr;            // NULL if implicit [length - 1]
     VarDeclaration *lengthVar;
-    d_bool upperIsInBounds;       // true if upr <= e1.length
-    d_bool lowerIsLessThanUpper;  // true if lwr <= upr
-    d_bool arrayop;               // an array operation, rather than a slice
+
+    bool upperIsInBounds() const; // true if upr <= e1.length
+    bool upperIsInBounds(bool v);
+    bool lowerIsLessThanUpper() const; // true if lwr <= upr
+    bool lowerIsLessThanUpper(bool v);
+    bool arrayop() const; // an array operation, rather than a slice
+    bool arrayop(bool v);
+private:
+    uint8_t bitFields;
 
     SliceExp *syntaxCopy() override;
     bool isLvalue() override;

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -79,10 +79,10 @@ enum class ModifyFlags
 class Expression : public ASTNode
 {
 public:
-    EXP op;                     // to minimize use of dynamic_cast
-    d_bool parens;                // if this is a parenthesized expression
     Type *type;                 // !=NULL means that semantic() has been run
     Loc loc;                    // file location
+    EXP op;                     // to minimize use of dynamic_cast
+    d_bool parens;              // if this is a parenthesized expression
 
     size_t size() const;
     static void _init();

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -439,9 +439,9 @@ public:
 class AssocArrayLiteralExp final : public Expression
 {
 public:
+    OwnedBy ownedByCtfe;
     Expressions *keys;
     Expressions *values;
-    OwnedBy ownedByCtfe;
 
     bool equals(const RootObject * const o) const override;
     AssocArrayLiteralExp *syntaxCopy() override;

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -419,10 +419,10 @@ public:
 class ArrayLiteralExp final : public Expression
 {
 public:
-    Expression *basis;
-    Expressions *elements;
     OwnedBy ownedByCtfe;
     d_bool onstack;
+    Expression *basis;
+    Expressions *elements;
 
     static ArrayLiteralExp *create(const Loc &loc, Expressions *elements);
     static void emplace(UnionExp *pue, const Loc &loc, Expressions *elements);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6960,7 +6960,7 @@ private:
         char dotvarexp[65LLU];
         char addrexp[56LLU];
         char indexexp[82LLU];
-        char sliceexp[83LLU];
+        char sliceexp[81LLU];
         char vectorexp[69LLU];
     };
     #pragma pack(pop)
@@ -7586,9 +7586,15 @@ public:
     Expression* upr;
     Expression* lwr;
     VarDeclaration* lengthVar;
-    bool upperIsInBounds;
-    bool lowerIsLessThanUpper;
-    bool arrayop;
+    bool upperIsInBounds() const;
+    bool upperIsInBounds(bool v);
+    bool lowerIsLessThanUpper() const;
+    bool lowerIsLessThanUpper(bool v);
+    bool arrayop() const;
+    bool arrayop(bool v);
+private:
+    uint8_t bitFields;
+public:
     SliceExp* syntaxCopy() override;
     bool isLvalue() override;
     Expression* toLvalue(Scope* sc, Expression* e) override;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6951,7 +6951,7 @@ private:
         char realexp[64LLU];
         char complexexp[80LLU];
         char symoffexp[72LLU];
-        char stringexp[60LLU];
+        char stringexp[58LLU];
         char arrayliteralexp[56LLU];
         char assocarrayliteralexp[56LLU];
         char structliteralexp[92LLU];
@@ -7100,20 +7100,20 @@ public:
 
 class StringExp final : public Expression
 {
+public:
+    char postfix;
+    OwnedBy ownedByCtfe;
     union
     {
         char* string;
         char16_t* wstring;
         char32_t* dstring;
     };
-public:
     size_t len;
     uint8_t sz;
     bool committed;
     enum : char { NoPostfix = 0u };
 
-    char postfix;
-    OwnedBy ownedByCtfe;
     static StringExp* create(const Loc& loc, const char* s);
     static StringExp* create(const Loc& loc, const void* string, size_t len);
     static void emplace(UnionExp* pue, const Loc& loc, const char* s);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -958,10 +958,10 @@ struct Optional final
 class Expression : public ASTNode
 {
 public:
-    const EXP op;
-    bool parens;
     Type* type;
     Loc loc;
+    const EXP op;
+    bool parens;
     size_t size() const;
     static void _init();
     static void deinitialize();
@@ -6945,9 +6945,9 @@ struct UnionExp final
 private:
     union __AnonStruct__u
     {
-        char exp[40LLU];
+        char exp[34LLU];
         char integerexp[48LLU];
-        char errorexp[40LLU];
+        char errorexp[34LLU];
         char realexp[64LLU];
         char complexexp[80LLU];
         char symoffexp[72LLU];
@@ -6956,7 +6956,7 @@ private:
         char assocarrayliteralexp[57LLU];
         char structliteralexp[95LLU];
         char compoundliteralexp[48LLU];
-        char nullexp[40LLU];
+        char nullexp[34LLU];
         char dotvarexp[65LLU];
         char addrexp[56LLU];
         char indexexp[82LLU];

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6952,7 +6952,7 @@ private:
         char complexexp[80LLU];
         char symoffexp[72LLU];
         char stringexp[60LLU];
-        char arrayliteralexp[58LLU];
+        char arrayliteralexp[56LLU];
         char assocarrayliteralexp[57LLU];
         char structliteralexp[92LLU];
         char compoundliteralexp[48LLU];
@@ -7146,10 +7146,10 @@ public:
 class ArrayLiteralExp final : public Expression
 {
 public:
-    Expression* basis;
-    Array<Expression* >* elements;
     OwnedBy ownedByCtfe;
     bool onstack;
+    Expression* basis;
+    Array<Expression* >* elements;
     static ArrayLiteralExp* create(const Loc& loc, Array<Expression* >* elements);
     static void emplace(UnionExp* pue, const Loc& loc, Array<Expression* >* elements);
     ArrayLiteralExp* syntaxCopy() override;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6953,7 +6953,7 @@ private:
         char symoffexp[72LLU];
         char stringexp[60LLU];
         char arrayliteralexp[56LLU];
-        char assocarrayliteralexp[57LLU];
+        char assocarrayliteralexp[56LLU];
         char structliteralexp[92LLU];
         char compoundliteralexp[48LLU];
         char nullexp[34LLU];
@@ -7164,9 +7164,9 @@ public:
 class AssocArrayLiteralExp final : public Expression
 {
 public:
+    OwnedBy ownedByCtfe;
     Array<Expression* >* keys;
     Array<Expression* >* values;
-    OwnedBy ownedByCtfe;
     bool equals(const RootObject* const o) const override;
     AssocArrayLiteralExp* syntaxCopy() override;
     Optional<bool > toBool() override;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6954,7 +6954,7 @@ private:
         char stringexp[60LLU];
         char arrayliteralexp[58LLU];
         char assocarrayliteralexp[57LLU];
-        char structliteralexp[95LLU];
+        char structliteralexp[92LLU];
         char compoundliteralexp[48LLU];
         char nullexp[34LLU];
         char dotvarexp[65LLU];
@@ -7182,7 +7182,7 @@ public:
     Symbol* sym;
     StructLiteralExp* origin;
     StructLiteralExp* inlinecopy;
-    int32_t stageflags;
+    uint8_t stageflags;
     bool useStaticInit;
     bool isOriginal;
     OwnedBy ownedByCtfe;

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -1488,7 +1488,7 @@ public:
         //printf("StructLiteralExp.inlineScan()\n");
         if (e.stageflags & stageInlineScan)
             return;
-        int old = e.stageflags;
+        const old = e.stageflags;
         e.stageflags |= stageInlineScan;
         arrayInlineScan(e.elements);
         e.stageflags = old;

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -371,7 +371,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
     {
         if (e.stageflags & stageOptimize)
             return;
-        int old = e.stageflags;
+        const old = e.stageflags;
         e.stageflags |= stageOptimize;
         if (e.elements)
         {

--- a/compiler/src/dmd/visitor.d
+++ b/compiler/src/dmd/visitor.d
@@ -152,7 +152,7 @@ extern (C++) class SemanticTimeTransitiveVisitor : SemanticTimePermissiveVisitor
         // need to avoid infinite recursion.
         if (!(e.stageflags & stageToCBuffer))
         {
-            int old = e.stageflags;
+            const old = e.stageflags;
             e.stageflags |= stageToCBuffer;
             foreach (el; *e.elements)
                 if (el)


### PR DESCRIPTION
After https://github.com/dlang/dmd/pull/14989, it becomes beneficial to avoid padding between class fields by putting the 2 byte-sized fields in `Expression` last, and putting 2 byte-sized fields at the beginning of a class deriving from `Expression`.

The reduced class instance sizes can be seen in the diff `UnionExp` of `frontend.h`.