### PR TITLE
Revert the removal of `Expression.parens`

### DIFF
--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -4558,6 +4558,7 @@ struct ASTBase
     {
         EXP op;
         ubyte size;
+        ubyte parens;
         Type type;
         Loc loc;
 
@@ -5159,8 +5160,6 @@ struct ASTBase
 
     extern (C++) final class TypeExp : Expression
     {
-        bool parens;
-
         extern (D) this(const ref Loc loc, Type type)
         {
             super(loc, EXP.type, __traits(classInstanceSize, TypeExp));
@@ -5193,7 +5192,6 @@ struct ASTBase
     extern (C++) class IdentifierExp : Expression
     {
         Identifier ident;
-        bool parens;
 
         final extern (D) this(const ref Loc loc, Identifier ident)
         {

--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -314,6 +314,7 @@ extern (C++) abstract class Expression : ASTNode
     Type type;      // !=null means that semantic() has been run
     Loc loc;        // file location
     const EXP op;   // to minimize use of dynamic_cast
+    bool parens;    // if this is a parenthesized expression
 
     extern (D) this(const ref Loc loc, EXP op) scope @safe
     {
@@ -1310,7 +1311,6 @@ extern (C++) final class ComplexExp : Expression
 extern (C++) class IdentifierExp : Expression
 {
     Identifier ident;
-    bool parens;        // if it appears as (identifier)
 
     extern (D) this(const ref Loc loc, Identifier ident) scope @safe
     {
@@ -2432,8 +2432,6 @@ extern (C++) final class CompoundLiteralExp : Expression
  */
 extern (C++) final class TypeExp : Expression
 {
-    bool parens;    // if this is a parenthesized expression
-
     extern (D) this(const ref Loc loc, Type type) @safe
     {
         super(loc, EXP.type);

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -90,6 +90,7 @@ public:
     Type *type;                 // !=NULL means that semantic() has been run
     Loc loc;                    // file location
     EXP op;                     // to minimize use of dynamic_cast
+    d_bool parens;              // if this is a parenthesized expression
 
     size_t size() const;
     static void _init();
@@ -300,7 +301,6 @@ class IdentifierExp : public Expression
 {
 public:
     Identifier *ident;
-    d_bool parens;
 
     static IdentifierExp *create(const Loc &loc, Identifier *ident);
     bool isLvalue() override final;

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2102,6 +2102,7 @@ public:
     Type* type;
     Loc loc;
     const EXP op;
+    bool parens;
     size_t size() const;
     static void _init();
     static void deinitialize();
@@ -2591,7 +2592,6 @@ class IdentifierExp : public Expression
 {
 public:
     Identifier* ident;
-    bool parens;
     static IdentifierExp* create(const Loc& loc, Identifier* ident);
     bool isLvalue() final override;
     void accept(Visitor* v) override;
@@ -3462,7 +3462,6 @@ public:
 class TypeExp final : public Expression
 {
 public:
-    bool parens;
     TypeExp* syntaxCopy() override;
     bool checkType() override;
     bool checkValue() override;
@@ -5396,9 +5395,9 @@ struct UnionExp final
 private:
     union _AnonStruct_u
     {
-        char exp[29LLU];
+        char exp[30LLU];
         char integerexp[40LLU];
-        char errorexp[29LLU];
+        char errorexp[30LLU];
         char realexp[48LLU];
         char complexexp[64LLU];
         char symoffexp[64LLU];
@@ -5407,7 +5406,7 @@ private:
         char assocarrayliteralexp[56LLU];
         char structliteralexp[76LLU];
         char compoundliteralexp[40LLU];
-        char nullexp[29LLU];
+        char nullexp[30LLU];
         char dotvarexp[49LLU];
         char addrexp[40LLU];
         char indexexp[74LLU];

--- a/compiler/src/dmd/importc.d
+++ b/compiler/src/dmd/importc.d
@@ -243,16 +243,15 @@ Expression castCallAmbiguity(Expression e, Scope* sc)
 
             case EXP.call:
                 auto ce = (*pe).isCallExp();
-                auto ie = ce.e1.isIdentifierExp();
-                if (ie && ie.parens)
+                if (ce.e1.parens)
                 {
-                    ce.e1 = expressionSemantic(ie, sc);
+                    ce.e1 = expressionSemantic(ce.e1, sc);
                     if (ce.e1.op == EXP.type)
                     {
                         const numArgs = ce.arguments ? ce.arguments.length : 0;
                         if (numArgs >= 1)
                         {
-                            ie.parens = false;
+                            ce.e1.parens = false;
                             Expression arg;
                             foreach (a; (*ce.arguments)[])
                             {


### PR DESCRIPTION
Having this at the `Expression` level is useful to libdparse and will also help fix this regression
https://issues.dlang.org/show_bug.cgi?id=24371 whose underlying issue is that the lowering doesn't take parentheses into account.

This reverts the follwoing commits
- 6e604e22b1e7f5f25ab2eb808a5691b2f7d3a9a0
- e60d027582d2fa6c9236db7da5ead4b47d6e3f87
- 71ffbe08c5fdfe91c11471b60a99a0f608cef628