### PR TITLE
Fix Bugzilla Issue 24370 - static array values in static AA initialis…

### DIFF
--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -876,7 +876,7 @@ private extern(C++) final class StaticAAVisitor : SemanticTimeTransitiveVisitor
         hookFunc = new DotIdExp(aaExp.loc, hookFunc, Id.object);
         hookFunc = new DotIdExp(aaExp.loc, hookFunc, Id._aaAsStruct);
         auto arguments = new Expressions();
-        arguments.push(aaExp.syntaxCopy());
+        arguments.push(aaExp);
         Expression loweredExp = new CallExp(aaExp.loc, hookFunc, arguments);
 
         sc = sc.startCTFE();

--- a/compiler/test/runnable/staticaa.d
+++ b/compiler/test/runnable/staticaa.d
@@ -165,6 +165,22 @@ void testEnumInit()
 
 /////////////////////////////////////////////
 
+// https://issues.dlang.org/show_bug.cgi?id=24370
+immutable uint[3][string] test = [
+	"oneTwoThree": [1,2,3],
+	"fourFiveSix": [4,5,6],
+	"sevenEightNine": [7,8,9],
+];
+
+void testStaticArray()
+{
+	assert(test["oneTwoThree"] == [1, 2, 3]);
+	assert(test["fourFiveSix"] == [4, 5, 6]);
+	assert(test["sevenEightNine"] == [7, 8, 9]);
+}
+
+/////////////////////////////////////////////
+
 void main()
 {
     testSimple();
@@ -175,4 +191,5 @@ void main()
     testImmutable();
     testLocalStatic();
     testEnumInit();
+    testStaticArray();
 }


### PR DESCRIPTION
…e to dynamic arrays

SyntaxCopy strips the type and does semantic again, while we want to keep the static array type in the literal.