### PR TITLE
turn tryagain into while loop

### DIFF
--- a/compiler/src/dmd/common/blake3.d
+++ b/compiler/src/dmd/common/blake3.d
@@ -17,7 +17,7 @@ nothrow:
  *     data = byte array to hash
  * Returns: Blake 3 hash of data
  **/
-
+@trusted
 public ubyte[32] blake3(scope const ubyte[] data)
 {
     ChunkState state;


### PR DESCRIPTION
Fixed a few comments along the way. Should be viewed with whitespace diffs off.

I had to add @trusted back into common/blake3.d, because now it produces:
```
src/dmd/common/blake3.d(33): Deprecation: scope variable `chunk` assigned to non-scope parameter `chunk` calling `updateChunkStateFull`
src/dmd/common/blake3.d(51): Deprecation: scope variable `data` assigned to non-scope parameter `block` calling `bytesToWords`
src/dmd/common/blake3.d(72): Deprecation: reference to local variable `lastBlock` assigned to non-scope parameter `block` calling `bytesToWords`
```