### PR TITLE
Remained "AboutToStart" stuff moved out from osthread module

### DIFF
--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -443,9 +443,8 @@ class Thread : ThreadBase
         slock.lock_nothrow();
         scope(exit) slock.unlock_nothrow();
         {
-            ++nAboutToStart;
-            pAboutToStart = cast(ThreadBase*)realloc(pAboutToStart, Thread.sizeof * nAboutToStart);
-            pAboutToStart[nAboutToStart - 1] = this;
+            incrementAboutToStart(this);
+
             version (Windows)
             {
                 if ( ResumeThread( m_hndl ) == -1 )

--- a/druntime/src/core/thread/threadbase.d
+++ b/druntime/src/core/thread/threadbase.d
@@ -584,8 +584,8 @@ package(core.thread):
     __gshared size_t        sm_tlen;
 
     // can't use core.internal.util.array in public code
-    __gshared ThreadBase* pAboutToStart;
-    __gshared size_t      nAboutToStart;
+    private __gshared ThreadBase* pAboutToStart;
+    private __gshared size_t      nAboutToStart;
 
     //
     // Used for ordering threads in the global thread list.
@@ -654,6 +654,12 @@ package(core.thread):
     // Global Thread List Operations
     ///////////////////////////////////////////////////////////////////////////
 
+    package static void incrementAboutToStart(ThreadBase t) nothrow @nogc
+    {
+        ++nAboutToStart;
+        pAboutToStart = cast(ThreadBase*)realloc(pAboutToStart, ThreadBase.sizeof * nAboutToStart);
+        pAboutToStart[nAboutToStart - 1] = t;
+    }
 
     //
     // Add a thread to the global thread list.


### PR DESCRIPTION
`nAboutToStart` and `pAboutToStart` defined and used by `threadbase` module

Makes code a little easier to understand