### PR TITLE
ImportC: better diagnostic for malformed __declspec

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -3298,8 +3298,10 @@ final class CParser(AST) : Parser!AST
                 nextToken();
             else
             {
-                error("extended-decl-modifier expected");
-                break;
+                error("extended-decl-modifier expected after `__declspec(`, saw `%s` instead", token.toChars());
+                nextToken();
+                if (token.value != TOK.rightParenthesis)
+                    break;
             }
         }
     }

--- a/compiler/test/fail_compilation/msg24094.c
+++ b/compiler/test/fail_compilation/msg24094.c
@@ -1,0 +1,7 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/msg24094.c(7): Error: extended-decl-modifier expected after `__declspec(`, saw `*` instead
+---
+*/
+
+__declspec(*) void* __cdecl _calloc_base(int, int);


### PR DESCRIPTION
Inspired by https://issues.dlang.org/show_bug.cgi?id=24094