### PR TITLE
Fix Bugzilla 24399 - Link failure on MacOS with address=0x0 points to section(2) with no content

### DIFF
--- a/compiler/src/dmd/todt.d
+++ b/compiler/src/dmd/todt.d
@@ -92,6 +92,11 @@ extern (C++) void Initializer_toDt(Initializer init, ref DtBuilder dtb, bool isC
         if (tb.ty == Tvector)
             tb = (cast(TypeVector)tb).basetype;
 
+        if (ai.dim == 0 && tb.isZeroInit(ai.loc))
+        {
+            dtb.nzeros(cast(uint)ai.type.size());
+            return;
+        }
         Type tn = tb.nextOf().toBasetype();
 
         //printf("\tdim = %d\n", ai.dim);

--- a/compiler/test/compilable/issue24399.d
+++ b/compiler/test/compilable/issue24399.d
@@ -1,0 +1,9 @@
+// REQUIRED_ARGS: -main
+// LINK:
+template rt_options()
+{
+    __gshared string[] rt_options = [];
+    string[] rt_options_tls = [];
+}
+
+alias _ = rt_options!();


### PR DESCRIPTION
~~Since ld64 236.3 (i.e: Xcode/CommandLineTools as of MacOS 10.8), the use of coalesced sections has been deprecated, and LLVM has stopped generating them for near [10 years now](https://reviews.llvm.org/D13188?id=37373).~~

~~The preference is to not use a special comdat section, rather put everything in the regular data sections and mark the symbol as weak as-needed.~~

**Update**

Not going to bother touch anything more wrt machobj backend - if it bites dmd sometime in the future, I'll let someone else deal with it.

Related issue https://issues.dlang.org/show_bug.cgi?id=22464

This PR now instead enables `T[] foo;` and `T[] foo = [];` to be emitted in exactly the same way if `T` is zero-initialized. This both allows dmd to "optimize" empty initializers into a comdef, and thus avoid putting an empty initializer into a section that expects non-empty data.