### PR TITLE
Allow C++ headers to be generated without druntime being built (add import to druntime)

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -675,7 +675,10 @@ alias buildFrontendHeaders = makeRule!((builder, rule) {
             ["-J" ~ env["RES"], "-c", "-o-", "-HCf="~rule.target,
             // Enforce the expected target architecture
             "-m64", "-os=linux",
-            ] ~ dmdSources);
+            ] ~ dmdSources ~
+            // Set druntime up to be imported explicitly,
+            //  so that druntime doesn't have to be built to run the updating of c++ headers.
+            ["-I../druntime/src"]);
 });
 
 alias runCxxHeadersTest = makeRule!((builder, rule) {


### PR DESCRIPTION
I asked @RazvanN7 to build druntime and then generate the C++ headers and that worked according to him.

This change means that the generation of C++ headers no longer require you to have druntime built (and therefore compiler configured).

It simplifies development quite a bit for those of us who only work with the frontend.