### PR TITLE
Use separate line for extra Loc in various error messages

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -7056,10 +7056,10 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
             if (td_ambig)
             {
-                .error(loc, "%s `%s.%s` matches more than one template declaration:\n%s:     `%s`\nand\n%s:     `%s`",
-                    td_best.kind(), td_best.parent.toPrettyChars(), td_best.ident.toChars(),
-                    td_best.loc.toChars(), td_best.toChars(),
-                    td_ambig.loc.toChars(), td_ambig.toChars());
+                .error(loc, "%s `%s.%s` matches more than one template declaration:",
+                    td_best.kind(), td_best.parent.toPrettyChars(), td_best.ident.toChars());
+                .errorSupplemental(td_best.loc, "`%s`", td_best.toChars());
+                .errorSupplemental(td_ambig.loc, "`%s`", td_ambig.toChars());
                 return false;
             }
             if (td_best)

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -7058,7 +7058,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             {
                 .error(loc, "%s `%s.%s` matches more than one template declaration:",
                     td_best.kind(), td_best.parent.toPrettyChars(), td_best.ident.toChars());
-                .errorSupplemental(td_best.loc, "`%s`", td_best.toChars());
+                .errorSupplemental(td_best.loc, "`%s`\nand:", td_best.toChars());
                 .errorSupplemental(td_ambig.loc, "`%s`", td_ambig.toChars());
                 return false;
             }

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -1415,9 +1415,10 @@ private bool onlyOneMain(FuncDeclaration fd)
     if (lastMain)
     {
         const format = (target.os == Target.OS.Windows)
-            ? "only one entry point `main`, `WinMain` or `DllMain` is allowed. Previously found `%s` at %s"
-            : "only one entry point `main` is allowed. Previously found `%s` at %s";
-        error(fd.loc, format.ptr, lastMain.toChars(), lastMain.loc.toChars());
+            ? "only one entry point `main`, `WinMain` or `DllMain` is allowed"
+            : "only one entry point `main` is allowed";
+        error(fd.loc, format.ptr);
+        errorSupplemental(lastMain.loc, "previously found `%s` here", lastMain.toFullSignature());
         return false;
     }
     lastMain = fd;

--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1767,10 +1767,10 @@ private FuncDeclaration findBestOpApplyMatch(Expression ethis, FuncDeclaration f
 
     if (fd_ambig)
     {
-        .error(ethis.loc, "`%s.%s` matches more than one declaration:\n`%s`:     `%s`\nand:\n`%s`:     `%s`",
-            ethis.toChars(), fstart.ident.toChars(),
-            fd_best.loc.toChars(), fd_best.type.toChars(),
-            fd_ambig.loc.toChars(), fd_ambig.type.toChars());
+        .error(ethis.loc, "`%s.%s` matches more than one declaration:",
+            ethis.toChars(), fstart.ident.toChars());
+        .errorSupplemental(fd_best.loc, "`%s`\nand:", fd_best.type.toChars());
+        .errorSupplemental(fd_ambig.loc, "`%s`", fd_ambig.type.toChars());
         return null;
     }
 

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1863,17 +1863,15 @@ extern (C++) final class GotoStatement : Statement
         {
             // Lifetime ends at end of expression, so no issue with skipping the statement
         }
-        else if (vd.ident == Id.withSym)
-        {
-            error("`goto` skips declaration of `with` temporary at %s", vd.loc.toChars());
-            return true;
-        }
         else
         {
-            error("`goto` skips declaration of variable `%s` at %s", vd.toPrettyChars(), vd.loc.toChars());
+            if (vd.ident == Id.withSym)
+                error("`goto` skips declaration of `with` temporary");
+            else
+                error("`goto` skips declaration of variable `%s`", vd.toPrettyChars());
+            errorSupplemental(vd.loc, "declared here");
             return true;
         }
-
         return false;
     }
 

--- a/compiler/test/fail_compilation/fail1900.d
+++ b/compiler/test/fail_compilation/fail1900.d
@@ -3,11 +3,11 @@ EXTRA_FILES: imports/fail1900a.d imports/fail1900b.d
 TEST_OUTPUT:
 ---
 fail_compilation/fail1900.d(27): Error: template `fail1900.Mix1a!().Foo` matches more than one template declaration:
-fail_compilation/fail1900.d(14):     `Foo(ubyte x)`
-and
-fail_compilation/fail1900.d(15):     `Foo(byte x)`
+fail_compilation/fail1900.d(14):        `Foo(ubyte x)`
+fail_compilation/fail1900.d(15):        `Foo(byte x)`
 ---
 */
+
 
 template Mix1a()
 {

--- a/compiler/test/fail_compilation/fail1900.d
+++ b/compiler/test/fail_compilation/fail1900.d
@@ -4,10 +4,10 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail1900.d(27): Error: template `fail1900.Mix1a!().Foo` matches more than one template declaration:
 fail_compilation/fail1900.d(14):        `Foo(ubyte x)`
+and:
 fail_compilation/fail1900.d(15):        `Foo(byte x)`
 ---
 */
-
 
 template Mix1a()
 {

--- a/compiler/test/fail_compilation/goto_skip.d
+++ b/compiler/test/fail_compilation/goto_skip.d
@@ -1,0 +1,57 @@
+/*
+REQUIRED_ARGS: -verrors=context
+TEST_OUTPUT:
+---
+fail_compilation/goto_skip.d(28): Error: `goto` skips declaration of variable `goto_skip.skip.ch`
+        goto Lskip;
+        ^
+fail_compilation/goto_skip.d(29):        declared here
+    char ch = '!';
+         ^
+fail_compilation/goto_skip.d(36): Error: `goto` skips declaration of `with` temporary
+    goto L1;
+    ^
+fail_compilation/goto_skip.d(38):        declared here
+    with (S()) {
+    ^
+fail_compilation/goto_skip.d(46): Error: `goto` skips declaration of variable `goto_skip.test8.e`
+  goto L2;
+  ^
+fail_compilation/goto_skip.d(51):        declared here
+  catch (Exception e) {
+  ^
+---
+*/
+char skip(bool b)
+{
+    if (b)
+        goto Lskip;
+    char ch = '!';
+Lskip:
+    return ch;
+}
+
+int f()
+{
+    goto L1;
+    struct S { int e = 5; }
+    with (S()) {
+L1:
+        return e;
+    }
+}
+
+void test8(int a)
+{
+  goto L2;
+
+  try {
+      a += 2;
+  }
+  catch (Exception e) {
+      a += 3;
+L2: ;
+      a += 100;
+  }
+  assert(a == 100);
+}

--- a/compiler/test/fail_compilation/ice11518.d
+++ b/compiler/test/fail_compilation/ice11518.d
@@ -2,11 +2,11 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11518.d(17): Error: class `ice11518.B` matches more than one template declaration:
-fail_compilation/ice11518.d(12):     `B(T : A!T)`
-and
-fail_compilation/ice11518.d(13):     `B(T : A!T)`
+fail_compilation/ice11518.d(12):        `B(T : A!T)`
+fail_compilation/ice11518.d(13):        `B(T : A!T)`
 ---
 */
+
 
 class A(T) {}
 class B(T : A!T) {}

--- a/compiler/test/fail_compilation/ice11518.d
+++ b/compiler/test/fail_compilation/ice11518.d
@@ -1,13 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11518.d(18): Error: class `ice11518.B` matches more than one template declaration:
-fail_compilation/ice11518.d(13):        `B(T : A!T)`
+fail_compilation/ice11518.d(17): Error: class `ice11518.B` matches more than one template declaration:
+fail_compilation/ice11518.d(12):        `B(T : A!T)`
 and:
-fail_compilation/ice11518.d(14):        `B(T : A!T)`
+fail_compilation/ice11518.d(13):        `B(T : A!T)`
 ---
 */
-
 
 class A(T) {}
 class B(T : A!T) {}

--- a/compiler/test/fail_compilation/ice11518.d
+++ b/compiler/test/fail_compilation/ice11518.d
@@ -1,9 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11518.d(17): Error: class `ice11518.B` matches more than one template declaration:
-fail_compilation/ice11518.d(12):        `B(T : A!T)`
+fail_compilation/ice11518.d(18): Error: class `ice11518.B` matches more than one template declaration:
 fail_compilation/ice11518.d(13):        `B(T : A!T)`
+and:
+fail_compilation/ice11518.d(14):        `B(T : A!T)`
 ---
 */
 

--- a/compiler/test/fail_compilation/main.d
+++ b/compiler/test/fail_compilation/main.d
@@ -1,0 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/main.d(9): Error: only one entry point `main`$?:windows=, `WinMain` or `DllMain`$ is allowed
+fail_compilation/main.d(8):        previously found `void main()` here
+---
+*/
+void main() {}
+void main(string[] args) {}

--- a/compiler/test/fail_compilation/testOpApply.d
+++ b/compiler/test/fail_compilation/testOpApply.d
@@ -48,9 +48,9 @@ void testSameAttr() @system
 TEST_OUTPUT:
 ---
 fail_compilation/testOpApply.d(217): Error: `sa.opApply` matches more than one declaration:
-`fail_compilation/testOpApply.d(203)`:     `int(int delegate(int) dg)`
+fail_compilation/testOpApply.d(203):        `int(int delegate(int) dg)`
 and:
-`fail_compilation/testOpApply.d(208)`:     `int(int delegate(string) dg)`
+fail_compilation/testOpApply.d(208):        `int(int delegate(string) dg)`
 fail_compilation/testOpApply.d(217): Error: cannot uniquely infer `foreach` argument types
 ---
 +/
@@ -79,9 +79,9 @@ void testDifferentTypes()
 TEST_OUTPUT:
 ---
 fail_compilation/testOpApply.d(317): Error: `sa.opApply` matches more than one declaration:
-`fail_compilation/testOpApply.d(303)`:     `int(int delegate(int) dg)`
+fail_compilation/testOpApply.d(303):        `int(int delegate(int) dg)`
 and:
-`fail_compilation/testOpApply.d(308)`:     `int(int delegate(long) dg)`
+fail_compilation/testOpApply.d(308):        `int(int delegate(long) dg)`
 fail_compilation/testOpApply.d(317): Error: cannot uniquely infer `foreach` argument types
 ---
 +/
@@ -112,9 +112,9 @@ See https://issues.dlang.org/show_bug.cgi?id=21683
 TEST_OUTPUT:
 ---
 fail_compilation/testOpApply.d(420): Error: `sa.opApply` matches more than one declaration:
-`fail_compilation/testOpApply.d(404)`:     `int(int delegate(int) dg)`
+fail_compilation/testOpApply.d(404):        `int(int delegate(int) dg)`
 and:
-`fail_compilation/testOpApply.d(410)`:     `int(int delegate(ref int) dg)`
+fail_compilation/testOpApply.d(410):        `int(int delegate(ref int) dg)`
 fail_compilation/testOpApply.d(420): Error: cannot uniquely infer `foreach` argument types
 ---
 +/
@@ -146,9 +146,9 @@ void testDifferentQualifiers()
 TEST_OUTPUT:
 ---
 fail_compilation/testOpApply.d(504): Error: `sa.opApply` matches more than one declaration:
-`fail_compilation/testOpApply.d(404)`:     `int(int delegate(int) dg)`
+fail_compilation/testOpApply.d(404):        `int(int delegate(int) dg)`
 and:
-`fail_compilation/testOpApply.d(410)`:     `int(int delegate(ref int) dg)`
+fail_compilation/testOpApply.d(410):        `int(int delegate(ref int) dg)`
 fail_compilation/testOpApply.d(504): Error: cannot uniquely infer `foreach` argument types
 ---
 +/


### PR DESCRIPTION
Adds missing test cases for:
* more than one entry point
* goto skips variable declaration errors.