### PR TITLE
Fix isLvalue error message

### DIFF
--- a/compiler/test/fail_compilation/fail10299.d
+++ b/compiler/test/fail_compilation/fail10299.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10299.d(11): Error: `foo!string` is not an lvalue and cannot be modified
+fail_compilation/fail10299.d(11): Error: `foo!string` is not an lvalue
 ---
 */
 

--- a/compiler/test/fail_compilation/fail13116.d
+++ b/compiler/test/fail_compilation/fail13116.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail13116.d(14): Error: returning `this` escapes a reference to parameter `this`
-fail_compilation/fail13116.d(23): Error: `super` is not an lvalue and cannot be modified
+fail_compilation/fail13116.d(23): Error: `super` is not an lvalue
 ---
 */
 struct S

--- a/compiler/test/fail_compilation/fail13336b.d
+++ b/compiler/test/fail_compilation/fail13336b.d
@@ -6,8 +6,8 @@ double sy;
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13336b.d(16): Error: `cast(double)sx` is not an lvalue and cannot be modified
-fail_compilation/fail13336b.d(24): Error: `cast(double)sx` is not an lvalue and cannot be modified
+fail_compilation/fail13336b.d(16): Error: `cast(double)sx` is not an lvalue
+fail_compilation/fail13336b.d(24): Error: `cast(double)sx` is not an lvalue
 ---
 */
 ref f1(bool f)

--- a/compiler/test/fail_compilation/fail17491.d
+++ b/compiler/test/fail_compilation/fail17491.d
@@ -1,13 +1,13 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/fail17491.d(22): Error: `(S17491).init` is not an lvalue and cannot be modified
-fail_compilation/fail17491.d(23): Error: `S17491(0)` is not an lvalue and cannot be modified
+fail_compilation/fail17491.d(23): Error: `S17491(0)` is not an lvalue
 fail_compilation/fail17491.d(25): Error: `S17491(0).field` is not an lvalue and cannot be modified
-fail_compilation/fail17491.d(26): Error: `S17491(0).field` is not an lvalue and cannot be modified
+fail_compilation/fail17491.d(26): Error: `S17491(0).field` is not an lvalue
 fail_compilation/fail17491.d(31): Error: `S17491(0)` is not an lvalue and cannot be modified
-fail_compilation/fail17491.d(32): Error: `S17491(0)` is not an lvalue and cannot be modified
+fail_compilation/fail17491.d(32): Error: `S17491(0)` is not an lvalue
 fail_compilation/fail17491.d(34): Error: `S17491(0).field` is not an lvalue and cannot be modified
-fail_compilation/fail17491.d(35): Error: `S17491(0).field` is not an lvalue and cannot be modified
+fail_compilation/fail17491.d(35): Error: `S17491(0).field` is not an lvalue
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=17491

--- a/compiler/test/fail_compilation/fail6795.d
+++ b/compiler/test/fail_compilation/fail6795.d
@@ -6,8 +6,8 @@ fail_compilation/fail6795.d(19): Error: `[0][0]` is not an lvalue and cannot be 
 fail_compilation/fail6795.d(20): Error: `[0:0][0]` is not an lvalue and cannot be modified
 fail_compilation/fail6795.d(22): Error: `[0][0]` is not an lvalue and cannot be modified
 fail_compilation/fail6795.d(23): Error: `[0:0][0]` is not an lvalue and cannot be modified
-fail_compilation/fail6795.d(25): Error: `[0][0]` is not an lvalue and cannot be modified
-fail_compilation/fail6795.d(26): Error: `[0:0][0]` is not an lvalue and cannot be modified
+fail_compilation/fail6795.d(25): Error: `[0][0]` is not an lvalue
+fail_compilation/fail6795.d(26): Error: `[0:0][0]` is not an lvalue
 ---
 */
 

--- a/compiler/test/fail_compilation/fail7603a.d
+++ b/compiler/test/fail_compilation/fail7603a.d
@@ -1,7 +1,17 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7603a.d(7): Error: `true` is a constant, not an lvalue
+fail_compilation/fail7603a.d(10): Error: `true` is a constant, not an lvalue
+fail_compilation/fail7603a.d(11): Error: `true` is a constant, not an lvalue
+fail_compilation/fail7603a.d(14): Error: `3` is a constant, not an lvalue
+fail_compilation/fail7603a.d(17): Error: `S` is a `struct` definition, not an lvalue
 ---
 */
 void test(ref bool val = true) { }
+void test(out bool val = true) { }
+
+enum x = 3;
+void test(ref int val = x) { }
+
+struct S;
+void test(ref S val = S) { }

--- a/compiler/test/fail_compilation/fail7603a.d
+++ b/compiler/test/fail_compilation/fail7603a.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7603a.d(7): Error: cannot modify constant `true`
+fail_compilation/fail7603a.d(7): Error: `true` is a constant, not an lvalue
 ---
 */
 void test(ref bool val = true) { }

--- a/compiler/test/fail_compilation/fail7603b.d
+++ b/compiler/test/fail_compilation/fail7603b.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7603b.d(7): Error: cannot modify constant `true`
+fail_compilation/fail7603b.d(7): Error: `true` is a constant, not an lvalue
 ---
 */
 void test(out bool val = true) { }

--- a/compiler/test/fail_compilation/fail7603b.d
+++ b/compiler/test/fail_compilation/fail7603b.d
@@ -1,7 +1,0 @@
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail7603b.d(7): Error: `true` is a constant, not an lvalue
----
-*/
-void test(out bool val = true) { }

--- a/compiler/test/fail_compilation/fail7603c.d
+++ b/compiler/test/fail_compilation/fail7603c.d
@@ -1,8 +1,0 @@
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail7603c.d(8): Error: `3` is a constant, not an lvalue
----
-*/
-enum x = 3;
-void test(ref int val = x) { }

--- a/compiler/test/fail_compilation/fail7603c.d
+++ b/compiler/test/fail_compilation/fail7603c.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7603c.d(8): Error: cannot modify constant `3`
+fail_compilation/fail7603c.d(8): Error: `3` is a constant, not an lvalue
 ---
 */
 enum x = 3;

--- a/compiler/test/fail_compilation/fail9537.d
+++ b/compiler/test/fail_compilation/fail9537.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9537.d(26): Error: `foo(tuple(1, 2))` is not an lvalue and cannot be modified
+fail_compilation/fail9537.d(26): Error: `foo(tuple(1, 2))` is not an lvalue
 ---
 */
 

--- a/compiler/test/fail_compilation/fail9773.d
+++ b/compiler/test/fail_compilation/fail9773.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9773.d(7): Error: `""` is not an lvalue and cannot be modified
+fail_compilation/fail9773.d(7): Error: `""` is not an lvalue
 ---
 */
 void f(ref string a = "")

--- a/compiler/test/fail_compilation/fail9891.d
+++ b/compiler/test/fail_compilation/fail9891.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail9891.d(13): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `ref int` of parameter `n`
 fail_compilation/fail9891.d(18): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `out int` of parameter `n`
-fail_compilation/fail9891.d(23): Error: `prop()` is not an lvalue and cannot be modified
+fail_compilation/fail9891.d(23): Error: `prop()` is not an lvalue
 ---
 */
 

--- a/compiler/test/fail_compilation/fail_arrayop2.d
+++ b/compiler/test/fail_compilation/fail_arrayop2.d
@@ -207,7 +207,7 @@ fail_compilation/fail_arrayop2.d(265): Error: array operation `[1] * 6` without 
 fail_compilation/fail_arrayop2.d(268): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(269): Error: array operation `"abc"[] + '\x01'` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(272): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(275): Error: `([1] * 6)[0..2]` is not an lvalue and cannot be modified
+fail_compilation/fail_arrayop2.d(275): Error: `([1] * 6)[0..2]` is not an lvalue
 fail_compilation/fail_arrayop2.d(278): Error: can only `*` a pointer, not a `int[]`
 fail_compilation/fail_arrayop2.d(281): Error: the `delete` keyword is obsolete
 fail_compilation/fail_arrayop2.d(281):        use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead

--- a/compiler/test/fail_compilation/failcstuff2.c
+++ b/compiler/test/fail_compilation/failcstuff2.c
@@ -1,21 +1,21 @@
 // check semantic analysis of C files
 /* TEST_OUTPUT:
 ---
-fail_compilation/failcstuff2.c(113): Error: `cast(int)var` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(113): Error: `cast(int)var` is not an lvalue
 fail_compilation/failcstuff2.c(114): Error: `sizeof` is not a member of `int`
 fail_compilation/failcstuff2.c(115): Error: `cast(short)3` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(116): Error: cannot modify constant `4`
-fail_compilation/failcstuff2.c(117): Error: cannot modify constant `5`
-fail_compilation/failcstuff2.c(118): Error: cannot modify constant `6`
-fail_compilation/failcstuff2.c(119): Error: `cast(int)var` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(120): Error: `cast(int)var` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(121): Error: `cast(int)var` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(122): Error: `cast(int)var` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(123): Error: `cast(int)var` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(124): Error: `makeS22067().field` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(125): Error: `makeS22067().field` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(126): Error: `makeS22067().field` is not an lvalue and cannot be modified
-fail_compilation/failcstuff2.c(127): Error: `makeS22067().field` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(116): Error: `4` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(117): Error: `5` is not an lvalue and cannot be modified
+fail_compilation/failcstuff2.c(118): Error: `6` is a constant, not an lvalue
+fail_compilation/failcstuff2.c(119): Error: `cast(int)var` is not an lvalue
+fail_compilation/failcstuff2.c(120): Error: `cast(int)var` is not an lvalue
+fail_compilation/failcstuff2.c(121): Error: `cast(int)var` is not an lvalue
+fail_compilation/failcstuff2.c(122): Error: `cast(int)var` is not an lvalue
+fail_compilation/failcstuff2.c(123): Error: `cast(int)var` is not an lvalue
+fail_compilation/failcstuff2.c(124): Error: `makeS22067().field` is not an lvalue
+fail_compilation/failcstuff2.c(125): Error: `makeS22067().field` is not an lvalue
+fail_compilation/failcstuff2.c(126): Error: `makeS22067().field` is not an lvalue
+fail_compilation/failcstuff2.c(127): Error: `makeS22067().field` is not an lvalue
 fail_compilation/failcstuff2.c(153): Error: `cast(short)var` is not an lvalue and cannot be modified
 fail_compilation/failcstuff2.c(154): Error: `cast(long)var` is not an lvalue and cannot be modified
 fail_compilation/failcstuff2.c(354): Error: variable `arr` cannot be read at compile time

--- a/compiler/test/fail_compilation/ice11974.d
+++ b/compiler/test/fail_compilation/ice11974.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11974.d(7): Error: cannot modify constant `0`
+fail_compilation/ice11974.d(7): Error: `0` is not an lvalue and cannot be modified
 ---
 */
 void main() {  0 = __LINE__ ^^ [ 0 ] ; }

--- a/compiler/test/fail_compilation/ice12841.d
+++ b/compiler/test/fail_compilation/ice12841.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12841.d(23): Error: `taskPool().amap(Args...)(Args args)` is not an lvalue and cannot be modified
-fail_compilation/ice12841.d(24): Error: `amap(Args...)(Args args)` is not an lvalue and cannot be modified
+fail_compilation/ice12841.d(23): Error: `taskPool().amap(Args...)(Args args)` is not an lvalue
+fail_compilation/ice12841.d(24): Error: `amap(Args...)(Args args)` is not an lvalue
 ---
 */
 

--- a/compiler/test/fail_compilation/issue20704.d
+++ b/compiler/test/fail_compilation/issue20704.d
@@ -1,12 +1,12 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/issue20704.d(17): Error: cannot modify constant `0`
+fail_compilation/issue20704.d(17): Error: `0` is a constant, not an lvalue
 fail_compilation/issue20704.d(28): Error: template instance `issue20704.f2!int` error instantiating
-fail_compilation/issue20704.d(19): Error: cannot modify constant `0`
+fail_compilation/issue20704.d(19): Error: `0` is a constant, not an lvalue
 fail_compilation/issue20704.d(30): Error: template instance `issue20704.f4!int` error instantiating
-fail_compilation/issue20704.d(17): Error: `S(0)` is not an lvalue and cannot be modified
+fail_compilation/issue20704.d(17): Error: `S(0)` is not an lvalue
 fail_compilation/issue20704.d(36): Error: template instance `issue20704.f2!(S)` error instantiating
-fail_compilation/issue20704.d(17): Error: `null` is not an lvalue and cannot be modified
+fail_compilation/issue20704.d(17): Error: `null` is not an lvalue
 fail_compilation/issue20704.d(38): Error: template instance `issue20704.f2!(C)` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/test16381.d
+++ b/compiler/test/fail_compilation/test16381.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -m64
 TEST_OUTPUT:
 ---
-fail_compilation/test16381.d(15): Error: `foo()` is not an lvalue and cannot be modified
+fail_compilation/test16381.d(15): Error: `foo()` is not an lvalue
 ---
 */
 

--- a/compiler/test/fail_compilation/test22070.c
+++ b/compiler/test/fail_compilation/test22070.c
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test22070.c(10): Error: `&""` is not an lvalue and cannot be modified
+fail_compilation/test22070.c(10): Error: `&""` is not an lvalue
 ---
 */
 


### PR DESCRIPTION
Requiring an lvalue is not the same as requiring modification.
Fix Issue 23791 - Rvalue default argument for ref parameter gives misleading error.

 Merge 2 tests & add test for a type used as a default argument.