### PR TITLE
Remove deprecated rndtonl from core.math

### DIFF
--- a/druntime/src/core/math.d
+++ b/druntime/src/core/math.d
@@ -30,15 +30,6 @@ public:
 nothrow:
 @safe:
 
-/*****************************************
- * Returns x rounded to a long value using the FE_TONEAREST rounding mode.
- * If the integer value of x is
- * greater than long.max, the result is
- * indeterminate.
- */
-deprecated("rndtonl is to be removed by 2.100. Please use round instead")
-extern (C) real rndtonl(real x);
-
 pure:
 /***********************************
  * Returns cosine of x. x is in radians.


### PR DESCRIPTION
An old DigitalMars / OMF-only function. 

See https://github.com/dlang/druntime/pull/3676