### PR TITLE
Show `TypeFunction.mod` in overload candidates

### DIFF
--- a/compiler/src/dmd/common/outbuffer.d
+++ b/compiler/src/dmd/common/outbuffer.d
@@ -281,7 +281,7 @@ struct OutBuffer
         write(&v, v.sizeof);
     }
 
-    /// NOT zero-terminated
+    /// Buffer will NOT be zero-terminated
     extern (C++) void writestring(const(char)* s) pure nothrow @system
     {
         if (!s)
@@ -302,14 +302,14 @@ struct OutBuffer
         write(s);
     }
 
-    /// NOT zero-terminated, followed by newline
+    /// Buffer will NOT be zero-terminated, followed by newline
     void writestringln(const(char)[] s) pure nothrow @safe
     {
         writestring(s);
         writenl();
     }
 
-    /** Write string to buffer, ensure it is zero terminated
+    /** Write C string AND null byte
      */
     void writeStringz(const(char)* s) pure nothrow @system
     {

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -745,7 +745,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         OutBuffer buf;
         HdrGenState hgs;
 
-        buf.writestring(ident.toString());
+        buf.writestring(ident == Id.ctor ? "this" : ident.toString());
         buf.writeByte('(');
         foreach (i, const tp; *parameters)
         {

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -762,6 +762,11 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             {
                 TypeFunction tf = cast(TypeFunction)fd.type;
                 buf.writestring(parametersTypeToChars(tf.parameterList));
+                if (tf.mod)
+                {
+                    buf.writeByte(' ');
+                    buf.MODtoBuffer(tf.mod);
+                }
             }
         }
 

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3535,11 +3535,17 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
             if (!print)
                 return true;
             auto tf = cast(TypeFunction) fd.type;
+            OutBuffer buf;
+            buf.writestring(fd.toPrettyChars());
+            buf.writestring(parametersTypeToChars(tf.parameterList));
+            if (tf.mod)
+            {
+                buf.writeByte(' ');
+                buf.MODtoBuffer(tf.mod);
+            }
             .errorSupplemental(fd.loc,
-                    printed ? "                `%s%s`" :
-                    single_candidate ? "Candidate is: `%s%s`" : "Candidates are: `%s%s`",
-                    fd.toPrettyChars(),
-                parametersTypeToChars(tf.parameterList));
+                printed ? "                `%s`" :
+                single_candidate ? "Candidate is: `%s`" : "Candidates are: `%s`", buf.peekChars());
         }
         else if (auto td = s.isTemplateDeclaration())
         {

--- a/compiler/test/compilable/diag20916.d
+++ b/compiler/test/compilable/diag20916.d
@@ -7,7 +7,7 @@ compilable/diag20916.d(42):        instantiated from here: `jump1!(Foo)`
 compilable/diag20916.d(32): Deprecation: function `diag20916.FooBar.toString` is deprecated
 compilable/diag20916.d(37):        instantiated from here: `jump2!(Foo)`
 compilable/diag20916.d(42):        instantiated from here: `jump1!(Foo)`
-compilable/diag20916.d(32): Deprecation: template `diag20916.Bar.toString()()` is deprecated
+compilable/diag20916.d(32): Deprecation: template `diag20916.Bar.toString()() const` is deprecated
 compilable/diag20916.d(37):        instantiated from here: `jump2!(Bar)`
 compilable/diag20916.d(43):        instantiated from here: `jump1!(Bar)`
 compilable/diag20916.d(21): Deprecation: variable `diag20916.Something.something` is deprecated

--- a/compiler/test/fail_compilation/ctor_attr.d
+++ b/compiler/test/fail_compilation/ctor_attr.d
@@ -1,18 +1,20 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ctor_attr.d(24): Error: none of the overloads of `this` are callable using argument types `(int)`
-fail_compilation/ctor_attr.d(15):        Candidates are: `ctor_attr.S.this(int x) const`
-fail_compilation/ctor_attr.d(16):                        `ctor_attr.S.this(string x)`
-fail_compilation/ctor_attr.d(26): Error: none of the overloads of `foo` are callable using a mutable object
-fail_compilation/ctor_attr.d(18):        Candidates are: `ctor_attr.S.foo(int x) immutable`
-fail_compilation/ctor_attr.d(19):                        `ctor_attr.S.foo(string x)`
+fail_compilation/ctor_attr.d(26): Error: none of the overloads of `this` are callable using argument types `(int)`
+fail_compilation/ctor_attr.d(16):        Candidates are: `ctor_attr.S.this(int x) const`
+fail_compilation/ctor_attr.d(18):                        `ctor_attr.S.this(string x)`
+fail_compilation/ctor_attr.d(17):                        `this()(int x) shared`
+fail_compilation/ctor_attr.d(28): Error: none of the overloads of `foo` are callable using a mutable object
+fail_compilation/ctor_attr.d(20):        Candidates are: `ctor_attr.S.foo(int x) immutable`
+fail_compilation/ctor_attr.d(21):                        `ctor_attr.S.foo(string x)`
 ---
 */
 
 struct S
 {
     this(int x) const {}
+    this()(int x) shared {}
     this(string x) {}
 
     void foo(int x) immutable  {}

--- a/compiler/test/fail_compilation/ctor_attr.d
+++ b/compiler/test/fail_compilation/ctor_attr.d
@@ -1,0 +1,27 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ctor_attr.d(24): Error: none of the overloads of `this` are callable using argument types `(int)`
+fail_compilation/ctor_attr.d(15):        Candidates are: `ctor_attr.S.this(int x) const`
+fail_compilation/ctor_attr.d(16):                        `ctor_attr.S.this(string x)`
+fail_compilation/ctor_attr.d(26): Error: none of the overloads of `foo` are callable using a mutable object
+fail_compilation/ctor_attr.d(18):        Candidates are: `ctor_attr.S.foo(int x) immutable`
+fail_compilation/ctor_attr.d(19):                        `ctor_attr.S.foo(string x)`
+---
+*/
+
+struct S
+{
+    this(int x) const {}
+    this(string x) {}
+
+    void foo(int x) immutable  {}
+    void foo(string x) {}
+}
+
+void f()
+{
+   auto s = S(1);
+   S t;
+   t.foo(1);
+}

--- a/compiler/test/fail_compilation/diag10415.d
+++ b/compiler/test/fail_compilation/diag10415.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag10415.d(36): Error: none of the overloads of `x` are callable using argument types `(int) const`
-fail_compilation/diag10415.d(13):        Candidates are: `diag10415.C.x()`
+fail_compilation/diag10415.d(13):        Candidates are: `diag10415.C.x() const`
 fail_compilation/diag10415.d(18):                        `diag10415.C.x(int __param_0)`
 fail_compilation/diag10415.d(39): Error: d.x is not an lvalue
 ---

--- a/compiler/test/fail_compilation/fail7424d.d
+++ b/compiler/test/fail_compilation/fail7424d.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424d.d(10): Error: template `this.g()()` has no value
+fail_compilation/fail7424d.d(10): Error: template `this.g()() immutable` has no value
 ---
 */
 struct S7424d

--- a/compiler/test/fail_compilation/fail7424e.d
+++ b/compiler/test/fail_compilation/fail7424e.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424e.d(10): Error: template `this.g()()` has no value
+fail_compilation/fail7424e.d(10): Error: template `this.g()() immutable` has no value
 ---
 */
 struct S7424e

--- a/compiler/test/fail_compilation/fail7424f.d
+++ b/compiler/test/fail_compilation/fail7424f.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424f.d(10): Error: template `this.g()()` has no value
+fail_compilation/fail7424f.d(10): Error: template `this.g()() shared` has no value
 ---
 */
 struct S7424f

--- a/compiler/test/fail_compilation/fail7424i.d
+++ b/compiler/test/fail_compilation/fail7424i.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7424i.d(10): Error: template `this.g()()` has no value
+fail_compilation/fail7424i.d(10): Error: template `this.g()() immutable` has no value
 ---
 */
 struct S7424g

--- a/compiler/test/fail_compilation/ice13459.d
+++ b/compiler/test/fail_compilation/ice13459.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/ice13459.d(12): Error: undefined identifier `B`
 fail_compilation/ice13459.d(18): Error: none of the overloads of `opSlice` are callable using argument types `(int, int)`
-fail_compilation/ice13459.d(11):        Candidate is: `ice13459.A.opSlice()`
+fail_compilation/ice13459.d(11):        Candidate is: `ice13459.A.opSlice() const`
 ---
 */
 struct A

--- a/compiler/test/fail_compilation/ice9284.d
+++ b/compiler/test/fail_compilation/ice9284.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice9284.d(14): Error: template `ice9284.C.__ctor` is not callable using argument types `!()(int)`
-fail_compilation/ice9284.d(12):        Candidate is: `__ctor()(string)`
+fail_compilation/ice9284.d(12):        Candidate is: `this()(string)`
 fail_compilation/ice9284.d(20): Error: template instance `ice9284.C.__ctor!()` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/testrvaluecpctor.d
+++ b/compiler/test/fail_compilation/testrvaluecpctor.d
@@ -7,7 +7,7 @@ fail_compilation/testrvaluecpctor.d(16): Error: cannot define both an rvalue con
 fail_compilation/testrvaluecpctor.d(24):        Template instance `testrvaluecpctor.Foo!int.Foo.__ctor!(immutable(Foo!int), immutable(Foo!int))` creates an rvalue constructor for `struct Foo`
 fail_compilation/testrvaluecpctor.d(24): Error: none of the overloads of `__ctor` are callable using a `immutable` object
 fail_compilation/testrvaluecpctor.d(18):        Candidates are: `testrvaluecpctor.Foo!int.Foo.this(ref scope Foo!int rhs)`
-fail_compilation/testrvaluecpctor.d(16):                        `__ctor(Rhs, this This)(scope Rhs rhs)`
+fail_compilation/testrvaluecpctor.d(16):                        `this(Rhs, this This)(scope Rhs rhs)`
 ---
 */
 


### PR DESCRIPTION
Fix Issue 22216 - Incomplete/incorrect error message for mutability overloads