### PR TITLE
Fix Issue 23863 -  typeof rejects AliasSeq!()  as argument

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -2804,8 +2804,10 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, out Expression pe, out Type 
         }
         mt.exp = exp2;
 
-        if (mt.exp.op == EXP.type ||
-            mt.exp.op == EXP.scope_)
+        if ((mt.exp.op == EXP.type || mt.exp.op == EXP.scope_) &&
+            // https://issues.dlang.org/show_bug.cgi?id=23863
+            // compile time sequences are valid types
+            !mt.exp.type.isTypeTuple())
         {
             if (!(sc.flags & SCOPE.Cfile) && // in (extended) C typeof may be used on types as with sizeof
                 mt.exp.checkType())

--- a/compiler/test/compilable/test23863.d
+++ b/compiler/test/compilable/test23863.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=23863
+
+alias AliasSeq(T...) = T;
+
+struct S
+{
+}
+alias Empty = S.tupleof;
+Empty x; // accepts valid
+
+static assert(is(typeof(x)));
+static assert(is(typeof(Empty)));
+static assert(is(typeof(AliasSeq!(int))));
+static assert(is(typeof(Empty) == AliasSeq!()));
+static assert(is(typeof(AliasSeq!()) == AliasSeq!()));


### PR DESCRIPTION
It seems that TypeExp is created as a placeholder for situations where types are used as expressions. In typeof, these call `checkType` which errors for TypeExp. However, when a TypeExp is created for a compile time  sequence (TupleDeclaration AST node), then that is a valid type.