### PR TITLE
Fix issue 24174 - [CTFE] goto within with statements & catch blocks cause a infinite loop

### DIFF
--- a/compiler/test/compilable/issue24174.d
+++ b/compiler/test/compilable/issue24174.d
@@ -1,0 +1,38 @@
+/* TEST_OUTPUT:
+---
+true
+false
+---
+*/
+
+bool func1() {
+    struct BtMatcher {
+        uint pc = 0;
+    }
+    BtMatcher matcher;
+    with (matcher) {
+        goto StartLoop;
+        StartLoop:
+        goto SecondLabel;
+        SecondLabel:
+        return true;
+    }
+}
+
+bool func2() {
+    try {
+        throw new Exception("a");
+        return true;
+    } catch (Exception e) {
+        goto StartA;
+        StartA:
+        goto StartB;
+        StartB:
+        return false;
+    }
+}
+
+pragma(msg, func1());
+pragma(msg, func2());
+
+void main() {}

--- a/compiler/test/compilable/issue24174.d
+++ b/compiler/test/compilable/issue24174.d
@@ -34,5 +34,3 @@ bool func2() {
 
 pragma(msg, func1());
 pragma(msg, func2());
-
-void main() {}


### PR DESCRIPTION
This PR fixes an issue in the CTFE engine, where using two (or more) goto's inside a with-statement or a catch block causes the compiler to enter a infinite loop.

The patch implements the fix the same way `visitTryFinally` already does it.

Example code (also added as test):
```d
bool func1() {
    struct BtMatcher {
        uint pc = 0;
    }
    BtMatcher matcher;
    with (matcher) {
        goto StartLoop;
        StartLoop:
        goto SecondLabel;
        SecondLabel:
        return true;
    }
}

bool func2() {
    try {
        throw new Exception("a");
        return true;
    } catch (Exception e) {
        goto StartA;
        StartA:
        goto StartB;
        StartB:
        return false;
    }
}

// Either of these will put dmd into a endless loop
pragma(msg, func1());
pragma(msg, func2());

void main() {}
```