### PR TITLE
give better message when cannot inline a function

### DIFF
--- a/compiler/test/compilable/pragmainline2.d
+++ b/compiler/test/compilable/pragmainline2.d
@@ -2,9 +2,9 @@
 REQUIRED_ARGS: -inline -wi
 TEST_OUTPUT:
 ---
-compilable/pragmainline2.d(14): Warning: cannot inline function `pragmainline2.foo`
-compilable/pragmainline2.d(22): Warning: cannot inline function `pragmainline2.f1t`
-compilable/pragmainline2.d(25): Warning: cannot inline function `pragmainline2.f2t`
+compilable/pragmainline2.d(14): Warning: cannot inline function `pragmainline2.foo` because too costly
+compilable/pragmainline2.d(22): Warning: cannot inline function `pragmainline2.f1t` because too costly
+compilable/pragmainline2.d(25): Warning: cannot inline function `pragmainline2.f2t` because too costly
 ---
 */
 
@@ -41,8 +41,8 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-compilable/pragmainline2.d(50): Warning: cannot inline function `pragmainline2.jazz`
-compilable/pragmainline2.d(63): Warning: cannot inline function `pragmainline2.metal`
+compilable/pragmainline2.d(50): Warning: cannot inline function `pragmainline2.jazz` because too costly
+compilable/pragmainline2.d(63): Warning: cannot inline function `pragmainline2.metal` because too costly
 ---
 */
 


### PR DESCRIPTION
It can be baffling sometimes why a particular function isn't inlined.