### PR TITLE
Un-deprecate cent/ucent

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -505,16 +505,6 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 
     Type visitType(Type t)
     {
-        // @@@DEPRECATED_2.110@@@
-        // Use of `cent` and `ucent` has always been an error.
-        // Starting from 2.100, recommend core.int128 as a replace for the
-        // lack of compiler support.
-        if (t.ty == Tint128 || t.ty == Tuns128)
-        {
-            .error(loc, "`cent` and `ucent` types are obsolete, use `core.int128.Cent` instead");
-            return error();
-        }
-
         return t.merge();
     }
 

--- a/compiler/test/fail_compilation/fail22827.d
+++ b/compiler/test/fail_compilation/fail22827.d
@@ -1,9 +1,0 @@
-// https://issues.dlang.org/show_bug.cgi?id=22827
-/* TEST_OUTPUT:
----
-fail_compilation/fail22827.d(8): Error: `cent` and `ucent` types are obsolete, use `core.int128.Cent` instead
-fail_compilation/fail22827.d(9): Error: `cent` and `ucent` types are obsolete, use `core.int128.Cent` instead
----
-*/
-cent i22827;
-ucent j22827;


### PR DESCRIPTION
I shouldn't have to import a module to use int 128

If there are problems in DMD that causes it to compile slow, they should be fixed, not ignored

From a UX point of view, having to import a module just to use it feels bad