### PR TITLE
Fix Bugzilla 24383 - Index assignment expression in __traits(compiles…

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -7180,6 +7180,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         }
         if (!isDeclarator(&t, &haveId, &haveTpl, endtok, needId != NeedDeclaratorId.mustIfDstyle))
             goto Lisnot;
+        // needed for `__traits(compiles, arr[0] = 0)`
+        if (!haveId && t.value == TOK.assign)
+            goto Lisnot;
         if ((needId == NeedDeclaratorId.no && !haveId) ||
             (needId == NeedDeclaratorId.opt) ||
             (needId == NeedDeclaratorId.must && haveId) ||
@@ -8384,18 +8387,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 ident = token.ident;
                 nextToken();
                 if (token.value == TOK.comma)
-                {
-                    // __traits(compiles, expr) - expr might not be a compile-time expression
-                    if (ident == Id.compiles)
-                    {
-                        nextToken();
-                        args = new AST.Objects();
-                        args.push(parseAssignExp());
-                        check(TOK.rightParenthesis);
-                    }
-                    else
-                        args = parseTemplateArgumentList(); // __traits(identifier, args...)
-                }
+                    args = parseTemplateArgumentList(); // __traits(identifier, args...)
                 else
                     check(TOK.rightParenthesis); // __traits(identifier)
 

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8384,7 +8384,18 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 ident = token.ident;
                 nextToken();
                 if (token.value == TOK.comma)
-                    args = parseTemplateArgumentList(); // __traits(identifier, args...)
+                {
+                    // __traits(compiles, expr) - expr might not be a compile-time expression
+                    if (ident == Id.compiles)
+                    {
+                        nextToken();
+                        args = new AST.Objects();
+                        args.push(parseAssignExp());
+                        check(TOK.rightParenthesis);
+                    }
+                    else
+                        args = parseTemplateArgumentList(); // __traits(identifier, args...)
+                }
                 else
                     check(TOK.rightParenthesis); // __traits(identifier)
 

--- a/compiler/test/compilable/traits.d
+++ b/compiler/test/compilable/traits.d
@@ -316,3 +316,7 @@ extern(C++, `inst`)
 mixin GetNamespaceTestTemplatedMixin!() GNTT;
 
 static assert (__traits(getCppNamespaces, GNTT.foo) == Seq!(`inst`,/*`decl`,*/ `f`));
+
+int[1] arr;
+// test parsing a non-compile-time expression
+enum _ = __traits(compiles, arr[0] = 0);

--- a/compiler/test/compilable/traits.d
+++ b/compiler/test/compilable/traits.d
@@ -318,5 +318,5 @@ mixin GetNamespaceTestTemplatedMixin!() GNTT;
 static assert (__traits(getCppNamespaces, GNTT.foo) == Seq!(`inst`,/*`decl`,*/ `f`));
 
 int[1] arr;
-// test parsing a non-compile-time expression
+// test that index assignment parses as an expression, not a type
 enum _ = __traits(compiles, arr[0] = 0);


### PR DESCRIPTION
…) fails to parse

https://dlang.org/spec/traits.html#TraitsArguments