### PR TITLE
convert actionTable to pointer to Barray

### DIFF
--- a/compiler/src/dmd/backend/blockopt.d
+++ b/compiler/src/dmd/backend/blockopt.d
@@ -318,7 +318,11 @@ void block_free(block *b)
             break;
 
         case BCjcatch:
-            free(b.actionTable);
+            if (b.actionTable)
+            {
+                b.actionTable.dtor();
+                free(b.actionTable);
+            }
             break;
 
         case BCasm:

--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -375,9 +375,9 @@ nothrow:
 
         struct
         {
-            Symbol* Bcatchtype;     // one type for each catch block
-            uint* actionTable;      // EH_DWARF: indices into typeTable, first is # of entries
-        }                           // BCjcatch
+            Symbol* Bcatchtype;       // one type for each catch block
+            Barray!uint* actionTable; // EH_DWARF: indices into typeTable
+        }                             // BCjcatch
 
         struct
         {

--- a/compiler/src/dmd/backend/dwarfeh.d
+++ b/compiler/src/dmd/backend/dwarfeh.d
@@ -125,16 +125,16 @@ static if (0)
             {
                 d.lpad = cast(uint)bf.Boffset;
                 d.bcatch = bf;
-                uint *pat = bf.actionTable;
-                uint length = pat[0];
+                uint[] pat = (*bf.actionTable)[];
+                size_t length = pat.length;
                 assert(length);
                 uint offset = -1;
-                for (uint u = length; u; --u)
+                for (size_t u = length; u; --u)
                 {
                     /* Buy doing depth-first insertion into the Action Table,
                      * we can combine common tails.
                      */
-                    offset = actionTableInsert(&atbuf, pat[u], offset);
+                    offset = actionTableInsert(&atbuf, pat[u - 1], offset);
                 }
                 d.action = offset + 1;
             }

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -50,6 +50,7 @@ import dmd.toir;
 import dmd.tokens;
 import dmd.visitor;
 
+import dmd.backend.barray;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.cgcv;
@@ -1052,11 +1053,11 @@ void Statement_toIR(Statement s, IRState *irs, StmtState* stmtstate)
             /* Make a copy of the switch case table, which will later become the Action Table.
              * Need a copy since the bswitch may get rewritten by the optimizer.
              */
-            alias TAction = typeof(bcatch.actionTable[0]);
-            bcatch.actionTable = cast(TAction*)Mem.check(.malloc(TAction.sizeof * (numcases + 1)));
-            foreach (i; 0 .. numcases + 1)
-                bcatch.actionTable[i] = cast(TAction)bswitch.Bswitch[i];
-
+            alias TAction = typeof((*bcatch.actionTable)[0]);
+            bcatch.actionTable = cast(Barray!TAction*)Mem.check(.calloc(Barray!TAction.sizeof, 1));
+            bcatch.actionTable.setLength(numcases);
+            foreach (i; 0 .. numcases)
+                (*bcatch.actionTable)[i] = cast(TAction)bswitch.Bswitch[i + 1];
         }
         else
         {


### PR DESCRIPTION
A pointer to a Barray is safer than a pointer to an unchecked length-prefixed array with all its potential off-by-one errors.

Since its use is relatively rare in `struct block`, keep it pointer-sized and malloc it on demand.