### PR TITLE
replace common.smallbuffer.asDstring() with inline code

### DIFF
--- a/compiler/src/dmd/common/file.d
+++ b/compiler/src/dmd/common/file.d
@@ -17,7 +17,7 @@ module dmd.common.file;
 import core.stdc.errno : errno;
 import core.stdc.stdio : fprintf, remove, rename, stderr;
 import core.stdc.stdlib : exit;
-import core.stdc.string : strerror;
+import core.stdc.string : strerror, strlen;
 import core.sys.windows.winbase;
 import core.sys.windows.winnt;
 import core.sys.posix.fcntl;
@@ -129,7 +129,8 @@ struct FileMapping(Datum)
                 enum openFlags = CREATE_ALWAYS;
             }
 
-            handle = filename.asDString.extendedPathThen!(p => CreateFileW(p.ptr, createFileMode, 0, null, openFlags, FILE_ATTRIBUTE_NORMAL, null));
+            handle = filename[0 .. strlen(filename)].
+                extendedPathThen!(p => CreateFileW(p.ptr, createFileMode, 0, null, openFlags, FILE_ATTRIBUTE_NORMAL, null));
             if (handle == invalidHandle)
             {
                 static if (is(Datum == const))
@@ -312,7 +313,7 @@ struct FileMapping(Datum)
         else version(Windows)
         {
             import core.sys.windows.winbase;
-            if (deleteme.asDString.extendedPathThen!(p => DeleteFileW(p.ptr)) == 0)
+            if (deleteme[0 .. strlen(deleteme)].extendedPathThen!(p => DeleteFileW(p.ptr)) == 0)
             {
                 fprintf(stderr, "DeleteFileW error %d\n", GetLastError());
                 return false;
@@ -447,8 +448,8 @@ struct FileMapping(Datum)
         else version(Windows)
         {
             import core.sys.windows.winbase;
-            auto r = oldname.asDString.extendedPathThen!(
-                p1 => filename.asDString.extendedPathThen!(p2 => MoveFileExW(p1.ptr, p2.ptr, MOVEFILE_REPLACE_EXISTING))
+            auto r = oldname[0 .. strlen(oldname)].extendedPathThen!(
+                p1 => filename[0 .. strlen(filename)].extendedPathThen!(p2 => MoveFileExW(p1.ptr, p2.ptr, MOVEFILE_REPLACE_EXISTING))
             );
             if (r == 0)
             {
@@ -483,7 +484,7 @@ extern(D) static bool writeFile(const(char)* name, const void[] data) nothrow
     else version (Windows)
     {
         DWORD numwritten; // here because of the gotos
-        const nameStr = name.asDString;
+        const nameStr = name[0 .. strlen(name)];
         // work around Windows file path length limitation
         // (see documentation for extendedPathThen).
         HANDLE h = nameStr.extendedPathThen!

--- a/compiler/src/dmd/common/smallbuffer.d
+++ b/compiler/src/dmd/common/smallbuffer.d
@@ -107,28 +107,6 @@ unittest
 }
 
 /**
-Converts a zero-terminated C string to a D slice. Takes linear time and allocates no memory.
-
-Params:
-stringz = the C string to be converted
-
-Returns:
-a slice comprehending the string. The terminating 0 is not part of the slice.
-*/
-auto asDString(C)(C* stringz) pure @nogc nothrow
-{
-    import core.stdc.string : strlen;
-    return stringz[0 .. strlen(stringz)];
-}
-
-///
-unittest
-{
-    const char* p = "123".ptr;
-    assert(p.asDString == "123");
-}
-
-/**
 (Windows only) Converts a narrow string to a wide string using `buffer` as strorage. Returns a slice managed by
 `buffer` containing the converted string. The terminating zero is not part of the returned slice,
 but is guaranteed to follow it.


### PR DESCRIPTION
`asDString():`

1. duplicates (badly, skips null check) `root.string.toDstring()`
2. is only used by `common.file`
3. is trivia, as `[0 .. strlen(s)]` is instantly recognizable and easier to understand
4. takes many lines of text to document (3), plus a unittest