### PR TITLE
Move dmd/root/object.h to dmd/rootobject.h

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1566,8 +1566,8 @@ auto sourceFiles()
         frontendHeaders: fileArray(env["D"], "
             aggregate.h aliasthis.h arraytypes.h attrib.h compiler.h cond.h
             ctfe.h declaration.h dsymbol.h doc.h enum.h errors.h expression.h globals.h hdrgen.h
-            identifier.h id.h import.h init.h json.h mangle.h module.h mtype.h nspace.h objc.h scope.h
-            statement.h staticassert.h target.h template.h tokens.h version.h visitor.h
+            identifier.h id.h import.h init.h json.h mangle.h module.h mtype.h nspace.h objc.h rootobject.h
+            scope.h statement.h staticassert.h target.h template.h tokens.h version.h visitor.h
         "),
         lexer: fileArray(env["D"], "
             console.d entity.d errors.d errorsink.d file_manager.d globals.d id.d identifier.d lexer.d location.d tokens.d
@@ -1586,7 +1586,7 @@ auto sourceFiles()
         "),
         rootHeaders: fileArray(env["ROOT"], "
             array.h bitarray.h complex_t.h ctfloat.h dcompat.h dsystem.h filename.h longdouble.h
-            object.h optional.h port.h rmem.h root.h
+            optional.h port.h rmem.h root.h
         "),
         backend: fileArray(env["C"], "
             backend.d bcomplex.d evalu8.d divcoeff.d dvec.d go.d gsroa.d glocal.d gdag.d gother.d gflow.d

--- a/compiler/src/dmd/ast_node.h
+++ b/compiler/src/dmd/ast_node.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "root/object.h"
+#include "rootobject.h"
 
 class Visitor;
 

--- a/compiler/src/dmd/identifier.h
+++ b/compiler/src/dmd/identifier.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "root/dcompat.h"
-#include "root/object.h"
+#include "rootobject.h"
 
 class Identifier final : public RootObject
 {

--- a/compiler/src/dmd/root/array.h
+++ b/compiler/src/dmd/root/array.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "dsystem.h"
-#include "object.h"
 #include "rmem.h"
 
 template <typename TYPE>
@@ -44,7 +43,7 @@ struct Array
         d_size_t len = 2;
         for (d_size_t u = 0; u < length; u++)
         {
-            buf[u] = ((RootObject *)data.ptr[u])->toChars();
+            buf[u] = ((TYPE)data.ptr[u])->toChars();
             len += strlen(buf[u]) + 1;
         }
         char *str = (char *)mem.xmalloc(len);

--- a/compiler/src/dmd/root/bitarray.h
+++ b/compiler/src/dmd/root/bitarray.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "dsystem.h"
-#include "object.h"
 #include "rmem.h"
 
 struct BitArray

--- a/compiler/src/dmd/rootobject.h
+++ b/compiler/src/dmd/rootobject.h
@@ -4,13 +4,13 @@
  * https://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * https://www.boost.org/LICENSE_1_0.txt
- * https://github.com/dlang/dmd/blob/master/src/dmd/root/object.h
+ * https://github.com/dlang/dmd/blob/master/src/dmd/rootobject.h
  */
 
 #pragma once
 
-#include "dsystem.h"
-#include "dcompat.h"
+#include "root/dsystem.h"
+#include "root/dcompat.h"
 
 typedef size_t hash_t;
 

--- a/compiler/src/dmd/template.h
+++ b/compiler/src/dmd/template.h
@@ -36,7 +36,7 @@ public:
     // kludge for template.isType()
     DYNCAST dyncast() const override { return DYNCAST_TUPLE; }
 
-    const char *toChars() const override { return objects.toChars(); }
+    const char *toChars() const override;
 };
 
 struct TemplatePrevious

--- a/compiler/src/tests/cxxfrontend.cc
+++ b/compiler/src/tests/cxxfrontend.cc
@@ -16,12 +16,12 @@
 #include "root/dsystem.h"
 #include "root/filename.h"
 #include "root/longdouble.h"
-#include "root/object.h"
 #include "root/optional.h"
 #include "common/outbuffer.h"
 #include "root/port.h"
 #include "root/rmem.h"
 
+#include "rootobject.h"
 #include "aggregate.h"
 #include "aliasthis.h"
 #include "argtypes.h"
@@ -307,6 +307,7 @@ void test_skip_importall()
     /* Similar to test_semantic(), but importAll step is skipped.  */
     const char *buf =
         "module rootobject;\n"
+	"import object;\n"
         "class RootObject : Object { }";
 
     DArray<unsigned char> src = DArray<unsigned char>(strlen(buf), (unsigned char *)mem.xstrdup(buf));
@@ -455,6 +456,15 @@ void test_array()
     arrayA.zero();
     for (size_t i = 0; i < arrayA.length; i++)
         assert(arrayA[i] == 0);
+
+    Array<IntegerExp *> arrayInts;
+    arrayInts.push(IntegerExp::create(Loc(), 10, Type::tint32));
+    arrayInts.shift(IntegerExp::create(Loc(), 200, Type::tint32));
+    arrayInts.push(IntegerExp::create(Loc(), 15, Type::tint32));
+    arrayInts.shift(IntegerExp::create(Loc(), 100, Type::tint32));
+    arrayInts.push(IntegerExp::create(Loc(), 20, Type::tint32));
+
+    assert(strcmp(arrayInts.toChars(), "[100,200,10,15,20]") == 0);
 }
 
 void test_outbuffer()


### PR DESCRIPTION
The D module was moved in #15703 - these really should be mirrored in location.

The `root/array.h` header has been fixed up to not depend on `RootObject` directly.  By using `TYPE` instead of `RootObject*`, a compile-time error is reported if `TYPE::toChars()` does not exist - which is a better result than compiling successfull but segfaults at run-time.

G++ is smart enough to only run semantic on inline method bodies only if they are called. So no errors will be reported just by instantiating an `Array<int>` alone - you've got to run `Array<int>::toChars()`.