### PR TITLE
druntime: Transform _d_arrayshrinkfit into a template

### DIFF
--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -3968,7 +3968,7 @@ Returns:
 */
 auto ref inout(T[]) assumeSafeAppend(T)(auto ref inout(T[]) arr) nothrow @system
 {
-    import rt.lifetime : _d_arrayshrinkfit;
+    import core.lifetime : _d_arrayshrinkfit;
     _d_arrayshrinkfit(arr);
     return arr;
 }

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -3951,10 +3951,6 @@ size_t reserve(T)(ref T[] arr, size_t newcapacity) pure nothrow @trusted
     a.reserve(10);
 }
 
-// HACK:  This is a lie.  `_d_arrayshrinkfit` is not `nothrow`, but this lie is necessary
-// for now to prevent breaking code.
-private extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow;
-
 /**
 Assume that it is safe to append to this array. Appends made to this array
 after calling this function may append in place, even if the array was a
@@ -3972,7 +3968,8 @@ Returns:
 */
 auto ref inout(T[]) assumeSafeAppend(T)(auto ref inout(T[]) arr) nothrow @system
 {
-    _d_arrayshrinkfit(typeid(T[]), *(cast(void[]*)&arr));
+    import rt.lifetime : _d_arrayshrinkfit;
+    _d_arrayshrinkfit(arr);
     return arr;
 }
 


### PR DESCRIPTION
Gets rid of TypeInfo usage.

Best viewed with whitespace off.