### PR TITLE
remove file name handling from lib.d

### DIFF
--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -97,7 +97,25 @@ void generateCodeAndWrite(Module[] modules, const(char)*[] libmodules,
     if (writeLibrary)
     {
         library = Library.factory(target.objectFormat(), target.lib_ext, eSink);
-        library.setFilename(objdir, libname);
+
+        /* Determine actual file name of library to write to by combining
+         * objdir, libname, the first object file name, and lib_ext
+         */
+        const(char)[] arg;
+        if (!libname.length)
+        {
+            // get name of the first object file
+            const(char)[] n = global.params.objfiles[0].toDString;
+            n = FileName.name(n);                // remove its path
+            arg = FileName.forceExt(n, library.lib_ext); // force library name extension
+        }
+        else
+            arg = FileName.defaultExt(libname, library.lib_ext);
+        if (!FileName.absolute(arg))
+            arg = FileName.combine(objdir, arg);
+
+        library.setFilename(arg);
+
         // Add input object and input library files to output library
         foreach (p; libmodules)
             library.addObject(p.toDString(), null);

--- a/compiler/src/dmd/lib.d
+++ b/compiler/src/dmd/lib.d
@@ -13,23 +13,16 @@
 module dmd.lib;
 
 import core.stdc.stdio;
-import core.stdc.stdarg;
-
-import dmd.globals;
-import dmd.location;
-import dmd.errorsink;
-import dmd.target : Target;
-import dmd.utils;
 
 import dmd.common.outbuffer;
-import dmd.root.file;
-import dmd.root.filename;
-import dmd.root.string;
+import dmd.errorsink;
+import dmd.location;
+import dmd.target : Target;
 
-import dmd.libomf;
-import dmd.libmscoff;
 import dmd.libelf;
 import dmd.libmach;
+import dmd.libmscoff;
+import dmd.libomf;
 
 private enum LOG = false;
 
@@ -59,34 +52,26 @@ class Library
 
 
     /***********************************
-     * Set the library file name based on the output directory
-     * and the filename.
-     * Add default library file name extension.
+     * Set library file name
      * Params:
-     *  dir = path to file
-     *  filename = name of file relative to `dir`
+     *  filename = name of library file
      */
-    final void setFilename(const(char)[] dir, const(char)[] filename)
+    final void setFilename(const char[] filename)
     {
         static if (LOG)
         {
-            printf("LibElf::setFilename(dir = '%.*s', filename = '%.*s')\n",
-                   cast(int)dir.length, dir.ptr, cast(int)filename.length, filename.ptr);
+            printf("LibElf::setFilename(filename = '%.*s')\n",
+                   cast(int)filename.length, filename.ptr);
         }
-        const(char)[] arg = filename;
-        if (!arg.length)
-        {
-            // Generate lib file name from first obj name
-            const(char)[] n = global.params.objfiles[0].toDString;
-            n = FileName.name(n);
-            arg = FileName.forceExt(n, lib_ext);
-        }
-        if (!FileName.absolute(arg))
-            arg = FileName.combine(dir, arg);
 
-        loc = Loc(FileName.defaultExt(arg, lib_ext).ptr, 0, 0);
+        loc = Loc(filename.ptr, 0, 0);
     }
 
+    /*************
+     * Retrieve library file name
+     * Returns:
+     *  filename = name of library file
+     */
     final const(char)* getFilename() const
     {
         return loc.filename;

--- a/compiler/src/dmd/libelf.d
+++ b/compiler/src/dmd/libelf.d
@@ -25,13 +25,11 @@ version (Windows)
     import core.sys.windows.stat;
 }
 
-import dmd.globals;
 import dmd.lib;
 import dmd.location;
 import dmd.utils;
 
 import dmd.root.array;
-import dmd.root.file;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.port;

--- a/compiler/src/dmd/libmach.d
+++ b/compiler/src/dmd/libmach.d
@@ -27,13 +27,11 @@ version (Windows)
     import core.sys.windows.stat;
 }
 
-import dmd.globals;
 import dmd.lib;
 import dmd.location;
 import dmd.utils;
 
 import dmd.root.array;
-import dmd.root.file;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.port;

--- a/compiler/src/dmd/libmscoff.d
+++ b/compiler/src/dmd/libmscoff.d
@@ -33,7 +33,6 @@ import dmd.location;
 import dmd.utils;
 
 import dmd.root.array;
-import dmd.root.file;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.port;

--- a/compiler/src/dmd/libomf.d
+++ b/compiler/src/dmd/libomf.d
@@ -16,13 +16,11 @@ import core.stdc.string;
 import core.stdc.stdlib;
 import core.bitop;
 
-import dmd.globals;
 import dmd.utils;
 import dmd.lib;
 import dmd.location;
 
 import dmd.root.array;
-import dmd.root.file;
 import dmd.root.filename;
 import dmd.root.rmem;
 import dmd.common.outbuffer;


### PR DESCRIPTION
and added it to glue.d, where it fits better. Straightened out the logic in constructing the file name.

Seeing the shrink in the number of imports needed tells the tale. Even with adding documentation, the amount of code shrunk, too.