### PR TITLE
fix Issue 23974 - A ModuleInfo in a separate Windows DLL should not b…

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -347,6 +347,7 @@ extern (C++) final class Module : Package
     FileType filetype;          // source file type
     bool hasAlwaysInlines;      // contains references to functions that must be inlined
     bool isPackageFile;         // if it is a package.d
+    bool isImportedModule;      // module contains exported declarations, meaning it is an interface to a DLL
     Package pkg;                // if isPackageFile is true, the Package that contains this package.d
     Strings contentImportedFiles; // array of files whose content was imported
     int needmoduleinfo;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -645,6 +645,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (ad)
             dsym.storage_class |= ad.storage_class & STC.TYPECTOR;
 
+        if (dsym.isImportedSymbol())
+        {
+            /* A module with imported symbols is an imported module
+             */
+            sc._module.isImportedModule = true;
+        }
+
         /* If auto type inference, do the inference
          */
         int inferred = 0;
@@ -3675,6 +3682,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (funcdecl.isAbstract() && funcdecl.isFinalFunc())
             .error(funcdecl.loc, "%s `%s` cannot be both `final` and `abstract`", funcdecl.kind, funcdecl.toPrettyChars);
+
+        if (funcdecl.isImportedSymbol())
+        {
+            /* A module with imported symbols is an imported module
+             */
+            sc._module.isImportedModule = true;
+        }
 
         if (funcdecl.printf || funcdecl.scanf)
         {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7163,6 +7163,7 @@ public:
     FileType filetype;
     bool hasAlwaysInlines;
     bool isPackageFile;
+    bool isImportedModule;
     Package* pkg;
     Array<const char* > contentImportedFiles;
     int32_t needmoduleinfo;

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -75,6 +75,7 @@ public:
     FileType filetype;  // source file type
     d_bool hasAlwaysInlines; // contains references to functions that must be inlined
     d_bool isPackageFile; // if it is a package.d
+    d_bool isImportedModule; // module contains exported declarations, meaning it is an interface to a DLL
     Package *pkg;       // if isPackageFile is true, the Package that contains this package.d
     Strings contentImportedFiles;  // array of files whose content was imported
     int needmoduleinfo;

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -105,7 +105,7 @@ void genModuleInfo(Module m)
     for (size_t i = 0; i < m.aimports.length; i++)
     {
         Module mod = m.aimports[i];
-        if (!mod.needmoduleinfo)
+        if (!mod.needmoduleinfo || mod.isImportedModule)
             aimports_dim--;
     }
 
@@ -174,7 +174,7 @@ void genModuleInfo(Module m)
         {
             Module mod = m.aimports[i];
 
-            if (!mod.needmoduleinfo)
+            if (!mod.needmoduleinfo || mod.isImportedModule)
                 continue;
 
             Symbol *s = toSymbol(mod);


### PR DESCRIPTION
…e referred to by MIimportedModules

(Somebody put tabs in transitivevisitor.d, and it got fixed by my detabber.)