### PR TITLE
fix issue 24309 - Memory allocation failed on Azure pipeline

### DIFF
--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -4989,8 +4989,8 @@ version (D_LP64) unittest
         // only run if the system has enough physical memory
         size_t sz = 2L^^32;
         //import core.stdc.stdio;
-        //printf("availphys = %lld", os_physical_mem());
-        if (os_physical_mem() > sz)
+        //printf("availphys = %lld", os_physical_mem(true));
+        if (os_physical_mem(true) > sz)
         {
             import core.memory;
             GC.collect();


### PR DESCRIPTION
only run GC test that requires 4 GB of memory if that's available as *free* physical memory

Please note that `os_physical_mem()` is only used by this test.