### PR TITLE
eliminate global references from printTemplateStats()

### DIFF
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -6553,7 +6553,8 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     TemplateDeclaration tempdecl = tempinst.tempdecl.isTemplateDeclaration();
     assert(tempdecl);
 
-    TemplateStats.incInstance(tempdecl, tempinst);
+    if (global.params.v.templates)
+        TemplateStats.incInstance(tempdecl, tempinst, global.params.v.templatesListInstances);
 
     tempdecl.checkDeprecated(tempinst.loc, sc);
 
@@ -6746,7 +6747,8 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, ArgumentList
     tempinst.parent = tempinst.enclosing ? tempinst.enclosing : tempdecl.parent;
     //printf("parent = '%s'\n", parent.kind());
 
-    TemplateStats.incUnique(tempdecl, tempinst);
+    if (global.params.v.templates)
+        TemplateStats.incUnique(tempdecl, tempinst);
 
     TemplateInstance tempdecl_instance_idx = tempdecl.addInstance(tempinst);
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1938,7 +1938,7 @@ extern Tuple* isTuple(RootObject* o);
 
 extern Type* isType(RootObject* o);
 
-extern void printTemplateStats();
+extern void printTemplateStats(bool listInstances, ErrorSink* eSink);
 
 class DebugSymbol final : public Dsymbol
 {

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -561,7 +561,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     }
 
     printCtfePerformanceStats();
-    printTemplateStats();
+    printTemplateStats(global.params.v.templatesListInstances, global.errorSink);
 
     // Generate output files
     if (params.json.doOutput)

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -324,4 +324,4 @@ Tuple *isTuple(RootObject *o);
 Parameter *isParameter(RootObject *o);
 TemplateParameter *isTemplateParameter(RootObject *o);
 bool isError(const RootObject *const o);
-void printTemplateStats();
+void printTemplateStats(bool listInstances, ErrorSink* eSink);


### PR DESCRIPTION
Front door only