### PR TITLE
fileSize() return value misused

### DIFF
--- a/compiler/src/dmd/common/file.d
+++ b/compiler/src/dmd/common/file.d
@@ -566,7 +566,7 @@ else version (Windows)
     private ulong fileSize(HANDLE fd)
     {
         ulong result;
-        if (GetFileSizeEx(fd, cast(LARGE_INTEGER*) &result) == 0)
+        if (GetFileSizeEx(fd, cast(LARGE_INTEGER*) &result))
             return result;
         return ulong.max;
     }


### PR DESCRIPTION
I tracked this error down while trying to figure out why memory mapping didn't work on Windows.

https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfilesizeex

There doesn't seem to be any other code that uses memory mapped files in dmd, so the test case is inherent to https://github.com/dlang/dmd/pull/16348