### PR TITLE
target: Rename is64bit to isX86_64

### DIFF
--- a/compiler/src/dmd/cpreprocess.d
+++ b/compiler/src/dmd/cpreprocess.d
@@ -117,7 +117,7 @@ private const(char)[] cppCommand()
         {
             VSOptions vsopt;
             vsopt.initialize();
-            auto path = vsopt.compilerPath(target.is64bit);
+            auto path = vsopt.compilerPath(target.isX86_64);
             return toDString(path);
         }
         if (target.objectFormat() == Target.ObjectFormat.omf)

--- a/compiler/src/dmd/dmdparams.d
+++ b/compiler/src/dmd/dmdparams.d
@@ -66,7 +66,7 @@ struct Triple
 {
     private const(char)[] source;
     CPU               cpu;
-    bool              is64bit;
+    bool              isX86_64;
     bool              isLP64;
     Target.OS         os;
     ubyte             osMajor;
@@ -135,14 +135,14 @@ struct Triple
         }
 
         if (matches("x86_64"))
-            is64bit = true;
+            isX86_64 = true;
         else if (matches("x86"))
-            is64bit = false;
+            isX86_64 = false;
         else if (matches("x64"))
-            is64bit = true;
+            isX86_64 = true;
         else if (matches("x32"))
         {
-            is64bit = true;
+            isX86_64 = true;
             isLP64 = false;
         }
         else
@@ -297,7 +297,7 @@ struct Triple
 void setTriple(ref Target target, const ref Triple triple)
 {
     target.cpu     = triple.cpu;
-    target.is64bit = triple.is64bit;
+    target.isX86_64 = triple.isX86_64;
     target.isLP64  = triple.isLP64;
     target.os      = triple.os;
     target.osMajor = triple.osMajor;

--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -44,12 +44,12 @@ void backend_init()
     exefmt_t exfmt;
     switch (target.os)
     {
-        case Target.OS.Windows: exfmt = target.is64bit ? EX_WIN64 : EX_WIN32;       break;
-        case Target.OS.linux:   exfmt = target.is64bit ? EX_LINUX64 : EX_LINUX;     break;
-        case Target.OS.OSX:     exfmt = target.is64bit ? EX_OSX64 : EX_OSX;         break;
-        case Target.OS.FreeBSD: exfmt = target.is64bit ? EX_FREEBSD64 : EX_FREEBSD; break;
-        case Target.OS.OpenBSD: exfmt = target.is64bit ? EX_OPENBSD64 : EX_OPENBSD; break;
-        case Target.OS.Solaris: exfmt = target.is64bit ? EX_SOLARIS64 : EX_SOLARIS; break;
+        case Target.OS.Windows: exfmt = target.isX86_64 ? EX_WIN64 : EX_WIN32;       break;
+        case Target.OS.linux:   exfmt = target.isX86_64 ? EX_LINUX64 : EX_LINUX;     break;
+        case Target.OS.OSX:     exfmt = target.isX86_64 ? EX_OSX64 : EX_OSX;         break;
+        case Target.OS.FreeBSD: exfmt = target.isX86_64 ? EX_FREEBSD64 : EX_FREEBSD; break;
+        case Target.OS.OpenBSD: exfmt = target.isX86_64 ? EX_OPENBSD64 : EX_OPENBSD; break;
+        case Target.OS.Solaris: exfmt = target.isX86_64 ? EX_SOLARIS64 : EX_SOLARIS; break;
         case Target.OS.DragonFlyBSD: exfmt = EX_DRAGONFLYBSD64; break;
         default: assert(0);
     }
@@ -68,7 +68,7 @@ void backend_init()
         exe = true;         // if writing out EXE file
 
     out_config_init(
-        (target.is64bit ? 64 : 32) | (target.objectFormat() == Target.ObjectFormat.coff ? 1 : 0),
+        (target.isX86_64 ? 64 : 32) | (target.objectFormat() == Target.ObjectFormat.coff ? 1 : 0),
         exe,
         false, //params.trace,
         driverParams.nofloat,

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -111,7 +111,7 @@ bool ISX64REF(Declaration var)
 
     if (var.isParameter())
     {
-        if (target.os == Target.OS.Windows && target.is64bit)
+        if (target.os == Target.OS.Windows && target.isX86_64)
         {
             /* Use Microsoft C++ ABI
              * https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#parameter-passing
@@ -134,7 +134,7 @@ bool ISX64REF(Declaration var)
  */
 bool ISX64REF(IRState* irs, Expression exp)
 {
-    if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
+    if (irs.target.os == Target.OS.Windows && irs.target.isX86_64)
     {
         return exp.type.size(Loc.initial) > registerSize
                || (exp.type.isTypeStruct() && exp.type.isTypeStruct().sym.hasCopyConstruction());
@@ -1280,7 +1280,7 @@ elem* toElem(Expression e, IRState *irs)
                 elem *earray = ExpressionsToStaticArray(irs, ne.loc, ne.arguments, &sdata);
 
                 e = el_pair(TYdarray, el_long(TYsize_t, ne.arguments.length), el_ptr(sdata));
-                if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
+                if (irs.target.os == Target.OS.Windows && irs.target.isX86_64)
                     e = addressElem(e, Type.tsize_t.arrayOf());
                 e = el_param(e, getTypeInfo(ne, ne.type, irs));
                 const rtl = t.isZeroInit(Loc.initial) ? RTLSYM.NEWARRAYMTX : RTLSYM.NEWARRAYMITX;
@@ -1507,7 +1507,7 @@ elem* toElem(Expression e, IRState *irs)
                 size_t len = strlen(id);
                 Symbol *si = toStringSymbol(id, len, 1);
                 elem *efilename = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-                if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
+                if (irs.target.os == Target.OS.Windows && irs.target.isX86_64)
                     efilename = addressElem(efilename, Type.tstring, true);
 
                 if (ae.msg)
@@ -1519,7 +1519,7 @@ elem* toElem(Expression e, IRState *irs)
                      */
                     elem *emsg = toElemDtor(ae.msg, irs);
                     emsg = array_toDarray(ae.msg.type, emsg);
-                    if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
+                    if (irs.target.os == Target.OS.Windows && irs.target.isX86_64)
                         emsg = addressElem(emsg, Type.tvoid.arrayOf(), false);
 
                     ea = el_var(getRtlsym(ud ? RTLSYM.DUNITTEST_MSG : RTLSYM.DASSERT_MSG));
@@ -1698,7 +1698,7 @@ elem* toElem(Expression e, IRState *irs)
     {
         elem *ex = toElem(e, irs);
         ex = array_toDarray(e.type, ex);
-        if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
+        if (irs.target.os == Target.OS.Windows && irs.target.isX86_64)
         {
             ex = addressElem(ex, Type.tvoid.arrayOf(), false);
         }
@@ -1963,7 +1963,7 @@ elem* toElem(Expression e, IRState *irs)
 
                 if (t1.ty == Tarray)
                 {
-                    elen1 = el_una(target.is64bit ? OP128_64 : OP64_32, TYsize_t, el_same(&earr1));
+                    elen1 = el_una(target.isX86_64 ? OP128_64 : OP64_32, TYsize_t, el_same(&earr1));
                     esiz1 = el_bin(OPmul, TYsize_t, el_same(&elen1), el_long(TYsize_t, sz));
                     eptr1 = array_toPtr(t1, el_same(&earr1));
                 }
@@ -1977,7 +1977,7 @@ elem* toElem(Expression e, IRState *irs)
 
                 if (t2.ty == Tarray)
                 {
-                    elen2 = el_una(target.is64bit ? OP128_64 : OP64_32, TYsize_t, el_same(&earr2));
+                    elen2 = el_una(target.isX86_64 ? OP128_64 : OP64_32, TYsize_t, el_same(&earr2));
                     esiz2 = el_bin(OPmul, TYsize_t, el_same(&elen2), el_long(TYsize_t, sz));
                     eptr2 = array_toPtr(t2, el_same(&earr2));
                 }
@@ -2236,7 +2236,7 @@ elem* toElem(Expression e, IRState *irs)
                     einit = resolveLengthVar(are.lengthVar, &n1, ta);
                     enbytes = el_copytree(n1);
                     n1 = array_toPtr(ta, n1);
-                    enbytes = el_una(target.is64bit ? OP128_64 : OP64_32, TYsize_t, enbytes);
+                    enbytes = el_una(target.isX86_64 ? OP128_64 : OP64_32, TYsize_t, enbytes);
                 }
                 else if (ta.ty == Tpointer)
                 {
@@ -2350,7 +2350,7 @@ elem* toElem(Expression e, IRState *irs)
                         else
                         {
                             // It's not a constant, so pull it from the dynamic array
-                            return el_una(target.is64bit ? OP128_64 : OP64_32, TYsize_t, el_copytree(ex));
+                            return el_una(target.isX86_64 ? OP128_64 : OP64_32, TYsize_t, el_copytree(ex));
                         }
                     }
 
@@ -2413,7 +2413,7 @@ elem* toElem(Expression e, IRState *irs)
                     // Generate:
                     //      _d_arraycopy(eto, efrom, esize)
 
-                    if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
+                    if (irs.target.os == Target.OS.Windows && irs.target.isX86_64)
                     {
                         eto   = addressElem(eto,   Type.tvoid.arrayOf());
                         efrom = addressElem(efrom, Type.tvoid.arrayOf());
@@ -3661,7 +3661,7 @@ elem* toElem(Expression e, IRState *irs)
     elem* visitArrayLength(ArrayLengthExp ale)
     {
         elem *e = toElem(ale.e1, irs);
-        e = el_una(target.is64bit ? OP128_64 : OP64_32, totym(ale.type), e);
+        e = el_una(target.isX86_64 ? OP128_64 : OP64_32, totym(ale.type), e);
         elem_setLoc(e, ale.loc);
         return e;
     }
@@ -3683,7 +3683,7 @@ elem* toElem(Expression e, IRState *irs)
         elem *e = toElem(dfpe.e1, irs);
         Type tb1 = dfpe.e1.type.toBasetype();
         e = addressElem(e, tb1);
-        e = el_bin(OPadd, TYnptr, e, el_long(TYsize_t, target.is64bit ? 8 : 4));
+        e = el_bin(OPadd, TYnptr, e, el_long(TYsize_t, target.isX86_64 ? 8 : 4));
         e = el_una(OPind, totym(dfpe.type), e);
         elem_setLoc(e, dfpe.loc);
         return e;
@@ -3743,7 +3743,7 @@ elem* toElem(Expression e, IRState *irs)
                         {
                             elen = e;
                             e = el_same(&elen);
-                            elen = el_una(target.is64bit ? OP128_64 : OP64_32, TYsize_t, elen);
+                            elen = el_una(target.isX86_64 ? OP128_64 : OP64_32, TYsize_t, elen);
                         }
                     }
 
@@ -3901,7 +3901,7 @@ elem* toElem(Expression e, IRState *irs)
                 {
                     elength = n1;
                     n1 = el_same(&elength);
-                    elength = el_una(target.is64bit ? OP128_64 : OP64_32, TYsize_t, elength);
+                    elength = el_una(target.isX86_64 ? OP128_64 : OP64_32, TYsize_t, elength);
                 L1:
                     elem *n2x = n2;
                     n2 = el_same(&n2x);
@@ -4047,7 +4047,7 @@ elem* toElem(Expression e, IRState *irs)
 
             elem *ev = el_pair(TYdarray, el_long(TYsize_t, dim), el_ptr(svalues));
             elem *ek = el_pair(TYdarray, el_long(TYsize_t, dim), el_ptr(skeys  ));
-            if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
+            if (irs.target.os == Target.OS.Windows && irs.target.isX86_64)
             {
                 ev = addressElem(ev, Type.tvoid.arrayOf());
                 ek = addressElem(ek, Type.tvoid.arrayOf());
@@ -4461,7 +4461,7 @@ elem *toElemCast(CastExp ce, elem *e, bool isLvalue)
         else
         {
             // e1 . (uint)(e1 >> 32)
-            if (target.is64bit)
+            if (target.isX86_64)
             {
                 e = el_bin(OPshr, TYucent, e, el_long(TYint, 64));
                 e = el_una(OP128_64, totym(t), e);
@@ -4505,7 +4505,7 @@ elem *toElemCast(CastExp ce, elem *e, bool isLvalue)
                 elem *es = el_same(&e);
 
                 elem *eptr = el_una(OPmsw, TYnptr, es);
-                elem *elen = el_una(target.is64bit ? OP128_64 : OP64_32, TYsize_t, e);
+                elem *elen = el_una(target.isX86_64 ? OP128_64 : OP64_32, TYsize_t, e);
                 elem *elen2 = el_bin(OPmul, TYsize_t, elen, el_long(TYsize_t, fsize / tsize));
                 e = el_pair(totym(ce.type), elen2, eptr);
             }
@@ -4626,7 +4626,7 @@ elem *toElemCast(CastExp ce, elem *e, bool isLvalue)
         case Tpointer:
             if (fty == Tdelegate)
                 return Lpaint(ce, e, ttym);
-            tty = target.is64bit ? Tuns64 : Tuns32;
+            tty = target.isX86_64 ? Tuns64 : Tuns32;
             break;
 
         case Tchar:     tty = Tuns8;    break;
@@ -4651,7 +4651,7 @@ elem *toElemCast(CastExp ce, elem *e, bool isLvalue)
             // typeof(null) is same with void* in binary level.
             return Lzero(ce, e, ttym);
         }
-        case Tpointer:  fty = target.is64bit ? Tuns64 : Tuns32;  break;
+        case Tpointer:  fty = target.isX86_64 ? Tuns64 : Tuns32;  break;
         case Tchar:     fty = Tuns8;    break;
         case Twchar:    fty = Tuns16;   break;
         case Tdchar:    fty = Tuns32;   break;
@@ -5327,13 +5327,13 @@ elem *callfunc(const ref Loc loc,
         assert(tf);
         ethis = ec;
         ec = el_same(&ethis);
-        ethis = el_una(target.is64bit ? OP128_64 : OP64_32, TYnptr, ethis); // get this
+        ethis = el_una(target.isX86_64 ? OP128_64 : OP64_32, TYnptr, ethis); // get this
         ec = array_toPtr(t, ec);                // get funcptr
         tym_t tym;
         /* Delegates use the same calling convention as member functions.
          * For extern(C++) on Win32 this differs from other functions.
          */
-        if (tf.linkage == LINK.cpp && !target.is64bit && target.os == Target.OS.Windows)
+        if (tf.linkage == LINK.cpp && !target.isX86_64 && target.os == Target.OS.Windows)
             tym = (tf.parameterList.varargs == VarArg.variadic) ? TYnfunc : TYmfunc;
         else
             tym = totym(tf);
@@ -5411,7 +5411,7 @@ elem *callfunc(const ref Loc loc,
                 continue;
             }
 
-            if (irs.target.os == Target.OS.Windows && irs.target.is64bit && tybasic(ea.Ety) == TYcfloat)
+            if (irs.target.os == Target.OS.Windows && irs.target.isX86_64 && tybasic(ea.Ety) == TYcfloat)
             {
                 /* Treat a cfloat like it was a struct { float re,im; }
                  */
@@ -5590,7 +5590,7 @@ elem *callfunc(const ref Loc loc,
             assert(cast(int)vindex >= 0);
 
             // Build *(ev + vindex * 4)
-            if (!target.is64bit)
+            if (!target.isX86_64)
                 assert(tysize(TYnptr) == 4);
             ec = el_bin(OPadd,TYnptr,ev,el_long(TYsize_t, vindex * tysize(TYnptr)));
             ec = el_una(OPind,TYnptr,ec);
@@ -6141,20 +6141,20 @@ Lagain:
             break;
         case Tfloat32:
         case Timaginary32:
-            if (!target.is64bit)
+            if (!target.isX86_64)
                 goto default;          // legacy binary compatibility
             r = RTLSYM.MEMSETFLOAT;
             break;
         case Tfloat64:
         case Timaginary64:
-            if (!target.is64bit)
+            if (!target.isX86_64)
                 goto default;          // legacy binary compatibility
             r = RTLSYM.MEMSETDOUBLE;
             break;
 
         case Tstruct:
         {
-            if (!target.is64bit)
+            if (!target.isX86_64)
                 goto default;
 
             TypeStruct tc = cast(TypeStruct)tb2;
@@ -6178,7 +6178,7 @@ Lagain:
                 case 2:      r = RTLSYM.MEMSET16;   break;
                 case 4:      r = RTLSYM.MEMSET32;   break;
                 case 8:      r = RTLSYM.MEMSET64;   break;
-                case 16:     r = target.is64bit ? RTLSYM.MEMSET128ii : RTLSYM.MEMSET128; break;
+                case 16:     r = target.isX86_64 ? RTLSYM.MEMSET128ii : RTLSYM.MEMSET128; break;
                 default:     r = RTLSYM.MEMSETN;    break;
             }
 
@@ -6195,7 +6195,7 @@ Lagain:
                 }
             }
 
-            if (target.is64bit && tybasic(evalue.Ety) == TYstruct && r != RTLSYM.MEMSETN)
+            if (target.isX86_64 && tybasic(evalue.Ety) == TYstruct && r != RTLSYM.MEMSETN)
             {
                 /* If this struct is in-memory only, i.e. cannot necessarily be passed as
                  * a gp register parameter.
@@ -6238,7 +6238,7 @@ Lagain:
         edim = el_bin(OPmul, TYsize_t, edim, el_long(TYsize_t, sz));
     }
 
-    if (irs.target.os == Target.OS.Windows && irs.target.is64bit && sz > registerSize)
+    if (irs.target.os == Target.OS.Windows && irs.target.isX86_64 && sz > registerSize)
     {
         evalue = addressElem(evalue, tb);
     }
@@ -6644,7 +6644,7 @@ elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi)
 
     if (edtors)
     {
-        if (irs.target.os == Target.OS.Windows && !irs.target.is64bit) // Win32
+        if (irs.target.os == Target.OS.Windows && !irs.target.isX86_64) // Win32
         {
             Blockx *blx = irs.blx;
             nteh_declarvars(blx);
@@ -6704,7 +6704,7 @@ elem *filelinefunction(IRState *irs, const ref Loc loc)
     size_t len = strlen(id);
     Symbol *si = toStringSymbol(id, len, 1);
     elem *efilename = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-    if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
+    if (irs.target.os == Target.OS.Windows && irs.target.isX86_64)
         efilename = addressElem(efilename, Type.tstring, true);
 
     elem *elinnum = el_long(TYint, loc.linnum);
@@ -6719,7 +6719,7 @@ elem *filelinefunction(IRState *irs, const ref Loc loc)
     len = strlen(s);
     si = toStringSymbol(s, len, 1);
     elem *efunction = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
-    if (irs.target.os == Target.OS.Windows && irs.target.is64bit)
+    if (irs.target.os == Target.OS.Windows && irs.target.isX86_64)
         efunction = addressElem(efunction, Type.tstring, true);
 
     return el_params(efunction, elinnum, efilename, null);
@@ -6979,7 +6979,7 @@ elem* constructVa_start(elem* e)
 
     e.Eoper = OPva_start;
     e.Ety = TYvoid;
-    if (target.is64bit)
+    if (target.isX86_64)
     {
         // (OPparam &va &arg)
         // call as (OPva_start &va)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8189,7 +8189,7 @@ struct Target final
     TargetObjC objc;
     _d_dynamicArray< const char > architectureName;
     CPU cpu;
-    bool is64bit;
+    bool isX86_64;
     bool isLP64;
     _d_dynamicArray< const char > obj_ext;
     _d_dynamicArray< const char > lib_ext;
@@ -8262,7 +8262,7 @@ public:
         objc(),
         architectureName(),
         cpu((CPU)11u),
-        is64bit(true),
+        isX86_64(true),
         isLP64(),
         obj_ext(),
         lib_ext(),
@@ -8276,7 +8276,7 @@ public:
         params()
     {
     }
-    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(), TargetCPP cpp = TargetCPP(), TargetObjC objc = TargetObjC(), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11u, bool is64bit = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool omfobj = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(), Type* tvalist = nullptr, const Param* params = nullptr) :
+    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(), TargetCPP cpp = TargetCPP(), TargetObjC objc = TargetObjC(), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11u, bool isX86_64 = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool omfobj = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(), Type* tvalist = nullptr, const Param* params = nullptr) :
         os(os),
         osMajor(osMajor),
         ptrsize(ptrsize),
@@ -8290,7 +8290,7 @@ public:
         objc(objc),
         architectureName(architectureName),
         cpu(cpu),
-        is64bit(is64bit),
+        isX86_64(isX86_64),
         isLP64(isLP64),
         obj_ext(obj_ext),
         lib_ext(lib_ext),

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -567,14 +567,14 @@ private void genObjFile(Module m, bool multiobj)
         elem *ecov  = el_pair(TYdarray, el_long(TYsize_t, m.numlines), el_ptr(m.cov));
         elem *ebcov = el_pair(TYdarray, el_long(TYsize_t, m.numlines), el_ptr(bcov));
 
-        if (target.os == Target.OS.Windows && target.is64bit)
+        if (target.os == Target.OS.Windows && target.isX86_64)
         {
             ecov  = addressElem(ecov,  Type.tvoid.arrayOf(), false);
             ebcov = addressElem(ebcov, Type.tvoid.arrayOf(), false);
         }
 
         elem *efilename = toEfilename(m);
-        if (target.os == Target.OS.Windows && target.is64bit)
+        if (target.os == Target.OS.Windows && target.isX86_64)
             efilename = addressElem(efilename, Type.tstring, true);
 
         elem *e = el_params(
@@ -1000,7 +1000,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         {
             if (fpr.alloc(sp.Stype, sp.Stype.Tty, &sp.Spreg, &sp.Spreg2))
             {
-                sp.Sclass = (target.os == Target.OS.Windows && target.is64bit) ? SC.shadowreg : SC.fastpar;
+                sp.Sclass = (target.os == Target.OS.Windows && target.isX86_64) ? SC.shadowreg : SC.fastpar;
                 sp.Sfl = (sp.Sclass == SC.shadowreg) ? FLpara : FLfast;
             }
         }
@@ -1029,7 +1029,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     if (fd.v_argptr)
     {
         // Declare va_argsave
-        if (target.is64bit &&
+        if (target.isX86_64 &&
             target.os & Target.OS.Posix)
         {
             type *t = type_struct_class("__va_argsave_t", 16, 8 * 6 + 8 * 16 + 8 * 3 + 8, null, null, false, false, true, false);
@@ -1537,7 +1537,7 @@ tym_t totym(Type tx)
             final switch (tf.linkage)
             {
                 case LINK.windows:
-                    if (target.is64bit)
+                    if (target.isX86_64)
                         goto case LINK.c;
                     t = (tf.parameterList.varargs == VarArg.variadic ||
                          tf.parameterList.varargs == VarArg.KRvariadic) ? TYnfunc : TYnsfunc;
@@ -1550,7 +1550,7 @@ tym_t totym(Type tx)
                     if (target.os == Target.OS.Windows)
                     {
                     }
-                    else if (!target.is64bit && retStyle(tf, false) == RET.stack)
+                    else if (!target.isX86_64 && retStyle(tf, false) == RET.stack)
                         t = TYhfunc;
                     break;
 

--- a/compiler/src/dmd/iasmdmd.d
+++ b/compiler/src/dmd/iasmdmd.d
@@ -749,7 +749,7 @@ RETRY:
     switch (usActual)
     {
         case 0:
-            if (target.is64bit && (pop.ptb.pptb0.usFlags & _i64_bit))
+            if (target.isX86_64 && (pop.ptb.pptb0.usFlags & _i64_bit))
             {
                 asmerr("opcode `%s` is unavailable in 64bit mode", asm_opstr(pop));  // illegal opcode in 64bit mode
                 break;
@@ -792,7 +792,7 @@ RETRY:
                         continue;
 
                     // Check if match is invalid in 64bit mode
-                    if (target.is64bit && (table1.usFlags & _i64_bit))
+                    if (target.isX86_64 && (table1.usFlags & _i64_bit))
                     {
                         bInvalid64bit = true;
                         continue;
@@ -859,7 +859,7 @@ RETRY:
             {
                 if (log) { printf("table1   = "); asm_output_flags(table2.usOp1); printf("\n"); }
                 if (log) { printf("table2   = "); asm_output_flags(table2.usOp2); printf("\n"); }
-                if (target.is64bit && (table2.usFlags & _i64_bit))
+                if (target.isX86_64 && (table2.usFlags & _i64_bit))
                     asmerr("opcode `%s` is unavailable in 64bit mode", asm_opstr(pop));
 
                 const bMatch1 = asm_match_flags(opflags[0], table2.usOp1);
@@ -1354,7 +1354,7 @@ code *asm_emit(Loc loc,
     {
         emit(0x67);
         pc.Iflags |= CFaddrsize;
-        if (!target.is64bit)
+        if (!target.isX86_64)
             amods[i] = _addr16;
         else
             amods[i] = _addr32;
@@ -1475,10 +1475,10 @@ code *asm_emit(Loc loc,
 
     asmstate.statement.regs |= asm_modify_regs(ptb, opnds);
 
-    if (ptb.pptb0.usFlags & _64_bit && !target.is64bit)
+    if (ptb.pptb0.usFlags & _64_bit && !target.isX86_64)
         asmerr("use -m64 to compile 64 bit instructions");
 
-    if (target.is64bit && (ptb.pptb0.usFlags & _64_bit))
+    if (target.isX86_64 && (ptb.pptb0.usFlags & _64_bit))
     {
         emit(REX | REX_W);
         pc.Irex |= REX_W;
@@ -1503,7 +1503,7 @@ code *asm_emit(Loc loc,
         // an immediate and does not affect operation size
         case 3:
         case 2:
-            if ((!target.is64bit &&
+            if ((!target.isX86_64 &&
                   (amods[1] == _addr16 ||
                    (isOneOf(OpndSize._16, uSizemaskTable[1]) && aoptyTable[1] == _rel ) ||
                    (isOneOf(OpndSize._32, uSizemaskTable[1]) && aoptyTable[1] == _mnoi) ||
@@ -1522,7 +1522,7 @@ code *asm_emit(Loc loc,
             goto case;
 
         case 1:
-            if ((!target.is64bit &&
+            if ((!target.isX86_64 &&
                   (amods[0] == _addr16 ||
                    (isOneOf(OpndSize._16, uSizemaskTable[0]) && aoptyTable[0] == _rel ) ||
                    (isOneOf(OpndSize._32, uSizemaskTable[0]) && aoptyTable[0] == _mnoi) ||
@@ -1873,7 +1873,7 @@ L3:
                 {
                     reg &= 7;
                     pc.Irex |= REX_B;
-                    assert(target.is64bit);
+                    assert(target.isX86_64);
                 }
                 if (asmstate.ucItype == ITfloat)
                     pc.Irm += reg;
@@ -1955,12 +1955,12 @@ L3:
                 {
                     reg &= 7;
                     pc.Irex |= REX_B;
-                    assert(target.is64bit);
+                    assert(target.isX86_64);
                 }
                 else if (opnds[0].base.isSIL_DIL_BPL_SPL())
                 {
                     pc.Irex |= REX;
-                    assert(target.is64bit);
+                    assert(target.isX86_64);
                 }
                 if (asmstate.ucItype == ITfloat)
                     pc.Irm += reg;
@@ -1977,12 +1977,12 @@ L3:
                 {
                     reg &= 7;
                     pc.Irex |= REX_B;
-                    assert(target.is64bit);
+                    assert(target.isX86_64);
                 }
                 else if (opnds[0].base.isSIL_DIL_BPL_SPL())
                 {
                     pc.Irex |= REX;
-                    assert(target.is64bit);
+                    assert(target.isX86_64);
                 }
                 if (asmstate.ucItype == ITfloat)
                     pc.Irm += reg;
@@ -2054,7 +2054,7 @@ L3:
                     {
                         reg &= 7;
                         pc.Irex |= REX_B;
-                        assert(target.is64bit);
+                        assert(target.isX86_64);
                     }
                     if (asmstate.ucItype == ITfloat)
                         pc.Irm += reg;
@@ -2532,7 +2532,7 @@ void asm_make_modrm_byte(
                 }
                 else
                 {
-                    pc.IFL1 = target.is64bit ? FLblock : FLblockoff;
+                    pc.IFL1 = target.isX86_64 ? FLblock : FLblockoff;
                     pc.IEV1.Vlsym = cast(_LabelDsymbol*)label;
                 }
                 pc.Iflags |= CFoff;
@@ -2586,7 +2586,7 @@ void asm_make_modrm_byte(
             assert(d);
             if (d.isDataseg() || d.isCodeseg())
             {
-                if (!target.is64bit && amod == _addr16)
+                if (!target.isX86_64 && amod == _addr16)
                 {
                     asmerr("cannot have 16 bit addressing mode in 32 bit code");
                     return;
@@ -2673,7 +2673,7 @@ void asm_make_modrm_byte(
             bOffsetsym = true;
 
     }
-    else if (amod == _addr32 || (amod == _flbl && !target.is64bit))
+    else if (amod == _addr32 || (amod == _flbl && !target.isX86_64))
     {
         bool bModset = false;
 
@@ -3394,7 +3394,7 @@ immutable(REG)* asm_reg_lookup(const(char)[] s)
             return &regtab[i];
         }
     }
-    if (target.is64bit)
+    if (target.isX86_64)
     {
         for (int i = 0; i < regtab64.length; i++)
         {
@@ -3459,7 +3459,7 @@ OpndSize asm_type_size(Type ptype, bool bPtr)
             case 4:     u = OpndSize._32;        break;
             case 6:     u = OpndSize._48;        break;
 
-            case 8:     if (target.is64bit || bPtr)
+            case 8:     if (target.isX86_64 || bPtr)
                             u = OpndSize._64;
                         break;
 

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -317,13 +317,13 @@ public int runLINK()
                 driverParams.mscrtlib[0..6] != "msvcrt" || !isdigit(driverParams.mscrtlib[6]))
                 vsopt.initialize();
 
-            const(char)* linkcmd = getenv(target.is64bit ? "LINKCMD64" : "LINKCMD");
+            const(char)* linkcmd = getenv(target.isX86_64 ? "LINKCMD64" : "LINKCMD");
             if (!linkcmd)
                 linkcmd = getenv("LINKCMD"); // backward compatible
             if (!linkcmd)
-                linkcmd = vsopt.linkerPath(target.is64bit);
+                linkcmd = vsopt.linkerPath(target.isX86_64);
 
-            if (!target.is64bit && FileName.equals(FileName.name(linkcmd), "lld-link.exe"))
+            if (!target.isX86_64 && FileName.equals(FileName.name(linkcmd), "lld-link.exe"))
             {
                 // object files not SAFESEH compliant, but LLD is more picky than MS link
                 cmdbuf.writestring(" /SAFESEH:NO");
@@ -332,7 +332,7 @@ public int runLINK()
                 vsopt.uninitialize();
             }
 
-            if (const(char)* lflags = vsopt.linkOptions(target.is64bit))
+            if (const(char)* lflags = vsopt.linkOptions(target.isX86_64))
             {
                 cmdbuf.writeByte(' ');
                 cmdbuf.writestring(lflags);
@@ -578,7 +578,7 @@ public int runLINK()
         ensurePathToNameExists(Loc.initial, global.params.exefile);
         if (driverParams.symdebug)
             argv.push("-g");
-        if (target.is64bit)
+        if (target.isX86_64)
             argv.push("-m64");
         else
             argv.push("-m32");
@@ -1272,7 +1272,7 @@ public int runPreprocessor(const(char)[] cpp, const(char)[] filename, const(char
         }
 
         // Set memory model
-        argv.push(target.is64bit ? "-m64" : "-m32");
+        argv.push(target.isX86_64 ? "-m64" : "-m32");
 
         // merge #define's with output
         argv.push("-dD");       // https://gcc.gnu.org/onlinedocs/cpp/Invocation.html#index-dD

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -697,7 +697,7 @@ bool parseCommandlineAndConfig(size_t argc, const(char)** argv, ref Param params
     sections.push("Environment");
     parseConfFile(environment, global.inifilename, inifilepath, inifileBuffer, &sections);
 
-    const(char)[] arch = target.is64bit ? "64" : "32"; // use default
+    const(char)[] arch = target.isX86_64 ? "64" : "32"; // use default
     arch = parse_arch_arg(&arguments, arch);
 
     // parse architecture from DFLAGS read from [Environment] section
@@ -708,7 +708,7 @@ bool parseCommandlineAndConfig(size_t argc, const(char)** argv, ref Param params
         arch = parse_arch_arg(&dflags, arch);
     }
 
-    bool is64bit = arch[0] == '6';
+    bool isX86_64 = arch[0] == '6';
 
     version(Windows) // delete LIB entry in [Environment] (necessary for optlink) to allow inheriting environment for MS-COFF
     if (arch != "32omf")
@@ -731,7 +731,7 @@ bool parseCommandlineAndConfig(size_t argc, const(char)** argv, ref Param params
         return true;
     }
 
-    if (target.is64bit != is64bit)
+    if (target.isX86_64 != isX86_64)
         error(Loc.initial, "the architecture must not be changed in the %s section of %.*s",
               envsection.ptr, cast(int)global.inifilename.length, global.inifilename.ptr);
 
@@ -1127,7 +1127,7 @@ private void setDefaultLibrary(ref Param params, const ref Target target)
     {
         if (target.os == Target.OS.Windows)
         {
-            if (target.is64bit)
+            if (target.isX86_64)
                 driverParams.defaultlibname = "phobos64";
             else if (!target.omfobj)
                 driverParams.defaultlibname = "phobos32mscoff";
@@ -1620,22 +1620,22 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         }
         else if (arg == "-m32") // https://dlang.org/dmd.html#switch-m32
         {
-            target.is64bit = false;
+            target.isX86_64 = false;
             target.omfobj = false;
         }
         else if (arg == "-m64") // https://dlang.org/dmd.html#switch-m64
         {
-            target.is64bit = true;
+            target.isX86_64 = true;
             target.omfobj = false;
         }
         else if (arg == "-m32mscoff") // https://dlang.org/dmd.html#switch-m32mscoff
         {
-            target.is64bit = false;
+            target.isX86_64 = false;
             target.omfobj = false;
         }
         else if (arg == "-m32omf") // https://dlang.org/dmd.html#switch-m32omfobj
         {
-            target.is64bit = false;
+            target.isX86_64 = false;
             target.omfobj = true;
         }
         else if (startsWith(p + 1, "mscrtlib="))
@@ -2435,7 +2435,7 @@ private void reconcileCommands(ref Param params, ref Target target)
     }
     else if (target.os == Target.OS.DragonFlyBSD)
     {
-        if (!target.is64bit)
+        if (!target.isX86_64)
             error(Loc.initial, "`-m32` is not supported on DragonFlyBSD, it is 64-bit only");
     }
 
@@ -2550,7 +2550,7 @@ private void reconcileLinkRunLib(ref Param params, size_t numSrcFiles, const cha
             {
                 VSOptions vsopt;
                 vsopt.initialize();
-                driverParams.mscrtlib = vsopt.defaultRuntimeLibrary(target.is64bit).toDString;
+                driverParams.mscrtlib = vsopt.defaultRuntimeLibrary(target.isX86_64).toDString;
             }
             else
             {

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -1076,7 +1076,7 @@ void Statement_toIR(Statement s, IRState *irs, StmtState* stmtstate)
                 tryblock.appendSucc(bcatch);
                 block_goto(blx, BCjcatch, null);
 
-                if (cs.type && irs.target.os == Target.OS.Windows && irs.target.is64bit) // Win64
+                if (cs.type && irs.target.os == Target.OS.Windows && irs.target.isX86_64) // Win64
                 {
                     /* The linker will attempt to merge together identical functions,
                      * even if the catch types differ. So add a reference to the

--- a/compiler/src/dmd/target.h
+++ b/compiler/src/dmd/target.h
@@ -156,7 +156,7 @@ struct Target
 
     DString architectureName;    // name of the platform architecture (e.g. X86_64)
     CPU cpu;                // CPU instruction set to target
-    d_bool is64bit;           // generate 64 bit code for x86_64; true by default for 64 bit dmd
+    d_bool isX86_64;          // generate 64 bit code for x86_64; true by default for 64 bit dmd
     d_bool isLP64;            // pointers are 64 bits
 
     // Environmental

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -172,7 +172,7 @@ Symbol *toSymbol(Dsymbol s)
             }
             else if (vd.storage_class & STC.lazy_)
             {
-                if (target.os == Target.OS.Windows && target.is64bit && vd.isParameter())
+                if (target.os == Target.OS.Windows && target.isX86_64 && vd.isParameter())
                     t = type_fake(TYnptr);
                 else
                     t = type_fake(TYdelegate);          // Tdelegate as C type
@@ -284,7 +284,7 @@ Symbol *toSymbol(Dsymbol s)
             final switch (vd.resolvedLinkage())
             {
                 case LINK.windows:
-                    m = target.is64bit ? mTYman_c : mTYman_std;
+                    m = target.isX86_64 ? mTYman_c : mTYman_std;
                     break;
 
                 case LINK.objc:
@@ -402,7 +402,7 @@ Symbol *toSymbol(Dsymbol s)
                 final switch (fd.resolvedLinkage())
                 {
                     case LINK.windows:
-                        t.Tmangle = target.is64bit ? mTYman_c : mTYman_std;
+                        t.Tmangle = target.isX86_64 ? mTYman_c : mTYman_std;
                         break;
 
                     case LINK.c:
@@ -420,7 +420,7 @@ Symbol *toSymbol(Dsymbol s)
                         s.Sflags |= SFLpublic;
                         /* Nested functions use the same calling convention as
                          * member functions, because both can be used as delegates. */
-                        if ((fd.isThis() || fd.isNested()) && !target.is64bit && target.os == Target.OS.Windows)
+                        if ((fd.isThis() || fd.isNested()) && !target.isX86_64 && target.os == Target.OS.Windows)
                         {
                             if ((cast(TypeFunction)fd.type).parameterList.varargs == VarArg.variadic)
                             {
@@ -529,14 +529,14 @@ private Symbol *createImport(Symbol *sym, Loc loc)
     }
     else if (sym.Stype.Tmangle == mTYman_std && tyfunc(sym.Stype.Tty))
     {
-        if (target.os == Target.OS.Windows && target.is64bit)
+        if (target.os == Target.OS.Windows && target.isX86_64)
             idlen = snprintf(id, allocLen, "__imp_%s",n);
         else
             idlen = snprintf(id, allocLen, "_imp__%s@%u",n,cast(uint)type_paramsize(sym.Stype));
     }
     else
     {
-        idlen = snprintf(id, allocLen, (target.os == Target.OS.Windows && target.is64bit) ? "__imp_%s" : (sym.Stype.Tmangle == mTYman_cpp) ? "_imp_%s" : "_imp__%s",n);
+        idlen = snprintf(id, allocLen, (target.os == Target.OS.Windows && target.isX86_64) ? "__imp_%s" : (sym.Stype.Tmangle == mTYman_cpp) ? "_imp_%s" : "_imp__%s",n);
     }
     auto t = type_alloc(TYnptr | mTYconst);
     t.Tnext = sym.Stype;
@@ -661,7 +661,7 @@ Symbol *toInitializer(AggregateDeclaration ad)
             sd.type.size() <= 128 &&
             sd.zeroInit &&
             config.objfmt != OBJ_MACH && // same reason as in toobj.d toObjFile()
-            !(config.objfmt == OBJ_MSCOFF && !target.is64bit)) // -m32mscoff relocations are wrong
+            !(config.objfmt == OBJ_MSCOFF && !target.isX86_64)) // -m32mscoff relocations are wrong
         {
             auto bzsave = bzeroSymbol;
             ad.sinit = getBzeroSymbol();

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -1404,7 +1404,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoStructDeclaration d)
     {
         //printf("TypeInfoStructDeclaration.toDt() '%s'\n", d.toChars());
-        if (target.is64bit)
+        if (target.isX86_64)
             verifyStructSize(Type.typeinfostruct, 17 * target.ptrsize);
         else
             verifyStructSize(Type.typeinfostruct, 15 * target.ptrsize);
@@ -1529,7 +1529,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         // uint m_align;
         dtb.size(tc.alignsize());
 
-        if (target.is64bit)
+        if (target.isX86_64)
         {
             foreach (i; 0 .. 2)
             {

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -598,7 +598,7 @@ int intrinsic_op(FuncDeclaration fd)
         }
     }
 
-    if (!target.is64bit)
+    if (!target.isX86_64)
     // No 64-bit bsf bsr in 32bit mode
     {
         if ((op == OPbsf || op == OPbsr) && argtype1 is Type.tuns64)
@@ -607,7 +607,7 @@ int intrinsic_op(FuncDeclaration fd)
     return op;
 
 Lva_start:
-    if (target.is64bit &&
+    if (target.isX86_64 &&
         fd.toParent().isTemplateInstance() &&
         id3 == Id.va_start &&
         id2 == Id.stdarg &&
@@ -653,7 +653,7 @@ elem *resolveLengthVar(VarDeclaration lengthVar, elem **pe, Type t1)
         {
             elength = *pe;
             *pe = el_same(&elength);
-            elength = el_una(target.is64bit ? OP128_64 : OP64_32, TYsize_t, elength);
+            elength = el_una(target.isX86_64 ? OP128_64 : OP64_32, TYsize_t, elength);
 
         L3:
             slength = toSymbol(lengthVar);

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -618,7 +618,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             }
 
             auto dtb = DtBuilder(0);
-            if (config.objfmt == OBJ_MACH && target.is64bit && (s.Stype.Tty & mTYLINK) == mTYthread)
+            if (config.objfmt == OBJ_MACH && target.isX86_64 && (s.Stype.Tty & mTYLINK) == mTYthread)
             {
                 tlsToDt(vd, s, sz, dtb, isCfile);
             }
@@ -926,7 +926,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
          */
         static void tlsToDt(VarDeclaration vd, Symbol *s, uint sz, ref DtBuilder dtb, bool isCfile)
         {
-            assert(config.objfmt == OBJ_MACH && target.is64bit && (s.Stype.Tty & mTYLINK) == mTYthread);
+            assert(config.objfmt == OBJ_MACH && target.isX86_64 && (s.Stype.Tty & mTYLINK) == mTYthread);
 
             Symbol *tlvInit = createTLVDataSymbol(vd, s);
             auto tlvInitDtb = DtBuilder(0);
@@ -941,7 +941,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             tlvInit.Sdt = tlvInitDtb.finish();
             outdata(tlvInit);
 
-            if (target.is64bit)
+            if (target.isX86_64)
                 tlvInit.Sclass = SC.extern_;
 
             Symbol* tlvBootstrap = objmod.tlv_bootstrap();
@@ -961,7 +961,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
          */
         static Symbol *createTLVDataSymbol(VarDeclaration vd, Symbol *s)
         {
-            assert(config.objfmt == OBJ_MACH && target.is64bit && (s.Stype.Tty & mTYLINK) == mTYthread);
+            assert(config.objfmt == OBJ_MACH && target.isX86_64 && (s.Stype.Tty & mTYLINK) == mTYthread);
 
             // Compute identifier for tlv symbol
             OutBuffer buffer;
@@ -997,7 +997,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             final switch (vd.resolvedLinkage())
             {
                 case LINK.windows:
-                    return target.is64bit ? mTYman_c : mTYman_std;
+                    return target.isX86_64 ? mTYman_c : mTYman_std;
 
                 case LINK.objc:
                 case LINK.c:

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -72,7 +72,7 @@ static void frontend_init()
     global.params.objname = NULL;
 
     target.os = Target::OS_linux;
-    target.is64bit = true;
+    target.isX86_64 = true;
     target.cpu = CPU::native;
     target._init(global.params);
 

--- a/compiler/test/dub_package/avg.d
+++ b/compiler/test/dub_package/avg.d
@@ -53,7 +53,7 @@ void main()
     Id.initialize();
     global._init();
     target.os = Target.OS.linux;
-    target.is64bit = (size_t.sizeof == 8);
+    target.isX86_64 = (size_t.sizeof == 8);
     global.params.useUnitTests = true;
     ASTBase.Type._init();
 

--- a/compiler/test/dub_package/impvisitor.d
+++ b/compiler/test/dub_package/impvisitor.d
@@ -100,7 +100,7 @@ void main()
         Id.initialize();
         global._init();
         target.os = Target.OS.linux;
-        target.is64bit = (size_t.sizeof == 8);
+        target.isX86_64 = (size_t.sizeof == 8);
         global.params.useUnitTests = true;
         ASTBase.Type._init();
 

--- a/compiler/test/unit/triple.d
+++ b/compiler/test/unit/triple.d
@@ -16,7 +16,7 @@ unittest
 {
     auto triple = Triple("x86-unknown-windows-msvc");
     assert(triple.os == Target.OS.Windows);
-    assert(triple.is64bit == false);
+    assert(triple.isX86_64 == false);
     assert(triple.cenv == TargetC.Runtime.Microsoft);
 }
 
@@ -25,7 +25,7 @@ unittest
 {
     auto triple = Triple("x64-apple-darwin20.3.0");
     assert(triple.os == Target.OS.OSX);
-    assert(triple.is64bit == true);
+    assert(triple.isX86_64 == true);
 }
 
 @("-target=x86_64+avx2-apple-darwin20.3.0")
@@ -33,7 +33,7 @@ unittest
 {
     auto triple = Triple("x86_64+avx2-apple-darwin20.3.0");
     assert(triple.os == Target.OS.OSX);
-    assert(triple.is64bit == true);
+    assert(triple.isX86_64 == true);
     assert(triple.cpu == CPU.avx2);
 }
 
@@ -41,7 +41,7 @@ unittest
 unittest
 {
     auto triple = Triple("x86_64-unknown-linux-musl-clang");
-    assert(triple.is64bit == true);
+    assert(triple.isX86_64 == true);
     assert(triple.os == Target.OS.linux);
     assert(triple.cenv == TargetC.Runtime.Musl);
     assert(triple.cppenv == TargetCPP.Runtime.Clang);


### PR DESCRIPTION
This ought to discourage any contributor from accidentally using it in front-end/semantic pass code.