### PR TITLE
Fix Bugzilla 24402 - OSX: Linker warning: pointer not aligned at __OBJC_PROTOCOL_$_Foo

### DIFF
--- a/compiler/src/dmd/objc_glue.d
+++ b/compiler/src/dmd/objc_glue.d
@@ -338,7 +338,7 @@ struct Segments
         immutable(char*) sectionName;
         immutable(char*) segmentName;
         immutable int flags;
-        immutable int alignment;
+        immutable int p2align;
 
         this(typeof(this.tupleof) tuple) @safe
         {
@@ -388,7 +388,7 @@ struct Segments
             return segments[id] = Obj.getsegment(
                 seg.sectionName,
                 seg.segmentName,
-                seg.alignment,
+                seg.p2align,
                 seg.flags
             );
         }
@@ -1159,7 +1159,7 @@ private:
         const symbolName = prefix ~ classDeclaration.objc.identifier.toString();
         auto symbol = Symbols.getStatic(symbolName);
         symbol.Sseg = Segments[Segments.Id.const_];
-        symbol.Salignment = 3;
+        symbol.Salignment = 8;
         symbol.Sdt = dtb.finish();
 
         return symbol;
@@ -1311,7 +1311,7 @@ struct ProtocolDeclaration
             symbol.Sseg = Segments[Segments.Id.protolist];
             symbol.Sclass = SC.comdat;
             symbol.Sflags |= SFLhidden;
-            symbol.Salignment = 3;
+            symbol.Salignment = 8;
 
             auto dtb = DtBuilder(0);
             dtb.xoff(protocol, 0);
@@ -1326,7 +1326,7 @@ struct ProtocolDeclaration
         symbol.Sseg = Segments[Segments.Id.data];
         symbol.Sclass = SC.comdat;
         symbol.Sflags |= SFLhidden;
-        symbol.Salignment = 3;
+        symbol.Salignment = 8;
 
         auto dtb = DtBuilder(0);
         toDt(dtb);
@@ -1478,7 +1478,7 @@ private:
 
         symbol.Sdt = dtb.finish();
         symbol.Sseg = Segments[Segments.Id.const_];
-        symbol.Salignment = 3;
+        symbol.Salignment = 8;
 
         return symbol;
     }
@@ -1512,7 +1512,7 @@ private:
 
         symbol.Sdt = dtb.finish();
         symbol.Sseg = Segments[Segments.Id.const_];
-        symbol.Salignment = 3;
+        symbol.Salignment = 8;
 
         outdata(symbol);
 
@@ -1546,7 +1546,7 @@ private:
 
         symbol.Sdt = dtb.finish();
         symbol.Sseg = Segments[Segments.Id.const_];
-        symbol.Salignment = 3;
+        symbol.Salignment = 8;
 
         outdata(symbol);
 


### PR DESCRIPTION
`Salignment` was confused as being a "power of 2" alignment - it is not.  Fixed up all values from `3` to `8` (i.e: `1 << 3`), and renamed the `Segments` field to `p2align` to make it distinct from other alignment fields.

No tests added because:
1. The test that triggers this is already present in the testsuite (runnable/objc_protocol_sections.d)
2. It depends on `MACOSX_DEPLOYMENT_TARGET` being unset to make use of the latest linker features/warnings - and that still currently breaks too much.