### PR TITLE
Fix Bugzilla 24434 - Casting away const with cast() is not a @safe lv…

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -3824,6 +3824,7 @@ extern (C++) final class CastExp : UnaExp
 {
     Type to;                    // type to cast to
     ubyte mod = cast(ubyte)~0;  // MODxxxxx
+    bool trusted; // assume cast is safe
 
     extern (D) this(const ref Loc loc, Expression e, Type t) @safe
     {

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15734,7 +15734,7 @@ private Expression toLvalueImpl(Expression _this, Scope* sc, const(char)* action
         if (_this.isLvalue())
         {
             with (_this)
-            if (mod && !e1.type.pointerTo().implicitConvTo(to.pointerTo()))
+            if (mod != ubyte.max && !e1.type.pointerTo().implicitConvTo(to.pointerTo()))
                 sc.setUnsafePreview(FeatureState.default_, false, loc,
                     "cast from `%s` to `%s` cannot be used as an lvalue in @safe code",
                     e1.type, to);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15733,8 +15733,8 @@ private Expression toLvalueImpl(Expression _this, Scope* sc, const(char)* action
         }
         if (_this.isLvalue())
         {
-            with (_this) // FIXME: avoid new
-            if (mod && !new TypePointer(e1.type).implicitConvTo(new TypePointer(to)))
+            with (_this)
+            if (mod && !e1.type.pointerTo().implicitConvTo(to.pointerTo()))
                 sc.setUnsafe(false, loc,
                     "cast from `%s` to `%s` cannot be used as an lvalue in @safe code",
                     e1.type, to);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15732,7 +15732,15 @@ private Expression toLvalueImpl(Expression _this, Scope* sc, const(char)* action
             return visit(_this);
         }
         if (_this.isLvalue())
+        {
+            with (_this) // FIXME: avoid new
+            if (mod && !new TypePointer(e1.type).implicitConvTo(new TypePointer(to)))
+                sc.setUnsafe(false, loc,
+                    "cast from `%s` to `%s` cannot be used as an lvalue in @safe code",
+                    e1.type, to);
+
             return _this;
+        }
         return visit(_this);
     }
 

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -11864,7 +11864,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (checkNewEscape(sc, exp.e2, false))
                 return setError();
 
-            exp = new CatElemAssignExp(exp.loc, exp.type, exp.e1, exp.e2.castTo(sc, tb1next));
+            auto ecast = exp.e2.castTo(sc, tb1next);
+            if (auto ce = ecast.isCastExp())
+                ce.trusted = true;
+
+            exp = new CatElemAssignExp(exp.loc, exp.type, exp.e1, ecast);
             exp.e2 = doCopyOrMove(sc, exp.e2);
         }
         else if (tb1.ty == Tarray &&
@@ -15734,7 +15738,7 @@ private Expression toLvalueImpl(Expression _this, Scope* sc, const(char)* action
         if (_this.isLvalue())
         {
             with (_this)
-            if (mod != ubyte.max && !e1.type.pointerTo().implicitConvTo(to.pointerTo()))
+            if (!trusted && !e1.type.pointerTo().implicitConvTo(to.pointerTo()))
                 sc.setUnsafePreview(FeatureState.default_, false, loc,
                     "cast from `%s` to `%s` cannot be used as an lvalue in @safe code",
                     e1.type, to);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15735,7 +15735,7 @@ private Expression toLvalueImpl(Expression _this, Scope* sc, const(char)* action
         {
             with (_this)
             if (mod && !e1.type.pointerTo().implicitConvTo(to.pointerTo()))
-                sc.setUnsafe(false, loc,
+                sc.setUnsafePreview(FeatureState.default_, false, loc,
                     "cast from `%s` to `%s` cannot be used as an lvalue in @safe code",
                     e1.type, to);
 

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -2425,6 +2425,7 @@ class CastExp final : public UnaExp
 public:
     Type* to;
     uint8_t mod;
+    bool trusted;
     CastExp* syntaxCopy() override;
     bool isLvalue() override;
     void accept(Visitor* v) override;

--- a/compiler/test/fail_compilation/cast_qual.d
+++ b/compiler/test/fail_compilation/cast_qual.d
@@ -1,8 +1,8 @@
 /*
-REQUIRED_ARGS: -preview=dip1000
+REQUIRED_ARGS: -preview=dip1000 -de
 TEST_OUTPUT:
 ---
-fail_compilation/cast_qual.d(14): Error: cast from `const(int)` to `int` cannot be used as an lvalue in @safe code
+fail_compilation/cast_qual.d(14): Deprecation: cast from `const(int)` to `int` cannot be used as an lvalue in @safe code
 ---
 */
 

--- a/compiler/test/fail_compilation/cast_qual.d
+++ b/compiler/test/fail_compilation/cast_qual.d
@@ -2,7 +2,8 @@
 REQUIRED_ARGS: -preview=dip1000 -de
 TEST_OUTPUT:
 ---
-fail_compilation/cast_qual.d(14): Deprecation: cast from `const(int)` to `int` cannot be used as an lvalue in @safe code
+fail_compilation/cast_qual.d(15): Deprecation: cast from `const(int)` to `int` cannot be used as an lvalue in @safe code
+fail_compilation/cast_qual.d(17): Deprecation: cast from `const(int)` to `int` cannot be used as an lvalue in @safe code
 ---
 */
 
@@ -13,5 +14,6 @@ void main() {
     int j = cast() i; // OK
     int* p = &cast() i; // this should not compile in @safe code
     *p = 4; // oops
+    cast() i = 5; // NG
     auto q = &cast(const) j; // OK, int* to const int*
 }

--- a/compiler/test/fail_compilation/cast_qual.d
+++ b/compiler/test/fail_compilation/cast_qual.d
@@ -1,0 +1,17 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/cast_qual.d(14): Error: cast from `const(int)` to `int` cannot be used as an lvalue in @safe code
+---
+*/
+
+@safe:
+
+void main() {
+    const int i = 3;
+    int j = cast() i; // OK
+    int* p = &cast() i; // this should not compile in @safe code
+    *p = 4; // oops
+    auto q = &cast(const) j; // OK, int* to const int*
+}

--- a/druntime/src/core/internal/array/duplication.d
+++ b/druntime/src/core/internal/array/duplication.d
@@ -35,7 +35,7 @@ U[] _dupCtfe(T, U)(scope T[] a)
     {
         U[] res;
         foreach (ref e; a)
-            res ~= e;
+            res ~= cast(U) e;
         return res;
     }
 }

--- a/druntime/src/core/internal/array/duplication.d
+++ b/druntime/src/core/internal/array/duplication.d
@@ -35,7 +35,7 @@ U[] _dupCtfe(T, U)(scope T[] a)
     {
         U[] res;
         foreach (ref e; a)
-            res ~= cast(U) e;
+            res ~= e;
         return res;
     }
 }

--- a/druntime/src/core/sync/mutex.d
+++ b/druntime/src/core/sync/mutex.d
@@ -317,7 +317,7 @@ unittest
             cargo = 42;
         }
 
-        void useResource() shared @safe nothrow @nogc
+        void useResource() shared @trusted nothrow @nogc
         {
             mtx.lock_nothrow();
             (cast() cargo) += 1;


### PR DESCRIPTION
…alue