### PR TITLE
Fix 23979 - ICE on failed alias this attempt on pointer expression

### DIFF
--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -416,9 +416,11 @@ Expression op_overload(Expression e, Scope* sc, EXP* pop = null)
                      *      op(e1.aliasthis)
                      */
                     //printf("att una %s e1 = %s\n", EXPtoString(op).ptr, this.e1.type.toChars());
-                    e.e1 = resolveAliasThis(sc, e.e1, true);
-                    if (e.e1)
+                    if (auto e1 = resolveAliasThis(sc, e.e1, true))
+                    {
+                        e.e1 = e1;
                         continue;
+                    }
                     break;
                 }
                 break;

--- a/compiler/test/compilable/test23979.d
+++ b/compiler/test/compilable/test23979.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -o-
+// https://issues.dlang.org/show_bug.cgi?id=23979
+// Issue 23979 - ICE on failed alias this attempt on pointer expression
+
+class A {}
+
+void h()
+{
+    const auto classPtr = SPtr.init;
+    assert(!__traits(compiles, *classPtr));
+}
+
+struct SPtr
+{
+    A ptr() { return A.init; }
+    alias ptr this;
+}


### PR DESCRIPTION
`e.e1 = resolveAliasThis` would rewrite the input `UnaExp`, which could give it a `null` child it it didn't succeed in finding a `opUnary` or pointer type after attempting alias this.