### PR TITLE
blockexit.d: use ErrorSink

### DIFF
--- a/compiler/src/dmd/blockexit.d
+++ b/compiler/src/dmd/blockexit.d
@@ -18,7 +18,7 @@ import dmd.astenums;
 import dmd.canthrow;
 import dmd.dclass;
 import dmd.declaration;
-import dmd.errors;
+import dmd.errorsink;
 import dmd.expression;
 import dmd.func;
 import dmd.globals;
@@ -57,11 +57,11 @@ enum BE : int
  * Params:
  *   s = statement to check for block exit status
  *   func = function that statement s is in
- *   mustNotThrow = generate an error if it throws
+ *   eSink = generate an error if it throws
  * Returns:
  *   BE.xxxx
  */
-int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
+int blockExit(Statement s, FuncDeclaration func, ErrorSink eSink)
 {
         int result = BE.none;
 
@@ -98,7 +98,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                 if (s.exp.type && s.exp.type.toBasetype().isTypeNoreturn())
                     result = BE.halt;
 
-                result |= canThrow(s.exp, func, mustNotThrow);
+                result |= canThrow(s.exp, func, eSink !is null);
             }
         }
 
@@ -144,9 +144,9 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                                 // Deprecated in 2.100
                                 // Make an error in 2.110
                                 if (sl && sl.isCaseStatement())
-                                    deprecation(s.loc, "switch case fallthrough - use 'goto %s;' if intended", gototype);
+                                    global.errorSink.deprecation(s.loc, "switch case fallthrough - use 'goto %s;' if intended", gototype);
                                 else
-                                    error(s.loc, "switch case fallthrough - use 'goto %s;' if intended", gototype);
+                                    global.errorSink.error(s.loc, "switch case fallthrough - use 'goto %s;' if intended", gototype);
                             }
                         }
                     }
@@ -154,14 +154,14 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                     if (!(result & BE.fallthru) && !s.comeFrom())
                     {
                         import dmd.errorsink : DiagnosticFlag;
-                        if (blockExit(s, func, mustNotThrow) != BE.halt && s.hasCode() &&
+                        if (blockExit(s, func, eSink) != BE.halt && s.hasCode() &&
                             s.loc != Loc.initial) // don't emit warning for generated code
-                            warning(DiagnosticFlag.unreachable, s.loc, "statement is not reachable");
+                            global.errorSink.warning(DiagnosticFlag.unreachable, s.loc, "statement is not reachable");
                     }
                     else
                     {
                         result &= ~BE.fallthru;
-                        result |= blockExit(s, func, mustNotThrow);
+                        result |= blockExit(s, func, eSink);
                     }
                     slast = s;
                 }
@@ -175,7 +175,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             {
                 if (s)
                 {
-                    int r = blockExit(s, func, mustNotThrow);
+                    int r = blockExit(s, func, eSink);
                     result |= r & ~(BE.break_ | BE.continue_ | BE.fallthru);
                     if ((r & (BE.fallthru | BE.continue_ | BE.break_)) == 0)
                         result &= ~BE.fallthru;
@@ -186,7 +186,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         void visitScope(ScopeStatement s)
         {
             //printf("ScopeStatement::blockExit(%p)\n", s.statement);
-            result = blockExit(s.statement, func, mustNotThrow);
+            result = blockExit(s.statement, func, eSink);
         }
 
         void visitWhile(WhileStatement s)
@@ -199,7 +199,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         {
             if (s._body)
             {
-                result = blockExit(s._body, func, mustNotThrow);
+                result = blockExit(s._body, func, eSink);
                 if (result == BE.break_)
                 {
                     result = BE.fallthru;
@@ -212,7 +212,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                 result = BE.fallthru;
             if (result & BE.fallthru)
             {
-                result |= canThrow(s.condition, func, mustNotThrow);
+                result |= canThrow(s.condition, func, eSink !is null);
 
                 if (!(result & BE.break_) && s.condition.toBool().hasValue(true))
                     result &= ~BE.fallthru;
@@ -225,13 +225,13 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             result = BE.fallthru;
             if (s._init)
             {
-                result = blockExit(s._init, func, mustNotThrow);
+                result = blockExit(s._init, func, eSink);
                 if (!(result & BE.fallthru))
                     return;
             }
             if (s.condition)
             {
-                result |= canThrow(s.condition, func, mustNotThrow);
+                result |= canThrow(s.condition, func, eSink !is null);
 
                 const opt = s.condition.toBool();
                 if (opt.hasValue(true))
@@ -243,22 +243,22 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                 result &= ~BE.fallthru; // the body must do the exiting
             if (s._body)
             {
-                int r = blockExit(s._body, func, mustNotThrow);
+                int r = blockExit(s._body, func, eSink);
                 if (r & (BE.break_ | BE.goto_))
                     result |= BE.fallthru;
                 result |= r & ~(BE.fallthru | BE.break_ | BE.continue_);
             }
             if (s.increment)
-                result |= canThrow(s.increment, func, mustNotThrow);
+                result |= canThrow(s.increment, func, eSink !is null);
         }
 
         void visitForeach(ForeachStatement s)
         {
             result = BE.fallthru;
-            result |= canThrow(s.aggr, func, mustNotThrow);
+            result |= canThrow(s.aggr, func, eSink !is null);
 
             if (s._body)
-                result |= blockExit(s._body, func, mustNotThrow) & ~(BE.break_ | BE.continue_);
+                result |= blockExit(s._body, func, eSink) & ~(BE.break_ | BE.continue_);
         }
 
         void visitForeachRange(ForeachRangeStatement s)
@@ -271,30 +271,30 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         {
             //printf("IfStatement::blockExit(%p)\n", s);
             result = BE.none;
-            result |= canThrow(s.condition, func, mustNotThrow);
+            result |= canThrow(s.condition, func, eSink !is null);
 
             const opt = s.condition.toBool();
             if (opt.hasValue(true))
             {
-                result |= blockExit(s.ifbody, func, mustNotThrow);
+                result |= blockExit(s.ifbody, func, eSink);
             }
             else if (opt.hasValue(false))
             {
-                result |= blockExit(s.elsebody, func, mustNotThrow);
+                result |= blockExit(s.elsebody, func, eSink);
             }
             else
             {
-                result |= blockExit(s.ifbody, func, mustNotThrow);
-                result |= blockExit(s.elsebody, func, mustNotThrow);
+                result |= blockExit(s.ifbody, func, eSink);
+                result |= blockExit(s.elsebody, func, eSink);
             }
             //printf("IfStatement::blockExit(%p) = x%x\n", s, result);
         }
 
         void visitConditional(ConditionalStatement s)
         {
-            result = blockExit(s.ifbody, func, mustNotThrow);
+            result = blockExit(s.ifbody, func, eSink);
             if (s.elsebody)
-                result |= blockExit(s.elsebody, func, mustNotThrow);
+                result |= blockExit(s.elsebody, func, eSink);
         }
 
         void visitPragma(PragmaStatement s)
@@ -310,11 +310,11 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         void visitSwitch(SwitchStatement s)
         {
             result = BE.none;
-            result |= canThrow(s.condition, func, mustNotThrow);
+            result |= canThrow(s.condition, func, eSink !is null);
 
             if (s._body)
             {
-                result |= blockExit(s._body, func, mustNotThrow);
+                result |= blockExit(s._body, func, eSink);
                 if (result & BE.break_)
                 {
                     result |= BE.fallthru;
@@ -327,12 +327,12 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
 
         void visitCase(CaseStatement s)
         {
-            result = blockExit(s.statement, func, mustNotThrow);
+            result = blockExit(s.statement, func, eSink);
         }
 
         void visitDefault(DefaultStatement s)
         {
-            result = blockExit(s.statement, func, mustNotThrow);
+            result = blockExit(s.statement, func, eSink);
         }
 
         void visitGotoDefault(GotoDefaultStatement s)
@@ -355,7 +355,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         {
             result = BE.return_;
             if (s.exp)
-                result |= canThrow(s.exp, func, mustNotThrow);
+                result |= canThrow(s.exp, func, eSink !is null);
         }
 
         void visitBreak(BreakStatement s)
@@ -371,20 +371,20 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
 
         void visitSynchronized(SynchronizedStatement s)
         {
-            result = blockExit(s._body, func, mustNotThrow);
+            result = blockExit(s._body, func, eSink);
         }
 
         void visitWith(WithStatement s)
         {
             result = BE.none;
-            result |= canThrow(s.exp, func, mustNotThrow);
-            result |= blockExit(s._body, func, mustNotThrow);
+            result |= canThrow(s.exp, func, eSink !is null);
+            result |= blockExit(s._body, func, eSink);
         }
 
         void visitTryCatch(TryCatchStatement s)
         {
             assert(s._body);
-            result = blockExit(s._body, func, false);
+            result = blockExit(s._body, func, null);
 
             int catchresult = 0;
             foreach (c; *s.catches)
@@ -392,7 +392,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                 if (c.type == Type.terror)
                     continue;
 
-                int cresult = blockExit(c.handler, func, mustNotThrow);
+                int cresult = blockExit(c.handler, func, eSink);
 
                 /* If we're catching Object, then there is no throwing
                  */
@@ -413,10 +413,10 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                 }
                 catchresult |= cresult;
             }
-            if (mustNotThrow && (result & BE.throw_))
+            if (eSink && (result & BE.throw_))
             {
                 // now explain why this is nothrow
-                blockExit(s._body, func, mustNotThrow);
+                blockExit(s._body, func, eSink);
             }
             result |= catchresult;
         }
@@ -425,12 +425,12 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         {
             result = BE.fallthru;
             if (s._body)
-                result = blockExit(s._body, func, false);
+                result = blockExit(s._body, func, null);
 
             // check finally body as well, it may throw (bug #4082)
             int finalresult = BE.fallthru;
             if (s.finalbody)
-                finalresult = blockExit(s.finalbody, func, false);
+                finalresult = blockExit(s.finalbody, func, null);
 
             // If either body or finalbody halts
             if (result == BE.halt)
@@ -438,13 +438,13 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             if (finalresult == BE.halt)
                 result = BE.none;
 
-            if (mustNotThrow)
+            if (eSink)
             {
                 // now explain why this is nothrow
                 if (s._body && (result & BE.throw_))
-                    blockExit(s._body, func, mustNotThrow);
+                    blockExit(s._body, func, eSink);
                 if (s.finalbody && (finalresult & BE.throw_))
-                    blockExit(s.finalbody, func, mustNotThrow);
+                    blockExit(s.finalbody, func, eSink);
             }
 
             version (none)
@@ -455,7 +455,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
                 if (result == BE.halt && finalresult != BE.halt && s.finalbody && s.finalbody.hasCode())
                 {
                     import dmd.errorsink : DiagnosticFlag;
-                    s.finalbody.warning(DiagnosticFlag.unreachable, "statement is not reachable");
+                    eSink.warning(s.finalbody.loc, DiagnosticFlag.unreachable, "statement is not reachable");
                 }
             }
 
@@ -475,12 +475,12 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             if (s.internalThrow)
             {
                 // https://issues.dlang.org/show_bug.cgi?id=8675
-                // Allow throwing 'Throwable' object even if mustNotThrow.
+                // Allow throwing 'Throwable' object even if eSink.
                 result = BE.fallthru;
                 return;
             }
 
-            result = checkThrow(s.loc, s.exp, mustNotThrow, func);
+            result = checkThrow(s.loc, s.exp, func, eSink);
         }
 
         void visitGoto(GotoStatement s)
@@ -492,7 +492,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
         void visitLabel(LabelStatement s)
         {
             //printf("LabelStatement::blockExit(%p)\n", s);
-            result = blockExit(s.statement, func, mustNotThrow);
+            result = blockExit(s.statement, func, eSink);
             if (s.breaks)
                 result |= BE.fallthru;
         }
@@ -505,8 +505,8 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             {
                 if(func)
                     func.setThrow(s.loc, "`asm` statement is assumed to throw - mark it with `nothrow` if it does not");
-                if (mustNotThrow)
-                    error(s.loc, "`asm` statement is assumed to throw - mark it with `nothrow` if it does not"); // TODO
+                if (eSink)
+                    eSink.error(s.loc, "`asm` statement is assumed to throw - mark it with `nothrow` if it does not"); // TODO
                 else
                     result |= BE.throw_;
             }
@@ -531,15 +531,13 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
  + Params:
  +   loc          = location of the `throw`
  +   exp          = expression yielding the throwable
- +   mustNotThrow = inside of a `nothrow` scope?
+ +   eSink        = if !null then inside of a `nothrow` scope
  +   func         = function containing the `throw`
  +
  + Returns: `BE.[err]throw` depending on the type of `exp`
  +/
-BE checkThrow(ref const Loc loc, Expression exp, const bool mustNotThrow, FuncDeclaration func)
+BE checkThrow(ref const Loc loc, Expression exp, FuncDeclaration func, ErrorSink eSink)
 {
-    import dmd.errors : error;
-
     Type t = exp.type.toBasetype();
     ClassDeclaration cd = t.isClassHandle();
     assert(cd);
@@ -548,8 +546,8 @@ BE checkThrow(ref const Loc loc, Expression exp, const bool mustNotThrow, FuncDe
     {
         return BE.errthrow;
     }
-    if (mustNotThrow)
-        loc.error("`%s` is thrown but not caught", exp.type.toChars());
+    if (eSink)
+        eSink.error(loc, "`%s` is thrown but not caught", exp.type.toChars());
     else if (func)
         func.setThrow(loc, "`%s` is thrown but not caught", exp.type);
 

--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -202,7 +202,7 @@ extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, bool mustN
 
         override void visit(ThrowExp te)
         {
-            const res = checkThrow(te.loc, te.e1, mustNotThrow, func);
+            const res = checkThrow(te.loc, te.e1, func, mustNotThrow ? global.errorSink : null);
             assert((res & ~(CT.exception | CT.error)) == 0);
             result |= res;
         }

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -173,7 +173,7 @@ public:
             Identifier id = Identifier.generateId("__o");
 
             Statement handler = new PeelStatement(sexception);
-            if (sexception.blockExit(fd, false) & BE.fallthru)
+            if (sexception.blockExit(fd, null) & BE.fallthru)
             {
                 auto ts = new ThrowStatement(Loc.initial, new IdentifierExp(Loc.initial, id));
                 ts.internalThrow = true;

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -1134,7 +1134,7 @@ public void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         Statement sf = ExpStatement.create(fd.loc, e);
 
         Statement stf;
-        if (sbody.blockExit(fd, false) == BE.fallthru)
+        if (sbody.blockExit(fd, null) == BE.fallthru)
             stf = CompoundStatement.create(Loc.initial, sbody, sf);
         else
             stf = TryFinallyStatement.create(Loc.initial, sbody, sf);

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -749,7 +749,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 funcdecl.buildEnsureRequire();
 
                 // Check for errors related to 'nothrow'.
-                const blockexit = funcdecl.fbody.blockExit(funcdecl, f.isnothrow);
+                const blockexit = funcdecl.fbody.blockExit(funcdecl, f.isnothrow ? global.errorSink : null);
                 if (f.isnothrow && blockexit & BE.throw_)
                     error(funcdecl.loc, "%s `%s` may throw but is marked as `nothrow`", funcdecl.kind(), funcdecl.toPrettyChars());
 
@@ -993,7 +993,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 freq = freq.statementSemantic(sc2);
 
                 // @@@DEPRECATED_2.111@@@ - pass `isnothrow` instead of `false` to print a more detailed error msg`
-                const blockExit = freq.blockExit(funcdecl, false);
+                const blockExit = freq.blockExit(funcdecl, null);
                 if (blockExit & BE.throw_)
                 {
                     if (isnothrow)
@@ -1040,7 +1040,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 fens = fens.statementSemantic(sc2);
 
                 // @@@DEPRECATED_2.111@@@ - pass `isnothrow` instead of `false` to print a more detailed error msg`
-                const blockExit = fens.blockExit(funcdecl, false);
+                const blockExit = fens.blockExit(funcdecl, null);
                 if (blockExit & BE.throw_)
                 {
                     if (isnothrow)
@@ -1177,7 +1177,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                             s = s.statementSemantic(sc2);
 
-                            const blockexit = s.blockExit(funcdecl, isnothrow);
+                            const blockexit = s.blockExit(funcdecl, isnothrow ? global.errorSink : null);
                             if (blockexit & BE.throw_)
                             {
                                 funcdecl.hasNoEH = false;
@@ -1187,7 +1187,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                                     f.isnothrow = false;
                             }
 
-                            if (sbody.blockExit(funcdecl, f.isnothrow) == BE.fallthru)
+                            if (sbody.blockExit(funcdecl, f.isnothrow ? global.errorSink : null) == BE.fallthru)
                                 sbody = new CompoundStatement(Loc.initial, sbody, s);
                             else
                                 sbody = new TryFinallyStatement(Loc.initial, sbody, s);

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -350,7 +350,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     Identifier id = Identifier.generateId("__o");
 
                     Statement handler = new PeelStatement(sexception);
-                    if (sexception.blockExit(sc.func, false) & BE.fallthru)
+                    if (sexception.blockExit(sc.func, null) & BE.fallthru)
                     {
                         auto ts = new ThrowStatement(Loc.initial, new IdentifierExp(Loc.initial, id));
                         ts.internalThrow = true;
@@ -2071,7 +2071,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             a.reserve(2);
             sc.sw.sdefault = new DefaultStatement(ss.loc, s);
             a.push(ss._body);
-            if (ss._body.blockExit(sc.func, false) & BE.fallthru)
+            if (ss._body.blockExit(sc.func, null) & BE.fallthru)
                 a.push(new BreakStatement(Loc.initial, null));
             a.push(sc.sw.sdefault);
             cs = new CompoundStatement(ss.loc, a);
@@ -3378,7 +3378,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         /* If the try body never throws, we can eliminate any catches
          * of recoverable exceptions.
          */
-        if (!(tcs._body.blockExit(sc.func, false) & BE.throw_) && ClassDeclaration.exception)
+        if (!(tcs._body.blockExit(sc.func, null) & BE.throw_) && ClassDeclaration.exception)
         {
             foreach_reverse (i; 0 .. tcs.catches.length)
             {
@@ -3428,7 +3428,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             return;
         }
 
-        auto blockexit = tfs._body.blockExit(sc.func, false);
+        auto blockexit = tfs._body.blockExit(sc.func, null);
 
         // if not worrying about exceptions
         if (!(global.params.useExceptions && ClassDeclaration.throwable))


### PR DESCRIPTION
instead of global `error()`.