### PR TITLE
core.stdc: Add bindings for CRuntime_Newlib

### DIFF
--- a/druntime/src/core/stdc/assert_.d
+++ b/druntime/src/core/stdc/assert_.d
@@ -113,6 +113,15 @@ else version (CRuntime_Musl)
      */
     noreturn __assert_fail(const(char)* exp, const(char)* file, uint line, const(char)* func);
 }
+else version (CRuntime_Newlib)
+{
+    /***
+     * Assert failure function in the Newlib library.
+     */
+    noreturn __assert(const(char)* file, int line, const(char)* exp);
+    ///
+    noreturn __assert_func(const(char)* file, int line, const(char)* func, const(char)* exp);
+}
 else version (CRuntime_UClibc)
 {
     noreturn __assert(const(char)* exp, const(char)* file, uint line, const(char)* func);

--- a/druntime/src/core/stdc/errno.d
+++ b/druntime/src/core/stdc/errno.d
@@ -75,6 +75,14 @@ else version (CRuntime_Musl)
         alias errno = __errno_location;
     }
 }
+else version (CRuntime_Newlib)
+{
+    extern (C)
+    {
+        ref int __errno();
+        alias errno = __errno;
+    }
+}
 else version (OpenBSD)
 {
     // https://github.com/openbsd/src/blob/master/include/errno.h
@@ -164,7 +172,7 @@ else
 extern (C):
 
 
-version (Windows)
+version (CRuntime_DigitalMars)
 {
     enum EPERM              = 1;        /// Operation not permitted
     enum ENOENT             = 2;        /// No such file or directory
@@ -249,6 +257,230 @@ version (Windows)
     enum ETIMEDOUT          = 138;
     enum ETXTBSY            = 139;
     enum EWOULDBLOCK        = 140;
+}
+else version (CRuntime_Microsoft)
+{
+    enum EPERM              = 1;        /// Operation not permitted
+    enum ENOENT             = 2;        /// No such file or directory
+    enum ESRCH              = 3;        /// No such process
+    enum EINTR              = 4;        /// Interrupted system call
+    enum EIO                = 5;        /// I/O error
+    enum ENXIO              = 6;        /// No such device or address
+    enum E2BIG              = 7;        /// Argument list too long
+    enum ENOEXEC            = 8;        /// Exec format error
+    enum EBADF              = 9;        /// Bad file number
+    enum ECHILD             = 10;       /// No child processes
+    enum EAGAIN             = 11;       /// Try again
+    enum ENOMEM             = 12;       /// Out of memory
+    enum EACCES             = 13;       /// Permission denied
+    enum EFAULT             = 14;       /// Bad address
+    enum EBUSY              = 16;       /// Device or resource busy
+    enum EEXIST             = 17;       /// File exists
+    enum EXDEV              = 18;       /// Cross-device link
+    enum ENODEV             = 19;       /// No such device
+    enum ENOTDIR            = 20;       /// Not a directory
+    enum EISDIR             = 21;       /// Is a directory
+    enum EINVAL             = 22;       /// Invalid argument
+    enum ENFILE             = 23;       /// File table overflow
+    enum EMFILE             = 24;       /// Too many open files
+    enum ENOTTY             = 25;       /// Not a typewriter
+    enum EFBIG              = 27;       /// File too large
+    enum ENOSPC             = 28;       /// No space left on device
+    enum ESPIPE             = 29;       /// Illegal seek
+    enum EROFS              = 30;       /// Read-only file system
+    enum EMLINK             = 31;       /// Too many links
+    enum EPIPE              = 32;       /// Broken pipe
+    enum EDOM               = 33;       /// Math argument out of domain of func
+    enum ERANGE             = 34;       /// Math result not representable
+    enum EDEADLK            = 36;       /// Resource deadlock would occur
+    enum ENAMETOOLONG       = 38;       /// File name too long
+    enum ENOLCK             = 39;       /// No record locks available
+    enum ENOSYS             = 40;       /// Function not implemented
+    enum ENOTEMPTY          = 41;       /// Directory not empty
+    enum EILSEQ             = 42;       /// Illegal byte sequence
+    enum EDEADLOCK          = EDEADLK;  /// Resource deadlock would occur
+
+    // POSIX compatibility
+    // See_Also: https://docs.microsoft.com/en-us/cpp/c-runtime-library/errno-constants
+    enum EADDRINUSE         = 100;
+    enum EADDRNOTAVAIL      = 101;
+    enum EAFNOSUPPORT       = 102;
+    enum EALREADY           = 103;
+    enum EBADMSG            = 104;
+    enum ECANCELED          = 105;
+    enum ECONNABORTED       = 106;
+    enum ECONNREFUSED       = 107;
+    enum ECONNRESET         = 108;
+    enum EDESTADDRREQ       = 109;
+    enum EHOSTUNREACH       = 110;
+    enum EIDRM              = 111;
+    enum EINPROGRESS        = 112;
+    enum EISCONN            = 113;
+    enum ELOOP              = 114;
+    enum EMSGSIZE           = 115;
+    enum ENETDOWN           = 116;
+    enum ENETRESET          = 117;
+    enum ENETUNREACH        = 118;
+    enum ENOBUFS            = 119;
+    enum ENODATA            = 120;
+    enum ENOLINK            = 121;
+    enum ENOMSG             = 122;
+    enum ENOPROTOOPT        = 123;
+    enum ENOSR              = 124;
+    enum ENOSTR             = 125;
+    enum ENOTCONN           = 126;
+    enum ENOTRECOVERABLE    = 127;
+    enum ENOTSOCK           = 128;
+    enum ENOTSUP            = 129;
+    enum EOPNOTSUPP         = 130;
+    enum EOTHER             = 131;
+    enum EOVERFLOW          = 132;
+    enum EOWNERDEAD         = 133;
+    enum EPROTO             = 134;
+    enum EPROTONOSUPPORT    = 135;
+    enum EPROTOTYPE         = 136;
+    enum ETIME              = 137;
+    enum ETIMEDOUT          = 138;
+    enum ETXTBSY            = 139;
+    enum EWOULDBLOCK        = 140;
+}
+else version (CRuntime_Newlib)
+{
+    enum EPERM = 1;
+    enum ENOENT = 2;
+    enum ESRCH = 3;
+    enum EINTR = 4;
+    enum EIO = 5;
+    enum ENXIO = 6;
+    enum E2BIG = 7;
+    enum ENOEXEC = 8;
+    enum EBADF = 9;
+    enum ECHILD = 10;
+    enum EAGAIN = 11;
+    enum ENOMEM = 12;
+    enum EACCES = 13;
+    enum EFAULT = 14;
+    enum EBUSY = 16;
+    enum EEXIST = 17;
+    enum EXDEV = 18;
+    enum ENODEV = 19;
+    enum ENOTDIR = 20;
+    enum EISDIR = 21;
+    enum EINVAL = 22;
+    enum ENFILE = 23;
+    enum EMFILE = 24;
+    enum ENOTTY = 25;
+    enum ETXTBSY = 26;
+    enum EFBIG = 27;
+    enum ENOSPC = 28;
+    enum ESPIPE = 29;
+    enum EROFS = 30;
+    enum EMLINK = 31;
+    enum EPIPE = 32;
+    enum EDOM = 33;
+    enum ERANGE = 34;
+    enum ENOMSG = 35;
+    enum EIDRM = 36;
+    enum EDEADLK = 45;
+    enum ENOLCK = 46;
+    enum ENOSTR = 60;
+    enum ENODATA = 61;
+    enum ETIME = 62;
+    enum ENOSR = 63;
+    enum ENOLINK = 67;
+    enum EPROTO = 71;
+    enum EMULTIHOP = 74;
+    enum EBADMSG = 77;
+    enum EFTYPE = 79;
+    enum ENOSYS = 88;
+    enum ENOTEMPTY = 90;
+    enum ENAMETOOLONG = 91;
+    enum ELOOP = 92;
+    enum EOPNOTSUPP = 95;
+    enum EPFNOSUPPORT = 96;
+    enum ECONNRESET = 104;
+    enum ENOBUFS = 105;
+    enum EAFNOSUPPORT = 106;
+    enum EPROTOTYPE = 107;
+    enum ENOTSOCK = 108;
+    enum ENOPROTOOPT = 109;
+    enum ECONNREFUSED = 111;
+    enum EADDRINUSE = 112;
+    enum ECONNABORTED = 113;
+    enum ENETUNREACH = 114;
+    enum ENETDOWN = 115;
+    enum ETIMEDOUT = 116;
+    enum EHOSTDOWN = 117;
+    enum EHOSTUNREACH = 118;
+    enum EINPROGRESS = 119;
+    enum EALREADY = 120;
+    enum EDESTADDRREQ = 121;
+    enum EMSGSIZE = 122;
+    enum EPROTONOSUPPORT = 123;
+    enum EADDRNOTAVAIL = 125;
+    enum ENETRESET = 126;
+    enum EISCONN = 127;
+    enum ENOTCONN = 128;
+    enum ETOOMANYREFS = 129;
+    enum EDQUOT = 132;
+    enum ESTALE = 133;
+    enum ENOTSUP = 134;
+    enum EILSEQ = 138;
+    enum EOVERFLOW = 139;
+    enum ECANCELED = 140;
+    enum ENOTRECOVERABLE = 141;
+    enum EOWNERDEAD = 142;
+
+    enum EWOULDBLOCK = EAGAIN;
+
+    enum __ELASTERROR = 2000;
+
+    // Linux errno extensions
+    version (Cygwin)
+    {
+        enum ENOTBLK = 15;
+        enum ECHRNG = 37;
+        enum EL2NSYNC = 38;
+        enum EL3HLT = 39;
+        enum EL3RST = 40;
+        enum ELNRNG = 41;
+        enum EUNATCH = 42;
+        enum ENOCSI = 43;
+        enum EL2HLT = 44;
+        enum EBADE = 50;
+        enum EBADR = 51;
+        enum EXFULL = 52;
+        enum ENOANO = 53;
+        enum EBADRQC = 54;
+        enum EBADSLT = 55;
+        enum EDEADLOCK = 56;
+        enum EBFONT = 57;
+        enum ENONET = 64;
+        enum ENOPKG = 65;
+        enum EREMOTE = 66;
+        enum EADV = 68;
+        enum ESRMNT = 69;
+        enum ECOMM = 70;
+        enum ELBIN = 75;
+        enum EDOTDOT = 76;
+        enum ENOTUNIQ = 80;
+        enum EBADFD = 81;
+        enum EREMCHG = 82;
+        enum ELIBACC = 83;
+        enum ELIBBAD = 84;
+        enum ELIBSCN = 85;
+        enum ELIBMAX = 86;
+        enum ELIBEXEC = 87;
+        enum ENMFILE = 89;
+        enum ESHUTDOWN = 110;
+        enum ESOCKTNOSUPPORT = 124;
+        enum EPROCLIM = 130;
+        enum EUSERS = 131;
+        enum ENOMEDIUM = 135;
+        enum ENOSHARE = 136;
+        enum ECASECLASH = 137;
+        enum ESTRPIPE = 143;
+    }
 }
 else version (linux)
 {

--- a/druntime/src/core/stdc/fenv.d
+++ b/druntime/src/core/stdc/fenv.d
@@ -448,6 +448,49 @@ else version (CRuntime_Musl)
         static assert(false, "Architecture not supported.");
     }
 }
+else version (CRuntime_Newlib)
+{
+    version (AArch64)
+    {
+        alias fenv_t = ulong;
+        alias fexcept_t = ulong;
+    }
+    else version (RISCV_Any)
+    {
+        alias fenv_t = size_t;
+        alias fexcept_t = size_t;
+    }
+    else version (X86_Any)
+    {
+        struct fenv_t
+        {
+            uint _fpu_cw;
+            uint _fpu_sw;
+            uint _fpu_tagw;
+            uint _fpu_ipoff;
+            uint _fpu_ipsel;
+            uint _fpu_opoff;
+            uint _fpu_opsel;
+            uint _sse_mxcsr;
+        }
+        alias fexcept_t = uint;
+    }
+    else version (SPARC64)
+    {
+        alias fenv_t = ulong;
+        alias fexcept_t = ulong;
+    }
+    else version (SPARC)
+    {
+        alias fenv_t = uint;
+        alias fexcept_t = uint;
+    }
+    else
+    {
+        alias fenv_t = int;
+        alias fexcept_t = int;
+    }
+}
 else version (CRuntime_UClibc)
 {
     version (X86)

--- a/druntime/src/core/stdc/locale.d
+++ b/druntime/src/core/stdc/locale.d
@@ -252,6 +252,23 @@ else version (CRuntime_Musl)
     ///
     enum LC_ALL            = 6;
 }
+else version (CRuntime_Newlib)
+{
+    ///
+    enum LC_ALL            = 0;
+    ///
+    enum LC_COLLATE        = 1;
+    ///
+    enum LC_CTYPE          = 2;
+    ///
+    enum LC_MONETARY       = 3;
+    ///
+    enum LC_NUMERIC        = 4;
+    ///
+    enum LC_TIME           = 5;
+    ///
+    enum LC_MESSAGES       = 6;
+}
 else version (CRuntime_UClibc)
 {
     ///

--- a/druntime/src/core/stdc/stdio.d
+++ b/druntime/src/core/stdc/stdio.d
@@ -328,6 +328,30 @@ else version (CRuntime_Bionic)
         int _size;
     }
 }
+else version (CRuntime_Newlib)
+{
+    enum
+    {
+        ///
+        BUFSIZ       = 1024,
+        ///
+        EOF          = -1,
+        ///
+        FOPEN_MAX    = 20,
+        ///
+        FILENAME_MAX = 1024,
+        ///
+        TMP_MAX      = 26,
+        ///
+        L_tmpnam     = 1024
+    }
+
+    struct __sbuf
+    {
+        ubyte* _base;
+        int _size;
+    }
+}
 else version (CRuntime_UClibc)
 {
     enum
@@ -769,6 +793,57 @@ else version (CRuntime_Bionic)
     ///
     alias shared(__sFILE) FILE;
 }
+else version (CRuntime_Newlib)
+{
+    import core.sys.posix.sys.types : ssize_t;
+    import core.stdc.wchar_ : mbstate_t;
+
+    ///
+    alias fpos_t = c_long;
+
+    ///
+    struct __sFILE
+    {
+        ubyte* _p;
+        int _r;
+        int _w;
+        short _flags;
+        short _file;
+        __sbuf _bf;
+        int _lbfsize;
+
+        void* _data;
+        void* _cookie;
+
+        ssize_t function(void*, void*, scope char*, size_t) _read;
+        ssize_t function(void*, void*, scope const char*, size_t) _write;
+        fpos_t function(void*, void*, fpos_t, int) _seek;
+        int function(void*, void*) _close;
+
+        __sbuf _ub;
+        ubyte* _up;
+        int _ur;
+
+        ubyte[3] _ubuf;
+        ubyte[1] _nbuf;
+
+        __sbuf _lb;
+
+        int _blksize;
+        int _flags2;
+
+        long _offset;
+        void* _unused;
+
+        void* _lock;
+        mbstate_t _mbstate;
+    }
+
+    ///
+    alias __sFILE _iobuf; // needed for phobos
+    ///
+    alias shared(__sFILE) FILE;
+}
 else version (CRuntime_UClibc)
 {
     import core.stdc.wchar_ : mbstate_t;
@@ -1135,6 +1210,40 @@ else version (CRuntime_Musl)
         _IOLBF = 1,
         ///
         _IONBF = 2,
+    }
+}
+else version (CRuntime_Newlib)
+{
+    enum
+    {
+        ///
+        _IOFBF = 0,
+        ///
+        _IOLBF = 1,
+        ///
+        _IONBF = 2,
+    }
+
+    private
+    {
+        shared struct _reent
+        {
+            int _errno;
+            __sFILE* _stdin;
+            __sFILE* _stdout;
+            __sFILE* _stderr;
+        }
+        _reent* __getreent();
+    }
+
+    pragma(inline, true)
+    {
+        ///
+        @property auto stdin()() { return __getreent()._stdin; }
+        ///
+        @property auto stdout()() { return __getreent()._stdout; }
+        ///
+        @property auto stderr()() { return __getreent()._stderr; }
     }
 }
 else version (CRuntime_UClibc)
@@ -1868,6 +1977,47 @@ else version (CRuntime_Musl)
     ///
     pragma(printf)
     int vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
+}
+else version (CRuntime_Newlib)
+{
+  // No unsafe pointer manipulation.
+  @trusted
+  {
+    ///
+    void rewind(FILE* stream);
+    ///
+    pure void clearerr(FILE* stream);
+    ///
+    pure int  feof(FILE* stream);
+    ///
+    pure int  ferror(FILE* stream);
+    ///
+    int  fileno(FILE *);
+  }
+
+    ///
+    pragma(printf)
+    int  snprintf(scope char* s, size_t n, scope const char* format, scope const ...);
+    ///
+    pragma(printf)
+    int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
+
+    //
+    // Gnu under-the-hood C I/O functions. Uses _iobuf* for the unshared
+    // version of FILE*, usable when the FILE is locked.
+    // See http://gnu.org/software/libc/manual/html_node/I_002fO-on-Streams.html
+    //
+    import core.stdc.wchar_ : wint_t;
+    import core.stdc.stddef : wchar_t;
+
+    ///
+    int fputc_unlocked(int c, _iobuf* stream);
+    ///
+    int fgetc_unlocked(_iobuf* stream);
+    ///
+    wint_t fputwc_unlocked(wchar_t wc, _iobuf* stream);
+    ///
+    wint_t fgetwc_unlocked(_iobuf* stream);
 }
 else version (CRuntime_UClibc)
 {

--- a/druntime/src/core/stdc/stdlib.d
+++ b/druntime/src/core/stdc/stdlib.d
@@ -28,6 +28,8 @@ else version (WatchOS)
 
 version (CRuntime_Glibc)
     version = AlignedAllocSupported;
+else version (CRuntime_Newlib)
+    version = AlignedAllocSupported;
 else {}
 
 extern (C):
@@ -97,6 +99,7 @@ else version (DragonFlyBSD) enum RAND_MAX = 0x7fffffff;
 else version (Solaris) enum RAND_MAX = 0x7fff;
 else version (CRuntime_Bionic) enum RAND_MAX = 0x7fffffff;
 else version (CRuntime_Musl) enum RAND_MAX = 0x7fffffff;
+else version (CRuntime_Newlib) enum RAND_MAX = 0x7fffffff;
 else version (CRuntime_UClibc) enum RAND_MAX = 0x7fffffff;
 else version (WASI) enum RAND_MAX = 0x7fffffff;
 else static assert( false, "Unsupported platform" );

--- a/druntime/src/core/stdc/string.d
+++ b/druntime/src/core/stdc/string.d
@@ -72,8 +72,15 @@ version (ReturnStrerrorR)
     const(char)* strerror_r(int errnum, return scope char* buf, size_t buflen);
 }
 // This one is
+else version (CRuntime_Newlib)
+{
+    ///
+    pragma(mangle, "__xpg_strerror_r")
+    int strerror_r(int errnum, scope char* buf, size_t buflen);
+}
 else
 {
+    ///
     int strerror_r(int errnum, scope char* buf, size_t buflen);
 }
 ///

--- a/druntime/src/core/stdc/wchar_.d
+++ b/druntime/src/core/stdc/wchar_.d
@@ -106,6 +106,20 @@ else version (Solaris)
     ///
     alias mbstate_t = __mbstate_t;
 }
+else version (CRuntime_Newlib)
+{
+    ///
+    struct mbstate_t
+    {
+        int __count;
+        union ___value
+        {
+            wint_t __wch = 0;
+            char[4] __wchb;
+        }
+        ___value __value;
+    }
+}
 else version (CRuntime_UClibc)
 {
     ///


### PR DESCRIPTION
This library is supported on both linux and Windows (Cygwin) platforms, but is distinct from the Glibc and Microsoft C runtimes.