### PR TITLE
make purpose of alignmember() clearer

### DIFF
--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -613,7 +613,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
                 if (!b.sym.alignsize)
                     b.sym.alignsize = target.ptrsize;
-                alignmember(structalign_t(cast(ushort)b.sym.alignsize), b.sym.alignsize, &offset);
+                offset = alignmember(structalign_t(cast(ushort)b.sym.alignsize), b.sym.alignsize, offset);
                 assert(bi < vtblInterfaces.length);
 
                 BaseClass* bv = (*vtblInterfaces)[bi];

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -745,7 +745,7 @@ uint setClosureVarOffset(FuncDeclaration fd)
             memalignsize = v.type.alignsize();
             xalign = v.alignment;
         }
-        AggregateDeclaration.alignmember(xalign, memalignsize, &offset);
+        offset = AggregateDeclaration.alignmember(xalign, memalignsize, offset);
         v.offset = offset;
         //printf("closure var %s, offset = %d\n", v.toChars(), v.offset);
 
@@ -1001,7 +1001,7 @@ uint setAlignSectionVarOffset(FuncDeclaration fd)
         const memalignsize = v.type.alignsize();
         const xalign = v.alignment;
 
-        AggregateDeclaration.alignmember(xalign, memalignsize, &offset);
+        offset = AggregateDeclaration.alignmember(xalign, memalignsize, offset);
         v.offset = offset;
         //printf("align closure var %s, offset = %d\n", v.toChars(), offset);
 


### PR DESCRIPTION
Have it compute a straightforward return value.