### PR TITLE
Remove function prototypes from backend pt18

### DIFF
--- a/compiler/src/dmd/backend/type.d
+++ b/compiler/src/dmd/backend/type.d
@@ -140,20 +140,10 @@ extern __gshared
     type* tstrace;
 }
 
-public import dmd.backend.dtype : type_print;
+public import dmd.backend.dtype : type_print, type_free, type_init, type_term, type_copy,
+    type_setdim, type_setdependent, type_isdependent;
 
 /* Functions    */
-void type_free(type *);
-void type_init();
-void type_term();
-type *type_copy(type *);
-elem *type_vla_fix(type **pt);
-type *type_setdim(type **,targ_size_t);
-type *type_setdependent(type *t);
-int type_isdependent(type *t);
-void type_hydrate(type **);
-void type_dehydrate(type **);
-
 targ_size_t type_size(const type *);
 uint type_alignsize(type *);
 bool type_zeroSize(type *t, tym_t tyf);


### PR DESCRIPTION
dtype was succesfully imported in https://github.com/dlang/dmd/pull/15188, slowly replace more prototypes now