### PR TITLE
Feature: Member of Operator

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -5409,6 +5409,22 @@ struct ASTBase
         }
     }
 
+    extern (C++) class MemberOfOperatorExp : Expression
+    {
+        Identifier ident;
+
+        extern (D) this(const ref Loc loc, Identifier ident) scope @safe
+        {
+            super(loc, EXP.memberOf);
+            this.ident = ident;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
     extern (C++) class ThisExp : Expression
     {
         final extern (D) this(const ref Loc loc)

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -5413,7 +5413,7 @@ struct ASTBase
     {
         Identifier ident;
 
-        extern (D) this(const ref Loc loc, Identifier ident) scope @safe
+        extern (D) this(const ref Loc loc, Identifier ident)
         {
             super(loc, EXP.memberOf, __traits(classInstanceSize, MemberOfOperatorExp));
             this.ident = ident;

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -5415,7 +5415,7 @@ struct ASTBase
 
         extern (D) this(const ref Loc loc, Identifier ident) scope @safe
         {
-            super(loc, EXP.memberOf);
+            super(loc, EXP.memberOf, __traits(classInstanceSize, MemberOfOperatorExp));
             this.ident = ident;
         }
 

--- a/compiler/src/dmd/astenums.d
+++ b/compiler/src/dmd/astenums.d
@@ -199,6 +199,7 @@ enum TY : ubyte
     Tchar,
     Twchar,
     Tdchar,
+    Tmemberof,
     Terror,
     Tinstance,
     Ttypeof,
@@ -251,6 +252,7 @@ alias Tbool = TY.Tbool;
 alias Tchar = TY.Tchar;
 alias Twchar = TY.Twchar;
 alias Tdchar = TY.Tdchar;
+alias Tmemberof = TY.Tmemberof;
 alias Terror = TY.Terror;
 alias Tinstance = TY.Tinstance;
 alias Ttypeof = TY.Ttypeof;

--- a/compiler/src/dmd/basicmangle.d
+++ b/compiler/src/dmd/basicmangle.d
@@ -82,6 +82,7 @@ immutable char[TMAX] mangleChar =
     Tmixin       : '@',
     Ttag         : '@',
     Tnoreturn    : '@',         // becomes 'Nn'
+    Tmemberof    : '@',         // member of is an internal rewrite for delayed semantic
 ];
 
 unittest

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -717,6 +717,7 @@ extern (C++) abstract class Expression : ASTNode
         inout(ComplexExp)   isComplexExp() { return op == EXP.complex80 ? cast(typeof(return))this : null; }
         inout(IdentifierExp) isIdentifierExp() { return op == EXP.identifier ? cast(typeof(return))this : null; }
         inout(DollarExp)    isDollarExp() { return op == EXP.dollar ? cast(typeof(return))this : null; }
+        inout(MemberOfOperatorExp) isMemberOfExp() { return op == EXP.memberOf ? cast(typeof(return))this : null; }
         inout(DsymbolExp)   isDsymbolExp() { return op == EXP.dSymbol ? cast(typeof(return))this : null; }
         inout(ThisExp)      isThisExp() { return op == EXP.this_ ? cast(typeof(return))this : null; }
         inout(SuperExp)     isSuperExp() { return op == EXP.super_ ? cast(typeof(return))this : null; }
@@ -1344,6 +1345,27 @@ extern (C++) final class DollarExp : IdentifierExp
     extern (D) this(const ref Loc loc)
     {
         super(loc, Id.dollar);
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+extern (C++) class MemberOfOperatorExp : Expression
+{
+    Identifier ident;
+
+    extern (D) this(const ref Loc loc, Identifier ident) scope @safe
+    {
+        super(loc, EXP.memberOf);
+        this.ident = ident;
+    }
+
+    static MemberOfOperatorExp create(const ref Loc loc, Identifier ident) @safe
+    {
+        return new MemberOfOperatorExp(loc, ident);
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -1363,11 +1363,6 @@ extern (C++) class MemberOfOperatorExp : Expression
         this.ident = ident;
     }
 
-    static MemberOfOperatorExp create(const ref Loc loc, Identifier ident) @safe
-    {
-        return new MemberOfOperatorExp(loc, ident);
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -124,6 +124,7 @@ public:
     ComplexExp* isComplexExp();
     IdentifierExp* isIdentifierExp();
     DollarExp* isDollarExp();
+    MemberOfOperatorExp* isMemberOfExp();
     DsymbolExp* isDsymbolExp();
     ThisExp* isThisExp();
     SuperExp* isSuperExp();
@@ -1055,6 +1056,13 @@ class AddAssignExp final : public BinAssignExp
 {
 public:
     void accept(Visitor *v) override { v->visit(this); }
+};
+
+class MemberOfOperator : public Expression
+{
+public:
+    Identifier* ident;
+    void accept(Visitor* v) override { v->visit(this); }
 };
 
 class MinAssignExp final : public BinAssignExp

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3984,9 +3984,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(MemberOfOperatorExp e)
     {
-        error(e.loc, "Member of operator may not used in infering of lhs for %s", e.ident.toChars());
-        result = ErrorExp.get();
-        setError();
+        // this will be handled elsewhere
+        e.type = Type.tmemberOfOperator;
+        result = e;
     }
 
     override void visit(DsymbolExp e)

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3149,6 +3149,14 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                 if (!((hasCopyCtor && typesMatch) || tprm.equals(arg.type)))
                 {
                     //printf("arg.type = %s, p.type = %s\n", arg.type.toChars(), p.type.toChars());
+
+                    if (auto moexp = arg.isMemberOfExp)
+                    {
+                        TypeExp paramExpr = new TypeExp(moexp.loc, tprm);
+                        Expression getMember = cast(Expression)new DotIdExp(moexp.loc, paramExpr, moexp.ident);
+                        arg = getMember.expressionSemantic(sc);
+                    }
+
                     arg = arg.implicitCastTo(sc, tprm);
                     arg = arg.optimize(WANTvalue, p.isReference());
                 }

--- a/compiler/src/dmd/globals.h
+++ b/compiler/src/dmd/globals.h
@@ -274,6 +274,8 @@ struct CompileEnv
     DString timestamp;
     d_bool previewIn;
     d_bool ddocOutput;
+    d_bool masm;
+    d_bool ignoreMemberOf;
 };
 
 struct Global

--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -4401,6 +4401,7 @@ string EXPtoString(EXP op)
         EXP.void_ : "void",
         EXP.vectorArray : "vectorarray",
         EXP._Generic : "_Generic",
+        EXP.memberOf : "memberofoperator",
 
         // post
         EXP.dotTemplateInstance : "dotti",

--- a/compiler/src/dmd/iasmgcc.d
+++ b/compiler/src/dmd/iasmgcc.d
@@ -420,7 +420,7 @@ unittest
         scope p = new Parser!ASTCodegen(null, ";", false, global.errorSink, &cenv, doUnittests);
         p.token = *tokens;
 
-        GccAsmStatement s = p.parseGccAsm(gas);
+        p.parseGccAsm(gas);
         return global.errors - errors;
     }
 

--- a/compiler/src/dmd/iasmgcc.d
+++ b/compiler/src/dmd/iasmgcc.d
@@ -303,7 +303,9 @@ extern (C++) public Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
 {
     //printf("GccAsmStatement.semantic()\n");
     const bool doUnittests = global.params.parsingUnittestsRequired();
-    scope p = new Parser!ASTCodegen(sc._module, ";", false, global.errorSink, &global.compileEnv, doUnittests);
+    CompileEnv cenv = global.compileEnv;
+    cenv.ignoreMemberOf = true;
+    scope p = new Parser!ASTCodegen(sc._module, ";", false, global.errorSink, &cenv, doUnittests);
 
     // Make a safe copy of the token list before parsing.
     Token *toklist = null;
@@ -412,9 +414,13 @@ unittest
         const errors = global.errors;
         scope gas = new GccAsmStatement(Loc.initial, tokens);
         const bool doUnittests = false;
-        scope p = new Parser!ASTCodegen(null, ";", false, global.errorSink, &global.compileEnv, doUnittests);
+
+        CompileEnv cenv = global.compileEnv;
+        cenv.ignoreMemberOf = true;
+        scope p = new Parser!ASTCodegen(null, ";", false, global.errorSink, &cenv, doUnittests);
         p.token = *tokens;
-        p.parseGccAsm(gas);
+
+        GccAsmStatement s = p.parseGccAsm(gas);
         return global.errors - errors;
     }
 

--- a/compiler/src/dmd/impcnvtab.d
+++ b/compiler/src/dmd/impcnvtab.d
@@ -100,6 +100,7 @@ ImpCnvTab generateImpCnvTab()
         Tchar,
         Twchar,
         Tdchar,
+        Tmemberof,
         Terror,
         Tinstance,
         Ttypeof,

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -51,6 +51,7 @@ struct CompileEnv
     bool previewIn;          /// `in` means `[ref] scope const`, accepts rvalues
     bool ddocOutput;         /// collect embedded documentation comments
     bool masm;               /// use MASM inline asm syntax
+    bool ignoreMemberOf;    /// ':' Identifier support in parser, needed for iasmgcc
 }
 
 /***********************************************************

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -354,6 +354,9 @@ extern (C++) abstract class Type : ASTNode
     extern (C++) __gshared Type tptrdiff_t;  // matches ptrdiff_t alias
     extern (C++) __gshared Type thash_t;     // matches hash_t alias
 
+    // for member of operator, shouldn't appear unless matching is delayed
+    extern (C++) __gshared Type tmemberOfOperator;
+
     extern (C++) __gshared ClassDeclaration dtypeinfo;
     extern (C++) __gshared ClassDeclaration typeinfoclass;
     extern (C++) __gshared ClassDeclaration typeinfointerface;
@@ -521,6 +524,7 @@ extern (C++) abstract class Type : ASTNode
             Tchar,
             Twchar,
             Tdchar,
+            Tmemberof,
             Terror
         ];
 
@@ -603,6 +607,8 @@ extern (C++) abstract class Type : ASTNode
         tsize_t    = basic[isLP64 ? Tuns64 : Tuns32];
         tptrdiff_t = basic[isLP64 ? Tint64 : Tint32];
         thash_t = tsize_t;
+
+        tmemberOfOperator = basic[Tmemberof];
     }
 
     /**
@@ -2471,6 +2477,10 @@ extern (C++) final class TypeBasic : Type
         case Tdchar:
             d = Token.toChars(TOK.dchar_);
             flags |= TFlags.integral | TFlags.unsigned;
+            break;
+
+        case Tmemberof:
+            d = "memberof";
             break;
 
         default:
@@ -5968,6 +5978,7 @@ mixin template VisitType(Result)
             case TY.Tchar:
             case TY.Twchar:
             case TY.Tdchar:
+            case TY.Tmemberof:
             case TY.Tint128:
             case TY.Tuns128:    mixin(visitTYCase("Basic"));
             case TY.Tarray:     mixin(visitTYCase("DArray"));

--- a/compiler/src/dmd/mtype.h
+++ b/compiler/src/dmd/mtype.h
@@ -82,6 +82,7 @@ enum class TY : uint8_t
     Tchar,
     Twchar,
     Tdchar,
+    Tmemberof,
     Terror,
     Tinstance,
     Ttypeof,
@@ -191,6 +192,7 @@ public:
     static Type *tsize_t;               // matches size_t alias
     static Type *tptrdiff_t;            // matches ptrdiff_t alias
     static Type *thash_t;               // matches hash_t alias
+    static Type *tmemberOfOperator;
 
     static ClassDeclaration *dtypeinfo;
     static ClassDeclaration *typeinfoclass;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8599,6 +8599,25 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 break;
             }
 
+        case TOK.colon:
+            {
+                // Member of Operator
+                // ':' Identifier
+                nextToken();
+
+                if (token.value != TOK.identifier)
+                {
+                    error("identifier expected, not %s", token.toChars());
+                    goto Lerr;
+                }
+
+                e = new AST.MemberOfOperatorExp(loc, token.ident);
+
+                // consume the identifier
+                nextToken();
+            }
+            break;
+
         default:
             error("expression expected, not `%s`", token.toChars());
         Lerr:
@@ -9673,6 +9692,7 @@ immutable PREC[EXP.max + 1] precedence =
     EXP.void_ : PREC.primary,
     EXP.vectorArray : PREC.primary,
     EXP._Generic : PREC.primary,
+    EXP.memberOf : PREC.primary,
 
     // post
     EXP.dotTemplateInstance : PREC.primary,

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8600,6 +8600,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             }
 
         case TOK.colon:
+            if (this.compileEnv.ignoreMemberOf)
+                goto default;
+            else
             {
                 // Member of Operator
                 // ':' Identifier
@@ -8609,9 +8612,10 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                     error("identifier expected, not %s", token.toChars());
                     goto Lerr;
                 }
-
                 nextToken(); // consume ':'
+
                 e = new AST.MemberOfOperatorExp(loc, token.ident);
+                nextToken(); // consume Identifier
                 break;
             }
 

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8604,22 +8604,16 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 // Member of Operator
                 // ':' Identifier
 
-                Token previous = this.token;
-                nextToken(); // consume ':'
-
                 if (peekNext() != TOK.identifier)
                 {
-                    this.token = previous;
                     error("identifier expected, not %s", token.toChars());
                     goto Lerr;
                 }
 
+                nextToken(); // consume ':'
                 e = new AST.MemberOfOperatorExp(loc, token.ident);
-
-                // consume the identifier
-                nextToken();
+                break;
             }
-            break;
 
         default:
             error("expression expected, not `%s`", token.toChars());

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8603,10 +8603,13 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             {
                 // Member of Operator
                 // ':' Identifier
-                nextToken();
 
-                if (token.value != TOK.identifier)
+                Token previous = this.token;
+                nextToken(); // consume ':'
+
+                if (peekNext() != TOK.identifier)
                 {
+                    this.token = previous;
                     error("identifier expected, not %s", token.toChars());
                     goto Lerr;
                 }

--- a/compiler/src/dmd/parsetimevisitor.d
+++ b/compiler/src/dmd/parsetimevisitor.d
@@ -193,6 +193,7 @@ public:
     void visit(AST.TypeExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.ScopeExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.IdentifierExp e) { visit(cast(AST.Expression)e); }
+    void visit(AST.MemberOfOperatorExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.UnaExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.DefaultInitExp e) { visit(cast(AST.Expression)e); }
     void visit(AST.BinExp e) { visit(cast(AST.Expression)e); }

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2109,6 +2109,8 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         //printf("CaseStatement::semantic() %s\n", toChars());
         sc = sc.startCTFE();
+        if (auto moexp = cs.exp.isMemberOfExp)
+            cs.exp = new DotIdExp(moexp.loc, sw.condition, moexp.ident);
         cs.exp = cs.exp.expressionSemantic(sc);
         cs.exp = resolveProperties(sc, cs.exp);
         sc = sc.endCTFE();

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -2506,6 +2506,11 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         {
             fd.hasReturnExp |= (fd.hasReturnExp & 1 ? 16 : 1);
 
+            if (auto moexp = rs.exp.isMemberOfExp)
+            {
+                rs.exp = new DotIdExp(moexp.loc, new TypeExp(moexp.loc, new TypeReturn(moexp.loc)), moexp.ident);
+            }
+
             FuncLiteralDeclaration fld = fd.isFuncLiteralDeclaration();
             if (tret)
                 rs.exp = inferType(rs.exp, tret);

--- a/compiler/src/dmd/tokens.d
+++ b/compiler/src/dmd/tokens.d
@@ -387,6 +387,7 @@ enum EXP : ubyte
     halt,
     tuple,
     error,
+    memberOf,
 
     // Basic types
     void_,

--- a/compiler/src/dmd/tokens.h
+++ b/compiler/src/dmd/tokens.h
@@ -397,6 +397,7 @@ enum class EXP : unsigned char
     halt,
     tuple,
     error,
+    memberOf,
 
     // Basic types
     void_,

--- a/compiler/src/dmd/visitor.h
+++ b/compiler/src/dmd/visitor.h
@@ -190,6 +190,7 @@ class RealExp;
 class ComplexExp;
 class IdentifierExp;
 class DollarExp;
+class MemberOfOperatorExp;
 class DsymbolExp;
 class ThisExp;
 class SuperExp;
@@ -491,6 +492,7 @@ public:
     virtual void visit(TypeExp *e) { visit((Expression *)e); }
     virtual void visit(ScopeExp *e) { visit((Expression *)e); }
     virtual void visit(IdentifierExp *e) { visit((Expression *)e); }
+    virtual void visit(MemberOfOperatorExp *e) { visit((Expression *)e); }
     virtual void visit(UnaExp *e) { visit((Expression *)e); }
     virtual void visit(DefaultInitExp *e) { visit((Expression *)e); }
     virtual void visit(BinExp *e) { visit((Expression *)e); }

--- a/compiler/test/runnable/memberOfProperty.d
+++ b/compiler/test/runnable/memberOfProperty.d
@@ -1,0 +1,41 @@
+extern(C) void printf(const char*, ...);
+
+extern(C) void main() {
+    int varB = :max;
+    Context varS = :max;
+    Enum varE = :End;
+    Enum varF1 = functionReturn();
+    Enum varF2 = identity(:Middle);
+    printf("%d <> %d <> %d <> %d <> %d\n", varB, varS.value, varE, varF1, varF2);
+
+    switch(varF1) {
+        case :Start:
+            static assert(!__traits(compiles, { const fail = :max; }));
+            break;
+        default:
+            assert(0);
+    }
+
+    static assert(!__traits(compiles, { const fail = :max; }));
+    static assert(!__traits(compiles, { Context fail = :max.min; }));
+}
+
+struct Context {
+    int value;
+    enum Context min = Context(int.min);
+    enum Context max = Context(int.max);
+}
+
+enum Enum {
+    Start,
+    Middle,
+    End
+}
+
+Enum functionReturn() {
+    return :Start;
+}
+
+Enum identity(Enum input) {
+    return input;
+}


### PR DESCRIPTION
This is a new feature, which I'm calling member of operator.
It is based upon Neat's [Identifier Type](https://neat-lang.github.io/manual.html#symbol-identifier).

In certain statements and expressions, there is a context, when seen with the operator it gets the member and rewrites the AST to use that instead.

Supports function calls, variable declarations, case statements for switch statements, and return expressions.
Dot expressions after it has not been implemented, although that should be done.

Why did I implement this? To prove that even I with limited knowledge can do it. It isn't a complex feature. It was less than 10 hours work with a bit of help from @dkorpel to point in the right direction!

My motivation is to make it be the mechanism to describe sum-type tags without a value type. It also applies to value type exceptions aka zero cost, to replace zero size struct support.

Test case which has all the examples in it:
https://github.com/dlang/dmd/compare/master...rikkimax:dmd:member-of-property#diff-476a4c5f24136a55eb521b2a39faad10ce01dc3075af4f4ceceb82acd22242c3

But the difficult one that is worth copying ``Enum varF2 = identity(:Middle);``.