### PR TITLE
Fix issue 23826: Check for deprecation when passing type member as template argument.

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -290,6 +290,8 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
         if (!sm)
             return helper3();
 
+        if (sm.isAliasDeclaration)
+            sm.checkDeprecated(loc, sc);
         s = sm.toAlias();
     }
 

--- a/compiler/test/fail_compilation/fail23826.d
+++ b/compiler/test/fail_compilation/fail23826.d
@@ -1,0 +1,24 @@
+// https://issues.dlang.org/show_bug.cgi?id=23826
+
+// REQUIRED_ARGS: -de
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail23826.d(23): Deprecation: alias `fail23826.S.value` is deprecated
+---
+*/
+
+alias Alias(alias A) = A;
+
+class S
+{
+    deprecated alias value = Alias!5;
+}
+
+enum identity(alias A) = A;
+
+void main()
+{
+    auto a = identity!(S.value);
+}


### PR DESCRIPTION
See also #15077 .

## Example

```
alias Alias(alias A) = A;

class S { deprecated alias value = Alias!5; }
enum identity(alias A) = A;
void main() { auto a = identity!(S.value); }
```
