### PR TITLE
add const to toString() overrides

### DIFF
--- a/druntime/src/object.d
+++ b/druntime/src/object.d
@@ -2649,7 +2649,7 @@ class Throwable : Object
      * Internally this forwards to the $(D toString) overload that
      * takes a $(D_PARAM sink) delegate.
      */
-    override string toString()
+    override string toString() const
     {
         string s;
         toString((in buf) { s ~= buf; });

--- a/druntime/src/rt/util/typeinfo.d
+++ b/druntime/src/rt/util/typeinfo.d
@@ -630,7 +630,7 @@ class TypeInfo_n : TypeInfo
 {
     const: pure: @nogc: nothrow: @safe:
 
-    override string toString() { return "typeof(null)"; }
+    override string toString() const { return "typeof(null)"; }
 
     override size_t getHash(scope const void*) { return 0; }
 


### PR DESCRIPTION
Most had already been done, but I found a couple stragglers.