### PR TITLE
Fix Issue 22014 - Make core.stdc.stddef.wchar_t match C++ mangling

### DIFF
--- a/compiler/test/compilable/cppmangle.d
+++ b/compiler/test/compilable/cppmangle.d
@@ -1131,11 +1131,7 @@ else version (CppMangle_Itanium)
 // https://issues.dlang.org/show_bug.cgi?id=18958
 // Issue 18958 - extern(C++) wchar, dchar mangling not correct
 
-version (Posix)
-    enum __c_wchar_t : dchar;
-else version (Windows)
-    enum __c_wchar_t : wchar;
-alias wchar_t = __c_wchar_t;
+import core.stdc.stddef : wchar_t;
 extern (C++) void test_char_mangling(char, wchar, dchar, wchar_t);
 version (CppMangle_Itanium)
 {

--- a/compiler/test/runnable_cxx/cpp_abi_tests.d
+++ b/compiler/test/runnable_cxx/cpp_abi_tests.d
@@ -4,11 +4,7 @@
 // N.B MSVC doesn't have a C++11 switch, but it defaults to the latest fully-supported standard
 // N.B MSVC 2013 doesn't support char16_t/char32_t
 
-version(Posix)
-    enum __c_wchar_t : dchar;
-else version(Windows)
-    enum __c_wchar_t : wchar;
-alias wchar_t = __c_wchar_t;
+import core.stdc.stddef : wchar_t;
 
 extern(C++) {
 

--- a/compiler/test/runnable_cxx/cppa.d
+++ b/compiler/test/runnable_cxx/cppa.d
@@ -15,6 +15,7 @@ import core.stdc.stdio;
 import core.stdc.stdarg;
 import core.stdc.config;
 import core.stdc.stdint;
+import core.stdc.stddef;
 
 extern (C++)
         int foob(int i, int j, int k);
@@ -555,15 +556,6 @@ void test13289()
     assert(f13289_cpp_test());
 }
 
-version(Posix)
-{
-    enum __c_wchar_t : dchar;
-}
-else version(Windows)
-{
-    enum __c_wchar_t : wchar;
-}
-alias wchar_t = __c_wchar_t;
 extern(C++)
 {
     bool f13289_cpp_test();

--- a/druntime/src/core/stdc/config.d
+++ b/druntime/src/core/stdc/config.d
@@ -259,6 +259,21 @@ else
     alias cpp_ptrdiff_t = ptrdiff_t;
 }
 
+version (Windows)
+{
+    enum __c_wchar_t : wchar;
+
+    alias c_wchar_t = wchar;
+    alias cpp_wchar_t = __c_wchar_t;
+}
+else
+{
+    enum __c_wchar_t : dchar;
+
+    alias c_wchar_t = dchar;
+    alias cpp_wchar_t = __c_wchar_t;
+}
+
 /** ABI layout of native complex types.
  */
 struct _Complex(T)

--- a/druntime/src/core/stdc/stddef.d
+++ b/druntime/src/core/stdc/stddef.d
@@ -14,6 +14,8 @@
 
 module core.stdc.stddef;
 
+import core.stdc.config;
+
 extern (C):
 @trusted: // Types only.
 nothrow:
@@ -24,18 +26,5 @@ alias nullptr_t = typeof(null);
 
 // size_t and ptrdiff_t are defined in the object module.
 
-version (Windows)
-{
-    ///
-    alias wchar wchar_t;
-}
-else version (Posix)
-{
-    ///
-    alias dchar wchar_t;
-}
-else version (WASI)
-{
-    ///
-    alias dchar wchar_t;
-}
+///
+alias wchar_t = cpp_wchar_t;


### PR DESCRIPTION
Just like we already do in `core.stdc.stdint`.