### PR TITLE
Fix endian issue when printing hex string literals

### DIFF
--- a/compiler/src/dmd/hdrgen.d
+++ b/compiler/src/dmd/hdrgen.d
@@ -2281,7 +2281,8 @@ private void expressionPrettyPrint(Expression e, ref OutBuffer buf, ref HdrGenSt
         {
             buf.writeByte('x');
             buf.writeByte('"');
-            buf.writeHexString(e.peekData, true);
+            foreach (i; 0 .. e.len)
+                buf.printf("%0*llX", e.sz, e.getIndex(i));
             buf.writeByte('"');
             if (e.postfix)
                 buf.writeByte(e.postfix);

--- a/compiler/test/fail_compilation/hexstring.d
+++ b/compiler/test/fail_compilation/hexstring.d
@@ -12,8 +12,8 @@ fail_compilation/hexstring.d(38): Error: array cast from `string` to `immutable(
 fail_compilation/hexstring.d(39): Error: array cast from `string` to `immutable(uint[])` is not supported at compile time
 fail_compilation/hexstring.d(39):        perhaps remove postfix `c` from hex string
 fail_compilation/hexstring.d(40): Error: hex string with `dstring` type needs to be multiple of 4 bytes, not 5
-fail_compilation/hexstring.d(41): Error: cannot implicitly convert expression `x"44332211"d` of type `dstring` to `immutable(float[])`
-fail_compilation/hexstring.d(42): Error: cannot implicitly convert expression `x"2211"w` of type `wstring` to `immutable(ubyte[])`
+fail_compilation/hexstring.d(41): Error: cannot implicitly convert expression `x"11223344"d` of type `dstring` to `immutable(float[])`
+fail_compilation/hexstring.d(42): Error: cannot implicitly convert expression `x"1122"w` of type `wstring` to `immutable(ubyte[])`
 fail_compilation/hexstring.d(28): Error: cannot implicitly convert expression `x"123F"` of type `string` to `ubyte[]`
 ---
 */

--- a/compiler/test/runnable/literal.d
+++ b/compiler/test/runnable/literal.d
@@ -263,7 +263,7 @@ void testHexstring()
 
     // Test printing StringExp with size 8
     enum toStr(immutable ulong[] v) = v.stringof;
-    static assert(toStr!y == `x"88776655443322119900FFEEDDCCBBAA"`);
+    static assert(toStr!y == `x"1122334455667788AABBCCDDEEFF0099"`);
 
     // Hex string postfixes
     // https://issues.dlang.org/show_bug.cgi?id=24363


### PR DESCRIPTION
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114155