### PR TITLE
make toChars(Type) work

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7996,6 +7996,8 @@ extern Expression* modifiableLvalue(Expression* _this, Scope* sc);
 
 extern const char* toChars(const Initializer* const i);
 
+extern const char* toChars(const Type* const t);
+
 extern void json_generate(Array<Module* >& modules, OutBuffer& buf);
 
 extern JsonFieldFlags tryParseJsonField(const char* fieldName);

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -116,6 +116,17 @@ public extern (C++) const(char)* toChars(const Initializer i)
     return buf.extractChars();
 }
 
+public extern (C++) const(char)* toChars(const Type t)
+{
+    OutBuffer buf;
+    buf.reserve(16);
+    HdrGenState hgs;
+    hgs.fullQual = (t.ty == Tclass && !t.mod);
+
+    toCBuffer(t, buf, null, hgs);
+    return buf.extractChars();
+}
+
 public const(char)[] toString(const Initializer i)
 {
     OutBuffer buf;

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -525,13 +525,7 @@ extern (C++) abstract class Type : ASTNode
      */
     final override const(char)* toChars() const
     {
-        OutBuffer buf;
-        buf.reserve(16);
-        HdrGenState hgs;
-        hgs.fullQual = (ty == Tclass && !mod);
-
-        toCBuffer(this, buf, null, hgs);
-        return buf.extractChars();
+	return dmd.hdrgen.toChars(this);
     }
 
     /// ditto

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -39,6 +39,7 @@ typedef union tree_node type;
 typedef struct TYPE type;
 #endif
 
+extern const char* toChars(const Type* const t);
 Type *typeSemantic(Type *t, const Loc &loc, Scope *sc);
 Type *merge(Type *type);
 


### PR DESCRIPTION
Gradually move towards toChars() being an overloaded function rather than a member function.