### PR TITLE
Delete unused enforceTypedArrayConformable* from druntime/src/core/internal/util/array.d

### DIFF
--- a/druntime/src/core/internal/util/array.d
+++ b/druntime/src/core/internal/util/array.d
@@ -26,14 +26,6 @@ private char[] errorMessage(Args...)(scope const(char*) format,
 
 @safe /* pure dmd @@@BUG11461@@@ */ nothrow:
 
-void enforceTypedArraysConformable(T)(const char[] action,
-    const T[] a1, const T[] a2, const bool allowOverlap = false)
-{
-    _enforceSameLength(action, a1.length, a2.length);
-    if (!allowOverlap)
-        _enforceNoOverlap(action, arrayToPtr(a1), arrayToPtr(a2), T.sizeof * a1.length);
-}
-
 void enforceRawArraysConformable(const char[] action, const size_t elementSize,
     const void[] a1, const void[] a2, const bool allowOverlap = false)
 {
@@ -74,14 +66,6 @@ private void _enforceNoOverlap(const char[] action,
     msg ~= " byte(s) overlap of ";
     msg ~= bytes.unsignedToTempString(tmpBuff);
     assert(0, msg);
-}
-
-void enforceTypedArraysConformableNogc(T)(const char[] action,
-    const T[] a1, const T[] a2, const bool allowOverlap = false)
-{
-    _enforceSameLengthNogc(action, a1.length, a2.length);
-    if (!allowOverlap)
-        _enforceNoOverlapNogc(action, arrayToPtr(a1), arrayToPtr(a2), T.sizeof * a1.length);
 }
 
 void enforceRawArraysConformableNogc(const char[] action, const size_t elementSize,


### PR DESCRIPTION
These functions don't seem to be used anywhere.