### PR TITLE
IFTI with Alias Templates.

### DIFF
--- a/changelog/dmd.alias-template-ifti.dd
+++ b/changelog/dmd.alias-template-ifti.dd
@@ -1,0 +1,29 @@
+IFTI works with alias template parameters.
+
+The alias declaration should contain and end with one `TemplateInstance`.
+
+---
+struct S(T) {}
+alias A(T) = S!T;
+void f(T)(A!T) {}
+
+struct C(T)
+{
+    struct D(U)
+    {
+    }
+}
+
+alias E(T, U) = C!T.D!U;
+
+void f(T, U)(E!(T, U)) {}
+void main()
+{
+    A!int a;
+    f(a); // OK
+    static assert(is(A!int == A!U, U)); // OK
+
+    C!int.D!char cd;
+    // f(cd); // error
+}
+---

--- a/changelog/dmd.alias-template-ifti.dd
+++ b/changelog/dmd.alias-template-ifti.dd
@@ -1,29 +1,65 @@
 IFTI works with alias template parameters.
 
-The alias declaration should contain and end with one `TemplateInstance`.
+The alias declaration should contain and end with only one `TemplateInstance` that uses all alias template parameters.
 
 ---
-struct S(T) {}
+struct S(T)
+{
+}
+
 alias A(T) = S!T;
-void f(T)(A!T) {}
+void f(T)(A!T)
+{
+}
 
 struct C(T)
 {
     struct D(U)
     {
     }
+
+    struct E
+    {
+
+    }
 }
 
-alias E(T, U) = C!T.D!U;
+struct G
+{
+    struct H(U)
+    {
 
-void f(T, U)(E!(T, U)) {}
+    }
+}
+
+alias CD(T, U) = C!T.D!U;
+alias CE(T) = C!T.E;
+alias GH(T) = G.H!T;
+
+void f(T, U)(CD!(T, U))
+{
+}
+
+void g(T)(CE!T)
+{
+}
+
+void h(T)(GH!T)
+{
+}
+
 void main()
 {
     A!int a;
     f(a); // OK
     static assert(is(A!int == A!U, U)); // OK
 
-    C!int.D!char cd;
+    CD!(int, char) cd;
+    CE!int ce;
     // f(cd); // error
+    // g(ce); // error
+
+    GH!float gh;
+    h(gh); // OK
 }
 ---

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -4183,7 +4183,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                                             size_t k = (t2 && t2.ty == Tident && j == tp.tempinst.tiargs.length - 1)
                                                 ? templateParameterLookup(t2, parameters) : IDX_NOTFOUND;
                                             if (k != IDX_NOTFOUND && k == parameters.length - 1 &&
-                                                (*parameters)[j].isTemplateTupleParameter())
+                                                (*parameters)[k].isTemplateTupleParameter())
                                             {
                                                 size_t vtdim = adedtypes.length - j;
                                                 auto vt = new Tuple(vtdim);

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -4074,6 +4074,20 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             // Extra check
             if (tparam && tparam.ty == Tinstance && t.tempinst.tempdecl)
             {
+                void flattenDedTypes(Objects* dedtypes)
+                {
+                    if ((*dedtypes)[$ - 1].isTuple())
+                    {
+                        auto ptp = (*dedtypes)[$ - 1].isTuple();
+                        dedtypes.pop();
+                        dedtypes.reserve(dedtypes.length + ptp.objects.length);
+                        for (int j = 0; j < ptp.objects.length; j++)
+                        {
+                            dedtypes.push(ptp.objects[j]);
+                        }
+                    }
+                }
+
                 TemplateDeclaration tempdecl = t.tempinst.tempdecl.isTemplateDeclaration();
                 assert(tempdecl);
 
@@ -4167,17 +4181,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                                         MATCH am = deduceType(t, asc, atdi, td.parameters, adedtypes);
                                         if (am != MATCH.exact)
                                             goto Lnomatch;
-                                        // flatten adedtypes
-                                        if ((*adedtypes)[$ - 1].isTuple())
-                                        {
-                                            auto ptp = (*adedtypes)[$ - 1].isTuple();
-                                            adedtypes.pop();
-                                            adedtypes.reserve(adedtypes.length + ptp.objects.length);
-                                            for (int j = 0; j < ptp.objects.length; j++)
-                                            {
-                                                adedtypes.push(ptp.objects[j]);
-                                            }
-                                        }
+                                        flattenDedTypes(adedtypes);
                                         // yet to deduce
                                         // <parameters> (SomeAlias<adedtypes>);
                                         // a simplistic matcher

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -4260,7 +4260,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                                                 k = templateParameterLookup(t2, parameters);
                                                 if (k == IDX_NOTFOUND)
                                                     goto Lnomatch;
-                                                if (!(*parameters)[j].matchArg(sc, e1, j, parameters, dedtypes, null))
+                                                if (!(*parameters)[k].matchArg(sc, e1, k, parameters, dedtypes, null))
                                                     goto Lnomatch;
                                             }
                                             else if (s1 && s2)
@@ -4270,10 +4270,10 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                                             }
                                             else if (s1 && t2 && t2.ty == Tident)
                                             {
-                                                j = templateParameterLookup(t2, parameters);
-                                                if (j == IDX_NOTFOUND)
+                                                k = templateParameterLookup(t2, parameters);
+                                                if (k == IDX_NOTFOUND)
                                                     goto Lnomatch;
-                                                if (!(*parameters)[j].matchArg(sc, s1, j, parameters, dedtypes, null))
+                                                if (!(*parameters)[k].matchArg(sc, s1, k, parameters, dedtypes, null))
                                                     goto Lnomatch;
                                             }
                                             else

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -4141,178 +4141,8 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     goto Lnomatch;
 
             L2:
-                for (size_t i = 0; 1; i++)
-                {
-                    //printf("\ttest: tempinst.tiargs[%zu]\n", i);
-                    RootObject o1 = null;
-                    if (i < t.tempinst.tiargs.length)
-                        o1 = (*t.tempinst.tiargs)[i];
-                    else if (i < t.tempinst.tdtypes.length && i < tp.tempinst.tiargs.length)
-                    {
-                        // Pick up default arg
-                        o1 = t.tempinst.tdtypes[i];
-                    }
-                    else if (i >= tp.tempinst.tiargs.length)
-                        break;
-                    //printf("\ttest: o1 = %s\n", o1.toChars());
-                    if (i >= tp.tempinst.tiargs.length)
-                    {
-                        size_t dim = tempdecl.parameters.length - (tempdecl.isVariadic() ? 1 : 0);
-                        while (i < dim && ((*tempdecl.parameters)[i].dependent || (*tempdecl.parameters)[i].hasDefaultArg()))
-                        {
-                            i++;
-                        }
-                        if (i >= dim)
-                            break; // match if all remained parameters are dependent
-                        goto Lnomatch;
-                    }
-
-                    RootObject o2 = (*tp.tempinst.tiargs)[i];
-                    Type t2 = isType(o2);
-                    //printf("\ttest: o2 = %s\n", o2.toChars());
-                    size_t j = (t2 && t2.ty == Tident && i == tp.tempinst.tiargs.length - 1)
-                        ? templateParameterLookup(t2, parameters) : IDX_NOTFOUND;
-                    if (j != IDX_NOTFOUND && j == parameters.length - 1 &&
-                        (*parameters)[j].isTemplateTupleParameter())
-                    {
-                        /* Given:
-                         *  struct A(B...) {}
-                         *  alias A!(int, float) X;
-                         *  static if (is(X Y == A!(Z), Z...)) {}
-                         * deduce that Z is a tuple(int, float)
-                         */
-
-                        /* Create tuple from remaining args
-                         */
-                        size_t vtdim = (tempdecl.isVariadic() ? t.tempinst.tiargs.length : t.tempinst.tdtypes.length) - i;
-                        auto vt = new Tuple(vtdim);
-                        for (size_t k = 0; k < vtdim; k++)
-                        {
-                            RootObject o;
-                            if (k < t.tempinst.tiargs.length)
-                                o = (*t.tempinst.tiargs)[i + k];
-                            else // Pick up default arg
-                                o = t.tempinst.tdtypes[i + k];
-                            vt.objects[k] = o;
-                        }
-
-                        Tuple v = cast(Tuple)(*dedtypes)[j];
-                        if (v)
-                        {
-                            if (!match(v, vt))
-                                goto Lnomatch;
-                        }
-                        else
-                            (*dedtypes)[j] = vt;
-                        break;
-                    }
-                    else if (!o1)
-                        break;
-
-                    Type t1 = isType(o1);
-                    Dsymbol s1 = isDsymbol(o1);
-                    Dsymbol s2 = isDsymbol(o2);
-                    Expression e1 = s1 ? getValue(s1) : getValue(isExpression(o1));
-                    Expression e2 = isExpression(o2);
-                    version (none)
-                    {
-                        Tuple v1 = isTuple(o1);
-                        Tuple v2 = isTuple(o2);
-                        if (t1)
-                            printf("t1 = %s\n", t1.toChars());
-                        if (t2)
-                            printf("t2 = %s\n", t2.toChars());
-                        if (e1)
-                            printf("e1 = %s\n", e1.toChars());
-                        if (e2)
-                            printf("e2 = %s\n", e2.toChars());
-                        if (s1)
-                            printf("s1 = %s\n", s1.toChars());
-                        if (s2)
-                            printf("s2 = %s\n", s2.toChars());
-                        if (v1)
-                            printf("v1 = %s\n", v1.toChars());
-                        if (v2)
-                            printf("v2 = %s\n", v2.toChars());
-                    }
-
-                    if (t1 && t2)
-                    {
-                        if (!deduceType(t1, sc, t2, parameters, dedtypes))
-                            goto Lnomatch;
-                    }
-                    else if (e1 && e2)
-                    {
-                    Le:
-                        e1 = e1.ctfeInterpret();
-
-                        /* If it is one of the template parameters for this template,
-                         * we should not attempt to interpret it. It already has a value.
-                         */
-                        if (e2.op == EXP.variable && (e2.isVarExp().var.storage_class & STC.templateparameter))
-                        {
-                            /*
-                             * (T:Number!(e2), int e2)
-                             */
-                            j = templateIdentifierLookup(e2.isVarExp().var.ident, parameters);
-                            if (j != IDX_NOTFOUND)
-                                goto L1;
-                            // The template parameter was not from this template
-                            // (it may be from a parent template, for example)
-                        }
-
-                        e2 = e2.expressionSemantic(sc); // https://issues.dlang.org/show_bug.cgi?id=13417
-                        e2 = e2.ctfeInterpret();
-
-                        //printf("e1 = %s, type = %s %d\n", e1.toChars(), e1.type.toChars(), e1.type.ty);
-                        //printf("e2 = %s, type = %s %d\n", e2.toChars(), e2.type.toChars(), e2.type.ty);
-                        if (!e1.equals(e2))
-                        {
-                            if (!e2.implicitConvTo(e1.type))
-                                goto Lnomatch;
-
-                            e2 = e2.implicitCastTo(sc, e1.type);
-                            e2 = e2.ctfeInterpret();
-                            if (!e1.equals(e2))
-                                goto Lnomatch;
-                        }
-                    }
-                    else if (e1 && t2 && t2.ty == Tident)
-                    {
-                        j = templateParameterLookup(t2, parameters);
-                    L1:
-                        if (j == IDX_NOTFOUND)
-                        {
-                            t2.resolve((cast(TypeIdentifier)t2).loc, sc, e2, t2, s2);
-                            if (e2)
-                                goto Le;
-                            goto Lnomatch;
-                        }
-                        if (!(*parameters)[j].matchArg(sc, e1, j, parameters, dedtypes, null))
-                            goto Lnomatch;
-                    }
-                    else if (s1 && s2)
-                    {
-                    Ls:
-                        if (!s1.equals(s2))
-                            goto Lnomatch;
-                    }
-                    else if (s1 && t2 && t2.ty == Tident)
-                    {
-                        j = templateParameterLookup(t2, parameters);
-                        if (j == IDX_NOTFOUND)
-                        {
-                            t2.resolve((cast(TypeIdentifier)t2).loc, sc, e2, t2, s2);
-                            if (s2)
-                                goto Ls;
-                            goto Lnomatch;
-                        }
-                        if (!(*parameters)[j].matchArg(sc, s1, j, parameters, dedtypes, null))
-                            goto Lnomatch;
-                    }
-                    else
-                        goto Lnomatch;
-                }
+                if (!resolveTemplateInstantiation(t.tempinst.tiargs, &t.tempinst.tdtypes, tempdecl, tp, dedtypes))
+                    goto Lnomatch;
             }
             visit(cast(Type)t);
             return;
@@ -4320,6 +4150,197 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         Lnomatch:
             //printf("no match\n");
             result = MATCH.nomatch;
+        }
+
+        /********************
+         * Example
+         *    struct Temp(U, int Z) {}
+         *    void foo(T)(Temp!(T, 3));
+         *    foo(Temp!(int, 3)());
+         * Input:
+         *    this.parameters  [T]
+         *    tiargs           <Temp!(int, 3)>.tiargs  -> [int, 3]
+         *    tdtypes          <Temp!(int, 3)>.tdtypes -> [int, 3]
+         *    tempdecl         <struct Temp!(T, int Z)>
+         *    tp               <Temp!(T, 3)>
+         * Output:
+         *    dedtypes  [int]
+         */
+        private bool resolveTemplateInstantiation(Objects* tiargs, Objects* tdtypes, TemplateDeclaration tempdecl, TypeInstance tp, Objects* dedtypes)
+        {
+            for (size_t i = 0; 1; i++)
+            {
+                //printf("\ttest: tempinst.tiargs[%zu]\n", i);
+                RootObject o1 = null;
+                if (i < tiargs.length)
+                    o1 = (*tiargs)[i];
+                else if (i < tdtypes.length && i < tp.tempinst.tiargs.length)
+                {
+                    // Pick up default arg
+                    o1 = (*tdtypes)[i];
+                }
+                else if (i >= tp.tempinst.tiargs.length)
+                    break;
+                //printf("\ttest: o1 = %s\n", o1.toChars());
+                if (i >= tp.tempinst.tiargs.length)
+                {
+                    size_t dim = tempdecl.parameters.length - (tempdecl.isVariadic() ? 1 : 0);
+                    while (i < dim && ((*tempdecl.parameters)[i].dependent || (*tempdecl.parameters)[i].hasDefaultArg()))
+                    {
+                        i++;
+                    }
+                    if (i >= dim)
+                        break; // match if all remained parameters are dependent
+                    return false;
+                }
+
+                RootObject o2 = (*tp.tempinst.tiargs)[i];
+                Type t2 = isType(o2);
+                //printf("\ttest: o2 = %s\n", o2.toChars());
+                size_t j = (t2 && t2.ty == Tident && i == tp.tempinst.tiargs.length - 1)
+                    ? templateParameterLookup(t2, parameters) : IDX_NOTFOUND;
+                if (j != IDX_NOTFOUND && j == parameters.length - 1 &&
+                    (*parameters)[j].isTemplateTupleParameter())
+                {
+                    /* Given:
+                         *  struct A(B...) {}
+                         *  alias A!(int, float) X;
+                         *  static if (is(X Y == A!(Z), Z...)) {}
+                         * deduce that Z is a tuple(int, float)
+                         */
+
+                    /* Create tuple from remaining args
+                         */
+                    size_t vtdim = (tempdecl.isVariadic() ? tiargs.length : tdtypes.length) - i;
+                    auto vt = new Tuple(vtdim);
+                    for (size_t k = 0; k < vtdim; k++)
+                    {
+                        RootObject o;
+                        if (k < tiargs.length)
+                            o = (*tiargs)[i + k];
+                        else // Pick up default arg
+                            o = (*tdtypes)[i + k];
+                        vt.objects[k] = o;
+                    }
+
+                    Tuple v = cast(Tuple)(*dedtypes)[j];
+                    if (v)
+                    {
+                        if (!match(v, vt))
+                            return false;
+                    }
+                    else
+                        (*dedtypes)[j] = vt;
+                    break;
+                }
+                else if (!o1)
+                    break;
+
+                Type t1 = isType(o1);
+                Dsymbol s1 = isDsymbol(o1);
+                Dsymbol s2 = isDsymbol(o2);
+                Expression e1 = s1 ? getValue(s1) : getValue(isExpression(o1));
+                Expression e2 = isExpression(o2);
+                version (none)
+                {
+                    Tuple v1 = isTuple(o1);
+                    Tuple v2 = isTuple(o2);
+                    if (t1)
+                        printf("t1 = %s\n", t1.toChars());
+                    if (t2)
+                        printf("t2 = %s\n", t2.toChars());
+                    if (e1)
+                        printf("e1 = %s\n", e1.toChars());
+                    if (e2)
+                        printf("e2 = %s\n", e2.toChars());
+                    if (s1)
+                        printf("s1 = %s\n", s1.toChars());
+                    if (s2)
+                        printf("s2 = %s\n", s2.toChars());
+                    if (v1)
+                        printf("v1 = %s\n", v1.toChars());
+                    if (v2)
+                        printf("v2 = %s\n", v2.toChars());
+                }
+
+                if (t1 && t2)
+                {
+                    if (!deduceType(t1, sc, t2, parameters, dedtypes))
+                        return false;
+                }
+                else if (e1 && e2)
+                {
+                Le:
+                    e1 = e1.ctfeInterpret();
+
+                    /* If it is one of the template parameters for this template,
+                         * we should not attempt to interpret it. It already has a value.
+                         */
+                    if (e2.op == EXP.variable && (e2.isVarExp().var.storage_class & STC.templateparameter))
+                    {
+                        /*
+                             * (T:Number!(e2), int e2)
+                             */
+                        j = templateIdentifierLookup(e2.isVarExp().var.ident, parameters);
+                        if (j != IDX_NOTFOUND)
+                            goto L1;
+                        // The template parameter was not from this template
+                        // (it may be from a parent template, for example)
+                    }
+
+                    e2 = e2.expressionSemantic(sc); // https://issues.dlang.org/show_bug.cgi?id=13417
+                    e2 = e2.ctfeInterpret();
+
+                    //printf("e1 = %s, type = %s %d\n", e1.toChars(), e1.type.toChars(), e1.type.ty);
+                    //printf("e2 = %s, type = %s %d\n", e2.toChars(), e2.type.toChars(), e2.type.ty);
+                    if (!e1.equals(e2))
+                    {
+                        if (!e2.implicitConvTo(e1.type))
+                            return false;
+
+                        e2 = e2.implicitCastTo(sc, e1.type);
+                        e2 = e2.ctfeInterpret();
+                        if (!e1.equals(e2))
+                            return false;
+                    }
+                }
+                else if (e1 && t2 && t2.ty == Tident)
+                {
+                    j = templateParameterLookup(t2, parameters);
+                L1:
+                    if (j == IDX_NOTFOUND)
+                    {
+                        t2.resolve((cast(TypeIdentifier)t2).loc, sc, e2, t2, s2);
+                        if (e2)
+                            goto Le;
+                        return false;
+                    }
+                    if (!(*parameters)[j].matchArg(sc, e1, j, parameters, dedtypes, null))
+                        return false;
+                }
+                else if (s1 && s2)
+                {
+                Ls:
+                    if (!s1.equals(s2))
+                        return false;
+                }
+                else if (s1 && t2 && t2.ty == Tident)
+                {
+                    j = templateParameterLookup(t2, parameters);
+                    if (j == IDX_NOTFOUND)
+                    {
+                        t2.resolve((cast(TypeIdentifier)t2).loc, sc, e2, t2, s2);
+                        if (s2)
+                            goto Ls;
+                        return false;
+                    }
+                    if (!(*parameters)[j].matchArg(sc, s1, j, parameters, dedtypes, null))
+                        return false;
+                }
+                else
+                    return false;
+            }
+            return true;
         }
 
         override void visit(TypeStruct t)

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -4153,18 +4153,19 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         }
 
         /********************
-         * Example
+         * Match template `parameters` to the target template instance.
+         * Example:
          *    struct Temp(U, int Z) {}
          *    void foo(T)(Temp!(T, 3));
          *    foo(Temp!(int, 3)());
          * Input:
-         *    this.parameters  [T]
-         *    tiargs           <Temp!(int, 3)>.tiargs  -> [int, 3]
-         *    tdtypes          <Temp!(int, 3)>.tdtypes -> [int, 3]
-         *    tempdecl         <struct Temp!(T, int Z)>
-         *    tp               <Temp!(T, 3)>
+         *    this.parameters  = template params of foo -> [T]
+         *    tiargs           = <Temp!(int, 3)>.tiargs  -> [int, 3]
+         *    tdtypes          = <Temp!(int, 3)>.tdtypes -> [int, 3]
+         *    tempdecl         = <struct Temp!(T, int Z)> -> [T, Z]
+         *    tp               = <Temp!(T, 3)>
          * Output:
-         *    dedtypes  [int]
+         *    dedtypes         = deduced params of `foo(Temp!(int, 3)())` -> [int]
          */
         private bool resolveTemplateInstantiation(Objects* tiargs, Objects* tdtypes, TemplateDeclaration tempdecl, TypeInstance tp, Objects* dedtypes)
         {

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -4118,8 +4118,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         if (s)
                         {
                             s = s.toAlias();
-                            TemplateDeclaration td = s.isTemplateDeclaration();
-                            if (td)
+                            if (TemplateDeclaration td = s.isTemplateDeclaration())
                             {
                                 if (td.overroot)
                                     td = td.overroot;
@@ -4127,6 +4126,137 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                                 {
                                     if (td == tempdecl)
                                         goto L2;
+                                }
+                            }
+                            if (TemplateDeclaration td = s.isTemplateDeclaration())
+                            {
+                                // for alias decl without overloads
+                                if (!td.overroot && td.onemember && td.onemember.isAliasDeclaration())
+                                {
+                                    AliasDeclaration atd = td.onemember.isAliasDeclaration();
+                                    if (TypeInstance atdi = atd.getType().isTypeInstance())
+                                    {
+                                        Objects* adedtypes = new Objects(td.parameters.length);
+                                        adedtypes.zero();
+                                        // alias SomeAlias(<td.parameters>) = SomeTempOrAlias!(<adedtypes>>);
+                                        MATCH am = deduceType(t, s._scope, atdi, td.parameters, adedtypes);
+                                        if (am != MATCH.exact)
+                                            goto Lnomatch;
+                                        // flatten adedtypes
+                                        if ((*adedtypes)[$ - 1].isTuple())
+                                        {
+                                            auto ptp = (*adedtypes)[$ - 1].isTuple();
+                                            adedtypes.pop();
+                                            adedtypes.reserve(adedtypes.length + ptp.objects.length);
+                                            for (int j = 0; j < ptp.objects.length; j++)
+                                            {
+                                                adedtypes.push(ptp.objects[j]);
+                                            }
+                                        }
+                                        // yet to deduce
+                                        // <parameters> (SomeAlias<adedtypes>);
+                                        // a simplistic matcher
+                                        // dedtypes           -- output
+                                        // parameters         -- corresponding to dedtypes
+                                        // tp.tempinst.tiargs -- alias inst tiargs
+                                        // adedtypes          -- alias decl params deduced
+                                        for (size_t j = 0; 1; j++)
+                                        {
+                                            RootObject o1 = null;
+                                            RootObject o2 = null;
+                                            if (j < adedtypes.length)
+                                                o1 = (*adedtypes)[j];
+                                            else
+                                                break;
+                                            if (j < tp.tempinst.tiargs.length)
+                                            {
+                                                o2 = (*tp.tempinst.tiargs)[j];
+                                            }
+                                            else if (j < td.parameters.length)
+                                            {
+                                                if ((*td.parameters)[j].hasDefaultArg())
+                                                {
+                                                    break;
+                                                }
+                                            }
+                                            Type t2 = isType(o2);
+                                            size_t k = (t2 && t2.ty == Tident && j == tp.tempinst.tiargs.length - 1)
+                                                ? templateParameterLookup(t2, parameters) : IDX_NOTFOUND;
+                                            if (k != IDX_NOTFOUND && k == parameters.length - 1 &&
+                                                (*parameters)[j].isTemplateTupleParameter())
+                                            {
+                                                size_t vtdim = adedtypes.length - j;
+                                                auto vt = new Tuple(vtdim);
+                                                for (size_t l = 0; l < vtdim; l ++)
+                                                {
+                                                    vt.objects[l] = (*adedtypes)[l];
+                                                }
+                                                if (Tuple v = cast(Tuple)(*dedtypes)[j])
+                                                {
+                                                    if (!match(v, vt))
+                                                        goto Lnomatch;
+                                                }
+                                                else
+                                                {
+                                                    (*dedtypes)[k] = vt;
+                                                }
+                                                break;
+                                            }
+                                            else if (!o1)
+                                                break;
+                                            Type t1 = o1.isType();
+                                            Dsymbol s1 = o1.isDsymbol();
+                                            Dsymbol s2 = isDsymbol(o2);
+                                            Expression e1 = s1 ? s1.getValue() : o1.isExpression().getValue();
+                                            Expression e2 = o2.isExpression();
+                                            if (t1 && t2)
+                                            {
+                                                if (!deduceType(t1, sc, t2, parameters, dedtypes))
+                                                    goto Lnomatch;
+                                            }
+                                            else if (e1 && e2)
+                                            {
+                                                e1 = e1.ctfeInterpret();
+                                                e2 = e2.expressionSemantic(sc);
+                                                e2 = e2.ctfeInterpret();
+                                                if (!e1.equals(e2))
+                                                {
+                                                    if (!e2.implicitConvTo(e1.type))
+                                                        goto Lnomatch;
+
+                                                    e2 = e2.implicitCastTo(sc, e1.type);
+                                                    e2 = e2.ctfeInterpret();
+                                                    if (!e1.equals(e2))
+                                                        goto Lnomatch;
+                                                }
+                                            }
+                                            else if (e1 && t2 && t2.ty == Tident)
+                                            {
+                                                k = templateParameterLookup(t2, parameters);
+                                                if (k == IDX_NOTFOUND)
+                                                    goto Lnomatch;
+                                                if (!(*parameters)[j].matchArg(sc, e1, j, parameters, dedtypes, null))
+                                                    goto Lnomatch;
+                                            }
+                                            else if (s1 && s2)
+                                            {
+                                                if (s1.equals(s2))
+                                                    goto Lnomatch;
+                                            }
+                                            else if (s1 && t2 && t2.ty == Tident)
+                                            {
+                                                j = templateParameterLookup(t2, parameters);
+                                                if (j == IDX_NOTFOUND)
+                                                    goto Lnomatch;
+                                                if (!(*parameters)[j].matchArg(sc, s1, j, parameters, dedtypes, null))
+                                                    goto Lnomatch;
+                                            }
+                                            else
+                                                goto Lnomatch;
+                                        }
+                                        visit(cast(Type) t);
+                                        return;
+                                    }
                                 }
                             }
                         }

--- a/compiler/test/compilable/imports/imptestatifti.d
+++ b/compiler/test/compilable/imports/imptestatifti.d
@@ -1,0 +1,6 @@
+module imports.imptestatifti;
+
+struct Temp2(U)
+{
+
+}

--- a/compiler/test/compilable/testatifti.d
+++ b/compiler/test/compilable/testatifti.d
@@ -1,3 +1,5 @@
+// https://issues.dlang.org/show_bug.cgi?id=16486
+// Alias Template IFTI
 module testatifti;
 
 struct TempT(T)

--- a/compiler/test/compilable/testatifti.d
+++ b/compiler/test/compilable/testatifti.d
@@ -1,0 +1,102 @@
+module testatifti;
+
+struct TempT(T)
+{
+
+}
+
+alias AliasT(U) = TempT!U;
+alias AliasPT(U) = TempT!(U*);
+
+void fooAliasT(U)(AliasT!U v)
+{
+    static assert(is(U == float));
+    static assert(is(typeof(v) == TempT!(float)));
+}
+
+void fooAliasPT(U)(AliasPT!(U) v)
+{
+    static assert(is(U == float));
+    static assert(is(typeof(v) == TempT!(float*)));
+}
+
+void pfooAliasPT(U)(AliasPT!(U*) v)
+{
+    static assert(is(U == float));
+    static assert(is(typeof(v) == TempT!(float**)));
+}
+
+struct TempVar(T...)
+{
+
+}
+
+alias AliasVar(T, U...) = TempVar!(T, U);
+
+void fooAliasVar(U...)(AliasVar!U v)
+{
+    static assert(is(U[0] == float));
+    static assert(is(U[1] == int));
+    static assert(is(U[2] == char));
+    static assert(is(U[3] == string));
+}
+
+struct TempDiverse(X, Y, size_t Z, alias W)
+{
+}
+
+alias AliasDiverse(P, Q, alias R, size_t S) = TempDiverse!(Q, P, S, R);
+
+void fooAliasDiverse(A, B, alias C, size_t D)(AliasDiverse!(B, A, C, D) v)
+{
+    static assert(is(A == string));
+    static assert(is(B == char));
+    static assert(C == 1);
+    static assert(D == 12);
+    static assert(is(typeof(v) == TempDiverse!(string, char, 12, 1)));
+}
+
+struct Matrix(U, size_t M, size_t N)
+{
+
+}
+
+alias Vector(U, size_t N) = Matrix!(U, N, 1);
+alias Vector3(U) = Vector!(U, 3);
+
+void normalize(U, size_t N)(ref Vector!(U, N) v)
+{
+}
+
+Vector3!U cross(U)(Vector3!U a, Vector3!U b)
+{
+    return Vector3!U.init;
+}
+
+// a case grabbed from PR #9778
+struct TestType(T, Q)
+{
+}
+
+alias TestAliasA(A, B) = TestType!(A, B);
+alias TestAlias(T, Q) = TestAliasA!(Q, T);
+void test(X, Y)(TestAliasA!(X, Y) v)
+{
+}
+
+void main()
+{
+    fooAliasT(AliasT!float());
+    fooAliasPT(AliasPT!(float)());
+    pfooAliasPT(AliasPT!(float*)());
+    fooAliasVar(AliasVar!(float, int, char, string)());
+    fooAliasDiverse(AliasDiverse!(char, string, 1, 12)());
+
+    static assert(is(Vector3!float == Vector3!U, U)); // !!! 
+
+    Vector!(float, 10) v;
+    normalize(v);
+    auto vv = cross(Vector3!float(), Vector3!float());
+
+    test(TestAlias!(float, char)());
+}

--- a/compiler/test/compilable/testatifti.d
+++ b/compiler/test/compilable/testatifti.d
@@ -92,7 +92,8 @@ void main()
     fooAliasVar(AliasVar!(float, int, char, string)());
     fooAliasDiverse(AliasDiverse!(char, string, 1, 12)());
 
-    static assert(is(Vector3!float == Vector3!U, U)); // !!! 
+    static assert(is(Vector3!float == Vector3!U, U)); // !!!
+    static assert(is(Vector!(float, 3) == Vector!(U, N), U, size_t N));
 
     Vector!(float, 10) v;
     normalize(v);

--- a/compiler/test/compilable/testatifti.d
+++ b/compiler/test/compilable/testatifti.d
@@ -1,6 +1,14 @@
 // https://issues.dlang.org/show_bug.cgi?id=16486
+// EXTRA_FILES: imports/imptestatifti.d
 // Alias Template IFTI
 module testatifti;
+static import imports.imptestatifti;
+
+alias Alias1(U) = imports.imptestatifti.Temp2!U;
+
+void foo1(U)(Alias1!U v)
+{
+}
 
 struct TempT(T)
 {
@@ -107,4 +115,6 @@ void main()
 
     Vector3!float vv = cross(Vector3!float(), Vector3!float());
     test(TestAlias!(float, char)());
+
+    foo1(Alias1!float());
 }

--- a/compiler/test/compilable/testatifti.d
+++ b/compiler/test/compilable/testatifti.d
@@ -56,6 +56,11 @@ void fooAliasDiverse(A, B, alias C, size_t D)(AliasDiverse!(B, A, C, D) v)
     static assert(is(typeof(v) == TempDiverse!(string, char, 12, 1)));
 }
 
+void fooAliasDiverse2(U)(AliasDiverse!(U, U, 1, 1) v)
+{
+    static assert(is(U == float));
+}
+
 struct Matrix(U, size_t M, size_t N)
 {
 
@@ -91,13 +96,13 @@ void main()
     pfooAliasPT(AliasPT!(float*)());
     fooAliasVar(AliasVar!(float, int, char, string)());
     fooAliasDiverse(AliasDiverse!(char, string, 1, 12)());
-
+    fooAliasDiverse2(AliasDiverse!(float, float, 1, 1)());
     static assert(is(Vector3!float == Vector3!U, U)); // !!!
     static assert(is(Vector!(float, 3) == Vector!(U, N), U, size_t N));
 
     Vector!(float, 10) v;
     normalize(v);
-    auto vv = cross(Vector3!float(), Vector3!float());
 
+    Vector3!float vv = cross(Vector3!float(), Vector3!float());
     test(TestAlias!(float, char)());
 }


### PR DESCRIPTION
This PR tries to enhance IFTI with certain amount of capability to resolve the parameters of alias templates.

Previous attempts include [DIP1023](https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1023.md).

Some of the related issues (all fixable with this PR):
[16465](https://issues.dlang.org/show_bug.cgi?id=16465)
[16486](https://issues.dlang.org/show_bug.cgi?id=16486)

# The problem

The following code doesn't compile.

```D
struct Matrix(U, size_t M, size_t N) {}
alias Vector(U, size_t N) = Matrix!(U, N, 1);
void foo(U, size_t N)(Vector!(U, N) v) {}
void main()
{
 foo(Vector!(float, 3)()); // error
 
 import std.regex: Regex;
 import std.traits: isInstanceOf;

 static assert(isInstanceOf!(Vector, Vector!(float, 3))); // error
 static assert(isInstanceOf!(Regex, Regex!char)); // error.
}
```

The cause is, D only tries to match the template declarations (in this case, `Vector` to `Matrix` ), it of course fails and returns nomatch.

# The solution

We can introduces an extra procedure after failing:

1. find the alias declaration (`alias Vector(U, size_t N) = Matrix!(U, N, 1)`)) and the type `Matrix!(U, N, 1)`.
2. call `deduceType` with (`[U, N]`, `Matrix!(U, N, 1)`, and the target instance `Matrix!(float, 3, 1)`).
3. the output `[float, 3]` can then be matched to the `parameters` in this frame, with largly the same parameter matching algorithm existing.*\
<del>*In fact the current implementation is a copy and paste, with minor alterations and simplifications (just to prove the idea).</del>\
*Current implementation reuses the old matching code.

This works recursivly on a chain of aliases. e.g.

```D
struct Matrix(U, size_t M, size_t N)
{

}

alias Vector(U, size_t N) = Matrix!(U, N, 1); // 1. resolves [U, N] > [float, 3] for Matrix!(float, 3, 1)
alias Vector3(U) = Vector!(U, 3); // 2. resolves [U] > [float] with the result from 1

Vector3!U cross(U)(Vector3!U a, Vector3!U b) // 3. resolves [U] > [float] with the result from 2
{
    return Vector3!U.init;
}

void main()
{
    Vector3!float vv = cross(Vector3!float(), Vector3!float());
}

```

# The limitation

The alias template has no overloads and one single `TemplateInstance` must be found in `AliasDeclaration`. More complicated cases will fail. E.g.

```D
alias SomeAlias1(T) = SomeTemp!T; // ok
alias SomeAlias2(T) = somemod.SomeTemp!T; // ok
/////////////////
// IFTI will fail for the rest
alias SomeAlias3(T) = SomeTemp!T.SomeInnerType; 
alias SomeAlias4(T, U) = somemod.SomeTemp!T.SomeInnerTemp!U;
alias SomeAlias5(T) = int;
```
The analogous code of the failed cases can't compile in C++ either. The correct resolution may not be as much desired and will be much more difficult to achieve.

Since the matching part is <del>simplified from</del> the same as the old, it does no more than whatever the old does. e.g.

```D
struct TempT(U) {}

void foo(U : U*)(TempT!U v) {} // nomatch

alias AliasT(U: U*) = TempT!U; // nomatch

void fee(U)(AliasT!U v);

void main()
{
 foo(TempT!(float)()); // error
 fee(AliasT!(float*)()); // error
}
```

----

Previous discussions and rationale:\
<https://github.com/dlang/dmd/pull/9778>\
<https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1023.md>

A fuller test can be found here:\
<https://github.com/Lucipetus/dmd_test/blob/master/atifti.d>\
With cases of aliases defined across modules, and of `isInstanceOf` from `std`.