### PR TITLE
Fix aliasing function type returning a Type with TypeSuffixes

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4943,7 +4943,13 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
                     auto t = parseBasicType();
                     t = parseTypeSuffixes(t);
-                    if (token.value == TOK.leftParenthesis)
+                    if (token.value == TOK.identifier)
+                    {
+                        error("unexpected identifier `%s` after `%s`",
+                            token.ident.toChars(), t.toChars());
+                        nextToken();
+                    }
+                    else if (token.value == TOK.leftParenthesis)
                     {
                         // function type:
                         // StorageClasses Type ( Parameters ) MemberFunctionAttributes

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -4892,10 +4892,10 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     token.value == TOK.ref_ && peekNext() == TOK.leftParenthesis &&
                         skipAttributes(peekPastParen(peek(&token)), &tk) &&
                         (tk.value == TOK.goesTo || tk.value == TOK.leftCurly) ||
-                    token.value == TOK.auto_ && peekNext() == TOK.ref_ &&
-                        peekNext2() == TOK.leftParenthesis &&
-                        skipAttributes(peekPastParen(peek(peek(&token))), &tk) &&
-                        (tk.value == TOK.goesTo || tk.value == TOK.leftCurly)
+                    token.value == TOK.auto_ &&
+                        (peekNext() == TOK.leftParenthesis || // for better error
+                            peekNext() == TOK.ref_ &&
+                            peekNext2() == TOK.leftParenthesis)
                    )
                 {
                     // function (parameters) { statements... }

--- a/compiler/test/compilable/issue16020.d
+++ b/compiler/test/compilable/issue16020.d
@@ -20,6 +20,18 @@ alias void F51() @system;
 alias F52 = void() @safe;
 static assert (!is(F51 == F52));
 
+alias F61 = int() const shared;
+alias int F62() const shared ;
+alias F63 = const shared int();
+static assert (is(F61 == F62));
+static assert (is(F63 == F62));
+
+alias F71 = int() immutable inout;
+alias int F72() immutable inout;
+alias F73 = immutable inout int();
+static assert (is(F71 == F72));
+static assert (is(F73 == F72));
+
 alias FunTemplate(T) = void(T t);
 alias Specialized = FunTemplate!int;
 alias Compared = void(int);

--- a/compiler/test/compilable/issue16020.d
+++ b/compiler/test/compilable/issue16020.d
@@ -1,3 +1,4 @@
+// function type aliases
 module issue16020;
 
 alias F1 = const(int)(); const(int) f1(){return 42;}
@@ -24,4 +25,9 @@ alias Specialized = FunTemplate!int;
 alias Compared = void(int);
 static assert(is(Specialized == Compared));
 
-void main() {}
+// type suffixes
+alias FT = const(int)*();
+static assert(is(FT* == const(int)* function()));
+alias FT2 = int*[2]() pure;
+static assert(is(FT2* == int*[2] function() pure));
+

--- a/compiler/test/compilable/issue16020.d
+++ b/compiler/test/compilable/issue16020.d
@@ -30,4 +30,3 @@ alias FT = const(int)*();
 static assert(is(FT* == const(int)* function()));
 alias FT2 = int*[2]() pure;
 static assert(is(FT2* == int*[2] function() pure));
-

--- a/compiler/test/compilable/issue16020.d
+++ b/compiler/test/compilable/issue16020.d
@@ -19,18 +19,6 @@ alias void F51() @system;
 alias F52 = void() @safe;
 static assert (!is(F51 == F52));
 
-alias F61 = int() const shared;
-alias int F62() const shared ;
-alias F63 = const shared int();
-static assert (is(F61 == F62));
-static assert (is(F63 == F62));
-
-alias F71 = int() immutable inout;
-alias int F72() immutable inout;
-alias F73 = immutable inout int();
-static assert (is(F71 == F72));
-static assert (is(F73 == F72));
-
 alias FunTemplate(T) = void(T t);
 alias Specialized = FunTemplate!int;
 alias Compared = void(int);

--- a/compiler/test/fail_compilation/fail21243.d
+++ b/compiler/test/fail_compilation/fail21243.d
@@ -1,16 +1,12 @@
 /+ TEST_OUTPUT:
 ---
-fail_compilation/fail21243.d(16): Error: found `(` when expecting `ref` and function literal following `auto`
-fail_compilation/fail21243.d(16): Error: semicolon expected following auto declaration, not `int`
-fail_compilation/fail21243.d(16): Error: semicolon needed to end declaration of `x` instead of `)`
-fail_compilation/fail21243.d(16): Error: declaration expected, not `)`
-fail_compilation/fail21243.d(17): Error: `auto` can only be used as part of `auto ref` for function literal return values
-fail_compilation/fail21243.d(18): Error: basic type expected, not `(`
-fail_compilation/fail21243.d(18): Error: function declaration without return type. (Note that constructors are always named `this`)
-fail_compilation/fail21243.d(18): Deprecation: storage class `auto` has no effect in type aliases
-fail_compilation/fail21243.d(18): Error: semicolon expected to close `alias` declaration, not `=>`
-fail_compilation/fail21243.d(18): Error: declaration expected, not `=>`
-fail_compilation/fail21243.d(19): Error: `auto` can only be used as part of `auto ref` for function literal return values
+fail_compilation/fail21243.d(12): Error: found `(` when expecting `ref` and function literal following `auto`
+fail_compilation/fail21243.d(12): Error: semicolon expected following auto declaration, not `int`
+fail_compilation/fail21243.d(12): Error: semicolon needed to end declaration of `x` instead of `)`
+fail_compilation/fail21243.d(12): Error: declaration expected, not `)`
+fail_compilation/fail21243.d(13): Error: `auto` can only be used as part of `auto ref` for function literal return values
+fail_compilation/fail21243.d(14): Error: `auto` can only be used as part of `auto ref` for function literal return values
+fail_compilation/fail21243.d(15): Error: `auto` can only be used as part of `auto ref` for function literal return values
 ---
 +/
 auto a = auto (int x) => x;

--- a/compiler/test/fail_compilation/issue16020.d
+++ b/compiler/test/fail_compilation/issue16020.d
@@ -1,9 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/issue16020.d(12): Error: user-defined attributes not allowed for `alias` declarations
-fail_compilation/issue16020.d(13): Error: semicolon expected to close `alias` declaration, not `(`
-fail_compilation/issue16020.d(13): Error: declaration expected, not `(`
+fail_compilation/issue16020.d(13): Error: user-defined attributes not allowed for `alias` declarations
+fail_compilation/issue16020.d(14): Error: semicolon expected to close `alias` declaration, not `(`
+fail_compilation/issue16020.d(14): Error: declaration expected, not `(`
+fail_compilation/issue16020.d(15): Deprecation: storage class `final` has no effect in type aliases
 ---
 */
 module issue16020;
@@ -11,3 +12,4 @@ module issue16020;
 struct UDA{}
 alias Fun = @UDA void();
 alias FunTemplate = void(T)(T t);
+alias F2 = final int();

--- a/compiler/test/fail_compilation/issue16020.d
+++ b/compiler/test/fail_compilation/issue16020.d
@@ -1,13 +1,31 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/issue16020.d(12): Error: user-defined attributes not allowed for `alias` declarations
-fail_compilation/issue16020.d(13): Error: semicolon expected to close `alias` declaration, not `(`
-fail_compilation/issue16020.d(13): Error: declaration expected, not `(`
+fail_compilation/issue16020.d(17): Error: user-defined attributes not allowed for `alias` declarations
+fail_compilation/issue16020.d(18): Error: semicolon expected to close `alias` declaration, not `(`
+fail_compilation/issue16020.d(18): Error: declaration expected, not `(`
+fail_compilation/issue16020.d(20): Deprecation: storage class `const shared` has no effect in type aliases
+fail_compilation/issue16020.d(22): Deprecation: storage class `const shared` has no effect in type aliases
+fail_compilation/issue16020.d(26): Deprecation: storage class `immutable inout` has no effect in type aliases
+fail_compilation/issue16020.d(28): Deprecation: storage class `immutable inout` has no effect in type aliases
 ---
 */
+// function type aliases
 module issue16020;
 
 struct UDA{}
 alias Fun = @UDA void();
 alias FunTemplate = void(T)(T t);
+
+alias F61 = int() const shared;
+alias int F62() const shared ;
+alias F63 = const shared int();
+static assert (is(F61 == F62));
+static assert (is(F63 == F62));
+
+alias F71 = int() immutable inout;
+alias int F72() immutable inout;
+alias F73 = immutable inout int();
+static assert (is(F71 == F72));
+static assert (is(F73 == F72));
+

--- a/compiler/test/fail_compilation/issue16020.d
+++ b/compiler/test/fail_compilation/issue16020.d
@@ -1,30 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/issue16020.d(17): Error: user-defined attributes not allowed for `alias` declarations
-fail_compilation/issue16020.d(18): Error: semicolon expected to close `alias` declaration, not `(`
-fail_compilation/issue16020.d(18): Error: declaration expected, not `(`
-fail_compilation/issue16020.d(20): Deprecation: storage class `const shared` has no effect in type aliases
-fail_compilation/issue16020.d(22): Deprecation: storage class `const shared` has no effect in type aliases
-fail_compilation/issue16020.d(26): Deprecation: storage class `immutable inout` has no effect in type aliases
-fail_compilation/issue16020.d(28): Deprecation: storage class `immutable inout` has no effect in type aliases
+fail_compilation/issue16020.d(12): Error: user-defined attributes not allowed for `alias` declarations
+fail_compilation/issue16020.d(13): Error: semicolon expected to close `alias` declaration, not `(`
+fail_compilation/issue16020.d(13): Error: declaration expected, not `(`
 ---
 */
-// function type aliases
 module issue16020;
 
 struct UDA{}
 alias Fun = @UDA void();
 alias FunTemplate = void(T)(T t);
-
-alias F61 = int() const shared;
-alias int F62() const shared ;
-alias F63 = const shared int();
-static assert (is(F61 == F62));
-static assert (is(F63 == F62));
-
-alias F71 = int() immutable inout;
-alias int F72() immutable inout;
-alias F73 = immutable inout int();
-static assert (is(F71 == F72));
-static assert (is(F73 == F72));

--- a/compiler/test/fail_compilation/issue16020.d
+++ b/compiler/test/fail_compilation/issue16020.d
@@ -28,4 +28,3 @@ alias int F72() immutable inout;
 alias F73 = immutable inout int();
 static assert (is(F71 == F72));
 static assert (is(F73 == F72));
-

--- a/compiler/test/fail_compilation/test22048.d
+++ b/compiler/test/fail_compilation/test22048.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test22048.d(10): Error: unexpected identifier `p` in declarator
+fail_compilation/test22048.d(10): Error: unexpected identifier `p` after `int`
 ---
 */
 


### PR DESCRIPTION
This merges function type alias and type alias parsing, leading to simpler code.
A function type with a ~~_TypeCtor_ (or other~~ invalid storage class ~~)~~ is now deprecated, ~~just like a function pointer type with a _TypeCtor_.~~

Because the merge affected two tests' errors a bit:
* I made the check to parse `auto ref` starting a function literal less strict, causing a better error message when `ref` is missing.
* I preserved the error when detecting an identifier after *Type*.