### PR TITLE
dmd: Move all public C++ functions into a dmd namespace

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -756,7 +756,7 @@ alias runCxxUnittest = makeRule!((runCxxBuilder, runCxxRule) {
         .description("Build the C++ unittests")
         .msg("(DC) CXX-UNITTEST")
         .deps([lexer(null, null), cxxFrontend])
-        .sources(sources.dmd.driver ~ sources.dmd.frontend ~ sources.root ~ sources.common)
+        .sources(sources.dmd.driver ~ sources.dmd.frontend ~ sources.root ~ sources.common ~ env["D"].buildPath("cxxfrontend.d"))
         .target(env["G"].buildPath("cxx-unittest").exeName)
         .command([ env["HOST_DMD_RUN"], "-of=" ~ exeRule.target, "-vtls", "-J" ~ env["RES"],
                     "-L-lstdc++", "-version=NoMain", "-version=NoBackend"

--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -41,8 +41,11 @@ enum class Baseok : uint8_t
     semanticdone  // all base classes semantic done
 };
 
-FuncDeclaration *search_toString(StructDeclaration *sd);
-void semanticTypeInfoMembers(StructDeclaration *sd);
+namespace dmd
+{
+    FuncDeclaration *search_toString(StructDeclaration *sd);
+    void semanticTypeInfoMembers(StructDeclaration *sd);
+}
 
 enum class ClassKind : uint8_t
 {

--- a/compiler/src/dmd/argtypes.h
+++ b/compiler/src/dmd/argtypes.h
@@ -13,10 +13,13 @@
 class Type;
 class TypeTuple;
 
-// in argtypes_x86.d
-TypeTuple *toArgTypes_x86(Type *t);
-// in argtypes_sysv_x64.d
-TypeTuple *toArgTypes_sysv_x64(Type *t);
-// in argtypes_aarch64.d
-TypeTuple *toArgTypes_aarch64(Type *t);
-bool isHFVA(Type *t, int maxNumElements = 4, Type **rewriteType = NULL);
+namespace dmd
+{
+    // in argtypes_x86.d
+    TypeTuple *toArgTypes_x86(Type *t);
+    // in argtypes_sysv_x64.d
+    TypeTuple *toArgTypes_sysv_x64(Type *t);
+    // in argtypes_aarch64.d
+    TypeTuple *toArgTypes_aarch64(Type *t);
+    bool isHFVA(Type *t, int maxNumElements = 4, Type **rewriteType = NULL);
+}

--- a/compiler/src/dmd/argtypes_aarch64.d
+++ b/compiler/src/dmd/argtypes_aarch64.d
@@ -27,7 +27,7 @@ import dmd.mtype;
  *      A tuple of zero length means the type cannot be passed/returned in registers.
  *      null indicates a `void`.
  */
-extern (C++) TypeTuple toArgTypes_aarch64(Type t)
+TypeTuple toArgTypes_aarch64(Type t)
 {
     if (t == Type.terror)
         return new TypeTuple(t);
@@ -82,7 +82,7 @@ extern (C++) TypeTuple toArgTypes_aarch64(Type t)
  * If the type is an HFVA and `rewriteType` is specified, it is set to a
  * corresponding static array type.
  */
-extern (C++) bool isHFVA(Type t, int maxNumElements = 4, Type* rewriteType = null)
+bool isHFVA(Type t, int maxNumElements = 4, Type* rewriteType = null)
 {
     t = t.toBasetype();
     if ((t.ty != Tstruct && t.ty != Tsarray && !t.iscomplex()) || !isPOD(t))

--- a/compiler/src/dmd/argtypes_sysv_x64.d
+++ b/compiler/src/dmd/argtypes_sysv_x64.d
@@ -30,7 +30,7 @@ import dmd.visitor;
  *      A tuple of zero length means the type cannot be passed/returned in registers.
  *      null indicates a `void`.
  */
-extern (C++) TypeTuple toArgTypes_sysv_x64(Type t)
+TypeTuple toArgTypes_sysv_x64(Type t)
 {
     if (t == Type.terror)
         return new TypeTuple(t);

--- a/compiler/src/dmd/argtypes_x86.d
+++ b/compiler/src/dmd/argtypes_x86.d
@@ -33,7 +33,7 @@ import dmd.visitor;
  *      A tuple of zero length means the type cannot be passed/returned in registers.
  *      null indicates a `void`.
  */
-extern (C++) TypeTuple toArgTypes_x86(Type t)
+TypeTuple toArgTypes_x86(Type t)
 {
     extern (C++) final class ToArgTypes : Visitor
     {

--- a/compiler/src/dmd/cppmangle.d
+++ b/compiler/src/dmd/cppmangle.d
@@ -65,7 +65,7 @@ package CppOperator isCppOperator(Identifier id)
 }
 
 ///
-extern(C++) const(char)* toCppMangleItanium(Dsymbol s)
+const(char)* toCppMangleItanium(Dsymbol s)
 {
     //printf("toCppMangleItanium(%s)\n", s.toChars());
     OutBuffer buf;
@@ -75,7 +75,7 @@ extern(C++) const(char)* toCppMangleItanium(Dsymbol s)
 }
 
 ///
-extern(C++) const(char)* cppTypeInfoMangleItanium(Dsymbol s)
+const(char)* cppTypeInfoMangleItanium(Dsymbol s)
 {
     //printf("cppTypeInfoMangle(%s)\n", s.toChars());
     OutBuffer buf;
@@ -86,7 +86,7 @@ extern(C++) const(char)* cppTypeInfoMangleItanium(Dsymbol s)
 }
 
 ///
-extern(C++) const(char)* cppThunkMangleItanium(FuncDeclaration fd, int offset)
+const(char)* cppThunkMangleItanium(FuncDeclaration fd, int offset)
 {
     //printf("cppThunkMangleItanium(%s)\n", fd.toChars());
     OutBuffer buf;

--- a/compiler/src/dmd/cppmanglewin.d
+++ b/compiler/src/dmd/cppmanglewin.d
@@ -38,9 +38,6 @@ import dmd.tokens;
 import dmd.typesem;
 import dmd.visitor;
 
-extern (C++):
-
-
 const(char)* toCppMangleMSVC(Dsymbol s)
 {
     scope VisualCPPMangler v = new VisualCPPMangler(false, s.loc);
@@ -65,7 +62,7 @@ const(char)* cppTypeInfoMangleDMC(Dsymbol s) @safe
     assert(0);
 }
 
-private final class VisualCPPMangler : Visitor
+private extern (C++) final class VisualCPPMangler : Visitor
 {
     alias visit = Visitor.visit;
     Identifier[10] saved_idents;

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -1,0 +1,605 @@
+/**
+ * Contains C++ interfaces for interacting with DMD as a library.
+ *
+ * Copyright:   Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 https://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/cxxfrontend.d, _cxxfrontend.d)
+ * Documentation:  https://dlang.org/phobos/dmd_cxxfrontend.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/cxxfrontend.d
+ */
+module dmd.cxxfrontend;
+
+import dmd.aggregate : AggregateDeclaration;
+import dmd.arraytypes;
+import dmd.astenums;
+import dmd.common.outbuffer : OutBuffer;
+import dmd.dmodule /*: Module*/;
+import dmd.dscope : Scope;
+import dmd.dstruct /*: StructDeclaration*/;
+import dmd.dsymbol : Dsymbol, ScopeDsymbol, SearchOpt, SearchOptFlags;
+import dmd.dtemplate /*: TemplateInstance, TemplateParameter, Tuple*/;
+import dmd.errorsink : ErrorSink;
+import dmd.expression /*: Expression*/;
+import dmd.func : FuncDeclaration;
+import dmd.globals;
+import dmd.identifier : Identifier;
+import dmd.init : Initializer, NeedInterpret;
+import dmd.location : Loc;
+import dmd.mtype /*: Covariant, Type, Parameter, ParameterList*/;
+import dmd.rootobject : RootObject;
+import dmd.statement : Statement, AsmStatement, GccAsmStatement;
+
+// NB: At some point in the future, we can switch to shortened function syntax.
+extern (C++, "dmd"):
+
+/***********************************************************
+ * cppmangle.d
+ */
+const(char)* toCppMangleItanium(Dsymbol s)
+{
+    import dmd.cppmangle;
+    return dmd.cppmangle.toCppMangleItanium(s);
+}
+
+const(char)* cppTypeInfoMangleItanium(Dsymbol s)
+{
+    import dmd.cppmangle;
+    return dmd.cppmangle.cppTypeInfoMangleItanium(s);
+}
+
+const(char)* cppThunkMangleItanium(FuncDeclaration fd, int offset)
+{
+    import dmd.cppmangle;
+    return dmd.cppmangle.cppThunkMangleItanium(fd, offset);
+}
+
+/***********************************************************
+ * dinterpret.d
+ */
+Expression ctfeInterpret(Expression e)
+{
+    import dmd.dinterpret;
+    return dmd.dinterpret.ctfeInterpret(e);
+}
+
+/***********************************************************
+ * dmangle.d
+ */
+const(char)* mangleExact(FuncDeclaration fd)
+{
+    import dmd.dmangle;
+    return dmd.dmangle.mangleExact(fd);
+}
+
+void mangleToBuffer(Type t, ref OutBuffer buf)
+{
+    import dmd.dmangle;
+    return dmd.dmangle.mangleToBuffer(t, buf);
+}
+
+void mangleToBuffer(Expression e, ref OutBuffer buf)
+{
+    import dmd.dmangle;
+    return dmd.dmangle.mangleToBuffer(e, buf);
+}
+
+void mangleToBuffer(Dsymbol s, ref OutBuffer buf)
+{
+    import dmd.dmangle;
+    return dmd.dmangle.mangleToBuffer(s, buf);
+}
+
+void mangleToBuffer(TemplateInstance ti, ref OutBuffer buf)
+{
+    import dmd.dmangle;
+    return dmd.dmangle.mangleToBuffer(ti, buf);
+}
+
+/***********************************************************
+ * dmodule.d
+ */
+void getLocalClasses(Module mod, ref ClassDeclarations aclasses)
+{
+    return dmd.dmodule.getLocalClasses(mod, aclasses);
+}
+
+FuncDeclaration findGetMembers(ScopeDsymbol dsym)
+{
+    return dmd.dmodule.findGetMembers(dsym);
+}
+
+/***********************************************************
+ * doc.d
+ */
+void gendocfile(Module m, const char* ddoctext_ptr, size_t ddoctext_length,
+                const char* datetime, ErrorSink eSink, ref OutBuffer outbuf)
+{
+    import dmd.doc;
+    return dmd.doc.gendocfile(m, ddoctext_ptr, ddoctext_length, datetime, eSink, outbuf);
+}
+
+/***********************************************************
+ * dstruct.d
+ */
+FuncDeclaration search_toString(StructDeclaration sd)
+{
+    return dmd.dstruct.search_toString(sd);
+}
+
+/***********************************************************
+ * dsymbolsem.d
+ */
+void dsymbolSemantic(Dsymbol dsym, Scope* sc)
+{
+    import dmd.dsymbolsem;
+    return dmd.dsymbolsem.dsymbolSemantic(dsym, sc);
+}
+
+void addMember(Dsymbol dsym, Scope* sc, ScopeDsymbol sds)
+{
+    import dmd.dsymbolsem;
+    return dmd.dsymbolsem.addMember(dsym, sc, sds);
+}
+
+Dsymbol search(Dsymbol d, const ref Loc loc, Identifier ident, SearchOptFlags
+               flags = SearchOpt.all)
+{
+    import dmd.dsymbolsem;
+    return dmd.dsymbolsem.search(d, loc, ident, flags);
+}
+
+void setScope(Dsymbol d, Scope* sc)
+{
+    import dmd.dsymbolsem;
+    return dmd.dsymbolsem.setScope(d, sc);
+}
+
+void importAll(Dsymbol d, Scope* sc)
+{
+    import dmd.dsymbolsem;
+    return dmd.dsymbolsem.importAll(d, sc);
+}
+
+/***********************************************************
+ * dtemplate.d
+ */
+inout(Expression) isExpression(inout RootObject o)
+{
+    return dmd.dtemplate.isExpression(o);
+}
+
+inout(Dsymbol) isDsymbol(inout RootObject o)
+{
+    return dmd.dtemplate.isDsymbol(o);
+}
+
+inout(Type) isType(inout RootObject o)
+{
+    return dmd.dtemplate.isType(o);
+}
+
+inout(Tuple) isTuple(inout RootObject o)
+{
+    return dmd.dtemplate.isTuple(o);
+}
+
+inout(Parameter) isParameter(inout RootObject o)
+{
+    return dmd.dtemplate.isParameter(o);
+}
+
+inout(TemplateParameter) isTemplateParameter(inout RootObject o)
+{
+    return dmd.dtemplate.isTemplateParameter(o);
+}
+
+bool isError(const RootObject o)
+{
+    return dmd.dtemplate.isError(o);
+}
+
+void printTemplateStats(bool listInstances, ErrorSink eSink)
+{
+    return dmd.dtemplate.printTemplateStats(listInstances, eSink);
+}
+
+/***********************************************************
+ * dtoh.d
+ */
+void genCppHdrFiles(ref Modules ms)
+{
+    import dmd.dtoh;
+    return dmd.dtoh.genCppHdrFiles(ms);
+}
+
+/***********************************************************
+ * expression.d
+ */
+void expandTuples(Expressions* exps, Identifiers* names = null)
+{
+    return dmd.expression.expandTuples(exps, names);
+}
+
+/***********************************************************
+ * expressionsem.d
+ */
+Expression expressionSemantic(Expression e, Scope* sc)
+{
+    import dmd.expressionsem;
+    return dmd.expressionsem.expressionSemantic(e, sc);
+}
+
+/***********************************************************
+ * funcsem.d
+ */
+bool functionSemantic(FuncDeclaration fd)
+{
+    import dmd.funcsem;
+    return dmd.funcsem.functionSemantic(fd);
+}
+
+bool functionSemantic3(FuncDeclaration fd)
+{
+    import dmd.funcsem;
+    return dmd.funcsem.functionSemantic3(fd);
+}
+
+/***********************************************************
+ * hdrgen.d
+ */
+void genhdrfile(Module m, bool doFuncBodies, ref OutBuffer buf)
+{
+    import dmd.hdrgen;
+    return dmd.hdrgen.genhdrfile(m, doFuncBodies, buf);
+}
+
+const(char)* toChars(const Statement s)
+{
+    import dmd.hdrgen;
+    return dmd.hdrgen.toChars(s);
+}
+
+const(char)* toChars(const Expression e)
+{
+    import dmd.hdrgen;
+    return dmd.hdrgen.toChars(e);
+}
+
+const(char)* toChars(const Initializer i)
+{
+    import dmd.hdrgen;
+    return dmd.hdrgen.toChars(i);
+}
+
+const(char)* toChars(const Type t)
+{
+    import dmd.hdrgen;
+    return dmd.hdrgen.toChars(t);
+}
+
+void moduleToBuffer(ref OutBuffer buf, bool vcg_ast, Module m)
+{
+    import dmd.hdrgen;
+    return dmd.hdrgen.moduleToBuffer(buf, vcg_ast, m);
+}
+
+const(char)* parametersTypeToChars(ParameterList pl)
+{
+    import dmd.hdrgen;
+    return dmd.hdrgen.parametersTypeToChars(pl);
+}
+
+/***********************************************************
+ * iasm.d
+ */
+Statement asmSemantic(AsmStatement s, Scope *sc)
+{
+    import dmd.iasm;
+    return dmd.iasm.asmSemantic(s, sc);
+}
+
+/***********************************************************
+ * iasmgcc.d
+ */
+Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
+{
+    import dmd.iasmgcc;
+    return dmd.iasmgcc.gccAsmSemantic(s, sc);
+}
+
+/***********************************************************
+ * initsem.d
+ */
+Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx,
+                                NeedInterpret needInterpret)
+{
+    import dmd.initsem;
+    return dmd.initsem.initializerSemantic(init, sc, tx, needInterpret);
+}
+
+Expression initializerToExpression(Initializer init, Type itype = null, const
+                                   bool isCfile = false)
+{
+    import dmd.initsem;
+    return dmd.initsem.initializerToExpression(init, itype, isCfile);
+}
+
+/***********************************************************
+ * json.d
+ */
+void json_generate(ref Modules modules, ref OutBuffer buf)
+{
+    import dmd.json;
+    return dmd.json.json_generate(modules, buf);
+}
+
+JsonFieldFlags tryParseJsonField(const(char)* fieldName)
+{
+    import dmd.json;
+    return dmd.json.tryParseJsonField(fieldName);
+}
+
+/***********************************************************
+ * mtype.d
+ */
+AggregateDeclaration isAggregate(Type t)
+{
+    return dmd.mtype.isAggregate(t);
+}
+
+/***********************************************************
+ * optimize.d
+ */
+Expression optimize(Expression e, int result, bool keepLvalue = false)
+{
+    import dmd.optimize;
+    return dmd.optimize.optimize(e, result, keepLvalue);
+}
+
+/***********************************************************
+ * semantic2.d
+ */
+void semantic2(Dsymbol dsym, Scope* sc)
+{
+    import dmd.semantic2;
+    return dmd.semantic2.semantic2(dsym, sc);
+}
+
+/***********************************************************
+ * semantic3.d
+ */
+void semantic3(Dsymbol dsym, Scope* sc)
+{
+    import dmd.semantic3;
+    return dmd.semantic3.semantic3(dsym, sc);
+}
+
+void semanticTypeInfoMembers(StructDeclaration sd)
+{
+    import dmd.semantic3;
+    return dmd.semantic3.semanticTypeInfoMembers(sd);
+}
+
+/***********************************************************
+ * statementsem.d
+ */
+Statement statementSemantic(Statement s, Scope* sc)
+{
+    import dmd.statementsem;
+    return dmd.statementsem.statementSemantic(s, sc);
+}
+
+/***********************************************************
+ * templateparamsem.d
+ */
+bool tpsemantic(TemplateParameter tp, Scope* sc, TemplateParameters* parameters)
+{
+    import dmd.templateparamsem;
+    return dmd.templateparamsem.tpsemantic(tp, sc, parameters);
+}
+
+/***********************************************************
+ * typesem.d
+ */
+bool hasPointers(Type t)
+{
+    import dmd.typesem;
+    return dmd.typesem.hasPointers(t);
+}
+
+Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
+{
+    import dmd.typesem;
+    return dmd.typesem.typeSemantic(type, loc, sc);
+}
+
+Type trySemantic(Type type, const ref Loc loc, Scope* sc)
+{
+    import dmd.typesem;
+    return dmd.typesem.trySemantic(type, loc, sc);
+}
+
+Type merge(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.merge(type);
+}
+
+Type merge2(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.merge2(type);
+}
+
+Expression defaultInit(Type mt, const ref Loc loc, const bool isCfile = false)
+{
+    import dmd.typesem;
+    return dmd.typesem.defaultInit(mt, loc, isCfile);
+}
+
+Dsymbol toDsymbol(Type type, Scope* sc)
+{
+    import dmd.typesem;
+    return dmd.typesem.toDsymbol(type, sc);
+}
+
+Covariant covariant(Type src, Type t, StorageClass* pstc = null, bool
+                    cppCovariant = false)
+{
+    import dmd.typesem;
+    return dmd.typesem.covariant(src, t, pstc, cppCovariant);
+}
+
+bool isBaseOf(Type tthis, Type t, int* poffset)
+{
+    import dmd.typesem;
+    return dmd.typesem.isBaseOf(tthis, t, poffset);
+}
+
+bool equivalent(Type src, Type t)
+{
+    import dmd.typesem;
+    return dmd.typesem.equivalent(src, t);
+}
+
+Type constOf(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.constOf(type);
+}
+
+Type immutableOf(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.immutableOf(type);
+}
+
+Type mutableOf(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.mutableOf(type);
+}
+
+Type sharedOf(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.sharedOf(type);
+}
+
+Type sharedConstOf(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.sharedConstOf(type);
+}
+
+Type unSharedOf(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.unSharedOf(type);
+}
+
+Type wildOf(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.wildOf(type);
+}
+
+Type wildConstOf(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.wildConstOf(type);
+}
+
+Type sharedWildOf(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.sharedWildOf(type);
+}
+
+Type sharedWildConstOf(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.sharedWildConstOf(type);
+}
+
+Type castMod(Type type, MOD mod)
+{
+    import dmd.typesem;
+    return dmd.typesem.castMod(type, mod);
+}
+
+Type addMod(Type type, MOD mod)
+{
+    import dmd.typesem;
+    return dmd.typesem.addMod(type, mod);
+}
+
+Type pointerTo(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.pointerTo(type);
+}
+
+Type referenceTo(Type type)
+{
+    import dmd.typesem;
+    return dmd.typesem.referenceTo(type);
+}
+
+/***********************************************************
+ * typinf.d
+ */
+bool genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc)
+{
+    import dmd.typinf;
+    return dmd.typinf.genTypeInfo(e, loc, torig, sc);
+}
+
+bool isSpeculativeType(Type t)
+{
+    import dmd.typinf;
+    return dmd.typinf.isSpeculativeType(t);
+}
+
+bool builtinTypeInfo(Type t)
+{
+    import dmd.typinf;
+    return dmd.typinf.builtinTypeInfo(t);
+}
+
+version (IN_LLVM)
+{
+    /***********************************************************
+     * argtypes_aarch64.d
+     */
+    TypeTuple toArgTypes_aarch64(Type t)
+    {
+        import dmd.argtypes_aarch64;
+        return dmd.argtypes_aarch64.toArgTypes_aarch64(t);
+    }
+
+    bool isHFVA(Type t, int maxNumElements = 4, Type* rewriteType = null)
+    {
+        import dmd.argtypes_aarch64;
+        return dmd.argtypes_aarch64.isHFVA(t, maxNumElements, rewriteType);
+    }
+
+    /***********************************************************
+     * argtypes_sysv_x64.d
+     */
+    TypeTuple toArgTypes_sysv_x64(Type t)
+    {
+        import dmd.argtypes_sysv_x64;
+        return dmd.argtypes_sysv_x64.toArgTypes_sysv_x64(t);
+    }
+
+    /***********************************************************
+     * argtypes_x86.d
+     */
+    TypeTuple toArgTypes_x86(Type t)
+    {
+        import dmd.argtypes_x86;
+        return dmd.argtypes_x86.toArgTypes_x86(t);
+    }
+}

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -30,8 +30,11 @@ class StructDeclaration;
 struct IntRange;
 struct AttributeViolation;
 
-bool functionSemantic(FuncDeclaration* fd);
-bool functionSemantic3(FuncDeclaration* fd);
+namespace dmd
+{
+    bool functionSemantic(FuncDeclaration* fd);
+    bool functionSemantic3(FuncDeclaration* fd);
+}
 
 //enum STC : ulong from astenums.d:
 

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -63,7 +63,7 @@ import dmd.visitor;
  * functions and may invoke a function that contains `ErrorStatement` in its body.
  * If that, the "CTFE failed because of previous errors" error is raised.
  */
-extern(C++) public Expression ctfeInterpret(Expression e)
+public Expression ctfeInterpret(Expression e)
 {
     switch (e.op)
     {

--- a/compiler/src/dmd/dmangle.d
+++ b/compiler/src/dmd/dmangle.d
@@ -18,7 +18,7 @@ module dmd.dmangle;
 /******************************************************************************
  * Returns exact mangled name of function.
  */
-extern (C++) const(char)* mangleExact(FuncDeclaration fd)
+const(char)* mangleExact(FuncDeclaration fd)
 {
     //printf("mangleExact()\n");
     if (!fd.mangleString)
@@ -32,7 +32,7 @@ extern (C++) const(char)* mangleExact(FuncDeclaration fd)
     return fd.mangleString;
 }
 
-extern (C++) void mangleToBuffer(Type t, ref OutBuffer buf)
+void mangleToBuffer(Type t, ref OutBuffer buf)
 {
     //printf("mangleToBuffer t()\n");
     if (t.deco)
@@ -45,7 +45,7 @@ extern (C++) void mangleToBuffer(Type t, ref OutBuffer buf)
     }
 }
 
-extern (C++) void mangleToBuffer(Expression e, ref OutBuffer buf)
+void mangleToBuffer(Expression e, ref OutBuffer buf)
 {
     //printf("mangleToBuffer e()\n");
     auto backref = Backref(null);
@@ -53,7 +53,7 @@ extern (C++) void mangleToBuffer(Expression e, ref OutBuffer buf)
     e.accept(v);
 }
 
-extern (C++) void mangleToBuffer(Dsymbol s, ref OutBuffer buf)
+void mangleToBuffer(Dsymbol s, ref OutBuffer buf)
 {
     //printf("mangleToBuffer s(%s)\n", s.toChars());
     auto backref = Backref(null);
@@ -61,7 +61,7 @@ extern (C++) void mangleToBuffer(Dsymbol s, ref OutBuffer buf)
     s.accept(v);
 }
 
-extern (C++) void mangleToBuffer(TemplateInstance ti, ref OutBuffer buf)
+void mangleToBuffer(TemplateInstance ti, ref OutBuffer buf)
 {
     //printf("mangleToBuffer ti()\n");
     auto backref = Backref(null);

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1300,7 +1300,7 @@ extern (C++) struct ModuleDeclaration
  *      aclasses = array to fill in
  * Returns: array of local classes
  */
-extern (C++) void getLocalClasses(Module mod, ref ClassDeclarations aclasses)
+void getLocalClasses(Module mod, ref ClassDeclarations aclasses)
 {
     //printf("members.length = %d\n", mod.members.length);
     int pushAddClassDg(size_t n, Dsymbol sm)
@@ -1565,7 +1565,7 @@ private const(char)[] processSource (const(ubyte)[] src, Module mod)
  *      const(MemberInfo)[] getMembers(string);
  * Returns NULL if not found
  */
-extern(C++) FuncDeclaration findGetMembers(ScopeDsymbol dsym)
+FuncDeclaration findGetMembers(ScopeDsymbol dsym)
 {
     import dmd.opover : search_function;
     Dsymbol s = search_function(dsym, Id.getmembers);

--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -15,8 +15,6 @@ import core.stdc.stdio;
 import core.stdc.string;
 import core.stdc.stddef;
 
-extern (C++):
-
 import dmd.globals;
 import dmd.dclass;
 import dmd.dmdparams;

--- a/compiler/src/dmd/doc.d
+++ b/compiler/src/dmd/doc.d
@@ -382,7 +382,7 @@ immutable ddoc_decl_dd_e = ")\n";
  *      outbuf = append the Ddoc text to this
  */
 public
-extern(C++) void gendocfile(Module m, const char* ddoctext_ptr, size_t ddoctext_length, const char* datetime, ErrorSink eSink, ref OutBuffer outbuf)
+void gendocfile(Module m, const char* ddoctext_ptr, size_t ddoctext_length, const char* datetime, ErrorSink eSink, ref OutBuffer outbuf)
 {
     gendocfile(m, ddoctext_ptr[0 .. ddoctext_length], datetime, eSink, outbuf);
 }

--- a/compiler/src/dmd/doc.h
+++ b/compiler/src/dmd/doc.h
@@ -15,5 +15,8 @@
 class Module;
 class ErrorSink;
 
-void gendocfile(Module *m, const char *ddoctext_ptr, d_size_t ddoctext_length,
-                const char *datetime, ErrorSink *eSink, OutBuffer &outbuf);
+namespace dmd
+{
+    void gendocfile(Module *m, const char *ddoctext_ptr, d_size_t ddoctext_length,
+                    const char *datetime, ErrorSink *eSink, OutBuffer &outbuf);
+}

--- a/compiler/src/dmd/dstruct.d
+++ b/compiler/src/dmd/dstruct.d
@@ -48,7 +48,7 @@ import dmd.visitor;
  * Returns:
  *   FuncDeclaration of `toString()` if found, `null` if not
  */
-extern (C++) FuncDeclaration search_toString(StructDeclaration sd)
+FuncDeclaration search_toString(StructDeclaration sd)
 {
     Dsymbol s = search_function(sd, Id.tostring);
     FuncDeclaration fd = s ? s.isFuncDeclaration() : null;

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -95,9 +95,12 @@ enum class ThreeState : uint8_t
     yes,          // value is true
 };
 
-void dsymbolSemantic(Dsymbol *dsym, Scope *sc);
-void semantic2(Dsymbol *dsym, Scope *sc);
-void semantic3(Dsymbol *dsym, Scope* sc);
+namespace dmd
+{
+    void dsymbolSemantic(Dsymbol *dsym, Scope *sc);
+    void semantic2(Dsymbol *dsym, Scope *sc);
+    void semantic3(Dsymbol *dsym, Scope* sc);
+}
 
 struct Visibility
 {
@@ -425,7 +428,10 @@ public:
     size_t length() const;
 };
 
-void addMember(Dsymbol *dsym, Scope *sc, ScopeDsymbol *sds);
-Dsymbol *search(Dsymbol *d, const Loc &loc, Identifier *ident, SearchOptFlags flags = (SearchOptFlags)SearchOpt::localsOnly);
-void setScope(Dsymbol *d, Scope *sc);
-void importAll(Dsymbol *d, Scope *sc);
+namespace dmd
+{
+    void addMember(Dsymbol *dsym, Scope *sc, ScopeDsymbol *sds);
+    Dsymbol *search(Dsymbol *d, const Loc &loc, Identifier *ident, SearchOptFlags flags = (SearchOptFlags)SearchOpt::localsOnly);
+    void setScope(Dsymbol *d, Scope *sc);
+    void importAll(Dsymbol *d, Scope *sc);
+}

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -85,7 +85,7 @@ enum LOG = false;
 /*************************************
  * Does semantic analysis on the public face of declarations.
  */
-extern(C++) void dsymbolSemantic(Dsymbol dsym, Scope* sc)
+void dsymbolSemantic(Dsymbol dsym, Scope* sc)
 {
     scope v = new DsymbolSemanticVisitor(sc);
     dsym.accept(v);
@@ -4059,7 +4059,7 @@ Params:
     sc = scope where the dsymbol is declared
     sds = ScopeDsymbol where dsym is inserted
 */
-extern(C++) void addMember(Dsymbol dsym, Scope* sc, ScopeDsymbol sds)
+void addMember(Dsymbol dsym, Scope* sc, ScopeDsymbol sds)
 {
     auto addMemberVisitor = new AddMemberVisitor(sc, sds);
     dsym.accept(addMemberVisitor);
@@ -5979,7 +5979,7 @@ void checkPrintfScanfSignature(FuncDeclaration funcdecl, TypeFunction f, Scope* 
  * Returns:
  *  null if not found
  */
-extern(C++) Dsymbol search(Dsymbol d, const ref Loc loc, Identifier ident, SearchOptFlags flags = SearchOpt.all)
+Dsymbol search(Dsymbol d, const ref Loc loc, Identifier ident, SearchOptFlags flags = SearchOpt.all)
 {
     scope v = new SearchVisitor(loc, ident, flags);
     d.accept(v);
@@ -6621,7 +6621,7 @@ private extern(C++) class SearchVisitor : Visitor
  *   d = dsymbol for which the scope is set
  *   sc = scope that is used to set the value
  */
-extern(C++) void setScope(Dsymbol d, Scope* sc)
+void setScope(Dsymbol d, Scope* sc)
 {
     scope setScopeVisitor = new SetScopeVisitor(sc);
     d.accept(setScopeVisitor);
@@ -6764,7 +6764,7 @@ private extern(C++) class SetScopeVisitor : Visitor
     }
 }
 
-extern(C++) void importAll(Dsymbol d, Scope* sc)
+void importAll(Dsymbol d, Scope* sc)
 {
     scope iav = new ImportAllVisitor(sc);
     d.accept(iav);

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -96,7 +96,7 @@ pure nothrow @nogc @safe
  * These functions substitute for dynamic_cast. dynamic_cast does not work
  * on earlier versions of gcc.
  */
-extern (C++) inout(Expression) isExpression(inout RootObject o)
+inout(Expression) isExpression(inout RootObject o)
 {
     //return dynamic_cast<Expression *>(o);
     if (!o || o.dyncast() != DYNCAST.expression)
@@ -104,7 +104,7 @@ extern (C++) inout(Expression) isExpression(inout RootObject o)
     return cast(inout(Expression))o;
 }
 
-extern (C++) inout(Dsymbol) isDsymbol(inout RootObject o)
+inout(Dsymbol) isDsymbol(inout RootObject o)
 {
     //return dynamic_cast<Dsymbol *>(o);
     if (!o || o.dyncast() != DYNCAST.dsymbol)
@@ -112,7 +112,7 @@ extern (C++) inout(Dsymbol) isDsymbol(inout RootObject o)
     return cast(inout(Dsymbol))o;
 }
 
-extern (C++) inout(Type) isType(inout RootObject o)
+inout(Type) isType(inout RootObject o)
 {
     //return dynamic_cast<Type *>(o);
     if (!o || o.dyncast() != DYNCAST.type)
@@ -120,7 +120,7 @@ extern (C++) inout(Type) isType(inout RootObject o)
     return cast(inout(Type))o;
 }
 
-extern (C++) inout(Tuple) isTuple(inout RootObject o)
+inout(Tuple) isTuple(inout RootObject o)
 {
     //return dynamic_cast<Tuple *>(o);
     if (!o || o.dyncast() != DYNCAST.tuple)
@@ -128,7 +128,7 @@ extern (C++) inout(Tuple) isTuple(inout RootObject o)
     return cast(inout(Tuple))o;
 }
 
-extern (C++) inout(Parameter) isParameter(inout RootObject o)
+inout(Parameter) isParameter(inout RootObject o)
 {
     //return dynamic_cast<Parameter *>(o);
     if (!o || o.dyncast() != DYNCAST.parameter)
@@ -136,7 +136,7 @@ extern (C++) inout(Parameter) isParameter(inout RootObject o)
     return cast(inout(Parameter))o;
 }
 
-extern (C++) inout(TemplateParameter) isTemplateParameter(inout RootObject o)
+inout(TemplateParameter) isTemplateParameter(inout RootObject o)
 {
     if (!o || o.dyncast() != DYNCAST.templateparameter)
         return null;
@@ -146,7 +146,7 @@ extern (C++) inout(TemplateParameter) isTemplateParameter(inout RootObject o)
 /**************************************
  * Is this Object an error?
  */
-extern (C++) bool isError(const RootObject o)
+bool isError(const RootObject o)
 {
     if (const t = isType(o))
         return (t.ty == Terror);
@@ -6311,7 +6311,7 @@ struct TemplateStats
  *      listInstances = list instances of templates
  *      eSink = where the print is sent
  */
-extern (C++) void printTemplateStats(bool listInstances, ErrorSink eSink)
+void printTemplateStats(bool listInstances, ErrorSink eSink)
 {
     static struct TemplateDeclarationStats
     {

--- a/compiler/src/dmd/dtoh.d
+++ b/compiler/src/dmd/dtoh.d
@@ -54,7 +54,7 @@ import dmd.utils;
  *  - ignored declarations are mentioned in a comment if `global.params.doCxxHdrGeneration`
  *    is set to `CxxHeaderMode.verbose`
  */
-extern(C++) void genCppHdrFiles(ref Modules ms)
+void genCppHdrFiles(ref Modules ms)
 {
     initialize();
 

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -108,7 +108,7 @@ inout(Expression) lastComma(inout Expression e)
  *     exps  = array of Expressions
  *     names = optional array of names corresponding to Expressions
  */
-extern (C++) void expandTuples(Expressions* exps, Identifiers* names = null)
+void expandTuples(Expressions* exps, Identifiers* names = null)
 {
     //printf("expandTuples()\n");
     if (exps is null)

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -46,16 +46,19 @@ typedef union tree_node Symbol;
 struct Symbol;          // back end symbol
 #endif
 
-// in expressionsem.d
-Expression *expressionSemantic(Expression *e, Scope *sc);
-// in typesem.d
-Expression *defaultInit(Type *mt, const Loc &loc, const bool isCfile = false);
+namespace dmd
+{
+    // in expressionsem.d
+    Expression *expressionSemantic(Expression *e, Scope *sc);
+    // in typesem.d
+    Expression *defaultInit(Type *mt, const Loc &loc, const bool isCfile = false);
 
-// Entry point for CTFE.
-// A compile-time result is required. Give an error if not possible
-Expression *ctfeInterpret(Expression *e);
-void expandTuples(Expressions *exps, Identifiers *names = nullptr);
-Expression *optimize(Expression *exp, int result, bool keepLvalue = false);
+    // Entry point for CTFE.
+    // A compile-time result is required. Give an error if not possible
+    Expression *ctfeInterpret(Expression *e);
+    void expandTuples(Expressions *exps, Identifiers *names = nullptr);
+    Expression *optimize(Expression *exp, int result, bool keepLvalue = false);
+}
 
 typedef unsigned char OwnedBy;
 enum

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -14203,7 +14203,7 @@ Expression binSemanticProp(BinExp e, Scope* sc)
 }
 
 // entrypoint for semantic ExpressionSemanticVisitor
-extern (C++) Expression expressionSemantic(Expression e, Scope* sc)
+Expression expressionSemantic(Expression e, Scope* sc)
 {
     scope v = new ExpressionSemanticVisitor(sc);
     e.accept(v);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -106,7 +106,6 @@ class DsymbolTable;
 struct MangleOverride;
 class AliasThis;
 class Expression;
-class TypeTuple;
 class Condition;
 class StaticForeach;
 struct UnionExp;
@@ -117,18 +116,19 @@ class ForeachStatement;
 class ForeachRangeStatement;
 struct OutBuffer;
 class TypeInfoClassDeclaration;
+class TypeTuple;
 class Initializer;
 struct IntRange;
 struct ModuleDeclaration;
 template <typename Datum>
 struct FileMapping;
 struct Escape;
-class ErrorSink;
 class LabelStatement;
 class SwitchStatement;
 class Statement;
 class TryFinallyStatement;
 class ScopeGuardStatement;
+class ErrorSink;
 struct DocComment;
 class WithStatement;
 struct AA;
@@ -1914,22 +1914,6 @@ public:
     MATCH matchAll(Type* tt);
 };
 
-extern Dsymbol* isDsymbol(RootObject* o);
-
-extern bool isError(const RootObject* const o);
-
-extern Expression* isExpression(RootObject* o);
-
-extern Parameter* isParameter(RootObject* o);
-
-extern TemplateParameter* isTemplateParameter(RootObject* o);
-
-extern Tuple* isTuple(RootObject* o);
-
-extern Type* isType(RootObject* o);
-
-extern void printTemplateStats(bool listInstances, ErrorSink* eSink);
-
 class DebugSymbol final : public Dsymbol
 {
 public:
@@ -3560,8 +3544,6 @@ public:
     void accept(Visitor* v) override;
 };
 
-extern void expandTuples(Array<Expression* >* exps, Array<Identifier* >* names = nullptr);
-
 enum : int32_t { stageApply = 8 };
 
 enum : int32_t { stageInlineScan = 16 };
@@ -4104,14 +4086,6 @@ struct HdrGenState final
 
 enum : int32_t { TEST_EMIT_ALL = 0 };
 
-extern void genhdrfile(Module* m, bool doFuncBodies, OutBuffer& buf);
-
-extern void moduleToBuffer(OutBuffer& buf, bool vcg_ast, Module* m);
-
-extern const char* parametersTypeToChars(ParameterList pl);
-
-extern const char* toChars(const Statement* const s);
-
 enum class InitKind : uint8_t
 {
     void_ = 0u,
@@ -4202,10 +4176,6 @@ public:
     Type* type;
     void accept(Visitor* v) override;
 };
-
-extern Initializer* initializerSemantic(Initializer* init, Scope* sc, Type*& tx, NeedInterpret needInterpret);
-
-extern Expression* initializerToExpression(Initializer* init, Type* itype = nullptr, const bool isCfile = false);
 
 enum class Covariant
 {
@@ -4790,8 +4760,6 @@ public:
     bool isZeroInit(const Loc& loc) override;
     void accept(Visitor* v) override;
 };
-
-extern AggregateDeclaration* isAggregate(Type* t);
 
 class Nspace final : public ScopeDsymbol
 {
@@ -5422,54 +5390,6 @@ public:
     void accept(Visitor* v) override;
 };
 
-extern Type* addMod(Type* type, uint8_t mod);
-
-extern Type* castMod(Type* type, uint8_t mod);
-
-extern Type* constOf(Type* type);
-
-extern Covariant covariant(Type* src, Type* t, uint64_t* pstc = nullptr, bool cppCovariant = false);
-
-extern Expression* defaultInit(Type* mt, const Loc& loc, const bool isCfile = false);
-
-extern bool equivalent(Type* src, Type* t);
-
-extern bool hasPointers(Type* t);
-
-extern Type* immutableOf(Type* type);
-
-extern bool isBaseOf(Type* tthis, Type* t, int32_t* poffset);
-
-extern Type* merge(Type* type);
-
-extern Type* merge2(Type* type);
-
-extern Type* mutableOf(Type* type);
-
-extern Type* pointerTo(Type* type);
-
-extern Type* referenceTo(Type* type);
-
-extern Type* sharedConstOf(Type* type);
-
-extern Type* sharedOf(Type* type);
-
-extern Type* sharedWildConstOf(Type* type);
-
-extern Type* sharedWildOf(Type* type);
-
-extern Dsymbol* toDsymbol(Type* type, Scope* sc);
-
-extern Type* trySemantic(Type* type, const Loc& loc, Scope* sc);
-
-extern Type* typeSemantic(Type* type, const Loc& loc, Scope* sc);
-
-extern Type* unSharedOf(Type* type);
-
-extern Type* wildConstOf(Type* type);
-
-extern Type* wildOf(Type* type);
-
 struct UnionExp final
 {
     #pragma pack(push, 8)
@@ -6041,15 +5961,6 @@ public:
     virtual void visit(LoweredAssignExp* e);
 };
 
-enum class JsonFieldFlags : uint32_t
-{
-    none = 0u,
-    compilerInfo = 1u,
-    buildInfo = 2u,
-    modules = 4u,
-    semantics = 8u,
-};
-
 class StoppableVisitor : public Visitor
 {
 public:
@@ -6235,6 +6146,15 @@ enum class CHECKACTION : uint8_t
     context = 3u,
 };
 
+enum class JsonFieldFlags : uint32_t
+{
+    none = 0u,
+    compilerInfo = 1u,
+    buildInfo = 2u,
+    modules = 4u,
+    semantics = 8u,
+};
+
 struct CompileEnv final
 {
     uint32_t versionNumber;
@@ -6330,14 +6250,6 @@ public:
     void accept(Visitor* v) override;
     bool isDeprecated() const override;
 };
-
-extern TypeTuple* toArgTypes_x86(Type* t);
-
-extern TypeTuple* toArgTypes_sysv_x64(Type* t);
-
-extern TypeTuple* toArgTypes_aarch64(Type* t);
-
-extern bool isHFVA(Type* t, int32_t maxNumElements = 4, Type** rewriteType = nullptr);
 
 struct structalign_t final
 {
@@ -6652,20 +6564,6 @@ public:
     StaticIfCondition* isStaticIfCondition() override;
     const char* toChars() const override;
 };
-
-extern const char* toCppMangleItanium(Dsymbol* s);
-
-extern const char* cppTypeInfoMangleItanium(Dsymbol* s);
-
-extern const char* cppThunkMangleItanium(FuncDeclaration* fd, int32_t offset);
-
-extern const char* toCppMangleMSVC(Dsymbol* s);
-
-extern const char* cppTypeInfoMangleMSVC(Dsymbol* s);
-
-extern const char* toCppMangleDMC(Dsymbol* s);
-
-extern const char* cppTypeInfoMangleDMC(Dsymbol* s);
 
 extern DArray<uint8_t > preprocess(FileName csrcfile, const Loc& loc, OutBuffer& defines);
 
@@ -7146,19 +7044,7 @@ public:
     void accept(Visitor* v) override;
 };
 
-extern Expression* ctfeInterpret(Expression* e);
-
 extern void printCtfePerformanceStats();
-
-extern const char* mangleExact(FuncDeclaration* fd);
-
-extern void mangleToBuffer(Type* t, OutBuffer& buf);
-
-extern void mangleToBuffer(Expression* e, OutBuffer& buf);
-
-extern void mangleToBuffer(Dsymbol* s, OutBuffer& buf);
-
-extern void mangleToBuffer(TemplateInstance* ti, OutBuffer& buf);
 
 class Package : public ScopeDsymbol
 {
@@ -7278,12 +7164,6 @@ struct ModuleDeclaration final
     {
     }
 };
-
-extern void getLocalClasses(Module* mod, Array<ClassDeclaration* >& aclasses);
-
-extern FuncDeclaration* findGetMembers(ScopeDsymbol* dsym);
-
-extern void gendocfile(Module* m, const char* const ddoctext_ptr, size_t ddoctext_length, const char* const datetime, ErrorSink* eSink, OutBuffer& outbuf);
 
 struct Scope final
 {
@@ -7413,8 +7293,6 @@ struct Scope final
         aliasAsg(aliasAsg)
         {}
 };
-
-extern FuncDeclaration* search_toString(StructDeclaration* sd);
 
 class StructDeclaration : public AggregateDeclaration
 {
@@ -7546,16 +7424,6 @@ public:
     DsymbolTable();
 };
 
-extern void dsymbolSemantic(Dsymbol* dsym, Scope* sc);
-
-extern void addMember(Dsymbol* dsym, Scope* sc, ScopeDsymbol* sds);
-
-extern Dsymbol* search(Dsymbol* d, const Loc& loc, Identifier* ident, uint32_t flags = 0u);
-
-extern void setScope(Dsymbol* d, Scope* sc);
-
-extern void importAll(Dsymbol* d, Scope* sc);
-
 class ImportAllVisitor : public Visitor
 {
 public:
@@ -7569,28 +7437,6 @@ public:
     void visit(StaticIfDeclaration* _) override;
     void visit(StaticForeachDeclaration* _) override;
 };
-
-extern void genCppHdrFiles(Array<Module* >& ms);
-
-extern Expression* expressionSemantic(Expression* e, Scope* sc);
-
-extern bool functionSemantic(FuncDeclaration* fd);
-
-extern bool functionSemantic3(FuncDeclaration* fd);
-
-extern const char* toChars(const Expression* const e);
-
-extern const char* toChars(const Initializer* const i);
-
-extern const char* toChars(const Type* const t);
-
-extern Statement* asmSemantic(AsmStatement* s, Scope* sc);
-
-extern Statement* gccAsmSemantic(GccAsmStatement* s, Scope* sc);
-
-extern void json_generate(Array<Module* >& modules, OutBuffer& buf);
-
-extern JsonFieldFlags tryParseJsonField(const char* fieldName);
 
 class NOGCVisitor final : public StoppableVisitor
 {
@@ -7640,8 +7486,6 @@ public:
     virtual void checkTupleof(Expression* expression, TypeClass* type) const = 0;
 };
 
-extern Expression* optimize(Expression* e, int32_t result, bool keepLvalue = false);
-
 template <typename AST>
 class PermissiveVisitor : public ParseTimeVisitor<AST >
 {
@@ -7656,14 +7500,6 @@ public:
     virtual void visit(typename AST::Condition ) override;
     virtual void visit(typename AST::Initializer ) override;
 };
-
-extern void semantic2(Dsymbol* dsym, Scope* sc);
-
-extern void semantic3(Dsymbol* dsym, Scope* sc);
-
-extern void semanticTypeInfoMembers(StructDeclaration* sd);
-
-extern Statement* statementSemantic(Statement* s, Scope* sc);
 
 struct Target final
 {
@@ -7811,15 +7647,7 @@ public:
 
 extern Target target;
 
-extern bool tpsemantic(TemplateParameter* tp, Scope* sc, Array<TemplateParameter* >* parameters);
-
-extern bool genTypeInfo(Expression* e, const Loc& loc, Type* torig, Scope* sc);
-
 extern Type* getTypeInfoType(const Loc& loc, Type* t, Scope* sc, bool genObjCode = true);
-
-extern bool isSpeculativeType(Type* t);
-
-extern bool builtinTypeInfo(Type* t);
 
 class SemanticTimeTransitiveVisitor : public SemanticTimePermissiveVisitor
 {

--- a/compiler/src/dmd/funcsem.d
+++ b/compiler/src/dmd/funcsem.d
@@ -1042,7 +1042,6 @@ Ldone:
  *  false if any errors exist in the signature.
  */
 public
-extern (C++)
 bool functionSemantic(FuncDeclaration fd)
 {
     //printf("functionSemantic() %p %s\n", this, toChars());
@@ -1101,7 +1100,6 @@ bool functionSemantic(FuncDeclaration fd)
  * Returns false if any errors exist in the body.
  */
 public
-extern (C++)
 bool functionSemantic3(FuncDeclaration fd)
 {
     if (fd.semanticRun < PASS.semantic3 && fd._scope)

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -83,7 +83,7 @@ enum TEST_EMIT_ALL = 0;
  *      doFuncBodies = generate function definitions rather than just declarations
  *      buf = buffer to write the data to
  */
-extern (C++) void genhdrfile(Module m, bool doFuncBodies, ref OutBuffer buf)
+void genhdrfile(Module m, bool doFuncBodies, ref OutBuffer buf)
 {
     buf.doindent = 1;
     buf.printf("// D import file generated from '%s'", m.srcfile.toChars());
@@ -103,7 +103,7 @@ extern (C++) void genhdrfile(Module m, bool doFuncBodies, ref OutBuffer buf)
  * Returns:
  *      0-terminated string
  */
-public extern (C++) const(char)* toChars(const Statement s)
+public const(char)* toChars(const Statement s)
 {
     HdrGenState hgs;
     OutBuffer buf;
@@ -112,7 +112,7 @@ public extern (C++) const(char)* toChars(const Statement s)
     return buf.extractSlice().ptr;
 }
 
-public extern (C++) const(char)* toChars(const Expression e)
+public const(char)* toChars(const Expression e)
 {
     HdrGenState hgs;
     OutBuffer buf;
@@ -120,7 +120,7 @@ public extern (C++) const(char)* toChars(const Expression e)
     return buf.extractChars();
 }
 
-public extern (C++) const(char)* toChars(const Initializer i)
+public const(char)* toChars(const Initializer i)
 {
     OutBuffer buf;
     HdrGenState hgs;
@@ -128,7 +128,7 @@ public extern (C++) const(char)* toChars(const Initializer i)
     return buf.extractChars();
 }
 
-public extern (C++) const(char)* toChars(const Type t)
+public const(char)* toChars(const Type t)
 {
     OutBuffer buf;
     buf.reserve(16);
@@ -154,7 +154,7 @@ public const(char)[] toString(const Initializer i)
  *   vcg_ast = write out codegen ast
  *   m = module to visit all members of.
  */
-extern (C++) void moduleToBuffer(ref OutBuffer buf, bool vcg_ast, Module m)
+void moduleToBuffer(ref OutBuffer buf, bool vcg_ast, Module m)
 {
     HdrGenState hgs;
     hgs.fullDump = true;
@@ -3418,7 +3418,7 @@ void arrayObjectsToBuffer(ref OutBuffer buf, Objects* objects)
  *  pl = parameter list to print
  * Returns: Null-terminated string representing parameters.
  */
-extern (C++) const(char)* parametersTypeToChars(ParameterList pl)
+const(char)* parametersTypeToChars(ParameterList pl)
 {
     OutBuffer buf;
     HdrGenState hgs;

--- a/compiler/src/dmd/hdrgen.h
+++ b/compiler/src/dmd/hdrgen.h
@@ -18,12 +18,15 @@ class Initializer;
 class Module;
 class Statement;
 
-void genhdrfile(Module *m, bool doFuncBodies, OutBuffer &buf);
-void genCppHdrFiles(Modules &ms);
-void moduleToBuffer(OutBuffer& buf, bool vcg_ast, Module *m);
-const char *parametersTypeToChars(ParameterList pl);
+namespace dmd
+{
+    void genhdrfile(Module *m, bool doFuncBodies, OutBuffer &buf);
+    void genCppHdrFiles(Modules &ms);
+    void moduleToBuffer(OutBuffer& buf, bool vcg_ast, Module *m);
+    const char *parametersTypeToChars(ParameterList pl);
 
-const char* toChars(const Expression* const e);
-const char* toChars(const Initializer* const i);
-const char* toChars(const Statement* const s);
-const char* toChars(const Type* const t);
+    const char* toChars(const Expression* const e);
+    const char* toChars(const Initializer* const i);
+    const char* toChars(const Statement* const s);
+    const char* toChars(const Type* const t);
+}

--- a/compiler/src/dmd/iasm.d
+++ b/compiler/src/dmd/iasm.d
@@ -38,7 +38,7 @@ else
 
 /************************ AsmStatement ***************************************/
 
-extern(C++) Statement asmSemantic(AsmStatement s, Scope *sc)
+Statement asmSemantic(AsmStatement s, Scope *sc)
 {
     //printf("AsmStatement.semantic()\n");
 

--- a/compiler/src/dmd/iasmgcc.d
+++ b/compiler/src/dmd/iasmgcc.d
@@ -299,7 +299,7 @@ Ldone:
  * Returns:
  *      the completed gcc asm statement, or null if errors occurred
  */
-extern (C++) public Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
+public Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
 {
     //printf("GccAsmStatement.semantic()\n");
     const bool doUnittests = global.params.parsingUnittestsRequired();

--- a/compiler/src/dmd/init.h
+++ b/compiler/src/dmd/init.h
@@ -124,5 +124,8 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-Expression *initializerToExpression(Initializer *init, Type *t = NULL, const bool isCfile = false);
-Initializer *initializerSemantic(Initializer *init, Scope *sc, Type *&tx, NeedInterpret needInterpret);
+namespace dmd
+{
+    Expression *initializerToExpression(Initializer *init, Type *t = NULL, const bool isCfile = false);
+    Initializer *initializerSemantic(Initializer *init, Scope *sc, Type *&tx, NeedInterpret needInterpret);
+}

--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -103,7 +103,7 @@ Expression toAssocArrayLiteral(ArrayInitializer ai)
  *      `Initializer` with completed semantic analysis, `ErrorInitializer` if errors
  *      were encountered
  */
-extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedInterpret needInterpret)
+Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedInterpret needInterpret)
 {
     //printf("initializerSemantic() tx: %p %s\n", tx, tx.toChars());
     Type t = tx;
@@ -1224,7 +1224,7 @@ Initializer inferType(Initializer init, Scope* sc)
  * Returns:
  *      `Expression` created, `null` if cannot, `ErrorExp` for other errors
  */
-extern (C++) Expression initializerToExpression(Initializer init, Type itype = null, const bool isCfile = false)
+Expression initializerToExpression(Initializer init, Type itype = null, const bool isCfile = false)
 {
     //printf("initializerToExpression() isCfile: %d\n", isCfile);
 

--- a/compiler/src/dmd/json.d
+++ b/compiler/src/dmd/json.d
@@ -978,7 +978,7 @@ public:
  *      modules = array of Modules
  *      buf = write json output to buf
  */
-extern (C++) void json_generate(ref Modules modules, ref OutBuffer buf)
+void json_generate(ref Modules modules, ref OutBuffer buf)
 {
     scope ToJsonVisitor json = new ToJsonVisitor(&buf);
     // write trailing newline
@@ -1047,7 +1047,7 @@ Params:
 Returns: JsonFieldFlags.none on error, otherwise the JsonFieldFlags value
          corresponding to the given fieldName.
 */
-extern (C++) JsonFieldFlags tryParseJsonField(const(char)* fieldName)
+JsonFieldFlags tryParseJsonField(const(char)* fieldName)
 {
     auto fieldNameString = fieldName.toDString();
     foreach (idx, enumName; __traits(allMembers, JsonFieldFlags))

--- a/compiler/src/dmd/json.h
+++ b/compiler/src/dmd/json.h
@@ -15,5 +15,8 @@
 
 struct OutBuffer;
 
-void json_generate(Modules &, OutBuffer &);
-JsonFieldFlags tryParseJsonField(const char *fieldName);
+namespace dmd
+{
+    void json_generate(Modules &, OutBuffer &);
+    JsonFieldFlags tryParseJsonField(const char *fieldName);
+}

--- a/compiler/src/dmd/mangle.h
+++ b/compiler/src/dmd/mangle.h
@@ -17,18 +17,21 @@ class TemplateInstance;
 class Type;
 struct OutBuffer;
 
-// In cppmangle.d
-const char *toCppMangleItanium(Dsymbol *s);
-const char *cppTypeInfoMangleItanium(Dsymbol *s);
-const char *cppThunkMangleItanium(FuncDeclaration *fd, int offset);
+namespace dmd
+{
+    // In cppmangle.d
+    const char *toCppMangleItanium(Dsymbol *s);
+    const char *cppTypeInfoMangleItanium(Dsymbol *s);
+    const char *cppThunkMangleItanium(FuncDeclaration *fd, int offset);
 
-// In cppmanglewin.d
-const char *toCppMangleMSVC(Dsymbol *s);
-const char *cppTypeInfoMangleMSVC(Dsymbol *s);
+    // In cppmanglewin.d
+    const char *toCppMangleMSVC(Dsymbol *s);
+    const char *cppTypeInfoMangleMSVC(Dsymbol *s);
 
-// In dmangle.d
-const char *mangleExact(FuncDeclaration *fd);
-void mangleToBuffer(Type *s, OutBuffer& buf);
-void mangleToBuffer(Expression *s, OutBuffer& buf);
-void mangleToBuffer(Dsymbol *s, OutBuffer& buf);
-void mangleToBuffer(TemplateInstance *s, OutBuffer& buf);
+    // In dmangle.d
+    const char *mangleExact(FuncDeclaration *fd);
+    void mangleToBuffer(Type *s, OutBuffer& buf);
+    void mangleToBuffer(Expression *s, OutBuffer& buf);
+    void mangleToBuffer(Dsymbol *s, OutBuffer& buf);
+    void mangleToBuffer(TemplateInstance *s, OutBuffer& buf);
+}

--- a/compiler/src/dmd/module.h
+++ b/compiler/src/dmd/module.h
@@ -167,5 +167,8 @@ struct ModuleDeclaration
     const char *toChars() const;
 };
 
-extern void getLocalClasses(Module* mod, Array<ClassDeclaration* >& aclasses);
-FuncDeclaration *findGetMembers(ScopeDsymbol *dsym);
+namespace dmd
+{
+    void getLocalClasses(Module* mod, Array<ClassDeclaration* >& aclasses);
+    FuncDeclaration *findGetMembers(ScopeDsymbol *dsym);
+}

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -5643,7 +5643,7 @@ void attributesApply(const TypeFunction tf, void delegate(string) dg, TRUSTforma
  * If the type is a class or struct, returns the symbol for it,
  * else null.
  */
-extern (C++) AggregateDeclaration isAggregate(Type t)
+AggregateDeclaration isAggregate(Type t)
 {
     t = t.toBasetype();
     if (t.ty == Tclass)

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -39,8 +39,11 @@ typedef union tree_node type;
 typedef struct TYPE type;
 #endif
 
-Type *typeSemantic(Type *t, const Loc &loc, Scope *sc);
-Type *merge(Type *type);
+namespace dmd
+{
+    Type *typeSemantic(Type *t, const Loc &loc, Scope *sc);
+    Type *merge(Type *type);
+}
 
 enum class TY : uint8_t
 {
@@ -878,28 +881,30 @@ public:
 
 /**************************************************************/
 
-
-// If the type is a class or struct, returns the symbol for it, else null.
-AggregateDeclaration *isAggregate(Type *t);
-bool hasPointers(Type *t);
-// return the symbol to which type t resolves
-Dsymbol *toDsymbol(Type *t, Scope *sc);
-bool equivalent(Type *src, Type *t);
-Covariant covariant(Type *, Type *, StorageClass * = NULL, bool = false);
-bool isBaseOf(Type *tthis, Type *t, int *poffset);
-Type *trySemantic(Type *type, const Loc &loc, Scope *sc);
-Type *pointerTo(Type *type);
-Type *referenceTo(Type *type);
-Type *merge2(Type *type);
-Type *constOf(Type *type);
-Type *immutableOf(Type *type);
-Type *mutableOf(Type *type);
-Type *sharedOf(Type *type);
-Type *sharedConstOf(Type *type);
-Type *unSharedOf(Type *type);
-Type *wildOf(Type *type);
-Type *wildConstOf(Type *type);
-Type *sharedWildOf(Type *type);
-Type *sharedWildConstOf(Type *type);
-Type *castMod(Type *type, MOD mod);
-Type *addMod(Type *type, MOD mod);
+namespace dmd
+{
+    // If the type is a class or struct, returns the symbol for it, else null.
+    AggregateDeclaration *isAggregate(Type *t);
+    bool hasPointers(Type *t);
+    // return the symbol to which type t resolves
+    Dsymbol *toDsymbol(Type *t, Scope *sc);
+    bool equivalent(Type *src, Type *t);
+    Covariant covariant(Type *, Type *, StorageClass * = NULL, bool = false);
+    bool isBaseOf(Type *tthis, Type *t, int *poffset);
+    Type *trySemantic(Type *type, const Loc &loc, Scope *sc);
+    Type *pointerTo(Type *type);
+    Type *referenceTo(Type *type);
+    Type *merge2(Type *type);
+    Type *constOf(Type *type);
+    Type *immutableOf(Type *type);
+    Type *mutableOf(Type *type);
+    Type *sharedOf(Type *type);
+    Type *sharedConstOf(Type *type);
+    Type *unSharedOf(Type *type);
+    Type *wildOf(Type *type);
+    Type *wildConstOf(Type *type);
+    Type *sharedWildOf(Type *type);
+    Type *sharedWildConstOf(Type *type);
+    Type *castMod(Type *type, MOD mod);
+    Type *addMod(Type *type, MOD mod);
+}

--- a/compiler/src/dmd/optimize.d
+++ b/compiler/src/dmd/optimize.d
@@ -273,7 +273,7 @@ package void setLengthVarIfKnown(VarDeclaration lengthVar, Type type)
  * Returns:
  *      Constant folded version of `e`
  */
-extern (C++) Expression optimize(Expression e, int result, bool keepLvalue = false)
+Expression optimize(Expression e, int result, bool keepLvalue = false)
 {
     //printf("optimize() e: %s result: %d keepLvalue %d\n", e.toChars(), result, keepLvalue);
     Expression ret = e;

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -73,7 +73,7 @@ enum LOG = false;
 /*************************************
  * Does semantic analysis on initializers and members of aggregates.
  */
-extern(C++) void semantic2(Dsymbol dsym, Scope* sc)
+void semantic2(Dsymbol dsym, Scope* sc)
 {
     scope v = new Semantic2Visitor(sc);
     dsym.accept(v);

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -79,7 +79,7 @@ enum LOG = false;
 /*************************************
  * Does semantic analysis on function bodies.
  */
-extern(C++) void semantic3(Dsymbol dsym, Scope* sc)
+void semantic3(Dsymbol dsym, Scope* sc)
 {
     scope v = new Semantic3Visitor(sc);
     dsym.accept(v);
@@ -1636,7 +1636,7 @@ private struct FuncDeclSem3
     }
 }
 
-extern (C++) void semanticTypeInfoMembers(StructDeclaration sd)
+void semanticTypeInfoMembers(StructDeclaration sd)
 {
     if (sd.xeq &&
         sd.xeq._scope &&

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -701,12 +701,15 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-// in statementsem.d
-Statement* statementSemantic(Statement *s, Scope *sc);
-// in iasm.d
-Statement* asmSemantic(AsmStatement *s, Scope *sc);
-// in iasmgcc.d
-Statement *gccAsmSemantic(GccAsmStatement *s, Scope *sc);
+namespace dmd
+{
+    // in statementsem.d
+    Statement* statementSemantic(Statement *s, Scope *sc);
+    // in iasm.d
+    Statement* asmSemantic(AsmStatement *s, Scope *sc);
+    // in iasmgcc.d
+    Statement *gccAsmSemantic(GccAsmStatement *s, Scope *sc);
+}
 
 class AsmStatement : public Statement
 {

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -135,7 +135,7 @@ private Expression checkAssignmentAsCondition(Expression e, Scope* sc)
 }
 
 // Performs semantic analysis in Statement AST nodes
-extern(C++) Statement statementSemantic(Statement s, Scope* sc)
+Statement statementSemantic(Statement s, Scope* sc)
 {
     import dmd.compiler;
 

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -317,14 +317,17 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
-// in templateparamsem.d
-bool tpsemantic(TemplateParameter *tp, Scope *sc, TemplateParameters *parameters);
+namespace dmd
+{
+    // in templateparamsem.d
+    bool tpsemantic(TemplateParameter *tp, Scope *sc, TemplateParameters *parameters);
 
-Expression *isExpression(RootObject *o);
-Dsymbol *isDsymbol(RootObject *o);
-Type *isType(RootObject *o);
-Tuple *isTuple(RootObject *o);
-Parameter *isParameter(RootObject *o);
-TemplateParameter *isTemplateParameter(RootObject *o);
-bool isError(const RootObject *const o);
-void printTemplateStats(bool listInstances, ErrorSink* eSink);
+    Expression *isExpression(RootObject *o);
+    Dsymbol *isDsymbol(RootObject *o);
+    Type *isType(RootObject *o);
+    Tuple *isTuple(RootObject *o);
+    Parameter *isParameter(RootObject *o);
+    TemplateParameter *isTemplateParameter(RootObject *o);
+    bool isError(const RootObject *const o);
+    void printTemplateStats(bool listInstances, ErrorSink* eSink);
+}

--- a/compiler/src/dmd/templateparamsem.d
+++ b/compiler/src/dmd/templateparamsem.d
@@ -35,7 +35,7 @@ import dmd.visitor;
  * Returns:
  *      `true` if no errors
  */
-extern(C++) bool tpsemantic(TemplateParameter tp, Scope* sc, TemplateParameters* parameters)
+bool tpsemantic(TemplateParameter tp, Scope* sc, TemplateParameters* parameters)
 {
     scope v = new TemplateParameterSemanticVisitor(sc, parameters);
     tp.accept(v);

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -1222,7 +1222,7 @@ private extern(D) MATCH matchTypeSafeVarArgs(TypeFunction tf, Parameter p,
  * Return !=0 if type has pointers that need to
  * be scanned by the GC during a collection cycle.
  */
-extern(C++) bool hasPointers(Type t)
+bool hasPointers(Type t)
 {
     bool visitType(Type _)              { return false; }
     bool visitDArray(TypeDArray _)      { return true; }
@@ -1292,7 +1292,7 @@ extern(C++) bool hasPointers(Type t)
  *      `Type` with completed semantic analysis, `Terror` if errors
  *      were encountered
  */
-extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
+Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
 {
     static Type error()
     {
@@ -2821,7 +2821,7 @@ extern(C++) Type typeSemantic(Type type, const ref Loc loc, Scope* sc)
     }
 }
 
-extern(C++) Type trySemantic(Type type, const ref Loc loc, Scope* sc)
+Type trySemantic(Type type, const ref Loc loc, Scope* sc)
 {
     //printf("+trySemantic(%s) %d\n", toChars(), global.errors);
 
@@ -2855,7 +2855,7 @@ extern(C++) Type trySemantic(Type type, const ref Loc loc, Scope* sc)
  * Returns:
  *      the type that was merged
  */
-extern (C++) Type merge(Type type)
+Type merge(Type type)
 {
     switch (type.ty)
     {
@@ -2925,7 +2925,7 @@ extern (C++) Type merge(Type type)
  * This version does a merge even if the deco is already computed.
  * Necessary for types that have a deco, but are not merged.
  */
-extern(C++) Type merge2(Type type)
+Type merge2(Type type)
 {
     //printf("merge2(%s)\n", toChars());
     Type t = type;
@@ -5365,7 +5365,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, DotExpFlag
  * Returns:
  *  The initialization expression for the type.
  */
-extern (C++) Expression defaultInit(Type mt, const ref Loc loc, const bool isCfile = false)
+Expression defaultInit(Type mt, const ref Loc loc, const bool isCfile = false)
 {
     Expression visitBasic(TypeBasic mt)
     {
@@ -5545,7 +5545,7 @@ Returns:
   if the type does resolve to any symbol (for example,
   in the case of basic types).
 */
-extern(C++) Dsymbol toDsymbol(Type type, Scope* sc)
+Dsymbol toDsymbol(Type type, Scope* sc)
 {
     Dsymbol visitType(Type _)            { return null; }
     Dsymbol visitStruct(TypeStruct type) { return type.sym; }
@@ -5722,7 +5722,7 @@ Type getComplexLibraryType(const ref Loc loc, Scope* sc, TY ty)
  * Returns:
  *     An enum value of either `Covariant.yes` or a reason it's not covariant.
  */
-extern(C++) Covariant covariant(Type src, Type t, StorageClass* pstc = null, bool cppCovariant = false)
+Covariant covariant(Type src, Type t, StorageClass* pstc = null, bool cppCovariant = false)
 {
     version (none)
     {
@@ -6085,7 +6085,7 @@ StorageClass parameterStorageClass(TypeFunction tf, Type tthis, Parameter p, Var
         return stc | STC.scope_;
 }
 
-extern(C++) bool isBaseOf(Type tthis, Type t, int* poffset)
+bool isBaseOf(Type tthis, Type t, int* poffset)
 {
     auto tc = tthis.isTypeClass();
     if (!tc)
@@ -6106,12 +6106,12 @@ extern(C++) bool isBaseOf(Type tthis, Type t, int* poffset)
     return false;
 }
 
-extern(C++) bool equivalent(Type src, Type t)
+bool equivalent(Type src, Type t)
 {
     return immutableOf(src).equals(t.immutableOf());
 }
 
-extern(C++) Type pointerTo(Type type)
+Type pointerTo(Type type)
 {
     if (type.ty == Terror)
         return type;
@@ -6129,7 +6129,7 @@ extern(C++) Type pointerTo(Type type)
     return type.pto;
 }
 
-extern(C++) Type referenceTo(Type type)
+Type referenceTo(Type type)
 {
     if (type.ty == Terror)
         return type;
@@ -6144,7 +6144,7 @@ extern(C++) Type referenceTo(Type type)
 /********************************
  * Convert to 'const'.
  */
-extern(C++) Type constOf(Type type)
+Type constOf(Type type)
 {
     //printf("Type::constOf() %p %s\n", type, type.toChars());
     if (type.mod == MODFlags.const_)
@@ -6164,7 +6164,7 @@ extern(C++) Type constOf(Type type)
 /********************************
  * Convert to 'immutable'.
  */
-extern(C++) Type immutableOf(Type type)
+Type immutableOf(Type type)
 {
     //printf("Type::immutableOf() %p %s\n", this, toChars());
     if (type.isImmutable())
@@ -6184,7 +6184,7 @@ extern(C++) Type immutableOf(Type type)
 /********************************
  * Make type mutable.
  */
-extern(C++) Type mutableOf(Type type)
+Type mutableOf(Type type)
 {
     //printf("Type::mutableOf() %p, %s\n", type, type.toChars());
     Type t = type;
@@ -6234,7 +6234,7 @@ extern(C++) Type mutableOf(Type type)
     return t;
 }
 
-extern(C++) Type sharedOf(Type type)
+Type sharedOf(Type type)
 {
     //printf("Type::sharedOf() %p, %s\n", type, type.toChars());
     if (type.mod == MODFlags.shared_)
@@ -6251,7 +6251,7 @@ extern(C++) Type sharedOf(Type type)
     return t;
 }
 
-extern(C++) Type sharedConstOf(Type type)
+Type sharedConstOf(Type type)
 {
     //printf("Type::sharedConstOf() %p, %s\n", type, type.toChars());
     if (type.mod == (MODFlags.shared_ | MODFlags.const_))
@@ -6280,7 +6280,7 @@ extern(C++) Type sharedConstOf(Type type)
  *      shared wild  => wild
  *      shared wild const => wild const
  */
-extern(C++) Type unSharedOf(Type type)
+Type unSharedOf(Type type)
 {
     //printf("Type::unSharedOf() %p, %s\n", type, type.toChars());
     Type t = type;
@@ -6322,7 +6322,7 @@ extern(C++) Type unSharedOf(Type type)
 /********************************
  * Convert to 'wild'.
  */
-extern(C++) Type wildOf(Type type)
+Type wildOf(Type type)
 {
     //printf("Type::wildOf() %p %s\n", type, type.toChars());
     if (type.mod == MODFlags.wild)
@@ -6339,7 +6339,7 @@ extern(C++) Type wildOf(Type type)
     return t;
 }
 
-extern(C++) Type wildConstOf(Type type)
+Type wildConstOf(Type type)
 {
     //printf("Type::wildConstOf() %p %s\n", type, type.toChars());
     if (type.mod == MODFlags.wildconst)
@@ -6356,7 +6356,7 @@ extern(C++) Type wildConstOf(Type type)
     return t;
 }
 
-extern(C++) Type sharedWildOf(Type type)
+Type sharedWildOf(Type type)
 {
     //printf("Type::sharedWildOf() %p, %s\n", type, type.toChars());
     if (type.mod == (MODFlags.shared_ | MODFlags.wild))
@@ -6373,7 +6373,7 @@ extern(C++) Type sharedWildOf(Type type)
     return t;
 }
 
-extern(C++) Type sharedWildConstOf(Type type)
+Type sharedWildConstOf(Type type)
 {
     //printf("Type::sharedWildConstOf() %p, %s\n", type, type.toChars());
     if (type.mod == (MODFlags.shared_ | MODFlags.wildconst))
@@ -6393,7 +6393,7 @@ extern(C++) Type sharedWildConstOf(Type type)
 /************************************
  * Apply MODxxxx bits to existing type.
  */
-extern(C++) Type castMod(Type type, MOD mod)
+Type castMod(Type type, MOD mod)
 {
     Type t;
     switch (mod)
@@ -6445,7 +6445,7 @@ extern(C++) Type castMod(Type type, MOD mod)
  * We're adding, not replacing, so adding const to
  * a shared type => "shared const"
  */
-extern(C++) Type addMod(Type type, MOD mod)
+Type addMod(Type type, MOD mod)
 {
     /* Add anything to immutable, and it remains immutable
      */

--- a/compiler/src/dmd/typinf.d
+++ b/compiler/src/dmd/typinf.d
@@ -35,7 +35,7 @@ import core.stdc.stdio;
  * Returns:
  *      true if `TypeInfo` was generated and needs compiling to object file
  */
-extern (C++) bool genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc)
+bool genTypeInfo(Expression e, const ref Loc loc, Type torig, Scope* sc)
 {
     // printf("genTypeInfo() %s\n", torig.toChars());
 
@@ -157,7 +157,7 @@ private TypeInfoDeclaration getTypeInfoDeclaration(Type t)
  *      true if any part of type t is speculative.
  *      if t is null, returns false.
  */
-extern (C++) bool isSpeculativeType(Type t)
+bool isSpeculativeType(Type t)
 {
     static bool visitVector(TypeVector t)
     {
@@ -254,7 +254,7 @@ extern (C++) bool isSpeculativeType(Type t)
 /* Indicates whether druntime already contains an appropriate TypeInfo instance
  * for the specified type (in module rt.util.typeinfo).
  */
-extern (C++) bool builtinTypeInfo(Type t)
+bool builtinTypeInfo(Type t)
 {
     if (!t.mod) // unqualified types only
     {

--- a/compiler/src/dmd/typinf.h
+++ b/compiler/src/dmd/typinf.h
@@ -16,7 +16,10 @@ class Expression;
 class Type;
 struct Scope;
 
-bool genTypeInfo(Expression *e, const Loc &loc, Type *torig, Scope *sc);
+namespace dmd
+{
+    bool genTypeInfo(Expression *e, const Loc &loc, Type *torig, Scope *sc);
+    bool isSpeculativeType(Type *t);
+    bool builtinTypeInfo(Type *t);
+}
 Type *getTypeInfoType(const Loc &loc, Type *t, Scope *sc, bool genObjCode = true);
-bool isSpeculativeType(Type *t);
-bool builtinTypeInfo(Type *t);

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -24,6 +24,7 @@
 
 #include "aggregate.h"
 #include "aliasthis.h"
+#include "argtypes.h"
 #include "arraytypes.h"
 #include "ast_node.h"
 #include "attrib.h"
@@ -92,8 +93,8 @@ extern "C" void gc_enable();
 
 static void frontend_term()
 {
-  gc_enable();
-  rt_term();
+    gc_enable();
+    rt_term();
 }
 
 /**********************************/
@@ -220,7 +221,7 @@ void test_visitors()
     assert(tv.stmt == true);
 
     TypePointer *tp = TypePointer::create(Type::tvoid);
-    assert(hasPointers(tp) == true);
+    assert(dmd::hasPointers(tp) == true);
     tp->accept(&tv);
     assert(tv.type == true);
 
@@ -280,12 +281,12 @@ void test_semantic()
     m->src = src;
     m->parse();
     m->importedFrom = m;
-    importAll(m, NULL);
-    dsymbolSemantic(m, NULL);
-    semantic2(m, NULL);
-    semantic3(m, NULL);
+    dmd::importAll(m, NULL);
+    dmd::dsymbolSemantic(m, NULL);
+    dmd::semantic2(m, NULL);
+    dmd::semantic3(m, NULL);
 
-    Dsymbol *s = search(m, Loc(), Identifier::idPool("Error"));
+    Dsymbol *s = dmd::search(m, Loc(), Identifier::idPool("Error"));
     assert(s);
     AggregateDeclaration *ad = s->isAggregateDeclaration();
     assert(ad && ad->ctor && ad->sizeok == Sizeok::done);
@@ -317,9 +318,9 @@ void test_skip_importall()
     m->src = src;
     m->parse();
     m->importedFrom = m;
-    dsymbolSemantic(m, NULL);
-    semantic2(m, NULL);
-    semantic3(m, NULL);
+    dmd::dsymbolSemantic(m, NULL);
+    dmd::semantic2(m, NULL);
+    dmd::semantic3(m, NULL);
 
     assert(!global.endGagging(errors));
 }
@@ -330,7 +331,7 @@ void test_expression()
 {
     Loc loc;
     IntegerExp *ie = IntegerExp::create(loc, 42, Type::tint32);
-    Expression *e = ctfeInterpret(ie);
+    Expression *e = dmd::ctfeInterpret(ie);
 
     assert(e);
     assert(e->isConst());
@@ -459,7 +460,7 @@ void test_array()
 void test_outbuffer()
 {
     OutBuffer buf;
-    mangleToBuffer(Type::tint64, buf);
+    dmd::mangleToBuffer(Type::tint64, buf);
     assert(strcmp(buf.peekChars(), "l") == 0);
     buf.reset();
 
@@ -496,12 +497,12 @@ void test_cppmangle()
     m->src = src;
     m->parse();
     m->importedFrom = m;
-    importAll(m, NULL);
-    dsymbolSemantic(m, NULL);
-    semantic2(m, NULL);
-    semantic3(m, NULL);
+    dmd::importAll(m, NULL);
+    dmd::dsymbolSemantic(m, NULL);
+    dmd::semantic2(m, NULL);
+    dmd::semantic3(m, NULL);
 
-    Dsymbol *s = search(m, Loc(), Identifier::idPool("Derived"));
+    Dsymbol *s = dmd::search(m, Loc(), Identifier::idPool("Derived"));
     assert(s);
     ClassDeclaration *cd = s->isClassDeclaration();
     assert(cd && cd->sizeok == Sizeok::done);
@@ -511,12 +512,12 @@ void test_cppmangle()
 
     fd = (*cd->members)[0]->isFuncDeclaration();
     assert(fd);
-    mangle = cppThunkMangleItanium(fd, b->offset);
+    mangle = dmd::cppThunkMangleItanium(fd, b->offset);
     assert(strcmp(mangle, "_ZThn8_N7Derived9MethodCPPEv") == 0);
 
     fd = (*cd->members)[1]->isFuncDeclaration();
     assert(fd);
-    mangle = cppThunkMangleItanium(fd, b->offset);
+    mangle = dmd::cppThunkMangleItanium(fd, b->offset);
     assert(strcmp(mangle, "_ZThn8_N7Derived7MethodDEv") == 0);
 
     assert(!global.endGagging(errors));
@@ -690,11 +691,11 @@ public:
         Expressions *attrs = sym->userAttribDecl()->getAttributes();
         if (attrs)
         {
-            expandTuples(attrs);
+            dmd::expandTuples(attrs);
             for (size_t i = 0; i < attrs->length; i++)
             {
                 Expression *attr = (*attrs)[i];
-                Dsymbol *sym = toDsymbol(attr->type, 0);
+                Dsymbol *sym = dmd::toDsymbol(attr->type, 0);
                 if (!sym)
                 {
                     if (TemplateExp *te = attr->isTemplateExp())
@@ -708,7 +709,7 @@ public:
                 }
                 sym->getModule()->accept(this);
                 if (attr->op == EXP::call)
-                    attr = ctfeInterpret(attr);
+                    attr = dmd::ctfeInterpret(attr);
                 if (attr->op != EXP::structLiteral)
                     continue;
             }
@@ -1172,14 +1173,14 @@ public:
                 s->accept(this);
             }
             ClassDeclarations aclasses;
-            getLocalClasses(d, aclasses);
+            dmd::getLocalClasses(d, aclasses);
             for (size_t i = 0; i < d->aimports.length; i++)
             {
                 Module *mi = d->aimports[i];
                 if (mi->needmoduleinfo)
                     mi->accept(this);
             }
-            (void)findGetMembers(d);
+            (void)dmd::findGetMembers(d);
             (void)d->sctor;
             (void)d->sdtor;
             (void)d->ssharedctor;
@@ -1240,7 +1241,7 @@ public:
     }
     void visit(Nspace *d) override
     {
-        if (isError(d) || !d->members)
+        if (dmd::isError(d) || !d->members)
             return;
         for (size_t i = 0; i < d->members->length; i++)
             (*d->members)[i]->accept(this);
@@ -1262,7 +1263,7 @@ public:
     }
     void visit(TemplateInstance *d) override
     {
-        if (isError(d) || !d->members)
+        if (dmd::isError(d) || !d->members)
             return;
         if (!d->needsCodegen())
             return;
@@ -1271,7 +1272,7 @@ public:
     }
     void visit(TemplateMixin *d) override
     {
-        if (isError(d) || !d->members)
+        if (dmd::isError(d) || !d->members)
             return;
         for (size_t i = 0; i < d->members->length; i++)
             (*d->members)[i]->accept(this);
@@ -1316,7 +1317,7 @@ public:
             FuncDeclaration *fd = d->vtbl[i]->isFuncDeclaration();
             if (!fd || (!fd->fbody && d->isAbstract()))
                 continue;
-            if (!functionSemantic(fd))
+            if (!dmd::functionSemantic(fd))
                 return;
             if (!d->isFuncHidden(fd) || fd->isFuture())
                 continue;
@@ -1341,7 +1342,7 @@ public:
         (void)d->sinit;
         NewExp *ne = NewExp::create(d->loc, NULL, d->type, NULL);
         ne->type = d->type;
-        Expression *e = ctfeInterpret(ne);
+        Expression *e = dmd::ctfeInterpret(ne);
         assert(e->op == EXP::classReference);
         ClassReferenceExp *exp = e->isClassReferenceExp();
         ClassDeclaration *cd = exp->originalClass();
@@ -1452,7 +1453,7 @@ public:
         }
         if (FuncDeclaration *fd = decl->isFuncDeclaration())
         {
-            if (!functionSemantic(fd))
+            if (!dmd::functionSemantic(fd))
                 return;
             if (fd->needThis() && !fd->isMember2())
                 return;
@@ -1489,7 +1490,7 @@ public:
             {
                 if (vd->_init && !vd->_init->isVoidInitializer())
                 {
-                    Expression *ie = initializerToExpression(vd->_init);
+                    Expression *ie = dmd::initializerToExpression(vd->_init);
                     ie->accept(this);
                 }
             }
@@ -1552,7 +1553,7 @@ public:
             {
                 if (!d->_init->isVoidInitializer())
                 {
-                    Expression *e = initializerToExpression(d->_init, d->type);
+                    Expression *e = dmd::initializerToExpression(d->_init, d->type);
                     e->accept(this);
                 }
             }
@@ -1568,7 +1569,7 @@ public:
             if (d->_init && !d->_init->isVoidInitializer())
             {
                 ExpInitializer *vinit = d->_init->isExpInitializer();
-                initializerToExpression(vinit)->accept(this);
+                dmd::initializerToExpression(vinit)->accept(this);
                 if (d->needsScopeDtor())
                     d->edtor->accept(this);
             }
@@ -1610,7 +1611,7 @@ public:
         }
         if (d->semanticRun < PASS::semantic3)
         {
-            functionSemantic3(d);
+            dmd::functionSemantic3(d);
             Module::runDeferredSemantic3();
         }
         if (global.errors)
@@ -1659,15 +1660,6 @@ public:
     }
 };
 
-void test_typinf(Expression *e, const Loc &loc, Type *t, Scope *sc)
-{
-    // Link tests
-    genTypeInfo(e, loc, t, sc);
-    getTypeInfoType(loc, t, sc, false);
-    isSpeculativeType(t);
-    builtinTypeInfo(t);
-}
-
 void test_backend(FuncDeclaration *f, Type *t)
 {
     MiniGlueVisitor v(f);
@@ -1675,16 +1667,11 @@ void test_backend(FuncDeclaration *f, Type *t)
         t->accept(&v);
     else
     {
-        Type *tb = castMod(t, 0);
+        Type *tb = dmd::castMod(t, 0);
         tb->accept(&v);
         (void)t->mod;
     }
     f->fbody->accept(&v);
-}
-
-void link_test_typesem(Type *t1, Type *t2)
-{
-    covariant(t1, t2);
 }
 
 /**********************************/
@@ -1713,4 +1700,157 @@ int main(int argc, char **argv)
     frontend_term();
 
     return 0;
+}
+
+/**********************************/
+// Link Tests
+
+void aggregate_h(StructDeclaration *sd)
+{
+    dmd::search_toString(sd);
+    dmd::semanticTypeInfoMembers(sd);
+}
+
+void argtypes_h(Type *t)
+{
+    // LLVM-only
+    //dmd::toArgTypes_x86(t);
+    //dmd::toArgTypes_sysv_x64(t);
+    //dmd::toArgTypes_aarch64(t);
+    //dmd::isHFVA(t);
+}
+
+void declaration_h(FuncDeclaration *fd, const Loc &loc, Expressions* args)
+{
+    dmd::functionSemantic(fd);
+    dmd::functionSemantic3(fd);
+    ::eval_builtin(loc, fd, args);
+    ::isBuiltin(fd);
+}
+
+void doc_h(Module *m, const char *ptr, d_size_t length, const char *date,
+           ErrorSink *sink, OutBuffer &buf)
+{
+    dmd::gendocfile(m, ptr, length, date, sink, buf);
+}
+
+void dsymbol_h(Dsymbol *d, Scope *sc, ScopeDsymbol *sds, const Loc &loc, Identifier *ident)
+{
+    dmd::dsymbolSemantic(d, sc);
+    dmd::semantic2(d, sc);
+    dmd::semantic3(d, sc);
+    dmd::addMember(d, sc, sds);
+    dmd::search(d, loc, ident);
+    dmd::setScope(d, sc);
+    dmd::importAll(d, sc);
+}
+
+void expression_h(Expression *e, Scope *sc, Type *t, const Loc &loc, Expressions *es)
+{
+    dmd::expressionSemantic(e, sc);
+    dmd::defaultInit(t, loc);
+    dmd::ctfeInterpret(e);
+    dmd::expandTuples(es);
+    dmd::optimize(e, 0);
+}
+
+void hdrgen_h(Module *m, OutBuffer &buf, Modules &ms, ParameterList pl,
+              Expression *e, Initializer *i, Statement *s, Type *t)
+{
+    dmd::genhdrfile(m, true, buf);
+    dmd::genCppHdrFiles(ms);
+    dmd::moduleToBuffer(buf, true, m);
+    dmd::parametersTypeToChars(pl);
+    dmd::toChars(e);
+    dmd::toChars(i);
+    dmd::toChars(s);
+    dmd::toChars(t);
+}
+
+void init_h(Initializer *i, Type *t, Scope *sc, NeedInterpret ni)
+{
+    dmd::initializerToExpression(i, t, true);
+    dmd::initializerSemantic(i, sc, t, ni);
+}
+
+void json_h(Modules &ms, OutBuffer &buf, const char *name)
+{
+    dmd::json_generate(ms, buf);
+    dmd::tryParseJsonField(name);
+}
+
+void mangle_h(Dsymbol *s, FuncDeclaration *fd, Type *t, OutBuffer &buf,
+              Expression *e, TemplateInstance *ti)
+{
+    dmd::toCppMangleItanium(s);
+    dmd::cppTypeInfoMangleItanium(s);
+    dmd::cppThunkMangleItanium(fd, 42);
+    dmd::mangleExact(fd);
+    dmd::mangleToBuffer(t, buf);
+    dmd::mangleToBuffer(e, buf);
+    dmd::mangleToBuffer(s, buf);
+    dmd::mangleToBuffer(ti, buf);
+}
+
+void module_h(Module *m, Array<ClassDeclaration* >& acs, ScopeDsymbol *sds)
+{
+    dmd::getLocalClasses(m, acs);
+    dmd::findGetMembers(sds);
+}
+
+void mtype_h(Type *t1, Type *t2, const Loc &loc, Scope *sc, int *p)
+{
+    dmd::typeSemantic(t1, loc, sc);
+    dmd::merge(t1);
+    dmd::isAggregate(t1);
+    dmd::hasPointers(t1);
+    dmd::toDsymbol(t1, sc);
+    dmd::equivalent(t1, t2);
+    dmd::covariant(t1, t2);
+    dmd::isBaseOf(t1, t2, p);
+    dmd::trySemantic(t1, loc, sc);
+    dmd::merge2(t1);
+    dmd::constOf(t1);
+    dmd::immutableOf(t1);
+    dmd::mutableOf(t1);
+    dmd::sharedOf(t1);
+    dmd::sharedConstOf(t1);
+    dmd::unSharedOf(t1);
+    dmd::wildOf(t1);
+    dmd::wildConstOf(t1);
+    dmd::sharedWildOf(t1);
+    dmd::sharedWildConstOf(t1);
+    dmd::castMod(t1, 0);
+    dmd::addMod(t1, 0);
+    dmd::pointerTo(t1);
+    dmd::referenceTo(t1);
+}
+
+void statement_h(Statement *s, AsmStatement *as, GccAsmStatement *gas, Scope *sc)
+{
+    dmd::statementSemantic(s, sc);
+    dmd::asmSemantic(as, sc);
+    dmd::gccAsmSemantic(gas, sc);
+}
+
+void template_h(TemplateParameter *tp, Scope *sc, TemplateParameters *tps,
+                RootObject *o, ErrorSink *sink)
+{
+    dmd::tpsemantic(tp, sc, tps);
+    dmd::isExpression(o);
+    dmd::isDsymbol(o);
+    dmd::isType(o);
+    dmd::isTuple(o);
+    dmd::isParameter(o);
+    dmd::isTemplateParameter(o);
+    dmd::isError(o);
+    dmd::printTemplateStats(true, sink);
+}
+
+void typinf_h(Expression *e, const Loc &loc, Type *t, Scope *sc)
+{
+    dmd::genTypeInfo(e, loc, t, sc);
+    ::getTypeInfoType(loc, t, sc, false);
+    dmd::isSpeculativeType(t);
+    dmd::builtinTypeInfo(t);
 }


### PR DESCRIPTION
As discussed @kinke / @RazvanN7.

`extern(C++)` can/should be move to separate PR - I've just bundled it all in here, as it was simpler to fix them up so they didn't appear in the regexp I was using to match functions as I was going through them.

---

Update: now all `extern(C++)` top-level functions are in one (boilerplate) leaf module.