### PR TITLE
Fix Bugzilla 20802 - Link failure with writefln

### DIFF
--- a/compiler/test/runnable/extra-files/link20802a.d
+++ b/compiler/test/runnable/extra-files/link20802a.d
@@ -1,0 +1,8 @@
+import link20802b;
+void main()
+{
+     // First test from https://issues.dlang.org/show_bug.cgi?id=20802#c3
+     CodepointSet('a', 'z');
+     dstring s;
+     decodeGrapheme(s);
+}

--- a/compiler/test/runnable/extra-files/link20802b.d
+++ b/compiler/test/runnable/extra-files/link20802b.d
@@ -1,0 +1,30 @@
+module link20802b;
+
+// First test from https://issues.dlang.org/show_bug.cgi?id=20802#c3
+
+enum TransformRes { goOn }
+
+void writeAligned()()
+{
+    final switch (TransformRes.goOn) { case TransformRes.goOn: break; }
+}
+
+struct GcPolicy {}
+alias CodepointSet = InversionList!GcPolicy;
+struct InversionList(SP=GcPolicy)
+{
+    this()(uint[] intervals...)
+    {
+        sanitize();
+    }
+
+    void sanitize()
+    {
+        writeAligned();
+    }
+}
+
+void decodeGrapheme(Input)(ref Input inp)
+{
+    final switch (TransformRes.goOn) { case TransformRes.goOn: break; }
+}

--- a/compiler/test/runnable/link20802.sh
+++ b/compiler/test/runnable/link20802.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+
+dir=${RESULTS_DIR}${SEP}runnable
+
+libname=${OUTPUT_BASE}${LIBEXT}
+exename=${OUTPUT_BASE}${EXE}
+
+$DMD -m${MODEL} -I${EXTRA_FILES} -lib -release -of${libname} ${EXTRA_FILES}${SEP}link20802b.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${exename} ${EXTRA_FILES}${SEP}link20802a.d ${libname}
+
+${exename}
+
+rm_retry ${OUTPUT_BASE}{${LIBEXT},${EXE},${OBJ}}

--- a/druntime/src/core/exception.d
+++ b/druntime/src/core/exception.d
@@ -19,6 +19,19 @@ void __switch_errorT()(string file = __FILE__, size_t line = __LINE__) @trusted
         assert(0, "No appropriate switch clause found");
 }
 
+/*
+ * Make sure template __switch_errorT is always instantiated when building
+ * druntime. This works around https://issues.dlang.org/show_bug.cgi?id=20802.
+ * When druntime and phobos are compiled with -release, the instance for
+ * __switch_errorT is not needed. An application compiled with -release
+ * could need the instance for __switch_errorT, but the compiler would
+ * not generate code for it, because it assumes, that it was already
+ * generated for druntime. Always including the instance in a compiled
+ * druntime allows to use an application without -release with druntime
+ * with -release.
+ */
+private alias dummy__switch_errorT = __switch_errorT!();
+
 /**
  * Thrown on a range error.
  */


### PR DESCRIPTION
The issue is caused by compiling druntime/phobos and the application with different flags. The template instance for __switch_errorT is not included in the build of druntime/phobos, because they are compiled with -release. DMD will also not include it in an application compiled without -release, because it assumes, that it is already in druntime. See comment https://issues.dlang.org/show_bug.cgi?id=20802#c3 by Spoov.

The template instance for __switch_errorT is now always instantiated in druntime, so it is part of the ABI of druntime.