### PR TITLE
partial bugzilla 24389 - importC: Parser support for top-level asm definitions

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -501,6 +501,22 @@ struct ASTBase
         }
     }
 
+    extern (C++) final class CAsmDeclaration : Dsymbol
+    {
+        Expression code;
+
+        extern (D) this(Expression e)
+        {
+            super();
+            this.code = e;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
     extern (C++) class VarDeclaration : Declaration
     {
         Type type;

--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -136,6 +136,23 @@ final class CParser(AST) : Parser!AST
                 return wrap;
             }
 
+            /* GNU Extensions
+             * external-declaration:
+             *    simple-asm-expr ;
+             */
+            if (token.value == TOK.asm_)
+            {
+                nextToken();     // move past asm
+                check(TOK.leftParenthesis);
+                if (token.value != TOK.string_)
+                    error("string literal expected for Asm Definition, not `%s`", token.toChars());
+                auto code = cparsePrimaryExp();
+                check(TOK.rightParenthesis);
+                symbols.push(new AST.CAsmDeclaration(code));
+                check(TOK.semicolon);
+                continue;
+            }
+
             cparseDeclaration(LVL.global);
         }
     }

--- a/compiler/src/dmd/cxxfrontend.d
+++ b/compiler/src/dmd/cxxfrontend.d
@@ -17,7 +17,7 @@ import dmd.common.outbuffer : OutBuffer;
 import dmd.dmodule /*: Module*/;
 import dmd.dscope : Scope;
 import dmd.dstruct /*: StructDeclaration*/;
-import dmd.dsymbol : Dsymbol, ScopeDsymbol, SearchOpt, SearchOptFlags;
+import dmd.dsymbol : Dsymbol, ScopeDsymbol, CAsmDeclaration, SearchOpt, SearchOptFlags;
 import dmd.dtemplate /*: TemplateInstance, TemplateParameter, Tuple*/;
 import dmd.errorsink : ErrorSink;
 import dmd.expression /*: Expression*/;
@@ -299,6 +299,12 @@ Statement asmSemantic(AsmStatement s, Scope *sc)
     return dmd.iasm.asmSemantic(s, sc);
 }
 
+void asmSemantic(CAsmDeclaration d, Scope *sc)
+{
+    import dmd.iasm;
+    return dmd.iasm.asmSemantic(d, sc);
+}
+
 /***********************************************************
  * iasmgcc.d
  */
@@ -306,6 +312,12 @@ Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
 {
     import dmd.iasmgcc;
     return dmd.iasmgcc.gccAsmSemantic(s, sc);
+}
+
+void gccAsmSemantic(CAsmDeclaration d, Scope *sc)
+{
+    import dmd.iasmgcc;
+    return dmd.iasmgcc.gccAsmSemantic(d, sc);
 }
 
 /***********************************************************

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -1105,6 +1105,7 @@ extern (C++) class Dsymbol : ASTNode
     inout(MixinDeclaration)            isMixinDeclaration()            inout { return null; }
     inout(StaticAssert)                isStaticAssert()                inout { return null; }
     inout(StaticIfDeclaration)         isStaticIfDeclaration()         inout { return null; }
+    inout(CAsmDeclaration)             isCAsmDeclaration()             inout { return null; }
 }
 
 /***********************************************************
@@ -1697,5 +1698,28 @@ extern (C++) final class DsymbolTable : RootObject
     size_t length() const pure
     {
         return tab.length;
+    }
+}
+
+/**
+ * ImportC global `asm` definition.
+ */
+extern (C++) final class CAsmDeclaration : Dsymbol
+{
+    Expression code;
+    extern (D) this(Expression e) nothrow @safe
+    {
+        super();
+        this.code = e;
+    }
+
+    override inout(CAsmDeclaration) isCAsmDeclaration() inout nothrow
+    {
+        return this;
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
     }
 }

--- a/compiler/src/dmd/dsymbol.h
+++ b/compiler/src/dmd/dsymbol.h
@@ -73,6 +73,7 @@ class AliasAssign;
 class OverloadSet;
 class StaticAssert;
 class StaticIfDeclaration;
+class CAsmDeclaration;
 struct AA;
 #ifdef IN_GCC
 typedef union tree_node Symbol;
@@ -100,6 +101,10 @@ namespace dmd
     void dsymbolSemantic(Dsymbol *dsym, Scope *sc);
     void semantic2(Dsymbol *dsym, Scope *sc);
     void semantic3(Dsymbol *dsym, Scope* sc);
+    // in iasm.d
+    void asmSemantic(CAsmDeclaration *ad, Scope *sc);
+    // in iasmgcc.d
+    void gccAsmSemantic(CAsmDeclaration *ad, Scope *sc);
 }
 
 struct Visibility
@@ -318,6 +323,7 @@ public:
     virtual MixinDeclaration *isMixinDeclaration() { return NULL; }
     virtual StaticAssert *isStaticAssert() { return NULL; }
     virtual StaticIfDeclaration *isStaticIfDeclaration() { return NULL; }
+    virtual CAsmDeclaration *isCAsmDeclaration() { return NULL; }
     void accept(Visitor *v) override { v->visit(this); }
 };
 
@@ -405,6 +411,15 @@ public:
     Expression *exp;
 
     ExpressionDsymbol *isExpressionDsymbol() override { return this; }
+};
+
+class CAsmDeclaration final : public Dsymbol
+{
+public:
+    Expression *code;   // string expression
+
+    CAsmDeclaration *isCAsmDeclaration() override { return this; }
+    void accept(Visitor *v) override { v->visit(this); }
 };
 
 // Table of Dsymbol's

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -1440,6 +1440,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         assert(dsym._linkage == LINK.c);
     }
 
+    override void visit(CAsmDeclaration dsym)
+    {
+        if (dsym.semanticRun >= PASS.semanticdone)
+            return;
+        import dmd.iasm : asmSemantic;
+        asmSemantic(dsym, sc);
+        dsym.semanticRun = PASS.semanticdone;
+    }
+
     override void visit(BitFieldDeclaration dsym)
     {
         //printf("BitField::semantic('%s')\n", dsym.toChars());

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -102,6 +102,7 @@ class OverloadSet;
 class MixinDeclaration;
 class StaticAssert;
 class StaticIfDeclaration;
+class CAsmDeclaration;
 class DsymbolTable;
 struct MangleOverride;
 class AliasThis;
@@ -582,6 +583,7 @@ public:
     virtual MixinDeclaration* isMixinDeclaration();
     virtual StaticAssert* isStaticAssert();
     virtual StaticIfDeclaration* isStaticIfDeclaration();
+    virtual CAsmDeclaration* isCAsmDeclaration();
 };
 
 struct BitArray final
@@ -969,6 +971,7 @@ public:
     virtual void visit(typename AST::DebugSymbol s);
     virtual void visit(typename AST::VersionSymbol s);
     virtual void visit(typename AST::AliasAssign s);
+    virtual void visit(typename AST::CAsmDeclaration s);
     virtual void visit(typename AST::Package s);
     virtual void visit(typename AST::EnumDeclaration s);
     virtual void visit(typename AST::AggregateDeclaration s);
@@ -5601,6 +5604,7 @@ struct ASTCodegen final
     using UnionDeclaration = ::UnionDeclaration;
     using AliasAssign = ::AliasAssign;
     using ArrayScopeSymbol = ::ArrayScopeSymbol;
+    using CAsmDeclaration = ::CAsmDeclaration;
     using Dsymbol = ::Dsymbol;
     using DsymbolTable = ::DsymbolTable;
     using ExpressionDsymbol = ::ExpressionDsymbol;
@@ -7422,6 +7426,14 @@ public:
     Dsymbol* insert(const Identifier* const ident, Dsymbol* s);
     size_t length() const;
     DsymbolTable();
+};
+
+class CAsmDeclaration final : public Dsymbol
+{
+public:
+    Expression* code;
+    CAsmDeclaration* isCAsmDeclaration() override;
+    void accept(Visitor* v) override;
 };
 
 class ImportAllVisitor : public Visitor

--- a/compiler/src/dmd/iasm.d
+++ b/compiler/src/dmd/iasm.d
@@ -16,6 +16,7 @@ module dmd.iasm;
 import core.stdc.stdio;
 
 import dmd.dscope;
+import dmd.dsymbol;
 import dmd.expression;
 import dmd.func;
 import dmd.mtype;
@@ -83,5 +84,23 @@ Statement asmSemantic(AsmStatement s, Scope *sc)
     {
         s.error("D inline assembler statements are not supported");
         return new ErrorStatement();
+    }
+}
+
+/************************ CAsmDeclaration ************************************/
+
+void asmSemantic(CAsmDeclaration ad, Scope *sc)
+{
+    version (NoBackend)
+    {
+    }
+    else version (IN_GCC)
+    {
+        return gccAsmSemantic(ad, sc);
+    }
+    else
+    {
+        import dmd.errors : error;
+        error(ad.code.loc, "Gnu Asm not supported - compile this file with gcc or clang");
     }
 }

--- a/compiler/src/dmd/iasmgcc.d
+++ b/compiler/src/dmd/iasmgcc.d
@@ -16,6 +16,7 @@ import core.stdc.string;
 import dmd.arraytypes;
 import dmd.astcodegen;
 import dmd.dscope;
+import dmd.dsymbol;
 import dmd.errors;
 import dmd.errorsink;
 import dmd.expression;
@@ -380,6 +381,26 @@ public Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
     }
 
     return s;
+}
+
+/***********************************
+ * Run semantic analysis on an CAsmDeclaration.
+ * Params:
+ *      ad  = asm declaration
+ *      sc = the scope where the asm declaration is located
+ */
+public void gccAsmSemantic(CAsmDeclaration ad, Scope *sc)
+{
+    import dmd.typesem : pointerTo;
+    ad.code = semanticString(sc, ad.code, "asm definition");
+    ad.code.type = ad.code.type.nextOf().pointerTo();
+
+    // Asm definition always needs emitting into the root module.
+    import dmd.dmodule : Module;
+    if (sc._module && sc._module.isRoot())
+        return;
+    if (Module m = Module.rootModule)
+        m.members.push(ad);
 }
 
 unittest

--- a/compiler/src/dmd/parsetimevisitor.d
+++ b/compiler/src/dmd/parsetimevisitor.d
@@ -36,6 +36,7 @@ public:
     void visit(AST.DebugSymbol s) { visit(cast(AST.Dsymbol)s); }
     void visit(AST.VersionSymbol s) { visit(cast(AST.Dsymbol)s); }
     void visit(AST.AliasAssign s) { visit(cast(AST.Dsymbol)s); }
+    void visit(AST.CAsmDeclaration s) { visit(cast(AST.Dsymbol)s); }
 
     // ScopeDsymbols
     void visit(AST.Package s) { visit(cast(AST.ScopeDsymbol)s); }

--- a/compiler/src/dmd/visitor.h
+++ b/compiler/src/dmd/visitor.h
@@ -126,6 +126,7 @@ class WithScopeSymbol;
 class ArrayScopeSymbol;
 class Nspace;
 class AliasAssign;
+class CAsmDeclaration;
 
 class AggregateDeclaration;
 class StructDeclaration;
@@ -339,6 +340,7 @@ public:
     virtual void visit(DebugSymbol *s) { visit((Dsymbol *)s); }
     virtual void visit(VersionSymbol *s) { visit((Dsymbol *)s); }
     virtual void visit(AliasAssign *s) { visit((Dsymbol *)s); }
+    virtual void visit(CAsmDeclaration *s) { visit((Dsymbol *)s); }
 
     // ScopeDsymbols
     virtual void visit(Package *s) { visit((ScopeDsymbol *)s); }

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -1826,11 +1826,14 @@ void mtype_h(Type *t1, Type *t2, const Loc &loc, Scope *sc, int *p)
     dmd::referenceTo(t1);
 }
 
-void statement_h(Statement *s, AsmStatement *as, GccAsmStatement *gas, Scope *sc)
+void statement_h(Statement *s, AsmStatement *as, GccAsmStatement *gas,
+                 CAsmDeclaration *ad, Scope *sc)
 {
     dmd::statementSemantic(s, sc);
     dmd::asmSemantic(as, sc);
+    dmd::asmSemantic(ad, sc);
     dmd::gccAsmSemantic(gas, sc);
+    dmd::gccAsmSemantic(ad, sc);
 }
 
 void template_h(TemplateParameter *tp, Scope *sc, TemplateParameters *tps,

--- a/compiler/test/fail_compilation/fail24389.c
+++ b/compiler/test/fail_compilation/fail24389.c
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail24389.c(10): Error: Gnu Asm not supported - compile this file with gcc or clang
+---
+*/
+typedef unsigned long size_t;
+void __qsort_r_compat(void *, size_t, size_t, void *,
+     int (*)(void *, const void *, const void *));
+__asm__(".symver " "__qsort_r_compat" ", " "qsort_r" "@" "FBSD_1.0");


### PR DESCRIPTION
Adds parser support for top-level asm definitions, so they aren't rejected with a bad parser error.

The dmd backend still can't compile such definitions so an error is still diagnosed.  However, gdc can, so semantic support is added to iasmgcc to allow it to generate the right thing at codegen.

If it's instead found harmless to instead ignore such top-level asm definitions, can remove the error for dmd.

@jmdavis @WalterBright 