### PR TITLE
Remove D1 warning about length shadowing local variables

### DIFF
--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -479,12 +479,6 @@ extern (C++) struct Scope
                             s = *ps;
                         }
                     }
-                    if (!(flags & (SearchImportsOnly | IgnoreErrors)) &&
-                        ident == Id.length && sc.scopesym.isArrayScopeSymbol() &&
-                        sc.enclosing && sc.enclosing.search(loc, ident, null, flags))
-                    {
-                        warning(s.loc, "array `length` hides other `length` name in outer scope");
-                    }
                     //printMsg("\tfound local", s);
                     if (pscopesym)
                         *pscopesym = sc.scopesym;


### PR DESCRIPTION
Using an implicitly declared 'length' variable in index expressions was removed from the D2 language in 2.062 in favour of '$'.