### PR TITLE
Fix Issue 23905 - Initialization of SumType with opaque enum causes ICE

### DIFF
--- a/compiler/src/dmd/denum.d
+++ b/compiler/src/dmd/denum.d
@@ -169,7 +169,12 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             return defaultval;
         }
         //printf("EnumDeclaration::getDefaultValue() %p %s\n", this, toChars());
-        if (defaultval)
+        // https://issues.dlang.org/show_bug.cgi?id=23904
+        // Return defaultval only if it is not ErrorExp.
+        // A speculative context may set defaultval to ErrorExp;
+        // subsequent non-speculative contexts need to be able
+        // to print the error.
+        if (defaultval && !defaultval.isErrorExp())
             return defaultval;
 
         if (isCsymbol())

--- a/compiler/test/fail_compilation/test23905.d
+++ b/compiler/test/fail_compilation/test23905.d
@@ -1,0 +1,25 @@
+// https://issues.dlang.org/show_bug.cgi?id=23905
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test23905.d(24): Error: enum `test23905.Foo` is opaque and has no default initializer
+---
+*/
+
+struct SumType(T)
+{
+    T storage;
+
+    bool opEquals(Rhs)(Rhs rhs)
+    if (is(typeof(Rhs.init)))
+    {
+    }
+
+}
+
+enum Foo;
+
+void main(){
+    SumType!Foo data = Foo.init;
+}


### PR DESCRIPTION
When the default value of an enum is deduced it no longer changes. In case of errors, the default value is set to `ErrorExp`. This means that if the default value is wrong and user code uses it, no error is going to be outputted. This leads to the present ICE. To fix the issue, `getDefaultValue` returns the `defaultval` only if `defaultval` is not an `ErrorExp`. If it's an `ErrorExp` then it just outputs the error again. This makes sense, since using `Enum.init` should output an error every time it is used.