### PR TITLE
core.stdc.stdatomic: Do nothing for atomic fence with relaxed memory orders

### DIFF
--- a/druntime/src/core/stdc/stdatomic.d
+++ b/druntime/src/core/stdc/stdatomic.d
@@ -273,7 +273,7 @@ void atomic_signal_fence_impl()(memory_order order)
     final switch (order)
     {
         case memory_order.memory_order_relaxed:
-            atomicSignalFence!(memory_order.memory_order_relaxed);
+            // This is a no-op operation for relaxed memory orders.
             break;
 
         case memory_order.memory_order_acquire:
@@ -307,7 +307,7 @@ void atomic_thread_fence_impl()(memory_order order)
     final switch (order)
     {
         case memory_order.memory_order_relaxed:
-            atomicFence!(memory_order.memory_order_relaxed);
+            // This is a no-op operation for relaxed memory orders.
             break;
 
         case memory_order.memory_order_acquire:


### PR DESCRIPTION
This is really for the benefit of LDC only, where LLVM flags such calls as invalid.. GDC already treats this as a no-op if seen, and DMD ignores the memory order.

FYI @kinke @rikkimax 