### PR TITLE
test: Add UNICODE_NAMES directive to files with utf-8 symbols

### DIFF
--- a/compiler/test/README.md
+++ b/compiler/test/README.md
@@ -343,6 +343,12 @@ The following is a list of all available settings:
                                             arguments: the regex
                                             note: patterns containing ')' must be quoted
 
+    UNICODE_NAMES:      file containing symbols with unicode characters in their name, which might
+                        not be supported on some specific platforms. It is currently ignored by the
+                        test runner, but serves as documentation of the test itself.
+                        default: (none)
+
+
 Environment variables
 ------------------------------
 

--- a/compiler/test/runnable/mangle.d
+++ b/compiler/test/runnable/mangle.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS:
 // EXTRA_SOURCES: imports/mangle10077.d
 // EXTRA_FILES: imports/testmangle.d
+// UNICODE_NAMES:
 /*
 TEST_OUTPUT:
 ---

--- a/compiler/test/runnable/testmodule.d
+++ b/compiler/test/runnable/testmodule.d
@@ -1,4 +1,5 @@
 // PERMUTE_ARGS:
+// UNICODE_NAMES:
 
 // $HeadURL$
 // $Date$
@@ -11,6 +12,7 @@
 
 module run.unicode_06_哪里;
 
+//UTF-8 chars
 int 哪里(int ö){
         return ö+2;
 }

--- a/compiler/test/runnable/ufcs.d
+++ b/compiler/test/runnable/ufcs.d
@@ -1,4 +1,5 @@
 // EXTRA_SOURCES: imports/ufcs5a.d imports/ufcs5b.d imports/ufcs5c.d imports/ufcs5d.d imports/ufcs5e.d
+// UNICODE_NAMES:
 
 module ufcs;
 
@@ -677,6 +678,7 @@ void test8453()
 /*******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=8503
 
+//UTF-8 chars
 void α8503(int i) {}
 
 void test8503()


### PR DESCRIPTION
Files containing symbols with unicode characters in their name might not be supported on some specific platforms.  For example, the Solaris assembler lacks support for UTF-8 characters.

```
Assembler: mangle.d
        "/var/tmp//cci9q2Sc.s", line 115 : Syntax error
        Near line: "    movzbl  test_эльфийские_письмена_9, %eax"
Assembler: testmodule.d
        "/var/tmp//ccBtixAd.s", line 3 : Syntax error
        Near line: "    .globl  _D3run17unicode_06_哪里6哪里FiZi"
Assembler: ufcs.d
        "/var/tmp//ccodJ7Ib.s", line 6662 : Syntax error
        Near line: "    .globl  _D4ufcs6α8503FiZv"
```

Add a new directive which can be used by other testsuite runners as a hint to selectively disable the test if they know they can't compile this ahead of time.