### PR TITLE
update usages of allocreg to use the newer API

### DIFF
--- a/compiler/src/dmd/backend/cg87.d
+++ b/compiler/src/dmd/backend/cg87.d
@@ -852,8 +852,7 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs, ref regm_t outretre
         pop87();
         cdb.genfltreg(ESC(mf,1),3,0);
         genfwait(cdb);
-        reg_t reg;
-        allocreg(cdb,outretregs,reg,(sz == FLOATSIZE) ? TYfloat : TYdouble);
+        reg_t reg = allocreg(cdb,outretregs,(sz == FLOATSIZE) ? TYfloat : TYdouble);
         if (sz == FLOATSIZE)
         {
             if (!I16)
@@ -918,8 +917,7 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs, ref regm_t outretre
             cdb.genfltreg(ESC(mf,1),3,0);
             genfwait(cdb);
             // MOVD XMM?,floatreg
-            reg_t reg;
-            allocreg(cdb,outretregs,reg,(sz == FLOATSIZE) ? TYfloat : TYdouble);
+            reg_t reg = allocreg(cdb,outretregs,(sz == FLOATSIZE) ? TYfloat : TYdouble);
             cdb.genxmmreg(xmmload(tym),reg,0,tym);
         }
         else
@@ -2974,10 +2972,9 @@ private void cdd_u64_I32(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     retregs = *pretregs;
     if (!retregs)
         retregs = ALLREGS;
-    reg_t reg, reg2;
-    allocreg(cdb,retregs,reg,tym);
+    reg_t reg = allocreg(cdb,retregs,tym);
     reg  = findreglsw(retregs);
-    reg2 = findregmsw(retregs);
+    reg_t reg2 = findregmsw(retregs);
     movregconst(cdb,reg2,0x80000000,0);
     getregs(cdb,mask(reg2) | mAX);
 
@@ -3059,11 +3056,9 @@ private void cdd_u64_I64(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     retregs = *pretregs;
     if (!retregs)
         retregs = ALLREGS;
-    reg_t reg;
-    allocreg(cdb,retregs,reg,tym);
+    reg_t reg = allocreg(cdb,retregs,tym);
     regm_t regm2 = ALLREGS & ~retregs & ~mAX;
-    reg_t reg2;
-    allocreg(cdb,regm2,reg2,tym);
+    reg_t reg2 = allocreg(cdb,regm2,tym);
     movregconst(cdb,reg2,0x80000000,0);
     getregs(cdb,mask(reg2) | mAX);
 
@@ -3133,8 +3128,7 @@ void cdd_u32(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     retregs = *pretregs & ALLREGS;
     if (!retregs)
         retregs = ALLREGS;
-    reg_t reg;
-    allocreg(cdb,retregs,reg,tym);
+    reg_t reg = allocreg(cdb,retregs,tym);
 
     cdb.genfltreg(0xC7,0,8);
     code *cf3 = cdb.last();
@@ -3261,7 +3255,7 @@ void cnvt87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         retregs = *pretregs & (ALLREGS | mBP);
         if (!retregs)
                 retregs = ALLREGS;
-        allocreg(cdb,retregs,reg,tym);
+        reg = allocreg(cdb,retregs,tym);
 
         genfwait(cdb);                                           // FWAIT
         cdb.genc1(0xD9,modregrm(2,5,4) + 256*modregrm(0,4,SP),FLconst,szoff); // FLDCW szoff[ESP]
@@ -3293,7 +3287,7 @@ void cnvt87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         retregs = *pretregs & (ALLREGS | mBP);
         if (!retregs)
                 retregs = ALLREGS;
-        allocreg(cdb,retregs,reg,tym);
+        reg = allocreg(cdb,retregs,tym);
 
         genfwait(cdb);
 
@@ -3350,8 +3344,7 @@ void cdrndtol(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     retregs = *pretregs & (ALLREGS | mBP);
     if (!retregs)
         retregs = ALLREGS;
-    reg_t reg;
-    allocreg(cdb,retregs,reg,tym);
+    reg_t reg = allocreg(cdb,retregs,tym);
     genfwait(cdb);                      // FWAIT
     if (tysize(tym) > REGSIZE)
     {

--- a/compiler/src/dmd/backend/cgcod.d
+++ b/compiler/src/dmd/backend/cgcod.d
@@ -1638,12 +1638,6 @@ static if (0)
  * Returns:
  *      Register number of first allocated register
  */
-
-void allocreg(ref CodeBuilder cdb,ref regm_t outretregs,out reg_t outreg,tym_t tym)
-{
-    outreg = allocreg(cdb, outretregs, tym, __LINE__, __FILE__);
-}
-
 reg_t allocreg(ref CodeBuilder cdb,ref regm_t outretregs,tym_t tym){
     return allocreg(cdb, outretregs, tym, __LINE__, __FILE__);
 }
@@ -1840,9 +1834,7 @@ L3:
 @trusted
 reg_t allocScratchReg(ref CodeBuilder cdb, regm_t regm)
 {
-    reg_t r;
-    allocreg(cdb, regm, r, TYoffset);
-    return r;
+    return allocreg(cdb, regm, TYoffset);
 }
 
 
@@ -2238,7 +2230,7 @@ private void comsub(ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
                     retregs = BYTEREGS;
                 else if (!(retregs & allregs))
                     retregs = allregs;
-                allocreg(cdb,retregs,reg,tym);
+                reg = allocreg(cdb,retregs,tym);
                 code *cr = &cse.csimple;
                 cr.setReg(reg);
                 if (I64 && reg >= 4 && tysize(cse.e.Ety) == 1)
@@ -2255,7 +2247,7 @@ private void comsub(ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
                     if (config.fpxmmregs && (tyxmmreg(cse.e.Ety) || tyvector(cse.e.Ety)))
                     {
                         retregs = XMMREGS;
-                        allocreg(cdb,retregs,reg,tym);
+                        reg = allocreg(cdb,retregs,tym);
                         gen_loadcse(cdb, cse.e.Ety, reg, cse.slot);
                         regcon.cse.mval |= mask(reg); // cs is in a reg
                         regcon.cse.value[reg] = e;
@@ -2272,7 +2264,7 @@ private void comsub(ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
                     retregs = pretregs;
                     if (byte_ && !(retregs & BYTEREGS))
                         retregs = BYTEREGS;
-                    allocreg(cdb,retregs,reg,tym);
+                    reg = allocreg(cdb,retregs,tym);
                     gen_loadcse(cdb, cse.e.Ety, reg, cse.slot);
                 L10:
                     regcon.cse.mval |= mask(reg); // cs is in a reg
@@ -2320,7 +2312,7 @@ private void comsub(ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
         {
             if (!regm)
                 regm = mMSW & ALLREGS;
-            allocreg(cdb,regm,msreg,TYint);
+            msreg = allocreg(cdb,regm,TYint);
             loadcse(cdb,e,msreg,mMSW);
         }
 
@@ -2333,7 +2325,7 @@ private void comsub(ref CodeBuilder cdb,elem *e, ref regm_t pretregs)
         {
             if (!regm)
                 regm = mLSW;
-            allocreg(cdb,regm,lsreg,TYint);
+            lsreg = allocreg(cdb,regm,TYint);
             loadcse(cdb,e,lsreg,mLSW | mBP);
         }
 

--- a/compiler/src/dmd/backend/cgen.d
+++ b/compiler/src/dmd/backend/cgen.d
@@ -242,7 +242,7 @@ void regwithvalue(ref CodeBuilder cdb,regm_t regm,targ_size_t value, out reg_t p
         return; // already have a register with the right value in it
 
     regm_t save = regcon.immed.mval;
-    allocreg(cdb,regm,preg,TYint);  // allocate register
+    preg = allocreg(cdb,regm,TYint);  // allocate register
     regcon.immed.mval = save;
     movregconst(cdb,preg,value,flags);   // store value into reg
 }

--- a/compiler/src/dmd/backend/cgxmm.d
+++ b/compiler/src/dmd/backend/cgxmm.d
@@ -114,9 +114,8 @@ void movxmmconst(ref CodeBuilder cdb, reg_t xreg, tym_t ty, eve* pev, regm_t fla
 
     if (I32 && sz == 8)
     {
-        reg_t r;
         regm_t rm = ALLREGS;
-        allocreg(cdb,rm,r,TYint);         // allocate scratch register
+        reg_t r = allocreg(cdb,rm,TYint);         // allocate scratch register
         static union U { targ_size_t s; targ_long[2] l; }
         U u = void;
         u.l[1] = 0;
@@ -187,9 +186,8 @@ void orthxmm(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         if (e.Eoper == OPmin)
         {
             regm_t nretregs = XMMREGS & ~retregs;
-            reg_t sreg; // hold sign bit
+            reg_t sreg = allocreg(cdb,nretregs,e2.Ety); // hold sign bit
             const uint sz = tysize(e1.Ety);
-            allocreg(cdb,nretregs,sreg,e2.Ety);
             eve signbit;
             signbit.Vint = 0x80000000;
             if (sz == 8)
@@ -510,8 +508,7 @@ void xmmcnvt(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             retregs = ALLREGS;
     }
 
-    reg_t rreg;
-    allocreg(cdb,retregs,rreg,ty);
+    reg_t rreg = allocreg(cdb,retregs,ty);
     if (isXMMreg(rreg))
         rreg -= XMM0;
 
@@ -567,7 +564,7 @@ void xmmopass(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         retregs = *pretregs & XMMREGS & ~rretregs;
         if (!retregs)
             retregs = XMMREGS & ~rretregs;
-        allocreg(cdb,retregs,reg,ty1);
+        reg = allocreg(cdb,retregs,ty1);
         cs.Iop = xmmload(ty1, true);            // MOVSD xmm,xmm_m64
         code_newreg(&cs,reg - XMM0);
         cdb.gen(&cs);
@@ -636,7 +633,7 @@ void xmmpost(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         retregs = XMMREGS & ~*pretregs;
         if (!retregs)
             retregs = XMMREGS;
-        allocreg(cdb,retregs,reg,ty1);
+        reg = allocreg(cdb,retregs,ty1);
         cs.Iop = xmmload(ty1, true);            // MOVSD xmm,xmm_m64
         code_newreg(&cs,reg - XMM0);
         cdb.gen(&cs);
@@ -647,8 +644,7 @@ void xmmpost(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     regm_t resultregs = XMMREGS & *pretregs & ~retregs;
     if (!resultregs)
         resultregs = XMMREGS & ~retregs;
-    reg_t resultreg;
-    allocreg(cdb,resultregs, resultreg, ty1);
+    reg_t resultreg = allocreg(cdb,resultregs, ty1);
 
     cdb.gen2(xmmload(ty1,true),modregxrmx(3,resultreg-XMM0,reg-XMM0));   // MOVSS/D resultreg,reg
     checkSetVex(cdb.last(), ty1);
@@ -709,8 +705,7 @@ void xmmneg(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     getregs(cdb,retregs);
     const reg = findreg(retregs);
     regm_t rretregs = XMMREGS & ~retregs;
-    reg_t rreg;
-    allocreg(cdb,rretregs,rreg,tyml);
+    reg_t rreg = allocreg(cdb,rretregs,tyml);
 
     eve signbit;
     signbit.Vint = 0x80000000;
@@ -751,8 +746,7 @@ void xmmabs(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     getregs(cdb,retregs);
     const reg = findreg(retregs);
     regm_t rretregs = XMMREGS & ~retregs;
-    reg_t rreg;
-    allocreg(cdb,rretregs,rreg,tyml);
+    reg_t rreg = allocreg(cdb,rretregs,tyml);
 
     eve mask;
     mask.Vint = 0x7FFF_FFFF;
@@ -1298,8 +1292,7 @@ static if (0)
         retregs = *pretregs & XMMREGS;
         if (!retregs)
             retregs = XMMREGS;
-        reg_t reg;
-        allocreg(cdb,retregs, reg, e.Ety);
+        reg_t reg = allocreg(cdb,retregs, e.Ety);
         code_newreg(&cs, reg - XMM0);
         cs.Iop = op;
         cdb.gen(&cs);
@@ -1485,8 +1478,7 @@ static if (0)
                 // VBROADCASTSS X/YMM,MEM
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
-                reg_t reg;
-                allocreg(cdb,retregs,reg,ty);
+                reg_t reg = allocreg(cdb,retregs,ty);
                 cs.Iop = VBROADCASTSS;
                 cs.Irex &= ~REX_W;
                 code_newreg(&cs,reg - XMM0);
@@ -1526,8 +1518,7 @@ static if (0)
                 // VBROADCASTSD YMM,MEM
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
-                reg_t reg;
-                allocreg(cdb,retregs,reg,ty);
+                reg_t reg = allocreg(cdb,retregs,ty);
                 cs.Iop = VBROADCASTSD;
                 cs.Irex &= ~REX_W;
                 code_newreg(&cs,reg - XMM0);
@@ -1569,8 +1560,7 @@ static if (0)
                 // VPBROADCASTB X/YMM,MEM
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
-                reg_t reg;
-                allocreg(cdb,retregs,reg,ty);
+                reg_t reg = allocreg(cdb,retregs,ty);
                 cs.Iop = VPBROADCASTB;
                 cs.Irex &= ~REX_W;
                 code_newreg(&cs,reg - XMM0);
@@ -1583,8 +1573,7 @@ static if (0)
                 codelem(cdb,e1,&regm,true); // eval left leaf
                 const r = findreg(regm);
 
-                reg_t reg;
-                allocreg(cdb,retregs,reg, e.Ety);
+                reg_t reg = allocreg(cdb,retregs, e.Ety);
                 reg -= XMM0;
                 // (V)MOVD reg,r
                 cdb.gen2(LODD,modregxrmx(3,reg,r));
@@ -1599,10 +1588,9 @@ static if (0)
                 {
                     if (config.avx)
                     {
-                        reg_t zeroreg;
                         regm = XMMREGS & ~retregs;
                         // VPXOR XMM1,XMM1,XMM1
-                        allocreg(cdb,regm,zeroreg, ty);
+                        reg_t zeroreg = allocreg(cdb,regm, ty);
                         zeroreg -= XMM0;
                         cdb.gen2(PXOR, modregxrmx(3,zeroreg,zeroreg));
                         checkSetVex(cdb.last(), TYuchar16); // AVX-128
@@ -1638,8 +1626,7 @@ static if (0)
                 // VPBROADCASTW X/YMM,MEM
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
-                reg_t reg;
-                allocreg(cdb,retregs,reg,ty);
+                reg_t reg = allocreg(cdb,retregs,ty);
                 cs.Iop = VPBROADCASTW;
                 cs.Irex &= ~REX_W;
                 cs.Iflags &= ~CFopsize;
@@ -1653,8 +1640,7 @@ static if (0)
                 codelem(cdb,e1,&regm,true); // eval left leaf
                 reg_t r = findreg(regm);
 
-                reg_t reg;
-                allocreg(cdb,retregs,reg, e.Ety);
+                reg_t reg = allocreg(cdb,retregs, e.Ety);
                 reg -= XMM0;
                 // (V)MOVD reg,r
                 cdb.gen2(LODD,modregxrmx(3,reg,r));
@@ -1692,8 +1678,7 @@ static if (0)
                 // VPBROADCASTD/VBROADCASTSS X/YMM,MEM
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
-                reg_t reg;
-                allocreg(cdb,retregs,reg,ty);
+                reg_t reg = allocreg(cdb,retregs,ty);
                 cs.Iop = config.avx >= 2 ? VPBROADCASTD : VBROADCASTSS;
                 cs.Irex &= ~REX_W;
                 code_newreg(&cs,reg - XMM0);
@@ -1735,8 +1720,7 @@ static if (0)
                 // VPBROADCASTQ/VBROADCASTSD/(V)PUNPCKLQDQ X/YMM,MEM
                 getlvalue(cdb,&cs, e1, 0);         // get addressing mode
                 assert((cs.Irm & 0xC0) != 0xC0);   // AVX1 doesn't have register source operands
-                reg_t reg;
-                allocreg(cdb,retregs,reg,ty);
+                reg_t reg = allocreg(cdb,retregs,ty);
                 cs.Iop = config.avx >= 2 ? VPBROADCASTQ : tysize(ty) == 32 ? VBROADCASTSD : PUNPCKLQDQ;
                 cs.Irex &= ~REX_W;
                 code_newreg(&cs,reg - XMM0);
@@ -1945,14 +1929,12 @@ void cloadxmm(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         opcode_t opmv = xmmload(tym, xmmIsAligned(e));
 
         regm_t retregs0 = mXMM0;
-        reg_t reg0;
-        allocreg(cdb, retregs0, reg0, ty);
+        reg_t reg0 = allocreg(cdb, retregs0, ty);
         loadea(cdb, e, &cs, opmv, reg0, 0, RMload, 0);  // MOVSS/MOVSD XMM0,data
         checkSetVex(cdb.last(), ty);
 
         regm_t retregs1 = mXMM1;
-        reg_t reg1;
-        allocreg(cdb, retregs1, reg1, ty);
+        reg_t reg1 = allocreg(cdb, retregs1, ty);
         loadea(cdb, e, &cs, opmv, reg1, tysize(ty), RMload, mXMM0); // MOVSS/MOVSD XMM1,data+offset
         checkSetVex(cdb.last(), ty);
 

--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -438,8 +438,7 @@ void genstackclean(ref CodeBuilder cdb,uint numpara,regm_t keepmsk)
 
             if (scratchm)
             {
-                reg_t r;
-                allocreg(cdb, scratchm, r, TYint);
+                reg_t r = allocreg(cdb, scratchm, TYint);
                 cdb.gen1(0x58 + r);           // POP r
             }
             else
@@ -1032,10 +1031,9 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                         else
                         {
                             int rbase;
-                            reg_t r;
 
                             scratchm = ALLREGS & ~keepmsk;
-                            allocreg(cdb, scratchm, r, TYint);
+                            reg_t r = allocreg(cdb, scratchm, TYint);
 
                             if (ssflags & SSFLnobase1)
                             {
@@ -1142,16 +1140,14 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                     uint flagsave;
 
                     regm_t idxregs = IDXREGS & ~keepmsk;
-                    allocreg(cdb, idxregs, reg, TYoffset);
+                    reg = allocreg(cdb, idxregs, TYoffset);
 
                     /* If desired result is a far pointer, we'll have       */
                     /* to load another register with the segment of v       */
                     if (e1ty == TYfptr)
                     {
-                        reg_t msreg;
-
                         idxregs |= mMSW & ALLREGS & ~keepmsk;
-                        allocreg(cdb, idxregs, msreg, TYfptr);
+                        reg_t msreg = allocreg(cdb, idxregs, TYfptr);
                         msreg = findregmsw(idxregs);
                                                     /* MOV msreg,segreg     */
                         genregs(cdb, 0x8C, segfl[f], msreg);
@@ -1637,7 +1633,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
         Lfardata:
         {
             regm_t regm = ALLREGS & ~keepmsk;       // need scratch register
-            allocreg(cdb, regm, reg, TYint);
+            reg = allocreg(cdb, regm, TYint);
             getregs(cdb,mES);
             // MOV mreg,seg of symbol
             cdb.gencs(0xB8 + reg, 0, FLextern, s);
@@ -1746,9 +1742,8 @@ void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, uint saveflag)
     }
     if (regm & XMMREGS)
     {
-        reg_t xreg;
         regm_t xregs = XMMREGS & ~regm;
-        allocreg(cdb,xregs, xreg, TYdouble);
+        reg_t xreg = allocreg(cdb,xregs, TYdouble);
         opcode_t op = 0;
         if (tym == TYdouble || tym == TYidouble || tym == TYcdouble)
             op = 0x660000;
@@ -1773,7 +1768,7 @@ void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, uint saveflag)
                 if (saveflag)
                 {
                     scrregm = allregs & ~regm;              // possible scratch regs
-                    allocreg(cdb, scrregm, scrreg, TYoffset); // allocate scratch reg
+                    scrreg = allocreg(cdb, scrregm, TYoffset); // allocate scratch reg
                     genmovreg(cdb, scrreg, reg);  // MOV scrreg,msreg
                     reg = scrreg;
                 }
@@ -1796,7 +1791,7 @@ void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, uint saveflag)
     {
     L1:
         scrregm = ALLREGS & ~regm;              // possible scratch regs
-        allocreg(cdb, scrregm, scrreg, TYoffset); // allocate scratch reg
+        scrreg = allocreg(cdb, scrregm, TYoffset); // allocate scratch reg
         if (I32 || sz == REGSIZE * 2)
         {
             assert(regm & mMSW && regm & mLSW);
@@ -1958,7 +1953,7 @@ void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, ref regm_t outretre
         }
         else
         {
-            allocreg(cdb, outretregs, rreg, tym);  // allocate return regs
+            rreg = allocreg(cdb, outretregs, tym);  // allocate return regs
             if (retregs & XMMREGS)
             {
                 reg = findreg(retregs & XMMREGS);
@@ -5057,8 +5052,7 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
             else
             {
                 retregs = IDXREGS;                             // get an index reg
-                reg_t reg;
-                allocreg(cdb, retregs, reg, TYoffset);
+                reg_t reg = allocreg(cdb, retregs, TYoffset);
                 genregs(cdb, 0x89, SP, reg);         // MOV reg,SP
                 pop87();
                 cdb.gen2(op, modregrm(0, r, regtorm[reg]));       // FSTP [reg]
@@ -5116,7 +5110,7 @@ void offsetinreg(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
     }
 
     *pretregs = retregs;
-    allocreg(cdb, *pretregs, reg, TYoffset);
+    reg = allocreg(cdb, *pretregs, TYoffset);
     getoffset(cdb,e,reg);
 L3:
     cssave(e, *pretregs,false);
@@ -5211,13 +5205,13 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
         {
             if (!I16 && (tym == TYfloat || tym == TYifloat))
             {
-                allocreg(cdb, regm, reg, TYoffset);   // get a register
+                reg = allocreg(cdb, regm, TYoffset);   // get a register
                 loadea(cdb, e, &cs, 0x8B, reg, 0, 0, 0);    // MOV reg,data
                 cdb.gen2(0xD1,modregrmx(3,4,reg));           // SHL reg,1
             }
             else if (I64 && (tym == TYdouble || tym ==TYidouble))
             {
-                allocreg(cdb, regm, reg, TYoffset);   // get a register
+                reg = allocreg(cdb, regm, TYoffset);   // get a register
                 loadea(cdb, e,&cs, 0x8B, reg, 0, 0, 0);    // MOV reg,data
                 // remove sign bit, so that -0.0 == 0.0
                 cdb.gen2(0xD1, modregrmx(3, 4, reg));           // SHL reg,1
@@ -5225,7 +5219,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
             }
             else if (TARGET_OSX && e.Eoper == OPvar && movOnly(e))
             {
-                allocreg(cdb, regm, reg, TYoffset);   // get a register
+                reg = allocreg(cdb, regm, TYoffset);   // get a register
                 loadea(cdb, e, &cs, 0x8B, reg, 0, 0, 0);    // MOV reg,data
                 fixresult(cdb, e, regm, outretregs);
             }
@@ -5252,7 +5246,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
         }
         else if (sz < 8)
         {
-            allocreg(cdb, regm, reg, TYoffset);  // get a register
+            reg = allocreg(cdb, regm, TYoffset);  // get a register
             if (I32)                                    // it's a 48 bit pointer
                 loadea(cdb, e, &cs, MOVZXw, reg, REGSIZE, 0, 0); // MOVZX reg,data+4
             else
@@ -5265,7 +5259,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
         }
         else if (sz == 8 || (I64 && sz == 2 * REGSIZE && !tyfloating(tym)))
         {
-            allocreg(cdb, regm, reg, TYoffset);       // get a register
+            reg = allocreg(cdb, regm, TYoffset);       // get a register
             int i = sz - REGSIZE;
             loadea(cdb, e, &cs, 0x8B, reg, i, 0, 0);        // MOV reg,data+6
             if (tyfloating(tym))                             // TYdouble or TYdouble_alias
@@ -5298,8 +5292,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
         if (tyvector(tym) && forregs & XMMREGS)
         {
             assert(!flags);
-            reg_t xreg;
-            allocreg(cdb, forregs, xreg, tym);     // allocate registers
+            reg_t xreg = allocreg(cdb, forregs, tym);     // allocate registers
             movxmmconst(cdb, xreg, tym, &e.EV, flags);
             fixresult(cdb, e, forregs, outretregs);
             return;
@@ -5313,7 +5306,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
             forregs = mask(reg);
 
         regm_t save = regcon.immed.mval;
-        allocreg(cdb, forregs, reg, tym);        // allocate registers
+        reg = allocreg(cdb, forregs, tym);        // allocate registers
         regcon.immed.mval = save;               // allocreg could unnecessarily clear .mval
         if (sz <= REGSIZE)
         {
@@ -5372,9 +5365,8 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
                      * in the data segment, because they are x87 opcodes.
                      * Not so efficient. We should at least do a PXOR for 0.
                      */
-                    reg_t r;
                     regm_t rm = ALLREGS;
-                    allocreg(cdb, rm, r, TYint);    // allocate scratch register
+                    reg_t r = allocreg(cdb, rm, TYint);    // allocate scratch register
                     movregconst(cdb, r, p[0], 0);
                     cdb.genfltreg(0x89, r, 0);               // MOV floatreg,r
                     movregconst(cdb, r, p[1], 0);
@@ -5439,7 +5431,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
             }
         }
 
-        allocreg(cdb, forregs, reg, tym);            // allocate registers
+        reg = allocreg(cdb, forregs, tym);            // allocate registers
 
         if (sz == 1)
         {   regm_t nregm;
@@ -5475,7 +5467,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, ref regm_t outretregs)
                 if (outretregs & nregm)
                     nreg = reg;                             // already allocated
                 else
-                    allocreg(cdb, nregm, nreg, tym);
+                    nreg = allocreg(cdb, nregm, tym);
                 loadea(cdb, e, &cs, opmv, nreg, 0, 0, 0);    // MOV nregL,data
                 if (reg != nreg)
                 {


### PR DESCRIPTION
Finally some red diffs.

cod3.d line 1852 is the only spot that looks weird.  It looks like it was just assigning a dummy initializer that was overwritten immediately, but worth another set of eyes looking more closely.