### PR TITLE
Add test for parser instantiated with ASTBase in the testsuite

### DIFF
--- a/compiler/test/unit/parser/test_astbase.d
+++ b/compiler/test/unit/parser/test_astbase.d
@@ -1,7 +1,8 @@
-#!/usr/bin/env dub
-/+dub.sdl:
-dependency "dmd" path="../../.."
-+/
+module parser.test_astbase;
+
+// Simple test to check whether ASTBase respects the interface
+// that the parser expects from an AST family
+
 void main()
 {
     import dmd.astbase;


### PR DESCRIPTION
For some reason, dub tests are no longer ran with run.d

Edit: It seems that the dub package for dmdlib was only tested on Travis. This looks like something that should be tested otherwise users will get unexpected failures due to missing files if the file organization fails for dmd as a lib.