### PR TITLE
core.internal.dassert: Remove top-level import of core.atomic.

### DIFF
--- a/druntime/src/core/internal/dassert.d
+++ b/druntime/src/core/internal/dassert.d
@@ -180,6 +180,8 @@ private string miniFormat(V)(const scope ref V v)
     /// `shared` values are formatted as their base type
     static if (is(V == shared T, T))
     {
+        import core.atomic : atomicLoad;
+
         // Use atomics to avoid race conditions whenever possible
         static if (__traits(compiles, atomicLoad(v)))
         {
@@ -471,11 +473,6 @@ private bool[] calcFieldOverlap(const scope size_t[] offsets)
 
     return overlaps;
 }
-
-// This should be a local import in miniFormat but fails with a cyclic dependency error
-// core.thread.osthread -> core.time -> object -> core.internal.array.capacity
-// -> core.atomic -> core.thread -> core.thread.osthread
-import core.atomic : atomicLoad;
 
 /// Negates a comparison token, e.g. `==` is mapped to `!=`
 private string invertCompToken(scope string comp) pure nothrow @nogc @safe


### PR DESCRIPTION
Make it a local import to miniFormat, as the cyclic dependency described in the comment was almost certainly fixed by #14678.

This potentially removes 2-3 module imports from every D compilation if they don't use said imports.

To confirm, benchmarking `dmd -c empty_file.d`
```
Benchmark 1: master/dmd empty.d -c
  Time (mean ± σ):      56.3 ms ±   5.2 ms    [User: 20.5 ms, System: 34.6 ms]
  Range (min … max):    50.7 ms …  68.4 ms    10 runs

Benchmark 2: remove_toplevel_imports/dmd empty.d -c
  Time (mean ± σ):      52.3 ms ±   6.0 ms    [User: 17.0 ms, System: 34.9 ms]
  Range (min … max):    45.2 ms …  61.1 ms    10 runs
```
