### PR TITLE
add -fIBT switch and emit ENDBR for function and thunk prologs

### DIFF
--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -45,6 +45,7 @@ nothrow:
                     2 for fake it with C symbolic debug info
     alwaysframe   = always create standard function frame
     stackstomp    = add stack stomping code
+    ibt           = generate Indirect Branch Tracking code
     avx           = use AVX instruction set (0, 1, 2)
     pic           = position independence level (0, 1, 2)
     useModuleInfo = implement ModuleInfo
@@ -68,6 +69,7 @@ extern (C) void out_config_init(
         int symdebug,
         bool alwaysframe,
         bool stackstomp,
+        bool ibt,
         ubyte avx,
         ubyte pic,
         bool useModuleInfo,
@@ -99,6 +101,8 @@ extern (C) void out_config_init(
     model &= 32 | 64;
     if (generatedMain)
         cfg.flags2 |= CFG2genmain;
+    if (ibt)
+        cfg.flags3 |= CFG3ibt;
 
     if (dwarf < 3 || dwarf > 5)
     {

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -532,6 +532,7 @@ enum
     CFG3semirelax   = 0x40000, // moderate relaxed type checking (non-Windows targets)
     CFG3pic         = 0x80000, // position independent code
     CFG3pie         = 0x10_0000, // position independent executable (CFG3pic also set)
+    CFG3ibt         = 0x20_0000, // indirect branch tracking
 }
 
 alias config_flags4_t = uint;

--- a/compiler/src/dmd/backend/cgcod.d
+++ b/compiler/src/dmd/backend/cgcod.d
@@ -678,6 +678,9 @@ void prolog(ref CodeBuilder cdb)
     tym_t tym = tybasic(tyf);
     const farfunc = tyfarfunc(tym) != 0;
 
+    if (config.flags3 & CFG3ibt && !I16)
+        cdb.gen1(I32 ? ENDBR32 : ENDBR64);
+
     // Special Intel 64 bit ABI prolog setup for variadic functions
     Symbol *sv64 = null;                        // set to __va_argsave
     if (I64 && variadic(funcsym_p.Stype))

--- a/compiler/src/dmd/backend/cod3.d
+++ b/compiler/src/dmd/backend/cod3.d
@@ -1659,6 +1659,8 @@ void doswitch(ref CodeBuilder cdb, block *b)
         goto Lifthen;
     else if (I16 && cast(targ_ullong)(vmax - vmin) <= ncases * 2)
         goto Ljmptab;           // >=50% of the table is case values, rest is default
+    else if (config.flags3 & CFG3ibt)
+        goto Lifthen;           // no jump table for ENDBR
     else if (cast(targ_ullong)(vmax - vmin) <= ncases * 3)
         goto Ljmptab;           // >= 33% of the table is case values, rest is default
     else if (I16)
@@ -4731,6 +4733,9 @@ void cod3_thunk(Symbol *sthunk,Symbol *sfunc,uint p,tym_t thisty,
             MOV EAX, d2[EAX]                    EAX = this.vptr
             JMP i[EAX]                          jump to virtual function
          */
+        if (config.flags3 & CFG3ibt)
+            cdb.gen1(I32 ? ENDBR32 : ENDBR64);
+
         reg_t reg = 0;
         if (cast(int)d < 0)
         {

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -351,6 +351,9 @@ dmd -cov -unittest myprog.d
         Option("extern-std=[h|help|?]",
             "list all supported standards"
         ),
+        Option("fIBT",
+            "generate Indirect Branch Tracking code"
+        ),
         Option("fPIC",
             "generate position independent code",
             cast(TargetOS) (TargetOS.all & ~(TargetOS.Windows | TargetOS.OSX))

--- a/compiler/src/dmd/dmdparams.d
+++ b/compiler/src/dmd/dmdparams.d
@@ -35,6 +35,7 @@ struct DMDparams
 
     bool optimize;          // run optimizer
     bool nofloat;           // code should not pull in floating point support
+    bool ibt;               // generate indirect branch tracking
     PIC pic = PIC.fixed;    // generate fixed, pic or pie code
     bool stackstomp;        // add stack stomping code
 

--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -78,6 +78,7 @@ void backend_init()
         driverParams.symdebug,
         driverParams.alwaysframe,
         driverParams.stackstomp,
+        driverParams.ibt,
         target.cpu >= CPU.avx2 ? 2 : target.cpu >= CPU.avx ? 1 : 0,
         driverParams.pic,
         params.useModuleInfo && Module.moduleinfo,

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1562,6 +1562,10 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         }
         else if (arg == "-shared")
             driverParams.dll = true;
+        else if (arg == "-fIBT")
+        {
+            driverParams.ibt = true;
+        }
         else if (arg == "-fPIC")
         {
             driverParams.pic = PIC.pic;


### PR DESCRIPTION
See https://news.ycombinator.com/item?id=36722823 for more information on IBT.

For the ENDBR32/64 instructions:

https://www.felixcloutier.com/x86/endbr32
https://www.felixcloutier.com/x86/endbr64

I still need to add support for switch jump tables.

I have no way to test this, as my machines don't use IBT. All I can say is disassembly shows the instruction is generated, and the programs still run.