### PR TITLE
typinf.h: Remove unused forward declarations

### DIFF
--- a/compiler/src/dmd/typinf.h
+++ b/compiler/src/dmd/typinf.h
@@ -15,8 +15,6 @@
 class Expression;
 class Type;
 struct Scope;
-class FuncDeclaration;
-class ScopeDsymbol;
 
 bool genTypeInfo(Expression *e, const Loc &loc, Type *torig, Scope *sc);
 Type *getTypeInfoType(const Loc &loc, Type *t, Scope *sc, bool genObjCode = true);


### PR DESCRIPTION
Self explanatory.