### PR TITLE
Introduce version() which disables memory-greedy unittests

### DIFF
--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -4941,6 +4941,7 @@ unittest
 // improve predictability of coverage of code that is eventually not hit by other tests
 debug (SENTINEL) {} else // cannot extend with SENTINEL
 debug (MARK_PRINTF) {} else // takes forever
+version (OnlyLowMemUnittests) {} else
 unittest
 {
     import core.memory;

--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -575,7 +575,7 @@ extern(C):
 
     // https://issues.dlang.org/show_bug.cgi?id=13111
     ///
-    version (OnlyLowMemUnittests) {} else
+    version (OnlyLowMemUnittests) {} else // Test needs a lot of RAM
     unittest
     {
         enum size1 = 1 << 11 + 1; // page in large object pool

--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -575,6 +575,7 @@ extern(C):
 
     // https://issues.dlang.org/show_bug.cgi?id=13111
     ///
+    version (OnlyLowMemUnittests) {} else
     unittest
     {
         enum size1 = 1 << 11 + 1; // page in large object pool

--- a/druntime/src/rt/aaA.d
+++ b/druntime/src/rt/aaA.d
@@ -437,6 +437,7 @@ unittest
         string[412] names;
         ubyte[1024] moredata;
     }
+    version (OnlyLowMemUnittests) {} else
     test!(Large, Large);
 }
 

--- a/druntime/src/rt/lifetime.d
+++ b/druntime/src/rt/lifetime.d
@@ -2247,6 +2247,7 @@ unittest
         assert(GC.getAttr(p) == BlkAttr.NO_SCAN);
     }
     test(16);
+    version (OnlyLowMemUnittests) {} else
     test(1024 * 1024);
 }
 


### PR DESCRIPTION
Adds ability to run unittests on systems in which there are <= 128Kb of the RAM