### PR TITLE
[trivial] [object] Document `setSameMutex`

### DIFF
--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -526,6 +526,12 @@ unittest
 
 private extern(C) void _d_setSameMutex(shared Object ownee, shared Object owner) nothrow;
 
+/** Makes ownee use owner's mutex.
+ * This will initialize owner's mutex if it hasn't been set yet.
+ * Params:
+ * ownee = object to change
+ * owner = source object
+ */
 void setSameMutex(shared Object ownee, shared Object owner)
 {
     import core.atomic : atomicLoad;


### PR DESCRIPTION
It's mentioned in TDPL:
https://www.informit.com/articles/article.aspx?p=1609144&seqNum=14