### PR TITLE
Always implicitly add 'return 0' to extern(C) main functions

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -231,7 +231,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 return true;
 
             return f.next.ty == Tvoid &&
-                (funcdecl.isMain() || global.params.betterC && funcdecl.isCMain());
+                (funcdecl.isMain() || funcdecl.isCMain());
         }
 
         VarDeclaration _arguments = null;

--- a/compiler/test/runnable/testcmain.d
+++ b/compiler/test/runnable/testcmain.d
@@ -1,0 +1,3 @@
+module object;
+extern(D) void main() { }
+extern(C) void main() { }


### PR DESCRIPTION
I'm not sure why we need `-betterC` in order to do this.

It is possible to have:
```
module object;
extern(D) void main() { }
extern(C) void main() { }
```
And it's expected that the program should return 0.