### PR TITLE
obj_includelib parameter to slice

### DIFF
--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -1426,7 +1426,7 @@ void ElfObj_startaddress(Symbol *s)
  * Output library name.
  */
 
-bool ElfObj_includelib(const(char)* name)
+bool ElfObj_includelib(scope const char[] name)
 {
     //dbg_printf("ElfObj_includelib(name *%s)\n",name);
     return false;

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -1540,9 +1540,9 @@ void MachObj_startaddress(Symbol *s)
  * Output library name.
  */
 
-bool MachObj_includelib(const(char)* name)
+bool MachObj_includelib(scope const char[] name)
 {
-    //dbg_printf("MachObj_includelib(name *%s)\n",name);
+    //dbg_printf("MachObj_includelibx(name *%s)\n",name);
     return false;
 }
 

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -977,12 +977,13 @@ void MsCoffObj_startaddress(Symbol *s)
  */
 
 @trusted
-bool MsCoffObj_includelib(const(char)* name)
+extern (D)
+bool MsCoffObj_includelib(scope const char[] name)
 {
     int seg = MsCoffObj_seg_drectve();
     //dbg_printf("MsCoffObj_includelib(name *%s)\n",name);
     SegData[seg].SDbuf.write(" /DEFAULTLIB:\"".ptr, 14);
-    SegData[seg].SDbuf.write(name, cast(uint)strlen(name));
+    SegData[seg].SDbuf.write(name.ptr, cast(uint)name.length);
     SegData[seg].SDbuf.writeByte('"');
     return true;
 }

--- a/compiler/src/dmd/backend/obj.d
+++ b/compiler/src/dmd/backend/obj.d
@@ -118,7 +118,7 @@ else
             mixin(genRetVal("startaddress(s)"));
         }
 
-        bool includelib(const(char)* name)
+        bool includelib(scope const(char)[] name)
         {
             mixin(genRetVal("includelib(name)"));
         }

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -402,14 +402,9 @@ private void obj_end(ref OutBuffer objbuf, Library library, const(char)* objfile
     }
 }
 
-bool obj_includelib(const(char)* name) nothrow
+extern (D) bool obj_includelib(scope const char[] name) nothrow
 {
     return objmod.includelib(name);
-}
-
-extern(D) bool obj_includelib(const(char)[] name) nothrow
-{
-    return name.toCStringThen!(n => obj_includelib(n.ptr));
 }
 
 void obj_startaddress(Symbol *s)

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -776,7 +776,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                  * The linker will then automatically
                  * search that library, too.
                  */
-                if (!obj_includelib(name))
+                if (!obj_includelib(name[0 .. strlen(name)]))
                 {
                     /* The format does not allow embedded library names,
                      * so instead append the library name to the list to be passed


### PR DESCRIPTION
I'd like to move the compiler code to all D strings instead of C strings. The code cannot be marked @safe with C strings.