### PR TITLE
parse.d: remove more dependencies on globals.d

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3348,20 +3348,29 @@ struct CompileEnv final
     _d_dynamicArray< const char > time;
     _d_dynamicArray< const char > vendor;
     _d_dynamicArray< const char > timestamp;
+    bool previewIn;
+    bool ddocOutput;
+    bool shortenedMethods;
     CompileEnv() :
         versionNumber(),
         date(),
         time(),
         vendor(),
-        timestamp()
+        timestamp(),
+        previewIn(),
+        ddocOutput(),
+        shortenedMethods(true)
     {
     }
-    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}) :
+    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}, bool previewIn = false, bool ddocOutput = false, bool shortenedMethods = true) :
         versionNumber(versionNumber),
         date(date),
         time(time),
         vendor(vendor),
-        timestamp(timestamp)
+        timestamp(timestamp),
+        previewIn(previewIn),
+        ddocOutput(ddocOutput),
+        shortenedMethods(shortenedMethods)
         {}
 };
 

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -259,6 +259,9 @@ struct CompileEnv
     DString time;
     DString vendor;
     DString timestamp;
+    bool previewIn;
+    bool ddocOutput;
+    bool shortenedMethods;
 };
 
 struct Global

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -47,6 +47,10 @@ struct CompileEnv
     const(char)[] time;      /// __TIME__
     const(char)[] vendor;    /// __VENDOR__
     const(char)[] timestamp; /// __TIMESTAMP__
+
+    bool previewIn;          /// `in` means `[ref] scope const`, accepts rvalues
+    bool ddocOutput;	     /// collect embedded documentation comments
+    bool shortenedMethods = true;   /// allow => in normal function declarations
 }
 
 /***********************************************************
@@ -75,6 +79,7 @@ class Lexer
     ubyte wchar_tsize;          /// size of C wchar_t, 2 or 4
 
     ErrorSink eSink;            /// send error messages through this interface
+    CompileEnv compileEnv;      /// environment
 
     private
     {
@@ -93,8 +98,6 @@ class Lexer
         int lastDocLine;        // last line of previous doc comment
 
         Token* tokenFreelist;
-
-        CompileEnv compileEnv;  // environment
     }
 
   nothrow:

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -153,6 +153,10 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (parseCommandlineAndConfig(argc, argv, params, files))
         return EXIT_FAILURE;
 
+    global.compileEnv.previewIn = global.params.previewIn;
+    global.compileEnv.ddocOutput = global.params.ddoc.doOutput;
+    global.compileEnv.shortenedMethods = global.params.shortenedMethods;
+
     if (params.usage)
     {
         usage();

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1237,7 +1237,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         {
             if (added & STC.const_)
                 error("attribute `const` is redundant with previously-applied `in`");
-            else if (global.params.previewIn)
+            else if (compileEnv.previewIn)
             {
                 error("attribute `%s` is redundant with previously-applied `in`",
                       (orig & STC.scope_) ? "scope".ptr : "ref".ptr);
@@ -1253,7 +1253,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         {
             if (orig & STC.const_)
                 error("attribute `in` cannot be added after `const`: remove `const`");
-            else if (global.params.previewIn)
+            else if (compileEnv.previewIn)
             {
                 // Windows `printf` does not support `%1$s`
                 const(char*) stc_str = (orig & STC.scope_) ? "scope".ptr : "ref".ptr;
@@ -2738,7 +2738,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         /** Extract unittest body as a string. Must be done eagerly since memory
          will be released by the lexer before doc gen. */
         char* docline = null;
-        if (global.params.ddoc.doOutput && endPtr > begPtr)
+        if (compileEnv.ddocOutput && endPtr > begPtr)
         {
             /* Remove trailing whitespaces */
             for (const(char)* p = endPtr - 1; begPtr <= p && (*p == ' ' || *p == '\r' || *p == '\n' || *p == '\t'); --p)
@@ -5186,7 +5186,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         case TOK.goesTo:
             if (requireDo)
                 error("missing `do { ... }` after `in` or `out`");
-            if (!global.params.shortenedMethods)
+            if (!compileEnv.shortenedMethods)
                 error("=> shortened method not enabled, compile with compiler switch `-preview=shortenedMethods`");
             const returnloc = token.loc;
             nextToken();


### PR DESCRIPTION
in the service of making Parser a standalone entity.