### PR TITLE
Fix Issue 4663 - Wrong 'static' position error message

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1405,6 +1405,15 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     break;
                 }
             default:
+                Token* tk;
+                if (skipAttributes(&token, &tk) && tk.ptr != token.ptr ||
+                    token.value == TOK.static_ || token.value == TOK.extern_)
+                {
+                    error("`%s` token is not allowed in postfix position",
+                        Token.toChars(token.value));
+                    nextToken();
+                    continue;
+                }
                 return storageClass;
             }
             storageClass = appendStorageClass(storageClass, stc);

--- a/compiler/test/fail_compilation/funcpostattr.d
+++ b/compiler/test/fail_compilation/funcpostattr.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/funcpostattr.d(11): Error: `deprecated` token is not allowed in postfix position
+fail_compilation/funcpostattr.d(11): Error: `extern` token is not allowed in postfix position
+fail_compilation/funcpostattr.d(15): Error: `static` token is not allowed in postfix position
+fail_compilation/funcpostattr.d(15): Error: `ref` token is not allowed in postfix position
+fail_compilation/funcpostattr.d(20): Error: `override` token is not allowed in postfix position
+---
+*/
+void foo() deprecated extern;
+
+void main() {
+    int i;
+    int foo() static ref => i;
+}
+
+class C
+{
+    void foo() override {}
+}


### PR DESCRIPTION
Also detects other tokens in postfix attribute position: `extern`, `deprecated`, `ref`, `override` and friends.

@RazvanN7 This implements an issue in the error messages project:
https://github.com/orgs/dlang/projects/9/views/1?pane=issue&itemId=9664251