### PR TITLE
Fix 24208, 24212, 24213 - `scope` escape via `pure` + nested context

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -2471,7 +2471,8 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
             //printf("type: %s\n", arg.type.toChars());
             //printf("param: %s\n", p.toChars());
 
-            const pStc = tf.parameterStorageClass(tthis, p, fd ? &fd.outerVars : null);
+            const indirect = (fd is null) || (fd.isVirtual() && !fd.isFinal());
+            const pStc = tf.parameterStorageClass(tthis, p, fd ? &fd.outerVars : null, indirect);
 
             if (firstArg && (pStc & STC.return_))
             {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -2471,7 +2471,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
             //printf("type: %s\n", arg.type.toChars());
             //printf("param: %s\n", p.toChars());
 
-            const pStc = tf.parameterStorageClass(tthis, p);
+            const pStc = tf.parameterStorageClass(tthis, p, fd ? &fd.outerVars : null);
 
             if (firstArg && (pStc & STC.return_))
             {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3854,7 +3854,7 @@ public:
     void purityLevel();
     bool hasLazyParameters();
     bool isDstyleVariadic() const;
-    StorageClass parameterStorageClass(Type* tthis, Parameter* p);
+    StorageClass parameterStorageClass(Type* tthis, Parameter* p, Array<VarDeclaration* >* outerVars = nullptr, bool indirect = false);
     Type* addStorageClass(StorageClass stc) override;
     Type* substWildTo(uint32_t __param_0_) override;
     MATCH constConv(Type* to) override;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4405,10 +4405,12 @@ extern (C++) final class TypeFunction : TypeNext
      *  tthis = type of `this` parameter, null if none
      *  p = parameter to this function
      *  outerVars = context variables p could escape into, if any
+     *  indirect = is this for an indirect or virtual function call?
      * Returns:
      *  storage class with STC.scope_ or STC.return_ OR'd in
      */
-    StorageClass parameterStorageClass(Type tthis, Parameter p, VarDeclarations* outerVars = null)
+    StorageClass parameterStorageClass(Type tthis, Parameter p, VarDeclarations* outerVars = null,
+        bool indirect = false)
     {
         //printf("parameterStorageClass(p: %s)\n", p.toChars());
         auto stc = p.storageClass;
@@ -4442,6 +4444,15 @@ extern (C++) final class TypeFunction : TypeNext
         // See if p can escape via any of the other parameters
         if (purity == PURE.weak)
         {
+            /*
+             * Indirect calls may escape p through a nested context
+             * See:
+             *   https://issues.dlang.org/show_bug.cgi?id=24212
+             *   https://issues.dlang.org/show_bug.cgi?id=24213
+             */
+            if (indirect)
+                return stc;
+
             // Check escaping through parameters
             foreach (i, fparam; parameterList)
             {

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -4404,10 +4404,11 @@ extern (C++) final class TypeFunction : TypeNext
      * Params:
      *  tthis = type of `this` parameter, null if none
      *  p = parameter to this function
+     *  outerVars = context variables p could escape into, if any
      * Returns:
      *  storage class with STC.scope_ or STC.return_ OR'd in
      */
-    StorageClass parameterStorageClass(Type tthis, Parameter p)
+    StorageClass parameterStorageClass(Type tthis, Parameter p, VarDeclarations* outerVars = null)
     {
         //printf("parameterStorageClass(p: %s)\n", p.toChars());
         auto stc = p.storageClass;
@@ -4473,6 +4474,16 @@ extern (C++) final class TypeFunction : TypeNext
             if (tthis && tthis.isMutable())
             {
                 foreach (VarDeclaration v; isAggregate(tthis).fields)
+                {
+                    if (v.hasPointers())
+                        return stc;
+                }
+            }
+
+            // Check escaping through nested context
+            if (outerVars && this.isMutable())
+            {
+                foreach (VarDeclaration v; *outerVars)
                 {
                     if (v.hasPointers())
                         return stc;

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -610,7 +610,7 @@ public:
     void purityLevel();
     bool hasLazyParameters();
     bool isDstyleVariadic() const;
-    StorageClass parameterStorageClass(Parameter *p);
+    StorageClass parameterStorageClass(Type* tthis, Parameter *p, VarDeclarations* outerVars = nullptr, bool indirect = false);
     Type *addStorageClass(StorageClass stc) override;
 
     Type *substWildTo(unsigned mod) override;

--- a/compiler/test/fail_compilation/fail24208.d
+++ b/compiler/test/fail_compilation/fail24208.d
@@ -1,0 +1,20 @@
+/+
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/fail24208.d(19): Error: reference to local variable `n` assigned to non-scope parameter `p` calling `escape`
+fail_compilation/fail24208.d(15):        which is not `scope` because of `escaped = p`
+---
++/
+void test() @safe
+{
+    int* escaped;
+
+    void escape(int* p) @safe
+    {
+        escaped = p;
+    }
+
+    int n;
+    escape(&n);
+}

--- a/compiler/test/fail_compilation/fail24212.d
+++ b/compiler/test/fail_compilation/fail24212.d
@@ -1,0 +1,30 @@
+/+
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/fail24212.d(29): Error: reference to local variable `n` assigned to non-scope parameter `p` calling `fun`
+---
++/
+class Base
+{
+    @safe pure nothrow
+    void fun(int* p) {}
+}
+
+void test() @safe
+{
+    int* escaped;
+
+    class Escaper : Base
+    {
+        @safe pure nothrow
+        override void fun(int* p)
+        {
+            escaped = p;
+        }
+    }
+
+    int n;
+    Base base = new Escaper;
+    base.fun(&n);
+}

--- a/compiler/test/fail_compilation/fail24213.d
+++ b/compiler/test/fail_compilation/fail24213.d
@@ -1,0 +1,17 @@
+/+
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/fail24213.d(16): Error: reference to local variable `n` assigned to non-scope parameter `p`
+---
++/
+alias Dg = void delegate(int* p) @safe pure nothrow;
+
+void main() @safe
+{
+    int* escaped;
+
+    int n;
+    Dg dg = delegate void (int* p) { escaped = p; };
+    dg(&n);
+}


### PR DESCRIPTION
The compiler sometimes allows scope pointers to be passed to non-scope parameters of `pure` function, with the exact rules documented in this section of the language spec:

https://dlang.org/spec/function.html#pure-scope-inference

Unfortunately, when checking for parameters with mutable indirections that an argument could escape through, the compiler previously:

* did not include variables accessed through the function's nested context, and
* did not assume conservatively that escape was possible if the function had a context that could vary at runtime.

As a result, it was possible to escape a `scope` pointer in `@safe` code.