### PR TITLE
C++: Use d_size_t in gendocfile declaration

### DIFF
--- a/compiler/src/dmd/doc.h
+++ b/compiler/src/dmd/doc.h
@@ -10,8 +10,10 @@
 
 #pragma once
 
+#include "root/dcompat.h" // for d_size_t
+
 class Module;
 class ErrorSink;
 
-void gendocfile(Module *m, const char *ddoctext_ptr, size_t ddoctext_length,
+void gendocfile(Module *m, const char *ddoctext_ptr, d_size_t ddoctext_length,
                 const char *datetime, ErrorSink *eSink, OutBuffer &outbuf);


### PR DESCRIPTION
Fixes undefined symbol errors on i686 darwin.