### PR TITLE
Deprecate the DRT Windows-specific versions of ODBC.

### DIFF
--- a/druntime/src/core/sys/windows/sql.d
+++ b/druntime/src/core/sys/windows/sql.d
@@ -1,4 +1,10 @@
+// @@@DEPRECATED_2.112@@@
+
 /**
+$(RED Warning:
+      This module is deprecated. It will be removed in 2.112.
+      Use `etc.c.odbc.sql` instead.)
+
  * Windows API header module
  *
  * Translated from MinGW Windows headers
@@ -6,6 +12,8 @@
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source: $(DRUNTIMESRC core/sys/windows/_sql.d)
  */
+ 
+deprecated("Import etc.c.odbc.sql instead.")
 module core.sys.windows.sql;
 version (Windows):
 

--- a/druntime/src/core/sys/windows/sql.d
+++ b/druntime/src/core/sys/windows/sql.d
@@ -1,9 +1,6 @@
-// @@@DEPRECATED_2.112@@@
-
 /**
 $(RED Warning:
-      This module is deprecated. It will be removed in 2.112.
-      Use `etc.c.odbc.sql` instead.)
+      This binding is out-of-date and does not allow use on non-Windows platforms. Use `etc.c.odbc.sql` instead.)
 
  * Windows API header module
  *
@@ -13,7 +10,6 @@ $(RED Warning:
  * Source: $(DRUNTIMESRC core/sys/windows/_sql.d)
  */
 
-deprecated("Import etc.c.odbc.sql instead.")
 module core.sys.windows.sql;
 version (Windows):
 

--- a/druntime/src/core/sys/windows/sql.d
+++ b/druntime/src/core/sys/windows/sql.d
@@ -12,7 +12,7 @@ $(RED Warning:
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source: $(DRUNTIMESRC core/sys/windows/_sql.d)
  */
- 
+
 deprecated("Import etc.c.odbc.sql instead.")
 module core.sys.windows.sql;
 version (Windows):

--- a/druntime/src/core/sys/windows/sqlext.d
+++ b/druntime/src/core/sys/windows/sqlext.d
@@ -1,4 +1,10 @@
+// @@@DEPRECATED_2.112@@@
+
 /**
+$(RED Warning:
+      This module is deprecated. It will be removed in 2.112.
+      Use `etc.c.odbc.sqlext` instead.)
+
  * Windows API header module
  *
  * Translated from MinGW Windows headers
@@ -6,6 +12,8 @@
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source: $(DRUNTIMESRC core/sys/windows/_sqlext.d)
  */
+
+deprecated("Import etc.c.odbc.sqlext instead.")
 module core.sys.windows.sqlext;
 version (Windows):
 

--- a/druntime/src/core/sys/windows/sqlext.d
+++ b/druntime/src/core/sys/windows/sqlext.d
@@ -1,9 +1,6 @@
-// @@@DEPRECATED_2.112@@@
-
 /**
 $(RED Warning:
-      This module is deprecated. It will be removed in 2.112.
-      Use `etc.c.odbc.sqlext` instead.)
+      This binding is out-of-date and does not allow use on non-Windows platforms. Use `etc.c.odbc.sqlext` instead.)
 
  * Windows API header module
  *
@@ -13,7 +10,6 @@ $(RED Warning:
  * Source: $(DRUNTIMESRC core/sys/windows/_sqlext.d)
  */
 
-deprecated("Import etc.c.odbc.sqlext instead.")
 module core.sys.windows.sqlext;
 version (Windows):
 

--- a/druntime/src/core/sys/windows/sqltypes.d
+++ b/druntime/src/core/sys/windows/sqltypes.d
@@ -1,9 +1,6 @@
-// @@@DEPRECATED_2.112@@@
-
 /**
 $(RED Warning:
-      This module is deprecated. It will be removed in 2.112.
-      Use `etc.c.odbc.sqltypes` instead.)
+      This binding is out-of-date and does not allow use on non-Windows platforms. Use `etc.c.odbc.sqltypes` instead.)
 
  * Windows API header module
  *
@@ -13,7 +10,6 @@ $(RED Warning:
  * Source: $(DRUNTIMESRC core/sys/windows/_sqltypes.d)
  */
 
-deprecated("Import etc.c.odbc.sqltypes instead.")
 module core.sys.windows.sqltypes;
 version (Windows):
 

--- a/druntime/src/core/sys/windows/sqltypes.d
+++ b/druntime/src/core/sys/windows/sqltypes.d
@@ -1,4 +1,10 @@
+// @@@DEPRECATED_2.112@@@
+
 /**
+$(RED Warning:
+      This module is deprecated. It will be removed in 2.112.
+      Use `etc.c.odbc.sqltypes` instead.)
+
  * Windows API header module
  *
  * Translated from MinGW Windows headers
@@ -6,6 +12,8 @@
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source: $(DRUNTIMESRC core/sys/windows/_sqltypes.d)
  */
+
+deprecated("Import etc.c.odbc.sqltypes instead.")
 module core.sys.windows.sqltypes;
 version (Windows):
 

--- a/druntime/src/core/sys/windows/sqlucode.d
+++ b/druntime/src/core/sys/windows/sqlucode.d
@@ -1,9 +1,6 @@
-// @@@DEPRECATED_2.112@@@
-
 /**
 $(RED Warning:
-      This module is deprecated. It will be removed in 2.112.
-      Use `etc.c.odbc.sqlucode` instead.)
+      This binding is out-of-date and does not allow use on non-Windows platforms. Use `etc.c.odbc.sqlucode` instead.)
 
  * Windows API header module
  *
@@ -13,7 +10,6 @@ $(RED Warning:
  * Source: $(DRUNTIMESRC core/sys/windows/_sqlucode.d)
  */
 
-deprecated("Import etc.c.odbc.sqlucode instead.")
 module core.sys.windows.sqlucode;
 version (Windows):
 

--- a/druntime/src/core/sys/windows/sqlucode.d
+++ b/druntime/src/core/sys/windows/sqlucode.d
@@ -1,4 +1,10 @@
+// @@@DEPRECATED_2.112@@@
+
 /**
+$(RED Warning:
+      This module is deprecated. It will be removed in 2.112.
+      Use `etc.c.odbc.sqlucode` instead.)
+
  * Windows API header module
  *
  * Translated from MinGW Windows headers
@@ -6,6 +12,8 @@
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source: $(DRUNTIMESRC core/sys/windows/_sqlucode.d)
  */
+
+deprecated("Import etc.c.odbc.sqlucode instead.")
 module core.sys.windows.sqlucode;
 version (Windows):
 


### PR DESCRIPTION
ODBC is supported on all major OSes and should not be limited to Windows in D. Furthermore, Database access interfaces are never appropriate in the Runtime.

Related to and supersedes: https://github.com/dlang/phobos/pull/8748
Pairs with: https://github.com/dlang/phobos/pull/8804