### PR TITLE
ImportC: add __declspec and __attribute__ nothrow

### DIFF
--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -53,7 +53,7 @@ enum CT : BE
  */
 extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, bool mustNotThrow)
 {
-    //printf("Expression::canThrow(%d) %s\n", mustNotThrow, toChars());
+    //printf("Expression::canThrow(%d) %s\n", mustNotThrow, e.toChars());
     // stop walking if we determine this expression can throw
     extern (C++) final class CanThrow : StoppableVisitor
     {

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -2892,7 +2892,8 @@ final class CParser(AST) : Parser!AST
 
                         auto parameterList = cparseParameterList();
                         const lkg = specifier.mod & MOD.x__stdcall ? LINK.windows : linkage;
-                        AST.Type tf = new AST.TypeFunction(parameterList, t, lkg, 0);
+                        StorageClass stc = specifier._nothrow ? STC.nothrow_ : 0;
+                        AST.Type tf = new AST.TypeFunction(parameterList, t, lkg, stc);
     //                  tf = tf.addSTC(storageClass);  // TODO
                         insertTx(ts, tf, t);  // ts -> ... -> tf -> t
 
@@ -3176,6 +3177,7 @@ final class CParser(AST) : Parser!AST
      *    naked
      *    noinline
      *    noreturn
+     *    nothrow
      *    thread
      * Params:
      *  specifier = filled in with the attribute(s)
@@ -3222,6 +3224,11 @@ final class CParser(AST) : Parser!AST
                 else if (token.ident == Id.noreturn)
                 {
                     specifier.noreturn = true;
+                    nextToken();
+                }
+                else if (token.ident == Id._nothrow)
+                {
+                    specifier._nothrow = true;
                     nextToken();
                 }
                 else if (token.ident == Id.thread)
@@ -3520,6 +3527,11 @@ final class CParser(AST) : Parser!AST
             else if (token.ident == Id.noreturn)
             {
                 specifier.noreturn = true;
+                nextToken();
+            }
+            else if (token.ident == Id._nothrow)
+            {
+                specifier._nothrow = true;
                 nextToken();
             }
             else if (token.ident == Id.vector_size)
@@ -4926,6 +4938,7 @@ final class CParser(AST) : Parser!AST
     {
         bool noreturn;  /// noreturn attribute
         bool naked;     /// naked attribute
+        bool _nothrow;  /// nothrow attribute
         bool dllimport; /// dllimport attribute
         bool dllexport; /// dllexport attribute
         bool _deprecated;       /// deprecated attribute

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8879,6 +8879,7 @@ struct Id final
     static Identifier* vector_size;
     static Identifier* noinline;
     static Identifier* noreturn;
+    static Identifier* _nothrow;
     static Identifier* _deprecated;
     static Identifier* _align;
     static Identifier* aligned;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -529,6 +529,7 @@ immutable Msgtable[] msgtable =
     { "__func__" },
     { "noinline" },
     { "noreturn" },
+    { "_nothrow", "nothrow" },
     { "_deprecated", "deprecated" },
     { "_align", "align" },
     { "aligned" },

--- a/compiler/test/fail_compilation/testnothrow.c
+++ b/compiler/test/fail_compilation/testnothrow.c
@@ -1,0 +1,31 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/testnothrow.c(105): Error: function `testnothrow.throwing` is not `nothrow`
+fail_compilation/testnothrow.c(104): Error: function `testnothrow.mul` may throw but is marked as `nothrow`
+fail_compilation/testnothrow.c(111): Error: function `testnothrow.throwing` is not `nothrow`
+fail_compilation/testnothrow.c(110): Error: function `testnothrow.add` may throw but is marked as `nothrow`
+---
+*/
+
+// https://issues.dlang.org/show_bug?id=21938
+
+#line 100
+
+void throwing() { }
+
+__attribute__((nothrow)) int mul(int x)
+{
+    throwing();
+    return x * x;
+}
+
+__declspec(nothrow) int add(int x)
+{
+    throwing();
+    return x + x;
+}
+
+int doSquare(int x)
+{
+    return mul(x) + add(x);
+}


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html

https://learn.microsoft.com/en-us/cpp/cpp/nothrow-cpp?view=msvc-170

Easier to support it than argue about it.