### PR TITLE
Remove function prototypes from backend pt1

### DIFF
--- a/compiler/src/dmd/backend/barray.d
+++ b/compiler/src/dmd/backend/barray.d
@@ -20,7 +20,9 @@ import core.stdc.string;
 nothrow:
 @safe:
 
-extern (C++): private void err_nomem();
+extern (C++):
+
+import dmd.backend.global : err_nomem;
 
 /*************************************
  * A reusable array that ratchets up in capacity.

--- a/compiler/src/dmd/backend/cg87.d
+++ b/compiler/src/dmd/backend/cg87.d
@@ -47,10 +47,6 @@ nothrow:
 //       a multi-threaded version of the backend
 __gshared Globals87 global87;
 
-private:
-
-int REGSIZE();
-
 private extern (D) uint mask(uint m) { return 1 << m; }
 void callcdxxx(ref CodeBuilder cdb, elem *e, regm_t *pretregs, OPER op);
 
@@ -528,7 +524,7 @@ void comsub87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
  * Decide if we need to gen an FWAIT.
  */
 
-void genfwait(ref CodeBuilder cdb)
+public void genfwait(ref CodeBuilder cdb)
 {
     if (ADDFWAIT())
         cdb.gen1(FWAIT);
@@ -2268,7 +2264,7 @@ private void cnvteq87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
  */
 
 @trusted
-void opass87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
+public void opass87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 {
     code cs;
     uint op;

--- a/compiler/src/dmd/backend/cgcod.d
+++ b/compiler/src/dmd/backend/cgcod.d
@@ -72,7 +72,6 @@ else
     enum MARS = false;
 
 void dwarf_except_gentables(Funcsym *sfunc, uint startoffset, uint retoffset);
-int REGSIZE();
 
 private extern (D) uint mask(uint m) { return 1 << m; }
 

--- a/compiler/src/dmd/backend/cgxmm.d
+++ b/compiler/src/dmd/backend/cgxmm.d
@@ -47,8 +47,6 @@ extern (C++):
 nothrow:
 @safe:
 
-int REGSIZE();
-
 uint mask(uint m);
 
 /*******************************************
@@ -794,7 +792,7 @@ void xmmabs(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
  */
 
 @trusted
-opcode_t xmmload(tym_t tym, bool aligned)
+opcode_t xmmload(tym_t tym, bool aligned = true)
 {
     opcode_t op;
     if (tysize(tym) == 32)
@@ -847,7 +845,7 @@ opcode_t xmmload(tym_t tym, bool aligned)
  */
 
 @trusted
-opcode_t xmmstore(tym_t tym, bool aligned)
+opcode_t xmmstore(tym_t tym, bool aligned = true)
 {
     opcode_t op;
     switch (tybasic(tym))

--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -51,8 +51,6 @@ extern (C++):
 nothrow:
 @safe:
 
-int REGSIZE();
-
 extern __gshared CGstate cgstate;
 extern __gshared ubyte[FLMAX] segfl;
 extern __gshared bool[FLMAX] stackfl;

--- a/compiler/src/dmd/backend/cod2.d
+++ b/compiler/src/dmd/backend/cod2.d
@@ -52,8 +52,6 @@ extern (C++):
 nothrow:
 @safe:
 
-int REGSIZE();
-
 extern __gshared CGstate cgstate;
 extern __gshared ubyte[FLMAX] segfl;
 extern __gshared bool[FLMAX] stackfl;

--- a/compiler/src/dmd/backend/cod3.d
+++ b/compiler/src/dmd/backend/cod3.d
@@ -72,8 +72,6 @@ version (MARS)
 else
     enum MARS = false;
 
-int REGSIZE();
-
 extern __gshared CGstate cgstate;
 extern __gshared ubyte[FLMAX] segfl;
 extern __gshared bool[FLMAX] stackfl, flinsymtab;
@@ -1547,7 +1545,7 @@ regm_t allocretregs(const tym_t ty, type* t, const tym_t tyf, out reg_t reg1, ou
  * Struct necessary for sorting switch cases.
  */
 
-alias _compare_fp_t = extern(C) nothrow int function(const void*, const void*);
+private alias _compare_fp_t = extern(C) nothrow int function(const void*, const void*);
 extern(C) void qsort(void* base, size_t nmemb, size_t size, _compare_fp_t compar);
 
 extern (C)  // qsort cmp functions need to be "C"

--- a/compiler/src/dmd/backend/cod4.d
+++ b/compiler/src/dmd/backend/cod4.d
@@ -53,8 +53,6 @@ extern (C++):
 nothrow:
 @safe:
 
-int REGSIZE();
-
 extern __gshared CGstate cgstate;
 extern __gshared bool[FLMAX] datafl;
 

--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -354,6 +354,7 @@ extern __gshared
 }
 
 /* cgcod.c */
+public import dmd.backend.cgcod;
 extern __gshared BackendPass pass;
 enum BackendPass
 {
@@ -478,97 +479,14 @@ void cdvector(ref CodeBuilder cdb, elem* e, regm_t* pretregs);
 void cdvoid(ref CodeBuilder cdb, elem* e, regm_t* pretregs);
 void loaddata(ref CodeBuilder cdb, elem* e, regm_t* pretregs);
 
-/* cod1.c */
-extern __gshared int clib_inited;
+public import dmd.backend.cod1;
+public import dmd.backend.cod2;
+public import dmd.backend.cod3;
+public import dmd.backend.cod4;
+public import dmd.backend.cod5;
+public import dmd.backend.cgen : outfixlist, addtofixlist;
 
-bool regParamInPreg(Symbol* s);
-int isscaledindex(elem *);
-int ssindex(int op,targ_uns product);
-void buildEA(code *c,int base,int index,int scale,targ_size_t disp);
-uint buildModregrm(int mod, int reg, int rm);
-void andregcon (con_t *pregconsave);
-void genEEcode();
-void docommas(ref CodeBuilder cdb,elem **pe);
-uint gensaverestore(regm_t, ref CodeBuilder cdbsave, ref CodeBuilder cdbrestore);
-void genstackclean(ref CodeBuilder cdb,uint numpara,regm_t keepmsk);
-void logexp(ref CodeBuilder cdb, elem *e, int jcond, uint fltarg, code *targ);
-uint getaddrmode(regm_t idxregs);
-void setaddrmode(code *c, regm_t idxregs);
-void fltregs(ref CodeBuilder cdb, code *pcs, tym_t tym);
-void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, uint saveflag);
-void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs);
-void callclib(ref CodeBuilder cdb, elem *e, uint clib, regm_t *pretregs, regm_t keepmask);
-void pushParams(ref CodeBuilder cdb,elem *, uint, tym_t tyf);
-void offsetinreg(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void argtypes(type* t, ref type* arg1type, ref type* arg2type);
-
-/* cod2.c */
-bool movOnly(const elem *e);
-regm_t idxregm(const code *c);
-void opdouble(ref CodeBuilder cdb, elem *e, regm_t *pretregs, uint clib);
-void WRcodlst(code *c);
-void getoffset(ref CodeBuilder cdb, elem *e, reg_t reg);
-
-/* cod3.c */
-
-int cod3_EA(code *c);
-regm_t cod3_useBP();
-void cod3_initregs();
-void cod3_setdefault();
-void cod3_set32();
-void cod3_set64();
-void cod3_align_bytes(int seg, size_t nbytes);
-void cod3_align(int seg);
-void cod3_buildmodulector(OutBuffer* buf, int codeOffset, int refOffset);
-void cod3_stackadj(ref CodeBuilder cdb, int nbytes);
-void cod3_stackalign(ref CodeBuilder cdb, int nbytes);
-regm_t regmask(tym_t tym, tym_t tyf);
-void cgreg_dst_regs(reg_t* dst_integer_reg, reg_t* dst_float_reg);
-void cgreg_set_priorities(tym_t ty, const(reg_t)** pseq, const(reg_t)** pseqmsw);
-void outblkexitcode(ref CodeBuilder cdb, block *bl, ref int anyspill, const(char)* sflsave, Symbol** retsym, const regm_t mfuncregsave );
-void outjmptab(block *b);
-void outswitab(block *b);
-int jmpopcode(elem *e);
-void cod3_ptrchk(ref CodeBuilder cdb,code *pcs,regm_t keepmsk);
-void genregs(ref CodeBuilder cdb, opcode_t op, uint dstreg, uint srcreg);
-void gentstreg(ref CodeBuilder cdb, uint reg);
-void genpush(ref CodeBuilder cdb, reg_t reg);
-void genpop(ref CodeBuilder cdb, reg_t reg);
-void gen_storecse(ref CodeBuilder cdb, tym_t tym, reg_t reg, size_t slot);
-void gen_testcse(ref CodeBuilder cdb, tym_t tym, uint sz, size_t i);
-void gen_loadcse(ref CodeBuilder cdb, tym_t tym, reg_t reg, size_t slot);
-code *genmovreg(uint to, uint from);
-void genmovreg(ref CodeBuilder cdb, uint to, uint from);
-void genmovreg(ref CodeBuilder cdb, uint to, uint from, tym_t tym);
-void genmulimm(ref CodeBuilder cdb,uint r1,uint r2,targ_int imm);
-void genshift(ref CodeBuilder cdb);
-void movregconst(ref CodeBuilder cdb,reg_t reg,targ_size_t value,regm_t flags);
-void genjmp(ref CodeBuilder cdb, opcode_t op, uint fltarg, block *targ);
-void prolog(ref CodeBuilder cdb);
-void epilog (block *b);
-void gen_spill_reg(ref CodeBuilder cdb, Symbol *s, bool toreg);
-void load_localgot(ref CodeBuilder cdb);
-targ_size_t cod3_spoff();
-void makeitextern (Symbol *s );
-void fltused();
-int branch(block *bl, int flag);
-void cod3_adjSymOffsets();
-void assignaddr(block *bl);
-void assignaddrc(code *c);
-targ_size_t cod3_bpoffset(Symbol *s);
-void pinholeopt (code *c , block *bn );
-void simplify_code(code *c);
-void jmpaddr (code *c);
-int code_match(code *c1,code *c2);
-uint calcblksize (code *c);
-uint calccodsize(code *c);
-uint codout(int seg, code *c,Barray!ubyte*);
-size_t addtofixlist(Symbol *s , targ_size_t soffset , int seg , targ_size_t val , int flags );
 void searchfixlist(Symbol *s) {}
-void outfixlist();
-void code_hydrate(code **pc);
-void code_dehydrate(code **pc);
-regm_t allocretregs(const tym_t ty, type* t, const tym_t tyf, out reg_t reg1, out reg_t reg2);
 
 extern __gshared
 {
@@ -598,68 +516,8 @@ void prolog_gen_win64_varargs(ref CodeBuilder cdb);
 void prolog_genvarargs(ref CodeBuilder cdb, Symbol* sv, regm_t namedargs);
 void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc, out regm_t namedargs);
 
-/* cod4.c */
-extern __gshared
-{
-const reg_t[4] dblreg;
-int cdcmp_flag;
-}
-
-int doinreg(Symbol *s, elem *e);
-void modEA(ref CodeBuilder cdb, code *c);
-void longcmp(ref CodeBuilder,elem *,bool,uint,code *);
-
-/* cod5.c */
-void cod5_prol_epi();
-void cod5_noprol();
-
-/* cgxmm.c */
-bool isXMMstore(opcode_t op);
-@trusted
-void movxmmconst(ref CodeBuilder cdb, reg_t xreg, uint sz, eve* pvalue, regm_t flags);
-void orthxmm(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void xmmeq(ref CodeBuilder cdb, elem *e, opcode_t op, elem *e1, elem *e2, regm_t *pretregs);
-void xmmcnvt(ref CodeBuilder cdb,elem *e,regm_t *pretregs);
-void xmmopass(ref CodeBuilder cdb,elem *e, regm_t *pretregs);
-void xmmpost(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void xmmneg(ref CodeBuilder cdb,elem *e, regm_t *pretregs);
-void xmmabs(ref CodeBuilder cdb,elem *e, regm_t *pretregs);
-void cloadxmm(ref CodeBuilder cdb,elem *e, regm_t *pretregs);
-uint xmmload(tym_t tym, bool aligned = true);
-uint xmmstore(tym_t tym, bool aligned = true);
-bool xmmIsAligned(elem *e);
-void checkSetVex3(code *c);
-void checkSetVex(code *c, tym_t ty);
-
-/* cg87.c */
-void note87(elem *e, uint offset, int i);
-void pop87(int, const(char)*);
-void pop87();
-void push87(ref CodeBuilder cdb);
-void save87(ref CodeBuilder cdb);
-void save87regs(ref CodeBuilder cdb, uint n);
-void gensaverestore87(regm_t, ref CodeBuilder cdbsave, ref CodeBuilder cdbrestore);
-//code *genfltreg(code *c,opcode_t opcode,uint reg,targ_size_t offset);
-void genfwait(ref CodeBuilder cdb);
-void comsub87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void fixresult87(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs, bool isReturnValue = false);
-void fixresult_complex87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs, bool isReturnValue = false);
-void orth87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void load87(ref CodeBuilder cdb, elem *e, uint eoffset, regm_t *pretregs, elem *eleft, int op);
-int cmporder87 (elem *e );
-void eq87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void complex_eq87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void opass87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void cdnegass87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void post87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void cnvt87(ref CodeBuilder cdb, elem *e , regm_t *pretregs );
-void neg87(ref CodeBuilder cdb, elem *e , regm_t *pretregs);
-void neg_complex87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void cdind87(ref CodeBuilder cdb,elem *e,regm_t *pretregs);
-void cload87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void cdd_u64(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void cdd_u32(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void loadPair87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
+public import dmd.backend.cgxmm;
+public import dmd.backend.cg87;
 
 /**********************************
  * Get registers used by a given block

--- a/compiler/src/dmd/backend/code_x86.d
+++ b/compiler/src/dmd/backend/code_x86.d
@@ -138,9 +138,6 @@ enum
 enum RMload  = (1 << 30);
 enum RMstore = (1 << 31);
 
-extern (C++) extern __gshared regm_t ALLREGS;
-extern (C++) extern __gshared regm_t BYTEREGS;
-
     // To support positional independent code,
     // must be able to remove BX from available registers
     enum ALLREGS_INIT          = (mAX|mBX|mCX|mDX|mSI|mDI);
@@ -573,11 +570,3 @@ struct Globals87
 
     Barray!NDP save;           // 8087 values spilled to memory
 }
-
-extern (C++) extern __gshared Globals87 global87;
-
-void getlvalue_msw(code *);
-void getlvalue_lsw(code *);
-void getlvalue(ref CodeBuilder cdb, code *pcs, elem *e, regm_t keepmsk);
-void loadea(ref CodeBuilder cdb, elem *e, code *cs, uint op, uint reg, targ_size_t offset, regm_t keepmsk, regm_t desmsk);
-bool loadxmmconst(elem* e);

--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -28,6 +28,7 @@ import core.stdc.stdlib;
 import core.stdc.string;
 
 // qsort is only nothrow in newer versions of druntime (since 2.081.0)
+alias _compare_fp_t = extern(C) nothrow int function(const void*, const void*);
 private extern(C) void qsort(scope void* base, size_t nmemb, size_t size, _compare_fp_t compar) nothrow @nogc;
 
 import dmd.backend.barray;

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -119,18 +119,6 @@ void exp2_setstrthis(elem *e,Symbol *s,targ_size_t offset,type *t);
 Symbol *exp2_qualified_lookup(Classsym *sclass, int flags, int *pflags);
 elem *exp2_copytotemp(elem *e);
 
-/* util.c */
-//#if __clang__
-//void util_exit(int) __attribute__((noreturn));
-//#elif _MSC_VER
-//__declspec(noreturn) void util_exit(int);
-//#else
-void util_exit(int);
-//#if __DMC__
-//#pragma ZTC noreturn(util_exit)
-//#endif
-//#endif
-
 void util_progress();
 void util_set16();
 void util_set32(exefmt_t);
@@ -204,7 +192,7 @@ void preerr(uint,...);
 //void err_fatal(uint,...) __attribute__((analyzer_noreturn));
 //#else
 void err_exit();
-void err_nomem();
+public import dmd.backend.ph2 : err_nomem;
 void err_fatal(uint,...);
 //#if __DMC__
 //#pragma ZTC noreturn(err_exit)
@@ -354,9 +342,7 @@ void symbol_reset(Symbol *s);
 tym_t symbol_pointerType(const Symbol* s);
 
 // cg87.c
-void cg87_reset();
-
-ubyte loadconst(elem *e, int im);
+public import dmd.backend.cg87 : loadconst, cg87_reset;
 
 /* From cgopt.c */
 void opt();
@@ -369,8 +355,7 @@ void objfile_delete();
 void objfile_term();
 
 /* cod3.c */
-void cod3_thunk(Symbol *sthunk,Symbol *sfunc,uint p,tym_t thisty,
-        uint d,int i,uint d2);
+public import dmd.backend.cod3 : cod3_thunk;
 
 /* out.c */
 void outfilename(char *name,int linnum);

--- a/compiler/src/dmd/backend/go.d
+++ b/compiler/src/dmd/backend/go.d
@@ -53,47 +53,7 @@ extern (C++):
 nothrow:
 @safe:
 
-int os_clock();
-
-/* gdag.c */
-void builddags();
-void boolopt();
-void opt_arraybounds();
-
-/* gflow.c */
-void flowrd();
-void flowlv();
-void flowae();
-void flowvbe();
-void flowcp();
-void genkillae();
-void flowarraybounds();
-int ae_field_affect(elem *lvalue,elem *e);
-
-/* glocal.c */
-void localize();
-
-/* gloop.c */
-bool blockinit();
-void compdom();
-void loopopt();
-void fillInDNunambig(vec_t v, elem *e);
-void updaterd(elem *n,vec_t GEN,vec_t KILL);
-
-/* gother.c */
-void rd_arraybounds();
-void rd_free();
-void constprop();
-void copyprop();
-void rmdeadass();
-void elimass(elem *);
-void deadvar();
-void verybusyexp();
-void listrds(vec_t, elem *, vec_t, Barray!(elem*)*);
-
-/* gslice.c */
-void sliceStructs(ref symtab_t, block*);
-
+import dmd.backend.os : os_clock;
 /***************************************************************************/
 
 extern (C) void mem_free(void* p);

--- a/compiler/src/dmd/backend/ph2.d
+++ b/compiler/src/dmd/backend/ph2.d
@@ -24,7 +24,7 @@ import dmd.backend.global;
 
 extern (C++):
 
-nothrow:
+nothrow: @nogc:
 
 /**********************************************
  * Do our own storage allocator, a replacement

--- a/compiler/src/dmd/backend/symtab.d
+++ b/compiler/src/dmd/backend/symtab.d
@@ -33,9 +33,7 @@ alias MEM_PH_FREEFP = mem_freefp;
 alias MEM_PH_STRDUP = mem_strdup;
 alias MEM_PH_REALLOC = mem_realloc;
 
-void stackoffsets(ref symtab_t, bool);
-
-private void err_nomem();
+import dmd.backend.global : err_nomem;
 
 struct symtab_t
 {


### PR DESCRIPTION
Remove function prototypes and resolve the resulting errors:

- turning some `private` functions `public`
- missing default parameter in `xmmload` and `xmmstore`
- missing `@nogc` in ph2
