### PR TITLE
fix Issue 24129 - ImportC: MS-Link cannot handle multiple COMDATs wit…

### DIFF
--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -787,14 +787,16 @@ public void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         return;
     }
 
+    Symbol *s = toSymbol(fd); // may set skipCodegen
+    func_t *f = s.Sfunc;
+    if (fd.skipCodegen) // test it again, as toSymbol() might have set it
+        return;
+
     // start code generation
     fd.semanticRun = PASS.obj;
 
     if (global.params.verbose)
         message("function  %s", fd.toPrettyChars());
-
-    Symbol *s = toSymbol(fd);
-    func_t *f = s.Sfunc;
 
     // tunnel type of "this" to debug info generation
     if (AggregateDeclaration ad = fd.parent.isAggregateDeclaration())

--- a/compiler/test/runnable/extra-files/test24129b.c
+++ b/compiler/test/runnable/extra-files/test24129b.c
@@ -1,0 +1,10 @@
+
+inline int dup()
+{
+    return 73;
+}
+
+void *abc()
+{
+    return &dup;
+}

--- a/compiler/test/runnable/test24129.c
+++ b/compiler/test/runnable/test24129.c
@@ -1,0 +1,19 @@
+/* REQUIRED_ARGS: runnable/extra-files/test24129b.c
+ */
+
+// https:issues.dlang.org/show_bug_cgi?id=24129
+
+inline int dup()
+{
+    return 73;
+}
+
+void *def()
+{
+    return &dup;
+}
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
…h the same name

Took me a while to figure out where to put this tweak. Although it is meant just for MS-LINK, I enabled it for all targets to flush out any bugs in it.