### PR TITLE
Make `Visibility` and `Loc` ctors available to C++

### DIFF
--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -141,12 +141,13 @@ struct Visibility
     Kind kind;
     Package pkg;
 
-    extern (D):
-
-    this(Visibility.Kind kind) pure nothrow @nogc @safe
+    extern(C++) this(Visibility.Kind kind, Package pkg = null) pure nothrow @nogc @safe
     {
         this.kind = kind;
+        this.pkg  = pkg;
     }
+
+    extern (D):
 
     /**
      * Checks if `this` is less or more visible than `other`

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -385,6 +385,7 @@ public:
     static bool showColumns;
     static MessageStyle messageStyle;
     static void set(bool showColumns, MessageStyle messageStyle);
+    Loc(const char* filename, uint32_t linnum, uint32_t charnum);
     uint32_t charnum() const;
     uint32_t charnum(uint32_t num);
     uint32_t linnum() const;
@@ -442,6 +443,7 @@ struct Visibility final
 
     Kind kind;
     Package* pkg;
+    Visibility(Kind kind, Package* pkg = nullptr);
     Visibility() :
         pkg()
     {

--- a/compiler/src/dmd/location.d
+++ b/compiler/src/dmd/location.d
@@ -64,7 +64,7 @@ nothrow:
         this.messageStyle = messageStyle;
     }
 
-    extern (D) this(const(char)* filename, uint linnum, uint charnum) @safe
+    extern (C++) this(const(char)* filename, uint linnum, uint charnum) @safe
     {
         this._linnum = linnum;
         this._charnum = charnum;


### PR DESCRIPTION
this avoids calls to constructors that don't exist when generating the `frontend.h` C++ header with `-HC`.