### PR TITLE
Remove e2ir/dmsc 'import' from backend

### DIFF
--- a/compiler/src/dmd/backend/dtype.d
+++ b/compiler/src/dmd/backend/dtype.d
@@ -296,7 +296,7 @@ debug
  * Returns:
  *      pointer to newly created type.
  */
-
+@nogc
 type *type_fake(tym_t ty)
 {   type *t;
 

--- a/compiler/src/dmd/backend/symbol.d
+++ b/compiler/src/dmd/backend/symbol.d
@@ -43,7 +43,7 @@ import dmd.backend.code_x86;
 
 void struct_free(struct_t *st) { }
 
-@trusted
+@trusted @nogc
 func_t* func_calloc()
 {
     func_t* f = cast(func_t *) calloc(1, func_t.sizeof);
@@ -272,7 +272,7 @@ Symbol * symbol_calloc(const(char)[] id)
  *      created Symbol
  */
 
-@trusted
+@trusted @nogc
 extern (C)
 Symbol * symbol_name(const(char)[] name, SC sclass, type *t)
 {
@@ -308,7 +308,7 @@ Funcsym *symbol_funcalias(Funcsym *sf)
  * Create a symbol, give it a name, storage class and type.
  */
 
-@trusted
+@trusted @nogc
 Symbol * symbol_generate(SC sclass,type *t)
 {
     __gshared int tmpnum;
@@ -359,7 +359,7 @@ Symbol *symbol_genauto(tym_t ty)
  * Add in the variants for a function symbol.
  */
 
-@trusted
+@trusted @nogc
 void symbol_func(Symbol *s)
 {
     //printf("symbol_func(%s, x%x)\n", s.Sident.ptr, fregsaved);

--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -100,66 +100,6 @@ void backend_init()
     );
 }
 
-
-/***********************************
- * Return aligned 'offset' if it is of size 'size'.
- */
-
-targ_size_t _align(targ_size_t size, targ_size_t offset)
-{
-    switch (size)
-    {
-        case 1:
-            break;
-        case 2:
-        case 4:
-        case 8:
-        case 16:
-        case 32:
-        case 64:
-            offset = (offset + size - 1) & ~(size - 1);
-            break;
-        default:
-            if (size >= 16)
-                offset = (offset + 15) & ~15;
-            else
-                offset = (offset + _tysize[TYnptr] - 1) & ~(_tysize[TYnptr] - 1);
-            break;
-    }
-    return offset;
-}
-
-
-/*******************************
- * Get size of ty
- */
-
-targ_size_t size(tym_t ty)
-{
-    int sz = (tybasic(ty) == TYvoid) ? 1 : tysize(ty);
-    debug
-    {
-        if (sz == -1)
-            printf("ty: %s\n", tym_str(ty));
-    }
-    assert(sz!= -1);
-    return sz;
-}
-
-/****************************
- * Generate symbol of type ty at DATA:offset
- */
-
-Symbol *symboldata(targ_size_t offset,tym_t ty)
-{
-    Symbol *s = symbol_generate(SC.locstat, type_fake(ty));
-    s.Sfl = FLdata;
-    s.Soffset = offset;
-    s.Stype.Tmangle = mTYman_sys; // writes symbol unmodified in Obj::mangle
-    symbol_keep(s);               // keep around
-    return s;
-}
-
 /**************************************
  */
 

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -86,7 +86,7 @@ alias toSymbol = dmd.glue.toSymbol;
 void* mem_malloc2(uint);
 
 
-int REGSIZE() { return _tysize[TYnptr]; }
+private int registerSize() { return _tysize[TYnptr]; }
 
 /* If variable var is a reference
  */
@@ -117,7 +117,7 @@ bool ISX64REF(Declaration var)
              * https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#parameter-passing
              * but watch out because the spec doesn't mention copy construction
              */
-            return var.type.size(Loc.initial) > REGSIZE
+            return var.type.size(Loc.initial) > registerSize
                 || (var.storage_class & STC.lazy_)
                 || (var.type.isTypeStruct() && var.type.isTypeStruct().sym.hasCopyConstruction());
         }
@@ -136,7 +136,7 @@ bool ISX64REF(IRState* irs, Expression exp)
 {
     if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
     {
-        return exp.type.size(Loc.initial) > REGSIZE
+        return exp.type.size(Loc.initial) > registerSize
                || (exp.type.isTypeStruct() && exp.type.isTypeStruct().sym.hasCopyConstruction());
     }
     else if (irs.target.os & Target.OS.Posix)
@@ -6238,7 +6238,7 @@ Lagain:
         edim = el_bin(OPmul, TYsize_t, edim, el_long(TYsize_t, sz));
     }
 
-    if (irs.target.os == Target.OS.Windows && irs.target.is64bit && sz > REGSIZE)
+    if (irs.target.os == Target.OS.Windows && irs.target.is64bit && sz > registerSize)
     {
         evalue = addressElem(evalue, tb);
     }


### PR DESCRIPTION
I asked Walter what to do about the extern declarations of frontend symbols in the backend, and he said that "Those are all hacks I did to get things to work", but "import from the front end is the wrong answer".

So instead, I move the following dmsc.d functions to the backend: `_align, symboldata, size`. I copy the `REGSIZE` function from `e2ir` per Walter's suggestion. No code changes.

That only leaves `dmd.eh : except_gentables` and `dmd.backends.errors.di`, which this PR doesn't touch yet.