### PR TITLE
Fix issue 23822: Check for deprecation before resolving alias on struct type member access.

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -3758,6 +3758,9 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         {
             return noMember(mt, sc, e, ident, flag);
         }
+        // check before alias resolution; the alias itself might be deprecated!
+        if (s.isAliasDeclaration)
+            e.checkDeprecated(sc, s);
         s = s.toAlias();
 
         if (auto em = s.isEnumMember())

--- a/compiler/test/fail_compilation/fail23822.d
+++ b/compiler/test/fail_compilation/fail23822.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=23822
+
+// REQUIRED_ARGS: -de
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23822.d(21): Deprecation: alias `fail23822.S.value` is deprecated
+---
+*/
+
+alias Alias(alias A) = A;
+
+struct S
+{
+    deprecated alias value = Alias!5;
+}
+
+void main()
+{
+    auto a = S.value;
+}


### PR DESCRIPTION
## Example

```
alias Alias(alias A) = A;
struct S { deprecated alias value = Alias!5; }
// make this access give a deprecation
void main() { auto a = S.value; }
```

## Stable or master?

CONTRIBUTING.md says "only regressions on stable, everything else on master, as outlined in [our release process](https://wiki.dlang.org/DIP75)."

But [our release process](https://wiki.dlang.org/DIP75) says: "TL;DR Safe fixes should always go into stable, all the time." And doesn't define what a "safe fix" is.

So I'll go for 'master' for now, because this PR may cause programs to error that previously (wrongly) didn't.