### PR TITLE
Fix Issue 24088 - Nested functions using the shortened syntax were no…

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -7562,7 +7562,7 @@ LagainStc:
                 }
                 continue;
 
-            // Valid tokens that follow a declaration
+            // Valid tokens that follow the start of a declaration
             case TOK.rightParenthesis:
             case TOK.rightBracket:
             case TOK.assign:
@@ -7580,6 +7580,23 @@ LagainStc:
                     return true;
                 }
                 return false;
+
+            // To recognize the shortened function declaration syntax
+            case TOK.goesTo:
+                /*
+                    1. https://issues.dlang.org/show_bug.cgi?id=24088
+
+                    2. We need to make sure the would-be
+                       declarator has an identifier otherwise function literals
+                       are handled incorrectly. Some special treatment is required
+                       here, it turns out that a lot of code in the compiler relies
+                       on this mess (in the parser), i.e. having isDeclarator be more
+                       precise the parsing of other things go kaboom, so we do it in a
+                       separate case.
+                */
+                if (*haveId)
+                    goto case TOK.do_;
+                goto default;
 
             case TOK.identifier:
                 if (t.ident == Id._body)

--- a/compiler/test/compilable/shortened_methods.d
+++ b/compiler/test/compilable/shortened_methods.d
@@ -27,7 +27,12 @@ string test() => "hello"; // works at any scope
 static assert(test() == "hello"); // works normally
 static assert(is(typeof(&test) == string function())); // same normal type
 
+struct S(T) {}
+
 void func() {
     int a;
     int nested() => a; // and at nested scopes too
+
+    // Issue 24088 - https://issues.dlang.org/show_bug.cgi?id=24088
+    S!int f() => S!int();
 }


### PR DESCRIPTION
…t recognized correctly as declarations.

The fix was simply to amend `isDeclarator` to look for TOK.goesTo (i.e. `=>`)