### PR TITLE
 fix bugzilla Issue 24397 ImportC: support function-like macros

### DIFF
--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1255,9 +1255,16 @@ public DArray!ubyte runPreprocessor(ref const Loc loc, const(char)[] cpp, const(
                                 break;
 
                             case S.hash:
-                                defines.writeByte(c);
-                                if (c == '\n')
+                                if (c == '\r')
+                                {
+                                }
+                                else if (c == '\n')
+                                {
+                                    defines.writeByte(0); // 0-terminate lines in defines[]
                                     state = S.start;
+                                }
+                                else
+                                    defines.writeByte(c);
                                 break;
 
                             case S.other:
@@ -1267,7 +1274,6 @@ public DArray!ubyte runPreprocessor(ref const Loc loc, const(char)[] cpp, const(
                                 break;
                         }
                     }
-                    //printf("%.*s", cast(int)data.length, data.ptr);
                 }
 
                 // Convert command to wchar

--- a/compiler/src/dmd/toir.d
+++ b/compiler/src/dmd/toir.d
@@ -172,7 +172,7 @@ extern (D) elem *incUsageElem(ref IRState irs, const ref Loc loc)
     uint linnum = loc.linnum;
 
     Module m = cast(Module)irs.blx._module;
-    //printf("m.cov %p linnum %d filename %s srcfile %s\n", m.cov, linnum, loc.filename, m.srcfile.toChars());
+    //printf("m.cov %p linnum %d filename %s srcfile %s numlines %d\n", m.cov, linnum, loc.filename, m.srcfile.toChars(), m.numlines);
     if (!m.cov || !linnum ||
         strcmp(loc.filename, m.srcfile.toChars()))
         return null;

--- a/compiler/test/compilable/imports/defines.c
+++ b/compiler/test/compilable/imports/defines.c
@@ -30,3 +30,28 @@ _Static_assert(SSS[0] == 'h', "10");
 #define ABC 12
 #define GHI (size) abbadabba
 #define DEF (ABC + 5)
+
+#define ADD(a, b) a + b
+#define SUB() 3 - 2
+
+#define NO_BODY()
+#define NO_BODY_PARAMS(a, b)
+#define DO_WHILE() do { } while(0)
+
+#define pr16199_trigger(cond,func,args) _Generic (cond, default: func args)
+#define pr16199_skipped1(a) (1)
+#define pr16199_skipped2(b) (2)
+#define pr16199_ice         0x3
+
+#define M16199Ea(TYPE) (TYPE __x;)
+#define M16199E(X,S,M) ({ M16199Ea(S *); })
+
+#define M16199Da(TYPE,VAR) ((TYPE)(VAR))
+#define M16199D(X,S,M) ({ int *__x = (X); M16199Da(S *, __x); })
+int pr16199d() { return 7; }
+
+#define M16199C(X,S,M) ({ int __x; })
+int pr16199c()
+{
+    return 8;
+}

--- a/compiler/test/compilable/testdefines.d
+++ b/compiler/test/compilable/testdefines.d
@@ -15,3 +15,13 @@ static assert(SSS == "hello");
 
 static assert(ABC == 12);
 static assert(DEF == 17);
+
+static assert(ADD(3, 4) == 7);
+static assert(SUB() == 1);
+
+static assert(pr16199_skipped1(5) == 1);
+static assert(pr16199_skipped2(6) == 2);
+static assert(pr16199_ice == 3);
+
+static assert(pr16199d() == 7);
+static assert(pr16199c() == 8);


### PR DESCRIPTION
Finally! Now macros like:

```
#define ADD(a, b) a + b
```
are rewritten as:
```
auto ADD(__MP1, __MP2)(__MP1 a, __MP2 b) { return a + b; }
```

It's a miracle!