### PR TITLE
hdrgen.d: remove reference to global target

### DIFF
--- a/compiler/test/compilable/test9565.d
+++ b/compiler/test/compilable/test9565.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -o-
+// REQUIRED_ARGS: -o- -m32
 // PERMUTE_ARGS:
 
 template TypeTuple(T...) { alias TypeTuple = T; }
@@ -30,7 +30,7 @@ void main()
 
         // index == NegExp
         static assert((arr[-4  ]).stringof == "arr[" ~ castPrefix ~ "-4]");
-        static assert((arr[-4U ]).stringof == "arr[4294967292]");
+        static assert((arr[-4U ]).stringof == "arr[cast(size_t)4294967292]");
         static assert((arr[int.min] ).stringof == "arr[" ~ castPrefix ~ "-2147483648]");
       static if (is(size_t == ulong))
       {

--- a/compiler/test/fail_compilation/fail19890a.d
+++ b/compiler/test/fail_compilation/fail19890a.d
@@ -1,7 +1,7 @@
-/*
+/* REQUIRED_ARGS: -m32
 TEST_OUTPUT:
 ---
-fail_compilation/fail19890a.d(8): Error: `void[$n$$?:64=LU$]` size 1 * $n$ exceeds $?:windows+32omf=0x1000000|0x7fffffff$ size limit for static array
+fail_compilation/fail19890a.d(8): Error: `void[cast(size_t)4294967295]` size 1 * 4294967295 exceeds 0x7fffffff size limit for static array
 ---
 */
 

--- a/compiler/test/fail_compilation/fail19890b.d
+++ b/compiler/test/fail_compilation/fail19890b.d
@@ -1,7 +1,7 @@
-/*
+/* REQUIRED_ARGS: -m32
 TEST_OUTPUT:
 ---
-fail_compilation/fail19890b.d(8): Error: `void[$n$$?:64=LU$]` size 1 * $n$ exceeds $?:windows+32omf=0x1000000|0x7fffffff$ size limit for static array
+fail_compilation/fail19890b.d(8): Error: `void[cast(size_t)4294967294]` size 1 * 4294967294 exceeds 0x7fffffff size limit for static array
 ---
 */
 

--- a/compiler/test/fail_compilation/fail4611.d
+++ b/compiler/test/fail_compilation/fail4611.d
@@ -1,7 +1,7 @@
-/*
+/* REQUIRED_ARGS: -m32
 TEST_OUTPUT:
 ---
-fail_compilation/fail4611.d(15): Error: `Vec[$n$]` size 4 * $n$ exceeds $?:windows+32omf=0x1000000|0x7fffffff$ size limit for static array
+fail_compilation/fail4611.d(15): Error: `Vec[cast(size_t)2147483647]` size 4 * 2147483647 exceeds 0x7fffffff size limit for static array
 ---
 */
 

--- a/compiler/test/fail_compilation/staticarrayoverflow.d
+++ b/compiler/test/fail_compilation/staticarrayoverflow.d
@@ -2,13 +2,13 @@
 REQUIRED_ARGS: -m64
 TEST_OUTPUT:
 ---
-fail_compilation/staticarrayoverflow.d(23): Error: static array `S[1879048192]` size overflowed to 7516192768000
+fail_compilation/staticarrayoverflow.d(23): Error: static array `S[cast(size_t)1879048192]` size overflowed to 7516192768000
 fail_compilation/staticarrayoverflow.d(23): Error: variable `staticarrayoverflow.y` size overflow
-fail_compilation/staticarrayoverflow.d(25): Error: static array `S[8070450532247928832]` size overflowed to 8070450532247928832
+fail_compilation/staticarrayoverflow.d(25): Error: static array `S[cast(size_t)8070450532247928832]` size overflowed to 8070450532247928832
 fail_compilation/staticarrayoverflow.d(25): Error: variable `staticarrayoverflow.a` size overflow
 fail_compilation/staticarrayoverflow.d(26): Error: static array `S[0][18446744073709551615LU]` size overflowed to 18446744073709551615
 fail_compilation/staticarrayoverflow.d(26): Error: variable `staticarrayoverflow.b` size overflow
-fail_compilation/staticarrayoverflow.d(27): Error: static array `S[0][4294967295]` size overflowed to 4294967295
+fail_compilation/staticarrayoverflow.d(27): Error: static array `S[0][cast(size_t)4294967295]` size overflowed to 4294967295
 fail_compilation/staticarrayoverflow.d(27): Error: variable `staticarrayoverflow.c` size overflow
 ---
 */


### PR DESCRIPTION
dmd.target was standing in the way of making hdrgen.d stateless. Finally I realized it could be replaced with a `cast(size_t)`.