### PR TITLE
dtoh: Always refer to default arguments using their FQN.

### DIFF
--- a/changelog/dmd.dtoh-improvements.dd
+++ b/changelog/dmd.dtoh-improvements.dd
@@ -1,0 +1,10 @@
+Improvements for the C++ header generation
+
+The following features/bugfixes/improvements were implemented for the
+experimental C++ header generator:
+
+- Static variables used in a default argument context are now emitted using
+  their fully qualified name.
+
+Note: The header generator is still considered experimental, so please submit
+      any bugs encountered to [the bug tracker](https://issues.dlang.org).

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -2327,7 +2327,12 @@ public:
         {
             //printf("%s %d\n", p.defaultArg.toChars, p.defaultArg.op);
             buf.writestring(" = ");
+            // Always emit the FDN of a symbol for the default argument,
+            // to avoid generating an ambiguous assignment.
+            auto save = adparent;
+            adparent = null;
             printExpressionFor(p.type, p.defaultArg);
+            adparent = save;
         }
     }
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -391,7 +391,7 @@ public:
     uint32_t linnum(uint32_t num);
     const char* filename() const;
     void filename(const char* name);
-    const char* toChars(bool showColumns = showColumns, MessageStyle messageStyle = messageStyle) const;
+    const char* toChars(bool showColumns = Loc::showColumns, MessageStyle messageStyle = Loc::messageStyle) const;
     bool equals(const Loc& loc) const;
     Loc() :
         _linnum(),

--- a/compiler/test/compilable/dtoh_StructDeclaration.d
+++ b/compiler/test/compilable/dtoh_StructDeclaration.d
@@ -224,6 +224,15 @@ struct Params final
         ddocfiles(ddocfiles)
         {}
 };
+
+struct Loc final
+{
+    static int32_t showColumns;
+    void toChars(int32_t showColumns = Loc::showColumns);
+    Loc()
+    {
+    }
+};
 ---
 */
 
@@ -336,4 +345,10 @@ extern (C++) struct Params
 {
     bool obj = true;
     Array ddocfiles;
+}
+
+extern (C++) struct Loc
+{
+    __gshared int showColumns;
+    void toChars(int showColumns = Loc.showColumns) {}
 }

--- a/compiler/test/compilable/dtoh_functions.d
+++ b/compiler/test/compilable/dtoh_functions.d
@@ -45,10 +45,10 @@ struct S final
     int32_t get(int32_t , int32_t );
     static int32_t get();
     static const int32_t staticVar;
-    void useVars(int32_t pi = i, int32_t psv = staticVar);
+    void useVars(int32_t pi = i, int32_t psv = S::staticVar);
     struct Nested final
     {
-        void useStaticVar(int32_t i = staticVar);
+        void useStaticVar(int32_t i = S::staticVar);
         Nested()
         {
         }


### PR DESCRIPTION
Static variables used in a default argument context are now emitted using their fully qualified name. This is to avoid generating ambiguous assignments, for instance:
```
struct S
{
    __gshared int param;
    void example(int param = S.param);
}
```
In the above example, the visitor for dtoh VarExp will omit the `S` parent, as the static field is nested in `S`.
```
    void example(int param = param);
```
Although D understands that `param` refers to the static field, this is not the case in C++, and the compilation will fail with:
```
error: parameter 'param' may not appear in this context
```