### PR TITLE
[stable] Revert "fix Issue 24024 - cannot pass class this to ref class"

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -2468,13 +2468,19 @@ extern (C++) class ThisExp : Expression
         return typeof(return)(true);
     }
 
-    override bool isLvalue()
+    override final bool isLvalue()
     {
-        return true;
+        // Class `this` should be an rvalue; struct `this` should be an lvalue.
+        return type.toBasetype().ty != Tclass;
     }
 
-    override Expression toLvalue(Scope* sc, Expression e)
+    override final Expression toLvalue(Scope* sc, Expression e)
     {
+        if (type.toBasetype().ty == Tclass)
+        {
+            // Class `this` is an rvalue; struct `this` is an lvalue.
+            return Expression.toLvalue(sc, e);
+        }
         return this;
     }
 
@@ -2492,18 +2498,6 @@ extern (C++) final class SuperExp : ThisExp
     extern (D) this(const ref Loc loc)
     {
         super(loc, EXP.super_);
-    }
-
-    override bool isLvalue()
-    {
-        // Class `super` should be an rvalue
-        return false;
-    }
-
-    override Expression toLvalue(Scope* sc, Expression e)
-    {
-        // Class `super` is an rvalue
-        return Expression.toLvalue(sc, e);
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -348,8 +348,8 @@ public:
 
     ThisExp *syntaxCopy() override;
     Optional<bool> toBool() override;
-    bool isLvalue() override;
-    Expression *toLvalue(Scope *sc, Expression *e) override;
+    bool isLvalue() override final;
+    Expression *toLvalue(Scope *sc, Expression *e) override final;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -357,8 +357,6 @@ public:
 class SuperExp final : public ThisExp
 {
 public:
-    bool isLvalue() override;
-    Expression* toLvalue(Scope* sc, Expression* e) final override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7153,16 +7153,14 @@ public:
     ThisExp(const Loc& loc, const EXP tok);
     ThisExp* syntaxCopy() override;
     Optional<bool > toBool() override;
-    bool isLvalue() override;
-    Expression* toLvalue(Scope* sc, Expression* e) override;
+    bool isLvalue() final override;
+    Expression* toLvalue(Scope* sc, Expression* e) final override;
     void accept(Visitor* v) override;
 };
 
 class SuperExp final : public ThisExp
 {
 public:
-    bool isLvalue() override;
-    Expression* toLvalue(Scope* sc, Expression* e) override;
     void accept(Visitor* v) override;
 };
 

--- a/compiler/test/compilable/deprecate14283.d
+++ b/compiler/test/compilable/deprecate14283.d
@@ -1,12 +1,12 @@
-// REQUIRED_ARGS:
+// REQUIRED_ARGS: -dw
 // PERMUTE_ARGS:
 class C
 {
     void bug()
     {
-        autoref!(true, C)(this);  // 'auto ref' becomes ref parameter
-        autoref!(false, Object)(super); // 'auto ref' becomes non-ref parameter
+        autoref(this);  // 'auto ref' becomes non-ref parameter
+        autoref(super); // 'auto ref' becomes non-ref parameter
     }
 }
 
-void autoref(bool result, T)(auto ref T t) { static assert(__traits(isRef, t) == result); }
+void autoref(T)(auto ref T t) { static assert(__traits(isRef, t) == false); }

--- a/compiler/test/fail_compilation/diag4596.d
+++ b/compiler/test/fail_compilation/diag4596.d
@@ -1,12 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/diag4596.d(15): Error: `this` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(16): Error: conditional expression `1 ? this : this` is not a modifiable lvalue
 fail_compilation/diag4596.d(18): Error: `super` is not an lvalue and cannot be modified
 fail_compilation/diag4596.d(19): Error: conditional expression `1 ? super : super` is not a modifiable lvalue
 ---
 */
-
-
 
 class NoGo4596
 {

--- a/compiler/test/fail_compilation/fail13116.d
+++ b/compiler/test/fail_compilation/fail13116.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13116.d(14): Error: returning `this` escapes a reference to parameter `this`
+fail_compilation/fail13116.d(14): Error: `this` is not an lvalue and cannot be modified
 fail_compilation/fail13116.d(23): Error: `super` is not an lvalue and cannot be modified
 ---
 */

--- a/compiler/test/fail_compilation/test24157.d
+++ b/compiler/test/fail_compilation/test24157.d
@@ -1,0 +1,28 @@
+// https://issues.dlang.org/show_bug.cgi?id=24157
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test24157.d(23): Error: `p.self()` is not an lvalue and cannot be modified
+fail_compilation/test24157.d(27): Error: `p.unshared()` is not an lvalue and cannot be modified
+---
+*/
+
+class Promise {
+    auto ref self() {
+        return this;
+    }
+
+    auto ref unshared() shared {
+        return cast() this;
+    }
+}
+
+
+void testThis(Promise p) {
+    auto ptr = &p.self(); // must not return a ref to the Promise class ref
+}
+
+void testCastThis(shared Promise p) {
+    auto ptr = &p.unshared(); // ditto
+}


### PR DESCRIPTION
In order to fix regression [24157](https://issues.dlang.org/show_bug.cgi?id=24157). In general, I don't think making class-this an lvalue (the v2.105 change) is in any way desirable. It should be seen as an implicit rvalue that doesn't change throughout the entire function.