### PR TITLE
Fix issue 19460 - C style cast error has wrong line number for functions

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8899,7 +8899,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                                 {
                                     e = parseUnaryExp();
                                     e = new AST.CastExp(loc, e, t);
-                                    error("C style cast illegal, use `%s`", e.toChars());
+                                    error(loc, "C style cast illegal, use `%s`", e.toChars());
                                 }
                                 return e;
                             }

--- a/compiler/test/fail_compilation/ccast.d
+++ b/compiler/test/fail_compilation/ccast.d
@@ -1,9 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ccast.d(11): Error: C style cast illegal, use `cast(byte)i`
-fail_compilation/ccast.d(24): Error: C style cast illegal, use `cast(foo)5`
-fail_compilation/ccast.d(26): Error: C style cast illegal, use `cast(void*)5`
+fail_compilation/ccast.d(12): Error: C style cast illegal, use `cast(byte)i`
+fail_compilation/ccast.d(25): Error: C style cast illegal, use `cast(foo)5`
+fail_compilation/ccast.d(27): Error: C style cast illegal, use `cast(void*)5`
+fail_compilation/ccast.d(30): Error: C style cast illegal, use `cast(void*)5`
 ---
 */
 
@@ -25,4 +26,7 @@ void main()
 
     (void*)5;
     (void*)(5); // semantic implicit cast error
+
+    (void*)
+        5;
 }


### PR DESCRIPTION
This PR changes the way errors for c-style casts gets it's line number. It now uses the location from the type of the cast (aka the beginning) instead of the value (aka the end). This makes a difference when a cast spanns over multiple lines (i.e. 2); the new behavior sets the location correctly onto the first line instead of the last.