### PR TITLE
another correction for caller destroying args

### DIFF
--- a/compiler/src/dmd/inline.d
+++ b/compiler/src/dmd/inline.d
@@ -1813,16 +1813,21 @@ private bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool stat
          * 2. don't inline when the return value has a destructor, as it doesn't
          *    get handled properly
          */
-        if (tf.next && tf.next.ty != Tvoid &&
-            (!(fd.hasReturnExp & 1) ||
-             statementsToo && hasDtor(tf.next)) &&
-            !hdrscan)
+        if (auto tfnext = tf.next)
         {
-            static if (CANINLINE_LOG)
+            /* for the isTypeSArray() case see https://github.com/dlang/dmd/pull/16145#issuecomment-1932776873
+             */
+            if (tfnext.ty != Tvoid &&
+                (!(fd.hasReturnExp & 1) ||
+                 hasDtor(tfnext) && (statementsToo || tfnext.isTypeSArray())) &&
+                !hdrscan)
             {
-                printf("\t3: no %s\n", fd.toChars());
+                static if (CANINLINE_LOG)
+                {
+                    printf("\t3: no %s\n", fd.toChars());
+                }
+                goto Lno;
             }
-            goto Lno;
         }
 
         /* https://issues.dlang.org/show_bug.cgi?id=14560


### PR DESCRIPTION
This is a fix for this problem:

https://github.com/dlang/dmd/pull/16145#issuecomment-1932776873

In case that PR never gets pulled. Don't know how to trigger the test case without the rest of that PR.

The problem is that functions that return a static array with elements that need to be destructed should not be inlined, because the e2ir.d code no longer will call _d_arrayctor() to do it.