### PR TITLE
push memory allocation up out of FileName.splitPath()

### DIFF
--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -766,7 +766,7 @@ public:
     const char* name() const;
     static const char* path(const char* str);
     static const char* combine(const char* path, const char* name);
-    static Array<const char* >* splitPath(const char* path);
+    static void appendSplitPath(const char* path, Array<const char* >& array);
     static const char* defaultExt(const char* name, const char* ext);
     static const char* forceExt(const char* name, const char* ext);
     static bool equalsExt(const char* name, const char* ext);

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -318,14 +318,12 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
 
     static void buildPath(ref Strings imppath, ref Strings result)
     {
+        Strings array;
         foreach (const path; imppath)
         {
-            Strings* a = FileName.splitPath(path);
-            if (a)
-            {
-                result.append(a);
-            }
+            FileName.appendSplitPath(path, array);
         }
+        result.append(&array);
     }
 
     if (params.mixinOut.doOutput)

--- a/compiler/src/dmd/root/filename.d
+++ b/compiler/src/dmd/root/filename.d
@@ -452,17 +452,15 @@ nothrow:
             assert(buildPath("a/", "bb", "ccc") == "a/bb/ccc");
     }
 
-    // Split a path into an Array of paths
-    extern (C++) static Strings* splitPath(const(char)* path)
+    // Split a path and append the results to `array`
+    extern (C++) static void appendSplitPath(const(char)* path, ref Strings array)
     {
-        auto array = new Strings();
         int sink(const(char)* p) nothrow
         {
             array.push(p);
             return 0;
         }
         splitPath(&sink, path);
-        return array;
     }
 
     /****

--- a/compiler/src/dmd/root/filename.h
+++ b/compiler/src/dmd/root/filename.h
@@ -31,7 +31,7 @@ public:
     static const char *path(const char *);
 
     static const char *combine(const char *path, const char *name);
-    static Strings *splitPath(const char *path);
+    static void appendSplitPath(const char *path, Strings& array);
     static const char *defaultExt(const char *name, const char *ext);
     static const char *forceExt(const char *name, const char *ext);
     static bool equalsExt(const char *name, const char *ext);


### PR DESCRIPTION
i.e. the call to `new` is replaced with stack allocation and RAII cleanup