### PR TITLE
use slices instead of char*

### DIFF
--- a/compiler/src/dmd/backend/cgobj.d
+++ b/compiler/src/dmd/backend/cgobj.d
@@ -691,7 +691,7 @@ void OmfObj_termfile()
  */
 
 @trusted
-void OmfObj_term(const(char)* objfilename)
+void OmfObj_term(const(char)[] objfilename)
 {
         //printf("OmfObj_term()\n");
         list_t dl;

--- a/compiler/src/dmd/backend/cv8.d
+++ b/compiler/src/dmd/backend/cv8.d
@@ -212,7 +212,7 @@ void cv8_initfile(const(char)* filename)
 }
 
 @trusted
-void cv8_termfile(const(char)* objfilename)
+void cv8_termfile(const(char)[] objfilename)
 {
     //printf("cv8_termfile()\n");
 
@@ -227,11 +227,11 @@ void cv8_termfile(const(char)* objfilename)
     /* Start with starting symbol in separate "F1" section
      */
     auto buf = OutBuffer(1024);
-    size_t len = strlen(objfilename);
+    size_t len = objfilename.length;
     buf.write16(cast(int)(2 + 4 + len + 1));
     buf.write16(S_COMPILAND_V3);
     buf.write32(0);
-    buf.write(objfilename, cast(uint)(len + 1));
+    buf.write(objfilename.ptr, cast(uint)(len + 1));
 
     // write S_COMPILE record
     buf.write16(2 + 1 + 1 + 2 + 1 + VERSION.length + 1);

--- a/compiler/src/dmd/backend/elfobj.d
+++ b/compiler/src/dmd/backend/elfobj.d
@@ -1019,7 +1019,7 @@ void ElfObj_termfile()
  *    objfilename = file name for object module (not used)
  */
 
-void ElfObj_term(const(char)* objfilename)
+void ElfObj_term(const(char)[] objfilename)
 {
     //printf("ElfObj_term()\n");
     outfixlist();           // backpatches

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -607,7 +607,7 @@ void MachObj_termfile()
  * Terminate package.
  */
 @trusted
-void MachObj_term(const(char)* objfilename)
+void MachObj_term(const(char)[] objfilename)
 {
     //printf("MachObj_term()\n");
     outfixlist();           // backpatches

--- a/compiler/src/dmd/backend/mscoffobj.d
+++ b/compiler/src/dmd/backend/mscoffobj.d
@@ -596,7 +596,7 @@ void MsCoffObj_termfile()
  */
 
 @trusted
-void MsCoffObj_term(const(char)* objfilename)
+void MsCoffObj_term(const(char)[] objfilename)
 {
     //printf("MsCoffObj_term()\n");
     assert(fobjbuf.length() == 0);

--- a/compiler/src/dmd/backend/obj.d
+++ b/compiler/src/dmd/backend/obj.d
@@ -80,7 +80,7 @@ else
             mixin(genRetVal("termfile()"));
         }
 
-        void term(const(char)* objfilename)
+        void term(const(char)[] objfilename)
         {
             mixin(genRetVal("term(objfilename)"));
         }

--- a/compiler/src/dmd/common/blake3.d
+++ b/compiler/src/dmd/common/blake3.d
@@ -17,6 +17,7 @@ nothrow:
  *     data = byte array to hash
  * Returns: Blake 3 hash of data
  **/
+@trusted
 public ubyte[32] blake3(const ubyte[] data)
 {
     ChunkState state;

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -148,7 +148,7 @@ public void generateCodeAndWrite(Module[] modules, const(char)*[] libmodules,
         }
         if (!global.errors && firstm)
         {
-            obj_end(objbuf, library, firstm.objfile.toChars());
+            obj_end(objbuf, library, firstm.objfile.toString());
         }
     }
     else
@@ -162,7 +162,7 @@ public void generateCodeAndWrite(Module[] modules, const(char)*[] libmodules,
                 eSink.message(Loc.initial, "code      %s", m.toChars());
             obj_start(objbuf, m.srcfile.toChars());
             genObjFile(m, multiobj);
-            obj_end(objbuf, library, m.objfile.toChars());
+            obj_end(objbuf, library, m.objfile.toString());
             obj_write_deferred(objbuf, library, glue.obj_symbols_towrite);
             if (global.errors && !writeLibrary)
                 m.deleteObjFile();
@@ -258,6 +258,7 @@ private void obj_write_deferred(ref OutBuffer objbuf, Library library, ref Dsymb
             mname = glue.lastmname;
             assert(mname);
         }
+        auto mnames = mname.toDString();
 
         obj_start(objbuf, mname);
 
@@ -282,7 +283,7 @@ private void obj_write_deferred(ref OutBuffer objbuf, Library library, ref Dsymb
         {
             Identifier id = Identifier.create(idbuf.extractChars());
 
-            Module md = new Module(mname.toDString, id, 0, 0);
+            Module md = new Module(mnames, id, 0, 0);
             md.members = new Dsymbols();
             md.members.push(s);   // its only 'member' is s
             md.doppelganger = 1;       // identify this module as doppelganger
@@ -295,18 +296,18 @@ private void obj_write_deferred(ref OutBuffer objbuf, Library library, ref Dsymb
         /* Set object file name to be source name with sequence number,
          * as mangled symbol names get way too long.
          */
-        const(char)* fname = FileName.removeExt(mname);
+        const length = FileName.ext(mnames).length;
+        const fname = mnames[0 .. mnames.length - (length ? length + 1 : 0)];  // +1 to remove .
         OutBuffer namebuf;
         uint hash = 0;
         for (const(char)* p = s.toChars(); *p; p++)
             hash += *p;
-        namebuf.printf("%s_%x_%x.%.*s", fname, count, hash,
+        namebuf.printf("%.*s_%x_%x.%.*s", cast(int)fname.length, fname.ptr, count, hash,
                        cast(int)target.obj_ext.length, target.obj_ext.ptr);
-        FileName.free(cast(char *)fname);
-        fname = namebuf.extractChars();
 
         //printf("writing '%s'\n", fname);
-        obj_end(objbuf, library, fname);
+        // terminating 0 still needed for library.addObject()
+        obj_end(objbuf, library, namebuf.extractSlice(true));
     }
     glue.obj_symbols_towrite.length = 0;
 }
@@ -426,7 +427,7 @@ private void obj_start(ref OutBuffer objbuf, const(char)* srcfile)
  *      objfilename = what to call the object module
  *      library = if non-null, add object module to this library
  */
-private void obj_end(ref OutBuffer objbuf, Library library, const(char)* objfilename)
+private void obj_end(ref OutBuffer objbuf, Library library, const(char)[] objfilename)
 {
     objmod.term(objfilename);
     //delete objmod;
@@ -435,12 +436,12 @@ private void obj_end(ref OutBuffer objbuf, Library library, const(char)* objfile
     if (library)
     {
         // Transfer ownership of image buffer to library
-        library.addObject(objfilename.toDString(), cast(ubyte[]) objbuf.extractSlice[]);
+        library.addObject(objfilename, cast(ubyte[]) objbuf.extractSlice[]);
     }
     else
     {
         //printf("write obj %s\n", objfilename);
-        if (!writeFile(Loc.initial, objfilename.toDString, objbuf[]))
+        if (!writeFile(Loc.initial, objfilename, objbuf[]))
             return fatal();
 
         // For non-libraries, the object buffer should be cleared to


### PR DESCRIPTION
The compiler is a mess with respect to file I/O and using [ ] vs char* and when is there a 0 termination. I propose to alter it all to use slices. Only when an operating system function is called should there be a conversion to a 0 terminated string. This should be done with toCStringThen() which has the nice property of cleaning up the extra memory allocation, or usually not allocating at all.

This PR is a start.

The @trusted is added to blake3.d because the compiler says:
```
src/dmd/common/blake3.d(72): Deprecation: reference to local variable `lastBlock` assigned to non-scope parameter `block` calling `bytesToWords`
```