### PR TITLE
fix Issue 10910 - Duplicate error messages for array bounds errors

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1081,7 +1081,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         if (ai && tb.ty == Taarray)
                             e = ai.toAssocArrayLiteral();
                         else
-                            e = dsym._init.initializerToExpression(null, (sc.flags & SCOPE.Cfile) != 0);
+                            e = dsym._init.initializerToExpression(dsym.type, (sc.flags & SCOPE.Cfile) != 0);
                         if (!e)
                         {
                             // Run semantic, but don't need to interpret

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -8675,6 +8675,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             break;
 
         case Tarray:
+            exp.e2 = exp.e2.optimize(WANTvalue);
             exp.e2 = exp.e2.implicitCastTo(sc, Type.tsize_t);
             if (exp.e2.type == Type.terror)
                 return setError();
@@ -9736,6 +9737,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
 
+            e2x = e2x.optimize(WANTvalue);
             if (e2x.implicitConvTo(e1x.type))
             {
                 if (exp.op != EXP.blit && (e2x.op == EXP.slice && (cast(UnaExp)e2x).e1.isLvalue() || e2x.op == EXP.cast_ && (cast(UnaExp)e2x).e1.isLvalue() || e2x.op != EXP.slice && e2x.isLvalue()))
@@ -10108,6 +10110,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 e2x = e2x.castTo(sc, exp.e1.type);
             else
             {
+                e2x = e2x.optimize(WANTvalue);
                 e2x = e2x.implicitCastTo(sc, exp.e1.type);
 
                 // Fix Issue 13435: https://issues.dlang.org/show_bug.cgi?id=13435

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -272,7 +272,7 @@ package void setLengthVarIfKnown(VarDeclaration lengthVar, Type type)
  */
 Expression Expression_optimize(Expression e, int result, bool keepLvalue)
 {
-    //printf("Expression_optimize() e: %s result: %d keepLvalue %d\n", e.toChars(), result, keepLvalue);
+    //printf("+Expression_optimize()   e: %s result: %d keepLvalue %d\n", e.toChars(), result, keepLvalue);
     Expression ret = e;
 
     void error()
@@ -1432,5 +1432,6 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
         if (ex == ret)
             break;
     }
+    //printf("-Expression_optimize() ret: %s\n", ret.toChars());
     return ret;
 }

--- a/compiler/test/compilable/test9565.d
+++ b/compiler/test/compilable/test9565.d
@@ -35,11 +35,11 @@ void main()
       static if (is(size_t == ulong))
       {
         static assert((arr[-4L ]).stringof == "arr[" ~ castPrefix ~ "-4L]");
-        static assert((arr[-4LU]).stringof == "arr[-4LU]");
+        static assert((arr[-4LU]).stringof == "arr[18446744073709551612LU]");
 
         // IntegerLiteral needs suffix if the value is greater than long.max
         static assert((arr[long.max + 0]).stringof == "arr[9223372036854775807]");
-        static assert((arr[long.max + 1]).stringof == "arr[" ~ castPrefix ~ "(9223372036854775807L + 1L)]");
+        static assert((arr[long.max + 1]).stringof == "arr[" ~ castPrefix ~ "cast(long)-9223372036854775808]");
       }
 
         foreach (Int; TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong))
@@ -64,8 +64,11 @@ void main()
             else
                 static assert(!__traits(compiles, arr[m4]));
 
-            enum string result2 = (arr[cast(Int)-4]).stringof;
-            static assert(result2.startsWith("arr[" ~ castPrefix));
+            static if (is(size_t == ulong))
+            {
+                enum string result2 = (arr[cast(Int)-4]).stringof;
+                static assert(result2.startsWith("arr[" ~ castPrefix));
+            }
         }
     }
 

--- a/compiler/test/fail_compilation/fail201.d
+++ b/compiler/test/fail_compilation/fail201.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail201.d(10): Error: shift by 33 is outside the range `0..31`
-fail_compilation/fail201.d(10): Error: shift by 33 is outside the range `0..31`
 ---
 */
+
 void main() {
         int c;
         c = c >>> 33;

--- a/compiler/test/fail_compilation/fail202.d
+++ b/compiler/test/fail_compilation/fail202.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail202.d(10): Error: shift by 33 is outside the range `0..31`
-fail_compilation/fail202.d(10): Error: shift by 33 is outside the range `0..31`
 ---
 */
+
 void main() {
         int c;
         c = c >> 33;

--- a/compiler/test/fail_compilation/fail203.d
+++ b/compiler/test/fail_compilation/fail203.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail203.d(10): Error: shift by 33 is outside the range `0..31`
-fail_compilation/fail203.d(10): Error: shift by 33 is outside the range `0..31`
 ---
 */
+
 void main() {
         int c;
         c = c << 33;

--- a/compiler/test/fail_compilation/fail232.d
+++ b/compiler/test/fail_compilation/fail232.d
@@ -2,13 +2,13 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail232.d(15): Error: shift by 33 is outside the range `0..31`
-fail_compilation/fail232.d(15): Error: shift by 33 is outside the range `0..31`
 fail_compilation/fail232.d(16): Error: shift by 33 is outside the range `0..31`
-fail_compilation/fail232.d(16): Error: shift by 33 is outside the range `0..31`
-fail_compilation/fail232.d(17): Error: shift by 33 is outside the range `0..31`
 fail_compilation/fail232.d(17): Error: shift by 33 is outside the range `0..31`
 ---
 */
+
+
+
 void bug1601() {
     int i;
 

--- a/compiler/test/fail_compilation/fail57.d
+++ b/compiler/test/fail_compilation/fail57.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail57.d(11): Error: divide by 0
-fail_compilation/fail57.d(11): Error: divide by 0
 ---
 */
+
 
 int main()
 {

--- a/compiler/test/fail_compilation/test10910.d
+++ b/compiler/test/fail_compilation/test10910.d
@@ -1,0 +1,18 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/test10910.d(103): Error: string index 17 is out of bounds `[0 .. 6]`
+fail_compilation/test10910.d(104): Error: string index 12 is out of bounds `[0 .. 3]`
+fail_compilation/test10910.d(105): Error: string index 9 is out of bounds `[0 .. 4]`
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=10910
+
+#line 100
+
+void example()
+{
+   char c = "abcdef"[17];
+   char[7] x = "abc"[12];
+   int ww = "abc"["afds"[9]];
+}


### PR DESCRIPTION
I'll work on a more general solution after this is pulled.