### PR TITLE
Add -fPIC to DFLAGS. This is necessary to avoid issues with statics.

### DIFF
--- a/compiler/ini/freebsd/bin64/dmd.conf
+++ b/compiler/ini/freebsd/bin64/dmd.conf
@@ -1,5 +1,5 @@
 [Environment32]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic
+DFLAGS=-fPIC -I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic
 
 [Environment64]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic
+DFLAGS=-fPIC -I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic


### PR DESCRIPTION
modified:   compiler/ini/freebsd/bin64/dmd.conf

This pull request is the fix for the problem I identified in this post:
https://forum.dlang.org/post/qbcyozpryyzonoqtkeix@forum.dlang.org

to which Johnathan Davis replied, suggesting this fix. 

I have only changed the freebsd/bin64/dmd.conf as I only have direct experience with this issue on a 64-bit system. It is probably the case that this needs to be done for 32-bit systems as well, but I don't want to assume that.