### PR TITLE
test: Add float stringof comparison tests for GDC

### DIFF
--- a/compiler/test/compilable/test13281.d
+++ b/compiler/test/compilable/test13281.d
@@ -36,12 +36,27 @@ static assert((123  ).stringof == "123");
 static assert((123u ).stringof == "123u");
 static assert((123L ).stringof == "123L");
 static assert((123uL).stringof == "123LU");
-static assert((123.5  ).stringof == "123.5");
-static assert((123.5f ).stringof == "123.5F");
-static assert((123.5L ).stringof == "123.5L");
-static assert((123.5i ).stringof == "123.5i");
-static assert((123.5fi).stringof == "123.5Fi");
-static assert((123.5Li).stringof == "123.5Li");
-static assert((123.5 +5.5i ).stringof == "123.5 + 5.5i");
-static assert((123.5f+5.5fi).stringof == "123.5F + 5.5Fi");
-static assert((123.5L+5.5Li).stringof == "123.5L + 5.5Li");
+version (GNU)
+{
+    static assert((123.5  ).stringof == "1.235e+2");
+    static assert((123.5f ).stringof == "1.235e+2F");
+    static assert((123.5L ).stringof == "1.235e+2L");
+    static assert((123.5i ).stringof == "1.235e+2i");
+    static assert((123.5fi).stringof == "1.235e+2Fi");
+    static assert((123.5Li).stringof == "1.235e+2Li");
+    static assert((123.5 +5.5i ).stringof == "1.235e+2 + 5.5e+0i");
+    static assert((123.5f+5.5fi).stringof == "1.235e+2F + 5.5e+0Fi");
+    static assert((123.5L+5.5Li).stringof == "1.235e+2L + 5.5e+0Li");
+}
+else
+{
+    static assert((123.5  ).stringof == "123.5");
+    static assert((123.5f ).stringof == "123.5F");
+    static assert((123.5L ).stringof == "123.5L");
+    static assert((123.5i ).stringof == "123.5i");
+    static assert((123.5fi).stringof == "123.5Fi");
+    static assert((123.5Li).stringof == "123.5Li");
+    static assert((123.5 +5.5i ).stringof == "123.5 + 5.5i");
+    static assert((123.5f+5.5fi).stringof == "123.5F + 5.5Fi");
+    static assert((123.5L+5.5Li).stringof == "123.5L + 5.5Li");
+}

--- a/compiler/test/runnable/test42.d
+++ b/compiler/test/runnable/test42.d
@@ -721,8 +721,16 @@ void test48()
 
 void test49()
 {
-    assert((25.5).stringof ~ (3.01).stringof == "25.53.01");
-    assert(25.5.stringof ~ 3.01.stringof == "25.53.01");
+    version(GNU)
+    {
+        assert((25.5).stringof ~ (3.0625).stringof == "2.55e+13.0625e+0");
+        assert(25.5.stringof ~ 3.0625.stringof == "2.55e+13.0625e+0");
+    }
+    else
+    {
+        assert((25.5).stringof ~ (3.01).stringof == "25.53.01");
+        assert(25.5.stringof ~ 3.01.stringof == "25.53.01");
+    }
 }
 
 /***************************************************/


### PR DESCRIPTION
The GNU D compiler uses a software floating point type to represent and emulate reals at compile-time. The formatting routines for this type differs from libc's `snprintf` for formatting native reals.