### PR TITLE
Print linker command on failure

### DIFF
--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -779,17 +779,17 @@ public int runLINK()
             // Link against -lexecinfo for backtrace symbols
             argv.push("-lexecinfo");
         }
-        if (global.params.v.verbose)
+        OutBuffer buf;
+        foreach (i; 0 .. argv.length)
         {
-            // Print it
-            OutBuffer buf;
-            for (size_t i = 0; i < argv.length; i++)
-            {
-                buf.writestring(argv[i]);
-                buf.writeByte(' ');
-            }
-            message(buf.peekChars());
+            buf.writestring(argv[i]);
+            buf.writeByte(' ');
         }
+        const(char)* linkerCommand = buf.peekChars();
+
+        if (global.params.v.verbose)
+            message("%s", linkerCommand);
+
         argv.push(null);
         // set up pipes
         int[2] fds;
@@ -830,6 +830,7 @@ public int runLINK()
                 else
                 {
                     error(Loc.initial, "linker exited with status %d", status);
+                    errorSupplemental(Loc.initial, "%s", linkerCommand);
                     if (nme == 1)
                         error(Loc.initial, "no main function specified");
                 }
@@ -923,7 +924,10 @@ version (Windows)
             if (status == -1)
                 error(Loc.initial, "can't run '%s', check PATH", cmd);
             else
+            {
                 error(Loc.initial, "linker exited with status %d", status);
+                errorSupplemental(Loc.initial, "%s %s", cmd, args);
+            }
         }
         return status;
     }

--- a/compiler/test/fail_compilation/needspkgmod.d
+++ b/compiler/test/fail_compilation/needspkgmod.d
@@ -10,6 +10,7 @@ TEST_OUTPUT:
 ----
 $r:.+_D7imports9pkgmod3133mod3barFZv.*$
 Error: $r:.+$ exited with status $n$
+$r:.+$
 ----
 */
 import imports.pkgmod313.mod;


### PR DESCRIPTION
See: https://github.com/dlang/dmd/pull/16021#issuecomment-1888148127

Currently you can only see the linker command with `-v`, which spams the console with way more than that.

