### PR TITLE
[core/memory] Make GC enable, disable, collect, minimize `@safe`

### DIFF
--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -270,7 +270,7 @@ extern(C):
      * reentrant, and must be called once for every call to disable before
      * automatic collections are enabled.
      */
-    pragma(mangle, "gc_enable") static void enable() nothrow pure;
+    pragma(mangle, "gc_enable") static void enable() @safe nothrow pure;
 
 
     /**
@@ -280,7 +280,7 @@ extern(C):
      * such as during an out of memory condition.  This function is reentrant,
      * but enable must be called once for each call to disable.
      */
-    pragma(mangle, "gc_disable") static void disable() nothrow pure;
+    pragma(mangle, "gc_disable") static void disable() @safe nothrow pure;
 
 
     /**
@@ -290,14 +290,14 @@ extern(C):
      * and then to reclaim free space.  This action may need to suspend all
      * running threads for at least part of the collection process.
      */
-    pragma(mangle, "gc_collect") static void collect() nothrow pure;
+    pragma(mangle, "gc_collect") static void collect() @safe nothrow pure;
 
     /**
      * Indicates that the managed memory space be minimized by returning free
      * physical memory to the operating system.  The amount of free memory
      * returned depends on the allocator design and on program behavior.
      */
-    pragma(mangle, "gc_minimize") static void minimize() nothrow pure;
+    pragma(mangle, "gc_minimize") static void minimize() @safe nothrow pure;
 
 extern(D):
 


### PR DESCRIPTION
AFAICT these functions should be memory-safe:
https://forum.dlang.org/post/uadlkn$2m05$1@digitalmars.com

I'm following the change that added `pure` for these functions (and some others):
https://github.com/dlang/druntime/pull/3561