### PR TITLE
Fix Issue 23890 - "Warning: cannot inline function" in core.lifetime

### DIFF
--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -1570,7 +1570,11 @@ template forward(args...)
             alias fwd = arg;
         // (r)value
         else
-            @property auto fwd(){ pragma(inline, true); return move(arg); }
+            @property auto fwd()
+            {
+                version (DigitalMars) { /* @@BUG 23890@@ */ } else pragma(inline, true);
+                return move(arg);
+            }
     }
 
     alias Result = AliasSeq!();

--- a/druntime/test/profile/Makefile
+++ b/druntime/test/profile/Makefile
@@ -5,6 +5,18 @@ TESTS:=profile profilegc both
 DIFF:=diff
 GREP:=grep
 
+ifeq (freebsd,$(OS))
+    SHELL=/usr/local/bin/bash
+else ifeq (openbsd,$(OS))
+    SHELL=/usr/local/bin/bash
+else ifeq (netbsd,$(OS))
+    SHELL=/usr/pkg/bin/bash
+else ifeq (dragonflybsd,$(OS))
+    SHELL=/usr/local/bin/bash
+else
+    SHELL=/bin/bash
+endif
+
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 
@@ -25,7 +37,9 @@ $(ROOT)/profilegc.done: $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	@rm -f $(ROOT)/myprofilegc.log
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(ROOT)/myprofilegc.log
-	$(QUIET)$(DIFF) myprofilegc.log.$(OS).$(MODEL).exp $(ROOT)/myprofilegc.log
+	$(QUIET)$(DIFF) \
+		<($(GREP) -vF 'core.' myprofilegc.log.$(OS).$(MODEL).exp) \
+		<($(GREP) -vF 'core.' $(ROOT)/myprofilegc.log)
 	@touch $@
 
 $(ROOT)/both.done: DFLAGS+=-profile -profile=gc

--- a/druntime/test/profile/myprofilegc.log.freebsd.32.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.32.exp
@@ -16,5 +16,4 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:14
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
-             16	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2755
              16	              1	wchar[] D main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.freebsd.64.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.64.exp
@@ -6,7 +6,6 @@ bytes allocated, allocations, type, function, file:line
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
              32	              1	C D main src/profilegc.d:12
-             32	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2755
              32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36

--- a/druntime/test/profile/myprofilegc.log.linux.32.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.32.exp
@@ -16,5 +16,4 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:14
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
-             16	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2755
              16	              1	wchar[] D main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.linux.64.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.64.exp
@@ -6,7 +6,6 @@ bytes allocated, allocations, type, function, file:line
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
              32	              1	C D main src/profilegc.d:12
-             32	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2755
              32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36

--- a/druntime/test/profile/myprofilegc.log.osx.32.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.32.exp
@@ -16,5 +16,4 @@ bytes allocated, allocations, type, function, file:line
              16	              1	int[] D main src/profilegc.d:14
              16	              1	int[] D main src/profilegc.d:22
              16	              1	int[] D main src/profilegc.d:37
-             16	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2755
              16	              1	wchar[] D main src/profilegc.d:35

--- a/druntime/test/profile/myprofilegc.log.osx.64.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.64.exp
@@ -6,7 +6,6 @@ bytes allocated, allocations, type, function, file:line
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
              32	              1	C D main src/profilegc.d:12
-             32	              1	profilegc.main.C core.lifetime._d_newclassT!(C)._d_newclassT ../../src/core/lifetime.d:2755
              32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36


### PR DESCRIPTION
I don't think we really need this, do we? CC @radcapricorn 