### PR TITLE
macOS CI: Don't brew-install packages provided in the base image already 

### DIFF
--- a/ci/cirrusci.sh
+++ b/ci/cirrusci.sh
@@ -27,9 +27,6 @@ if [ "$OS_NAME" == "linux" ]; then
   fi
   apt-get -q update
   apt-get install -yq $packages
-elif [ "$OS_NAME" == "osx" ]; then
-  # required for dlang install.sh
-  brew install gnupg libarchive xz llvm
 elif [ "$OS_NAME" == "freebsd" ]; then
   packages="git gmake devel/llvm12"
   if [ "$HOST_DMD" == "dmd-2.079.0" ] ; then


### PR DESCRIPTION
It's slow and prone to sporadic failures (possibly caused by a missing initial `brew update` invocation), and seems superfluous for the used macOS 12+13 GitHub Actions images, according to the CI logs.

Motivated by earlier CI failures today, e.g.:
* https://github.com/dlang/dmd/actions/runs/7074379413/job/19255349468?pr=15876 (failure on macOS 12 after 1m 18s of needless provisioning)
* https://github.com/dlang/dmd/actions/runs/7074536451/job/19255678102?pr=15877 (failure on macOS 13 after 9m 38s!)