### PR TITLE
Do not use `Loc.inital` as a default parameter

### DIFF
--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6712,7 +6712,7 @@ Statement findGotoTarget(InterState* istate, Identifier ident)
     Statement target = null;
     if (ident)
     {
-        LabelDsymbol label = istate.fd.searchLabel(ident);
+        LabelDsymbol label = istate.fd.searchLabel(ident, Loc.initial);
         assert(label && label.statement);
         LabelStatement ls = label.statement;
         target = ls.gotoTarget ? ls.gotoTarget : ls.statement;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3790,7 +3790,7 @@ public:
     bool overloadInsert(Dsymbol* s) override;
     bool inUnittest();
     MATCH leastAsSpecialized(FuncDeclaration* g, Array<Identifier* >* names);
-    LabelDsymbol* searchLabel(Identifier* ident, const Loc& loc = Loc::initial);
+    LabelDsymbol* searchLabel(Identifier* ident, const Loc& loc);
     enum : int32_t { LevelError = -2 };
 
     const char* toPrettyChars(bool QualifyTypes = false) override;
@@ -4404,7 +4404,7 @@ public:
     const char* kind() const override;
     TypeEnum* syntaxCopy() override;
     uinteger_t size(const Loc& loc) override;
-    Type* memType(const Loc& loc = Loc::initial);
+    Type* memType();
     uint32_t alignsize() override;
     Dsymbol* toDsymbol(Scope* sc) override;
     bool isintegral() override;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1195,7 +1195,7 @@ extern (C++) class FuncDeclaration : Declaration
      *
      * Returns: the `LabelDsymbol` for `ident`
      */
-    final LabelDsymbol searchLabel(Identifier ident, const ref Loc loc = Loc.initial)
+    final LabelDsymbol searchLabel(Identifier ident, const ref Loc loc)
     {
         Dsymbol s;
         if (!labtab)

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -5220,9 +5220,9 @@ extern (C++) final class TypeEnum : Type
         return sym.getMemtype(loc).size(loc);
     }
 
-    Type memType(const ref Loc loc = Loc.initial)
+    Type memType()
     {
-        return sym.getMemtype(loc);
+        return sym.getMemtype(Loc.initial);
     }
 
     override uint alignsize()

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -798,7 +798,7 @@ public:
     TypeEnum *syntaxCopy() override;
     uinteger_t size(const Loc &loc) override;
     unsigned alignsize() override;
-    Type *memType(const Loc &loc = Loc());
+    Type *memType(const Loc &loc);
     Dsymbol *toDsymbol(Scope *sc) override;
     bool isintegral() override;
     bool isfloating() override;

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -569,7 +569,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 if ((needEnsure && global.params.useOut == CHECKENABLE.on) || fpostinv)
                 {
-                    funcdecl.returnLabel = funcdecl.searchLabel(Id.returnLabel);
+                    funcdecl.returnLabel = funcdecl.searchLabel(Id.returnLabel, Loc.initial);
                 }
 
                 // scope of out contract (need for vresult.semantic)


### PR DESCRIPTION
because `dtoh` messes up emission of it. This only fixes (that particular part of)  `frontend.h` emission issues, not the issue of `dtoh` messing up `extern(D)` symbols appearing in `extern(C++)` parameter lists.