### PR TITLE
Add building dmd with dub

### DIFF
--- a/.github/workflows/build_with_dub.yml
+++ b/.github/workflows/build_with_dub.yml
@@ -1,0 +1,21 @@
+name: Build D compiler using dub
+
+on:
+  - pull_request
+  - push
+
+jobs:
+    test:
+        name: Build D compiler using dub
+        strategy:
+            matrix:
+                os: [ubuntu-latest, windows-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Install Host D compiler
+              uses: dlang-community/setup-dlang@v1.3.0
+
+            - name: Invoke dub
+              run: dub run dmd:compiler -- --version

--- a/.github/workflows/build_with_dub.yml
+++ b/.github/workflows/build_with_dub.yml
@@ -12,10 +12,10 @@ jobs:
                 os: [ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Install Host D compiler
-              uses: dlang-community/setup-dlang@v1.3.0
+              uses: dlang-community/setup-dlang@v1
 
             - name: Invoke dub
               run: dub run dmd:compiler -- --version

--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ Refer to their respective `README.md` for more in-depth information.
 | [compiler/samples](compiler/samples) | Various code examples                             |
 | [druntime](druntime)                 | root of all runtime related code                  |
 
-For more general information regarding compiling, installing, and
+With a D compiler and dub installed, dmd can be built with:
+
+```
+dub build dmd:compiler
+```
+
+For more information regarding compiling, installing, and
 hacking on DMD, check the [contribution guide](CONTRIBUTING.md) and
 visit the [D Wiki](https://wiki.dlang.org/DMD).
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -8,6 +8,17 @@ targetType "none"
 dependency ":frontend" version="*"
 
 subPackage {
+  name "compiler"
+  targetType "executable"
+  targetName "dmd"
+  sourcePaths "compiler/src/dmd"
+  importPaths "compiler/src"
+  stringImportPaths "compiler/src/dmd/res" "."
+  dflags "-L/STACK:16777216" platform="windows"
+  preGenerateCommands "echo -n /etc > SYSCONFDIR.imp" platform="posix"
+}
+
+subPackage {
   name "root"
   targetType "library"
   importPaths "compiler/src"


### PR DESCRIPTION
Proof of concept, based on my DConf 23 lightning talk.

I don't want this to be a subpackage, but I presume removing the default 'targetType: none' and frontend dependency will break using dmd as a library by depending on "dmd". 

Works on my Windows machine, I still need to test on Posix and add to CI.