### PR TITLE
Deprecate boolean evaluation of array/string literals

### DIFF
--- a/changelog/dmd.boolean-array-literal.dd
+++ b/changelog/dmd.boolean-array-literal.dd
@@ -1,0 +1,26 @@
+Boolean evaluation of array literals and string literals is now deprecated
+
+Boolean evaluation of a string literal could happen unintentionally
+e.g. when an `assert(0, "message")` was meant and the `0` was missing.
+
+```d
+assert("unexpected runtime condition");
+static assert("unhandled case for `", T, "`");
+
+enum int[] arr = [];
+...
+if (arr) { ... } // was arr.length meant?
+```
+
+The 2 asserts would silently always have no effect and the `if` condition
+is always true. The author of the `if` test may have intended to write `if (arr.length)`.
+
+Now these cases will be detected with deprecation messages.
+If the original behaviour was actually intended, use `expr !is null` instead:
+
+```d
+static assert("" !is null);
+enum arr = [1, 2];
+...
+static if (arr !is null) { ... }
+```

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -14175,6 +14175,10 @@ Expression toBoolean(Expression exp, Scope* sc)
                               exp.toChars(), t.toChars());
                 return ErrorExp.get();
             }
+            if (exp.isArrayLiteralExp() || exp.isStringExp())
+            {
+                deprecation(exp.loc, "boolean evaluation of array/string literals is deprecated");
+            }
             return e;
     }
 }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -14178,7 +14178,10 @@ Expression toBoolean(Expression exp, Scope* sc)
             // Note: `"".ptr` is apparently still a StringExp
             if (exp.isArrayLiteralExp() || (t.ty != Tpointer && exp.isStringExp()))
             {
+                // deprecated in 2.107
                 deprecation(exp.loc, "boolean evaluation of array literals and string literals is deprecated");
+                deprecationSupplemental(exp.loc, "If intentional, use `%s !is null` instead to preserve behaviour",
+                    exp.toChars());
             }
             return e;
     }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -14178,7 +14178,7 @@ Expression toBoolean(Expression exp, Scope* sc)
             // Note: `"".ptr` is apparently still a StringExp
             if (exp.isArrayLiteralExp() || (t.ty != Tpointer && exp.isStringExp()))
             {
-                deprecation(exp.loc, "boolean evaluation of array/string literals is deprecated");
+                deprecation(exp.loc, "boolean evaluation of array literals and string literals is deprecated");
             }
             return e;
     }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -14175,7 +14175,8 @@ Expression toBoolean(Expression exp, Scope* sc)
                               exp.toChars(), t.toChars());
                 return ErrorExp.get();
             }
-            if (exp.isArrayLiteralExp() || exp.isStringExp())
+            // Note: `"".ptr` is apparently still a StringExp
+            if (exp.isArrayLiteralExp() || (t.ty != Tpointer && exp.isStringExp()))
             {
                 deprecation(exp.loc, "boolean evaluation of array/string literals is deprecated");
             }

--- a/compiler/test/fail_compilation/array_bool.d
+++ b/compiler/test/fail_compilation/array_bool.d
@@ -1,0 +1,20 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/array_bool.d(15): Deprecation: boolean evaluation of array/string literals is deprecated
+fail_compilation/array_bool.d(16): Deprecation: boolean evaluation of array/string literals is deprecated
+fail_compilation/array_bool.d(17): Deprecation: boolean evaluation of array/string literals is deprecated
+fail_compilation/array_bool.d(19): Deprecation: boolean evaluation of array/string literals is deprecated
+fail_compilation/array_bool.d(19):        while evaluating: `static assert(e)`
+---
+*/
+void main()
+{
+    enum a = [2];
+    if (a) {}
+    auto b = [1] && true;
+    assert("foo");
+    enum e = "bar";
+    static assert(e);
+}

--- a/compiler/test/fail_compilation/array_bool.d
+++ b/compiler/test/fail_compilation/array_bool.d
@@ -2,11 +2,15 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/array_bool.d(15): Deprecation: boolean evaluation of array literals and string literals is deprecated
-fail_compilation/array_bool.d(16): Deprecation: boolean evaluation of array literals and string literals is deprecated
-fail_compilation/array_bool.d(17): Deprecation: boolean evaluation of array literals and string literals is deprecated
 fail_compilation/array_bool.d(19): Deprecation: boolean evaluation of array literals and string literals is deprecated
-fail_compilation/array_bool.d(19):        while evaluating: `static assert(e)`
+fail_compilation/array_bool.d(19):        If intentional, use `[2] !is null` instead to preserve behaviour
+fail_compilation/array_bool.d(20): Deprecation: boolean evaluation of array literals and string literals is deprecated
+fail_compilation/array_bool.d(20):        If intentional, use `[1] !is null` instead to preserve behaviour
+fail_compilation/array_bool.d(21): Deprecation: boolean evaluation of array literals and string literals is deprecated
+fail_compilation/array_bool.d(21):        If intentional, use `"foo" !is null` instead to preserve behaviour
+fail_compilation/array_bool.d(23): Deprecation: boolean evaluation of array literals and string literals is deprecated
+fail_compilation/array_bool.d(23):        If intentional, use `"bar" !is null` instead to preserve behaviour
+fail_compilation/array_bool.d(23):        while evaluating: `static assert(e)`
 ---
 */
 void main()

--- a/compiler/test/fail_compilation/array_bool.d
+++ b/compiler/test/fail_compilation/array_bool.d
@@ -2,10 +2,10 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/array_bool.d(15): Deprecation: boolean evaluation of array/string literals is deprecated
-fail_compilation/array_bool.d(16): Deprecation: boolean evaluation of array/string literals is deprecated
-fail_compilation/array_bool.d(17): Deprecation: boolean evaluation of array/string literals is deprecated
-fail_compilation/array_bool.d(19): Deprecation: boolean evaluation of array/string literals is deprecated
+fail_compilation/array_bool.d(15): Deprecation: boolean evaluation of array literals and string literals is deprecated
+fail_compilation/array_bool.d(16): Deprecation: boolean evaluation of array literals and string literals is deprecated
+fail_compilation/array_bool.d(17): Deprecation: boolean evaluation of array literals and string literals is deprecated
+fail_compilation/array_bool.d(19): Deprecation: boolean evaluation of array literals and string literals is deprecated
 fail_compilation/array_bool.d(19):        while evaluating: `static assert(e)`
 ---
 */

--- a/compiler/test/fail_compilation/array_bool.d
+++ b/compiler/test/fail_compilation/array_bool.d
@@ -17,4 +17,8 @@ void main()
     assert("foo");
     enum e = "bar";
     static assert(e);
+
+    // OK
+    b = "".ptr || false;
+    b = a.ptr || false;
 }

--- a/compiler/test/fail_compilation/imports/constraints.d
+++ b/compiler/test/fail_compilation/imports/constraints.d
@@ -44,8 +44,8 @@ void variadic(A, T...)(A a, T v) if (N!int);
 
 // constraints_tmpl
 void dummy()() if (false);
-void message_nice(T, U)() if (P!T && "message 1" && N!U && "message 2");
-void message_ugly(T)(T v) if (!N!T && (T.stringof ~ " must be that") && N!T);
+void message_nice(T, U)() if (P!T && "message 1".ptr && N!U && "message 2".ptr);
+void message_ugly(T)(T v) if (!N!T && (T.stringof ~ " must be that").ptr && N!T);
 void args(T, U)() if (N!T || N!U);
 void lambda(alias pred)() if (N!int);
 

--- a/compiler/test/fail_compilation/pragmainline.d
+++ b/compiler/test/fail_compilation/pragmainline.d
@@ -6,4 +6,4 @@ fail_compilation/pragmainline.d(8): Error: one boolean expression expected for `
 */
 
 pragma(inline, 1,2,3) void bar();
-pragma(inline, "string") void baz(); // works now
+pragma(inline, "string".ptr) void baz(); // works now

--- a/compiler/test/fail_compilation/pragmas.d
+++ b/compiler/test/fail_compilation/pragmas.d
@@ -23,7 +23,7 @@ void test2()
 
 void test3()
 {
-    pragma(inline, "string"); // works now
+    pragma(inline, "string".ptr); // works now
 }
 
 void test4()


### PR DESCRIPTION
Fix Issue 14387 - Disallow string literals as assert conditions