### PR TITLE
Fix Bugzilla issue 24405 - FreeBSD's ifaddrs missing the ifa_broadaddr field.

### DIFF
--- a/druntime/src/core/sys/freebsd/ifaddrs.d
+++ b/druntime/src/core/sys/freebsd/ifaddrs.d
@@ -3,7 +3,7 @@
 /++
     D header file for FreeBSD's ifaddrs.h.
 
-    Copyright: Copyright 2023
+    Copyright: Copyright 2023 - 2024
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)
  +/
@@ -23,6 +23,7 @@ struct ifaddrs
     uint      ifa_flags;
     sockaddr* ifa_addr;
     sockaddr* ifa_netmask;
+    alias ifa_broadaddr = ifa_dstaddr;
     sockaddr* ifa_dstaddr;
     void*     ifa_data;
 }


### PR DESCRIPTION
FreeBSD #defines ifa_broadaddr to be ifa_dstaddr, and I missed it when adding it to druntime. So, this adds the appropriate alias.

It does feel a bit weird to list the alias before the field that it's aliasing, but that's the order presented in the man page, so it's what I did.