### PR TITLE
add funcsem.d for function semantics

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1541,7 +1541,7 @@ auto sourceFiles()
             cli.d clone.d compiler.d cond.d constfold.d cppmangle.d cppmanglewin.d cpreprocess.d ctfeexpr.d
             ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d dimport.d
             dinterpret.d dmacro.d dmangle.d dmodule.d doc.d dscope.d dstruct.d dsymbol.d dsymbolsem.d
-            dtemplate.d dtoh.d dversion.d escape.d expression.d expressionsem.d func.d hdrgen.d impcnvtab.d
+            dtemplate.d dtoh.d dversion.d escape.d expression.d expressionsem.d func.d funcsem.d hdrgen.d impcnvtab.d
             imphint.d importc.d init.d initsem.d inline.d inlinecost.d intrange.d json.d lambdacomp.d
             mtype.d mustuse.d nogc.d nspace.d ob.d objc.d opover.d optimize.d
             parse.d parsetimevisitor.d permissivevisitor.d postordervisitor.d printast.d rootobject.d safe.d sapply.d

--- a/compiler/src/dmd/README.md
+++ b/compiler/src/dmd/README.md
@@ -110,6 +110,7 @@ Note that these groups have no strict meaning, the category assignments are a bi
 | File                                                                                      | Purpose                                                           |
 |-------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
 | [dsymbolsem.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/dsymbolsem.d)             | Do semantic 1 pass (symbol identifiers/types)                     |
+| [funcsem.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/funcsem.d)                   | Function semantics                                                                                               |
 | [semantic2.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/semantic2.d)               | Do semantic 2 pass (symbol initializers)                          |
 | [semantic3.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/semantic3.d)               | Do semantic 3 pass (function bodies)                              |
 | [inline.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/inline.d)                     | Do inline pass (optimization pass that dmd does in the front-end) |

--- a/compiler/src/dmd/clone.d
+++ b/compiler/src/dmd/clone.d
@@ -27,6 +27,7 @@ import dmd.errors;
 import dmd.expression;
 import dmd.expressionsem;
 import dmd.func;
+import dmd.funcsem;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
@@ -905,7 +906,7 @@ void buildDtors(AggregateDeclaration ad, Scope* sc)
                 a.addMember(sc, ad); // temporarily add to symbol table
             }
 
-            FuncDeclaration.functionSemantic(sdv.dtor);
+            functionSemantic(sdv.dtor);
 
             stc = mergeFuncAttrs(stc, sdv.dtor);
             if (stc & STC.disable)
@@ -1154,7 +1155,7 @@ private DtorDeclaration buildExternDDtor(AggregateDeclaration ad, Scope* sc)
     ad.members.push(func);
     func.addMember(sc2, ad);
     func.dsymbolSemantic(sc2);
-    FuncDeclaration.functionSemantic(func); // to infer attributes
+    functionSemantic(func); // to infer attributes
 
     sc2.pop();
     return func;
@@ -1336,7 +1337,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         // perform semantic on the member postblit in order to
         // be able to aggregate it later on with the rest of the
         // postblits
-        FuncDeclaration.functionSemantic(sdv.postblit);
+        functionSemantic(sdv.postblit);
 
         stc = mergeFuncAttrs(stc, sdv.postblit);
         stc = mergeFuncAttrs(stc, sdv.dtor);
@@ -1401,7 +1402,7 @@ FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
          */
         if (sdv.dtor)
         {
-            FuncDeclaration.functionSemantic(sdv.dtor);
+            functionSemantic(sdv.dtor);
 
             // keep a list of fields that need to be destroyed in case
             // of a future postblit failure

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -30,6 +30,8 @@ class StructDeclaration;
 struct IntRange;
 struct AttributeViolation;
 
+bool functionSemantic(FuncDeclaration* fd);
+
 //enum STC : ulong from astenums.d:
 
     #define STCundefined          0ULL
@@ -698,7 +700,6 @@ public:
     FuncDeclaration *fdensure(FuncDeclaration *fde);
     Expressions *fdrequireParams(Expressions *fdrp);
     Expressions *fdensureParams(Expressions *fdep);
-    static bool functionSemantic(FuncDeclaration* fd);
     bool functionSemantic3();
     bool equals(const RootObject * const o) const override final;
 

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -43,6 +43,7 @@ import dmd.escape;
 import dmd.expression;
 import dmd.expressionsem;
 import dmd.func;
+import dmd.funcsem;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
@@ -3740,7 +3741,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         continue;
                     if (cbd.parent && cbd.parent.isTemplateInstance())
                     {
-                        if (!FuncDeclaration.functionSemantic(f2))
+                        if (!functionSemantic(f2))
                             goto Ldone;
                     }
                     may_override = true;

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -60,6 +60,7 @@ import dmd.errorsink;
 import dmd.expression;
 import dmd.expressionsem;
 import dmd.func;
+import dmd.funcsem;
 import dmd.globals;
 import dmd.hdrgen;
 import dmd.id;
@@ -6888,7 +6889,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 }
                 FuncDeclaration fd = sa.isFuncDeclaration();
                 if (fd)
-                    FuncDeclaration.functionSemantic(fd);
+                    functionSemantic(fd);
             }
             else if (isParameter(o))
             {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -46,6 +46,7 @@ import dmd.escape;
 import dmd.expression;
 import dmd.file_manager;
 import dmd.func;
+import dmd.funcsem;
 import dmd.globals;
 import dmd.hdrgen;
 import dmd.id;
@@ -1579,7 +1580,7 @@ Lagain:
     if (auto f = s.isFuncDeclaration())
     {
         f = f.toAliasFunc();
-        if (!FuncDeclaration.functionSemantic(f))
+        if (!functionSemantic(f))
             return ErrorExp.get();
 
         if (!hasOverloads && f.checkForwardRef(loc))
@@ -2866,7 +2867,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
     // If inferring return type, and semantic3() needs to be run if not already run
     if (!tf.next && fd.inferRetType)
     {
-        FuncDeclaration.functionSemantic(fd);
+        functionSemantic(fd);
     }
     else if (fd && fd.parent)
     {
@@ -5444,7 +5445,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (fd)
         {
             //printf("L%d fd = %s\n", __LINE__, f.toChars());
-            if (!FuncDeclaration.functionSemantic(fd))
+            if (!functionSemantic(fd))
                 return setError();
         }
 
@@ -8249,7 +8250,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (FuncDeclaration fd = exp.var.isFuncDeclaration())
         {
             // for functions, do checks after overload resolution
-            if (!FuncDeclaration.functionSemantic(fd))
+            if (!functionSemantic(fd))
                 return setError();
 
             /* https://issues.dlang.org/show_bug.cgi?id=13843
@@ -9016,7 +9017,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         bool err = false;
         if (cd.dtor)
         {
-            err |= !FuncDeclaration.functionSemantic(cd.dtor);
+            err |= !functionSemantic(cd.dtor);
             err |= cd.dtor.checkPurity(exp.loc, sc);
             err |= cd.dtor.checkSafety(exp.loc, sc);
             err |= cd.dtor.checkNogc(exp.loc, sc);
@@ -14435,7 +14436,7 @@ Expression dotIdSemanticProp(DotIdExp exp, Scope* sc, bool gag)
             if (auto f = s.isFuncDeclaration())
             {
                 //printf("it's a function\n");
-                if (!FuncDeclaration.functionSemantic(f))
+                if (!functionSemantic(f))
                     return ErrorExp.get();
                 Expression e;
                 if (f.needThis())

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -3793,7 +3793,6 @@ public:
     Array<Expression* >* fdrequireParams(Array<Expression* >* param);
     Array<Expression* >* fdensureParams(Array<Expression* >* param);
     FuncDeclaration* syntaxCopy(Dsymbol* s) override;
-    static bool functionSemantic(FuncDeclaration* fd);
     bool functionSemantic3();
     bool equals(const RootObject* const o) const final override;
     int32_t findVtblIndex(Array<Dsymbol* >* vtbl, int32_t dim);
@@ -7564,6 +7563,8 @@ extern Expression* expressionSemantic(Expression* e, Scope* sc);
 extern Expression* toLvalue(Expression* _this, Scope* sc, const char* action);
 
 extern Expression* modifiableLvalue(Expression* _this, Scope* sc);
+
+extern bool functionSemantic(FuncDeclaration* fd);
 
 extern const char* toChars(const Expression* const e);
 

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1,0 +1,119 @@
+/**
+ * Does semantic analysis for functions.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/function.html, Functions)
+ *
+ * Copyright:   Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/funcsem.d, _funcsem.d)
+ * Documentation:  https://dlang.org/phobos/dmd_funcsem.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/funcsem.d
+ */
+
+module dmd.funcsem;
+
+import core.stdc.stdio;
+
+import dmd.aggregate;
+import dmd.arraytypes;
+import dmd.astenums;
+import dmd.blockexit;
+import dmd.gluelayer;
+import dmd.dcast;
+import dmd.dclass;
+import dmd.declaration;
+import dmd.delegatize;
+import dmd.dinterpret;
+import dmd.dmodule;
+import dmd.dscope;
+import dmd.dstruct;
+import dmd.dsymbol;
+import dmd.dsymbolsem;
+import dmd.dtemplate;
+import dmd.errors;
+import dmd.escape;
+import dmd.expression;
+import dmd.func;
+import dmd.globals;
+import dmd.hdrgen;
+import dmd.id;
+import dmd.identifier;
+import dmd.init;
+import dmd.location;
+import dmd.mtype;
+import dmd.objc;
+import dmd.root.aav;
+import dmd.common.outbuffer;
+import dmd.rootobject;
+import dmd.root.string;
+import dmd.root.stringtable;
+import dmd.semantic2;
+import dmd.semantic3;
+import dmd.statement_rewrite_walker;
+import dmd.statement;
+import dmd.statementsem;
+import dmd.tokens;
+import dmd.visitor;
+
+/****************************************************
+ * Resolve forward reference of function signature -
+ * parameter types, return type, and attributes.
+ * Params:
+ *  fd = function declaration
+ * Returns:
+ *  false if any errors exist in the signature.
+ */
+public
+bool functionSemantic(FuncDeclaration fd)
+{
+    //printf("functionSemantic() %p %s\n", this, toChars());
+    if (!fd._scope)
+        return !fd.errors;
+
+    fd.cppnamespace = fd._scope.namespace;
+
+    if (!fd.originalType) // semantic not yet run
+    {
+        TemplateInstance spec = fd.isSpeculative();
+        uint olderrs = global.errors;
+        uint oldgag = global.gag;
+        if (global.gag && !spec)
+            global.gag = 0;
+        dsymbolSemantic(fd, fd._scope);
+        global.gag = oldgag;
+        if (spec && global.errors != olderrs)
+            spec.errors = (global.errors - olderrs != 0);
+        if (olderrs != global.errors) // if errors compiling this function
+            return false;
+    }
+
+    // if inferring return type, sematic3 needs to be run
+    // - When the function body contains any errors, we cannot assume
+    //   the inferred return type is valid.
+    //   So, the body errors should become the function signature error.
+    if (fd.inferRetType && fd.type && !fd.type.nextOf())
+        return fd.functionSemantic3();
+
+    TemplateInstance ti;
+    if (fd.isInstantiated() && !fd.isVirtualMethod() &&
+        ((ti = fd.parent.isTemplateInstance()) is null || ti.isTemplateMixin() || ti.tempdecl.ident == fd.ident))
+    {
+        AggregateDeclaration ad = fd.isMemberLocal();
+        if (ad && ad.sizeok != Sizeok.done)
+        {
+            /* Currently dmd cannot resolve forward references per methods,
+             * then setting SIZOKfwd is too conservative and would break existing code.
+             * So, just stop method attributes inference until ad.dsymbolSemantic() done.
+             */
+            //ad.sizeok = Sizeok.fwd;
+        }
+        else
+            return fd.functionSemantic3() || !fd.errors;
+    }
+
+    if (fd.storage_class & STC.inference)
+        return fd.functionSemantic3() || !fd.errors;
+
+    return !fd.errors;
+}

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -65,6 +65,7 @@ import dmd.visitor;
  *  false if any errors exist in the signature.
  */
 public
+extern (C++)
 bool functionSemantic(FuncDeclaration fd)
 {
     //printf("functionSemantic() %p %s\n", this, toChars());

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -30,6 +30,7 @@ import dmd.dtemplate;
 import dmd.errors;
 import dmd.expression;
 import dmd.func;
+import dmd.funcsem;
 import dmd.globals;
 import dmd.hdrgen;
 import dmd.id;
@@ -1693,7 +1694,7 @@ extern (C++) abstract class Type : ASTNode
         if (callable)
         {
             auto fd = resolveFuncCall(Loc.initial, null, callable, null, this, ArgumentList(), FuncResolveFlag.quiet);
-            if (!fd || fd.errors || !FuncDeclaration.functionSemantic(fd))
+            if (!fd || fd.errors || !functionSemantic(fd))
                 return Type.terror;
 
             auto t = fd.type.nextOf();

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -43,6 +43,7 @@ import dmd.escape;
 import dmd.expression;
 import dmd.expressionsem;
 import dmd.func;
+import dmd.funcsem;
 import dmd.globals;
 import dmd.gluelayer;
 import dmd.hdrgen;
@@ -1284,7 +1285,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 Type tfront;
                 if (auto fd = sfront.isFuncDeclaration())
                 {
-                    if (!FuncDeclaration.functionSemantic(fd))
+                    if (!functionSemantic(fd))
                         return rangeError();
                     tfront = fd.type;
                 }

--- a/compiler/src/dmd/toobj.d
+++ b/compiler/src/dmd/toobj.d
@@ -40,6 +40,7 @@ import dmd.errors;
 import dmd.errorsink;
 import dmd.expression;
 import dmd.func;
+import dmd.funcsem;
 import dmd.globals;
 import dmd.glue;
 import dmd.hdrgen;
@@ -1075,7 +1076,7 @@ private bool finishVtbl(ClassDeclaration cd)
         }
         // Ensure function has a return value
         // https://issues.dlang.org/show_bug.cgi?id=4869
-        if (!FuncDeclaration.functionSemantic(fd))
+        if (!functionSemantic(fd))
         {
             hasError = true;
         }

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1316,7 +1316,7 @@ public:
             FuncDeclaration *fd = d->vtbl[i]->isFuncDeclaration();
             if (!fd || (!fd->fbody && d->isAbstract()))
                 continue;
-            if (!FuncDeclaration::functionSemantic(fd))
+            if (!functionSemantic(fd))
                 return;
             if (!d->isFuncHidden(fd) || fd->isFuture())
                 continue;
@@ -1452,7 +1452,7 @@ public:
         }
         if (FuncDeclaration *fd = decl->isFuncDeclaration())
         {
-            if (!FuncDeclaration::functionSemantic(fd))
+            if (!functionSemantic(fd))
                 return;
             if (fd->needThis() && !fd->isMember2())
                 return;


### PR DESCRIPTION
Start moving semantic functions out of func.d into funcsem.d

Cut & paste job.