### PR TITLE
Azure CI: Migrate from legacy MODEL=32mscoff to MODEL=32

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         x64:
-          OS: Win_64
           MODEL: 64
           ARCH: x64
     steps:
@@ -29,11 +28,9 @@ jobs:
     strategy:
       matrix:
         x64:
-          OS: Win_64
           MODEL: 64
           ARCH: x64
         x86-OMF:
-          OS: Win_32
           MODEL: 32omf
           ARCH: x86
     steps:
@@ -52,13 +49,11 @@ jobs:
     strategy:
       matrix:
         x64:
-          OS: Win_64
           MODEL: 64
           ARCH: x64
 
         # x64 only because 32bit causes weird linker errors for several tests???
         # x86-OMF:
-        #   OS: Win_32
         #   MODEL: 32omf
         #   ARCH: x86
     steps:
@@ -75,17 +70,14 @@ jobs:
     strategy:
       matrix:
         x64_Debug:
-          OS: Win_64
           MODEL: 64
           ARCH: x64
           CONFIGURATION: Debug
         x86-mscoff:
-          OS: Win_32
-          MODEL: 32mscoff
+          MODEL: 32
           ARCH: x86
         x86-mscoff_MinGW:
-          OS: Win_32
-          MODEL: 32mscoff
+          MODEL: 32
           ARCH: x86
           C_RUNTIME: mingw
     steps:

--- a/compiler/test/README.md
+++ b/compiler/test/README.md
@@ -204,6 +204,7 @@ Valid platforms:
 Valid models:
 - 32
 - 32mscoff  (windows only)
+- 32omf  (windows only)
 - 64
 
 Note that test parameters *MUST* be followed by a colon (intermediate whitespace is allowed).
@@ -423,7 +424,7 @@ depend on the current platform and target:
 
                     Supported conditions:
                     - OS: posix, windows, ...
-                    - Model: 64, 32mscoff and 32 (also matches 32mscoff)
+                    - Model: 64, 32mscoff, 32omf and 32 (also matches 32mscoff + 32omf)
 
     $r:<regex>$     any text matching <regex> (using $ inside of <regex> is not
                     supported, use multiple regexes instead)

--- a/compiler/test/runnable/test23011.c
+++ b/compiler/test/runnable/test23011.c
@@ -1,4 +1,4 @@
-/* DISABLED: win32 win32mscoff win64 osx32 osx64
+/* DISABLED: win osx
  */
 
 /* https://issues.dlang.org/show_bug.cgi?id=23011


### PR DESCRIPTION
Incl. fixing up the `d_do_test.d` tool to work properly with `MODEL=32` on Windows.

And somewhat improve the documentation of `MODEL=32omf`, nowadays used for the 32-bit OMF toolchain.