### PR TITLE
revamp File.read()

### DIFF
--- a/compiler/src/dmd/dinifile.d
+++ b/compiler/src/dmd/dinifile.d
@@ -13,6 +13,7 @@
 module dmd.dinifile;
 
 import core.stdc.ctype;
+import core.stdc.stdio;
 import core.stdc.string;
 import core.stdc.stdlib;
 
@@ -193,6 +194,7 @@ void updateRealEnvironment(ref StringTable!(char*) environment)
  */
 bool parseConfFile(ref StringTable!(char*) environment, const(char)[] filename, const(char)[] path, const(ubyte)[] buffer, const(Strings)* sections)
 {
+    //printf("buffer: '%.*s'\n", cast(int)buffer.length, buffer.ptr);
     /********************
      * Skip spaces.
      */

--- a/compiler/src/dmd/libelf.d
+++ b/compiler/src/dmd/libelf.d
@@ -102,10 +102,10 @@ final class LibElf : Library
         {
             assert(module_name.length);
             // read file and take buffer ownership
-            Buffer b;
+            OutBuffer b;
             if (readFile(Loc.initial, module_name, b))
                 fatal();
-            buffer = b.extractSlice();
+            buffer = cast(ubyte[])b.extractSlice();
             fromfile = 1;
         }
         if (buffer.length < 16)

--- a/compiler/src/dmd/libmach.d
+++ b/compiler/src/dmd/libmach.d
@@ -103,10 +103,10 @@ final class LibMach : Library
         {
             assert(module_name[0]);
             // read file and take buffer ownership
-            Buffer b;
+            OutBuffer b;
             if (readFile(Loc.initial, module_name, b))
                 fatal();
-            buffer = b.extractSlice();
+            buffer = cast(ubyte[])b.extractSlice();
             fromfile = 1;
         }
         if (buffer.length < 16)

--- a/compiler/src/dmd/libmscoff.d
+++ b/compiler/src/dmd/libmscoff.d
@@ -110,10 +110,10 @@ final class LibMSCoff : Library
         {
             assert(module_name.length, "No module nor buffer provided to `addObject`");
             // read file and take buffer ownership
-            Buffer b;
+            OutBuffer b;
             if (readFile(Loc.initial, module_name, b))
                 fatal();
-            buffer = b.extractSlice();
+            buffer = cast(ubyte[])b.extractSlice();
             fromfile = 1;
         }
         if (buffer.length < 16)

--- a/compiler/src/dmd/libomf.d
+++ b/compiler/src/dmd/libomf.d
@@ -92,10 +92,10 @@ final class LibOMF : Library
         {
             assert(module_name.length, "No module nor buffer provided to `addObject`");
             // read file and take buffer ownership
-            Buffer b;
+            OutBuffer b;
             if (readFile(Loc.initial, module_name, b))
                 fatal();
-            buffer = b.extractSlice();
+            buffer = cast(ubyte[])b.extractSlice();
         }
         uint g_page_size;
         ubyte* pstart = cast(ubyte*)buffer.ptr;

--- a/compiler/src/dmd/link.d
+++ b/compiler/src/dmd/link.d
@@ -1089,12 +1089,13 @@ public int runPreprocessor(ref const Loc loc, const(char)[] cpp, const(char)[] f
                 return STATUS_FAILED;
             }
             //printf("C preprocess succeeded %s\n", ifilename.ptr);
-            auto readResult = File.read(ifilename);
+            OutBuffer buf;
+            auto readResult = File.read(ifilename, buf);
             File.remove(ifilename.ptr);
             Mem.xfree(cast(void*)ifilename.ptr);
-            if (!readResult.success)
+            if (readResult)
                 return STATUS_FAILED;
-            text = DArray!ubyte(readResult.extractSlice());
+            text = DArray!ubyte(cast(ubyte[])buf.extractSlice(true));
             return 0;
         }
 

--- a/compiler/src/dmd/root/file.d
+++ b/compiler/src/dmd/root/file.d
@@ -19,11 +19,13 @@ import core.sys.posix.fcntl;
 import core.sys.posix.unistd;
 import core.sys.windows.winbase;
 import core.sys.windows.winnt;
+
 import dmd.root.filename;
 import dmd.root.rmem;
 import dmd.root.string;
 
 import dmd.common.file;
+import dmd.common.outbuffer;
 import dmd.common.smallbuffer;
 
 nothrow:
@@ -76,62 +78,52 @@ struct File
     }
 
 nothrow:
-    /// Read the full content of a file.
-    static ReadResult read(const(char)[] name)
+    /** Read the full content of a file, and append it to `buffer`
+     * Params:
+     *  name = name of file
+     *  buffer = file contents appended to it
+     * Returns:
+     *  false = success, true = failed
+     */
+    static bool read(const char[] name, ref OutBuffer buffer)
     {
-        ReadResult result;
+        enum Success = false;
+        enum Failure = true;
 
         version (Posix)
         {
-            size_t size;
-            stat_t buf;
-            ssize_t numread;
             //printf("File::read('%s')\n",name);
             int fd = name.toCStringThen!(slice => open(slice.ptr, O_RDONLY));
             if (fd == -1)
             {
                 //perror("\topen error");
-                return result;
+                return Failure;
             }
             //printf("\tfile opened\n");
-            if (fstat(fd, &buf))
+            stat_t statbuf;
+            if (fstat(fd, &statbuf))
             {
                 //perror("\tfstat error");
                 close(fd);
-                return result;
+                return Failure;
             }
-            size = cast(size_t)buf.st_size;
-            ubyte* buffer = cast(ubyte*)mem.xmalloc_noscan(size + 4);
-            numread = .read(fd, buffer, size);
+            size_t size = cast(size_t)statbuf.st_size;
+            auto buf = buffer.allocate(size);
+            ssize_t numread = .read(fd, buf.ptr, size);
             if (numread != size)
             {
                 //perror("\tread error");
-                goto err2;
+                close(fd);
+                return Failure;
             }
             if (close(fd) == -1)
             {
                 //perror("\tclose error");
-                goto err;
+                return Failure;
             }
-            // Always store a wchar ^Z past end of buffer so scanner has a
-            // sentinel, although ^Z got obselete, so fill with two 0s and add
-            // two more so lexer doesn't read pass the buffer.
-            buffer[size .. size + 4] = 0;
-
-            result.success = true;
-            result.buffer.data = buffer[0 .. size];
-            return result;
-        err2:
-            close(fd);
-        err:
-            mem.xfree(buffer);
-            return result;
         }
         else version (Windows)
         {
-            DWORD size;
-            DWORD numread;
-
             // work around Windows file path length limitation
             // (see documentation for extendedPathThen).
             HANDLE h = name.extendedPathThen!
@@ -143,32 +135,24 @@ nothrow:
                                   FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
                                   null));
             if (h == INVALID_HANDLE_VALUE)
-                return result;
-            size = GetFileSize(h, null);
-            ubyte* buffer = cast(ubyte*)mem.xmalloc_noscan(size + 4);
-            if (ReadFile(h, buffer, size, &numread, null) != TRUE)
-                goto err2;
-            if (numread != size)
-                goto err2;
+                return Failure;
+            DWORD size = GetFileSize(h, null);
+            auto buf = buffer.allocate(size);
+            DWORD numread;
+            if (ReadFile(h, buf.ptr, size, &numread, null) != TRUE ||
+                numread != size)
+            {
+                CloseHandle(h);
+                return Failure;
+            }
             if (!CloseHandle(h))
-                goto err;
-            // Always store a wchar ^Z past end of buffer so scanner has a
-            // sentinel, although ^Z got obselete, so fill with two 0s and add
-            // two more so lexer doesn't read pass the buffer.
-            buffer[size .. size + 4] = 0;
-            result.success = true;
-            result.buffer.data = buffer[0 .. size];
-            return result;
-        err2:
-            CloseHandle(h);
-        err:
-            mem.xfree(buffer);
-            return result;
+                return Failure;
         }
         else
         {
-            assert(0);
+            static assert(0);
         }
+        return Success;
     }
 
     /// Write a file, returning `true` on success.

--- a/compiler/src/dmd/root/response.d
+++ b/compiler/src/dmd/root/response.d
@@ -16,6 +16,7 @@ module dmd.root.response;
 
 import dmd.root.file;
 import dmd.root.filename;
+import dmd.common.outbuffer;
 
 ///
 alias responseExpand = responseExpandFrom!lookupInEnvironment;
@@ -207,7 +208,7 @@ bool insertArgumentsFromResponse(char[] buffer, ref Strings args, ref size_t arg
                 lastc = c;
                 if (p >= buffer.length)
                 {
-                    buffer[d] = '\0';
+                    buffer[d] = '\0';  // this looks suspicious
                     return recurse;
                 }
                 c = buffer[p];
@@ -354,10 +355,11 @@ private char[] lookupInEnvironment(scope const(char)* cp) nothrow {
     else
     {
         import dmd.root.string : toDString;
-        auto readResult = File.read(cp.toDString());
-        if (!readResult.success)
+        OutBuffer buf;
+        if (File.read(cp.toDString(), buf))
             return null;
+        buf.writeByte(0);
         // take ownership of buffer (leaking)
-        return cast(char[]) readResult.extractDataZ();
+        return cast(char[]) buf.extractSlice();
     }
 }

--- a/compiler/src/dmd/utils.d
+++ b/compiler/src/dmd/utils.d
@@ -52,23 +52,18 @@ const(char)* toWinPath(const(char)* src)
  * Params:
  *   loc = The line number information from where the call originates
  *   filename = Path to file
- *   buf = set to contents of file
+ *   buf = append contents of file to
  * Returns:
  *   true on failure
  */
-bool readFile(Loc loc, const(char)[] filename, out Buffer buf)
+bool readFile(Loc loc, const(char)[] filename, ref OutBuffer buf)
 {
-    auto result = File.read(filename);
-    if (result.success)
-    {
-        buf.data = result.extractSlice();
-        return false;
-    }
-    else
+    if (File.read(filename, buf))
     {
         error(loc, "error reading file `%.*s`", cast(int)filename.length, filename.ptr);
         return true;
     }
+    return false;
 }
 
 

--- a/compiler/src/dmd/vsoptions.d
+++ b/compiler/src/dmd/vsoptions.d
@@ -343,21 +343,21 @@ private:
             if (FileName.exists(defverFile))
             {
                 // VS 2017
-                auto readResult = File.read(defverFile.toDString); // adds sentinel 0 at end of file
-                if (readResult.success)
-                {
-                    auto ver = cast(char*)readResult.buffer.data.ptr;
-                    // trim version number
-                    while (*ver && isspace(*ver))
-                        ver++;
-                    auto p = ver;
-                    while (*p == '.' || (*p >= '0' && *p <= '9'))
-                        p++;
-                    *p = 0;
+                OutBuffer buf;
+                if (File.read(defverFile.toDString, buf)) // read file into buf
+                    return; // failed to read the file
 
-                    if (ver && *ver)
-                        VCToolsInstallDir = FileName.buildPath(VCInstallDir.toDString, r"Tools\MSVC", ver.toDString).ptr;
-                }
+                auto ver = cast(char*)buf.extractSlice(true).ptr;
+                // trim version number
+                while (*ver && isspace(*ver))
+                    ver++;
+                auto p = ver;
+                while (*p == '.' || (*p >= '0' && *p <= '9'))
+                    p++;
+                *p = 0;
+
+                if (ver && *ver)
+                    VCToolsInstallDir = FileName.buildPath(VCInstallDir.toDString, r"Tools\MSVC", ver.toDString).ptr;
             }
         }
     }


### PR DESCRIPTION
Simplify File.read() to do only one thing.

1. does not allocate memory - appends data to sink (i.e. the venerable `OutBuffer`) instead
2. does not add sentinel, that sometimes is needed and sometimes not, thus the caller makes this decision
3. simplifies error return, doesn't need an option type for it

By not allocating memory, it makes file content concatenation possible without double buffering. It also makes buffer recycling possible.

I thought for many years that File.read() could not be improved. Yet here it is, significantly improved!