### PR TITLE
core.internal.atomic: Fix atomicLoad for N sized atomic types

### DIFF
--- a/druntime/src/core/internal/atomic.d
+++ b/druntime/src/core/internal/atomic.d
@@ -642,7 +642,7 @@ else version (GNU)
             else static if (GNU_Have_LibAtomic)
             {
                 T value;
-                __atomic_load(T.sizeof, cast(shared)src, &value, order);
+                __atomic_load(T.sizeof, cast(shared)src, cast(void*)&value, order);
                 return *cast(typeof(return)*)&value;
             }
             else


### PR DESCRIPTION
Unlike all other fallback paths to libatomic in this module, `atomicLoad` was missing a cast to `void*`.