### PR TITLE
betterC: do not store variable in TLS

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1384,6 +1384,9 @@ extern (C++) class VarDeclaration : Declaration
      */
     override final bool isThreadlocal()
     {
+        // https://issues.dlang.org/show_bug.cgi?id=20737
+        if (global.params.betterC) return false;
+
         //printf("VarDeclaration::isThreadlocal(%p, '%s')\n", this, toChars());
         /* Data defaults to being thread-local. It is not thread-local
          * if it is immutable, const or shared.


### PR DESCRIPTION
Due to issues like this: https://issues.dlang.org/show_bug.cgi?id=20737

I think it's best to just don't store anything there until it's fixed, otherwise user get segfault that are hard to debug

I'd rather see a @tls for betterC