### PR TITLE
Cirrus CI: Allow single remaining FreeBSD coverage job to fail (might be out of credits)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -54,6 +54,7 @@ coverage_environment_template: &COVERAGE_ENVIRONMENT_TEMPLATE
 # FreeBSD
 freebsd13_task:
   name: FreeBSD 13.0 x64, DMD ($TASK_NAME_TYPE)
+  allow_failures: true # might be out of credits
   freebsd_instance:
     image_family: freebsd-13-0
     cpu: 4


### PR DESCRIPTION
I don't think it's a big loss to make it optional, i.e., extra FreeBSD coverage possibly not showing up near the end of the month.

(I'm a bit reluctant to move the job to GHA, as it would IMO probably disproportionately uglify the current GHA script.)