### PR TITLE
Move constOf from mtype.type to typesem

### DIFF
--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -30,6 +30,7 @@ import dmd.location;
 import dmd.root.filename;
 import dmd.visitor;
 import dmd.tokens;
+import dmd.typesem;
 
 import dmd.common.outbuffer;
 import dmd.utils;

--- a/compiler/src/dmd/e2ir.d
+++ b/compiler/src/dmd/e2ir.d
@@ -621,6 +621,7 @@ elem* toElem(Expression e, ref IRState irs)
         {
             if (se.type.isTypeDArray())
             {
+                import dmd.typesem : constOf;
                 assert(se.type == Type.tvoid.arrayOf().constOf(), se.toString());
 
                 // Generate s[0 .. Aggregate.sizeof] for non-zero initialised aggregates

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -1742,9 +1742,7 @@ public:
             {}
     };
 
-private:
     Mcache* mcache;
-public:
     Type* pto;
     Type* rto;
     Type* arrayof;
@@ -1841,7 +1839,6 @@ public:
     bool isSharedWild() const;
     bool isNaked() const;
     Type* nullAttributes() const;
-    Type* constOf();
     Type* immutableOf();
     Type* mutableOf();
     Type* sharedOf();
@@ -5439,6 +5436,8 @@ public:
     StaticAssert* isStaticAssert() override;
     void accept(Visitor* v) override;
 };
+
+extern Type* constOf(Type* type);
 
 extern Covariant covariant(Type* src, Type* t, uint64_t* pstc = nullptr, bool cppCovariant = false);
 

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -299,7 +299,7 @@ extern (C++) abstract class Type : ASTNode
         Type swto;      // MODFlags.shared_ | MODFlags.wild
         Type swcto;     // MODFlags.shared_ | MODFlags.wildconst
     }
-    private Mcache* mcache;
+    Mcache* mcache;
 
     Type pto;       // merged pointer to this type
     Type rto;       // reference to this type
@@ -782,26 +782,6 @@ extern (C++) abstract class Type : ASTNode
             (cast(TypeStruct)t).att = AliasThisRec.fwdref;
         if (t.ty == Tclass)
             (cast(TypeClass)t).att = AliasThisRec.fwdref;
-        return t;
-    }
-
-    /********************************
-     * Convert to 'const'.
-     */
-    final Type constOf()
-    {
-        //printf("Type::constOf() %p %s\n", this, toChars());
-        if (mod == MODFlags.const_)
-            return this;
-        if (mcache && mcache.cto)
-        {
-            assert(mcache.cto.mod == MODFlags.const_);
-            return mcache.cto;
-        }
-        Type t = makeConst();
-        t = t.merge();
-        t.fixTo(this);
-        //printf("-Type::constOf() %p %s\n", t, t.toChars());
         return t;
     }
 
@@ -1515,7 +1495,7 @@ extern (C++) abstract class Type : ASTNode
                     if (isWild())
                         t = wildConstOf();
                     else
-                        t = constOf();
+                        t = t.constOf();
                 }
                 break;
 

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -142,11 +142,7 @@ public:
     TY ty;
     MOD mod;  // modifiers MODxxxx
     char *deco;
-
-private:
     void* mcache;
-
-public:
     Type *pto;          // merged pointer to this type
     Type *rto;          // reference to this type
     Type *arrayof;      // array of this type
@@ -257,7 +253,6 @@ public:
     bool isSharedWild() const  { return (mod & (MODshared | MODwild)) == (MODshared | MODwild); }
     bool isNaked() const       { return mod == 0; }
     Type *nullAttributes() const;
-    Type *constOf();
     Type *immutableOf();
     Type *mutableOf();
     Type *sharedOf();
@@ -909,3 +904,4 @@ bool isBaseOf(Type *tthis, Type *t, int *poffset);
 Type *trySemantic(Type *type, const Loc &loc, Scope *sc);
 void purityLevel(TypeFunction *type);
 Type *merge2(Type *type);
+Type *constOf(Type *type);

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -6106,6 +6106,26 @@ extern(C++) bool isBaseOf(Type tthis, Type t, int* poffset)
     return false;
 }
 
+/********************************
+ * Convert to 'const'.
+ */
+extern(C++) Type constOf(Type type)
+{
+    //printf("Type::constOf() %p %s\n", type, type.toChars());
+    if (type.mod == MODFlags.const_)
+        return type;
+    if (type.mcache && type.mcache.cto)
+    {
+        assert(type.mcache.cto.mod == MODFlags.const_);
+        return type.mcache.cto;
+    }
+    Type t = type.makeConst();
+    t = t.merge();
+    t.fixTo(type);
+    //printf("-Type::constOf() %p %s\n", t, t.toChars());
+    return t;
+}
+
 /******************************* Private *****************************************/
 
 private:


### PR DESCRIPTION
This PR is the first in a series of PRs to extract the ?of functions (? = const, shared, immutable, array etc.) from mtype and move them to typesem. This is needed because these functions also merge the newly obtained type  by calling the `merge` function which depends on the mangler which depends on semantic. The fact that the mangler depends on semantic looks like a code smell to me, however, I have not investigated that further so I don't actually know why semantic methods are needed in the mangler.

Regardless, moving these functions outside of mtype should be a plus since it makes the type classes thinner. Ideally, these could be moved to a different file called mtype_helpers.