### PR TITLE
Fix dip1000 errors in blake3.d

### DIFF
--- a/compiler/src/dmd/common/blake3.d
+++ b/compiler/src/dmd/common/blake3.d
@@ -17,7 +17,6 @@ nothrow:
  *     data = byte array to hash
  * Returns: Blake 3 hash of data
  **/
-@trusted
 public ubyte[32] blake3(scope const ubyte[] data)
 {
     ChunkState state;
@@ -210,7 +209,7 @@ uint[16] compress(const ref uint[8] chainingValue, const ref uint[16] blockWords
 
 //if block isn't full, only the first blockLength/4 words
 //will be filled in
-uint[16] bytesToWords(const ubyte[] block)
+uint[16] bytesToWords(scope const ubyte[] block)
 {
     uint[16] ret = 0;
     foreach(i; 0 .. (block.length/4))
@@ -225,7 +224,7 @@ uint[16] bytesToWords(const ubyte[] block)
 
 
 //full sized chunks, so no need to check for partial blocks, etc
-void updateChunkStateFull(ref ChunkState chunkState, const ubyte[] chunk)
+void updateChunkStateFull(ref ChunkState chunkState, scope const ubyte[] chunk)
 {
     for (size_t cursor = 0; cursor < ChunkLength; cursor += BlockLength)
     {

--- a/dub.sdl
+++ b/dub.sdl
@@ -15,6 +15,7 @@ subPackage {
   importPaths "compiler/src"
   stringImportPaths "compiler/src/dmd/res" "."
   dflags "-L/STACK:16777216" platform="windows"
+  dflags "-preview=dip1000"
   preGenerateCommands "echo -n /etc > SYSCONFDIR.imp" platform="posix"
 }
 


### PR DESCRIPTION
See https://github.com/dlang/dmd/pull/16299#issuecomment-1994118633

Build with -preview=dip1000 via dub  to prevent future violations. I tried adding `-preview=dip1000` in build.d, but the bootstrap version (2.079) doesn't support it yet. It does have a `-dip1000` flag, but it segfaults in `dmd.escape.escapeByValue` on the lexer.