### PR TITLE
use buf in toCharsMaybeConstraints()

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1458,8 +1458,7 @@ public:
     bool hasStaticCtorOrDtor() override;
     const char* kind() const override;
     const char* toChars() const override;
-    const char* toCharsNoConstraints() const;
-    const char* toCharsMaybeConstraints(bool includeConstraints) const;
+    void toCharsMaybeConstraints(bool includeConstraints, OutBuffer& buf) const;
     Visibility visible() override;
     const char* getConstraintEvalError(const char*& tip);
     Scope* scopeForTemplateParameters(TemplateInstance* ti, Scope* sc);

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -3574,7 +3574,9 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
 
             if (!print)
                 return true;
-            const tmsg = td.toCharsNoConstraints();
+            OutBuffer buf;
+            td.toCharsMaybeConstraints(false, buf);
+            const tmsg = buf.peekChars();
             const cmsg = td.getConstraintEvalError(constraintsTip);
 
             // add blank space if there are multiple candidates


### PR DESCRIPTION
Eliminates redundant toCharsNoConstraints().

The memory used for the generated string is now recycled rather than leaked. This is part of a general theme that memory management should be pushed up the call stack, not leave it at the bottom.