### PR TITLE
stdcheaders.c: Don't include signal.h on aarch64 linux due to int128

### DIFF
--- a/compiler/test/compilable/stdcheaders.c
+++ b/compiler/test/compilable/stdcheaders.c
@@ -30,7 +30,9 @@ float x = NAN;
 #include <setjmp.h>
 #endif
 
+#if !(defined(__linux__) && defined(__aarch64__)) // /usr/include/linux/types.h(12): Error: __int128 not supported
 #include <signal.h>
+#endif
 
 #ifndef __DMC__ // no stdalign.h
 #include <stdalign.h>


### PR DESCRIPTION
Using ldc2, trying to include `<signal.h>` on a Raspberry Pi 4 I get:
```
/usr/include/linux/types.h(12): Error: __int128 not supported
/usr/include/linux/types.h(13): Error: unsigned __int128 not supported
```

Looking at the test file, disabling the include on aarch64 seems like the intended solution.