### PR TITLE
fix Issue 23629 - importC: Need to support code coverage analysis

### DIFF
--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -672,9 +672,12 @@ private void genObjFile(Module m, bool multiobj)
      /* Generate module info for templates and -cov.
      *  Don't generate ModuleInfo if `object.ModuleInfo` is not declared or
      *  explicitly disabled through compiler switches such as `-betterC`.
-     *  Don't generate ModuleInfo for C files.
+     *  Don't generate ModuleInfo for C files unless coverage testing,
+     *  although a D main needs to be present in order to pull in the druntime
+     *  code to actually generate the coverage report.
      */
-    if (global.params.useModuleInfo && Module.moduleinfo && m.filetype != FileType.c/*|| needModuleInfo()*/)
+    if (global.params.useModuleInfo && Module.moduleinfo &&
+        (global.params.cov || m.filetype != FileType.c) /*|| needModuleInfo()*/)
         genModuleInfo(m);
 
     objmod.termfile();

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -172,8 +172,9 @@ extern (D) elem *incUsageElem(ref IRState irs, const ref Loc loc)
     uint linnum = loc.linnum;
 
     Module m = cast(Module)irs.blx._module;
+    //printf("m.cov %p linnum %d filename %s srcfile %s\n", m.cov, linnum, loc.filename, m.srcfile.toChars());
     if (!m.cov || !linnum ||
-        loc.filename != m.srcfile.toChars())
+        strcmp(loc.filename, m.srcfile.toChars()))
         return null;
 
     //printf("cov = %p, covb = %p, linnum = %u\n", m.cov, m.covb.ptr, p, linnum);

--- a/compiler/test/runnable/cov2.d
+++ b/compiler/test/runnable/cov2.d
@@ -50,6 +50,17 @@ void test3()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=24264
+// EXTRA_SOURCES: imports/ccov2.c
+
+import ccov2;
+
+int test24264()
+{
+    return def();
+}
+
+/***************************************************/
 
 int main(string[] args)
 {
@@ -57,5 +68,6 @@ int main(string[] args)
     test1();
     test2();
     test3();
+    test24264();
     return 0;
 }

--- a/compiler/test/runnable/extra-files/runnable-cov2.lst
+++ b/compiler/test/runnable/extra-files/runnable-cov2.lst
@@ -50,6 +50,17 @@
         |}
         |
         |/***************************************************/
+        |// https://issues.dlang.org/show_bug.cgi?id=24264
+        |// EXTRA_SOURCES: imports/ccov2.c
+        |
+        |import ccov2;
+        |
+        |int test24264()
+        |{
+       1|    return def();
+        |}
+        |
+        |/***************************************************/
         |
         |int main(string[] args)
         |{
@@ -57,5 +68,6 @@
        1|    test1();
        1|    test2();
        1|    test3();
+       1|    test24264();
        1|    return 0;
         |}

--- a/compiler/test/runnable/imports/ccov2.c
+++ b/compiler/test/runnable/imports/ccov2.c
@@ -1,0 +1,7 @@
+int def()
+{
+    int i;
+    for (i = 0; i < 10; ++i)
+	;
+    return i;
+}


### PR DESCRIPTION
It'll work now, but only if there's a D main somewhere to pull in the coverage generator. It won't work with a 100% C program. For the latter one is better off just using the coverage analyzer in the associated C compiler.