### PR TITLE
feat(frontend): store raw comments

### DIFF
--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -695,6 +695,10 @@ class Lexer
                         getDocComment(t, lastLine == startLoc.linnum, startLoc.linnum - lastDocLine > 1);
                         lastDocLine = scanloc.linnum;
                     }
+                    version (DMDLIB)
+                    {
+                        getRawComment(t);
+                    }
                     continue;
                 case '/': // do // style comments
                     startLoc = loc();
@@ -722,6 +726,10 @@ class Lexer
                             {
                                 getDocComment(t, lastLine == startLoc.linnum, startLoc.linnum - lastDocLine > 1);
                                 lastDocLine = scanloc.linnum;
+                            }
+                            version (DMDLIB)
+                            {
+                                getRawComment(t);
                             }
                             p = end;
                             t.loc = loc();
@@ -754,6 +762,10 @@ class Lexer
                     {
                         getDocComment(t, lastLine == startLoc.linnum, startLoc.linnum - lastDocLine > 1);
                         lastDocLine = scanloc.linnum;
+                    }
+                    version (DMDLIB)
+                    {
+                        getRawComment(t);
                     }
                     p++;
                     endOfLine();
@@ -826,6 +838,10 @@ class Lexer
                             // if /++ but not /++/
                             getDocComment(t, lastLine == startLoc.linnum, startLoc.linnum - lastDocLine > 1);
                             lastDocLine = scanloc.linnum;
+                        }
+                        version (DMDLIB)
+                        {
+                            getRawComment(t);
                         }
                         continue;
                     }
@@ -3070,6 +3086,66 @@ class Lexer
         if (!msg && isBidiControl(u))
             msg = "Bidirectional control characters are disallowed for security reasons.";
         return u;
+    }
+
+    version (DMDLIB)
+    {
+        /***************************************************
+     * Parse a comment embedded between t.ptr and p.
+     * Remove trailing blanks and tabs from lines.
+     * Replace all newlines with \n.
+     * Preserve leading comment string in each line.
+     * Append to previous one for this token.
+     */
+        private void getRawComment(Token* t) pure
+        {
+            const(char)* q = t.ptr; // start of comment text
+            OutBuffer buf;
+
+            for (; q < p /* start of next token */ ; q++)
+            {
+                char c = *q;
+                switch (c)
+                {
+                case ' ':
+                case '\t':
+                    break;
+                case '\r':
+                    if (q[1] == '\n')
+                        continue; // skip the \r
+                    goto Lnewline;
+                default:
+                    if (c == 226)
+                    {
+                        // If LS or PS
+                        if (q[1] == 128 && (q[2] == 168 || q[2] == 169))
+                        {
+                            q += 2;
+                            goto Lnewline;
+                        }
+                    }
+                    break;
+                Lnewline:
+                    c = '\n'; // replace all newlines with \n
+                    break;
+                }
+                buf.writeByte(c);
+            }
+
+            // Always end with a newline
+            const s = buf[];
+            if (s.length == 0 || s[$ - 1] != '\n')
+                buf.writeByte('\n');
+
+            // Combine with previous comments, if any
+            if (t.rawComment)
+            {
+                auto comment = combineComments(t.rawComment, buf[], false);
+                t.rawComment = comment ? comment[0 .. strlen(comment)] : null;
+            }
+            else
+                t.rawComment = buf.extractSlice(true);
+        }
     }
 
     /***************************************************

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -9582,8 +9582,15 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     {
         if (s !is null)
         {
-            s.addComment(combineComments(blockComment, token.lineComment, true));
-            token.lineComment = null;
+            version (DMDLIB)
+            {
+                s.addComment(token.rawComment.ptr);
+            }
+            else
+            {
+                s.addComment(combineComments(blockComment, token.lineComment, true));
+                token.lineComment = null;
+            }
         }
     }
 

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -632,6 +632,10 @@ extern (C++) struct Token
     Loc loc;
     const(char)* ptr; // pointer to first character of this token within buffer
     TOK value;
+    version (DMDLIB)
+    {
+        const(char)[] rawComment;
+    }
     const(char)[] blockComment; // doc comment string prior to this token
     const(char)[] lineComment; // doc comment for previous token
 


### PR DESCRIPTION
Previously, non-doc comments were discarded and not available in the AST. Now, it is stored in a `rawComment` field in the top-level AST node associated with the comment, gated behind the `DMDLIB` version flag.

@rikkimax also suggested that we should put it behind a different version flag, but I'm not sure if everyone's okay with introducing another gate into the frontend, so wanted to clarify it once here.

Also, I've been running into an interesting bug while using these changes - the doc comments are correctly attached to their respective node, but the regular comments get attached to the node **above** the respective node. E.g.

```d
// This is a comment for foo
struct Foo {}
// This is a coment for bar
void bar() {}
```

The first comment disappears after parsing, and the second comment is attached to the struct instead of the function. Any ideas as to what's happening here? I've tried debugging it across this week but not had much luck.

cc @WebFreak001 @RazvanN7