### PR TITLE
ImportC: __attribute((deprecated)) and __declspec(deprecated)

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -3172,6 +3172,7 @@ final class CParser(AST) : Parser!AST
      *
      * extended-decl-modifier:
      *    align(number)
+     *    deprecated(depMsg)
      *    dllimport
      *    dllexport
      *    naked
@@ -3245,6 +3246,17 @@ final class CParser(AST) : Parser!AST
                     }
 
                     check(TOK.rightParenthesis);
+                }
+                else if (token.ident == Id._deprecated)
+                {
+                    specifier._deprecated = true;
+                    nextToken();
+                    if (token.value == TOK.leftParenthesis)  // optional deprecation message
+                    {
+                        nextToken();
+                        specifier.depMsg = cparseExpression();
+                        check(TOK.rightParenthesis);
+                    }
                 }
                 else
                 {
@@ -3469,6 +3481,17 @@ final class CParser(AST) : Parser!AST
                 /* ignore __attribute__((aligned)), which sets the alignment to the largest value for any data
                  * type on the target machine. It's the opposite of __attribute__((packed))
                  */
+            }
+            else if (token.ident == Id._deprecated)
+            {
+                specifier._deprecated = true;
+                nextToken();
+                if (token.value == TOK.leftParenthesis)  // optional deprecation message
+                {
+                    nextToken();
+                    specifier.depMsg = cparseExpression();
+                    check(TOK.rightParenthesis);
+                }
             }
             else if (token.ident == Id.dllimport)
             {
@@ -4894,6 +4917,9 @@ final class CParser(AST) : Parser!AST
         bool naked;     /// naked attribute
         bool dllimport; /// dllimport attribute
         bool dllexport; /// dllexport attribute
+        bool _deprecated;       /// deprecated attribute
+        AST.Expression depMsg;  /// deprecated message
+
         SCW scw;        /// storage-class specifiers
         MOD mod;        /// type qualifiers
         AST.Expressions*  alignExps;  /// alignment
@@ -4970,6 +4996,8 @@ final class CParser(AST) : Parser!AST
                     stc = AST.STC.gshared;
             }
         }
+        if (specifier._deprecated && !specifier.depMsg)
+            stc |= AST.STC.deprecated_;
         return stc;
     }
 
@@ -5161,6 +5189,17 @@ final class CParser(AST) : Parser!AST
     private AST.Dsymbol applySpecifier(AST.Dsymbol s, ref Specifier specifier)
     {
         //printf("applySpecifier() %s\n", s.toChars());
+        if (specifier._deprecated)
+        {
+            if (specifier.depMsg)
+            {
+                // Wrap declaration in a DeprecatedDeclaration
+                auto decls = new AST.Dsymbols(1);
+                (*decls)[0] = s;
+                s = new AST.DeprecatedDeclaration(specifier.depMsg, decls);
+            }
+        }
+
         if (specifier.alignExps)
         {
             //printf("  applying _Alignas %s, packalign %d\n", (*specifier.alignExps)[0].toChars(), cast(int)specifier.packalign);

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -528,6 +528,7 @@ immutable Msgtable[] msgtable =
     { "vector_size" },
     { "__func__" },
     { "noreturn" },
+    { "_deprecated", "deprecated" },
     { "_align", "align" },
     { "aligned" },
     { "__pragma", "pragma" },

--- a/compiler/test/fail_compilation/cdeprecated.i
+++ b/compiler/test/fail_compilation/cdeprecated.i
@@ -1,0 +1,22 @@
+/* REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/cdeprecated.i(18): Deprecation: function `cdeprecated.mars` is deprecated
+fail_compilation/cdeprecated.i(19): Deprecation: function `cdeprecated.jupiter` is deprecated - jumping jupiter
+fail_compilation/cdeprecated.i(20): Deprecation: function `cdeprecated.saturn` is deprecated
+fail_compilation/cdeprecated.i(21): Deprecation: function `cdeprecated.neptune` is deprecated - spinning neptune
+---
+*/
+__declspec(deprecated) int mars();
+__declspec(deprecated("jumping jupiter")) int jupiter();
+__attribute__((deprecated)) extern int saturn();
+__attribute__((deprecated("spinning neptune"))) extern int neptune();
+
+int test()
+{
+    return
+        mars() +
+        jupiter() +
+        saturn() +
+        neptune();
+}

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -109,6 +109,9 @@
 #if _MSC_VER
 //#undef _Post_writable_size
 //#define _Post_writable_size(x) // consider #include <no_sal2.h>
+#define _CRT_INSECURE_DEPRECATE(x)
+#define _CRT_NONSTDC_NO_DEPRECATE 1
+#define _CRT_SECURE_NO_WARNINGS 1
 #define __ptr32
 #define __ptr64
 #define __unaligned


### PR DESCRIPTION
As suggested by @ibuclaw https://issues.dlang.org/show_bug.cgi?id=21938

It just converts it to the D deprecate.