### PR TITLE
Demangle symbols in linker errors

### DIFF
--- a/changelog/dmd.linker-error.dd
+++ b/changelog/dmd.linker-error.dd
@@ -1,0 +1,66 @@
+Missing symbol errors are made less cryptic
+
+It is not uncommon to forget to link a library, list a .d file on the command line, or include a `main` function.
+Example:
+---
+module app;
+
+unittest
+{
+    import assertions;
+    assertEquals('D', 'D');
+}
+---
+
+---
+module assertions;
+
+void assertEquals(char a, char b)
+{
+    assert(a == b);
+}
+---
+
+When compiling this as follows:
+
+$(CONSOLE
+\> dmd -unittest app.d
+)
+
+The compiler would not see any error, but at link time there are missing symbols.
+Formerly, this would result in a cryptic linker error with mangled symbol names:
+
+$(CONSOLE
+/usr/bin/ld: /usr/lib/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../lib/Scrt1.o: in function `_start':
+(.text+0x1b): undefined reference to `main'
+/usr/bin/ld: app.o: in function `_D3app16__unittest_L5_C1FZv':
+app.d:(.text._D3app16__unittest_L5_C1FZv[_D3app16__unittest_L5_C1FZv]+0xc): undefined reference to `_D10assertions12assertEqualsFaaZv'
+collect2: error: ld returned 1 exit status
+)
+
+Experienced users might know how to demangle the symbol to make it more readable:
+
+$(CONSOLE
+\> echo _D10assertions12assertEqualsFaaZv | ddemangle
+void assertions.assertEquals(char, char)
+)
+
+But this is inconvenient to do manually every time.
+Now, when the compiler invokes the linker program, it will read its output, scan for undefined symbol errors, and demangle the names:
+
+$(CONSOLE
+Error: undefined reference to `main`
+Error: undefined reference to `void assertions.assertEquals(char, char)`
+       referenced from `void app.__unittest_L5_C1()`
+       perhaps define a `void main() {}` function or use the `-main` switch
+       perhaps `.d` files need to be added on the command line, or use `-i` to compile imports
+Error: linker exited with status 1
+)
+
+Which makes it easier to fix the command:
+$(CONSOLE
+\> dmd -unittest -main -i app.d
+)
+
+Currently supported linkers are ld, bfd, gold, mold, and Microsoft LINK.
+Please file an issue if your linker's errors aren't detected.

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -105,54 +105,35 @@ else
 version (Posix)
 {
     /*****************************
-     * As it forwards the linker error message to stderr, checks for the presence
-     * of an error indicating lack of a main function (NME_ERR_MSG).
+     * Extract stderr piped through `fd` into OutBuffer `o` so it can be parsed for better error messages.
      *
-     * Returns:
-     *      1 if there is a no main error
-     *     -1 if there is an IO error
-     *      0 otherwise
+     * Returns: `true` on success, `false` on IO error
      */
-    private int findNoMainError(int fd)
+    private bool pipeProcessOutput(int fd, ref OutBuffer o)
     {
-        version (OSX)
-        {
-            static immutable(char*) nmeErrorMessage = "`__Dmain`, referenced from:";
-        }
-        else
-        {
-            static immutable(char*) nmeErrorMessage = "undefined reference to `_Dmain`";
-        }
         FILE* stream = fdopen(fd, "r");
         if (stream is null)
-            return -1;
+            return false;
         const(size_t) len = 64 * 1024 - 1;
-        char[len + 1] buffer; // + '\0'
+        char[len + 1] buffer = '\0'; // + '\0'
         size_t beg = 0, end = len;
-        bool nmeFound = false;
         for (;;)
         {
             // read linker output
             const(size_t) n = fread(&buffer[beg], 1, len - beg, stream);
             if (beg + n < len && ferror(stream))
-                return -1;
-            buffer[(end = beg + n)] = '\0';
-            // search error message, stop at last complete line
-            const(char)* lastSep = strrchr(buffer.ptr, '\n');
-            if (lastSep)
-                buffer[(end = lastSep - &buffer[0])] = '\0';
-            if (strstr(&buffer[0], nmeErrorMessage))
-                nmeFound = true;
-            if (lastSep)
-                buffer[end++] = '\n';
-            if (fwrite(&buffer[0], 1, end, stderr) < end)
-                return -1;
+                return false;
+            end = beg + n;
+
+            o.writestring(buffer[0 .. end]);
+            if (fwrite(&buffer[0], char.sizeof, end, stderr) < end)
+                return false;
             if (beg + n < len && feof(stream))
                 break;
             // copy over truncated last line
             memcpy(&buffer[0], &buffer[end], (beg = len - end));
         }
-        return nmeFound ? 1 : 0;
+        return true;
     }
 }
 
@@ -345,12 +326,14 @@ public int runLINK(bool verbose, ErrorSink eSink)
                 }
             }
 
-            const int status = executecmd(linkcmd, p.ptr, verbose, eSink);
+            OutBuffer buf;
+            const int status = executecmd(linkcmd, p.ptr, verbose, eSink, buf);
             if (lnkfilename)
             {
                 lnkfilename.toCStringThen!(lf => remove(lf.ptr));
                 FileName.free(lnkfilename.ptr);
             }
+            parseLinkerOutput(cast(const(char)[]) buf.peekSlice(), new ErrorSinkCompiler());
             return status;
         }
         else if (target.objectFormat() == Target.ObjectFormat.omf)
@@ -459,12 +442,15 @@ public int runLINK(bool verbose, ErrorSink eSink)
             const(char)* linkcmd = getenv("LINKCMD");
             if (!linkcmd)
                 linkcmd = "optlink";
-            const int status = executecmd(linkcmd, p.ptr, verbose, eSink);
+            OutBuffer buf;
+            const int status = executecmd(linkcmd, p.ptr, verbose, eSink, buf);
             if (lnkfilename)
             {
                 lnkfilename.toCStringThen!(lf => remove(lf.ptr));
                 FileName.free(lnkfilename.ptr);
             }
+            parseLinkerOutput(cast(const(char)[]) buf.peekSlice(), new ErrorSinkCompiler());
+
             return status;
         }
         else
@@ -803,24 +789,26 @@ public int runLINK(bool verbose, ErrorSink eSink)
             return STATUS_FAILED;
         }
         close(fds[1]);
-        const(int) nme = findNoMainError(fds[0]);
+        OutBuffer outputBuf;
+        const pipeSuccess = pipeProcessOutput(fds[0], outputBuf);
+
+        ///
         waitpid(childpid, &status, 0);
         if (WIFEXITED(status))
         {
             status = WEXITSTATUS(status);
             if (status)
             {
-                if (nme == -1)
+                if (!pipeSuccess)
                 {
                     perror("error with the linker pipe");
                     return -1;
                 }
                 else
                 {
+                    parseLinkerOutput(cast(const(char)[]) outputBuf.peekSlice(), new ErrorSinkCompiler());
                     eSink.error(Loc.initial, "linker exited with status %d", status);
                     eSink.errorSupplemental(Loc.initial, "%s", linkerCommand);
-                    if (nme == 1)
-                        eSink.error(Loc.initial, "no main function specified");
                 }
             }
         }
@@ -851,7 +839,7 @@ public int runLINK(bool verbose, ErrorSink eSink)
  */
 version (Windows)
 {
-    private int executecmd(const(char)* cmd, const(char)* args, bool verbose, ErrorSink eSink)
+    private int executecmd(const(char)* cmd, const(char)* args, bool verbose, ErrorSink eSink, ref OutBuffer buf)
     {
         int status;
         size_t len;
@@ -882,14 +870,44 @@ version (Windows)
                 cmdbuf.writestring("\" ");
                 cmdbuf.writestring(args);
 
+                HANDLE[2] pipe;
+                SECURITY_ATTRIBUTES saAttr;
+                saAttr.nLength = SECURITY_ATTRIBUTES.sizeof;
+                saAttr.bInheritHandle = true;
+                saAttr.lpSecurityDescriptor = null;
+                if (!CreatePipe(&pipe[0], &pipe[1], &saAttr, /*buffer size suggestion*/ 0))
+                {
+                    GetLastError();
+                }
+                if (!SetHandleInformation(pipe[0], /*mask*/ HANDLE_FLAG_INHERIT, /*flags*/ 0))
+                {
+                    GetLastError();
+                }
+
                 STARTUPINFOA startInf;
+                startInf.cb = startInf.sizeof;
                 startInf.dwFlags = STARTF_USESTDHANDLES;
                 startInf.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
-                startInf.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+                startInf.hStdOutput = pipe[1];
                 startInf.hStdError = GetStdHandle(STD_ERROR_HANDLE);
                 PROCESS_INFORMATION procInf;
 
                 BOOL b = CreateProcessA(null, cmdbuf.peekChars(), null, null, 1, NORMAL_PRIORITY_CLASS, null, null, &startInf, &procInf);
+                CloseHandle(pipe[1]); // child does not need this end
+
+                ubyte[1024] buffer;
+                DWORD bytesRead;
+                for (;;)
+                {
+                    if (ReadFile(pipe[0], buffer.ptr, buffer.length, &bytesRead, /*lpOverlapped*/ null))
+                    {
+                        fwrite(buffer.ptr, bytesRead, ubyte.sizeof, stderr);
+                        buf.write(buffer[0 .. bytesRead]);
+                    }
+                    else
+                        break;
+                }
+
                 if (b)
                 {
                     WaitForSingleObject(procInf.hProcess, INFINITE);
@@ -1602,6 +1620,11 @@ int runProcessCollectStdout(const(wchar)* szCommand, ubyte[] buffer, void delega
 /****************************************
  * Write filename to cmdbuf, quoting if necessary.
  */
+private void writeFilename(OutBuffer* buf, const(char)* filename)
+{
+    writeFilename(buf, filename.toDString());
+}
+
 private void writeFilename(OutBuffer* buf, const(char)[] filename) @safe
 {
     /* Loop and see if we need to quote
@@ -1622,7 +1645,235 @@ private void writeFilename(OutBuffer* buf, const(char)[] filename) @safe
     buf.writestring(filename);
 }
 
-private void writeFilename(OutBuffer* buf, const(char)* filename)
+/**
+Translate linker output to more user-friendly error messages, by extracting mangled symbols and demangling them
+Params:
+    linkerOutput = text that the linker printed
+    eSink = sink for translated errors
+*/
+void parseLinkerOutput(const(char)[] linkerOutput, ErrorSink eSink)
 {
-    writeFilename(buf, filename.toDString());
+    // Some linkers quote symbols like `so' or 'so', strip the quotes
+    static string unquote(string s)
+    {
+        if (s.length < 2)
+            return s;
+        if (s[0] == '\'' || s[0] == '`' || s[0] == '"')
+            s = s[1 .. $];
+        if (s[$ - 1] == '\'' || s[$ - 1] == '"')
+            s = s[0 .. $ - 1];
+        return s;
+    }
+
+    static string stripLeft(string s)
+    {
+        while (s.length > 0 && s[0] == ' ')
+            s = s[1 .. $];
+        return s;
+    }
+
+    bool missingSymbols = false;
+    bool missingDfunction = false;
+    bool missingMain = false;
+
+    void missingSymbol(const(char)[] name, const(char)[] referencedFrom)
+    {
+        import core.demangle: demangle;
+        if (name.startsWith("__D"))
+            name = name[1 .. $]; // MS LINK prepends underscore to the existing one
+        auto sym = demangle(name);
+
+        missingSymbols = true;
+        if (sym == "main")
+            missingMain = true;
+        if (sym != name)
+            missingDfunction = true;
+
+        eSink.error(Loc.initial, "undefined reference to `%.*s`", cast(int) sym.length, sym.ptr);
+        if (referencedFrom.length > 0)
+        {
+            if (referencedFrom.startsWith("__D"))
+                referencedFrom = referencedFrom[1 .. $];
+
+            const(char)[] refFunc = demangle(referencedFrom);
+            eSink.errorSupplemental(Loc.initial, "referenced from `%.*s`", cast(int) refFunc.length, refFunc.ptr);
+        }
+    }
+
+    string lastSymbol;
+    void parseLine(const char[] line)
+    {
+        if (auto s0 = line.findSplit(" undefined reference to "))
+        {
+            if (string sym = unquote(s0[2]))
+            {
+                if (auto r = s0[0].findBetween("(.text.", "["))
+                    missingSymbol(sym, r);
+                else if (auto r = s0[0].findBetween(":function ", ":(.text"))
+                    missingSymbol(sym, r);
+                else
+                    missingSymbol(sym, null);
+            }
+        }
+        if (auto s0 = line.findSplit("LNK2019: unresolved external symbol "))
+        {
+            if (auto s1 = s0[2].findSplit(" referenced in function "))
+                missingSymbol(s1[0], s1[2]);
+            else
+                missingSymbol(s0[2], null);
+        }
+        if (auto s0 = line.findSplit("undefined symbol: "))
+        {
+            missingSymbol(s0[2], null);
+        }
+        if (auto s0 = line.findSplit(", referenced from:"))
+        {
+            if (string sym = unquote(stripLeft(s0[0])))
+            {
+                lastSymbol = sym; // ;missingSymbol(sym, null);
+            }
+        }
+        if (lastSymbol.length > 0)
+        {
+            if (auto s0 = line.findSplit(" in "))
+                missingSymbol(lastSymbol, stripLeft(s0[0]));
+            else
+                missingSymbol(lastSymbol,null);
+
+            lastSymbol = null;
+        }
+
+    }
+
+    size_t s = 0;
+    foreach (i; 0 .. linkerOutput.length)
+    {
+        if (linkerOutput[i] == '\n')
+        {
+            const cr = i > 0 && linkerOutput[i - 1] == '\r';
+            parseLine(linkerOutput[s .. i - cr]);
+            s = i + 1;
+        }
+    }
+    parseLine(linkerOutput[s .. $]);
+
+    if (missingMain)
+        eSink.errorSupplemental(Loc.initial, "perhaps define a `void main() {}` function or use the `-main` switch");
+
+    if (missingDfunction)
+        eSink.errorSupplemental(Loc.initial, "perhaps `.d` files need to be added on the command line, or use `-i` to compile imports");
+    else if (missingSymbols)
+        eSink.errorSupplemental(Loc.initial, "perhaps a library needs to be added with the `-L` flag or `pragma(lib, ...)`");
+}
+
+unittest
+{
+    // The following strings are the output of various linkers for this code:
+    // module app; void f(); void g() { f(); }
+
+    // ld (bfd is very similar)
+    string ldOutput = "
+/usr/bin/ld: app.o: in function `_D3app1gFZv':
+app.d:(.text._D3app1gFZv[_D3app1gFZv]+0x5): undefined reference to `_D3app1fFZv'
+";
+
+    // lld (mold is very similar)
+    string lldOutput = "
+ld.lld: error: undefined symbol: _D3app1fFZv
+>>> referenced by app.d
+>>>               app.o:(_D3app1gFZv)
+>>> did you mean: _D3app1gFZv
+>>> defined in: app.o
+";
+
+    // gold linker
+    string goldOutput = "
+app.o:app.d:function _D3app1gFZv:(.text._D3app1gFZv+0x5): error: undefined reference to '_D3app1fFZv'
+";
+
+    // Microsoft LINK
+    string linkOutput = "
+app.obj : error LNK2019: unresolved external symbol __D3app1fFZv referenced in function __D3app1gFZv
+app.exe : fatal error LNK1120: 1 unresolved externals
+";
+
+    // ld on MacOS
+    string macLd0 = `
+Undefined symbols for architecture arm64:
+  "__D3app1fFZv", referenced from:
+      __D3app1gFZv in app.o
+  "__D3app1hFZv", referenced from:
+      __D3app1fFZv in app.o
+ld: symbol(s) not found for architecture arm64
+clang: error: linker command failed with exit code 1 (use -v to see invocation)
+`;
+
+    string macLd1 = `
+ld: Undefined symbols:
+  __D3app1fFZv, referenced from:
+  __D3app1gFZv in test6.o
+clang: error: linker command failed with exit code 1 (use -v to see invocation)
+`;
+
+    class ErrorSinkTest : ErrorSink
+    {
+        public int errorCount = 0;
+        string expectedFormat = "undefined reference to `%.*s`";
+        string[] expectedSymbols;
+
+        extern(C++): override:
+
+        void error(const ref Loc loc, const(char)* format, ...)
+        {
+            assert(format[0 .. strlen(format)] == expectedFormat);
+            va_list ap;
+            va_start(ap, format);
+            const expectedSymbol = expectedSymbols[errorCount++];
+            assert(va_arg!int(ap) == expectedSymbol.length);
+            const actualSymbol = va_arg!(char*)(ap)[0 .. expectedSymbol.length];
+            assert(actualSymbol == expectedSymbol, "expected " ~ expectedSymbol ~ ", not " ~ actualSymbol);
+        }
+
+        void errorSupplemental(const ref Loc loc, const(char)* format, ...)
+        {
+            assert(format.startsWith("perhaps") || format.startsWith("referenced from "));
+        }
+
+        void warning(const ref Loc loc, const(char)* format, ...) {}
+        void warningSupplemental(const ref Loc loc, const(char)* format, ...) {}
+        void message(const ref Loc loc, const(char)* format, ...) {}
+        void deprecation(const ref Loc loc, const(char)* format, ...) {}
+        void deprecationSupplemental(const ref Loc loc, const(char)* format, ...) {}
+    }
+
+    void test(T...)(string linkerName, string output, T expectedSymbols)
+    {
+        auto testSink = new ErrorSinkTest();
+        testSink.expectedSymbols = [expectedSymbols];
+        parseLinkerOutput(output, testSink);
+        assert(testSink.errorCount > 0, "failed to demangle output of " ~ linkerName);
+    }
+
+    test("ld", ldOutput, "void app.f()");
+    test("lld", lldOutput, "void app.f()");
+    test("gold", goldOutput, "void app.f()");
+    test("link", linkOutput, "void app.f()");
+    test("ld", macLd0, "void app.f()", "void app.h()");
+    test("ld", macLd1, "void app.f()");
+
+    string missingMainOutput = "
+/usr/bin/ld: /usr/lib/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../lib/Scrt1.o: in function `_start':
+(.text+0x1b): undefined reference to `main'
+";
+
+    test("ld", missingMainOutput, "main");
+
+    string missingExternCOutput = "
+/usr/bin/ld: app.o: in function `_D3app__T2αVAyaa3_616263ZQrFZv':
+../test/app.d:(.text._D3app__T2αVAyaa3_616263ZQrFZv[_D3app__T2αVAyaa3_616263ZQrFZv]+0x5): undefined reference to `my_A'
+/usr/bin/ld: ../test/app.d:(.text._D3app__T2αVAyaa3_616263ZQrFZv[_D3app__T2αVAyaa3_616263ZQrFZv]+0xa): undefined reference to `my_B'
+";
+
+    test("ld", missingExternCOutput, "my_A", "my_B");
+
 }

--- a/compiler/src/dmd/root/string.d
+++ b/compiler/src/dmd/root/string.d
@@ -294,6 +294,15 @@ do
     return true;
 }
 
+///ditto
+nothrow @nogc pure @safe
+bool startsWith(scope const(char)[] str, scope const(char)[] prefix)
+{
+    if (str.length < prefix.length)
+        return false;
+    return str[0 .. prefix.length] == prefix;
+}
+
 ///
 @system pure nothrow @nogc
 unittest
@@ -404,4 +413,72 @@ auto splitLines(const char[] text)
     }
 
     return Range(text);
+}
+
+private struct FindSplit
+{
+@nogc nothrow pure @safe:
+    const(char)[][3] elem;
+
+    ref const(char)[] opIndex(size_t i) scope return { return elem[i]; }
+    bool opCast() const scope { return elem[1].length > 0; }
+}
+
+/**
+Find a substring in a string and split the string into before and after parts.
+Params:
+  str = string to look into
+  needle = substring to find in str (must not be empty)
+Returns:
+   a `FindSplit` object that casts to `true` iff `needle` was found inside `str`.
+   In that case, `split[1]` is the needle, and `split[0]`/`split[2]` are before/after the needle.
+*/
+FindSplit findSplit(return scope const(char)[] str, scope const(char)[] needle)
+{
+    if (needle.length > str.length)
+        return FindSplit([str, null, null]);
+
+    foreach (i; 0 .. str.length - needle.length + 1)
+    {
+        if (str[i .. i+needle.length] == needle[])
+            return FindSplit([ str[0 .. i], str[i .. i+needle.length], str[i+needle.length .. $] ]);
+    }
+    return FindSplit([str, null, null]);
+}
+
+unittest
+{
+    auto s = findSplit("a b c", "c");
+    assert(s[0] == "a b ");
+    assert(s[1] == "c");
+    assert(s[2] == "");
+    auto s1 = findSplit("a b c", "b");
+    assert(s1[0] == "a ");
+    assert(s1[1] == "b");
+    assert(s1[2] == " c");
+    assert(!findSplit("a b c", "d"));
+    assert(!findSplit("", "d"));
+}
+
+/**
+Find a string inbetween two substrings
+Params:
+  str = string to look into
+  l = substring to find on the left
+  r = substring to find on the right
+Returns:
+   substring of `str` inbetween `l` and `r`
+*/
+const(char)[] findBetween(const(char)[] str, const(char)[] l, const(char)[] r)
+{
+    if (auto s0 = str.findSplit(l))
+        if (auto s1 = s0[2].findSplit(r))
+            return s1[0];
+    return null;
+}
+
+unittest
+{
+    assert(findBetween("a b c", "a ", " c") == "b");
+    assert(findBetween("a b c", "a ", " d") == null);
 }

--- a/compiler/test/fail_compilation/needspkgmod.d
+++ b/compiler/test/fail_compilation/needspkgmod.d
@@ -8,9 +8,7 @@
 /*
 TEST_OUTPUT:
 ----
-$r:.+_D7imports9pkgmod3133mod3barFZv.*$
-Error: $r:.+$ exited with status $n$
-$r:.+$
+$r:.+_D7imports9pkgmod3133mod3barFZv.*Error: linker exited with status.+$
 ----
 */
 import imports.pkgmod313.mod;

--- a/compiler/test/link.d
+++ b/compiler/test/link.d
@@ -1,9 +1,0 @@
-import std.stdio;
-
-void main()
-{
-    writeln("
-app.obj : error LNK2019: unresolved external symbol __D3app1fFZv referenced in function __D3app1gFZv
-app.exe : fatal error LNK1120: 1 unresolved externals
-");
-}

--- a/compiler/test/link.d
+++ b/compiler/test/link.d
@@ -1,0 +1,9 @@
+import std.stdio;
+
+void main()
+{
+    writeln("
+app.obj : error LNK2019: unresolved external symbol __D3app1fFZv referenced in function __D3app1gFZv
+app.exe : fatal error LNK1120: 1 unresolved externals
+");
+}


### PR DESCRIPTION
Linker errors are notoriously cryptic, and read almost like internal compiler errors. With this PR, when dmd invokes the linker and sees the output contains missing (mangled) symbols, it prints them in its own error format, with demangled symbols. 

It also provides some suggestions (`-i`, `-L`, `pragma(lib)`, `-main`) for new users who are not familiar with D's 'old-fashioned' compilation model.

I don't want to write an end-to-end test depending on various linkers to be installed, so I made a unittest with a mock `ErrorSink`, which is very portable.

Todo:
- Add code to parse OSX linker errors
- Pipe linker output on Windows as well (parsing sample output of LINK.exe works in the unittest)
- Determine the best default output format. Currently it prints linker output followed by translated errors, but it could also print it after, interspersed, or not at all.
