### PR TITLE
fix Issue 23936 - ImportC: pragma pack is not working for structs

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -3876,6 +3876,10 @@ final class CParser(AST) : Parser!AST
         else if (!tag)
             error("missing tag `identifier` after `%s`", Token.toChars(structOrUnion));
 
+        // many ways and places to declare alignment
+        if (packalign.isUnknown() && !this.packalign.isUnknown())
+            packalign.set(this.packalign.get());
+
         /* Need semantic information to determine if this is a declaration,
          * redeclaration, or reference to existing declaration.
          * Defer to the semantic() pass with a TypeTag.

--- a/compiler/test/compilable/pragmapack.c
+++ b/compiler/test/compilable/pragmapack.c
@@ -51,7 +51,7 @@ struct S2
 #pragma pack(pop)
 #pragma pack(show)
 
-_Static_assert(sizeof(struct S2) == 1 + 1, "2");
+_Static_assert(sizeof(struct S2) == 8, "2");
 
 #pragma pack(push, 8)
 #pragma pack(show)
@@ -63,7 +63,7 @@ struct S3
 #pragma pack(pop)
 #pragma pack(show)
 
-_Static_assert(sizeof(struct S3) == 4, "3");
+_Static_assert(sizeof(struct S3) == 8, "3");
 
 #pragma pack()
 #pragma pack(show)

--- a/compiler/test/compilable/test23936.i
+++ b/compiler/test/compilable/test23936.i
@@ -1,0 +1,32 @@
+// https://issues.dlang.org/show_bug.cgi?ide=23936
+
+#pragma pack(push,16)
+typedef struct AAATAG {
+    int LastExceptionFromRip;
+} AAA;
+#pragma pack(pop)
+
+#pragma pack(push, 16)
+typedef struct {
+    long long val;
+} BBB;
+#pragma pack(pop)
+
+
+__pragma(pack(push,16))
+typedef struct XXXTAG {
+    int LastExceptionFromRip;
+} XXX;
+__pragma(pack(pop))
+
+__pragma(pack(push, 16))
+typedef struct {
+    long long val;
+} YYY;
+__pragma(pack(pop))
+
+
+_Static_assert(_Alignof(AAA) == 16, "1");
+_Static_assert(_Alignof(BBB) == 16, "2");
+_Static_assert(_Alignof(XXX) == 16, "3");
+_Static_assert(_Alignof(YYY) == 16, "4");


### PR DESCRIPTION
C has too many different ways to set alignment.