### PR TITLE
Rename Event.set() to Event.setIfInitialized()

### DIFF
--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -3336,7 +3336,7 @@ Lmark:
 
         busyThreads.atomicOp!"+="(1); // main thread is busy
 
-        evStart.set();
+        evStart.setIfInitialized();
 
         debug(PARALLEL_PRINTF) printf("mark %lld roots\n", cast(ulong)(ptop - pbot));
 
@@ -3438,7 +3438,7 @@ Lmark:
         stopGC = true;
         while (atomicLoad(stoppedThreads) < startedThreads && !allThreadsDead)
         {
-            evStart.set();
+            evStart.setIfInitialized();
             evDone.wait(dur!"msecs"(1));
         }
 
@@ -3467,7 +3467,7 @@ Lmark:
         {
             evStart.wait();
             pullFromScanStack();
-            evDone.set();
+            evDone.setIfInitialized();
         }
         stoppedThreads.atomicOp!"+="(1);
     }

--- a/druntime/src/core/sync/event.d
+++ b/druntime/src/core/sync/event.d
@@ -61,7 +61,7 @@ struct ProcessFile
             group.create(&doProcess);
 
         buffer = std.file.read(filename);
-        event.set();
+        event.setIfInitialized();
         group.joinAll();
         event.terminate();
     }
@@ -162,9 +162,13 @@ nothrow @nogc:
         }
     }
 
+    deprecated void set()
+    {
+        setIfInitialized();
+    }
 
     /// Set the event to "signaled", so that waiting clients are resumed
-    void set()
+    void setIfInitialized()
     {
         version (Windows)
         {
@@ -302,7 +306,7 @@ private:
     // auto-reset, initial state false
     Event ev1 = Event(false, false);
     assert(!ev1.wait(1.dur!"msecs"));
-    ev1.set();
+    ev1.setIfInitialized();
     assert(ev1.wait());
     assert(!ev1.wait(1.dur!"msecs"));
 
@@ -336,7 +340,7 @@ unittest
     auto start = MonoTime.currTime;
     assert(numRunning == 0);
 
-    event.set();
+    event.setIfInitialized();
     group.joinAll();
 
     assert(numRunning == numThreads);

--- a/druntime/src/core/sync/event.d
+++ b/druntime/src/core/sync/event.d
@@ -162,7 +162,7 @@ nothrow @nogc:
         }
     }
 
-    deprecated void set()
+    deprecated ("Use setIfInitialized() instead") void set()
     {
         setIfInitialized();
     }


### PR DESCRIPTION
Proposed to rename `Event.set()` to `Event.setIfInitialized()` to better reflect behavior of this method.

Yes, it really drives me crazy when setting just doesn’t work because event isn't initialized.

Previously I already tried to do something with it: https://github.com/dlang/druntime/pull/3273