### PR TITLE
move DDOCFILE from doc.d to main.d

### DIFF
--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -371,26 +371,28 @@ private immutable ddoc_decl_dd_s = "$(DDOC_DECL_DD ";
 private immutable ddoc_decl_dd_e = ")\n";
 
 /****************************************************
+ * Generate Ddoc file for Module m.
+ * Params:
+ *      m = Module
+ *      ddocfiles = array of .ddoc files to read for macro definitions
+ *	datetime = string returned by ctime()
+ *      eSink = send error messages to eSink
  */
-extern(C++) void gendocfile(Module m, const(char)* datetime, ErrorSink eSink)
+extern(C++) void gendocfile(Module m, const ref Array!(const(char)*) ddocfiles, const(char)* datetime, ErrorSink eSink)
 {
     __gshared OutBuffer mbuf;
     __gshared int mbuf_done;
     OutBuffer buf;
     //printf("Module::gendocfile()\n");
-    if (!mbuf_done) // if not already read the ddoc files
+    if (!mbuf_done) // if not already read the ddocfiles
     {
         mbuf_done = 1;
         // Use our internal default
         mbuf.writestring(ddoc_default);
-        // Override with DDOCFILE specified in the sc.ini file
-        char* p = getenv("DDOCFILE");
-        if (p)
-            global.params.ddoc.files.shift(p);
-        // Override with the ddoc macro files from the command line
-        for (size_t i = 0; i < global.params.ddoc.files.length; i++)
+        // Override with the ddoc macro files from the environemnt and command line
+        foreach (file; ddocfiles)
         {
-            auto buffer = readFile(m.loc, global.params.ddoc.files[i].toDString());
+            auto buffer = readFile(m.loc, file.toDString());
             // BUG: convert file contents to UTF-8 before use
             const data = buffer.data;
             //printf("file: '%.*s'\n", cast(int)data.length, data.ptr);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6500,7 +6500,7 @@ struct ModuleDeclaration final
 
 extern void getLocalClasses(Module* mod, Array<ClassDeclaration* >& aclasses);
 
-extern void gendocfile(Module* m, const char* datetime, ErrorSink* eSink);
+extern void gendocfile(Module* m, const Array<const char* >& ddocfiles, const char* datetime, ErrorSink* eSink);
 
 struct Scope final
 {

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -388,7 +388,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         if (m.filetype == FileType.ddoc)
         {
             anydocfiles = true;
-            gendocfile(m, global.datetime.ptr, global.errorSink);
+            gendocfile(m, global.params.ddoc.files, global.datetime.ptr, global.errorSink);
             // Remove m from list of modules
             modules.remove(modi);
             modi--;
@@ -549,7 +549,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     {
         foreach (m; modules)
         {
-            gendocfile(m, global.datetime.ptr, global.errorSink);
+            gendocfile(m, global.params.ddoc.files, global.datetime.ptr, global.errorSink);
         }
     }
     if (params.vcg_ast)
@@ -642,7 +642,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
  * Params:
  *   argc = Number of arguments passed via command line
  *   argv = Array of string arguments passed via command line
- *   params = parametes from argv
+ *   params = parameters from argv
  *   files = files from argv
  * Returns: true on faiure
  */
@@ -668,7 +668,6 @@ bool parseCommandlineAndConfig(size_t argc, const(char)** argv, ref Param params
     if (const(char)* missingFile = responseExpand(arguments)) // expand response files
         error(Loc.initial, "cannot open response file '%s'", missingFile);
     //for (size_t i = 0; i < arguments.length; ++i) printf("arguments[%d] = '%s'\n", i, arguments[i]);
-    files.reserve(arguments.length - 1);
     // Set default values
     params.argv0 = arguments[0].toDString;
 
@@ -739,6 +738,10 @@ bool parseCommandlineAndConfig(size_t argc, const(char)** argv, ref Param params
         errorSupplemental(loc, "run `dmd -man` to open browser on manual");
         return true;
     }
+
+    // DDOCFILE specified in the sc.ini file comes first and gets overridden by user specified files
+    if (char* p = getenv("DDOCFILE"))
+        global.params.ddoc.files.shift(p);
 
     if (target.isX86_64 != isX86_64)
         error(Loc.initial, "the architecture must not be changed in the %s section of %.*s",

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -592,6 +592,9 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             printf("arguments[%d] = '%s'\n", i, arguments[i]);
         }
     }
+
+    files.reserve(arguments.length - 1);
+
     for (size_t i = 1; i < arguments.length; i++)
     {
         const(char)* p = arguments[i];


### PR DESCRIPTION
The doc.d code should not be fiddling with the environment. That should all get set up beforehand.

This also picked up some tabs.

Some of the parameters should be `out` to clarify where they get initialized.

Note that this may require some adjustment to gdc and ldc, but it will be for the best. @kinke @ibuclaw 

@RazvanN7 this may affect dmd as library, but I kinda doubt it as the environment from where DDOCFILE was drawn was also set in main.d. This PR should make the behavior consistent.