### PR TITLE
Fix alignment of calloc memory in rt.dwarfeh

### DIFF
--- a/druntime/src/rt/dwarfeh.d
+++ b/druntime/src/rt/dwarfeh.d
@@ -181,7 +181,7 @@ struct ExceptionHeader
         auto eh = &ehstorage;
         if (eh.object)                  // if in use
         {
-            eh = cast(ExceptionHeader*)core.stdc.stdlib.calloc(ExceptionHeader.sizeof, 1);
+            eh = cast(ExceptionHeader*)core.stdc.stdlib.calloc(1, ExceptionHeader.sizeof);
             if (!eh)
                 terminate(__LINE__);              // out of memory while throwing - not much else can be done
         }


### PR DESCRIPTION
The signature of calloc is `void* calloc( size_t num, size_t size )`, where `num` is the number of objects and `size` is the byte size per object. (https://en.cppreference.com/w/c/memory/calloc) The number of bytes allocated is the same with this fix, but it solves potential memory alignment issues.