### PR TITLE
druntime: removes copydir target from Windows makefiles

### DIFF
--- a/druntime/mak/WINDOWS
+++ b/druntime/mak/WINDOWS
@@ -2,10 +2,6 @@ $(mak\COPY)
 
 ######################## Header file copy ##############################
 
-import: copy
-
-copydir: $(IMPDIR)
-
 copy: ..\generated\windows\copyimports.exe
 	@~..\generated\windows\copyimports.exe $(COPY)
 

--- a/druntime/win32.mak
+++ b/druntime/win32.mak
@@ -32,7 +32,7 @@ DRUNTIME=lib\$(DRUNTIME_BASE).lib
 
 DOCFMT=
 
-target: copydir copy $(DRUNTIME)
+target: copy $(DRUNTIME)
 
 $(mak\COPY)
 $(mak\DOCS)
@@ -49,9 +49,6 @@ OBJS_TO_DELETE= errno_c_32omf.obj
 ######################## Header file copy ##############################
 
 import: copy
-
-copydir:
-	"$(MAKE)" -f mak/WINDOWS copydir DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=32 IMPDIR="$(IMPDIR)"
 
 copy:
 	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=32 IMPDIR="$(IMPDIR)"

--- a/druntime/win64.mak
+++ b/druntime/win64.mak
@@ -37,7 +37,7 @@ DRUNTIME=lib\$(DRUNTIME_BASE).lib
 
 DOCFMT=
 
-target: copydir copy $(DRUNTIME)
+target: copy $(DRUNTIME)
 
 $(mak\COPY)
 $(mak\DOCS)
@@ -52,9 +52,6 @@ OBJS_TO_DELETE= errno_c_$(MODEL).obj
 ######################## Header file copy ##############################
 
 import: copy
-
-copydir:
-	"$(MAKE)" -f mak/WINDOWS copydir DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 copy:
 	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"


### PR DESCRIPTION
`copydir` seems as legacy since times when there were maintained two separate lists of sources, for Posix and for Windows

Also removes not in use `import` target from `mak/WINDOWS`