### PR TITLE
Remove StringExp.peekString casts

### DIFF
--- a/compiler/src/dmd/dcast.d
+++ b/compiler/src/dmd/dcast.d
@@ -1884,7 +1884,7 @@ Expression castTo(Expression e, Scope* sc, Type t, Type att = null)
             if (szx != se.sz && (e.len % szx) == 0)
             {
                 import dmd.utils: arrayCastBigEndian;
-                const data = cast(const ubyte[]) e.peekString();
+                const data = e.peekData();
                 se.setData(arrayCastBigEndian(data, szx).ptr, data.length / szx, szx);
                 se.type = t;
                 return se;

--- a/compiler/src/dmd/dinterpret.d
+++ b/compiler/src/dmd/dinterpret.d
@@ -6118,7 +6118,7 @@ public:
                     return;
                 }
 
-                auto str = arrayCastBigEndian((cast(const ubyte[]) se.peekString()), sz);
+                auto str = arrayCastBigEndian(se.peekData(), sz);
                 emplaceExp!(StringExp)(pue, e1.loc, str, se.len / sz, cast(ubyte) sz);
                 result = pue.exp();
                 result.type = e.to;

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -4246,7 +4246,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (e.hexString)
         {
-            const data = cast(const ubyte[]) e.peekString(); // peek before size is set to something larger than 1
             switch (e.postfix)
             {
                 case 'd':
@@ -4271,7 +4270,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 error(e.loc, "hex string with `%s` type needs to be multiple of %d bytes, not %d",
                     e.type.toChars(), e.sz, cast(int) e.len);
 
-            e.setData(arrayCastBigEndian(data, e.sz).ptr, e.len / e.sz, e.sz);
+            e.setData(arrayCastBigEndian(e.peekData(), e.sz).ptr, e.len / e.sz, e.sz);
         }
         else switch (e.postfix)
         {

--- a/compiler/src/dmd/iasmdmd.d
+++ b/compiler/src/dmd/iasmdmd.d
@@ -3670,7 +3670,7 @@ code *asm_db_parse(OP *pop)
                 else if (auto se = e.isStringExp())
                 {
                     const len = se.numberOfCodeUnits();
-                    auto q = cast(char *)se.peekString().ptr;
+                    auto q = se.peekString().ptr;
                     if (q)
                     {
                         writeBytes(q[0 .. len]);


### PR DESCRIPTION
I was needlessly using `peekString` and casting to `ubyte[]` instead of just using `peekData`. 