### PR TITLE
Turn foreach_reverse(AA) into an error

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1196,7 +1196,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             }
         case Taarray:
             if (fs.op == TOK.foreach_reverse_)
-                warning(fs.loc, "cannot use `foreach_reverse` with an associative array");
+                error(fs.loc, "cannot use `foreach_reverse` with an associative array");
             if (checkForArgTypes(fs))
                 return retError();
 

--- a/compiler/test/fail_compilation/warn13679.d
+++ b/compiler/test/fail_compilation/warn13679.d
@@ -3,9 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/warn13679.d(15): Warning: cannot use `foreach_reverse` with an associative array
-Error: warnings are treated as errors
-       Use -wi if you wish to treat warnings only as informational.
+fail_compilation/warn13679.d(13): Error: cannot use `foreach_reverse` with an associative array
 ---
 */
 


### PR DESCRIPTION
This is a continuation of some previous removals of `warning()` throughout the compiler (i.e: #15718)

Either this is valid code, or it is rejected by the language and backed up by the spec.

The spec says: https://dlang.org/spec/statement.html#foreach_over_associative_arrays

> The order in which the elements of the array are iterated over is unspecified for foreach. This is why foreach_reverse for associative arrays is illegal.

So the interpretation is `illegal` -> `error`.