### PR TITLE
Fix bugzilla issue 24417: fds_bits named incorrectly on FreeBSD

### DIFF
--- a/druntime/src/core/sys/posix/sys/select.d
+++ b/druntime/src/core/sys/posix/sys/select.d
@@ -183,7 +183,8 @@ else version (FreeBSD)
 
     struct fd_set
     {
-        __fd_mask[(FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS] __fds_bits;
+        __fd_mask[(FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS] fds_bits;
+        deprecated("druntime incorrectly named fds_bits __fds_bits") alias __fds_bits = fds_bits;
     }
 
     extern (D) __fd_mask __fdset_mask(uint n) pure
@@ -193,17 +194,17 @@ else version (FreeBSD)
 
     extern (D) void FD_CLR( int n, fd_set* p ) pure
     {
-        p.__fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
+        p.fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
     }
 
     extern (D) bool FD_ISSET( int n, const(fd_set)* p ) pure
     {
-        return (p.__fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
+        return (p.fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
     }
 
     extern (D) void FD_SET( int n, fd_set* p ) pure
     {
-        p.__fds_bits[n / _NFDBITS] |= __fdset_mask(n);
+        p.fds_bits[n / _NFDBITS] |= __fdset_mask(n);
     }
 
     extern (D) void FD_ZERO( fd_set* p ) pure
@@ -214,7 +215,7 @@ else version (FreeBSD)
         _p = p;
         _n = (FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS;
         while (_n > 0)
-            _p.__fds_bits[--_n] = 0;
+            _p.fds_bits[--_n] = 0;
     }
 
     int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
@@ -232,7 +233,8 @@ else version (NetBSD)
 
     struct fd_set
     {
-        __fd_mask[(FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS] __fds_bits;
+        __fd_mask[(FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS] fds_bits;
+        deprecated("druntime incorrectly named fds_bits __fds_bits") alias __fds_bits = fds_bits;
     }
 
     extern (D) __fd_mask __fdset_mask(uint n) pure
@@ -242,17 +244,17 @@ else version (NetBSD)
 
     extern (D) void FD_CLR( int n, fd_set* p ) pure
     {
-        p.__fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
+        p.fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
     }
 
     extern (D) bool FD_ISSET( int n, const(fd_set)* p ) pure
     {
-        return (p.__fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
+        return (p.fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
     }
 
     extern (D) void FD_SET( int n, fd_set* p ) pure
     {
-        p.__fds_bits[n / _NFDBITS] |= __fdset_mask(n);
+        p.fds_bits[n / _NFDBITS] |= __fdset_mask(n);
     }
 
     extern (D) void FD_ZERO( fd_set* p ) pure
@@ -263,7 +265,7 @@ else version (NetBSD)
         _p = p;
         _n = (FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS;
         while (_n > 0)
-            _p.__fds_bits[--_n] = 0;
+            _p.fds_bits[--_n] = 0;
     }
 
     int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
@@ -281,7 +283,8 @@ else version (OpenBSD)
 
     struct fd_set
     {
-        __fd_mask[(FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS] __fds_bits;
+        __fd_mask[(FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS] fds_bits;
+        deprecated("druntime incorrectly named fds_bits __fds_bits") alias __fds_bits = fds_bits;
     }
 
     extern (D) __fd_mask __fdset_mask(uint n) pure
@@ -291,17 +294,17 @@ else version (OpenBSD)
 
     extern (D) void FD_CLR(int n, fd_set* p) pure
     {
-        p.__fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
+        p.fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
     }
 
     extern (D) bool FD_ISSET(int n, const(fd_set)* p) pure
     {
-        return (p.__fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
+        return (p.fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
     }
 
     extern (D) void FD_SET(int n, fd_set* p) pure
     {
-        p.__fds_bits[n / _NFDBITS] |= __fdset_mask(n);
+        p.fds_bits[n / _NFDBITS] |= __fdset_mask(n);
     }
 
     extern (D) void FD_ZERO(fd_set* p) pure
@@ -310,7 +313,7 @@ else version (OpenBSD)
         size_t _n = (FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS;
 
         while (_n > 0)
-            _p.__fds_bits[--_n] = 0;
+            _p.fds_bits[--_n] = 0;
     }
 
     int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
@@ -328,7 +331,8 @@ else version (DragonFlyBSD)
 
     struct fd_set
     {
-        __fd_mask[(FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS] __fds_bits;
+        __fd_mask[(FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS] fds_bits;
+        deprecated("druntime incorrectly named fds_bits __fds_bits") alias __fds_bits = fds_bits;
     }
 
     extern (D) __fd_mask __fdset_mask(uint n) pure
@@ -338,17 +342,17 @@ else version (DragonFlyBSD)
 
     extern (D) void FD_CLR( int n, fd_set* p ) pure
     {
-        p.__fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
+        p.fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
     }
 
     extern (D) bool FD_ISSET( int n, const(fd_set)* p ) pure
     {
-        return (p.__fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
+        return (p.fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
     }
 
     extern (D) void FD_SET( int n, fd_set* p ) pure
     {
-        p.__fds_bits[n / _NFDBITS] |= __fdset_mask(n);
+        p.fds_bits[n / _NFDBITS] |= __fdset_mask(n);
     }
 
     extern (D) void FD_ZERO( fd_set* p ) pure
@@ -359,7 +363,7 @@ else version (DragonFlyBSD)
         _p = p;
         _n = (FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS;
         while (_n > 0)
-            _p.__fds_bits[--_n] = 0;
+            _p.fds_bits[--_n] = 0;
     }
 
     int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);


### PR DESCRIPTION
This fixes the name of fds_bits on FreeBSD - or actually, on all of the BSDs listed in select.d. The way that they're declared in C is with a member named __fds_bits and then a #define for fds_bits. The D declarations managed to copy the struct declarations with the __ name but didn't add aliases to correspond to the #defines.

The standard name is fds_bits and is what any user code should be using, so I don't see any reason to have the __ versions other than to avoid breaking any code that used the __ versions, because that's what was there. So, I fixed the names and added deprecated aliases for the old ones.