### PR TITLE
eliminate static constructor in mustuse.d

### DIFF
--- a/compiler/src/dmd/mustuse.d
+++ b/compiler/src/dmd/mustuse.d
@@ -18,17 +18,6 @@ import dmd.globals;
 import dmd.identifier;
 import dmd.location;
 
-// Used in isIncrementOrDecrement
-private const StringExp plusPlus, minusMinus;
-
-// Loc.initial cannot be used in static initializers, so
-// these need a static constructor.
-shared static this()
-{
-    plusPlus = new StringExp(Loc.initial, "++");
-    minusMinus = new StringExp(Loc.initial, "--");
-}
-
 /**
  * Check whether discarding an expression would violate the requirements of
  * @mustuse. If so, emit an error.
@@ -173,9 +162,15 @@ private bool isIncrementOrDecrement(Expression e)
                     {
                         if (auto argExp = (*tiargs)[0].isExpression())
                         {
-                            auto op = argExp.isStringExp();
-                            if (op && (op.compare(plusPlus) == 0 || op.compare(minusMinus) == 0))
-                                return true;
+                            if (auto op = argExp.isStringExp())
+                            {
+                                if (op.len == 2 && op.sz == 1)
+                                {
+                                    const s = op.peekString();
+                                    if (s == "++" || s == "--")
+                                        return true;
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The static constructor is subject to cyclic construction errors, as seen in https://github.com/dlang/dmd/pull/15702

So just eliminate the constructor.