### PR TITLE
Fix Issue 4733 - Possible bugs caused by dynamic arrays in boolean ev…

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -14177,6 +14177,7 @@ Expression toBoolean(Expression exp, Scope* sc)
             }
             if (global.compileEnv.obsolete && tb.ty == Tarray)
             {
+                // obsolete from 2.105
                 warning(exp.loc, "boolean evaluation of dynamic arrays is obsolete");
                 warningSupplemental(exp.loc, "Use one of: %s !is null, %s.length, or %s.ptr instead",
                     exp.toChars(), exp.toChars(), exp.toChars());

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -14175,6 +14175,12 @@ Expression toBoolean(Expression exp, Scope* sc)
                               exp.toChars(), t.toChars());
                 return ErrorExp.get();
             }
+            if (global.compileEnv.obsolete && tb.ty == Tarray)
+            {
+                warning(exp.loc, "boolean evaluation of dynamic arrays is obsolete");
+                warningSupplemental(exp.loc, "Use one of: %s !is null, %s.length, or %s.ptr instead",
+                    exp.toChars(), exp.toChars(), exp.toChars());
+            }
             return e;
     }
 }

--- a/compiler/test/fail_compilation/array_bool.d
+++ b/compiler/test/fail_compilation/array_bool.d
@@ -1,0 +1,25 @@
+/*
+REQUIRED_ARGS: -wo -w
+TEST_OUTPUT:
+---
+fail_compilation/array_bool.d(20): Warning: boolean evaluation of dynamic arrays is obsolete
+fail_compilation/array_bool.d(20):        Use one of: a !is null, a.length, or a.ptr instead
+fail_compilation/array_bool.d(21): Warning: boolean evaluation of dynamic arrays is obsolete
+fail_compilation/array_bool.d(21):        Use one of: [1] !is null, [1].length, or [1].ptr instead
+fail_compilation/array_bool.d(22): Warning: boolean evaluation of dynamic arrays is obsolete
+fail_compilation/array_bool.d(22):        Use one of: "foo" !is null, "foo".length, or "foo".ptr instead
+fail_compilation/array_bool.d(24): Warning: boolean evaluation of dynamic arrays is obsolete
+fail_compilation/array_bool.d(24):        Use one of: "bar" !is null, "bar".length, or "bar".ptr instead
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
+---
+*/
+void main()
+{
+    int[] a = [2];
+    if (a) {}
+    auto b = [1] && true;
+    assert("foo");
+    enum e = "bar";
+    static assert(e);
+}


### PR DESCRIPTION
…aluation context

Make this surprising and bug-prone behaviour obsolete now we have `-wo`.

Fix Issue 14387 - Disallow string literals as assert conditions.