### PR TITLE
eliminate dependence on global.params.dihdr.fullOutput

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4051,6 +4051,7 @@ struct HdrGenState final
     bool ddoc;
     bool fullDump;
     bool importcHdr;
+    bool doFuncBodies;
     bool fullQual;
     int32_t tpltMember;
     int32_t autoMember;
@@ -4064,6 +4065,7 @@ struct HdrGenState final
         ddoc(),
         fullDump(),
         importcHdr(),
+        doFuncBodies(),
         fullQual(),
         tpltMember(),
         autoMember(),
@@ -4074,11 +4076,12 @@ struct HdrGenState final
         inEnumDecl()
     {
     }
-    HdrGenState(bool hdrgen, bool ddoc = false, bool fullDump = false, bool importcHdr = false, bool fullQual = false, int32_t tpltMember = 0, int32_t autoMember = 0, int32_t forStmtInit = 0, int32_t insideFuncBody = 0, int32_t insideAggregate = 0, bool declstring = false, EnumDeclaration* inEnumDecl = nullptr) :
+    HdrGenState(bool hdrgen, bool ddoc = false, bool fullDump = false, bool importcHdr = false, bool doFuncBodies = false, bool fullQual = false, int32_t tpltMember = 0, int32_t autoMember = 0, int32_t forStmtInit = 0, int32_t insideFuncBody = 0, int32_t insideAggregate = 0, bool declstring = false, EnumDeclaration* inEnumDecl = nullptr) :
         hdrgen(hdrgen),
         ddoc(ddoc),
         fullDump(fullDump),
         importcHdr(importcHdr),
+        doFuncBodies(doFuncBodies),
         fullQual(fullQual),
         tpltMember(tpltMember),
         autoMember(autoMember),
@@ -4092,7 +4095,7 @@ struct HdrGenState final
 
 enum : int32_t { TEST_EMIT_ALL = 0 };
 
-extern void genhdrfile(Module* m, OutBuffer& buf);
+extern void genhdrfile(Module* m, bool doFuncBodies, OutBuffer& buf);
 
 extern void moduleToBuffer(OutBuffer& buf, Module* m);
 

--- a/compiler/src/dmd/hdrgen.h
+++ b/compiler/src/dmd/hdrgen.h
@@ -15,7 +15,7 @@
 
 class Module;
 
-void genhdrfile(Module *m, OutBuffer &buf);
+void genhdrfile(Module *m, bool doFuncBodies, OutBuffer &buf);
 void genCppHdrFiles(Modules &ms);
 void moduleToBuffer(OutBuffer& buf, Module *m);
 const char *parametersTypeToChars(ParameterList pl);

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -448,7 +448,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
                 message("import    %s", m.toChars());
 
             buf.reset();         // reuse the buffer
-            genhdrfile(m, buf);
+            genhdrfile(m, params.dihdr.fullOutput, buf);
             if (!writeFile(m.loc, m.hdrfile.toString(), buf[]))
                 fatal();
         }


### PR DESCRIPTION
I am to eliminate all dependence on global variables in hdrgen.d