### PR TITLE
Fix Issue 24109 - [REG2.103] 'need this' when invoking outer method from inner method

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -1190,6 +1190,11 @@ private bool haveSameThis(FuncDeclaration outerFunc, FuncDeclaration calledFunc)
     if (thisAd == requiredAd)
         return true;
 
+    // if outerfunc is the member of a nested aggregate, then let
+    // getRightThis take care of this.
+    if (thisAd.isNested())
+        return true;
+
     // outerfunc is the member of a base class that contains calledFunc,
     // then we consider that they have the same this.
     auto cd = requiredAd.isClassDeclaration();
@@ -1197,11 +1202,6 @@ private bool haveSameThis(FuncDeclaration outerFunc, FuncDeclaration calledFunc)
         return false;
 
     if (cd.isBaseOf2(thisAd.isClassDeclaration()))
-        return true;
-
-    // if outerfunc is the member of a nested aggregate, then let
-    // getRightThis take care of this.
-    if (thisAd.isNested())
         return true;
 
     return false;

--- a/compiler/test/compilable/test24109.d
+++ b/compiler/test/compilable/test24109.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=24109
+
+struct Outer
+{
+    void method1() {}
+
+    void method2()
+    {
+        class Inner
+        {
+            void innerMethod()
+            {
+                method1();
+            }
+        }
+    }
+}


### PR DESCRIPTION
A slip up on my side when implementing the `haveSameThis` function. It needs to check the case for inheriting classes last because the check on [line 1218](https://github.com/dlang/dmd/pull/15577/files#diff-a556a8e6917dd4042f541bdb19673f96940149ec3d416b0156af4d0e4cc5e4bdR1218) used to eagerly return `false` before the nested check had a chance to return `true`.

cc @kinke @WalterBright 