### PR TITLE
fix Issue 23969 - Windows cannot export/import TLS from DLLs

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -736,7 +736,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             fields.push(vthis2);
     }
 
-    override final bool isExport() const
+    override final bool isExport()
     {
         return visibility.kind == Visibility.Kind.export_;
     }

--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -123,7 +123,7 @@ public:
     bool isDeprecated() const override final; // is aggregate deprecated?
     void setDeprecated();
     bool isNested() const;
-    bool isExport() const override final;
+    bool isExport() override final;
     Dsymbol *searchCtor();
 
     Visibility visible() override final;

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1325,12 +1325,17 @@ extern (C++) class VarDeclaration : Declaration
         return isField();
     }
 
-    override final bool isExport() const
+    override final bool isExport()
     {
-        return visibility.kind == Visibility.Kind.export_ || dllExport;
+        bool result = visibility.kind == Visibility.Kind.export_ || dllExport;
+
+	if (target.os == Target.OS.Windows && isThreadlocal())
+	    result = false;		// doesn't work on VC, either
+
+        return result;
     }
 
-    override final bool isImportedSymbol() const
+    override final bool isImportedSymbol()
     {
         /* If global variable has `export` and `extern` then it is imported
          *   export int sym1;            // definition:  exported
@@ -1342,6 +1347,10 @@ extern (C++) class VarDeclaration : Declaration
             visibility.kind == Visibility.Kind.export_ &&
             storage_class & STC.extern_ &&
             (storage_class & STC.static_ || parent.isModule());
+
+	if (target.os == Target.OS.Windows && isThreadlocal())
+	    result = false;		// doesn't work on VC, either
+
         //printf("isImportedSymbol() %s %d\n", toChars(), result);
         return result;
     }

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -286,8 +286,8 @@ public:
     const char *kind() const override;
     AggregateDeclaration *isThis() override final;
     bool needThis() override final;
-    bool isExport() const override final;
-    bool isImportedSymbol() const override final;
+    bool isExport() override final;
+    bool isImportedSymbol() override final;
     bool isCtorinit() const;
     bool isDataseg() override final;
     bool isThreadlocal() override final;
@@ -720,8 +720,8 @@ public:
     bool isCMain() const;
     bool isWinMain() const;
     bool isDllMain() const;
-    bool isExport() const override final;
-    bool isImportedSymbol() const override final;
+    bool isExport() override final;
+    bool isImportedSymbol() override final;
     bool isCodeseg() const override final;
     bool isOverloadable() const override final;
     bool isAbstract() override final;

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -1042,13 +1042,13 @@ extern (C++) class Dsymbol : ASTNode
     }
 
     // is Dsymbol exported?
-    bool isExport() const
+    bool isExport()
     {
         return false;
     }
 
     // is Dsymbol imported?
-    bool isImportedSymbol() const
+    bool isImportedSymbol()
     {
         return false;
     }

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -240,8 +240,8 @@ public:
     virtual uinteger_t size(const Loc &loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration *isThis();     // is a 'this' required to access the member
-    virtual bool isExport() const;              // is Dsymbol exported?
-    virtual bool isImportedSymbol() const;      // is Dsymbol imported?
+    virtual bool isExport();                    // is Dsymbol exported?
+    virtual bool isImportedSymbol();            // is Dsymbol imported?
     virtual bool isDeprecated() const;                // is Dsymbol deprecated?
     virtual bool isOverloadable() const;
     virtual LabelDsymbol *isLabel();            // is this a LabelDsymbol?

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -508,8 +508,8 @@ public:
     virtual uinteger_t size(const Loc& loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration* isThis();
-    virtual bool isExport() const;
-    virtual bool isImportedSymbol() const;
+    virtual bool isExport();
+    virtual bool isImportedSymbol();
     virtual bool isDeprecated() const;
     virtual bool isOverloadable() const;
     virtual LabelDsymbol* isLabel();
@@ -2594,8 +2594,8 @@ public:
     bool isWinMain() const;
     bool isDllMain() const;
     bool isRtInit() const;
-    bool isExport() const final override;
-    bool isImportedSymbol() const final override;
+    bool isExport() final override;
+    bool isImportedSymbol() final override;
     bool isCodeseg() const final override;
     bool isOverloadable() const final override;
     bool isAbstract() final override;
@@ -5480,7 +5480,7 @@ public:
     bool isDeprecated() const final override;
     void setDeprecated();
     bool isNested() const;
-    bool isExport() const final override;
+    bool isExport() final override;
     Dsymbol* searchCtor();
     Visibility visible() final override;
     Type* handleType();
@@ -6135,8 +6135,8 @@ public:
     const char* kind() const override;
     AggregateDeclaration* isThis() final override;
     bool needThis() final override;
-    bool isExport() const final override;
-    bool isImportedSymbol() const final override;
+    bool isExport() final override;
+    bool isImportedSymbol() final override;
     bool isCtorinit() const;
     bool isDataseg() final override;
     bool isThreadlocal() final override;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1350,12 +1350,12 @@ extern (C++) class FuncDeclaration : Declaration
         return ident == Id.rt_init && resolvedLinkage() == LINK.c && !isMember() && !isNested();
     }
 
-    override final bool isExport() const
+    override final bool isExport()
     {
         return visibility.kind == Visibility.Kind.export_ || dllExport;
     }
 
-    override final bool isImportedSymbol() const
+    override final bool isImportedSymbol()
     {
         //printf("isImportedSymbol()\n");
         //printf("protection = %d\n", visibility);


### PR DESCRIPTION
So we aren't going to do it, either.

Microsoft sez:

"On Windows operating systems before Windows Vista, __declspec( thread ) has some limitations. If a DLL declares any data or object as __declspec( thread ), it can cause a protection fault if dynamically loaded. After the DLL is loaded with [LoadLibrary](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw), it causes system failure whenever the code references the __declspec( thread ) data."

https://learn.microsoft.com/en-us/cpp/parallel/thread-local-storage-tls?view=msvc-170

I suppose we could invent our own TLS system, like we did for OSX, but it doesn't seem worth it just for the DLLs. After all, one should export/import only functions anyway.