### PR TITLE
ImportC: support noinline

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -3175,6 +3175,7 @@ final class CParser(AST) : Parser!AST
      *    dllimport
      *    dllexport
      *    naked
+     *    noinline
      *    noreturn
      *    thread
      * Params:
@@ -3212,6 +3213,11 @@ final class CParser(AST) : Parser!AST
                 else if (token.ident == Id.naked)
                 {
                     specifier.naked = true;
+                    nextToken();
+                }
+                else if (token.ident == Id.noinline)
+                {
+                    specifier.scw |= SCW.xnoinline;
                     nextToken();
                 }
                 else if (token.ident == Id.noreturn)
@@ -3483,6 +3489,11 @@ final class CParser(AST) : Parser!AST
             else if (token.ident == Id.naked)
             {
                 specifier.naked = true;
+                nextToken();
+            }
+            else if (token.ident == Id.noinline)
+            {
+                specifier.scw |= SCW.xnoinline;
                 nextToken();
             }
             else if (token.ident == Id.noreturn)
@@ -4872,6 +4883,8 @@ final class CParser(AST) : Parser!AST
         // C11 6.7.4 Function specifiers
         xinline    = 0x40,
         x_Noreturn = 0x80,
+
+        xnoinline  = 0x100,
     }
 
     /// C11 6.7.3 Type qualifiers
@@ -4984,6 +4997,11 @@ final class CParser(AST) : Parser!AST
         fd.isNaked = specifier.naked;
         fd.dllImport = specifier.dllimport;
         fd.dllExport = specifier.dllexport;
+
+        if (specifier.scw & SCW.xnoinline)
+            fd.inlining = PINLINE.never;
+        else if (specifier.scw & SCW.xinline)
+            fd.inlining = PINLINE.always;
     }
 
     /***********************

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -527,6 +527,7 @@ immutable Msgtable[] msgtable =
     { "thread" },
     { "vector_size" },
     { "__func__" },
+    { "noinline" },
     { "noreturn" },
     { "_align", "align" },
     { "aligned" },

--- a/compiler/test/compilable/testnoinline.c
+++ b/compiler/test/compilable/testnoinline.c
@@ -1,0 +1,9 @@
+
+__attribute__((noinline)) int abc() { return 1; }
+__declspec(noinline)      int def() { return 2; }
+inline                    int ghi() { return 3; }
+
+int test()
+{
+    return abc() + def() + ghi();
+}


### PR DESCRIPTION
Supports __declspec(noinline) and __attribute__(noinline). Turns out Microsoft's .h files require this to work, giving the One Definition Rule (ODR) as the reason.