### PR TITLE
Remove shortenedMethods from CompileEnv

### DIFF
--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -908,7 +908,7 @@ dmd -cov -unittest myprog.d
         Feature("inclusiveincontracts", "inclusiveInContracts",
             "'in' contracts of overridden methods must be a superset of parent contract"),
         Feature("shortenedMethods", "shortenedMethods",
-            "allow use of => for methods and top-level functions in addition to lambdas", false, false),
+            "allow use of => for methods and top-level functions in addition to lambdas", false, true),
         Feature("fixImmutableConv", "fixImmutableConv",
             "disallow unsound immutable conversions that were formerly incorrectly permitted"),
         Feature("systemVariables", "systemVariables",

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3416,7 +3416,6 @@ struct CompileEnv final
     _d_dynamicArray< const char > timestamp;
     bool previewIn;
     bool ddocOutput;
-    bool shortenedMethods;
     bool masm;
     CompileEnv() :
         versionNumber(),
@@ -3426,11 +3425,10 @@ struct CompileEnv final
         timestamp(),
         previewIn(),
         ddocOutput(),
-        shortenedMethods(true),
         masm()
     {
     }
-    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}, bool previewIn = false, bool ddocOutput = false, bool shortenedMethods = true, bool masm = false) :
+    CompileEnv(uint32_t versionNumber, _d_dynamicArray< const char > date = {}, _d_dynamicArray< const char > time = {}, _d_dynamicArray< const char > vendor = {}, _d_dynamicArray< const char > timestamp = {}, bool previewIn = false, bool ddocOutput = false, bool masm = false) :
         versionNumber(versionNumber),
         date(date),
         time(time),
@@ -3438,7 +3436,6 @@ struct CompileEnv final
         timestamp(timestamp),
         previewIn(previewIn),
         ddocOutput(ddocOutput),
-        shortenedMethods(shortenedMethods),
         masm(masm)
         {}
 };

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -274,7 +274,6 @@ struct CompileEnv
     DString timestamp;
     d_bool previewIn;
     d_bool ddocOutput;
-    d_bool shortenedMethods;
 };
 
 struct Global

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -50,7 +50,6 @@ struct CompileEnv
 
     bool previewIn;          /// `in` means `[ref] scope const`, accepts rvalues
     bool ddocOutput;         /// collect embedded documentation comments
-    bool shortenedMethods = true;   /// allow => in normal function declarations
     bool masm;               /// use MASM inline asm syntax
 }
 

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -161,7 +161,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
 
     global.compileEnv.previewIn        = global.params.previewIn;
     global.compileEnv.ddocOutput       = global.params.ddoc.doOutput;
-    global.compileEnv.shortenedMethods = global.params.shortenedMethods;
 
     if (params.help.usage)
     {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -5203,8 +5203,6 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         case TOK.goesTo:
             if (requireDo)
                 error("missing `do { ... }` after `in` or `out`");
-            if (!compileEnv.shortenedMethods)
-                error("=> shortened method not enabled, compile with compiler switch `-preview=shortenedMethods`");
             const returnloc = token.loc;
             nextToken();
             f.fbody = new AST.ReturnStatement(returnloc, parseExpression());


### PR DESCRIPTION
Related https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109681

Shortened methods were made the default a few releases ago.  Deprecate the `-preview` switch and remove the lone condition in the parser.

@schveiguy 