### PR TITLE
Fix 23857 - backend inliner takes too long on recursive function call

### DIFF
--- a/compiler/src/dmd/backend/inliner.d
+++ b/compiler/src/dmd/backend/inliner.d
@@ -66,6 +66,11 @@ bool canInlineFunction(Symbol *sfunc)
     assert(f && tyfunc(t.Tty));
 
     bool result = false;
+
+    // Disable backend inliner until this issue if fixed:
+    // https://issues.dlang.org/show_bug.cgi?id=23857
+    return result;
+
     if (!(config.flags & CFGnoinlines) && /* if inlining is turned on   */
         f.Fflags & Finline &&
         /* Cannot inline varargs or unprototyped functions      */

--- a/compiler/test/compilable/backend_inliner.d
+++ b/compiler/test/compilable/backend_inliner.d
@@ -1,0 +1,24 @@
+/*
+REQUIRED_ARGS: -O -inline
+https://issues.dlang.org/show_bug.cgi?id=23857
+backend inliner takes too long on recursive function call
+
+This test doesn't need a timeout, since it would trip up an assert in dmd/backend/go.d:
+```
+if (++iter > 200)
+{   assert(iter < iterationLimit);      // infinite loop check
+    break;
+}
+```
+*/
+
+int f(int[] a, int u)
+{
+    return (a.ptr[u] < 0) ? u : (a.ptr[u] = f(a, a.ptr[u]));
+}
+
+void main()
+{
+    f([], 0);
+    f([], 0);
+}


### PR DESCRIPTION
Blunt fix: disable backend inliner for now