### PR TITLE
Don't build backend with `-betterC`

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -371,11 +371,6 @@ alias backend = makeRuleWithArgs!((MethodInitializer!BuildRule builder, BuildRul
         "-of" ~ rule.target,
         ]
         .chain(
-            (
-                // Only use -betterC when it doesn't break other features
-                extraFlags.canFind("-unittest", env["COVERAGE_FLAG"]) ||
-                flags["DFLAGS"].canFind("-unittest", env["COVERAGE_FLAG"])
-            ) ? [] : ["-betterC"],
             flags["DFLAGS"], extraFlags,
 
             // source files need to have relative paths in order for the code coverage


### PR DESCRIPTION
The C to D translation of the backend has been completed for a long time. While replacing old function prototypes with imports (e.g. https://github.com/dlang/dmd/pull/15111) I sometimes encounter linker errors because of the betterC mismatch:

```
/usr/bin/ld: dmd/generated/linux/debug/64/dmd.o: in function `_D3dmd7backend6barray__T6BarrayTPSQBgQBf2cc5blockZQBa11__xopEqualsMxFKxSQCsQCrQCm__TQCiTQCeZQCqZb':
src/dmd/root/strtold.d:(.text._D3dmd7backend6barray__T6BarrayTPSQBgQBf2cc5blockZQBa11__xopEqualsMxFKxSQCsQCrQCm__TQCiTQCeZQCqZb[_D3dmd7backend6barray__T6BarrayTPSQBgQBf2cc5blockZQBa11__xopEqualsMxFKxSQCsQCrQCm__TQCiTQCeZQCqZb]+0x39): undefined reference to `_D4core8internal5array8equality__T8__equalsTPxS3dmd7backend2cc5blockTQzZQBmFNaNbNiNeMxAPQBqMxQhZb'
/usr/bin/ld: dmd/generated/linux/debug/64/dmd.o: in function `_D3dmd7backend6barray__T6BarrayTiZQk11__xopEqualsMxFKxSQCbQCaQBv__TQBrTiZQBxZb':
src/dmd/root/strtold.d:(.text._D3dmd7backend6barray__T6BarrayTiZQk11__xopEqualsMxFKxSQCbQCaQBv__TQBrTiZQBxZb[_D3dmd7backend6barray__T6BarrayTiZQk11__xopEqualsMxFKxSQCbQCaQBv__TQBrTiZQBxZb]+0x39): undefined reference to `_D4core8internal5array8equality__T8__equalsTiTiZQoFNaNbNiNeMxAiMxQeZb'
```

This PR fixes that and simplifies building the compiler.