### PR TITLE
Fix Issue 24079 - core.sys.windows.winnt.IMAGE_FIRST_SECTION returns bad pointer

### DIFF
--- a/druntime/src/core/sys/windows/winnt.d
+++ b/druntime/src/core/sys/windows/winnt.d
@@ -1199,7 +1199,7 @@ enum size_t
 
 PIMAGE_SECTION_HEADER IMAGE_FIRST_SECTION(PIMAGE_NT_HEADERS h) {
     return cast(PIMAGE_SECTION_HEADER)
-        (&h.OptionalHeader + h.FileHeader.SizeOfOptionalHeader);
+        (cast(ubyte*) &h.OptionalHeader + h.FileHeader.SizeOfOptionalHeader);
 }
 
 // ImageDirectoryEntryToDataEx()


### PR DESCRIPTION
`IMAGE_FIRST_SECTION` adds an integer representing a number of bytes to a pointer of type `IMAGE_OPTIONAL_HEADER*` resulting in a change 240 times (`IMAGE_OPTIONAL_HEADER64*`) or 224 times (`IMAGE_OPTIONAL_HEADER32*`) as large as intended.

https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-image_file_header
> SizeOfOptionalHeader: The size of the optional header, in bytes.