### PR TITLE
core.internal.array.duplication: Replace `_d_newarrayU` with template in `_dup`

### DIFF
--- a/druntime/src/core/internal/array/construction.d
+++ b/druntime/src/core/internal/array/construction.d
@@ -339,16 +339,19 @@ void _d_arraysetctor(Tarr : T[], T)(scope Tarr p, scope ref T value) @trusted
  * Returns:
  *      newly allocated array
  */
-T[] _d_newarrayU(T)(size_t length, bool isShared=false) pure nothrow @nogc @trusted
+T[] _d_newarrayUPureNothrow(T)(size_t length, bool isShared=false) pure nothrow @trusted
 {
-    alias PureType = T[] function(size_t length, bool isShared) pure nothrow @nogc @trusted;
-    return (cast(PureType) &_d_newarrayUImpl!T)(length, isShared);
+    alias PureType = T[] function(size_t length, bool isShared) pure nothrow @trusted;
+    return (cast(PureType) &_d_newarrayU!T)(length, isShared);
 }
 
-T[] _d_newarrayUImpl(T)(size_t length, bool isShared=false) @trusted
+T[] _d_newarrayU(T)(size_t length, bool isShared=false) @trusted
 {
     import core.exception : onOutOfMemoryError;
+    import core.internal.traits : Unqual;
     import core.internal.array.utils : __arrayStart, __setArrayAllocLength, __arrayAlloc;
+
+    alias UnqT = Unqual!T;
 
     size_t elemSize = T.sizeof;
     size_t arraySize;
@@ -392,14 +395,14 @@ Loverflow:
     assert(0);
 
 Lcontinue:
-    auto info = __arrayAlloc!T(arraySize);
+    auto info = __arrayAlloc!UnqT(arraySize);
     if (!info.base)
         goto Loverflow;
     debug(PRINTF) printf("p = %p\n", info.base);
 
     auto arrstart = __arrayStart(info);
 
-    __setArrayAllocLength!T(info, arraySize, isShared);
+    __setArrayAllocLength!UnqT(info, arraySize, isShared);
 
     return (cast(T*) arrstart)[0 .. length];
 }

--- a/druntime/src/core/internal/array/utils.d
+++ b/druntime/src/core/internal/array/utils.d
@@ -33,7 +33,6 @@ private
 auto gcStatsPure() nothrow pure
 {
     import core.memory : GC;
-
     auto impureBypass = cast(GC.Stats function() pure nothrow)&GC.stats;
     return impureBypass();
 }

--- a/druntime/src/core/lifetime.d
+++ b/druntime/src/core/lifetime.d
@@ -3009,5 +3009,5 @@ version (D_ProfileGC)
 template TypeInfoSize(T)
 {
     import core.internal.traits : hasElaborateDestructor;
-    enum TypeInfoSize = hasElaborateDestructor!T ? size_t.sizeof : 0;
+    enum TypeInfoSize = (is (T == struct) && hasElaborateDestructor!T) ? size_t.sizeof : 0;
 }


### PR DESCRIPTION
- Only use the `pure nothrow` wrapper `_d_newarrayUPureNothrow` for the `pure nothrow` `_dup`
- Unqualify the template type given to `_d_newarrayU`. The initial template relied on this unqualification being done by the compiler, but now it's called from `_dup`
- Fix `TypeInfoSize` to only account for type `struct`s
- Cannot remove `_d_newarray{iT,T,U}` from `rt.lifetime` because they're used by `aaA.d`
