### PR TITLE
dmd: Move default field initializers to runtime

### DIFF
--- a/compiler/src/dmd/dmdparams.d
+++ b/compiler/src/dmd/dmdparams.d
@@ -313,6 +313,20 @@ struct Triple
     }
 }
 
+/**
+Initializes Target settings to compile for the same target
+as the build compiler.
+*/
+void setTargetBuildDefaults(ref Target target)
+{
+    target = target.init;
+    target.os = defaultTargetOS();
+    target.osMajor = defaultTargetOSMajor();
+    target.cpu = CPU.baseline;
+    target.omfobj = false;
+    target.isX86_64 = (size_t.sizeof == 8);
+}
+
 void setTriple(ref Target target, const ref Triple triple) @safe
 {
     target.cpu     = triple.cpu;

--- a/compiler/src/dmd/frontend.d
+++ b/compiler/src/dmd/frontend.d
@@ -142,6 +142,7 @@ void initDMD(
     versionIdentifiers.each!(VersionCondition.addGlobalIdent);
 
     target.os = defaultTargetOS();
+    target.isX86_64 = (size_t.sizeof == 8);
     target._init(global.params);
     Type._init();
     Id.initialize();

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7749,8 +7749,7 @@ public:
     bool libraryObjectMonitors(FuncDeclaration* fd, Statement* fbody);
     bool supportsLinkerDirective() const;
     Target() :
-        os((OS)1u),
-        osMajor(0u),
+        osMajor(),
         ptrsize(),
         realsize(),
         realpad(),
@@ -7761,14 +7760,13 @@ public:
         cpp(),
         objc(),
         architectureName(),
-        cpu((CPU)11u),
-        isX86_64(true),
+        isX86_64(),
         isLP64(),
         obj_ext(),
         lib_ext(),
         dll_ext(),
         run_noext(),
-        omfobj(false),
+        omfobj(),
         FloatProperties(),
         DoubleProperties(),
         RealProperties(),
@@ -7776,7 +7774,7 @@ public:
         params()
     {
     }
-    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(), TargetCPP cpp = TargetCPP(), TargetObjC objc = TargetObjC(), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)11u, bool isX86_64 = true, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool omfobj = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(), Type* tvalist = nullptr, const Param* params = nullptr) :
+    Target(OS os, uint8_t osMajor = 0u, uint8_t ptrsize = 0u, uint8_t realsize = 0u, uint8_t realpad = 0u, uint8_t realalignsize = 0u, uint8_t classinfosize = 0u, uint64_t maxStaticDataSize = 0LLU, TargetC c = TargetC(), TargetCPP cpp = TargetCPP(), TargetObjC objc = TargetObjC(), _d_dynamicArray< const char > architectureName = {}, CPU cpu = (CPU)0u, bool isX86_64 = false, bool isLP64 = false, _d_dynamicArray< const char > obj_ext = {}, _d_dynamicArray< const char > lib_ext = {}, _d_dynamicArray< const char > dll_ext = {}, bool run_noext = false, bool omfobj = false, FPTypeProperties<float > FloatProperties = FPTypeProperties<float >(), FPTypeProperties<double > DoubleProperties = FPTypeProperties<double >(), FPTypeProperties<_d_real > RealProperties = FPTypeProperties<_d_real >(), Type* tvalist = nullptr, const Param* params = nullptr) :
         os(os),
         osMajor(osMajor),
         ptrsize(ptrsize),

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -155,6 +155,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     Strings files;
     Strings libmodules;
     global._init();
+    target.setTargetBuildDefaults();
 
     if (parseCommandlineAndConfig(argc, argv, params, files))
         return EXIT_FAILURE;

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -322,8 +322,8 @@ extern (C++) struct Target
         omf
     }
 
-    OS os = defaultTargetOS();
-    ubyte osMajor = defaultTargetOSMajor();
+    OS os;
+    ubyte osMajor;
 
     // D ABI
     ubyte ptrsize;            /// size of a pointer in bytes
@@ -344,8 +344,8 @@ extern (C++) struct Target
 
     /// Architecture name
     const(char)[] architectureName;
-    CPU cpu = CPU.baseline; // CPU instruction set to target
-    bool isX86_64 = (size_t.sizeof == 8);  // generate 64 bit code for x86_64; true by default for 64 bit dmd
+    CPU cpu;                // CPU instruction set to target
+    bool isX86_64;          // generate 64 bit code for x86_64; true by default for 64 bit dmd
     bool isLP64;            // pointers are 64 bits
 
     // Environmental
@@ -353,7 +353,7 @@ extern (C++) struct Target
     const(char)[] lib_ext;    /// extension for static library files
     const(char)[] dll_ext;    /// extension for dynamic library files
     bool run_noext;           /// allow -run sources without extensions
-    bool omfobj = false;      // for Win32: write OMF object files instead of MsCoff
+    bool omfobj;              // for Win32: write OMF object files instead of MsCoff
     /**
      * Values representing all properties for floating point types
      */

--- a/compiler/test/unit/deinitialization.d
+++ b/compiler/test/unit/deinitialization.d
@@ -88,6 +88,7 @@ unittest
 unittest
 {
     import dmd.globals : Param;
+    import dmd.dmdparams : setTargetBuildDefaults;
     import dmd.target : target, Target;
 
     static bool isFPTypeProperties(T)()
@@ -114,6 +115,7 @@ unittest
     assertStructsEqual(target, init);
 
     Param params;
+    target.setTargetBuildDefaults();
     target._init(params);
     target.deinitialize();
 


### PR DESCRIPTION
Both gdc and ldc ignore these default values and/or remove the field entirely.

Only dmd depends on them having a value before parsing command-line arguments, so initialize them immediately after `global._init`.

Unblocks #16158, where 2.083 is ICE'ing when compiling the dmd.target module.