### PR TITLE
Address review comments for class name signature support

### DIFF
--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -234,7 +234,8 @@ struct ClassFlags
         hasTypeInfo = 0x20,
         isAbstract = 0x40,
         isCPPclass = 0x80,
-        hasDtor = 0x100
+        hasDtor = 0x100,
+        hasNameSig = 0x200,
     };
 };
 

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -123,6 +123,7 @@ extern (C++) struct BaseClass
     }
 }
 
+// These must match the values in druntime/src/object.d
 enum ClassFlags : uint
 {
     none          = 0x0,
@@ -135,6 +136,7 @@ enum ClassFlags : uint
     isAbstract    = 0x40,
     isCPPclass    = 0x80,
     hasDtor       = 0x100,
+    hasNameSig    = 0x200,
 }
 
 /***********************************************************

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1320,6 +1320,7 @@ enum class ClassFlags : uint32_t
     isAbstract = 64u,
     isCPPclass = 128u,
     hasDtor = 256u,
+    hasNameSig = 512u,
 };
 
 struct MatchAccumulator final

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -1225,7 +1225,8 @@ private void genClassInfoForClass(ClassDeclaration cd, Symbol* sinit)
         if (Type.typeinfoclass.structsize != target.classinfosize)
         {
             debug printf("target.classinfosize = x%x, Type.typeinfoclass.structsize = x%x\n", target.classinfosize, Type.typeinfoclass.structsize);
-            .error(cd.loc, "%s `%s` mismatch between dmd and object.d or object.di found. Check installation and import paths with -v compiler switch.", cd.kind, cd.toPrettyChars);
+            .error(cd.loc, "%s `%s` mismatch between compiler (%d bytes) and object.d or object.di (%d bytes) found. Check installation and import paths with -v compiler switch.",
+                   cd.kind, cd.toPrettyChars, cast(uint)target.classinfosize, cast(uint)Type.typeinfoclass.structsize);
             fatal();
         }
     }
@@ -1264,10 +1265,10 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
             void* deallocator;
             OffsetTypeInfo[] offTi;
             void function(Object) defaultConstructor;
-            ulong[2] nameSig;
             //const(MemberInfo[]) function(string) xgetMembers;   // module getMembers() function
             immutable(void)* m_RTInfo;
             //TypeInfo typeinfo;
+            uint[4] nameSig;
        }
      */
     uint offset = target.classinfosize;    // must be ClassInfo.size
@@ -1338,6 +1339,7 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
     if (cd.isCPPclass()) flags |= ClassFlags.isCPPclass;
     flags |= ClassFlags.hasGetMembers;
     flags |= ClassFlags.hasTypeInfo;
+    flags |= ClassFlags.hasNameSig;
     if (cd.ctor)
         flags |= ClassFlags.hasCtor;
     for (ClassDeclaration pc = cd; pc; pc = pc.baseClass)
@@ -1390,17 +1392,6 @@ Louter:
     else
         dtb.size(0);
 
-    // ulong[2] nameSig
-    {
-        import dmd.common.md5;
-        MD5_CTX mdContext = void;
-        MD5Init(&mdContext);
-        MD5Update(&mdContext, cast(ubyte*)name, cast(uint)namelen);
-        MD5Final(&mdContext);
-        assert(mdContext.digest.length == 16);
-        dtb.nbytes(16, cast(char*)mdContext.digest.ptr);
-    }
-
     // m_RTInfo
     if (cd.getRTInfo)
         Expression_toDt(cd.getRTInfo, dtb);
@@ -1410,6 +1401,17 @@ Louter:
         dtb.size(1);
 
     //dtb.xoff(toSymbol(cd.type.vtinfo), 0, TYnptr); // typeinfo
+
+    // uint[4] nameSig
+    {
+        import dmd.common.md5;
+        MD5_CTX mdContext = void;
+        MD5Init(&mdContext);
+        MD5Update(&mdContext, cast(ubyte*)name, cast(uint)namelen);
+        MD5Final(&mdContext);
+        assert(mdContext.digest.length == 16);
+        dtb.nbytes(16, cast(char*)mdContext.digest.ptr);
+    }
 
     //////////////////////////////////////////////
 
@@ -1522,10 +1524,10 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
             void* deallocator;
             OffsetTypeInfo[] offTi;
             void function(Object) defaultConstructor;
-            ulong[2] nameSig;
             //const(MemberInfo[]) function(string) xgetMembers;   // module getMembers() function
             immutable(void)* m_RTInfo;
             //TypeInfo typeinfo;
+            uint[4] nameSig;
        }
      */
     if (auto tic = Type.typeinfoclass)
@@ -1563,7 +1565,8 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
         {
             if (Type.typeinfoclass.structsize != offset)
             {
-                .error(id.loc, "%s `%s` mismatch between dmd and object.d or object.di found. Check installation and import paths with -v compiler switch.", id.kind, id.toPrettyChars);
+                .error(id.loc, "%s `%s` mismatch between compiler (%d bytes) and object.d or object.di (%d bytes) found. Check installation and import paths with -v compiler switch.",
+                       id.kind, id.toPrettyChars, cast(uint)offset, cast(uint)Type.typeinfoclass.structsize);
                 fatal();
             }
         }
@@ -1587,6 +1590,7 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
     // flags
     ClassFlags flags = ClassFlags.hasOffTi | ClassFlags.hasTypeInfo;
     if (id.isCOMinterface()) flags |= ClassFlags.isCOMclass;
+    flags |= ClassFlags.hasNameSig;
     dtb.size(flags); // depth part is 0
 
     // deallocator
@@ -1599,17 +1603,6 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
     // defaultConstructor
     dtb.size(0);
 
-    // ulong[2] nameSig
-    {
-        import dmd.common.md5;
-        MD5_CTX mdContext = void;
-        MD5Init(&mdContext);
-        MD5Update(&mdContext, cast(ubyte*)name, cast(uint)namelen);
-        MD5Final(&mdContext);
-        assert(mdContext.digest.length == 16);
-        dtb.nbytes(16, cast(char*)mdContext.digest.ptr);
-    }
-
     // xgetMembers
     //dtb.size(0);
 
@@ -1620,6 +1613,17 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
         dtb.size(0);       // no pointers
 
     //dtb.xoff(toSymbol(id.type.vtinfo), 0, TYnptr); // typeinfo
+
+    // uint[4] nameSig
+    {
+        import dmd.common.md5;
+        MD5_CTX mdContext = void;
+        MD5Init(&mdContext);
+        MD5Update(&mdContext, cast(ubyte*)name, cast(uint)namelen);
+        MD5Final(&mdContext);
+        assert(mdContext.digest.length == 16);
+        dtb.nbytes(16, cast(char*)mdContext.digest.ptr);
+    }
 
     //////////////////////////////////////////////
 

--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -1667,10 +1667,11 @@ class TypeInfo_Class : TypeInfo
     void*      deallocator;
     OffsetTypeInfo[] m_offTi;
     void function(Object) defaultConstructor;   // default Constructor
-    ulong[2] nameSig;            /// unique signature for `name`
 
     immutable(void)* m_RTInfo;        // data for precise GC
     override @property immutable(void)* rtInfo() const { return m_RTInfo; }
+
+    uint[4] nameSig;            /// unique signature for `name`
 
     /**
      * Search all modules for TypeInfo_Class corresponding to classname.

--- a/druntime/src/rt/cast_.d
+++ b/druntime/src/rt/cast_.d
@@ -24,11 +24,18 @@ pure:
 extern (D) private bool areClassInfosEqual(scope const ClassInfo a, scope const ClassInfo b) @safe
 {
     // same class if signatures match, works with potential duplicates across binaries
-    return a is b ||
-        (a.m_flags & TypeInfo_Class.ClassFlags.hasNameSig
-        ? (a.nameSig[0] == b.nameSig[0] &&
-           a.nameSig[1] == b.nameSig[1])  // new fast way
-        : (a is b || a.name == b.name));  // old slow way for temporary binary compatibility
+    if (a is b)
+        return true;
+
+    // new fast way
+    if (a.m_flags & TypeInfo_Class.ClassFlags.hasNameSig)
+        return a.nameSig[0] == b.nameSig[0]
+            && a.nameSig[1] == b.nameSig[1]
+            && a.nameSig[2] == b.nameSig[2]
+            && a.nameSig[3] == b.nameSig[3];
+
+    // old slow way for temporary binary compatibility
+    return a.name == b.name;
 }
 
 /******************************************


### PR DESCRIPTION
- Split up the complex conditional expression.
- The second `a is b` condition is always false.
- Move nameSig to the end of the record to not break code using old layout.
- The "fast way" was never being executed.