### PR TITLE
dmd.typinf: Remove dependency on gluelayer

### DIFF
--- a/compiler/src/dmd/asttypename.d
+++ b/compiler/src/dmd/asttypename.d
@@ -32,7 +32,6 @@ import dmd.denum;
 import dmd.dimport;
 import dmd.dmodule;
 import dmd.mtype;
-import dmd.typinf;
 import dmd.identifier;
 import dmd.init;
 import dmd.root.complex;

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -56,7 +56,6 @@ import dmd.toctype;
 import dmd.toir;
 import dmd.tokens;
 import dmd.toobj;
-import dmd.typinf;
 import dmd.visitor;
 
 import dmd.backend.cc;
@@ -6060,7 +6059,7 @@ private
 elem *getTypeInfo(Expression e, Type t, ref IRState irs)
 {
     assert(t.ty != Terror);
-    genTypeInfo(e, e.loc, t, null);
+    TypeInfo_toObjFile(e, e.loc, t);
     elem* result = el_ptr(toSymbol(t.vtinfo));
     return result;
 }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8267,9 +8267,11 @@ extern Target target;
 
 extern bool tpsemantic(TemplateParameter* tp, Scope* sc, Array<TemplateParameter* >* parameters);
 
-extern void genTypeInfo(Expression* e, const Loc& loc, Type* torig, Scope* sc, bool genObjCode = true);
+extern bool genTypeInfo(Expression* e, const Loc& loc, Type* torig, Scope* sc);
 
 extern Type* getTypeInfoType(const Loc& loc, Type* t, Scope* sc, bool genObjCode = true);
+
+extern bool isSpeculativeType(Type* t);
 
 extern bool builtinTypeInfo(Type* t);
 

--- a/compiler/src/dmd/gluelayer.d
+++ b/compiler/src/dmd/gluelayer.d
@@ -39,9 +39,6 @@ version (NoBackend)
             return null;
         }
 
-        // toir
-        void toObjFile(Dsymbol ds, bool multiobj)   {}
-
         extern(C++) abstract class ObjcGlue
         {
             static void initialize() {}
@@ -59,7 +56,6 @@ else version (IN_GCC)
     extern (C++)
     {
         Statement asmSemantic(AsmStatement s, Scope* sc);
-        void toObjFile(Dsymbol ds, bool multiobj);
     }
 
     // stubs
@@ -76,5 +72,4 @@ else
     public import dmd.backend.code_x86 : code;
     public import dmd.iasm : asmSemantic;
     public import dmd.objc_glue : ObjcGlue;
-    public import dmd.toobj : toObjFile;
 }

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -46,7 +46,6 @@ import dmd.toctype;
 import dmd.todt;
 import dmd.toir;
 import dmd.tokens;
-import dmd.typinf;
 import dmd.visitor;
 import dmd.dmangle;
 

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -43,7 +43,6 @@ import dmd.tokens;
 import dmd.tocsym;
 import dmd.toobj;
 import dmd.typesem;
-import dmd.typinf;
 import dmd.visitor;
 
 import dmd.backend.cc;
@@ -600,7 +599,7 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
     {
         if (Type t = isType(e.obj))
         {
-            genTypeInfo(e, e.loc, t, null);
+            TypeInfo_toObjFile(e, e.loc, t);
             Symbol *s = toSymbol(t.vtinfo);
             dtb.xoff(s, 0);
             return;
@@ -1177,7 +1176,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             dtb.size(0);                                  // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
-        genTypeInfo(null, d.loc, tm, null);
+        TypeInfo_toObjFile(null, d.loc, tm);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1191,7 +1190,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             dtb.size(0);                                      // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
-        genTypeInfo(null, d.loc, tm, null);
+        TypeInfo_toObjFile(null, d.loc, tm);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1205,7 +1204,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             dtb.size(0);                                 // monitor
         Type tm = d.tinfo.unSharedOf();
         tm = tm.merge();
-        genTypeInfo(null, d.loc, tm, null);
+        TypeInfo_toObjFile(null, d.loc, tm);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1219,7 +1218,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             dtb.size(0);                              // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
-        genTypeInfo(null, d.loc, tm, null);
+        TypeInfo_toObjFile(null, d.loc, tm);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1246,7 +1245,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         // TypeInfo for enum members
         if (sd.memtype)
         {
-            genTypeInfo(null, d.loc, sd.memtype, null);
+            TypeInfo_toObjFile(null, d.loc, sd.memtype);
             dtb.xoff(toSymbol(sd.memtype.vtinfo), 0);
         }
         else
@@ -1286,7 +1285,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypePointer();
 
-        genTypeInfo(null, d.loc, tc.next, null);
+        TypeInfo_toObjFile(null, d.loc, tc.next);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0); // TypeInfo for type being pointed to
     }
 
@@ -1301,7 +1300,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeDArray();
 
-        genTypeInfo(null, d.loc, tc.next, null);
+        TypeInfo_toObjFile(null, d.loc, tc.next);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0); // TypeInfo for array of type
     }
 
@@ -1316,7 +1315,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeSArray();
 
-        genTypeInfo(null, d.loc, tc.next, null);
+        TypeInfo_toObjFile(null, d.loc, tc.next);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0);   // TypeInfo for array of type
 
         dtb.size(tc.dim.toInteger());          // length
@@ -1333,7 +1332,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeVector();
 
-        genTypeInfo(null, d.loc, tc.basetype, null);
+        TypeInfo_toObjFile(null, d.loc, tc.basetype);
         dtb.xoff(toSymbol(tc.basetype.vtinfo), 0); // TypeInfo for equivalent static array
     }
 
@@ -1348,10 +1347,10 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeAArray();
 
-        genTypeInfo(null, d.loc, tc.next, null);
+        TypeInfo_toObjFile(null, d.loc, tc.next);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0);   // TypeInfo for array of type
 
-        genTypeInfo(null, d.loc, tc.index, null);
+        TypeInfo_toObjFile(null, d.loc, tc.index);
         dtb.xoff(toSymbol(tc.index.vtinfo), 0);  // TypeInfo for array of type
     }
 
@@ -1366,7 +1365,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeFunction();
 
-        genTypeInfo(null, d.loc, tc.next, null);
+        TypeInfo_toObjFile(null, d.loc, tc.next);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0); // TypeInfo for function return value
 
         const name = d.tinfo.deco;
@@ -1390,7 +1389,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         auto tc = d.tinfo.isTypeDelegate();
 
-        genTypeInfo(null, d.loc, tc.next.nextOf(), null);
+        TypeInfo_toObjFile(null, d.loc, tc.next.nextOf());
         dtb.xoff(toSymbol(tc.next.nextOf().vtinfo), 0); // TypeInfo for delegate return value
 
         const name = d.tinfo.deco;
@@ -1538,7 +1537,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
                 // m_argi
                 if (auto t = sd.argType(i))
                 {
-                    genTypeInfo(null, d.loc, t, null);
+                    TypeInfo_toObjFile(null, d.loc, t);
                     dtb.xoff(toSymbol(t.vtinfo), 0);
                 }
                 else
@@ -1600,7 +1599,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         auto dtbargs = DtBuilder(0);
         foreach (arg; *tu.arguments)
         {
-            genTypeInfo(null, d.loc, arg.type, null);
+            TypeInfo_toObjFile(null, d.loc, arg.type);
             Symbol* s = toSymbol(arg.type.vtinfo);
             dtbargs.xoff(s, 0);
         }

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -266,6 +266,24 @@ void write_instance_pointers(Type type, Symbol *s, uint offset)
     }
 }
 
+/****************************************************
+ * Put out instance of the `TypeInfo` object associated with `t` if it
+ * hasn't already been generated
+ * Params:
+ *      e   = if not null, then expression for pretty-printing errors
+ *      loc = the location for reporting line numbers in errors
+ *      t   = the type to generate the `TypeInfo` object for
+ */
+void TypeInfo_toObjFile(Expression e, const ref Loc loc, Type t)
+{
+    // printf("TypeInfo_toObjFIle() %s\n", torig.toChars());
+    if (genTypeInfo(e, loc, t, null))
+    {
+        // generate a COMDAT for other TypeInfos not available as builtins in druntime
+        toObjFile(t.vtinfo, global.params.multiobj);
+    }
+}
+
 /* ================================================================== */
 
 void toObjFile(Dsymbol ds, bool multiobj)
@@ -379,7 +397,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
             // Put out the TypeInfo
             if (gentypeinfo)
-                genTypeInfo(null, cd.loc, cd.type, null);
+                TypeInfo_toObjFile(null, cd.loc, cd.type);
             //toObjFile(cd.type.vtinfo, multiobj);
 
             if (genclassinfo)
@@ -462,7 +480,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             // Put out the TypeInfo
             if (gentypeinfo)
             {
-                genTypeInfo(null, id.loc, id.type, null);
+                TypeInfo_toObjFile(null, id.loc, id.type);
                 id.type.vtinfo.accept(this);
             }
 
@@ -498,7 +516,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                     toDebug(sd);
 
                 if (global.params.useTypeInfo && Type.dtypeinfo)
-                    genTypeInfo(null, sd.loc, sd.type, null);
+                    TypeInfo_toObjFile(null, sd.loc, sd.type);
 
                 // Generate static initializer
                 auto sinit = toInitializer(sd);
@@ -679,7 +697,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 toDebug(ed);
 
             if (global.params.useTypeInfo && Type.dtypeinfo)
-                genTypeInfo(null, ed.loc, ed.type, null);
+                TypeInfo_toObjFile(null, ed.loc, ed.type);
 
             TypeEnum tc = cast(TypeEnum)ed.type;
             if (!tc.sym.members || ed.type.isZeroInit(Loc.initial))

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -4,7 +4,7 @@
  * Copyright:   Copyright (C) 1999-2023 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/typeinf.d, _typeinf.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/typinf.d, _typinf.d)
  * Documentation:  https://dlang.org/phobos/dmd_typinf.html
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/typinf.d
  */
@@ -20,10 +20,8 @@ import dmd.dstruct;
 import dmd.errors;
 import dmd.expression;
 import dmd.globals;
-import dmd.gluelayer;
 import dmd.location;
 import dmd.mtype;
-import dmd.visitor;
 import core.stdc.stdio;
 
 /****************************************************
@@ -34,9 +32,10 @@ import core.stdc.stdio;
  *      loc   = the location for reporting line numbers in errors
  *      torig = the type to generate the `TypeInfo` object for
  *      sc    = the scope
- *      genObjCode = if true, object code will be generated for the obtained TypeInfo
+ * Returns:
+ *      true if `TypeInfo` was generated and needs compiling to object file
  */
-extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc, bool genObjCode = true)
+extern (C++) bool genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc)
 {
     // printf("genTypeInfo() %s\n", torig.toChars());
 
@@ -67,6 +66,7 @@ extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope
     }
 
     Type t = torig.merge2(); // do this since not all Type's are merge'd
+    bool needsCodegen = false;
     if (!t.vtinfo)
     {
         if (t.isShared()) // does both 'shared' and 'shared const'
@@ -84,25 +84,13 @@ extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope
         // ClassInfos are generated as part of ClassDeclaration codegen
         const isUnqualifiedClassInfo = (t.ty == Tclass && !t.mod);
 
-        // generate a COMDAT for other TypeInfos not available as builtins in
-        // druntime
-        if (!isUnqualifiedClassInfo && !builtinTypeInfo(t) && genObjCode)
-        {
-            if (sc) // if in semantic() pass
-            {
-                // Find module that will go all the way to an object file
-                Module m = sc._module.importedFrom;
-                m.members.push(t.vtinfo);
-            }
-            else // if in obj generation pass
-            {
-                toObjFile(t.vtinfo, global.params.multiobj);
-            }
-        }
+        if (!isUnqualifiedClassInfo && !builtinTypeInfo(t))
+            needsCodegen = true;
     }
     if (!torig.vtinfo)
         torig.vtinfo = t.vtinfo; // Types aren't merged, but we can share the vtinfo's
     assert(torig.vtinfo);
+    return needsCodegen;
 }
 
 /****************************************************
@@ -118,7 +106,12 @@ extern (C++) void genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope
 extern (C++) Type getTypeInfoType(const ref Loc loc, Type t, Scope* sc, bool genObjCode = true)
 {
     assert(t.ty != Terror);
-    genTypeInfo(null, loc, t, sc, genObjCode);
+    if (genTypeInfo(null, loc, t, sc) && genObjCode)
+    {
+        // Find module that will go all the way to an object file
+        Module m = sc._module.importedFrom;
+        m.members.push(t.vtinfo);
+    }
     return t.vtinfo.type;
 }
 
@@ -163,7 +156,7 @@ private TypeInfoDeclaration getTypeInfoDeclaration(Type t)
  *      true if any part of type t is speculative.
  *      if t is null, returns false.
  */
-bool isSpeculativeType(Type t)
+extern (C++) bool isSpeculativeType(Type t)
 {
     static bool visitVector(TypeVector t)
     {

--- a/compiler/src/dmd/typinf.h
+++ b/compiler/src/dmd/typinf.h
@@ -1,0 +1,22 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (C) 1999-2023 by The D Language Foundation, All Rights Reserved
+ * written by Walter Bright
+ * https://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * https://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/dlang/dmd/blob/master/src/dmd/typinf.h
+ */
+
+#pragma once
+
+#include "globals.h"
+
+class Expression;
+class Type;
+struct Scope;
+
+bool genTypeInfo(Expression *e, const Loc &loc, Type *torig, Scope *sc);
+Type *getTypeInfoType(const Loc &loc, Type *t, Scope *sc, bool genObjCode = true);
+bool isSpeculativeType(Type *t);
+bool builtinTypeInfo(Type *t);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -54,6 +54,7 @@
 #include "target.h"
 #include "template.h"
 #include "tokens.h"
+#include "typinf.h"
 #include "version.h"
 #include "visitor.h"
 
@@ -1657,6 +1658,15 @@ public:
             visitDeclaration(d->v_argptr);
     }
 };
+
+void test_typinf(Expression *e, const Loc &loc, Type *t, Scope *sc)
+{
+    // Link tests
+    genTypeInfo(e, loc, t, sc);
+    getTypeInfoType(loc, t, sc, false);
+    isSpeculativeType(t);
+    builtinTypeInfo(t);
+}
 
 void test_backend(FuncDeclaration *f, Type *t)
 {


### PR DESCRIPTION
This module is really shareable between compiler back-ends, but it has one problematic call to a DMD-specific glue function that makes it unusable for GDC.

1. Updates `genTypeInfo` to return a bool.
2. Moves calling of `toObjFile()` to a new function `TypeInfo_toObjFile` defined in glue code.
3. Moves appending rtti to module to `getTypeInfoType`
4. Adds `extern (C++)` functions to `typinf.h` header, so that GDC could include it and use them instead of duplicating the implementation in C++.
5. Remove `toObjFile` stubs from gluelayer module.