### PR TITLE
Don't allocate argument list on the stack

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1254,12 +1254,12 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                 return ErrorExp.get();
             e2 = resolveProperties(sc, e2);
 
-            Expressions a;
+            Expressions* a = new Expressions();
             a.push(e2);
 
             for (size_t i = 0; i < os.a.length; i++)
             {
-                if (FuncDeclaration f = resolveFuncCall(loc, sc, os.a[i], tiargs, tthis, ArgumentList(&a), FuncResolveFlag.quiet))
+                if (FuncDeclaration f = resolveFuncCall(loc, sc, os.a[i], tiargs, tthis, ArgumentList(a), FuncResolveFlag.quiet))
                 {
                     if (f.errors)
                         return ErrorExp.get();
@@ -1378,10 +1378,10 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                 return ErrorExp.get();
             e2 = resolveProperties(sc, e2);
 
-            Expressions a;
+            Expressions* a = new Expressions();
             a.push(e2);
 
-            FuncDeclaration fd = resolveFuncCall(loc, sc, s, tiargs, tthis, ArgumentList(&a), FuncResolveFlag.quiet);
+            FuncDeclaration fd = resolveFuncCall(loc, sc, s, tiargs, tthis, ArgumentList(a), FuncResolveFlag.quiet);
             if (fd && fd.type)
             {
                 if (fd.errors)

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -7119,9 +7119,9 @@ bool isCopyable(Type t)
             assert(ctor);
             scope el = new IdentifierExp(Loc.initial, Id.p); // dummy lvalue
             el.type = cast() ts;
-            Expressions args;
+            Expressions* args = new Expressions();
             args.push(el);
-            FuncDeclaration f = resolveFuncCall(Loc.initial, null, ctor, null, cast()ts, ArgumentList(&args), FuncResolveFlag.quiet);
+            FuncDeclaration f = resolveFuncCall(Loc.initial, null, ctor, null, cast()ts, ArgumentList(args), FuncResolveFlag.quiet);
             if (!f || f.storage_class & STC.disable)
                 return false;
         }

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -607,8 +607,6 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
             //printf("BinExp::op_overload() (%s)\n", e.toChars());
             Identifier id = opId(e);
             Identifier id_r = opId_r(e);
-            Expressions args1;
-            Expressions args2;
             int argsset = 0;
             AggregateDeclaration ad1 = isAggregate(e.e1.type);
             AggregateDeclaration ad2 = isAggregate(e.e2.type);
@@ -701,6 +699,8 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                     }
                 }
             }
+            Expressions* args1 = new Expressions();
+            Expressions* args2 = new Expressions();
             if (s || s_r)
             {
                 /* Try:
@@ -709,16 +709,16 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                  * and see which is better.
                  */
                 args1.setDim(1);
-                args1[0] = e.e1;
-                expandTuples(&args1);
+                (*args1)[0] = e.e1;
+                expandTuples(args1);
                 args2.setDim(1);
-                args2[0] = e.e2;
-                expandTuples(&args2);
+                (*args2)[0] = e.e2;
+                expandTuples(args2);
                 argsset = 1;
                 MatchAccumulator m;
                 if (s)
                 {
-                    functionResolve(m, s, e.loc, sc, tiargs, e.e1.type, ArgumentList(&args2));
+                    functionResolve(m, s, e.loc, sc, tiargs, e.e1.type, ArgumentList(args2));
                     if (m.lastf && (m.lastf.errors || m.lastf.hasSemantic3Errors()))
                     {
                         return ErrorExp.get();
@@ -727,7 +727,7 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                 FuncDeclaration lastf = m.lastf;
                 if (s_r)
                 {
-                    functionResolve(m, s_r, e.loc, sc, tiargs, e.e2.type, ArgumentList(&args1));
+                    functionResolve(m, s_r, e.loc, sc, tiargs, e.e2.type, ArgumentList(args1));
                     if (m.lastf && (m.lastf.errors || m.lastf.hasSemantic3Errors()))
                     {
                         return ErrorExp.get();
@@ -791,16 +791,16 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                         if (!argsset)
                         {
                             args1.setDim(1);
-                            args1[0] = e.e1;
-                            expandTuples(&args1);
+                            (*args1)[0] = e.e1;
+                            expandTuples(args1);
                             args2.setDim(1);
-                            args2[0] = e.e2;
-                            expandTuples(&args2);
+                            (*args2)[0] = e.e2;
+                            expandTuples(args2);
                         }
                         MatchAccumulator m;
                         if (s_r)
                         {
-                            functionResolve(m, s_r, e.loc, sc, tiargs, e.e1.type, ArgumentList(&args2));
+                            functionResolve(m, s_r, e.loc, sc, tiargs, e.e1.type, ArgumentList(args2));
                             if (m.lastf && (m.lastf.errors || m.lastf.hasSemantic3Errors()))
                             {
                                 return ErrorExp.get();
@@ -809,7 +809,7 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                         FuncDeclaration lastf = m.lastf;
                         if (s)
                         {
-                            functionResolve(m, s, e.loc, sc, tiargs, e.e2.type, ArgumentList(&args1));
+                            functionResolve(m, s, e.loc, sc, tiargs, e.e2.type, ArgumentList(args1));
                             if (m.lastf && (m.lastf.errors || m.lastf.hasSemantic3Errors()))
                             {
                                 return ErrorExp.get();
@@ -1197,7 +1197,7 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                 return ErrorExp.get();
             }
             Identifier id = opId(e);
-            Expressions args2;
+            Expressions* args2 = new Expressions();
             AggregateDeclaration ad1 = isAggregate(e.e1.type);
             Dsymbol s = null;
             Objects* tiargs = null;
@@ -1240,10 +1240,10 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                  *      a.opOpAssign(b)
                  */
                 args2.setDim(1);
-                args2[0] = e.e2;
-                expandTuples(&args2);
+                (*args2)[0] = e.e2;
+                expandTuples(args2);
                 MatchAccumulator m;
-                functionResolve(m, s, e.loc, sc, tiargs, e.e1.type, ArgumentList(&args2));
+                functionResolve(m, s, e.loc, sc, tiargs, e.e1.type, ArgumentList(args2));
                 if (m.lastf && (m.lastf.errors || m.lastf.hasSemantic3Errors()))
                 {
                     return ErrorExp.get();
@@ -1322,12 +1322,12 @@ private Expression compare_overload(BinExp e, Scope* sc, Identifier id, EXP* pop
          *      b.opEquals(a)
          * and see which is better.
          */
-        Expressions args1 = Expressions(1);
-        args1[0] = e.e1;
-        expandTuples(&args1);
-        Expressions args2 = Expressions(1);
-        args2[0] = e.e2;
-        expandTuples(&args2);
+        Expressions* args1 = new Expressions(1);
+        (*args1)[0] = e.e1;
+        expandTuples(args1);
+        Expressions* args2 = new Expressions(1);
+        (*args2)[0] = e.e2;
+        expandTuples(args2);
         MatchAccumulator m;
         if (0 && s && s_r)
         {
@@ -1336,7 +1336,7 @@ private Expression compare_overload(BinExp e, Scope* sc, Identifier id, EXP* pop
         }
         if (s)
         {
-            functionResolve(m, s, e.loc, sc, tiargs, e.e1.type, ArgumentList(&args2));
+            functionResolve(m, s, e.loc, sc, tiargs, e.e1.type, ArgumentList(args2));
             if (m.lastf && (m.lastf.errors || m.lastf.hasSemantic3Errors()))
                 return ErrorExp.get();
         }
@@ -1344,7 +1344,7 @@ private Expression compare_overload(BinExp e, Scope* sc, Identifier id, EXP* pop
         int count = m.count;
         if (s_r)
         {
-            functionResolve(m, s_r, e.loc, sc, tiargs, e.e2.type, ArgumentList(&args1));
+            functionResolve(m, s_r, e.loc, sc, tiargs, e.e2.type, ArgumentList(args1));
             if (m.lastf && (m.lastf.errors || m.lastf.hasSemantic3Errors()))
                 return ErrorExp.get();
         }

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1273,8 +1273,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 }
                 else if (auto td = sfront.isTemplateDeclaration())
                 {
-                    Expressions a;
-                    if (auto f = resolveFuncCall(loc, sc, td, null, tab, ArgumentList(&a), FuncResolveFlag.quiet))
+                    if (auto f = resolveFuncCall(loc, sc, td, null, tab, ArgumentList(), FuncResolveFlag.quiet))
                         tfront = f.type;
                 }
                 else if (auto d = sfront.toAlias().isDeclaration())


### PR DESCRIPTION
Similar to https://github.com/dlang/dmd/pull/15204

`functionResolve` can escape its argumentList parameter, so don't pass it a stack pointer