### PR TITLE
Add core.sys.freebsd.sys.types.

### DIFF
--- a/druntime/mak/COPY
+++ b/druntime/mak/COPY
@@ -193,6 +193,7 @@ COPY=\
 	$(IMPDIR)\core\sys\freebsd\sys\mount.d \
 	$(IMPDIR)\core\sys\freebsd\sys\socket.d \
 	$(IMPDIR)\core\sys\freebsd\sys\sysctl.d \
+	$(IMPDIR)\core\sys\freebsd\sys\types.d \
 	\
 	$(IMPDIR)\core\sys\dragonflybsd\dlfcn.d \
 	$(IMPDIR)\core\sys\dragonflybsd\err.d \

--- a/druntime/mak/SRCS
+++ b/druntime/mak/SRCS
@@ -188,6 +188,7 @@ SRCS=\
 	src\core\sys\freebsd\sys\mount.d \
 	src\core\sys\freebsd\sys\socket.d \
 	src\core\sys\freebsd\sys\sysctl.d \
+	src\core\sys\freebsd\sys\types.d \
 	\
 	src\core\sys\dragonflybsd\dlfcn.d \
 	src\core\sys\dragonflybsd\err.d \

--- a/druntime/src/core/sys/freebsd/sys/types.d
+++ b/druntime/src/core/sys/freebsd/sys/types.d
@@ -1,0 +1,58 @@
+//Written in the D programming language
+
+/++
+    D header file for FreeBSD's extensions to POSIX's sys/types.h.
+
+    Copyright: Copyright 2023
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)
+ +/
+module core.sys.freebsd.sys.types;
+
+public import core.sys.posix.sys.types;
+
+version (FreeBSD):
+extern(C):
+@nogc:
+nothrow:
+
+import core.stdc.config;
+
+alias caddr_t = ubyte*;
+alias c_caddr_t = const(ubyte)*;
+
+alias cpuwhich_t = int;
+alias cpulevel_t = int;
+alias cpusetid_t = int;
+
+alias critical_t = size_t;
+alias daddr_t = long;
+
+alias fixpt_t = uint;
+
+alias accmode_t = int;
+
+alias register_t = size_t;
+
+alias sbintime_t = long;
+
+alias segsz_t = size_t;
+
+alias u_register_t = size_t;
+
+alias cap_ioctl_t = size_t;
+
+alias kpaddr_t = ulong;
+alias kvaddr_t = ulong;
+alias ksize_t = ulong;
+alias kssize_t = long;
+
+alias vm_offset_t = size_t;
+alias vm_ooffset_t = ulong;
+alias vm_paddr_t = ulong;
+alias vm_pindex_t = ulong;
+alias vm_size_t = size_t;
+
+alias rman_res_t = ulong;
+
+alias syscallarg_t = register_t;

--- a/druntime/src/core/sys/posix/sys/types.d
+++ b/druntime/src/core/sys/posix/sys/types.d
@@ -187,7 +187,7 @@ else version (FreeBSD)
     alias c_long    ssize_t;
     alias c_long    time_t;
     alias uint      uid_t;
-    alias uint      fflags_t;
+    alias uint      fflags_t; // non-standard
 }
 else version (NetBSD)
 {
@@ -866,7 +866,7 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
-    alias int lwpid_t;
+    alias int lwpid_t; // non-standard
 
     alias void* pthread_attr_t;
     alias void* pthread_cond_t;


### PR DESCRIPTION
In addition to adding the non-standard declarations in core.sys.freebsd.sys.types, I also commented a couple of the ones in core.sys.posix.sys.types as non-standard, since they are and really should have been in core.sys.freebsd.sys.types. Unfortunately, moving them to the right place risks breaking existing code.