### PR TITLE
Shortcircuit mtype.Type._init call to typesem.merge()

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1537,7 +1537,7 @@ auto sourceFiles()
         "),
         frontend: fileArray(env["D"], "
             access.d aggregate.d aliasthis.d argtypes_x86.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d
-            arraytypes.d astenums.d ast_node.d astcodegen.d asttypename.d attrib.d blockexit.d builtin.d canthrow.d chkformat.d
+            arraytypes.d astenums.d ast_node.d astcodegen.d asttypename.d attrib.d basicmangle.d blockexit.d builtin.d canthrow.d chkformat.d
             cli.d clone.d compiler.d cond.d constfold.d cppmangle.d cppmanglewin.d cpreprocess.d ctfeexpr.d
             ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d dimport.d
             dinterpret.d dmacro.d dmangle.d dmodule.d doc.d dscope.d dstruct.d dsymbol.d dsymbolsem.d

--- a/compiler/src/dmd/README.md
+++ b/compiler/src/dmd/README.md
@@ -230,6 +230,7 @@ Note that these groups have no strict meaning, the category assignments are a bi
 |-----------------------------------------------------------------------------------|------------------------------------------------------------------|
 | [cppmangle.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/cppmangle.d)       | C++ name mangling                                                |
 | [cppmanglewin.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/cppmanglewin.d) | C++ name mangling for Windows                                    |
+| [basicmangle.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/basicmangle.d)   | D name mangling for basic types                                  |
 | [dmangle.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dmangle.d)           | D [name mangling](https://dlang.org/spec/abi.html#name_mangling) |
 
 ### Linking

--- a/compiler/src/dmd/basicmangle.d
+++ b/compiler/src/dmd/basicmangle.d
@@ -1,0 +1,109 @@
+/**
+ * Defines the building blocks for creating the mangled names for basic types.
+ *
+ * Copyright:   Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved
+ * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/basicmangle.d, _basicmangle.d)
+ * Documentation:  https://dlang.org/phobos/dmd_basicmangle.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/basicmangle.d
+ */
+module dmd.basicmangle;
+
+import dmd.astenums;
+import dmd.common.outbuffer : OutBuffer;
+
+/// Type mangling mapping for basic, derived and user defined types
+immutable char[TMAX] mangleChar =
+[
+    Tchar        : 'a',
+    Tbool        : 'b',
+    Tcomplex80   : 'c',
+    Tfloat64     : 'd',
+    Tfloat80     : 'e',
+    Tfloat32     : 'f',
+    Tint8        : 'g',
+    Tuns8        : 'h',
+    Tint32       : 'i',
+    Timaginary80 : 'j',
+    Tuns32       : 'k',
+    Tint64       : 'l',
+    Tuns64       : 'm',
+    Tnull        : 'n',
+    Timaginary32 : 'o',
+    Timaginary64 : 'p',
+    Tcomplex32   : 'q',
+    Tcomplex64   : 'r',
+    Tint16       : 's',
+    Tuns16       : 't',
+    Twchar       : 'u',
+    Tvoid        : 'v',
+    Tdchar       : 'w',
+    //              x   // const
+    //              y   // immutable
+    Tint128      : 'z', // zi
+    Tuns128      : 'z', // zk
+
+    Tarray       : 'A',
+    Ttuple       : 'B',
+    Tclass       : 'C',
+    Tdelegate    : 'D',
+    Tenum        : 'E',
+    Tfunction    : 'F', // D function
+    Tsarray      : 'G',
+    Taarray      : 'H',
+    //              I   // in
+    //              J   // out
+    //              K   // ref
+    //              L   // lazy
+    //              M   // has this, or scope
+    //              N   // Nh:vector Ng:wild Nn:noreturn
+    //              O   // shared
+    Tpointer     : 'P',
+    //              Q   // Type/symbol/identifier backward reference
+    Treference   : 'R',
+    Tstruct      : 'S',
+    //              T   // Ttypedef
+    //              U   // C function
+    //              W   // Windows function
+    //              X   // variadic T t...)
+    //              Y   // variadic T t,...)
+    //              Z   // not variadic, end of parameters
+
+    // '@' shouldn't appear anywhere in the deco'd names
+    Tnone        : '@',
+    Tident       : '@',
+    Tinstance    : '@',
+    Terror       : '@',
+    Ttypeof      : '@',
+    Tslice       : '@',
+    Treturn      : '@',
+    Tvector      : '@',
+    Ttraits      : '@',
+    Tmixin       : '@',
+    Ttag         : '@',
+    Tnoreturn    : '@',         // becomes 'Nn'
+];
+
+unittest
+{
+    foreach (i, mangle; mangleChar)
+    {
+        if (mangle == char.init)
+        {
+            import core.stdc.stdio;
+            fprintf(stderr, "ty = %u\n", cast(uint)i);
+            assert(0);
+        }
+    }
+}
+
+/***********************
+ * Mangle basic type ty to buf.
+ */
+void tyToDecoBuffer(ref OutBuffer buf, int ty) @safe
+{
+    const c = mangleChar[ty];
+    buf.writeByte(c);
+    if (c == 'z')
+        buf.writeByte(ty == Tint128 ? 'i' : 'k');
+}

--- a/compiler/src/dmd/dmangle.d
+++ b/compiler/src/dmd/dmangle.d
@@ -137,6 +137,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astenums;
+import dmd.basicmangle;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dinterpret;
@@ -160,89 +161,6 @@ import dmd.root.utf;
 import dmd.target;
 import dmd.tokens;
 import dmd.visitor;
-
-private immutable char[TMAX] mangleChar =
-[
-    Tchar        : 'a',
-    Tbool        : 'b',
-    Tcomplex80   : 'c',
-    Tfloat64     : 'd',
-    Tfloat80     : 'e',
-    Tfloat32     : 'f',
-    Tint8        : 'g',
-    Tuns8        : 'h',
-    Tint32       : 'i',
-    Timaginary80 : 'j',
-    Tuns32       : 'k',
-    Tint64       : 'l',
-    Tuns64       : 'm',
-    Tnull        : 'n',
-    Timaginary32 : 'o',
-    Timaginary64 : 'p',
-    Tcomplex32   : 'q',
-    Tcomplex64   : 'r',
-    Tint16       : 's',
-    Tuns16       : 't',
-    Twchar       : 'u',
-    Tvoid        : 'v',
-    Tdchar       : 'w',
-    //              x   // const
-    //              y   // immutable
-    Tint128      : 'z', // zi
-    Tuns128      : 'z', // zk
-
-    Tarray       : 'A',
-    Ttuple       : 'B',
-    Tclass       : 'C',
-    Tdelegate    : 'D',
-    Tenum        : 'E',
-    Tfunction    : 'F', // D function
-    Tsarray      : 'G',
-    Taarray      : 'H',
-    //              I   // in
-    //              J   // out
-    //              K   // ref
-    //              L   // lazy
-    //              M   // has this, or scope
-    //              N   // Nh:vector Ng:wild Nn:noreturn
-    //              O   // shared
-    Tpointer     : 'P',
-    //              Q   // Type/symbol/identifier backward reference
-    Treference   : 'R',
-    Tstruct      : 'S',
-    //              T   // Ttypedef
-    //              U   // C function
-    //              W   // Windows function
-    //              X   // variadic T t...)
-    //              Y   // variadic T t,...)
-    //              Z   // not variadic, end of parameters
-
-    // '@' shouldn't appear anywhere in the deco'd names
-    Tnone        : '@',
-    Tident       : '@',
-    Tinstance    : '@',
-    Terror       : '@',
-    Ttypeof      : '@',
-    Tslice       : '@',
-    Treturn      : '@',
-    Tvector      : '@',
-    Ttraits      : '@',
-    Tmixin       : '@',
-    Ttag         : '@',
-    Tnoreturn    : '@',         // becomes 'Nn'
-];
-
-unittest
-{
-    foreach (i, mangle; mangleChar)
-    {
-        if (mangle == char.init)
-        {
-            fprintf(stderr, "ty = %u\n", cast(uint)i);
-            assert(0);
-        }
-    }
-}
 
 /************************************************
  * Append the mangling of type `t` to `buf`.
@@ -1211,19 +1129,6 @@ private struct Backref
     Type rootType;                          /// avoid infinite recursion
     AssocArray!(Type, size_t) types;        /// Type => (offset+1) in buf
     AssocArray!(Identifier, size_t) idents; /// Identifier => (offset+1) in buf
-}
-
-
-/***********************
- * Mangle basic type ty to buf.
- */
-
-private void tyToDecoBuffer(ref OutBuffer buf, int ty) @safe
-{
-    const c = mangleChar[ty];
-    buf.writeByte(c);
-    if (c == 'z')
-        buf.writeByte(ty == Tint128 ? 'i' : 'k');
 }
 
 /*********************************

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -516,16 +516,39 @@ extern (C++) abstract class Type : ASTNode
             Terror
         ];
 
+        static Type merge(Type t)
+        {
+            import dmd.basicmangle : tyToDecoBuffer;
+
+            OutBuffer buf;
+            buf.reserve(3);
+
+            if (t.ty == Tnoreturn)
+                buf.writestring("Nn");
+            else
+                tyToDecoBuffer(buf, t.ty);
+
+            auto sv = t.stringtable.update(buf[]);
+            if (sv.value)
+                return sv.value;
+            else
+            {
+                t.deco = cast(char*)sv.toDchars();
+                sv.value = t;
+                return t;
+            }
+        }
+
         for (size_t i = 0; basetab[i] != Terror; i++)
         {
             Type t = new TypeBasic(basetab[i]);
-            t = t.merge();
+            t = merge(t);
             basic[basetab[i]] = t;
         }
         basic[Terror] = new TypeError();
 
         tnoreturn = new TypeNoreturn();
-        tnoreturn.deco = tnoreturn.merge().deco;
+        tnoreturn.deco = merge(tnoreturn).deco;
         basic[Tnoreturn] = tnoreturn;
 
         tvoid = basic[Tvoid];
@@ -560,7 +583,7 @@ extern (C++) abstract class Type : ASTNode
         terror = basic[Terror];
         tnoreturn = basic[Tnoreturn];
         tnull = new TypeNull();
-        tnull.deco = tnull.merge().deco;
+        tnull.deco = merge(tnull).deco;
 
         tvoidptr = tvoid.pointerTo();
         tstring = tchar.immutableOf().arrayOf();


### PR DESCRIPTION
This is done in the attempt to break the dependency of mtype.d on typesem.d. The _init method is called on type before anything else, therefore it should not depend on any semantic analysis, however, `merge` uses the mangler to get a mangled name for the type which is used as a unique identifier (and the mangler itself does some semantic/optimizations, therefore it cannot be imported in mtype.d).

To break the dependency, I used a shortcircuited version of the merge method that simply uses the mangle names for basic types. This allows us to break the dependency and also has the benefit of being faster (by avoiding all of the calls that the classic and complex `merge` function does). 

An alternative to this would be to move the initialization method outside of the Type class, however, that would be in stark contrast to the other initialization methods for other AST nodes (such as expression, module etc.).

I think that this alternative is better, at the cost of a small code duplication (a subset of the merge function) + moving a private array and a function that uses it to `astenums.d` so that it is usable from mtype.d without adding any indirect dependencies.