### PR TITLE
[stable] druntime: Fix malloc-leaks in ModuleGroup.sortCtors()

### DIFF
--- a/druntime/src/rt/minfo.d
+++ b/druntime/src/rt/minfo.d
@@ -267,10 +267,16 @@ struct ModuleGroup
                             edge[nEdges++] = *impidx;
                     }
                 }
-                // trim space to what is needed.
-                edges[i] = nEdges > 0
-                    ? (cast(int*)realloc(edge, int.sizeof * nEdges))[0 .. nEdges]
-                    : null;
+                if (nEdges > 0)
+                {
+                    // trim space to what is needed
+                    edges[i] = (cast(int*)realloc(edge, int.sizeof * nEdges))[0 .. nEdges];
+                }
+                else
+                {
+                    edges[i] = null;
+                    .free(edge);
+                }
             }
         }
 


### PR DESCRIPTION
I guess the recent removal of module constructors in druntime has brought these to light, for a little LDC ASan smoke test, which newly complains with D v2.105, e.g.:

> Direct leak of 78624 byte(s) in 126 object(s) allocated from:
>     #0 0x55606978c40d in malloc /local/mnt/workspace/tmp/final/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
>     #1 0x5560698050b1 in _D2rt5minfo11ModuleGroup9sortCtorsMFNbAyaZv