### PR TITLE
Print instantiation trace when TypeInfo needs to be generated for betterC code

### DIFF
--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -52,6 +52,13 @@ extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope
                 .error(loc, "expression `%s` uses the GC and cannot be used with switch `-betterC`", e.toChars());
             else
                 .error(loc, "`TypeInfo` cannot be used with -betterC");
+
+            if (sc && sc.tinst)
+            {
+                global.params.verbose = true;
+                sc.tinst.printInstantiationTrace();
+            }
+
             fatal();
         }
     }


### PR DESCRIPTION
When the compiler generates template instances originating from a speculative scope (__traits(compiles), is(typeof())) subsequent template instances are not marked as not needing codegen. As a consequence, you might end up having code failing with "Error: Cannot generate TypeInfo" for some library code that you have no idea how it ended needing typeinfo.

This patch does not fix the issue (which would require propagating the fact that template instances do not need codegen if the root instantiation is in speculative context), but adds code that prints the instantiation trace so that it is easier to understand where the error comes from.