### PR TITLE
Disallow dynamic cast to extern(C++) class

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9197,9 +9197,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (e1c && toc.classKind == ClassKind.cpp &&
                 e1c.isBaseOf(toc, null))
             {
-                // @@@DEPRECATED_2.114@@@
+                // @@@DEPRECATED_2.120@@@
                 // When turning into error, uncomment the return statement
-                exp.deprecation("dynamic cast is not implemented for `extern(C++)` classes");
+                deprecation(exp.loc, "dynamic cast is not implemented for `extern(C++)` classes");
                 deprecationSupplemental(exp.loc, "use `cast(T)cast(void*)obj` instead");
                 //return setError();
             }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9191,9 +9191,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (exp.to == Type.terror)
                 return setError();
         }
-        if (auto ttc = exp.to.isTypeClass())
+        if (auto toc = exp.to.isClassHandle())
         {
-            if (exp.e1.type.isTypeClass() && ttc.sym.classKind == ClassKind.cpp)
+            auto e1c = exp.e1.type.isClassHandle();
+            if (e1c && toc.classKind == ClassKind.cpp &&
+                !toc.isBaseOf(e1c, null))
             {
                 // @@@DEPRECATED_2.114@@@
                 // When turning into error, uncomment the return statement

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9159,6 +9159,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             error(exp.loc, "cannot cast `%s`", exp.e1.toChars());
             return setError();
         }
+        else if (auto ttc = exp.to.isTypeClass())
+        {
+            if (exp.e1.type.isTypeClass() && ttc.sym.classKind == ClassKind.cpp)
+            {
+                exp.error("dynamic cast not supported for `extern(C++)` class");
+                return setError();
+            }
+        }
 
         // https://issues.dlang.org/show_bug.cgi?id=19954
         if (exp.e1.type.ty == Ttuple)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9200,7 +9200,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // @@@DEPRECATED_2.120@@@
                 // When turning into error, uncomment the return statement
                 deprecation(exp.loc, "dynamic cast is not implemented for `extern(C++)` classes");
-                deprecationSupplemental(exp.loc, "use `cast(T)cast(void*)obj` instead");
+                deprecationSupplemental(exp.loc, "use `*cast(%s*) &object` instead",
+                    exp.to.toChars(), exp.e1.toChars());
                 //return setError();
             }
         }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9195,11 +9195,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             auto e1c = exp.e1.type.isClassHandle();
             if (e1c && toc.classKind == ClassKind.cpp &&
-                !toc.isBaseOf(e1c, null))
+                e1c.isBaseOf(toc, null))
             {
                 // @@@DEPRECATED_2.114@@@
                 // When turning into error, uncomment the return statement
-                exp.deprecation("dynamic cast not supported for `extern(C++)` class");
+                exp.deprecation("dynamic cast is not implemented for `extern(C++)` classes");
+                deprecationSupplemental(exp.loc, "use `cast(T)cast(void*)obj` instead");
                 //return setError();
             }
         }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9195,8 +9195,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             if (exp.e1.type.isTypeClass() && ttc.sym.classKind == ClassKind.cpp)
             {
-                exp.error("dynamic cast not supported for `extern(C++)` class");
-                return setError();
+                // @@@DEPRECATED_2.114@@@
+                // When turning into error, uncomment the return statement
+                exp.deprecation("dynamic cast not supported for `extern(C++)` class");
+                //return setError();
             }
         }
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9159,14 +9159,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             error(exp.loc, "cannot cast `%s`", exp.e1.toChars());
             return setError();
         }
-        else if (auto ttc = exp.to.isTypeClass())
-        {
-            if (exp.e1.type.isTypeClass() && ttc.sym.classKind == ClassKind.cpp)
-            {
-                exp.error("dynamic cast not supported for `extern(C++)` class");
-                return setError();
-            }
-        }
 
         // https://issues.dlang.org/show_bug.cgi?id=19954
         if (exp.e1.type.ty == Ttuple)
@@ -9198,6 +9190,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             if (exp.to == Type.terror)
                 return setError();
+        }
+        if (auto ttc = exp.to.isTypeClass())
+        {
+            if (exp.e1.type.isTypeClass() && ttc.sym.classKind == ClassKind.cpp)
+            {
+                exp.error("dynamic cast not supported for `extern(C++)` class");
+                return setError();
+            }
         }
 
         if (exp.to.ty == Ttuple)

--- a/compiler/test/fail_compilation/cppcast.d
+++ b/compiler/test/fail_compilation/cppcast.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
 fail_compilation/cppcast.d(14): Deprecation: dynamic cast is not implemented for `extern(C++)` classes
-fail_compilation/cppcast.d(14):        use `cast(T)cast(void*)obj` instead
+fail_compilation/cppcast.d(14):        use `*cast(cppcast.D*) &object` instead
 ---
 */
 extern(C++) class C { void f() { } }

--- a/compiler/test/fail_compilation/cppcast.d
+++ b/compiler/test/fail_compilation/cppcast.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/cppcast.d(12): Error: dynamic cast not supported for `extern(C++)` class
+---
+*/
+extern(C++) class C { void f() { } }
+extern(C++) class D : C { }
+
+void main() @safe
+{
+    assert(cast(D)(new C) is null); // would fail as RTTI not checked
+}

--- a/compiler/test/fail_compilation/cppcast.d
+++ b/compiler/test/fail_compilation/cppcast.d
@@ -1,7 +1,8 @@
 /*
+REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/cppcast.d(12): Error: dynamic cast not supported for `extern(C++)` class
+fail_compilation/cppcast.d(13): Deprecation: dynamic cast not supported for `extern(C++)` class
 ---
 */
 extern(C++) class C { void f() { } }

--- a/compiler/test/fail_compilation/cppcast.d
+++ b/compiler/test/fail_compilation/cppcast.d
@@ -2,7 +2,8 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/cppcast.d(13): Deprecation: dynamic cast not supported for `extern(C++)` class
+fail_compilation/cppcast.d(14): Deprecation: dynamic cast is not implemented for `extern(C++)` classes
+fail_compilation/cppcast.d(14):        use `cast(T)cast(void*)obj` instead
 ---
 */
 extern(C++) class C { void f() { } }

--- a/compiler/test/fail_compilation/cppcast.d
+++ b/compiler/test/fail_compilation/cppcast.d
@@ -11,4 +11,5 @@ extern(C++) class D : C { }
 void main() @safe
 {
     assert(cast(D)(new C) is null); // would fail as RTTI not checked
+    auto c = cast(C)(new D); // OK
 }

--- a/compiler/test/runnable/fix22115.d
+++ b/compiler/test/runnable/fix22115.d
@@ -24,7 +24,7 @@ static if (1)
         int a;
 
         void func() { }
-        final inout(AddExp) isAddExp() inout { return a == 3 ? cast(typeof(return))this : null; }
+        final inout(AddExp) isAddExp() inout { return a == 3 ? cast(typeof(return))cast(void*)this : null; }
     }
 
     extern (C++) class AddExp : Exp

--- a/compiler/test/runnable_cxx/cppa.d
+++ b/compiler/test/runnable_cxx/cppa.d
@@ -1296,7 +1296,7 @@ void test15589()
     A15589 c = new B15589;
     assert(A15589.dtorSeq == null);
     assert(c.foo() == 100);
-    assert((cast(B15589)c).bar() == 200);
+    assert((cast(B15589)cast(void*)c).bar() == 200);
     c.__xdtor(); // virtual dtor call
     assert(A15589.dtorSeq[] == [ 20, 3, 10, 2, 1 ]); // destroyed full hierarchy!
 


### PR DESCRIPTION
See Issue 21690 - Unable to dynamic cast extern(C++) classes.

Instead, use `cast(Derived)cast(void*)base`.