### PR TITLE
doc.d: use errorSink

### DIFF
--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -29,6 +29,7 @@ import dmd.dsymbolsem;
 import dmd.dtemplate;
 import dmd.expression;
 import dmd.errors;
+import dmd.errorsink;
 import dmd.func;
 import dmd.globals;
 import dmd.id;
@@ -96,6 +97,7 @@ extern (C++) struct Scope
     bool inLoop;                    /// true if inside a loop (where constructor calls aren't allowed)
     int intypeof;                   /// in typeof(exp)
     VarDeclaration lastVar;         /// Previous symbol used to prevent goto-skips-init
+    ErrorSink eSink;                /// sink for error messages
 
     /* If  minst && !tinst, it's in definitely non-speculative scope (eg. module member scope).
      * If !minst && !tinst, it's in definitely speculative scope (eg. template constraint).

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -68,6 +68,14 @@ class ErrorSinkCompiler : ErrorSink
         va_end(ap);
     }
 
+    void warningSupplemental(const ref Loc loc, const(char)* format, ...)
+    {
+        va_list ap;
+        va_start(ap, format);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.warning);
+        va_end(ap);
+    }
+
     void deprecation(const ref Loc loc, const(char)* format, ...)
     {
         va_list ap;

--- a/compiler/src/dmd/errorsink.d
+++ b/compiler/src/dmd/errorsink.d
@@ -27,6 +27,8 @@ abstract class ErrorSink
 
     void warning(const ref Loc loc, const(char)* format, ...);
 
+    void warningSupplemental(const ref Loc loc, const(char)* format, ...);
+
     void message(const ref Loc loc, const(char)* format, ...);
 
     void deprecation(const ref Loc loc, const(char)* format, ...);
@@ -48,6 +50,8 @@ class ErrorSinkNull : ErrorSink
     void errorSupplemental(const ref Loc loc, const(char)* format, ...) { }
 
     void warning(const ref Loc loc, const(char)* format, ...) { }
+
+    void warningSupplemental(const ref Loc loc, const(char)* format, ...) { }
 
     void message(const ref Loc loc, const(char)* format, ...) { }
 
@@ -103,6 +107,8 @@ class ErrorSinkStderr : ErrorSink
         fputc('\n', stderr);
         va_end(ap);
     }
+
+    void warningSupplemental(const ref Loc loc, const(char)* format, ...) { }
 
     void deprecation(const ref Loc loc, const(char)* format, ...)
     {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -239,6 +239,7 @@ struct ModuleDeclaration;
 template <typename Datum>
 struct FileMapping;
 struct Escape;
+class ErrorSink;
 class LabelStatement;
 class SwitchStatement;
 class Statement;
@@ -309,7 +310,6 @@ class ArrayInitializer;
 class ExpInitializer;
 class CInitializer;
 class FileManager;
-class ErrorSink;
 class ErrorStatement;
 class ExpStatement;
 class ConditionalStatement;
@@ -6495,7 +6495,7 @@ struct ModuleDeclaration final
 
 extern void getLocalClasses(Module* mod, Array<ClassDeclaration* >& aclasses);
 
-extern void gendocfile(Module* m);
+extern void gendocfile(Module* m, ErrorSink* eSink);
 
 struct Scope final
 {
@@ -6519,6 +6519,7 @@ struct Scope final
     bool inLoop;
     int32_t intypeof;
     VarDeclaration* lastVar;
+    ErrorSink* eSink;
     Module* minst;
     TemplateInstance* tinst;
     CtorFlow ctorflow;
@@ -6559,6 +6560,7 @@ struct Scope final
         inLoop(),
         intypeof(),
         lastVar(),
+        eSink(),
         minst(),
         tinst(),
         ctorflow(),
@@ -6578,7 +6580,7 @@ struct Scope final
         aliasAsg()
     {
     }
-    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* sw = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tf = nullptr, ScopeGuardStatement* os = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, bool nofree = false, bool inLoop = false, int32_t intypeof = 0, VarDeclaration* lastVar = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), int32_t explicitVisibility = 0, uint64_t stc = 0LLU, DeprecatedDeclaration* depdecl = nullptr, uint32_t flags = 0u, UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr) :
+    Scope(Scope* enclosing, Module* _module = nullptr, ScopeDsymbol* scopesym = nullptr, FuncDeclaration* func = nullptr, VarDeclaration* varDecl = nullptr, Dsymbol* parent = nullptr, LabelStatement* slabel = nullptr, SwitchStatement* sw = nullptr, Statement* tryBody = nullptr, TryFinallyStatement* tf = nullptr, ScopeGuardStatement* os = nullptr, Statement* sbreak = nullptr, Statement* scontinue = nullptr, ForeachStatement* fes = nullptr, Scope* callsc = nullptr, Dsymbol* inunion = nullptr, bool nofree = false, bool inLoop = false, int32_t intypeof = 0, VarDeclaration* lastVar = nullptr, ErrorSink* eSink = nullptr, Module* minst = nullptr, TemplateInstance* tinst = nullptr, CtorFlow ctorflow = CtorFlow(), AlignDeclaration* aligndecl = nullptr, CPPNamespaceDeclaration* namespace_ = nullptr, LINK linkage = (LINK)1u, CPPMANGLE cppmangle = (CPPMANGLE)0u, PragmaDeclaration* inlining = nullptr, Visibility visibility = Visibility((Visibility::Kind)5u, nullptr), int32_t explicitVisibility = 0, uint64_t stc = 0LLU, DeprecatedDeclaration* depdecl = nullptr, uint32_t flags = 0u, UserAttributeDeclaration* userAttribDecl = nullptr, DocComment* lastdc = nullptr, void* anchorCounts = nullptr, Identifier* prevAnchor = nullptr, AliasDeclaration* aliasAsg = nullptr) :
         enclosing(enclosing),
         _module(_module),
         scopesym(scopesym),
@@ -6599,6 +6601,7 @@ struct Scope final
         inLoop(inLoop),
         intypeof(intypeof),
         lastVar(lastVar),
+        eSink(eSink),
         minst(minst),
         tinst(tinst),
         ctorflow(ctorflow),

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -382,7 +382,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         if (m.filetype == FileType.ddoc)
         {
             anydocfiles = true;
-            gendocfile(m);
+            gendocfile(m, global.errorSink);
             // Remove m from list of modules
             modules.remove(modi);
             modi--;
@@ -540,7 +540,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     {
         foreach (m; modules)
         {
-            gendocfile(m);
+            gendocfile(m, global.errorSink);
         }
     }
     if (params.vcg_ast)

--- a/compiler/src/dmd/scope.h
+++ b/compiler/src/dmd/scope.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+class ErrorSink;
 class Identifier;
 class Module;
 class Statement;
@@ -85,6 +86,7 @@ struct Scope
     d_bool inLoop;                // true if inside a loop (where constructor calls aren't allowed)
     int intypeof;               // in typeof(exp)
     VarDeclaration *lastVar;    // Previous symbol used to prevent goto-skips-init
+    ErrorSink *eSink;           // sink for error messages
 
     /* If  minst && !tinst, it's in definitely non-speculative scope (eg. module member scope).
      * If !minst && !tinst, it's in definitely speculative scope (eg. template constraint).

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1423,7 +1423,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
          */
         AggregateDeclaration ad = ctor.isMemberDecl();
         if (!ctor.fbody || !ad || !ad.fieldDtor ||
-	    global.params.dtorFields == FeatureState.disabled || !global.params.useExceptions || ctor.type.toTypeFunction.isnothrow)
+            global.params.dtorFields == FeatureState.disabled || !global.params.useExceptions || ctor.type.toTypeFunction.isnothrow)
             return visit(cast(FuncDeclaration)ctor);
 
         /* Generate:


### PR DESCRIPTION
To make dmd an LSP, messages to stderr will have to be abstracted away. This does it for doc.d.

This required adding `warningSupplemental`.