### PR TITLE
make toChars() nothrow

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -728,7 +728,9 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
     override const(char)* toChars() const
     {
-        return toCharsMaybeConstraints(true);
+        try
+            return toCharsMaybeConstraints(true);
+        catch (Exception) assert(0);
     }
 
     /****************************
@@ -6024,7 +6026,9 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     override const(char)* toChars() const
     {
         OutBuffer buf;
-        toCBufferInstance(this, &buf);
+        try
+            toCBufferInstance(this, &buf);
+        catch (Exception) assert(0);
         return buf.extractChars();
     }
 
@@ -7825,7 +7829,9 @@ extern (C++) final class TemplateMixin : TemplateInstance
     override const(char)* toChars() const
     {
         OutBuffer buf;
-        toCBufferInstance(this, &buf);
+        try
+            toCBufferInstance(this, &buf);
+        catch (Exception) assert(0);
         return buf.extractChars();
     }
 

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -813,7 +813,9 @@ extern (C++) abstract class Expression : ASTNode
     {
         OutBuffer buf;
         HdrGenState hgs;
-        toCBuffer(this, &buf, &hgs);
+        try
+            toCBuffer(this, &buf, &hgs);
+        catch (Exception) assert(0);
         return buf.extractChars();
     }
 

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -2016,6 +2016,7 @@ extern (C++) class FuncDeclaration : Declaration
     final bool isUnique() const
     {
         bool result = false;
+        try
         overloadApply(cast() this, (Dsymbol s)
         {
             auto f = s.isFuncDeclaration();
@@ -2033,6 +2034,7 @@ extern (C++) class FuncDeclaration : Declaration
                 return 0;
             }
         });
+        catch (Exception) assert(0);
         return result;
     }
 

--- a/compiler/src/dmd/init.d
+++ b/compiler/src/dmd/init.d
@@ -61,7 +61,9 @@ extern (C++) class Initializer : ASTNode
     {
         OutBuffer buf;
         HdrGenState hgs;
-        .toCBuffer(this, &buf, &hgs);
+        try
+            .toCBuffer(this, &buf, &hgs);
+        catch (Exception) assert(0);
         return buf.extractChars();
     }
 

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -787,7 +787,9 @@ extern (C++) abstract class Type : ASTNode
         HdrGenState hgs;
         hgs.fullQual = (ty == Tclass && !mod);
 
-        .toCBuffer(this, &buf, null, &hgs);
+        try
+            .toCBuffer(this, &buf, null, &hgs);
+        catch (Exception) assert(0);
         return buf.extractChars();
     }
 
@@ -2392,7 +2394,9 @@ extern (C++) abstract class Type : ASTNode
             return this;
         Type unqualThis = cast(Type) this;
         // `mutableOf` needs a mutable `this` only for caching
-        return cast(inout(Type)) unqualThis.mutableOf();
+        try
+            return cast(inout(Type)) unqualThis.mutableOf();
+        catch (Exception) assert(0);
     }
 
     inout(ClassDeclaration) isClassHandle() inout

--- a/compiler/src/dmd/root/rootobject.d
+++ b/compiler/src/dmd/root/rootobject.d
@@ -47,13 +47,13 @@ extern (C++) class RootObject
         return o is this;
     }
 
-    const(char)* toChars() const
+    const(char)* toChars() const nothrow
     {
         assert(0);
     }
 
     ///
-    extern(D) const(char)[] toString() const
+    extern(D) const(char)[] toString() const nothrow
     {
         import core.stdc.string : strlen;
         auto p = this.toChars();

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -118,7 +118,9 @@ extern (C++) abstract class Statement : ASTNode
     {
         HdrGenState hgs;
         OutBuffer buf;
-        .toCBuffer(this, &buf, &hgs);
+        try
+            .toCBuffer(this, &buf, &hgs);
+        catch (Exception) assert(0);
         buf.writeByte(0);
         return buf.extractSlice().ptr;
     }


### PR DESCRIPTION
Although nothing in DMD throws exceptions, the front end functions are all `may throw`. Since it also relies on RAII, this is costly. Converting it all to `nothrow` at once is a tremendous undertaking, so let's just do it bit by bit, starting with `toChars()`.

Note that changing `RootObject.toChars` to `nothrow` will cause every `toChars` to inherit the `nothrow`.