### PR TITLE
Allow using .ptr in @safe code when pointer is safe to dereference

### DIFF
--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -238,12 +238,11 @@ bool isSafeCast(Expression e, Type tfrom, Type tto)
  */
 bool checkUnsafeDotExp(Scope* sc, Expression e, Identifier id, int flag)
 {
-    if (!(flag & DotExpFlag.noDeref)) // this use is attempting a dereference
-    {
-        if (id == Id.ptr)
-            return sc.setUnsafe(false, e.loc, "`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e, e);
-        else
-            return sc.setUnsafe(false, e.loc, "`%s.%s` cannot be used in `@safe` code", e, id);
-    }
-    return false;
+    if (flag & DotExpFlag.noDeref) // this use is not attempting a dereference
+        return false;
+
+    if (id == Id.ptr)
+        return sc.setUnsafe(false, e.loc, "`(%s).ptr` cannot be used in `@safe` code, use `&(%s)[0]` instead", e, e);
+    else
+        return sc.setUnsafe(false, e.loc, "`(%s).%s` cannot be used in `@safe` code", e, id);
 }

--- a/compiler/test/fail_compilation/test11176.d
+++ b/compiler/test/fail_compilation/test11176.d
@@ -19,7 +19,9 @@ fail_compilation/test11176.d(21): Error: `[].ptr` cannot be used in `@safe` code
 @safe ubyte cool(ubyte[1] b) {
     auto p = "".ptr;
     auto q = [].ptr; // error
-    auto r = [ubyte(1)].ptr;
+    auto r = [b[0]].ptr; // runtime element
+    enum e = [1] ~ 2;
+    auto s = e.ptr;
     return *b.ptr;
 }
 

--- a/compiler/test/fail_compilation/test11176.d
+++ b/compiler/test/fail_compilation/test11176.d
@@ -3,9 +3,9 @@ TEST_OUTPUT:
 ---
 fail_compilation/test11176.d(12): Error: `(b).ptr` cannot be used in `@safe` code, use `&(b)[0]` instead
 fail_compilation/test11176.d(16): Error: `(b).ptr` cannot be used in `@safe` code, use `&(b)[0]` instead
+fail_compilation/test11176.d(21): Error: `[].ptr` cannot be used in `@safe` code
 ---
 */
-
 // https://issues.dlang.org/show_bug.cgi?id=11176
 
 @safe ubyte oops(ubyte[] b) {
@@ -17,5 +17,10 @@ fail_compilation/test11176.d(16): Error: `(b).ptr` cannot be used in `@safe` cod
 }
 
 @safe ubyte cool(ubyte[1] b) {
+    auto p = "".ptr;
+    auto q = [].ptr; // error
+    auto r = [ubyte(1)].ptr;
     return *b.ptr;
 }
+
+@system whatever(int[] a) => a.ptr;

--- a/compiler/test/fail_compilation/test11176.d
+++ b/compiler/test/fail_compilation/test11176.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test11176.d(12): Error: `b.ptr` cannot be used in `@safe` code, use `&b[0]` instead
-fail_compilation/test11176.d(16): Error: `b.ptr` cannot be used in `@safe` code, use `&b[0]` instead
+fail_compilation/test11176.d(12): Error: `(b).ptr` cannot be used in `@safe` code, use `&(b)[0]` instead
+fail_compilation/test11176.d(16): Error: `(b).ptr` cannot be used in `@safe` code, use `&(b)[0]` instead
 ---
 */
 

--- a/compiler/test/fail_compilation/test12822.d
+++ b/compiler/test/fail_compilation/test12822.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/test12822.d(13): Error: cannot modify delegate pointer in `@safe` code `dg.ptr`
-fail_compilation/test12822.d(14): Error: `dg.funcptr` cannot be used in `@safe` code
+fail_compilation/test12822.d(14): Error: `(dg).funcptr` cannot be used in `@safe` code
 ---
 */
 

--- a/compiler/test/fail_compilation/test16365.d
+++ b/compiler/test/fail_compilation/test16365.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/test16365.d(21): Error: `this` reference necessary to take address of member `f1` in `@safe` function `main`
 fail_compilation/test16365.d(23): Error: cannot implicitly convert expression `&f2` of type `void delegate() pure nothrow @nogc @safe` to `void function() @safe`
 fail_compilation/test16365.d(27): Warning: address of variable `s` assigned to `dg` with longer lifetime
-fail_compilation/test16365.d(28): Error: `dg.funcptr` cannot be used in `@safe` code
+fail_compilation/test16365.d(28): Error: `(dg).funcptr` cannot be used in `@safe` code
 ---
 */
 


### PR DESCRIPTION
Also parenthesize LHS expression in error message.
Allow for string literals.
Allow for array literals with length > 0.
~~Allow for compile-time length expression > 0.~~ - couldn't find any tests that needed this.