### PR TITLE
refactor isCppOperator()

### DIFF
--- a/compiler/src/dmd/cppmangle.d
+++ b/compiler/src/dmd/cppmangle.d
@@ -49,19 +49,30 @@ import dmd.typesem;
 import dmd.visitor;
 
 
-// helper to check if an identifier is a C++ operator
-enum CppOperator { Cast, Assign, Eq, Index, Call, Unary, Binary, OpAssign, Unknown }
-package CppOperator isCppOperator(Identifier id)
+// C++ operators
+enum CppOperator { Unknown, Cast, Assign, Eq, Index, Call, Unary, Binary, OpAssign }
+
+/**************
+ * Check if id is a C++ operator
+ * Params:
+ *      id = identifier to be checked
+ * Returns:
+ *      CppOperator, or Unknown if not a C++ operator
+ */
+package CppOperator isCppOperator(const scope Identifier id)
 {
-    __gshared const(Identifier)[] operators = null;
-    if (!operators)
-        operators = [Id._cast, Id.assign, Id.eq, Id.index, Id.call, Id.opUnary, Id.opBinary, Id.opOpAssign];
-    foreach (i, op; operators)
+    with (Id) with (CppOperator)
     {
-        if (op == id)
-            return cast(CppOperator)i;
+        return (id == _cast)      ? Cast     :
+               (id == assign)     ? Assign   :
+               (id == eq)         ? Eq       :
+               (id == index)      ? Index    :
+               (id == call)       ? Call     :
+               (id == opUnary)    ? Unary    :
+               (id == opBinary)   ? Binary   :
+               (id == opOpAssign) ? OpAssign :
+                                    Unknown  ;
     }
-    return CppOperator.Unknown;
 }
 
 ///


### PR DESCRIPTION
1. add ddoc comment
2. default value for CppOperator should be first and be zero
3. get rid of unnecessary global
4. make it as simple as possible
5. it's even faster!