### PR TITLE
Draft: Add -verror-verbosity and "Better Errors"

### DIFF
--- a/compiler/src/__deleteme.d
+++ b/compiler/src/__deleteme.d
@@ -1,0 +1,17 @@
+struct S(alias Func){ }
+
+int func1(int a){ return a*2; }
+int func2(int a){ return a*2; }
+
+void main()
+{
+   auto a = S!func1();
+   auto b = S!func2();
+
+   a = b;
+
+   auto c = S!((int a) => a*2)();
+   auto d = S!((int a) => a*2)();
+
+   c = d;
+}

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1565,13 +1565,14 @@ auto sourceFiles()
     Sources sources = {
         dmd: dmd,
         frontendHeaders: fileArray(env["D"], "
-            aggregate.h aliasthis.h arraytypes.h attrib.h compiler.h cond.h
+            aggregate.h aliasthis.h arraytypes.h attrib.h bettererrors.h compiler.h cond.h
             ctfe.h declaration.h dsymbol.h doc.h enum.h errors.h expression.h globals.h hdrgen.h
             identifier.h id.h import.h init.h json.h mangle.h module.h mtype.h nspace.h objc.h scope.h
             statement.h staticassert.h target.h template.h tokens.h version.h visitor.h
         "),
         lexer: fileArray(env["D"], "
-            console.d entity.d errors.d errorsink.d file_manager.d globals.d id.d identifier.d lexer.d location.d tokens.d
+            bettererrors.d console.d entity.d errors.d errorsink.d file_manager.d globals.d id.d identifier.d lexer.d location.d 
+            tokens.d
         ") ~ fileArray(env["ROOT"], "
             array.d bitarray.d ctfloat.d file.d filename.d hash.d port.d region.d rmem.d
             rootobject.d stringtable.d utf.d

--- a/compiler/src/dmd/bettererrors.d
+++ b/compiler/src/dmd/bettererrors.d
@@ -1,0 +1,342 @@
+module dmd.bettererrors;
+
+import dmd.ast_node;
+import dmd.console;
+import dmd.expression;
+import dmd.globals;
+import dmd.location;
+import dmd.mtype;
+import dmd.visitor;
+import dmd.root.optional;
+
+/++++ General types ++++/
+
+private alias SinkFuncT = void delegate(scope const(char)[], Optional!Color = Optional!Color.init) nothrow;
+
+private enum bool isInstanceOf(alias S, T) = is(T == S!Args, Args...);
+private template isInstanceOf(alias S, alias T)
+{
+    enum impl(alias T : S!Args, Args...) = true;
+    enum impl(alias T) = false;
+    enum isInstanceOf = impl!T;
+}
+
+/++++ Error configuration ++++/
+
+private:
+
+template ErrorConfig(Options_...)
+{
+    alias Options = Options_;
+
+    static foreach(option; Options)
+    {
+        static if(isInstanceOf!(WithParams, option))
+        {
+            alias Params = option.ParamTypes;
+        }
+        else static if(isInstanceOf!(WithBasicMessage, option) || isInstanceOf!(WithAdvancedMessage, option))
+        {
+            static if(option.Level == ErrorVerbosity.normal)
+                alias MessageNormal = option;
+            else static if(option.Level == ErrorVerbosity.verbose)
+                alias MessageVerbose = option;
+            else static if(option.Level == ErrorVerbosity.detailed)
+                alias MessageDetailed = option;
+            else static assert(false, "ErrorVerbosity level is unhandled");
+        }
+    }
+
+    static if(__traits(compiles, MessageNormal))
+    {
+        static if(!__traits(compiles, MessageVerbose))
+            alias MessageVerbose = MessageNormal;
+        static if(!__traits(compiles, MessageDetailed))
+            alias MessageDetailed = MessageVerbose;
+    } else static assert(false, "A message for ErrorVerbosity.normal must be specified");
+}
+
+template WithParams(ParamT_...)
+{
+    alias ParamTypes = ParamT_;
+}
+
+template WithBasicMessage(ErrorVerbosity Level_, Values_...)
+{
+    enum Level = Level_;
+    alias Values = Values_;
+
+    void toSink(Params...)(scope SinkFuncT sink, Params params)
+    {
+        static foreach(value; Values)
+        {
+            static if(isInstanceOf!(ParamRef, value))
+            {
+                formatterToSink(Level, sink, params[value.ParamIndex]);
+            }
+            else static if(__traits(compiles, typeof(value)))
+            {
+                formatterToSink(Level, sink, value);
+            }
+            else static assert(false, "TODO: Message");
+        }
+    }
+}
+
+template ParamRef(size_t ParamIndex_)
+{
+    enum ParamIndex = ParamIndex_;
+}
+
+template WithAdvancedMessage(ErrorVerbosity Level_, alias MessageFunc_)
+{
+    enum Level = Level_;
+    alias MessageFunc = MessageFunc_;
+
+    void toSink(Params...)(scope SinkFuncT sink, Params params) nothrow
+    {
+        MessageFunc(sink, params);
+    }
+}
+
+/++++ Type Formatters ++++/
+
+private:
+
+void formatterToSink(ErrorVerbosity level, scope SinkFuncT sink, string value) nothrow
+{
+    sink(value);
+}
+
+void formatterToSink(ErrorVerbosity level, scope SinkFuncT sink, ASTNode node) nothrow
+{
+    scope visitor = new FormatVisitor(level, sink);
+
+    try node.accept(visitor);
+    catch(Exception ex)
+        assert(false);
+}
+
+extern(C++) class FormatVisitor : Visitor
+{
+    import core.stdc.string : strlen;
+
+    alias visit = Visitor.visit;
+    ErrorVerbosity level;
+    SinkFuncT sink;
+
+    extern(D) this(ErrorVerbosity level, scope SinkFuncT sink) nothrow scope
+    {
+        this.level = level;
+        this.sink = sink;
+    }
+
+    override void visit(Expression exp)
+    {
+        scope ptr = exp.toChars();
+        sink("`");
+        sink(ptr[0..strlen(ptr)], Optional!Color(Color.bright));
+        sink("`");
+    }
+
+    override void visit(Type type)
+    {
+        scope ptr = type.toChars();
+        sink("`");
+        sink(ptr[0..strlen(ptr)], Optional!Color(Color.bright));
+        sink("`");
+    }
+}
+
+/++++ Errors ++++/
+
+private:
+
+mixin template ErrorFuncs(alias Config)
+{
+    import dmd.errors;
+
+    nothrow static:
+
+    extern(D) void toSink(
+        ErrorVerbosity level,
+        scope SinkFuncT sink, 
+        Config.Params params,
+    )
+    {
+        final switch(level) with(ErrorVerbosity)
+        {
+            case normal: Config.MessageNormal.toSink(sink, params); break;
+            case verbose: Config.MessageVerbose.toSink(sink, params); break;
+            case detailed: Config.MessageDetailed.toSink(sink, params); break;
+        }
+    }
+
+    extern(D) void byLine(
+        ErrorVerbosity level,
+        scope void delegate(size_t, scope const(char)[], Optional!Color) nothrow sink,
+        Config.Params params,
+    )
+    {
+        import dmd.common.outbuffer;
+
+        size_t lineNum;
+        scope buffer = OutBuffer(1024);
+        Optional!Color lastColor;
+
+        void flushLines()
+        {
+            size_t index;
+            while(index < buffer.length)
+            {
+                if(buffer[index] == '\n')
+                {
+                    scope slice = buffer[0..index];
+                    sink(lineNum++, slice, lastColor);
+                    foreach(i, ch; buffer[index+1..$])
+                        buffer.buf[i] = ch;
+                    buffer.setsize(buffer.length - (slice.length + 1));
+                    index = 0;
+                }
+                else
+                    index++;
+            }
+            sink(lineNum, buffer[0..$], lastColor);
+            buffer.setsize(0);
+        }
+
+        toSink(level, (scope line, color)
+        {
+            if(color != lastColor)
+            {
+                flushLines();
+                lastColor = color;
+            }
+            buffer.writestring(line);
+        }, params);
+        flushLines();
+    }
+
+    void toStderr(
+        const ref Loc loc,
+        ErrorVerbosity level,
+        Color headerColor,
+        scope const(char)* header,
+        Config.Params params,
+    )
+    {
+        import core.stdc.stdio : fprintf, stderr, fflush, fputs;
+        import core.stdc.string : strlen;
+        import dmd.root.rmem : mem;
+
+        const locChars = loc.toChars();
+        scope(exit)
+        {
+            if(*locChars)
+                mem.xfree(cast(void*)locChars);
+            fflush(stderr);
+        }
+
+        char[32] paddingChars;
+        size_t headerLen;
+        if(header)
+        {
+            headerLen = strlen(header);
+            assert(headerLen <= paddingChars.length-1, "Header is larger than padding chars");
+
+            if(headerLen)
+            {
+                paddingChars[0..headerLen] = ' ';
+                paddingChars[headerLen] = '\0';
+            }
+        }
+
+        Console con = cast(Console) global.console;
+        auto lastLineNum = size_t.max;
+        byLine(level, (lineNum, scope line, color)
+        {
+            if(lineNum != lastLineNum)
+            {
+                if(lineNum != 0)
+                    fputs("\n", stderr);
+
+                if(con)
+                    con.setColorBright(true);
+                fprintf(stderr, "%s: ", locChars);
+
+                if(con)
+                    con.setColor(headerColor);
+                if(lineNum == 0)
+                    fputs(header, stderr);
+                else if(headerLen)
+                    fputs(paddingChars.ptr, stderr);
+
+                lastLineNum = lineNum;
+            }
+
+            if(con)
+            {
+                con.resetColor();
+                if(color.isPresent())
+                {
+                    if(color.get() != Color.bright)
+                        con.setColor(color.get());
+                    else
+                        con.setColorBright(true);
+                }
+            }
+
+            if(line.length)
+            {
+                assert(line.length <= int.max, "Line slice is too large");
+                fprintf(stderr, "%.*s", cast(int)line.length, &line[0]);
+            }
+        }, params);
+        fputs("\n", stderr);
+    }
+
+    void error(const ref Loc loc, Config.Params params)
+    {
+        import dmd.errors : fatal;
+
+        const verbosity = global.params.errorVerbosity;
+        global.errors++;
+        if (!global.gag)
+        {
+            toStderr(loc, verbosity, Color.brightRed, "Error: ", params);
+            if (global.params.errorLimit && global.errors >= global.params.errorLimit)
+                fatal(); // moderate blizzard of cascading messages
+        }
+        else
+        {
+            if (global.params.showGaggedErrors)
+                toStderr(loc, verbosity, Color.brightRed, "Error: ", params);
+            global.gaggedErrors++;
+        }
+    }
+}
+
+public:
+
+extern(C++) struct ErrorCannotImplicitlyCast
+{
+    mixin ErrorFuncs!(ErrorConfig!(
+        WithParams!(Expression, Type, Type),
+        WithBasicMessage!(ErrorVerbosity.normal,
+            "cannot implicitly convert expression ",
+            ParamRef!0,
+            " of type ",
+            ParamRef!1,
+            " to ",
+            ParamRef!2
+        ),
+        WithBasicMessage!(ErrorVerbosity.verbose,
+            "cannot implicitly convert expression ",
+            ParamRef!0,
+            " of type\n  ",
+            ParamRef!1,
+            "\nto\n  ",
+            ParamRef!2,
+        )
+    ));
+}

--- a/compiler/src/dmd/bettererrors.h
+++ b/compiler/src/dmd/bettererrors.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "expression.h"
+#include "mtype.h"
+
+struct Loc;
+
+enum ErrorVerbosity
+{
+    normal,
+    verbose,
+    detailed,
+};
+
+struct ErrorCannotImplicitlyCast
+{
+    static void toStderr(const Loc& loc, ErrorVerbosity level, const char* header, Expression* p1, Type* p2, Type* p3);
+    static void error(const Loc& loc, Expression* p1, Type* p2, Type* p3);
+};

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -777,6 +777,9 @@ dmd -cov -unittest myprog.d
         Option("verror-supplements=<num>",
             "limit the number of supplemental messages for each error (0 means unlimited)"
         ),
+        Option("verror-verbosity=[normal|verbose|detailed]",
+            "verbose compilation errors"
+        ),
         Option("verrors=<num>",
             "limit the number of error messages (0 means unlimited)"
         ),

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -141,9 +141,13 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
                 //printf("type %p ty %d deco %p\n", type, type.ty, type.deco);
                 //type = type.typeSemantic(loc, sc);
                 //printf("type %s t %s\n", type.deco, t.deco);
-                auto ts = toAutoQualChars(e.type, t);
-                e.error("cannot implicitly convert expression `%s` of type `%s` to `%s`",
-                    e.toChars(), ts[0], ts[1]);
+                
+                // auto ts = toAutoQualChars(e.type, t);
+                // e.error("cannot implicitly convert expression `%s` of type `%s` to `%s`",
+                //     e.toChars(), ts[0], ts[1]);
+
+                import dmd.bettererrors;
+                ErrorCannotImplicitlyCast.error(e.loc, e, e.type, t);
             }
         }
         return ErrorExp.get();

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -84,6 +84,13 @@ enum FeatureState : byte
     enabled = 1    /// Specified as `-preview=`
 }
 
+enum ErrorVerbosity
+{
+    normal,
+    verbose,
+    detailed,
+}
+
 extern(C++) struct Output
 {
     bool doOutput;      // Output is enabled
@@ -184,6 +191,7 @@ extern (C++) struct Param
 
     uint errorLimit = 20;
     uint errorSupplementLimit = 6;      // Limit the number of supplemental messages for each error (0 means unlimited)
+    ErrorVerbosity errorVerbosity;      // How verbose the error message should be
 
     const(char)[] argv0;                // program name
     Array!(const(char)*) modFileAliasStrings; // array of char*'s of -I module filename alias strings

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -74,6 +74,13 @@ enum CppStdRevision
     CppStdRevisionCpp20 = 202002
 };
 
+enum ErrorVerbosity
+{
+    normal,
+    verbose,
+    detailed,
+};
+
 /// Trivalent boolean to represent the state of a `revert`able change
 enum class FeatureState : signed char
 {
@@ -181,6 +188,7 @@ struct Param
 
     unsigned errorLimit;
     unsigned errorSupplementLimit; // Limit the number of supplemental messages for each error (0 means unlimited)
+    ErrorVerbosity errorVerbosity; 
 
     DString  argv0;    // program name
     Array<const char *> modFileAliasStrings; // array of char*'s of -I module filename alias strings

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1735,6 +1735,25 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                 error("unknown error style '%.*s', must be 'digitalmars' or 'gnu'", cast(int) style.length, style.ptr);
             }
         }
+        else if (startsWith(p + 1, "verror-verbosity="))
+        {
+            const(char)[] level = arg["verror-verbosity=".length + 1 .. $];
+
+            switch (level)
+            {
+            case "normal":
+                params.errorVerbosity = ErrorVerbosity.normal;
+                break;
+            case "verbose":
+                params.errorVerbosity = ErrorVerbosity.verbose;
+                break;
+            case "detailed":
+                params.errorVerbosity = ErrorVerbosity.detailed;
+                break;
+            default:
+                error("unknown error verbosity '%.*s', must be 'normal', 'verbose', or 'detailed'", cast(int) level.length, level.ptr);
+            }
+        }
         else if (startsWith(p + 1, "target"))
         {
             enum len = "-target=".length;


### PR DESCRIPTION
# Overview

This is basically just a rehash of #12526 but with a hopefully saner interface, as well as a lack of [terrible code](https://github.com/dlang/dmd/pull/12526/files#diff-3c626703199066ace8dff330a356369686c9652f9a36db059683b963f4ff0061R52).

This MR is effectively serving as a **general proof-of-concept** right now, and not a merge-able implementation;  as I would like the discussion to focus more around whether this is generally a good idea/design or not, and then worry about getting it ready for inclusion after its been given the go-ahead.

e.g. the code isn't in DMD's style; the headers probably don't work, documentation is needed, etc. are things I'd like to tackle after a preliminary approval.

# What does this MR do for the end user?

This MR adds a new compiler flag `-verror-verbosity` that currently has three levels: normal, verbose, and detailed.

This MR in its current state only modifies one error message to support the new flag, which can be see using this example:

```d
struct S(alias Func){ }

int func1(int a){ return a*2; }
int func2(int a){ return a*2; }

void main()
{
   auto a = S!func1();
   auto b = S!func2();

   a = b;

   auto c = S!((int a) => a*2)();
   auto d = S!((int a) => a*2)();

   c = d;
}
```

Normal verbosity:

```
__deleteme.d(11): Error: cannot implicitly convert expression `b` of type `S!(func2)` to `S!(func1)`
__deleteme.d(16): Error: cannot implicitly convert expression `d` of type `S!(function (int a) pure nothrow @nogc @safe => a * 2)` to `S!(function (int a) pure nothrow @nogc @safe => a * 2)`
```

Verbose verbosity:

```
__deleteme.d(11): Error: cannot implicitly convert expression `b` of type
__deleteme.d(11):          `S!(func2)`
__deleteme.d(11):        to
__deleteme.d(11):          `S!(func1)`
__deleteme.d(16): Error: cannot implicitly convert expression `d` of type
__deleteme.d(16):          `S!(function (int a) pure nothrow @nogc @safe => a * 2)`
__deleteme.d(16):        to
__deleteme.d(16):          `S!(function (int a) pure nothrow @nogc @safe => a * 2)`
```

Detailed verbosity is not implemented for anything yet, however it's existence is mainly spelled out in the old MR (as the theoretical `level 3` formatter), I'll also touch upon it later in this comment.

# What does this MR do for the compiler developers?

This MR creates a new file (mainly just for my own sake: could easily merge this into errors.d instead) called `bettererrors.d` that contains the proposed "Better" error system.

The general idea is that instead of relying on `printf` style error messages, we instead build up a catalogue of statically defined errors, that also provide a statically typed interface.

The rationale behind this is so that the caller code is as simple as it needs to be, while the implementation code is shoved somewhere unrelated so we don't litter parsing code with code that makes pretty errors.

## Example - Creating and using an error

For example, in `bettererrors.d` we define the `ErrorCannotImplicitlyConvert` error as:

```d
extern(C++) struct ErrorCannotImplicitlyCast
{
    mixin ErrorFuncs!(ErrorConfig!(
        WithParams!(Expression, Type, Type),
        WithBasicMessage!(ErrorVerbosity.normal,
            "cannot implicitly convert expression ",
            ParamRef!0,
            " of type ",
            ParamRef!1,
            " to ",
            ParamRef!2
        ),
        WithBasicMessage!(ErrorVerbosity.verbose,
            "cannot implicitly convert expression ",
            ParamRef!0,
            " of type\n  ",
            ParamRef!1,
            "\nto\n  ",
            ParamRef!2,
        )
    ));
}
```

Then when we want to produce this error, we can simply call it as:

```d
// e is Expression
// t is Type
ErrorCannotImplicitlyCast.error(e.loc, e, e.type, t);
```

The `.error` function is one of the many functions generated by the `ErrorFuncs` mixin. It is statically typed (because of the `WithParams` option we pass into it) which among other things, also should allow it to be header friendly without us having to compromise much on the D side to compensate.

## Example - Formatters

You can register any type with `WithParams`, and as long as there is an overload of `formatterToSink` then it should just work (tm).

For example the string formatter is super simple:

```d
void formatterToSink(ErrorVerbosity level, scope SinkFuncT sink, string value) nothrow
{
    sink(value);
}
```

Formatting AST nodes is also pretty simple since we can just use a `Visitor` to implement most of the logic we need.

# Potential feature - Stronger diagnostics

Because we're offloading the error implementations somewhere different than the caller's code; and because we are now able to work with fully static functions instead of a vararg of strings - this should hopefully be able to provide the motivation to improve diagnostics in the future.

As a really basic example, we could replace the `WithBasicMessage` inside of the `ErrorCannotImplicitlyCast` error to instead be:

```d
extern(C++) struct ErrorCannotImplicitlyCast
{
    // Example is super shortened for the MR comment
    mixin ErrorFuncs!(ErrorConfig!(
        WithParams!(Expression, Type, Type),
        WithAdvancedMessage!(ErrorVerbosity.normal, genMessage),
    ));

    extern(D) private static void genMessage(
        ErrorVerbosity level,
        SinkFuncT sink,
        Expression p0,
        Type p1,
        Type p2
    ) nothrow
    {
        if(p1 is Type.tint32 && p2 is Type.tint16)
        {
            sink("cannot implicitly convert `int` to `short`\n"); // again: this is just so the snippet is short
            sink("you can read more about D's promotion rules at https://dlang.org/spec/type.html#integer-promotions");
        }
    }
}
```

Producing:

```
__deleteme.d(4): Error: cannot implicitly convert `int` to `short`
__deleteme.d(4):        you can read more about D's promotion rules at https://dlang.org/spec/type.html#integer-promotions
```

# Rationale

Mainly explained in the old MR, but TL;DR - better errors are good for the mind and soul.

# Improvements over the last attempt

Other than the amazingly hacky code that I'm embarrassed I even tried to get into a serious project like DMD - I feel this proposal in general has a better and more extensible design.

This proposal produces statically typed functions instead of using varargs. This should be self explanatory for the most part, and as mentioned should also make it possible to write `.h` files while still using D's metaprogramming for code generation.

This proposal also has potential for further future advancements and features, as also mentioned earlier in this comment.