### PR TITLE
fixresult87 take output by ref not pointer

### DIFF
--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -1919,7 +1919,7 @@ void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs)
     {
         if ((forregs | retregs) & (mST01 | mST0))
         {
-            fixresult87(cdb, e, retregs, pretregs);
+            fixresult87(cdb, e, retregs, *pretregs);
             return;
         }
         bool opsflag = false;
@@ -2042,7 +2042,7 @@ void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs)
         if (retregs & (mST01 | mST0))
         {
             *pretregs |= forccs;
-            fixresult87(cdb, e, retregs, pretregs);
+            fixresult87(cdb, e, retregs, *pretregs);
         }
         else
             tstresult(cdb, retregs, tym, forregs);
@@ -4074,7 +4074,7 @@ static if (0)
         {
             //assert(global87.stackused == 0);
             push87(cdb);                // one item on 8087 stack
-            fixresult87(cdb,e,retregs,pretregs);
+            fixresult87(cdb,e,retregs,*pretregs);
             return;
         }
         else

--- a/compiler/src/dmd/backend/cod3.d
+++ b/compiler/src/dmd/backend/cod3.d
@@ -1143,7 +1143,7 @@ static if (NTEXCEPTIONS)
             {
                 assert(reg1 == lreg && reg2 == NOREG);
                 regm_t pretregs = mask(reg1) | mask(reg2);
-                fixresult87(cdb, e, retregs, &pretregs, true);
+                fixresult87(cdb, e, retregs, pretregs, true);
             }
             // fix return registers
             else if (tybasic(e.Ety) == TYcfloat)

--- a/compiler/src/dmd/backend/cod4.d
+++ b/compiler/src/dmd/backend/cod4.d
@@ -3406,7 +3406,7 @@ void cdcnvt(ref CodeBuilder cdb,elem *e, regm_t *pretregs)
                 }
                 regm_t retregsx = mST0 | (*pretregs & mPSW);
                 codelem(cdb,e.EV.E1, &retregsx, false);
-                fixresult87(cdb, e, retregsx, pretregs);
+                fixresult87(cdb, e, retregsx, *pretregs);
                 return;
             }
 
@@ -3475,7 +3475,7 @@ void cdcnvt(ref CodeBuilder cdb,elem *e, regm_t *pretregs)
                     cdb.genfltreg(0xDF,5,0);     // FILD m64int
 
                     regm_t retregsy = mST0 /*| (*pretregs & mPSW)*/;
-                    fixresult87(cdb, e, retregsy, pretregs);
+                    fixresult87(cdb, e, retregsy, *pretregs);
                     return;
                 }
                 break;


### PR DESCRIPTION
pretregs can be updated in tons of places, but this one seemed like a good place to start since it's a small-ish diff.