### PR TITLE
pull leaf functions out of VisualCPPMangler

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -3564,7 +3564,7 @@ final class CParser(AST) : Parser!AST
          *   enum Identifier : Type
          */
         //AST.Type base = AST.Type.tint32;  // C11 6.7.2.2-4 implementation defined default base type
-        AST.Type base = null;		    // C23 says base type is determined by enum member values
+        AST.Type base = null;               // C23 says base type is determined by enum member values
         if (token.value == TOK.colon)
         {
             nextToken();


### PR DESCRIPTION
The idea is to pull them out:

1. to reduce the length of VisualCPPMangler
2. functions are easier to understand when their inputs and outputs are through the front door

This is a cut&paste job.