### PR TITLE
fix Issue 24155 - ImportC: accept C23 default initializers

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -6655,6 +6655,19 @@ struct ASTBase
         }
     }
 
+    extern (C++) final class DefaultInitializer : Initializer
+    {
+        extern (D) this(const ref Loc loc)
+        {
+            super(loc, InitKind.default_);
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
     struct Designator
     {
         Expression exp;         /// [ constant-expression ]

--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -383,6 +383,7 @@ enum STMT : ubyte
 enum InitKind : ubyte
 {
     void_,
+    default_,
     error,
     struct_,
     array,

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -2168,6 +2168,7 @@ final class CParser(AST) : Parser!AST
      * C11 Initialization
      * initializer:
      *    assignment-expression
+     *    { }                       // C23 6.7.10 addition
      *    { initializer-list }
      *    { initializer-list , }
      *
@@ -2197,6 +2198,12 @@ final class CParser(AST) : Parser!AST
         }
         nextToken();
         const loc = token.loc;
+
+        if (token.value == TOK.rightCurly)      // { }
+        {
+            nextToken();
+            return new AST.DefaultInitializer(loc);
+        }
 
         /* Collect one or more `designation (opt) initializer`
          * into ci.initializerList, but lazily create ci

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -305,6 +305,7 @@ class TryCatchStatement;
 class DebugStatement;
 class ErrorInitializer;
 class VoidInitializer;
+class DefaultInitializer;
 class StructInitializer;
 class ArrayInitializer;
 class ExpInitializer;
@@ -1881,6 +1882,7 @@ public:
     virtual void visit(typename AST::StructInitializer i);
     virtual void visit(typename AST::ArrayInitializer i);
     virtual void visit(typename AST::VoidInitializer i);
+    virtual void visit(typename AST::DefaultInitializer i);
     virtual void visit(typename AST::CInitializer i);
 };
 
@@ -2709,11 +2711,12 @@ extern const char* toChars(const Statement* const s);
 enum class InitKind : uint8_t
 {
     void_ = 0u,
-    error = 1u,
-    struct_ = 2u,
-    array = 3u,
-    exp = 4u,
-    C_ = 5u,
+    default_ = 1u,
+    error = 2u,
+    struct_ = 3u,
+    array = 4u,
+    exp = 5u,
+    C_ = 6u,
 };
 
 class Initializer : public ASTNode
@@ -2724,6 +2727,7 @@ public:
     DYNCAST dyncast() const override;
     ErrorInitializer* isErrorInitializer();
     VoidInitializer* isVoidInitializer();
+    DefaultInitializer* isDefaultInitializer();
     StructInitializer* isStructInitializer();
     ArrayInitializer* isArrayInitializer();
     ExpInitializer* isExpInitializer();
@@ -2750,6 +2754,13 @@ public:
     Array<DesigInit > initializerList;
     Type* type;
     bool sem;
+    void accept(Visitor* v) override;
+};
+
+class DefaultInitializer final : public Initializer
+{
+public:
+    Type* type;
     void accept(Visitor* v) override;
 };
 
@@ -4946,6 +4957,7 @@ struct ASTCodegen final
     using HdrGenState = ::HdrGenState;
     using ArrayInitializer = ::ArrayInitializer;
     using CInitializer = ::CInitializer;
+    using DefaultInitializer = ::DefaultInitializer;
     using DesigInit = ::DesigInit;
     using Designator = ::Designator;
     using ErrorInitializer = ::ErrorInitializer;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -3862,6 +3862,11 @@ private void initializerToBuffer(Initializer inx, ref OutBuffer buf, HdrGenState
         buf.writestring("void");
     }
 
+    void visitDefault(DefaultInitializer iz)
+    {
+        buf.writestring("{ }");
+    }
+
     void visitStruct(StructInitializer si)
     {
         //printf("StructInitializer::toCBuffer()\n");

--- a/compiler/src/dmd/init.h
+++ b/compiler/src/dmd/init.h
@@ -20,6 +20,7 @@ class Expression;
 class Type;
 class ErrorInitializer;
 class VoidInitializer;
+class DefaultInitializer;
 class StructInitializer;
 class ArrayInitializer;
 class ExpInitializer;
@@ -37,6 +38,7 @@ public:
 
     ErrorInitializer   *isErrorInitializer();
     VoidInitializer    *isVoidInitializer();
+    DefaultInitializer *isDefaultInitializer();
     StructInitializer  *isStructInitializer();
     ArrayInitializer   *isArrayInitializer();
     ExpInitializer     *isExpInitializer();
@@ -46,6 +48,14 @@ public:
 };
 
 class VoidInitializer final : public Initializer
+{
+public:
+    Type *type;         // type that this will initialize to
+
+    void accept(Visitor *v) override { v->visit(this); }
+};
+
+class DefaultInitializer final : public Initializer
 {
 public:
     Type *type;         // type that this will initialize to

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -106,6 +106,7 @@ Expression toAssocArrayLiteral(ArrayInitializer ai)
  */
 extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedInterpret needInterpret)
 {
+    //printf("initializerSemantic() tx: %p %s\n", tx, tx.toChars());
     Type t = tx;
 
     static Initializer err()
@@ -114,6 +115,12 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Typ
     }
 
     Initializer visitVoid(VoidInitializer i)
+    {
+        i.type = t;
+        return i;
+    }
+
+    Initializer visitDefault(DefaultInitializer i)
     {
         i.type = t;
         return i;
@@ -1017,6 +1024,12 @@ Initializer inferType(Initializer init, Scope* sc)
         return new ErrorInitializer();
     }
 
+    Initializer visitDefault(DefaultInitializer i)
+    {
+        error(i.loc, "cannot infer type from default initializer");
+        return new ErrorInitializer();
+    }
+
     Initializer visitError(ErrorInitializer i)
     {
         return i;
@@ -1173,6 +1186,11 @@ extern (C++) Expression initializerToExpression(Initializer init, Type itype = n
     Expression visitVoid(VoidInitializer)
     {
         return null;
+    }
+
+    Expression visitDefault(DefaultInitializer di)
+    {
+        return di.type ? di.type.defaultInit(Loc.initial, isCfile) : null;
     }
 
     Expression visitError(ErrorInitializer)

--- a/compiler/src/dmd/parsetimevisitor.d
+++ b/compiler/src/dmd/parsetimevisitor.d
@@ -298,5 +298,6 @@ public:
     void visit(AST.StructInitializer i) { visit(cast(AST.Initializer)i); }
     void visit(AST.ArrayInitializer i) { visit(cast(AST.Initializer)i); }
     void visit(AST.VoidInitializer i) { visit(cast(AST.Initializer)i); }
+    void visit(AST.DefaultInitializer i) { visit(cast(AST.Initializer)i); }
     void visit(AST.CInitializer i) { visit(cast(AST.CInitializer)i); }
 }

--- a/compiler/src/dmd/strictvisitor.d
+++ b/compiler/src/dmd/strictvisitor.d
@@ -234,5 +234,6 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.StructInitializer) { assert(0); }
     override void visit(AST.ArrayInitializer) { assert(0); }
     override void visit(AST.VoidInitializer) { assert(0); }
+    override void visit(AST.DefaultInitializer) { assert(0); }
     override void visit(AST.CInitializer) { assert(0); }
 }

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -205,6 +205,13 @@ extern (C++) void Initializer_toDt(Initializer init, ref DtBuilder dtb, bool isC
         assert(0);
     }
 
+    void visitDefault(DefaultInitializer di)
+    {
+        /* Default initializers are set to 0, because C23 says so
+         */
+        dtb.nzeros(cast(uint)di.type.size());
+    }
+
     mixin VisitInitializer!void visit;
     visit.VisitInitializer(init);
 }

--- a/compiler/src/dmd/visitor.h
+++ b/compiler/src/dmd/visitor.h
@@ -176,6 +176,7 @@ class NewDeclaration;
 
 class Initializer;
 class VoidInitializer;
+class DefaultInitializer;
 class ErrorInitializer;
 class StructInitializer;
 class ArrayInitializer;
@@ -591,6 +592,7 @@ public:
     virtual void visit(StructInitializer *i) { visit((Initializer *)i); }
     virtual void visit(ArrayInitializer *i) { visit((Initializer *)i); }
     virtual void visit(VoidInitializer *i) { visit((Initializer *)i); }
+    virtual void visit(DefaultInitializer *i) { visit((Initializer *)i); }
     virtual void visit(CInitializer *i) { visit((Initializer *)i); }
 };
 

--- a/compiler/test/runnable/initializer.c
+++ b/compiler/test/runnable/initializer.c
@@ -844,6 +844,30 @@ void test24154()
 
 /*******************************************/
 
+// https://issues.dlang.org/show_bug.cgi?id=24155
+
+struct S24155 { int x, y; };
+
+struct S24155 s = { };
+
+void abc(int i)
+{
+    assert(s.x == 0 && s.y == 0, __LINE__);
+    struct S24155 s1 = { };
+    assert(s1.x == 0 && s1.y == 0, __LINE__);
+    struct S24155 s2 = { { i }, { } };
+    assert(s2.x == i && s2.y == 0, __LINE__);
+    struct S24155 s3 = { { }, { i } };
+    assert(s3.x == 0 && s3.y == i, __LINE__);
+}
+
+void test24155()
+{
+    abc(1);
+}
+
+/*******************************************/
+
 int main()
 {
     test1();
@@ -893,6 +917,7 @@ int main()
     test22925();
     test47();
     test24154();
+    test24155();
 
     return 0;
 }


### PR DESCRIPTION
Did it by adding a `DefaultInitializer` AST node. Mostly boilerplate.