### PR TITLE
Turn -preview=dip1000 warning into a deprecation

### DIFF
--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -4336,9 +4336,9 @@ bool setUnsafePreview(Scope* sc, FeatureState fs, bool gag, Loc loc, const(char)
             return false;
         if (sc.func.isSafeBypassingInference())
         {
-            if (!gag)
+            if (!gag && !sc.isDeprecated())
             {
-                warning(loc, msg, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
+                deprecation(loc, msg, arg0 ? arg0.toChars() : "", arg1 ? arg1.toChars() : "", arg2 ? arg2.toChars() : "");
             }
         }
         else if (!sc.func.safetyViolation)


### PR DESCRIPTION
This was originally removed in #15721 as part of the warning clean-ups/obsolete reverts, then re-added again in #15661.

This appears to be dead code, however, so it seems removing again might be the corrective action.  Instead though, just issue a deprecation (as per documentation of the function).