### PR TITLE
Azure CI: Avoid deprecated `compiler/src/win{32,64}.mak` Makefiles

### DIFF
--- a/.azure-pipelines/windows-visual-studio.yml
+++ b/.azure-pipelines/windows-visual-studio.yml
@@ -8,7 +8,7 @@ steps:
     fetchDepth: 1
   - script: |
       bash --version
-      sh --login .azure-pipelines/windows-visual-studio.sh
+      bash --login .azure-pipelines/windows-visual-studio.sh
     displayName: Download required binaries
   - script: |
       call .azure-pipelines/windows-msbuild.bat

--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -10,7 +10,7 @@ steps:
       @echo on
       call "%VSINSTALLDIR%\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
       bash --version
-      sh --login .azure-pipelines/windows.sh
+      bash --login .azure-pipelines/windows.sh
     displayName: Build and test
 
   # Try to upload the coverage files from the previous step to CodeCov

--- a/compiler/src/dmd/backend/util2.d
+++ b/compiler/src/dmd/backend/util2.d
@@ -76,7 +76,7 @@ int binary(const(char)* p, const(char)*  *table,int high)
 version (X86asm)
 {
     alias len = high;        // reuse parameter storage
-    asm nothrow
+    asm nothrow @nogc
     {
 
 // First find the length of the identifier.


### PR DESCRIPTION
Using `build.d` directly instead, analogous to #15832 for Posix CI.