### PR TITLE
Fix 24301 - Misleading error message when passing non-copyable struct…

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -711,7 +711,15 @@ private extern(D) bool isCopyConstructorCallable (StructDeclaration argStruct,
                 s ~= "@safe ";
             if (!f.isNogc && sc.func.setGC(arg.loc, null))
                 s ~= "nogc ";
-            if (s)
+            if (f.isDisabled() && !f.isGenerated())
+            {
+                /* https://issues.dlang.org/show_bug.cgi?id=24301
+                 * Copy constructor is explicitly disabled
+                 */
+                buf.printf("`%s` copy constructor cannot be used because it is annotated with `@disable`",
+                    f.type.toChars());
+            }
+            else if (s)
             {
                 s[$-1] = '\0';
                 buf.printf("`%s` copy constructor cannot be called from a `%s` context", f.type.toChars(), s.ptr);

--- a/compiler/test/fail_compilation/fail24301.d
+++ b/compiler/test/fail_compilation/fail24301.d
@@ -1,0 +1,19 @@
+/+
+TEST_OUTPUT:
+---
+fail_compilation/fail24301.d(18): Error: function `fail24301.fun(S __param_0)` is not callable using argument types `(S)`
+fail_compilation/fail24301.d(18):        `ref S(ref S)` copy constructor cannot be used because it is annotated with `@disable`
+---
++/
+struct S
+{
+    @disable this(ref S);
+}
+
+@safe void fun(S) {}
+
+@safe void main()
+{
+    S s;
+    fun(s);
+}


### PR DESCRIPTION
… by value in `@safe` code

If a copy constructor is explicitly marked with `@disable`, the error message should mention that, regardless of whether its attributes are allowed in the calling scope.