### PR TITLE
ImportC: align not set to default

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5293,7 +5293,7 @@ final class CParser(AST) : Parser!AST
             (*decls)[0] = s;
             s = new AST.AlignDeclaration(s.loc, specifier.alignExps, decls);
         }
-        else if (!specifier.packalign.isDefault())
+        else if (!specifier.packalign.isDefault() && !specifier.packalign.isUnknown())
         {
             //printf("  applying packalign %d\n", cast(int)specifier.packalign);
             // Wrap #pragma pack in an AlignDeclaration

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -7,7 +7,16 @@ TEST_OUTPUT:
 ---
 === ${RESULTS_DIR}/compilable/ctod.di
 // D import file generated from 'compilable/ctod.i'
-extern (C) uint equ(double x, double y);
+extern (C)
+{
+	uint equ(double x, double y);
+	enum SQLINTERVAL
+	{
+		SQL_IS_YEAR = 1,
+		SQL_IS_MONTH = 2,
+	}
+	alias SQLINTERVAL = enum SQLINTERVAL;
+}
 ---
  */
 
@@ -16,3 +25,9 @@ unsigned equ(double x, double y)
 {
     return *(long long *)&x == *(long long *)&y;
 }
+
+typedef enum
+{
+    SQL_IS_YEAR = 1,
+    SQL_IS_MONTH = 2
+} SQLINTERVAL;


### PR DESCRIPTION
This is a partial fix for https://issues.dlang.org/show_bug.cgi?id=24121 in that it gets rid of the spurious `align` emission.

Turns out that fixing the .di output is finding bugs in ImportC.