### PR TITLE
Fix Issue 24010 - Destructor called before end of scope for tuples

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -279,6 +279,24 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 ++i;
                 continue;       // look for errors in rest of statements
             }
+
+            // expand tuple variables in order to attach destruction/exception logic
+            if (auto es = s.isExpStatement())
+            {
+                if (es.exp && es.exp.isDeclarationExp())
+                {
+                    auto de = es.exp.isDeclarationExp();
+                    auto vd = de.declaration.isVarDeclaration();
+                    if (vd && vd.aliasTuple && vd.aliasTuple.objects.length)
+                    {
+                        auto j = i;
+                        cs.statements.insert(i, vd.aliasTuple.objects.length - 1, null);
+                        vd.aliasTuple.foreachVar((v) { (*cs.statements)[j++] = toStatement(v); });
+                        s = (*cs.statements)[i];
+                    }
+                }
+            }
+
             Statement sentry;
             Statement sexception;
             Statement sfinally;

--- a/compiler/test/runnable/sdtor.d
+++ b/compiler/test/runnable/sdtor.d
@@ -4814,6 +4814,41 @@ void testPR12012()
 }
 
 /**********************************/
+// https://issues.dlang.org/show_bug.cgi?id=24010
+
+alias AliasSeq(TList...) = TList;
+
+__gshared int x24010 = 7;
+
+struct A24010 {
+    int x;
+    ~this() {
+        printf("A.~this\n");
+        x24010 += 1;
+    }
+}
+
+struct B24010 {
+    ~this() {
+        printf("B.~this\n");
+        x24010 *= 10;
+    }
+}
+
+void test24010()
+{
+    {
+        AliasSeq!(A24010, B24010) params;
+        printf("statement\n");
+        params[0].x = 3;
+        printf(".x = %d\n", params[0].x);
+        assert(params[0].x == 3);
+        assert(x24010 == 7);
+    }
+    assert(x24010 == 71);
+}
+
+/**********************************/
 
 int main()
 {
@@ -4954,6 +4989,7 @@ int main()
     test67();
     test68();
     testPR12012();
+    test24010();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Expand tuple declarations to separate statements, this way each variable gets the usual destruction/exception code attached.