### PR TITLE
Fix Bugzilla 15504 - core.demangle: exceptions gone from normal control flow

### DIFF
--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -476,15 +476,15 @@ pure @safe:
         Namechar
         Namechar Namechars
     */
-    void parseLName(out string err_status) scope nothrow
+    void parseLName(out string err_msg) scope nothrow
     {
         debug(trace) printf( "parseLName+\n" );
         debug(trace) scope(success) printf( "parseLName-\n" );
 
         static if (__traits(hasMember, Hooks, "parseLName"))
         {
-            auto r = hooks.parseLName(err_status, this);
-            if (err_status !is null) return;
+            auto r = hooks.parseLName(err_msg, this);
+            if (err_msg !is null) return;
             if (r) return;
         }
 
@@ -496,7 +496,7 @@ pure @safe:
             size_t n = decodeBackref();
             if ( !n || n > refPos )
             {
-                err_status = "Invalid LName back reference";
+                err_msg = "Invalid LName back reference";
                 return;
             }
             if ( !mute )
@@ -504,7 +504,7 @@ pure @safe:
                 auto savePos = pos;
                 scope(exit) pos = savePos;
                 pos = refPos - n;
-                parseLName(err_status);
+                parseLName(err_msg);
             }
             return;
         }
@@ -513,7 +513,7 @@ pure @safe:
         auto n = decodeNumber(err_flag);
         if(err_flag)
         {
-            err_status = "Number overflow";
+            err_msg = "Number overflow";
             return;
         }
 
@@ -524,19 +524,19 @@ pure @safe:
         }
         if ( n > buf.length || n > buf.length - pos )
         {
-            err_status = "LName must be at least 1 character";
+            err_msg = "LName must be at least 1 character";
             return;
         }
         if ( '_' != front && !isAlpha( front ) )
         {
-            err_status = "Invalid character in LName";
+            err_msg = "Invalid character in LName";
             return;
         }
         foreach (char e; buf[pos + 1 .. pos + n] )
         {
             if ( '_' != e && !isAlpha( e ) && !isDigit( e ) )
             {
-                err_status = "Invalid character in LName";
+                err_msg = "Invalid character in LName";
                 return;
             }
         }

--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -93,7 +93,7 @@ pure @safe:
     }
 
 
-    static bool isDigit( char val )
+    static bool isDigit( char val ) nothrow
     {
         return '0' <= val && '9' >= val;
     }
@@ -107,7 +107,7 @@ pure @safe:
     }
 
 
-    static ubyte ascii2hex( char val )
+    static ubyte ascii2hex( out bool err_status, char val ) nothrow
     {
         if (val >= 'a' && val <= 'f')
             return cast(ubyte)(val - 'a' + 10);
@@ -115,7 +115,9 @@ pure @safe:
             return cast(ubyte)(val - 'A' + 10);
         if (val >= '0' && val <= '9')
             return cast(ubyte)(val - '0');
-        error();
+
+        err_status = true;
+        return 0;
     }
 
     BufSlice shift(scope const BufSlice val) return scope
@@ -143,7 +145,7 @@ pure @safe:
         put(val.getSlice);
     }
 
-    void put(scope const(char)[] val) return scope
+    void put(scope const(char)[] val) return scope nothrow
     {
         if (mute)
             return;
@@ -178,7 +180,7 @@ pure @safe:
     }
 
 
-    void silent( void delegate() pure @safe dg )
+    void silent( void delegate() pure @safe nothrow dg ) nothrow
     {
         debug(trace) printf( "silent+\n" );
         debug(trace) scope(success) printf( "silent-\n" );
@@ -210,41 +212,45 @@ pure @safe:
     }
 
 
-    void test( char val )
+    bool test( char val ) nothrow
     {
-        if ( val != front )
-            error();
+        return val == front;
     }
 
-
-    void popFront()
+    void popFront() nothrow
     {
+        import core.exception : RangeError;
+
         if ( pos++ >= buf.length )
-            error();
+            throw new RangeError;
     }
 
 
-    void popFront(int i)
+    void popFront(int i) nothrow
     {
         while (i--)
             popFront();
     }
 
 
-    void match( char val )
+    bool match( char val ) nothrow
     {
-        test( val );
-        popFront();
+        if(!test(val))
+            return false;
+        else
+        {
+            popFront();
+            return true;
+        }
     }
 
-
-    void match( const(char)[] val )
+    bool match( const(char)[] val ) nothrow
     {
         foreach (char e; val )
-        {
-            test( e );
-            popFront();
-        }
+            if(!match( e ))
+                return false;
+
+        return true;
     }
 
 
@@ -254,7 +260,7 @@ pure @safe:
             popFront();
     }
 
-    bool isSymbolNameFront()
+    bool isSymbolNameFront(out bool err_status) nothrow
     {
         char val = front;
         if ( isDigit( val ) || val == '_' )
@@ -264,21 +270,28 @@ pure @safe:
 
         // check the back reference encoding after 'Q'
         val = peekBackref();
+        if(val == 0)
+        {
+            // invalid back reference
+            err_status = true;
+            return false;
+        }
+
         return isDigit( val ); // identifier ref
     }
 
     // return the first character at the back reference
-    char peekBackref()
+    char peekBackref() nothrow
     {
         assert( front == 'Q' );
         auto n = decodeBackref!1();
         if (!n || n > pos)
-            error("invalid back reference");
+            return 0; // invalid back reference
 
         return buf[pos - n];
     }
 
-    size_t decodeBackref(size_t peekAt = 0)()
+    size_t decodeBackref(size_t peekAt = 0)() nothrow
     {
         enum base = 26;
         size_t n = 0;
@@ -297,7 +310,8 @@ pure @safe:
             if (t < 'A' || t > 'Z')
             {
                 if (t < 'a' || t > 'z')
-                    error("invalid back reference");
+                    return 0; // invalid back reference
+
                 n = base * n + t - 'a';
                 return n;
             }
@@ -333,16 +347,15 @@ pure @safe:
     }
 
 
-    size_t decodeNumber() scope
+    size_t decodeNumber(out bool err_status) scope nothrow
     {
         debug(trace) printf( "decodeNumber+\n" );
         debug(trace) scope(success) printf( "decodeNumber-\n" );
 
-        return decodeNumber( sliceNumber() );
+        return decodeNumber( err_status, sliceNumber() );
     }
 
-
-    size_t decodeNumber( scope const(char)[] num ) scope
+    size_t decodeNumber( out bool err_status, scope const(char)[] num ) scope nothrow
     {
         debug(trace) printf( "decodeNumber+\n" );
         debug(trace) scope(success) printf( "decodeNumber-\n" );
@@ -357,13 +370,21 @@ pure @safe:
             val = mulu(val, 10, overflow);
             val = addu(val, c - '0',  overflow);
             if (overflow)
-                error();
+            {
+                err_status = true;
+                return 0;
+            }
         }
         return val;
     }
 
+    private template matchOrF(alias s)
+    {
+        enum matchOrF = "err_status = !match("~s.stringof~");"~
+                        "if (err_status) return;";
+    }
 
-    void parseReal() scope
+    void parseReal(out bool err_status) scope nothrow
     {
         debug(trace) printf( "parseReal+\n" );
         debug(trace) scope(success) printf( "parseReal-\n" );
@@ -374,7 +395,7 @@ pure @safe:
 
         if ( 'I' == front )
         {
-            match( "INF" );
+            mixin(matchOrF!( "INF" ));
             put( "real.infinity" );
             return;
         }
@@ -383,13 +404,13 @@ pure @safe:
             popFront();
             if ( 'I' == front )
             {
-                match( "INF" );
+                mixin(matchOrF!( "INF" ));
                 put( "-real.infinity" );
                 return;
             }
             if ( 'A' == front )
             {
-                match( "AN" );
+                mixin(matchOrF!( "AN" ));
                 put( "real.nan" );
                 return;
             }
@@ -398,8 +419,9 @@ pure @safe:
 
         tbuf[tlen++] = '0';
         tbuf[tlen++] = 'X';
-        if ( !isHexDigit( front ) )
-            error( "Expected hex digit" );
+        err_status = !isHexDigit( front );
+        if (err_status) return; // Expected hex digit
+
         tbuf[tlen++] = front;
         tbuf[tlen++] = '.';
         popFront();
@@ -409,7 +431,7 @@ pure @safe:
             tbuf[tlen++] = front;
             popFront();
         }
-        match( 'P' );
+        mixin(matchOrF!( 'P' ));
         tbuf[tlen++] = 'p';
         if ( 'N' == front )
         {
@@ -454,14 +476,17 @@ pure @safe:
         Namechar
         Namechar Namechars
     */
-    void parseLName() scope
+    void parseLName(out string err_status) scope nothrow
     {
         debug(trace) printf( "parseLName+\n" );
         debug(trace) scope(success) printf( "parseLName-\n" );
 
         static if (__traits(hasMember, Hooks, "parseLName"))
-            if (hooks.parseLName(this))
-                return;
+        {
+            auto r = hooks.parseLName(err_status, this);
+            if (err_status !is null) return;
+            if (r) return;
+        }
 
         if ( front == 'Q' )
         {
@@ -470,30 +495,50 @@ pure @safe:
             popFront();
             size_t n = decodeBackref();
             if ( !n || n > refPos )
-                error( "Invalid LName back reference" );
+            {
+                err_status = "Invalid LName back reference";
+                return;
+            }
             if ( !mute )
             {
                 auto savePos = pos;
                 scope(exit) pos = savePos;
                 pos = refPos - n;
-                parseLName();
+                parseLName(err_status);
             }
             return;
         }
-        auto n = decodeNumber();
+
+        bool err_flag;
+        auto n = decodeNumber(err_flag);
+        if(err_flag)
+        {
+            err_status = "Number overflow";
+            return;
+        }
+
         if ( n == 0 )
         {
             put( "__anonymous" );
             return;
         }
         if ( n > buf.length || n > buf.length - pos )
-            error( "LName must be at least 1 character" );
+        {
+            err_status = "LName must be at least 1 character";
+            return;
+        }
         if ( '_' != front && !isAlpha( front ) )
-            error( "Invalid character in LName" );
+        {
+            err_status = "Invalid character in LName";
+            return;
+        }
         foreach (char e; buf[pos + 1 .. pos + n] )
         {
             if ( '_' != e && !isAlpha( e ) && !isDigit( e ) )
-                error( "Invalid character in LName" );
+            {
+                err_status = "Invalid character in LName";
+                return;
+            }
         }
 
         put( buf[pos .. pos + n] );
@@ -676,7 +721,7 @@ pure @safe:
     TypeTuple:
         B Number Arguments
     */
-    BufSlice parseType() return scope
+    BufSlice parseType(out bool err_status) return scope nothrow
     {
         static immutable string[23] primitives = [
             "char", // a
@@ -705,23 +750,37 @@ pure @safe:
         ];
 
         static if (__traits(hasMember, Hooks, "parseType"))
-            if (auto n = hooks.parseType(this, null))
-                return BufSlice(n, 0, n.length);
+        {
+            auto n = hooks.parseType(err_status, this, null);
+            if (err_status)
+                return dst.bslice_empty;
+            else
+                if(n !is null)
+                    return BufSlice(n, 0, n.length);
+        }
 
         debug(trace) printf( "parseType+\n" );
         debug(trace) scope(success) printf( "parseType-\n" );
         auto beg = dst.length;
         auto t = front;
 
-        BufSlice parseBackrefType(scope BufSlice delegate() pure @safe parseDg) pure @safe
+        BufSlice parseBackrefType(out string err_status, scope BufSlice delegate(bool err_flag) pure @safe nothrow parseDg) pure @safe nothrow
         {
             if (pos == brp)
-                error("recursive back reference");
+            {
+                err_status = "recursive back reference";
+                return dst.bslice_empty;
+            }
+
             auto refPos = pos;
             popFront();
             auto n = decodeBackref();
             if (n == 0 || n > pos)
-                error("invalid back reference");
+            {
+                err_status = "invalid back reference";
+                return dst.bslice_empty;
+            }
+
             if ( mute )
                 return dst.bslice_empty;
             auto savePos = pos;
@@ -729,30 +788,47 @@ pure @safe:
             scope(success) { pos = savePos; brp = saveBrp; }
             pos = refPos - n;
             brp = refPos;
-            auto ret = parseDg();
+
+            bool err_flag;
+            auto ret = parseDg(err_flag);
+            if(err_flag)
+            {
+                err_status = "parseDg error";
+                return dst.bslice_empty;
+            }
+
             return ret;
+        }
+
+        // call parseType() and return error if occured
+        template parseTypeOrF()
+        {
+            enum parseTypeOrF = "parseType(err_status); if(err_status) return dst.bslice_empty;";
         }
 
         switch ( t )
         {
         case 'Q': // Type back reference
-            return parseBackrefType(() => parseType());
+            string err_msg;
+            auto r = parseBackrefType(err_msg, (e_flag) => parseType(e_flag));
+            if(err_msg !is null) return dst.bslice_empty;
+            return r;
         case 'O': // Shared (O Type)
             popFront();
             put( "shared(" );
-            parseType();
+            mixin(parseTypeOrF!());
             put( ')' );
             return dst[beg .. $];
         case 'x': // Const (x Type)
             popFront();
             put( "const(" );
-            parseType();
+            mixin(parseTypeOrF!());
             put( ')' );
             return dst[beg .. $];
         case 'y': // Immutable (y Type)
             popFront();
             put( "immutable(" );
-            parseType();
+            mixin(parseTypeOrF!());
             put( ')' );
             return dst[beg .. $];
         case 'N':
@@ -767,27 +843,28 @@ pure @safe:
                 popFront();
                 // TODO: Anything needed here?
                 put( "inout(" );
-                parseType();
+                mixin(parseTypeOrF!());
                 put( ')' );
                 return dst[beg .. $];
             case 'h': // TypeVector (Nh Type)
                 popFront();
                 put( "__vector(" );
-                parseType();
+                mixin(parseTypeOrF!());
                 put( ')' );
                 return dst[beg .. $];
             default:
-                error();
+                err_status = true;
+                return dst.bslice_empty;
             }
         case 'A': // TypeArray (A Type)
             popFront();
-            parseType();
+            mixin(parseTypeOrF!());
             put( "[]" );
             return dst[beg .. $];
         case 'G': // TypeStaticArray (G Number Type)
             popFront();
             auto num = sliceNumber();
-            parseType();
+            mixin(parseTypeOrF!());
             put( '[' );
             put( num );
             put( ']' );
@@ -795,33 +872,46 @@ pure @safe:
         case 'H': // TypeAssocArray (H Type Type)
             popFront();
             // skip t1
-            auto tx = parseType();
-            parseType();
+            auto tx = parseType(err_status);
+            if(err_status) return dst.bslice_empty;
+            mixin(parseTypeOrF!());
             put( '[' );
             shift(tx);
             put( ']' );
             return dst[beg .. $];
         case 'P': // TypePointer (P Type)
             popFront();
-            parseType();
+            mixin(parseTypeOrF!());
             put( '*' );
             return dst[beg .. $];
         case 'F': case 'U': case 'W': case 'V': case 'R': // TypeFunction
-            return parseTypeFunction();
+            auto r = parseTypeFunction(err_status);
+            if(err_status) return dst.bslice_empty;
+            return r;
         case 'C': // TypeClass (C LName)
         case 'S': // TypeStruct (S LName)
         case 'E': // TypeEnum (E LName)
         case 'T': // TypeTypedef (T LName)
             popFront();
-            parseQualifiedName();
+            parseQualifiedName(err_status);
+            if(err_status) return dst.bslice_empty;
             return dst[beg .. $];
         case 'D': // TypeDelegate (D TypeFunction)
             popFront();
             auto modifiers = parseModifier();
             if ( front == 'Q' )
-                parseBackrefType(() => parseTypeFunction(IsDelegate.yes));
+            {
+                string err_msg;
+                auto r = parseBackrefType(err_msg, (e_flag) => parseTypeFunction(e_flag, IsDelegate.yes));
+                if(err_msg !is null) return dst.bslice_empty;
+                return r;
+            }
             else
-                parseTypeFunction(IsDelegate.yes);
+            {
+                parseTypeFunction(err_status, IsDelegate.yes);
+                if(err_status) return dst.bslice_empty;
+            }
+
             if (modifiers)
             {
                 // write modifiers behind the function arguments
@@ -871,10 +961,12 @@ pure @safe:
                     put( "ucent" );
                     return dst[beg .. $];
                 default:
-                    error();
+                    err_status = true;
+                    return dst.bslice_empty;
                 }
             }
-            error();
+            err_status = true;
+            return dst.bslice_empty;
         }
     }
 
@@ -950,7 +1042,7 @@ pure @safe:
         Y     // variadic T t...) style
         Z     // not variadic
     */
-    void parseCallConvention()
+    void parseCallConvention(out bool err_status) nothrow
     {
         // CallConvention
         switch ( front )
@@ -971,7 +1063,7 @@ pure @safe:
             put( "extern (C++) " );
             break;
         default:
-            error();
+            err_status = true;
         }
     }
 
@@ -1009,7 +1101,7 @@ pure @safe:
         }
     }
 
-    ushort parseFuncAttr()
+    ushort parseFuncAttr(out bool err_status) nothrow
     {
         // FuncAttrs
         ushort result;
@@ -1086,13 +1178,14 @@ pure @safe:
                 result |= FuncAttributes.Live;
                 continue;
             default:
-                error();
+                err_status = true;
+                return 0;
             }
         }
         return result;
     }
 
-    void parseFuncArguments() scope
+    void parseFuncArguments(out bool err_status) scope nothrow
     {
         // Arguments
         for ( size_t n = 0; true; n++ )
@@ -1184,6 +1277,13 @@ pure @safe:
                 else
                     pos--;
             }
+
+            // call parseType() and return error if occured
+            template parseTypeOrF()
+            {
+                enum parseTypeOrF = "parseType(err_status); if(err_status) return;";
+            }
+
             switch ( front )
             {
             case 'I': // in  (I Type)
@@ -1191,25 +1291,25 @@ pure @safe:
                 put("in ");
                 if (front == 'K')
                     goto case;
-                parseType();
+                mixin(parseTypeOrF!());
                 continue;
             case 'K': // ref (K Type)
                 popFront();
                 put( "ref " );
-                parseType();
+                mixin(parseTypeOrF!());
                 continue;
             case 'J': // out (J Type)
                 popFront();
                 put( "out " );
-                parseType();
+                mixin(parseTypeOrF!());
                 continue;
             case 'L': // lazy (L Type)
                 popFront();
                 put( "lazy " );
-                parseType();
+                mixin(parseTypeOrF!());
                 continue;
             default:
-                parseType();
+                mixin(parseTypeOrF!());
             }
         }
     }
@@ -1220,19 +1320,23 @@ pure @safe:
         TypeFunction:
             CallConvention FuncAttrs Arguments ArgClose Type
     */
-    BufSlice parseTypeFunction(IsDelegate isdg = IsDelegate.no) return scope
+    BufSlice parseTypeFunction(out bool err_status, IsDelegate isdg = IsDelegate.no) return scope nothrow
     {
         debug(trace) printf( "parseTypeFunction+\n" );
         debug(trace) scope(success) printf( "parseTypeFunction-\n" );
         auto beg = dst.length;
 
-        parseCallConvention();
-        auto attributes = parseFuncAttr();
+        parseCallConvention(err_status);
+        if (err_status) return dst.bslice_empty;
+
+        auto attributes = parseFuncAttr(err_status);
+        if (err_status) return dst.bslice_empty;
 
         auto argbeg = dst.length;
         put(IsDelegate.yes == isdg ? "delegate" : "function");
         put( '(' );
-        parseFuncArguments();
+        parseFuncArguments(err_status);
+        if (err_status) return dst.bslice_empty;
         put( ')' );
         if (attributes)
         {
@@ -1249,7 +1353,8 @@ pure @safe:
         // e.g. `delegate(int) @safedouble ' => 'double delegate(int) @safe'
         {
             auto retbeg = dst.length;
-            parseType();
+            parseType(err_status);
+            if (err_status) return dst.bslice_empty;
             put(' ');
             shift(dst[argbeg .. retbeg]);
         }
@@ -1303,12 +1408,12 @@ pure @safe:
         F
     */
 
-    void parseValue() scope
+    void parseValue(out bool err_status) scope nothrow
     {
-        parseValue(dst.bslice_empty);
+        parseValue(err_status, dst.bslice_empty);
     }
 
-    void parseValue(scope BufSlice name, char type = '\0' ) scope
+    void parseValue(out bool err_status, scope BufSlice name, char type = '\0' ) scope nothrow
     {
         debug(trace) printf( "parseValue+\n" );
         debug(trace) scope(success) printf( "parseValue-\n" );
@@ -1322,39 +1427,48 @@ pure @safe:
             return;
         case 'i':
             popFront();
-            if ( '0' > front || '9' < front )
-                error( "Number expected" );
+            err_status = ( '0' > front || '9' < front );
+            if(err_status) return; // Number expected
             goto case;
         case '0': .. case '9':
-            parseIntegerValue( name, type );
+            parseIntegerValue( err_status, name, type );
             return;
         case 'N':
             popFront();
             put( '-' );
-            parseIntegerValue( name, type );
+            parseIntegerValue( err_status, name, type );
             return;
         case 'e':
             popFront();
-            parseReal();
+            parseReal(err_status);
             return;
         case 'c':
             popFront();
-            parseReal();
+            parseReal(err_status);
+            if (err_status) return;
             put( '+' );
-            match( 'c' );
-            parseReal();
+            mixin(matchOrF!( 'c' ));
+            parseReal(err_status);
+            if (err_status) return;
             put( 'i' );
             return;
         case 'a': case 'w': case 'd':
             char t = front;
             popFront();
-            auto n = decodeNumber();
-            match( '_' );
+            auto n = decodeNumber(err_status);
+            if (err_status) return;
+            mixin(matchOrF!( '_' ));
             put( '"' );
             foreach (i; 0..n)
             {
-                auto a = ascii2hex( front ); popFront();
-                auto b = ascii2hex( front ); popFront();
+                auto a = ascii2hex( err_status, front );
+                if(err_status) return;
+                popFront();
+
+                auto b = ascii2hex( err_status, front );
+                if(err_status) return;
+                popFront();
+
                 auto v = cast(char)((a << 4) | b);
                 if (' ' <= v && v <= '~')   // ASCII printable
                 {
@@ -1384,11 +1498,13 @@ pure @safe:
             // An array literal. Value is repeated Number times.
             popFront();
             put( '[' );
-            auto n = decodeNumber();
+            auto n = decodeNumber(err_status);
+            if (err_status) return;
             foreach ( i; 0 .. n )
             {
                 putComma(i);
-                parseValue();
+                parseValue(err_status);
+                if (err_status) return;
             }
             put( ']' );
             return;
@@ -1398,13 +1514,16 @@ pure @safe:
             // An associative array literal. Value is repeated 2*Number times.
             popFront();
             put( '[' );
-            auto n = decodeNumber();
+            auto n = decodeNumber(err_status);
+            if (err_status) return;
             foreach ( i; 0 .. n )
             {
                 putComma(i);
-                parseValue();
+                parseValue(err_status);
+                if (err_status) return;
                 put(':');
-                parseValue();
+                parseValue(err_status);
+                if (err_status) return;
             }
             put( ']' );
             return;
@@ -1415,11 +1534,13 @@ pure @safe:
             if ( name.length )
                 put( name );
             put( '(' );
-            auto n = decodeNumber();
+            auto n = decodeNumber(err_status);
+            if (err_status) return;
             foreach ( i; 0 .. n )
             {
                 putComma(i);
-                parseValue();
+                parseValue(err_status);
+                if (err_status) return;
             }
             put( ')' );
             return;
@@ -1427,19 +1548,14 @@ pure @safe:
             // f MangledName
             // A function literal symbol
             popFront();
-            parseMangledName(false, 1);
+            parseMangledName(err_status, false, 1);
             return;
         default:
-            error();
+            err_status = true;
         }
     }
 
-    void parseIntegerValue() scope
-    {
-        parseIntegerValue(dst.bslice_empty);
-    }
-
-    void parseIntegerValue( scope BufSlice name, char type = '\0' ) scope
+    void parseIntegerValue( out bool err_status, scope BufSlice name, char type = '\0' ) scope nothrow
     {
         debug(trace) printf( "parseIntegerValue+\n" );
         debug(trace) scope(success) printf( "parseIntegerValue-\n" );
@@ -1451,7 +1567,8 @@ pure @safe:
         case 'w': // dchar
         {
             auto val = sliceNumber();
-            auto num = decodeNumber( val );
+            auto num = decodeNumber( err_status, val );
+            if (err_status) return;
 
             switch ( num )
             {
@@ -1513,7 +1630,9 @@ pure @safe:
             }
         }
         case 'b': // bool
-            put( decodeNumber() ? "true" : "false" );
+            auto d = decodeNumber(err_status);
+            if (err_status) return;
+            put( d ? "true" : "false" );
             return;
         case 'h', 't', 'k': // ubyte, ushort, uint
             put( sliceNumber() );
@@ -1549,7 +1668,7 @@ pure @safe:
         S Number_opt QualifiedName
         X ExternallyMangledName
     */
-    void parseTemplateArgs() scope
+    void parseTemplateArgs(out bool err_status) scope nothrow
     {
         debug(trace) printf( "parseTemplateArgs+\n" );
         debug(trace) scope(success) printf( "parseTemplateArgs-\n" );
@@ -1565,7 +1684,8 @@ pure @safe:
             case 'T':
                 popFront();
                 putComma(n);
-                parseType();
+                parseType(err_status);
+                if (err_status) return;
                 continue;
             case 'V':
                 popFront();
@@ -1576,9 +1696,20 @@ pure @safe:
                 //       decrement len and let put/append do its thing.
                 char t = front; // peek at type for parseValue
                 if ( t == 'Q' )
+                {
                     t = peekBackref();
-                BufSlice name = dst.bslice_empty; silent( delegate void() { name = parseType(); } );
-                parseValue( name, t );
+                    if(t == 0)
+                    {
+                        // invalid back reference
+                        err_status = true;
+                        return;
+                    }
+                }
+                BufSlice name = dst.bslice_empty;
+                silent( delegate void() nothrow { name = parseType(err_status); } );
+                if (err_status) return;
+                parseValue( err_status, name, t );
+                if (err_status) return;
                 continue;
             case 'S':
                 popFront();
@@ -1589,13 +1720,12 @@ pure @safe:
                     auto l = dst.length;
                     auto p = pos;
                     auto b = brp;
-                    try
-                    {
-                        debug(trace) printf( "may be mangled name arg\n" );
-                        parseMangledNameArg();
+
+                    debug(trace) printf( "may be mangled name arg\n" );
+
+                    if(parseMangledNameArg())
                         continue;
-                    }
-                    catch ( ParseException e )
+                    else
                     {
                         dst.len = l;
                         pos = p;
@@ -1607,34 +1737,43 @@ pure @safe:
                 {
                     // ambiguity: length followed by qualified name (starting with number)
                     // try all possible pairs of numbers
-                    auto qlen = decodeNumber() / 10; // last digit needed for QualifiedName
+                    auto qlen = decodeNumber(err_status);
+                    if (err_status) return;
+
+                    qlen /= 10; // last digit needed for QualifiedName
                     pos--;
                     auto l = dst.length;
                     auto p = pos;
                     auto b = brp;
                     while ( qlen > 0 )
                     {
-                        try
+                        err_status = false;
+                        parseQualifiedName(err_status);
+
+                        if(!err_status)
                         {
-                            parseQualifiedName();
                             if ( pos == p + qlen )
                                 continue L_nextArg;
                         }
-                        catch ( ParseException e )
-                        {
-                        }
+
                         qlen /= 10; // retry with one digit less
                         pos = --p;
                         dst.len = l;
                         brp = b;
                     }
                 }
-                parseQualifiedName();
+
+                parseQualifiedName(err_status);
+                if(err_status) return;
                 continue;
             case 'X':
                 popFront();
                 putComma(n);
-                parseLName();
+                {
+                    string err_msg;
+                    parseLName(err_msg);
+                    if (err_msg) return;
+                }
                 continue;
             default:
                 return;
@@ -1643,79 +1782,132 @@ pure @safe:
     }
 
 
-    bool mayBeMangledNameArg()
+    bool mayBeMangledNameArg() nothrow
     {
         debug(trace) printf( "mayBeMangledNameArg+\n" );
         debug(trace) scope(success) printf( "mayBeMangledNameArg-\n" );
 
+        bool err_status;
         auto p = pos;
         scope(exit) pos = p;
+
         if ( isDigit( buf[pos] ) )
         {
-            auto n = decodeNumber();
-            return n >= 4 &&
+            auto n = decodeNumber(err_status);
+
+            return !err_status && n >= 4 &&
                 pos < buf.length && '_' == buf[pos++] &&
                 pos < buf.length && 'D' == buf[pos++] &&
                 isDigit( buf[pos] );
         }
         else
         {
-            return pos < buf.length && '_' == buf[pos++] &&
+            const isSNF = isSymbolNameFront(err_status);
+
+            return !err_status &&
+                   pos < buf.length && '_' == buf[pos++] &&
                    pos < buf.length && 'D' == buf[pos++] &&
-                   isSymbolNameFront();
+                   isSNF;
         }
     }
 
-
-    void parseMangledNameArg()
+    bool parseMangledNameArg() nothrow
     {
         debug(trace) printf( "parseMangledNameArg+\n" );
         debug(trace) scope(success) printf( "parseMangledNameArg-\n" );
 
+        bool err_status;
+
         size_t n = 0;
         if ( isDigit( front ) )
-            n = decodeNumber();
-        parseMangledName( false, n );
-    }
+        {
+            n = decodeNumber(err_status);
 
+            if(err_status)
+                return false;
+        }
+
+        parseMangledName(err_status, false, n );
+
+        return !err_status;
+    }
 
     /*
     TemplateInstanceName:
         Number __T LName TemplateArgs Z
     */
-    void parseTemplateInstanceName(bool hasNumber) scope
+    void parseTemplateInstanceName(out bool err_status, bool hasNumber) scope nothrow
     {
         debug(trace) printf( "parseTemplateInstanceName+\n" );
         debug(trace) scope(success) printf( "parseTemplateInstanceName-\n" );
 
         auto sav = pos;
         auto saveBrp = brp;
-        scope(failure)
+
+        void call_if_failure()
         {
             pos = sav;
             brp = saveBrp;
         }
-        auto n = hasNumber ? decodeNumber() : 0;
+
+        template check4err()
+        {
+            enum check4err =
+            "if (err_status) {"~
+            "   call_if_failure();"~
+            "   return;"~
+            "}";
+        }
+
+        size_t n = 0;
+        if (hasNumber)
+        {
+            n = decodeNumber(err_status);
+            mixin(check4err!());
+        }
+
         auto beg = pos;
-        match( "__T" );
-        parseLName();
+        err_status = !match( "__T" );
+        mixin(check4err!());
+
+        {
+            string err_msg;
+            parseLName(err_msg);
+            err_status = err_msg !is null;
+            mixin(check4err!());
+        }
+
         put( "!(" );
-        parseTemplateArgs();
-        match( 'Z' );
+
+        parseTemplateArgs(err_status);
+        mixin(check4err!());
+
+        err_status = !match( 'Z' );
+        mixin(check4err!());
+
         if ( hasNumber && pos - beg != n )
-            error( "Template name length mismatch" );
+        {
+            // Template name length mismatch
+            err_status = true;
+            call_if_failure();
+        }
+
         put( ')' );
     }
 
 
-    bool mayBeTemplateInstanceName() scope
+    bool mayBeTemplateInstanceName() scope nothrow
     {
         debug(trace) printf( "mayBeTemplateInstanceName+\n" );
         debug(trace) scope(success) printf( "mayBeTemplateInstanceName-\n" );
 
         auto p = pos;
         scope(exit) pos = p;
-        auto n = decodeNumber();
+
+        bool err_status;
+        auto n = decodeNumber(err_status);
+        if (err_status) return false;
+
         return n >= 5 &&
                pos < buf.length && '_' == buf[pos++] &&
                pos < buf.length && '_' == buf[pos++] &&
@@ -1728,7 +1920,7 @@ pure @safe:
         LName
         TemplateInstanceName
     */
-    void parseSymbolName() scope
+    void parseSymbolName(out bool err_status) scope nothrow
     {
         debug(trace) printf( "parseSymbolName+\n" );
         debug(trace) scope(success) printf( "parseSymbolName-\n" );
@@ -1739,7 +1931,7 @@ pure @safe:
         {
         case '_':
             // no length encoding for templates for new mangling
-            parseTemplateInstanceName(false);
+            parseTemplateInstanceName(err_status, false);
             return;
 
         case '0': .. case '9':
@@ -1747,13 +1939,11 @@ pure @safe:
             {
                 auto t = dst.length;
 
-                try
-                {
-                    debug(trace) printf( "may be template instance name\n" );
-                    parseTemplateInstanceName(true);
+                debug(trace) printf( "may be template instance name\n" );
+                parseTemplateInstanceName(err_status, true);
+                if (!err_status)
                     return;
-                }
-                catch ( ParseException e )
+                else
                 {
                     debug(trace) printf( "not a template instance name\n" );
                     dst.len = t;
@@ -1761,63 +1951,69 @@ pure @safe:
             }
             goto case;
         case 'Q':
-            parseLName();
+            string err_msg;
+            parseLName(err_msg);
+            err_status = err_msg !is null;
             return;
         default:
-            error();
+            err_status = true;
         }
     }
 
     // parse optional function arguments as part of a symbol name, i.e without return type
     // if keepAttr, the calling convention and function attributes are not discarded, but returned
-    BufSlice parseFunctionTypeNoReturn( bool keepAttr = false ) return scope
+    BufSlice parseFunctionTypeNoReturn( bool keepAttr = false ) return scope nothrow
     {
         // try to demangle a function, in case we are pointing to some function local
         auto prevpos = pos;
         auto prevlen = dst.length;
         auto prevbrp = brp;
 
-        try
+        if ( 'M' == front )
         {
-            if ( 'M' == front )
+            // do not emit "needs this"
+            popFront();
+            auto modifiers = parseModifier();
+            while (auto str = typeCtors.toStringConsume(modifiers))
             {
-                // do not emit "needs this"
-                popFront();
-                auto modifiers = parseModifier();
-                while (auto str = typeCtors.toStringConsume(modifiers))
-                {
-                    put(str);
-                    put(' ');
-                }
-            }
-            if ( isCallConvention( front ) )
-            {
-                BufSlice attr = dst.bslice_empty;
-                // we don't want calling convention and attributes in the qualified name
-                parseCallConvention();
-                auto attributes = parseFuncAttr();
-                if (keepAttr) {
-                    while (auto str = funcAttrs.toStringConsume(attributes))
-                    {
-                        put(str);
-                        put(' ');
-                    }
-                    attr = dst[prevlen .. $];
-                }
-
-                put( '(' );
-                parseFuncArguments();
-                put( ')' );
-                return attr;
+                put(str);
+                put(' ');
             }
         }
-        catch ( ParseException )
+        if ( isCallConvention( front ) )
         {
+            BufSlice attr = dst.bslice_empty;
+            // we don't want calling convention and attributes in the qualified name
+            bool err_status;
+            parseCallConvention(err_status);
+            if (!err_status)
+            {
+                auto attributes = parseFuncAttr(err_status);
+                if (!err_status)
+                {
+                    if (keepAttr) {
+                        while (auto str = funcAttrs.toStringConsume(attributes))
+                        {
+                            put(str);
+                            put(' ');
+                        }
+                        attr = dst[prevlen .. $];
+                    }
+
+                    put( '(' );
+                    parseFuncArguments(err_status);
+                    if (err_status) return dst.bslice_empty;
+                    put( ')' );
+                    return attr;
+                }
+            }
+
             // not part of a qualified name, so back up
             pos = prevpos;
             dst.len = prevlen;
             brp = prevbrp;
         }
+
         return dst.bslice_empty;
     }
 
@@ -1826,22 +2022,28 @@ pure @safe:
         SymbolName
         SymbolName QualifiedName
     */
-    BufSlice parseQualifiedName() return scope
+    void parseQualifiedName(out bool err_status) return scope nothrow
     {
         debug(trace) printf( "parseQualifiedName+\n" );
         debug(trace) scope(success) printf( "parseQualifiedName-\n" );
-        size_t  beg = dst.length;
+
         size_t  n   = 0;
+        bool is_sym_name_front;
 
         do
         {
             if ( n++ )
                 put( '.' );
-            parseSymbolName();
+
+            parseSymbolName(err_status);
+            if(err_status) return;
+
             parseFunctionTypeNoReturn();
 
-        } while ( isSymbolNameFront() );
-        return dst[beg .. $];
+            is_sym_name_front = isSymbolNameFront(err_status);
+            if(err_status) return;
+
+        } while ( is_sym_name_front );
     }
 
 
@@ -1850,7 +2052,7 @@ pure @safe:
         _D QualifiedName Type
         _D QualifiedName M Type
     */
-    void parseMangledName( bool displayType, size_t n = 0 ) scope
+    void parseMangledName( out bool err_status, bool displayType, size_t n = 0 ) scope nothrow
     {
         debug(trace) printf( "parseMangledName+\n" );
         debug(trace) scope(success) printf( "parseMangledName-\n" );
@@ -1859,23 +2061,32 @@ pure @safe:
         auto end = pos + n;
 
         eat( '_' );
-        match( 'D' );
+        err_status = !match( 'D' );
+        if (err_status) return;
+
         do
         {
             size_t  beg = dst.length;
             size_t  nameEnd = dst.length;
             BufSlice attr = dst.bslice_empty;
+            bool is_sym_name_front;
+
             do
             {
                 if ( attr.length )
                     dst.remove(attr); // dump attributes of parent symbols
                 if (beg != dst.length)
                     put( '.' );
-                parseSymbolName();
+
+                parseSymbolName(err_status);
+                if (err_status) return;
+
                 nameEnd = dst.length;
                 attr = parseFunctionTypeNoReturn( displayType );
 
-            } while ( isSymbolNameFront() );
+                is_sym_name_front = isSymbolNameFront(err_status);
+                if(err_status) return;
+            } while (is_sym_name_front);
 
             if ( displayType )
             {
@@ -1889,7 +2100,9 @@ pure @safe:
                 popFront(); // has 'this' pointer
 
             auto lastlen = dst.length;
-            auto type = parseType();
+            auto type = parseType(err_status);
+            if(err_status) return;
+
             if ( displayType )
             {
                 if ( type.length )
@@ -1920,33 +2133,28 @@ pure @safe:
         } while ( true );
     }
 
-    void parseMangledName()
+    void parseMangledName(out bool err_status) nothrow
     {
-        parseMangledName( AddType.yes == addType );
+        parseMangledName(err_status, AddType.yes == addType);
     }
 
-    char[] doDemangle(alias FUNC)() return scope
+    char[] doDemangle(alias FUNC)() return scope nothrow
     {
         while ( true )
         {
-            try
+            debug(info) printf( "demangle(%.*s)\n", cast(int) buf.length, buf.ptr );
+
+            bool err_status;
+            FUNC(err_status);
+            if (!err_status)
             {
-                debug(info) printf( "demangle(%.*s)\n", cast(int) buf.length, buf.ptr );
-                FUNC();
                 return dst[0 .. $].getSlice;
             }
-            catch ( ParseException e )
+            else
             {
-                debug(info)
-                {
-                    auto msg = e.toString();
-                    printf( "error: %.*s\n", cast(int) msg.length, msg.ptr );
-                }
+                debug(info) printf( "error" );
+
                 return dst.copyInput(buf);
-            }
-            catch ( Exception e )
-            {
-                assert( false ); // no other exceptions thrown
             }
         }
     }
@@ -2062,7 +2270,7 @@ char[] reencodeMangled(return scope const(char)[] mangled) nothrow pure @safe
             }
         }
 
-        bool parseLName(scope ref Remangle d) scope @trusted
+        bool parseLName(out string err_msg, scope ref Remangle d) scope @trusted nothrow
         {
             flushPosition(d);
 
@@ -2077,19 +2285,34 @@ char[] reencodeMangled(return scope const(char)[] mangled) nothrow pure @safe
                     d.popFront();
                     size_t n = d.decodeBackref();
                     if (!n || n > refpos)
-                        error("invalid back reference");
-
+                    {
+                        err_msg = "invalid back reference";
+                        return false;
+                    }
                     auto savepos = d.pos;
                     scope(exit) d.pos = savepos;
                     size_t srcpos = refpos - n;
 
-                    auto idlen = d.decodeNumber();
+                    bool err_status;
+                    auto idlen = d.decodeNumber(err_status);
+                    if (err_status)
+                    {
+                        err_msg = "invalid number";
+                        return false;
+                    }
+
                     if (d.pos + idlen > d.buf.length)
-                        error("invalid back reference");
+                    {
+                        err_msg = "invalid back reference";
+                        return false;
+                    }
                     auto id = d.buf[d.pos .. d.pos + idlen];
                     auto pid = id in idpos;
                     if (!pid)
-                        error("invalid back reference");
+                    {
+                        err_msg = "invalid back reference";
+                        return false;
+                    }
                     npos = positionInResult(*pid);
                 }
                 encodeBackref(reslen - npos);
@@ -2098,9 +2321,19 @@ char[] reencodeMangled(return scope const(char)[] mangled) nothrow pure @safe
             }
             else
             {
-                auto n = d.decodeNumber();
+                bool err_status;
+                auto n = d.decodeNumber(err_status);
+                if (err_status)
+                {
+                    err_msg = "invalid number";
+                    return false;
+                }
+
                 if (!n || n > d.buf.length || n > d.buf.length - d.pos)
-                    error("LName too shot or too long");
+                {
+                    err_msg = "LName too shot or too long";
+                    return false;
+                }
                 auto id = d.buf[d.pos .. d.pos + n];
                 d.pos += n;
                 if (auto pid = id in idpos)
@@ -2121,7 +2354,7 @@ char[] reencodeMangled(return scope const(char)[] mangled) nothrow pure @safe
             return true;
         }
 
-        char[] parseType( ref Remangle d, char[] name ) return scope
+        char[] parseType( out bool err_status, ref Remangle d, char[] name ) return scope nothrow
         {
             if (d.front != 'Q')
                 return null;
@@ -2132,7 +2365,11 @@ char[] reencodeMangled(return scope const(char)[] mangled) nothrow pure @safe
             d.popFront();
             auto n = d.decodeBackref();
             if (n == 0 || n > refPos)
-                error("invalid back reference");
+            {
+                // invalid back reference
+                err_status = true;
+                return null;
+            }
 
             size_t npos = positionInResult(refPos - n);
             size_t reslen = result.length;
@@ -2163,18 +2400,18 @@ char[] reencodeMangled(return scope const(char)[] mangled) nothrow pure @safe
     auto d = Demangle!(PrependHooks)(mangled, null);
     d.hooks = PrependHooks();
     d.mute = true; // no demangled output
-    try
+
+    bool err_status;
+    d.parseMangledName(err_status);
+    if (err_status)
     {
-        d.parseMangledName();
-        if (d.hooks.lastpos < d.pos)
-            d.hooks.result ~= d.buf[d.hooks.lastpos .. d.pos];
-        return d.hooks.result;
-    }
-    catch (Exception)
-    {
-        // overflow exception cannot occur
+        // Error cannot occur
         return mangled.dup;
     }
+
+    if (d.hooks.lastpos < d.pos)
+        d.hooks.result ~= d.buf[d.hooks.lastpos .. d.pos];
+    return d.hooks.result;
 }
 
 /**
@@ -2838,32 +3075,6 @@ private char[] demangleCXX(return scope const(char)[] buf, CXX_DEMANGLER __cxa_d
     return dst;
 }
 
-/**
- * Error handling through Exceptions
- *
- * The following types / functions are only used in this module,
- * hence why the functions are `@trusted`.
- * To make things `@nogc`, default-initialized instances are thrown.
- */
-private class ParseException : Exception
-{
-    public this(string msg) @safe pure nothrow
-    {
-        super(msg);
-    }
-}
-
-/// Ditto
-private noreturn error(string msg = "Invalid symbol") @trusted pure
-{
-    version (DigitalMars) pragma(inline, false); // tame dmd inliner
-
-    //throw new ParseException( msg );
-    debug(info) printf( "error: %.*s\n", cast(int) msg.length, msg.ptr );
-    throw __ctfe ? new ParseException(msg)
-        : cast(ParseException) __traits(initSymbol, ParseException).ptr;
-}
-
 private struct Buffer
 {
     enum size_t minSize = 4000;
@@ -2886,7 +3097,7 @@ private struct Buffer
         return bslice(from, to);
     }
 
-    static bool contains(scope const(char)[] a, scope const BufSlice b) @safe
+    static bool contains(scope const(char)[] a, scope const BufSlice b) @safe nothrow
     {
         return
             b.from < a.length &&
@@ -2903,7 +3114,7 @@ private struct Buffer
         return r;
     }
 
-    private void checkAndStretchBuf(size_t len_to_add) scope
+    private void checkAndStretchBuf(size_t len_to_add) scope nothrow
     {
         const required = len + len_to_add;
 
@@ -2912,7 +3123,7 @@ private struct Buffer
     }
 
     // move val to the end of the dst buffer
-    BufSlice shift(scope const BufSlice val) return scope
+    BufSlice shift(scope const BufSlice val) return scope nothrow
     {
         version (DigitalMars) pragma(inline, false); // tame dmd inliner
 
@@ -2943,7 +3154,7 @@ private struct Buffer
     }
 
     // remove val from dst buffer
-    void remove(scope BufSlice val) scope
+    void remove(scope BufSlice val) scope nothrow
     {
         version (DigitalMars) pragma(inline, false); // tame dmd inliner
 
@@ -2958,7 +3169,7 @@ private struct Buffer
         }
     }
 
-    void append(scope const(char)[] val) scope
+    void append(scope const(char)[] val) scope nothrow
     {
         version (DigitalMars) pragma(inline, false); // tame dmd inliner
 
@@ -2981,12 +3192,6 @@ private struct Buffer
 
     @nogc:
 
-    // from index to end of current buf
-    private scope bslice(size_t from) nothrow
-    {
-        return bslice(from, len);
-    }
-
     private scope bslice(size_t from, size_t to) nothrow
     {
         return BufSlice(dst, from, to);
@@ -2994,7 +3199,7 @@ private struct Buffer
 
     private scope bslice_empty() nothrow
     {
-        return BufSlice(null, 0, 0);
+        return BufSlice.init;
     }
 }
 

--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -180,11 +180,14 @@ pure @safe:
     }
 
 
-    void silent( void delegate() pure @safe nothrow dg ) nothrow
+    void silent( out bool err_status, void delegate(out bool err_status) pure @safe nothrow dg ) nothrow
     {
         debug(trace) printf( "silent+\n" );
         debug(trace) scope(success) printf( "silent-\n" );
-        auto n = dst.length; dg(); dst.len = n;
+        auto n = dst.length;
+        dg(err_status);
+        if(!err_status)
+            dst.len = n;
     }
 
 
@@ -1704,7 +1707,7 @@ pure @safe:
                     }
                 }
                 BufSlice name = dst.bslice_empty;
-                silent( delegate void() nothrow { name = parseType(err_status); } );
+                silent( err_status, delegate void(out bool e_flg) nothrow { name = parseType(e_flg); } );
                 if (err_status) return;
                 parseValue( err_status, name, t );
                 if (err_status) return;

--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -2405,7 +2405,7 @@ char[] reencodeMangled(return scope const(char)[] mangled) nothrow pure @safe
     d.parseMangledName(err_status);
     if (err_status)
     {
-        // Error cannot occur
+        // error cannot occur
         return mangled.dup;
     }
 
@@ -3197,7 +3197,7 @@ private struct Buffer
         return BufSlice(dst, from, to);
     }
 
-    private scope bslice_empty() nothrow
+    private static scope bslice_empty() nothrow
     {
         return BufSlice.init;
     }

--- a/druntime/src/core/demangle.d
+++ b/druntime/src/core/demangle.d
@@ -219,10 +219,8 @@ pure @safe:
 
     void popFront() nothrow
     {
-        import core.exception : RangeError;
-
         if ( pos++ >= buf.length )
-            throw new RangeError;
+            assert(false);
     }
 
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15504

How it implemented: methods containing those two loops in which exceptions were used for normal control flow were declared as `nothrow`. In each method, which previously could throw internal `ParseException`, now boolean flags (`err_status`) is used. Subsequently, gradually all functions used inside calls were also converted into `nothrow`. In fact, as a result all exceptions disappeared from code.

I don’t like that there is introduced a lot of code that looks like copy-paste (all these `if (err_state) ...` statements). Need ideas