### PR TITLE
Environment variable OS is required for CI

### DIFF
--- a/compiler/test/tools/d_do_test.d
+++ b/compiler/test/tools/d_do_test.d
@@ -167,7 +167,7 @@ immutable(EnvData) processEnvironment()
     envData.dsep           = environment.get("DSEP");
     envData.obj            = envGetRequired ("OBJ");
     envData.exe            = envGetRequired ("EXE");
-    envData.os             = environment.get("OS");
+    envData.os             = envGetRequired ("OS");
     envData.dmd            = replace(envGetRequired("DMD"), "/", envData.sep);
     envData.compiler       = "dmd"; //should be replaced for other compilers
     envData.ccompiler      = environment.get("CC");


### PR DESCRIPTION
Trying to understand why CI fails on https://github.com/dlang/dmd/pull/16386