### PR TITLE
fix Issue 24156 - ImportC: Apple uses __signed as a keyword

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -111,6 +111,7 @@
 #define __builtin___strlcat_chk(dest, src, x, n) strlcat(dest,src,x)
 #define __builtin___strlcpy_chk(dest, src, x, n) strlcpy(dest,src,x)
 #define __builtin_object_size
+#define __signed signed
 #endif
 
 #if __FreeBSD__


### PR DESCRIPTION
There is always somebody doing this! `signed` is the correct keyword for 24 years now.