### PR TITLE
ci/run.sh: Avoid deprecated Makefiles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,8 @@ jobs:
       FULL_BUILD: true
       # for coverage:
       DMD_TEST_COVERAGE: ${{ matrix.coverage && '1' || '0' }}
+      # work around https://issues.dlang.org/show_bug.cgi?id=23517
+      MACOSX_DEPLOYMENT_TARGET: '11'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 40
     env:
       # for ci/run.sh:
-      OS_NAME: ${{ startsWith(matrix.os, 'ubuntu') && 'linux' || (startsWith(matrix.os, 'macos') && 'darwin' || '') }}
+      OS_NAME: ${{ startsWith(matrix.os, 'ubuntu') && 'linux' || (startsWith(matrix.os, 'macos') && 'osx' || '') }}
       MODEL: ${{ matrix.model || '64' }}
       HOST_DMD: ${{ matrix.host_dmd }}
       N: ${{ startsWith(matrix.os, 'macos') && '3' || '2' }}
@@ -102,7 +102,7 @@ jobs:
         run: ci/run.sh build
       - name: Rebuild dmd (with enabled coverage)
         if: matrix.coverage
-        run: ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ${{ runner.os == 'macOS' && 'OS_NAME=osx' || '' }} ci/run.sh rebuild
+        run: ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ci/run.sh rebuild
       - name: Test dmd
         run: ci/run.sh test_dmd
       - name: Test druntime

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           - job_name: Ubuntu 22.04 x64, DMD (bootstrap)
             os: ubuntu-22.04
             host_dmd: dmd-2.079.0
+            disable_debug_for_dmd_unittests: true # no `-debug` - host frontend too old
           - job_name: Ubuntu 22.04 x86, DMD (latest)
             os: ubuntu-22.04
             model: 32
@@ -46,6 +47,7 @@ jobs:
           - job_name: Ubuntu 22.04 x64, GDC
             os: ubuntu-22.04
             host_dmd: gdmd-9
+            disable_debug_for_dmd_unittests: true # no `-debug` - host frontend too old
           # macOS
           - job_name: macOS 13 x64, DMD (latest)
             os: macos-13
@@ -99,7 +101,7 @@ jobs:
 
           ci/run.sh setup_repos "$REPO_BRANCH"
       - name: Build
-        run: ci/run.sh build
+        run: ${{ matrix.disable_debug_for_dmd_unittests && 'ENABLE_DEBUG=0' || '' }} ci/run.sh build
       - name: Rebuild dmd (with enabled coverage)
         if: matrix.coverage
         run: ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ci/run.sh rebuild

--- a/ci/cirrusci.sh
+++ b/ci/cirrusci.sh
@@ -6,7 +6,7 @@
 
 set -uexo pipefail
 
-# OS_NAME: linux|darwin|freebsd
+# OS_NAME: linux|osx|freebsd
 if [ -z ${OS_NAME+x} ] ; then echo "Variable 'OS_NAME' needs to be set."; exit 1; fi
 # MODEL: 32|64
 if [ -z ${MODEL+x} ] ; then echo "Variable 'MODEL' needs to be set."; exit 1; fi
@@ -27,7 +27,7 @@ if [ "$OS_NAME" == "linux" ]; then
   fi
   apt-get -q update
   apt-get install -yq $packages
-elif [ "$OS_NAME" == "darwin" ]; then
+elif [ "$OS_NAME" == "osx" ]; then
   # required for dlang install.sh
   brew install gnupg libarchive xz llvm
 elif [ "$OS_NAME" == "freebsd" ]; then

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -7,7 +7,7 @@ set -uexo pipefail
 
 # N: number of parallel build jobs
 if [ -z ${N+x} ] ; then echo "Variable 'N' needs to be set."; exit 1; fi
-# OS_NAME: linux|darwin|freebsd
+# OS_NAME: linux|osx|freebsd
 if [ -z ${OS_NAME+x} ] ; then echo "Variable 'OS_NAME' needs to be set."; exit 1; fi
 # FULL_BUILD: true|false (true on Linux: use full permutations for DMD tests)
 if [ -z ${FULL_BUILD+x} ] ; then echo "Variable 'FULL_BUILD' needs to be set."; exit 1; fi
@@ -34,7 +34,7 @@ if [ "$OS_NAME" == "linux" ]; then
 else
     NM=nm
 
-  if [ "$OS_NAME" == "darwin" ]; then
+  if [ "$OS_NAME" == "osx" ]; then
     export PATH="/usr/local/opt/llvm/bin:$PATH"
   fi
 fi


### PR DESCRIPTION
Switching directly to `build.d` / `run.d` instead, thus eliminating a layer and reducing complexity.