### PR TITLE
Fix Issue 23816 - Typing invalid mnemonic in asm{} block segfaults

### DIFF
--- a/compiler/src/dmd/backend/dvarstats.d
+++ b/compiler/src/dmd/backend/dvarstats.d
@@ -374,12 +374,12 @@ private targ_size_t getLineOffset(int linnum)
 // return the first record index in the lineOffsets array with linnum >= line
 private int findLineIndex(uint line)
 {
-    uint low = 0;
-    uint high = cast(uint)lineOffsets.length;
+    int low = 0;
+    int high = cast(int)lineOffsets.length;
     while (low < high)
     {
-        uint mid = low + ((high - low) >> 1);
-        uint ln = lineOffsets[mid].linnum;
+        int mid = low + ((high - low) >> 1);
+        int ln = lineOffsets[mid].linnum;
         if (line < ln)
             high = mid;
         else if (line > ln)

--- a/compiler/src/dmd/backend/ptrntab.d
+++ b/compiler/src/dmd/backend/ptrntab.d
@@ -5833,9 +5833,9 @@ extern (C++) OP *asm_op_lookup(const(char)* s)
 @trusted
 private int binary(const(char)* p, const OP[] table)
 {
-    uint low = 0;
+    int low = 0;
     char cp = *p;
-    uint high = cast(uint)(table.length) - 1;
+    int high = cast(int)(table.length) - 1;
     p++;
 
     while (low <= high)

--- a/compiler/test/fail_compilation/fail23816.d
+++ b/compiler/test/fail_compilation/fail23816.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=23816
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23816.d(14): Error: opcode expected, not `NOP`
+---
+*/
+
+void main()
+{
+    asm
+    {
+        NOP;
+    }
+}


### PR DESCRIPTION
cc @WalterBright as this partially reverts: https://github.com/dlang/dmd/pull/14556. The PR wanted to guard against overflow but it introduced an underflow.