### PR TITLE
Fix Issue 23832 - dmd regression 2.103.0 silent error cannot call decode at runtime

### DIFF
--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -47,6 +47,7 @@ extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope
     {
         if (!global.params.useTypeInfo)
         {
+            global.gag = 0;
             if (e)
                 .error(loc, "expression `%s` uses the GC and cannot be used with switch `-betterC`", e.toChars());
             else


### PR DESCRIPTION
The code in the bug report apparently finishes compilation gracefully when compiled with `-betterC`, however, it does not produce an object file or an executable. This happens because the failure in `genTypeInfo` simply exits the program after it prints an error message. However, no error message gets printed because in this context error generation is gagged.

I was not able to reduce the test case and therefore I don't know for sure what is the code that causes this (that's why I did not add a test case, since I don't want to add more phobos imports in the testsuite). I find it inelegant that genTypeInfo can be called from the frontend, this should be entirely the backend's job. However, this fix should be accepted regardless, since any call to `fatal` should be preceded by a `global.gag = 0` to not risk quietly exiting.