### PR TITLE
[stable] GHA: Bump Xcode version to 15.1 for macOS-13 jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,12 @@ jobs:
           # macOS
           - job_name: macOS 13 x64, DMD (latest)
             os: macos-13
-            host_dmd: dmd
+            # FIXME: Revert this back to "dmd" after 2.107.1 is released.
+            host_dmd: ldc
           - job_name: macOS 13 x64, DMD (coverage)
             os: macos-13
-            host_dmd: dmd
+            # FIXME: Revert this back to "dmd" after 2.107.1 is released.
+            host_dmd: ldc
             coverage: true
           - job_name: macOS 12 x64, DMD (bootstrap)
             os: macos-12
@@ -101,12 +103,12 @@ jobs:
         with:
           arch: ${{ env.MODEL == '64' && 'x64' || 'x86' }}
 
-      # FIXME: starting with Xcode 15:
-      # * https://issues.dlang.org/show_bug.cgi?id=24137
-      # * https://issues.dlang.org/show_bug.cgi?id=24399
-      - name: 'macOS 13: Switch to Xcode v14'
+      # NOTE: Linker ICEs with Xcode 15.0.1 (default version on macos-13)
+      # * https://issues.dlang.org/show_bug.cgi?id=24407
+      # Remove this step if the default gets changed to 15.1 in actions/runner-images.
+      - name: 'macOS 13: Switch to Xcode v15.1'
         if: matrix.os == 'macos-13'
-        run: sudo xcode-select -switch /Applications/Xcode_14.3.1.app
+        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
 
       - name: 'Posix: Install host compiler'
         if: runner.os != 'Windows'


### PR DESCRIPTION
Nearly a dozen bug fixes later, all woes on macOS / Xcode 15 might now be dealt with.

As there is no release of dmd with these fixes in yet, use `ldc` as the host D compiler for the interim until a new release is made.