### PR TITLE
[stable] Fix bugzilla 24505 - ImportC: Don't generate symbols for #undef'd macros

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -5860,13 +5860,15 @@ final class CParser(AST) : Parser!AST
 
         const(char)* endp = &slice[length - 7];
 
+        AST.Dsymbols newSymbols;
+
         size_t[void*] defineTab;    // hash table of #define's turned into Symbol's
-                                    // indexed by Identifier, returns index into symbols[]
+                                    // indexed by Identifier, returns index into newSymbols[]
                                     // The memory for this is leaked
 
-        void addVar(AST.Dsymbol s)
+        void addSym(AST.Dsymbol s)
         {
-            //printf("addVar() %s\n", s.toChars());
+            //printf("addSym() %s\n", s.toChars());
             if (auto v = s.isVarDeclaration())
                 v.isCmacro(true);       // mark it as coming from a C #define
             /* If it's already defined, replace the earlier
@@ -5874,13 +5876,22 @@ final class CParser(AST) : Parser!AST
              */
             if (size_t* pd = cast(void*)s.ident in defineTab)
             {
-                //printf("replacing %s\n", v.toChars());
-                (*symbols)[*pd] = s;
+                //printf("replacing %s\n", s.toChars());
+                newSymbols[*pd] = s;
                 return;
             }
-            assert(symbols, "symbols is null");
-            defineTab[cast(void*)s.ident] = symbols.length;
-            symbols.push(s);
+            defineTab[cast(void*)s.ident] = newSymbols.length;
+            newSymbols.push(s);
+        }
+
+        void removeSym(Identifier ident)
+        {
+            //printf("removeSym() %s\n", ident.toChars());
+            if (size_t* pd = cast(void*)ident in defineTab)
+            {
+                //printf("removing %s\n", ident.toChars());
+                newSymbols[*pd] = null;
+            }
         }
 
         while (p < endp)
@@ -5924,7 +5935,7 @@ final class CParser(AST) : Parser!AST
                                  */
                                 AST.Expression e = new AST.IntegerExp(scanloc, intvalue, t);
                                 auto v = new AST.VarDeclaration(scanloc, t, id, new AST.ExpInitializer(scanloc, e), STC.manifest);
-                                addVar(v);
+                                addSym(v);
                                 ++p;
                                 continue;
                             }
@@ -5947,7 +5958,7 @@ final class CParser(AST) : Parser!AST
                                  */
                                 AST.Expression e = new AST.RealExp(scanloc, floatvalue, t);
                                 auto v = new AST.VarDeclaration(scanloc, t, id, new AST.ExpInitializer(scanloc, e), STC.manifest);
-                                addVar(v);
+                                addSym(v);
                                 ++p;
                                 continue;
                             }
@@ -5965,7 +5976,7 @@ final class CParser(AST) : Parser!AST
                                  */
                                 AST.Expression e = new AST.StringExp(scanloc, str[0 .. len], len, 1, postfix);
                                 auto v = new AST.VarDeclaration(scanloc, null, id, new AST.ExpInitializer(scanloc, e), STC.manifest);
-                                addVar(v);
+                                addSym(v);
                                 ++p;
                                 continue;
                             }
@@ -6001,7 +6012,7 @@ final class CParser(AST) : Parser!AST
                             AST.TemplateParameters* tpl = new AST.TemplateParameters();
                             AST.Expression constraint = null;
                             auto tempdecl = new AST.TemplateDeclaration(exp.loc, id, tpl, constraint, decldefs, false);
-                            addVar(tempdecl);
+                            addSym(tempdecl);
                             ++p;
                             continue;
                         }
@@ -6092,7 +6103,7 @@ final class CParser(AST) : Parser!AST
                             AST.Dsymbols* decldefs = new AST.Dsymbols();
                             decldefs.push(fd);
                             auto tempdecl = new AST.TemplateDeclaration(exp.loc, id, tpl, null, decldefs, false);
-                            addVar(tempdecl);
+                            addSym(tempdecl);
 
                             ++p;
                             continue;
@@ -6103,11 +6114,29 @@ final class CParser(AST) : Parser!AST
                     }
                 }
             }
+            else if (p[0 .. 6] == "#undef")
+            {
+                p += 6;
+                nextToken();
+                //printf("undef %s\n", token.toChars());
+                if (token.value == TOK.identifier)
+                    removeSym(token.ident);
+            }
             // scan to end of line
             while (*p)
                 ++p;
             ++p; // advance to start of next line
             scanloc.linnum = scanloc.linnum + 1;
+        }
+
+        if (newSymbols.length)
+        {
+            assert(symbols, "symbols is null");
+            symbols.reserve(newSymbols.length);
+
+            foreach (sym; newSymbols)
+                if (sym) // undefined entries are null
+                    symbols.push(sym);
         }
 
         scanloc = scanlocSave;

--- a/compiler/test/compilable/test24505.c
+++ b/compiler/test/compilable/test24505.c
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=24505
+
+// PERMUTE_ARGS:
+
+struct stat { int x; };
+
+void __stat(int x, int y);
+#define stat(x, y) __stat(x, y)
+
+// reversed order:
+#define stat2(x, y) __stat(x, y)
+struct stat2 { int x; };
+
+#undef stat
+#undef stat2


### PR DESCRIPTION
Don't leak 'internal', later-undefined macros to the D interface anymore.

This also allows users to handle macros conflicting with regular symbols (a compile/import error) by explicitly undefining them in the .c file. So this is an alternative (could be combined as well...) to https://github.com/dlang/dmd/pull/16396.