### PR TITLE
[editions] Make `body` after contract an error

### DIFF
--- a/compiler/src/build.d
+++ b/compiler/src/build.d
@@ -5,6 +5,8 @@ DMD builder
 Usage:
   ./build.d dmd
 
+See `--help` for targets.
+
 detab, tolf, install targets - require the D Language Tools (detab.exe, tolf.exe)
   https://github.com/dlang/tools.
 

--- a/compiler/src/dmd/astbase.d
+++ b/compiler/src/dmd/astbase.d
@@ -1397,6 +1397,7 @@ struct ASTBase
 
         const FileName srcfile;
         const(char)[] arg;
+        Edition edition = Edition.legacy;
 
         extern (D) this(const ref Loc loc, const(char)[] filename, Identifier ident, int doDocComment, int doHdrGen)
         {

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -1212,9 +1212,10 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             params.warnings = DiagnosticReporting.inform;
         else if (arg == "-wo")  // https://dlang.org/dmd.html#switch-wo
         {
-            // Obsolete features has been obsoleted until a DIP for "additions"
+            // Obsolete features has been obsoleted until a DIP for "editions"
             // has been drafted and ratified in the language spec.
             // Rather, these old features will just be accepted without warning.
+            // See also: @__edition_latest_do_not_use
         }
         else if (arg == "-O")   // https://dlang.org/dmd.html#switch-O
             driverParams.optimize = true;

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -9589,9 +9589,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
     void usageOfBodyKeyword()
     {
-        version (none)  // disable obsolete warning
+        if (mod.edition >= Edition.v2024)
         {
-            eSink.warning(token.loc, "usage of identifer `body` as a keyword is obsolete. Use `do` instead.");
+            eSink.error(token.loc, "usage of identifer `body` as a keyword is obsolete. Use `do` instead.");
         }
     }
 }

--- a/compiler/test/fail_compilation/obsolete_body.d
+++ b/compiler/test/fail_compilation/obsolete_body.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/obsolete_body.d(11): Error: usage of identifer `body` as a keyword is obsolete. Use `do` instead.
+---
+*/
+@__edition_latest_do_not_use
+module m;
+
+void test()
+in { } body { }


### PR DESCRIPTION
See also: https://github.com/dlang/dmd/pull/16340, https://github.com/dlang/dmd/pull/15612.