### PR TITLE
Make 'private function is not accessible' deprecation an error.

### DIFF
--- a/changelog/dmd.private-deprecation-error.dd
+++ b/changelog/dmd.private-deprecation-error.dd
@@ -1,0 +1,18 @@
+Deprecation phase ended for access to private method when overloaded with public method.
+
+When a private method was overloaded with a public method that came after it,
+you could access the private overload as if it was public.
+
+After a deprecation period starting with 2.094, this code is now an error.
+
+Example:
+
+```
+struct Foo
+{
+    private void test(int) { }
+    public void test(string) { }
+}
+...
+Foo().test(3);
+```

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5017,11 +5017,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else if (!checkSymbolAccess(sc, exp.f))
             {
-                // @@@DEPRECATED_2.105@@@
-                // When turning into error, uncomment the return statement
-                exp.deprecation("%s `%s` of type `%s` is not accessible from module `%s`",
+                exp.error("%s `%s` of type `%s` is not accessible from module `%s`",
                     exp.f.kind(), exp.f.toPrettyChars(), exp.f.type.toChars(), sc._module.toChars);
-                //return ErrorExp.get();
+                return setError();
             }
 
             if (!exp.f.needThis())

--- a/compiler/test/fail_compilation/fail21275.d
+++ b/compiler/test/fail_compilation/fail21275.d
@@ -1,12 +1,11 @@
 // https://issues.dlang.org/show_bug.cgi?id=21275
-// REQUIRED_ARGS: -de
 // EXTRA_FILES: imports/fail21275a.d
 
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail21275.d(18): Deprecation: function `imports.fail21275a.Foo.x` of type `ref int() return` is not accessible from module `fail21275`
-fail_compilation/fail21275.d(21): Deprecation: function `imports.fail21275a.Bar.x` of type `int(int)` is not accessible from module `fail21275`
+fail_compilation/fail21275.d(17): Error: function `imports.fail21275a.Foo.x` of type `ref int() return` is not accessible from module `fail21275`
+fail_compilation/fail21275.d(20): Error: function `imports.fail21275a.Bar.x` of type `int(int)` is not accessible from module `fail21275`
 ---
 */
 

--- a/compiler/test/fail_compilation/issue23947.d
+++ b/compiler/test/fail_compilation/issue23947.d
@@ -1,9 +1,8 @@
 // https://issues.dlang.org/show_bug.cgi?id=23947
-// REQUIRED_ARGS: -de
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/issue23947.d(11): Deprecation: function `imports.issue23947a.Class.handle` of type `void(X x)` is not accessible from module `issue23947`
+fail_compilation/issue23947.d(10): Error: function `imports.issue23947a.Class.handle` of type `void(X x)` is not accessible from module `issue23947`
 ---
 */
 import imports.issue23947a;


### PR DESCRIPTION
Affects issue 21275, 23947.
Followup to https://github.com/dlang/dmd/pull/15282