### PR TITLE
Remove need to set version=MARS

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1360,7 +1360,7 @@ void processEnvironment()
     else
         env.setDefault("ZIP", "zip");
 
-    string[] dflags = ["-version=MARS", "-w", "-de", env["PIC_FLAG"], env["MODEL_FLAG"], "-J"~env["G"], "-I" ~ srcDir];
+    string[] dflags = ["-w", "-de", env["PIC_FLAG"], env["MODEL_FLAG"], "-J"~env["G"], "-I" ~ srcDir];
 
     // TODO: add support for dObjc
     auto dObjc = false;

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -44,6 +44,10 @@ import dmd.tokens;
 import dmd.typesem;
 import dmd.visitor;
 
+version (IN_GCC) {}
+else version (IN_LLVM) {}
+else version = MARS;
+
 /************************************
  * Check to see the aggregate type is nested and its context pointer is
  * accessible from the current scope.

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -77,6 +77,10 @@ import dmd.templateparamsem;
 import dmd.typesem;
 import dmd.visitor;
 
+version (IN_GCC) {}
+else version (IN_LLVM) {}
+else version = MARS;
+
 enum LOG = false;
 
 private uint setMangleOverride(Dsymbol s, const(char)[] sym)

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -59,6 +59,10 @@ import dmd.statementsem;
 import dmd.tokens;
 import dmd.visitor;
 
+version (IN_GCC) {}
+else version (IN_LLVM) {}
+else version = MARS;
+
 /// Inline Status
 enum ILS : ubyte
 {

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -26,6 +26,10 @@ import dmd.location;
 import dmd.lexer : CompileEnv;
 import dmd.utils;
 
+version (IN_GCC) {}
+else version (IN_LLVM) {}
+else version = MARS;
+
 /// Defines a setting for how compiler warnings and deprecations are handled
 enum DiagnosticReporting : ubyte
 {

--- a/compiler/src/dmd/gluelayer.d
+++ b/compiler/src/dmd/gluelayer.d
@@ -48,16 +48,6 @@ version (NoBackend)
         }
     }
 }
-else version (MARS)
-{
-    public import dmd.backend.cc : block, Blockx, Symbol;
-    public import dmd.backend.type : type;
-    public import dmd.backend.el : elem;
-    public import dmd.backend.code_x86 : code;
-    public import dmd.iasm : asmSemantic;
-    public import dmd.objc_glue : ObjcGlue;
-    public import dmd.toobj : toObjFile;
-}
 else version (IN_GCC)
 {
     extern (C++) union tree_node;
@@ -79,4 +69,12 @@ else version (IN_GCC)
     }
 }
 else
-    static assert(false, "Unsupported compiler backend");
+{
+    public import dmd.backend.cc : block, Blockx, Symbol;
+    public import dmd.backend.type : type;
+    public import dmd.backend.el : elem;
+    public import dmd.backend.code_x86 : code;
+    public import dmd.iasm : asmSemantic;
+    public import dmd.objc_glue : ObjcGlue;
+    public import dmd.toobj : toObjFile;
+}

--- a/compiler/src/dmd/iasm.d
+++ b/compiler/src/dmd/iasm.d
@@ -23,13 +23,14 @@ import dmd.tokens;
 import dmd.statement;
 import dmd.statementsem;
 
-version (MARS)
-{
-    import dmd.iasmdmd;
-}
-else version (IN_GCC)
+version (IN_GCC)
 {
     import dmd.iasmgcc;
+}
+else
+{
+    import dmd.iasmdmd;
+    version = MARS;
 }
 
 /************************ AsmStatement ***************************************/


### PR DESCRIPTION
Trying to make building the compiler simpler, see https://forum.dlang.org/post/ltpjhrigitsizepwcuhs@forum.dlang.org

The only version(MARS) blocks left are dmd inline assembly, glue layer, and the recent 'align section' for closures which GDC and LDC don't need.