### PR TITLE
Fix Issue 24110 - [REG2.104] Array comparison lowering apparently not handled properly in __traits(compiles) 

### DIFF
--- a/compiler/test/compilable/test24110.d
+++ b/compiler/test/compilable/test24110.d
@@ -1,0 +1,6 @@
+// https://issues.dlang.org/show_bug.cgi?id=24110
+
+struct S { int x; }
+alias T = shared S;
+static assert(__traits(compiles, (T[] a, T[] b) => a < b));
+bool foo(T[] a, T[] b) { return a < b; }

--- a/druntime/src/core/internal/array/comparison.d
+++ b/druntime/src/core/internal/array/comparison.d
@@ -123,7 +123,7 @@ if (!__traits(isScalar, T1) && !__traits(isScalar, T2))
             // https://issues.dlang.org/show_bug.cgi?id=17244
             static assert(is(U1 == U2), "Internal error.");
             import core.stdc.string : memcmp;
-            auto c = (() @trusted => memcmp(&at(s1, u), &at(s2, u), U1.sizeof))();
+            auto c = (() @trusted => memcmp(cast(void*)(&at(s1, u)), cast(void*)(&at(s2, u)), U1.sizeof))();
             if (c != 0)
                 return c;
         }


### PR DESCRIPTION
This is an alternative to: https://github.com/dlang/dmd/pull/15575

It fixes druntime to accept the code, however, it casts shared away but that should be fine since technically the user should be synchronizing the access to the array prior to the comparison.

A third approach would be to disallow comparing array of structs that do not define an opCmp as suggested in: https://issues.dlang.org/show_bug.cgi?id=17244 . IMO this would be the best approach, however, that would potentially break code.