### PR TITLE
fix Issue 24024 - cannot pass class this to ref class

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -2468,19 +2468,13 @@ extern (C++) class ThisExp : Expression
         return typeof(return)(true);
     }
 
-    override final bool isLvalue()
+    override bool isLvalue()
     {
-        // Class `this` should be an rvalue; struct `this` should be an lvalue.
-        return type.toBasetype().ty != Tclass;
+        return true;
     }
 
-    override final Expression toLvalue(Scope* sc, Expression e)
+    override Expression toLvalue(Scope* sc, Expression e)
     {
-        if (type.toBasetype().ty == Tclass)
-        {
-            // Class `this` is an rvalue; struct `this` is an lvalue.
-            return Expression.toLvalue(sc, e);
-        }
         return this;
     }
 
@@ -2498,6 +2492,18 @@ extern (C++) final class SuperExp : ThisExp
     extern (D) this(const ref Loc loc)
     {
         super(loc, EXP.super_);
+    }
+
+    override final bool isLvalue()
+    {
+        // Class `super` should be an rvalue
+        return false;
+    }
+
+    override final Expression toLvalue(Scope* sc, Expression e)
+    {
+        // Class `super` is an rvalue
+        return Expression.toLvalue(sc, e);
     }
 
     override void accept(Visitor v)

--- a/compiler/test/compilable/deprecate14283.d
+++ b/compiler/test/compilable/deprecate14283.d
@@ -1,12 +1,12 @@
-// REQUIRED_ARGS: -dw
+// REQUIRED_ARGS:
 // PERMUTE_ARGS:
 class C
 {
     void bug()
     {
-        autoref(this);  // 'auto ref' becomes non-ref parameter
-        autoref(super); // 'auto ref' becomes non-ref parameter
+        autoref!(true, C)(this);  // 'auto ref' becomes ref parameter
+        autoref!(false, Object)(super); // 'auto ref' becomes non-ref parameter
     }
 }
 
-void autoref(T)(auto ref T t) { static assert(__traits(isRef, t) == false); }
+void autoref(bool result, T)(auto ref T t) { static assert(__traits(isRef, t) == result); }

--- a/compiler/test/fail_compilation/diag4596.d
+++ b/compiler/test/fail_compilation/diag4596.d
@@ -1,12 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag4596.d(15): Error: `this` is not an lvalue and cannot be modified
-fail_compilation/diag4596.d(16): Error: conditional expression `1 ? this : this` is not a modifiable lvalue
 fail_compilation/diag4596.d(18): Error: `super` is not an lvalue and cannot be modified
 fail_compilation/diag4596.d(19): Error: conditional expression `1 ? super : super` is not a modifiable lvalue
 ---
 */
+
+
 
 class NoGo4596
 {

--- a/compiler/test/fail_compilation/fail13116.d
+++ b/compiler/test/fail_compilation/fail13116.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13116.d(14): Error: `this` is not an lvalue and cannot be modified
+fail_compilation/fail13116.d(14): Error: returning `this` escapes a reference to parameter `this`
 fail_compilation/fail13116.d(23): Error: `super` is not an lvalue and cannot be modified
 ---
 */


### PR DESCRIPTION
This more or less reverts the change engendered by https://issues.dlang.org/show_bug.cgi?id=13116

https://issues.dlang.org/show_bug.cgi?id=13116#c0 is taken care of by dip1000 now.

https://issues.dlang.org/show_bug.cgi?id=13116#c1 no longer compiles

https://issues.dlang.org/show_bug.cgi?id=13116#c5 doesn't compile

so the justification for 13116 is no longer valid.

`super` is still not an lvalue, because it would allow the "slicing" problem mentioned in 13116.