### PR TITLE
Fix issue 24179 - Fix line breaks in DDoc

### DIFF
--- a/compiler/src/dmd/res/default_ddoc_theme.ddoc
+++ b/compiler/src/dmd/res/default_ddoc_theme.ddoc
@@ -70,7 +70,7 @@ D_CODE =
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">$0</code></li>
+        <li><pre><code class="code">$0</code></pre></li>
       </ol>
     </div>
   </div>
@@ -81,7 +81,7 @@ OTHER_CODE =
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code language-$1">$+</code></li>
+        <li><pre><code class="code language-$1">$+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/src/dmd/res/default_ddoc_theme.ddoc
+++ b/compiler/src/dmd/res/default_ddoc_theme.ddoc
@@ -517,6 +517,10 @@ DDOC =
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc1.html
+++ b/compiler/test/compilable/extra-files/ddoc1.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc1.html
+++ b/compiler/test/compilable/extra-files/ddoc1.html
@@ -584,12 +584,12 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">#include &lt;stdio.h&gt;
+        <li><pre><code class="code">#include &lt;stdio.h&gt;
 <span class="keyword">void</span> main()
 {
 	printf(<span class="string_literal">"hello\n"</span>);
 }
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc10.html
+++ b/compiler/test/compilable/extra-files/ddoc10.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc10325.html
+++ b/compiler/test/compilable/extra-files/ddoc10325.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc10334.html
+++ b/compiler/test/compilable/extra-files/ddoc10334.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc10366.html
+++ b/compiler/test/compilable/extra-files/ddoc10366.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc10367.html
+++ b/compiler/test/compilable/extra-files/ddoc10367.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc10869.html
+++ b/compiler/test/compilable/extra-files/ddoc10869.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc10870.html
+++ b/compiler/test/compilable/extra-files/ddoc10870.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc11.html
+++ b/compiler/test/compilable/extra-files/ddoc11.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc11.html
+++ b/compiler/test/compilable/extra-files/ddoc11.html
@@ -1028,9 +1028,9 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">private</span>:
+        <li><pre><code class="code"><span class="keyword">private</span>:
     <span class="keyword">int</span> i = 0;
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc11479.html
+++ b/compiler/test/compilable/extra-files/ddoc11479.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc11511.html
+++ b/compiler/test/compilable/extra-files/ddoc11511.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc11823.html
+++ b/compiler/test/compilable/extra-files/ddoc11823.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc12.html
+++ b/compiler/test/compilable/extra-files/ddoc12.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc12706.html
+++ b/compiler/test/compilable/extra-files/ddoc12706.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc12745.html
+++ b/compiler/test/compilable/extra-files/ddoc12745.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc13.html
+++ b/compiler/test/compilable/extra-files/ddoc13.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc13270.html
+++ b/compiler/test/compilable/extra-files/ddoc13270.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc13645.html
+++ b/compiler/test/compilable/extra-files/ddoc13645.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc14.html
+++ b/compiler/test/compilable/extra-files/ddoc14.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc14383.html
+++ b/compiler/test/compilable/extra-files/ddoc14383.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc14383.html
+++ b/compiler/test/compilable/extra-files/ddoc14383.html
@@ -524,8 +524,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span> iShouldAppearInTheDocs;
-</code></li>
+        <li><pre><code class="code"><span class="keyword">int</span> iShouldAppearInTheDocs;
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc14413.html
+++ b/compiler/test/compilable/extra-files/ddoc14413.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc14778.html
+++ b/compiler/test/compilable/extra-files/ddoc14778.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc15475.html
+++ b/compiler/test/compilable/extra-files/ddoc15475.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc15475.html
+++ b/compiler/test/compilable/extra-files/ddoc15475.html
@@ -518,9 +518,9 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">   <span class="comment">// Computes the interval [x,y)
+        <li><pre><code class="code">   <span class="comment">// Computes the interval [x,y)
 </span>   <span class="keyword">auto</span> interval = computeInterval(x, y);
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -538,8 +538,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">(
-</code></li>
+        <li><pre><code class="code">(
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -550,8 +550,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">)
-</code></li>
+        <li><pre><code class="code">)
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -562,9 +562,9 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">    Here are some nested <span class="string_literal">`backticks`</span>
+        <li><pre><code class="code">    Here are some nested <span class="string_literal">`backticks`</span>
     <span class="comment">// Another interval [x,y)
-</span></code></li>
+</span></code></pre></li>
       </ol>
     </div>
   </div>
@@ -575,9 +575,9 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">    This won't end the code block: --- )
+        <li><pre><code class="code">    This won't end the code block: --- )
     <span class="comment">// Yet another interval [x,y)
-</span></code></li>
+</span></code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc17169.html
+++ b/compiler/test/compilable/extra-files/ddoc17169.html
@@ -379,6 +379,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc17697.html
+++ b/compiler/test/compilable/extra-files/ddoc17697.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc198.html
+++ b/compiler/test/compilable/extra-files/ddoc198.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc19814.html
+++ b/compiler/test/compilable/extra-files/ddoc19814.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc19814.html
+++ b/compiler/test/compilable/extra-files/ddoc19814.html
@@ -524,13 +524,13 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="comment">/**
+        <li><pre><code class="code"><span class="comment">/**
  * Examples:
  * --------------------
  * writeln("3"); // writes '3' to stdout
  * --------------------
  */</span>
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc2.html
+++ b/compiler/test/compilable/extra-files/ddoc2.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc2273.html
+++ b/compiler/test/compilable/extra-files/ddoc2273.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc3.html
+++ b/compiler/test/compilable/extra-files/ddoc3.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc3.html
+++ b/compiler/test/compilable/extra-files/ddoc3.html
@@ -551,10 +551,10 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">      <b>pragma</b>( <i>name</i> );
+        <li><pre><code class="code">      <b>pragma</b>( <i>name</i> );
       <b>pragma</b>( <i>name</i> , <i>option</i> [ <i>option</i> ] );
       <u>(</u>
-  </code></li>
+  </code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc4.html
+++ b/compiler/test/compilable/extra-files/ddoc4.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc4162.html
+++ b/compiler/test/compilable/extra-files/ddoc4162.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc5.html
+++ b/compiler/test/compilable/extra-files/ddoc5.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc5446.html
+++ b/compiler/test/compilable/extra-files/ddoc5446.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc6.html
+++ b/compiler/test/compilable/extra-files/ddoc6.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc648.html
+++ b/compiler/test/compilable/extra-files/ddoc648.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc6491.html
+++ b/compiler/test/compilable/extra-files/ddoc6491.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc7.html
+++ b/compiler/test/compilable/extra-files/ddoc7.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc7555.html
+++ b/compiler/test/compilable/extra-files/ddoc7555.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc7656.html
+++ b/compiler/test/compilable/extra-files/ddoc7656.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc7656.html
+++ b/compiler/test/compilable/extra-files/ddoc7656.html
@@ -542,9 +542,9 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span> x; <span class="comment">// This is a $ comment (and here is some
+        <li><pre><code class="code"><span class="keyword">int</span> x; <span class="comment">// This is a $ comment (and here is some
 </span><span class="keyword">int</span> y; <span class="comment">// more information about that comment)
-</span></code></li>
+</span></code></pre></li>
       </ol>
     </div>
   </div>
@@ -593,8 +593,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">assert</span>(<span class="psymbol">add</span>(1, 1) == 2);
-</code></li>
+        <li><pre><code class="code"><span class="keyword">assert</span>(<span class="psymbol">add</span>(1, 1) == 2);
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc7715.html
+++ b/compiler/test/compilable/extra-files/ddoc7715.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc7715.html
+++ b/compiler/test/compilable/extra-files/ddoc7715.html
@@ -543,8 +543,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">string s = <span class="string_literal">"$1$2 $ &amp;#36;4"</span>;
-</code></li>
+        <li><pre><code class="code">string s = <span class="string_literal">"$1$2 $ &amp;#36;4"</span>;
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc7795.html
+++ b/compiler/test/compilable/extra-files/ddoc7795.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc8.html
+++ b/compiler/test/compilable/extra-files/ddoc8.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc8271.html
+++ b/compiler/test/compilable/extra-files/ddoc8271.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc8739.html
+++ b/compiler/test/compilable/extra-files/ddoc8739.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9.html
+++ b/compiler/test/compilable/extra-files/ddoc9.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9037.html
+++ b/compiler/test/compilable/extra-files/ddoc9037.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9037.html
+++ b/compiler/test/compilable/extra-files/ddoc9037.html
@@ -543,8 +543,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">D d = d;
-</code></li>
+        <li><pre><code class="code">D d = d;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -554,8 +554,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">D d = d;
-</code></li>
+        <li><pre><code class="code">D d = d;
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc9155.html
+++ b/compiler/test/compilable/extra-files/ddoc9155.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9155.html
+++ b/compiler/test/compilable/extra-files/ddoc9155.html
@@ -551,7 +551,7 @@ test document note
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">import</span> std.stdio;   <span class="comment">//&amp;
+        <li><pre><code class="code"><span class="keyword">import</span> std.stdio;   <span class="comment">//&amp;
 </span>writeln(<span class="string_literal">"Hello world!"</span>);
 <span class="keyword">if</span> (test) {
   writefln(<span class="string_literal">"D programming language"</span>);
@@ -570,7 +570,7 @@ xxx;    <span class="comment">//comment
 <span class="keyword">uint</span> line = 0;
 <span class="comment">// The ElementType of data is not aggregation type
 </span><span class="keyword">foreach</span> (encoded; Base64.encoder(data))
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -581,10 +581,10 @@ xxx;    <span class="comment">//comment
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">wstring ws;
+        <li><pre><code class="code">wstring ws;
 transcode(<span class="string_literal">"hello world"</span>,ws);
     <span class="comment">// transcode from UTF-8 to UTF-16
-</span></code></li>
+</span></code></pre></li>
       </ol>
     </div>
   </div>
@@ -601,7 +601,7 @@ transcode(<span class="string_literal">"hello world"</span>,ws);
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">import</span> std.stdio;   <span class="comment">//&amp;
+        <li><pre><code class="code"><span class="keyword">import</span> std.stdio;   <span class="comment">//&amp;
 </span>writeln(<span class="string_literal">"Hello world!"</span>);
 <span class="keyword">if</span> (test) {
   writefln(<span class="string_literal">"D programming language"</span>);
@@ -614,7 +614,7 @@ xxx;    <span class="comment">//comment
 <span class="comment">/+ test
  + comment
  +/</span>
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -625,10 +625,10 @@ xxx;    <span class="comment">//comment
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">#!/usr/bin/env rdmd
+        <li><pre><code class="code">#!/usr/bin/env rdmd
 <span class="comment">// Computes average line length for standard input.
 </span><span class="keyword">import</span> std.stdio;
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -639,13 +639,13 @@ xxx;    <span class="comment">//comment
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">writefln(<span class="string_literal">q"EOS
+        <li><pre><code class="code">writefln(<span class="string_literal">q"EOS
 This
 is a multi-line
 heredoc string
 EOS"</span>
 );
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc9305.html
+++ b/compiler/test/compilable/extra-files/ddoc9305.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9369.html
+++ b/compiler/test/compilable/extra-files/ddoc9369.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9369.html
+++ b/compiler/test/compilable/extra-files/ddoc9369.html
@@ -543,11 +543,11 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">a=1;
+        <li><pre><code class="code">a=1;
 writeln(AddressOf!a);
 Exclamation
 QuestionMark
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc9475.html
+++ b/compiler/test/compilable/extra-files/ddoc9475.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9475.html
+++ b/compiler/test/compilable/extra-files/ddoc9475.html
@@ -548,13 +548,13 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="comment">// comment 1
+        <li><pre><code class="code"><span class="comment">// comment 1
 </span><span class="keyword">foreach</span> (i; 0 .. 10)
 {
     <span class="comment">// comment 2
 </span>    documentedFunction();
 }
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -601,8 +601,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="comment">// bar comment
-</span></code></li>
+        <li><pre><code class="code"><span class="comment">// bar comment
+</span></code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc9497a.html
+++ b/compiler/test/compilable/extra-files/ddoc9497a.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9497b.html
+++ b/compiler/test/compilable/extra-files/ddoc9497b.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9497c.html
+++ b/compiler/test/compilable/extra-files/ddoc9497c.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9497d.html
+++ b/compiler/test/compilable/extra-files/ddoc9497d.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9676a.html
+++ b/compiler/test/compilable/extra-files/ddoc9676a.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9676b.html
+++ b/compiler/test/compilable/extra-files/ddoc9676b.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9727.html
+++ b/compiler/test/compilable/extra-files/ddoc9727.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9727.html
+++ b/compiler/test/compilable/extra-files/ddoc9727.html
@@ -548,8 +548,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">foo</span>(1);
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">foo</span>(1);
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -565,8 +565,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">foo</span>(2);
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">foo</span>(2);
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -582,8 +582,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">foo</span>(3);
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">foo</span>(3);
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc9764.html
+++ b/compiler/test/compilable/extra-files/ddoc9764.html
@@ -379,6 +379,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9789.html
+++ b/compiler/test/compilable/extra-files/ddoc9789.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc9903.html
+++ b/compiler/test/compilable/extra-files/ddoc9903.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddocYear.html
+++ b/compiler/test/compilable/extra-files/ddocYear.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_breaks.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_breaks.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_breaks.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_breaks.html
@@ -530,8 +530,8 @@ Some text after
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">This <span class="keyword">is</span> a code block
-</code></li>
+        <li><pre><code class="code">This <span class="keyword">is</span> a code block
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc_markdown_breaks_verbose.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_breaks_verbose.html
@@ -420,6 +420,10 @@ compilable/ddoc_markdown_breaks_verbose.d(13): Ddoc: converted '***' to a themat
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_code.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_code.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_code.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_code.html
@@ -524,8 +524,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">A regular ol' code block (note the uneven delimiter lengths)
-</code></li>
+        <li><pre><code class="code">A regular ol' code block (note the uneven delimiter lengths)
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -536,8 +536,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">A backtick-fenced code block
-</code></li>
+        <li><pre><code class="code">A backtick-fenced code block
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -548,8 +548,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">A tilde-fenced code block
-</code></li>
+        <li><pre><code class="code">A tilde-fenced code block
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -560,8 +560,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">A hyphen-fenced D code block
-</code></li>
+        <li><pre><code class="code">A hyphen-fenced D code block
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -572,8 +572,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">A backtick-fenced D code block
-</code></li>
+        <li><pre><code class="code">A backtick-fenced D code block
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -584,8 +584,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">A tilde-fenced D code block
-</code></li>
+        <li><pre><code class="code">A tilde-fenced D code block
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -596,8 +596,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code language-ruby">A hyphen-fenced ruby code block
-</code></li>
+        <li><pre><code class="code language-ruby">A hyphen-fenced ruby code block
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -608,8 +608,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code language-ruby">A backtick-fenced ruby code block
-</code></li>
+        <li><pre><code class="code language-ruby">A backtick-fenced ruby code block
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -620,8 +620,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code language-ruby">A tilde-fenced ruby code block
-</code></li>
+        <li><pre><code class="code language-ruby">A tilde-fenced ruby code block
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc_markdown_code_verbose.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_code_verbose.html
@@ -418,6 +418,11 @@ compilable/ddoc_markdown_code_verbose.d(13): Ddoc: adding code block for languag
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_emphasis.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_emphasis.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_emphasis_verbose.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_emphasis_verbose.html
@@ -419,6 +419,10 @@ compilable/ddoc_markdown_emphasis_verbose.d(13): Ddoc: emphasized text 'strongly
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_escapes.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_escapes.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_escapes.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_escapes.html
@@ -528,8 +528,8 @@ But not in code:
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">\{\}
-</code></li>
+        <li><pre><code class="code">\{\}
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc_markdown_headings.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_headings.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
@@ -418,6 +418,10 @@ compilable/ddoc_markdown_headings_verbose.d(9): Ddoc: added heading 'Heading'
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_links.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_links.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_links_verbose.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_links_verbose.html
@@ -423,6 +423,10 @@ compilable/ddoc_markdown_links_verbose.d(17): Ddoc: linking '![D-Man](https://dl
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_lists.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_lists.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_lists.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_lists.html
@@ -530,8 +530,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="comment">// code in item one
-</span></code></li>
+        <li><pre><code class="code"><span class="comment">// code in item one
+</span></code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc_markdown_lists_verbose.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_lists_verbose.html
@@ -418,6 +418,10 @@ compilable/ddoc_markdown_lists_verbose.d(9): Ddoc: starting list item 'list item
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_quote.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_quote.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_quote.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_quote.html
@@ -557,8 +557,8 @@ with a continuation
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">is</span> ended by <span class="keyword">this</span> code
-</code></li>
+        <li><pre><code class="code"><span class="keyword">is</span> ended by <span class="keyword">this</span> code
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -571,8 +571,8 @@ with a continuation
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code">Some code
-</code></li>
+        <li><pre><code class="code">Some code
+</code></pre></li>
       </ol>
     </div>
   </div>

--- a/compiler/test/compilable/extra-files/ddoc_markdown_quote_verbose.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_quote_verbose.html
@@ -418,6 +418,10 @@ compilable/ddoc_markdown_quote_verbose.d(11): Ddoc: starting quote block with '>
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_tables.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_tables.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_tables_22285.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_tables_22285.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddoc_markdown_tables_verbose.html
+++ b/compiler/test/compilable/extra-files/ddoc_markdown_tables_verbose.html
@@ -418,6 +418,10 @@ compilable/ddoc_markdown_tables_verbose.d(13): Ddoc: formatting table '| this | 
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddocbackticks.html
+++ b/compiler/test/compilable/extra-files/ddocbackticks.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddocunittest.html
+++ b/compiler/test/compilable/extra-files/ddocunittest.html
@@ -417,6 +417,10 @@
         white-space: pre-wrap;
       }
 
+      .ddoc .code_lines pre {
+        display: contents;
+      }
+
       .ddoc .code_lines li:only-of-type::before {
         color: rgba(255, 255, 255, 1);
         content: " ";

--- a/compiler/test/compilable/extra-files/ddocunittest.html
+++ b/compiler/test/compilable/extra-files/ddocunittest.html
@@ -548,8 +548,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">assert</span>(<span class="psymbol">foo</span>(1, 1) == 2);
-</code></li>
+        <li><pre><code class="code"><span class="keyword">assert</span>(<span class="psymbol">foo</span>(1, 1) == 2);
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -596,9 +596,9 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="comment">// documented
+        <li><pre><code class="code"><span class="comment">// documented
 </span><span class="keyword">assert</span>(<span class="psymbol">bar</span>());
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -684,8 +684,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">assert</span>(<span class="psymbol">add</span>(1, 1) == 2);
-</code></li>
+        <li><pre><code class="code"><span class="keyword">assert</span>(<span class="psymbol">add</span>(1, 1) == 2);
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -700,10 +700,10 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="comment">// documented
+        <li><pre><code class="code"><span class="comment">// documented
 </span><span class="keyword">assert</span>(<span class="psymbol">add</span>(3, 3) == 6);
 <span class="keyword">assert</span>(<span class="psymbol">add</span>(4, 4) == 8);
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -718,10 +718,10 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="comment">// documented
+        <li><pre><code class="code"><span class="comment">// documented
 </span><span class="keyword">assert</span>(<span class="psymbol">add</span>(5, 5) == 10);
 <span class="keyword">assert</span>(<span class="psymbol">add</span>(6, 6) == 12);
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -768,8 +768,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">Foo</span> foo = <span class="keyword">new</span> <span class="psymbol">Foo</span>;
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">Foo</span> foo = <span class="keyword">new</span> <span class="psymbol">Foo</span>;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -816,8 +816,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">SomeClass</span> sc = <span class="keyword">new</span> <span class="psymbol">SomeClass</span>;
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">SomeClass</span> sc = <span class="keyword">new</span> <span class="psymbol">SomeClass</span>;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -864,8 +864,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">Outer</span> outer = <span class="keyword">new</span> <span class="psymbol">Outer</span>;
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">Outer</span> outer = <span class="keyword">new</span> <span class="psymbol">Outer</span>;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -910,8 +910,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">Inner</span> inner = <span class="keyword">new</span> <span class="psymbol">Inner</span>;
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">Inner</span> inner = <span class="keyword">new</span> <span class="psymbol">Inner</span>;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -996,8 +996,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">foo</span>(1);
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">foo</span>(1);
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1013,8 +1013,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">foo</span>(2);
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">foo</span>(2);
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1029,8 +1029,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">foo</span>(2);
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">foo</span>(2);
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1045,8 +1045,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">foo</span>(4);
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">foo</span>(4);
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1089,8 +1089,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fooImport</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fooImport</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1133,8 +1133,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fooStaticImport</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fooStaticImport</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1177,8 +1177,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fooSelectiveImport</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fooSelectiveImport</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1221,8 +1221,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fooRenamedImport</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fooRenamedImport</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1524,8 +1524,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span> x1a;
-</code></li>
+        <li><pre><code class="code"><span class="keyword">int</span> x1a;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1567,8 +1567,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span> x1b;
-</code></li>
+        <li><pre><code class="code"><span class="keyword">int</span> x1b;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1660,8 +1660,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span> x4a;
-</code></li>
+        <li><pre><code class="code"><span class="keyword">int</span> x4a;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1703,8 +1703,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span> x4b;
-</code></li>
+        <li><pre><code class="code"><span class="keyword">int</span> x4b;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1746,8 +1746,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span> x6a;
-</code></li>
+        <li><pre><code class="code"><span class="keyword">int</span> x6a;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1789,8 +1789,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span> x6b;
-</code></li>
+        <li><pre><code class="code"><span class="keyword">int</span> x6b;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1833,8 +1833,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">foo9474</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">foo9474</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1882,8 +1882,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">bar9474</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">bar9474</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1925,8 +1925,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">S9474</span> s;
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">S9474</span> s;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -1968,8 +1968,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span> v = <span class="psymbol">autovar9474</span>;
-</code></li>
+        <li><pre><code class="code"><span class="keyword">int</span> v = <span class="psymbol">autovar9474</span>;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2011,8 +2011,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span> n = <span class="psymbol">autofun9474</span>();
-</code></li>
+        <li><pre><code class="code"><span class="keyword">int</span> n = <span class="psymbol">autofun9474</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2053,8 +2053,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">alias</span> <span class="psymbol">Template9474</span>!() T;
-</code></li>
+        <li><pre><code class="code"><span class="keyword">alias</span> <span class="psymbol">Template9474</span>!() T;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2131,8 +2131,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fooNoDescription</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fooNoDescription</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2147,8 +2147,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">if</span> (<span class="keyword">true</span>) {<span class="psymbol">fooNoDescription</span>(); } <span class="comment">/* comment */</span>
-</code></li>
+        <li><pre><code class="code"><span class="keyword">if</span> (<span class="keyword">true</span>) {<span class="psymbol">fooNoDescription</span>(); } <span class="comment">/* comment */</span>
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2199,8 +2199,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">foo9757</span>(); <span class="psymbol">bar9757</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">foo9757</span>(); <span class="psymbol">bar9757</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2215,8 +2215,8 @@
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">bar9757</span>(); <span class="psymbol">foo9757</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">bar9757</span>(); <span class="psymbol">foo9757</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2267,11 +2267,11 @@ auto <code class="code">redBlackTree</code>(alias less, E)(E[] <code class="code
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">auto</span> rbt1 = <span class="psymbol">redBlackTree</span>(0, 1, 5, 7);
+        <li><pre><code class="code"><span class="keyword">auto</span> rbt1 = <span class="psymbol">redBlackTree</span>(0, 1, 5, 7);
 <span class="keyword">auto</span> rbt2 = <span class="psymbol">redBlackTree</span>!string(<span class="string_literal">"hello"</span>, <span class="string_literal">"world"</span>);
 <span class="keyword">auto</span> rbt3 = <span class="psymbol">redBlackTree</span>!<span class="keyword">true</span>(0, 1, 5, 7, 5);
 <span class="keyword">auto</span> rbt4 = <span class="psymbol">redBlackTree</span>!<span class="string_literal">"a &gt; b"</span>(0, 1, 5, 7);
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2350,9 +2350,9 @@ auto <code class="code">redBlackTree</code>(alias less, E)(E[] <code class="code
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">auto</span> s = <span class="string_literal">"1 + (2 * (3 + 1 / 2)"</span>;
+        <li><pre><code class="code"><span class="keyword">auto</span> s = <span class="string_literal">"1 + (2 * (3 + 1 / 2)"</span>;
 <span class="keyword">assert</span>(!<span class="psymbol">balancedParens10519</span>(s, '(', ')'));
-</code></li>
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2404,8 +2404,8 @@ auto <code class="code">redBlackTree</code>(alias less, E)(E[] <code class="code
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span> a = 1;
-</code></li>
+        <li><pre><code class="code"><span class="keyword">int</span> a = 1;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2421,8 +2421,8 @@ auto <code class="code">redBlackTree</code>(alias less, E)(E[] <code class="code
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="keyword">int</span>[] arr;
-</code></li>
+        <li><pre><code class="code"><span class="keyword">int</span>[] arr;
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2504,8 +2504,8 @@ auto <code class="code">redBlackTree</code>(alias less, E)(E[] <code class="code
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fun14594a</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fun14594a</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2554,8 +2554,8 @@ void <code class="code">fun14594b</code>(T)(T);
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fun14594b</span>(); <span class="psymbol">fun14594b</span>(1);
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fun14594b</span>(); <span class="psymbol">fun14594b</span>(1);
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2604,8 +2604,8 @@ void <code class="code">fun14594c</code>(T)(T);
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fun14594c</span>(); <span class="psymbol">fun14594c</span>(1);
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fun14594c</span>(); <span class="psymbol">fun14594c</span>(1);
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2654,8 +2654,8 @@ void <code class="code">fun14594d</code>(T)(T);
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fun14594d</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fun14594d</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2670,8 +2670,8 @@ void <code class="code">fun14594d</code>(T)(T);
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fun14594d</span>(1);
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fun14594d</span>(1);
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2726,8 +2726,8 @@ void <code class="code">fun14594d</code>(T)(T);
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fun14594e</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fun14594e</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>
@@ -2784,8 +2784,8 @@ void <code class="code">fun14594f</code>(T)(T);
   <div class="code_sample">
     <div class="dlang">
       <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fun14594f</span>();
-</code></li>
+        <li><pre><code class="code"><span class="psymbol">fun14594f</span>();
+</code></pre></li>
       </ol>
     </div>
   </div>


### PR DESCRIPTION
![image](https://github.com/dlang/dmd/assets/52950755/4db93956-ebfa-475c-a11a-2aeab0ca4969)
Left is with this PR; Right is without this PR
The tool is just `less`. I am not sure if the issue is actually associated with this, but it sounds a lot like Walter Bright faced the exact same issue as me.
I think this StackOverflow answer is pretty much what we are talking about here: https://stackoverflow.com/a/4611735