### PR TITLE
ImportC: support __attribute__((always_inline))

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -3486,6 +3486,11 @@ final class CParser(AST) : Parser!AST
                  * type on the target machine. It's the opposite of __attribute__((packed))
                  */
             }
+            else if (token.ident == Id.always_inline) // https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
+            {
+                specifier.scw |= SCW.xinline;
+                nextToken();
+            }
             else if (token.ident == Id._deprecated)
             {
                 specifier._deprecated = true;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8877,6 +8877,7 @@ struct Id final
     static Identifier* naked;
     static Identifier* thread;
     static Identifier* vector_size;
+    static Identifier* always_inline;
     static Identifier* noinline;
     static Identifier* noreturn;
     static Identifier* _deprecated;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -527,6 +527,7 @@ immutable Msgtable[] msgtable =
     { "thread" },
     { "vector_size" },
     { "__func__" },
+    { "always_inline" },
     { "noinline" },
     { "noreturn" },
     { "_deprecated", "deprecated" },

--- a/compiler/test/compilable/always_inline.i
+++ b/compiler/test/compilable/always_inline.i
@@ -1,0 +1,5 @@
+// https://issues.dlang.org/show_bug?id=21938
+
+__attribute__((always_inline)) int square(int x) { return x * x; }
+
+int doSquare(int x) { return square(x); }


### PR DESCRIPTION
There doesn't seem to be a __declspec equivalent.

For reference: https://issues.dlang.org/show_bug.cgi?id=21938