### PR TITLE
optimize idPool() a bit

### DIFF
--- a/compiler/src/dmd/compiler.d
+++ b/compiler/src/dmd/compiler.d
@@ -401,7 +401,7 @@ private void parseModulePattern(const(char)* modulePattern, MatcherNode* dst, us
                 if (*modulePattern == '.')
                 {
                     assert(modulePattern > idStart, "empty module pattern");
-                    *dst = MatcherNode(Identifier.idPool(idStart, cast(uint)(modulePattern - idStart)));
+                    *dst = MatcherNode(Identifier.idPool(idStart[0 .. modulePattern - idStart]));
                     modulePattern++;
                     idStart = modulePattern;
                     break;
@@ -413,7 +413,7 @@ private void parseModulePattern(const(char)* modulePattern, MatcherNode* dst, us
             if (*modulePattern == '\0')
             {
                 assert(modulePattern > idStart, "empty module pattern");
-                *lastNode = MatcherNode(Identifier.idPool(idStart, cast(uint)(modulePattern - idStart)));
+                *lastNode = MatcherNode(Identifier.idPool(idStart[0 .. modulePattern - idStart]));
                 break;
             }
         }

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -259,7 +259,7 @@ extern (C++) final class StaticForeach : RootObject
         auto sdecl = new StructDeclaration(loc, sid, false);
         sdecl.storage_class |= STC.static_;
         sdecl.members = new Dsymbols();
-        auto fid = Identifier.idPool(tupleFieldName.ptr, tupleFieldName.length);
+        auto fid = Identifier.idPool(tupleFieldName);
         auto ty = new TypeTypeof(loc, new TupleExp(loc, e));
         sdecl.members.push(new VarDeclaration(loc, ty, fid, null, 0));
         auto r = cast(TypeStruct)sdecl.type;

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -633,9 +633,7 @@ extern (C++) final class TupleDeclaration : Declaration
                 version (none)
                 {
                     buf.printf("_%s_%d", ident.toChars(), i);
-                    const len = buf.offset;
-                    const name = buf.extractSlice().ptr;
-                    auto id = Identifier.idPool(name, len);
+                    auto id = Identifier.idPool(buf.extractSlice());
                     auto arg = new Parameter(STC.in_, t, id, null);
                 }
                 else

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -2764,7 +2764,7 @@ extern (C++) class FuncDeclaration : Declaration
      */
     static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, const(char)* name, StorageClass stc = 0)
     {
-        return genCfunc(fparams, treturn, Identifier.idPool(name, cast(uint)strlen(name)), stc);
+        return genCfunc(fparams, treturn, Identifier.idPool(name[0 .. strlen(name)]), stc);
     }
 
     static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, Identifier id, StorageClass stc = 0)

--- a/compiler/src/dmd/identifier.d
+++ b/compiler/src/dmd/identifier.d
@@ -274,12 +274,7 @@ nothrow:
         return idPool(s[0 .. len]);
     }
 
-    extern (D) static Identifier idPool(const(char)[] s)
-    {
-        return idPool(s, false);
-    }
-
-    extern (D) private static Identifier idPool(const(char)[] s, bool isAnonymous)
+    extern (D) static Identifier idPool(const(char)[] s, bool isAnonymous = false)
     {
         auto sv = stringtable.update(s);
         auto id = sv.value;
@@ -291,18 +286,18 @@ nothrow:
         return id;
     }
 
-    extern (D) static Identifier idPool(const(char)* s, size_t len, int value)
-    {
-        return idPool(s[0 .. len], value);
-    }
-
-    extern (D) static Identifier idPool(const(char)[] s, int value)
+    /******************************************
+     * Used for inserting keywords into the string table.
+     * Params:
+     *  s = string for keyword
+     *  value = TOK.xxxx for the keyword
+     */
+    extern (D) static void idPool(const(char)[] s, TOK value)
     {
         auto sv = stringtable.insert(s, null);
         assert(sv);
         auto id = new Identifier(sv.toString(), value);
         sv.value = id;
-        return id;
     }
 
     /**********************************

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -573,7 +573,7 @@ class Lexer
                         }
                         break;
                     }
-                    Identifier id = Identifier.idPool(cast(char*)t.ptr, cast(uint)(p - t.ptr));
+                    Identifier id = Identifier.idPool((cast(char*)t.ptr)[0 .. p - t.ptr], false);
                     t.ident = id;
                     t.value = cast(TOK)id.getValue();
 

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2448,7 +2448,7 @@ extern (C++) abstract class Type : ASTNode
         //printf("%p %s, deco = %s, name = %s\n", this, toChars(), deco, name);
         assert(0 < length && length < namelen); // don't overflow the buffer
 
-        auto id = Identifier.idPool(name, length);
+        auto id = Identifier.idPool(name[0 .. length]);
 
         if (name != namebuf.ptr)
             free(name);

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -593,7 +593,7 @@ shared static this() nothrow
     foreach (kw; keywords)
     {
         //printf("keyword[%d] = '%s'\n",kw, Token.tochars[kw].ptr);
-        Identifier.idPool(Token.tochars[kw].ptr, Token.tochars[kw].length, cast(uint)kw);
+        Identifier.idPool(Token.tochars[kw], kw);
     }
 }
 

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -163,7 +163,7 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
         /* Look for what user might have intended
          */
         const p = mt.mutableOf().unSharedOf().toChars();
-        auto id = Identifier.idPool(p, cast(uint)strlen(p));
+        auto id = Identifier.idPool(p[0 .. strlen(p)]);
         if (const n = importHint(id.toString()))
             error(loc, "`%s` is not defined, perhaps `import %.*s;` ?", p, cast(int)n.length, n.ptr);
         else if (auto s2 = sc.search_correct(id))


### PR DESCRIPTION
You see... a while back, I was walking down the yellow brick road and noticed that the idPool function had remnants of the old C version of the implementation. Thought I'd fix it by:

1. removing the ptr/length interface, except for the C++ entry point
2. use a default value instead of a forwarding function
3. recognize that one of the overloads was only used for keyword setup
4. remove 32 bit legacy cast to `uint`
5. add some clarifying documentation