### PR TITLE
Only predefine D_ModuleInfo, D_Exceptions, D_TypeInfo if feature is enabled

### DIFF
--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -135,9 +135,12 @@ void addDefaultVersionIdentifiers(const ref Param params, const ref Target tgt)
     }
     else
     {
-        VersionCondition.addPredefinedGlobalIdent("D_ModuleInfo");
-        VersionCondition.addPredefinedGlobalIdent("D_Exceptions");
-        VersionCondition.addPredefinedGlobalIdent("D_TypeInfo");
+        if (params.useModuleInfo)
+            VersionCondition.addPredefinedGlobalIdent("D_ModuleInfo");
+        if (params.useExceptions)
+            VersionCondition.addPredefinedGlobalIdent("D_Exceptions");
+        if (params.useTypeInfo)
+            VersionCondition.addPredefinedGlobalIdent("D_TypeInfo");
     }
 
     VersionCondition.addPredefinedGlobalIdent("D_HardFloat");


### PR DESCRIPTION
Doesn't affect dmd right now, as there's only a global option to enable/disable these features (`-betterC`).

There is a level of possibly redundant future-proofing in this (i.e: this only makes sense if `-betterC` gets broken up into individual feature-disabling flags).  However, `params.betterC` should never be used as the gate to control compile-time behaviour where existing feature controls are much more appropriate.