### PR TITLE
Fix Issue 20908 -  -preview=nosharedaccess requires zero-initializion for aggregates

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -13278,6 +13278,12 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
 
         bool visitVar(VarExp e)
         {
+            // https://issues.dlang.org/show_bug.cgi?id=20908
+            // direct access to init symbols is ok as they
+            // cannot be modified.
+            if (e.var.isSymbolDeclaration())
+                return false;
+
             // https://issues.dlang.org/show_bug.cgi?id=22626
             // Synchronized functions don't need to use core.atomic
             // when accessing `this`.

--- a/compiler/test/compilable/shared.d
+++ b/compiler/test/compilable/shared.d
@@ -11,34 +11,48 @@ ref shared(int) f(return shared ref int y)
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=20908
+struct S
+{
+    int i = 2;
+}
+
+union U
+{
+    int i = 1;
+    bool b;
+}
+
 void test20908()
 {
-  // shared locals (or struct members) should be able to be initialised:
-  shared int x;
+    // shared locals (or struct members) should be able to be initialised:
+    shared int x;
 
-  ref shared(int) fun()
-  {
-    static shared(int) val;
+    ref shared(int) fun()
+    {
+        static shared(int) val;
 
-    // return by reference
-    return val;
-  }
+        // return by reference
+        return val;
+    }
 
-  ref shared(int) fun2()
-  {
-    static shared(int)* val;
+    ref shared(int) fun2()
+    {
+        static shared(int)* val;
 
-    // transfer pointer to reference
-    return *val;
-  }
+        // transfer pointer to reference
+        return *val;
+    }
 
-  ref shared(int) fun3()
-  {
-    static shared(int)*** val;
+    ref shared(int) fun3()
+    {
+        static shared(int)*** val;
 
-    // Multiple indirections
-    return ***val;
-  }
+        // Multiple indirections
+        return ***val;
+    }
+
+    shared S s;
+    shared U u;
 }
 
 // Simple tests for `DotVarExp`


### PR DESCRIPTION
`SymbolDeclaration`s are created so that the backend allocates space for the default initializer of structs/unions. If we encounter a `VarExp` that references a `SymbolDeclaration` then we can directly access it since it cannot be modified from user code.