### PR TITLE
Improve expected `;` after expression error

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -5824,7 +5824,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 AST.Expression exp = parseExpression();
                 /* https://issues.dlang.org/show_bug.cgi?id=15103
                  * Improve declaration / initialization syntax error message
-                 * Error: found 'foo' when expecting ';' following statement
+                 * Error: found 'foo' when expecting ';' following expression
                  * becomes Error: found `(` when expecting `;` or `=`, did you mean `Foo foo = 42`?
                  */
                 if (token.value == TOK.identifier && exp.op == EXP.identifier)
@@ -5849,13 +5849,13 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                      * otherwise we fall back on the old path (advancing the token).
                      */
                     if (token.value != TOK.semicolon && peek(&token).value == TOK.semicolon)
-                        error("found `%s` when expecting `;` following statement", token.toChars());
+                        error("found `%s` when expecting `;` following expression", token.toChars());
                     else
                     {
                         if (token.value != TOK.semicolon)
                         {
-                            error("found `%s` when expecting `;` following statement", token.toChars());
-                            eSink.errorSupplemental(exp.loc, "`%s` found here", exp.toChars());
+                            error("found `%s` when expecting `;` following expression", token.toChars());
+                            eSink.errorSupplemental(exp.loc, "expression: `%s`", exp.toChars());
                         }
                         nextToken();
                     }

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -5853,7 +5853,10 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     else
                     {
                         if (token.value != TOK.semicolon)
-                            error("found `%s` when expecting `;` following statement `%s` on line %s", token.toChars(), exp.toChars(), exp.loc.toChars());
+                        {
+                            error("found `%s` when expecting `;` following statement", token.toChars());
+                            eSink.errorSupplemental(exp.loc, "`%s` found here", exp.toChars());
+                        }
                         nextToken();
                     }
                 }

--- a/compiler/test/fail_compilation/fail136.d
+++ b/compiler/test/fail_compilation/fail136.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail136.d(10): Error: found `"EF BB BF"` when expecting `;` following statement
+fail_compilation/fail136.d(10): Error: found `"EF BB BF"` when expecting `;` following expression
 ---
 */
 

--- a/compiler/test/fail_compilation/fail196.d
+++ b/compiler/test/fail_compilation/fail196.d
@@ -6,24 +6,24 @@ fail_compilation/fail196.d(38): Error: implicit string concatenation is error-pr
 fail_compilation/fail196.d(38):        Use the explicit syntax instead (concatenating literals is `@nogc`): "foo(xxx)" ~ ";\n    assert(s == "
 fail_compilation/fail196.d(39): Error: semicolon needed to end declaration of `s`, instead of `foo`
 fail_compilation/fail196.d(38):        `s` declared here
-fail_compilation/fail196.d(39): Error: found `");\n\n    s = q"` when expecting `;` following statement
-fail_compilation/fail196.d(39):        `foo(xxx)` found here
-fail_compilation/fail196.d(41): Error: found `";\n    assert(s == "` when expecting `;` following statement
-fail_compilation/fail196.d(41):        `[foo[xxx]]` found here
-fail_compilation/fail196.d(42): Error: found `");\n\n    s = q"` when expecting `;` following statement
-fail_compilation/fail196.d(42):        `foo[xxx]` found here
-fail_compilation/fail196.d(44): Error: found `{` when expecting `;` following statement
-fail_compilation/fail196.d(44):        `foo` found here
-fail_compilation/fail196.d(44): Error: found `}` when expecting `;` following statement
-fail_compilation/fail196.d(44):        `xxx` found here
-fail_compilation/fail196.d(45): Error: found `foo` when expecting `;` following statement
-fail_compilation/fail196.d(44):        `";\n    assert(s == "` found here
-fail_compilation/fail196.d(45): Error: found `}` when expecting `;` following statement
-fail_compilation/fail196.d(45):        `xxx` found here
-fail_compilation/fail196.d(47): Error: found `<` when expecting `;` following statement
-fail_compilation/fail196.d(45):        `");\n\n    s = q" < foo` found here
-fail_compilation/fail196.d(48): Error: found `foo` when expecting `;` following statement
-fail_compilation/fail196.d(47):        `xxx >> ";\n    assert(s == "` found here
+fail_compilation/fail196.d(39): Error: found `");\n\n    s = q"` when expecting `;` following expression
+fail_compilation/fail196.d(39):        expression: `foo(xxx)`
+fail_compilation/fail196.d(41): Error: found `";\n    assert(s == "` when expecting `;` following expression
+fail_compilation/fail196.d(41):        expression: `[foo[xxx]]`
+fail_compilation/fail196.d(42): Error: found `");\n\n    s = q"` when expecting `;` following expression
+fail_compilation/fail196.d(42):        expression: `foo[xxx]`
+fail_compilation/fail196.d(44): Error: found `{` when expecting `;` following expression
+fail_compilation/fail196.d(44):        expression: `foo`
+fail_compilation/fail196.d(44): Error: found `}` when expecting `;` following expression
+fail_compilation/fail196.d(44):        expression: `xxx`
+fail_compilation/fail196.d(45): Error: found `foo` when expecting `;` following expression
+fail_compilation/fail196.d(44):        expression: `";\n    assert(s == "`
+fail_compilation/fail196.d(45): Error: found `}` when expecting `;` following expression
+fail_compilation/fail196.d(45):        expression: `xxx`
+fail_compilation/fail196.d(47): Error: found `<` when expecting `;` following expression
+fail_compilation/fail196.d(45):        expression: `");\n\n    s = q" < foo`
+fail_compilation/fail196.d(48): Error: found `foo` when expecting `;` following expression
+fail_compilation/fail196.d(47):        expression: `xxx >> ";\n    assert(s == "`
 fail_compilation/fail196.d(48): Error: found `<` instead of statement
 fail_compilation/fail196.d(54): Error: unterminated string constant starting at fail_compilation/fail196.d(54)
 fail_compilation/fail196.d(56): Error: matching `}` expected following compound statement, not `End of File`

--- a/compiler/test/fail_compilation/fail196.d
+++ b/compiler/test/fail_compilation/fail196.d
@@ -1,26 +1,35 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail196.d(29): Error: delimited string must end in `)"`
-fail_compilation/fail196.d(29): Error: implicit string concatenation is error-prone and disallowed in D
-fail_compilation/fail196.d(29):        Use the explicit syntax instead (concatenating literals is `@nogc`): "foo(xxx)" ~ ";\n    assert(s == "
-fail_compilation/fail196.d(30): Error: semicolon needed to end declaration of `s`, instead of `foo`
-fail_compilation/fail196.d(29):        `s` declared here
-fail_compilation/fail196.d(30): Error: found `");\n\n    s = q"` when expecting `;` following statement `foo(xxx)` on line fail_compilation/fail196.d(30)
-fail_compilation/fail196.d(32): Error: found `";\n    assert(s == "` when expecting `;` following statement `[foo[xxx]]` on line fail_compilation/fail196.d(32)
-fail_compilation/fail196.d(33): Error: found `");\n\n    s = q"` when expecting `;` following statement `foo[xxx]` on line fail_compilation/fail196.d(33)
-fail_compilation/fail196.d(35): Error: found `{` when expecting `;` following statement `foo` on line fail_compilation/fail196.d(35)
-fail_compilation/fail196.d(35): Error: found `}` when expecting `;` following statement `xxx` on line fail_compilation/fail196.d(35)
-fail_compilation/fail196.d(36): Error: found `foo` when expecting `;` following statement `";\n    assert(s == "` on line fail_compilation/fail196.d(35)
-fail_compilation/fail196.d(36): Error: found `}` when expecting `;` following statement `xxx` on line fail_compilation/fail196.d(36)
-fail_compilation/fail196.d(38): Error: found `<` when expecting `;` following statement `");\n\n    s = q" < foo` on line fail_compilation/fail196.d(36)
-fail_compilation/fail196.d(39): Error: found `foo` when expecting `;` following statement `xxx >> ";\n    assert(s == "` on line fail_compilation/fail196.d(38)
-fail_compilation/fail196.d(39): Error: found `<` instead of statement
-fail_compilation/fail196.d(45): Error: unterminated string constant starting at fail_compilation/fail196.d(45)
-fail_compilation/fail196.d(47): Error: matching `}` expected following compound statement, not `End of File`
-fail_compilation/fail196.d(36):        unmatched `{`
-fail_compilation/fail196.d(47): Error: matching `}` expected following compound statement, not `End of File`
-fail_compilation/fail196.d(28):        unmatched `{`
+fail_compilation/fail196.d(38): Error: delimited string must end in `)"`
+fail_compilation/fail196.d(38): Error: implicit string concatenation is error-prone and disallowed in D
+fail_compilation/fail196.d(38):        Use the explicit syntax instead (concatenating literals is `@nogc`): "foo(xxx)" ~ ";\n    assert(s == "
+fail_compilation/fail196.d(39): Error: semicolon needed to end declaration of `s`, instead of `foo`
+fail_compilation/fail196.d(38):        `s` declared here
+fail_compilation/fail196.d(39): Error: found `");\n\n    s = q"` when expecting `;` following statement
+fail_compilation/fail196.d(39):        `foo(xxx)` found here
+fail_compilation/fail196.d(41): Error: found `";\n    assert(s == "` when expecting `;` following statement
+fail_compilation/fail196.d(41):        `[foo[xxx]]` found here
+fail_compilation/fail196.d(42): Error: found `");\n\n    s = q"` when expecting `;` following statement
+fail_compilation/fail196.d(42):        `foo[xxx]` found here
+fail_compilation/fail196.d(44): Error: found `{` when expecting `;` following statement
+fail_compilation/fail196.d(44):        `foo` found here
+fail_compilation/fail196.d(44): Error: found `}` when expecting `;` following statement
+fail_compilation/fail196.d(44):        `xxx` found here
+fail_compilation/fail196.d(45): Error: found `foo` when expecting `;` following statement
+fail_compilation/fail196.d(44):        `";\n    assert(s == "` found here
+fail_compilation/fail196.d(45): Error: found `}` when expecting `;` following statement
+fail_compilation/fail196.d(45):        `xxx` found here
+fail_compilation/fail196.d(47): Error: found `<` when expecting `;` following statement
+fail_compilation/fail196.d(45):        `");\n\n    s = q" < foo` found here
+fail_compilation/fail196.d(48): Error: found `foo` when expecting `;` following statement
+fail_compilation/fail196.d(47):        `xxx >> ";\n    assert(s == "` found here
+fail_compilation/fail196.d(48): Error: found `<` instead of statement
+fail_compilation/fail196.d(54): Error: unterminated string constant starting at fail_compilation/fail196.d(54)
+fail_compilation/fail196.d(56): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/fail196.d(45):        unmatched `{`
+fail_compilation/fail196.d(56): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/fail196.d(37):        unmatched `{`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail22529.d
+++ b/compiler/test/fail_compilation/fail22529.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22529.d(13): Error: found `return` when expecting `;` following statement
+fail_compilation/fail22529.d(13): Error: found `return` when expecting `;` following expression
 ---
 */
 

--- a/compiler/test/fail_compilation/ice11982.d
+++ b/compiler/test/fail_compilation/ice11982.d
@@ -1,20 +1,22 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11982.d(20): Error: basic type expected, not `scope`
-fail_compilation/ice11982.d(20): Error: found `scope` when expecting `;` following statement `new _error_` on line fail_compilation/ice11982.d(20)
-fail_compilation/ice11982.d(20): Error: basic type expected, not `}`
-fail_compilation/ice11982.d(20): Error: missing `{ ... }` for function literal
-fail_compilation/ice11982.d(20): Error: C style cast illegal, use `cast(funk)function _error_()
+fail_compilation/ice11982.d(22): Error: basic type expected, not `scope`
+fail_compilation/ice11982.d(22): Error: found `scope` when expecting `;` following statement
+fail_compilation/ice11982.d(22):        `new _error_` found here
+fail_compilation/ice11982.d(22): Error: basic type expected, not `}`
+fail_compilation/ice11982.d(22): Error: missing `{ ... }` for function literal
+fail_compilation/ice11982.d(22): Error: C style cast illegal, use `cast(funk)function _error_()
 {
 }
 `
-fail_compilation/ice11982.d(20): Error: found `}` when expecting `;` following statement `cast(funk)function _error_()
+fail_compilation/ice11982.d(22): Error: found `}` when expecting `;` following statement
+fail_compilation/ice11982.d(22):        `cast(funk)function _error_()
 {
 }
-` on line fail_compilation/ice11982.d(20)
-fail_compilation/ice11982.d(21): Error: matching `}` expected following compound statement, not `End of File`
-fail_compilation/ice11982.d(20):        unmatched `{`
+` found here
+fail_compilation/ice11982.d(23): Error: matching `}` expected following compound statement, not `End of File`
+fail_compilation/ice11982.d(22):        unmatched `{`
 ---
 */
 void main() { new scope ( funk ) function }

--- a/compiler/test/fail_compilation/ice11982.d
+++ b/compiler/test/fail_compilation/ice11982.d
@@ -2,19 +2,19 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11982.d(22): Error: basic type expected, not `scope`
-fail_compilation/ice11982.d(22): Error: found `scope` when expecting `;` following statement
-fail_compilation/ice11982.d(22):        `new _error_` found here
+fail_compilation/ice11982.d(22): Error: found `scope` when expecting `;` following expression
+fail_compilation/ice11982.d(22):        expression: `new _error_`
 fail_compilation/ice11982.d(22): Error: basic type expected, not `}`
 fail_compilation/ice11982.d(22): Error: missing `{ ... }` for function literal
 fail_compilation/ice11982.d(22): Error: C style cast illegal, use `cast(funk)function _error_()
 {
 }
 `
-fail_compilation/ice11982.d(22): Error: found `}` when expecting `;` following statement
-fail_compilation/ice11982.d(22):        `cast(funk)function _error_()
+fail_compilation/ice11982.d(22): Error: found `}` when expecting `;` following expression
+fail_compilation/ice11982.d(22):        expression: `cast(funk)function _error_()
 {
 }
-` found here
+`
 fail_compilation/ice11982.d(23): Error: matching `}` expected following compound statement, not `End of File`
 fail_compilation/ice11982.d(22):        unmatched `{`
 ---

--- a/compiler/test/fail_compilation/misc_parser_err_cov1.d
+++ b/compiler/test/fail_compilation/misc_parser_err_cov1.d
@@ -23,8 +23,8 @@ fail_compilation/misc_parser_err_cov1.d(40): Error: semicolon expected following
 fail_compilation/misc_parser_err_cov1.d(40): Error: identifier or `new` expected following `.`, not `+`
 fail_compilation/misc_parser_err_cov1.d(41): Error: identifier or new keyword expected following `(...)`.
 fail_compilation/misc_parser_err_cov1.d(41): Error: expression expected, not `;`
-fail_compilation/misc_parser_err_cov1.d(42): Error: found `}` when expecting `;` following statement
-fail_compilation/misc_parser_err_cov1.d(41):        `(__error) + 0` found here
+fail_compilation/misc_parser_err_cov1.d(42): Error: found `}` when expecting `;` following expression
+fail_compilation/misc_parser_err_cov1.d(41):        expression: `(__error) + 0`
 fail_compilation/misc_parser_err_cov1.d(43): Error: matching `}` expected following compound statement, not `End of File`
 fail_compilation/misc_parser_err_cov1.d(33):        unmatched `{`
 ---

--- a/compiler/test/fail_compilation/misc_parser_err_cov1.d
+++ b/compiler/test/fail_compilation/misc_parser_err_cov1.d
@@ -23,7 +23,8 @@ fail_compilation/misc_parser_err_cov1.d(40): Error: semicolon expected following
 fail_compilation/misc_parser_err_cov1.d(40): Error: identifier or `new` expected following `.`, not `+`
 fail_compilation/misc_parser_err_cov1.d(41): Error: identifier or new keyword expected following `(...)`.
 fail_compilation/misc_parser_err_cov1.d(41): Error: expression expected, not `;`
-fail_compilation/misc_parser_err_cov1.d(42): Error: found `}` when expecting `;` following statement `(__error) + 0` on line fail_compilation/misc_parser_err_cov1.d(41)
+fail_compilation/misc_parser_err_cov1.d(42): Error: found `}` when expecting `;` following statement
+fail_compilation/misc_parser_err_cov1.d(41):        `(__error) + 0` found here
 fail_compilation/misc_parser_err_cov1.d(43): Error: matching `}` expected following compound statement, not `End of File`
 fail_compilation/misc_parser_err_cov1.d(33):        unmatched `{`
 ---

--- a/compiler/test/fail_compilation/parseStc.d
+++ b/compiler/test/fail_compilation/parseStc.d
@@ -3,12 +3,12 @@ TEST_OUTPUT:
 ---
 fail_compilation/parseStc.d(12): Error: missing closing `)` after `if (x`
 fail_compilation/parseStc.d(12): Error: use `{ }` for an empty statement, not `;`
-fail_compilation/parseStc.d(12): Error: found `)` when expecting `;` following statement `1` on line fail_compilation/parseStc.d(12)
+fail_compilation/parseStc.d(12): Error: found `)` when expecting `;` following statement
+fail_compilation/parseStc.d(12):        `1` found here
 fail_compilation/parseStc.d(13): Error: redundant attribute `const`
 ---
 */
-void test1()
-{
+void test1() {
     if (x; 1) {}
     if (const const auto x = 1) {}
 }

--- a/compiler/test/fail_compilation/parseStc.d
+++ b/compiler/test/fail_compilation/parseStc.d
@@ -3,8 +3,8 @@ TEST_OUTPUT:
 ---
 fail_compilation/parseStc.d(12): Error: missing closing `)` after `if (x`
 fail_compilation/parseStc.d(12): Error: use `{ }` for an empty statement, not `;`
-fail_compilation/parseStc.d(12): Error: found `)` when expecting `;` following statement
-fail_compilation/parseStc.d(12):        `1` found here
+fail_compilation/parseStc.d(12): Error: found `)` when expecting `;` following expression
+fail_compilation/parseStc.d(12):        expression: `1`
 fail_compilation/parseStc.d(13): Error: redundant attribute `const`
 ---
 */


### PR DESCRIPTION
The expected semi-colon is to close the statement, so it actually follows an expression, not a statement.