### PR TITLE
druntime: fix architecture configuration issues on MIPS64

### DIFF
--- a/druntime/src/core/sys/posix/fcntl.d
+++ b/druntime/src/core/sys/posix/fcntl.d
@@ -135,6 +135,27 @@ version (linux)
     enum F_SETLK        = 6;
     enum F_SETLKW       = 7;
   }
+  else version (MIPS_N64)
+  {
+    enum F_GETLK        = 14;
+    enum F_SETLK        = 6;
+    enum F_SETLKW       = 7;
+  }
+  else version (MIPS_Any)
+  {
+    static if ( __USE_FILE_OFFSET64 )
+    {
+      enum F_GETLK      = 33;
+      enum F_SETLK      = 34;
+      enum F_SETLKW     = 35;
+    }
+    else
+    {
+      enum F_GETLK      = 14;
+      enum F_SETLK      = 6;
+      enum F_SETLKW     = 7;
+    }
+  }
   else
   static if ( __USE_FILE_OFFSET64 )
   {

--- a/druntime/src/core/sys/posix/signal.d
+++ b/druntime/src/core/sys/posix/signal.d
@@ -2390,11 +2390,23 @@ version (CRuntime_Glibc)
     //ucontext_t (defined in core.sys.posix.ucontext)
     //mcontext_t (defined in core.sys.posix.ucontext)
 
-    struct stack_t
+    version (MIPS_Any)
     {
-        void*   ss_sp;
-        int     ss_flags;
-        size_t  ss_size;
+        struct stack_t
+        {
+            void*   ss_sp;
+            size_t  ss_size;
+            int     ss_flags;
+        }
+    }
+    else
+    {
+        struct stack_t
+        {
+            void*   ss_sp;
+            int     ss_flags;
+            size_t  ss_size;
+        }
     }
 
     struct sigstack
@@ -2760,7 +2772,7 @@ else version (CRuntime_UClibc)
     enum MINSIGSTKSZ    = 2048;
     enum SIGSTKSZ       = 8192;
 
-    version (MIPS32)
+    version (MIPS_Any)
     {
         struct stack_t
         {

--- a/druntime/src/core/sys/posix/sys/resource.d
+++ b/druntime/src/core/sys/posix/sys/resource.d
@@ -22,6 +22,9 @@ else version (TVOS)
 else version (WatchOS)
     version = Darwin;
 
+version (MIPS32)  version = MIPS_Any;
+version (MIPS64)  version = MIPS_Any;
+
 nothrow @nogc extern(C):
 
 //
@@ -120,15 +123,31 @@ version (linux)
             c_long[16] __reserved;
     }
 
-    enum
+    version (MIPS_Any)
     {
-        RLIMIT_CORE   = 4,
-        RLIMIT_CPU    = 0,
-        RLIMIT_DATA   = 2,
-        RLIMIT_FSIZE  = 1,
-        RLIMIT_NOFILE = 7,
-        RLIMIT_STACK  = 3,
-        RLIMIT_AS     = 9,
+        enum
+        {
+            RLIMIT_CORE   = 4,
+            RLIMIT_CPU    = 0,
+            RLIMIT_DATA   = 2,
+            RLIMIT_FSIZE  = 1,
+            RLIMIT_NOFILE = 5,
+            RLIMIT_STACK  = 3,
+            RLIMIT_AS     = 6,
+        }
+    }
+    else
+    {
+        enum
+        {
+            RLIMIT_CORE   = 4,
+            RLIMIT_CPU    = 0,
+            RLIMIT_DATA   = 2,
+            RLIMIT_FSIZE  = 1,
+            RLIMIT_NOFILE = 7,
+            RLIMIT_STACK  = 3,
+            RLIMIT_AS     = 9,
+        }
     }
 }
 else version (Darwin)


### PR DESCRIPTION
This pull request fixes several architectural issues on MIPS64 (when using GLibc).

- Some `fcntl` constants are incorrect on MIPS64 (when using N64 ABI)
- `struct stack_t` has a different layout on MIPS32/MIPS64
- `RLIMIT` constants are very different on MIPS