### PR TITLE
Issue 24132 - ImportC: Add support for wide-chars.

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3675,10 +3675,12 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             goto LabelX;
 
         case TOK.wchar_:
+        case TOK.wchar_t:
             t = AST.Type.twchar;
             goto LabelX;
 
         case TOK.dchar_:
+        case TOK.char32_t:
             t = AST.Type.tdchar;
             goto LabelX;
         LabelX:

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -607,7 +607,7 @@ static immutable TOK[TOK.max + 1] Ckeywords =
     with (TOK)
     {
         TOK[TOK.max + 1] tab = identifier;  // default to identifier
-        enum Ckwds = [ auto_, break_, case_, char_, const_, continue_, default_, do_, float64, else_,
+        enum Ckwds = [ auto_, break_, case_, char_, wchar_, dchar_, const_, continue_, default_, do_, float64, else_,
                        enum_, extern_, float32, for_, goto_, if_, inline, int32, int64, register,
                        restrict, return_, int16, signed, sizeof_, static_, struct_, switch_, typedef_,
                        union_, unsigned, void_, volatile, while_, asm_, typeof_,

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -268,6 +268,8 @@ enum TOK : ubyte
     _Noreturn,
     _Static_assert,
     _Thread_local,
+	wchar_t,
+    char32_t,
 
     // C only extended keywords
     _assert,
@@ -574,6 +576,8 @@ private immutable TOK[] keywords =
     TOK._Noreturn,
     TOK._Static_assert,
     TOK._Thread_local,
+    TOK.wchar_t,
+    TOK.char32_t,
 
     // C only extended keywords
     TOK._assert,
@@ -607,7 +611,7 @@ static immutable TOK[TOK.max + 1] Ckeywords =
     with (TOK)
     {
         TOK[TOK.max + 1] tab = identifier;  // default to identifier
-        enum Ckwds = [ auto_, break_, case_, char_, wchar_, dchar_, const_, continue_, default_, do_, float64, else_,
+        enum Ckwds = [ auto_, break_, case_, char_, wchar_t, char32_t, const_, continue_, default_, do_, float64, else_,
                        enum_, extern_, float32, for_, goto_, if_, inline, int32, int64, register,
                        restrict, return_, int16, signed, sizeof_, static_, struct_, switch_, typedef_,
                        union_, unsigned, void_, volatile, while_, asm_, typeof_,

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -883,6 +883,8 @@ extern (C++) struct Token
         TOK._Noreturn : "_Noreturn",
         TOK._Static_assert : "_Static_assert",
         TOK._Thread_local  : "_Thread_local",
+        TOK.wchar_t  : "wchar_t",
+        TOK.char32_t  : "char32_t",
 
         // C only extended keywords
         TOK._assert       : "__check",

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -20,6 +20,9 @@ extern (C)
 	struct Foo
 	{
 		int x = void;
+		wchar wc;
+		wchar csixteen;
+		dchar cthreetwo;
 	}
 	Foo abc();
 }
@@ -40,6 +43,9 @@ typedef enum
 
 struct Foo {
     int x;
+	wchar_t wc;
+	char16_t csixteen;
+	char32_t cthreetwo;
 };
 
 struct Foo abc(void);

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -160,3 +160,8 @@
 #if __APPLE__
 #undef __SIZEOF_INT128__
 #endif
+
+// Wide-char compatibility
+#define wchar_t wchar
+#define char16_t wchar
+#define char32_t dchar

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -166,6 +166,7 @@
 #endif
 
 // Wide-char compatibility
-#define wchar_t wchar
-#define char16_t wchar
-#define char32_t dchar
+#define __WCHAR_TYPE__ wchar_t
+#define wchar_t wchar_t
+#define char16_t wchar_t
+#define char32_t char32_t


### PR DESCRIPTION
Fix Issue 24132. Add wchar/dchar to C Keywords list. Use #defines to convert C wide-chars to wchar/dchar