### PR TITLE
remove Expression.parens

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -4536,7 +4536,6 @@ struct ASTBase
     {
         EXP op;
         ubyte size;
-        ubyte parens;
         Type type;
         Loc loc;
 
@@ -5115,6 +5114,8 @@ struct ASTBase
 
     extern (C++) final class TypeExp : Expression
     {
+        bool parens;
+
         extern (D) this(const ref Loc loc, Type type)
         {
             super(loc, EXP.type, __traits(classInstanceSize, TypeExp));
@@ -5147,6 +5148,7 @@ struct ASTBase
     extern (C++) class IdentifierExp : Expression
     {
         Identifier ident;
+        bool parens;
 
         final extern (D) this(const ref Loc loc, Identifier ident)
         {

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -737,7 +737,6 @@ extern (C++) abstract class Expression : ASTNode
     Type type;      // !=null means that semantic() has been run
     Loc loc;        // file location
     const EXP op;   // to minimize use of dynamic_cast
-    bool parens;    // if this is a parenthesized expression
 
     extern (D) this(const ref Loc loc, EXP op) scope
     {
@@ -2357,6 +2356,7 @@ extern (C++) final class ComplexExp : Expression
 extern (C++) class IdentifierExp : Expression
 {
     Identifier ident;
+    bool parens;        // if it appears as (identifier)
 
     extern (D) this(const ref Loc loc, Identifier ident) scope
     {
@@ -3539,6 +3539,8 @@ extern (C++) final class CompoundLiteralExp : Expression
  */
 extern (C++) final class TypeExp : Expression
 {
+    bool parens;    // if this is a parenthesized expression
+
     extern (D) this(const ref Loc loc, Type type)
     {
         super(loc, EXP.type);

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -83,7 +83,6 @@ public:
     Type *type;                 // !=NULL means that semantic() has been run
     Loc loc;                    // file location
     EXP op;                     // to minimize use of dynamic_cast
-    d_bool parens;              // if this is a parenthesized expression
 
     size_t size() const;
     static void _init();
@@ -316,6 +315,7 @@ class IdentifierExp : public Expression
 {
 public:
     Identifier *ident;
+    d_bool parens;
 
     static IdentifierExp *create(const Loc &loc, Identifier *ident);
     bool isLvalue() override final;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -979,7 +979,6 @@ public:
     Type* type;
     Loc loc;
     const EXP op;
-    bool parens;
     size_t size() const;
     static void _init();
     static void deinitialize();
@@ -7013,9 +7012,9 @@ struct UnionExp final
 private:
     union __AnonStruct__u
     {
-        char exp[26LLU];
+        char exp[25LLU];
         char integerexp[40LLU];
-        char errorexp[26LLU];
+        char errorexp[25LLU];
         char realexp[48LLU];
         char complexexp[64LLU];
         char symoffexp[64LLU];
@@ -7024,7 +7023,7 @@ private:
         char assocarrayliteralexp[48LLU];
         char structliteralexp[76LLU];
         char compoundliteralexp[40LLU];
-        char nullexp[26LLU];
+        char nullexp[25LLU];
         char dotvarexp[49LLU];
         char addrexp[40LLU];
         char indexexp[74LLU];
@@ -7117,6 +7116,7 @@ class IdentifierExp : public Expression
 {
 public:
     Identifier* ident;
+    bool parens;
     static IdentifierExp* create(const Loc& loc, Identifier* ident);
     bool isLvalue() final override;
     Expression* toLvalue(Scope* sc, Expression* e) final override;
@@ -7277,6 +7277,7 @@ public:
 class TypeExp final : public Expression
 {
 public:
+    bool parens;
     TypeExp* syntaxCopy() override;
     bool checkType() override;
     bool checkValue() override;

--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -237,15 +237,16 @@ Expression castCallAmbiguity(Expression e, Scope* sc)
 
             case EXP.call:
                 auto ce = (*pe).isCallExp();
-                if (ce.e1.parens)
+                auto ie = ce.e1.isIdentifierExp();
+                if (ie && ie.parens)
                 {
-                    ce.e1 = expressionSemantic(ce.e1, sc);
+                    ce.e1 = expressionSemantic(ie, sc);
                     if (ce.e1.op == EXP.type)
                     {
                         const numArgs = ce.arguments ? ce.arguments.length : 0;
                         if (numArgs >= 1)
                         {
-                            ce.e1.parens = false;
+                            ie.parens = false;
                             Expression arg;
                             foreach (a; (*ce.arguments)[])
                             {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8479,7 +8479,6 @@ LagainStc:
                 // ( expression )
                 nextToken();
                 e = parseExpression();
-                e.parens = true;
                 check(loc, TOK.rightParenthesis);
                 break;
             }
@@ -8800,9 +8799,9 @@ LagainStc:
                                         nextToken();
                                         return AST.ErrorExp.get();
                                     }
-                                    e = new AST.TypeExp(loc, t);
-                                    e.parens = true;
-                                    e = parsePostExp(e);
+                                    auto te = new AST.TypeExp(loc, t);
+                                    te.parens = true;
+                                    e = parsePostExp(te);
                                 }
                                 else
                                 {


### PR DESCRIPTION
and put it in IdentiferExp.parens and TypeExp.parens. The idea is to minimize complexity by putting parens only where it is needed. Sadly, due to alignment, it doesn't actually save any space. But it could with future work. In the meantime, the deadwood is removed.