### PR TITLE
Fix Issue 23966 - [REG2.102] Cannot use traits(getAttributes) with overloaded template

### DIFF
--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1968,7 +1968,8 @@ extern (C++) class FuncDeclaration : Declaration
         overloadApply(cast() this, (Dsymbol s)
         {
             auto f = s.isFuncDeclaration();
-            if (!f)
+            auto td = s.isTemplateDeclaration();
+            if (!f && !td)
                 return 0;
             if (result)
             {

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1223,7 +1223,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             // @@@DEPRECATION 2.100.2
             if (auto td = s.isTemplateDeclaration())
             {
-                if (td.overnext || td.funcroot)
+                if (td.overnext || td.overroot)
                 {
                     deprecation(e.loc, "`__traits(getAttributes)` may only be used for individual functions, not overload sets such as: `%s`", td.ident.toChars());
                     deprecationSupplemental(e.loc, "the result of `__traits(getOverloads)` may be used to select the desired function to extract attributes from");

--- a/compiler/test/compilable/cppmangle.d
+++ b/compiler/test/compilable/cppmangle.d
@@ -528,7 +528,6 @@ version (CppMangle_Itanium)
     static assert(basic_ostream!(char, char_traits!char).food.mangleof == "_ZNSo4foodEv");
     static assert(basic_iostream!(char, char_traits!char).fooe.mangleof == "_ZNSd4fooeEv");
 
-    static assert(func_18957_2.mangleof == `_Z12func_18957_2PSaIiE`);
     static assert(func_18957_2!(allocator!int).mangleof == `_Z12func_18957_2ISaIiEET_PS1_`);
 
     static assert(func_20413.mangleof == `_Z10func_20413St4pairIifES_IfiE`);

--- a/compiler/test/compilable/test23966.d
+++ b/compiler/test/compilable/test23966.d
@@ -1,0 +1,19 @@
+// https://issues.dlang.org/show_bug.cgi?id=23966
+module test23966;
+
+@("gigi")
+void fun() {}
+@("mimi")
+void fun(int) {}
+@("hihi")
+void fun(int, int) {}
+@("bibi")
+void fun()(int, ulong) {}
+
+void main()
+{
+    static foreach (t; __traits(getOverloads, test23966, "fun", true))
+        static foreach(attr; __traits(getAttributes, t))
+        {}
+
+}


### PR DESCRIPTION
`FuncDeclaration.isUnique` did not take into account template overloads. This caused some FuncAliasDeclarations (used by `traits(getOverloads)`) to be wrongfully substituted and therefore tripped the deprecation. I fixed the `isUnique` function to take into consideration templates, however, this affects the mangling of some functions (see commented test). 