### PR TITLE
hdrgen.d public functions use ref HdrGenState

### DIFF
--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -1296,7 +1296,7 @@ void toDocBuffer(Dsymbol s, ref OutBuffer buf, Scope* sc)
                 Type origType = d.originalType ? d.originalType : d.type;
                 if (origType.ty == Tfunction)
                 {
-                    functionToBufferFull(cast(TypeFunction)origType, *buf, d.ident, &hgs, td);
+                    functionToBufferFull(cast(TypeFunction)origType, *buf, d.ident, hgs, td);
                 }
                 else
                     toCBuffer(origType, *buf, d.ident, hgs);

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -4096,7 +4096,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
                     auto fd = s.isFuncDeclaration();
                     functionToBufferFull(cast(TypeFunction)(funcdecl.type), buf,
-                        new Identifier(funcdecl.toPrettyChars()), &hgs, null);
+                        new Identifier(funcdecl.toPrettyChars()), hgs, null);
                     const(char)* funcdeclToChars = buf.peekChars();
 
                     if (fd)
@@ -4119,7 +4119,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         else
                         {
                             functionToBufferFull(cast(TypeFunction)(fd.type), buf1,
-                                new Identifier(fd.toPrettyChars()), &hgs, null);
+                                new Identifier(fd.toPrettyChars()), hgs, null);
 
                             error(funcdecl.loc, "function `%s` does not override any function, did you mean to override `%s`?",
                                 funcdeclToChars, buf1.peekChars());

--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -456,7 +456,7 @@ string prettyPrint(Module m)
     auto buf = OutBuffer();
     buf.doindent = 1;
     HdrGenState hgs = { fullDump: 1 };
-    moduleToBuffer2(m, buf, &hgs);
+    moduleToBuffer2(m, buf, hgs);
 
     import std.string : replace, fromStringz;
     import std.exception : assumeUnique;

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -140,14 +140,14 @@ extern (C++) void moduleToBuffer(ref OutBuffer buf, Module m)
     toCBuffer(m, buf, hgs);
 }
 
-void moduleToBuffer2(Module m, ref OutBuffer buf, HdrGenState* hgs)
+void moduleToBuffer2(Module m, ref OutBuffer buf, ref HdrGenState hgs)
 {
     if (m.md)
     {
         if (m.userAttribDecl)
         {
             buf.writestring("@(");
-            argsToBuffer(m.userAttribDecl.atts, buf, hgs);
+            argsToBuffer(m.userAttribDecl.atts, buf, &hgs);
             buf.writeByte(')');
             buf.writenl();
         }
@@ -156,7 +156,7 @@ void moduleToBuffer2(Module m, ref OutBuffer buf, HdrGenState* hgs)
             if (m.md.msg)
             {
                 buf.writestring("deprecated(");
-                m.md.msg.expressionToBuffer(buf, hgs);
+                m.md.msg.expressionToBuffer(buf, &hgs);
                 buf.writestring(") ");
             }
             else
@@ -170,7 +170,7 @@ void moduleToBuffer2(Module m, ref OutBuffer buf, HdrGenState* hgs)
 
     foreach (s; *m.members)
     {
-        s.dsymbolToBuffer(buf, hgs);
+        s.dsymbolToBuffer(buf, &hgs);
     }
 }
 
@@ -1363,7 +1363,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
             assert(fd.type);
             if (stcToBuffer(buf, fd.storage_class))
                 buf.writeByte(' ');
-            functionToBufferFull(cast(TypeFunction)fd.type, buf, d.ident, &hgs, d);
+            functionToBufferFull(cast(TypeFunction)fd.type, buf, d.ident, hgs, d);
             visitTemplateConstraint(d.constraint);
             hgs.tpltMember++;
             bodyToBuffer(fd);
@@ -1877,7 +1877,7 @@ void toCBuffer(Dsymbol s, ref OutBuffer buf, ref HdrGenState hgs)
 
     void visitModule(Module m)
     {
-        moduleToBuffer2(m, buf, &hgs);
+        moduleToBuffer2(m, buf, hgs);
     }
 
     extern (C++)
@@ -3258,10 +3258,10 @@ extern (D) string visibilityToString(Visibility.Kind kind) nothrow pure @safe
 }
 
 // Print the full function signature with correct ident, attributes and template args
-void functionToBufferFull(TypeFunction tf, ref OutBuffer buf, const Identifier ident, HdrGenState* hgs, TemplateDeclaration td)
+void functionToBufferFull(TypeFunction tf, ref OutBuffer buf, const Identifier ident, ref HdrGenState hgs, TemplateDeclaration td)
 {
     //printf("TypeFunction::toCBuffer() this = %p\n", this);
-    visitFuncIdentWithPrefix(tf, ident, td, buf, hgs);
+    visitFuncIdentWithPrefix(tf, ident, td, buf, &hgs);
 }
 
 // ident is inserted before the argument list and will be "function" or "delegate" for a type


### PR DESCRIPTION
instead of C-style pointers.