### PR TITLE
Fix a bug on MacOS with app subprocess hanging on fork()

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -1951,6 +1951,13 @@ extern (C) void thread_init() @nogc nothrow
         static extern(C) void initChildAfterFork()
         {
             auto thisThread = Thread.getThis();
+            if (!thisThread)
+            {
+                // It is possible that runtime was not properly initialized in the current process or thread -
+                // it may happen after `fork` call when using a dynamically loaded shared library written in D from a multithreaded non-D program.
+                // In such case getThis will return null.
+                return;
+            }
             thisThread.m_addr = pthread_self();
             assert( thisThread.m_addr != thisThread.m_addr.init );
             thisThread.m_tmach = pthread_mach_thread_np( thisThread.m_addr );


### PR DESCRIPTION
I have a dylib written in D. This dylib is dynamically loaded (with `dlopen`) from a program written in Go.
After I load the dylib and call its initializer method (which, among other things, calls `Runtime.initialize()`), and then try to run any subprocess from the main app, it hangs forever. In that state it has 2 identically looking processes: the main one waits for the child, and the child is hanging with 100% CPU load in the `MOV` instruction from this line: https://github.com/dlang/dmd/blob/c1afb4c72f44ec05284efc489a66fc194205f507/druntime/src/core/thread/osthread.d#L1954

Looks like it happens because we try to write to some "strange" memory area. I'll yet try to implement a minimal reproducing sample.