### PR TITLE
Discriminate between different kinds of warnings

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -170,7 +170,7 @@ struct ASTBase
                 va_list ap;
                 va_start(ap, format);
                 // last parameter : toPrettyChars
-                verrorReport(loc, format, ap, ErrorKind.error, kind(), "");
+                verrorReport(loc, format, ap, ErrorKind.error, 0, kind(), "");
                 va_end(ap);
             }
         else
@@ -179,7 +179,7 @@ struct ASTBase
                 va_list ap;
                 va_start(ap, format);
                 // last parameter : toPrettyChars
-                verrorReport(loc, format, ap, ErrorKind.error, kind(), "");
+                verrorReport(loc, format, ap, ErrorKind.error, 0, kind(), "");
                 va_end(ap);
             }
 

--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -152,9 +152,10 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
 
                     if (!(result & BE.fallthru) && !s.comeFrom())
                     {
+                        import dmd.errorsink : DiagnosticFlag;
                         if (blockExit(s, func, mustNotThrow) != BE.halt && s.hasCode() &&
                             s.loc != Loc.initial) // don't emit warning for generated code
-                            s.warning("statement is not reachable");
+                            s.warning(DiagnosticFlag.unreachable, "statement is not reachable");
                     }
                     else
                     {
@@ -452,7 +453,8 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                 // destructor call, exit of synchronized statement, etc.
                 if (result == BE.halt && finalresult != BE.halt && s.finalbody && s.finalbody.hasCode())
                 {
-                    s.finalbody.warning("statement is not reachable");
+                    import dmd.errorsink : DiagnosticFlag;
+                    s.finalbody.warning(DiagnosticFlag.unreachable, "statement is not reachable");
                 }
             }
 

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5590,9 +5590,9 @@ final class CParser(AST) : Parser!AST
         if (n.value == TOK.identifier && n.ident == Id.show)
         {
             if (packalign.isDefault())
-                eSink.warning(startloc, "current pack attribute is default");
+                eSink.warning(DiagnosticFlag.pragma_, startloc, "current pack attribute is default");
             else
-                eSink.warning(startloc, "current pack attribute is %d", packalign.get());
+                eSink.warning(DiagnosticFlag.pragma_, startloc, "current pack attribute is %d", packalign.get());
             scan(&n);
             return closingParen();
         }

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -252,7 +252,7 @@ private final class ParamSection : Section
                             }
                             else if (!fparam)
                             {
-                                sc.eSink.warning(s.loc, "Ddoc: function declaration has no parameter '%.*s'", cast(int)namelen, namestart);
+                                sc.eSink.warning(DiagnosticFlag.ddoc, s.loc, "Ddoc: function declaration has no parameter '%.*s'", cast(int)namelen, namestart);
                             }
                             buf.write(namestart[0 .. namelen]);
                         }
@@ -303,12 +303,12 @@ private final class ParamSection : Section
                             cast(int)(tf.parameterList.varargs == VarArg.variadic);
             if (pcount != paramcount)
             {
-                sc.eSink.warning(s.loc, "Ddoc: parameter count mismatch, expected %llu, got %llu",
+                sc.eSink.warning(DiagnosticFlag.ddoc, s.loc, "Ddoc: parameter count mismatch, expected %llu, got %llu",
                         cast(ulong) pcount, cast(ulong) paramcount);
                 if (paramcount == 0)
                 {
                     // Chances are someone messed up the format
-                    sc.eSink.warningSupplemental(s.loc, "Note that the format is `param = description`");
+                    sc.eSink.warningSupplemental(DiagnosticFlag.ddoc, s.loc, "Note that the format is `param = description`");
                 }
             }
         }
@@ -589,7 +589,7 @@ private void escapeStrayParenthesis(Loc loc, OutBuffer* buf, size_t start, bool 
                 if (par_open == 0)
                 {
                     //stray ')'
-                    eSink.warning(loc, "Ddoc: Stray ')'. This may cause incorrect Ddoc output. Use $(RPAREN) instead for unpaired right parentheses.");
+                    eSink.warning(DiagnosticFlag.ddoc, loc, "Ddoc: Stray ')'. This may cause incorrect Ddoc output. Use $(RPAREN) instead for unpaired right parentheses.");
                     buf.remove(u, 1); //remove the )
                     buf.insert(u, "$(RPAREN)"); //insert this instead
                     u += 8; //skip over newly inserted macro
@@ -667,7 +667,7 @@ private void escapeStrayParenthesis(Loc loc, OutBuffer* buf, size_t start, bool 
                 if (par_open == 0)
                 {
                     //stray '('
-                    eSink.warning(loc, "Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.");
+                    eSink.warning(DiagnosticFlag.ddoc, loc, "Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.");
                     buf.remove(u, 1); //remove the (
                     buf.insert(u, "$(LPAREN)"); //insert this instead
                 }

--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -482,7 +482,7 @@ extern (C++) struct Scope
                         ident == Id.length && sc.scopesym.isArrayScopeSymbol() &&
                         sc.enclosing && sc.enclosing.search(loc, ident, null, flags))
                     {
-                        warning(s.loc, "array `length` hides other `length` name in outer scope");
+                        warning(DiagnosticFlag.shadow, s.loc, "array `length` hides other `length` name in outer scope");
                     }
                     //printMsg("\tfound local", s);
                     if (pscopesym)

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -381,7 +381,7 @@ extern (C++) class Dsymbol : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .verrorReport(loc, format, ap, ErrorKind.error, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.error, 0, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -390,7 +390,7 @@ extern (C++) class Dsymbol : ASTNode
             va_list ap;
             va_start(ap, format);
             const loc = getLoc();
-            .verrorReport(loc, format, ap, ErrorKind.error, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.error, 0, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -398,7 +398,7 @@ extern (C++) class Dsymbol : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .verrorReport(loc, format, ap, ErrorKind.deprecation, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.deprecation, 0, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -407,7 +407,7 @@ extern (C++) class Dsymbol : ASTNode
             va_list ap;
             va_start(ap, format);
             const loc = getLoc();
-            .verrorReport(loc, format, ap, ErrorKind.deprecation, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.deprecation, 0, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
     }
@@ -417,7 +417,7 @@ extern (C++) class Dsymbol : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .verrorReport(loc, format, ap, ErrorKind.error, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.error, 0, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -426,7 +426,7 @@ extern (C++) class Dsymbol : ASTNode
             va_list ap;
             va_start(ap, format);
             const loc = getLoc();
-            .verrorReport(loc, format, ap, ErrorKind.error, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.error, 0, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -434,7 +434,7 @@ extern (C++) class Dsymbol : ASTNode
         {
             va_list ap;
             va_start(ap, format);
-            .verrorReport(loc, format, ap, ErrorKind.deprecation, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.deprecation, 0, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
 
@@ -443,7 +443,7 @@ extern (C++) class Dsymbol : ASTNode
             va_list ap;
             va_start(ap, format);
             const loc = getLoc();
-            .verrorReport(loc, format, ap, ErrorKind.deprecation, kind(), prettyFormatHelper().ptr);
+            .verrorReport(loc, format, ap, ErrorKind.deprecation, 0, kind(), prettyFormatHelper().ptr);
             va_end(ap);
         }
     }

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1125,7 +1125,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                                     if (sc.setUnsafeDIP1000(false, dsym.loc, "`scope` allocation of `%s` requires that constructor be annotated with `scope`", dsym))
                                         errorSupplemental(ne.member.loc, "is the location of the constructor");
                                     else if (global.params.obsolete && inSafeFunc)
-                                        warningSupplemental(ne.member.loc, "is the location of the constructor");
+                                        warningSupplemental(DiagnosticFlag.obsolete, ne.member.loc, "is the location of the constructor");
                                 }
                                 ne.onstack = 1;
                                 dsym.onstack = true;
@@ -3833,7 +3833,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                              * an interface function?
                              */
                             //if (!isOverride())
-                            //    warning(loc, "overrides base class function %s, but is not marked with 'override'", fdv.toPrettyChars());
+                            //    warning(DiagnosticFlag.override_, loc, "overrides base class function %s, but is not marked with 'override'", fdv.toPrettyChars());
 
                             if (fdv.tintro)
                                 ti = fdv.tintro;

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -6058,11 +6058,9 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             {
                 case Classification.error:
                     return &errorSupplemental;
-                case Classification.warning:
-                    return &warningSupplemental;
                 case Classification.deprecation:
                     return &deprecationSupplemental;
-                case Classification.gagged, Classification.tip:
+                case Classification.gagged, Classification.tip, Classification.warning:
                     assert(0);
             }
         }();

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -479,11 +479,11 @@ public:
             }
 
             __gshared bool warned = false;
-            warning(loc, "%s `%s` is a %s", kind, ident.toChars(), reason);
+            warning(DiagnosticFlag.cxxcompat, loc, "%s `%s` is a %s", kind, ident.toChars(), reason);
 
             if (!warned)
             {
-                warningSupplemental(loc, "The generated C++ header will contain " ~
+                warningSupplemental(DiagnosticFlag.cxxcompat, loc, "The generated C++ header will contain " ~
                                     "identifiers that are keywords in C++");
                 warned = true;
             }

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -23,6 +23,8 @@ import dmd.root.rmem;
 import dmd.root.string;
 import dmd.console;
 
+public import dmd.errorsink : DiagnosticFlag;
+
 nothrow:
 
 /// Constants used to discriminate kinds of error messages.
@@ -60,19 +62,19 @@ class ErrorSinkCompiler : ErrorSink
         va_end(ap);
     }
 
-    void warning(const ref Loc loc, const(char)* format, ...)
+    void warning(uint flag, const ref Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
-        verrorReport(loc, format, ap, ErrorKind.warning);
+        verrorReport(loc, format, ap, ErrorKind.warning, flag);
         va_end(ap);
     }
 
-    void warningSupplemental(const ref Loc loc, const(char)* format, ...)
+    void warningSupplemental(uint flag, const ref Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
-        verrorReportSupplemental(loc, format, ap, ErrorKind.warning);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.warning, flag);
         va_end(ap);
     }
 
@@ -232,24 +234,25 @@ else
 /**
  * Print a warning message, increasing the global warning count.
  * Params:
+ *      flag   = which flag directly controls this warning
  *      loc    = location of warning
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
 static if (__VERSION__ < 2092)
-    extern (C++) void warning(const ref Loc loc, const(char)* format, ...)
+    extern (C++) void warning(uint flag, const ref Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
-        verrorReport(loc, format, ap, ErrorKind.warning);
+        verrorReport(loc, format, ap, ErrorKind.warning, flag);
         va_end(ap);
     }
 else
-    pragma(printf) extern (C++) void warning(const ref Loc loc, const(char)* format, ...)
+    pragma(printf) extern (C++) void warning(uint flag, const ref Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
-        verrorReport(loc, format, ap, ErrorKind.warning);
+        verrorReport(loc, format, ap, ErrorKind.warning, flag);
         va_end(ap);
     }
 
@@ -257,24 +260,25 @@ else
  * Print additional details about a warning message.
  * Doesn't increase the warning count or print an additional warning prefix.
  * Params:
+ *      flag   = which flag directly controls this warning
  *      loc    = location of warning
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
 static if (__VERSION__ < 2092)
-    extern (C++) void warningSupplemental(const ref Loc loc, const(char)* format, ...)
+    extern (C++) void warningSupplemental(uint flag, const ref Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
-        verrorReportSupplemental(loc, format, ap, ErrorKind.warning);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.warning, flag);
         va_end(ap);
     }
 else
-    pragma(printf) extern (C++) void warningSupplemental(const ref Loc loc, const(char)* format, ...)
+    pragma(printf) extern (C++) void warningSupplemental(uint flag, const ref Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
-        verrorReportSupplemental(loc, format, ap, ErrorKind.warning);
+        verrorReportSupplemental(loc, format, ap, ErrorKind.warning, flag);
         va_end(ap);
     }
 
@@ -443,10 +447,11 @@ private struct ErrorInfo
  *      format      = printf-style format specification
  *      ap          = printf-style variadic arguments
  *      kind        = kind of error being printed
+ *      flag        = which flag directly controls this error (default is none)
  *      p1          = additional message prefix
  *      p2          = additional message prefix
  */
-extern (C++) void verrorReport(const ref Loc loc, const(char)* format, va_list ap, ErrorKind kind, const(char)* p1 = null, const(char)* p2 = null)
+extern (C++) void verrorReport(const ref Loc loc, const(char)* format, va_list ap, ErrorKind kind, uint flag = 0, const(char)* p1 = null, const(char)* p2 = null)
 {
     auto info = ErrorInfo(loc, kind, p1, p2);
     final switch (info.kind)
@@ -539,8 +544,9 @@ extern (C++) void verrorReport(const ref Loc loc, const(char)* format, va_list a
  *      format      = printf-style format specification
  *      ap          = printf-style variadic arguments
  *      kind        = kind of error being printed
+ *      flag        = which flag directly controls this error (default is none)
  */
-extern (C++) void verrorReportSupplemental(const ref Loc loc, const(char)* format, va_list ap, ErrorKind kind)
+extern (C++) void verrorReportSupplemental(const ref Loc loc, const(char)* format, va_list ap, ErrorKind kind, uint flag = 0)
 {
     auto info = ErrorInfo(loc, kind);
     info.supplemental = true;

--- a/compiler/src/dmd/errors.h
+++ b/compiler/src/dmd/errors.h
@@ -14,6 +14,7 @@
 
 struct Loc;
 
+// Constants used to discriminate kinds of error messages.
 enum class ErrorKind
 {
     warning = 0,
@@ -21,6 +22,23 @@ enum class ErrorKind
     error = 2,
     tip = 3,
     message = 4,
+};
+
+// Constants used to map compiler warnings to a specific flag.
+enum class DiagnosticFlag
+{
+    none = 0,
+    cxxcompat = 1,
+    conversion = 2,
+    dangling_else = 3,
+    ddoc = 4,
+    discarded = 5,
+    foreach_reverse_aa = 6,
+    inline_ = 7,
+    obsolete = 8,
+    pragma_ = 9,
+    shadow = 10,
+    unreachable = 11,
 };
 
 bool isConsoleColorSupported();
@@ -32,8 +50,8 @@ bool isConsoleColorSupported();
 #endif
 
 // Print a warning, deprecation, or error, accepts printf-like format specifiers.
-D_ATTRIBUTE_FORMAT(2, 3) void warning(const Loc& loc, const char *format, ...);
-D_ATTRIBUTE_FORMAT(2, 3) void warningSupplemental(const Loc& loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(3, 4) void warning(unsigned flag, const Loc& loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(3, 4) void warningSupplemental(unsigned flag, const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void deprecation(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void deprecationSupplemental(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void error(const Loc& loc, const char *format, ...);
@@ -43,8 +61,8 @@ D_ATTRIBUTE_FORMAT(1, 2) void message(const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void message(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(1, 2) void tip(const char *format, ...);
 
-D_ATTRIBUTE_FORMAT(2, 0) void verrorReport(const Loc& loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
-D_ATTRIBUTE_FORMAT(2, 0) void verrorReportSupplemental(const Loc& loc, const char* format, va_list ap, ErrorKind kind);
+D_ATTRIBUTE_FORMAT(2, 0) void verrorReport(const Loc& loc, const char *format, va_list ap, ErrorKind kind, unsigned flag = 0, const char *p1 = NULL, const char *p2 = NULL);
+D_ATTRIBUTE_FORMAT(2, 0) void verrorReportSupplemental(const Loc& loc, const char* format, va_list ap, ErrorKind kind, unsigned flag = 0);
 
 #if defined(__GNUC__) || defined(__clang__)
 #define D_ATTRIBUTE_NORETURN __attribute__((noreturn))

--- a/compiler/src/dmd/errorsink.d
+++ b/compiler/src/dmd/errorsink.d
@@ -13,6 +13,23 @@ module dmd.errorsink;
 
 import dmd.location;
 
+/// Constants used to map compiler warnings to a specific flag.
+enum DiagnosticFlag
+{
+    none,
+    cxxcompat,
+    conversion,
+    dangling_else,
+    ddoc,
+    discarded,
+    foreach_reverse_aa,
+    inline_,
+    obsolete,
+    pragma_,
+    shadow,
+    unreachable,
+}
+
 /***************************************
  * Where error/warning/deprecation messages go.
  */
@@ -25,9 +42,9 @@ abstract class ErrorSink
 
     void errorSupplemental(const ref Loc loc, const(char)* format, ...);
 
-    void warning(const ref Loc loc, const(char)* format, ...);
+    void warning(uint flag, const ref Loc loc, const(char)* format, ...);
 
-    void warningSupplemental(const ref Loc loc, const(char)* format, ...);
+    void warningSupplemental(uint flag, const ref Loc loc, const(char)* format, ...);
 
     void message(const ref Loc loc, const(char)* format, ...);
 
@@ -49,9 +66,9 @@ class ErrorSinkNull : ErrorSink
 
     void errorSupplemental(const ref Loc loc, const(char)* format, ...) { }
 
-    void warning(const ref Loc loc, const(char)* format, ...) { }
+    void warning(uint flag, const ref Loc loc, const(char)* format, ...) { }
 
-    void warningSupplemental(const ref Loc loc, const(char)* format, ...) { }
+    void warningSupplemental(uint flag, const ref Loc loc, const(char)* format, ...) { }
 
     void message(const ref Loc loc, const(char)* format, ...) { }
 
@@ -91,7 +108,7 @@ class ErrorSinkStderr : ErrorSink
 
     void errorSupplemental(const ref Loc loc, const(char)* format, ...) { }
 
-    void warning(const ref Loc loc, const(char)* format, ...)
+    void warning(uint flag, const ref Loc loc, const(char)* format, ...)
     {
         fputs("Warning: ", stderr);
         const p = loc.toChars();
@@ -108,7 +125,7 @@ class ErrorSinkStderr : ErrorSink
         va_end(ap);
     }
 
-    void warningSupplemental(const ref Loc loc, const(char)* format, ...) { }
+    void warningSupplemental(uint flag, const ref Loc loc, const(char)* format, ...) { }
 
     void deprecation(const ref Loc loc, const(char)* format, ...)
     {

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -841,13 +841,13 @@ extern (C++) abstract class Expression : ASTNode
             va_end(ap);
         }
 
-        final void warning(const(char)* format, ...) const
+        final void warning(uint flag, const(char)* format, ...) const
         {
             if (type != Type.terror)
             {
                 va_list ap;
                 va_start(ap, format);
-                .verrorReport(loc, format, ap, ErrorKind.warning);
+                .verrorReport(loc, format, ap, ErrorKind.warning, flag);
                 va_end(ap);
             }
         }
@@ -887,13 +887,13 @@ extern (C++) abstract class Expression : ASTNode
             va_end(ap);
         }
 
-        pragma(printf) final void warning(const(char)* format, ...) const
+        pragma(printf) final void warning(uint flag, const(char)* format, ...) const
         {
             if (type != Type.terror)
             {
                 va_list ap;
                 va_start(ap, format);
-                .verrorReport(loc, format, ap, ErrorKind.warning);
+                .verrorReport(loc, format, ap, ErrorKind.warning, flag);
                 va_end(ap);
             }
         }
@@ -4533,7 +4533,7 @@ extern (C++) abstract class BinExp : Expression
         {
             if ((type.isintegral() && t2.isfloating()))
             {
-                warning("`%s %s %s` is performing truncating conversion", type.toChars(), EXPtoString(op).ptr, t2.toChars());
+                warning(DiagnosticFlag.conversion, "`%s %s %s` is performing truncating conversion", type.toChars(), EXPtoString(op).ptr, t2.toChars());
             }
         }
 

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -94,7 +94,7 @@ public:
 
     const char *toChars() const override;
     void error(const char *format, ...) const;
-    void warning(const char *format, ...) const;
+    void warning(unsigned flag, const char *format, ...) const;
     void deprecation(const char *format, ...) const;
 
     virtual dinteger_t toInteger();

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -10025,19 +10025,22 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
             }
 
-            if (0 && global.params.warnings != DiagnosticReporting.off && !global.gag && exp.op == EXP.assign &&
-                e2x.op != EXP.slice && e2x.op != EXP.assign &&
-                e2x.op != EXP.arrayLiteral && e2x.op != EXP.string_ &&
-                !(e2x.op == EXP.add || e2x.op == EXP.min ||
-                  e2x.op == EXP.mul || e2x.op == EXP.div ||
-                  e2x.op == EXP.mod || e2x.op == EXP.xor ||
-                  e2x.op == EXP.and || e2x.op == EXP.or ||
-                  e2x.op == EXP.pow ||
-                  e2x.op == EXP.tilde || e2x.op == EXP.negate))
+            version (none)
             {
-                const(char)* e1str = exp.e1.toChars();
-                const(char)* e2str = e2x.toChars();
-                exp.warning("explicit element-wise assignment `%s = (%s)[]` is better than `%s = %s`", e1str, e2str, e1str, e2str);
+                if (global.params.warnings != DiagnosticReporting.off && !global.gag && exp.op == EXP.assign &&
+                    e2x.op != EXP.slice && e2x.op != EXP.assign &&
+                    e2x.op != EXP.arrayLiteral && e2x.op != EXP.string_ &&
+                    !(e2x.op == EXP.add || e2x.op == EXP.min ||
+                      e2x.op == EXP.mul || e2x.op == EXP.div ||
+                      e2x.op == EXP.mod || e2x.op == EXP.xor ||
+                      e2x.op == EXP.and || e2x.op == EXP.or ||
+                      e2x.op == EXP.pow ||
+                      e2x.op == EXP.tilde || e2x.op == EXP.negate))
+                {
+                    const(char)* e1str = exp.e1.toChars();
+                    const(char)* e2str = e2x.toChars();
+                    exp.warning(DiagnosticFlag.assignment, "explicit element-wise assignment `%s = (%s)[]` is better than `%s = %s`", e1str, e2str, e1str, e2str);
+                }
             }
 
             Type t2n = t2.nextOf();
@@ -10086,17 +10089,20 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else
         {
-            if (0 && global.params.warnings != DiagnosticReporting.off && !global.gag && exp.op == EXP.assign &&
-                t1.ty == Tarray && t2.ty == Tsarray &&
-                e2x.op != EXP.slice &&
-                t2.implicitConvTo(t1))
+            version (none)
             {
-                // Disallow ar[] = sa (Converted to ar[] = sa[])
-                // Disallow da   = sa (Converted to da   = sa[])
-                const(char)* e1str = exp.e1.toChars();
-                const(char)* e2str = e2x.toChars();
-                const(char)* atypestr = exp.e1.op == EXP.slice ? "element-wise" : "slice";
-                exp.warning("explicit %s assignment `%s = (%s)[]` is better than `%s = %s`", atypestr, e1str, e2str, e1str, e2str);
+                if (global.params.warnings != DiagnosticReporting.off && !global.gag && exp.op == EXP.assign &&
+                    t1.ty == Tarray && t2.ty == Tsarray &&
+                    e2x.op != EXP.slice &&
+                    t2.implicitConvTo(t1))
+                {
+                    // Disallow ar[] = sa (Converted to ar[] = sa[])
+                    // Disallow da   = sa (Converted to da   = sa[])
+                    const(char)* e1str = exp.e1.toChars();
+                    const(char)* e2str = e2x.toChars();
+                    const(char)* atypestr = exp.e1.op == EXP.slice ? "element-wise" : "slice";
+                    exp.warning(DiagnosticFlag.assignment, "explicit %s assignment `%s = (%s)[]` is better than `%s = %s`", atypestr, e1str, e2str, e1str, e2str);
+                }
             }
             if (exp.op == EXP.blit)
                 e2x = e2x.castTo(sc, exp.e1.type);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -989,7 +989,7 @@ public:
     const char* toChars() const override;
     void error(const char* format, ...) const;
     void errorSupplemental(const char* format, ...);
-    void warning(const char* format, ...) const;
+    void warning(uint32_t flag, const char* format, ...) const;
     void deprecation(const char* format, ...) const;
     virtual dinteger_t toInteger();
     virtual uinteger_t toUInteger();
@@ -4157,7 +4157,7 @@ public:
     static Array<Statement* >* arraySyntaxCopy(Array<Statement* >* a);
     const char* toChars() const final override;
     void error(const char* format, ...);
-    void warning(const char* format, ...);
+    void warning(uint32_t flag, const char* format, ...);
     void deprecation(const char* format, ...);
     virtual Statement* getRelatedLabeled();
     virtual bool hasBreak() const;
@@ -5393,6 +5393,22 @@ enum class CPU : uint8_t
     avx512 = 10u,
     baseline = 11u,
     native = 12u,
+};
+
+enum class DiagnosticFlag
+{
+    none = 0,
+    cxxcompat = 1,
+    conversion = 2,
+    dangling_else = 3,
+    ddoc = 4,
+    discarded = 5,
+    foreach_reverse_aa = 6,
+    inline_ = 7,
+    obsolete = 8,
+    pragma_ = 9,
+    shadow = 10,
+    unreachable = 11,
 };
 
 enum class ErrorKind
@@ -8508,9 +8524,9 @@ extern void error(const char* filename, uint32_t linnum, uint32_t charnum, const
 
 extern void errorSupplemental(const Loc& loc, const char* format, ...);
 
-extern void warning(const Loc& loc, const char* format, ...);
+extern void warning(uint32_t flag, const Loc& loc, const char* format, ...);
 
-extern void warningSupplemental(const Loc& loc, const char* format, ...);
+extern void warningSupplemental(uint32_t flag, const Loc& loc, const char* format, ...);
 
 extern void deprecation(const Loc& loc, const char* format, ...);
 
@@ -8522,9 +8538,9 @@ extern void message(const char* format, ...);
 
 extern void tip(const char* format, ...);
 
-extern void verrorReport(const Loc& loc, const char* format, va_list ap, ErrorKind kind, const char* p1 = nullptr, const char* p2 = nullptr);
+extern void verrorReport(const Loc& loc, const char* format, va_list ap, ErrorKind kind, uint32_t flag = 0u, const char* p1 = nullptr, const char* p2 = nullptr);
 
-extern void verrorReportSupplemental(const Loc& loc, const char* format, va_list ap, ErrorKind kind);
+extern void verrorReportSupplemental(const Loc& loc, const char* format, va_list ap, ErrorKind kind, uint32_t flag = 0u);
 
 extern void fatal();
 

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -4624,7 +4624,7 @@ bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, const(char)
             if (!gag)
             {
                 if (!sc.isDeprecated() && global.params.obsolete)
-                    warning(loc, msg, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+                    warning(DiagnosticFlag.obsolete, loc, msg, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
             }
         }
         else if (!sc.func.safetyViolation)

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -1887,7 +1887,7 @@ private bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool stat
 
 Lno:
     if (fd.inlining == PINLINE.always && global.params.warnings == DiagnosticReporting.inform)
-        warning(fd.loc, "cannot inline function `%s`", fd.toPrettyChars());
+        warning(DiagnosticFlag.inline_, fd.loc, "cannot inline function `%s`", fd.toPrettyChars());
 
     if (!hdrscan) // Don't modify inlineStatus for header content scan
     {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -5373,7 +5373,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         if (token.value != TOK.else_ && token.value != TOK.catch_ && token.value != TOK.finally_ && lookingForElse.linnum != 0)
         {
-            eSink.warning(elseloc, "else is dangling, add { } after condition at %s", lookingForElse.toChars());
+            eSink.warning(DiagnosticFlag.dangling_else, elseloc, "else is dangling, add { } after condition at %s", lookingForElse.toChars());
         }
     }
 
@@ -9559,7 +9559,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         if (compileEnv.obsolete)
         {
-            eSink.warning(token.loc, "usage of identifer `body` as a keyword is obsolete. Use `do` instead.");
+            eSink.warning(DiagnosticFlag.obsolete, token.loc, "usage of identifer `body` as a keyword is obsolete. Use `do` instead.");
         }
     }
 }

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -299,7 +299,8 @@ bool discardValue(Expression e)
                     }
                     else
                         s = ce.e1.toChars();
-                    e.warning("calling `%s` without side effects discards return value of type `%s`; prepend a `cast(void)` if intentional", s, e.type.toChars());
+                    import dmd.errors : DiagnosticFlag;
+                    e.warning(DiagnosticFlag.discarded, "calling `%s` without side effects discards return value of type `%s`; prepend a `cast(void)` if intentional", s, e.type.toChars());
                 }
             }
         }

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -133,11 +133,11 @@ extern (C++) abstract class Statement : ASTNode
             va_end(ap);
         }
 
-        final void warning(const(char)* format, ...)
+        final void warning(uint flag, const(char)* format, ...)
         {
             va_list ap;
             va_start(ap, format);
-            .verrorReport(loc, format, ap, ErrorKind.warning);
+            .verrorReport(loc, format, ap, ErrorKind.warning, flag);
             va_end(ap);
         }
 
@@ -159,11 +159,11 @@ extern (C++) abstract class Statement : ASTNode
             va_end(ap);
         }
 
-        pragma(printf) final void warning(const(char)* format, ...)
+        pragma(printf) final void warning(uint flag, const(char)* format, ...)
         {
             va_list ap;
             va_start(ap, format);
-            .verrorReport(loc, format, ap, ErrorKind.warning);
+            .verrorReport(loc, format, ap, ErrorKind.warning, flag);
             va_end(ap);
         }
 

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -116,7 +116,7 @@ public:
     const char *toChars() const override final;
 
     void error(const char *format, ...);
-    void warning(const char *format, ...);
+    void warning(unsigned flag, const char *format, ...);
     void deprecation(const char *format, ...);
     virtual Statement *getRelatedLabeled() { return this; }
     virtual bool hasBreak() const;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1197,7 +1197,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             }
         case Taarray:
             if (fs.op == TOK.foreach_reverse_)
-                fs.warning("cannot use `foreach_reverse` with an associative array");
+                fs.warning(DiagnosticFlag.foreach_reverse_aa, "cannot use `foreach_reverse` with an associative array");
             if (checkForArgTypes(fs))
                 return retError();
 


### PR DESCRIPTION
Adds a new `DiagnosticFlag` and adds it to the signature of (`ErrorSink`) `warning` and `warningSupplemental` so that the diagnostics reporter knows the origin of the warning being emitted, allowing it to make even more fine-grained decisions on whether to emit or suppress.

The main user of this is GDC, whose diagnostic back-end is aware of which compiler flags directly control which diagnostic.

DMD could make use of this as well, for instance it would make the condition `if (global.params.obsolete)` before a warning redundant if DMD's diagnostic reporting were changed to work in the same way.