### PR TITLE
core.atomic: Reject invalid memory models in load, store and exchange

### DIFF
--- a/changelog/druntime.coreatomic.dd
+++ b/changelog/druntime.coreatomic.dd
@@ -1,0 +1,8 @@
+Using an invalid MemoryOrder for core.atomic operations are now rejected at compile time
+
+The following core.atomic functions have become more restrictive:
+- atomicStore now rejects `MemoryOrder.acq_rel`. Previously it only rejected `MemoryOrder.acq`.
+- atomicLoad now rejects `MemoryOrder.acq_rel`. Previously it only rejected `MemoryOrder.rel`.
+- atomicExchange now rejects `MemoryOrder.acq`. Previously it accepted all MemoryOrders.
+
+Code that previously used any of these MemoryOrders should switch to `MemoryOrder.seq` instead.

--- a/druntime/src/core/internal/atomic.d
+++ b/druntime/src/core/internal/atomic.d
@@ -54,7 +54,8 @@ version (DigitalMars)
     inout(T) atomicLoad(MemoryOrder order = MemoryOrder.seq, T)(inout(T)* src) pure nothrow @nogc @trusted
         if (CanCAS!T)
     {
-        static assert(order != MemoryOrder.rel, "invalid MemoryOrder for atomicLoad()");
+        static assert(order != MemoryOrder.rel && order != MemoryOrder.acq_rel,
+                      "invalid MemoryOrder for atomicLoad()");
 
         static if (T.sizeof == size_t.sizeof * 2)
         {
@@ -171,7 +172,8 @@ version (DigitalMars)
     void atomicStore(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @trusted
         if (CanCAS!T)
     {
-        static assert(order != MemoryOrder.acq, "Invalid MemoryOrder for atomicStore()");
+        static assert(order != MemoryOrder.acq && order != MemoryOrder.acq_rel,
+                      "Invalid MemoryOrder for atomicStore()");
 
         static if (T.sizeof == size_t.sizeof * 2)
         {
@@ -293,6 +295,8 @@ version (DigitalMars)
     T atomicExchange(MemoryOrder order = MemoryOrder.seq, bool result = true, T)(T* dest, T value) pure nothrow @nogc @trusted
     if (CanCAS!T)
     {
+        static assert(order != MemoryOrder.acq, "Invalid MemoryOrder for atomicExchange()");
+
         version (D_InlineAsm_X86)
         {
             static assert(T.sizeof <= 4, "64bit atomicExchange not supported on 32bit target." );
@@ -705,40 +709,35 @@ else version (GNU)
     inout(T) atomicLoad(MemoryOrder order = MemoryOrder.seq, T)(inout(T)* src) pure nothrow @nogc @trusted
         if (CanCAS!T)
     {
-        // MemoryOrder.rel and MemoryOrder.acq_rel are not valid for load.
-        static assert(order != MemoryOrder.rel, "invalid MemoryOrder for atomicLoad()");
-
-        static if (order == MemoryOrder.acq_rel)
-            enum smodel = PreferAcquireRelease ? MemoryOrder.acq : MemoryOrder.seq;
-        else
-            enum smodel = order;
+        static assert(order != MemoryOrder.rel && order != MemoryOrder.acq_rel,
+                      "invalid MemoryOrder for atomicLoad()");
 
         static if (GNU_Have_Atomics || GNU_Have_LibAtomic)
         {
             static if (T.sizeof == ubyte.sizeof)
             {
-                ubyte value = __atomic_load_1(cast(shared)src, smodel);
+                ubyte value = __atomic_load_1(cast(shared)src, order);
                 return *cast(typeof(return)*)&value;
             }
             else static if (T.sizeof == ushort.sizeof)
             {
-                ushort value = __atomic_load_2(cast(shared)src, smodel);
+                ushort value = __atomic_load_2(cast(shared)src, order);
                 return *cast(typeof(return)*)&value;
             }
             else static if (T.sizeof == uint.sizeof)
             {
-                uint value = __atomic_load_4(cast(shared)src, smodel);
+                uint value = __atomic_load_4(cast(shared)src, order);
                 return *cast(typeof(return)*)&value;
             }
             else static if (T.sizeof == ulong.sizeof && GNU_Have_64Bit_Atomics)
             {
-                ulong value = __atomic_load_8(cast(shared)src, smodel);
+                ulong value = __atomic_load_8(cast(shared)src, order);
                 return *cast(typeof(return)*)&value;
             }
             else static if (GNU_Have_LibAtomic)
             {
                 T value;
-                __atomic_load(T.sizeof, cast(shared)src, &value, smodel);
+                __atomic_load(T.sizeof, cast(shared)src, &value, order);
                 return *cast(typeof(return)*)&value;
             }
             else
@@ -755,26 +754,21 @@ else version (GNU)
     void atomicStore(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @trusted
         if (CanCAS!T)
     {
-        // MemoryOrder.acq and MemoryOrder.acq_rel are not valid for store.
-        static assert(order != MemoryOrder.acq, "Invalid MemoryOrder for atomicStore()");
-
-        static if (order == MemoryOrder.acq_rel)
-            enum smodel = PreferAcquireRelease ? MemoryOrder.rel : MemoryOrder.seq;
-        else
-            enum smodel = order;
+        static assert(order != MemoryOrder.acq && order != MemoryOrder.acq_rel,
+                      "Invalid MemoryOrder for atomicStore()");
 
         static if (GNU_Have_Atomics || GNU_Have_LibAtomic)
         {
             static if (T.sizeof == ubyte.sizeof)
-                __atomic_store_1(cast(shared)dest, *cast(ubyte*)&value, smodel);
+                __atomic_store_1(cast(shared)dest, *cast(ubyte*)&value, order);
             else static if (T.sizeof == ushort.sizeof)
-                __atomic_store_2(cast(shared)dest, *cast(ushort*)&value, smodel);
+                __atomic_store_2(cast(shared)dest, *cast(ushort*)&value, order);
             else static if (T.sizeof == uint.sizeof)
-                __atomic_store_4(cast(shared)dest, *cast(uint*)&value, smodel);
+                __atomic_store_4(cast(shared)dest, *cast(uint*)&value, order);
             else static if (T.sizeof == ulong.sizeof && GNU_Have_64Bit_Atomics)
-                __atomic_store_8(cast(shared)dest, *cast(ulong*)&value, smodel);
+                __atomic_store_8(cast(shared)dest, *cast(ulong*)&value, order);
             else static if (GNU_Have_LibAtomic)
-                __atomic_store(T.sizeof, cast(shared)dest, cast(void*)&value, smodel);
+                __atomic_store(T.sizeof, cast(shared)dest, cast(void*)&value, order);
             else
                 static assert(0, "Invalid template type specified.");
         }
@@ -845,38 +839,34 @@ else version (GNU)
     T atomicExchange(MemoryOrder order = MemoryOrder.seq, bool result = true, T)(T* dest, T value) pure nothrow @nogc @trusted
         if (is(T : ulong) || is(T == class) || is(T == interface) || is(T U : U*))
     {
+        static assert(order != MemoryOrder.acq, "Invalid MemoryOrder for atomicExchange()");
+
         static if (GNU_Have_Atomics || GNU_Have_LibAtomic)
         {
-            // MemoryOrder.acq is not valid for exchange.
-            static if (order == MemoryOrder.acq)
-                enum smodel = PreferAcquireRelease ? MemoryOrder.acq_rel : MemoryOrder.seq;
-            else
-                enum smodel = order;
-
             static if (T.sizeof == byte.sizeof)
             {
-                ubyte res = __atomic_exchange_1(cast(shared)dest, *cast(ubyte*)&value, smodel);
+                ubyte res = __atomic_exchange_1(cast(shared)dest, *cast(ubyte*)&value, order);
                 return *cast(typeof(return)*)&res;
             }
             else static if (T.sizeof == short.sizeof)
             {
-                ushort res = __atomic_exchange_2(cast(shared)dest, *cast(ushort*)&value, smodel);
+                ushort res = __atomic_exchange_2(cast(shared)dest, *cast(ushort*)&value, order);
                 return *cast(typeof(return)*)&res;
             }
             else static if (T.sizeof == int.sizeof)
             {
-                uint res = __atomic_exchange_4(cast(shared)dest, *cast(uint*)&value, smodel);
+                uint res = __atomic_exchange_4(cast(shared)dest, *cast(uint*)&value, order);
                 return *cast(typeof(return)*)&res;
             }
             else static if (T.sizeof == long.sizeof && GNU_Have_64Bit_Atomics)
             {
-                ulong res = __atomic_exchange_8(cast(shared)dest, *cast(ulong*)&value, smodel);
+                ulong res = __atomic_exchange_8(cast(shared)dest, *cast(ulong*)&value, order);
                 return *cast(typeof(return)*)&res;
             }
             else static if (GNU_Have_LibAtomic)
             {
                 T res = void;
-                __atomic_exchange(T.sizeof, cast(shared)dest, cast(void*)&value, &res, smodel);
+                __atomic_exchange(T.sizeof, cast(shared)dest, cast(void*)&value, &res, order);
                 return res;
             }
             else

--- a/druntime/src/core/stdc/stdatomic.d
+++ b/druntime/src/core/stdc/stdatomic.d
@@ -169,6 +169,7 @@ void atomic_flag_clear_explicit_impl()(atomic_flag* obj, memory_order order)
             break;
 
         case memory_order.memory_order_acquire:
+        case memory_order.memory_order_acq_rel:
             // Ideally this would error at compile time but alas it is not an intrinsic.
             // Note: this is not a valid memory order for this operation.
             atomicStore!(memory_order.memory_order_seq_cst)(&obj.b, false);
@@ -176,10 +177,6 @@ void atomic_flag_clear_explicit_impl()(atomic_flag* obj, memory_order order)
 
         case memory_order.memory_order_release:
             atomicStore!(memory_order.memory_order_release)(&obj.b, false);
-            break;
-
-        case memory_order.memory_order_acq_rel:
-            atomicStore!(memory_order.memory_order_acq_rel)(&obj.b, false);
             break;
 
         case memory_order.memory_order_seq_cst:
@@ -216,7 +213,9 @@ bool atomic_flag_test_and_set_explicit_impl()(atomic_flag* obj, memory_order ord
             return atomicExchange!(memory_order.memory_order_relaxed)(&obj.b, true);
 
         case memory_order.memory_order_acquire:
-            return atomicExchange!(memory_order.memory_order_acquire)(&obj.b, true);
+            // Ideally this would error at compile time but alas it is not an intrinsic.
+            // Note: this is not a valid memory order for this operation.
+            return atomicExchange!(memory_order.memory_order_seq_cst)(&obj.b, true);
 
         case memory_order.memory_order_release:
             return atomicExchange!(memory_order.memory_order_release)(&obj.b, true);
@@ -436,6 +435,7 @@ void atomic_store_explicit_impl(A, C)(shared(A)* obj, C desired, memory_order or
             break;
 
         case memory_order.memory_order_acquire:
+        case memory_order.memory_order_acq_rel:
             // Ideally this would error at compile time but alas it is not an intrinsic.
             // Note: this is not a valid memory order for this operation.
             atomicStore!(memory_order.memory_order_release)(obj, cast(A)desired);
@@ -443,10 +443,6 @@ void atomic_store_explicit_impl(A, C)(shared(A)* obj, C desired, memory_order or
 
         case memory_order.memory_order_release:
             atomicStore!(memory_order.memory_order_release)(obj, cast(A)desired);
-            break;
-
-        case memory_order.memory_order_acq_rel:
-            atomicStore!(memory_order.memory_order_acq_rel)(obj, cast(A)desired);
             break;
 
         case memory_order.memory_order_seq_cst:
@@ -492,12 +488,10 @@ A atomic_load_explicit_impl(A)(const shared(A)* obj, memory_order order) @truste
             return atomicLoad!(memory_order.memory_order_acquire)(obj);
 
         case memory_order.memory_order_release:
+        case memory_order.memory_order_acq_rel:
             // Ideally this would error at compile time but alas it is not an intrinsic.
             // Note: this is not a valid memory order for this operation.
             return atomicLoad!(memory_order.memory_order_acquire)(obj);
-
-        case memory_order.memory_order_acq_rel:
-            return atomicLoad!(memory_order.memory_order_acq_rel)(obj);
 
         case memory_order.memory_order_seq_cst:
             return atomicLoad!(memory_order.memory_order_seq_cst)(obj);
@@ -538,7 +532,9 @@ A atomic_exchange_explicit_impl(A, C)(shared(A)* obj, C desired, memory_order or
             return atomicExchange!(memory_order.memory_order_relaxed)(obj, cast(A)desired);
 
         case memory_order.memory_order_acquire:
-            return atomicExchange!(memory_order.memory_order_acquire)(obj, cast(A)desired);
+            // Ideally this would error at compile time but alas it is not an intrinsic.
+            // Note: this is not a valid memory order for this operation.
+            return atomicExchange!(memory_order.memory_order_seq_cst)(obj, cast(A)desired);
 
         case memory_order.memory_order_release:
             return atomicExchange!(memory_order.memory_order_release)(obj, cast(A)desired);


### PR DESCRIPTION
- Rejects MemoryOrder.acq_rel in atomicLoad and atomicStore.
- Rejects MemoryOrder.acq in atomicExchange.

These are rejected as an invalid memory models if ever encountered
compiling with GDC or LDC, so make it also rejected by druntime atomics

FYI @kinke - s̶t̶i̶l̶l̶ ̶m̶i̶s̶s̶i̶n̶g̶ ̶i̶n̶v̶a̶l̶i̶d̶ ̶e̶x̶c̶h̶a̶n̶g̶e̶ ̶o̶r̶d̶e̶r̶s̶,̶ ̶b̶u̶t̶ ̶t̶h̶a̶t̶ ̶c̶a̶n̶ ̶b̶e̶ ̶d̶o̶n̶e̶ ̶s̶e̶p̶a̶r̶a̶t̶e̶l̶y̶    atomicExchange turned out to be smaller than I thought, so included it here (also don't want to conflate this with #15996 @rikkimax in case you were trying to tackle both at once) - however atomicCompareExchage is a different beast altogether and will need tackling separately.