### PR TITLE
[stable] Fix Issue 24139 - 'this' corruption in extern(C++) dtor when destructing via TypeInfo_Struct

### DIFF
--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -1126,7 +1126,7 @@ private DtorDeclaration buildExternDDtor(AggregateDeclaration ad, Scope* sc)
         return null;
 
     // Generate shim only when ABI incompatible on target platform
-    if (ad.classKind != ClassKind.cpp || !target.cpp.wrapDtorInExternD)
+    if (dtor._linkage != LINK.cpp || !target.cpp.wrapDtorInExternD)
         return dtor;
 
     // generate member function that adjusts calling convention

--- a/compiler/test/runnable/test24139.d
+++ b/compiler/test/runnable/test24139.d
@@ -1,0 +1,25 @@
+// https://issues.dlang.org/show_bug.cgi?id=24139
+
+struct S1
+{
+    int x;
+    extern(C++) ~this() { assert(&this == s1); }
+}
+
+extern(C++) struct S2
+{
+    int x;
+    ~this() { assert(&this == s2); }
+}
+
+S1* s1;
+S2* s2;
+
+void main()
+{
+    s1 = new S1;
+    s2 = new S2;
+
+    typeid(S1).destroy(s1);
+    typeid(S2).destroy(s2);
+}


### PR DESCRIPTION
For the `TypeInfo_Struct.xdtor` field, the linkage of the aggregate itself plays no role; it's the linkage of the destructor that matters.

A real-life example for this is DMD's own `OutBuffer`.