### PR TITLE
Fix bugzilla 24509: importC cannot handle _stdcall Function Calling …

### DIFF
--- a/compiler/test/compilable/test22727.c
+++ b/compiler/test/compilable/test22727.c
@@ -1,11 +1,18 @@
 // https://issues.dlang.org/show_bug.cgi?id=22727
 
+
 int fooc(int a) { return a; }
+
+#ifdef _WIN32
 
 __stdcall int foostdcall(int a) { return a; }
 
 int __stdcall foostdcall2(int a) { return a; }
 
+int _stdcall foostdcall3(int a) { return a; } // test issue 24509
+
 int __stdcall (*fp1)(int a) = &foostdcall;
 
 int (__stdcall *fp2)(int a) = &foostdcall2;
+
+#endif

--- a/compiler/test/compilable/test22727.c
+++ b/compiler/test/compilable/test22727.c
@@ -1,18 +1,15 @@
 // https://issues.dlang.org/show_bug.cgi?id=22727
 
-
 int fooc(int a) { return a; }
-
-#ifdef _WIN32
 
 __stdcall int foostdcall(int a) { return a; }
 
 int __stdcall foostdcall2(int a) { return a; }
 
+#if _MSC_VER
 int _stdcall foostdcall3(int a) { return a; } // test issue 24509
+#endif
 
 int __stdcall (*fp1)(int a) = &foostdcall;
 
-int (__stdcall *fp2)(int a) = &foostdcall2;
-
-#endif
+int(__stdcall *fp2)(int a) = &foostdcall2;

--- a/compiler/test/compilable/test22727.c
+++ b/compiler/test/compilable/test22727.c
@@ -12,4 +12,4 @@ int _stdcall foostdcall3(int a) { return a; } // test issue 24509
 
 int __stdcall (*fp1)(int a) = &foostdcall;
 
-int(__stdcall *fp2)(int a) = &foostdcall2;
+int (__stdcall *fp2)(int a) = &foostdcall2;

--- a/druntime/src/importc.h
+++ b/druntime/src/importc.h
@@ -134,6 +134,7 @@ typedef unsigned long long __uint64_t;
 #define __ptr64
 #define __unaligned
 #define _NO_CRT_STDIO_INLINE 1
+#define _stdcall __stdcall
 
 // This header disables the Windows API Annotations macros
 // Need to include sal.h to get the pragma once to prevent macro redefinition.


### PR DESCRIPTION
…Convention with single heading underscore