### PR TITLE
Fix bugzilla 24477 - Union access of bool shouldn't be allowed in `@s…

### DIFF
--- a/compiler/src/dmd/safe.d
+++ b/compiler/src/dmd/safe.d
@@ -75,6 +75,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
         if (ad.sizeok != Sizeok.done)
             ad.determineSize(ad.loc);
 
+        import dmd.globals : FeatureState;
         const hasPointers = v.type.hasPointers();
         if (hasPointers)
         {
@@ -87,7 +88,6 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
                 }
                 else
                 {
-                    import dmd.globals : FeatureState;
                     // @@@DEPRECATED_2.116@@@
                     // https://issues.dlang.org/show_bug.cgi?id=20655
                     // Inferring `@system` because of union access breaks code,
@@ -109,6 +109,17 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
                     ad, v))
                     return true;
             }
+        }
+
+        // @@@DEPRECATED_2.119@@@
+        // https://issues.dlang.org/show_bug.cgi?id=24477
+        // Should probably be turned into an error in a new edition
+        if (v.type.hasUnsafeBitpatterns() && v.overlapped && sc.setUnsafePreview(
+            FeatureState.default_, !printmsg, e.loc,
+            "cannot access overlapped field `%s.%s` with unsafe bit patterns in `@safe` code", ad, v)
+        )
+        {
+            return true;
         }
 
         if (readonly || !e.type.isMutable())

--- a/compiler/test/fail_compilation/systemvariables_bool_union.d
+++ b/compiler/test/fail_compilation/systemvariables_bool_union.d
@@ -1,0 +1,22 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/systemvariables_bool_union.d(21): Deprecation: cannot access overlapped field `Box.b` with unsafe bit patterns in `@safe` code
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=24477
+
+bool schrodingersCat() @safe
+{
+    union Box
+    {
+        bool b;
+        ubyte y;
+    }
+
+    Box u;
+    u.y = 2;
+    return u.b;
+}

--- a/compiler/test/runnable/test15.d
+++ b/compiler/test/runnable/test15.d
@@ -1420,7 +1420,7 @@ void test19758()
 /************************************/
 // https://issues.dlang.org/show_bug.cgi?id=19968
 
-@safe void test19968()
+void test19968()
 {
     int[2] array = [16, 678];
     union U { int i; bool b; }


### PR DESCRIPTION
…afe`