### PR TITLE
fix Issue 23509 - ImportC: need statement expressions extension

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -196,10 +196,9 @@ private void statementToBuffer(Statement s, OutBuffer* buf, HdrGenState* hgs)
         foreach (sx; *s.statements)
         {
             auto ds = sx ? sx.isExpStatement() : null;
-            if (ds && ds.exp.op == EXP.declaration)
+            if (ds && ds.exp.isDeclarationExp())
             {
-                auto d = (cast(DeclarationExp)ds.exp).declaration;
-                assert(d.isDeclaration());
+                auto d = ds.exp.isDeclarationExp().declaration;
                 if (auto v = d.isVarDeclaration())
                 {
                     scope ppv = new DsymbolPrettyPrintVisitor(buf, hgs);

--- a/compiler/test/compilable/test23509.i
+++ b/compiler/test/compilable/test23509.i
@@ -1,0 +1,8 @@
+// https://issues.dlang.org/show_bug.cgi?id=23509
+
+int max(int a, int b)
+{
+    return ({int _a = (a), _b = (b); _a > _b ? _a : _b; });
+}
+
+_Static_assert(max(3,4) == 4, "1");


### PR DESCRIPTION
I've looked at this now and then, with no way we're going to do that. Then it turned up in some implementations of `assert()`. Howinell am I going to make that work?

Then, I started thinking "they look a lot like D lambdas", and then "maybe I could bend them into being D lambdas!"

And so, here we are.

One difference with gcc's version is gcc allows a goto, break, continue out of a statement expression. This doesn't support that. It's madness anyway to code such a thing. I do have some scruples (fewer every day).