### PR TITLE
fix Issue 24390 - AssertError@src/dmd/backend/cgxmm.d(1476): Assertion failure

### DIFF
--- a/compiler/src/dmd/backend/inliner.d
+++ b/compiler/src/dmd/backend/inliner.d
@@ -617,8 +617,8 @@ private elem* initializeParamsWithArgs(elem* eargs, SYMIDX sistart, SYMIDX siend
             ty = TYshort;
             if (szs == 1)
             {
-                ex = el_una(OP16_8, TYchar, ex);
-                ty = TYchar;
+                ex = el_una(OP16_8, TYschar, ex);
+                ty = TYschar;
             }
         }
         evar.Ety = ty;

--- a/compiler/test/compilable/imports/test24390a.d
+++ b/compiler/test/compilable/imports/test24390a.d
@@ -1,0 +1,2 @@
+module imports.test24390a;
+public import imports.test24390b;

--- a/compiler/test/compilable/imports/test24390b.d
+++ b/compiler/test/compilable/imports/test24390b.d
@@ -1,0 +1,9 @@
+module imports.test24390b;
+static if (__traits(compiles, __vector(int[4])) && __traits(compiles, __vector(byte[16])))
+{
+    __vector(int[4]) _mm_set1_epi8 (byte a)
+    {
+        __vector(byte[16]) b = a;
+        return cast(__vector(int[4]))b;
+    }
+}

--- a/compiler/test/compilable/test24390.d
+++ b/compiler/test/compilable/test24390.d
@@ -1,0 +1,26 @@
+// PERMUTE_ARGS: -O -inline
+// EXTRA_SOURCES: imports/test24390a.d imports/test24390b.d
+static if (__traits(compiles, __vector(int[4])) && __traits(compiles, __vector(byte[16])))
+{
+    import imports.test24390a;
+
+    void main()
+    {
+        __vector(int[4]) mmA ;
+        __vector(int[4]) mmB ;
+        auto mask = _mm_cmpestrm(mmA, mmB);
+    }
+
+    __vector(int[4]) _mm_cmpestrm(__vector(int[4]) mmA, __vector(int[4]) mmB)
+    {
+        __vector(int[4]) R;
+        for (int pos ; pos < 16; ++pos)
+        {
+            byte charK = (cast(__vector(byte[16]))mmA).array[pos];
+            __vector(int[4]) eqMask = _mm_set1_epi8(charK);
+            R = R & eqMask;
+
+        }
+        return R;
+    }
+}


### PR DESCRIPTION
This is tickled by #16173, so not actually in any released version of the compiler.

As far as I can tell, the inliner reverts integer promotions by casting from `int` -> `short` -> `char`, the latter type is invalid for vectors.  Instead, do cast from `int` -> `short` -> `byte`.