### PR TITLE
Fix Bugzilla issue 24111 - [ImportC] fatal error C1034: stdio.h: no include path set

### DIFF
--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1168,6 +1168,57 @@ public DArray!ubyte runPreprocessor(ref const Loc loc, const(char)[] cpp, const(
                 // Convert command to wchar
                 wchar[1024] scratch = void;
                 auto smbuf = SmallBuffer!wchar(scratch.length, scratch[]);
+
+                // INCLUDE
+                static VSOptions vsopt; // cache, as this can be expensive
+                static Strings includePaths;
+                if (includePaths.length == 0)
+                {
+                    if (!vsopt.VSInstallDir)
+                        vsopt.initialize();
+
+                    if (auto vcincludedir = vsopt.getVCIncludeDir()) {
+                        includePaths.push(vcincludedir);
+                    } else {
+                        return DArray!ubyte();
+                    }
+                    if (auto sdkincludedir = vsopt.getSDKIncludePath()) {
+                        includePaths.push(FileName.combine(sdkincludedir, "ucrt"));
+                        includePaths.push(FileName.combine(sdkincludedir, "shared"));
+                        includePaths.push(FileName.combine(sdkincludedir, "um"));
+                        includePaths.push(FileName.combine(sdkincludedir, "winrt"));
+                        includePaths.push(FileName.combine(sdkincludedir, "cppwinrt"));
+                    } else {
+                        includePaths = Strings.init;
+                        return DArray!ubyte();
+                    }
+                }
+
+                // Get current environment variable and rollback
+                auto oldIncludePathLen = GetEnvironmentVariableW("INCLUDE"w.ptr, null, 0);
+                wchar* oldIncludePaths = cast(wchar*)mem.xmalloc(oldIncludePathLen * wchar.sizeof);
+                oldIncludePathLen = GetEnvironmentVariableW("INCLUDE"w.ptr, oldIncludePaths, oldIncludePathLen);
+                scope (exit)
+                {
+                    SetEnvironmentVariableW("INCLUDE"w.ptr, oldIncludePaths);
+                    mem.xfree(oldIncludePaths);
+                }
+
+                // Make new environment variable
+                OutBuffer envbuf;
+                foreach (inc; includePaths[])
+                {
+                    if (FileName.exists(inc) == 2)
+                    {
+                        envbuf.write(cast(const ubyte[])toWStringz(inc[0..strlen(inc)], smbuf));
+                        envbuf.writewchar(';');
+                    }
+                }
+                envbuf.write(cast(const ubyte[])oldIncludePaths[0..oldIncludePathLen]);
+                envbuf.writewchar('\0');
+                // Temporarily set INCLUDE environment variable
+                SetEnvironmentVariableW("INCLUDE"w.ptr, cast(LPCWSTR)envbuf.buf);
+
                 auto szCommand = toWStringz(buf.peekChars()[0 .. buf.length], smbuf);
 
                 int exitCode = runProcessCollectStdout(szCommand.ptr, buffer[], &sink);

--- a/compiler/test/dshell/extra-files/issue24111.c
+++ b/compiler/test/dshell/extra-files/issue24111.c
@@ -1,0 +1,1 @@
+#include <stdio.h>

--- a/compiler/test/dshell/issue24111.d
+++ b/compiler/test/dshell/issue24111.d
@@ -1,0 +1,15 @@
+import dshell;
+
+int main()
+{
+	version (Windows)
+	{
+		auto cmd = "$DMD -m$MODEL -c $EXTRA_FILES" ~ SEP ~ "issue24111.c";
+		run(cmd);
+
+		import std.process: environment;
+		environment.remove("INCLUDE");
+		run(cmd);
+	}
+	return 0;
+}


### PR DESCRIPTION
I have attempted a fix for this problem: https://issues.dlang.org/show_bug.cgi?id=24111
https://github.com/dlang/dmd/pull/15780 is the predecessor's approach to this problem.
My implementation is based on how it is used in LDC ( https://github.com/ldc-developers/ldc/blob/8399e47ceb4dfbbcf1ca0b7cf934c04a864387b7/driver/tool.cpp#L297-L312 )
Also, I refer to a part of std.process to pass environment variables to CreateProcess. ( https://github.com/dlang/phobos/blob/dcbfbd43ac321e81af60afd795bd0f3c3f47cfa0/std/process.d#L412-L440 , https://github.com/dlang/phobos/blob/dcbfbd43ac321e81af60afd795bd0f3c3f47cfa0/std/process.d#L1450-L1482 )

I have very little experience with dmd code, so my coding style may be incorrect or inefficiently implemented. Please point out any problems.