### PR TITLE
update frontend.d to also include comments when using parseModule method

### DIFF
--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -396,7 +396,7 @@ Tuple!(Module, "module_", Diagnostics, "diagnostics") parseModule(AST = ASTCodeg
     import std.typecons : tuple;
 
     auto id = Identifier.idPool(fileName.baseName.stripExtension);
-    auto m = new Module(fileName, id, 0, 0);
+    auto m = new Module(fileName, id, 1, 0);
 
     if (code is null)
         m.read(Loc.initial);


### PR DESCRIPTION
This is a minor change. For my use case the parameter changes refer to whether you want the comments included in the AST. I think the user should be able to access that information, but I am not sure if the best approach would be to hardcode the value inside the `Module` constructor or to add another parameter with a default value