### PR TITLE
gha: Update cross-platform-actions to v0.23.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,18 +171,18 @@ jobs:
             freebsd_version: '13.2'
             host_dmd: dmd-2.095.0
     name: ${{ matrix.job_name }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: Run in VM
-        uses: cross-platform-actions/action@v0.22.0
+        uses: cross-platform-actions/action@v0.23.0
         with:
           operating_system: freebsd
           hypervisor: qemu
-          memory: 8G
+          memory: 12G
           sync_files: runner-to-vm
           version: ${{ matrix.freebsd_version }}
           shell: bash


### PR DESCRIPTION
We can now use the Ubuntu runners with hardware acceleration. :crossed_fingers: it'll be faster than macOS hosts, and will speed up overall CI speeds by not having too much clogging up the macOS host queue.

Edit:
- FreeBSD 13 (latest): [~27 minutes](https://github.com/dlang/dmd/actions/runs/7947874053/job/21697230213) -> [~11 minutes](https://github.com/dlang/dmd/actions/runs/7952425736/job/21706999957?pr=16201).
- FreeBSD 13 (bootstrap): [~19 minutes](https://github.com/dlang/dmd/actions/runs/7947874053/job/21697230322) -> [~10 minutes](https://github.com/dlang/dmd/actions/runs/7952425736/job/21707000159?pr=16201).