### PR TITLE
fix Issue 24171 - [REG 2.100] Segfault compiling an empty ddoc file

### DIFF
--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -433,7 +433,7 @@ extern(C++) void gendocfile(Module m)
         if (!loc.filename)
             loc.filename = srcfilename.ptr;
 
-        size_t commentlen = strlen(cast(char*)m.comment);
+        size_t commentlen = m.comment ? strlen(cast(char*)m.comment) : 0;
         Dsymbols a;
         // https://issues.dlang.org/show_bug.cgi?id=9764
         // Don't push m in a, to prevent emphasize ddoc file name.

--- a/compiler/test/compilable/test24171.sh
+++ b/compiler/test/compilable/test24171.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+output_html=${OUTPUT_BASE}.html
+
+rm_retry ${output_html}
+
+$DMD -m${MODEL} -D -o- ${EXTRA_FILES}/ddoc24171.dd -Df${output_html}


### PR DESCRIPTION
The issue in the PR is that the logic in [this line](https://github.com/dlang/dmd/pull/13769/files#diff-754aebf8df440c85fc348a10b6be50cd2789588e370eeea283aec7bd686a5df0R1215) was changed from `!comment` to `!comment || !*comment`.

Rather than reverting though, assume this change is correct and adjust the one place where a null comment is problematic.