### PR TITLE
Trivial: Use REQUIRED_ARGS instead of PERMUTE_ARGS for preview=in test

### DIFF
--- a/compiler/test/fail_compilation/diagin.d
+++ b/compiler/test/fail_compilation/diagin.d
@@ -1,5 +1,5 @@
 /*
-PERMUTE_ARGS: -preview=in
+REQUIRED_ARGS: -preview=in
 TEST_OUTPUT:
 ---
 fail_compilation/diagin.d(14): Error: function `diagin.foo(in int)` is not callable using argument types `()`


### PR DESCRIPTION
If the mangling was to change, this test would fail. There is no reason to use PERMUTE_ARGS here,
and so it's better to use the more restrictive REQUIRED_ARGS.