### PR TITLE
Fix IsAtomicLockFree for PPC targets

### DIFF
--- a/druntime/src/core/internal/atomic.d
+++ b/druntime/src/core/internal/atomic.d
@@ -609,7 +609,7 @@ else version (GNU)
     import gcc.builtins;
     import gcc.config;
 
-    enum IsAtomicLockFree(T) = __atomic_is_lock_free(T.sizeof, null);
+    enum IsAtomicLockFree(T) = __traits(compiles, { enum E = __atomic_is_lock_free(T.sizeof, null); });
 
     inout(T) atomicLoad(MemoryOrder order = MemoryOrder.seq, T)(inout(T)* src) pure nothrow @nogc @trusted
         if (CanCAS!T)


### PR DESCRIPTION
At compile-time, the GNU built-in `__atomic_is_lock_free` either returns `true` (always lock free) or `null` (meaning defer to run-time). So when the type isn't always lock free - eg: 64-bit types on PPC - a compile-time error occurs as we have no way of evaluating the run-time implementation of libatomics at CTFE.

This has been fixed by checking `__traits(compiles)` instead.