### PR TITLE
Refer to bugzilla issues by hyperlink

### DIFF
--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -653,7 +653,8 @@ extern (C++) final class VisibilityDeclaration : AttribDeclaration
         {
             Module m = sc._module;
 
-            // While isAncestorPackageOf does an equality check, the fix for issue 17441 adds a check to see if
+            // https://issues.dlang.org/show_bug.cgi?id=17441
+            // While isAncestorPackageOf does an equality check, the fix for the issue adds a check to see if
             // each package's .isModule() properites are equal.
             //
             // Properties generated from `package(foo)` i.e. visibility.pkg have .isModule() == null.

--- a/compiler/src/dmd/backend/cgcod.d
+++ b/compiler/src/dmd/backend/cgcod.d
@@ -2883,7 +2883,7 @@ void scodelem(ref CodeBuilder cdb, elem *e,regm_t *pretregs,regm_t keepmsk,bool 
 
     assert((mfuncreg & (regcon.cse.mval & ~oldregcon)) == 0);
 
-    /* bugzilla 3521
+    /* https://issues.dlang.org/show_bug.cgi?id=3521
      * The problem is:
      *    reg op (reg = exp)
      * where reg must be preserved (in keepregs) while the expression to be evaluated

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -4235,7 +4235,7 @@ final class CParser(AST) : Parser!AST
                         return false;
                     /*
                         https://issues.dlang.org/show_bug.cgi?id=22267
-                        Fix issue 22267: If the parser encounters the following
+                        If the parser encounters the following
                             `identifier variableName = (expression);`
                         the initializer is not identified as such since the parentheses
                         cause the parser to keep walking indefinitely

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -3334,7 +3334,7 @@ elem* toElem(Expression e, IRState *irs)
             {
                 // This optimization is not valid if alloca can be called
                 // multiple times within the same function, eg in a loop
-                // see issue 3822
+                // see https://issues.dlang.org/show_bug.cgi?id=3822
                 if (fd && fd.ident == Id.__alloca &&
                     !fd.fbody && fd._linkage == LINK.c &&
                     arguments && arguments.length == 1)

--- a/compiler/src/dmd/eh.d
+++ b/compiler/src/dmd/eh.d
@@ -291,7 +291,7 @@ void except_fillInEHTable(Symbol *s)
                                 cf = code_next(cf);
                                 foffset += calccodsize(cf);
                             }
-                            // issue 9438
+                            // https://issues.dlang.org/show_bug.cgi?id=9438
                             //cf = code_next(cf);
                             //foffset += calccodsize(cf);
                             if (config.ehmethod == EHmethod.EH_DM)

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -4512,7 +4512,7 @@ extern (C++) abstract class BinExp : Expression
         Type t2 = e2.type;
 
         // T opAssign floating yields a floating. Prevent truncating conversions (float to int).
-        // See issue 3841.
+        // See https://issues.dlang.org/show_bug.cgi?id=3841.
         // Should we also prevent double to float (type.isfloating() && type.size() < t2.size()) ?
         if (op == EXP.addAssign || op == EXP.minAssign ||
             op == EXP.mulAssign || op == EXP.divAssign || op == EXP.modAssign ||

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3387,7 +3387,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (ve && ve.var && exp.parens && !ve.var.isStatic() && !(sc.stc & STC.static_) &&
                 sc.func && sc.func.needThis && ve.var.isMember2())
             {
-                // printf("apply fix for issue 9490: add `this.` to `%s`...\n", e.toChars());
+                // printf("apply fix for bugzilla issue 9490: add `this.` to `%s`...\n", e.toChars());
                 e = new DotVarExp(exp.loc, new ThisExp(exp.loc), ve.var, false);
             }
             //printf("e = %s %s\n", Token.toChars(e.op), e.toChars());

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -927,7 +927,7 @@ public:
         }
         if (d.decl.length == 0 || (hgs.hdrgen && d.decl.length == 1 && (*d.decl)[0].isUnitTestDeclaration()))
         {
-            // hack for bugzilla 8081
+            // hack for https://issues.dlang.org/show_bug.cgi?id=8081
             if (hasSTC) buf.writeByte(' ');
             buf.writestring("{}");
         }

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -84,8 +84,8 @@ private void inlineScanDsymbol(Dsymbol s)
  * Perform the "inline copying" of a default argument for a function parameter.
  *
  * Todo:
- *  The hack for bugzilla 4820 case is still questionable. Perhaps would have to
- *  handle a delegate expression with 'null' context properly in front-end.
+ *  The hack for https://issues.dlang.org/show_bug.cgi?id=4820 case is still questionable.
+ *  Perhaps would have to handle a delegate expression with 'null' context properly in front-end.
  */
 public Expression inlineCopy(Expression e, Scope* sc)
 {

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -2054,7 +2054,7 @@ extern (C++) abstract class Type : ASTNode
                 return Type.terror;
 
             auto t = fd.type.nextOf();
-            if (!t) // issue 14185
+            if (!t) // https://issues.dlang.org/show_bug.cgi?id=14185
                 return Type.terror;
             t = t.substWildTo(mod == 0 ? MODFlags.mutable : mod);
             return t;
@@ -5105,7 +5105,7 @@ extern (C++) final class TypeDelegate : TypeNext
  * This is a shell containing a TraitsExp that can be
  * either resolved to a type or to a symbol.
  *
- * The point is to allow AliasDeclarationY to use `__traits()`, see issue 7804.
+ * The point is to allow AliasDeclarationY to use `__traits()`, see https://issues.dlang.org/show_bug.cgi?id=7804.
  */
 extern (C++) final class TypeTraits : Type
 {
@@ -7271,7 +7271,7 @@ private extern(D) bool isCopyConstructorCallable (StructDeclaration argStruct,
             {
                 /* Although a copy constructor may exist, no suitable match was found.
                  * i.e: `inout` constructor creates `const` object, not mutable.
-                 * Fallback to using the original generic error before bugzilla 22202.
+                 * Fallback to using the original generic error before https://issues.dlang.org/show_bug.cgi?id=22202.
                  */
                 goto Lnocpctor;
             }

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -189,7 +189,7 @@ private Expression fromConstInitializer(int result, Expression e1)
         {
             // If it is a comma expression involving a declaration, we mustn't
             // perform a copy -- we'd get two declarations of the same variable.
-            // See bugzilla 4465.
+            // See https://issues.dlang.org/show_bug.cgi?id=4465.
             if (e.op == EXP.comma && e.isCommaExp().e1.isDeclarationExp())
                 e = e1;
             else if (e.type != e1.type && e1.type && e1.type.ty != Tident)

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -845,7 +845,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
             v.inClosure = true;
 
             // Hack for the case fail_compilation/fail10666.d,
-            // until proper issue 5730 fix will come.
+            // until proper https://issues.dlang.org/show_bug.cgi?id=5730 fix will come.
             bool isScopeDtorParam = v.edtor && (v.storage_class & STC.parameter);
             if (v.needsScopeDtor() || isScopeDtorParam)
             {

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -2116,7 +2116,7 @@ private bool isSame(RootObject o1, RootObject o2, Scope* sc)
             return true;
     }
 
-    // issue 12001, allow isSame, <BasicType>, <BasicType>
+    // https://issues.dlang.org/show_bug.cgi?id=12001, allow isSame, <BasicType>, <BasicType>
     Type t1 = isType(o1);
     Type t2 = isType(o2);
     if (t1 && t2 && t1.equals(t2))

--- a/compiler/test/compilable/b20938.d
+++ b/compiler/test/compilable/b20938.d
@@ -1,4 +1,5 @@
-// issue 20938 - Cannot create const arrays mixing immutable and mutable structs with indirections
+// https://issues.dlang.org/show_bug.cgi?id=20938
+// Cannot create const arrays mixing immutable and mutable structs with indirections
 struct S { int[] a; }
 enum A { a }
 enum B { b }

--- a/compiler/test/compilable/test16635.d
+++ b/compiler/test/compilable/test16635.d
@@ -39,7 +39,7 @@ void test16635_1()
     Vector2 b = Vector2(3, 4);
 
     // this line causes application to run infinitely
-    // Already fixed. It was issue 16621
+    // Already fixed. It was https://issues.dlang.org/show_bug.cgi?id=16621
     Vector2 c = a + b;
 
     // OK <- this line seg faults without the above line

--- a/compiler/test/compilable/testInference.d
+++ b/compiler/test/compilable/testInference.d
@@ -171,9 +171,9 @@ template map7017(fun...) if (fun.length >= 1)
     auto map7017()
     {
         struct Result {
-            this(int dummy){}   // impure member function -> inferred to pure by fixing issue 10329
+            this(int dummy){}   // impure member function -> inferred to pure by fixing https://issues.dlang.org/show_bug.cgi?id=10329
         }
-        return Result(0);   // impure call -> inferred to pure by fixing issue 10329
+        return Result(0);   // impure call -> inferred to pure by fixing https://issues.dlang.org/show_bug.cgi?id=10329
     }
 }
 
@@ -588,7 +588,7 @@ auto fb10148(T)()
             static assert(is(typeof(&fc) == void delegate()));
             fa10148();
         }
-        // [1] this is now inferred to @safe by implementing issue 7511
+        // [1] this is now inferred to @safe by implementing https://issues.dlang.org/show_bug.cgi?id=7511
         this(S a) {}
     }
 

--- a/compiler/test/runnable/functype.d
+++ b/compiler/test/runnable/functype.d
@@ -301,7 +301,7 @@ void test10734()
 
 void test14656()
 {
-    //void unaryFun()(auto int a) pure nothrow @safe @nogc {}   // changed to invalid by fixing issue 14669
+    //void unaryFun()(auto int a) pure nothrow @safe @nogc {}   // changed to invalid by fixing https://issues.dlang.org/show_bug.cgi?id=14669
     alias Identity(F) = F;
     //unaryFun!()(41);
     static void fun(int n) pure nothrow @safe @nogc {}

--- a/compiler/test/runnable/interface2.d
+++ b/compiler/test/runnable/interface2.d
@@ -962,11 +962,11 @@ void test1747()
     assert(pia == pc + n);
 
     assert(id.mA() == 1);
-    assert(id.mB() == 2);   // OK <- NG (bugzilla 2013 case)
+    assert(id.mB() == 2);   // OK <- NG (https://issues.dlang.org/show_bug.cgi?id=2013 case)
     assert(id.mD() == 3);
 
     assert(ic.mA() == 1);
-    assert(ic.mB() == 2);   // OK <- NG (bugzilla 2013 case)
+    assert(ic.mB() == 2);   // OK <- NG (https://issues.dlang.org/show_bug.cgi?id=2013 case)
 
     assert(ib.mA() == 1);
     assert(ib.mB() == 2);   // OK <- NG

--- a/compiler/test/runnable/link10425.d
+++ b/compiler/test/runnable/link10425.d
@@ -10,7 +10,7 @@ void main()
      * the TypeInfo object on comdat section (done by TypeInfoDeclaration::toObjFile),
      * even if the associated struct belongs *non-root modules*.
      *
-     * And, from 2.062, issue 7511 is implemented.
+     * And, from 2.062, https://issues.dlang.org/show_bug.cgi?id=7511 is implemented.
      * The attribute inference for member functions in instantiated struct may modify
      * their actual mangled names. Then TypeInfo object compiled in this module would
      * use wrong symbol names, to link non-template opEquals/opCmp/toHash/toString

--- a/compiler/test/runnable/template9.d
+++ b/compiler/test/runnable/template9.d
@@ -4689,7 +4689,8 @@ struct S14604
 }
 alias Id14604(alias thing) = thing;
 alias c14604 = Id14604!(S14604.opDispatch!"go");     // ok
-alias d14604 = Id14604!(S14604.go);                  // issue 14604, 'Error: template instance opDispatch!"go" cannot resolve forward reference'
+// https://issues.dlang.org/show_bug.cgi?id=14604
+alias d14604 = Id14604!(S14604.go);                  // 'Error: template instance opDispatch!"go" cannot resolve forward reference'
 
 /******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=14735

--- a/compiler/test/runnable/testcontracts.d
+++ b/compiler/test/runnable/testcontracts.d
@@ -936,7 +936,7 @@ void test9383()
 
 /*******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=15524
-// Different from issue 9383 cases, closed variable size is bigger than REGSIZE.
+// Different from https://issues.dlang.org/show_bug.cgi?id=9383 cases, closed variable size is bigger than REGSIZE.
 
 class A15524
 {

--- a/druntime/src/core/atomic.d
+++ b/druntime/src/core/atomic.d
@@ -1203,7 +1203,7 @@ version (CoreUnittest)
         }
     }
 
-    @betterC pure nothrow @nogc @safe unittest // issue 16651
+    @betterC pure nothrow @nogc @safe unittest // https://issues.dlang.org/show_bug.cgi?id=16651
     {
         shared ulong a = 2;
         uint b = 1;
@@ -1216,7 +1216,7 @@ version (CoreUnittest)
         assert(c == 1);
     }
 
-    pure nothrow @safe unittest // issue 16230
+    pure nothrow @safe unittest // https://issues.dlang.org/show_bug.cgi?id=16230
     {
         shared int i;
         static assert(is(typeof(atomicLoad(i)) == int));

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -93,7 +93,7 @@ private
         int rt_hasFinalizerInSegment(void* p, size_t size, uint attr, const scope void[] segment) nothrow;
 
         // Declared as an extern instead of importing core.exception
-        // to avoid inlining - see issue 13725.
+        // to avoid inlining - see https://issues.dlang.org/show_bug.cgi?id=13725.
         void onInvalidMemoryOperationError(void* pretend_sideffect = null) @trusted pure nothrow @nogc;
         void onOutOfMemoryErrorNoGC() @trusted nothrow @nogc;
 
@@ -4453,7 +4453,7 @@ struct SmallObjectPool
 }
 
 debug(SENTINEL) {} else // no additional capacity with SENTINEL
-unittest // bugzilla 14467
+unittest // https://issues.dlang.org/show_bug.cgi?id=14467
 {
     int[] arr = new int[10];
     assert(arr.capacity);
@@ -4461,7 +4461,7 @@ unittest // bugzilla 14467
     assert(arr.capacity);
 }
 
-unittest // bugzilla 15353
+unittest // https://issues.dlang.org/show_bug.cgi?id=15353
 {
     import core.memory : GC;
 
@@ -4478,7 +4478,7 @@ unittest // bugzilla 15353
     GC.collect();
 }
 
-unittest // bugzilla 15822
+unittest // https://issues.dlang.org/show_bug.cgi?id=15822
 {
     import core.memory : GC;
 
@@ -4499,7 +4499,7 @@ unittest // bugzilla 15822
     GC.collect();
 }
 
-unittest // bugzilla 1180
+unittest // https://issues.dlang.org/show_bug.cgi?id=1180
 {
     import core.exception;
     try

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -364,7 +364,7 @@ T* emplace(T, Args...)(void[] chunk, auto ref Args args)
     assert(u1.a == "hello");
 }
 
-@system unittest // bugzilla 15772
+@system unittest // https://issues.dlang.org/show_bug.cgi?id=15772
 {
     abstract class Foo {}
     class Bar: Foo {}
@@ -2322,7 +2322,7 @@ pure nothrow @nogc @system unittest
     assert(val == 1);
 }
 
-// issue 18913
+// https://issues.dlang.org/show_bug.cgi?id=18913
 @safe unittest
 {
     static struct NoCopy
@@ -2454,7 +2454,7 @@ template _d_delstructImpl(T)
     assert(outerDtors == 1);
 }
 
-// issue 25552
+// https://issues.dlang.org/show_bug.cgi?id=25552
 pure nothrow @system unittest
 {
     int i;
@@ -2478,7 +2478,7 @@ pure nothrow @system unittest
     assert(i == 2);
 }
 
-// issue 25552
+// https://issues.dlang.org/show_bug.cgi?id=25552
 @safe unittest
 {
     int i;
@@ -2527,7 +2527,7 @@ pure nothrow @system unittest
     assert(i == 6);
 }
 
-// issue 25552
+// https://issues.dlang.org/show_bug.cgi?id=25552
 @safe unittest
 {
     int i;

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -289,8 +289,9 @@ if ((is(LHS : const Object) || is(LHS : const shared Object)) &&
         // If same exact type => one call to method opEquals
         if (typeid(lhs) is typeid(rhs) ||
             !__ctfe && typeid(lhs).opEquals(typeid(rhs)))
-                /* CTFE doesn't like typeid much. 'is' works, but opEquals doesn't
-                (issue 7147). But CTFE also guarantees that equal TypeInfos are
+                /* CTFE doesn't like typeid much. 'is' works, but opEquals doesn't:
+                https://issues.dlang.org/show_bug.cgi?id=7147
+                But CTFE also guarantees that equal TypeInfos are
                 always identical. So, no opEquals needed during CTFE. */
         {
             return true;
@@ -983,7 +984,7 @@ class TypeInfo_Enum : TypeInfo
 }
 
 
-@safe unittest // issue 12233
+@safe unittest // https://issues.dlang.org/show_bug.cgi?id=12233
 {
     static assert(is(typeof(TypeInfo.init) == TypeInfo));
     assert(TypeInfo.init is null);

--- a/druntime/src/rt/dwarfeh.d
+++ b/druntime/src/rt/dwarfeh.d
@@ -590,7 +590,8 @@ ClassInfo getClassInfo(_Unwind_Exception* exceptionObject, const(ubyte)* current
     for (ExceptionHeader* ehn = eh.next; ehn; ehn = ehn.next)
     {
         // like __dmd_personality_v0, don't combine when the exceptions are from different functions
-        // (fixes issue 19831, exception thrown and caught while inside finally block)
+        // Fixes "exception thrown and caught while inside finally block"
+        // https://issues.dlang.org/show_bug.cgi?id=19831
         if (currentLsd != ehn.languageSpecificData)
         {
             debug (EH_personality) writeln("break: %p %p", currentLsd, ehn.languageSpecificData);

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -2381,7 +2381,7 @@ unittest
 
 unittest
 {
-    // bugzilla 13854
+    // https://issues.dlang.org/show_bug.cgi?id=13854
     auto arr = new ubyte[PAGESIZE]; // ensure page size
     auto info1 = GC.query(arr.ptr);
     assert(info1.base !is arr.ptr); // offset is required for page size or larger
@@ -2424,7 +2424,7 @@ unittest
 
 unittest
 {
-    // bugzilla 13878
+    // https://issues.dlang.org/show_bug.cgi?id=13878
     auto arr = new ubyte[1];
     auto info = GC.query(arr.ptr);
     assert(info.attr & BlkAttr.NO_SCAN); // should be NO_SCAN

--- a/druntime/src/rt/util/typeinfo.d
+++ b/druntime/src/rt/util/typeinfo.d
@@ -545,7 +545,7 @@ unittest
 
 unittest
 {
-    // Original test case from issue 13073
+    // Original test case from https://issues.dlang.org/show_bug.cgi?id=13073
     uint x = 0x22_DF_FF_FF;
     uint y = 0xA2_DF_FF_FF;
     assert(!(x < y && y < x));


### PR DESCRIPTION
"Issue xxxxx" will become ambiguous after the bugzilla -> github issues migration, so disambiguate issue references in the source code