### PR TITLE
cache file lookup of importc.h

### DIFF
--- a/compiler/src/dmd/cpreprocess.d
+++ b/compiler/src/dmd/cpreprocess.d
@@ -39,6 +39,7 @@ version (Windows) version = runPreprocessor;
  * Preprocess C file.
  * Params:
  *      csrcfile = C file to be preprocessed, with .c or .h extension
+ *      importc_h = the path/file of importc.h
  *      loc = The source location where preprocess is requested from
  *      ifile = set to true if an output file was written
  *      defines = buffer to append any `#define` and `#undef` lines encountered to
@@ -46,23 +47,8 @@ version (Windows) version = runPreprocessor;
  *      filename of preprocessed output
  */
 extern (C++)
-FileName preprocess(FileName csrcfile, ref const Loc loc, out bool ifile, OutBuffer* defines)
+FileName preprocess(FileName csrcfile, const(char)* importc_h, ref const Loc loc, out bool ifile, ref OutBuffer defines)
 {
-    /* Look for "importc.h" by searching along import path.
-     */
-    const(char)* importc_h = findImportcH(global.path ? (*global.path)[] : null);
-
-    if (importc_h)
-    {
-        if (global.params.v.verbose)
-            message("include   %s", importc_h);
-    }
-    else
-    {
-        error(loc, "cannot find \"importc.h\" along import path");
-        fatal();
-    }
-
     //printf("preprocess %s\n", csrcfile.toChars());
     version (runPreprocessor)
     {

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -21,6 +21,7 @@ import dmd.arraytypes;
 import dmd.astcodegen;
 import dmd.astenums;
 import dmd.compiler;
+import dmd.cpreprocess;
 import dmd.gluelayer;
 import dmd.dimport;
 import dmd.dmacro;
@@ -690,7 +691,18 @@ extern (C++) final class Module : Package
             FileName.equalsExt(srcfile.toString(), c_ext) &&
             FileName.exists(srcfile.toString()))
         {
-            filename = global.preprocess(srcfile, loc, ifile, &defines);  // run C preprocessor
+            if (!global.importc_h)
+            {
+                global.importc_h = findImportcH(global.path ? (*global.path)[] : null);
+                if (!global.importc_h)
+                {
+                    error(loc, "cannot find \"importc.h\" along import path");
+                    fatal();
+                }
+            }
+            if (global.params.v.verbose)
+                message("include   %s", global.importc_h);
+            filename = global.preprocess(srcfile, global.importc_h, loc, ifile, defines);  // run C preprocessor
         }
 
         if (auto result = global.fileManager.lookup(filename))

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6631,7 +6631,7 @@ extern const char* toCppMangleDMC(Dsymbol* s);
 
 extern const char* cppTypeInfoMangleDMC(Dsymbol* s);
 
-extern FileName preprocess(FileName csrcfile, const Loc& loc, bool& ifile, OutBuffer* defines);
+extern FileName preprocess(FileName csrcfile, const char* importc_h, const Loc& loc, bool& ifile, OutBuffer& defines);
 
 extern MATCH implicitConvTo(Expression* e, Type* t);
 
@@ -8358,6 +8358,7 @@ struct Global final
     _d_dynamicArray< const char > written;
     Array<const char* >* path;
     Array<const char* >* filePath;
+    const char* importc_h;
     char datetime[26LLU];
     CompileEnv compileEnv;
     Param params;
@@ -8376,7 +8377,7 @@ struct Global final
 
     ErrorSink* errorSink;
     ErrorSink* errorSinkNull;
-    FileName(*preprocess)(FileName , const Loc& , bool& , OutBuffer* );
+    FileName(*preprocess)(FileName , const char* , const Loc& , bool& , OutBuffer& );
     uint32_t startGagging();
     bool endGagging(uint32_t oldGagged);
     void increaseErrorCount();
@@ -8389,6 +8390,7 @@ struct Global final
         written(24, "written by Walter Bright"),
         path(),
         filePath(),
+        importc_h(),
         compileEnv(),
         params(),
         errors(),
@@ -8407,12 +8409,13 @@ struct Global final
         preprocess()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, CompileEnv compileEnv = CompileEnv(), Param params = Param(), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, ErrorSink* errorSink = nullptr, ErrorSink* errorSinkNull = nullptr, FileName(*preprocess)(FileName , const Loc& , bool& , OutBuffer* ) = nullptr) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* >* path = nullptr, Array<const char* >* filePath = nullptr, const char* importc_h = nullptr, CompileEnv compileEnv = CompileEnv(), Param params = Param(), uint32_t errors = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* >* versionids = nullptr, Array<Identifier* >* debugids = nullptr, bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, ErrorSink* errorSink = nullptr, ErrorSink* errorSinkNull = nullptr, FileName(*preprocess)(FileName , const char* , const Loc& , bool& , OutBuffer& ) = nullptr) :
         inifilename(inifilename),
         copyright(copyright),
         written(written),
         path(path),
         filePath(filePath),
+        importc_h(importc_h),
         compileEnv(compileEnv),
         params(params),
         errors(errors),

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -281,6 +281,8 @@ extern (C++) struct Global
     Array!(const(char)*)* path;         /// Array of char*'s which form the import lookup path
     Array!(const(char)*)* filePath;     /// Array of char*'s which form the file import lookup path
 
+    const(char)* importc_h;             /// full path of the file importc.h
+
     private enum string _version = import("VERSION");
     char[26] datetime;      /// string returned by ctime()
     CompileEnv compileEnv;
@@ -308,7 +310,7 @@ extern (C++) struct Global
     ErrorSink errorSink;       /// where the error messages go
     ErrorSink errorSinkNull;   /// where the error messages are ignored
 
-    extern (C++) FileName function(FileName, ref const Loc, out bool, OutBuffer*) preprocess;
+    extern (C++) FileName function(FileName, const(char)*, ref const Loc, out bool, ref OutBuffer) preprocess;
 
   nothrow:
 

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -285,6 +285,8 @@ struct Global
     Array<const char *> *path;        // Array of char*'s which form the import lookup path
     Array<const char *> *filePath;    // Array of char*'s which form the file import lookup path
 
+    const char* importc_h;            // full path of the file importc.h
+
     char datetime[26];       /// string returned by ctime()
     CompileEnv compileEnv;
 
@@ -307,7 +309,7 @@ struct Global
     ErrorSink* errorSink;       // where the error messages go
     ErrorSink* errorSinkNull;   // where the error messages disappear
 
-    FileName (*preprocess)(FileName, const Loc&, bool&, OutBuffer&);
+    FileName (*preprocess)(FileName, const char*, const Loc&, bool&, OutBuffer&);
 
     /* Start gagging. Return the current number of gagged errors
      */

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1050,7 +1050,7 @@ public int runProgram()
  *    exit status.
  */
 public int runPreprocessor(const(char)[] cpp, const(char)[] filename, const(char)* importc_h, ref Array!(const(char)*) cppswitches,
-    const(char)[] output, OutBuffer* defines)
+    const(char)[] output, ref OutBuffer defines)
 {
     //printf("runPreprocessor() cpp: %.*s filename: %.*s\n", cast(int)cpp.length, cpp.ptr, cast(int)filename.length, filename.ptr);
     version (Windows)


### PR DESCRIPTION
1. caches lookup of importc.h so it isn't redone for every .c file
2. passes OutBuffer by ref instead of pointer
3. instead of passing ErrorSink to the function, move the reporting of errors up a level
4. not sure if it should be calling fatal() at all, will revisit in another PR
5. reduce use of `global` in lower level function

@ibuclaw @kinke this change probably affects you, as it changes the signature of preprocess().