### PR TITLE
[stable] Fix overzealous assert in `TemplateInstance.appendToModuleMember()`

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -7509,7 +7509,12 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         }
         //printf("\t-. mi = %s\n", mi.toPrettyChars());
 
-        assert(!memberOf || (!memberOf.isRoot() && mi.isRoot()), "can only re-append from non-root to root module");
+        if (memberOf) // already appended to some module
+        {
+            assert(mi.isRoot(), "can only re-append to a root module");
+            if (memberOf.isRoot())
+                return null; // no need to move to another root module
+        }
 
         Dsymbols* a = mi.members;
         a.push(this);


### PR DESCRIPTION
This assert is hit when compiling a private codebase. I'm not sure how it comes about, but there are apparently cases where the primary template instance has a non-root `minst`, but has been added to a root module's members already (so `memberOf` NOT identical to `minst`), at the time the primary instance's `minst` is swapped-out with a root `minst` from a sibling instance (in `templateInstanceSemantic()`).

Previously, the primary instance was appended to 2 root modules in such a case, most likely causing it to be codegen'd twice.