### PR TITLE
[dtoh] don't emit typedef's for size_t/ptrdiff_t

### DIFF
--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -23,6 +23,7 @@ import dmd.dsymbol;
 import dmd.errors;
 import dmd.globals;
 import dmd.hdrgen;
+import dmd.id;
 import dmd.identifier;
 import dmd.location;
 import dmd.root.filename;
@@ -1045,6 +1046,10 @@ public:
     override void visit(AST.AliasDeclaration ad)
     {
         debug (Debug_DtoH) mixin(traceVisit!ad);
+
+        // Declared in object.d but already included in `#include`s
+        if (ad.ident == Id._size_t || ad.ident == Id._ptrdiff_t)
+            return;
 
         if (!shouldEmitAndMarkVisited(ad))
             return;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -592,8 +592,6 @@ public:
     virtual StaticIfDeclaration* isStaticIfDeclaration();
 };
 
-typedef uint64_t size_t;
-
 struct BitArray final
 {
     typedef uint64_t Chunk_t;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8558,6 +8558,8 @@ struct Id final
     static Identifier* IUnknown;
     static Identifier* Object;
     static Identifier* object;
+    static Identifier* _size_t;
+    static Identifier* _ptrdiff_t;
     static Identifier* string;
     static Identifier* wstring;
     static Identifier* dstring;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -61,6 +61,8 @@ immutable Msgtable[] msgtable =
     { "IUnknown" },
     { "Object" },
     { "object" },
+    { "_size_t", "size_t" },
+    { "_ptrdiff_t", "ptrdiff_t" },
     { "string" },
     { "wstring" },
     { "dstring" },

--- a/compiler/test/compilable/dtoh_TemplateDeclaration.d
+++ b/compiler/test/compilable/dtoh_TemplateDeclaration.d
@@ -39,8 +39,6 @@ struct _d_dynamicArray final
 };
 #endif
 
-typedef uint$?:32=32|64=64$_t size_t;
-
 struct Outer final
 {
     int32_t a;


### PR DESCRIPTION
This causes redefinition errors on macOS and is already taken care of in the generated `#include <stddef.h>`