### PR TITLE
Fix Issue 24017 - Bypassing nothrow  with debug  doesn’t work

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -745,6 +745,11 @@ private Expression resolveUFCSProperties(Scope* sc, Expression e1, Expression e2
         auto arguments = new Expressions(1);
         (*arguments)[0] = eleft;
         e = new CallExp(loc, e, arguments);
+
+        // https://issues.dlang.org/show_bug.cgi?id=24017
+        if (sc.flags & SCOPE.debug_)
+            (cast(CallExp)e).inDebugStatement = true;
+
         e = e.expressionSemantic(sc);
         checkPropertyCall(e);
         return e.expressionSemantic(sc);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -748,7 +748,7 @@ private Expression resolveUFCSProperties(Scope* sc, Expression e1, Expression e2
 
         // https://issues.dlang.org/show_bug.cgi?id=24017
         if (sc.flags & SCOPE.debug_)
-            (cast(CallExp)e).inDebugStatement = true;
+            e.isCallExp().inDebugStatement = true;
 
         e = e.expressionSemantic(sc);
         checkPropertyCall(e);

--- a/compiler/test/compilable/test24017.d
+++ b/compiler/test/compilable/test24017.d
@@ -1,0 +1,11 @@
+// https://issues.dlang.org/show_bug.cgi?id=24017
+
+// REQUIRED_ARGS: -debug
+
+void writeln(string) {}
+
+void main() nothrow
+{
+    debug writeln("Hello");
+    debug "Hello".writeln;
+}


### PR DESCRIPTION
The way debug scopes are handled is messy. Right now, only call expressions are marked as being in debug statements, however, other expressions which are later rewritten as UFCS call expressions will fall between the cracks. This PR catches a category, but there might be others. I think that a subsequent PR should just unify the implementations and use the scope to deduce whether we are in a debug statement or not. I can only assume that this was not implemented because `canThrow` does not receive a scope as argument.