### PR TITLE
druntime/test/*.mak: replaces -Isrc by -Iimport

### DIFF
--- a/druntime/test/allocations/win64.mak
+++ b/druntime/test/allocations/win64.mak
@@ -7,6 +7,6 @@ DRUNTIMELIB=druntime64.lib
 test: alloc_from_assert
 
 alloc_from_assert:
-	$(DMD) -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\allocations\src\$@.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) test\allocations\src\$@.d
 	$@.exe
 	del $@.*

--- a/druntime/test/betterc/win64.mak
+++ b/druntime/test/betterc/win64.mak
@@ -8,43 +8,43 @@ TESTS=test18828 test19416 test19421 test19561 test20088 test20613 test19924 test
 test: $(TESTS)
 
 test18828:
-	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -betterC -run test\betterc\src\$@.d
 	del $@.*
 
 test19416:
-	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -betterC -run test\betterc\src\$@.d
 	del $@.*
 
 test19421:
-	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -betterC -run test\betterc\src\$@.d
 	del $@.*
 
 test19561:
-	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -betterC -run test\betterc\src\$@.d
 	del $@.*
 
 test20088:
-	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -betterC -run test\betterc\src\$@.d
 	del $@.*
 
 test20613:
-	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -betterC -run test\betterc\src\$@.d
 	del $@.*
 
 test19924:
-	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -betterC -run test\betterc\src\$@.d
 	del $@.*
 
 test22336:
-	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -betterC -run test\betterc\src\$@.d
 	del $@.*
 
 test19933:
-	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -betterC -run test\betterc\src\$@.d
 	del $@.*
 
 test19933_mingw:
 	# DFLAGS=-mscrtlib=msvcrt120 takes precedence over any command line flags, so
 	# specify vcruntime140.lib explicitly for using mingw with Universal CRT
-	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -Lvcruntime140.lib -Llegacy_stdio_definitions.lib -L/NODEFAULTLIB:msvcrt120.lib -run test\betterc\src\test19933.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -betterC -Lvcruntime140.lib -Llegacy_stdio_definitions.lib -L/NODEFAULTLIB:msvcrt120.lib -run test\betterc\src\test19933.d
 	del $@.*

--- a/druntime/test/cpuid/win64.mak
+++ b/druntime/test/cpuid/win64.mak
@@ -7,6 +7,6 @@ DRUNTIMELIB=druntime64.lib
 test: cpuid
 
 cpuid:
-	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\cpuid\src\cpuid.d
+	$(DMD) -g -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) test\cpuid\src\cpuid.d
 	cpuid.exe
 	del cpuid.exe cpuid.obj

--- a/druntime/test/exceptions/win64.mak
+++ b/druntime/test/exceptions/win64.mak
@@ -5,6 +5,6 @@ MODEL=64
 DRUNTIMELIB=druntime64.lib
 
 test:
-	$(DMD) -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -g test\exceptions\src\winstack.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) -g test\exceptions\src\winstack.d
 	winstack.exe
 	del winstack.*

--- a/druntime/test/gc/win64.mak
+++ b/druntime/test/gc/win64.mak
@@ -6,7 +6,7 @@ DRUNTIMELIB=druntime64.lib
 
 SRC_GC = src/core/internal/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) src/rt/lifetime.d src/object.d
-_DFLAGS = -m$(MODEL) -g -conf= -Isrc -defaultlib=$(DRUNTIMELIB)
+_DFLAGS = -m$(MODEL) -g -conf= -Iimport -defaultlib=$(DRUNTIMELIB)
 UDFLAGS = $(_DFLAGS) -unittest -version=CoreUnittest
 RM = del
 

--- a/druntime/test/gc/win64.mak
+++ b/druntime/test/gc/win64.mak
@@ -6,7 +6,7 @@ DRUNTIMELIB=druntime64.lib
 
 SRC_GC = src/core/internal/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) src/rt/lifetime.d src/object.d
-_DFLAGS = -m$(MODEL) -g -conf= -Iimport -defaultlib=$(DRUNTIMELIB)
+_DFLAGS = -m$(MODEL) -g -conf= -Iimport -Isrc -defaultlib=$(DRUNTIMELIB)
 UDFLAGS = $(_DFLAGS) -unittest -version=CoreUnittest
 RM = del
 

--- a/druntime/test/init_fini/win64.mak
+++ b/druntime/test/init_fini/win64.mak
@@ -7,6 +7,6 @@ DRUNTIMELIB=druntime64.lib
 test: custom_gc
 
 custom_gc:
-	$(DMD) -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\init_fini\src\custom_gc.d
+	$(DMD) -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) test\init_fini\src\custom_gc.d
 	custom_gc.exe
 	del custom_gc.exe custom_gc.obj

--- a/druntime/test/shared/win64.mak
+++ b/druntime/test/shared/win64.mak
@@ -7,24 +7,24 @@ DRUNTIMELIB=druntime64.lib
 test: loadlibwin dllrefcount dllgc dynamiccast
 
 dllrefcount:
-	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\shared\src\dllrefcount.d
+	$(DMD) -g -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) test\shared\src\dllrefcount.d
 	dllrefcount.exe
 	del dllrefcount.exe dllrefcount.obj
 
 loadlibwin:
-	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\shared\src\loadlibwin.d
+	$(DMD) -g -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) test\shared\src\loadlibwin.d
 	loadlibwin.exe
 	del loadlibwin.exe loadlibwin.obj
 
 dllgc:
-	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -version=DLL -shared -ofdllgc.dll test\shared\src\dllgc.d
-	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -ofloaddllgc.exe test\shared\src\dllgc.d
+	$(DMD) -g -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) -version=DLL -shared -ofdllgc.dll test\shared\src\dllgc.d
+	$(DMD) -g -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) -ofloaddllgc.exe test\shared\src\dllgc.d
 	loaddllgc.exe
 	del loaddllgc.exe loaddllgc.obj dllgc.dll dllgc.obj
 
 dynamiccast:
-	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -version=DLL -shared -ofdynamiccast.dll test\shared\src\dynamiccast.d
-	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -ofdynamiccast.exe test\shared\src\dynamiccast.d
+	$(DMD) -g -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) -version=DLL -shared -ofdynamiccast.dll test\shared\src\dynamiccast.d
+	$(DMD) -g -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) -ofdynamiccast.exe test\shared\src\dynamiccast.d
 	dynamiccast.exe
 	cmd /c "if not exist dynamiccast_endbar exit 1"
 	cmd /c "if not exist dynamiccast_endmain exit 1"

--- a/druntime/test/stdcpp/win64.mak
+++ b/druntime/test/stdcpp/win64.mak
@@ -18,21 +18,21 @@ test: $(TESTS)
 
 $(TESTS):
 	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MT $(ADD_CFLAGS)
-	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=CoreUnittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=libcmt $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
+	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) -main -unittest -version=CoreUnittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=libcmt $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
 	$@.exe
 	del $@.exe $@.obj $@_cpp.obj
 
 	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MD $(ADD_CFLAGS)
-	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=CoreUnittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=msvcrt $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
+	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) -main -unittest -version=CoreUnittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=msvcrt $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
 	$@.exe
 	del $@.exe $@.obj $@_cpp.obj
 
 	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MTd $(ADD_CFLAGS)
-	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=CoreUnittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=libcmtd $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
+	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) -main -unittest -version=CoreUnittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=libcmtd $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
 	$@.exe
 	del $@.exe $@.obj $@_cpp.obj
 
 	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MDd $(ADD_CFLAGS)
-	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=CoreUnittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=msvcrtd $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
+	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) -main -unittest -version=CoreUnittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=msvcrtd $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
 	$@.exe
 	del $@.exe $@.obj $@_cpp.obj

--- a/druntime/test/uuid/win64.mak
+++ b/druntime/test/uuid/win64.mak
@@ -5,5 +5,5 @@ MODEL=64
 DRUNTIMELIB=druntime64.lib
 
 test:
-	$(DMD) -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\uuid\test.d uuid.lib
+	$(DMD) -m$(MODEL) -conf= -Iimport -defaultlib=$(DRUNTIMELIB) test\uuid\test.d uuid.lib
 	del test.exe test.obj


### PR DESCRIPTION
We have a special directory for modules importing and nothing prevents us to use this good practice

My motivation for this PR: this is need for https://github.com/dlang/dmd/pull/15822 - importing OS-depended files can be implemented only by using `import/` directory