### PR TITLE
Fix Issue 22760 - Segmentation fault in CppMangleVisitor.template_arg

### DIFF
--- a/compiler/src/dmd/cppmangle.d
+++ b/compiler/src/dmd/cppmangle.d
@@ -446,7 +446,15 @@ private final class CppMangleVisitor : Visitor
                 if (this.context.res.dyncast() == DYNCAST.dsymbol)
                     parentti = this.context.res.asFuncDecl().parent.isTemplateInstance();
                 else
-                    parentti = this.context.res.asType().toDsymbol(null).parent.isTemplateInstance();
+                {
+                    auto parent = this.context.res.asType().toDsymbol(null).parent;
+                    parentti = parent.isTemplateInstance();
+                    // https://issues.dlang.org/show_bug.cgi?id=22760
+                    // The template instance may sometimes have the form
+                    // S1!int.S1, therefore the above instruction might yield null
+                    if (parentti is null && parent.parent)
+                        parentti = parent.parent.isTemplateInstance();
+                }
                 return (*parentti.tiargs)[arg];
             }());
         scope (exit) this.context.pop(prev);

--- a/compiler/test/compilable/test22760.d
+++ b/compiler/test/compilable/test22760.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=22760
+
+extern(C++) void f(T)(T)
+{
+}
+struct S1(T)
+{
+    struct S2
+    {
+    }
+}
+void fun()
+{
+    f(S1!int.S2());
+}


### PR DESCRIPTION
For aggregate declarations at the template level the parent is not the template instance but the aggregate. For example:

```d
struct T(U)
{
      struct S {}
}
```

For a given instantiation, say `T!int`, the parent of S is not `T!int` but `T!int.T`. That is because the compiler rewrites the struct to an eponymous template. That is why, in this PR, I am checking the parent of parent for writing the cpp mangled name. I am keeping the old case because there are situations such as:

```d
template T(U)
{
     int a;
     struct T {}
}
```

In this case, the parent of `a` is going to be `T!whatever`, not `T!whatever.T`.

@Geod24 can you please take a look at this, since you are the original author? I don't particularly like this fix, it looks like a special case handling, however, I have no idea if a better fix is possible.