### PR TITLE
Bswitch to D array

### DIFF
--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -361,7 +361,8 @@ nothrow:
                                 // the same function.
     union
     {
-        targ_llong*      Bswitch;      // BCswitch: pointer to switch data
+        long[] Bswitch;                // BCswitch: case expression values
+
         struct
         {
             regm_t usIasmregs;         // Registers modified

--- a/compiler/src/dmd/backend/debugprint.d
+++ b/compiler/src/dmd/backend/debugprint.d
@@ -395,9 +395,6 @@ void WRblock(block *b)
     }
     else
     {
-        targ_llong *pu;
-        int ncases;
-
         assert(b);
         printf("%2d: %s", b.Bnumber, bc_str(b.BC));
         if (b.Btry)
@@ -427,20 +424,20 @@ void WRblock(block *b)
                 printf(" B%d",list_block(bl).Bnumber);
             printf("\n");
         }
-        list_t bl = b.Bsucc;
+
         switch (b.BC)
         {
             case BCswitch:
-                pu = b.Bswitch;
-                assert(pu);
-                ncases = cast(int)*pu;
-                printf("\tncases = %d\n",ncases);
+                printf("\tncases = %d\n", cast(int)b.Bswitch.length);
+                list_t bl = b.Bsucc;
                 printf("\tdefault: B%d\n",list_block(bl) ? list_block(bl).Bnumber : 0);
-                while (ncases--)
-                {   bl = list_next(bl);
-                    printf("\tcase %lld: B%d\n", cast(long)*++pu,list_block(bl).Bnumber);
+                foreach (val; b.Bswitch)
+                {
+                    bl = list_next(bl);
+                    printf("\tcase %lld: B%d\n", cast(long)val, list_block(bl).Bnumber);
                 }
                 break;
+
             case BCiftrue:
             case BCgoto:
             case BCasm:
@@ -453,8 +450,7 @@ void WRblock(block *b)
             case BC_lpad:
             case BC_ret:
             case BC_except:
-
-                if (bl)
+                if (list_t bl = b.Bsucc)
                 {
                     printf("\tBsucc:");
                     for ( ; bl; bl = list_next(bl))
@@ -462,10 +458,12 @@ void WRblock(block *b)
                     printf("\n");
                 }
                 break;
+
             case BCret:
             case BCretexp:
             case BCexit:
                 break;
+
             default:
                 printf("bc = %d\n", b.BC);
                 assert(0);


### PR DESCRIPTION
Convert Bswitch from from a length-prefixed array. This is a tricky conversion, because the length prefix can introduce all kinds of off-by-one errors. This is why it is not quite an easy to review PR. Off-by-one error potential, however, is what makes this conversion worthwhile.