### PR TITLE
Revert "Turn semicolon as empty statement into an error"

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -199,7 +199,7 @@ final class CParser(AST) : Parser!AST
                     else if (token.value == TOK.leftCurly)
                         s = cparseStatement(ParseStatementFlags.curly | ParseStatementFlags.scope_);
                     else
-                        s = cparseStatement(0);
+                        s = cparseStatement(ParseStatementFlags.semiOk);
                     s = new AST.LabelStatement(loc, ident, s);
                     break;
                 }
@@ -376,7 +376,7 @@ final class CParser(AST) : Parser!AST
             auto statements = new AST.Statements();
             while (token.value != TOK.rightCurly && token.value != TOK.endOfFile)
             {
-                statements.push(cparseStatement(ParseStatementFlags.curlyScope));
+                statements.push(cparseStatement(ParseStatementFlags.semi | ParseStatementFlags.curlyScope));
             }
             if (endPtr)
                 *endPtr = token.ptr;
@@ -525,7 +525,7 @@ final class CParser(AST) : Parser!AST
                 auto statements = new AST.Statements();
                 while (token.value != TOK.case_ && token.value != TOK.default_ && token.value != TOK.endOfFile && token.value != TOK.rightCurly)
                 {
-                    auto cur = cparseStatement(ParseStatementFlags.curlyScope);
+                    auto cur = cparseStatement(ParseStatementFlags.semi | ParseStatementFlags.curlyScope);
                     statements.push(cur);
 
                     // https://issues.dlang.org/show_bug.cgi?id=21739
@@ -540,7 +540,7 @@ final class CParser(AST) : Parser!AST
             }
             else
             {
-                s = cparseStatement(0);
+                s = cparseStatement(ParseStatementFlags.semi);
             }
             s = new AST.ScopeStatement(loc, s, token.loc);
             if (expHigh)
@@ -560,12 +560,12 @@ final class CParser(AST) : Parser!AST
                 auto statements = new AST.Statements();
                 while (token.value != TOK.case_ && token.value != TOK.default_ && token.value != TOK.endOfFile && token.value != TOK.rightCurly)
                 {
-                    statements.push(cparseStatement(ParseStatementFlags.curlyScope));
+                    statements.push(cparseStatement(ParseStatementFlags.semi | ParseStatementFlags.curlyScope));
                 }
                 s = new AST.CompoundStatement(loc, statements);
             }
             else
-                s = cparseStatement(0);
+                s = cparseStatement(ParseStatementFlags.semi);
             s = new AST.ScopeStatement(loc, s, token.loc);
             s = new AST.DefaultStatement(loc, s);
             break;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -4809,7 +4809,7 @@ private Statements* flatten(Statement statement, Scope* sc)
             auto a = new Statements();
             while (p.token.value != TOK.endOfFile)
             {
-                Statement s = p.parseStatement(ParseStatementFlags.curlyScope);
+                Statement s = p.parseStatement(ParseStatementFlags.semi | ParseStatementFlags.curlyScope);
                 if (!s || global.errors != errors)
                     return errorStatements();
                 a.push(s);

--- a/compiler/test/fail_compilation/fail4559.d
+++ b/compiler/test/fail_compilation/fail4559.d
@@ -1,10 +1,10 @@
 /*
-REQUIRED_ARGS:
+REQUIRED_ARGS: -o- -de
 TEST_OUTPUT:
 ---
-fail_compilation/fail4559.d(13): Error: use `{ }` for an empty statement, not `;`
-fail_compilation/fail4559.d(19): Error: use `{ }` for an empty statement, not `;`
-fail_compilation/fail4559.d(21): Error: use `{ }` for an empty statement, not `;`
+fail_compilation/fail4559.d(13): Deprecation: use `{ }` for an empty statement, not `;`
+fail_compilation/fail4559.d(19): Deprecation: use `{ }` for an empty statement, not `;`
+fail_compilation/fail4559.d(21): Deprecation: use `{ }` for an empty statement, not `;`
 ---
 */
 


### PR DESCRIPTION
Reverts dlang/dmd#15072

Because it isn't really necessary to make empty statements an error, and it causes users unnecessary grief.