### PR TITLE
Do not generate context for `assert(0)`

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6427,7 +6427,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         const generateMsg = !exp.msg &&
                             sc.needsCodegen() && // let ctfe interpreter handle the error message
                             global.params.checkAction == CHECKACTION.context &&
-                            global.params.useAssert == CHECKENABLE.on;
+                            global.params.useAssert == CHECKENABLE.on &&
+                            !((exp.e1.isIntegerExp() && (exp.e1.toInteger() == 0)) ||
+                               exp.e1.isNullExp());
         Expression temporariesPrefix;
 
         if (generateMsg)

--- a/compiler/test/compilable/checkaction-context-assert-0.d
+++ b/compiler/test/compilable/checkaction-context-assert-0.d
@@ -1,0 +1,10 @@
+module checkaction_context_assert_0;
+/*
+REQUIRED_ARGS: -vcg-ast -o- -checkaction=context
+OUTPUT_FILES: compilable/checkaction-context-assert-0.d.cg
+TEST_OUTPUT_FILE: extra-files/checkaction-context-assert-0.d.cg
+*/
+
+void a() { assert(0); }
+void b() { assert(false); }
+void c() { assert(null); }

--- a/compiler/test/compilable/extra-files/checkaction-context-assert-0.d.cg
+++ b/compiler/test/compilable/extra-files/checkaction-context-assert-0.d.cg
@@ -1,0 +1,15 @@
+=== compilable/checkaction-context-assert-0.d.cg
+module checkaction_context_assert_0;
+import object;
+void a()
+{
+	assert(0);
+}
+void b()
+{
+	assert(false);
+}
+void c()
+{
+	assert(null);
+}


### PR DESCRIPTION
This generates a bunch of useless code, the error message it adds is `0 != true`. 
More importantly it also prevents LDC from compiling dcompute kernels when `-checkaction=context` is passed.