### PR TITLE
Break dependency of compiler/src/dmd/statement.d on gluelayer

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -331,7 +331,6 @@ class InlineAsmStatement;
 class GccAsmStatement;
 class ImportStatement;
 struct Token;
-struct code;
 class Object;
 class TypeInfo_Class;
 class TypeInfo;
@@ -4334,7 +4333,7 @@ public:
 class InlineAsmStatement final : public AsmStatement
 {
 public:
-    code* asmcode;
+    void* asmcode;
     uint32_t asmalign;
     uint32_t regs;
     bool refparam;

--- a/compiler/src/dmd/s2ir.d
+++ b/compiler/src/dmd/s2ir.d
@@ -1378,11 +1378,11 @@ void Statement_toIR(Statement s, ref IRState irs, StmtState* stmtstate)
         block_next(blx,BCgoto,null);
         basm = blx.curblock;
         bpre.appendSucc(basm);
-        basm.Bcode = s.asmcode;
+        basm.Bcode = cast(code*)s.asmcode;
         basm.Balign = cast(ubyte)s.asmalign;
 
         // Loop through each instruction, fixing Dsymbols into Symbol's
-        for (code *c = s.asmcode; c; c = c.next)
+        for (code *c = cast(code*)s.asmcode; c; c = c.next)
         {
             switch (c.IFL1)
             {

--- a/compiler/src/dmd/statement.d
+++ b/compiler/src/dmd/statement.d
@@ -20,7 +20,6 @@ import dmd.arraytypes;
 import dmd.astenums;
 import dmd.ast_node;
 import dmd.errors;
-import dmd.gluelayer;
 import dmd.cond;
 import dmd.declaration;
 import dmd.dsymbol;
@@ -1773,7 +1772,7 @@ extern (C++) class AsmStatement : Statement
  */
 extern (C++) final class InlineAsmStatement : AsmStatement
 {
-    code* asmcode;
+    void* asmcode;
     uint asmalign;  // alignment of this statement
     uint regs;      // mask of registers modified (must match regm_t in back end)
     bool refparam;  // true if function parameter is referenced

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -716,7 +716,7 @@ public:
 class InlineAsmStatement final : public AsmStatement
 {
 public:
-    code *asmcode;
+    void *asmcode;
     unsigned asmalign;          // alignment of this statement
     unsigned regs;              // mask of registers modified (must match regm_t in back end)
     d_bool refparam;              // true if function parameter is referenced


### PR DESCRIPTION
@WalterBright this is one approach to breaking the dependency of the frontend on the gluelayer.

@ibuclaw @kinke is this workable on your side or is there anything else that I need to do?