### PR TITLE
use SmallBuffer for directive

### DIFF
--- a/compiler/src/dmd/backend/cgobj.d
+++ b/compiler/src/dmd/backend/cgobj.d
@@ -1159,7 +1159,7 @@ bool OmfObj_includelib(scope const char[] name)
 *      true if operation is supported
 */
 
-bool OmfObj_linkerdirective(const(char)* name)
+bool OmfObj_linkerdirective(scope const(char)* name)
 {
     return false;
 }

--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -1436,7 +1436,7 @@ bool ElfObj_includelib(scope const char[] name)
 * Output linker directive.
 */
 
-bool ElfObj_linkerdirective(const(char)* name)
+bool ElfObj_linkerdirective(scope const(char)* name)
 {
     return false;
 }

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -1550,7 +1550,7 @@ bool MachObj_includelib(scope const char[] name)
 * Output linker directive.
 */
 
-bool MachObj_linkerdirective(const(char)* name)
+bool MachObj_linkerdirective(scope const(char)* name)
 {
     return false;
 }

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -993,7 +993,7 @@ bool MsCoffObj_includelib(scope const char[] name)
 */
 
 @trusted
-bool MsCoffObj_linkerdirective(const(char)* directive)
+bool MsCoffObj_linkerdirective(scope const(char)* directive)
 {
     int seg = MsCoffObj_seg_drectve();
     //dbg_printf("MsCoffObj::linkerdirective(directive *%s)\n",directive);

--- a/compiler/src/dmd/backend/obj.d
+++ b/compiler/src/dmd/backend/obj.d
@@ -123,7 +123,7 @@ else
             mixin(genRetVal("includelib(name)"));
         }
 
-        bool linkerdirective(const(char)* p)
+        bool linkerdirective(scope const(char)* p)
         {
             mixin(genRetVal("linkerdirective(p)"));
         }

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -460,7 +460,7 @@ public void obj_startaddress(Symbol *s)
     return objmod.startaddress(s);
 }
 
-public bool obj_linkerdirective(const(char)* directive)
+public bool obj_linkerdirective(scope const(char)* directive)
 {
     return objmod.linkerdirective(directive);
 }

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -18,6 +18,7 @@ import core.stdc.time;
 
 import dmd.root.array;
 import dmd.common.outbuffer;
+import dmd.common.string : SmallBuffer;
 import dmd.root.rmem;
 import dmd.rootobject;
 
@@ -821,10 +822,14 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 assert(e.op == EXP.string_);
 
                 StringExp se = e.isStringExp();
-                char *directive = cast(char *)mem.xmalloc(se.numberOfCodeUnits() + 1);
-                se.writeTo(directive, true);
+                size_t length = se.numberOfCodeUnits() + 1;
+                debug enum LEN = 2; else enum LEN = 20;
+                char[LEN] buffer = void;
+                SmallBuffer!char directive = SmallBuffer!char(length, buffer);
 
-                obj_linkerdirective(directive);
+                se.writeTo(directive.ptr, true);
+
+                obj_linkerdirective(directive.ptr);
             }
 
             visit(cast(AttribDeclaration)pd);


### PR DESCRIPTION
This replaces a memory leak with a stack buffer for most cases, falling back to an RAII allocation. `scope` added to check for escapes.