### PR TITLE
oneMember() should use out for ps

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -100,13 +100,13 @@ struct ASTBase
             return ident ? ident.toChars() : "__anonymous";
         }
 
-        bool oneMember(Dsymbol *ps, Identifier ident)
+        bool oneMember(out Dsymbol ps, Identifier ident)
         {
-            *ps = this;
+            ps = this;
             return true;
         }
 
-        extern (D) static bool oneMembers(ref Dsymbols members, Dsymbol* ps, Identifier ident)
+        extern (D) static bool oneMembers(ref Dsymbols members, out Dsymbol ps, Identifier ident)
         {
             Dsymbol s = null;
             for (size_t i = 0; i < members.length; i++)
@@ -115,21 +115,21 @@ struct ASTBase
                 bool x = sx.oneMember(ps, ident);
                 if (!x)
                 {
-                    assert(*ps is null);
+                    assert(ps is null);
                     return false;
                 }
-                if (*ps)
+                if (ps)
                 {
                     assert(ident);
-                    if (!(*ps).ident || !(*ps).ident.equals(ident))
+                    if (!ps.ident || !ps.ident.equals(ident))
                         continue;
                     if (!s)
-                        s = *ps;
-                    else if (s.isOverloadable() && (*ps).isOverloadable())
+                        s = ps;
+                    else if (s.isOverloadable() && ps.isOverloadable())
                     {
                         // keep head of overload set
                         FuncDeclaration f1 = s.isFuncDeclaration();
-                        FuncDeclaration f2 = (*ps).isFuncDeclaration();
+                        FuncDeclaration f2 = ps.isFuncDeclaration();
                         if (f1 && f2)
                         {
                             for (; f1 != f2; f1 = f1.overnext0)
@@ -144,13 +144,13 @@ struct ASTBase
                     }
                     else // more than one symbol
                     {
-                        *ps = null;
+                        ps = null;
                         //printf("\tfalse 2\n");
                         return false;
                     }
                 }
             }
-            *ps = s;
+            ps = s;
             return true;
         }
 
@@ -928,7 +928,7 @@ struct ASTBase
             if (members && ident)
             {
                 Dsymbol s;
-                if (Dsymbol.oneMembers(*members, &s, ident) && s)
+                if (Dsymbol.oneMembers(*members, s, ident) && s)
                 {
                     onemember = s;
                     s.parent = this;

--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -137,7 +137,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         return "attribute";
     }
 
-    override bool oneMember(Dsymbol* ps, Identifier ident)
+    override bool oneMember(out Dsymbol ps, Identifier ident)
     {
         Dsymbols* d = include(null);
         return Dsymbol.oneMembers(d, ps, ident);
@@ -225,10 +225,10 @@ extern (C++) class StorageClassDeclaration : AttribDeclaration
             sc.visibility, sc.explicitVisibility, sc.aligndecl, sc.inlining);
     }
 
-    override final bool oneMember(Dsymbol* ps, Identifier ident)
+    override final bool oneMember(out Dsymbol ps, Identifier ident)
     {
         bool t = Dsymbol.oneMembers(decl, ps, ident);
-        if (t && *ps)
+        if (t && ps)
         {
             /* This is to deal with the following case:
              * struct Tick {
@@ -238,7 +238,7 @@ extern (C++) class StorageClassDeclaration : AttribDeclaration
              * before the semantic analysis of 'to', so that template overloading based on the
              * 'this' pointer can be successful.
              */
-            FuncDeclaration fd = (*ps).isFuncDeclaration();
+            FuncDeclaration fd = ps.isFuncDeclaration();
             if (fd)
             {
                 /* Use storage_class2 instead of storage_class otherwise when we do .di generation
@@ -743,7 +743,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
         return new ConditionalDeclaration(loc, condition.syntaxCopy(), Dsymbol.arraySyntaxCopy(decl), Dsymbol.arraySyntaxCopy(elsedecl));
     }
 
-    override final bool oneMember(Dsymbol* ps, Identifier ident)
+    override final bool oneMember(out Dsymbol ps, Identifier ident)
     {
         //printf("ConditionalDeclaration::oneMember(), inc = %d\n", condition.inc);
         if (condition.inc != Include.notComputed)
@@ -753,8 +753,8 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
         }
         else
         {
-            bool res = (Dsymbol.oneMembers(decl, ps, ident) && *ps is null && Dsymbol.oneMembers(elsedecl, ps, ident) && *ps is null);
-            *ps = null;
+            bool res = (Dsymbol.oneMembers(decl, ps, ident) && ps is null && Dsymbol.oneMembers(elsedecl, ps, ident) && ps is null);
+            ps = null;
             return res;
         }
     }
@@ -901,7 +901,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
             Dsymbol.arraySyntaxCopy(decl));
     }
 
-    override bool oneMember(Dsymbol* ps, Identifier ident)
+    override bool oneMember(out Dsymbol ps, Identifier ident)
     {
         // Required to support IFTI on a template that contains a
         // `static foreach` declaration.  `super.oneMember` calls
@@ -912,7 +912,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
         {
             return super.oneMember(ps, ident);
         }
-        *ps = null; // a `static foreach` declaration may in general expand to multiple symbols
+        ps = null; // a `static foreach` declaration may in general expand to multiple symbols
         return false;
     }
 

--- a/compiler/src/dmd/attrib.h
+++ b/compiler/src/dmd/attrib.h
@@ -28,7 +28,7 @@ public:
     virtual Scope *newScope(Scope *sc);
     void addComment(const utf8_t *comment) override;
     const char *kind() const override;
-    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     bool hasPointers() override final;
     bool hasStaticCtorOrDtor() override final;
     void checkCtorConstInit() override final;
@@ -44,7 +44,7 @@ public:
 
     StorageClassDeclaration *syntaxCopy(Dsymbol *s) override;
     Scope *newScope(Scope *sc) override;
-    bool oneMember(Dsymbol **ps, Identifier *ident) override final;
+    bool oneMember(Dsymbol *&ps, Identifier *ident) override final;
     StorageClassDeclaration *isStorageClassDeclaration() override { return this; }
 
     void accept(Visitor *v) override { v->visit(this); }
@@ -153,7 +153,7 @@ public:
     Dsymbols *elsedecl; // array of Dsymbol's for else block
 
     ConditionalDeclaration *syntaxCopy(Dsymbol *s) override;
-    bool oneMember(Dsymbol **ps, Identifier *ident) override final;
+    bool oneMember(Dsymbol *&ps, Identifier *ident) override final;
     Dsymbols *include(Scope *sc) override;
     void addComment(const utf8_t *comment) override final;
     void accept(Visitor *v) override { v->visit(this); }
@@ -183,7 +183,7 @@ public:
     Dsymbols *cache;
 
     StaticForeachDeclaration *syntaxCopy(Dsymbol *s) override;
-    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     Dsymbols *include(Scope *sc) override;
     void addComment(const utf8_t *comment) override;
     const char *kind() const override;

--- a/compiler/src/dmd/denum.d
+++ b/compiler/src/dmd/denum.d
@@ -83,7 +83,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         return ed;
     }
 
-    override bool oneMember(Dsymbol* ps, Identifier ident)
+    override bool oneMember(out Dsymbol ps, Identifier ident)
     {
         if (isAnonymous())
             return Dsymbol.oneMembers(members, ps, ident);

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -845,27 +845,27 @@ extern (C++) class Dsymbol : ASTNode
     /**************************************
      * Determine if this symbol is only one.
      * Returns:
-     *      false, *ps = NULL: There are 2 or more symbols
-     *      true,  *ps = NULL: There are zero symbols
-     *      true,  *ps = symbol: The one and only one symbol
+     *      false, ps = null: There are 2 or more symbols
+     *      true,  ps = null: There are zero symbols
+     *      true,  ps = symbol: The one and only one symbol
      */
-    bool oneMember(Dsymbol* ps, Identifier ident)
+    bool oneMember(out Dsymbol ps, Identifier ident)
     {
         //printf("Dsymbol::oneMember()\n");
-        *ps = this;
+        ps = this;
         return true;
     }
 
     /*****************************************
      * Same as Dsymbol::oneMember(), but look at an array of Dsymbols.
      */
-    extern (D) static bool oneMembers(Dsymbols* members, Dsymbol* ps, Identifier ident)
+    extern (D) static bool oneMembers(Dsymbols* members, out Dsymbol ps, Identifier ident)
     {
         //printf("Dsymbol::oneMembers() %d\n", members ? members.length : 0);
         Dsymbol s = null;
         if (!members)
         {
-            *ps = null;
+            ps = null;
             return true;
         }
 
@@ -877,21 +877,21 @@ extern (C++) class Dsymbol : ASTNode
             if (!x)
             {
                 //printf("\tfalse 1\n");
-                assert(*ps is null);
+                assert(ps is null);
                 return false;
             }
-            if (*ps)
+            if (ps)
             {
                 assert(ident);
-                if (!(*ps).ident || !(*ps).ident.equals(ident))
+                if (!ps.ident || !ps.ident.equals(ident))
                     continue;
                 if (!s)
-                    s = *ps;
-                else if (s.isOverloadable() && (*ps).isOverloadable())
+                    s = ps;
+                else if (s.isOverloadable() && ps.isOverloadable())
                 {
                     // keep head of overload set
                     FuncDeclaration f1 = s.isFuncDeclaration();
-                    FuncDeclaration f2 = (*ps).isFuncDeclaration();
+                    FuncDeclaration f2 = ps.isFuncDeclaration();
                     if (f1 && f2)
                     {
                         assert(!f1.isFuncAliasDeclaration());
@@ -908,13 +908,13 @@ extern (C++) class Dsymbol : ASTNode
                 }
                 else // more than one symbol
                 {
-                    *ps = null;
+                    ps = null;
                     //printf("\tfalse 2\n");
                     return false;
                 }
             }
         }
-        *ps = s; // s is the one symbol, null if none
+        ps = s; // s is the one symbol, null if none
         //printf("\ttrue\n");
         return true;
     }

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -246,7 +246,7 @@ public:
     virtual bool needThis();                    // need a 'this' pointer?
     virtual Visibility visible();
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
-    virtual bool oneMember(Dsymbol **ps, Identifier *ident);
+    virtual bool oneMember(Dsymbol *&ps, Identifier *ident);
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();
     virtual void addObjcSymbols(ClassDeclarations *, ClassDeclarations *) { }

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -2964,7 +2964,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (tempdecl.members)
         {
             Dsymbol s;
-            if (Dsymbol.oneMembers(tempdecl.members, &s, tempdecl.ident) && s)
+            if (Dsymbol.oneMembers(tempdecl.members, s, tempdecl.ident) && s)
             {
                 tempdecl.onemember = s;
                 s.parent = tempdecl;
@@ -6807,7 +6807,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     if (tempinst.members.length)
     {
         Dsymbol s;
-        if (Dsymbol.oneMembers(tempinst.members, &s, tempdecl.ident) && s)
+        if (Dsymbol.oneMembers(tempinst.members, s, tempdecl.ident) && s)
         {
             //printf("tempdecl.ident = %s, s = `%s %s`\n", tempdecl.ident.toChars(), s.kind(), s.toPrettyChars());
             //printf("setting aliasdecl\n");
@@ -6852,7 +6852,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     if (tempinst.members.length)
     {
         Dsymbol s;
-        if (Dsymbol.oneMembers(tempinst.members, &s, tempdecl.ident) && s)
+        if (Dsymbol.oneMembers(tempinst.members, s, tempdecl.ident) && s)
         {
             if (!tempinst.aliasdecl || tempinst.aliasdecl != s)
             {

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -615,7 +615,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             return;
 
         Dsymbol s;
-        if (!Dsymbol.oneMembers(members, &s, ident) || !s)
+        if (!Dsymbol.oneMembers(members, s, ident) || !s)
             return;
 
         onemember = s;
@@ -6029,9 +6029,9 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         return "template instance";
     }
 
-    override bool oneMember(Dsymbol* ps, Identifier ident)
+    override bool oneMember(out Dsymbol ps, Identifier ident)
     {
-        *ps = null;
+        ps = null;
         return true;
     }
 
@@ -7599,7 +7599,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 if (members.length)
                 {
                     Dsymbol sa;
-                    if (Dsymbol.oneMembers(members, &sa, tempdecl.ident) && sa)
+                    if (Dsymbol.oneMembers(members, sa, tempdecl.ident) && sa)
                         aliasdecl = sa;
                 }
                 done = true;
@@ -7820,7 +7820,7 @@ extern (C++) final class TemplateMixin : TemplateInstance
         return "mixin";
     }
 
-    override bool oneMember(Dsymbol* ps, Identifier ident)
+    override bool oneMember(out Dsymbol ps, Identifier ident)
     {
         return Dsymbol.oneMember(ps, ident);
     }

--- a/compiler/src/dmd/enum.h
+++ b/compiler/src/dmd/enum.h
@@ -46,7 +46,7 @@ public:
     bool inuse(bool v);
 
     EnumDeclaration *syntaxCopy(Dsymbol *s) override;
-    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     Type *getType() override;
     const char *kind() const override;
     bool isDeprecated() const override;       // is Dsymbol deprecated?

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -513,7 +513,7 @@ public:
     virtual bool needThis();
     virtual Visibility visible();
     virtual Dsymbol* syntaxCopy(Dsymbol* s);
-    virtual bool oneMember(Dsymbol** ps, Identifier* ident);
+    virtual bool oneMember(Dsymbol*& ps, Identifier* ident);
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();
     virtual void addObjcSymbols(Array<ClassDeclaration* >* classes, Array<ClassDeclaration* >* categories);
@@ -1505,7 +1505,7 @@ public:
     TemplateInstance* syntaxCopy(Dsymbol* s) override;
     Dsymbol* toAlias() final override;
     const char* kind() const override;
-    bool oneMember(Dsymbol** ps, Identifier* ident) override;
+    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     const char* toChars() const override;
     const char* toPrettyCharsHelper() final override;
     Identifier* getIdent() final override;
@@ -1531,7 +1531,7 @@ public:
     TypeQualified* tqual;
     TemplateInstance* syntaxCopy(Dsymbol* s) override;
     const char* kind() const override;
-    bool oneMember(Dsymbol** ps, Identifier* ident) override;
+    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     bool hasPointers() override;
     const char* toChars() const override;
     TemplateMixin* isTemplateMixin() override;
@@ -5965,7 +5965,7 @@ public:
     Expression* exp;
     Array<Expression* >* msgs;
     StaticAssert* syntaxCopy(Dsymbol* s) override;
-    bool oneMember(Dsymbol** ps, Identifier* ident) override;
+    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     const char* kind() const override;
     StaticAssert* isStaticAssert() override;
     void accept(Visitor* v) override;
@@ -6795,7 +6795,7 @@ public:
     virtual Scope* newScope(Scope* sc);
     void addComment(const char* comment) override;
     const char* kind() const override;
-    bool oneMember(Dsymbol** ps, Identifier* ident) override;
+    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     bool hasPointers() final override;
     bool hasStaticCtorOrDtor() final override;
     void checkCtorConstInit() final override;
@@ -6810,7 +6810,7 @@ public:
     StorageClass stc;
     StorageClassDeclaration* syntaxCopy(Dsymbol* s) override;
     Scope* newScope(Scope* sc) override;
-    bool oneMember(Dsymbol** ps, Identifier* ident) final override;
+    bool oneMember(Dsymbol*& ps, Identifier* ident) final override;
     StorageClassDeclaration* isStorageClassDeclaration() override;
     void accept(Visitor* v) override;
 };
@@ -6910,7 +6910,7 @@ public:
     Condition* condition;
     Array<Dsymbol* >* elsedecl;
     ConditionalDeclaration* syntaxCopy(Dsymbol* s) override;
-    bool oneMember(Dsymbol** ps, Identifier* ident) final override;
+    bool oneMember(Dsymbol*& ps, Identifier* ident) final override;
     Array<Dsymbol* >* include(Scope* sc) override;
     void addComment(const char* comment) final override;
     void accept(Visitor* v) override;
@@ -6940,7 +6940,7 @@ public:
     bool cached;
     Array<Dsymbol* >* cache;
     StaticForeachDeclaration* syntaxCopy(Dsymbol* s) override;
-    bool oneMember(Dsymbol** ps, Identifier* ident) override;
+    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     Array<Dsymbol* >* include(Scope* sc) override;
     void addComment(const char* comment) override;
     const char* kind() const override;
@@ -7519,7 +7519,7 @@ private:
     uint8_t bitFields;
 public:
     EnumDeclaration* syntaxCopy(Dsymbol* s) override;
-    bool oneMember(Dsymbol** ps, Identifier* ident) override;
+    bool oneMember(Dsymbol*& ps, Identifier* ident) override;
     Type* getType() override;
     const char* kind() const override;
     bool isDeprecated() const override;

--- a/compiler/src/dmd/staticassert.d
+++ b/compiler/src/dmd/staticassert.d
@@ -49,10 +49,10 @@ extern (C++) final class StaticAssert : Dsymbol
         return new StaticAssert(loc, exp.syntaxCopy(), msgs ? Expression.arraySyntaxCopy(msgs) : null);
     }
 
-    override bool oneMember(Dsymbol* ps, Identifier ident)
+    override bool oneMember(out Dsymbol ps, Identifier ident)
     {
         //printf("StaticAssert::oneMember())\n");
-        *ps = null;
+        ps = null;
         return true;
     }
 

--- a/compiler/src/dmd/staticassert.h
+++ b/compiler/src/dmd/staticassert.h
@@ -21,7 +21,7 @@ public:
     Expressions *msg;
 
     StaticAssert *syntaxCopy(Dsymbol *s) override;
-    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     const char *kind() const override;
     StaticAssert *isStaticAssert() override { return this; }
     void accept(Visitor *v) override { v->visit(this); }

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -290,7 +290,7 @@ public:
     TemplateInstance *syntaxCopy(Dsymbol *) override;
     Dsymbol *toAlias() override final;   // resolve real symbol
     const char *kind() const override;
-    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     const char *toChars() const override;
     const char* toPrettyCharsHelper() override final;
     Identifier *getIdent() override final;
@@ -309,7 +309,7 @@ public:
 
     TemplateMixin *syntaxCopy(Dsymbol *s) override;
     const char *kind() const override;
-    bool oneMember(Dsymbol **ps, Identifier *ident) override;
+    bool oneMember(Dsymbol *&ps, Identifier *ident) override;
     bool hasPointers() override;
     const char *toChars() const override;
 


### PR DESCRIPTION
More self-evident, more safe.