### PR TITLE
Remove warning for discarded return value

### DIFF
--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -269,41 +269,6 @@ bool discardValue(Expression e)
             break;
         }
     case EXP.call:
-        /* Issue 3882: */
-        if (global.params.warnings != DiagnosticReporting.off && !global.gag)
-        {
-            CallExp ce = cast(CallExp)e;
-            if (e.type.ty == Tvoid)
-            {
-                /* Don't complain about calling void-returning functions with no side-effect,
-                 * because purity and nothrow are inferred, and because some of the
-                 * runtime library depends on it. Needs more investigation.
-                 *
-                 * One possible solution is to restrict this message to only be called in hierarchies that
-                 * never call assert (and or not called from inside unittest blocks)
-                 */
-            }
-            else if (ce.e1.type)
-            {
-                Type t = ce.e1.type.toBasetype();
-                if (t.ty == Tdelegate)
-                    t = (cast(TypeDelegate)t).next;
-                if (t.ty == Tfunction && (ce.f ? callSideEffectLevel(ce.f) : callSideEffectLevel(ce.e1.type)) > 0)
-                {
-                    const(char)* s;
-                    if (ce.f)
-                        s = ce.f.toPrettyChars();
-                    else if (ce.e1.op == EXP.star)
-                    {
-                        // print 'fp' if ce.e1 is (*fp)
-                        s = (cast(PtrExp)ce.e1).e1.toChars();
-                    }
-                    else
-                        s = ce.e1.toChars();
-                    warning(e.loc, "calling `%s` without side effects discards return value of type `%s`; prepend a `cast(void)` if intentional", s, e.type.toChars());
-                }
-            }
-        }
         return false;
     case EXP.andAnd:
     case EXP.orOr:

--- a/compiler/test/fail_compilation/fail3882.d
+++ b/compiler/test/fail_compilation/fail3882.d
@@ -1,18 +1,17 @@
-// REQUIRED_ARGS: -w
-// PERMUTE_ARGS: -debug
+/*
+PERMUTE_ARGS: -debug
+TEST_OUTPUT:
+---
+fail_compilation/fail3882.d(32): Error: `@mustuse` on functions is reserved for future use
+fail_compilation/fail3882.d(33): Error: `@mustuse` on functions is reserved for future use
+---
+*/
+import core.attribute;
 
 /******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=3882
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail3882.d(23): Warning: calling `fail3882.strictlyPure!int.strictlyPure` without side effects discards return value of type `int`; prepend a `cast(void)` if intentional
-fail_compilation/fail3882.d(27): Warning: calling `fp` without side effects discards return value of type `int`; prepend a `cast(void)` if intentional
----
-*/
-
-@safe pure nothrow T strictlyPure(T)(T x)
+@mustuse @safe pure nothrow T strictlyPure(T)(T x)
 {
     return x*x;
 }
@@ -30,18 +29,8 @@ void main()
 /******************************************/
 // bugfix in TypeFunction::purityLevel
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail3882.d(48): Warning: calling `fail3882.f1` without side effects discards return value of type `int`; prepend a `cast(void)` if intentional
-fail_compilation/fail3882.d(49): Warning: calling `fail3882.f2` without side effects discards return value of type `int`; prepend a `cast(void)` if intentional
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
----
-*/
-
-nothrow pure int f1(immutable(int)[] a) { return 0; }
-nothrow pure int f2(immutable(int)*  p) { return 0; }
+@mustuse nothrow pure int f1(immutable(int)[] a) { return 0; }
+@mustuse nothrow pure int f2(immutable(int)*  p) { return 0; }
 
 void test_bug()
 {


### PR DESCRIPTION
Either this is valid code, or it is rejected by the language and backed up by the spec.

Since we now have `@mustuse`, this warning makes even less sense to keep around as applying the attribute would make such code an error in the future when/if it gets implemented for functions.