### PR TITLE
Exclude MSVC-* on Ubuntu

### DIFF
--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -76,6 +76,10 @@ jobs:
           - { os: ubuntu-20.04, target: clang-10.0.0 }
           - { os: ubuntu-20.04, target: clang-9.0.0 }
           - { os: ubuntu-20.04, target: clang-8.0.0 }
+          - { os: ubuntu-20.04, target: msvc-2019 }
+          - { os: ubuntu-20.04, target: msvc-2017 }
+          - { os: ubuntu-20.04, target: msvc-2015 }
+          - { os: ubuntu-20.04, target: msvc-2013 }
           # OSX only supports clang
           - { os: macOS-11, target: g++-11 }
           - { os: macOS-11, target: g++-10 }


### PR DESCRIPTION
Removes the Ubuntu/MSVC builds from the GitHub Actions as MSVC is obviously not supported on Ubuntu but it still runs the tests. This should reduce the CI resources and failure modes.