### PR TITLE
Fix regression introduced by #15359

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4065,7 +4065,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (arg.op == EXP.error)
                     return setError();
                 arg = arg.optimize(WANTvalue);
-                if (arg.op == EXP.int64 && (target.is64bit ?
+                if (arg.op == EXP.int64 && (target.isLP64 ?
                     cast(sinteger_t)arg.toInteger() : cast(int)arg.toInteger()) < 0)
                 {
                     exp.error("negative array dimension `%s`", (*exp.arguments)[i].toChars());


### PR DESCRIPTION
PR broke 64-bit targets such as amd64, ppc64, etc.  Use isLP64 instead to distinguish between 64-bit and 32-bit (*ahem*, 16-bit) pointer targets and others.