### PR TITLE
revert deprecation of body

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -718,13 +718,16 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                      tk.value == TOK.out_ || tk.value == TOK.do_ || tk.value == TOK.goesTo ||
                      tk.value == TOK.identifier && tk.ident == Id._body))
                 {
-                    // @@@DEPRECATED_2.117@@@
-                    // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
-                    // Deprecated in 2.097 - Can be removed from 2.117
-                    // The deprecation period is longer than usual as `body`
-                    // was quite widely used.
-                    if (tk.value == TOK.identifier && tk.ident == Id._body)
-                        deprecation("usage of the `body` keyword is deprecated. Use `do` instead.");
+                    version (none)
+                    {
+                        // @@@DEPRECATED_2.117@@@
+                        // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                        // Deprecated in 2.097 - Can be removed from 2.117
+                        // The deprecation period is longer than usual as `body`
+                        // was quite widely used.
+                        if (tk.value == TOK.identifier && tk.ident == Id._body)
+                            deprecation("usage of the `body` keyword is deprecated. Use `do` instead.");
+                    }
 
                     a = parseDeclarations(true, pAttrs, pAttrs.comment);
                     if (a && a.length)
@@ -4450,13 +4453,16 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     (tk.value == TOK.leftParenthesis || tk.value == TOK.leftCurly || tk.value == TOK.in_ || tk.value == TOK.out_ || tk.value == TOK.goesTo ||
                      tk.value == TOK.do_ || tk.value == TOK.identifier && tk.ident == Id._body))
                 {
-                    // @@@DEPRECATED_2.117@@@
-                    // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
-                    // Deprecated in 2.097 - Can be removed from 2.117
-                    // The deprecation period is longer than usual as `body`
-                    // was quite widely used.
-                    if (tk.value == TOK.identifier && tk.ident == Id._body)
-                        deprecation("usage of the `body` keyword is deprecated. Use `do` instead.");
+                    version (none)
+                    {
+                        // @@@DEPRECATED_2.117@@@
+                        // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                        // Deprecated in 2.097 - Can be removed from 2.117
+                        // The deprecation period is longer than usual as `body`
+                        // was quite widely used.
+                        if (tk.value == TOK.identifier && tk.ident == Id._body)
+                            deprecation("usage of the `body` keyword is deprecated. Use `do` instead.");
+                    }
 
                     ts = null;
                 }
@@ -5193,12 +5199,15 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         case TOK.identifier:
             if (token.ident == Id._body)
             {
-                // @@@DEPRECATED_2.117@@@
-                // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
-                // Deprecated in 2.097 - Can be removed from 2.117
-                // The deprecation period is longer than usual as `body`
-                // was quite widely used.
-                deprecation("usage of the `body` keyword is deprecated. Use `do` instead.");
+                version (none)
+                {
+                    // @@@DEPRECATED_2.117@@@
+                    // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                    // Deprecated in 2.097 - Can be removed from 2.117
+                    // The deprecation period is longer than usual as `body`
+                    // was quite widely used.
+                    deprecation("usage of the `body` keyword is deprecated. Use `do` instead.");
+                }
                 goto case TOK.do_;
             }
             goto default;
@@ -7572,12 +7581,15 @@ LagainStc:
             case TOK.identifier:
                 if (t.ident == Id._body)
                 {
-                    // @@@DEPRECATED_2.117@@@
-                    // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
-                    // Deprecated in 2.097 - Can be removed from 2.117
-                    // The deprecation period is longer than usual as `body`
-                    // was quite widely used.
-                    deprecation("usage of the `body` keyword is deprecated. Use `do` instead.");
+                    version (none)
+                    {
+                        // @@@DEPRECATED_2.117@@@
+                        // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                        // Deprecated in 2.097 - Can be removed from 2.117
+                        // The deprecation period is longer than usual as `body`
+                        // was quite widely used.
+                        deprecation("usage of the `body` keyword is deprecated. Use `do` instead.");
+                    }
                     goto case TOK.do_;
                 }
                 goto default;

--- a/compiler/test/runnable/testcontracts.d
+++ b/compiler/test/runnable/testcontracts.d
@@ -1,20 +1,4 @@
 /* PERMUTE_ARGS: -inline -g -O
-TEST_OUTPUT:
----
-runnable/testcontracts.d(323): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(324): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(325): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(326): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(328): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(329): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(330): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(331): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(502): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(503): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(504): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(505): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
-runnable/testcontracts.d(505): Deprecation: usage of the `body` keyword is deprecated. Use `do` instead.
----
 */
 extern(C) int printf(const char*, ...);
 


### PR DESCRIPTION
The code comment says it all:

"`body` was quite widely used"

And it doesn't actually hurt anything to leave it in.