### PR TITLE
make new safety checks warnings when using default feature setting

### DIFF
--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -4606,6 +4606,7 @@ bool setUnsafe(Scope* sc,
 bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, const(char)* msg,
     RootObject arg0 = null, RootObject arg1 = null, RootObject arg2 = null)
 {
+    //printf("setUnsafePreview() fs:%d %s\n", fs, msg);
     with (FeatureState) final switch (fs)
     {
       case disabled:
@@ -4620,9 +4621,10 @@ bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, const(char)
         if (sc.func.isSafeBypassingInference())
         {
             if (!gag)
-                previewErrorFunc(sc.isDeprecated(), fs)(
-                    loc, msg, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : ""
-                );
+            {
+                if (!sc.isDeprecated() && global.params.obsolete)
+                    warning(loc, msg, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+            }
         }
         else if (!sc.func.safetyViolation)
         {

--- a/compiler/test/fail_compilation/dip1000_deprecation.d
+++ b/compiler/test/fail_compilation/dip1000_deprecation.d
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS: -de
+REQUIRED_ARGS: -de -wo
 TEST_OUTPUT:
 ---
 fail_compilation/dip1000_deprecation.d(20): Deprecation: `@safe` function `main` calling `inferred`
@@ -9,17 +9,17 @@ fail_compilation/dip1000_deprecation.d(22): Deprecation: `@safe` function `main`
 fail_compilation/dip1000_deprecation.d(39):        which calls `dip1000_deprecation.inferred`
 fail_compilation/dip1000_deprecation.d(28):        which wouldn't be `@safe` because of:
 fail_compilation/dip1000_deprecation.d(28):        scope variable `x0` may not be returned
-fail_compilation/dip1000_deprecation.d(54): Deprecation: escaping reference to stack allocated value returned by `S(null)`
-fail_compilation/dip1000_deprecation.d(55): Deprecation: escaping reference to stack allocated value returned by `createS()`
-fail_compilation/dip1000_deprecation.d(58): Deprecation: returning `s.incorrectReturnRef()` escapes a reference to local variable `s`
+fail_compilation/dip1000_deprecation.d(54): Warning: escaping reference to stack allocated value returned by `S(null)`
+fail_compilation/dip1000_deprecation.d(55): Warning: escaping reference to stack allocated value returned by `createS()`
+fail_compilation/dip1000_deprecation.d(58): Warning: returning `s.incorrectReturnRef()` escapes a reference to local variable `s`
 ---
 */
 
 void main() @safe
 {
-    inferred();
-    inferredB(); // no deprecation, trusted
-    inferredC(); // nested deprecation
+    cast(void)inferred();
+    cast(void)inferredB(); // no deprecation, trusted
+    cast(void)inferredC(); // nested deprecation
 }
 
 auto inferred()
@@ -49,10 +49,10 @@ struct S
 
 S createS() { return S.init; }
 
-int* escape()
+int* escape(int i)
 {
-    return S().incorrectReturnRef();
-    return createS().incorrectReturnRef();
+    if (i) return S().incorrectReturnRef();
+    if (i) return createS().incorrectReturnRef();
 
     S s;
     return s.incorrectReturnRef();

--- a/compiler/test/fail_compilation/fail_scope.d
+++ b/compiler/test/fail_compilation/fail_scope.d
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS:
+REQUIRED_ARGS: -wo
 TEST_OUTPUT:
 ---
 fail_compilation/fail_scope.d(30): Deprecation: scope parameter `da` may not be returned
@@ -16,7 +16,7 @@ fail_compilation/fail_scope.d(82): Error: returning `& string` escapes a referen
 fail_compilation/fail_scope.d(92): Error: returning `cast(int[])a` escapes a reference to local variable `a`
 fail_compilation/fail_scope.d(100): Error: returning `cast(int[])a` escapes a reference to local variable `a`
 fail_compilation/fail_scope.d(108): Error: escaping reference to outer local variable `x`
-fail_compilation/fail_scope.d(127): Deprecation: returning `s.bar()` escapes a reference to local variable `s`
+fail_compilation/fail_scope.d(127): Warning: returning `s.bar()` escapes a reference to local variable `s`
 fail_compilation/fail_scope.d(137): Error: returning `foo16226(i)` escapes a reference to local variable `i`
 ---
 //fail_compilation/fail_scope.d(35): Error: scope variable `da` may not be returned

--- a/compiler/test/fail_compilation/test13536.d
+++ b/compiler/test/fail_compilation/test13536.d
@@ -1,8 +1,8 @@
-/*
+/* REQUIRED_ARGS: -wo
 TEST_OUTPUT:
 ---
 fail_compilation/test13536.d(23): Error: field `U.sysDg` cannot access pointers in `@safe` code that overlap other fields
-fail_compilation/test13536.d(23): Deprecation: address of variable `s` assigned to `u` with longer lifetime
+fail_compilation/test13536.d(23): Warning: address of variable `s` assigned to `u` with longer lifetime
 fail_compilation/test13536.d(24): Error: field `U.safeDg` cannot access pointers in `@safe` code that overlap other fields
 ---
 */

--- a/compiler/test/fail_compilation/test16365.d
+++ b/compiler/test/fail_compilation/test16365.d
@@ -1,9 +1,9 @@
-/*
+/* REQUIRED_ARGS: -wo
 TEST_OUTPUT:
 ---
 fail_compilation/test16365.d(21): Error: `this` reference necessary to take address of member `f1` in `@safe` function `main`
 fail_compilation/test16365.d(23): Error: cannot implicitly convert expression `&f2` of type `void delegate() pure nothrow @nogc @safe` to `void function() @safe`
-fail_compilation/test16365.d(27): Deprecation: address of variable `s` assigned to `dg` with longer lifetime
+fail_compilation/test16365.d(27): Warning: address of variable `s` assigned to `dg` with longer lifetime
 fail_compilation/test16365.d(28): Error: `dg.funcptr` cannot be used in `@safe` code
 ---
 */


### PR DESCRIPTION
Consider this error:
```
../.dub/packages/vibe-core/1.22.6/vibe-core/source/vibe/core/log.d(426,19): Deprecation: scope variable `text` assigned to non-scope parameter `__param_0` calling `write`
```
which occurs when compiling buildkite/dlang-tour/core. It's been failing for quite a while now, and doesn't get fixed. There are pages of variations of this error. A simple repro of the error:
```
@safe:
void foo(int* p);
void bar(scope int* abc) {    foo(abc); }
```
so yes, it is an error according to dip1000. But this message is occurring by default. What we did is break everyone's code that was working, and working when in good faith they added `scope` and it remained working, but now it fails to compile. The fact that this is long time broken in dlang-tour/core shows why we need to fix this.

This PR changes it to a warning, but only if `-wo` is used.