### PR TITLE
Move lowerings to `_d_array{setassign,assign_{l,r}}` to a `LoweredAssignExp` AST node

### DIFF
--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -118,7 +118,7 @@ extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, bool mustN
                     {
                         auto sd = ts.sym;
                         const id = ce.f.ident;
-                        if (sd.postblit && isArrayConstructionOrAssign(id))
+                        if (sd.postblit && isArrayConstruction(id))
                         {
                             checkFuncThrows(ce, sd.postblit);
                             return;

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -3891,7 +3891,7 @@ public:
             newval = copyLiteral(newval).copy();
             assignInPlace(oldval, newval);
         }
-        else if (wantCopy && e.op == EXP.assign)
+        else if (wantCopy && (e.op == EXP.assign || e.op == EXP.loweredAssignExp))
         {
             // Currently postblit/destructor calls on static array are done
             // in the druntime internal functions so they don't appear in AST.
@@ -4300,7 +4300,7 @@ public:
             rb.newval = newval;
             rb.refCopy = wantRef || cow;
             rb.needsPostblit = sd && sd.postblit && e.op != EXP.blit && e.e2.isLvalue();
-            rb.needsDtor = sd && sd.dtor && e.op == EXP.assign;
+            rb.needsDtor = sd && sd.dtor && (e.op == EXP.assign || e.op == EXP.loweredAssignExp);
             if (Expression ex = rb.assignTo(existingAE, cast(size_t)lowerbound, cast(size_t)upperbound))
                 return ex;
 
@@ -4774,12 +4774,11 @@ public:
                     result = CTFEExp.voidexp;
                 return;
             }
-            else if (isArrayConstructionOrAssign(fd.ident))
+            else if (isArrayConstruction(fd.ident))
             {
-                // In expressionsem.d, the following lowerings were performed:
-                // * `T[x] ea = eb;` to `_d_array{,set}ctor(ea[], eb[]);`.
-                // * `ea = eb` to `_d_array{,setassign,assign_l,assign_r}(ea[], eb)`.
-                // The following code will rewrite them back to `ea = eb` and
+                // In expressionsem.d, `T[x] ea = eb;` was lowered to:
+                // `_d_array{,set}ctor(ea[], eb[]);`.
+                // The following code will rewrite it back to `ea = eb` and
                 // then interpret that expression.
 
                 if (fd.ident == Id._d_arrayctor)
@@ -4792,17 +4791,14 @@ public:
                     ea = ea.isCastExp.e1;
 
                 Expression eb = (*e.arguments)[1];
-                if (eb.isCastExp() && fd.ident != Id._d_arraysetctor)
+                if (eb.isCastExp() && fd.ident == Id._d_arrayctor)
                     eb = eb.isCastExp.e1;
 
-                Expression rewrittenExp;
-                if (fd.ident == Id._d_arrayctor || fd.ident == Id._d_arraysetctor)
-                    rewrittenExp = new ConstructExp(e.loc, ea, eb);
-                else
-                    rewrittenExp = new AssignExp(e.loc, ea, eb);
+                ConstructExp ce = new ConstructExp(e.loc, ea, eb);
+                ce.type = ea.type;
 
-                rewrittenExp.type = ea.type;
-                result = interpret(rewrittenExp, istate);
+                ce.type = ea.type;
+                result = interpret(ce, istate);
 
                 return;
             }

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -7390,23 +7390,20 @@ extern(D) Modifiable checkModifiable(Expression exp, Scope* sc, ModifyFlags flag
 }
 
 /**
- * Verify if the given identifier is any of
- * _d_array{ctor,setctor,setassign,assign_l, assign_r}.
+ * Verify if the given identifier is _d_array{,set}ctor.
  *
  * Params:
  *  id = the identifier to verify
  *
  * Returns:
- *  `true` if the identifier corresponds to a construction of assignement
- *  runtime hook, `false` otherwise.
+ *  `true` if the identifier corresponds to a construction runtime hook,
+ *  `false` otherwise.
  */
-bool isArrayConstructionOrAssign(const Identifier id)
+bool isArrayConstruction(const Identifier id)
 {
     import dmd.id : Id;
 
-    return id == Id._d_arrayctor || id == Id._d_arraysetctor ||
-        id == Id._d_arrayassign_l || id == Id._d_arrayassign_r ||
-        id == Id._d_arraysetassign;
+    return id == Id._d_arrayctor || id == Id._d_arraysetctor;
 }
 
 /******************************

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -10308,6 +10308,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (global.params.verbose)
             message("lowered   %s =>\n          %s", ae.toChars(), res.toChars());
 
+        res = new LoweredAssignExp(ae, res);
+        res.type = ae.type;
+
         return res;
     }
 

--- a/compiler/test/runnable/test23959.d
+++ b/compiler/test/runnable/test23959.d
@@ -1,0 +1,30 @@
+// https://issues.dlang.org/show_bug.cgi?id=23959;
+
+struct ST()
+{
+    int i;
+    this(this) {}
+}
+
+alias S = ST!();
+
+void poison()
+{
+    static S g;
+    auto s = g;
+}
+
+S[1] sa;
+
+void fun(S[] values...)
+{
+    sa[] = values;
+}
+
+int main()
+{
+    fun(S(1));
+    assert(sa[0].i);
+
+    return 0;
+}


### PR DESCRIPTION
This PR does the following:
- uses a `LoweredAssignExp` node for assignments that lower to `_d_arrayassign_{l,r}`
- removes the code in `dinterpret.d` that recreates the original `AssigExp`
- simplifies `isArrayConstructionOrAssign()` to just `isArrayConstruction()` since assignments are now handled by a separate AST node
- fixes issue 23959