### PR TITLE
make FL a ubyte

### DIFF
--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -1170,7 +1170,7 @@ struct Symbol
 //#endif
 
     SC Sclass;                  // storage class (SCxxxx)
-    char Sfl;                   // flavor (FLxxxx)
+    FL Sfl;                     // flavor (FLxxxx)
     SYMFLGS Sflags;             // flag bits (SFLxxxx)
 
     vec_t       Srange;         // live range, if any
@@ -1344,7 +1344,7 @@ void param_debug(const param_t *p)
  * These should be combined with storage classes.
  */
 
-alias FL = int;
+alias FL = ubyte;
 enum
 {
     // Change this, update debug.c too

--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -866,7 +866,8 @@ void getlvalue_lsw(code *c)
 @trusted
 void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
 {
-    uint fl, f, opsave;
+    FL fl;
+    uint f, opsave;
     elem* e1, e11, e12;
     bool e1isadd, e1free;
     reg_t reg;
@@ -1658,7 +1659,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
             break;
 
         default:
-            WRFL(cast(FL)fl);
+            WRFL(fl);
             symbol_print(s);
             assert(0);
     }
@@ -3915,7 +3916,7 @@ private void funccall(ref CodeBuilder cdb, elem* e, uint numpara, uint numalign,
         // Function calls may throw Errors
         funcsym_p.Sfunc.Fflags3 &= ~Fnothrow;
 
-        if (e1.Eoper != OPind) { WRFL(cast(FL)el_fl(e1)); printf("e1.Eoper: %s\n", oper_str(e1.Eoper)); }
+        if (e1.Eoper != OPind) { WRFL(el_fl(e1)); printf("e1.Eoper: %s\n", oper_str(e1.Eoper)); }
         save87(cdb);                   // assume 8087 regs are all trashed
         assert(e1.Eoper == OPind);
         elem *e11 = e1.EV.E1;

--- a/compiler/src/dmd/backend/cod3.d
+++ b/compiler/src/dmd/backend/cod3.d
@@ -5612,7 +5612,7 @@ targ_size_t cod3_bpoffset(Symbol *s)
             break;
 
         default:
-            WRFL(cast(FL)s.Sfl);
+            WRFL(s.Sfl);
             symbol_print(s);
             assert(0);
     }
@@ -6181,7 +6181,7 @@ void pinholeopt(code *c,block *b)
                             break;
 
                         default:
-                            WRFL(cast(FL)c.IFL2);
+                            WRFL(c.IFL2);
                             assert(0);
                     }
                     break;
@@ -7187,7 +7187,7 @@ uint codout(int seg, code *c, Barray!ubyte* disasmBuf)
                             goto ptr1632;
 
                     case 0x68:              // PUSH immed32
-                        if (cast(FL)c.IFL2 == FLblock)
+                        if (c.IFL2 == FLblock)
                         {
                             c.IFL2 = FLblockoff;
                             goto do32;
@@ -7254,7 +7254,7 @@ uint codout(int seg, code *c, Barray!ubyte* disasmBuf)
                         break;
 
                     case 0x68:              // PUSH immed16
-                        if (cast(FL)c.IFL2 == FLblock)
+                        if (c.IFL2 == FLblock)
                         {   c.IFL2 = FLblockoff;
                             goto do16;
                         }
@@ -7691,17 +7691,16 @@ private void do16bit(ref MiniCodeBuf pbuf, FL fl, evc *uev,int flags)
 @trusted
 private void do8bit(ref MiniCodeBuf pbuf, FL fl, evc *uev)
 {
-    char c;
-    targ_ptrdiff_t delta;
+    ubyte c;
 
     switch (fl)
     {
         case FLconst:
-            c = cast(char)uev.Vuns;
+            c = cast(ubyte)uev.Vuns;
             break;
 
         case FLblock:
-            delta = uev.Vblock.Boffset - pbuf.getOffset() - 1;
+            targ_ptrdiff_t delta = uev.Vblock.Boffset - pbuf.getOffset() - 1;
             if (cast(byte)delta != delta)
             {
                 if (uev.Vblock.Bsrcpos.Slinnum)
@@ -7709,7 +7708,7 @@ private void do8bit(ref MiniCodeBuf pbuf, FL fl, evc *uev)
                 printf("block displacement of %lld exceeds the maximum offset of -128 to 127.\n", cast(long)delta);
                 err_exit();
             }
-            c = cast(char)delta;
+            c = cast(ubyte)delta;
             debug assert(uev.Vblock.Boffset > pbuf.getOffset() || c != 0x7F);
             break;
 
@@ -7848,14 +7847,14 @@ extern (C) void code_print(scope code* c)
                 case FLtlsdata:
                 case FLextern:
                     printf(" ");
-                    WRFL(cast(FL)c.IFL1);
+                    WRFL(c.IFL1);
                     printf(" sym='%s'",c.IEV1.Vsym.Sident.ptr);
                     if (c.IEV1.Voffset)
                         printf(".%d", cast(int)c.IEV1.Voffset);
                     break;
 
                 default:
-                    WRFL(cast(FL)c.IFL1);
+                    WRFL(c.IFL1);
                     break;
             }
         }
@@ -7863,7 +7862,7 @@ extern (C) void code_print(scope code* c)
     if (ins & T)
     {
         printf(" ");
-        WRFL(cast(FL)c.IFL2);
+        WRFL(c.IFL2);
         switch (c.IFL2)
         {
             case FLconst:
@@ -7902,7 +7901,7 @@ extern (C) void code_print(scope code* c)
                 break;
 
             default:
-                WRFL(cast(FL)c.IFL2);
+                WRFL(c.IFL2);
                 break;
         }
     }

--- a/compiler/src/dmd/backend/code_x86.d
+++ b/compiler/src/dmd/backend/code_x86.d
@@ -15,7 +15,7 @@ module dmd.backend.code_x86;
 // Online documentation: https://dlang.org/phobos/dmd_backend_code_x86.html
 
 import dmd.backend.cdef;
-import dmd.backend.cc : config;
+import dmd.backend.cc : config, FL;
 import dmd.backend.code;
 import dmd.backend.codebuilder : CodeBuilder;
 import dmd.backend.el : elem;
@@ -370,7 +370,7 @@ struct code
      * operand, usually for immediate instructions.
      */
 
-    ubyte IFL1,IFL2;    // FLavors of 1st, 2nd operands
+    FL IFL1,IFL2;         // FLavors of 1st, 2nd operands
     evc IEV1;             // 1st operand, if any
     evc IEV2;             // 2nd operand, if any
 

--- a/compiler/src/dmd/backend/el.d
+++ b/compiler/src/dmd/backend/el.d
@@ -132,7 +132,7 @@ void elem_debug(const elem* e)
 }
 
 @trusted
-FL el_fl(const elem* e) { return cast(FL)e.EV.Vsym.Sfl; }
+FL el_fl(const elem* e) { return e.EV.Vsym.Sfl; }
 
 //#define Eoffset         EV.sp.Voffset
 //#define Esymnum         EV.sp.Vsymnum


### PR DESCRIPTION
A step on the way to making FL an `enum FL : ubyte`. Moving towards a consistent use of types in the backend.