### PR TITLE
Fix sliceCmpStringWithArray for StringExp with size 8

### DIFF
--- a/compiler/src/dmd/constfold.d
+++ b/compiler/src/dmd/constfold.d
@@ -1331,9 +1331,9 @@ int sliceCmpStringWithArray(const StringExp se1, ArrayLiteralExp ae2, size_t lo1
 {
     foreach (j; 0 .. len)
     {
-        const val2 = cast(dchar)ae2[j + lo2].toInteger();
-        const val1 = se1.getCodeUnit(j + lo1);
-        const int c = val1 - val2;
+        const val2 = ae2[j + lo2].toInteger();
+        const val1 = se1.getIndex(j + lo1);
+        const int c = (val1 > val2) - (val1 < val2);
         if (c)
             return c;
     }

--- a/compiler/test/runnable/literal.d
+++ b/compiler/test/runnable/literal.d
@@ -268,6 +268,11 @@ void testHexstring()
     assert(wStr[0] == 0xAABB);
     assert(wStr[1] == 0xCCDD);
     assert(dStr[0] == 0xAABBCCDD);
+
+    // Test sliceCmpStringWithArray with size 8
+    static immutable ulong[] z0 = cast(immutable ulong[]) x"1111 1111 1111 1111 0000 000F 0000 0000";
+    static immutable ulong[] z1 = [0x1111_1111_1111_1111, 0x0000_000E_0000_0000];
+    static assert(z0 !is z1);
 }
 
 /***************************************************/


### PR DESCRIPTION
Comparison with `<` or `==` gets lowered to `__cmp`, it seems the function is only used for comparison with the `is` operator.