### PR TITLE
Remove version (MARS) blocks pt1

### DIFF
--- a/compiler/src/dmd/backend/aarray.d
+++ b/compiler/src/dmd/backend/aarray.d
@@ -19,11 +19,8 @@ import core.stdc.string;
 
 alias hash_t = size_t;
 
-version (MARS)
-{
-    import dmd.root.hash;
-    import dmd.backend.global : err_nomem;
-}
+import dmd.root.hash;
+import dmd.backend.global : err_nomem;
 
 nothrow:
 @safe:
@@ -428,19 +425,8 @@ nothrow:
 
     static hash_t getHash(Key* pk)
     {
-        version (MARS)
-        {
-            auto buf = *pk;
-            return calcHash(cast(const(ubyte[]))buf);
-        }
-        else
-        {
-            auto buf = *pk;
-            hash_t hash = 0;
-            foreach (v; buf)
-                hash = hash * 11 + v;
-            return hash;
-        }
+        auto buf = *pk;
+        return calcHash(cast(const(ubyte[]))buf);
     }
 
     @trusted
@@ -504,19 +490,8 @@ nothrow:
     @trusted
     hash_t getHash(Key* pk)
     {
-        version (MARS)
-        {
-            auto buf = (*pbase)[pk.start .. pk.end];
-            return calcHash(buf);
-        }
-        else
-        {
-            auto buf = (*pbase)[pk.start .. pk.end];
-            hash_t hash = 0;
-            foreach (v; buf)
-                hash = hash * 11 + v;
-            return hash;
-        }
+        auto buf = (*pbase)[pk.start .. pk.end];
+        return calcHash(buf);
     }
 
     @trusted

--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -27,10 +27,7 @@ extern (C++):
 nothrow:
 @safe:
 
-version (MARS)
-{
-    void ph_init();
-}
+void ph_init();
 
 /**************************************
  * Initialize configuration for backend.
@@ -83,8 +80,6 @@ extern (C) void out_config_init(
         exefmt_t exefmt,
         bool generatedMain      // a main entrypoint is generated
         )
-{
-version (MARS)
 {
     //printf("out_config_init()\n");
 
@@ -377,7 +372,6 @@ static if (0)
     else if (cfg.objfmt == OBJ_ELF)
         elfDebugSectionsInit();
     rtlsym_init(); // uses fregsaved, so must be after it's set inside cod3_set*
-}
 }
 
 /****************************

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -102,10 +102,7 @@ enum SIXTEENBIT = false;
  * This is not quite the same as !SIXTEENBIT, as one could
  * have near/far with 32 bit code.
  */
-version (MARS)
-    enum TARGET_SEGMENTED = false;
-else
-    enum TARGET_SEGMENTED = TARGET_WINDOS;
+enum TARGET_SEGMENTED = false;
 
 
 @trusted
@@ -260,10 +257,7 @@ enum
     Vmodel = 4,        // large code, large data, vcm
 }
 
-version (MARS)
-    enum MEMMODELS = 1; // number of memory models
-else
-    enum MEMMODELS = 5;
+enum MEMMODELS = 1; // number of memory models
 
 /* Segments     */
 enum

--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -463,12 +463,9 @@ private elem *fixconvop(elem *e)
     {   if (e.Eoper != OPshlass && e.Eoper != OPshrass && e.Eoper != OPashrass)
             e.EV.E2 = el_una(icop,tym,e2);
 
-        version (MARS)
-        {
-            // https://issues.dlang.org/show_bug.cgi?id=23618
-            if ((cop == OPu16_32 || cop == OPu8_16) && e.Eoper == OPashrass)
-                e.Eoper = OPshrass;     // always unsigned right shift for MARS
-        }
+        // https://issues.dlang.org/show_bug.cgi?id=23618
+        if ((cop == OPu16_32 || cop == OPu8_16) && e.Eoper == OPashrass)
+            e.Eoper = OPshrass;     // always unsigned right shift for MARS
 
         return e;
     }
@@ -3242,11 +3239,8 @@ private elem * elbit(elem *e, goal_t goal)
     e2.Ety = e.Ety;
 
     OPER shift = OPshr;
-    version (MARS)
-    {
-        if (!tyuns(tym1))
-            shift = OPashr;
-    }
+    if (!tyuns(tym1))
+        shift = OPashr;
     e.EV.E1 = el_bin(shift,tym1,
                 el_bin(OPshl,tym1,e.EV.E1,el_long(TYint,c)),
                 el_long(TYint,b));
@@ -4058,10 +4052,7 @@ static if (0)
         else                            /* signed bit field             */
         {
             OPER shift = OPshr;
-            version (MARS)
-            {
-                shift = OPashr;
-            }
+            shift = OPashr;
             c = sz - w;                 /* e2 = (r << c) >> c           */
             e2 = el_bin(shift,t,el_bin(OPshl,tyl,r,el_long(TYint,c)),el_long(TYint,c));
             pe = &e2.EV.E1.EV.E1;
@@ -6001,7 +5992,7 @@ beg:
         if (OTcommut(op))                // if commutative
         {
               /* see if we should swap the leaves       */
-              version (MARS) { enum MARS = true; } else { enum MARS = false; }
+              enum MARS = true;
               if (
                 MARS ? (
                 cost(e2) > cost(e1) &&
@@ -6215,13 +6206,11 @@ void postoptelem(elem *e)
         {
             /* This is necessary as the optimizer tends to lose this information
              */
-            version (MARS)
             if (e.Esrcpos.Slinnum > pos.Slinnum)
                 pos = e.Esrcpos;
 
             if (e.Eoper == OPind)
             {
-                version (MARS)
                 if (e.EV.E1.Eoper == OPconst &&
                     /* Allow TYfgptr to reference GS:[0000] etc.
                      */
@@ -6244,7 +6233,6 @@ void postoptelem(elem *e)
         {
             /* This is necessary as the optimizer tends to lose this information
              */
-            version (MARS)
             if (e.Esrcpos.Slinnum > pos.Slinnum)
                 pos = e.Esrcpos;
 

--- a/compiler/src/dmd/backend/cgobj.d
+++ b/compiler/src/dmd/backend/cgobj.d
@@ -299,10 +299,7 @@ enum
 
 struct Linnum
 {
-version (MARS)
         const(char)* filename;  // source file name
-else
-        Sfile *filptr;          // file pointer
 
         int cseg;               // our internal segment number
         int seg;                // segment/public index
@@ -374,12 +371,9 @@ static if (MULTISCOPE)
 
     int fisegi;                 // SegData[] index of FI segment
 
-version (MARS)
-{
     int fmsegi;                 // SegData[] of FM segment
     int datrefsegi;             // SegData[] of DATA pointer ref segment
     int tlsrefsegi;             // SegData[] of TLS pointer ref segment
-}
 
     int tlssegi;                // SegData[] of tls segment
     int fardataidx;
@@ -404,10 +398,7 @@ version (MARS)
     Rarray!(Linnum) linnum_list;
     Barray!(char*) linreclist;  // array of line records
 
-version (MARS)
-{
     Barray!PtrRef ptrrefs;      // buffer for pointer references
-}
 }
 
 __gshared

--- a/compiler/src/dmd/backend/cgxmm.d
+++ b/compiler/src/dmd/backend/cgxmm.d
@@ -28,8 +28,7 @@ import dmd.backend.oper;
 import dmd.backend.ty;
 import dmd.backend.xmm;
 
-version (MARS)
-    import dmd.backend.errors;
+import dmd.backend.errors;
 
 
 extern (C++):
@@ -1362,9 +1361,8 @@ static if (0)
             case SHUFPD:  case SHUFPS:
                 if (n == 3)
                 {
-                    version (MARS)
-                        if (pass == BackendPass.final_)
-                            error(e.Esrcpos.Sfilename, e.Esrcpos.Slinnum, e.Esrcpos.Scharnum, "missing 4th parameter to `__simd()`");
+                    if (pass == BackendPass.final_)
+                        error(e.Esrcpos.Sfilename, e.Esrcpos.Slinnum, e.Esrcpos.Scharnum, "missing 4th parameter to `__simd()`");
                     cs.IFL2 = FLconst;
                     cs.IEV2.Vsize_t = 0;
                 }
@@ -1377,8 +1375,6 @@ static if (0)
         {
             elem *imm8 = params[3];
             cs.IFL2 = FLconst;
-version (MARS)
-{
             if (imm8.Eoper != OPconst)
             {
                 error(imm8.Esrcpos.Sfilename, imm8.Esrcpos.Slinnum, imm8.Esrcpos.Scharnum, "last parameter to `__simd()` must be a constant");
@@ -1386,11 +1382,6 @@ version (MARS)
             }
             else
                 cs.IEV2.Vsize_t = cast(targ_size_t)el_tolong(imm8);
-}
-else
-{
-            cs.IEV2.Vsize_t = cast(targ_size_t)el_tolong(imm8);
-}
         }
         code_newreg(&cs, reg - XMM0);
         cs.Iop = op;

--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -1614,34 +1614,22 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
             break;
 
         case FLpseudo:
-            version (MARS)
             {
-                {
-                    getregs(cdb, mask(s.Sreglsw));
-                    pcs.Irm = modregrm(3, 0, s.Sreglsw & 7);
-                    if (s.Sreglsw & 8)
-                        pcs.Irex |= REX_B;
-                    if (e.EV.Voffset == 1 && sz == 1)
-                    {   assert(s.Sregm & BYTEREGS);
-                        assert(s.Sreglsw < 4);
-                        pcs.Irm |= 4;                  // use 2nd byte of register
-                    }
-                    else
-                    {   assert(!e.EV.Voffset);
-                        if (I64 && sz == 1 && s.Sreglsw >= 4)
-                            pcs.Irex |= REX;
-                    }
-                    break;
+                getregs(cdb, mask(s.Sreglsw));
+                pcs.Irm = modregrm(3, 0, s.Sreglsw & 7);
+                if (s.Sreglsw & 8)
+                    pcs.Irex |= REX_B;
+                if (e.EV.Voffset == 1 && sz == 1)
+                {   assert(s.Sregm & BYTEREGS);
+                    assert(s.Sreglsw < 4);
+                    pcs.Irm |= 4;                  // use 2nd byte of register
                 }
-            }
-            else
-            {
-                {
-                    uint u = s.Sreglsw;
-                    getregs(cdb, pseudomask[u]);
-                    pcs.Irm = modregrm(3, 0, pseudoreg[u] & 7);
-                    break;
+                else
+                {   assert(!e.EV.Voffset);
+                    if (I64 && sz == 1 && s.Sreglsw >= 4)
+                        pcs.Irex |= REX;
                 }
+                break;
             }
 
         case FLfardata:

--- a/compiler/src/dmd/backend/cod2.d
+++ b/compiler/src/dmd/backend/cod2.d
@@ -5607,14 +5607,11 @@ void cdinfo(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 {
     switch (e.EV.E1.Eoper)
     {
-version (MARS)
-{
         case OPdctor:
             codelem(cdb,e.EV.E2,pretregs,false);
             regm_t retregs = 0;
             codelem(cdb,e.EV.E1,&retregs,false);
             break;
-}
         default:
             assert(0);
     }

--- a/compiler/src/dmd/backend/codebuilder.d
+++ b/compiler/src/dmd/backend/codebuilder.d
@@ -197,8 +197,6 @@ extern (C++) struct CodeBuilder
         pTail = &ce.next;
     }
 
-version (MARS)
-{
     @trusted
     void genasm(_LabelDsymbol *label)
     {
@@ -211,7 +209,6 @@ version (MARS)
         *pTail = ce;
         pTail = &ce.next;
     }
-}
 
     @trusted
     void genasm(block *label)

--- a/compiler/src/dmd/backend/cv8.d
+++ b/compiler/src/dmd/backend/cv8.d
@@ -51,18 +51,9 @@ static if (1)
 @trusted
 private bool symbol_iscomdat4(Symbol* s)
 {
-    version (MARS)
-    {
-        return s.Sclass == SC.comdat ||
-            config.flags2 & CFG2comdat && s.Sclass == SC.inline ||
-            config.flags4 & CFG4allcomdat && s.Sclass == SC.global;
-    }
-    else
-    {
-        return s.Sclass == SC.comdat ||
-            config.flags2 & CFG2comdat && s.Sclass == SC.inline ||
-            config.flags4 & CFG4allcomdat && (s.Sclass == SC.global || s.Sclass == SC.static_);
-    }
+    return s.Sclass == SC.comdat ||
+        config.flags2 & CFG2comdat && s.Sclass == SC.inline ||
+        config.flags4 & CFG4allcomdat && s.Sclass == SC.global;
 }
 
 
@@ -408,10 +399,8 @@ void cv8_func_term(Symbol *sfunc)
     else
         typidx = cv_typidx(sfunc.Stype);
 
-    version (MARS)
-        const(char)* id = sfunc.prettyIdent ? sfunc.prettyIdent : prettyident(sfunc);
-    else
-        const(char)* id = prettyident(sfunc);
+    const(char)* id = sfunc.prettyIdent ? sfunc.prettyIdent : prettyident(sfunc);
+
     size_t len = strlen(id);
     if(len > CV8_MAX_SYMBOL_LENGTH)
         len = CV8_MAX_SYMBOL_LENGTH;
@@ -517,10 +506,7 @@ void cv8_func_term(Symbol *sfunc)
 @trusted
 void cv8_linnum(Srcpos srcpos, uint offset)
 {
-    version (MARS)
-        const sfilename = srcpos.Sfilename;
-    else
-        const sfilename = srcpos_name(srcpos);
+    const sfilename = srcpos.Sfilename;
     //printf("cv8_linnum(file = %s, line = %d, offset = x%x)\n", sfilename, cast(int)srcpos.Slinnum, cast(uint)offset);
 
     if (!sfilename)
@@ -692,10 +678,7 @@ void cv8_outsym(Symbol *s)
 
     idx_t typidx = cv_typidx(s.Stype);
     //printf("typidx = %x\n", typidx);
-    version (MARS)
-        const(char)* id = s.prettyIdent ? s.prettyIdent : prettyident(s);
-    else
-        const(char)* id = prettyident(s);
+    const(char)* id = s.prettyIdent ? s.prettyIdent : prettyident(s);
     size_t len = strlen(id);
 
     if(len > CV8_MAX_SYMBOL_LENGTH)

--- a/compiler/src/dmd/backend/dcgcv.d
+++ b/compiler/src/dmd/backend/dcgcv.d
@@ -95,17 +95,10 @@ enum LCFD32offset     =      (LOCATsegrel | 0x2404);
 enum LCFD32pointer    =      (LOCATsegrel | 0x2C00);
 enum LCFD16pointer    =      (LOCATsegrel | 0x0C00);
 
-version (MARS)
-    extern Cgcv cgcv; // already declared in cgcv.d
-else
-    Cgcv cgcv;
-
+extern Cgcv cgcv; // already declared in cgcv.d
 }
 
-version (MARS)
-    enum MARS = true;
-else
-    enum MARS = false;
+enum MARS = true;
 
 /******************************************
  * Return number of bytes consumed in OBJ file by a name.
@@ -860,10 +853,7 @@ idx_t cv4_struct(Classsym *s,int flags)
         return s.Stypidx;
     }
 
-version (MARS)
     util_progress();
-else
-    file_progress();
 
     // Compute the number of fields, and the length of the fieldlist record
     nfields = 0;
@@ -1039,15 +1029,9 @@ ubyte cv4_callconv(type *t)
 /**********************************************
  * Return type index for the type of a symbol.
  */
-
-version (MARS)
-{
-
 private uint cv4_symtypidx(Symbol *s)
 {
     return cv4_typidx(s.Stype);
-}
-
 }
 
 /***********************************
@@ -1130,11 +1114,8 @@ L1:
         case TYimmutPtr:
         case TYsharePtr:
         case TYrestrictPtr:
-version (MARS)
-{
             if (t.Tkey)
                 goto Laarray;
-}
             goto Lptr;
         case TYsptr:
         case TYcptr:
@@ -1207,14 +1188,11 @@ version (MARS)
         Ldarray:
             switch (config.fulltypes)
             {
-version (MARS)
-{
                 case CV8:
                 {
                     typidx = cv8_darray(t, next);
                     break;
                 }
-}
                 case CV4:
 static if (1)
 {


### PR DESCRIPTION
The backend is now dmd-only, so `version (MARS)` is redundant. Best reviewed with whitespace off