### PR TITLE
allocregs use ref and out instead of pointer

### DIFF
--- a/compiler/src/dmd/backend/cg87.d
+++ b/compiler/src/dmd/backend/cg87.d
@@ -853,7 +853,7 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs, ref regm_t outretre
         cdb.genfltreg(ESC(mf,1),3,0);
         genfwait(cdb);
         reg_t reg;
-        allocreg(cdb,&outretregs,&reg,(sz == FLOATSIZE) ? TYfloat : TYdouble);
+        allocreg(cdb,outretregs,reg,(sz == FLOATSIZE) ? TYfloat : TYdouble);
         if (sz == FLOATSIZE)
         {
             if (!I16)
@@ -919,7 +919,7 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs, ref regm_t outretre
             genfwait(cdb);
             // MOVD XMM?,floatreg
             reg_t reg;
-            allocreg(cdb,&outretregs,&reg,(sz == FLOATSIZE) ? TYfloat : TYdouble);
+            allocreg(cdb,outretregs,reg,(sz == FLOATSIZE) ? TYfloat : TYdouble);
             cdb.genxmmreg(xmmload(tym),reg,0,tym);
         }
         else
@@ -2975,7 +2975,7 @@ private void cdd_u64_I32(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     if (!retregs)
         retregs = ALLREGS;
     reg_t reg, reg2;
-    allocreg(cdb,&retregs,&reg,tym);
+    allocreg(cdb,retregs,reg,tym);
     reg  = findreglsw(retregs);
     reg2 = findregmsw(retregs);
     movregconst(cdb,reg2,0x80000000,0);
@@ -3060,10 +3060,10 @@ private void cdd_u64_I64(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     if (!retregs)
         retregs = ALLREGS;
     reg_t reg;
-    allocreg(cdb,&retregs,&reg,tym);
+    allocreg(cdb,retregs,reg,tym);
     regm_t regm2 = ALLREGS & ~retregs & ~mAX;
     reg_t reg2;
-    allocreg(cdb,&regm2,&reg2,tym);
+    allocreg(cdb,regm2,reg2,tym);
     movregconst(cdb,reg2,0x80000000,0);
     getregs(cdb,mask(reg2) | mAX);
 
@@ -3134,7 +3134,7 @@ void cdd_u32(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     if (!retregs)
         retregs = ALLREGS;
     reg_t reg;
-    allocreg(cdb,&retregs,&reg,tym);
+    allocreg(cdb,retregs,reg,tym);
 
     cdb.genfltreg(0xC7,0,8);
     code *cf3 = cdb.last();
@@ -3261,7 +3261,7 @@ void cnvt87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         retregs = *pretregs & (ALLREGS | mBP);
         if (!retregs)
                 retregs = ALLREGS;
-        allocreg(cdb,&retregs,&reg,tym);
+        allocreg(cdb,retregs,reg,tym);
 
         genfwait(cdb);                                           // FWAIT
         cdb.genc1(0xD9,modregrm(2,5,4) + 256*modregrm(0,4,SP),FLconst,szoff); // FLDCW szoff[ESP]
@@ -3293,7 +3293,7 @@ void cnvt87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         retregs = *pretregs & (ALLREGS | mBP);
         if (!retregs)
                 retregs = ALLREGS;
-        allocreg(cdb,&retregs,&reg,tym);
+        allocreg(cdb,retregs,reg,tym);
 
         genfwait(cdb);
 
@@ -3351,7 +3351,7 @@ void cdrndtol(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     if (!retregs)
         retregs = ALLREGS;
     reg_t reg;
-    allocreg(cdb,&retregs,&reg,tym);
+    allocreg(cdb,retregs,reg,tym);
     genfwait(cdb);                      // FWAIT
     if (tysize(tym) > REGSIZE)
     {

--- a/compiler/src/dmd/backend/cgen.d
+++ b/compiler/src/dmd/backend/cgen.d
@@ -242,7 +242,7 @@ void regwithvalue(ref CodeBuilder cdb,regm_t regm,targ_size_t value, out reg_t p
         return; // already have a register with the right value in it
 
     regm_t save = regcon.immed.mval;
-    allocreg(cdb,&regm,&preg,TYint);  // allocate register
+    allocreg(cdb,regm,preg,TYint);  // allocate register
     regcon.immed.mval = save;
     movregconst(cdb,preg,value,flags);   // store value into reg
 }

--- a/compiler/src/dmd/backend/cgxmm.d
+++ b/compiler/src/dmd/backend/cgxmm.d
@@ -116,7 +116,7 @@ void movxmmconst(ref CodeBuilder cdb, reg_t xreg, tym_t ty, eve* pev, regm_t fla
     {
         reg_t r;
         regm_t rm = ALLREGS;
-        allocreg(cdb,&rm,&r,TYint);         // allocate scratch register
+        allocreg(cdb,rm,r,TYint);         // allocate scratch register
         static union U { targ_size_t s; targ_long[2] l; }
         U u = void;
         u.l[1] = 0;
@@ -189,7 +189,7 @@ void orthxmm(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
             regm_t nretregs = XMMREGS & ~retregs;
             reg_t sreg; // hold sign bit
             const uint sz = tysize(e1.Ety);
-            allocreg(cdb,&nretregs,&sreg,e2.Ety);
+            allocreg(cdb,nretregs,sreg,e2.Ety);
             eve signbit;
             signbit.Vint = 0x80000000;
             if (sz == 8)
@@ -511,7 +511,7 @@ void xmmcnvt(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     }
 
     reg_t rreg;
-    allocreg(cdb,&retregs,&rreg,ty);
+    allocreg(cdb,retregs,rreg,ty);
     if (isXMMreg(rreg))
         rreg -= XMM0;
 
@@ -567,7 +567,7 @@ void xmmopass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         retregs = *pretregs & XMMREGS & ~rretregs;
         if (!retregs)
             retregs = XMMREGS & ~rretregs;
-        allocreg(cdb,&retregs,&reg,ty1);
+        allocreg(cdb,retregs,reg,ty1);
         cs.Iop = xmmload(ty1, true);            // MOVSD xmm,xmm_m64
         code_newreg(&cs,reg - XMM0);
         cdb.gen(&cs);
@@ -636,7 +636,7 @@ void xmmpost(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         retregs = XMMREGS & ~*pretregs;
         if (!retregs)
             retregs = XMMREGS;
-        allocreg(cdb,&retregs,&reg,ty1);
+        allocreg(cdb,retregs,reg,ty1);
         cs.Iop = xmmload(ty1, true);            // MOVSD xmm,xmm_m64
         code_newreg(&cs,reg - XMM0);
         cdb.gen(&cs);
@@ -648,7 +648,7 @@ void xmmpost(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     if (!resultregs)
         resultregs = XMMREGS & ~retregs;
     reg_t resultreg;
-    allocreg(cdb,&resultregs, &resultreg, ty1);
+    allocreg(cdb,resultregs, resultreg, ty1);
 
     cdb.gen2(xmmload(ty1,true),modregxrmx(3,resultreg-XMM0,reg-XMM0));   // MOVSS/D resultreg,reg
     checkSetVex(cdb.last(), ty1);
@@ -710,7 +710,7 @@ void xmmneg(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     const reg = findreg(retregs);
     regm_t rretregs = XMMREGS & ~retregs;
     reg_t rreg;
-    allocreg(cdb,&rretregs,&rreg,tyml);
+    allocreg(cdb,rretregs,rreg,tyml);
 
     eve signbit;
     signbit.Vint = 0x80000000;
@@ -752,7 +752,7 @@ void xmmabs(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     const reg = findreg(retregs);
     regm_t rretregs = XMMREGS & ~retregs;
     reg_t rreg;
-    allocreg(cdb,&rretregs,&rreg,tyml);
+    allocreg(cdb,rretregs,rreg,tyml);
 
     eve mask;
     mask.Vint = 0x7FFF_FFFF;
@@ -1299,7 +1299,7 @@ static if (0)
         if (!retregs)
             retregs = XMMREGS;
         reg_t reg;
-        allocreg(cdb,&retregs, &reg, e.Ety);
+        allocreg(cdb,retregs, reg, e.Ety);
         code_newreg(&cs, reg - XMM0);
         cs.Iop = op;
         cdb.gen(&cs);
@@ -1486,7 +1486,7 @@ static if (0)
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 reg_t reg;
-                allocreg(cdb,&retregs,&reg,ty);
+                allocreg(cdb,retregs,reg,ty);
                 cs.Iop = VBROADCASTSS;
                 cs.Irex &= ~REX_W;
                 code_newreg(&cs,reg - XMM0);
@@ -1527,7 +1527,7 @@ static if (0)
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 reg_t reg;
-                allocreg(cdb,&retregs,&reg,ty);
+                allocreg(cdb,retregs,reg,ty);
                 cs.Iop = VBROADCASTSD;
                 cs.Irex &= ~REX_W;
                 code_newreg(&cs,reg - XMM0);
@@ -1570,7 +1570,7 @@ static if (0)
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 reg_t reg;
-                allocreg(cdb,&retregs,&reg,ty);
+                allocreg(cdb,retregs,reg,ty);
                 cs.Iop = VPBROADCASTB;
                 cs.Irex &= ~REX_W;
                 code_newreg(&cs,reg - XMM0);
@@ -1584,7 +1584,7 @@ static if (0)
                 const r = findreg(regm);
 
                 reg_t reg;
-                allocreg(cdb,&retregs,&reg, e.Ety);
+                allocreg(cdb,retregs,reg, e.Ety);
                 reg -= XMM0;
                 // (V)MOVD reg,r
                 cdb.gen2(LODD,modregxrmx(3,reg,r));
@@ -1602,7 +1602,7 @@ static if (0)
                         reg_t zeroreg;
                         regm = XMMREGS & ~retregs;
                         // VPXOR XMM1,XMM1,XMM1
-                        allocreg(cdb,&regm,&zeroreg, ty);
+                        allocreg(cdb,regm,zeroreg, ty);
                         zeroreg -= XMM0;
                         cdb.gen2(PXOR, modregxrmx(3,zeroreg,zeroreg));
                         checkSetVex(cdb.last(), TYuchar16); // AVX-128
@@ -1639,7 +1639,7 @@ static if (0)
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 reg_t reg;
-                allocreg(cdb,&retregs,&reg,ty);
+                allocreg(cdb,retregs,reg,ty);
                 cs.Iop = VPBROADCASTW;
                 cs.Irex &= ~REX_W;
                 cs.Iflags &= ~CFopsize;
@@ -1654,7 +1654,7 @@ static if (0)
                 reg_t r = findreg(regm);
 
                 reg_t reg;
-                allocreg(cdb,&retregs,&reg, e.Ety);
+                allocreg(cdb,retregs,reg, e.Ety);
                 reg -= XMM0;
                 // (V)MOVD reg,r
                 cdb.gen2(LODD,modregxrmx(3,reg,r));
@@ -1693,7 +1693,7 @@ static if (0)
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 reg_t reg;
-                allocreg(cdb,&retregs,&reg,ty);
+                allocreg(cdb,retregs,reg,ty);
                 cs.Iop = config.avx >= 2 ? VPBROADCASTD : VBROADCASTSS;
                 cs.Irex &= ~REX_W;
                 code_newreg(&cs,reg - XMM0);
@@ -1736,7 +1736,7 @@ static if (0)
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
                 reg_t reg;
-                allocreg(cdb,&retregs,&reg,ty);
+                allocreg(cdb,retregs,reg,ty);
                 cs.Iop = config.avx >= 2 ? VPBROADCASTQ : tysize(ty) == 32 ? VBROADCASTSD : PUNPCKLQDQ;
                 cs.Irex &= ~REX_W;
                 code_newreg(&cs,reg - XMM0);
@@ -1946,13 +1946,13 @@ void cloadxmm(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
 
         regm_t retregs0 = mXMM0;
         reg_t reg0;
-        allocreg(cdb, &retregs0, &reg0, ty);
+        allocreg(cdb, retregs0, reg0, ty);
         loadea(cdb, e, &cs, opmv, reg0, 0, RMload, 0);  // MOVSS/MOVSD XMM0,data
         checkSetVex(cdb.last(), ty);
 
         regm_t retregs1 = mXMM1;
         reg_t reg1;
-        allocreg(cdb, &retregs1, &reg1, ty);
+        allocreg(cdb, retregs1, reg1, ty);
         loadea(cdb, e, &cs, opmv, reg1, tysize(ty), RMload, mXMM0); // MOVSS/MOVSD XMM1,data+offset
         checkSetVex(cdb.last(), ty);
 

--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -439,7 +439,7 @@ void genstackclean(ref CodeBuilder cdb,uint numpara,regm_t keepmsk)
             if (scratchm)
             {
                 reg_t r;
-                allocreg(cdb, &scratchm, &r, TYint);
+                allocreg(cdb, scratchm, r, TYint);
                 cdb.gen1(0x58 + r);           // POP r
             }
             else
@@ -1035,7 +1035,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                             reg_t r;
 
                             scratchm = ALLREGS & ~keepmsk;
-                            allocreg(cdb, &scratchm, &r, TYint);
+                            allocreg(cdb, scratchm, r, TYint);
 
                             if (ssflags & SSFLnobase1)
                             {
@@ -1142,7 +1142,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                     uint flagsave;
 
                     regm_t idxregs = IDXREGS & ~keepmsk;
-                    allocreg(cdb, &idxregs, &reg, TYoffset);
+                    allocreg(cdb, idxregs, reg, TYoffset);
 
                     /* If desired result is a far pointer, we'll have       */
                     /* to load another register with the segment of v       */
@@ -1151,7 +1151,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                         reg_t msreg;
 
                         idxregs |= mMSW & ALLREGS & ~keepmsk;
-                        allocreg(cdb, &idxregs, &msreg, TYfptr);
+                        allocreg(cdb, idxregs, msreg, TYfptr);
                         msreg = findregmsw(idxregs);
                                                     /* MOV msreg,segreg     */
                         genregs(cdb, 0x8C, segfl[f], msreg);
@@ -1637,7 +1637,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
         Lfardata:
         {
             regm_t regm = ALLREGS & ~keepmsk;       // need scratch register
-            allocreg(cdb, &regm, &reg, TYint);
+            allocreg(cdb, regm, reg, TYint);
             getregs(cdb,mES);
             // MOV mreg,seg of symbol
             cdb.gencs(0xB8 + reg, 0, FLextern, s);
@@ -1748,7 +1748,7 @@ void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, uint saveflag)
     {
         reg_t xreg;
         regm_t xregs = XMMREGS & ~regm;
-        allocreg(cdb,&xregs, &xreg, TYdouble);
+        allocreg(cdb,xregs, xreg, TYdouble);
         opcode_t op = 0;
         if (tym == TYdouble || tym == TYidouble || tym == TYcdouble)
             op = 0x660000;
@@ -1773,7 +1773,7 @@ void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, uint saveflag)
                 if (saveflag)
                 {
                     scrregm = allregs & ~regm;              // possible scratch regs
-                    allocreg(cdb, &scrregm, &scrreg, TYoffset); // allocate scratch reg
+                    allocreg(cdb, scrregm, scrreg, TYoffset); // allocate scratch reg
                     genmovreg(cdb, scrreg, reg);  // MOV scrreg,msreg
                     reg = scrreg;
                 }
@@ -1796,7 +1796,7 @@ void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, uint saveflag)
     {
     L1:
         scrregm = ALLREGS & ~regm;              // possible scratch regs
-        allocreg(cdb, &scrregm, &scrreg, TYoffset); // allocate scratch reg
+        allocreg(cdb, scrregm, scrreg, TYoffset); // allocate scratch reg
         if (I32 || sz == REGSIZE * 2)
         {
             assert(regm & mMSW && regm & mLSW);
@@ -1958,7 +1958,7 @@ void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, ref regm_t outretre
         }
         else
         {
-            allocreg(cdb, &outretregs, &rreg, tym);  // allocate return regs
+            allocreg(cdb, outretregs, rreg, tym);  // allocate return regs
             if (retregs & XMMREGS)
             {
                 reg = findreg(retregs & XMMREGS);
@@ -5058,7 +5058,7 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
             {
                 retregs = IDXREGS;                             // get an index reg
                 reg_t reg;
-                allocreg(cdb, &retregs, &reg, TYoffset);
+                allocreg(cdb, retregs, reg, TYoffset);
                 genregs(cdb, 0x89, SP, reg);         // MOV reg,SP
                 pop87();
                 cdb.gen2(op, modregrm(0, r, regtorm[reg]));       // FSTP [reg]
@@ -5116,7 +5116,7 @@ void offsetinreg(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
     }
 
     *pretregs = retregs;
-    allocreg(cdb, pretregs, &reg, TYoffset);
+    allocreg(cdb, *pretregs, reg, TYoffset);
     getoffset(cdb,e,reg);
 L3:
     cssave(e, *pretregs,false);
@@ -5211,13 +5211,13 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
         {
             if (!I16 && (tym == TYfloat || tym == TYifloat))
             {
-                allocreg(cdb, &regm, &reg, TYoffset);   // get a register
+                allocreg(cdb, regm, reg, TYoffset);   // get a register
                 loadea(cdb, e, &cs, 0x8B, reg, 0, 0, 0);    // MOV reg,data
                 cdb.gen2(0xD1,modregrmx(3,4,reg));           // SHL reg,1
             }
             else if (I64 && (tym == TYdouble || tym ==TYidouble))
             {
-                allocreg(cdb, &regm, &reg, TYoffset);   // get a register
+                allocreg(cdb, regm, reg, TYoffset);   // get a register
                 loadea(cdb, e,&cs, 0x8B, reg, 0, 0, 0);    // MOV reg,data
                 // remove sign bit, so that -0.0 == 0.0
                 cdb.gen2(0xD1, modregrmx(3, 4, reg));           // SHL reg,1
@@ -5225,7 +5225,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
             }
             else if (TARGET_OSX && e.Eoper == OPvar && movOnly(e))
             {
-                allocreg(cdb, &regm, &reg, TYoffset);   // get a register
+                allocreg(cdb, regm, reg, TYoffset);   // get a register
                 loadea(cdb, e, &cs, 0x8B, reg, 0, 0, 0);    // MOV reg,data
                 fixresult(cdb, e, regm, outretregs);
             }
@@ -5252,7 +5252,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
         }
         else if (sz < 8)
         {
-            allocreg(cdb, &regm, &reg, TYoffset);  // get a register
+            allocreg(cdb, regm, reg, TYoffset);  // get a register
             if (I32)                                    // it's a 48 bit pointer
                 loadea(cdb, e, &cs, MOVZXw, reg, REGSIZE, 0, 0); // MOVZX reg,data+4
             else
@@ -5265,7 +5265,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
         }
         else if (sz == 8 || (I64 && sz == 2 * REGSIZE && !tyfloating(tym)))
         {
-            allocreg(cdb, &regm, &reg, TYoffset);       // get a register
+            allocreg(cdb, regm, reg, TYoffset);       // get a register
             int i = sz - REGSIZE;
             loadea(cdb, e, &cs, 0x8B, reg, i, 0, 0);        // MOV reg,data+6
             if (tyfloating(tym))                             // TYdouble or TYdouble_alias
@@ -5299,7 +5299,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
         {
             assert(!flags);
             reg_t xreg;
-            allocreg(cdb, &forregs, &xreg, tym);     // allocate registers
+            allocreg(cdb, forregs, xreg, tym);     // allocate registers
             movxmmconst(cdb, xreg, tym, &e.EV, flags);
             fixresult(cdb, e, forregs, outretregs);
             return;
@@ -5313,7 +5313,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
             forregs = mask(reg);
 
         regm_t save = regcon.immed.mval;
-        allocreg(cdb, &forregs, &reg, tym);        // allocate registers
+        allocreg(cdb, forregs, reg, tym);        // allocate registers
         regcon.immed.mval = save;               // allocreg could unnecessarily clear .mval
         if (sz <= REGSIZE)
         {
@@ -5374,7 +5374,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
                      */
                     reg_t r;
                     regm_t rm = ALLREGS;
-                    allocreg(cdb, &rm, &r, TYint);    // allocate scratch register
+                    allocreg(cdb, rm, r, TYint);    // allocate scratch register
                     movregconst(cdb, r, p[0], 0);
                     cdb.genfltreg(0x89, r, 0);               // MOV floatreg,r
                     movregconst(cdb, r, p[1], 0);
@@ -5439,7 +5439,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
             }
         }
 
-        allocreg(cdb, &forregs, &reg, tym);            // allocate registers
+        allocreg(cdb, forregs, reg, tym);            // allocate registers
 
         if (sz == 1)
         {   regm_t nregm;
@@ -5475,7 +5475,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
                 if (outretregs & nregm)
                     nreg = reg;                             // already allocated
                 else
-                    allocreg(cdb, &nregm, &nreg, tym);
+                    allocreg(cdb, nregm, nreg, tym);
                 loadea(cdb, e, &cs, opmv, nreg, 0, 0, 0);    // MOV nregL,data
                 if (reg != nreg)
                 {

--- a/compiler/src/dmd/backend/cod3.d
+++ b/compiler/src/dmd/backend/cod3.d
@@ -1708,7 +1708,7 @@ void doswitch(ref CodeBuilder cdb, block *b)
             // See if we need a scratch register
             if (sreg == NOREG && I64 && sz == 8 && val != cast(int)val)
             {   regm_t regm = ALLREGS & ~mask(reg);
-                allocreg(cdb,&regm, &sreg, TYint);
+                allocreg(cdb,regm, sreg, TYint);
             }
         }
 
@@ -1793,10 +1793,10 @@ void doswitch(ref CodeBuilder cdb, block *b)
                  */
                 reg_t r1;
                 regm_t scratchm = ALLREGS & ~mask(reg);
-                allocreg(cdb,&scratchm,&r1,TYint);
+                allocreg(cdb,scratchm,r1,TYint);
                 reg_t r2;
                 scratchm = ALLREGS & ~(mask(reg) | mask(r1));
-                allocreg(cdb,&scratchm,&r2,TYint);
+                allocreg(cdb,scratchm,r2,TYint);
 
                 CodeBuilder cdbe; cdbe.ctor();
                 cdbe.genc1(LEA,(REX_W << 16) | modregxrm(0,r1,5),FLswitch,0);        // LEA R1,disp[RIP]
@@ -1852,7 +1852,7 @@ static if (JMPJMPTABLE)
             // Allocate scratch register jreg
             regm_t scratchm = ALLREGS & ~mask(reg);
             uint jreg = AX;
-            allocreg(cdb,&scratchm,&jreg,TYint);
+            allocreg(cdb,scratchm,jreg,TYint);
 
             // LEA jreg, offset ctable[reg][reg*4]
             cdb.genc1(LEA,modregrm(2,jreg,4),FLcode,6);
@@ -1875,7 +1875,7 @@ else
             // Allocate scratch register r1
             regm_t scratchm = ALLREGS & ~mask(reg);
             reg_t r1;
-            allocreg(cdb,&scratchm,&r1,TYint);
+            allocreg(cdb,scratchm,r1,TYint);
 
             cdb.genc2(CALL,0,0);                           //     CALL L1
             cdb.gen1(0x58 + r1);                           // L1: POP R1
@@ -1899,7 +1899,7 @@ else
                 // Allocate scratch register r1
                 regm_t scratchm = ALLREGS & ~(mask(reg) | mBX);
                 reg_t r1;
-                allocreg(cdb,&scratchm,&r1,TYint);
+                allocreg(cdb,scratchm,r1,TYint);
 
                 genmovreg(cdb,r1,BX);              // MOV R1,EBX
                 cdb.genc1(0x2B,modregxrm(2,r1,4),FLswitch,0);   // SUB R1,disp[reg*4][EBX]
@@ -2405,7 +2405,7 @@ void cod3_ptrchk(ref CodeBuilder cdb,code *pcs,regm_t keepmsk)
         // Load the offset into a register, so we can push the address
         regm_t idxregs2 = (I16 ? IDXREGS : ALLREGS) & ~keepmsk; // only these can be index regs
         assert(idxregs2);
-        allocreg(cdb,&idxregs2,&reg,TYoffset);
+        allocreg(cdb,idxregs2,reg,TYoffset);
 
         const opsave = pcs.Iop;
         flagsave = pcs.Iflags;
@@ -2682,7 +2682,7 @@ void cdframeptr(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     if  (!retregs)
         retregs = allregs;
     reg_t reg;
-    allocreg(cdb,&retregs, &reg, TYint);
+    allocreg(cdb,retregs, reg, TYint);
 
     code cs;
     cs.Iop = ESCAPE | ESCframeptr;
@@ -2707,7 +2707,7 @@ void cdgot(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         if  (!retregs)
             retregs = allregs;
         reg_t reg;
-        allocreg(cdb,&retregs, &reg, TYnptr);
+        allocreg(cdb,retregs, reg, TYnptr);
 
         cdb.genc(CALL,0,0,0,FLgot,0);     //     CALL L1
         cdb.gen1(0x58 + reg);             // L1: POP reg
@@ -2720,7 +2720,7 @@ void cdgot(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         if  (!retregs)
             retregs = allregs;
         reg_t reg;
-        allocreg(cdb,&retregs, &reg, TYnptr);
+        allocreg(cdb,retregs, reg, TYnptr);
 
         cdb.genc2(CALL,0,0);        //     CALL L1
         cdb.gen1(0x58 + reg);       // L1: POP reg

--- a/compiler/src/dmd/backend/cod4.d
+++ b/compiler/src/dmd/backend/cod4.d
@@ -1102,7 +1102,7 @@ void cdaddass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                 if (sregm & forregs)
                     sregm &= forregs;
 
-                allocreg(cdb,&sregm,&reg,tyml);      // allocate register
+                allocreg(cdb,sregm,reg,tyml);      // allocate register
 
                 cs2 = cs;
                 cs2.Iflags &= ~CFpsw;
@@ -1298,7 +1298,7 @@ void cdaddass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                 if (cs.Irex & REX_R)
                     reg |= 8;
                 retregs = mask(reg);
-                allocreg(cdb,&retregs,&reg,tyml);
+                allocreg(cdb,retregs,reg,tyml);
             }
             // If lvalue is a register, just use that register
             else if ((cs.Irm & 0xC0) == 0xC0)
@@ -1307,11 +1307,11 @@ void cdaddass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                 if (cs.Irex & REX_B)
                     reg |= 8;
                 retregs = mask(reg);
-                allocreg(cdb,&retregs,&reg,tyml);
+                allocreg(cdb,retregs,reg,tyml);
             }
             else
             {
-                allocreg(cdb,&retregs,&reg,tyml);
+                allocreg(cdb,retregs,reg,tyml);
                 cs.Iop = LOD ^ isbyte ^ reverse;
                 code_newreg(&cs, reg);
                 if (I64 && isbyte && reg >= 4)
@@ -1331,7 +1331,7 @@ void cdaddass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                 retregs |= IDXREGS & ~idxregs;
             if (!(retregs & mMSW))
                 retregs |= mMSW & ALLREGS;
-            allocreg(cdb,&retregs,&reg,tyml);
+            allocreg(cdb,retregs,reg,tyml);
             NEWREG(cs.Irm,findreglsw(retregs));
             if (retregs & mES)              // if want ES loaded
             {
@@ -1355,7 +1355,7 @@ void cdaddass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             retregs = forregs;
             if (!retregs)
                 retregs = ALLREGS;
-            allocreg(cdb,&retregs,&reg,tyml);
+            allocreg(cdb,retregs,reg,tyml);
             cs.Iop = LOD;
             NEWREG(cs.Irm,reg);
 
@@ -1472,7 +1472,7 @@ void cdmulass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                     if (!regm)
                         regm = allregs & ~(idxregs | mBP | mR13);
                     reg_t reg;
-                    allocreg(cdb,&regm,&reg,tyml);
+                    allocreg(cdb,regm,reg,tyml);
                     cs.Iop = LOD;
                     code_newreg(&cs,reg);
                     cs.Irex |= rex;
@@ -1513,7 +1513,7 @@ void cdmulass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                     if (!regm)
                         regm = allregs & ~(idxregs | mBP | mR13);
                     reg_t reg;                          // return register
-                    allocreg(cdb,&regm,&reg,tyml);
+                    allocreg(cdb,regm,reg,tyml);
 
                     reg_t sreg = allocScratchReg(cdb, allregs & ~(regm | idxregs | mBP | mR13));
 
@@ -1558,7 +1558,7 @@ void cdmulass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             retregs = *pretregs & (ALLREGS | mBP) & ~idxregs;
             if (!retregs)
                 retregs = ALLREGS & ~idxregs;
-            allocreg(cdb,&retregs,&resreg,tyml);
+            allocreg(cdb,retregs,resreg,tyml);
             cs.Iop = 0x69;                  // IMUL reg,EA,e2value
             cs.IFL2 = FLconst;
             cs.IEV2.Vint = cast(int)e2factor;
@@ -1888,7 +1888,7 @@ void cddivass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                     if (!el_signx32(e2))
                         regm3 &= ~mAX;
                 }
-                allocreg(cdb,&regm3,&r3,TYint);
+                allocreg(cdb,regm3,r3,TYint);
                 cdb.gen2sib(LEA,grex | modregxrm(0,r3,4),modregrm(0,AX,DX)); // LEA R3,[EAX][EDX]
                 if (shpost != 1)
                     cdb.genc2(0xC1,grex | modregrmx(3,5,r3),shpost-1);   // SHR R3,shpost-1
@@ -2215,7 +2215,7 @@ void cddivass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         {
             scratchm = allregs & ~(retregs | scratchm);
             reg_t r2;
-            allocreg(cdb,&scratchm,&r2,TYint);
+            allocreg(cdb,scratchm,r2,TYint);
 
             cdb.genmovreg(r1,rhi);                                      // MOV  r1,rhi
             cdb.genc2(0xC1,grex | modregrmx(3,7,r1),REGSIZE * 8 - 1);   // SAR  r1,31
@@ -2415,7 +2415,7 @@ void cdshass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             if (retregs)
             {
                 retregs &= ~idxregm(&cs);
-                allocreg(cdb,&retregs,&reg,tym);
+                allocreg(cdb,retregs,reg,tym);
                 cs.Iop = LOD;
 
                 // be careful not to trash any index regs
@@ -2433,7 +2433,7 @@ void cdshass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             else        // flags only
             {
                 retregs = ALLREGS & ~idxregm(&cs);
-                allocreg(cdb,&retregs,&reg,TYint);
+                allocreg(cdb,retregs,reg,TYint);
                 cs.Iop = LOD;
                 NEWREG(cs.Irm,reg);
                 cdb.gen(&cs);           // MOV reg,EA
@@ -2459,7 +2459,7 @@ void cdshass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             retregs = *pretregs & possregs;
             if (retregs == 0)
                 retregs = possregs;
-            allocreg(cdb,&retregs,&reg,tym);
+            allocreg(cdb,retregs,reg,tym);
             cs.Iop = LOD ^ isbyte;
             code_newreg(&cs, reg);
             if (isbyte && I64 && (reg >= 4))
@@ -3111,7 +3111,7 @@ L3:
                 if (!resregs)
                     resregs = BYTEREGS;
             }
-            allocreg(cdb,&resregs,&reg,TYint);
+            allocreg(cdb,resregs,reg,TYint);
             cdb.gen2(0x0F90 + (jop & 0x0F),modregrmx(3,0,reg)); // SETcc reg
             if (I64 && reg >= 4)
                 code_orrex(cdb.last(),REX);
@@ -3130,7 +3130,7 @@ L3:
         {
             code *nop = null;
             regm_t save = regcon.immed.mval;
-            allocreg(cdb,&retregs,&reg,TYint);
+            allocreg(cdb,retregs,reg,TYint);
             regcon.immed.mval = save;
             if ((*pretregs & mPSW) == 0 &&
                 (jop == JC || jop == JNC))
@@ -3320,7 +3320,7 @@ void longcmp(ref CodeBuilder cdb,elem *e,bool jcond,uint fltarg,code *targ)
                 freenode(e1);
                 reg = findreg(retregs);
                 retregs = allregs & ~retregs;
-                allocreg(cdb,&retregs,&msreg,TYint);
+                allocreg(cdb,retregs,msreg,TYint);
                 genmovreg(cdb,msreg,reg);                  // MOV msreg,reg
                 cdb.genc2(0xC1,modregrm(3,7,msreg),REGSIZE * 8 - 1);    // SAR msreg,31
                 cse_flush(cdb,1);
@@ -3610,7 +3610,7 @@ void cdshtlng(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         regm_t regm = *pretregs & (mMSW & ALLREGS);
         if (regm == 0)                  // *pretregs could be mES
             regm = mMSW & ALLREGS;
-        allocreg(cdb,&regm,&reg,TYint);
+        allocreg(cdb,regm,reg,TYint);
         if (e1comsub)
             getregs(cdb,retregsx);
         if (op == OPnp_fp)
@@ -3642,7 +3642,7 @@ void cdshtlng(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         {
             code cs;
 
-            allocreg(cdb,&retregs,&reg,TYint);
+            allocreg(cdb,retregs,reg,TYint);
             loadea(cdb,e1,&cs,LOD,reg,0,retregs,retregs);  //  MOV Ereg,EA
             freenode(e1);
         }
@@ -3692,7 +3692,7 @@ void cdshtlng(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             retregs = *pretregs & BYTEREGS;
             if (!retregs)
                 retregs = BYTEREGS;
-            allocreg(cdb,&retregs,&reg,TYint);
+            allocreg(cdb,retregs,reg,TYint);
             movregconst(cdb,reg,0,0);                   //  XOR reg,reg
             loadea(cdb,e11,&cs,0x8A,reg,0,retregs,retregs);  //  MOV regL,EA
             freenode(e11);
@@ -3706,7 +3706,7 @@ void cdshtlng(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             if (I32 && op == OPu16_32 && config.flags4 & CFG4speed)
                 goto L2;
             retregs = *pretregs;
-            allocreg(cdb,&retregs,&reg,TYint);
+            allocreg(cdb,retregs,reg,TYint);
             const opcode = (op == OPu16_32) ? MOVZXw : MOVSXw; // MOVZX/MOVSX reg,EA
             if (op == OPs32_64)
             {
@@ -3797,7 +3797,7 @@ void cdshtlng(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         assert(retregs);
         codelem(cdb,e.EV.E1,&retregs,false);
         retregs |= *pretregs & mMSW;
-        allocreg(cdb,&retregs,&reg,e.Ety);
+        allocreg(cdb,retregs,reg,e.Ety);
         msreg = findregmsw(retregs);
         lsreg = findreglsw(retregs);
         genmovreg(cdb,msreg,lsreg);                // MOV msreg,lsreg
@@ -3839,7 +3839,7 @@ void cdbyteint(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 
             regm_t retregsx = *pretregs;
             reg_t reg;
-            allocreg(cdb,&retregsx,&reg,TYint);
+            allocreg(cdb,retregsx,reg,TYint);
             if (config.flags4 & CFG4speed &&
                 op == OPu8_16 && mask(reg) & BYTEREGS &&
                 config.target_cpu < TARGET_PentiumPro)
@@ -4158,7 +4158,7 @@ void cdfar16(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         reg_t rx;
 
         regm_t retregs = BYTEREGS & ~*pretregs;
-        allocreg(cdb,&retregs,&rx,TYint);
+        allocreg(cdb,retregs,rx,TYint);
         cnop = gennop(null);
         int jop = JCXZ;
         if (reg != CX)
@@ -4294,7 +4294,7 @@ void cdbtst(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         if (tysize(e.Ety) == 1)
         {
             assert(I64 || retregs & BYTEREGS);
-            allocreg(cdb,&retregs,&reg,TYint);
+            allocreg(cdb,retregs,reg,TYint);
             cdb.gen2(0x0F92,modregrmx(3,0,reg));        // SETC reg
             if (I64 && reg >= 4)
                 code_orrex(cdb.last(), REX);
@@ -4304,7 +4304,7 @@ void cdbtst(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         {
             code *cnop = null;
             regm_t save = regcon.immed.mval;
-            allocreg(cdb,&retregs,&reg,TYint);
+            allocreg(cdb,retregs,reg,TYint);
             regcon.immed.mval = save;
             if ((*pretregs & mPSW) == 0)
             {
@@ -4413,7 +4413,7 @@ void cdbt(ref CodeBuilder cdb,elem *e, regm_t *pretregs)
         if (_tysize[e.Ety] == 1)
         {
             assert(I64 || retregs & BYTEREGS);
-            allocreg(cdb,&retregs,&reg,TYint);
+            allocreg(cdb,retregs,reg,TYint);
             cdb.gen2(0x0F92,modregrmx(3,0,reg));        // SETC reg
             if (I64 && reg >= 4)
                 code_orrex(cdb.last(), REX);
@@ -4423,7 +4423,7 @@ void cdbt(ref CodeBuilder cdb,elem *e, regm_t *pretregs)
         {
             code *cnop = null;
             const save = regcon.immed.mval;
-            allocreg(cdb,&retregs,&reg,TYint);
+            allocreg(cdb,retregs,reg,TYint);
             regcon.immed.mval = save;
             if ((*pretregs & mPSW) == 0)
             {
@@ -4486,7 +4486,7 @@ void cdbscan(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     if  (!retregs)
         retregs = allregs;
     reg_t reg;
-    allocreg(cdb,&retregs, &reg, e.Ety);
+    allocreg(cdb,retregs, reg, e.Ety);
 
     cs.Iop = (e.Eoper == OPbsf) ? 0x0FBC : 0x0FBD;        // BSF/BSR reg,EA
     code_newreg(&cs, reg);
@@ -4541,7 +4541,7 @@ void cdpopcnt(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     if  (!retregs)
         retregs = allregs;
     reg_t reg;
-    allocreg(cdb,&retregs, &reg, e.Ety);
+    allocreg(cdb,retregs, reg, e.Ety);
 
     cs.Iop = POPCNT;            // POPCNT reg,EA
     code_newreg(&cs, reg);
@@ -4711,7 +4711,7 @@ void cdcmpxchg(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         assert(tysize(e.Ety) == 1);
         assert(I64 || retregs & BYTEREGS);
         reg_t reg;
-        allocreg(cdb,&retregs,&reg,TYint);
+        allocreg(cdb,retregs,reg,TYint);
         uint ea = modregrmx(3,0,reg);
         if (I64 && reg >= 4)
             ea |= REX << 16;
@@ -4778,7 +4778,7 @@ private
 void opAssLoadReg(ref CodeBuilder cdb, ref code cs, elem* e, out reg_t reg, regm_t retregs)
 {
     modEA(cdb, &cs);
-    allocreg(cdb,&retregs,&reg,TYoffset);
+    allocreg(cdb,retregs,reg,TYoffset);
 
     cs.Iop = LOD;
     code_newreg(&cs,reg);
@@ -4803,7 +4803,7 @@ void opAssLoadPair(ref CodeBuilder cdb, ref code cs, elem* e, out reg_t rhi, out
     getlvalue(cdb,&cs,e.EV.E1,retregs | keepmsk);
     const tym_t tyml = tybasic(e.EV.E1.Ety);              // type of lvalue
     reg_t reg;
-    allocreg(cdb,&retregs,&reg,tyml);
+    allocreg(cdb,retregs,reg,tyml);
 
     rhi = findregmsw(retregs);
     rlo = findreglsw(retregs);


### PR DESCRIPTION
Seems like it makes sense to just return `outreg` since it's a void method.  A more substantial change, but probably wouldn't be too bad to do by adding a temporary overload.