### PR TITLE
Mark Thread.sleep as @trusted

### DIFF
--- a/changelog/druntime.thread-sleep-trusted.dd
+++ b/changelog/druntime.thread-sleep-trusted.dd
@@ -1,0 +1,4 @@
+Mark `Thread.sleep` as `@trusted`
+
+The static method `core.thread.Thread.sleep` is now marked as `@trusted` and
+can be called directly from `@safe` code.

--- a/druntime/src/core/thread/osthread.d
+++ b/druntime/src/core/thread/osthread.d
@@ -911,7 +911,7 @@ class Thread : ThreadBase
      *
      * ------------------------------------------------------------------------
      */
-    static void sleep( Duration val ) @nogc nothrow
+    static void sleep( Duration val ) @nogc nothrow @trusted
     in
     {
         assert( !val.isNegative );
@@ -1174,6 +1174,12 @@ unittest
     thread_suspendAll();
     assert(!inCriticalRegion);
     thread_resumeAll();
+}
+
+@nogc @safe nothrow
+unittest
+{
+    Thread.sleep(1.msecs);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I am fairly convinced that no possible arguments to or global state at the time of any call to Thread.sleep can result in memory corruption.

There is a precondition on Thread.sleep, that the duration must be non-negative. On Windows, Thread.sleep calls Sleep, which takes an unsigned integer. On POSIX, Thread.sleep calls nanosleep, which is specified to handle negative durations gracefully. As such, violating this precondition should not be a source of undefined behavior.