### PR TITLE
make frontend.parseModule root module by default

### DIFF
--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -410,6 +410,7 @@ Tuple!(Module, "module_", Diagnostics, "diagnostics") parseModule(AST = ASTCodeg
         m.src = fb;
     }
 
+    m.importedFrom = m;
     m = m.parseModule!AST();
 
     Diagnostics diagnostics = {


### PR DESCRIPTION
This ensures that the `module` created using `parseModule` from `frontend.d` will have the `isRoot()` property `true`. This is useful because when the module is not a root module, the parser will create simply an empty node for unittests(https://github.com/dlang/dmd/blob/master/compiler/src/dmd/parse.d#L549). In my use case I would want to include the corresponding unittest information in the AST when parsing. Should this be the default behavior, or maybe it should be configured, and we should add an additional parameter to the `parseModule` method?