### PR TITLE
fix Issue 18528 - dmd should deduplicate identical errors

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1457,9 +1457,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (sym)
                 {
                     import dmd.access : symbolIsVisible;
-                    if (!symbolIsVisible(sc, sym))
+                    if (!symbolIsVisible(sc, sym) && !sym.errors)
+                    {
                         imp.mod.error(imp.loc, "member `%s` is not visible from module `%s`",
                             imp.names[i].toChars(), sc._module.toChars());
+                        sym.errors = true;
+                    }
                     ad.dsymbolSemantic(sc);
                     // If the import declaration is in non-root module,
                     // analysis of the aliased symbol is deferred.

--- a/compiler/test/fail_compilation/fail15896.d
+++ b/compiler/test/fail_compilation/fail15896.d
@@ -14,5 +14,6 @@ int func()
 {
     thebar +=1;
     packagebar += 1;
+    thebar +=1;
     return 0;
 }


### PR DESCRIPTION
3rd attempt at a fix (see https://github.com/dlang/dmd/pull/15303 and https://github.com/dlang/dmd/pull/15306).

Rather than a general approach, this is targeted at the specific message in the bug report. Although the current compiler handles these as an error rather than a deprecation.