### PR TITLE
fix bugzilla Issue 23515 - Named Enum of function SIGSEGFAULT 

### DIFF
--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -3292,7 +3292,7 @@ elem* toElem(Expression e, ref IRState irs)
 
     elem* visitCall(CallExp ce)
     {
-        printf("[%s] CallExp.toElem('%s') %p, %s\n", ce.loc.toChars(), ce.toChars(), ce, ce.type.toChars());
+        //printf("[%s] CallExp.toElem('%s') %p, %s\n", ce.loc.toChars(), ce.toChars(), ce, ce.type.toChars());
         assert(ce.e1.type);
         Type t1 = ce.e1.type.toBasetype();
         Type ectype = t1;

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -3292,7 +3292,7 @@ elem* toElem(Expression e, ref IRState irs)
 
     elem* visitCall(CallExp ce)
     {
-        //printf("[%s] CallExp.toElem('%s') %p, %s\n", ce.loc.toChars(), ce.toChars(), ce, ce.type.toChars());
+        printf("[%s] CallExp.toElem('%s') %p, %s\n", ce.loc.toChars(), ce.toChars(), ce, ce.type.toChars());
         assert(ce.e1.type);
         Type t1 = ce.e1.type.toBasetype();
         Type ectype = t1;

--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -503,6 +503,8 @@ void enumMemberSemantic(Scope* sc, EnumMember em)
     {
         Expression e = em.value;
         assert(e.dyncast() == DYNCAST.expression);
+        if (em.ed.memtype)
+            e = inferType(e, em.ed.memtype);
         e = e.expressionSemantic(sc);
         e = resolveProperties(sc, e);
         e = e.ctfeInterpret();

--- a/compiler/test/runnable/xtestenum.d
+++ b/compiler/test/runnable/xtestenum.d
@@ -156,6 +156,19 @@ class C7379
 }
 
 /***********************************/
+// https://issues.dlang.org/show_bug.cgi?id=23515
+
+enum Easing : void function()
+{
+    identity1 = (){},
+}
+
+void test23515()
+{
+    Easing.identity1();
+}
+
+/***********************************/
 
 int main()
 {
@@ -166,6 +179,7 @@ int main()
     test5();
     test6();
     test7();
+    test23515();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
The crash was because the ()[] delegate was supposed to be a function pointer.