### PR TITLE
Deprecate string literals as (static) assert conditions

### DIFF
--- a/changelog/dmd.assert-string.dd
+++ b/changelog/dmd.assert-string.dd
@@ -13,7 +13,6 @@ Now these cases will be detected with deprecation messages.
 If the original behaviour was actually intended, use `expr !is null` instead:
 
 ```d
-enum s = "";
-assert(s !is null);
+assert("" !is null);
 static assert("" !is null);
 ```

--- a/changelog/dmd.assert-string.dd
+++ b/changelog/dmd.assert-string.dd
@@ -1,0 +1,19 @@
+A string literal as an assert condition is deprecated
+
+Boolean evaluation of a string literal could happen unintentionally
+e.g. when an `assert(0, "message")` was meant and the `0` was missing.
+
+```d
+assert("unexpected runtime condition");
+static assert("unhandled case for `", T, "`");
+```
+
+The 2 asserts would silently always have no effect.
+Now these cases will be detected with deprecation messages.
+If the original behaviour was actually intended, use `expr !is null` instead:
+
+```d
+enum s = "";
+assert(s !is null);
+static assert("" !is null);
+```

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7592,6 +7592,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             printf("AssertExp::semantic('%s')\n", exp.toChars());
         }
+        if (auto e = exp.e1.isStringExp())
+        {
+            // deprecated in 2.107
+            deprecation(e.loc, "assert condition cannot be a string literal");
+            deprecationSupplemental(e.loc, "If intentional, use `%s !is null` instead to preserve behaviour",
+                e.toChars());
+        }
 
         const generateMsg = !exp.msg &&
                             sc.needsCodegen() && // let ctfe interpreter handle the error message
@@ -7844,15 +7851,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             result = ex;
             return;
-        }
-        // Note: `"".ptr` is apparently still a StringExp
-        if (exp.e1.type.ty != Tpointer)
-        if (auto e = exp.e1.isStringExp())
-        {
-            // deprecated in 2.107
-            deprecation(e.loc, "assert condition cannot be a string literal");
-            deprecationSupplemental(e.loc, "If intentional, use `%s !is null` instead to preserve behaviour",
-                e.toChars());
         }
 
         exp.e1 = resolveProperties(sc, exp.e1);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7845,6 +7845,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = ex;
             return;
         }
+        // Note: `"".ptr` is apparently still a StringExp
+        if (exp.e1.type.ty != Tpointer)
+        if (auto e = exp.e1.isStringExp())
+        {
+            // deprecated in 2.107
+            deprecation(e.loc, "assert condition cannot be a string literal");
+            deprecationSupplemental(e.loc, "If intentional, use `%s !is null` instead to preserve behaviour",
+                e.toChars());
+        }
 
         exp.e1 = resolveProperties(sc, exp.e1);
         // BUG: see if we can do compile time elimination of the Assert

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -93,6 +93,13 @@ private extern(C++) final class Semantic2Visitor : Visitor
     override void visit(StaticAssert sa)
     {
         //printf("StaticAssert::semantic2() %s\n", sa.toChars());
+        if (const e = sa.exp.isStringExp())
+        {
+            // deprecated in 2.107
+            deprecation(e.loc, "static assert condition cannot be a string literal");
+            deprecationSupplemental(e.loc, "If intentional, use `%s !is null` instead to preserve behaviour",
+                e.toChars());
+        }
         auto sds = new ScopeDsymbol();
         sc = sc.push(sds);
         sc.tinst = null;

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1854,17 +1854,6 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         s.sa.semantic2(sc);
         if (s.sa.errors)
             return setError();
-
-        ref exp() => s.sa.exp;
-        exp = exp.expressionSemantic(sc);
-        // Note: `"".ptr` is apparently still a StringExp
-        if (exp.type.ty != Tpointer && exp.isStringExp())
-        {
-            // deprecated in 2.107
-            deprecation(exp.loc, "static assert condition cannot be a string literal");
-            deprecationSupplemental(exp.loc, "If intentional, use `%s !is null` instead to preserve behaviour",
-                exp.toChars());
-        }
     }
 
     void visitSwitch(SwitchStatement ss)

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1854,6 +1854,17 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         s.sa.semantic2(sc);
         if (s.sa.errors)
             return setError();
+
+        ref exp() => s.sa.exp;
+        exp = exp.expressionSemantic(sc);
+        // Note: `"".ptr` is apparently still a StringExp
+        if (exp.type.ty != Tpointer && exp.isStringExp())
+        {
+            // deprecated in 2.107
+            deprecation(exp.loc, "static assert condition cannot be a string literal");
+            deprecationSupplemental(exp.loc, "If intentional, use `%s !is null` instead to preserve behaviour",
+                exp.toChars());
+        }
     }
 
     void visitSwitch(SwitchStatement ss)

--- a/compiler/test/fail_compilation/array_bool.d
+++ b/compiler/test/fail_compilation/array_bool.d
@@ -1,0 +1,19 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/array_bool.d(13): Deprecation: assert condition cannot be a string literal
+fail_compilation/array_bool.d(13):        If intentional, use `"foo" !is null` instead to preserve behaviour
+fail_compilation/array_bool.d(15): Deprecation: static assert condition cannot be a string literal
+fail_compilation/array_bool.d(15):        If intentional, use `"bar" !is null` instead to preserve behaviour
+---
+*/
+void main()
+{
+    assert("foo");
+    enum e = "bar";
+    static assert(e);
+
+    static assert("foo".ptr); // OK
+    assert(e.ptr); // OK
+}

--- a/compiler/test/fail_compilation/array_bool.d
+++ b/compiler/test/fail_compilation/array_bool.d
@@ -4,16 +4,19 @@ TEST_OUTPUT:
 ---
 fail_compilation/array_bool.d(13): Deprecation: assert condition cannot be a string literal
 fail_compilation/array_bool.d(13):        If intentional, use `"foo" !is null` instead to preserve behaviour
-fail_compilation/array_bool.d(15): Deprecation: static assert condition cannot be a string literal
-fail_compilation/array_bool.d(15):        If intentional, use `"bar" !is null` instead to preserve behaviour
+fail_compilation/array_bool.d(14): Deprecation: static assert condition cannot be a string literal
+fail_compilation/array_bool.d(14):        If intentional, use `"foo" !is null` instead to preserve behaviour
 ---
 */
 void main()
 {
     assert("foo");
-    enum e = "bar";
-    static assert(e);
+    static assert("foo");
 
+    assert("foo".ptr); // OK
     static assert("foo".ptr); // OK
-    assert(e.ptr); // OK
+
+    enum e = "bar";
+    static assert(e); // OK
+    assert(e); // OK
 }

--- a/compiler/test/runnable/testpdb.d
+++ b/compiler/test/runnable/testpdb.d
@@ -1087,7 +1087,7 @@ bool openDebugInfo(IDiaDataSource* source, IDiaSession* session, IDiaSymbol* glo
 {
     wchar[MAX_PATH] exepath;
     DWORD len = GetModuleFileNameW(null, exepath.ptr, MAX_PATH);
-    len < MAX_PATH || assert("executable path too long");
+    len < MAX_PATH || assert(false, "executable path too long");
 
     HRESULT hr = CoInitialize(NULL);
 


### PR DESCRIPTION
Fix Issue 14387 - Disallow string literals as assert conditions

@Geod24 