### PR TITLE
Tweak switch skipping variable errors

### DIFF
--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1252,9 +1252,10 @@ extern (C++) final class SwitchStatement : Statement
                 if (v.isDataseg() || (v.storage_class & (STC.manifest | STC.temp) && vd.ident != Id.withSym) || v._init.isVoidInitializer())
                     continue;
                 if (vd.ident == Id.withSym)
-                    error("`switch` skips declaration of `with` temporary at %s", v.loc.toChars());
+                    error("`switch` skips declaration of `with` temporary");
                 else
-                    error("`switch` skips declaration of variable `%s` at %s", v.toPrettyChars(), v.loc.toChars());
+                    error("`switch` skips declaration of variable `%s`", v.toPrettyChars());
+                errorSupplemental(v.loc, "declared here");
                 return true;
             }
             return false;

--- a/compiler/test/fail_compilation/skip.d
+++ b/compiler/test/fail_compilation/skip.d
@@ -2,8 +2,10 @@
  * REQUIRED_ARGS: -de
  * TEST_OUTPUT:
 ---
-fail_compilation/skip.d(21): Error: `switch` skips declaration of `with` temporary at fail_compilation/skip.d(26)
-fail_compilation/skip.d(43): Error: `switch` skips declaration of variable `skip.test14532.n` at fail_compilation/skip.d(45)
+fail_compilation/skip.d(23): Error: `switch` skips declaration of `with` temporary
+fail_compilation/skip.d(28):        declared here
+fail_compilation/skip.d(45): Error: `switch` skips declaration of variable `skip.test14532.n`
+fail_compilation/skip.d(47):        declared here
 ---
  */
 // https://issues.dlang.org/show_bug.cgi?id=10524

--- a/compiler/test/fail_compilation/switch_skip.d
+++ b/compiler/test/fail_compilation/switch_skip.d
@@ -1,10 +1,19 @@
 /*
+REQUIRED_ARGS: -verrors=context
 TEST_OUTPUT:
 ---
-fail_compilation/switch_skip.d(13): Error: `switch` skips declaration of variable `switch_skip.test3.j`
-fail_compilation/switch_skip.d(17):        declared here
-fail_compilation/switch_skip.d(30): Error: `switch` skips declaration of variable `switch_skip.test.z`
-fail_compilation/switch_skip.d(32):        declared here
+fail_compilation/switch_skip.d(22): Error: `switch` skips declaration of variable `switch_skip.test3.j`
+    switch (i)
+    ^
+fail_compilation/switch_skip.d(26):        declared here
+            int j;
+                ^
+fail_compilation/switch_skip.d(39): Error: `switch` skips declaration of variable `switch_skip.test.z`
+    final switch(n)
+    ^
+fail_compilation/switch_skip.d(41):        declared here
+        int z = 5;
+            ^
 ---
 */
 

--- a/compiler/test/fail_compilation/switch_skip.d
+++ b/compiler/test/fail_compilation/switch_skip.d
@@ -1,0 +1,39 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/switch_skip.d(13): Error: `switch` skips declaration of variable `switch_skip.test3.j`
+fail_compilation/switch_skip.d(17):        declared here
+fail_compilation/switch_skip.d(30): Error: `switch` skips declaration of variable `switch_skip.test.z`
+fail_compilation/switch_skip.d(32):        declared here
+---
+*/
+
+void test3(int i)
+{
+    switch (i)
+    {
+        case 1:
+        {
+            int j;
+        case 2:
+            ++j;
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=18858
+int test(int n)
+{
+    final switch(n)
+    {
+        int z = 5;
+        enum e = 6;
+
+        case 1:
+            int y = 2;
+            return y;
+    }
+}

--- a/compiler/test/fail_compilation/switches.d
+++ b/compiler/test/fail_compilation/switches.d
@@ -1,13 +1,11 @@
-/************************************************************/
-
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/switches.d(105): Error: `case 2` not found
+fail_compilation/switches.d(14): Error: `case 2` not found
+fail_compilation/switches.d(25): Error: no `case` statement following `goto case;`
 ---
 */
 
-#line 100
 void test1(int i)
 {
     switch (i)
@@ -19,16 +17,6 @@ void test1(int i)
     }
 }
 
-/************************************************************/
-
-/*
-TEST_OUTPUT:
----
-fail_compilation/switches.d(205): Error: no `case` statement following `goto case;`
----
-*/
-
-#line 200
 void test2(int i)
 {
     switch (i)
@@ -37,57 +25,5 @@ void test2(int i)
             goto case;
         defaut:
             break;
-    }
-}
-
-/************************************************************/
-
-/*
-TEST_OUTPUT:
----
-fail_compilation/switches.d(302): Error: `switch` skips declaration of variable `switches.test3.j` at fail_compilation/switches.d(306)
----
-*/
-
-#line 300
-void test3(int i)
-{
-    switch (i)
-    {
-        case 1:
-        {
-            int j;
-        case 2:
-            ++j;
-            break;
-        }
-        default:
-            break;
-    }
-}
-
-
-/************************************************************/
-
-/*
-TEST_OUTPUT:
----
-fail_compilation/switches.d(404): Error: `switch` skips declaration of variable `switches.test.z` at fail_compilation/switches.d(406)
----
-*/
-
-#line 400
-// https://issues.dlang.org/show_bug.cgi?id=18858
-
-int test(int n)
-{
-    final switch(n)
-    {
-        int z = 5;
-        enum e = 6;
-
-        case 1:
-            int y = 2;
-            return y;
     }
 }


### PR DESCRIPTION
Use supplemental line to show location of variable. 
Break out skip tests from switches.d test to new file switch_skip.d, no changes in content. 
Make switches.d test use only one TEST_OUTPUT block for AUTO_UPDATE compat.