### PR TITLE
fix Issue 24130 - ImportC: Windows headers use inline asm with differ…

### DIFF
--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -610,7 +610,7 @@ dmd -cov -unittest myprog.d
         Option("nothrow",
             "assume no Exceptions will be thrown",
             `Turns off generation of exception stack unwinding code, enables
-	    more efficient code for RAII objects.`,
+            more efficient code for RAII objects.`,
         ),
         Option("O",
             "optimize",

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -626,7 +626,7 @@ final class CParser(AST) : Parser!AST
 
                 default:
                     // ImportC extensions: parse as a D asm block.
-                    s = parseAsm();
+                    s = parseAsm(compileEnv.masm);
                     break;
             }
             break;

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -780,7 +780,9 @@ extern (C++) final class Module : Package
         {
             filetype = FileType.c;
 
+            global.compileEnv.masm = target.os == Target.OS.Windows && !target.omfobj; // Microsoft inline assembler format
             scope p = new CParser!AST(this, buf, cast(bool) docfile, global.errorSink, target.c, &defines, &global.compileEnv);
+            global.compileEnv.masm = false;
             p.nextToken();
             checkCompiledImport();
             members = p.parseModule();

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3403,6 +3403,7 @@ struct CompileEnv final
     bool ddocOutput;
     bool shortenedMethods;
     bool obsolete;
+    bool masm;
     CompileEnv() :
         versionNumber(),
         date(),
@@ -3412,10 +3413,11 @@ struct CompileEnv final
         previewIn(),
         ddocOutput(),
         shortenedMethods(true),
-        obsolete()
+        obsolete(),
+        masm()
     {
     }
-    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}, bool previewIn = false, bool ddocOutput = false, bool shortenedMethods = true, bool obsolete = false) :
+    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}, bool previewIn = false, bool ddocOutput = false, bool shortenedMethods = true, bool obsolete = false, bool masm = false) :
         versionNumber(versionNumber),
         date(date),
         time(time),
@@ -3424,7 +3426,8 @@ struct CompileEnv final
         previewIn(previewIn),
         ddocOutput(ddocOutput),
         shortenedMethods(shortenedMethods),
-        obsolete(obsolete)
+        obsolete(obsolete),
+        masm(masm)
         {}
 };
 
@@ -4237,6 +4240,7 @@ class AsmStatement : public Statement
 {
 public:
     Token* tokens;
+    bool caseSensitive;
     AsmStatement* syntaxCopy() override;
     void accept(Visitor* v) override;
 };

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -565,10 +565,10 @@ private void genObjFile(Module m, bool multiobj)
 
         outdata(m.cov);
 
-	size_t sz = m.covb[0].sizeof;
-	size_t n = (m.numlines + sz * 8) / (sz * 8);
-	uint* p =  cast(uint*)Mem.check(calloc(n, sz));
-	m.covb = p[0 .. n];
+        size_t sz = m.covb[0].sizeof;
+        size_t n = (m.numlines + sz * 8) / (sz * 8);
+        uint* p =  cast(uint*)Mem.check(calloc(n, sz));
+        m.covb = p[0 .. n];
     }
 
     for (int i = 0; i < m.members.length; i++)

--- a/compiler/src/dmd/iasm.d
+++ b/compiler/src/dmd/iasm.d
@@ -64,6 +64,7 @@ extern(C++) Statement asmSemantic(AsmStatement s, Scope *sc)
             return statementSemantic(se, sc);
         }
         auto ias = new InlineAsmStatement(s.loc, s.tokens);
+        ias.caseSensitive = s.caseSensitive;
         return inlineAsmSemantic(ias, sc);
     }
     else version (IN_GCC)

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -52,6 +52,7 @@ struct CompileEnv
     bool ddocOutput;         /// collect embedded documentation comments
     bool shortenedMethods = true;   /// allow => in normal function declarations
     bool obsolete;           /// warn on use of legacy code
+    bool masm;               /// use MASM inline asm syntax
 }
 
 /***********************************************************

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1958,6 +1958,7 @@ extern (C++) final class LabelDsymbol : Dsymbol
 extern (C++) class AsmStatement : Statement
 {
     Token* tokens;
+    bool caseSensitive;  // for register names
 
     extern (D) this(const ref Loc loc, Token* tokens) @safe
     {

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -712,6 +712,7 @@ class AsmStatement : public Statement
 {
 public:
     Token *tokens;
+    bool caseSensitive;  // for register names
 
     AsmStatement *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/test/compilable/test24130.c
+++ b/compiler/test/compilable/test24130.c
@@ -1,0 +1,18 @@
+/*
+ * DISABLED: freebsd32 freebsd64 linux32 linux64 osx32 osx64 win64 dragonflybsd openbsd
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=24130
+
+void test(int ShiftCount, int Value)
+{
+#ifdef _MSC_VER
+__asm    {
+        mov     ecx, ShiftCount
+        mov     eax, dword ptr [Value]
+        mov     edx, dword ptr [Value+4]
+        shrd    eax, edx, cl
+        shr     edx, cl
+    }
+#endif
+}


### PR DESCRIPTION
…ent syntax

Microsoft inline asm looks like this:
```
    __asm    {
        mov     ecx, ShiftCount
        mov     eax, dword ptr [Value]
        mov     edx, dword ptr [Value+4]
        shrd    eax, edx, cl
        shr     edx, cl
    }
```
Look ma, no semicolons. ImportC's inline asm wants semicolons. Microsoft uses generic C code instead when `_M_CEE_PURE` is set, so we set it, too. The other macros Microsoft uses for generic C code look rather more dangerous to use:
```
#if defined(MIDL_PASS) || defined(RC_INVOKED) || defined(_M_CEE_PURE) \
    || defined(_68K_) || defined(_MPPC_) \
    || defined(_M_IA64) || defined(_M_AMD64) || defined(_M_ARM) || defined(_M_ARM64) \
    || defined(_M_HYBRID_X86_ARM64)
```
