### PR TITLE
Make `foreach_reverse` with a delegate an error

### DIFF
--- a/changelog/dmd.foreach-reverse-delegate-error.dd
+++ b/changelog/dmd.foreach-reverse-delegate-error.dd
@@ -1,0 +1,6 @@
+`foreach_reverse` on a delegate is now an error
+
+The compiler did not try to implement reverse traversal of the results returned by
+the delegate when $(D foreach_reverse) was used. That could result in code
+that was confusing to read, so it was deprecated (for many years). Using
+$(D foreach_reverse) with a delegate is now an error.

--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -1409,7 +1409,7 @@ Statement statementSemanticVisit(Statement s, Scope* sc)
             }
         case Tdelegate:
             if (fs.op == TOK.foreach_reverse_)
-                deprecation(fs.loc, "cannot use `foreach_reverse` with a delegate");
+                error(fs.loc, "cannot use `foreach_reverse` with a delegate");
             return retStmt(apply());
         case Terror:
             return retError();

--- a/compiler/test/fail_compilation/deprecate1553.d
+++ b/compiler/test/fail_compilation/deprecate1553.d
@@ -1,9 +1,7 @@
-// REQUIRED_ARGS: -de
-
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate1553.d(18): Deprecation: cannot use `foreach_reverse` with a delegate
+fail_compilation/deprecate1553.d(16): Error: cannot use `foreach_reverse` with a delegate
 ---
 */
 


### PR DESCRIPTION
Deprecation goes back to at least 2016:
https://github.com/dlang/dmd/commit/68fb91a1305e6a1682db77b734d4335b2349b246#diff-13f50d9dea67df89a0535d6b8957f3145d49f71f6b72fdd3913f329a265e1423R1155