### PR TITLE
Add --ftime-trace to dmd

### DIFF
--- a/changelog/dmd.ftime-trace.dd
+++ b/changelog/dmd.ftime-trace.dd
@@ -11,6 +11,6 @@ This will output `app.o.time-trace`.
 
 A different output file can be selected with `-ftime-trace-file=trace.json`.
 
-The output is in Google Chrome's profiler format, which can be converted to readable text with the included `timetrace2txt` tool, or be viewed in an interactive viewer like [ui.perfetto.dev](https://ui.perfetto.dev).
+The output is in Google Chrome's profiler format, which can be viewed in an interactive viewer like [ui.perfetto.dev](https://ui.perfetto.dev).
 
 See also this YouTube tutorial: [Easily Reduce Build Times by Profiling the D Compiler](https://www.youtube.com/watch?v=b8wZqU5t9vs)

--- a/changelog/dmd.ftime-trace.dd
+++ b/changelog/dmd.ftime-trace.dd
@@ -1,0 +1,16 @@
+Build time profiling has been added to dmd
+
+The `-ftime-trace` switch that the LDC compiler already has, is now also available in dmd.
+It can be used to figure out which parts of your code take the longest to compile, so you can optimize your build times.
+
+$(CONSOLE
+dmd -ftime-trace app.d
+)
+
+This will output `app.o.time-trace`.
+
+A different output file can be selected with `-ftime-trace-file=trace.json`.
+
+The output is in Google Chrome's profiler format, which can be converted to readable text with the included `timetrace2txt` tool, or be viewed in an interactive viewer like [ui.perfetto.dev](https://ui.perfetto.dev).
+
+See also this YouTube tutorial: [Easily Reduce Build Times by Profiling the D Compiler](https://www.youtube.com/watch?v=b8wZqU5t9vs)

--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1560,7 +1560,7 @@ auto sourceFiles()
             s2ir.d tocsym.d toctype.d tocvdebug.d todt.d toir.d toobj.d
         "),
         driver: fileArray(env["D"], "dinifile.d dmdparams.d gluelayer.d lib.d libelf.d libmach.d libmscoff.d
-            link.d mars.d main.d scanelf.d scanmach.d scanmscoff.d vsoptions.d
+            link.d mars.d main.d scanelf.d scanmach.d scanmscoff.d timetrace.d vsoptions.d
         "),
         frontend: fileArray(env["D"], "
             access.d aggregate.d aliasthis.d argtypes_x86.d argtypes_sysv_x64.d argtypes_aarch64.d arrayop.d

--- a/compiler/src/dmd/README.md
+++ b/compiler/src/dmd/README.md
@@ -44,6 +44,7 @@ Note that these groups have no strict meaning, the category assignments are a bi
 | [target.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/target.d)       | Manage target-specific parameters for cross-compiling (for LDC/GDC)   |
 | [compiler.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/compiler.d)   | Describe a back-end compiler and implements compiler-specific actions |
 | [deps.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/deps.d)           | Implement the `-deps` and `-makedeps` switches                        |
+| [timetrace.d](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/timetrace.d) | Build time profiling utility                                          |
 
 ### Lexing / parsing
 

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -375,7 +375,7 @@ dmd -cov -unittest myprog.d
             "generate position independent executables",
             cast(TargetOS) (TargetOS.all & ~(TargetOS.Windows | TargetOS.OSX))
         ),
-        Option("-ftime-trace",
+        Option("ftime-trace",
             "turn on compile time profiler, generate JSON file with results",
             "Per function, the time to analyze it, call it from CTFE, generate code for it etc. will be measured,
             and events with a time longer than 500 microseconds (adjustable with `-ftime-trace-granularity`)
@@ -385,13 +385,13 @@ dmd -cov -unittest myprog.d
             This can be turned into a more readable text file with the included tool `timetrace2txt`, or inspected
             with an interactive viewer such as $(LINK2 https://ui.perfetto.dev/, Perfetto)."
         ),
-        Option("-ftime-trace-granularity=",
+        Option("ftime-trace-granularity=",
             "Minimum time granularity (in microseconds) traced by time profiler (default: 500)",
             "Measured events shorter than the specified time will be discarded from the output.
             Set it too high, and interesting events may not show up in the output.
             Set too low, and the profiler overhead will be larger, and the output will be cluttered with tiny events."
         ),
-        Option("-ftime-trace-file=<filename>",
+        Option("ftime-trace-file=<filename>",
             "specify output file for -ftime-trace",
             "By default, the output name is the same as the first object file name, but with the `.time-trace` extension appended.
             A different filename can be chosen with this option, including a path relative to the current directory or an absolute path."

--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -375,6 +375,27 @@ dmd -cov -unittest myprog.d
             "generate position independent executables",
             cast(TargetOS) (TargetOS.all & ~(TargetOS.Windows | TargetOS.OSX))
         ),
+        Option("-ftime-trace",
+            "turn on compile time profiler, generate JSON file with results",
+            "Per function, the time to analyze it, call it from CTFE, generate code for it etc. will be measured,
+            and events with a time longer than 500 microseconds (adjustable with `-ftime-trace-granularity`)
+            will be recorded.
+            The profiling result is output in the Chrome Trace Event Format,
+            $(LINK2 https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview, described here).
+            This can be turned into a more readable text file with the included tool `timetrace2txt`, or inspected
+            with an interactive viewer such as $(LINK2 https://ui.perfetto.dev/, Perfetto)."
+        ),
+        Option("-ftime-trace-granularity=",
+            "Minimum time granularity (in microseconds) traced by time profiler (default: 500)",
+            "Measured events shorter than the specified time will be discarded from the output.
+            Set it too high, and interesting events may not show up in the output.
+            Set too low, and the profiler overhead will be larger, and the output will be cluttered with tiny events."
+        ),
+        Option("-ftime-trace-file=<filename>",
+            "specify output file for -ftime-trace",
+            "By default, the output name is the same as the first object file name, but with the `.time-trace` extension appended.
+            A different filename can be chosen with this option, including a path relative to the current directory or an absolute path."
+        ),
         Option("g",
             "add symbolic debug info",
             `$(WINDOWS

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -715,6 +715,11 @@ extern (C++) final class Module : Package
     {
         const(char)* srcname = srcfile.toChars();
         //printf("Module::parse(srcname = '%s')\n", srcname);
+
+        import dmd.timetrace;
+        timeTraceBeginEvent(TimeTraceEventType.parse);
+        scope (exit) timeTraceEndEvent(TimeTraceEventType.parse, this);
+
         isPackageFile = isPackageFileName(srcfile);
         const(char)[] buf = processSource(src, this);
         // an error happened on UTF conversion

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -65,7 +65,6 @@ import dmd.root.array;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
-import dmd.root.string : toDString;
 import dmd.rootobject;
 import dmd.semantic2;
 import dmd.semantic3;
@@ -1517,7 +1516,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(Import imp)
     {
-        auto timeScope = TimeTraceScope("Sema1: Import " ~ imp.id.toString(), imp.toPrettyChars().toDString(), imp.loc);
+        timeTraceBeginEvent(TimeTraceEventType.sema1Import);
+        scope (exit) timeTraceEndEvent(TimeTraceEventType.sema1Import, imp);
         static if (LOG)
         {
             printf("Import::semantic('%s') %s\n", imp.toPrettyChars(), imp.id.toChars());
@@ -1889,9 +1889,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(Module m)
     {
-        auto timeScope = TimeTraceScope("Sema 1: Module " ~ m.toPrettyChars().toDString(), m.loc);
         if (m.semanticRun != PASS.initial)
             return;
+
+        timeTraceBeginEvent(TimeTraceEventType.sema1Module);
+        scope (exit) timeTraceEndEvent(TimeTraceEventType.sema1Module, m);
+
         //printf("+Module::semantic(this = %p, '%s'): parent = %p\n", this, toChars(), parent);
         m.semanticRun = PASS.semantic;
         // Note that modules get their own scope, from scratch.

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -24,6 +24,7 @@ import dmd.attrib;
 import dmd.attribsem;
 import dmd.clone;
 import dmd.cond;
+import dmd.timetrace;
 import dmd.dcast;
 import dmd.dclass;
 import dmd.declaration;
@@ -64,6 +65,7 @@ import dmd.root.array;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
+import dmd.root.string : toDString;
 import dmd.rootobject;
 import dmd.semantic2;
 import dmd.semantic3;
@@ -1515,6 +1517,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(Import imp)
     {
+        auto timeScope = TimeTraceScope("Sema1: Import " ~ imp.id.toString(), imp.toPrettyChars().toDString(), imp.loc);
         static if (LOG)
         {
             printf("Import::semantic('%s') %s\n", imp.toPrettyChars(), imp.id.toChars());
@@ -1886,6 +1889,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(Module m)
     {
+        auto timeScope = TimeTraceScope("Sema 1: Module " ~ m.toPrettyChars().toDString(), m.loc);
         if (m.semanticRun != PASS.initial)
             return;
         //printf("+Module::semantic(this = %p, '%s'): parent = %p\n", this, toChars(), parent);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8144,7 +8144,7 @@ struct Param final
         resfile(),
         exefile(),
         mapfile(),
-        timeTrace(),
+        timeTrace(false),
         timeTraceGranularityUs(500u),
         timeTraceFile()
     {

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -8065,6 +8065,9 @@ struct Param final
     _d_dynamicArray< const char > resfile;
     _d_dynamicArray< const char > exefile;
     _d_dynamicArray< const char > mapfile;
+    bool timeTrace;
+    uint32_t timeTraceGranularityUs;
+    const char* timeTraceFile;
     bool parsingUnittestsRequired();
     Param() :
         obj(true),
@@ -8140,10 +8143,13 @@ struct Param final
         deffile(),
         resfile(),
         exefile(),
-        mapfile()
+        mapfile(),
+        timeTrace(),
+        timeTraceGranularityUs(500u),
+        timeTraceFile()
     {
     }
-    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* > imppath = Array<const char* >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, uint32_t versionlevel = 0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
+    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* > imppath = Array<const char* >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, uint32_t versionlevel = 0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}, bool timeTrace = false, uint32_t timeTraceGranularityUs = 500u, const char* timeTraceFile = nullptr) :
         obj(obj),
         multiobj(multiobj),
         trace(trace),
@@ -8224,7 +8230,10 @@ struct Param final
         deffile(deffile),
         resfile(resfile),
         exefile(exefile),
-        mapfile(mapfile)
+        mapfile(mapfile),
+        timeTrace(timeTrace),
+        timeTraceGranularityUs(timeTraceGranularityUs),
+        timeTraceFile(timeTraceFile)
         {}
 };
 

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -248,6 +248,11 @@ extern (C++) struct Param
     const(char)[] exefile;
     const(char)[] mapfile;
 
+    // Time tracing
+    bool timeTrace; /// Whether profiling of compile time is enabled
+    uint timeTraceGranularityUs = 500; /// In microseconds, minimum event size to report
+    const(char)* timeTraceFile; /// File path of output file
+
     ///
     bool parsingUnittestsRequired()
     {

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -249,7 +249,7 @@ extern (C++) struct Param
     const(char)[] mapfile;
 
     // Time tracing
-    bool timeTrace; /// Whether profiling of compile time is enabled
+    bool timeTrace = false; /// Whether profiling of compile time is enabled
     uint timeTraceGranularityUs = 500; /// In microseconds, minimum event size to report
     const(char)* timeTraceFile; /// File path of output file
 

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -466,6 +466,10 @@ private void genObjFile(Module m, bool multiobj)
 
     //printf("Module.genobjfile(multiobj = %d) %s\n", multiobj, m.toChars());
 
+    import dmd.timetrace;
+    import dmd.root.string : toDString;
+    auto timeScope = TimeTraceScope("Codegen: Module " ~ m.toChars().toDString(), m.toPrettyChars().toDString(), m.loc);
+
     glue.lastmname = m.srcfile.toChars();
 
     objmod.initfile(glue.lastmname, null, m.toPrettyChars());
@@ -746,6 +750,9 @@ public void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     UnitTestDeclaration ud = fd.isUnitTestDeclaration();
     if (ud && !global.params.useUnitTests)
         return;
+
+    import dmd.timetrace;
+    auto timeScope = TimeTraceScope("Codegen: Function " ~ fd.toChars().toDString(), fd.toPrettyChars().toDString(), fd.loc);
 
     if (multiobj && !fd.isStaticDtorDeclaration() && !fd.isStaticCtorDeclaration()
         && !(fd.isCrtCtor || fd.isCrtDtor))

--- a/compiler/src/dmd/glue.d
+++ b/compiler/src/dmd/glue.d
@@ -467,8 +467,8 @@ private void genObjFile(Module m, bool multiobj)
     //printf("Module.genobjfile(multiobj = %d) %s\n", multiobj, m.toChars());
 
     import dmd.timetrace;
-    import dmd.root.string : toDString;
-    auto timeScope = TimeTraceScope("Codegen: Module " ~ m.toChars().toDString(), m.toPrettyChars().toDString(), m.loc);
+    timeTraceBeginEvent(TimeTraceEventType.codegenModule);
+    scope(exit) timeTraceEndEvent(TimeTraceEventType.codegenModule, m);
 
     glue.lastmname = m.srcfile.toChars();
 
@@ -752,7 +752,8 @@ public void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         return;
 
     import dmd.timetrace;
-    auto timeScope = TimeTraceScope("Codegen: Function " ~ fd.toChars().toDString(), fd.toPrettyChars().toDString(), fd.loc);
+    timeTraceBeginEvent(TimeTraceEventType.codegenFunction);
+    scope (exit) timeTraceEndEvent(TimeTraceEventType.codegenFunction, fd);
 
     if (multiobj && !fd.isStaticDtorDeclaration() && !fd.isStaticCtorDeclaration()
         && !(fd.isCrtCtor || fd.isCrtDtor))

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -67,6 +67,7 @@ import dmd.root.stringtable;
 import dmd.semantic2;
 import dmd.semantic3;
 import dmd.target;
+import dmd.timetrace;
 import dmd.utils;
 import dmd.vsoptions;
 
@@ -400,7 +401,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (params.timeTrace)
     {
         import dmd.timetrace;
-        initializeTimeTrace(params.timeTraceGranularityUs, 0, argv[0]);
+        initializeTimeTrace(params.timeTraceGranularityUs, argv[0]);
     }
 
     // Create Modules
@@ -433,9 +434,12 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         ddocbufIsRead = true;
     }
 
-    // Parse files
     bool anydocfiles = false;
     OutBuffer ddocOutputText;
+    {
+    // Parse files
+    timeTraceBeginEvent(TimeTraceEventType.parseGeneral);
+    scope (exit) timeTraceEndEvent(TimeTraceEventType.parseGeneral);
     size_t filecount = modules.length;
     for (size_t filei = 0, modi = 0; filei < filecount; filei++, modi++)
     {
@@ -491,6 +495,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
                 driverParams.link = false;
         }
     }
+    }
 
     if (anydocfiles && modules.length && (driverParams.oneobj || params.objname))
     {
@@ -523,6 +528,10 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     }
     if (global.errors)
         removeHdrFilesAndFail(params, modules);
+
+    {
+    timeTraceBeginEvent(TimeTraceEventType.semaGeneral);
+    scope (exit) timeTraceEndEvent(TimeTraceEventType.semaGeneral);
 
     // load all unconditional imports for better symbol resolving
     foreach (m; modules)
@@ -630,6 +639,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         else
             printf("%.*s", cast(int)data.length, data.ptr);
     }
+    }
 
     printCtfePerformanceStats();
     printTemplateStats(global.params.v.templatesListInstances, global.errorSink);
@@ -690,8 +700,8 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     }
 
     {
-        import dmd.timetrace;
-        auto timeScope = TimeTraceScope("Code generation", "", Loc.initial);
+        timeTraceBeginEvent(TimeTraceEventType.codegenGlobal);
+        scope (exit) timeTraceEndEvent(TimeTraceEventType.codegenGlobal);
         generateCodeAndWrite(modules[], libmodules[], params.libname, params.objdir,
                             driverParams.lib, params.obj, driverParams.oneobj, params.multiobj,
                             params.v.verbose);
@@ -710,7 +720,11 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     else
     {
         if (driverParams.link)
+        {
+            timeTraceBeginEvent(TimeTraceEventType.link);
+            scope (exit) timeTraceEndEvent(TimeTraceEventType.link);
             status = runLINK(global.params.v.verbose, global.errorSink);
+        }
         if (params.run)
         {
             if (!status)
@@ -733,8 +747,39 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (params.timeTrace)
     {
         import dmd.timetrace;
-        const s = params.timeTraceFile;
-        writeTimeTraceProfile(s ? s : "");
+        auto fileName = params.timeTraceFile.toDString();
+        if (!fileName)
+        {
+            if (global.params.objfiles.length)
+            {
+                fileName = global.params.objfiles[0].toDString() ~ ".time-trace";
+            }
+            else
+            {
+                fileName = "out.time-trace";
+            }
+        }
+
+        OutBuffer buf;
+        timeTraceProfiler.writeToBuffer(buf);
+        if (fileName == "-")
+        {
+            // Write to stdout
+            import core.stdc.stdio : fwrite, stdout;
+
+            size_t n = fwrite(buf[].ptr, 1, buf.length, stdout);
+            if (n != buf.length)
+            {
+                error(Loc.initial, "Error writing -ftime-trace profile to stdout");
+            }
+        }
+        else if (!File.write(fileName, buf[]))
+        {
+            error(Loc.initial,
+                "Error writing -ftime-trace profile: could not open '%*.s'",
+                cast(int) fileName.length, fileName.ptr);
+        }
+
         deinitializeTimeTrace();
     }
 

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -851,7 +851,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         }
         else if (arg == "-ftime-trace")
             params.timeTrace = true;
-        else if (startsWith(p + 1, "-ftime-trace-granularity="))
+        else if (startsWith(p + 1, "ftime-trace-granularity="))
         {
             enum len = "-ftime-trace-granularity=".length;
             if (arg.length < len || !params.timeTraceGranularityUs.parseDigits(arg[len .. $]))
@@ -860,7 +860,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                 return false;
             }
         }
-        else if (startsWith(p + 1, "-ftime-trace-file="))
+        else if (startsWith(p + 1, "ftime-trace-file="))
         {
             enum l = "-ftime-trace-file=".length;
             auto tmp = p + l;

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -849,6 +849,25 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         {
             driverParams.pic = PIC.pie;
         }
+        else if (arg == "-ftime-trace")
+            params.timeTrace = true;
+        else if (startsWith(p + 1, "-ftime-trace-granularity="))
+        {
+            enum len = "-ftime-trace-granularity=".length;
+            if (arg.length < len || !params.timeTraceGranularityUs.parseDigits(arg[len .. $]))
+            {
+                error("`-ftime-trace-granularity` requires a positive number of microseconds", p);
+                return false;
+            }
+        }
+        else if (startsWith(p + 1, "-ftime-trace-file="))
+        {
+            enum l = "-ftime-trace-file=".length;
+            auto tmp = p + l;
+            if (!tmp[0])
+                goto Lnoarg;
+            params.timeTraceFile = mem.xstrdup(tmp);
+        }
         else if (arg == "-map") // https://dlang.org/dmd.html#switch-map
             driverParams.map = true;
         else if (arg == "-multiobj")

--- a/compiler/src/dmd/root/rmem.d
+++ b/compiler/src/dmd/root/rmem.d
@@ -149,6 +149,7 @@ enum CHUNK_SIZE = (256 * 4096 - 64);
 
 __gshared size_t heapleft = 0;
 __gshared void* heapp;
+__gshared size_t heapTotal = 0; // Total amount of memory allocated using malloc
 
 extern (D) void* allocmemoryNoFree(size_t m_size) nothrow @nogc
 {
@@ -167,11 +168,13 @@ extern (D) void* allocmemoryNoFree(size_t m_size) nothrow @nogc
 
     if (m_size > CHUNK_SIZE)
     {
+        heapTotal += m_size;
         return Mem.check(malloc(m_size));
     }
 
     heapleft = CHUNK_SIZE;
     heapp = Mem.check(malloc(CHUNK_SIZE));
+    heapTotal += CHUNK_SIZE;
     goto L1;
 }
 

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -359,7 +359,8 @@ private extern(C++) final class Semantic2Visitor : Visitor
         assert(fd.semanticRun <= PASS.semantic2);
         fd.semanticRun = PASS.semantic2;
 
-        auto timeScope = TimeTraceScope("Sema2: Func " ~ fd.toChars().toDString(), fd.toPrettyChars().toDString(), fd.loc);
+        timeTraceBeginEvent(TimeTraceEventType.sema2);
+        scope(exit) timeTraceEndEvent(TimeTraceEventType.sema2, fd);
 
         //printf("FuncDeclaration::semantic2 [%s] fd: %s type: %s\n", fd.loc.toChars(), fd.toChars(), fd.type ? fd.type.toChars() : "".ptr);
 

--- a/compiler/src/dmd/semantic2.d
+++ b/compiler/src/dmd/semantic2.d
@@ -21,6 +21,7 @@ import dmd.astcodegen;
 import dmd.astenums;
 import dmd.attrib;
 import dmd.blockexit;
+import dmd.timetrace;
 import dmd.clone;
 import dmd.dcast;
 import dmd.dclass;
@@ -56,6 +57,7 @@ import dmd.parse;
 import dmd.root.filename;
 import dmd.common.outbuffer;
 import dmd.root.rmem;
+import dmd.root.string : toDString;
 import dmd.rootobject;
 import dmd.root.utf;
 import dmd.sideeffect;
@@ -356,6 +358,8 @@ private extern(C++) final class Semantic2Visitor : Visitor
         }
         assert(fd.semanticRun <= PASS.semantic2);
         fd.semanticRun = PASS.semantic2;
+
+        auto timeScope = TimeTraceScope("Sema2: Func " ~ fd.toChars().toDString(), fd.toPrettyChars().toDString(), fd.loc);
 
         //printf("FuncDeclaration::semantic2 [%s] fd: %s type: %s\n", fd.loc.toChars(), fd.toChars(), fd.type ? fd.type.toChars() : "".ptr);
 

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -223,7 +223,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
         //printf("FuncDeclaration::semantic3(%s '%s', sc = %p)\n", funcdecl.kind(), funcdecl.toChars(), sc);
         import dmd.timetrace;
         import dmd.root.string : toDString;
-        auto timeScope = TimeTraceScope("Sema2: Func " ~ funcdecl.toChars().toDString(), funcdecl.toPrettyChars().toDString(), funcdecl.loc);
+        timeTraceBeginEvent(TimeTraceEventType.sema3);
+        scope (exit) timeTraceEndEvent(TimeTraceEventType.sema3, funcdecl);
 
         /* Determine if function should add `return 0;`
          */

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -221,6 +221,10 @@ private extern(C++) final class Semantic3Visitor : Visitor
     override void visit(FuncDeclaration funcdecl)
     {
         //printf("FuncDeclaration::semantic3(%s '%s', sc = %p)\n", funcdecl.kind(), funcdecl.toChars(), sc);
+        import dmd.timetrace;
+        import dmd.root.string : toDString;
+        auto timeScope = TimeTraceScope("Sema2: Func " ~ funcdecl.toChars().toDString(), funcdecl.toPrettyChars().toDString(), funcdecl.loc);
+
         /* Determine if function should add `return 0;`
          */
         bool addReturn0()

--- a/compiler/src/dmd/timetrace.d
+++ b/compiler/src/dmd/timetrace.d
@@ -1,0 +1,482 @@
+/**
+Compilation time tracing, -ftime-trace.
+
+The time trace profile is output in the Chrome Trace Event Format, described
+here: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+
+This file is originally from LDC (the LLVM D compiler).
+
+Copyright: Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved
+Authors:   Johan Engelen, Max Haughton
+License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/timetrace.d, common/_timetrace.d)
+Documentation: https://dlang.org/phobos/dmd_common_timetrace.html
+Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/common/timetrace.d
+*/
+module dmd.timetrace;
+
+import dmd.errors;
+import dmd.globals;
+import dmd.location;
+import dmd.root.array;
+import dmd.root.file;
+import dmd.common.outbuffer;
+import dmd.root.string : toDString;
+
+// Thread local profiler instance (multithread currently not supported because compiler is single-threaded)
+TimeTraceProfiler* timeTraceProfiler = null;
+
+// processName pointer is captured
+extern(C++)
+void initializeTimeTrace(uint timeGranularity, uint memoryGranularity, const(char)* processName)
+{
+    assert(timeTraceProfiler is null, "Double initialization of timeTraceProfiler");
+    timeTraceProfiler = new TimeTraceProfiler(timeGranularity, memoryGranularity, processName);
+}
+
+extern(C++)
+void deinitializeTimeTrace()
+{
+    if (timeTraceProfilerEnabled())
+    {
+        object.destroy(timeTraceProfiler);
+        timeTraceProfiler = null;
+    }
+}
+
+pragma(inline, true)
+extern(C++)
+bool timeTraceProfilerEnabled()
+{
+    version (LDC)
+    {
+        import ldc.intrinsics: llvm_expect;
+        return llvm_expect(timeTraceProfiler !is null, false);
+    }
+    else
+    {
+        return timeTraceProfiler !is null;
+    }
+}
+
+const(char)[] getTimeTraceProfileFilename(const(char)* filename_cstr)
+{
+    const(char)[] filename;
+    if (filename_cstr)
+    {
+        filename = filename_cstr.toDString();
+    }
+    if (filename.length == 0)
+    {
+        if (global.params.objfiles.length)
+        {
+            filename = global.params.objfiles[0].toDString() ~ ".time-trace";
+        }
+        else
+        {
+            filename = "out.time-trace";
+        }
+    }
+    return filename;
+}
+
+extern(C++)
+void writeTimeTraceProfile(const(char)* filename_cstr)
+{
+    if (!timeTraceProfiler)
+        return;
+
+    const filename = getTimeTraceProfileFilename(filename_cstr);
+
+    OutBuffer buf;
+    timeTraceProfiler.writeToBuffer(&buf);
+    if (filename == "-")
+    {
+        // Write to stdout
+        import core.stdc.stdio : fwrite, stdout;
+        size_t n = fwrite(buf[].ptr, 1, buf.length, stdout);
+        if (n != buf.length)
+        {
+            error(Loc.initial, "Error writing -ftime-trace profile to stdout");
+            fatal();
+        }
+    }
+    else if (!File.write(filename, buf[]))
+    {
+        error(Loc.initial, "Error writing -ftime-trace profile: could not open '%*.s'", cast(int) filename.length, filename.ptr);
+        fatal();
+    }
+}
+
+// Pointers should not be stored, string copies must be made.
+extern(C++)
+void timeTraceProfilerBegin(const(char)* name_ptr, const(char)* detail_ptr, Loc loc)
+{
+    import dmd.root.rmem : xarraydup;
+    import core.stdc.string : strdup;
+
+    assert(timeTraceProfiler);
+
+    timeTraceProfiler.beginScope(xarraydup(name_ptr.toDString()),
+                                 xarraydup(detail_ptr.toDString()), loc);
+}
+
+extern(C++)
+void timeTraceProfilerEnd()
+{
+    assert(timeTraceProfiler);
+    timeTraceProfiler.endScope();
+}
+
+
+
+struct TimeTraceProfiler
+{
+    import core.time;
+    alias TimeTicks = long;
+
+    TimeTicks timeGranularity;
+    uint memoryGranularity;
+    const(char)[] processName;
+    const(char)[] pidtid_string = `"pid":101,"tid":101`;
+
+    TimeTicks beginningOfTime;
+    Array!CounterEvent counterEvents;
+    Array!DurationEvent durationEvents;
+    Array!DurationEvent durationStack;
+
+    struct CounterEvent
+    {
+        size_t memoryInUse;
+        ulong allocatedMemory;
+        size_t numberOfGCCollections;
+        TimeTicks timepoint;
+    }
+    struct DurationEvent
+    {
+        const(char)[] name;
+        const(char)[] details;
+        Loc loc;
+        TimeTicks timeBegin;
+        TimeTicks timeDuration;
+    }
+
+    @disable this();
+    @disable this(this);
+
+    this(uint timeGranularity_usecs, uint memoryGranularity, const(char)* processName)
+    {
+        this.timeGranularity = timeGranularity_usecs * (MonoTime.ticksPerSecond() / 1_000_000);
+        this.memoryGranularity = memoryGranularity;
+        this.processName = processName.toDString();
+        this.beginningOfTime = getTimeTicks();
+    }
+
+    TimeTicks getTimeTicks()
+    {
+        return MonoTime.currTime().ticks();
+    }
+
+    void beginScope(const(char)[] name, const(char)[] details, Loc loc)
+    {
+        DurationEvent event;
+        event.name = name;
+        event.details = details;
+        event.loc = loc;
+        event.timeBegin = getTimeTicks();
+        durationStack.push(event);
+
+        //counterEvents.push(generateCounterEvent(event.timeBegin));
+    }
+
+    void endScope()
+    {
+        TimeTicks timeEnd = getTimeTicks();
+
+        DurationEvent event = durationStack.pop();
+        event.timeDuration = timeEnd - event.timeBegin;
+        if (event.timeDuration >= timeGranularity)
+        {
+            // Event passes the logging threshold
+            event.timeBegin -= beginningOfTime;
+            durationEvents.push(event);
+            counterEvents.push(generateCounterEvent(timeEnd-beginningOfTime));
+        }
+    }
+
+    /// Takes ownership of the string returned by `details`.
+    void endScopeUpdateDetails(scope const(char)[] delegate() details)
+    {
+        TimeTicks timeEnd = getTimeTicks();
+
+        DurationEvent event = durationStack.pop();
+        event.timeDuration = timeEnd - event.timeBegin;
+        if (event.timeDuration >= timeGranularity)
+        {
+            // Event passes the logging threshold
+            event.details = details();
+            event.timeBegin -= beginningOfTime;
+            durationEvents.push(event);
+            counterEvents.push(generateCounterEvent(timeEnd-beginningOfTime));
+        }
+    }
+
+
+    CounterEvent generateCounterEvent(TimeTicks timepoint)
+    {
+        static import dmd.root.rmem;
+        CounterEvent counters;
+        if (dmd.root.rmem.mem.isGCEnabled)
+        {
+            static if (__VERSION__ >= 2085)
+            {
+                import core.memory : GC;
+                auto stats = GC.stats();
+                auto profileStats = GC.profileStats();
+
+                counters.allocatedMemory = stats.usedSize + stats.freeSize;
+                counters.memoryInUse = stats.usedSize;
+                counters.numberOfGCCollections = profileStats.numCollections;
+            }
+        }
+        else
+        {
+            counters.allocatedMemory = dmd.root.rmem.heapTotal;
+            counters.memoryInUse = dmd.root.rmem.heapTotal - dmd.root.rmem.heapleft;
+        }
+        counters.timepoint = timepoint;
+        return counters;
+    }
+
+    void writeToBuffer(OutBuffer* buf)
+    {
+        writePrologue(buf);
+        writeEvents(buf);
+        writeEpilogue(buf);
+    }
+
+    void writePrologue(OutBuffer* buf)
+    {
+        // Time is to be output in microseconds
+        long timescale = MonoTime.ticksPerSecond() / 1_000_000;
+
+        buf.write("{\n\"beginningOfTime\":");
+        buf.print(beginningOfTime / timescale);
+        buf.write(",\n\"traceEvents\": [\n");
+    }
+
+    void writeEpilogue(OutBuffer* buf)
+    {
+        buf.write("]\n}\n");
+    }
+
+    void writeEvents(OutBuffer* buf)
+    {
+        writeMetadataEvents(buf);
+        writeCounterEvents(buf);
+        writeDurationEvents(buf);
+        // Remove the trailing comma (and newline!) to obtain valid JSON.
+        if ((*buf)[buf.length()-2] == ',')
+        {
+            buf.setsize(buf.length()-2);
+            buf.writeByte('\n');
+        }
+    }
+
+    void writeMetadataEvents(OutBuffer* buf)
+    {
+        // {"ph":"M","ts":0,"args":{"name":"bin/ldc2"},"name":"thread_name","pid":0,"tid":0},
+
+        buf.write(`{"ph":"M","ts":0,"args":{"name":"`);
+        buf.writeEscapeJSONString(processName);
+        buf.write(`"},"name":"process_name",`);
+        buf.write(pidtid_string);
+        buf.write("},\n");
+        buf.write(`{"ph":"M","ts":0,"args":{"name":"`);
+        buf.writeEscapeJSONString(processName);
+        buf.write(`"},"cat":"","name":"thread_name",`);
+        buf.write(pidtid_string);
+        buf.write("},\n");
+    }
+
+    void writeCounterEvents(OutBuffer* buf)
+    {
+        // {"ph":"C","name":"ctr","ts":111,"args": {"Allocated_Memory_bytes":  0, "hello":  0}},
+
+        // Time is to be output in microseconds
+        long timescale = MonoTime.ticksPerSecond() / 1_000_000;
+
+        foreach (const ref event; counterEvents)
+        {
+            buf.write(`{"ph":"C","name":"ctr","ts":`);
+            buf.print(event.timepoint / timescale);
+            buf.write(`,"args": {"memoryInUse_bytes":`);
+            buf.print(event.memoryInUse);
+            buf.write(`,"allocatedMemory_bytes":`);
+            buf.print(event.allocatedMemory);
+            buf.write(`,"GC collections":`);
+            buf.print(event.numberOfGCCollections);
+            buf.write("},");
+            buf.write(pidtid_string);
+            buf.write("},\n");
+        }
+    }
+
+    void writeDurationEvents(OutBuffer* buf)
+    {
+        // {"ph":"X","name": "Sema1: somename","ts":111,"dur":222,"loc":"filename.d:123","args": {"detail": "something", "loc":"filename.d:123"},"pid":0,"tid":0}
+
+        void writeLocation(Loc loc)
+        {
+            if (loc.filename())
+            {
+                writeEscapeJSONString(buf, loc.filename().toDString());
+                if (loc.linnum())
+                {
+                    buf.writeByte(':');
+                    buf.print(loc.linnum());
+                }
+            }
+            else
+            {
+                buf.write(`<no file>`);
+            }
+        }
+
+        // Time is to be output in microseconds
+        long timescale = MonoTime.ticksPerSecond() / 1_000_000;
+
+        foreach (event; durationEvents)
+        {
+            buf.write(`{"ph":"X","name": "`);
+            writeEscapeJSONString(buf, event.name);
+            buf.write(`","ts":`);
+            buf.print(event.timeBegin / timescale);
+            buf.write(`,"dur":`);
+            buf.print(event.timeDuration / timescale);
+            buf.write(`,"loc":"`);
+            writeLocation(event.loc);
+            buf.write(`","args":{"detail": "`);
+            writeEscapeJSONString(buf, event.details);
+            // Also output loc data in the "args" field so it shows in trace viewers that do not support the "loc" variable
+            buf.write(`","loc":"`);
+            writeLocation(event.loc);
+            buf.write(`"},`);
+            buf.write(pidtid_string);
+            buf.write("},\n");
+        }
+    }
+}
+
+
+/// RAII helper class to call the begin and end functions of the time trace
+/// profiler.  When the object is constructed, it begins the section; and when
+/// it is destroyed, it stops it.
+struct TimeTraceScope
+{
+    @disable this();
+    @disable this(this);
+
+    this(lazy const(char)[] name, Loc loc = Loc())
+    {
+        if (timeTraceProfilerEnabled())
+        {
+            assert(timeTraceProfiler);
+            timeTraceProfiler.beginScope(name.dup, "", loc);
+        }
+    }
+    this(lazy const(char)[] name, lazy const(char)[] detail, Loc loc = Loc())
+    {
+        if (timeTraceProfilerEnabled())
+        {
+            assert(timeTraceProfiler);
+            timeTraceProfiler.beginScope(name.dup, detail.dup, loc);
+        }
+    }
+    /// Takes ownership of string returned by `detail`.
+    this(lazy const(char)[] name, scope const(char)[] delegate() detail, Loc loc = Loc())
+    {
+        if (timeTraceProfilerEnabled())
+        {
+            assert(timeTraceProfiler);
+            timeTraceProfiler.beginScope(name.dup, detail(), loc);
+        }
+    }
+
+    ~this()
+    {
+        if (timeTraceProfilerEnabled())
+            timeTraceProfiler.endScope();
+    }
+}
+
+/// RAII helper class to call the begin and end functions of the time trace
+/// profiler.  When the object is constructed, it begins the section; and when
+/// it is destroyed, it stops it.
+/// Delays string evaluation (via delegate) until the object is destroyed and the delegate
+/// is only called when the event passes the granularity threshold.
+struct TimeTraceScopeDelayedDetail
+{
+    @disable this();
+    @disable this(this);
+
+    const(char)[] delegate() details_dlg;
+
+    /// Takes ownership of string returned by `detail`.
+    /// `detail` is stored in the struct, but does not escape the lifetime of the struct object.
+    this(lazy const(char)[] name, scope const(char)[] delegate() detail, Loc loc = Loc()) scope @system
+    {
+        if (timeTraceProfilerEnabled())
+        {
+            assert(timeTraceProfiler);
+            details_dlg = detail;
+            timeTraceProfiler.beginScope(name.dup, "", loc);
+        }
+    }
+
+    ~this()
+    {
+        if (timeTraceProfilerEnabled())
+            timeTraceProfiler.endScopeUpdateDetails(details_dlg);
+    }
+}
+
+private void writeEscapeJSONString(OutBuffer* buf, const(char[]) str)
+{
+    foreach (char c; str)
+    {
+        switch (c)
+        {
+        case '\n':
+            buf.writestring("\\n");
+            break;
+        case '\r':
+            buf.writestring("\\r");
+            break;
+        case '\t':
+            buf.writestring("\\t");
+            break;
+        case '\"':
+            buf.writestring("\\\"");
+            break;
+        case '\\':
+            buf.writestring("\\\\");
+            break;
+        case '\b':
+            buf.writestring("\\b");
+            break;
+        case '\f':
+            buf.writestring("\\f");
+            break;
+        default:
+            if (c < 0x20)
+                buf.printf("\\u%04x", c);
+            else
+            {
+                // Note that UTF-8 chars pass through here just fine
+                buf.writeByte(c);
+            }
+            break;
+        }
+    }
+}

--- a/compiler/src/dmd/timetrace.d
+++ b/compiler/src/dmd/timetrace.d
@@ -7,7 +7,7 @@ here: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKch
 This file is originally from LDC (the LLVM D compiler).
 
 Copyright: Copyright (C) 1999-2022 by The D Language Foundation, All Rights Reserved
-Authors:   Johan Engelen, Max Haughton
+Authors:   Johan Engelen, Max Haughton, Dennis Korpel
 License:   $(LINK2 https://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
 Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/common/timetrace.d, common/_timetrace.d)
 Documentation: https://dlang.org/phobos/dmd_common_timetrace.html
@@ -15,26 +15,38 @@ Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/common/timetrace
 */
 module dmd.timetrace;
 
-import dmd.errors;
-import dmd.globals;
 import dmd.location;
+import dmd.dsymbol;
+import dmd.expression;
 import dmd.root.array;
-import dmd.root.file;
 import dmd.common.outbuffer;
 import dmd.root.string : toDString;
 
 // Thread local profiler instance (multithread currently not supported because compiler is single-threaded)
 TimeTraceProfiler* timeTraceProfiler = null;
 
-// processName pointer is captured
-extern(C++)
-void initializeTimeTrace(uint timeGranularity, uint memoryGranularity, const(char)* processName)
+/**
+ * Initialize time tracing functionality.
+ *
+ * Must be called before any other calls to timeTrace functions.
+ *
+ * Params:
+ *   timeGranularityUs = minimum event size in microseconds
+ *   processName = name of this executable
+ */
+extern (C++)
+void initializeTimeTrace(uint timeGranularityUs, const(char)* processName)
 {
     assert(timeTraceProfiler is null, "Double initialization of timeTraceProfiler");
-    timeTraceProfiler = new TimeTraceProfiler(timeGranularity, memoryGranularity, processName);
+    timeTraceProfiler = new TimeTraceProfiler(timeGranularityUs, processName);
 }
 
-extern(C++)
+/**
+ * Cleanup for time tracing functionality.
+ *
+ * After this, no more calls to timeTrace functions can be made.
+ */
+extern (C++)
 void deinitializeTimeTrace()
 {
     if (timeTraceProfilerEnabled())
@@ -44,13 +56,17 @@ void deinitializeTimeTrace()
     }
 }
 
+/**
+ * Returns: Whether time tracing is enabled.
+ */
 pragma(inline, true)
-extern(C++)
+extern (C++)
 bool timeTraceProfilerEnabled()
 {
     version (LDC)
     {
-        import ldc.intrinsics: llvm_expect;
+        import ldc.intrinsics : llvm_expect;
+
         return llvm_expect(timeTraceProfiler !is null, false);
     }
     else
@@ -59,120 +75,181 @@ bool timeTraceProfilerEnabled()
     }
 }
 
-const(char)[] getTimeTraceProfileFilename(const(char)* filename_cstr)
+/**
+ * Write all time tracing results so far to JSON, in the Chrome Trace Event Format.
+ * Params:
+ *   buf = output buffer to write JSON into
+ */
+extern (C++)
+void writeTimeTraceProfile(OutBuffer* buf)
 {
-    const(char)[] filename;
-    if (filename_cstr)
-    {
-        filename = filename_cstr.toDString();
-    }
-    if (filename.length == 0)
-    {
-        if (global.params.objfiles.length)
-        {
-            filename = global.params.objfiles[0].toDString() ~ ".time-trace";
-        }
-        else
-        {
-            filename = "out.time-trace";
-        }
-    }
-    return filename;
+    timeTraceProfiler.writeToBuffer(*buf);
 }
 
-extern(C++)
-void writeTimeTraceProfile(const(char)* filename_cstr)
-{
-    if (!timeTraceProfiler)
-        return;
-
-    const filename = getTimeTraceProfileFilename(filename_cstr);
-
-    OutBuffer buf;
-    timeTraceProfiler.writeToBuffer(&buf);
-    if (filename == "-")
-    {
-        // Write to stdout
-        import core.stdc.stdio : fwrite, stdout;
-        size_t n = fwrite(buf[].ptr, 1, buf.length, stdout);
-        if (n != buf.length)
-        {
-            error(Loc.initial, "Error writing -ftime-trace profile to stdout");
-            fatal();
-        }
-    }
-    else if (!File.write(filename, buf[]))
-    {
-        error(Loc.initial, "Error writing -ftime-trace profile: could not open '%*.s'", cast(int) filename.length, filename.ptr);
-        fatal();
-    }
-}
-
-// Pointers should not be stored, string copies must be made.
-extern(C++)
-void timeTraceProfilerBegin(const(char)* name_ptr, const(char)* detail_ptr, Loc loc)
+/**
+ * Start a new time trace event (C++ interface using upfront C-strings instead of lazy delegates)
+ *
+ * Params:
+ *   name_ptr = event name, visible in high level profile view
+ *   detail_ptr = further details, visible when this event is selected
+ *   loc = source location corresponding to this event
+ */
+extern (C++)
+void timeTraceBeginEvent(scope const(char)* name_ptr, scope const(char)* detail_ptr, Loc loc)
 {
     import dmd.root.rmem : xarraydup;
-    import core.stdc.string : strdup;
 
     assert(timeTraceProfiler);
 
-    timeTraceProfiler.beginScope(xarraydup(name_ptr.toDString()),
-                                 xarraydup(detail_ptr.toDString()), loc);
+    timeTraceProfiler.beginScope(
+        xarraydup(name_ptr.toDString()),
+        xarraydup(detail_ptr.toDString()), loc
+    );
 }
 
-extern(C++)
-void timeTraceProfilerEnd()
+/**
+ * Start a new time trace event
+ *
+ * Details of the event will be passed as delegates to `timeTraceEndEvent` so
+ * they're only generated when the event is actually written.
+ *
+ * Params:
+ *   eventType = what compilation stage the event belongs to
+ *      (redundant with the eventType of `timeTraceEndEvent` but used by GDC)
+ */
+extern (C++)
+void timeTraceBeginEvent(TimeTraceEventType eventType)
 {
-    assert(timeTraceProfiler);
-    timeTraceProfiler.endScope();
+    if (timeTraceProfilerEnabled)
+        timeTraceProfiler.beginScope(null, null, Loc.initial);
+}
+
+/**
+ * End a time tracing event, optionally updating the event name and details
+ * with a delegate. Delegates are used to prevent spending time on string
+ * generation when an event is too small to be generated anyway.
+ *
+ * Params:
+ *   eventType = what compilation stage the event belongs to
+ *   sym = Dsymbol which was analyzed, used to generate 'name' and 'detail'
+ *   e = Expression which was analyzed, used to generate 'name' and 'detail'
+ *   detail = custom lazy string for 'detail' of event
+ */
+extern (C++)
+void timeTraceEndEvent(TimeTraceEventType eventType)
+{
+    if (timeTraceProfilerEnabled)
+        timeTraceProfiler.endScope(eventType, null, null, Loc.initial);
+}
+
+/// ditto
+void timeTraceEndEvent(TimeTraceEventType eventType, Dsymbol sym, scope const(char)[] delegate() detail = null)
+{
+    if (timeTraceProfilerEnabled)
+    {
+        timeTraceProfiler.endScope(
+            eventType,
+            () => sym.isImport() ? sym.toPrettyChars().toDString() : sym.toChars().toDString(),
+            detail ? detail : () => sym.toPrettyChars().toDString(),
+            sym.loc
+        );
+    }
+}
+
+/// ditto
+extern (C++)
+void timeTraceEndEvent(TimeTraceEventType eventType, Expression e)
+{
+    if (timeTraceProfilerEnabled)
+        timeTraceProfiler.endScope(eventType, () => e.toChars().toDString(),
+            () => e.toChars().toDString(), e.loc);
+}
+
+/// Identifies which compilation stage the event is associated to
+enum TimeTraceEventType
+{
+    generic,
+    parseGeneral,
+    parse,
+    semaGeneral,
+    sema1Import,
+    sema1Module,
+    sema2,
+    sema3,
+    ctfe,
+    ctfeCall,
+    codegenGlobal,
+    codegenModule,
+    codegenFunction,
+    link,
+}
+
+/// Names corresponding to `TimeTraceEventType`
+private immutable string[] eventPrefixes = [
+    "",
+    "Parsing",
+    "Parse: Module ",
+    "Semantic analysis",
+    "Import ",
+    "Sema1: Module ",
+    "Sema2: ",
+    "Sema3: ",
+    "Ctfe: ",
+    "Ctfe: call ",
+    "Code generation",
+    "Codegen: module ",
+    "Codegen: function ",
+    "Linking",
+];
+
+/// Integer type holding timer value
+private alias TimeTicks = long;
+
+/// A measurement at a point in time. Used for reporting RAM usage.
+private struct CounterEvent
+{
+    size_t memoryInUse;
+    ulong allocatedMemory;
+    size_t numberOfGCCollections;
+    TimeTicks timepoint;
+}
+
+/// An event with a start and end time
+private struct DurationEvent
+{
+    const(char)[] name = null;
+    const(char)[] details = null;
+    Loc loc;
+    TimeTicks timeBegin;
+    TimeTicks timeDuration;
 }
 
 
-
-struct TimeTraceProfiler
+private struct TimeTraceProfiler
 {
     import core.time;
-    alias TimeTicks = long;
 
-    TimeTicks timeGranularity;
-    uint memoryGranularity;
-    const(char)[] processName;
-    const(char)[] pidtid_string = `"pid":101,"tid":101`;
+    TimeTicks timeGranularity; /// Minimum duration event size
+    const(char)[] processName; /// Name of the executable being profiled
+    /// String to identify process and thread (in this case, there's just a single process and thread)
+    const(char)[] pidtidString = `"pid":101,"tid":101`;
 
-    TimeTicks beginningOfTime;
-    Array!CounterEvent counterEvents;
-    Array!DurationEvent durationEvents;
-    Array!DurationEvent durationStack;
-
-    struct CounterEvent
-    {
-        size_t memoryInUse;
-        ulong allocatedMemory;
-        size_t numberOfGCCollections;
-        TimeTicks timepoint;
-    }
-    struct DurationEvent
-    {
-        const(char)[] name;
-        const(char)[] details;
-        Loc loc;
-        TimeTicks timeBegin;
-        TimeTicks timeDuration;
-    }
+    TimeTicks beginningOfTime; /// Timer value at start of profiling
+    Array!CounterEvent counterEvents; /// All counter event so far
+    Array!DurationEvent durationEvents; /// All duration events so far
+    Array!DurationEvent durationStack; /// Gets pushed to / popped from when an event begins/ends.
 
     @disable this();
     @disable this(this);
 
-    this(uint timeGranularity_usecs, uint memoryGranularity, const(char)* processName)
+    this(uint timeGranularity_usecs, const(char)* processName)
     {
         this.timeGranularity = timeGranularity_usecs * (MonoTime.ticksPerSecond() / 1_000_000);
-        this.memoryGranularity = memoryGranularity;
         this.processName = processName.toDString();
         this.beginningOfTime = getTimeTicks();
     }
 
-    TimeTicks getTimeTicks()
+    private TimeTicks getTimeTicks()
     {
         return MonoTime.currTime().ticks();
     }
@@ -185,11 +262,10 @@ struct TimeTraceProfiler
         event.loc = loc;
         event.timeBegin = getTimeTicks();
         durationStack.push(event);
-
-        //counterEvents.push(generateCounterEvent(event.timeBegin));
     }
 
-    void endScope()
+    /// Takes ownership of the string returned by `name` and `details`.
+    void endScope(TimeTraceEventType eventType, scope const(char)[] delegate() name, scope const(char)[] delegate() details, Loc loc)
     {
         TimeTicks timeEnd = getTimeTicks();
 
@@ -198,39 +274,32 @@ struct TimeTraceProfiler
         if (event.timeDuration >= timeGranularity)
         {
             // Event passes the logging threshold
+            if (name)
+                event.name = eventPrefixes[eventType] ~ name();
+            else if (!event.name)
+                event.name = eventPrefixes[eventType];
+
+            if (details)
+                event.details = details();
+            if (loc != Loc.initial)
+                event.loc = loc;
             event.timeBegin -= beginningOfTime;
             durationEvents.push(event);
-            counterEvents.push(generateCounterEvent(timeEnd-beginningOfTime));
+            counterEvents.push(generateCounterEvent(timeEnd - beginningOfTime));
         }
     }
 
-    /// Takes ownership of the string returned by `details`.
-    void endScopeUpdateDetails(scope const(char)[] delegate() details)
-    {
-        TimeTicks timeEnd = getTimeTicks();
-
-        DurationEvent event = durationStack.pop();
-        event.timeDuration = timeEnd - event.timeBegin;
-        if (event.timeDuration >= timeGranularity)
-        {
-            // Event passes the logging threshold
-            event.details = details();
-            event.timeBegin -= beginningOfTime;
-            durationEvents.push(event);
-            counterEvents.push(generateCounterEvent(timeEnd-beginningOfTime));
-        }
-    }
-
-
-    CounterEvent generateCounterEvent(TimeTicks timepoint)
+    private CounterEvent generateCounterEvent(TimeTicks timepoint)
     {
         static import dmd.root.rmem;
+
         CounterEvent counters;
         if (dmd.root.rmem.mem.isGCEnabled)
         {
             static if (__VERSION__ >= 2085)
             {
                 import core.memory : GC;
+
                 auto stats = GC.stats();
                 auto profileStats = GC.profileStats();
 
@@ -248,14 +317,7 @@ struct TimeTraceProfiler
         return counters;
     }
 
-    void writeToBuffer(OutBuffer* buf)
-    {
-        writePrologue(buf);
-        writeEvents(buf);
-        writeEpilogue(buf);
-    }
-
-    void writePrologue(OutBuffer* buf)
+    void writeToBuffer(ref OutBuffer buf)
     {
         // Time is to be output in microseconds
         long timescale = MonoTime.ticksPerSecond() / 1_000_000;
@@ -263,43 +325,35 @@ struct TimeTraceProfiler
         buf.write("{\n\"beginningOfTime\":");
         buf.print(beginningOfTime / timescale);
         buf.write(",\n\"traceEvents\": [\n");
-    }
-
-    void writeEpilogue(OutBuffer* buf)
-    {
-        buf.write("]\n}\n");
-    }
-
-    void writeEvents(OutBuffer* buf)
-    {
         writeMetadataEvents(buf);
         writeCounterEvents(buf);
         writeDurationEvents(buf);
         // Remove the trailing comma (and newline!) to obtain valid JSON.
-        if ((*buf)[buf.length()-2] == ',')
+        if (buf[buf.length() - 2] == ',')
         {
-            buf.setsize(buf.length()-2);
+            buf.setsize(buf.length() - 2);
             buf.writeByte('\n');
         }
+        buf.write("]\n}\n");
     }
 
-    void writeMetadataEvents(OutBuffer* buf)
+    private void writeMetadataEvents(ref OutBuffer buf)
     {
         // {"ph":"M","ts":0,"args":{"name":"bin/ldc2"},"name":"thread_name","pid":0,"tid":0},
 
         buf.write(`{"ph":"M","ts":0,"args":{"name":"`);
         buf.writeEscapeJSONString(processName);
         buf.write(`"},"name":"process_name",`);
-        buf.write(pidtid_string);
+        buf.write(pidtidString);
         buf.write("},\n");
         buf.write(`{"ph":"M","ts":0,"args":{"name":"`);
         buf.writeEscapeJSONString(processName);
         buf.write(`"},"cat":"","name":"thread_name",`);
-        buf.write(pidtid_string);
+        buf.write(pidtidString);
         buf.write("},\n");
     }
 
-    void writeCounterEvents(OutBuffer* buf)
+    private void writeCounterEvents(ref OutBuffer buf)
     {
         // {"ph":"C","name":"ctr","ts":111,"args": {"Allocated_Memory_bytes":  0, "hello":  0}},
 
@@ -317,12 +371,12 @@ struct TimeTraceProfiler
             buf.write(`,"GC collections":`);
             buf.print(event.numberOfGCCollections);
             buf.write("},");
-            buf.write(pidtid_string);
+            buf.write(pidtidString);
             buf.write("},\n");
         }
     }
 
-    void writeDurationEvents(OutBuffer* buf)
+    private void writeDurationEvents(ref OutBuffer buf)
     {
         // {"ph":"X","name": "Sema1: somename","ts":111,"dur":222,"loc":"filename.d:123","args": {"detail": "something", "loc":"filename.d:123"},"pid":0,"tid":0}
 
@@ -362,86 +416,19 @@ struct TimeTraceProfiler
             buf.write(`","loc":"`);
             writeLocation(event.loc);
             buf.write(`"},`);
-            buf.write(pidtid_string);
+            buf.write(pidtidString);
             buf.write("},\n");
         }
     }
 }
 
-
-/// RAII helper class to call the begin and end functions of the time trace
-/// profiler.  When the object is constructed, it begins the section; and when
-/// it is destroyed, it stops it.
-struct TimeTraceScope
-{
-    @disable this();
-    @disable this(this);
-
-    this(lazy const(char)[] name, Loc loc = Loc())
-    {
-        if (timeTraceProfilerEnabled())
-        {
-            assert(timeTraceProfiler);
-            timeTraceProfiler.beginScope(name.dup, "", loc);
-        }
-    }
-    this(lazy const(char)[] name, lazy const(char)[] detail, Loc loc = Loc())
-    {
-        if (timeTraceProfilerEnabled())
-        {
-            assert(timeTraceProfiler);
-            timeTraceProfiler.beginScope(name.dup, detail.dup, loc);
-        }
-    }
-    /// Takes ownership of string returned by `detail`.
-    this(lazy const(char)[] name, scope const(char)[] delegate() detail, Loc loc = Loc())
-    {
-        if (timeTraceProfilerEnabled())
-        {
-            assert(timeTraceProfiler);
-            timeTraceProfiler.beginScope(name.dup, detail(), loc);
-        }
-    }
-
-    ~this()
-    {
-        if (timeTraceProfilerEnabled())
-            timeTraceProfiler.endScope();
-    }
-}
-
-/// RAII helper class to call the begin and end functions of the time trace
-/// profiler.  When the object is constructed, it begins the section; and when
-/// it is destroyed, it stops it.
-/// Delays string evaluation (via delegate) until the object is destroyed and the delegate
-/// is only called when the event passes the granularity threshold.
-struct TimeTraceScopeDelayedDetail
-{
-    @disable this();
-    @disable this(this);
-
-    const(char)[] delegate() details_dlg;
-
-    /// Takes ownership of string returned by `detail`.
-    /// `detail` is stored in the struct, but does not escape the lifetime of the struct object.
-    this(lazy const(char)[] name, scope const(char)[] delegate() detail, Loc loc = Loc()) scope @system
-    {
-        if (timeTraceProfilerEnabled())
-        {
-            assert(timeTraceProfiler);
-            details_dlg = detail;
-            timeTraceProfiler.beginScope(name.dup, "", loc);
-        }
-    }
-
-    ~this()
-    {
-        if (timeTraceProfilerEnabled())
-            timeTraceProfiler.endScopeUpdateDetails(details_dlg);
-    }
-}
-
-private void writeEscapeJSONString(OutBuffer* buf, const(char[]) str)
+/**
+ * Escape special characters (such as quotes and whitespaces) for a JSON string literal
+ * Params:
+ *   buf = buffer to write to
+ *   str = string to escape and write as string literal
+ */
+private void writeEscapeJSONString(ref OutBuffer buf, const(char[]) str)
 {
     foreach (char c; str)
     {

--- a/compiler/test/README.md
+++ b/compiler/test/README.md
@@ -337,6 +337,13 @@ The following is a list of all available settings:
                                             of -Xi (see test/tools/sanitize_json.d)
                                             arguments: none
 
+                        - sanitize_timetrace: Parse output of -ftime-trace profiling data,
+                                            extract event name / detail strings, and sort them.
+                                            Raw profiler output can't be tested against because it
+                                            contains non-deterministic timing data, or implementation
+                                            details such as semantic analysis order and memory usage,
+                                            so use this when writing a test for -ftime-trace.
+
                         - remove_lines:     Remove lines matching a given regex
                                             arguments: the regex
                                             note: patterns containing ')' must be quoted

--- a/compiler/test/compilable/extra-files/ftime-trace-postscript.sh
+++ b/compiler/test/compilable/extra-files/ftime-trace-postscript.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# Just test that the output file exists
-[[ -f ${OUTPUT_BASE}.json ]] || { echo "ERROR: ${OUTPUT_BASE}.json does not exist"; exit 1; }
-
-# The output itself is not deterministic but a future test could verify that it satisfies a JSON schema

--- a/compiler/test/compilable/extra-files/ftime-trace-postscript.sh
+++ b/compiler/test/compilable/extra-files/ftime-trace-postscript.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Just test that the output file exists
+[[ -f ${OUTPUT_BASE}.json ]] || { echo "ERROR: ${OUTPUT_BASE}.json does not exist"; exit 1; }
+
+# The output itself is not deterministic but a future test could verify that it satisfies a JSON schema

--- a/compiler/test/compilable/ftimetrace.d
+++ b/compiler/test/compilable/ftimetrace.d
@@ -1,0 +1,9 @@
+/**
+REQUIRED_ARGS: -ftime-trace -ftime-trace-file=${RESULTS_DIR}/compilable/ftimetrace.json
+POST_SCRIPT: compilable/extra-files/ftime-trace-postscript.sh
+*/
+
+void f()
+{
+
+}

--- a/compiler/test/compilable/ftimetrace.d
+++ b/compiler/test/compilable/ftimetrace.d
@@ -1,9 +1,34 @@
 /**
-REQUIRED_ARGS: -ftime-trace -ftime-trace-file=${RESULTS_DIR}/compilable/ftimetrace.json
-POST_SCRIPT: compilable/extra-files/ftime-trace-postscript.sh
+REQUIRED_ARGS: -ftime-trace -ftime-trace-file=- -ftime-trace-granularity=0
+TRANSFORM_OUTPUT: sanitize_timetrace
+TEST_OUTPUT:
+---
+Code generation,
+Codegen: function add, object.add
+Codegen: function fun, object.fun
+Codegen: module object, object
+Ctfe: add(4, 8), add(4, 8)
+Ctfe: call add, object.add(4, 8)
+Import object.object, object.object
+Parse: Module object, object
+Parsing,
+Sema1: Module object, object
+Sema2: add, object.add
+Sema2: fun, object.fun
+Sema3: add, object.add
+Sema3: fun, object.fun
+Semantic analysis,
+---
 */
 
-void f()
-{
+module object; // Don't clutter time trace output with object.d
 
+void fun()
+{
+    enum z = add(4, 8);
+}
+
+int add(int x, int y)
+{
+    return x + y;
 }

--- a/compiler/test/fail_compilation/ftimetrace.d
+++ b/compiler/test/fail_compilation/ftimetrace.d
@@ -1,0 +1,7 @@
+/**
+REQUIRED_ARGS: -ftime-trace-granularity=-800
+TEST_OUTPUT:
+---
+Error: `-ftime-trace-granularity` requires a positive number of microseconds
+---
+*/

--- a/compiler/test/tools/d_do_test.d
+++ b/compiler/test/tools/d_do_test.d
@@ -1127,6 +1127,7 @@ Applies custom transformations defined in transformOutput to testOutput.
 
 Currently the following actions are supported:
  * "sanitize_json"       = replace compiler/plattform specific data from generated JSON
+ * "sanitize_timetrace"  = parse -ftime-trace profiler output, and only extract event names
  * "remove_lines(<re>)" = remove all lines matching a regex <re>
 
 Params:
@@ -1184,6 +1185,11 @@ void applyOutputTransformations(ref string testOutput, string transformOutput)
                     .join('\n');
                 break;
             }
+
+            case "sanitize_timetrace":
+                import sanitize_timetrace;
+                sanitizeTimeTrace(testOutput);
+                break;
 
             default:
                 throw new Exception(format(`Unknown transformation: "%s"!`, step));

--- a/compiler/test/tools/sanitize_timetrace.d
+++ b/compiler/test/tools/sanitize_timetrace.d
@@ -1,0 +1,28 @@
+/**
+The output of -ftime-trace is not deterministic because it contains timer data,
+and it's also full of implementation details (such as the order of semantic analysis).
+In order to test the output, this program extracts only 'name' and 'details' strings of events,
+and sorts them, so the output can be tested.
+*/
+module sanitize_timetrace;
+
+import std.algorithm;
+import std.array;
+import std.conv;
+import std.json;
+import std.range;
+import std.string;
+
+void sanitizeTimeTrace(ref string testOutput)
+{
+    parseJSON(testOutput);
+    auto json = parseJSON(testOutput);
+    string result = json["traceEvents"].array
+        .filter!(x => x["ph"].str == "X")
+        .map!(x => strip(x["name"].str ~ ", " ~ x["args"]["detail"].str))
+        .array
+        .sort
+        .uniq
+        .joiner("\n").text;
+    testOutput = result;
+}


### PR DESCRIPTION
Reboot of https://github.com/dlang/dmd/pull/13965

This feature has been in LDC for a while now with success, and inclusion into dmd has been pre-approved a long time ago by Walter, but the PR has stalled since then. There's improvements possible with choosing better zones and refactoring the code, but for now I focused on making it closely match LDC's current implementation. 

For this PR, I still need to include the `timetrace2txt` tool, and test it a bit better.