### PR TITLE
Add hint when declaring function with TypeCtor

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -3384,9 +3384,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (!tf.isNaked() && !(funcdecl.isThis() || funcdecl.isNested()))
             {
-                OutBuffer buf;
-                MODtoBuffer(buf, tf.mod);
-                .error(funcdecl.loc, "%s `%s` without `this` cannot be `%s`", funcdecl.kind, funcdecl.toPrettyChars, buf.peekChars());
+                import core.bitop;
+                auto mods = MODtoChars(tf.mod);
+                .error(funcdecl.loc, "%s `%s` without `this` cannot be `%s`", funcdecl.kind, funcdecl.toPrettyChars, mods);
+                if (tf.next && tf.next.ty != Tvoid && popcnt(tf.mod) == 1)
+                    .errorSupplemental(funcdecl.loc,
+                        "did you mean to use `%s(%s)` as the return type?", mods, tf.next.toChars());
+
                 tf.mod = 0; // remove qualifiers
             }
 

--- a/compiler/test/fail_compilation/fail212.d
+++ b/compiler/test/fail_compilation/fail212.d
@@ -1,9 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail212.d(14): Error: function `fail212.S.bar` without `this` cannot be `const`
+fail_compilation/fail212.d(10): Error: function `fail212.baz` without `this` cannot be `const`
+fail_compilation/fail212.d(10):        did you mean to use `const(int)` as the return type?
+fail_compilation/fail212.d(18): Error: function `fail212.S.bar` without `this` cannot be `const`
 ---
 */
+
+const int baz();
 
 struct S
 {


### PR DESCRIPTION
If a separate *TypeCtor* is given before the function signature, suggest using e.g. `const(T)` as the return type instead.