### PR TITLE
[REG master] Explicitly instantiate StringValue!Type in dmd.mtype

### DIFF
--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -52,6 +52,12 @@ enum LOGDEFAULTINIT = 0;    // log ::defaultInit()
 
 enum SIZE_INVALID = (~cast(uinteger_t)0);   // error return from size() functions
 
+static if (__VERSION__ < 2095)
+{
+    // Fix linker errors when building with older compilers.
+    // See: https://issues.dlang.org/show_bug.cgi?id=21299
+    private alias StringValueType = StringValue!Type;
+}
 
 /***************************
  * Return !=0 if modfrom can be implicitly converted to modto


### PR DESCRIPTION
Previous history: #11827 #11838 #15854 #15872 #15873

Issue 21299 has reared its ugly head again, this time the revert needed to resolve it is:
```diff
--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -21,6 +21,7 @@ import dmd.arraytypes;
 import dmd.astcodegen;
 import dmd.astenums;
 import dmd.attrib;
+import dmd.blockexit;
 import dmd.clone;
 import dmd.cond;
 import dmd.dcast;
```

These code migrations between modules are making the import graph extremely brittle for compilers with the known template emission bug, and the relation between the bug and the change that triggered it is becoming less obvious.

In order to inure ourselves against these linker errors then, the `String!Value` type is now explicitly instantiated inside `dmd.mtype`. This is safe for compilers with and without the template issue, but it is put inside a `static if` block anyway to make it clear that it shouldn't be removed.