### PR TITLE
Fix Issue 23814 - [Codegen] Calling member function of extern(C++) class with multiple inheritance doesn't preserve the EBX register in some cases

### DIFF
--- a/compiler/src/dmd/backend/cod3.d
+++ b/compiler/src/dmd/backend/cod3.d
@@ -4889,7 +4889,7 @@ void cod3_thunk(Symbol *sthunk,Symbol *sfunc,uint p,tym_t thisty,
     }
     else
     {
-        if (config.flags3 & CFG3pic)
+        if (0 && config.flags3 & CFG3pic)
         {
             localgot = null;                // no local variables
             CodeBuilder cdbgot; cdbgot.ctor();


### PR DESCRIPTION
I'm not sure how to test this.
Also I  have little idea what I'm doing, so help is appreciated.