### PR TITLE
Fix static AA initialization

### DIFF
--- a/compiler/test/runnable/staticaa.d
+++ b/compiler/test/runnable/staticaa.d
@@ -56,7 +56,7 @@ struct Key
 {
     int v;
     bool opEquals(ref const Key o) const { return v == o.v; }
-    size_t toHash() const { return v; }
+    size_t toHash() const nothrow { return v; }
 }
 
 Destructing[Key] dAa = [Key(1): Destructing(10), Key(2): Destructing(20)];

--- a/druntime/src/core/internal/newaa.d
+++ b/druntime/src/core/internal/newaa.d
@@ -154,7 +154,15 @@ AAShell makeAA(K, V)(V[K] src) @trusted
             K.sizeof, V.sizeof, E.value.offsetof, flags, hashFn));
 }
 
+version(unittest):
+struct Foo {
+    ubyte x;
+    double d;
+}
+int[Foo] utaa = [Foo(1, 2.0) : 5];
 unittest {
-    static int[double[2]] utaa = [[1.0, 2.0] : 5];
-    assert(utaa[[1.0, 2.0]] == 5);
+    auto k = Foo(1, 2.0);
+    // verify that getHash doesn't match hashOf for Foo
+    assert(typeid(Foo).getHash(&k) != hashOf(k));
+    assert(utaa[Foo(1, 2.0)] == 5);
 }

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -642,7 +642,8 @@ class TypeInfo
      */
     size_t getHash(scope const void* p) @trusted nothrow const
     {
-        return hashOf(p);
+        // by default, do not assume anything about the type
+        return 0;
     }
 
     /// Compares two instances for equality.

--- a/druntime/src/rt/aaA.d
+++ b/druntime/src/rt/aaA.d
@@ -73,14 +73,15 @@ private:
     uint used;
     uint deleted;
     TypeInfo_Struct entryTI;
-    // function that calculates hash of a key. Set on creation
-    // the parameter is a pointer to the key.
-    size_t delegate(scope const void*) nothrow hashFn;
     uint firstUsed;
     immutable uint keysz;
     immutable uint valsz;
     immutable uint valoff;
     Flags flags;
+
+    // function that calculates hash of a key. Set on creation
+    // the parameter is a pointer to the key.
+    size_t delegate(scope const void*) nothrow hashFn;
 
     enum Flags : ubyte
     {

--- a/druntime/src/rt/aaA.d
+++ b/druntime/src/rt/aaA.d
@@ -57,6 +57,7 @@ private:
         buckets = allocBuckets(sz);
         firstUsed = cast(uint) buckets.length;
         valoff = cast(uint) talign(keysz, ti.value.talign);
+        hashFn = &ti.key.getHash;
 
         import rt.lifetime : hasPostblit, unqualify;
 
@@ -72,6 +73,9 @@ private:
     uint used;
     uint deleted;
     TypeInfo_Struct entryTI;
+    // function that calculates hash of a key. Set on creation
+    // the parameter is a pointer to the key.
+    size_t delegate(scope const void*) nothrow hashFn;
     uint firstUsed;
     immutable uint keysz;
     immutable uint valsz;
@@ -457,9 +461,9 @@ private size_t mix(size_t h) @safe pure nothrow @nogc
     return h;
 }
 
-private size_t calcHash(scope const void* pkey, scope const TypeInfo keyti) nothrow
+private size_t calcHash(scope const void *pkey, scope const Impl* impl) nothrow
 {
-    immutable hash = keyti.getHash(pkey);
+    immutable hash = impl.hashFn(pkey);
     // highest bit is set to distinguish empty/deleted from filled buckets
     return mix(hash) | HASH_FILLED_MARK;
 }
@@ -550,7 +554,7 @@ extern (C) void* _aaGetX(scope AA* paa, const TypeInfo_AssociativeArray ti,
     }
 
     // get hash and bucket for key
-    immutable hash = calcHash(pkey, ti.key);
+    immutable hash = calcHash(pkey, aa);
 
     // found a value => return it
     if (auto p = aa.findSlotLookup(hash, pkey, ti.key))
@@ -617,7 +621,7 @@ extern (C) inout(void)* _aaInX(inout AA aa, scope const TypeInfo keyti, scope co
     if (aa.empty)
         return null;
 
-    immutable hash = calcHash(pkey, keyti);
+    immutable hash = calcHash(pkey, aa);
     if (auto p = aa.findSlotLookup(hash, pkey, keyti))
         return p.entry + aa.valoff;
     return null;
@@ -629,7 +633,7 @@ extern (C) bool _aaDelX(AA aa, scope const TypeInfo keyti, scope const void* pke
     if (aa.empty)
         return false;
 
-    immutable hash = calcHash(pkey, keyti);
+    immutable hash = calcHash(pkey, aa);
     if (auto p = aa.findSlotLookup(hash, pkey, keyti))
     {
         // clear entry
@@ -778,7 +782,7 @@ extern (C) Impl* _d_assocarrayliteralTX(const TypeInfo_AssociativeArray ti, void
     uint actualLength = 0;
     foreach (_; 0 .. length)
     {
-        immutable hash = calcHash(pkey, ti.key);
+        immutable hash = calcHash(pkey, aa);
 
         auto p = aa.findSlotLookup(hash, pkey, ti.key);
         if (p is null)

--- a/druntime/test/profile/README.md
+++ b/druntime/test/profile/README.md
@@ -1,0 +1,21 @@
+# How to interpret failures of this test
+
+The test code in src is built using profiling. Then it checks against the expected output based on the arch/os.
+
+If any of these values are wrong, you will see a diff in the error report, e.g.:
+
+```
+diff \
+	<(grep -vF 'core.' myprofilegc.log.linux.64.exp) \
+	<(grep -vF 'core.' ./generated/linux/debug/64/myprofilegc.log)
+2c2
+<             464	              1	immutable(char)[][int] D main src/profilegc.d:23
+---
+>             496	              1	immutable(char)[][int] D main src/profilegc.d:23
+```
+
+This means that the line 23 in `src/profilegc.d` allocated 496 bytes, but was expected to allocate 464 bytes.
+
+To accept the difference, edit the file given (in this case `myprofile.log.linux.64.exp`) to record the correct value.
+
+Changes to these expectation files should be accompanied by a comment as to why the number changed. Do not change these numbers without understanding why it changed!

--- a/druntime/test/profile/myprofilegc.log.freebsd.64.exp
+++ b/druntime/test/profile/myprofilegc.log.freebsd.64.exp
@@ -1,5 +1,5 @@
 bytes allocated, allocations, type, function, file:line
-            464	              1	immutable(char)[][int] D main src/profilegc.d:23
+            496	              1	immutable(char)[][int] D main src/profilegc.d:23
             160	              1	float[][] D main src/profilegc.d:18
             160	              1	int[][] D main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56

--- a/druntime/test/profile/myprofilegc.log.linux.64.exp
+++ b/druntime/test/profile/myprofilegc.log.linux.64.exp
@@ -1,5 +1,5 @@
 bytes allocated, allocations, type, function, file:line
-            464	              1	immutable(char)[][int] D main src/profilegc.d:23
+            496	              1	immutable(char)[][int] D main src/profilegc.d:23
             160	              1	float[][] D main src/profilegc.d:18
             160	              1	int[][] D main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56

--- a/druntime/test/profile/myprofilegc.log.osx.64.exp
+++ b/druntime/test/profile/myprofilegc.log.osx.64.exp
@@ -1,5 +1,5 @@
 bytes allocated, allocations, type, function, file:line
-            464	              1	immutable(char)[][int] D main src/profilegc.d:23
+            496	              1	immutable(char)[][int] D main src/profilegc.d:23
             160	              1	float[][] D main src/profilegc.d:18
             160	              1	int[][] D main src/profilegc.d:15
              64	              1	double[] profilegc.main src/profilegc.d:56


### PR DESCRIPTION
Static AA initialization (the yet unreleased feature, added in #15468) is broken for some cases of AA initialization.

The issue comes from `TypeInfo.getHash` not always behaving the same as `hashOf`. The fix here is to add a delegate which does the hashing to the `Impl` struct of the AA. Normal AA initialization at runtime copies the key's `TypeInfo.getHash` function, whereas when we initialize it using static AA initialization, we write our own function that always uses `hashOf`, making the hashing consistent.

FWIW, this means some cases where the compiler passes in the key `TypeInfo` are not needed, though we still call `opEquals` from the key `TypeInfo`. Possibly we can remove that usage by storing all the delegates needed upon creation.