### PR TITLE
Fix unittest failure in rt/aaA.d

### DIFF
--- a/druntime/src/core/internal/newaa.d
+++ b/druntime/src/core/internal/newaa.d
@@ -154,13 +154,14 @@ AAShell makeAA(K, V)(V[K] src) @trusted
             K.sizeof, V.sizeof, E.value.offsetof, flags, hashFn));
 }
 
-version(unittest):
-struct Foo {
-    ubyte x;
-    double d;
-}
-int[Foo] utaa = [Foo(1, 2.0) : 5];
-unittest {
+unittest
+{
+    static struct Foo
+    {
+        ubyte x;
+        double d;
+    }
+    static int[Foo] utaa = [Foo(1, 2.0) : 5];
     auto k = Foo(1, 2.0);
     // verify that getHash doesn't match hashOf for Foo
     assert(typeid(Foo).getHash(&k) != hashOf(k));


### PR DESCRIPTION
Underlying cause for writing the test this way was fixed in #15774.

Hiding symbols behind `version (unittest)` is problematic because it introduces linker errors when building the unit-tests of other modules.
```
ld: /tmp/ccjp8CS1.o:(.data.rel.ro+0x1c8): undefined reference to `_D4core8internal5newaa3Foo6__initZ'
ld: /tmp/ccjp8CS1.o:(.data.rel.ro+0x1d0): undefined reference to `_D4core8internal5newaa3Foo9__xtoHashFNbNeKxSQBqQBoQBiQBfZm'
ld: /tmp/ccjp8CS1.o:(.data.rel.ro+0x1d8): undefined reference to `_D4core8internal5newaa3Foo11__xopEqualsMxFKxSQBrQBpQBjQBgZb'
ld: /tmp/ccjp8CS1.o:(.data.rel.ro+0x328): undefined reference to `_D4core8internal5newaa__T5EntryTSQBfQBdQx3FooTiZQx6__initZ'
ld: /tmp/ccjp8CS1.o:(.data.rel.ro+0x330): undefined reference to `_D4core8internal5newaa__T5EntryTSQBfQBdQx3FooTiZQx9__xtoHashFNbNeKxSQCoQCmQCg__TQCdTQCaTiZQCnZm'
ld: /tmp/ccjp8CS1.o:(.data.rel.ro+0x338): undefined reference to `_D4core8internal5newaa__T5EntryTSQBfQBdQx3FooTiZQx11__xopEqualsMxFKxSQCpQCnQCh__TQCeTQCbTiZQCoZb'
```