### PR TITLE
functionResolve() use delegate instead of pointer

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -2624,10 +2624,10 @@ extern (C++) final class TypeDeduced : Type
  *      tiargs      = initial list of template arguments
  *      tthis       = if !NULL, the 'this' pointer argument
  *      argumentList= arguments to function
- *      pMessage    = address to store error message, or null
+ *      errorHelper = delegate to send error message to if not null
  */
 void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiargs,
-    Type tthis, ArgumentList argumentList, const(char)** pMessage = null)
+    Type tthis, ArgumentList argumentList, void delegate(const(char)*) scope errorHelper = null)
 {
     version (none)
     {
@@ -2733,8 +2733,12 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
             else if (shared_this && !shared_dtor && tthis_fd !is null)
                 tf.mod = tthis_fd.mod;
         }
+        const(char)* failMessage;
+        const(char)** pMessage = errorHelper ? &failMessage : null;
         MATCH mfa = tf.callMatch(tthis_fd, argumentList, 0, pMessage, sc);
         //printf("test1: mfa = %d\n", mfa);
+        if (failMessage)
+            errorHelper(failMessage);
         if (mfa == MATCH.nomatch)
             return 0;
 

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3444,16 +3444,19 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
             return null;
         }
 
-        const(char)* failMessage;
-        functionResolve(m, orig_s, loc, sc, tiargs, tthis, argumentList, &failMessage);
-        if (failMessage)
+        bool calledHelper;
+        void errorHelper(const(char)* failMessage) scope
         {
             .error(loc, "%s `%s%s%s` is not callable using argument types `%s`",
                    fd.kind(), fd.toPrettyChars(), parametersTypeToChars(tf.parameterList),
                    tf.modToChars(), fargsBuf.peekChars());
             errorSupplemental(loc, failMessage);
-            return null;
+            calledHelper = true;
         }
+
+        functionResolve(m, orig_s, loc, sc, tiargs, tthis, argumentList, &errorHelper);
+        if (calledHelper)
+            return null;
 
         if (fd.isCtorDeclaration())
             .error(loc, "%s%s `%s` cannot construct a %sobject",
@@ -3508,10 +3511,13 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
                 }
             }
         }
-        const(char)* failMessage;
-        functionResolve(m, orig_s, loc, sc, tiargs, tthis, argumentList, &failMessage);
-        if (failMessage)
+
+        void errorHelper2(const(char)* failMessage) scope
+        {
             errorSupplemental(loc, failMessage);
+        }
+
+        functionResolve(m, orig_s, loc, sc, tiargs, tthis, argumentList, &errorHelper2);
     }
     return null;
 }


### PR DESCRIPTION
The tangle of function calls and their error messages is too much. There are two culprits at the top of this - functionResolve() and callMatch(). This PR replaces the pointer to a message with a delegate to handle the error messages. After this, I'll do the same to callMatch().

In the meantime, you can see the kludge around the call to callMatch() which the next installment should fix.

It is not good that two error messages that are emitted as pairs are in different functions and different modules.