### PR TITLE
[TEST] Revert "Don't store recursive alias this type in `UnaExp` (#15064)"

### DIFF
--- a/compiler/src/dmd/aliasthis.d
+++ b/compiler/src/dmd/aliasthis.d
@@ -200,29 +200,15 @@ bool checkDeprecatedAliasThis(AliasThis at, const ref Loc loc, Scope* sc)
 
 /**************************************
  * Check and set 'att' if 't' is a recursive 'alias this' type
- *
- * The goal is to prevent endless loops when there is a cycle in the alias this chain.
- * Since there is no multiple `alias this`, the chain either ends in a leaf,
- * or it loops back on itself as some point.
- *
- * Example: S0 -> (S1 -> S2 -> S3 -> S1)
- *
- * `S0` is not a recursive alias this, so this returns `false`, and a rewrite to `S1` can be tried.
- * `S1` is a recursive alias this type, but since `att` is initialized to `null`,
- * this still returns `false`, but `att1` is set to `S1`.
- * A rewrite to `S2` and `S3` can be tried, but when we want to try a rewrite to `S1` again,
- * we notice `att == t`, so we're back at the start of the loop, and this returns `true`.
- *
  * Params:
- *   att = type reference used to detect recursion. Should be initialized to `null`.
- *   t   = type of 'alias this' rewrite to attempt
+ *   att = type reference used to detect recursion
+ *   t   = 'alias this' type
  *
  * Returns:
- *   `false` if the rewrite is safe, `true` if it would loop back around
+ *   Whether the 'alias this' is recursive or not
  */
 bool isRecursiveAliasThis(ref Type att, Type t)
 {
-    //printf("+isRecursiveAliasThis(att = %s, t = %s)\n", att ? att.toChars() : "null", t.toChars());
     auto tb = t.toBasetype();
     if (att && tb.equivalent(att))
         return true;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -4360,6 +4360,7 @@ extern (C++) final class IsExp : Expression
 extern (C++) abstract class UnaExp : Expression
 {
     Expression e1;
+    Type att1;      // Save alias this type to detect recursion
 
     extern (D) this(const ref Loc loc, EXP op, Expression e1) scope
     {

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -699,6 +699,7 @@ class UnaExp : public Expression
 {
 public:
     Expression *e1;
+    Type *att1; // Save alias this type to detect recursion
 
     UnaExp *syntaxCopy() override;
     Expression *incompatibleTypes();

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4565,7 +4565,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
-        Type att = null;
     Lagain:
         //printf("Lagain: %s\n", toChars());
         exp.f = null;
@@ -4776,7 +4775,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // overload of opCall, therefore it's a call
                 if (exp.e1.op != EXP.type)
                 {
-                    if (sd.aliasthis && !isRecursiveAliasThis(att, exp.e1.type))
+                    if (sd.aliasthis && !isRecursiveAliasThis(exp.att1, exp.e1.type))
                     {
                         exp.e1 = resolveAliasThis(sc, exp.e1);
                         goto Lagain;
@@ -8952,7 +8951,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 assert((*ae.arguments)[0].op == EXP.interval);
                 ie = cast(IntervalExp)(*ae.arguments)[0];
             }
-            Type att = null; // first cyclic `alias this` type
             while (true)
             {
                 if (ae.e1.op == EXP.error)
@@ -9027,7 +9025,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 // No operator overloading member function found yet, but
                 // there might be an alias this to try.
-                if (ad.aliasthis && !isRecursiveAliasThis(att, ae.e1.type))
+                if (ad.aliasthis && !isRecursiveAliasThis(ae.att1, ae.e1.type))
                 {
                     /* Rewrite (a[arguments] op e2) as:
                      *      a.aliasthis[arguments] op e2

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6981,11 +6981,11 @@ private:
         char structliteralexp[84LLU];
         char compoundliteralexp[48LLU];
         char nullexp[34LLU];
-        char dotvarexp[57LLU];
-        char addrexp[48LLU];
+        char dotvarexp[65LLU];
+        char addrexp[56LLU];
         char indexexp[82LLU];
-        char sliceexp[73LLU];
-        char vectorexp[61LLU];
+        char sliceexp[81LLU];
+        char vectorexp[69LLU];
     };
     #pragma pack(pop)
 
@@ -7389,6 +7389,7 @@ class UnaExp : public Expression
 {
 public:
     Expression* e1;
+    Type* att1;
     UnaExp* syntaxCopy() override;
     Expression* incompatibleTypes();
     void setNoderefOperand();

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2072,12 +2072,6 @@ extern (C++) abstract class Type : ASTNode
         return null;
     }
 
-    /**
-     * Check whether this type has endless `alias this` recursion.
-     * Returns:
-     *   `true` if this type has an `alias this` that can be implicitly
-     *    converted back to this type itself.
-     */
     extern (D) final bool checkAliasThisRec()
     {
         Type tb = toBasetype();


### PR DESCRIPTION
This reverts commit be231c0c03fc21e079f0530be3afd51b163ca44f.

The test suite spuriously fails on Windows OMF targets:
```
FAILED targets:
- fail_compilation\bug9631.d
- fail_compilation\fail19948.d
```
The diff shows that the module name is not printed in front of a struct name in error messages.

I don't see how this commit is responsible for that, but it was the first commit where master doesn't pass anymore, so let's see what happens when I revert this. 

I can't reproduce the failure locally on my Windows laptop.