### PR TITLE
change deprecation of scope constructor to warning

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1127,11 +1127,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                                 {
                                     if (sc.func.isSafe())
                                     {
-                                        // @@@DEPRECATED_2.112@@@
-                                        deprecation(dsym.loc,
-                                            "`scope` allocation of `%s` requires that constructor be annotated with `scope`",
-                                            dsym.toChars());
-                                        deprecationSupplemental(ne.member.loc, "is the location of the constructor");
+                                        if (global.params.obsolete)
+                                        {
+                                            warning(dsym.loc,
+                                                "`scope` allocation of `%s` requires that constructor be annotated with `scope`",
+                                                dsym.toChars());
+                                            warningSupplemental(ne.member.loc, "is the location of the constructor");
+                                        }
                                      }
                                      else
                                          sc.func.setUnsafe();

--- a/compiler/test/compilable/test23145.d
+++ b/compiler/test/compilable/test23145.d
@@ -1,8 +1,9 @@
-/* TEST_OUTPUT:
+/* REQUIRED_ARGS: -wo -wi
+TEST_OUTPUT:
 ---
-compilable/test23145.d(117): Deprecation: `scope` allocation of `c` requires that constructor be annotated with `scope`
+compilable/test23145.d(117): Warning: `scope` allocation of `c` requires that constructor be annotated with `scope`
 compilable/test23145.d(111):        is the location of the constructor
-compilable/test23145.d(124): Deprecation: `scope` allocation of `c` requires that constructor be annotated with `scope`
+compilable/test23145.d(124): Warning: `scope` allocation of `c` requires that constructor be annotated with `scope`
 compilable/test23145.d(111):        is the location of the constructor
 ---
 */


### PR DESCRIPTION
First use of the `-wo` switch. Changes https://github.com/dlang/dmd/pull/14175, which tripped up a lot of code, from a deprecation to an opt-in warning.

This is one of those cases I mentioned where the user's code is most likely not buggy, but the compiler cannot verify it. For fully @safe code, the user will need to address this warning.