### PR TITLE
generate code for modules in DFO

### DIFF
--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -126,6 +126,14 @@ public void generateCodeAndWrite(Module[] modules, const(char)*[] libmodules,
             library.addObject(p.toDString(), null);
     }
 
+    /* Rearrange modules[] into depth first order. This is so that functions to be
+     * inlined are compiled first.
+     */
+    if (driverParams.optimize)
+    {
+        rootModuleDFO(Module.amodules[], modules);
+    }
+
     if (!obj)
     {
     }


### PR DESCRIPTION
The backend inliner relies on the code for functions to be inlined to be already generated. To that end, the modules presented to the code generator should be presented in depth-first-order to maximize the possibilities for inlining.

It still won't be able to inline functions for which code is not generated, as modules not listed on the command line. This seems to be a costly to overcome problem. Does gdc or ldc resolve it?

It also won't be able to inline functions that appear later in the source file than the function that wants to inline them. The functions in a module would also have to be in DFO order.