### PR TITLE
Improve GC performance for multiple threads

### DIFF
--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -160,7 +160,7 @@ class ConservativeGC : GC
 
     Gcx *gcx;                   // implementation
 
-    static gcLock = shared(AlignedSpinLock)(SpinLock.Contention.lengthy);
+    static gcLock = shared(AlignedSpinLock)(SpinLock.Contention.brief);
     static bool _inFinalizer;
     __gshared bool isPrecise = false;
 

--- a/druntime/src/core/internal/spinlock.d
+++ b/druntime/src/core/internal/spinlock.d
@@ -53,9 +53,9 @@ shared struct SpinLock
         import core.time;
         if (k < pauseThresh)
             return core.atomic.pause();
-        else if (k < 32)
+        else // if (k < 32)
             return Thread.yield();
-        Thread.sleep(1.msecs);
+        // Thread.sleep(1.msecs);
     }
 
 private:


### PR DESCRIPTION
When multiple threads try to access the GC (for memory allocation), the SpinLock sleeps for a millisecond after trying to lock the GC a few times. Perhaps the logic is to allow other applications running on the CPU more time to execute. But it results in a situation where multiple threads that are trying to allocate memory, sleep for a millisecond. In certain scenarios, it has a huge adverse impact on the multi-threading performance of D programs.