### PR TITLE
[dmd/parse] Refactor enum declaration

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3127,7 +3127,6 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         else if (!ident)
                         {
                             error("no identifier for declarator `%s`", type.toChars());
-
                             type = null;
                         }
                         else

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3149,7 +3149,11 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         }
                         else
                             check(TOK.identifier);
-                        continue;
+
+                        // avoid extra error messages
+                        const tv = token.value;
+                        if (tv != TOK.assign && tv != TOK.comma && tv != TOK.rightCurly && tv != TOK.endOfFile)
+                            continue;
                     }
                 }
 

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3127,6 +3127,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                         else if (!ident)
                         {
                             error("no identifier for declarator `%s`", type.toChars());
+
                             type = null;
                         }
                         else
@@ -3141,8 +3142,14 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     }
                     else
                     {
-                        // error
-                        check(TOK.identifier);
+                        Token* t = &token;
+                        if (isBasicType(&t))
+                        {
+                            error("named enum cannot declare member with type", (*t).toChars());
+                            nextToken();
+                        }
+                        else
+                            check(TOK.identifier);
                         continue;
                     }
                 }

--- a/compiler/test/fail_compilation/biterrors3.d
+++ b/compiler/test/fail_compilation/biterrors3.d
@@ -3,8 +3,8 @@
 ---
 fail_compilation/biterrors3.d(103): Error: storage class not allowed for bit-field declaration
 fail_compilation/biterrors3.d(106): Error: expected `,` or `=` after identifier, not `:`
-fail_compilation/biterrors3.d(106): Error: `:` is not a valid attribute for enum members
-fail_compilation/biterrors3.d(106): Error: `3` is not a valid attribute for enum members
+fail_compilation/biterrors3.d(106): Error: found `:` when expecting `,`
+fail_compilation/biterrors3.d(106): Error: found `3` when expecting `identifier`
 ---
 */
 

--- a/compiler/test/fail_compilation/enum_member.d
+++ b/compiler/test/fail_compilation/enum_member.d
@@ -1,0 +1,23 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/enum_member.d(14): Error: basic type expected, not `for`
+fail_compilation/enum_member.d(15): Error: no identifier for declarator `T`
+fail_compilation/enum_member.d(15): Error: found `@` when expecting `,`
+fail_compilation/enum_member.d(22): Error: found `}` when expecting `identifier`
+fail_compilation/enum_member.d(24): Error: found `End of File` when expecting `,`
+fail_compilation/enum_member.d(24): Error: premature end of file
+---
+*/
+enum
+{
+    for,
+    T @a b = 1
+}
+// See also: fail10285.d
+
+enum E
+{
+    @a
+}
+// See also: fail20538.d

--- a/compiler/test/fail_compilation/fail10285.d
+++ b/compiler/test/fail_compilation/fail10285.d
@@ -1,11 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10285.d(13): Error: no identifier for declarator `int`
-fail_compilation/fail10285.d(14): Error: expected `,` or `=` after identifier, not `y`
-fail_compilation/fail10285.d(15): Error: expected identifier after type, not `bool`
-fail_compilation/fail10285.d(16): Error: expected identifier after type, not `int`
-fail_compilation/fail10285.d(18): Error: initializer required after `z` when type is specified
+fail_compilation/fail10285.d(16): Error: no identifier for declarator `int`
+fail_compilation/fail10285.d(17): Error: expected `,` or `=` after identifier, not `y`
+fail_compilation/fail10285.d(17): Error: initializer required after `x` when type is specified
+fail_compilation/fail10285.d(18): Error: no identifier for declarator `int`
+fail_compilation/fail10285.d(18): Error: found `bool` when expecting `,`
+fail_compilation/fail10285.d(19): Error: no identifier for declarator `j`
+fail_compilation/fail10285.d(19): Error: found `int` when expecting `,`
+fail_compilation/fail10285.d(21): Error: initializer required after `z` when type is specified
 ---
 */
 enum

--- a/compiler/test/fail_compilation/fail10285.d
+++ b/compiler/test/fail_compilation/fail10285.d
@@ -1,15 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10285.d(17): Error: no identifier for declarator `int`
-fail_compilation/fail10285.d(18): Error: expected `,` or `=` after identifier, not `y`
-fail_compilation/fail10285.d(18): Error: initializer required after `x` when type is specified
-fail_compilation/fail10285.d(19): Error: no identifier for declarator `int`
-fail_compilation/fail10285.d(19): Error: found `bool` when expecting `,`
-fail_compilation/fail10285.d(20): Error: no identifier for declarator `j`
-fail_compilation/fail10285.d(20): Error: found `int` when expecting `,`
-fail_compilation/fail10285.d(21): Error: basic type expected, not `for`
-fail_compilation/fail10285.d(23): Error: initializer required after `z` when type is specified
+fail_compilation/fail10285.d(16): Error: no identifier for declarator `int`
+fail_compilation/fail10285.d(17): Error: expected `,` or `=` after identifier, not `y`
+fail_compilation/fail10285.d(17): Error: initializer required after `x` when type is specified
+fail_compilation/fail10285.d(18): Error: no identifier for declarator `int`
+fail_compilation/fail10285.d(18): Error: found `bool` when expecting `,`
+fail_compilation/fail10285.d(19): Error: no identifier for declarator `j`
+fail_compilation/fail10285.d(19): Error: found `int` when expecting `,`
+fail_compilation/fail10285.d(21): Error: initializer required after `z` when type is specified
 ---
 */
 enum
@@ -18,6 +17,5 @@ enum
     int x y,
     int bool i = 3,
     j int k = 3,
-    for,
     int z
 }

--- a/compiler/test/fail_compilation/fail10285.d
+++ b/compiler/test/fail_compilation/fail10285.d
@@ -1,14 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10285.d(16): Error: no identifier for declarator `int`
-fail_compilation/fail10285.d(17): Error: expected `,` or `=` after identifier, not `y`
-fail_compilation/fail10285.d(17): Error: initializer required after `x` when type is specified
-fail_compilation/fail10285.d(18): Error: no identifier for declarator `int`
-fail_compilation/fail10285.d(18): Error: found `bool` when expecting `,`
-fail_compilation/fail10285.d(19): Error: no identifier for declarator `j`
-fail_compilation/fail10285.d(19): Error: found `int` when expecting `,`
-fail_compilation/fail10285.d(21): Error: initializer required after `z` when type is specified
+fail_compilation/fail10285.d(17): Error: no identifier for declarator `int`
+fail_compilation/fail10285.d(18): Error: expected `,` or `=` after identifier, not `y`
+fail_compilation/fail10285.d(18): Error: initializer required after `x` when type is specified
+fail_compilation/fail10285.d(19): Error: no identifier for declarator `int`
+fail_compilation/fail10285.d(19): Error: found `bool` when expecting `,`
+fail_compilation/fail10285.d(20): Error: no identifier for declarator `j`
+fail_compilation/fail10285.d(20): Error: found `int` when expecting `,`
+fail_compilation/fail10285.d(21): Error: basic type expected, not `for`
+fail_compilation/fail10285.d(23): Error: initializer required after `z` when type is specified
 ---
 */
 enum
@@ -17,5 +18,6 @@ enum
     int x y,
     int bool i = 3,
     j int k = 3,
+    for,
     int z
 }

--- a/compiler/test/fail_compilation/fail20538.d
+++ b/compiler/test/fail_compilation/fail20538.d
@@ -1,9 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20538.d(13): Error: found `=` when expecting `identifier`
-fail_compilation/fail20538.d(13): Error: found `1` when expecting `identifier`
-fail_compilation/fail20538.d(13): Error: found `,` when expecting `identifier`
+fail_compilation/fail20538.d(14): Error: found `=` when expecting `identifier`
+fail_compilation/fail20538.d(14): Error: found `1` when expecting `identifier`
+fail_compilation/fail20538.d(14): Error: found `,` when expecting `identifier`
+fail_compilation/fail20538.d(15): Error: found `,` when expecting `identifier`
 ---
 */
 
@@ -11,5 +12,6 @@ enum smth
 {
     a,
     = 1,
+    @a,
     @disable b
 }

--- a/compiler/test/fail_compilation/fail20538.d
+++ b/compiler/test/fail_compilation/fail20538.d
@@ -1,10 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20538.d(14): Error: found `=` when expecting `identifier`
-fail_compilation/fail20538.d(14): Error: found `1` when expecting `identifier`
-fail_compilation/fail20538.d(14): Error: found `,` when expecting `identifier`
+fail_compilation/fail20538.d(15): Error: found `=` when expecting `identifier`
+fail_compilation/fail20538.d(15): Error: found `1` when expecting `identifier`
 fail_compilation/fail20538.d(15): Error: found `,` when expecting `identifier`
+fail_compilation/fail20538.d(16): Error: named enum cannot declare member with type
+fail_compilation/fail20538.d(17): Error: found `,` when expecting `identifier`
 ---
 */
 
@@ -12,6 +13,7 @@ enum smth
 {
     a,
     = 1,
+    int x = 1,
     @a,
     @disable b
 }

--- a/compiler/test/fail_compilation/fail20538.d
+++ b/compiler/test/fail_compilation/fail20538.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20538.d(12): Error: assignment must be preceded by an identifier
-fail_compilation/fail20538.d(12): Error: found `1` when expecting `,`
+fail_compilation/fail20538.d(13): Error: found `=` when expecting `identifier`
+fail_compilation/fail20538.d(13): Error: found `1` when expecting `identifier`
+fail_compilation/fail20538.d(13): Error: found `,` when expecting `identifier`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail20538.d
+++ b/compiler/test/fail_compilation/fail20538.d
@@ -1,11 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail20538.d(15): Error: found `=` when expecting `identifier`
-fail_compilation/fail20538.d(15): Error: found `1` when expecting `identifier`
-fail_compilation/fail20538.d(15): Error: found `,` when expecting `identifier`
-fail_compilation/fail20538.d(16): Error: named enum cannot declare member with type
-fail_compilation/fail20538.d(17): Error: found `,` when expecting `identifier`
+fail_compilation/fail20538.d(13): Error: found `=` when expecting `identifier`
+fail_compilation/fail20538.d(13): Error: found `1` when expecting `identifier`
+fail_compilation/fail20538.d(14): Error: named enum cannot declare member with type
 ---
 */
 
@@ -14,6 +12,5 @@ enum smth
     a,
     = 1,
     int x = 1,
-    @a,
     @disable b
 }

--- a/compiler/test/fail_compilation/failcontracts.d
+++ b/compiler/test/fail_compilation/failcontracts.d
@@ -8,8 +8,8 @@ fail_compilation/failcontracts.d(19): Error: semicolon expected following functi
 fail_compilation/failcontracts.d(20): Error: semicolon expected following function declaration, not `bode`
 fail_compilation/failcontracts.d(22): Error: unexpected `(` in declarator
 fail_compilation/failcontracts.d(22): Error: found `T` when expecting `)`
-fail_compilation/failcontracts.d(22): Error: enum declaration is invalid
-fail_compilation/failcontracts.d(22): Error: found `)` instead of statement
+fail_compilation/failcontracts.d(22): Error: expected `{`, not `;` for enum declaration
+fail_compilation/failcontracts.d(22): Error: use `{ }` for an empty statement, not `;`
 ---
 */
 

--- a/compiler/test/fail_compilation/test9701.d
+++ b/compiler/test/fail_compilation/test9701.d
@@ -5,27 +5,27 @@ fail_compilation/test9701.d(38): Error: `@safe` is not a valid attribute for enu
 fail_compilation/test9701.d(39): Error: `@system` is not a valid attribute for enum members
 fail_compilation/test9701.d(40): Error: `@trusted` is not a valid attribute for enum members
 fail_compilation/test9701.d(41): Error: `@nogc` is not a valid attribute for enum members
-fail_compilation/test9701.d(42): Error: `pure` is not a valid attribute for enum members
-fail_compilation/test9701.d(43): Error: `shared` is not a valid attribute for enum members
-fail_compilation/test9701.d(44): Error: `inout` is not a valid attribute for enum members
-fail_compilation/test9701.d(45): Error: `immutable` is not a valid attribute for enum members
-fail_compilation/test9701.d(46): Error: `const` is not a valid attribute for enum members
-fail_compilation/test9701.d(47): Error: `synchronized` is not a valid attribute for enum members
-fail_compilation/test9701.d(48): Error: `scope` is not a valid attribute for enum members
-fail_compilation/test9701.d(49): Error: `auto` is not a valid attribute for enum members
-fail_compilation/test9701.d(50): Error: `ref` is not a valid attribute for enum members
-fail_compilation/test9701.d(51): Error: `__gshared` is not a valid attribute for enum members
-fail_compilation/test9701.d(52): Error: `final` is not a valid attribute for enum members
-fail_compilation/test9701.d(53): Error: `extern` is not a valid attribute for enum members
-fail_compilation/test9701.d(54): Error: `export` is not a valid attribute for enum members
-fail_compilation/test9701.d(55): Error: `nothrow` is not a valid attribute for enum members
-fail_compilation/test9701.d(56): Error: `public` is not a valid attribute for enum members
-fail_compilation/test9701.d(57): Error: `private` is not a valid attribute for enum members
-fail_compilation/test9701.d(58): Error: `package` is not a valid attribute for enum members
-fail_compilation/test9701.d(59): Error: `static` is not a valid attribute for enum members
-fail_compilation/test9701.d(60): Error: `static` is not a valid attribute for enum members
-fail_compilation/test9701.d(61): Error: `static` is not a valid attribute for enum members
-fail_compilation/test9701.d(62): Error: `static` is not a valid attribute for enum members
+fail_compilation/test9701.d(42): Error: found `pure` when expecting `identifier`
+fail_compilation/test9701.d(43): Error: found `shared` when expecting `identifier`
+fail_compilation/test9701.d(44): Error: found `inout` when expecting `identifier`
+fail_compilation/test9701.d(45): Error: found `immutable` when expecting `identifier`
+fail_compilation/test9701.d(46): Error: found `const` when expecting `identifier`
+fail_compilation/test9701.d(47): Error: found `synchronized` when expecting `identifier`
+fail_compilation/test9701.d(48): Error: found `scope` when expecting `identifier`
+fail_compilation/test9701.d(49): Error: found `auto` when expecting `identifier`
+fail_compilation/test9701.d(50): Error: found `ref` when expecting `identifier`
+fail_compilation/test9701.d(51): Error: found `__gshared` when expecting `identifier`
+fail_compilation/test9701.d(52): Error: found `final` when expecting `identifier`
+fail_compilation/test9701.d(53): Error: found `extern` when expecting `identifier`
+fail_compilation/test9701.d(54): Error: found `export` when expecting `identifier`
+fail_compilation/test9701.d(55): Error: found `nothrow` when expecting `identifier`
+fail_compilation/test9701.d(56): Error: found `public` when expecting `identifier`
+fail_compilation/test9701.d(57): Error: found `private` when expecting `identifier`
+fail_compilation/test9701.d(58): Error: found `package` when expecting `identifier`
+fail_compilation/test9701.d(59): Error: found `static` when expecting `identifier`
+fail_compilation/test9701.d(60): Error: found `static` when expecting `identifier`
+fail_compilation/test9701.d(61): Error: found `static` when expecting `identifier`
+fail_compilation/test9701.d(62): Error: found `static` when expecting `identifier`
 ---
 */
 


### PR DESCRIPTION
~~**Includes #15392 commits**, probably easier to review this if merging that first.~~

Tip: set ignore whitespace for smaller diff.

Remove `prevTOK`.
Only use token loop for attributes, making code much easier to follow.
"expected identifier after type" introduced in previous pull replaced with "no identifier for declarator" for consistency.
Non-`@attr` token "not a valid attribute" error replaced with "expected identifier", as it might not even be an attribute keyword - this is for named enums.
Replace "type only allowed if anonymous enum and no enum type" error, this was never hit:
* The named enum case triggered "not a valid attribute" error instead. Now "named enum cannot declare member with type".
* There was no error for anonymous enums with base type, I'll do that separately

No need to check `terror` as well as `type` which will be null anyway.
"assignment must be preceded by an identifier" has been superceded by other errors.
Make "enum declaration is invalid" error more informative.

New errors:
* lone attribute `@a,`
* attribute after type `T @a b = 1`