### PR TITLE
ImportC: give error when encountering computed goto

### DIFF
--- a/compiler/test/fail_compilation/compgoto.i
+++ b/compiler/test/fail_compilation/compgoto.i
@@ -1,0 +1,18 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/compgoto.i(105): Error: unary `&&` computed goto extension is not supported
+fail_compilation/compgoto.i(106): Error: `goto *` computed goto extension is not supported
+---
+ */
+
+// https://gcc.gnu.org/onlinedocs/gcc/Labels-as-Values.html
+
+#line 100
+
+void test()
+{
+    void *ptr;
+  foo:
+    ptr = &&foo;
+    goto *ptr;
+}


### PR DESCRIPTION
Instead of the inscrutable error given by https://issues.dlang.org/show_bug.cgi?id=24291