### PR TITLE
test: Remove 'ref' checks from -preview=in tests

### DIFF
--- a/compiler/test/compilable/previewin.d
+++ b/compiler/test/compilable/previewin.d
@@ -79,14 +79,11 @@ version (Win64)
 {
     void checkReal(in real p)
     {
-        // ref for x87 real, value for double-precision real
-        static assert(__traits(isRef, p) == (real.sizeof > 8));
     }
 
     struct RGB { ubyte r, g, b; }
     void checkNonPowerOf2(in RGB p)
     {
-        static assert(__traits(isRef, p));
     }
 }
 else version (X86_64) // Posix x86_64
@@ -94,7 +91,6 @@ else version (X86_64) // Posix x86_64
     struct Empty {} // 1 dummy byte passed on the stack
     void checkEmptyStruct(in Empty p)
     {
-        static assert(!__traits(isRef, p));
     }
 
     static if (is(__vector(double[4])))
@@ -102,7 +98,6 @@ else version (X86_64) // Posix x86_64
         struct AvxVectorWrapper { __vector(double[4]) a; } // 256 bits
         void checkAvxVector(in AvxVectorWrapper p)
         {
-            static assert(!__traits(isRef, p));
         }
     }
 }
@@ -111,6 +106,5 @@ else version (AArch64)
     alias HVA = __vector(float[4])[4]; // can be passed in 4 vector registers
     void checkHVA(in HVA p)
     {
-        static assert(!__traits(isRef, p));
     }
 }

--- a/compiler/test/runnable/previewin.d
+++ b/compiler/test/runnable/previewin.d
@@ -154,27 +154,25 @@ struct WithDtor
 @safe pure nothrow @nogc:
 
 // By value
-void testin1(in uint p) { static assert(!__traits(isRef, p)); }
+void testin1(in uint p) { }
 // By ref because of size
-void testin2(in ulong[64] p) { static assert(__traits(isRef, p)); }
+void testin2(in ulong[64] p) { }
 // By value or ref depending on size (or structs always passed by reference)
-void testin3(in ValueT p) { static assert(!__traits(isRef, p) || true); }
-void testin3(in RefT p) { static assert(__traits(isRef, p)); }
+void testin3(in ValueT p) { }
+void testin3(in RefT p) { }
 // By ref because of size (or arrays always passed by reference)
-void testin4(in ValueT[64] p) { static assert(__traits(isRef, p)); }
-void testin4(in RefT[4] p) { static assert(__traits(isRef, p)); }
+void testin4(in ValueT[64] p) { }
+void testin4(in RefT[4] p) { }
 
 // By ref because of non-copyability
-void testin5(in NonCopyable noncopy) { static assert(__traits(isRef, noncopy)); }
-static assert(testin5.mangleof == "_D9previewin7testin5FNaNbNiNfIKSQBe11NonCopyableZv"); // incl. `ref`
+void testin5(in NonCopyable noncopy) { }
 //  By ref because of postblit
-void testin6(in WithPostblit withpostblit) { static assert(__traits(isRef, withpostblit)); }
+void testin6(in WithPostblit withpostblit) { }
 //  By ref because of copy ctor
-void testin7(in WithCopyCtor withcopy) { static assert(__traits(isRef, withcopy)); }
+void testin7(in WithCopyCtor withcopy) { }
 //  By ref because of dtor
 void testin8(in WithDtor withdtor, scope bool* isTestOver)
 {
-    static assert(__traits(isRef, withdtor));
     if (isTestOver)
         *isTestOver = true;
 }


### PR DESCRIPTION
Having `ref` semantics of `in` parameters in the language semantic is broken, and these asserts could fail from one target to the next.

There's also these related issues:

https://gcc.gnu.org/PR112285
https://gcc.gnu.org/PR112290
https://gcc.gnu.org/PR112291

In all cases, the FE is requesting what is the ABI of an incomplete type - and completing the type so that an accurate response can be given corrupts the AST (in other words, `preferPassByRef` is called too early in semantic pass, or can be called when a type is in the middle of resolving itself).

Rather than _maybe_ marking `in` parameters as `ref`, either of the following behaviours is more desirable:

1. _All_ `in` parameters are `ref` - but this doesn't work with the current implementation of `-preview=in` (i.e: `cannot convert 42 of type 'int' to type 'ref int'`)
2. Let the code generator decide the `ref`-ness of a parameter _after_ all semantic passes have complete, so its role is reduced to an optimization only (i.e: same as NRVO or non-POD parameters).

FYI - [1] was already agreed by both @WalterBright and @atilaneves in an earlier D foundation meeting, it's just that nobody has had the time to implement it yet.

In the meantime, don't enforce that any particular semantic is being done on the type.

GDC meanwhile will return `false` for this `Target` function for the forseeable future - and _maybe_ silently convert them to `ref` during code-gen pass later.