### PR TITLE
fix issue 23859 - [REG 2.103] Throwing while in a deep callstack causes memory corruption

### DIFF
--- a/druntime/src/core/sys/windows/stacktrace.d
+++ b/druntime/src/core/sys/windows/stacktrace.d
@@ -239,6 +239,8 @@ private:
             if (frameNum >= skip)
             {
                 buffer[nframes++] = stackframe.AddrPC.Offset;
+                if (nframes >= buffer.length)
+                    break;
             }
             frameNum++;
         }

--- a/druntime/test/exceptions/src/winstack.d
+++ b/druntime/test/exceptions/src/winstack.d
@@ -49,6 +49,15 @@ void main()
             assert(checkStack(ex), "Bad stack");
         }
     }
+
+    // see https://issues.dlang.org/show_bug.cgi?id=23859
+    try
+    {
+        recurseThrow(200);
+    }
+    catch(Exception e)
+    {
+    }
 }
 
 void regular()
@@ -65,4 +74,11 @@ void recursion(int i)
         void function() f = cast(void function())0;
         f();
     }
+}
+
+void* recurseThrow(int n)
+{
+    if (n > 0)
+        return recurseThrow(n - 1) + 1; // avoid tail call optimization
+    throw new Exception("cancel");
 }


### PR DESCRIPTION
avoid writing beyond the end of the trace buffer