### PR TITLE
Fix objdump not outputting intel syntax

### DIFF
--- a/compiler/test/compilable/extra-files/objdump-postscript.sh
+++ b/compiler/test/compilable/extra-files/objdump-postscript.sh
@@ -6,7 +6,7 @@ expect_file=${EXTRA_FILES}/${TEST_NAME}.out
 obj_file=${OUTPUT_BASE}_0.o
 
 echo Creating objdump
-objdump --disassemble --disassembler-options=intel-mnemonic "${obj_file}" > "${obj_file}.dump"
+objdump --disassemble --disassembler-options=intel "${obj_file}" > "${obj_file}.dump"
 
 echo SANITIZING Objdump...
 < "${obj_file}.dump" \

--- a/compiler/test/runnable/cdvecfill.sh
+++ b/compiler/test/runnable/cdvecfill.sh
@@ -10,17 +10,17 @@ obj_file=${RESULTS_TEST_DIR}/${TEST_NAME}.o
 
 if [ $OS == "linux" ] && [ $MODEL == "64" ]; then
   $DMD -betterC -c -O -m64 ${src_file} -of${obj_file}
-  objdump --disassemble --disassembler-options=intel-mnemonic ${obj_file} | tail -n+3 | sed 's/[ \t]\s*$//' > ${tmp_file}
+  objdump --disassemble --disassembler-options=intel ${obj_file} | tail -n+3 | sed 's/[ \t]\s*$//' > ${tmp_file}
   diff ${expect_file} ${tmp_file}
   rm_retry ${obj_file} ${tmp_file}
 
   $DMD -betterC -c -O -m64 -mcpu=avx ${src_file} -of${obj_file}
-  objdump --disassemble --disassembler-options=intel-mnemonic ${obj_file} | tail -n+3 | sed 's/[ \t]\s*$//' > ${tmp_file}
+  objdump --disassemble --disassembler-options=intel ${obj_file} | tail -n+3 | sed 's/[ \t]\s*$//' > ${tmp_file}
   diff ${expect_file_avx} ${tmp_file}
   rm_retry ${obj_file} ${tmp_file}
 
   $DMD -betterC -c -O -m64 -mcpu=avx2 ${src_file} -of${obj_file}
-  objdump --disassemble --disassembler-options=intel-mnemonic ${obj_file} | tail -n+3 | sed 's/[ \t]\s*$//' > ${tmp_file}
+  objdump --disassemble --disassembler-options=intel ${obj_file} | tail -n+3 | sed 's/[ \t]\s*$//' > ${tmp_file}
   diff ${expect_file_avx2} ${tmp_file}
   rm_retry ${obj_file} ${tmp_file}
 fi


### PR DESCRIPTION
These tests fail locally for me as of recent, because objdump is prefixing registers with a % sign, despite using the intel-mnemonic option. I looked at the changelog of GNU binutils, but couldn't find a change explaining this. I have objdump 2.42.0.  Looking at the docs:

https://man7.org/linux/man-pages/man1/objdump.1.html

```
           "intel"
           "att"
               Select between intel syntax mode and AT&T syntax mode.

           "intel-mnemonic"
           "att-mnemonic"
               Select between intel mnemonic mode and AT&T mnemonic
               mode.  Note: "intel-mnemonic" implies "intel" and
               "att-mnemonic" implies "att".
```

It's not clear what 'implies' means to me, does it set the 'intel' option for you, or does it expect you to enable that option? In any case, simply setting the 'intel' option instead of 'intel-mnemonic' fixes it for me, so let's see how the test runners react.
