### PR TITLE
Fix out of sync C++ headers for GDC and LDC

### DIFF
--- a/compiler/src/dmd/doc.h
+++ b/compiler/src/dmd/doc.h
@@ -11,5 +11,7 @@
 #pragma once
 
 class Module;
+class ErrorSink;
 
-void gendocfile(Module *m);
+void gendocfile(Module *m, const char *ddoctext_ptr, size_t ddoctext_length,
+                const char *datetime, ErrorSink *eSink, OutBuffer &outbuf);

--- a/compiler/src/dmd/errors.h
+++ b/compiler/src/dmd/errors.h
@@ -33,8 +33,8 @@ bool isConsoleColorSupported();
 #endif
 
 // Print a warning, deprecation, or error, accepts printf-like format specifiers.
-D_ATTRIBUTE_FORMAT(3, 4) void warning(unsigned flag, const Loc& loc, const char *format, ...);
-D_ATTRIBUTE_FORMAT(3, 4) void warningSupplemental(unsigned flag, const Loc& loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 3) void warning(const Loc& loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 3) void warningSupplemental(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void deprecation(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void deprecationSupplemental(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void error(const Loc& loc, const char *format, ...);
@@ -44,8 +44,8 @@ D_ATTRIBUTE_FORMAT(1, 2) void message(const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void message(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(1, 2) void tip(const char *format, ...);
 
-D_ATTRIBUTE_FORMAT(2, 0) void verrorReport(const Loc& loc, const char *format, va_list ap, ErrorKind kind, unsigned flag = 0, const char *p1 = NULL, const char *p2 = NULL);
-D_ATTRIBUTE_FORMAT(2, 0) void verrorReportSupplemental(const Loc& loc, const char* format, va_list ap, ErrorKind kind, unsigned flag = 0);
+D_ATTRIBUTE_FORMAT(2, 0) void verrorReport(const Loc& loc, const char *format, va_list ap, ErrorKind kind, const char *p1 = NULL, const char *p2 = NULL);
+D_ATTRIBUTE_FORMAT(2, 0) void verrorReportSupplemental(const Loc& loc, const char* format, va_list ap, ErrorKind kind);
 
 #if defined(__GNUC__) || defined(__clang__)
 #define D_ATTRIBUTE_NORETURN __attribute__((noreturn))

--- a/compiler/src/dmd/hdrgen.h
+++ b/compiler/src/dmd/hdrgen.h
@@ -15,7 +15,7 @@
 
 class Module;
 
-void genhdrfile(Module *m);
+void genhdrfile(Module *m, OutBuffer &buf);
 void genCppHdrFiles(Modules &ms);
 void moduleToBuffer(OutBuffer& buf, Module *m);
 const char *parametersTypeToChars(ParameterList pl);

--- a/compiler/src/dmd/json.h
+++ b/compiler/src/dmd/json.h
@@ -15,5 +15,5 @@
 
 struct OutBuffer;
 
-void json_generate(OutBuffer *, Modules *);
+void json_generate(Modules &, OutBuffer &);
 JsonFieldFlags tryParseJsonField(const char *fieldName);


### PR DESCRIPTION
People really need to stop merging things that break existing downstream DMD-as-a-library users.