### PR TITLE
expression.Expression : delete implicitConvTo shell function + modify usage site + update C++ headers

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -232,7 +232,7 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
  * Returns:
  *   The `MATCH` level between `e.type` and `t`.
  */
-MATCH implicitConvTo(Expression e, Type t)
+extern(C++) MATCH implicitConvTo(Expression e, Type t)
 {
     MATCH visit(Expression e)
     {

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -22,6 +22,7 @@ import dmd.attrib;
 import dmd.builtin;
 import dmd.constfold;
 import dmd.ctfeexpr;
+import dmd.dcast;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dstruct;

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -26,7 +26,6 @@ import dmd.ast_node;
 import dmd.gluelayer;
 import dmd.ctfeexpr;
 import dmd.ctorflow;
-import dmd.dcast;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.delegatize;
@@ -741,11 +740,6 @@ extern (C++) abstract class Expression : ASTNode
             }
         }
         return toLvalue(sc, e);
-    }
-
-    final MATCH implicitConvTo(Type t)
-    {
-        return .implicitConvTo(this, t);
     }
 
     /****************************************
@@ -2189,12 +2183,13 @@ extern (C++) final class NullExp : Expression
 
     override StringExp toStringExp()
     {
-        if (implicitConvTo(Type.tstring))
+        if (this.type.implicitConvTo(Type.tstring))
         {
             auto se = new StringExp(loc, (cast(char*)mem.xcalloc(1, 1))[0 .. 0]);
             se.type = Type.tstring;
             return se;
         }
+
         return null;
     }
 

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -47,6 +47,7 @@ struct Symbol;          // back end symbol
 
 void expandTuples(Expressions *exps, Identifiers *names = nullptr);
 StringExp *toUTF8(StringExp *se, Scope *sc);
+MATCH implicitConvTo(Expression *e, Type *t);
 
 typedef unsigned char OwnedBy;
 enum
@@ -97,7 +98,6 @@ public:
     virtual bool isLvalue();
     virtual Expression *toLvalue(Scope *sc, Expression *e);
     virtual Expression *modifiableLvalue(Scope *sc, Expression *e);
-    MATCH implicitConvTo(Type *t);
     virtual Expression *resolveLoc(const Loc &loc, Scope *sc);
     virtual bool checkType();
     virtual bool checkValue();

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -932,14 +932,6 @@ struct complex_t final
     int32_t opEquals(complex_t y) const;
 };
 
-enum class MATCH
-{
-    nomatch = 0,
-    convert = 1,
-    constant = 2,
-    exact = 3,
-};
-
 template <typename T>
 struct Optional final
 {
@@ -977,7 +969,6 @@ public:
     virtual bool isLvalue();
     virtual Expression* toLvalue(Scope* sc, Expression* e);
     virtual Expression* modifiableLvalue(Scope* sc, Expression* e);
-    MATCH implicitConvTo(Type* t);
     virtual Expression* resolveLoc(const Loc& loc, Scope* sc);
     virtual bool checkType();
     virtual bool checkValue();
@@ -1105,6 +1096,14 @@ public:
     BinExp* isBinExp();
     BinAssignExp* isBinAssignExp();
     void accept(Visitor* v) override;
+};
+
+enum class MATCH
+{
+    nomatch = 0,
+    convert = 1,
+    constant = 2,
+    exact = 3,
 };
 
 enum class ThreeState : uint8_t
@@ -5861,6 +5860,8 @@ class CTFEExp final : public Expression
 public:
     const char* toChars() const override;
 };
+
+extern MATCH implicitConvTo(Expression* e, Type* t);
 
 struct BaseClass final
 {

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -24,6 +24,7 @@ import dmd.astenums;
 import dmd.ast_node;
 import dmd.gluelayer;
 import dmd.dclass;
+import dmd.dcast;
 import dmd.declaration;
 import dmd.denum;
 import dmd.dmangle;

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -25,6 +25,7 @@ import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astenums;
 import dmd.attrib;
+import dmd.dcast;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.denum;


### PR DESCRIPTION
This is part of the effort of pulling out semantic out of expression. After this PR, a follow up will be to move the Expression.toUTF8  member function and we can get rid of importing module dcast.

cc @ibuclaw + @kinke is this function really used by GDC and LDC or could we leave it extern(D)?

