### PR TITLE
dmd.errors: Use a distinct entrypoint for obsolete warnings.

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -58,6 +58,14 @@ class ErrorSinkCompiler : ErrorSink
         va_end(ap);
     }
 
+    void obsolete(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vobsolete(loc, format, ap);
+        va_end(ap);
+    }
+
     void deprecation(const ref Loc loc, const(char)* format, ...)
     {
         va_list ap;
@@ -257,6 +265,30 @@ else
         va_list ap;
         va_start(ap, format);
         vwarningSupplemental(loc, format, ap);
+        va_end(ap);
+    }
+
+/**
+ * Print an obsolete warning message, increasing the global warning count.
+ * Params:
+ *      loc    = location of warning
+ *      format = printf-style format specification
+ *      ...    = printf-style variadic arguments
+ */
+static if (__VERSION__ < 2092)
+    extern (C++) void obsolete(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vobsolete(loc, format, ap);
+        va_end(ap);
+    }
+else
+    pragma(printf) extern (C++) void obsolete(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        vobsolete(loc, format, ap);
         va_end(ap);
     }
 
@@ -568,6 +600,24 @@ static if (__VERSION__ < 2092)
     }
 else
     pragma(printf) extern (C++) void vwarning(const ref Loc loc, const(char)* format, va_list ap)
+    {
+        _vwarning(loc, format, ap);
+    }
+
+/**
+ * Same as $(D obsolete), but takes a va_list parameter.
+ * Params:
+ *      loc    = location of warning
+ *      format = printf-style format specification
+ *      ap     = printf-style variadic arguments
+ */
+static if (__VERSION__ < 2092)
+    extern (C++) void vobsolete(const ref Loc loc, const(char)* format, va_list ap)
+    {
+        _vwarning(loc, format, ap);
+    }
+else
+    pragma(printf) extern (C++) void vobsolete(const ref Loc loc, const(char)* format, va_list ap)
     {
         _vwarning(loc, format, ap);
     }

--- a/compiler/src/dmd/errors.h
+++ b/compiler/src/dmd/errors.h
@@ -25,6 +25,7 @@ bool isConsoleColorSupported();
 // Print a warning, deprecation, or error, accepts printf-like format specifiers.
 D_ATTRIBUTE_FORMAT(2, 3) void warning(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void warningSupplemental(const Loc& loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 3) void obsolete(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void deprecation(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void deprecationSupplemental(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void error(const Loc& loc, const char *format, ...);
@@ -34,6 +35,7 @@ D_ATTRIBUTE_FORMAT(2, 0) void verror(const Loc& loc, const char *format, va_list
 D_ATTRIBUTE_FORMAT(2, 0) void verrorSupplemental(const Loc& loc, const char *format, va_list ap);
 D_ATTRIBUTE_FORMAT(2, 0) void vwarning(const Loc& loc, const char *format, va_list);
 D_ATTRIBUTE_FORMAT(2, 0) void vwarningSupplemental(const Loc& loc, const char *format, va_list ap);
+D_ATTRIBUTE_FORMAT(2, 0) void vobsolete(const Loc& loc, const char *format, va_list);
 D_ATTRIBUTE_FORMAT(2, 0) void vdeprecation(const Loc& loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
 D_ATTRIBUTE_FORMAT(2, 0) void vdeprecationSupplemental(const Loc& loc, const char *format, va_list ap);
 D_ATTRIBUTE_FORMAT(1, 2) void message(const char *format, ...);

--- a/compiler/src/dmd/errorsink.d
+++ b/compiler/src/dmd/errorsink.d
@@ -27,6 +27,8 @@ abstract class ErrorSink
 
     void warning(const ref Loc loc, const(char)* format, ...);
 
+    void obsolete(const ref Loc loc, const(char)* format, ...);
+
     void message(const ref Loc loc, const(char)* format, ...);
 
     void deprecation(const ref Loc loc, const(char)* format, ...);
@@ -48,6 +50,8 @@ class ErrorSinkNull : ErrorSink
     void errorSupplemental(const ref Loc loc, const(char)* format, ...) { }
 
     void warning(const ref Loc loc, const(char)* format, ...) { }
+
+    void obsolete(const ref Loc loc, const(char)* format, ...) { }
 
     void message(const ref Loc loc, const(char)* format, ...) { }
 
@@ -88,6 +92,23 @@ class ErrorSinkStderr : ErrorSink
     void errorSupplemental(const ref Loc loc, const(char)* format, ...) { }
 
     void warning(const ref Loc loc, const(char)* format, ...)
+    {
+        fputs("Warning: ", stderr);
+        const p = loc.toChars();
+        if (*p)
+        {
+            fprintf(stderr, "%s: ", p);
+            //mem.xfree(cast(void*)p); // loc should provide the free()
+        }
+
+        va_list ap;
+        va_start(ap, format);
+        vfprintf(stderr, format, ap);
+        fputc('\n', stderr);
+        va_end(ap);
+    }
+
+    void obsolete(const ref Loc loc, const(char)* format, ...)
     {
         fputs("Warning: ", stderr);
         const p = loc.toChars();

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8493,6 +8493,8 @@ extern void warning(const Loc& loc, const char* format, ...);
 
 extern void warningSupplemental(const Loc& loc, const char* format, ...);
 
+extern void obsolete(const Loc& loc, const char* format, ...);
+
 extern void deprecation(const Loc& loc, const char* format, ...);
 
 extern void deprecationSupplemental(const Loc& loc, const char* format, ...);
@@ -8508,6 +8510,8 @@ extern void verror(const Loc& loc, const char* format, va_list ap, const char* p
 extern void verrorSupplemental(const Loc& loc, const char* format, va_list ap);
 
 extern void vwarning(const Loc& loc, const char* format, va_list ap);
+
+extern void vobsolete(const Loc& loc, const char* format, va_list ap);
 
 extern void vwarningSupplemental(const Loc& loc, const char* format, va_list ap);
 

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -9547,7 +9547,7 @@ LagainStc:
     {
         if (compileEnv.obsolete)
         {
-            eSink.warning(token.loc, "usage of identifer `body` as a keyword is obsolete. Use `do` instead.");
+            eSink.obsolete(token.loc, "usage of identifer `body` as a keyword is obsolete. Use `do` instead.");
         }
     }
 }


### PR DESCRIPTION
Actually, this doesn't go far enough, as to fix the GDC problem report in a way that doesn't involve matching and rewriting format strings, I'd also need a mechanism to discriminate between other command-line flags as well.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109681

I am considering rethinking how we do diagnostics, most likely by putting all these parameters spread across various functions into some kind of `ErrorInfo` struct, one of the fields of which would be a flag to represent which `Param` field triggered the diagnostic.

For example, to use a mixin to generate such an enum flag.
```
mixin({
    string ret = "enum ParamFlag {";
    foreach (member; __traits(allMembers, Param))
    {
        alias T = typeof(__traits(getMember, Param, member));
        static if (is(T == bool) || is(T == FeatureState))
            ret ~= member ~ ",";
    }
    ret ~= "}";
    return ret;
}());
```