### PR TITLE
Run backend inliner on pragma(inline) functions

### DIFF
--- a/compiler/src/dmd/backend/dout.d
+++ b/compiler/src/dmd/backend/dout.d
@@ -1005,6 +1005,7 @@ private void writefunc2(Symbol *sfunc)
     else
     {
         //printf("blockopt()\n");
+        scanForInlines(funcsym_p);      /* inline                       */
         blockopt(0);                    /* optimize                     */
     }
 


### PR DESCRIPTION
Currently, it's only ran when `-O` is passed (see lines 1000..1004 immediately above this PR addition).

This copies the order that `optfunc` calls these two functions in: https://github.com/dlang/dmd/blob/8ab0636400d890a777889b3c84b09bcaa119fd57/compiler/src/dmd/backend/go.d#L287-L291)