### PR TITLE
fiber: Fixes mem allocation call status code ambiguity

### DIFF
--- a/druntime/src/core/thread/fiber.d
+++ b/druntime/src/core/thread/fiber.d
@@ -1065,11 +1065,8 @@ private:
     // Free this fiber's stack.
     //
     final void freeStack() nothrow @nogc
-    in
-    {
-        assert( m_pmem && m_ctxt );
-    }
-    do
+    in(m_pmem)
+    in(m_ctxt)
     {
         // NOTE: m_ctxt is guaranteed to be alive because it is held in the
         //       global context list.

--- a/druntime/src/core/thread/fiber.d
+++ b/druntime/src/core/thread/fiber.d
@@ -1015,13 +1015,11 @@ private:
             {
                 m_pmem = valloc( sz );
             }
-            else static if ( __traits( compiles, malloc ) )
-            {
-                m_pmem = malloc( sz );
-            }
             else
             {
-                m_pmem = null;
+                import core.stdc.stdlib : malloc;
+
+                m_pmem = malloc( sz );
             }
 
             if ( !m_pmem )

--- a/druntime/src/core/thread/fiber.d
+++ b/druntime/src/core/thread/fiber.d
@@ -1084,11 +1084,7 @@ private:
             {
                 munmap( m_pmem, m_size );
             }
-            else static if ( __traits( compiles, valloc ) )
-            {
-                free( m_pmem );
-            }
-            else static if ( __traits( compiles, malloc ) )
+            else
             {
                 free( m_pmem );
             }


### PR DESCRIPTION
If for some reason (during druntime hacking) you forget to provide a way to allocate memory, you will receive runtime "Out of memory" error. I think there is must be a compilation error instead.

All our platforms, at least, provide `malloc`, so it is need to be used as lates option.

Because of this changes, deallocation also must be unconditional. Related code is changed too.

Also this PR splits contract check for easier debugging