### PR TITLE
fix CI builds: use absolute path for importc.h

### DIFF
--- a/compiler/src/dmd/cpreprocess.d
+++ b/compiler/src/dmd/cpreprocess.d
@@ -57,7 +57,7 @@ FileName preprocess(FileName csrcfile, ref const Loc loc, out bool ifile, OutBuf
         auto f = FileName.combine(entry, "importc.h");
         if (FileName.exists(f) == 1)
         {
-            importc_h = f;
+            importc_h = FileName.toAbsolute(f);
             break;
         }
         FileName.free(f);


### PR DESCRIPTION
cl.exe interprets the path to /FI as relative to the source file, so use an absolute path instead.
unlikely to be a user issue, as the configuration usually points to the absolute import path.