### PR TITLE
Fix Issue 24013 - [REG 2.103.0] address of a __traits(getOverloads) item is not converted to a delegate anymore

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1189,6 +1189,13 @@ L1:
  */
 private bool haveSameThis(FuncDeclaration outerFunc, FuncDeclaration calledFunc)
 {
+    // https://issues.dlang.org/show_bug.cgi?id=24013
+    // traits(getOverloads) inserts an alias to select the overload.
+    // When searching for the right this we need to use the aliased
+    // overload/function, not the alias.
+    outerFunc = outerFunc.toAliasFunc();
+    calledFunc = calledFunc.toAliasFunc();
+
     auto thisAd = outerFunc.isMemberLocal();
     if (!thisAd)
         return false;

--- a/compiler/test/compilable/test24013.d
+++ b/compiler/test/compilable/test24013.d
@@ -1,0 +1,43 @@
+// https://issues.dlang.org/show_bug.cgi?id=24013
+
+struct PropDescriptor(T)
+{
+    void define(T delegate() aGetter, string aName) {}
+}
+
+enum Get;
+
+mixin template PropertyPublisherImpl()
+{
+    void collectPublicationsFromPairs(T)()
+    {
+        foreach (member; __traits(derivedMembers, T))
+        foreach (overload; __traits(getOverloads, T, member))
+        {
+            alias Attributes = __traits(getAttributes, overload);
+            static if (Attributes.length != 0)
+            {
+                auto descriptor = new PropDescriptor!size_t;
+                auto dg = &overload;
+                descriptor.define(dg, member);
+            }
+        }
+    }
+}
+
+void main()
+{
+    class Bar
+    {
+        size_t _field;
+        mixin PropertyPublisherImpl;
+        this()
+        {
+            collectPublicationsFromPairs!Bar;
+        }
+        @Get size_t field()
+        {
+            return _field;
+        }
+    }
+}


### PR DESCRIPTION
`traits(getOverloads)` uses an alias to single out overloads iterated over with (static) foreach. However, the function alias does not share any of the aliased functions properties, such as the parent. When establishing whether a function that is used should be prepended with a this, we need the original function, not the alias.