### PR TITLE
ImportC: predefine _NO_CRT_STDIO_INLINE

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -112,6 +112,7 @@
 #define __ptr32
 #define __ptr64
 #define __unaligned
+#define _NO_CRT_STDIO_INLINE 1
 #endif
 
 /****************************


### PR DESCRIPTION
Prevents the insertion into the object file of a blizzard of inline functions from Microsoft's stdio.h.