### PR TITLE
bubble errors up from writeFile()

### DIFF
--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -34,6 +34,7 @@ import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.dtemplate;
+import dmd.errors : fatal;
 import dmd.errorsink;
 import dmd.func;
 import dmd.globals;
@@ -494,7 +495,8 @@ extern(C++) void gendocfile(Module m, ErrorSink eSink)
                 buf.writeByte(c);
             }
         }
-        writeFile(m.loc, m.docfile.toString(), buf[]);
+        if (!writeFile(m.loc, m.docfile.toString(), buf[]))
+            return fatal();
     }
     else
     {
@@ -515,7 +517,8 @@ extern(C++) void gendocfile(Module m, ErrorSink eSink)
             }
             buf2.setsize(i);
         }
-        writeFile(m.loc, m.docfile.toString(), buf2[]);
+        if (!writeFile(m.loc, m.docfile.toString(), buf2[]))
+            return fatal();
     }
 }
 

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -199,7 +199,8 @@ struct _d_dynamicArray final
     else
     {
         const(char)[] name = FileName.combine(global.params.cxxhdr.dir, global.params.cxxhdr.name);
-        writeFile(Loc.initial, name, buf[]);
+        if (!writeFile(Loc.initial, name, buf[]))
+            return fatal();
     }
 }
 

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -394,7 +394,8 @@ private void obj_end(ref OutBuffer objbuf, Library library, const(char)* objfile
     else
     {
         //printf("write obj %s\n", objfilename);
-        writeFile(Loc.initial, objfilename.toDString, objbuf[]);
+        if (!writeFile(Loc.initial, objfilename.toDString, objbuf[]))
+            return fatal();
 
         // For non-libraries, the object buffer should be cleared to
         // avoid repetitions.

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -33,6 +33,7 @@ import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.dtemplate;
 import dmd.dversion;
+import dmd.errors : fatal;
 import dmd.expression;
 import dmd.func;
 import dmd.globals;
@@ -82,7 +83,8 @@ extern (C++) void genhdrfile(Module m)
     HdrGenState hgs;
     hgs.hdrgen = true;
     toCBuffer(m, &buf, &hgs);
-    writeFile(m.loc, m.hdrfile.toString(), buf[]);
+    if (!writeFile(m.loc, m.hdrfile.toString(), buf[]))
+        fatal();
 }
 
 /**

--- a/compiler/src/dmd/lib.d
+++ b/compiler/src/dmd/lib.d
@@ -91,7 +91,8 @@ class Library
             message("library   %s", loc.filename);
 
         auto filenameString = loc.filename.toDString;
-        ensurePathToNameExists(Loc.initial, filenameString);
+        if (!ensurePathToNameExists(Loc.initial, filenameString))
+            return;
         auto tmpname = filenameString ~ ".tmp\0";
         scope(exit) destroy(tmpname);
 

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -268,7 +268,8 @@ public int runLINK()
                 setExeFile();
             }
             // Make sure path to exe file exists
-            ensurePathToNameExists(Loc.initial, global.params.exefile);
+            if (!ensurePathToNameExists(Loc.initial, global.params.exefile))
+                fatal();
             cmdbuf.writeByte(' ');
             if (global.params.mapfile)
             {
@@ -344,7 +345,8 @@ public int runLINK()
             if (p.length > 7000)
             {
                 lnkfilename = FileName.forceExt(global.params.exefile, "lnk");
-                writeFile(Loc.initial, lnkfilename, p);
+                if (!writeFile(Loc.initial, lnkfilename, p))
+                    fatal();
                 if (lnkfilename.length < p.length)
                 {
                     p[0] = '@';
@@ -390,7 +392,8 @@ public int runLINK()
                 setExeFile();
             }
             // Make sure path to exe file exists
-            ensurePathToNameExists(Loc.initial, global.params.exefile);
+            if (!ensurePathToNameExists(Loc.initial, global.params.exefile))
+                fatal();
             cmdbuf.writeByte(',');
             if (global.params.mapfile)
                 writeFilename(&cmdbuf, global.params.mapfile);
@@ -455,7 +458,8 @@ public int runLINK()
             if (p.length > 7000)
             {
                 lnkfilename = FileName.forceExt(global.params.exefile, "lnk");
-                writeFile(Loc.initial, lnkfilename, p);
+                if (!writeFile(Loc.initial, lnkfilename, p))
+                    fatal();
                 if (lnkfilename.length < p.length)
                 {
                     p[0] = '@';
@@ -575,7 +579,8 @@ public int runLINK()
             global.params.exefile = ex;
         }
         // Make sure path to exe file exists
-        ensurePathToNameExists(Loc.initial, global.params.exefile);
+        if (!ensurePathToNameExists(Loc.initial, global.params.exefile))
+            fatal();
         if (driverParams.symdebug)
             argv.push("-g");
         if (target.isX86_64)

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -529,7 +529,10 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
 
         const data = (*ob)[];
         if (params.moduleDeps.name)
-            writeFile(Loc.initial, params.moduleDeps.name, data);
+        {
+            if (!writeFile(Loc.initial, params.moduleDeps.name, data))
+                fatal();
+        }
         else
             printf("%.*s", cast(int)data.length, data.ptr);
     }
@@ -795,7 +798,10 @@ void emitMakeDeps(ref Param params)
 
     const data = buf[];
     if (params.makeDeps.name)
-        writeFile(Loc.initial, params.makeDeps.name, data);
+    {
+        if (!writeFile(Loc.initial, params.makeDeps.name, data))
+            fatal();
+    }
     else
         printf("%.*s", cast(int) data.length, data.ptr);
 }

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -153,7 +153,8 @@ extern (C++) void generateJson(Modules* modules)
             //    name = FileName::combine(dir, name);
             jsonfilename = FileName.forceExt(n, json_ext);
         }
-        writeFile(Loc.initial, jsonfilename, buf[]);
+        if (!writeFile(Loc.initial, jsonfilename, buf[]))
+            fatal();
     }
 }
 

--- a/compiler/src/dmd/utils.d
+++ b/compiler/src/dmd/utils.d
@@ -78,15 +78,19 @@ Buffer readFile(Loc loc, const(char)[] filename)
  *   loc = The line number information from where the call originates
  *   filename = Path to file
  *   data = Full content of the file to be written
+ * Returns:
+ *   false on error
  */
-extern (D) void writeFile(Loc loc, const(char)[] filename, const void[] data)
+extern (D) bool writeFile(Loc loc, const(char)[] filename, const void[] data)
 {
-    ensurePathToNameExists(Loc.initial, filename);
+    if (!ensurePathToNameExists(Loc.initial, filename))
+        return false;
     if (!File.update(filename, data))
     {
         error(loc, "error writing file '%.*s'", cast(int) filename.length, filename.ptr);
-        fatal();
+        return false;
     }
+    return true;
 }
 
 
@@ -97,8 +101,10 @@ extern (D) void writeFile(Loc loc, const(char)[] filename, const void[] data)
  * Params:
  *   loc = The line number information from where the call originates
  *   name = a path to check (the name is stripped)
+ * Returns:
+ *      false on error
  */
-void ensurePathToNameExists(Loc loc, const(char)[] name)
+bool ensurePathToNameExists(Loc loc, const(char)[] name)
 {
     const char[] pt = FileName.path(name);
     if (pt.length)
@@ -106,10 +112,12 @@ void ensurePathToNameExists(Loc loc, const(char)[] name)
         if (!FileName.ensurePathExists(pt))
         {
             error(loc, "cannot create directory %*.s", cast(int) pt.length, pt.ptr);
-            fatal();
+            FileName.free(pt.ptr);
+            return false;
         }
     }
     FileName.free(pt.ptr);
+    return true;
 }
 
 


### PR DESCRIPTION
Leaf functions should not abort on error, they should bubble up the failure to let the caller decide what to do about it. This is essential for packaging DMD as a library or as an LSP.