### PR TITLE
CI: Reduce parallelism on Windows from N=3 to N=2

### DIFF
--- a/.azure-pipelines/lib.sh
+++ b/.azure-pipelines/lib.sh
@@ -2,7 +2,7 @@
 
 CURL_USER_AGENT="DMD-CI $(curl --version | head -n 1)"
 DMD_DIR="$PWD"
-N=$(($(nproc)+1))
+N=$(nproc)
 
 clone() {
     local url="$1"

--- a/.azure-pipelines/windows-msbuild.bat
+++ b/.azure-pipelines/windows-msbuild.bat
@@ -17,7 +17,7 @@ if "%ARCH%"=="x64" set MODEL=64
 set DMD=%DMD_DIR%\generated\Windows\%CONFIGURATION%\%PLATFORM%\dmd.exe
 
 set VISUALD_INSTALLER=VisualD-%VISUALD_VER%.exe
-set N=3
+set N=2
 set LDC_DIR=%DMD_DIR%\ldc2-%LDC_VERSION%-windows-multilib
 
 if "%D_COMPILER%" == "ldc" set HOST_DMD=%LDC_DIR%\bin\ldmd2.exe


### PR DESCRIPTION
As the runners have 2 CPU cores and there's a slight OOM risk, e.g.: https://dev.azure.com/dlanguage/dmd/_build/results?buildId=40094&view=logs&jobId=6775e4b2-0d76-5db7-9bcd-015c7821c824&j=6775e4b2-0d76-5db7-9bcd-015c7821c824&t=1bf40372-f529-586c-b834-12b53d9adf74