### PR TITLE
Match if expression is const, to get the proper error message

### DIFF
--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -1719,7 +1719,14 @@ private FuncDeclaration findBestOpApplyMatch(Expression ethis, FuncDeclaration f
         if (f.isThis())
         {
             if (!MODimplicitConv(mod, tf.mod))
+            {
+                if (mod & MODFlags.const_)
+                {
+                    fd_best = f;
+                    return 0;
+                }
                 m = MATCH.nomatch;
+            }
             else if (mod != tf.mod)
                 m = MATCH.constant;
         }


### PR DESCRIPTION
Consider:

```D
struct Stuff {

    int opApply(scope int delegate(const (Stuff)*) dg) 
    {
        return 0;
    }

};
extern(C) void main()
{
    const(Stuff)* stuff;
    foreach(const (Stuff)* it;*stuff)
    {}
}
```


Before:

```
_.d(13): Error: cannot uniquely infer `foreach` argument types
```

After:

```
_.d(13): Error: mutable method `_.Stuff.opApply` is not callable using a `const` object
_.d(4):        Consider adding `const` or `inout` here
```

Fixes bugzilla Issue 19114 - cannot uniquely infer foreach argument types is not a descriptive message
Fixes bugzilla Issue 24353 - Misleading error for foreach when opApply has wrong qualifier

