### PR TITLE
Remove unneeded `@trusted` annotations

### DIFF
--- a/compiler/src/dmd/backend/cc.d
+++ b/compiler/src/dmd/backend/cc.d
@@ -469,7 +469,6 @@ nothrow:
     @trusted
     void prependSucc(block* b)       { list_prepend(&this.Bsucc, b); }
 
-    @trusted
     int numSucc()                    { return list_nitems(this.Bsucc); }
 
     @trusted

--- a/compiler/src/dmd/backend/cgcod.d
+++ b/compiler/src/dmd/backend/cgcod.d
@@ -1470,14 +1470,11 @@ private void blcodgen(block *bl)
  * Given a register mask, find and return the number
  * of the first register that fits.
  */
-
-@trusted
 reg_t findreg(regm_t regm)
 {
     return findreg(regm, __LINE__, __FILE__);
 }
 
-@trusted
 reg_t findreg(regm_t regm, int line, const(char)* file)
 {
     debug
@@ -1501,7 +1498,7 @@ reg_t findreg(regm_t regm, int line, const(char)* file)
 
     debug
     printf("findreg(%s, line=%d, file='%s', function = '%s')\n",regm_str(regmsave),line,file,funcsym_p.Sident.ptr);
-    fflush(stdout);
+    debug fflush(stdout);
 
 //    *(char*)0=0;
     assert(0);
@@ -1831,7 +1828,6 @@ L3:
  * Returns:
  *      selected register
  */
-@trusted
 reg_t allocScratchReg(ref CodeBuilder cdb, regm_t regm)
 {
     return allocreg(cdb, regm, TYoffset);

--- a/compiler/src/dmd/backend/cgreg.d
+++ b/compiler/src/dmd/backend/cgreg.d
@@ -528,8 +528,6 @@ Lcant:
  *      cdbstore = append store code to this
  *      cdbload = append load code to this
  */
-
-@trusted
 void cgreg_spillreg_prolog(block *b,Symbol *s,ref CodeBuilder cdbstore,ref CodeBuilder cdbload)
 {
     const int bi = b.Bdfoidx;
@@ -604,8 +602,6 @@ void cgreg_spillreg_prolog(block *b,Symbol *s,ref CodeBuilder cdbstore,ref CodeB
  *      cdbstore = append store code to this
  *      cdbload = append load code to this
  */
-
-@trusted
 void cgreg_spillreg_epilog(block *b,Symbol *s,ref CodeBuilder cdbstore, ref CodeBuilder cdbload)
 {
     const bi = b.Bdfoidx;

--- a/compiler/src/dmd/backend/cgsched.d
+++ b/compiler/src/dmd/backend/cgsched.d
@@ -1275,8 +1275,6 @@ private int pair_class(code *c)
  * Returns:
  *     CInfo struct containing info about c
  */
-
-@trusted
 private Cinfo getinfo(code *c)
 {
     if (!c)
@@ -2243,13 +2241,11 @@ nothrow:
         fpustackused = fpustackinit;
     }
 
-    @trusted
     void dtor()
     {
         stagelist.dtor();
     }
 
-@trusted
 code **assemble(code **pc)  // reassemble scheduled instructions
 {
     code *c;

--- a/compiler/src/dmd/backend/cod1.d
+++ b/compiler/src/dmd/backend/cod1.d
@@ -1664,8 +1664,6 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
  * Input:
  *      tym     either TYdouble or TYfloat
  */
-
-@trusted
 void fltregs(ref CodeBuilder cdb, code* pcs, tym_t tym)
 {
     assert(!I64);

--- a/compiler/src/dmd/backend/cod2.d
+++ b/compiler/src/dmd/backend/cod2.d
@@ -5714,8 +5714,6 @@ void cdddtor(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 /*******************************************
  * C++ constructor.
  */
-
-@trusted
 void cdctor(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 {
 }

--- a/compiler/src/dmd/backend/cod3.d
+++ b/compiler/src/dmd/backend/cod3.d
@@ -6722,7 +6722,6 @@ nothrow:
     Barray!ubyte* disasmBuf;
     ubyte[256] bytes; // = void;
 
-    @trusted
     this(int seg)
     {
         index = 0;
@@ -6746,25 +6745,20 @@ nothrow:
         index = 0;
     }
 
-    @trusted
     void gen(ubyte c) { bytes[index++] = c; }
 
     @trusted
     void genp(uint n, void *p) { memcpy(&bytes[index], p, n); index += n; }
 
-    @trusted
     void flush() { if (index) flushx(); }
 
-    @trusted
     uint getOffset() { return offset + index; }
 
-    @trusted
     uint available() { return cast(uint)bytes.length - index; }
 
     /******************************
      * write64/write32/write16 write `value` to `disasmBuf`
      */
-    @trusted
     void write64(ulong value)
     {
         if (disasmBuf)
@@ -6781,7 +6775,6 @@ nothrow:
     }
 
     pragma(inline, true)
-    @trusted
     void write32(uint value)
     {
         if (disasmBuf)
@@ -6794,7 +6787,6 @@ nothrow:
     }
 
     pragma(inline, true)
-    @trusted
     void write16(uint value)
     {
         if (disasmBuf)

--- a/compiler/src/dmd/backend/cod5.d
+++ b/compiler/src/dmd/backend/cod5.d
@@ -36,8 +36,6 @@ nothrow:
  * Determine which blocks get the function prolog and epilog
  * attached to them.
  */
-
-@trusted
 void cod5_prol_epi(block* startblock)
 {
 static if(1)
@@ -151,8 +149,6 @@ else
 /**********************************************
  * No prolog/epilog optimization.
  */
-
-@trusted
 void cod5_noprol(block* startblock)
 {
     block *b;

--- a/compiler/src/dmd/backend/code.d
+++ b/compiler/src/dmd/backend/code.d
@@ -240,10 +240,8 @@ public import dmd.backend.cgobj : SegData;
 @trusted
 ref targ_size_t Offset(int seg) { return SegData[seg].SDoffset; }
 
-@trusted
 ref targ_size_t Doffset() { return Offset(DATA); }
 
-@trusted
 ref targ_size_t CDoffset() { return Offset(CDATA); }
 
 /**************************************************/
@@ -254,10 +252,8 @@ ref targ_size_t CDoffset() { return Offset(CDATA); }
 struct FuncParamRegs
 {
     //this(tym_t tyf);
-    @trusted
     static FuncParamRegs create(tym_t tyf) { return FuncParamRegs_create(tyf); }
 
-    @trusted
     int alloc(type *t, tym_t ty, ubyte *reg1, ubyte *reg2)
     { return FuncParamRegs_alloc(this, t, ty, reg1, reg2); }
 

--- a/compiler/src/dmd/backend/codebuilder.d
+++ b/compiler/src/dmd/backend/codebuilder.d
@@ -112,7 +112,6 @@ struct CodeBuilder
         }
     }
 
-    @trusted
     void gen(code *cs)
     {
         /* this is a high usage routine */
@@ -130,7 +129,6 @@ struct CodeBuilder
         pTail = &ce.next;
     }
 
-    @trusted
     void gen1(opcode_t op)
     {
         code *ce = code_calloc();
@@ -142,7 +140,6 @@ struct CodeBuilder
         pTail = &ce.next;
     }
 
-    @trusted
     void gen2(opcode_t op, uint rm)
     {
         code *ce = code_calloc();
@@ -157,14 +154,12 @@ struct CodeBuilder
     /***************************************
      * Generate floating point instruction.
      */
-    @trusted
     void genf2(opcode_t op, uint rm)
     {
         genfwait(this);
         gen2(op, rm);
     }
 
-    @trusted
     void gen2sib(opcode_t op, uint rm, uint sib)
     {
         code *ce = code_calloc();

--- a/compiler/src/dmd/backend/dcode.d
+++ b/compiler/src/dmd/backend/dcode.d
@@ -96,8 +96,6 @@ void code_free(code *cstart)
 /*****************
  * Terminate code
  */
-
-@trusted
 void code_term()
 {
 static if (TERMCODE)

--- a/compiler/src/dmd/backend/dt.d
+++ b/compiler/src/dmd/backend/dt.d
@@ -98,8 +98,6 @@ void dtpatchoffset(dt_t *dt, uint offset)
 /**************************
  * Make a common block for s.
  */
-
-@trusted
 void init_common(Symbol *s)
 {
     //printf("init_common('%s')\n", s.Sident);
@@ -116,8 +114,6 @@ void init_common(Symbol *s)
 /**********************************
  * Compute size of a dt
  */
-
-@trusted
 uint dt_size(const(dt_t)* dtstart)
 {
     uint datasize = 0;
@@ -221,7 +217,7 @@ nothrow:
     /************************************
      * Print state of DtBuilder for debugging.
      */
-    void print() @trusted
+    void print()
     {
         debug printf("DtBuilder: %p head: %p, pTail: %p\n", &head, head, pTail);
     }
@@ -440,7 +436,6 @@ nothrow:
      * Create a reference to another dt.
      * Returns: the internal symbol used for the other dt
      */
-    @trusted
     Symbol *dtoff(dt_t *dt, uint offset)
     {
         type *t = type_alloc(TYint);

--- a/compiler/src/dmd/backend/dvec.d
+++ b/compiler/src/dmd/backend/dvec.d
@@ -684,7 +684,6 @@ void vec_println(const vec_t v)
     }
 }
 
-@trusted
 pure
 void vec_print(const vec_t v)
 {

--- a/compiler/src/dmd/backend/el.d
+++ b/compiler/src/dmd/backend/el.d
@@ -125,7 +125,7 @@ void elem_debug(const elem* e)
     debug assert(e.id == e.IDelem);
 }
 
-@trusted tym_t typemask(const elem* e)
+tym_t typemask(const elem* e)
 {
     return e.Ety;
 }

--- a/compiler/src/dmd/backend/elem.d
+++ b/compiler/src/dmd/backend/elem.d
@@ -479,8 +479,6 @@ void el_copy(elem *to, const elem *from)
 /***********************************
  * Allocate a temporary, and return temporary elem.
  */
-
-@trusted
 elem * el_alloctmp(tym_t ty)
 {
     Symbol *s;
@@ -2419,8 +2417,6 @@ bool el_isdependent(elem* e)
 /****************************************
  * Returns: alignment size of elem e
  */
-
-@trusted
 uint el_alignsize(elem *e)
 {
     const tym = tybasic(e.Ety);

--- a/compiler/src/dmd/backend/gflow.d
+++ b/compiler/src/dmd/backend/gflow.d
@@ -398,8 +398,6 @@ private void fillInDNunambig(vec_t v, elem *e, size_t start, DefNode[] defnod)
  *      n = elem tree to evaluate for GEN and KILL
  *      deftop = number of bits in vectors
  */
-
-@trusted
 private void rdelem(out vec_t GEN, out vec_t KILL, elem *n, uint deftop)
 {
     GEN  = vec_calloc(deftop);
@@ -1477,7 +1475,6 @@ private void lvgenkill()
  *      length = number of global symbols
  */
 
-@trusted
 private void lvelem(out vec_t gen, out vec_t kill, const elem* n, const vec_t ambigsym, size_t length)
 {
     gen = vec_calloc(length);

--- a/compiler/src/dmd/backend/global.d
+++ b/compiler/src/dmd/backend/global.d
@@ -76,7 +76,7 @@ targ_size_t _align(targ_size_t size, targ_size_t offset) @trusted
 /*******************************
  * Get size of ty
  */
-targ_size_t size(tym_t ty) @trusted
+targ_size_t size(tym_t ty)
 {
     int sz = (tybasic(ty) == TYvoid) ? 1 : tysize(ty);
     debug

--- a/compiler/src/dmd/backend/glocal.d
+++ b/compiler/src/dmd/backend/glocal.d
@@ -502,7 +502,6 @@ private void local_ins(ref Barray!loc_t lt, elem *e)
 //////////////////////////////////////
 // Remove entry i from lt[], and then compress the table.
 //
-@trusted
 private void local_rem(ref Barray!loc_t lt, size_t u)
 {
     //printf("local_rem(%u)\n",u);

--- a/compiler/src/dmd/backend/gloop.d
+++ b/compiler/src/dmd/backend/gloop.d
@@ -67,7 +67,6 @@ nothrow:
     /*************************
      * Reset memory so this allocation can be re-used.
      */
-    @trusted
     void reset()
     {
         vec_free(Lloop);
@@ -86,8 +85,6 @@ nothrow:
     /***********************
      * Write loop.
      */
-
-    @trusted
     void print()
     {
         debug
@@ -122,7 +119,6 @@ nothrow:
         el_free(c2);
     }
 
-    @trusted
     void print() const
     {
         debug
@@ -150,7 +146,6 @@ nothrow:
     elem **IVincr;          // pointer to parent of IV increment elem
     Barray!famlist IVfamily;      // variables in this family
 
-    @trusted
     void reset()
     {
         foreach (ref fl; IVfamily)
@@ -160,7 +155,6 @@ nothrow:
         IVfamily.reset();
     }
 
-    @trusted
     void print() const
     {
         debug

--- a/compiler/src/dmd/backend/gother.d
+++ b/compiler/src/dmd/backend/gother.d
@@ -54,7 +54,6 @@ nothrow:
     /***************************
      * Reset memory so this allocation can be re-used.
      */
-    @trusted
     void reset()
     {
         rdlist.reset();

--- a/compiler/src/dmd/backend/machobj.d
+++ b/compiler/src/dmd/backend/machobj.d
@@ -2707,7 +2707,6 @@ void MachObj_moduleinfo(Symbol *scc)
 
 /*************************************
  */
-@trusted
 void MachObj_gotref(Symbol *s)
 {
     //printf("MachObj_gotref(%x '%s', %d)\n",s,s.Sident.ptr, s.Sclass);

--- a/compiler/src/dmd/backend/mem.d
+++ b/compiler/src/dmd/backend/mem.d
@@ -65,5 +65,4 @@ void* mem_realloc(void* p, size_t u)
 @trusted
 void mem_free(void* p) { free(p); }
 
-@trusted
 void mem_ffree(void *) { }

--- a/compiler/src/dmd/backend/symbol.d
+++ b/compiler/src/dmd/backend/symbol.d
@@ -57,7 +57,6 @@ void func_free(func_t* f) { free(f); }
 /*******************************
  * Type out symbol information.
  */
-@trusted
 void symbol_print(const ref Symbol s)
 {
 debug
@@ -234,11 +233,9 @@ bool Symbol_isAffected(const ref Symbol s)
 /***********************************
  * Get user name of symbol.
  */
-
-@trusted
 const(char)* symbol_ident(return ref const Symbol s)
 {
-    return s.Sident.ptr;
+    return &s.Sident[0];
 }
 
 /****************************************
@@ -270,7 +267,7 @@ Symbol * symbol_calloc(const(char)[] id)
  *      created Symbol
  */
 
-@trusted @nogc
+@nogc
 extern (C)
 Symbol * symbol_name(const(char)[] name, SC sclass, type *t)
 {

--- a/compiler/src/dmd/backend/ty.d
+++ b/compiler/src/dmd/backend/ty.d
@@ -280,7 +280,6 @@ bool ty64reg(tym_t ty) { return tytab[ty & 0xFF] & (TYFLintegral | TYFLptr | TYF
 uint tyxmmreg(tym_t ty) { return tytab[ty & 0xFF] & TYFLxmmreg; }
 
 // Is a vector type
-@trusted
 bool tyvector(tym_t ty) { return tybasic(ty) >= TYfloat4 && tybasic(ty) <= TYullong4; }
 
 /* Types that are chars or shorts       */
@@ -312,7 +311,6 @@ uint tynullptr(tym_t ty) { return tytab[ty & 0xFF] & TYFLnullptr; }
 uint tyfv(tym_t ty) { return tytab[ty & 0xFF] & TYFLfv; }
 
 /* All data types that fit in exactly 8 bits    */
-@trusted
 bool tybyte(tym_t ty) { return tysize(ty) == 1; }
 
 /* Types that fit into a single machine register        */

--- a/compiler/src/dmd/common/outbuffer.d
+++ b/compiler/src/dmd/common/outbuffer.d
@@ -141,7 +141,7 @@ struct OutBuffer
     memory buffer. The config variables `notlinehead`, `doindent` etc. are
     not changed.
     */
-    extern (C++) void destroy() pure nothrow @trusted
+    extern (C++) void destroy() pure nothrow
     {
         dtor();
         fileMapping = null;
@@ -247,7 +247,7 @@ struct OutBuffer
     /**
      * Writes a 16 bit value, no reserve check.
      */
-    @trusted nothrow
+    nothrow
     void write16n(int v)
     {
         auto x = cast(ushort) v;
@@ -367,7 +367,6 @@ struct OutBuffer
     }
 
     // Position buffer to accept the specified number of bytes at offset
-    @trusted
     void position(size_t where, size_t nbytes) nothrow
     {
         if (where + nbytes > data.length)
@@ -382,7 +381,7 @@ struct OutBuffer
     /**
      * Writes an 8 bit byte, no reserve check.
      */
-    extern (C++) @trusted nothrow
+    extern (C++) nothrow @safe
     void writeByten(int b)
     {
         this.data[offset++] = cast(ubyte) b;

--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -5767,7 +5767,7 @@ struct TemplateInstanceBox
         assert(this.ti.hash);
     }
 
-    size_t toHash() const @trusted pure nothrow
+    size_t toHash() const @safe pure nothrow
     {
         assert(ti.hash);
         return ti.hash;


### PR DESCRIPTION
Most backend modules have `@safe:` on top with `@trusted` bulk added to individual functions. Lots of those are no longer needed as the calls to functions that made them `@system` are now also `@trusted`.