### PR TITLE
Flags comment section as strings and mergeable

### DIFF
--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -706,7 +706,7 @@ Obj ElfObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
         elf_newsection2(NAMIDX.STRTAB,SHT_STRTAB, 0,                    0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX.SYMTAB,SHT_SYMTAB, 0,                    0,0,0,0,0, 8,0);
         elf_newsection2(NAMIDX.SHSTRTAB,SHT_STRTAB, 0,                  0,0,0,0,0, 1,0);
-        elf_newsection2(NAMIDX.COMMENT, SHT_PROGBITS,0,                 0,0,0,0,0, 1,0);
+        elf_newsection2(NAMIDX.COMMENT, SHT_PROGBITS,SHF_STRINGS|SHF_MERGE,0,0,0,0,0, 1,1);
         elf_newsection2(NAMIDX.NOTE,SHT_NOTE,   0,                      0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX.GNUSTACK,SHT_PROGBITS,0,                 0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX.CDATAREL,SHT_PROGBITS,SHF_ALLOC|SHF_WRITE,0,0,0,0,0, 16,0);
@@ -749,7 +749,7 @@ Obj ElfObj_init(OutBuffer *objbuf, const(char)* filename, const(char)* csegname)
         elf_newsection2(NAMIDX.STRTAB,SHT_STRTAB, 0,                    0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX.SYMTAB,SHT_SYMTAB, 0,                    0,0,0,0,0, 4,0);
         elf_newsection2(NAMIDX.SHSTRTAB,SHT_STRTAB, 0,                  0,0,0,0,0, 1,0);
-        elf_newsection2(NAMIDX.COMMENT, SHT_PROGBITS,0,                 0,0,0,0,0, 1,0);
+        elf_newsection2(NAMIDX.COMMENT, SHT_PROGBITS,SHF_STRINGS|SHF_MERGE,0,0,0,0,0, 1,1);
         elf_newsection2(NAMIDX.NOTE,SHT_NOTE,   0,                      0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX.GNUSTACK,SHT_PROGBITS,0,                 0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX.CDATAREL,SHT_PROGBITS,SHF_ALLOC|SHF_WRITE,0,0,0,0,0, 1,0);


### PR DESCRIPTION
* Before

```console
$ readelf -WS hello| grep \.comment
  [31] .comment          PROGBITS        0000000000000000 0b0600 006327 00      0   0  1
$ readelf -p .comment hello| head -20

String dump of section '.comment':
  [     0]  GCC: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
  [    2c]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [    4f]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [    72]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [    95]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [    b8]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [    db]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [    fe]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [   121]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [   144]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [   167]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [   18a]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [   1ad]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [   1d0]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [   1f3]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [   216]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [   239]  DMD v2.107.0-rc.1-130-g3c5b39b575
  [   25c]  DMD v2.107.0-rc.1-130-g3c5b39b575
```

* After

```console
$ readelf -WS hello| grep \.comment
  [31] .comment          PROGBITS        0000000000000000 0b0600 00004d 01  MS  0   0  1
$ readelf -p .comment hello

String dump of section '.comment':
  [     0]  GCC: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
  [    2b]  DMD v2.107.0-rc.1-131-g5a72fccdc2
```