### PR TITLE
supply definitions for if_nameindex_t and related symbols on musl libc

### DIFF
--- a/druntime/src/core/sys/posix/net/if_.d
+++ b/druntime/src/core/sys/posix/net/if_.d
@@ -143,6 +143,21 @@ else version (CRuntime_Bionic)
     uint            if_nametoindex(const scope char*);
     char*           if_indextoname(uint, char*);
 }
+else version (CRuntime_Musl)
+{
+    struct if_nameindex_t
+    {
+        uint    if_index;
+        char*   if_name;
+    }
+
+    enum IF_NAMESIZE = 16;
+
+    uint            if_nametoindex(const scope char*);
+    char*           if_indextoname(uint, char*);
+    if_nameindex_t* if_nameindex();
+    void            if_freenameindex(if_nameindex_t*);
+}
 else version (CRuntime_UClibc)
 {
     struct if_nameindex_t


### PR DESCRIPTION
From net/if.h on musl:
```c
struct if_nameindex {
        unsigned int if_index;
        char *if_name;
};

unsigned int if_nametoindex (const char *);
char *if_indextoname (unsigned int, char *);
struct if_nameindex *if_nameindex (void);
void if_freenameindex (struct if_nameindex *);
```