### PR TITLE
Fix bugzilla issue 24493: FreeBSD_14 version identifier missing

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -1437,6 +1437,23 @@ void processEnvironment()
         dflags ~= ["-fsanitize="~sanitizers];
     }
 
+    // Determine the version of FreeBSD that we're building on if the target OS
+    // version has not already been set.
+    version (FreeBSD)
+    {
+        import std.ascii : isDigit;
+
+        if (flags.get("DFLAGS", []).find!(a => a.startsWith("-version=TARGET_FREEBSD"))().empty)
+        {
+            // uname -K gives the kernel version, e.g. 1400097. The first two
+            // digits correspond to the major version of the OS.
+            immutable result = executeShell("uname -K");
+            if (result.status != 0 || !result.output.take(2).all!isDigit())
+                throw abortBuild("Failed to get the kernel version");
+            dflags ~= ["-version=TARGET_FREEBSD" ~ result.output[0 .. 2]];
+        }
+    }
+
     // Retain user-defined flags
     flags["DFLAGS"] = dflags ~= flags.get("DFLAGS", []);
 }

--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -79,6 +79,8 @@ ubyte defaultTargetOSMajor() @safe
             return 12;
         else version (TARGET_FREEBSD13)
             return 13;
+        else version (TARGET_FREEBSD14)
+            return 14;
         else
             return 0;
     }
@@ -200,13 +202,14 @@ void addPredefinedGlobalIdentifiers(const ref Target tgt)
             case OS.FreeBSD:
             {
                 predef("FreeBSD");
-                switch (tgt.osMajor)
+
+                if(tgt.osMajor != 0)
                 {
-                    case 10: predef("FreeBSD_10");  break;
-                    case 11: predef("FreeBSD_11"); break;
-                    case 12: predef("FreeBSD_12"); break;
-                    case 13: predef("FreeBSD_13"); break;
-                    default: predef("FreeBSD_11"); break;
+                    import core.stdc.stdio : snprintf;
+
+                    char["FreeBSD_100".length + 1] buffer;
+                    immutable len = snprintf(buffer.ptr, buffer.length, "FreeBSD_%u", uint(tgt.osMajor));
+                    predef(buffer[0 .. len]);
                 }
                 break;
             }


### PR DESCRIPTION
Apparently, there were two problems that needed fixing.

1. The code for the FreeBSD_14 version identifier had not been added yet.

2. The build did nothing to detect the version of FreeBSD, which makes it very easy to build for the wrong version. The CI apparently sets the version - e.g. TARGET_FREEBSD13 - but unless one of those TARGET_FREEBSD* versions is set, the build defaults to FreeBSD 11, which isn't even supported any longer.

So, this adds the code for the FreeBSD_14 identifier, and it makes it so that the build queries the OS version on FreeBSD if TARGET_FREEBSD* has not been set. So, anything that sets the TARGET_FREEBSD* version when building will control the target version as before, but if it's not set, then it will target whatever the current system is.