### PR TITLE
Introduce a parameter to -unittest that lets you filter out unittests…

### DIFF
--- a/compiler/src/dmd/compiler.d
+++ b/compiler/src/dmd/compiler.d
@@ -144,6 +144,7 @@ extern (C++) struct Compiler
             {
                 if (global.params.v.verbose)
                     message("compileimport (%s)", m.srcfile.toChars);
+                m.specifiedOnCmdLine = false;
                 compiledImports.push(m);
                 return true; // this import will be compiled
             }

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -351,6 +351,7 @@ extern (C++) final class Module : Package
     extern (C++) __gshared AggregateDeclaration moduleinfo;
 
     const(char)[] arg;           // original argument name
+    bool specifiedOnCmdLine = true;    // Was the module explicitly mentioned on the compiler invocation.
     ModuleDeclaration* md;      // if !=null, the contents of the ModuleDeclaration declaration
     const FileName srcfile;     // input source file
     const FileName objfile;     // output .obj file
@@ -1246,6 +1247,13 @@ extern (C++) final class Module : Package
     bool isRoot() nothrow
     {
         return this.importedFrom == this;
+    }
+
+    ///
+    bool isSpecifiedOnCommandLine() const nothrow
+    {
+        // Hiding details in anticipation of the future.
+        return this.specifiedOnCmdLine;
     }
 
     /// Returns: Whether this module is in the `core` package and has name `ident`

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4578,15 +4578,27 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         }
 
-        if (global.params.useUnitTests)
-        {
-            if (!utd.type)
-                utd.type = new TypeFunction(ParameterList(), Type.tvoid, LINK.d, utd.storage_class);
-            Scope* sc2 = sc.push();
-            sc2.linkage = LINK.d;
-            funcDeclarationSemantic(utd);
-            sc2.pop();
+        if (!global.params.useUnitTests)
+            return;
+
+        final switch(global.params.unittestFilter) with (UnittestFilter) {
+            case all:
+                break;
+            case explicitOnly:
+                auto mod = utd.getModule();
+                if (mod.isSpecifiedOnCommandLine())
+                    break;
+                utd.skipCodegen = true;
+                return;
         }
+
+        auto mod = utd.getModule();
+        if (!utd.type)
+            utd.type = new TypeFunction(ParameterList(), Type.tvoid, LINK.d, utd.storage_class);
+        Scope* sc2 = sc.push();
+        sc2.linkage = LINK.d;
+        funcDeclarationSemantic(utd);
+        sc2.pop();
 
         version (none)
         {

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -88,6 +88,17 @@ enum FeatureState : ubyte
     enabled  = 2,  /// Specified as `-preview=`
 }
 
+///
+enum UnittestFilter : ubyte
+{
+    ///
+    @("Include unit tests from all compiled modules")
+    all,
+    ///
+    @("Include unit tests only from modules listed explicitly")
+    explicitOnly
+}
+
 extern(C++) struct Output
 {
     bool doOutput;      // Output is enabled
@@ -160,6 +171,7 @@ extern (C++) struct Param
     bool vcg_ast;           // write-out codegen-ast
     DiagnosticReporting useDeprecated = DiagnosticReporting.inform;  // how use of deprecated features are handled
     bool useUnitTests;          // generate unittest code
+    UnittestFilter unittestFilter = UnittestFilter.all;
     bool useInline = false;     // inline expand functions
     bool release;           // build release version
     bool preservePaths;     // true means don't strip path from source file

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1427,8 +1427,31 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         {
             params.useExceptions = false;
         }
-        else if (arg == "-unittest")
+        else if (startsWith(p, "-unittest"))
+        {
+            const ugh = "-unittest".length;
             params.useUnitTests = true;
+            if (arg.length == ugh)
+                continue;
+            if (arg[ugh] != '=')
+                continue;
+            const suffix = arg[ugh+1..$];
+
+            with(UnittestFilter) switch(suffix) {
+                case "all":
+                    params.unittestFilter = all;
+                    continue;
+                case "explicit":
+                    message("`-unittest=explicit` is experimental.");
+                    params.unittestFilter = explicitOnly;
+                    continue;
+                case "?":
+                    goto default;
+                default:
+                    // TODO print help string.
+                    break;
+            }
+        }
         else if (p[1] == 'I')              // https://dlang.org/dmd.html#switch-I
         {
             if (!params.imppath)

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1830,6 +1830,15 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 }
                 else if (auto ud = s.isUnitTestDeclaration())
                 {
+                    /+
+                        Skip UTs here rather than have semantic
+                        fail later.
+
+                        This works but is a little ugly i.e. use
+                        existing TypeFunction stuff?
+                    +/
+                    if (ud.skipCodegen)
+                        return;
                     if (cast(void*)ud in uniqueUnitTests)
                         return;
 


### PR DESCRIPTION
… from modules that aren't listed explicitly on the command line.

For example -i foo.d should only run unittests from foo but not anything foo imports and thus compiles because of -i