### PR TITLE
fix Issue 22483 - DMD generates invalid string sections that work by coincidence

### DIFF
--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -609,8 +609,8 @@ int ElfObj_string_literal_segment(uint sz)
      */
     static immutable char[4][3] name = [ "1.1", "2.2", "4.4" ];
     const int i = (sz == 4) ? 2 : sz - 1;
-    const IDXSEC seg =
-        ElfObj_getsegment(".rodata.str".ptr, name[i].ptr, SHT_PROGBITS, SHF_ALLOC | SHF_MERGE | SHF_STRINGS, sz);
+    // FIXME: can't use SHF_MERGE | SHF_STRINGS because of https://issues.dlang.org/show_bug.cgi?id=22483
+    const IDXSEC seg = ElfObj_getsegment(".rodata.str".ptr, name[i].ptr, SHT_PROGBITS, SHF_ALLOC, sz);
     return seg;
 }
 


### PR DESCRIPTION
DMD generates bogus ".rodata.str" segment, which isn't really mergeable by proper linkers and this trips https://github.com/rui314/mold linker up. As a workaround, just don't set the SHF_MERGE | SHF_STRINGS flags.

This patch seems to fix the problem, but I have only done some limited tests so far. It's important to address this issue because `mold` is the current linking speed champion and this makes it a good companion for `dmd`.

See https://github.com/rui314/mold/issues/126 and https://issues.dlang.org/show_bug.cgi?id=22483 for more information.