### PR TITLE
Fix Issue 23802 - ImportC: __volatile__ is yet another alias for vola…

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -29,6 +29,7 @@
 #define __asm asm
 #define __inline__ inline
 #define __inline inline
+#define __volatile__ volatile
 
 /********************
  * Clang nullability extension used by macOS headers.


### PR DESCRIPTION
…tile

Some system headers on macOS use this GCC pre-ansi spelling of volatile.