### PR TITLE
Always run backend inliner when -inline seen on command-line

### DIFF
--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -74,7 +74,7 @@ void backend_init()
         driverParams.nofloat,
         driverParams.vasm,
         params.v.verbose,
-        driverParams.optimize,
+        driverParams.optimize || params.useInline,
         driverParams.symdebug,
         driverParams.alwaysframe,
         driverParams.stackstomp,

--- a/compiler/test/compilable/interpret3.d
+++ b/compiler/test/compilable/interpret3.d
@@ -2326,7 +2326,7 @@ struct Bug10840
     Data10840* _data;
 }
 
-bool bug10840(int n)
+enum bug10840 = (int n)
 {
     Bug10840 stack;
     if (n == 1)
@@ -2336,7 +2336,7 @@ bool bug10840(int n)
     }
     // Wrong-code for ?:
     return stack._data ? false : true;
-}
+};
 
 static assert(bug10840(0));
 static assert(!is(typeof(Compileable!(bug10840(1)))));
@@ -5910,13 +5910,13 @@ struct Bug7527
     char[] data;
 }
 
-int bug7527()
+enum bug7527 = ()
 {
     auto app = Bug7527();
 
     app.data.ptr[0 .. 1] = "x";
     return 1;
-}
+};
 
 static assert(!is(typeof(compiles!(bug7527()))));
 

--- a/compiler/test/runnable/link15021.d
+++ b/compiler/test/runnable/link15021.d
@@ -13,7 +13,7 @@ class AliasDecl {}
 
 void aliasDecl(AliasDecl ad)
 {
-    AliasDecl* zis;
+    AliasDecl* zis = &ad;
 
     static if (is(typeof(to!string(*zis))))
     {

--- a/compiler/test/runnable_cxx/test7925.d
+++ b/compiler/test/runnable_cxx/test7925.d
@@ -1,10 +1,10 @@
 // EXTRA_CPP_SOURCES: cpp7925.cpp
 
 /*
-Exclude -O due to a codegen bug on OSX:
+Exclude -O/-inline due to a codegen bug on OSX:
 https://issues.dlang.org/show_bug.cgi?id=22556
 
-PERMUTE_ARGS(osx): -inline -release -g
+PERMUTE_ARGS(osx): -release -g
 */
 
 import core.vararg;


### PR DESCRIPTION
The back-end inliner is only called from `optfunc()` - itself called if any back-end optimization `go_flag` has been set.

I had a cursory look at adding it as a new `go_flag`, but it seems that _all_ backend optimizations are enabled if _any_ individual optimization is turned on, so I went with the simplest thing and make  `-inline` synonymous with `-O -inline`.

