### PR TITLE
ImportC: Issue 24022 - Error: attribute `__anonymous` is used as a type

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1909,14 +1909,12 @@ final class CParser(AST) : Parser!AST
                     if (tt.id || tt.tok == TOK.enum_)
                     {
                         if (!tt.id && id)
+                            /* This applies for enums declared as
+                             * typedef enum {A} E;
+                             */
                             tt.id = id;
                         Specifier spec;
-                        auto stag = declareTag(tt, spec);
-                        if (tt.tok == TOK.enum_)
-                        {
-                            isalias = false;
-                            s = new AST.AliasDeclaration(token.loc, id, stag);
-                        }
+                        declareTag(tt, spec);
                     }
                 }
                 if (isalias)

--- a/compiler/test/compilable/imports/imp24022.c
+++ b/compiler/test/compilable/imports/imp24022.c
@@ -1,0 +1,4 @@
+// https://issues.dlang.org/show_bug.cgi?id=24022
+typedef enum {
+    A = 1,
+} E;

--- a/compiler/test/compilable/imports/imp24022.c
+++ b/compiler/test/compilable/imports/imp24022.c
@@ -1,4 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=24022
 typedef enum {
     A = 1,
+    B,
 } E;

--- a/compiler/test/compilable/test24022.d
+++ b/compiler/test/compilable/test24022.d
@@ -15,10 +15,14 @@ auto some_d_other_func() {
 }
 
 void main(string[] args) {
-    E expected = A;
-    auto res = some_d_func(A);
+    E expected = E.A;
+    E res = some_d_func(A);
     assert (res == A);
     assert (res == expected);
+
+    res = some_d_func(E.B);
+    assert (res == B);
+    assert (res == E.B);
 
     auto res2 = some_d_other_func();
     assert (res2.r == A);

--- a/compiler/test/compilable/test24022.d
+++ b/compiler/test/compilable/test24022.d
@@ -1,0 +1,26 @@
+// https://issues.dlang.org/show_bug.cgi?id=24022
+// EXTRA_FILES: imports/imp24022.c
+import imports.imp24022;
+
+auto some_d_func(E v) {
+    return v;
+}
+
+auto some_d_other_func() {
+    const struct R {
+        E r;
+        this(in E vparam) { r = vparam; }
+    }
+    return R(A);
+}
+
+void main(string[] args) {
+    E expected = A;
+    auto res = some_d_func(A);
+    assert (res == A);
+    assert (res == expected);
+
+    auto res2 = some_d_other_func();
+    assert (res2.r == A);
+    assert (res2.r == expected);
+}


### PR DESCRIPTION
Added test case for Issue 24022, related to #14859

#### Minimal example

```c
// testlib.c
typedef enum {
    A = 1,
} E;
```

```d
// test.d
import testlib;

auto some_d_func(E v) {
    return v;
}

void main(string[] args) {
    E expected = A;
    auto res = some_d_func(A);
    assert (res == A);
    assert (res == expected);
}

```

This example produces following error:

```
dmd test.d testlib.c
test.d(3): Error: attribute `__anonymous` is used as a type
```

#### Other example

```c
// testlib.c
typedef enum {
    A = 1,
} E;
```

```d
// test2.d
import testlib;

auto some_d_other_func() {
    const struct R {
        E r;

        this(in E vparam) {
            r = vparam;
        }
    }

    return R(A);
}

void main(string[] args) {
    E expected = A;
    auto res = some_d_other_func(A);
    assert (res.r == A);
    assert (res.r == expected);
}
```

This example produces following error:

```
dmd test2.d testlib.c
test2.d(5): Error: attribute `__anonymous` is used as a type
test2.d(7): Error: attribute `__anonymous` is used as a type
test2.d(16): Error: attribute `__anonymous` is used as a type
```
