### PR TITLE
getLines() shouldn't be reading files

### DIFF
--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -661,9 +661,9 @@ private void verrorPrint(const(char)* format, va_list ap, ref ErrorInfo info)
     {
         import dmd.root.filename : FileName;
         const fileName = FileName(loc.filename.toDString);
-        if (auto file = global.fileManager.lookup(fileName))
+        if (auto text = global.fileManager.lookup(fileName))
         {
-            const(char)[][] lines = global.fileManager.getLines(fileName);
+            const(char[])[] lines = global.fileManager.splitTextIntoLines(cast(const(char[])) text);
             if (loc.linnum - 1 < lines.length)
             {
                 auto line = lines[loc.linnum - 1];


### PR DESCRIPTION
It's fewer lines of code, too, to not do it!

Renamed `file` and `getLines` for clarity.

Most of the diff is changing the indent level.