### PR TITLE
Fix Issue 23827 - IsExpression allows Identifier outside static if/assert

### DIFF
--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -62,6 +62,7 @@ enum SCOPE
     compile       = 0x0100,   /// inside __traits(compile)
     ignoresymbolvisibility    = 0x0200,   /// ignore symbol visibility
                                           /// https://issues.dlang.org/show_bug.cgi?id=15907
+    shortcut      = 0x0400,   /// in compile-time expression but not `condition`
     Cfile         = 0x0800,   /// C semantics apply
     free          = 0x8000,   /// is on free list
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -613,7 +613,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             bool needctfe = (dsym.storage_class & (STC.manifest | STC.static_)) != 0 || !sc.func;
             if (needctfe)
             {
-                sc.flags |= SCOPE.condition;
+                sc.flags |= SCOPE.shortcut;
                 sc = sc.startCTFE();
             }
             //printf("inferring type for %s with init %s\n", dsym.toChars(), dsym._init.toChars());

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -13248,7 +13248,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         e1x = resolveProperties(sc, e1x);
         e1x = e1x.toBoolean(sc);
 
-        if (sc.flags & SCOPE.condition)
+        if (sc.flags & (SCOPE.condition | SCOPE.shortcut))
         {
             /* If in static if, don't evaluate e2 if we don't have to.
              */

--- a/compiler/test/fail_compilation/isexpident.d
+++ b/compiler/test/fail_compilation/isexpident.d
@@ -1,0 +1,16 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/isexpident.d(11): Error: can only declare type aliases within `static if` conditionals or `static assert`s
+fail_compilation/isexpident.d(12): Error: can only declare type aliases within `static if` conditionals or `static assert`s
+fail_compilation/isexpident.d(14): Error: can only declare type aliases within `static if` conditionals or `static assert`s
+fail_compilation/isexpident.d(15): Error: can only declare type aliases within `static if` conditionals or `static assert`s
+---
+*/
+void main()
+{
+    enum e = is(int Int);
+    assert(is(int Int1 == const));
+
+    if (is(int Int2)) {}
+    auto x = is(int Int3 : float);
+}


### PR DESCRIPTION
Bug introduced in #10939.