### PR TITLE
ImportC: accept __declspec(thread) and __declspec(naked)

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -3105,7 +3105,9 @@ final class CParser(AST) : Parser!AST
      *    align(number)
      *    dllimport
      *    dllexport
+     *    naked
      *    noreturn
+     *    thread
      * Params:
      *  specifier = filled in with the attribute(s)
      */
@@ -3117,6 +3119,7 @@ final class CParser(AST) : Parser!AST
          */
         bool dllimport;  // TODO implement
         bool dllexport;  // TODO implement
+        bool naked;      // TODO implement
         nextToken();     // move past __declspec
         check(TOK.leftParenthesis);
         while (1)
@@ -3140,9 +3143,19 @@ final class CParser(AST) : Parser!AST
                     dllexport = true;
                     nextToken();
                 }
+                else if (token.ident == Id.naked)
+                {
+                    naked = true;
+                    nextToken();
+                }
                 else if (token.ident == Id.noreturn)
                 {
                     specifier.noreturn = true;
+                    nextToken();
+                }
+                else if (token.ident == Id.thread)
+                {
+                    specifier.scw |= SCW.x_Thread_local;
                     nextToken();
                 }
                 else if (token.ident == Id._align)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8836,6 +8836,8 @@ struct Id final
     static Identifier* ImportC;
     static Identifier* dllimport;
     static Identifier* dllexport;
+    static Identifier* naked;
+    static Identifier* thread;
     static Identifier* vector_size;
     static Identifier* noreturn;
     static Identifier* _align;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -523,6 +523,8 @@ immutable Msgtable[] msgtable =
     { "__tag" },
     { "dllimport" },
     { "dllexport" },
+    { "naked" },
+    { "thread" },
     { "vector_size" },
     { "__func__" },
     { "noreturn" },

--- a/compiler/test/compilable/testcstuff1.c
+++ b/compiler/test/compilable/testcstuff1.c
@@ -278,6 +278,7 @@ void test2()
     //extern int ei;
     static int si;
     _Thread_local int tli;
+    int __declspec(thread) tlj;
     auto int ai;
     register int reg;
     const int ci;


### PR DESCRIPTION
This just interprets __declspec(thread) as _Thread_local, and parses bug ignores __declspec(naked)