### PR TITLE
Fix Issue 24319 - OpenBSD: Use correct type for file_time

### DIFF
--- a/compiler/src/dmd/libmach.d
+++ b/compiler/src/dmd/libmach.d
@@ -484,7 +484,14 @@ struct MachObjModule
     uint length; // in bytes
     uint offset; // offset from start of library
     const(char)[] name; // module name (file name) with terminating 0
+version (OpenBSD)
+{
+    long file_time; // file time
+}
+else
+{
     c_long file_time; // file time
+}
     uint user_id;
     uint group_id;
     uint file_mode;

--- a/compiler/src/dmd/libmach.d
+++ b/compiler/src/dmd/libmach.d
@@ -484,14 +484,7 @@ struct MachObjModule
     uint length; // in bytes
     uint offset; // offset from start of library
     const(char)[] name; // module name (file name) with terminating 0
-version (OpenBSD)
-{
-    long file_time; // file time
-}
-else
-{
-    c_long file_time; // file time
-}
+    time_t file_time; // file time
     uint user_id;
     uint group_id;
     uint file_mode;


### PR DESCRIPTION
statbuf.st_ctime is always 64-bit on OpenBSD.