### PR TITLE
[core.int128] Make I, U private, document Cent type

### DIFF
--- a/druntime/src/core/int128.d
+++ b/druntime/src/core/int128.d
@@ -14,8 +14,8 @@ nothrow:
 @safe:
 @nogc:
 
-alias I = long;
-alias U = ulong;
+private alias I = long;
+private alias U = ulong;
 enum Ubits = uint(U.sizeof * 8);
 
 version (DigitalMars)
@@ -36,6 +36,10 @@ else
     else             private enum Cent_alignment = (size_t.sizeof * 2);
 }
 
+/**
+ * 128 bit integer type.
+ * See_also: $(REF Int128, std,int128).
+ */
 align(Cent_alignment) struct Cent
 {
     version (LittleEndian)


### PR DESCRIPTION
I'm guessing I and U shouldn't be public, they're not documented. Also if they should be accessible, they might be better as members of Cent.

Cent is used in public function signatures so should be documented.