### PR TITLE
Fix issue 23947: Class method private is ignored if there's a public overload after it

### DIFF
--- a/compiler/test/fail_compilation/imports/issue23947a.d
+++ b/compiler/test/fail_compilation/imports/issue23947a.d
@@ -1,0 +1,8 @@
+module imports.issue23947a;
+
+struct X { }
+struct Y { }
+class Class {
+    private void handle(X x) { }
+    public void handle(Y y) { }
+}

--- a/compiler/test/fail_compilation/issue23947.d
+++ b/compiler/test/fail_compilation/issue23947.d
@@ -1,0 +1,11 @@
+// https://issues.dlang.org/show_bug.cgi?id=23947
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/issue23947.d(11): Deprecation: function `imports.issue23947a.Class.handle` of type `void(X x)` is not accessible from module `issue23947`
+---
+*/
+import imports.issue23947a;
+
+void main() { Class.init.handle(X.init); }


### PR DESCRIPTION
If checking access after overload resolution, only check the specific overload selected, not the most public overload of the set.

Can we please take this opportunity to make issue 21275 an error as well, so I don't have to emit a deprecation for this? It's been two and a half years.