### PR TITLE
Fix Bugzilla 20297 - Link warning: no platform load command found in object.o, assuming: macOS

### DIFF
--- a/compiler/src/dmd/backend/mach.d
+++ b/compiler/src/dmd/backend/mach.d
@@ -94,6 +94,12 @@ enum
     LC_SYMTAB       = 2,
     LC_DYSYMTAB     = 11,
     LC_SEGMENT_64   = 0x19,
+
+    /// Build for MacOSX min OS version.
+    LC_VERSION_MIN_MACOSX = 0x24,
+
+    /// Build for platform min OS version.
+    LC_BUILD_VERSION = 0x32,
 }
 
 struct load_command
@@ -406,4 +412,63 @@ struct scattered_relocation_info
     uint r_pcrel() { return (xxx >> (24 + 4 + 2)) & 1; }
 
     int r_value;
+}
+
+/**
+ * The version_min_command contains the min OS version on which this binary was
+ * built to run.
+ */
+struct version_min_command
+{
+    ///
+    uint cmd = LC_VERSION_MIN_MACOSX;
+
+    ///
+    uint cmdsize = typeof(this).sizeof;
+
+    /// X.Y.Z is encoded in nibbles xxxx.yy.zz
+    uint version_;
+
+    /// X.Y.Z is encoded in nibbles xxxx.yy.zz
+    uint sdk = 0;
+}
+
+/**
+ * The `build_version_command` contains the min OS version on which this binary
+ * was built to run for its platform.
+ */
+struct build_version_command
+{
+    ///
+    uint cmd = LC_BUILD_VERSION;
+
+    ///
+    uint cmdsize = typeof(this).sizeof;
+
+    /// Platform
+    uint platform = PLATFORM_MACOS;
+
+    /// X.Y.Z is encoded in nibbles xxxx.yy.zz
+    uint minos;
+
+    /// X.Y.Z is encoded in nibbles xxxx.yy.zz
+    uint sdk = 0;
+
+    /// Number of tool entries following this
+    uint ntools = 0;
+}
+
+/// Known values for the platform field in `build_version_command`
+enum
+{
+    PLATFORM_MACOS = 1,
+    PLATFORM_IOS = 2,
+    PLATFORM_TVOS = 3,
+    PLATFORM_WATCHOS = 4,
+    PLATFORM_BRIDGEOS = 5,
+    PLATFORM_MACCATALYST = 6,
+    PLATFORM_IOSSIMULATOR = 7,
+    PLATFORM_TVOSSIMULATOR = 8,
+    PLATFORM_WATCHOSSIMULATOR = 9,
+    PLATFORM_DRIVERKIT = 10
 }


### PR DESCRIPTION
Encode `.macosx_version_min` or `.build_version` into the object file, originally authored by @jacob-carlborg in https://github.com/dlang/dmd/pull/10476.

This has been simplified to omit parsing the SDK version. Based on what I see GCC is doing (`-platform_version macos $version_min 0.0`), this information is not required in order for things to work.  Should support for SDKs/frameworks be wanted in future, then that can be done as a feature, not a bug fix.

This is good for both i386 and x86_64, as `.macosx_version_min` has been around since the beginning of macOS X.

No tests required as it effects _all_ objects compiled by dmd.

(And earlier iteration of this was done in #16178).