### PR TITLE
embed DMD VERSION in object file

### DIFF
--- a/compiler/src/dmd/backend/cgobj.d
+++ b/compiler/src/dmd/backend/cgobj.d
@@ -1473,13 +1473,9 @@ void OmfObj_theadr(const(char)* modname)
  */
 
 @trusted
-void OmfObj_compiler()
+void OmfObj_compiler(const(char)* p)
 {
-    const(char)* compiler = "\0\xDB" ~ "Digital Mars C/C++"
-        ~ VERSION
-        ;       // compiled by ...
-
-    objrecord(COMENT,compiler,cast(uint)strlen(compiler));
+    obj_comment(0xDB, p, strlen(p));
 }
 
 /*******************************

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -1656,9 +1656,10 @@ void MachObj_filename(const(char)* modname)
  * Embed compiler version in .obj file.
  */
 
-void MachObj_compiler()
+void MachObj_compiler(const(char)* p)
 {
     //dbg_printf("MachObj_compiler\n");
+    MachObj_user(p);
 }
 
 

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -1114,9 +1114,10 @@ void MsCoffObj_filename(const(char)* modname)
  * Embed compiler version in .obj file.
  */
 
-void MsCoffObj_compiler()
+void MsCoffObj_compiler(const(char)* p)
 {
     //dbg_printf("MsCoffObj_compiler\n");
+    MsCoffObj_user(p);
 }
 
 /**************************************

--- a/compiler/src/dmd/backend/obj.d
+++ b/compiler/src/dmd/backend/obj.d
@@ -52,7 +52,7 @@ mixin(ObjMemDecl("bool $Obj_linkerdirective(const(char)* )"));
 mixin(ObjMemDecl("bool $Obj_allowZeroSize()"));
 mixin(ObjMemDecl("void $Obj_exestr(const(char)* p)"));
 mixin(ObjMemDecl("void $Obj_user(const(char)* p)"));
-mixin(ObjMemDecl("void $Obj_compiler()"));
+mixin(ObjMemDecl("void $Obj_compiler(const(char)* p)"));
 mixin(ObjMemDecl("void $Obj_wkext(Symbol *,Symbol *)"));
 mixin(ObjMemDecl("void $Obj_alias(const(char)* n1,const(char)* n2)"));
 mixin(ObjMemDecl("void $Obj_staticctor(Symbol *s,int dtor,int seg)"));
@@ -265,9 +265,9 @@ else
             mixin(genRetVal("user(p)"));
         }
 
-        void compiler()
+        void compiler(const(char)* p)
         {
-            mixin(genRetVal("compiler()"));
+            mixin(genRetVal("compiler(p)"));
         }
 
         void wkext(Symbol* s1, Symbol* s2)

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -356,6 +356,11 @@ private void obj_start(ref OutBuffer objbuf, const(char)* srcfile)
         objmod = Obj.initialize(&objbuf, srcfile, null);
     }
 
+    OutBuffer buf;
+    buf.write("DMD ");
+    buf.write(global.versionString());
+    Obj.compiler(buf.peekChars());
+
     el_reset();
     cg87_reset();
     out_reset();


### PR DESCRIPTION
Looks like this for Elf:
```
Section 10  .comment  PROGBITS,SIZE=0x0023(35),OFFSET=0x0178
 0178:   0 44 4d 44 20 76 32 2e 30 39 30 2e 30 2d 31 34   .DMD v2.090.0-14
 0188:  30 32 33 2d 67 63 33 61 39 36 30 64 2d 64 69 72   023-gc3a960d-dir
 0198:  74 79  0                                          ty.
```
and for OMF:
```
0081  COMENT  0 df 44 4d 44 20 76 32 2e 30 39 30 2e 30 2d 31   ..DMD v2.090.0-1
             34 30 32 33 2d 67 63 33 61 39 36 30 64 2d 64 69   4023-gc3a960d-di
             72 74 79                                          rty
```
Not implemented for Mach and Mscoff, because I haven't yet figured out how to do it.