### PR TITLE
fix issue 4071 and others: shared runtime DLL for Windows

### DIFF
--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -77,8 +77,8 @@ extern (C) void out_config_init(
         ubyte dwarf,
         string _version,
         exefmt_t exefmt,
-        bool generatedMain      // a main entrypoint is generated
-        )
+        bool generatedMain,     // a main entrypoint is generated
+        bool dataimports)
 {
     //printf("out_config_init()\n");
 
@@ -139,6 +139,8 @@ extern (C) void out_config_init(
             cfg.objfmt = mscoff ? OBJ_MSCOFF : OBJ_OMF;
             if (mscoff)
                 cfg.flags |= CFGnoebp;    // test suite fails without this
+            if (dataimports)
+                cfg.flags2 |= CFG2noreadonly;
         }
 
         if (exe)

--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -54,6 +54,8 @@ nothrow:
     _version      = Compiler version
     exefmt        = Executable file format
     generatedMain = a main entrypoint is generated
+    dataimports   = do not place data symbols into read-only segment,
+                    it might be necessary to resolve relocations at runtime
  */
 public
 @trusted

--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -1060,6 +1060,7 @@ enum
     SFLpmask        = 0x60,        // mask for the visibility bits
 
     SFLvtbl         = 0x2000,      // VEC_VTBL_LIST: Symbol is a vtable or vbtable
+    SFLimported     = 0x200000,    // symbol is in another DSO (D only, SFLdyninit unused)
 
     // OPTIMIZER and CODGEN
     GTregcand       = 0x100,       // if Symbol is a register candidate
@@ -1100,6 +1101,7 @@ struct Symbol
 
     Symbol* Sl, Sr;             // left, right child
     Symbol* Snext;              // next in threaded list
+    Symbol* Sisym;              // import version of this symbol
     dt_t* Sdt;                  // variables: initializer
     int Salignment;             // variables: alignment, 0 or -1 means default alignment
 

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -485,6 +485,7 @@ enum
     CFG2stomp       = 0x8000,  // enable stack stomping code
     CFG2gms         = 0x10000, // optimize debug symbols for microsoft debuggers
     CFG2genmain     = 0x20000, // main entrypoint is generated
+    CFG2noreadonly  = 0x40000, // do not generate read-only symbols, dllimport might have to patch them
 }
 
 alias config_flags3_t = uint;

--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -499,6 +499,8 @@ void outcommon(Symbol *s,targ_size_t n)
 @trusted
 void out_readonly(Symbol *s)
 {
+    if (config.flags2 & CFG2noreadonly)
+        return;
     if (config.objfmt == OBJ_ELF || config.objfmt == OBJ_MACH)
     {
         /* Cannot have pointers in CDATA when compiling PIC code, because

--- a/compiler/src/dmd/backend/elpicpie.d
+++ b/compiler/src/dmd/backend/elpicpie.d
@@ -309,6 +309,13 @@ elem * el_ptr(Symbol *s)
         e = el_una(OPaddr, typtr, e);
         e = doptelem(e, GOALvalue | GOALflags);
     }
+    if (config.exe & EX_windos)
+    {
+        if (s.Sflags & SFLimported)
+        {
+            e = el_una(OPind, s.Stype.Tty, e);
+        }
+    }
     return e;
 }
 

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -91,6 +91,7 @@ IMAGE_SECTION_HEADER* ScnhdrTab() { return cast(IMAGE_SECTION_HEADER *)ScnhdrBuf
     extern (D) int pointersSeg;      // segment index for __pointers
 
     OutBuffer *ptrref_buf;           // buffer for pointer references
+    OutBuffer *impref_buf;           // buffer for import table references
 
     int floatused;
 
@@ -603,6 +604,7 @@ void MsCoffObj_term(const(char)* objfilename)
 
     objflush_pointerRefs();
     outfixlist();           // backpatches
+    objflush_importTableRefs();
 
     if (configv.addlinenumbers)
     {
@@ -2076,6 +2078,12 @@ static if (0)
 void MsCoffObj_addrel(segidx_t seg, targ_size_t offset, Symbol *targsym,
         uint targseg, int rtype, int val)
 {
+    if (targsym && targsym.Sflags & SFLimported && !SegData[seg].isCode())
+    {
+        assert(rtype == RELaddr && val == 0);
+        write_importTableRef(seg, offset, targsym);
+        return;
+    }
     //printf("addrel()\n");
     if (!targsym)
     {   // Generate one
@@ -2231,7 +2239,11 @@ static if (0)
     }
     else
     {
-        if (I64 || I32)
+        if ((s.Sisym || (s.Sflags & SFLimported)) && !SegData[seg].isCode())
+        {
+            write_importTableRef(seg, offset, s.Sisym ? s.Sisym : s);
+        }
+        else if (I64 || I32)
         {
             //if (s.Sclass != SCcomdat)
                 //val += s.Soffset;
@@ -2481,4 +2493,108 @@ extern (D) private void objflush_pointerRefs()
         objflush_pointerRef(s, soff);
     }
     ptrref_buf.reset();
+}
+
+/*****************************************
+ * write a reference to the import table into the object file
+ * Params:
+ *      seg  = segment of the reference
+ *      soff = offset of the reference in the segment
+ *      imp  = symbol referenced in the import table
+ *      ioff = offset to add to pointer from import table
+ */
+@trusted
+void write_importTableRef(segidx_t seg, targ_size_t soff, Symbol* imp)
+{
+    if (!imp.Sxtrnnum)
+        MsCoffObj_external(imp);
+
+    if (!impref_buf)
+    {
+        impref_buf = cast(OutBuffer*) calloc(1, OutBuffer.sizeof);
+        if (!impref_buf)
+            err_nomem();
+    }
+
+    // defer writing pointer references until the symbols are written out
+    impref_buf.write32(seg);
+    impref_buf.write32(cast(uint)soff);
+    impref_buf.write((&imp)[0 .. 1]);
+}
+
+/*****************************************
+ * flush all pointer references saved by write_importTableRef
+ * to the object file as a crt_constructor function
+ */
+@trusted
+extern (D) private void objflush_importTableRefs()
+{
+    if (!impref_buf)
+        return;
+
+    auto align_ = I64 ? 16 : 4;
+    auto seg = MsCoffObj_getsegment(".text", IMAGE_SCN_CNT_CODE |
+                                    IMAGE_SCN_LNK_COMDAT |
+                                    (I64 ? IMAGE_SCN_ALIGN_16BYTES : IMAGE_SCN_ALIGN_4BYTES) |
+                                    IMAGE_SCN_MEM_EXECUTE |
+                                    IMAGE_SCN_MEM_READ);
+
+    targ_size_t offset = SegData[seg].SDoffset;
+    OutBuffer* buf = SegData[seg].SDbuf;
+    buf.setsize(cast(uint)offset);
+
+    ubyte *p = impref_buf.buf;
+    ubyte *end = impref_buf.buf + impref_buf.length();
+    while (p < end)
+    {
+        int sseg = *cast(int*)p;
+        p += sseg.sizeof;
+        uint soff = *cast(uint*)p;
+        p += soff.sizeof;
+        Symbol* imp = *cast(Symbol**)p;
+        p += imp.sizeof;
+
+        if (I64)
+        {
+            buf.writeByte(0x48); // opcode for mov RAX,[addr]
+            buf.writeByte(0x8b);
+            buf.writeByte(0x05);
+        }
+        else
+            buf.writeByte(0xA1);
+        SegData[seg].SDoffset = offset = buf.length;
+        MsCoffObj_addrel(seg, offset, imp, 0, RELaddr32, 0);
+        buf.write32(0);
+
+        if (I64)
+        {
+            buf.writeByte(0x48); // opcode for add [addr],RAX
+            buf.writeByte(0x01);
+            buf.writeByte(0x05);
+        }
+        else
+        {
+            buf.writeByte(0x01);
+            buf.writeByte(0x05);
+        }
+
+        SegData[seg].SDoffset = offset = buf.length;
+        MsCoffObj_addrel(seg, offset, null, sseg, RELaddr32, 0);
+        //buf.setsize(cast(uint)offset);
+        buf.write32(soff);
+    }
+    buf.writeByte(0xc3); // ret
+    SegData[seg].SDoffset = buf.length();
+
+    // use an early .CRT$XC group so C init code can access relocated pointers, too
+    const int align2 = I64 ? IMAGE_SCN_ALIGN_8BYTES : IMAGE_SCN_ALIGN_4BYTES;
+    const int attr = IMAGE_SCN_CNT_INITIALIZED_DATA | align2 | IMAGE_SCN_MEM_READ;
+    const int cseg = MsCoffObj_getsegment(".CRT$XCB", attr);
+
+    MsCoffObj_addrel(cseg, SegData[cseg].SDoffset, null, seg, RELaddr, 0);
+    OutBuffer* cbuf = SegData[cseg].SDbuf;
+    cbuf.fill0(I64 ? 8 : 4);
+    SegData[cseg].SDoffset = cbuf.length();
+
+    impref_buf.reset();
 }

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -336,6 +336,15 @@ dmd -cov -unittest myprog.d
             With $(I filename), write module dependencies as text to $(I filename)
             (only imports).`,
         ),
+        Option("dllimport=<value>",
+            "Windows only: select symbols to dllimport (none/defaultLibsOnly/all)",
+            `Which extern(D) global variables to dllimport implicitly if not defined in a root module
+            $(UL
+                $(LI $(I none): None (default with -link-defaultlib-shared=false)
+                $(LI $(I defaultLibsOnly): Only druntime/Phobos symbols (default with -link-defaultlib-shared and -fvisibility=hidden)
+                $(LI $(I all): All (default with -link-defaultlib-shared and -fvisibility=public)
+            )`,
+        ),
         Option("extern-std=<standard>",
             "set C++ name mangling compatibility with <standard>",
             "Standards supported are:

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -812,6 +812,14 @@ dmd -cov -unittest myprog.d
         Option("vgc",
             "list all gc allocations including hidden ones"
         ),
+        Option("visibility=<value>",
+            "default visibility of symbols (default/hidden/public)",
+            "$(UL
+               $(LI $(I default): Hidden for Windows targets without -shared, otherwise public)
+               $(LI $(I hidden):  Only export symbols marked with 'export')
+               $(LI $(I public):  Export all symbols)
+            )",
+        ),
         Option("vtls",
             "list all variables going into thread local storage"
         ),

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -338,11 +338,11 @@ dmd -cov -unittest myprog.d
         ),
         Option("dllimport=<value>",
             "Windows only: select symbols to dllimport (none/defaultLibsOnly/all)",
-            `Which extern(D) global variables to dllimport implicitly if not defined in a root module
+            `Which global variables to dllimport implicitly if not defined in a root module
             $(UL
-                $(LI $(I none): None (default with -link-defaultlib-shared=false)
-                $(LI $(I defaultLibsOnly): Only druntime/Phobos symbols (default with -link-defaultlib-shared and -fvisibility=hidden)
-                $(LI $(I all): All (default with -link-defaultlib-shared and -fvisibility=public)
+                $(LI $(I none): None
+                $(LI $(I defaultLibsOnly): Only druntime/Phobos symbols
+                $(LI $(I all): All
             )`,
         ),
         Option("extern-std=<standard>",

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -246,8 +246,6 @@ extern (C++) abstract class Declaration : Dsymbol
       enum nounderscore = 4; // don't prepend _ to mangled name
       enum hidden       = 8; // don't print this in .di files
 
-    Symbol* isym;           // import version of csym
-
     // overridden symbol with pragma(mangle, "...")
     const(char)[] mangleOverride;
 

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -118,7 +118,6 @@ public:
     LINK _linkage;              // may be `LINK::system`; use `resolvedLinkage()` to resolve it
     short inuse;                // used to detect cycles
     uint8_t adFlags;
-    Symbol* isym;               // import version of csym
     DString mangleOverride;     // overridden symbol with pragma(mangle, "...")
 
     const char *kind() const override;

--- a/compiler/src/dmd/dmdparams.d
+++ b/compiler/src/dmd/dmdparams.d
@@ -21,6 +21,14 @@ enum PIC : ubyte
     pie,                /// Position Independent Executable
 }
 
+/// export visibility
+enum ExpVis : ubyte
+{
+    default_,           /// hidden for Windows targets without -shared, otherwise public
+    hidden,             /// only export symbols marked with 'export'
+    public_,            /// export all symbols
+}
+
 struct DMDparams
 {
     bool alwaysframe;       // always emit standard stack frame
@@ -38,6 +46,7 @@ struct DMDparams
     bool ibt;               // generate indirect branch tracking
     PIC pic = PIC.fixed;    // generate fixed, pic or pie code
     bool stackstomp;        // add stack stomping code
+    ExpVis exportVisibility = ExpVis.hidden; // which symbols to "dllexport"
 
     bool symdebug;          // insert debug symbolic information
     bool symdebugref;       // insert debug information for all referenced types, too

--- a/compiler/src/dmd/dmdparams.d
+++ b/compiler/src/dmd/dmdparams.d
@@ -29,6 +29,14 @@ enum ExpVis : ubyte
     public_,            /// export all symbols
 }
 
+/// symbol dllimport
+enum SymImport : ubyte
+{
+    none,               /// no symbols
+    defaultLibsOnly,    /// only druntime/phobos symbols
+    all,                /// all non-root symbols
+}
+
 struct DMDparams
 {
     bool alwaysframe;       // always emit standard stack frame
@@ -47,6 +55,7 @@ struct DMDparams
     PIC pic = PIC.fixed;    // generate fixed, pic or pie code
     bool stackstomp;        // add stack stomping code
     ExpVis exportVisibility = ExpVis.hidden; // which symbols to "dllexport"
+    SymImport symImport;    // which symbols to "dllimport"
 
     bool symdebug;          // insert debug symbolic information
     bool symdebugref;       // insert debug information for all referenced types, too

--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -87,7 +87,8 @@ void backend_init()
         driverParams.dwarf,
         global.versionString(),
         exfmt,
-        params.addMain
+        params.addMain,
+        driverParams.symImport != SymImport.none
     );
 
     out_config_debug(

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -501,7 +501,7 @@ private __gshared StringTable!(Symbol*) *stringTab;
  */
 bool isDllImported(Dsymbol var)
 {
-    if (target.os & Target.OS.Posix)
+    if (!(target.os & Target.OS.Windows))
         return false;
     if (var.isImportedSymbol())
         return true;

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -493,14 +493,16 @@ void clearStringTab()
 private __gshared StringTable!(Symbol*) *stringTab;
 
 /*********************************************
-* Figure out whether a data symbol should be dllimported
-* Params:
-*      var = declaration of the symbol
-* Returns:
-*      true if symbol should be imported from a DLL
-*/
+ * Figure out whether a data symbol should be dllimported
+ * Params:
+ *      var = declaration of the symbol
+ * Returns:
+ *      true if symbol should be imported from a DLL
+ */
 bool isDllImported(Dsymbol var)
 {
+    if (target.os & Target.OS.Posix)
+        return false;
     if (var.isImportedSymbol())
         return true;
     if (driverParams.symImport == SymImport.none)
@@ -523,6 +525,14 @@ bool isDllImported(Dsymbol var)
     return false;
 }
 
+/*********************************************
+ * Generate a backend symbol for a frontend symbol
+ * Params:
+ *      s = frontend symbol
+ * Returns:
+ *      the backend symbol or the associated symbol in the
+ *      import table if it is expected to be imported from a DLL
+ */
 Symbol* toExtSymbol(Dsymbol s)
 {
     if (isDllImported(s))
@@ -4627,8 +4637,7 @@ elem *toElemCast(CastExp ce, elem *e, bool isLvalue, ref IRState irs)
             const rtl = cdfrom.isInterfaceDeclaration()
                         ? RTLSYM.INTERFACE_CAST
                         : RTLSYM.DYNAMIC_CAST;
-            Symbol* csym = toExtSymbol(cdto);
-            elem *ep = el_param(el_ptr(csym), e);
+            elem *ep = el_param(el_ptr(toExtSymbol(cdto)), e);
             e = el_bin(OPcall, TYnptr, el_var(getRtlsym(rtl)), ep);
         }
         return Lret(ce, e);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6739,7 +6739,6 @@ public:
 
     enum : int32_t { hidden = 8 };
 
-    Symbol* isym;
     _d_dynamicArray< const char > mangleOverride;
     const char* kind() const override;
     uinteger_t size(const Loc& loc) final override;

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -1266,7 +1266,7 @@ public void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     // Restore symbol table
     cstate.CSpsymtab = symtabsave;
 
-    if (fd.isExport())
+    if (fd.isExport() || driverParams.exportVisibility == ExpVis.public_)
         objmod.export_symbol(s, cast(uint)Para.offset);
 
     if (fd.isCrtCtor)

--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -669,7 +669,6 @@ public:
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
                 vto.csym = null;
-                vto.isym = null;
 
                 ids.from.push(vd);
                 ids.to.push(vto);
@@ -845,7 +844,6 @@ public:
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
                 vto.csym = null;
-                vto.isym = null;
 
                 ids.from.push(vd);
                 ids.to.push(vto);
@@ -874,7 +872,6 @@ public:
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
                 vto.csym = null;
-                vto.isym = null;
 
                 ids.from.push(vd);
                 ids.to.push(vto);

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -881,6 +881,8 @@ void reconcileCommands(ref Param params, ref Target target)
             error(Loc.initial, "`-fPIC` and `-fPIE` cannot be used when targetting windows");
         if (driverParams.dwarf)
             error(Loc.initial, "`-gdwarf` cannot be used when targetting windows");
+        if (driverParams.exportVisibility == ExpVis.default_)
+            driverParams.exportVisibility = driverParams.dll ? ExpVis.public_ : ExpVis.hidden;
     }
     else if (target.os == Target.OS.DragonFlyBSD)
     {

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -793,6 +793,25 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         {
             driverParams.ibt = true;
         }
+        else if (startsWith(p + 1, "visibility="))
+        {
+            const(char)[] vis = arg["-visibility=".length .. $];
+
+            switch (vis)
+            {
+                case "default":
+                    driverParams.exportVisibility = ExpVis.default_;
+                    break;
+                case "hidden":
+                    driverParams.exportVisibility = ExpVis.hidden;
+                    break;
+                case "public":
+                    driverParams.exportVisibility = ExpVis.public_;
+                    break;
+                default:
+                    error("unknown visibility '%.*s', must be 'dwfault', 'hidden' or 'public'", cast(int) vis.length, vis.ptr);
+            }
+        }
         else if (arg == "-fPIC")
         {
             driverParams.pic = PIC.pic;

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -809,7 +809,26 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                     driverParams.exportVisibility = ExpVis.public_;
                     break;
                 default:
-                    error("unknown visibility '%.*s', must be 'dwfault', 'hidden' or 'public'", cast(int) vis.length, vis.ptr);
+                    error("unknown visibility '%.*s', must be 'default', 'hidden' or 'public'", cast(int) vis.length, vis.ptr);
+            }
+        }
+        else if (startsWith(p + 1, "dllimport="))
+        {
+            const(char)[] imp = arg["-dllimport=".length .. $];
+
+            switch (imp)
+            {
+                case "none":
+                    driverParams.symImport = SymImport.none;
+                    break;
+                case "defaultLibsOnly":
+                    driverParams.symImport = SymImport.defaultLibsOnly;
+                    break;
+                case "all":
+                    driverParams.symImport = SymImport.all;
+                    break;
+                default:
+                    error("unknown dllimport '%.*s', must be 'none', 'defaultLibsOnly' or 'all'", cast(int) imp.length, imp.ptr);
             }
         }
         else if (arg == "-fPIC")

--- a/compiler/src/dmd/tocsym.d
+++ b/compiler/src/dmd/tocsym.d
@@ -561,15 +561,15 @@ private Symbol *createImport(Symbol *sym, Loc loc)
     int idlen;
     if (target.os & Target.OS.Posix)
     {
-        error(loc, "could not generate import symbol for this platform");
+        error(loc, "could not generate import symbol `%s` for this platform", n);
         fatal();
     }
-    if (target.os & Target.OS.Windows && sym.Stype.Tty & mTYthread)
+    else if (target.os & Target.OS.Windows && sym.Stype.Tty & mTYthread)
     {
         error(loc, "cannot generate import symbol for thread local symbol `%s`", n);
         fatal();
     }
-    if (sym.Stype.Tmangle == mTYman_std && tyfunc(sym.Stype.Tty))
+    else if (sym.Stype.Tmangle == mTYman_std && tyfunc(sym.Stype.Tty))
     {
         if (target.os == Target.OS.Windows && target.isX86_64)
             idlen = snprintf(id, allocLen, "__imp_%s",n);

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -214,6 +214,8 @@ void genModuleInfo(Module m)
     //////////////////////////////////////////////
 
     objmod.moduleinfo(msym);
+    if (driverParams.exportVisibility == ExpVis.public_)
+        objmod.export_symbol(msym, 0);
 }
 
 /*****************************************
@@ -392,6 +394,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 sinit.Sdt = dtb.finish();
                 out_readonly(sinit);
                 outdata(sinit);
+                if (cd.isExport() || driverParams.exportVisibility == ExpVis.public_)
+                    objmod.export_symbol(sinit, 0);
             }
 
             //////////////////////////////////////////////
@@ -439,7 +443,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             out_readonly(cd.vtblsym.csym);
             outdata(cd.vtblsym.csym);
             if (cd.isExport() || driverParams.exportVisibility == ExpVis.public_)
-                objmod.export_symbol(cd.vtblsym.csym,0);
+                objmod.export_symbol(cd.vtblsym.csym, 0);
         }
 
         override void visit(InterfaceDeclaration id)
@@ -544,6 +548,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
                     else
                         out_readonly(sinit);    // put in read-only segment
                     outdata(sinit);
+                    if (sd.isExport() || driverParams.exportVisibility == ExpVis.public_)
+                        objmod.export_symbol(sinit, 0);
                 }
 
                 // Put out the members

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -438,7 +438,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             cd.vtblsym.csym.Sfl = FLdata;
             out_readonly(cd.vtblsym.csym);
             outdata(cd.vtblsym.csym);
-            if (cd.isExport())
+            if (cd.isExport() || driverParams.exportVisibility == ExpVis.public_)
                 objmod.export_symbol(cd.vtblsym.csym,0);
         }
 
@@ -673,7 +673,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             outdata(s);
             if (vd.type.isMutable() || !vd._init)
                 write_pointers(vd.type, s, 0);
-            if (vd.isExport())
+            if (vd.isExport() || driverParams.exportVisibility == ExpVis.public_)
                 objmod.export_symbol(s, 0);
         }
 
@@ -755,7 +755,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             }
 
             outdata(s);
-            if (tid.isExport())
+            if (tid.isExport() || driverParams.exportVisibility == ExpVis.public_)
                 objmod.export_symbol(s, 0);
         }
 
@@ -1443,7 +1443,7 @@ Louter:
     cd.csym.Sdt = dtb.finish();
     // ClassInfo cannot be const data, because we use the monitor on it
     outdata(cd.csym);
-    if (cd.isExport())
+    if (cd.isExport() || driverParams.exportVisibility == ExpVis.public_)
         objmod.export_symbol(cd.csym, 0);
 }
 
@@ -1598,6 +1598,6 @@ private void genClassInfoForInterface(InterfaceDeclaration id)
     id.csym.Sdt = dtb.finish();
     out_readonly(id.csym);
     outdata(id.csym);
-    if (id.isExport())
+    if (id.isExport() || driverParams.exportVisibility == ExpVis.public_)
         objmod.export_symbol(id.csym, 0);
 }


### PR DESCRIPTION
Rebases #14849 

Note that this PR is missing the changes in that PR to `win64.mak` because the makefiles have been redone. But that can be done os a separate PR.