### PR TITLE
eliminate dependence on global.params.dihdr.vcg_ast

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -4052,6 +4052,7 @@ struct HdrGenState final
     bool fullDump;
     bool importcHdr;
     bool doFuncBodies;
+    bool vcg_ast;
     bool fullQual;
     int32_t tpltMember;
     int32_t autoMember;
@@ -4066,6 +4067,7 @@ struct HdrGenState final
         fullDump(),
         importcHdr(),
         doFuncBodies(),
+        vcg_ast(),
         fullQual(),
         tpltMember(),
         autoMember(),
@@ -4076,12 +4078,13 @@ struct HdrGenState final
         inEnumDecl()
     {
     }
-    HdrGenState(bool hdrgen, bool ddoc = false, bool fullDump = false, bool importcHdr = false, bool doFuncBodies = false, bool fullQual = false, int32_t tpltMember = 0, int32_t autoMember = 0, int32_t forStmtInit = 0, int32_t insideFuncBody = 0, int32_t insideAggregate = 0, bool declstring = false, EnumDeclaration* inEnumDecl = nullptr) :
+    HdrGenState(bool hdrgen, bool ddoc = false, bool fullDump = false, bool importcHdr = false, bool doFuncBodies = false, bool vcg_ast = false, bool fullQual = false, int32_t tpltMember = 0, int32_t autoMember = 0, int32_t forStmtInit = 0, int32_t insideFuncBody = 0, int32_t insideAggregate = 0, bool declstring = false, EnumDeclaration* inEnumDecl = nullptr) :
         hdrgen(hdrgen),
         ddoc(ddoc),
         fullDump(fullDump),
         importcHdr(importcHdr),
         doFuncBodies(doFuncBodies),
+        vcg_ast(vcg_ast),
         fullQual(fullQual),
         tpltMember(tpltMember),
         autoMember(autoMember),
@@ -4097,7 +4100,7 @@ enum : int32_t { TEST_EMIT_ALL = 0 };
 
 extern void genhdrfile(Module* m, bool doFuncBodies, OutBuffer& buf);
 
-extern void moduleToBuffer(OutBuffer& buf, Module* m);
+extern void moduleToBuffer(OutBuffer& buf, bool vcg_ast, Module* m);
 
 extern const char* parametersTypeToChars(ParameterList pl);
 

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -61,6 +61,7 @@ struct HdrGenState
     bool fullDump;      /// true if generating a full AST dump file
     bool importcHdr;    /// true if generating a .di file from an ImportC file
     bool doFuncBodies;  /// include function bodies in output
+    bool vcg_ast;       /// write out codegen-ast
 
     bool fullQual;      /// fully qualify types when printing
     int tpltMember;
@@ -131,12 +132,14 @@ public const(char)[] toString(const Initializer i)
  * Dumps the full contents of module `m` to `buf`.
  * Params:
  *   buf = buffer to write to.
+ *   vcg_ast = write out codegen ast
  *   m = module to visit all members of.
  */
-extern (C++) void moduleToBuffer(ref OutBuffer buf, Module m)
+extern (C++) void moduleToBuffer(ref OutBuffer buf, bool vcg_ast, Module m)
 {
     HdrGenState hgs;
     hgs.fullDump = true;
+    hgs.vcg_ast = vcg_ast;
     toCBuffer(m, buf, hgs);
 }
 
@@ -2475,7 +2478,7 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, HdrGenState*
 
     void visitLoweredAssignExp(LoweredAssignExp e)
     {
-        if (global.params.vcg_ast)
+        if (hgs.vcg_ast)
         {
             expressionToBuffer(e.lowering, buf, hgs);
             return;

--- a/compiler/src/dmd/hdrgen.h
+++ b/compiler/src/dmd/hdrgen.h
@@ -17,5 +17,5 @@ class Module;
 
 void genhdrfile(Module *m, bool doFuncBodies, OutBuffer &buf);
 void genCppHdrFiles(Modules &ms);
-void moduleToBuffer(OutBuffer& buf, Module *m);
+void moduleToBuffer(OutBuffer& buf, bool vcg_ast, Module *m);
 const char *parametersTypeToChars(ParameterList pl);

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -589,7 +589,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         {
             auto buf = OutBuffer();
             buf.doindent = 1;
-            moduleToBuffer(buf, mod);
+            moduleToBuffer(buf, params.vcg_ast, mod);
 
             // write the output to $(filename).cg
             auto cgFilename = FileName.addExt(mod.srcfile.toString(), "cg");


### PR DESCRIPTION
another global reference removed from hdrgen.d