### PR TITLE
Fix Bugzilla issue 24404 - ifaddrs union fields incorrectly name on Linux.

### DIFF
--- a/druntime/src/core/sys/linux/ifaddrs.d
+++ b/druntime/src/core/sys/linux/ifaddrs.d
@@ -39,10 +39,17 @@ struct ifaddrs
     union
     {
         /// Broadcast address of the interface
-        sockaddr* ifu_broadaddr;
+        sockaddr* ifa_broadaddr;
+
         /// Point-to-point destination addresss
-        sockaddr* if_dstaddr;
+        sockaddr* ifa_dstaddr;
     }
+
+    deprecated("druntime declared this incorrectly before. The correct name is ifa_broadaddr.")
+    alias ifu_broadaddr = ifa_broadaddr;
+
+    deprecated("druntime declared this incorrectly before. The correct name is ifa_dstaddr.")
+    alias if_dstaddr = ifa_dstaddr;
 
     /// Address specific data
     void* ifa_data;


### PR DESCRIPTION
You can see the correct declaration for ifaddrs on Linux here:

https://www.man7.org/linux/man-pages/man3/getifaddrs.3.html

What the fields are supposed to be named is ifa_broadaddr and ifa_dstaddr. However, because Linux defines them using a union, it gives them different names within the union - ifu_broadaddr and ifu_dstaddr - and then #defines the proper names to access the union names.

What druntime did was use the union names - and then incorrectly name ifu_dtsaddr as if_dstaddr. So, it was doubly wrong for that field.

The two approaches that we could take here would be to either

1. Turn the union into a type so that we could have an ifa_ifu field to allow accessing the ifu_* names that way - as is technically possible in C - and then add wrapper functions with the ifa_* names (since we couldn't use an alias to access members of the union member variable).

2. Just rename the fields to ifa_* and ignore the fact that you can technically access the ifu_* fields via the union name in C.

The simpler approach is #2, so that's what this commit does. I'm pretty sure that the ability to access the ifu_* fields via the union name is just an implementation detail - particularly since other platforms just declare the ifa_* names without using a union at all.

Either way, deprecated aliases are provided so that existing code doesn't break.