### PR TITLE
Improve readability of 'not callable using argument types' error message

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6564,11 +6564,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         .errorSupplemental(exp.loc, "the following error occured while looking for a UFCS match");
                     }
 
-                    .error(exp.loc, "%s is not callable using argument types `%s`",
-                        exp.f.kind(), buf.peekChars());
-                    .errorSupplemental(exp.loc, "\t`%s%s`", exp.f.toPrettyChars(), parametersTypeToChars(tf.parameterList));
+                    .error(exp.loc, "%s `%s` is not callable using argument types `%s`",
+                        exp.f.kind(), exp.f.toChars(), buf.peekChars());
                     if (failMessage)
                         errorSupplemental(exp.loc, "%s", failMessage);
+                    .errorSupplemental(exp.f.loc, "`%s%s` declared here", exp.f.toPrettyChars(), parametersTypeToChars(tf.parameterList));
                     exp.f = null;
                 }
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6564,8 +6564,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         .errorSupplemental(exp.loc, "the following error occured while looking for a UFCS match");
                     }
 
-                    .error(exp.loc, "%s `%s%s` is not callable using argument types `%s`",
-                        exp.f.kind(), exp.f.toPrettyChars(), parametersTypeToChars(tf.parameterList), buf.peekChars());
+                    .error(exp.loc, "%s is not callable using argument types `%s`",
+                        exp.f.kind(), buf.peekChars());
+                    .errorSupplemental(exp.loc, "\t`%s%s`", exp.f.toPrettyChars(), parametersTypeToChars(tf.parameterList));
                     if (failMessage)
                         errorSupplemental(exp.loc, "%s", failMessage);
                     exp.f = null;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3383,12 +3383,18 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
         // all of overloads are templates
         if (td)
         {
-            const(char)* msg = "none of the overloads of %s `%s.%s` are callable using argument types `!(%s)%s`";
             if (!od && !td.overnext)
-                msg = "%s `%s.%s` is not callable using argument types `!(%s)%s`";
-            .error(loc, msg,
+            {
+                .error(loc, "%s `%s` is not callable using argument types `!(%s)%s`",
+                   td.kind(), td.ident.toChars(), tiargsBuf.peekChars(), fargsBuf.peekChars());
+            }
+            else
+            {
+                .error(loc, "none of the overloads of %s `%s.%s` are callable using argument types `!(%s)%s`",
                    td.kind(), td.parent.toPrettyChars(), td.ident.toChars(),
                    tiargsBuf.peekChars(), fargsBuf.peekChars());
+            }
+
 
             if (!global.gag || global.params.v.showGaggedErrors)
                 printCandidates(loc, td, sc.isDeprecated());

--- a/compiler/test/fail_compilation/b19523.d
+++ b/compiler/test/fail_compilation/b19523.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
----
-fail_compilation\b19523.d(12): Error: undefined identifier `SomeStruct`
-fail_compilation\b19523.d(13): Error: function is not callable using argument types `(_error_)`
-fail_compilation\b19523.d(13):          `b19523.foo(int delegate() arg)`
-fail_compilation\b19523.d(13):        cannot pass argument `__lambda2` of type `_error_` to parameter `int delegate() arg`
----
+----
+fail_compilation/b19523.d(13): Error: undefined identifier `SomeStruct`
+fail_compilation/b19523.d(14): Error: function `foo` is not callable using argument types `(_error_)`
+fail_compilation/b19523.d(14):        cannot pass argument `__lambda2` of type `_error_` to parameter `int delegate() arg`
+fail_compilation/b19523.d(19):        `b19523.foo(int delegate() arg)` declared here
+----
 */
 module b19523;
 

--- a/compiler/test/fail_compilation/b19523.d
+++ b/compiler/test/fail_compilation/b19523.d
@@ -1,9 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/b19523.d(12): Error: undefined identifier `SomeStruct`
-fail_compilation/b19523.d(13): Error: function `b19523.foo(int delegate() arg)` is not callable using argument types `(_error_)`
-fail_compilation/b19523.d(13):        cannot pass argument `__lambda2` of type `_error_` to parameter `int delegate() arg`
+fail_compilation\b19523.d(12): Error: undefined identifier `SomeStruct`
+fail_compilation\b19523.d(13): Error: function is not callable using argument types `(_error_)`
+fail_compilation\b19523.d(13):          `b19523.foo(int delegate() arg)`
+fail_compilation\b19523.d(13):        cannot pass argument `__lambda2` of type `_error_` to parameter `int delegate() arg`
 ---
 */
 module b19523;

--- a/compiler/test/fail_compilation/b20011.d
+++ b/compiler/test/fail_compilation/b20011.d
@@ -5,11 +5,14 @@ fail_compilation/b20011.d(25): Error: cannot modify expression `S1(cast(ubyte)0u
 fail_compilation/b20011.d(28): Error: cannot modify expression `S2(null).member` because it is not an lvalue
 fail_compilation/b20011.d(29): Error: cannot modify expression `S2(null).member` because it is not an lvalue
 fail_compilation/b20011.d(32): Error: cannot modify expression `U1(cast(ubyte)0u, ).m2` because it is not an lvalue
-fail_compilation/b20011.d(37): Error: function `b20011.main.assignableByRef(ref ubyte p)` is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(37): Error: function is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(37):          `b20011.main.assignableByRef(ref ubyte p)`
 fail_compilation/b20011.d(37):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref ubyte p`
-fail_compilation/b20011.d(38): Error: function `b20011.main.assignableByOut(out ubyte p)` is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(38): Error: function is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(38):          `b20011.main.assignableByOut(out ubyte p)`
 fail_compilation/b20011.d(38):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `out ubyte p`
-fail_compilation/b20011.d(39): Error: function `b20011.main.assignableByConstRef(ref const(ubyte) p)` is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(39): Error: function is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(39):          `b20011.main.assignableByConstRef(ref const(ubyte) p)`
 fail_compilation/b20011.d(39):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref const(ubyte) p`
 ---
 */

--- a/compiler/test/fail_compilation/b20011.d
+++ b/compiler/test/fail_compilation/b20011.d
@@ -1,19 +1,19 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/b20011.d(25): Error: cannot modify expression `S1(cast(ubyte)0u).member` because it is not an lvalue
-fail_compilation/b20011.d(28): Error: cannot modify expression `S2(null).member` because it is not an lvalue
-fail_compilation/b20011.d(29): Error: cannot modify expression `S2(null).member` because it is not an lvalue
-fail_compilation/b20011.d(32): Error: cannot modify expression `U1(cast(ubyte)0u, ).m2` because it is not an lvalue
-fail_compilation/b20011.d(37): Error: function is not callable using argument types `(ubyte)`
-fail_compilation/b20011.d(37):          `b20011.main.assignableByRef(ref ubyte p)`
-fail_compilation/b20011.d(37):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref ubyte p`
-fail_compilation/b20011.d(38): Error: function is not callable using argument types `(ubyte)`
-fail_compilation/b20011.d(38):          `b20011.main.assignableByOut(out ubyte p)`
-fail_compilation/b20011.d(38):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `out ubyte p`
-fail_compilation/b20011.d(39): Error: function is not callable using argument types `(ubyte)`
-fail_compilation/b20011.d(39):          `b20011.main.assignableByConstRef(ref const(ubyte) p)`
-fail_compilation/b20011.d(39):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref const(ubyte) p`
+fail_compilation\b20011.d(28): Error: cannot modify expression `S1(cast(ubyte)0u).member` because it is not an lvalue
+fail_compilation\b20011.d(31): Error: cannot modify expression `S2(null).member` because it is not an lvalue
+fail_compilation\b20011.d(32): Error: cannot modify expression `S2(null).member` because it is not an lvalue
+fail_compilation\b20011.d(35): Error: cannot modify expression `U1(cast(ubyte)0u, ).m2` because it is not an lvalue
+fail_compilation\b20011.d(40): Error: function is not callable using argument types `(ubyte)`
+fail_compilation\b20011.d(40):          `b20011.main.assignableByRef(ref ubyte p)`
+fail_compilation\b20011.d(40):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref ubyte p`
+fail_compilation\b20011.d(41): Error: function is not callable using argument types `(ubyte)`
+fail_compilation\b20011.d(41):          `b20011.main.assignableByOut(out ubyte p)`
+fail_compilation\b20011.d(41):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `out ubyte p`
+fail_compilation\b20011.d(42): Error: function is not callable using argument types `(ubyte)`
+fail_compilation\b20011.d(42):          `b20011.main.assignableByConstRef(ref const(ubyte) p)`
+fail_compilation\b20011.d(42):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref const(ubyte) p`
 ---
 */
 module b20011;

--- a/compiler/test/fail_compilation/b20011.d
+++ b/compiler/test/fail_compilation/b20011.d
@@ -1,19 +1,19 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation\b20011.d(28): Error: cannot modify expression `S1(cast(ubyte)0u).member` because it is not an lvalue
-fail_compilation\b20011.d(31): Error: cannot modify expression `S2(null).member` because it is not an lvalue
-fail_compilation\b20011.d(32): Error: cannot modify expression `S2(null).member` because it is not an lvalue
-fail_compilation\b20011.d(35): Error: cannot modify expression `U1(cast(ubyte)0u, ).m2` because it is not an lvalue
-fail_compilation\b20011.d(40): Error: function is not callable using argument types `(ubyte)`
-fail_compilation\b20011.d(40):          `b20011.main.assignableByRef(ref ubyte p)`
-fail_compilation\b20011.d(40):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref ubyte p`
-fail_compilation\b20011.d(41): Error: function is not callable using argument types `(ubyte)`
-fail_compilation\b20011.d(41):          `b20011.main.assignableByOut(out ubyte p)`
-fail_compilation\b20011.d(41):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `out ubyte p`
-fail_compilation\b20011.d(42): Error: function is not callable using argument types `(ubyte)`
-fail_compilation\b20011.d(42):          `b20011.main.assignableByConstRef(ref const(ubyte) p)`
-fail_compilation\b20011.d(42):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref const(ubyte) p`
+fail_compilation/b20011.d(41): Error: cannot modify expression `S1(cast(ubyte)0u).member` because it is not an lvalue
+fail_compilation/b20011.d(44): Error: cannot modify expression `S2(null).member` because it is not an lvalue
+fail_compilation/b20011.d(45): Error: cannot modify expression `S2(null).member` because it is not an lvalue
+fail_compilation/b20011.d(48): Error: cannot modify expression `U1(cast(ubyte)0u, ).m2` because it is not an lvalue
+fail_compilation/b20011.d(53): Error: function `assignableByRef` is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(53):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref ubyte p`
+fail_compilation/b20011.d(50):        `b20011.main.assignableByRef(ref ubyte p)` declared here
+fail_compilation/b20011.d(54): Error: function `assignableByOut` is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(54):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `out ubyte p`
+fail_compilation/b20011.d(51):        `b20011.main.assignableByOut(out ubyte p)` declared here
+fail_compilation/b20011.d(55): Error: function `assignableByConstRef` is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(55):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref const(ubyte) p`
+fail_compilation/b20011.d(52):        `b20011.main.assignableByConstRef(ref const(ubyte) p)` declared here
 ---
 */
 module b20011;

--- a/compiler/test/fail_compilation/b20011.d
+++ b/compiler/test/fail_compilation/b20011.d
@@ -1,19 +1,19 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/b20011.d(41): Error: cannot modify expression `S1(cast(ubyte)0u).member` because it is not an lvalue
-fail_compilation/b20011.d(44): Error: cannot modify expression `S2(null).member` because it is not an lvalue
-fail_compilation/b20011.d(45): Error: cannot modify expression `S2(null).member` because it is not an lvalue
-fail_compilation/b20011.d(48): Error: cannot modify expression `U1(cast(ubyte)0u, ).m2` because it is not an lvalue
-fail_compilation/b20011.d(53): Error: function `assignableByRef` is not callable using argument types `(ubyte)`
-fail_compilation/b20011.d(53):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref ubyte p`
-fail_compilation/b20011.d(50):        `b20011.main.assignableByRef(ref ubyte p)` declared here
-fail_compilation/b20011.d(54): Error: function `assignableByOut` is not callable using argument types `(ubyte)`
-fail_compilation/b20011.d(54):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `out ubyte p`
-fail_compilation/b20011.d(51):        `b20011.main.assignableByOut(out ubyte p)` declared here
-fail_compilation/b20011.d(55): Error: function `assignableByConstRef` is not callable using argument types `(ubyte)`
-fail_compilation/b20011.d(55):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref const(ubyte) p`
-fail_compilation/b20011.d(52):        `b20011.main.assignableByConstRef(ref const(ubyte) p)` declared here
+fail_compilation/b20011.d(28): Error: cannot modify expression `S1(cast(ubyte)0u).member` because it is not an lvalue
+fail_compilation/b20011.d(31): Error: cannot modify expression `S2(null).member` because it is not an lvalue
+fail_compilation/b20011.d(32): Error: cannot modify expression `S2(null).member` because it is not an lvalue
+fail_compilation/b20011.d(35): Error: cannot modify expression `U1(cast(ubyte)0u, ).m2` because it is not an lvalue
+fail_compilation/b20011.d(40): Error: function `assignableByRef` is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(40):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref ubyte p`
+fail_compilation/b20011.d(37):        `b20011.main.assignableByRef(ref ubyte p)` declared here
+fail_compilation/b20011.d(41): Error: function `assignableByOut` is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(41):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `out ubyte p`
+fail_compilation/b20011.d(38):        `b20011.main.assignableByOut(out ubyte p)` declared here
+fail_compilation/b20011.d(42): Error: function `assignableByConstRef` is not callable using argument types `(ubyte)`
+fail_compilation/b20011.d(42):        cannot pass rvalue argument `S1(cast(ubyte)0u).member` of type `ubyte` to parameter `ref const(ubyte) p`
+fail_compilation/b20011.d(39):        `b20011.main.assignableByConstRef(ref const(ubyte) p)` declared here
 ---
 */
 module b20011;

--- a/compiler/test/fail_compilation/bug15613.d
+++ b/compiler/test/fail_compilation/bug15613.d
@@ -1,12 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation\bug15613.d(16): Error: function is not callable using argument types `(typeof(null))`
-fail_compilation\bug15613.d(16):            `bug15613.f(int...)`
-fail_compilation\bug15613.d(16):        cannot pass argument `null` of type `typeof(null)` to parameter `int...`
-fail_compilation\bug15613.d(17): Error: function is not callable using argument types `(int)`
-fail_compilation\bug15613.d(17):            `bug15613.g(Object, ...)`
-fail_compilation\bug15613.d(17):        cannot pass argument `8` of type `int` to parameter `Object`
+fail_compilation/bug15613.d(18): Error: function `f` is not callable using argument types `(typeof(null))`
+fail_compilation/bug15613.d(18):        cannot pass argument `null` of type `typeof(null)` to parameter `int...`
+fail_compilation/bug15613.d(13):        `bug15613.f(int...)` declared here
+fail_compilation/bug15613.d(19): Error: function `g` is not callable using argument types `(int)`
+fail_compilation/bug15613.d(19):        cannot pass argument `8` of type `int` to parameter `Object`
+fail_compilation/bug15613.d(14):        `bug15613.g(Object, ...)` declared here
 ---
 */
 
@@ -22,9 +22,9 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation\bug15613.d(32): Error: function is not callable using argument types `(int, void function(int[]...))`
-fail_compilation\bug15613.d(32):            `bug15613.h(int[]...)`
-fail_compilation\bug15613.d(32):        cannot pass argument `& h` of type `void function(int[]...)` to parameter `int[]...`
+fail_compilation/bug15613.d(35): Error: function `h` is not callable using argument types `(int, void function(int[]...))`
+fail_compilation/bug15613.d(35):        cannot pass argument `& h` of type `void function(int[]...)` to parameter `int[]...`
+fail_compilation/bug15613.d(31):        `bug15613.h(int[]...)` declared here
 ---
 */
 

--- a/compiler/test/fail_compilation/bug15613.d
+++ b/compiler/test/fail_compilation/bug15613.d
@@ -1,10 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug15613.d(16): Error: function `bug15613.f(int...)` is not callable using argument types `(typeof(null))`
-fail_compilation/bug15613.d(16):        cannot pass argument `null` of type `typeof(null)` to parameter `int...`
-fail_compilation/bug15613.d(17): Error: function `bug15613.g(Object, ...)` is not callable using argument types `(int)`
-fail_compilation/bug15613.d(17):        cannot pass argument `8` of type `int` to parameter `Object`
+fail_compilation\bug15613.d(16): Error: function is not callable using argument types `(typeof(null))`
+fail_compilation\bug15613.d(16):            `bug15613.f(int...)`
+fail_compilation\bug15613.d(16):        cannot pass argument `null` of type `typeof(null)` to parameter `int...`
+fail_compilation\bug15613.d(17): Error: function is not callable using argument types `(int)`
+fail_compilation\bug15613.d(17):            `bug15613.g(Object, ...)`
+fail_compilation\bug15613.d(17):        cannot pass argument `8` of type `int` to parameter `Object`
 ---
 */
 
@@ -20,8 +22,9 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug15613.d(32): Error: function `bug15613.h(int[]...)` is not callable using argument types `(int, void function(int[]...))`
-fail_compilation/bug15613.d(32):        cannot pass argument `& h` of type `void function(int[]...)` to parameter `int[]...`
+fail_compilation\bug15613.d(32): Error: function is not callable using argument types `(int, void function(int[]...))`
+fail_compilation\bug15613.d(32):            `bug15613.h(int[]...)`
+fail_compilation\bug15613.d(32):        cannot pass argument `& h` of type `void function(int[]...)` to parameter `int[]...`
 ---
 */
 

--- a/compiler/test/fail_compilation/bug16165.d
+++ b/compiler/test/fail_compilation/bug16165.d
@@ -10,11 +10,11 @@ void g()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation\bug16165.d(6): Error: function is not callable using argument types `(Object, Object, int)`
-fail_compilation\bug16165.d(6):         `bug16165.f(int x, Object y)`
-fail_compilation\bug16165.d(6):        cannot pass argument `o` of type `object.Object` to parameter `int x`
-fail_compilation\bug16165.d(7): Error: function is not callable using argument types `(int, int, int)`
-fail_compilation\bug16165.d(7):         `bug16165.f(int x, Object y)`
-fail_compilation\bug16165.d(7):        cannot pass argument `6` of type `int` to parameter `Object y`
+fail_compilation/bug16165.d(6): Error: function `f` is not callable using argument types `(Object, Object, int)`
+fail_compilation/bug16165.d(6):        cannot pass argument `o` of type `object.Object` to parameter `int x`
+fail_compilation/bug16165.d(1):        `bug16165.f(int x, Object y)` declared here
+fail_compilation/bug16165.d(7): Error: function `f` is not callable using argument types `(int, int, int)`
+fail_compilation/bug16165.d(7):        cannot pass argument `6` of type `int` to parameter `Object y`
+fail_compilation/bug16165.d(1):        `bug16165.f(int x, Object y)` declared here
 ---
  */

--- a/compiler/test/fail_compilation/bug16165.d
+++ b/compiler/test/fail_compilation/bug16165.d
@@ -10,9 +10,11 @@ void g()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug16165.d(6): Error: function `bug16165.f(int x, Object y)` is not callable using argument types `(Object, Object, int)`
-fail_compilation/bug16165.d(6):        cannot pass argument `o` of type `object.Object` to parameter `int x`
-fail_compilation/bug16165.d(7): Error: function `bug16165.f(int x, Object y)` is not callable using argument types `(int, int, int)`
-fail_compilation/bug16165.d(7):        cannot pass argument `6` of type `int` to parameter `Object y`
+fail_compilation\bug16165.d(6): Error: function is not callable using argument types `(Object, Object, int)`
+fail_compilation\bug16165.d(6):         `bug16165.f(int x, Object y)`
+fail_compilation\bug16165.d(6):        cannot pass argument `o` of type `object.Object` to parameter `int x`
+fail_compilation\bug16165.d(7): Error: function is not callable using argument types `(int, int, int)`
+fail_compilation\bug16165.d(7):         `bug16165.f(int x, Object y)`
+fail_compilation\bug16165.d(7):        cannot pass argument `6` of type `int` to parameter `Object y`
 ---
  */

--- a/compiler/test/fail_compilation/bug9631.d
+++ b/compiler/test/fail_compilation/bug9631.d
@@ -62,8 +62,9 @@ void test3()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug9631.d(79): Error: function `bug9631.arg.f(int i, S s)` is not callable using argument types `(int, S)`
+fail_compilation/bug9631.d(79): Error: function `f` is not callable using argument types `(int, S)`
 fail_compilation/bug9631.d(79):        cannot pass argument `y` of type `bug9631.tem!().S` to parameter `bug9631.S s`
+fail_compilation/bug9631.d(78):        `bug9631.arg.f(int i, S s)` declared here
 fail_compilation/bug9631.d(80): Error: function literal `__lambda4(S s)` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(80):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S s`
 fail_compilation/bug9631.d(86): Error: constructor `bug9631.arg.A.this(S __param_0)` is not callable using argument types `(S)`
@@ -89,11 +90,12 @@ void arg()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug9631.d(106): Error: function `bug9631.targ.ft!().ft(S __param_0)` is not callable using argument types `(S)`
+fail_compilation/bug9631.d(106): Error: function `ft` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(106):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S __param_0`
-fail_compilation/bug9631.d(107): Error: template `bug9631.targ.ft` is not callable using argument types `!()(S)`
+fail_compilation/bug9631.d(105):        `bug9631.targ.ft!().ft(S __param_0)` declared here
+fail_compilation/bug9631.d(107): Error: template `ft` is not callable using argument types `!()(S)`
 fail_compilation/bug9631.d(105):        Candidate is: `ft()(tem!().S)`
-fail_compilation/bug9631.d(109): Error: template `bug9631.targ.ft2` is not callable using argument types `!()(S, int)`
+fail_compilation/bug9631.d(109): Error: template `ft2` is not callable using argument types `!()(S, int)`
 fail_compilation/bug9631.d(108):        Candidate is: `ft2(T)(S, T)`
 ---
 */

--- a/compiler/test/fail_compilation/bug9631.d
+++ b/compiler/test/fail_compilation/bug9631.d
@@ -62,13 +62,13 @@ void test3()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug9631.d(79): Error: function `f` is not callable using argument types `(int, S)`
-fail_compilation/bug9631.d(79):        cannot pass argument `y` of type `bug9631.tem!().S` to parameter `bug9631.S s`
-fail_compilation/bug9631.d(78):        `bug9631.arg.f(int i, S s)` declared here
-fail_compilation/bug9631.d(80): Error: function literal `__lambda4(S s)` is not callable using argument types `(S)`
-fail_compilation/bug9631.d(80):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S s`
-fail_compilation/bug9631.d(86): Error: constructor `bug9631.arg.A.this(S __param_0)` is not callable using argument types `(S)`
-fail_compilation/bug9631.d(86):        cannot pass argument `S(0)` of type `bug9631.tem!().S` to parameter `bug9631.S __param_0`
+fail_compilation/bug9631.d(80): Error: function `f` is not callable using argument types `(int, S)`
+fail_compilation/bug9631.d(80):        cannot pass argument `y` of type `bug9631.tem!().S` to parameter `bug9631.S s`
+fail_compilation/bug9631.d(79):        `bug9631.arg.f(int i, S s)` declared here
+fail_compilation/bug9631.d(81): Error: function literal `__lambda4(S s)` is not callable using argument types `(S)`
+fail_compilation/bug9631.d(81):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S s`
+fail_compilation/bug9631.d(87): Error: constructor `bug9631.arg.A.this(S __param_0)` is not callable using argument types `(S)`
+fail_compilation/bug9631.d(87):        cannot pass argument `S(0)` of type `bug9631.tem!().S` to parameter `bug9631.S __param_0`
 ---
 */
 void arg()
@@ -90,13 +90,13 @@ void arg()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug9631.d(106): Error: function `ft` is not callable using argument types `(S)`
-fail_compilation/bug9631.d(106):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S __param_0`
-fail_compilation/bug9631.d(105):        `bug9631.targ.ft!().ft(S __param_0)` declared here
-fail_compilation/bug9631.d(107): Error: template `ft` is not callable using argument types `!()(S)`
-fail_compilation/bug9631.d(105):        Candidate is: `ft()(tem!().S)`
-fail_compilation/bug9631.d(109): Error: template `ft2` is not callable using argument types `!()(S, int)`
-fail_compilation/bug9631.d(108):        Candidate is: `ft2(T)(S, T)`
+fail_compilation/bug9631.d(108): Error: function `ft` is not callable using argument types `(S)`
+fail_compilation/bug9631.d(108):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S __param_0`
+fail_compilation/bug9631.d(107):        `bug9631.targ.ft!().ft(S __param_0)` declared here
+fail_compilation/bug9631.d(109): Error: template `ft` is not callable using argument types `!()(S)`
+fail_compilation/bug9631.d(107):        Candidate is: `ft()(tem!().S)`
+fail_compilation/bug9631.d(111): Error: template `ft2` is not callable using argument types `!()(S, int)`
+fail_compilation/bug9631.d(110):        Candidate is: `ft2(T)(S, T)`
 ---
 */
 void targ()

--- a/compiler/test/fail_compilation/callconst.d
+++ b/compiler/test/fail_compilation/callconst.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/callconst.d(19): Error: function `func` is not callable using argument types `(const(X))`
-fail_compilation/callconst.d(19):        cannot pass argument `x` of type `const(X)` to parameter `ref X`
-fail_compilation/callconst.d(22):        `callconst.func(ref X)` declared here
+fail_compilation/callconst.d(14): Error: function `func` is not callable using argument types `(const(X))`
+fail_compilation/callconst.d(14):        cannot pass argument `x` of type `const(X)` to parameter `ref X`
+fail_compilation/callconst.d(17):        `callconst.func(ref X)` declared here
 ---
 */
 struct X {}

--- a/compiler/test/fail_compilation/callconst.d
+++ b/compiler/test/fail_compilation/callconst.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/callconst.d(13): Error: function is not callable using argument types `(const(X))`
-fail_compilation/callconst.d(13):               `callconst.func(ref X)`
-fail_compilation/callconst.d(13):        cannot pass argument `x` of type `const(X)` to parameter `ref X`
+fail_compilation\callconst.d(14): Error: function is not callable using argument types `(const(X))`
+fail_compilation\callconst.d(14):           `callconst.func(ref X)`
+fail_compilation\callconst.d(14):        cannot pass argument `x` of type `const(X)` to parameter `ref X`
 ---
 */
 struct X {}

--- a/compiler/test/fail_compilation/callconst.d
+++ b/compiler/test/fail_compilation/callconst.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/callconst.d(13): Error: function `callconst.func(ref X)` is not callable using argument types `(const(X))`
+fail_compilation/callconst.d(13): Error: function is not callable using argument types `(const(X))`
+fail_compilation/callconst.d(13):               `callconst.func(ref X)`
 fail_compilation/callconst.d(13):        cannot pass argument `x` of type `const(X)` to parameter `ref X`
 ---
 */

--- a/compiler/test/fail_compilation/callconst.d
+++ b/compiler/test/fail_compilation/callconst.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation\callconst.d(14): Error: function is not callable using argument types `(const(X))`
-fail_compilation\callconst.d(14):           `callconst.func(ref X)`
-fail_compilation\callconst.d(14):        cannot pass argument `x` of type `const(X)` to parameter `ref X`
+fail_compilation/callconst.d(19): Error: function `func` is not callable using argument types `(const(X))`
+fail_compilation/callconst.d(19):        cannot pass argument `x` of type `const(X)` to parameter `ref X`
+fail_compilation/callconst.d(22):        `callconst.func(ref X)` declared here
 ---
 */
 struct X {}

--- a/compiler/test/fail_compilation/constraints_aggr.d
+++ b/compiler/test/fail_compilation/constraints_aggr.d
@@ -2,12 +2,12 @@
 EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_aggr.d(32): Error: template `imports.constraints.C.f` is not callable using argument types `!()(int)`
+fail_compilation/constraints_aggr.d(32): Error: template `f` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(60):        Candidate is: `f(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_aggr.d(33): Error: template `imports.constraints.C.g` is not callable using argument types `!()()`
+fail_compilation/constraints_aggr.d(33): Error: template `g` is not callable using argument types `!()()`
 fail_compilation/imports/constraints.d(63):        Candidate is: `g(this T)()`
   with `T = imports.constraints.C`
   must satisfy the following constraint:

--- a/compiler/test/fail_compilation/constraints_func1.d
+++ b/compiler/test/fail_compilation/constraints_func1.d
@@ -2,72 +2,72 @@
 EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func1.d(79): Error: template `imports.constraints.test1` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(79): Error: template `test1` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(9):        Candidate is: `test1(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(80): Error: template `imports.constraints.test2` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(80): Error: template `test2` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(10):        Candidate is: `test2(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(81): Error: template `imports.constraints.test3` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(81): Error: template `test3` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(11):        Candidate is: `test3(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(82): Error: template `imports.constraints.test4` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(82): Error: template `test4` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(12):        Candidate is: `test4(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(83): Error: template `imports.constraints.test5` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(83): Error: template `test5` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(13):        Candidate is: `test5(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func1.d(84): Error: template `imports.constraints.test6` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(84): Error: template `test6` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(14):        Candidate is: `test6(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T
        !P!T`
-fail_compilation/constraints_func1.d(85): Error: template `imports.constraints.test7` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(85): Error: template `test7` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(15):        Candidate is: `test7(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func1.d(86): Error: template `imports.constraints.test8` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(86): Error: template `test8` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(16):        Candidate is: `test8(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func1.d(87): Error: template `imports.constraints.test9` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(87): Error: template `test9` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(17):        Candidate is: `test9(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(88): Error: template `imports.constraints.test10` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(88): Error: template `test10` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(18):        Candidate is: `test10(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(89): Error: template `imports.constraints.test11` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(89): Error: template `test11` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(19):        Candidate is: `test11(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T`
-fail_compilation/constraints_func1.d(90): Error: template `imports.constraints.test12` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func1.d(90): Error: template `test12` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(20):        Candidate is: `test12(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       !P!T`
-fail_compilation/constraints_func1.d(92): Error: template `imports.constraints.test1` is not callable using argument types `!()(int, int)`
+fail_compilation/constraints_func1.d(92): Error: template `test1` is not callable using argument types `!()(int, int)`
 fail_compilation/imports/constraints.d(9):        Candidate is: `test1(T)(T v)`
 ---
 */

--- a/compiler/test/fail_compilation/constraints_func2.d
+++ b/compiler/test/fail_compilation/constraints_func2.d
@@ -2,83 +2,83 @@
 EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
 ---
-fail_compilation/constraints_func2.d(94): Error: template `imports.constraints.test13` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(94): Error: template `test13` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(23):        Candidate is: `test13(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T`
-fail_compilation/constraints_func2.d(95): Error: template `imports.constraints.test14` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(95): Error: template `test14` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(24):        Candidate is: `test14(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        N!T`
-fail_compilation/constraints_func2.d(96): Error: template `imports.constraints.test15` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(96): Error: template `test15` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(25):        Candidate is: `test15(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        !P!T`
-fail_compilation/constraints_func2.d(97): Error: template `imports.constraints.test16` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(97): Error: template `test16` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(26):        Candidate is: `test16(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(98): Error: template `imports.constraints.test17` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(98): Error: template `test17` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(27):        Candidate is: `test17(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(99): Error: template `imports.constraints.test18` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(99): Error: template `test18` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(28):        Candidate is: `test18(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(100): Error: template `imports.constraints.test19` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(100): Error: template `test19` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(29):        Candidate is: `test19(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        !P!T
        N!T`
-fail_compilation/constraints_func2.d(101): Error: template `imports.constraints.test20` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(101): Error: template `test20` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(30):        Candidate is: `test20(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(102): Error: template `imports.constraints.test21` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(102): Error: template `test21` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(31):        Candidate is: `test21(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       N!T
        N!T`
-fail_compilation/constraints_func2.d(103): Error: template `imports.constraints.test22` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(103): Error: template `test22` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(32):        Candidate is: `test22(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        !P!T`
-fail_compilation/constraints_func2.d(104): Error: template `imports.constraints.test23` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(104): Error: template `test23` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(33):        Candidate is: `test23(T)(T v)`
   with `T = int`
   must satisfy one of the following constraints:
 `       !P!T
        N!T
        !P!T`
-fail_compilation/constraints_func2.d(105): Error: template `imports.constraints.test24` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(105): Error: template `test24` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(34):        Candidate is: `test24(R)(R r)`
   with `R = int`
   must satisfy the following constraint:
 `       __traits(hasMember, R, "stuff")`
-fail_compilation/constraints_func2.d(106): Error: template `imports.constraints.test25` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func2.d(106): Error: template `test25` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(35):        Candidate is: `test25(T)(T v)`
   with `T = int`
   must satisfy the following constraint:
 `       N!T`
-fail_compilation/constraints_func2.d(107): Error: template `imports.constraints.test26` is not callable using argument types `!(float)(int)`
+fail_compilation/constraints_func2.d(107): Error: template `test26` is not callable using argument types `!(float)(int)`
 fail_compilation/imports/constraints.d(36):        Candidate is: `test26(T, U)(U u)`
   with `T = float,
        U = int`

--- a/compiler/test/fail_compilation/constraints_func3.d
+++ b/compiler/test/fail_compilation/constraints_func3.d
@@ -1,7 +1,7 @@
 /*
 EXTRA_FILES: imports/constraints.d
 TEST_OUTPUT:
----
+----
 fail_compilation/constraints_func3.d(53): Error: none of the overloads of template `imports.constraints.overload` are callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(39):        Candidates are: `overload(T)(T v)`
   with `T = int`
@@ -23,27 +23,27 @@ fail_compilation/imports/constraints.d(42):                        `overload(T, 
   must satisfy one of the following constraints:
 `       N!T
        N!V`
-fail_compilation/constraints_func3.d(56): Error: template `imports.constraints.variadic` is not callable using argument types `!()()`
+fail_compilation/constraints_func3.d(56): Error: template `variadic` is not callable using argument types `!()()`
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
-fail_compilation/constraints_func3.d(57): Error: template `imports.constraints.variadic` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func3.d(57): Error: template `variadic` is not callable using argument types `!()(int)`
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = ()`
   must satisfy the following constraint:
 `       N!int`
-fail_compilation/constraints_func3.d(58): Error: template `imports.constraints.variadic` is not callable using argument types `!()(int, int)`
+fail_compilation/constraints_func3.d(58): Error: template `variadic` is not callable using argument types `!()(int, int)`
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = (int)`
   must satisfy the following constraint:
 `       N!int`
-fail_compilation/constraints_func3.d(59): Error: template `imports.constraints.variadic` is not callable using argument types `!()(int, int, int)`
+fail_compilation/constraints_func3.d(59): Error: template `variadic` is not callable using argument types `!()(int, int, int)`
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
   with `A = int,
        T = (int, int)`
   must satisfy the following constraint:
 `       N!int`
----
+----
 */
 
 void main()

--- a/compiler/test/fail_compilation/constraints_func4.d
+++ b/compiler/test/fail_compilation/constraints_func4.d
@@ -2,7 +2,7 @@
 EXTRA_FILES: imports/constraints.d
 REQUIRED_ARGS: -verrors=context
 TEST_OUTPUT:
----
+----
 fail_compilation/constraints_func4.d(90): Error: none of the overloads of template `imports.constraints.overload` are callable using argument types `!()(int)`
     overload(0);
             ^
@@ -44,13 +44,13 @@ fail_compilation/imports/constraints.d(42):                        `overload(T, 
        N!V`
 void overload(T, V)(T v1, V v2) if (N!T || N!V);
      ^
-fail_compilation/constraints_func4.d(93): Error: template `imports.constraints.variadic` is not callable using argument types `!()()`
+fail_compilation/constraints_func4.d(93): Error: template `variadic` is not callable using argument types `!()()`
     variadic();
             ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
 void variadic(A, T...)(A a, T v) if (N!int);
      ^
-fail_compilation/constraints_func4.d(94): Error: template `imports.constraints.variadic` is not callable using argument types `!()(int)`
+fail_compilation/constraints_func4.d(94): Error: template `variadic` is not callable using argument types `!()(int)`
     variadic(0);
             ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
@@ -60,7 +60,7 @@ fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T.
 `       N!int`
 void variadic(A, T...)(A a, T v) if (N!int);
      ^
-fail_compilation/constraints_func4.d(95): Error: template `imports.constraints.variadic` is not callable using argument types `!()(int, int)`
+fail_compilation/constraints_func4.d(95): Error: template `variadic` is not callable using argument types `!()(int, int)`
     variadic(0, 1);
             ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
@@ -70,7 +70,7 @@ fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T.
 `       N!int`
 void variadic(A, T...)(A a, T v) if (N!int);
      ^
-fail_compilation/constraints_func4.d(96): Error: template `imports.constraints.variadic` is not callable using argument types `!()(int, int, int)`
+fail_compilation/constraints_func4.d(96): Error: template `variadic` is not callable using argument types `!()(int, int, int)`
     variadic(0, 1, 2);
             ^
 fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T...)(A a, T v)`
@@ -80,7 +80,7 @@ fail_compilation/imports/constraints.d(43):        Candidate is: `variadic(A, T.
 `       N!int`
 void variadic(A, T...)(A a, T v) if (N!int);
      ^
----
+----
 */
 
 void main()

--- a/compiler/test/fail_compilation/diag13942.d
+++ b/compiler/test/fail_compilation/diag13942.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag13942.d(18): Error: template instance `isRawStaticArray!()` does not match template declaration `isRawStaticArray(T, A...)`
-fail_compilation/diag13942.d(26): Error: template `diag13942.to!double.to` is not callable using argument types `!()()`
+fail_compilation/diag13942.d(26): Error: template `to` is not callable using argument types `!()()`
 fail_compilation/diag13942.d(17):        Candidate is: `to(A...)(A args)`
 ---
 */

--- a/compiler/test/fail_compilation/diag16977.d
+++ b/compiler/test/fail_compilation/diag16977.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/diag16977.d(25): Error: undefined identifier `undefined`, did you mean function `undefinedId`?
 fail_compilation/diag16977.d(26): Error: cannot implicitly convert expression `"\x01string"` of type `string` to `int`
-fail_compilation/diag16977.d(27): Error: template `diag16977.templ` is not callable using argument types `!()(int)`
+fail_compilation/diag16977.d(27): Error: template `templ` is not callable using argument types `!()(int)`
 fail_compilation/diag16977.d(20):        Candidate is: `templ(S)(S s)`
   with `S = int`
   must satisfy the following constraint:

--- a/compiler/test/fail_compilation/diag20268.d
+++ b/compiler/test/fail_compilation/diag20268.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag20268.d(12): Error: template `diag20268.__lambda4` is not callable using argument types `!()(int)`
+fail_compilation/diag20268.d(12): Error: template `__lambda4` is not callable using argument types `!()(int)`
 fail_compilation/diag20268.d(11):        Candidate is: `__lambda4(__T1, __T2)(x, y)`
 ---
 */

--- a/compiler/test/fail_compilation/diag23355.d
+++ b/compiler/test/fail_compilation/diag23355.d
@@ -2,10 +2,10 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag23355.d(1): Error: undefined identifier `n`
-fail_compilation/diag23355.d(4): Error: template `diag23355.ffi1` is not callable using argument types `!()(int[4])`
+fail_compilation/diag23355.d(4): Error: template `ffi1` is not callable using argument types `!()(int[4])`
 fail_compilation/diag23355.d(1):        Candidate is: `ffi1(T)(T[n] s)`
 fail_compilation/diag23355.d(2): Error: undefined identifier `n`
-fail_compilation/diag23355.d(4): Error: template `diag23355.ffi2` is not callable using argument types `!()(int[4])`
+fail_compilation/diag23355.d(4): Error: template `ffi2` is not callable using argument types `!()(int[4])`
 fail_compilation/diag23355.d(2):        Candidate is: `ffi2()(T[n] s)`
 ---
 */

--- a/compiler/test/fail_compilation/diag8101.d
+++ b/compiler/test/fail_compilation/diag8101.d
@@ -1,33 +1,33 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation\diag8101.d(61): Error: function is not callable using argument types `()`
-fail_compilation\diag8101.d(61):            `diag8101.f_0(int)`
-fail_compilation\diag8101.d(61):        too few arguments, expected 1, got 0
-fail_compilation\diag8101.d(62): Error: none of the overloads of `f_1` are callable using argument types `()`
-fail_compilation\diag8101.d(35):        Candidates are: `diag8101.f_1(int)`
-fail_compilation\diag8101.d(36):                        `diag8101.f_1(int, int)`
-fail_compilation\diag8101.d(63): Error: none of the overloads of `f_2` are callable using argument types `()`
-fail_compilation\diag8101.d(38):        Candidates are: `diag8101.f_2(int)`
-fail_compilation\diag8101.d(39):                        `diag8101.f_2(int, int)`
-fail_compilation\diag8101.d(40):                        `diag8101.f_2(int, int, int)`
-fail_compilation\diag8101.d(41):                        `diag8101.f_2(int, int, int, int)`
-fail_compilation\diag8101.d(42):                        `diag8101.f_2(int, int, int, int, int)`
-fail_compilation\diag8101.d(43):                        `diag8101.f_2(int, int, int, int, int, int)`
-fail_compilation\diag8101.d(63):        ... (1 more, -v to show) ...
-fail_compilation\diag8101.d(65): Error: template `diag8101.t_0` is not callable using argument types `!()()`
-fail_compilation\diag8101.d(46):        Candidate is: `t_0(T1)()`
-fail_compilation\diag8101.d(66): Error: none of the overloads of template `diag8101.t_1` are callable using argument types `!()()`
-fail_compilation\diag8101.d(48):        Candidates are: `t_1(T1)()`
-fail_compilation\diag8101.d(49):                        `t_1(T1, T2)()`
-fail_compilation\diag8101.d(67): Error: none of the overloads of template `diag8101.t_2` are callable using argument types `!()()`
-fail_compilation\diag8101.d(51):        Candidates are: `t_2(T1)()`
-fail_compilation\diag8101.d(52):                        `t_2(T1, T2)()`
-fail_compilation\diag8101.d(53):                        `t_2(T1, T2, T3)()`
-fail_compilation\diag8101.d(54):                        `t_2(T1, T2, T3, T4)()`
-fail_compilation\diag8101.d(55):                        `t_2(T1, T2, T3, T4, T5)()`
-fail_compilation\diag8101.d(56):                        `t_2(T1, T2, T3, T4, T5, T6)()`
-fail_compilation\diag8101.d(67):        ... (1 more, -v to show) ...
+fail_compilation/diag8101.d(62): Error: function `f_0` is not callable using argument types `()`
+fail_compilation/diag8101.d(62):        too few arguments, expected 1, got 0
+fail_compilation/diag8101.d(34):        `diag8101.f_0(int)` declared here
+fail_compilation/diag8101.d(63): Error: none of the overloads of `f_1` are callable using argument types `()`
+fail_compilation/diag8101.d(36):        Candidates are: `diag8101.f_1(int)`
+fail_compilation/diag8101.d(37):                        `diag8101.f_1(int, int)`
+fail_compilation/diag8101.d(64): Error: none of the overloads of `f_2` are callable using argument types `()`
+fail_compilation/diag8101.d(39):        Candidates are: `diag8101.f_2(int)`
+fail_compilation/diag8101.d(40):                        `diag8101.f_2(int, int)`
+fail_compilation/diag8101.d(41):                        `diag8101.f_2(int, int, int)`
+fail_compilation/diag8101.d(42):                        `diag8101.f_2(int, int, int, int)`
+fail_compilation/diag8101.d(43):                        `diag8101.f_2(int, int, int, int, int)`
+fail_compilation/diag8101.d(44):                        `diag8101.f_2(int, int, int, int, int, int)`
+fail_compilation/diag8101.d(64):        ... (1 more, -v to show) ...
+fail_compilation/diag8101.d(66): Error: template `t_0` is not callable using argument types `!()()`
+fail_compilation/diag8101.d(47):        Candidate is: `t_0(T1)()`
+fail_compilation/diag8101.d(67): Error: none of the overloads of template `diag8101.t_1` are callable using argument types `!()()`
+fail_compilation/diag8101.d(49):        Candidates are: `t_1(T1)()`
+fail_compilation/diag8101.d(50):                        `t_1(T1, T2)()`
+fail_compilation/diag8101.d(68): Error: none of the overloads of template `diag8101.t_2` are callable using argument types `!()()`
+fail_compilation/diag8101.d(52):        Candidates are: `t_2(T1)()`
+fail_compilation/diag8101.d(53):                        `t_2(T1, T2)()`
+fail_compilation/diag8101.d(54):                        `t_2(T1, T2, T3)()`
+fail_compilation/diag8101.d(55):                        `t_2(T1, T2, T3, T4)()`
+fail_compilation/diag8101.d(56):                        `t_2(T1, T2, T3, T4, T5)()`
+fail_compilation/diag8101.d(57):                        `t_2(T1, T2, T3, T4, T5, T6)()`
+fail_compilation/diag8101.d(68):        ... (1 more, -v to show) ...
 ---
 */
 

--- a/compiler/test/fail_compilation/diag8101.d
+++ b/compiler/test/fail_compilation/diag8101.d
@@ -1,32 +1,33 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8101.d(61): Error: function `diag8101.f_0(int)` is not callable using argument types `()`
-fail_compilation/diag8101.d(61):        too few arguments, expected 1, got 0
-fail_compilation/diag8101.d(62): Error: none of the overloads of `f_1` are callable using argument types `()`
-fail_compilation/diag8101.d(35):        Candidates are: `diag8101.f_1(int)`
-fail_compilation/diag8101.d(36):                        `diag8101.f_1(int, int)`
-fail_compilation/diag8101.d(63): Error: none of the overloads of `f_2` are callable using argument types `()`
-fail_compilation/diag8101.d(38):        Candidates are: `diag8101.f_2(int)`
-fail_compilation/diag8101.d(39):                        `diag8101.f_2(int, int)`
-fail_compilation/diag8101.d(40):                        `diag8101.f_2(int, int, int)`
-fail_compilation/diag8101.d(41):                        `diag8101.f_2(int, int, int, int)`
-fail_compilation/diag8101.d(42):                        `diag8101.f_2(int, int, int, int, int)`
-fail_compilation/diag8101.d(43):                        `diag8101.f_2(int, int, int, int, int, int)`
-fail_compilation/diag8101.d(63):        ... (1 more, -v to show) ...
-fail_compilation/diag8101.d(65): Error: template `diag8101.t_0` is not callable using argument types `!()()`
-fail_compilation/diag8101.d(46):        Candidate is: `t_0(T1)()`
-fail_compilation/diag8101.d(66): Error: none of the overloads of template `diag8101.t_1` are callable using argument types `!()()`
-fail_compilation/diag8101.d(48):        Candidates are: `t_1(T1)()`
-fail_compilation/diag8101.d(49):                        `t_1(T1, T2)()`
-fail_compilation/diag8101.d(67): Error: none of the overloads of template `diag8101.t_2` are callable using argument types `!()()`
-fail_compilation/diag8101.d(51):        Candidates are: `t_2(T1)()`
-fail_compilation/diag8101.d(52):                        `t_2(T1, T2)()`
-fail_compilation/diag8101.d(53):                        `t_2(T1, T2, T3)()`
-fail_compilation/diag8101.d(54):                        `t_2(T1, T2, T3, T4)()`
-fail_compilation/diag8101.d(55):                        `t_2(T1, T2, T3, T4, T5)()`
-fail_compilation/diag8101.d(56):                        `t_2(T1, T2, T3, T4, T5, T6)()`
-fail_compilation/diag8101.d(67):        ... (1 more, -v to show) ...
+fail_compilation\diag8101.d(61): Error: function is not callable using argument types `()`
+fail_compilation\diag8101.d(61):            `diag8101.f_0(int)`
+fail_compilation\diag8101.d(61):        too few arguments, expected 1, got 0
+fail_compilation\diag8101.d(62): Error: none of the overloads of `f_1` are callable using argument types `()`
+fail_compilation\diag8101.d(35):        Candidates are: `diag8101.f_1(int)`
+fail_compilation\diag8101.d(36):                        `diag8101.f_1(int, int)`
+fail_compilation\diag8101.d(63): Error: none of the overloads of `f_2` are callable using argument types `()`
+fail_compilation\diag8101.d(38):        Candidates are: `diag8101.f_2(int)`
+fail_compilation\diag8101.d(39):                        `diag8101.f_2(int, int)`
+fail_compilation\diag8101.d(40):                        `diag8101.f_2(int, int, int)`
+fail_compilation\diag8101.d(41):                        `diag8101.f_2(int, int, int, int)`
+fail_compilation\diag8101.d(42):                        `diag8101.f_2(int, int, int, int, int)`
+fail_compilation\diag8101.d(43):                        `diag8101.f_2(int, int, int, int, int, int)`
+fail_compilation\diag8101.d(63):        ... (1 more, -v to show) ...
+fail_compilation\diag8101.d(65): Error: template `diag8101.t_0` is not callable using argument types `!()()`
+fail_compilation\diag8101.d(46):        Candidate is: `t_0(T1)()`
+fail_compilation\diag8101.d(66): Error: none of the overloads of template `diag8101.t_1` are callable using argument types `!()()`
+fail_compilation\diag8101.d(48):        Candidates are: `t_1(T1)()`
+fail_compilation\diag8101.d(49):                        `t_1(T1, T2)()`
+fail_compilation\diag8101.d(67): Error: none of the overloads of template `diag8101.t_2` are callable using argument types `!()()`
+fail_compilation\diag8101.d(51):        Candidates are: `t_2(T1)()`
+fail_compilation\diag8101.d(52):                        `t_2(T1, T2)()`
+fail_compilation\diag8101.d(53):                        `t_2(T1, T2, T3)()`
+fail_compilation\diag8101.d(54):                        `t_2(T1, T2, T3, T4)()`
+fail_compilation\diag8101.d(55):                        `t_2(T1, T2, T3, T4, T5)()`
+fail_compilation\diag8101.d(56):                        `t_2(T1, T2, T3, T4, T5, T6)()`
+fail_compilation\diag8101.d(67):        ... (1 more, -v to show) ...
 ---
 */
 

--- a/compiler/test/fail_compilation/diag8648.d
+++ b/compiler/test/fail_compilation/diag8648.d
@@ -2,13 +2,13 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag8648.d(18): Error: undefined identifier `X`
-fail_compilation/diag8648.d(29): Error: template `diag8648.foo` is not callable using argument types `!()(Foo!(int, 1))`
+fail_compilation/diag8648.d(29): Error: template `foo` is not callable using argument types `!()(Foo!(int, 1))`
 fail_compilation/diag8648.d(18):        Candidate is: `foo(T, n)(X!(T, n))`
 fail_compilation/diag8648.d(20): Error: undefined identifier `a`
-fail_compilation/diag8648.d(31): Error: template `diag8648.bar` is not callable using argument types `!()(Foo!(int, 1))`
+fail_compilation/diag8648.d(31): Error: template `bar` is not callable using argument types `!()(Foo!(int, 1))`
 fail_compilation/diag8648.d(20):        Candidate is: `bar(T)(Foo!(T, a))`
 fail_compilation/diag8648.d(20): Error: undefined identifier `a`
-fail_compilation/diag8648.d(32): Error: template `diag8648.bar` is not callable using argument types `!()(Foo!(int, f))`
+fail_compilation/diag8648.d(32): Error: template `bar` is not callable using argument types `!()(Foo!(int, f))`
 fail_compilation/diag8648.d(20):        Candidate is: `bar(T)(Foo!(T, a))`
 ---
 */

--- a/compiler/test/fail_compilation/diag9004.d
+++ b/compiler/test/fail_compilation/diag9004.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9004.d(21): Error: template `diag9004.bar` is not callable using argument types `!()(Foo!int, int)`
+fail_compilation/diag9004.d(21): Error: template `bar` is not callable using argument types `!()(Foo!int, int)`
 fail_compilation/diag9004.d(14):        Candidate is: `bar(FooT)(FooT foo, FooT.T x)`
 ---
 */

--- a/compiler/test/fail_compilation/diagin.d
+++ b/compiler/test/fail_compilation/diagin.d
@@ -2,11 +2,11 @@
 REQUIRED_ARGS: -preview=in
 TEST_OUTPUT:
 ---
-fail_compilation\diagin.d(15): Error: function is not callable using argument types `()`
-fail_compilation\diagin.d(15):          `diagin.foo(in int)`
-fail_compilation\diagin.d(15):        too few arguments, expected 1, got 0
-fail_compilation\diagin.d(17): Error: template `diagin.foo1` is not callable using argument types `!()(bool[])`
-fail_compilation\diagin.d(21):        Candidate is: `foo1(T)(in T v, string)`
+fail_compilation/diagin.d(22): Error: function `foo` is not callable using argument types `()`
+fail_compilation/diagin.d(22):        too few arguments, expected 1, got 0
+fail_compilation/diagin.d(27):        `diagin.foo(in int)` declared here
+fail_compilation/diagin.d(24): Error: template `foo1` is not callable using argument types `!()(bool[])`
+fail_compilation/diagin.d(28):        Candidate is: `foo1(T)(in T v, string)`
 ---
  */
 

--- a/compiler/test/fail_compilation/diagin.d
+++ b/compiler/test/fail_compilation/diagin.d
@@ -2,11 +2,11 @@
 REQUIRED_ARGS: -preview=in
 TEST_OUTPUT:
 ---
-fail_compilation/diagin.d(14): Error: function is not callable using argument types `()`
-fail_compilation/diagin.d(14):          `diagin.foo(in int)`
-fail_compilation/diagin.d(14):        too few arguments, expected 1, got 0
-fail_compilation/diagin.d(16): Error: template `diagin.foo1` is not callable using argument types `!()(bool[])`
-fail_compilation/diagin.d(20):        Candidate is: `foo1(T)(in T v, string)`
+fail_compilation\diagin.d(15): Error: function is not callable using argument types `()`
+fail_compilation\diagin.d(15):          `diagin.foo(in int)`
+fail_compilation\diagin.d(15):        too few arguments, expected 1, got 0
+fail_compilation\diagin.d(17): Error: template `diagin.foo1` is not callable using argument types `!()(bool[])`
+fail_compilation\diagin.d(21):        Candidate is: `foo1(T)(in T v, string)`
 ---
  */
 

--- a/compiler/test/fail_compilation/diagin.d
+++ b/compiler/test/fail_compilation/diagin.d
@@ -2,7 +2,8 @@
 REQUIRED_ARGS: -preview=in
 TEST_OUTPUT:
 ---
-fail_compilation/diagin.d(14): Error: function `diagin.foo(in int)` is not callable using argument types `()`
+fail_compilation/diagin.d(14): Error: function is not callable using argument types `()`
+fail_compilation/diagin.d(14):          `diagin.foo(in int)`
 fail_compilation/diagin.d(14):        too few arguments, expected 1, got 0
 fail_compilation/diagin.d(16): Error: template `diagin.foo1` is not callable using argument types `!()(bool[])`
 fail_compilation/diagin.d(20):        Candidate is: `foo1(T)(in T v, string)`

--- a/compiler/test/fail_compilation/diagin.d
+++ b/compiler/test/fail_compilation/diagin.d
@@ -2,11 +2,11 @@
 REQUIRED_ARGS: -preview=in
 TEST_OUTPUT:
 ---
-fail_compilation/diagin.d(22): Error: function `foo` is not callable using argument types `()`
-fail_compilation/diagin.d(22):        too few arguments, expected 1, got 0
-fail_compilation/diagin.d(27):        `diagin.foo(in int)` declared here
-fail_compilation/diagin.d(24): Error: template `foo1` is not callable using argument types `!()(bool[])`
-fail_compilation/diagin.d(28):        Candidate is: `foo1(T)(in T v, string)`
+fail_compilation/diagin.d(15): Error: function `foo` is not callable using argument types `()`
+fail_compilation/diagin.d(15):        too few arguments, expected 1, got 0
+fail_compilation/diagin.d(20):        `diagin.foo(in int)` declared here
+fail_compilation/diagin.d(17): Error: template `foo1` is not callable using argument types `!()(bool[])`
+fail_compilation/diagin.d(21):        Candidate is: `foo1(T)(in T v, string)`
 ---
  */
 

--- a/compiler/test/fail_compilation/fail12744.d
+++ b/compiler/test/fail_compilation/fail12744.d
@@ -14,10 +14,10 @@ fail_compilation/fail12744.d(61): Error: template instance `fail12744.bar12744L!
 fail_compilation/fail12744.d(40): Error: incompatible parameter storage classes `lazy` and `out`
 fail_compilation/fail12744.d(62): Error: template instance `fail12744.bar12744L!(foo12744O)` error instantiating
 fail_compilation/fail12744.d(41): Error: incompatible parameter storage classes `auto ref` and `out`
-fail_compilation/fail12744.d(67): Error: template `fail12744.bar12744A` is not callable using argument types `!(foo12744O)(int)`
+fail_compilation/fail12744.d(67): Error: template `bar12744A` is not callable using argument types `!(foo12744O)(int)`
 fail_compilation/fail12744.d(41):        Candidate is: `bar12744A(alias f)(auto ref PTT12744!f args)`
 fail_compilation/fail12744.d(41): Error: incompatible parameter storage classes `auto ref` and `lazy`
-fail_compilation/fail12744.d(68): Error: template `fail12744.bar12744A` is not callable using argument types `!(foo12744L)(int)`
+fail_compilation/fail12744.d(68): Error: template `bar12744A` is not callable using argument types `!(foo12744L)(int)`
 fail_compilation/fail12744.d(41):        Candidate is: `bar12744A(alias f)(auto ref PTT12744!f args)`
 ---
 */

--- a/compiler/test/fail_compilation/fail14669.d
+++ b/compiler/test/fail_compilation/fail14669.d
@@ -18,7 +18,7 @@ void test1()
 }
 
 /*
-TEST_OUTPUT:*
+TEST_OUTPUT:
 ---
 fail_compilation/fail14669.d(29): Error: cannot explicitly instantiate template function with `auto ref` parameter
 fail_compilation/fail14669.d(38): Error: template instance `fail14669.bar1!int` error instantiating

--- a/compiler/test/fail_compilation/fail14669.d
+++ b/compiler/test/fail_compilation/fail14669.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/fail14669.d(11): Error: `auto` can only be used as part of `auto ref` for template function parameters
 fail_compilation/fail14669.d(16): Error: template instance `fail14669.foo1!()` error instantiating
 fail_compilation/fail14669.d(12): Error: `auto` can only be used as part of `auto ref` for template function parameters
-fail_compilation/fail14669.d(17): Error: template `fail14669.foo2` is not callable using argument types `!()(int)`
+fail_compilation/fail14669.d(17): Error: template `foo2` is not callable using argument types `!()(int)`
 fail_compilation/fail14669.d(12):        Candidate is: `foo2()(auto int a)`
 ---
 */
@@ -18,7 +18,7 @@ void test1()
 }
 
 /*
-TEST_OUTPUT:
+TEST_OUTPUT:*
 ---
 fail_compilation/fail14669.d(29): Error: cannot explicitly instantiate template function with `auto ref` parameter
 fail_compilation/fail14669.d(38): Error: template instance `fail14669.bar1!int` error instantiating

--- a/compiler/test/fail_compilation/fail162.d
+++ b/compiler/test/fail_compilation/fail162.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
----
-fail_compilation/fail162.d(25): Error: template `fail162.testHelper` is not callable using argument types `!()(string, string)`
+----
+fail_compilation/fail162.d(25): Error: template `testHelper` is not callable using argument types `!()(string, string)`
 fail_compilation/fail162.d(10):        Candidate is: `testHelper(A...)()`
 fail_compilation/fail162.d(30): Error: template instance `fail162.test!("hello", "world")` error instantiating
----
+----
 */
 
 template testHelper(A ...)

--- a/compiler/test/fail_compilation/fail162.d
+++ b/compiler/test/fail_compilation/fail162.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
-----
+---
 fail_compilation/fail162.d(25): Error: template `testHelper` is not callable using argument types `!()(string, string)`
 fail_compilation/fail162.d(10):        Candidate is: `testHelper(A...)()`
 fail_compilation/fail162.d(30): Error: template instance `fail162.test!("hello", "world")` error instantiating
-----
+---
 */
 
 template testHelper(A ...)

--- a/compiler/test/fail_compilation/fail19948.d
+++ b/compiler/test/fail_compilation/fail19948.d
@@ -3,9 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail19948.d(15): Error: function `func` is not callable using argument types `(X)`
-fail_compilation/fail19948.d(15):        cannot pass argument `X()` of type `fail19948.main.X` to parameter `const(fail19948.X)`
-fail_compilation/fail19948.d(18):        `fail19948.func(const(X))` declared here
+fail_compilation/fail19948.d(16): Error: function `func` is not callable using argument types `(X)`
+fail_compilation/fail19948.d(16):        cannot pass argument `X()` of type `fail19948.main.X` to parameter `const(fail19948.X)`
+fail_compilation/fail19948.d(19):        `fail19948.func(const(X))` declared here
 ---
 */
 // DISABLED: win32

--- a/compiler/test/fail_compilation/fail19948.d
+++ b/compiler/test/fail_compilation/fail19948.d
@@ -3,8 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail19948.d(15): Error: function `fail19948.func(const(X))` is not callable using argument types `(X)`
+fail_compilation/fail19948.d(15): Error: function `func` is not callable using argument types `(X)`
 fail_compilation/fail19948.d(15):        cannot pass argument `X()` of type `fail19948.main.X` to parameter `const(fail19948.X)`
+fail_compilation/fail19948.d(18):        `fail19948.func(const(X))` declared here
 ---
 */
 // DISABLED: win32

--- a/compiler/test/fail_compilation/fail20183.d
+++ b/compiler/test/fail_compilation/fail20183.d
@@ -1,8 +1,9 @@
 /* REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/fail20183.d(1016): Error: function `fail20183.addr(return ref int b)` is not callable using argument types `(int)`
+fail_compilation/fail20183.d(1016): Error: function `addr` is not callable using argument types `(int)`
 fail_compilation/fail20183.d(1016):        cannot pass rvalue argument `S(0).i` of type `int` to parameter `return ref int b`
+fail_compilation/fail20183.d(1005):        `fail20183.addr(return ref int b)` declared here
 fail_compilation/fail20183.d(1017): Error: address of struct temporary returned by `s()` assigned to longer lived variable `q`
 ---
  */

--- a/compiler/test/fail_compilation/fail20730b.d
+++ b/compiler/test/fail_compilation/fail20730b.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -verrors=spec -o-
 TEST_OUTPUT:
 ---
 (spec:1) fail_compilation/fail20730b.d-mixin-43(43): Error: C style cast illegal, use `cast(int)mod`
-fail_compilation/fail20730b.d(26): Error: template `fail20730b.atomicOp` is not callable using argument types `!("+=")(shared(uint), int)`
+fail_compilation/fail20730b.d(26): Error: template `atomicOp` is not callable using argument types `!("+=")(shared(uint), int)`
 fail_compilation/fail20730b.d(41):        Candidate is: `atomicOp(string op, T, V1)(shared ref T val, V1 mod)`
   with `op = "+=",
        T = uint,

--- a/compiler/test/fail_compilation/fail20800.d
+++ b/compiler/test/fail_compilation/fail20800.d
@@ -2,10 +2,11 @@
 
 /*
 TEST_OUTPUT:
----
-fail_compilation/fail20800.d(22): Error: function `fail20800.fun(int a)` is not callable using argument types `(string)`
-fail_compilation/fail20800.d(22):        cannot pass argument `(m()).index()` of type `string` to parameter `int a`
----
+----
+fail_compilation/fail20800.d(23): Error: function `fun` is not callable using argument types `(string)`
+fail_compilation/fail20800.d(23):        cannot pass argument `(m()).index()` of type `string` to parameter `int a`
+fail_compilation/fail20800.d(19):        `fail20800.fun(int a)` declared here
+----
 */
 
 struct RegexMatch

--- a/compiler/test/fail_compilation/fail22202.d
+++ b/compiler/test/fail_compilation/fail22202.d
@@ -3,9 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22202.d(21): Error: function `fun` is not callable using argument types `(SystemCopy)`
-fail_compilation/fail22202.d(21):        `inout ref inout(SystemCopy)(ref inout(SystemCopy) other)` copy constructor cannot be called from a `pure @safe nogc` context
-fail_compilation/fail22202.d(16):        `fail22202.fun(SystemCopy __param_0)` declared here
+fail_compilation/fail22202.d(22): Error: function `fun` is not callable using argument types `(SystemCopy)`
+fail_compilation/fail22202.d(22):        `inout ref inout(SystemCopy)(ref inout(SystemCopy) other)` copy constructor cannot be called from a `pure @safe nogc` context
+fail_compilation/fail22202.d(17):        `fail22202.fun(SystemCopy __param_0)` declared here
 ---
 */
 

--- a/compiler/test/fail_compilation/fail22202.d
+++ b/compiler/test/fail_compilation/fail22202.d
@@ -3,9 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22202.d(21): Error: function is not callable using argument types `(SystemCopy)`
-fail_compilation/fail22202.d(21):               `fail22202.fun(SystemCopy __param_0)`
+fail_compilation/fail22202.d(21): Error: function `fun` is not callable using argument types `(SystemCopy)`
 fail_compilation/fail22202.d(21):        `inout ref inout(SystemCopy)(ref inout(SystemCopy) other)` copy constructor cannot be called from a `pure @safe nogc` context
+fail_compilation/fail22202.d(16):        `fail22202.fun(SystemCopy __param_0)` declared here
 ---
 */
 

--- a/compiler/test/fail_compilation/fail22202.d
+++ b/compiler/test/fail_compilation/fail22202.d
@@ -3,7 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22202.d(21): Error: function `fail22202.fun(SystemCopy __param_0)` is not callable using argument types `(SystemCopy)`
+fail_compilation/fail22202.d(21): Error: function is not callable using argument types `(SystemCopy)`
+fail_compilation/fail22202.d(21):               `fail22202.fun(SystemCopy __param_0)`
 fail_compilation/fail22202.d(21):        `inout ref inout(SystemCopy)(ref inout(SystemCopy) other)` copy constructor cannot be called from a `pure @safe nogc` context
 ---
 */

--- a/compiler/test/fail_compilation/fail236.d
+++ b/compiler/test/fail_compilation/fail236.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail236.d(14): Error: undefined identifier `x`
-fail_compilation/fail236.d(22): Error: template `fail236.Templ2` is not callable using argument types `!()(int)`
+fail_compilation/fail236.d(22): Error: template `Templ2` is not callable using argument types `!()(int)`
 fail_compilation/fail236.d(12):        Candidate is: `Templ2(alias a)(x)`
 ---
 */

--- a/compiler/test/fail_compilation/fail24301.d
+++ b/compiler/test/fail_compilation/fail24301.d
@@ -1,8 +1,9 @@
 /+
 TEST_OUTPUT:
 ---
-fail_compilation/fail24301.d(18): Error: function `fail24301.fun(S __param_0)` is not callable using argument types `(S)`
-fail_compilation/fail24301.d(18):        `ref S(ref S)` copy constructor cannot be used because it is annotated with `@disable`
+fail_compilation/fail24301.d(19): Error: function `fun` is not callable using argument types `(S)`
+fail_compilation/fail24301.d(19):        `ref S(ref S)` copy constructor cannot be used because it is annotated with `@disable`
+fail_compilation/fail24301.d(14):        `fail24301.fun(S __param_0)` declared here
 ---
 +/
 struct S

--- a/compiler/test/fail_compilation/fail263.d
+++ b/compiler/test/fail_compilation/fail263.d
@@ -1,9 +1,10 @@
 /*
 TEST_OUTPUT:
----
-fail_compilation/fail263.d(19): Error: function `fail263.f(byte* p)` is not callable using argument types `(const(byte)*)`
-fail_compilation/fail263.d(19):        cannot pass argument `cast(const(byte)*)A` of type `const(byte)*` to parameter `byte* p`
----
+----
+fail_compilation/fail263.d(20): Error: function `f` is not callable using argument types `(const(byte)*)`
+fail_compilation/fail263.d(20):        cannot pass argument `cast(const(byte)*)A` of type `const(byte)*` to parameter `byte* p`
+fail_compilation/fail263.d(14):        `fail263.f(byte* p)` declared here
+----
 */
 
 // https://issues.dlang.org/show_bug.cgi?id=2766

--- a/compiler/test/fail_compilation/fail322.d
+++ b/compiler/test/fail_compilation/fail322.d
@@ -1,11 +1,13 @@
 /*
 TEST_OUTPUT:
----
-fail_compilation/fail322.d(13): Error: function `fail322.digestToString2(ref char[16] digest)` is not callable using argument types `(string)`
-fail_compilation/fail322.d(13):        cannot pass rvalue argument `"1234567890123456"` of type `string` to parameter `ref char[16] digest`
-fail_compilation/fail322.d(15): Error: function `fail322.digestToString2(ref char[16] digest)` is not callable using argument types `(const(char[16]))`
-fail_compilation/fail322.d(15):        cannot pass argument `s` of type `const(char[16])` to parameter `ref char[16] digest`
----
+----
+fail_compilation/fail322.d(15): Error: function `digestToString2` is not callable using argument types `(string)`
+fail_compilation/fail322.d(15):        cannot pass rvalue argument `"1234567890123456"` of type `string` to parameter `ref char[16] digest`
+fail_compilation/fail322.d(20):        `fail322.digestToString2(ref char[16] digest)` declared here
+fail_compilation/fail322.d(17): Error: function `digestToString2` is not callable using argument types `(const(char[16]))`
+fail_compilation/fail322.d(17):        cannot pass argument `s` of type `const(char[16])` to parameter `ref char[16] digest`
+fail_compilation/fail322.d(20):        `fail322.digestToString2(ref char[16] digest)` declared here
+----
 */
 
 void main()

--- a/compiler/test/fail_compilation/fail332.d
+++ b/compiler/test/fail_compilation/fail332.d
@@ -1,18 +1,18 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail332.d(22): Error: function `foo` is not callable using argument types `()`
-fail_compilation/fail332.d(22):        missing argument for parameter #1: `int __param_0`
-fail_compilation/fail332.d(17):        `fail332.foo(int __param_0, ...)` declared here
-fail_compilation/fail332.d(23): Error: function `foo` is not callable using argument types `(typeof(null))`
-fail_compilation/fail332.d(23):        cannot pass argument `null` of type `typeof(null)` to parameter `int __param_0`
-fail_compilation/fail332.d(17):        `fail332.foo(int __param_0, ...)` declared here
-fail_compilation/fail332.d(25): Error: function `baz` is not callable using argument types `(string)`
-fail_compilation/fail332.d(25):        cannot pass argument `""` of type `string` to parameter `int[] __param_0...`
-fail_compilation/fail332.d(18):        `fail332.baz(int[] __param_0...)` declared here
-fail_compilation/fail332.d(26): Error: function `baz` is not callable using argument types `(int, typeof(null))`
-fail_compilation/fail332.d(26):        cannot pass argument `null` of type `typeof(null)` to parameter `int[] __param_0...`
-fail_compilation/fail332.d(18):        `fail332.baz(int[] __param_0...)` declared here
+fail_compilation/fail332.d(26): Error: function `foo` is not callable using argument types `()`
+fail_compilation/fail332.d(26):        missing argument for parameter #1: `int __param_0`
+fail_compilation/fail332.d(21):        `fail332.foo(int __param_0, ...)` declared here
+fail_compilation/fail332.d(27): Error: function `foo` is not callable using argument types `(typeof(null))`
+fail_compilation/fail332.d(27):        cannot pass argument `null` of type `typeof(null)` to parameter `int __param_0`
+fail_compilation/fail332.d(21):        `fail332.foo(int __param_0, ...)` declared here
+fail_compilation/fail332.d(29): Error: function `baz` is not callable using argument types `(string)`
+fail_compilation/fail332.d(29):        cannot pass argument `""` of type `string` to parameter `int[] __param_0...`
+fail_compilation/fail332.d(22):        `fail332.baz(int[] __param_0...)` declared here
+fail_compilation/fail332.d(30): Error: function `baz` is not callable using argument types `(int, typeof(null))`
+fail_compilation/fail332.d(30):        cannot pass argument `null` of type `typeof(null)` to parameter `int[] __param_0...`
+fail_compilation/fail332.d(22):        `fail332.baz(int[] __param_0...)` declared here
 ---
 */
 
@@ -33,24 +33,24 @@ void test()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail332.d(50): Error: function `bar` is not callable using argument types `()`
-fail_compilation/fail332.d(50):        missing argument for parameter #1: `Object`
-fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
-fail_compilation/fail332.d(51): Error: function `bar` is not callable using argument types `(int)`
-fail_compilation/fail332.d(51):        cannot pass argument `4` of type `int` to parameter `Object`
-fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
-fail_compilation/fail332.d(52): Error: function `bar` is not callable using argument types `(typeof(null))`
-fail_compilation/fail332.d(52):        expected 2 variadic argument(s), not 0
-fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
-fail_compilation/fail332.d(53): Error: function `bar` is not callable using argument types `(typeof(null), int)`
-fail_compilation/fail332.d(53):        expected 2 variadic argument(s), not 1
-fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
-fail_compilation/fail332.d(54): Error: function `bar` is not callable using argument types `(typeof(null), int, string)`
-fail_compilation/fail332.d(54):        cannot pass argument `""` of type `string` to parameter `int[2]...`
-fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
-fail_compilation/fail332.d(55): Error: function `bar` is not callable using argument types `(typeof(null), int, int, int)`
-fail_compilation/fail332.d(55):        expected 2 variadic argument(s), not 3
-fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
+fail_compilation/fail332.d(60): Error: function `bar` is not callable using argument types `()`
+fail_compilation/fail332.d(60):        missing argument for parameter #1: `Object`
+fail_compilation/fail332.d(56):        `fail332.bar(Object, int[2]...)` declared here
+fail_compilation/fail332.d(61): Error: function `bar` is not callable using argument types `(int)`
+fail_compilation/fail332.d(61):        cannot pass argument `4` of type `int` to parameter `Object`
+fail_compilation/fail332.d(56):        `fail332.bar(Object, int[2]...)` declared here
+fail_compilation/fail332.d(62): Error: function `bar` is not callable using argument types `(typeof(null))`
+fail_compilation/fail332.d(62):        expected 2 variadic argument(s), not 0
+fail_compilation/fail332.d(56):        `fail332.bar(Object, int[2]...)` declared here
+fail_compilation/fail332.d(63): Error: function `bar` is not callable using argument types `(typeof(null), int)`
+fail_compilation/fail332.d(63):        expected 2 variadic argument(s), not 1
+fail_compilation/fail332.d(56):        `fail332.bar(Object, int[2]...)` declared here
+fail_compilation/fail332.d(64): Error: function `bar` is not callable using argument types `(typeof(null), int, string)`
+fail_compilation/fail332.d(64):        cannot pass argument `""` of type `string` to parameter `int[2]...`
+fail_compilation/fail332.d(56):        `fail332.bar(Object, int[2]...)` declared here
+fail_compilation/fail332.d(65): Error: function `bar` is not callable using argument types `(typeof(null), int, int, int)`
+fail_compilation/fail332.d(65):        expected 2 variadic argument(s), not 3
+fail_compilation/fail332.d(56):        `fail332.bar(Object, int[2]...)` declared here
 ---
 */
 void bar(Object, int[2]...);

--- a/compiler/test/fail_compilation/fail332.d
+++ b/compiler/test/fail_compilation/fail332.d
@@ -1,14 +1,18 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail332.d(22): Error: function `fail332.foo(int __param_0, ...)` is not callable using argument types `()`
+fail_compilation/fail332.d(22): Error: function `foo` is not callable using argument types `()`
 fail_compilation/fail332.d(22):        missing argument for parameter #1: `int __param_0`
-fail_compilation/fail332.d(23): Error: function `fail332.foo(int __param_0, ...)` is not callable using argument types `(typeof(null))`
+fail_compilation/fail332.d(17):        `fail332.foo(int __param_0, ...)` declared here
+fail_compilation/fail332.d(23): Error: function `foo` is not callable using argument types `(typeof(null))`
 fail_compilation/fail332.d(23):        cannot pass argument `null` of type `typeof(null)` to parameter `int __param_0`
-fail_compilation/fail332.d(25): Error: function `fail332.baz(int[] __param_0...)` is not callable using argument types `(string)`
+fail_compilation/fail332.d(17):        `fail332.foo(int __param_0, ...)` declared here
+fail_compilation/fail332.d(25): Error: function `baz` is not callable using argument types `(string)`
 fail_compilation/fail332.d(25):        cannot pass argument `""` of type `string` to parameter `int[] __param_0...`
-fail_compilation/fail332.d(26): Error: function `fail332.baz(int[] __param_0...)` is not callable using argument types `(int, typeof(null))`
+fail_compilation/fail332.d(18):        `fail332.baz(int[] __param_0...)` declared here
+fail_compilation/fail332.d(26): Error: function `baz` is not callable using argument types `(int, typeof(null))`
 fail_compilation/fail332.d(26):        cannot pass argument `null` of type `typeof(null)` to parameter `int[] __param_0...`
+fail_compilation/fail332.d(18):        `fail332.baz(int[] __param_0...)` declared here
 ---
 */
 
@@ -29,18 +33,24 @@ void test()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail332.d(50): Error: function `fail332.bar(Object, int[2]...)` is not callable using argument types `()`
+fail_compilation/fail332.d(50): Error: function `bar` is not callable using argument types `()`
 fail_compilation/fail332.d(50):        missing argument for parameter #1: `Object`
-fail_compilation/fail332.d(51): Error: function `fail332.bar(Object, int[2]...)` is not callable using argument types `(int)`
+fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
+fail_compilation/fail332.d(51): Error: function `bar` is not callable using argument types `(int)`
 fail_compilation/fail332.d(51):        cannot pass argument `4` of type `int` to parameter `Object`
-fail_compilation/fail332.d(52): Error: function `fail332.bar(Object, int[2]...)` is not callable using argument types `(typeof(null))`
+fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
+fail_compilation/fail332.d(52): Error: function `bar` is not callable using argument types `(typeof(null))`
 fail_compilation/fail332.d(52):        expected 2 variadic argument(s), not 0
-fail_compilation/fail332.d(53): Error: function `fail332.bar(Object, int[2]...)` is not callable using argument types `(typeof(null), int)`
+fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
+fail_compilation/fail332.d(53): Error: function `bar` is not callable using argument types `(typeof(null), int)`
 fail_compilation/fail332.d(53):        expected 2 variadic argument(s), not 1
-fail_compilation/fail332.d(54): Error: function `fail332.bar(Object, int[2]...)` is not callable using argument types `(typeof(null), int, string)`
+fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
+fail_compilation/fail332.d(54): Error: function `bar` is not callable using argument types `(typeof(null), int, string)`
 fail_compilation/fail332.d(54):        cannot pass argument `""` of type `string` to parameter `int[2]...`
-fail_compilation/fail332.d(55): Error: function `fail332.bar(Object, int[2]...)` is not callable using argument types `(typeof(null), int, int, int)`
+fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
+fail_compilation/fail332.d(55): Error: function `bar` is not callable using argument types `(typeof(null), int, int, int)`
 fail_compilation/fail332.d(55):        expected 2 variadic argument(s), not 3
+fail_compilation/fail332.d(46):        `fail332.bar(Object, int[2]...)` declared here
 ---
 */
 void bar(Object, int[2]...);

--- a/compiler/test/fail_compilation/fail58.d
+++ b/compiler/test/fail_compilation/fail58.d
@@ -1,11 +1,13 @@
 /*
 TEST_OUTPUT:
----
-fail_compilation/fail58.d(26): Error: function `fail58.SomeFunc(dchar[] pText, out int pStopPosn)` is not callable using argument types `(string, int)`
-fail_compilation/fail58.d(26):        cannot pass argument `"123"` of type `string` to parameter `dchar[] pText`
-fail_compilation/fail58.d(30): Error: function `fail58.SomeFunc(dchar[] pText, out int pStopPosn)` is not callable using argument types `(string, int)`
-fail_compilation/fail58.d(30):        cannot pass argument `""` of type `string` to parameter `dchar[] pText`
----
+----
+fail_compilation/fail58.d(28): Error: function `SomeFunc` is not callable using argument types `(string, int)`
+fail_compilation/fail58.d(28):        cannot pass argument `"123"` of type `string` to parameter `dchar[] pText`
+fail_compilation/fail58.d(14):        `fail58.SomeFunc(dchar[] pText, out int pStopPosn)` declared here
+fail_compilation/fail58.d(32): Error: function `SomeFunc` is not callable using argument types `(string, int)`
+fail_compilation/fail58.d(32):        cannot pass argument `""` of type `string` to parameter `dchar[] pText`
+fail_compilation/fail58.d(14):        `fail58.SomeFunc(dchar[] pText, out int pStopPosn)` declared here
+----
 */
 debug import std.stdio;
 const int anything = -1000; // Line #2

--- a/compiler/test/fail_compilation/fail8009.d
+++ b/compiler/test/fail_compilation/fail8009.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail8009.d(9): Error: template `fail8009.filter` is not callable using argument types `!()(void)`
+fail_compilation/fail8009.d(9): Error: template `filter` is not callable using argument types `!()(void)`
 fail_compilation/fail8009.d(8):        Candidate is: `filter(R)(scope bool delegate(ref BAD!R) func)`
 ---
 */

--- a/compiler/test/fail_compilation/fail95.d
+++ b/compiler/test/fail_compilation/fail95.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail95.d(19): Error: template `fail95.A` is not callable using argument types `!()(int)`
+fail_compilation/fail95.d(19): Error: template `A` is not callable using argument types `!()(int)`
 fail_compilation/fail95.d(11):        Candidate is: `A(alias T)(T)`
 ---
 */

--- a/compiler/test/fail_compilation/ice10922.d
+++ b/compiler/test/fail_compilation/ice10922.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10922.d(10): Error: function `ice10922.__lambda4(in uint n)` is not callable using argument types `()`
-fail_compilation/ice10922.d(10):        too few arguments, expected 1, got 0
+fail_compilation/ice10922.d(11): Error: function `__lambda4` is not callable using argument types `()`
+fail_compilation/ice10922.d(11):        too few arguments, expected 1, got 0
+fail_compilation/ice10922.d(10):        `ice10922.__lambda4(in uint n)` declared here
 ---
 */
 

--- a/compiler/test/fail_compilation/ice11856_1.d
+++ b/compiler/test/fail_compilation/ice11856_1.d
@@ -1,14 +1,14 @@
 /*
 TEST_OUTPUT:
----
+----
 fail_compilation/ice11856_1.d(18): Error: no property `g` for `A()` of type `A`
 fail_compilation/ice11856_1.d(18):        the following error occured while looking for a UFCS match
-fail_compilation/ice11856_1.d(18): Error: template `ice11856_1.g` is not callable using argument types `!()(A)`
+fail_compilation/ice11856_1.d(18): Error: template `g` is not callable using argument types `!()(A)`
 fail_compilation/ice11856_1.d(16):        Candidate is: `g(T)(T x)`
   with `T = A`
   must satisfy the following constraint:
 `       is(typeof(x.f()))`
----
+----
 */
 struct A {}
 

--- a/compiler/test/fail_compilation/ice12501.d
+++ b/compiler/test/fail_compilation/ice12501.d
@@ -1,12 +1,14 @@
 /*
 TEST_OUTPUT:
----
-fail_compilation/ice12501.d(31): Error: function `ice12501.foo(int value)` is not callable using argument types `(int, int)`
-fail_compilation/ice12501.d(31):        expected 1 argument(s), not 2
-fail_compilation/ice12501.d(31): Error: function `ice12501.foo(int value)` is not callable using argument types `(int, int)`
-fail_compilation/ice12501.d(31):        expected 1 argument(s), not 2
-fail_compilation/ice12501.d(45): Error: template instance `ice12501.reduce!(foo, foo).reduce!(Tuple!(int, int), int[])` error instantiating
----
+----
+fail_compilation/ice12501.d(33): Error: function `foo` is not callable using argument types `(int, int)`
+fail_compilation/ice12501.d(33):        expected 1 argument(s), not 2
+fail_compilation/ice12501.d(40):        `ice12501.foo(int value)` declared here
+fail_compilation/ice12501.d(33): Error: function `foo` is not callable using argument types `(int, int)`
+fail_compilation/ice12501.d(33):        expected 1 argument(s), not 2
+fail_compilation/ice12501.d(40):        `ice12501.foo(int value)` declared here
+fail_compilation/ice12501.d(47): Error: template instance `ice12501.reduce!(foo, foo).reduce!(Tuple!(int, int), int[])` error instantiating
+----
 */
 
 struct Tuple(T...)

--- a/compiler/test/fail_compilation/ice14130.d
+++ b/compiler/test/fail_compilation/ice14130.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice14130.d(10): Error: undefined identifier `Undef`
-fail_compilation/ice14130.d(14): Error: template `ice14130.foo` is not callable using argument types `!()(int)`
+fail_compilation/ice14130.d(14): Error: template `foo` is not callable using argument types `!()(int)`
 fail_compilation/ice14130.d(10):        Candidate is: `foo(R, F = Undef)(R r, F s = 0)`
 ---
 */

--- a/compiler/test/fail_compilation/ice14907.d
+++ b/compiler/test/fail_compilation/ice14907.d
@@ -1,14 +1,14 @@
 /*
 TEST_OUTPUT:
----
+----
 fail_compilation/ice14907.d(14): Error: struct `ice14907.S(int v = S)` recursive template expansion
 fail_compilation/ice14907.d(19):        while looking for match for `S!()`
 fail_compilation/ice14907.d(15): Error: template `ice14907.f(int v = f)()` recursive template expansion
 fail_compilation/ice14907.d(20):        while looking for match for `f!()`
 fail_compilation/ice14907.d(15): Error: template `ice14907.f(int v = f)()` recursive template expansion
-fail_compilation/ice14907.d(21): Error: template `ice14907.f` is not callable using argument types `!()()`
+fail_compilation/ice14907.d(21): Error: template `f` is not callable using argument types `!()()`
 fail_compilation/ice14907.d(15):        Candidate is: `f(int v = f)()`
----
+----
 */
 
 struct S(int v = S) {}

--- a/compiler/test/fail_compilation/ice14923.d
+++ b/compiler/test/fail_compilation/ice14923.d
@@ -1,10 +1,11 @@
 /*
 TEST_OUTPUT:
----
-fail_compilation/ice14923.d(22): Error: function `ice14923.parse(C a)` is not callable using argument types `(A)`
-fail_compilation/ice14923.d(22):        cannot pass argument `b` of type `ice14923.A` to parameter `C a`
-fail_compilation/ice14923.d(22):        instantiated from here: `bar!((b) => parse(b))`
----
+----
+fail_compilation/ice14923.d(23): Error: function `parse` is not callable using argument types `(A)`
+fail_compilation/ice14923.d(23):        cannot pass argument `b` of type `ice14923.A` to parameter `C a`
+fail_compilation/ice14923.d(21):        `ice14923.parse(C a)` declared here
+fail_compilation/ice14923.d(23):        instantiated from here: `bar!((b) => parse(b))`
+----
 */
 
 auto bar(alias fun)()

--- a/compiler/test/fail_compilation/ice23097.d
+++ b/compiler/test/fail_compilation/ice23097.d
@@ -3,8 +3,9 @@ TEST_OUTPUT:
 ---
 fail_compilation/ice23097.d(12): Error: undefined identifier `ICE`
 fail_compilation/ice23097.d(27): Error: template instance `ice23097.ice23097!(S23097)` error instantiating
-fail_compilation/ice23097.d(27): Error: function `ice23097.ice23097!(S23097).ice23097(S23097 __param_0)` is not callable using argument types `(S23097)`
+fail_compilation/ice23097.d(27): Error: function `ice23097` is not callable using argument types `(S23097)`
 fail_compilation/ice23097.d(27):        generating a copy constructor for `struct S23097` failed, therefore instances of it are uncopyable
+fail_compilation/ice23097.d(10):        `ice23097.ice23097!(S23097).ice23097(S23097 __param_0)` declared here
 ---
 */
 auto ice23097(I)(I)

--- a/compiler/test/fail_compilation/ice23097.d
+++ b/compiler/test/fail_compilation/ice23097.d
@@ -1,11 +1,11 @@
 /* https://issues.dlang.org/show_bug.cgi?id=23097
 TEST_OUTPUT:
 ---
-fail_compilation/ice23097.d(12): Error: undefined identifier `ICE`
-fail_compilation/ice23097.d(27): Error: template instance `ice23097.ice23097!(S23097)` error instantiating
-fail_compilation/ice23097.d(27): Error: function `ice23097` is not callable using argument types `(S23097)`
-fail_compilation/ice23097.d(27):        generating a copy constructor for `struct S23097` failed, therefore instances of it are uncopyable
-fail_compilation/ice23097.d(10):        `ice23097.ice23097!(S23097).ice23097(S23097 __param_0)` declared here
+fail_compilation/ice23097.d(13): Error: undefined identifier `ICE`
+fail_compilation/ice23097.d(28): Error: template instance `ice23097.ice23097!(S23097)` error instantiating
+fail_compilation/ice23097.d(28): Error: function `ice23097` is not callable using argument types `(S23097)`
+fail_compilation/ice23097.d(28):        generating a copy constructor for `struct S23097` failed, therefore instances of it are uncopyable
+fail_compilation/ice23097.d(11):        `ice23097.ice23097!(S23097).ice23097(S23097 __param_0)` declared here
 ---
 */
 auto ice23097(I)(I)

--- a/compiler/test/fail_compilation/ice6538.d
+++ b/compiler/test/fail_compilation/ice6538.d
@@ -7,7 +7,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice6538.d(23): Error: template instance `Sym!(super)` expression `super` is not a valid template value argument
-fail_compilation/ice6538.d(28): Error: template `ice6538.D.foo` is not callable using argument types `!()()`
+fail_compilation/ice6538.d(28): Error: template `foo` is not callable using argument types `!()()`
 fail_compilation/ice6538.d(23):        Candidate is: `foo()()`
 ---
 */

--- a/compiler/test/fail_compilation/ice9284.d
+++ b/compiler/test/fail_compilation/ice9284.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9284.d(14): Error: template `ice9284.C.__ctor` is not callable using argument types `!()(int)`
+fail_compilation/ice9284.d(14): Error: template `__ctor` is not callable using argument types `!()(int)`
 fail_compilation/ice9284.d(12):        Candidate is: `this()(string)`
 fail_compilation/ice9284.d(20): Error: template instance `ice9284.C.__ctor!()` error instantiating
 ---

--- a/compiler/test/fail_compilation/ice9540.d
+++ b/compiler/test/fail_compilation/ice9540.d
@@ -1,10 +1,11 @@
 /*
 TEST_OUTPUT:
----
-fail_compilation/ice9540.d(35): Error: function `ice9540.A.test.AddFront!(this, f).AddFront.dg(int __param_0)` is not callable using argument types `()`
-fail_compilation/ice9540.d(35):        too few arguments, expected 1, got 0
-fail_compilation/ice9540.d(26): Error: template instance `ice9540.A.test.AddFront!(this, f)` error instantiating
----
+----
+fail_compilation/ice9540.d(36): Error: function `dg` is not callable using argument types `()`
+fail_compilation/ice9540.d(36):        too few arguments, expected 1, got 0
+fail_compilation/ice9540.d(33):        `ice9540.A.test.AddFront!(this, f).AddFront.dg(int __param_0)` declared here
+fail_compilation/ice9540.d(27): Error: template instance `ice9540.A.test.AddFront!(this, f)` error instantiating
+----
 */
 
 template Tuple(E...) { alias E Tuple; }

--- a/compiler/test/fail_compilation/iconv_interface_array.d
+++ b/compiler/test/fail_compilation/iconv_interface_array.d
@@ -1,12 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/iconv_interface_array.d(45): Error: function `iconv_interface_array.testA(I1[4] arr)` is not callable using argument types `(C[4])`
-fail_compilation/iconv_interface_array.d(45):        cannot pass argument `arr` of type `C[4]` to parameter `I1[4] arr`
-fail_compilation/iconv_interface_array.d(46): Error: function `iconv_interface_array.testB(I2[4] arr)` is not callable using argument types `(C[4])`
-fail_compilation/iconv_interface_array.d(46):        cannot pass argument `arr` of type `C[4]` to parameter `I2[4] arr`
-fail_compilation/iconv_interface_array.d(47): Error: function `iconv_interface_array.testC(I3[4] arr)` is not callable using argument types `(C[4])`
-fail_compilation/iconv_interface_array.d(47):        cannot pass argument `arr` of type `C[4]` to parameter `I3[4] arr`
+fail_compilation/iconv_interface_array.d(48): Error: function `testA` is not callable using argument types `(C[4])`
+fail_compilation/iconv_interface_array.d(48):        cannot pass argument `arr` of type `C[4]` to parameter `I1[4] arr`
+fail_compilation/iconv_interface_array.d(27):        `iconv_interface_array.testA(I1[4] arr)` declared here
+fail_compilation/iconv_interface_array.d(49): Error: function `testB` is not callable using argument types `(C[4])`
+fail_compilation/iconv_interface_array.d(49):        cannot pass argument `arr` of type `C[4]` to parameter `I2[4] arr`
+fail_compilation/iconv_interface_array.d(33):        `iconv_interface_array.testB(I2[4] arr)` declared here
+fail_compilation/iconv_interface_array.d(50): Error: function `testC` is not callable using argument types `(C[4])`
+fail_compilation/iconv_interface_array.d(50):        cannot pass argument `arr` of type `C[4]` to parameter `I3[4] arr`
+fail_compilation/iconv_interface_array.d(39):        `iconv_interface_array.testC(I3[4] arr)` declared here
 ---
 */
 

--- a/compiler/test/fail_compilation/named_arguments_error.d
+++ b/compiler/test/fail_compilation/named_arguments_error.d
@@ -1,27 +1,27 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/named_arguments_error.d(32): Error: function `f` is not callable using argument types `(int, int, int)`
-fail_compilation/named_arguments_error.d(32):        parameter `x` assigned twice
-fail_compilation/named_arguments_error.d(26):        `named_arguments_error.f(int x, int y, int z)` declared here
-fail_compilation/named_arguments_error.d(33): Error: function `f` is not callable using argument types `(int, int, int)`
-fail_compilation/named_arguments_error.d(33):        argument `4` goes past end of parameter list
-fail_compilation/named_arguments_error.d(26):        `named_arguments_error.f(int x, int y, int z)` declared here
-fail_compilation/named_arguments_error.d(34): Error: function `f` is not callable using argument types `(int, int, int)`
-fail_compilation/named_arguments_error.d(34):        parameter `y` assigned twice
-fail_compilation/named_arguments_error.d(26):        `named_arguments_error.f(int x, int y, int z)` declared here
-fail_compilation/named_arguments_error.d(35): Error: function `f` is not callable using argument types `(int, int, int)`
-fail_compilation/named_arguments_error.d(35):        no parameter named `a`
-fail_compilation/named_arguments_error.d(26):        `named_arguments_error.f(int x, int y, int z)` declared here
-fail_compilation/named_arguments_error.d(36): Error: function `g` is not callable using argument types `(int, int)`
-fail_compilation/named_arguments_error.d(36):        missing argument for parameter #1: `int x`
-fail_compilation/named_arguments_error.d(28):        `named_arguments_error.g(int x, int y, int z = 3)` declared here
-fail_compilation/named_arguments_error.d(38): Error: no named argument `element` allowed for array dimension
-fail_compilation/named_arguments_error.d(39): Error: no named argument `number` allowed for scalar
-fail_compilation/named_arguments_error.d(40): Error: cannot implicitly convert expression `g(x: 3, y: 4, z: 5)` of type `int` to `string`
-fail_compilation/named_arguments_error.d(41): Error: named arguments with Implicit Function Template Instantiation are not supported yet
-fail_compilation/named_arguments_error.d(41): Error: template `tempfun` is not callable using argument types `!()(string, int)`
-fail_compilation/named_arguments_error.d(45):        Candidate is: `tempfun(T, U)(T t, U u)`
+fail_compilation/named_arguments_error.d(37): Error: function `f` is not callable using argument types `(int, int, int)`
+fail_compilation/named_arguments_error.d(37):        parameter `x` assigned twice
+fail_compilation/named_arguments_error.d(31):        `named_arguments_error.f(int x, int y, int z)` declared here
+fail_compilation/named_arguments_error.d(38): Error: function `f` is not callable using argument types `(int, int, int)`
+fail_compilation/named_arguments_error.d(38):        argument `4` goes past end of parameter list
+fail_compilation/named_arguments_error.d(31):        `named_arguments_error.f(int x, int y, int z)` declared here
+fail_compilation/named_arguments_error.d(39): Error: function `f` is not callable using argument types `(int, int, int)`
+fail_compilation/named_arguments_error.d(39):        parameter `y` assigned twice
+fail_compilation/named_arguments_error.d(31):        `named_arguments_error.f(int x, int y, int z)` declared here
+fail_compilation/named_arguments_error.d(40): Error: function `f` is not callable using argument types `(int, int, int)`
+fail_compilation/named_arguments_error.d(40):        no parameter named `a`
+fail_compilation/named_arguments_error.d(31):        `named_arguments_error.f(int x, int y, int z)` declared here
+fail_compilation/named_arguments_error.d(41): Error: function `g` is not callable using argument types `(int, int)`
+fail_compilation/named_arguments_error.d(41):        missing argument for parameter #1: `int x`
+fail_compilation/named_arguments_error.d(33):        `named_arguments_error.g(int x, int y, int z = 3)` declared here
+fail_compilation/named_arguments_error.d(43): Error: no named argument `element` allowed for array dimension
+fail_compilation/named_arguments_error.d(44): Error: no named argument `number` allowed for scalar
+fail_compilation/named_arguments_error.d(45): Error: cannot implicitly convert expression `g(x: 3, y: 4, z: 5)` of type `int` to `string`
+fail_compilation/named_arguments_error.d(46): Error: named arguments with Implicit Function Template Instantiation are not supported yet
+fail_compilation/named_arguments_error.d(46): Error: template `tempfun` is not callable using argument types `!()(string, int)`
+fail_compilation/named_arguments_error.d(50):        Candidate is: `tempfun(T, U)(T t, U u)`
 ---
 */
 

--- a/compiler/test/fail_compilation/named_arguments_error.d
+++ b/compiler/test/fail_compilation/named_arguments_error.d
@@ -1,21 +1,26 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/named_arguments_error.d(32): Error: function `named_arguments_error.f(int x, int y, int z)` is not callable using argument types `(int, int, int)`
+fail_compilation/named_arguments_error.d(32): Error: function `f` is not callable using argument types `(int, int, int)`
 fail_compilation/named_arguments_error.d(32):        parameter `x` assigned twice
-fail_compilation/named_arguments_error.d(33): Error: function `named_arguments_error.f(int x, int y, int z)` is not callable using argument types `(int, int, int)`
+fail_compilation/named_arguments_error.d(26):        `named_arguments_error.f(int x, int y, int z)` declared here
+fail_compilation/named_arguments_error.d(33): Error: function `f` is not callable using argument types `(int, int, int)`
 fail_compilation/named_arguments_error.d(33):        argument `4` goes past end of parameter list
-fail_compilation/named_arguments_error.d(34): Error: function `named_arguments_error.f(int x, int y, int z)` is not callable using argument types `(int, int, int)`
+fail_compilation/named_arguments_error.d(26):        `named_arguments_error.f(int x, int y, int z)` declared here
+fail_compilation/named_arguments_error.d(34): Error: function `f` is not callable using argument types `(int, int, int)`
 fail_compilation/named_arguments_error.d(34):        parameter `y` assigned twice
-fail_compilation/named_arguments_error.d(35): Error: function `named_arguments_error.f(int x, int y, int z)` is not callable using argument types `(int, int, int)`
+fail_compilation/named_arguments_error.d(26):        `named_arguments_error.f(int x, int y, int z)` declared here
+fail_compilation/named_arguments_error.d(35): Error: function `f` is not callable using argument types `(int, int, int)`
 fail_compilation/named_arguments_error.d(35):        no parameter named `a`
-fail_compilation/named_arguments_error.d(36): Error: function `named_arguments_error.g(int x, int y, int z = 3)` is not callable using argument types `(int, int)`
+fail_compilation/named_arguments_error.d(26):        `named_arguments_error.f(int x, int y, int z)` declared here
+fail_compilation/named_arguments_error.d(36): Error: function `g` is not callable using argument types `(int, int)`
 fail_compilation/named_arguments_error.d(36):        missing argument for parameter #1: `int x`
+fail_compilation/named_arguments_error.d(28):        `named_arguments_error.g(int x, int y, int z = 3)` declared here
 fail_compilation/named_arguments_error.d(38): Error: no named argument `element` allowed for array dimension
 fail_compilation/named_arguments_error.d(39): Error: no named argument `number` allowed for scalar
 fail_compilation/named_arguments_error.d(40): Error: cannot implicitly convert expression `g(x: 3, y: 4, z: 5)` of type `int` to `string`
 fail_compilation/named_arguments_error.d(41): Error: named arguments with Implicit Function Template Instantiation are not supported yet
-fail_compilation/named_arguments_error.d(41): Error: template `named_arguments_error.tempfun` is not callable using argument types `!()(string, int)`
+fail_compilation/named_arguments_error.d(41): Error: template `tempfun` is not callable using argument types `!()(string, int)`
 fail_compilation/named_arguments_error.d(45):        Candidate is: `tempfun(T, U)(T t, U u)`
 ---
 */

--- a/compiler/test/fail_compilation/previewin.d
+++ b/compiler/test/fail_compilation/previewin.d
@@ -1,20 +1,23 @@
 /*
 REQUIRED_ARGS: -preview=in -preview=dip1000
 TEST_OUTPUT:
----
-fail_compilation/previewin.d(4): Error: function `previewin.takeFunction(void function(in real) f)` is not callable using argument types `(void function(real x) pure nothrow @nogc @safe)`
+----
+fail_compilation/previewin.d(4): Error: function `takeFunction` is not callable using argument types `(void function(real x) pure nothrow @nogc @safe)`
 fail_compilation/previewin.d(4):        cannot pass argument `__lambda1` of type `void function(real x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
-fail_compilation/previewin.d(5): Error: function `previewin.takeFunction(void function(in real) f)` is not callable using argument types `(void function(scope const(real) x) pure nothrow @nogc @safe)`
+fail_compilation/previewin.d(11):        `previewin.takeFunction(void function(in real) f)` declared here
+fail_compilation/previewin.d(5): Error: function `takeFunction` is not callable using argument types `(void function(scope const(real) x) pure nothrow @nogc @safe)`
 fail_compilation/previewin.d(5):        cannot pass argument `__lambda2` of type `void function(scope const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
-fail_compilation/previewin.d(6): Error: function `previewin.takeFunction(void function(in real) f)` is not callable using argument types `(void function(ref scope const(real) x) pure nothrow @nogc @safe)`
+fail_compilation/previewin.d(11):        `previewin.takeFunction(void function(in real) f)` declared here
+fail_compilation/previewin.d(6): Error: function `takeFunction` is not callable using argument types `(void function(ref scope const(real) x) pure nothrow @nogc @safe)`
 fail_compilation/previewin.d(6):        cannot pass argument `__lambda3` of type `void function(ref scope const(real) x) pure nothrow @nogc @safe` to parameter `void function(in real) f`
+fail_compilation/previewin.d(11):        `previewin.takeFunction(void function(in real) f)` declared here
 fail_compilation/previewin.d(15): Error: scope variable `arg` assigned to global variable `myGlobal`
 fail_compilation/previewin.d(16): Error: scope variable `arg` assigned to global variable `myGlobal`
 fail_compilation/previewin.d(17): Error: scope parameter `arg` may not be returned
 fail_compilation/previewin.d(18): Error: scope variable `arg` assigned to `ref` variable `escape` with longer lifetime
 fail_compilation/previewin.d(22): Error: returning `arg` escapes a reference to parameter `arg`
 fail_compilation/previewin.d(22):        perhaps annotate the parameter with `return`
----
+----
  */
 
 #line 1

--- a/compiler/test/fail_compilation/pull12941.d
+++ b/compiler/test/fail_compilation/pull12941.d
@@ -4,10 +4,12 @@ fail_compilation/pull12941.d(110): Error: `pull12941.foo` called with argument t
 fail_compilation/pull12941.d(101):     `pull12941.foo(return ref scope int* p)`
 and:
 fail_compilation/pull12941.d(102):     `pull12941.foo(return out scope int* p)`
-fail_compilation/pull12941.d(111): Error: function `pull12941.bar(return scope int* p)` is not callable using argument types `(int)`
+fail_compilation/pull12941.d(111): Error: function `bar` is not callable using argument types `(int)`
 fail_compilation/pull12941.d(111):        cannot pass argument `1` of type `int` to parameter `return scope int* p`
-fail_compilation/pull12941.d(112): Error: function `pull12941.abc(return ref int* p)` is not callable using argument types `(int)`
+fail_compilation/pull12941.d(104):        `pull12941.bar(return scope int* p)` declared here
+fail_compilation/pull12941.d(112): Error: function `abc` is not callable using argument types `(int)`
 fail_compilation/pull12941.d(112):        cannot pass rvalue argument `1` of type `int` to parameter `return ref int* p`
+fail_compilation/pull12941.d(105):        `pull12941.abc(return ref int* p)` declared here
 ---
  */
 

--- a/compiler/test/fail_compilation/test19107.d
+++ b/compiler/test/fail_compilation/test19107.d
@@ -2,7 +2,7 @@
 EXTRA_FILES: imports/imp19661.d imports/test19107a.d imports/test19107b.d
 TEST_OUTPUT:
 ---
-fail_compilation/test19107.d(24): Error: template `test19107.all` is not callable using argument types `!((c) => c)(string[])`
+fail_compilation/test19107.d(24): Error: template `all` is not callable using argument types `!((c) => c)(string[])`
 fail_compilation/test19107.d(18):        Candidate is: `all(alias pred, T)(T t)`
   with `pred = __lambda2,
        T = string[]`

--- a/compiler/test/fail_compilation/test19971.d
+++ b/compiler/test/fail_compilation/test19971.d
@@ -1,9 +1,10 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test19971.d(15): Error: function `test19971.f(int x)` is not callable using argument types `(string)`
-fail_compilation/test19971.d(15):        cannot pass argument `"%s"` of type `string` to parameter `int x`
-fail_compilation/test19971.d(16): Error: function literal `__lambda1(int x)` is not callable using argument types `(string)`
+fail_compilation/test19971.d(16): Error: function `f` is not callable using argument types `(string)`
 fail_compilation/test19971.d(16):        cannot pass argument `"%s"` of type `string` to parameter `int x`
+fail_compilation/test19971.d(13):        `test19971.f(int x)` declared here
+fail_compilation/test19971.d(17): Error: function literal `__lambda1(int x)` is not callable using argument types `(string)`
+fail_compilation/test19971.d(17):        cannot pass argument `"%s"` of type `string` to parameter `int x`
 ---
 */
 

--- a/compiler/test/fail_compilation/test21008.d
+++ b/compiler/test/fail_compilation/test21008.d
@@ -6,14 +6,14 @@ fail_compilation/test21008.d(117): Error: calling non-static function `toString`
 fail_compilation/test21008.d(117): Error: calling non-static function `toHash` requires an instance of type `Object`
 fail_compilation/test21008.d(117): Error: function `opCmp` is not callable using argument types `()`
 fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
-/home/runner/work/dmd/dmd/compiler/test/../../druntime/import/object.d(160):        `object.Object.opCmp(Object o)` declared here
+$p:druntime/import/object.d$($n$):        `object.Object.opCmp(Object o)` declared here
 fail_compilation/test21008.d(117): Error: function `opEquals` is not callable using argument types `()`
 fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
-/home/runner/work/dmd/dmd/compiler/test/../../druntime/import/object.d(214):        `object.Object.opEquals(Object o)` declared here
+$p:druntime/import/object.d$($n$):        `object.Object.opEquals(Object o)` declared here
 fail_compilation/test21008.d(117): Error: `Monitor` has no effect
 fail_compilation/test21008.d(117): Error: function `factory` is not callable using argument types `()`
 fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
-/home/runner/work/dmd/dmd/compiler/test/../../druntime/import/object.d(249):        `object.Object.factory(string classname)` declared here
+$p:druntime/import/object.d$($n$):        `object.Object.factory(string classname)` declared here
 fail_compilation/test21008.d(105):        called from here: `handleMiddlewareAnnotation()`
 ---
 */

--- a/compiler/test/fail_compilation/test21008.d
+++ b/compiler/test/fail_compilation/test21008.d
@@ -4,13 +4,16 @@ TEST_OUTPUT:
 fail_compilation/test21008.d(110): Error: function `test21008.C.after` circular reference to class `C`
 fail_compilation/test21008.d(117): Error: calling non-static function `toString` requires an instance of type `Object`
 fail_compilation/test21008.d(117): Error: calling non-static function `toHash` requires an instance of type `Object`
-fail_compilation/test21008.d(117): Error: function `object.Object.opCmp(Object o)` is not callable using argument types `()`
+fail_compilation/test21008.d(117): Error: function `opCmp` is not callable using argument types `()`
 fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
-fail_compilation/test21008.d(117): Error: function `object.Object.opEquals(Object o)` is not callable using argument types `()`
+/home/ryuukk/dev/dmd/compiler/test/../../druntime/import/object.d(160):        `object.Object.opCmp(Object o)` declared here
+fail_compilation/test21008.d(117): Error: function `opEquals` is not callable using argument types `()`
 fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
+/home/ryuukk/dev/dmd/compiler/test/../../druntime/import/object.d(214):        `object.Object.opEquals(Object o)` declared here
 fail_compilation/test21008.d(117): Error: `Monitor` has no effect
-fail_compilation/test21008.d(117): Error: function `object.Object.factory(string classname)` is not callable using argument types `()`
+fail_compilation/test21008.d(117): Error: function `factory` is not callable using argument types `()`
 fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
+/home/ryuukk/dev/dmd/compiler/test/../../druntime/import/object.d(249):        `object.Object.factory(string classname)` declared here
 fail_compilation/test21008.d(105):        called from here: `handleMiddlewareAnnotation()`
 ---
 */

--- a/compiler/test/fail_compilation/test21008.d
+++ b/compiler/test/fail_compilation/test21008.d
@@ -6,14 +6,14 @@ fail_compilation/test21008.d(117): Error: calling non-static function `toString`
 fail_compilation/test21008.d(117): Error: calling non-static function `toHash` requires an instance of type `Object`
 fail_compilation/test21008.d(117): Error: function `opCmp` is not callable using argument types `()`
 fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
-/home/ryuukk/dev/dmd/compiler/test/../../druntime/import/object.d(160):        `object.Object.opCmp(Object o)` declared here
+/home/runner/work/dmd/dmd/compiler/test/../../druntime/import/object.d(160):        `object.Object.opCmp(Object o)` declared here
 fail_compilation/test21008.d(117): Error: function `opEquals` is not callable using argument types `()`
 fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
-/home/ryuukk/dev/dmd/compiler/test/../../druntime/import/object.d(214):        `object.Object.opEquals(Object o)` declared here
+/home/runner/work/dmd/dmd/compiler/test/../../druntime/import/object.d(214):        `object.Object.opEquals(Object o)` declared here
 fail_compilation/test21008.d(117): Error: `Monitor` has no effect
 fail_compilation/test21008.d(117): Error: function `factory` is not callable using argument types `()`
 fail_compilation/test21008.d(117):        too few arguments, expected 1, got 0
-/home/ryuukk/dev/dmd/compiler/test/../../druntime/import/object.d(249):        `object.Object.factory(string classname)` declared here
+/home/runner/work/dmd/dmd/compiler/test/../../druntime/import/object.d(249):        `object.Object.factory(string classname)` declared here
 fail_compilation/test21008.d(105):        called from here: `handleMiddlewareAnnotation()`
 ---
 */

--- a/compiler/test/fail_compilation/test21025.d
+++ b/compiler/test/fail_compilation/test21025.d
@@ -6,7 +6,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/test21025.d(15): Error: variable `r` cannot be read at compile time
 fail_compilation/test21025.d(15):        called from here: `binaryFun(r, r)`
-fail_compilation/test21025.d(24): Error: template `test21025.uniq` is not callable using argument types `!()(void[])`
+fail_compilation/test21025.d(24): Error: template `uniq` is not callable using argument types `!()(void[])`
 fail_compilation/test21025.d(14):        Candidate is: `uniq()(int[] r)`
 ---
 */

--- a/compiler/test/fail_compilation/test21807.d
+++ b/compiler/test/fail_compilation/test21807.d
@@ -27,8 +27,9 @@ class Foo
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test21807.d(117): Error: function `test21807.addr(return ref int b)` is not callable using argument types `(int)`
+fail_compilation/test21807.d(117): Error: function `addr` is not callable using argument types `(int)`
 fail_compilation/test21807.d(117):        cannot pass rvalue argument `S(0).i` of type `int` to parameter `return ref int b`
+fail_compilation/test21807.d(106):        `test21807.addr(return ref int b)` declared here
 ---
 */
 #line 100

--- a/compiler/test/fail_compilation/ufcs.d
+++ b/compiler/test/fail_compilation/ufcs.d
@@ -1,20 +1,20 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ufcs.d(25): Error: no property `regularF` for `s` of type `S`
-fail_compilation/ufcs.d(25):        the following error occured while looking for a UFCS match
-fail_compilation/ufcs.d(25): Error: function `regularF` is not callable using argument types `(S)`
-fail_compilation/ufcs.d(25):        expected 0 argument(s), not 1
-fail_compilation/ufcs.d(30):        `ufcs.regularF()` declared here
-fail_compilation/ufcs.d(26): Error: no property `templateF` for `s` of type `S`
+fail_compilation/ufcs.d(26): Error: no property `regularF` for `s` of type `S`
 fail_compilation/ufcs.d(26):        the following error occured while looking for a UFCS match
-fail_compilation/ufcs.d(26): Error: template `templateF` is not callable using argument types `!()(S)`
-fail_compilation/ufcs.d(31):        Candidate is: `templateF()()`
-fail_compilation/ufcs.d(27): Error: no property `templateO` for `s` of type `S`
+fail_compilation/ufcs.d(26): Error: function `regularF` is not callable using argument types `(S)`
+fail_compilation/ufcs.d(26):        expected 0 argument(s), not 1
+fail_compilation/ufcs.d(31):        `ufcs.regularF()` declared here
+fail_compilation/ufcs.d(27): Error: no property `templateF` for `s` of type `S`
 fail_compilation/ufcs.d(27):        the following error occured while looking for a UFCS match
-fail_compilation/ufcs.d(27): Error: none of the overloads of template `ufcs.templateO` are callable using argument types `!()(S)`
-fail_compilation/ufcs.d(33):        Candidates are: `templateO()(int x)`
-fail_compilation/ufcs.d(34):                        `templateO()(float y)`
+fail_compilation/ufcs.d(27): Error: template `templateF` is not callable using argument types `!()(S)`
+fail_compilation/ufcs.d(32):        Candidate is: `templateF()()`
+fail_compilation/ufcs.d(28): Error: no property `templateO` for `s` of type `S`
+fail_compilation/ufcs.d(28):        the following error occured while looking for a UFCS match
+fail_compilation/ufcs.d(28): Error: none of the overloads of template `ufcs.templateO` are callable using argument types `!()(S)`
+fail_compilation/ufcs.d(34):        Candidates are: `templateO()(int x)`
+fail_compilation/ufcs.d(35):                        `templateO()(float y)`
 ---
 */
 

--- a/compiler/test/fail_compilation/ufcs.d
+++ b/compiler/test/fail_compilation/ufcs.d
@@ -3,11 +3,12 @@ TEST_OUTPUT:
 ---
 fail_compilation/ufcs.d(25): Error: no property `regularF` for `s` of type `S`
 fail_compilation/ufcs.d(25):        the following error occured while looking for a UFCS match
-fail_compilation/ufcs.d(25): Error: function `ufcs.regularF()` is not callable using argument types `(S)`
+fail_compilation/ufcs.d(25): Error: function `regularF` is not callable using argument types `(S)`
 fail_compilation/ufcs.d(25):        expected 0 argument(s), not 1
+fail_compilation/ufcs.d(30):        `ufcs.regularF()` declared here
 fail_compilation/ufcs.d(26): Error: no property `templateF` for `s` of type `S`
 fail_compilation/ufcs.d(26):        the following error occured while looking for a UFCS match
-fail_compilation/ufcs.d(26): Error: template `ufcs.templateF` is not callable using argument types `!()(S)`
+fail_compilation/ufcs.d(26): Error: template `templateF` is not callable using argument types `!()(S)`
 fail_compilation/ufcs.d(31):        Candidate is: `templateF()()`
 fail_compilation/ufcs.d(27): Error: no property `templateO` for `s` of type `S`
 fail_compilation/ufcs.d(27):        the following error occured while looking for a UFCS match

--- a/compiler/test/fail_compilation/vararg2.d
+++ b/compiler/test/fail_compilation/vararg2.d
@@ -1,10 +1,12 @@
 /* TEST_OUTPUT:
----
-fail_compilation/vararg2.d(106): Error: function `vararg2.foo(int x, const return ...)` is not callable using argument types `(double)`
+----
+fail_compilation/vararg2.d(106): Error: function `foo` is not callable using argument types `(double)`
 fail_compilation/vararg2.d(106):        cannot pass argument `1.0` of type `double` to parameter `int x`
-fail_compilation/vararg2.d(111): Error: function `vararg2.bar(int x, scope shared ...)` is not callable using argument types `(double)`
+fail_compilation/vararg2.d(101):        `vararg2.foo(int x, const return ...)` declared here
+fail_compilation/vararg2.d(111): Error: function `bar` is not callable using argument types `(double)`
 fail_compilation/vararg2.d(111):        cannot pass argument `1.0` of type `double` to parameter `int x`
----
+fail_compilation/vararg2.d(102):        `vararg2.bar(int x, scope shared ...)` declared here
+----
 */
 
 #line 100


### PR DESCRIPTION
before:

```
$ dmd -run app.d                                                                                                                                                                                                    
app.d(9): Error: function `app.why_do_i_have_to_read_this_long_ass_function_man_useless(int aa)` is not callable using argument types `(string)`
app.d(9):        cannot pass argument `"wrong"` of type `string` to parameter `int aa`
```



after:

```
$ ./dmd -run app.d 
app.d(9): Error: function is not callable using argument types `(string)`
app.d(9):               `app.why_do_i_have_to_read_this_long_ass_function_man_useless(int aa)`
app.d(9):        cannot pass argument `"wrong"` of type `string` to parameter `int aa`
```


I personally think this is more readable

If your function is long, and the path if quite long, then you have to first go throught reading the name of a long function + long params before knowing what the actual error is

And it looks very bad in editors, it duplicates the information

![image](https://github.com/dlang/dmd/assets/44361234/dd5f3e06-059f-4da8-b577-7ab0e62c2185)

With this PR, the error message is clear

```
    <filename>:<position>    <actual problem>
```
Then it gives you the details in the next line

I tried to update as many tests as possible, but my terminal cut off the tests result, and i don't feel like running the tests again on this weak laptop, so i'll see what CI says and i'll fix them