### PR TITLE
fix Issue 24338 - Cannot concatenate dynamic arrays of enum type with static array base type

### DIFF
--- a/compiler/test/compilable/test24338.d
+++ b/compiler/test/compilable/test24338.d
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=24338
+
+enum Foo: char[4]
+{
+    elem = "test"
+}
+
+immutable a = [Foo.elem];
+immutable b = [Foo.elem];
+immutable c = a ~ b;

--- a/druntime/src/core/internal/traits.d
+++ b/druntime/src/core/internal/traits.d
@@ -38,7 +38,7 @@ template Unqual(T : const U, U)
 
 template BaseElemOf(T)
 {
-    static if (is(T == E[N], E, size_t N))
+    static if (is(OriginalType!T == E[N], E, size_t N))
         alias BaseElemOf = BaseElemOf!E;
     else
         alias BaseElemOf = T;
@@ -51,6 +51,8 @@ unittest
     static assert(is(BaseElemOf!(int[1][2]) == int));
     static assert(is(BaseElemOf!(int[1][]) == int[1][]));
     static assert(is(BaseElemOf!(int[][1]) == int[]));
+    static enum E : int[2]{ test = [0, 1] }
+    static assert(is(BaseElemOf!(E) == int));
 }
 
 // [For internal use]


### PR DESCRIPTION
The base type of `enum` is not properly taken into account. There are a lot of bugs of a similar kind in the same file, those will have to be fixed as well.