### PR TITLE
Fix several errors parsing enum members

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3036,6 +3036,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         }
 
         e = new AST.EnumDeclaration(loc, id, memtype);
+        // opaque type
         if (token.value == TOK.semicolon && id)
             nextToken();
         else if (token.value == TOK.leftCurly)
@@ -3068,7 +3069,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     && token.value != TOK.comma
                     && token.value != TOK.assign)
                 {
-                    switch(token.value)
+                    switch (token.value)
                     {
                         case TOK.at:
                             if (StorageClass _stc = parseAttribute(udas))
@@ -3104,7 +3105,12 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                             }
                             else
                             {
-                                goto default;
+                                if (isAnonymousEnum)
+                                    goto default; // maybe `Type identifier`
+
+                                prevTOK = token.value;
+                                nextToken();
+                                error("expected `,` or `=` after identifier, not `%s`", token.toChars());
                             }
                             break;
                         default:

--- a/compiler/test/fail_compilation/biterrors3.d
+++ b/compiler/test/fail_compilation/biterrors3.d
@@ -2,7 +2,7 @@
  * TEST_OUTPUT:
 ---
 fail_compilation/biterrors3.d(103): Error: storage class not allowed for bit-field declaration
-fail_compilation/biterrors3.d(106): Error: `d` is not a valid attribute for enum members
+fail_compilation/biterrors3.d(106): Error: expected `,` or `=` after identifier, not `:`
 fail_compilation/biterrors3.d(106): Error: `:` is not a valid attribute for enum members
 fail_compilation/biterrors3.d(106): Error: `3` is not a valid attribute for enum members
 ---

--- a/compiler/test/fail_compilation/fail10285.d
+++ b/compiler/test/fail_compilation/fail10285.d
@@ -1,10 +1,18 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10285.d(9): Error: no identifier for declarator `int`
+fail_compilation/fail10285.d(13): Error: no identifier for declarator `int`
+fail_compilation/fail10285.d(14): Error: expected `,` or `=` after identifier, not `y`
+fail_compilation/fail10285.d(15): Error: expected identifier after type, not `bool`
+fail_compilation/fail10285.d(16): Error: expected identifier after type, not `int`
+fail_compilation/fail10285.d(18): Error: initializer required after `z` when type is specified
 ---
 */
 enum
 {
-    int = 5
+    int = 5,
+    int x y,
+    int bool i = 3,
+    j int k = 3,
+    int z
 }


### PR DESCRIPTION
See commits. The first one just fixes an existing confusing error.

TBH I think the code needs rewriting, using the switch loop only for attributes. If I do that I'll do it separately after this is merged.

Also added docs for `parseType`, as it confusingly also parses an identifier!