### PR TITLE
Fix Issue 23874 - -profile=gc segfaults / ICE regression - part 2

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -484,7 +484,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             // Infering the type requires running semantic,
             // so mark the scope as ctfe if required
-            bool needctfe = (dsym.storage_class & (STC.manifest | STC.static_)) != 0;
+            bool needctfe = (dsym.storage_class & (STC.manifest | STC.static_)) != 0 || !sc.func;
             if (needctfe)
             {
                 sc.flags |= SCOPE.condition;

--- a/compiler/test/compilable/test23874.d
+++ b/compiler/test/compilable/test23874.d
@@ -7,3 +7,4 @@ string myToString()
 }
 
 enum x = myToString ~ "";
+immutable x2 = myToString ~ "";


### PR DESCRIPTION
When inferring a type for a variable, semantic analysis is performed on the initializer. For static variables or manifest constants, while the initializer is analyzed, ctfe is perfomed, however, due to a slip, global variables (which are static by default) did not have their initializers interpreted if the type needed to be inferred. This was causing unneeded lowerings to druntime hooks (when the result could be interpreted).