### PR TITLE
add SearchOpt to enum type

### DIFF
--- a/compiler/src/dmd/astcodegen.d
+++ b/compiler/src/dmd/astcodegen.d
@@ -97,6 +97,6 @@ struct ASTCodegen
     alias isExpression              = dmd.dtemplate.isExpression;
     alias isTuple                   = dmd.dtemplate.isTuple;
 
-    alias IgnoreErrors              = dmd.dsymbol.IgnoreErrors;
+    alias SearchOpt                 = dmd.dsymbol.SearchOpt;
     alias PASS                      = dmd.dsymbol.PASS;
 }

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -614,7 +614,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     final bool isFuncHidden(FuncDeclaration fd)
     {
         //printf("ClassDeclaration.isFuncHidden(class = %s, fd = %s)\n", toChars(), fd.toPrettyChars());
-        Dsymbol s = this.search(Loc.initial, fd.ident, IgnoreAmbiguous | IgnoreErrors);
+        Dsymbol s = this.search(Loc.initial, fd.ident, SearchOpt.ignoreAmbiguous | SearchOpt.ignoreErrors);
         if (!s)
         {
             //printf("not found\n");

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -401,7 +401,7 @@ extern (C++) final class Module : Package
 
     Identifier searchCacheIdent;
     Dsymbol searchCacheSymbol;  // cached value of search
-    int searchCacheFlags;       // cached flags
+    SearchOptFlags searchCacheFlags;       // cached flags
     bool insearch;
 
     /**
@@ -1021,14 +1021,14 @@ extern (C++) final class Module : Package
         }
     }
 
-    override bool isPackageAccessible(Package p, Visibility visibility, int flags = 0)
+    override bool isPackageAccessible(Package p, Visibility visibility, SearchOptFlags flags = SearchOpt.all)
     {
         if (insearch) // don't follow import cycles
             return false;
         insearch = true;
         scope (exit)
             insearch = false;
-        if (flags & IgnorePrivateImports)
+        if (flags & SearchOpt.ignorePrivateImports)
             visibility = Visibility(Visibility.Kind.public_); // only consider public imports
         return super.isPackageAccessible(p, visibility);
     }

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -3638,11 +3638,11 @@ struct MarkdownLinkReferences
         {
             auto loc = Loc();
             Dsymbol pscopesym;
-            auto symbol = _scope.search(loc, id, pscopesym, IgnoreErrors);
+            auto symbol = _scope.search(loc, id, pscopesym, SearchOpt.ignoreErrors);
             for (size_t i = 1; symbol && i < ids.length; ++i)
             {
                 id = Identifier.lookup(ids[i].ptr, ids[i].length);
-                symbol = id !is null ? symbol.search(loc, id, IgnoreErrors) : null;
+                symbol = id !is null ? symbol.search(loc, id, SearchOpt.ignoreErrors) : null;
             }
             if (symbol)
                 link = MarkdownLink(createHref(symbol), null, name, symbol);

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -203,20 +203,21 @@ enum PASS : ubyte
 }
 
 // Search options
-enum : int
+alias SearchOptFlags = uint;
+enum SearchOpt : SearchOptFlags
 {
-    IgnoreNone              = 0x00, // default
-    IgnorePrivateImports    = 0x01, // don't search private imports
-    IgnoreErrors            = 0x02, // don't give error messages
-    IgnoreAmbiguous         = 0x04, // return NULL if ambiguous
-    SearchLocalsOnly        = 0x08, // only look at locals (don't search imports)
-    SearchImportsOnly       = 0x10, // only look in imports
-    SearchUnqualifiedModule = 0x20, // the module scope search is unqualified,
+    all                     = 0x00, // search for all symbols
+    ignorePrivateImports    = 0x01, // don't search private imports
+    ignoreErrors            = 0x02, // don't give error messages
+    ignoreAmbiguous         = 0x04, // return NULL if ambiguous
+    localsOnly              = 0x08, // only look at locals (don't search imports)
+    importsOnly             = 0x10, // only look in imports
+    unqualifiedModule       = 0x20, // the module scope search is unqualified,
                                     // meaning don't search imports in that scope,
                                     // because qualified module searches search
                                     // their imports
-    IgnoreSymbolVisibility  = 0x80, // also find private and package protected symbols
-    TagNameSpace            = 0x100, // search ImportC tag symbol table
+    tagNameSpace            = 0x40, // search ImportC tag symbol table
+    ignoreVisibility        = 0x80, // also find private and package protected symbols
 }
 
 /***********************************************************
@@ -1263,7 +1264,7 @@ public:
         (*pary)[p.tag] = true;
     }
 
-    bool isPackageAccessible(Package p, Visibility visibility, int flags = 0) nothrow
+    bool isPackageAccessible(Package p, Visibility visibility, SearchOptFlags flags = SearchOpt.all) nothrow
     {
         if (p.tag < accessiblePackages.length && accessiblePackages[p.tag] ||
             visibility.kind == Visibility.Kind.private_ && p.tag < privateAccessiblePackages.length && privateAccessiblePackages[p.tag])
@@ -1272,7 +1273,7 @@ public:
         {
             // only search visible scopes && imported modules should ignore private imports
             if (visibility.kind <= visibilities[i] &&
-                ss.isScopeDsymbol.isPackageAccessible(p, visibility, IgnorePrivateImports))
+                ss.isScopeDsymbol.isPackageAccessible(p, visibility, SearchOpt.ignorePrivateImports))
                 return true;
         }
         return false;

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -147,20 +147,21 @@ enum
 
 /* Flags for symbol search
  */
-enum
+typedef uint SearchOptFlags;
+enum class SearchOpt : SearchOptFlags
 {
-    IgnoreNone              = 0x00, // default
-    IgnorePrivateImports    = 0x01, // don't search private imports
-    IgnoreErrors            = 0x02, // don't give error messages
-    IgnoreAmbiguous         = 0x04, // return NULL if ambiguous
-    SearchLocalsOnly        = 0x08, // only look at locals (don't search imports)
-    SearchImportsOnly       = 0x10, // only look in imports
-    SearchUnqualifiedModule = 0x20, // the module scope search is unqualified,
-                                    // meaning don't search imports in that scope,
-                                    // because qualified module searches search
-                                    // their imports
-    IgnoreSymbolVisibility  = 0x80,  // also find private and package protected symbols
-    TagNameSpace            = 0x100, // search ImportC tag symbol table
+    all                    = 0x00, // default
+    ignorePrivateImports   = 0x01, // don't search private imports
+    ignoreErrors           = 0x02, // don't give error messages
+    ignoreAmbiguous        = 0x04, // return NULL if ambiguous
+    localsOnly             = 0x08, // only look at locals (don't search imports)
+    importsOnly            = 0x10, // only look in imports
+    unqualifiedModule      = 0x20, // the module scope search is unqualified,
+                                   // meaning don't search imports in that scope,
+                                   // because qualified module searches search
+                                   // their imports
+    tagNameSpace           = 0x40, // search ImportC tag symbol table
+    ignoreVisibility       = 0x80, // also find private and package protected symbols
 };
 
 struct FieldState
@@ -336,7 +337,7 @@ private:
 public:
     ScopeDsymbol *syntaxCopy(Dsymbol *s) override;
     virtual void importScope(Dsymbol *s, Visibility visibility);
-    virtual bool isPackageAccessible(Package *p, Visibility visibility, int flags = 0);
+    virtual bool isPackageAccessible(Package *p, Visibility visibility, SearchOptFlags flags = (SearchOptFlags)SearchOpt::all);
     bool isforwardRef() override final;
     static void multiplyDefined(const Loc &loc, Dsymbol *s1, Dsymbol *s2);
     const char *kind() const override;
@@ -427,6 +428,6 @@ public:
 };
 
 void addMember(Dsymbol *dsym, Scope *sc, ScopeDsymbol *sds);
-Dsymbol *search(Dsymbol *d, const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
+Dsymbol *search(Dsymbol *d, const Loc &loc, Identifier *ident, SearchOptFlags flags = (SearchOptFlags)SearchOpt::localsOnly);
 bool checkDeprecated(Dsymbol *d, const Loc &loc, Scope *sc);
 void setScope(Dsymbol *d, Scope *sc);

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1617,7 +1617,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 AliasDeclaration ad = imp.aliasdecls[i];
                 //printf("\tImport %s alias %s = %s, scope = %p\n", toPrettyChars(), aliases[i].toChars(), names[i].toChars(), ad._scope);
-                Dsymbol sym = imp.mod.search(imp.loc, imp.names[i], IgnorePrivateImports);
+                Dsymbol sym = imp.mod.search(imp.loc, imp.names[i], SearchOpt.ignorePrivateImports);
                 if (sym)
                 {
                     import dmd.access : symbolIsVisible;
@@ -7957,11 +7957,11 @@ void checkPrintfScanfSignature(FuncDeclaration funcdecl, TypeFunction f, Scope* 
  *  d = dsymbol where ident is searched for
  *  loc = location to print for error messages
  *  ident = identifier to search for
- *  flags = IgnoreXXXX
+ *  flags = search options
  * Returns:
  *  null if not found
  */
-extern(C++) Dsymbol search(Dsymbol d, const ref Loc loc, Identifier ident, int flags = IgnoreNone)
+extern(C++) Dsymbol search(Dsymbol d, const ref Loc loc, Identifier ident, SearchOptFlags flags = SearchOpt.all)
 {
     scope v = new SearchVisitor(loc, ident, flags);
     d.accept(v);
@@ -7986,13 +7986,13 @@ Dsymbol search_correct(Dsymbol d, Identifier ident)
         cost = 0;   // all the same cost
         Dsymbol s = d;
         Module.clearCache();
-        return s.search(Loc.initial, id, IgnoreErrors);
+        return s.search(Loc.initial, id, SearchOpt.ignoreErrors);
     }
 
     if (global.gag)
         return null; // don't do it for speculative compiles; too time consuming
     // search for exact name first
-    if (auto s = d.search(Loc.initial, ident, IgnoreErrors))
+    if (auto s = d.search(Loc.initial, ident, SearchOpt.ignoreErrors))
         return s;
 
     import dmd.root.speller : speller;
@@ -8005,10 +8005,10 @@ private extern(C++) class SearchVisitor : Visitor
 
     const Loc loc;
     Identifier ident;
-    int flags;
+    SearchOptFlags flags;
     Dsymbol result;
 
-    this(const ref Loc loc, Identifier ident, int flags)
+    this(const ref Loc loc, Identifier ident, SearchOptFlags flags)
     {
         this.loc = loc;
         this.ident = ident;
@@ -8032,7 +8032,7 @@ private extern(C++) class SearchVisitor : Visitor
         //if (strcmp(ident.toChars(),"c") == 0) *(char*)0=0;
 
         // Look in symbols declared in this module
-        if (sds.symtab && !(flags & SearchImportsOnly))
+        if (sds.symtab && !(flags & SearchOpt.importsOnly))
         {
             //printf(" look in locals\n");
             auto s1 = sds.symtab.lookup(ident);
@@ -8055,30 +8055,30 @@ private extern(C++) class SearchVisitor : Visitor
         for (size_t i = 0; i < sds.importedScopes.length; i++)
         {
             // If private import, don't search it
-            if ((flags & IgnorePrivateImports) && sds.visibilities[i] == Visibility.Kind.private_)
+            if ((flags & SearchOpt.ignorePrivateImports) && sds.visibilities[i] == Visibility.Kind.private_)
                 continue;
-            int sflags = flags & (IgnoreErrors | IgnoreAmbiguous); // remember these in recursive searches
+            SearchOptFlags sflags = flags & (SearchOpt.ignoreErrors | SearchOpt.ignoreAmbiguous); // remember these in recursive searches
             Dsymbol ss = (*sds.importedScopes)[i];
             //printf("\tscanning import '%s', visibilities = %d, isModule = %p, isImport = %p\n", ss.toChars(), visibilities[i], ss.isModule(), ss.isImport());
 
             if (ss.isModule())
             {
-                if (flags & SearchLocalsOnly)
+                if (flags & SearchOpt.localsOnly)
                     continue;
             }
             else // mixin template
             {
-                if (flags & SearchImportsOnly)
+                if (flags & SearchOpt.importsOnly)
                     continue;
 
-                sflags |= SearchLocalsOnly;
+                sflags |= SearchOpt.localsOnly;
             }
 
             /* Don't find private members if ss is a module
              */
-            Dsymbol s2 = ss.search(loc, ident, sflags | (ss.isModule() ? IgnorePrivateImports : IgnoreNone));
+            Dsymbol s2 = ss.search(loc, ident, sflags | (ss.isModule() ? SearchOpt.ignorePrivateImports : SearchOpt.all));
             import dmd.access : symbolIsVisible;
-            if (!s2 || !(flags & IgnoreSymbolVisibility) && !symbolIsVisible(sds, s2))
+            if (!s2 || !(flags & SearchOpt.ignoreVisibility) && !symbolIsVisible(sds, s2))
                 continue;
             if (!s)
             {
@@ -8149,7 +8149,7 @@ private extern(C++) class SearchVisitor : Visitor
                             }
                         }
 
-                        if (flags & IgnoreAmbiguous) // if return NULL on ambiguity
+                        if (flags & SearchOpt.ignoreAmbiguous) // if return NULL on ambiguity
                             return setResult(null);
 
                         /* If two imports from C import files, pick first one, as C has global name space
@@ -8157,7 +8157,7 @@ private extern(C++) class SearchVisitor : Visitor
                         if (s.isCsymbol() && s2.isCsymbol())
                             continue;
 
-                        if (!(flags & IgnoreErrors))
+                        if (!(flags & SearchOpt.ignoreErrors))
                             ScopeDsymbol.multiplyDefined(loc, s, s2);
                         break;
                     }
@@ -8184,7 +8184,7 @@ private extern(C++) class SearchVisitor : Visitor
     override void visit(WithScopeSymbol ws)
     {
         //printf("WithScopeSymbol.search(%s)\n", ident.toChars());
-        if (flags & SearchImportsOnly)
+        if (flags & SearchOpt.importsOnly)
             return setResult(null);
         // Acts as proxy to the with class declaration
         Dsymbol s = null;
@@ -8425,7 +8425,7 @@ private extern(C++) class SearchVisitor : Visitor
 
         if (!ns.members || !ns.symtab) // opaque or semantic() is not yet called
         {
-            if (!(flags & IgnoreErrors))
+            if (!(flags & SearchOpt.ignoreErrors))
                 .error(loc, "%s `%s` is forward referenced when looking for `%s`", ns.kind, ns.toPrettyChars, ident.toChars());
             return setResult(null);
         }
@@ -8448,7 +8448,7 @@ private extern(C++) class SearchVisitor : Visitor
     override void visit(Package pkg)
     {
         //printf("%s Package.search('%s', flags = x%x)\n", pkg.toChars(), ident.toChars(), flags);
-        flags &= ~SearchLocalsOnly;  // searching an import is always transitive
+        flags &= ~cast(int)SearchOpt.localsOnly;  // searching an import is always transitive
         if (!pkg.isModule() && pkg.mod)
         {
             // Prefer full package name.
@@ -8475,8 +8475,8 @@ private extern(C++) class SearchVisitor : Visitor
         /* Qualified module searches always search their imports,
          * even if SearchLocalsOnly
          */
-        if (!(flags & SearchUnqualifiedModule))
-            flags &= ~(SearchUnqualifiedModule | SearchLocalsOnly);
+        if (!(flags & SearchOpt.unqualifiedModule))
+            flags &= ~(SearchOpt.unqualifiedModule | SearchOpt.localsOnly);
 
         if (m.searchCacheIdent == ident && m.searchCacheFlags == flags)
         {
@@ -8525,7 +8525,7 @@ private extern(C++) class SearchVisitor : Visitor
         if (!sd.members || !sd.symtab) // opaque or semantic() is not yet called
         {
             // .stringof is always defined (but may be hidden by some other symbol)
-            if(ident != Id.stringof && !(flags & IgnoreErrors) && sd.semanticRun < PASS.semanticdone)
+            if(ident != Id.stringof && !(flags & SearchOpt.ignoreErrors) && sd.semanticRun < PASS.semanticdone)
                 .error(loc, "%s `%s` is forward referenced when looking for `%s`", sd.kind, sd.toPrettyChars, ident.toChars());
             return setResult(null);
         }
@@ -8551,7 +8551,7 @@ private extern(C++) class SearchVisitor : Visitor
         if (!cd.members || !cd.symtab) // opaque or addMember is not yet done
         {
             // .stringof is always defined (but may be hidden by some other symbol)
-            if (ident != Id.stringof && !(flags & IgnoreErrors) && cd.semanticRun < PASS.semanticdone)
+            if (ident != Id.stringof && !(flags & SearchOpt.ignoreErrors) && cd.semanticRun < PASS.semanticdone)
                 cd.classError("%s `%s` is forward referenced when looking for `%s`", ident.toChars());
             //*(char*)0=0;
             return setResult(null);
@@ -8561,7 +8561,7 @@ private extern(C++) class SearchVisitor : Visitor
         auto s = result;
 
         // don't search imports of base classes
-        if (flags & SearchImportsOnly)
+        if (flags & SearchOpt.importsOnly)
             return setResult(s);
 
         if (s)
@@ -8586,7 +8586,7 @@ private extern(C++) class SearchVisitor : Visitor
                 continue;
             else if (s == cd) // happens if s is nested in this and derives from this
                 s = null;
-            else if (!(flags & IgnoreSymbolVisibility) && !(s.visible().kind == Visibility.Kind.protected_) && !symbolIsVisible(cd, s))
+            else if (!(flags & SearchOpt.ignoreVisibility) && !(s.visible().kind == Visibility.Kind.protected_) && !symbolIsVisible(cd, s))
                 s = null;
             else
                 break;

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -3284,7 +3284,7 @@ ASTCodegen.Dsymbol symbolFromType(ASTCodegen.Type t) @safe
  */
 ASTCodegen.Dsymbol findMember(ASTCodegen.Dsymbol sym, Identifier name)
 {
-    if (auto mem = sym.search(Loc.initial, name, ASTCodegen.IgnoreErrors))
+    if (auto mem = sym.search(Loc.initial, name, ASTCodegen.SearchOpt.ignoreErrors))
         return mem;
 
     // search doesn't work for declarations inside of uninstantiated

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -875,7 +875,7 @@ private Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
     Loc loc = ue.loc;
 
     // TODO: merge with Scope.search.searchScopes()
-    Dsymbol searchScopes(int flags)
+    Dsymbol searchScopes(SearchOptFlags flags)
     {
         Dsymbol s = null;
         for (Scope* scx = sc; scx; scx = scx.enclosing)
@@ -883,7 +883,7 @@ private Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
             if (!scx.scopesym)
                 continue;
             if (scx.scopesym.isModule())
-                flags |= SearchUnqualifiedModule;    // tell Module.search() that SearchLocalsOnly is to be obeyed
+                flags |= SearchOpt.unqualifiedModule;    // tell Module.search() that SearchOpt.localsOnly is to be obeyed
             s = scx.scopesym.search(loc, ident, flags);
             if (s)
             {
@@ -910,18 +910,18 @@ private Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
         return s;
     }
 
-    int flags = 0;
+    SearchOptFlags flags = SearchOpt.all;
     Dsymbol s;
 
     if (sc.flags & SCOPE.ignoresymbolvisibility)
-        flags |= IgnoreSymbolVisibility;
+        flags |= SearchOpt.ignoreVisibility;
 
     // First look in local scopes
-    s = searchScopes(flags | SearchLocalsOnly);
+    s = searchScopes(flags | SearchOpt.localsOnly);
     if (!s)
     {
         // Second look in imported modules
-        s = searchScopes(flags | SearchImportsOnly);
+        s = searchScopes(flags | SearchOpt.importsOnly);
     }
 
     if (!s)
@@ -14211,15 +14211,15 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
 
     if (auto ie = eright.isScopeExp()) // also used for template alias's
     {
-        auto flags = SearchLocalsOnly;
+        SearchOptFlags flags = SearchOpt.localsOnly;
         /* Disable access to another module's private imports.
          * The check for 'is sds our current module' is because
          * the current module should have access to its own imports.
          */
         if (ie.sds.isModule() && ie.sds != sc._module)
-            flags |= IgnorePrivateImports;
+            flags |= SearchOpt.ignorePrivateImports;
         if (sc.flags & SCOPE.ignoresymbolvisibility)
-            flags |= IgnoreSymbolVisibility;
+            flags |= SearchOpt.ignoreVisibility;
         Dsymbol s = ie.sds.search(exp.loc, exp.ident, flags);
         /* Check for visibility before resolving aliases because public
          * aliases to private symbols are public.

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -624,7 +624,7 @@ private:
 public:
     ScopeDsymbol* syntaxCopy(Dsymbol* s) override;
     virtual void importScope(Dsymbol* s, Visibility visibility);
-    virtual bool isPackageAccessible(Package* p, Visibility visibility, int32_t flags = 0);
+    virtual bool isPackageAccessible(Package* p, Visibility visibility, uint32_t flags = 0u);
     bool isforwardRef() final override;
     static void multiplyDefined(const Loc& loc, Dsymbol* s1, Dsymbol* s2);
     const char* kind() const override;
@@ -2064,18 +2064,20 @@ struct FieldState final
         {}
 };
 
-enum
+enum class SearchOpt : uint32_t
 {
-    IgnoreNone = 0,
-    IgnorePrivateImports = 1,
-    IgnoreErrors = 2,
-    IgnoreAmbiguous = 4,
-    SearchLocalsOnly = 8,
-    SearchImportsOnly = 16,
-    SearchUnqualifiedModule = 32,
-    IgnoreSymbolVisibility = 128,
-    TagNameSpace = 256,
+    all = 0u,
+    ignorePrivateImports = 1u,
+    ignoreErrors = 2u,
+    ignoreAmbiguous = 4u,
+    localsOnly = 8u,
+    importsOnly = 16u,
+    unqualifiedModule = 32u,
+    tagNameSpace = 64u,
+    ignoreVisibility = 128u,
 };
+
+typedef uint32_t SearchOptFlags;
 
 enum : int32_t { IDX_NOTFOUND = 305419896 };
 
@@ -4784,6 +4786,8 @@ struct ASTCodegen final
     using OverloadSet = ::OverloadSet;
     using PASS = ::PASS;
     using ScopeDsymbol = ::ScopeDsymbol;
+    using SearchOpt = ::SearchOpt;
+    using SearchOptFlags = ::SearchOptFlags;
     using Ungag = ::Ungag;
     using Visibility = ::Visibility;
     using WithScopeSymbol = ::WithScopeSymbol;
@@ -5058,6 +5062,7 @@ struct ASTCodegen final
     typedef Dsymbol* Dsymbol;
     typedef Array<Dsymbol* > Dsymbols;
     typedef Visibility Visibility;
+    typedef SearchOpt SearchOpt;
     typedef PASS PASS;
     ASTCodegen()
     {
@@ -6229,7 +6234,7 @@ public:
     bool rootImports();
     Identifier* searchCacheIdent;
     Dsymbol* searchCacheSymbol;
-    int32_t searchCacheFlags;
+    uint32_t searchCacheFlags;
     bool insearch;
     Module* importedFrom;
     Array<Dsymbol* >* decldefs;
@@ -6253,7 +6258,7 @@ public:
     void importAll(Scope* prevsc) override;
     int32_t needModuleInfo();
     void checkImportDeprecation(const Loc& loc, Scope* sc);
-    bool isPackageAccessible(Package* p, Visibility visibility, int32_t flags = 0) override;
+    bool isPackageAccessible(Package* p, Visibility visibility, uint32_t flags = 0u) override;
     Dsymbol* symtabInsert(Dsymbol* s) override;
     static void runDeferredSemantic();
     static void runDeferredSemantic2();
@@ -6342,7 +6347,7 @@ struct Scope final
     void* anchorCounts;
     Identifier* prevAnchor;
     AliasDeclaration* aliasAsg;
-    Dsymbol* search(const Loc& loc, Identifier* ident, Dsymbol*& pscopesym, int32_t flags = 0);
+    Dsymbol* search(const Loc& loc, Identifier* ident, Dsymbol*& pscopesym, uint32_t flags = 0u);
     Scope() :
         enclosing(),
         _module(),
@@ -6563,7 +6568,7 @@ extern void dsymbolSemantic(Dsymbol* dsym, Scope* sc);
 
 extern void addMember(Dsymbol* dsym, Scope* sc, ScopeDsymbol* sds);
 
-extern Dsymbol* search(Dsymbol* d, const Loc& loc, Identifier* ident, int32_t flags = 0);
+extern Dsymbol* search(Dsymbol* d, const Loc& loc, Identifier* ident, uint32_t flags = 0u);
 
 extern void setScope(Dsymbol* d, Scope* sc);
 

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -88,7 +88,7 @@ public:
 
     Identifier *searchCacheIdent;
     Dsymbol *searchCacheSymbol; // cached value of search
-    int searchCacheFlags;       // cached flags
+    SearchOptFlags searchCacheFlags;       // cached flags
     d_bool insearch;
 
     // module from command line we're imported from,
@@ -123,7 +123,7 @@ public:
     Module *parse();    // syntactic parse
     void importAll(Scope *sc) override;
     int needModuleInfo();
-    bool isPackageAccessible(Package *p, Visibility visibility, int flags = 0) override;
+    bool isPackageAccessible(Package *p, Visibility visibility, SearchOptFlags flags = (SearchOptFlags)SearchOpt::all) override;
     Dsymbol *symtabInsert(Dsymbol *s) override;
     static void runDeferredSemantic();
     static void runDeferredSemantic2();

--- a/compiler/src/dmd/scope.h
+++ b/compiler/src/dmd/scope.h
@@ -130,5 +130,5 @@ struct Scope
     AliasDeclaration *aliasAsg; // if set, then aliasAsg is being assigned a new value,
                                 // do not set wasRead for it
 
-    Dsymbol *search(const Loc &loc, Identifier *ident, Dsymbol **pscopesym, int flags = IgnoreNone);
+    Dsymbol *search(const Loc &loc, Identifier *ident, Dsymbol **pscopesym, SearchOptFlags flags = (SearchOptFlags)SearchOpt::all);
 };

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -228,7 +228,7 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
 
         Type t = s.getType(); // type symbol, type alias, or type tuple?
         uint errorsave = global.errors;
-        int flags = t is null ? SearchLocalsOnly : IgnorePrivateImports;
+        SearchOptFlags flags = t is null ? SearchOpt.localsOnly : SearchOpt.ignorePrivateImports;
 
         Dsymbol sm = s.searchX(loc, sc, id, flags);
         if (sm)
@@ -380,12 +380,12 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
  *  loc = location to print the error messages
  *  sc = the scope where the symbol is located
  *  id = the id of the symbol
- *  flags = the search flags which can be `SearchLocalsOnly` or `IgnorePrivateImports`
+ *  flags = the search flags which can be `SearchLocalsOnly` or `SearchOpt.ignorePrivateImports`
  *
  * Returns:
  *      symbol found, NULL if not
  */
-private Dsymbol searchX(Dsymbol dsym, const ref Loc loc, Scope* sc, RootObject id, int flags)
+private Dsymbol searchX(Dsymbol dsym, const ref Loc loc, Scope* sc, RootObject id, SearchOptFlags flags)
 {
     //printf("Dsymbol::searchX(this=%p,%s, ident='%s')\n", this, toChars(), ident.toChars());
     Dsymbol s = dsym.toAlias();
@@ -1878,7 +1878,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         /* look for pre-existing declaration
          */
         Dsymbol scopesym;
-        auto s = sc2.search(mtype.loc, mtype.id, scopesym, IgnoreErrors | TagNameSpace);
+        auto s = sc2.search(mtype.loc, mtype.id, scopesym, SearchOpt.ignoreErrors | SearchOpt.tagNameSpace);
         if (!s || s.isModule())
         {
             // no pre-existing declaration, so declare it
@@ -3794,8 +3794,8 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
             return e;
         }
 
-        immutable flags = sc.flags & SCOPE.ignoresymbolvisibility ? IgnoreSymbolVisibility : 0;
-        s = mt.sym.search(e.loc, ident, flags | IgnorePrivateImports);
+        immutable flags = sc.flags & SCOPE.ignoresymbolvisibility ? SearchOpt.ignoreVisibility : 0;
+        s = mt.sym.search(e.loc, ident, flags | SearchOpt.ignorePrivateImports);
     L1:
         if (!s)
         {
@@ -4074,8 +4074,8 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
             return e;
         }
 
-        int flags = sc.flags & SCOPE.ignoresymbolvisibility ? IgnoreSymbolVisibility : 0;
-        s = mt.sym.search(e.loc, ident, flags | IgnorePrivateImports);
+        SearchOptFlags flags = sc.flags & SCOPE.ignoresymbolvisibility ? SearchOpt.ignoreVisibility : SearchOpt.all;
+        s = mt.sym.search(e.loc, ident, flags | SearchOpt.ignorePrivateImports);
 
     L1:
         if (!s)
@@ -4723,7 +4723,7 @@ Type getComplexLibraryType(const ref Loc loc, Scope* sc, TY ty)
         return *pt;
     }
 
-    Dsymbol s = mConfig.searchX(Loc.initial, sc, id, IgnorePrivateImports);
+    Dsymbol s = mConfig.searchX(Loc.initial, sc, id, SearchOpt.ignorePrivateImports);
     if (!s)
     {
         error(loc, "`%s` not found in core.stdc.config", id.toChars());

--- a/compiler/test/unit/compilable/searching.d
+++ b/compiler/test/unit/compilable/searching.d
@@ -175,7 +175,7 @@ Dsymbol findSymbol(Dsymbol sym, string name, bool allowMissing = false)
 
     const oldErrors = global.errors;
     Identifier id = Identifier.idPool(name);
-    Dsymbol found = sym.search(Loc.initial, id, IgnoreErrors);
+    Dsymbol found = sym.search(Loc.initial, id, SearchOpt.ignoreErrors);
 
     assert(global.errors == oldErrors, "Searching " ~ name ~ " caused errors!");
     assert(allowMissing || found, name ~ " not found!");


### PR DESCRIPTION
This replaces `int` usage with a specific type - `SearchOptFlags` - for a much more robust and self-documenting implementation.