### PR TITLE
Upstream vendor-specific errors relating to missing object.d

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -53,6 +53,10 @@ import dmd.target;
 import dmd.utils;
 import dmd.visitor;
 
+version (IN_GCC) {}
+else version (IN_LLVM) {}
+else version = MARS;
+
 // function used to call semantic3 on a module's dependencies
 void semantic3OnDependencies(Module m)
 {
@@ -615,9 +619,18 @@ extern (C++) final class Module : Package
         if (FileName.equals(srcfile.toString(), "object.d"))
         {
             .error(loc, "cannot find source code for runtime library file 'object.d'");
-            errorSupplemental(loc, "dmd might not be correctly installed. Run 'dmd -man' for installation instructions.");
-            const dmdConfFile = global.inifilename.length ? FileName.canonicalName(global.inifilename) : "not found";
-            errorSupplemental(loc, "config file: %.*s", cast(int)dmdConfFile.length, dmdConfFile.ptr);
+            version (IN_LLVM)
+            {
+                errorSupplemental(loc, "ldc2 might not be correctly installed.");
+                errorSupplemental(loc, "Please check your ldc2.conf configuration file.");
+                errorSupplemental(loc, "Installation instructions can be found at http://wiki.dlang.org/LDC.");
+            }
+            version (MARS)
+            {
+                errorSupplemental(loc, "dmd might not be correctly installed. Run 'dmd -man' for installation instructions.");
+                const dmdConfFile = global.inifilename.length ? FileName.canonicalName(global.inifilename) : "not found";
+                errorSupplemental(loc, "config file: %.*s", cast(int)dmdConfFile.length, dmdConfFile.ptr);
+            }
         }
         else if (FileName.ext(this.arg) || !loc.isValid())
         {


### PR DESCRIPTION
Each downstream compiler has subtle differences in its set-up, and so it doesn't work to just emit the same set of errors for all.

DMD:
1. Is installed as a standalone D compiler (has its own releases).
2. Has a dmd.conf configuration file.
3. Has a command-line option to get to installation instructions.

LDC:
1. Is installed as a standalone D compiler (has its own releases).
2. Has an ldc2.conf configuration file.
3. Has a fixed wiki page with installation instructions.

GDC:
1. Is installed as part of a toolchain with other languages, assembler, linker, ...
2. Has no configuration file.
3. Has documentation, but the root URL path is a configure option `--with-documentation-root-url` and not available to the D front-end.