### PR TITLE
CHANGE: Make `array.length = n` `@system` if default construction is disabled on the array type (fixes 24018)

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -9846,7 +9846,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             ale.e1 = ale1x;
 
             Type tn = ale.e1.type.toBasetype().nextOf();
-            checkDefCtor(ale.loc, tn);
+            TypeStruct ts = tn.isTypeStruct();
+            if (ts && ts.sym.noDefaultCtor) {
+                if (sc.setUnsafe(false, exp.loc,
+                    "cannot reallocate array of structs without default constructor in `@safe` function `%s`",
+                    sc.func))
+                {
+                    return setError();
+                }
+            }
 
             Identifier hook = global.params.tracegc ? Id._d_arraysetlengthTTrace : Id._d_arraysetlengthT;
             if (!verifyHookExist(exp.loc, *sc, Id._d_arraysetlengthTImpl, "resizing arrays"))

--- a/compiler/test/compilable/issue24018.d
+++ b/compiler/test/compilable/issue24018.d
@@ -1,0 +1,10 @@
+struct S
+{
+    @disable this();
+}
+
+void main()
+{
+    S[] s;
+    s = s ~ s;
+}


### PR DESCRIPTION
# This is a language change!

Before: `array.length = 10;` will error if `array` is of a nonconstructable type.
After: `array.length = 10;` allocates the array, but marks the current scope as `@system`.

This is needed as there is otherwise no good way to reallocate an array of non-constructable elements in runtime code. (We can't use concatenation, because we *are* concatenation in the 24018 case.)

Hm, I guess we could call `GC.realloc` manually? But I'm not sure what the args would be.