### PR TITLE
Add predefined version identifier for visionOS

### DIFF
--- a/changelog/dmd.visionos-version-identifier.dd
+++ b/changelog/dmd.visionos-version-identifier.dd
@@ -1,0 +1,3 @@
+Added predefined version identifier `VisionOS`
+
+This is Apple's new operating system for their VR/AR device Vision Pro.

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -733,6 +733,7 @@ extern (C++) final class VersionCondition : DVCondition
             case "SysV4":
             case "TVOS":
             case "unittest":
+            case "VisionOS":
             case "WASI":
             case "WatchOS":
             case "WebAssembly":

--- a/compiler/test/fail_compilation/reserved_version.d
+++ b/compiler/test/fail_compilation/reserved_version.d
@@ -118,6 +118,7 @@ fail_compilation/reserved_version.d(219): Error: version identifier `D_PostCondi
 fail_compilation/reserved_version.d(220): Error: version identifier `D_ProfileGC` is reserved and cannot be set
 fail_compilation/reserved_version.d(221): Error: version identifier `D_Invariants` is reserved and cannot be set
 fail_compilation/reserved_version.d(222): Error: version identifier `D_Optimized` is reserved and cannot be set
+fail_compilation/reserved_version.d(223): Error: version identifier `VisionOS` is reserved and cannot be set
 ---
 */
 
@@ -242,6 +243,7 @@ version = D_PostConditions;
 version = D_ProfileGC;
 version = D_Invariants;
 version = D_Optimized;
+version = VisionOS;
 
 // This should work though
 debug = DigitalMars;


### PR DESCRIPTION
This is Apple's new operating system for their VR/AR device Vision Pro.

Regarding the name of the version identifier. "visionOS" is the official name, it's used by Apple on their website and in the GUI in Xcode. The LLVM target is named `xros`. The predefined macro set by Clang is `TARGET_OS_XR`. I was not able to find a corresponding identifier in Swift.

Spec PR: https://github.com/dlang/dlang.org/pull/3650.