### PR TITLE
Fixed use of const with "macros" in FreeBSD's if_dl.d.

### DIFF
--- a/druntime/src/core/sys/freebsd/net/if_dl.d
+++ b/druntime/src/core/sys/freebsd/net/if_dl.d
@@ -29,9 +29,9 @@ struct sockaddr_dl
     ubyte[46]   sdl_data;
 }
 
-auto LLADDR(sockaddr_dl* s) { return cast(caddr_t)(s.sdl_data.ptr + s.sdl_nlen); }
-auto CLLADDR(sockaddr_dl* s) { return cast(c_caddr_t)(s.sdl_data.ptr + s.sdl_nlen); }
-auto LLINDEX(sockaddr_dl* s) { return s.sdl_index; }
+auto LLADDR()(sockaddr_dl* s) { return cast(caddr_t)(s.sdl_data.ptr + s.sdl_nlen); }
+auto CLLADDR()(const sockaddr_dl* s) { return cast(c_caddr_t)(s.sdl_data.ptr + s.sdl_nlen); }
+ushort LLINDEX()(const sockaddr_dl* s) { return s.sdl_index; }
 
 struct ifnet;
 sockaddr_dl* link_alloc_sdl(size_t, int);


### PR DESCRIPTION
LLADDR, CLLADDR, and LLINDEX were macros to begin with, so they obviously weren't as worried about const as we have to be when they're functions, and I screwed up the constness, so this fixes it.

LLADDR gives a mutable pointer back, so of course, it should take a mutable pointer, which it already did.

CLLADDR gives a const pointer back, so it makes sense for it to take const.

LLINDEX returns a ushort, so the constness of the pointer is irrelevant, so it makes more sense for it to accept const.

I also templatized them all so that the attributes wouldn't matter. It also makes them more like macros in that there's no function compiled into druntime, though I don't know that that actually matters.