### PR TITLE
Remove nothrow from doGNUABITagSemantic predicate function

### DIFF
--- a/compiler/src/dmd/root/array.d
+++ b/compiler/src/dmd/root/array.d
@@ -574,7 +574,7 @@ unittest
 private template arraySortWrapper(T, alias fn)
 {
     pragma(mangle, "arraySortWrapper_" ~ T.mangleof ~ "_" ~ fn.mangleof)
-    extern(C) int arraySortWrapper(scope const void* e1, scope const void* e2) nothrow
+    extern(C) int arraySortWrapper(scope const void* e1, scope const void* e2)
     {
         return fn(cast(const(T*))e1, cast(const(T*))e2);
     }

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -805,9 +805,8 @@ private void doGNUABITagSemantic(ref Expression e, ref Expression* lastTag)
     // but it's a concession to practicality.
     // Casts are unfortunately necessary as `implicitConvTo` is not
     // `const` (and nor is `StringExp`, by extension).
-    static int predicate(const scope Expression* e1, const scope Expression* e2) nothrow
+    static int predicate(const scope Expression* e1, const scope Expression* e2)
     {
-        scope(failure) assert(0, "An exception was thrown");
         return (cast(Expression*)e1).toStringExp().compare((cast(Expression*)e2).toStringExp());
     }
     ale.elements.sort!predicate;


### PR DESCRIPTION
The `scope(failure)` construct means that a try/catch statement is inserted into the function, this raises an error when `params.useExceptions` is disabled.  This might look less than ideal, however counter-intuitively this change makes it possible to compile the _whole_ front-end with `-fno-exceptions`.

So the good news is, we could mark every function in the front-end as `nothrow` and it'd successfully compile.

The downside is, that change requires hundreds-to-thousands of code changes everywhere at once.

I'd prefer to do the simplest thing for now and get `-fno-exceptions` working, then if someone finds the time to - or can automate - adding `nothrow` everywhere in the compiler, then all the better later.

@Geod24