### PR TITLE
make use of body as keyword a legacy feature

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -2494,13 +2494,13 @@ extern (C++) final class SuperExp : ThisExp
         super(loc, EXP.super_);
     }
 
-    override final bool isLvalue()
+    override bool isLvalue()
     {
         // Class `super` should be an rvalue
         return false;
     }
 
-    override final Expression toLvalue(Scope* sc, Expression e)
+    override Expression toLvalue(Scope* sc, Expression e)
     {
         // Class `super` is an rvalue
         return Expression.toLvalue(sc, e);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3384,6 +3384,7 @@ struct CompileEnv final
     bool previewIn;
     bool ddocOutput;
     bool shortenedMethods;
+    bool obsolete;
     CompileEnv() :
         versionNumber(),
         date(),
@@ -3392,10 +3393,11 @@ struct CompileEnv final
         timestamp(),
         previewIn(),
         ddocOutput(),
-        shortenedMethods(true)
+        shortenedMethods(true),
+        obsolete()
     {
     }
-    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}, bool previewIn = false, bool ddocOutput = false, bool shortenedMethods = true) :
+    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}, bool previewIn = false, bool ddocOutput = false, bool shortenedMethods = true, bool obsolete = false) :
         versionNumber(versionNumber),
         date(date),
         time(time),
@@ -3403,7 +3405,8 @@ struct CompileEnv final
         timestamp(timestamp),
         previewIn(previewIn),
         ddocOutput(ddocOutput),
-        shortenedMethods(shortenedMethods)
+        shortenedMethods(shortenedMethods),
+        obsolete(obsolete)
         {}
 };
 
@@ -7150,14 +7153,16 @@ public:
     ThisExp(const Loc& loc, const EXP tok);
     ThisExp* syntaxCopy() override;
     Optional<bool > toBool() override;
-    bool isLvalue() final override;
-    Expression* toLvalue(Scope* sc, Expression* e) final override;
+    bool isLvalue() override;
+    Expression* toLvalue(Scope* sc, Expression* e) override;
     void accept(Visitor* v) override;
 };
 
 class SuperExp final : public ThisExp
 {
 public:
+    bool isLvalue() override;
+    Expression* toLvalue(Scope* sc, Expression* e) override;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -264,6 +264,7 @@ struct CompileEnv
     bool previewIn;
     bool ddocOutput;
     bool shortenedMethods;
+    bool obsolete;
 };
 
 struct Global

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -51,6 +51,7 @@ struct CompileEnv
     bool previewIn;          /// `in` means `[ref] scope const`, accepts rvalues
     bool ddocOutput;         /// collect embedded documentation comments
     bool shortenedMethods = true;   /// allow => in normal function declarations
+    bool obsolete;           /// warn on use of legacy code
 }
 
 /***********************************************************

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -153,9 +153,10 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (parseCommandlineAndConfig(argc, argv, params, files))
         return EXIT_FAILURE;
 
-    global.compileEnv.previewIn = global.params.previewIn;
-    global.compileEnv.ddocOutput = global.params.ddoc.doOutput;
+    global.compileEnv.previewIn        = global.params.previewIn;
+    global.compileEnv.ddocOutput       = global.params.ddoc.doOutput;
     global.compileEnv.shortenedMethods = global.params.shortenedMethods;
+    global.compileEnv.obsolete         = global.params.obsolete;
 
     if (params.usage)
     {
@@ -1943,7 +1944,10 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         else if (arg == "-wi")  // https://dlang.org/dmd.html#switch-wi
             params.warnings = DiagnosticReporting.inform;
         else if (arg == "-wo")  // https://dlang.org/dmd.html#switch-wo
+        {
+            params.warnings = DiagnosticReporting.inform;
             params.obsolete = true;
+        }
         else if (arg == "-O")   // https://dlang.org/dmd.html#switch-O
             driverParams.optimize = true;
         else if (arg == "-o-")  // https://dlang.org/dmd.html#switch-o-

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -9515,14 +9515,9 @@ LagainStc:
 
     void usageOfBodyKeyword()
     {
-        version (none)
+        if (compileEnv.obsolete)
         {
-            // @@@DEPRECATED_2.117@@@
-            // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
-            // Deprecated in 2.097 - Can be removed from 2.117
-            // The deprecation period is longer than usual as `body`
-            // was quite widely used.
-            deprecation("usage of the `body` keyword is deprecated. Use `do` instead.");
+            eSink.warning(token.loc, "usage of identifer `body` as a keyword is obsolete. Use `do` instead.");
         }
     }
 }

--- a/compiler/test/fail_compilation/body.d
+++ b/compiler/test/fail_compilation/body.d
@@ -1,0 +1,11 @@
+/* REQUIRED_ARGS: -wo -w
+TEST_OUTPUT:
+---
+fail_compilation/body.d(11): Warning: usage of identifer `body` as a keyword is obsolete. Use `do` instead.
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
+---
+*/
+
+void test()
+in { } body { }


### PR DESCRIPTION
with a warning when `-wo` is used.