### PR TITLE
dmd.errors: Merge the 'v*' and 'v*Supplemental' routines.

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -170,7 +170,7 @@ struct ASTBase
                 va_list ap;
                 va_start(ap, format);
                 // last parameter : toPrettyChars
-                verror(loc, format, ap, kind(), "");
+                verrorReport(loc, format, ap, ErrorKind.error, kind(), "");
                 va_end(ap);
             }
         else
@@ -179,7 +179,7 @@ struct ASTBase
                 va_list ap;
                 va_start(ap, format);
                 // last parameter : toPrettyChars
-                verror(loc, format, ap, kind(), "");
+                verrorReport(loc, format, ap, ErrorKind.error, kind(), "");
                 va_end(ap);
             }
 
@@ -4557,7 +4557,7 @@ struct ASTBase
             {
                 va_list ap;
                 va_start(ap, format);
-                verror(loc, format, ap);
+                verrorReport(loc, format, ap, ErrorKind.error);
                 va_end(ap);
             }
         }

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -381,7 +381,7 @@ extern (C++) class Dsymbol : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .verror(loc, format, ap, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.error, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -390,7 +390,7 @@ extern (C++) class Dsymbol : ASTNode
             va_list ap;
             va_start(ap, format);
             const loc = getLoc();
-            .verror(loc, format, ap, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.error, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -398,7 +398,7 @@ extern (C++) class Dsymbol : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .vdeprecation(loc, format, ap, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.deprecation, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -407,7 +407,7 @@ extern (C++) class Dsymbol : ASTNode
             va_list ap;
             va_start(ap, format);
             const loc = getLoc();
-            .vdeprecation(loc, format, ap, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.deprecation, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
     }
@@ -417,7 +417,7 @@ extern (C++) class Dsymbol : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .verror(loc, format, ap, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.error, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -426,7 +426,7 @@ extern (C++) class Dsymbol : ASTNode
             va_list ap;
             va_start(ap, format);
             const loc = getLoc();
-            .verror(loc, format, ap, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.error, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -434,7 +434,7 @@ extern (C++) class Dsymbol : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .vdeprecation(loc, format, ap, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.deprecation, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -443,7 +443,7 @@ extern (C++) class Dsymbol : ASTNode
             va_list ap;
             va_start(ap, format);
             const loc = getLoc();
-            .vdeprecation(loc, format, ap, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.deprecation, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
     }

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -25,6 +25,16 @@ import dmd.console;
 
 nothrow:
 
+/// Constants used to discriminate kinds of error messages.
+enum ErrorKind
+{
+    warning,
+    deprecation,
+    error,
+    tip,
+    message,
+}
+
 /***************************
  * Error message sink for D compiler.
  */
@@ -38,7 +48,7 @@ class ErrorSinkCompiler : ErrorSink
     {
         va_list ap;
         va_start(ap, format);
-        verror(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.error);
         va_end(ap);
     }
 
@@ -46,7 +56,7 @@ class ErrorSinkCompiler : ErrorSink
     {
         va_list ap;
         va_start(ap, format);
-        verrorSupplemental(loc, format, ap);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.error);
         va_end(ap);
     }
 
@@ -54,7 +64,7 @@ class ErrorSinkCompiler : ErrorSink
     {
         va_list ap;
         va_start(ap, format);
-        vwarning(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.warning);
         va_end(ap);
     }
 
@@ -62,7 +72,7 @@ class ErrorSinkCompiler : ErrorSink
     {
         va_list ap;
         va_start(ap, format);
-        vdeprecation(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.deprecation);
         va_end(ap);
     }
 
@@ -70,7 +80,7 @@ class ErrorSinkCompiler : ErrorSink
     {
         va_list ap;
         va_start(ap, format);
-        vdeprecationSupplemental(loc, format, ap);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.deprecation);
         va_end(ap);
     }
 
@@ -78,7 +88,7 @@ class ErrorSinkCompiler : ErrorSink
     {
         va_list ap;
         va_start(ap, format);
-        vmessage(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.message);
         va_end(ap);
     }
 }
@@ -146,7 +156,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        verror(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.error);
         va_end(ap);
     }
 else
@@ -154,7 +164,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        verror(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.error);
         va_end(ap);
     }
 
@@ -173,7 +183,7 @@ static if (__VERSION__ < 2092)
         const loc = Loc(filename, linnum, charnum);
         va_list ap;
         va_start(ap, format);
-        verror(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.error);
         va_end(ap);
     }
 else
@@ -182,7 +192,7 @@ else
         const loc = Loc(filename, linnum, charnum);
         va_list ap;
         va_start(ap, format);
-        verror(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.error);
         va_end(ap);
     }
 
@@ -199,7 +209,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        verrorSupplemental(loc, format, ap);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.error);
         va_end(ap);
     }
 else
@@ -207,7 +217,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        verrorSupplemental(loc, format, ap);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.error);
         va_end(ap);
     }
 
@@ -223,7 +233,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vwarning(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.warning);
         va_end(ap);
     }
 else
@@ -231,7 +241,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vwarning(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.warning);
         va_end(ap);
     }
 
@@ -248,7 +258,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vwarningSupplemental(loc, format, ap);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.warning);
         va_end(ap);
     }
 else
@@ -256,7 +266,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vwarningSupplemental(loc, format, ap);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.warning);
         va_end(ap);
     }
 
@@ -273,7 +283,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vdeprecation(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.deprecation);
         va_end(ap);
     }
 else
@@ -281,7 +291,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vdeprecation(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.deprecation);
         va_end(ap);
     }
 
@@ -298,7 +308,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vdeprecationSupplemental(loc, format, ap);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.deprecation);
         va_end(ap);
     }
 else
@@ -306,7 +316,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vdeprecationSupplemental(loc, format, ap);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.deprecation);
         va_end(ap);
     }
 
@@ -323,7 +333,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vmessage(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.message);
         va_end(ap);
     }
 else
@@ -331,7 +341,7 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vmessage(loc, format, ap);
+        verrorReport(loc, format, ap, ErrorKind.message);
         va_end(ap);
     }
 
@@ -346,7 +356,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vmessage(Loc.initial, format, ap);
+        verrorReport(Loc.initial, format, ap, ErrorKind.message);
         va_end(ap);
     }
 else
@@ -354,13 +364,13 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vmessage(Loc.initial, format, ap);
+        verrorReport(Loc.initial, format, ap, ErrorKind.message);
         va_end(ap);
     }
 
 /**
  * The type of the diagnostic handler
- * see verrorPrint for arguments
+ * see verrorReport for arguments
  * Returns: true if error handling is done, false to continue printing to stderr
  */
 alias DiagnosticHandler = bool delegate(const ref Loc location, Color headerColor, const(char)* header, const(char)* messageFormat, va_list args, const(char)* prefix1, const(char)* prefix2);
@@ -383,7 +393,7 @@ static if (__VERSION__ < 2092)
     {
         va_list ap;
         va_start(ap, format);
-        vtip(format, ap);
+        verrorReport(Loc.initial, format, ap, ErrorKind.tip);
         va_end(ap);
     }
 else
@@ -391,32 +401,211 @@ else
     {
         va_list ap;
         va_start(ap, format);
-        vtip(format, ap);
+        verrorReport(Loc.initial, format, ap, ErrorKind.tip);
         va_end(ap);
     }
+
+
+// Encapsulates an error as described by its location, format message, and kind.
+private struct ErrorInfo
+{
+    this(const ref Loc loc, const ErrorKind kind, const(char)* p1 = null, const(char)* p2 = null) @safe @nogc pure nothrow
+    {
+        this.loc = loc;
+        this.p1 = p1;
+        this.p2 = p2;
+        this.kind = kind;
+    }
+
+    const Loc loc;              // location of error
+    Classification headerColor; // color to set `header` output to
+    const(char)* p1;            // additional message prefix
+    const(char)* p2;            // additional message prefix
+    const ErrorKind kind;       // kind of error being printed
+    bool supplemental;          // true if supplemental error
+}
+
+/**
+ * Implements $(D error), $(D warning), $(D deprecation), $(D message), and
+ * $(D tip). Report a diagnostic error, taking a va_list parameter, and
+ * optionally additional message prefixes. Whether the message gets printed
+ * depends on runtime values of DiagnosticReporting and global gagging.
+ * Params:
+ *      loc         = location of error
+ *      format      = printf-style format specification
+ *      ap          = printf-style variadic arguments
+ *      kind        = kind of error being printed
+ *      p1          = additional message prefix
+ *      p2          = additional message prefix
+ */
+extern (C++) void verrorReport(const ref Loc loc, const(char)* format, va_list ap, ErrorKind kind, const(char)* p1 = null, const(char)* p2 = null)
+{
+    auto info = ErrorInfo(loc, kind, p1, p2);
+    final switch (info.kind)
+    {
+    case ErrorKind.error:
+        global.errors++;
+        if (!global.gag)
+        {
+            info.headerColor = Classification.error;
+            verrorPrint(format, ap, info);
+            if (global.params.errorLimit && global.errors >= global.params.errorLimit)
+                fatal(); // moderate blizzard of cascading messages
+        }
+        else
+        {
+            if (global.params.showGaggedErrors)
+            {
+                info.headerColor = Classification.gagged;
+                verrorPrint(format, ap, info);
+            }
+            global.gaggedErrors++;
+        }
+        break;
+
+    case ErrorKind.deprecation:
+        if (global.params.useDeprecated == DiagnosticReporting.error)
+            goto case ErrorKind.error;
+        else if (global.params.useDeprecated == DiagnosticReporting.inform)
+        {
+            if (!global.gag)
+            {
+                info.headerColor = Classification.deprecation;
+                verrorPrint(format, ap, info);
+            }
+            else
+            {
+                global.gaggedWarnings++;
+            }
+        }
+        break;
+
+    case ErrorKind.warning:
+        if (global.params.warnings != DiagnosticReporting.off)
+        {
+            if (!global.gag)
+            {
+                info.headerColor = Classification.warning;
+                verrorPrint(format, ap, info);
+                if (global.params.warnings == DiagnosticReporting.error)
+                    global.warnings++;
+            }
+            else
+            {
+                global.gaggedWarnings++;
+            }
+        }
+        break;
+
+    case ErrorKind.tip:
+        if (!global.gag)
+        {
+            info.headerColor = Classification.tip;
+            verrorPrint(format, ap, info);
+        }
+        break;
+
+    case ErrorKind.message:
+        const p = info.loc.toChars();
+        if (*p)
+        {
+            fprintf(stdout, "%s: ", p);
+            mem.xfree(cast(void*)p);
+        }
+        OutBuffer tmp;
+        tmp.vprintf(format, ap);
+        fputs(tmp.peekChars(), stdout);
+        fputc('\n', stdout);
+        fflush(stdout);     // ensure it gets written out in case of compiler aborts
+        break;
+    }
+}
+
+/**
+ * Implements $(D errorSupplemental), $(D warningSupplemental), and
+ * $(D deprecationSupplemental). Report an addition diagnostic error, taking a
+ * va_list parameter. Whether the message gets printed depends on runtime
+ * values of DiagnosticReporting and global gagging.
+ * Params:
+ *      loc         = location of error
+ *      format      = printf-style format specification
+ *      ap          = printf-style variadic arguments
+ *      kind        = kind of error being printed
+ */
+extern (C++) void verrorReportSupplemental(const ref Loc loc, const(char)* format, va_list ap, ErrorKind kind)
+{
+    auto info = ErrorInfo(loc, kind);
+    info.supplemental = true;
+    switch (info.kind)
+    {
+    case ErrorKind.error:
+        if (global.gag)
+        {
+            if (!global.params.showGaggedErrors)
+                return;
+            info.headerColor = Classification.gagged;
+        }
+        else
+            info.headerColor = Classification.error;
+        verrorPrint(format, ap, info);
+        break;
+
+    case ErrorKind.deprecation:
+        if (global.params.useDeprecated == DiagnosticReporting.error)
+            goto case ErrorKind.error;
+        else if (global.params.useDeprecated == DiagnosticReporting.inform && !global.gag)
+        {
+            info.headerColor = Classification.deprecation;
+            verrorPrint(format, ap, info);
+        }
+        break;
+
+    case ErrorKind.warning:
+        if (global.params.warnings != DiagnosticReporting.off && !global.gag)
+        {
+            info.headerColor = Classification.warning;
+            verrorPrint(format, ap, info);
+        }
+        break;
+
+    default:
+        assert(false, "internal error: unhandled kind in error report");
+    }
+}
 
 /**
  * Just print to stderr, doesn't care about gagging.
  * (format,ap) text within backticks gets syntax highlighted.
  * Params:
- *      loc         = location of error
- *      headerColor = color to set `header` output to
- *      header      = title of error message
- *      format      = printf-style format specification
- *      ap          = printf-style variadic arguments
- *      p1          = additional message prefix
- *      p2          = additional message prefix
+ *      format  = printf-style format specification
+ *      ap      = printf-style variadic arguments
+ *      info    = context of error
  */
-private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* header,
-        const(char)* format, va_list ap, const(char)* p1 = null, const(char)* p2 = null)
+private void verrorPrint(const(char)* format, va_list ap, ref ErrorInfo info)
 {
-    if (diagnosticHandler && diagnosticHandler(loc, headerColor, header, format, ap, p1, p2))
+    const(char)* header;    // title of error message
+    if (info.supplemental)
+        header = "       ";
+    else
+    {
+        final switch (info.kind)
+        {
+            case ErrorKind.error:       header = "Error: "; break;
+            case ErrorKind.deprecation: header = "Deprecation: "; break;
+            case ErrorKind.warning:     header = "Warning: "; break;
+            case ErrorKind.tip:         header = "  Tip: "; break;
+            case ErrorKind.message:     assert(0);
+        }
+    }
+
+    if (diagnosticHandler !is null &&
+        diagnosticHandler(info.loc, info.headerColor, header, format, ap, info.p1, info.p2))
         return;
 
     if (global.params.showGaggedErrors && global.gag)
         fprintf(stderr, "(spec:%d) ", global.gag);
     Console con = cast(Console) global.console;
-    const p = loc.toChars();
+    const p = info.loc.toChars();
     if (con)
         con.setColorBright(true);
     if (*p)
@@ -425,19 +614,19 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
         mem.xfree(cast(void*)p);
     }
     if (con)
-        con.setColor(headerColor);
+        con.setColor(info.headerColor);
     fputs(header, stderr);
     if (con)
         con.resetColor();
     OutBuffer tmp;
-    if (p1)
+    if (info.p1)
     {
-        tmp.writestring(p1);
+        tmp.writestring(info.p1);
         tmp.writestring(" ");
     }
-    if (p2)
+    if (info.p2)
     {
-        tmp.writestring(p2);
+        tmp.writestring(info.p2);
         tmp.writestring(" ");
     }
     tmp.vprintf(format, ap);
@@ -452,9 +641,10 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
     fputc('\n', stderr);
 
     __gshared Loc old_loc;
+    Loc loc = info.loc;
     if (global.params.printErrorContext &&
         // ignore supplemental messages with same loc
-        (loc != old_loc || strchr(header, ':')) &&
+        (loc != old_loc || !info.supplemental) &&
         // ignore invalid files
         loc != Loc.initial &&
         // ignore mixins for now
@@ -492,236 +682,6 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
     }
     old_loc = loc;
     fflush(stderr);     // ensure it gets written out in case of compiler aborts
-}
-
-/**
- * Same as $(D error), but takes a va_list parameter, and optionally additional message prefixes.
- * Params:
- *      loc    = location of error
- *      format = printf-style format specification
- *      ap     = printf-style variadic arguments
- *      p1     = additional message prefix
- *      p2     = additional message prefix
- *      header = title of error message
- */
-extern (C++) void verror(const ref Loc loc, const(char)* format, va_list ap, const(char)* p1 = null, const(char)* p2 = null, const(char)* header = "Error: ")
-{
-    global.errors++;
-    if (!global.gag)
-    {
-        verrorPrint(loc, Classification.error, header, format, ap, p1, p2);
-        if (global.params.errorLimit && global.errors >= global.params.errorLimit)
-            fatal(); // moderate blizzard of cascading messages
-    }
-    else
-    {
-        if (global.params.showGaggedErrors)
-            verrorPrint(loc, Classification.gagged, header, format, ap, p1, p2);
-        global.gaggedErrors++;
-    }
-}
-
-/**
- * Same as $(D errorSupplemental), but takes a va_list parameter.
- * Params:
- *      loc    = location of error
- *      format = printf-style format specification
- *      ap     = printf-style variadic arguments
- */
-static if (__VERSION__ < 2092)
-    extern (C++) void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap)
-    {
-        _verrorSupplemental(loc, format, ap);
-    }
-else
-    pragma(printf) extern (C++) void verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap)
-    {
-        _verrorSupplemental(loc, format, ap);
-    }
-
-private void _verrorSupplemental(const ref Loc loc, const(char)* format, va_list ap)
-{
-    Color color;
-    if (global.gag)
-    {
-        if (!global.params.showGaggedErrors)
-            return;
-        color = Classification.gagged;
-    }
-    else
-        color = Classification.error;
-
-    verrorPrint(loc, color, "       ", format, ap);
-}
-
-/**
- * Same as $(D warning), but takes a va_list parameter.
- * Params:
- *      loc    = location of warning
- *      format = printf-style format specification
- *      ap     = printf-style variadic arguments
- */
-static if (__VERSION__ < 2092)
-    extern (C++) void vwarning(const ref Loc loc, const(char)* format, va_list ap)
-    {
-        _vwarning(loc, format, ap);
-    }
-else
-    pragma(printf) extern (C++) void vwarning(const ref Loc loc, const(char)* format, va_list ap)
-    {
-        _vwarning(loc, format, ap);
-    }
-
-private void _vwarning(const ref Loc loc, const(char)* format, va_list ap)
-{
-    if (global.params.warnings != DiagnosticReporting.off)
-    {
-        if (!global.gag)
-        {
-            verrorPrint(loc, Classification.warning, "Warning: ", format, ap);
-            if (global.params.warnings == DiagnosticReporting.error)
-                global.warnings++;
-        }
-        else
-        {
-            global.gaggedWarnings++;
-        }
-    }
-}
-
-/**
- * Same as $(D warningSupplemental), but takes a va_list parameter.
- * Params:
- *      loc    = location of warning
- *      format = printf-style format specification
- *      ap     = printf-style variadic arguments
- */
-static if (__VERSION__ < 2092)
-    extern (C++) void vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap)
-    {
-        _vwarningSupplemental(loc, format, ap);
-    }
-else
-    pragma(printf) extern (C++) void vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap)
-    {
-        _vwarningSupplemental(loc, format, ap);
-    }
-
-private void _vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap)
-{
-    if (global.params.warnings != DiagnosticReporting.off && !global.gag)
-        verrorPrint(loc, Classification.warning, "       ", format, ap);
-}
-
-/**
- * Same as $(D deprecation), but takes a va_list parameter, and optionally additional message prefixes.
- * Params:
- *      loc    = location of deprecation
- *      format = printf-style format specification
- *      ap     = printf-style variadic arguments
- *      p1     = additional message prefix
- *      p2     = additional message prefix
- */
-extern (C++) void vdeprecation(const ref Loc loc, const(char)* format, va_list ap, const(char)* p1 = null, const(char)* p2 = null)
-{
-    static immutable header = "Deprecation: ";
-    if (global.params.useDeprecated == DiagnosticReporting.error)
-        verror(loc, format, ap, p1, p2, header.ptr);
-    else if (global.params.useDeprecated == DiagnosticReporting.inform)
-    {
-        if (!global.gag)
-        {
-            verrorPrint(loc, Classification.deprecation, header.ptr, format, ap, p1, p2);
-        }
-        else
-        {
-            global.gaggedWarnings++;
-        }
-    }
-}
-
-/**
- * Same as $(D message), but takes a va_list parameter.
- * Params:
- *      loc       = location of message
- *      format    = printf-style format specification
- *      ap        = printf-style variadic arguments
- */
-static if (__VERSION__ < 2092)
-    extern (C++) void vmessage(const ref Loc loc, const(char)* format, va_list ap)
-    {
-        _vmessage(loc, format, ap);
-    }
-else
-    pragma(printf) extern (C++) void vmessage(const ref Loc loc, const(char)* format, va_list ap)
-    {
-        _vmessage(loc, format, ap);
-    }
-
-private void _vmessage(const ref Loc loc, const(char)* format, va_list ap)
-{
-    const p = loc.toChars();
-    if (*p)
-    {
-        fprintf(stdout, "%s: ", p);
-        mem.xfree(cast(void*)p);
-    }
-    OutBuffer tmp;
-    tmp.vprintf(format, ap);
-    fputs(tmp.peekChars(), stdout);
-    fputc('\n', stdout);
-    fflush(stdout);     // ensure it gets written out in case of compiler aborts
-}
-
-/**
- * Same as $(D tip), but takes a va_list parameter.
- * Params:
- *      format    = printf-style format specification
- *      ap        = printf-style variadic arguments
- */
-static if (__VERSION__ < 2092)
-    extern (C++) void vtip(const(char)* format, va_list ap)
-    {
-        _vtip(format, ap);
-    }
-else
-    pragma(printf) extern (C++) void vtip(const(char)* format, va_list ap)
-    {
-        _vtip(format, ap);
-    }
-private void _vtip(const(char)* format, va_list ap)
-{
-    if (!global.gag)
-    {
-        Loc loc = Loc.init;
-        verrorPrint(loc, Classification.tip, "  Tip: ", format, ap);
-    }
-}
-
-/**
- * Same as $(D deprecationSupplemental), but takes a va_list parameter.
- * Params:
- *      loc    = location of deprecation
- *      format = printf-style format specification
- *      ap     = printf-style variadic arguments
- */
-static if (__VERSION__ < 2092)
-    extern (C++) void vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap)
-    {
-        _vdeprecationSupplemental(loc, format, ap);
-    }
-else
-    pragma(printf) extern (C++) void vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap)
-    {
-        _vdeprecationSupplemental(loc, format, ap);
-    }
-
-private void _vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap)
-{
-    if (global.params.useDeprecated == DiagnosticReporting.error)
-        verrorSupplemental(loc, format, ap);
-    else if (global.params.useDeprecated == DiagnosticReporting.inform && !global.gag)
-        verrorPrint(loc, Classification.deprecation, "       ", format, ap);
 }
 
 /**

--- a/compiler/src/dmd/errors.h
+++ b/compiler/src/dmd/errors.h
@@ -14,6 +14,15 @@
 
 struct Loc;
 
+enum class ErrorKind
+{
+    warning = 0,
+    deprecation = 1,
+    error = 2,
+    tip = 3,
+    message = 4,
+};
+
 bool isConsoleColorSupported();
 
 #if defined(__GNUC__)
@@ -30,17 +39,12 @@ D_ATTRIBUTE_FORMAT(2, 3) void deprecationSupplemental(const Loc& loc, const char
 D_ATTRIBUTE_FORMAT(2, 3) void error(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(4, 5) void error(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void errorSupplemental(const Loc& loc, const char *format, ...);
-D_ATTRIBUTE_FORMAT(2, 0) void verror(const Loc& loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL, const char *header = "Error: ");
-D_ATTRIBUTE_FORMAT(2, 0) void verrorSupplemental(const Loc& loc, const char *format, va_list ap);
-D_ATTRIBUTE_FORMAT(2, 0) void vwarning(const Loc& loc, const char *format, va_list);
-D_ATTRIBUTE_FORMAT(2, 0) void vwarningSupplemental(const Loc& loc, const char *format, va_list ap);
-D_ATTRIBUTE_FORMAT(2, 0) void vdeprecation(const Loc& loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
-D_ATTRIBUTE_FORMAT(2, 0) void vdeprecationSupplemental(const Loc& loc, const char *format, va_list ap);
 D_ATTRIBUTE_FORMAT(1, 2) void message(const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void message(const Loc& loc, const char *format, ...);
-D_ATTRIBUTE_FORMAT(2, 0) void vmessage(const Loc& loc, const char *format, va_list ap);
 D_ATTRIBUTE_FORMAT(1, 2) void tip(const char *format, ...);
-D_ATTRIBUTE_FORMAT(1, 0) void vtip(const char *format, va_list ap);
+
+D_ATTRIBUTE_FORMAT(2, 0) void verrorReport(const Loc& loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
+D_ATTRIBUTE_FORMAT(2, 0) void verrorReportSupplemental(const Loc& loc, const char* format, va_list ap, ErrorKind kind);
 
 #if defined(__GNUC__) || defined(__clang__)
 #define D_ATTRIBUTE_NORETURN __attribute__((noreturn))

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -825,7 +825,7 @@ extern (C++) abstract class Expression : ASTNode
             {
                 va_list ap;
                 va_start(ap, format);
-                .verror(loc, format, ap);
+                .verrorReport(loc, format, ap, ErrorKind.error);
                 va_end(ap);
             }
         }
@@ -837,7 +837,7 @@ extern (C++) abstract class Expression : ASTNode
 
             va_list ap;
             va_start(ap, format);
-            .verrorSupplemental(loc, format, ap);
+            .verrorReportSupplemental(loc, format, ap, ErrorKind.error);
             va_end(ap);
         }
 
@@ -847,7 +847,7 @@ extern (C++) abstract class Expression : ASTNode
             {
                 va_list ap;
                 va_start(ap, format);
-                .vwarning(loc, format, ap);
+                .verrorReport(loc, format, ap, ErrorKind.warning);
                 va_end(ap);
             }
         }
@@ -858,7 +858,7 @@ extern (C++) abstract class Expression : ASTNode
             {
                 va_list ap;
                 va_start(ap, format);
-                .vdeprecation(loc, format, ap);
+                .verrorReport(loc, format, ap, ErrorKind.deprecation);
                 va_end(ap);
             }
         }
@@ -871,7 +871,7 @@ extern (C++) abstract class Expression : ASTNode
             {
                 va_list ap;
                 va_start(ap, format);
-                .verror(loc, format, ap);
+                .verrorReport(loc, format, ap, ErrorKind.error);
                 va_end(ap);
             }
         }
@@ -883,7 +883,7 @@ extern (C++) abstract class Expression : ASTNode
 
             va_list ap;
             va_start(ap, format);
-            .verrorSupplemental(loc, format, ap);
+            .verrorReportSupplemental(loc, format, ap, ErrorKind.error);
             va_end(ap);
         }
 
@@ -893,7 +893,7 @@ extern (C++) abstract class Expression : ASTNode
             {
                 va_list ap;
                 va_start(ap, format);
-                .vwarning(loc, format, ap);
+                .verrorReport(loc, format, ap, ErrorKind.warning);
                 va_end(ap);
             }
         }
@@ -904,7 +904,7 @@ extern (C++) abstract class Expression : ASTNode
             {
                 va_list ap;
                 va_start(ap, format);
-                .vdeprecation(loc, format, ap);
+                .verrorReport(loc, format, ap, ErrorKind.deprecation);
                 va_end(ap);
             }
         }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5390,6 +5390,15 @@ enum class CPU : uint8_t
     native = 12u,
 };
 
+enum class ErrorKind
+{
+    warning = 0,
+    deprecation = 1,
+    error = 2,
+    tip = 3,
+    message = 4,
+};
+
 typedef _d_real longdouble;
 
 typedef uint64_t uint64_t;
@@ -8503,21 +8512,9 @@ extern void message(const char* format, ...);
 
 extern void tip(const char* format, ...);
 
-extern void verror(const Loc& loc, const char* format, va_list ap, const char* p1 = nullptr, const char* p2 = nullptr, const char* header = "Error: ");
+extern void verrorReport(const Loc& loc, const char* format, va_list ap, ErrorKind kind, const char* p1 = nullptr, const char* p2 = nullptr);
 
-extern void verrorSupplemental(const Loc& loc, const char* format, va_list ap);
-
-extern void vwarning(const Loc& loc, const char* format, va_list ap);
-
-extern void vwarningSupplemental(const Loc& loc, const char* format, va_list ap);
-
-extern void vdeprecation(const Loc& loc, const char* format, va_list ap, const char* p1 = nullptr, const char* p2 = nullptr);
-
-extern void vmessage(const Loc& loc, const char* format, va_list ap);
-
-extern void vtip(const char* format, va_list ap);
-
-extern void vdeprecationSupplemental(const Loc& loc, const char* format, va_list ap);
+extern void verrorReportSupplemental(const Loc& loc, const char* format, va_list ap, ErrorKind kind);
 
 extern void fatal();
 

--- a/compiler/src/dmd/iasmdmd.d
+++ b/compiler/src/dmd/iasmdmd.d
@@ -2099,7 +2099,7 @@ void asmerr(const(char)* format, ...)
 
     va_list ap;
     va_start(ap, format);
-    verror(asmstate.loc, format, ap);
+    verrorReport(asmstate.loc, format, ap, ErrorKind.error);
     va_end(ap);
 
     asmstate.errors = true;

--- a/compiler/src/dmd/lib.d
+++ b/compiler/src/dmd/lib.d
@@ -109,7 +109,7 @@ class Library
     {
         va_list ap;
         va_start(ap, format);
-        .verror(loc, format, ap);
+        .verrorReport(loc, format, ap, ErrorKind.error);
         va_end(ap);
     }
 

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -129,7 +129,7 @@ extern (C++) abstract class Statement : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .verror(loc, format, ap);
+            .verrorReport(loc, format, ap, ErrorKind.error);
             va_end(ap);
         }
 
@@ -137,7 +137,7 @@ extern (C++) abstract class Statement : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .vwarning(loc, format, ap);
+            .verrorReport(loc, format, ap, ErrorKind.warning);
             va_end(ap);
         }
 
@@ -145,7 +145,7 @@ extern (C++) abstract class Statement : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .vdeprecation(loc, format, ap);
+            .verrorReport(loc, format, ap, ErrorKind.deprecation);
             va_end(ap);
         }
     }
@@ -155,7 +155,7 @@ extern (C++) abstract class Statement : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .verror(loc, format, ap);
+            .verrorReport(loc, format, ap, ErrorKind.error);
             va_end(ap);
         }
 
@@ -163,7 +163,7 @@ extern (C++) abstract class Statement : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .vwarning(loc, format, ap);
+            .verrorReport(loc, format, ap, ErrorKind.warning);
             va_end(ap);
         }
 
@@ -171,7 +171,7 @@ extern (C++) abstract class Statement : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .vdeprecation(loc, format, ap);
+            .verrorReport(loc, format, ap, ErrorKind.deprecation);
             va_end(ap);
         }
     }


### PR DESCRIPTION
Replaces the vagary of `v*` and `v*Supplemental` functions with two entrypoints, `verrorReport` and `verrorReportSupplemental`.

The hope is that by reducing the surface area, make it simplier to add extra contextual information about a given warning or error message.

Alternative starting point for #15422.