### PR TITLE
fix C to D translation error with version/case

### DIFF
--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -1384,11 +1384,13 @@ int el_depends(const(elem)* ea, const elem *eb)
         case OPconst:
         case OPrelconst:
         case OPstring:
+            goto Lnodep;
 
     version (SCPP_HTOD)
+    {
         case OPsizeof:
-
             goto Lnodep;
+    }
 
         case OPvar:
             if (ea.Eoper == OPvar && ea.EV.Vsym != eb.EV.Vsym)


### PR DESCRIPTION
The conversion of elem.d from C to D introduced an error, as detected by @dkorpel 

https://github.com/dkorpel/dmd/commit/d2e944bbcd3fe41b987395b5fedced332c26f23b