### PR TITLE
Make distinction between CC and CXX in the testsuite.

### DIFF
--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -31,9 +31,11 @@ GNU_MAKE="$(which make)" # must be done before installing dmc (tampers with PATH
 if [ "$MODEL" == "32omf" ] ; then
     install_host_dmc
     CC="$PWD/dm/bin/dmc.exe"
+    CXX="$PWD/dm/bin/dmc.exe"
     export CPPCMD="$PWD/dm/bin/sppn.exe"
 else
     CC="cl.exe"
+    CXX="cl.exe"
 fi
 
 ################################################################################
@@ -139,7 +141,7 @@ if [ "$HOST_DMD_VERSION" = "2.079.0" ] ; then
     targets=("runnable" "compilable" "fail_compilation" "dshell")
     args=() # use default set of args
 fi
-./run --environment --jobs=$N "${targets[@]}" "${args[@]}" CC="$CC"
+./run --environment --jobs=$N "${targets[@]}" "${args[@]}" CC="$CC" CXX="$CXX"
 
 ###############################################################################
 # Upload coverage reports and exit if ENABLE_COVERAGE is specified

--- a/.github/workflows/runnable_cxx.yml
+++ b/.github/workflows/runnable_cxx.yml
@@ -207,7 +207,7 @@ jobs:
         tar -x -C ${{ github.workspace }} -f ${{ github.workspace }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}.tar.xz
         TMP_CC='${{ github.workspace }}/clang+llvm-${{ matrix.cxx-version }}-${{ matrix.arch }}/bin/clang'
         # On OSX, the system header are installed via `xcode-select` and not distributed with clang
-        # Since some part of the testsuite rely on CC being only a binary (not a command),
+        # Since some part of the testsuite rely on CC and CXX being only a binary (not a command),
         # and config files where only introduced from 6.0.0, use a wrapper script.
         if [ "${{ matrix.os }}" == "macOS-11" ]; then
           # Note: heredoc shouldn't be indented

--- a/compiler/test/dshell/cpp_header_gen.d
+++ b/compiler/test/dshell/cpp_header_gen.d
@@ -4,16 +4,16 @@ import dshell;
 
 int main()
 {
-    if (!CC.length)
+    if (!CXX.length)
     {
-        writeln("CPP header generation test was skipped because $CC is empty!");
+        writeln("CPP header generation test was skipped because $CXX is empty!");
         return DISABLED;
     }
     // DMC cannot compile the generated headers ...
     version (Windows)
     {
         import std.algorithm : canFind;
-        if (CC.canFind("dmc"))
+        if (CXX.canFind("dmc"))
         {
             writeln("CPP header generation test was skipped because DMC is not supported!");
             return DISABLED;
@@ -41,9 +41,9 @@ int main()
     }
 
     version (Windows)
-        run([CC, "/c", "/Fo" ~ Vars.CPP_OBJ, "/I" ~ OUTPUT_BASE, "/I" ~ EXTRA_FILES ~"/../../../src/dmd/root", Vars.SOURCE_DIR ~ "/app.cpp"]);
+        run([CXX, "/c", "/Fo" ~ Vars.CPP_OBJ, "/I" ~ OUTPUT_BASE, "/I" ~ EXTRA_FILES ~"/../../../src/dmd/root", Vars.SOURCE_DIR ~ "/app.cpp"]);
     else
-        run("$CC -m$MODEL -c -o $CPP_OBJ -I$OUTPUT_BASE -I$EXTRA_FILES/../../../src/dmd/root $SOURCE_DIR/app.cpp");
+        run("$CXX -m$MODEL -c -o $CPP_OBJ -I$OUTPUT_BASE -I$EXTRA_FILES/../../../src/dmd/root $SOURCE_DIR/app.cpp");
     run("$DMD -m$MODEL -conf= -of=$HEADER_EXE $LIB $CPP_OBJ");
     run("$HEADER_EXE");
 

--- a/compiler/test/dshell/dll_cxx.d
+++ b/compiler/test/dshell/dll_cxx.d
@@ -4,8 +4,8 @@ import std.stdio;
 
 int main()
 {
-    // Only run this test, if CC has been set.
-    if (Vars.CC.empty)
+    // Only run this test, if CXX has been set.
+    if (Vars.CXX.empty)
         return DISABLED;
 
     version (Windows)
@@ -20,20 +20,20 @@ int main()
     Vars.set(`EXE_NAME`, `$OUTPUT_BASE${SEP}testdll$EXE`);
     Vars.set(`DLL`, `$OUTPUT_BASE${SEP}mydll$SOEXT`);
 
-    string[] dllCmd = [Vars.CC];
+    string[] dllCmd = [Vars.CXX];
     string mainExtra;
     version (Windows)
     {
         Vars.set(`DLL_LIB`, `$OUTPUT_BASE${SEP}mydll.lib`);
         if (Vars.MODEL == "32omf")
         {
-            // CC should be dmc for win32omf.
+            // CXX should be dmc for win32omf.
             dllCmd ~= [`-mn`, `-L/implib:` ~ Vars.DLL_LIB, `-WD`, `-o` ~ Vars.DLL, `kernel32.lib`, `user32.lib`];
             mainExtra = `$DLL_LIB`;
         }
         else
         {
-            // CC should be cl for win32mscoff.
+            // CXX should be cl for win32mscoff.
             dllCmd ~= [`/LD`, `/nologo`, `/Fe` ~ Vars.DLL];
             mainExtra = `$DLL_LIB`;
         }

--- a/compiler/test/tools/d_do_test.d
+++ b/compiler/test/tools/d_do_test.d
@@ -60,7 +60,8 @@ void usage()
           ~ "      ARGS:          set to execute all combinations of\n"
           ~ "      REQUIRED_ARGS: arguments always passed to the compiler\n"
           ~ "      DMD:           compiler to use, ex: ../src/dmd (required)\n"
-          ~ "      CC:            C++ compiler to use, ex: dmc, g++\n"
+          ~ "      CC:            C compiler to use, ex: dmc, cc\n"
+          ~ "      CXX:           C++ compiler to use, ex: dmc, g++\n"
           ~ "      OS:            windows, linux, freebsd, osx, netbsd, dragonflybsd\n"
           ~ "      RESULTS_DIR:   base directory for test results\n"
           ~ "      MODEL:         32 or 64 (required)\n"
@@ -93,7 +94,7 @@ struct TestArgs
     bool     link;                  /// `LINK`: force linking for `fail_compilation` & `compilable` tests
     bool     clearDflags;           /// `DFLAGS`: whether DFLAGS should be cleared before invoking dmd
     string   executeArgs;           /// `EXECUTE_ARGS`: arguments passed to the compiled executable (for `runnable[_cxx]`)
-    string   cxxflags;              /// `CXXFLAGS`: arguments passed to $CC when compiling `EXTRA_CPP_SOURCES`
+    string   cxxflags;              /// `CXXFLAGS`: arguments passed to $CXX when compiling `EXTRA_CPP_SOURCES`
     string[] sources;               /// `EXTRA_SOURCES`: additional D sources (+ main source file)
     string[] compiledImports;       /// `COMPILED_IMPORTS`: files compiled alongside the main source
     string[] cppSources;            /// `EXTRA_CPP_SOURCES`: additional C++ sources
@@ -130,7 +131,8 @@ struct EnvData
     string exe;                  /// `EXE`: executable file extension (none or `.exe`)
     string os;                   /// `OS`: host operating system (`linux`, `windows`, ...)
     string compiler;             /// `HOST_DMD`: host D compiler
-    string ccompiler;            /// `CC`: host C++ compiler
+    string ccompiler;            /// `CC`: host C compiler
+    string cxxcompiler;          /// `CXX`: host C++ compiler
     string model;                /// `MODEL`: target model (`32` or `64`)
     string required_args;        /// `REQUIRED_ARGS`: flags added to the tests `REQUIRED_ARGS` parameter
     string cxxCompatFlags;       /// Additional flags passed to $(compiler) when `EXTRA_CPP_SOURCES` is present
@@ -171,6 +173,7 @@ immutable(EnvData) processEnvironment()
     envData.dmd            = replace(envGetRequired("DMD"), "/", envData.sep);
     envData.compiler       = "dmd"; //should be replaced for other compilers
     envData.ccompiler      = environment.get("CC");
+    envData.cxxcompiler    = environment.get("CXX");
     envData.model          = envGetRequired("MODEL");
     if (envData.os == "windows" && envData.model == "32")
     {
@@ -194,7 +197,7 @@ immutable(EnvData) processEnvironment()
     if (envData.ccompiler.empty)
     {
         if (envData.os != "windows")
-            envData.ccompiler = "c++";
+            envData.ccompiler = "cc";
         else if (envData.model == "32omf")
             envData.ccompiler = "dmc";
         else if (envData.model == "64")
@@ -203,7 +206,23 @@ immutable(EnvData) processEnvironment()
             envData.ccompiler = "cl";
         else
         {
-            writeln("Unknown $OS$MODEL combination: ", envData.os, envData.model);
+            writeln("Can't determine C compiler (CC). Unknown $OS$MODEL combination: ", envData.os, envData.model);
+            throw new SilentQuit();
+        }
+    }
+    if (envData.cxxcompiler.empty)
+    {
+        if (envData.os != "windows")
+            envData.cxxcompiler = "c++";
+        else if (envData.model == "32omf")
+            envData.cxxcompiler = "dmc";
+        else if (envData.model == "64")
+            envData.cxxcompiler = "cl";
+        else if (envData.model == "32mscoff")
+            envData.cxxcompiler = "cl";
+        else
+        {
+            writeln("Can't determine C++ compiler (CXX). Unknown $OS$MODEL combination: ", envData.os, envData.model);
             throw new SilentQuit();
         }
     }
@@ -1098,14 +1117,15 @@ unittest
  * Returns: false if a compilation error occurred
  */
 bool collectExtraSources (in string input_dir, in string output_dir, in string[] extraSources,
-                          ref string[] sources, in EnvData envData, in string compiler,
-                          const(char)[] cxxflags, ref File logfile)
+                          ref string[] sources, in EnvData envData, in string ccompiler,
+                          in string cxxcompiler, const(char)[] cxxflags, ref File logfile)
 {
     foreach (cur; extraSources)
     {
         auto curSrc = input_dir ~ envData.sep ~"extra-files" ~ envData.sep ~ cur;
         auto curObj = output_dir ~ envData.sep ~ cur ~ envData.obj;
-        string command = quoteSpaces(compiler);
+        bool is_cpp_file = cur.extension() == ".cpp";
+        string command = quoteSpaces(is_cpp_file ? cxxcompiler : ccompiler);
         if (envData.model == "32omf") // dmc.exe
         {
             command ~= " -c "~curSrc~" -o"~curObj;
@@ -1706,10 +1726,10 @@ int tryMain(string[] args)
 
     if (
         //prepare cpp extra sources
-        !collectExtraSources(input_dir, output_dir, testArgs.cppSources, testArgs.sources, envData, envData.ccompiler, testArgs.cxxflags, f) ||
+        !collectExtraSources(input_dir, output_dir, testArgs.cppSources, testArgs.sources, envData, envData.ccompiler, envData.cxxcompiler, testArgs.cxxflags, f) ||
 
         //prepare objc extra sources
-        !collectExtraSources(input_dir, output_dir, testArgs.objcSources, testArgs.sources, envData, "clang", null, f)
+        !collectExtraSources(input_dir, output_dir, testArgs.objcSources, testArgs.sources, envData, "clang", "clang++", null, f)
     )
     {
         writeln();

--- a/compiler/test/tools/dshell_prebuilt/dshell_prebuilt.d
+++ b/compiler/test/tools/dshell_prebuilt/dshell_prebuilt.d
@@ -50,7 +50,7 @@ private alias requiredEnvVars = AliasSeq!(
     "BUILD"
 );
 private alias optionalEnvVars = AliasSeq!(
-    "CC", "PIC_FLAG"
+    "CC", "CXX", "PIC_FLAG"
 );
 private alias allVars = AliasSeq!(
     requiredEnvVars,


### PR DESCRIPTION
Clang makes a distinction between clang and clang++. In particular, clang++ will give a warning when it is passed `.c` source files; and the extra output warning text means that dmd testsuite output checking fails. The warning can be silenced (-Wno-deprecated) but then other tests will fail because `#ifdef __cplusplus` will be true, leading to header file import issues.

(I ran into this issue during Alpine MUSL LDC work, and also when explicitly setting CC=clang++ on macOS.  With this PR, CC=clang CXX=clang++ works)