### PR TITLE
Fix issue 22905 - gdb backtrace contains wrong location

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15037,6 +15037,8 @@ bool checkSharedAccess(Expression e, Scope* sc, bool returnRef = false)
  */
 Expression resolveLoc(Expression exp, const ref Loc loc, Scope* sc)
 {
+    exp.loc = loc;
+
     Expression visit(Expression exp)
     {
         if (auto unaExp = exp.isUnaExp())
@@ -15044,7 +15046,6 @@ Expression resolveLoc(Expression exp, const ref Loc loc, Scope* sc)
             unaExp.e1 = unaExp.e1.resolveLoc(loc, sc);
             return unaExp;
         }
-        exp.loc = loc;
         return exp;
     }
 

--- a/compiler/test/runnable/gdb22905.d
+++ b/compiler/test/runnable/gdb22905.d
@@ -1,0 +1,20 @@
+/*
+EXTRA_SOURCES: imports/gdb22905b.d imports/gdb22905c.d
+REQUIRED_ARGS: -g
+GDB_SCRIPT:
+---
+b gdb22905c.d:6
+commands
+bt
+cont
+end
+run
+---
+GDB_MATCH: _D7imports9gdb22905b5funcBFZv .. at runnable/imports/gdb22905b.d:7
+*/
+import imports.gdb22905b;
+
+void main()
+{
+    funcB();
+}

--- a/compiler/test/runnable/imports/gdb22905b.d
+++ b/compiler/test/runnable/imports/gdb22905b.d
@@ -1,0 +1,8 @@
+module imports.gdb22905b;
+import imports.gdb22905c;
+
+pragma(inline, false)
+void funcB()
+{
+    funcC(0);
+}

--- a/compiler/test/runnable/imports/gdb22905c.d
+++ b/compiler/test/runnable/imports/gdb22905c.d
@@ -1,0 +1,13 @@
+module imports.gdb22905c;
+
+pragma(inline, false)
+void funcC(T)(T param, void delegate() dg = null)
+{
+    return;
+}
+
+struct S
+{
+    void function() f;
+    void *ptr;
+}


### PR DESCRIPTION
The default argument for function funcC in the example is wrapped in an implicit cast expression. The location for this expression was not changed to the call site, because the visit function returned earlier for unary expressions. Now the location is changed for every type of expression.