### PR TITLE
Fix lookup of ImportC character tables

### DIFF
--- a/compiler/src/dmd/cparse.d
+++ b/compiler/src/dmd/cparse.d
@@ -89,6 +89,9 @@ final class CParser(AST) : Parser!AST
         this.wchar_tsize = target.wchar_tsize;
 
         // C `char` is always unsigned in ImportC
+
+        // We know that we are parsing out C, due the parent not knowing this, we have to setup tables here.
+        charLookup = compileEnv.cCharLookupTable;
     }
 
     /********************************************

--- a/compiler/src/dmd/lexer.d
+++ b/compiler/src/dmd/lexer.d
@@ -57,8 +57,8 @@ struct CompileEnv
     bool masm;               /// use MASM inline asm syntax
 
     // these need a default otherwise tests won't work.
-    IdentifierCharLookup cCharLookupTable;
-    IdentifierCharLookup dCharLookupTable;
+    IdentifierCharLookup cCharLookupTable; /// C identifier table (set to the lexer by the C parser)
+    IdentifierCharLookup dCharLookupTable; /// D identifier table
 }
 
 /***********************************************************
@@ -74,7 +74,7 @@ class Lexer
 
     Token token;
 
-    IdentifierCharLookup charLookup;
+    IdentifierCharLookup charLookup; /// Character table for identifiers
 
     // For ImportC
     bool Ccompile;              /// true if compiling ImportC
@@ -189,14 +189,9 @@ class Lexer
         }
 
         // setup the identifier table lookup functions
-        if (this.Ccompile)
-        {
-            charLookup = this.compileEnv.cCharLookupTable;
-        }
-        else
-        {
-            charLookup = this.compileEnv.dCharLookupTable;
-        }
+        // C tables are setup in its parser constructor
+        // Due to us not knowing if we're in C at this point in time.
+        charLookup = this.compileEnv.dCharLookupTable;
     }
 
     /***********************


### PR DESCRIPTION
Right we need to get this into 2.109 otherwise the ImportC character table switch won't work.