### PR TITLE
[stable] druntime: Restrict some `pragma(inline, false)` kludges to DMD only

### DIFF
--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -127,7 +127,7 @@ pure @safe:
 
     void putComma(size_t n)
     {
-        pragma(inline, false);
+        version (DigitalMars) pragma(inline, false);
         if (n)
             put(", ");
     }
@@ -2861,7 +2861,7 @@ private class OverflowException : Exception
 /// Ditto
 private noreturn error(string msg = "Invalid symbol") @trusted pure
 {
-    pragma(inline, false); // tame dmd inliner
+    version (DigitalMars) pragma(inline, false); // tame dmd inliner
 
     //throw new ParseException( msg );
     debug(info) printf( "error: %.*s\n", cast(int) msg.length, msg.ptr );
@@ -2872,7 +2872,7 @@ private noreturn error(string msg = "Invalid symbol") @trusted pure
 /// Ditto
 private noreturn overflow(string msg = "Buffer overflow") @trusted pure
 {
-    pragma(inline, false); // tame dmd inliner
+    version (DigitalMars) pragma(inline, false); // tame dmd inliner
 
     //throw new OverflowException( msg );
     debug(info) printf( "overflow: %.*s\n", cast(int) msg.length, msg.ptr );
@@ -2927,7 +2927,7 @@ private struct Buffer
     // move val to the end of the dst buffer
     char[] shift(scope const(char)[] val) return scope
     {
-        pragma(inline, false); // tame dmd inliner
+        version (DigitalMars) pragma(inline, false); // tame dmd inliner
 
         if (val.length)
         {
@@ -2949,7 +2949,7 @@ private struct Buffer
     // remove val from dst buffer
     void remove(scope const(char)[] val) scope
     {
-        pragma(inline, false); // tame dmd inliner
+        version (DigitalMars) pragma(inline, false); // tame dmd inliner
 
         if ( val.length )
         {
@@ -2965,7 +2965,7 @@ private struct Buffer
 
     char[] append(scope const(char)[] val) return scope
     {
-        pragma(inline, false); // tame dmd inliner
+        version (DigitalMars) pragma(inline, false); // tame dmd inliner
 
         if (val.length)
         {

--- a/druntime/src/core/internal/array/appending.d
+++ b/druntime/src/core/internal/array/appending.d
@@ -35,7 +35,7 @@ template _d_arrayappendcTXImpl(Tarr : T[], T)
     ref Tarr _d_arrayappendcTX(return ref scope Tarr px, size_t n) @trusted pure nothrow
     {
         // needed for CTFE: https://github.com/dlang/druntime/pull/3870#issuecomment-1178800718
-        pragma(inline, false);
+        version (DigitalMars) pragma(inline, false);
         version (D_TypeInfo)
         {
             auto ti = typeid(Tarr);
@@ -70,7 +70,7 @@ template _d_arrayappendcTXImpl(Tarr : T[], T)
 /// Implementation of `_d_arrayappendT`
 ref Tarr _d_arrayappendT(Tarr : T[], T)(return ref scope Tarr x, scope Tarr y) @trusted
 {
-    pragma(inline, false);
+    version (DigitalMars) pragma(inline, false);
 
     import core.stdc.string : memcpy;
     import core.internal.traits : hasElaborateCopyConstructor, Unqual;

--- a/druntime/src/core/internal/array/capacity.d
+++ b/druntime/src/core/internal/array/capacity.d
@@ -36,7 +36,7 @@ template _d_arraysetlengthTImpl(Tarr : T[], T)
      */
     size_t _d_arraysetlengthT(return scope ref Tarr arr, size_t newlength) @trusted pure nothrow
     {
-        pragma(inline, false);
+        version (DigitalMars) pragma(inline, false);
         version (D_TypeInfo)
         {
             auto ti = typeid(Tarr);

--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -36,7 +36,7 @@ import core.internal.traits : Unqual;
  */
 Tarr _d_arrayctor(Tarr : T[], T)(return scope Tarr to, scope Tarr from, char* makeWeaklyPure = null) @trusted
 {
-    pragma(inline, false);
+    version (DigitalMars) pragma(inline, false);
     import core.internal.traits : hasElaborateCopyConstructor;
     import core.lifetime : copyEmplace;
     import core.stdc.string : memcpy;
@@ -200,7 +200,7 @@ Tarr _d_arrayctor(Tarr : T[], T)(return scope Tarr to, scope Tarr from, char* ma
  */
 void _d_arraysetctor(Tarr : T[], T)(scope Tarr p, scope ref T value) @trusted
 {
-    pragma(inline, false);
+    version (DigitalMars) pragma(inline, false);
     import core.lifetime : copyEmplace;
 
     size_t i;


### PR DESCRIPTION
They appear related to DMD's inlining at the AST level; LDC at least doesn't need them, so let the optimizer decide for non-DMD backends.