### PR TITLE
Fix Issue 23838 - DMD lexer / parser examples might not compile

### DIFF
--- a/compiler/test/dub_package/avg.d
+++ b/compiler/test/dub_package/avg.d
@@ -1,6 +1,6 @@
 #!/usr/bin/env dub
 /+dub.sdl:
-dependency "dmd" path="../.."
+dependency "dmd" path="../../.."
 +/
 /* This file contains an example on how to use the transitive visitor.
    It implements a visitor which computes the average function length from
@@ -10,7 +10,7 @@ dependency "dmd" path="../.."
 module examples.avg;
 
 import dmd.astbase;
-import dmd.errors;
+import dmd.errorsink;
 import dmd.parse;
 import dmd.target;
 import dmd.transitivevisitor;
@@ -60,8 +60,9 @@ void main()
     auto id = Identifier.idPool(fname);
     auto m = new ASTBase.Module(&(fname.dup)[0], id, false, false);
     auto input = readText(fname);
+    input ~= '\0';
 
-    scope p = new Parser!ASTBase(m, input, false);
+    scope p = new Parser!ASTBase(m, input, false, new ErrorSinkStderr(), null, false);
     p.nextToken();
     m.members = p.parseModule();
 

--- a/compiler/test/dub_package/frontend.d
+++ b/compiler/test/dub_package/frontend.d
@@ -1,6 +1,6 @@
 #!/usr/bin/env dub
 /+dub.sdl:
-dependency "dmd" path="../.."
+dependency "dmd" path="../../.."
 +/
 import std.stdio;
 

--- a/compiler/test/dub_package/frontend_file.d
+++ b/compiler/test/dub_package/frontend_file.d
@@ -1,6 +1,6 @@
 #!/usr/bin/env dub
 /+dub.sdl:
-dependency "dmd" path="../.."
+dependency "dmd" path="../../.."
 +/
 import std.stdio;
 import std.string : replace;

--- a/compiler/test/dub_package/impvisitor.d
+++ b/compiler/test/dub_package/impvisitor.d
@@ -1,6 +1,6 @@
 #!/usr/bin/env dub
 /+dub.sdl:
-dependency "dmd" path="../.."
+dependency "dmd" path="../../.."
 +/
 
 import dmd.permissivevisitor;
@@ -27,7 +27,7 @@ extern(C++) class ImportVisitor2(AST) : ParseTimeTransitiveVisitor!AST
 
         printf("%s", imp.id.toChars());
 
-        if (imp.names.dim)
+        if (imp.names.length)
         {
             printf(" : ");
             foreach (const i, const name; imp.names)
@@ -82,12 +82,13 @@ void main()
     import dmd.id;
     import dmd.globals;
     import dmd.identifier;
+    import dmd.errorsink;
     import dmd.target;
 
     import core.memory;
 
     GC.disable();
-    string path = __FILE_FULL_PATH__.dirName.buildPath("../../../phobos/std/");
+    string path = __FILE_FULL_PATH__.dirName.buildPath("../../../../phobos/std/");
     string regex = "*.d";
 
     auto dFiles = dirEntries(path, regex, SpanMode.depth);
@@ -106,9 +107,10 @@ void main()
         auto id = Identifier.idPool(fn);
         auto m = new ASTBase.Module(&(fn.dup)[0], id, false, false);
         auto input = readText(fn);
+        input ~= '\0';
 
         //writeln("Started parsing...");
-        scope p = new Parser!ASTBase(m, input, false);
+        scope p = new Parser!ASTBase(m, input, false, new ErrorSinkStderr(), null, false);
         p.nextToken();
         m.members = p.parseModule();
         //writeln("Finished parsing. Starting transitive visitor");

--- a/compiler/test/dub_package/lexer.d
+++ b/compiler/test/dub_package/lexer.d
@@ -1,12 +1,13 @@
 #!/usr/bin/env dub
 /+dub.sdl:
-dependency "dmd" path="../.."
+dependency "dmd" path="../../.."
 +/
 void main()
 {
     import dmd.globals;
     import dmd.lexer;
     import dmd.tokens;
+    import dmd.errorsink;
 
     immutable expected = [
         TOK.void_,
@@ -18,7 +19,7 @@ void main()
     ];
 
     immutable sourceCode = "void test() {} // foobar";
-    scope lexer = new Lexer("test", sourceCode.ptr, 0, sourceCode.length, 0, 0);
+    scope lexer = new Lexer("test", sourceCode.ptr, 0, sourceCode.length, 0, 0, 0, new ErrorSinkStderr);
     lexer.nextToken;
 
     TOK[] result;

--- a/compiler/test/dub_package/parser.d
+++ b/compiler/test/dub_package/parser.d
@@ -1,13 +1,14 @@
 #!/usr/bin/env dub
 /+dub.sdl:
-dependency "dmd" path="../.."
+dependency "dmd" path="../../.."
 +/
 void main()
 {
     import dmd.astbase;
     import dmd.globals;
     import dmd.parse;
+    import dmd.errorsink;
 
-    scope parser = new Parser!ASTBase(null, null, false);
+    scope parser = new Parser!ASTBase(null, null, false, new ErrorSinkStderr, null, false);
     assert(parser !is null);
 }

--- a/compiler/test/dub_package/retrieveScope.d
+++ b/compiler/test/dub_package/retrieveScope.d
@@ -1,6 +1,6 @@
 #!/usr/bin/env dub
 /+dub.sdl:
-dependency "dmd" path="../.."
+dependency "dmd" path="../../.."
 versions "CallbackAPI"
 +/
 /*
@@ -20,13 +20,13 @@ import std.path : dirName;
 
 import dmd.errors;
 import dmd.frontend;
-import dmd.mars;
 import dmd.console;
 import dmd.arraytypes;
 import dmd.compiler;
 import dmd.dmodule;
 import dmd.dsymbol;
 import dmd.dsymbolsem;
+import dmd.location;
 import dmd.semantic2;
 import dmd.semantic3;
 import dmd.statement;
@@ -77,13 +77,8 @@ int main()
     global.gag = 1;
     initDMD(diagnosticHandler);
 
-    Strings libmodules;
-    Module m = createModule((dirName(__FILE_FULL_PATH__) ~ "/testfiles/correct.d").ptr,
-                                libmodules);
+    Module m = parseModule(__FILE_FULL_PATH__ ~ "/testfiles/correct.d").module_;
     m.importedFrom = m; // m.isRoot() == true
-
-    m.read(Loc.initial);
-    m.parse();
 
     CallbackHelper.cursorLoc = Loc(to!string(m.srcfile).ptr, 22, 10);
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -31,7 +31,8 @@ subPackage {
     "compiler/src/dmd/lexer.d" \
     "compiler/src/dmd/location.d" \
     "compiler/src/dmd/tokens.d" \
-    "compiler/src/dmd/utils.d"
+    "compiler/src/dmd/utils.d" \
+    "compiler/src/dmd/errorsink.d"
 
   versions \
     "CallbackAPI" \


### PR DESCRIPTION
This patch:

- updates paths to `dub.sdl` file
- updates `dub.sdl` to contain errorsink
- updates the test to compile and run

It seems that the dub tests are not run by the testing pipeline. Anyone knows how to enable them?

If we want dmd as a lib to be usable we should be more careful when breaking the user facing api, such as the constructors of the lexer and parse (cc @WalterBright - you broke the api with your work on the parser/lexer).

Also, one thing to take into account is the fact that the parser expects a null terminated string that is bases as a `const(char)[]`. So you either use `parseModule` from `frontend.d` which adds the `\0` or you need to manually add it (as can be seen in the updated test).