### PR TITLE
[dtoh] emit full base class declarations before subclasses

### DIFF
--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -1088,6 +1088,7 @@ public:
         }
         if (auto sd = ad.aliassym.isStructDeclaration())
         {
+            includeSymbol(sd);
             buf.writestring("typedef ");
             sd.type.accept(this);
             buf.writestring(" ");


### PR DESCRIPTION
This avoids errors of the form "base class has incomplete type" for

class A; // fwd decl

class B : A {}

class A {}

Test case for this will be frontend.h, will update it once Circle gives the diff