### PR TITLE
Use params.useExceptions instead of betterC to gate generation of try/catch in ctors

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1422,7 +1422,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
          * https://issues.dlang.org/show_bug.cgi?id=14246
          */
         AggregateDeclaration ad = ctor.isMemberDecl();
-        if (!ctor.fbody || !ad || !ad.fieldDtor || !global.params.dtorFields || global.params.betterC || ctor.type.toTypeFunction.isnothrow)
+        if (!ctor.fbody || !ad || !ad.fieldDtor || !global.params.dtorFields || !global.params.useExceptions || ctor.type.toTypeFunction.isnothrow)
             return visit(cast(FuncDeclaration)ctor);
 
         /* Generate:


### PR DESCRIPTION
In DMD, `-betterC` is the mechanism that controls this individual feature setting, it should not be the gauge as to whether nothrow violating code should be generated or not.

This almost allows the entire front-end to be built with `-fno-exceptions`.  The one remaining place that falls foul is a [scope(failure)](https://github.com/dlang/dmd/blob/7247bb725c0eb358b730341be40563406260ac87/compiler/src/dmd/semantic2.d#L808-L812) in semantic2 that shouldn't be there.