### PR TITLE
Issue 23889 - ImportC: alloca() not supported

### DIFF
--- a/compiler/test/runnable/test23889.c
+++ b/compiler/test/runnable/test23889.c
@@ -1,0 +1,13 @@
+// DISABLED: win32mscoff win64 freebsd
+
+// https://issues.dlang.org/show_bug.cgi?id=23886
+
+#include <stdlib.h>
+
+int main()
+{
+    int *p = (int*)alloca(100 * sizeof(int));
+    for (int i = 0; i < 100; ++i)
+	p[i] = i;
+    return 0;
+}

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -79,6 +79,7 @@
 
 #define __builtin_isnan(x) isnan(x)
 #define __builtin_isfinite(x) finite(x)
+#define __builtin_alloca(x) alloca(x)
 
 /********************************
  * __has_extension is a clang thing:


### PR DESCRIPTION
This works because `alloca()` is already a magic function for dmd.