### PR TITLE
Fix bugzilla issue 24408 - Remove duplicate AF_INET6 declaration.

### DIFF
--- a/druntime/src/core/sys/linux/sys/socket.d
+++ b/druntime/src/core/sys/linux/sys/socket.d
@@ -71,7 +71,6 @@ enum
     AF_BRIDGE     = PF_BRIDGE,
     AF_ATMPVC     = PF_ATMPVC,
     AF_X25        = PF_X25,
-    AF_INET6      = PF_INET6,
     AF_ROSE       = PF_ROSE,
     AF_DECnet     = PF_DECnet,
     AF_NETBEUI    = PF_NETBEUI,


### PR DESCRIPTION
It's already declared in core.sys.posix.sys.socket, so declaring it in core.sys.linux.sys.socket causes a conflict in code that imports both.

The Linux-specific module publicly imports the POSIX one, so the declaration in the Linux one is unnecessary. This removes it.