### PR TITLE
rename lookup() to getFileContents()

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -705,7 +705,7 @@ extern (C++) final class Module : Package
             filename = global.preprocess(srcfile, global.importc_h, loc, ifile, defines);  // run C preprocessor
         }
 
-        if (auto result = global.fileManager.lookup(filename))
+        if (auto result = global.fileManager.getFileContents(filename))
         {
             this.src = result;
             if (global.params.makeDeps.doOutput)

--- a/compiler/src/dmd/errors.d
+++ b/compiler/src/dmd/errors.d
@@ -661,7 +661,7 @@ private void verrorPrint(const(char)* format, va_list ap, ref ErrorInfo info)
     {
         import dmd.root.filename : FileName;
         const fileName = FileName(loc.filename.toDString);
-        if (auto text = global.fileManager.lookup(fileName))
+        if (auto text = global.fileManager.getFileContents(fileName))
         {
             auto range = global.fileManager.splitLines(cast(const(char[])) text);
             size_t linnum;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -7584,7 +7584,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         {
             auto fileName = FileName(resolvedNamez);
-            if (auto fmResult = global.fileManager.lookup(fileName))
+            if (auto fmResult = global.fileManager.getFileContents(fileName))
             {
                 se = new StringExp(e.loc, fmResult);
             }


### PR DESCRIPTION
`lookup()` is an overused name in the source code. Rename it and document it better.