### PR TITLE
Remove the interface function fullCollectNoStack from the gcinterface

### DIFF
--- a/changelog/druntime.removenostackcollect.dd
+++ b/changelog/druntime.removenostackcollect.dd
@@ -1,0 +1,38 @@
+Remove all `collectNoStack` functions and API from druntime.
+
+The function `collectNoStack` in the D garbage collector performed a
+collection, without using any roots from thread stacks or thread-local-storage.
+The danger of running this mechanism is that any blocks of memory which only
+have a reference from a thread might be collected, while the thread is still
+running and possibly using the memory.
+
+The only time this function was called was at GC termination. At GC
+termination, the GC is about to be destroyed, and so we want to run as many
+destructors as possible. However, if some thread is using GC-allocated memory,
+cleaning up that memory isn't going to help matters. Either it will crash after
+the GC cleans the memory, or it will crash after the GC is destroyed.
+
+The original purpose of this function (from D1) was to ensure simple uses of
+the GC were cleaned up in small test programs, as this mechanism was only used
+on single-threaded programs (and of course, at program exit). Also note at the
+time, D1 was 32-bit, and false pointers where much more common. Avoiding
+scanning stacks would aid in avoiding seemingly random behavior in cleanup.
+However, as shown below, there are more deterministic ways to ensure data is
+always cleaned up.
+
+Today, the dangers are much greater that such a function is even callable --
+any call to such a function would immediately start use-after-free memory
+corruption in any thread that is still running. Therefore, we are removing the
+functionality entirely, and simply doing a standard GC cleanup (scanning stacks
+and all). One less footgun is the benefit for having less guaranteed GC clean
+up at program exit.
+
+In addition, the GC today is a bit smarter about where the valid stack is, so
+there is even less of a chance of leaving blocks unfinalized.
+
+As always, the GC is *not* guaranteed to clean up any block at the end of
+runtime. Any change in behavior with code that had blocks clean up before, but
+no longer are cleaned up is still within specification. And if you want the
+behavior that absolutely cleans all blocks, you can use the
+`--DRT-gcopt=cleanup:finalize` druntime configuration option, which will clean
+up all blocks without even scanning.

--- a/druntime/src/core/gc/gcinterface.d
+++ b/druntime/src/core/gc/gcinterface.d
@@ -54,11 +54,6 @@ interface GC
     void collect() nothrow;
 
     /**
-     *
-     */
-    void collectNoStack() nothrow;
-
-    /**
      * minimize free space usage
      */
     void minimize() nothrow;

--- a/druntime/src/core/internal/gc/impl/conservative/gc.d
+++ b/druntime/src/core/internal/gc/impl/conservative/gc.d
@@ -1252,12 +1252,6 @@ class ConservativeGC : GC
     }
 
 
-    void collectNoStack() nothrow
-    {
-        fullCollectNoStack();
-    }
-
-
     /**
      * Begins a full collection, scanning all stack segments for roots.
      *
@@ -1287,21 +1281,6 @@ class ConservativeGC : GC
 
         gcx.leakDetector.log_collect();
         return result;
-    }
-
-
-    /**
-     * Begins a full collection while ignoring all stack segments for roots.
-     */
-    void fullCollectNoStack() nothrow
-    {
-        // Since a finalizer could launch a new thread, we always need to lock
-        // when collecting.
-        static size_t go(Gcx* gcx) nothrow
-        {
-            return gcx.fullcollect(true, true, true); // standard stop the world
-        }
-        runLocked!go(gcx);
     }
 
 

--- a/druntime/src/core/internal/gc/impl/manual/gc.d
+++ b/druntime/src/core/internal/gc/impl/manual/gc.d
@@ -79,10 +79,6 @@ class ManualGC : GC
     {
     }
 
-    void collectNoStack() nothrow
-    {
-    }
-
     void minimize() nothrow
     {
     }

--- a/druntime/src/core/internal/gc/impl/proto/gc.d
+++ b/druntime/src/core/internal/gc/impl/proto/gc.d
@@ -76,10 +76,6 @@ class ProtoGC : GC
     {
     }
 
-    void collectNoStack() nothrow
-    {
-    }
-
     void minimize() nothrow
     {
     }

--- a/druntime/src/core/internal/gc/proxy.d
+++ b/druntime/src/core/internal/gc/proxy.d
@@ -106,18 +106,7 @@ extern (C)
                 case "none":
                     break;
                 case "collect":
-                    // NOTE: There may be daemons threads still running when this routine is
-                    //       called.  If so, cleaning memory out from under then is a good
-                    //       way to make them crash horribly.  This probably doesn't matter
-                    //       much since the app is supposed to be shutting down anyway, but
-                    //       I'm disabling cleanup for now until I can think about it some
-                    //       more.
-                    //
-                    // NOTE: Due to popular demand, this has been re-enabled.  It still has
-                    //       the problems mentioned above though, so I guess we'll see.
-
-                    instance.collectNoStack();  // not really a 'collect all' -- still scans
-                                                // static data area, roots, and ranges.
+                    instance.collect();
                     break;
                 case "finalize":
                     instance.runFinalizers((cast(ubyte*)null)[0 .. size_t.max]);

--- a/druntime/test/exceptions/src/invalid_memory_operation.d
+++ b/druntime/test/exceptions/src/invalid_memory_operation.d
@@ -8,5 +8,6 @@ struct S
 
 void main()
 {
-    new S;
+    foreach(i; 0 .. 100)
+        new S;
 }

--- a/druntime/test/valgrind/src/no_use_after_gc.d
+++ b/druntime/test/valgrind/src/no_use_after_gc.d
@@ -16,11 +16,24 @@ struct S
 
 __gshared int result; // Trick the optimizer
 
-int main()
+int makeBadInstances()
 {
     auto a = new S;
     auto b = new S;
     a.other = b;
     b.other = a;
     return result;
+}
+
+int destroyStack()
+{
+    int[1000] x = result;
+    return x[123];
+}
+
+int main()
+{
+    int x = makeBadInstances();
+    x += destroyStack();
+    return x;
 }


### PR DESCRIPTION
~~This is an experiment to see whether anything will fail if we completely remove the (seemingly useless/dangerous) fullCollectNoStack.~~

OK, no longer an experiment. I think we should remove this function.

I probably should write a changelog...

See the investigation I did here: https://forum.dlang.org/post/lkjgoekakzjfjijojipe@forum.dlang.org