### PR TITLE
Get rid of extra indirection for implictCastTo and castTo for expressions

### DIFF
--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -20,6 +20,7 @@ import core.stdc.stdio;
 import dmd.arraytypes;
 import dmd.astenums;
 import dmd.ctfeexpr;
+import dmd.dcast;
 import dmd.declaration;
 import dmd.dstruct;
 import dmd.errors;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -745,19 +745,9 @@ extern (C++) abstract class Expression : ASTNode
         return toLvalue(sc, e);
     }
 
-    extern (D) final Expression implicitCastTo(Scope* sc, Type t)
-    {
-        return .implicitCastTo(this, sc, t);
-    }
-
     final MATCH implicitConvTo(Type t)
     {
         return .implicitConvTo(this, t);
-    }
-
-    extern (D) final Expression castTo(Scope* sc, Type t)
-    {
-        return .castTo(this, sc, t);
     }
 
     /****************************************
@@ -2426,7 +2416,7 @@ extern (C++) final class StringExp : Expression
         {
             // Convert to UTF-8 string
             committed = false;
-            Expression e = castTo(sc, Type.tchar.arrayOf());
+            Expression e = castTo(this, sc, Type.tchar.arrayOf());
             e = e.optimize(WANTvalue);
             auto se = e.isStringExp();
             assert(se.sz == 1);

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -25,6 +25,7 @@ import dmd.arraytypes;
 import dmd.astenums;
 import dmd.blockexit;
 import dmd.gluelayer;
+import dmd.dcast;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.delegatize;

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -16,6 +16,7 @@ import core.stdc.stdio;
 import dmd.astenums;
 import dmd.constfold;
 import dmd.ctfeexpr;
+import dmd.dcast;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dsymbol;


### PR DESCRIPTION
The end goal is to break the dependency of expression.d on cast.d, but a few more work is needed for that. Follow-up PRs will take care of that.