### PR TITLE
Fix 23978 - ICE: dip1021 memory corruption

### DIFF
--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -93,22 +93,7 @@ bool checkMutableArguments(Scope* sc, FuncDeclaration fd, TypeFunction tf,
         bool isMutable;         // true if reference to mutable
     }
 
-    /* Store escapeBy as static data escapeByStorage so we can keep reusing the same
-     * arrays rather than reallocating them.
-     */
-    __gshared EscapeBy[] escapeByStorage;
-    auto escapeBy = escapeByStorage;
-    if (escapeBy.length < len)
-    {
-        auto newPtr = cast(EscapeBy*)mem.xrealloc(escapeBy.ptr, len * EscapeBy.sizeof);
-        // Clear the new section
-        memset(newPtr + escapeBy.length, 0, (len - escapeBy.length) * EscapeBy.sizeof);
-        escapeBy = newPtr[0 .. len];
-        escapeByStorage = escapeBy;
-    }
-    else
-        escapeBy = escapeBy[0 .. len];
-
+    auto escapeBy = new EscapeBy[len];
     const paramLength = tf.parameterList.length;
 
     // Fill in escapeBy[] with arguments[], ethis, and outerVars[]
@@ -226,13 +211,6 @@ bool checkMutableArguments(Scope* sc, FuncDeclaration fd, TypeFunction tf,
     {
         escape(i, eb, true);
         escape(i, eb, false);
-    }
-
-    /* Reset the arrays in escapeBy[] so we can reuse them next time through
-     */
-    foreach (ref eb; escapeBy)
-    {
-        eb.er.reset();
     }
 
     return errors;

--- a/compiler/test/compilable/test23978.d
+++ b/compiler/test/compilable/test23978.d
@@ -1,0 +1,30 @@
+// REQUIRED_ARGS: -preview=dip1021 -lowmem
+// https://issues.dlang.org/show_bug.cgi?id=23978
+
+// Note: this is a memory corruption bug.
+// Memory returned by `GC.realloc` retains references to old memory in it,
+// mostly because of the smallarray optimization for `Array(T)`.
+// If this fails again, it might not be consistent, so try running it multiple times.
+
+class LUBench { }
+void lup(ulong , ulong , int , int = 1)
+{
+    new LUBench;
+}
+void lup_3200(ulong iters, ulong flops)
+{
+    lup(iters, flops, 3200);
+}
+void raytrace()
+{
+    struct V
+    {
+        float x, y, z;
+        auto normalize() { }
+        struct Tid { }
+        auto spawnLinked() { }
+        string[] namesByTid;
+        class MessageBox { }
+        auto cross() { }
+    }
+}


### PR DESCRIPTION
@ibuclaw It's not actually a regression, -preview=dip1021 has been broken from the start. It just happened to manifest in the report's piece of code after the _d_newclassT PR. 

I don't want to add a slow test for this, so I added a comment instead of PERMUTE_ARGS to run it 256 times.