### PR TITLE
Fix Issue 24025 - Expressions contained in parentheses should not be …

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8823,6 +8823,12 @@ LagainStc:
                                     te.parens = true;
                                     e = parsePostExp(te);
                                 }
+                                else if (token.value == TOK.leftParenthesis)
+                                {
+                                    auto te = new AST.TypeExp(loc, t);
+                                    te.parens = true;
+                                    e = parsePostExp(te);
+                                }
                                 else
                                 {
                                     e = parseUnaryExp();

--- a/compiler/test/fail_compilation/ccast.d
+++ b/compiler/test/fail_compilation/ccast.d
@@ -1,9 +1,28 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ccast.d(9): Error: C style cast illegal, use `cast(byte)i`
+fail_compilation/ccast.d(11): Error: C style cast illegal, use `cast(byte)i`
+fail_compilation/ccast.d(24): Error: C style cast illegal, use `cast(foo)5`
+fail_compilation/ccast.d(26): Error: C style cast illegal, use `cast(void*)5`
 ---
 */
 
 int i;
 byte b = (byte)i;
+
+void bar(int x);
+
+void main()
+{
+    (&bar)(5); // ok
+    auto foo = &bar;
+    (foo = foo)(5); // ok
+    (*foo)(5); // ok
+
+    (foo)(5); // ok
+    (bar)(5); // ok
+    (foo)5;
+
+    (void*)5;
+    (void*)(5); // semantic implicit cast error
+}


### PR DESCRIPTION
…assumed to be C casts

Allow `(Identifier)` and `(BasicType)` when followed by a left parenthesis. These can be a function call or an implicit conversion - the latter may produce a semantic error (not a parse error).