### PR TITLE
Fix issue 11070 - Allow declaration statement in a switch expression

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -2143,16 +2143,20 @@ struct ASTBase
 
     extern (C++) final class SwitchStatement : Statement
     {
+        Parameter param;
         Expression condition;
         Statement _body;
         bool isFinal;
+        Loc endloc;             // location of closing curly bracket
 
-        extern (D) this(const ref Loc loc, Expression c, Statement b, bool isFinal)
+        extern (D) this(const ref Loc loc, Parameter param, Expression c, Statement b, bool isFinal, Loc endloc)
         {
             super(loc, STMT.Switch);
+            this.param = param;
             this.condition = c;
             this._body = b;
             this.isFinal = isFinal;
+            this.endloc = endloc;
         }
 
         override void accept(Visitor v)

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -504,7 +504,7 @@ final class CParser(AST) : Parser!AST
             auto condition = cparseExpression();
             check(TOK.rightParenthesis);
             auto _body = cparseStatement(ParseStatementFlags.scope_);
-            s = new AST.SwitchStatement(loc, condition, _body, false);
+            s = new AST.SwitchStatement(loc, null, condition, _body, false, token.loc);
             break;
         }
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4650,9 +4650,11 @@ public:
 class SwitchStatement final : public Statement
 {
 public:
+    Parameter *param;
     Expression* condition;
     Statement* _body;
     bool isFinal;
+    Loc endloc;
     bool hasDefault;
     bool hasVars;
     DefaultStatement* sdefault;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -543,6 +543,20 @@ private void statementToBuffer(Statement s, ref OutBuffer buf, HdrGenState* hgs)
     void visitSwitch(SwitchStatement s)
     {
         buf.writestring(s.isFinal ? "final switch (" : "switch (");
+        if (auto p = s.param)
+        {
+            // Print condition assignment
+            StorageClass stc = p.storageClass;
+            if (!p.type && !stc)
+                stc = STC.auto_;
+            if (stcToBuffer(buf, stc))
+                buf.writeByte(' ');
+            if (p.type)
+                typeToBuffer(p.type, p.ident, buf, hgs);
+            else
+                buf.writestring(p.ident.toString());
+            buf.writestring(" = ");
+        }
         s.condition.expressionToBuffer(buf, hgs);
         buf.writeByte(')');
         buf.writenl();

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -6329,10 +6329,11 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             {
                 nextToken();
                 check(TOK.leftParenthesis);
+                auto param = parseAssignCondition();
                 AST.Expression condition = parseExpression();
                 closeCondition("switch", null, condition);
                 AST.Statement _body = parseStatement(ParseStatementFlags.scope_);
-                s = new AST.SwitchStatement(loc, condition, _body, isfinal);
+                s = new AST.SwitchStatement(loc, param, condition, _body, isfinal, token.loc);
                 break;
             }
         case TOK.case_:

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1098,9 +1098,11 @@ extern (C++) final class StaticAssertStatement : Statement
  */
 extern (C++) final class SwitchStatement : Statement
 {
+    Parameter param;
     Expression condition;           /// switch(condition)
     Statement _body;                ///
     bool isFinal;                   /// https://dlang.org/spec/statement.html#final-switch-statement
+    Loc endloc;
 
     bool hasDefault;                /// true if has default statement
     bool hasVars;                   /// true if has variable case values
@@ -1111,17 +1113,24 @@ extern (C++) final class SwitchStatement : Statement
     CaseStatements* cases;          /// array of CaseStatement's
     VarDeclaration lastVar;         /// last observed variable declaration in this statement
 
-    extern (D) this(const ref Loc loc, Expression condition, Statement _body, bool isFinal)
+    extern (D) this(const ref Loc loc, Parameter param, Expression condition, Statement _body, bool isFinal, Loc endloc)
     {
         super(loc, STMT.Switch);
+        this.param = param;
         this.condition = condition;
         this._body = _body;
         this.isFinal = isFinal;
+        this.endloc = endloc;
     }
 
     override SwitchStatement syntaxCopy()
     {
-        return new SwitchStatement(loc, condition.syntaxCopy(), _body.syntaxCopy(), isFinal);
+        return new SwitchStatement(loc,
+            param ? param.syntaxCopy() : null,
+            condition.syntaxCopy(),
+            _body.syntaxCopy(),
+            isFinal,
+            endloc);
     }
 
     override bool hasBreak() const pure nothrow

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -429,9 +429,11 @@ public:
 class SwitchStatement final : public Statement
 {
 public:
+    Parameter *param;
     Expression *condition;
     Statement *_body;
     d_bool isFinal;
+    Loc endloc;
 
     d_bool hasDefault;             // true if default statement
     d_bool hasVars;                // true if has variable case values

--- a/compiler/test/fail_compilation/issue11070.d
+++ b/compiler/test/fail_compilation/issue11070.d
@@ -11,7 +11,7 @@ void test() {
     import std.stdio : writeln;
     switch (auto x = get()) {
         default:
-            writeln("inside switch: ", x);
+            auto z = x;
     }
-    writeln("outside switch: ", x);
+    x = 1;
 }

--- a/compiler/test/fail_compilation/issue11070.d
+++ b/compiler/test/fail_compilation/issue11070.d
@@ -1,0 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/issue11070.d(16): Error: undefined identifier `x`
+---
+*/
+
+int get() { return 1; }
+
+void test() {
+    import std.stdio : writeln;
+    switch (auto x = get()) {
+        default:
+            writeln("inside switch: ", x);
+    }
+    writeln("outside switch: ", x);
+}

--- a/compiler/test/runnable/issue11070.d
+++ b/compiler/test/runnable/issue11070.d
@@ -7,10 +7,10 @@ inside switch: 1
 int get() { return 1; }
 
 void test() {
-    import std.stdio : writeln;
+    import core.stdc.stdio : printf;
     switch (auto x = get()) {
         default:
-            writeln("inside switch: ", x);
+            printf("inside switch: %d\n", x);
     }
 }
 

--- a/compiler/test/runnable/issue11070.d
+++ b/compiler/test/runnable/issue11070.d
@@ -1,0 +1,19 @@
+/* RUN_OUTPUT:
+---
+inside switch: 1
+---
+*/
+
+int get() { return 1; }
+
+void test() {
+    import std.stdio : writeln;
+    switch (auto x = get()) {
+        default:
+            writeln("inside switch: ", x);
+    }
+}
+
+void main() {
+    test();
+}


### PR DESCRIPTION
This PR adds the ability to use a variable declaration inside the switch's condition like if, while and so on already allow.

This is done by letting statementsem.d rewrite switch expressions that use this feature from:
```d
switch (auto a = exp) { body }
```
into
```d
{
    auto a = exp;
    switch (a) { body }
}
```

Added two tests; one that verifies that a isnt leaked beyond the switch's inner scope, and one that verifies it actually works & runs.