### PR TITLE
Move a couple of functions out of dsymbol.d

### DIFF
--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -45,7 +45,6 @@ import dmd.lexer;
 import dmd.location;
 import dmd.mtype;
 import dmd.nspace;
-import dmd.opover;
 import dmd.root.aav;
 import dmd.root.rmem;
 import dmd.rootobject;
@@ -875,64 +874,6 @@ extern (C++) class Dsymbol : ASTNode
         return speller!symbol_search_fp(ident.toString());
     }
 
-    /***************************************
-     * Search for identifier id as a member of `this`.
-     * `id` may be a template instance.
-     *
-     * Params:
-     *  loc = location to print the error messages
-     *  sc = the scope where the symbol is located
-     *  id = the id of the symbol
-     *  flags = the search flags which can be `SearchLocalsOnly` or `IgnorePrivateImports`
-     *
-     * Returns:
-     *      symbol found, NULL if not
-     */
-    extern (D) final Dsymbol searchX(const ref Loc loc, Scope* sc, RootObject id, int flags)
-    {
-        //printf("Dsymbol::searchX(this=%p,%s, ident='%s')\n", this, toChars(), ident.toChars());
-        Dsymbol s = toAlias();
-        Dsymbol sm;
-        if (Declaration d = s.isDeclaration())
-        {
-            if (d.inuse)
-            {
-                .error(loc, "circular reference to `%s`", d.toPrettyChars());
-                return null;
-            }
-        }
-        switch (id.dyncast())
-        {
-        case DYNCAST.identifier:
-            sm = s.search(loc, cast(Identifier)id, flags);
-            break;
-        case DYNCAST.dsymbol:
-            {
-                // It's a template instance
-                //printf("\ttemplate instance id\n");
-                Dsymbol st = cast(Dsymbol)id;
-                TemplateInstance ti = st.isTemplateInstance();
-                sm = s.search(loc, ti.name);
-                if (!sm)
-                    return null;
-                sm = sm.toAlias();
-                TemplateDeclaration td = sm.isTemplateDeclaration();
-                if (!td)
-                    return null; // error but handled later
-                ti.tempdecl = td;
-                if (!ti.semanticRun)
-                    ti.dsymbolSemantic(sc);
-                sm = ti.toAlias();
-                break;
-            }
-        case DYNCAST.type:
-        case DYNCAST.expression:
-        default:
-            assert(0);
-        }
-        return sm;
-    }
-
     bool overloadInsert(Dsymbol s)
     {
         //printf("Dsymbol::overloadInsert('%s')\n", s.toChars());
@@ -1702,38 +1643,6 @@ public:
     override const(char)* kind() const
     {
         return "ScopeDsymbol";
-    }
-
-    /*******************************************
-     * Look for member of the form:
-     *      const(MemberInfo)[] getMembers(string);
-     * Returns NULL if not found
-     */
-    final FuncDeclaration findGetMembers()
-    {
-        Dsymbol s = search_function(this, Id.getmembers);
-        FuncDeclaration fdx = s ? s.isFuncDeclaration() : null;
-        version (none)
-        {
-            // Finish
-            __gshared TypeFunction tfgetmembers;
-            if (!tfgetmembers)
-            {
-                Scope sc;
-                sc.eSink = global.errorSink;
-                auto parameters = new Parameters();
-                Parameters* p = new Parameter(STC.in_, Type.tchar.constOf().arrayOf(), null, null);
-                parameters.push(p);
-                Type tret = null;
-                TypeFunction tf = new TypeFunction(parameters, tret, VarArg.none, LINK.d);
-                tfgetmembers = tf.dsymbolSemantic(Loc.initial, &sc).isTypeFunction();
-            }
-            if (fdx)
-                fdx = fdx.overloadExactMatch(tfgetmembers);
-        }
-        if (fdx && fdx.isVirtual())
-            fdx = null;
-        return fdx;
     }
 
     /********************************

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -346,7 +346,6 @@ public:
     bool isforwardRef() override final;
     static void multiplyDefined(const Loc &loc, Dsymbol *s1, Dsymbol *s2);
     const char *kind() const override;
-    FuncDeclaration *findGetMembers();
     virtual Dsymbol *symtabInsert(Dsymbol *s);
     virtual Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
     bool hasStaticCtorOrDtor() override;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -632,7 +632,6 @@ public:
     bool isforwardRef() final override;
     static void multiplyDefined(const Loc& loc, Dsymbol* s1, Dsymbol* s2);
     const char* kind() const override;
-    FuncDeclaration* findGetMembers();
     virtual Dsymbol* symtabInsert(Dsymbol* s);
     virtual Dsymbol* symtabLookup(Dsymbol* s, Identifier* id);
     bool hasStaticCtorOrDtor() override;
@@ -8227,6 +8226,8 @@ extern Type* getTypeInfoType(const Loc& loc, Type* t, Scope* sc, bool genObjCode
 extern bool isSpeculativeType(Type* t);
 
 extern bool builtinTypeInfo(Type* t);
+
+extern FuncDeclaration* findGetMembers(ScopeDsymbol* dsym);
 
 class SemanticTimeTransitiveVisitor : public SemanticTimePermissiveVisitor
 {

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -47,6 +47,7 @@ import dmd.location;
 import dmd.mtype;
 import dmd.nspace;
 import dmd.objc_glue;
+import dmd.opover;
 import dmd.statement;
 import dmd.staticassert;
 import dmd.target;

--- a/compiler/src/dmd/typinf.h
+++ b/compiler/src/dmd/typinf.h
@@ -15,8 +15,11 @@
 class Expression;
 class Type;
 struct Scope;
+class FuncDeclaration;
+class ScopeDsymbol;
 
 bool genTypeInfo(Expression *e, const Loc &loc, Type *torig, Scope *sc);
 Type *getTypeInfoType(const Loc &loc, Type *t, Scope *sc, bool genObjCode = true);
 bool isSpeculativeType(Type *t);
 bool builtinTypeInfo(Type *t);
+FuncDeclaration *findGetMembers(ScopeDsymbol *dsym);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1179,7 +1179,7 @@ public:
                 if (mi->needmoduleinfo)
                     mi->accept(this);
             }
-            (void)d->findGetMembers();
+            (void)findGetMembers(d);
             (void)d->sctor;
             (void)d->sdtor;
             (void)d->ssharedctor;


### PR DESCRIPTION
- `findGetMembers` is only used in toobj, but seems to be used from gdc so I didn't make it private.
- `searchX` is only used in typesem.d