### PR TITLE
lift fatal() out of utils.d

### DIFF
--- a/compiler/src/dmd/libelf.d
+++ b/compiler/src/dmd/libelf.d
@@ -30,11 +30,13 @@ else version (Windows)
 else
     static assert(0, "unsupported operating system");
 
+import dmd.errors : fatal;
 import dmd.lib;
 import dmd.location;
 import dmd.utils;
 
 import dmd.root.array;
+import dmd.root.file;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.port;
@@ -102,7 +104,10 @@ final class LibElf : Library
         {
             assert(module_name.length);
             // read file and take buffer ownership
-            auto data = readFile(Loc.initial, module_name).extractSlice();
+            Buffer b;
+            if (readFile(Loc.initial, module_name, b))
+                fatal();
+            auto data = b.extractSlice();
             buf = data.ptr;
             buflen = data.length;
             fromfile = 1;

--- a/compiler/src/dmd/libmach.d
+++ b/compiler/src/dmd/libmach.d
@@ -31,11 +31,13 @@ else version (Windows)
 else
     static assert(0, "unsupported operating system");
 
+import dmd.errors : fatal;
 import dmd.lib;
 import dmd.location;
 import dmd.utils;
 
 import dmd.root.array;
+import dmd.root.file;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.port;
@@ -103,7 +105,10 @@ final class LibMach : Library
         {
             assert(module_name[0]);
             // read file and take buffer ownership
-            auto data = readFile(Loc.initial, module_name).extractSlice();
+            Buffer b;
+            if (readFile(Loc.initial, module_name, b))
+                fatal();
+            auto data = b.extractSlice();
             buf = data.ptr;
             buflen = data.length;
             fromfile = 1;

--- a/compiler/src/dmd/libmscoff.d
+++ b/compiler/src/dmd/libmscoff.d
@@ -31,12 +31,14 @@ else version (Windows)
 else
     static assert(0, "unsupported operating system");
 
+import dmd.errors : fatal;
 import dmd.globals;
 import dmd.lib;
 import dmd.location;
 import dmd.utils;
 
 import dmd.root.array;
+import dmd.root.file;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.port;
@@ -110,7 +112,10 @@ final class LibMSCoff : Library
         {
             assert(module_name.length, "No module nor buffer provided to `addObject`");
             // read file and take buffer ownership
-            auto data = readFile(Loc.initial, module_name).extractSlice();
+            Buffer b;
+            if (readFile(Loc.initial, module_name, b))
+                fatal();
+            auto data = b.extractSlice();
             buf = data.ptr;
             buflen = data.length;
             fromfile = 1;

--- a/compiler/src/dmd/libomf.d
+++ b/compiler/src/dmd/libomf.d
@@ -16,11 +16,13 @@ import core.stdc.string;
 import core.stdc.stdlib;
 import core.bitop;
 
+import dmd.errors : fatal;
 import dmd.utils;
 import dmd.lib;
 import dmd.location;
 
 import dmd.root.array;
+import dmd.root.file;
 import dmd.root.filename;
 import dmd.root.rmem;
 import dmd.common.outbuffer;
@@ -92,7 +94,10 @@ final class LibOMF : Library
         {
             assert(module_name.length, "No module nor buffer provided to `addObject`");
             // read file and take buffer ownership
-            auto data = readFile(Loc.initial, module_name).extractSlice();
+            Buffer b;
+            if (readFile(Loc.initial, module_name, b))
+                fatal();
+            auto data = b.extractSlice();
             buf = data.ptr;
             buflen = data.length;
         }

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -351,11 +351,12 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     {
         foreach (file; ddocfiles)
         {
-            auto buffer = readFile(loc, file.toDString());
+            Buffer buffer;
+            if (readFile(loc, file.toDString(), buffer))
+                fatal();
             // BUG: convert file contents to UTF-8 before use
-            const data = buffer.data;
-            //printf("file: '%.*s'\n", cast(int)data.length, data.ptr);
-            ddocbuf.write(data);
+            //printf("file: '%.*s'\n", cast(int)buffer.data.length, buffer.data.ptr);
+            ddocbuf.write(buffer.data);
         }
         ddocbufIsRead = true;
     }

--- a/compiler/src/dmd/utils.d
+++ b/compiler/src/dmd/utils.d
@@ -52,16 +52,23 @@ const(char)* toWinPath(const(char)* src)
  * Params:
  *   loc = The line number information from where the call originates
  *   filename = Path to file
+ *   buf = set to contents of file
+ * Returns:
+ *   true on failure
  */
-Buffer readFile(Loc loc, const(char)[] filename)
+bool readFile(Loc loc, const(char)[] filename, out Buffer buf)
 {
     auto result = File.read(filename);
-    if (!result.success)
+    if (result.success)
+    {
+        buf.data = result.extractSlice();
+        return false;
+    }
+    else
     {
         error(loc, "error reading file `%.*s`", cast(int)filename.length, filename.ptr);
-        fatal();
+        return true;
     }
-    return Buffer(result.extractSlice());
 }
 
 


### PR DESCRIPTION
Probably should get rid of readFile() completely.