### PR TITLE
fix Issue 23784 - ImportC: __ptr32, __ptr64

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -107,6 +107,8 @@
 #if _MSC_VER
 //#undef _Post_writable_size
 //#define _Post_writable_size(x) // consider #include <no_sal2.h>
+#define __ptr32
+#define __ptr64
 #endif
 
 /****************************


### PR DESCRIPTION
The backend has no support for these, so just ignore them.