### PR TITLE
Add toPrettyChars method in ASTBase.Dsymbol

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -95,6 +95,8 @@ struct ASTBase
                 this.comment = Lexer.combineComments(this.comment.toDString(), comment.toDString(), true);
         }
 
+        alias toPrettyChars = toChars;
+
         override const(char)* toChars() const
         {
             return ident ? ident.toChars() : "__anonymous";


### PR DESCRIPTION
Prior to https://github.com/dlang/dmd/pull/14906 , the parser did not use toPrettyChars as that function relies on hdrgen.d which technically should not use any semantical information but it does import modules such as `optimize.d`. For now, just add toPrettyChars as an alias to toChars and eventually we should make hdrgen not rely on semantic information. That way we can use it during parsing.