### PR TITLE
Fix Issue 23932 - Slot is allocated before evaluating the value during associative array initialization

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -10174,7 +10174,36 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.type = exp.e1.type;
         assert(exp.type);
         auto assignElem = exp.e2;
-        auto res = exp.op == EXP.assign ? exp.reorderSettingAAElem(sc) : exp;
+
+        /***
+         * https://issues.dlang.org/show_bug.cgi?id=23932
+         *
+         * For AA item assignments of type struct, the compiler
+         * lowers code such as `aa[key] = e2;`, to:
+         *
+         *   ref __aatmp = aa;
+         *   ref __aakey = key;
+         *   ref __aaval = e2;
+         *   (__aakey in __aatmp
+         *       ? __aatmp[__aakey].opAssign(__aaval)
+         *       : ConstructExp(__aatmp[__aakey], __aaval));
+         *
+         * However, if `aa[key] = e2` is actually a construct expression
+         * (for example, the first assignment of aa in a constructor),
+         * then the side effects are no longer extracted, causing the
+         * manifestation of Issue 23932.
+         *
+         * To fix this, we call `reorderSettingAAElem` to extract side effects
+         * on all assignments (construct or assign), excepting on the ConstructExps
+         * that were already lowered.
+         */
+
+        Expression res;
+        auto ve = assignElem.isVarExp();
+        if (ve && (ve.var.storage_class & STC.temp) && ve.var.storage_class & (STC.ref_ | STC.rvalue))
+                res = exp;
+        else
+            res = exp.reorderSettingAAElem(sc);
         /* https://issues.dlang.org/show_bug.cgi?id=22366
          *
          * `reorderSettingAAElem` creates a tree of comma expressions, however,

--- a/compiler/test/runnable/testaa.d
+++ b/compiler/test/runnable/testaa.d
@@ -1314,9 +1314,9 @@ void test14321()
     Bar[string] bars;
     assert(Bar.op == "");
     bars["test"] = Bar(42);     // initialization
-    assert(Bar.op == "");
-    bars["test"] = Bar(42);     // assignment
     assert(Bar.op == "d");
+    bars["test"] = Bar(42);     // assignment
+    assert(Bar.op == "dd");
 }
 
 /************************************************/
@@ -1334,6 +1334,35 @@ void test19112()
 }
 
 /************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=23932
+
+void test23932()
+{
+    static class C
+    {
+        int[int] aa;
+
+        this()
+        {
+            try
+            {
+                aa[42] = {
+                    if (true)
+                        throw new Exception("oops");
+                    else
+                        return 9;
+                }();
+            }
+            catch (Exception e) {}
+        }
+    }
+
+    auto c = new C;
+    assert(c.aa.length == 0);
+}
+
+/************************************************/
+
 
 int main()
 {
@@ -1385,6 +1414,7 @@ int main()
     test14089();
     test14321();
     test19112();
+    test23932();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
It seems that this behavior was on purpose: avoiding to create a temporary when an aa value is initialized, whereas creating it when an aa value is assigned. However, that does not make any sense in my opinion, because initialization is not properly defined for an aa elem. Currently, the compiler considers that an AA is initialized only when it encounters the first use of the aa variable (be it an element initialization or an aa initializer), it doesn't  actually check if a particular element is initialized. Therefore, this PR creates temporaries for both the key and the value for both the initialization and the assignment case.

I had to modify a runnable test since now you will have an extra destructor call for the copy. This might be viewed as a breaking change for code that relies on it. However,  this was buggy behavior and I expect no code to actually rely on it (famous last words).