### PR TITLE
Fix 24286 - String literals not merged by linker because of wrong ELF output

### DIFF
--- a/compiler/test/runnable/imports/string_literal_merge_imp.d
+++ b/compiler/test/runnable/imports/string_literal_merge_imp.d
@@ -1,0 +1,1 @@
+extern(C) string getHello() { return "hello"; }

--- a/compiler/test/runnable/string_literal_merge.d
+++ b/compiler/test/runnable/string_literal_merge.d
@@ -1,0 +1,14 @@
+/**
+COMPILE_SEPARATELY:
+EXTRA_SOURCES: imports/string_literal_merge_imp.d
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=24286
+
+extern(C) string getHello();
+
+extern(C) int main()
+{
+    assert(getHello.ptr == "hello".ptr);
+    return 0;
+}


### PR DESCRIPTION
See https://github.com/dlang/dmd/pull/15915 for context

Doesn't work yet, the test still fails