### PR TITLE
Fix Issue 24248 - const constructor call with mutable target gives wrong error message

### DIFF
--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3412,7 +3412,10 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
     if (!tf)
         tf = fd.originalType.toTypeFunction();
 
-    if (tthis && !MODimplicitConv(tthis.mod, tf.mod)) // modifier mismatch
+    // modifier mismatch
+    if (tthis && (fd.isCtorDeclaration() ?
+        !MODimplicitConv(tf.mod, tthis.mod) :
+        !MODimplicitConv(tthis.mod, tf.mod)))
     {
         OutBuffer thisBuf, funcBuf;
         MODMatchToBuffer(&thisBuf, tthis.mod, tf.mod);

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3423,7 +3423,7 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
         if (hasOverloads)
         {
             .error(loc, "none of the overloads of `%s` are callable using a %sobject",
-                   fd.ident.toChars(), thisBuf.peekChars());
+                   fd.toChars(), thisBuf.peekChars());
             if (!global.gag || global.params.v.showGaggedErrors)
                 printCandidates(loc, fd, sc.isDeprecated());
             return null;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3422,8 +3422,15 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
         auto mismatches = MODMatchToBuffer(&funcBuf, tf.mod, tthis.mod);
         if (hasOverloads)
         {
-            .error(loc, "none of the overloads of `%s` are callable using a %sobject",
-                   fd.toChars(), thisBuf.peekChars());
+            OutBuffer buf;
+            buf.argExpTypesToCBuffer(fargs);
+            if (fd.isCtorDeclaration())
+                .error(loc, "none of the overloads of `%s` can construct a %sobject with argument types `(%s)`",
+                    fd.toChars(), thisBuf.peekChars(), buf.peekChars());
+            else
+                .error(loc, "none of the overloads of `%s` are callable using a %sobject",
+                    fd.toChars(), thisBuf.peekChars());
+
             if (!global.gag || global.params.v.showGaggedErrors)
                 printCandidates(loc, fd, sc.isDeprecated());
             return null;

--- a/compiler/test/fail_compilation/const_ctor.d
+++ b/compiler/test/fail_compilation/const_ctor.d
@@ -1,0 +1,26 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/const_ctor.d(23): Error: `const` copy constructor `const_ctor.S1.this` cannot construct a mutable object
+fail_compilation/const_ctor.d(25): Error: `const` constructor `const_ctor.S2.this` cannot construct a mutable object
+---
+*/
+
+struct S1
+{
+    this(ref const S1 s) const {}
+    int* i;
+}
+struct S2
+{
+    this(int) const {}
+    int* i;
+}
+
+void main()
+{
+    const(S1) s1;
+    S1 m1 = s1;
+
+    S2 s2 = S2(5);
+}

--- a/compiler/test/fail_compilation/ctor_attr.d
+++ b/compiler/test/fail_compilation/ctor_attr.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ctor_attr.d(26): Error: none of the overloads of `this` are callable using a mutable object
+fail_compilation/ctor_attr.d(26): Error: none of the overloads of `this` can construct a mutable object with argument types `(int)`
 fail_compilation/ctor_attr.d(16):        Candidates are: `ctor_attr.S.this(int x) const`
 fail_compilation/ctor_attr.d(18):                        `ctor_attr.S.this(string x)`
 fail_compilation/ctor_attr.d(17):                        `this()(int x) shared`

--- a/compiler/test/fail_compilation/ctor_attr.d
+++ b/compiler/test/fail_compilation/ctor_attr.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ctor_attr.d(26): Error: none of the overloads of `this` are callable using argument types `(int)`
+fail_compilation/ctor_attr.d(26): Error: none of the overloads of `this` are callable using a mutable object
 fail_compilation/ctor_attr.d(16):        Candidates are: `ctor_attr.S.this(int x) const`
 fail_compilation/ctor_attr.d(18):                        `ctor_attr.S.this(string x)`
 fail_compilation/ctor_attr.d(17):                        `this()(int x) shared`

--- a/compiler/test/fail_compilation/testrvaluecpctor.d
+++ b/compiler/test/fail_compilation/testrvaluecpctor.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/testrvaluecpctor.d(16): Error: cannot define both an rvalue constructor and a copy constructor for `struct Foo`
 fail_compilation/testrvaluecpctor.d(24):        Template instance `testrvaluecpctor.Foo!int.Foo.__ctor!(immutable(Foo!int), immutable(Foo!int))` creates an rvalue constructor for `struct Foo`
-fail_compilation/testrvaluecpctor.d(24): Error: none of the overloads of `__ctor` are callable using a `immutable` object
+fail_compilation/testrvaluecpctor.d(24): Error: none of the overloads of `this` are callable using a `immutable` object
 fail_compilation/testrvaluecpctor.d(18):        Candidates are: `testrvaluecpctor.Foo!int.Foo.this(ref scope Foo!int rhs)`
 fail_compilation/testrvaluecpctor.d(16):                        `this(Rhs, this This)(scope Rhs rhs)`
 ---

--- a/compiler/test/fail_compilation/testrvaluecpctor.d
+++ b/compiler/test/fail_compilation/testrvaluecpctor.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/testrvaluecpctor.d(16): Error: cannot define both an rvalue constructor and a copy constructor for `struct Foo`
 fail_compilation/testrvaluecpctor.d(24):        Template instance `testrvaluecpctor.Foo!int.Foo.__ctor!(immutable(Foo!int), immutable(Foo!int))` creates an rvalue constructor for `struct Foo`
-fail_compilation/testrvaluecpctor.d(24): Error: none of the overloads of `this` are callable using a `immutable` object
+fail_compilation/testrvaluecpctor.d(24): Error: none of the overloads of `this` can construct a `immutable` object with argument types `(immutable(Foo!int))`
 fail_compilation/testrvaluecpctor.d(18):        Candidates are: `testrvaluecpctor.Foo!int.Foo.this(ref scope Foo!int rhs)`
 fail_compilation/testrvaluecpctor.d(16):                        `this(Rhs, this This)(scope Rhs rhs)`
 ---


### PR DESCRIPTION
~~**This depends on #15826, please merge that first.**~~

The implicit conversion check direction for a constructor call should be the opposite to a method call.
Also fixes a case of using `this` instead of `__ctor`.