### PR TITLE
Add `CastExp.toLvalue` dip1000 error if implicit pointer conversion would fail

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -5619,13 +5619,6 @@ extern (C++) final class CastExp : UnaExp
         if (to.ty == Tsarray && (e1.type.ty == Tvector || e1.type.ty == Tsarray))
             return true;
 
-        // enable for next edition
-        // mutable/const -> immutable, const -> mutable can't be lvalue
-        // allow casting to/from shared as lvalue
-        if (0 && !e1.type.unSharedOf().pointerTo.implicitConvTo(
-            to.unSharedOf().pointerTo()))
-            return false;
-
         return e1.type.mutableOf().unSharedOf().equals(to.mutableOf().unSharedOf());
     }
 
@@ -5639,13 +5632,14 @@ extern (C++) final class CastExp : UnaExp
         }
         if (isLvalue())
         {
-            // see isLvalue
+            // mutable/const -> immutable, const -> mutable can't be lvalue
+            // allow casting to/from shared as lvalue
             if (to.ty != Tsarray && !e1.type.unSharedOf().pointerTo.implicitConvTo(
                 to.unSharedOf().pointerTo()))
             {
-                warning(DiagnosticFlag.obsolete,
-                    "using cast from `%s` to `%s` as an lvalue is obsolete",
-                    e1.type.toChars(), to.toChars());
+                setUnsafePreview(sc, global.params.useDIP1000, false, loc,
+                    "cannot use cast from `%s` to `%s` as an lvalue in @safe code",
+                    e1.type, to);
             }
             return this;
         }

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -5634,7 +5634,7 @@ extern (C++) final class CastExp : UnaExp
         {
             // mutable/const -> immutable, const -> mutable can't be lvalue
             // allow casting to/from shared as lvalue
-            if (to.ty != Tsarray && !e1.type.unSharedOf().pointerTo.implicitConvTo(
+            if (!(sc && sc.flags & SCOPE.ctfe) && to.ty != Tsarray && !e1.type.unSharedOf().pointerTo.implicitConvTo(
                 to.unSharedOf().pointerTo()))
             {
                 setUnsafePreview(sc, global.params.useDIP1000, false, loc,

--- a/compiler/test/fail_compilation/cast_lvalue.d
+++ b/compiler/test/fail_compilation/cast_lvalue.d
@@ -1,0 +1,30 @@
+/*
+REQUIRED_ARGS: -wo -w
+TEST_OUTPUT:
+---
+fail_compilation/cast_lvalue.d(18): Warning: using cast from `int` to `immutable(int)` as an lvalue is obsolete
+fail_compilation/cast_lvalue.d(20): Warning: using cast from `const(int)` to `immutable(int)` as an lvalue is obsolete
+fail_compilation/cast_lvalue.d(24): Warning: using cast from `const(int)` to `int` as an lvalue is obsolete
+fail_compilation/cast_lvalue.d(26): Warning: using cast from `const(int)` to `immutable(int)` as an lvalue is obsolete
+Error: warnings are treated as errors
+       Use -wi if you wish to treat warnings only as informational.
+---
+*/
+
+void main()
+{
+    int x;
+    auto p = &cast(const int) x; // OK
+    auto r = &cast(immutable int) x;
+    x++; // would mutate *r
+    auto s = &cast(immutable) *p;
+    auto t = &cast(shared) x; // allowed
+
+    const int y;
+    auto q = &cast(int) y;
+    *q = 5; // would mutate y
+    auto u = &cast(immutable) y;
+
+    shared int z;
+    auto v = &cast(int) z; // allowed
+}

--- a/compiler/test/fail_compilation/cast_lvalue.d
+++ b/compiler/test/fail_compilation/cast_lvalue.d
@@ -1,30 +1,30 @@
 /*
-REQUIRED_ARGS: -wo -w
+REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/cast_lvalue.d(18): Warning: using cast from `int` to `immutable(int)` as an lvalue is obsolete
-fail_compilation/cast_lvalue.d(20): Warning: using cast from `const(int)` to `immutable(int)` as an lvalue is obsolete
-fail_compilation/cast_lvalue.d(24): Warning: using cast from `const(int)` to `int` as an lvalue is obsolete
-fail_compilation/cast_lvalue.d(26): Warning: using cast from `const(int)` to `immutable(int)` as an lvalue is obsolete
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/cast_lvalue.d(16): Error: cannot use cast from `int` to `immutable(int)` as an lvalue in @safe code
+fail_compilation/cast_lvalue.d(18): Error: cannot use cast from `const(int)` to `immutable(int)` as an lvalue in @safe code
+fail_compilation/cast_lvalue.d(23): Error: cannot use cast from `const(int)` to `int` as an lvalue in @safe code
+fail_compilation/cast_lvalue.d(25): Error: cannot use cast from `const(int)` to `immutable(int)` as an lvalue in @safe code
 ---
 */
 
-void main()
+void main() @safe
 {
     int x;
     auto p = &cast(const int) x; // OK
     auto r = &cast(immutable int) x;
     x++; // would mutate *r
     auto s = &cast(immutable) *p;
-    auto t = &cast(shared) x; // allowed
+    auto t = &cast(shared) x; // TODO
 
     const int y;
+    x = cast() y; // OK, rvalue
     auto q = &cast(int) y;
     *q = 5; // would mutate y
     auto u = &cast(immutable) y;
 
     shared int z;
-    auto v = &cast(int) z; // allowed
+    auto v = &cast(int) z; // TODO
+    auto w = &cast(shared) x; // TODO
 }


### PR DESCRIPTION
From https://dlang.org/spec/expression.html#.define-lvalue

> The following expressions, and no others, are called lvalue expressions or lvalues
...
> cast(U) expressions applied to lvalues of type T when T* is implicitly convertible to U*;
> cast() and cast(qualifier list) when applied to an lvalue.

The first rule was not enforced by dmd.
The second rule contradicts the point of the first rule. It ~~should~~ perhaps could be updated to work in the same way.

Fixes Issue 23530 - casting immutable away allowed in safe.

Edit: Changed to dip1000 error rather than obsolete warning.