### PR TITLE
Fix 23722 - Lambdas are mangled incorrectly when using multiple compi…

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5548,7 +5548,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         if (exp.fd.ident == Id.empty)
         {
-            const(char)[] s;
+            string s;
             if (exp.fd.fes)
                 s = "__foreachbody";
             else if (exp.fd.tok == TOK.reserved)
@@ -5582,7 +5582,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 symtab = sds.symtab;
             }
             assert(symtab);
-            Identifier id = Identifier.generateId(s, symtab.length() + 1);
+            Identifier id = Identifier.generateIdWithLoc(s, exp.loc);
             exp.fd.ident = id;
             if (exp.td)
                 exp.td.ident = id;

--- a/compiler/test/fail_compilation/b19523.d
+++ b/compiler/test/fail_compilation/b19523.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ----
 fail_compilation/b19523.d(13): Error: undefined identifier `SomeStruct`
 fail_compilation/b19523.d(14): Error: function `foo` is not callable using argument types `(_error_)`
-fail_compilation/b19523.d(14):        cannot pass argument `__lambda2` of type `_error_` to parameter `int delegate() arg`
+fail_compilation/b19523.d(14):        cannot pass argument `__lambda_L14_C6` of type `_error_` to parameter `int delegate() arg`
 fail_compilation/b19523.d(19):        `b19523.foo(int delegate() arg)` declared here
 ----
 */

--- a/compiler/test/fail_compilation/bug9631.d
+++ b/compiler/test/fail_compilation/bug9631.d
@@ -65,7 +65,7 @@ TEST_OUTPUT:
 fail_compilation/bug9631.d(80): Error: function `f` is not callable using argument types `(int, S)`
 fail_compilation/bug9631.d(80):        cannot pass argument `y` of type `bug9631.tem!().S` to parameter `bug9631.S s`
 fail_compilation/bug9631.d(79):        `bug9631.arg.f(int i, S s)` declared here
-fail_compilation/bug9631.d(81): Error: function literal `__lambda4(S s)` is not callable using argument types `(S)`
+fail_compilation/bug9631.d(81): Error: function literal `__lambda_L81_C5(S s)` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(81):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S s`
 fail_compilation/bug9631.d(87): Error: constructor `bug9631.arg.A.this(S __param_0)` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(87):        cannot pass argument `S(0)` of type `bug9631.tem!().S` to parameter `bug9631.S __param_0`

--- a/compiler/test/fail_compilation/constraints_defs.d
+++ b/compiler/test/fail_compilation/constraints_defs.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 fail_compilation/constraints_defs.d(49): Error: template instance `constraints_defs.main.def!(int, 0, (a) => a)` does not match template declaration `def(T, int i = 5, alias R)()`
   with `T = int,
        i = 0,
-       R = __lambda1`
+       R = __lambda_L49_C18`
   must satisfy the following constraint:
 `       N!T`
 fail_compilation/constraints_defs.d(50): Error: template instance `imports.constraints.defa!int` does not match template declaration `defa(T, U = int)()`

--- a/compiler/test/fail_compilation/constraints_tmpl.d
+++ b/compiler/test/fail_compilation/constraints_tmpl.d
@@ -22,7 +22,7 @@ fail_compilation/constraints_tmpl.d(41): Error: template instance `imports.const
 `       N!T
        N!U`
 fail_compilation/constraints_tmpl.d(43): Error: template instance `constraints_tmpl.main.lambda!((a) => a)` does not match template declaration `lambda(alias pred)()`
-  with `pred = __lambda1`
+  with `pred = __lambda_L43_C13`
   must satisfy the following constraint:
 `       N!int`
 ---

--- a/compiler/test/fail_compilation/cppvar.d
+++ b/compiler/test/fail_compilation/cppvar.d
@@ -9,7 +9,7 @@ fail_compilation/cppvar.d(21): Error: variable `cppvar.staticVar` cannot have `e
 fail_compilation/cppvar.d(21):        perhaps declare it as `__gshared` instead
 fail_compilation/cppvar.d(22): Error: variable `cppvar.sharedVar` cannot have `extern(C++)` linkage because it is `shared`
 fail_compilation/cppvar.d(22):        perhaps declare it as `__gshared` instead
-fail_compilation/cppvar.d(30): Error: delegate `cppvar.__lambda7` cannot return type `bool[3]` because its linkage is `extern(C++)`
+fail_compilation/cppvar.d(30): Error: delegate `cppvar.__lambda_L30_C46` cannot return type `bool[3]` because its linkage is `extern(C++)`
 ---
 */
 #line 10

--- a/compiler/test/fail_compilation/diag12829.d
+++ b/compiler/test/fail_compilation/diag12829.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag12829.d(15): Error: function `diag12829.test1` is `@nogc` yet allocates closure for `test1()` with the GC
-fail_compilation/diag12829.d(18):        delegate `diag12829.test1.__lambda2` closes over variable `x`
+fail_compilation/diag12829.d(18):        delegate `diag12829.test1.__lambda_L18_C33` closes over variable `x`
 fail_compilation/diag12829.d(17):        `x` declared here
 fail_compilation/diag12829.d(22):        function `diag12829.test1.bar` closes over variable `x`
 fail_compilation/diag12829.d(17):        `x` declared here

--- a/compiler/test/fail_compilation/diag15411.d
+++ b/compiler/test/fail_compilation/diag15411.d
@@ -2,9 +2,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag15411.d(17): Error: function `diag15411.test15411.__funcliteral2` cannot access variable `i` in frame of function `diag15411.test15411`
+fail_compilation/diag15411.d(17): Error: function `diag15411.test15411.__funcliteral_L17_C15` cannot access variable `i` in frame of function `diag15411.test15411`
 fail_compilation/diag15411.d(16):        `i` declared here
-fail_compilation/diag15411.d(18): Error: function `diag15411.test15411.__funcliteral4` cannot access variable `i` in frame of function `diag15411.test15411`
+fail_compilation/diag15411.d(18): Error: function `diag15411.test15411.__funcliteral_L18_C15` cannot access variable `i` in frame of function `diag15411.test15411`
 fail_compilation/diag15411.d(16):        `i` declared here
 fail_compilation/diag15411.d(26): Error: `static` function `diag15411.testNestedFunction.myFunc2` cannot access function `myFunc1` in frame of function `diag15411.testNestedFunction`
 fail_compilation/diag15411.d(25):        `myFunc1` declared here

--- a/compiler/test/fail_compilation/diag20268.d
+++ b/compiler/test/fail_compilation/diag20268.d
@@ -3,8 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag20268.d(12): Error: template `__lambda4` is not callable using argument types `!()(int)`
-fail_compilation/diag20268.d(11):        Candidate is: `__lambda4(__T1, __T2)(x, y)`
+fail_compilation/diag20268.d(12): Error: template `__lambda_L11_C1` is not callable using argument types `!()(int)`
+fail_compilation/diag20268.d(11):        Candidate is: `__lambda_L11_C1(__T1, __T2)(x, y)`
 ---
 */
 

--- a/compiler/test/fail_compilation/diag9831.d
+++ b/compiler/test/fail_compilation/diag9831.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9831.d(13): Error: function `diag9831.main.__lambda3(__T1)(x)` cannot access variable `c` in frame of function `D main`
+fail_compilation/diag9831.d(13): Error: function `diag9831.main.__lambda_L13_C12(__T1)(x)` cannot access variable `c` in frame of function `D main`
 fail_compilation/diag9831.d(11):        `c` declared here
 ---
 */

--- a/compiler/test/fail_compilation/diag_funclit.d
+++ b/compiler/test/fail_compilation/diag_funclit.d
@@ -1,19 +1,19 @@
 /**
 TEST_OUTPUT:
 ---
-fail_compilation/diag_funclit.d(103): Error: function literal `__lambda1(x, y, z)` is not callable using argument types `()`
+fail_compilation/diag_funclit.d(103): Error: function literal `__lambda_L103_C5(x, y, z)` is not callable using argument types `()`
 fail_compilation/diag_funclit.d(103):        too few arguments, expected 3, got 0
-fail_compilation/diag_funclit.d(106): Error: function literal `__lambda2(x, y, z)` is not callable using argument types `(int, string, int, int)`
+fail_compilation/diag_funclit.d(106): Error: function literal `__lambda_L106_C5(x, y, z)` is not callable using argument types `(int, string, int, int)`
 fail_compilation/diag_funclit.d(106):        too many arguments, expected 3, got 4
-fail_compilation/diag_funclit.d(108): Error: function literal `__lambda3(x, y, string z = "Hello")` is not callable using argument types `(int, int, string, string)`
+fail_compilation/diag_funclit.d(108): Error: function literal `__lambda_L108_C5(x, y, string z = "Hello")` is not callable using argument types `(int, int, string, string)`
 fail_compilation/diag_funclit.d(108):        too many arguments, expected 3, got 4
-fail_compilation/diag_funclit.d(110): Error: function literal `__lambda4(x, y, string z = "Hello")` is not callable using argument types `(int)`
+fail_compilation/diag_funclit.d(110): Error: function literal `__lambda_L110_C5(x, y, string z = "Hello")` is not callable using argument types `(int)`
 fail_compilation/diag_funclit.d(110):        too few arguments, expected 3, got 1
-fail_compilation/diag_funclit.d(112): Error: function literal `__lambda5(x, y, z)` is not callable using argument types `(int)`
+fail_compilation/diag_funclit.d(112): Error: function literal `__lambda_L112_C5(x, y, z)` is not callable using argument types `(int)`
 fail_compilation/diag_funclit.d(112):        too few arguments, expected 3, got 1
-fail_compilation/diag_funclit.d(115): Error: function literal `__lambda6(x, y, ...)` is not callable using argument types `(int)`
+fail_compilation/diag_funclit.d(115): Error: function literal `__lambda_L115_C5(x, y, ...)` is not callable using argument types `(int)`
 fail_compilation/diag_funclit.d(115):        too few arguments, expected 2, got 1
-fail_compilation/diag_funclit.d(117): Error: function literal `__lambda7(x, y, string z = "Hey", ...)` is not callable using argument types `(int)`
+fail_compilation/diag_funclit.d(117): Error: function literal `__lambda_L117_C5(x, y, string z = "Hey", ...)` is not callable using argument types `(int)`
 fail_compilation/diag_funclit.d(117):        too few arguments, expected 3, got 1
 ---
  */

--- a/compiler/test/fail_compilation/fail11125.d
+++ b/compiler/test/fail_compilation/fail11125.d
@@ -2,11 +2,11 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail11125.d(26): Error: template instance `fail11125.filter!(function (int a) pure nothrow @nogc @safe => a + 1)` does not match template declaration `filter(alias predfun)`
-  with `predfun = __lambda1`
+  with `predfun = __lambda_L26_C13`
   must satisfy the following constraint:
 `       is(ReturnType!predfun == bool)`
 fail_compilation/fail11125.d(27): Error: template instance `fail11125.filter!(function (int a) pure nothrow @nogc @safe => a + 1)` does not match template declaration `filter(alias predfun)`
-  with `predfun = __lambda2`
+  with `predfun = __lambda_L27_C17`
   must satisfy the following constraint:
 `       is(ReturnType!predfun == bool)`
 ---

--- a/compiler/test/fail_compilation/fail12236.d
+++ b/compiler/test/fail_compilation/fail12236.d
@@ -6,8 +6,8 @@ fail_compilation/fail12236.d(16):        while evaluating `pragma(msg, f1.mangle
 fail_compilation/fail12236.d(21): Error: forward reference to inferred return type of function `f2`
 fail_compilation/fail12236.d(21):        while evaluating `pragma(msg, f2(T)(T).mangleof)`
 fail_compilation/fail12236.d(27): Error: template instance `fail12236.f2!int` error instantiating
-fail_compilation/fail12236.d(31): Error: forward reference to inferred return type of function `__lambda1`
-fail_compilation/fail12236.d(31):        while evaluating `pragma(msg, __lambda1(__T1)(a).mangleof)`
+fail_compilation/fail12236.d(31): Error: forward reference to inferred return type of function `__lambda_L29_C5`
+fail_compilation/fail12236.d(31):        while evaluating `pragma(msg, __lambda_L29_C5(__T1)(a).mangleof)`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail12378.d
+++ b/compiler/test/fail_compilation/fail12378.d
@@ -5,7 +5,7 @@ fail_compilation/fail12378.d(18): Error: undefined identifier `ANYTHING`
 fail_compilation/fail12378.d(18): Error: undefined identifier `GOES`
 fail_compilation/fail12378.d(91):        instantiated from here: `MapResultS!((x0) => ANYTHING - GOES, Result)`
 fail_compilation/fail12378.d(17):        instantiated from here: `mapS!(Result)`
-fail_compilation/fail12378.d(100):        instantiated from here: `__lambda1!int`
+fail_compilation/fail12378.d(100):        instantiated from here: `__lambda_L16_C19!int`
 fail_compilation/fail12378.d(91):        instantiated from here: `MapResultS!((y0) => iota(2).mapS!((x0) => ANYTHING - GOES), Result)`
 fail_compilation/fail12378.d(16):        instantiated from here: `mapS!(Result)`
 ---
@@ -27,7 +27,7 @@ fail_compilation/fail12378.d(40): Error: undefined identifier `ANYTHING`
 fail_compilation/fail12378.d(40): Error: undefined identifier `GOES`
 fail_compilation/fail12378.d(112):        instantiated from here: `MapResultC!((x0) => ANYTHING - GOES, Result)`
 fail_compilation/fail12378.d(39):        instantiated from here: `mapC!(Result)`
-fail_compilation/fail12378.d(123):        instantiated from here: `__lambda1!int`
+fail_compilation/fail12378.d(123):        instantiated from here: `__lambda_L38_C19!int`
 fail_compilation/fail12378.d(112):        instantiated from here: `MapResultC!((y0) => iota(2).mapC!((x0) => ANYTHING - GOES), Result)`
 fail_compilation/fail12378.d(38):        instantiated from here: `mapC!(Result)`
 ---
@@ -49,7 +49,7 @@ fail_compilation/fail12378.d(64): Error: undefined identifier `ANYTHING`
 fail_compilation/fail12378.d(64): Error: undefined identifier `GOES`
 fail_compilation/fail12378.d(135):        instantiated from here: `MapResultI!((x0) => ANYTHING - GOES, Result)`
 fail_compilation/fail12378.d(63):        instantiated from here: `mapI!(Result)`
-fail_compilation/fail12378.d(143):        instantiated from here: `__lambda1!int`
+fail_compilation/fail12378.d(143):        instantiated from here: `__lambda_L62_C19!int`
 fail_compilation/fail12378.d(135):        instantiated from here: `MapResultI!((y0) => iota(2).mapI!((x0) => ANYTHING - GOES), Result)`
 fail_compilation/fail12378.d(62):        instantiated from here: `mapI!(Result)`
 ---

--- a/compiler/test/fail_compilation/fail12908.d
+++ b/compiler/test/fail_compilation/fail12908.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12908.d(14): Error: `pure` delegate `fail12908.main.__foreachbody1` cannot call impure function `fail12908.g`
+fail_compilation/fail12908.d(14): Error: `pure` delegate `fail12908.main.__foreachbody_L12_C5` cannot call impure function `fail12908.g`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail13120.d
+++ b/compiler/test/fail_compilation/fail13120.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13120.d(13): Error: `pure` delegate `fail13120.g1.__foreachbody2` cannot call impure function `fail13120.f1`
-fail_compilation/fail13120.d(13): Error: `@nogc` delegate `fail13120.g1.__foreachbody2` cannot call non-@nogc function `fail13120.f1`
+fail_compilation/fail13120.d(13): Error: `pure` delegate `fail13120.g1.__foreachbody_L12_C5` cannot call impure function `fail13120.f1`
+fail_compilation/fail13120.d(13): Error: `@nogc` delegate `fail13120.g1.__foreachbody_L12_C5` cannot call non-@nogc function `fail13120.f1`
 ---
 */
 void f1() {}

--- a/compiler/test/fail_compilation/fail13424.d
+++ b/compiler/test/fail_compilation/fail13424.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13424.d(12): Error: delegate `fail13424.S.__lambda2` cannot be struct members
-fail_compilation/fail13424.d(17): Error: delegate `fail13424.U.__lambda2` cannot be union members
-fail_compilation/fail13424.d(22): Error: delegate `fail13424.C.__lambda2` cannot be class members
+fail_compilation/fail13424.d(12): Error: delegate `fail13424.S.__lambda_L12_C35` cannot be struct members
+fail_compilation/fail13424.d(17): Error: delegate `fail13424.U.__lambda_L17_C35` cannot be union members
+fail_compilation/fail13424.d(22): Error: delegate `fail13424.C.__lambda_L22_C35` cannot be class members
 ---
 */
 

--- a/compiler/test/fail_compilation/fail17969.d
+++ b/compiler/test/fail_compilation/fail17969.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail17969.d(10): Error: no property `sum` for type `fail17969.__lambda6!(int[]).__lambda6.MapResult2!((b) => b)`
+fail_compilation/fail17969.d(10): Error: no property `sum` for type `fail17969.__lambda_L10_C1!(int[]).__lambda_L10_C1.MapResult2!((b) => b)`
 fail_compilation/fail17969.d(16):        struct `MapResult2` defined here
 ---
  * https://issues.dlang.org/show_bug.cgi?id=17969

--- a/compiler/test/fail_compilation/fail39.d
+++ b/compiler/test/fail_compilation/fail39.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail39.d(12): Error: function `fail39.main.__funcliteral2` cannot access function `foo` in frame of function `D main`
+fail_compilation/fail39.d(12): Error: function `fail39.main.__funcliteral_L12_C27` cannot access function `foo` in frame of function `D main`
 fail_compilation/fail39.d(11):        `foo` declared here
 ---
 */

--- a/compiler/test/fail_compilation/iasm1.d
+++ b/compiler/test/fail_compilation/iasm1.d
@@ -116,7 +116,7 @@ void test5()
 
 /* TEST_OUTPUT:
 ---
-fail_compilation/iasm1.d(615): Error: delegate `iasm1.test6.__foreachbody1` label `L1` is undefined
+fail_compilation/iasm1.d(615): Error: delegate `iasm1.test6.__foreachbody_L611_C5` label `L1` is undefined
 ---
 */
 

--- a/compiler/test/fail_compilation/ice10922.d
+++ b/compiler/test/fail_compilation/ice10922.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10922.d(11): Error: function `__lambda4` is not callable using argument types `()`
+fail_compilation/ice10922.d(11): Error: function `__lambda_L10_C12` is not callable using argument types `()`
 fail_compilation/ice10922.d(11):        too few arguments, expected 1, got 0
-fail_compilation/ice10922.d(10):        `ice10922.__lambda4(in uint n)` declared here
+fail_compilation/ice10922.d(10):        `ice10922.__lambda_L10_C12(in uint n)` declared here
 ---
 */
 

--- a/compiler/test/fail_compilation/ice11822.d
+++ b/compiler/test/fail_compilation/ice11822.d
@@ -5,8 +5,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11822.d(33): Deprecation: function `ice11822.d` is deprecated
-fail_compilation/ice11822.d(16):        instantiated from here: `__lambda2!int`
-fail_compilation/ice11822.d(22):        instantiated from here: `S!(__lambda2)`
+fail_compilation/ice11822.d(16):        instantiated from here: `__lambda_L33_C15!int`
+fail_compilation/ice11822.d(22):        instantiated from here: `S!(__lambda_L33_C15)`
 fail_compilation/ice11822.d(33):        instantiated from here: `g!((n) => d(i))`
 ---
 */

--- a/compiler/test/fail_compilation/ice11850.d
+++ b/compiler/test/fail_compilation/ice11850.d
@@ -3,7 +3,7 @@ EXTRA_FILES: imports/a11850.d
 TEST_OUTPUT:
 ---
 fail_compilation/ice11850.d(15): Error: incompatible types for `(a) < ([0])`: `uint[]` and `int[]`
-fail_compilation/imports/a11850.d(9):        instantiated from here: `FilterResult!(__lambda1, uint[][])`
+fail_compilation/imports/a11850.d(9):        instantiated from here: `FilterResult!(__lambda_L15_C13, uint[][])`
 fail_compilation/ice11850.d(15):        instantiated from here: `filter!(uint[][])`
 ---
 */

--- a/compiler/test/fail_compilation/ice12235.d
+++ b/compiler/test/fail_compilation/ice12235.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12235.d(14): Error: forward reference to inferred return type of function `__lambda1`
-fail_compilation/ice12235.d(15): Error: forward reference to inferred return type of function `__lambda1`
-fail_compilation/ice12235.d(15):        while evaluating `pragma(msg, __lambda1.mangleof)`
+fail_compilation/ice12235.d(14): Error: forward reference to inferred return type of function `__lambda_L12_C5`
+fail_compilation/ice12235.d(15): Error: forward reference to inferred return type of function `__lambda_L12_C5`
+fail_compilation/ice12235.d(15):        while evaluating `pragma(msg, __lambda_L12_C5.mangleof)`
 ---
 */
 

--- a/compiler/test/fail_compilation/ice8309.d
+++ b/compiler/test/fail_compilation/ice8309.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice8309.d(10): Error: incompatible types for `(__lambda1) : (__lambda2)`: `double function() pure nothrow @nogc @safe` and `int function() pure nothrow @nogc @safe`
+fail_compilation/ice8309.d(10): Error: incompatible types for `(__lambda_L10_C15) : (__lambda_L10_C24)`: `double function() pure nothrow @nogc @safe` and `int function() pure nothrow @nogc @safe`
 ---
 */
 

--- a/compiler/test/fail_compilation/misc1.d
+++ b/compiler/test/fail_compilation/misc1.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/misc1.d(108): Error: `5` has no effect
 fail_compilation/misc1.d(109): Error: `1 + 2` has no effect
 fail_compilation/misc1.d(115): Deprecation: `1 * 1` has no effect
-fail_compilation/misc1.d(116): Deprecation: `__lambda3` has no effect
+fail_compilation/misc1.d(116): Deprecation: `__lambda_L116_C34` has no effect
 fail_compilation/misc1.d(122): Deprecation: `false` has no effect
 fail_compilation/misc1.d(125): Deprecation: `*sp++` has no effect
 fail_compilation/misc1.d(126): Deprecation: `j` has no effect

--- a/compiler/test/fail_compilation/opapplyscope.d
+++ b/compiler/test/fail_compilation/opapplyscope.d
@@ -1,7 +1,7 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/opapplyscope.d(113): Error: function `opapplyscope.S.opApply(scope int delegate(scope int* ptr) @safe dg)` is not callable using argument types `(int delegate(int* x) nothrow @nogc @safe)`
-fail_compilation/opapplyscope.d(113):        cannot pass argument `__foreachbody3` of type `int delegate(int* x) nothrow @nogc @safe` to parameter `scope int delegate(scope int* ptr) @safe dg`
+fail_compilation/opapplyscope.d(113):        cannot pass argument `__foreachbody_L113_C5` of type `int delegate(int* x) nothrow @nogc @safe` to parameter `scope int delegate(scope int* ptr) @safe dg`
 ---
  */
 

--- a/compiler/test/fail_compilation/previewin.d
+++ b/compiler/test/fail_compilation/previewin.d
@@ -3,13 +3,13 @@ REQUIRED_ARGS: -preview=in -preview=dip1000
 TEST_OUTPUT:
 ----
 fail_compilation/previewin.d(4): Error: function `takeFunction` is not callable using argument types `(void function(real x) pure nothrow @nogc @safe)`
-fail_compilation/previewin.d(4):        cannot pass argument `__lambda1` of type `void function(real x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
+fail_compilation/previewin.d(4):        cannot pass argument `__lambda_L4_C18` of type `void function(real x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
 fail_compilation/previewin.d(11):        `previewin.takeFunction(void function(in real) f)` declared here
 fail_compilation/previewin.d(5): Error: function `takeFunction` is not callable using argument types `(void function(scope const(real) x) pure nothrow @nogc @safe)`
-fail_compilation/previewin.d(5):        cannot pass argument `__lambda2` of type `void function(scope const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
+fail_compilation/previewin.d(5):        cannot pass argument `__lambda_L5_C18` of type `void function(scope const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
 fail_compilation/previewin.d(11):        `previewin.takeFunction(void function(in real) f)` declared here
 fail_compilation/previewin.d(6): Error: function `takeFunction` is not callable using argument types `(void function(ref scope const(real) x) pure nothrow @nogc @safe)`
-fail_compilation/previewin.d(6):        cannot pass argument `__lambda3` of type `void function(ref scope const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
+fail_compilation/previewin.d(6):        cannot pass argument `__lambda_L6_C18` of type `void function(ref scope const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
 fail_compilation/previewin.d(11):        `previewin.takeFunction(void function(in real) f)` declared here
 fail_compilation/previewin.d(15): Error: scope variable `arg` assigned to global variable `myGlobal`
 fail_compilation/previewin.d(16): Error: scope variable `arg` assigned to global variable `myGlobal`

--- a/compiler/test/fail_compilation/retscope.d
+++ b/compiler/test/fail_compilation/retscope.d
@@ -55,7 +55,7 @@ void test2(scope int* p, int[] a ...) @safe
 TEST_OUTPUT:
 ---
 fail_compilation/retscope.d(75): Error: function `retscope.HTTP.Impl.onReceive` is `@nogc` yet allocates closure for `onReceive()` with the GC
-fail_compilation/retscope.d(77):        delegate `retscope.HTTP.Impl.onReceive.__lambda1` closes over variable `this`
+fail_compilation/retscope.d(77):        delegate `retscope.HTTP.Impl.onReceive.__lambda_L77_C23` closes over variable `this`
 ---
 */
 
@@ -234,10 +234,10 @@ void* funretscope(scope dg_t ptr) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
-fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
-fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda4` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
-fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda4` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `__lambda_L248_C21` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(248): Error: cannot implicitly convert expression `__lambda_L248_C21` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda_L249_C21` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda_L249_C21` of type `void* delegate() pure nothrow @nogc @safe` to `void* delegate() scope @safe`
 ---
 */
 

--- a/compiler/test/fail_compilation/test15306.d
+++ b/compiler/test/fail_compilation/test15306.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test15306.d(15): Error: `immutable` delegate `test15306.main.__dgliteral2` cannot access mutable data `i`
-fail_compilation/test15306.d(19): Error: `shared` delegate `test15306.main.__dgliteral5` cannot access non-shared data `p`
+fail_compilation/test15306.d(15): Error: `immutable` delegate `test15306.main.__dgliteral_L15_C16` cannot access mutable data `i`
+fail_compilation/test15306.d(19): Error: `shared` delegate `test15306.main.__dgliteral_L19_C16` cannot access non-shared data `p`
 ---
 */
 

--- a/compiler/test/fail_compilation/test16193.d
+++ b/compiler/test/fail_compilation/test16193.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test16193.d(39): Error: function `test16193.abc` is `@nogc` yet allocates closure for `abc()` with the GC
-fail_compilation/test16193.d(41):        delegate `test16193.abc.__foreachbody2` closes over variable `x`
+fail_compilation/test16193.d(41):        delegate `test16193.abc.__foreachbody_L41_C5` closes over variable `x`
 fail_compilation/test16193.d(40):        `x` declared here
 ---
 */

--- a/compiler/test/fail_compilation/test17451.d
+++ b/compiler/test/fail_compilation/test17451.d
@@ -2,7 +2,7 @@
 ---
 fail_compilation/test17451.d(22): Error: undefined identifier `allocator`
 fail_compilation/test17451.d(23): Error: `false` has no effect
-fail_compilation/test17451.d(30): Error: variable `test17451.HashMap!(ThreadSlot).HashMap.__lambda2.v` - size of type `ThreadSlot` is invalid
+fail_compilation/test17451.d(30): Error: variable `test17451.HashMap!(ThreadSlot).HashMap.__lambda_L30_C20.v` - size of type `ThreadSlot` is invalid
 fail_compilation/test17451.d(44): Error: template instance `test17451.HashMap!(ThreadSlot)` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/test19107.d
+++ b/compiler/test/fail_compilation/test19107.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/test19107.d(24): Error: template `all` is not callable using argument types `!((c) => c)(string[])`
 fail_compilation/test19107.d(18):        Candidate is: `all(alias pred, T)(T t)`
-  with `pred = __lambda2,
+  with `pred = __lambda_L24_C15,
        T = string[]`
   must satisfy the following constraint:
 `       is(typeof(I!pred(t)))`

--- a/compiler/test/fail_compilation/test19971.d
+++ b/compiler/test/fail_compilation/test19971.d
@@ -3,7 +3,7 @@
 fail_compilation/test19971.d(16): Error: function `f` is not callable using argument types `(string)`
 fail_compilation/test19971.d(16):        cannot pass argument `"%s"` of type `string` to parameter `int x`
 fail_compilation/test19971.d(13):        `test19971.f(int x)` declared here
-fail_compilation/test19971.d(17): Error: function literal `__lambda1(int x)` is not callable using argument types `(string)`
+fail_compilation/test19971.d(17): Error: function literal `__lambda_L17_C5(int x)` is not callable using argument types `(string)`
 fail_compilation/test19971.d(17):        cannot pass argument `"%s"` of type `string` to parameter `int x`
 ---
 */

--- a/compiler/test/fail_compilation/test20719.d
+++ b/compiler/test/fail_compilation/test20719.d
@@ -1,7 +1,7 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/test20719.d(13): Error: struct `test20719.SumType` no size because of forward reference
-fail_compilation/test20719.d(32): Error: variable `test20719.isCopyable!(SumType).__lambda2.foo` - size of type `SumType` is invalid
+fail_compilation/test20719.d(32): Error: variable `test20719.isCopyable!(SumType).__lambda_L32_C22.foo` - size of type `SumType` is invalid
 fail_compilation/test20719.d(18): Error: template instance `test20719.isCopyable!(SumType)` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/test21912.d
+++ b/compiler/test/fail_compilation/test21912.d
@@ -3,16 +3,16 @@ PERMUTE_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
 fail_compilation/test21912.d(28): Error: function `test21912.escapeParam` is `@nogc` yet allocates closure for `escapeParam()` with the GC
-fail_compilation/test21912.d(30):        delegate `test21912.escapeParam.__lambda2` closes over variable `i`
+fail_compilation/test21912.d(30):        delegate `test21912.escapeParam.__lambda_L30_C21` closes over variable `i`
 fail_compilation/test21912.d(28):        `i` declared here
 fail_compilation/test21912.d(33): Error: function `test21912.escapeAssign` is `@nogc` yet allocates closure for `escapeAssign()` with the GC
-fail_compilation/test21912.d(35):        delegate `test21912.escapeAssign.__lambda3` closes over variable `i`
+fail_compilation/test21912.d(35):        delegate `test21912.escapeAssign.__lambda_L35_C10` closes over variable `i`
 fail_compilation/test21912.d(33):        `i` declared here
 fail_compilation/test21912.d(44): Error: function `test21912.escapeAssignRef` is `@nogc` yet allocates closure for `escapeAssignRef()` with the GC
-fail_compilation/test21912.d(46):        delegate `test21912.escapeAssignRef.__lambda3` closes over variable `i`
+fail_compilation/test21912.d(46):        delegate `test21912.escapeAssignRef.__lambda_L46_C10` closes over variable `i`
 fail_compilation/test21912.d(44):        `i` declared here
 fail_compilation/test21912.d(55): Error: function `test21912.escapeParamInferred` is `@nogc` yet allocates closure for `escapeParamInferred()` with the GC
-fail_compilation/test21912.d(57):        delegate `test21912.escapeParamInferred.__lambda2` closes over variable `i`
+fail_compilation/test21912.d(57):        delegate `test21912.escapeParamInferred.__lambda_L57_C29` closes over variable `i`
 fail_compilation/test21912.d(55):        `i` declared here
 ---
 */

--- a/compiler/test/fail_compilation/test23170.d
+++ b/compiler/test/fail_compilation/test23170.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test23170.d(10): Error: array literal in `@nogc` delegate `test23170.__lambda5` may cause a GC allocation
+fail_compilation/test23170.d(10): Error: array literal in `@nogc` delegate `test23170.__lambda_L10_C15` may cause a GC allocation
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=23170

--- a/compiler/test/fail_compilation/testInference.d
+++ b/compiler/test/fail_compilation/testInference.d
@@ -138,7 +138,7 @@ immutable(void)* g10063(inout int* p) pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(154): Error: `pure` function `testInference.bar14049` cannot call impure function `testInference.foo14049!int.foo14049`
-fail_compilation/testInference.d(149):        which calls `testInference.foo14049!int.foo14049.__lambda2`
+fail_compilation/testInference.d(149):        which calls `testInference.foo14049!int.foo14049.__lambda_L147_C14`
 fail_compilation/testInference.d(148):        which calls `testInference.impure14049`
 fail_compilation/testInference.d(143):        which wasn't inferred `pure` because of:
 fail_compilation/testInference.d(143):        `pure` function `testInference.impure14049` cannot access mutable static data `i`

--- a/compiler/test/fail_compilation/var_func_attr.d
+++ b/compiler/test/fail_compilation/var_func_attr.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/var_func_attr.d(19): Error: cannot implicitly convert expression `__lambda8` of type `void function() nothrow @nogc @safe` to `void function() pure`
+fail_compilation/var_func_attr.d(19): Error: cannot implicitly convert expression `__lambda_L19_C27` of type `void function() nothrow @nogc @safe` to `void function() pure`
 ---
 */
 

--- a/compiler/test/runnable/imports/test23722b.d
+++ b/compiler/test/runnable/imports/test23722b.d
@@ -1,14 +1,6 @@
-struct A {
-    import core.stdc.stdio;
-    alias x = () {
-        printf("x\n");
-    };
-    alias y = () {
-        printf("y\n");
-    };
+auto f(string s, alias g)() {
+    return true;
 }
 
-// do_x should call A.x (and print "x")
-void do_x() {
-    A.x();
-}
+alias a = f!("a", output => output);
+alias b = f!("b", output => true);

--- a/compiler/test/runnable/imports/test23722b.d
+++ b/compiler/test/runnable/imports/test23722b.d
@@ -1,0 +1,14 @@
+struct A {
+    import core.stdc.stdio;
+    alias x = () {
+        printf("x\n");
+    };
+    alias y = () {
+        printf("y\n");
+    };
+}
+
+// do_x should call A.x (and print "x")
+void do_x() {
+    A.x();
+}

--- a/compiler/test/runnable/mangle.d
+++ b/compiler/test/runnable/mangle.d
@@ -448,11 +448,11 @@ void test11776()
         if (1)
         {
             auto s = S11776!(a => 1)();
-            static assert(typeof(s).mangleof ==
-                "S"~"6mangle"~tl!("56")~
+            enum expected = "S"~"6mangle"~tl!("56")~
                 ("__T"~"6S11776"~"S"~tl!("42")~
-                 (id!("6mangle","Qs")~"9test11776"~"FZ"~"9__lambda1MFZ"~id!("9__lambda1","Qn"))~"Z"
-                 )~id!("6S11776", "QBm"));
+                 (id!("6mangle","Qs")~"9test11776"~"FZ"~"17__lambda_L444_C14MFZ17__lambda_L450_C30")~"Z"
+                 )~id!("6S11776", "QCm");
+            static assert(typeof(s).mangleof == expected);
         }
     };
 }
@@ -509,7 +509,7 @@ void func12231a()()
 if (is(typeof({
         class C {}
         static assert(C.mangleof ==
-            "C6mangle"~tl!("16")~"__U10func12231aZ"~id!("10func12231a","Qn")~"FZ9__lambda1MFZ1C");
+            "C6mangle"~tl!("16")~"__U10func12231aZ"~id!("10func12231a","Qn")~"FZ17__lambda_L509_C15MFZ1C");
             //         ###            L                       #
     })))
 {}
@@ -517,13 +517,13 @@ if (is(typeof({
 void func12231b()()
 if (is(typeof({
         class C {}        static assert(C.mangleof ==
-            "C6mangle"~tl!("16")~"__U10func12231bZ"~id!("10func12231b","Qn")~"FZ9__lambda1MFZ1C");
+            "C6mangle"~tl!("16")~"__U10func12231bZ"~id!("10func12231b","Qn")~"FZ17__lambda_L518_C15MFZ1C");
             //         L__L           L                       LL
       })) &&
     is(typeof({
         class C {}
         static assert(C.mangleof ==
-            "C6mangle"~tl!("16")~"__U10func12231bZ"~id!("10func12231b","Qn")~"FZ9__lambda2MFZ1C");
+            "C6mangle"~tl!("16")~"__U10func12231bZ"~id!("10func12231b","Qn")~"FZ17__lambda_L523_C15MFZ1C");
             //         L__L           L                       LL
     })))
 {}
@@ -532,14 +532,14 @@ void func12231c()()
 if (is(typeof({
         class C {}
         static assert(C.mangleof ==
-            "C6mangle"~tl!("16")~"__U10func12231cZ"~id!("10func12231c","Qn")~"FZ9__lambda1MFZ1C");
+            "C6mangle"~tl!("16")~"__U10func12231cZ"~id!("10func12231c","Qn")~"FZ17__lambda_L532_C15MFZ1C");
             //         L__L           L                       LL
     })))
 {
     (){
         class C {}
         static assert(C.mangleof ==
-            "C6mangle"~tl!("16")~"__T10func12231cZ"~id!("10func12231c","Qn")~"FZ9__lambda1MFZ1C");
+            "C6mangle"~tl!("16")~"__T10func12231cZ"~id!("10func12231c","Qn")~"FZ16__lambda_L539_C5MFZ1C");
             //         L__L           L                       LL
     }();
 }
@@ -548,14 +548,14 @@ void func12231c(X)()
 if (is(typeof({
         class C {}
     static assert(C.mangleof ==
-            "C6mangle"~tl!("20")~"__U10func12231cTAyaZ"~id!("10func12231c","Qr")~"FZ9__lambda1MFZ1C");
+            "C6mangle"~tl!("20")~"__U10func12231cTAyaZ"~id!("10func12231c","Qr")~"FZ17__lambda_L548_C15MFZ1C");
             //         L__L           L___L                       LL
     })))
 {
     (){
         class C {}
         static assert(C.mangleof ==
-            "C6mangle"~tl!("20")~"__T10func12231cTAyaZ"~id!("10func12231c","Qr")~"FZ9__lambda1MFZ1C");
+            "C6mangle"~tl!("20")~"__T10func12231cTAyaZ"~id!("10func12231c","Qr")~"FZ16__lambda_L555_C5MFZ1C");
             //         L__L           L___L                       LL
     }();
 }
@@ -616,7 +616,7 @@ static assert(funcd.mangleof == "_D6mangle5funcdFPFZNnZi");
 struct S21753 { void function() f1; }
 void fun21753(S21753 v)() {}
 alias fl21753 = (){};
-static assert((fun21753!(S21753(fl21753))).mangleof == "_D6mangle__T8fun21753VSQv6S21753S1f_DQBj10" ~ fl21753.stringof ~ "MFNaNbNiNfZvZQCbQp");
+static assert((fun21753!(S21753(fl21753))).mangleof == "_D6mangle__T8fun21753VSQv6S21753S1f_DQBj16" ~ fl21753.stringof ~ "MFNaNbNiNfZvZQChQp");
 
 /***************************************************/
 void main()

--- a/compiler/test/runnable/test23722.d
+++ b/compiler/test/runnable/test23722.d
@@ -1,0 +1,16 @@
+// COMPILE_SEPARATELY:
+// EXTRA_SOURCES: imports/test23722b.d
+// REQUIRED_ARGS: -betterC
+// https://issues.dlang.org/show_bug.cgi?id=23722
+// Lambdas are mangled incorrectly when using multiple compilation units, resulting in incorrect code
+import imports.test23722b;
+
+// do_y should call A.y (and print "y")
+void do_y() {
+    A.y();
+}
+
+extern (C) void main() {
+    do_y(); // should print y
+    do_x(); // should print x
+}

--- a/compiler/test/runnable/test23722.d
+++ b/compiler/test/runnable/test23722.d
@@ -5,12 +5,8 @@
 // Lambdas are mangled incorrectly when using multiple compilation units, resulting in incorrect code
 import imports.test23722b;
 
-// do_y should call A.y (and print "y")
-void do_y() {
-    A.y();
+bool f() {
+    return b;
 }
 
-extern (C) void main() {
-    do_y(); // should print y
-    do_x(); // should print x
-}
+void main() {}

--- a/compiler/test/runnable/testkeyword.d
+++ b/compiler/test/runnable/testkeyword.d
@@ -97,8 +97,8 @@ void main(string[] args) nothrow
 
     auto funcLiteral = (int x, int y)
     {
-        enum thisFunc  = "testkeyword.main.__lambda5";
-        enum thisFunc2 = "testkeyword.main.__lambda5(int x, int y)";
+        enum thisFunc  = "testkeyword.main.__lambda_L98_C24";
+        enum thisFunc2 = "testkeyword.main.__lambda_L98_C24(int x, int y)";
 
         static assert(getFuncArgFile()  == thisFile);
         static assert(getFuncArgLine()  == 104);

--- a/compiler/test/runnable/traits.d
+++ b/compiler/test/runnable/traits.d
@@ -10,7 +10,7 @@ Creating library {{RESULTS_DIR}}/runnable/traits_0.lib and object {{RESULTS_DIR}
 TRANSFORM_OUTPUT: remove_lines("Creating library")
 TEST_OUTPUT:
 ---
-__lambda1
+__lambda_L1073_C5
 ---
 */
 


### PR DESCRIPTION
…lation units, resulting in incorrect code

The problem now is that `FuncExp` in an `alias` is emitted in neither compilation unit, resulting in an undefined reference error.