### PR TITLE
Issue 24118 - ICE / regression from 2.103.1 - segfault on CTFE only code in 2.104.2 and 2.105.0

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11013,7 +11013,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             (exp.e2.isStringExp() && (exp.e1.isIntegerExp() || exp.e1.isStringExp())))
             return exp;
 
-        Identifier hook = global.params.tracegc ? Id._d_arraycatnTXTrace : Id._d_arraycatnTX;
+        bool useTraceGCHook = global.params.tracegc && sc.needsCodegen();
+
+        Identifier hook = useTraceGCHook ? Id._d_arraycatnTXTrace : Id._d_arraycatnTX;
         if (!verifyHookExist(exp.loc, *sc, hook, "concatenating arrays"))
         {
             setError();
@@ -11042,7 +11044,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         auto arguments = new Expressions();
-        if (global.params.tracegc)
+        if (useTraceGCHook)
         {
             auto funcname = (sc.callsc && sc.callsc.func) ?
                 sc.callsc.func.toPrettyChars() : sc.func.toPrettyChars();
@@ -11069,7 +11071,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         /* `_d_arraycatnTX` canot be used with `-betterC`, but `CatExp`s may be
          * used with `-betterC`, but only during CTFE.
          */
-        if (global.params.betterC || !sc.needsCodegen())
+        if (global.params.betterC)
             return;
 
         if (auto ce = exp.isCatExp())

--- a/compiler/test/compilable/test24118.d
+++ b/compiler/test/compilable/test24118.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=24118
+
+void map(alias fun, T)(T[] arr)
+{
+    fun(arr);
+}
+
+
+void foo()
+{
+    if( __ctfe )
+    {
+        ["a", "b", "c"].map!( a => " " ~ a[0] );
+    }
+}


### PR DESCRIPTION
The problem here is that when a lambda is passed to a template instance, the lambda call is inlined in the template instance. The context of the lambda is __ctfe so the compiler decides to not create a lowering for it, however, the template instance is still generated (without the lowering) thus causing the current regression.

A general solution would be to mark template instances as not needing code generation when instantiated from a speculative context, however, this is not easy to implement given the current caching strategy of template instances.

Until we fix that, we need to bail out of not generating the compiler hook call to avoid ices in e2ir.