### PR TITLE
[new syntax] Support `function` `ref` Type Parameters for function pointer types

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3660,10 +3660,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             auto parameterList = parseParameterList(null);
             parsePostfix(stc, null);
             auto tf = new AST.TypeFunction(parameterList, tret, linkage, stc);
-            if (stc & (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild | STC.return_))
+            if (save == TOK.function_ && stc & (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild | STC.return_))
             {
-                if (save == TOK.function_)
-                    error("`const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions");
+                error("`const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions");
             }
             t = save == TOK.delegate_ ? new AST.TypeDelegate(tf) : new AST.TypePointer(tf); // pointer to function
             break;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3649,7 +3649,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             // function ref type (parameters) attributes
             const save = token.value;
             nextToken();
-            STC stc;
+            StorageClass stc;
             if (token.value == TOK.ref_)
             {
                 stc = STC.ref_;
@@ -3658,11 +3658,12 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             auto tret = parseBasicType();
             tret = parseTypeSuffixes(tret); // function return type
             auto parameterList = parseParameterList(null);
-            parsePostfix(stc, null);
+            stc = parsePostfix(stc, null);
             auto tf = new AST.TypeFunction(parameterList, tret, linkage, stc);
-            if (save == TOK.function_ && stc & (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild | STC.return_))
+            if (save == TOK.function_ &&
+                stc & (STC.TYPECTOR | STC.scope_ | STC.return_ | STC.returnScope))
             {
-                error("`const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions");
+                error("`const`/`immutable`/`shared`/`inout`/`scope`/`return` attributes are only valid for non-static member functions");
             }
             t = save == TOK.delegate_ ? new AST.TypeDelegate(tf) : new AST.TypePointer(tf); // pointer to function
             break;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4833,21 +4833,6 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     tpl = parseTemplateParameterList();
                 check(TOK.assign);
 
-                // function ref type (parameters) attributes
-                bool isLeadingFunctionType = {
-                    if (token.value != TOK.function_ && token.value != TOK.delegate_)
-                        return false;
-                    Token* tk = peek(&token);
-                    if (tk.value == TOK.ref_)
-                        tk = peek(tk);
-                    if (!isBasicType(&tk))
-                        return false;
-                    if (!skipParens(tk, &tk))
-                        return false;
-                    if (!skipAttributes(tk, &tk))
-                        return false;
-                    return tk.value == TOK.semicolon || tk.value == TOK.comma;
-                }();
                 bool hasParsedAttributes;
                 void parseAttributes()
                 {
@@ -4875,7 +4860,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 const StorageClass funcStc = parseTypeCtor();
                 Token* tlu = &token;
                 Token* tk;
-                if (isLeadingFunctionType)
+                if (isLeadingFunctionType(&token))
                 {
                     AST.Type tf = parseBasicType();
                     v = new AST.AliasDeclaration(loc, ident, tf);
@@ -7711,6 +7696,23 @@ LagainStc:
         t = peek(t);
         *pt = t;
         return true;
+    }
+
+    // function ref type (parameters) attributes
+    private bool isLeadingFunctionType(Token *tk)
+    {
+        if (tk.value != TOK.function_ && tk.value != TOK.delegate_)
+            return false;
+        tk = peek(tk);
+        if (tk.value == TOK.ref_)
+            tk = peek(tk);
+        if (!isBasicType(&tk))
+            return false;
+        if (!skipParens(tk, &tk))
+            return false;
+        if (!skipAttributes(tk, &tk))
+            return false;
+        return tk.value == TOK.semicolon || tk.value == TOK.comma;
     }
 
     private bool isExpression(Token** pt)

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -422,6 +422,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             case TOK.class_:
             case TOK.interface_:
             case TOK.traits:
+            case TOK.function_:
+            case TOK.delegate_:
             Ldeclaration:
                 a = parseDeclarations(false, pAttrs, pAttrs.comment);
                 if (a && a.length)

--- a/compiler/test/fail_compilation/test4838.d
+++ b/compiler/test/fail_compilation/test4838.d
@@ -1,12 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test4838.d(13): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
 fail_compilation/test4838.d(14): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
 fail_compilation/test4838.d(15): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
 fail_compilation/test4838.d(16): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
 fail_compilation/test4838.d(17): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
 fail_compilation/test4838.d(18): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
+fail_compilation/test4838.d(19): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
+fail_compilation/test4838.d(23): Error: `const`/`immutable`/`shared`/`inout`/`scope`/`return` attributes are only valid for non-static member functions
 ---
 */
 
@@ -16,3 +17,8 @@ void function() shared fps;
 void function() shared const fpsc;
 void function() inout fpw;
 void function() shared inout fpsw;
+
+//function void() scope lfps; // FIXME module level leading function decl
+void f(){
+    function void() return lfpr;
+}

--- a/compiler/test/fail_compilation/test4838.d
+++ b/compiler/test/fail_compilation/test4838.d
@@ -1,13 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test4838.d(14): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
 fail_compilation/test4838.d(15): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
 fail_compilation/test4838.d(16): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
 fail_compilation/test4838.d(17): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
 fail_compilation/test4838.d(18): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
 fail_compilation/test4838.d(19): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
-fail_compilation/test4838.d(23): Error: `const`/`immutable`/`shared`/`inout`/`scope`/`return` attributes are only valid for non-static member functions
+fail_compilation/test4838.d(20): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
+fail_compilation/test4838.d(22): Error: `const`/`immutable`/`shared`/`inout`/`scope`/`return` attributes are only valid for non-static member functions
+fail_compilation/test4838.d(24): Error: `const`/`immutable`/`shared`/`inout`/`scope`/`return` attributes are only valid for non-static member functions
 ---
 */
 
@@ -18,7 +19,7 @@ void function() shared const fpsc;
 void function() inout fpw;
 void function() shared inout fpsw;
 
-//function void() scope lfps; // FIXME module level leading function decl
+function void() scope lfps;
 void f(){
     function void() return lfpr;
 }

--- a/compiler/test/runnable/reffunctype.d
+++ b/compiler/test/runnable/reffunctype.d
@@ -1,0 +1,11 @@
+void f(function ref int() g) { g()++; }
+
+int i;
+ref int h() => i;
+
+void main()
+{
+    f(&h);
+    f(ref() => i);
+    assert(i == 2);
+}

--- a/compiler/test/runnable/reffunctype.d
+++ b/compiler/test/runnable/reffunctype.d
@@ -10,7 +10,7 @@ unittest
     f(&h);
     f(ref() => i);
     assert(i == 2);
-    
+
     function ref int() fp = &h;
     fp()++;
     assert(i == 3);

--- a/compiler/test/runnable/reffunctype.d
+++ b/compiler/test/runnable/reffunctype.d
@@ -4,6 +4,7 @@ void f(function ref int() g) { g()++; }
 
 int i;
 ref int h() => i;
+function ref int() mfp = &h;
 
 unittest
 {
@@ -14,6 +15,9 @@ unittest
     function ref int() fp = &h;
     fp()++;
     assert(i == 3);
+
+    mfp()++;
+    assert(i == 4);
 }
 
 alias Func = function ref int();

--- a/compiler/test/runnable/reffunctype.d
+++ b/compiler/test/runnable/reffunctype.d
@@ -9,3 +9,6 @@ void main()
     f(ref() => i);
     assert(i == 2);
 }
+
+alias Func = function ref int();
+static assert(is(Func == typeof(&h)));

--- a/compiler/test/runnable/reffunctype.d
+++ b/compiler/test/runnable/reffunctype.d
@@ -32,3 +32,6 @@ unittest
     d()++;
     assert(s.i == 1);
 }
+
+alias Del = delegate ref int();
+static assert(is(Del == typeof(&S().get)));

--- a/compiler/test/runnable/reffunctype.d
+++ b/compiler/test/runnable/reffunctype.d
@@ -1,14 +1,34 @@
+// REQUIRED_ARGS: -unittest -main
+
 void f(function ref int() g) { g()++; }
 
 int i;
 ref int h() => i;
 
-void main()
+unittest
 {
     f(&h);
     f(ref() => i);
     assert(i == 2);
+    
+    function ref int() fp = &h;
+    fp()++;
+    assert(i == 3);
 }
 
 alias Func = function ref int();
 static assert(is(Func == typeof(&h)));
+
+struct S
+{
+    int i;
+    ref int get() => i;
+}
+
+unittest
+{
+    S s;
+    delegate ref int() d = &s.get;
+    d()++;
+    assert(s.i == 1);
+}


### PR DESCRIPTION
Fixes Issue 2753 - Cannot declare pointer to function returning ref.

This token ordering is consistent with function literals:
```
function RefOrAutoRefopt Typeopt ParameterWithAttributesopt FunctionLiteralBody2
```
https://dlang.org/spec/expression.html#function_literals

See https://forum.dlang.org/post/qngjoxgihmcsvoprnanb@forum.dlang.org for more on the grammar.

Alternatively, allowing *Type* `function` *Parameters* `ref` would also fix the issue, though that is less easy to see that the return value is actually a reference when looking at the return type. Also there is no precedent for that AIUI in the grammar, though the compiler does use this ordering in error messages despite it being invalid syntax.

Another option would be *Type* `ref` `function` *Parameters*, but again, no precedent for that.

---
This pull implements support for 'leading function' pointer types in most places, ~~but not for a declaration at module scope yet~~.