### PR TITLE
Fix 21520 - dmd does not honor the NO_COLOR environment variable

### DIFF
--- a/compiler/src/dmd/console.d
+++ b/compiler/src/dmd/console.d
@@ -228,6 +228,19 @@ bool detectTerminal() nothrow
 }
 
 /**
+ * Tries to detect the preference for colorized console output
+ * based on the `NO_COLOR` environment variable: https://no-color.org/
+ *
+ * Returns: `true` if colorized console output is preferred
+*/
+bool detectColorPreference() nothrow @trusted
+{
+    import core.stdc.stdlib : getenv;
+    const noColor = getenv("NO_COLOR");
+	return noColor == null || noColor[0] == '\0';
+}
+
+/**
  * Creates an instance of Console connected to stream fp.
  * Params:
  *      fp = io stream

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -344,8 +344,8 @@ extern (C++) struct Global
             compileEnv.vendor = "Digital Mars D";
 
             // -color=auto is the default value
-            import dmd.console : detectTerminal;
-            params.color = detectTerminal();
+            import dmd.console : detectTerminal, detectColorPreference;
+            params.color = detectTerminal() && detectColorPreference();
         }
         else version (IN_GCC)
         {


### PR DESCRIPTION
I tested this manually. I tried adding it to `test/compilable/testcolor.sh`, but the problem is that in such a script, the default is already to have colors off, and setting `-color=on` supersedes `NO_COLOR`.