### PR TITLE
fix Issue 24071 - When enum has typedef integer constants do not have…

### DIFF
--- a/compiler/test/compilable/testcstuff2.c
+++ b/compiler/test/compilable/testcstuff2.c
@@ -749,3 +749,12 @@ static void parse() {
     Typ* ty;
     void* fields = &ty->fields;
 }
+
+/************************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=24071
+
+typedef enum
+{
+    DISPLAYCONFIG_OUTPUT_TECHNOLOGY_SVIDEO                  = 1,
+    DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INTERNAL                = 0x80000000,
+} DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY;


### PR DESCRIPTION
… types determined correctly

Could not repro the problem, so just included the test case.