### PR TITLE
dwarfeh: version (DWARFEH) added to use by OSes which need it

### DIFF
--- a/druntime/src/rt/dwarfeh.d
+++ b/druntime/src/rt/dwarfeh.d
@@ -11,7 +11,8 @@
 
 module rt.dwarfeh;
 
-version (Posix):
+version (Posix) { version = DWARFEH; }
+version (DWARFEH):
 
 // debug = EH_personality;
 


### PR DESCRIPTION
Another little thing important to support non-Windows non-Posix targets: such targets also need EH support