### PR TITLE
Improve expected `}` error after aggregate members

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3285,8 +3285,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             if (token.value != TOK.rightCurly)
             {
                 /* { */
-                error(token.loc, "`}` expected following members in `%s` declaration at %s",
-                    Token.toChars(tok), loc.toChars());
+                error(token.loc, "`}` expected following members in `%s` declaration",
+                    Token.toChars(tok));
+                eSink.errorSupplemental(loc, "declared here");
             }
             nextToken();
         }

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3287,7 +3287,12 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 /* { */
                 error(token.loc, "`}` expected following members in `%s` declaration",
                     Token.toChars(tok));
-                eSink.errorSupplemental(loc, "declared here");
+                if (id)
+                    eSink.errorSupplemental(loc, "%s `%s` starts here",
+                        Token.toChars(tok), id.toChars());
+                else
+                    eSink.errorSupplemental(loc, "%s starts here",
+                        Token.toChars(tok));
             }
             nextToken();
         }

--- a/compiler/test/fail_compilation/diag13609a.d
+++ b/compiler/test/fail_compilation/diag13609a.d
@@ -1,11 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag13609a.d(12): Error: `}` expected following members in `class` declaration
-fail_compilation/diag13609a.d(9):        declared here
+fail_compilation/diag13609a.d(16): Error: `}` expected following members in `struct` declaration
+fail_compilation/diag13609a.d(15):        struct starts here
+fail_compilation/diag13609a.d(16): Error: `}` expected following members in `class` declaration
+fail_compilation/diag13609a.d(11):        class `C` starts here
 ---
 */
 
 class C
 {
     void foo() {}
+
+    struct {

--- a/compiler/test/fail_compilation/diag13609a.d
+++ b/compiler/test/fail_compilation/diag13609a.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag13609a.d(11): Error: `}` expected following members in `class` declaration at fail_compilation/diag13609a.d(8)
+fail_compilation/diag13609a.d(12): Error: `}` expected following members in `class` declaration
+fail_compilation/diag13609a.d(9):        declared here
 ---
 */
 

--- a/compiler/test/fail_compilation/fail17570.d
+++ b/compiler/test/fail_compilation/fail17570.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/fail17570.d(12): Error: cannot use function constraints for non-template functions. Use `static if` instead
 fail_compilation/fail17570.d(12): Error: declaration expected, not `if`
 fail_compilation/fail17570.d(15): Error: `}` expected following members in `struct` declaration
-fail_compilation/fail17570.d(11):        declared here
+fail_compilation/fail17570.d(11):        struct `S` starts here
 ---
 */
 

--- a/compiler/test/fail_compilation/fail17570.d
+++ b/compiler/test/fail_compilation/fail17570.d
@@ -1,9 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail17570.d(11): Error: cannot use function constraints for non-template functions. Use `static if` instead
-fail_compilation/fail17570.d(11): Error: declaration expected, not `if`
-fail_compilation/fail17570.d(14): Error: `}` expected following members in `struct` declaration at fail_compilation/fail17570.d(10)
+fail_compilation/fail17570.d(12): Error: cannot use function constraints for non-template functions. Use `static if` instead
+fail_compilation/fail17570.d(12): Error: declaration expected, not `if`
+fail_compilation/fail17570.d(15): Error: `}` expected following members in `struct` declaration
+fail_compilation/fail17570.d(11):        declared here
 ---
 */
 

--- a/compiler/test/fail_compilation/fnconstraint.d
+++ b/compiler/test/fail_compilation/fnconstraint.d
@@ -1,11 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fnconstraint.d(13): Error: template constraint must follow parameter lists and attributes
-fail_compilation/fnconstraint.d(13): Error: declaration expected, not `if`
-fail_compilation/fnconstraint.d(22): Error: template constraint must follow parameter lists and attributes
-fail_compilation/fnconstraint.d(22): Error: declaration expected, not `if`
-fail_compilation/fnconstraint.d(26): Error: `}` expected following members in `struct` declaration at fail_compilation/fnconstraint.d(18)
+fail_compilation/fnconstraint.d(14): Error: template constraint must follow parameter lists and attributes
+fail_compilation/fnconstraint.d(14): Error: declaration expected, not `if`
+fail_compilation/fnconstraint.d(23): Error: template constraint must follow parameter lists and attributes
+fail_compilation/fnconstraint.d(23): Error: declaration expected, not `if`
+fail_compilation/fnconstraint.d(27): Error: `}` expected following members in `struct` declaration
+fail_compilation/fnconstraint.d(19):        declared here
 ---
 */
 void foo()()

--- a/compiler/test/fail_compilation/fnconstraint.d
+++ b/compiler/test/fail_compilation/fnconstraint.d
@@ -6,7 +6,7 @@ fail_compilation/fnconstraint.d(14): Error: declaration expected, not `if`
 fail_compilation/fnconstraint.d(23): Error: template constraint must follow parameter lists and attributes
 fail_compilation/fnconstraint.d(23): Error: declaration expected, not `if`
 fail_compilation/fnconstraint.d(27): Error: `}` expected following members in `struct` declaration
-fail_compilation/fnconstraint.d(19):        declared here
+fail_compilation/fnconstraint.d(19):        struct `S` starts here
 ---
 */
 void foo()()

--- a/compiler/test/fail_compilation/testsemi.d
+++ b/compiler/test/fail_compilation/testsemi.d
@@ -9,7 +9,7 @@ fail_compilation/testsemi.d(117): Error: no identifier for declarator `x`
 fail_compilation/testsemi.d(123): Error: found `int` when expecting `;` following mixin
 fail_compilation/testsemi.d(129): Error: found `int` when expecting `;` following `import` Expression
 fail_compilation/testsemi.d(131): Error: `}` expected following members in `class` declaration
-fail_compilation/testsemi.d(112):        declared here
+fail_compilation/testsemi.d(112):        class `C` starts here
 ---
  */
 

--- a/compiler/test/fail_compilation/testsemi.d
+++ b/compiler/test/fail_compilation/testsemi.d
@@ -8,7 +8,8 @@ fail_compilation/testsemi.d(117): Error: found `int` when expecting `;` followin
 fail_compilation/testsemi.d(117): Error: no identifier for declarator `x`
 fail_compilation/testsemi.d(123): Error: found `int` when expecting `;` following mixin
 fail_compilation/testsemi.d(129): Error: found `int` when expecting `;` following `import` Expression
-fail_compilation/testsemi.d(131): Error: `}` expected following members in `class` declaration at fail_compilation/testsemi.d(112)
+fail_compilation/testsemi.d(131): Error: `}` expected following members in `class` declaration
+fail_compilation/testsemi.d(112):        declared here
 ---
  */
 


### PR DESCRIPTION
Show name of declaration if not anonymous.