### PR TITLE
fix Issue 24280 - ImportC: forward reference error when compiling mul…

### DIFF
--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -2318,11 +2318,16 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
     Type visitTag(TypeTag mtype)
     {
         //printf("TypeTag.semantic() %s\n", mtype.toChars());
+        Type returnType(Type t)
+        {
+            return t.deco ? t : t.merge();
+        }
+
         if (mtype.resolved)
         {
             /* struct S s, *p;
              */
-            return mtype.resolved.addSTC(mtype.mod);
+            return returnType(mtype.resolved.addSTC(mtype.mod));
         }
 
         /* Find the current scope by skipping tag scopes.
@@ -2395,7 +2400,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
         {
             mtype.id = Identifier.generateId("__tag"[]);
             declareTag();
-            return mtype.resolved.addSTC(mtype.mod);
+            return returnType(mtype.resolved.addSTC(mtype.mod));
         }
 
         /* look for pre-existing declaration
@@ -2408,7 +2413,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
             if (mtype.tok == TOK.enum_ && !mtype.members)
                 .error(mtype.loc, "`enum %s` is incomplete without members", mtype.id.toChars()); // C11 6.7.2.3-3
             declareTag();
-            return mtype.resolved.addSTC(mtype.mod);
+            return returnType(mtype.resolved.addSTC(mtype.mod));
         }
 
         /* A redeclaration only happens if both declarations are in
@@ -2508,7 +2513,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
                 declareTag();
             }
         }
-        return mtype.resolved.addSTC(mtype.mod);
+        return returnType(mtype.resolved.addSTC(mtype.mod));
     }
 
     switch (type.ty)

--- a/compiler/test/compilable/imports/test24280b.i
+++ b/compiler/test/compilable/imports/test24280b.i
@@ -1,0 +1,19 @@
+struct S;
+
+struct timespec
+{
+    int s;
+};
+
+typedef struct timespec Clock;
+
+Clock now()
+{
+    Clock result;
+    return result;
+}
+
+struct S
+{
+    Clock clock;
+};

--- a/compiler/test/compilable/test24280.i
+++ b/compiler/test/compilable/test24280.i
@@ -1,0 +1,6 @@
+// EXTRA_SOURCES: imports/test24280b.i
+
+struct timespec
+{
+    int s;
+};


### PR DESCRIPTION
…tiple files

When there are 3 declarations of a struct, ensure only one is being referenced by doing a final merge().

It took me a while to find the cause of this problem.