### PR TITLE
Fix Issue 21459: Store lowering of `CatAssignExp` in a separate field

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -5901,7 +5901,7 @@ private bool isDRuntimeHook(Identifier id)
         id == Id._d_arraysetlengthTImpl || id == Id._d_arraysetlengthT ||
         id == Id._d_arraysetlengthTTrace ||
         id == Id._d_arrayappendT || id == Id._d_arrayappendTTrace ||
-        id == Id._d_arrayappendcTXImpl;
+        id == Id._d_arrayappendcTX;
 }
 
 void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList argumentList)

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -5633,7 +5633,9 @@ extern (C++) final class UshrAssignExp : BinAssignExp
  */
 extern (C++) class CatAssignExp : BinAssignExp
 {
-    extern (D) this(const ref Loc loc, Expression e1, Expression e2) @safe
+    Expression lowering;    // lowered druntime hook `_d_arrayappend{cTX,T}`
+
+    extern (D) this(const ref Loc loc, Expression e1, Expression e2)
     {
         super(loc, EXP.concatenateAssign, e1, e2);
     }

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -1148,6 +1148,8 @@ public:
 class CatAssignExp : public BinAssignExp
 {
 public:
+    Expression *lowering;   // lowered druntime hook `_d_arrayappend{cTX,T}`
+
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7831,6 +7831,7 @@ public:
 class CatAssignExp : public BinAssignExp
 {
 public:
+    Expression* lowering;
     void accept(Visitor* v) override;
 };
 
@@ -8714,7 +8715,6 @@ struct Id final
     static Identifier* _d_arraysetlengthTTrace;
     static Identifier* _d_arrayappendT;
     static Identifier* _d_arrayappendTTrace;
-    static Identifier* _d_arrayappendcTXImpl;
     static Identifier* _d_arrayappendcTX;
     static Identifier* _d_arrayappendcTXTrace;
     static Identifier* _d_arraycatnTX;

--- a/compiler/src/dmd/id.d
+++ b/compiler/src/dmd/id.d
@@ -366,7 +366,6 @@ immutable Msgtable[] msgtable =
     { "_d_arraysetlengthTTrace"},
     { "_d_arrayappendT" },
     { "_d_arrayappendTTrace" },
-    { "_d_arrayappendcTXImpl" },
     { "_d_arrayappendcTX" },
     { "_d_arrayappendcTXTrace" },
     { "_d_arraycatnTX" },

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -773,6 +773,21 @@ public:
             result = ce;
         }
 
+        override void visit(CatAssignExp e)
+        {
+            auto cae = cast(CatAssignExp) e.copy();
+
+            if (auto lowering = cae.lowering)
+                cae.lowering = doInlineAs!Expression(cae.lowering, ids);
+            else
+            {
+                cae.e1 = doInlineAs!Expression(e.e1, ids);
+                cae.e2 = doInlineAs!Expression(e.e2, ids);
+            }
+
+            result = cae;
+        }
+
         override void visit(BinExp e)
         {
             auto be = cast(BinExp)e.copy();
@@ -1277,6 +1292,14 @@ public:
 
         inlineScan(e.e1);
         inlineScan(e.e2);
+    }
+
+    override void visit(CatAssignExp e)
+    {
+        if (auto lowering = e.lowering)
+            inlineScan(lowering);
+        else
+            visit(cast(BinExp) e);
     }
 
     override void visit(BinExp e)

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -108,12 +108,6 @@ public:
                 return;
             f.printGCUsage(e.loc, "setting `length` may cause a GC allocation");
         }
-        else if (fd.ident == Id._d_arrayappendT || fd.ident == Id._d_arrayappendcTX)
-        {
-            if (setGC(e, "cannot use operator `~=` in `@nogc` %s `%s`"))
-                return;
-            f.printGCUsage(e.loc, "operator `~=` may cause a GC allocation");
-        }
     }
 
     override void visit(ArrayLiteralExp e)
@@ -187,20 +181,14 @@ public:
 
     override void visit(CatAssignExp e)
     {
-        /* CatAssignExp will exist in `__traits(compiles, ...)` and in the `.e1` branch of a `__ctfe ? :` CondExp.
-         * The other branch will be `_d_arrayappendcTX(e1, 1), e1[$-1]=e2` which will generate the warning about
-         * GC usage. See visit(CallExp).
-         */
         if (checkOnly)
         {
             err = true;
             return;
         }
-        if (f.setGC(e.loc, null))
-        {
-            err = true;
+        if (setGC(e, "cannot use operator `~=` in `@nogc` %s `%s`"))
             return;
-        }
+        f.printGCUsage(e.loc, "operator `~=` may cause a GC allocation");
     }
 
     override void visit(CatExp e)

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -928,6 +928,14 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
         }
     }
 
+    void visitCatAssign(CatAssignExp e)
+    {
+        if (auto lowering = e.lowering)
+            Expression_optimize(lowering, result, keepLvalue);
+        else
+            visitBinAssign(e);
+    }
+
     void visitBin(BinExp e)
     {
         //printf("BinExp::optimize(result = %d) %s\n", result, e.toChars());
@@ -1392,9 +1400,9 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             case EXP.leftShiftAssign:
             case EXP.rightShiftAssign:
             case EXP.unsignedRightShiftAssign:
+            case EXP.concatenateDcharAssign: visitBinAssign(ex.isBinAssignExp()); break;
             case EXP.concatenateElemAssign:
-            case EXP.concatenateDcharAssign:
-            case EXP.concatenateAssign: visitBinAssign(ex.isBinAssignExp()); break;
+            case EXP.concatenateAssign:      visitCatAssign(cast(CatAssignExp) ex); break;
 
             case EXP.minusMinus:
             case EXP.plusPlus:

--- a/compiler/test/fail_compilation/test24159.d
+++ b/compiler/test/fail_compilation/test24159.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=24159
+// REQUIRED_ARGS: -betterC
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test24159.d(13): Error: appending to array in `x ~= 3` requires the GC which is not available with -betterC
+---
+*/
+
+extern(C) void main()
+{
+    int[] x = null;
+    x ~= 3;
+}

--- a/druntime/src/core/internal/array/appending.d
+++ b/druntime/src/core/internal/array/appending.d
@@ -14,56 +14,55 @@ private extern (C) byte[] _d_arrayappendcTX(const TypeInfo ti, ref return scope 
 
 private enum isCopyingNothrow(T) = __traits(compiles, (ref T rhs) nothrow { T lhs = rhs; });
 
-/// Implementation of `_d_arrayappendcTX` and `_d_arrayappendcTXTrace`
-template _d_arrayappendcTXImpl(Tarr : T[], T)
+/**
+ * Extend an array `px` by `n` elements.
+ * Caller must initialize those elements.
+ * Params:
+ *  px = the array that will be extended, taken as a reference
+ *  n = how many new elements to extend it with
+ * Returns:
+ *  The new value of `px`
+ * Bugs:
+ *  This function template was ported from a much older runtime hook that bypassed safety,
+ *  purity, and throwabilty checks. To prevent breaking existing code, this function template
+ *  is temporarily declared `@trusted pure` until the implementation can be brought up to modern D expectations.
+ */
+ref Tarr _d_arrayappendcTX(Tarr : T[], T)(return ref scope Tarr px, size_t n) @trusted
 {
-    private enum errorMessage = "Cannot append to array if compiling without support for runtime type information!";
-
-    /**
-     * Extend an array `px` by `n` elements.
-     * Caller must initialize those elements.
-     * Params:
-     *  px = the array that will be extended, taken as a reference
-     *  n = how many new elements to extend it with
-     * Returns:
-     *  The new value of `px`
-     * Bugs:
-     *  This function template was ported from a much older runtime hook that bypassed safety,
-     *  purity, and throwabilty checks. To prevent breaking existing code, this function template
-     *  is temporarily declared `@trusted pure` until the implementation can be brought up to modern D expectations.
-     */
-    ref Tarr _d_arrayappendcTX(return ref scope Tarr px, size_t n) @trusted pure nothrow
+    // needed for CTFE: https://github.com/dlang/druntime/pull/3870#issuecomment-1178800718
+    version (DigitalMars) pragma(inline, false);
+    version (D_TypeInfo)
     {
-        // needed for CTFE: https://github.com/dlang/druntime/pull/3870#issuecomment-1178800718
-        version (DigitalMars) pragma(inline, false);
+        auto ti = typeid(Tarr);
+
+        // _d_arrayappendcTX takes the `px` as a ref byte[], but its length
+        // should still be the original length
+        auto pxx = (cast(byte*)px.ptr)[0 .. px.length];
+        ._d_arrayappendcTX(ti, pxx, n);
+        px = (cast(T*)pxx.ptr)[0 .. pxx.length];
+
+        return px;
+    }
+    else
+        assert(0, "Cannot append to array if compiling without support for runtime type information!");
+}
+
+version (D_ProfileGC)
+{
+    /**
+     * TraceGC wrapper around $(REF _d_arrayappendT, core,internal,array,appending).
+     */
+    ref Tarr _d_arrayappendcTXTrace(Tarr : T[], T)(string file, int line, string funcname, return ref scope Tarr px, size_t n) @trusted
+    {
         version (D_TypeInfo)
         {
-            auto ti = typeid(Tarr);
+            import core.internal.array.utils: TraceHook, gcStatsPure, accumulatePure;
+            mixin(TraceHook!(Tarr.stringof, "_d_arrayappendcTX"));
 
-            // _d_arrayappendcTX takes the `px` as a ref byte[], but its length
-            // should still be the original length
-            auto pxx = (cast(byte*)px.ptr)[0 .. px.length];
-            ._d_arrayappendcTX(ti, pxx, n);
-            px = (cast(T*)pxx.ptr)[0 .. pxx.length];
-
-            return px;
+            return _d_arrayappendcTX(px, n);
         }
         else
-            assert(0, errorMessage);
-    }
-
-    version (D_ProfileGC)
-    {
-        import core.internal.array.utils : _d_HookTraceImpl;
-
-        /**
-         * TraceGC wrapper around $(REF _d_arrayappendcTX, rt,array,appending,_d_arrayappendcTXImpl).
-         * Bugs:
-         *  This function template was ported from a much older runtime hook that bypassed safety,
-         *  purity, and throwabilty checks. To prevent breaking existing code, this function template
-         *  is temporarily declared `@trusted pure` until the implementation can be brought up to modern D expectations.
-         */
-        alias _d_arrayappendcTXTrace = _d_HookTraceImpl!(Tarr, _d_arrayappendcTX, errorMessage);
+            static assert(0, "Cannot append to array if compiling without support for runtime type information!");
     }
 }
 
@@ -78,7 +77,7 @@ ref Tarr _d_arrayappendT(Tarr : T[], T)(return ref scope Tarr x, scope Tarr y) @
     enum hasPostblit = __traits(hasPostblit, T);
     auto length = x.length;
 
-    _d_arrayappendcTXImpl!Tarr._d_arrayappendcTX(x, y.length);
+    _d_arrayappendcTX(x, y.length);
 
     // Only call `copyEmplace` if `T` has a copy ctor and no postblit.
     static if (hasElaborateCopyConstructor!T && !hasPostblit)
@@ -126,7 +125,7 @@ version (D_ProfileGC)
             return _d_arrayappendT(x, y);
         }
         else
-            assert(0, "Cannot append to array if compiling without support for runtime type information!");
+            static assert(0, "Cannot append to array if compiling without support for runtime type information!");
     }
 }
 

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -4667,11 +4667,12 @@ public import core.internal.array.appending : _d_arrayappendT;
 version (D_ProfileGC)
 {
     public import core.internal.array.appending : _d_arrayappendTTrace;
+    public import core.internal.array.appending : _d_arrayappendcTXTrace;
     public import core.internal.array.concatenation : _d_arraycatnTXTrace;
     public import core.lifetime : _d_newitemTTrace;
     public import core.internal.array.construction : _d_newarrayTTrace;
 }
-public import core.internal.array.appending : _d_arrayappendcTXImpl;
+public import core.internal.array.appending : _d_arrayappendcTX;
 public import core.internal.array.comparison : __cmp;
 public import core.internal.array.equality : __equals;
 public import core.internal.array.casting: __ArrayCast;


### PR DESCRIPTION
This preserves the `CatAssignExp` in the AST until the glue layer where an error is printed in case this expression is used with `-betterC`. This is required to happen in the glue layer as the semantic analysis doesn't correctly distinguish when code needs to be generated.