### PR TITLE
Add strndup to `core.stdc.string` module

### DIFF
--- a/druntime/src/core/stdc/string.d
+++ b/druntime/src/core/stdc/string.d
@@ -64,6 +64,8 @@ size_t strcspn(scope const char* s1, scope const char* s2) pure;
 ///
 char*  strdup(scope const char *s);
 ///
+char*  strndup(const char *str, size_t size);
+///
 char*  strerror(int errnum);
 // This `strerror_r` definition is not following the POSIX standard
 version (ReturnStrerrorR)

--- a/druntime/src/core/stdc/string.d
+++ b/druntime/src/core/stdc/string.d
@@ -64,7 +64,7 @@ size_t strcspn(scope const char* s1, scope const char* s2) pure;
 ///
 char*  strdup(scope const char *s);
 ///
-char*  strndup(const char *str, size_t size);
+char*  strndup(scope const char *str, size_t size);
 ///
 char*  strerror(int errnum);
 // This `strerror_r` definition is not following the POSIX standard

--- a/druntime/src/core/sys/posix/string.d
+++ b/druntime/src/core/sys/posix/string.d
@@ -39,8 +39,6 @@ char*  stpncpy(return scope char* dst, const char* src, size_t len) pure;
 int    strcoll_l(scope const char* s1, scope const char* s2, locale_t locale);
 ///
 char*  strerror_l(int, locale_t);
-/// Save a copy of a string
-char*  strndup(scope const char* str, size_t len);
 /// Find length of string up to `maxlen`
 size_t strnlen(scope const char* str, size_t maxlen) pure;
 /// System signal messages


### PR DESCRIPTION
It was added in c23 https://en.cppreference.com/w/c/string/byte/strndup