### PR TITLE
dmd: Remove extern(C++) from global functions that don't need it

### DIFF
--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -152,7 +152,7 @@ bool isRefReturnScope(const ulong stc)
 
 /* This is different from the one in declaration.d, make that fix a separate PR */
 static if (0)
-extern (C++) __gshared const(StorageClass) STCStorageClass =
+__gshared const(StorageClass) STCStorageClass =
     (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ |
      STC.abstract_ | STC.synchronized_ | STC.deprecated_ | STC.override_ | STC.lazy_ |
      STC.alias_ | STC.out_ | STC.in_ | STC.manifest | STC.immutable_ | STC.shared_ |

--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -235,7 +235,7 @@ Expression implicitCastTo(Expression e, Scope* sc, Type t)
  * Returns:
  *   The `MATCH` level between `e.type` and `t`.
  */
-extern(C++) MATCH implicitConvTo(Expression e, Type t)
+MATCH implicitConvTo(Expression e, Type t)
 {
     MATCH visit(Expression e)
     {

--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -213,7 +213,7 @@ bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
 
 /******************************************
  */
-extern (C++) void ObjectNotFound(Identifier id)
+void ObjectNotFound(Identifier id)
 {
     error(Loc.initial, "`%s` not found. object.d may be incorrectly installed or corrupt.", id.toChars());
     fatal();

--- a/compiler/src/dmd/declaration.h
+++ b/compiler/src/dmd/declaration.h
@@ -107,8 +107,6 @@ bool functionSemantic3(FuncDeclaration* fd);
 #define STC_TYPECTOR    (STCconst | STCimmutable | STCshared | STCwild)
 #define STC_FUNCATTR    (STCref | STCnothrow | STCnogc | STCpure | STCproperty | STCsafe | STCtrusted | STCsystem)
 
-void ObjectNotFound(Identifier *id);
-
 /**************************************************************/
 
 class Declaration : public Dsymbol

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -427,7 +427,5 @@ public:
 
 void addMember(Dsymbol *dsym, Scope *sc, ScopeDsymbol *sds);
 Dsymbol *search(Dsymbol *d, const Loc &loc, Identifier *ident, SearchOptFlags flags = (SearchOptFlags)SearchOpt::localsOnly);
-bool checkDeprecated(Dsymbol *d, const Loc &loc, Scope *sc);
 void setScope(Dsymbol *d, Scope *sc);
 void importAll(Dsymbol *d, Scope *sc);
-void setFieldOffset(Dsymbol *d, AggregateDeclaration *ad, FieldState& fieldState, bool isunion);

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -6907,7 +6907,7 @@ extern(C++) class ImportAllVisitor : Visitor
     override void visit(StaticForeachDeclaration _) {}
 }
 
-extern(C++) void setFieldOffset(Dsymbol d, AggregateDeclaration ad, FieldState* fieldState, bool isunion)
+void setFieldOffset(Dsymbol d, AggregateDeclaration ad, FieldState* fieldState, bool isunion)
 {
     scope v = new SetFieldOffsetVisitor(ad, fieldState, isunion);
     d.accept(v);

--- a/compiler/src/dmd/errors.h
+++ b/compiler/src/dmd/errors.h
@@ -24,8 +24,6 @@ enum class ErrorKind
     message = 4,
 };
 
-bool isConsoleColorSupported();
-
 #if defined(__GNUC__)
 #define D_ATTRIBUTE_FORMAT(m, n) __attribute__((format(printf, m, n))) __attribute__((nonnull (m)))
 #else

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -50,11 +50,6 @@ struct Symbol;          // back end symbol
 // A compile-time result is required. Give an error if not possible
 Expression *ctfeInterpret(Expression *e);
 void expandTuples(Expressions *exps, Identifiers *names = nullptr);
-StringExp *toUTF8(StringExp *se, Scope *sc);
-Expression *resolveLoc(Expression *exp, const Loc &loc, Scope *sc);
-MATCH implicitConvTo(Expression *e, Type *t);
-Expression *toLvalue(Expression *_this, Scope *sc, const char* action);
-Expression *modifiableLvalue(Expression* exp, Scope *sc);
 Expression *optimize(Expression *exp, int result, bool keepLvalue = false);
 
 typedef unsigned char OwnedBy;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -2523,7 +2523,7 @@ private bool checkRightThis(Expression e, Scope* sc)
     return false;
 }
 
-extern (C++) Expression resolveProperties(Scope* sc, Expression e)
+Expression resolveProperties(Scope* sc, Expression e)
 {
     //printf("resolveProperties(%s)\n", e.toChars());
     e = resolvePropertiesX(sc, e);
@@ -15534,7 +15534,7 @@ Expression addDtorHook(Expression e, Scope* sc)
  *     action = for error messages, what the lvalue is needed for (e.g. take address of for `&x`, modify for `x++`)
  * Returns: converted expression, or `ErrorExp` on error
 */
-extern(C++) Expression toLvalue(Expression _this, Scope* sc, const(char)* action)
+Expression toLvalue(Expression _this, Scope* sc, const(char)* action)
 {
     return toLvalueImpl(_this, sc, action, _this);
 }
@@ -15955,7 +15955,7 @@ Modifiable checkModifiable(Expression exp, Scope* sc, ModifyFlags flag = ModifyF
  *     sc = scope
  * Returns: `_this` converted to an lvalue, or an `ErrorExp`
  */
-extern(C++) Expression modifiableLvalue(Expression _this, Scope* sc)
+Expression modifiableLvalue(Expression _this, Scope* sc)
 {
     return modifiableLvalueImpl(_this, sc, _this);
 }

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -781,14 +781,6 @@ public:
     }
 };
 
-enum class MATCH
-{
-    nomatch = 0,
-    convert = 1,
-    constant = 2,
-    exact = 3,
-};
-
 enum class ThreeState : uint8_t
 {
     none = 0u,
@@ -1320,6 +1312,14 @@ enum class ClassFlags : uint32_t
     isCPPclass = 128u,
     hasDtor = 256u,
     hasNameSig = 512u,
+};
+
+enum class MATCH
+{
+    nomatch = 0,
+    convert = 1,
+    constant = 2,
+    exact = 3,
 };
 
 struct MatchAccumulator final
@@ -5446,8 +5446,6 @@ extern Type* merge2(Type* type);
 
 extern Type* mutableOf(Type* type);
 
-extern void purityLevel(TypeFunction* typeFunction);
-
 extern Type* sharedConstOf(Type* type);
 
 extern Type* sharedOf(Type* type);
@@ -6667,8 +6665,6 @@ extern const char* cppTypeInfoMangleDMC(Dsymbol* s);
 
 extern DArray<uint8_t > preprocess(FileName csrcfile, const Loc& loc, OutBuffer& defines);
 
-extern MATCH implicitConvTo(Expression* e, Type* t);
-
 struct BaseClass final
 {
     Type* type;
@@ -6752,8 +6748,6 @@ public:
     InterfaceDeclaration* isInterfaceDeclaration() override;
     void accept(Visitor* v) override;
 };
-
-extern void ObjectNotFound(Identifier* id);
 
 class Declaration : public Dsymbol
 {
@@ -7572,17 +7566,9 @@ public:
     void visit(StaticForeachDeclaration* _) override;
 };
 
-extern void setFieldOffset(Dsymbol* d, AggregateDeclaration* ad, FieldState* fieldState, bool isunion);
-
 extern void genCppHdrFiles(Array<Module* >& ms);
 
-extern Expression* resolveProperties(Scope* sc, Expression* e);
-
 extern Expression* expressionSemantic(Expression* e, Scope* sc);
-
-extern Expression* toLvalue(Expression* _this, Scope* sc, const char* action);
-
-extern Expression* modifiableLvalue(Expression* _this, Scope* sc);
 
 extern bool functionSemantic(FuncDeclaration* fd);
 

--- a/compiler/src/dmd/libelf.d
+++ b/compiler/src/dmd/libelf.d
@@ -532,7 +532,7 @@ struct ElfLibHeader
     char[ELF_TRAILER_SIZE] trailer;
 }
 
-extern (C++) void ElfOmToHeader(ElfLibHeader* h, ElfObjModule* om)
+void ElfOmToHeader(ElfLibHeader* h, ElfObjModule* om)
 {
     char* buffer = cast(char*)h;
     // user_id and group_id are padded on 6 characters in Header struct.

--- a/compiler/src/dmd/libmach.d
+++ b/compiler/src/dmd/libmach.d
@@ -511,7 +511,7 @@ struct MachLibHeader
     char[MACH_TRAILER_SIZE] trailer;
 }
 
-extern (C++) void MachOmToHeader(MachLibHeader* h, MachObjModule* om)
+void MachOmToHeader(MachLibHeader* h, MachObjModule* om)
 {
     const slen = om.name.length;
     int nzeros = 8 - ((slen + 4) & 7);

--- a/compiler/src/dmd/libmscoff.d
+++ b/compiler/src/dmd/libmscoff.d
@@ -645,7 +645,7 @@ struct MSCoffLibHeader
     char[MSCOFF_TRAILER_SIZE] trailer;
 }
 
-extern (C++) void MSCoffOmToHeader(MSCoffLibHeader* h, MSCoffObjModule* om)
+void MSCoffOmToHeader(MSCoffLibHeader* h, MSCoffObjModule* om)
 {
     size_t len;
     if (om.name_offset == -1)

--- a/compiler/src/dmd/libomf.d
+++ b/compiler/src/dmd/libomf.d
@@ -30,7 +30,7 @@ import dmd.root.stringtable;
 import dmd.scanomf;
 
 // Entry point (only public symbol in this module).
-extern (C++) Library LibOMF_factory()
+Library LibOMF_factory()
 {
     return new LibOMF();
 }

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -892,7 +892,6 @@ Dsymbol *toDsymbol(Type *t, Scope *sc);
 Covariant covariant(Type *, Type *, StorageClass * = NULL, bool = false);
 bool isBaseOf(Type *tthis, Type *t, int *poffset);
 Type *trySemantic(Type *type, const Loc &loc, Scope *sc);
-void purityLevel(TypeFunction *type);
 Type *merge2(Type *type);
 Type *constOf(Type *type);
 Type *immutableOf(Type *type);

--- a/compiler/src/dmd/toctype.d
+++ b/compiler/src/dmd/toctype.d
@@ -77,7 +77,7 @@ tym_t modToTym(MOD mod) pure @safe
  * Returns:
  *      back end equivalent `type`
  */
-extern (C++) type* Type_toCtype(Type t)
+type* Type_toCtype(Type t)
 {
     if (t.ctype)
         return cast(type*)t.ctype;

--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -61,7 +61,7 @@ alias Dts = Array!(dt_t*);
 
 /* ================================================================ */
 
-extern (C++) void Initializer_toDt(Initializer init, ref DtBuilder dtb, bool isCfile)
+void Initializer_toDt(Initializer init, ref DtBuilder dtb, bool isCfile)
 {
     void visitError(ErrorInitializer)
     {
@@ -218,7 +218,7 @@ extern (C++) void Initializer_toDt(Initializer init, ref DtBuilder dtb, bool isC
 
 /* ================================================================ */
 
-extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
+void Expression_toDt(Expression e, ref DtBuilder dtb)
 {
     dtb.checkInitialized();
 
@@ -649,7 +649,7 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
 
 // Generate the data for the static initializer.
 
-extern (C++) void ClassDeclaration_toDt(ClassDeclaration cd, ref DtBuilder dtb)
+void ClassDeclaration_toDt(ClassDeclaration cd, ref DtBuilder dtb)
 {
     //printf("ClassDeclaration.toDt(this = '%s')\n", cd.toChars());
 
@@ -658,7 +658,7 @@ extern (C++) void ClassDeclaration_toDt(ClassDeclaration cd, ref DtBuilder dtb)
     //printf("-ClassDeclaration.toDt(this = '%s')\n", cd.toChars());
 }
 
-extern (C++) void StructDeclaration_toDt(StructDeclaration sd, ref DtBuilder dtb)
+void StructDeclaration_toDt(StructDeclaration sd, ref DtBuilder dtb)
 {
     //printf("+StructDeclaration.toDt(), this='%s'\n", sd.toChars());
     membersToDt(sd, dtb, null, 0, null, null);
@@ -673,7 +673,7 @@ extern (C++) void StructDeclaration_toDt(StructDeclaration sd, ref DtBuilder dtb
  *      cd = C++ class
  *      dtb = data table builder
  */
-extern (C++) void cpp_type_info_ptr_toDt(ClassDeclaration cd, ref DtBuilder dtb)
+void cpp_type_info_ptr_toDt(ClassDeclaration cd, ref DtBuilder dtb)
 {
     //printf("cpp_type_info_ptr_toDt(this = '%s')\n", cd.toChars());
     assert(cd.isCPPclass());
@@ -1043,7 +1043,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
 
 /* ================================================================= */
 
-extern (C++) void Type_toDt(Type t, ref DtBuilder dtb, bool isCtype = false)
+void Type_toDt(Type t, ref DtBuilder dtb, bool isCtype = false)
 {
     switch (t.ty)
     {
@@ -1121,7 +1121,7 @@ private void ClassReferenceExp_toDt(ClassReferenceExp e, ref DtBuilder dtb, int 
         write_instance_pointers(e.type, s, 0);
 }
 
-extern (C++) void ClassReferenceExp_toInstanceDt(ClassReferenceExp ce, ref DtBuilder dtb)
+void ClassReferenceExp_toInstanceDt(ClassReferenceExp ce, ref DtBuilder dtb)
 {
     //printf("ClassReferenceExp.toInstanceDt() %d\n", ce.op);
     ClassDeclaration cd = ce.originalClass();
@@ -1616,7 +1616,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     }
 }
 
-extern (C++) void TypeInfo_toDt(ref DtBuilder dtb, TypeInfoDeclaration d)
+void TypeInfo_toDt(ref DtBuilder dtb, TypeInfoDeclaration d)
 {
     scope v = new TypeInfoDtVisitor(dtb);
     d.accept(v);

--- a/compiler/src/dmd/typesem.d
+++ b/compiler/src/dmd/typesem.d
@@ -520,7 +520,7 @@ int mutabilityOfType(bool isref, Type t)
  * Set 'purity' field of 'typeFunction'.
  * Do this lazily, as the parameter types might be forward referenced.
  */
-extern(C++) void purityLevel(TypeFunction typeFunction)
+void purityLevel(TypeFunction typeFunction)
 {
     TypeFunction tf = typeFunction;
     if (tf.purity != PURE.fwdref)


### PR DESCRIPTION
Extracted from #16155.