### PR TITLE
move fatal() out of link.d

### DIFF
--- a/compiler/src/dmd/cpreprocess.d
+++ b/compiler/src/dmd/cpreprocess.d
@@ -68,7 +68,11 @@ DArray!ubyte preprocess(FileName csrcfile, ref const Loc loc, ref OutBuffer defi
     version (runPreprocessor)
     {
         const command = global.params.cpp ? toDString(global.params.cpp) : cppCommand();
-        return runPreprocessor(loc, command, csrcfile.toString(), importc_h, global.params.cppswitches, global.params.v.verbose, global.errorSink, defines);
+        DArray!ubyte text;
+        int status = runPreprocessor(loc, command, csrcfile.toString(), importc_h, global.params.cppswitches, global.params.v.verbose, global.errorSink, defines, text);
+        if (status)
+            fatal();
+        return text;
     }
     else
     {


### PR DESCRIPTION
Shouldn't make a library that exits your process. This moves that decision out of link.d.