### PR TITLE
Fix Bugzilla 24401 - OSX: Linker error: GOT load reloc does not point to a movq instruction

### DIFF
--- a/compiler/src/dmd/backend/cgelem.d
+++ b/compiler/src/dmd/backend/cgelem.d
@@ -5035,14 +5035,9 @@ private elem * el64_32(elem *e, goal_t goal)
         }
         break;
 
-    case OPmul:
-        if (config.exe & (EX_OSX | EX_OSX64)) // https://issues.dlang.org/show_bug.cgi?id=21047
-            break;
-        else
-            goto case;
-
     case OPadd:
     case OPmin:
+    case OPmul:
     case OPor:
     case OPand:
     case OPxor:

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -942,6 +942,8 @@ void MachObj_term(const(char)* objfilename)
     }
 
     // Put out relocation data
+    // See mach-o/reloc.h for some examples of what should be generated and when:
+    // https://github.com/apple-oss-distributions/xnu/blob/rel/xnu-10002/EXTERNAL_HEADERS/mach-o/x86_64/reloc.h
     mach_numbersyms();
     for (int seg = 1; seg < SegData.length; seg++)
     {
@@ -1053,12 +1055,8 @@ void MachObj_term(const(char)* objfilename)
                                     rel.r_type = X86_64_RELOC_SIGNED;
                                 else if ((s.Sfl == FLfunc || s.Sfl == FLextern || s.Sclass == SC.global ||
                                           s.Sclass == SC.comdat || s.Sclass == SC.comdef) && r.rtype == RELaddr)
-                                {
-                                    rel.r_type = X86_64_RELOC_GOT_LOAD;
-                                    if (seg == eh_frame_seg ||
-                                        seg == except_table_seg)
-                                        rel.r_type = X86_64_RELOC_GOT;
-                                }
+                                    rel.r_type = X86_64_RELOC_GOT;
+
                                 rel.r_address = cast(int)r.offset;
                                 rel.r_symbolnum = s.Sxtrnnum;
                                 rel.r_pcrel = 1;

--- a/compiler/test/runnable/issue24401.d
+++ b/compiler/test/runnable/issue24401.d
@@ -1,0 +1,6 @@
+// PERMUTE_ARGS:
+// https://issues.dlang.org/show_bug.cgi?id=24401
+int main()
+{
+    return (() @trusted => 0)();
+}

--- a/compiler/test/runnable_cxx/test7925.d
+++ b/compiler/test/runnable_cxx/test7925.d
@@ -1,12 +1,5 @@
 // EXTRA_CPP_SOURCES: cpp7925.cpp
 
-/*
-Exclude -O due to a codegen bug on OSX:
-https://issues.dlang.org/show_bug.cgi?id=22556
-
-PERMUTE_ARGS(osx): -inline -release -g
-*/
-
 import core.vararg;
 
 extern(C++) class C1


### PR DESCRIPTION
This falls under "seems to work", and the explanation I have feels pretty lacklustre, but here we go...

As far as I can tell both `X86_64_RELOC_GOT_LOAD` and `X86_64_RELOC_GOT`  are handled almost identically, however GOT_LOAD is specifically for "a MOVQ load of a GOT entry",  compared with "other GOT references".

These are given as valid example of GOT relocations in reloc.h
```
movq _foo@GOTPCREL(%rip), %rax
        r_type=X86_64_RELOC_GOT_LOAD, r_length=2, r_extern=1, r_pcrel=1, r_symbolnum=_foo
        48 8B 05 00 00 00 00

pushq _foo@GOTPCREL(%rip)
        r_type=X86_64_RELOC_GOT, r_length=2, r_extern=1, r_pcrel=1, r_symbolnum=_foo
        FF 35 00 00 00 00
```

It's firstly not clear to me then why dmd emits a GOT relocation entry for functions calls in its codegen when both gdc and ldc emit BRANCH relocations.
```
call *(%rip), %rax
```
But regardless, out of the two GOT types, GOT_LOAD is obviously the wrong one to pick.

These relocation fix-ups are emitted by dmd after the function body has been generated, and there is no context for _how_ the referenced symbol is used.

In @WalterBright's blog post about OSX, it alludes to there being a valid use of GOT_LOAD somewhere in the code generator - https://digitalmars.com/articles/b71.html

So the best I can guess at why dmd is doing it wrong is - @WalterBright ran into this with some code that does a `cmp` with the address of a function, and from this somehow `X86_64_RELOC_GOT_LOAD` just ended up being incorrectly used for everything as the general case.

Instead then, always emit a `X86_64_RELOC_GOT` relocation.  The linker doesn't seem to care about movq on a plain GOT relocation.

---

Given the similarity of the error message to two other open Bugzilla issues, I'm going to punt that this will fix them too.