### PR TITLE
Add test for "static import cannot have an import bind list"

### DIFF
--- a/compiler/test/fail_compilation/static_import.d
+++ b/compiler/test/fail_compilation/static_import.d
@@ -1,0 +1,8 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/static_import.d(8): Error: static import `core` cannot have an import bind list
+---
+*/
+
+static import core.stdc.stdio : p = q;


### PR DESCRIPTION
I noticed missing test coverage for this error