### PR TITLE
Attempt at fixing gdc regression

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -33,6 +33,7 @@ import dmd.errorsink;
 import dmd.expression;
 import dmd.expressionsem;
 import dmd.file_manager;
+import dmd.func;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
@@ -1575,4 +1576,37 @@ private const(char)[] processSource (const(ubyte)[] src, Module mod)
     }
 
     return buf;
+}
+
+/*******************************************
+ * Look for member of the form:
+ *      const(MemberInfo)[] getMembers(string);
+ * Returns NULL if not found
+ */
+extern(C++) FuncDeclaration findGetMembers(ScopeDsymbol dsym)
+{
+    import dmd.opover : search_function;
+    Dsymbol s = search_function(dsym, Id.getmembers);
+    FuncDeclaration fdx = s ? s.isFuncDeclaration() : null;
+    version (none)
+    {
+        // Finish
+        __gshared TypeFunction tfgetmembers;
+        if (!tfgetmembers)
+        {
+            Scope sc;
+            sc.eSink = global.errorSink;
+            auto parameters = new Parameters();
+            Parameters* p = new Parameter(STC.in_, Type.tchar.constOf().arrayOf(), null, null);
+            parameters.push(p);
+            Type tret = null;
+            TypeFunction tf = new TypeFunction(parameters, tret, VarArg.none, LINK.d);
+            tfgetmembers = tf.dsymbolSemantic(Loc.initial, &sc).isTypeFunction();
+        }
+        if (fdx)
+            fdx = fdx.overloadExactMatch(tfgetmembers);
+    }
+    if (fdx && fdx.isVirtual())
+        fdx = null;
+    return fdx;
 }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6297,6 +6297,8 @@ struct ModuleDeclaration final
 
 extern void getLocalClasses(Module* mod, Array<ClassDeclaration* >& aclasses);
 
+extern FuncDeclaration* findGetMembers(ScopeDsymbol* dsym);
+
 extern void gendocfile(Module* m, const char* const ddoctext_ptr, size_t ddoctext_length, const char* const datetime, ErrorSink* eSink, OutBuffer& outbuf);
 
 struct Scope final
@@ -8201,8 +8203,6 @@ extern Type* getTypeInfoType(const Loc& loc, Type* t, Scope* sc, bool genObjCode
 extern bool isSpeculativeType(Type* t);
 
 extern bool builtinTypeInfo(Type* t);
-
-extern FuncDeclaration* findGetMembers(ScopeDsymbol* dsym);
 
 class SemanticTimeTransitiveVisitor : public SemanticTimePermissiveVisitor
 {

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -169,3 +169,4 @@ struct ModuleDeclaration
 };
 
 extern void getLocalClasses(Module* mod, Array<ClassDeclaration* >& aclasses);
+FuncDeclaration *findGetMembers(ScopeDsymbol *dsym);

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -49,7 +49,6 @@ import dmd.location;
 import dmd.mtype;
 import dmd.nspace;
 import dmd.objc_glue;
-import dmd.opover;
 import dmd.statement;
 import dmd.staticassert;
 import dmd.target;

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -15,17 +15,13 @@ import dmd.astenums;
 import dmd.declaration;
 import dmd.dmodule;
 import dmd.dscope;
-import dmd.dsymbol;
 import dmd.dclass;
 import dmd.dstruct;
 import dmd.errors;
 import dmd.expression;
-import dmd.func;
 import dmd.globals;
-import dmd.id;
 import dmd.location;
 import dmd.mtype;
-import dmd.opover;
 import core.stdc.stdio;
 
 /****************************************************
@@ -274,36 +270,4 @@ extern (C++) bool builtinTypeInfo(Type t)
         }
     }
     return false;
-}
-
-/*******************************************
- * Look for member of the form:
- *      const(MemberInfo)[] getMembers(string);
- * Returns NULL if not found
- */
-extern(C++) FuncDeclaration findGetMembers(ScopeDsymbol dsym)
-{
-    Dsymbol s = search_function(dsym, Id.getmembers);
-    FuncDeclaration fdx = s ? s.isFuncDeclaration() : null;
-    version (none)
-    {
-        // Finish
-        __gshared TypeFunction tfgetmembers;
-        if (!tfgetmembers)
-        {
-            Scope sc;
-            sc.eSink = global.errorSink;
-            auto parameters = new Parameters();
-            Parameters* p = new Parameter(STC.in_, Type.tchar.constOf().arrayOf(), null, null);
-            parameters.push(p);
-            Type tret = null;
-            TypeFunction tf = new TypeFunction(parameters, tret, VarArg.none, LINK.d);
-            tfgetmembers = tf.dsymbolSemantic(Loc.initial, &sc).isTypeFunction();
-        }
-        if (fdx)
-            fdx = fdx.overloadExactMatch(tfgetmembers);
-    }
-    if (fdx && fdx.isVirtual())
-        fdx = null;
-    return fdx;
 }

--- a/compiler/src/dmd/typinf.h
+++ b/compiler/src/dmd/typinf.h
@@ -22,4 +22,3 @@ bool genTypeInfo(Expression *e, const Loc &loc, Type *torig, Scope *sc);
 Type *getTypeInfoType(const Loc &loc, Type *t, Scope *sc, bool genObjCode = true);
 bool isSpeculativeType(Type *t);
 bool builtinTypeInfo(Type *t);
-FuncDeclaration *findGetMembers(ScopeDsymbol *dsym);


### PR DESCRIPTION
I think we should create a file that contains functions related to generating module info. Currently, these function are located in `dmodule.d` so I moved `findGetMembers` there to unblock gdc, however, in the future, we need to find a better place for it.

cc @ibuclaw does this fix the gdc regression?