### PR TITLE
Removes unused DDOCFLAGS variable from druntime/win64.mak

### DIFF
--- a/druntime/win64.mak
+++ b/druntime/win64.mak
@@ -28,7 +28,6 @@ HOST_DMD=dmd
 
 DFLAGS=-m$(MODEL) -conf= -O -release -preview=dip1000 -preview=fieldwise -preview=dtorfields -inline -w -Isrc -Iimport
 UDFLAGS=-m$(MODEL) -conf= -O -release -preview=dip1000 -preview=fieldwise -w -version=_MSC_VER_$(_MSC_VER) -Isrc -Iimport
-DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 
 UTFLAGS=-version=CoreUnittest -unittest -checkaction=context
 


### PR DESCRIPTION
This is left over from past times. Now documentation is generated only in posix.mak