### PR TITLE
C++: Mark many non-virtual 'final' methods as 'extern (D)'

### DIFF
--- a/compiler/src/dmd/aggregate.d
+++ b/compiler/src/dmd/aggregate.d
@@ -192,7 +192,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      * Returns:
      *      The total number of fields minus the number of hidden fields.
      */
-    final size_t nonHiddenFields()
+    extern (D) final size_t nonHiddenFields()
     {
         return fields.length - isNested() - (vthis2 !is null);
     }
@@ -202,7 +202,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      * Returns:
      *      false if failed to determine the size.
      */
-    final bool determineSize(const ref Loc loc)
+    extern (D) final bool determineSize(const ref Loc loc)
     {
         //printf("AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
 
@@ -609,7 +609,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     }
 
     /// Flag this aggregate as deprecated
-    final void setDeprecated()
+    extern (D) final void setDeprecated()
     {
         this.storage_class |= STC.deprecated_;
     }
@@ -745,7 +745,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     /*******************************************
      * Look for constructor declaration.
      */
-    final Dsymbol searchCtor()
+    extern (D) final Dsymbol searchCtor()
     {
         auto s = search(Loc.initial, Id.ctor);
         if (s)

--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -114,17 +114,13 @@ public:
 
     virtual Scope *newScope(Scope *sc);
     void setScope(Scope *sc) override final;
-    size_t nonHiddenFields();
-    bool determineSize(const Loc &loc);
     virtual void finalizeSize() = 0;
     uinteger_t size(const Loc &loc) override final;
     bool fill(const Loc &loc, Expressions &elements, bool ctorinit);
     Type *getType() override final;
     bool isDeprecated() const override final; // is aggregate deprecated?
-    void setDeprecated();
     bool isNested() const;
     bool isExport() const override final;
-    Dsymbol *searchCtor();
 
     Visibility visible() override final;
 
@@ -279,12 +275,10 @@ public:
     ObjcClassDeclaration objc;          // Data for a class declaration that is needed for the Objective-C integration
     Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
-    void classError(const char* fmt, const char* arg);
     static ClassDeclaration *create(const Loc &loc, Identifier *id, BaseClasses *baseclasses, Dsymbols *members, bool inObject);
     const char *toPrettyChars(bool QualifyTypes = false) override;
     ClassDeclaration *syntaxCopy(Dsymbol *s) override;
     Scope *newScope(Scope *sc) override;
-    bool isBaseOf2(ClassDeclaration *cd);
 
     #define OFFSET_RUNTIME 0x76543210
     #define OFFSET_FWDREF 0x76543211
@@ -292,11 +286,9 @@ public:
 
     bool isBaseInfoComplete();
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override final;
-    ClassDeclaration *searchBase(Identifier *ident);
     void finalizeSize() override;
     bool hasMonitor();
     bool isFuncHidden(FuncDeclaration *fd);
-    FuncDeclaration *findFunc(Identifier *ident, TypeFunction *tf);
     bool isCOMclass() const;
     virtual bool isCOMinterface() const;
     bool isCPPclass() const;

--- a/compiler/src/dmd/attrib.h
+++ b/compiler/src/dmd/attrib.h
@@ -123,7 +123,6 @@ public:
     Expressions *alignExps;
     structalign_t salign;
 
-    AlignDeclaration(const Loc &loc, Expression *ealign, Dsymbols *decl);
     AlignDeclaration *syntaxCopy(Dsymbol *s) override;
     Scope *newScope(Scope *sc) override;
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/src/dmd/canthrow.d
+++ b/compiler/src/dmd/canthrow.d
@@ -55,7 +55,7 @@ enum CT : BE
  *      eSink = if !null, then send error messages to eSink
  * Returns: `CT.exception` or `CT.error` if the expression may throw exceptions.
  */
-extern (C++) /* CT */ BE canThrow(Expression e, FuncDeclaration func, ErrorSink eSink)
+CT canThrow(Expression e, FuncDeclaration func, ErrorSink eSink)
 {
     //printf("Expression::canThrow(%d) %s\n", mustNotThrow, e.toChars());
     // stop walking if we determine this expression can throw

--- a/compiler/src/dmd/cond.d
+++ b/compiler/src/dmd/cond.d
@@ -133,7 +133,7 @@ extern (C++) final class StaticForeach : RootObject
         this.rangefe = rangefe;
     }
 
-    StaticForeach syntaxCopy()
+    extern (D) StaticForeach syntaxCopy()
     {
         return new StaticForeach(
             loc,

--- a/compiler/src/dmd/cond.h
+++ b/compiler/src/dmd/cond.h
@@ -53,8 +53,6 @@ public:
     ForeachRangeStatement *rangefe;
 
     d_bool needExpansion;
-
-    StaticForeach *syntaxCopy();
 };
 
 class DVCondition : public Condition

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -3684,7 +3684,7 @@ void fix16997(Scope* sc, UnaExp ue)
  * This is to enable comparing things like an immutable
  * array with a mutable one.
  */
-extern (C++) bool arrayTypeCompatibleWithoutCasting(Type t1, Type t2)
+extern (D) bool arrayTypeCompatibleWithoutCasting(Type t1, Type t2)
 {
     t1 = t1.toBasetype();
     t2 = t2.toBasetype();

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -367,7 +367,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         baseok = Baseok.none;
     }
 
-    final void classError(const(char)* fmt, const(char)* arg)
+    extern (D) private void classError(const(char)* fmt, const(char)* arg)
     {
         .error(loc, fmt, kind, toPrettyChars, arg);
     }
@@ -423,7 +423,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
      * Determine if 'this' is a base class of cd.
      * This is used to detect circular inheritance only.
      */
-    final bool isBaseOf2(ClassDeclaration cd) pure nothrow @nogc
+    extern (D) final bool isBaseOf2(ClassDeclaration cd) pure nothrow @nogc
     {
         if (!cd)
             return false;
@@ -538,7 +538,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
      * Returns:
      *  ClassDeclaration if found, null if not
      */
-    final ClassDeclaration searchBase(Identifier ident)
+    extern (D) final ClassDeclaration searchBase(Identifier ident)
     {
         foreach (b; *baseclasses)
         {
@@ -716,7 +716,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
      * Errors:
      *  prints error message if more than one match
      */
-    final FuncDeclaration findFunc(Identifier ident, TypeFunction tf)
+    extern (D) final FuncDeclaration findFunc(Identifier ident, TypeFunction tf)
     {
         //printf("ClassDeclaration.findFunc(%s, %s) %s\n", ident.toChars(), tf.toChars(), toChars());
         FuncDeclaration fdmatch = null;

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -705,15 +705,11 @@ public:
     bool functionSemantic3();
     bool equals(const RootObject * const o) const override final;
 
-    int overrides(FuncDeclaration *fd);
     int findVtblIndex(Dsymbols *vtbl, int dim);
-    BaseClass *overrideInterface();
     bool overloadInsert(Dsymbol *s) override;
     bool inUnittest();
     MATCH leastAsSpecialized(FuncDeclaration *g, Identifiers *names);
     LabelDsymbol *searchLabel(Identifier *ident, const Loc &loc);
-    int getLevel(FuncDeclaration *fd, int intypeof); // lexical nesting level difference
-    int getLevelAndCheck(const Loc &loc, Scope *sc, FuncDeclaration *fd);
     const char *toPrettyChars(bool QualifyTypes = false) override;
     const char *toFullSignature();  // for diagnostics, e.g. 'int foo(int x, int y) pure'
     bool isMain() const;
@@ -726,13 +722,9 @@ public:
     bool isOverloadable() const override final;
     bool isAbstract() override final;
     PURE isPure();
-    PURE isPureBypassingInference();
     bool isSafe();
-    bool isSafeBypassingInference();
     bool isTrusted();
-
     bool isNogc();
-    bool isNogcBypassingInference();
 
     virtual bool isNested() const;
     AggregateDeclaration *isThis() override;
@@ -751,8 +743,6 @@ public:
 
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc=0);
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc=0);
-
-    bool checkNRVO();
 
     FuncDeclaration *isFuncDeclaration() override final { return this; }
 
@@ -788,8 +778,6 @@ public:
     bool isVirtual() const override;
     bool addPreInvariant() override;
     bool addPostInvariant() override;
-
-    void modifyReturns(Scope *sc, Type *tret);
 
     FuncLiteralDeclaration *isFuncLiteralDeclaration() override { return this; }
     const char *kind() const override;

--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -128,7 +128,7 @@ extern (C++) final class Import : Dsymbol
      * Returns:
      *  true for errors, false for success
      */
-    bool load(Scope* sc)
+    extern (D) bool load(Scope* sc)
     {
         //printf("Import::load('%s') %p\n", toPrettyChars(), this);
         // See if existing module

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1095,7 +1095,7 @@ extern (C++) final class Module : Package
         return Package.symtabInsert(s);
     }
 
-    void deleteObjFile()
+    extern (D) void deleteObjFile()
     {
         if (global.params.obj)
             File.remove(objfile.toChars());

--- a/compiler/src/dmd/dscope.d
+++ b/compiler/src/dmd/dscope.d
@@ -344,7 +344,7 @@ extern (C++) struct Scope
      * Returns:
      *  symbol if found, null if not
      */
-    extern (C++) Dsymbol search(const ref Loc loc, Identifier ident, Dsymbol* pscopesym, int flags = IgnoreNone)
+    extern (D) Dsymbol search(const ref Loc loc, Identifier ident, Dsymbol* pscopesym, int flags = IgnoreNone)
     {
         version (LOGSEARCH)
         {

--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -71,7 +71,7 @@ extern (C++) FuncDeclaration search_toString(StructDeclaration sd)
  *      sc = context
  *      t = type that TypeInfo is being generated for
  */
-extern (C++) void semanticTypeInfo(Scope* sc, Type t)
+extern (D) void semanticTypeInfo(Scope* sc, Type t)
 {
     if (sc)
     {

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -1241,7 +1241,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
      *      match   this is at least as specialized as td2
      *      0       td2 is more specialized than this
      */
-    MATCH leastAsSpecialized(Scope* sc, TemplateDeclaration td2, ArgumentList argumentList)
+    extern (D) MATCH leastAsSpecialized(Scope* sc, TemplateDeclaration td2, ArgumentList argumentList)
     {
         enum LOG_LEASTAS = 0;
         static if (LOG_LEASTAS)
@@ -2258,7 +2258,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
     /**************************************************
      * Declare template parameter tp with value o, and install it in the scope sc.
      */
-    RootObject declareParameter(Scope* sc, TemplateParameter tp, RootObject o)
+    extern (D) RootObject declareParameter(Scope* sc, TemplateParameter tp, RootObject o)
     {
         //printf("TemplateDeclaration.declareParameter('%s', o = %p)\n", tp.ident.toChars(), o);
         Type ta = isType(o);
@@ -2508,7 +2508,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
      * Returns:
      *   The last template parameter if it's a `TemplateTupleParameter`
      */
-    TemplateTupleParameter isVariadic()
+    extern (D) TemplateTupleParameter isVariadic()
     {
         size_t dim = parameters.length;
         if (dim == 0)
@@ -6203,7 +6203,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         return false;
     }
 
-    final size_t toHash()
+    extern (D) final size_t toHash()
     {
         if (!hash)
         {

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -526,7 +526,7 @@ extern (C++) abstract class Expression : ASTNode
     /*********************************
      * Does *not* do a deep copy.
      */
-    final Expression copy()
+    extern (D) final Expression copy()
     {
         Expression e;
         if (!size)
@@ -745,7 +745,7 @@ extern (C++) abstract class Expression : ASTNode
         return toLvalue(sc, e);
     }
 
-    final Expression implicitCastTo(Scope* sc, Type t)
+    extern (D) final Expression implicitCastTo(Scope* sc, Type t)
     {
         return .implicitCastTo(this, sc, t);
     }
@@ -755,7 +755,7 @@ extern (C++) abstract class Expression : ASTNode
         return .implicitConvTo(this, t);
     }
 
-    final Expression castTo(Scope* sc, Type t)
+    extern (D) final Expression castTo(Scope* sc, Type t)
     {
         return .castTo(this, sc, t);
     }
@@ -861,7 +861,7 @@ extern (C++) abstract class Expression : ASTNode
         return checkValue();
     }
 
-    final bool checkDeprecated(Scope* sc, Dsymbol s)
+    extern (D) final bool checkDeprecated(Scope* sc, Dsymbol s)
     {
         return s.checkDeprecated(loc, sc);
     }
@@ -1642,7 +1642,7 @@ extern (C++) final class IntegerExp : Expression
         return value;
     }
 
-    void setInteger(dinteger_t value)
+    extern (D) void setInteger(dinteger_t value)
     {
         this.value = normalize(type.toBasetype().ty, value);
     }
@@ -2429,7 +2429,7 @@ extern (C++) final class StringExp : Expression
      *  i = index
      *  c = code unit to set it to
      */
-    void setCodeUnit(size_t i, dchar c)
+    extern (D) void setCodeUnit(size_t i, dchar c)
     {
         assert(i < len);
         final switch (sz)
@@ -2823,12 +2823,12 @@ extern (C++) final class ArrayLiteralExp : Expression
         return false;
     }
 
-    Expression getElement(size_t i)
+    Expression getElement(size_t i) // use opIndex instead
     {
         return this[i];
     }
 
-    Expression opIndex(size_t i)
+    extern (D) Expression opIndex(size_t i)
     {
         auto el = (*elements)[i];
         return el ? el : basis;
@@ -3064,7 +3064,7 @@ extern (C++) final class StructLiteralExp : Expression
      * Gets expression at offset of type.
      * Returns NULL if not found.
      */
-    Expression getField(Type type, uint offset)
+    extern (D) Expression getField(Type type, uint offset)
     {
         //printf("StructLiteralExp::getField(this = %s, type = %s, offset = %u)\n",
         //  /*toChars()*/"", type.toChars(), offset);
@@ -3114,7 +3114,7 @@ extern (C++) final class StructLiteralExp : Expression
      * Get index of field.
      * Returns -1 if not found.
      */
-    int getFieldIndex(Type type, uint offset)
+    extern (D) int getFieldIndex(Type type, uint offset)
     {
         /* Find which field offset is by looking at the field offsets
          */
@@ -4073,7 +4073,7 @@ extern (C++) abstract class UnaExp : Expression
      * Returns:
      *  ErrorExp
      */
-    final Expression incompatibleTypes()
+    extern (D) final Expression incompatibleTypes()
     {
         if (e1.type.toBasetype() == Type.terror)
             return e1;
@@ -4148,7 +4148,7 @@ extern (C++) abstract class BinExp : Expression
      * Returns:
      *  ErrorExp
      */
-    final Expression incompatibleTypes()
+    extern (D) final Expression incompatibleTypes()
     {
         if (e1.type.toBasetype() == Type.terror)
             return e1;
@@ -4358,7 +4358,7 @@ extern (C++) abstract class BinExp : Expression
 
     }
 
-    final Expression reorderSettingAAElem(Scope* sc)
+    extern (D) final Expression reorderSettingAAElem(Scope* sc)
     {
         BinExp be = this;
 
@@ -4730,7 +4730,7 @@ extern (C++) final class DotTemplateInstanceExp : UnaExp
         return new DotTemplateInstanceExp(loc, e1.syntaxCopy(), ti.name, TemplateInstance.arraySyntaxCopy(ti.tiargs));
     }
 
-    bool findTempDecl(Scope* sc)
+    extern (D) bool findTempDecl(Scope* sc)
     {
         static if (LOGSEMANTIC)
         {

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -47,11 +47,6 @@ struct Symbol;          // back end symbol
 #endif
 
 void expandTuples(Expressions *exps, Identifiers *names = nullptr);
-bool isTrivialExp(Expression *e);
-bool hasSideEffect(Expression *e, bool assumeImpureCalls = false);
-
-enum BE : int32_t;
-BE canThrow(Expression *e, FuncDeclaration *func, ErrorSink *eSink);
 
 typedef unsigned char OwnedBy;
 enum
@@ -86,7 +81,6 @@ public:
 
     size_t size() const;
     static void _init();
-    Expression *copy();
     virtual Expression *syntaxCopy();
 
     // kludge for template.isExpression()
@@ -103,13 +97,10 @@ public:
     virtual bool isLvalue();
     virtual Expression *toLvalue(Scope *sc, Expression *e);
     virtual Expression *modifiableLvalue(Scope *sc, Expression *e);
-    Expression *implicitCastTo(Scope *sc, Type *t);
     MATCH implicitConvTo(Type *t);
-    Expression *castTo(Scope *sc, Type *t);
     virtual Expression *resolveLoc(const Loc &loc, Scope *sc);
     virtual bool checkType();
     virtual bool checkValue();
-    bool checkDeprecated(Scope *sc, Dsymbol *s);
     virtual Expression *addDtorHook(Scope *sc);
     Expression *addressOf();
     Expression *deref();
@@ -258,7 +249,6 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e) override;
     void accept(Visitor *v) override { v->visit(this); }
     dinteger_t getInteger() { return value; }
-    void setInteger(dinteger_t value);
     template<int v>
     static IntegerExp literal();
 };
@@ -384,7 +374,6 @@ public:
     static void emplace(UnionExp *pue, const Loc &loc, const char *s);
     bool equals(const RootObject * const o) const override;
     char32_t getCodeUnit(d_size_t i) const;
-    void setCodeUnit(d_size_t i, char32_t c);
     StringExp *toStringExp() override;
     StringExp *toUTF8(Scope *sc);
     Optional<bool> toBool() override;
@@ -430,8 +419,7 @@ public:
     static void emplace(UnionExp *pue, const Loc &loc, Expressions *elements);
     ArrayLiteralExp *syntaxCopy() override;
     bool equals(const RootObject * const o) const override;
-    Expression *getElement(d_size_t i); // use opIndex instead
-    Expression *opIndex(d_size_t i);
+    Expression *getElement(d_size_t i);
     Optional<bool> toBool() override;
     StringExp *toStringExp() override;
 
@@ -490,8 +478,6 @@ public:
     static StructLiteralExp *create(const Loc &loc, StructDeclaration *sd, void *elements, Type *stype = NULL);
     bool equals(const RootObject * const o) const override;
     StructLiteralExp *syntaxCopy() override;
-    Expression *getField(Type *type, unsigned offset);
-    int getFieldIndex(Type *type, unsigned offset);
     Expression *addDtorHook(Scope *sc) override;
     Expression *toLvalue(Scope *sc, Expression *e) override;
 
@@ -702,7 +688,6 @@ public:
     Expression *e1;
 
     UnaExp *syntaxCopy() override;
-    Expression *incompatibleTypes();
     Expression *resolveLoc(const Loc &loc, Scope *sc) override final;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -718,9 +703,6 @@ public:
     Type *att2; // Save alias this type to detect recursion
 
     BinExp *syntaxCopy() override;
-    Expression *incompatibleTypes();
-
-    Expression *reorderSettingAAElem(Scope *sc);
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -806,7 +788,6 @@ public:
     TemplateInstance *ti;
 
     DotTemplateInstanceExp *syntaxCopy() override;
-    bool findTempDecl(Scope *sc);
     bool checkType() override;
     bool checkValue() override;
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -689,7 +689,7 @@ extern (C++) class FuncDeclaration : Declaration
      * Determine if 'this' overrides fd.
      * Return !=0 if it does.
      */
-    final int overrides(FuncDeclaration fd)
+    extern (D) final int overrides(FuncDeclaration fd)
     {
         int result = 0;
         if (fd.ident == ident)
@@ -838,7 +838,7 @@ extern (C++) class FuncDeclaration : Declaration
      * Returns:
      *  base class if overriding, null if not
      */
-    final BaseClass* overrideInterface()
+    extern (D) final BaseClass* overrideInterface()
     {
         for (ClassDeclaration cd = toParent2().isClassDeclaration(); cd; cd = cd.baseClass)
         {
@@ -1215,7 +1215,7 @@ extern (C++) class FuncDeclaration : Declaration
      *      -1      increase nesting by 1 (`fd` is nested within `this`)
      *      LevelError  error, `this` cannot call `fd`
      */
-    final int getLevel(FuncDeclaration fd, int intypeof)
+    extern (D) final int getLevel(FuncDeclaration fd, int intypeof)
     {
         //printf("FuncDeclaration::getLevel(fd = '%s')\n", fd.toChars());
         Dsymbol fdparent = fd.toParent2();
@@ -1276,8 +1276,8 @@ extern (C++) class FuncDeclaration : Declaration
      *      -1      increase nesting by 1 (`fd` is nested within 'this')
      *      LevelError  error
      */
-    final int getLevelAndCheck(const ref Loc loc, Scope* sc, FuncDeclaration fd,
-                               Declaration decl)
+    extern (D) final int getLevelAndCheck(const ref Loc loc, Scope* sc, FuncDeclaration fd,
+                                          Declaration decl)
     {
         int level = getLevel(fd, sc.intypeof);
         if (level != LevelError)
@@ -1490,7 +1490,7 @@ extern (C++) class FuncDeclaration : Declaration
         return purity;
     }
 
-    final PURE isPureBypassingInference()
+    extern (D) final PURE isPureBypassingInference()
     {
         if (purityInprocess)
             return PURE.fwdref;
@@ -1544,7 +1544,7 @@ extern (C++) class FuncDeclaration : Declaration
         return type.toTypeFunction().trust == TRUST.safe;
     }
 
-    final bool isSafeBypassingInference()
+    extern (D) final bool isSafeBypassingInference()
     {
         return !(safetyInprocess) && isSafe();
     }
@@ -1612,7 +1612,7 @@ extern (C++) class FuncDeclaration : Declaration
         return type.toTypeFunction().isnogc;
     }
 
-    final bool isNogcBypassingInference()
+    extern (D) final bool isNogcBypassingInference()
     {
         return !nogcInprocess && isNogc();
     }
@@ -2935,7 +2935,7 @@ extern (C++) class FuncDeclaration : Declaration
      * Returns:
      *      `false` if the result cannot be returned by hidden reference.
      */
-    final bool checkNRVO()
+    extern (D) final bool checkNRVO()
     {
         if (!isNRVO() || returns is null)
             return false;
@@ -3939,7 +3939,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
      * If B to A conversion is convariant that requires offseet adjusting,
      * all return statements should be adjusted to return expressions typed A.
      */
-    void modifyReturns(Scope* sc, Type tret)
+    extern (D) void modifyReturns(Scope* sc, Type tret)
     {
         import dmd.statement_rewrite_walker;
 

--- a/compiler/src/dmd/import.h
+++ b/compiler/src/dmd/import.h
@@ -41,7 +41,6 @@ public:
     const char *kind() const override;
     Visibility visible() override;
     Import *syntaxCopy(Dsymbol *s) override; // copy only syntax trees
-    void load(Scope *sc);
     void importAll(Scope *sc) override;
     Dsymbol *toAlias() override;
     void addMember(Scope *sc, ScopeDsymbol *sds) override;

--- a/compiler/src/dmd/init.h
+++ b/compiler/src/dmd/init.h
@@ -79,7 +79,6 @@ public:
     d_bool isCarray;      // C array semantics
 
     bool isAssociativeArray() const;
-    Expression *toAssocArrayLiteral();
 
     void accept(Visitor *v) override { v->visit(this); }
 };

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -127,7 +127,6 @@ public:
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly) override;
     bool isPackageAccessible(Package *p, Visibility visibility, int flags = 0) override;
     Dsymbol *symtabInsert(Dsymbol *s) override;
-    void deleteObjFile();
     static void runDeferredSemantic();
     static void runDeferredSemantic2();
     static void runDeferredSemantic3();

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -1393,7 +1393,7 @@ extern (C++) abstract class Type : ASTNode
      * For our new type 'this', which is type-constructed from t,
      * fill in the cto, ito, sto, scto, wto shortcuts.
      */
-    final void fixTo(Type t)
+    extern (D) final void fixTo(Type t)
     {
         // If fixing this: immutable(T*) by t: immutable(T)*,
         // cache t to this.xto won't break transitivity.
@@ -1528,7 +1528,7 @@ extern (C++) abstract class Type : ASTNode
     /***************************
      * Look for bugs in constructing types.
      */
-    final void check()
+    extern (D) final void check()
     {
         if (mcache)
         with (mcache)
@@ -1722,7 +1722,7 @@ extern (C++) abstract class Type : ASTNode
      * Apply STCxxxx bits to existing type.
      * Use *before* semantic analysis is run.
      */
-    final Type addSTC(StorageClass stc)
+    extern (D) final Type addSTC(StorageClass stc)
     {
         Type t = this;
         if (t.isImmutable())
@@ -2555,7 +2555,7 @@ extern (C++) abstract class Type : ASTNode
      * Return the mask that an integral type will
      * fit into.
      */
-    final uinteger_t sizemask()
+    extern (D) final uinteger_t sizemask()
     {
         uinteger_t m;
         switch (toBasetype().ty)
@@ -5227,7 +5227,7 @@ extern (C++) abstract class TypeQualified : Type
     // us a `TypeQualified`
     abstract override TypeQualified syntaxCopy();
 
-    final void syntaxCopyHelper(TypeQualified t)
+    extern (D) final void syntaxCopyHelper(TypeQualified t)
     {
         //printf("TypeQualified::syntaxCopyHelper(%s) %s\n", t.toChars(), toChars());
         idents.setDim(t.idents.length);
@@ -5265,17 +5265,17 @@ extern (C++) abstract class TypeQualified : Type
         }
     }
 
-    final void addIdent(Identifier ident)
+    extern (D) final void addIdent(Identifier ident)
     {
         idents.push(ident);
     }
 
-    final void addInst(TemplateInstance inst)
+    extern (D) final void addInst(TemplateInstance inst)
     {
         idents.push(inst);
     }
 
-    final void addIndex(RootObject e)
+    extern (D) final void addIndex(RootObject e)
     {
         idents.push(e);
     }

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -39,8 +39,6 @@ typedef union tree_node type;
 typedef struct TYPE type;
 #endif
 
-void semanticTypeInfo(Scope *sc, Type *t);
-
 Type *typeSemantic(Type *t, const Loc &loc, Scope *sc);
 Type *merge(Type *type);
 
@@ -272,9 +270,6 @@ public:
     Type *wildConstOf();
     Type *sharedWildOf();
     Type *sharedWildConstOf();
-    void fixTo(Type *t);
-    void check();
-    Type *addSTC(StorageClass stc);
     Type *castMod(MOD mod);
     Type *addMod(MOD mod);
     virtual Type *addStorageClass(StorageClass stc);
@@ -316,7 +311,6 @@ public:
     virtual bool hasInvariant();
     virtual Type *nextOf();
     Type *baseElemOf();
-    uinteger_t sizemask();
     virtual bool needsDestruction();
     virtual bool needsCopyOrPostblit();
     virtual bool needsNested();
@@ -707,10 +701,6 @@ public:
     // representing ident.ident!tiargs.ident. ... etc.
     Objects idents;
 
-    void syntaxCopyHelper(TypeQualified *t);
-    void addIdent(Identifier *ident);
-    void addInst(TemplateInstance *inst);
-    void addIndex(RootObject *expr);
     uinteger_t size(const Loc &loc) override;
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -936,8 +926,6 @@ public:
 };
 
 /**************************************************************/
-
-bool arrayTypeCompatibleWithoutCasting(Type *t1, Type *t2);
 
 // If the type is a class or struct, returns the symbol for it, else null.
 AggregateDeclaration *isAggregate(Type *t);

--- a/compiler/src/dmd/objc.h
+++ b/compiler/src/dmd/objc.h
@@ -30,8 +30,6 @@ struct ObjcSelector
 
     static void _init();
 
-    ObjcSelector(const char *sv, size_t len, size_t pcount);
-
     static ObjcSelector *create(FuncDeclaration *fdecl);
 };
 

--- a/compiler/src/dmd/scope.h
+++ b/compiler/src/dmd/scope.h
@@ -126,6 +126,4 @@ struct Scope
 
     AliasDeclaration *aliasAsg; // if set, then aliasAsg is being assigned a new value,
                                 // do not set wasRead for it
-
-    Dsymbol *search(const Loc &loc, Identifier *ident, Dsymbol **pscopesym, int flags = IgnoreNone);
 };

--- a/compiler/src/dmd/sideeffect.d
+++ b/compiler/src/dmd/sideeffect.d
@@ -32,7 +32,7 @@ import dmd.visitor;
  *  1. save evaluation order
  *  2. prevent sharing of sub-expression in AST
  */
-extern (C++) bool isTrivialExp(Expression e)
+bool isTrivialExp(Expression e)
 {
     extern (C++) final class IsTrivialExp : StoppableVisitor
     {
@@ -70,7 +70,7 @@ extern (C++) bool isTrivialExp(Expression e)
  *   assumeImpureCalls = whether function calls should always be assumed to
  *                       be impure (e.g. debug is allowed to violate purity)
  */
-extern (C++) bool hasSideEffect(Expression e, bool assumeImpureCalls = false)
+bool hasSideEffect(Expression e, bool assumeImpureCalls = false)
 {
     extern (C++) final class LambdaHasSideEffect : StoppableVisitor
     {

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -114,7 +114,7 @@ extern (C++) abstract class Statement : ASTNode
      * Returns:
      *     `true` if statement uses exception handling
      */
-    final bool usesEH()
+    extern (D) final bool usesEH()
     {
         extern (C++) final class UsesEH : StoppableVisitor
         {
@@ -153,7 +153,7 @@ extern (C++) abstract class Statement : ASTNode
      * Returns:
      *   `true` if statement 'comes from' somewhere else, like a goto
      */
-    final bool comeFrom()
+    extern (D) final bool comeFrom()
     {
         extern (C++) final class ComeFrom : StoppableVisitor
         {
@@ -192,7 +192,7 @@ extern (C++) abstract class Statement : ASTNode
      * Returns:
      *   `true` if statement has executable code.
      */
-    final bool hasCode()
+    extern (D) final bool hasCode()
     {
         extern (C++) final class HasCode : StoppableVisitor
         {

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -116,8 +116,6 @@ public:
     virtual Statement *getRelatedLabeled() { return this; }
     virtual bool hasBreak() const;
     virtual bool hasContinue() const;
-    bool usesEH();
-    bool comeFrom();
     bool hasCode();
     virtual Statement *last();
 

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -96,12 +96,8 @@ public:
 
     Visibility visible() override;
 
-    MATCH leastAsSpecialized(Scope* sc, TemplateDeclaration* td2, ArgumentList argumentList);
-    RootObject *declareParameter(Scope *sc, TemplateParameter *tp, RootObject *o);
-
     TemplateDeclaration *isTemplateDeclaration() override { return this; }
 
-    TemplateTupleParameter *isVariadic();
     bool isDeprecated() const override;
     bool isOverloadable() const override;
 
@@ -298,7 +294,6 @@ public:
     const char *toChars() const override;
     const char* toPrettyCharsHelper() override final;
     Identifier *getIdent() override final;
-    hash_t toHash();
 
     bool isDiscardable();
     bool needsCodegen();

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -900,7 +900,7 @@ extern (C++) struct Token
 
 nothrow:
 
-    int isKeyword() pure const @safe @nogc
+    extern (D) int isKeyword() pure const @safe @nogc
     {
         foreach (kw; keywords)
         {

--- a/compiler/src/dmd/tokens.h
+++ b/compiler/src/dmd/tokens.h
@@ -469,10 +469,7 @@ struct Token
         Identifier *ident;
     };
 
-    void free();
-
     Token() : next(NULL) {}
-    int isKeyword();
     const char *toChars() const;
 
     static const char *toChars(TOK value);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -541,11 +541,6 @@ void test_cppmangle()
     mangle = cppThunkMangleItanium(fd, b->offset);
     assert(strcmp(mangle, "_ZThn8_N7Derived7MethodDEv") == 0);
 
-    assert(fd->fbody);
-    auto rs = (*fd->fbody->isCompoundStatement()->statements)[0]->isReturnStatement();
-    assert(rs);
-    assert(!canThrow(rs->exp, fd, NULL));
-
     assert(!global.endGagging(errors));
 }
 


### PR DESCRIPTION
These are mostly specific to semantic, or changing the AST state. Neither of which is of any relevance to GDC or LDC.