### PR TITLE
move ddoc file reads out of doc.d

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6501,7 +6501,7 @@ struct ModuleDeclaration final
 
 extern void getLocalClasses(Module* mod, Array<ClassDeclaration* >& aclasses);
 
-extern void gendocfile(Module* m, const Array<const char* >& ddocfiles, const char* datetime, ErrorSink* eSink);
+extern void gendocfile(Module* m, const char* const ddoctext_ptr, size_t ddoctext_length, const char* const datetime, ErrorSink* eSink);
 
 struct Scope final
 {


### PR DESCRIPTION
This is because:

1. gendocfile() should not be doing I/O
2. its reliance on global state makes it impractical to use as a server

I eventually plan to remove the rest of the I/O out of doc.d, as the other operating system interactions have already been removed. This will make gendocfile() have a lot fewer obscure dependencies, and will only depend on its "front door".