### PR TITLE
Fix issue 24340 - Invalid export directives generated

### DIFF
--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -1751,7 +1751,9 @@ void MsCoffObj_export_symbol(Symbol *s,uint argsize)
     int seg = MsCoffObj_seg_drectve();
     //printf("MsCoffObj_export_symbol(%s,%d)\n",s.Sident.ptr,argsize);
     SegData[seg].SDbuf.write(" /EXPORT:".ptr, 9);
-    SegData[seg].SDbuf.write(dest.ptr, cast(uint)strlen(dest.ptr));
+    // obj_mangle2 may not use the buffer dest,
+    //  this will result in https://issues.dlang.org/show_bug.cgi?id=24340
+    SegData[seg].SDbuf.write(destr, cast(uint)strlen(destr));
 }
 
 /*******************************


### PR DESCRIPTION
Found this one out when testing Rainer's shared library support.

Doesn't look like the other object file formats have the same problem.