### PR TITLE
fix Issue 24200 - ImportC: .di file collected macro conflicts with Sp…

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -1968,6 +1968,10 @@ private void visitVarDecl(VarDeclaration v, bool anywritten, ref OutBuffer buf, 
             v._init.initializerToBuffer(buf, &hgs);
     }
 
+    const commentIt = hgs.importcHdr && isSpecialCName(v.ident);
+    if (commentIt)
+        buf.writestring("/+");
+
     if (anywritten)
     {
         buf.writestring(", ");
@@ -2000,8 +2004,31 @@ private void visitVarDecl(VarDeclaration v, bool anywritten, ref OutBuffer buf, 
         buf.writestring(" = ");
         vinit(v);
     }
+    if (commentIt)
+        buf.writestring("+/");
 }
 
+/*************************************
+ * The names __DATE__, __TIME__,__EOF__, __VENDOR__, __TIMESTAMP__, __VERSION__
+ * are special to the D lexer and cannot be used as D source variable names.
+ * Params:
+ *      id = name to check
+ * Returns:
+ *      true if special C name
+ */
+private bool isSpecialCName(Identifier id)
+{
+    auto s = id.toString();
+    if (s.length >= 7 && s[0] == '_' && s[1] == '_' &&
+        (id == Id.DATE ||
+         id == Id.TIME ||
+         id == Id.EOFX ||
+         id == Id.VENDOR ||
+         id == Id.TIMESTAMP ||
+         id == Id.VERSIONX))
+        return true;
+    return false;
+}
 
 /*********************************************
  * Print expression to buffer.

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -22,6 +22,11 @@ extern (C)
 		int x = void;
 	}
 	Foo abc();
+	/+enum int __DATE__ = 1+/;
+	/+enum int __TIME__ = 1+/;
+	/+enum int __TIMESTAMP__ = 1+/;
+	/+enum int __EOF__ = 1+/;
+	/+enum int __VENDOR__ = 1+/;
 }
 ---
  */
@@ -43,3 +48,11 @@ struct Foo {
 };
 
 struct Foo abc(void);
+
+// https://issues.dlang.org/show_bug.cgi?id=24200
+
+#define __DATE__ 1
+#define __TIME__  1
+#define __TIMESTAMP__  1
+#define __EOF__  1
+#define __VENDOR__  1


### PR DESCRIPTION
…ecial Token

This resolves the issue by commenting out the emissions to the .di file, so the user can see that they aren't being ignored. The symbols will still be available to anyone importing the C file.