### PR TITLE
Encapsulate `Loc` member access

### DIFF
--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -430,7 +430,7 @@ extern(C++) void gendocfile(Module m)
     {
         const ploc = m.md ? &m.md.loc : &m.loc;
         Loc loc = *ploc;
-        if (!loc.fileIndex)
+        if (!loc.filename)
             loc.filename = srcfilename.ptr;
 
         size_t commentlen = strlen(cast(char*)m.comment);
@@ -4151,7 +4151,7 @@ private size_t endRowAndTable(ref OutBuffer buf, size_t iStart, size_t iEnd, con
 private void highlightText(Scope* sc, Dsymbols* a, Loc loc, ref OutBuffer buf, size_t offset)
 {
     const incrementLoc = loc.linnum == 0 ? 1 : 0;
-    loc.linnum += incrementLoc;
+    loc.linnum = loc.linnum + incrementLoc;
     loc.charnum = 0;
     //printf("highlightText()\n");
     bool leadingBlank = true;
@@ -4256,7 +4256,7 @@ private void highlightText(Scope* sc, Dsymbols* a, Loc loc, ref OutBuffer buf, s
             lineQuoted = false;
             tableRowDetected = false;
             iLineStart = i + 1;
-            loc.linnum += incrementLoc;
+            loc.linnum = loc.linnum + incrementLoc;
 
             // update the paragraph start if we just entered a macro
             if (previousMacroLevel < macroLevel && iParagraphStart < iLineStart)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -377,19 +377,25 @@ enum class MessageStyle : uint8_t
 
 struct Loc final
 {
-    uint32_t linnum;
-    uint16_t charnum;
+private:
+    uint32_t _linnum;
+    uint16_t _charnum;
     uint16_t fileIndex;
+public:
     static bool showColumns;
     static MessageStyle messageStyle;
     static void set(bool showColumns, MessageStyle messageStyle);
+    uint32_t charnum() const;
+    uint32_t charnum(uint32_t num);
+    uint32_t linnum() const;
+    uint32_t linnum(uint32_t num);
     const char* filename() const;
     void filename(const char* name);
     const char* toChars(bool showColumns = showColumns, MessageStyle messageStyle = messageStyle) const;
     bool equals(const Loc& loc) const;
     Loc() :
-        linnum(),
-        charnum(),
+        _linnum(),
+        _charnum(),
         fileIndex()
     {
     }

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -353,10 +353,11 @@ typedef unsigned long long uinteger_t;
 // file location
 struct Loc
 {
-    unsigned linnum;
-    unsigned short charnum;
+private:
+    unsigned _linnum;
+    unsigned short _charnum;
     unsigned short fileIndex;
-
+public:
     static void set(bool showColumns, MessageStyle messageStyle);
 
     static bool showColumns;
@@ -364,18 +365,22 @@ struct Loc
 
     Loc()
     {
-        linnum = 0;
-        charnum = 0;
+        _linnum = 0;
+        _charnum = 0;
         fileIndex = 0;
     }
 
     Loc(const char *filename, unsigned linnum, unsigned charnum)
     {
-        this->linnum = linnum;
-        this->charnum = charnum;
+        this->linnum(linnum);
+        this->charnum(charnum);
         this->filename(filename);
     }
 
+    uint32_t charnum() const;
+    uint32_t charnum(uint32_t num);
+    uint32_t linnum() const;
+    uint32_t linnum(uint32_t num);
     const char *filename() const;
     void filename(const char *name);
 

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -2672,7 +2672,7 @@ class Lexer
         return result;
     }
 
-    final Loc loc() pure @nogc
+    final Loc loc() @nogc
     {
         scanloc.charnum = cast(ushort)(1 + p - line);
         version (LocOffset)
@@ -3098,9 +3098,9 @@ class Lexer
     /**************************
      * `p` should be at start of next line
      */
-    private void endOfLine() pure @nogc @safe
+    private void endOfLine() @nogc @safe
     {
-        scanloc.linnum++;
+        scanloc.linnum = scanloc.linnum + 1;
         line = p;
     }
 }

--- a/compiler/src/dmd/location.d
+++ b/compiler/src/dmd/location.d
@@ -37,9 +37,9 @@ debug info etc.
 */
 struct Loc
 {
-    uint linnum; /// line number, starting from 1
-    ushort charnum; /// utf8 code unit index relative to start of line, starting from 1
-    ushort fileIndex; // index into filenames[], starting from 1 (0 means no filename)
+    private uint _linnum;
+    private ushort _charnum;
+    private ushort fileIndex; // index into filenames[], starting from 1 (0 means no filename)
     version (LocOffset)
         uint fileOffset; /// utf8 code unit index relative to start of file, starting from 0
 
@@ -66,9 +66,33 @@ nothrow:
 
     extern (D) this(const(char)* filename, uint linnum, uint charnum)
     {
-        this.linnum = linnum;
-        this.charnum = cast(ushort)charnum;
+        this._linnum = linnum;
+        this._charnum = cast(ushort) charnum;
         this.filename = filename;
+    }
+
+    /// utf8 code unit index relative to start of line, starting from 1
+    extern (C++) uint charnum() const @nogc @safe
+    {
+        return _charnum;
+    }
+
+    /// ditto
+    extern (C++) uint charnum(uint num) @nogc @safe
+    {
+        return _charnum = cast(ushort) num;
+    }
+
+    /// line number, starting from 1
+    extern (C++) uint linnum() const @nogc @safe
+    {
+        return _linnum;
+    }
+
+    /// ditto
+    extern (C++) uint linnum(uint num) @nogc @safe
+    {
+        return _linnum = num;
     }
 
     /***


### PR DESCRIPTION
Using functions instead of direct field access allows `Loc` to change its internals more easily, which helps with the recent effort to reduce its size: [struct Location size](https://forum.dlang.org/post/u3c3s9$2cs1$1@digitalmars.com)