### PR TITLE
Fix Issue 18151 - wrong auto ref lvalue inference for implicitly converted alias this parameters

### DIFF
--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -7346,7 +7346,12 @@ private extern(D) MATCH argumentMatchParameter (TypeFunction tf, Parameter p,
         else
         {
             import dmd.dcast : cimplicitConvTo;
+            import dmd.aliasthis : resolveAliasThis;
             m = (sc && sc.flags & SCOPE.Cfile) ? arg.cimplicitConvTo(tprm) : arg.implicitConvTo(tprm);
+            argStruct = targ.ty == Tstruct ? (cast(TypeStruct)targ).sym : null;
+            // if the matching was done on alias this, then do ref checking on the alias this
+            if (argStruct && argStruct.aliasthis && !(cast(TypeStruct)targ).implicitConvToWithoutAliasThis(tprm))
+                arg = resolveAliasThis(sc, arg);
         }
     }
 

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1383,6 +1383,14 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                         (*mtype.fargs)[eidx] : eparam.defaultArg;
                     if (farg && (eparam.storageClass & STC.ref_))
                     {
+                        // https://issues.dlang.org/show_bug.cgi?id=18151
+                        // deduce `auto ref` on the aliased this member
+                        // if no match on the original argument.
+                        if (auto ts = farg.type.isTypeStruct())
+                        {
+                            if (ts.sym.aliasthis && !ts.implicitConvToWithoutAliasThis(eparam.type))
+                                farg = resolveAliasThis(sc, farg);
+                        }
                         if (!farg.isLvalue())
                             eparam.storageClass &= ~STC.ref_; // value parameter
                         eparam.storageClass &= ~STC.auto_;    // https://issues.dlang.org/show_bug.cgi?id=14656

--- a/compiler/test/compilable/test18151.d
+++ b/compiler/test/compilable/test18151.d
@@ -1,0 +1,30 @@
+// https://issues.dlang.org/show_bug.cgi?id=18151
+
+/*
+TEST_OUTPUT:
+---
+value
+---
+*/
+
+void test()(auto ref Inner inner)
+{
+    pragma(msg, __traits(isRef, inner) ? "ref" : "value");
+}
+
+struct Inner
+{
+}
+
+struct Outer
+{
+    Inner inner;
+    Inner get() { return inner; }
+    alias get this;
+}
+
+void bug()
+{
+    Outer outer;
+    test(outer);
+}


### PR DESCRIPTION
`auto ref` is resolved during semantic on the function type and after overload resolution. To make sure that it is correctly resolved, check whether the match was on the alias this or on the original argument. In case of the former, deduce the `auto ref` on the alias this.