### PR TITLE
Fix Issue 22765 for windows

### DIFF
--- a/compiler/src/dmd/cppmanglewin.d
+++ b/compiler/src/dmd/cppmanglewin.d
@@ -997,9 +997,14 @@ extern(D):
             {
                 tmp.mangleTemplateValue(o, tv, actualti, is_dmc_template);
             }
-            else
-            if (!tp || tp.isTemplateTypeParameter())
+            else if (!tp || tp.isTemplateTypeParameter())
             {
+                Type t = isType(o);
+                if (t is null)
+                {
+                    actualti.error("internal compiler error: C++ `%s` template value parameter is not supported", o.toChars());
+                    fatal();
+                }
                 tmp.mangleTemplateType(o);
             }
             else if (tp.isTemplateAliasParameter())


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/15100 introduced a test that was passing only on linux. On windows, the assertion failure still manifested. That has led to breaking the CIs on stable.

The PR had entered because some windows tests that are disabled on master were still running on stable (and led to spurious failures). Therefore, the real error slipped under the radar.