### PR TITLE
Fix Issue 24078 - Fold constants on array concatenation only for strings

### DIFF
--- a/compiler/test/runnable/test24078.d
+++ b/compiler/test/runnable/test24078.d
@@ -1,0 +1,6 @@
+//https://issues.dlang.org/show_bug.cgi?id=24078
+
+void main()
+{
+    assert(["c"] ~ "a" ~ "b" == ["c", "a", "b"]);
+}


### PR DESCRIPTION
Without this limitation, the code could incorrectly concatenate `["c"] ~ "a" ~ "b"` as `["c"] ~ "ab"`, which was incorrect.