### PR TITLE
use slices to eliminate call to removeExt()

### DIFF
--- a/compiler/src/dmd/identifier.d
+++ b/compiler/src/dmd/identifier.d
@@ -269,12 +269,12 @@ nothrow:
     /********************************************
      * Create an identifier in the string table.
      */
-    static Identifier idPool(const(char)* s, uint len)
+    static Identifier idPool(scope const(char)* s, uint len)
     {
         return idPool(s[0 .. len]);
     }
 
-    extern (D) static Identifier idPool(const(char)[] s, bool isAnonymous = false)
+    extern (D) static Identifier idPool(scope const(char)[] s, bool isAnonymous = false)
     {
         auto sv = stringtable.update(s);
         auto id = sv.value;
@@ -292,7 +292,7 @@ nothrow:
      *  s = string for keyword
      *  value = TOK.xxxx for the keyword
      */
-    extern (D) static void idPool(const(char)[] s, TOK value)
+    extern (D) static void idPool(scope const(char)[] s, TOK value)
     {
         auto sv = stringtable.insert(s, null);
         assert(sv);


### PR DESCRIPTION
idPool() doesn't save a copy, so it is not necessary to make a copy