### PR TITLE
compare class name signatures

### DIFF
--- a/changelog/dmd.classinfo.dd
+++ b/changelog/dmd.classinfo.dd
@@ -1,0 +1,10 @@
+Added .nameSig field to TypeInfo_Class in object.d
+
+This is a 16 byte md5 signature of the fully qualified name of the class.
+It is used to compare two classes for equality, rather than comparing the
+pointers with a fallback to doing a string compare on the name, which can
+be rather slow.
+
+The result is both druntime and phobos will need to be recompiled to be
+compatible with this change. Any libraries will need to be recompiled
+as well.

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -414,7 +414,7 @@ extern (C++) struct Target
         // These have default values for 32 bit code, they get
         // adjusted for 64 bit code.
         ptrsize = 4;
-        classinfosize = 0x4C; // 76
+        classinfosize = 0x4C+16; // 92
 
         /* gcc uses int.max for 32 bit compilations, and long.max for 64 bit ones.
          * Set to int.max for both, because the rest of the compiler cannot handle
@@ -427,7 +427,7 @@ extern (C++) struct Target
         if (isLP64)
         {
             ptrsize = 8;
-            classinfosize = 0x98; // 152
+            classinfosize = 0x98+16; // 168
         }
         if (os & (Target.OS.linux | Target.OS.FreeBSD | Target.OS.OpenBSD | Target.OS.DragonFlyBSD | Target.OS.Solaris))
         {

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -1240,6 +1240,7 @@ private void genClassInfoForClass(ClassDeclaration cd, Symbol* sinit)
             void* deallocator;
             OffsetTypeInfo[] offTi;
             void function(Object) defaultConstructor;
+            ulong[2] nameSig;
             //const(MemberInfo[]) function(string) xgetMembers;   // module getMembers() function
             immutable(void)* m_RTInfo;
             //TypeInfo typeinfo;
@@ -1370,6 +1371,17 @@ Louter:
     else
         dtb.size(0);
 
+    // ulong[2] nameSig
+    {
+        import dmd.common.md5;
+        MD5_CTX mdContext = void;
+        MD5Init(&mdContext);
+        MD5Update(&mdContext, cast(ubyte*)name, cast(uint)namelen);
+        MD5Final(&mdContext);
+        assert(mdContext.digest.length == 16);
+        dtb.nbytes(16, cast(char*)mdContext.digest.ptr);
+    }
+
     // m_RTInfo
     if (cd.getRTInfo)
         Expression_toDt(cd.getRTInfo, dtb);
@@ -1483,6 +1495,7 @@ private void genClassInfoForInterface(InterfaceDeclaration id)
             void* deallocator;
             OffsetTypeInfo[] offTi;
             void function(Object) defaultConstructor;
+            ulong[2] nameSig;
             //const(MemberInfo[]) function(string) xgetMembers;   // module getMembers() function
             immutable(void)* m_RTInfo;
             //TypeInfo typeinfo;
@@ -1560,6 +1573,17 @@ private void genClassInfoForInterface(InterfaceDeclaration id)
 
     // defaultConstructor
     dtb.size(0);
+
+    // ulong[2] nameSig
+    {
+        import dmd.common.md5;
+        MD5_CTX mdContext = void;
+        MD5Init(&mdContext);
+        MD5Update(&mdContext, cast(ubyte*)name, cast(uint)namelen);
+        MD5Final(&mdContext);
+        assert(mdContext.digest.length == 16);
+        dtb.nbytes(16, cast(char*)mdContext.digest.ptr);
+    }
 
     // xgetMembers
     //dtb.size(0);

--- a/compiler/test/compilable/b18242.d
+++ b/compiler/test/compilable/b18242.d
@@ -7,7 +7,7 @@ class Object { }
 class TypeInfo { }
 class TypeInfo_Class : TypeInfo
 {
-    version(D_LP64) { ubyte[136] _x; } else { ubyte[68] _x; }
+    version(D_LP64) { ubyte[136+16] _x; } else { ubyte[68+16] _x; }
 }
 
 class Throwable { }

--- a/compiler/test/runnable/xtest46.d
+++ b/compiler/test/runnable/xtest46.d
@@ -8049,6 +8049,9 @@ void test24332()
     auto b = cast(A) new B();
     auto c = cast(B) b;
     assert(c);
+    B e;
+    auto d = cast(B) cast(A) e;
+    assert(d is null);
 }
 
 /***************************************************/

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -1660,11 +1660,13 @@ class TypeInfo_Class : TypeInfo
         isAbstract = 0x40,
         isCPPclass = 0x80,
         hasDtor = 0x100,
+        hasNameSig = 0x200,
     }
     ClassFlags m_flags;
     void*       deallocator;
     OffsetTypeInfo[] m_offTi;
     void function(Object) defaultConstructor;   // default Constructor
+    ulong[2] nameSig;            /// unique signature for `name`
 
     immutable(void)* m_RTInfo;        // data for precise GC
     override @property immutable(void)* rtInfo() const { return m_RTInfo; }

--- a/druntime/src/rt/cast_.d
+++ b/druntime/src/rt/cast_.d
@@ -23,10 +23,12 @@ pure:
 // but we are trying to implement dynamic cast.
 extern (D) private bool areClassInfosEqual(scope const ClassInfo a, scope const ClassInfo b) @safe
 {
-    if (a is b)
-        return true;
-    // take care of potential duplicates across binaries
-    return a.name == b.name;
+    // same class if signatures match, works with potential duplicates across binaries
+    return a is b ||
+        (a.m_flags & TypeInfo_Class.ClassFlags.hasNameSig
+        ? (a.nameSig[0] == b.nameSig[0] &&
+           a.nameSig[1] == b.nameSig[1])  // new fast way
+        : (a is b || a.name == b.name));  // old slow way for temporary binary compatibility
 }
 
 /******************************************


### PR DESCRIPTION
This speeds up class name matches by comparing name md5 signatures rather than doing a string compare, as names can get really long. It matches names with only two compares. It also matches names across shared libraries and DLLs.

Since it also changes the layout of ClassInfo, you'll need to update library builds.

(md5 is also used to merge identical strings across compilation units.)