### PR TITLE
Fix Issue 17541 - @safe/pure/nothrow attribute deduction depends on c…

### DIFF
--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1510,6 +1510,12 @@ extern (C++) class FuncDeclaration : Declaration
      */
     extern (D) final bool setImpure(Loc loc = Loc.init, const(char)* fmt = null, RootObject arg0 = null)
     {
+        if (purityInprocess && semanticRun < PASS.semantic3 && _scope)
+        {
+            this.semantic2(_scope);
+            this.semantic3(_scope);
+        }
+
         if (purityInprocess)
         {
             purityInprocess = false;
@@ -1572,6 +1578,12 @@ extern (C++) class FuncDeclaration : Declaration
         bool gag = false, Loc loc = Loc.init, const(char)* fmt = null,
         RootObject arg0 = null, RootObject arg1 = null, RootObject arg2 = null)
     {
+        if (safetyInprocess && semanticRun < PASS.semantic3 && _scope)
+        {
+            this.semantic2(_scope);
+            this.semantic3(_scope);
+        }
+
         if (safetyInprocess)
         {
             safetyInprocess = false;
@@ -1677,9 +1689,16 @@ extern (C++) class FuncDeclaration : Declaration
      */
     extern (D) final void setThrow(Loc loc, const(char)* fmt, RootObject arg0 = null)
     {
-        if (nothrowInprocess && !nothrowViolation)
+        if (nothrowInprocess)
         {
-            nothrowViolation = new AttributeViolation(loc, fmt, arg0); // action that requires GC
+            if (semanticRun < PASS.semantic3 && _scope)
+            {
+                this.semantic2(_scope);
+                this.semantic3(_scope);
+            }
+
+            if (nothrowInprocess && !nothrowViolation)
+                nothrowViolation = new AttributeViolation(loc, fmt, arg0); // action that requires GC
         }
     }
 

--- a/compiler/test/compilable/imports/test17541_2.d
+++ b/compiler/test/compilable/imports/test17541_2.d
@@ -15,6 +15,7 @@ struct TWOR(size_t M)
 
     void open()
     {
+        BB bb;
         bb.foo();
     }
 }

--- a/compiler/test/compilable/imports/test17541_3.d
+++ b/compiler/test/compilable/imports/test17541_3.d
@@ -1,6 +1,6 @@
 module three;
 
-void aaa() @nogc
+void aaa() pure @safe @nogc nothrow
 {
 
 }

--- a/compiler/test/compilable/test17541.d
+++ b/compiler/test/compilable/test17541.d
@@ -20,9 +20,8 @@ struct BB
     }
 }
 
-BB bb;
-
-@nogc bar()
+pure @safe @nogc nothrow bar()
 {
+    BB bb;
     bb.foo();
 }


### PR DESCRIPTION
…ompile invocation

A reboot of #10959 follow-up plus implementation for `nothrow`.