### PR TITLE
CI: Move non-FreeBSD Cirrus CI coverage jobs to GitHub Actions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,42 +51,6 @@ coverage_environment_template: &COVERAGE_ENVIRONMENT_TEMPLATE
   DMD_TEST_COVERAGE: 1
   CODECOV_TOKEN: ENCRYPTED[cc6ce01618eaee6c9a08ebc81446a9233588df3b2c6ba4e30ffb7715ee9815734ccfd9fcec4f6abfc6a1b9dd8253110d]
 
-# Linux
-linux_task:
-  name: Ubuntu 22.04 $TASK_NAME_SUFFIX
-  container:
-    image: ubuntu:22.04
-    cpu: 4
-    memory: 8G
-    # Workaround GDB bug on 22.04 by requesting a privileged container
-    # See https://github.com/cirruslabs/cirrus-ci-docs/issues/1136
-    kvm: true
-  timeout_in: 60m
-  environment:
-    matrix:
-      - TASK_NAME_SUFFIX: x86, DMD (coverage)
-        MODEL: 32
-        << : *COVERAGE_ENVIRONMENT_TEMPLATE
-      # Enable this to replace coverage tests on CircleCI
-      # - TASK_NAME_SUFFIX: x64, DMD (coverage)
-      #   << : *COVERAGE_ENVIRONMENT_TEMPLATE
-  << : *COMMON_STEPS_TEMPLATE
-
-# Mac
-macos13_task:
-  name: macOS 13.x x64 (M1), $TASK_NAME_SUFFIX
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:latest
-  timeout_in: 60m
-  environment:
-    OS_NAME: darwin
-    # override Cirrus default OS (`darwin`)
-    OS: osx
-    matrix:
-      - TASK_NAME_SUFFIX: DMD (coverage)
-        << : *COVERAGE_ENVIRONMENT_TEMPLATE
-  << : *COMMON_STEPS_TEMPLATE
-
 # FreeBSD
 freebsd13_task:
   name: FreeBSD 13.0 x64, DMD ($TASK_NAME_TYPE)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
         run: ci/run.sh build
       - name: Rebuild dmd (with enabled coverage)
         if: matrix.coverage
-        run: ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ci/run.sh rebuild
+        run: ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ${{ runner.os == 'macOS' && 'OS_NAME=osx' || '' }} ci/run.sh rebuild
       - name: Test dmd
         run: ci/run.sh test_dmd
       - name: Test druntime

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,6 @@ jobs:
       FULL_BUILD: true
       # for coverage:
       DMD_TEST_COVERAGE: ${{ matrix.coverage && '1' || '0' }}
-      CODECOV_TOKEN: ${{ matrix.coverage && secrets.CODECOV_TOKEN || '' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  posix:
     strategy:
       fail-fast: false
       matrix:
@@ -19,6 +19,11 @@ jobs:
           - job_name: Ubuntu 22.04 x64, DMD (latest)
             os: ubuntu-22.04
             host_dmd: dmd
+          # Enable this to replace coverage tests on CircleCI
+          # - job_name: Ubuntu 22.04 x64, DMD (coverage)
+          #   os: ubuntu-22.04
+          #   host_dmd: dmd
+          #   coverage: true
           - job_name: Ubuntu 22.04 x64, DMD (bootstrap)
             os: ubuntu-22.04
             host_dmd: dmd-2.079.0
@@ -26,6 +31,11 @@ jobs:
             os: ubuntu-22.04
             model: 32
             host_dmd: dmd
+          - job_name: Ubuntu 22.04 x86, DMD (coverage)
+            os: ubuntu-22.04
+            model: 32
+            host_dmd: dmd
+            coverage: true
           - job_name: Ubuntu 22.04 x86, DMD (bootstrap)
             os: ubuntu-22.04
             model: 32
@@ -40,6 +50,10 @@ jobs:
           - job_name: macOS 13 x64, DMD (latest)
             os: macos-13
             host_dmd: dmd
+          - job_name: macOS 13 x64, DMD (coverage)
+            os: macos-13
+            host_dmd: dmd
+            coverage: true
           - job_name: macOS 12 x64, DMD (bootstrap)
             os: macos-12
             # de-facto bootstrap version on OSX
@@ -55,6 +69,9 @@ jobs:
       HOST_DMD: ${{ matrix.host_dmd }}
       N: ${{ startsWith(matrix.os, 'macos') && '3' || '2' }}
       FULL_BUILD: true
+      # for coverage:
+      DMD_TEST_COVERAGE: ${{ matrix.coverage && '1' || '0' }}
+      CODECOV_TOKEN: ${{ matrix.coverage && secrets.CODECOV_TOKEN || '' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,12 +99,20 @@ jobs:
             exit 1
           fi
 
-          ./ci/run.sh setup_repos "$REPO_BRANCH"
+          ci/run.sh setup_repos "$REPO_BRANCH"
       - name: Build
         run: ci/run.sh build
+      - name: Rebuild dmd (with enabled coverage)
+        if: matrix.coverage
+        run: ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ci/run.sh rebuild
       - name: Test dmd
         run: ci/run.sh test_dmd
       - name: Test druntime
+        if: '!matrix.coverage'
         run: ci/run.sh test_druntime
       - name: Test phobos
+        if: '!matrix.coverage'
         run: ci/run.sh test_phobos
+      - name: Upload coverage report
+        if: matrix.coverage
+        run: ci/run.sh codecov


### PR DESCRIPTION
(~~draft: depends on/includes #15613, and needs a `CODECOV_TOKEN` secret env var~~)