### PR TITLE
[stable] Fix Issue 24144 - [REG2.105] Silent file name index overflow

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -379,8 +379,8 @@ struct Loc final
 {
 private:
     uint32_t _linnum;
-    uint16_t _charnum;
-    uint16_t fileIndex;
+    uint32_t _charnum;
+    uint32_t fileIndex;
 public:
     static bool showColumns;
     static MessageStyle messageStyle;
@@ -7019,9 +7019,9 @@ struct UnionExp final
 private:
     union __AnonStruct__u
     {
-        char exp[25LLU];
+        char exp[29LLU];
         char integerexp[40LLU];
-        char errorexp[25LLU];
+        char errorexp[29LLU];
         char realexp[48LLU];
         char complexexp[64LLU];
         char symoffexp[64LLU];
@@ -7030,7 +7030,7 @@ private:
         char assocarrayliteralexp[48LLU];
         char structliteralexp[76LLU];
         char compoundliteralexp[40LLU];
-        char nullexp[25LLU];
+        char nullexp[29LLU];
         char dotvarexp[49LLU];
         char addrexp[40LLU];
         char indexexp[74LLU];

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -357,8 +357,8 @@ struct Loc
 {
 private:
     unsigned _linnum;
-    unsigned short _charnum;
-    unsigned short fileIndex;
+    unsigned _charnum;
+    unsigned fileIndex;
 public:
     static void set(bool showColumns, MessageStyle messageStyle);
 

--- a/compiler/src/dmd/location.d
+++ b/compiler/src/dmd/location.d
@@ -38,8 +38,8 @@ debug info etc.
 struct Loc
 {
     private uint _linnum;
-    private ushort _charnum;
-    private ushort fileIndex; // index into filenames[], starting from 1 (0 means no filename)
+    private uint _charnum;
+    private uint fileIndex; // index into filenames[], starting from 1 (0 means no filename)
     version (LocOffset)
         uint fileOffset; /// utf8 code unit index relative to start of file, starting from 0
 
@@ -67,7 +67,7 @@ nothrow:
     extern (D) this(const(char)* filename, uint linnum, uint charnum)
     {
         this._linnum = linnum;
-        this._charnum = cast(ushort) charnum;
+        this._charnum = charnum;
         this.filename = filename;
     }
 
@@ -80,7 +80,7 @@ nothrow:
     /// ditto
     extern (C++) uint charnum(uint num) @nogc @safe
     {
-        return _charnum = cast(ushort) num;
+        return _charnum = num;
     }
 
     /// line number, starting from 1
@@ -114,8 +114,16 @@ nothrow:
         {
             //printf("setting %s\n", name);
             filenames.push(name);
-            fileIndex = cast(ushort)filenames.length;
-            assert(fileIndex);  // no overflow
+            fileIndex = cast(uint)filenames.length;
+            if (!fileIndex)
+            {
+                import dmd.globals : global;
+                import dmd.errors : error, fatal;
+
+                global.gag = 0; // ensure error message gets printed
+                error(Loc.initial, "internal compiler error: file name index overflow!");
+                fatal();
+            }
         }
         else
             fileIndex = 0;


### PR DESCRIPTION
* Print an ICE message for `Loc.filename` overflows
* Increase the `Loc` size again, raising the file name limit from 64K to 4G but keeping the index indirection from #15199. The `Loc` size for DMD-as-a-library is 16 bytes then, and 12 bytes otherwise.