### PR TITLE
Reduce quotes clutter on ctfe assert failure

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6105,7 +6105,10 @@ public:
                 result = interpret(&ue, e.msg, istate);
                 if (exceptionOrCant(result))
                     return;
-                e.error("`%s`", result.toChars());
+                if (StringExp se = result.isStringExp())
+                    e.error("%s", se.toStringz().ptr);
+                else
+                    e.error("%s", result.toChars());
             }
             else
                 e.error("`%s` failed", e.toChars());

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6638,7 +6638,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             else
             {
                 OutBuffer buf;
-                buf.printf("%s failed", exp.toChars());
+                buf.printf("`%s` failed", exp.toChars());
                 exp.msg = new StringExp(Loc.initial, buf.extractSlice());
                 goto LSkip;
             }

--- a/compiler/test/fail_compilation/fail144.d
+++ b/compiler/test/fail_compilation/fail144.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail144.d(13): Error: `"message"`
+fail_compilation/fail144.d(13): Error: message
 fail_compilation/fail144.d(26):        called from here: `bar(7)`
 ---
 */

--- a/compiler/test/fail_compilation/fail145.d
+++ b/compiler/test/fail_compilation/fail145.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -checkaction=context
 TEST_OUTPUT:
 ---
-fail_compilation/fail145.d(14): Error: `"assert(i && (i < 0)) failed"`
+fail_compilation/fail145.d(14): Error: `assert(i && (i < 0))` failed
 fail_compilation/fail145.d(27):        called from here: `bar(7)`
 ---
 */

--- a/compiler/test/fail_compilation/noreturn.d
+++ b/compiler/test/fail_compilation/noreturn.d
@@ -3,18 +3,18 @@ REQUIRED_ARGS: -w -o-
 
 TEST_OUTPUT:
 ---
-fail_compilation\noreturn.d(38): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(38): Error: Accessed expression of type `noreturn`
 fail_compilation\noreturn.d(42):        called from here: `assign()`
-fail_compilation\noreturn.d(49): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(49): Error: Accessed expression of type `noreturn`
 fail_compilation\noreturn.d(49):        called from here: `foo(n)`
 fail_compilation\noreturn.d(53):        called from here: `calling()`
-fail_compilation\noreturn.d(59): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(59): Error: Accessed expression of type `noreturn`
 fail_compilation\noreturn.d(62):        called from here: `nested()`
-fail_compilation\noreturn.d(68): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(68): Error: Accessed expression of type `noreturn`
 fail_compilation\noreturn.d(78):        called from here: `casting(0)`
-fail_compilation\noreturn.d(69): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(69): Error: Accessed expression of type `noreturn`
 fail_compilation\noreturn.d(79):        called from here: `casting(1)`
-fail_compilation\noreturn.d(72): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation\noreturn.d(72): Error: Accessed expression of type `noreturn`
 fail_compilation\noreturn.d(80):        called from here: `casting(2)`
 fail_compilation/noreturn.d(120): Error: uncaught CTFE exception `object.Exception("")`
 ---
@@ -125,7 +125,7 @@ https://issues.dlang.org/show_bug.cgi?id=23063
 
 TEST_OUTPUT:
 ---
-fail_compilation/noreturn.d(135): Error: `"Accessed expression of type `noreturn`"`
+fail_compilation/noreturn.d(135): Error: Accessed expression of type `noreturn`
 fail_compilation/noreturn.d(138):        called from here: `func()`
 ---
 */


### PR DESCRIPTION
I noticed that `` `"Accessed expression of type `noreturn`"` `` looks really cluttered.