### PR TITLE
move dmd/root/rootobject.d to dmd

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1544,7 +1544,7 @@ auto sourceFiles()
             dtemplate.d dtoh.d dversion.d escape.d expression.d expressionsem.d func.d hdrgen.d impcnvtab.d
             imphint.d importc.d init.d initsem.d inline.d inlinecost.d intrange.d json.d lambdacomp.d
             mtype.d mustuse.d nogc.d nspace.d ob.d objc.d opover.d optimize.d
-            parse.d parsetimevisitor.d permissivevisitor.d postordervisitor.d printast.d safe.d sapply.d
+            parse.d parsetimevisitor.d permissivevisitor.d postordervisitor.d printast.d rootobject.d safe.d sapply.d
             semantic2.d semantic3.d sideeffect.d statement.d statement_rewrite_walker.d
             statementsem.d staticassert.d staticcond.d stmtstate.d target.d templateparamsem.d traits.d
             transitivevisitor.d typesem.d typinf.d utils.d visitor.d foreachvar.d
@@ -1573,7 +1573,7 @@ auto sourceFiles()
             console.d entity.d errors.d errorsink.d file_manager.d globals.d id.d identifier.d lexer.d location.d tokens.d
         ") ~ fileArray(env["ROOT"], "
             array.d bitarray.d ctfloat.d file.d filename.d hash.d port.d region.d rmem.d
-            rootobject.d stringtable.d utf.d
+            stringtable.d utf.d
         "),
         common: fileArray(env["COMMON"], "
             bitfields.d file.d int128.d outbuffer.d string.d

--- a/compiler/src/dmd/README.md
+++ b/compiler/src/dmd/README.md
@@ -84,6 +84,7 @@ Note that these groups have no strict meaning, the category assignments are a bi
 | [astcodegen.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/astcodegen.d)     | Namespace of AST nodes of a AST ready for code generation   |
 | [astenums.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/astenums.d)         | Enums common to DMD and AST                                 |
 | [expression.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/expression.d)     | Define expression AST nodes                                 |
+| [rootobject.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/rootobject.d)     | Define an abstract root class                           |
 | [statement.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/statement.d)       | Define statement AST nodes                                  |
 | [staticassert.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/staticassert.d) | Define a `static assert` AST node                           |
 | [aggregate.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/aggregate.d)       | Define an aggregate (`struct`, `union` or `class`) AST node |

--- a/compiler/src/dmd/arraytypes.d
+++ b/compiler/src/dmd/arraytypes.d
@@ -22,7 +22,7 @@ import dmd.identifier;
 import dmd.init;
 import dmd.mtype;
 import dmd.root.array;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.statement;
 
 alias Strings = Array!(const(char)*);

--- a/compiler/src/dmd/ast_node.d
+++ b/compiler/src/dmd/ast_node.d
@@ -10,7 +10,7 @@
  */
 module dmd.ast_node;
 
-import dmd.root.rootobject : RootObject;
+import dmd.rootobject : RootObject;
 import dmd.visitor : Visitor;
 
 /// The base class of all AST nodes.

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -25,7 +25,7 @@ struct ASTBase
     import dmd.root.file;
     import dmd.root.filename;
     import dmd.root.array;
-    import dmd.root.rootobject;
+    import dmd.rootobject;
     import dmd.common.outbuffer;
     import dmd.root.ctfloat;
     import dmd.root.rmem;

--- a/compiler/src/dmd/asttypename.d
+++ b/compiler/src/dmd/asttypename.d
@@ -36,7 +36,7 @@ import dmd.typinf;
 import dmd.identifier;
 import dmd.init;
 import dmd.root.complex;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.statement;
 import dmd.staticassert;
 import dmd.nspace;

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -30,7 +30,7 @@ import dmd.location;
 import dmd.mtype;
 import dmd.typesem;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.string;
 import dmd.tokens;
 import dmd.utils;

--- a/compiler/src/dmd/cppmangle.d
+++ b/compiler/src/dmd/cppmangle.d
@@ -42,7 +42,7 @@ import dmd.mtype;
 import dmd.nspace;
 import dmd.root.array;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.string;
 import dmd.target;
 import dmd.typesem;

--- a/compiler/src/dmd/cppmanglewin.d
+++ b/compiler/src/dmd/cppmanglewin.d
@@ -31,7 +31,7 @@ import dmd.identifier;
 import dmd.location;
 import dmd.mtype;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.target;
 import dmd.tokens;
 import dmd.typesem;

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -37,7 +37,7 @@ import dmd.intrange;
 import dmd.location;
 import dmd.mtype;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.target;
 import dmd.tokens;
 import dmd.typesem;

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -44,7 +44,7 @@ import dmd.root.rmem;
 import dmd.root.array;
 import dmd.root.ctfloat;
 import dmd.root.region;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.utf;
 import dmd.statement;
 import dmd.tokens;

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -45,7 +45,7 @@ import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.port;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.string;
 import dmd.semantic2;
 import dmd.semantic3;

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -48,7 +48,7 @@ import dmd.nspace;
 import dmd.opover;
 import dmd.root.aav;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.speller;
 import dmd.root.string;
 import dmd.statement;

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -62,7 +62,7 @@ import dmd.root.array;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.utf;
 import dmd.semantic2;
 import dmd.semantic3;

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -70,7 +70,7 @@ import dmd.mtype;
 import dmd.opover;
 import dmd.root.array;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.semantic2;
 import dmd.semantic3;
 import dmd.tokens;

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -1813,7 +1813,7 @@ public:
         {
             buf.writestring("::");
 
-            import dmd.root.rootobject;
+            import dmd.rootobject;
             // Is this even possible?
             if (arg.dyncast != DYNCAST.identifier)
             {

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -19,7 +19,7 @@ import core.stdc.time;
 import dmd.root.array;
 import dmd.root.ctfloat;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.stringtable;
 
 import dmd.aggregate;

--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -32,7 +32,7 @@ import dmd.init;
 import dmd.location;
 import dmd.mtype;
 import dmd.printast;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.tokens;
 import dmd.visitor;
 import dmd.arraytypes;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -63,7 +63,7 @@ import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.optional;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.string;
 import dmd.root.utf;
 import dmd.safe;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -67,7 +67,7 @@ import dmd.root.array;
 import dmd.root.ctfloat;
 import dmd.root.filename;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.string;
 import dmd.root.utf;
 import dmd.semantic2;

--- a/compiler/src/dmd/foreachvar.d
+++ b/compiler/src/dmd/foreachvar.d
@@ -35,7 +35,7 @@ import dmd.mtype;
 import dmd.postordervisitor;
 import dmd.printast;
 import dmd.root.array;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.statement;
 import dmd.tokens;
 import dmd.visitor;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -48,7 +48,7 @@ import dmd.mtype;
 import dmd.objc;
 import dmd.root.aav;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.string;
 import dmd.root.stringtable;
 import dmd.semantic2;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -45,7 +45,7 @@ import dmd.parse;
 import dmd.root.complex;
 import dmd.root.ctfloat;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.string;
 import dmd.statement;
 import dmd.staticassert;

--- a/compiler/src/dmd/iasmdmd.d
+++ b/compiler/src/dmd/iasmdmd.d
@@ -41,7 +41,7 @@ import dmd.tokens;
 import dmd.root.ctfloat;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;

--- a/compiler/src/dmd/identifier.d
+++ b/compiler/src/dmd/identifier.d
@@ -17,7 +17,7 @@ import core.stdc.string;
 import dmd.id;
 import dmd.location;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.string;
 import dmd.root.stringtable;
 import dmd.root.utf;

--- a/compiler/src/dmd/init.d
+++ b/compiler/src/dmd/init.d
@@ -25,7 +25,7 @@ import dmd.identifier;
 import dmd.location;
 import dmd.mtype;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.tokens;
 import dmd.visitor;
 

--- a/compiler/src/dmd/json.d
+++ b/compiler/src/dmd/json.d
@@ -35,7 +35,7 @@ import dmd.identifier;
 import dmd.location;
 import dmd.mtype;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.string;
 import dmd.target;
 import dmd.visitor;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -46,7 +46,7 @@ import dmd.opover;
 import dmd.root.ctfloat;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.stringtable;
 import dmd.target;
 import dmd.tokens;

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -256,7 +256,7 @@ private FuncDeclaration stripHookTraceImpl(FuncDeclaration fd)
 {
     import dmd.id : Id;
     import dmd.dsymbol : Dsymbol;
-    import dmd.root.rootobject : RootObject, DYNCAST;
+    import dmd.rootobject : RootObject, DYNCAST;
 
     if (fd.ident != Id._d_HookTraceImpl)
         return fd;

--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -16,7 +16,7 @@ import core.stdc.stdlib;
 import core.stdc.string;
 
 import dmd.root.array;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.rmem;
 
 import dmd.aggregate;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -25,7 +25,7 @@ import dmd.location;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.string;
 import dmd.tokens;
 

--- a/compiler/src/dmd/rootobject.d
+++ b/compiler/src/dmd/rootobject.d
@@ -4,12 +4,12 @@
  * Copyright: Copyright (C) 1999-2023 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/rootobject.d, root/_rootobject.d)
- * Documentation:  https://dlang.org/phobos/dmd_root_rootobject.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/rootobject.d
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/rootobject.d, _rootobject.d)
+ * Documentation:  https://dlang.org/phobos/dmd_rootobject.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/rootobject.d
  */
 
-module dmd.root.rootobject;
+module dmd.rootobject;
 
 /***********************************************************
  */

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -19,7 +19,7 @@ import core.stdc.time;
 
 import dmd.root.array;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 
 import dmd.aggregate;
 import dmd.astenums;

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -55,7 +55,7 @@ import dmd.parse;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.utf;
 import dmd.sideeffect;
 import dmd.statementsem;

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -58,7 +58,7 @@ import dmd.parse;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.utf;
 import dmd.sideeffect;
 import dmd.statementsem;

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -33,7 +33,7 @@ import dmd.identifier;
 import dmd.location;
 import dmd.mtype;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.sapply;
 import dmd.staticassert;
 import dmd.tokens;

--- a/compiler/src/dmd/templateparamsem.d
+++ b/compiler/src/dmd/templateparamsem.d
@@ -19,7 +19,7 @@ import dmd.globals;
 import dmd.location;
 import dmd.expression;
 import dmd.expressionsem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.mtype;
 import dmd.typesem;
 import dmd.visitor;

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -19,7 +19,7 @@ import core.stdc.time;
 import dmd.root.array;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
-import dmd.root.rootobject;
+import dmd.rootobject;
 
 import dmd.aggregate;
 import dmd.arraytypes;

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -49,7 +49,7 @@ import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
 import dmd.visitor;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.common.outbuffer;
 import dmd.root.string;
 

--- a/compiler/src/dmd/transitivevisitor.d
+++ b/compiler/src/dmd/transitivevisitor.d
@@ -8,7 +8,7 @@ module dmd.transitivevisitor;
 import dmd.astenums;
 import dmd.permissivevisitor;
 import dmd.tokens;
-import dmd.root.rootobject;
+import dmd.rootobject;
 
 import core.stdc.stdio;
 

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -57,7 +57,7 @@ import dmd.root.complex;
 import dmd.root.ctfloat;
 import dmd.root.rmem;
 import dmd.common.outbuffer;
-import dmd.root.rootobject;
+import dmd.rootobject;
 import dmd.root.string;
 import dmd.root.stringtable;
 import dmd.safe;

--- a/compiler/src/dmd/visitor.d
+++ b/compiler/src/dmd/visitor.d
@@ -17,7 +17,7 @@ import dmd.parsetimevisitor;
 import dmd.tokens;
 import dmd.transitivevisitor;
 import dmd.expression;
-import dmd.root.rootobject;
+import dmd.rootobject;
 
 /**
  * Classic Visitor class which implements visit methods for all the AST


### PR DESCRIPTION
root/rootobject.d originally was meant as the root object for a general purpose library. It turns out that wasn't a good design, and the only use for RootObject was as the ancestor to ASTNode. The root directory was for general purpose modules, not dmd specific ones. This moves it from dmd/root to dmd.

The previous attempt at this, https://github.com/dlang/dmd/pull/15702, caused complex cyclical import problems.