### PR TITLE
Fix Issue 18493 - [betterC] Can't use aggregated type with postblit

### DIFF
--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -1261,8 +1261,9 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
 
         // if this field's postblit is not `nothrow`, add a `scope(failure)`
         // block to destroy any prior successfully postblitted fields should
-        // this field's postblit fail
-        if (fieldsToDestroy.length > 0 && !(cast(TypeFunction)sdv.postblit.type).isnothrow)
+        // this field's postblit fail.
+        // Don't generate it for betterC code since it cannot throw exceptions.
+        if (fieldsToDestroy.length > 0 && !(cast(TypeFunction)sdv.postblit.type).isnothrow && !global.params.betterC)
         {
              // create a list of destructors that need to be called
             Expression[] dtorCalls;

--- a/compiler/test/compilable/test18493.d
+++ b/compiler/test/compilable/test18493.d
@@ -1,0 +1,19 @@
+// https://issues.dlang.org/show_bug.cgi?id=18493
+// REQUIRED_ARGS: -betterC
+
+struct S
+{
+    this(this)
+    {
+    }
+
+    ~this()
+    {
+    }
+}
+
+struct C
+{
+    S s1;
+    S s2;
+}


### PR DESCRIPTION
For this code:

```d
struct S
{
    this(this)
    {
    }

    ~this()
    {
    }
}

struct C
{
    S s1;
    S s2;
}
```

The compiler generates a field postblit for `C` which generates a `scope(failure)` block that calls the destructor of `s1`, in case the copy construction of `s2` issues an exception. This code generates an error in betterC because the scope failure is lowered to a try-catch block which requires druntime. This problem has been tackled in the past by #8253 by requiring the addition of nothow to postblits/destructors in betterC code, however, that was not accepted (see the PR for more information).

However, a much more simpler solution can be used: for betterC code just don't generate the `scope(failure)` code. This should be fine, since betterC code cannot throw exceptions, therefore no code is broken and no other annotations are required. I can imagine situations where this might be problematic: if you link betterC code with non-betterC code and you somehow call a user provided function in the postblit which is part of the non-betterC code, then you might end up with some problems  (namely if the user provided function throws, you will not destruct your already constructed fields), however I find this use case very exotic. Why would mix betterC code with non-betterC code?

Other than that, I think that this should be fine as is.

Thoughts?

Targeting master as this might be controversial.

cc @WalterBright @JinShil @PetarKirov as you have participated in the initial discussion.