### PR TITLE
Fix a unittest for character tables that was missed matching to function

### DIFF
--- a/compiler/src/dmd/common/charactertables.d
+++ b/compiler/src/dmd/common/charactertables.d
@@ -78,7 +78,7 @@ bool isAnyIdentifierCharacter(dchar c)
 ///
 unittest
 {
-    assert(isAnyContinue('ğ'));
+    assert(isAnyIdentifierCharacter('ğ'));
 }
 
 /**


### PR DESCRIPTION
Thanks to @etienne02 for catching that I didn't quite get all the unittests to match to their respective functions.