### PR TITLE
Make non-scope constructor a DIP1000 error

### DIFF
--- a/changelog/dmd.scope-ctor-error.dd
+++ b/changelog/dmd.scope-ctor-error.dd
@@ -1,0 +1,3 @@
+Creating a `scope` class instance with a non-scope constructor is `@system` only with DIP1000
+
+The fix for [issue 23145](https://issues.dlang.org/show_bug.cgi?id=23145) broke existing code, so it's put behind `-preview=DIP1000` now, just like other `scope` related errors.

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1120,18 +1120,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                                  */
                                 if (ne.member && !(ne.member.storage_class & STC.scope_))
                                 {
-                                    if (sc.func.isSafe())
-                                    {
-                                        if (global.params.obsolete)
-                                        {
-                                            warning(dsym.loc,
-                                                "`scope` allocation of `%s` requires that constructor be annotated with `scope`",
-                                                dsym.toChars());
-                                            warningSupplemental(ne.member.loc, "is the location of the constructor");
-                                        }
-                                     }
-                                     else
-                                         sc.func.setUnsafe();
+                                    import dmd.escape : setUnsafeDIP1000;
+                                    const inSafeFunc = sc.func && sc.func.isSafeBypassingInference();
+                                    if (sc.setUnsafeDIP1000(false, dsym.loc, "`scope` allocation of `%s` requires that constructor be annotated with `scope`", dsym))
+                                        errorSupplemental(ne.member.loc, "is the location of the constructor");
+                                    else if (global.params.obsolete && inSafeFunc)
+                                        warningSupplemental(ne.member.loc, "is the location of the constructor");
                                 }
                                 ne.onstack = 1;
                                 dsym.onstack = true;

--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -2561,7 +2561,7 @@ private void addMaybe(VarDeclaration va, VarDeclaration v)
 }
 
 // `setUnsafePreview` partially evaluated for dip1000
-private bool setUnsafeDIP1000(Scope* sc, bool gag, Loc loc, const(char)* msg,
+bool setUnsafeDIP1000(Scope* sc, bool gag, Loc loc, const(char)* msg,
     RootObject arg0 = null, RootObject arg1 = null, RootObject arg2 = null)
 {
     return setUnsafePreview(sc, global.params.useDIP1000, gag, loc, msg, arg0, arg1, arg2);

--- a/compiler/test/compilable/test23145.d
+++ b/compiler/test/compilable/test23145.d
@@ -25,7 +25,7 @@ class C
     this(D d) @safe @nogc;
 }
 
-C foo(D d)@nogc @safe
+C foo(D d) @nogc @safe
 {
     scope e = new C(1);  // ok
     scope c = new C(d);  // deprecation
@@ -37,4 +37,9 @@ C bax(D d) @safe
     scope e = new C(1);  // ok
     scope c = new C(d);  // deprecation
     return c.d.c;
+}
+
+void inferred(D d)
+{
+    scope c = new C(d);  // ok
 }

--- a/compiler/test/fail_compilation/test23145.d
+++ b/compiler/test/fail_compilation/test23145.d
@@ -1,0 +1,50 @@
+/* REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test23145.d(117): Error: `scope` allocation of `c` requires that constructor be annotated with `scope`
+fail_compilation/test23145.d(111):        is the location of the constructor
+fail_compilation/test23145.d(124): Error: `scope` allocation of `c` requires that constructor be annotated with `scope`
+fail_compilation/test23145.d(111):        is the location of the constructor
+fail_compilation/test23145.d(125): Error: `@safe` function `test23145.bax` cannot call `@system` function `test23145.inferred`
+fail_compilation/test23145.d(131):        which wasn't inferred `@safe` because of:
+fail_compilation/test23145.d(131):        `scope` allocation of `c` requires that constructor be annotated with `scope`
+fail_compilation/test23145.d(129):        `test23145.inferred` is declared here
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=23145
+
+#line 100
+
+class D
+{
+    C c;
+}
+
+class C
+{
+    D d;
+    int x=3;
+    this(int i) scope @safe @nogc;
+    this(D d) @safe @nogc;
+}
+
+C foo(D d) @nogc @safe
+{
+    scope e = new C(1);  // ok
+    scope c = new C(d);  // error
+    return c.d.c;
+}
+
+C bax(D d) @safe
+{
+    scope e = new C(1);  // ok
+    scope c = new C(d);  // error
+    inferred(d);
+    return c.d.c;
+}
+
+auto inferred(D d)
+{
+    scope c = new C(d);  // infer system
+}


### PR DESCRIPTION
Follow up on https://github.com/dlang/dmd/pull/15391
 
- don't infer the function `@system` without `-preview=dip1000`
- do infer `@system` / make it a `@safe` error with `-preview=dip1000` 
- put the error in the function's `safetyViolation` so it's printed when calling a function that's inferred `@system`