### PR TITLE
fix issues 20737 and 23014 - TLS variables unusable with -betterC/imp…

### DIFF
--- a/compiler/src/dmd/backend/cod2.d
+++ b/compiler/src/dmd/backend/cod2.d
@@ -2238,7 +2238,7 @@ void cdbswap(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 
     const tym = tybasic(e.Ety);
     const sz = _tysize[tym];
-    const posregs = (sz == 2) ? BYTEREGS : allregs;
+    const posregs = (sz == 2) ? mAX|mBX|mCX|mDX : allregs;
     regm_t retregs = *pretregs & posregs;
     if (retregs == 0)
         retregs = posregs;

--- a/compiler/src/dmd/backend/elpicpie.d
+++ b/compiler/src/dmd/backend/elpicpie.d
@@ -206,7 +206,7 @@ else if (config.exe & EX_windos)
         e1.EV.Vsym = s;
         e1.Ety = TYnptr;
 
-        if (config.wflags & WFexe)
+        if (false && config.wflags & WFexe) // disabled to work with betterC/importC
         {
             // e => *(&s + *(FS:_tls_array))
             e2 = el_var(getRtlsym(RTLSYM.TLS_ARRAY));

--- a/compiler/test/runnable/betterc.d
+++ b/compiler/test/runnable/betterc.d
@@ -42,6 +42,7 @@ extern (C) void main()
     test18472();
     testRuntimeLowerings();
     test18457();
+    test20737();
 }
 
 /*******************************************/
@@ -198,4 +199,14 @@ void test18457()
         assert(dtor == 0);
     }
     assert(dtor == 1);
+}
+
+/**********************************************/
+// https://issues.dlang.org/show_bug.cgi?id=20737
+int tlsVar;
+
+int test20737()
+{
+    tlsVar = 123;
+    return 0;
 }

--- a/compiler/test/runnable/test23014.i
+++ b/compiler/test/runnable/test23014.i
@@ -1,5 +1,4 @@
 /* EXTRA_SOURCES: imports/imp23014.i
- * DISABLED: win32mscoff win64
  */
 
 static _Thread_local int tmp;


### PR DESCRIPTION
…ortC for Windows MSVC targets

extracts the relevant parts from https://github.com/dlang/dmd/pull/15081