### PR TITLE
Enables C preprocessing for .i files

### DIFF
--- a/compiler/src/dmd/cli.d
+++ b/compiler/src/dmd/cli.d
@@ -273,8 +273,8 @@ dmd -cov -unittest myprog.d
         Option("cpp=<filename>",
             "use filename as the name of the C preprocessor to use for ImportC files",
             `Normally the C preprocessor used by the associated C compiler is used to
-            preprocess ImportC files,
-            this is overridden by the $(TT -cpp) switch.`
+            preprocess ImportC files, this is overridden by the $(TT -cpp) switch.
+            Preprocessing disabled if specified with empty <filename>.`
         ),
         Option("D",
             "generate documentation",

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -675,19 +675,21 @@ extern (C++) final class Module : Package
 
         //printf("Module::read('%s') file '%s'\n", toChars(), srcfile.toChars());
 
-        /* Preprocess the file if it's a .c file
+        /* Preprocess the file if it's a .c or .i file
          */
         FileName filename = srcfile;
 
         const(ubyte)[] srctext;
+        bool alreadyPreprocessed;
         if (global.preprocess &&
-            FileName.equalsExt(srcfile.toString(), c_ext) &&
+            ((alreadyPreprocessed = FileName.equalsExt(srcfile.toString(), i_ext)) == true ||
+            FileName.equalsExt(srcfile.toString(), c_ext)) &&
             FileName.exists(srcfile.toString()))
         {
-            /* Apply C preprocessor to the .c file, returning the contents
+            /* Apply C preprocessor to the file, returning the contents
              * after preprocessing
              */
-            srctext = global.preprocess(srcfile, loc, defines).data;
+            srctext = global.preprocess(srcfile, loc, alreadyPreprocessed, defines).data;
         }
         else
             srctext = global.fileManager.getFileContents(filename);

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -6561,7 +6561,7 @@ public:
     const char* toChars() const override;
 };
 
-extern DArray<uint8_t > preprocess(FileName csrcfile, const Loc& loc, OutBuffer& defines);
+extern DArray<const uint8_t > preprocess(FileName csrcfile, const Loc& loc, bool alreadyPreprocessed, OutBuffer& defines);
 
 struct BaseClass final
 {
@@ -8062,6 +8062,7 @@ struct Param final
     bool addMain;
     bool allInst;
     bool bitfields;
+    bool usePreprocessor;
     CppStdRevision cplusplus;
     Help help;
     Verbose v;
@@ -8145,6 +8146,7 @@ struct Param final
         addMain(),
         allInst(),
         bitfields(),
+        usePreprocessor(true),
         cplusplus((CppStdRevision)201103u),
         help(),
         v(),
@@ -8198,7 +8200,7 @@ struct Param final
         mapfile()
     {
     }
-    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* > imppath = Array<const char* >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, uint32_t versionlevel = 0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
+    Param(bool obj, bool multiobj = false, bool trace = false, bool tracegc = false, bool vcg_ast = false, DiagnosticReporting useDeprecated = (DiagnosticReporting)1u, bool useUnitTests = false, bool useInline = false, bool release = false, bool preservePaths = false, DiagnosticReporting warnings = (DiagnosticReporting)2u, bool cov = false, uint8_t covPercent = 0u, bool ctfe_cov = false, bool ignoreUnsupportedPragmas = true, bool useModuleInfo = true, bool useTypeInfo = true, bool useExceptions = true, bool useGC = true, bool betterC = false, bool addMain = false, bool allInst = false, bool bitfields = false, bool usePreprocessor = true, CppStdRevision cplusplus = (CppStdRevision)201103u, Help help = Help(), Verbose v = Verbose(), FeatureState useDIP25 = (FeatureState)2u, FeatureState useDIP1000 = (FeatureState)0u, bool ehnogc = false, bool useDIP1021 = false, FeatureState fieldwise = (FeatureState)0u, bool fixAliasThis = false, FeatureState rvalueRefParam = (FeatureState)0u, FeatureState noSharedAccess = (FeatureState)0u, bool previewIn = false, bool inclusiveInContracts = false, bool shortenedMethods = true, bool fixImmutableConv = false, bool fix16997 = true, FeatureState dtorFields = (FeatureState)0u, FeatureState systemVariables = (FeatureState)0u, CHECKENABLE useInvariants = (CHECKENABLE)0u, CHECKENABLE useIn = (CHECKENABLE)0u, CHECKENABLE useOut = (CHECKENABLE)0u, CHECKENABLE useArrayBounds = (CHECKENABLE)0u, CHECKENABLE useAssert = (CHECKENABLE)0u, CHECKENABLE useSwitchError = (CHECKENABLE)0u, CHECKENABLE boundscheck = (CHECKENABLE)0u, CHECKACTION checkAction = (CHECKACTION)0u, CLIIdentifierTable dIdentifierTable = (CLIIdentifierTable)0u, CLIIdentifierTable cIdentifierTable = (CLIIdentifierTable)0u, _d_dynamicArray< const char > argv0 = {}, Array<const char* > modFileAliasStrings = Array<const char* >(), Array<const char* > imppath = Array<const char* >(), Array<const char* > fileImppath = Array<const char* >(), _d_dynamicArray< const char > objdir = {}, _d_dynamicArray< const char > objname = {}, _d_dynamicArray< const char > libname = {}, Output ddoc = Output(), Output dihdr = Output(), Output cxxhdr = Output(), Output json = Output(), JsonFieldFlags jsonFieldFlags = (JsonFieldFlags)0u, Output makeDeps = Output(), Output mixinOut = Output(), Output moduleDeps = Output(), uint32_t debuglevel = 0u, uint32_t versionlevel = 0u, bool run = false, Array<const char* > runargs = Array<const char* >(), Array<const char* > cppswitches = Array<const char* >(), const char* cpp = nullptr, Array<const char* > objfiles = Array<const char* >(), Array<const char* > linkswitches = Array<const char* >(), Array<bool > linkswitchIsForCC = Array<bool >(), Array<const char* > libfiles = Array<const char* >(), Array<const char* > dllfiles = Array<const char* >(), _d_dynamicArray< const char > deffile = {}, _d_dynamicArray< const char > resfile = {}, _d_dynamicArray< const char > exefile = {}, _d_dynamicArray< const char > mapfile = {}) :
         obj(obj),
         multiobj(multiobj),
         trace(trace),
@@ -8222,6 +8224,7 @@ struct Param final
         addMain(addMain),
         allInst(allInst),
         bitfields(bitfields),
+        usePreprocessor(usePreprocessor),
         cplusplus(cplusplus),
         help(help),
         v(v),
@@ -8309,7 +8312,7 @@ struct Global final
 
     ErrorSink* errorSink;
     ErrorSink* errorSinkNull;
-    DArray<uint8_t >(*preprocess)(FileName , const Loc& , OutBuffer& );
+    DArray<const uint8_t >(*preprocess)(FileName , const Loc& , bool alreadyPreprocessed, OutBuffer& );
     uint32_t startGagging();
     bool endGagging(uint32_t oldGagged);
     void increaseErrorCount();
@@ -8341,7 +8344,7 @@ struct Global final
         preprocess()
     {
     }
-    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* > path = Array<const char* >(), Array<const char* > filePath = Array<const char* >(), CompileEnv compileEnv = CompileEnv(), Param params = Param(), uint32_t errors = 0u, uint32_t deprecations = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* > versionids = Array<Identifier* >(), Array<Identifier* > debugids = Array<Identifier* >(), bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, ErrorSink* errorSink = nullptr, ErrorSink* errorSinkNull = nullptr, DArray<uint8_t >(*preprocess)(FileName , const Loc& , OutBuffer& ) = nullptr) :
+    Global(_d_dynamicArray< const char > inifilename, _d_dynamicArray< const char > copyright = { 73, "Copyright (C) 1999-2024 by The D Language Foundation, All Rights Reserved" }, _d_dynamicArray< const char > written = { 24, "written by Walter Bright" }, Array<const char* > path = Array<const char* >(), Array<const char* > filePath = Array<const char* >(), CompileEnv compileEnv = CompileEnv(), Param params = Param(), uint32_t errors = 0u, uint32_t deprecations = 0u, uint32_t warnings = 0u, uint32_t gag = 0u, uint32_t gaggedErrors = 0u, uint32_t gaggedWarnings = 0u, void* console = nullptr, Array<Identifier* > versionids = Array<Identifier* >(), Array<Identifier* > debugids = Array<Identifier* >(), bool hasMainFunction = false, uint32_t varSequenceNumber = 1u, FileManager* fileManager = nullptr, ErrorSink* errorSink = nullptr, ErrorSink* errorSinkNull = nullptr, DArray<const uint8_t >(*preprocess)(FileName , const Loc& , bool alreadyPreprocessed, OutBuffer& ) = nullptr) :
         inifilename(inifilename),
         copyright(copyright),
         written(written),

--- a/compiler/src/dmd/globals.d
+++ b/compiler/src/dmd/globals.d
@@ -170,6 +170,7 @@ extern (C++) struct Param
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations
     bool bitfields;         // support C style bit fields
+    bool usePreprocessor = true; // enable preprocessor for importC
 
     CppStdRevision cplusplus = CppStdRevision.cpp11;    // version of C++ standard to support
 
@@ -306,7 +307,7 @@ extern (C++) struct Global
     ErrorSink errorSink;       /// where the error messages go
     ErrorSink errorSinkNull;   /// where the error messages are ignored
 
-    extern (C++) DArray!ubyte function(FileName, ref const Loc, ref OutBuffer) preprocess;
+    extern (C++) DArray!(const ubyte) function(FileName, ref const Loc, bool alreadyPreprocessed, ref OutBuffer) preprocess;
 
   nothrow:
 

--- a/compiler/src/dmd/mars.d
+++ b/compiler/src/dmd/mars.d
@@ -629,8 +629,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             }
             else
             {
-                errorInvalidSwitch(p, "it must be followed by the filename of the desired C preprocessor");
-                return false;
+                params.usePreprocessor = false;
             }
         }
         else if (arg == "-de")               // https://dlang.org/dmd.html#switch-de

--- a/compiler/src/dmd/utils.d
+++ b/compiler/src/dmd/utils.d
@@ -77,7 +77,7 @@ bool readFile(Loc loc, const(char)[] filename, ref OutBuffer buf)
  * Returns:
  *   false on error
  */
-extern (D) bool writeFile(Loc loc, const(char)[] filename, const void[] data)
+extern (D) bool writeFile(const Loc loc, const(char)[] filename, const void[] data)
 {
     if (!ensurePathToNameExists(Loc.initial, filename))
         return false;

--- a/compiler/test/compilable/ctod.i
+++ b/compiler/test/compilable/ctod.i
@@ -1,6 +1,6 @@
 /*
 PERMUTE_ARGS:
-REQUIRED_ARGS: -Hf=${RESULTS_DIR}/compilable/ctod.di
+REQUIRED_ARGS: -cpp= -Hf=${RESULTS_DIR}/compilable/ctod.di
 OUTPUT_FILES: ${RESULTS_DIR}/compilable/ctod.di
 
 TEST_OUTPUT:

--- a/compiler/test/compilable/iprepr.i
+++ b/compiler/test/compilable/iprepr.i
@@ -1,0 +1,11 @@
+// Checks that D compiler successfully consumes .i files using preprocessor
+
+# 0 "/blah-blah/components/driver/gpio/gpio.c"
+# 1 "/blah-blah/build//"
+# 0 "<built-in>"
+# 0 "<command-line>"
+# 1 "/blah-blah/components/driver/gpio/gpio.c"
+
+# 41 "/blah-blah/sys-include/machine/_default_types.h" 3 4
+
+__extension__ typedef long long off64_t;

--- a/compiler/test/compilable/jsonc.i
+++ b/compiler/test/compilable/jsonc.i
@@ -1,5 +1,5 @@
 /*
-REQUIRED_ARGS: -o- -X -Xf-
+REQUIRED_ARGS: -cpp= -o- -X -Xf-
 TRANSFORM_OUTPUT: sanitize_json
 TEST_OUTPUT:
 ---

--- a/compiler/test/compilable/test22294.i
+++ b/compiler/test/compilable/test22294.i
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -cpp=
 /*********************************************************/
 
 // https://issues.dlang.org/show_bug.cgi?id=22294

--- a/compiler/test/compilable/test23936.i
+++ b/compiler/test/compilable/test23936.i
@@ -1,4 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?ide=23936
+// REQUIRED_ARGS: -cpp=
 
 #pragma pack(push,16)
 typedef struct AAATAG {

--- a/compiler/test/compilable/testcdefines.i
+++ b/compiler/test/compilable/testcdefines.i
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -vcg-ast -o-
+// REQUIRED_ARGS: -cpp= -vcg-ast -o-
 // OUTPUT_FILES: compilable/testcdefines.i.cg
 // TEST_OUTPUT_FILE: extra-files/testcdefines.i.cg
 #undef _ATFILE_SOURCE

--- a/compiler/test/compilable/testcstuff4.i
+++ b/compiler/test/compilable/testcstuff4.i
@@ -1,5 +1,5 @@
-
 /* cpp doesn't like this, so don't run preprocessor on this file
+REQUIRED_ARGS: -cpp=
  */
 
 /********************************/

--- a/compiler/test/fail_compilation/alignedext.i
+++ b/compiler/test/fail_compilation/alignedext.i
@@ -1,9 +1,12 @@
-/* TEST_OUTPUT:
+/*
+REQUIRED_ARGS: -cpp=
+TEST_OUTPUT:
+
 ---
-fail_compilation/alignedext.i(10): Error: __decspec(align(123)) must be an integer positive power of 2 and be <= 8,192
-fail_compilation/alignedext.i(11): Error: __decspec(align(16384)) must be an integer positive power of 2 and be <= 8,192
-fail_compilation/alignedext.i(13): Error: __attribute__((aligned(123))) must be an integer positive power of 2 and be <= 32,768
-fail_compilation/alignedext.i(14): Error: __attribute__((aligned(65536))) must be an integer positive power of 2 and be <= 32,768
+fail_compilation/alignedext.i(13): Error: __decspec(align(123)) must be an integer positive power of 2 and be <= 8,192
+fail_compilation/alignedext.i(14): Error: __decspec(align(16384)) must be an integer positive power of 2 and be <= 8,192
+fail_compilation/alignedext.i(16): Error: __attribute__((aligned(123))) must be an integer positive power of 2 and be <= 32,768
+fail_compilation/alignedext.i(17): Error: __attribute__((aligned(65536))) must be an integer positive power of 2 and be <= 32,768
 ---
 */
 

--- a/compiler/test/fail_compilation/attrpure.i
+++ b/compiler/test/fail_compilation/attrpure.i
@@ -1,6 +1,8 @@
-/* TEST_OUTPUT:
+/*
+REQUIRED_ARGS: -cpp=
+TEST_OUTPUT:
 ---
-fail_compilation/attrpure.i(11): Error: `pure` function `attrpure.pureAsSnow` cannot call impure function `attrpure.impure`
+fail_compilation/attrpure.i(13): Error: `pure` function `attrpure.pureAsSnow` cannot call impure function `attrpure.impure`
 ---
 */
 

--- a/compiler/test/fail_compilation/cdeprecated.i
+++ b/compiler/test/fail_compilation/cdeprecated.i
@@ -1,4 +1,4 @@
-/* REQUIRED_ARGS: -de
+/* REQUIRED_ARGS: -cpp= -de
 TEST_OUTPUT:
 ---
 fail_compilation/cdeprecated.i(18): Deprecation: function `cdeprecated.mars` is deprecated

--- a/compiler/test/fail_compilation/compgoto.i
+++ b/compiler/test/fail_compilation/compgoto.i
@@ -1,4 +1,6 @@
-/* TEST_OUTPUT:
+/*
+REQUIRED_ARGS: -cpp=
+TEST_OUTPUT:
 ---
 fail_compilation/compgoto.i(105): Error: unary `&&` computed goto extension is not supported
 fail_compilation/compgoto.i(106): Error: `goto *` computed goto extension is not supported

--- a/compiler/test/fail_compilation/fail22853a.i
+++ b/compiler/test/fail_compilation/fail22853a.i
@@ -1,5 +1,7 @@
 /+ https://issues.dlang.org/show_bug.cgi?id=22853 +/
-/* TEST_OUTPUT:
+/*
+REQUIRED_ARGS: -cpp=
+TEST_OUTPUT:
 ---
 fail_compilation/fail22853a.i(1): Error: no type for declarator before `/`
 ---

--- a/compiler/test/fail_compilation/failcstuff4b.i
+++ b/compiler/test/fail_compilation/failcstuff4b.i
@@ -1,4 +1,6 @@
-/* TEST_OUTPUT:
+/*
+REQUIRED_ARGS: -cpp=
+TEST_OUTPUT:
 ---
 fail_compilation/failcstuff4b.i(605): Error: invalid flag for line marker directive
 ---

--- a/compiler/test/fail_compilation/test128.i
+++ b/compiler/test/fail_compilation/test128.i
@@ -1,7 +1,9 @@
-/* TEST_OUTPUT:
+/*
+REQUIRED_ARGS: -cpp=
+TEST_OUTPUT:
 ---
-fail_compilation/test128.i(12): Error: unsigned __int128 not supported
-fail_compilation/test128.i(12): Error: __int128 not supported
+fail_compilation/test128.i(14): Error: unsigned __int128 not supported
+fail_compilation/test128.i(14): Error: __int128 not supported
 ---
  */
 

--- a/compiler/test/fail_compilation/test23672.i
+++ b/compiler/test/fail_compilation/test23672.i
@@ -1,8 +1,9 @@
 /*
+REQUIRED_ARGS: -cpp=
 TEST_OUTPUT:
 ---
-fail_compilation/test23672.i(9): Error: found `End of File` when expecting `)`
-fail_compilation/test23672.i(9): Error: `=`, `;` or `,` expected to end declaration instead of `End of File`
+fail_compilation/test23672.i(10): Error: found `End of File` when expecting `)`
+fail_compilation/test23672.i(10): Error: `=`, `;` or `,` expected to end declaration instead of `End of File`
 ---
 */
 extern int feof (FILE *__strea

--- a/compiler/test/fail_compilation/test23715.i
+++ b/compiler/test/fail_compilation/test23715.i
@@ -1,6 +1,8 @@
-/* TEST_OUTPUT:
+/*
+REQUIRED_ARGS: -cpp=
+TEST_OUTPUT:
 ---
-fail_compilation/test23715.i(11): Error: `_Thread_local` in block scope must be accompanied with `static` or `extern`
+fail_compilation/test23715.i(13): Error: `_Thread_local` in block scope must be accompanied with `static` or `extern`
 ---
 */
 

--- a/compiler/test/fail_compilation/test23886.i
+++ b/compiler/test/fail_compilation/test23886.i
@@ -1,4 +1,6 @@
-/* TEST_OUTPUT:
+/*
+REQUIRED_ARGS: -cpp=
+TEST_OUTPUT:
 ---
 fail_compilation/test23886.i(103): Error: "string" expected after `#ident`
 fail_compilation/test23886.i(103): Error: no type for declarator before `#`


### PR DESCRIPTION
Use case: Almost any C build system provides way to create *.i files during compilation (`-save-temps` flag). But usually C sources do not meet to the strict requirements of C11 standard needed by importC.

Ability to preprocess already preprocessed C files is useful in this case. ~~We can just pass preprocessor over all *.i files recursively and it will convert files to a suitable for importC C version (replaces `__inline__` to `inline` and so)~~

upd: This PR enables implicit preprocessing of .i files (same as works preprocessing .c files and included .h files) 

This way we are spared from the need of enter/search/maintain/fetch of sets of definition flags for .c code used by D compiler - external C preprocessor does this job for us, just use generated .i files as bindings!