### PR TITLE
eliminate toChars() from Statement

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2895,7 +2895,7 @@ extern void moduleToBuffer(OutBuffer& buf, Module* m);
 
 extern const char* parametersTypeToChars(ParameterList pl);
 
-extern const char* toChars(const Initializer* const i);
+extern const char* toChars(const Statement* const s);
 
 enum class InitKind : uint8_t
 {
@@ -4184,7 +4184,6 @@ public:
     DYNCAST dyncast() const final override;
     virtual Statement* syntaxCopy();
     static Array<Statement* >* arraySyntaxCopy(Array<Statement* >* a);
-    const char* toChars() const final override;
     virtual Statement* getRelatedLabeled();
     virtual bool hasBreak() const;
     virtual bool hasContinue() const;
@@ -8116,6 +8115,8 @@ public:
 extern Expression* resolveProperties(Scope* sc, Expression* e);
 
 extern Expression* expressionSemantic(Expression* e, Scope* sc);
+
+extern const char* toChars(const Initializer* const i);
 
 extern void json_generate(Array<Module* >& modules, OutBuffer& buf);
 

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -88,6 +88,23 @@ extern (C++) void genhdrfile(Module m, ref OutBuffer buf)
     toCBuffer(m, buf, hgs);
 }
 
+/***************************************
+ * Turn a Statement into a string suitable for printf.
+ * Leaks memory.
+ * Params:
+ *	s = Statement to convert
+ * Returns:
+ *	0-terminated string
+ */
+public extern (C++) const(char)* toChars(const Statement s)
+{
+    HdrGenState hgs;
+    OutBuffer buf;
+    toCBuffer(s, buf, hgs);
+    buf.writeByte(0);
+    return buf.extractSlice().ptr;
+}
+
 public extern (C++) const(char)* toChars(const Initializer i)
 {
     OutBuffer buf;

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -82,15 +82,6 @@ extern (C++) abstract class Statement : ASTNode
         return b;
     }
 
-    override final const(char)* toChars() const
-    {
-        HdrGenState hgs;
-        OutBuffer buf;
-        toCBuffer(this, buf, hgs);
-        buf.writeByte(0);
-        return buf.extractSlice().ptr;
-    }
-
     Statement getRelatedLabeled()
     {
         return this;

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -113,8 +113,6 @@ public:
 
     virtual Statement *syntaxCopy();
 
-    const char *toChars() const override final;
-
     void error(const char *format, ...);
     void warning(unsigned flag, const char *format, ...);
     void deprecation(const char *format, ...);


### PR DESCRIPTION
There's no longer a point to it being a virtual function.