### PR TITLE
dmd: Add extern(C++) functions missing from the headers

### DIFF
--- a/compiler/src/dmd/aggregate.h
+++ b/compiler/src/dmd/aggregate.h
@@ -42,6 +42,7 @@ enum class Baseok : uint8_t
 };
 
 FuncDeclaration *search_toString(StructDeclaration *sd);
+void semanticTypeInfoMembers(StructDeclaration *sd);
 
 enum class ClassKind : uint8_t
 {

--- a/compiler/src/dmd/argtypes.h
+++ b/compiler/src/dmd/argtypes.h
@@ -1,0 +1,22 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved
+ * written by Walter Bright
+ * https://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * https://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/dlang/dmd/blob/master/compiler/src/dmd/argtypes.h
+ */
+
+#pragma once
+
+class Type;
+class TypeTuple;
+
+// in argtypes_x86.d
+TypeTuple *toArgTypes_x86(Type *t);
+// in argtypes_sysv_x64.d
+TypeTuple *toArgTypes_sysv_x64(Type *t);
+// in argtypes_aarch64.d
+TypeTuple *toArgTypes_aarch64(Type *t);
+bool isHFVA(Type *t, int maxNumElements = 4, Type **rewriteType = NULL);

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -46,6 +46,11 @@ typedef union tree_node Symbol;
 struct Symbol;          // back end symbol
 #endif
 
+// in expressionsem.d
+Expression *expressionSemantic(Expression *e, Scope *sc);
+// in typesem.d
+Expression *defaultInit(Type *mt, const Loc &loc, const bool isCfile = false);
+
 // Entry point for CTFE.
 // A compile-time result is required. Give an error if not possible
 Expression *ctfeInterpret(Expression *e);

--- a/compiler/src/dmd/hdrgen.h
+++ b/compiler/src/dmd/hdrgen.h
@@ -13,9 +13,17 @@
 #include "globals.h"
 #include "mtype.h"
 
+class Expression;
+class Initializer;
 class Module;
+class Statement;
 
 void genhdrfile(Module *m, bool doFuncBodies, OutBuffer &buf);
 void genCppHdrFiles(Modules &ms);
 void moduleToBuffer(OutBuffer& buf, bool vcg_ast, Module *m);
 const char *parametersTypeToChars(ParameterList pl);
+
+const char* toChars(const Expression* const e);
+const char* toChars(const Initializer* const i);
+const char* toChars(const Statement* const s);
+const char* toChars(const Type* const t);

--- a/compiler/src/dmd/init.h
+++ b/compiler/src/dmd/init.h
@@ -125,3 +125,4 @@ public:
 };
 
 Expression *initializerToExpression(Initializer *init, Type *t = NULL, const bool isCfile = false);
+Initializer *initializerSemantic(Initializer *init, Scope *sc, Type *&tx, NeedInterpret needInterpret);

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -39,7 +39,6 @@ typedef union tree_node type;
 typedef struct TYPE type;
 #endif
 
-extern const char* toChars(const Type* const t);
 Type *typeSemantic(Type *t, const Loc &loc, Scope *sc);
 Type *merge(Type *type);
 

--- a/compiler/src/dmd/statement.h
+++ b/compiler/src/dmd/statement.h
@@ -701,7 +701,12 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
+// in statementsem.d
+Statement* statementSemantic(Statement *s, Scope *sc);
+// in iasm.d
 Statement* asmSemantic(AsmStatement *s, Scope *sc);
+// in iasmgcc.d
+Statement *gccAsmSemantic(GccAsmStatement *s, Scope *sc);
 
 class AsmStatement : public Statement
 {

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -317,6 +317,9 @@ public:
     void accept(Visitor *v) override { v->visit(this); }
 };
 
+// in templateparamsem.d
+bool tpsemantic(TemplateParameter *tp, Scope *sc, TemplateParameters *parameters);
+
 Expression *isExpression(RootObject *o);
 Dsymbol *isDsymbol(RootObject *o);
 Type *isType(RootObject *o);


### PR DESCRIPTION
I can't say why they are `extern (C++)`, other than maybe they're used by LDC @kinke.

This adds them to the headers so you don't need to declare them locally, or in `#if IN_LLVM` macro blocks.