### PR TITLE
Fix Issue 16384 - Invariant not called with multiple defined.

### DIFF
--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -101,9 +101,11 @@ extern (C++) bool hasSideEffect(Expression e, bool assumeImpureCalls = false)
 int callSideEffectLevel(FuncDeclaration f)
 {
     /* https://issues.dlang.org/show_bug.cgi?id=12760
-     * ctor call always has side effects.
+     * https://issues.dlang.org/show_bug.cgi?id=16384
+     *
+     * ctor calls and invariant calls always have side effects
      */
-    if (f.isCtorDeclaration())
+    if (f.isCtorDeclaration() || f.isInvariantDeclaration())
         return 0;
     assert(f.type.ty == Tfunction);
     TypeFunction tf = cast(TypeFunction)f.type;

--- a/compiler/test/runnable/testinvariant.d
+++ b/compiler/test/runnable/testinvariant.d
@@ -176,6 +176,58 @@ void test13147()
     s.test();
 }
 
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=16384
+
+struct S(T)
+{
+    T x = 5;
+    invariant { assert(x == 6); }
+    invariant { assert(x > 0); }
+
+    void foo() {}
+}
+
+void f(int i) pure { assert( i == 6); }
+
+struct S2(T)
+{
+    T x = 5;
+    invariant { f(x); }
+    invariant { assert(x > 0); }
+
+    void foo() {}
+}
+
+void test16384()
+{
+    string s;
+    S!int y;
+    try
+    {
+        y.foo();
+    }
+    catch(Error)
+    {
+        s = "needs to be thrown";
+    }
+
+    assert(s == "needs to be thrown");
+
+    S2!int y2;
+
+    try
+    {
+        y2.foo();
+    }
+    catch(Error)
+    {
+        s = "needs to be thrown2";
+    }
+
+    assert(s == "needs to be thrown2");
+}
+
 
 /***************************************************/
 
@@ -183,6 +235,7 @@ void main()
 {
     testinvariant();
     test6453();
+    test16384();
     test13113();
     test13147();
 }


### PR DESCRIPTION
It seems that the optimizer pruned the first invariant call on the basis that it has no side effects. Indeed, throwing an assert error is allowed in pure nothrow code. Since the invariant is essentially a func declaration and is in a templated struct it is inffered as being pure nothrow so the optimizer decides to drop it. To fix this, we assume that invariants always have side effects.