### PR TITLE
Move cond.StaticForeach.prepare and cond.StaticForeach.lowerNonArrayA…

### DIFF
--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -873,6 +873,7 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
 
 extern (C++) final class StaticForeachDeclaration : AttribDeclaration
 {
+    import dmd.statementsem : prepare;
     StaticForeach sfe; /// contains `static foreach` expansion logic
 
     ScopeDsymbol scopesym; /// cached enclosing scope (mimics `static if` declaration)
@@ -930,7 +931,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
 
         if (_scope)
         {
-            sfe.prepare(_scope); // lower static foreach aggregate
+            prepare(_scope); // lower static foreach aggregate
         }
         if (!sfe.ready())
         {


### PR DESCRIPTION
no point in having StaticForeach.prepare and StaticForeach.lowerNonArrayAggregate in `cond.d`:

`prepare` requires semantic information from `lowerNonArrayAggregate` which also requires type semantic information from `typesem`.
moving them to `statementsem.d` which pass semantic routines on statements simply achieves the dependency break. 