### PR TITLE
Remove SPP version blocks

### DIFF
--- a/compiler/src/dmd/backend/blockopt.d
+++ b/compiler/src/dmd/backend/blockopt.d
@@ -12,9 +12,6 @@
 
 module dmd.backend.blockopt;
 
-version (SPP) {} else
-{
-
 version (SCPP)
     version = COMPILE;
 else version (HTOD)
@@ -2518,5 +2515,3 @@ private void blexit()
 
     bexits.dtor();
 }
-
-} //!SPP

--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -81,12 +81,7 @@ else
     bool LARGECODE() { return (config.memmodel & 5) != 0; }
 }
 
-version (SPP)
-{
-    enum COMPILER = "Preprocessor";
-    enum ACTIVITY = "preprocessing...";
-}
-else version (HTOD)
+version (HTOD)
 {
     enum COMPILER = ".h to D Migration Tool";
     enum ACTIVITY = "migrating...";
@@ -184,11 +179,6 @@ nothrow:
         Sfile **Sfilptr;            // file
         short Sfilnum;              // file number
     }
-    version (SPP)
-    {
-        Sfile **Sfilptr;            // file
-        short Sfilnum;              // file number
-    }
     version (HTOD)
     {
         Sfile **Sfilptr;            // file
@@ -230,11 +220,6 @@ nothrow:
 }
 
 version (SCPP)
-{
-    static Sfile srcpos_sfile(Srcpos p) { return **(p).Sfilptr; }
-    static char* srcpos_name(Srcpos p)   { return srcpos_sfile(p).SFname; }
-}
-version (SPP)
 {
     static Sfile srcpos_sfile(Srcpos p) { return **(p).Sfilptr; }
     static char* srcpos_name(Srcpos p)   { return srcpos_sfile(p).SFname; }
@@ -805,12 +790,9 @@ struct func_t
 
     char *Fredirect;            // redirect function name to this name in object
 
-version (SPP) { } else
-{
     version (MARS)
         // Array of catch types for EH_DWARF Types Table generation
         Barray!(Symbol*) typesTable;
-}
 
     union
     {
@@ -1491,12 +1473,6 @@ version (SCPP)
     const(char)* prettyident(const Symbol *s) { return CPP ? cpp_prettyident(s) : &s.Sident[0]; }
 }
 
-version (SPP)
-{
-    const(char)* cpp_prettyident (const Symbol *s);
-    const(char)* prettyident(const Symbol *s) { return &s.Sident[0]; }
-}
-
 version (HTOD)
 {
     const(char)* cpp_prettyident (const Symbol *s);
@@ -1704,14 +1680,7 @@ void sfile_debug(const Sfile* sf)
 // means that pfiles[] cannot be reallocated to larger numbers, its size is
 // fixed at SRCFILES_MAX.
 
-version (SPP)
-{
-    enum SRCFILES_MAX = (2*512*4);      // no precompiled headers for SPP
-}
-else
-{
-    enum SRCFILES_MAX = (2*512);
-}
+enum SRCFILES_MAX = (2*512);
 
 struct Srcfiles
 {

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -34,8 +34,6 @@ enum VERSIONINT = 0x900;        // for precompiled headers and DLL version
 
 version (SCPP)
     version = XVERSION;
-version (SPP)
-    version = XVERSION;
 version (HTOD)
     version = XVERSION;
 version (MARS)

--- a/compiler/src/dmd/backend/cgcs.d
+++ b/compiler/src/dmd/backend/cgcs.d
@@ -16,12 +16,6 @@
 
 module dmd.backend.cgcs;
 
-version (SPP)
-{
-}
-else
-{
-
 import core.stdc.stdio;
 import core.stdc.stdlib;
 
@@ -746,6 +740,4 @@ void touchaccess(ref Barray!HCS hcstab, const elem *ev) pure nothrow
         if (e && (e.Eoper == OPvp_fp || e.Eoper == OPcvp_fp) && e.EV.E1 != ev1)
             hcs.Helem = null;
     }
-}
-
 }

--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -19,12 +19,6 @@
 
 module dmd.backend.cgelem;
 
-version (SPP)
-{
-}
-else
-{
-
 import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
@@ -6608,5 +6602,3 @@ private extern (D) immutable elfp_t[OPMAX] elxxx =
     OPva_start: &elvalist,
     OPprefetch: &elzot,
 ];
-
-}

--- a/compiler/src/dmd/backend/ee.d
+++ b/compiler/src/dmd/backend/ee.d
@@ -12,9 +12,6 @@
  */
 module dmd.backend.ee;
 
-version (SPP) {} else
-{
-
 import core.stdc.stdio;
 import core.stdc.string;
 import core.stdc.time;
@@ -125,5 +122,4 @@ void eecontext_parse()
     }
 }
 
-}
 }

--- a/compiler/src/dmd/backend/evalu8.d
+++ b/compiler/src/dmd/backend/evalu8.d
@@ -13,12 +13,6 @@
 
 module dmd.backend.evalu8;
 
-version (SPP)
-{
-}
-else
-{
-
 import core.stdc.math;
 import core.stdc.stdio;
 import core.stdc.stdlib;
@@ -2074,5 +2068,4 @@ version (CRuntime_Microsoft)
 else
 {
     targ_ldouble _modulo(targ_ldouble x, targ_ldouble y);
-}
 }

--- a/compiler/src/dmd/backend/fp.d
+++ b/compiler/src/dmd/backend/fp.d
@@ -10,38 +10,35 @@
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/fp.d
  */
 
- module dmd.backend.fp;
+module dmd.backend.fp;
 
-version (SPP) {} else
+import core.stdc.math;
+import core.stdc.fenv;
+import dmd.root.longdouble;
+import dmd.backend.cdef;
+
+extern (C++):
+
+nothrow:
+
+int statusFE()
 {
-    import core.stdc.math;
-    import core.stdc.fenv;
-    import dmd.root.longdouble;
-    import dmd.backend.cdef;
+    return 0;
+}
 
-    extern (C++):
+int testFE()
+{
+    return fetestexcept(FE_ALL_EXCEPT);
+}
 
-    nothrow:
+void clearFE()
+{
+    feclearexcept(FE_ALL_EXCEPT);
+}
 
-    int statusFE()
-    {
-        return 0;
-    }
+bool have_float_except() { return true; }
 
-    int testFE()
-    {
-        return fetestexcept(FE_ALL_EXCEPT);
-    }
-
-    void clearFE()
-    {
-        feclearexcept(FE_ALL_EXCEPT);
-    }
-
-    bool have_float_except() { return true; }
-
-    longdouble _modulo(longdouble x, longdouble y)
-    {
-        return fmodl(x, y);
-    }
+longdouble _modulo(longdouble x, longdouble y)
+{
+    return fmodl(x, y);
 }

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -457,15 +457,6 @@ version (SCPP)
     void srcpos_hydrate(Srcpos *);
     void srcpos_dehydrate(Srcpos *);
 }
-version (SPP)
-{
-    extern __gshared Srcfiles srcfiles;
-    Sfile **filename_indirect(Sfile *sf);
-    Sfile  *filename_search(const(char)* name);
-    Sfile *filename_add(const(char)* name);
-    int filename_cmp(const(char)* f1,const(char)* f2);
-    void filename_translate(Srcpos *);
-}
 version (HTOD)
 {
     extern __gshared Srcfiles srcfiles;

--- a/compiler/src/dmd/backend/go.d
+++ b/compiler/src/dmd/backend/go.d
@@ -14,12 +14,6 @@
 
 module dmd.backend.go;
 
-version (SPP)
-{
-}
-else
-{
-
 import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
@@ -389,6 +383,4 @@ else
         block_optimizer_free(b);
     }
 }
-}
-
 }

--- a/compiler/src/dmd/backend/nteh.d
+++ b/compiler/src/dmd/backend/nteh.d
@@ -14,12 +14,6 @@
 
 module dmd.backend.nteh;
 
-version (SPP)
-{
-}
-else
-{
-
 import core.stdc.stdio;
 import core.stdc.string;
 
@@ -938,5 +932,4 @@ void nteh_monitor_epilog(ref CodeBuilder cdb,regm_t retregs)
 
 }
 
-}
 }

--- a/compiler/src/dmd/backend/obj.d
+++ b/compiler/src/dmd/backend/obj.d
@@ -27,9 +27,7 @@ extern (C++):
 
 nothrow:
 
-version (SPP)
-    version = STUB;
-else version (HTOD)
+version (HTOD)
     version = STUB;
 else version (Windows)
 {

--- a/compiler/src/dmd/backend/out.d
+++ b/compiler/src/dmd/backend/out.d
@@ -13,9 +13,6 @@
 
 module dmd.backend.dout;
 
-version (SPP) { } else
-{
-
 import core.stdc.stdio;
 import core.stdc.string;
 
@@ -1826,7 +1823,4 @@ version (SCPP) version (Win32)
         }
     }
 }
-}
-
-
 }

--- a/compiler/src/dmd/backend/var.d
+++ b/compiler/src/dmd/backend/var.d
@@ -26,11 +26,6 @@ import dmd.backend.symtab;
 import dmd.backend.ty;
 import dmd.backend.type;
 
-version (SPP)
-{
-    import parser;
-    import phstring;
-}
 version (SCPP)
 {
     import parser;
@@ -127,10 +122,6 @@ extern (C)
 FILE *fdep = null;              // dependency file stream pointer
 FILE *flst = null;              // list file stream pointer
 FILE *fin = null;               // input file
-version (SPP)
-{
-FILE *fout;
-}
 }
 
 // htod
@@ -146,11 +137,6 @@ char*   foutdir = null,       // directory to place output files in
         fdepname = null,
         flstname = null;       /* the filename strings                 */
 
-version (SPP)
-{
-    phstring_t fdeplist;
-    phstring_t pathlist;            // include paths
-}
 version (SCPP)
 {
     phstring_t fdeplist;
@@ -191,9 +177,6 @@ tym_t pointertype = TYnptr;     /* default data pointer type            */
 /*****************************
  * SCxxxx types.
  */
-
-version (SPP) { } else
-{
 
 char[SCMAX] sytab =
 [
@@ -241,8 +224,6 @@ char[SCMAX] sytab =
     /* stack */    SCEXP|SCSS       ,      /* offset from stack pointer (not frame pointer) */
     /* adl */      0                ,      /* list of ADL symbols for overloading  */
 ];
-
-}
 
 extern (C) int controlc_saw = 0;              /* a control C was seen         */
 symtab_t globsym;               /* global symbol table                  */


### PR DESCRIPTION
`version (SPP)` was used to version out parts not needed for a standalone C Preprocessor, but dmd's backend is not used by a C preprocessor anymore.