### PR TITLE
Fix issue 5445 - DMD does not look for ".dmd.conf" in HOME dir

### DIFF
--- a/compiler/src/dmd/dinifile.d
+++ b/compiler/src/dmd/dinifile.d
@@ -60,6 +60,15 @@ const(char)[] findConfFile(const(char)[] argv0, const(char)[] inifile)
     auto filename = FileName.combine(getenv("HOME").toDString, inifile);
     if (FileName.exists(filename))
         return filename;
+
+    version (Posix)
+    {
+        // Retry lookup in HOME with dot preceding inifile
+        filename = FileName.combine(getenv("HOME").toDString, '.' ~ inifile);
+        if (FileName.exists(filename))
+            return filename;
+    }
+
     version (Windows)
     {
         // This fix by Tim Matthews


### PR DESCRIPTION
This PR adds the ability to also look for a `.dmd.conf` file inside the `$HOME` directory on Posix systems when no `dmd.conf` file was found inside the same directory.

This PR is based on the old PR https://github.com/dlang/dmd/pull/9450, but which got closed for unknown reasons.