### PR TITLE
Issue 24124 - ImportC: gcc simd intrinsics not supported by dmd

### DIFF
--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -164,3 +164,5 @@
 #if __APPLE__
 #undef __SIZEOF_INT128__
 #endif
+
+#define STBI_NO_SIMD /* disable gcc simd intrinsics */


### PR DESCRIPTION
This doesn't actually cause gcc simd intrinsics to be supported, it just causes dmd to ignore them.

Since ldc and gdc support them, @ibuclaw and @kinke should adjust this for their implementations.

cc @schveiguy 