### PR TITLE
Fix Issue 22427 - betterC: casting an array causes linker error in string comparison

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -6307,7 +6307,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         // This should only be called on the primary instantiation.
         assert(this is inst);
 
-        if (global.params.allInst)
+        if (global.params.allInst || global.params.betterC)
         {
             // Do codegen if there is an instantiation from a root module, to maximize link-ability.
             static ThreeState needsCodegenAllInst(TemplateInstance tithis, TemplateInstance tinst)

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -6307,7 +6307,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         // This should only be called on the primary instantiation.
         assert(this is inst);
 
-        if (global.params.allInst || global.params.betterC)
+        if (global.params.allInst)
         {
             // Do codegen if there is an instantiation from a root module, to maximize link-ability.
             static ThreeState needsCodegenAllInst(TemplateInstance tithis, TemplateInstance tinst)

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -2159,7 +2159,10 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         else if (arg == "-release")     // https://dlang.org/dmd.html#switch-release
             params.release = true;
         else if (arg == "-betterC")     // https://dlang.org/dmd.html#switch-betterC
+        {
             params.betterC = true;
+            params.allInst = true;
+        }
         else if (arg == "-noboundscheck") // https://dlang.org/dmd.html#switch-noboundscheck
         {
             params.boundscheck = CHECKENABLE.off;

--- a/compiler/test/runnable/betterc.d
+++ b/compiler/test/runnable/betterc.d
@@ -210,3 +210,14 @@ int test20737()
     tlsVar = 123;
     return 0;
 }
+
+/*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22427
+void test22427()
+{
+    if("a" == "a")
+        return;
+
+    char[] p;
+    auto a = cast(int[])p;
+}


### PR DESCRIPTION
```d
extern(C)
int main(){
    if("a" == "a")
        return 1;
    char[] p;
    auto a = cast(int[])p;
    return 0;
}
```

It seems that the cast is lowered to __ArrayCast which in turn ends up instantiating __equals with the same template parameters, but in a [speculative context](https://github.com/dlang/dmd/blob/master/druntime/src/core/memory.d#L1129). Somehow, the template emission strategy decides that the instance does not require codegen (from what I can tell, the compiler decides that it's better to put the instance in the imported module - core.memory in this case), hence the linker errors.

I think that this strategy should be disabled in the case of betterC as it currently is with -allinst.

Targeting master as this might be controversial.