### PR TITLE
Fix Bugzilla 24137 - Link failure on macOS with symbol count from symbol table and dynamic symbol table differ

### DIFF
--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -1426,6 +1426,7 @@ void MachObj_term(const(char)* objfilename)
             sym32.n_sect = sym.n_sect;
             fobjbuf.write(&sym32, sym32.sizeof);
         }
+        dysymtab_cmd.nundefsym++;
         symtab_cmd.nsyms++;
     }
     foffset += symtab_cmd.nsyms * (I64 ? nlist_64.sizeof : nlist.sizeof);


### PR DESCRIPTION
The `symtab_cmd` and `dysymtab_cmd` symbol counts need to be kept in sync. The off-by-one error occurred as the former got adjusted after being initially computed by the latter (see line [1289](https://github.com/ibuclaw/dmd/blob/89d8446f11ec8ce36950a6595d78a8dad5e7d515/compiler/src/dmd/backend/machobj.d#L1289-L1299))

No tests as this is one of those issues where _every_ program fails to link (even `extern(C) void main(){}`). To trigger it also depends on using the latest version of ld (Xcode 15), and that remains disabled for being broken (PR16194).