### PR TITLE
Mark some functions `@safe` or `@trusted`

### DIFF
--- a/compiler/src/dmd/declaration.d
+++ b/compiler/src/dmd/declaration.d
@@ -1384,7 +1384,7 @@ extern (C++) class VarDeclaration : Declaration
     /*************************************
      * Return true if we can take the address of this variable.
      */
-    final bool canTakeAddressOf()
+    final bool canTakeAddressOf() @safe
     {
         return !(storage_class & STC.manifest);
     }
@@ -1392,7 +1392,7 @@ extern (C++) class VarDeclaration : Declaration
     /******************************************
      * Return true if variable needs to call the destructor.
      */
-    final bool needsScopeDtor()
+    final bool needsScopeDtor() @safe
     {
         //printf("VarDeclaration::needsScopeDtor() %s %d\n", toChars(), edtor && !(storage_class & STC.nodtor));
         return edtor && !(storage_class & STC.nodtor);

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -453,7 +453,7 @@ extern (C++) class Dsymbol : ASTNode
      *
      * See also `parent`, `toParent` and `toParent2`.
      */
-    final inout(Dsymbol) pastMixin() inout
+    final inout(Dsymbol) pastMixin() inout @safe
     {
         //printf("Dsymbol::pastMixin() %s\n", toChars());
         if (!isTemplateMixin() && !isForwardingAttribDeclaration() && !isForwardingScopeDsymbol())
@@ -503,13 +503,13 @@ extern (C++) class Dsymbol : ASTNode
      *  // s.toParentLocal() == FuncDeclaration('mod.test')
      * ---
      */
-    final inout(Dsymbol) toParent() inout
+    final inout(Dsymbol) toParent() inout @safe
     {
         return parent ? parent.pastMixin() : null;
     }
 
     /// ditto
-    final inout(Dsymbol) toParent2() inout
+    final inout(Dsymbol) toParent2() inout @safe
     {
         if (!parent || !parent.isTemplateInstance && !parent.isForwardingAttribDeclaration() && !parent.isForwardingScopeDsymbol())
             return parent;

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -1862,7 +1862,7 @@ extern (C++) class FuncDeclaration : Declaration
         return this;
     }
 
-    inout(FuncDeclaration) toAliasFunc() inout
+    inout(FuncDeclaration) toAliasFunc() inout @safe
     {
         return this;
     }

--- a/compiler/src/dmd/init.d
+++ b/compiler/src/dmd/init.d
@@ -51,38 +51,38 @@ extern (C++) class Initializer : ASTNode
         this.kind = kind;
     }
 
-    final inout(ErrorInitializer) isErrorInitializer() inout @nogc nothrow pure
+    final inout(ErrorInitializer) isErrorInitializer() inout @nogc nothrow pure @trusted
     {
         // Use void* cast to skip dynamic casting call
         return kind == InitKind.error ? cast(inout ErrorInitializer)cast(void*)this : null;
     }
 
-    final inout(VoidInitializer) isVoidInitializer() inout @nogc nothrow pure
+    final inout(VoidInitializer) isVoidInitializer() inout @nogc nothrow pure @trusted
     {
         return kind == InitKind.void_ ? cast(inout VoidInitializer)cast(void*)this : null;
     }
 
-    final inout(DefaultInitializer) isDefaultInitializer() inout @nogc nothrow pure
+    final inout(DefaultInitializer) isDefaultInitializer() inout @nogc nothrow pure @trusted
     {
         return kind == InitKind.default_ ? cast(inout DefaultInitializer)cast(void*)this : null;
     }
 
-    final inout(StructInitializer) isStructInitializer() inout @nogc nothrow pure
+    final inout(StructInitializer) isStructInitializer() inout @nogc nothrow pure @trusted
     {
         return kind == InitKind.struct_ ? cast(inout StructInitializer)cast(void*)this : null;
     }
 
-    final inout(ArrayInitializer) isArrayInitializer() inout @nogc nothrow pure
+    final inout(ArrayInitializer) isArrayInitializer() inout @nogc nothrow pure @trusted
     {
         return kind == InitKind.array ? cast(inout ArrayInitializer)cast(void*)this : null;
     }
 
-    final inout(ExpInitializer) isExpInitializer() inout @nogc nothrow pure
+    final inout(ExpInitializer) isExpInitializer() inout @nogc nothrow pure @trusted
     {
         return kind == InitKind.exp ? cast(inout ExpInitializer)cast(void*)this : null;
     }
 
-    final inout(CInitializer) isCInitializer() inout @nogc nothrow pure
+    final inout(CInitializer) isCInitializer() inout @nogc nothrow pure @trusted
     {
         return kind == InitKind.C_ ? cast(inout CInitializer)cast(void*)this : null;
     }

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -1690,7 +1690,7 @@ extern (C++) abstract class TypeNext : Type
      * type is meant to be inferred, and semantic() hasn't yet ben run
      * on the function. After semantic(), it must no longer be NULL.
      */
-    override final Type nextOf()
+    override final Type nextOf() @safe
     {
         return next;
     }
@@ -3175,7 +3175,7 @@ extern (C++) final class TypeFunction : TypeNext
      * Returns:
      *  true if D-style variadic
      */
-    bool isDstyleVariadic() const pure nothrow
+    bool isDstyleVariadic() const pure nothrow @safe
     {
         return linkage == LINK.d && parameterList.varargs == VarArg.variadic;
     }


### PR DESCRIPTION
Trying to get escape.d to be more `@safe`, I found some elementary functions with a `@safe` interface lacking either `@safe` or `@trusted`.