### PR TITLE
Fix Issue 19706 - Attribute inference in struct fails

### DIFF
--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1276,6 +1276,19 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             return ErrorExp.get();
         }
 
+        // https://issues.dlang.org/show_bug.cgi?id=19706
+        // When getting the attributes of the instance of a
+        // templated member function semantic tiargs does
+        // not perform semantic3 on the instance.
+        // For more information see FuncDeclaration.functionSemantic.
+        // For getFunctionAttributes it is mandatory to do
+        // attribute inference.
+        if (fd && fd.parent && fd.parent.isTemplateInstance)
+        {
+            fd.functionSemantic3();
+            tf = cast(TypeFunction)fd.type;
+        }
+
         auto mods = new Expressions();
 
         void addToMods(string str)

--- a/compiler/test/compilable/traits_getFunctionAttributes.d
+++ b/compiler/test/compilable/traits_getFunctionAttributes.d
@@ -1,9 +1,10 @@
 
 module traits_getFunctionAttributes;
 
+alias tuple(T...) = T;
+
 void test_getFunctionAttributes()
 {
-    alias tuple(T...) = T;
 
     struct S
     {
@@ -117,4 +118,15 @@ void test_getFunctionAttributes()
     auto systemDel = delegate() @system { };
     static assert(__traits(getFunctionAttributes, systemDel) == tuple!("pure", "nothrow", "@nogc", "@system"));
     static assert(__traits(getFunctionAttributes, typeof(systemDel)) == tuple!("pure", "nothrow", "@nogc", "@system"));
+}
+
+void bug19706()
+{
+    struct S
+    {
+        static int fImpl(Ret)() { return Ret.init; }
+
+        // tells us: `fImpl!int` is @system
+        static assert(__traits(getFunctionAttributes, fImpl!int) == tuple!("pure", "nothrow", "@nogc", "@safe"));
+    }
 }


### PR DESCRIPTION
The fundamental problem lies with [this code](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/func.d#L458) . Essentially, that hack makes it so that member functions that are part of a template instance will not have semantic3 run on them (thus attributes will not be inferred). That is to avoid issues with forward references in case we have mixed in symbols ([see this this for example](https://github.com/dlang/dmd/blob/master/compiler/test/runnable/test7511.d#L353)). Any modifications to that code lead to all sorts of failures. Therefore, I am not fixing the underlying issue - how to insert symbols in the symbol table in presence of mixins, static ifs etc. - because that is a broader issue with deep implications (could probably be fixed by doing an initial pass through the module members and only analyze static ifs, mixins, mixin templates etc).

However, to fix this particular test case I am bluntly performing semantic3. This should be fine since otherwise you get an invalid result, but could, theoretically, lead to `undefined symbol` errors in the presence of forward references to symbols masked by mixins. I guess a forward reference error is better than an invalid result.