### PR TITLE
Fix optional type & parameters for `function` literal

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -5026,7 +5026,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 stc = STC.ref_;
                 nextToken();
             }
-            if (token.value != TOK.leftParenthesis && token.value != TOK.leftCurly)
+            if (token.value != TOK.leftParenthesis && token.value != TOK.leftCurly &&
+                token.value != TOK.goesTo)
             {
                 // function type (parameters) { statements... }
                 // delegate type (parameters) { statements... }

--- a/compiler/test/runnable/funclit.d
+++ b/compiler/test/runnable/funclit.d
@@ -1263,6 +1263,7 @@ void assign16271(T)(ref T a, T b)
 void test16271()
 {
     int x;
+    (delegate ref => x)() = -1;     assert(x == -1);
     (ref () => x )() = 1;           assert(x == 1);
     func16271!(ref () => x) = 2;    assert(x == 2);
     assign16271(x, 3);              assert(x == 3);


### PR DESCRIPTION
Fix issue found in https://github.com/dlang/dlang.org/pull/3608.
```d
auto f3 = function => 3; // Error
auto d3 = delegate => 3; // error
```