### PR TITLE
Use import for `dmd.backend.out : outdata`

### DIFF
--- a/compiler/src/dmd/backend/dt.d
+++ b/compiler/src/dmd/backend/dt.d
@@ -204,7 +204,6 @@ private:
 
 public:
 nothrow:
-@nogc:
     @trusted
     this(int dummy)
     {

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -151,9 +151,7 @@ public import dmd.backend.cg87 : loadconst, cg87_reset;
 public import dmd.backend.cod3 : cod3_thunk;
 
 public import dmd.backend.dout : outthunk, out_readonly, out_readonly_comdat,
-    out_regcand, writefunc, alignOffset, out_reset, out_readonly_sym, out_string_literal;
-
-void outdata(Symbol *s);
+    out_regcand, writefunc, alignOffset, out_reset, out_readonly_sym, out_string_literal, outdata;
 
 public import dmd.backend.blockopt : bc_goal, block_calloc, block_init, block_term, block_next,
     block_next, block_goto, block_goto, block_goto, block_goto, block_ptr, block_pred,


### PR DESCRIPTION
Trying to make it `@nogc` proper causes a ripple effect of requiring `@nogc` for all functions it transitively calls, so I just removed the `@nogc` from dt. It doesn't seem to do any favors.