### PR TITLE
remove file I/O from hdrgen.d

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2874,7 +2874,7 @@ struct HdrGenState final
 
 enum : int32_t { TEST_EMIT_ALL = 0 };
 
-extern void genhdrfile(Module* m);
+extern void genhdrfile(Module* m, OutBuffer& buf);
 
 extern void moduleToBuffer(OutBuffer* buf, Module* m);
 

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -33,7 +33,6 @@ import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.dtemplate;
 import dmd.dversion;
-import dmd.errors : fatal;
 import dmd.expression;
 import dmd.func;
 import dmd.globals;
@@ -52,7 +51,6 @@ import dmd.statement;
 import dmd.staticassert;
 import dmd.target;
 import dmd.tokens;
-import dmd.utils;
 import dmd.visitor;
 
 struct HdrGenState
@@ -74,17 +72,20 @@ struct HdrGenState
 
 enum TEST_EMIT_ALL = 0;
 
-extern (C++) void genhdrfile(Module m)
+/****************************************
+ * Generate a header (.di) file for Module m.
+ * Params:
+ *      m = Module to generate header for
+ *      buf = buffer to write the data to
+ */
+extern (C++) void genhdrfile(Module m, ref OutBuffer buf)
 {
-    OutBuffer buf;
     buf.doindent = 1;
     buf.printf("// D import file generated from '%s'", m.srcfile.toChars());
     buf.writenl();
     HdrGenState hgs;
     hgs.hdrgen = true;
     toCBuffer(m, &buf, &hgs);
-    if (!writeFile(m.loc, m.hdrfile.toString(), buf[]))
-        fatal();
 }
 
 /**

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -421,13 +421,18 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
          * line switches and what else is imported, they are generated
          * before any semantic analysis.
          */
+        OutBuffer buf;
         foreach (m; modules)
         {
             if (m.filetype == FileType.dhdr)
                 continue;
             if (params.verbose)
                 message("import    %s", m.toChars());
-            genhdrfile(m);
+
+            buf.reset();         // reuse the buffer
+            genhdrfile(m, buf);
+            if (!writeFile(m.loc, m.hdrfile.toString(), buf[]))
+                fatal();
         }
     }
     if (global.errors)


### PR DESCRIPTION
The various engines in the compiler should not be doing file I/O. That should be done at the top level, making it easier to have dmd-as-library and LSP. Error handling is also pushed up.

This also saves memory, as the buffer gets recycled instead of free'd and reallocated.