### PR TITLE
Add a mechanism for forcing codegen for an import/module.

### DIFF
--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -41,6 +41,8 @@ extern (C++) final class Import : Dsymbol
     // corresponding AliasDeclarations for alias=name pairs
     AliasDeclarations aliasdecls;
 
+    bool forceCodegen;      // whether codegen should be forced for the imported module
+
     extern (D) this(const ref Loc loc, Identifier[] packages, Identifier id, Identifier aliasId, int isstatic)
     {
         Identifier selectIdent()

--- a/compiler/src/dmd/dmodule.d
+++ b/compiler/src/dmd/dmodule.d
@@ -362,6 +362,7 @@ extern (C++) final class Module : Package
     Package pkg;                // if isPackageFile is true, the Package that contains this package.d
     Strings contentImportedFiles; // array of files whose content was imported
     int needmoduleinfo;
+    bool forceCodegen;          // if codegen should take place for this module, even if it normally wouldn't
     private ThreeState selfimports;
     private ThreeState rootimports;
     Dsymbol[void*] tagSymTab;   /// ImportC: tag symbols that conflict with other symbols used as the index

--- a/compiler/src/dmd/dsymbolsem.d
+++ b/compiler/src/dmd/dsymbolsem.d
@@ -7020,8 +7020,16 @@ extern (D) bool load(Import imp, Scope* sc)
             dst.insert(imp.id, imp.mod);
         }
     }
-    if (imp.mod && !imp.mod.importedFrom)
-        imp.mod.importedFrom = sc ? sc._module.importedFrom : Module.rootModule;
+    if (imp.mod)
+    {
+        if (imp.forceCodegen)
+            imp.mod.forceCodegen = true;
+        // if codegen is forced, promote imp.mod to a root module, so that codegen takes place
+        if (imp.mod.forceCodegen)
+            imp.mod.importedFrom = imp.mod;
+        else if (!imp.mod.importedFrom)
+            imp.mod.importedFrom = sc ? sc._module.importedFrom : Module.rootModule;
+    }
     if (!imp.pkg)
     {
         if (imp.mod && imp.mod.isPackageFile)

--- a/compiler/src/dmd/frontend.h
+++ b/compiler/src/dmd/frontend.h
@@ -7032,6 +7032,7 @@ public:
     Module* mod;
     Package* pkg;
     Array<AliasDeclaration* > aliasdecls;
+    bool forceCodegen;
     const char* kind() const override;
     Visibility visible() override;
     Import* syntaxCopy(Dsymbol* s) override;
@@ -7086,6 +7087,7 @@ public:
     Package* pkg;
     Array<const char* > contentImportedFiles;
     int32_t needmoduleinfo;
+    bool forceCodegen;
 private:
     ThreeState selfimports;
     ThreeState rootimports;

--- a/compiler/src/dmd/main.d
+++ b/compiler/src/dmd/main.d
@@ -577,6 +577,22 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         }
     }
     Module.runDeferredSemantic3();
+
+    // Ensure codegen is performed for modules where codegen is forced
+    for (size_t i = 0; i < Module.amodules.length; ++i)
+    {
+        auto m = Module.amodules[i];
+        if (m.forceCodegen && m.semanticRun != PASS.semantic3done)
+        {
+            assert(m.isRoot());
+            if (params.v.verbose)
+                message("semantic3 %s", m.toChars());
+            m.semantic3(null);
+            modules.push(m);
+        }
+    }
+    Module.runDeferredSemantic3();
+
     if (global.errors)
         removeHdrFilesAndFail(params, modules);
 


### PR DESCRIPTION
This PR adds a mechanism which lets the frontend indicate that codegen should always take place for an import/module, even if that module wasn't supplied on the command-line when the compiler was invoked, and regardless of whether the `-i` switch was supplied or not.

My main motivation for this is for https://github.com/dlang/dmd/pull/16372; so that codegen can be forced for the `__builtins_msvc` module, so that `#include <importc_msvc_builtins.h>` just works regardless of how the compiler was invoked. (Additional context: https://github.com/dlang/dmd/pull/16372#issuecomment-2060143177; https://github.com/dlang/dmd/pull/16372#issuecomment-2073554257; https://github.com/dlang/dmd/pull/16372#issuecomment-2094507228)