### PR TITLE
fix Issue 23789 - ImportC: __declspec(align(n)) take 2

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -3767,18 +3767,22 @@ struct ASTBase
         Loc loc;
         TOK tok;
         Identifier id;
+        structalign_t packalign;
         Dsymbols* members;
+        Type base;
 
         Type resolved;
         MOD mod;
 
-        extern (D) this(const ref Loc loc, TOK tok, Identifier id, Dsymbols* members)
+        extern (D) this(const ref Loc loc, TOK tok, Identifier id, structalign_t packalign, Type base, Dsymbols* members)
         {
             //printf("TypeTag %p\n", this);
             super(Ttag);
             this.loc = loc;
             this.tok = tok;
             this.id = id;
+            this.packalign = packalign;
+            this.base = base;
             this.members = members;
             this.mod = 0;
         }

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4666,7 +4666,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             sd.visibility = sc.visibility;
 
-            sd.alignment = sc.alignment();
+            if (sd.alignment.isUnknown())       // can be set already by `struct __declspec(align(N)) Tag { ... }`
+                sd.alignment = sc.alignment();
 
             sd.storage_class |= sc.stc;
             if (sd.storage_class & STC.abstract_)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3957,6 +3957,7 @@ class TypeTag final : public Type
 public:
     Loc loc;
     TOK tok;
+    structalign_t packalign;
     Identifier* id;
     Type* base;
     Array<Dsymbol* >* members;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -6515,6 +6515,7 @@ extern (C++) final class TypeTag : Type
 {
     Loc loc;                /// location of declaration
     TOK tok;                /// TOK.struct_, TOK.union_, TOK.enum_
+    structalign_t packalign; /// alignment of struct/union fields
     Identifier id;          /// tag name identifier
     Type base;              /// base type for enums otherwise null
     Dsymbols* members;      /// members of struct, null if none
@@ -6524,13 +6525,14 @@ extern (C++) final class TypeTag : Type
                             ///   struct S { int a; } s1, *s2;
     MOD mod;                /// modifiers to apply after type is resolved (only MODFlags.const_ at the moment)
 
-    extern (D) this(const ref Loc loc, TOK tok, Identifier id, Type base, Dsymbols* members)
+    extern (D) this(const ref Loc loc, TOK tok, Identifier id, structalign_t packalign, Type base, Dsymbols* members)
     {
         //printf("TypeTag ctor %s %p\n", id ? id.toChars() : "null".ptr, this);
         super(Ttag);
         this.loc = loc;
         this.tok = tok;
         this.id = id;
+        this.packalign = packalign;
         this.base = base;
         this.members = members;
         this.mod = 0;

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1809,12 +1809,14 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
                 case TOK.struct_:
                     auto sd = new StructDeclaration(mtype.loc, mtype.id, false);
+                    sd.alignment = mtype.packalign;
                     declare(sd);
                     mtype.resolved = visitStruct(new TypeStruct(sd));
                     break;
 
                 case TOK.union_:
                     auto ud = new UnionDeclaration(mtype.loc, mtype.id);
+                    ud.alignment = mtype.packalign;
                     declare(ud);
                     mtype.resolved = visitStruct(new TypeStruct(ud));
                     break;

--- a/compiler/test/compilable/imports/c23789.i
+++ b/compiler/test/compilable/imports/c23789.i
@@ -4,7 +4,7 @@ struct __declspec(align(64)) M128A {
     char c;
 };
 
-typedef struct __declspec(align(16)) _M128B {
+typedef struct __declspec(align(32)) _M128B {
     int x;
 } M128B, *PM128A;
 

--- a/compiler/test/compilable/test23789.d
+++ b/compiler/test/compilable/test23789.d
@@ -3,3 +3,5 @@
 import imports.c23789;
 
 static assert(M128A.alignof == 64);
+static assert(_M128B.alignof == 32);
+static assert(M128B.alignof == 32);


### PR DESCRIPTION
Putting the alignment in between the `struct` and the Tag needs a different solution than wrapping it in an AlignDeclaration.