### PR TITLE
Fix Issue 23805 - Runtime segmentation fault when destructor access function frame

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -61,7 +61,7 @@ bool checkFrameAccess(Loc loc, Scope* sc, AggregateDeclaration ad, size_t iStart
         //printf("sparent2 = %p %s [%s], parent: %s\n", sparent2, sparent2.toChars(), sparent2.loc.toChars(), sparent2.parent,toChars());
         if (!ensureStaticLinkTo(s, sparent) || sparent != sparent2 && !ensureStaticLinkTo(s, sparent2))
         {
-            error(loc, "cannot access frame pointer of `%s`", ad.toPrettyChars());
+            error(loc, "cannot implicitly initialize frame pointer for `%s`", ad.toPrettyChars());
             return true;
         }
     }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -2093,11 +2093,14 @@ Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier iden
         }
         else if (ident == Id._init)
         {
-            Type tb = mt.toBasetype();
+            auto tarr = mt.isTypeSArray();
+            Type tb = tarr ? tarr.next.toBasetype() : mt.toBasetype();
             e = mt.defaultInitLiteral(loc);
             if (tb.ty == Tstruct && tb.needsNested())
             {
-                e.isStructLiteralExp().useStaticInit = true;
+                // https://issues.dlang.org/show_bug.cgi?id=23805
+                if(checkFrameAccess(loc, scope_, tb.isTypeStruct().sym))
+                    e = ErrorExp.get();
             }
         }
         else if (ident == Id._mangleof)
@@ -3191,11 +3194,14 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             }
             else if (ident == Id._init)
             {
-                Type tb = mt.toBasetype();
+                auto tarr = mt.isTypeSArray();
+                Type tb = tarr ? tarr.next.toBasetype() : mt.toBasetype();
                 e = mt.defaultInitLiteral(e.loc);
                 if (tb.ty == Tstruct && tb.needsNested())
                 {
-                    e.isStructLiteralExp().useStaticInit = true;
+                    // https://issues.dlang.org/show_bug.cgi?id=23805
+                    if(checkFrameAccess(e.loc, sc, tb.isTypeStruct().sym))
+                        e = ErrorExp.get();
                 }
                 goto Lreturn;
             }

--- a/compiler/test/fail_compilation/fail9665b.d
+++ b/compiler/test/fail_compilation/fail9665b.d
@@ -43,13 +43,15 @@ struct S1
 /+
 TEST_OUTPUT:
 ---
-fail_compilation/fail9665b.d(65): Error: one path skips field `x2`
-fail_compilation/fail9665b.d(66): Error: one path skips field `x3`
-fail_compilation/fail9665b.d(68): Error: one path skips field `x5`
-fail_compilation/fail9665b.d(69): Error: one path skips field `x6`
-fail_compilation/fail9665b.d(63): Error: field `x1` must be initialized in constructor, because it is nested struct
-fail_compilation/fail9665b.d(63): Error: field `x4` must be initialized in constructor, because it is nested struct
-fail_compilation/fail9665b.d(76): Error: template instance `fail9665b.S2!(X)` error instantiating
+fail_compilation/fail9665b.d(67): Error: one path skips field `x2`
+fail_compilation/fail9665b.d(68): Error: cannot implicitly initialize frame pointer for `fail9665b.test2.X`
+fail_compilation/fail9665b.d(68): Error: one path skips field `x3`
+fail_compilation/fail9665b.d(70): Error: one path skips field `x5`
+fail_compilation/fail9665b.d(71): Error: cannot implicitly initialize frame pointer for `fail9665b.test2.X`
+fail_compilation/fail9665b.d(71): Error: one path skips field `x6`
+fail_compilation/fail9665b.d(65): Error: field `x1` must be initialized in constructor, because it is nested struct
+fail_compilation/fail9665b.d(65): Error: field `x4` must be initialized in constructor, because it is nested struct
+fail_compilation/fail9665b.d(78): Error: template instance `fail9665b.S2!(X)` error instantiating
 ---
 +/
 struct S2(X)

--- a/compiler/test/fail_compilation/ice14096.d
+++ b/compiler/test/fail_compilation/ice14096.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14096.d(29): Error: cannot access frame pointer of `ice14096.main.Baz!((i) => i).Baz`
+fail_compilation/ice14096.d(29): Error: cannot implicitly initialize frame pointer for `ice14096.main.Baz!((i) => i).Baz`
 fail_compilation/ice14096.d(23): Error: template instance `ice14096.foo!(Tuple!(Baz!((i) => i))).foo.bar!(t)` error instantiating
 fail_compilation/ice14096.d(40):        instantiated from here: `foo!(Tuple!(Baz!((i) => i)))`
 ---

--- a/compiler/test/fail_compilation/nestedtempl3.d
+++ b/compiler/test/fail_compilation/nestedtempl3.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nestedtempl3.d(23): Error: cannot access frame pointer of `nestedtempl3.test.S!(i).S`
+fail_compilation/nestedtempl3.d(23): Error: cannot implicitly initialize frame pointer for `nestedtempl3.test.S!(i).S`
 ---
 */
 

--- a/compiler/test/runnable/test23805.d
+++ b/compiler/test/runnable/test23805.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=23805
+
+void main ()
+{
+    size_t destructionCount;
+    struct CantDestruct
+    {
+        int value;
+        ~this () { ++destructionCount; }
+    }
+    static void test(CantDestruct a) {}
+
+    test(CantDestruct.init);
+    CantDestruct b;
+    CantDestruct a = b.init;
+}


### PR DESCRIPTION
When using the `.init` property for a nested struct, the context pointer is set to null. This leads to segmentation fault whenever a method is called on the instance (including the destructor).

Initially, I had thought that using the `.init` property should be an error, however, pondering more about it, I came to the conclusion that it should be an error only if it is not used in a context where the struct it not defined. For example:

```d
void main ()
{
    size_t destructionCount;
    struct CantDestruct {
        int value;
        ~this () { ++destructionCount; }
    }
    static void test(CantDestruct a) {}
    test(CantDestruct.init);
}
```

This code should compile and the context pointer may be appropriately set, since the call to `test` is performed in a context that is known. However, if the type is passed to a template, then the context is no longer available:

```d
void fun(T)()
{
     T a = T.init;   // would fail when `fun` is instantiated with DontDestruct
                           //  T a; already fails anyway
}
```

This is in line with how the default initializer for nested struct works (i.e. `DontDestruct a`).

The test suite fails one runnable test:

```d
void test9003()
{
    int i;
    struct NS { 
        int n1;    // Comment to pass all asserts
        int n2;    // Uncomment to fail assert on line 19
        int f() { return i; } 
    }    

    static struct SS1 {                                                                                                 
        NS ns;
    }    
    SS1 ss1; 
    assert(ss1.ns != NS.init);   // => ss1.ns == NS.init with this patch
}
```

I think that the original patch for Issue 9003 [1] was misguided. I interpret `static` in this case as meaning "no context pointer". Since SS1 does not have a context pointer, it does not mean that its fields may not have one. And since we are using SS1 in a context where NS is defined, why not use that context pointer?

However, if `static` means "no dependence on the current scope", then it should be an error for SS1 to have a field of type NS.

Suggestions are welcome.

[1] https://github.com/dlang/dmd/pull/1282
