### PR TITLE
Fix issue 24298 - cpp_delete should check for null

### DIFF
--- a/druntime/src/core/stdcpp/new_.d
+++ b/druntime/src/core/stdcpp/new_.d
@@ -59,6 +59,8 @@ T cpp_new(T, Args...)(auto ref Args args) if (is(T == class))
 ///
 void cpp_delete(T)(T* ptr) if (!is(T == class))
 {
+    if (ptr is null)
+        return;
     destroy!false(*ptr);
     __cpp_delete(ptr);
 }
@@ -66,6 +68,8 @@ void cpp_delete(T)(T* ptr) if (!is(T == class))
 ///
 void cpp_delete(T)(T instance) if (is(T == class))
 {
+    if (instance is null)
+        return;
     destroy!false(instance);
     __cpp_delete(cast(void*) instance);
 }

--- a/druntime/test/stdcpp/src/new_test.d
+++ b/druntime/test/stdcpp/src/new_test.d
@@ -135,3 +135,56 @@ unittest
         assert(MyClassGC.numDeleted == 1);
     }
 }
+
+unittest
+{
+    import core.stdcpp.new_: cpp_new, cpp_delete;
+
+    {
+        extern(C++) static struct S
+        {
+            __gshared int numDeleted;
+            __gshared int lastDeleted;
+            int i;
+            ~this()
+            {
+                lastDeleted = i;
+                numDeleted++;
+            }
+        }
+        S *s = cpp_new!S(12345);
+        cpp_delete(s);
+        assert(S.numDeleted == 1);
+        assert(S.lastDeleted == 12345);
+        s = null;
+        cpp_delete(s);
+        assert(S.numDeleted == 1);
+        assert(S.lastDeleted == 12345);
+    }
+
+    {
+        extern(C++) static class C
+        {
+            __gshared int numDeleted;
+            __gshared int lastDeleted;
+            int i;
+            this(int i)
+            {
+                this.i = i;
+            }
+            ~this()
+            {
+                lastDeleted = i;
+                numDeleted++;
+            }
+        }
+        C c = cpp_new!C(54321);
+        cpp_delete(c);
+        assert(C.numDeleted == 1);
+        assert(C.lastDeleted == 54321);
+        c = null;
+        cpp_delete(c);
+        assert(C.numDeleted == 1);
+        assert(C.lastDeleted == 54321);
+    }
+}


### PR DESCRIPTION
The delete operator in C++ can be called with a null pointer and ignores it. This commit makes cpp_delete consistent with C++, so null pointers are also ignored.