### PR TITLE
Move static method dsymbol.Dsymbol._foreach out of dsymbol

### DIFF
--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -1372,48 +1372,6 @@ public:
         return false;
     }
 
-    extern (D) alias ForeachDg = int delegate(size_t idx, Dsymbol s);
-
-    /***************************************
-     * Expands attribute declarations in members in depth first
-     * order. Calls dg(size_t symidx, Dsymbol *sym) for each
-     * member.
-     * If dg returns !=0, stops and returns that value else returns 0.
-     * Use this function to avoid the O(N + N^2/2) complexity of
-     * calculating dim and calling N times getNth.
-     * Returns:
-     *  last value returned by dg()
-     */
-    extern (D) static int _foreach(Scope* sc, Dsymbols* members, scope ForeachDg dg, size_t* pn = null)
-    {
-        assert(dg);
-        if (!members)
-            return 0;
-        size_t n = pn ? *pn : 0; // take over index
-        int result = 0;
-        foreach (size_t i; 0 .. members.length)
-        {
-            Dsymbol s = (*members)[i];
-            if (AttribDeclaration a = s.isAttribDeclaration())
-                result = _foreach(sc, a.include(sc), dg, &n);
-            else if (TemplateMixin tm = s.isTemplateMixin())
-                result = _foreach(sc, tm.members, dg, &n);
-            else if (s.isTemplateInstance())
-            {
-            }
-            else if (s.isUnitTestDeclaration())
-            {
-            }
-            else
-                result = dg(n++, s);
-            if (result)
-                break;
-        }
-        if (pn)
-            *pn = n; // update index
-        return result;
-    }
-
     override final inout(ScopeDsymbol) isScopeDsymbol() inout
     {
         return this;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4770,6 +4770,7 @@ struct ASTCodegen final
     using EnumDeclaration = ::EnumDeclaration;
     using EnumMember = ::EnumMember;
     using Import = ::Import;
+    using ForeachDg = ::ForeachDg;
     using Module = ::Module;
     using ModuleDeclaration = ::ModuleDeclaration;
     using Package = ::Package;

--- a/compiler/src/dmd/traits.d
+++ b/compiler/src/dmd/traits.d
@@ -1665,12 +1665,12 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             }
             else if (auto ed = sm.isEnumDeclaration())
             {
-                ScopeDsymbol._foreach(null, ed.members, &pushIdentsDg);
+                _foreach(null, ed.members, &pushIdentsDg);
             }
             return 0;
         }
 
-        ScopeDsymbol._foreach(sc, sds.members, &pushIdentsDg);
+        _foreach(sc, sds.members, &pushIdentsDg);
         auto cd = sds.isClassDeclaration();
         if (cd && e.ident == Id.allMembers)
         {
@@ -1684,7 +1684,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 {
                     auto cb = (*cd.baseclasses)[i].sym;
                     assert(cb);
-                    ScopeDsymbol._foreach(null, cb.members, &pushIdentsDg);
+                    _foreach(null, cb.members, &pushIdentsDg);
                     if (cb.baseclasses.length)
                         pushBaseMembersDg(cb);
                 }


### PR DESCRIPTION
`_foreach` is used 3 times in `traits.d` and once in `dmodule.getLocalClasses`. The latter function is used only from `toobj.d`. When I'm going to extract semantic routines out of `dmodule.d` I'm going to move `getLocalClasses` to `toobj.d` and `_foreach` to `traits.d` (which is imported from `toobj.d`). But for now, simply moving it to `dmodule.d`, next to `getLocalClasses`, should suffice.