### PR TITLE
Implement C-style atomic alignment rules for shared types

### DIFF
--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -5060,7 +5060,7 @@ extern (C++) final class TypeStruct : Type
     override uint alignsize()
     {
         sym.size(Loc.initial); // give error for forward references
-        return sym.alignsize;
+        return target.alignsize(this);
     }
 
     override TypeStruct syntaxCopy()


### PR DESCRIPTION
@kinke this is trivially done.  As it's target-specific, I'm not keen on adding tests for it.

```
struct S
{
    size_t[2] values;
}

struct T
{
    shared(S) field;
}
pragma(msg, S.alignof);           // 8u
pragma(msg, shared(S).alignof);   // 16u
```

In C, `_Atomic` overrides any explicit alignment too, however I don't think we should follow _that_ example, so `align(8) struct S` still has an alignment of 8 when it is qualified `shared`.