### PR TITLE
Bump the minimum D language version in order to build DMD to 2.083

### DIFF
--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -74,7 +74,7 @@ fi
 
 # no `-debug` for unittests build with old host compilers (to avoid compile errors)
 disable_debug_for_unittests=()
-if [[ "$HOST_DMD_VERSION" == "2.079.0" ]]; then
+if [[ "$HOST_DMD_VERSION" == "2.083.1" ]]; then
     disable_debug_for_unittests=(ENABLE_DEBUG=0)
 fi
 
@@ -137,7 +137,7 @@ fi
 
 targets=("all")
 args=('ARGS=-O -inline -g') # no -release for faster builds
-if [ "$HOST_DMD_VERSION" = "2.079.0" ] ; then
+if [ "$HOST_DMD_VERSION" = "2.083.1" ] ; then
     # skip runnable_cxx and unit_tests with older bootstrap compilers
     targets=("runnable" "compilable" "fail_compilation" "dshell")
     args=() # use default set of args

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           #   coverage: true
           - job_name: Ubuntu 22.04 x64, DMD (bootstrap)
             os: ubuntu-22.04
-            host_dmd: dmd-2.079.0
+            host_dmd: dmd-2.083.1
             disable_debug_for_dmd_unittests: true # no `-debug` - host frontend too old
           - job_name: Ubuntu 22.04 x86, DMD (latest)
             os: ubuntu-22.04

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
       vmImage: 'windows-2019'
     variables:
       D_COMPILER: dmd
-      HOST_DMD_VERSION: 2.079.0
+      HOST_DMD_VERSION: 2.083.1
     strategy:
       matrix:
         x64:

--- a/ci/cirrusci.sh
+++ b/ci/cirrusci.sh
@@ -29,7 +29,7 @@ if [ "$OS_NAME" == "linux" ]; then
   apt-get install -yq $packages
 elif [ "$OS_NAME" == "freebsd" ]; then
   packages="git gmake devel/llvm12"
-  if [ "$HOST_DMD" == "dmd-2.079.0" ] ; then
+  if [ "$HOST_DMD" == "dmd-2.083.1" ] ; then
     packages="$packages lang/gcc9"
   fi
   pkg install -y $packages

--- a/compiler/src/README.md
+++ b/compiler/src/README.md
@@ -11,7 +11,7 @@ The compiler can be built using the integrated build system `build.d`.
 ./build.d
 ```
 
-Building requires a host D compiler (DMD/LDC/GDC) of version 2.079.1 or above
+Building requires a host D compiler (DMD/LDC/GDC) of version 2.083.1 or above
 and defaults to `dmd` as found on the path. This behaviour can be overriden
 by explicitly specifying a different host compiler using the `HOST_DMD` variable.
 

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1457,17 +1457,6 @@ void processEnvironmentCxx()
     if (!sanitizers.empty)
         cxxFlags ~= "-fsanitize=" ~ sanitizers;
 
-    // Enable a temporary workaround in globals.h and rmem.h concerning
-    // wrong name mangling using DMD.
-    // Remove when the minimally required D version becomes 2.082 or later
-    if (env["HOST_DMD_KIND"] == "dmd")
-    {
-        const output = run([ env["HOST_DMD_RUN"], "--version" ]);
-
-        if (output.canFind("v2.079", "v2.080", "v2.081"))
-            cxxFlags ~= "-DDMD_VERSION=2080";
-    }
-
     // Retain user-defined flags
     flags["CXXFLAGS"] = cxxFlags ~= flags.get("CXXFLAGS", []);
 }

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -343,13 +343,7 @@ extern Global global;
 // we have to explicitly ask for the correct integer type to get the correct
 // mangling with dmd. The #if logic here should match the mangling of
 // Tint64 and Tuns64 in cppmangle.d.
-#if MARS && DMD_VERSION >= 2079 && DMD_VERSION <= 2081 && \
-    __APPLE__ && __SIZEOF_LONG__ == 8
-// DMD versions between 2.079 and 2.081 mapped D long to int64_t on OS X.
-typedef uint64_t dinteger_t;
-typedef int64_t sinteger_t;
-typedef uint64_t uinteger_t;
-#elif __SIZEOF_LONG__ == 8
+#if __SIZEOF_LONG__ == 8
 // Be careful not to care about sign when using dinteger_t
 // use this instead of integer_t to
 // avoid conflicts with system #include's

--- a/compiler/src/dmd/root/dcompat.h
+++ b/compiler/src/dmd/root/dcompat.h
@@ -39,10 +39,6 @@ struct DString : public DArray<const char>
 #if __APPLE__ && (__i386__ || __ppc__)
 // size_t is 'unsigned long', which makes it mangle differently than D's 'uint'
 typedef unsigned d_size_t;
-#elif MARS && DMD_VERSION >= 2079 && DMD_VERSION <= 2081 && \
-        __APPLE__ && __SIZEOF_SIZE_T__ == 8
-// DMD versions between 2.079 and 2.081 mapped D ulong to uint64_t on OS X.
-typedef uint64_t d_size_t;
 #elif defined(__OpenBSD__) && !defined(__LP64__)
 // size_t is 'unsigned long', which makes it mangle differently than D's 'uint'
 typedef unsigned d_size_t;


### PR DESCRIPTION
This removes the OSX workaround caused by the mistake in changing C++ type mangling.

The dmd front-end still needs to be buildable by gdc-9 - the baseline compiler used to build all versions of gdc from 12..14 - and although it says that it's `__VERSION__` is 2.076, but it _does_ support some of the features that are present in 2.083, such as `extern(C++, "ns")`.