### PR TITLE
reduce Loc.sizeof by 8 bytes

### DIFF
--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -429,9 +429,9 @@ extern(C++) void gendocfile(Module m)
     if (m.filetype == FileType.ddoc)
     {
         const ploc = m.md ? &m.md.loc : &m.loc;
-        const loc = Loc(ploc.filename ? ploc.filename : srcfilename.ptr,
-                        ploc.linnum,
-                        ploc.charnum);
+        Loc loc = *ploc;
+        if (!loc.fileIndex)
+            loc.filename = srcfilename.ptr;
 
         size_t commentlen = strlen(cast(char*)m.comment);
         Dsymbols a;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -377,18 +377,20 @@ enum class MessageStyle : uint8_t
 
 struct Loc final
 {
-    const char* filename;
     uint32_t linnum;
-    uint32_t charnum;
+    uint16_t charnum;
+    uint16_t fileIndex;
     static bool showColumns;
     static MessageStyle messageStyle;
     static void set(bool showColumns, MessageStyle messageStyle);
+    const char* filename() const;
+    void filename(const char* name);
     const char* toChars(bool showColumns = showColumns, MessageStyle messageStyle = messageStyle) const;
     bool equals(const Loc& loc) const;
     Loc() :
-        filename(),
         linnum(),
-        charnum()
+        charnum(),
+        fileIndex()
     {
     }
 };
@@ -2345,7 +2347,7 @@ struct AttributeViolation final
     RootObject* arg1;
     RootObject* arg2;
     AttributeViolation() :
-        loc(Loc(nullptr, 0u, 0u)),
+        loc(Loc(0u, 0u, 0u)),
         fmtStr(nullptr),
         arg0(nullptr),
         arg1(nullptr),
@@ -7004,23 +7006,23 @@ struct UnionExp final
 private:
     union __AnonStruct__u
     {
-        char exp[34LLU];
-        char integerexp[48LLU];
-        char errorexp[34LLU];
-        char realexp[64LLU];
-        char complexexp[80LLU];
-        char symoffexp[72LLU];
-        char stringexp[58LLU];
-        char arrayliteralexp[56LLU];
-        char assocarrayliteralexp[56LLU];
-        char structliteralexp[84LLU];
-        char compoundliteralexp[48LLU];
-        char nullexp[34LLU];
-        char dotvarexp[57LLU];
-        char addrexp[48LLU];
-        char indexexp[82LLU];
-        char sliceexp[73LLU];
-        char vectorexp[61LLU];
+        char exp[26LLU];
+        char integerexp[40LLU];
+        char errorexp[26LLU];
+        char realexp[48LLU];
+        char complexexp[64LLU];
+        char symoffexp[64LLU];
+        char stringexp[50LLU];
+        char arrayliteralexp[48LLU];
+        char assocarrayliteralexp[48LLU];
+        char structliteralexp[76LLU];
+        char compoundliteralexp[40LLU];
+        char nullexp[26LLU];
+        char dotvarexp[49LLU];
+        char addrexp[40LLU];
+        char indexexp[74LLU];
+        char sliceexp[65LLU];
+        char vectorexp[53LLU];
     };
     #pragma pack(pop)
 

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -353,9 +353,9 @@ typedef unsigned long long uinteger_t;
 // file location
 struct Loc
 {
-    const char *filename; // either absolute or relative to cwd
     unsigned linnum;
-    unsigned charnum;
+    unsigned short charnum;
+    unsigned short fileIndex;
 
     static void set(bool showColumns, MessageStyle messageStyle);
 
@@ -366,15 +366,18 @@ struct Loc
     {
         linnum = 0;
         charnum = 0;
-        filename = NULL;
+        fileIndex = 0;
     }
 
     Loc(const char *filename, unsigned linnum, unsigned charnum)
     {
         this->linnum = linnum;
         this->charnum = charnum;
-        this->filename = filename;
+        this->filename(filename);
     }
+
+    const char *filename() const;
+    void filename(const char *name);
 
     const char *toChars(
         bool showColumns = Loc::showColumns,

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -119,7 +119,7 @@ class Lexer
     this(const(char)* filename, const(char)* base, size_t begoffset,
         size_t endoffset, bool doDocComment, bool commentToken,
         ErrorSink errorSink,
-        const CompileEnv* compileEnv) pure scope
+        const CompileEnv* compileEnv) scope
     {
         scanloc = Loc(filename, 1, 1);
         // debug printf("Lexer::Lexer(%p)\n", base);
@@ -2674,7 +2674,7 @@ class Lexer
 
     final Loc loc() pure @nogc
     {
-        scanloc.charnum = cast(uint)(1 + p - line);
+        scanloc.charnum = cast(ushort)(1 + p - line);
         version (LocOffset)
             scanloc.fileOffset = cast(uint)(p - base);
         return scanloc;

--- a/compiler/src/dmd/location.d
+++ b/compiler/src/dmd/location.d
@@ -11,7 +11,10 @@
 
 module dmd.location;
 
+import core.stdc.stdio;
+
 import dmd.common.outbuffer;
+import dmd.root.array;
 import dmd.root.filename;
 
 version (DMDLIB)
@@ -34,10 +37,9 @@ debug info etc.
 */
 struct Loc
 {
-    /// zero-terminated filename string, either absolute or relative to cwd
-    const(char)* filename;
     uint linnum; /// line number, starting from 1
-    uint charnum; /// utf8 code unit index relative to start of line, starting from 1
+    ushort charnum; /// utf8 code unit index relative to start of line, starting from 1
+    ushort fileIndex; // index into filenames[], starting from 1 (0 means no filename)
     version (LocOffset)
         uint fileOffset; /// utf8 code unit index relative to start of file, starting from 0
 
@@ -45,6 +47,8 @@ struct Loc
 
     extern (C++) __gshared bool showColumns;
     extern (C++) __gshared MessageStyle messageStyle;
+
+    __gshared Array!(const(char)*) filenames;
 
 nothrow:
 
@@ -60,19 +64,45 @@ nothrow:
         this.messageStyle = messageStyle;
     }
 
-    extern (D) this(const(char)* filename, uint linnum, uint charnum) pure
+    extern (D) this(const(char)* filename, uint linnum, uint charnum)
     {
         this.linnum = linnum;
-        this.charnum = charnum;
+        this.charnum = cast(ushort)charnum;
         this.filename = filename;
+    }
+
+    /***
+     * Returns: filename for this location, null if none
+     */
+    extern (C++) const(char)* filename() const @nogc
+    {
+        return fileIndex ? filenames[fileIndex - 1] : null;
+    }
+
+    /***
+     * Set file name for this location
+     * Params:
+     *   name = file name for location, null for no file name
+     */
+    extern (C++) void filename(const(char)* name)
+    {
+        if (name)
+        {
+            //printf("setting %s\n", name);
+            filenames.push(name);
+            fileIndex = cast(ushort)filenames.length;
+            assert(fileIndex);  // no overflow
+        }
+        else
+            fileIndex = 0;
     }
 
     extern (C++) const(char)* toChars(
         bool showColumns = Loc.showColumns,
-        MessageStyle messageStyle = Loc.messageStyle) const pure nothrow
+        MessageStyle messageStyle = Loc.messageStyle) const nothrow
     {
         OutBuffer buf;
-        if (filename)
+        if (fileIndex)
         {
             buf.writestring(filename);
         }
@@ -126,7 +156,7 @@ nothrow:
      * may lead to multiple equivalent filenames (`foo.d-mixin-<line>`),
      * e.g., for test/runnable/test18880.d.
      */
-    extern (D) bool opEquals(ref const(Loc) loc) const @trusted pure nothrow @nogc
+    extern (D) bool opEquals(ref const(Loc) loc) const @trusted nothrow @nogc
     {
         import core.stdc.string : strcmp;
 
@@ -137,7 +167,7 @@ nothrow:
     }
 
     /// ditto
-    extern (D) size_t toHash() const @trusted pure nothrow
+    extern (D) size_t toHash() const @trusted nothrow
     {
         import dmd.root.string : toDString;
 
@@ -153,6 +183,6 @@ nothrow:
      */
     bool isValid() const pure
     {
-        return filename !is null;
+        return fileIndex != 0;
     }
 }

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -75,7 +75,7 @@ alias toSymbol = dmd.glue.toSymbol;
 alias StmtState = dmd.stmtstate.StmtState!block;
 
 
-void elem_setLoc(elem *e, const ref Loc loc) pure nothrow
+void elem_setLoc(elem *e, const ref Loc loc) nothrow
 {
     srcpos_setLoc(e.Esrcpos, loc);
 }
@@ -1707,12 +1707,12 @@ void insertFinallyBlockGotos(block *startblock)
     }
 }
 
-private void block_setLoc(block *b, const ref Loc loc) pure nothrow
+private void block_setLoc(block *b, const ref Loc loc) nothrow
 {
     srcpos_setLoc(b.Bsrcpos, loc);
 }
 
-private void srcpos_setLoc(ref Srcpos s, const ref Loc loc) pure nothrow
+private void srcpos_setLoc(ref Srcpos s, const ref Loc loc) nothrow
 {
     s.set(loc.filename, loc.linnum, loc.charnum);
 }

--- a/compiler/test/unit/interfaces/check_implementations_20861.d
+++ b/compiler/test/unit/interfaces/check_implementations_20861.d
@@ -45,7 +45,7 @@ import support : afterEach, beforeEach, compiles, stripDelimited, Diagnostic;
         }.stripDelimited;
 
         enum message = "Error: class test.Bar interface function void foo() is not implemented";
-        enum expected = Diagnostic(Loc(filename, 6, 1), message);
+        const expected = Diagnostic(Loc(filename, 6, 1), message);
 
         const diagnostics = compiles(code, filename);
         assert(diagnostics == [expected], "\n" ~ diagnostics.toString);
@@ -67,7 +67,7 @@ import support : afterEach, beforeEach, compiles, stripDelimited, Diagnostic;
         }.stripDelimited;
 
         enum message = "Error: class test.Bar interface function void foo() is not implemented";
-        enum expected = Diagnostic(Loc(filename, 6, 1), message);
+        const expected = Diagnostic(Loc(filename, 6, 1), message);
 
         const diagnostics = compiles(code, filename);
         assert(diagnostics == [expected], "\n" ~ diagnostics.toString);
@@ -94,7 +94,7 @@ import support : afterEach, beforeEach, compiles, stripDelimited, Diagnostic;
         }.stripDelimited;
 
         enum message = "Error: class test.Bar interface function void foo() is not implemented";
-        enum expected = Diagnostic(Loc(filename, 11, 1), message);
+        const expected = Diagnostic(Loc(filename, 11, 1), message);
 
         const diagnostics = compiles(code, filename);
         assert(diagnostics == [expected], "\n" ~ diagnostics.toString);
@@ -123,7 +123,7 @@ import support : afterEach, beforeEach, compiles, stripDelimited, Diagnostic;
         }.stripDelimited;
 
         enum message = "Error: class test.B interface function void foo() is not implemented";
-        enum expected = Diagnostic(Loc(filename, 11, 1), message);
+        const expected = Diagnostic(Loc(filename, 11, 1), message);
 
         const diagnostics = compiles(code, filename);
         assert(diagnostics == [expected], "\n" ~ diagnostics.toString);

--- a/compiler/test/unit/objc/protocols/diagnostic_messages.d
+++ b/compiler/test/unit/objc/protocols/diagnostic_messages.d
@@ -41,7 +41,7 @@ unittest
     }.stripDelimited;
 
     enum message = "Error: class test.Bar interface function extern (Objective-C) static void foo() is not implemented";
-    enum expected = Diagnostic(Loc(filename, 8, 1), message);
+    auto expected = Diagnostic(Loc(filename, 8, 1), message);
 
     const diagnostics = compiles(code, filename);
     assert(diagnostics == [expected], "\n" ~ diagnostics.toString);
@@ -65,7 +65,7 @@ unittest
     }.stripDelimited;
 
     enum message = "Error: function test.Foo.foo function body only allowed in final functions in interface Foo";
-    enum expected = Diagnostic(Loc(filename, 4, 17), message);
+    auto expected = Diagnostic(Loc(filename, 4, 17), message);
 
     const diagnostics = compiles(code, filename);
     assert(diagnostics == [expected], "\n" ~ diagnostics.toString);

--- a/compiler/test/unit/objc/protocols/optional_methods.d
+++ b/compiler/test/unit/objc/protocols/optional_methods.d
@@ -129,10 +129,10 @@ unittest
         }
     }.stripDelimited;
 
-    enum loc = Loc(filename, 5, 20);
+    Loc loc = Loc(filename, 5, 20);
     enum message = "Error: function test.Foo.foo only functions with Objective-C linkage can be declared as optional";
     enum supplemental = "function is declared with D linkage";
-    enum expected = [Diagnostic(loc, message), Diagnostic(loc, supplemental)];
+    auto expected = [Diagnostic(loc, message), Diagnostic(loc, supplemental)];
 
     const diagnostics = compiles(code, filename);
     assert(diagnostics == expected, "\n" ~ diagnostics.toString);
@@ -154,9 +154,9 @@ unittest
         }
     }.stripDelimited;
 
-    enum loc = Loc(filename, 6, 30);
+    Loc loc = Loc(filename, 6, 30);
     enum message = "Error: function test.Foo.foo can only declare a function as optional once";
-    enum expected = Diagnostic(loc, message);
+    auto expected = Diagnostic(loc, message);
 
     const diagnostics = compiles(code, filename);
     assert(diagnostics == [expected], "\n" ~ diagnostics.toString);
@@ -184,9 +184,9 @@ unittest
         }
     }.stripDelimited;
 
-    enum loc = Loc(filename, 6, 20);
+    Loc loc = Loc(filename, 6, 20);
 
-    enum expected = [
+    auto expected = [
         Diagnostic(
             Loc(filename, 6, 20),
             "Error: function test.Foo.foo!().foo template cannot be optional"
@@ -223,10 +223,10 @@ unittest
         }
     }.stripDelimited;
 
-    enum loc = Loc(filename, 6, 20);
+    Loc loc = Loc(filename, 6, 20);
     enum message = "Error: function test.Foo.foo only functions declared inside interfaces can be optional";
     enum supplemental = "function is declared inside class";
-    enum expected = [Diagnostic(loc, message), Diagnostic(loc, supplemental)];
+    auto expected = [Diagnostic(loc, message), Diagnostic(loc, supplemental)];
 
     const diagnostics = compiles(code, filename);
     assert(diagnostics == expected, "\n" ~ diagnostics.toString);


### PR DESCRIPTION
by replacing the pointer to a filename string with a ushort index into an array.

Also reduced the column number to a ushort, because 65,000 character lines is good enough for anyone.

Could probably convert all filename pointers to an index.

Since Loc is used everywhere, this should have a decent impact.

We could get the size to 4 bytes if willing to restrict the number of lines, chars, and files.