### PR TITLE
Fix C translation error in elem.d

### DIFF
--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -1374,10 +1374,6 @@ int el_depends(const(elem)* ea, const elem *eb)
         case OPconst:
         case OPrelconst:
         case OPstring:
-
-    version (SCPP_HTOD)
-        case OPsizeof:
-
             goto Lnodep;
 
         case OPvar:
@@ -2426,9 +2422,6 @@ L1:
                 break;
             case OPrelconst:
             case OPvar:
-version (SCPP_HTOD)
-            case OPsizeof:
-
                 symbol_debug(n1.EV.Vsym);
                 symbol_debug(n2.EV.Vsym);
                 if (n1.EV.Voffset != n2.EV.Voffset)


### PR DESCRIPTION
Found while refactoring the backend. In https://github.com/dlang/dmd/pull/8524, this C code:
```C
#if SCPP
        case OPsizeof:
#endif
```
Was translated to this D code:
```D
version (SCPP_HTOD)
        case OPsizeof:
```

However, this not only attaches to the case statement, but also the first statement following the case statement, which makes `el_depends` incorrect on `OPconst`, `OPrelconst` and `OPstring` if I'm not mistaken. 

@WalterBright is this right?