### PR TITLE
Fix bugzilla issue 24495 - ImportC: Struct initialization expression fails to initialize field

### DIFF
--- a/compiler/src/dmd/initsem.d
+++ b/compiler/src/dmd/initsem.d
@@ -868,11 +868,12 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                          * by the initializer syntax. if a CInitializer has a Designator, it is probably
                          * a nested anonymous struct
                          */
-                        if (cix.initializerList.length)
+                        int found;
+                        foreach (dix; cix.initializerList)
                         {
-                            DesigInit dix = cix.initializerList[0];
                             Designators* dlistx = dix.designatorList;
-                            if (dlistx && (*dlistx).length == 1 && (*dlistx)[0].ident)
+                            if (!dlistx) continue;
+                            if ((*dlistx).length == 1 && (*dlistx)[0].ident)
                             {
                                 auto id = (*dlistx)[0].ident;
                                 foreach (k, f; sd.fields[])         // linear search for now
@@ -883,11 +884,18 @@ Initializer initializerSemantic(Initializer init, Scope* sc, ref Type tx, NeedIn
                                         si.addInit(id, dix.initializer);
                                         ++fieldi;
                                         ++index;
-                                        continue Loop1;
+                                        ++found;
+                                        break;
                                     }
                                 }
                             }
+                            else {
+                                error(ci.loc, "only 1 designator currently allowed for C struct field initializer `%s`", toChars(ci));
+                            }
                         }
+
+                        if (found == cix.initializerList.length)
+                            continue Loop1;
                     }
 
                     VarDeclaration field;

--- a/compiler/test/runnable/test24495.c
+++ b/compiler/test/runnable/test24495.c
@@ -1,0 +1,40 @@
+struct Subitem {
+    int x;
+    int y;
+};
+
+struct Item {
+
+    int a;
+
+    struct {
+        int b1;
+        struct Subitem b2;
+        int b3;
+    };
+
+};
+
+int main() {
+
+    struct Item first = {
+        .a = 1,
+        .b1 = 2,
+        .b3 = 3,
+    };
+    struct Item second = {
+        .a = 1,
+        {
+            .b1 = 2,
+            .b2 = { 1, 2 },
+            .b3 = 3
+        }
+    };
+
+    return second.a != 1
+        || second.b1 != 2
+        || second.b2.x != 1
+        || second.b2.y != 2
+        || second.b3 != 3;
+
+}


### PR DESCRIPTION
Makes it possible to use multiple designated initializers for anonymous structs in expressions like `{{ .b = 2, .c = 3 }}`. This previously worked only if there was one initializer.

This is my first PR. I had some issues setting up the D runtime and I'm getting linker errors in some tests, but I didn't find any relevant documentation. I built with `make`/`make test`.

I have doubts in regards to initializers for anonymous structs/unions in general. I'm not sure if this is the correct way to approach the overall issue, but I will leave it for others to consider.