### PR TITLE
Improve error when generating first enum member of non-scalar type

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2528,9 +2528,14 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (!em.ed.isAnonymous())
                     em.ed.memtype = t;
             }
+            const errors = global.startGagging();
             Expression e = new IntegerExp(em.loc, 0, t);
             e = e.ctfeInterpret();
-
+            if (global.endGagging(errors))
+            {
+                error(em.loc, "cannot generate 0 value of type `%s` for `%s`",
+                    t.toChars(), em.toChars());
+            }
             // save origValue for better json output
             em.origValue = e;
 

--- a/compiler/test/fail_compilation/diag7477.d
+++ b/compiler/test/fail_compilation/diag7477.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag7477.d(13): Error: integral constant must be scalar type, not `Foo`
-fail_compilation/diag7477.d(20): Error: integral constant must be scalar type, not `string`
+fail_compilation/diag7477.d(13): Error: cannot generate 0 value of type `Foo` for `a`
+fail_compilation/diag7477.d(20): Error: cannot generate 0 value of type `string` for `a`
 ---
 */
 


### PR DESCRIPTION
Related to Issue 23522 - Error message when enum type is not integral and a value lacks an initializer and #15588.