### PR TITLE
do not add __gshared to functions generated from C

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1960,7 +1960,9 @@ final class CParser(AST) : Parser!AST
                         error("no initializer for function declaration");
                     if (specifier.scw & SCW.x_Thread_local)
                         error("functions cannot be `_Thread_local`"); // C11 6.7.1-4
-                    auto fd = new AST.FuncDeclaration(token.loc, Loc.initial, id, specifiersToSTC(level, specifier), dt, specifier.noreturn);
+                    StorageClass stc = specifiersToSTC(level, specifier);
+                    stc &= ~STC.gshared;        // no gshared functions
+                    auto fd = new AST.FuncDeclaration(token.loc, Loc.initial, id, stc, dt, specifier.noreturn);
                     specifiersToFuncDeclaration(fd, specifier);
                     s = fd;
                 }
@@ -2136,7 +2138,9 @@ final class CParser(AST) : Parser!AST
         auto body = cparseStatement(ParseStatementFlags.curly);  // don't start a new scope; continue with parameter scope
         typedefTab.pop();                                        // end of function scope
 
-        auto fd = new AST.FuncDeclaration(locFunc, prevloc, id, specifiersToSTC(LVL.global, specifier), ft, specifier.noreturn);
+        StorageClass stc = specifiersToSTC(LVL.global, specifier);
+        stc &= ~STC.gshared;    // no gshared functions
+        auto fd = new AST.FuncDeclaration(locFunc, prevloc, id, stc, ft, specifier.noreturn);
         specifiersToFuncDeclaration(fd, specifier);
 
         if (addFuncName)

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -1,0 +1,18 @@
+/*
+PERMUTE_ARGS:
+REQUIRED_ARGS: -Hf=${RESULTS_DIR}/compilable/ctod.di
+OUTPUT_FILES: ${RESULTS_DIR}/compilable/ctod.di
+
+TEST_OUTPUT:
+---
+=== ${RESULTS_DIR}/compilable/ctod.di
+// D import file generated from 'compilable/ctod.i'
+extern (C) uint equ(double x, double y);
+---
+ */
+
+
+unsigned equ(double x, double y)
+{
+    return *(long long *)&x == *(long long *)&y;
+}

--- a/compiler/test/compilable/extra-files/ctod.di
+++ b/compiler/test/compilable/extra-files/ctod.di
@@ -1,0 +1,2 @@
+// D import file generated from 'test.i'
+extern (C) uint equ(double x, double y);


### PR DESCRIPTION
First PR on generating .di files from C modules!

This one removes `__gshared` from function declarations.