### PR TITLE
Fix Issue 23790 - Cannot use cas on member variable with -preview=nosharedaccess

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -13315,9 +13315,16 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
             //printf("dotvarexp = %s\n", e.toChars());
             if (e.type.isShared())
             {
-                // / https://issues.dlang.org/show_bug.cgi?id=22626
-                if (e.e1.isThisExp() && sc.func && sc.func.isSynchronized())
-                    return false;
+                if (e.e1.isThisExp())
+                {
+                    // https://issues.dlang.org/show_bug.cgi?id=22626
+                    if (sc.func && sc.func.isSynchronized())
+                        return false;
+
+                    // https://issues.dlang.org/show_bug.cgi?id=23790
+                    if (e.e1.type.isTypeStruct())
+                        return false;
+                }
 
                 auto fd = e.var.isFuncDeclaration();
                 const sharedFunc = fd && fd.type.isShared;

--- a/compiler/test/compilable/shared.d
+++ b/compiler/test/compilable/shared.d
@@ -130,3 +130,15 @@ void main()
 {
     auto b = new shared Class();
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=23790
+bool cas(shared bool*, bool, bool) { return true; }
+
+struct Argh
+{
+    bool locked;
+    void lock() shared
+    {
+        while(!cas(&locked, false, true)) {}
+    }
+}


### PR DESCRIPTION
Maybe I am missing something but I don't see how the `this` of a struct instance could be modified by another thread.

If I am indeed mistaken, then the bug is invalid and we `atomicLoad` needs to be performed: `cas(&atomicLoad(this).locked, true, false)`.