### PR TITLE
[foreach] Deprecate `ref` for array index or ForeachRangeStatement

### DIFF
--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -1321,7 +1321,7 @@ private const(char)[] processSource (const(ubyte)[] src, Module mod)
         dbuf.reserve(eBuf.length);
 
         //i will be incremented in the loop for high codepoints
-        foreach (ref i; 0 .. eBuf.length)
+        for (size_t i = 0; i < eBuf.length; i++)
         {
             uint u = readNext(&eBuf[i]);
             if (u & ~0x7F)

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1002,7 +1002,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     if (p0.storageClass & STC.ref_ &&
                         !(p0.storageClass & (STC.const_ | STC.immutable_ | STC.wild)))
                     {
-                        // @@@DEPRECATED_2.119@@@
+                        // @@@DEPRECATED_2.121@@@
                         // turn deprecation into an error & uncomment return
                         deprecation(fs.loc, "`foreach` array index variable `%s` cannot be `ref`",
                             p0.toChars());
@@ -1476,7 +1476,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         if (fs.param.storageClass & STC.ref_ &&
             !(fs.param.storageClass & (STC.const_ | STC.immutable_ | STC.wild)))
         {
-            // @@@DEPRECATED_2.119@@@
+            // @@@DEPRECATED_2.121@@@
             // turn deprecation into an error & uncomment return
             deprecation(fs.loc, "`foreach` range variable `%s` cannot be `ref`",
                 fs.param.toChars());

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -996,14 +996,20 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     return retError();
                 }
 
-                if (dim == 2 && (*fs.parameters)[0].storageClass & STC.ref_)
+                if (dim == 2)
                 {
-                    // @@@DEPRECATED_2.119@@@
-                    // turn deprecation into an error & uncomment return
-                    deprecation(fs.loc, "`foreach` array index variable `%s` cannot be `ref`",
-                        (*fs.parameters)[0].toChars());
-                    deprecationSupplemental(fs.loc, "use a `for` loop instead");
-                    //return retError();
+                    auto p0 = (*fs.parameters)[0];
+                    if (p0.storageClass & STC.ref_ &&
+                        !(p0.storageClass & (STC.const_ | STC.immutable_)))
+                    {
+                        // @@@DEPRECATED_2.119@@@
+                        // turn deprecation into an error & uncomment return
+                        deprecation(fs.loc, "`foreach` array index variable `%s` cannot be `ref`",
+                            p0.toChars());
+                        deprecationSupplemental(fs.loc, "either make `%s` const or use a `for` loop instead",
+                            p0.toChars());
+                        //return retError();
+                    }
                 }
 
                 // Finish semantic on all foreach parameter types.
@@ -1467,13 +1473,15 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         /* https://dlang.org/spec/statement.html#foreach-range-statement
          */
 
-        if (fs.prm.storageClass & STC.ref_)
+        if (fs.prm.storageClass & STC.ref_ &&
+            !(fs.prm.storageClass & (STC.const_ | STC.immutable_)))
         {
             // @@@DEPRECATED_2.119@@@
             // turn deprecation into an error & uncomment return
             deprecation(fs.loc, "`foreach` range variable `%s` cannot be `ref`",
                 fs.prm.toChars());
-            deprecationSupplemental(fs.loc, "use a `for` loop instead");
+            deprecationSupplemental(fs.loc, "either make `%s` const or use a `for` loop instead",
+                fs.prm.toChars());
             //return setError();
         }
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -996,6 +996,12 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                     return retError();
                 }
 
+                if (dim == 2 && (*fs.parameters)[0].storageClass & STC.ref_)
+                {
+                    deprecation(fs.loc, "`%s` cannot be `ref`", (*fs.parameters)[0].toChars());
+                    return retError();
+                }
+
                 // Finish semantic on all foreach parameter types.
                 foreach (i; 0 .. dim)
                 {
@@ -1456,6 +1462,12 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
     {
         /* https://dlang.org/spec/statement.html#foreach-range-statement
          */
+
+        if (fs.prm.storageClass & STC.ref_)
+        {
+            deprecation(fs.loc, "`%s` cannot be `ref`", fs.prm.toChars());
+            return setError();
+        }
 
         //printf("ForeachRangeStatement::semantic() %p\n", fs);
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -998,10 +998,12 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
                 if (dim == 2 && (*fs.parameters)[0].storageClass & STC.ref_)
                 {
+                    // @@@DEPRECATED_2.119@@@
+                    // turn deprecation into an error & uncomment return
                     deprecation(fs.loc, "`foreach` array index variable `%s` cannot be `ref`",
                         (*fs.parameters)[0].toChars());
                     deprecationSupplemental(fs.loc, "use a `for` loop instead");
-                    return retError();
+                    //return retError();
                 }
 
                 // Finish semantic on all foreach parameter types.
@@ -1467,10 +1469,12 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         if (fs.prm.storageClass & STC.ref_)
         {
+            // @@@DEPRECATED_2.119@@@
+            // turn deprecation into an error & uncomment return
             deprecation(fs.loc, "`foreach` range variable `%s` cannot be `ref`",
                 fs.prm.toChars());
             deprecationSupplemental(fs.loc, "use a `for` loop instead");
-            return setError();
+            //return setError();
         }
 
         //printf("ForeachRangeStatement::semantic() %p\n", fs);

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1471,16 +1471,6 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         /* https://dlang.org/spec/statement.html#foreach-range-statement
          */
 
-        if (fs.param.storageClass & STC.ref_)
-        {
-            // @@@DEPRECATED_2.121@@@
-            // turn deprecation into an error & uncomment return
-            deprecation(fs.loc, "`foreach` range variable `%s` cannot be `ref`",
-                fs.param.toChars());
-            deprecationSupplemental(fs.loc, "use a `for` loop instead");
-            //return setError();
-        }
-
         //printf("ForeachRangeStatement::semantic() %p\n", fs);
 
         if (fs.param.storageClass & STC.manifest)
@@ -1564,6 +1554,18 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         if (fs.param.type.ty == Terror || fs.lwr.op == EXP.error || fs.upr.op == EXP.error)
         {
             return setError();
+        }
+
+        // a struct is allowed to be `ref` to prevent destructor calls
+        // see runnable/foreach5.d:test6659
+        if (fs.param.storageClass & STC.ref_ && !fs.param.type.isTypeStruct())
+        {
+            // @@@DEPRECATED_2.121@@@
+            // turn deprecation into an error & uncomment return
+            deprecation(fs.loc, "`foreach` range variable `%s` cannot be `ref`",
+                fs.param.toChars());
+            deprecationSupplemental(fs.loc, "use a `for` loop instead");
+            //return setError();
         }
 
         /* Convert to a for loop:

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -999,15 +999,13 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 if (dim == 2)
                 {
                     auto p0 = (*fs.parameters)[0];
-                    if (p0.storageClass & STC.ref_ &&
-                        !(p0.storageClass & (STC.const_ | STC.immutable_ | STC.wild)))
+                    if (p0.storageClass & STC.ref_)
                     {
                         // @@@DEPRECATED_2.121@@@
                         // turn deprecation into an error & uncomment return
                         deprecation(fs.loc, "`foreach` array index variable `%s` cannot be `ref`",
                             p0.toChars());
-                        deprecationSupplemental(fs.loc, "either make `%s` const or use a `for` loop instead",
-                            p0.toChars());
+                        deprecationSupplemental(fs.loc, "use a `for` loop instead");
                         //return retError();
                     }
                 }
@@ -1473,15 +1471,13 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         /* https://dlang.org/spec/statement.html#foreach-range-statement
          */
 
-        if (fs.param.storageClass & STC.ref_ &&
-            !(fs.param.storageClass & (STC.const_ | STC.immutable_ | STC.wild)))
+        if (fs.param.storageClass & STC.ref_)
         {
             // @@@DEPRECATED_2.121@@@
             // turn deprecation into an error & uncomment return
             deprecation(fs.loc, "`foreach` range variable `%s` cannot be `ref`",
                 fs.param.toChars());
-            deprecationSupplemental(fs.loc, "either make `%s` const or use a `for` loop instead",
-                fs.param.toChars());
+            deprecationSupplemental(fs.loc, "use a `for` loop instead");
             //return setError();
         }
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -998,7 +998,9 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
                 if (dim == 2 && (*fs.parameters)[0].storageClass & STC.ref_)
                 {
-                    deprecation(fs.loc, "`%s` cannot be `ref`", (*fs.parameters)[0].toChars());
+                    deprecation(fs.loc, "`foreach` array index variable `%s` cannot be `ref`",
+                        (*fs.parameters)[0].toChars());
+                    deprecationSupplemental(fs.loc, "use a `for` loop instead");
                     return retError();
                 }
 
@@ -1465,7 +1467,9 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
 
         if (fs.prm.storageClass & STC.ref_)
         {
-            deprecation(fs.loc, "`%s` cannot be `ref`", fs.prm.toChars());
+            deprecation(fs.loc, "`foreach` range variable `%s` cannot be `ref`",
+                fs.prm.toChars());
+            deprecationSupplemental(fs.loc, "use a `for` loop instead");
             return setError();
         }
 

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1000,7 +1000,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
                 {
                     auto p0 = (*fs.parameters)[0];
                     if (p0.storageClass & STC.ref_ &&
-                        !(p0.storageClass & (STC.const_ | STC.immutable_)))
+                        !(p0.storageClass & (STC.const_ | STC.immutable_ | STC.wild)))
                     {
                         // @@@DEPRECATED_2.119@@@
                         // turn deprecation into an error & uncomment return
@@ -1473,15 +1473,15 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
         /* https://dlang.org/spec/statement.html#foreach-range-statement
          */
 
-        if (fs.prm.storageClass & STC.ref_ &&
-            !(fs.prm.storageClass & (STC.const_ | STC.immutable_)))
+        if (fs.param.storageClass & STC.ref_ &&
+            !(fs.param.storageClass & (STC.const_ | STC.immutable_ | STC.wild)))
         {
             // @@@DEPRECATED_2.119@@@
             // turn deprecation into an error & uncomment return
             deprecation(fs.loc, "`foreach` range variable `%s` cannot be `ref`",
-                fs.prm.toChars());
+                fs.param.toChars());
             deprecationSupplemental(fs.loc, "either make `%s` const or use a `for` loop instead",
-                fs.prm.toChars());
+                fs.param.toChars());
             //return setError();
         }
 

--- a/compiler/test/compilable/interpret3.d
+++ b/compiler/test/compilable/interpret3.d
@@ -3,7 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/interpret3.d(6351): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
+compilable/interpret3.d(5308): Deprecation: `foreach` range variable `i` cannot be `ref`
+compilable/interpret3.d(5308):        either make `i` const or use a `for` loop instead
+compilable/interpret3.d(6353): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
 ---
 */
 

--- a/compiler/test/compilable/interpret3.d
+++ b/compiler/test/compilable/interpret3.d
@@ -4,7 +4,7 @@
 TEST_OUTPUT:
 ---
 compilable/interpret3.d(5308): Deprecation: `foreach` range variable `i` cannot be `ref`
-compilable/interpret3.d(5308):        either make `i` const or use a `for` loop instead
+compilable/interpret3.d(5308):        use a `for` loop instead
 compilable/interpret3.d(6353): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
 ---
 */

--- a/compiler/test/compilable/test4090.d
+++ b/compiler/test/compilable/test4090.d
@@ -82,24 +82,10 @@ void test4090b()
         foreach (    const i, x; arr) static assert(is(typeof(i) == const size_t));
         foreach (immutable i, x; arr) static assert(is(typeof(i) == immutable size_t));
 
-        // inference + qualifier + ref
-        foreach (          ref i, x; arr) static assert(is(typeof(i) == size_t));
-        foreach (    const ref i, x; arr) static assert(is(typeof(i) == const size_t));
-      static assert(!__traits(compiles, {
-        foreach (immutable ref i, x; arr) {}
-      }));
-
         // with exact type + qualifier
         foreach (          size_t i, x; arr) static assert(is(typeof(i) == size_t));
         foreach (    const size_t i, x; arr) static assert(is(typeof(i) == const size_t));
         foreach (immutable size_t i, x; arr) static assert(is(typeof(i) == immutable size_t));
-
-        // with exact type + qualifier + ref
-        foreach (          ref size_t i, x; arr) static assert(is(typeof(i) == size_t));
-        foreach (    const ref size_t i, x; arr) static assert(is(typeof(i) == const size_t));
-      static assert(!__traits(compiles, {
-        foreach (immutable ref size_t i, x; arr) {}
-      }));
     }
 
     // for the mutable elements
@@ -200,19 +186,7 @@ void test4090c()
     foreach (    const int x; 1..11) static assert(is(typeof(x) == const int));
     foreach (immutable int x; 1..11) static assert(is(typeof(x) == immutable int));
 
-    foreach (          ref x; 1..11) static assert(is(typeof(x) == int));
-    foreach (    const ref x; 1..11) static assert(is(typeof(x) == const int));
-  static assert(!__traits(compiles, {
-    foreach (immutable ref x; 1..11) {}
-  }));
-
     foreach (          double x; 1..11) static assert(is(typeof(x) == double));
     foreach (    const double x; 1..11) static assert(is(typeof(x) == const double));
     foreach (immutable double x; 1..11) static assert(is(typeof(x) == immutable double));
-
-    foreach (          ref double x; 1..11) static assert(is(typeof(x) == double));
-    foreach (    const ref double x; 1..11) static assert(is(typeof(x) == const double));
-  static assert(!__traits(compiles, {
-    foreach (immutable ref double x; 1..11) {}
-  }));
 }

--- a/compiler/test/fail_compilation/diag10221.d
+++ b/compiler/test/fail_compilation/diag10221.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10221.d(10): Error: cannot implicitly convert expression `256` of type `int` to `ubyte`
+fail_compilation/diag10221.d(10): Error: cannot implicitly convert expression `257` of type `int` to `ubyte`
 ---
 */
 
 void main()
 {
-    foreach(ref ubyte i; 0..256) {}
+    foreach(ubyte i; 0..257) {}
 }

--- a/compiler/test/fail_compilation/fail6652.d
+++ b/compiler/test/fail_compilation/fail6652.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -w -dw -de -d
+// REQUIRED_ARGS: -de
 
 /******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=6652
@@ -7,9 +7,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail6652.d(20): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(25): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(23): Deprecation: `i` cannot be `ref`
 fail_compilation/fail6652.d(30): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(35): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(33): Deprecation: `i` cannot be `ref`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail6652.d
+++ b/compiler/test/fail_compilation/fail6652.d
@@ -6,10 +6,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6652.d(20): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(23): Deprecation: `i` cannot be `ref`
-fail_compilation/fail6652.d(30): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(33): Deprecation: `i` cannot be `ref`
+fail_compilation/fail6652.d(22): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(25): Deprecation: `foreach` range variable `i` cannot be `ref`
+fail_compilation/fail6652.d(25):        use a `for` loop instead
+fail_compilation/fail6652.d(32): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(35): Deprecation: `foreach` array index variable `i` cannot be `ref`
+fail_compilation/fail6652.d(35):        use a `for` loop instead
 ---
 */
 

--- a/compiler/test/fail_compilation/fail6652.d
+++ b/compiler/test/fail_compilation/fail6652.d
@@ -6,12 +6,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6652.d(22): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(25): Deprecation: `foreach` range variable `i` cannot be `ref`
-fail_compilation/fail6652.d(25):        use a `for` loop instead
-fail_compilation/fail6652.d(32): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(35): Deprecation: `foreach` array index variable `i` cannot be `ref`
-fail_compilation/fail6652.d(35):        use a `for` loop instead
+fail_compilation/fail6652.d(20): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(25): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(30): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(35): Error: cannot modify `const` expression `i`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail6652.d
+++ b/compiler/test/fail_compilation/fail6652.d
@@ -6,10 +6,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6652.d(20): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(25): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(30): Error: cannot modify `const` expression `i`
-fail_compilation/fail6652.d(35): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(24): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(27): Deprecation: `foreach` range variable `i` cannot be `ref`
+fail_compilation/fail6652.d(27):        use a `for` loop instead
+fail_compilation/fail6652.d(29): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(34): Error: cannot modify `const` expression `i`
+fail_compilation/fail6652.d(37): Deprecation: `foreach` array index variable `i` cannot be `ref`
+fail_compilation/fail6652.d(37):        use a `for` loop instead
+fail_compilation/fail6652.d(39): Error: cannot modify `const` expression `i`
 ---
 */
 

--- a/compiler/test/runnable/foreach5.d
+++ b/compiler/test/runnable/foreach5.d
@@ -348,7 +348,7 @@ void test6659()
         static size_t _dtor;
     }
 
-    foreach (ref iter; Iter(0) .. Iter(10))
+    foreach (ref const iter; Iter(0) .. Iter(10))
     {
         assert(Iter._dtor == 0);
     }

--- a/compiler/test/runnable/foreach5.d
+++ b/compiler/test/runnable/foreach5.d
@@ -528,19 +528,9 @@ void test6652()
     assert(sum == 45);
 
     sum = 0;
-    foreach (ref i; 0 .. 10)
-        sum += i++; // 02468
-    assert(sum == 20);
-
-    sum = 0;
     foreach_reverse (i; 0 .. 10)
         sum += i--; // 9876543210
     assert(sum == 45);
-
-    sum = 0;
-    foreach_reverse (ref i; 0 .. 10)
-        sum += i--; // 97531
-    assert(sum == 25);
 
     enum ary = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     sum = 0;
@@ -552,28 +542,12 @@ void test6652()
     assert(sum == 45);
 
     sum = 0;
-    foreach (ref i, v; ary)
-    {
-        assert(i == v);
-        sum += i++; // 02468
-    }
-    assert(sum == 20);
-
-    sum = 0;
     foreach_reverse (i, v; ary)
     {
         assert(i == v);
         sum += i--; // 9876543210
     }
     assert(sum == 45);
-
-    sum = 0;
-    foreach_reverse (ref i, v; ary)
-    {
-        assert(i == v);
-        sum += i--; // 97531
-    }
-    assert(sum == 25);
 
     static struct Iter
     {
@@ -601,21 +575,11 @@ void test6652()
         sum += v._pos++; // 0123456789
     assert(sum == 45 && Iter._dtorCount == 12);
 
-    Iter._dtorCount = sum = 0;
-    foreach (ref v; Iter(0) .. Iter(10))
-        sum += v._pos++; // 02468
-    assert(sum == 20 && Iter._dtorCount == 2);
-
     // additional dtor calls due to unnecessary postdecrements
     Iter._dtorCount = sum = 0;
     foreach_reverse (v; Iter(0) .. Iter(10))
         sum += v._pos--; // 9876543210
     assert(sum == 45 && Iter._dtorCount >= 12);
-
-    Iter._dtorCount = sum = 0;
-    foreach_reverse (ref v; Iter(0) .. Iter(10))
-        sum += v._pos--; // 97531
-    assert(sum == 25 && Iter._dtorCount >= 2);
 }
 
 /***************************************/

--- a/compiler/test/runnable/foreach5.d
+++ b/compiler/test/runnable/foreach5.d
@@ -348,7 +348,7 @@ void test6659()
         static size_t _dtor;
     }
 
-    foreach (const iter; Iter(0) .. Iter(10))
+    foreach (ref iter; Iter(0) .. Iter(10))
     {
         assert(Iter._dtor == 0);
     }

--- a/compiler/test/runnable/foreach5.d
+++ b/compiler/test/runnable/foreach5.d
@@ -233,7 +233,7 @@ void test4090b()
   static assert(!__traits(compiles, {
     foreach (immutable ref x; 1..11) {}
   }));
-    foreach (const ref x; 1..11)
+    foreach (const x; 1..11)
     {
         static assert(is(typeof(x) == const int));
         tot += x;
@@ -348,7 +348,7 @@ void test6659()
         static size_t _dtor;
     }
 
-    foreach (ref const iter; Iter(0) .. Iter(10))
+    foreach (const iter; Iter(0) .. Iter(10))
     {
         assert(Iter._dtor == 0);
     }

--- a/compiler/test/runnable/iasm.d
+++ b/compiler/test/runnable/iasm.d
@@ -3899,7 +3899,7 @@ L1:     pop     EAX     ;
         mov     p[EBP],EAX ;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4284,7 +4284,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4578,7 +4578,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4656,7 +4656,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4720,7 +4720,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4785,7 +4785,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         // printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4835,7 +4835,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);

--- a/compiler/test/runnable/iasm.d
+++ b/compiler/test/runnable/iasm.d
@@ -3899,7 +3899,7 @@ L1:     pop     EAX     ;
         mov     p[EBP],EAX ;
     }
 
-    foreach (const ref i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4284,7 +4284,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4578,7 +4578,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4656,7 +4656,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4720,7 +4720,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4785,7 +4785,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         // printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4835,7 +4835,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);

--- a/compiler/test/runnable/iasm.d
+++ b/compiler/test/runnable/iasm.d
@@ -4284,7 +4284,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4578,7 +4578,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4656,7 +4656,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4720,7 +4720,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4785,7 +4785,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         // printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4835,7 +4835,7 @@ L1:     pop     EAX;
         mov     p[EBP],EAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);

--- a/compiler/test/runnable/iasm64.d
+++ b/compiler/test/runnable/iasm64.d
@@ -3926,7 +3926,7 @@ L1:     pop     RAX     ;
         mov     p[RBP],RAX ;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4061,7 +4061,7 @@ L1:     pop     RAX     ;
         mov     p[RBP],RAX ;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4140,7 +4140,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4190,7 +4190,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4390,7 +4390,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4722,7 +4722,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4812,7 +4812,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4848,7 +4848,7 @@ L1:
         mov p[RBP], RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         assert(p[i] == b);
     }
@@ -6460,7 +6460,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6525,7 +6525,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6587,7 +6587,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         // printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6621,7 +6621,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6673,7 +6673,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         // printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6723,7 +6723,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6757,7 +6757,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6800,7 +6800,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6849,7 +6849,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (ref i, b; data)
+    foreach (const ref i, b; data)
     {
         assert(p[i] == b);
     }

--- a/compiler/test/runnable/iasm64.d
+++ b/compiler/test/runnable/iasm64.d
@@ -3926,7 +3926,7 @@ L1:     pop     RAX     ;
         mov     p[RBP],RAX ;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4061,7 +4061,7 @@ L1:     pop     RAX     ;
         mov     p[RBP],RAX ;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4140,7 +4140,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4190,7 +4190,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4390,7 +4390,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4722,7 +4722,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4812,7 +4812,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4848,7 +4848,7 @@ L1:
         mov p[RBP], RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         assert(p[i] == b);
     }
@@ -6460,7 +6460,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6525,7 +6525,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6587,7 +6587,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         // printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6621,7 +6621,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6673,7 +6673,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         // printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6723,7 +6723,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6757,7 +6757,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6800,7 +6800,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6849,7 +6849,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const i, b; data)
+    foreach (i, b; data)
     {
         assert(p[i] == b);
     }

--- a/compiler/test/runnable/iasm64.d
+++ b/compiler/test/runnable/iasm64.d
@@ -3926,7 +3926,7 @@ L1:     pop     RAX     ;
         mov     p[RBP],RAX ;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4061,7 +4061,7 @@ L1:     pop     RAX     ;
         mov     p[RBP],RAX ;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4140,7 +4140,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4190,7 +4190,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4390,7 +4390,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4722,7 +4722,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4812,7 +4812,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -4848,7 +4848,7 @@ L1:
         mov p[RBP], RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         assert(p[i] == b);
     }
@@ -6460,7 +6460,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6525,7 +6525,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6587,7 +6587,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         // printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6621,7 +6621,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6673,7 +6673,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         // printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6723,7 +6723,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6757,7 +6757,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6800,7 +6800,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
         assert(p[i] == b);
@@ -6849,7 +6849,7 @@ L1:     pop     RAX;
         mov     p[RBP],RAX;
     }
 
-    foreach (const ref i, b; data)
+    foreach (const i, b; data)
     {
         assert(p[i] == b);
     }

--- a/compiler/test/runnable/test_cdstrpar.d
+++ b/compiler/test/runnable/test_cdstrpar.d
@@ -193,7 +193,7 @@ alias baselineCases = AliasSeq!(
 bool matches(const(ubyte)[] code, const(ubyte)[] exp)
 {
     assert(code.length == exp.length);
-    foreach (ref i; 0 .. code.length)
+    for (size_t i = 0; i < code.length; i++)
     {
         if (code[i] == exp[i])
             continue;


### PR DESCRIPTION
Fix Bugzilla 24499 - foreach over a ref parameter to an rvalue should be an error 
Fix Bugzilla 24232 - ref for index of foreach for arrays is not allowed by spec but accepted by compiler