### PR TITLE
Fix Issue 24061 - constructor with assert(0) failed to compile

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -705,7 +705,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     }
                     sc2.ctorflow.freeFieldinit();
 
-                    if (cd && !(sc2.ctorflow.callSuper & CSX.any_ctor) && cd.baseClass && cd.baseClass.ctor)
+                    if (cd && !(sc2.ctorflow.callSuper & (CSX.any_ctor | CSX.halt)) && cd.baseClass && cd.baseClass.ctor)
                     {
                         sc2.ctorflow.callSuper = CSX.none;
 

--- a/compiler/test/compilable/test24061.d
+++ b/compiler/test/compilable/test24061.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=24061
+
+class Exception2
+{
+    this(string, int) {}
+}
+
+class E : Exception2
+{
+    this(int i)
+    {
+        scope (success) assert(0, "assume nothrow");
+        super("hehe", 2);
+    }
+}


### PR DESCRIPTION
If a constructor contains a halt expression, it really doesn't matter if the base class constructor was called or not.