### PR TITLE
Fix Issue 23914 - auto ref resolution on return value prevented by noreturn

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2732,7 +2732,8 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 tbret = tret.toBasetype();
             }
 
-            if (inferRef) // deduce 'auto ref'
+            // https://issues.dlang.org/show_bug.cgi?id=23914
+            if (inferRef && !resType.isTypeNoreturn()) // deduce 'auto ref'
                 tf.isref = false;
 
             if (tbret.ty != Tvoid && !resType.isTypeNoreturn()) // if non-void return

--- a/compiler/test/compilable/noreturn3.d
+++ b/compiler/test/compilable/noreturn3.d
@@ -91,8 +91,8 @@ auto ref forwardOrExit(ref int num)
 
 static assert( is(typeof(forwardOrExit(global)) == int));
 
-// // Must not infer ref due to the noreturn rvalue
-static assert(!is(typeof(&forwardOrExit(global))));
+// Noreturn types do not affect `auto ref` deduction
+static assert(is(typeof(&forwardOrExit(global))));
 
 auto ref forwardOrExit2(ref int num)
 {
@@ -104,8 +104,8 @@ auto ref forwardOrExit2(ref int num)
 
 static assert( is(typeof(forwardOrExit2(global)) == int));
 
-// // Must not infer ref due to the noreturn rvalue
-static assert(!is(typeof(&forwardOrExit2(global))));
+// Noreturn types do not affect `auto ref` deduction
+static assert(is(typeof(&forwardOrExit2(global))));
 
 /*****************************************************************************/
 


### PR DESCRIPTION
The reported behavior seems to have been added on purpose [1] (not the code, but the tests), however, I don't understand why this behavior is useful. I think that the purpose was to avoid having ref being deduce on functions that are of type noreturn. However, defining a ref noreturn function is accepted (`ref noreturn fun() { assert(0);}) ` and I see no harm in allowing that. In addition, the DIP specifically states that noreturn is implicitly convertible to any type, so it makes sense that noreturn returns are not taken into account when deducing if the return type is ref or not.

cc @MoonlightSentinel @dkorpel 

[1] https://github.com/dlang/dmd/pull/13155/files#diff-11202231105178d634cd13a199cc3d2d0be08dd1f282da897edc16e2ecf1f3e2R92