### PR TITLE
Add WinAPI Annotations to importc.h

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -125,23 +125,8 @@
 #define __unaligned
 #define _NO_CRT_STDIO_INLINE 1
 
-// Windows API Annotations - This may be incomplete
-#define _Inexpressible_
-#define _In_
-#define _In_opt_
-#define _In_reads_(x)
-#define _In_reads_opt_(x)
-#define _In_reads_bytes_opt_(x)
-#define _Inout_
-#define _Inout_opt_
-#define _Inout_updates_opt_(x)
-#define _Inout_updates_bytes_opt_(x)
-#define _Out_
-#define _Out_opt_
-#define _Out_writes_(x)
-#define _Out_writes_opt_(x)
-#define _Out_writes_bytes_opt_(x)
-#define _Success_(x)
+// This header disables the Windows API Annotations macros
+#include "no_sal2.h"
 #endif
 
 /****************************

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -132,7 +132,7 @@
 #define _In_reads_(x)
 #define _In_reads_opt_(x)
 #define _In_reads_bytes_opt_(x)
-#define _Inout_ 
+#define _Inout_
 #define _Inout_opt_
 #define _Inout_updates_opt_(x)
 #define _Inout_updates_bytes_opt_(x)

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -124,6 +124,24 @@
 #define __ptr64
 #define __unaligned
 #define _NO_CRT_STDIO_INLINE 1
+
+// Windows API Annotations - This may be incomplete
+#define _Inexpressible_
+#define _In_
+#define _In_opt_
+#define _In_reads_(x)
+#define _In_reads_opt_(x)
+#define _In_reads_bytes_opt_(x)
+#define _Inout_ 
+#define _Inout_opt_
+#define _Inout_updates_opt_(x)
+#define _Inout_updates_bytes_opt_(x)
+#define _Out_
+#define _Out_opt_
+#define _Out_writes_(x)
+#define _Out_writes_opt_(x)
+#define _Out_writes_bytes_opt_(x)
+#define _Success_(x)
 #endif
 
 /****************************

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -126,6 +126,8 @@
 #define _NO_CRT_STDIO_INLINE 1
 
 // This header disables the Windows API Annotations macros
+// Need to include sal.h to get the pragma once to prevent macro redefinition.
+#include "sal.h"
 #include "no_sal2.h"
 #endif
 

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -115,8 +115,6 @@
 #endif
 
 #if _MSC_VER
-//#undef _Post_writable_size
-//#define _Post_writable_size(x) // consider #include <no_sal2.h>
 #define _CRT_INSECURE_DEPRECATE(x)
 #define _CRT_NONSTDC_NO_DEPRECATE 1
 #define _CRT_SECURE_NO_WARNINGS 1


### PR DESCRIPTION
This is incomplete but sufficient to pass the canonical ODBC headers from Microsoft. Based on the reference docs here: https://learn.microsoft.com/en-us/windows/win32/winprog/header-annotations