### PR TITLE
GHA Windows: Make sure building compiler/druntime/Phobos does NOT need an MSVC env anymore

### DIFF
--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -58,13 +58,10 @@ clone_repos
 ################################################################################
 
 if [ "$MODEL" == "64" ] ; then
-    MAKE_FILE="win64.mak"
     LIBNAME=phobos64.lib
 elif [ "$MODEL" == "32" ] ; then
-    MAKE_FILE="win64.mak"
     LIBNAME=phobos32mscoff.lib
 else # 32omf
-    MAKE_FILE="win32.mak"
     LIBNAME=phobos.lib
 fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,11 +97,6 @@ jobs:
       - name: 'Posix: Install prerequisites'
         if: runner.os != 'Windows'
         run: ${{ runner.os == 'macOS' && 'ci/cirrusci.sh' || 'sudo -E ci/cirrusci.sh' }}
-      - name: 'Windows: Set up MSVC environment'
-        if: runner.os == 'Windows'
-        uses: seanmiddleditch/gha-setup-vsdevenv@v4
-        with:
-          arch: ${{ env.MODEL == '64' && 'x64' || 'x86' }}
 
       # NOTE: Linker ICEs with Xcode 15.0.1 (default version on macos-13)
       # * https://issues.dlang.org/show_bug.cgi?id=24407
@@ -143,12 +138,14 @@ jobs:
         env:
           # on Windows, `ci/run.sh build` expects the DMD env var to be set to the DMD-CLI-compatible host compiler
           DMD: ${{ runner.os == 'Windows' && (startsWith(matrix.host_dmd, 'ldc') && 'ldmd2' || 'dmd') || '' }}
-          # work around the LDC host compiler on Windows assuming the first link.exe in PATH is the MSVC one
-          # (VSINSTALLDIR is set, but GHA uses Git's bin\bash.exe for `shell: bash`, which prepends Git's usr\bin to PATH, with GNU link.exe)
-          LDC_VSDIR_FORCE: ${{ runner.os == 'Windows' && startsWith(matrix.host_dmd, 'ldc') && '1' || '' }}
       - name: Rebuild dmd (with enabled coverage)
         if: matrix.coverage
         run: ENABLE_RELEASE=0 ENABLE_DEBUG=1 ENABLE_COVERAGE=1 ci/run.sh rebuild
+      - name: 'Windows: Set up MSVC environment' # some tests need cl.exe etc. in PATH
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-vsdevenv@v4
+        with:
+          arch: ${{ env.MODEL == '64' && 'x64' || 'x86' }}
       - name: Test dmd
         run: ci/run.sh test_dmd
       - name: Test druntime

--- a/druntime/Makefile
+++ b/druntime/Makefile
@@ -374,10 +374,6 @@ $(abspath ../generated/$(OS)/$(BUILD)/$(MODEL)/dmd$(DOTEXE)): ../generated/$(OS)
 
 ################### C/ASM Targets ############################
 
-# Although dmd is compiling the .c files, the preprocessor used on Windows is cl.exe.
-# Until https://issues.dlang.org/show_bug.cgi?id=24111 is fixed, the INCLUDE
-# enviroment variable needs to be set with the path to the VC system include files.
-
 OBJS:=$(ROOT)/errno_c$(DOTOBJ)
 ifeq (32omf,$(MODEL))
     # minit.asm is only used for -m32omf on Windows; there's a pre-built minit.obj


### PR DESCRIPTION
After https://github.com/dlang/dmd/pull/16248.