### PR TITLE
[stable] Make enum function a deprecation, not an error

### DIFF
--- a/changelog/dmd.enum-function.dd
+++ b/changelog/dmd.enum-function.dd
@@ -1,0 +1,3 @@
+A function with enum storage class is now deprecated, not an error
+
+The error was introduced in 2.105.0.

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4581,8 +4581,10 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             }
             else if (t.ty == Tfunction)
             {
+                /* @@@DEPRECATED_2.105.1@@@
+                 * change to error */
                 if (storage_class & STC.manifest)
-                    error("function cannot have enum storage class");
+                    deprecation("function cannot have enum storage class");
 
                 AST.Expression constraint = null;
                 //printf("%s funcdecl t = %s, storage_class = x%lx\n", loc.toChars(), t.toChars(), storage_class);

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4581,8 +4581,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             }
             else if (t.ty == Tfunction)
             {
-                /* @@@DEPRECATED_2.105.1@@@
-                 * change to error */
+                /* @@@DEPRECATED_2.115@@@
+                 * change to error, deprecated in 2.105.1 */
                 if (storage_class & STC.manifest)
                     deprecation("function cannot have enum storage class");
 

--- a/compiler/test/fail_compilation/enum_function.d
+++ b/compiler/test/fail_compilation/enum_function.d
@@ -1,10 +1,11 @@
 /*
+REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/enum_function.d(10): Error: function cannot have enum storage class
-fail_compilation/enum_function.d(11): Error: function cannot have enum storage class
-fail_compilation/enum_function.d(12): Error: function cannot have enum storage class
-fail_compilation/enum_function.d(13): Error: function cannot have enum storage class
+fail_compilation/enum_function.d(11): Deprecation: function cannot have enum storage class
+fail_compilation/enum_function.d(12): Deprecation: function cannot have enum storage class
+fail_compilation/enum_function.d(13): Deprecation: function cannot have enum storage class
+fail_compilation/enum_function.d(14): Deprecation: function cannot have enum storage class
 ---
 */
 enum void f1() { return; }


### PR DESCRIPTION
The error broke `btdu` - see: https://github.com/dlang/dmd/pull/15405#issuecomment-1673888184

@CyberShadow 