### PR TITLE
Stack growth direction definition for supported architectures only

### DIFF
--- a/druntime/src/core/thread/types.d
+++ b/druntime/src/core/thread/types.d
@@ -41,8 +41,9 @@ version (GNU)
 }
 else
 {
-    // this should be true for most architectures
-    enum isStackGrowingDown = true;
+    version (X86) enum isStackGrowingDown = true;
+    else version (X86_64) enum isStackGrowingDown = true;
+    else static assert(0, "It is undefined how the stack grows on this architecture.");
 }
 
 package


### PR DESCRIPTION
According to https://github.com/dlang/phobos/blob/master/std/experimental/allocator/building_blocks/region.d#L702 we have only one architecture with stack growing up: HPPA

I propose to define this and delete bunch of `version` here (https://github.com/dlang/phobos/pull/8742)