### PR TITLE
Fix Issue 23912 - Destructor disables scope inference

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -699,6 +699,20 @@ VarDeclaration expToVariable(Expression e)
             case EXP.super_:
                 return (cast(ThisExp)e).var.isVarDeclaration();
 
+            // Temporaries for rvalues that need destruction
+            // are of form: (T s = rvalue, s). For these cases
+            // we can just return var declaration of `s`. However,
+            // this is intentionally not calling `Expression.extractLast`
+            // because at this point we cannot infer the var declaration
+            // of more complex generated comma expressions such as the
+            // one for the array append hook.
+            case EXP.comma:
+            {
+                if (auto ve = e.isCommaExp().e2.isVarExp())
+                    return ve.var.isVarDeclaration();
+
+                return null;
+            }
             default:
                 return null;
         }

--- a/compiler/test/compilable/test23912.d
+++ b/compiler/test/compilable/test23912.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=23912
+// REQUIRED_ARGS: -preview=dip1000
+
+struct Test
+{
+    string val;
+
+    this(return scope string val) scope @safe {}
+    ~this() scope @safe {}
+}
+
+void giver(scope string input) @safe
+{
+    accepts(Test(input));
+}
+
+void accepts(scope Test test) @safe {}


### PR DESCRIPTION
```d
struct Test {
    string val;
    
    this(return scope string val) scope @safe {
    }

    ~this() scope @safe {
    }
}

void giver(scope string input) @safe {
    accepts(Test(input));
}

void accepts(scope Test test) @safe {
}
```

The compiler generates temporaries for rvalues that need destruction. Those temporaries are typically wrapped in a Comma Exp. As such the compiler rewrites `accepts(Test(input))` to `accepts((Test __tmp = Test(input), __tmp))` . When checking for escape analysis, it calls expToVariable on the resulted comma expression and null is returned, hence the bug. To fix it, I added the necessary logic to expToVariable to return the variable the decalration of __tmp in case of a comma exp.

Since comma expressions are generated for a multitude of compiler lowerings, this case is added specifically for the case of comma expressions that are necessary for destroying temporaries.

cc @dkorpel 