### PR TITLE
Fix Issue 23980 - OpenBSD: Add getthrname(2) and setthrname(2) to unistd.d

### DIFF
--- a/druntime/src/core/sys/openbsd/unistd.d
+++ b/druntime/src/core/sys/openbsd/unistd.d
@@ -12,6 +12,10 @@ extern (C):
 nothrow:
 @nogc:
 
+public import core.sys.posix.sys.types;
+
 int getentropy(void*, size_t);
+int getthrname(pid_t, char*, size_t);
 int pledge(const scope char*, const scope char*);
+int setthrname(pid_t, const scope char*);
 int unveil(const scope char*, const scope char*);


### PR DESCRIPTION
As it says on the tin.