### PR TITLE
Fix ICE: failed to detect static initialization of associative array

### DIFF
--- a/compiler/src/dmd/ctfeexpr.d
+++ b/compiler/src/dmd/ctfeexpr.d
@@ -305,9 +305,10 @@ UnionExp copyLiteral(Expression e)
     }
     if (auto aae = e.isAssocArrayLiteralExp())
     {
-        emplaceExp!(AssocArrayLiteralExp)(&ue, e.loc, copyLiteralArray(aae.keys), copyLiteralArray(aae.values));
+        emplaceExp!(AssocArrayLiteralExp)(&ue, aae.loc, copyLiteralArray(aae.keys), copyLiteralArray(aae.values));
         AssocArrayLiteralExp r = ue.exp().isAssocArrayLiteralExp();
-        r.type = e.type;
+        r.type = aae.type;
+        r.lowering = aae.lowering;
         r.ownedByCtfe = OwnedBy.ctfe;
         return ue;
     }

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1601,6 +1601,8 @@ extern (C++) class VarDeclaration : Declaration
         {
             inuse++;
             _init = _init.initializerSemantic(_scope, type, INITinterpret);
+            import dmd.semantic2 : lowerStaticAAs;
+            lowerStaticAAs(this, _scope);
             _scope = null;
             inuse--;
         }

--- a/compiler/test/runnable/staticaa.d
+++ b/compiler/test/runnable/staticaa.d
@@ -90,6 +90,20 @@ void testStructInit()
     assert(s.t[A.y] == "A.y");
 }
 
+struct S2
+{
+    string[A] t = [A.x : "A.x", A.y : "A.y"];
+}
+
+bool testStructInitCTFE()
+{
+    S2 s2;
+    assert(s2.t[A.x] == "A.x");
+    assert(s2.t[A.y] == "A.y");
+    return true;
+}
+static assert(testStructInitCTFE());
+
 /////////////////////////////////////////////
 
 class C
@@ -102,6 +116,19 @@ void testClassInit()
     C c = new C();
     assert(c.t[0] == "zero");
 }
+
+class C2
+{
+    string[int] t = [0 : "zero"];
+}
+
+bool testClassInitCTFE()
+{
+    C2 c2 = new C2();
+    assert(c2.t[0] == "zero");
+    return true;
+}
+static assert(testClassInitCTFE());
 
 /////////////////////////////////////////////
 


### PR DESCRIPTION
When an associative array field initializer was evaluated by CTFE, then its "lowering" would neither be generated, nor copied back out of CTFE.

This would cause an assertion failure in dmd at src/dmd/todt.d(491).