### PR TITLE
Fix issue 11989 -- deprecate TickDuration, it's no longer used anywhere.

### DIFF
--- a/compiler/test/runnable/testpdb.d
+++ b/compiler/test/runnable/testpdb.d
@@ -7,9 +7,9 @@ import core.demangle;
 void main(string[] args)
 {
     // https://issues.dlang.org/show_bug.cgi?id=4014
-    // -gf should drag in full definitions of Object, TickDuration and ClockType
+    // -gf should drag in full definitions of Object, Duration and ClockType
     Object o = new Object;
-    TickDuration duration; // struct
+    Duration duration; // struct
     ClockType ct; // enumerator
 
     version (CRuntime_Microsoft)
@@ -29,8 +29,8 @@ void main(string[] args)
         testSymbolHasChildren(objsym, "object.Object");
         objsym.Release();
 
-        IDiaSymbol ticksym = searchSymbol(globals, "core.time.TickDuration");
-        testSymbolHasChildren(ticksym, "core.time.TickDuration");
+        IDiaSymbol ticksym = searchSymbol(globals, "core.time.Duration");
+        testSymbolHasChildren(ticksym, "core.time.Duration");
         ticksym.Release();
 
         IDiaSymbol ctsym = searchSymbol(globals, "core.time.ClockType");


### PR DESCRIPTION
See prior work https://github.com/dlang/druntime/pull/2886

Note all the changes to `assert` statements are to work around https://issues.dlang.org/show_bug.cgi?id=23800

Once this is removed, all that is going away anyway.

Any ideas on how to do the `_assertThrownDep` better?

Note also that this deprecates the `to` overload, which is one of the banes of my D existence!