### PR TITLE
Revert "make equals() nothrow"

### DIFF
--- a/compiler/src/.dscanner.ini
+++ b/compiler/src/.dscanner.ini
@@ -5,8 +5,8 @@
 style_check="disabled"
 ; Check for array literals that cause unnecessary allocation
 enum_array_literal_check="enabled"
-; Check for catching Error or Throwable
-exception_check="disabled"
+; Check for poor exception handling practices
+exception_check="enabled"
 ; Check for use of the deprecated 'delete' keyword
 delete_check="enabled"
 ; Check for use of the deprecated floating point operators

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -551,7 +551,7 @@ extern (C++) class Dsymbol : ASTNode
      *
      * See also `parent`, `toParent` and `toParent2`.
      */
-    final inout(Dsymbol) pastMixin() inout nothrow
+    final inout(Dsymbol) pastMixin() inout
     {
         //printf("Dsymbol::pastMixin() %s\n", toChars());
         if (!isTemplateMixin() && !isForwardingAttribDeclaration() && !isForwardingScopeDsymbol())
@@ -601,7 +601,7 @@ extern (C++) class Dsymbol : ASTNode
      *  // s.toParentLocal() == FuncDeclaration('mod.test')
      * ---
      */
-    final inout(Dsymbol) toParent() inout nothrow
+    final inout(Dsymbol) toParent() inout
     {
         return parent ? parent.pastMixin() : null;
     }

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -636,7 +636,7 @@ private:
  *      true if x1 is x2
  *      else false
  */
-bool RealIdentical(real_t x1, real_t x2) @safe nothrow
+bool RealIdentical(real_t x1, real_t x2) @safe
 {
     return (CTFloat.isNaN(x1) && CTFloat.isNaN(x2)) || CTFloat.isIdentical(x1, x2);
 }

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -2013,10 +2013,9 @@ extern (C++) class FuncDeclaration : Declaration
      * Returns:
      *  true if there are no overloads of this function
      */
-    final bool isUnique() const nothrow
+    final bool isUnique() const
     {
         bool result = false;
-        try
         overloadApply(cast() this, (Dsymbol s)
         {
             auto f = s.isFuncDeclaration();
@@ -2034,7 +2033,6 @@ extern (C++) class FuncDeclaration : Declaration
                 return 0;
             }
         });
-        catch (Throwable) assert(0);
         return result;
     }
 
@@ -2984,7 +2982,7 @@ extern (C++) class FuncDeclaration : Declaration
         return this;
     }
 
-    inout(FuncDeclaration) toAliasFunc() inout nothrow
+    inout(FuncDeclaration) toAliasFunc() inout
     {
         return this;
     }

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -480,7 +480,7 @@ extern (C++) abstract class Type : ASTNode
         assert(0);
     }
 
-    override bool equals(const RootObject o) const nothrow
+    override bool equals(const RootObject o) const
     {
         Type t = cast(Type)o;
         //printf("Type::equals(%s, %s)\n", toChars(), t.toChars());
@@ -2386,15 +2386,13 @@ extern (C++) abstract class Type : ASTNode
     /**************************
      * Return type with the top level of it being mutable.
      */
-    inout(Type) toHeadMutable() inout nothrow
+    inout(Type) toHeadMutable() inout
     {
         if (!mod)
             return this;
         Type unqualThis = cast(Type) this;
         // `mutableOf` needs a mutable `this` only for caching
-        try
-            return cast(inout(Type)) unqualThis.mutableOf();
-        catch (Throwable) assert(0);
+        return cast(inout(Type)) unqualThis.mutableOf();
     }
 
     inout(ClassDeclaration) isClassHandle() inout

--- a/compiler/src/dmd/root/rootobject.d
+++ b/compiler/src/dmd/root/rootobject.d
@@ -42,7 +42,7 @@ extern (C++) class RootObject
     {
     }
 
-    bool equals(const RootObject o) const nothrow
+    bool equals(const RootObject o) const
     {
         return o is this;
     }


### PR DESCRIPTION
Reverts dlang/dmd#15522

This approach doesn't work when exceptions are disabled globally.

https://github.com/dlang/dmd/blob/0ceaeb9219ee2c09cd8c39d31ed1b70d6e19dd59/compiler/src/dmd/statementsem.d#L3282-L3286