### PR TITLE
Fix issue 14854 - @disable this inconsistent between structs and classes

### DIFF
--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -1458,7 +1458,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         auto dd = new PostBlitDeclaration(declLoc, Loc.initial, stc, Id.__aggrPostblit);
         dd.isGenerated = true;
         dd.storage_class |= STC.inference;
-        dd.fbody = new ExpStatement(loc, e);
+        dd.fbody = (stc & STC.disable) ? null : new ExpStatement(loc, e);
         sd.members.push(dd);
         dd.dsymbolSemantic(sc);
         xpostblit = dd;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -3114,6 +3114,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             printf("type: %p, %s\n", funcdecl.type, funcdecl.type.toChars());
         }
 
+        if (funcdecl.fbody && (funcdecl.storage_class & STC.disable))
+            funcdecl.deprecation("cannot be annotated with `@disable` because it has a body");
+
         if (funcdecl.semanticRun != PASS.initial && funcdecl.isFuncLiteralDeclaration())
         {
             /* Member functions that have return types that are

--- a/compiler/test/compilable/b14854.d
+++ b/compiler/test/compilable/b14854.d
@@ -1,0 +1,20 @@
+/*
+TEST_OUTPUT:
+---
+compilable/b14854.d(10): Deprecation: constructor `b14854.C1.this` cannot be annotated with `@disable` because it has a body
+---
+*/
+
+class C1
+{
+    @disable this() {}
+}
+
+class C2
+{
+    @disable this();
+}
+
+void main()
+{
+}


### PR DESCRIPTION
This PR adds an deprecation warning for all `@disable` annotations on functions which have a body, so at a later point in time this can be made an error without breaking any existing code surprisingly.

This PR is based on the old PR #9413, but which got closed for unknown reason.