### PR TITLE
Add option to enable stack unwinding in betterC mode

### DIFF
--- a/compiler/src/dmd/backend/backconfig.d
+++ b/compiler/src/dmd/backend/backconfig.d
@@ -50,6 +50,7 @@ nothrow:
     useModuleInfo = implement ModuleInfo
     useTypeInfo   = implement TypeInfo
     useExceptions = implement exception handling
+    enableUnwinding = enable unwinding
     dwarf         = DWARF version used
     _version      = Compiler version
     exefmt        = Executable file format
@@ -76,6 +77,7 @@ extern (C) void out_config_init(
         bool useModuleInfo,
         bool useTypeInfo,
         bool useExceptions,
+        bool enableUnwinding,
         ubyte dwarf,
         string _version,
         exefmt_t exefmt,
@@ -126,7 +128,7 @@ extern (C) void out_config_init(
         {
             cfg.fpxmmregs = true;
             cfg.avx = avx;
-            cfg.ehmethod = useExceptions ? EHmethod.EH_DM : EHmethod.EH_NONE;
+            cfg.ehmethod = enableUnwinding ? EHmethod.EH_DM : EHmethod.EH_NONE;
 
             cfg.flags |= CFGnoebp;       // test suite fails without this
             //cfg.flags |= CFGalwaysframe;
@@ -135,7 +137,7 @@ extern (C) void out_config_init(
         }
         else
         {
-            cfg.ehmethod = useExceptions ? EHmethod.EH_WIN32 : EHmethod.EH_NONE;
+            cfg.ehmethod = enableUnwinding ? EHmethod.EH_WIN32 : EHmethod.EH_NONE;
             if (mscoff)
                 cfg.flags |= CFGnoebp;       // test suite fails without this
             cfg.objfmt = mscoff ? OBJ_MSCOFF : OBJ_OMF;
@@ -155,11 +157,11 @@ extern (C) void out_config_init(
         cfg.avx = avx;
         if (model == 64)
         {
-            cfg.ehmethod = useExceptions ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
+            cfg.ehmethod = enableUnwinding ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
         }
         else
         {
-            cfg.ehmethod = useExceptions ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
+            cfg.ehmethod = enableUnwinding ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
             if (!exe)
                 cfg.flags |= CFGromable; // put switch tables in code segment
         }
@@ -189,7 +191,7 @@ extern (C) void out_config_init(
     {
         cfg.fpxmmregs = true;
         cfg.avx = avx;
-        cfg.ehmethod = useExceptions ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
+        cfg.ehmethod = enableUnwinding ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
         cfg.flags |= CFGnoebp;
         if (!exe)
         {
@@ -207,13 +209,13 @@ extern (C) void out_config_init(
     {
         if (model == 64)
         {
-            cfg.ehmethod = useExceptions ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
+            cfg.ehmethod = enableUnwinding ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
             cfg.fpxmmregs = true;
             cfg.avx = avx;
         }
         else
         {
-            cfg.ehmethod = useExceptions ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
+            cfg.ehmethod = enableUnwinding ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
             if (!exe)
                 cfg.flags |= CFGromable; // put switch tables in code segment
         }
@@ -243,13 +245,13 @@ extern (C) void out_config_init(
         if (!exe)
             cfg.flags3 |= CFG3pic;
         cfg.objfmt = OBJ_ELF;
-        cfg.ehmethod = useExceptions ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
+        cfg.ehmethod = enableUnwinding ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
     }
     if (cfg.exe == EX_DRAGONFLYBSD64)
     {
         if (model == 64)
         {
-            cfg.ehmethod = useExceptions ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
+            cfg.ehmethod = enableUnwinding ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
             cfg.fpxmmregs = true;
             cfg.avx = avx;
         }
@@ -282,7 +284,7 @@ extern (C) void out_config_init(
         if (!exe)
             cfg.flags3 |= CFG3pic;
         cfg.objfmt = OBJ_ELF;
-        cfg.ehmethod = useExceptions ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
+        cfg.ehmethod = enableUnwinding ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
     }
 
     cfg.flags2 |= CFG2nodeflib;      // no default library
@@ -353,6 +355,7 @@ static if (0)
     cfg.useModuleInfo = useModuleInfo;
     cfg.useTypeInfo = useTypeInfo;
     cfg.useExceptions = useExceptions;
+    cfg.enableUnwinding = enableUnwinding;
 
     block_init();
 

--- a/compiler/src/dmd/backend/cdef.d
+++ b/compiler/src/dmd/backend/cdef.d
@@ -635,6 +635,7 @@ struct Config
     bool useModuleInfo;         // implement ModuleInfo
     bool useTypeInfo;           // implement TypeInfo
     bool useExceptions;         // implement exception handling
+    bool enableUnwinding;       // enable uwinding
     ubyte dwarf;                // DWARF version
 }
 

--- a/compiler/src/dmd/backend/dwarfdbginf.d
+++ b/compiler/src/dmd/backend/dwarfdbginf.d
@@ -114,7 +114,7 @@ static if (1)
          */
         assert(!(usednteh & ~(EHtry | EHcleanup)));
         return (usednteh & (EHtry | EHcleanup)) ||
-               (config.exe & (EX_FREEBSD | EX_FREEBSD64 | EX_OPENBSD | EX_OPENBSD64 | EX_DRAGONFLYBSD64)) && config.useExceptions;
+               (config.exe & (EX_FREEBSD | EX_FREEBSD64 | EX_OPENBSD | EX_OPENBSD64 | EX_DRAGONFLYBSD64)) && config.enableUnwinding;
     }
 
         SYMIDX MAP_SEG2SYMIDX(int seg) { return SegData[seg].SDsymidx; }

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -624,6 +624,10 @@ dmd -cov -unittest myprog.d
             `Turns off generation of exception stack unwinding code, enables
             more efficient code for RAII objects.`,
         ),
+        Option("unwinding",
+            "generate eh_frame",
+            `Useful for generating backtraces, while still having static analysis for no EH.`,
+        ),
         Option("O",
             "optimize",
             `Optimize generated code. For fastest executables, compile

--- a/compiler/src/dmd/dmsc.d
+++ b/compiler/src/dmd/dmsc.d
@@ -84,6 +84,7 @@ void backend_init()
         params.useModuleInfo && Module.moduleinfo,
         params.useTypeInfo && Type.dtypeinfo,
         params.useExceptions && ClassDeclaration.throwable,
+        params.enableUnwinding,
         driverParams.dwarf,
         global.versionString(),
         exfmt,

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -173,6 +173,7 @@ extern (C++) struct Param
     bool useModuleInfo = true;   // generate runtime module information
     bool useTypeInfo = true;     // generate runtime type information
     bool useExceptions = true;   // support exception handling
+    bool enableUnwinding = true;   // support unwinding
     bool useGC = true;           // support features that require the D runtime GC
     bool betterC;           // be a "better C" compiler; no dependency on D runtime
     bool addMain;           // add a default main() function

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -969,6 +969,15 @@ void reconcileCommands(ref Param params, ref Target target)
         params.useExceptions = false;
         params.useGC = false;
     }
+
+
+    if (params.release)
+    {
+        if (params.betterC)
+        {
+            params.enableUnwinding = false;
+        }
+    }
 }
 
 /***********************************************

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1464,6 +1464,10 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         {
             params.useExceptions = false;
         }
+        else if (arg == "-unwinding")
+        {
+            params.enableUnwinding = true;
+        }
         else if (arg == "-unittest")
             params.useUnitTests = true;
         else if (p[1] == 'I')              // https://dlang.org/dmd.html#switch-I


### PR DESCRIPTION
I wanted to debug my code in my project, but i'm using -betterC, wich removes the ability for the compiler to generate eh_frame, so ``backtrace`` wasn't working

This adds an option for `-betterC` to still get the benefits of `nothrow` static analysis + being able to debug code with ease, this option is disabled in `-release`

Documentation perhaps could be improved

```D
void crash_me()
{
    int* a;
    *a = 42;
}
```

Before:
```
-------------------------------------------------------------------+
Received signal 'SIGSEGV' (11)
-------------------------------------------------------------------+
executable: /tmp/dmd_run1UPD7W
backtrace: 1
```

After:
```
-------------------------------------------------------------------+
Received signal 'SIGSEGV' (11)
-------------------------------------------------------------------+
executable: /tmp/dmd_runXn753y
backtrace: 7
    ??:? _start+0x25
    ??:? __libc_start_main+0x8a
    ??:? +0x25cd0
    /run/media/ryuukk/E0C0C01FC0BFFA3C/dev/kdom/./_.d:4 main+0xe
    /run/media/ryuukk/E0C0C01FC0BFFA3C/dev/kdom/./_.d:11 void _.crash_me()+0xe
```

Test code:

``dmd -fPIC -fPIE -gs -debug -g -betterC -run _.d ``
https://gist.github.com/ryuukk/e2d5260b4c4acec1b972ad9ce9228753