### PR TITLE
Improve error message for declaring opaque type variable

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -587,6 +587,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     const loc = (s ? s : dsym).loc;
                     loc.errorSupplemental("required by type `%s`", dsym.type.toChars());
                 }
+                errorSupplemental(dsym.loc, "see https://dlang.org/spec/struct.html#opaque_struct_unions");
+                errorSupplemental(dsym.loc, "perhaps declare a variable with pointer type `%s*` instead", dsym.type.toChars());
 
                 // Flag variable as error to avoid invalid error messages due to unknown size
                 dsym.type = Type.terror;

--- a/compiler/test/fail_compilation/enum_init.d
+++ b/compiler/test/fail_compilation/enum_init.d
@@ -58,6 +58,8 @@ TEST_OUTPUT:
 ---
 fail_compilation/enum_init.d(306): Error: variable `enum_init.fooOB.ob` - no definition of struct `S`
 fail_compilation/enum_init.d(302):        required by type `OpaqueBase`
+fail_compilation/enum_init.d(306):        see https://dlang.org/spec/struct.html#opaque_struct_unions
+fail_compilation/enum_init.d(306):        perhaps declare a variable with pointer type `OpaqueBase*` instead
 ---
 */
 #line 300

--- a/compiler/test/fail_compilation/failcstuff4.c
+++ b/compiler/test/fail_compilation/failcstuff4.c
@@ -3,6 +3,8 @@
 ---
 fail_compilation/failcstuff4.c(100): Error: can only `*` a pointer, not a `int`
 fail_compilation/failcstuff4.c(157): Error: variable `failcstuff4.T22106.f1` - no definition of struct `S22106_t`
+fail_compilation/failcstuff4.c(157):        see https://dlang.org/spec/struct.html#opaque_struct_unions
+fail_compilation/failcstuff4.c(157):        perhaps declare a variable with pointer type `S22106_t*` instead
 ---
 */
 


### PR DESCRIPTION
Based on this forum question: https://forum.dlang.org/post/sukdgwuqltuuckbooxds@forum.dlang.org