### PR TITLE
Fix dangling stack pointer in clone.d

### DIFF
--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -106,18 +106,18 @@ FuncDeclaration hasIdentityOpAssign(AggregateDeclaration ad, Scope* sc)
         scope er = new NullExp(ad.loc, ad.type);    // dummy rvalue
         scope el = new IdentifierExp(ad.loc, Id.p); // dummy lvalue
         el.type = ad.type;
-        auto a = Expressions(1);
+        auto a = new Expressions(1);
         const errors = global.startGagging(); // Do not report errors, even if the template opAssign fbody makes it.
         sc = sc.push();
         sc.tinst = null;
         sc.minst = null;
 
-        a[0] = er;
-        auto f = resolveFuncCall(ad.loc, sc, assign, null, ad.type, ArgumentList(&a), FuncResolveFlag.quiet);
+        (*a)[0] = er;
+        auto f = resolveFuncCall(ad.loc, sc, assign, null, ad.type, ArgumentList(a), FuncResolveFlag.quiet);
         if (!f)
         {
-            a[0] = el;
-            f = resolveFuncCall(ad.loc, sc, assign, null, ad.type, ArgumentList(&a), FuncResolveFlag.quiet);
+            (*a)[0] = el;
+            f = resolveFuncCall(ad.loc, sc, assign, null, ad.type, ArgumentList(a), FuncResolveFlag.quiet);
         }
 
         sc = sc.pop();
@@ -465,7 +465,7 @@ private FuncDeclaration hasIdentityOpEquals(AggregateDeclaration ad, Scope* sc)
          */
         scope er = new NullExp(ad.loc, null); // dummy rvalue
         scope el = new IdentifierExp(ad.loc, Id.p); // dummy lvalue
-        auto a = Expressions(1);
+        auto a = new Expressions(1);
 
         bool hasIt(Type tthis)
         {
@@ -476,9 +476,9 @@ private FuncDeclaration hasIdentityOpEquals(AggregateDeclaration ad, Scope* sc)
 
             FuncDeclaration rfc(Expression e)
             {
-                a[0] = e;
-                a[0].type = tthis;
-                return resolveFuncCall(ad.loc, sc, eq, null, tthis, ArgumentList(&a), FuncResolveFlag.quiet);
+                (*a)[0] = e;
+                (*a)[0].type = tthis;
+                return resolveFuncCall(ad.loc, sc, eq, null, tthis, ArgumentList(a), FuncResolveFlag.quiet);
             }
 
             f = rfc(er);


### PR DESCRIPTION
`auto a = Expressions(1);` is an `Array` instance created on the stack, and then `&a` gets passed to `resolveFuncCall`. However, that function can store the arguments in `TypeFunction.fargs` (used for `auto ref` resolution), escaping the stack pointer. This can later be accessed in TypeSemantic of the function.

I found this while working on named arguments, see this branch: https://github.com/dkorpel/dmd/tree/clone-mem-corruption

When building Phobos with dmd built from that branch, there's a point where it resolves a `DotVarExp` calling the templated `opAssign` of `BigUintCore`, resulting in this error:
```
core.exception.ArraySliceError@/home/dennis/repos/dmd/compiler/src/dmd/root/array.d(326): slice [0 .. 140736757439568] extends past source array of length 4
----------------
??:? onArraySliceError [0x5584adb70f42]
??:? _d_arraybounds_slicep [0x5584adb62c26]
dmd/compiler/src/dmd/root/array.d:326 inout pure nothrow @nogc @safe inout(dmd.expression.Expression)[] dmd.root.array.Array!(dmd.expression.Expression).Array.opSlice() [0x5584ad7d13ac]
src/dmd/mtype.d:4814 dmd.root.array.Array!(dmd.expression.Expression).Array* dmd.mtype.TypeFunction.resolveNamedArgs(dmd.expression.ArgumentList, const(char)**, bool, bool) [0x5584ad978cf7]
src/dmd/typesem.d:1337 dmd.mtype.Type dmd.typesem.typeSemantic(dmd.mtype.Type, ref const(dmd.location.Loc), dmd.dscope.Scope*).visitFunction(dmd.mtype.TypeFunction) [0x5584ad9dd47d]
src/dmd/typesem.d:1954 _Z12typeSemanticP4TypeRK3LocP5Scope [0x5584ad9da9d4]
src/dmd/semantic3.d:1315 _ZN16Semantic3Visitor5visitEP15FuncDeclaration [0x5584ad9b3a72]
src/dmd/func.d:2940 _ZN15FuncDeclaration6acceptEP7Visitor [0x5584ad941859]
src/dmd/semantic3.d:83 _Z9semantic3P7DsymbolP5Scope [0x5584ad9afb2d]
src/dmd/func.d:493 _ZN15FuncDeclaration17functionSemantic3Ev [0x5584ad93b699]
src/dmd/func.d:467 _ZN15FuncDeclaration16functionSemanticEv [0x5584ad93b5b3]
src/dmd/expressionsem.d:6854 _ZN25ExpressionSemanticVisitor5visitEP9DotVarExp [0x5584ad923bfe]
src/dmd/expression.d:5012 _ZN9DotVarExp6acceptEP7Visitor [0x5584ad906651]
src/dmd/expressionsem.d:12744 _Z18expressionSemanticP10ExpressionP5Scope [0x5584ad93643f]
src/dmd/expressionsem.d:12690 dmd.expression.Expression dmd.expressionsem.unaSemantic(dmd.expression.UnaExp, dmd.dscope.Scope*) [0x5584ad936274]
src/dmd/expressionsem.d:4584 _ZN25ExpressionSemanticVisitor5visitEP7CallExp [0x5584ad91bb0d]
```

Which goes away by allocating with `new`. I also changed `hasIdentityOpEquals` to be sure, though I haven't encountered memory corruption from that one yet.

It's still not completely clear how this all happens exactly, and I'm still a bit worried that the access of `TypeFunction.fargs`, while not dangling anymore, might still be arguments from an earlier template instantiation (a logic bug instead of memory corruption).

