### PR TITLE
Fix bugzilla 24498 - Multidimensional array not scanned by GC

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5335,7 +5335,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 lowering = new DotIdExp(exp.loc, lowering, Id.object);
 
                 auto tbn = exp.type.nextOf();
-                while (tbn.ty == Tarray)
+                size_t i = nargs;
+                while (tbn.ty == Tarray && --i)
                     tbn = tbn.nextOf();
                 auto unqualTbn = tbn.unqualify(MODFlags.wild | MODFlags.const_ |
                     MODFlags.immutable_ | MODFlags.shared_);

--- a/compiler/test/runnable/test24498.d
+++ b/compiler/test/runnable/test24498.d
@@ -1,0 +1,21 @@
+import core.memory;
+
+void main()
+{
+    {
+        int[][] a = new int[][](2, 2);
+        assert(!(GC.getAttr(a.ptr) & GC.BlkAttr.NO_SCAN));
+        assert(GC.getAttr(a[0].ptr) & GC.BlkAttr.NO_SCAN);
+    }
+    {
+        void*[][] a = new void*[][](2, 2);
+        assert(!(GC.getAttr(a.ptr) & GC.BlkAttr.NO_SCAN));
+        assert(!(GC.getAttr(a[0].ptr) & GC.BlkAttr.NO_SCAN));
+    }
+    {
+        int[][][] a = new int[][][](2, 2);
+        assert(!(GC.getAttr(a.ptr) & GC.BlkAttr.NO_SCAN));
+        assert(!(GC.getAttr(a[0].ptr) & GC.BlkAttr.NO_SCAN));
+        assert(a[0][0].ptr is null);
+    }
+}


### PR DESCRIPTION
For expression `new int[][][](2, 2)` the relevant element type is `int[]` and not `int`, because only two dimensions are allocated.