### PR TITLE
C++: Fix use of bool in C++ headers for fields

### DIFF
--- a/compiler/src/dmd/aliasthis.h
+++ b/compiler/src/dmd/aliasthis.h
@@ -21,7 +21,7 @@ public:
    // alias Identifier this;
     Identifier *ident;
     Dsymbol    *sym;
-    bool       isDeprecated_;
+    d_bool     isDeprecated_;
 
     AliasThis *syntaxCopy(Dsymbol *) override;
     const char *kind() const override;

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -376,8 +376,8 @@ public:
     void *string;       // char, wchar, or dchar data
     size_t len;         // number of chars, wchars, or dchars
     unsigned char sz;   // 1: char, 2: wchar, 4: dchar
-    bool committed;     // if type is committed
-    bool hexString;     // if string is parsed from a hex string literal
+    d_bool committed;   // if type is committed
+    d_bool hexString;   // if string is parsed from a hex string literal
 
     static StringExp *create(const Loc &loc, const char *s);
     static StringExp *create(const Loc &loc, const void *s, d_size_t len);

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -272,9 +272,9 @@ struct CompileEnv
     DString time;
     DString vendor;
     DString timestamp;
-    bool previewIn;
-    bool ddocOutput;
-    bool shortenedMethods;
+    d_bool previewIn;
+    d_bool ddocOutput;
+    d_bool shortenedMethods;
 };
 
 struct Global

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -709,7 +709,7 @@ class AsmStatement : public Statement
 {
 public:
     Token *tokens;
-    bool caseSensitive;  // for register names
+    d_bool caseSensitive;  // for register names
 
     AsmStatement *syntaxCopy() override;
     void accept(Visitor *v) override { v->visit(this); }


### PR DESCRIPTION
This was originally introduced in 0579e27091bcdab91e8dfde46ae67c689de5a7b5/#14937 to fix bootstrapping on darwin-ppc targets where C/C++ `bool` is a 4-byte `unsigned` type.

It then promptly got broken in:
- a986508ed02ccea34bcb5d2acb3c1e5f6ff3a24e (4 days later by @WalterBright)
- 723e3773a22ae4e14ec57ffbf1e39710109e1d25 (20 days later by @dkorpel)
- 2e66b7eff7d7b9fd64ccd8dfe5f4bd638bcbaa22 (earlier last month by @WalterBright)
- d78e21e03056c2f7261a4534f9d5365f58563adf (earlier this month by @dkorpel)

The missing `d_bool` in aliasthis.h might have been overlooked on my part when doing an initial sweep of all headers, but as it appears at the end of the class (and is unreferenced by GDC C++ glue) it didn't affected the bootstrap initially succeeding.