### PR TITLE
Fix bugzilla 23657 - [REG2.101] Incorrect error escape reference to s…

### DIFF
--- a/compiler/test/compilable/returnscope_without_safe.d
+++ b/compiler/test/compilable/returnscope_without_safe.d
@@ -1,0 +1,16 @@
+// Stack pointers are being escaped here, but without
+// @safe and dip1000, it should still be allowed
+// because return scope could have been inferred incorrectly,
+// and it breaks existing code:
+// https://issues.dlang.org/show_bug.cgi?id=23657
+
+int* identity(return scope int* x);
+
+auto identityAuto(int* x) => x;
+
+int* f()
+{
+    int x;
+    return identity(&x);
+    return identityAuto(&x);
+}


### PR DESCRIPTION
…tack allocated value

Of course `return scope` shouldn't be inferred when the parameter could be `scope` in the first place ([Issue 23300](https://issues.dlang.org/show_bug.cgi?id=23300)), but this will do in the mean time.

@JohanEngelen Sorry for taking so long to get to this. In my mind it was just a dip1000 limitation that would be fixed in due time with 23300, but it really has been a regression for several releases now.