### PR TITLE
[stable] Fix tests race condition for fail_compilation/failcstuff4.{c,i}

### DIFF
--- a/compiler/test/fail_compilation/failcstuff4b.i
+++ b/compiler/test/fail_compilation/failcstuff4b.i
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/failcstuff4.i(605): Error: invalid flag for line marker directive
+fail_compilation/failcstuff4b.i(605): Error: invalid flag for line marker directive
 ---
 */
 


### PR DESCRIPTION
When compiling `failcstuff4.c`, the compiler generates a temporary `failcstuff4.i` for the preprocessed file, and removes that file after reading it. Too bad there's a `failcstuff4.i` under version control - rename it.

I've seen according sporadic failures for the DMD testsuite, when the `*.c` is tested earlier, and the `failcstuff4.i` test later fails because the source file was removed from disk.