### PR TITLE
improve _dynamic_class_cast() performance

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -4678,6 +4678,27 @@ elem *toElemCast(CastExp ce, elem *e, bool isLvalue, ref IRState irs)
             else if (rtl == RTLSYM.DYNAMIC_CAST &&
                      !cdto.isInterfaceDeclaration())
             {
+                //printf("cdfrom: %s cdto: %s\n", cdfrom.toChars(), cdto.toChars());
+                int level = 0;
+                auto b = cdto;
+                while (1)
+                {
+                    if (b == cdfrom)
+                        break;
+                    b = b.baseClass;
+                    if (!b)
+                    {
+                        // did not find cdfrom, so cast fails, return null
+                        e = el_long(TYnptr, 0);
+                        return Lret(ce, e);
+                    }
+                    ++level;
+                }
+                if (level == 0)
+                {
+                    return Lret(ce, e); // cast to self
+                }
+                // _d_class_cast(e, cdto);
                 rtl = RTLSYM.CLASS_CAST;
             }
             elem *ep = el_param(el_ptr(toExtSymbol(cdto)), e);

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -1260,6 +1260,7 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
             void* destructor;
             void function(Object) classInvariant;   // class invariant
             ClassFlags m_flags;
+            ushort depth;
             void* deallocator;
             OffsetTypeInfo[] offTi;
             void function(Object) defaultConstructor;
@@ -1367,7 +1368,13 @@ Louter:
             }
         }
     }
-    dtb.size(flags);
+
+    int depth = 0;
+    for (ClassDeclaration pc = cd; pc; pc = pc.baseClass)
+        ++depth;  // distance to Object
+
+    // m_flags and depth, align to size_t
+    dtb.size((depth << 16) | flags);
 
     // deallocator
     dtb.size(0);
@@ -1499,6 +1506,7 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
             void* destructor;
             void function(Object) classInvariant;   // class invariant
             ClassFlags m_flags;
+            ushort depth;
             void* deallocator;
             OffsetTypeInfo[] offTi;
             void function(Object) defaultConstructor;
@@ -1566,7 +1574,7 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
     // flags
     ClassFlags flags = ClassFlags.hasOffTi | ClassFlags.hasTypeInfo;
     if (id.isCOMinterface()) flags |= ClassFlags.isCOMclass;
-    dtb.size(flags);
+    dtb.size(flags); // depth part is 0
 
     // deallocator
     dtb.size(0);

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -1646,10 +1646,10 @@ class TypeInfo_Class : TypeInfo
     string      name;           /// class name
     void*[]     vtbl;           /// virtual function pointer table
     Interface[] interfaces;     /// interfaces this class implements
-    TypeInfo_Class   base;           /// base class
+    TypeInfo_Class   base;      /// base class
     void*       destructor;
     void function(Object) classInvariant;
-    enum ClassFlags : uint
+    enum ClassFlags : ushort
     {
         isCOMclass = 0x1,
         noPointers = 0x2,
@@ -1662,7 +1662,8 @@ class TypeInfo_Class : TypeInfo
         hasDtor = 0x100,
     }
     ClassFlags m_flags;
-    void*       deallocator;
+    ushort     depth;           /// inheritance distance from Object
+    void*      deallocator;
     OffsetTypeInfo[] m_offTi;
     void function(Object) defaultConstructor;   // default Constructor
 


### PR DESCRIPTION
This works because we can calculate at compile time how many levels are between the object's class and the class it is being cast to. No need to test the intermediate classes, just skip them and go right to checking the one that is levels down.

Shortcut to null if there is no inheritance relationship between the object and the class it is being cast to.

This should make downcasting much faster.