### PR TITLE
fix Issue 21425 - Using va_start twice results in wrong values

### DIFF
--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -5478,6 +5478,9 @@ private elem * elvalist(elem *e, goal_t goal)
         return e;
     }
 
+    elem* ap = e.EV.E1;         // pointer to va_list
+    elem* parmn = e.EV.E2;      // address of last named parameter
+
     if (I32)
     {
         // (OPva_start &va)
@@ -5501,7 +5504,7 @@ private elem * elvalist(elem *e, goal_t goal)
             lastNamed = arguments_typeinfo;
 
         e.Eoper = OPeq;
-        e.EV.E1 = el_una(OPind, TYnptr, e.EV.E1);
+        e.EV.E1 = el_una(OPind, TYnptr, ap);
         if (lastNamed)
         {
             e.EV.E2 = el_ptr(lastNamed);
@@ -5533,7 +5536,7 @@ if (config.exe & EX_windos)
     }
 
     e.Eoper = OPeq;
-    e.EV.E1 = el_una(OPind, TYnptr, e.EV.E1);
+    e.EV.E1 = el_una(OPind, TYnptr, ap);
     if (lastNamed)
     {
         e.EV.E2 = el_ptr(lastNamed);
@@ -5565,11 +5568,12 @@ if (config.exe & EX_posix)
     }
 
     e.Eoper = OPeq;
-    e.EV.E1 = el_una(OPind, TYnptr, e.EV.E1);
+    e.EV.E1 = el_una(OPind, TYnptr, ap);
     if (va_argsave)
     {
         e.EV.E2 = el_ptr(va_argsave);
-        e.EV.E2.EV.Voffset = 6 * 8 + 8 * 16;
+        e.EV.E2.EV.Voffset = 6 * 8 + 8 * 16; // offset to struct __va_list_tag defined in sysv_x64.d
+        return el_combine(prolog_genva_start(va_argsave, parmn.EV.Vsym), e);
     }
     else
         e.EV.E2 = el_long(TYnptr, 0);

--- a/compiler/src/dmd/backend/cod3.d
+++ b/compiler/src/dmd/backend/cod3.d
@@ -3862,12 +3862,8 @@ void prolog_genvarargs(ref CodeBuilder cdb, Symbol* sv)
         MOVAPS  -0x6F[RAX],XMM1
         MOVAPS  -0x7F[RAX],XMM0
       L2:
-        MOV     1[RAX],offset_regs          // set __va_argsave.offset_regs
-        MOV     5[RAX],offset_fpregs        // set __va_argsave.offset_fpregs
         LEA     R11, Para.size+Para.offset[RBP]
-        MOV     9[RAX],R11                  // set __va_argsave.stack_args
-        SUB     RAX,6*8+0x7F                // point to start of __va_argsave
-        MOV     6*8+8*16+4+4+8[RAX],RAX     // set __va_argsave.reg_args
+        MOV     9+16[RAX],R11                // set __va_argsave.stack_args
     * RAX and R11 are destroyed.
     */
 
@@ -3918,10 +3914,59 @@ void prolog_genvarargs(ref CodeBuilder cdb, Symbol* sv)
         cdb.genc1(0x0F29,modregrm(0,XMM7-i,0),FLconst,-15-16*i);
     }
 
+    // LEA R11, Para.size+Para.offset[RBP]
+    ea = modregxrm(2,R11,BPRM);
+    if (!hasframe)
+        ea = (modregrm(0,4,SP) << 8) | modregrm(2,DX,4);
+    Para.offset = (Para.offset + (REGSIZE - 1)) & ~(REGSIZE - 1);
+    cdb.genc1(LEA,(REX_W << 16) | ea,FLconst,Para.size + Para.offset);
+
+    // MOV 9+16[RAX],R11
+    cdb.genc1(0x89,(REX_W << 16) | modregxrm(2,R11,AX),FLconst,9 + 16);   // into stack_args_save
+
+    pinholeopt(cdb.peek(), null);
+    useregs(mAX|mR11);
+}
+
+/********************************
+ * Generate elems for va_start()
+ * Params:
+ *      sv = symbol for __va_argsave
+ *      parmn = last named parameter
+ */
+@trusted
+elem* prolog_genva_start(Symbol* sv, Symbol* parmn)
+{
+    enum Vregnum = 6;
+
+    /* the stack variable __va_argsave points to an instance of:
+     *   struct __va_argsave_t {
+     *     size_t[Vregnum] regs;
+     *     real[8] fpregs;
+     *     struct __va_list_tag {
+     *         uint offset_regs;
+     *         uint offset_fpregs;
+     *         void* stack_args;
+     *         void* reg_args;
+     *     }
+     *     void* stack_args_save;
+     *   }
+     */
+
+    enum OFF // offsets into __va_argsave_t
+    {
+        Offset_regs   = Vregnum*8 + 8*16,
+        Offset_fpregs = Offset_regs + 4,
+        Stack_args    = Offset_fpregs + 4,
+        Reg_args      = Stack_args + 8,
+        Stack_args_save = Reg_args + 8,
+    }
+
     /* Compute offset_regs and offset_fpregs
      */
+    regm_t namedargs = prolog_namedArgs();
     uint offset_regs = 0;
-    uint offset_fpregs = vregnum * 8;
+    uint offset_fpregs = Vregnum * 8;
     for (int i = AX; i <= XMM7; i++)
     {
         regm_t m = mask(i);
@@ -3936,31 +3981,52 @@ void prolog_genvarargs(ref CodeBuilder cdb, Symbol* sv)
                 break;
         }
     }
-    // MOV 1[RAX],offset_regs
-    cdb.genc(0xC7,modregrm(2,0,AX),FLconst,1,FLconst,offset_regs);
 
-    // MOV 5[RAX],offset_fpregs
-    cdb.genc(0xC7,modregrm(2,0,AX),FLconst,5,FLconst,offset_fpregs);
+    // set offset_regs
+    elem* e1 = el_bin(OPeq, TYint, el_var(sv), el_long(TYint, offset_regs));
+    e1.EV.E1.Ety = TYint;
+    e1.EV.E1.EV.Voffset = OFF.Offset_regs;
 
-    // LEA R11, Para.size+Para.offset[RBP]
-    ea = modregxrm(2,R11,BPRM);
-    if (!hasframe)
-        ea = (modregrm(0,4,SP) << 8) | modregrm(2,DX,4);
-    Para.offset = (Para.offset + (REGSIZE - 1)) & ~(REGSIZE - 1);
-    cdb.genc1(LEA,(REX_W << 16) | ea,FLconst,Para.size + Para.offset);
+    // set offset_fpregs
+    elem* e2 = el_bin(OPeq, TYint, el_var(sv), el_long(TYint, offset_fpregs));
+    e2.EV.E1.Ety = TYint;
+    e2.EV.E1.EV.Voffset = OFF.Offset_fpregs;
 
-    // MOV 9[RAX],R11
-    cdb.genc1(0x89,(REX_W << 16) | modregxrm(2,R11,AX),FLconst,9);
+    // set reg_args
+    elem* e4 = el_bin(OPeq, TYnptr, el_var(sv), el_ptr(sv));
+    e4.EV.E1.Ety = TYnptr;
+    e4.EV.E1.EV.Voffset = OFF.Reg_args;
 
-    // SUB RAX,6*8+0x7F             // point to start of __va_argsave
-    cdb.genc2(0x2D,0,6*8+0x7F);
-    code_orrex(cdb.last(), REX_W);
+    // set stack_args
+    /* which is a pointer to the first variadic argument on the stack.
+     * Normally, we could set it by taking the address of the last named parameter
+     * (parmn) and then skipping past it. The trouble, though, is it fails
+     * when all the named parameters get passed in a register.
+     *    elem* e3 = el_bin(OPeq, TYnptr, el_var(sv), el_ptr(parmn));
+     *    e3.EV.E1.Ety = TYnptr;
+     *    e3.EV.E1.EV.Voffset = OFF.Stack_args;
+     *    auto sz = type_size(parmn.Stype);
+     *    sz = (sz + (REGSIZE - 1)) & ~(REGSIZE - 1);
+     *    e3.EV.E2.EV.Voffset += sz;
+     * The next possibility is to do it the way prolog_genvarargs() does:
+     *    LEA R11, Para.size+Para.offset[RBP]
+     * The trouble there is Para.size and Para.offset is not available when
+     * this function is called. It might be possible to compute this earlier.(1)
+     * Another possibility is creating a special operand type that gets filled
+     * in after the prolog_genvarargs() is called.
+     * Or do it this simpler way - compute the needed value in prolog_genvarargs(),
+     * and save it in a slot just after va_argsave, called `stack_args_save`.
+     * Then, just copy from `stack_args_save` to `stack_args`.
+     * Although, doing (1) might be optimal.
+     */
+    elem* e3 = el_bin(OPeq, TYnptr, el_var(sv), el_var(sv));
+    e3.EV.E1.Ety = TYnptr;
+    e3.EV.E1.EV.Voffset = OFF.Stack_args;
+    e3.EV.E2.Ety = TYnptr;
+    e3.EV.E2.EV.Voffset = OFF.Stack_args_save;
 
-    // MOV 6*8+8*16+4+4+8[RAX],RAX  // set __va_argsave.reg_args
-    cdb.genc1(0x89,(REX_W << 16) | modregrm(2,AX,AX),FLconst,6*8+8*16+4+4+8);
-
-    pinholeopt(cdb.peek(), null);
-    useregs(mAX|mR11);
+    elem* e = el_combine(e1, el_combine(e2, el_combine(e3, e4)));
+    return e;
 }
 
 void prolog_gen_win64_varargs(ref CodeBuilder cdb)

--- a/compiler/src/dmd/backend/oper.d
+++ b/compiler/src/dmd/backend/oper.d
@@ -832,6 +832,7 @@ static immutable Ebinary =
         OPbt,OPbtc,OPbtr,OPbts,OPror,OProl,OPbtst,
         OPremquo,OPcmpxchg,
         OPoutp,OPscale,OPyl2x,OPyl2xp1,
+        OPva_start,
         OPvecsto,OPprefetch
     ];
 
@@ -854,7 +855,6 @@ static immutable Eunary =
         OPbsf,OPbsr,OPbswap,OPpopcnt,
         OPddtor,
         OPvector,OPvecfill,
-        OPva_start,
         OPsqrt,OPsin,OPcos,OPinp,
         OPvp_fp,OPcvp_fp,OPnp_fp,OPnp_f16p,OPf16p_np,OPoffset,
     ];

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -6983,9 +6983,6 @@ elem* constructVa_start(elem* e)
     {
         // (OPparam &va &arg)
         // call as (OPva_start &va)
-        auto earg = e.EV.E2;
-        e.EV.E2 = null;
-        return el_combine(earg, e);
     }
     else // 32 bit
     {
@@ -6993,7 +6990,7 @@ elem* constructVa_start(elem* e)
         // call as (OPva_start &va)
         auto earg = e.EV.E1;
         e.EV.E1 = e.EV.E2;
-        e.EV.E2 = null;
-        return el_combine(earg, e);
+        e.EV.E2 = earg;
     }
+    return e;
 }

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -924,13 +924,15 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         params[pi] = toSymbol(fd.v_arguments);
         pi += 1;
     }
+    Symbol* lastParam;
     if (fd.parameters)
     {
         foreach (i, v; *fd.parameters)
         {
-            //printf("param[%d] = %p, %s\n", i, v, v.toChars());
+            //printf("param[%d] = %p, %s\n", cast(int)i, v, v.toChars());
             assert(!v.csym);
-            params[pi + i] = toSymbol(v);
+            lastParam = toSymbol(v);
+            params[pi + i] = lastParam;
         }
         pi += fd.parameters.length;
     }
@@ -1029,7 +1031,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         if (target.is64bit &&
             target.os & Target.OS.Posix)
         {
-            type *t = type_struct_class("__va_argsave_t", 16, 8 * 6 + 8 * 16 + 8 * 3, null, null, false, false, true, false);
+            type *t = type_struct_class("__va_argsave_t", 16, 8 * 6 + 8 * 16 + 8 * 3 + 8, null, null, false, false, true, false);
             // The backend will pick this up by name
             Symbol *sv = symbol_name("__va_argsave", SC.auto_, t);
             sv.Stype.Tty |= mTYvolatile;
@@ -1041,7 +1043,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         {
             Symbol *sa = toSymbol(fd.v_argptr);
             symbol_add(sa);
-            elem *e = el_una(OPva_start, TYnptr, el_ptr(sa));
+            elem *e = el_bin(OPva_start, TYnptr, el_ptr(sa), lastParam ? el_ptr(lastParam) : el_long(TYnptr, 0));
             block_appendexp(irs.blx.curblock, e);
         }
     }

--- a/compiler/test/runnable/variadic.d
+++ b/compiler/test/runnable/variadic.d
@@ -1119,6 +1119,53 @@ void test15417()
 
 
 /***************************************/
+// https://issues.dlang.org/show_bug.cgi?id=21425
+
+import core.stdc.stdarg;
+import core.stdc.stdio;
+
+extern(C) void f5(int dummy, ...)
+{
+    va_list ap;
+
+    va_start(ap, dummy);
+    int x = va_arg!int(ap);
+    assert(x == 5);
+    va_end(ap);
+
+    va_start(ap, dummy);
+    int y = va_arg!int(ap);
+    assert(y == 5);
+    va_end(ap);
+}
+
+void test21425()
+{
+    f5(0, 5);
+}
+
+/*********************************************/
+// https://issues.dlang.org/show_bug.cgi?id=23409
+
+import core.stdc.string;
+
+void printf10(const(char)* fmt, ...){
+    char[30] s;
+    for(int i = 0; i < 10; i++){
+        va_list args;
+        va_start(args, fmt);
+        vsprintf(s.ptr, fmt, args);
+        va_end(args);
+        assert(strcmp(s.ptr, "Hello world\n") == 0);
+    }
+}
+
+void test23409()
+{
+    printf10("Hello %s\n".ptr, "world".ptr);
+}
+
+/***************************************/
 
 int main()
 {
@@ -1169,6 +1216,8 @@ int main()
     testCopy();
     test14179();
     test15417();
+    test21425();
+    test23409();
 
     return 0;
 }


### PR DESCRIPTION
The problem was that va_start didn't actually do anything, as the initialization was done in the function prolog. This moves the initialization from the prolog to va_start.

I'm not entirely happy with it, so WIP.