### PR TITLE
enum PAGESIZE eliminated inside of unittest

### DIFF
--- a/druntime/src/core/internal/gc/pooltable.d
+++ b/druntime/src/core/internal/gc/pooltable.d
@@ -181,9 +181,10 @@ package:
 
 unittest
 {
+    import core.internal.gc.impl.conservative.gc : PAGESIZE;
+
     enum NPOOLS = 6;
     enum NPAGES = 10;
-    enum PAGESIZE = 4096;
 
     static struct MockPool
     {


### PR DESCRIPTION
The goal is to get rid of the ubiquitous enum 4096