### PR TITLE
change & SC.global to ==

### DIFF
--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -652,7 +652,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 dt2common(&s.Sdt);
             }
 
-            if (s.Sclass & SC.global && s.Stype.Tty & mTYconst)
+            if (s.Sclass == SC.global && s.Stype.Tty & mTYconst)
                 out_readonly(s);
 
             outdata(s);


### PR DESCRIPTION
I noticed this typo. `SC.global` is an enumeration, not a flag. With trepidation let's see what fixing it does.