### PR TITLE
Refactor `toLvalue` by removing redundant parameter

### DIFF
--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -52,7 +52,7 @@ void expandTuples(Expressions *exps, Identifiers *names = nullptr);
 StringExp *toUTF8(StringExp *se, Scope *sc);
 Expression *resolveLoc(Expression *exp, const Loc &loc, Scope *sc);
 MATCH implicitConvTo(Expression *e, Type *t);
-Expression *toLvalue(Expression *_this, Scope *sc, Expression *e);
+Expression *toLvalue(Expression *_this, Scope *sc);
 Expression *modifiableLvalue(Expression* exp, Scope *sc, Expression *e);
 
 typedef unsigned char OwnedBy;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7988,7 +7988,7 @@ extern Expression* resolveProperties(Scope* sc, Expression* e);
 
 extern Expression* expressionSemantic(Expression* e, Scope* sc);
 
-extern Expression* toLvalue(Expression* _this, Scope* sc, Expression* e);
+extern Expression* toLvalue(Expression* _this, Scope* sc);
 
 extern Expression* modifiableLvalue(Expression* _this, Scope* sc, Expression* e);
 

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -2190,7 +2190,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
         import dmd.expressionsem : toLvalue;
         // https://issues.dlang.org/show_bug.cgi?id=11322
         if (tf.isref)
-            e = e.toLvalue(null, null);
+            e = e.toLvalue(null);
 
         /* If the inlined function returns a copy of a struct,
          * and then the return value is used subsequently as an

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -918,7 +918,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         if (f.isref)
                         {
                             // Function returns a reference
-                            exp = exp.toLvalue(sc2, exp);
+                            exp = exp.toLvalue(sc2);
                             checkReturnEscapeRef(sc2, exp, false);
                             exp = exp.optimize(WANTvalue, /*keepLvalue*/ true);
                         }

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1157,7 +1157,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             if (isRefOrOut && !isAuto &&
                 !(global.params.previewIn && (fparam.storageClass & STC.in_)) &&
                 global.params.rvalueRefParam != FeatureState.enabled)
-                e = e.toLvalue(sc, e);
+                e = e.toLvalue(sc);
 
             fparam.defaultArg = e;
             return (e.op != EXP.error);


### PR DESCRIPTION
I was looking to improve the error messages in `toLvalue` by adding a parameter with additional info, but wanted to fix the awkward current interface first. 