### PR TITLE
Fix Issue 22765 - Assertion failure in CppMangleVisitor.template_args

### DIFF
--- a/compiler/src/dmd/cppmangle.d
+++ b/compiler/src/dmd/cppmangle.d
@@ -560,7 +560,11 @@ private final class CppMangleVisitor : Visitor
                 foreach (j; i .. (*ti.tiargs).length)
                 {
                     Type t = isType((*ti.tiargs)[j]);
-                    assert(t);
+                    if (t is null)
+                    {
+                        ti.error("internal compiler error: C++ `%s` template value parameter is not supported", (*ti.tiargs)[j].toChars());
+                        fatal();
+                    }
                     t.accept(this);
                 }
 

--- a/compiler/test/fail_compilation/test22765.d
+++ b/compiler/test/fail_compilation/test22765.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=22765
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test22765.d(14): Error: template instance `test22765.Template!null` internal compiler error: C++ `null` template value parameter is not supported
+---
+*/
+
+template Template(T...)
+{
+    extern(C++) const __gshared int Template = 0;
+}
+auto x = Template!(null);


### PR DESCRIPTION
Replace assert with an error message.

The error looks weird, but I just followed the pattern already present. Rewording the error should be the subject of a different PR.