### PR TITLE
doc.d: move file writes to caller

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6501,7 +6501,7 @@ struct ModuleDeclaration final
 
 extern void getLocalClasses(Module* mod, Array<ClassDeclaration* >& aclasses);
 
-extern void gendocfile(Module* m, const char* const ddoctext_ptr, size_t ddoctext_length, const char* const datetime, ErrorSink* eSink);
+extern void gendocfile(Module* m, const char* const ddoctext_ptr, size_t ddoctext_length, const char* const datetime, ErrorSink* eSink, OutBuffer& outbuf);
 
 struct Scope final
 {

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -378,6 +378,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
 
     // Parse files
     bool anydocfiles = false;
+    OutBuffer ddocOutputText;
     size_t filecount = modules.length;
     for (size_t filei = 0, modi = 0; filei < filecount; filei++, modi++)
     {
@@ -410,7 +411,13 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
             anydocfiles = true;
             if (!ddocbufIsRead)
                 readDdocFiles(m.loc, global.params.ddoc.files, ddocbuf);
-            gendocfile(m, ddocbuf[], global.datetime.ptr, global.errorSink);
+
+            ddocOutputText.setsize(0);
+            gendocfile(m, ddocbuf[], global.datetime.ptr, global.errorSink, ddocOutputText);
+
+            if (!writeFile(m.loc, m.docfile.toString(), ddocOutputText[]))
+                fatal();
+
             // Remove m from list of modules
             modules.remove(modi);
             modi--;
@@ -578,7 +585,12 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         {
             if (!ddocbufIsRead)
                 readDdocFiles(m.loc, global.params.ddoc.files, ddocbuf);
-            gendocfile(m, ddocbuf[], global.datetime.ptr, global.errorSink);
+
+            ddocOutputText.setsize(0);
+            gendocfile(m, ddocbuf[], global.datetime.ptr, global.errorSink, ddocOutputText);
+
+            if (!writeFile(m.loc, m.docfile.toString(), ddocOutputText[]))
+                fatal();
         }
     }
     if (params.vcg_ast)


### PR DESCRIPTION
By doing this:

1. gendocfile is relieved of any need for dealing with files and can concentrate on just generating the ddoc text
2. the buffer memory can be recycled instead of free'd and alloc'd again
3. the error handling is now the caller's problem
4. doc.d doesn't need to import errors.d anymore
5. the caller can now decide what to do with the generated output