### PR TITLE
core.atomic: Reject invalid failure memory modules in compare exchange

### DIFF
--- a/changelog/druntime.coreatomic.dd
+++ b/changelog/druntime.coreatomic.dd
@@ -1,8 +1,79 @@
-Using an invalid MemoryOrder for core.atomic operations are now rejected at compile time
+Using an invalid MemoryOrder for `core.atomic` operations are now rejected at compile time
 
-The following core.atomic functions have become more restrictive:
-- atomicStore now rejects `MemoryOrder.acq_rel`. Previously it only rejected `MemoryOrder.acq`.
-- atomicLoad now rejects `MemoryOrder.acq_rel`. Previously it only rejected `MemoryOrder.rel`.
-- atomicExchange now rejects `MemoryOrder.acq`. Previously it accepted all MemoryOrders.
+The following `core.atomic` functions have become more restrictive:
 
-Code that previously used any of these MemoryOrders should switch to `MemoryOrder.seq` instead.
+1. `atomicLoad` and `atomicStore` now reject being instantiated with the
+argument `MemoryOrder.acq_rel`. Previously `atomicLoad` and `atomicStore` only
+rejected `MemoryOrder.rel` and `MemoryOrder.acq` respectively.
+
+In most cases, code that previously used `MemoryOrder.acq_rel` should switch to
+use `MemoryOrder.seq` instead.
+
+---
+// Error:
+atomicLoad!(MemoryOrder.acq_rel)(src);
+atomicStore!(MemoryOrder.acq_rel)(dest, value);
+
+// Corrective action:
+atomicLoad!(MemoryOrder.seq)(src);
+atomicStore!(MemoryOrder.seq)(dest, value);
+
+// Or:
+atomicLoad(src);
+atomicStore(dest, value);
+---
+
+2. `atomicExchange` now rejects being instantiated with the argument
+`MemoryOrder.acq`.
+
+In most cases, code that previously used `MemoryOrder.acq` should switch to use
+`MemoryOrder.seq` instead.
+
+---
+// Error:
+atomicExchange!(MemoryOrder.acq)(dest, value);
+
+// Corrective action:
+atomicExchange!(MemoryOrder.seq)(dest, value);
+
+// Or:
+atomicExchange(dest, value);
+---
+
+3. `atomicCompareExchangeWeak` and `atomicCompareExchangeStrong` now reject
+being instantiated when the second `fail` argument is `MemoryOrder.rel` or
+`MemoryOrder.acq_rel`.
+
+In most cases, code that previously used either of these should switch to use
+`MemoryOrder.raw` instead.
+
+---
+// Error:
+atomicExchangeWeak!(MemoryOrder.rel, MemoryOrder.rel)(dest, compare, value);
+atomicExchangeWeakNoResult!(MemoryOrder.acq_rel, MemoryOrder.acq_rel)(dest, compare, value);
+atomicExchangeStrong!(MemoryOrder.acq, MemoryOrder.rel)(dest, compare, value);
+atomicExchangeStrongNoResult!(MemoryOrder.seq, MemoryOrder.acq_rel)(dest, compare, value);
+
+// Corrective action:
+atomicExchangeWeak!(MemoryOrder.rel, MemoryOrder.raw)(dest, compare, value);
+atomicExchangeWeakNoResult!(MemoryOrder.acq_rel, MemoryOrder.raw)(dest, compare, value);
+atomicExchangeStrong!(MemoryOrder.acq, MemoryOrder.raw)(dest, compare, value);
+atomicExchangeStrongNoResult!(MemoryOrder.seq, MemoryOrder.raw)(dest, compare, value);
+---
+
+4. `atomicCompareExchangeWeak` and `atomicCompareExchangeStrong` additionally
+now reject being instantiated when the second `fail` argument has a greater
+value than its first `succ` argument.
+
+In most cases, code that violates this contract should use the same MemoryOrder
+for both `succ` and `fail` arguments.
+
+---
+// Error:
+atomicExchangeWeak!(MemoryOrder.raw)(dest, compare, value);
+atomicExchangeStrong!(MemoryOrder.acq, MemoryOrder.seq)(dest, compare, value);
+
+// Corrective action:
+atomicExchangeWeak!(MemoryOrder.raw, MemoryOrder.raw)(dest, compare, value);
+atomicExchangeStrong!(MemoryOrder.acq, MemoryOrder.acq)(dest, compare, value);
+---

--- a/druntime/src/core/stdc/stdatomic.d
+++ b/druntime/src/core/stdc/stdatomic.d
@@ -586,84 +586,23 @@ unittest
 
 ///
 pragma(inline, true)
-bool atomic_compare_exchange_strong_explicit_impl(A, C)(shared(A)* obj, A* expected, C desired, memory_order succ, memory_order fail) @trusted
+bool atomic_compare_exchange_strong_explicit_impl(A, C)(shared(A)* obj, A* expected, C desired, memory_order succ, memory_order /*fail*/) @trusted
 {
     assert(obj !is null);
-    // We use these giant switch inside switch statements
-    //  because as of 2023 they are capable of being for the most part inlined by gdc & ldc when using literal arguments for memory_order.
+    // NOTE: To not have to deal with all invalid cases, the failure model is ignored for now.
 
     final switch(succ)
     {
         case memory_order.memory_order_relaxed:
-            final switch(fail)
-            {
-                case memory_order.memory_order_relaxed:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_relaxed, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acquire:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_relaxed, memory_order.memory_order_acquire)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_release:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_relaxed, memory_order.memory_order_release)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acq_rel:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_relaxed, memory_order.memory_order_acq_rel)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_seq_cst:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_relaxed, memory_order.memory_order_seq_cst)(cast(A*)obj, expected, cast(A)desired);
-            }
+            return atomicCompareExchangeStrong!(memory_order.memory_order_relaxed, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
         case memory_order.memory_order_acquire:
-            final switch(fail)
-            {
-                case memory_order.memory_order_relaxed:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_acquire, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acquire:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_acquire, memory_order.memory_order_acquire)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_release:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_acquire, memory_order.memory_order_release)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acq_rel:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_acquire, memory_order.memory_order_acq_rel)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_seq_cst:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_acquire, memory_order.memory_order_seq_cst)(cast(A*)obj, expected, cast(A)desired);
-            }
+            return atomicCompareExchangeStrong!(memory_order.memory_order_acquire, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
         case memory_order.memory_order_release:
-            final switch(fail)
-            {
-                case memory_order.memory_order_relaxed:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_release, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acquire:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_release, memory_order.memory_order_acquire)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_release:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_release, memory_order.memory_order_release)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acq_rel:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_release, memory_order.memory_order_acq_rel)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_seq_cst:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_release, memory_order.memory_order_seq_cst)(cast(A*)obj, expected, cast(A)desired);
-            }
+            return atomicCompareExchangeStrong!(memory_order.memory_order_release, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
         case memory_order.memory_order_acq_rel:
-            final switch(fail)
-            {
-                case memory_order.memory_order_relaxed:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_acq_rel, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acquire:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_acq_rel, memory_order.memory_order_acquire)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_release:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_acq_rel, memory_order.memory_order_release)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acq_rel:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_acq_rel, memory_order.memory_order_acq_rel)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_seq_cst:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_acq_rel, memory_order.memory_order_seq_cst)(cast(A*)obj, expected, cast(A)desired);
-            }
+            return atomicCompareExchangeStrong!(memory_order.memory_order_acq_rel, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
         case memory_order.memory_order_seq_cst:
-            final switch(fail)
-            {
-                case memory_order.memory_order_relaxed:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_seq_cst, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acquire:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_seq_cst, memory_order.memory_order_acquire)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_release:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_seq_cst, memory_order.memory_order_release)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acq_rel:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_seq_cst, memory_order.memory_order_acq_rel)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_seq_cst:
-                    return atomicCompareExchangeStrong!(memory_order.memory_order_seq_cst, memory_order.memory_order_seq_cst)(cast(A*)obj, expected, cast(A)desired);
-            }
+            return atomicCompareExchangeStrong!(memory_order.memory_order_seq_cst, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
     }
 }
 
@@ -677,84 +616,23 @@ unittest
 
 ///
 pragma(inline, true)
-bool atomic_compare_exchange_weak_explicit_impl(A, C)(shared(A)* obj, A* expected, C desired, memory_order succ, memory_order fail) @trusted
+bool atomic_compare_exchange_weak_explicit_impl(A, C)(shared(A)* obj, A* expected, C desired, memory_order succ, memory_order /*fail*/) @trusted
 {
     assert(obj !is null);
-    // We use these giant switch inside switch statements
-    //  because as of 2023 they are capable of being for the most part inlined by gdc & ldc when using literal arguments for memory_order.
+    // NOTE: To not have to deal with all invalid cases, the failure model is ignored for now.
 
     final switch(succ)
     {
         case memory_order.memory_order_relaxed:
-            final switch(fail)
-            {
-                case memory_order.memory_order_relaxed:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_relaxed, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acquire:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_relaxed, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_release:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_relaxed, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acq_rel:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_relaxed, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_seq_cst:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_relaxed, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-            }
+            return atomicCompareExchangeWeak!(memory_order.memory_order_relaxed, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
         case memory_order.memory_order_acquire:
-            final switch(fail)
-            {
-                case memory_order.memory_order_relaxed:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_acquire, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acquire:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_acquire, memory_order.memory_order_acquire)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_release:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_acquire, memory_order.memory_order_release)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acq_rel:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_acquire, memory_order.memory_order_acq_rel)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_seq_cst:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_acquire, memory_order.memory_order_seq_cst)(cast(A*)obj, expected, cast(A)desired);
-            }
+            return atomicCompareExchangeWeak!(memory_order.memory_order_acquire, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
         case memory_order.memory_order_release:
-            final switch(fail)
-            {
-                case memory_order.memory_order_relaxed:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_release, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acquire:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_release, memory_order.memory_order_acquire)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_release:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_release, memory_order.memory_order_release)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acq_rel:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_release, memory_order.memory_order_acq_rel)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_seq_cst:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_release, memory_order.memory_order_seq_cst)(cast(A*)obj, expected, cast(A)desired);
-            }
+            return atomicCompareExchangeWeak!(memory_order.memory_order_release, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
         case memory_order.memory_order_acq_rel:
-            final switch(fail)
-            {
-                case memory_order.memory_order_relaxed:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_acq_rel, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acquire:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_acq_rel, memory_order.memory_order_acquire)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_release:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_acq_rel, memory_order.memory_order_release)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acq_rel:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_acq_rel, memory_order.memory_order_acq_rel)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_seq_cst:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_acq_rel, memory_order.memory_order_seq_cst)(cast(A*)obj, expected, cast(A)desired);
-            }
+            return atomicCompareExchangeWeak!(memory_order.memory_order_acq_rel, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
         case memory_order.memory_order_seq_cst:
-            final switch(fail)
-            {
-                case memory_order.memory_order_relaxed:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acquire:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_acquire)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_release:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_release)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_acq_rel:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_acq_rel)(cast(A*)obj, expected, cast(A)desired);
-                case memory_order.memory_order_seq_cst:
-                    return atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_seq_cst)(cast(A*)obj, expected, cast(A)desired);
-            }
+            return atomicCompareExchangeWeak!(memory_order.memory_order_seq_cst, memory_order.memory_order_relaxed)(cast(A*)obj, expected, cast(A)desired);
     }
 }
 
@@ -1014,7 +892,7 @@ A atomic_fetch_op(memory_order order, string op, A, M)(A* obj, M arg) @trusted
         {
             set = get;
             mixin("set " ~ op ~ " arg;"); // will error if op (which is not exposed to user) is invalid
-        } while (!atomicCompareExchangeWeak!(order, order)(obj, &get, set));
+        } while (!atomicCompareExchangeWeak!(order, MemoryOrder.raw)(obj, &get, set));
         return get; // unlike core.atomic we return the prior value, not the new one.
     }
 }


### PR DESCRIPTION
- Rejects MemoryOrder.rel and MemoryOrder.acq_rel as the `fail` argument in atomicCompareExchangeStrong and atomicCompareExchangeWeak.
- Rejects `fail` argument having a stronger value than the `succ` memory model.

These are rejected as invalid memory models if ever encountered compiling with GDC or LDC, so make it also rejected by druntime atomics.

I give up trying to make stdatomics handle the invalid cases nicely for `atomic_compare_exchange`, there's too much code expansion, and the overwhelming majority of them are considered invalid anyway*, so let's just ignore `fail` models for now.

FYI @rikkimax [this](https://github.com/ibuclaw/dmd/commit/9fc3d36ea9caf08c4b1eb613c7a8fb4c667a5527) is what #15996 should look like after rebasing on-top of this PR.

@kinke - I don't _think_ you should be seeing any warnings anymore, as all cases gdc complained about are now removed.

(*Of the 25 total combinations, only  `relaxed, relaxed`, `acquire, relaxed`, `acquire, acquire`, `release, relaxed`, `release, acquire`, `acq_rel, relaxed`, `acq_rel, acquire`, `seq_cst, relaxed`, `seq_cst, acquire`, `seq_cst, seq_cst`).