### PR TITLE
rename common/string.d to common/smallbuffer.d

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1576,7 +1576,7 @@ auto sourceFiles()
             stringtable.d utf.d
         "),
         common: fileArray(env["COMMON"], "
-            bitfields.d file.d int128.d outbuffer.d string.d
+            bitfields.d file.d int128.d outbuffer.d smallbuffer.d
         "),
         commonHeaders: fileArray(env["COMMON"], "
             outbuffer.h

--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -2870,7 +2870,7 @@ private bool optim_loglog(ref elem* pe)
         return false;
     uint ty = e.Ety;
 
-    import dmd.common.string : SmallBuffer;
+    import dmd.common.smallbuffer : SmallBuffer;
     elem*[100] tmp = void;
     auto sb = SmallBuffer!(elem*)(n, tmp[]);
     elem*[] array = sb[];

--- a/compiler/src/dmd/backend/cgobj.d
+++ b/compiler/src/dmd/backend/cgobj.d
@@ -1108,7 +1108,7 @@ void OmfObj_dosseg()
 @trusted
 private void obj_comment(ubyte x, const(char)* string, size_t len)
 {
-    import dmd.common.string : SmallBuffer;
+    import dmd.common.smallbuffer : SmallBuffer;
     char[128] buf = void;
     auto sb = SmallBuffer!char(2 + len, buf[]);
     char *library = sb.ptr;

--- a/compiler/src/dmd/backend/cod3.d
+++ b/compiler/src/dmd/backend/cod3.d
@@ -1694,7 +1694,7 @@ void doswitch(ref CodeBuilder cdb, block *b)
 
         // Put into casevals[0..ncases] so we can sort then slice
 
-        import dmd.common.string : SmallBuffer;
+        import dmd.common.smallbuffer : SmallBuffer;
         CaseVal[10] tmp = void;
         auto sb = SmallBuffer!(CaseVal)(ncases, tmp[]);
         CaseVal[] casevals = sb[];

--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -2618,7 +2618,7 @@ void ElfObj_addrel(int seg, targ_size_t offset, uint type,
             relidx = SHN_RELDATA;
         else
         {
-            import dmd.common.string : SmallBuffer;
+            import dmd.common.smallbuffer : SmallBuffer;
             // Get the section name, and make a copy because
             // elf_newsection() may reallocate the string buffer.
             char *section_name = cast(char *)GET_SECTION_NAME(secidx);

--- a/compiler/src/dmd/backend/gsroa.d
+++ b/compiler/src/dmd/backend/gsroa.d
@@ -344,7 +344,7 @@ if (enable) // disable while we test the inliner
         enum tmp_length = 6;
     SymInfo[tmp_length] tmp = void;
 
-    import dmd.common.string : SmallBuffer;
+    import dmd.common.smallbuffer : SmallBuffer;
     auto sb = SmallBuffer!(SymInfo)(3 * sia_length, tmp[]);
     SymInfo* sip = sb.ptr;
     memset(sip, 0, 3 * sia_length * SymInfo.sizeof);

--- a/compiler/src/dmd/common/README.md
+++ b/compiler/src/dmd/common/README.md
@@ -5,4 +5,4 @@
 | [bitfields.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/bitfields.d) | Pack multiple boolean fields into bit fields                    |
 | [file.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/file.d)           | Functions and objects dedicated to file I/O and management      |
 | [outbuffer.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/outbuffer.d) | An expandable buffer in which you can write text or binary data |
-| [string.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/string.d)       | Common string functions including filename manipulation         |
+| [string.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/common/smallbuffer.d)  | Common string functions including filename manipulation         |

--- a/compiler/src/dmd/common/file.d
+++ b/compiler/src/dmd/common/file.d
@@ -23,7 +23,7 @@ import core.sys.windows.winnt;
 import core.sys.posix.fcntl;
 import core.sys.posix.unistd;
 
-import dmd.common.string;
+import dmd.common.smallbuffer;
 
 nothrow:
 

--- a/compiler/src/dmd/common/smallbuffer.d
+++ b/compiler/src/dmd/common/smallbuffer.d
@@ -4,11 +4,11 @@
  * Copyright: Copyright (C) 1999-2023 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, https://www.digitalmars.com
  * License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/string.d, common/_string.d)
- * Documentation: https://dlang.org/phobos/dmd_common_string.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/common/string.d
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/smallbuffer.d, common/_smallbuffer.d)
+ * Documentation: https://dlang.org/phobos/dmd_common_smallbuffer.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/common/smallbuffer
  */
-module dmd.common.string;
+module dmd.common.smallbuffer;
 
 nothrow:
 

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -5346,7 +5346,7 @@ elem *callfunc(const ref Loc loc,
         else
             elem*[10] elems_array = void;
 
-        import dmd.common.string : SmallBuffer;
+        import dmd.common.smallbuffer : SmallBuffer;
         auto pe = SmallBuffer!(elem*)(n, elems_array[]);
         elem*[] elems = pe[];
 

--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -2343,7 +2343,7 @@ void finishScopeParamInference(FuncDeclaration funcdecl, ref TypeFunction f)
         VarDeclaration[10] tmp = void;
         size_t dim = (funcdecl.vthis !is null) + (funcdecl.parameters ? funcdecl.parameters.length : 0);
 
-        import dmd.common.string : SmallBuffer;
+        import dmd.common.smallbuffer : SmallBuffer;
         auto sb = SmallBuffer!VarDeclaration(dim, tmp[]);
         VarDeclaration[] array = sb[];
 

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -28,7 +28,7 @@ import dmd.root.env;
 import dmd.root.file;
 import dmd.root.filename;
 import dmd.common.outbuffer;
-import dmd.common.string;
+import dmd.common.smallbuffer;
 import dmd.root.rmem;
 import dmd.root.string;
 import dmd.utils;

--- a/compiler/src/dmd/root/file.d
+++ b/compiler/src/dmd/root/file.d
@@ -24,7 +24,7 @@ import dmd.root.rmem;
 import dmd.root.string;
 
 import dmd.common.file;
-import dmd.common.string;
+import dmd.common.smallbuffer;
 
 nothrow:
 

--- a/compiler/src/dmd/root/filename.d
+++ b/compiler/src/dmd/root/filename.d
@@ -37,7 +37,7 @@ version (Windows)
     import core.sys.windows.windef;
     import core.sys.windows.winnls;
 
-    import dmd.common.string : extendedPathThen;
+    import dmd.common.smallbuffer : extendedPathThen;
 
     extern (Windows) DWORD GetFullPathNameW(LPCWSTR, DWORD, LPWSTR, LPWSTR*) nothrow @nogc;
     extern (Windows) void SetLastError(DWORD) nothrow @nogc;
@@ -1177,7 +1177,7 @@ version(Windows)
      */
     private auto toWStringzThen(alias F)(const(char)[] str) nothrow
     {
-        import dmd.common.string : SmallBuffer, toWStringz;
+        import dmd.common.smallbuffer : SmallBuffer, toWStringz;
 
         if (!str.length) return F(""w.ptr);
 

--- a/compiler/src/dmd/root/speller.d
+++ b/compiler/src/dmd/root/speller.d
@@ -42,7 +42,7 @@ private:
 
 import core.stdc.stdlib;
 import core.stdc.string;
-import dmd.common.string : SmallBuffer;
+import dmd.common.smallbuffer : SmallBuffer;
 
 enum isSearchFunction(alias fun) = is(searchFunctionType!fun);
 alias searchFunctionType(alias fun) = typeof(() {int x; return fun("", x);}());

--- a/compiler/src/dmd/root/string.d
+++ b/compiler/src/dmd/root/string.d
@@ -69,7 +69,7 @@ The return value of `T`
 auto toCStringThen(alias dg)(const(char)[] src) nothrow
 {
     import dmd.root.rmem : mem;
-    import dmd.common.string : SmallBuffer;
+    import dmd.common.smallbuffer : SmallBuffer;
 
     const len = src.length + 1;
     char[512] small = void;

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -69,7 +69,7 @@ extern (C++):
 Symbol *toSymbolX(Dsymbol ds, const(char)* prefix, SC sclass, type *t, const(char)* suffix)
 {
     //printf("Dsymbol::toSymbolX('%s')\n", prefix);
-    import dmd.common.string : SmallBuffer;
+    import dmd.common.smallbuffer : SmallBuffer;
     import dmd.common.outbuffer : OutBuffer;
 
     OutBuffer buf;

--- a/compiler/src/dmd/toctype.d
+++ b/compiler/src/dmd/toctype.d
@@ -118,7 +118,7 @@ extern (C++) type* Type_toCtype(Type t)
     static type* visitFunction(TypeFunction t)
     {
         const nparams = t.parameterList.length;
-        import dmd.common.string : SmallBuffer;
+        import dmd.common.smallbuffer : SmallBuffer;
         type*[10] tmp = void;
         auto sb = SmallBuffer!(type*)(nparams, tmp[]);
         type*[] types = sb[];

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -18,7 +18,7 @@ import core.stdc.time;
 
 import dmd.root.array;
 import dmd.common.outbuffer;
-import dmd.common.string : SmallBuffer;
+import dmd.common.smallbuffer : SmallBuffer;
 import dmd.root.rmem;
 import dmd.rootobject;
 

--- a/compiler/src/dmd/vsoptions.d
+++ b/compiler/src/dmd/vsoptions.d
@@ -571,7 +571,7 @@ extern(D):
     //  one with the largest version that also contains the test file
     static const(char)* findLatestSDKDir(const(char)* baseDir, string testfile)
     {
-        import dmd.common.string : SmallBuffer, toWStringz;
+        import dmd.common.smallbuffer : SmallBuffer, toWStringz;
 
         const(char)* pattern = FileName.combine(baseDir, "*");
         wchar[1024] support = void;


### PR DESCRIPTION
Using the name `string` for it is inappropriate because:

1. `root.string` already exists, also the `string` alias
2. only 1 of the 4 entities in it is about strings
3. Windows specific code does not belong in a 'strings' package

I'll deal with the non-SmallBuffer entities in a later PR.