### PR TITLE
Fix GDC regression wrt to headers - make dmd.typesem.covariant extern(C++)

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -5439,6 +5439,8 @@ public:
     void accept(Visitor* v) override;
 };
 
+extern Covariant covariant(Type* src, Type* t, uint64_t* pstc = nullptr, bool cppCovariant = false);
+
 extern Expression* defaultInit(Type* mt, const Loc& loc, const bool isCfile = false);
 
 extern Type* merge(Type* type);

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -5295,7 +5295,7 @@ Type getComplexLibraryType(const ref Loc loc, Scope* sc, TY ty)
  * Returns:
  *     An enum value of either `Covariant.yes` or a reason it's not covariant.
  */
-Covariant covariant(Type src, Type t, StorageClass* pstc = null, bool cppCovariant = false)
+extern(C++) Covariant covariant(Type src, Type t, StorageClass* pstc = null, bool cppCovariant = false)
 {
     version (none)
     {

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1682,6 +1682,11 @@ void test_backend(FuncDeclaration *f, Type *t)
     f->fbody->accept(&v);
 }
 
+void link_test_typesem(Type *t1, Type *t2)
+{
+    covariant(t1, t2);
+}
+
 /**********************************/
 
 int main(int argc, char **argv)


### PR DESCRIPTION
When moving the function outside of Type I forgot to add `extern(C++)`. Previously, the method was `extern(C++)` because Type is `extern(C++)`.