### PR TITLE
Fix Issue 22857 - Segfault for malformed static if in imported template

### DIFF
--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -935,9 +935,6 @@ extern (C++) final class StaticIfCondition : Condition
             import dmd.staticcond;
             bool errors;
 
-            if (!exp)
-                return errorReturn();
-
             bool result = evalStaticCondition(sc, exp, exp, errors);
 
             // Prevent repeated condition evaluation.

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1383,10 +1383,14 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         imp.semanticRun = PASS.semantic;
 
         // Load if not already done so
-        bool loadErrored = false;
         if (!imp.mod)
         {
-            loadErrored = imp.load(sc);
+            // https://issues.dlang.org/show_bug.cgi?id=22857
+            // if parser errors occur when loading a module
+            // we should just stop compilation
+            if (imp.load(sc))
+                return;
+
             if (imp.mod)
             {
                 imp.mod.importAll(null);
@@ -1427,10 +1431,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 imp.addPackageAccess(scopesym);
             }
 
-            if (!loadErrored)
-            {
-                imp.mod.dsymbolSemantic(null);
-            }
+            imp.mod.dsymbolSemantic(null);
 
             if (imp.mod.needmoduleinfo)
             {

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -4528,8 +4528,7 @@ public auto makeTupleForeach(Scope* sc, bool isStatic, bool isDecl, ForeachState
             decls.append(Dsymbol.arraySyntaxCopy(dbody));
         else
         {
-            if (fs._body) // https://issues.dlang.org/show_bug.cgi?id=17646
-                stmts.push(fs._body.syntaxCopy());
+            stmts.push(fs._body.syntaxCopy());
             s = new CompoundStatement(loc, stmts);
         }
 

--- a/compiler/test/fail_compilation/fail17646.d
+++ b/compiler/test/fail_compilation/fail17646.d
@@ -4,7 +4,7 @@ EXTRA_FILES: imports/fail17646.d
 TEST_OUTPUT:
 ---
 fail_compilation/imports/fail17646.d(10): Error: found `}` instead of statement
-fail_compilation/fail17646.d(11): Error: function `fail17646.runTests!"".runTests` has no `return` statement, but is expected to return a value of type `int`
+fail_compilation/fail17646.d(15): Error: template instance `allTestData!Modules` template `allTestData` is not defined
 fail_compilation/fail17646.d(18): Error: template instance `fail17646.runTests!""` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/fail22857.d
+++ b/compiler/test/fail_compilation/fail22857.d
@@ -1,0 +1,18 @@
+// https://issues.dlang.org/show_bug.cgi?id=22857
+// EXTRA_FILES: imports/import22857.d
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/imports/import22857.d(4): Error: (expression) expected following `static if`
+fail_compilation/imports/import22857.d(4): Error: declaration expected, not `}`
+fail_compilation/fail22857.d(17): Error: template instance `unaryFun!()` template `unaryFun` is not defined
+---
+*/
+
+void isPrettyPropertyName()
+{
+    import imports.import22857;
+
+    unaryFun!();
+}

--- a/compiler/test/fail_compilation/imports/import22857.d
+++ b/compiler/test/fail_compilation/imports/import22857.d
@@ -1,0 +1,4 @@
+template unaryFun()
+{
+    static if
+}

--- a/compiler/test/fail_compilation/test21164.d
+++ b/compiler/test/fail_compilation/test21164.d
@@ -3,7 +3,8 @@ TEST_OUTPUT:
 ---
 fail_compilation/imports/test21164d.d(3): Error: (expression) expected following `static if`
 fail_compilation/imports/test21164d.d(3): Error: found `}` instead of statement
-fail_compilation/test21164.d(11): Error: template instance `test21164a.D!(R!(O(), 1))` error instantiating
+fail_compilation/imports/test21164a.d(5): Error: undefined identifier `I`
+fail_compilation/test21164.d(12): Error: template instance `test21164a.D!(R!(O(), 1))` error instantiating
 ---
 */
 import imports.test21164a;


### PR DESCRIPTION
When loading a module, if there are parser errors, we should not continue considering the import because we have an incomplete AST which leads to all sorts of ICEs. This is what mars.d does: if we have parser error, we don't continue with semantic.

I had to revert past fixes for some cases because they were treating the effects of accepting a malformed AST. See:

https://github.com/dlang/dmd/pull/6993
https://github.com/dlang/dmd/pull/11585

With this patch, semantic is not attempted, therefore those safety checks become redundant.