### PR TITLE
fix Issue 24276 - ImportC: typedef aliases not emitted correctly in .…

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -1899,6 +1899,7 @@ final class CParser(AST) : Parser!AST
                 }
 
                 bool isalias = true;
+                Identifier idt;
                 if (auto ts = dt.isTypeStruct())
                 {
                     if (ts.sym.isAnonymous())
@@ -1908,6 +1909,7 @@ final class CParser(AST) : Parser!AST
                         ts.sym.ident = id;
                         isalias = false;
                     }
+                    idt = ts.sym.ident;
                 }
                 else if (auto te = dt.isTypeEnum())
                 {
@@ -1917,6 +1919,7 @@ final class CParser(AST) : Parser!AST
                         te.sym.ident = id;
                         isalias = false;
                     }
+                    idt = te.sym.ident;
                 }
                 else if (auto tt = dt.isTypeTag())
                 {
@@ -1930,11 +1933,13 @@ final class CParser(AST) : Parser!AST
                         Specifier spec;
                         declareTag(tt, spec);
                     }
+                    idt = tt.id;
                 }
                 if (isalias)
                 {
                     auto ad = new AST.AliasDeclaration(token.loc, id, dt);
-                    ad.adFlags |= ad.hidden; // do not print when generating .di files
+                    if (id == idt)
+                        ad.adFlags |= ad.hidden; // do not print when generating .di files
                     s = ad;
                 }
 

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -22,6 +22,11 @@ extern (C)
 		int x = void;
 	}
 	Foo abc();
+	union S
+	{
+		int x = void;
+	}
+	alias T = S;
 	/+enum int __DATE__ = 1+/;
 	/+enum int __TIME__ = 1+/;
 	/+enum int __TIMESTAMP__ = 1+/;
@@ -48,6 +53,14 @@ struct Foo {
 };
 
 struct Foo abc(void);
+
+// https://issues.dlang.org/show_bug.cgi?id=24276
+
+union S
+{
+     int x;
+};
+typedef S T;
 
 // https://issues.dlang.org/show_bug.cgi?id=24200
 


### PR DESCRIPTION
…di files

As explained in the bugzilla issue, this is only a partial fix. The rest is wontfix, as some C semantics do not translate without herculean efforts. In particular, having the same name in both the regular name space and the tag name space - D does not have a tag name space.