### PR TITLE
Fix issue 21893 - Fix `std.atomic.atomicStore` infinitely and recursively calling itself

### DIFF
--- a/druntime/src/core/atomic.d
+++ b/druntime/src/core/atomic.d
@@ -158,7 +158,15 @@ void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)(ref shared T val, V new
         static assert(!hasUnsharedIndirections!V, "Copying argument `" ~ V.stringof ~ " newval` to `" ~ shared(T).stringof ~ " here` would violate shared.");
         alias Thunk = V;
     }
-    atomicStore!ms(*cast(T*)&val, *cast(Thunk*)&newval);
+
+    static if (__traits(isFloating, T))
+    {
+        alias IntTy = IntForFloat!T;
+        alias IntTz = IntForFloat!Thunk;
+        core.internal.atomic.atomicStore!ms(cast(IntTy*)&val, *cast(IntTz*)&newval);
+    }
+    else
+        core.internal.atomic.atomicStore!ms(cast(T*)&val, *cast(Thunk*)&newval);
 }
 
 /// Ditto


### PR DESCRIPTION
Implements the change proposal in [bug #21893](https://issues.dlang.org/show_bug.cgi?id=21893), where `std.atomic.atomicStore` would infinitely and recursively call itself out of a vaguely-referenced function [which the compiler interpreted as calling itself].

Here's the minimal reproducable example to demonstrate the bug. Strangely, it works on some platforms, but does not on others.
```d
import std.stdio;
import core.atomic;

shared string test = "Hello";

void main() {
    writeln(test);
    atomicStore(test, "Goodbye");
    writeln(test);
}
```