### PR TITLE
Remove SYMDEB_TDB

### DIFF
--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -482,13 +482,6 @@ version (HTOD)
     void srcpos_dehydrate(Srcpos *);
 }
 
-// tdb.c
-uint tdb_gettimestamp();
-void tdb_write(void *buf,uint size,uint numindices);
-uint tdb_typidx(void *buf);
-//uint tdb_typidx(ubyte *buf,uint length);
-void tdb_term();
-
 // rtlsym.c
 void rtlsym_init();
 void rtlsym_reset();


### PR DESCRIPTION
I can find very little about tbd.dll, but it seems to be an old debugger. The code has been dead for a while, and unsurprisingly, setting `SYMDEB_TDB = true` results in errors. There's no future for it.
