### PR TITLE
test: Add missing EXTRA_FILES directives to tests

### DIFF
--- a/compiler/test/compilable/test20008.d
+++ b/compiler/test/compilable/test20008.d
@@ -1,6 +1,6 @@
 /*
 REQUIRED_ARGS: -Icompilable/imports -c -o-
-EXTRA_FILES: imports/pkg20008/package.d imports/pkg20008/submod.d
+EXTRA_FILES: imports/pkg20008/package.d imports/pkg20008/submod.d imports/pkg20008/subpkg/package.d imports/pkg20008/subpkg/subsubmod.d
 */
 import pkg20008;
 import pkg20008.subpkg;

--- a/compiler/test/compilable/test23789.d
+++ b/compiler/test/compilable/test23789.d
@@ -1,4 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=23789
+// EXTRA_FILES: imports/c23789.i
 
 import imports.c23789;
 

--- a/compiler/test/runnable/test23837.d
+++ b/compiler/test/runnable/test23837.d
@@ -1,4 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=23837
+// EXTRA_FILES: imports/mainx23837.c
 
 import imports.mainx23837;
 


### PR DESCRIPTION
These tests are currently failing because dependency files aren't scp'd to remote.