### PR TITLE
ImportC remove alias from enum declaration in di file

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1923,7 +1923,12 @@ final class CParser(AST) : Parser!AST
                     }
                 }
                 if (isalias)
-                    s = new AST.AliasDeclaration(token.loc, id, dt);
+                {
+                    auto ad = new AST.AliasDeclaration(token.loc, id, dt);
+                    ad.adFlags |= ad.hidden; // do not print when generating .di files
+                    s = ad;
+                }
+
                 insertTypedefToTypedefTab(id, dt);       // remember typedefs
             }
             else if (id)

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -244,6 +244,7 @@ extern (C++) abstract class Declaration : Dsymbol
       enum wasRead    = 1; // set if AliasDeclaration was read
       enum ignoreRead = 2; // ignore any reads of AliasDeclaration
       enum nounderscore = 4; // don't prepend _ to mangled name
+      enum hidden       = 8; // don't print this in .di files
 
     Symbol* isym;           // import version of csym
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5938,6 +5938,8 @@ public:
 
     enum : int32_t { nounderscore = 4 };
 
+    enum : int32_t { hidden = 8 };
+
     Symbol* isym;
     _d_dynamicArray< const char > mangleOverride;
     const char* kind() const override;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -1595,6 +1595,8 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
     {
         if (d.storage_class & STC.local)
             return;
+        if (d.adFlags & d.hidden)
+            return;
         buf.writestring("alias ");
         if (d.aliassym)
         {
@@ -4064,6 +4066,7 @@ private void typeToBufferx(Type t, ref OutBuffer buf, HdrGenState* hgs)
 
     void visitEnum(TypeEnum t)
     {
+        //printf("visitEnum: %s\n", t.sym.toChars());
         buf.writestring(hgs.fullQual ? t.sym.toPrettyChars() : t.sym.toChars());
     }
 

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -15,7 +15,6 @@ extern (C)
 		SQL_IS_YEAR = 1,
 		SQL_IS_MONTH = 2,
 	}
-	alias SQLINTERVAL = enum SQLINTERVAL;
 }
 ---
  */


### PR DESCRIPTION
Another fix for https://issues.dlang.org/show_bug.cgi?id=24121

ImportC generates an alias declaration to move the enum tag name into the regular name space. But since a .di file is a D file, which doesn't have a tag name space, that is not necessary. So no need to generate it into the .di file.