### PR TITLE
Fix issue 24018: set length manually via runtime function.

### DIFF
--- a/compiler/test/compilable/issue24018.d
+++ b/compiler/test/compilable/issue24018.d
@@ -1,0 +1,10 @@
+struct S
+{
+    @disable this();
+}
+
+void main()
+{
+    S[] s;
+    s = s ~ s;
+}

--- a/druntime/src/core/internal/array/concatenation.d
+++ b/druntime/src/core/internal/array/concatenation.d
@@ -19,6 +19,7 @@ module core.internal.array.concatenation;
  */
 Tret _d_arraycatnTX(Tret, Tarr...)(auto ref Tarr froms) @trusted
 {
+    import core.internal.array.capacity : _d_arraysetlengthTImpl;
     import core.internal.traits : hasElaborateCopyConstructor, Unqual;
     import core.lifetime : copyEmplace;
     import core.stdc.string : memcpy;
@@ -38,7 +39,21 @@ Tret _d_arraycatnTX(Tret, Tarr...)(auto ref Tarr froms) @trusted
 
     if (totalLen == 0)
         return res;
-    res.length = totalLen;
+
+    // We cannot use this, because it refuses to work if the array type has disabled default construction.
+    // res.length = totalLen;
+    // Call the runtime function directly instead.
+    // TODO: once `__arrayAlloc` is templated, call that instead.
+    version (D_ProfileGC)
+    {
+        // TODO: forward file, line, name from _d_arraycatnTXTrace
+        _d_arraysetlengthTImpl!(typeof(res))._d_arraysetlengthTTrace(
+            __FILE__, __LINE__, "_d_arraycatnTX", res, totalLen);
+    }
+    else
+    {
+        _d_arraysetlengthTImpl!(typeof(res))._d_arraysetlengthT(res, totalLen);
+    }
 
     /* Currently, if both a postblit and a cpctor are defined, the postblit is
      * used. If this changes, the condition below will have to be adapted.


### PR DESCRIPTION
Alternative solution to https://github.com/dlang/dmd/pull/15352

The "`arr.length = n` doesn't work if `ElementType` is not constructable" check is in the compiler, not in the runtime. So if we call the runtime function directly, we can bypass it.

This is correct because array concatenation doesn't expose unconstructed memory.