### PR TITLE
Fix some invalid links

### DIFF
--- a/compiler/src/dmd/argtypes_aarch64.d
+++ b/compiler/src/dmd/argtypes_aarch64.d
@@ -18,7 +18,7 @@ import dmd.mtype;
  * This breaks a type down into 'simpler' types that can be passed to a function
  * in registers, and returned in registers.
  * This is the implementation for the AAPCS64 ABI, based on
- * https://github.com/ARM-software/abi-aa/blob/master/aapcs64/aapcs64.rst.
+ * $(LINK https://github.com/ARM-software/abi-aa/blob/master/aapcs64/aapcs64.rst).
  * Params:
  *      t = type to break down
  * Returns:

--- a/compiler/src/dmd/mtype.d
+++ b/compiler/src/dmd/mtype.d
@@ -3492,7 +3492,7 @@ extern (C++) final class TypeDelegate : TypeNext
  * This is a shell containing a TraitsExp that can be
  * either resolved to a type or to a symbol.
  *
- * The point is to allow AliasDeclarationY to use `__traits()`, see https://issues.dlang.org/show_bug.cgi?id=7804.
+ * The point is to allow AliasDeclarationY to use `__traits()`, see $(LINK https://issues.dlang.org/show_bug.cgi?id=7804).
  */
 extern (C++) final class TypeTraits : Type
 {

--- a/druntime/src/core/memory.d
+++ b/druntime/src/core/memory.d
@@ -322,7 +322,7 @@ extern(D):
         This can be used to manually allocate arrays. Initial slice size is 0.
 
         Note: The slice's usable size will not match the block size. Use
-        $(LREF capacity) to retrieve actual usable capacity.
+        $(REF1 capacity, object) to retrieve actual usable capacity.
 
         Example:
         ----
@@ -611,7 +611,7 @@ extern(C):
      * Note:
      *  Extend may also be used to extend slices (or memory blocks with
      *  $(LREF APPENDABLE) info). However, use the return value only
-     *  as an indicator of success. $(LREF capacity) should be used to
+     *  as an indicator of success. $(REF1 capacity, object) should be used to
      *  retrieve actual usable slice capacity.
      */
     version (D_ProfileGC)
@@ -1197,13 +1197,13 @@ $(UL
 )
 
 Note: Users should prefer $(REF1 destroy, object) to explicitly finalize objects,
-and only resort to $(REF __delete, core,memory) when $(REF destroy, object)
+and only resort to $(LREF __delete) when $(REF1 destroy, object)
 wouldn't be a feasible option.
 
 Params:
     x = aggregate object that should be destroyed
 
-See_Also: $(REF1 destroy, object), $(REF free, core,GC)
+See_Also: $(REF1 destroy, object), $(LREF GC.free)
 
 History:
 

--- a/druntime/src/core/sys/solaris/sys/priocntl.d
+++ b/druntime/src/core/sys/solaris/sys/priocntl.d
@@ -2,7 +2,7 @@
  * D header file for the Solaris priocntl(2) and priocntlset(2) functions.
  *
  * Copyright:   Copyright 2014 Jason King.
- * License:     $(HTTP www.boost.org/LICENSE_1.0.txt, Boost License 1.0).
+ * License:     $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:     Jason King
  */
 

--- a/druntime/src/core/sys/solaris/sys/procset.d
+++ b/druntime/src/core/sys/solaris/sys/procset.d
@@ -2,7 +2,7 @@
  * D header file defining a process set.
  *
  * Copyright:   Copyright 2014 Jason King.
- * License:     $(HTTP www.boost.org/LICENSE_1.0.txt, Boost License 1.0).
+ * License:     $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:     Jason King
  */
 

--- a/druntime/src/core/sys/solaris/sys/types.d
+++ b/druntime/src/core/sys/solaris/sys/types.d
@@ -2,7 +2,7 @@
  * D header file that defines Solaris-specific types.
  *
  * Copyright:   Copyright 2014 Jason King.
- * License:     $(HTTP www.boost.org/LICENSE_1.0.txt, Boost License 1.0).
+ * License:     $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:     Jason King
  */
 


### PR DESCRIPTION
I have not verified this, so I do not know if the correct link will be generated.

In particular, the `__delete` and `GC.free` links in `core/memory.d` may need to be fixed in a different way.