### PR TITLE
Revert "Catch need not be a RootObject"

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -2529,7 +2529,7 @@ struct ASTBase
         }
     }
 
-    extern (C++) final class Catch
+    extern (C++) final class Catch : RootObject
     {
         Loc loc;
         Type type;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4278,7 +4278,7 @@ public:
     void accept(Visitor* v) override;
 };
 
-class Catch final
+class Catch final : public RootObject
 {
 public:
     const Loc loc;

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -1484,7 +1484,7 @@ extern (C++) final class TryCatchStatement : Statement
 /***********************************************************
  * https://dlang.org/spec/statement.html#Catch
  */
-extern (C++) final class Catch
+extern (C++) final class Catch : RootObject
 {
     const Loc loc;
     Type type;

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -590,7 +590,7 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-class Catch final
+class Catch final : public RootObject
 {
 public:
     Loc loc;


### PR DESCRIPTION
Reverts dlang/dmd#15700

> Catch need not be a RootObject

Yes it does.
```
FAIL: gdc.test/compilable/b18242.d   (internal compiler error: Segmentation fault)
FAIL: gdc.test/compilable/b18242.d   output-exists b18242.s
FAIL: gdc.test/compilable/interpret3.d   (internal compiler error: Segmentation fault)
FAIL: gdc.test/compilable/interpret3.d   output-exists interpret3.s
FAIL: gdc.test/compilable/interpret3.d -finline-functions    output-exists interpret3.s
FAIL: gdc.test/compilable/interpret3.d -finline-functions   (internal compiler error: Segmentation fault)
FAIL: gdc.test/compilable/issue24174.d   (internal compiler error: Segmentation fault)
FAIL: gdc.test/compilable/issue24174.d   output-exists issue24174.s
FAIL: gdc.test/compilable/test16031.d   (internal compiler error: Segmentation fault)
FAIL: gdc.test/compilable/test16031.d   output-exists test16031.s
FAIL: gdc.test/compilable/test20100.d   (internal compiler error: Segmentation fault)
FAIL: gdc.test/compilable/test20100.d   output-exists test20100.s
FAIL: gdc.test/compilable/test23626.d   (internal compiler error: Segmentation fault)
FAIL: gdc.test/compilable/test23626.d   output-exists test23626.s
FAIL: gdc.test/compilable/testInference.d   (internal compiler error: Segmentation fault)
FAIL: gdc.test/compilable/testInference.d   output-exists testInference.s
FAIL: gdc.test/compilable/testcontracts.d   (internal compiler error: Segmentation fault)
FAIL: gdc.test/compilable/testcontracts.d   output-exists testcontracts.s
FAIL: gdc.test/compilable/testdip1008.d   (internal compiler error: Segmentation fault)
FAIL: gdc.test/compilable/testdip1008.d   output-exists testdip1008.s
```

Hint: "final" C++ classes do not have a vtable.