### PR TITLE
fix Issue 24010 - Destructor called before end of scope for tuples

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -419,7 +419,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             printf(" type = %s\n", dsym.type ? dsym.type.toChars() : "null");
             printf(" stc = x%llx\n", dsym.storage_class);
             printf(" storage_class = x%llx\n", dsym.storage_class);
-            printf("linkage = %d\n", dsym.linkage);
+            printf("linkage = %d\n", dsym._linkage);
             //if (strcmp(toChars(), "mul") == 0) assert(0);
         }
         //if (semanticRun > PASS.initial)

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -83,6 +83,8 @@ void elem_setLoc(elem *e, const ref Loc loc) nothrow
 
 void Statement_toIR(Statement s, IRState *irs)
 {
+    //printf("Statement_toIR() %s\n", s.toChars());
+
     /* Generate a block for each label
      */
     FuncDeclaration fd = irs.getFunc();
@@ -99,6 +101,7 @@ void Statement_toIR(Statement s, IRState *irs)
     Statement_toIR(s, irs, &stmtstate);
 }
 
+private
 void Statement_toIR(Statement s, IRState *irs, StmtState* stmtstate)
 {
     /****************************************

--- a/compiler/src/dmd/transitivevisitor.d
+++ b/compiler/src/dmd/transitivevisitor.d
@@ -162,14 +162,14 @@ package mixin template ParseVisitMethods(AST)
     }
 
     override void visit(AST.StaticForeachStatement s)
-	{
+    {
         // printf("Visiting StaticForeachStatement\n");
-		if (s.sfe.aggrfe)
+        if (s.sfe.aggrfe)
             s.sfe.aggrfe.accept(this);
 
-		if (s.sfe.rangefe)
+        if (s.sfe.rangefe)
             s.sfe.rangefe.accept(this);
-	}
+    }
 
     override void visit(AST.IfStatement s)
     {

--- a/compiler/test/runnable/sdtor.d
+++ b/compiler/test/runnable/sdtor.d
@@ -4814,6 +4814,41 @@ void testPR12012()
 }
 
 /**********************************/
+// https://issues.dlang.org/show_bug.cgi?id=24010
+
+alias AliasSeq(TList...) = TList;
+
+__gshared int x24010 = 7;
+
+struct A24010 {
+    int x;
+    ~this() {
+        printf("A.~this\n");
+        x24010 += 1;
+    }
+}
+
+struct B24010 {
+    ~this() {
+        printf("B.~this\n");
+        x24010 *= 10;
+    }
+}
+
+void test24010()
+{
+    {
+        AliasSeq!(A24010, B24010) params;
+        printf("statement\n");
+        params[0].x = 3;
+        printf(".x = %d\n", params[0].x);
+        assert(params[0].x == 3);
+        assert(x24010 == 7);
+    }
+    assert(x24010 == 71);
+}
+
+/**********************************/
 
 int main()
 {
@@ -4954,6 +4989,7 @@ int main()
     test67();
     test68();
     testPR12012();
+    test24010();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
I fixed this in 3 separate places, each breaking some unexpected aspect. Finally found the right place to put it. We'll see if it behaves.