### PR TITLE
Fix bugzilla issue 24363 - hex string postfixes are useless

### DIFF
--- a/changelog/dmd.hexstring-cast.dd
+++ b/changelog/dmd.hexstring-cast.dd
@@ -11,10 +11,19 @@ immutable uint[] data = cast(immutable uint[]) x"AABBCCDD";
 static assert(data[0] == 0xAABBCCDD);
 ---
 
-When the hex string has a character postfix, or its length is not a multiple of the element size, it is an error:
+Character postfixes can now also be used for integers of size 2 or 4:
+---
+immutable ushort[] f = x"80 3F"w;
+static assert(f[0] == 0x803F);
+
+immutable int[] f = x"80 35 FF FD"d;
+static assert(f[0] == 0x803FFF);
+---
+
+Formerly, they would pad each byte with 1 or 3 zeros, which did not serve a purpose (See [Issue 24363](https://issues.dlang.org/show_bug.cgi?id=24363)).
+
+If the string's byte length is not a multiple of the target element size, it is an error:
 
 ---
-auto e = cast(immutable ushort[]) x"AABBCC"; // Error, 3 bytes is not a multiple of `ushort.sizeof`
-
-auto f = cast(immutable ushort[]) x"AABB"w; // Error, hex string has wide character postfix
+immutable ushort[] e = x"AABBCC"w; // Error, 3 bytes is not a multiple of `ushort.sizeof`
 ---

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -721,11 +721,6 @@ extern(C++) MATCH implicitConvTo(Expression e, Type t)
                     return m;
                 case Tint8:
                 case Tuns8:
-                    if (e.hexString)
-                    {
-                        m = MATCH.convert;
-                        return m;
-                    }
                     break;
                 case Tenum:
                     if (tn.isTypeEnum().sym.isSpecial())
@@ -738,6 +733,14 @@ extern(C++) MATCH implicitConvTo(Expression e, Type t)
                     break;
                 default:
                     break;
+                }
+            }
+            if (e.hexString)
+            {
+                if (tn.isintegral && tn.size == e.sz)
+                {
+                    m = MATCH.convert;
+                    return m;
                 }
             }
             break;

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -50,6 +50,7 @@ import dmd.rootobject;
 import dmd.root.utf;
 import dmd.statement;
 import dmd.tokens;
+import dmd.utils : arrayCastBigEndian;
 import dmd.visitor;
 
 /*************************************
@@ -7743,45 +7744,4 @@ private void removeHookTraceImpl(ref CallExp ce, ref FuncDeclaration fd)
 
     if (global.params.v.verbose)
         message("strip     %s =>\n          %s", oldCE.toChars(), ce.toChars());
-}
-
-/**
- * Cast a `ubyte[]` to an array of larger integers as if we are on a big endian architecture
- * Params:
- *   data = array with big endian data
- *   size = 1 for ubyte[], 2 for ushort[], 4 for uint[], 8 for ulong[]
- * Returns: copy of `data`, with bytes shuffled if compiled for `version(LittleEndian)`
- */
-ubyte[] arrayCastBigEndian(const ubyte[] data, size_t size)
-{
-    ubyte[] impl(T)()
-    {
-        auto result = new T[](data.length / T.sizeof);
-        foreach (i; 0 .. result.length)
-        {
-            result[i] = 0;
-            foreach (j; 0 .. T.sizeof)
-            {
-                result[i] |= T(data[i * T.sizeof + j]) << ((T.sizeof - 1 - j) * 8);
-            }
-        }
-        return cast(ubyte[]) result;
-    }
-    switch (size)
-    {
-        case 1: return data.dup;
-        case 2: return impl!ushort;
-        case 4: return impl!uint;
-        case 8: return impl!ulong;
-        default: assert(0);
-    }
-}
-
-unittest
-{
-    ubyte[] data = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22];
-    assert(cast(ulong[]) arrayCastBigEndian(data, 8) == [0xAABBCCDDEEFF1122]);
-    assert(cast(uint[]) arrayCastBigEndian(data, 4) == [0xAABBCCDD, 0xEEFF1122]);
-    assert(cast(ushort[]) arrayCastBigEndian(data, 2) == [0xAABB, 0xCCDD, 0xEEFF, 0x1122]);
-    assert(cast(ubyte[]) arrayCastBigEndian(data, 1) == data);
 }

--- a/compiler/src/dmd/dmangle.d
+++ b/compiler/src/dmd/dmangle.d
@@ -951,6 +951,14 @@ public:
         OutBuffer tmp;
         const(char)[] q;
 
+        void mangleAsArray()
+        {
+            buf.writeByte('A');
+            buf.print(e.len);
+            foreach (i; 0 .. e.len)
+                mangleInteger(e.getIndex(i));
+        }
+
         /* Write string in UTF-8 format
          */
         switch (e.sz)
@@ -967,7 +975,7 @@ public:
             {
                 dchar c;
                 if (const s = utf_decodeWchar(slice, u, c))
-                    error(e.loc, "%.*s", cast(int)s.length, s.ptr);
+                    return mangleAsArray();
                 else
                     tmp.writeUTF8(c);
             }
@@ -981,7 +989,7 @@ public:
             foreach (c; slice)
             {
                 if (!utf_isValidDchar(c))
-                    error(e.loc, "invalid UCS-32 char \\U%08x", c);
+                    return mangleAsArray();
                 else
                     tmp.writeUTF8(c);
             }
@@ -990,13 +998,7 @@ public:
         }
         case 8:
             // String of size 8 has to be hexstring cast to long[], mangle as array literal
-            buf.writeByte('A');
-            buf.print(e.len);
-            foreach (i; 0 .. e.len)
-            {
-                mangleInteger(e.getIndex(i));
-            }
-            return;
+            return mangleAsArray();
         default:
             assert(0);
         }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -85,6 +85,7 @@ import dmd.traits;
 import dmd.typesem;
 import dmd.typinf;
 import dmd.utils;
+import dmd.utils : arrayCastBigEndian;
 import dmd.visitor;
 
 enum LOGSEMANTIC = false;
@@ -4242,7 +4243,33 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         size_t u;
         dchar c;
 
-        switch (e.postfix)
+        if (e.hexString)
+        {
+            const data = cast(const ubyte[]) e.peekString();
+            switch (e.postfix)
+            {
+                case 'd':
+                    e.sz = 4;
+                    e.type = Type.tdstring;
+                    break;
+                case 'w':
+                    e.sz = 2;
+                    e.type = Type.twstring;
+                    break;
+                case 'c':
+                default:
+                    e.type = Type.tstring;
+                    e.sz = 1;
+                    break;
+            }
+            if ((e.len % e.sz) != 0)
+                error(e.loc, "hex string with `%s` type needs to be multiple of %d bytes, not %d",
+                    e.type.toChars(), e.sz, cast(int) e.len);
+
+            e.setData(arrayCastBigEndian(data, e.sz).ptr, e.len / e.sz, e.sz);
+            e.committed = true;
+        }
+        else switch (e.postfix)
         {
         case 'd':
             for (u = 0; u < e.len;)

--- a/compiler/src/dmd/utils.d
+++ b/compiler/src/dmd/utils.d
@@ -299,3 +299,44 @@ bool parseDigits(T)(ref T val, const(char)[] p, const T max = T.max)
     assert(i.parseDigits("420", 500) && i == 420);
     assert(!i.parseDigits("420", 400));
 }
+
+/**
+ * Cast a `ubyte[]` to an array of larger integers as if we are on a big endian architecture
+ * Params:
+ *   data = array with big endian data
+ *   size = 1 for ubyte[], 2 for ushort[], 4 for uint[], 8 for ulong[]
+ * Returns: copy of `data`, with bytes shuffled if compiled for `version(LittleEndian)`
+ */
+ubyte[] arrayCastBigEndian(const ubyte[] data, size_t size)
+{
+    ubyte[] impl(T)()
+    {
+        auto result = new T[](data.length / T.sizeof);
+        foreach (i; 0 .. result.length)
+        {
+            result[i] = 0;
+            foreach (j; 0 .. T.sizeof)
+            {
+                result[i] |= T(data[i * T.sizeof + j]) << ((T.sizeof - 1 - j) * 8);
+            }
+        }
+        return cast(ubyte[]) result;
+    }
+    switch (size)
+    {
+        case 1: return data.dup;
+        case 2: return impl!ushort;
+        case 4: return impl!uint;
+        case 8: return impl!ulong;
+        default: assert(0);
+    }
+}
+
+unittest
+{
+    ubyte[] data = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22];
+    assert(cast(ulong[]) arrayCastBigEndian(data, 8) == [0xAABBCCDDEEFF1122]);
+    assert(cast(uint[]) arrayCastBigEndian(data, 4) == [0xAABBCCDD, 0xEEFF1122]);
+    assert(cast(ushort[]) arrayCastBigEndian(data, 2) == [0xAABB, 0xCCDD, 0xEEFF, 0x1122]);
+    assert(cast(ubyte[]) arrayCastBigEndian(data, 1) == data);
+}

--- a/compiler/test/fail_compilation/hexstring.d
+++ b/compiler/test/fail_compilation/hexstring.d
@@ -2,8 +2,6 @@
 TEST_OUTPUT:
 ---
 fail_compilation/hexstring.d(29): Error: cannot implicitly convert expression `"123F"` of type `string` to `immutable(ubyte[])`
-fail_compilation/hexstring.d(30): Error: cannot implicitly convert expression `x"123F"c` of type `string` to `immutable(ubyte[])`
-fail_compilation/hexstring.d(31): Error: cannot implicitly convert expression `x"123F"` of type `string` to `immutable(ubyte[])`
 fail_compilation/hexstring.d(33): Error: hex string length 1 must be a multiple of 2 to cast to `immutable(ushort[])`
 fail_compilation/hexstring.d(34): Error: hex string length 3 must be a multiple of 4 to cast to `immutable(uint[])`
 fail_compilation/hexstring.d(35): Error: hex string length 5 must be a multiple of 8 to cast to `immutable(ulong[])`
@@ -13,6 +11,8 @@ fail_compilation/hexstring.d(37): Error: array cast from `string` to `immutable(
 fail_compilation/hexstring.d(38): Error: array cast from `string` to `immutable(ushort[])` is not supported at compile time
 fail_compilation/hexstring.d(39): Error: array cast from `string` to `immutable(uint[])` is not supported at compile time
 fail_compilation/hexstring.d(39):        perhaps remove postfix `c` from hex string
+fail_compilation/hexstring.d(40): Error: hex string with `dstring` type needs to be multiple of 4 bytes, not 5
+fail_compilation/hexstring.d(41): Error: cannot implicitly convert expression `x"44332211"d` of type `dstring` to `immutable(float[])`
 fail_compilation/hexstring.d(28): Error: cannot implicitly convert expression `x"123F"` of type `string` to `ubyte[]`
 ---
 */
@@ -33,7 +33,9 @@ immutable ubyte[] f4 = cast(string) x"123F";
 immutable ushort[] f5 = cast(immutable ushort[]) x"11";
 immutable uint[] f6 = cast(immutable uint[]) x"112233";
 immutable ulong[] f7 = cast(immutable ulong[]) x"1122334455";
-immutable ulong[] f8 = cast(immutable ulong[]) x"1122334455"w;
+immutable ulong[] f8 = cast(immutable ulong[]) x"11223344"w;
 immutable uint[] f9 = cast(immutable uint[]) "ABCD";
 immutable ushort[] f10 = cast(immutable ushort[]) (x"1122" ~ "");
 immutable uint[] f11 = cast(immutable uint[]) x"AABBCCDD"c;
+immutable uint[] f12 = x"1122334455"d;
+immutable float[] f13 = x"11223344"d;

--- a/compiler/test/runnable/literal.d
+++ b/compiler/test/runnable/literal.d
@@ -260,6 +260,14 @@ void testHexstring()
     // Test printing StringExp with size 8
     enum toStr(immutable ulong[] v) = v.stringof;
     static assert(toStr!y == `x"88776655443322119900FFEEDDCCBBAA"`);
+
+    // Hex string postfixes
+    // https://issues.dlang.org/show_bug.cgi?id=24363
+    wstring wStr = x"AA BB CC DD"w;
+    immutable int[] dStr = x"AA BB CC DD"d;
+    assert(wStr[0] == 0xAABB);
+    assert(wStr[1] == 0xCCDD);
+    assert(dStr[0] == 0xAABBCCDD);
 }
 
 /***************************************************/


### PR DESCRIPTION
`arrayCastBigEndian` is cut and pasted to utils.d with no further changes.