### PR TITLE
Replace DMD-specific flags with GDC in error messages when IN_GCC

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1320,7 +1320,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
 
         if (!(global.params.bitfields || sc.flags & SCOPE.Cfile))
-            .error(dsym.loc, "%s `%s` use -preview=bitfields for bitfield support", dsym.kind, dsym.toPrettyChars);
+        {
+            version (IN_GCC)
+                .error(dsym.loc, "%s `%s` use `-fpreview=bitfields` for bitfield support", dsym.kind, dsym.toPrettyChars);
+            else
+                .error(dsym.loc, "%s `%s` use -preview=bitfields for bitfield support", dsym.kind, dsym.toPrettyChars);
+        }
 
         if (!dsym.parent.isStructDeclaration() && !dsym.parent.isClassDeclaration())
         {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1223,11 +1223,15 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             }
             else if (added & STC.ref_)
             {
-                // accept for legacy compatibility
-                //deprecation("using `in ref` is deprecated, use `-preview=in` and `in` instead");
+                // accept using `in ref` for legacy compatibility
             }
             else
-                error("attribute `scope` cannot be applied with `in`, use `-preview=in` instead");
+            {
+                version (IN_GCC)
+                    error("attribute `scope` cannot be applied with `in`, use `-fpreview=in` instead");
+                else
+                    error("attribute `scope` cannot be applied with `in`, use `-preview=in` instead");
+            }
             return orig;
         }
 
@@ -1244,11 +1248,15 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             }
             else if (orig & STC.ref_)
             {
-                // accept for legacy compatibility
-                //deprecation("using `in ref` is deprecated, use `-preview=in` and `in` instead");
+                // accept using `in ref` for legacy compatibility
             }
             else
-                error("attribute `in` cannot be added after `scope`: remove `scope` and use `-preview=in`");
+            {
+                version (IN_GCC)
+                    error("attribute `in` cannot be added after `scope`: remove `scope` and use `-fpreview=in`");
+                else
+                    error("attribute `in` cannot be added after `scope`: remove `scope` and use `-preview=in`");
+            }
             return orig;
         }
 

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -412,7 +412,12 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if (!global.params.useTypeInfo || !Type.dtypeinfo || !Type.typeinfotypelist)
                     {
                         if (!global.params.useTypeInfo)
-                            .error(funcdecl.loc, "%s `%s` D-style variadic functions cannot be used with -betterC", funcdecl.kind, funcdecl.toPrettyChars);
+                        {
+                            version (IN_GCC)
+                                .error(funcdecl.loc, "%s `%s` D-style variadic functions cannot be used with `-fno-rtti`", funcdecl.kind, funcdecl.toPrettyChars);
+                            else
+                                .error(funcdecl.loc, "%s `%s` D-style variadic functions cannot be used with -betterC", funcdecl.kind, funcdecl.toPrettyChars);
+                        }
                         else if (!Type.typeinfotypelist)
                             .error(funcdecl.loc, "%s `%s` `object.TypeInfo_Tuple` could not be found, but is implicitly used in D-style variadic functions", funcdecl.kind, funcdecl.toPrettyChars);
                         else

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -3483,7 +3483,10 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             // https://issues.dlang.org/show_bug.cgi?id=23159
             if (!global.params.useExceptions)
             {
-                error(oss.loc, "`%s` cannot be used with -betterC", Token.toChars(oss.tok));
+                version (IN_GCC)
+                    error(oss.loc, "`%s` cannot be used with `-fno-exceptions`", Token.toChars(oss.tok));
+                else
+                    error(oss.loc, "`%s` cannot be used with -betterC", Token.toChars(oss.tok));
                 return setError();
             }
 


### PR DESCRIPTION
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109681

This is the pretty route-one way of going about it - similar to #15349.

@schveiguy 