### PR TITLE
Fix IFTI with named arguments

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4621,12 +4621,11 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
         return aliasInstanceSemantic(tempinst, sc, tempdecl);
     }
 
-    Expressions* fargs = argumentList.arguments; // TODO: resolve named args
 
     /* See if there is an existing TemplateInstantiation that already
      * implements the typeargs. If so, just refer to that one instead.
      */
-    tempinst.inst = tempdecl.findExistingInstance(tempinst, fargs);
+    tempinst.inst = tempdecl.findExistingInstance(tempinst, argumentList);
     TemplateInstance errinst = null;
     if (!tempinst.inst)
     {
@@ -4874,7 +4873,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
 
     /* If function template declaration
      */
-    if (fargs && tempinst.aliasdecl)
+    if (argumentList.length > 0 && tempinst.aliasdecl)
     {
         if (auto fd = tempinst.aliasdecl.isFuncDeclaration())
         {
@@ -4883,7 +4882,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
              */
             if (fd.type)
                 if (auto tf = fd.type.isTypeFunction())
-                    tf.fargs = fargs;
+                    tf.inferenceArguments = argumentList;
         }
     }
 

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -800,6 +800,21 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
+struct ArgumentList final
+{
+    Expressions* arguments;
+    Identifiers* names;
+    ArgumentList() :
+        arguments(),
+        names()
+    {
+    }
+    ArgumentList(Expressions* arguments, Identifiers* names = nullptr) :
+        arguments(arguments),
+        names(names)
+        {}
+};
+
 class CallExp final : public UnaExp
 {
 public:

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -2984,6 +2984,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                         foreach (u; 0 .. elements.length)
                         {
                             Expression a = (*arguments)[i + u];
+                            assert(a);
                             if (tret && a.implicitConvTo(tret))
                             {
                                 // p is a lazy array of delegates, tret is return type of the delegates

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1500,6 +1500,7 @@ public:
     ScopeDsymbol* argsym;
     size_t hash;
     Array<Expression* >* fargs;
+    Array<Identifier* >* fnames;
     Array<TemplateInstance* >* deferred;
     Module* memberOf;
     TemplateInstance* tinst;
@@ -4445,7 +4446,7 @@ public:
     TRUST trust;
     PURE purity;
     int8_t inuse;
-    Array<Expression* >* fargs;
+    ArgumentList inferenceArguments;
     static TypeFunction* create(Array<Parameter* >* parameters, Type* treturn, uint8_t varargs, LINK linkage, StorageClass stc = 0);
     const char* kind() const override;
     TypeFunction* syntaxCopy() override;

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -14,6 +14,7 @@
 
 #include "arraytypes.h"
 #include "ast_node.h"
+#include "expression.h"
 #include "globals.h"
 #include "visitor.h"
 
@@ -567,7 +568,7 @@ public:
     TRUST trust;                 // level of trust
     PURE purity;                 // PURExxxx
     char inuse;
-    Expressions *fargs;          // function arguments
+    ArgumentList inferenceArguments; // function arguments
 
     static TypeFunction *create(Parameters *parameters, Type *treturn, VarArg varargs, LINK linkage, StorageClass stc = 0);
     const char *kind() override;

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -12,6 +12,7 @@
 
 #include "arraytypes.h"
 #include "dsymbol.h"
+#include "expression.h"
 
 class Identifier;
 class TemplateInstance;
@@ -46,20 +47,6 @@ struct TemplatePrevious
     Objects *dedargs;
 };
 
-struct ArgumentList final
-{
-    Expressions* arguments;
-    Identifiers* names;
-    ArgumentList() :
-        arguments(),
-        names()
-    {
-    }
-    ArgumentList(Expressions* arguments, Identifiers* names = nullptr) :
-        arguments(arguments),
-        names(names)
-        {}
-};
 
 class TemplateDeclaration final : public ScopeDsymbol
 {
@@ -271,6 +258,7 @@ public:
     ScopeDsymbol *argsym;               // argument symbol table
     hash_t hash;                        // cached result of toHash()
     Expressions *fargs;                 // for function template, these are the function arguments
+    Identifiers *fnames;                // for function template, argument names
 
     TemplateInstances* deferred;
 

--- a/compiler/test/compilable/named_arguments_auto_ref.d
+++ b/compiler/test/compilable/named_arguments_auto_ref.d
@@ -1,0 +1,39 @@
+/**
+TEST_OUTPUT:
+---
+Call 0
+(x: true, y: false)
+Call 1
+Call 2
+(x: false, y: false)
+Call 3
+(x: false, y: true)
+Call 4
+---
+
+As of writing this test, template function instances store the function arguments from the call site.
+When looking in cache for an existing template instantiation, matching template arguments isn't
+sufficient: `auto ref` parameters being ref or not also create different template instances.
+This test checks that the special logic for it still works with named arguments.
+*/
+
+void autoref()(auto ref int x, auto ref int y)
+{
+    pragma(msg, "(x: ", __traits(isRef, x), ", y: ", __traits(isRef, y), ")");
+}
+
+void main()
+{
+    int REF = 0;
+    enum NOT = 0;
+    pragma(msg, "Call 0");
+    autoref(y: NOT, x: REF); // new instance
+    pragma(msg, "Call 1");
+    autoref(x: REF, y: NOT); // existing instance
+    pragma(msg, "Call 2");
+    autoref(x: NOT, y: NOT); // new instance
+    pragma(msg, "Call 3");
+    autoref(x: NOT, y: REF); // new instance
+    pragma(msg, "Call 4");
+    autoref(y: REF, x: NOT); // existing instance
+}

--- a/compiler/test/compilable/named_arguments_ifti.d
+++ b/compiler/test/compilable/named_arguments_ifti.d
@@ -1,0 +1,27 @@
+// Basic out-of-order test
+int f0(T0, T1)(T0 t0, T1 t1)
+{
+    static assert(is(T0 == int));
+    static assert(is(T1 == string));
+    return t0;
+}
+
+static assert(f0(t1: "a", t0: 10) == 10);
+
+// Default argument at beginning instead of end
+int f1(T0, T1)(T0 t0 = 20, T1 t1) { return t0; }
+static assert(f1(t1: "a") == 20);
+
+// Two default arguments
+int f2(T0, T1)(T0 t0 = 20, T1 t1, T2 t2 = 30) { return t2; }
+
+// Selecting overload based on name
+string f3(T)(T x) { return "x"; }
+string f3(T)(T y) { return "y"; }
+static assert(f3(x: 0) == "x");
+static assert(f3(y: 0) == "y");
+
+// Variadic tuple cut short by named argument
+int f4(T...)(T x, int y, int z) { assert(y == 30); assert(z == 50); return T.length; }
+static assert(f4(10, 10, 10, y: 30, z: 50) == 3);
+static assert(f4(10, 10, 30, z: 50) == 2);

--- a/compiler/test/fail_compilation/named_arguments_error.d
+++ b/compiler/test/fail_compilation/named_arguments_error.d
@@ -19,11 +19,11 @@ fail_compilation/named_arguments_error.d(33):        `named_arguments_error.g(in
 fail_compilation/named_arguments_error.d(43): Error: no named argument `element` allowed for array dimension
 fail_compilation/named_arguments_error.d(44): Error: no named argument `number` allowed for scalar
 fail_compilation/named_arguments_error.d(45): Error: cannot implicitly convert expression `g(x: 3, y: 4, z: 5)` of type `int` to `string`
-fail_compilation/named_arguments_error.d(46): Error: named arguments with Implicit Function Template Instantiation are not supported yet
-fail_compilation/named_arguments_error.d(46): Error: template `tempfun` is not callable using argument types `!()(string, int)`
-fail_compilation/named_arguments_error.d(50):        Candidate is: `tempfun(T, U)(T t, U u)`
+fail_compilation/named_arguments_error.d(46): Error: template `tempfun` is not callable using argument types `!()(int, int)`
+fail_compilation/named_arguments_error.d(49):        Candidate is: `tempfun(T, U)(T t, U u)`
 ---
 */
+
 
 
 
@@ -43,11 +43,10 @@ void main()
 	auto g0 = new int[](element: 3);
 	auto g1 = new int(number: 3);
 	string s = g(x: 3, y: 4, z: 5);
-	enum x = tempfun(u: "u", t: 0);
+	enum x = tempfun(u: 0, 1);
 }
 
-// template arguments
 int tempfun(T, U)(T t, U u)
 {
-	return 3;
+    return 3;
 }

--- a/compiler/test/fail_compilation/named_arguments_ifti_error.d
+++ b/compiler/test/fail_compilation/named_arguments_ifti_error.d
@@ -1,0 +1,20 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/named_arguments_ifti_error.d(17): Error: template `f` is not callable using argument types `!()(int, int)`
+fail_compilation/named_arguments_ifti_error.d(13):        Candidate is: `f(T, U)(T x, U y)`
+fail_compilation/named_arguments_ifti_error.d(18): Error: template `f` is not callable using argument types `!()(int, int)`
+fail_compilation/named_arguments_ifti_error.d(13):        Candidate is: `f(T, U)(T x, U y)`
+fail_compilation/named_arguments_ifti_error.d(19): Error: template `f` is not callable using argument types `!()(int)`
+fail_compilation/named_arguments_ifti_error.d(13):        Candidate is: `f(T, U)(T x, U y)`
+---
+*/
+
+void f(T, U)(T x, U y) {}
+
+void main()
+{
+	f(x: 3, x: 3); // double assignment of x
+	f(y: 3,    3); // overflow past last parameter
+	f(y: 3);       // skipping parameter x
+}


### PR DESCRIPTION
`deduceFunctionTemplateMatch` makes the assumption that the arguments and parameters arrays are parallel, and `resolveNamedArguments` doesn't handle template tuple parameters yet. Also, default parameters can come before `nfargs` now, so the logic comparing `argi` with `nfargs` has to be rewritten.