### PR TITLE
Fix Bugzilla 24485 - Invalid implicit ref return reinterpret cast for structs with copy constructor

### DIFF
--- a/compiler/test/fail_compilation/fail24485.d
+++ b/compiler/test/fail_compilation/fail24485.d
@@ -1,0 +1,32 @@
+// https://issues.dlang.org/show_bug.cgi?id=24485
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail24485.d(25): Error: cannot implicitly convert expression `*a` of type `A` to `B`
+fail_compilation/fail24485.d(31): Error: cannot implicitly convert expression `this.a` of type `A` to `B`
+
+---
+*/
+
+struct A
+{
+    int i = 43;
+    this(ref A rhs) {}
+}
+
+struct B
+{
+    int i = 42;
+}
+
+ref B foo()
+{
+    auto a = new A;
+    return *a;
+}
+
+struct C
+{
+    A a;
+    @property ref B b() { return a; }
+}


### PR DESCRIPTION
This should be made an error directly, even though it is a breaking change. There is no way code depending on this is correct.

Targeting master since this is 5 years old regression and is potentially introducing breaking changes.