### PR TITLE
Fix Bugzilla Issue 24504 - ImportC: Enum declarations with a mixture …

### DIFF
--- a/compiler/src/dmd/enumsem.d
+++ b/compiler/src/dmd/enumsem.d
@@ -325,7 +325,10 @@ void enumSemantic(Scope* sc, EnumDeclaration ed)
                 if (EnumMember em = s.isEnumMember())
                 {
                     em.type = commonType;
-                    em.value = em.value.castTo(sc, commonType);
+                    // optimize out the cast so that other parts of the compiler can
+                    // assume that an integral enum's members are `IntegerExp`s.
+                    // https://issues.dlang.org/show_bug.cgi?id=24504
+                    em.value = em.value.castTo(sc, commonType).optimize(WANTvalue);
                 }
             });
         }

--- a/compiler/test/compilable/test24504.c
+++ b/compiler/test/compilable/test24504.c
@@ -1,0 +1,10 @@
+// REQUIRED_ARGS: -os=windows -g
+// DISABLED: osx
+// This is disabled on macOS because ld complains about _main being undefined
+// when clang attempts to preprocess the C file.
+
+typedef enum
+{
+    HasIntAndUIntValuesInt = 0,
+    HasIntAndUIntValuesUInt = 0x80000000
+} HasIntAndUIntValues;


### PR DESCRIPTION
…of `int` and `uint` literal values cause errors, when targeting Windows, when debug info generation is enabled.

---

The value of a C enum's member can be a `CastExp` instead of an `IntegerExp`, causing these calls to `toInteger` to emit an error.
So instead, if the value is a `CastExp` we make an `IntegerExp` out of it and go about as normal from there.
