### PR TITLE
fix(tokens): annotate `isKeyword` with `pure @nogc`

### DIFF
--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -900,7 +900,7 @@ extern (C++) struct Token
 
 nothrow:
 
-    int isKeyword() const @safe
+    int isKeyword() pure const @safe @nogc
     {
         foreach (kw; keywords)
         {


### PR DESCRIPTION
The `isKeyword` function is pure, and also does not allocate. It can be annotated with `pure` and `@nogc`, which will allow us to retain the annotations for the functions that call this in dfmt.

cc @RazvanN7 