### PR TITLE
Enhancement: `Base(child)` class object upcast

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6171,6 +6171,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else if (t1.ty == Tclass)
             {
+                // upcast `Base(child)`
+                if (exp.e1.op == EXP.type && exp.arguments.length == 1 &&
+                    (*exp.arguments)[0].type.implicitConvTo(t1))
+                {
+                    Expression e = new CastExp(exp.loc, (*exp.arguments)[0], t1);
+                    e = e.expressionSemantic(sc);
+                    result = e;
+                    return;
+                }
             L1:
                 // Rewrite as e1.call(arguments)
                 Expression e = new DotIdExp(exp.loc, exp.e1, Id.call);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6173,7 +6173,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 // upcast `Base(child)`
                 if (exp.e1.op == EXP.type && exp.arguments.length == 1 &&
-                    (*exp.arguments)[0].type.implicitConvTo(t1))
+                    (*exp.arguments)[0].type.implicitConvTo(t1) &&
+                    !t1.isTypeClass().sym.symtab.lookup(Id.call))
                 {
                     Expression e = new CastExp(exp.loc, (*exp.arguments)[0], t1);
                     e = e.expressionSemantic(sc);

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -6133,7 +6133,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 // No constructor, look for overload of opCall
                 if (search_function(sd, Id.call))
-                    goto L1;
+                    goto LopCall;
                 // overload of opCall, therefore it's a call
                 if (exp.e1.op != EXP.type)
                 {
@@ -6181,7 +6181,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     result = e;
                     return;
                 }
-            L1:
+            LopCall:
                 // Rewrite as e1.call(arguments)
                 Expression e = new DotIdExp(exp.loc, exp.e1, Id.call);
                 e = new CallExp(exp.loc, e, exp.arguments, exp.names);

--- a/compiler/test/compilable/b16346.d
+++ b/compiler/test/compilable/b16346.d
@@ -1,3 +1,0 @@
-enum A { B }
-static assert(is(typeof(A.B) == A));
-static assert(is(typeof(A(A.B)) == A));

--- a/compiler/test/compilable/type_call_expr.d
+++ b/compiler/test/compilable/type_call_expr.d
@@ -1,0 +1,10 @@
+enum A { B }
+static assert(is(typeof(A.B) == A));
+static assert(is(typeof(A(A.B)) == A));
+
+void main()
+{
+    Exception ex;
+    auto o = Object(ex);
+    static assert(is(typeof(o) == Object));
+}


### PR DESCRIPTION
`FundamentalType(arg)` works, e.g. `int(2)`.

`Enum(Enum.foo)` works, which does nothing - see `compilable/b16346.d` below and/or https://issues.dlang.org/show_bug.cgi?id=16346.

Let's allow class instance upcasting without having to use `cast` - `Base(child)`. `cast` can be bug-prone, and upcasting is always fine. In generic code it's not always clear what a type resolves to, so avoiding `cast` makes code reviews easier.

Here upcasting takes precedence over a static opCall, but that could be swapped.