### PR TITLE
Fix Issue 23973 - static constructors should have to be nothrow

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4374,7 +4374,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         }
         if (!scd.type)
-            scd.type = new TypeFunction(ParameterList(), Type.tvoid, LINK.d, scd.storage_class);
+            scd.type = new TypeFunction(ParameterList(), Type.tvoid, LINK.d,
+                    /* static constructors are nothrow because the runtime hasn't been yet initialized */
+                    scd.storage_class | STC.nothrow_);
 
         /* If the static ctor appears within a template instantiation,
          * it could get called multiple times by the module constructors

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -738,7 +738,7 @@ extern (C++) abstract class Expression : ASTNode
     Loc loc;        // file location
     const EXP op;   // to minimize use of dynamic_cast
 
-    extern (D) this(const ref Loc loc, EXP op) scope
+    extern (D) this(const ref Loc loc, EXP op) scope nothrow
     {
         //printf("Expression::Expression(op = %d) this = %p\n", op, this);
         this.loc = loc;
@@ -2582,7 +2582,7 @@ extern (C++) final class StringExp : Expression
 
     enum char NoPostfix = 0;
 
-    extern (D) this(const ref Loc loc, const(void)[] string) scope
+    extern (D) this(const ref Loc loc, const(void)[] string) scope nothrow
     {
         super(loc, EXP.string_);
         this.string = cast(char*)string.ptr; // note that this.string should be const

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -751,7 +751,12 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 // Check for errors related to 'nothrow'.
                 const blockexit = funcdecl.fbody.blockExit(funcdecl, f.isnothrow);
                 if (f.isnothrow && blockexit & BE.throw_)
-                    error(funcdecl.loc, "%s `%s` may throw but is marked as `nothrow`", funcdecl.kind(), funcdecl.toPrettyChars());
+                {
+                    if (funcdecl.isStaticCtorDeclaration())
+                        error(funcdecl.loc, "A module constructor may not throw as the runtime has not been yet initialized");
+                    else
+                        error(funcdecl.loc, "%s `%s` may throw but is marked as `nothrow`", funcdecl.kind(), funcdecl.toPrettyChars());
+                }
 
                 if (!(blockexit & (BE.throw_ | BE.halt) || funcdecl.hasCatches))
                 {
@@ -1182,7 +1187,12 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             {
                                 funcdecl.hasNoEH = false;
                                 if (isnothrow)
-                                    error(funcdecl.loc, "%s `%s` may throw but is marked as `nothrow`", funcdecl.kind(), funcdecl.toPrettyChars());
+                                {
+                                    if (funcdecl.isStaticCtorDeclaration())
+                                        error(funcdecl.loc, "A module constructor may not throw as the runtime has not been yet initialized");
+                                    else
+                                        error(funcdecl.loc, "%s `%s` may throw but is marked as `nothrow`", funcdecl.kind(), funcdecl.toPrettyChars());
+                                }
                                 else if (funcdecl.nothrowInprocess)
                                     f.isnothrow = false;
                             }

--- a/compiler/test/fail_compilation/test23973.d
+++ b/compiler/test/fail_compilation/test23973.d
@@ -1,0 +1,21 @@
+// https://issues.dlang.org/show_bug.cgi?id=23973
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test23973.d(16): Error: function `test23973.foo` is not `nothrow`
+fail_compilation/test23973.d(14): Error: A module constructor may not throw as the runtime has not been yet initialized
+---
+*/
+void foo()
+{
+}
+
+static this()
+{
+    foo();
+}
+
+void main()
+{
+}

--- a/compiler/test/runnable/imports/test3a.d
+++ b/compiler/test/runnable/imports/test3a.d
@@ -8,6 +8,6 @@ class Afoo
 {
     static this()
     {
-	printf("Afoo()\n");
+        debug printf("Afoo()\n");
     }
 }

--- a/compiler/test/runnable/test11.d
+++ b/compiler/test/runnable/test11.d
@@ -1123,7 +1123,7 @@ void test58()
     {
         static this()
         {
-            printf ("static constructor\n");
+            debug printf ("static constructor\n");
             x = 10;
         }
 

--- a/compiler/test/runnable/test15.d
+++ b/compiler/test/runnable/test15.d
@@ -412,7 +412,7 @@ void test26()
 
 /************************************/
 
-void foo27(ClassInfo ci) { }
+void foo27(ClassInfo ci) nothrow { }
 
 class A27
 {
@@ -434,9 +434,9 @@ void test27()
 
 /************************************/
 
-void foo28(ClassInfo ci)
+void foo28(ClassInfo ci) nothrow
 {
-    printf("%.*s\n", cast(int)ci.name.length, ci.name.ptr);
+    debug printf("%.*s\n", cast(int)ci.name.length, ci.name.ptr);
 
     static int i;
     switch (i++)
@@ -463,7 +463,7 @@ class B28 : A28
         foo28(B28.classinfo );
         (new B28()).bodge_it();
     }
-    void bodge_it() {
+    void bodge_it() nothrow {
         foo28(A28.classinfo );
     }
 }

--- a/compiler/test/runnable/test16.d
+++ b/compiler/test/runnable/test16.d
@@ -347,13 +347,13 @@ void test12()
     {
         static this()
         {
-            printf ("static constructor\n");
+            debug printf ("static constructor\n");
             x12 += 1;
         }
 
         this()
         {
-            printf ("class constructor\n");
+            debug printf ("class constructor\n");
             x12 += 10;
         }
     }

--- a/compiler/test/runnable/test19.d
+++ b/compiler/test/runnable/test19.d
@@ -69,12 +69,12 @@ int x2;
 
 class Foo4
 {
-    static  this() { x1 = 3; printf("Foo4 ctor()\n"); }
-    static ~this() { x1 = 4; printf("Foo4 dtor()\n"); }
+    static  this() { x1 = 3; debug printf("Foo4 ctor()\n"); }
+    static ~this() { x1 = 4; debug printf("Foo4 dtor()\n"); }
 }
 
-static  this() { x2 = 5; printf("ctor()\n"); }
-static ~this() { x2 = 6; printf("dtor()\n"); }
+static  this() { x2 = 5; debug printf("ctor()\n"); }
+static ~this() { x2 = 6; debug printf("dtor()\n"); }
 
 void test4()
 {

--- a/compiler/test/tools/dshell_prebuilt/dshell_prebuilt.d
+++ b/compiler/test/tools/dshell_prebuilt/dshell_prebuilt.d
@@ -67,42 +67,49 @@ static foreach (var; allVars)
 }
 
 /// called from the dshell module to initialize environment
-void dshellPrebuiltInit(string testDir, string testName)
+void dshellPrebuiltInit(string testDir, string testName) nothrow
 {
-    foreach (var; requiredEnvVars)
+    try
     {
-        Vars.set(var, requireEnv(var));
-    }
+        foreach (var; requiredEnvVars)
+        {
+            Vars.set(var, requireEnv(var));
+        }
 
-    foreach (var; optionalEnvVars)
-    {
-        Vars.set(var, environment.get(var, ""));
-    }
+        foreach (var; optionalEnvVars)
+        {
+            Vars.set(var, environment.get(var, ""));
+        }
 
-    Vars.set("TEST_DIR", testDir);
-    Vars.set("TEST_NAME", testName);
-    // reference to the resulting test_dir folder, e.g .test_results/runnable
-    Vars.set("RESULTS_TEST_DIR", buildPath(RESULTS_DIR, TEST_DIR));
-    // reference to the resulting files without a suffix, e.g. test_results/runnable/test123import test);
-    Vars.set("OUTPUT_BASE", buildPath(RESULTS_TEST_DIR, TEST_NAME));
-    // reference to the extra files directory
-    Vars.set("EXTRA_FILES", buildPath(TEST_DIR, "extra-files"));
-    // reference to the imports directory
-    Vars.set("IMPORT_FILES", buildPath(TEST_DIR, "imports"));
-    version (Windows)
-    {
-        Vars.set("LIBEXT", ".lib");
-        Vars.set("SOEXT", ".dll");
+        Vars.set("TEST_DIR", testDir);
+        Vars.set("TEST_NAME", testName);
+        // reference to the resulting test_dir folder, e.g .test_results/runnable
+        Vars.set("RESULTS_TEST_DIR", buildPath(RESULTS_DIR, TEST_DIR));
+        // reference to the resulting files without a suffix, e.g. test_results/runnable/test123import test);
+        Vars.set("OUTPUT_BASE", buildPath(RESULTS_TEST_DIR, TEST_NAME));
+        // reference to the extra files directory
+        Vars.set("EXTRA_FILES", buildPath(TEST_DIR, "extra-files"));
+        // reference to the imports directory
+        Vars.set("IMPORT_FILES", buildPath(TEST_DIR, "imports"));
+        version (Windows)
+        {
+            Vars.set("LIBEXT", ".lib");
+            Vars.set("SOEXT", ".dll");
+        }
+        else version (OSX)
+        {
+            Vars.set("LIBEXT", ".a");
+            Vars.set(`SOEXT`, `.dylib`);
+        }
+        else
+        {
+            Vars.set("LIBEXT", ".a");
+            Vars.set("SOEXT", ".so");
+        }
     }
-    else version (OSX)
+    catch(Exception e)
     {
-        Vars.set("LIBEXT", ".a");
-        Vars.set(`SOEXT`, `.dylib`);
-    }
-    else
-    {
-        Vars.set("LIBEXT", ".a");
-        Vars.set("SOEXT", ".so");
+        assert(0, e.msg);
     }
 }
 

--- a/druntime/src/core/runtime.d
+++ b/druntime/src/core/runtime.d
@@ -284,7 +284,7 @@ struct Runtime
      *      handler is used to generate TraceInfo.
      */
     extern(C) pragma(mangle, "rt_setTraceHandler") static @property void traceHandler(TraceHandler h,
-                    Throwable.TraceDeallocator d = null);
+                    Throwable.TraceDeallocator d = null) nothrow;
 
     /**
      * Gets the current trace handler.
@@ -399,7 +399,7 @@ struct Runtime
      * }
      * ---------
      */
-    static @property void extendedModuleUnitTester( ExtendedModuleUnitTester h )
+    static @property void extendedModuleUnitTester( ExtendedModuleUnitTester h ) nothrow
     {
         sm_extModuleUnitTester = h;
     }


### PR DESCRIPTION
This may need a deprecation, however, let's see what the test suite says.

I am reluctant to implement it as a deprecation since that would need to special case the nothrow errors for  StaticCtorDeclaration everywhere. Since the reason for this restriction is pretty clear I expect that most code out there is going to be nothrow anyway, the user just needs to annotate his functions (famous last words).

This still needs a changelog. cc @atilaneves @WalterBright what do you think?