### PR TITLE
Print stack trace for segfaults on linux

### DIFF
--- a/changelog/druntime.segfault-message.dd
+++ b/changelog/druntime.segfault-message.dd
@@ -1,0 +1,65 @@
+New segfault handler showing backtraces for null access / call stack overflow on linux
+
+While buffer overflows are usually caught by array bounds checks, there are still other situations where a segmentation fault occurs in D programs:
+
+- `null` pointer dereference
+- Corrupted or dangling pointer dereference in `@system` code
+- Call stack overflow (infinite recursion)
+
+These result in an uninformative runtime error such as:
+
+$(CONSOLE
+[1]    37856 segmentation fault (core dumped)  ./app
+)
+
+In order to find the cause of the error, the program needs to be run again in a debugger like gdb.
+
+There is the `registerMemoryErrorHandler` function in `etc.linux.memoryerror`, which catches `SIGSEGV` signals and transforms them into a thrown `InvalidPointerError`, providing a better message.
+However, it doesn't work on call stack overflow, because it uses stack memory itself, so the segfault handler segfaults.
+It also relies on inline assembly, limiting it to the x86 architecture.
+
+A new function `registerMemoryAssertHandler` has been introduced, which does handle stack overflow by setting up an [altstack](https://man7.org/linux/man-pages/man2/sigaltstack.2.html).
+It uses `assert(0)` instead of throwing an `Error` object, so the result corresponds to the chosen `-checkaction=[D|C|halt|context]` setting.
+
+Example:
+
+---
+void main()
+{
+    version (linux)
+    {
+        import etc.linux.memoryerror;
+        registerMemoryAssertHandler();
+    }
+    int* p = null;
+    int* q = cast(int*) 0xDEADBEEF;
+
+    // int a = *p; // segmentation fault: null pointer read/write operation
+    // int b = *q; // segmentation fault: invalid pointer read/write operation
+    recurse();     // segmentation fault: call stack overflow
+}
+
+void recurse()
+{
+    recurse();
+}
+---
+
+Output with `dmd -g -run app.d`:
+
+$(CONSOLE
+core.exception.AssertError@src/etc/linux/memoryerror.d(82): segmentation fault: call stack overflow
+$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
+src/core/exception.d:587 onAssertErrorMsg [0x58e270d2802d]
+src/core/exception.d:803 _d_assert_msg [0x58e270d1fb64]
+src/etc/linux/memoryerror.d:82 _d_handleSignalAssert [0x58e270d1f48d]
+??:? [0x7004139e876f]
+./app.d:16 void scratch.recurse() [0x58e270d1d757]
+./app.d:18 void scratch.recurse() [0x58e270d1d75c]
+./app.d:18 void scratch.recurse() [0x58e270d1d75c]
+./app.d:18 void scratch.recurse() [0x58e270d1d75c]
+./app.d:18 void scratch.recurse() [0x58e270d1d75c]
+...
+...
+...
+)

--- a/druntime/src/rt/dmain2.d
+++ b/druntime/src/rt/dmain2.d
@@ -453,6 +453,13 @@ private extern (C) int _d_run_main2(char[][] args, size_t totalArgsLength, MainF
             useExceptionTrap = false;
     }
 
+    version (none)
+    {
+        // Causes test failures related to Fibers, not enabled by default yet
+        import etc.linux.memoryerror;
+        cast(void) registerMemoryAssertHandler();
+    }
+
     void tryExec(scope void delegate() dg)
     {
         if (useExceptionTrap)

--- a/druntime/test/exceptions/Makefile
+++ b/druntime/test/exceptions/Makefile
@@ -5,7 +5,7 @@ TESTS=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor
       message_with_null
 
 ifeq ($(OS)-$(BUILD),linux-debug)
-    TESTS+=line_trace line_trace_21656 long_backtrace_trunc rt_trap_exceptions cpp_demangle
+    TESTS+=line_trace line_trace_21656 long_backtrace_trunc rt_trap_exceptions cpp_demangle memoryerror_null memoryerror_stackoverflow
     LINE_TRACE_DFLAGS:=-L--export-dynamic
 endif
 ifeq ($(OS),linux)
@@ -89,6 +89,9 @@ $(ROOT)/assert_fail.done: STDERR_EXP="success."
 $(ROOT)/cpp_demangle.done: STDERR_EXP="thrower(int)"
 
 $(ROOT)/message_with_null.done: STDERR_EXP=" world"
+
+$(ROOT)/memoryerror_null.done: STDERR_EXP="segmentation fault: null pointer read/write operation"
+$(ROOT)/memoryerror_stackoverflow.done: STDERR_EXP="segmentation fault: call stack overflow"
 
 $(ROOT)/%.done: $(ROOT)/%$(DOTEXE)
 	@echo Testing $*

--- a/druntime/test/exceptions/src/memoryerror_null.d
+++ b/druntime/test/exceptions/src/memoryerror_null.d
@@ -1,0 +1,9 @@
+import etc.linux.memoryerror;
+
+int* x = null;
+
+void main()
+{
+    registerMemoryAssertHandler();
+    *x = 3;
+}

--- a/druntime/test/exceptions/src/memoryerror_stackoverflow.d
+++ b/druntime/test/exceptions/src/memoryerror_stackoverflow.d
@@ -1,0 +1,15 @@
+import etc.linux.memoryerror;
+
+int* x = null;
+
+void f(ubyte[] arr)
+{
+    ubyte[1024] buf = 0;
+    f(buf[]);
+}
+
+void main()
+{
+    registerMemoryAssertHandler();
+    f([]);
+}


### PR DESCRIPTION
https://forum.dlang.org/post/vjqzjgcpbzbxisebktyt@forum.dlang.org

I don't know how to test this, because it requires the test to actually segfault.