### PR TITLE
Extract dmd.mtype.type.hasPointers and move it to dmd.typesem

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6648,6 +6648,7 @@ Expressions* copyArrayOnWrite(Expressions* exps, Expressions* original)
 private
 bool stopPointersEscaping(const ref Loc loc, Expression e)
 {
+    import dmd.typesem : hasPointers;
     if (!e.type.hasPointers())
         return true;
     if (isPointer(e.type))

--- a/compiler/src/dmd/escape.d
+++ b/compiler/src/dmd/escape.d
@@ -34,7 +34,7 @@ import dmd.mtype;
 import dmd.printast;
 import dmd.rootobject;
 import dmd.tokens;
-import dmd.typesem : parameterStorageClass;
+import dmd.typesem : hasPointers, parameterStorageClass;
 import dmd.visitor;
 import dmd.arraytypes;
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1875,7 +1875,6 @@ public:
     virtual bool isZeroInit(const Loc& loc);
     Identifier* getTypeInfoIdent();
     virtual int32_t hasWild() const;
-    virtual bool hasPointers();
     virtual bool hasVoidInitPointers();
     virtual bool hasSystemFields();
     virtual bool hasInvariant();
@@ -4310,7 +4309,6 @@ public:
     uinteger_t size(const Loc& loc) override;
     bool isZeroInit(const Loc& loc) override;
     bool isBoolean() override;
-    bool hasPointers() override;
     MATCH implicitConvTo(Type* to) override;
     MATCH constConv(Type* to) override;
     void accept(Visitor* v) override;
@@ -4367,7 +4365,6 @@ public:
     bool isZeroInit(const Loc& loc) override;
     bool isscope() override;
     bool isBoolean() override;
-    bool hasPointers() override;
     void accept(Visitor* v) override;
 };
 
@@ -4382,7 +4379,6 @@ public:
     bool isZeroInit(const Loc& loc) override;
     bool isBoolean() override;
     MATCH implicitConvTo(Type* to) override;
-    bool hasPointers() override;
     void accept(Visitor* v) override;
 };
 
@@ -4398,7 +4394,6 @@ public:
     MATCH implicitConvTo(Type* to) override;
     bool isZeroInit(const Loc& loc) override;
     bool isBoolean() override;
-    bool hasPointers() override;
     void accept(Visitor* v) override;
 };
 
@@ -4428,7 +4423,6 @@ public:
     MATCH implicitConvTo(Type* to) override;
     MATCH constConv(Type* to) override;
     bool isZeroInit(const Loc& loc) override;
-    bool hasPointers() override;
     bool hasVoidInitPointers() override;
     bool hasSystemFields() override;
     bool hasInvariant() override;
@@ -4623,7 +4617,6 @@ public:
     const char* kind() const override;
     TypeNull* syntaxCopy() override;
     MATCH implicitConvTo(Type* to) override;
-    bool hasPointers() override;
     bool isBoolean() override;
     uinteger_t size(const Loc& loc) override;
     void accept(Visitor* v) override;
@@ -4640,7 +4633,6 @@ public:
     MATCH constConv(Type* to) override;
     bool isscalar() override;
     bool isZeroInit(const Loc& loc) override;
-    bool hasPointers() override;
     void accept(Visitor* v) override;
 };
 
@@ -4678,7 +4670,6 @@ public:
     MATCH constConv(Type* to) override;
     MATCH implicitConvTo(Type* to) override;
     Expression* defaultInitLiteral(const Loc& loc) override;
-    bool hasPointers() override;
     bool hasSystemFields() override;
     bool hasVoidInitPointers() override;
     bool hasInvariant() override;
@@ -4718,7 +4709,6 @@ public:
     bool needsDestruction() override;
     bool needsCopyOrPostblit() override;
     bool needsNested() override;
-    bool hasPointers() override;
     bool hasVoidInitPointers() override;
     bool hasSystemFields() override;
     bool hasInvariant() override;
@@ -5441,6 +5431,8 @@ public:
 extern Covariant covariant(Type* src, Type* t, uint64_t* pstc = nullptr, bool cppCovariant = false);
 
 extern Expression* defaultInit(Type* mt, const Loc& loc, const bool isCfile = false);
+
+extern bool hasPointers(Type* t);
 
 extern Type* merge(Type* type);
 

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3624,6 +3624,7 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
  */
 Type getIndirection(Type t)
 {
+    import dmd.typesem : hasPointers;
     t = t.baseElemOf();
     if (t.ty == Tarray || t.ty == Tpointer)
         return t.nextOf().toBasetype();
@@ -3670,6 +3671,7 @@ private bool traverseIndirections(Type ta, Type tb)
 
     static bool traverse(Type ta, Type tb, ref scope AssocArray!(const(char)*, bool) table, bool reversePass)
     {
+        import dmd.typesem : hasPointers;
         //printf("traverse(%s, %s)\n", ta.toChars(), tb.toChars());
         ta = ta.baseElemOf();
         tb = tb.baseElemOf();

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -304,7 +304,6 @@ public:
     virtual bool isZeroInit(const Loc &loc = Loc()); // if initializer is 0
     Identifier *getTypeInfoIdent();
     virtual int hasWild() const;
-    virtual bool hasPointers();
     virtual bool hasVoidInitPointers();
     virtual bool hasSystemFields();
     virtual bool hasInvariant();
@@ -451,7 +450,6 @@ public:
     MATCH constConv(Type *to) override;
     MATCH implicitConvTo(Type *to) override;
     Expression *defaultInitLiteral(const Loc &loc) override;
-    bool hasPointers() override;
     bool hasSystemFields() override;
     bool hasVoidInitPointers() override;
     bool hasInvariant() override;
@@ -474,7 +472,6 @@ public:
     bool isZeroInit(const Loc &loc) override;
     bool isBoolean() override;
     MATCH implicitConvTo(Type *to) override;
-    bool hasPointers() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -491,7 +488,6 @@ public:
     uinteger_t size(const Loc &loc) override;
     bool isZeroInit(const Loc &loc) override;
     bool isBoolean() override;
-    bool hasPointers() override;
     MATCH implicitConvTo(Type *to) override;
     MATCH constConv(Type *to) override;
 
@@ -509,7 +505,6 @@ public:
     MATCH constConv(Type *to) override;
     bool isscalar() override;
     bool isZeroInit(const Loc &loc) override;
-    bool hasPointers() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -658,7 +653,6 @@ public:
     MATCH implicitConvTo(Type *to) override;
     bool isZeroInit(const Loc &loc) override;
     bool isBoolean() override;
-    bool hasPointers() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -784,7 +778,6 @@ public:
     bool needsDestruction() override;
     bool needsCopyOrPostblit() override;
     bool needsNested() override;
-    bool hasPointers() override;
     bool hasVoidInitPointers() override;
     bool hasSystemFields() override;
     bool hasInvariant() override;
@@ -823,7 +816,6 @@ public:
     MATCH implicitConvTo(Type *to) override;
     MATCH constConv(Type *to) override;
     bool isZeroInit(const Loc &loc) override;
-    bool hasPointers() override;
     bool hasVoidInitPointers() override;
     bool hasSystemFields() override;
     bool hasInvariant() override;
@@ -852,7 +844,6 @@ public:
     bool isZeroInit(const Loc &loc) override;
     bool isscope() override;
     bool isBoolean() override;
-    bool hasPointers() override;
 
     void accept(Visitor *v) override { v->visit(this); }
 };
@@ -893,7 +884,6 @@ public:
 
     TypeNull *syntaxCopy() override;
     MATCH implicitConvTo(Type *to) override;
-    bool hasPointers() override;
     bool isBoolean() override;
 
     uinteger_t size(const Loc &loc) override;
@@ -924,6 +914,8 @@ public:
 
 /**************************************************************/
 
+
 // If the type is a class or struct, returns the symbol for it, else null.
 AggregateDeclaration *isAggregate(Type *t);
+bool hasPointers(Type *t);
 Covariant covariant(Type *, Type *, StorageClass * = NULL, bool = false);

--- a/compiler/src/dmd/ob.d
+++ b/compiler/src/dmd/ob.d
@@ -2566,6 +2566,7 @@ void checkObErrors(ref ObState obstate)
                 //printf("%s: ", obstate.vars[i].toChars()); pvs.print(obstate.vars[]);
                 if (pvs.state == PtrState.Owner)
                 {
+                    import dmd.typesem : hasPointers;
                     auto v = obstate.vars[i];
                     if (v.type.hasPointers())
                         .error(v.loc, "%s `%s` is not disposed of before return", v.kind, v.toPrettyChars);

--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -26,6 +26,7 @@ import dmd.identifier;
 import dmd.mtype;
 import dmd.target;
 import dmd.tokens;
+import dmd.typesem : hasPointers;
 import dmd.func : setUnsafe, setUnsafePreview;
 
 /*************************************************************

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -245,6 +245,7 @@ void write_pointers(Type type, Symbol *s, uint offset)
 */
 void write_instance_pointers(Type type, Symbol *s, uint offset)
 {
+    import dmd.typesem : hasPointers;
     if (!type.hasPointers())
         return;
 

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -220,7 +220,7 @@ void test_visitors()
     assert(tv.stmt == true);
 
     TypePointer *tp = TypePointer::create(Type::tvoid);
-    assert(tp->hasPointers() == true);
+    assert(hasPointers(tp) == true);
     tp->accept(&tv);
     assert(tv.type == true);
 


### PR DESCRIPTION
Arguably, this could have been kept in dmd.mtype, however, struct types check recursively if any fields have pointers and for that we need to do semantic on all the field types. This means we need to extract from mtype.d