### PR TITLE
more typesafe code in codebuilder.d

### DIFF
--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -2831,7 +2831,7 @@ void callclib(ref CodeBuilder cdb, elem* e, uint clib, regm_t* pretregs, regm_t 
             0x66,0x0f,0xa4,0xc2,0x10,   // shld EDX,EAX,16      ;DX,AX = EAX
         ];
 
-        cdb.genasm(cast(char*)lmul.ptr, lmul.sizeof);
+        cdb.genasm(lmul[]);
     }
     else
     {
@@ -3876,7 +3876,7 @@ private void funccall(ref CodeBuilder cdb, elem* e, uint numpara, uint numalign,
         }
         else
         {
-            int fl = FLfunc;
+            FL fl = FLfunc;
             if (!tyfunc(s.ty()))
                 fl = el_fl(e1);
             if (tym1 == TYifunc)

--- a/compiler/src/dmd/backend/cod4.d
+++ b/compiler/src/dmd/backend/cod4.d
@@ -4113,7 +4113,7 @@ void cdasm(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 {
     // Assume only regs normally destroyed by a function are destroyed
     getregs(cdb,(ALLREGS | mES) & ~fregsaved);
-    cdb.genasm(cast(char *)e.EV.Vstring, cast(uint) e.EV.Vstrlen);
+    cdb.genasm(cast(ubyte[])e.EV.Vstring[0 .. e.EV.Vstrlen]);
     fixresult(cdb,e,(I16 ? mDX | mAX : mAX),pretregs);
 }
 

--- a/compiler/src/dmd/backend/codebuilder.d
+++ b/compiler/src/dmd/backend/codebuilder.d
@@ -27,7 +27,7 @@ import dmd.backend.type;
 
 @safe:
 
-extern (C++) struct CodeBuilder
+struct CodeBuilder
 {
   private:
 
@@ -184,14 +184,14 @@ extern (C++) struct CodeBuilder
      * Generate an ASM sequence.
      */
     @trusted
-    void genasm(char *s, uint slen)
+    void genasm(const ubyte[] bytes)
     {
         code *ce = code_calloc();
         ce.Iop = ASM;
         ce.IFL1 = FLasm;
-        ce.IEV1.len = slen;
-        ce.IEV1.bytes = cast(char *) mem_malloc(slen);
-        memcpy(ce.IEV1.bytes,s,slen);
+        ce.IEV1.len = bytes.length;
+        ce.IEV1.bytes = cast(char *) mem_malloc(bytes.length);
+        memcpy(ce.IEV1.bytes,bytes.ptr,bytes.length);
 
         *pTail = ce;
         pTail = &ce.next;
@@ -225,14 +225,14 @@ extern (C++) struct CodeBuilder
     }
 
     @trusted
-    void gencs(opcode_t op, uint ea, uint FL2, Symbol *s)
+    void gencs(opcode_t op, uint ea, FL FL2, Symbol *s)
     {
         code cs;
         cs.Iop = op;
         cs.Iflags = 0;
         cs.Iea = ea;
         ccheck(&cs);
-        cs.IFL2 = cast(ubyte)FL2;
+        cs.IFL2 = FL2;
         cs.IEV2.Vsym = s;
         cs.IEV2.Voffset = 0;
 
@@ -255,7 +255,7 @@ extern (C++) struct CodeBuilder
     }
 
     @trusted
-    void genc1(opcode_t op, uint ea, uint FL1, targ_size_t EV1)
+    void genc1(opcode_t op, uint ea, FL FL1, targ_size_t EV1)
     {
         code cs;
         assert(FL1 < FLMAX);
@@ -263,14 +263,14 @@ extern (C++) struct CodeBuilder
         cs.Iflags = CFoff;
         cs.Iea = ea;
         ccheck(&cs);
-        cs.IFL1 = cast(ubyte)FL1;
+        cs.IFL1 = FL1;
         cs.IEV1.Vsize_t = EV1;
 
         gen(&cs);
     }
 
     @trusted
-    void genc(opcode_t op, uint ea, uint FL1, targ_size_t EV1, uint FL2, targ_size_t EV2)
+    void genc(opcode_t op, uint ea, FL FL1, targ_size_t EV1, FL FL2, targ_size_t EV2)
     {
         code cs;
         assert(FL1 < FLMAX);
@@ -278,10 +278,10 @@ extern (C++) struct CodeBuilder
         cs.Iea = ea;
         ccheck(&cs);
         cs.Iflags = CFoff;
-        cs.IFL1 = cast(ubyte)FL1;
+        cs.IFL1 = FL1;
         cs.IEV1.Vsize_t = EV1;
         assert(FL2 < FLMAX);
-        cs.IFL2 = cast(ubyte)FL2;
+        cs.IFL2 = FL2;
         cs.IEV2.Vsize_t = EV2;
 
         gen(&cs);
@@ -347,7 +347,7 @@ extern (C++) struct CodeBuilder
      * Generate code to deal with floatreg.
      */
     @trusted
-    void genfltreg(opcode_t opcode,uint reg,targ_size_t offset)
+    void genfltreg(opcode_t opcode,int reg,targ_size_t offset)
     {
         floatreg = true;
         reflocal = true;

--- a/compiler/src/dmd/common/outbuffer.d
+++ b/compiler/src/dmd/common/outbuffer.d
@@ -711,6 +711,12 @@ struct OutBuffer
         return cast(char*)data.ptr;
     }
 
+    // Peek at slice of data without taking ownership
+    extern (D) ubyte[] peekSlice() pure nothrow
+    {
+        return data[0 .. offset];
+    }
+
     // Append terminating null if necessary and take ownership of data
     extern (C++) char* extractChars() pure nothrow
     {

--- a/compiler/src/dmd/iasmdmd.d
+++ b/compiler/src/dmd/iasmdmd.d
@@ -3699,7 +3699,7 @@ code *asm_db_parse(OP *pop)
     cdb.ctor();
     if (driverParams.symdebug)
         cdb.genlinnum(Srcpos.create(asmstate.loc.filename, asmstate.loc.linnum, asmstate.loc.charnum));
-    cdb.genasm(bytes.peekChars(), cast(uint)bytes.length);
+    cdb.genasm(bytes.peekSlice());
     code *c = cdb.finish();
 
     asmstate.statement.regs |= /* mES| */ ALLREGS;


### PR DESCRIPTION
Use correct types to eliminate casts and use D arrays for safety.